### PR TITLE
test(ui): register RTL cleanup in the first-run conductor suite (unmask #19692 client-lane failures)

### DIFF
--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -10,7 +10,7 @@
  * singleton + the background model download).
  */
 
-import { renderHook, waitFor } from "@testing-library/react";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FIRST_RUN_SIGN_IN_PROMPT } from "./first-run-greeting";
@@ -300,6 +300,12 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Unmount every conductor rendered by the test FIRST (globals: false in
+  // vitest.config.ts means @testing-library/react never auto-registers this).
+  // Otherwise a still-mounted conductor re-reads the store when the next line
+  // clears it, and the unseeded test fallback answers `firstRunName` with a
+  // function — masking real failures as a `normalizeFirstRunName` TypeError.
+  cleanup();
   __setAppValueForTests(null);
   resetTutorialState();
   ensureLocalStorage().clear();


### PR DESCRIPTION
# Relates to

- Fixes (partially — see **Known gaps**) #19692

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`.
- [x] `bun install` was run after sync; package `typecheck`/`lint`/focused tests were run (see below). `bun run verify` was not fully run on this machine (see **Known gaps**).
- [x] A reviewer can confirm the change works without reading the code, from the before/after test output below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@2c8c36908538fe5acf2a55b7c54d908808517d47:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Branched from the latest `origin/develop` (`2c8c369085`); zero conflicts.
- [ ] `bun run verify` passes post-sync — not run to completion on this machine; see **Known gaps**. Package-scoped `typecheck`, `lint`, and the affected/neighbor suites were run and pass.

# Risks

**Low.** Test-harness-only change: it adds `@testing-library/react`'s `cleanup()`
to one suite's `afterEach`. It changes no production/runtime code and no
assertion. It mirrors the pattern already used by the sibling suite
`packages/ui/src/backgrounds/useAppearanceApplyChannel.test.tsx`.

# Background

## What does this PR do?

The `Tests (client)` lane (and Smoke 1/3/4/5/6) is red on every open PR because
`packages/ui/src/first-run/use-first-run-conductor.test.ts` crashes with an
**opaque** `TypeError: (value ?? "").trim is not a function` thrown from
`normalizeFirstRunName` — which hides the *real* failures.

This PR fixes **Defect 1 (the masking)** and, per the scout work order's
STOP-condition, does **not** guess at a behavioral change for **Defect 2 (the
real regression)** — instead it documents the exact root cause below so a
maintainer can decide the correct test migration. See **Known gaps**.

### Defect 1 — missing React Testing Library cleanup (fixed here)

`packages/ui/vitest.config.ts` sets `globals: false`, so
`@testing-library/react` never auto-registers its `afterEach(cleanup)`. A
conductor mounted by one test stays mounted into the next test's `afterEach`.
When that `afterEach` runs `__setAppValueForTests(null)`, the still-mounted
conductor re-reads the app store through `useAppSelectorShallow`. With the store
cleared, `readAppValue()`'s `NODE_ENV=test` fallback
(`packages/ui/src/state/app-store.ts`) answers **every unknown field with
`noop` (a function)**, so `firstRunName` arrives as a function and
`normalizeFirstRunName` (`packages/ui/src/first-run/first-run.ts:71`) throws
`(value ?? "").trim is not a function` — far from the real cause, and as an
*unhandled* error that aborts cleanly-passing neighbours too.

The fix mirrors the already-correct sibling suite
`src/backgrounds/useAppearanceApplyChannel.test.tsx`, which does
`cleanup(); __setAppValueForTests(null);`: add `cleanup` to the
`@testing-library/react` import and call it as the **first** statement in the
failing suite's `afterEach`.

With the cleanup in place the 19 opaque `TypeError`s become **legible assertion
failures**, and the previously-poisoned tests stop tearing down mid-flight.

### Defect 2 — the real regression: the cloud path moved to `getPersonalSharedEliza` (NOT fixed here — needs a maintainer decision)

After Defect 1, the 19 remaining failures reproduce **in isolation** (single
`-t` run), so they are genuine regressions, not cross-test pollution. They are
**not** a "greeting never seeds" bug — the greeting seeds fine (all LOCAL-path,
fuzz, and greeting-seed tests pass). Every remaining failure is on the **cloud
onboarding** path and reduces to:

> the conductor's cloud pick now calls `client.getPersonalSharedEliza(...)`,
> but the test still mocks/asserts `client.selectOrProvisionCloudAgent(...)`.

Trace: `runtime:cloud` → `startCloudProvisionFlow()` →
`listOrAutoProvisionCloudAgent()` (`first-run-finish.ts`) → `runJoinFlow()`
(`src/cloud/join/lib/run-join-flow.ts`) → **`client.getPersonalSharedEliza()`**.
The suite's `mocks.client` has no `getPersonalSharedEliza`, so the call is
`undefined`, the flow rejects into `seedError`, `selectOrProvisionCloudAgent`
is never called, and every `expected 1 call, got 0` / `expected undefined to be
truthy (first-run:tutorial)` assertion fails.

This is a **landed** regression, not one of the open PRs below. `git log`
attributes the contract change to merged PR **#19511
(`a8a8b8d3e0` "feat(cloud): ship phone-first personal Eliza")**, which rewrote
`listOrAutoProvisionCloudAgent` from the old multi-agent list/select flow to the
rowless personal-Eliza `getPersonalSharedEliza` flow. That PR migrated its
**sibling** first-run-finish suites
(`first-run-finish.firstload-chain.test.ts`,
`first-run-finish.reused-shared-handoff.test.ts` now mock `getPersonalSharedEliza`)
but did **not** migrate `use-first-run-conductor.test.ts`, leaving it asserting
the removed `selectOrProvisionCloudAgent` / `getCloudCompatAgents` /
`preferAgentId` / `knownAgents` / multi-agent-picker contract. The scout's
"blamed commit `0468c1850a`" is unrelated (a cosmetic `elizacloud.ai` →
`eliza.app` domain change).

Why this is **not** fixed in this PR: greening the 19 tests correctly requires a
**behavioral** test migration to the personal-Eliza contract. ~13 of them just
need the mock swapped (`getPersonalSharedEliza` for
`selectOrProvisionCloudAgent`), but ~6 assert semantics that #19511
**deliberately removed** — e.g. "prefers the active Settings cloud agent without
surfacing a picker", "binds directly without surfacing the agent selector",
"zero agents narrate ONLY the real provisioning (create flow)",
"silent entry … one agent … `preferAgentId`". A rowless personal Eliza has no
agent list, no picker, no `preferAgentId`/`knownAgents`, and no create-narration
path, so those tests can't be greened without **deleting/rewriting assertions**
and **deciding new product behavior** (is there still a welcome-back turn? what
does provisioning narrate now?). Per the work order, that is a maintainer /
#19511-author decision, and I will not silently weaken assertions or guess at a
conflicting behavioral change. The correct follow-up is a focused test migration
owned alongside #19511's contract.

## What kind of change is this?

Bug fix (test-harness hygiene) + root-cause documentation for a separate landed
regression.

## Overlapping open PRs (acknowledged; this change is orthogonal)

- **#19336** — onboarding completion across shell remounts (`App.tsx`,
  `ChatOverlay.tsx`). Different files/behavior; does not touch this suite's
  `afterEach` or the RTL cleanup.
- **#19271** — bound the first-run cloud sign-in wait. It *does* touch
  `use-first-run-conductor.ts` / `.test.ts`, but it was written against the
  **old** `selectOrProvisionCloudAgent` contract (it adds
  `expect(mocks.client.selectOrProvisionCloudAgent).not.toHaveBeenCalled()`) and
  adds **no** RTL `cleanup()`. My one-line import + `cleanup()` call is
  independent of its changes and will not conflict semantically.
- **#19186** — first-turn warming 503 / 402 credit gate (`api/client-base.ts`,
  new files). Unrelated surface.

None of the three add the RTL cleanup, and none migrate the conductor suite to
the personal-Eliza contract, so this change is orthogonal and safe to land ahead
of them. (No prior open PR claims #19692.)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/ui/src/first-run/use-first-run-conductor.test.ts` `afterEach` (the
7-line diff) and the before/after test output below.

## Detailed testing steps

```bash
# repo root
bun install
node packages/shared/scripts/generate-keywords.mjs   # generate i18n data the ui suite imports
bun run --cwd packages/cloud/routing build            # build dep for ui typecheck

cd packages/ui
bunx vitest run src/first-run/use-first-run-conductor.test.ts
bunx vitest run src/first-run/use-first-run-conductor.fuzz.test.ts \
                src/first-run/first-run.test.ts \
                src/backgrounds/useAppearanceApplyChannel.test.tsx
bun run typecheck
bunx biome check src/first-run/use-first-run-conductor.test.ts
```

### Before (no cleanup fix) — opaque crash masks the real failures

```
⎯⎯ Failed Tests 19 ⎯⎯
⎯⎯ Unhandled Errors ⎯⎯
TypeError: (value ?? "").trim is not a function
 ❯ normalizeFirstRunName src/first-run/first-run.ts:71:24
 ❯ Module.useFirstRunConductor src/first-run/use-first-run-conductor.ts:448:16
 (x19)
 Test Files  1 failed (1)
      Tests  19 failed | 41 passed (60)
     Errors  19 errors
```

### After (with cleanup fix) — legible assertions, zero unhandled errors

```
⎯⎯ Failed Tests 19 ⎯⎯
      1 AssertionError: expected undefined to be truthy        (waitForTurn first-run:tutorial)
     11 AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
 Test Files  1 failed (1)
      Tests  19 failed | 41 passed (60)
```

The remaining 19 are the documented **Defect 2** (personal-Eliza contract); they
are intentionally out of scope for this PR.

### Neighbor suites (no regressions)

```
src/first-run/use-first-run-conductor.fuzz.test.ts     5 passed
src/first-run/first-run.test.ts + useAppearanceApplyChannel.test.tsx   16 passed
```

### Typecheck / lint

```
packages/ui typecheck: exit 0
biome check src/first-run/use-first-run-conductor.test.ts: Checked 1 file, No fixes applied
```

# Evidence Gate

<!-- evidence-head:df0d9e1b10196bcef456fd941def87c02baa8aaa -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-harness-only change to a *.test.ts file; no rendered UI surface (.tsx/.css/.svg) is modified
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-harness-only change; no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic client-side test change; the before/after vitest console output in the PR body is the full evidence
<!-- evidence-row:backend-logs -->
- [ ] N/A - no server/runtime path changes; this is a jsdom unit suite
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser runtime change; vitest console output is inlined in the PR body
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model change
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB/memory/scheduled-task/wallet/file output
<!-- evidence-row:ocr-review -->
- [ ] N/A - the change has no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

`N/A - deterministic client-side test-harness fix; no model is invoked.`

## Backend + frontend logs

`N/A - jsdom unit suite; the vitest before/after output above is the complete log.`

## Screenshots (before / after) + video walkthrough

`N/A - the only file changed is packages/ui/src/first-run/use-first-run-conductor.test.ts (a *.test.ts, not a rendered .tsx/.css/.svg). No UI pixels change.`

### Before

`N/A - see above.`

### After

`N/A - see above.`

### Walkthrough video

`N/A - see above.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- **The `Tests (client)` lane is NOT fully green after this PR.** This PR
  deliberately ships only **Defect 1** (RTL cleanup) plus the root-cause
  analysis of **Defect 2** (the merged #19511 personal-Eliza contract change),
  per the work order's instruction to STOP rather than guess at a conflicting
  behavioral test rewrite that needs a maintainer / #19511-author decision. It
  converts 19 opaque crashes into 19 legible, correctly-attributed assertion
  failures and stops those failures from poisoning neighbouring tests.
- **`bun run verify` was not run to completion on this machine.** The repo-wide
  gate requires building several workspace packages first; on this constrained
  host I ran the owning package's `typecheck` + `lint` + the affected and
  neighbouring vitest suites instead (all pass, output above). One env note: the
  ui vitest/typecheck require `node packages/shared/scripts/generate-keywords.mjs`
  and `bun run --cwd packages/cloud/routing build` to have been run first
  (documented in the testing steps), because those generated/dist artifacts are
  not checked in.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@2c8c36908538fe5acf2a55b7c54d908808517d47:packages/skills/skills/contribute-to-eliza"} -->

