### PR TITLE
fix(shared): format streaming text overlap paths

### DIFF
--- a/packages/shared/src/utils/streaming-text.test.ts
+++ b/packages/shared/src/utils/streaming-text.test.ts
@@ -73,9 +73,7 @@ describe("streaming text named regressions", () => {
     const expected = "foo\u1ea1\u0301 cafe\u0301";
 
     expect(mergeStreamingText(existing, incoming)).toBe(expected);
-    expect(computeStreamingDelta(existing, incoming)).toBe(
-      "\u0301 cafe\u0301",
-    );
+    expect(computeStreamingDelta(existing, incoming)).toBe("\u0301 cafe\u0301");
     expect(resolveStreamingUpdate(existing, incoming)).toEqual({
       kind: "append",
       nextText: expected,

--- a/packages/shared/src/utils/streaming-text.ts
+++ b/packages/shared/src/utils/streaming-text.ts
@@ -162,11 +162,7 @@ export function mergeStreamingText(existing: string, incoming: string): string {
       return incoming.length === 1 ? `${existing}${incoming}` : existing;
     }
 
-    const suffix = sliceAfterNormalizedOverlap(
-      incoming,
-      incomingNorm,
-      overlap,
-    );
+    const suffix = sliceAfterNormalizedOverlap(incoming, incomingNorm, overlap);
     return `${existing.slice(0, existing.length - (existingNorm.length - existingTrimmedLength))}${suffix}`;
   }
 


### PR DESCRIPTION
## Summary
- apply canonical Biome formatting to two streaming text overlap expressions
- restore the root lint gate after the develop-to-main promotion

## Verification
- `bun run --cwd packages/shared lint:check`
- `bun run --cwd packages/shared typecheck`
- `git diff --check`