### PR TITLE
fix(voice): harden outbound call retries

### DIFF
--- a/packages/cloud/api/v1/twilio/voice/calls/route.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/calls/route.test.ts
@@ -32,21 +32,13 @@ const dbWrite = {
   delete: mock(() => ({ where: deleteWhere })),
 };
 
-const dbRead = {
-  select: mock(() => ({
-    from: () => ({
-      where: () => ({ limit: async () => [] }),
-    }),
-  })),
-};
-
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg: requireUser,
 }));
 mock.module("@/db/repositories/users", () => ({
   usersRepository: { findById: findUser },
 }));
-mock.module("@/db/helpers", () => ({ dbRead, dbWrite }));
+mock.module("@/db/helpers", () => ({ dbWrite }));
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
   RateLimitPresets: { CRITICAL: { windowMs: 300_000, maxRequests: 5 } },
   rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
@@ -97,6 +89,7 @@ describe("POST Twilio outbound voice call", () => {
     queueCall.mockClear();
     returning.mockClear();
     returning.mockImplementation(async () => [{ key: "claimed" }]);
+    deleteWhere.mockClear();
   });
 
   test("queues the verified number through the signed realtime callback", async () => {
@@ -142,6 +135,39 @@ describe("POST Twilio outbound voice call", () => {
     await expect(response.json()).resolves.toMatchObject({
       code: "phone_verification_required",
     });
+    expect(queueCall).not.toHaveBeenCalled();
+  });
+
+  test("reclaims an expired idempotency key and queues the current call", async () => {
+    returning
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ key: "reclaimed" }]);
+
+    const response = await callRequest(
+      { to: "+14155550100" },
+      "00000000-0000-4000-8000-000000000001",
+    );
+
+    expect(response.status).toBe(200);
+    expect(deleteWhere).toHaveBeenCalledTimes(1);
+    expect(returning).toHaveBeenCalledTimes(2);
+    expect(queueCall).toHaveBeenCalledTimes(1);
+  });
+
+  test("keeps a live duplicate claim fail-closed", async () => {
+    returning.mockResolvedValue([]);
+
+    const response = await callRequest(
+      { to: "+14155550100" },
+      "00000000-0000-4000-8000-000000000002",
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "duplicate_call",
+    });
+    expect(deleteWhere).toHaveBeenCalledTimes(1);
+    expect(returning).toHaveBeenCalledTimes(2);
     expect(queueCall).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/v1/twilio/voice/calls/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/calls/route.ts
@@ -4,10 +4,10 @@
  */
 
 import { createHash } from "node:crypto";
-import { eq } from "drizzle-orm";
+import { and, eq, lt } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
-import { dbRead, dbWrite } from "@/db/helpers";
+import { dbWrite } from "@/db/helpers";
 import { usersRepository } from "@/db/repositories/users";
 import { idempotencyKeys } from "@/db/schemas";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
@@ -160,7 +160,7 @@ app.post("/", async (c) => {
     .update(`${auth.id}:${idempotencyHeader}`)
     .digest("hex");
   const idempotencyKey = `twilio-call:${idempotencyDigest}`;
-  const [claim] = await dbWrite
+  let [claim] = await dbWrite
     .insert(idempotencyKeys)
     .values({
       key: idempotencyKey,
@@ -171,23 +171,35 @@ app.post("/", async (c) => {
     .returning({ key: idempotencyKeys.key });
 
   if (!claim) {
-    const [existing] = await dbRead
-      .select({ expires_at: idempotencyKeys.expires_at })
-      .from(idempotencyKeys)
-      .where(eq(idempotencyKeys.key, idempotencyKey))
-      .limit(1);
-    if (existing?.expires_at && existing.expires_at < new Date()) {
-      await dbWrite
-        .delete(idempotencyKeys)
-        .where(eq(idempotencyKeys.key, idempotencyKey));
+    const now = new Date();
+    await dbWrite
+      .delete(idempotencyKeys)
+      .where(
+        and(
+          eq(idempotencyKeys.key, idempotencyKey),
+          lt(idempotencyKeys.expires_at, now),
+        ),
+      );
+
+    [claim] = await dbWrite
+      .insert(idempotencyKeys)
+      .values({
+        key: idempotencyKey,
+        source: "twilio-voice-outbound",
+        expires_at: new Date(now.getTime() + IDEMPOTENCY_TTL_MS),
+      })
+      .onConflictDoNothing({ target: idempotencyKeys.key })
+      .returning({ key: idempotencyKeys.key });
+
+    if (!claim) {
+      return c.json(
+        {
+          error: "This call request was already submitted",
+          code: "duplicate_call",
+        },
+        409,
+      );
     }
-    return c.json(
-      {
-        error: "This call request was already submitted",
-        code: "duplicate_call",
-      },
-      409,
-    );
   }
 
   try {

--- a/packages/ui/src/components/composites/chat/pstn-call-button.test.tsx
+++ b/packages/ui/src/components/composites/chat/pstn-call-button.test.tsx
@@ -57,6 +57,10 @@ describe("PstnCallButton", () => {
     });
     await user.click(trigger);
     await screen.findByDisplayValue("+14155550100");
+    expect(
+      (screen.getByLabelText("Phone number") as HTMLInputElement).readOnly,
+    ).toBe(true);
+    expect(document.body.textContent).not.toMatch(/808|788-1821/);
     await user.click(screen.getByRole("button", { name: "Call me" }));
 
     await waitFor(() => expect(mocks.api).toHaveBeenCalledTimes(2));
@@ -82,6 +86,36 @@ describe("PstnCallButton", () => {
       await screen.findByRole("button", { name: "Have Eliza call me" }),
     );
     await screen.findByText(/add and verify this phone number/i);
+    expect(
+      (screen.getByRole("button", { name: "Call me" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
+  it("clears a previously loaded number when a profile refresh fails", async () => {
+    mocks.api
+      .mockResolvedValueOnce({
+        phone_number: "+14155550100",
+        phone_verified: true,
+      })
+      .mockRejectedValueOnce(new Error("Profile unavailable"));
+    const user = userEvent.setup();
+    render(<PstnCallButton />);
+
+    const trigger = await screen.findByRole("button", {
+      name: "Have Eliza call me",
+    });
+    await user.click(trigger);
+    await screen.findByDisplayValue("+14155550100");
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    await user.click(trigger);
+
+    await waitFor(() =>
+      expect(mocks.error).toHaveBeenCalledWith("Profile unavailable"),
+    );
+    expect(
+      (screen.getByLabelText("Phone number") as HTMLInputElement).value,
+    ).toBe("");
     expect(
       (screen.getByRole("button", { name: "Call me" }) as HTMLButtonElement)
         .disabled,

--- a/packages/ui/src/components/composites/chat/pstn-call-button.tsx
+++ b/packages/ui/src/components/composites/chat/pstn-call-button.tsx
@@ -62,6 +62,8 @@ export function PstnCallButton({ disabled = false }: { disabled?: boolean }) {
   const handleOpenChange = async (nextOpen: boolean) => {
     setOpen(nextOpen);
     if (!nextOpen) return;
+    setPhoneNumber("");
+    setPhoneVerified(false);
     setLoadingProfile(true);
     try {
       const user = await api<CurrentUserResponse>("/api/v1/user");
@@ -116,8 +118,7 @@ export function PstnCallButton({ disabled = false }: { disabled?: boolean }) {
           <DialogHeader>
             <DialogTitle>Call me</DialogTitle>
             <DialogDescription>
-              Eliza will call your verified account phone from +1 (808)
-              788-1821.
+              Eliza will call your verified account phone.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-2">
@@ -128,7 +129,7 @@ export function PstnCallButton({ disabled = false }: { disabled?: boolean }) {
               autoComplete="tel"
               placeholder="+1 415 555 0100"
               value={phoneNumber}
-              onChange={(event) => setPhoneNumber(event.target.value)}
+              readOnly
               disabled={loadingProfile || submitting}
             />
             {!loadingProfile && !phoneVerified ? (


### PR DESCRIPTION
Closes #19706

## Summary
- remove the public Eliza line from the shared call-me dialog
- make the verified destination read-only and clear stale profile state before every refresh
- reclaim expired outbound-call idempotency claims in the current request
- preserve live duplicate claims under concurrent retries

## Validation
- `bun run --cwd packages/cloud/api typecheck` (includes production Worker dry-run)
- `bun run --cwd packages/ui typecheck`
- outbound route: 5 passing tests / 24 assertions
- call-me UI: 3 passing tests, including stale-profile failure and no-public-number assertions
- `bun run --cwd packages/app audit:app`: 219/219 captures passing; broken=0, needs-work=0; OCR broken=0
- `bunx biome check` on all changed files
- `git diff --check`
- full `bun run verify` running on exact head `3f431361227`

## Evidence Gate

<!-- evidence-head:3f431361227 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - corrective text removal and read-only state in an existing dialog; the repository aesthetic baseline covers the shared app surfaces
<!-- evidence-row:after-screenshots -->
- [x] `packages/app` aesthetic audit captured all 219 surfaces at desktop/mobile/tablet sizes with zero broken or needs-work verdicts
<!-- evidence-row:walkthrough-video -->
- [x] N/A - focused deterministic interaction tests exercise profile load, call submission, unverified state, and failed refresh
<!-- evidence-row:backend-logs -->
- [x] Cloud API typecheck and production Wrangler dry-run passed; focused route tests passed 5/5
<!-- evidence-row:frontend-logs -->
- [x] UI typecheck and focused Vitest suite passed 3/3; app capture audit passed 219/219
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model prompt, routing, or inference behavior changes
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head tests prove expired-key reclaim, live duplicate fail-closed behavior, immutable verified destination, public-number removal, and stale-profile clearing

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- ai-assistance: yes
<!-- attribution-row:models -->
- models: OpenAI Codex
<!-- attribution-row:client -->
- client: Codex desktop
<!-- attribution-row:skill-revision -->
- skill-revision: computer-use (account/session review only; no repository code generated)
<!-- attribution-row:status -->
- status: self-reported
