### PR TITLE
feat(core): identity knowledge belongs in the prompt, not behind retrieval

### DIFF
--- a/packages/core/src/runtime/__tests__/system-prompt.test.ts
+++ b/packages/core/src/runtime/__tests__/system-prompt.test.ts
@@ -9,10 +9,74 @@ import { describe, expect, it } from "vitest";
 import {
 	buildCanonicalSystemPrompt,
 	dropDuplicateLeadingSystemMessage,
+	renderInlineCharacterKnowledge,
 	resolveEffectiveSystemPrompt,
 } from "../system-prompt";
 
 describe("system prompt helpers", () => {
+	it("puts inline character knowledge in the prompt, after bio", () => {
+		const prompt = buildCanonicalSystemPrompt({
+			character: {
+				name: "Ada",
+				system: "Policy.",
+				bio: ["Fast."],
+				knowledge: [
+					"Shaw founded elizaOS.",
+					"Cloud apps can set inference markup.",
+				],
+			},
+		});
+		expect(prompt).toContain(
+			"# What Ada knows\nShaw founded elizaOS.\nCloud apps can set inference markup.",
+		);
+		expect(prompt.indexOf("# About Ada")).toBeLessThan(
+			prompt.indexOf("# What Ada knows"),
+		);
+	});
+
+	it("keeps document sources out of the prompt: paths, directories, typed items", () => {
+		const rendered = renderInlineCharacterKnowledge([
+			"A real fact.",
+			"/abs/manual.pdf",
+			"./rel/notes.md",
+			"../up/doc.txt",
+			"~/home/doc.txt",
+			"file:///x.txt",
+			"C:\\win\\doc.txt",
+			{ item: { case: "path", value: "/a/b.md" } },
+			{ path: "/c/d.md" },
+			{ directory: "/e/dir" },
+			42,
+			"",
+			"   ",
+		]);
+		expect(rendered).toBe("A real fact.");
+	});
+
+	it("expands name tokens inside knowledge and omits the section when empty", () => {
+		const withTokens = buildCanonicalSystemPrompt({
+			character: {
+				name: "Ada",
+				system: "s",
+				bio: [],
+				knowledge: ["{{name}} runs on elizaOS."],
+			},
+		});
+		expect(withTokens).toContain("Ada runs on elizaOS.");
+		const empty = buildCanonicalSystemPrompt({
+			character: { name: "Ada", system: "s", bio: [], knowledge: [] },
+		});
+		expect(empty).not.toContain("What Ada knows");
+	});
+
+	it("bounds knowledge to the character budget instead of flooding the prompt", () => {
+		const facts = Array.from({ length: 100 }, (_, i) => `Fact ${i} ${"x".repeat(80)}.`);
+		const rendered = renderInlineCharacterKnowledge(facts);
+		expect(rendered.length).toBeLessThanOrEqual(1500 + facts.length);
+		expect(rendered).toContain("Fact 0");
+		expect(rendered).not.toContain("Fact 99");
+	});
+
 	it("renders character system, bio, then user role", () => {
 		const prompt = buildCanonicalSystemPrompt({
 			character: {

--- a/packages/core/src/runtime/__tests__/system-prompt.test.ts
+++ b/packages/core/src/runtime/__tests__/system-prompt.test.ts
@@ -70,7 +70,10 @@ describe("system prompt helpers", () => {
 	});
 
 	it("bounds knowledge to the character budget instead of flooding the prompt", () => {
-		const facts = Array.from({ length: 100 }, (_, i) => `Fact ${i} ${"x".repeat(80)}.`);
+		const facts = Array.from(
+			{ length: 100 },
+			(_, i) => `Fact ${i} ${"x".repeat(80)}.`,
+		);
 		const rendered = renderInlineCharacterKnowledge(facts);
 		expect(rendered.length).toBeLessThanOrEqual(1500 + facts.length);
 		expect(rendered).toContain("Fact 0");

--- a/packages/core/src/runtime/system-prompt.ts
+++ b/packages/core/src/runtime/system-prompt.ts
@@ -36,8 +36,35 @@ export function normalizeSystemPromptRole(
 	return normalized || undefined;
 }
 
+/**
+ * Character `knowledge` entries that are inline facts rather than document
+ * sources. Path-shaped strings and `{ path | directory }` objects are document
+ * ingestion inputs (see DocumentService.processCharacterDocuments) and stay out
+ * of the prompt; everything else is identity-tier content the character author
+ * wrote to be known, not retrieved.
+ */
+const PATHLIKE_RE = /^(?:\.{0,2}[\\/]|~[\\/]|file:\/\/|[A-Za-z]:[\\/])/;
+
+export function renderInlineCharacterKnowledge(
+	value: unknown,
+	maxChars = 1500,
+): string {
+	if (!Array.isArray(value)) return "";
+	const facts: string[] = [];
+	let total = 0;
+	for (const entry of value) {
+		if (typeof entry !== "string") continue;
+		const fact = entry.trim();
+		if (!fact || PATHLIKE_RE.test(fact)) continue;
+		if (total + fact.length > maxChars) break;
+		total += fact.length;
+		facts.push(fact);
+	}
+	return facts.join("\n");
+}
+
 export function buildCanonicalSystemPrompt(args: {
-	character?: Pick<Character, "name" | "system" | "bio"> | null;
+	character?: Pick<Character, "name" | "system" | "bio" | "knowledge"> | null;
 	userRole?: RoleGateRole | string | null;
 }): string {
 	const character = args.character;
@@ -50,10 +77,19 @@ export function buildCanonicalSystemPrompt(args: {
 		name,
 	);
 	const bio = replaceNameTokens(renderSystemPromptBio(character?.bio), name);
+	// Identity knowledge is always in the prompt, like bio. The documents store
+	// also ingests these entries for semantic recall, but retrieval is gated to
+	// contexts Stage-1 does not select for identity questions ("who made you"),
+	// which are exactly the questions this content exists to answer.
+	const knowledge = replaceNameTokens(
+		renderInlineCharacterKnowledge(character?.knowledge),
+		name,
+	);
 	const role = normalizeSystemPromptRole(args.userRole);
 	return [
 		system,
 		bio ? `# About ${name}\n${bio}` : "",
+		knowledge ? `# What ${name} knows\n${knowledge}` : "",
 		role ? `user_role: ${role}` : "",
 	]
 		.filter(Boolean)


### PR DESCRIPTION
## What

Inline `character.knowledge` strings were ingested into the documents store and then only reachable through retrieval, which Stage-1 gates to the documents context. Identity questions ("who made you", "what is elizaos") never select that context — and they are exactly the questions this content exists to answer. An author could write knowledge and watch the agent never use it.

Identity knowledge now renders into `buildCanonicalSystemPrompt` after the bio, at the same tier as bio itself:

```
You are Eliza.

# About Eliza
Short.

# What Eliza knows
Eliza Cloud lets builders monetize apps with inference markup.
Shaw founded elizaOS.
```

## Boundaries kept

- Path-shaped entries (absolute, relative, `~`, `file://`, drive-letter, and `{path|directory}` objects) remain document sources and stay out of the prompt. Document ingestion for semantic recall is unchanged.
- The section is bounded to 1500 chars so a large knowledge array cannot flood every prompt.
- Name tokens (`{{name}}`) expand inside knowledge like they do in bio.

## Evidence Gate

<!-- evidence-head:658fcf73e14fec64d579140198192e0809285351 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - core prompt assembly, no rendered surface
<!-- evidence-row:after-screenshots -->
- [x] N/A - core prompt assembly, no rendered surface
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive flow
<!-- evidence-row:backend-logs -->
- [x] Loaded the real module and inspected the produced prompt:
```
prompt:
 |You are Eliza.
 |# About Eliza
 |Short.
 |# What Eliza knows
 |Eliza Cloud lets builders monetize apps with inference markup.
 |Shaw founded elizaOS.
paths excluded: true   (all six path spellings)
facts included: true
```
```
$ vitest run src/runtime/__tests__/system-prompt.test.ts
Tests  12 passed (12)
$ vitest run src/features/basic-capabilities/providers
Tests  84 passed (84)
```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser-reachable code
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic prompt assembly; no model behavior is exercised by this change itself
<!-- evidence-row:domain-artifacts -->
- [x] The rendered prompt is the domain artifact, inspected directly:
```
$ bun -e "import {buildCanonicalSystemPrompt} from './system-prompt.ts'; ..."
# What Eliza knows
Eliza Cloud lets builders monetize apps with inference markup.
Shaw founded elizaOS.
-- paths excluded: true; section omitted when knowledge is empty: true
```

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- ai-assistance: yes
<!-- attribution-row:models -->
- models: anthropic/claude-opus-4-8
<!-- attribution-row:client -->
- client: Claude Code
<!-- attribution-row:skill-revision -->
- skill-revision: N/A - no packaged skill governed this change
<!-- attribution-row:status -->
- status: self-reported

