### PR TITLE
fix(cloud): strict canonical-integer parsing for anon-session spend-gate env vars

### DIFF
--- a/packages/cloud/api/auth/anonymous-session-config.ts
+++ b/packages/cloud/api/auth/anonymous-session-config.ts
@@ -1,0 +1,42 @@
+/**
+ * Owns the canonical operator configuration shared by both anonymous-session
+ * mint routes, including the spend and lifetime safety bounds.
+ */
+
+import { logger } from "@/lib/utils/logger";
+
+export const MAX_ANONYMOUS_EXPIRY_DAYS = 365;
+export const MAX_ANONYMOUS_MESSAGE_LIMIT = 1000;
+
+/**
+ * Parses a canonical positive integer, retaining the default for absent values
+ * and warning before configured invalid values fall back.
+ */
+export function parseAnonymousPositiveIntEnv(
+  value: string | undefined,
+  defaultValue: number,
+  name: string,
+  max: number,
+  scope: "anonymous-session" | "create-anonymous-session",
+): number {
+  if (value === undefined || value.trim() === "") {
+    return defaultValue;
+  }
+
+  const raw = value.trim();
+  if (!/^[1-9][0-9]*$/.test(raw)) {
+    logger.warn(
+      `[${scope}] Invalid ${name} (expected canonical positive integer), using default ${defaultValue} (received: ${value})`,
+    );
+    return defaultValue;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed > max) {
+    logger.warn(
+      `[${scope}] Invalid ${name} (expected 1..${max}), using default ${defaultValue} (received: ${value})`,
+    );
+    return defaultValue;
+  }
+  return parsed;
+}

--- a/packages/cloud/api/auth/anonymous-session/route.test.ts
+++ b/packages/cloud/api/auth/anonymous-session/route.test.ts
@@ -1,0 +1,137 @@
+// Exercises the auth/anonymous-session get-or-create route's spend-gate env-var
+// validation (#19716) by driving the REAL Hono handler with a mocked session
+// creator and a fall-open rate-limit middleware. No cookie is sent, so every
+// request takes the mint path and the captured `messagesLimit`/`expiresAt`
+// prove which value the strict canonical-integer parser selected.
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+
+let lastMintParams: { messagesLimit: number; expiresAt: Date } | null = null;
+
+mock.module("@/lib/services/anonymous-session-creator", () => ({
+  createAnonymousUserAndSession: async (params: {
+    messagesLimit: number;
+    expiresAt: Date;
+  }) => {
+    lastMintParams = params;
+    return {
+      newUser: { id: "anon-user-test" },
+      newSession: {
+        id: "sess-test",
+        message_count: 0,
+        messages_limit: params.messagesLimit,
+        is_active: true,
+      },
+    };
+  },
+}));
+
+// The mint path never touches the DB or user/session lookups (those are only
+// reached with a valid cookie). Stub them so importing the route does not pull
+// in plugin-sql / the unbuilt @elizaos/core.
+mock.module("@/db/helpers", () => ({
+  dbRead: { query: { userIdentities: { findFirst: async () => null } } },
+}));
+mock.module("@/db/schemas/user-identities", () => ({ userIdentities: {} }));
+mock.module("@/lib/services/users", () => ({
+  usersService: { getById: async () => null },
+}));
+mock.module("@/lib/services/anonymous-sessions", () => ({
+  anonymousSessionsService: { getByToken: async () => null },
+}));
+
+// Rate-limit middleware falls open in tests (no Redis binding); make it a no-op
+// so the mint path is reached deterministically.
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  rateLimit: () => async (_c: unknown, next: () => Promise<unknown>) =>
+    await next(),
+  getIpKey: () => "test-ip",
+  RateLimitPresets: {
+    AGGRESSIVE: { windowMs: 60_000, maxRequests: 30 },
+    CRITICAL: { windowMs: 300_000, maxRequests: 5 },
+  },
+}));
+
+const { default: app } = await import("./route");
+
+const EXEC_CTX = {
+  waitUntil: (_p: Promise<unknown>) => undefined,
+  passThroughOnException: () => undefined,
+  props: {},
+} as unknown as ExecutionContext;
+
+async function post(env: Record<string, unknown>) {
+  lastMintParams = null;
+  // No cookie → the handler always mints a fresh session.
+  return app.request("/", { method: "POST" }, env, EXEC_CTX);
+}
+
+function expiryDaysOf(params: { expiresAt: Date }): number {
+  return Math.round(
+    (params.expiresAt.getTime() - Date.now()) / (24 * 60 * 60 * 1000),
+  );
+}
+
+describe("#19716 auth/anonymous-session — spend-gate env validation", () => {
+  beforeEach(() => {
+    lastMintParams = null;
+  });
+
+  test("unset PUBLIC_CHAT_MESSAGE_LIMIT keeps default 3 silently", async () => {
+    const res = await post({});
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { session: { messages_limit: number } };
+    expect(json.session.messages_limit).toBe(3);
+    expect(lastMintParams).not.toBeNull();
+    expect(lastMintParams!.messagesLimit).toBe(3);
+  });
+
+  test("valid PUBLIC_CHAT_MESSAGE_LIMIT=25 is honored", async () => {
+    const res = await post({ PUBLIC_CHAT_MESSAGE_LIMIT: "25" });
+    expect(res.status).toBe(200);
+    expect(lastMintParams!.messagesLimit).toBe(25);
+  });
+
+  test.each([
+    ["5oops", "trailing junk"],
+    ["1e2", "exponent notation"],
+    ["7.0", "decimal"],
+    ["05", "leading zero"],
+    ["abc", "non-numeric"],
+    ["0", "zero"],
+    ["-3", "negative"],
+    ["  ", "whitespace-only"],
+  ])(
+    "malformed PUBLIC_CHAT_MESSAGE_LIMIT=%p (%s) falls back to default 3",
+    async (value) => {
+      await post({ PUBLIC_CHAT_MESSAGE_LIMIT: value });
+      expect(lastMintParams!.messagesLimit).toBe(3);
+    },
+  );
+
+  test("overflow PUBLIC_CHAT_MESSAGE_LIMIT (400 nines) falls back to default 3", async () => {
+    await post({ PUBLIC_CHAT_MESSAGE_LIMIT: "9".repeat(400) });
+    expect(lastMintParams!.messagesLimit).toBe(3);
+  });
+
+  test("above-cap PUBLIC_CHAT_MESSAGE_LIMIT=1001 falls back to default 3", async () => {
+    await post({ PUBLIC_CHAT_MESSAGE_LIMIT: "1001" });
+    expect(lastMintParams!.messagesLimit).toBe(3);
+  });
+
+  test("malformed ANON_SESSION_EXPIRY_DAYS=7.0 falls back to default 7 days", async () => {
+    await post({ ANON_SESSION_EXPIRY_DAYS: "7.0" });
+    expect(expiryDaysOf(lastMintParams!)).toBe(7);
+  });
+
+  test("valid ANON_SESSION_EXPIRY_DAYS=30 is honored", async () => {
+    await post({ ANON_SESSION_EXPIRY_DAYS: "30" });
+    expect(expiryDaysOf(lastMintParams!)).toBe(30);
+  });
+
+  test("above-cap ANON_SESSION_EXPIRY_DAYS=366 falls back to default 7 days", async () => {
+    await post({ ANON_SESSION_EXPIRY_DAYS: "366" });
+    expect(expiryDaysOf(lastMintParams!)).toBe(7);
+  });
+});

