### PR TITLE
fix(ci): re-home #17012-swept behavior tests and add root-guide stale-reference gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,32 +110,32 @@ with `ELIZA_DEV_SERVER_REGISTRY`. See
 | `bun run test:lifeops` | `bun run test:plugin 'plugin-personal-assistant'` |
 | `bun run trajectory:inspect:test` | `bun test packages/scripts/__tests__/trajectory-validate.test.ts` |
 | `bun run audit:e2e-coverage:test` | `bun test packages/scripts/e2e-coverage/check-e2e-coverage.test.ts` |
-| `bun run test:browser-bridge` | `bun run --cwd packages/browser-extension test` |
-| `bun run test:browser-bridge:safari` | `bun run --cwd packages/browser-extension test:smoke:safari` |
+| `bun run test:browser-bridge` | retired with the removed `packages/browser-extension` workspace; no replacement |
+| `bun run test:browser-bridge:safari` | retired with the removed `packages/browser-extension` workspace; no replacement |
 | `bun run voice:latency-report` | `bun run --cwd packages/app-core voice:latency-report` |
 | `bun run voice:interactive` | `bun run --cwd packages/app-core voice:interactive` |
 | `bun run voice:duet` | `bun run --cwd packages/app-core voice:duet` |
 | `bun run voice:create-profile` | `bun run --cwd packages/app-core voice:create-profile` |
-| `bun run smartglasses:hardware:doctor` | `bun run --cwd packages/examples/smartglasses hardware:doctor` |
-| `bun run smartglasses:hardware:status` | `bun run --cwd packages/examples/smartglasses hardware:status-latest` |
-| `bun run smartglasses:hardware:validate` | `bun run --cwd packages/examples/smartglasses hardware:validate-latest` |
-| `bun run smartglasses:hardware:prove` | `bun run --cwd packages/examples/smartglasses hardware:prove:bleak` |
-| `bun run smartglasses:hardware:prove:watch` | `bun run --cwd packages/examples/smartglasses hardware:prove:bleak:watch` |
-| `bun run smartglasses:hardware:prove:noble` | `bun run --cwd packages/examples/smartglasses hardware:prove:noble` |
-| `bun run smartglasses:hardware:prove:noble:watch` | `bun run --cwd packages/examples/smartglasses hardware:prove:noble:watch` |
-| `bun run smartglasses:dev:hardware` | `bun run --cwd packages/examples/smartglasses dev:hardware` |
-| `bun run smartglasses:dev:simulator` | `bun run --cwd packages/examples/smartglasses dev:simulator` |
-| `bun run smartglasses:simulator` | `bun run --cwd packages/examples/smartglasses simulator` |
-| `bun run smartglasses:smoke:simulator` | `bun run --cwd packages/examples/smartglasses smoke:simulator` |
+| `bun run smartglasses:hardware:doctor` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
+| `bun run smartglasses:hardware:status` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
+| `bun run smartglasses:hardware:validate` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
+| `bun run smartglasses:hardware:prove` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
+| `bun run smartglasses:hardware:prove:watch` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
+| `bun run smartglasses:hardware:prove:noble` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
+| `bun run smartglasses:hardware:prove:noble:watch` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
+| `bun run smartglasses:dev:hardware` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
+| `bun run smartglasses:dev:simulator` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
+| `bun run smartglasses:simulator` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
+| `bun run smartglasses:smoke:simulator` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
 | `bun run test:ci:live` | `bun run test:live` |
 | `bun run test:lint` | retired with its aggregate tooling; no direct replacement |
 | `bun run test:lint:no-vi-mocks` | `bun run audit:test-integrity:no-vi-mocks` |
 | `bun run test:lint:lane-coverage` | retired with its tooling; no replacement |
 | `bun run test:lint:test-integrity` | retired with its tooling; no replacement |
 | `bun run test:lint:test-integrity:self-test` | retired with its tooling; no replacement |
