### PR TITLE
test(cloud): derive expected pending-migration count from the journal

### DIFF
--- a/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
+++ b/packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
@@ -97,6 +97,19 @@ async function journalEntries(): Promise<JournalEntry[]> {
   return journal.entries;
 }
 
+/**
+ * Journal prefix the fixture records as already applied. Everything after this
+ * index is what the migrator must report and apply as pending, so the expected
+ * pending count tracks the live journal instead of a hardcoded literal that
+ * breaks on every new migration.
+ */
+const CHECKPOINT_PREFIX_LENGTH = 184;
+
+async function expectedPendingBanner(): Promise<string> {
+  const total = (await journalEntries()).length;
+  return `pending migrations: ${total - CHECKPOINT_PREFIX_LENGTH}`;
+}
+
 async function seedAppliedPrefix(
   client: pg.Client,
   length: number,
@@ -260,7 +273,7 @@ describe.skipIf(!ENABLED)(
 
     test("applies the append-only fix-forward once and passes the reusable catalog preflight", async () => {
       const database = await createDatabase();
-      await seedAppliedPrefix(database.client, 184);
+      await seedAppliedPrefix(database.client, CHECKPOINT_PREFIX_LENGTH);
       await database.client.query(`
         INSERT INTO jobs (
           status,
@@ -279,7 +292,7 @@ describe.skipIf(!ENABLED)(
 
       const first = await runScript(MIGRATOR, database.url);
       expect(first.exitCode, first.output).toBe(0);
-      expect(first.output).toContain("pending migrations: 15");
+      expect(first.output).toContain(await expectedPendingBanner());
 
       const catalog = await database.client.query<{
         data_type: string;
@@ -336,7 +349,7 @@ describe.skipIf(!ENABLED)(
 
     test("accepts historical production hash drift but enforces hashes from the checkpoint forward", async () => {
       const database = await createDatabase();
-      await seedAppliedPrefix(database.client, 184);
+      await seedAppliedPrefix(database.client, CHECKPOINT_PREFIX_LENGTH);
       await database.client.query(
         "UPDATE drizzle.__drizzle_migrations SET hash = 'historical-drift' WHERE created_at = $1",
         [HISTORICAL_DRIFT_CREATED_AT],
@@ -344,7 +357,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 15");
+      expect(migrated.output).toContain(await expectedPendingBanner());
 
       await database.client.query(
         "UPDATE drizzle.__drizzle_migrations SET hash = 'checkpoint-drift' WHERE created_at = $1",
@@ -360,7 +373,11 @@ describe.skipIf(!ENABLED)(
 
     test("accepts production timestamp order when legacy journal indexes invert", async () => {
       const database = await createDatabase();
-      await seedAppliedPrefix(database.client, 184, "timestamp");
+      await seedAppliedPrefix(
+        database.client,
+        CHECKPOINT_PREFIX_LENGTH,
+        "timestamp",
+      );
       const entries = await journalEntries();
       const earlierTimestamp = entries[44];
       const laterTimestamp = entries[43];
@@ -390,23 +407,31 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 15");
+      expect(migrated.output).toContain(await expectedPendingBanner());
       await database.client.end();
     }, 120_000);
 
     test("accepts historical journal order when legacy timestamps invert", async () => {
       const database = await createDatabase();
-      await seedAppliedPrefix(database.client, 184, "journal");
+      await seedAppliedPrefix(
+        database.client,
+        CHECKPOINT_PREFIX_LENGTH,
+        "journal",
+      );
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 15");
+      expect(migrated.output).toContain(await expectedPendingBanner());
       await database.client.end();
     }, 120_000);
 
     test("accepts the production hybrid order with late historical backfills", async () => {
       const database = await createDatabase();
-      await seedAppliedPrefix(database.client, 184, "production-hybrid");
+      await seedAppliedPrefix(
+        database.client,
+        CHECKPOINT_PREFIX_LENGTH,
+        "production-hybrid",
+      );
       const entries = await journalEntries();
       const encryptionKeys = entries[17];
       const databaseOptimization = entries[81];
@@ -432,13 +457,17 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 15");
+      expect(migrated.output).toContain(await expectedPendingBanner());
       await database.client.end();
     }, 120_000);
 
     test("accepts production schema history missing ledger rows before the checkpoint", async () => {
       const database = await createDatabase();
-      await seedAppliedPrefix(database.client, 184, "production-hybrid");
+      await seedAppliedPrefix(
+        database.client,
+        CHECKPOINT_PREFIX_LENGTH,
+        "production-hybrid",
+      );
       const entries = await journalEntries();
       const missingEntries = PRODUCTION_UNRECORDED_TAGS.map((tag) => {
         const entry = entries.find((candidate) => candidate.tag === tag);
@@ -452,7 +481,7 @@ describe.skipIf(!ENABLED)(
 
       const migrated = await runScript(MIGRATOR, database.url);
       expect(migrated.exitCode, migrated.output).toBe(0);
-      expect(migrated.output).toContain("pending migrations: 15");
+      expect(migrated.output).toContain(await expectedPendingBanner());
 
       const remaining = await database.client.query<{ count: string }>(
         "SELECT count(*)::text AS count FROM drizzle.__drizzle_migrations WHERE created_at = ANY($1::bigint[])",
@@ -464,7 +493,7 @@ describe.skipIf(!ENABLED)(
 
     test("rejects historical rows appended after the immutable checkpoint", async () => {
       const database = await createDatabase();
-      await seedAppliedPrefix(database.client, 184);
+      await seedAppliedPrefix(database.client, CHECKPOINT_PREFIX_LENGTH);
       const entries = await journalEntries();
       for (const journalIndex of [193, 184, 185]) {
         const entry = entries[journalIndex];
@@ -489,7 +518,7 @@ describe.skipIf(!ENABLED)(
 
     test("rejects incompatible catalog drift and malformed ledger prefixes", async () => {
       const drift = await createDatabase();
-      await seedAppliedPrefix(drift.client, 184);
+      await seedAppliedPrefix(drift.client, CHECKPOINT_PREFIX_LENGTH);
       await drift.client.query(
         "ALTER TABLE jobs ADD COLUMN execution_interruptions text DEFAULT 'wrong'",
       );
@@ -515,7 +544,7 @@ describe.skipIf(!ENABLED)(
       await drift.client.end();
 
       const generated = await createDatabase();
-      await seedAppliedPrefix(generated.client, 184);
+      await seedAppliedPrefix(generated.client, CHECKPOINT_PREFIX_LENGTH);
       await generated.client.query(
         "ALTER TABLE jobs ADD COLUMN execution_interruptions integer GENERATED ALWAYS AS (0) STORED NOT NULL",
       );
@@ -527,7 +556,7 @@ describe.skipIf(!ENABLED)(
       await generated.client.end();
 
       const duplicate = await createDatabase();
-      await seedAppliedPrefix(duplicate.client, 184);
+      await seedAppliedPrefix(duplicate.client, CHECKPOINT_PREFIX_LENGTH);
       const last = (
         await duplicate.client.query<{ hash: string; created_at: string }>(
           "SELECT hash, created_at::text FROM drizzle.__drizzle_migrations ORDER BY id DESC LIMIT 1",
@@ -543,7 +572,7 @@ describe.skipIf(!ENABLED)(
       await duplicate.client.end();
 
       const unknownRow = await createDatabase();
-      await seedAppliedPrefix(unknownRow.client, 184);
+      await seedAppliedPrefix(unknownRow.client, CHECKPOINT_PREFIX_LENGTH);
       await unknownRow.client.query(
         "INSERT INTO drizzle.__drizzle_migrations (hash, created_at) VALUES ('unknown', 9999999999999)",
       );
@@ -555,7 +584,7 @@ describe.skipIf(!ENABLED)(
 
     test("serializes concurrent migrators and recovers from table-lock contention", async () => {
       const database = await createDatabase();
-      await seedAppliedPrefix(database.client, 184);
+      await seedAppliedPrefix(database.client, CHECKPOINT_PREFIX_LENGTH);
       const holder = new Client({ connectionString: database.url });
       await holder.connect();
       await holder.query("BEGIN");
@@ -590,7 +619,7 @@ describe.skipIf(!ENABLED)(
 
     test("fails observably after bounded table-lock retries without partial state", async () => {
       const database = await createDatabase();
-      await seedAppliedPrefix(database.client, 184);
+      await seedAppliedPrefix(database.client, CHECKPOINT_PREFIX_LENGTH);
       const holder = new Client({ connectionString: database.url });
       await holder.connect();
       await holder.query("BEGIN");


### PR DESCRIPTION
## Summary

Follow-up to #19274. The real-PostgreSQL migration safety suite hardcodes the expected pending-migration count (`pending migrations: 15`), so every newly landed migration breaks the suite until someone bumps the literal (it went 13 → 14 → 15 across the last two fixes). This derives the expectation from the live journal minus the 184-entry checkpoint prefix, which is now a named `CHECKPOINT_PREFIX_LENGTH` constant shared by every `seedAppliedPrefix` call.

No production code changes; test-only.

## Verification

Ran the full suite against a disposable real PostgreSQL 16 instance:

```
RUN_REAL_POSTGRES_MIGRATION_TESTS=1 MIGRATION_TEST_DATABASE_URL=postgres://... \
  bun test packages/cloud/scripts/admin/migrate-with-diagnostics.postgres.test.ts
10 pass, 0 fail, 47 expect() calls
```

## Contribution provenance
- AI assistance: yes
- Model(s) used: claude-fable-5
- Agent tooling: Claude Code
- Provenance status: self-reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)