--- a/packages/cloud/api/auth/anonymous-session/route.test.ts
+++ b/packages/cloud/api/auth/anonymous-session/route.test.ts
@@ -1,8 +1,7 @@
-// Exercises the auth/anonymous-session get-or-create route's spend-gate env-var
-// validation (#19716) by driving the REAL Hono handler with a mocked session
-// creator and a fall-open rate-limit middleware. No cookie is sent, so every
-// request takes the mint path and the captured `messagesLimit`/`expiresAt`
-// prove which value the strict canonical-integer parser selected.
+/**
+ * Drives the real anonymous-session mint route with deterministic service and
+ * rate-limit boundaries to verify spend-gate configuration reaches storage.
+ */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 process.env.DATABASE_URL ||= "pglite://memory";

--- a/packages/cloud/api/auth/anonymous-session/route.ts
+++ b/packages/cloud/api/auth/anonymous-session/route.ts
@@ -14,6 +14,11 @@ import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { getCookie, setCookie } from "hono/cookie";
 import { nanoid } from "nanoid";
+import {
+  MAX_ANONYMOUS_EXPIRY_DAYS,
+  MAX_ANONYMOUS_MESSAGE_LIMIT,
+  parseAnonymousPositiveIntEnv,
+} from "@/auth/anonymous-session-config";
 import { dbRead } from "@/db/helpers";
 import { userIdentities } from "@/db/schemas/user-identities";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
@@ -29,56 +34,6 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const ANON_SESSION_COOKIE = "eliza-anon-session";
 
-// Operator-sane upper bounds for the spend-gate env vars. A configured value
-// above these caps is treated as a typo and rejected in favour of the default,
-// because `messages_limit` is the per-guest anonymous spend gate and directly
-// bounds how much of the application owner's credit balance a guest can burn.
-const MAX_EXPIRY_DAYS = 365;
-const MAX_MESSAGE_LIMIT = 1000;
-
-/**
- * Parse an operator-facing positive-integer env var with a strict canonical
- * grammar. Unlike `Number.parseInt`, this rejects trailing junk (`"5oops"`),
- * exponent notation (`"1e2"`), decimals (`"7.0"`), and leading zeros (`"05"`)
- * instead of silently truncating them — a silently mutated spend gate has
- * direct billing impact on the application owner.
- *
- * Unset or blank/whitespace-only values keep the default silently (matches the
- * prior behavior and the affiliate routes' convention). Any other invalid or
- * out-of-range value warns — naming the env var and the rejected value — and
- * returns the default.
- */
-function parsePositiveIntEnv(
-  value: string | undefined,
-  defaultValue: number,
-  name: string,
-  max: number,
-): number {
-  if (value === undefined) {
-    return defaultValue;
-  }
-  const raw = value.trim();
-  if (raw === "") {
-    return defaultValue;
-  }
-  // Canonical positive decimal integer only: `[1-9][0-9]*` excludes leading
-  // zeros, signs, decimals, exponents, and any trailing junk.
-  if (!/^[1-9][0-9]*$/.test(raw)) {
-    logger.warn(
-      `[anonymous-session] Invalid ${name} (expected canonical positive integer), using default ${defaultValue} (received: ${value})`,
-    );
-    return defaultValue;
-  }
-  const n = Number.parseInt(raw, 10);
-  if (!Number.isSafeInteger(n) || n <= 0 || n > max) {
-    logger.warn(
-      `[anonymous-session] Invalid ${name} (expected 1..${max}), using default ${defaultValue} (received: ${value})`,
-    );
-    return defaultValue;
-  }
-  return n;
-}
-
 const app = new Hono<AppEnv>();
 
 app.use("*", rateLimit(RateLimitPresets.AGGRESSIVE));
