### PR TITLE
fix(core): keep heavy parsers and node-only module scope out of consumer bundles

### DIFF
--- a/packages/core/src/features/documents/naming.ts
+++ b/packages/core/src/features/documents/naming.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure document naming helpers: title derivation from content and safe note
+ * filenames. Split from `utils.ts` so callers that only name documents (the
+ * working-memory attachment action, character ingestion) do not drag the
+ * heavyweight parser graph (mammoth/unpdf) into edge and browser bundles;
+ * `utils.ts` re-exports these, so existing import sites keep working.
+ */
+
+const DOCUMENT_TITLE_MAX_LENGTH = 80;
+
+function truncateDocumentLabel(value: string): string {
+	return value.length > DOCUMENT_TITLE_MAX_LENGTH
+		? `${value.slice(0, DOCUMENT_TITLE_MAX_LENGTH - 1).trimEnd()}…`
+		: value;
+}
+
+export function stripDocumentFilenameExtension(filename: string): string {
+	const trimmed = filename.trim();
+	if (!trimmed) return "";
+
+	const lastDot = trimmed.lastIndexOf(".");
+	if (lastDot <= 0) return trimmed;
+	return trimmed.slice(0, lastDot);
+}
+
+export function deriveDocumentTitle(
+	content: string,
+	fallback = "Document note",
+): string {
+	const lines = content
+		.replace(/\r\n/g, "\n")
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0);
+
+	for (const line of lines) {
+		if (/^path:\s+/i.test(line)) continue;
+		const candidate = line
+			.replace(/^#+\s*/, "")
+			.replace(/^[-*]\s+/, "")
+			.replace(/^\d+[.)]\s+/, "")
+			.trim();
+		if (candidate.length > 0) {
+			return truncateDocumentLabel(candidate);
+		}
+	}
+
+	return fallback;
+}
+
+export function createDocumentNoteFilename(
+	title: string,
+	extension = "txt",
+): string {
+	const asciiTitle = Array.from(title.normalize("NFKD"))
+		.filter((character) => character.charCodeAt(0) <= 0x7f)
+		.join("");
+	const normalizedTitle = asciiTitle
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, 64);
+
+	const basename =
+		normalizedTitle.length > 0 ? normalizedTitle : "document-note";
+	const normalizedExtension = extension.replace(/^\./, "").trim();
+	return normalizedExtension.length > 0
+		? `${basename}.${normalizedExtension}`
+		: basename;
+}

--- a/packages/core/src/features/documents/utils.ts
+++ b/packages/core/src/features/documents/utils.ts
@@ -8,8 +8,6 @@
  */
 import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
