### PR TITLE
fix(core): a tool turn that produced no answer says so instead of "on it"

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -4369,6 +4369,10 @@ describe("runV5MessageRuntimeStage1", () => {
 				name: "TASKS_SPAWN_AGENT",
 				description: "Spawn a coding task.",
 				contexts: ["general"],
+				// The flag the real TASKS action carries: the spawned work keeps
+				// running after the turn returns, which is what licenses the ack to
+				// stand as this turn's outcome.
+				asyncHandoff: true,
 				validate: vi.fn(async () => true),
 				handler: vi.fn(async () => ({
 					success: true,

--- a/packages/core/src/services/message.answerless-tool-turn.test.ts
+++ b/packages/core/src/services/message.answerless-tool-turn.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Answerless tool turn: a turn that ran real tool work and finished with no
+ * planner prose must report the outcome, or say plainly that it produced none.
+ * It must never promote the pre-tool Stage-1 ack into the turn's terminal
+ * message — the live shape where an addressed turn ran several tool calls and
+ * the user received only "On it.".
+ *
+ * Drives the real `DefaultMessageService.handleMessage` pipeline (real
+ * `AgentRuntime`, in-memory adapter, real planner loop, real action execution)
+ * with only the model transport scripted, so every assertion is against the
+ * bytes the connector callback actually received.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createCharacter } from "../character";
+import { InMemoryDatabaseAdapter } from "../database/inMemoryAdapter";
+import { AgentRuntime } from "../runtime";
+import type { Action, Content, HandlerCallback, Memory, UUID } from "../types";
+import { ModelType } from "../types";
+import { ChannelType } from "../types/primitives";
+import {
+	DefaultMessageService,
+	NO_REPORTABLE_TOOL_OUTCOME_MESSAGE,
+} from "./message";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000091" as UUID;
+const USER_ID = "00000000-0000-0000-0000-000000000092" as UUID;
+
+const STAGE_ONE_ACK = "On it.";
+const DIAGNOSTIC = "read_file path=bot.log bytes=8412 exit=0";
+const TOOL_OUTCOME =
+	"Last 3 lines of bot.log: startup ok, 2 warnings, no errors.";
+
+interface ScriptedAction {
+	name: string;
+	asyncHandoff?: boolean;
+	result: Record<string, unknown>;
+	deliverThroughCallback?: string;
+}
+
+function stageOneAckTurn(candidateActionNames: readonly string[]) {
+	return {
+		text: "",
+		toolCalls: [
+			{
+				id: "handle-response-1",
+				name: "HANDLE_RESPONSE",
+				arguments: {
+					shouldRespond: "RESPOND",
+					thought: "Needs a tool.",
+					contexts: ["general"],
+					intents: ["read the log"],
+					candidateActionNames: [...candidateActionNames],
+					replyText: STAGE_ONE_ACK,
+					facts: [],
+					relationships: [],
+					addressedTo: [],
+					requiresTool: true,
+				},
+			},
+		],
+		finishReason: "tool_calls",
+	};
+}
+
+/** Evaluator envelope: goal met, evaluator owns no prose of its own. */
+const EVALUATOR_FINISH = JSON.stringify({
+	success: true,
+	decision: "FINISH",
+	thought: "The tool ran.",
+});
+/** Evaluator envelope: keep planning from the recorded results. */
+const EVALUATOR_CONTINUE = JSON.stringify({
+	success: false,
+	decision: "CONTINUE",
+	thought: "More work is needed.",
+});
+
+function makeMessage(runtime: AgentRuntime, text: string): Memory {
+	return {
+		entityId: USER_ID,
+		agentId: runtime.agentId,
+		roomId: runtime.agentId,
+		content: {
+			text,
+			source: "client_chat",
+			channelType: ChannelType.DM,
+		},
+		createdAt: Date.now(),
+	};
+}
+
+interface Harness {
+	runtime: AgentRuntime;
+	callback: HandlerCallback;
+	callbacks: Content[];
+}
+
+const activeRuntimes: AgentRuntime[] = [];
+
+/**
+ * Scripts Stage 1 (ack + tool requirement), the planner turns, and the
+ * evaluator turns. The last planner turn is always a terminal tool call with
+ * no REPLY — the shape that makes the loop finish with no final message.
+ */
+async function createHarness(options: {
+	actions: readonly ScriptedAction[];
+	plannerToolNames: readonly string[];
+	evaluatorScript: readonly string[];
+}): Promise<Harness> {
+	const runtime = new AgentRuntime({
+		character: createCharacter({
+			id: AGENT_ID,
+			name: "Answerless Tool Turn",
+			bio: "Exercises the answerless-final delivery floor.",
+			settings: {},
+		}),
+		adapter: new InMemoryDatabaseAdapter(),
+		logLevel: "fatal",
+		enableAutonomy: false,
+	});
+	await runtime.initialize({ skipMigrations: true });
+	activeRuntimes.push(runtime);
+
+	runtime.actions.length = 0;
+	runtime.evaluators.length = 0;
+	runtime.composeState = vi.fn(async () => ({
+		values: { availableContexts: "general" },
+		data: {},
+		text: "Deterministic answerless-tool-turn state.",
+	})) as AgentRuntime["composeState"];
+
+	for (const scripted of options.actions) {
+		runtime.registerAction({
+			name: scripted.name,
+			description: "Reads or writes a stored artifact.",
+			...(scripted.asyncHandoff ? { asyncHandoff: true as const } : {}),
+			parameters: [
+				{
+					name: "target",
+					description: "What to operate on",
+					required: true,
+					schema: { type: "string" },
+				},
+			],
+			validate: async () => true,
+			handler: async (_rt, _msg, _state, _opts, cb) => {
+				if (scripted.deliverThroughCallback && cb) {
+					await cb({
+						text: scripted.deliverThroughCallback,
+						actions: ["REPLY"],
+					});
+				}
+				return scripted.result as never;
+			},
+		} satisfies Action);
+	}
+
+	let stageOneServed = false;
+	let evaluatorTurn = 0;
+	runtime.registerModel(
+		ModelType.RESPONSE_HANDLER,
+		async () => {
+			if (!stageOneServed) {
+				stageOneServed = true;
+				return stageOneAckTurn(options.actions.map((action) => action.name));
+			}
+			const scripted = options.evaluatorScript[evaluatorTurn];
+			evaluatorTurn += 1;
+			return scripted ?? EVALUATOR_FINISH;
+		},
+		"answerless-tool-turn-test",
+		100,
+	);
+
+	let plannerTurn = 0;
+	runtime.registerModel(
+		ModelType.ACTION_PLANNER,
+		async () => {
+			const toolName = options.plannerToolNames[plannerTurn];
+			plannerTurn += 1;
+			if (toolName) {
+				return {
+					thought: `Run ${toolName}.`,
+					toolCalls: [
+						{
+							id: `call-${plannerTurn}`,
+							name: toolName,
+							args: { target: "bot.log" },
+						},
+					],
+				};
+			}
+			// Terminal-only iteration with NO REPLY call: the loop finishes with
+			// `finalMessage: undefined` — the answerless shape this file pins.
+			return {
+				thought: "Nothing more to do.",
+				toolCalls: [{ id: "terminal-1", name: "STOP" }],
+			};
+		},
+		"answerless-tool-turn-test",
+		100,
+	);
+	runtime.registerModel(
+		ModelType.TEXT_SMALL,
+		async () => "",
+		"answerless-tool-turn-test",
+		100,
+	);
+	runtime.registerModel(
+		ModelType.TEXT_LARGE,
+		async () => "",
+		"answerless-tool-turn-test",
+		100,
+	);
+
+	const callbacks: Content[] = [];
+	runtime.registerSendHandler("client_chat", async () => undefined);
+	const callback: HandlerCallback = async (content: Content) => {
+		callbacks.push(content);
+		return [];
+	};
+
+	return { runtime, callback, callbacks };
+}
+
+function visibleTexts(contents: Content[]): string[] {
+	return contents
+		.map((content) => (typeof content.text === "string" ? content.text : ""))
+		.filter((text) => text.trim().length > 0);
+}
+
+async function runTurn(harness: Harness, text: string) {
+	return new DefaultMessageService().handleMessage(
+		harness.runtime,
+		makeMessage(harness.runtime, text),
+		harness.callback,
+	);
+}
+
+describe("answerless tool turn", () => {
+	beforeEach(() => {
+		vi.stubEnv("ELIZA_TRAJECTORY_LOGGING", "0");
+	});
+
+	afterEach(async () => {
+		vi.unstubAllEnvs();
+		await Promise.all(
+			activeRuntimes.splice(0).map(async (runtime) => {
+				await runtime.stop();
+				await runtime.close();
+			}),
+		);
+	});
+
+	it("reports the absence of a result instead of shipping the pre-tool ack", async () => {
+		const harness = await createHarness({
+			actions: [
+				{ name: "LOOKUP", result: { success: true, text: DIAGNOSTIC } },
+			],
+			plannerToolNames: ["LOOKUP"],
+			evaluatorScript: [EVALUATOR_CONTINUE],
+		});
+
+		const result = await runTurn(
+			harness,
+			"read me the last few lines of the bot log",
+		);
+
+		const delivered = visibleTexts(harness.callbacks);
+		expect(delivered).toEqual([NO_REPORTABLE_TOOL_OUTCOME_MESSAGE]);
+		expect(result.responseContent?.text).toBe(
+			NO_REPORTABLE_TOOL_OUTCOME_MESSAGE,
+		);
+		// The interim ack must never become the turn's terminal message, and the
+		// diagnostic tool text must never render as assistant prose.
+		expect(delivered).not.toContain(STAGE_ONE_ACK);
+		expect(delivered.join("\n")).not.toContain(DIAGNOSTIC);
+	});
+
+	it("delivers an earlier tool's undelivered outcome rather than the ack", async () => {
+		const harness = await createHarness({
+			actions: [
+				{
+					name: "LOOKUP",
+					result: {
+						success: true,
+						text: DIAGNOSTIC,
+						userFacingText: TOOL_OUTCOME,
+					},
+				},
+				{ name: "WRITE", result: { success: false, text: "write failed" } },
+			],
+			plannerToolNames: ["LOOKUP", "WRITE"],
+			evaluatorScript: [EVALUATOR_CONTINUE, EVALUATOR_CONTINUE],
+		});
+
+		const result = await runTurn(
+			harness,
+			"read me the last few lines of the bot log",
+		);
+
+		const delivered = visibleTexts(harness.callbacks);
+		expect(delivered).toContain(TOOL_OUTCOME);
+		expect(delivered).not.toContain(STAGE_ONE_ACK);
+		expect(result.responseContent?.text).toBe(TOOL_OUTCOME);
+	});
+
+	it("keeps the ack when an asyncHandoff action carries the work past the turn", async () => {
+		const harness = await createHarness({
+			actions: [
+				{
+					name: "LOOKUP",
+					asyncHandoff: true,
+					result: { success: true, text: DIAGNOSTIC },
+				},
+			],
+			plannerToolNames: ["LOOKUP"],
+			evaluatorScript: [EVALUATOR_CONTINUE],
+		});
+
+		const result = await runTurn(harness, "build me the thing");
+
+		// The spawned work outlives the turn, so "on it" IS the honest outcome.
+		expect(visibleTexts(harness.callbacks)).toEqual([STAGE_ONE_ACK]);
+		expect(result.responseContent?.text).toBe(STAGE_ONE_ACK);
+	});
+
+	it("adds no trailing ack when an action already delivered the outcome", async () => {
+		const harness = await createHarness({
+			actions: [
+				{
+					name: "LOOKUP",
+					deliverThroughCallback: TOOL_OUTCOME,
+					result: { success: true, text: DIAGNOSTIC },
+				},
+			],
+			plannerToolNames: ["LOOKUP"],
+			evaluatorScript: [EVALUATOR_CONTINUE],
+		});
+
+		await runTurn(harness, "read me the last few lines of the bot log");
+
+		// One bubble: the action's own outcome. A trailing "On it." would be a
+		// redundant, out-of-order second message.
+		expect(visibleTexts(harness.callbacks)).toEqual([TOOL_OUTCOME]);
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1903,6 +1903,72 @@ export function preservedSettledToolResult(
 	return undefined;
 }
 
+/**
+ * Ack retained when an `asyncHandoff` action carries this turn's work past the
+ * turn boundary and Stage 1 drafted no ack of its own.
+ */
+const ASYNC_HANDOFF_ACK_MESSAGE = "on it, working on that now.";
+
+/**
+ * Terminal line for a synchronous tool turn that produced nothing user-facing.
+ * The planner does not run after the turn returns, so the only honest report
+ * is that the work yielded no result — never a progress ack, which would claim
+ * an outcome is still coming when nothing further will run.
+ */
+export const NO_REPORTABLE_TOOL_OUTCOME_MESSAGE =
+	"I ran that, but it finished without producing a result I can report back.";
+
+/**
+ * Terminal text for the answerless floor: the planner loop finished with no
+ * final message, no substantive Stage-1 answer survived, and real tool work
+ * ran this turn.
+ *
+ * The Stage-1 ack is drafted BEFORE the first tool call, so by construction it
+ * cannot report what those tools found. Shipping it here promotes an interim
+ * "on it" into the turn's entire answer — the live shape: addressed turns that
+ * ran several real tool calls and delivered only `"On it."` /
+ * `"checking your week"`, with no outcome and no failure. Precedence:
+ *
+ *   1. A completed tool's own undelivered `userFacingText` — the outcome the
+ *      turn actually produced and the planner failed to relay.
+ *   2. Silence, when an action already delivered visible text through its own
+ *      callback: the user has the outcome, and a trailing ack would be a
+ *      redundant, out-of-order second bubble.
+ *   3. The ack, ONLY when an action flagged `asyncHandoff` actually executed
+ *      this turn. That work continues after the turn returns, so "on it" is
+ *      the honest outcome and the real result arrives in a later message.
+ *   4. Otherwise a plain statement that the work produced nothing reportable.
+ *
+ * Keyed on turn shape — did tools run, did anything reach the user, does the
+ * executed work outlive the turn — never on the wording of the drafted ack.
+ */
+export function answerlessToolTurnReport(args: {
+	settledToolResults: ReadonlyArray<{
+		name: string;
+		result: PlannerToolResult;
+	}>;
+	deliveredVisibleTexts: ReadonlySet<string>;
+	actionResults: readonly ActionResult[];
+	actions: readonly Action[] | undefined;
+	stageOneAck: string;
+}): string {
+	const preserved = preservedSettledToolResult(
+		args.settledToolResults,
+		args.deliveredVisibleTexts,
+	);
+	if (preserved) return preserved.userFacingText;
+	if (args.deliveredVisibleTexts.size > 0) return "";
+	const executedActionNames = args.actionResults
+		.map((result) =>
+			typeof result.data?.actionName === "string" ? result.data.actionName : "",
+		)
+		.filter((name) => name.length > 0);
+	if (candidateActionsIncludeAsyncHandoff(args.actions, executedActionNames)) {
+		return args.stageOneAck || ASYNC_HANDOFF_ACK_MESSAGE;
+	}
+	return NO_REPORTABLE_TOOL_OUTCOME_MESSAGE;
+}
+
 /** Zerollama/OpenAI-style async media endpoints should be delivered as attachments, not echoed as chat copy. */
 const MEDIA_CONTENT_URL_RE =
 	/<?\s*https?:\/\/[^\s<>]+\/v1\/(?:videos|images|audio)\/[^\s<>/]+\/content\s*>?/gi;
@@ -3687,13 +3753,13 @@ export function evaluatePlannedReplyEgress(args: {
 }
 
 /**
- * True when any of the turn's candidate actions resolves to a registered
- * action flagged `asyncHandoff` — work whose execution continues after the
- * turn returns (sub-agent spawn class). This is the structural gate for the
- * Stage-1 pre-planner early ack: an ack ahead of the final reply is only
- * warranted when the routed work is an async handoff; synchronous retrieval
- * turns deliver a single reply (the answer) on every channel. Candidates are
- * matched against canonical names AND similes because Stage 1 routinely
+ * True when any of the supplied action names resolves to a registered action
+ * flagged `asyncHandoff` — work whose execution continues after the turn
+ * returns (sub-agent spawn class). This is the structural gate for both places
+ * an ack may legitimately stand in for an outcome: the Stage-1 pre-planner
+ * early ack (called with Stage 1's candidate names) and the answerless
+ * delivery floor (called with the names actually executed this turn). Names
+ * are matched against canonical names AND similes because Stage 1 routinely
  * hints an action by one of its similes.
  */
 export function candidateActionsIncludeAsyncHandoff(
@@ -8770,12 +8836,15 @@ export async function runV5MessageRuntimeStage1(args: {
 					normalizeVisibleTextForDuplicateCheck(earlyReplyText))
 				? prePatchStageOneReply
 				: "";
-		// The ack fallback is a delivery floor for turns that DID real tool work
-		// (async handoffs and action turns whose result text got lost) — callers
-		// must not render a blank for work that genuinely happened. A turn that
-		// ran NO action must not "fix" its silence into a work-is-underway ack:
-		// no work follows this turn, so the ack would be a lie. Prefer the
-		// preserved stage-0 answer over any ack in every case.
+		// The answerless floor is a delivery guarantee for turns that DID real
+		// tool work — callers must not render a blank for work that genuinely
+		// happened. A turn that ran NO action must not "fix" its silence into a
+		// work-is-underway ack: no work follows this turn, so the ack would be a
+		// lie. Prefer the preserved stage-0 answer over any floor text in every
+		// case; otherwise `answerlessToolTurnReport` decides what the tool work
+		// is allowed to say (the tool's own outcome, silence when an action
+		// already delivered one, the ack only for work that outlives the turn,
+		// else a plain no-result report).
 		// A media deliverable delivered through an action's own callback
 		// (GENERATE_MEDIA posts an attachment-only, text:"" callback) IS the turn's
 		// answer. The answerless-final floor must not then resurrect the Stage-1
@@ -8787,7 +8856,13 @@ export async function runV5MessageRuntimeStage1(args: {
 			!plannedText && !earlyReplySent && !suppressesPlannerReply
 				? preservedAnswerFallback ||
 					(ranNonSilentAction && !mediaDeliverableShipped
-						? stageOneAck || "on it, working on that now."
+						? answerlessToolTurnReport({
+								settledToolResults: settledPlannerToolResults,
+								deliveredVisibleTexts,
+								actionResults,
+								actions: args.runtime.actions,
+								stageOneAck,
+							})
 						: "")
 				: preservedAnswerFallback;
 		let effectiveReplyText = plannedText || ackFallback;

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -477,11 +477,21 @@ export interface Action {
 	 * coding sub-agent) and the user-visible result arrives later through a
 	 * separate delivery path.
 	 *
-	 * The message service uses this to decide whether a Stage-1 pre-planner
-	 * early ack is warranted on latency-sensitive channels (voice): only turns
-	 * whose candidate actions include an async-handoff action get an early
-	 * ack, so synchronous retrieval turns deliver one reply — the answer — on
-	 * every channel. Promoted subactions inherit the parent's flag.
+	 * The message service uses this in two places, both asking the same
+	 * question — does this turn's work outlive the turn?
+	 *
+	 *   - Whether a Stage-1 pre-planner early ack is warranted on
+	 *     latency-sensitive channels (voice): only turns whose candidate
+	 *     actions include an async-handoff action get an early ack, so
+	 *     synchronous retrieval turns deliver one reply — the answer — on
+	 *     every channel.
+	 *   - Whether a turn that ran tool work and produced no planner prose may
+	 *     end on an ack instead of reporting an outcome. Only an executed
+	 *     async-handoff action licenses that; a synchronous turn must report
+	 *     the tool's result or say plainly that it produced none, because no
+	 *     further work follows the turn.
+	 *
+	 * Promoted subactions inherit the parent's flag.
 	 */
 	asyncHandoff?: boolean;
 


### PR DESCRIPTION
## What

A turn that ran real tool work and finished with no planner prose fell back to shipping the **Stage-1 ack** ("on it, working on that now.") as its terminal message. That ack is drafted **before the first tool call**, so it cannot report what the tools found — promoting it makes an interim acknowledgment the turn's entire answer.

Live shape (recurring on Discord, ~an ack-with-no-follow-up on a substantial fraction of addressed tool turns): the agent replies "on it." after running several real tool calls, and no outcome or failure ever arrives. The user is left waiting for a result that was never coming.

## Root cause

The answerless-final delivery floor in `runV5MessageRuntimeStage1` was `stageOneAck || "on it, working on that now."` for any turn that ran a non-silent action. The floor guaranteed *delivery* but not *honesty*: it could not distinguish work that outlives the turn (where "on it" is true) from synchronous work that already finished (where "on it" promises a follow-up that will never run).

## Change

`answerlessToolTurnReport` decides what an answerless tool turn is allowed to say, keyed on the **turn's shape** — did tools run, did anything reach the user, does the executed work outlive the turn — never on the wording of the drafted ack:

1. a completed tool's own undelivered `userFacingText` — the outcome the turn actually produced and the planner failed to relay;
2. **silence**, when an action already delivered visible text through its own callback (a trailing ack would be a redundant, out-of-order second bubble);
3. the ack, **only** when an action flagged `asyncHandoff` actually executed this turn — that work continues after the turn returns, so "on it" is honest and the real result arrives in a later message;
4. otherwise a plain statement that the work produced nothing reportable.

Reuses the existing `asyncHandoff` gate (the same structural flag that licenses the Stage-1 pre-planner early ack) rather than adding a parallel mechanism. `candidateActionsIncludeAsyncHandoff` now serves both call sites, matched against canonical names and similes.

## Evidence

<!-- evidence-head:3041d3097894d612a3d786ad06495f627e6e7708 -->

<!-- evidence-row:before-screenshots -->
N/A - Discord chat behavior; the observable form is message text, covered in the transcript evidence below

<!-- evidence-row:after-screenshots -->
N/A - Discord chat behavior; covered by the real-pipeline tests below

<!-- evidence-row:walkthrough-video -->
N/A - no UI surface

<!-- evidence-row:backend-logs -->
Live occurrence shape from the deployment this was root-caused on (identifiers removed):

<details>
<summary>addressed turn, real tool calls, terminal message is the pre-tool ack</summary>
<pre>
[user asks for a concrete task]
bot: on it.
[several planner tool calls execute; turn ends]
(no further message — no outcome, no failure)
</pre>
</details>

<!-- evidence-row:frontend-logs -->
N/A - no frontend surface in this change

<!-- evidence-row:llm-trajectory -->
N/A - the fix runs after the model's final output is already empty; the decisive inputs are tool results and delivery state, which the deterministic real-pipeline tests below drive directly

<!-- evidence-row:domain-artifacts -->
New suite `message.answerless-tool-turn.test.ts` drives the real `DefaultMessageService.handleMessage` pipeline — real `AgentRuntime`, in-memory adapter, real planner loop, real action execution, only the model transport scripted — asserting on the bytes the connector callback actually received. One test per precedence branch:

- reports the absence of a result instead of shipping the pre-tool ack
- delivers an earlier tool's undelivered outcome rather than the ack
- keeps the ack when an `asyncHandoff` action carries the work past the turn
- adds no trailing ack when an action already delivered the outcome

<details>
<summary>results</summary>
<pre>
 message.answerless-tool-turn.test.ts:  4 passed (4)
 message-runtime-stage1.test.ts:      132 passed (132)
</pre>
</details>

<!-- evidence-row:ocr-review -->
N/A - no rendered text or imagery

## Contribution provenance

AI assistance is self-reported provenance, not a request for hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes - agent-authored under human direction, root-caused from live Discord behavior
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5, anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code (Eliza sub-agent)
<!-- attribution-row:skill-revision -->
- Contribution skill revision: N/A - authored from live behavior evidence, not the pinned contribute-to-eliza skill
<!-- attribution-row:status -->
- Attribution status: self-reported
