### PR TITLE
fix(plugin-calendar): planner debris in recurrenceScope degrades to unset

### DIFF
--- a/plugins/plugin-calendar/src/actions/calendar-handler.recurrence-scope.test.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.recurrence-scope.test.ts
@@ -44,6 +44,26 @@ describe("resolveRecurrenceScopeIntent planner boundary", () => {
     ).toBe("instance");
   });
 
+  it("treats debris from the update extraction as unspecified", () => {
+    expect(
+      resolveRecurrenceScopeIntent({
+        details: undefined,
+        fallbackDetails: { recurrenceScope: ',series:"' },
+        text: "change the standup",
+      }),
+    ).toBeNull();
+  });
+
+  it("uses explicit update extraction before falling back to phrasing", () => {
+    expect(
+      resolveRecurrenceScopeIntent({
+        details: undefined,
+        fallbackDetails: { recurrenceScope: "series" },
+        text: "change just this standup occurrence",
+      }),
+    ).toBe("series");
+  });
+
   it("stays null when both detail and phrasing are ambiguous", () => {
     expect(
       resolveRecurrenceScopeIntent({

--- a/plugins/plugin-calendar/src/actions/calendar-handler.recurrence-scope.test.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.recurrence-scope.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Pins the planner-boundary contract for `recurrenceScope`: recognized values
+ * normalize, junk degrades to "not specified" (falling back to the user's own
+ * phrasing), and ambiguity stays null. Deterministic — drives the exported
+ * resolver directly, no runtime or model.
+ *
+ * The case that matters: small models filling the aliased schema have been
+ * observed emitting fragments of neighboring key names into detail values.
+ * `normalizeRecurrenceScope` fail-closes such input with a 400 — correct for
+ * API callers, but at the action boundary it killed the whole update/delete
+ * turn for a value that carries no user intent, while every sibling detail
+ * (calendarId, windows, mode, side, grantId) already degrades junk to unset.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { resolveRecurrenceScopeIntent } from "./calendar-handler.js";
+
+describe("resolveRecurrenceScopeIntent planner boundary", () => {
+  it("honors a recognized explicit scope", () => {
+    expect(
+      resolveRecurrenceScopeIntent({
+        details: { recurrenceScope: "series" },
+        text: "delete my standup",
+      }),
+    ).toBe("series");
+  });
+
+  it("treats planner debris as unspecified instead of throwing", () => {
+    expect(
+      resolveRecurrenceScopeIntent({
+        details: { recurrenceScope: ',time_max:"' },
+        text: "delete my standup",
+      }),
+    ).toBeNull();
+  });
+
+  it("falls back to the user's own phrasing past a junk detail", () => {
+    expect(
+      resolveRecurrenceScopeIntent({
+        details: { recurrenceScope: ",series:" },
+        text: "cancel just this one occurrence of the standup",
+      }),
+    ).toBe("instance");
+  });
+
+  it("stays null when both detail and phrasing are ambiguous", () => {
+    expect(
+      resolveRecurrenceScopeIntent({
+        details: undefined,
+        text: "change the standup",
+      }),
+    ).toBeNull();
+  });
+});

--- a/plugins/plugin-calendar/src/actions/calendar-handler.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.ts
@@ -477,11 +477,14 @@ function lenientRecurrenceScope(
  */
 export function resolveRecurrenceScopeIntent(args: {
   details: Record<string, unknown> | undefined;
+  fallbackDetails?: Record<string, unknown>;
   text: string;
 }): LifeOpsCalendarRecurrenceScope | null {
-  const explicit = lenientRecurrenceScope(
-    detailString(args.details, "recurrenceScope"),
-  );
+  const explicit =
+    lenientRecurrenceScope(detailString(args.details, "recurrenceScope")) ??
+    lenientRecurrenceScope(
+      detailString(args.fallbackDetails, "recurrenceScope"),
+    );
   if (explicit) {
     return explicit;
   }
@@ -4353,16 +4356,9 @@ const calendarAction: CalendarHandlerAction = {
           detailRecurrenceLines(extractedForUpdate);
         let recurrenceScopeForUpdate = resolveRecurrenceScopeIntent({
           details,
+          fallbackDetails: extractedForUpdate,
           text: `${messageText(message)} ${intent}`,
         });
-        if (!recurrenceScopeForUpdate) {
-          recurrenceScopeForUpdate =
-            normalizeRecurrenceScope(
-              typeof extractedForUpdate.recurrenceScope === "string"
-                ? extractedForUpdate.recurrenceScope
-                : undefined,
-            ) ?? null;
-        }
         // A recurrence-rule change is inherently a series edit.
         if (recurrenceUpdate && !recurrenceScopeForUpdate) {
           recurrenceScopeForUpdate = "series";

--- a/plugins/plugin-calendar/src/actions/calendar-handler.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.ts
@@ -449,16 +449,37 @@ const RECURRENCE_SCOPE_SERIES_PATTERN =
   /\b(?:whole|entire|full)\s+series\b|\bthe\s+series\b|\ball\s+(?:occurrences|instances|of\s+them)\b|\bevery\s+(?:occurrence|instance|single\s+one)\b|\bstop\s+(?:it\s+)?(?:from\s+)?(?:repeating|recurring)\b|\bcancel\s+the\s+recurring\b/i;
 
 /**
+ * Planner-authored `recurrenceScope` at the action boundary: recognized values
+ * normalize, anything else means "the user did not specify". The strict
+ * normalizer's fail-closed 400 is for API callers; here the value is
+ * model-emitted, and junk in it (observed as fragments of neighboring key
+ * names) must degrade to unset — the same contract this file already applies
+ * to planner-authored calendarId, windows, mode, side, and grantId — so a
+ * mutation turn falls back to the user's own phrasing instead of dying.
+ */
+function lenientRecurrenceScope(
+  value: unknown,
+): LifeOpsCalendarRecurrenceScope | null {
+  try {
+    return normalizeRecurrenceScope(value) ?? null;
+  } catch {
+    // error-policy:J3 model-emitted debris is "not specified"; scope intent
+    // falls back to explicit message phrasing below.
+    return null;
+  }
+}
+
+/**
  * Structural resolution of one, following, or whole-series intent: explicit
  * `recurrenceScope` detail first, then unambiguous message phrasing. Returns
  * null when the intent stays ambiguous — the caller must ask instead of
  * mutating.
  */
-function resolveRecurrenceScopeIntent(args: {
+export function resolveRecurrenceScopeIntent(args: {
   details: Record<string, unknown> | undefined;
   text: string;
 }): LifeOpsCalendarRecurrenceScope | null {
-  const explicit = normalizeRecurrenceScope(
+  const explicit = lenientRecurrenceScope(
     detailString(args.details, "recurrenceScope"),
   );
   if (explicit) {


### PR DESCRIPTION
## What

A recurring-event **update or delete turn died with a 400** whenever the planner emitted junk into `recurrenceScope` — observed live as fragments of neighboring key names (e.g. `",series:"`) filling the detail. The user asked to change or cancel an event and got a hard failure for a value that carries no user intent.

## Root cause

`resolveRecurrenceScopeIntent` fed the planner-authored detail straight into `normalizeRecurrenceScope`, whose fail-closed 400 is designed for API callers. Every sibling planner detail in this handler — `calendarId`, time windows, `mode`, `side`, `grantId` — already degrades junk to unset (#18946 and predecessors); `recurrenceScope` was the one holdout.

## Change

Route the detail through a lenient boundary (`error-policy:J3`): a recognized value still normalizes; junk means "not specified", so scope intent falls back to the user's own phrasing; ambiguity still ends in a question, never a mutation. The strict normalizer is unchanged for API callers.

Part of the live-proven reminder/calendar mis-route arc (the routing floor and calendar-selector halves already landed via `537231a12ee` and #18946); this ports the remaining piece develop lacks.

## Evidence

<!-- evidence-head:36eb03b528199cd654c1547a395cc983aff12ec8 -->

<!-- evidence-row:before-screenshots -->
N/A - no UI surface; chat-action parameter boundary

<!-- evidence-row:after-screenshots -->
N/A - no UI surface; chat-action parameter boundary

<!-- evidence-row:walkthrough-video -->
N/A - no UI surface

<!-- evidence-row:backend-logs -->
Live failure shape this boundary removes (from the 2026-08-13 nubilio session where the equivalent patch was A/B-proven): a calendar mutation turn rejected with `CALENDAR_INVALID_RECURRENCE_SCOPE` / hard 400 paraphrased to the user as a calendar failure, for planner-authored debris the user never said.

<!-- evidence-row:frontend-logs -->
N/A - no frontend surface in this change

<!-- evidence-row:llm-trajectory -->
N/A - the fix is a deterministic parameter boundary below the model; the debris shape it guards is pinned verbatim in the test

<!-- evidence-row:domain-artifacts -->
New `calendar-handler.recurrence-scope.test.ts` drives the exported resolver directly:

- a recognized explicit scope still normalizes
- planner debris (`',time_max:"'`) degrades to unspecified instead of throwing
- past a junk detail, the user's own phrasing ("cancel just this one occurrence") resolves the scope
- ambiguity stays null (the caller asks, never mutates)

<details>
<summary>results</summary>
<pre>
 calendar action suites: 3 passed | 1 skipped
 Tests: 34 passed | 2 skipped
</pre>
</details>

The debris test fails on the parent commit with the exact live shape: `CalendarServiceError: recurrenceScope must be "instance", "this_and_following", or "series"`.

<!-- evidence-row:ocr-review -->
N/A - no rendered text or imagery

## Contribution provenance

AI assistance is self-reported provenance, not a request for hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes - agent-authored under human direction, ported from a live-proven deployment patch
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5, anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code (Eliza sub-agent)
<!-- attribution-row:skill-revision -->
- Contribution skill revision: N/A - authored from live deployment evidence, not the pinned contribute-to-eliza skill
<!-- attribution-row:status -->
- Attribution status: self-reported
