### PR TITLE
fix(agent): preserve provider field ordering

### DIFF
--- a/packages/agent/src/runtime/trajectory-internals.ts
+++ b/packages/agent/src/runtime/trajectory-internals.ts
@@ -3586,7 +3586,19 @@ function normalizeStepForPersistence(
     access: PersistedProviderAccess,
     index: number,
   ): PersistedProviderAccess => {
-    const bounded = snapshotCaptureParams({ ...access }, step.stepId);
+    const { providerId, providerName, timestamp, purpose, data, ...extras } =
+      access;
+    const bounded = snapshotCaptureParams(
+      {
+        providerId,
+        providerName,
+        timestamp,
+        purpose,
+        data,
+        ...extras,
+      },
+      step.stepId,
+    );
     return parsePersistedProviderAccess(
       bounded,
       trajectoryId,

--- a/packages/agent/src/runtime/trajectory-steps.test.ts
+++ b/packages/agent/src/runtime/trajectory-steps.test.ts
@@ -494,6 +494,30 @@ describe("trajectory_steps dedicated table", () => {
     });
   });
 
+  it("persists data-first provider records without starving required fields", async () => {
+    const trajectory = createBaseTrajectory(
+      trajectoryId,
+      1_700_000_000_000,
+      runtime.agentId,
+      "test",
+    );
+    trajectory.steps[0]?.providerAccesses.push({
+      data: { payload: "x".repeat(1_100_000) },
+      providerId: "provider-budget",
+      providerName: "KNOWLEDGE",
+      timestamp: 1_700_000_000_000,
+      purpose: "Provider KNOWLEDGE accessed for context",
+    });
+
+    await expect(saveTrajectory(runtime, trajectory)).resolves.toBe(true);
+    const loaded = await loadTrajectoryById(runtime, trajectoryId);
+    expect(loaded?.steps[0]?.providerAccesses[0]).toMatchObject({
+      providerId: "provider-budget",
+      providerName: "KNOWLEDGE",
+      purpose: "Provider KNOWLEDGE accessed for context",
+    });
+  });
+
   it("rejects malformed SQL result containers instead of reporting empty reads or deletes", async () => {
     type MalformedDb = {
       execute: () => Promise<Record<string, never>>;


### PR DESCRIPTION
## Relates to

Closes #19724.

## Summary

- preserves required provider identity, timestamp, and purpose fields before optional payload data when trajectory rows are byte-budgeted
- adds a mutation-sensitive persistence regression for a 1.1 MB data-first provider record
- contains no Cloud or UI changes; the Cloud persona fix was independently merged on `develop` and removed before this PR merged

## Risks

Low. The change only canonicalizes provider-record field order at the existing persistence budget boundary. The regression verifies save/load behavior and required-field survival.

## Verification

Merged commit: `f95e2b8643c0eb74c7515407737fcfd5c1a857ca`
Post-merge verified develop revision: `e21e3e2a18c1e1366c74bb0e56fea2774c261b58`

- `bun run verify` — 350/350 workspace tasks plus every repository audit passed
- trajectory persistence and bridge suites — 44/44 passed
- Smithers workflow package — 14/14 isolated files, 85/85 tests passed
- real local Chromium Smithers journey — created, triggered, ran, inspected, and reloaded a workflow; 1/1 passed

## Evidence Gate

<!-- evidence-head:47f8ad7814b206971f31bc106667c3fd6f7a34b4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A — no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A — no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — no user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [x] Deterministic persistence round-trip and full repository verification are recorded above.
<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no model decision, prompt, provider invocation, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] The regression reloads the persisted trajectory and asserts provider identity and purpose.
<!-- evidence-row:ocr-review -->
- [x] N/A — no visual surface changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-post-merge-evidence]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->