### PR TITLE
fix(cloud): source-control WARM_POOL_ENABLED in daemon deploy reconcile and wrangler vars

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -175,6 +175,15 @@ jobs:
       # image ref is auditable config) to roll the fleet pin via deploy;
       # leave it unset to preserve whatever is hand-set on the box.
       ELIZA_AGENT_IMAGE: ${{ vars.ELIZA_AGENT_IMAGE }}
+      # Warm-pool daemon half (#16961). The replenish phase self-gates on
+      # WARM_POOL_ENABLED, so a host that loses this key silently degrades every
+      # dedicated provision to the 30-120s cold path. Reconciling it here makes
+      # the GitHub environment VARIABLE (not secret — a boolean flag is
+      # auditable config) the source of truth so a CP re-arm can never drop it;
+      # leaving the GH var unset preserves whatever is hand-set on the box.
+      # Activation policy stays with #16961's checklist: flip the environment
+      # var, do not hand-edit the box.
+      WARM_POOL_ENABLED: ${{ vars.WARM_POOL_ENABLED }}
       # The edge Worker forwards the original per-agent host to this daemon.
       # Keep the daemon's parser on the same environment-specific suffix or a
       # staging host (`<uuid>.cloud-staging.eliza.app`) is rejected as malformed.
@@ -300,7 +309,7 @@ jobs:
           # Preserve setup/build headroom without weakening the preflight's own
           # eight-minute fail-closed fence near the end of this remote script.
           command_timeout: 20m
-          envs: DEPLOY_BRANCH,DEPLOY_SHA,SYSTEMD_UNIT,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,CONTAINERS_SSH_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL,SECRETS_MASTER_KEY,ELIZA_AGENT_IMAGE,ELIZA_CLOUD_AGENT_BASE_DOMAIN,AGENT_ROUTER_PUBLIC_HOST,LEGACY_AGENT_ROUTER_PUBLIC_HOST
+          envs: DEPLOY_BRANCH,DEPLOY_SHA,SYSTEMD_UNIT,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,CONTAINERS_SSH_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL,SECRETS_MASTER_KEY,ELIZA_AGENT_IMAGE,WARM_POOL_ENABLED,ELIZA_CLOUD_AGENT_BASE_DOMAIN,AGENT_ROUTER_PUBLIC_HOST,LEGACY_AGENT_ROUTER_PUBLIC_HOST
           script: |
             set -euo pipefail
             echo "=== Deploying eliza-provisioning-worker (branch: $DEPLOY_BRANCH sha: $DEPLOY_SHA) ==="
@@ -479,6 +488,7 @@ jobs:
               "DATABASE_URL=$DATABASE_URL" \
               "SECRETS_MASTER_KEY=$SECRETS_MASTER_KEY" \
               "ELIZA_AGENT_IMAGE=$ELIZA_AGENT_IMAGE" \
+              "WARM_POOL_ENABLED=$WARM_POOL_ENABLED" \
               "ELIZA_CLOUD_AGENT_BASE_DOMAIN=$ELIZA_CLOUD_AGENT_BASE_DOMAIN"; do
               key="${kv%%=*}"
               val="${kv#*=}"

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -181,6 +181,13 @@ GITHUB_TEMPLATE_REPO = "eliza-cloud-apps/cloud-apps-template"
 ENVIRONMENT = "production"
 DATABASE_REGION = "na"
 PAYOUT_TESTNET = "false"
+# Warm-pool claim half (#16961): the provision route only claims a pre-booted
+# sandbox when this is "true". Committed here — never a dashboard-only secret —
+# so the intended state survives every redeploy and is auditable in source.
+# Production activation is gated on the #16961 checklist (capacity, starvation,
+# identity, and health guards with staging soak evidence); flip this committed
+# value in the same PR that attaches that evidence.
+WARM_POOL_ENABLED = "false"
 X402_NETWORK = "base"
 X402_NETWORKS = "ethereum,sepolia,base-sepolia,base,bsc,bsc-testnet,solana-devnet,solana"
 X402_ETHEREUM_RPC_URL = "https://ethereum-rpc.publicnode.com"
@@ -488,6 +495,10 @@ ENVIRONMENT = "staging"
 THIN_INFERENCE_ENTRY_ENABLED = "true"
 DATABASE_REGION = "na"
 PAYOUT_TESTNET = "true"
+# Warm-pool claim half (#16961). Staging enablement is the next step of that
+# issue's dependency chain but is sequenced behind draining the residual
+# sentinel-org pool rows; flip this committed value when that drain is done.
+WARM_POOL_ENABLED = "false"
 X402_NETWORK = "base"
 X402_NETWORKS = "ethereum,sepolia,base-sepolia,base,bsc,bsc-testnet,solana-devnet,solana"
 X402_ETHEREUM_RPC_URL = "https://ethereum-rpc.publicnode.com"
