### PR TITLE
fix(agent): avoid duplicate provider fields during normalization

### DIFF
--- a/packages/agent/src/runtime/trajectory-internals.ts
+++ b/packages/agent/src/runtime/trajectory-internals.ts
@@ -3587,14 +3587,7 @@ function normalizeStepForPersistence(
     index: number,
   ): PersistedProviderAccess => {
     const bounded = snapshotCaptureParams(
-      {
-        providerId: access.providerId,
-        providerName: access.providerName,
-        timestamp: access.timestamp,
-        purpose: access.purpose,
-        data: access.data,
-        ...access,
-      },
+      { ...access },
       step.stepId,
     );
     return parsePersistedProviderAccess(


### PR DESCRIPTION
## Summary
- remove duplicate provider field declarations before trajectory snapshotting
- preserve the same complete provider record while satisfying strict TypeScript checks

## Verification
- `bun run --cwd packages/agent typecheck`
- `bun run --cwd packages/app-core typecheck`
- trajectory bridge suite: 28 tests passed (Bun emitted its known coverage-output write failure after the passing assertions)