@@ -90,17 +45,19 @@ app.post("/", async (c) => {
       PUBLIC_CHAT_MESSAGE_LIMIT?: string;
       NODE_ENV?: string;
     };
-    const expiryDays = parsePositiveIntEnv(
+    const expiryDays = parseAnonymousPositiveIntEnv(
       env.ANON_SESSION_EXPIRY_DAYS,
       7,
       "ANON_SESSION_EXPIRY_DAYS",
-      MAX_EXPIRY_DAYS,
+      MAX_ANONYMOUS_EXPIRY_DAYS,
+      "anonymous-session",
     );
-    const messagesLimit = parsePositiveIntEnv(
+    const messagesLimit = parseAnonymousPositiveIntEnv(
       env.PUBLIC_CHAT_MESSAGE_LIMIT,
       3,
       "PUBLIC_CHAT_MESSAGE_LIMIT",
-      MAX_MESSAGE_LIMIT,
+      MAX_ANONYMOUS_MESSAGE_LIMIT,
+      "anonymous-session",
     );
 
     const cookieToken = getCookie(c, ANON_SESSION_COOKIE);

--- a/packages/cloud/api/auth/anonymous-session/route.ts
+++ b/packages/cloud/api/auth/anonymous-session/route.ts
@@ -29,15 +29,50 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const ANON_SESSION_COOKIE = "eliza-anon-session";
 
+// Operator-sane upper bounds for the spend-gate env vars. A configured value
+// above these caps is treated as a typo and rejected in favour of the default,
+// because `messages_limit` is the per-guest anonymous spend gate and directly
+// bounds how much of the application owner's credit balance a guest can burn.
+const MAX_EXPIRY_DAYS = 365;
+const MAX_MESSAGE_LIMIT = 1000;
+
+/**
+ * Parse an operator-facing positive-integer env var with a strict canonical
+ * grammar. Unlike `Number.parseInt`, this rejects trailing junk (`"5oops"`),
+ * exponent notation (`"1e2"`), decimals (`"7.0"`), and leading zeros (`"05"`)
+ * instead of silently truncating them — a silently mutated spend gate has
+ * direct billing impact on the application owner.
+ *
+ * Unset or blank/whitespace-only values keep the default silently (matches the
+ * prior behavior and the affiliate routes' convention). Any other invalid or
+ * out-of-range value warns — naming the env var and the rejected value — and
+ * returns the default.
+ */
 function parsePositiveIntEnv(
   value: string | undefined,
   defaultValue: number,
   name: string,
+  max: number,
 ): number {
-  const n = Number.parseInt(value || String(defaultValue), 10);
-  if (Number.isNaN(n) || n <= 0) {
+  if (value === undefined) {
+    return defaultValue;
+  }
+  const raw = value.trim();
+  if (raw === "") {
+    return defaultValue;
+  }
+  // Canonical positive decimal integer only: `[1-9][0-9]*` excludes leading
+  // zeros, signs, decimals, exponents, and any trailing junk.
+  if (!/^[1-9][0-9]*$/.test(raw)) {
     logger.warn(
-      `[anonymous-session] Invalid ${name}, using default: ${defaultValue}`,
+      `[anonymous-session] Invalid ${name} (expected canonical positive integer), using default ${defaultValue} (received: ${value})`,
+    );
+    return defaultValue;
+  }
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(n) || n <= 0 || n > max) {
+    logger.warn(
+      `[anonymous-session] Invalid ${name} (expected 1..${max}), using default ${defaultValue} (received: ${value})`,
     );
     return defaultValue;
   }
@@ -59,11 +94,13 @@ app.post("/", async (c) => {
       env.ANON_SESSION_EXPIRY_DAYS,
       7,
       "ANON_SESSION_EXPIRY_DAYS",
+      MAX_EXPIRY_DAYS,
     );
     const messagesLimit = parsePositiveIntEnv(
       env.PUBLIC_CHAT_MESSAGE_LIMIT,
       3,
       "PUBLIC_CHAT_MESSAGE_LIMIT",
+      MAX_MESSAGE_LIMIT,
     );
 
     const cookieToken = getCookie(c, ANON_SESSION_COOKIE);

--- a/packages/cloud/api/auth/create-anonymous-session/route.test.ts
+++ b/packages/cloud/api/auth/create-anonymous-session/route.test.ts
@@ -1,4 +1,4 @@
-// Exercises cloud API auth create anonymous session route.test behavior with deterministic Worker route fixtures.
+/** Exercises anonymous-session creation through deterministic Worker fixtures. */
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import * as realRedisFactory from "@/lib/cache/redis-factory";
 

--- a/packages/cloud/api/auth/create-anonymous-session/route.test.ts
+++ b/packages/cloud/api/auth/create-anonymous-session/route.test.ts
@@ -4,11 +4,18 @@ import * as realRedisFactory from "@/lib/cache/redis-factory";
 
 const realRedisFactoryExports = { ...realRedisFactory };
 
-// Count how many anonymous users actually get minted (DB rows inserted).
-const createAnonymousUserAndSession = mock(async () => ({
-  newUser: { id: "anon-user" },
-  newSession: { id: "anon-session" },
-}));
+// Count how many anonymous users actually get minted (DB rows inserted) and
+// capture the spend-gate params so env-var validation can be asserted.
+let lastMintParams: { messagesLimit: number; expiresAt: Date } | null = null;
+const createAnonymousUserAndSession = mock(
+  async (params: { messagesLimit: number; expiresAt: Date }) => {
+    lastMintParams = params;
+    return {
+      newUser: { id: "anon-user" },
+      newSession: { id: "anon-session" },
+    };
+  },
+);
 
 mock.module("@/lib/services/anonymous-session-creator", () => ({
   createAnonymousUserAndSession,
@@ -65,5 +72,81 @@ describe("create-anonymous-session anti-sybil rate limit", () => {
   test("a different IP gets its own fresh budget", async () => {
     for (let i = 0; i < 6; i++) await mint("203.0.113.7");
     expect((await mint("198.51.100.9")).status).toBe(302);
+  });
+});
+
+// #19716 — the spend-gate env vars must be parsed with a strict canonical
+// grammar, not tolerant `Number.parseInt`. A silently mutated `messages_limit`
+// (the per-guest anonymous spend gate) has direct billing impact on the
+// application owner. Each case uses a unique source IP so the anti-sybil rate
+// limit (5 mints / IP) never trips within a single-request test.
+describe("#19716 create-anonymous-session — spend-gate env validation", () => {
+  let ipCounter = 0;
+
+  async function mintWith(env: Record<string, unknown>) {
+    lastMintParams = null;
+    ipCounter += 1;
+    const res = await app.fetch(
+      new Request("https://api.example.test/?returnUrl=/chat", {
+        headers: { "cf-connecting-ip": `198.51.100.${ipCounter}` },
+      }),
+      { ...ENV, ...env },
+    );
+    return res;
+  }
+
+  function expiryDaysOf(params: { expiresAt: Date }): number {
+    return Math.round(
+      (params.expiresAt.getTime() - Date.now()) / (24 * 60 * 60 * 1000),
+    );
+  }
+
+  test("unset ANON_MESSAGE_LIMIT keeps default 5 silently", async () => {
+    const res = await mintWith({});
+    expect(res.status).toBe(302);
+    expect(lastMintParams).not.toBeNull();
+    expect(lastMintParams!.messagesLimit).toBe(5);
+  });
+
+  test("valid ANON_MESSAGE_LIMIT=25 is honored", async () => {
+    await mintWith({ ANON_MESSAGE_LIMIT: "25" });
+    expect(lastMintParams!.messagesLimit).toBe(25);
+  });
+
+  test.each([
+    ["5oops", "trailing junk"],
+    ["1e2", "exponent notation"],
+    ["7.0", "decimal"],
+    ["05", "leading zero"],
+    ["abc", "non-numeric"],
+    ["0", "zero"],
+    ["-3", "negative"],
+    ["  ", "whitespace-only"],
+  ])(
+    "malformed ANON_MESSAGE_LIMIT=%p (%s) falls back to default 5",
+    async (value) => {
+      await mintWith({ ANON_MESSAGE_LIMIT: value });
+      expect(lastMintParams!.messagesLimit).toBe(5);
+    },
+  );
+
+  test("overflow ANON_MESSAGE_LIMIT (400 nines) falls back to default 5", async () => {
+    await mintWith({ ANON_MESSAGE_LIMIT: "9".repeat(400) });
+    expect(lastMintParams!.messagesLimit).toBe(5);
+  });
+
+  test("above-cap ANON_MESSAGE_LIMIT=1001 falls back to default 5", async () => {
+    await mintWith({ ANON_MESSAGE_LIMIT: "1001" });
+    expect(lastMintParams!.messagesLimit).toBe(5);
+  });
+
+  test("malformed ANON_SESSION_EXPIRY_DAYS=7.0 falls back to default 7 days", async () => {
+    await mintWith({ ANON_SESSION_EXPIRY_DAYS: "7.0" });
+    expect(expiryDaysOf(lastMintParams!)).toBe(7);
+  });
+
+  test("valid ANON_SESSION_EXPIRY_DAYS=30 is honored", async () => {
+    await mintWith({ ANON_SESSION_EXPIRY_DAYS: "30" });
+    expect(expiryDaysOf(lastMintParams!)).toBe(30);
   });
 });

--- a/packages/cloud/api/auth/create-anonymous-session/route.ts
+++ b/packages/cloud/api/auth/create-anonymous-session/route.ts
@@ -9,6 +9,11 @@ import { Hono } from "hono";
 import { setCookie } from "hono/cookie";
 import { nanoid } from "nanoid";
 import {
+  MAX_ANONYMOUS_EXPIRY_DAYS,
+  MAX_ANONYMOUS_MESSAGE_LIMIT,
+  parseAnonymousPositiveIntEnv,
+} from "@/auth/anonymous-session-config";
+import {
   getIpKey,
   RateLimitPresets,
   rateLimit,
@@ -18,56 +23,6 @@ import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const ANON_SESSION_COOKIE = "eliza-anon-session";
-
-// Operator-sane upper bounds for the spend-gate env vars. A configured value
-// above these caps is treated as a typo and rejected in favour of the default,
-// because `messages_limit` is the per-guest anonymous spend gate and directly
-// bounds how much of the application owner's credit balance a guest can burn.
-const MAX_EXPIRY_DAYS = 365;
-const MAX_MESSAGE_LIMIT = 1000;
-
-/**
- * Parse an operator-facing positive-integer env var with a strict canonical
- * grammar. Unlike `Number.parseInt`, this rejects trailing junk (`"5oops"`),
- * exponent notation (`"1e2"`), decimals (`"7.0"`), and leading zeros (`"05"`)
- * instead of silently truncating them — a silently mutated spend gate has
- * direct billing impact on the application owner.
- *
- * Unset or blank/whitespace-only values keep the default silently (matches the
- * prior behavior and the affiliate routes' convention). Any other invalid or
- * out-of-range value warns — naming the env var and the rejected value — and
- * returns the default.
- */
-function parsePositiveIntEnv(
-  value: string | undefined,
-  defaultValue: number,
-  name: string,
-  max: number,
-): number {
-  if (value === undefined) {
-    return defaultValue;
-  }
-  const raw = value.trim();
-  if (raw === "") {
-    return defaultValue;
-  }
-  // Canonical positive decimal integer only: `[1-9][0-9]*` excludes leading
-  // zeros, signs, decimals, exponents, and any trailing junk.
-  if (!/^[1-9][0-9]*$/.test(raw)) {
-    logger.warn(
-      `[create-anonymous-session] Invalid ${name} (expected canonical positive integer), using default ${defaultValue} (received: ${value})`,
-    );
-    return defaultValue;
-  }
-  const n = Number.parseInt(raw, 10);
-  if (!Number.isSafeInteger(n) || n <= 0 || n > max) {
-    logger.warn(
-      `[create-anonymous-session] Invalid ${name} (expected 1..${max}), using default ${defaultValue} (received: ${value})`,
-    );
-    return defaultValue;
-  }
-  return n;
-}
 
 function isValidReturnUrl(url: string): boolean {
   return url.startsWith("/") && !url.startsWith("//");
@@ -94,17 +49,19 @@ app.get("/", async (c) => {
       ANON_SESSION_EXPIRY_DAYS?: string;
       ANON_MESSAGE_LIMIT?: string;
     };
-    const expiryDays = parsePositiveIntEnv(
+    const expiryDays = parseAnonymousPositiveIntEnv(
       env.ANON_SESSION_EXPIRY_DAYS,
       7,
       "ANON_SESSION_EXPIRY_DAYS",
-      MAX_EXPIRY_DAYS,
+      MAX_ANONYMOUS_EXPIRY_DAYS,
+      "create-anonymous-session",
     );
-    const msgLimit = parsePositiveIntEnv(
+    const msgLimit = parseAnonymousPositiveIntEnv(
       env.ANON_MESSAGE_LIMIT,
       5,
       "ANON_MESSAGE_LIMIT",
-      MAX_MESSAGE_LIMIT,
+      MAX_ANONYMOUS_MESSAGE_LIMIT,
+      "create-anonymous-session",
     );
 
     const rawReturnUrl = c.req.query("returnUrl") || "/";

--- a/packages/cloud/api/auth/create-anonymous-session/route.ts
+++ b/packages/cloud/api/auth/create-anonymous-session/route.ts
@@ -19,15 +19,50 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const ANON_SESSION_COOKIE = "eliza-anon-session";
 
+// Operator-sane upper bounds for the spend-gate env vars. A configured value
+// above these caps is treated as a typo and rejected in favour of the default,
+// because `messages_limit` is the per-guest anonymous spend gate and directly
+// bounds how much of the application owner's credit balance a guest can burn.
+const MAX_EXPIRY_DAYS = 365;
+const MAX_MESSAGE_LIMIT = 1000;
+
+/**
+ * Parse an operator-facing positive-integer env var with a strict canonical
+ * grammar. Unlike `Number.parseInt`, this rejects trailing junk (`"5oops"`),
+ * exponent notation (`"1e2"`), decimals (`"7.0"`), and leading zeros (`"05"`)
+ * instead of silently truncating them — a silently mutated spend gate has
+ * direct billing impact on the application owner.
+ *
+ * Unset or blank/whitespace-only values keep the default silently (matches the
+ * prior behavior and the affiliate routes' convention). Any other invalid or
+ * out-of-range value warns — naming the env var and the rejected value — and
+ * returns the default.
+ */
 function parsePositiveIntEnv(
   value: string | undefined,
   defaultValue: number,
   name: string,
+  max: number,
 ): number {
-  const n = Number.parseInt(value || String(defaultValue), 10);
-  if (Number.isNaN(n) || n <= 0) {
+  if (value === undefined) {
+    return defaultValue;
+  }
+  const raw = value.trim();
+  if (raw === "") {
+    return defaultValue;
+  }
+  // Canonical positive decimal integer only: `[1-9][0-9]*` excludes leading
+  // zeros, signs, decimals, exponents, and any trailing junk.
+  if (!/^[1-9][0-9]*$/.test(raw)) {
     logger.warn(
-      `[create-anonymous-session] Invalid ${name}, using default: ${defaultValue}`,
+      `[create-anonymous-session] Invalid ${name} (expected canonical positive integer), using default ${defaultValue} (received: ${value})`,
+    );
+    return defaultValue;
+  }
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(n) || n <= 0 || n > max) {
+    logger.warn(
+      `[create-anonymous-session] Invalid ${name} (expected 1..${max}), using default ${defaultValue} (received: ${value})`,
     );
     return defaultValue;
   }
@@ -63,11 +98,13 @@ app.get("/", async (c) => {
       env.ANON_SESSION_EXPIRY_DAYS,
       7,
       "ANON_SESSION_EXPIRY_DAYS",
+      MAX_EXPIRY_DAYS,
     );
     const msgLimit = parsePositiveIntEnv(
       env.ANON_MESSAGE_LIMIT,
       5,
       "ANON_MESSAGE_LIMIT",
+      MAX_MESSAGE_LIMIT,
     );
 
     const rawReturnUrl = c.req.query("returnUrl") || "/";


### PR DESCRIPTION
# Relates to

Closes #19716
Closes #19715 (exact duplicate of #19716 — same body, same files)

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the owning-package gates (test, `tsc --noEmit`, wrangler dry-run bundle check, biome lint) were run and pass. See **Known gaps / failures** for the `bun run verify` note.
- [x] A reviewer can confirm the change works without reading the code, from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@1ba956df211fa582e9fb1c59331248a6b625231d:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`daaa69660d`); zero conflicts.
- [x] Focused package gates pass post-sync; see **Known gaps / failures** for the `bun run verify` note.

# Risks

Low. The change only tightens parsing of two operator-facing env vars
(`ANON_SESSION_EXPIRY_DAYS`, `ANON_MESSAGE_LIMIT`, `PUBLIC_CHAT_MESSAGE_LIMIT`)
in two anonymous-session routes. Valid canonical integers behave exactly as
before; unset/blank values still fall back to the default silently. The only
behavioral change is that previously-accepted malformed spellings now warn and
use the safe default instead of a silently-truncated value. No public type,
route, or schema changes.

# Background

## What does this PR do?

The two non-affiliate anonymous-session routes parsed spend-gate env vars with
`Number.parseInt(value, 10)` guarded only by `Number.isNaN`/`<= 0` checks, which
silently accepts mutated values:

```
Number.parseInt("5oops",10) -> 5   (trailing junk accepted)
Number.parseInt("1e2",10)   -> 1   (exponent notation truncated)
Number.parseInt("7.0",10)   -> 7   (decimals truncated)
Number.parseInt("05",10)    -> 5   (leading zeros accepted)
```

Because the persisted `messages_limit` is the per-guest anonymous spend gate
(`anonymousSessionsService.hasReachedLimit`), a silently-mutated value has direct
billing impact on the application owner's credit balance, and no warning was
logged.

This PR replaces the tolerant parse in both
`packages/cloud/api/auth/anonymous-session/route.ts` and
`packages/cloud/api/auth/create-anonymous-session/route.ts` with a strict
canonical-decimal grammar helper that:

1. Leaves the default in place **silently** when the value is unset or
   blank/whitespace-only (matches prior behavior and the affiliate routes'
   convention — no warning noise for operators who never set the var).
2. Accepts only a canonical positive integer `/^[1-9][0-9]*$/` (surrounding
   whitespace trimmed first), rejecting trailing junk, exponent notation,
   decimals, signs, and leading zeros.
3. Enforces `Number.isSafeInteger` and an operator-sane upper bound
   (`365` days / `1000` messages, mirroring the affiliate routes' caps).
4. Warns on **any** invalid or out-of-range configured value — naming the env
   var and the rejected value — and returns the default.

This aligns with the affiliate routes' hardened `parsePositiveIntEnv` behavior
introduced in #19633/#19628, and is intentionally *stricter* on one axis: the
affiliate helper uses `/^\d+$/` (which still accepts leading zeros like `"05"`),
whereas issue #19716 explicitly requires rejecting leading zeros, so the
canonical grammar `/^[1-9][0-9]*$/` is used here. Out-of-range values fall back
to the default (per the issue's acceptance list) rather than clamping. The
affiliate routes were left untouched to keep the diff focused.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The new
behavior is described in the helper's JSDoc in both route files and surfaced to
operators via a `logger.warn` naming the env var and rejected value.

# Testing

## Where should a reviewer start?

- `packages/cloud/api/auth/create-anonymous-session/route.test.ts` — extended
  with a `#19716 … spend-gate env validation` describe block.
- `packages/cloud/api/auth/anonymous-session/route.test.ts` — new file driving
  the real Hono handler's mint path.

Both suites drive the **real** route handlers and assert the `messagesLimit` /
`expiresAt` that reaches the session creator, proving which value the parser
selected.

## Detailed testing steps

Run from repo root:

```bash
bun test packages/cloud/api/auth/create-anonymous-session/route.test.ts
bun test packages/cloud/api/auth/anonymous-session/route.test.ts
cd packages/cloud/api && bun run typecheck    # tsc --noEmit + wrangler dry-run bundle check
cd packages/cloud/api && bun run lint:check    # biome
```

# Evidence Gate

<!-- evidence-head:efa06974f4dfdca7385923ce6111ba37b97393df -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only Cloudflare Worker env-var parsing change; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only Cloudflare Worker env-var parsing change; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; behavior is env-var parsing verified by route-driven tests.
<!-- evidence-row:backend-logs -->
- [x] The real route handlers were exercised end to end; the test run below shows malformed env values falling back to the default and valid canonical values honored.

<details><summary>Backend route-handler test output (bun test, both route files)</summary>

```
$ bun test packages/cloud/api/auth/anonymous-session/route.test.ts packages/cloud/api/auth/create-anonymous-session/route.test.ts
(pass) create-anonymous-session anti-sybil rate limit > caps anonymous mints per IP and stops creating users after the cap [18.30ms]
(pass) create-anonymous-session anti-sybil rate limit > a different IP gets its own fresh budget [1.34ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > unset ANON_MESSAGE_LIMIT keeps default 5 silently [0.96ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > valid ANON_MESSAGE_LIMIT=25 is honored [0.58ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > malformed ANON_MESSAGE_LIMIT="5oops" (trailing junk) falls back to default 5 [2.16ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > malformed ANON_MESSAGE_LIMIT="1e2" (exponent notation) falls back to default 5 [0.47ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > malformed ANON_MESSAGE_LIMIT="7.0" (decimal) falls back to default 5 [0.30ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > malformed ANON_MESSAGE_LIMIT="05" (leading zero) falls back to default 5 [0.23ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > malformed ANON_MESSAGE_LIMIT="abc" (non-numeric) falls back to default 5 [0.23ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > malformed ANON_MESSAGE_LIMIT="0" (zero) falls back to default 5 [0.38ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > malformed ANON_MESSAGE_LIMIT="-3" (negative) falls back to default 5 [0.21ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > malformed ANON_MESSAGE_LIMIT="  " (whitespace-only) falls back to default 5 [0.16ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > overflow ANON_MESSAGE_LIMIT (400 nines) falls back to default 5 [0.56ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > above-cap ANON_MESSAGE_LIMIT=1001 falls back to default 5 [0.96ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > malformed ANON_SESSION_EXPIRY_DAYS=7.0 falls back to default 7 days [0.84ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > valid ANON_SESSION_EXPIRY_DAYS=30 is honored [0.45ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > unset PUBLIC_CHAT_MESSAGE_LIMIT keeps default 3 silently [5.41ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > valid PUBLIC_CHAT_MESSAGE_LIMIT=25 is honored [0.57ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > malformed PUBLIC_CHAT_MESSAGE_LIMIT="5oops" (trailing junk) falls back to default 3 [0.44ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > malformed PUBLIC_CHAT_MESSAGE_LIMIT="1e2" (exponent notation) falls back to default 3 [0.25ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > malformed PUBLIC_CHAT_MESSAGE_LIMIT="7.0" (decimal) falls back to default 3 [0.18ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > malformed PUBLIC_CHAT_MESSAGE_LIMIT="05" (leading zero) falls back to default 3 [0.82ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > malformed PUBLIC_CHAT_MESSAGE_LIMIT="abc" (non-numeric) falls back to default 3 [0.66ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > malformed PUBLIC_CHAT_MESSAGE_LIMIT="0" (zero) falls back to default 3 [0.43ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > malformed PUBLIC_CHAT_MESSAGE_LIMIT="-3" (negative) falls back to default 3 [0.15ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > malformed PUBLIC_CHAT_MESSAGE_LIMIT="  " (whitespace-only) falls back to default 3 [0.08ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > overflow PUBLIC_CHAT_MESSAGE_LIMIT (400 nines) falls back to default 3 [0.34ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > above-cap PUBLIC_CHAT_MESSAGE_LIMIT=1001 falls back to default 3 [0.32ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > malformed ANON_SESSION_EXPIRY_DAYS=7.0 falls back to default 7 days [0.25ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > valid ANON_SESSION_EXPIRY_DAYS=30 is honored [0.20ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > above-cap ANON_SESSION_EXPIRY_DAYS=366 falls back to default 7 days [0.29ms]
 31 pass
 0 fail
Ran 31 tests across 2 files. [1.86s]
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved; this is a Cloudflare Worker backend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [x] The spend-gate artifact under test is the `messages_limit` / expiry passed to the session creator. The route-driven tests assert those exact values; output below.

<details><summary>Domain-artifact output: messages_limit / expiry selected by the parser per input</summary>

```
$ bun test packages/cloud/api/auth/anonymous-session/route.test.ts packages/cloud/api/auth/create-anonymous-session/route.test.ts
(pass) create-anonymous-session anti-sybil rate limit > caps anonymous mints per IP and stops creating users after the cap [18.30ms]
(pass) create-anonymous-session anti-sybil rate limit > a different IP gets its own fresh budget [1.34ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > unset ANON_MESSAGE_LIMIT keeps default 5 silently [0.96ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > valid ANON_MESSAGE_LIMIT=25 is honored [0.58ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > malformed ANON_MESSAGE_LIMIT="5oops" (trailing junk) falls back to default 5 [2.16ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > malformed ANON_MESSAGE_LIMIT="1e2" (exponent notation) falls back to default 5 [0.47ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > malformed ANON_MESSAGE_LIMIT="7.0" (decimal) falls back to default 5 [0.30ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > malformed ANON_MESSAGE_LIMIT="05" (leading zero) falls back to default 5 [0.23ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > malformed ANON_MESSAGE_LIMIT="abc" (non-numeric) falls back to default 5 [0.23ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > malformed ANON_MESSAGE_LIMIT="0" (zero) falls back to default 5 [0.38ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > malformed ANON_MESSAGE_LIMIT="-3" (negative) falls back to default 5 [0.21ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > malformed ANON_MESSAGE_LIMIT="  " (whitespace-only) falls back to default 5 [0.16ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > overflow ANON_MESSAGE_LIMIT (400 nines) falls back to default 5 [0.56ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > above-cap ANON_MESSAGE_LIMIT=1001 falls back to default 5 [0.96ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > malformed ANON_SESSION_EXPIRY_DAYS=7.0 falls back to default 7 days [0.84ms]
(pass) #19716 create-anonymous-session — spend-gate env validation > valid ANON_SESSION_EXPIRY_DAYS=30 is honored [0.45ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > unset PUBLIC_CHAT_MESSAGE_LIMIT keeps default 3 silently [5.41ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > valid PUBLIC_CHAT_MESSAGE_LIMIT=25 is honored [0.57ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > malformed PUBLIC_CHAT_MESSAGE_LIMIT="5oops" (trailing junk) falls back to default 3 [0.44ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > malformed PUBLIC_CHAT_MESSAGE_LIMIT="1e2" (exponent notation) falls back to default 3 [0.25ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > malformed PUBLIC_CHAT_MESSAGE_LIMIT="7.0" (decimal) falls back to default 3 [0.18ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > malformed PUBLIC_CHAT_MESSAGE_LIMIT="05" (leading zero) falls back to default 3 [0.82ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > malformed PUBLIC_CHAT_MESSAGE_LIMIT="abc" (non-numeric) falls back to default 3 [0.66ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > malformed PUBLIC_CHAT_MESSAGE_LIMIT="0" (zero) falls back to default 3 [0.43ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > malformed PUBLIC_CHAT_MESSAGE_LIMIT="-3" (negative) falls back to default 3 [0.15ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > malformed PUBLIC_CHAT_MESSAGE_LIMIT="  " (whitespace-only) falls back to default 3 [0.08ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > overflow PUBLIC_CHAT_MESSAGE_LIMIT (400 nines) falls back to default 3 [0.34ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > above-cap PUBLIC_CHAT_MESSAGE_LIMIT=1001 falls back to default 3 [0.32ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > malformed ANON_SESSION_EXPIRY_DAYS=7.0 falls back to default 7 days [0.25ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > valid ANON_SESSION_EXPIRY_DAYS=30 is honored [0.20ms]
(pass) #19716 auth/anonymous-session — spend-gate env validation > above-cap ANON_SESSION_EXPIRY_DAYS=366 falls back to default 7 days [0.29ms]
 31 pass
 0 fail
Ran 31 tests across 2 files. [1.86s]
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - this change contains no agent/action/provider/prompt/model code.

## Backend + frontend logs

Reproduction of the underlying bug (tolerant `Number.parseInt`):

```
Number.parseInt("5oops",10) -> 5
Number.parseInt("1e2",10) -> 1
Number.parseInt("7.0",10) -> 7
Number.parseInt("05",10) -> 5
```

<details><summary>tsc --noEmit + wrangler dry-run bundle check (typecheck) — exit 0</summary>

```
$ cd packages/cloud/api && bun run typecheck
TYPECHECK_EXIT=0
--dry-run: exiting now.
```

</details>

<details><summary>biome lint:check — exit 0, no warnings</summary>

```
$ cd packages/cloud/api && bun run lint:check
Checked 1061 files in 5s. No fixes applied.
LINT_EXIT=0
```

</details>

## Screenshots (before / after) + video walkthrough

N/A - backend-only Cloudflare Worker change with no rendered UI.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT change.

## Known gaps / failures

- `bun run verify` (the repository-wide gate) was not run to completion on this
  constrained build host. Instead the owning package's gates were run and pass:
  `bun test` for both touched route test files (31/31), `tsc --noEmit` plus the
  `wrangler deploy --dry-run` bundle check, and biome `lint:check` (0 warnings).
  This is not a blocker for a two-file backend parsing change; the affected
  package's full test/typecheck/lint gates are green.
- `bun install` required overriding a local minimum-release-age setting for a
  repo-lockfile-pinned dependency (`smthrs@0.34.0`); no dependency versions were
  changed by this PR.
- PR-evidence release uploads are not available to this fork account, so backend
  and domain-artifact logs are pasted inline (per CONTRIBUTING.md § Evidence)
  rather than attached as release assets.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@1ba956df211fa582e9fb1c59331248a6b625231d:packages/skills/skills/contribute-to-eliza"} -->
