### PR TITLE
fix(ci): gitleaks scans only PR-introduced commits via merge-base two-dot range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,13 +523,24 @@ jobs:
           set -euo pipefail
           if [ -n "$BASE_SHA" ] && [ "$BASE_SHA" != "0000000000000000000000000000000000000000" ]; then
             if [ "$EVENT_NAME" = "pull_request" ]; then
-              # Three-dot: scan merge-base(base,head)..head, i.e. only what THIS
-              # PR added. `pull_request.base.sha` is the base tip at event time,
-              # not the merge base, so a two-dot range also scans commits the
-              # branch merely inherited by merging develop and re-flags fixtures
-              # the PR never touched (#17971/#17984). Canonical CI now owns the
-              # only PR secret scan, so the three-dot range must live here.
-              range="${BASE_SHA}...${HEAD_SHA}"
+              # Scan only what THIS PR introduced: merge-base(base,head)..head.
+              # `gitleaks --log-opts` feeds `git log`, where a three-dot range
+              # A...B is the symmetric difference and also traverses commits
+              # reachable only from the base side. `pull_request.base.sha` is
+              # the base tip at event time, not the merge base, so a PR whose
+              # base branch advanced after the branch point would scan the
+              # base-only commits it never added (#17971/#17984/#19687).
+              # Resolve the real merge base and use a two-dot range so `git
+              # log` traverses exactly the PR-introduced commits. If the merge
+              # base cannot be resolved (e.g. an unexpected shallow clone),
+              # fall back to scanning only the head commit rather than the
+              # whole history.
+              MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA" || true)"
+              if [ -z "$MERGE_BASE" ]; then
+                range="-1 ${HEAD_SHA}"
+              else
+                range="${MERGE_BASE}..${HEAD_SHA}"
+              fi
             else
               range="${BASE_SHA}..${HEAD_SHA}"
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,16 +531,17 @@ jobs:
               # base branch advanced after the branch point would scan the
               # base-only commits it never added (#17971/#17984/#19687).
               # Resolve the real merge base and use a two-dot range so `git
-              # log` traverses exactly the PR-introduced commits. If the merge
-              # base cannot be resolved (e.g. an unexpected shallow clone),
-              # fall back to scanning only the head commit rather than the
-              # whole history.
-              MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA" || true)"
-              if [ -z "$MERGE_BASE" ]; then
-                range="-1 ${HEAD_SHA}"
-              else
-                range="${MERGE_BASE}..${HEAD_SHA}"
+              # log` traverses exactly the PR-introduced commits. Fail closed
+              # with an actionable error if the merge base cannot be resolved
+              # (empty result or non-zero exit, e.g. an unexpected shallow or
+              # incomplete graph): scanning only the head commit would silently
+              # leave earlier PR commits unscanned while this required security
+              # job still passed.
+              if ! MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")" || [ -z "$MERGE_BASE" ]; then
+                echo "::error::gitleaks: could not resolve the merge base of base ${BASE_SHA} and head ${HEAD_SHA}; refusing to scan an incomplete commit range. Ensure the checkout has full history (fetch-depth: 0)." >&2
+                exit 1
               fi
+              range="${MERGE_BASE}..${HEAD_SHA}"
             else
               range="${BASE_SHA}..${HEAD_SHA}"
             fi

--- a/packages/scripts/__tests__/fork-pr-workflow-contract.test.ts
+++ b/packages/scripts/__tests__/fork-pr-workflow-contract.test.ts
@@ -50,7 +50,9 @@ function scanChangedCommitsRun(ci: Workflow): string {
     (s) => s.name === "Scan changed commits",
   );
   if (!step?.run) {
-    throw new Error("gitleaks 'Scan changed commits' step is missing a run body");
+    throw new Error(
+      "gitleaks 'Scan changed commits' step is missing a run body",
+    );
   }
   return step.run;
 }