-import * as mammoth from "mammoth";
-import { extractText } from "unpdf";
 import { v5 as uuidv5 } from "uuid";
 
 const PLAIN_TEXT_CONTENT_TYPES = [
@@ -48,6 +46,9 @@ export async function extractTextFromFileBuffer(
 		"application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 	) {
 		try {
+			// Loaded on use: mammoth is a CJS parser whose static import drags the
+			// whole docx toolchain into every consumer bundle (edge included).
+			const mammoth = await import("mammoth");
 			const result = await mammoth.extractRawText({ buffer: fileBuffer });
 			return result.value;
 		} catch (docxError) {
@@ -118,6 +119,9 @@ export async function convertPdfToTextFromBuffer(
 			),
 		);
 
+		// Loaded on use like mammoth above: unpdf's static import would pin the
+		// PDF toolchain into every consumer bundle (edge included).
+		const { extractText } = await import("unpdf");
 		const result = await extractText(uint8Array, {
 			mergePages: true,
 		});
@@ -304,68 +308,13 @@ export function isBinaryContentType(
 	return binaryExtensions.includes(fileExt);
 }
 
-const DOCUMENT_TITLE_MAX_LENGTH = 80;
-
-function truncateDocumentLabel(value: string): string {
-	return value.length > DOCUMENT_TITLE_MAX_LENGTH
-		? `${value.slice(0, DOCUMENT_TITLE_MAX_LENGTH - 1).trimEnd()}…`
-		: value;
-}
-
-export function stripDocumentFilenameExtension(filename: string): string {
-	const trimmed = filename.trim();
-	if (!trimmed) return "";
-
-	const lastDot = trimmed.lastIndexOf(".");
-	if (lastDot <= 0) return trimmed;
-	return trimmed.slice(0, lastDot);
-}
-
-export function deriveDocumentTitle(
-	content: string,
-	fallback = "Document note",
-): string {
-	const lines = content
-		.replace(/\r\n/g, "\n")
-		.split("\n")
-		.map((line) => line.trim())
-		.filter((line) => line.length > 0);
-
-	for (const line of lines) {
-		if (/^path:\s+/i.test(line)) continue;
-		const candidate = line
-			.replace(/^#+\s*/, "")
-			.replace(/^[-*]\s+/, "")
-			.replace(/^\d+[.)]\s+/, "")
-			.trim();
-		if (candidate.length > 0) {
-			return truncateDocumentLabel(candidate);
-		}
-	}
-
-	return fallback;
-}
-
-export function createDocumentNoteFilename(
-	title: string,
-	extension = "txt",
-): string {
-	const asciiTitle = Array.from(title.normalize("NFKD"))
-		.filter((character) => character.charCodeAt(0) <= 0x7f)
-		.join("");
-	const normalizedTitle = asciiTitle
-		.toLowerCase()
-		.replace(/[^a-z0-9]+/g, "-")
-		.replace(/^-+|-+$/g, "")
-		.slice(0, 64);
-
-	const basename =
-		normalizedTitle.length > 0 ? normalizedTitle : "document-note";
-	const normalizedExtension = extension.replace(/^\./, "").trim();
-	return normalizedExtension.length > 0
-		? `${basename}.${normalizedExtension}`
-		: basename;
-}
+// Pure naming helpers live in ./naming so light consumers can import them
+// without the parser graph; re-exported here for compatibility.
+export {
+	createDocumentNoteFilename,
+	deriveDocumentTitle,
+	stripDocumentFilenameExtension,
+} from "./naming.ts";
 
 export function isTextBackedDocumentContent(
 	contentType: string,

--- a/packages/core/src/features/plugin-manager/actions/plugin.ts
+++ b/packages/core/src/features/plugin-manager/actions/plugin.ts
@@ -420,7 +420,11 @@ function buildResolverOptions(
 
 export function createPluginAction(deps: PluginActionDeps = {}): Action {
 	const ownerCheck = deps.hasOwnerAccess ?? defaultOwnerAccessFn;
-	const repoRoot = deps.repoRoot ?? defaultRepoRoot();
+	// Resolved lazily: createPluginAction runs at module scope when the action
+	// registry is assembled, and edge isolates (workerd) have no process.cwd.
+	// The repo root only matters once a handler actually runs on a host.
+	let resolvedRepoRoot = deps.repoRoot;
+	const repoRootLazy = (): string => (resolvedRepoRoot ??= defaultRepoRoot());
 
 	const canManagePlugins = async (
 		runtime: IAgentRuntime,
@@ -488,7 +492,7 @@ export function createPluginAction(deps: PluginActionDeps = {}): Action {
 					intent: params.intent ?? readStringOption(options, "intent"),
 					choice: readStringOption(options, "choice"),
 					editTarget: readStringOption(options, "editTarget"),
-					repoRoot,
+					repoRoot: repoRootLazy(),
 				});
 		}
 	};
@@ -649,7 +653,7 @@ export function createPluginAction(deps: PluginActionDeps = {}): Action {
 						options,
 						callback,
 						choice: text.trim(),
-						repoRoot,
+						repoRoot: repoRootLazy(),
 					});
 				}
 			}

--- a/packages/core/src/features/plugin-manager/services/coreManagerService.ts
+++ b/packages/core/src/features/plugin-manager/services/coreManagerService.ts
@@ -24,8 +24,13 @@ import { formatError } from "../../../utils/format-error.ts";
 import { resolveStateDir } from "../utils/paths.ts";
 import { getRegistryEntry } from "./pluginRegistryService.ts";
 
-const execAsync = promisify(exec);
-const execFileAsync = promisify(execFile);
+// Guarded for edge isolates: the child_process builtin is absent there, and
+// promisify(undefined) at module scope would kill the whole import. Node hosts
+// get the real promisified binding; edge paths fail at use instead.
+const execAsync =
+	typeof exec === "function" ? promisify(exec) : (undefined as never);
+const execFileAsync =
+	typeof execFile === "function" ? promisify(execFile) : (undefined as never);
 
 const CORE_GIT_URL = "https://github.com/elizaos/eliza.git";
 const CORE_BRANCH = "develop";

