### PR TITLE
fix(agent): validate connector health before readiness

### DIFF
--- a/packages/agent/AGENTS.md
+++ b/packages/agent/AGENTS.md
@@ -145,16 +145,13 @@ supervisor relaunches) — never a silent `process.exit`.
 - `ELIZA_MEMORY_WATCHDOG_INTERVAL_MS` — sample interval (default `30000`, floor `1000`).
 - `ELIZA_MEMORY_WATCHDOG_SUSTAINED` — consecutive over-threshold samples before a restart, to debounce transient spikes (default `3`, floor `1`).
 
-Connector health monitoring (`api/connector-health.ts`): `ConnectorHealthMonitor` is
-  constructed inside a post-listen deferred wave wrapped in a warn-and-continue catch
-  (`startDeferredStartupWork` in `api/server.ts`), so `resolveConnectorHealthIntervalMs`
-  never throws — a malformed value falls back to the default instead, so a bad env var
-  can't silently disable connector health monitoring for the process lifetime.
+Connector health monitoring (`api/connector-health.ts`): the interval is validated
+  synchronously by `startApiServer` before the HTTP server is created or bound, then
+  passed into the monitor's post-listen deferred construction. The deferred catch
+  therefore cannot hide malformed owner configuration or disable monitoring.
 - `CONNECTOR_HEALTH_INTERVAL_MS` — poll interval in ms (default `60000`, floor `10000`,
-  ceiling `2147483647`). Parsed with `Number.parseInt` (not a canonical-integer regex),
-  so trailing-junk/fractional/leading-zero forms truncate the same way they always have;
-  unset, non-numeric, below-floor, or above-ceiling values fall back to the default
-  (an above-ceiling value also logs a warning naming the env var).
+  ceiling `2147483647`). Configured values must be exact decimal integers; malformed,
+  non-canonical, below-floor, or above-ceiling values fail API startup before readiness.
 
 ## How to extend
 

--- a/packages/agent/CLAUDE.md
+++ b/packages/agent/CLAUDE.md
@@ -145,16 +145,13 @@ supervisor relaunches) — never a silent `process.exit`.
 - `ELIZA_MEMORY_WATCHDOG_INTERVAL_MS` — sample interval (default `30000`, floor `1000`).
 - `ELIZA_MEMORY_WATCHDOG_SUSTAINED` — consecutive over-threshold samples before a restart, to debounce transient spikes (default `3`, floor `1`).
 
-Connector health monitoring (`api/connector-health.ts`): `ConnectorHealthMonitor` is
-  constructed inside a post-listen deferred wave wrapped in a warn-and-continue catch
-  (`startDeferredStartupWork` in `api/server.ts`), so `resolveConnectorHealthIntervalMs`
-  never throws — a malformed value falls back to the default instead, so a bad env var
-  can't silently disable connector health monitoring for the process lifetime.
+Connector health monitoring (`api/connector-health.ts`): the interval is validated
+  synchronously by `startApiServer` before the HTTP server is created or bound, then
+  passed into the monitor's post-listen deferred construction. The deferred catch
+  therefore cannot hide malformed owner configuration or disable monitoring.
 - `CONNECTOR_HEALTH_INTERVAL_MS` — poll interval in ms (default `60000`, floor `10000`,
-  ceiling `2147483647`). Parsed with `Number.parseInt` (not a canonical-integer regex),
-  so trailing-junk/fractional/leading-zero forms truncate the same way they always have;
-  unset, non-numeric, below-floor, or above-ceiling values fall back to the default
-  (an above-ceiling value also logs a warning naming the env var).
+  ceiling `2147483647`). Configured values must be exact decimal integers; malformed,
+  non-canonical, below-floor, or above-ceiling values fail API startup before readiness.
 
 ## How to extend
 

--- a/packages/agent/src/api/__fixtures__/skip-listen-boot-harness.ts
+++ b/packages/agent/src/api/__fixtures__/skip-listen-boot-harness.ts
@@ -9,9 +9,10 @@
  * Bun child process and reports, on stdout as a single JSON line, whether the
  * agent port ends up bound.
  *
- * Usage: `bun <this> <mode> <port>` where mode is `skip` or `bind`.
+ * Usage: `bun <this> <mode> <port>` where mode is `skip`, `bind`, or `invalid`.
  *   skip → startApiServer({ skipListen: true })  → expect port NOT bound
  *   bind → startApiServer({})                     → expect port bound
