### PR TITLE
fix(cloud): normalize hosted persona examples

### DIFF
--- a/packages/cloud/shared/src/lib/eliza/agent.ts
+++ b/packages/cloud/shared/src/lib/eliza/agent.ts
@@ -1,5 +1,8 @@
-// Wires hosted Eliza agent agent behavior for cloud runtime services.
-import { buildCloudElizaPersona } from "../utils/cloud-eliza-persona";
+/** Wires the hosted Eliza character and runtime settings for Cloud services. */
+import {
+  buildCloudElizaPersona,
+  toCloudCharacterMessageExamples,
+} from "../utils/cloud-eliza-persona";
 import { getDefaultModels, getElizaCloudApiUrl } from "./config";
 
 // The persona is the shipped preset plus the cloud memory delta. Only the
@@ -7,8 +10,6 @@ import { getDefaultModels, getElizaCloudApiUrl } from "./config";
 // knowledge entries are owned by this file.
 const persona = buildCloudElizaPersona();
 
-// messageExamples uses grouped MessageExample[][] rows; createCharacter() normalizes it at
-// load time in agent-loader.ts. The type assertion below suppresses the structural mismatch.
 const character = {
   id: "b850bc30-45f8-0041-a00a-83df46d8555d", // existing agent id in DB
   name: "Eliza",
@@ -95,7 +96,7 @@ const character = {
     "Eliza and Eliza can help builders make money with Cloud apps by setting inference markup or purchase share, sending Stripe/OxaPay app-credit payment requests, sending x402 crypto payment requests, tracking paid status, routing payment results back into the initiating conversation, earning affiliate or creator revenue share, and requesting admin-reviewed elizaOS token payouts on Base, BSC, Ethereum, or Solana.",
     "Paid Cloud actions such as payment requests, domain purchases, and payout requests should be confirmed explicitly before they are created.",
   ],
-  messageExamples: persona.messageExamples,
+  messageExamples: toCloudCharacterMessageExamples(persona.messageExamples, persona.name),
   postExamples: persona.postExamples,
   topics: persona.topics,
   adjectives: persona.adjectives,

--- a/packages/cloud/shared/src/lib/utils/cloud-eliza-persona.ts
+++ b/packages/cloud/shared/src/lib/utils/cloud-eliza-persona.ts
@@ -45,6 +45,32 @@ export const CLOUD_RECALL_EXAMPLE: { user: string; content: { text: string } }[]
   { user: "{{agentName}}", content: { text: RECALL_REPLY } },
 ];
 
+interface PresetTurn {
+  user: string;
+  content: { text: string };
+}
+
+/**
+ * Projects preset speaker keys into the name-keyed character contract used by
+ * Cloud persistence and the hosted runtime loader.
+ */
+export function toCloudCharacterMessageExamples(
+  groups: readonly (readonly PresetTurn[])[],
+  agentName: string,
+): Array<Array<{ name: string; content: { text: string } }>> {
+  return groups.map((group) =>
+    group.map((turn) => ({
+      name:
+        turn.user === "{{agentName}}"
+          ? agentName
+          : turn.user === "{{user1}}"
+            ? "{{name1}}"
+            : turn.user,
+      content: { ...turn.content },
+    })),
+  );
+}
+
 /**
  * The shipped persona with the cloud memory delta applied, still in preset
  * shape. Callers map it into whatever shape they store.

--- a/packages/cloud/shared/src/lib/utils/default-eliza-character.test.ts
+++ b/packages/cloud/shared/src/lib/utils/default-eliza-character.test.ts
@@ -88,18 +88,10 @@ describe("getDefaultElizaCharacterData", () => {
     expect(defaultAgent.character.style).toEqual(character.style);
     expect(defaultAgent.character.postExamples).toEqual(character.post_examples);
 
-    const hostedExamples = defaultAgent.character.messageExamples.map((group) =>
-      group.map((turn) => ({
-        name:
-          turn.user === "{{agentName}}"
-            ? character.name
-            : turn.user === "{{user1}}"
-              ? "{{name1}}"
-              : turn.user,
-        content: { text: turn.content.text },
-      })),
-    );
-    expect(hostedExamples).toEqual(character.message_examples);
+    expect(defaultAgent.character.messageExamples).toEqual(character.message_examples);
+    expect(defaultAgent.character.messageExamples[0]?.[0]?.name).toBe("{{name1}}");
+    expect(defaultAgent.character.messageExamples[0]?.[1]?.name).toBe(character.name);
+    expect(defaultAgent.character.messageExamples[0]?.[0]).not.toHaveProperty("user");
   });
 });
 

--- a/packages/cloud/shared/src/lib/utils/default-eliza-character.ts
+++ b/packages/cloud/shared/src/lib/utils/default-eliza-character.ts
@@ -7,40 +7,10 @@
  * keys, `name`-keyed message turns, and DB-only columns. Editing the persona
  * means editing the preset, so the two can no longer drift apart.
  */