-| `bun run verify:smartglasses-software` | `bun run audit:smartglasses-software` |
-| `bun run personality:judge` | `bun run bench:personality` |
-| `bun run personality:bench:calibrate` | `bun run bench:personality:calibrate` |
+| `bun run verify:smartglasses-software` | retired with the removed smartglasses tooling; no replacement |
+| `bun run personality:judge` | retired with the removed personality benchmark tooling; no replacement |
+| `bun run personality:bench:calibrate` | retired with the removed personality benchmark tooling; no replacement |
 | `bun run lint:all` | `bun run verify` |
 | `bun run build:typescript` | `node packages/scripts/run-turbo.mjs run build` |
 | `bun run audit:mvp-board` | `bun run mvp:closeout-audit` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,32 +110,32 @@ with `ELIZA_DEV_SERVER_REGISTRY`. See
 | `bun run test:lifeops` | `bun run test:plugin 'plugin-personal-assistant'` |
 | `bun run trajectory:inspect:test` | `bun test packages/scripts/__tests__/trajectory-validate.test.ts` |
 | `bun run audit:e2e-coverage:test` | `bun test packages/scripts/e2e-coverage/check-e2e-coverage.test.ts` |
-| `bun run test:browser-bridge` | `bun run --cwd packages/browser-extension test` |
-| `bun run test:browser-bridge:safari` | `bun run --cwd packages/browser-extension test:smoke:safari` |
+| `bun run test:browser-bridge` | retired with the removed `packages/browser-extension` workspace; no replacement |
+| `bun run test:browser-bridge:safari` | retired with the removed `packages/browser-extension` workspace; no replacement |
 | `bun run voice:latency-report` | `bun run --cwd packages/app-core voice:latency-report` |
 | `bun run voice:interactive` | `bun run --cwd packages/app-core voice:interactive` |
 | `bun run voice:duet` | `bun run --cwd packages/app-core voice:duet` |
 | `bun run voice:create-profile` | `bun run --cwd packages/app-core voice:create-profile` |
-| `bun run smartglasses:hardware:doctor` | `bun run --cwd packages/examples/smartglasses hardware:doctor` |
-| `bun run smartglasses:hardware:status` | `bun run --cwd packages/examples/smartglasses hardware:status-latest` |
-| `bun run smartglasses:hardware:validate` | `bun run --cwd packages/examples/smartglasses hardware:validate-latest` |
-| `bun run smartglasses:hardware:prove` | `bun run --cwd packages/examples/smartglasses hardware:prove:bleak` |
-| `bun run smartglasses:hardware:prove:watch` | `bun run --cwd packages/examples/smartglasses hardware:prove:bleak:watch` |
-| `bun run smartglasses:hardware:prove:noble` | `bun run --cwd packages/examples/smartglasses hardware:prove:noble` |
-| `bun run smartglasses:hardware:prove:noble:watch` | `bun run --cwd packages/examples/smartglasses hardware:prove:noble:watch` |
-| `bun run smartglasses:dev:hardware` | `bun run --cwd packages/examples/smartglasses dev:hardware` |
-| `bun run smartglasses:dev:simulator` | `bun run --cwd packages/examples/smartglasses dev:simulator` |
-| `bun run smartglasses:simulator` | `bun run --cwd packages/examples/smartglasses simulator` |
-| `bun run smartglasses:smoke:simulator` | `bun run --cwd packages/examples/smartglasses smoke:simulator` |
+| `bun run smartglasses:hardware:doctor` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
+| `bun run smartglasses:hardware:status` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
+| `bun run smartglasses:hardware:validate` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
+| `bun run smartglasses:hardware:prove` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
+| `bun run smartglasses:hardware:prove:watch` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
+| `bun run smartglasses:hardware:prove:noble` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
+| `bun run smartglasses:hardware:prove:noble:watch` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
+| `bun run smartglasses:dev:hardware` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
+| `bun run smartglasses:dev:simulator` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
+| `bun run smartglasses:simulator` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
+| `bun run smartglasses:smoke:simulator` | retired with the removed `packages/examples/smartglasses` workspace; no replacement |
 | `bun run test:ci:live` | `bun run test:live` |
 | `bun run test:lint` | retired with its aggregate tooling; no direct replacement |
 | `bun run test:lint:no-vi-mocks` | `bun run audit:test-integrity:no-vi-mocks` |
 | `bun run test:lint:lane-coverage` | retired with its tooling; no replacement |
 | `bun run test:lint:test-integrity` | retired with its tooling; no replacement |
 | `bun run test:lint:test-integrity:self-test` | retired with its tooling; no replacement |