@@ -159,13 +161,11 @@ function assertForkPrDispatchContract(
   // resolves the real merge base and passes a two-dot `merge-base..head` range
   // to `git log`. A three-dot `BASE...HEAD` range is the symmetric difference
   // and re-flags base-only commits the branch merely inherited (#19687).
-  expect(scanScript).toContain('range="${MERGE_BASE}..${HEAD_SHA}"');
+  expect(scanScript).toContain('range="$' + "{MERGE_BASE}..$" + '{HEAD_SHA}"');
   expect(scanScript).toContain('git merge-base "$BASE_SHA" "$HEAD_SHA"');
-  expect(scanScript).not.toContain(
-    "$" + "{BASE_SHA}..." + "$" + "{HEAD_SHA}",
-  );
+  expect(scanScript).not.toContain("$" + "{BASE_SHA}..." + "$" + "{HEAD_SHA}");
   // The push path keeps its own two-dot `before..sha` range unchanged.
-  expect(scanScript).toContain('range="${BASE_SHA}..${HEAD_SHA}"');
+  expect(scanScript).toContain('range="$' + "{BASE_SHA}..$" + '{HEAD_SHA}"');
   // An unresolvable merge base must fail closed with a non-zero exit rather
   // than fall back to scanning only the head commit.
   expect(scanScript).not.toContain("|| true");
@@ -239,9 +239,9 @@ describe("fork pull-request workflow dispatch (#18443)", () => {
         HEAD_SHA: pushed,
       });
       expect(range).toBe(`${before}..${pushed}`);
-      expect(git(repo, ["rev-list", range]).split("\n").filter(Boolean)).toEqual(
-        [pushed],
-      );
+      expect(
+        git(repo, ["rev-list", range]).split("\n").filter(Boolean),
+      ).toEqual([pushed]);
     } finally {
       rmSync(repo, { recursive: true, force: true });
     }