-import { buildCloudElizaPersona } from "./cloud-eliza-persona";
+import { buildCloudElizaPersona, toCloudCharacterMessageExamples } from "./cloud-eliza-persona";
 
 const ELIZA_AVATAR_URL =
   "https://raw.githubusercontent.com/elizaOS/eliza-avatars/refs/heads/master/Eliza/portrait.png";
-
-/**
- * Preset turns key the speaker as `user` and address the agent with
- * `{{agentName}}`; the characters table keys it as `name` and stores the literal
- * agent name, with `{{name1}}` for the human.
- */
-interface PresetTurn {
-  user?: string;
-  name?: string;
-  content?: { text?: string };
-}
-
-function toRowSpeaker(turn: PresetTurn, agentName: string): string {
-  const speaker = turn.user ?? turn.name;
-  if (speaker === "{{agentName}}") return agentName;
-  if (speaker === "{{user1}}") return "{{name1}}";
-  return speaker ?? "{{name1}}";
-}
-
-function toRowExamples(
-  groups: readonly (readonly PresetTurn[])[],
-  agentName: string,
-): Record<string, unknown>[][] {
-  return groups.map((group) =>
-    group.map((turn) => ({
-      name: toRowSpeaker(turn, agentName),
-      content: { text: turn.content?.text ?? "" },
-    })),
-  );
-}
 
 /**
  * Returns the default Eliza character data for new accounts.
@@ -53,7 +23,7 @@ export function getDefaultElizaCharacterData() {
     name: persona.name,
     bio: [...persona.bio] as string[],
     system: persona.system,
-    message_examples: toRowExamples(persona.messageExamples, persona.name),
+    message_examples: toCloudCharacterMessageExamples(persona.messageExamples, persona.name),
     post_examples: [...persona.postExamples],
     avatar_url: ELIZA_AVATAR_URL,
     // Deliberately empty. Baked-in knowledge is retrieval-gated to the


### PR DESCRIPTION
Closes #19755.

## What changed

- Added one strict adapter from preset `user`-keyed message turns to Cloud's persisted/runtime `name`-keyed character contract.
- Reused it for both signup character persistence and the hosted default agent.
- Removed the permissive duplicate mapper that could fabricate empty text or a fallback speaker.
- Added regression assertions that hosted and signup examples are identical, use `{{name1}}` for the human and the literal agent name for Eliza, and expose no `user` field.

## Exact-head validation

Validated at `27321e2fb62dfa143d9ede4279b6399adfabd242`, rebased onto current `origin/develop` (`d69ddd617cd9c136481e0241411af5f124c7d9fe`).

- `bun test packages/cloud/shared/src/lib/utils/default-eliza-character.test.ts` with global coverage disabled for the invocation: 11 passed, 0 failed, 516 assertions.
- `bun run --cwd packages/cloud/shared typecheck`: passed.
- `bun run --cwd packages/cloud/api typecheck`: passed, including the production Worker dry-run bundle.
- Biome check on all four touched files: passed.
- `git diff --check`: passed.
- Root `bun run verify` advanced past the reported Cloud API failure, then stopped on an unrelated current-develop failure at `packages/agent/src/api/cloud-pair-route.test.ts:453` (TS2352, a partial object cast directly to `Response`). This PR does not touch that file.

## Evidence

This is a backend/type-contract correction with no rendered UI, so screenshots and video are N/A. The production Worker dry-run and exact structural assertions are the applicable runtime evidence.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - repository contribution skill is not available in this session
Attribution status: self-reported
— Codex
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - repository contribution skill is not available in this session"} -->
