### PR TITLE
fix(core): fully redact authorization credentials

### DIFF
--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -169,6 +169,11 @@ describe("redactSensitiveText (pattern detection)", () => {
 		for (const line of [
 			"Authorization: required for this endpoint",
 			"Authorization: none",
+			// Two-word prose must stay byte-identical: the token68 rule must not
+			// treat an ordinary English word after a short scheme-like token as a
+			// credential (e.g. masking "carefully" after "use").
+			"Authorization: use carefully",
+			"Authorization: use Bearer to authenticate",
 			"region=AsiaPacificRegion123 selected",
 			"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  file.txt",
 			"404fd6cd53 Merge pull request #19662 from elizaOS/develop",
@@ -181,8 +186,53 @@ describe("redactSensitiveText (pattern detection)", () => {
 		// `String.replace(string)` rewrites the FIRST occurrence; when the
 		// credential also appears earlier in the match it masked the scheme and
 		// left the credential itself in the output.
-		const out = redactSensitiveText("Authorization: abcdefgh abcdefgh");
-		expect(out).toBe("Authorization: abcdefgh ***");
+		const out = redactSensitiveText("Authorization: abcd1234 abcd1234");
+		expect(out).toBe("Authorization: abcd1234 ***");
+	});
+
+	it("masks Digest and custom auth-param credentials as a whole", () => {
+		// RFC 9110 allows credentials = auth-scheme SP #auth-param. A token68-
+		// only rule captures the first parameter *name* and leaves username /
+		// realm / response values in plaintext — looking redacted while leaking.
+		const responseHash = "0123456789abcdef0123456789abcdef";
+		const digest = `Authorization: Digest username="Mufasa", realm="test", response="${responseHash}"`;
+		const out = redactSensitiveText(digest);
+		expect(out).toContain("Authorization: Digest");
+		expect(out).toContain("***");
+		expect(out).not.toContain("Mufasa");
+		expect(out).not.toContain(responseHash);
+		expect(out).not.toContain("realm=");
+		expect(out).not.toContain("username=");
+		expect(out).not.toContain("response=");
+
+		const digestAlice = `Authorization: Digest username="alice", nonce="n-0S6_WzA2Mj", response="${responseHash}"`;
+		const outAlice = redactSensitiveText(digestAlice);
+		expect(outAlice).not.toContain("alice");
+		expect(outAlice).not.toContain(responseHash);
+		expect(outAlice).not.toContain("n-0S6_WzA2Mj");
+
+		const custom =
+			'Authorization: Custom token="secret-value-here", extra="more-secret-data"';
+		const outCustom = redactSensitiveText(custom);
+		expect(outCustom).toContain("Authorization: Custom");
+		expect(outCustom).not.toContain("secret-value-here");
+		expect(outCustom).not.toContain("more-secret-data");
+		expect(outCustom).toMatch(/Authorization: Custom\s+\*\*\*/);
+	});
+
+	it("masks Bearer credentials that contain / or ~", () => {
+		// Standard base64 (not base64url) uses `/`; without it in the Bearer
+		// class the rule truncated at the first slash and leaked the tail while
+		// shadowing the /~-aware general rules.
+		const withSlash = "AbCd/EfGhIjKlMnOpQrStUvWxYz0123456789/+/34";
+		const slashOut = redactSensitiveText(`Authorization: Bearer ${withSlash}`);
+		expect(slashOut).not.toContain(withSlash);
+		expect(slashOut).not.toContain("EfGhIjKlMnOpQrStUvWxYz");
+		expect(slashOut).toContain("Authorization: Bearer");
+
+		const withTilde = "abcdefghijklmnopqrst~uvwxyz012345";
+		const tildeOut = redactSensitiveText(`Authorization: Bearer ${withTilde}`);
+		expect(tildeOut).not.toContain(withTilde);
 	});
 
 	it("masks an AWS access key id", () => {

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -27,24 +27,37 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
 	String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|refreshToken|mnemonic|seedPhrase|passphrase|privateKey|credential)"\s*:\s*"([^"]+)"`,
 	// CLI flags (space-separated and --flag=value forms).
 	String.raw`--(?:api[-_]?key|token|secret|password|passwd)(?:\s+|=)(["']?)([^\s"']+)\1`,
-	// Authorization headers. RFC 7235 credentials are `<auth-scheme> SP
-	// <credentials>` and the scheme set is open-ended, so matching `Bearer`
-	// alone left every other scheme in plaintext: a `curl -v` trace or a config
-	// dump relayed `Basic <base64 of user:password>` — a complete, reusable
-	// credential — verbatim. Key on the header grammar rather than a scheme
-	// list: any scheme token followed by a credential-shaped value, plus the
-	// scheme-less form. The length floors keep header-shaped prose
-	// ("Authorization: required for this endpoint") byte-identical.
+	// Authorization headers. RFC 9110 credentials are `<auth-scheme> SP
+	// ( token68 / #auth-param )` and the scheme set is open-ended, so matching
+	// `Bearer` alone left every other scheme in plaintext: a `curl -v` trace or
+	// a config dump relayed `Basic <base64 of user:password>` — a complete,
+	// reusable credential — verbatim. Key on the header grammar rather than a
+	// scheme list:
+	//   1. Bearer (floor-free, includes `/` and `~` so standard base64 tokens
+	//      are not truncated and shadowed before the general rules run),
+	//   2. auth-param lists (Digest/custom: `name=value` pairs, quoted values,
+	//      comma-separated) captured as a whole so a partial mask cannot leave
+	//      `response=` / `username=` material behind,
+	//   3. token68 after a scheme, plus the scheme-less form.
+	// token68 length floors keep short header-shaped prose byte-identical
+	// ("Authorization: required for this endpoint"). Pure-lowercase tokens
+	// shorter than 18 chars are also left alone so two-word prose such as
+	// "Authorization: use carefully" is not rewritten; base64/mixed/digit
+	// credentials still mask at the 8-char floor.
 	// Deliberately unanchored on the left, matching the rule this replaces: `_`
 	// is a word character, so a `\b` here would stop matching the env-style
 	// `SERVICE_AUTHORIZATION=Bearer …` names that an `env` dump prints.
 	// Bearer keeps its own floor-free rule so this stays a strict superset of the
 	// behaviour it replaces; the general rules below carry a length floor that
 	// would otherwise stop masking a short `Bearer <value>`.
-	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*Bearer\s+([A-Za-z0-9._\-+=]+)`,
-	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z][A-Za-z0-9-]*)[ \t]+([A-Za-z0-9._\-+=/~]{8,})`,
+	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*Bearer\s+([A-Za-z0-9._\-+=/~]+)`,
+	// #auth-param (Digest, etc.): one or more name=token|quoted-string pairs.
+	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z][A-Za-z0-9-]*)[ \t]+([A-Za-z0-9!#$%&'*+.^_\`|~-]+\s*=\s*(?:"[^"]*"|[^,\r\n]+)(?:\s*,\s*[A-Za-z0-9!#$%&'*+.^_\`|~-]+\s*=\s*(?:"[^"]*"|[^,\r\n]+))*)`,
+	// token68 after a scheme. Require a non-lowercase char at len 8–17 so
+	// ordinary two-word prose is preserved; any token68 shape at len ≥18.
+	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z][A-Za-z0-9-]*)[ \t]+((?=[A-Za-z0-9._\-+=/~]{8,})(?=[A-Za-z0-9._\-+=/~]*[^a-z])[A-Za-z0-9._\-+=/~]+|[A-Za-z0-9._\-+=/~]{18,})`,
 	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z0-9._\-+=/~]{18,})`,
-	String.raw`\bBearer\s+([A-Za-z0-9._\-+=]{18,})\b`,
+	String.raw`\bBearer\s+([A-Za-z0-9._\-+=/~]{18,})`,
 	// URI userinfo. Mask the complete userinfo component (user:password,
 	// token-only, or password-only) so credentials in database URLs, curl
 	// arguments, and remote URLs never survive as output.
@@ -216,6 +229,16 @@ function redactMatch(match: string, groups: string[]): string {
 		(value) => typeof value === "string" && value.length > 0,
 	);
 	const token = filteredGroups[filteredGroups.length - 1] ?? match;
+	// Auth-param credentials (Digest and custom schemes) are a comma-separated
+	// list of name=value fields. A prefix/suffix window would keep `username=`
+	// or the tail of `response=` — mask the whole parameter list.
+	if (/[=,"]/.test(token) && token !== match) {
+		const tailIndex = match.length - token.length;
+		if (tailIndex > 0 && match.startsWith(token, tailIndex)) {
+			return `${match.slice(0, tailIndex)}***`;
+		}
+		return match.replace(token, () => "***");
+	}
 	// Unlike provider tokens, URI userinfo includes an account identifier; do
 	// not preserve its usual six-character prefix in diagnostics.
 	// Anchor the rewrite to the userinfo span. A plain `replace(token, …)` hits


### PR DESCRIPTION
## Repair for #19691

Addresses the outstanding Authorization redaction review at exact parent `c5781ec5c6d203a12ce44638f370a01d94be0219`.

- masks complete RFC auth-param lists for Digest and custom schemes rather than only the first parameter name;
- includes `/` and `~` in Bearer/token68 handling so standard-base64 credentials are not partially leaked;
- preserves representative short two-word prose while retaining credential-shaped token floors;
- adds Digest, custom auth-param, slash/tilde Bearer, and prose-preservation regressions.

## Verification

Run from a `.git`-free source archive in a no-network, read-only, capability-dropped container using repo-pinned Bun:

```text
redact.test.ts: 35 passed
Biome changed-file check: pass
git diff --check: pass
```

Mutation proof: restoring the exact old production implementation made the new Digest/auth-param and slash-Bearer regressions fail (`2 failed`, exit 1).

## Evidence Gate

<!-- evidence-head:72d04e7ffd60d875f99778c814bb0b75660371f3 -->
<!-- evidence-row:before-screenshots -->
- [ ] N/A - core security redaction change; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - core security redaction change; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] Exact isolated test transcript
<details><summary>Test output</summary>

```text
$ node ../scripts/run-vitest.mjs run src/security/redact.test.ts
[1m[30m[46m RUN [49m[39m[22m [36mv4.1.5 [39m[90m/src/packages/core[39m
 [32m✓[39m src/security/redact.test.ts [2m([22m[2m35 tests[22m[2m)[22m[32m 25[2mms[22m[39m
[2m Test Files [22m [1m[32m1 passed[39m[22m[90m (1)[39m
[2m      Tests [22m [1m[32m35 passed[39m[22m[90m (35)[39m
[2m   Start at [22m 02:22:58
[2m   Duration [22m 260ms[2m (transform 98ms, setup 0ms, import 117ms, tests 25ms, environment 0ms)[22m
exit_code=0
```
</details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, action, or LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact committed repair artifact
<details><summary>Commit and patch excerpt</summary>

```diff
From 72d04e7ffd60d875f99778c814bb0b75660371f3 Mon Sep 17 00:00:00 2001
From: TrapLord <dev@intelsignal.xyz>
Date: Sat, 15 Aug 2026 02:17:41 +0000
Subject: [PATCH] fix(core): fully redact authorization credentials

Mask complete auth-param lists, include slash and tilde token68 characters, and preserve ordinary short authorization prose with mutation-sensitive coverage.

AI provider/model: openai / gpt-5.6-sol

Client / agent tooling: Hermes Agent

Attribution status: self-reported
---
 packages/core/src/security/redact.test.ts | 54 ++++++++++++++++++++++-
 packages/core/src/security/redact.ts      | 45 ++++++++++++++-----
 2 files changed, 86 insertions(+), 13 deletions(-)

diff --git a/packages/core/src/security/redact.test.ts b/packages/core/src/security/redact.test.ts
index b373ef37d..ad8b4432f 100644
--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -169,6 +169,11 @@ describe("redactSensitiveText (pattern detection)", () => {
 		for (const line of [
 			"Authorization: required for this endpoint",
 			"Authorization: none",
+			// Two-word prose must stay byte-identical: the token68 rule must not
+			// treat an ordinary English word after a short scheme-like token as a
+			// credential (e.g. masking "carefully" after "use").
+			"Authorization: use carefully",
+			"Authorization: use Bearer to authenticate",
 			"region=AsiaPacificRegion123 selected",
 			"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  file.txt",
```
</details>
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Hermes Agent
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Hermes Agent"} -->
