### PR TITLE
fix(cloud): canonicalize Discord conversation rooms (production)

### DIFF
--- a/packages/cloud/shared/src/lib/services/agent-gateway-router.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-gateway-router.test.ts
@@ -867,6 +867,49 @@ describe("AgentGatewayRouterService discord DM onboarding (#17341)", () => {
     expect(result.agentId).toBe("sb-stopped");
     expect(runOnboardingChat).not.toHaveBeenCalled();
   });
+
+  test("routes an authenticated DM with a canonical deterministic conversation UUID", async () => {
+    findByDiscordIdWithOrganization.mockResolvedValue({
+      id: "user-1",
+      organization_id: "org-1",
+    });
+    listOwnerSessions.mockResolvedValue([]);
+    listByOrganization.mockResolvedValue([
+      {
+        id: "sb-running",
+        status: "running",
+        user_id: "user-1",
+        organization_id: "org-1",
+        agent_config: {},
+      },
+    ]);
+    bridge.mockResolvedValue({ result: { text: "hello from eliza" } });
+
+    const result = await newRouter().routeDiscordMessage(discordArgs());
+
+    expect(result).toMatchObject({
+      handled: true,
+      replyText: "hello from eliza",
+      agentId: "sb-running",
+      organizationId: "org-1",
+      userId: "user-1",
+    });
+    expect(bridge).toHaveBeenCalledWith(
+      "sb-running",
+      "org-1",
+      expect.objectContaining({
+        method: "message.send",
+        params: expect.objectContaining({
+          roomId: expect.stringMatching(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+          ),
+          channelType: "DM",
+          source: "discord",
+        }),
+      }),
+    );
+    expect(result.roomId).not.toContain("discord-dm:");
+  });
 });
 
 describe("AgentGatewayRouterService telegram onboarding", () => {

--- a/packages/cloud/shared/src/lib/services/agent-gateway-router.ts
+++ b/packages/cloud/shared/src/lib/services/agent-gateway-router.ts
@@ -773,16 +773,25 @@ export class AgentGatewayRouterService {
       };
     }
 
+    const targetAgentId =
+      resolved.target.kind === "local-session" && resolved.target.session
+        ? resolved.target.session.runtimeAgentId
+        : (resolved.target.sandbox?.id ?? resolved.agentId ?? args.sender.id);
+    const guildId = args.guildId?.trim();
+    const roomId = buildDirectConversationRoomIdFromIds(
+      targetAgentId,
+      "discord",
+      guildId || args.sender.id,
+      args.channelId,
+    );
     const rpcRequest: BridgeRequest = {
       jsonrpc: "2.0",
       id: randomUUID(),
       method: "message.send",
       params: {
         text: args.content,
-        roomId: args.guildId?.trim()
-          ? `discord-guild:${args.guildId.trim()}:channel:${args.channelId}`
-          : `discord-dm:${args.sender.id}:channel:${args.channelId}`,
-        channelType: args.guildId?.trim() ? "GROUP" : "DM",
+        roomId,
+        channelType: guildId ? "GROUP" : "DM",
         source: "discord",
         sender: {
           id: args.sender.id,
@@ -799,7 +808,7 @@ export class AgentGatewayRouterService {
         },
         metadata: {
           discord: {
-            ...(args.guildId?.trim() ? { guildId: args.guildId.trim() } : {}),
+            ...(guildId ? { guildId } : {}),
             channelId: args.channelId,
             messageId: args.messageId,
           },


### PR DESCRIPTION
Production promotion of #19746 / #19745.\n\nThis fixes the live Discord DM bridge failure after the polling fallback successfully receives a user-installed app DM. Explicit production deployment authorization was provided in the active incident.