### PR TITLE
fix(elizaresearch): add addEventListener to canvas test mock (follow-up to #19727)

### DIFF
--- a/packages/elizaresearch/lifecycle-alpha.test.mjs
+++ b/packages/elizaresearch/lifecycle-alpha.test.mjs
@@ -47,6 +47,7 @@ function loadProductionLifecycle() {
     clientWidth: 1200,
     clientHeight: 800,
     getContext: () => drawingContext,
+    addEventListener: noOp,
   };
   context.document = {
     hidden: false,


### PR DESCRIPTION
# Relates to

Closes #19762. Follows up merged PR #19727, which moved the
`contextmenu`/`selectstart`/`dragstart` `preventDefault` listeners in
`packages/elizaresearch/index.html` from `document.body` onto the `#swarm`
canvas element. That production change is correct but silently broke the
package's checked-in Bun test harness, which did not mock
`canvas.addEventListener`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker. See **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@93a600929a04deb55a5f17498cdea5f59156bb5c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The change adds a single no-op property to a test-harness mock object. No
production code is touched, and no test assertions change.

# Background

## What does this PR do?

Adds the missing `addEventListener: noOp` property to the `canvas` mock in
`packages/elizaresearch/lifecycle-alpha.test.mjs`. The test runs the production
inline `<script>` from `index.html` inside a `node:vm` context. After #19727,
script initialization runs:

```js
for (const type of ["contextmenu", "selectstart", "dragstart"]) {
  canvas.addEventListener(type, (event) => event.preventDefault());
}
```

The mock previously only exposed `parentElement`, `clientWidth`, `clientHeight`,
and `getContext`, so this threw
`TypeError: canvas.addEventListener is not a function` during
`loadProductionLifecycle()`, failing all four lifecycle tests. The harness
already defines `noOp` and uses it for `header.addEventListener`,
`document.body.addEventListener`, `document.addEventListener`, and the
context-level `addEventListener`; this change makes the `canvas` mock match
those other mocked event targets.

## What kind of change is this?

Bug fix (test-harness mock completeness). Non-breaking.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/elizaresearch/lifecycle-alpha.test.mjs`.

## Detailed testing steps

```bash
cd packages/elizaresearch && bun test lifecycle-alpha.test.mjs
# Expect: 4 pass / 0 fail
```

### Before (at this branch's parent, canvas mock without addEventListener)

```
bun test v1.3.14 (0d9b296a)

lifecycle-alpha.test.mjs:

# Unhandled error between tests
-------------------------------
TypeError: canvas.addEventListener is not a function. (In 'canvas.addEventListener(type, (event) => event.preventDefault())', 'canvas.addEventListener' is undefined)
      at index.html:171:28
-------------------------------

 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [161.00ms]
```

### After (with `addEventListener: noOp` added to the canvas mock)

```
bun test v1.3.14 (0d9b296a)

lifecycle-alpha.test.mjs:
(pass) elizaresearch particle lifecycle > keeps the first steady-state draw opaque across initial lifetimes [4.98ms]
(pass) elizaresearch particle lifecycle > initializes particles created by a post-entrance resize as opaque [0.33ms]
(pass) elizaresearch particle lifecycle > preserves the original lifetime when it already clears the handoff [1.57ms]
(pass) elizaresearch particle lifecycle > renders a reseeded particle at true zero before it fades in [0.18ms]

 4 pass
 0 fail
 103 expect() calls
Ran 4 tests across 1 file. [51.00ms]
```

# Evidence Gate

<!-- evidence-head:84d951ebedb7424c8da4e537b21baeead3e28e25 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - internal Bun test-harness mock fix; no UI surface changes.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - internal Bun test-harness mock fix; no UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-only change with no user-facing flow.
<!-- evidence-row:backend-logs -->
- [ ] N/A - test-only change; the before/after Bun test transcripts in the PR body show the real code path (production inline script under node:vm) firing end to end.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser runtime or network activity; the change only affects a Node vm-based unit test.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB rows, memories, scheduled tasks, wallet output, or generated files involved.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changes.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

See the before/after Bun test transcripts under **Testing** above. They show the
production inline particle script executing inside the `node:vm` context and the
four lifecycle assertions passing.

## Screenshots (before / after) + video walkthrough

`N/A - internal test-harness mock fix; no UI surface is affected.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- This package (`@elizaos/elizaresearch-site`) has no `test`, `typecheck`, or
  `lint` script in its `package.json`, so `packages/scripts/run-all-tests.mjs`
  discovery skips it. The test is real and directly runnable
  (`bun test lifecycle-alpha.test.mjs`) but invisible to CI lanes. This is a
  pre-existing infra gap and is intentionally **not** addressed in this PR to
  keep the diff minimal and surgical.
- The change is a single added mock property on a `.mjs` test file, so package
  typecheck/lint are no-ops here; the focused Bun test is the authoritative
  gate and passes 4/0.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@93a600929a04deb55a5f17498cdea5f59156bb5c:packages/skills/skills/contribute-to-eliza"} -->