--- a/packages/core/src/features/plugin-manager/services/pluginManagerService.ts
+++ b/packages/core/src/features/plugin-manager/services/pluginManagerService.ts
@@ -58,7 +58,11 @@ import {
 	searchPluginsByContent,
 } from "./pluginRegistryService.ts";
 
-const execAsync = promisify(exec);
+// Guarded for edge isolates: the child_process builtin is absent there, and
+// promisify(undefined) at module scope would kill the whole import. Node hosts
+// get the real promisified binding; edge paths fail at use instead.
+const execAsync =
+	typeof exec === "function" ? promisify(exec) : (undefined as never);
 
 // ---------------------------------------------------------------------------
 // Input validation — prevent shell injection

--- a/packages/core/src/features/plugin-manager/services/pluginRegistryService.ts
+++ b/packages/core/src/features/plugin-manager/services/pluginRegistryService.ts
@@ -29,7 +29,11 @@ const CACHE_DURATION = 3_600_000; // 1 hour
 // ---------------------------------------------------------------------------
 
 const LOCAL_PLUGINS_DIR = "plugins";
-const execFileAsync = promisify(execFile);
+// Guarded for edge isolates: the child_process builtin is absent there, and
+// promisify(undefined) at module scope would kill the whole import. Node hosts
+// get the real promisified binding; edge paths fail at use instead.
+const execFileAsync =
+	typeof execFile === "function" ? promisify(execFile) : (undefined as never);
 
 // ---------------------------------------------------------------------------
 // Wire types for the generated-registry.json format

--- a/packages/core/src/features/working-memory/readAttachmentAction.ts
+++ b/packages/core/src/features/working-memory/readAttachmentAction.ts
@@ -37,11 +37,11 @@ import {
 	type UUID,
 } from "../../types/index.ts";
 import { getLocalServerUrl } from "../../utils.ts";
-import { DocumentService } from "../documents/service.ts";
 import {
 	createDocumentNoteFilename,
 	deriveDocumentTitle,
-} from "../documents/utils.ts";
+} from "../documents/naming.ts";
+import type { DocumentService } from "../documents/service.ts";
 import {
 	listConversationAttachments,
 	readAttachmentRecords,
@@ -621,9 +621,9 @@ async function saveAttachmentAsDocument(params: {
 		};
 	}
 
-	const service = params.runtime.getService<DocumentService>(
-		DocumentService.serviceType,
-	);
+	// Type-only DocumentService import + the literal service type keep the
+	// fs/parser-heavy service module out of this action's bundle graph.
+	const service = params.runtime.getService<DocumentService>("documents");
 	if (!service) {
 		const text =
 			"I can't save documents right now — document storage isn't available.";


### PR DESCRIPTION
## What

The slimmed complement to the merged #19794 workerd slice. This PR's original edge-build work (getBuiltinModule post-process, workerd/edge-light export conditions) was grafted onto #19794 before its merge — composed proof there: a genuine AgentRuntime constructed, initialized, and memory-round-tripping inside real workerd, where the branch alone died at import.

What remains here is node/browser bundle hygiene at each defect's structural home:

- **documents**: pure naming helpers split into `naming.ts` (`utils.ts` re-exports them; every import site keeps working); mammoth and unpdf become dynamic imports loaded when a docx/pdf is actually parsed, so no consumer bundle carries the parser toolchain.
- **working-memory**: `readAttachmentAction` imports the naming helpers from `naming.ts` and holds `DocumentService` as a type plus the literal service id, keeping the fs-heavy service module out of its graph.
- **plugin-manager**: `repoRoot` resolves on first handler run instead of `process.cwd()` at registry assembly; the exec/execFile promisifications guard on the builtin's presence and fail at use.

6 files, +42/-76.

## Evidence

```
$ bun x vitest run src/features/documents src/features/working-memory src/features/plugin-manager
Tests  297 passed (297)     # against post-#19794 develop
```

The workerd runtime evidence lives on #19794 (merged): real wrangler dev boot, memory round trip, dist audit (0 static builtin imports, guarded bindings, fail-loud residual check).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- ai-assistance: yes
<!-- attribution-row:models -->
- models: anthropic/claude-opus-4-8
<!-- attribution-row:client -->
- client: Claude Code
<!-- attribution-row:skill-revision -->
- skill-revision: N/A - no packaged skill governed this change
<!-- attribution-row:status -->
- status: self-reported
