### PR TITLE
fix(cloud): authorize canonical DM recovery import

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-agent-router.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-agent-router.test.ts
@@ -231,6 +231,7 @@ describe("ElizaSandboxService Worker agent-router fetch", () => {
         {
           ELIZA_CLOUD_AGENT_BASE_DOMAIN: "elizacloud.ai",
           AGENT_ROUTER_ORIGIN_HOST: "eliza-production-1.elizacloud.ai",
+          AGENT_SERVER_SHARED_SECRET: "server-secret",
         },
         () =>
           service().importCanonicalConversation(sandbox.id, "org-1", "personal:user-1", [
@@ -249,6 +250,7 @@ describe("ElizaSandboxService Worker agent-router fetch", () => {
         "https://eliza-production-1.elizacloud.ai/api/conversations/personal%3Auser-1/import",
       );
       expect(requests[0]?.headers.get("authorization")).toBe("Bearer agent-token");
+      expect(requests[0]?.headers.get("x-server-token")).toBe("server-secret");
       expect(requests[0]?.headers.get("x-forwarded-host")).toBe(`${sandbox.id}.elizacloud.ai`);
       expect(JSON.parse(requests[0]!.body)).toEqual({
         messages: [{ sourceId: "source-1", role: "user", text: "hello", timestamp: 123 }],

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -5546,12 +5546,15 @@ export class ElizaSandboxService {
   } | null> {
     const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
     if (!rec) return null;
+    const serverSecret = getCloudAwareEnv().AGENT_SERVER_SHARED_SECRET?.trim();
+    if (!serverSecret) return null;
 
     const res = await this.fetchCanonicalConversationApi(
       rec,
       `/api/conversations/${encodeURIComponent(conversationId)}/import`,
       {
         method: "POST",
+        headers: { "X-Server-Token": serverSecret },
         body: JSON.stringify({ messages }),
         signal: AbortSignal.timeout(20_000),
       },


### PR DESCRIPTION
## Summary

- authenticate automatic canonical DM conversation recovery with the Cloud Worker server secret
- keep the tenant-scoped forwarded host and per-agent bearer credential intact
- fail closed when the trusted server credential is unavailable

## Why

Telegram DM recovery correctly detected a missing canonical conversation and reached the runtime import endpoint, but production rejected the import because that privileged endpoint requires the trusted server token. This makes the existing repair flow authorized without broadening the public route.

## Verification

- `bun test packages/cloud/shared/src/lib/services/eliza-sandbox-agent-router.test.ts` (11 passed)
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/eliza-sandbox.ts packages/cloud/shared/src/lib/services/eliza-sandbox-agent-router.test.ts`
- `bun run --cwd packages/cloud/shared typecheck`
- `git diff --check`

## Evidence

- Unit coverage asserts the import request carries `X-Server-Token`, the per-agent bearer credential, and the canonical tenant route.
- Live production webhook validation will be run from the exact merged main revision.

## AI provenance

- Tool: Codex desktop
- Model: OpenAI GPT-5
- Repository guidance: `elizaOS/eliza@404fd6cd53a6ec101fe9288fdd44885fe7601f2a:packages/skills/skills/contribute-to-eliza`
