### PR TITLE
test(app): align Group A cloud-surface ui-smoke specs with the eliza.app consolidation

### DIFF
--- a/packages/app/test/ui-smoke/agent-detail-invalid-date-capture.spec.ts
+++ b/packages/app/test/ui-smoke/agent-detail-invalid-date-capture.spec.ts
@@ -14,6 +14,19 @@ import {
 
 test.use({ video: "on" });
 
+const TEST_AUTH_ENABLED =
+  process.env.VITE_PLAYWRIGHT_TEST_AUTH === "true" ||
+  process.env.NEXT_PUBLIC_PLAYWRIGHT_TEST_AUTH === "true";
+
+// The /dashboard cloud-console shell only renders in a renderer built with
+// VITE_PLAYWRIGHT_TEST_AUTH=true (the Steward test-auth route shell); without
+// it the app never leaves boot. Same gate as cloud-console-routes.spec.ts and
+// the cloud-surfaces audit, which share these fixtures.
+test.skip(
+  !TEST_AUTH_ENABLED,
+  "set VITE_PLAYWRIGHT_TEST_AUTH=true so StewardProvider renders the cloud console route shell",
+);
+
 test("agent detail page renders explicit fallbacks for a malformed agent timestamp", async ({
   page,
 }) => {

--- a/packages/app/test/ui-smoke/cloud-login-callsite-popup.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-login-callsite-popup.spec.ts
@@ -99,9 +99,25 @@ async function installCloudLoginRoutes(page: Page): Promise<void> {
 async function bootCloudSettings(
   page: Page,
   size: { width: number; height: number },
+  apiBase: string,
 ): Promise<void> {
   await page.setViewportSize(size);
-  await seedAppStorage(page);
+  // Since the eliza.app consolidation (0468c1850a3) the Cloud settings group
+  // is cloudOnly: it renders only when the startup coordinator restores a
+  // cloud-managed runtime target (activeServerToTarget maps a persisted
+  // kind:"cloud" server to "cloud-managed"). Seed that restored server so the
+  // real Settings → Cloud → Overview surface (the CTA callsite under test)
+  // mounts, exactly as it does for a managed-cloud shell; no Steward session
+  // is seeded, so the section renders the disconnected Connect CTA.
+  await seedAppStorage(page, {
+    "elizaos:active-server": JSON.stringify({
+      id: "cloud:ui-smoke-callsite",
+      kind: "cloud",
+      label: "Eliza Cloud",
+      apiBase,
+    }),
+    "eliza:mobile-runtime-mode": "cloud",
+  });
   await installDefaultAppRoutes(page);
   await installCloudLoginRoutes(page);
   await openAppPath(page, "/settings");
@@ -118,6 +134,7 @@ test.describe("cloud login callsite — interactive popup opens from the real Se
   for (const viewport of VIEWPORTS) {
     test(`clicking the connect CTA opens the eliza-cloud-auth popup on ${viewport.name}`, async ({
       page,
+      baseURL,
     }, testInfo) => {
       const consoleLogs: string[] = [];
       const networkLogs: string[] = [];
@@ -144,7 +161,9 @@ test.describe("cloud login callsite — interactive popup opens from the real Se
         }
       });
 
-      await bootCloudSettings(page, viewport);
+      const apiBase = (baseURL ?? "").replace(/\/$/, "");
+      expect(apiBase, "Playwright baseURL must be configured").toBeTruthy();
+      await bootCloudSettings(page, viewport, apiBase);
       await screenshot(page, testInfo, `${viewport.name}-1-before-connect-cta`);
 
       // The interactive path must open a REAL popup named eliza-cloud-auth.

--- a/packages/app/test/ui-smoke/launcher-cloud-gating.spec.ts
+++ b/packages/app/test/ui-smoke/launcher-cloud-gating.spec.ts
@@ -7,7 +7,6 @@ import { expect, type Page, type TestInfo, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,
   openAppPath,
-  openSettingsSection,
   seedAppStorage,
 } from "./helpers";
 import { captureScreenshotWithQualityRetry } from "./helpers/screenshot-quality";
@@ -238,33 +237,15 @@ test.describe("launcher: one apps tile — cloud-apps never tiles", () => {
       await expect(cloudTile(page)).toHaveCount(0);
       await screenshot(page, testInfo, "walkthrough-1-launcher-disconnected");
 
-      // Agent-first cloud setup: Settings → Cloud → Overview → Connect Cloud.
-      // (The cloud group's overview section registers with defaultLabel
-      // "Overview" and defaultTitle "Eliza Cloud" — settings-sections.ts.)
-      await openAppPath(page, "/settings");
-      await openSettingsSection(page, /^Overview$/);
-      const connectButton = page.getByRole("button", {
-        name: /Connect Cloud|Connect Eliza Cloud/i,
-      });
-      await expect(connectButton.first()).toBeVisible({ timeout: 30_000 });
-      await screenshot(page, testInfo, "walkthrough-2-settings-cloud-section");
-
-      // Completing the (stubbed) login flips the backend status; the UI must
-      // observe it through its own status poll — the same signal a real
-      // device-code/Steward completion produces.
+      // Since the eliza.app consolidation (0468c1850a3) the local-runtime
+      // Settings hub no longer hosts a Cloud group (its sections are cloudOnly
+      // and render only for a managed-cloud runtime target), so cloud connect
+      // happens outside this shell (on eliza.app). Flip the stubbed backend
+      // status directly — the same signal a completed external device-code /
+      // Steward login produces — and let the UI observe it through its own
+      // status poll.
       state.connected = true;
-      await connectButton.first().click();
-      await expect(
-        page.getByRole("button", { name: /Open Eliza Cloud/i }).first(),
-      ).toBeVisible({ timeout: 60_000 });
-      await expect(
-        page.getByRole("button", { name: /Open Eliza Cloud/i }).first(),
-      ).toContainText("Cloud connected");
-      await screenshot(
-        page,
-        testInfo,
-        "walkthrough-3-settings-cloud-connected",
-      );
+      await screenshot(page, testInfo, "walkthrough-2-backend-connected");
 
       await openAppPath(page, "/views");
       await expect(page.getByTestId("launcher")).toBeVisible({
@@ -294,8 +275,8 @@ test.describe("launcher: one apps tile — cloud-apps never tiles", () => {
           notePath,
           [
             "Recorded by launcher-cloud-gating.spec.ts (cloud setup walkthrough).",
-            "Flow: launcher without cloud-apps tile → Settings → Eliza Cloud →",
-            "Connect Cloud → status flips connected → launcher still shows only",
+            "Flow: launcher without cloud-apps tile → backend cloud status flips",
+            "connected (external eliza.app login) → launcher still shows only",
             "the My Apps tile (the studio lives inside My Apps).",
             "",
             "Repro: bun run --cwd packages/app test:e2e -- --project=chromium test/ui-smoke/launcher-cloud-gating.spec.ts",


### PR DESCRIPTION
## What

Completes the Group A triage from #19307 on current `develop@daaa69660d6`: fresh local reproduction found 4 of the 13 Group A test cases still red, all traceable to the deliberate product change in 0468c1850a3 ("consolidate Eliza Cloud into eliza.app"), which made the Cloud settings group `cloudOnly` — `SettingsView` renders it only when the startup coordinator restores a `cloud-managed` runtime target. The local-runtime `Settings → Cloud → Overview → Connect Cloud` walk these specs performed no longer exists in the product.

- **cloud-login-callsite-popup.spec.ts** (2 cases): boots the real Settings → Cloud surface by seeding a persisted `kind:"cloud"` active server (`activeServerToTarget` → `cloud-managed`, the same seed cloud-agent-lifecycle uses). The #17129 interactive-popup contract stays fully under test — real Settings CTA click → real `eliza-cloud-auth` popup — on the shell where the CTA now lives. No Steward session is seeded, so the disconnected Connect CTA renders.
- **launcher-cloud-gating.spec.ts** (connect walkthrough): cloud connect now happens outside this shell (on eliza.app), so the walkthrough flips the stubbed backend cloud status directly — the same signal an external login completion produces, observed through the UI's own status poll — and keeps every launcher one-apps-tile gating assertion.
- **agent-detail-invalid-date-capture.spec.ts**: gated on `VITE_PLAYWRIGHT_TEST_AUTH` exactly like its siblings that share the same cloud-audit fixtures (cloud-console-routes, cloud-surfaces audit). Without the test-auth renderer the `/dashboard` console shell never leaves "Booting up…", which is the observed standing failure; coverage continues under the audit-cloud project.

## Triage results (unmodified develop@daaa69660d6, real Chromium harness)

- `all-views-interaction.spec.ts`: **33/33 passed** (including the `automations` and `relationships` cases named in the issue — fixed upstream by b8320ff38d9/f252a42e0ef).
- `cloud-agent-lifecycle`, `cloud-apps-deploy-deeplink`, `hosted-signin-focus`: already pass.
- `cloud-login-callsite-popup` (2), `launcher-cloud-gating` walkthrough, `agent-detail-invalid-date-capture`: red before this PR, green after.

Group B was fixed previously (cloud-pair-evidence by 8c819716da9; direct-sandbox first-run by open PR #19550).

## Tests

- `bun run --cwd packages/app test:e2e test/ui-smoke/cloud-login-callsite-popup.spec.ts` → 2 passed
- `bun run --cwd packages/app test:e2e test/ui-smoke/launcher-cloud-gating.spec.ts test/ui-smoke/agent-detail-invalid-date-capture.spec.ts` → 5 passed, 1 skipped (the new test-auth gate, matching siblings)
- `bun run --cwd packages/app test:e2e test/ui-smoke/all-views-interaction.spec.ts` → 33 passed
- `bun run --cwd packages/app typecheck` → clean
- Biome on the three touched specs → clean (one pre-existing upstream `CLOUD_AUTH_TOKEN` unused-var warning, untouched)

## Residual risk

- The agent-detail invalid-date regression proof now only runs where the test-auth renderer is built (audit-cloud / explicit `VITE_PLAYWRIGHT_TEST_AUTH=true`), same as its sibling console specs.
- If a local-runtime cloud-connect entry point is reintroduced later, the launcher walkthrough should walk it again.

Refs #19307

🤖 Generated with [Claude Code](https://claude.com/claude-code)