### PR TITLE
fix(cloud): poll user-installed Discord DMs

### DIFF
--- a/packages/cloud/services/gateway-discord/src/dm-polling.ts
+++ b/packages/cloud/services/gateway-discord/src/dm-polling.ts
@@ -1,0 +1,86 @@
+/** Polls tracked Discord bot DM channels when user-installed apps do not emit message events. */
+
+export interface TrackedDiscordDm {
+  channelId: string;
+  userId: string;
+  lastMessageId: string;
+}
+
+export interface DiscordDmPollMessage {
+  id: string;
+  author: { bot: boolean };
+  content: string;
+}
+
+export interface DiscordDmPollReport {
+  channels: number;
+  messages: number;
+  routed: number;
+  deduplicated: number;
+  removed: number;
+}
+
+function compareSnowflakes(left: string, right: string): number {
+  const a = BigInt(left);
+  const b = BigInt(right);
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
+ * Reads every tracked channel once and advances its durable cursor in message
+ * order. A per-message claim lets this safely overlap Discord Gateway delivery.
+ */
+export async function pollTrackedDiscordDms<
+  T extends DiscordDmPollMessage,
+>(options: {
+  listTracked: () => Promise<TrackedDiscordDm[]>;
+  fetchAfter: (state: TrackedDiscordDm) => Promise<T[]>;
+  claimMessage: (messageId: string) => Promise<boolean>;
+  routeMessage: (message: T) => Promise<void>;
+  updateCursor: (state: TrackedDiscordDm, messageId: string) => Promise<void>;
+  removeTracked: (state: TrackedDiscordDm) => Promise<void>;
+  isTerminalChannelError: (error: unknown) => boolean;
+  onError?: (state: TrackedDiscordDm, error: unknown) => void;
+}): Promise<DiscordDmPollReport> {
+  const report: DiscordDmPollReport = {
+    channels: 0,
+    messages: 0,
+    routed: 0,
+    deduplicated: 0,
+    removed: 0,
+  };
+
+  const tracked = await options.listTracked();
+  report.channels = tracked.length;
+  for (const state of tracked) {
+    let messages: T[];
+    try {
+      messages = await options.fetchAfter(state);
+    } catch (error) {
+      if (options.isTerminalChannelError(error)) {
+        await options.removeTracked(state);
+        report.removed += 1;
+      } else {
+        options.onError?.(state, error);
+      }
+      continue;
+    }
+
+    messages.sort((left, right) => compareSnowflakes(left.id, right.id));
+    for (const message of messages) {
+      report.messages += 1;
+      const content = message.content.trim();
+      if (!message.author.bot && content) {
+        if (await options.claimMessage(message.id)) {
+          await options.routeMessage(message);
+          report.routed += 1;
+        } else {
+          report.deduplicated += 1;
+        }
+      }
+      await options.updateCursor(state, message.id);
+      state.lastMessageId = message.id;
+    }
+  }
+  return report;
+}

--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -20,6 +20,7 @@ import {
   type User,
 } from "discord.js";
 import { reconcileDiscordConnectionReady } from "./connection-lifecycle";
+import { pollTrackedDiscordDms, type TrackedDiscordDm } from "./dm-polling";
 import { logger } from "./logger";
 import {
   deliverManagedReply,
@@ -209,6 +210,18 @@ const GREETING_POLL_INTERVAL_MS = parseIntEnv(
   15_000,
 );
 
+/** User-installed apps expose bot DMs but may omit freeform message events. */
+const ELIZA_APP_DM_POLL_INTERVAL_MS = parseIntEnv(
+  "ELIZA_APP_DM_POLL_INTERVAL_MS",
+  2_000,
+  500,
+);
+const ELIZA_APP_DM_CHANNELS_KEY = "discord:eliza-app-bot:dm-channels";
+const ELIZA_APP_DM_STATE_PREFIX = "discord:eliza-app-bot:dm-state:";
+const ELIZA_APP_DM_CLAIM_PREFIX = "discord:eliza-app-bot:dm-message:";
+const ELIZA_APP_DM_STATE_TTL_SECONDS = 180 * 24 * 60 * 60;
+const ELIZA_APP_DM_CLAIM_TTL_SECONDS = 7 * 24 * 60 * 60;
+
 /** How often to check/renew leadership (3 seconds) */
 const ELIZA_APP_LEADER_CHECK_INTERVAL_MS = 3000;
 
@@ -355,6 +368,9 @@ export class GatewayManager {
    * provider nonce also recover correctly from abrupt process termination.
    */
   private greetingDrainInFlight: Promise<void> | null = null;
+  /** Poll fallback for user-installed bot DMs that omit Gateway message events. */
+  private dmPollInterval: NodeJS.Timeout | null = null;
+  private dmPollInFlight: Promise<void> | null = null;
   /** Interval for leader election checks */
   private elizaAppLeaderInterval: NodeJS.Timeout | null = null;
 
@@ -584,6 +600,7 @@ export class GatewayManager {
     if (this.tokenRefreshTimeout) clearTimeout(this.tokenRefreshTimeout);
     if (this.elizaAppLeaderInterval) clearInterval(this.elizaAppLeaderInterval);
     if (this.greetingPollInterval) clearInterval(this.greetingPollInterval);
+    if (this.dmPollInterval) clearInterval(this.dmPollInterval);
     this.voiceHandler.stopCleanupJob();
 
     // Let an in-flight delivery acknowledge before disconnecting. This is an
@@ -592,6 +609,10 @@ export class GatewayManager {
     if (this.greetingDrainInFlight) {
       await this.greetingDrainInFlight;
       this.greetingDrainInFlight = null;
+    }
+    if (this.dmPollInFlight) {
+      await this.dmPollInFlight;
+      this.dmPollInFlight = null;
     }
 
     // Release Eliza App bot leadership for faster failover
@@ -1903,10 +1924,22 @@ export class GatewayManager {
         userId: this.elizaAppClient?.user?.id,
       });
       this.startGreetingPolling();
+      this.startDmPolling();
     });
 
     this.elizaAppClient.on(Events.MessageCreate, async (message: Message) => {
+      if (!message.guild) {
+        const claimed = await this.claimElizaAppDmMessage(message.id);
+        if (!claimed) return;
+      }
       await this.handleElizaAppMessage(message);
+      if (!message.guild) {
+        await this.trackElizaAppDm(
+          message.channelId,
+          message.author.id,
+          message.id,
+        );
+      }
     });
 
     this.elizaAppClient.on(Events.Error, (error: Error) => {
@@ -1945,11 +1978,19 @@ export class GatewayManager {
       clearInterval(this.greetingPollInterval);
       this.greetingPollInterval = null;
     }
+    if (this.dmPollInterval) {
+      clearInterval(this.dmPollInterval);
+      this.dmPollInterval = null;
+    }
     // Let an in-flight delivery acknowledge before disconnecting. A crash or
     // forced shutdown remains safe through lease expiry and nonce deduplication.
     if (this.greetingDrainInFlight) {
       await this.greetingDrainInFlight;
       this.greetingDrainInFlight = null;
+    }
+    if (this.dmPollInFlight) {
+      await this.dmPollInFlight;
+      this.dmPollInFlight = null;
     }
     if (this.elizaAppClient) {
       logger.info("Disconnecting Eliza App bot", {
@@ -2031,11 +2072,12 @@ export class GatewayManager {
           },
         ),
       sendDirectMessage: async (userId, content, deliveryNonce) => {
-        await client.users.send(userId, {
+        const sent = await client.users.send(userId, {
           content,
           nonce: deliveryNonce,
           enforceNonce: true,
         });
+        await this.trackElizaAppDm(sent.channelId, userId, sent.id);
       },
       isTerminalError: isTerminalDiscordDirectMessageError,
       refreshAuth: () => this.refreshToken(),
@@ -2067,6 +2109,132 @@ export class GatewayManager {
         }
       },
     });
+  }
+
+  private startDmPolling(): void {
+    if (this.dmPollInterval) return;
+    const run = (): void => {
+      if (this.dmPollInFlight) return;
+      const poll = this.pollElizaAppDms()
+        .catch((error) => {
+          // error-policy:J1 This timer callback is the background-job boundary;
+          // durable cursors and per-message claims make the next poll safe.
+          logger.error("Error polling Eliza App Discord DMs", {
+            error: sanitizeError(error),
+          });
+        })
+        .finally(() => {
+          if (this.dmPollInFlight === poll) this.dmPollInFlight = null;
+        });
+      this.dmPollInFlight = poll;
+    };
+    run();
+    this.dmPollInterval = setInterval(run, ELIZA_APP_DM_POLL_INTERVAL_MS);
+    logger.info("Eliza App DM fallback polling started", {
+      podName: this.config.podName,
+      intervalMs: ELIZA_APP_DM_POLL_INTERVAL_MS,
+    });
+  }
+
+  private dmStateKey(channelId: string): string {
+    return `${ELIZA_APP_DM_STATE_PREFIX}${channelId}`;
+  }
+
+  private async trackElizaAppDm(
+    channelId: string,
+    userId: string,
+    lastMessageId: string,
+  ): Promise<void> {
+    if (!this.redis) return;
+    const state: TrackedDiscordDm = { channelId, userId, lastMessageId };
+    await this.redis.sadd(ELIZA_APP_DM_CHANNELS_KEY, channelId);
+    await this.redis.setex(
+      this.dmStateKey(channelId),
+      ELIZA_APP_DM_STATE_TTL_SECONDS,
+      JSON.stringify(state),
+    );
+  }
+
+  private async listTrackedElizaAppDms(): Promise<TrackedDiscordDm[]> {
+    if (!this.redis) return [];
+    const channelIds = await this.redis.smembers(ELIZA_APP_DM_CHANNELS_KEY);
+    const tracked: TrackedDiscordDm[] = [];
+    for (const channelId of channelIds) {
+      const state = await this.redis.get<TrackedDiscordDm>(
+        this.dmStateKey(channelId),
+      );
+      if (
+        !state ||
+        state.channelId !== channelId ||
+        !state.userId ||
+        !/^\d+$/.test(state.lastMessageId)
+      ) {
+        await this.redis.srem(ELIZA_APP_DM_CHANNELS_KEY, channelId);
+        await this.redis.del(this.dmStateKey(channelId));
+        continue;
+      }
+      tracked.push(state);
+    }
+    return tracked;
+  }
+
+  private async claimElizaAppDmMessage(messageId: string): Promise<boolean> {
+    if (!this.redis) return true;
+    const result = await this.redis.set(
+      `${ELIZA_APP_DM_CLAIM_PREFIX}${messageId}`,
+      "1",
+      { ex: ELIZA_APP_DM_CLAIM_TTL_SECONDS, nx: true },
+    );
+    return result === "OK";
+  }
+
+  private async pollElizaAppDms(): Promise<void> {
+    const client = this.elizaAppClient;
+    if (!this.redis || !this.isElizaAppLeader || !client?.isReady()) return;
+
+    const report = await pollTrackedDiscordDms<Message>({
+      listTracked: () => this.listTrackedElizaAppDms(),
+      fetchAfter: async (state) => {
+        const channel = await client.channels.fetch(state.channelId);
+        if (!channel?.isDMBased() || !("messages" in channel)) {
+          throw Object.assign(new Error("Tracked channel is not a bot DM"), {
+            code: 10003,
+          });
+        }
+        const messages = await channel.messages.fetch({
+          after: state.lastMessageId,
+          limit: 50,
+          cache: false,
+        });
+        return [...messages.values()];
+      },
+      claimMessage: (messageId) => this.claimElizaAppDmMessage(messageId),
+      routeMessage: (message) => this.handleElizaAppMessage(message),
+      updateCursor: (state, messageId) =>
+        this.trackElizaAppDm(state.channelId, state.userId, messageId),
+      removeTracked: async (state) => {
+        if (!this.redis) return;
+        await this.redis.srem(ELIZA_APP_DM_CHANNELS_KEY, state.channelId);
+        await this.redis.del(this.dmStateKey(state.channelId));
+      },
+      isTerminalChannelError: (error) => {
+        const code =
+          error && typeof error === "object"
+            ? (error as { code?: unknown }).code
+            : undefined;
+        return code === 10003 || code === 50001 || code === 50007;
+      },
+      onError: (state, error) => {
+        logger.warn("Failed to poll tracked Eliza App Discord DM", {
+          channelId: state.channelId,
+          error: sanitizeError(error),
+        });
+      },
+    });
+
+    if (report.routed > 0 || report.removed > 0) {
+      logger.info("Eliza App DM fallback poll completed", { ...report });
+    }
   }
 
   /**

--- a/packages/cloud/services/gateway-discord/tests/dm-polling.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/dm-polling.test.ts
@@ -1,0 +1,83 @@
+/** Verifies deterministic Discord user-install DM polling and deduplication. */
+
+import { describe, expect, it, mock } from "bun:test";
+import {
+  pollTrackedDiscordDms,
+  type TrackedDiscordDm,
+} from "../src/dm-polling";
+
+const tracked: TrackedDiscordDm = {
+  channelId: "channel-1",
+  userId: "user-1",
+  lastMessageId: "100",
+};
+
+describe("pollTrackedDiscordDms", () => {
+  it("routes human messages oldest-first and advances over bot messages", async () => {
+    const routed: string[] = [];
+    const cursors: string[] = [];
+    const report = await pollTrackedDiscordDms({
+      listTracked: async () => [{ ...tracked }],
+      fetchAfter: async () => [
+        { id: "103", author: { bot: false }, content: "third" },
+        { id: "101", author: { bot: false }, content: "first" },
+        { id: "102", author: { bot: true }, content: "bot reply" },
+      ],
+      claimMessage: async () => true,
+      routeMessage: async (message) => routed.push(message.id),
+      updateCursor: async (_state, id) => cursors.push(id),
+      removeTracked: async () => {},
+      isTerminalChannelError: () => false,
+    });
+
+    expect(routed).toEqual(["101", "103"]);
+    expect(cursors).toEqual(["101", "102", "103"]);
+    expect(report).toEqual({
+      channels: 1,
+      messages: 3,
+      routed: 2,
+      deduplicated: 0,
+      removed: 0,
+    });
+  });
+
+  it("does not reroute a message already claimed by the Gateway path", async () => {
+    const routeMessage = mock(async () => {});
+    const report = await pollTrackedDiscordDms({
+      listTracked: async () => [{ ...tracked }],
+      fetchAfter: async () => [
+        { id: "101", author: { bot: false }, content: "hello" },
+      ],
+      claimMessage: async () => false,
+      routeMessage,
+      updateCursor: async () => {},
+      removeTracked: async () => {},
+      isTerminalChannelError: () => false,
+    });
+
+    expect(routeMessage).not.toHaveBeenCalled();
+    expect(report.deduplicated).toBe(1);
+  });
+
+  it("removes only definitively unavailable channels", async () => {
+    const removeTracked = mock(async () => {});
+    const onError = mock(() => {});
+    const report = await pollTrackedDiscordDms({
+      listTracked: async () => [{ ...tracked }],
+      fetchAfter: async () => {
+        throw Object.assign(new Error("Unknown Channel"), { code: 10003 });
+      },
+      claimMessage: async () => true,
+      routeMessage: async () => {},
+      updateCursor: async () => {},
+      removeTracked,
+      isTerminalChannelError: (error) =>
+        (error as { code?: number }).code === 10003,
+      onError,
+    });
+
+    expect(removeTracked).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(report.removed).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- persist DM channels opened by proactive greetings
- poll user-installed bot DMs when Discord omits Gateway MESSAGE_CREATE events
- deduplicate poll and Gateway delivery with durable Redis claims

## Verification
- 31 focused gateway tests pass
- gateway-discord typecheck passes
- Biome check passes
- live diagnosis: Discord REST can read the DM while Gateway emits no message event