### PR TITLE
fix(cloud): prewarm voice conversation during greeting

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/voice-agent-scope-hydration.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/voice-agent-scope-hydration.test.ts
@@ -161,6 +161,43 @@ test("publishes the authorization scope before optional admission prefill comple
   });
 });
 
+test("prewarms the call conversation while the fixed greeting is playing", async () => {
+  const requests: Request[] = [];
+  const voiceEnv = {
+    ...env,
+    SHARED_RUNTIME_CONVERSATIONS: {
+      getByName(name: string) {
+        expect(name).toBe(`${AGENT_ID}:${CONVERSATION_ID}`);
+        return {
+          async fetch(input: RequestInfo | URL, init?: RequestInit) {
+            requests.push(new Request(input, init));
+            return Response.json({ success: true });
+          },
+        };
+      },
+    },
+  };
+
+  await runWithCloudBindingsAsync(voiceEnv, async () => {
+    await hydrateVoiceSharedAgentScope(
+      voiceEnv as unknown as Parameters<typeof hydrateVoiceSharedAgentScope>[0],
+      claims,
+      sharedAgent as never,
+    );
+  });
+
+  expect(requests).toHaveLength(1);
+  const request = requests[0];
+  if (!request) throw new Error("expected conversation prewarm request");
+  expect(request.url).toBe("https://shared-runtime.internal/prewarm");
+  const body = (await request.json()) as unknown;
+  expect(body).toEqual({
+    operation: "prewarm",
+    agentId: AGENT_ID,
+    roomId: CONVERSATION_ID,
+  });
+});
+
 test("does not overwrite an already-warm character entry", async () => {
   await runWithCloudBindingsAsync(env, async () => {
     await cache.set(CHARACTER_KEY, { id: CHARACTER_ID, name: "Existing" }, 60);

--- a/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
+++ b/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
@@ -15,6 +15,7 @@ import { cache } from "@/lib/cache/client";
 import { CacheKeys, CacheTTL } from "@/lib/cache/keys";
 import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
 import { warmInferenceAdmissionSnapshot } from "@/lib/services/inference-admission-snapshot";
+import { coordinateSharedConversationPrewarm } from "@/lib/services/shared-runtime/conversation-coordinator";
 import { logger } from "@/lib/utils/logger";
 import type { Bindings } from "@/types/cloud-worker-env";
 import type { InternalElizaConversationFetchClaims } from "./internal-eliza-conversation-fetch";
@@ -83,7 +84,7 @@ export async function hydrateVoiceSharedAgentScope(
 
         // error-policy:J7 a failed character prefill leaves the next turn on
         // its existing retryable warming path rather than failing hydration.
-        await Promise.all([
+        const optionalWarmups: Promise<unknown>[] = [
           hydrateCharacter().catch((error) => {
             logger.warn("[voice-scope-hydration] character prefill failed", {
               agentId: claims.agentId,
@@ -102,7 +103,28 @@ export async function hydrateVoiceSharedAgentScope(
               });
             },
           ),
-        ]);
+        ];
+        if (env.SHARED_RUNTIME_CONVERSATIONS) {
+          optionalWarmups.push(
+            coordinateSharedConversationPrewarm(
+              claims.agentId,
+              claims.conversationId,
+              { namespace: env.SHARED_RUNTIME_CONVERSATIONS },
+            ).catch((error) => {
+              // error-policy:J7 conversation hydration is a latency hint; the
+              // real turn retains its typed cache-warming retry fallback.
+              logger.warn(
+                "[voice-scope-hydration] conversation prefill failed",
+                {
+                  agentId: claims.agentId,
+                  conversationId: claims.conversationId,
+                  error: error instanceof Error ? error.message : String(error),
+                },
+              );
+            }),
+          );
+        }
+        await Promise.all(optionalWarmups);
       }),
   );
 }


### PR DESCRIPTION
Calls the existing conversation-scoped Durable Object prewarm from the Twilio inbound warmup, using the actual per-call conversation ID. This overlaps cold history hydration with ringing, greeting, and caller speech instead of making the first utterance pay the 503 retry staircase. Verified with 8 focused prewarm/hydration tests, cloud API typecheck, Worker dry-run bundle, and Biome.