### PR TITLE
fix(android): isolate fused cross-build dependencies

### DIFF
--- a/packages/app-core/scripts/aosp/compile-libllama.mjs
+++ b/packages/app-core/scripts/aosp/compile-libllama.mjs
@@ -1589,6 +1589,11 @@ export function buildLibllamaForAbi({
       // throughput win.
       "-DLLAMA_BUILD_SERVER=ON",
       "-DLLAMA_CURL=OFF",
+      // Cross-builds must not discover host OpenSSL or espeak-ng archives.
+      // Android uses localhost HTTP, and the app supplies IPA when Kokoro
+      // reports its built-in ASCII fallback.
+      "-DLLAMA_OPENSSL=OFF",
+      "-DKOKORO_ENABLE_ESPEAK=OFF",
       `-DCMAKE_C_COMPILER=${ccPath}`,
       `-DCMAKE_CXX_COMPILER=${cxxPath}`,
       // Archive ELF objects with zig's llvm-ar/ranlib. The host default
@@ -2447,6 +2452,8 @@ export function describeAndroidTargetDryRun({
     "-DLLAMA_BUILD_TESTS=OFF",
     "-DLLAMA_BUILD_SERVER=ON",
     "-DLLAMA_CURL=OFF",
+    "-DLLAMA_OPENSSL=OFF",
+    "-DKOKORO_ENABLE_ESPEAK=OFF",
     `-DCMAKE_C_COMPILER=${ccPath}`,
     `-DCMAKE_CXX_COMPILER=${cxxPath}`,
     `-DCMAKE_AR=${arPath}`,

--- a/packages/app-core/scripts/aosp/compile-libllama.test.mjs
+++ b/packages/app-core/scripts/aosp/compile-libllama.test.mjs
@@ -203,6 +203,8 @@ describe("compile-libllama Zig driver generation", () => {
     expect(output).toContain(
       `-DCMAKE_RANLIB=${path.join(driverDir, "zig-ranlib")}`,
     );
+    expect(output).toContain("-DLLAMA_OPENSSL=OFF");
+    expect(output).toContain("-DKOKORO_ENABLE_ESPEAK=OFF");
     expect(output).toContain("ggml-vulkan");
     expect(output).toContain("static marker in libelizainference.so");
   });


### PR DESCRIPTION
# Relates to

Closes #19741.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run; the earlier full verify failure is recorded below as an unrelated pre-rebase baseline blocker.
- [x] A reviewer can confirm the change from the native build and focused-test evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/GPT-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a0aac335269944cc2aef1e12991ad7605acdb56f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop`; zero conflicts.
- [x] Focused tests and formatting pass post-sync. The full-verification limitation is documented below.

# Risks

Low. The change only disables host OpenSSL and espeak discovery for Android/musl fused cross-builds. Android speech remains provided by the fused in-process OmniVoice/Kokoro implementation in `libelizainference.so`.

# Background

## What does this PR do?

It prevents CMake from finding macOS/Linux host OpenSSL or espeak libraries while cross-compiling Android and musl fused inference targets. Those host libraries cannot be linked into target binaries and previously made otherwise valid Android builds fail.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is required; this corrects cross-build configuration without changing the supported command or artifact contract.

# Testing

## Where should a reviewer start?

Review `packages/app-core/scripts/aosp/compile-libllama.mjs` and its adjacent test.

## Detailed testing steps

1. Run `bun test ./packages/app-core/scripts/aosp/compile-libllama.test.mjs`.
2. Run the Android fused compiler with Zig 0.13 and an Android arm64 assets directory.
3. Confirm `libelizainference.so` and `llama-server` are emitted and the fused symbol verifier succeeds.

# Evidence Gate

<!-- evidence-head:a0aac335269944cc2aef1e12991ad7605acdb56f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - build-only CMake configuration change with no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - build-only CMake configuration change with no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow changed.
<!-- evidence-row:backend-logs -->
- [x] [19761-pr19761-backend-log-v4.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19761-pr19761-backend-log-v4.txt)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, response, or state path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [19761-pr19761-domain-artifacts-v4.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19761-pr19761-domain-artifacts-v4.txt)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

The exact PR head completed the real `android-arm64-vulkan-fused` compiler path using Zig 0.13 and external llama.cpp sources. It produced both target artifacts and passed fused-symbol verification (`llama=231`, `omnivoice=12`, `abi=38`). Focused tests pass: 12 tests, 0 failures. Biome and `git diff --check` also pass.

## Screenshots (before / after) + video walkthrough

N/A - build-only change with no rendered UI.

## Audio / voice walkthrough

N/A - this changes cross-link dependency selection, not runtime audio behavior. The fused library's OmniVoice symbols are verified in the native output.

## Known gaps / failures

- No Android device or emulator boot is claimed by this narrow upstream fix. The downstream elizaOS build separately consumed the artifacts into a privileged Android APK; boot evidence belongs to the OS integration lane.
- A full `bun run verify` was attempted before the final rebase and stopped on an unrelated baseline missing `packages/cloud/api/auth/anonymous-session-config.ts`; latest `develop` now contains that file. Post-rebase focused tests, Biome, diff checks, and the exact-head native cross-build are green.
- `llama-server` reports that its voice route is a dead mount; this is pre-existing and harmless for Android because in-process `libelizainference.so` handles TTS.

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@a0aac335269944cc2aef1e12991ad7605acdb56f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-android-os]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"GPT-5","client":"Codex desktop","skill_revision":"elizaOS/eliza@a0aac335269944cc2aef1e12991ad7605acdb56f:packages/skills/skills/contribute-to-eliza"} -->