### PR TITLE
fix(cloud): fair oldest-first backup sweep, snapshot-capability tracking, and local-state staleness alerting (#15783 Phase 0/1)

### DIFF
--- a/packages/cloud/shared/src/db/ensure-agent-sandbox-schema.ts
+++ b/packages/cloud/shared/src/db/ensure-agent-sandbox-schema.ts
@@ -36,7 +36,9 @@ async function runEnsureAgentSandboxSchema(): Promise<void> {
       ADD COLUMN IF NOT EXISTS "replacement_cleanup_allocation_counted" boolean,
       ADD COLUMN IF NOT EXISTS "replacement_cleanup_created_at" timestamptz,
       ADD COLUMN IF NOT EXISTS "previous_image_digest" text,
-      ADD COLUMN IF NOT EXISTS "previous_docker_image" text
+      ADD COLUMN IF NOT EXISTS "previous_docker_image" text,
+      ADD COLUMN IF NOT EXISTS "last_backup_attempt_at" timestamptz,
+      ADD COLUMN IF NOT EXISTS "backup_unsupported_reason" text
   `);
 
   await dbWrite.execute(sql`

--- a/packages/cloud/shared/src/db/migrations/0200_agent_backup_attempt_tracking.sql
+++ b/packages/cloud/shared/src/db/migrations/0200_agent_backup_attempt_tracking.sql
@@ -1,0 +1,19 @@
+-- Backup sweep fairness + capability tracking (#15783 Phase 1).
+--
+-- `last_backup_at` is success-only (bumping it on a failed or skipped capture
+-- would mask staleness), so a snapshot-incapable agent image — one that 404s
+-- POST /api/snapshot (SNAPSHOT_ENDPOINT_UNSUPPORTED) — stays perpetually
+-- "due" and permanently competes for the scheduled sweep's capped window,
+-- nondeterministically starving backup-capable agents.
+--
+-- `last_backup_attempt_at` records every auto-snapshot attempt regardless of
+-- outcome; `backup_unsupported_reason` marks rows whose image cannot serve a
+-- snapshot so the sweep can re-probe them at a slow cadence instead of every
+-- tick. Both are metadata-only nullable ADDs, safe on a hot table.
+--
+-- ensure-agent-sandbox-schema.ts carries the same ADD COLUMN IF NOT EXISTS
+-- lines, so readers deployed ahead of this migration self-heal on first
+-- repository access.
+ALTER TABLE "agent_sandboxes"
+  ADD COLUMN IF NOT EXISTS "last_backup_attempt_at" timestamptz,
+  ADD COLUMN IF NOT EXISTS "backup_unsupported_reason" text;

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1394,6 +1394,13 @@
       "when": 1786910400000,
       "tag": "0199_personal_account_convergence_receipts",
       "breakpoints": true
+    },
+    {
+      "idx": 199,
+      "version": "7",
+      "when": 1786996800000,
+      "tag": "0200_agent_backup_attempt_tracking",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
@@ -152,6 +152,23 @@ export const agentSandboxes = pgTable(
     database_error: text("database_error"),
     snapshot_id: text("snapshot_id"),
     last_backup_at: timestamp("last_backup_at", { withTimezone: true }),
+    /**
+     * When a scheduled snapshot last ATTEMPTED to capture this agent —
+     * success, failure, or capability skip. `last_backup_at` stays
+     * success-only so staleness detection remains honest; this column exists
+     * so the sweep can distinguish "never tried" from "tried and cannot"
+     * (#15783 Phase 1).
+     */
+    last_backup_attempt_at: timestamp("last_backup_attempt_at", { withTimezone: true }),
+    /**
+     * Set when the last auto snapshot attempt was skipped because the agent
+     * image does not serve `POST /api/snapshot` (the
+     * SNAPSHOT_ENDPOINT_UNSUPPORTED sentinel). Cleared on any successful
+     * snapshot. While set, the scheduled sweep only re-probes the row at a
+     * slow cadence instead of letting it permanently occupy the capped
+     * due-set window and starve backup-capable agents (#15783).
+     */
+    backup_unsupported_reason: text("backup_unsupported_reason"),
     last_heartbeat_at: timestamp("last_heartbeat_at", { withTimezone: true }),
     error_message: text("error_message"),
     error_count: integer("error_count").notNull().default(0),

--- a/packages/cloud/shared/src/lib/services/__tests__/tier-upgrade-pglite-schema.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/tier-upgrade-pglite-schema.ts
@@ -184,6 +184,8 @@ export const PROVISIONING_JOB_TEST_TABLES: readonly string[] = [
   "database_error" text,
   "snapshot_id" text,
   "last_backup_at" timestamptz,
+  "last_backup_attempt_at" timestamptz,
+  "backup_unsupported_reason" text,
   "last_heartbeat_at" timestamptz,
   "error_message" text,
   "error_count" integer NOT NULL DEFAULT 0,

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts
@@ -70,6 +70,9 @@ interface SeedOpts {
   poolStatus?: string | null;
   lastBackupAt?: Date | null;
   lastHeartbeatAt?: Date | null;
+  lastBackupAttemptAt?: Date | null;
+  backupUnsupportedReason?: string | null;
+  environmentVars?: Record<string, string>;
 }
 
 async function seedSandbox(opts: SeedOpts = {}): Promise<string> {
@@ -87,6 +90,9 @@ async function seedSandbox(opts: SeedOpts = {}): Promise<string> {
       pool_status: (opts.poolStatus ?? null) as never,
       last_backup_at: opts.lastBackupAt ?? null,
       last_heartbeat_at: opts.lastHeartbeatAt ?? null,
+      last_backup_attempt_at: opts.lastBackupAttemptAt ?? null,
+      backup_unsupported_reason: opts.backupUnsupportedReason ?? null,
+      environment_vars: opts.environmentVars ?? {},
     })
     .returning();
   return sandbox.id;
@@ -141,7 +147,7 @@ describe("enqueueScheduledBackups — sentinel-bridge exclusion (#15737)", () =>
 
     // Both rows are `running` with a non-null bridge_url; only the reachable one
     // survives the scan predicate and gets a real `agent_snapshot` job row.
-    expect(res).toEqual({ scanned: 1, enqueued: 1 });
+    expect(res).toMatchObject({ scanned: 1, enqueued: 1 });
 
     const reachableJobs = await snapshotJobsFor(reachableId);
     expect(reachableJobs).toHaveLength(1);
@@ -158,7 +164,7 @@ describe("enqueueScheduledBackups — sentinel-bridge exclusion (#15737)", () =>
 
     const res = await provisioningJobService.enqueueScheduledBackups();
 
-    expect(res).toEqual({ scanned: 0, enqueued: 0 });
+    expect(res).toMatchObject({ scanned: 0, enqueued: 0 });
     for (const id of [a, b, c]) {
       expect(await snapshotJobsFor(id)).toHaveLength(0);
     }
@@ -173,7 +179,7 @@ describe("enqueueScheduledBackups — eligibility predicate", () => {
 
     const res = await provisioningJobService.enqueueScheduledBackups();
 
-    expect(res).toEqual({ scanned: 1, enqueued: 1 });
+    expect(res).toMatchObject({ scanned: 1, enqueued: 1 });
     expect(await snapshotJobsFor(running)).toHaveLength(1);
     expect(await snapshotJobsFor(sleeping)).toHaveLength(0);
     expect(await snapshotJobsFor(pending)).toHaveLength(0);
@@ -185,7 +191,7 @@ describe("enqueueScheduledBackups — eligibility predicate", () => {
 
     const res = await provisioningJobService.enqueueScheduledBackups();
 
-    expect(res).toEqual({ scanned: 1, enqueued: 1 });
+    expect(res).toMatchObject({ scanned: 1, enqueued: 1 });
     expect(await snapshotJobsFor(owned)).toHaveLength(1);
     expect(await snapshotJobsFor(warm)).toHaveLength(0);
   });
@@ -196,7 +202,7 @@ describe("enqueueScheduledBackups — eligibility predicate", () => {
 
     const res = await provisioningJobService.enqueueScheduledBackups();
 
-    expect(res).toEqual({ scanned: 1, enqueued: 1 });
+    expect(res).toMatchObject({ scanned: 1, enqueued: 1 });
     expect(await snapshotJobsFor(bridged)).toHaveLength(1);
     expect(await snapshotJobsFor(bridgeless)).toHaveLength(0);
   });
@@ -212,7 +218,7 @@ describe("enqueueScheduledBackups — eligibility predicate", () => {
 
     const res = await provisioningJobService.enqueueScheduledBackups({ minIntervalMs });
 
-    expect(res).toEqual({ scanned: 2, enqueued: 2 });
+    expect(res).toMatchObject({ scanned: 2, enqueued: 2 });
     expect(await snapshotJobsFor(neverBackedUp)).toHaveLength(1);
     expect(await snapshotJobsFor(staleBackup)).toHaveLength(1);
     expect(await snapshotJobsFor(freshBackup)).toHaveLength(0);
@@ -238,12 +244,12 @@ describe("enqueueScheduledBackups — enqueue behavior", () => {
     const agentId = await seedSandbox({ bridgeUrl: REACHABLE_BRIDGE });
 
     const first = await provisioningJobService.enqueueScheduledBackups();
-    expect(first).toEqual({ scanned: 1, enqueued: 1 });
+    expect(first).toMatchObject({ scanned: 1, enqueued: 1 });
 
     // The row is still due (last_backup_at unchanged) and the snapshot job is
     // still pending, so in-flight idempotency must reuse it — one job row total.
     const second = await provisioningJobService.enqueueScheduledBackups();
-    expect(second).toEqual({ scanned: 1, enqueued: 1 });
+    expect(second).toMatchObject({ scanned: 1, enqueued: 1 });
 
     expect(await snapshotJobsFor(agentId)).toHaveLength(1);
   });
@@ -939,5 +945,90 @@ describe("enqueueAgent*Once — real lifecycle-job inserts", () => {
         userId,
       }),
     ).rejects.toThrow("Agent not found");
+  });
+});
+
+describe("enqueueScheduledBackups — sweep fairness + capability tracking (#15783)", () => {
+  const HOUR = 60 * 60 * 1000;
+
+  test("the capped window is ordered oldest-successful-backup-first, never-backed-up leading", async () => {
+    const neverBacked = await seedSandbox({ lastBackupAt: null });
+    const oldest = await seedSandbox({ lastBackupAt: new Date(Date.now() - 48 * HOUR) });
+    const newerButDue = await seedSandbox({ lastBackupAt: new Date(Date.now() - 7 * HOUR) });
+
+    const res = await provisioningJobService.enqueueScheduledBackups({ maxAgents: 2 });
+
+    // Cap of 2 must take the NULL row and the 48h row; the merely-7h-stale row
+    // waits for the next tick instead of a planner-order lottery.
+    expect(res).toMatchObject({ scanned: 2, enqueued: 2 });
+    expect(await snapshotJobsFor(neverBacked)).toHaveLength(1);
+    expect(await snapshotJobsFor(oldest)).toHaveLength(1);
+    expect(await snapshotJobsFor(newerButDue)).toHaveLength(0);
+  });
+
+  test("snapshot-incapable rows stop competing for the window until their slow re-probe", async () => {
+    // An unsupported population AT the cap used to be able to consume the
+    // whole window every tick, starving the one healthy agent indefinitely.
+    const healthy = await seedSandbox({ lastBackupAt: new Date(Date.now() - 7 * HOUR) });
+    const unsupportedRecentProbe = [] as string[];
+    for (let i = 0; i < 2; i++) {
+      unsupportedRecentProbe.push(
+        await seedSandbox({
+          lastBackupAt: null,
+          backupUnsupportedReason: "Snapshot endpoint not supported by agent image",
+          lastBackupAttemptAt: new Date(Date.now() - 1 * HOUR),
+        }),
+      );
+    }
+
+    const res = await provisioningJobService.enqueueScheduledBackups({ maxAgents: 2 });
+
+    expect(res).toMatchObject({ scanned: 1, enqueued: 1 });
+    expect(await snapshotJobsFor(healthy)).toHaveLength(1);
+    for (const id of unsupportedRecentProbe) {
+      expect(await snapshotJobsFor(id)).toHaveLength(0);
+    }
+  });
+
+  test("a snapshot-incapable row is re-probed once its last attempt ages past the recheck interval", async () => {
+    const stalledProbe = await seedSandbox({
+      lastBackupAt: null,
+      backupUnsupportedReason: "Snapshot endpoint not supported by agent image",
+      lastBackupAttemptAt: new Date(Date.now() - 25 * HOUR),
+    });
+
+    const res = await provisioningJobService.enqueueScheduledBackups();
+
+    // Default recheck is 24h; a 25h-old attempt re-enters the due set so an
+    // image upgrade is noticed within one recheck interval.
+    expect(res).toMatchObject({ scanned: 1, enqueued: 1 });
+    expect(await snapshotJobsFor(stalledProbe)).toHaveLength(1);
+  });
+
+  test("the fleet report measures route-less, incapable, never-backed-up, and stale local-state populations", async () => {
+    await seedSandbox({ bridgeUrl: null }); // route-less
+    await seedSandbox({
+      backupUnsupportedReason: "Snapshot endpoint not supported by agent image",
+      lastBackupAttemptAt: new Date(),
+    }); // incapable, never backed up
+    await seedSandbox({
+      environmentVars: { ELIZA_AGENT_LOCAL_STATE: "1" },
+      lastBackupAt: new Date(Date.now() - 48 * HOUR),
+    }); // local-state, stale
+    await seedSandbox({
+      environmentVars: { ELIZA_AGENT_LOCAL_STATE: "1" },
+      lastBackupAt: new Date(Date.now() - 1 * HOUR),
+    }); // local-state, fresh
+
+    const res = await provisioningJobService.enqueueScheduledBackups();
+
+    expect(res.fleet).toMatchObject({
+      running: 4,
+      routeless: 1,
+      snapshotUnsupported: 1,
+      neverBackedUp: 2,
+      localState: 2,
+      localStateStale: 1,
+    });
   });
 });

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -104,6 +104,7 @@ import {
   JOB_TYPES,
   type ProvisioningJobType,
 } from "./provisioning-job-types";
+import { sendProvisioningWorkerAlert } from "./provisioning-worker-health-monitor";
 import {
   isWaifuWebhookTargetUrl,
   resolveWaifuWebhookTarget,
@@ -114,6 +115,33 @@ import {
   type WakeRestoreIntegrityFailure,
 } from "./wake-restore-integrity";
 import { hasReadyWarmClaimCredential } from "./warm-claim-key-push";
+
+/**
+ * Phase 0 fleet measurement emitted by every scheduled-backup sweep (#15783):
+ * of the running non-pool fleet, how many rows are route-less (no bridge or
+ * the loopback sentinel), snapshot-incapable (image 404s POST /api/snapshot),
+ * never backed up, or older than the staleness threshold — split out for
+ * local-state agents, whose whole state lives on one node's disk.
+ */
+export interface ScheduledBackupFleetReport {
+  running: number;
+  routeless: number;
+  snapshotUnsupported: number;
+  neverBackedUp: number;
+  staleBackup: number;
+  localState: number;
+  localStateStale: number;
+}
+
+const EMPTY_SCHEDULED_BACKUP_FLEET_REPORT: ScheduledBackupFleetReport = {
+  running: 0,
+  routeless: 0,
+  snapshotUnsupported: 0,
+  neverBackedUp: 0,
+  staleBackup: 0,
+  localState: 0,
+  localStateStale: 0,
+};
 
 // ---------------------------------------------------------------------------
 // Job data shapes (hydrated from object storage when jobs.data is offloaded)
@@ -2650,20 +2678,84 @@ export class ProvisioningJobService {
   }
 
   /**
+   * Stamp `last_backup_attempt_at` and set/clear `backup_unsupported_reason`
+   * after a snapshot capture attempt (#15783). Best-effort bookkeeping: a
+   * marker write failure must not fail (or retry) the snapshot job itself —
+   * the markers only tune sweep fairness and staleness measurement, and the
+   * next attempt rewrites them.
+   */
+  private async recordSnapshotAttemptMarkers(
+    agentId: string,
+    outcome: "success" | "unsupported" | "other",
+  ): Promise<void> {
+    try {
+      await dbWrite
+        .update(agentSandboxes)
+        .set({
+          last_backup_attempt_at: new Date(),
+          // "other" failures (agent not running, transport blip) neither prove
+          // nor disprove snapshot capability — leave the marker as it stands.
+          ...(outcome === "unsupported"
+            ? { backup_unsupported_reason: SNAPSHOT_ENDPOINT_UNSUPPORTED }
+            : {}),
+          ...(outcome === "success" ? { backup_unsupported_reason: null } : {}),
+        })
+        .where(eq(agentSandboxes.id, agentId));
+    } catch (error) {
+      // error-policy:J7 attempt-marker bookkeeping must not kill the snapshot
+      // job; the condition it records is re-observed on the next attempt.
+      logger.warn("[provisioning-jobs] failed to record snapshot attempt markers", {
+        agentId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  /**
    * Scan running agents and enqueue an `auto` snapshot for any whose last
    * backup is older than `minIntervalMs` (or who have never been backed up).
    * Drives the scheduled-backups cron. Per-agent dedup is handled by the
    * snapshot job's in-flight idempotency, so overlapping ticks are safe.
    * Warm-pool rows (`pool_status IS NOT NULL`) are excluded — they have no
    * user state worth backing up.
+   *
+   * Fairness (#15783): the due set is ordered oldest-successful-backup-first
+   * (never-backed-up rows first), so a due population larger than `maxAgents`
+   * degrades to round-robin-by-staleness instead of planner-dependent
+   * starvation. Rows marked snapshot-incapable (`backup_unsupported_reason`,
+   * set when the agent image 404s POST /api/snapshot) are re-probed only
+   * every `unsupportedRecheckMs` instead of consuming the capped window on
+   * every tick; `last_backup_at` stays success-only throughout so staleness
+   * measurement remains honest.
+   *
+   * The returned `fleet` block is the Phase 0 measurement: how much of the
+   * running non-pool fleet is route-less, snapshot-incapable, never backed
+   * up, or stale — and how many LOCAL-STATE agents (whose entire DB lives on
+   * one node's disk) currently have no backup younger than the staleness
+   * threshold. A non-zero local-state count triggers the ops staleness alert.
    */
   async enqueueScheduledBackups(params?: {
     minIntervalMs?: number;
     maxAgents?: number;
-  }): Promise<{ scanned: number; enqueued: number }> {
+    /** How often a snapshot-incapable row is re-probed. Default 24h. */
+    unsupportedRecheckMs?: number;
+    /**
+     * Age past which a running agent's newest successful backup counts as
+     * stale for alerting. Default 4× `minIntervalMs` (24h at the 6h cadence).
+     */
+    staleAfterMs?: number;
+  }): Promise<{
+    scanned: number;
+    enqueued: number;
+    fleet: ScheduledBackupFleetReport;
+  }> {
     const minIntervalMs = params?.minIntervalMs ?? 6 * 60 * 60 * 1000; // 6h
     const maxAgents = params?.maxAgents ?? 200;
+    const unsupportedRecheckMs = params?.unsupportedRecheckMs ?? 24 * 60 * 60 * 1000;
+    const staleAfterMs = params?.staleAfterMs ?? 4 * minIntervalMs;
     const cutoff = new Date(Date.now() - minIntervalMs);
+    const unsupportedRecheckCutoff = new Date(Date.now() - unsupportedRecheckMs);
+    const staleCutoff = new Date(Date.now() - staleAfterMs);
 
     const due = await dbWrite
       .select({
@@ -2687,9 +2779,50 @@ export class ProvisioningJobService {
           // URL is the loopback sentinel, so it must never be re-enqueued.
           ne(agentSandboxes.bridge_url, UNREACHABLE_BRIDGE_SENTINEL),
           sql`(${agentSandboxes.last_backup_at} IS NULL OR ${agentSandboxes.last_backup_at} < ${cutoff})`,
+          // A row whose image proved snapshot-incapable is only re-probed at
+          // the slow recheck cadence, so it cannot permanently occupy the
+          // capped window (#15783 starvation, worst case 3). An image upgrade
+          // is still noticed within one recheck interval, and any successful
+          // snapshot clears the marker immediately.
+          sql`(${agentSandboxes.backup_unsupported_reason} IS NULL OR ${agentSandboxes.last_backup_attempt_at} IS NULL OR ${agentSandboxes.last_backup_attempt_at} < ${unsupportedRecheckCutoff})`,
         ),
       )
+      // Oldest successful backup first; rows that have NEVER been backed up
+      // lead. Attempt time tiebreaks so equally-stale rows rotate instead of
+      // repeating in planner order.
+      .orderBy(
+        sql`${agentSandboxes.last_backup_at} ASC NULLS FIRST`,
+        sql`${agentSandboxes.last_backup_attempt_at} ASC NULLS FIRST`,
+      )
       .limit(maxAgents);
+
+    const [fleet = EMPTY_SCHEDULED_BACKUP_FLEET_REPORT] = (await dbWrite
+      .select({
+        running: sql<number>`count(*)::int`,
+        routeless: sql<number>`count(*) filter (where ${agentSandboxes.bridge_url} IS NULL OR ${agentSandboxes.bridge_url} = ${UNREACHABLE_BRIDGE_SENTINEL})::int`,
+        snapshotUnsupported: sql<number>`count(*) filter (where ${agentSandboxes.backup_unsupported_reason} IS NOT NULL)::int`,
+        neverBackedUp: sql<number>`count(*) filter (where ${agentSandboxes.last_backup_at} IS NULL)::int`,
+        staleBackup: sql<number>`count(*) filter (where ${agentSandboxes.last_backup_at} IS NULL OR ${agentSandboxes.last_backup_at} < ${staleCutoff})::int`,
+        localState: sql<number>`count(*) filter (where ${agentSandboxes.environment_vars}->>'ELIZA_AGENT_LOCAL_STATE' = '1')::int`,
+        localStateStale: sql<number>`count(*) filter (where ${agentSandboxes.environment_vars}->>'ELIZA_AGENT_LOCAL_STATE' = '1' AND (${agentSandboxes.last_backup_at} IS NULL OR ${agentSandboxes.last_backup_at} < ${staleCutoff}))::int`,
+      })
+      .from(agentSandboxes)
+      .where(
+        and(eq(agentSandboxes.status, "running"), sql`${agentSandboxes.pool_status} IS NULL`),
+      )) as ScheduledBackupFleetReport[];
+
+    if (fleet.localStateStale > 0) {
+      // Local-state agents keep their ENTIRE state (PGlite DB, media, vault)
+      // on one node's local disk; a stale backup there is an unbounded-loss
+      // exposure, not a cosmetic gap. Loud by design; the fixed dedup key
+      // keeps a sustained condition to one PagerDuty incident.
+      await sendProvisioningWorkerAlert({
+        title: "Local-state agents with stale or missing off-box backups",
+        message: `${fleet.localStateStale} running local-state agent(s) have no successful backup within ${Math.round(staleAfterMs / 60_000)} minutes; node loss would exceed the backup RPO (#15783).`,
+        details: { ...fleet, staleAfterMs, minIntervalMs },
+        dedupKey: "agent-backup-staleness",
+      });
+    }
 
     let enqueued = 0;
     for (const agent of due) {
@@ -2712,8 +2845,9 @@ export class ProvisioningJobService {
     logger.info("[provisioning-jobs] Scheduled backups enqueued", {
       scanned: due.length,
       enqueued,
+      fleet,
     });
-    return { scanned: due.length, enqueued };
+    return { scanned: due.length, enqueued, fleet };
   }
 
   /**
@@ -4831,6 +4965,21 @@ export class ProvisioningJobService {
     );
 
     if (await this.completeIfAgentGone(job, result, data.agentId)) return;
+
+    // Attempt bookkeeping (#15783): record that a capture was tried regardless
+    // of outcome, and keep the snapshot-capability marker current —
+    // `last_backup_at` stays success-only so staleness stays honest, while
+    // `backup_unsupported_reason` moves incapable images out of the sweep's
+    // hot window until their slow re-probe. A successful capture always
+    // clears the marker (the image evidently serves the route now).
+    await this.recordSnapshotAttemptMarkers(
+      data.agentId,
+      result.success
+        ? "success"
+        : result.error === SNAPSHOT_ENDPOINT_UNSUPPORTED
+          ? "unsupported"
+          : "other",
+    );
 
     // Scheduled (auto) backups run across every non-pool sandbox, but an idle
     // agent (stopped/sleeping/disconnected — no bridge_url) legitimately has no


### PR DESCRIPTION
## What

Implements the executable core of #15783 Phase 0/1 (B7, epic #15603):

**Sweep starvation fix (Phase 1 deliverable 1).** \`enqueueScheduledBackups\` (\`packages/cloud/shared/src/lib/services/provisioning-jobs.ts\`) previously selected due rows with \`.limit(maxAgents)\` and **no ORDER BY**, so an over-cap due population was picked planner-dependently, and rows whose image 404s \`POST /api/snapshot\` (the \`SNAPSHOT_ENDPOINT_UNSUPPORTED\` sentinel) stayed perpetually due — able to permanently occupy the 200-row window and starve backup-capable agents. Now:

- the due set is ordered \`last_backup_at ASC NULLS FIRST\` with a \`last_backup_attempt_at ASC NULLS FIRST\` tiebreak — never-backed-up first, then oldest, so over-cap pressure degrades to round-robin-by-staleness;
- snapshot-incapable rows are excluded from the hot window and re-probed only every \`unsupportedRecheckMs\` (default 24h), so an image upgrade is still noticed within one interval;
- the snapshot job handler stamps \`last_backup_attempt_at\` on every attempt and sets/clears \`backup_unsupported_reason\` (set on the sentinel, cleared on success, untouched by inconclusive failures). \`last_backup_at\` remains **success-only** so staleness measurement stays honest.

**Phase 0 fleet measurement.** Every sweep returns/logs a \`ScheduledBackupFleetReport\`: running, route-less (null bridge or the #15737 loopback sentinel), snapshot-incapable, never-backed-up, stale, plus the same split for \`ELIZA_AGENT_LOCAL_STATE=1\` agents (whose whole DB lives on one node's disk). Exposed through the existing cron route response (\`packages/cloud/api/v1/cron/agent-backups/route.ts\` spreads the result, additively).

**Staleness alert (Phase 1 deliverable 3).** When any running local-state agent has no successful backup within the threshold (default 4× interval = 24h at the 6h cadence), the sweep raises \`sendProvisioningWorkerAlert\` (the existing ops alert channel shared with the backup verifier) with a fixed \`agent-backup-staleness\` dedup key.

**Schema.** New nullable \`agent_sandboxes\` columns \`last_backup_attempt_at\` / \`backup_unsupported_reason\` via migration \`0200_agent_backup_attempt_tracking.sql\` **and** the \`ensure-agent-sandbox-schema.ts\` self-heal (both \`ADD COLUMN IF NOT EXISTS\`), so readers deployed ahead of the migration converge on first repository access.

**Deliberately NOT here** (per the issue's gating): the fleet-image rollout to a snapshot-route-bearing image stays with #17172, and the 15–30min cadence tightening for local-state agents stays gated on that rollout — the cron fan-out params (\`?intervalMs=&max=\` + new \`unsupportedRecheckMs\`/\`staleAfterMs\` params) are ready for it.

## Tests (real PGlite, no mocks on the system under test)

\`bun test src/lib/services/provisioning-jobs-scheduled-backup-sentinel.test.ts\` in \`packages/cloud/shared\` — **35 pass / 0 fail** (31 existing + 4 new):

- capped window takes NULL-backup + 48h-stale rows and leaves the 7h row (ordering proven);
- an unsupported population AT the cap no longer starves the one healthy agent;
- an unsupported row re-enters the due set once its last attempt ages past 24h;
- fleet report counts route-less / incapable / never-backed-up / local-state-stale correctly (and the staleness alert fired in the run's structured logs).

\`bun run typecheck\` in \`packages/cloud/shared\`: 1 pre-existing error in \`src/lib/eliza/agent-loader.ts\` (messageExamples shape vs core types) present identically on the base commit with my changes stashed — no new errors introduced. Biome clean on all touched files.

## Residual risk

- The unsupported marker is written by the job handler; agents that never get a job (route-less \`bridge_url IS NULL\` rows) are measured by the fleet report but still cannot be backed up until the #17172 rollout — that is the report's purpose.
- The alert fires at most once per sweep with a fixed PagerDuty dedup key; with no alert channels configured it degrades to the structured error log (existing behavior of the shared alert helper).

Fixes the Phase 0/1 scheduler/measurement/alerting scope of #15783.

🤖 Generated with [Claude Code](https://claude.com/claude-code)