-| `bun run verify:smartglasses-software` | `bun run audit:smartglasses-software` |
-| `bun run personality:judge` | `bun run bench:personality` |
-| `bun run personality:bench:calibrate` | `bun run bench:personality:calibrate` |
+| `bun run verify:smartglasses-software` | retired with the removed smartglasses tooling; no replacement |
+| `bun run personality:judge` | retired with the removed personality benchmark tooling; no replacement |
+| `bun run personality:bench:calibrate` | retired with the removed personality benchmark tooling; no replacement |
 | `bun run lint:all` | `bun run verify` |
 | `bun run build:typescript` | `node packages/scripts/run-turbo.mjs run build` |
 | `bun run audit:mvp-board` | `bun run mvp:closeout-audit` |

--- a/packages/scripts/__tests__/root-guide-command-migrations.test.ts
+++ b/packages/scripts/__tests__/root-guide-command-migrations.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Stale-reference regression check for the root guide's "Removed root command
+ * migrations" table. #17012 left several rows pointing at `audit:test-integrity*`
+ * scripts that no longer existed (#17003); this contract fails whenever a
+ * migration target references a `bun run` script that is absent from the named
+ * package manifest or a `bun test <path>` file that is gone. Deterministic:
+ * reads CLAUDE.md and package manifests from the repository checkout only.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../..",
+);
+
+interface MigrationTarget {
+  raw: string;
+  /** package dir relative to repo root ("." for the root manifest) */
+  packageDir: string;
+  script?: string;
+  testFile?: string;
+}
+
+/** Parse every `Use instead` cell of the migrations table into checkable refs. */
+function parseMigrationTargets(guide: string): MigrationTarget[] {
+  const section = guide.split("### Removed root command migrations")[1];
+  expect(section, "migrations section present in CLAUDE.md").toBeTruthy();
+  const targets: MigrationTarget[] = [];
+  for (const line of (section ?? "").split("\n")) {
+    if (!line.startsWith("| `bun run ")) continue;
+    const cells = line.split("|").map((cell) => cell.trim());
+    // | `removed` | replacement prose or `command` |
+    const replacement = cells[2] ?? "";
+    const match = replacement.match(/^`([^`]+)`$/);
+    if (!match) continue; // prose rows ("retired ...; no replacement") are fine
+    const command = match[1];
+    const cwdRun = command.match(/^bun run --cwd (\S+) (\S+)$/);
+    const rootRun = command.match(/^bun run (\S+)$/);
+    const bunTest = command.match(/^bun test (\S+)$/);
+    const nodeRun = command.match(/^node (\S+)/);
+    if (cwdRun) {
+      targets.push({ raw: command, packageDir: cwdRun[1], script: cwdRun[2] });
+    } else if (rootRun) {
+      targets.push({ raw: command, packageDir: ".", script: rootRun[1] });
+    } else if (bunTest) {
+      targets.push({ raw: command, packageDir: ".", testFile: bunTest[1] });
+    } else if (nodeRun) {
+      targets.push({ raw: command, packageDir: ".", testFile: nodeRun[1] });
+    }
+  }
+  return targets;
+}
+
+describe("root guide removed-command migrations", () => {
+  const guide = readFileSync(path.join(REPO_ROOT, "CLAUDE.md"), "utf8");
+  const targets = parseMigrationTargets(guide);
+
+  it("parses a non-trivial migration table", () => {
+    expect(targets.length).toBeGreaterThan(10);
+  });
+
+  it.each(targets.map((target) => [target.raw, target] as const))(
+    "migration target `%s` still exists",
+    (_raw, target) => {
+      if (target.script) {
+        const manifestPath = path.join(
+          REPO_ROOT,
+          target.packageDir,
+          "package.json",
+        );
+        expect(
+          existsSync(manifestPath),
+          `manifest ${manifestPath} exists`,
+        ).toBe(true);
+        const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+          scripts?: Record<string, string>;
+        };
+        expect(
+          manifest.scripts?.[target.script],
+          `script "${target.script}" in ${target.packageDir}/package.json`,
+        ).toBeTruthy();
+      }
+      if (target.testFile) {
+        expect(
+          existsSync(path.join(REPO_ROOT, target.testFile)),
+          `referenced path ${target.testFile} exists`,
+        ).toBe(true);
+      }
+    },
+  );
+});

--- a/plugins/plugin-discord/__tests__/banner-defaults.test.ts
+++ b/plugins/plugin-discord/__tests__/banner-defaults.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for `printDiscordBanner` — the startup settings panel. Mocked
+ * runtime logger, no live gateway. Re-homes the conversational-default rows
+ * assertion that previously lived in the deleted
+ * `__tests__/discord-defaults-lane.test.ts` composite lane (#17003 / #17012
+ * sweep), and pins the banner's hardcoded default markers to the live
+ * `DISCORD_DEFAULTS` values so a default flip cannot silently desynchronize
+ * the operator-facing panel.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { printDiscordBanner } from "../banner.ts";
+import { DISCORD_DEFAULTS } from "../environment.ts";
+
+function renderBanner(): string {
+	const settings: Record<string, unknown> = {
+		DISCORD_API_TOKEN: "token-value",
+		DISCORD_APPLICATION_ID: "123456789012345678", // gitleaks:allow test fixture
+	};
+	const info = vi.fn();
+	const runtime = {
+		character: { name: "TestBot" },
+		getSetting: (key: string) => settings[key],
+		logger: { info, warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+	} as unknown as IAgentRuntime;
+
+	printDiscordBanner(runtime);
+
+	return info.mock.calls.map((call) => String(call[0])).join("\n");
+}
+
+function settingRow(rendered: string, name: string): string {
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: strips terminal ANSI color codes before asserting columns
+	const plain = rendered.replace(/\x1b\[[0-9;]*m/g, "");
+	const row = plain.split("\n").find((line) => line.includes(name));
+	if (!row) throw new Error(`Missing banner row for ${name}`);
+	return row;
+}
+
+describe("printDiscordBanner conversational defaults", () => {
+	it("renders the startup banner with the response-gating rows", () => {
+		const rendered = renderBanner();
+		expect(rendered).toContain("DISCORD_SHOULD_IGNORE_BOT_MESSAGES");
+		expect(rendered).toContain("DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES");
+		expect(rendered).toContain("DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS");
+	});
+
+	it("keeps the banner's default markers in sync with DISCORD_DEFAULTS", () => {
+		// The banner hardcodes each row's defaultValue string; these mirror the
+		// conversational-default posture (#16956): engage bots, ignore DMs off is
+		// NOT the default (DMs are ignored by default), reply without @mention.
+		expect(DISCORD_DEFAULTS.SHOULD_IGNORE_BOT_MESSAGES).toBe(false);
+		expect(DISCORD_DEFAULTS.SHOULD_IGNORE_DIRECT_MESSAGES).toBe(true);
+		expect(DISCORD_DEFAULTS.SHOULD_RESPOND_ONLY_TO_MENTIONS).toBe(false);
+
+		const rendered = renderBanner();
+		expect(
+			settingRow(rendered, "DISCORD_SHOULD_IGNORE_BOT_MESSAGES"),
+		).toContain("false");
+		expect(
+			settingRow(rendered, "DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES"),
+		).toContain("true");
+		expect(
+			settingRow(rendered, "DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS"),
+		).toContain("false");
+	});
+});

--- a/plugins/plugin-sql/src/__tests__/unit/message-search-syntax.test.ts
+++ b/plugins/plugin-sql/src/__tests__/unit/message-search-syntax.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Unit tests for `usesWebsearchSyntax`, the classifier that decides whether a
+ * message-search query carries `websearch_to_tsquery` structural operators
+ * (quoted phrases, leading-minus exclusions, standalone OR) and therefore must
+ * not receive the literal/trigram lexical fallback OR-ed into it. Pure
+ * function, no database. Re-homes the ten structural-versus-lexical rows that
+ * previously lived in the deleted `__tests__/base-adapter.harness.test.ts`
+ * composite lane (#17003 / #17012 sweep).
+ */
+import { describe, expect, it } from "vitest";
+import { usesWebsearchSyntax } from "../../message-search";
+
+describe("structured websearch query classification", () => {
+  it.each(['"alpha beta"', "alpha -far", "-excluded", "alpha OR zephyr", "alpha\tor\tzephyr"])(
+    "preserves structural semantics for %s",
+    (query) => {
+      expect(usesWebsearchSyntax(query)).toBe(true);
+    }
+  );
+
+  it.each(["alpha beta", "quarterly-budget", "word-or-word", "orphan", "-"])(
+    "keeps lexical fallback for %s",
+    (query) => {
+      expect(usesWebsearchSyntax(query)).toBe(false);
+    }
+  );
+});


### PR DESCRIPTION
## What

Closes out the still-unmet residuals of #17003 (post-#17012 sweep). The headline acceptance — ordinary unit tests executing on the develop PR path — has since been satisfied structurally by the CI consolidation and is documented below rather than re-implemented; this PR delivers the remaining concrete gaps.

### Re-homed behavior-bearing tests

- **plugin-sql**: the ten `usesWebsearchSyntax` structural-versus-lexical rows (deleted with `__tests__/base-adapter.harness.test.ts`) now live in `plugins/plugin-sql/src/__tests__/unit/message-search-syntax.test.ts` as a plain unit suite.
- **plugin-discord**: the `printDiscordBanner` conversational-default rows (deleted with `__tests__/discord-defaults-lane.test.ts`) now live in `plugins/plugin-discord/__tests__/banner-defaults.test.ts`, plus a pin of the banner's hardcoded default markers to the live `DISCORD_DEFAULTS` values.

### Stale-reference regression gate

`packages/scripts/__tests__/root-guide-command-migrations.test.ts` parses the root guide's 'Removed root command migrations' table and fails when any backtick migration target references a nonexistent script or file. **It immediately caught 16 real stale rows** — `packages/browser-extension`, `packages/examples/smartglasses`, `audit:smartglasses-software`, and `bench:personality*` targets removed by `dc03207dc61` ('delete a bunch of stuff') — which this PR repairs in CLAUDE.md/AGENTS.md (byte-identical, parity gate passes). The originally-reported `audit:test-integrity*` rows were already repaired on develop; this gate prevents the next recurrence.

### Develop-PR test authority — current state (documented, not changed)

Since #17012, the develop PR gate was rebuilt: `ci.yml` (canonical `CI / Required` aggregate) runs on `pull_request -> develop` with **Tests (scripts)** always executing, **Tests (server/client/plugins)** lanes always emitting via `classify-paths.yml`, and `ci-path-gate.mjs`'s `applyFailSafe` guaranteeing an unmapped production diff cannot skip every test lane. Test-only diffs map through `packages/test/**` and per-package patterns. `develop-pr.yml` additionally runs changed-plugin unit tests (#17550). The `required` aggregate needs every lane. No changed-file LCOV policy was recreated.

### Policy record

The deliberate provider-purity reversal is now recorded on #16924: https://github.com/elizaOS/eliza/pull/16924#issuecomment-5300113948

## Tests

- `bun run --cwd plugins/plugin-sql test -- message-search-syntax` → 10/10 pass
- `bun run --cwd plugins/plugin-discord test -- banner-defaults` → 2/2 pass
- `bun test packages/scripts/__tests__/root-guide-command-migrations.test.ts` → 17 pass, 0 fail (and verified it FAILS on the pre-fix table: 16 failures)
- `bun run check:agents-claude` → 153 pairs byte-identical
- `bun run ensure-plugin-test-conventions:check` → pass
- `node packages/scripts/run-script-tests.mjs --inventory` discovers the new scripts test
- biome clean on all touched files

Residual risk: the stale-reference gate only validates the migrations table's backtick commands (`bun run`, `bun run --cwd`, `bun test`, `node`); prose rows are exempt by design.

Fixes #17003

🤖 Generated with [Claude Code](https://claude.com/claude-code)