### PR TITLE
fix(cloud): use Pages token for domain plans

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -85,7 +85,11 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       TF_IN_AUTOMATION: "true"
       HCLOUD_TOKEN: ${{ (inputs.component == 'control-plane' || inputs.component == 'prod-ops') && secrets.HCLOUD_TOKEN || secrets.HCLOUD_APPS_TOKEN }}
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      # Pages-domain plans need DNS, Pages, and SSL Certificates access. Prefer
+      # the environment-scoped credential for that root while preserving the
+      # shared credential contract for every other component and as a rollout
+      # fallback where the dedicated secret has not yet been provisioned.
+      CLOUDFLARE_API_TOKEN: ${{ inputs.component == 'pages-domains' && secrets.CLOUDFLARE_PAGES_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.R2_STATE_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_STATE_SECRET_ACCESS_KEY }}
       TERRAFORM_PLAN_ARTIFACT_PUBLIC_KEY: ${{ vars.TERRAFORM_PLAN_ARTIFACT_PUBLIC_KEY }}

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/README.md
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/README.md
@@ -142,8 +142,12 @@ Staging additionally requires the immutable live inventory in
 `STAGING_AGENT_WILDCARD_ORIGINS_JSON`, `STAGING_AGENT_CERTIFICATE_PACK_ID`, and
 `STAGING_AGENT_CERTIFICATE_HOSTS_JSON`.
 
-The shared credentials remain `CLOUDFLARE_API_TOKEN` (Pages, DNS, and SSL
-Certificates read/write), `CLOUDFLARE_ACCOUNT_ID`,
+For this root, the workflow prefers the environment-scoped
+`CLOUDFLARE_PAGES_API_TOKEN` and falls back to the shared
+`CLOUDFLARE_API_TOKEN` while environments transition. The selected token needs
+Pages, DNS, and SSL Certificates read/write access across both managed zones.
+Other Terraform roots continue to use only the shared token. The remaining
+shared credentials are `CLOUDFLARE_ACCOUNT_ID`,
 `ELIZA_APP_CLOUDFLARE_ZONE_ID`, `APPS_CLOUDFLARE_ZONE_ID`, and the two R2 state
 credentials. Keep record ids, origin addresses, and certificate pack ids in
 protected GitHub Environment variables rather than committing live values.

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -234,6 +234,17 @@ describe("canonical cloud deployment environment contract", () => {
     expect(validate.run).toContain('if [ "$SOURCE_REF" != "$expected_ref" ]');
   });
 
+  test("selects the dedicated Pages credential without changing other Terraform roots", () => {
+    const token = infra.jobs?.terraform?.env?.CLOUDFLARE_API_TOKEN;
+    expect(token).toContain("inputs.component == 'pages-domains'");
+    expect(token).toContain("secrets.CLOUDFLARE_PAGES_API_TOKEN");
+    expect(token).toContain("|| secrets.CLOUDFLARE_API_TOKEN");
+    expect(token?.match(/secrets\.CLOUDFLARE_PAGES_API_TOKEN/g)).toHaveLength(
+      1,
+    );
+    expect(token?.match(/secrets\.CLOUDFLARE_API_TOKEN/g)).toHaveLength(1);
+  });
+
   test("applies only an encrypted, service-bound artifact from a successful plan attempt", () => {
     const plan = step(infra, "terraform", "Plan");
     expect(plan.run).toContain("terraform plan");


### PR DESCRIPTION
# Relates to

Closes #19676.

- [x] Targets `develop` and is rebased onto exact base `54a47975922973dfcbc7e79bf27708f2cd612934`.
- [x] Uses the existing environment-scoped Pages credential only for the `pages-domains` Terraform root.
- [x] Preserves the shared Cloudflare credential as an explicit compatibility fallback for other environments.
- [x] Changes no Terraform resources, state, DNS, certificate, or provider configuration.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@9a0120bd3927919e06ebd80a3aefaf83004b5a2b:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Background

The exact staging `pages-domains` plan failed before producing an artifact because the Infrastructure workflow always selected the repository-wide `CLOUDFLARE_API_TOKEN`. The protected staging environment already has a dedicated `CLOUDFLARE_PAGES_API_TOKEN`, but the workflow did not consume it.

This patch selects that dedicated credential only when `inputs.component == 'pages-domains'`, retains the existing shared-token fallback, documents the required Pages/DNS/SSL Certificates permissions across both zones, and pins the selection contract in the executable workflow test.

# Risks

Low and fail-closed. No provider resource or Terraform definition changes. If the dedicated token itself lacks the required certificate permission, the next plan still stops with the provider error and produces no apply artifact; this PR does not weaken or remove certificate ownership.

# Testing

- Full pinned `bun install`: PASS, including the required 971 MiB artifact sync (7,118 packages).
- `bun test packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts`: PASS, 15/15 tests and 257 expectations, including the merged protected prod-ops runner contract.
- `bunx actionlint .github/workflows/infra.yml`: PASS.
- Changed-file Biome, guide parity, and `git diff --check`: PASS.
- Patch-equivalent pre-final-rebase `TURBO_FORCE=1 bun run verify`: PASS, 350/350 tasks, 0 cached, with all repository audits green.
- Exact final head `9f9f7f54ca67134ce2b4c68e988855b521686b04` `bun run verify`: PASS, 350/350 tasks with all repository audits green.
- No Terraform plan/apply, Cloudflare mutation, DNS change, or deployment was performed by this PR.

# Evidence Gate

<!-- evidence-head:9f9f7f54ca67134ce2b4c68e988855b521686b04 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - protected non-rendered workflow credential selection only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered product surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - the exact failing plan run is recorded in the issue; no application backend changes.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic workflow selection only.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no plan artifact was created before this fix and this PR performs no provider operation.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changes.

# Known gaps / follow-up

After merge, staging must dispatch a fresh `pages-domains` plan from the then-current `develop` SHA. The exact plan must be reviewed before applying its encrypted artifact. A repeated Cloudflare 9109/403 would prove the dedicated token still needs an SSL-certificate permission rotation; it must not be worked around by deleting certificate resources.

— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@9a0120bd3927919e06ebd80a3aefaf83004b5a2b:packages/skills/skills/contribute-to-eliza"} -->
