### PR TITLE
fix(cloud): require words before voice barge-in

### DIFF
--- a/packages/cloud/api/v1/twilio/voice/media/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/media/route.ts
@@ -315,9 +315,10 @@ app.get("/", async (c) => {
     clearAudio() {
       if (!streamSid) return;
       sendEvent({ event: "clear", streamSid });
-      logger.info("[twilio-media] caller turn-start flushed buffered audio", {
-        streamSid,
-      });
+      logger.info(
+        "[twilio-media] confirmed caller speech flushed buffered audio",
+        { streamSid },
+      );
     },
     close(code, reason) {
       releaseBootstrap();

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -1620,7 +1620,7 @@ describe("voice-session WS lifecycle", () => {
     expect(client.audioFrames.length).toBe(framesAfterInterrupt);
   });
 
-  test("semantic turn-start interrupts immediately and the caller gets the next response", async () => {
+  test("confirmed caller words interrupt immediately and get the next response", async () => {
     const client = new FakeClientSocket();
     await connectSession({
       client,
@@ -1642,13 +1642,19 @@ describe("voice-session WS lifecycle", () => {
     const audioBeforeInterruption = client.audioFrames.length;
     ink.emitTurn("turn.start");
     await flush();
+    expect(client.controlFrames).not.toContainEqual(
+      expect.objectContaining({ t: "interrupted", reason: "acoustic" }),
+    );
+    expect(cartesia.closed).toBe(false);
+
+    ink.emitTurn("turn.update", "wait");
+    await flush();
     expect(client.controlFrames).toContainEqual(
       expect.objectContaining({ t: "interrupted", reason: "acoustic" }),
     );
     expect(cartesia.closed).toBe(true);
     expect(client.audioFrames).toHaveLength(audioBeforeInterruption);
 
-    ink.emitTurn("turn.update", "wait");
     ink.emitTurn("turn.end", "wait");
     await flush();
     await flush();
@@ -1656,7 +1662,7 @@ describe("voice-session WS lifecycle", () => {
     expect(client.audioFrames.length).toBeGreaterThan(audioBeforeInterruption);
   });
 
-  test("semantic turn-start flushes transport audio after server TTS completed", async () => {
+  test("confirmed caller words flush transport audio after server TTS completed", async () => {
     const client = new FakeClientSocket();
     let clearCount = 0;
     await connectSession({
@@ -1678,6 +1684,10 @@ describe("voice-session WS lifecycle", () => {
     clearCount = 0;
 
     ink.emitTurn("turn.start");
+    await flush();
+    expect(clearCount).toBe(0);
+
+    ink.emitTurn("turn.update", "wait");
     await flush();
     expect(clearCount).toBe(1);
   });

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -536,17 +536,11 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         break;
       }
       case "start-of-turn": {
-        // Ink's semantic turn detector is the earliest reliable signal that
-        // the caller has begun a new utterance. Stop current audio immediately
-        // so Eliza never talks over the caller while transcription continues.
+        // Speech-start alone is not enough to cancel playback: phone echo and
+        // line noise can trigger Ink before it has recognized any caller words.
+        // Wait for a transcript update/final below, then interrupt immediately.
         this.resetSttPartialDelivery();
         this.activeSttTurn = true;
-        const responseActive = Boolean(this.currentVoiceTurnId);
-        this.interrupt("acoustic");
-        // A transport such as Twilio can still be playing audio it buffered
-        // before TTS reported completion. There is no active turn to emit an
-        // `interrupted` frame in that state, so flush the transport directly.
-        if (!responseActive) this.config.downlink.clearAudio?.();
         this.state = "transcribing";
         break;
       }
@@ -671,10 +665,9 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
 
   /** Cancel an active response only after Ink has produced caller words. */
   private interruptForConfirmedSpeech(transcript: string): void {
-    if (!this.currentVoiceTurnId || !SPOKEN_TRANSCRIPT_RE.test(transcript)) {
-      return;
-    }
-    this.interrupt("acoustic");
+    if (!SPOKEN_TRANSCRIPT_RE.test(transcript)) return;
+    if (this.currentVoiceTurnId) this.interrupt("acoustic");
+    else this.config.downlink.clearAudio?.();
     this.state = "transcribing";
   }
 


### PR DESCRIPTION
Hotfix promotion of #19771, already merged to develop. Stops false Ink speech-start events from clearing Twilio playback before caller words are confirmed. Verified with 57 focused voice tests, cloud API typecheck, Worker dry-run bundle, and Biome.