### PR TITLE
fix(voice): distinguish Twilio line from Blooio

### DIFF
--- a/packages/cloud/api/v1/twilio/voice/calls/route.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/calls/route.test.ts
@@ -55,7 +55,7 @@ const { default: app } = await import("./route");
 const env = {
   ELIZA_APP_TWILIO_ACCOUNT_SID: "AC123",
   ELIZA_APP_TWILIO_AUTH_TOKEN: "secret",
-  ELIZA_APP_TWILIO_PHONE_NUMBER: "+18087881821",
+  ELIZA_APP_TWILIO_PHONE_NUMBER: "+14484080429",
   TWILIO_PUBLIC_URL: "https://api.eliza.app",
 };
 
@@ -108,7 +108,7 @@ describe("POST Twilio outbound voice call", () => {
     expect(endpoint).toBe("/Calls.json");
     expect(form).toBeInstanceOf(URLSearchParams);
     expect((form as URLSearchParams).get("To")).toBe("+14155550100");
-    expect((form as URLSearchParams).get("From")).toBe("+18087881821");
+    expect((form as URLSearchParams).get("From")).toBe("+14484080429");
     expect((form as URLSearchParams).get("Url")).toBe(
       "https://api.eliza.app/api/v1/twilio/voice/inbound",
     );

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-call-direction.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-call-direction.test.ts
@@ -9,10 +9,10 @@ describe("resolveTwilioCallParticipants", () => {
       resolveTwilioCallParticipants({
         direction: "inbound",
         from: "+14155550100",
-        to: "+18087881821",
+        to: "+14484080429",
       }),
     ).toEqual({
-      publicLineNumber: "+18087881821",
+      publicLineNumber: "+14484080429",
       callerNumber: "+14155550100",
       outbound: false,
     });
@@ -22,11 +22,11 @@ describe("resolveTwilioCallParticipants", () => {
     expect(
       resolveTwilioCallParticipants({
         direction: "outbound-api",
-        from: "+18087881821",
+        from: "+14484080429",
         to: "+14155550100",
       }),
     ).toEqual({
-      publicLineNumber: "+18087881821",
+      publicLineNumber: "+14484080429",
       callerNumber: "+14155550100",
       outbound: true,
     });


### PR DESCRIPTION
## Summary
- align outbound and direction fixtures with the actual Twilio voice line, +1 (448) 408-0429
- keep the Blooio +1 (808) 788-1821 number isolated to messaging

## Root cause
Production had `ELIZA_APP_TWILIO_PHONE_NUMBER` set to the Blooio messaging number while Twilio routes voice for +1 (448) 408-0429. The exact-number resolver therefore rejected real inbound calls as unconfigured. The production secret has already been corrected.

Current develop already removed the stale hardcoded number from the UI and hardened outbound retries in #19714; this PR preserves that newer behavior.

## Validation
- focused cloud outbound and direction tests pass
- focused call-me UI tests pass
- UI typecheck passes
- Biome and diff checks pass