### PR TITLE
fix(cloud): resolve anonymous session config from API root

### DIFF
--- a/packages/cloud/api/auth/anonymous-session/route.ts
+++ b/packages/cloud/api/auth/anonymous-session/route.ts
@@ -18,7 +18,7 @@ import {
   MAX_ANONYMOUS_EXPIRY_DAYS,
   MAX_ANONYMOUS_MESSAGE_LIMIT,
   parseAnonymousPositiveIntEnv,
-} from "@/auth/anonymous-session-config";
+} from "@/api/auth/anonymous-session-config";
 import { dbRead } from "@/db/helpers";
 import { userIdentities } from "@/db/schemas/user-identities";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";

--- a/packages/cloud/api/auth/create-anonymous-session/route.ts
+++ b/packages/cloud/api/auth/create-anonymous-session/route.ts
@@ -12,7 +12,7 @@ import {
   MAX_ANONYMOUS_EXPIRY_DAYS,
   MAX_ANONYMOUS_MESSAGE_LIMIT,
   parseAnonymousPositiveIntEnv,
-} from "@/auth/anonymous-session-config";
+} from "@/api/auth/anonymous-session-config";
 import {
   getIpKey,
   RateLimitPresets,


### PR DESCRIPTION
## Summary
- correct two anonymous-session imports to use the API-local `@/api/*` alias
- restore Wrangler production bundling after the latest develop promotion

## Verification
- cloud API TypeScript check passes
- Wrangler production dry-run bundles successfully
- anonymous-session route assertions pass (Bun later emits the known coverage-output write failure)
- Biome and diff checks pass