### PR TITLE
fix(elizaresearch): text selection blocked page-wide — scope selection guard to hero canvas (#19719)

### DIFF
--- a/packages/elizaresearch/index.html
+++ b/packages/elizaresearch/index.html
@@ -57,7 +57,6 @@
     line-height: 1.55;
     -webkit-font-smoothing: antialiased;
     -webkit-tap-highlight-color: transparent;
-    -webkit-touch-callout: none;
   }
   h1, h2, h3 { text-wrap: balance; line-height: 1.02; }
   p { text-wrap: pretty; max-width: 62ch; }
@@ -420,7 +419,7 @@
     pointer.x = -1e4; pointer.y = -1e4;
   }, { passive: true });
   for (const type of ["contextmenu", "selectstart", "dragstart"]) {
-    document.body.addEventListener(type, (event) => event.preventDefault());
+    canvas.addEventListener(type, (event) => event.preventDefault());
   }
 
   function step(now) {


### PR DESCRIPTION
# Relates to

Fixes #19719. Follow-up to #19639, which moved `user-select: none` from `body`
to `#swarm` but left the behavior a **no-op**: an inline script still cancelled
`selectstart` / `dragstart` / `contextmenu` on `document.body`, and `body` still
carried `-webkit-touch-callout: none`. Together those blocked selection, copy,
right-click, and iOS long-press copy across the whole page.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` / `bun run verify` status is recorded honestly in
      **Known gaps / failures** below.
- [x] A reviewer can confirm the change works without reading the code, from the
      inline probe evidence below (reproducible in ~30s).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@1da8c4af80060383fc7f334be3e0a6797d18d8fc:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Post-sync verification recorded in **Known gaps / failures** below.

# Risks

Low. Two-line, surgical change to a single standalone static HTML file
(`packages/elizaresearch/index.html`) with no build step, no framework, and no
dependents. The hero particle-field guard is preserved by scoping the same three
listeners to the `#swarm` canvas.

# Background

## What does this PR do?

Two surgical edits in `packages/elizaresearch/index.html`:

1. Scope the `contextmenu` / `selectstart` / `dragstart` `preventDefault` loop
   from `document.body` to the already in-scope `#swarm` canvas
   (`const canvas = document.getElementById("swarm")`), so the decorative
   particle field keeps suppressing synthetic selection/drag while the rest of
   the page becomes fully selectable, copyable, and right-clickable.
2. Remove `-webkit-touch-callout: none;` from the `body` rule so iOS long-press
   copy works on body text. `#swarm` already sets
   `-webkit-user-select: none; user-select: none;`, so the callout stays
   suppressed over the canvas — scoping is preserved without the body-level rule.

```diff
@@ body { ... } @@
     -webkit-tap-highlight-color: transparent;
-    -webkit-touch-callout: none;
   }
@@ IIFE (const canvas = document.getElementById("swarm")) @@
   for (const type of ["contextmenu", "selectstart", "dragstart"]) {
-    document.body.addEventListener(type, (event) => event.preventDefault());
+    canvas.addEventListener(type, (event) => event.preventDefault());
   }
```

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Open `packages/elizaresearch/index.html` in Chromium/WebKit and confirm:
select/copy/right-click work on page text and product `<img>`s; a drag over the
hero `#swarm` canvas starts no selection; iOS long-press on body text shows the
copy callout.

## Detailed testing steps

Automated headless probe (Chromium 1228 via Playwright), served over HTTP with
real assets/fonts so layout is faithful. The probe compares the pre-fix
(`document.body`) build against the fixed (`canvas`) build. Full output is inline
in the **frontend-logs** row and the **Backend + frontend logs** section.

# Evidence Gate

<!-- evidence-head:5cd2e26f66943e7ae739368610c4d259807bb959 -->

<!-- evidence-row:before-screenshots -->
- [ ] `N/A - fork contributor without push access cannot upload trusted artifacts to the elizaOS/eliza pr-evidence release, and a headless CLI cannot mint GitHub user-attachments; the pre-fix state is proven inline in the frontend-logs row where Ctrl+A selects zero characters and dispatch on the paragraph and body is preventDefault true.`
<!-- evidence-row:after-screenshots -->
- [ ] `N/A - same upload constraint as the before row; the fixed state is proven inline in the frontend-logs row where Ctrl+A selects 1255 characters and dispatch on the paragraph and body is preventDefault false while the swarm canvas stays true.`
<!-- evidence-row:walkthrough-video -->
- [ ] `N/A - two-line static HTML/CSS change to a standalone site outside the packages/app and packages/ui surfaces; the inline dispatch and select-all probe below demonstrates the full behavior and no E2E video harness exists for this standalone static page.`
<!-- evidence-row:backend-logs -->
- [ ] `N/A - static HTML plus inline-JS page with no backend or server code path involved in this change.`
<!-- evidence-row:frontend-logs -->
- [ ] Headless-browser probe (page served over HTTP with real assets), comparing the pre-fix `document.body` build with the fixed `canvas` build:

<details><summary>Selection probe output: BEFORE (document.body) vs AFTER (canvas)</summary>

```
===== BEFORE (document.body listeners) =====
[Ctrl+A] selected chars: 0
[hero #swarm] selection empty: true
[dispatch] selectstart/dragstart/contextmenu preventDefault by element:
           canvas    #swarm : {"selectstart":true,"dragstart":true,"contextmenu":true}
           paragraph  <p>   : {"selectstart":true,"dragstart":true,"contextmenu":true}
           document.body    : {"selectstart":true,"dragstart":true,"contextmenu":true}

===== AFTER (canvas listeners) =====
[Ctrl+A] selected chars: 1255
[hero #swarm] selection empty: true
[dispatch] selectstart/dragstart/contextmenu preventDefault by element:
           canvas    #swarm : {"selectstart":true,"dragstart":true,"contextmenu":true}
           paragraph  <p>   : {"selectstart":false,"dragstart":false,"contextmenu":false}
           document.body    : {"selectstart":false,"dragstart":false,"contextmenu":false}
```

BEFORE blocks the three events on the paragraph and body page-wide and select-all
yields 0 characters. AFTER the three events fire only on `#swarm`; the paragraph
and body are free and select-all yields 1255 characters.
</details>

<!-- evidence-row:llm-trajectory -->
- [ ] `N/A - no agent, action, provider, prompt, or model change in this diff.`
<!-- evidence-row:domain-artifacts -->
- [ ] `N/A - no database rows, memories, scheduled tasks, wallet output, or generated files are produced by this change.`
<!-- evidence-row:ocr-review -->
- [ ] `N/A - change is in packages/elizaresearch (a standalone static site) rather than the packages/app or packages/ui surfaces the OCR gate governs.`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Backend: N/A - no server code path.

Frontend: deterministic headless-Chromium probe (page served over HTTP with real
assets). Note that a drag-based `selectstart` in headless Chromium reports its
target as the `HTML` root (a headless input quirk), so the page-wide block is
proven via the **explicit event dispatch** and **Ctrl+A** measurements above
rather than synthesized drags. The `#swarm` drag yields an empty
`window.getSelection()` in both builds (canvas guard plus CSS `user-select:
none`).

`-webkit-touch-callout` is a WebKit/iOS-only property; Chromium's
`getComputedStyle` returns an empty string for it regardless of the rule, so its
removal is verified by the source diff (line deleted from the `body` rule) and
by the fact that `#swarm` retains `user-select: none`.

## Screenshots (before / after) + video walkthrough

Visual confirmation was captured locally with the same probe: a `Ctrl+A`
screenshot of the pre-fix build shows **no** highlighted text, and the fixed
build shows **all** page text highlighted in the site's orange `::selection`
color while the hero canvas particles stay unselected. These image files could
not be attached because a fork contributor without push access cannot upload to
the `pr-evidence` release and a headless CLI cannot mint `user-attachments`
URLs; the equivalent measurements (0 vs 1255 selected characters) are in the
frontend-logs row and are reproducible with the probe in the testing steps.

### Before

See frontend-logs row — `[Ctrl+A] selected chars: 0`.

### After

See frontend-logs row — `[Ctrl+A] selected chars: 1255`.

### Walkthrough video

N/A - see walkthrough-video row reason above.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT change.

## Known gaps / failures

- `bun run verify` (repository-wide) was **not** run for this change. This PR
  touches only `packages/elizaresearch/index.html`, a standalone static site
  whose `package.json` defines only `preview`/`deploy` (no `build`, `test`,
  `typecheck`, or `lint`), and Biome does not process HTML (no prettier config
  applies to this path). The repo-wide verify gate exercises unrelated packages
  and is disproportionate for a two-line HTML/CSS edit. Behavior was instead
  verified with the headless-browser probe above. A maintainer can run the full
  gate in CI if desired.
- WebKit acceptance-criterion checks (Chromium **and** WebKit) were run in
  Chromium only; the Playwright WebKit browser is not installed on this build
  host. The fix relies only on standard DOM/CSS behavior (`user-select`,
  `selectstart`/`dragstart`/`contextmenu`, `-webkit-touch-callout`) that behaves
  identically in WebKit.
- Screenshot/video artifacts could not be attached because this fork
  contributor lacks push access to upload to the `pr-evidence` release and the
  headless CLI cannot create `user-attachments`; the equivalent numeric proof is
  inline in the frontend-logs row.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@1da8c4af80060383fc7f334be3e0a6797d18d8fc:packages/skills/skills/contribute-to-eliza"} -->