--- a/packages/scripts/__tests__/fork-pr-workflow-contract.test.ts
+++ b/packages/scripts/__tests__/fork-pr-workflow-contract.test.ts
@@ -1,10 +1,20 @@
 /**
  * Proves fork pull requests create only the canonical hosted CI workflow while
  * retaining develop compatibility, actionlint, and secret-scan coverage.
+ *
+ * Also locks the gitleaks "Scan changed commits" range semantics (#19687): the
+ * pull-request path must scan `merge-base..head` (only PR-introduced commits),
+ * the push path must keep its two-dot `before..sha` range, and an unresolvable
+ * merge base must fail closed instead of silently narrowing the scan. The
+ * diverged-graph suite executes the workflow's real range-selection shell over
+ * a scratch git repository so the `git diff`/`git log` semantic mix-up cannot
+ * recur.
  */
 
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -30,6 +40,80 @@ function workflow(name: string, source?: string): Workflow {
   return Bun.YAML.parse(
     source ?? readFileSync(join(workflowRoot, name), "utf8"),
   ) as Workflow;
+}
+
+// The literal `run:` body of the gitleaks range-selection step. The contract
+// tests exercise this exact shell so behavior is asserted against the shipped
+// workflow, not a copy.
+function scanChangedCommitsRun(ci: Workflow): string {
+  const step = ci.jobs?.secrets?.steps?.find(
+    (s) => s.name === "Scan changed commits",
+  );
+  if (!step?.run) {
+    throw new Error("gitleaks 'Scan changed commits' step is missing a run body");
+  }
+  return step.run;
+}
+
+// Runs the real range-selection shell, but stops before the `gitleaks detect`
+// invocation (gitleaks is not installed in this lane) and prints the computed
+// range so the test can feed it back to `git`.
+function runScanScript(
+  scanScript: string,
+  cwd: string,
+  env: Record<string, string>,
+): { status: number | null; stdout: string; stderr: string } {
+  const gitleaksAt = scanScript.indexOf("gitleaks detect");
+  if (gitleaksAt < 0) {
+    throw new Error("scan step no longer invokes gitleaks detect");
+  }
+  const probe = `${scanScript.slice(0, gitleaksAt)}printf 'RANGE<<<%s>>>' "$range"\n`;
+  const result = spawnSync("bash", ["-c", probe], {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function runRangeSelection(
+  scanScript: string,
+  cwd: string,
+  env: Record<string, string>,
+): string {
+  const result = runScanScript(scanScript, cwd, env);
+  if (result.status !== 0) {
+    throw new Error(
+      `range selection failed (status ${result.status}): ${result.stderr}`,
+    );
+  }
+  const match = result.stdout.match(/RANGE<<<(.*)>>>/s);
+  if (!match) {
+    throw new Error(`range not emitted; stdout=${result.stdout}`);
+  }
+  return match[1];
+}
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function makeTempRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gitleaks-range-"));
+  git(dir, ["init", "-q", "-b", "base"]);
+  git(dir, ["config", "user.email", "test@example.com"]);
+  git(dir, ["config", "user.name", "Range Test"]);
+  git(dir, ["config", "commit.gpgsign", "false"]);
+  return dir;
+}
+
+function commit(cwd: string, message: string): string {
+  git(cwd, ["commit", "-q", "--allow-empty", "-m", message]);
+  return git(cwd, ["rev-parse", "HEAD"]);
 }
 
 function assertForkPrDispatchContract(
@@ -69,13 +153,23 @@ function assertForkPrDispatchContract(
   const secretScan = ci.jobs?.secrets;
   expect(secretScan?.name).toBe("gitleaks");
   expect(secretScan?.["runs-on"]).toBe("ubuntu-24.04");
+  const scanScript = scanChangedCommitsRun(ci);
   expect(JSON.stringify(secretScan)).toContain("gitleaks detect");
-  // Canonical CI owns the only pull-request secret scan now, so it must keep
-  // the three-dot merge-base range from #17984; a two-dot range re-flags
-  // fixtures the branch merely inherited by merging develop.
-  expect(JSON.stringify(secretScan)).toContain(
+  // The pull-request path must scan exactly the PR-introduced commits, so it
+  // resolves the real merge base and passes a two-dot `merge-base..head` range
+  // to `git log`. A three-dot `BASE...HEAD` range is the symmetric difference
+  // and re-flags base-only commits the branch merely inherited (#19687).
+  expect(scanScript).toContain('range="${MERGE_BASE}..${HEAD_SHA}"');
+  expect(scanScript).toContain('git merge-base "$BASE_SHA" "$HEAD_SHA"');
+  expect(scanScript).not.toContain(
     "$" + "{BASE_SHA}..." + "$" + "{HEAD_SHA}",
   );
+  // The push path keeps its own two-dot `before..sha` range unchanged.
+  expect(scanScript).toContain('range="${BASE_SHA}..${HEAD_SHA}"');
+  // An unresolvable merge base must fail closed with a non-zero exit rather
+  // than fall back to scanning only the head commit.
+  expect(scanScript).not.toContain("|| true");
+  expect(scanScript).toMatch(/exit 1/);
   const required = JSON.stringify(ci.jobs?.required);
   expect(required).toContain("develop_pr");
   expect(required).toContain("needs.develop_pr.result");
@@ -97,6 +191,81 @@ describe("fork pull-request workflow dispatch (#18443)", () => {
     expect(() =>
       assertForkPrDispatchContract(ciSource, developSource, gitleaksSource),
     ).not.toThrow();
+  });
+
+  test("scans merge-base..head for a diverged pull request", () => {
+    const scanScript = scanChangedCommitsRun(workflow("ci.yml", ciSource));
+    const repo = makeTempRepo();
+    try {
+      // A shared root is the true branch point (merge base). The base branch
+      // then advances by one base-only commit while the PR adds one head-only
+      // commit, so `BASE...HEAD` (symmetric difference) contains both while
+      // `merge-base..HEAD` contains only the PR commit.
+      const root = commit(repo, "root");
+      const baseOnly = commit(repo, "base-only");
+      git(repo, ["checkout", "-q", "-b", "pr", root]);
+      const headOnly = commit(repo, "head-only");
+
+      const symmetric = git(repo, ["rev-list", `${baseOnly}...${headOnly}`])
+        .split("\n")
+        .filter(Boolean);
+      expect(symmetric).toContain(baseOnly);
+      expect(symmetric).toContain(headOnly);
+
+      const range = runRangeSelection(scanScript, repo, {
+        EVENT_NAME: "pull_request",
+        BASE_SHA: baseOnly,
+        HEAD_SHA: headOnly,
+      });
+      const scanned = git(repo, ["rev-list", range])
+        .split("\n")
+        .filter(Boolean);
+      expect(scanned).toEqual([headOnly]);
+      expect(scanned).not.toContain(baseOnly);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps the two-dot before..sha range for push events", () => {
+    const scanScript = scanChangedCommitsRun(workflow("ci.yml", ciSource));
+    const repo = makeTempRepo();
+    try {
+      const before = commit(repo, "before");
+      const pushed = commit(repo, "pushed");
+      const range = runRangeSelection(scanScript, repo, {
+        EVENT_NAME: "push",
+        BASE_SHA: before,
+        HEAD_SHA: pushed,
+      });
+      expect(range).toBe(`${before}..${pushed}`);
+      expect(git(repo, ["rev-list", range]).split("\n").filter(Boolean)).toEqual(
+        [pushed],
+      );
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("fails closed when the merge base cannot be resolved", () => {
+    const scanScript = scanChangedCommitsRun(workflow("ci.yml", ciSource));
+    const repo = makeTempRepo();
+    try {
+      // Two unrelated root histories share no merge base, so `git merge-base`
+      // exits non-zero and the step must fail rather than narrow the scan.
+      const base = commit(repo, "base-root");
+      git(repo, ["checkout", "-q", "--orphan", "orphan"]);
+      const head = commit(repo, "orphan-root");
+      const result = runScanScript(scanScript, repo, {
+        EVENT_NAME: "pull_request",
+        BASE_SHA: base,
+        HEAD_SHA: head,
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("could not resolve the merge base");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
   });
 
   test("fails if either specialized workflow restores a PR trigger", () => {


### PR DESCRIPTION
# Relates to

Fixes #19687. Corrects the repair made in #17971 / #17984.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker. — See **Known gaps / failures**: this is a CI workflow change plus a tracked contract test; validation was scoped to the focused `packages/scripts` contract test, changed-file Biome, YAML parse, and `git diff --check`.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@05fd0213ec17cf1e62f2edc4ac6fa1d3f4dd6407:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below. — See note; CI-only change, no build surface exercised.

# Risks

Low. The workflow change is confined to the revision range computation in the
`gitleaks` job's "Scan changed commits" step in `.github/workflows/ci.yml`. It
narrows what gitleaks scans (from a symmetric-difference commit set to only the
PR-introduced commits), reducing false positives. It does not weaken scanning
of the PR's own commits. When the merge base cannot be resolved it now **fails
closed** — emitting an actionable `::error::` and exiting non-zero — rather than
silently scanning only the head commit. No other workflow is touched. The
second changed file is a tracked contract test and has no runtime effect.

# Background

## What does this PR do?

The required `gitleaks` job built its `git log` revision range using a
**three-dot** range for `pull_request` events:

```bash
range="${BASE_SHA}...${HEAD_SHA}"
```

The inline comment claimed this yields `merge-base(base,head)..head`. That is
true for `git diff A...B`, but **wrong for `git log A...B`**. `gitleaks
--log-opts` feeds its underlying `git log -p`, where `A...B` is the
**symmetric difference** and includes commits reachable only from the base
side. Because `pull_request.base.sha` is the base tip at event time (not the
actual merge base), a PR whose base branch advanced after the branch point
made gitleaks scan every base-only commit the PR never introduced. A finding in
one of those inherited commits could block an otherwise valid PR through the
stable `CI / Required` status.

The fix computes the real merge base explicitly and uses a **two-dot** range so
`git log` traverses exactly the PR-introduced commits. If the merge base cannot
be resolved (empty result or a non-zero `git merge-base` exit, e.g. an
unexpected shallow/incomplete graph) the step **fails closed** instead of
scanning a partial range:

```bash
if ! MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")" || [ -z "$MERGE_BASE" ]; then
  echo "::error::gitleaks: could not resolve the merge base of base ${BASE_SHA} and head ${HEAD_SHA}; refusing to scan an incomplete commit range. Ensure the checkout has full history (fetch-depth: 0)." >&2
  exit 1
fi
range="${MERGE_BASE}..${HEAD_SHA}"
```

The push branch (`${BASE_SHA}..${HEAD_SHA}`) and the zero-SHA/no-base root path
(`-1 ${HEAD_SHA}`, used when `BASE_SHA` is empty or all-zero) are unchanged. The
misleading comment is rewritten to describe `git log` semantics accurately. This
corrects the #17971 / #17984 repair, which correctly identified the original
inherited-commit problem but introduced the wrong commit-set semantics for
`git log`.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue) — CI workflow only.

# Documentation changes needed?

My changes do not require a change to the project documentation. The
`.github/workflows/ci.yml` inline comment is updated in-place to accurately
describe the `git log` range semantics.

# Testing

## Where should a reviewer start?

`.github/workflows/ci.yml` — the `gitleaks` job's "Scan changed commits" step.

Two files change:

1. `.github/workflows/ci.yml` — the range-computation fix and fail-closed
   merge-base handling.
2. `packages/scripts/__tests__/fork-pr-workflow-contract.test.ts` — the tracked
   deterministic regression test that is the CI-runnable verification surface
   for this change (extracts the workflow's real "Scan changed commits" `run:`
   body from `ci.yml` and executes it over scratch git repos).

## Detailed testing steps

Because `pull_request.base.sha` / head SHAs are event-time values, the semantics
are proven with a deterministic git harness (below) that reproduces the
issue's scenario: a base branch that advances after the branch point.

# Evidence Gate

<!-- evidence-head:f3442eac0ca02f0802ac247baea9321c841a2e14 -->

This is a CI-only YAML/shell change with no rendered UI, backend, agent, or
domain surface. UI/LLM/media evidence rows are marked `N/A` with reasons and the
proof is a deterministic git-semantics harness plus static validation.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CI workflow (.github/workflows/ci.yml) change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - CI workflow change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - CI workflow change; no interactive user flow to record.
<!-- evidence-row:backend-logs -->
- [ ] N/A - CI-only YAML/shell change; the changed code path is git range computation, proven by the deterministic git-semantics harness in the PR body.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - CI workflow change; no frontend.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - CI workflow change; no agent/action/provider/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - CI-only change; the computed commit sets (git rev-list/log output) are shown in the PR body.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Deterministic before/after commit-set demonstration

Reproduces the issue scenario in a scratch repo: a branch point, one PR commit,
then the base branch (`develop`) advances by 20 commits after the branch point.
This mirrors the issue's real numbers (base tip `origin/develop`, head
`origin/pr-19569`): symmetric difference `11535 base-only + 1 head-only`, while
`merge-base..head` yields `1`.

<details>
<summary>Harness and output</summary>

```
$ git rev-list --left-right --count "$BASE_SHA...$HEAD_SHA"
20	1                # 20 base-only + 1 head-only commit (symmetric difference)

== OLD three-dot: git log BASE...HEAD count (what gitleaks scanned) ==
$ git rev-list --count "$BASE_SHA...$HEAD_SHA"
21                   # scans all 20 base-only commits + the 1 PR commit

== NEW two-dot: git log merge-base..HEAD count (what gitleaks scans now) ==
$ git merge-base "$BASE_SHA" "$HEAD_SHA"  # == the real branch point
$ git rev-list --count "$MERGE_BASE..$HEAD_SHA"
1                    # scans only the 1 PR-introduced commit
015a5d5 PR commit (the only thing this PR added)
```

Fail-closed path (unrelated histories → no merge base):

```
$ git merge-base "$BASE_SHA" "$HEAD_SHA"    # non-zero exit / empty result
::error::gitleaks: could not resolve the merge base ...; refusing to scan an
incomplete commit range.
$ exit 1                                     # required security job fails closed
```
</details>

Real-issue numbers from #19687 (for reference): `git merge-base origin/develop
origin/pr-19569` → `5a249cd9…`; `git rev-list --left-right --count
origin/develop...origin/pr-19569` → `11535  1`; `git rev-list --count
5a249cd9..origin/pr-19569` → `1`. The old three-dot range scanned 11,535
unrelated base commits; the fix scans only the 1 PR commit.

## Deterministic contract test (CI-runnable verification surface)

`packages/scripts/__tests__/fork-pr-workflow-contract.test.ts` extracts the
workflow's real "Scan changed commits" `run:` body from `ci.yml` and executes it
(stopping before `gitleaks detect`) over scratch git repos. It asserts: the
diverged PR range is exactly `[head-only]` and excludes the base-only commit
(while the symmetric `BASE...HEAD` range contains both); `EVENT_NAME=push` keeps
the two-dot `before..sha` range; and two unrelated histories (no merge base)
make the step exit non-zero with `could not resolve the merge base`.

<details>
<summary>Exact-head verification (head <code>f3442eac0c</code>, repo-pinned Bun 1.3.14)</summary>

```
$ bun test packages/scripts/__tests__/fork-pr-workflow-contract.test.ts
5 pass  0 fail  52 expect() calls

$ bunx @biomejs/biome@2.5.7 check packages/scripts/__tests__/fork-pr-workflow-contract.test.ts
Checked 1 file in 25ms. No fixes applied.   # exit 0

$ Bun.YAML.parse(.github/workflows/ci.yml)  # YAML OK
$ git diff --check                          # clean
```
</details>

## Real LLM-call trajectory

`N/A - CI workflow change; no agent/action/provider/prompt/model behavior changed.`

## Backend + frontend logs

Backend path proof is the git-semantics harness above (the changed code path is
git range computation). Frontend: `N/A - no frontend.`

## Screenshots (before / after) + video walkthrough

`N/A - CI workflow (.github/workflows/ci.yml) change; no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/audio surface.`

## Known gaps / failures

- `bun run verify` (full monorepo gate) was not run: this is a CI workflow
  change plus a tracked `packages/scripts` contract test, with no wider package
  build surface. Validation was scoped to the focused contract test, changed-file
  Biome, YAML parse, and `git diff --check` rather than a full monorepo build.
  Not a blocker for a two-file workflow/contract-test change.
- `actionlint` is not installed on this build host, so it was not run at exact
  head `f3442eac0c` locally; YAML was validated with `Bun.YAML.parse` and the
  extracted shell body executes under the contract test. Maintainer review has
  independently confirmed `actionlint` passes on a synthetic integration of this
  head onto current `develop`.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@05fd0213ec17cf1e62f2edc4ac6fa1d3f4dd6407:packages/skills/skills/contribute-to-eliza"} -->


