### PR TITLE
fix(ui): bound the boot poll against an unreachable dedicated cloud agent and name the dead host (#19627)

### DIFF
--- a/packages/ui/src/state/startup-coordinator.ts
+++ b/packages/ui/src/state/startup-coordinator.ts
@@ -45,6 +45,16 @@ export interface PlatformPolicy {
    * poll uses its 90s default.
    */
   nativeConsecutiveFailureBudgetMs?: number;
+  /**
+   * Hosted-web analogue for a DEDICATED cloud agent base (issue #19627): how
+   * long (ms) the backend poll may fail consecutively at the connection level
+   * — no HTTP response at all, e.g. a TLS handshake failure on
+   * `<id>.cloud.eliza.app` — before startup surfaces a distinct
+   * "agent unreachable" error instead of burning the whole `backendTimeoutMs`
+   * into a generic timeout. Optional; when absent the poll uses its 45s
+   * default from STARTUP_TIMING_POLICY.
+   */
+  agentUnreachableFailureBudgetMs?: number;
 }
 
 // ── State ────────────────────────────────────────────────────────────

--- a/packages/ui/src/state/startup-phase-poll.test.ts
+++ b/packages/ui/src/state/startup-phase-poll.test.ts
@@ -2568,3 +2568,161 @@ describe("isRecoverableRemoteBase — allowLoopback", () => {
     ).toBe(false);
   });
 });
+
+describe("runPollingBackend hosted-web unreachable dedicated agent (#19627)", () => {
+  const webPolicy = {
+    supportsLocalRuntime: false,
+    backendTimeoutMs: 30_000,
+    agentReadyTimeoutMs: 30_000,
+    probeForExistingInstall: false,
+    defaultTarget: null,
+  };
+
+  const dedicatedBase =
+    "https://123e4567-e89b-12d3-a456-426614174000.cloud.eliza.app";
+
+  function dedicatedCtx(): RestoringSessionCtx {
+    const server = {
+      id: "cloud:123e4567-e89b-12d3-a456-426614174000",
+      kind: "cloud" as const,
+      label: "Dedicated agent",
+      apiBase: dedicatedBase,
+    };
+    return {
+      persistedActiveServer: server,
+      restoredActiveServer: server,
+      shouldPreserveCompletedFirstRun: false,
+      hadPriorFirstRun: true,
+    };
+  }
+
+  function installWebWindow(): void {
+    (globalThis as { window?: unknown }).window = {
+      location: { origin: "https://cloud.eliza.app", protocol: "https:" },
+    };
+  }
+
+  it("bounds connection-level failures against a dedicated agent host and names the unreachable host", async () => {
+    // The #19627 production shape: no wildcard TLS on *.cloud.eliza.app, so
+    // every fetch to the agent subdomain dies at the handshake — a statusless
+    // "Failed to fetch". Without the bounded streak the shell spins
+    // "Booting up…" for the full backendTimeoutMs (180s in prod) and then
+    // reports a generic timeout that never names the dead host.
+    const deps = createDeps();
+    const dispatch = vi.fn();
+    installWebWindow();
+    clientMock.getBaseUrl.mockReturnValue(dedicatedBase);
+    clientMock.getAuthStatus.mockReset();
+    clientMock.getAuthStatus.mockRejectedValue(
+      Object.assign(new TypeError("Failed to fetch"), {
+        path: "/api/auth/status",
+      }),
+    );
+
+    await runPollingBackend(
+      deps,
+      dispatch,
+      { ...webPolicy, agentUnreachableFailureBudgetMs: 200 },
+      dedicatedCtx(),
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+    );
+
+    // The overall backendTimeoutMs (30s) never elapsed — the unreachable
+    // budget produced the terminal transition with a distinct error.
+    expect(dispatch).toHaveBeenCalledWith({ type: "BACKEND_TIMEOUT" });
+    expect(deps.setStartupError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "backend-unreachable",
+        message: expect.stringContaining(
+          "123e4567-e89b-12d3-a456-426614174000.cloud.eliza.app",
+        ),
+        detail: expect.stringContaining("Failed to fetch"),
+      }),
+    );
+    // The dedicated base must NOT be abandoned for the page origin.
+    expect(clearPersistedActiveServer).not.toHaveBeenCalled();
+  });
+
+  it("resets the unreachable streak on a successful probe (a slow agent is not a dead transport)", async () => {
+    const deps = createDeps();
+    const dispatch = vi.fn();
+    installWebWindow();
+    clientMock.getBaseUrl.mockReturnValue(dedicatedBase);
+    const networkError = () =>
+      Object.assign(new TypeError("Failed to fetch"), {
+        path: "/api/auth/status",
+      });
+    clientMock.getAuthStatus.mockReset();
+    clientMock.getAuthStatus
+      .mockRejectedValueOnce(networkError())
+      .mockResolvedValue({
+        required: false,
+        authenticated: true,
+        pairingEnabled: false,
+        expiresAt: null,
+      });
+    clientMock.getFirstRunStatus.mockReset();
+    clientMock.getFirstRunStatus
+      .mockRejectedValueOnce(networkError())
+      .mockResolvedValue({ complete: true, cloudProvisioned: false });
+
+    // Budget 450ms: WITHOUT the reset, the second failure (~500ms in, after
+    // the first backoff) would exceed the budget and dead-end on the
+    // unreachable card. WITH the reset (the auth probe between the two
+    // failures succeeded) the streak restarts and the third round completes.
+    await runPollingBackend(
+      deps,
+      dispatch,
+      { ...webPolicy, agentUnreachableFailureBudgetMs: 450 },
+      dedicatedCtx(),
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+    );
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "BACKEND_REACHED",
+      firstRunComplete: true,
+    });
+    expect(dispatch).not.toHaveBeenCalledWith({ type: "BACKEND_TIMEOUT" });
+  });
+
+  it("keeps the plain retry path for a NON-dedicated base (no premature unreachable card)", async () => {
+    // A same-origin base with connection-level failures must not trip the
+    // dedicated-agent unreachable card — it keeps the existing timeout path.
+    const deps = createDeps();
+    const dispatch = vi.fn();
+    installWebWindow();
+    clientMock.getBaseUrl.mockReturnValue("");
+    clientMock.getAuthStatus.mockReset();
+    clientMock.getAuthStatus.mockRejectedValue(
+      Object.assign(new TypeError("Failed to fetch"), {
+        path: "/api/auth/status",
+      }),
+    );
+
+    await runPollingBackend(
+      deps,
+      dispatch,
+      {
+        ...webPolicy,
+        backendTimeoutMs: 700,
+        agentUnreachableFailureBudgetMs: 200,
+      },
+      dedicatedCtx(),
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+    );
+
+    expect(dispatch).toHaveBeenCalledWith({ type: "BACKEND_TIMEOUT" });
+    expect(deps.setStartupError).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "backend-timeout" }),
+    );
+  });
+});