@@ -710,6 +721,13 @@ GITHUB_TEMPLATE_REPO = "eliza-cloud-apps/cloud-apps-template"
 ENVIRONMENT = "production"
 DATABASE_REGION = "na"
 PAYOUT_TESTNET = "false"
+# Warm-pool claim half (#16961): the provision route only claims a pre-booted
+# sandbox when this is "true". Committed here — never a dashboard-only secret —
+# so the intended state survives every redeploy and is auditable in source.
+# Production activation is gated on the #16961 checklist (capacity, starvation,
+# identity, and health guards with staging soak evidence); flip this committed
+# value in the same PR that attaches that evidence.
+WARM_POOL_ENABLED = "false"
 X402_NETWORK = "base"
 X402_NETWORKS = "ethereum,sepolia,base-sepolia,base,bsc,bsc-testnet,solana-devnet,solana"
 X402_ETHEREUM_RPC_URL = "https://ethereum-rpc.publicnode.com"

--- a/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts
@@ -81,6 +81,33 @@ describe("provisioning worker deployment contract", () => {
     }
   });
 
+  it("reconciles WARM_POOL_ENABLED from the protected environment so re-arms cannot drop it (#16961)", () => {
+    // The daemon replenish phase self-gates on this key; if a re-arm rebuilds
+    // /opt/eliza/cloud/.env.local without it, every dedicated provision
+    // silently falls back to the 30-120s cold path. The flag must flow from
+    // the GitHub environment VARIABLE through the SSH env passthrough into the
+    // skip-empty EnvironmentFile reconcile loop.
+    expect(workflow).toContain(
+      "WARM_POOL_ENABLED: ${{ vars.WARM_POOL_ENABLED }}",
+    );
+    expect(workflow).toMatch(/envs: [^\n]*\bWARM_POOL_ENABLED\b/);
+    expect(workflow).toContain('"WARM_POOL_ENABLED=$WARM_POOL_ENABLED" \\');
+  });
+
+  it("keeps the Worker warm-pool claim flag committed per wrangler environment (#16961)", () => {
+    const wranglerToml = readFileSync(
+      join(root, "packages/cloud/api/wrangler.toml"),
+      "utf8",
+    );
+    // A dashboard-only var disappears on redeploy; the intended state must be
+    // an explicit committed value in every environment block.
+    const occurrences = wranglerToml.match(
+      /^WARM_POOL_ENABLED = "(?:true|false)"$/gm,
+    );
+    expect(occurrences).not.toBeNull();
+    expect((occurrences ?? []).length).toBe(3);
+  });
+
   it("keeps replacement workload memory inside the control-plane service fence", () => {
     const oldSpaceMatches = [
       ...provisioningService.matchAll(


### PR DESCRIPTION
## What

Wires `WARM_POOL_ENABLED` through both source-controlled configuration paths so it can never again silently disappear (#16961: warm pool disabled in prod because the flag existed nowhere durable):

- **Daemon half** (`.github/workflows/deploy-eliza-provisioning-worker.yml`): the flag is now read from the protected GitHub environment variable `vars.WARM_POOL_ENABLED`, passed through the SSH `envs` list, and reconciled into `/opt/eliza/cloud/.env.local` by the existing skip-empty loop (same mechanism as `ELIZA_AGENT_IMAGE`). A CP re-arm can no longer drop it; an unset GH var preserves the hand-set host value.
- **Worker half** (`packages/cloud/api/wrangler.toml`): `WARM_POOL_ENABLED` is now an explicit committed var in all three vars blocks (`[vars]`, `[env.staging.vars]`, `[env.production.vars]`) rather than absent/dashboard-only state that a redeploy wipes.

## Why the committed value is "false", not "true"

The issue thread explicitly gates activation: production stays on the full capacity/starvation/identity/health checklist, and staging enablement is sequenced behind draining the residual sentinel-org pool rows. Per the triage there, "the safe production state is WARM_POOL_ENABLED=false on both sides" until that evidence lands. This PR delivers the deploy-guard row of that checklist ("comes only from source-controlled daemon env reconcile + wrangler.toml, no dashboard-only/manual env state"); the actual flip becomes a one-line auditable source change (Worker) plus a GH environment-variable set (daemon), each carrying its evidence.

## Tests

- `bun test packages/scripts/__tests__/provisioning-worker-deploy-workflow.test.ts` — 8 pass (2 new contract tests: workflow env->envs->reconcile chain; 3 committed wrangler occurrences)
- `bun test packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts` — 15 pass
- YAML + TOML syntax validated (js-yaml / smol-toml parse clean)
- Biome clean on the touched test file

## Residual risk

The workflow change only takes effect on the next protected daemon deploy, and the reconcile is skip-empty, so hosts keep their current values until the GH environment variable is set — no behavior change from merging alone. Restarting the daemon / deploying the Worker and verifying `pool_status` rows remain the ops steps tracked on #16961.

Refs #16961 (deliberately not `Fixes` — the card stays open on staged activation + evidence per its checklist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)