### PR TITLE
feat(cloud): continue personal Eliza across messaging and calls (#19772)

### DIFF
--- a/packages/cloud/api/internal/discord/eliza-app/messages/route.ts
+++ b/packages/cloud/api/internal/discord/eliza-app/messages/route.ts
@@ -6,6 +6,7 @@ import { agentGatewayRouterService } from "@/lib/services/agent-gateway-router";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { requireInternalAuth } from "../../../_auth";
+import personalSharedMessagesApp from "../../../eliza-app/personal-shared/messages/route";
 
 const messageSchema = z.object({
   guildId: z.string().trim().min(1).optional(),
@@ -28,14 +29,62 @@ app.post("/", async (c) => {
     if (auth instanceof Response) return auth;
 
     const body = messageSchema.parse(await c.req.json());
-    const result = await agentGatewayRouterService.routeDiscordMessage({
-      guildId: body.guildId,
-      channelId: body.channelId,
-      messageId: body.messageId,
-      content: body.content,
-      sender: body.sender,
+    if (body.guildId) {
+      const result = await agentGatewayRouterService.routeDiscordMessage({
+        guildId: body.guildId,
+        channelId: body.channelId,
+        messageId: body.messageId,
+        content: body.content,
+        sender: body.sender,
+      });
+      return c.json(result);
+    }
+
+    const response = await personalSharedMessagesApp.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          authorization: c.req.header("authorization") ?? "",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          platform: "discord",
+          discordUserId: body.sender.id,
+          discordUsername: body.sender.username,
+          displayName: body.sender.displayName,
+          avatarUrl: body.sender.avatar,
+          messageId: `discord:${body.messageId}`,
+          message: body.content,
+        }),
+      },
+      c.env,
+      c.executionCtx,
+    );
+    const payload = (await response.json()) as {
+      success?: boolean;
+      error?: string;
+      code?: string;
+      data?: {
+        identity: { id: string };
+        account: { userId: string; organizationId: string };
+        reply: string;
+      };
+    };
+    if (!response.ok || !payload.success || !payload.data) {
+      return c.json(
+        payload,
+        response.status as 400 | 401 | 402 | 403 | 500 | 503,
+      );
+    }
+    return c.json({
+      handled: true,
+      replyText: payload.data.reply,
+      agentId: payload.data.identity.id,
+      roomId: payload.data.identity.id,
+      userId: payload.data.account.userId,
+      organizationId: payload.data.account.organizationId,
     });
-    return c.json(result);
   } catch (err) {
     logger.error("[internal/discord/eliza-app/messages]", { error: err });
     return failureResponse(c, err);

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -14,6 +14,11 @@ const findOrCreateByPhone = mock(async () => ({
   organization: { id: "00000000-0000-4000-8000-000000000011" },
   isNew: true,
 }));
+const findOrCreateByDiscordId = mock(async () => ({
+  user: { id: "00000000-0000-4000-8000-000000000002" },
+  organization: { id: "00000000-0000-4000-8000-000000000001" },
+  isNew: false,
+}));
 const sharedRestMessageSend = mock(async () => ({ text: "hello from Eliza" }));
 const runOnboardingChat = mock(async (_input: OnboardingChatInput) => ({
   loginUrl:
@@ -106,7 +111,11 @@ const namespace = {
 const runtimeExecutionCtx = { waitUntil() {} };
 
 mock.module("@/lib/services/eliza-app", () => ({
-  elizaAppUserService: { findOrCreateByPhone, findOrCreateByTelegram },
+  elizaAppUserService: {
+    findOrCreateByDiscordId,
+    findOrCreateByPhone,
+    findOrCreateByTelegram,
+  },
 }));
 mock.module("@/lib/services/shared-runtime/shared-rest-adapter", () => ({
   sharedRestMessageSend,
@@ -181,6 +190,7 @@ const validPhone = {
 describe("personal Shared messaging deliveries", () => {
   beforeEach(() => {
     findOrCreateByPhone.mockClear();
+    findOrCreateByDiscordId.mockClear();
     activeTarget = null;
     findOrCreateByTelegram.mockClear();
     findActivePersonalDedicatedTarget.mockClear();
@@ -327,6 +337,38 @@ describe("personal Shared messaging deliveries", () => {
       runtimeExecutionCtx,
       namespace,
       "blooio:eliza:message-42",
+      "platform",
+    );
+  });
+
+  test("routes a linked Discord DM through the same personal room", async () => {
+    const response = await request({
+      platform: "discord",
+      discordUserId: "123456789012345678",
+      discordUsername: "shaw",
+      displayName: "Shaw",
+      avatarUrl: "https://cdn.discordapp.com/avatar.png",
+      messageId: "discord:message-42",
+      message: "continue our conversation",
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      data: { identity: { id: string } };
+    };
+    expect(findOrCreateByDiscordId).toHaveBeenCalledWith("123456789012345678", {
+      username: "shaw",
+      globalName: "Shaw",
+      avatarUrl: "https://cdn.discordapp.com/avatar.png",
+    });
+    expect(sharedRestMessageSend).toHaveBeenCalledWith(
+      expect.objectContaining({ id: body.data.identity.id }),
+      body.data.identity.id,
+      "continue our conversation",
+      "Eliza",
+      runtimeExecutionCtx,
+      namespace,
+      "discord:message-42",
       "platform",
     );
   });

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -166,6 +166,7 @@ function request(body: unknown, authorization = "Bearer test-secret") {
     {
       INTERNAL_SECRET: "test-secret",
       SHARED_RUNTIME_CONVERSATIONS: namespace,
+      WHISPER_STT_URL: "https://whisper.test",
     } as never,
     executionCtx as never,
   );
@@ -238,6 +239,68 @@ describe("personal Shared messaging deliveries", () => {
       "telegram:eliza:42",
       "platform",
     );
+  });
+
+  test("transcribes a Telegram voice note before the Shared turn", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async (input, init) => {
+      const outbound = new Request(input, init);
+      expect(outbound.url).toBe("https://whisper.test/v1/audio/transcriptions");
+      const form = await outbound.formData();
+      const file = form.get("file");
+      expect(file).toBeInstanceOf(File);
+      expect((file as File).type).toBe("audio/ogg");
+      return Response.json({ text: "remember the red bicycle" });
+    }) as unknown as typeof fetch;
+    const bytes = Buffer.from("OggSvoice-note");
+    try {
+      const response = await request({
+        ...valid,
+        message: undefined,
+        voiceNote: {
+          bytesBase64: bytes.toString("base64"),
+          mimeType: "audio/ogg",
+          filename: "telegram-42.ogg",
+          sizeBytes: bytes.length,
+          durationSeconds: 4,
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(sharedRestMessageSend).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringMatching(/^personal:/),
+        "remember the red bicycle",
+        "Eliza",
+        runtimeExecutionCtx,
+        namespace,
+        "telegram:eliza:42",
+        "platform",
+      );
+      await expect(response.json()).resolves.toMatchObject({
+        data: { reply: "hello from Eliza" },
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("rejects a forged voice payload before identity, storage, or inference", async () => {
+    const response = await request({
+      ...valid,
+      message: undefined,
+      voiceNote: {
+        bytesBase64: Buffer.from("not ogg").toString("base64"),
+        mimeType: "audio/ogg",
+        filename: "telegram-42.ogg",
+        sizeBytes: 7,
+        durationSeconds: 4,
+      },
+    });
+
+    expect(response.status).toBe(400);
+    expect(findOrCreateByTelegram).not.toHaveBeenCalled();
+    expect(sharedRestMessageSend).not.toHaveBeenCalled();
   });
 
   test("issues an account-bound Telegram claim without entering runtime or provisioning", async () => {

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -29,6 +29,15 @@ const sharedMessageSchema = z.discriminatedUnion("platform", [
     message: z.string().trim().min(1).max(4000),
   }),
   z.object({
+    platform: z.literal("discord"),
+    discordUserId: z.string().trim().min(1).max(32),
+    discordUsername: z.string().trim().min(1).max(80),
+    displayName: z.string().trim().min(1).max(128).optional(),
+    avatarUrl: z.string().url().nullable().optional(),
+    messageId: z.string().trim().min(1).max(160),
+    message: z.string().trim().min(1).max(4000),
+  }),
+  z.object({
     platform: z.enum(["twilio", "blooio"]),
     phoneNumber: z
       .string()
@@ -47,6 +56,7 @@ app.post("/", async (c) => {
     if (auth instanceof Response) return auth;
     if (
       auth.service !== "webhook-gateway" &&
+      auth.service !== "discord-gateway" &&
       auth.service !== "shared-secret"
     ) {
       return jsonError(c, 403, "Forbidden", "access_denied");
@@ -95,9 +105,18 @@ app.post("/", async (c) => {
             username: parsed.data.telegramUsername,
             displayName: parsed.data.displayName,
           })
-        : await elizaAppUserService.findOrCreateByPhone(
-            parsed.data.phoneNumber,
-          );
+        : parsed.data.platform === "discord"
+          ? await elizaAppUserService.findOrCreateByDiscordId(
+              parsed.data.discordUserId,
+              {
+                username: parsed.data.discordUsername,
+                globalName: parsed.data.displayName,
+                avatarUrl: parsed.data.avatarUrl,
+              },
+            )
+          : await elizaAppUserService.findOrCreateByPhone(
+              parsed.data.phoneNumber,
+            );
     const agent = personalSharedAgent({
       userId: account.user.id,
       organizationId: account.organization.id,
@@ -214,10 +233,14 @@ app.post("/", async (c) => {
           clientMessageId: parsed.data.messageId,
           platformName: parsed.data.platform,
           source: parsed.data.platform,
-          ...(parsed.data.platform === "telegram"
+          ...(parsed.data.platform === "telegram" ||
+          parsed.data.platform === "discord"
             ? {
                 senderName:
-                  parsed.data.displayName ?? parsed.data.telegramUsername,
+                  parsed.data.displayName ??
+                  (parsed.data.platform === "telegram"
+                    ? parsed.data.telegramUsername
+                    : parsed.data.discordUsername),
               }
             : {}),
         },
@@ -231,7 +254,14 @@ app.post("/", async (c) => {
         const history = await coordinateSharedHistory(agent.id, agent.id, {
           namespace: worker.namespace,
         });
-        const importMessages = history.flatMap((message) =>
+        const importableHistory = history.filter(
+          (
+            message,
+          ): message is typeof message & {
+            role: "user" | "assistant";
+          } => message.role === "user" || message.role === "assistant",
+        );
+        const importMessages = importableHistory.flatMap((message) =>
           message.id
             ? [
                 {
@@ -246,7 +276,7 @@ app.post("/", async (c) => {
             : [],
         );
         let receipt =
-          importMessages.length === history.length
+          importMessages.length === importableHistory.length
             ? await elizaSandboxService.importCanonicalConversation(
                 dedicated.id,
                 account.organization.id,

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -13,21 +13,50 @@ import { coordinateSharedHistory } from "@/lib/services/shared-runtime/conversat
 import { personalSharedAgent } from "@/lib/services/shared-runtime/personal-shared-agent";
 import { resolveSharedRuntimeWorkerRequestContext } from "@/lib/services/shared-runtime/resolve-shared-agent";
 import { sharedRestMessageSend } from "@/lib/services/shared-runtime/shared-rest-adapter";
+import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { requireInternalAuth } from "../../../_auth";
 
+// Telegram's hosted Bot API download ceiling is 20 MiB. This stricter product
+// ceiling keeps the base64 JSON body (~10.7 MiB) and decoded copies bounded in
+// a 128 MiB Worker isolate while covering ordinary conversational voice notes.
+const MAX_TELEGRAM_VOICE_BYTES = 8 * 1024 * 1024;
+const MAX_TELEGRAM_VOICE_BASE64_LENGTH =
+  Math.ceil(MAX_TELEGRAM_VOICE_BYTES / 3) * 4;
+const DEFAULT_WHISPER_MODEL = "Systran/faster-whisper-small";
+
+const telegramVoiceNoteSchema = z.object({
+  bytesBase64: z.string().min(1).max(MAX_TELEGRAM_VOICE_BASE64_LENGTH),
+  mimeType: z.literal("audio/ogg"),
+  filename: z
+    .string()
+    .trim()
+    .regex(/^telegram-[A-Za-z0-9:._-]+\.ogg$/),
+  sizeBytes: z.number().int().positive().max(MAX_TELEGRAM_VOICE_BYTES),
+  durationSeconds: z
+    .number()
+    .int()
+    .min(0)
+    .max(15 * 60),
+});
+
 const sharedMessageSchema = z.discriminatedUnion("platform", [
-  z.object({
-    platform: z.literal("telegram"),
-    telegramUserId: z
-      .string()
-      .trim()
-      .regex(/^\d{1,20}$/),
-    telegramUsername: z.string().trim().min(1).max(64).optional(),
-    displayName: z.string().trim().min(1).max(128).optional(),
-    messageId: z.string().trim().min(1).max(160),
-    message: z.string().trim().min(1).max(4000),
-  }),
+  z
+    .object({
+      platform: z.literal("telegram"),
+      telegramUserId: z
+        .string()
+        .trim()
+        .regex(/^\d{1,20}$/),
+      telegramUsername: z.string().trim().min(1).max(64).optional(),
+      displayName: z.string().trim().min(1).max(128).optional(),
+      messageId: z.string().trim().min(1).max(160),
+      message: z.string().trim().min(1).max(4000).optional(),
+      voiceNote: telegramVoiceNoteSchema.optional(),
+    })
+    .refine(
+      (input) => input.message !== undefined || input.voiceNote !== undefined,
+    ),
   z.object({
     platform: z.literal("discord"),
     discordUserId: z.string().trim().min(1).max(32),
@@ -47,6 +76,74 @@ const sharedMessageSchema = z.discriminatedUnion("platform", [
     message: z.string().trim().min(1).max(4000),
   }),
 ]);
+
+function decodeTelegramVoiceNote(
+  input: z.infer<typeof telegramVoiceNoteSchema>,
+): Uint8Array {
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(input.bytesBase64)) {
+    throw new Error("Telegram voice note is not canonical base64");
+  }
+  const bytes = Buffer.from(input.bytesBase64, "base64");
+  if (
+    bytes.byteLength !== input.sizeBytes ||
+    bytes.byteLength > MAX_TELEGRAM_VOICE_BYTES ||
+    bytes.toString("base64") !== input.bytesBase64
+  ) {
+    throw new Error("Telegram voice note byte length is invalid");
+  }
+  if (bytes.subarray(0, 4).toString("ascii") !== "OggS") {
+    throw new Error("Telegram voice note is not an Ogg stream");
+  }
+  return bytes;
+}
+
+async function transcribeTelegramVoiceNote(
+  env: AppEnv["Bindings"],
+  bytes: Uint8Array,
+  filename: string,
+): Promise<string> {
+  const whisperBaseUrl = env.WHISPER_STT_URL?.trim();
+  if (!whisperBaseUrl) {
+    throw new Error("Telegram voice transcription is not configured");
+  }
+  const audio = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(audio).set(bytes);
+  const form = new FormData();
+  form.append("file", new File([audio], filename, { type: "audio/ogg" }));
+  form.append("model", env.WHISPER_STT_MODEL?.trim() || DEFAULT_WHISPER_MODEL);
+  const response = await fetch(
+    `${whisperBaseUrl.replace(/\/+$/, "")}/v1/audio/transcriptions`,
+    {
+      method: "POST",
+      body: form,
+      signal: AbortSignal.timeout(60_000),
+    },
+  );
+  if (!response.ok) {
+    await response.body?.cancel();
+    throw new Error(`Telegram voice transcription failed (${response.status})`);
+  }
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    // error-policy:J3 the transcription provider response is untrusted input.
+    throw new Error("Telegram voice transcription returned invalid JSON", {
+      cause: error,
+    });
+  }
+  const transcript =
+    payload !== null &&
+    typeof payload === "object" &&
+    !Array.isArray(payload) &&
+    typeof (payload as Record<string, unknown>).text === "string"
+      ? ((payload as Record<string, unknown>).text as string).trim()
+      : "";
+  if (!transcript) {
+    throw new Error("Telegram voice transcription returned no speech");
+  }
+  return transcript;
+}
 
 const app = new Hono<AppEnv>();
 
@@ -82,6 +179,20 @@ app.post("/", async (c) => {
         "Invalid messaging delivery",
         "validation_error",
       );
+    }
+    let telegramVoiceBytes: Uint8Array | undefined;
+    if (parsed.data.platform === "telegram" && parsed.data.voiceNote) {
+      try {
+        telegramVoiceBytes = decodeTelegramVoiceNote(parsed.data.voiceNote);
+      } catch {
+        // error-policy:J3 decoded media bytes are untrusted transport input.
+        return jsonError(
+          c,
+          400,
+          "Invalid Telegram voice note",
+          "validation_error",
+        );
+      }
     }
 
     const worker = resolveSharedRuntimeWorkerRequestContext(c);
@@ -121,9 +232,43 @@ app.post("/", async (c) => {
       userId: account.user.id,
       organizationId: account.organization.id,
     });
+    let deliveryMessage = parsed.data.message;
     if (
       parsed.data.platform === "telegram" &&
-      /^\/connect(?:@[a-z0-9_]{5,32})?$/i.test(parsed.data.message)
+      parsed.data.voiceNote &&
+      telegramVoiceBytes
+    ) {
+      // Shared has no authenticated writer into the agent-owned canonical
+      // `/api/media/<sha>.<ext>` store. Keep only the transcript in durable
+      // conversation history; do not create a parallel R2 media namespace.
+      const transcript = await transcribeTelegramVoiceNote(
+        c.env,
+        telegramVoiceBytes,
+        parsed.data.voiceNote.filename,
+      );
+      deliveryMessage = parsed.data.message
+        ? `${parsed.data.message}\n\n[Voice note transcript]\n${transcript}`
+        : transcript;
+      logger.info(
+        "[personal-shared-messaging] Telegram voice note transcribed",
+        {
+          durationSeconds: parsed.data.voiceNote.durationSeconds,
+          sizeBytes: parsed.data.voiceNote.sizeBytes,
+          userId: account.user.id,
+        },
+      );
+    }
+    if (!deliveryMessage) {
+      return jsonError(
+        c,
+        400,
+        "Messaging delivery has no content",
+        "validation_error",
+      );
+    }
+    if (
+      parsed.data.platform === "telegram" &&
+      /^\/connect(?:@[a-z0-9_]{5,32})?$/i.test(deliveryMessage)
     ) {
       // A new command gets independent expiry while a webhook retry reaches
       // the same session. Reusing the sender's permanent session would make
@@ -225,7 +370,7 @@ app.post("/", async (c) => {
         id: parsed.data.messageId,
         method: "message.send",
         params: {
-          text: parsed.data.message,
+          text: deliveryMessage,
           roomId: agent.id,
           conversationId: agent.id,
           canonicalBridgeBase: dedicated.bridge_url,
@@ -336,7 +481,7 @@ app.post("/", async (c) => {
     const result = await sharedRestMessageSend(
       agent,
       agent.id,
-      parsed.data.message,
+      deliveryMessage,
       agent.agent_name ?? "Eliza",
       worker.executionCtx,
       worker.namespace,

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -26,20 +26,38 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 // `Date` columns arrive as ISO strings; `handle` rehydrates them before any
 // service consumes the row (the CONVERSATIONS-500 defect class).
 type ConversationRequest =
-  | { operation: "bridge"; agent: CachedAgentSandbox; rpc: BridgeRequest }
+  | {
+      operation: "bridge";
+      agent: CachedAgentSandbox;
+      rpc: BridgeRequest;
+      trustedMessageRole?: "system";
+    }
   | {
       operation: "personal-bridge";
       agent: SharedRuntimeAgent;
       rpc: BridgeRequest;
+      trustedMessageRole?: "system";
     }
-  | { operation: "stream"; agent: CachedAgentSandbox; rpc: BridgeRequest }
+  | {
+      operation: "stream";
+      agent: CachedAgentSandbox;
+      rpc: BridgeRequest;
+      trustedMessageRole?: "system";
+    }
   | {
       operation: "personal-stream";
       agent: SharedRuntimeAgent;
       rpc: BridgeRequest;
+      trustedMessageRole?: "system";
     }
   | { operation: "prewarm"; agentId: string; roomId: string }
   | { operation: "history"; agentId: string; roomId: string }
+  | {
+      operation: "lifecycle";
+      agentId: string;
+      roomId: string;
+      event: { id: string; content: string; createdAt: number };
+    }
   | {
       operation: "cutover-seal";
       agentId: string;
@@ -605,6 +623,7 @@ export class SharedRuntimeConversation {
     } else if (
       payload.operation === "prewarm" ||
       payload.operation === "history" ||
+      payload.operation === "lifecycle" ||
       payload.operation === "cutover-seal"
     ) {
       forwarded = {
@@ -970,6 +989,35 @@ export class SharedRuntimeConversation {
         { status: 423, headers: { "Retry-After": "1" } },
       );
     }
+    if (payload.operation === "lifecycle") {
+      if (
+        !payload.event?.id?.trim() ||
+        !payload.event.content?.trim() ||
+        !Number.isFinite(payload.event.createdAt)
+      ) {
+        return Response.json(
+          { success: false, code: "invalid_lifecycle_event" },
+          { status: 400 },
+        );
+      }
+      await this.runWithBindings(async () => {
+        const { sharedRuntimeChatService } = await import(
+          "@/lib/services/shared-runtime/shared-runtime-chat"
+        );
+        await sharedRuntimeChatService.recordLifecycleEvent(
+          payload.agentId,
+          payload.roomId,
+          {
+            id: payload.event.id,
+            role: "system",
+            content: payload.event.content,
+            createdAt: payload.event.createdAt,
+          },
+          historyStore,
+        );
+      });
+      return Response.json({ success: true });
+    }
     if (payload.operation === "prewarm") {
       await this.prewarmConversation(payload.agentId, payload.roomId);
       return Response.json({ success: true });
@@ -1105,6 +1153,7 @@ export class SharedRuntimeConversation {
           historyStore,
           turnClaims,
           funding: personal ? "platform" : "organization-credits",
+          trustedMessageRole: payload.trustedMessageRole,
         });
       }
       const result = await sharedRuntimeChatService.bridge(agent, payload.rpc, {
@@ -1112,6 +1161,7 @@ export class SharedRuntimeConversation {
         historyStore,
         turnClaims,
         funding: personal ? "platform" : "organization-credits",
+        trustedMessageRole: payload.trustedMessageRole,
       });
       return Response.json(result);
     });

--- a/packages/cloud/api/v1/twilio/voice/calls/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/calls/route.ts
@@ -22,7 +22,6 @@ import {
 } from "@/lib/utils/phone-normalization";
 import { twilioApiRequest } from "@/lib/utils/twilio-api";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
-import { resolveTwilioVoiceTarget } from "../lib/resolve-voice-target";
 
 const app = new Hono<AppEnv>();
 const IDEMPOTENCY_TTL_MS = 10 * 60 * 1000;
@@ -139,17 +138,6 @@ app.post("/", async (c) => {
     return c.json(
       {
         error: "Eliza calling is not configured",
-        code: "voice_not_configured",
-      },
-      503,
-    );
-  }
-
-  const target = await resolveTwilioVoiceTarget(c.env, fromNumber);
-  if (!target) {
-    return c.json(
-      {
-        error: "Eliza voice agent is not configured",
         code: "voice_not_configured",
       },
       503,

--- a/packages/cloud/api/v1/twilio/voice/inbound/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/inbound/route.ts
@@ -4,11 +4,12 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { and, eq, or } from "drizzle-orm";
+import { and, desc, eq, or } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
 import { dbRead, dbWrite } from "@/db/helpers";
-import { twilioInboundCalls } from "@/db/schemas";
+import { sharedRuntimeHistory, twilioInboundCalls } from "@/db/schemas";
+import { sharedRuntimeChannelId } from "@/lib/services/shared-runtime/shared-runtime-chat";
 import { ObjectNamespaces } from "@/lib/storage/object-namespace";
 import { offloadJsonField } from "@/lib/storage/object-store";
 import { logger } from "@/lib/utils/logger";
@@ -114,7 +115,11 @@ app.post("/", async (c) => {
     return new Response("Invalid signature", { status: 403 });
   }
 
-  const phoneNumber = await resolveTwilioVoiceTarget(c.env, publicLineNumber);
+  const phoneNumber = await resolveTwilioVoiceTarget(
+    c.env,
+    publicLineNumber,
+    callerNumber,
+  );
   if (!phoneNumber) {
     return new Response(buildTerminalVoiceTwiML(NOT_CONFIGURED_PROMPT), {
       headers: { "Content-Type": "text/xml" },
@@ -122,7 +127,7 @@ app.post("/", async (c) => {
   }
 
   const id = randomUUID();
-  const conversationId = randomUUID();
+  const conversationId = phoneNumber.agentId;
   try {
     scheduleTwilioVoiceScopePrewarm({
       agent: phoneNumber.agent,
@@ -144,7 +149,10 @@ app.post("/", async (c) => {
     });
   }
   const [priorCall] = await dbRead
-    .select({ id: twilioInboundCalls.id })
+    .select({
+      id: twilioInboundCalls.id,
+      receivedAt: twilioInboundCalls.received_at,
+    })
     .from(twilioInboundCalls)
     .where(
       and(
@@ -161,7 +169,26 @@ app.post("/", async (c) => {
         eq(twilioInboundCalls.agent_id, phoneNumber.agentId),
       ),
     )
+    .orderBy(desc(twilioInboundCalls.received_at))
     .limit(1);
+  const [priorConversation] = await dbRead
+    .select({ updatedAt: sharedRuntimeHistory.updated_at })
+    .from(sharedRuntimeHistory)
+    .where(
+      and(
+        eq(sharedRuntimeHistory.agent_id, phoneNumber.agentId),
+        eq(
+          sharedRuntimeHistory.channel_id,
+          sharedRuntimeChannelId(phoneNumber.agentId, conversationId),
+        ),
+      ),
+    )
+    .orderBy(desc(sharedRuntimeHistory.updated_at))
+    .limit(1);
+  const previousInteractionAt = Math.max(
+    priorCall?.receivedAt?.getTime() ?? 0,
+    priorConversation?.updatedAt?.getTime() ?? 0,
+  );
   const rawPayload = await offloadJsonField<Record<string, string>>({
     namespace: ObjectNamespaces.TwilioInboundPayloads,
     organizationId: phoneNumber?.organizationId ?? "twilio",
@@ -203,7 +230,9 @@ app.post("/", async (c) => {
       agentId: phoneNumber.agentId,
       conversationId,
       calledNumber: publicLineNumber,
-      returningCaller: Boolean(priorCall),
+      returningCaller: Boolean(priorCall || priorConversation),
+      previousInteractionAt:
+        previousInteractionAt > 0 ? previousInteractionAt : undefined,
     },
     authToken,
   );

--- a/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.ts
@@ -3,7 +3,7 @@
  * cold database work overlaps call setup, the greeting, and caller speech.
  */
 
-import type { AgentSandbox } from "@/db/repositories/agent-sandboxes";
+import type { SharedRuntimeAgent } from "@/lib/services/shared-runtime/shared-runtime-agent";
 import { logger } from "@/lib/utils/logger";
 import type { Bindings } from "@/types/cloud-worker-env";
 import type { InternalElizaConversationFetchClaims } from "../../../voice/session/lib/internal-eliza-conversation-fetch";
@@ -15,11 +15,11 @@ interface VoicePrewarmExecutionContext {
 type HydrateVoiceScope = (
   env: Bindings,
   claims: InternalElizaConversationFetchClaims,
-  preloadedAgent?: AgentSandbox,
+  preloadedAgent?: SharedRuntimeAgent,
 ) => Promise<void>;
 
 interface ScheduleVoiceScopePrewarmOptions {
-  agent?: AgentSandbox;
+  agent?: SharedRuntimeAgent;
   claims: InternalElizaConversationFetchClaims;
   env: Bindings;
   executionCtx: VoicePrewarmExecutionContext;

--- a/packages/cloud/api/v1/twilio/voice/lib/resolve-voice-target.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/resolve-voice-target.test.ts
@@ -1,97 +1,51 @@
 /**
- * Proves Twilio calls resolve only through the exact configured public line.
+ * Proves the public Twilio line resolves callers to account-native personal
+ * Shared agents and rejects every unconfigured destination.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-interface SandboxRow {
-  id: string;
-  organization_id: string;
-  user_id: string;
-  character_id: string | null;
-  agent_name: string | null;
-  agent_config: Record<string, unknown> | null;
-  execution_tier: "shared";
-}
+const findOrCreateByPhone = mock(async (_phone: string) => ({
+  user: { id: "11111111-1111-4111-a111-111111111111" },
+  organization: { id: "22222222-2222-4222-a222-222222222222" },
+}));
 
-function sandboxRow(id: string): SandboxRow {
-  return {
-    id,
-    organization_id: "org-public",
-    user_id: "user-public",
-    character_id: "character-public",
-    agent_name: "Eliza",
-    agent_config: null,
-    execution_tier: "shared",
-  };
-}
-
-const findById = mock(
-  async (_agentId: string): Promise<SandboxRow | null> => null,
-);
-const findLatestByCharacterId = mock(
-  async (_characterId: string): Promise<SandboxRow | null> => null,
-);
-
-mock.module("@/db/repositories/agent-sandboxes", () => ({
-  agentSandboxesRepository: {
-    findById,
-    findLatestByCharacterId,
-  },
+mock.module("@/lib/services/eliza-app/user-service", () => ({
+  elizaAppUserService: { findOrCreateByPhone },
 }));
 
 const { resolveTwilioVoiceTarget } = await import("./resolve-voice-target");
 
 const PUBLIC_NUMBER = "+14484080429";
-const DEFAULT_AGENT_ID = "agent-public";
-const publicEnv = {
-  ELIZA_APP_DEFAULT_AGENT_ID: DEFAULT_AGENT_ID,
-  ELIZA_APP_TWILIO_PHONE_NUMBER: PUBLIC_NUMBER,
-};
+const CALLER_NUMBER = "+14155550100";
+const publicEnv = { ELIZA_APP_TWILIO_PHONE_NUMBER: PUBLIC_NUMBER };
 
-beforeEach(() => {
-  findById.mockClear();
-  findLatestByCharacterId.mockClear();
-  findById.mockImplementation(async () => null);
-  findLatestByCharacterId.mockImplementation(async () => null);
-});
+beforeEach(() => findOrCreateByPhone.mockClear());
 
 describe("resolveTwilioVoiceTarget", () => {
-  test("resolves the exact public number to the configured sandbox", async () => {
-    const agent = sandboxRow(DEFAULT_AGENT_ID);
-    findById.mockImplementation(async () => agent);
+  test("finds or creates the caller account and returns its personal Shared agent", async () => {
+    const result = await resolveTwilioVoiceTarget(
+      publicEnv,
+      PUBLIC_NUMBER,
+      CALLER_NUMBER,
+    );
 
-    await expect(
-      resolveTwilioVoiceTarget(publicEnv, PUBLIC_NUMBER),
-    ).resolves.toEqual({
-      agent: agent as never,
-      agentId: DEFAULT_AGENT_ID,
-      organizationId: "org-public",
-      userId: "user-public",
+    expect(findOrCreateByPhone).toHaveBeenCalledWith(CALLER_NUMBER);
+    expect(result?.agentId).toMatch(/^personal:[0-9a-f-]{36}$/);
+    expect(result?.agent.id).toBe(result?.agentId);
+    expect(result).toMatchObject({
+      organizationId: "22222222-2222-4222-a222-222222222222",
+      userId: "11111111-1111-4111-a111-111111111111",
+      agent: {
+        execution_tier: "shared",
+      },
     });
-    expect(findLatestByCharacterId).not.toHaveBeenCalled();
   });
 
-  test("supports a legacy character id for the configured public agent", async () => {
-    const agent = sandboxRow("agent-from-character");
-    findLatestByCharacterId.mockImplementation(async () => agent);
-
+  test("rejects an unconfigured destination before creating an account", async () => {
     await expect(
-      resolveTwilioVoiceTarget(publicEnv, PUBLIC_NUMBER),
-    ).resolves.toEqual({
-      agent: agent as never,
-      agentId: "agent-from-character",
-      organizationId: "org-public",
-      userId: "user-public",
-    });
-    expect(findLatestByCharacterId).toHaveBeenCalledWith(DEFAULT_AGENT_ID);
-  });
-
-  test("refuses fallback for every number except the configured public line", async () => {
-    await expect(
-      resolveTwilioVoiceTarget(publicEnv, "+12525914471"),
+      resolveTwilioVoiceTarget(publicEnv, "+12525914471", CALLER_NUMBER),
     ).resolves.toBeNull();
-    expect(findById).not.toHaveBeenCalled();
-    expect(findLatestByCharacterId).not.toHaveBeenCalled();
+    expect(findOrCreateByPhone).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/v1/twilio/voice/lib/resolve-voice-target.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/resolve-voice-target.ts
@@ -1,48 +1,42 @@
 /**
- * Resolves only the exact public eliza.app Twilio line to its configured agent.
+ * Resolves the exact public eliza.app line into the caller's account-native
+ * personal Shared agent. The trusted Twilio boundary supplies the E.164 caller.
  */
 
-import {
-  type AgentSandbox,
-  agentSandboxesRepository,
-} from "@/db/repositories/agent-sandboxes";
+import { elizaAppUserService } from "@/lib/services/eliza-app/user-service";
+import { personalSharedAgent } from "@/lib/services/shared-runtime/personal-shared-agent";
+import type { SharedRuntimeAgent } from "@/lib/services/shared-runtime/shared-runtime-agent";
 
 export interface TwilioVoiceTarget {
-  agent: AgentSandbox;
+  agent: SharedRuntimeAgent;
   agentId: string;
   organizationId: string;
   userId: string;
 }
 
 interface PublicElizaVoiceEnv {
-  ELIZA_APP_DEFAULT_AGENT_ID?: string;
   ELIZA_APP_TWILIO_PHONE_NUMBER?: string;
 }
 
 export async function resolveTwilioVoiceTarget(
   env: PublicElizaVoiceEnv,
   calledNumber: string,
+  callerNumber: string,
 ): Promise<TwilioVoiceTarget | null> {
   const publicPhoneNumber = env.ELIZA_APP_TWILIO_PHONE_NUMBER?.trim();
-  const defaultAgentId = env.ELIZA_APP_DEFAULT_AGENT_ID?.trim();
-  if (
-    !publicPhoneNumber ||
-    publicPhoneNumber !== calledNumber ||
-    !defaultAgentId
-  ) {
+  if (!publicPhoneNumber || publicPhoneNumber !== calledNumber) {
     return null;
   }
 
-  const direct = await agentSandboxesRepository.findById(defaultAgentId);
-  const sandbox =
-    direct ??
-    (await agentSandboxesRepository.findLatestByCharacterId(defaultAgentId));
-  return sandbox
-    ? {
-        agent: sandbox,
-        agentId: sandbox.id,
-        organizationId: sandbox.organization_id,
-        userId: sandbox.user_id,
-      }
-    : null;
+  const account = await elizaAppUserService.findOrCreateByPhone(callerNumber);
+  const agent = personalSharedAgent({
+    userId: account.user.id,
+    organizationId: account.organization.id,
+  });
+  return {
+    agent,
+    agentId: agent.id,
+    organizationId: account.organization.id,
+    userId: account.user.id,
+  };
 }

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-stream-token.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-stream-token.test.ts
@@ -15,6 +15,7 @@ const input = {
   conversationId: "11111111-1111-4111-8111-111111111111",
   calledNumber: "+14484080429",
   returningCaller: true,
+  previousInteractionAt: 987_654,
 };
 
 describe("Twilio stream token", () => {
@@ -49,5 +50,23 @@ describe("Twilio stream token", () => {
     expect(
       await verifyTwilioStreamToken(minted.token, "secret", () => 1_130_000),
     ).toBeNull();
+  });
+
+  test("accepts personal Shared room ids and rejects arbitrary room text", async () => {
+    const personal = {
+      ...input,
+      agentId: "personal:da729919-c9f5-5fe7-b5fe-3e0ca681a8c1",
+      conversationId: "personal:da729919-c9f5-5fe7-b5fe-3e0ca681a8c1",
+    };
+    const minted = await mintTwilioStreamToken(personal, "secret");
+    expect(await verifyTwilioStreamToken(minted.token, "secret")).toEqual(
+      minted.claims,
+    );
+    await expect(
+      mintTwilioStreamToken(
+        { ...input, conversationId: "room-from-client" },
+        "secret",
+      ),
+    ).rejects.toThrow();
   });
 });

--- a/packages/cloud/api/v1/twilio/voice/lib/twilio-stream-token.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/twilio-stream-token.ts
@@ -4,10 +4,21 @@
  */
 
 import { z } from "zod";
+import { isPersonalSharedAgentId } from "@/lib/services/shared-runtime/personal-shared-agent";
 
 const TOKEN_VERSION = 1;
 const TOKEN_TTL_SECONDS = 120;
 const CLOCK_SKEW_SECONDS = 5;
+
+const ConversationIdSchema = z
+  .string()
+  .trim()
+  .refine(
+    (value) =>
+      z.string().uuid().safeParse(value).success ||
+      isPersonalSharedAgentId(value),
+    "conversationId must be a UUID or personal Shared agent id",
+  );
 
 const ClaimsSchema = z.object({
   v: z.literal(TOKEN_VERSION),
@@ -19,9 +30,10 @@ const ClaimsSchema = z.object({
   organizationId: z.string().min(1),
   userId: z.string().min(1),
   agentId: z.string().min(1),
-  conversationId: z.string().uuid(),
+  conversationId: ConversationIdSchema,
   calledNumber: z.string().min(1),
   returningCaller: z.boolean(),
+  previousInteractionAt: z.number().int().positive().optional(),
 });
 
 const WireClaimsSchema = z.object({
@@ -34,9 +46,10 @@ const WireClaimsSchema = z.object({
   o: z.string().min(1),
   u: z.string().min(1),
   g: z.string().min(1),
-  n: z.string().uuid(),
+  n: ConversationIdSchema,
   p: z.string().min(1),
   r: z.boolean(),
+  l: z.number().int().positive().optional(),
 });
 
 export type TwilioStreamTokenClaims = z.infer<typeof ClaimsSchema>;
@@ -98,6 +111,9 @@ export async function mintTwilioStreamToken(
         n: claims.conversationId,
         p: claims.calledNumber,
         r: claims.returningCaller,
+        ...(claims.previousInteractionAt
+          ? { l: claims.previousInteractionAt }
+          : {}),
       }),
     ),
   );
@@ -143,6 +159,7 @@ export async function verifyTwilioStreamToken(
       conversationId: wire.data.n,
       calledNumber: wire.data.p,
       returningCaller: wire.data.r,
+      previousInteractionAt: wire.data.l,
     });
     if (!parsed.success) return null;
     const nowSeconds = Math.floor(now() / 1_000);

--- a/packages/cloud/api/v1/twilio/voice/lib/voice-continuity.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/voice-continuity.test.ts
@@ -1,0 +1,31 @@
+/** Verifies deterministic, privacy-safe phone conversation lifecycle prompts. */
+
+import { describe, expect, test } from "bun:test";
+import {
+  callEndedEvent,
+  callStartedPrompt,
+  relativeInteractionAge,
+} from "./voice-continuity";
+
+describe("voice continuity", () => {
+  const now = Date.UTC(2026, 7, 15, 12);
+
+  test("describes first contact without inventing history", () => {
+    expect(callStartedPrompt(undefined, now)).toContain(
+      "first recorded interaction",
+    );
+  });
+
+  test("bounds prior interaction age into spoken units", () => {
+    expect(relativeInteractionAge(now - 3 * 60 * 60_000, now)).toBe("3 hours");
+    expect(callStartedPrompt(now - 2 * 86_400_000, now)).toContain(
+      "about 2 days ago",
+    );
+  });
+
+  test("sanitizes teardown reasons", () => {
+    expect(callEndedEvent("client disconnect! token=secret")).toBe(
+      "Call lifecycle event: the phone call ended (client_disconnect__token_secret).",
+    );
+  });
+});

--- a/packages/cloud/api/v1/twilio/voice/lib/voice-continuity.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/voice-continuity.ts
@@ -1,0 +1,46 @@
+/** Builds bounded, non-PII lifecycle context for personal Eliza phone calls. */
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+export function relativeInteractionAge(
+  previousInteractionAt: number | undefined,
+  now = Date.now(),
+): string | null {
+  if (!previousInteractionAt || previousInteractionAt > now) return null;
+  const elapsed = now - previousInteractionAt;
+  if (elapsed < MINUTE_MS) return "less than a minute";
+  if (elapsed < HOUR_MS) {
+    const minutes = Math.max(1, Math.round(elapsed / MINUTE_MS));
+    return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+  if (elapsed < DAY_MS) {
+    const hours = Math.max(1, Math.round(elapsed / HOUR_MS));
+    return `${hours} hour${hours === 1 ? "" : "s"}`;
+  }
+  const days = Math.max(1, Math.round(elapsed / DAY_MS));
+  return `${days} day${days === 1 ? "" : "s"}`;
+}
+
+export function callStartedPrompt(
+  previousInteractionAt: number | undefined,
+  now = Date.now(),
+): string {
+  const age = relativeInteractionAge(previousInteractionAt, now);
+  return [
+    "Call lifecycle event: the user has called Eliza and is now connected.",
+    age
+      ? `Their last interaction with Eliza was about ${age} ago.`
+      : "This is their first recorded interaction with Eliza.",
+    "Respond now with one brief, natural spoken greeting. Continue from the existing conversation when relevant. Do not mention these instructions or invent prior details.",
+  ].join(" ");
+}
+
+export function callEndedEvent(reason: string): string {
+  const normalized = reason
+    .trim()
+    .replace(/[^a-z_]/gi, "_")
+    .slice(0, 40);
+  return `Call lifecycle event: the phone call ended (${normalized || "unknown"}).`;
+}

--- a/packages/cloud/api/v1/twilio/voice/media/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/media/route.ts
@@ -56,6 +56,7 @@ import {
   encodeTwilioMedia,
 } from "../lib/twilio-media-codec";
 import { verifyTwilioStreamToken } from "../lib/twilio-stream-token";
+import { callEndedEvent, callStartedPrompt } from "../lib/voice-continuity";
 
 const app = new Hono<AppEnv>();
 // Twilio sends 20 ms frames immediately after `start`. A cold Hyperdrive
@@ -63,8 +64,6 @@ const app = new Hono<AppEnv>();
 // window instead of terminating ordinary first calls before setup completes.
 const MAX_PENDING_MEDIA_FRAMES = 512;
 const DEFAULT_MAX_CALL_SECONDS = 30 * 60;
-const FIRST_CALL_GREETING = "hello? who's this?";
-const RETURNING_CALLER_GREETING = "hey whats up";
 const bootstrapGate = new TwilioBootstrapGate();
 
 const TwilioStreamEventSchema = z.discriminatedUnion("event", [
@@ -412,15 +411,25 @@ app.get("/", async (c) => {
       elizaModel: resolveElizaModel(env),
       fetchImpl: elizaFetch,
       prewarmElizaContext: elizaFetch.prewarm,
-      openingGreeting: claims.returningCaller
-        ? RETURNING_CALLER_GREETING
-        : FIRST_CALL_GREETING,
+      openingPrompt: callStartedPrompt(claims.previousInteractionAt),
+      openingClientMessageId: `twilio-call:${claims.callSid}:started`,
       usageStore,
       usageLimits: resolveVoiceUsageLimits(env),
       isRevoked: (jti) =>
         isVoiceSessionTokenRevoked(jti, rawRedis ?? undefined),
       onTeardownRevoke: (jti, expSeconds) =>
         revokeVoiceSessionToken(jti, expSeconds),
+      onTeardown: (reason) => {
+        const persistence = runWithCloudBindingsAsync(workerBindings, () =>
+          elizaFetch.recordLifecycleEvent({
+            id: `twilio-call:${claims.callSid}:ended`,
+            content: callEndedEvent(reason),
+            createdAt: Date.now(),
+          }),
+        );
+        executionContext?.waitUntil(persistence);
+        return persistence;
+      },
       downlink,
     });
     session.start();

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-lifecycle.test.ts
@@ -459,6 +459,8 @@ async function connectSession(opts: {
   sttConnectTimeoutMs?: number;
   prewarmElizaContext?: () => Promise<void>;
   openingGreeting?: string;
+  openingPrompt?: string;
+  openingClientMessageId?: string;
   cacheWarmingRetryDelaysMs?: readonly number[];
   onClearAudio?: () => void;
   fish?: {
@@ -502,6 +504,10 @@ async function connectSession(opts: {
           : {}),
         ...(opts.openingGreeting
           ? { openingGreeting: opts.openingGreeting }
+          : {}),
+        ...(opts.openingPrompt ? { openingPrompt: opts.openingPrompt } : {}),
+        ...(opts.openingClientMessageId
+          ? { openingClientMessageId: opts.openingClientMessageId }
           : {}),
         ...(opts.cacheWarmingRetryDelaysMs
           ? {
@@ -581,6 +587,37 @@ describe("voice-session WS lifecycle", () => {
     cartesia.emitDone();
     await flush();
     expect(client.controlTypes()).toContain("speaking_end");
+  });
+
+  test("generates the call opener as a stable canonical system turn", async () => {
+    const requests: Array<Record<string, unknown>> = [];
+    const client = new FakeClientSocket();
+    await connectSession({
+      client,
+      openingPrompt: "The user called. Greet them using existing history.",
+      openingClientMessageId: "twilio-call:CA123:started",
+      fetchImpl: (async (_url: string, init?: RequestInit) => {
+        requests.push(
+          JSON.parse(String(init?.body)) as Record<string, unknown>,
+        );
+        return makeCanonicalChunkFetch(["Good to hear from you again."])(
+          "",
+          {},
+        );
+      }) as unknown as typeof fetch,
+    });
+    await flush();
+
+    expect(requests).toEqual([
+      expect.objectContaining({
+        text: "The user called. Greet them using existing history.",
+        messageRole: "system",
+        clientMessageId: "twilio-call:CA123:started",
+      }),
+    ]);
+    expect(FakeCartesiaSocket.instances.at(-1)?.sentText()).toBe(
+      "Good to hear from you again.",
+    );
   });
 
   test("stt_final posts the transcript to the canonical agent conversation stream with scoped identity", async () => {

--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -8,7 +8,6 @@
  * contract cannot select the legacy database-backed bridge.
  */
 
-import type { AgentSandbox } from "@/db/repositories/agent-sandboxes";
 import { timingSafeEqualSecret } from "@/lib/auth/cron";
 import { cache } from "@/lib/cache/client";
 import { CacheKeys } from "@/lib/cache/keys";
@@ -17,7 +16,16 @@ import {
   runWithCloudBindingsAsync,
 } from "@/lib/runtime/cloud-bindings";
 import { handleCanonicalScopedAgentStream } from "@/lib/services/shared-runtime/canonical-scoped-stream";
-import { coordinateSharedConversationPrewarm } from "@/lib/services/shared-runtime/conversation-coordinator";
+import {
+  coordinateSharedConversationPrewarm,
+  coordinateSharedLifecycleEvent,
+  type SharedConversationLifecycleEvent,
+} from "@/lib/services/shared-runtime/conversation-coordinator";
+import {
+  isPersonalSharedAgentId,
+  personalSharedAgent,
+} from "@/lib/services/shared-runtime/personal-shared-agent";
+import type { SharedRuntimeAgent } from "@/lib/services/shared-runtime/shared-runtime-agent";
 import type { BridgeExecutionContext } from "@/lib/services/shared-runtime/shared-runtime-chat";
 import { logger } from "@/lib/utils/logger";
 import type {
@@ -35,6 +43,10 @@ export interface InternalElizaConversationFetchClaims {
 export type InternalElizaConversationFetch = typeof fetch & {
   /** Read the immutable tenancy cache and schedule cold hydration before first turn. */
   prewarm: () => Promise<void>;
+  /** Persist an idempotent call lifecycle marker in the canonical room. */
+  recordLifecycleEvent: (
+    event: SharedConversationLifecycleEvent,
+  ) => Promise<void>;
 };
 
 export type InternalElizaConversationFetchFactory = (
@@ -44,14 +56,14 @@ export type InternalElizaConversationFetchFactory = (
 interface InternalVoiceSharedRuntime {
   executionCtx?: BridgeExecutionContext;
   namespace?: RuntimeDurableObjectNamespace;
-  readCachedAgent(): Promise<AgentSandbox | null>;
+  readCachedAgent(): Promise<SharedRuntimeAgent | null>;
   scheduleHydration(): boolean;
 }
 
 function isCachedVoiceAgent(
-  agent: AgentSandbox | null,
+  agent: SharedRuntimeAgent | null,
   claims: InternalElizaConversationFetchClaims,
-): agent is AgentSandbox {
+): agent is SharedRuntimeAgent {
   return Boolean(
     agent &&
       agent.id === claims.agentId &&
@@ -99,12 +111,20 @@ export function createInternalElizaConversationFetchFactory(
     );
     let hydrationPromise: Promise<void> | null = null;
 
-    const readCachedAgent = async (): Promise<AgentSandbox | null> => {
-      const cached = await cache.get<AgentSandbox>(cacheKey);
+    const personalAgent = isPersonalSharedAgentId(claims.agentId)
+      ? personalSharedAgent({
+          userId: claims.userId,
+          organizationId: claims.organizationId,
+        })
+      : null;
+    const readCachedAgent = async (): Promise<SharedRuntimeAgent | null> => {
+      if (personalAgent?.id === claims.agentId) return personalAgent;
+      const cached = await cache.get<SharedRuntimeAgent>(cacheKey);
       return isCachedVoiceAgent(cached, claims) ? cached : null;
     };
 
     const scheduleHydration = (): boolean => {
+      if (personalAgent) return true;
       if (!executionCtx) return false;
       if (hydrationPromise) return true;
 
@@ -195,6 +215,24 @@ export function createInternalElizaConversationFetchFactory(
       );
     }) as InternalElizaConversationFetch;
     fetchImpl.prewarm = prewarm;
+    fetchImpl.recordLifecycleEvent = async (event) => {
+      const namespace = env.SHARED_RUNTIME_CONVERSATIONS;
+      if (!namespace) {
+        throw new Error(
+          "Shared runtime conversation coordinator is unavailable.",
+        );
+      }
+      await runWithCloudBindingsAsync(
+        env as unknown as Record<string, unknown>,
+        () =>
+          coordinateSharedLifecycleEvent(
+            claims.agentId,
+            claims.conversationId,
+            event,
+            { namespace },
+          ),
+      );
+    };
     return fetchImpl;
   };
 }
@@ -283,6 +321,13 @@ async function dispatchInternalElizaConversationFetch(
     orgId: claims.organizationId,
     conversationId: claims.conversationId,
     userId: claims.userId,
+    agentKind: isPersonalSharedAgentId(claims.agentId) ? "personal" : "sandbox",
+    trustedMessageRole:
+      body &&
+      typeof body === "object" &&
+      (body as { messageRole?: unknown }).messageRole === "system"
+        ? "system"
+        : undefined,
     body,
     origin: headers.get("origin"),
     namespace: runtime.namespace,

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -155,6 +155,9 @@ export interface VoiceSessionConfig {
   prewarmElizaContext?: () => Promise<void>;
   /** Optional provider-synthesized opener that runs while agent context warms. */
   openingGreeting?: string;
+  /** Optional canonical agent turn that generates and persists the opener. */
+  openingPrompt?: string;
+  openingClientMessageId?: string;
   /** Deterministic test override; production uses bounded exponential backoff. */
   cacheWarmingRetryDelaysMs?: readonly number[];
   /** Deterministic test override for the bounded Ink reconnect schedule. */
@@ -181,6 +184,8 @@ export interface VoiceSessionConfig {
    * second paid session within the token's remaining TTL. Best-effort.
    */
   onTeardownRevoke?: (jti: string, expSeconds: number) => Promise<void>;
+  /** Persist transport lifecycle after the synchronous session is safely closed. */
+  onTeardown?: (reason: VoiceSessionSeverReason) => Promise<void>;
 }
 
 type SessionState =
@@ -342,7 +347,16 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
     const sessionTrace = this.mintTraceId("session");
     this.currentTraceId = sessionTrace;
     this.send({ t: "ready", sessionId: this.sessionId, traceId: sessionTrace });
-    if (this.config.openingGreeting?.trim()) {
+    if (this.config.openingPrompt?.trim()) {
+      const traceId = this.mintTraceId("turn");
+      this.currentTraceId = traceId;
+      this.currentVoiceTurnId = traceId;
+      this.state = "thinking";
+      void this.runResponseTurn(this.config.openingPrompt.trim(), traceId, {
+        messageRole: "system",
+        clientMessageId: this.config.openingClientMessageId,
+      });
+    } else if (this.config.openingGreeting?.trim()) {
       this.speakOpeningGreeting(this.config.openingGreeting.trim());
     }
   }
@@ -813,6 +827,10 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
   private async runResponseTurn(
     transcript: string,
     traceId: string,
+    options: {
+      messageRole?: "system";
+      clientMessageId?: string;
+    } = {},
   ): Promise<void> {
     const abort = new AbortController();
     this.llmAbort = abort;
@@ -884,6 +902,10 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         authorization: this.config.elizaAuthorization,
         model: this.config.elizaModel,
         transcript,
+        ...(options.messageRole ? { messageRole: options.messageRole } : {}),
+        ...(options.clientMessageId
+          ? { clientMessageId: options.clientMessageId }
+          : {}),
         agentId: this.config.agentId,
         conversationId: this.config.conversationId,
         organizationId: this.config.organizationId,
@@ -1178,6 +1200,17 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
           // error-policy:J6 best-effort teardown — revoke-on-end is defense in
           // depth; the token still dies at its <=120s TTL.
         });
+    }
+    if (this.config.onTeardown) {
+      void this.config.onTeardown(reason).catch((error) => {
+        // error-policy:J6 session closure is already committed; the durable
+        // lifecycle marker is idempotent and may be recovered by provider retry.
+        logger.warn("[voice-session] lifecycle teardown persistence failed", {
+          sessionId: this.sessionId,
+          reason,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
     }
 
     // Invalidate any live turn so racing callbacks are dropped.

--- a/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
+++ b/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
@@ -6,9 +6,7 @@
  */
 
 import { runWithDbCacheAsync } from "@/db/client";
-import {
-  agentSandboxesRepository,
-} from "@/db/repositories/agent-sandboxes";
+import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { userCharactersRepository } from "@/db/repositories/characters";
 import { cache } from "@/lib/cache/client";
 import { CacheKeys, CacheTTL } from "@/lib/cache/keys";

--- a/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
+++ b/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
@@ -7,7 +7,6 @@
 
 import { runWithDbCacheAsync } from "@/db/client";
 import {
-  type AgentSandbox,
   agentSandboxesRepository,
 } from "@/db/repositories/agent-sandboxes";
 import { userCharactersRepository } from "@/db/repositories/characters";
@@ -16,6 +15,7 @@ import { CacheKeys, CacheTTL } from "@/lib/cache/keys";
 import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
 import { warmInferenceAdmissionSnapshot } from "@/lib/services/inference-admission-snapshot";
 import { coordinateSharedConversationPrewarm } from "@/lib/services/shared-runtime/conversation-coordinator";
+import type { SharedRuntimeAgent } from "@/lib/services/shared-runtime/shared-runtime-agent";
 import { logger } from "@/lib/utils/logger";
 import type { Bindings } from "@/types/cloud-worker-env";
 import type { InternalElizaConversationFetchClaims } from "./internal-eliza-conversation-fetch";
@@ -23,7 +23,7 @@ import type { InternalElizaConversationFetchClaims } from "./internal-eliza-conv
 export async function hydrateVoiceSharedAgentScope(
   env: Bindings,
   claims: InternalElizaConversationFetchClaims,
-  preloadedAgent?: AgentSandbox,
+  preloadedAgent?: SharedRuntimeAgent,
 ): Promise<void> {
   await runWithCloudBindingsAsync(
     env as unknown as Record<string, unknown>,

--- a/packages/cloud/e2e/tests/personal-eliza-first-five-minutes.spec.ts
+++ b/packages/cloud/e2e/tests/personal-eliza-first-five-minutes.spec.ts
@@ -124,8 +124,12 @@ async function waitForMirroredHistory(agentId: string): Promise<{
     const history = channelId
       ? await sharedRuntimeHistoryRepository.get(agentId, channelId)
       : [];
-    if (channelIds.length === 1 && history.length === 2) {
-      return { channelIds, history };
+    const visibleHistory = history.filter(
+      (entry): entry is typeof entry & { role: "user" | "assistant" } =>
+        entry.role !== "system",
+    );
+    if (channelIds.length === 1 && visibleHistory.length === 2) {
+      return { channelIds, history: visibleHistory };
     }
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
@@ -135,7 +139,10 @@ async function waitForMirroredHistory(agentId: string): Promise<{
   return {
     channelIds,
     history: channelId
-      ? await sharedRuntimeHistoryRepository.get(agentId, channelId)
+      ? (await sharedRuntimeHistoryRepository.get(agentId, channelId)).filter(
+          (entry): entry is typeof entry & { role: "user" | "assistant" } =>
+            entry.role !== "system",
+        )
       : [],
   };
 }

--- a/packages/cloud/services/gateway-webhook/__tests__/telegram-voice-note.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/telegram-voice-note.test.ts
@@ -1,0 +1,172 @@
+/** Verifies Telegram voice-note parsing and credential-local bounded downloads. */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { telegramAdapter } from "../src/adapters/telegram";
+
+const originalFetch = globalThis.fetch;
+
+function update(voice: Record<string, unknown>) {
+  return JSON.stringify({
+    update_id: 101,
+    message: {
+      message_id: 7,
+      from: { id: 42, first_name: "Ada" },
+      chat: { id: 42, type: "private" },
+      voice,
+    },
+  });
+}
+
+describe("Telegram voice notes", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    mock.restore();
+  });
+
+  test("accepts a captionless private Ogg voice note", async () => {
+    const event = await telegramAdapter.extractEvent(
+      update({
+        file_id: "voice-file-1",
+        duration: 3,
+        mime_type: "audio/ogg",
+        file_size: 8,
+      }),
+    );
+    expect(event).toMatchObject({
+      messageId: "101",
+      text: "",
+      voiceNote: {
+        fileId: "voice-file-1",
+        durationSeconds: 3,
+        sizeBytes: 8,
+        mimeType: "audio/ogg",
+      },
+    });
+  });
+
+  test("rejects provider metadata beyond the stricter product byte limit", async () => {
+    const event = await telegramAdapter.extractEvent(
+      update({
+        file_id: "voice-file-1",
+        duration: 3,
+        file_size: 8 * 1024 * 1024 + 1,
+      }),
+    );
+    expect(event).toBeNull();
+  });
+
+  test("downloads through getFile without returning a token-bearing URL", async () => {
+    const bytes = Buffer.from("OggSvoice");
+    const urls: string[] = [];
+    globalThis.fetch = mock(async (input, init) => {
+      const request = new Request(input, init);
+      urls.push(request.url);
+      if (request.url.endsWith("/getFile")) {
+        return Response.json({
+          ok: true,
+          result: { file_path: "voice/file_1.oga", file_size: bytes.length },
+        });
+      }
+      return new Response(bytes, {
+        status: 200,
+        headers: { "content-length": String(bytes.length) },
+      });
+    }) as typeof fetch;
+    const event = await telegramAdapter.extractEvent(
+      update({
+        file_id: "voice-file-1",
+        duration: 3,
+        file_size: bytes.length,
+      }),
+    );
+    if (!event) throw new Error("expected voice event");
+    const resolved = await telegramAdapter.resolveVoiceNote?.(
+      { botToken: "secret-token" },
+      event,
+    );
+    expect(resolved).toEqual({
+      bytesBase64: bytes.toString("base64"),
+      mimeType: "audio/ogg",
+      filename: "telegram-101.ogg",
+      sizeBytes: bytes.length,
+      durationSeconds: 3,
+    });
+    expect(JSON.stringify(resolved)).not.toContain("secret-token");
+    expect(urls).toEqual([
+      "https://api.telegram.org/botsecret-token/getFile",
+      "https://api.telegram.org/file/botsecret-token/voice/file_1.oga",
+    ]);
+  });
+
+  test("rejects getFile path traversal before a download request", async () => {
+    let calls = 0;
+    globalThis.fetch = mock(async () => {
+      calls += 1;
+      return Response.json({
+        ok: true,
+        result: { file_path: "../token-leak.ogg", file_size: 8 },
+      });
+    }) as typeof fetch;
+    const event = await telegramAdapter.extractEvent(
+      update({ file_id: "voice-file-1", duration: 3, file_size: 8 }),
+    );
+    if (!event) throw new Error("expected voice event");
+    await expect(
+      telegramAdapter.resolveVoiceNote?.({ botToken: "secret-token" }, event),
+    ).rejects.toThrow("invalid file path");
+    expect(calls).toBe(1);
+  });
+
+  test("rejects non-Ogg bytes even when Telegram reports audio", async () => {
+    const bytes = Buffer.from("NOT-OGG!");
+    globalThis.fetch = mock(async (input, init) => {
+      const request = new Request(input, init);
+      if (request.url.endsWith("/getFile")) {
+        return Response.json({
+          ok: true,
+          result: { file_path: "voice/file_1.oga", file_size: bytes.length },
+        });
+      }
+      return new Response(bytes);
+    }) as typeof fetch;
+    const event = await telegramAdapter.extractEvent(
+      update({
+        file_id: "voice-file-1",
+        duration: 3,
+        file_size: bytes.length,
+      }),
+    );
+    if (!event) throw new Error("expected voice event");
+    await expect(
+      telegramAdapter.resolveVoiceNote?.({ botToken: "secret-token" }, event),
+    ).rejects.toThrow("Ogg stream");
+  });
+
+  test("sanitizes a download transport error that contains the bot token URL", async () => {
+    globalThis.fetch = mock(async (input, init) => {
+      const request = new Request(input, init);
+      if (request.url.endsWith("/getFile")) {
+        return Response.json({
+          ok: true,
+          result: { file_path: "voice/file_1.oga", file_size: 8 },
+        });
+      }
+      throw new Error(`network failure for ${request.url}`);
+    }) as typeof fetch;
+    const event = await telegramAdapter.extractEvent(
+      update({ file_id: "voice-file-1", duration: 3, file_size: 8 }),
+    );
+    if (!event) throw new Error("expected voice event");
+
+    const resolver = telegramAdapter.resolveVoiceNote;
+    if (!resolver) throw new Error("expected Telegram voice resolver");
+    const error = await resolver({ botToken: "secret-token" }, event).catch(
+      (failure) => failure,
+    );
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(
+      "Telegram voice download transport failed",
+    );
+    expect((error as Error).message).not.toContain("secret-token");
+  });
+});

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
@@ -476,6 +476,88 @@ describe("gateway webhook handler e2e routing", () => {
     );
   });
 
+  test("resolves captionless Telegram voice bytes before the trusted Shared boundary", async () => {
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    const event: ChatEvent = {
+      platform: "telegram",
+      messageId: "update-voice-1",
+      chatId: "chat-1",
+      chatType: "private",
+      senderId: "123456789",
+      senderName: "Ada",
+      text: "",
+      voiceNote: {
+        fileId: "provider-file-id",
+        durationSeconds: 2,
+        sizeBytes: 8,
+        mimeType: "audio/ogg",
+      },
+      rawPayload: {},
+    };
+    const resolveVoiceNote = mock(async () => ({
+      bytesBase64: Buffer.from("OggSdata").toString("base64"),
+      mimeType: "audio/ogg" as const,
+      filename: "telegram-update-voice-1.ogg",
+      sizeBytes: 8,
+      durationSeconds: 2,
+    }));
+    const sendReply = mock(async () => undefined);
+    const adapter: PlatformAdapter = {
+      platform: "telegram",
+      getDedupeScope: () => "scope",
+      verifyWebhook: mock(async () => true),
+      extractEvent: mock(async () => event),
+      resolveVoiceNote,
+      sendTypingIndicator: mock(async () => undefined),
+      sendReply,
+    };
+    const redis = new MemoryRedis();
+    let sharedBody: Record<string, unknown> | null = null;
+    globalThis.fetch = mock(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/api/internal/eliza-app/personal-shared/messages")) {
+        sharedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return Response.json({ data: { reply: "I heard you" } });
+      }
+      throw new Error(`unexpected request: ${url}`);
+    }) as typeof fetch;
+
+    const response = await handleWebhook(
+      new Request("https://gateway.example/webhook/eliza-app/telegram", {
+        method: "POST",
+        body: "{}",
+      }),
+      adapter,
+      {
+        redis,
+        cloudBaseUrl: "https://api.elizacloud.ai",
+        getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+      },
+      "eliza-app",
+    );
+
+    expect(response.status).toBe(200);
+    expect(resolveVoiceNote).toHaveBeenCalledWith(expect.anything(), event);
+    expect(sharedBody).toEqual({
+      platform: "telegram",
+      telegramUserId: "123456789",
+      displayName: "Ada",
+      messageId: "telegram:eliza-app:update-voice-1",
+      voiceNote: {
+        bytesBase64: Buffer.from("OggSdata").toString("base64"),
+        mimeType: "audio/ogg",
+        filename: "telegram-update-voice-1.ogg",
+        sizeBytes: 8,
+        durationSeconds: 2,
+      },
+    });
+    expect(sendReply).toHaveBeenCalledWith(
+      expect.anything(),
+      event,
+      "I heard you",
+    );
+  });
+
   test("retries personal Shared with fresh auth and the same message id", async () => {
     configureEnv();
     const redis = new MemoryRedis();

--- a/packages/cloud/services/gateway-webhook/src/adapters/telegram.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/telegram.ts
@@ -2,10 +2,20 @@
 import crypto from "node:crypto";
 import { resolveConnectorAccountId } from "../connector-account";
 import { logger } from "../logger";
-import type { ChatEvent, PlatformAdapter, WebhookConfig } from "./types";
+import type {
+  ChatEvent,
+  PlatformAdapter,
+  ResolvedVoiceNote,
+  WebhookConfig,
+} from "./types";
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
 const MAX_MESSAGE_LENGTH = 4096;
+export const TELEGRAM_HOSTED_FILE_MAX_BYTES = 20 * 1024 * 1024;
+export const TELEGRAM_VOICE_MAX_BYTES = 8 * 1024 * 1024;
+const TELEGRAM_API_TIMEOUT_MS = 10_000;
+export const TELEGRAM_VOICE_MAX_DURATION_SECONDS = 15 * 60;
+const TELEGRAM_FILE_FETCH_TIMEOUT_MS = 30_000;
 
 async function telegramApi<T>(
   botToken: string,
@@ -13,11 +23,19 @@ async function telegramApi<T>(
   params?: Record<string, unknown>,
 ): Promise<T> {
   const url = `${TELEGRAM_API_BASE}/bot${botToken}/${method}`;
-  const response = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: params ? JSON.stringify(params) : undefined,
-  });
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: params ? JSON.stringify(params) : undefined,
+      signal: AbortSignal.timeout(TELEGRAM_API_TIMEOUT_MS),
+    });
+  } catch {
+    // error-policy:J3 a fetch implementation may include the credential-bearing
+    // URL in its error, so translate before the adapter boundary logs it.
+    throw new Error(`Telegram API ${method} transport failed`);
+  }
   const data = await response.json();
   if (!data.ok) {
     throw new Error(
@@ -26,6 +44,12 @@ async function telegramApi<T>(
     );
   }
   return data.result as T;
+}
+
+function exceedsTelegramVoiceSizeLimit(size: number): boolean {
+  return (
+    size > TELEGRAM_HOSTED_FILE_MAX_BYTES || size > TELEGRAM_VOICE_MAX_BYTES
+  );
 }
 
 function splitMessage(text: string, maxLength = MAX_MESSAGE_LENGTH): string[] {
@@ -67,7 +91,12 @@ interface TelegramMessage {
   caption?: string;
   photo?: Array<{ file_id: string }>;
   document?: { file_id: string };
-  voice?: { file_id: string };
+  voice?: {
+    file_id: string;
+    duration: number;
+    mime_type?: string;
+    file_size?: number;
+  };
 }
 
 interface TelegramUpdate {
@@ -122,7 +151,26 @@ export const telegramAdapter: PlatformAdapter = {
     if (message.chat.type !== "private") return null;
 
     const text = message.text || message.caption || "";
-    if (!text) return null;
+    const voice = message.voice;
+    if (!text && !voice) return null;
+
+    if (voice) {
+      if (
+        !voice.file_id ||
+        voice.file_id.length > 256 ||
+        !Number.isInteger(voice.duration) ||
+        voice.duration < 0 ||
+        voice.duration > TELEGRAM_VOICE_MAX_DURATION_SECONDS ||
+        (voice.file_size !== undefined &&
+          (!Number.isInteger(voice.file_size) ||
+            voice.file_size <= 0 ||
+            exceedsTelegramVoiceSizeLimit(voice.file_size))) ||
+        (voice.mime_type !== undefined && voice.mime_type !== "audio/ogg")
+      ) {
+        logger.warn("Rejected invalid Telegram voice-note metadata");
+        return null;
+      }
+    }
 
     if (message.from?.is_bot) return null;
 
@@ -137,6 +185,120 @@ export const telegramAdapter: PlatformAdapter = {
       text,
       isCommand: text.startsWith("/"),
       rawPayload: update,
+      ...(voice
+        ? {
+            voiceNote: {
+              fileId: voice.file_id,
+              durationSeconds: voice.duration,
+              ...(voice.file_size !== undefined
+                ? { sizeBytes: voice.file_size }
+                : {}),
+              mimeType: "audio/ogg" as const,
+            },
+          }
+        : {}),
+    };
+  },
+
+  async resolveVoiceNote(
+    config: WebhookConfig,
+    event: ChatEvent,
+  ): Promise<ResolvedVoiceNote> {
+    if (!config.botToken) {
+      throw new Error("Missing botToken for Telegram voice download");
+    }
+    const voice = event.voiceNote;
+    if (!voice) throw new Error("Telegram event has no voice note");
+
+    let file: { file_path?: string; file_size?: number };
+    try {
+      file = await telegramApi(config.botToken, "getFile", {
+        file_id: voice.fileId,
+      });
+    } catch {
+      // error-policy:J3 sanitize the credential-bearing provider request at the
+      // adapter boundary so a fetch implementation cannot put its URL in logs.
+      throw new Error("Telegram getFile request failed");
+    }
+    const filePath = file.file_path;
+    if (
+      !filePath ||
+      filePath.length > 512 ||
+      filePath.startsWith("/") ||
+      filePath.split("/").includes("..") ||
+      !/^[A-Za-z0-9._/-]+$/.test(filePath)
+    ) {
+      throw new Error("Telegram getFile returned an invalid file path");
+    }
+    const reportedSize = file.file_size ?? voice.sizeBytes;
+    if (
+      reportedSize !== undefined &&
+      (!Number.isInteger(reportedSize) ||
+        reportedSize <= 0 ||
+        exceedsTelegramVoiceSizeLimit(reportedSize))
+    ) {
+      throw new Error("Telegram voice note exceeds the hosted download limit");
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(
+        `${TELEGRAM_API_BASE}/file/bot${config.botToken}/${filePath}`,
+        { signal: AbortSignal.timeout(TELEGRAM_FILE_FETCH_TIMEOUT_MS) },
+      );
+    } catch {
+      // error-policy:J3 the token-bearing URL is secret input and must not be
+      // retained in the propagated fetch error or structured service logs.
+      throw new Error("Telegram voice download transport failed");
+    }
+    if (!response.ok || !response.body) {
+      await response.body?.cancel();
+      throw new Error(`Telegram voice download failed (${response.status})`);
+    }
+    const contentLength = Number.parseInt(
+      response.headers.get("content-length") ?? "",
+      10,
+    );
+    if (
+      Number.isFinite(contentLength) &&
+      contentLength > TELEGRAM_VOICE_MAX_BYTES
+    ) {
+      await response.body.cancel();
+      throw new Error("Telegram voice note exceeds the hosted download limit");
+    }
+
+    const chunks: Uint8Array[] = [];
+    let received = 0;
+    const reader = response.body.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      received += value.byteLength;
+      if (received > TELEGRAM_VOICE_MAX_BYTES) {
+        await reader.cancel();
+        throw new Error(
+          "Telegram voice note exceeds the hosted download limit",
+        );
+      }
+      chunks.push(value);
+    }
+    if (received === 0) throw new Error("Telegram voice note was empty");
+    const bytes = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
+    if (bytes.subarray(0, 4).toString("ascii") !== "OggS") {
+      throw new Error("Telegram voice note did not contain an Ogg stream");
+    }
+    if (reportedSize !== undefined && received !== reportedSize) {
+      throw new Error(
+        "Telegram voice note size did not match provider metadata",
+      );
+    }
+
+    return {
+      bytesBase64: bytes.toString("base64"),
+      mimeType: "audio/ogg",
+      filename: `telegram-${event.messageId}.ogg`,
+      sizeBytes: received,
+      durationSeconds: voice.durationSeconds,
     };
   },
 

--- a/packages/cloud/services/gateway-webhook/src/adapters/types.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/types.ts
@@ -15,6 +15,13 @@ export interface ChatEvent {
   text: string;
   isCommand?: boolean;
   mediaUrls?: string[];
+  /** Provider-owned voice-note metadata; never contains an authenticated URL. */
+  voiceNote?: {
+    fileId: string;
+    durationSeconds: number;
+    sizeBytes?: number;
+    mimeType: "audio/ogg";
+  };
   rawPayload: unknown;
 }
 
@@ -38,6 +45,19 @@ export interface PlatformAdapter {
     text: string,
   ): Promise<void>;
   sendTypingIndicator(config: WebhookConfig, event: ChatEvent): Promise<void>;
+  /** Resolve provider-owned voice bytes while credentials are still local. */
+  resolveVoiceNote?(
+    config: WebhookConfig,
+    event: ChatEvent,
+  ): Promise<ResolvedVoiceNote>;
+}
+
+export interface ResolvedVoiceNote {
+  bytesBase64: string;
+  mimeType: "audio/ogg";
+  filename: string;
+  sizeBytes: number;
+  durationSeconds: number;
 }
 
 export interface WebhookConfig {

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -28,6 +28,7 @@ const TELEGRAM_DELIVERY_TTL_SECONDS = 30 * 24 * 60 * 60;
 const TELEGRAM_EGRESS_STARTED = "egress_started";
 const TELEGRAM_DELIVERED = "delivered";
 const TELEGRAM_TYPING_REFRESH_MS = 4_000;
+const PERSONAL_SHARED_VOICE_TIMEOUT_MS = 90_000;
 
 class TelegramEgressAlreadyClaimedError extends Error {
   override readonly name = "TelegramEgressAlreadyClaimedError";
@@ -568,6 +569,18 @@ async function sendPersonalSharedReply(
 ): Promise<void> {
   const { cloudBaseUrl, getAuthHeader } = deps;
   const reauth = deps.reacquireAuthHeader ?? reacquireAuthHeader;
+  const voiceNote = event.voiceNote
+    ? await adapter.resolveVoiceNote?.(config, event)
+    : undefined;
+  if (event.voiceNote && !voiceNote) {
+    throw new PersonalSharedPreEgressError(
+      "connector cannot resolve the supplied voice note",
+    );
+  }
+  // Voice turns can spend most of the 120-second processing lease in STT + the
+  // model. Only a stale-auth retry is safe inline; provider/transport failures
+  // reopen the webhook for Telegram's durable retry instead of overlapping it.
+  const maxAttempts = voiceNote ? 2 : PERSONAL_SHARED_ATTEMPTS;
   const postMessage = (authHeader: Record<string, string>) =>
     fetch(`${cloudBaseUrl}/api/internal/eliza-app/personal-shared/messages`, {
       method: "POST",
@@ -579,7 +592,8 @@ async function sendPersonalSharedReply(
               telegramUserId: event.senderId,
               displayName: event.senderName,
               messageId: `telegram:${project}:${event.messageId}`,
-              message: event.text,
+              ...(event.text ? { message: event.text } : {}),
+              ...(voiceNote ? { voiceNote } : {}),
             }
           : {
               platform: adapter.platform,
@@ -588,16 +602,18 @@ async function sendPersonalSharedReply(
               message: event.text,
             },
       ),
-      signal: AbortSignal.timeout(30_000),
+      signal: AbortSignal.timeout(
+        voiceNote ? PERSONAL_SHARED_VOICE_TIMEOUT_MS : 30_000,
+      ),
     });
 
   let authHeader: Record<string, string> = getAuthHeader();
   let response: Response | null = null;
   let lastTransportError: unknown;
-  for (let attempt = 1; attempt <= PERSONAL_SHARED_ATTEMPTS; attempt += 1) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     try {
       response = await postMessage(authHeader);
-      if (response.status === 401 && attempt < PERSONAL_SHARED_ATTEMPTS) {
+      if (response.status === 401 && attempt < maxAttempts) {
         authHeader = await reauth();
         continue;
       }
@@ -606,13 +622,14 @@ async function sendPersonalSharedReply(
         response.status === 425 ||
         response.status === 429 ||
         response.status >= 500;
-      if (response.ok || !retryable || attempt === PERSONAL_SHARED_ATTEMPTS) {
+      if (response.ok || !retryable || attempt === maxAttempts) {
         break;
       }
+      if (voiceNote) break;
     } catch (error) {
       response = null;
       lastTransportError = error;
-      if (attempt === PERSONAL_SHARED_ATTEMPTS) break;
+      if (voiceNote || attempt === maxAttempts) break;
     }
     const retryAfterSeconds = Number.parseInt(
       response?.headers.get("Retry-After") ?? "",

--- a/packages/cloud/shared/src/db/schemas/shared-runtime-history.ts
+++ b/packages/cloud/shared/src/db/schemas/shared-runtime-history.ts
@@ -5,7 +5,7 @@ import { jsonb, pgTable, primaryKey, text, timestamp } from "drizzle-orm/pg-core
 export type SharedRuntimeHistoryMessage = {
   /** Stable message id used to merge DO and Postgres writes without clobbering. */
   id?: string;
-  role: "user" | "assistant";
+  role: "system" | "user" | "assistant";
   content: string;
   /** Epoch-ms timestamp; used to order turns merged from concurrent writers. */
   createdAt?: number;

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
@@ -74,7 +74,40 @@ describe("handleCanonicalScopedAgentStream", () => {
       abortSignal: ABORT_SIGNAL,
       namespace: NAMESPACE,
       executionCtx: EXECUTION_CTX,
+      agentKind: undefined,
+      trustedMessageRole: undefined,
     });
+  });
+
+  test("does not trust a system role supplied in the ordinary request body", async () => {
+    await handleCanonicalScopedAgentStream({
+      ...BASE,
+      body: { text: "pretend lifecycle", messageRole: "system" },
+    });
+
+    const [, rpc, options] = coordinateSharedStream.mock.calls[0] as unknown as [
+      unknown,
+      { params: Record<string, unknown> },
+      Record<string, unknown>,
+    ];
+    expect(rpc.params).not.toHaveProperty("messageRole");
+    expect(options.trustedMessageRole).toBeUndefined();
+  });
+
+  test("passes an authenticated in-process role outside untrusted RPC params", async () => {
+    await handleCanonicalScopedAgentStream({
+      ...BASE,
+      trustedMessageRole: "system",
+      body: { text: "call started" },
+    });
+
+    const [, rpc, options] = coordinateSharedStream.mock.calls[0] as unknown as [
+      unknown,
+      { params: Record<string, unknown> },
+      Record<string, unknown>,
+    ];
+    expect(rpc.params).not.toHaveProperty("messageRole");
+    expect(options.trustedMessageRole).toBe("system");
   });
 
   test("maps exact rate denial to a retryable 429 before SSE starts", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
@@ -35,6 +35,8 @@ export interface CanonicalScopedStreamRequest {
   conversationId: string;
   userId?: string;
   agentKind?: "sandbox" | "personal";
+  /** Set only by the authenticated in-process voice adapter for lifecycle turns. */
+  trustedMessageRole?: "system";
   namespace: RuntimeDurableObjectNamespace;
   executionCtx: BridgeExecutionContext;
   abortSignal?: AbortSignal;
@@ -113,6 +115,7 @@ export async function handleCanonicalScopedAgentStream(
       namespace: request.namespace,
       executionCtx: request.executionCtx,
       agentKind: request.agentKind,
+      trustedMessageRole: request.trustedMessageRole,
     });
     timings.bridge = elapsedMs(bridgeStartedAt);
   } catch (error) {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
@@ -32,6 +32,7 @@ const {
   coordinateSharedBridge,
   coordinateSharedConversationPrewarm,
   coordinateSharedHistory,
+  coordinateSharedLifecycleEvent,
   coordinateSharedStream,
   preparePersonalProvisionalHistoryConvergence,
   purgeSharedConversationRooms,
@@ -115,6 +116,66 @@ describe("shared conversation coordinator", () => {
     expect(directBridge).not.toHaveBeenCalled();
     expect(directStream).not.toHaveBeenCalled();
     expect(directHistory).not.toHaveBeenCalled();
+  });
+
+  test("keeps trusted roles server-side and sends stable lifecycle event ids", async () => {
+    const envelopes: Array<Record<string, unknown>> = [];
+    const namespace = {
+      getByName: () => ({
+        fetch: async (_input: RequestInfo | URL, init?: RequestInit) => {
+          const envelope = JSON.parse(String(init?.body)) as Record<string, unknown>;
+          envelopes.push(envelope);
+          return envelope.operation === "personal-stream"
+            ? new Response("event: done\ndata: {}\n\n")
+            : Response.json({ success: true });
+        },
+      }),
+    };
+    const agent = {
+      id: "personal:11111111-1111-4111-a111-111111111111",
+      organization_id: "org-1",
+      user_id: "11111111-1111-4111-a111-111111111111",
+      execution_tier: "shared",
+    } as never;
+    const rpc = {
+      jsonrpc: "2.0" as const,
+      id: "rpc-1",
+      method: "message.send",
+      params: { text: "call started", roomId: agent.id },
+    };
+    const executionCtx = { waitUntil() {} };
+
+    await coordinateSharedStream(agent, rpc, {
+      namespace,
+      executionCtx,
+      agentKind: "personal",
+      trustedMessageRole: "system",
+    });
+    await coordinateSharedLifecycleEvent(
+      agent.id,
+      agent.id,
+      { id: "twilio-call:CA1:ended", content: "Call ended.", createdAt: 123 },
+      { namespace },
+    );
+
+    expect(envelopes).toEqual([
+      {
+        operation: "personal-stream",
+        agent,
+        rpc,
+        trustedMessageRole: "system",
+      },
+      {
+        operation: "lifecycle",
+        agentId: agent.id,
+        roomId: agent.id,
+        event: {
+          id: "twilio-call:CA1:ended",
+          content: "Call ended.",
+          createdAt: 123,
+        },
+      },
+    ]);
   });
 
   test("preserves cache warming as a retryable coordinator error", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -21,10 +21,18 @@ export interface SharedConversationCoordinatorOptions {
   abortSignal?: AbortSignal;
   /** Personal operations are server-selected and always platform-funded. */
   agentKind?: "sandbox" | "personal";
+  /** Authenticated server-only role override; never accepted from RPC params. */
+  trustedMessageRole?: "system";
 }
 
 export interface SharedConversationHistoryCoordinatorOptions {
   namespace: RuntimeDurableObjectNamespace;
+}
+
+export interface SharedConversationLifecycleEvent {
+  id: string;
+  content: string;
+  createdAt: number;
 }
 
 export interface SharedCutoverSeal {
@@ -69,6 +77,31 @@ export async function coordinateSharedConversationPrewarm(
   await requireCoordinatorResponse(response, "conversation prewarm");
   // The Durable Object releases its per-room queue when the response body is
   // consumed. Drain this tiny acknowledgement before the first real turn.
+  await response.arrayBuffer();
+}
+
+/** Persist one idempotent lifecycle marker without dispatching or billing a model turn. */
+export async function coordinateSharedLifecycleEvent(
+  agentId: string,
+  roomId: string,
+  event: SharedConversationLifecycleEvent,
+  options: SharedConversationHistoryCoordinatorOptions,
+): Promise<void> {
+  const namespace = requireHistoryCoordinator(options);
+  const response = await coordinatorStub(namespace, agentId, roomId).fetch(
+    "https://shared-runtime.internal/lifecycle",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        operation: "lifecycle",
+        agentId,
+        roomId,
+        event,
+      }),
+    },
+  );
+  await requireCoordinatorResponse(response, "conversation lifecycle");
   await response.arrayBuffer();
 }
 
@@ -179,6 +212,7 @@ export async function coordinateSharedBridge(
         operation: options.agentKind === "personal" ? "personal-bridge" : "bridge",
         agent,
         rpc,
+        ...(options.trustedMessageRole ? { trustedMessageRole: options.trustedMessageRole } : {}),
       }),
     });
   await requireCoordinatorResponse(response, "conversation");
@@ -200,6 +234,7 @@ export async function coordinateSharedStream(
         operation: options.agentKind === "personal" ? "personal-stream" : "stream",
         agent,
         rpc,
+        ...(options.trustedMessageRole ? { trustedMessageRole: options.trustedMessageRole } : {}),
       }),
       ...(options.abortSignal ? { signal: options.abortSignal } : {}),
     });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -33,7 +33,7 @@ import { resolveSharedNavIntent, type SharedNavIntent } from "./shared-nav-inten
 export interface SharedTurnMessage {
   /** Stable message id used by SSE, REST history, and storage merge paths. */
   id?: string;
-  role: "user" | "assistant";
+  role: "system" | "user" | "assistant";
   content: string;
   /** Epoch-ms timestamp used by REST chat clients to reconcile persisted turns. */
   createdAt?: number;
@@ -61,6 +61,8 @@ export interface RunSharedAgentTurnInput {
   history: SharedTurnMessage[];
   /** The incoming user message or event text. */
   message: string;
+  /** Trusted lifecycle callers may add a system event instead of impersonating the user. */
+  messageRole?: "system" | "user";
   /** Stable ids assigned by the transport for the persisted user/assistant pair. */
   messageIds?: {
     user: string;
@@ -223,11 +225,12 @@ function appendTurn(
   userMessage: string,
   reply: string,
   messageIds?: RunSharedAgentTurnInput["messageIds"],
+  messageRole: "system" | "user" = "user",
 ): SharedTurnMessage[] {
   const sentAt = Date.now();
   return [
     ...history,
-    { id: messageIds?.user, role: "user", content: userMessage, createdAt: sentAt },
+    { id: messageIds?.user, role: messageRole, content: userMessage, createdAt: sentAt },
     { id: messageIds?.assistant, role: "assistant", content: reply, createdAt: sentAt + 1 },
   ];
 }
@@ -255,7 +258,13 @@ export async function runSharedAgentTurn(
   if (capabilityWall) {
     return {
       reply: capabilityWall.reply,
-      history: appendTurn(input.history, message, capabilityWall.reply, input.messageIds),
+      history: appendTurn(
+        input.history,
+        message,
+        capabilityWall.reply,
+        input.messageIds,
+        input.messageRole,
+      ),
       model: "capability-wall",
       degraded: false,
       capabilityWall,
@@ -270,7 +279,13 @@ export async function runSharedAgentTurn(
   if (navIntent) {
     return {
       reply: navIntent.reply,
-      history: appendTurn(input.history, message, navIntent.reply, input.messageIds),
+      history: appendTurn(
+        input.history,
+        message,
+        navIntent.reply,
+        input.messageIds,
+        input.messageRole,
+      ),
       model: "nav-intent",
       degraded: false,
       navIntent,
@@ -283,7 +298,13 @@ export async function runSharedAgentTurn(
     const reply = `${input.character.name} is temporarily unavailable (no shared model configured).`;
     return {
       reply,
-      history: appendTurn(input.history, message, reply, input.messageIds),
+      history: appendTurn(
+        input.history,
+        message,
+        reply,
+        input.messageIds,
+        input.messageRole,
+      ),
       model: "none",
       degraded: true,
     };
@@ -294,7 +315,7 @@ export async function runSharedAgentTurn(
     const system = buildSystemPrompt(input.character);
     const messages = [
       ...input.history.map((m) => ({ role: m.role, content: modelHistoryContent(m) })),
-      { role: "user" as const, content: message },
+      { role: input.messageRole ?? ("user" as const), content: message },
     ];
     await input.onProviderDispatch?.();
     const { text, usage } = await generateText({
@@ -310,7 +331,13 @@ export async function runSharedAgentTurn(
     const reply = text.trim() || "…";
     return {
       reply,
-      history: appendTurn(input.history, message, reply, input.messageIds),
+      history: appendTurn(
+        input.history,
+        message,
+        reply,
+        input.messageIds,
+        input.messageRole,
+      ),
       model: modelId,
       degraded: false,
       usage,
@@ -352,7 +379,13 @@ export async function runSharedAgentTurnStream(
       model: "capability-wall",
       degraded: false,
       reply,
-      history: appendTurn(input.history, message, reply, input.messageIds),
+      history: appendTurn(
+        input.history,
+        message,
+        reply,
+        input.messageIds,
+        input.messageRole,
+      ),
       parts,
       capabilityWall,
     };
@@ -373,7 +406,13 @@ export async function runSharedAgentTurnStream(
       model: "nav-intent",
       degraded: false,
       reply,
-      history: appendTurn(input.history, message, reply, input.messageIds),
+      history: appendTurn(
+        input.history,
+        message,
+        reply,
+        input.messageIds,
+        input.messageRole,
+      ),
       parts,
       navIntent,
     };
@@ -385,7 +424,13 @@ export async function runSharedAgentTurnStream(
     const reply = `${input.character.name} is temporarily unavailable (no shared model configured).`;
     return {
       reply,
-      history: appendTurn(input.history, message, reply, input.messageIds),
+      history: appendTurn(
+        input.history,
+        message,
+        reply,
+        input.messageIds,
+        input.messageRole,
+      ),
       model: "none",
       degraded: true,
     };
@@ -396,7 +441,7 @@ export async function runSharedAgentTurnStream(
     const system = buildSystemPrompt(input.character);
     const messages = [
       ...input.history.map((m) => ({ role: m.role, content: modelHistoryContent(m) })),
-      { role: "user" as const, content: message },
+      { role: input.messageRole ?? ("user" as const), content: message },
     ];
     await input.onProviderDispatch?.();
     const result = streamText({

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -298,13 +298,7 @@ export async function runSharedAgentTurn(
     const reply = `${input.character.name} is temporarily unavailable (no shared model configured).`;
     return {
       reply,
-      history: appendTurn(
-        input.history,
-        message,
-        reply,
-        input.messageIds,
-        input.messageRole,
-      ),
+      history: appendTurn(input.history, message, reply, input.messageIds, input.messageRole),
       model: "none",
       degraded: true,
     };
@@ -331,13 +325,7 @@ export async function runSharedAgentTurn(
     const reply = text.trim() || "…";
     return {
       reply,
-      history: appendTurn(
-        input.history,
-        message,
-        reply,
-        input.messageIds,
-        input.messageRole,
-      ),
+      history: appendTurn(input.history, message, reply, input.messageIds, input.messageRole),
       model: modelId,
       degraded: false,
       usage,
@@ -379,13 +367,7 @@ export async function runSharedAgentTurnStream(
       model: "capability-wall",
       degraded: false,
       reply,
-      history: appendTurn(
-        input.history,
-        message,
-        reply,
-        input.messageIds,
-        input.messageRole,
-      ),
+      history: appendTurn(input.history, message, reply, input.messageIds, input.messageRole),
       parts,
       capabilityWall,
     };
@@ -406,13 +388,7 @@ export async function runSharedAgentTurnStream(
       model: "nav-intent",
       degraded: false,
       reply,
-      history: appendTurn(
-        input.history,
-        message,
-        reply,
-        input.messageIds,
-        input.messageRole,
-      ),
+      history: appendTurn(input.history, message, reply, input.messageIds, input.messageRole),
       parts,
       navIntent,
     };
@@ -424,13 +400,7 @@ export async function runSharedAgentTurnStream(
     const reply = `${input.character.name} is temporarily unavailable (no shared model configured).`;
     return {
       reply,
-      history: appendTurn(
-        input.history,
-        message,
-        reply,
-        input.messageIds,
-        input.messageRole,
-      ),
+      history: appendTurn(input.history, message, reply, input.messageIds, input.messageRole),
       model: "none",
       degraded: true,
     };

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -491,11 +491,17 @@ export async function sharedRestMessagesGet(
   namespace: RuntimeDurableObjectNamespace,
 ): Promise<{ messages: SharedRestMessage[] }> {
   const history = await coordinateSharedHistory(agentId, conversationId, { namespace });
-  const messages = history.map((turn, index) => ({
+  // Lifecycle system events shape model continuity but are not authored chat
+  // bubbles, so keep them private to the canonical history/prompt boundary.
+  const visibleHistory = history.filter(
+    (turn): turn is typeof turn & { role: "user" | "assistant" } =>
+      turn.role === "user" || turn.role === "assistant",
+  );
+  const messages = visibleHistory.map((turn, index) => ({
     id: turn.id ?? `${conversationId}:${index}`,
     role: turn.role,
     text: turn.content,
-    timestamp: sharedRestMessageTimestamp(turn, index, history.length),
+    timestamp: sharedRestMessageTimestamp(turn, index, visibleHistory.length),
     ...(turn.role === "assistant" && turn.interrupted ? { interrupted: true } : {}),
   }));
   return { messages };

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -20,6 +20,7 @@ let billError: Error | null;
 let billingGate: Promise<void> | null;
 let releaseBilling = () => {};
 let streamAbortSignal: AbortSignal | undefined;
+let lastTurnRole: "system" | "user" | undefined;
 const settleCalls: number[] = [];
 let settleUnknownCalls = 0;
 const billCalls: unknown[] = [];
@@ -155,8 +156,12 @@ mock.module("../../../db/repositories/characters", () => ({
 }));
 mock.module("./run-shared-agent-turn", () => ({
   resolveSharedAgentTurnModel: () => "openai/gpt-oss-120b",
-  runSharedAgentTurn: async (input: { messageIds?: { user: string; assistant: string } }) => {
+  runSharedAgentTurn: async (input: {
+    messageIds?: { user: string; assistant: string };
+    messageRole?: "system" | "user";
+  }) => {
     turnCalls++;
+    lastTurnRole = input.messageRole;
     if (turnError) throw turnError;
     const history = Array.isArray(turn.history)
       ? turn.history.map((message, index) =>
@@ -355,6 +360,7 @@ beforeEach(() => {
       };
     })(),
   };
+  lastTurnRole = undefined;
 });
 
 function wrappedProviderError(statusCode: number): Error {
@@ -384,6 +390,23 @@ describe("SharedRuntimeChatService", () => {
         })
       ).error?.code,
     ).toBe(-32602);
+  });
+
+  test("ignores untrusted RPC roles and accepts only the server option", async () => {
+    const service = new SharedRuntimeChatService();
+    const untrustedRpc = {
+      ...rpc,
+      params: { ...rpc.params, messageRole: "system" },
+    };
+
+    await service.bridge(agent, untrustedRpc, harness());
+    expect(lastTurnRole).toBe("user");
+
+    await service.bridge(agent, rpc, {
+      ...harness(),
+      trustedMessageRole: "system",
+    });
+    expect(lastTurnRole).toBe("system");
   });
 
   test("returns before billing and persists ordered cache-local history", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -140,6 +140,8 @@ export interface SharedRuntimeChatOptions {
   turnClaims?: SharedTurnClaimStore;
   /** Personal Shared keeps abuse limits but never debits account credits. */
   funding?: "organization-credits" | "platform";
+  /** Server-authenticated lifecycle prompt; never derived from bridge params. */
+  trustedMessageRole?: "system";
 }
 
 export {
@@ -227,15 +229,22 @@ function turnMessageIds(
   };
 }
 
+export function sharedRuntimeChannelId(agentId: string, roomId: string): string {
+  const room = roomId.trim() || "default";
+  return stableUuid(`cloud-bridge-channel:${agentId}:${room}`);
+}
+
 function channelId(agentId: string, params: Record<string, unknown>): string {
   const room = stringValue(params.roomId) ?? stringValue(params.userId) ?? "default";
-  return stableUuid(`cloud-bridge-channel:${agentId}:${room}`);
+  return sharedRuntimeChannelId(agentId, room);
 }
 
 function isTurn(value: unknown): value is SharedTurnMessage {
   const candidate = record(value);
   return (
-    (candidate?.role === "user" || candidate?.role === "assistant") &&
+    (candidate?.role === "system" ||
+      candidate?.role === "user" ||
+      candidate?.role === "assistant") &&
     typeof candidate.content === "string" &&
     candidate.content.trim().length > 0
   );
@@ -660,6 +669,15 @@ function sseError(message: string): Response {
 }
 
 export class SharedRuntimeChatService {
+  async recordLifecycleEvent(
+    agentId: string,
+    roomId: string,
+    event: SharedTurnMessage,
+    store: SharedRuntimeHistoryStore,
+  ): Promise<void> {
+    await mergeHistory(agentId, channelId(agentId, { roomId }), [event], store);
+  }
+
   async getHistory(
     agentId: string,
     roomId = agentId,
@@ -710,6 +728,7 @@ export class SharedRuntimeChatService {
       };
     }
     const roomId = channelId(agent.id, params);
+    const messageRole = options.trustedMessageRole ?? "user";
     const claimKey = options.turnClaims ? sharedTurnClientMessageId(params) : undefined;
     if (claimKey && options.turnClaims) {
       const replay = await claimSharedTurn(options.turnClaims, claimKey, text);
@@ -762,6 +781,7 @@ export class SharedRuntimeChatService {
         character,
         history,
         message: text,
+        messageRole,
         messageIds,
         onProviderDispatch: billing?.markProviderDispatched,
       });
@@ -851,6 +871,7 @@ export class SharedRuntimeChatService {
     const text = stringValue(params.text);
     if (!text) return sseError("message.send requires params.text");
     const roomId = channelId(agent.id, params);
+    const messageRole = options.trustedMessageRole ?? "user";
     const claimKey = options.turnClaims ? sharedTurnClientMessageId(params) : undefined;
     if (claimKey && options.turnClaims) {
       const replay = await claimSharedTurn(options.turnClaims, claimKey, text);
@@ -924,6 +945,7 @@ export class SharedRuntimeChatService {
         character,
         history,
         message: text,
+        messageRole,
         messageIds,
         onProviderDispatch: billing?.markProviderDispatched,
       });
@@ -978,7 +1000,7 @@ export class SharedRuntimeChatService {
     const makeTurnMessages = (reply: string, interrupted: boolean): SharedTurnMessage[] => {
       const sentAt = Date.now();
       const messages: SharedTurnMessage[] = [
-        { id: messageIds.user, role: "user", content: text, createdAt: sentAt },
+        { id: messageIds.user, role: messageRole, content: text, createdAt: sentAt },
       ];
       const assistantText = reply.trim();
       if (assistantText) {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.test.ts
@@ -60,6 +60,17 @@ describe("shared runtime history merge policy", () => {
       incoming[1],
     ]);
   });
+
+  test("deduplicates retried lifecycle system events by stable event id", () => {
+    const event = {
+      id: "twilio-call:CA1:ended",
+      role: "system" as const,
+      content: "The user ended the phone call.",
+      createdAt: 100,
+    };
+
+    expect(mergeSharedRuntimeHistoryMessages([event], [event], 40)).toEqual([event]);
+  });
 });
 
 describe("shared runtime long-term transcript context", () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-history-policy.ts
@@ -48,7 +48,7 @@ const STOP_WORDS = new Set([
 
 export interface SharedRuntimeHistoryMessageLike {
   id?: string;
-  role: "user" | "assistant";
+  role: "system" | "user" | "assistant";
   content: string;
   createdAt?: number;
   interrupted?: boolean;
@@ -58,7 +58,8 @@ function isPersistedMessage(value: unknown): value is SharedRuntimeHistoryMessag
   return (
     Boolean(value) &&
     typeof value === "object" &&
-    ((value as { role?: unknown }).role === "user" ||
+    ((value as { role?: unknown }).role === "system" ||
+      (value as { role?: unknown }).role === "user" ||
       (value as { role?: unknown }).role === "assistant") &&
     typeof (value as { content?: unknown }).content === "string" &&
     (value as { content: string }).content.trim().length > 0

--- a/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
+++ b/packages/cloud/shared/src/lib/voice-session/eliza-sse-bridge.ts
@@ -39,6 +39,10 @@ export interface ElizaSseBridgeRequest {
   model: string;
   /** The authoritative user turn (from stt_final). */
   transcript: string;
+  /** Trusted in-process voice lifecycle turns may enter history as system events. */
+  messageRole?: "system";
+  /** Stable provider lifecycle id used by the room's durable replay ledger. */
+  clientMessageId?: string;
   /** Agent this session is scoped to (from the verified token claims). */
   agentId: string;
   /** Conversation this session writes into (from the verified token claims). */
@@ -127,6 +131,8 @@ export async function streamElizaConversation(
       // sharedRestMessageSend/bridgeStream executes and persists this turn.
       body: JSON.stringify({
         text: request.transcript,
+        ...(request.messageRole ? { messageRole: request.messageRole } : {}),
+        ...(request.clientMessageId ? { clientMessageId: request.clientMessageId } : {}),
         metadata: {
           clientTransport: REALTIME_VOICE_CLIENT_TRANSPORT,
         },

--- a/plugins/plugin-discord/__tests__/discord-events-config.test.ts
+++ b/plugins/plugin-discord/__tests__/discord-events-config.test.ts
@@ -104,6 +104,21 @@ describe("setupDiscordEventListeners config", () => {
 			}),
 		);
 	});
+
+	it("forwards Discord voice-state changes to the voice manager", async () => {
+		const service = makeService(false);
+		const handleVoiceStateUpdate = vi.fn(async () => undefined);
+		service.voiceManager = { handleVoiceStateUpdate } as never;
+		setupDiscordEventListeners(service as never);
+		const oldState = { channelId: null };
+		const newState = { channelId: "voice-1" };
+
+		service.client.emit("voiceStateUpdate", oldState, newState);
+
+		await vi.waitFor(() => {
+			expect(handleVoiceStateUpdate).toHaveBeenCalledWith(oldState, newState);
+		});
+	});
 });
 
 // The cooldown-gating half of the "@bot ^^" pointer fix lives in the flush

--- a/plugins/plugin-discord/__tests__/slash-commands.test.ts
+++ b/plugins/plugin-discord/__tests__/slash-commands.test.ts
@@ -1,6 +1,6 @@
 /**
- * Unit tests for the `/app` embedded-app launch slash command (#9947).
- * Mocked runtime and interaction.
+ * Unit tests for built-in Discord slash commands, including privileged `/app`
+ * launch and owner-scoped live voice controls, with mocked runtime boundaries.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -251,7 +251,7 @@ describe("builtin command surface (privileged plumbing hidden from pickers)", ()
 
 	it("marks privileged builtins with requiredPermissions and leaves user commands open", () => {
 		const commands = getRegisteredCommands();
-		for (const name of ["settings", "setup", "app", "transcribe"]) {
+		for (const name of ["settings", "setup", "app", "voice", "transcribe"]) {
 			expect(
 				commands.get(name)?.requiredPermissions,
 				`${name} must carry requiredPermissions`,
@@ -266,6 +266,78 @@ describe("builtin command surface (privileged plumbing hidden from pickers)", ()
 				`${name} must stay visible to everyone`,
 			).toBeUndefined();
 		}
+	});
+
+	it("limits /voice join to the canonical owner's current guild channel", async () => {
+		const joinChannel = vi.fn(async () => undefined);
+		const channel = {
+			guild: { id: "guild-1" },
+			id: "voice-1",
+			isVoiceBased: () => true,
+			name: "Owners Room",
+		};
+		const voice = getRegisteredCommands().get("voice");
+		if (!voice) throw new Error('built-in "/voice" command not registered');
+		const runtime = makeRuntime() as IAgentRuntime & {
+			getService: ReturnType<typeof vi.fn>;
+		};
+		runtime.getService = vi.fn(() => ({
+			voiceManager: { joinChannel },
+		}));
+		const interaction = {
+			deferReply: vi.fn(async () => undefined),
+			editReply: vi.fn(async () => undefined),
+			guild: {
+				id: "guild-1",
+				members: {
+					cache: new Map([["owner-1", { voice: { channel } }]]),
+				},
+			},
+			guildId: "guild-1",
+			options: { get: () => ({ value: "join" }) },
+			reply: vi.fn(async () => undefined),
+			user: { id: "owner-1" },
+		};
+
+		await voice.execute(interaction as never, runtime);
+
+		expect(joinChannel).toHaveBeenCalledWith(channel);
+		expect(interaction.editReply).toHaveBeenCalledWith({
+			content: "Joined **Owners Room**.",
+		});
+		expect(voice.requiredRole).toBe("OWNER");
+	});
+
+	it("does not let /voice join place the bot into another member's channel", async () => {
+		const joinChannel = vi.fn(async () => undefined);
+		const voice = getRegisteredCommands().get("voice");
+		if (!voice) throw new Error('built-in "/voice" command not registered');
+		const runtime = makeRuntime() as IAgentRuntime & {
+			getService: ReturnType<typeof vi.fn>;
+		};
+		runtime.getService = vi.fn(() => ({
+			voiceManager: { joinChannel },
+		}));
+		const reply = vi.fn(async () => undefined);
+
+		await voice.execute(
+			{
+				guild: { id: "guild-1", members: { cache: new Map() } },
+				guildId: "guild-1",
+				options: { get: () => ({ value: "join" }) },
+				reply,
+				user: { id: "owner-1" },
+			} as never,
+			runtime,
+		);
+
+		expect(joinChannel).not.toHaveBeenCalled();
+		expect(reply).toHaveBeenCalledWith(
+			expect.objectContaining({
+				content: expect.stringContaining("Join a voice channel"),
+				ephemeral: true,
+			}),
+		);
 	});
 
 	it("transforms requiredPermissions into default_member_permissions on the wire", async () => {

--- a/plugins/plugin-discord/__tests__/voice.test.ts
+++ b/plugins/plugin-discord/__tests__/voice.test.ts
@@ -2,17 +2,25 @@
  * Unit tests for `VoiceManager` — voice-channel join/leave and audio routing,
  * against a mocked runtime and Discord voice stack (no real gateway).
  */
+import { EventEmitter } from "node:events";
+import { PassThrough, Transform } from "node:stream";
 import type { UUID } from "@elizaos/core";
-import { describe, expect, it, vi } from "vitest";
+import { ChannelType } from "discord.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ICompatRuntime } from "../compat";
 import { VoiceManager } from "../voice";
+
+const voiceModule = vi.hoisted(() => ({
+	entersState: vi.fn(),
+	joinVoiceChannel: vi.fn(),
+}));
 
 vi.mock("@discordjs/voice", () => ({
 	createAudioPlayer: vi.fn(),
 	createAudioResource: vi.fn(),
-	entersState: vi.fn(),
+	entersState: voiceModule.entersState,
 	getVoiceConnections: vi.fn(),
-	joinVoiceChannel: vi.fn(),
+	joinVoiceChannel: voiceModule.joinVoiceChannel,
 	NoSubscriberBehavior: { Pause: "pause" },
 	StreamType: { OggOpus: "ogg/opus" },
 	VoiceConnectionStatus: {
@@ -24,16 +32,76 @@ vi.mock("@discordjs/voice", () => ({
 	},
 }));
 
+vi.mock("prism-media", () => ({
+	default: {
+		opus: {
+			Decoder: class Decoder extends Transform {
+				override _transform(
+					chunk: Buffer,
+					_encoding: BufferEncoding,
+					callback: (error?: Error | null) => void,
+				) {
+					this.push(chunk);
+					callback();
+				}
+			},
+		},
+	},
+}));
+
+function makeRuntime() {
+	return {
+		agentId: "00000000-0000-4000-8000-000000000002",
+		getSetting: vi.fn(() => undefined),
+		logger: {
+			debug: vi.fn(),
+			error: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+		},
+	};
+}
+
+function makeConnection(receiveStream = new PassThrough()) {
+	const speaking = new EventEmitter();
+	return {
+		destroy: vi.fn(),
+		joinConfig: { channelId: "voice-1", guildId: "guild-1" },
+		on: vi.fn(),
+		receiver: {
+			speaking,
+			subscribe: vi.fn(() => receiveStream),
+		},
+		state: { status: "ready" },
+	};
+}
+
+function makeChannel(member?: unknown) {
+	const members = new Map<string, unknown>();
+	if (member) members.set("user-1", member);
+	return {
+		guildId: "guild-1",
+		id: "voice-1",
+		name: "Owners Room",
+		members,
+		type: ChannelType.GuildVoice,
+		guild: {
+			id: "guild-1",
+			members: { fetch: vi.fn() },
+			voiceAdapterCreator: vi.fn(),
+		},
+	};
+}
+
 describe("VoiceManager", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
 	it("uses the Discord entity resolver for live voice speaker attribution", () => {
 		const resolvedEntityId = "00000000-0000-4000-8000-000000000001" as UUID;
 		const resolveDiscordEntityId = vi.fn(() => resolvedEntityId);
-		const runtime = {
-			agentId: "00000000-0000-4000-8000-000000000002",
-			logger: {
-				error: vi.fn(),
-			},
-		};
+		const runtime = makeRuntime();
 
 		const manager = new VoiceManager(
 			{
@@ -52,5 +120,93 @@ describe("VoiceManager", () => {
 			).resolveVoiceSpeakerEntityId("1234567890"),
 		).toBe(resolvedEntityId);
 		expect(resolveDiscordEntityId).toHaveBeenCalledWith("1234567890");
+	});
+
+	it("rejects a text channel instead of reporting a successful join", async () => {
+		const manager = new VoiceManager(
+			{ accountId: "test", client: null },
+			makeRuntime() as unknown as ICompatRuntime,
+		);
+		const editReply = vi.fn(async () => undefined);
+		const textChannel = {
+			id: "text-1",
+			name: "general",
+			type: ChannelType.GuildText,
+		};
+
+		await manager.handleJoinChannelCommand({
+			deferReply: vi.fn(async () => undefined),
+			editReply,
+			guild: {
+				channels: {
+					cache: {
+						find: (predicate: (channel: typeof textChannel) => boolean) =>
+							predicate(textChannel) ? textChannel : undefined,
+					},
+				},
+			} as never,
+			options: { get: vi.fn(() => ({ value: textChannel.id })) },
+		});
+
+		expect(editReply).toHaveBeenCalledWith("Voice channel not found!");
+		expect(voiceModule.joinVoiceChannel).not.toHaveBeenCalled();
+	});
+
+	it("fails the join when the Discord connection never becomes ready", async () => {
+		const connection = makeConnection();
+		voiceModule.joinVoiceChannel.mockReturnValue(connection);
+		voiceModule.entersState.mockRejectedValue(new Error("not ready"));
+		const manager = new VoiceManager(
+			{ accountId: "test", client: new EventEmitter() as never },
+			makeRuntime() as unknown as ICompatRuntime,
+		);
+
+		await expect(manager.joinChannel(makeChannel() as never)).rejects.toThrow(
+			"not ready",
+		);
+		expect(connection.destroy).toHaveBeenCalledOnce();
+	});
+
+	it("subscribes to a newly-speaking member even before audio is buffered", async () => {
+		const receiveStream = new PassThrough();
+		expect(receiveStream.readableLength).toBe(0);
+		const connection = makeConnection(receiveStream);
+		voiceModule.joinVoiceChannel.mockReturnValue(connection);
+		voiceModule.entersState.mockResolvedValue(connection);
+
+		const client = new EventEmitter() as EventEmitter & {
+			user?: { id: string };
+		};
+		client.user = { id: "bot-1" };
+		const userStream = vi.fn();
+		client.on("userStream", userStream);
+		const member = {
+			displayName: "Owner",
+			guild: { id: "guild-1" },
+			id: "user-1",
+			user: { bot: false, displayName: "Owner", username: "owner" },
+		};
+		const channel = makeChannel(member);
+		const manager = new VoiceManager(
+			{ accountId: "test", client: client as never },
+			makeRuntime() as unknown as ICompatRuntime,
+		);
+
+		await manager.joinChannel(channel as never);
+		connection.receiver.speaking.emit("start", "user-1");
+
+		await vi.waitFor(() => {
+			expect(connection.receiver.subscribe).toHaveBeenCalledWith("user-1", {
+				autoDestroy: true,
+				emitClose: true,
+			});
+			expect(userStream).toHaveBeenCalledWith(
+				"user-1",
+				"Owner",
+				"owner",
+				channel,
+				expect.any(Transform),
+			);
+		});
 	});
 });

--- a/plugins/plugin-discord/discord-events.ts
+++ b/plugins/plugin-discord/discord-events.ts
@@ -913,6 +913,21 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 	});
 
 	// ── userStream (voice) ─────────────────────────────────────────────
+	service.client.on("voiceStateUpdate", async (oldState, newState) => {
+		try {
+			await service.voiceManager?.handleVoiceStateUpdate(oldState, newState);
+		} catch (error) {
+			service.runtime.logger.error(
+				{
+					src: "plugin:discord:service:voice",
+					agentId: service.runtime.agentId,
+					error: error instanceof Error ? error.message : String(error),
+				},
+				"Error handling Discord voice state update",
+			);
+		}
+	});
+
 	service.client.on(
 		"userStream",
 		(entityId, name, userName, channel, opusDecoder) => {

--- a/plugins/plugin-discord/slash-commands.ts
+++ b/plugins/plugin-discord/slash-commands.ts
@@ -459,6 +459,98 @@ function resolveTranscriptsViewUrl(runtime: IAgentRuntime): string | undefined {
 }
 
 /**
+ * `/voice join|leave` gives the canonical owner an explicit, consent-aware
+ * control surface for live Discord audio. Join is intentionally limited to
+ * the owner's current guild voice channel; accepting an arbitrary channel ID
+ * would let a remote command place the bot into somebody else's conversation.
+ */
+const voiceCommand: SlashCommand = {
+	name: "voice",
+	description: "Join or leave your current Discord voice channel",
+	requiredRole: "OWNER",
+	requiredPermissions: PermissionFlagsBits.ManageGuild,
+	options: [
+		{
+			name: "mode",
+			description: "join or leave voice",
+			type: "string",
+			required: true,
+			choices: [
+				{ name: "join", value: "join" },
+				{ name: "leave", value: "leave" },
+			],
+		},
+	],
+	async execute(interaction, runtime) {
+		const guild = interaction.guild;
+		if (!guild || !interaction.guildId) {
+			await interaction.reply({
+				content: "Voice controls are only available in a server.",
+				ephemeral: true,
+			});
+			return;
+		}
+
+		const service = runtime.getService("discord") as {
+			voiceManager?: VoiceManager;
+		} | null;
+		const voiceManager = service?.voiceManager;
+		if (!voiceManager) {
+			await interaction.reply({
+				content: "Voice support is not available right now.",
+				ephemeral: true,
+			});
+			return;
+		}
+
+		const mode = interaction.options.get("mode")?.value;
+		if (mode === "leave") {
+			const connection = voiceManager.getVoiceConnection(interaction.guildId);
+			const channelId = connection?.joinConfig.channelId;
+			const channel = channelId
+				? guild.channels.cache.get(channelId)
+				: undefined;
+			if (!channel?.isVoiceBased?.()) {
+				await interaction.reply({
+					content: "I'm not in a voice channel in this server.",
+					ephemeral: true,
+				});
+				return;
+			}
+			voiceManager.leaveChannel(channel);
+			await interaction.reply({
+				content: `Left **${channel.name}**.`,
+				ephemeral: true,
+			});
+			return;
+		}
+
+		if (mode !== "join") {
+			await interaction.reply({
+				content: "Use `/voice mode:join` or `/voice mode:leave`.",
+				ephemeral: true,
+			});
+			return;
+		}
+
+		const member = guild.members.cache.get(interaction.user.id);
+		const channel = member?.voice.channel;
+		if (!channel?.isVoiceBased() || channel.guild.id !== guild.id) {
+			await interaction.reply({
+				content:
+					"Join a voice channel in this server first, then run `/voice mode:join`.",
+				ephemeral: true,
+			});
+			return;
+		}
+
+		await interaction.deferReply({ ephemeral: true });
+		await voiceManager.joinChannel(channel);
+		await interaction.editReply({ content: `Joined **${channel.name}**.` });
+	},
+};
+
+/**
  * `/transcribe start|stop` — live diarized meeting transcription for the
  * voice channel the bot is currently connected to in this server. Start sets
  * a per-channel override (so it works regardless of the global
@@ -747,6 +839,7 @@ function registerBuiltins(): void {
 		settingsCommand,
 		setupCommand,
 		appCommand,
+		voiceCommand,
 		transcribeCommand,
 	]) {
 		commands.set(command.name, command);

--- a/plugins/plugin-discord/tests.ts
+++ b/plugins/plugin-discord/tests.ts
@@ -129,9 +129,12 @@ export class DiscordTestSuite implements TestSuite {
 			await this.waitForVoiceManagerReady(this.discordClient);
 
 			const channel = await this.getTestChannel(runtime);
-			if (!channel?.isTextBased()) {
-				throw new Error("Invalid test channel for slash command test.");
+			if (!channel || channel.type !== ChannelType.GuildVoice) {
+				throw new Error(
+					"DISCORD_TEST_CHANNEL_ID must identify a voice channel.",
+				);
 			}
+			let reply = "";
 
 			// Simulate a join channel slash command interaction
 			interface MockJoinInteraction {
@@ -151,9 +154,10 @@ export class DiscordTestSuite implements TestSuite {
 					get: (name: string) =>
 						name === "channel" ? { value: channel.id } : null,
 				},
-				guild: (channel as TextChannel).guild,
+				guild: channel.guild,
 				deferReply: async () => {},
 				editReply: async (message: string) => {
+					reply = message;
 					logger.info(`JoinChannel Slash Command Response: ${message}`);
 				},
 			};
@@ -164,6 +168,9 @@ export class DiscordTestSuite implements TestSuite {
 			await this.discordClient.voiceManager.handleJoinChannelCommand(
 				testJoinInteraction,
 			);
+			if (!reply.startsWith("Joined voice channel:")) {
+				throw new Error(`Voice join did not succeed: ${reply || "no reply"}`);
+			}
 
 			logger.success("Join voice slash command test completed successfully.");
 		} catch (error) {

--- a/plugins/plugin-discord/voice.ts
+++ b/plugins/plugin-discord/voice.ts
@@ -978,14 +978,18 @@ export class VoiceManager extends EventEmitter {
 			autoDestroy: true,
 			emitClose: true,
 		});
-		if (!receiveStream || receiveStream.readableLength === 0) {
+		// A newly subscribed Discord receive stream normally has no buffered
+		// frames yet. `readableLength === 0` means "waiting for speech", not that
+		// the subscription failed; rejecting it here made every fresh listener
+		// silently miss its first utterance.
+		if (!receiveStream) {
 			this.runtime.logger.warn(
 				{
 					src: "plugin:discord:service:voice",
 					agentId: this.runtime.agentId,
 					entityId,
 				},
-				"No receiveStream or empty stream",
+				"Discord voice receiver did not create a stream",
 			);
 			return;
 		}


### PR DESCRIPTION
# Relates to

Closes #19772.

- [x] Targets `develop` and was rebased onto `origin/develop` at `e302078b57f48cb75fe7d19c47f0c5bd1101469c` with zero conflicts.
- [x] `bun install` dependencies were already current; affected package gates passed. Root `bun run verify` is documented below because current develop has an unrelated post-merge Cloud typecheck regression from #19758.
- [ ] Live provider evidence must be captured from staging before merge and production after promotion.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e302078b57f48cb75fe7d19c47f0c5bd1101469c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts at push time.
- [ ] Root verify is blocked only by the exact upstream errors under **Known gaps / failures**.

# Risks

Medium-high: this changes personal identity routing and durable conversation history for Discord DMs and phone calls, and adds bounded Telegram media ingestion. Guild messages remain isolated from private personal history. System lifecycle events are server-only, idempotent, and filtered from public chat/import surfaces.

# Background

## What does this PR do?

- Routes Discord DMs into the same deterministic personal Shared agent/room used by Telegram, SMS, and phone; guild traffic remains on its existing guild-scoped route.
- Resolves inbound callers to their phone-backed account and stable personal conversation instead of a random call UUID.
- Persists idempotent `call.started` and `call.ended` lifecycle events and generates the call opener through Eliza with prior cross-channel context and elapsed-time context.
- Accepts private Telegram voice notes, securely downloads and validates Ogg bytes at the credential-local gateway, transcribes them through configured Whisper, and sends the transcript through the same personal conversation.
- Repairs standalone Discord guild voice receive subscriptions, voice-state event wiring, and adds owner-authorized `/voice join|leave` controls restricted to the invoking owner's current channel.
- Updates the Cloud E2E chat assertion so server-only lifecycle events do not masquerade as visible user/assistant chat.

## What kind of change is this?

Feature plus non-breaking reliability fixes.

# Documentation changes needed?

No user-facing docs are changed in this PR. Platform limitations and deployment requirements are recorded below and in #19772.

# Testing

## Where should a reviewer start?

Start with `packages/cloud/api/v1/twilio/voice/lib/voice-continuity.ts`, the personal Shared route, the Telegram gateway adapter, and `plugins/plugin-discord/voice.ts`.

## Detailed testing steps

- Cloud Shared typecheck: pass.
- Cloud API typecheck + Wrangler production dry-run: pass before upstream #19758 landed.
- Gateway webhook typecheck: pass.
- Gateway webhook full suite: 126 passed, 0 failed.
- Personal Shared + phone resolution/token/continuity tests: 28 passed, 0 failed.
- Shared runtime chat/coordinator/history tests: 38 passed, 0 failed.
- Twilio WebSocket lifecycle suite: 58 test cases passed; one aggregate rerun later hit the terminal output sink after completion, while the isolated run exited cleanly.
- Discord plugin: typecheck pass, build pass, 616 tests passed, 0 failed.
- Cloud E2E package typecheck: pass after lifecycle-history assertion update.
- Biome over all 43 changed files: pass.
- `git diff --check`: pass.

# Evidence Gate

<!-- evidence-head:7f5894b89648756eb90c9a8e9816d1128f206bdd -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI files change
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI files change
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered UI files change
<!-- evidence-row:backend-logs -->
- [ ] N/A - protected staging deploy only accepts develop, so feature-branch provider logs cannot be captured before merge
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request path changes
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - protected staging deploy only accepts develop; live returning-call trajectory is a post-merge staging gate
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - protected staging deploy only accepts develop; real provider history and transcript artifacts are a post-merge staging gate
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered UI files change

# Evidence Details

## Real LLM-call trajectory

Pending staging: call twice from one number after a Telegram/SMS marker and capture the second model-generated opener showing continuation without exposing private content to guild context.

## Backend + frontend logs

Pending staging: attach sanitized gateway, Worker, Durable Object, and provider response logs. No token-bearing Telegram URL or phone number will be posted.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface changes.

## Audio / voice walkthrough

Pending staging for Twilio and Telegram voice-note round trips. Discord guild voice needs an installed standalone agent bot in a real guild and is not a managed Eliza App DM-call feature.

## Known gaps / failures

- Current `origin/develop` commit `9888e68763777042879e425a431e3299aa4cf189` (#19758) breaks root verify independently of this diff: `LifecycleSandboxRow` omits `billing_status`, `shutdown_warning_sent_at`, and `scheduled_shutdown_at` that `provisioning-jobs.ts` reads; its delete fallback test also supplies an `error` property absent from the mock's declared return type. This branch does not touch those files. The prior full verify reached 345/348 tasks before the continuity E2E type mismatch, which is now fixed and independently typechecked.
- Telegram bots cannot join or answer Telegram calls. This PR supports inbound conversational voice notes and a text reply; Shared has no canonical outbound TTS media artifact yet, so it does not fabricate a voice response.
- Discord bots cannot participate in DM calls. Guild voice requires a separate guild installation, `ViewChannel/Connect/Speak/UseVAD`, `GuildVoiceStates`, ffmpeg/Opus runtime, and real two-way guild validation. The managed Eliza App Railway gateway does not yet host that standalone voice runtime.
- No production deployment is performed from this feature branch. Promotion must follow green required checks, staging evidence, merge to develop, and the protected main/production workflow.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@e302078b57f48cb75fe7d19c47f0c5bd1101469c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-continuity]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex desktop","skill_revision":"elizaOS/eliza@e302078b57f48cb75fe7d19c47f0c5bd1101469c:packages/skills/skills/contribute-to-eliza"} -->