--- a/packages/ui/src/state/startup-phase-poll.test.ts
+++ b/packages/ui/src/state/startup-phase-poll.test.ts
@@ -2615,6 +2615,7 @@ describe("runPollingBackend hosted-web unreachable dedicated agent (#19627)", ()
     clientMock.getAuthStatus.mockReset();
     clientMock.getAuthStatus.mockRejectedValue(
       Object.assign(new TypeError("Failed to fetch"), {
+        kind: "network",
         path: "/api/auth/status",
       }),
     );
@@ -2653,6 +2654,7 @@ describe("runPollingBackend hosted-web unreachable dedicated agent (#19627)", ()
     clientMock.getBaseUrl.mockReturnValue(dedicatedBase);
     const networkError = () =>
       Object.assign(new TypeError("Failed to fetch"), {
+        kind: "network",
         path: "/api/auth/status",
       });
     clientMock.getAuthStatus.mockReset();
@@ -2701,6 +2703,7 @@ describe("runPollingBackend hosted-web unreachable dedicated agent (#19627)", ()
     clientMock.getAuthStatus.mockReset();
     clientMock.getAuthStatus.mockRejectedValue(
       Object.assign(new TypeError("Failed to fetch"), {
+        kind: "network",
         path: "/api/auth/status",
       }),
     );
@@ -2723,6 +2726,45 @@ describe("runPollingBackend hosted-web unreachable dedicated agent (#19627)", ()
     expect(dispatch).toHaveBeenCalledWith({ type: "BACKEND_TIMEOUT" });
     expect(deps.setStartupError).toHaveBeenCalledWith(
       expect.objectContaining({ reason: "backend-timeout" }),
+    );
+  });
+
+  it("does not label a malformed HTTP-200 auth payload as a TLS or network failure", async () => {
+    // ElizaClient's successful-response parser can return null for an HTTP-200
+    // `null` body. The poll then throws while reading `auth.required`; that
+    // plain TypeError has no status, but the response was not a transport
+    // failure. This negative case makes the kind gate mutation-sensitive: a
+    // regression to `status === undefined` trips the short unreachable budget.
+    const deps = createDeps();
+    const dispatch = vi.fn();
+    installWebWindow();
+    clientMock.getBaseUrl.mockReturnValue(dedicatedBase);
+    clientMock.getAuthStatus.mockReset();
+    clientMock.getAuthStatus.mockResolvedValue(null);
+
+    await runPollingBackend(
+      deps,
+      dispatch,
+      {
+        ...webPolicy,
+        backendTimeoutMs: 700,
+        agentUnreachableFailureBudgetMs: 0,
+      },
+      dedicatedCtx(),
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+    );
+
+    expect(dispatch).toHaveBeenCalledWith({ type: "BACKEND_TIMEOUT" });
+    expect(deps.setStartupError).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "backend-timeout" }),
+    );
+    expect(deps.setStartupError).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("TLS or network failure"),
+      }),
     );
   });
 });

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -1242,8 +1242,12 @@ export async function runPollingBackend(
         // whole `backendTimeoutMs` and then report a generic timeout. Bound
         // the connection-level failure streak and surface the unreachable
         // host explicitly instead.
+        const isConnectionLevelFailure =
+          err instanceof ApiHangTimeoutError ||
+          ae?.kind === "network" ||
+          ae?.kind === "timeout";
         if (
-          ae?.status === undefined &&
+          isConnectionLevelFailure &&
           isDedicatedCloudAgentBase(client.getBaseUrl())
         ) {
           agentUnreachableStreakStartedAt ??= Date.now();
@@ -1272,7 +1276,9 @@ export async function runPollingBackend(
             return;
           }
         } else {
-          // An HTTP status means the host answered — not a transport wedge.
+          // Only explicit transport failures count. Parse/protocol failures —
+          // including malformed HTTP-200 payloads — prove the host answered
+          // and must break the TLS/network streak even when they lack status.
           agentUnreachableStreakStartedAt = null;
         }
       }

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -422,6 +422,18 @@ export async function runPollingBackend(
     policy.nativeConsecutiveFailureBudgetMs ??
     NATIVE_CONSECUTIVE_FAILURE_BUDGET_MS;
   let nativeFailureStreakStartedAt: number | null = null;
+  // Hosted-web bounded boot for a DEDICATED cloud agent base (issue #19627):
+  // timestamp of the first CONNECTION-LEVEL failure (no HTTP response at all —
+  // e.g. a TLS handshake failure on `<id>.cloud.eliza.app`) in the current
+  // unbroken streak. Reset by any successful probe or any response that
+  // carries an HTTP status; when the streak outlives the budget the poll
+  // surfaces a distinct "agent unreachable" error instead of spending the full
+  // `backendTimeoutMs` on a generic timeout card (error-policy J4: a transport
+  // failure is an error state, not a loading state).
+  const agentUnreachableBudgetMs =
+    policy.agentUnreachableFailureBudgetMs ??
+    STARTUP_TIMING_POLICY.agentUnreachableFailureBudgetMs;
+  let agentUnreachableStreakStartedAt: number | null = null;
   let latestAuth: Awaited<ReturnType<typeof client.getAuthStatus>> = {
     required: false,
     pairingEnabled: false,
@@ -724,6 +736,7 @@ export async function runPollingBackend(
       // transport works; any remaining slowness is the agent booting, which
       // the overall `deadline` already budgets for.
       nativeFailureStreakStartedAt = null;
+      agentUnreachableStreakStartedAt = null;
       if (cancelled.current) return;
       if (auth.required && !auth.authenticated && !client.hasToken()) {
         if (auth.bootstrapRequired) {
@@ -1220,6 +1233,49 @@ export async function runPollingBackend(
         continue;
       }
       lastErr = err;
+      if (!isCapacitorNative()) {
+        // Hosted-web bounded boot for a DEDICATED cloud agent base (#19627):
+        // `shouldFallBackToLocalOrigin` deliberately never abandons a
+        // dedicated base, so a host with broken transport (e.g. missing
+        // wildcard TLS on `<id>.cloud.eliza.app` — every fetch dies at the
+        // handshake with no HTTP status) used to spin "Booting up…" for the
+        // whole `backendTimeoutMs` and then report a generic timeout. Bound
+        // the connection-level failure streak and surface the unreachable
+        // host explicitly instead.
+        if (
+          ae?.status === undefined &&
+          isDedicatedCloudAgentBase(client.getBaseUrl())
+        ) {
+          agentUnreachableStreakStartedAt ??= Date.now();
+          const failingForMs = Date.now() - agentUnreachableStreakStartedAt;
+          if (failingForMs >= agentUnreachableBudgetMs) {
+            const detail = formatStartupErrorDetail(err) ?? String(err);
+            let agentHost = client.getBaseUrl();
+            try {
+              agentHost = new URL(client.getBaseUrl()).host;
+            } catch {
+              // error-policy:J3 unparsable base — report the raw base string.
+            }
+            logger.warn(
+              { failingForMs, agentHost, detail },
+              "[startup-phase-poll] dedicated cloud agent host is unreachable at the connection level; surfacing the startup error",
+            );
+            deps.setStartupError({
+              reason: "backend-unreachable",
+              phase: "starting-backend",
+              message: `Your agent at ${agentHost} is unreachable: every connection attempt for ${Math.round(failingForMs / 1000)}s failed without an HTTP response (TLS or network failure). Last failure: ${detail}`,
+              detail,
+              path: ae?.path,
+            });
+            deps.setFirstRunLoading(false);
+            dispatch({ type: "BACKEND_TIMEOUT" });
+            return;
+          }
+        } else {
+          // An HTTP status means the host answered — not a transport wedge.
+          agentUnreachableStreakStartedAt = null;
+        }
+      }
       if (isCapacitorNative()) {
         // Android detached local agent now exposes the service-owned boot
         // state over the Capacitor plugin. That distinguishes a cold boot

--- a/packages/ui/src/state/startup-timing-policy.ts
+++ b/packages/ui/src/state/startup-timing-policy.ts
@@ -10,5 +10,6 @@ export const STARTUP_TIMING_POLICY = Object.freeze({
   stewardRestoreRefreshTimeoutMs: 4_000,
   cloudAgentTierProbeTimeoutMs: 12_000,
   nativeConsecutiveFailureBudgetMs: 90_000,
+  agentUnreachableFailureBudgetMs: 45_000,
   probeRequestTimeoutMs: 12_000,
 });


### PR DESCRIPTION
# Relates to

Relates to #19627. This is the client-side diagnosis/recovery fix; the wildcard TLS certificate remains tracked by the issue's infrastructure lane.

# What changed

Hosted web now gives dedicated cloud-agent hosts a 45-second consecutive transport-failure budget. Explicit network/timeout failures then surface the existing `backend-unreachable` card with the affected host instead of showing “Booting up…” for the full 180-second backend deadline and ending in a generic timeout.

The classifier is intentionally narrow: only normalized `network`/`timeout` API errors and the poll's own hang timeout count. A successful probe or any parse/protocol/HTTP response resets the streak, so malformed HTTP-200 responses and slow-but-responsive agents are not mislabeled as TLS failures.

# Review and implementation notes

Independent review found the original statusless-error classifier too broad: a plain exception while parsing a malformed successful response also has no HTTP status. The branch was repaired to use the API client's typed transport kinds and gained a mutation-sensitive negative test for the malformed-200 case.

Risk is low and bounded. No rendered component or public API changed; the existing retryable startup error surface is reused. The certificate fix remains necessary.

# Testing

Exact reviewed head: `eb70e43ccdec341e6f3ca77c3a76a7b2676a46d5`
Frozen rebased develop base: `ac61a158310d5c6ad6de73b302662d43c0f691f8`

- `bunx vitest run src/state/startup-phase-poll.test.ts` from `packages/ui`: 55/55 passed after final rebase.
- `bun run typecheck` from `packages/ui`: passed.
- `bun run lint` from `packages/ui`: passed with 8 existing `noDocumentCookie` warnings.
- `bun run verify`: 350/350 workspace tasks passed on the exact reviewed head; all repository audits passed.
- Mutation proof: replacing the explicit transport-kind gate with `status === undefined` makes the malformed HTTP-200 regression test fail; restoring the implementation passes.
- `bun run --cwd packages/app audit:app`: 219/219 captures passed for the unchanged rendered diff; `broken=0`, `needs-work=0`, minimalism/hover/density failures all 0. Packaged OCR: 216 views, 200 verified, 0 broken, 16 needs-eyeball.

The four added cases cover: dedicated-host network failure; streak reset after a successful probe; non-dedicated bases retaining the ordinary timeout; and a malformed HTTP-200 payload not being described as TLS/network failure.

# Evidence Gate

<!-- evidence-head:eb70e43ccdec341e6f3ca77c3a76a7b2676a46d5 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered source changed; #19627 records the prior “Booting up…” state.
<!-- evidence-row:after-screenshots -->
- [x] N/A - the existing StartupError card is reused unchanged; the full app capture matrix passed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the real flow depends on the active wildcard-certificate incident; the real poll loop is covered deterministically.
<!-- evidence-row:backend-logs -->
- [x] N/A - client-only startup state logic.
<!-- evidence-row:frontend-logs -->
- [x] Focused poll-loop output and mutation result are summarized under Testing; a TLS handshake failure has no HTTP response log.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - startup polling creates no persisted domain artifact.
<!-- evidence-row:ocr-review -->
- [x] Full app audit passed: 219/219 captures; packaged OCR reported 0 broken views.

# Contribution provenance

The original implementation attribution is preserved: `anthropic/claude-fable-5` via `Claude Code`. The review repair and final verification used `OpenAI / gpt-5` via `Codex desktop`.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`; `OpenAI / gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`; `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used during review`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

---

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no contribution skill used during review
Attribution status: self-reported
