### PR TITLE
fix(core,agent,pa): owner mutations outrank VIEWS routing; absolute gate on BM25 chat injection

### DIFF
--- a/packages/agent/src/api/chat-augmentation.test.ts
+++ b/packages/agent/src/api/chat-augmentation.test.ts
@@ -212,6 +212,11 @@ describe("maybeAugmentChatMessageWithDocuments", () => {
 
   it("injects context on a real keyword match", async () => {
     const message = makeMessage();
+    // A query that genuinely shares meaningful terms with the fragment — the
+    // absolute coverage gate (#17028) requires literal query-term overlap,
+    // not just a relative BM25 rank.
+    (message.content as { text: string }).text =
+      "how do i set the inference markup for monetization?";
     const documents = {
       countMemories: vi.fn().mockResolvedValue(14),
       searchDocuments: vi.fn().mockResolvedValue([
@@ -231,6 +236,79 @@ describe("maybeAugmentChatMessageWithDocuments", () => {
     expect(result.content.text).toContain("set inference markup");
     const [, , searchMode] = documents.searchDocuments.mock.calls[0];
     expect(searchMode).toBe("keyword");
+  });
+
+  it("does not inject an unrelated help FAQ on a workout query (#17028)", async () => {
+    // Keyword search max-normalizes BM25 within each result set, so the best
+    // positive match reports similarity 1.0 even when the only shared words
+    // are stopwords. Live this injected the navigation FAQ's "Do not ...
+    // invoke tools/actions" envelope into a routine-creation turn. The
+    // absolute query-term coverage gate must reject it.
+    const message = makeMessage();
+    (message.content as { text: string }).text =
+      "can you help me schedule a workout every day";
+    const documents = {
+      countMemories: vi.fn().mockResolvedValue(14),
+      searchDocuments: vi.fn().mockResolvedValue([
+        {
+          content: {
+            text: "How do I switch screens or views? Say the view name or ask me to open it.",
+          },
+          similarity: 1,
+          metadata: { filename: "help-navigation.txt" },
+        },
+      ]),
+    };
+    const useModel = vi.fn();
+    const runtime = makeRuntime(documents, useModel);
+
+    const result = await maybeAugmentChatMessageWithDocuments(runtime, message);
+
+    expect(result).toBe(message);
+    expect(useModel).not.toHaveBeenCalled();
+  });
+
+  it("still injects a genuinely-answering help FAQ on a navigation ask (#17028)", async () => {
+    const message = makeMessage();
+    (message.content as { text: string }).text = "how do i switch views?";
+    const documents = {
+      countMemories: vi.fn().mockResolvedValue(14),
+      searchDocuments: vi.fn().mockResolvedValue([
+        {
+          content: {
+            text: "How do I switch screens or views? Say the view name or ask me to open it.",
+          },
+          similarity: 1,
+          metadata: { filename: "help-navigation.txt" },
+        },
+      ]),
+    };
+    const runtime = makeRuntime(documents);
+
+    const result = await maybeAugmentChatMessageWithDocuments(runtime, message);
+
+    expect(result).not.toBe(message);
+    expect(result.content.text).toContain("<contextual_documents>");
+  });
+
+  it("never injects for a query made only of stopwords", async () => {
+    const message = makeMessage();
+    (message.content as { text: string }).text = "what are you up to?";
+    const documents = {
+      countMemories: vi.fn().mockResolvedValue(14),
+      searchDocuments: vi.fn().mockResolvedValue([
+        {
+          content: { text: "Anything at all scores 1.0 relative to itself." },
+          similarity: 1,
+          metadata: { filename: "noise.txt" },
+        },
+      ]),
+    };
+    const runtime = makeRuntime(documents);
+
+    const result = await maybeAugmentChatMessageWithDocuments(runtime, message);
+
+    expect(result).toBe(message);
   });
 
   it("keeps uploaded corpora on the lexical pre-model path", async () => {
@@ -269,6 +347,9 @@ describe("maybeAugmentChatMessageWithDocuments", () => {
 
   it("aliases the augmentation envelope onto the clean prompt's recall embed — in-run recall of the rewritten text issues zero new embeds", async () => {
     const message = makeMessage();
+    // Meaningful-term overlap with the fragment so the absolute coverage
+    // gate (#17028) admits the injection this test depends on.
+    (message.content as { text: string }).text = "tell me the qa codeword";
     const documents = {
       countMemories: vi.fn().mockResolvedValue(3),
       getMemories: vi
@@ -300,7 +381,7 @@ describe("maybeAugmentChatMessageWithDocuments", () => {
 
     // The rewrite warmed ONE embed of the clean prompt (the mocked service
     // never embedded, so the warm is the turn's only round-trip)…
-    expect(embedCalls).toEqual(["what are you up to?"]);
+    expect(embedCalls).toEqual(["tell me the qa codeword"]);
 
     // …and the in-run recall callers presenting the ENVELOPE text (as the
     // message-service prefetch and relevant-conversations provider do) resolve
@@ -310,7 +391,7 @@ describe("maybeAugmentChatMessageWithDocuments", () => {
       messageId: message.id as string,
     });
     expect(vec).toEqual([0.1, 0.2, 0.3]);
-    expect(embedCalls).toEqual(["what are you up to?"]);
+    expect(embedCalls).toEqual(["tell me the qa codeword"]);
   });
 
   it("passes the original message id as turnMessageId so the in-run recall embed adopts this pre-run embed (#15253)", async () => {

--- a/packages/agent/src/api/chat-augmentation.test.ts
+++ b/packages/agent/src/api/chat-augmentation.test.ts
@@ -291,16 +291,16 @@ describe("maybeAugmentChatMessageWithDocuments", () => {
     expect(result.content.text).toContain("<contextual_documents>");
   });
 
-  it("never injects for a query made only of stopwords", async () => {
+  it("keeps literal document relevance available for non-English scripts", async () => {
     const message = makeMessage();
-    (message.content as { text: string }).text = "what are you up to?";
+    (message.content as { text: string }).text = "如何切换视图";
     const documents = {
       countMemories: vi.fn().mockResolvedValue(14),
       searchDocuments: vi.fn().mockResolvedValue([
         {
-          content: { text: "Anything at all scores 1.0 relative to itself." },
+          content: { text: "帮助：如何切换视图。" },
           similarity: 1,
-          metadata: { filename: "noise.txt" },
+          metadata: { filename: "help-navigation-zh.txt" },
         },
       ]),
     };
@@ -308,7 +308,33 @@ describe("maybeAugmentChatMessageWithDocuments", () => {
 
     const result = await maybeAugmentChatMessageWithDocuments(runtime, message);
 
-    expect(result).toBe(message);
+    expect(result).not.toBe(message);
+    expect(result.content.text).toContain("如何切换视图");
+  });
+
+  it("never injects for a query made only of stopwords", async () => {
+    for (const query of ["what are you up to?", "this does not do it"]) {
+      const message = makeMessage();
+      (message.content as { text: string }).text = query;
+      const documents = {
+        countMemories: vi.fn().mockResolvedValue(14),
+        searchDocuments: vi.fn().mockResolvedValue([
+          {
+            content: { text: "This does not do it either." },
+            similarity: 1,
+            metadata: { filename: "noise.txt" },
+          },
+        ]),
+      };
+      const runtime = makeRuntime(documents);
+
+      const result = await maybeAugmentChatMessageWithDocuments(
+        runtime,
+        message,
+      );
+
+      expect(result).toBe(message);
+    }
   });
 
   it("keeps uploaded corpora on the lexical pre-model path", async () => {

--- a/packages/agent/src/api/chat-augmentation.ts
+++ b/packages/agent/src/api/chat-augmentation.ts
@@ -78,6 +78,123 @@ const CHAT_DOCUMENTS_THRESHOLD = 0.2;
 const CHAT_DOCUMENTS_LIMIT = 4;
 const CHAT_DOCUMENTS_SNIPPET_MAX_CHARS = 700;
 
+// Keyword search max-normalizes BM25 within each result set, so the BEST
+// positive match is always similarity 1.0 even when the lexical overlap is a
+// single ubiquitous word — the similarity threshold above is a relative
+// ranking cut, not an absolute relevance gate. Injecting on that signal let an
+// unrelated navigation FAQ reach 1.0 on a workout query and its "Do not ...
+// invoke tools/actions" envelope suppress the correct mutation path (#17028).
+// This boundary therefore adds an ABSOLUTE gate: at least half of the query's
+// meaningful (non-stopword) terms must literally appear in a fragment before
+// it may be injected. Deliberately local to chat augmentation — the shared
+// normalizer also feeds hybrid search's blend and must stay relative.
+const CHAT_DOCUMENTS_MIN_QUERY_TERM_COVERAGE = 0.5;
+
+const CHAT_DOCUMENT_QUERY_STOPWORDS: ReadonlySet<string> = new Set([
+  "a",
+  "about",
+  "an",
+  "and",
+  "any",
+  "are",
+  "as",
+  "at",
+  "be",
+  "but",
+  "by",
+  "can",
+  "could",
+  "did",
+  "do",
+  "does",
+  "for",
+  "from",
+  "get",
+  "has",
+  "have",
+  "he",
+  "her",
+  "his",
+  "how",
+  "i",
+  "if",
+  "in",
+  "is",
+  "it",
+  "its",
+  "just",
+  "me",
+  "my",
+  "no",
+  "not",
+  "of",
+  "on",
+  "or",
+  "our",
+  "out",
+  "please",
+  "she",
+  "should",
+  "so",
+  "some",
+  "than",
+  "that",
+  "the",
+  "their",
+  "them",
+  "then",
+  "there",
+  "these",
+  "they",
+  "this",
+  "to",
+  "up",
+  "us",
+  "was",
+  "we",
+  "were",
+  "what",
+  "whats",
+  "when",
+  "where",
+  "which",
+  "who",
+  "why",
+  "will",
+  "with",
+  "would",
+  "you",
+  "your",
+]);
+
+/** Lowercase alphanumeric tokens with a trailing plural "s" stripped. */
+function coverageTokens(text: string): string[] {
+  return (text.toLowerCase().match(/[a-z0-9]+/g) ?? []).map((token) =>
+    token.length > 3 && token.endsWith("s") ? token.slice(0, -1) : token,
+  );
+}
+
+function meaningfulQueryTerms(query: string): string[] {
+  return [
+    ...new Set(
+      coverageTokens(query).filter(
+        (token) =>
+          token.length >= 2 && !CHAT_DOCUMENT_QUERY_STOPWORDS.has(token),
+      ),
+    ),
+  ];
+}
+
+function queryTermCoverage(
+  terms: readonly string[],
+  fragmentText: string,
+): number {
+  if (terms.length === 0) return 0;
+  const fragmentTokens = new Set(coverageTokens(fragmentText));
+  const covered = terms.filter((term) => fragmentTokens.has(term)).length;
+  return covered / terms.length;
+}
+
 // Sentinel requester id for an unresolved/unauthenticated chat turn. It is the
 // nil UUID — guaranteed to be neither the agent nor any real owner — so the
 // scope-read filter resolves it to a least-privileged USER and strips every
@@ -256,13 +373,18 @@ export async function maybeAugmentChatMessageWithDocuments(
     return matches;
   };
 
+  // A query whose every token is a stopword has no lexical anchor at all —
+  // any keyword "match" for it is noise, so nothing may be injected.
+  const queryTerms = meaningfulQueryTerms(userPrompt);
   const selectRelevantMatches = (matches: DocumentMatches): DocumentMatches =>
     matches.filter((match) => {
       const text = match.content.text?.trim();
       return (
         typeof text === "string" &&
         text.length > 0 &&
-        (match.similarity ?? 0) >= CHAT_DOCUMENTS_THRESHOLD
+        (match.similarity ?? 0) >= CHAT_DOCUMENTS_THRESHOLD &&
+        queryTermCoverage(queryTerms, text) >=
+          CHAT_DOCUMENTS_MIN_QUERY_TERM_COVERAGE
       );
     });
 

--- a/packages/agent/src/api/chat-augmentation.ts
+++ b/packages/agent/src/api/chat-augmentation.ts
@@ -167,10 +167,22 @@ const CHAT_DOCUMENT_QUERY_STOPWORDS: ReadonlySet<string> = new Set([
   "your",
 ]);
 
-/** Lowercase alphanumeric tokens with a trailing plural "s" stripped. */
+/** Lowercase Unicode word tokens with conservative English plural folding. */
 function coverageTokens(text: string): string[] {
-  return (text.toLowerCase().match(/[a-z0-9]+/g) ?? []).map((token) =>
-    token.length > 3 && token.endsWith("s") ? token.slice(0, -1) : token,
+  return (text.toLocaleLowerCase().match(/[\p{L}\p{N}]+/gu) ?? []).map(
+    (token) => {
+      // Preserve stopwords before folding: otherwise "this" became "thi" and
+      // "does" became "doe", manufacturing lexical anchors for stopword-only
+      // queries. Restrict the fold to Latin-looking plurals so non-English
+      // scripts remain exact instead of passing through English morphology.
+      if (CHAT_DOCUMENT_QUERY_STOPWORDS.has(token)) return token;
+      return /^[a-z]+$/u.test(token) &&
+        token.length > 3 &&
+        token.endsWith("s") &&
+        !token.endsWith("ss")
+        ? token.slice(0, -1)
+        : token;
+    },
   );
 }
 

--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -1109,13 +1109,32 @@ describe("VIEWS hijack of answered simple turns (tj-501e594bfb23a7)", () => {
 		expect(routed.plan.candidateActions).toContain("VIEWS");
 	});
 
-	it("suppression is keyed on the answered shape — an unanswered turn still escalates", () => {
+	it("the hijack message no longer produces a candidate on ANY stage-1 shape (#17028)", () => {
+		// The phrase-coverage fix removed the "times"→screen-time overlap at the
+		// source, so even an unanswered turn has nothing to escalate with.
 		const routed = messageHandlerFromFieldResult(
 			stageOneAnswered(""),
 			undefined,
 			{
 				actions: [replyAction, viewsAction],
 				messageText: "whats 17 times 23?",
+			},
+		);
+
+		expect(routed.plan.requiresTool).toBe(false);
+		expect(routed.plan.candidateActions ?? []).toEqual([]);
+	});
+
+	it("suppression is keyed on the answered shape — an unanswered turn still escalates", () => {
+		// A genuine weak capability overlap (settings tag with only directional
+		// operation evidence) keeps the original valve behavior: unanswered
+		// turns escalate, answered simple turns are suppressed elsewhere.
+		const routed = messageHandlerFromFieldResult(
+			stageOneAnswered(""),
+			undefined,
+			{
+				actions: [replyAction, viewsAction],
+				messageText: "move my settings to the right",
 			},
 		);
 

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -560,15 +560,103 @@ describe("inferDirectCurrentRequestCandidateInference kinds", () => {
 		],
 	};
 
-	it("classifies the live hijack message as weak view-capability evidence", () => {
-		// "whats" bypasses the instructional-question guard ("what is" does not)
-		// and "times" singularizes to TIME, matching the "screen-time" tag.
+	it("never matches multiword capability tags on partial token overlap (#17028)", () => {
+		// "times" singularizes to TIME but the "screen-time" tag is a PHRASE:
+		// without SCREEN in the message it must not produce a candidate. This
+		// was the live hijack — arithmetic and cadence turns routed to VIEWS.
+		for (const message of [
+			"whats 17 times 23?",
+			"3 times a day",
+			"i need to get the time for the meeting",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateInference([viewsAction], message),
+			).toEqual({ names: [], kind: null });
+		}
+	});
+
+	it("still matches capability vocabulary with navigation intent", () => {
+		// SCREEN is a surface noun, so the full screen-time phrase resolves on
+		// the stronger view-surface leg; a plain capability tag ("calendar")
+		// still resolves on the capability leg.
 		expect(
 			inferDirectCurrentRequestCandidateInference(
 				[viewsAction],
-				"whats 17 times 23?",
+				"get my screen time",
+			),
+		).toEqual({ names: ["VIEWS"], kind: "view-surface" });
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction],
+				"show my settings",
 			),
 		).toEqual({ names: ["VIEWS"], kind: "view-capability" });
+	});
+
+	it("routes recurring-habit commitments to the owner routine surface, never VIEWS (#17028)", () => {
+		const routinesAction: Pick<Action, "name" | "similes" | "tags"> = {
+			name: "OWNER_ROUTINES",
+			similes: ["HABIT", "ROUTINE", "TRACK_HABIT", "CREATE_ROUTINE"],
+			tags: [],
+		};
+		const pushupTurn =
+			"25 pushups, 3 times a day, doesnt matter when i just need to get them in";
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, routinesAction],
+				pushupTurn,
+			),
+		).toEqual({ names: ["OWNER_ROUTINES"], kind: "owner-routines" });
+		for (const message of [
+			"track this habit",
+			"schedule pushups every morning",
+			"remind me daily to do pushups",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateInference(
+					[viewsAction, routinesAction],
+					message,
+				),
+			).toEqual({ names: ["OWNER_ROUTINES"], kind: "owner-routines" });
+		}
+		// Unregistered runtimes yield NO candidate — an owner mutation must not
+		// degrade into the view catalog; the unresolvable-capability path
+		// declines explicitly instead.
+		expect(
+			inferDirectCurrentRequestCandidateInference([viewsAction], pushupTurn),
+		).toEqual({ names: [], kind: null });
+		// Advice questions are lookups, not commitments.
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, routinesAction],
+				"how many times a day should i do pushups",
+			),
+		).toEqual({ names: [], kind: null });
+	});
+
+	it("gives owner goal mutations precedence over the views goals tag (#17028)", () => {
+		const goalsAction: Pick<Action, "name" | "similes" | "tags"> = {
+			name: "OWNER_GOALS",
+			similes: ["GOALS"],
+			tags: [],
+		};
+		const goalsTaggedViews: Pick<Action, "name" | "similes" | "tags"> = {
+			...viewsAction,
+			tags: [...(viewsAction.tags ?? []), "goals"],
+		};
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[goalsTaggedViews, goalsAction],
+				"add a savings goal to save 500 dollars by march",
+			),
+		).toEqual({ names: ["OWNER_GOALS"], kind: "owner-goals" });
+		// Without the goal surface, the mutation still never selects VIEWS.
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[goalsTaggedViews],
+				"add a savings goal to save 500 dollars by march",
+			),
+		).toEqual({ names: [], kind: null });
 	});
 
 	it("classifies explicit surface asks and bare-noun navigation as strong evidence", () => {

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -354,14 +354,16 @@ export function isShellDirectActionName(
  * - "shell" / "coding" / "settings-write" / "web": explicit intent phrasing
  *   in the message.
  * - "owner-goals": concrete owner goal create/save/confirm phrasing.
+ * - "owner-routines": habit/routine commitment phrasing, including recurring
+ *   cadences ("3 times a day") — an owner mutation, never navigation.
  * - "view-surface": an operation verb PLUS an explicit UI-surface noun
  *   (view/window/panel/app/screen/ui) — strong navigation evidence.
  * - "view-navigation": the message is nothing but a bare registered surface
  *   name ("settings") — the voice-transcription navigation contract (#9950).
- * - "view-capability": only an incidental token overlap between the message
- *   and a views action's tag/simile vocabulary (e.g. "whats 17 TIMES 23"
- *   matching the "screen-time" tag via TIME). Weak evidence — observed live
- *   hijacking already-answered trivial chat turns into a required-tool
+ * - "view-capability": a navigation-shaped message whose tokens cover a views
+ *   action's tag/simile phrase ("get my screen time" covering screen-time).
+ *   Still the weakest evidence — an earlier variant that matched partial
+ *   phrases hijacked already-answered trivial chat turns into a required-tool
  *   planner deadlock (trajectories tj-501e594bfb23a7, tj-5d1c9601f33e8d).
  */
 export type DirectCurrentRequestCandidateKind =
@@ -369,6 +371,7 @@ export type DirectCurrentRequestCandidateKind =
 	| "coding"
 	| "settings-write"
 	| "owner-goals"
+	| "owner-routines"
 	| "view-surface"
 	| "view-navigation"
 	| "view-capability"
@@ -381,6 +384,23 @@ export interface DirectCurrentRequestCandidateInference {
 
 const EMPTY_DIRECT_CANDIDATE_INFERENCE: DirectCurrentRequestCandidateInference =
 	{ names: [], kind: null };
+
+// Owner routine/habit surface, in preference order. Matches the personal
+// assistant's OWNER_ROUTINES action by name or by its declared similes
+// (findAvailableActionName matches either), so runtimes exposing only a
+// legacy habit action still resolve.
+const OWNER_ROUTINES_ACTION_NAMES = [
+	"OWNER_ROUTINES",
+	"ROUTINES",
+	"ROUTINE",
+	"TRACK_HABIT",
+	"CREATE_ROUTINE",
+	"CREATE_HABIT",
+	"DAILY_HABIT",
+	"HABITS",
+	"HABIT",
+	"RECURRING_TASK",
+] as const;
 
 const OWNER_GOALS_ACTION_NAMES = [
 	"OWNER_GOALS",
@@ -548,6 +568,62 @@ function findOwnerGoalsActionName(
 	return findAvailableActionName(actions, OWNER_GOALS_ACTION_NAMES);
 }
 
+/**
+ * Detects an owner commitment to a recurring habit/routine — the phrasing that
+ * live hijacked into a VIEWS catalog dump ("25 pushups, 3 times a day …",
+ * #17028). Three legs: an explicit recurring cadence ("N times a day/week"),
+ * a habit/routine noun coupled with a write verb, or a recurring reminder ask.
+ * Advice questions ("how many times a day should I …") are excluded so the
+ * detector never converts an information ask into a mutation candidate.
+ */
+function looksLikeOwnerRoutineWriteRequest(text: string): boolean {
+	const normalized = text.toLowerCase().replace(/\s+/gu, " ").trim();
+	if (!normalized) return false;
+	// A leading question word marks an advice/lookup ask, not a commitment.
+	// "can/could you …" polite imperatives are deliberately NOT excluded.
+	if (
+		/^\s*(?:what|whats|what's|how|why|when|where|is|are|does|should)\b/iu.test(
+			normalized,
+		)
+	) {
+		return false;
+	}
+	const hasRecurringCadence =
+		/\b\d+\s+times?\s+(?:a|per|each|every)\s+(?:day|week|month)\b/iu.test(
+			normalized,
+		) ||
+		/\b(?:every|each)\s+(?:day|morning|evening|night|week(?:day)?)\b/iu.test(
+			normalized,
+		) ||
+		/\b(?:daily|weekly)\b/iu.test(normalized);
+	if (
+		/\b\d+\s+times?\s+(?:a|per|each|every)\s+(?:day|week|month)\b/iu.test(
+			normalized,
+		)
+	) {
+		return true;
+	}
+	const hasRoutineNoun = /\b(?:habit|routine)s?\b/iu.test(normalized);
+	const hasWriteVerb =
+		/\b(?:track|start|create|add|set\s+up|save|log|schedule|build|make)\b/iu.test(
+			normalized,
+		);
+	if (hasRoutineNoun && hasWriteVerb) return true;
+	if (
+		/\bremind\s+me\b/iu.test(normalized) &&
+		(hasRecurringCadence || hasRoutineNoun)
+	) {
+		return true;
+	}
+	return hasRecurringCadence && /\bschedule\b/iu.test(normalized);
+}
+
+function findOwnerRoutinesActionName(
+	actions: ReadonlyArray<Pick<Action, "name" | "similes">>,
+): string | undefined {
+	return findAvailableActionName(actions, OWNER_ROUTINES_ACTION_NAMES);
+}
+
 export function inferDirectCurrentRequestCandidateActions(
 	actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>,
 	messageText: string,
@@ -624,6 +700,27 @@ export function inferDirectCurrentRequestCandidateInference(
 	if (bareViewNavigationAction) {
 		return { names: [bareViewNavigationAction], kind: "view-navigation" };
 	}
+	// Owner mutations outrank navigation: a commitment to create/track/schedule
+	// something must never degrade into a view-catalog dump because a domain
+	// word incidentally overlaps a views tag (#17028). When the phrasing is an
+	// owner mutation but no owner surface is registered, the turn deliberately
+	// yields NO deterministic candidate — the model handles it and the
+	// unresolvable-capability path declines explicitly — instead of falling
+	// through to the weak view-capability overlap below.
+	if (looksLikeOwnerRoutineWriteRequest(messageText)) {
+		const ownerRoutinesAction = findOwnerRoutinesActionName(actions);
+		if (ownerRoutinesAction) {
+			return { names: [ownerRoutinesAction], kind: "owner-routines" };
+		}
+		return EMPTY_DIRECT_CANDIDATE_INFERENCE;
+	}
+	if (looksLikeOwnerGoalWriteRequest(messageText)) {
+		const ownerGoalsAction = findOwnerGoalsActionName(actions);
+		if (ownerGoalsAction) {
+			return { names: [ownerGoalsAction], kind: "owner-goals" };
+		}
+		return EMPTY_DIRECT_CANDIDATE_INFERENCE;
+	}
 	const viewCapabilityAction = findViewCapabilityActionName(
 		actions,
 		messageText,
@@ -634,12 +731,6 @@ export function inferDirectCurrentRequestCandidateInference(
 	if (looksLikeWebSearchRequest(messageText)) {
 		const lookupActions = findWebLookupActionNames(actions);
 		if (lookupActions.length > 0) return { names: lookupActions, kind: "web" };
-	}
-	if (looksLikeOwnerGoalWriteRequest(messageText)) {
-		const ownerGoalsAction = findOwnerGoalsActionName(actions);
-		if (ownerGoalsAction) {
-			return { names: [ownerGoalsAction], kind: "owner-goals" };
-		}
 	}
 	return EMPTY_DIRECT_CANDIDATE_INFERENCE;
 }
@@ -737,6 +828,17 @@ function hasLayoutDirectionToken(tokens: readonly string[]): boolean {
 const VIEW_REQUEST_OPERATION_TOKENS: ReadonlySet<string> = new Set<string>(
 	Object.values(VIEW_REQUEST_OPERATION_GROUPS).flat(),
 );
+
+// Operation groups that read as navigation over the view surface. The
+// mutation groups (create/update/delete) are deliberately absent: VIEWS can
+// only navigate, so a mutation verb is owner-domain evidence (#17028).
+const VIEW_NAVIGATION_OPERATION_GROUP_NAMES = [
+	"read",
+	"open",
+	"close",
+	"layout",
+	"pin",
+] as const;
 
 const VIEW_REQUEST_GENERIC_TOKENS: ReadonlySet<string> = new Set<string>([
 	"ACTION",
@@ -1001,6 +1103,23 @@ function findViewCapabilityActionName(
 	) {
 		return undefined;
 	}
+	// VIEWS can only NAVIGATE. Mutation verbs alone (create/update/delete) are
+	// owner-domain evidence, not view evidence — "add a savings goal" must not
+	// select the view catalog just because a "goals" tag exists (#17028). The
+	// capability leg needs navigation-shaped intent: a read/open/close/layout/
+	// pin operation, a directional qualifier, or an explicit UI-surface noun.
+	const hasNavigationOperation = VIEW_NAVIGATION_OPERATION_GROUP_NAMES.some(
+		(group) => messageOperationGroups.has(group),
+	);
+	if (
+		!hasNavigationOperation &&
+		!hasLayoutDirectionToken(messageTokens) &&
+		![...VIEW_REQUEST_SURFACE_TOKENS].some((token) =>
+			messageTokenSet.has(token),
+		)
+	) {
+		return undefined;
+	}
 
 	for (const viewAction of viewActions) {
 		for (const alias of [
@@ -1017,15 +1136,22 @@ function findViewCapabilityActionName(
 			) {
 				continue;
 			}
-			const targetTokens = aliasTokens
-				.map(normalizeSingularToken)
-				.filter(
-					(token) =>
-						!VIEW_REQUEST_OPERATION_TOKENS.has(token) &&
-						!VIEW_REQUEST_GENERIC_TOKENS.has(token),
-				);
-			if (targetTokens.length === 0) continue;
-			if (targetTokens.every((token) => messageTokenSet.has(token))) {
+			// Multiword capability tags are PHRASES: every non-operation token —
+			// generic ones like SCREEN included — must appear in the message.
+			// Filtering generics out let "screen-time" collapse to the bare TIME
+			// token, so "whats 17 times 23" and "3 times a day" matched a
+			// screen-time capability (#17028, tj-501e594bfb23a7). At least one
+			// concrete (non-generic) token is still required so purely generic
+			// aliases ("view-capability") never match on their own vocabulary.
+			const singularAliasTokens = aliasTokens.map(normalizeSingularToken);
+			const requiredTokens = singularAliasTokens.filter(
+				(token) => !VIEW_REQUEST_OPERATION_TOKENS.has(token),
+			);
+			const concreteTokens = requiredTokens.filter(
+				(token) => !VIEW_REQUEST_GENERIC_TOKENS.has(token),
+			);
+			if (concreteTokens.length === 0) continue;
+			if (requiredTokens.every((token) => messageTokenSet.has(token))) {
 				return viewActionName;
 			}
 		}

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/candidate-backstop.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/candidate-backstop.test.ts
@@ -43,6 +43,12 @@ describe("looksLikeScheduledTaskRequest", () => {
     ).toBe(true);
   });
 
+  it("does not treat bare scheduled status prose as a mutation claim", () => {
+    expect(
+      looksLikeScheduledTaskRequest("the report was scheduled by the server"),
+    ).toBe(false);
+  });
+
   it("keeps existing reminder and time phrasing matching", () => {
     expect(looksLikeScheduledTaskRequest("remind me tomorrow at 9am")).toBe(
       true,

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/candidate-backstop.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/candidate-backstop.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Deterministic unit coverage for the LifeOps scheduled-task candidate
+ * backstop rule: the matcher's habit/routine and recurring-cadence phrasing,
+ * the past-tense fabricated-claim shape, coding-text non-matches, and the
+ * owner-surface recovery targets in the declared action-name list (#17028).
+ * Pure functions, no runtime or mocks.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  createScheduledTaskCandidateBackstopRule,
+  looksLikeScheduledTaskRequest,
+} from "./candidate-backstop";
+
+describe("looksLikeScheduledTaskRequest", () => {
+  it("matches recurring-cadence commitments without a task noun (#17028)", () => {
+    for (const text of [
+      "25 pushups, 3 times a day, doesnt matter when i just need to get them in",
+      "drink water 8 times a day",
+      "call mom 2 times per week",
+    ]) {
+      expect(looksLikeScheduledTaskRequest(text)).toBe(true);
+    }
+  });
+
+  it("matches habit/routine write phrasing", () => {
+    for (const text of [
+      "track this habit for me",
+      "create a morning routine",
+      "set up a weekly routine",
+    ]) {
+      expect(looksLikeScheduledTaskRequest(text)).toBe(true);
+    }
+  });
+
+  it("matches the past-tense fabricated side-effect claim shape", () => {
+    // core.simple_completed_side_effect_claim matches rules against the
+    // fabricated REPLY text to pick recovery candidates.
+    expect(
+      looksLikeScheduledTaskRequest(
+        "Done! I've scheduled your pushups for 9am, 2pm and 7pm.",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps existing reminder and time phrasing matching", () => {
+    expect(looksLikeScheduledTaskRequest("remind me tomorrow at 9am")).toBe(
+      true,
+    );
+    expect(looksLikeScheduledTaskRequest("snooze that check-in")).toBe(true);
+  });
+
+  it("does not match coding or arithmetic text", () => {
+    for (const text of [
+      "refactor the auth module and add unit tests",
+      "whats 17 times 23?",
+      "fix the build failure in ci",
+      "",
+    ]) {
+      expect(looksLikeScheduledTaskRequest(text)).toBe(false);
+    }
+  });
+});
+
+describe("createScheduledTaskCandidateBackstopRule", () => {
+  it("declares the owner recurring-commitment surfaces as recovery targets", () => {
+    const rule = createScheduledTaskCandidateBackstopRule();
+    expect(rule.actionNames).toContain("OWNER_ROUTINES");
+    expect(rule.actionNames).toContain("OWNER_REMINDERS");
+    expect(rule.actionNames).toContain("SCHEDULED_TASKS_CREATE");
+    expect(rule.matches("25 pushups, 3 times a day")).toBe(true);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/candidate-backstop.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/candidate-backstop.ts
@@ -62,10 +62,11 @@ export function looksLikeScheduledTaskRequest(text: string): boolean {
     /\b(?:schedule|create|make|add|set\s+up|track)\b[\s\S]{0,80}\b(?:task|reminder|todo|to[- ]?do|check[- ]?in|follow[- ]?up|watcher|recap|approval|habit|routine)\b/iu.test(
       normalized,
     ) ||
-    // Past tense covers fabricated side-effect claims ("I've scheduled your
-    // pushups"), which are matched against REPLY text to pick recovery
-    // candidates (#17028).
-    /\bscheduled\b/iu.test(normalized) ||
+    // First-person past tense covers fabricated side-effect claims ("I've
+    // scheduled your pushups"), which are matched against REPLY text to pick
+    // recovery candidates. A bare "scheduled" is intentionally insufficient:
+    // status reports and coding asks commonly discuss scheduled work (#17028).
+    /\b(?:i|we)(?:['’]ve| have)\s+scheduled\b/iu.test(normalized) ||
     // Recurring cadence phrasing is a scheduled-item commitment even without
     // an explicit task/reminder noun ("25 pushups, 3 times a day").
     /\b\d+\s+times?\s+(?:a|per|each|every)\s+(?:day|week|month)\b/iu.test(

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/candidate-backstop.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/candidate-backstop.ts
@@ -37,6 +37,13 @@ const SCHEDULED_TASK_ACTION_NAMES: readonly string[] = [
   "SCHEDULED_TASKS_SKIP",
   "SCHEDULED_TASKS_SNOOZE",
   "SCHEDULED_TASKS_UPDATE",
+  // Owner recurring-commitment surfaces. Habit/routine phrasing ("25 pushups,
+  // 3 times a day") is a scheduled-item mutation, and the fabricated-claim
+  // recovery path resolves its candidates from this list — without these
+  // names a fake "I've scheduled your pushups" reply had no owner-routine
+  // recovery target (#17028).
+  "OWNER_ROUTINES",
+  "OWNER_REMINDERS",
 ];
 
 /**
@@ -49,10 +56,19 @@ export function looksLikeScheduledTaskRequest(text: string): boolean {
     return false;
   }
   return (
-    /\b(?:remind\s+me|reminder|scheduled\s+task|scheduled\s+item|lifeops|todo|to[- ]?do|snooze|recap|check[- ]?in|follow[- ]?up|watcher|approval)\b/iu.test(
+    /\b(?:remind\s+me|reminder|scheduled?\s+task|scheduled\s+item|lifeops|todo|to[- ]?do|snooze|recap|check[- ]?in|follow[- ]?up|watcher|approval)\b/iu.test(
       normalized,
     ) ||
-    /\b(?:schedule|create|make|add|set\s+up)\b[\s\S]{0,80}\b(?:task|reminder|todo|to[- ]?do|check[- ]?in|follow[- ]?up|watcher|recap|approval)\b/iu.test(
+    /\b(?:schedule|create|make|add|set\s+up|track)\b[\s\S]{0,80}\b(?:task|reminder|todo|to[- ]?do|check[- ]?in|follow[- ]?up|watcher|recap|approval|habit|routine)\b/iu.test(
+      normalized,
+    ) ||
+    // Past tense covers fabricated side-effect claims ("I've scheduled your
+    // pushups"), which are matched against REPLY text to pick recovery
+    // candidates (#17028).
+    /\bscheduled\b/iu.test(normalized) ||
+    // Recurring cadence phrasing is a scheduled-item commitment even without
+    // an explicit task/reminder noun ("25 pushups, 3 times a day").
+    /\b\d+\s+times?\s+(?:a|per|each|every)\s+(?:day|week|month)\b/iu.test(
       normalized,
     ) ||
     /\b(?:tomorrow|tonight|later|next\s+(?:week|month|monday|tuesday|wednesday|thursday|friday|saturday|sunday)|at\s+\d{1,2}(?::\d{2})?\s*(?:am|pm)?|every\s+(?:day|week|month|morning|evening))\b/iu.test(


### PR DESCRIPTION
## Problem (#17028)

A routine-creation turn — "25 pushups, 3 times a day, doesnt matter when i just need to get them in" — was deterministically hijacked into a VIEWS catalog dump: `times` singularizes to `TIME` and satisfied the collapsed `screen-time` capability tag, the view-capability leg ran before any owner-domain detector, and the max-normalized BM25 keyword search let an unrelated navigation help FAQ reach similarity 1.0 and inject a "Do not ... invoke tools/actions" envelope that suppressed the mutation path.

## Changes

**`packages/core/src/services/message/direct-action-heuristics.ts`**
- Multiword capability tags are preserved as phrases: every non-operation alias token (generics like SCREEN included) must literally appear in the message, and at least one concrete token is still required. `screen-time` can never again be satisfied by bare TIME.
- The capability leg now requires navigation-shaped intent (a read/open/close/layout/pin operation, a directional qualifier, or a UI surface noun). Mutation verbs (create/update/delete groups) alone never select VIEWS — VIEWS can only navigate.
- New `owner-routines` inference kind: `looksLikeOwnerRoutineWriteRequest` (habit/routine writes, "N times a day/week" cadences, recurring reminders; advice questions excluded) resolved via `OWNER_ROUTINES` and its similes. Owner-mutation detectors (routines + goals) now run BEFORE the view-capability leg, and a mutation-shaped turn with no registered owner surface yields NO candidate — the explicit unavailable path — instead of falling through to the view catalog.

**`plugins/plugin-personal-assistant/src/lifeops/scheduled-task/candidate-backstop.ts`**
- `OWNER_ROUTINES`/`OWNER_REMINDERS` added to the backstop's action names (the fabricated-claim recovery path picks targets from this list), matcher extended for recurring cadences and past-tense "scheduled" claim shapes.

**`packages/agent/src/api/chat-augmentation.ts`**
- Keyword BM25 similarity is max-normalized within each result set (the best hit is ALWAYS 1.0), so the threshold was a relative rank cut, not a relevance gate. Injection now additionally requires ≥50% literal coverage of the query's meaningful (non-stopword) terms in the fragment; all-stopword queries never inject. Deliberately local to this boundary — `normalizeBm25Scores`/`tokenize` are untouched, so hybrid search's 0.6/0.4 blend is unchanged.

## Deterministic tests (all per issue AC)

- The exact push-up turn resolves `OWNER_ROUTINES` when registered and `{names:[],kind:null}` when not — never VIEWS.
- "3 times a day", "whats 17 times 23?", "i need to get the time for the meeting" produce no candidate.
- "show my screen time", "whats my screen time" (ack-promotion fence at live-regression :1170), "list views", bare "settings", "move my settings to the right" all keep their VIEWS routing.
- Workout query vs seeded navigation FAQ: no injection; genuine "how do i switch views?" still injects.
- Two fences that pinned the buggy behavior were deliberately rewritten as the issue's plan specifies.

## Test results

- `packages/core`: direct-action-heuristics 58 pass; message-routing-live-regression 69 pass; full `src/services/message` + stage1 lane 711 pass, 1 fail — **pre-existing** (`does not re-add generic inferred actions after an evaluator clears the candidate route`), reproduced identically on clean `develop` in the same environment via `git stash`.
- `packages/agent`: chat-augmentation 17 pass, access-context 4 pass.
- `plugin-personal-assistant`: new candidate-backstop suite 6 pass.
- Typecheck: touched files clean in core/agent/PA (remaining package errors are pre-existing unbuilt-sibling-dep noise, unchanged by this PR).
- Biome clean on all touched files.

## Residual risk

The deterministic layer cannot forbid a MODEL-emitted VIEWS candidate (those escalate by design), and the VIEWS action's broad domain tags / routingHint prose (sibling scope, #17026/#17029 overlap) still influence live Stage-1 prompts — full live-trajectory proof of the transcript remains for the epic's live lane. Retrieval-side `CANDIDATE_ACTION_PARENT_ALIASES` OWNER_ prefix aliasing (action-retrieval.ts) is tracked on the issue and intentionally not bundled here.

Fixes #17028

🤖 Generated with [Claude Code](https://claude.com/claude-code)