### PR TITLE
fix(core): gate shared personality profile operations

### DIFF
--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-action.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-action.test.ts
@@ -2,8 +2,8 @@
  * Covers the PERSONALITY action handler against the in-memory FakeRuntime and a
  * real PersonalityStore (no live model): scope-clarification for ambiguous
  * requests, trait/reply-gate/directive mutations, named-profile load/save, and
- * the audit-memory trail. Admin-only paths run on an owner-seeded runtime so
- * hasRoleAccess grants access.
+ * the audit-memory trail. Agent-wide profile ops run on an owner-seeded runtime
+ * so hasRoleAccess grants the OWNER / ADMIN floors those shapes require.
  */
 import { beforeEach, describe, expect, test } from "vitest";
 import type { ActionResult, HandlerOptions } from "../../../../types/index.ts";
@@ -23,7 +23,8 @@ describe("personalityAction — routing ownership", () => {
 });
 
 // Fixed sender entity for the `run` helper. Pass it as `owner` to makeFakeRuntime
-// when a test needs the sender treated as admin/owner (admin-only ops).
+// when a test needs the sender treated as owner (agent-wide reconfigure / shared
+// catalog ops) or as `admins` for agent-wide inspect-only paths.
 const TEST_SENDER = "00000000-0000-4000-8000-0000000000ff" as never;
 
 async function run(
@@ -239,8 +240,9 @@ describe("personalityAction — subactions write structured state", () => {
 describe("personalityAction — profiles", () => {
 	let fake: ReturnType<typeof makeFakeRuntime>;
 	beforeEach(async () => {
-		// load_profile / save_profile are admin-only; make the test sender the
-		// canonical owner so hasRoleAccess grants admin (it now fails CLOSED on an
+		// load_profile / save_profile rewrite or extend shared agent-wide storage
+		// (OWNER floor); list_profiles reads that catalog (ADMIN floor). Seed the
+		// sender as owner so hasRoleAccess grants both (it fails CLOSED on an
 		// unresolved role — the old "no world → admin" leniency is gone).
 		fake = makeFakeRuntime({ owner: TEST_SENDER });
 		await initStore(fake);
@@ -343,7 +345,7 @@ describe("personalityAction — single-delivery settlement", () => {
 
 	for (const { op, userText, params } of cases) {
 		test(`${op} settles its confirmation as the sole user-facing delivery`, async () => {
-			// Owner-seeded so the admin-only profile ops pass the role gate.
+			// Owner-seeded so agent-wide profile ops clear OWNER/ADMIN floors.
 			const fake = makeFakeRuntime({ owner: TEST_SENDER });
 			await initStore(fake);
 			const { result, calls } = await run(fake, userText, op, params);
@@ -443,14 +445,94 @@ describe("personalityAction — authorization floors (blast radius, not op name)
 		// slot — the case an op-name allowlist misses and the shape table catches.
 		const fake = makeFakeRuntime({ admins: [TEST_SENDER] });
 		await initStore(fake);
-		const { result } = await run(fake, "load the weekend vibe", "load_profile", {
-			name: "weekend",
-		});
+		const { result } = await run(
+			fake,
+			"load the weekend vibe",
+			"load_profile",
+			{
+				name: "weekend",
+			},
+		);
 		expect(result.success).toBe(false);
 		expect(result.data).toMatchObject({
 			reach: "agent_wide",
 			requiredRole: "OWNER",
 		});
+	});
+
+	test("list_profiles is agent-wide inspection of the shared catalog", async () => {
+		// list_profiles takes no scope, but runListProfiles reads the complete
+		// shared PersonalityStore catalog — ADMIN floor, not requester inspect.
+		const plain = makeFakeRuntime();
+		await initStore(plain);
+		const denied = await run(plain, "list saved profiles", "list_profiles", {});
+		expect(denied.result.success).toBe(false);
+		expect(denied.result.data).toMatchObject({
+			reach: "agent_wide",
+			requiredRole: "ADMIN",
+		});
+
+		const admin = makeFakeRuntime({ admins: [TEST_SENDER] });
+		await initStore(admin);
+		const allowed = await run(
+			admin,
+			"list saved profiles",
+			"list_profiles",
+			{},
+		);
+		expect(allowed.result.success).toBe(true);
+	});
+
+	test("save_profile is shared-catalog reconfiguration from the global slot", async () => {
+		// save_profile persists a named profile into the shared catalog from the
+		// global slot — agent-wide reconfigure (OWNER), not a read-only inspect.
+		const plain = makeFakeRuntime();
+		await initStore(plain);
+		const beforeNames = plain.store
+			.listProfiles()
+			.map((p) => p.name)
+			.sort();
+		const denied = await run(plain, "save this vibe", "save_profile", {
+			name: "user-snapshot",
+			description: "must not land",
+		});
+		expect(denied.result.success).toBe(false);
+		expect(denied.result.data).toMatchObject({
+			reach: "agent_wide",
+			requiredRole: "OWNER",
+		});
+		// Refusal changed nothing: the shared catalog is untouched.
+		expect(plain.store.getProfile("user-snapshot")).toBeNull();
+		expect(
+			plain.store
+				.listProfiles()
+				.map((p) => p.name)
+				.sort(),
+		).toEqual(beforeNames);
+
+		const admin = makeFakeRuntime({ admins: [TEST_SENDER] });
+		await initStore(admin);
+		const adminDenied = await run(admin, "save this vibe", "save_profile", {
+			name: "admin-snapshot",
+			description: "must not land either",
+		});
+		expect(adminDenied.result.success).toBe(false);
+		expect(adminDenied.result.data).toMatchObject({
+			reach: "agent_wide",
+			requiredRole: "OWNER",
+		});
+		expect(admin.store.getProfile("admin-snapshot")).toBeNull();
+
+		const owner = makeFakeRuntime({ owner: TEST_SENDER });
+		await initStore(owner);
+		const allowed = await run(owner, "save this vibe", "save_profile", {
+			name: "owner-snapshot",
+			description: "owner may persist shared profiles",
+		});
+		expect(allowed.result.success).toBe(true);
+		expect(owner.store.getProfile("owner-snapshot")?.description).toBe(
+			"owner may persist shared profiles",
+		);
 	});
 
 	test("the owner clears the agent-wide floor", async () => {

--- a/packages/core/src/features/advanced-capabilities/personality/actions/personality.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/actions/personality.ts
@@ -83,9 +83,11 @@ type PersonalityEffect = "inspect" | "reconfigure";
  * is whatever scope the request resolves to; the rest carry no scope parameter
  * and so have a fixed reach. `load_profile` is the case that shape catches and
  * an op-name list does not: it takes no scope yet writes the agent-wide slot, so
- * it is an agent-wide reconfiguration however it is spelled. `save_profile`
- * files a copy of that slot without changing behaviour, so it sits with the
- * agent-wide inspections.
+ * it is an agent-wide reconfiguration however it is spelled. `list_profiles`
+ * takes no scope either, but `runListProfiles` reads the complete shared
+ * PersonalityStore catalog — agent-wide inspection, not a requester-local view.
+ * `save_profile` snapshots the global slot into that same shared catalog, so it
+ * is shared-storage reconfiguration (OWNER), not a read-only inspection.
  */
 const PERSONALITY_OP_SHAPE: Record<
 	PersonalityOp,
@@ -99,8 +101,8 @@ const PERSONALITY_OP_SHAPE: Record<
 	clear_directives: { effect: "reconfigure", reach: "scoped" },
 	show_state: { effect: "inspect", reach: "scoped" },
 	load_profile: { effect: "reconfigure", reach: "agent_wide" },
-	save_profile: { effect: "inspect", reach: "agent_wide" },
-	list_profiles: { effect: "inspect", reach: "requester" },
+	save_profile: { effect: "reconfigure", reach: "agent_wide" },
+	list_profiles: { effect: "inspect", reach: "agent_wide" },
 };
 
 /**


### PR DESCRIPTION
## Repair for #19689

Addresses the outstanding authorization-shape review at exact parent `1516d9bcf1c884bb549b1de0c19d9e54aebfedd5`.

- classifies `list_profiles` as agent-wide inspection, requiring `ADMIN`;
- classifies `save_profile` as shared-catalog reconfiguration, requiring `OWNER`;
- proves plain users cannot read or mutate the shared catalog, admins may list but not save, and owners may save;
- verifies denied saves leave the shared catalog unchanged.

## Verification

Run from a `.git`-free source archive in a no-network, read-only, capability-dropped container using repo-pinned Bun:

```text
personality-action.test.ts: 35 passed
personality-echo.test.ts: 4 passed
Total: 39 passed
Biome changed-file check: pass
git diff --check: pass
```

Mutation proof: reverting both classifications to the old values caused exactly the two new authorization tests to fail (`2 failed`, exit 1), then the verified source was restored before commit.

## Evidence Gate

<!-- evidence-head:b490c6540f6ca0cf8d042fe238d2272689723092 -->
<!-- evidence-row:before-screenshots -->
- [ ] N/A - authorization-only core runtime change; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - authorization-only core runtime change; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] Exact isolated test transcript
<details><summary>Test output</summary>

```text
$ node ../scripts/run-vitest.mjs run src/features/advanced-capabilities/personality/__tests__/personality-action.test.ts src/features/advanced-capabilities/personality/__tests__/personality-echo.test.ts
^[[1m^[[30m^[[46m RUN ^[[49m^[[39m^[[22m ^[[36mv4.1.5 ^[[39m^[[90m/src/packages/core^[[39m
 ^[[32m✓^[[39m src/features/advanced-capabilities/personality/__tests__/personality-action.test.ts ^[[2m(^[[22m^[[2m35 tests^[[22m^[[2m)^[[22m^[[32m 49^[[2mms^[[22m^[[39m
 ^[[32m✓^[[39m src/features/advanced-capabilities/personality/__tests__/personality-echo.test.ts ^[[2m(^[[22m^[[2m4 tests^[[22m^[[2m)^[[22m^[[32m 13^[[2mms^[[22m^[[39m
^[[2m Test Files ^[[22m ^[[1m^[[32m2 passed^[[39m^[[22m^[[90m (2)^[[39m
^[[2m      Tests ^[[22m ^[[1m^[[32m39 passed^[[39m^[[22m^[[90m (39)^[[39m
^[[2m   Start at ^[[22m 02:22:33
^[[2m   Duration ^[[22m 1.66s^[[2m (transform 861ms, setup 0ms, import 1.35s, tests 62ms, environment 0ms)^[[22m
exit_code=0
```
</details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, action selection, or LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact committed repair artifact
<details><summary>Commit and patch excerpt</summary>

```diff
From b490c6540f6ca0cf8d042fe238d2272689723092 Mon Sep 17 00:00:00 2001
From: TrapLord <dev@intelsignal.xyz>
Date: Sat, 15 Aug 2026 02:17:41 +0000
Subject: [PATCH] fix(core): gate shared personality profile operations

Classify list_profiles as agent-wide inspection and save_profile as shared-catalog reconfiguration, enforcing ADMIN and OWNER floors with non-vacuous matrix coverage.

AI provider/model: openai / gpt-5.6-sol

Client / agent tooling: Hermes Agent

Attribution status: self-reported
---
 .../__tests__/personality-action.test.ts      | 100 ++++++++++++++++--
 .../personality/actions/personality.ts        |  12 ++-
 2 files changed, 98 insertions(+), 14 deletions(-)

diff --git a/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-action.test.ts b/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-action.test.ts
index 2fb035429..5ba25f579 100644
--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-action.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-action.test.ts
@@ -2,8 +2,8 @@
  * Covers the PERSONALITY action handler against the in-memory FakeRuntime and a
  * real PersonalityStore (no live model): scope-clarification for ambiguous
  * requests, trait/reply-gate/directive mutations, named-profile load/save, and
- * the audit-memory trail. Admin-only paths run on an owner-seeded runtime so
- * hasRoleAccess grants access.
+ * the audit-memory trail. Agent-wide profile ops run on an owner-seeded runtime
+ * so hasRoleAccess grants the OWNER / ADMIN floors those shapes require.
  */
 import { beforeEach, describe, expect, test } from "vitest";
 import type { ActionResult, HandlerOptions } from "../../../../types/index.ts";
```
</details>
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Hermes Agent
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Hermes Agent"} -->

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