+ *   invalid → malformed connector interval        → expect rejection before bind
  */
 
 import net from "node:net";
@@ -43,9 +44,12 @@ function isPortBound(
 async function main(): Promise<void> {
   const mode = process.argv[2];
   const port = Number(process.argv[3]);
-  if ((mode !== "skip" && mode !== "bind") || !Number.isInteger(port)) {
+  if (
+    (mode !== "skip" && mode !== "bind" && mode !== "invalid") ||
+    !Number.isInteger(port)
+  ) {
     process.stdout.write(
-      `${JSON.stringify({ ok: false, error: "usage: <skip|bind> <port>" })}\n`,
+      `${JSON.stringify({ ok: false, error: "usage: <skip|bind|invalid> <port>" })}\n`,
     );
     process.exit(2);
   }
@@ -53,8 +57,33 @@ async function main(): Promise<void> {
   // Route this process's own listener to the requested port so the bind-mode
   // control lands on a free, deterministic port.
   process.env.ELIZA_API_PORT = String(port);
+  if (mode === "invalid") {
+    process.env.CONNECTOR_HEALTH_INTERVAL_MS = "10000junk";
+  }
 
   const { startApiServer } = await import("../server.ts");
+  if (mode === "invalid") {
+    try {
+      await startApiServer({ port, initialAgentState: "starting" });
+    } catch (err) {
+      const bound = await isPortBound(port);
+      process.stdout.write(
+        `${JSON.stringify({
+          ok: true,
+          mode,
+          port,
+          bound,
+          rejected: true,
+          error: err instanceof Error ? err.message : String(err),
+        })}\n`,
+      );
+      process.exit(0);
+    }
+    process.stdout.write(
+      `${JSON.stringify({ ok: false, error: "invalid interval was accepted" })}\n`,
+    );
+    process.exit(1);
+  }
   const server = await startApiServer({
     port,
     skipListen: mode === "skip",

--- a/packages/agent/src/api/connector-health.test.ts
+++ b/packages/agent/src/api/connector-health.test.ts
@@ -1,8 +1,9 @@
 /**
- * Unit coverage for connector health probing. Telegram exposes poller liveness,
- * so a registered service object is not enough to report the connector healthy.
+ * Unit coverage for strict startup interval validation and connector health
+ * probing. Telegram exposes poller liveness, so a registered service object is
+ * not enough to report the connector healthy.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   ConnectorHealthMonitor,
   resolveConnectorHealthIntervalMs,
@@ -46,111 +47,26 @@ describe("ConnectorHealthMonitor", () => {
     setIntervalSpy.mockRestore();
   });
 
-  // Defaulting (not throwing) is deliberate: the monitor is constructed
-  // inside a post-listen deferred wave wrapped in a warn-and-continue catch,
-  // so a throw here would silently disable connector health monitoring (and
-  // the /api/health connector status) for the rest of the process lifetime
-  // instead of failing fast. Number.parseInt truncates at the first
-  // non-digit, so these all resolved to 10000 in production before this
-  // file's validation existed, and the fix preserves that exactly.
-  it.each(["10000junk", "10000.5", "010000", " 10000"])(
-    "preserves the pre-existing Number.parseInt truncation for %s",
-    (value) => {
-      expect(resolveConnectorHealthIntervalMs(value)).toBe(10_000);
-    },
-  );
-
-  // "1e4" truncates to 1 (parseInt stops at "e"); "Infinity" isn't a valid
-  // leading digit at all (NaN). Both fall through to the default, matching
-  // pre-existing behavior.
-  it.each(["1e4", "Infinity"])(
-    "falls back to the default for non-canonical connector-health interval %s",
-    (value) => {
-      expect(resolveConnectorHealthIntervalMs(value)).toBe(60_000);
-    },
-  );
-
-  it.each(["0", "9999"])(
-    "falls back to the default for a below-minimum connector-health interval %s",
-    (value) => {
-      expect(resolveConnectorHealthIntervalMs(value)).toBe(60_000);
-    },
-  );
-
-  // Mutation-resistant: proves the fix actually closes the real bug (the
-  // overflow silently reaching setInterval and firing a hot loop), not just
-  // that the parser returns *a* number. Confirmed against the original
-  // Number.parseInt-based resolver, which returned 2147483648 and
-  // 9007199254740992 verbatim.
-  it.each(["2147483648", "9007199254740992"])(
-    "falls back to the default instead of overflowing setInterval for %s",
-    (value) => {
-      expect(resolveConnectorHealthIntervalMs(value)).toBe(60_000);
-    },
-  );
+  it.each([
+    "10000junk",
+    "10000.5",
+    "010000",
+    " 10000",
+    "10000 ",
+    "1e4",
+    "Infinity",
+    "0",
+    "9999",
+    "2147483648",
+    "9007199254740992",
+  ])("fails fast on invalid CONNECTOR_HEALTH_INTERVAL_MS=%s", (value) => {
+    expect(() => resolveConnectorHealthIntervalMs(value)).toThrowError(
+      expect.objectContaining({ code: "CONNECTOR_HEALTH_INTERVAL_INVALID" }),
+    );
+  });
 
   it("keeps the default when the connector-health interval is unset", () => {
     expect(resolveConnectorHealthIntervalMs(undefined)).toBe(60_000);
-  });
-
-  describe("constructing ConnectorHealthMonitor from the real env var", () => {
-    const originalValue = process.env.CONNECTOR_HEALTH_INTERVAL_MS;
-
-    afterEach(() => {
-      if (originalValue === undefined) {
-        delete process.env.CONNECTOR_HEALTH_INTERVAL_MS;
-      } else {
-        process.env.CONNECTOR_HEALTH_INTERVAL_MS = originalValue;
-      }
-    });
-
-    // Proves the actual regression this fix closes: constructing the monitor
-    // (the real call site, inside a post-listen deferred wave wrapped in a
-    // warn-and-continue catch in server.ts) never throws for a malformed
-    // value, so connector health monitoring is never silently disabled for
-    // the rest of the process lifetime.
-    it.each(["2147483648", "1e4", "not-a-number"])(
-      "never throws when CONNECTOR_HEALTH_INTERVAL_MS=%s, and defaults the interval",
-      (value) => {
-        process.env.CONNECTOR_HEALTH_INTERVAL_MS = value;
-        const setIntervalSpy = vi
-          .spyOn(globalThis, "setInterval")
-          .mockReturnValue({} as ReturnType<typeof setInterval>);
-
-        let monitor: ConnectorHealthMonitor | undefined;
-        expect(() => {
-          monitor = new ConnectorHealthMonitor({
-            runtime: { getService: vi.fn() } as never,
-            config: { connectors: {} },
-            broadcastWs: vi.fn(),
-          });
-        }).not.toThrow();
-
-        monitor?.start();
-        expect(setIntervalSpy).toHaveBeenCalledWith(
-          expect.any(Function),
-          60_000,
-        );
-        setIntervalSpy.mockRestore();
-      },
-    );
-
-    it("uses the real env var when intervalMs is not passed explicitly", () => {
-      process.env.CONNECTOR_HEALTH_INTERVAL_MS = "45000";
-      const setIntervalSpy = vi
-        .spyOn(globalThis, "setInterval")
-        .mockReturnValue({} as ReturnType<typeof setInterval>);
-
-      const monitor = new ConnectorHealthMonitor({
-        runtime: { getService: vi.fn() } as never,
-        config: { connectors: {} },
-        broadcastWs: vi.fn(),
-      });
-      monitor.start();
-
-      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 45_000);
-      setIntervalSpy.mockRestore();
-    });
   });
 
   it("reports Telegram missing when the service exists but the poller is not live", async () => {

--- a/packages/agent/src/api/connector-health.ts
+++ b/packages/agent/src/api/connector-health.ts
@@ -6,7 +6,7 @@
  * "missing", broadcasts a system-warning via WebSocket.
  */
 
-import { type AgentRuntime, logger } from "@elizaos/core";
+import { type AgentRuntime, ElizaError } from "@elizaos/core";
 
 export type ConnectorStatus = "ok" | "missing" | "unknown";
 
@@ -20,7 +20,7 @@ export interface ConnectorHealthMonitorOptions {
   runtime: AgentRuntime;
   config: { connectors?: Record<string, unknown> };
   broadcastWs: (payload: object) => void;
-  intervalMs?: number;
+  intervalMs: number;
 }
 
 const DEFAULT_INTERVAL_MS = 60_000;
@@ -28,29 +28,35 @@ const MIN_INTERVAL_MS = 10_000;
 const MAX_INTERVAL_MS = 2_147_483_647;
 
 /**
- * `ConnectorHealthMonitor` is constructed inside a post-listen deferred wave
- * wrapped in a warn-and-continue catch (see `startDeferredStartupWork` in
- * `server.ts`), so a throw here doesn't fail fast - it silently disables
- * connector health monitoring (and the `/api/health` connector status) for
- * the rest of the process lifetime. Defaulting instead of throwing preserves
- * the original `Number.parseInt`-based tolerance (trailing-junk, fractional,
- * and leading-zero forms all still resolve the same way they always did),
- * while logging a discoverable warning naming the env var so a malformed
- * value isn't silently invisible either.
+ * Resolves the owner-facing interval before the API server binds. The monitor
+ * receives only this validated number, so its deferred post-listen startup has
+ * no configuration failure left for the best-effort boundary to hide.
  */
 export function resolveConnectorHealthIntervalMs(
   envVal: string | undefined,
 ): number {
-  if (!envVal) return DEFAULT_INTERVAL_MS;
-  const parsed = Number.parseInt(envVal, 10);
-  if (Number.isNaN(parsed) || parsed < MIN_INTERVAL_MS) {
-    return DEFAULT_INTERVAL_MS;
-  }
-  if (parsed > MAX_INTERVAL_MS) {
-    logger.warn(
-      `[connector-health] CONNECTOR_HEALTH_INTERVAL_MS=${envVal} exceeds the max setInterval delay (${MAX_INTERVAL_MS}); using the ${DEFAULT_INTERVAL_MS}ms default instead.`,
+  if (envVal === undefined || envVal === "") return DEFAULT_INTERVAL_MS;
+
+  const parsed = Number(envVal);
+  if (
+    !/^[1-9][0-9]*$/.test(envVal) ||
+    !Number.isSafeInteger(parsed) ||
+    parsed < MIN_INTERVAL_MS ||
+    parsed > MAX_INTERVAL_MS
+  ) {
+    throw new ElizaError(
+      `Invalid CONNECTOR_HEALTH_INTERVAL_MS value ${JSON.stringify(envVal)}: expected an exact decimal integer from ${MIN_INTERVAL_MS} through ${MAX_INTERVAL_MS}`,
+      {
+        code: "CONNECTOR_HEALTH_INTERVAL_INVALID",
+        context: {
+          setting: "CONNECTOR_HEALTH_INTERVAL_MS",
+          configured: envVal,
+          minimum: MIN_INTERVAL_MS,
+          maximum: MAX_INTERVAL_MS,
+        },
+        severity: "fatal",
+      },
     );
-    return DEFAULT_INTERVAL_MS;
   }
   return parsed;
 }
@@ -112,11 +118,7 @@ export class ConnectorHealthMonitor {
     this.runtime = opts.runtime;
     this.config = opts.config;
     this.broadcastWs = opts.broadcastWs;
-    this.intervalMs =
-      opts.intervalMs ??
-      resolveConnectorHealthIntervalMs(
-        process.env.CONNECTOR_HEALTH_INTERVAL_MS,
-      );
+    this.intervalMs = opts.intervalMs;
   }
 
   start(): void {

--- a/packages/agent/src/api/server-skip-listen.test.ts
+++ b/packages/agent/src/api/server-skip-listen.test.ts
@@ -78,10 +78,17 @@ function resolveBunExecutable(): string | null {
 
 /** Run the boot harness under Bun and parse its single JSON result line. */
 async function runBootHarness(
-  mode: "skip" | "bind",
+  mode: "skip" | "bind" | "invalid",
   port: number,
 ): Promise<
-  | { ok: true; mode: string; port: number; bound: boolean }
+  | {
+      ok: true;
+      mode: string;
+      port: number;
+      bound: boolean;
+      rejected?: boolean;
+      error?: string;
+    }
   | { ok: false; error: string }
 > {
   const bun = resolveBunExecutable();
@@ -91,7 +98,7 @@ async function runBootHarness(
   try {
     const { stdout } = await execFileAsync(
       bun,
-      [HARNESS_PATH, mode, String(port)],
+      ["--conditions=eliza-source", HARNESS_PATH, mode, String(port)],
       { timeout: 120_000, env: { ...process.env } },
     );
     const lastLine = stdout.trim().split("\n").filter(Boolean).at(-1) ?? "{}";
@@ -227,4 +234,14 @@ describe("startApiServer skipListen — real boot in a Bun subprocess (#12180)",
       expect(bindResult.bound).toBe(true);
     }
   }, 240_000);
+
+  it("rejects malformed connector-health configuration before binding", async () => {
+    const result = await runBootHarness("invalid", 39325);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.bound).toBe(false);
+      expect(result).toMatchObject({ mode: "invalid", rejected: true });
+      expect(result.error).toContain("CONNECTOR_HEALTH_INTERVAL_MS");
+    }
+  }, 120_000);
 });

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -69,6 +69,7 @@ import { type WebSocket, WebSocketServer } from "ws";
 import { installPlugin as installPluginDirect } from "../services/plugin-installer.ts";
 import { writeAgentBackupJsonResponse } from "./backup-json-response.ts";
 import { handleStandaloneCloudPairRoute } from "./cloud-pair-route.ts";
+import { resolveConnectorHealthIntervalMs } from "./connector-health.ts";
 import { handlePluginDirectoryRoutes } from "./plugin-directory-routes.ts";
 
 // `@elizaos/plugin-browser` and `@elizaos/plugin-x402` load lazily: X402 only
@@ -3500,6 +3501,12 @@ export async function startApiServer(opts?: {
       : resolveServerOnlyPort(process.env));
   const host = resolveApiBindHost(process.env);
   ensureApiTokenForBindHost(host);
+  // Resolve owner configuration before any HTTP server is created or bound.
+  // The monitor itself starts later, but its deferred catch must never turn a
+  // malformed interval into a healthy-looking default.
+  const connectorHealthIntervalMs = resolveConnectorHealthIntervalMs(
+    process.env.CONNECTOR_HEALTH_INTERVAL_MS,
+  );
   logger.debug(`[eliza-api] Token check done (${Date.now() - apiStartTime}ms)`);
 
   let config: ElizaConfig;
@@ -3897,6 +3904,7 @@ export async function startApiServer(opts?: {
           runtime: state.runtime,
           config: state.config,
           broadcastWs,
+          intervalMs: connectorHealthIntervalMs,
         });
         state.connectorHealthMonitor.start();
       } catch (err) {


### PR DESCRIPTION
## Summary

- validate `CONNECTOR_HEALTH_INTERVAL_MS` as an exact canonical decimal integer before API readiness or TCP bind
- reject configured malformed, non-canonical, unsafe, and out-of-range values with fatal typed `ElizaError` code `CONNECTOR_HEALTH_INTERVAL_INVALID`
- pass the already-validated interval into deferred connector-health startup so its boundary catch cannot hide configuration parsing failures
- add a real Bun subprocess regression proving malformed configuration rejects while the requested port remains unbound

This deliberately removes permissive `parseInt`/fallback behavior. The default remains only for unset or empty configuration; configured invalid input fails fast.

Closes #19583.

## Validation

- exact head `aa1ff5322e9e9530a39ac226df4ee7a41ed2148d`
- `bun install` — 3,822 workspace installs checked; artifact bundle present
- focused connector/startup contract — 26/26 pass, including real Bun bind/no-bind control
- agent typecheck — pass
- agent lint — 887 files clean
- guide parity — 153/153 pairs
- `git diff --check` — pass
- exhaustive prior exact revision: full agent lane 403/403 and root verification 350/350 plus all audits

The latest exact root attempt reaches an unrelated cloud typecheck regression introduced by #19668: its new canonical persona emits `{ user, content }` message examples while the existing Cloud `ElizaCharacter` boundary requires `{ name, content }`. Exact reproduction is recorded on [#19668](https://github.com/elizaOS/eliza/pull/19668#issuecomment-5300076925). This PR does not suppress or absorb that separate failure.

## Evidence

<!-- evidence-head:aa1ff5322e9e9530a39ac226df4ee7a41ed2148d -->

| Evidence | Result |
| --- | --- |
| Before screenshots | N/A — backend startup/configuration boundary only |
| After screenshots | N/A — backend startup/configuration boundary only |
| MP4 walkthrough | N/A — no interactive surface |
| Backend logs | Attached through the repository evidence workflow |
| Frontend console/network logs | N/A — no frontend execution |
| Live-model trajectory | N/A — no model behavior |
| Domain artifact | Attached through the repository evidence workflow |
| OCR | N/A — no visual text |

# Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend startup/configuration boundary only

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend startup/configuration boundary only

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive surface

<!-- evidence-row:backend-logs -->
- [x] [19750-eliza-19583-backend-v1.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19750-eliza-19583-backend-v1.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend execution

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model behavior

<!-- evidence-row:domain-artifacts -->
- [x] [19750-eliza-19583-domain-v1.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19750-eliza-19583-domain-v1.txt)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual text

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->

