### PR TITLE
fix: restore post-merge formatting gates

### DIFF
--- a/packages/agent/src/runtime/trajectory-internals.ts
+++ b/packages/agent/src/runtime/trajectory-internals.ts
@@ -3586,10 +3586,7 @@ function normalizeStepForPersistence(
     access: PersistedProviderAccess,
     index: number,
   ): PersistedProviderAccess => {
-    const bounded = snapshotCaptureParams(
-      { ...access },
-      step.stepId,
-    );
+    const bounded = snapshotCaptureParams({ ...access }, step.stepId);
     return parsePersistedProviderAccess(
       bounded,
       trajectoryId,

--- a/packages/shared/src/utils/streaming-text.test.ts
+++ b/packages/shared/src/utils/streaming-text.test.ts
@@ -73,9 +73,7 @@ describe("streaming text named regressions", () => {
     const expected = "foo\u1ea1\u0301 cafe\u0301";
 
     expect(mergeStreamingText(existing, incoming)).toBe(expected);
-    expect(computeStreamingDelta(existing, incoming)).toBe(
-      "\u0301 cafe\u0301",
-    );
+    expect(computeStreamingDelta(existing, incoming)).toBe("\u0301 cafe\u0301");
     expect(resolveStreamingUpdate(existing, incoming)).toEqual({
       kind: "append",
       nextText: expected,

--- a/packages/shared/src/utils/streaming-text.ts
+++ b/packages/shared/src/utils/streaming-text.ts
@@ -162,11 +162,7 @@ export function mergeStreamingText(existing: string, incoming: string): string {
       return incoming.length === 1 ? `${existing}${incoming}` : existing;
     }
 
-    const suffix = sliceAfterNormalizedOverlap(
-      incoming,
-      incomingNorm,
-      overlap,
-    );
+    const suffix = sliceAfterNormalizedOverlap(incoming, incomingNorm, overlap);
     return `${existing.slice(0, existing.length - (existingNorm.length - existingTrimmedLength))}${suffix}`;
   }
 


### PR DESCRIPTION
## Summary

- restore Biome's canonical formatting for the provider-access normalization corrected by #19721
- restore canonical formatting for the streaming-text call and regression assertion merged in #19681
- keep this repair strictly formatting-only: no expression, assertion, or runtime behavior changes

This is a narrow post-merge gate repair for current `develop`. It does not add defensive handling or suppress any failure; it makes the existing lint failures visible and green again.

## Validation

- exact-head `bun run --cwd packages/agent lint` — 887 files clean
- exact-head `bun run --cwd packages/shared lint` — 382 files clean
- exact-head `git diff --check` — pass
- prior exact revision on the immediately preceding healthy base: root `bun run verify` — 350/350 workspace tasks and all audits pass
- prior exact revision: focused trajectory contract 55/55 and streaming-text contract 14/14 pass

The latest base currently has an unrelated cloud typecheck regression from #19725: its new API-local module is imported through the package's cloud-shared `@/*` alias. Exact reproduction and diagnosis are recorded on [#19725](https://github.com/elizaOS/eliza/pull/19725#issuecomment-5300035625). This PR does not hide or absorb that separate source regression.

## Evidence

<!-- evidence-head:dc3ccf95bb9d990aa9a408692747ad16d2f604ff -->

| Evidence | Result |
| --- | --- |
| Before screenshots | N/A — no rendered surface |
| After screenshots | N/A — no rendered surface |
| MP4 walkthrough | N/A — no interactive surface |
| Backend logs | Attached through the repository evidence workflow |
| Frontend console/network logs | N/A — no frontend execution |
| Live-model trajectory | N/A — no model behavior |
| Domain artifact | Attached through the repository evidence workflow |
| OCR | N/A — no visual text |

# Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- evidence-row:before-screenshots -->
- [ ] N/A - formatter-only change with no rendered surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - formatter-only change with no rendered surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive surface

<!-- evidence-row:backend-logs -->
- [x] [19736-eliza-format-gate-evidence-v2.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19736-eliza-format-gate-evidence-v2.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend execution

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model behavior

<!-- evidence-row:domain-artifacts -->
- [x] [19736-eliza-format-gate-domain-proof.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19736-eliza-format-gate-domain-proof.txt)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->



