### PR TITLE
fix(cloud): retire isolated Headscale upgrade map

### DIFF
--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -421,8 +421,65 @@ validate_retirable_legacy_vhost() {
       if (directive ~ /^[[:alpha:]_][[:alnum:]_]*$/) print directive
     }
   ')
+  legacy_upgrade_map_shape=$(printf '%s\\n' "$legacy_vhost_source" | awk '
+    {
+      line = $0
+      sub(/^[[:space:]]+/, "", line)
+      sub(/[[:space:]]+$/, "", line)
+      if (line == "" || line ~ /^#/) next
+      normalized = line
+      gsub(/[[:space:]]+/, " ", normalized)
+      if (in_upgrade_map) {
+        if (normalized == "default upgrade;") {
+          defaults += 1
+        } else if (normalized == "\\047\\047 close;") {
+          closes += 1
+        } else if (normalized == "}") {
+          endings += 1
+          in_upgrade_map = 0
+        } else {
+          unexpected += 1
+        }
+        next
+      }
+      if (normalized ~ /^map[[:space:]]/) {
+        if (normalized == "map $http_upgrade $connection_upgrade {") {
+          blocks += 1
+          in_upgrade_map = 1
+        } else {
+          unexpected += 1
+        }
+      } else if (normalized ~ /^default[[:space:]]/) {
+        unexpected += 1
+      }
+    }
+    END {
+      if (in_upgrade_map) unexpected += 1
+      printf "%d %d %d %d %d\\n", blocks + 0, defaults + 0, closes + 0, endings + 0, unexpected + 0
+    }
+  ')
+  read -r legacy_upgrade_map_blocks legacy_upgrade_map_defaults \\
+    legacy_upgrade_map_closes legacy_upgrade_map_endings \\
+    legacy_upgrade_map_unexpected \\
+    <<<"$legacy_upgrade_map_shape"
+  legacy_has_upgrade_map=false
+  if [ "$legacy_upgrade_map_blocks" -ne 0 ] \\
+      || [ "$legacy_upgrade_map_defaults" -ne 0 ] \\
+      || [ "$legacy_upgrade_map_closes" -ne 0 ] \\
+      || [ "$legacy_upgrade_map_endings" -ne 0 ] \\
+      || [ "$legacy_upgrade_map_unexpected" -ne 0 ]; then
+    if [ "$legacy_upgrade_map_blocks" -ne 1 ] \\
+        || [ "$legacy_upgrade_map_defaults" -ne 1 ] \\
+        || [ "$legacy_upgrade_map_closes" -ne 1 ] \\
+        || [ "$legacy_upgrade_map_endings" -ne 1 ] \\
+        || [ "$legacy_upgrade_map_unexpected" -ne 0 ]; then
+      echo "legacy Headscale vhost has an unexpected upgrade map shape"
+      return 1
+    fi
+    legacy_has_upgrade_map=true
+  fi
   unexpected_legacy_directives=$(printf '%s\\n' "$legacy_vhost_directives" \\
-    | awk '$0 !~ /^(server|listen|server_name|location|root|default_type|try_files|return|ssl_certificate|ssl_certificate_key|proxy_pass|proxy_http_version|proxy_set_header|proxy_buffering|proxy_read_timeout|proxy_send_timeout)$/ { print }')
+    | awk '$0 !~ /^(map|default|server|listen|server_name|location|root|default_type|try_files|return|ssl_certificate|ssl_certificate_key|proxy_pass|proxy_http_version|proxy_set_header|proxy_buffering|proxy_read_timeout|proxy_send_timeout)$/ { print }')
   if [ "\${HS_ENFORCE_LEGACY_VHOST_DIRECTIVE_ALLOWLIST:-false}" = "true" ] \\
       && [ -n "$unexpected_legacy_directives" ]; then
     echo "legacy Headscale vhost contains directives outside the reviewed retirement allowlist:"
@@ -468,7 +525,8 @@ validate_retirable_legacy_vhost() {
     return 1
   fi
 
-  loaded_legacy_owners=$(sudo nginx -T 2>&1 | awk \\
+  loaded_nginx_config=$(sudo nginx -T 2>&1)
+  loaded_legacy_owners=$(printf '%s\\n' "$loaded_nginx_config" | awk \\
     -v target="$HS_RETIRABLE_LEGACY_VHOST" \\
     -v canonical="$HS_HOST" \\
     -v legacy="$HS_LEGACY_HOST" '
@@ -512,6 +570,23 @@ validate_retirable_legacy_vhost() {
     | awk -v host="$HS_HOST" '$0 == host { count += 1 } END { print count + 0 }')
   if [ "$loaded_legacy_count" -ne 2 ] || [ "$loaded_canonical_count" -ne 0 ]; then
     echo "legacy Headscale vhost ownership no longer matches the reviewed two-listener contract"
+    return 1
+  fi
+  legacy_upgrade_map_external_references=$(printf '%s\\n' "$loaded_nginx_config" \\
+    | awk -v target="$HS_RETIRABLE_LEGACY_VHOST" '
+      /^# configuration file / {
+        config_file = $0
+        sub(/^# configuration file /, "", config_file)
+        sub(/:$/, "", config_file)
+        next
+      }
+      config_file != target \\
+          && $0 ~ /[$]connection_upgrade([^[:alnum:]_]|$)/ { count += 1 }
+      END { print count + 0 }
+    ')
+  if [ "$legacy_has_upgrade_map" = "true" ] \\
+      && [ "$legacy_upgrade_map_external_references" -ne 0 ]; then
+    echo "legacy Headscale upgrade-map output is referenced outside the reviewed file"
     return 1
   fi
 }
@@ -970,6 +1045,11 @@ sudo stat -c 'type=%F owner=%U group=%G mode=%a bytes=%s path=%n' \\
 echo "reviewed-sha256=$legacy_vhost_sha256"
 echo "--- reviewed nginx directive-name inventory (values withheld) ---"
 printf '%s\\n' "$legacy_vhost_directives" | sort | uniq -c
+if [ "$legacy_has_upgrade_map" = "true" ]; then
+  echo "reviewed-upgrade-map=headscale-websocket-v1 external-references=0"
+else
+  echo "reviewed-upgrade-map=absent external-references=0"
+fi
 echo "reviewed-shape=server-blocks:$legacy_server_block_count server-names:$legacy_server_name_count exact-host:$HS_LEGACY_HOST"
 echo "Legacy Headscale vhost passed the read-only retirement preflight"
 `;

--- a/packages/scripts/__tests__/headscale-arm-workflow.test.ts
+++ b/packages/scripts/__tests__/headscale-arm-workflow.test.ts
@@ -596,7 +596,11 @@ describe("protected Headscale arm workflow", () => {
 });
 
 describe("Headscale migration-overlap remote script", () => {
-  const expectedLegacySource = `server {
+  const expectedLegacySource = `map $http_upgrade $connection_upgrade {
+  default upgrade;
+  ''      close;
+}
+server {
   listen 80;
   listen [::]:80;
   server_name headscale-staging.elizacloud.ai;
@@ -613,6 +617,10 @@ server {
 server_name headscale-staging.eliza.app headscale-staging.elizacloud.ai;
 server_name headscale-staging.eliza.app headscale-staging.elizacloud.ai;
 # configuration file REPLACE_LEGACY_PATH:
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' close;
+}
 server_name headscale-staging.elizacloud.ai;
 server_name headscale-staging.elizacloud.ai;
 `;
@@ -807,6 +815,9 @@ server_name headscale-staging.elizacloud.ai;
     expect(result.stdout).toContain(
       "directive-name inventory (values withheld)",
     );
+    expect(result.stdout).toContain(
+      "reviewed-upgrade-map=headscale-websocket-v1 external-references=0",
+    );
     expect(result.stdout).toContain("reviewed-shape=server-blocks:");
     expect(result.stdout).not.toContain(
       "reviewed public routing/TLS directives",
@@ -933,6 +944,58 @@ server {
     expect(unrelatedDirective.status).toBe(1);
     expect(unrelatedDirective.stdout).toContain(
       "directives outside the reviewed retirement allowlist",
+    );
+  });
+
+  test("retires only the isolated standard Headscale websocket upgrade map", () => {
+    const inspection = runLegacyVhostInspection(
+      expectedLegacySource,
+      expectedLoadedConfig,
+    );
+    expect(inspection.status).toBe(0);
+    expect(inspection.stdout).toContain(
+      "reviewed-upgrade-map=headscale-websocket-v1 external-references=0",
+    );
+    expect(inspection.stdout).not.toContain("$connection_upgrade");
+
+    const valid = runLegacyVhostValidation({
+      source: expectedLegacySource,
+      loadedConfig: expectedLoadedConfig,
+      enforceDirectiveAllowlist: true,
+    });
+    expect(valid.status).toBe(0);
+
+    for (const source of [
+      expectedLegacySource.replace("$http_upgrade", "$http_connection"),
+      expectedLegacySource.replace("$connection_upgrade", "$shared_upgrade"),
+      expectedLegacySource.replace("default upgrade;", "default close;"),
+      expectedLegacySource.replace("''      close;", "''      upgrade;"),
+      expectedLegacySource.replace("  ''      close;\n", ""),
+      expectedLegacySource.replace(
+        "  ''      close;",
+        "  ''      close;\n  ''      close;",
+      ),
+    ]) {
+      const invalid = runLegacyVhostValidation({
+        source,
+        loadedConfig: expectedLoadedConfig,
+        enforceDirectiveAllowlist: true,
+      });
+      expect(invalid.status).not.toBe(0);
+      expect(invalid.stdout).toContain("unexpected upgrade map shape");
+    }
+
+    const externallyReferenced = runLegacyVhostValidation({
+      source: expectedLegacySource,
+      loadedConfig: `${expectedLoadedConfig}
+# configuration file /etc/nginx/conf.d/unrelated.conf:
+proxy_set_header Connection $connection_upgrade;
+`,
+      enforceDirectiveAllowlist: true,
+    });
+    expect(externallyReferenced.status).not.toBe(0);
+    expect(externallyReferenced.stdout).toContain(
+      "upgrade-map output is referenced outside the reviewed file",
     );
   });
 


### PR DESCRIPTION
# Relates to

Closes #19568.

- [x] Targets `develop` and is rebased onto the exact current base.
- [x] Retires only the fixed staging path `/etc/nginx/conf.d/headscale-staging.conf` under the existing SHA-bound rollback transaction.
- [x] Accepts only the exact isolated Headscale websocket upgrade map and proves its output has zero references in every other loaded nginx file.
- [x] Performs no host, DNS, certificate, or provider mutation in this PR.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@9a0120bd3927919e06ebd80a3aefaf83004b5a2b:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Background

The protected staging retirement correctly failed closed in run [31852275388](https://github.com/elizaOS/eliza/actions/runs/31852275388): the reviewed legacy-only nginx file still had the exact inspected hash and two-server shape, but its value-withheld directive inventory contained one `map` and one `default` directive outside the retirement allowlist.

Fresh read-only run [31854225418](https://github.com/elizaOS/eliza/actions/runs/31854225418) reconfirmed a root-owned regular file at the fixed path, SHA-256 `33a19405371271ce2323cbfcb81814dc39d5ddea651f0af0752b69ca339d9a0c`, exactly two legacy-only server owners, and the single `map`/`default` inventory. It performed no convergence.

This patch does not broadly allow nginx maps. It recognizes only the standard four-line Headscale websocket map from `$http_upgrade` to `$connection_upgrade`, requires exactly one `default upgrade;`, exactly one empty-value `close;`, one closing brace, and no other map entry. It then parses the full loaded `nginx -T` inventory and fails if `$connection_upgrade` is referenced outside the exact reviewed file. The intended canonical vhost continues to use the independent `$hs_connection_upgrade` variable.

# Risks

Narrow, staging-only, and fail-closed. A changed map, missing or duplicated branch, another map, an external reference, a hash change, an unexpected owner/directive, or any downstream convergence/liveness failure prevents retirement or restores the prior vhost through the existing transaction. Inspection output remains value-free.

# Testing

- Full pinned `bun install`: PASS, including the required artifact synchronization.
- `bun test packages/scripts/__tests__/headscale-arm-workflow.test.ts`: PASS, 30/30 tests and 323 expectations.
- The executable generated shell tests cover exact-map acceptance; input/output/default/close mutation; missing and duplicated close branch; external-reference rejection; digest binding; owner enumeration; downstream rollback; renewal hook; and environment/source gates.
- Node syntax, Headscale workflow actionlint, changed-file Biome, and `git diff --check`: PASS.
- `bun run verify:cloud`: PASS.
- Patch-equivalent pre-final-rebase `TURBO_FORCE=1 bun run verify`: PASS, 350/350 tasks, 0 cached, and all repository audits green.
- Exact final head `1ad270610a87c86671608c3ea38f19bc5f083245` `bun run verify`: PASS, 350/350 tasks and all repository audits green.

# Evidence Gate

<!-- evidence-head:1ad270610a87c86671608c3ea38f19bc5f083245 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - protected non-rendered server convergence logic only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered product surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - this PR changes the protected script and its executable contract tests but does not execute a backend; the linked read-only host run in Background is pre-change context, and a fresh merged-SHA inspection is required post-merge.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic infrastructure validation only.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the PR intentionally performs no host/provider mutation, so it cannot produce a post-change domain artifact; Post-merge acceptance requires the protected inspection and convergence artifacts before release.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual evidence.

# Post-merge acceptance

Dispatch a fresh read-only staging inspection from the merged SHA. It must identify the exact map shape and report zero external references without emitting directive values. Only then dispatch `retire-legacy-vhost-and-converge` with that exact inspected digest. The protected run must prove exclusive intended ownership, identical public canonical/legacy leaf fingerprints with both SANs, and both health endpoints under normal TLS.

— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@9a0120bd3927919e06ebd80a3aefaf83004b5a2b:packages/skills/skills/contribute-to-eliza"} -->
