### PR TITLE
fix(cloud): unblock first realtime voice response

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/voice-agent-scope-hydration.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/voice-agent-scope-hydration.test.ts
@@ -135,6 +135,32 @@ test("publishes the authorization scope even when the character prefill fails", 
   });
 });
 
+test("publishes the authorization scope before optional admission prefill completes", async () => {
+  let resolveAdmission: () => void = () => {};
+  warmInferenceAdmissionSnapshot.mockImplementationOnce(
+    () =>
+      new Promise<undefined>((resolve) => {
+        resolveAdmission = () => resolve(undefined);
+      }),
+  );
+
+  await runWithCloudBindingsAsync(env, async () => {
+    const hydration = hydrateVoiceSharedAgentScope(
+      env as unknown as Parameters<typeof hydrateVoiceSharedAgentScope>[0],
+      claims,
+    );
+
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      if (await cache.get(SCOPE_KEY)) break;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    expect(await cache.get(SCOPE_KEY)).toMatchObject({ id: AGENT_ID });
+
+    resolveAdmission();
+    await hydration;
+  });
+});
+
 test("does not overwrite an already-warm character entry", async () => {
   await runWithCloudBindingsAsync(env, async () => {
     await cache.set(CHARACTER_KEY, { id: CHARACTER_ID, name: "Existing" }, 60);

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -810,13 +810,10 @@ describe("voice-session WS lifecycle", () => {
     expect(prewarmCalls).toBe(1);
   });
 
-  test("first response joins prewarm and an interruption discards the obsolete turn", async () => {
-    let resolvePrewarm: () => void = () => {};
-    const prewarm = new Promise<void>((resolve) => {
-      resolvePrewarm = resolve;
-    });
+  test("first response does not wait for latency-only prewarm", async () => {
+    const prewarm = new Promise<void>(() => undefined);
     const requestTexts: string[] = [];
-    const successFetch = makeSseFetch(["Replacement response."]);
+    const successFetch = makeSseFetch(["Immediate response."]);
     const client = new FakeClientSocket();
     await connectSession({
       client,
@@ -831,20 +828,11 @@ describe("voice-session WS lifecycle", () => {
     const ttsBefore = FakeCartesiaSocket.instances.length;
 
     ink.emitTurn("turn.start");
-    ink.emitTurn("turn.end", "obsolete first request");
+    ink.emitTurn("turn.end", "first request");
+    await flush();
     await flush();
     expect(FakeCartesiaSocket.instances.length).toBe(ttsBefore + 1);
-    expect(requestTexts).toEqual([]);
-
-    ink.emitTurn("turn.start");
-    ink.emitTurn("turn.end", "replacement request");
-    await flush();
-    expect(requestTexts).toEqual([]);
-
-    resolvePrewarm();
-    await flush();
-    await flush();
-    expect(requestTexts).toEqual(["replacement request"]);
+    expect(requestTexts).toEqual(["first request"]);
     expect(client.controlTypes()).toContain("llm_first_text");
   });
 

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -229,7 +229,6 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
   private lastSttPartialSentAtMs = Number.NEGATIVE_INFINITY;
   private sttPartialTimer: ReturnType<typeof setTimeout> | null = null;
   private llmAbort: AbortController | null = null;
-  private elizaPrewarm: Promise<void> | null = null;
   private phrase: PhraseAggregator | null = null;
   private turnSttMs = 0;
   private turnTtsChars = 0;
@@ -326,10 +325,11 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
 
     this.state = "listening";
     // Read immutable tenancy from cache while the user is beginning to speak.
-    // A miss schedules authoritative hydration under the Worker lifetime; the
-    // first turn joins that work so it does not burn time polling a cold cache.
+    // A miss schedules authoritative hydration under the Worker lifetime. This
+    // is a latency hint only: the response path has its own typed cache-warming
+    // retries and must never wait indefinitely for optional background fills.
     if (this.config.prewarmElizaContext) {
-      this.elizaPrewarm = this.config.prewarmElizaContext().catch((error) => {
+      void this.config.prewarmElizaContext().catch((error) => {
         // error-policy:J7 prewarm is latency-only; the response path retains
         // its typed cache-warming retry fallback and reports the failed hint.
         logger.warn("[voice-session] Eliza context prewarm failed", {
@@ -885,13 +885,6 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       // turn does not await readiness because outbound phrases queue in the
       // adapter, so consume that designed rejection on fast teardown.
       void prewarmedTts.opened.catch(() => undefined);
-
-      const elizaPrewarm = this.elizaPrewarm;
-      if (elizaPrewarm) {
-        await elizaPrewarm;
-        if (this.elizaPrewarm === elizaPrewarm) this.elizaPrewarm = null;
-        if (abort.signal.aborted || this.currentVoiceTurnId !== traceId) return;
-      }
 
       const request = {
         endpoint: this.config.elizaEndpoint,

--- a/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
+++ b/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
@@ -67,8 +67,20 @@ export async function hydrateVoiceSharedAgentScope(
           await cache.set(cacheKey, character, CacheTTL.agent.characterData);
         };
 
-        // The scope entry is the authorization gate: never let an optional
-        // character prefill failure prevent it from being written.
+        // Publish the authorization gate as soon as the authoritative agent
+        // lookup succeeds. Character and admission prefills are latency hints;
+        // keeping this write behind either one turns a slow optional dependency
+        // into the full 503/backoff staircase on the caller's first response.
+        await cache.set(
+          CacheKeys.sharedAgentScope.voice(
+            claims.organizationId,
+            claims.userId,
+            claims.agentId,
+          ),
+          agent,
+          CacheTTL.sharedAgentScope.resolve,
+        );
+
         // error-policy:J7 a failed character prefill leaves the next turn on
         // its existing retryable warming path rather than failing hydration.
         await Promise.all([
@@ -91,16 +103,6 @@ export async function hydrateVoiceSharedAgentScope(
             },
           ),
         ]);
-
-        await cache.set(
-          CacheKeys.sharedAgentScope.voice(
-            claims.organizationId,
-            claims.userId,
-            claims.agentId,
-          ),
-          agent,
-          CacheTTL.sharedAgentScope.resolve,
-        );
       }),
   );
 }


### PR DESCRIPTION
Hotfix promotion of #19756 (already merged to develop).

Production trace showed an ~8s internal conversation request caused by cache-warming 503 retries. This makes session prewarm non-blocking and publishes verified voice scope before optional prefills.

Verified: 62 focused voice tests pass; cloud API typecheck and production Worker dry-run bundle pass; changed files pass Biome.