### PR TITLE
test(agent): use a real response for pair timeout

### DIFF
--- a/packages/agent/src/api/cloud-pair-route.test.ts
+++ b/packages/agent/src/api/cloud-pair-route.test.ts
@@ -450,10 +450,9 @@ describe("handleStandaloneCloudPairRoute", () => {
         vi.fn((_input: string | URL | Request, init?: RequestInit) => {
           const signal = init?.signal;
           if (!signal) throw new Error("Expected the relay abort signal.");
-          return Promise.resolve({
-            ok: true,
-            status: 200,
-            json: () =>
+          const response = new Response(null, { status: 200 });
+          vi.spyOn(response, "json").mockImplementation(
+            () =>
               new Promise<never>((_resolve, reject) => {
                 signal.addEventListener(
                   "abort",
@@ -466,7 +465,8 @@ describe("handleStandaloneCloudPairRoute", () => {
                   { once: true },
                 );
               }),
-          } as Response);
+          );
+          return Promise.resolve(response);
         }),
       );
 


### PR DESCRIPTION
Closes #19768.

## What changed

The stalled successful `/pair` relay test now uses a real Web API `Response` and spies only its `json()` method to model a body that rejects when the relay abort signal fires. This preserves the production response contract and removes the invalid direct cast from a partial object to `Response`.

## Exact-head validation

Validated at `fc1624f43c0b3bad9b7e86ef34526287635e9ace`, rebased onto current `origin/develop` (`e1b39f54ac572c56c5e19c8eb64bb779cb9e7636`).

- Focused Vitest route suite: 21 passed, 0 failed.
- Agent dependency build: 84/84 tasks passed.
- `bun run --cwd packages/agent typecheck`: passed.
- Biome check on the touched test: passed.
- `git diff --check`: passed.
- Root `bun run verify` advances past the original `@elizaos/agent#typecheck` TS2352 failure and stops at the independently tracked Cloud persona regression #19755, fixed by PR #19767.

## Evidence

This is a test/type-contract correction with no rendered or user-facing behavior. Screenshots, video, live-model trajectory, and persistent artifacts are N/A. The focused timeout-path test and package typecheck are the applicable evidence.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - repository contribution skill is not available in this session
Attribution status: self-reported
— Codex
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - repository contribution skill is not available in this session"} -->
