### PR TITLE
fix(discord): durably queue authorization welcome DMs

### DIFF
--- a/packages/cloud/services/gateway-discord/AGENTS.md
+++ b/packages/cloud/services/gateway-discord/AGENTS.md
@@ -71,6 +71,8 @@ Optional features / toggles:
 - `ELIZA_APP_DISCORD_BOT_ENABLED=true` + `ELIZA_APP_DISCORD_BOT_TOKEN` — run the
   Eliza App system bot; `ELIZA_APP_LEADER_KEY` (default `discord:eliza-app-bot:leader`)
   for leader election.
+- `ELIZA_APP_DISCORD_PUBLIC_KEY` — recommended local Ed25519 verification key
+  for the signed install webhook; avoids a bounded first-request key lookup.
 - `VOICE_MESSAGE_ENABLED` (`"false"` disables the voice path),
   `VOICE_AUDIO_TTL_SECONDS`, `VOICE_CLEANUP_INTERVAL_MS`,
   `CLOUD_API_BASE_URL`/`ELIZAOS_CLOUD_BASE_URL`, `BLOB_READ_WRITE_TOKEN` — voice upload.

--- a/packages/cloud/services/gateway-discord/CLAUDE.md
+++ b/packages/cloud/services/gateway-discord/CLAUDE.md
@@ -71,6 +71,8 @@ Optional features / toggles:
 - `ELIZA_APP_DISCORD_BOT_ENABLED=true` + `ELIZA_APP_DISCORD_BOT_TOKEN` — run the
   Eliza App system bot; `ELIZA_APP_LEADER_KEY` (default `discord:eliza-app-bot:leader`)
   for leader election.
+- `ELIZA_APP_DISCORD_PUBLIC_KEY` — recommended local Ed25519 verification key
+  for the signed install webhook; avoids a bounded first-request key lookup.
 - `VOICE_MESSAGE_ENABLED` (`"false"` disables the voice path),
   `VOICE_AUDIO_TTL_SECONDS`, `VOICE_CLEANUP_INTERVAL_MS`,
   `CLOUD_API_BASE_URL`/`ELIZAOS_CLOUD_BASE_URL`, `BLOB_READ_WRITE_TOKEN` — voice upload.

--- a/packages/cloud/services/gateway-discord/README.md
+++ b/packages/cloud/services/gateway-discord/README.md
@@ -466,6 +466,7 @@ Eliza Cloud logs show:
 | `ELIZA_APP_DISCORD_BOT_ENABLED` | No | `false` | Set to `"true"` to enable Eliza App bot |
 | `ELIZA_APP_DISCORD_BOT_TOKEN` | No* | - | Eliza App system bot token (required if enabled) |
 | `ELIZA_APP_DISCORD_APPLICATION_ID` | No | - | Eliza App bot application ID (for reference) |
+| `ELIZA_APP_DISCORD_PUBLIC_KEY` | No | - | Discord application's Ed25519 public key; recommended so signed install webhooks never need a first-request API lookup |
 
 **\*** Required when `ELIZA_APP_DISCORD_BOT_ENABLED=true`
 

--- a/packages/cloud/services/gateway-discord/scripts/deploy-railway.sh
+++ b/packages/cloud/services/gateway-discord/scripts/deploy-railway.sh
@@ -20,7 +20,7 @@
 # WS lib (lazy require -> graceful fallback to no compression).
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")/.." && pwd)"
-PACKAGES_DIR="$(cd "$HERE/../.." && pwd)"
+PACKAGES_DIR="$(cd "$HERE/../../.." && pwd)"
 CLEANUP_HELPER="$PACKAGES_DIR/scripts/rm-path-recursive.mjs"
 STAGE="$(mktemp -d)"
 cleanup_stage() {
@@ -52,5 +52,16 @@ DOCKER
 cp "$HERE/railway.toml" "$STAGE/railway.toml" 2>/dev/null || true
 
 echo "[deploy] railway up from staged bundle ..."
-( cd "$STAGE" && railway up --service gateway-discord --environment production --detach )
+(
+  cd "$STAGE"
+  railway link \
+    --project "${RAILWAY_PROJECT:-eliza-cloud}" \
+    --service "${RAILWAY_SERVICE:-gateway-discord}" \
+    --environment "${RAILWAY_ENVIRONMENT:-production}" \
+    >/dev/null
+  railway up \
+    --service "${RAILWAY_SERVICE:-gateway-discord}" \
+    --environment "${RAILWAY_ENVIRONMENT:-production}" \
+    --detach
+)
 echo "[deploy] done — current deployment stays live until the new one passes healthcheck."

--- a/packages/cloud/services/gateway-discord/src/discord-event-webhook.ts
+++ b/packages/cloud/services/gateway-discord/src/discord-event-webhook.ts
@@ -1,12 +1,17 @@
 /**
- * Verifies Discord application event webhooks and starts a DM after a user
- * installs Eliza to their account.
+ * Verifies Discord application event webhooks and durably enqueues a welcome
+ * after a user installs Eliza to their account.
  */
 import { createHash, createPublicKey, verify } from "node:crypto";
+import { Hono } from "hono";
+import type { DiscordInstallWelcomeJob } from "./discord-install-welcome-queue";
+import { sanitizeDiscordInstallWelcomeError } from "./discord-install-welcome-queue";
 
 const DISCORD_API_BASE = "https://discord.com/api/v10";
 const APPLICATION_AUTHORIZED = "APPLICATION_AUTHORIZED";
 const USER_INSTALL = 1;
+const PUBLIC_KEY_TIMEOUT_MS = 750;
+const ENQUEUE_TIMEOUT_MS = 1_250;
 
 interface DiscordWebhookPayload {
   application_id?: string;
@@ -21,16 +26,16 @@ interface DiscordWebhookPayload {
   };
 }
 
-interface DiscordApiError {
-  message?: string;
-  code?: number;
-}
-
 export interface DiscordEventWebhookDependencies {
   applicationId: string;
-  botToken: string;
   getPublicKey: () => Promise<string>;
-  fetchImpl?: typeof fetch;
+  enqueue: (job: DiscordInstallWelcomeJob) => Promise<void>;
+}
+
+export interface DiscordEventWebhookRouteConfig
+  extends DiscordEventWebhookDependencies {
+  enabled: boolean;
+  logError?: (message: string, context: { error: string }) => void;
 }
 
 function discordPublicKey(rawPublicKey: string) {
@@ -60,64 +65,35 @@ export function verifyDiscordEventSignature(
   );
 }
 
-function deliveryNonce(userId: string, eventTimestamp: string): string {
-  const digest = createHash("sha256")
-    .update(`${userId}:${eventTimestamp}`)
-    .digest();
-  return digest.readBigUInt64BE().toString();
-}
-
-async function discordApi<T>(
-  path: string,
-  body: Record<string, unknown>,
-  botToken: string,
-  fetchImpl: typeof fetch,
-): Promise<T> {
-  const response = await fetchImpl(`${DISCORD_API_BASE}${path}`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bot ${botToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(body),
-  });
-  const result = (await response.json()) as T & DiscordApiError;
-  if (!response.ok) {
-    throw new Error(
-      `Discord API request failed (${response.status}): ${result.message ?? result.code ?? "unknown error"}`,
-    );
-  }
-  return result;
-}
-
-async function sendInstallWelcome(
-  user: { id: string; global_name?: string | null; username?: string },
+function welcomeJobId(
+  applicationId: string,
+  userId: string,
   eventTimestamp: string,
-  deps: DiscordEventWebhookDependencies,
-): Promise<void> {
-  const fetchImpl = deps.fetchImpl ?? fetch;
-  const channel = await discordApi<{ id: string }>(
-    "/users/@me/channels",
-    { recipient_id: user.id },
-    deps.botToken,
-    fetchImpl,
-  );
-  if (!channel.id) throw new Error("Discord did not return a DM channel");
+): string {
+  return createHash("sha256")
+    .update(`${applicationId}:${userId}:${eventTimestamp}`)
+    .digest("hex");
+}
 
-  const displayName = user.global_name?.trim() || user.username?.trim();
-  const greeting = displayName
-    ? `Hey ${displayName} — Eliza here. You're connected. Send me a message here and I'll reply.`
-    : "Hey — Eliza here. You're connected. Send me a message here and I'll reply.";
-  await discordApi(
-    `/channels/${encodeURIComponent(channel.id)}/messages`,
-    {
-      content: greeting,
-      nonce: deliveryNonce(user.id, eventTimestamp),
-      enforce_nonce: true,
-    },
-    deps.botToken,
-    fetchImpl,
-  );
+async function withinWebhookBudget<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  operation: string,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`${operation} timed out`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
 }
 
 export async function handleDiscordEventWebhook(
@@ -127,7 +103,11 @@ export async function handleDiscordEventWebhook(
   const rawBody = await request.text();
   const timestamp = request.headers.get("x-signature-timestamp") ?? "";
   const signature = request.headers.get("x-signature-ed25519") ?? "";
-  const publicKey = await deps.getPublicKey();
+  const publicKey = await withinWebhookBudget(
+    deps.getPublicKey(),
+    PUBLIC_KEY_TIMEOUT_MS,
+    "Discord public-key resolution",
+  );
   if (!verifyDiscordEventSignature(rawBody, timestamp, signature, publicKey)) {
     return new Response(JSON.stringify({ error: "invalid signature" }), {
       status: 401,
@@ -167,14 +147,18 @@ export async function handleDiscordEventWebhook(
     event.timestamp &&
     user?.id
   ) {
-    await sendInstallWelcome(
-      {
-        id: user.id,
-        global_name: user.global_name,
-        username: user.username,
-      },
-      event.timestamp,
-      deps,
+    await withinWebhookBudget(
+      deps.enqueue({
+        id: welcomeJobId(deps.applicationId, user.id, event.timestamp),
+        eventTimestamp: event.timestamp,
+        user: {
+          id: user.id,
+          globalName: user.global_name,
+          username: user.username,
+        },
+      }),
+      ENQUEUE_TIMEOUT_MS,
+      "Discord install welcome enqueue",
     );
   }
 
@@ -182,6 +166,28 @@ export async function handleDiscordEventWebhook(
     status: 204,
     headers: { "Content-Type": "application/json" },
   });
+}
+
+export function createDiscordEventWebhookApp(
+  config: DiscordEventWebhookRouteConfig,
+): Hono {
+  const app = new Hono();
+  app.post("/discord/event-webhook", async (c) => {
+    if (!config.enabled) {
+      return c.json({ error: "Discord app bot is disabled" }, 503);
+    }
+    try {
+      return await handleDiscordEventWebhook(c.req.raw, config);
+    } catch (error) {
+      // error-policy:J1 Bound all pre-ACK work and translate transient
+      // verification/queue failures so Discord retries without a dropped job.
+      config.logError?.("Discord application event webhook failed", {
+        error: sanitizeDiscordInstallWelcomeError(error),
+      });
+      return c.json({ error: "Discord webhook processing failed" }, 503);
+    }
+  });
+  return app;
 }
 
 export function createDiscordPublicKeyResolver(options: {

--- a/packages/cloud/services/gateway-discord/src/discord-event-webhook.ts
+++ b/packages/cloud/services/gateway-discord/src/discord-event-webhook.ts
@@ -1,0 +1,213 @@
+/**
+ * Verifies Discord application event webhooks and starts a DM after a user
+ * installs Eliza to their account.
+ */
+import { createHash, createPublicKey, verify } from "node:crypto";
+
+const DISCORD_API_BASE = "https://discord.com/api/v10";
+const APPLICATION_AUTHORIZED = "APPLICATION_AUTHORIZED";
+const USER_INSTALL = 1;
+
+interface DiscordWebhookPayload {
+  application_id?: string;
+  type?: number;
+  event?: {
+    type?: string;
+    timestamp?: string;
+    data?: {
+      integration_type?: number;
+      user?: { id?: string; global_name?: string | null; username?: string };
+    };
+  };
+}
+
+interface DiscordApiError {
+  message?: string;
+  code?: number;
+}
+
+export interface DiscordEventWebhookDependencies {
+  applicationId: string;
+  botToken: string;
+  getPublicKey: () => Promise<string>;
+  fetchImpl?: typeof fetch;
+}
+
+function discordPublicKey(rawPublicKey: string) {
+  if (!/^[0-9a-f]{64}$/i.test(rawPublicKey)) {
+    throw new Error("Discord application public key is invalid");
+  }
+  const spkiPrefix = Buffer.from("302a300506032b6570032100", "hex");
+  return createPublicKey({
+    key: Buffer.concat([spkiPrefix, Buffer.from(rawPublicKey, "hex")]),
+    format: "der",
+    type: "spki",
+  });
+}
+
+export function verifyDiscordEventSignature(
+  rawBody: string,
+  timestamp: string,
+  signature: string,
+  publicKey: string,
+): boolean {
+  if (!/^[0-9a-f]{128}$/i.test(signature) || !timestamp) return false;
+  return verify(
+    null,
+    Buffer.from(`${timestamp}${rawBody}`),
+    discordPublicKey(publicKey),
+    Buffer.from(signature, "hex"),
+  );
+}
+
+function deliveryNonce(userId: string, eventTimestamp: string): string {
+  const digest = createHash("sha256")
+    .update(`${userId}:${eventTimestamp}`)
+    .digest();
+  return digest.readBigUInt64BE().toString();
+}
+
+async function discordApi<T>(
+  path: string,
+  body: Record<string, unknown>,
+  botToken: string,
+  fetchImpl: typeof fetch,
+): Promise<T> {
+  const response = await fetchImpl(`${DISCORD_API_BASE}${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bot ${botToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  const result = (await response.json()) as T & DiscordApiError;
+  if (!response.ok) {
+    throw new Error(
+      `Discord API request failed (${response.status}): ${result.message ?? result.code ?? "unknown error"}`,
+    );
+  }
+  return result;
+}
+
+async function sendInstallWelcome(
+  user: { id: string; global_name?: string | null; username?: string },
+  eventTimestamp: string,
+  deps: DiscordEventWebhookDependencies,
+): Promise<void> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const channel = await discordApi<{ id: string }>(
+    "/users/@me/channels",
+    { recipient_id: user.id },
+    deps.botToken,
+    fetchImpl,
+  );
+  if (!channel.id) throw new Error("Discord did not return a DM channel");
+
+  const displayName = user.global_name?.trim() || user.username?.trim();
+  const greeting = displayName
+    ? `Hey ${displayName} — Eliza here. You're connected. Send me a message here and I'll reply.`
+    : "Hey — Eliza here. You're connected. Send me a message here and I'll reply.";
+  await discordApi(
+    `/channels/${encodeURIComponent(channel.id)}/messages`,
+    {
+      content: greeting,
+      nonce: deliveryNonce(user.id, eventTimestamp),
+      enforce_nonce: true,
+    },
+    deps.botToken,
+    fetchImpl,
+  );
+}
+
+export async function handleDiscordEventWebhook(
+  request: Request,
+  deps: DiscordEventWebhookDependencies,
+): Promise<Response> {
+  const rawBody = await request.text();
+  const timestamp = request.headers.get("x-signature-timestamp") ?? "";
+  const signature = request.headers.get("x-signature-ed25519") ?? "";
+  const publicKey = await deps.getPublicKey();
+  if (!verifyDiscordEventSignature(rawBody, timestamp, signature, publicKey)) {
+    return new Response(JSON.stringify({ error: "invalid signature" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  let payload: DiscordWebhookPayload;
+  try {
+    payload = JSON.parse(rawBody) as DiscordWebhookPayload;
+  } catch {
+    return new Response(JSON.stringify({ error: "invalid payload" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (payload.application_id && payload.application_id !== deps.applicationId) {
+    return new Response(JSON.stringify({ error: "wrong application" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  if (payload.type === 0) {
+    return new Response(null, {
+      status: 204,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const event = payload.event;
+  const user = event?.data?.user;
+  if (
+    payload.type === 1 &&
+    event?.type === APPLICATION_AUTHORIZED &&
+    event.data?.integration_type === USER_INSTALL &&
+    event.timestamp &&
+    user?.id
+  ) {
+    await sendInstallWelcome(
+      {
+        id: user.id,
+        global_name: user.global_name,
+        username: user.username,
+      },
+      event.timestamp,
+      deps,
+    );
+  }
+
+  return new Response(null, {
+    status: 204,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export function createDiscordPublicKeyResolver(options: {
+  botToken: string;
+  configuredPublicKey?: string;
+  fetchImpl?: typeof fetch;
+}): () => Promise<string> {
+  let cached = options.configuredPublicKey?.trim();
+  return async () => {
+    if (cached) return cached;
+    const fetchImpl = options.fetchImpl ?? fetch;
+    const response = await fetchImpl(`${DISCORD_API_BASE}/applications/@me`, {
+      headers: { Authorization: `Bot ${options.botToken}` },
+    });
+    const application = (await response.json()) as {
+      public_key?: string;
+      verify_key?: string;
+      message?: string;
+    };
+    const publicKey = application.public_key ?? application.verify_key;
+    if (!response.ok || !publicKey) {
+      throw new Error(
+        `Unable to resolve Discord application public key (${response.status}): ${application.message ?? "missing public key"}`,
+      );
+    }
+    cached = publicKey;
+    return cached;
+  };
+}

--- a/packages/cloud/services/gateway-discord/src/discord-install-welcome-queue.ts
+++ b/packages/cloud/services/gateway-discord/src/discord-install-welcome-queue.ts
@@ -1,0 +1,225 @@
+/**
+ * Persists Discord user-install welcome jobs in Redis and delivers them with
+ * crash recovery and deterministic Discord nonces.
+ */
+import { createHash } from "node:crypto";
+import { logger } from "./logger";
+
+const DISCORD_API_BASE = "https://discord.com/api/v10";
+const QUEUE_KEY = "discord:eliza-app:install-welcome:pending";
+const PROCESSING_KEY = "discord:eliza-app:install-welcome:processing";
+const DELIVERED_PREFIX = "discord:eliza-app:install-welcome:delivered:";
+const DELIVERED_TTL_SECONDS = 7 * 24 * 60 * 60;
+const POLL_INTERVAL_MS = 1_000;
+const DISCORD_TOKEN_PATTERN =
+  /[A-Za-z0-9_-]{15,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{20,}/g;
+
+export interface DiscordInstallWelcomeJob {
+  id: string;
+  eventTimestamp: string;
+  user: {
+    id: string;
+    globalName?: string | null;
+    username?: string;
+  };
+}
+
+export interface DiscordInstallWelcomeRedis {
+  get<T = string>(key: string): Promise<T | null>;
+  set(
+    key: string,
+    value: unknown,
+    options?: { ex?: number; px?: number; nx?: boolean },
+  ): Promise<unknown>;
+  lpush(key: string, ...values: string[]): Promise<number>;
+  lmove(
+    source: string,
+    destination: string,
+    whereFrom: "left" | "right",
+    whereTo: "left" | "right",
+  ): Promise<string | null>;
+  lrem(key: string, count: number, value: string): Promise<number>;
+}
+
+interface DiscordApiError {
+  message?: string;
+  code?: number;
+}
+
+export function sanitizeDiscordInstallWelcomeError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.replace(DISCORD_TOKEN_PATTERN, "[REDACTED_TOKEN]");
+}
+
+function deliveryNonce(job: DiscordInstallWelcomeJob): string {
+  const digest = createHash("sha256")
+    .update(`${job.user.id}:${job.eventTimestamp}`)
+    .digest();
+  return digest.readBigUInt64BE().toString();
+}
+
+async function discordApi<T>(
+  path: string,
+  body: Record<string, unknown>,
+  botToken: string,
+  fetchImpl: typeof fetch,
+): Promise<T> {
+  const response = await fetchImpl(`${DISCORD_API_BASE}${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bot ${botToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  const result = (await response.json()) as T & DiscordApiError;
+  if (!response.ok) {
+    throw new Error(
+      `Discord API request failed (${response.status}): ${result.message ?? result.code ?? "unknown error"}`,
+    );
+  }
+  return result;
+}
+
+export async function sendDiscordInstallWelcome(
+  job: DiscordInstallWelcomeJob,
+  options: { botToken: string; fetchImpl?: typeof fetch },
+): Promise<void> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const channel = await discordApi<{ id: string }>(
+    "/users/@me/channels",
+    { recipient_id: job.user.id },
+    options.botToken,
+    fetchImpl,
+  );
+  if (!channel.id) throw new Error("Discord did not return a DM channel");
+
+  const displayName = job.user.globalName?.trim() || job.user.username?.trim();
+  const greeting = displayName
+    ? `Hey ${displayName} — Eliza here. You're connected. Send me a message here and I'll reply.`
+    : "Hey — Eliza here. You're connected. Send me a message here and I'll reply.";
+  await discordApi(
+    `/channels/${encodeURIComponent(channel.id)}/messages`,
+    {
+      content: greeting,
+      nonce: deliveryNonce(job),
+      enforce_nonce: true,
+      allowed_mentions: { parse: [] },
+    },
+    options.botToken,
+    fetchImpl,
+  );
+}
+
+export class DiscordInstallWelcomeQueue {
+  private interval: ReturnType<typeof setInterval> | null = null;
+  private drainInFlight: Promise<void> | null = null;
+
+  constructor(
+    private readonly redis: DiscordInstallWelcomeRedis,
+    private readonly botToken: string,
+    private readonly fetchImpl: typeof fetch = fetch,
+  ) {}
+
+  async enqueue(job: DiscordInstallWelcomeJob): Promise<void> {
+    await this.redis.lpush(QUEUE_KEY, JSON.stringify(job));
+  }
+
+  async start(): Promise<void> {
+    if (this.interval) return;
+    await this.recoverProcessingJobs();
+    this.interval = setInterval(() => this.scheduleDrain(), POLL_INTERVAL_MS);
+    this.scheduleDrain();
+  }
+
+  async stop(): Promise<void> {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+    await this.drainInFlight;
+  }
+
+  async drainOnce(): Promise<boolean> {
+    let raw = await this.redis.lmove(
+      QUEUE_KEY,
+      PROCESSING_KEY,
+      "right",
+      "left",
+    );
+    if (!raw) {
+      const recovered = await this.redis.lmove(
+        PROCESSING_KEY,
+        QUEUE_KEY,
+        "right",
+        "left",
+      );
+      if (!recovered) return false;
+      raw = await this.redis.lmove(QUEUE_KEY, PROCESSING_KEY, "right", "left");
+      if (!raw) return false;
+    }
+
+    let job: DiscordInstallWelcomeJob;
+    try {
+      job = JSON.parse(raw) as DiscordInstallWelcomeJob;
+      if (!job.id || !job.user?.id || !job.eventTimestamp) {
+        throw new Error("Discord install welcome job is invalid");
+      }
+    } catch (error) {
+      await this.redis.lrem(PROCESSING_KEY, 1, raw);
+      logger.error("Discarded invalid Discord install welcome job", {
+        error: sanitizeDiscordInstallWelcomeError(error),
+      });
+      return true;
+    }
+
+    const deliveredKey = `${DELIVERED_PREFIX}${job.id}`;
+    if (await this.redis.get(deliveredKey)) {
+      await this.redis.lrem(PROCESSING_KEY, 1, raw);
+      return true;
+    }
+
+    try {
+      await sendDiscordInstallWelcome(job, {
+        botToken: this.botToken,
+        fetchImpl: this.fetchImpl,
+      });
+      // Discord's enforce_nonce makes a replay safe if the process dies after
+      // the REST response but before this durable delivered marker is written.
+      await this.redis.set(deliveredKey, "1", {
+        ex: DELIVERED_TTL_SECONDS,
+      });
+      await this.redis.lrem(PROCESSING_KEY, 1, raw);
+    } catch (error) {
+      // Requeue before removing the processing claim. A crash between these
+      // operations creates a harmless duplicate rather than losing the job.
+      await this.redis.lpush(QUEUE_KEY, raw);
+      await this.redis.lrem(PROCESSING_KEY, 1, raw);
+      logger.warn("Discord install welcome delivery will retry", {
+        jobId: job.id,
+        error: sanitizeDiscordInstallWelcomeError(error),
+      });
+    }
+    return true;
+  }
+
+  private scheduleDrain(): void {
+    if (this.drainInFlight) return;
+    this.drainInFlight = this.drainOnce()
+      .then(() => undefined)
+      .catch((error) => {
+        logger.error("Discord install welcome queue drain failed", {
+          error: sanitizeDiscordInstallWelcomeError(error),
+        });
+      })
+      .finally(() => {
+        this.drainInFlight = null;
+      });
+  }
+
+  private async recoverProcessingJobs(): Promise<void> {
+    while (await this.redis.lmove(PROCESSING_KEY, QUEUE_KEY, "right", "left")) {
+      // Move every abandoned in-flight job back to the durable pending list.
+    }
+  }
+}

--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -20,6 +20,10 @@ import {
   type User,
 } from "discord.js";
 import { reconcileDiscordConnectionReady } from "./connection-lifecycle";
+import {
+  type DiscordInstallWelcomeJob,
+  DiscordInstallWelcomeQueue,
+} from "./discord-install-welcome-queue";
 import { pollTrackedDiscordDms, type TrackedDiscordDm } from "./dm-polling";
 import { logger } from "./logger";
 import {
@@ -60,6 +64,13 @@ interface GatewayRedis {
   srem(key: string, ...members: string[]): Promise<number>;
   smembers(key: string): Promise<string[]>;
   lpush(key: string, ...values: string[]): Promise<number>;
+  lmove(
+    source: string,
+    destination: string,
+    whereFrom: "left" | "right",
+    whereTo: "left" | "right",
+  ): Promise<string | null>;
+  lrem(key: string, count: number, value: string): Promise<number>;
   ltrim(key: string, start: number, stop: number): Promise<string>;
 }
 
@@ -371,6 +382,8 @@ export class GatewayManager {
   /** Poll fallback for user-installed bot DMs that omit Gateway message events. */
   private dmPollInterval: NodeJS.Timeout | null = null;
   private dmPollInFlight: Promise<void> | null = null;
+  /** Durable user-install welcome delivery, active on the system-bot leader. */
+  private installWelcomeQueue: DiscordInstallWelcomeQueue | null = null;
   /** Interval for leader election checks */
   private elizaAppLeaderInterval: NodeJS.Timeout | null = null;
 
@@ -406,6 +419,25 @@ export class GatewayManager {
         "Redis URL provided without token - failover disabled. Set REDIS_URL (TCP) or KV_REST_API_TOKEN/redisToken (Upstash).",
       );
     }
+
+    const elizaAppEnabled =
+      process.env.ELIZA_APP_DISCORD_BOT_ENABLED === "true";
+    const elizaAppBotToken = process.env.ELIZA_APP_DISCORD_BOT_TOKEN?.trim();
+    if (elizaAppEnabled && elizaAppBotToken && this.redis) {
+      this.installWelcomeQueue = new DiscordInstallWelcomeQueue(
+        this.redis,
+        elizaAppBotToken,
+      );
+    }
+  }
+
+  async enqueueDiscordInstallWelcome(
+    job: DiscordInstallWelcomeJob,
+  ): Promise<void> {
+    if (!this.installWelcomeQueue) {
+      throw new Error("Discord install welcome queue is unavailable");
+    }
+    await this.installWelcomeQueue.enqueue(job);
   }
 
   /**
@@ -1925,6 +1957,11 @@ export class GatewayManager {
       });
       this.startGreetingPolling();
       this.startDmPolling();
+      void this.installWelcomeQueue?.start().catch((error) => {
+        logger.error("Failed to start Discord install welcome queue", {
+          error: sanitizeError(error),
+        });
+      });
     });
 
     this.elizaAppClient.on(Events.MessageCreate, async (message: Message) => {
@@ -1992,6 +2029,7 @@ export class GatewayManager {
       await this.dmPollInFlight;
       this.dmPollInFlight = null;
     }
+    await this.installWelcomeQueue?.stop();
     if (this.elizaAppClient) {
       logger.info("Disconnecting Eliza App bot", {
         podName: this.config.podName,

--- a/packages/cloud/services/gateway-discord/src/index.ts
+++ b/packages/cloud/services/gateway-discord/src/index.ts
@@ -9,8 +9,8 @@ import { hostname } from "node:os";
 import { serve } from "@hono/node-server";
 import { Hono } from "hono";
 import {
+  createDiscordEventWebhookApp,
   createDiscordPublicKeyResolver,
-  handleDiscordEventWebhook,
 } from "./discord-event-webhook";
 import { GatewayManager } from "./gateway-manager";
 import { logger } from "./logger";
@@ -63,6 +63,7 @@ const gatewayManager = new GatewayManager({
 });
 
 const elizaAppBotToken = process.env.ELIZA_APP_DISCORD_BOT_TOKEN?.trim();
+const elizaAppBotEnabled = process.env.ELIZA_APP_DISCORD_BOT_ENABLED === "true";
 const elizaAppApplicationId =
   process.env.ELIZA_APP_DISCORD_APPLICATION_ID?.trim() ?? "1474591626759376967";
 const resolveDiscordPublicKey = elizaAppBotToken
@@ -72,25 +73,20 @@ const resolveDiscordPublicKey = elizaAppBotToken
     })
   : null;
 
-app.post("/discord/event-webhook", async (c) => {
-  if (!elizaAppBotToken || !resolveDiscordPublicKey) {
-    return c.json({ error: "Discord app bot is not configured" }, 503);
-  }
-  try {
-    return await handleDiscordEventWebhook(c.req.raw, {
-      applicationId: elizaAppApplicationId,
-      botToken: elizaAppBotToken,
-      getPublicKey: resolveDiscordPublicKey,
-    });
-  } catch (error) {
-    // error-policy:J1 The HTTP webhook boundary acknowledges only completed
-    // delivery so Discord retries transient API failures.
-    logger.error("Discord application event webhook failed", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return c.json({ error: "Discord webhook processing failed" }, 502);
-  }
-});
+app.route(
+  "/",
+  createDiscordEventWebhookApp({
+    enabled: elizaAppBotEnabled && Boolean(resolveDiscordPublicKey),
+    applicationId: elizaAppApplicationId,
+    getPublicKey:
+      resolveDiscordPublicKey ??
+      (async () => {
+        throw new Error("Discord application public key is unavailable");
+      }),
+    enqueue: (job) => gatewayManager.enqueueDiscordInstallWelcome(job),
+    logError: (message, context) => logger.error(message, context),
+  }),
+);
 
 // Liveness check - is the pod alive and should NOT be restarted?
 // Returns 200 for healthy/degraded (don't restart), 503 for unhealthy (restart)

--- a/packages/cloud/services/gateway-discord/src/index.ts
+++ b/packages/cloud/services/gateway-discord/src/index.ts
@@ -8,6 +8,10 @@
 import { hostname } from "node:os";
 import { serve } from "@hono/node-server";
 import { Hono } from "hono";
+import {
+  createDiscordPublicKeyResolver,
+  handleDiscordEventWebhook,
+} from "./discord-event-webhook";
 import { GatewayManager } from "./gateway-manager";
 import { logger } from "./logger";
 
@@ -56,6 +60,36 @@ const gatewayManager = new GatewayManager({
   redisUrl: process.env.REDIS_URL ?? process.env.KV_REST_API_URL,
   redisToken: process.env.KV_REST_API_TOKEN,
   project,
+});
+
+const elizaAppBotToken = process.env.ELIZA_APP_DISCORD_BOT_TOKEN?.trim();
+const elizaAppApplicationId =
+  process.env.ELIZA_APP_DISCORD_APPLICATION_ID?.trim() ?? "1474591626759376967";
+const resolveDiscordPublicKey = elizaAppBotToken
+  ? createDiscordPublicKeyResolver({
+      botToken: elizaAppBotToken,
+      configuredPublicKey: process.env.ELIZA_APP_DISCORD_PUBLIC_KEY,
+    })
+  : null;
+
+app.post("/discord/event-webhook", async (c) => {
+  if (!elizaAppBotToken || !resolveDiscordPublicKey) {
+    return c.json({ error: "Discord app bot is not configured" }, 503);
+  }
+  try {
+    return await handleDiscordEventWebhook(c.req.raw, {
+      applicationId: elizaAppApplicationId,
+      botToken: elizaAppBotToken,
+      getPublicKey: resolveDiscordPublicKey,
+    });
+  } catch (error) {
+    // error-policy:J1 The HTTP webhook boundary acknowledges only completed
+    // delivery so Discord retries transient API failures.
+    logger.error("Discord application event webhook failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return c.json({ error: "Discord webhook processing failed" }, 502);
+  }
 });
 
 // Liveness check - is the pod alive and should NOT be restarted?

--- a/packages/cloud/services/gateway-discord/src/redis-adapter.ts
+++ b/packages/cloud/services/gateway-discord/src/redis-adapter.ts
@@ -37,6 +37,13 @@ interface IoRedisLike {
   srem(key: string, ...members: string[]): Promise<number>;
   smembers(key: string): Promise<string[]>;
   lpush(key: string, ...values: string[]): Promise<number>;
+  lmove(
+    source: string,
+    destination: string,
+    whereFrom: "LEFT" | "RIGHT",
+    whereTo: "LEFT" | "RIGHT",
+  ): Promise<string | null>;
+  lrem(key: string, count: number, value: string): Promise<number>;
   ltrim(key: string, start: number, stop: number): Promise<string>;
   quit(): Promise<string>;
 }
@@ -131,6 +138,24 @@ export class UpstashCompatRedis {
   async lpush(key: string, ...values: string[]): Promise<number> {
     if (values.length === 0) return 0;
     return this.client.lpush(key, ...values);
+  }
+
+  async lmove(
+    source: string,
+    destination: string,
+    whereFrom: "left" | "right",
+    whereTo: "left" | "right",
+  ): Promise<string | null> {
+    return this.client.lmove(
+      source,
+      destination,
+      whereFrom.toUpperCase() as "LEFT" | "RIGHT",
+      whereTo.toUpperCase() as "LEFT" | "RIGHT",
+    );
+  }
+
+  async lrem(key: string, count: number, value: string): Promise<number> {
+    return this.client.lrem(key, count, value);
   }
 
   async ltrim(key: string, start: number, stop: number): Promise<string> {

--- a/packages/cloud/services/gateway-discord/tests/discord-event-webhook.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/discord-event-webhook.test.ts
@@ -1,14 +1,16 @@
 /**
- * Exercises signed Discord application event webhooks and real REST request
- * shapes with deterministic cryptographic and network fixtures.
+ * Exercises signed Discord application-event parsing and the Hono route's
+ * bounded durable-enqueue boundary with deterministic crypto fixtures.
  */
 import { describe, expect, test } from "bun:test";
 import { generateKeyPairSync, sign } from "node:crypto";
 import {
+  createDiscordEventWebhookApp,
   createDiscordPublicKeyResolver,
   handleDiscordEventWebhook,
   verifyDiscordEventSignature,
 } from "../src/discord-event-webhook";
+import type { DiscordInstallWelcomeJob } from "../src/discord-install-welcome-queue";
 
 const APPLICATION_ID = "1474591626759376967";
 const { privateKey, publicKey } = generateKeyPairSync("ed25519");
@@ -36,6 +38,21 @@ function signedRequest(payload: unknown, valid = true): Request {
   });
 }
 
+function userInstallPayload(integrationType = 1) {
+  return {
+    application_id: APPLICATION_ID,
+    type: 1,
+    event: {
+      type: "APPLICATION_AUTHORIZED",
+      timestamp: "2026-08-14T09:00:00.000000",
+      data: {
+        integration_type: integrationType,
+        user: { id: "498273781589213185", global_name: "shaw" },
+      },
+    },
+  };
+}
+
 describe("Discord application event webhook", () => {
   test("verifies Ed25519 signatures and rejects invalid requests", async () => {
     const body = JSON.stringify({ type: 0 });
@@ -61,8 +78,8 @@ describe("Discord application event webhook", () => {
       signedRequest({ type: 0 }, false),
       {
         applicationId: APPLICATION_ID,
-        botToken: "token",
         getPublicKey: async () => rawPublicKey,
+        enqueue: async () => undefined,
       },
     );
     expect(response.status).toBe(401);
@@ -73,82 +90,97 @@ describe("Discord application event webhook", () => {
       signedRequest({ application_id: APPLICATION_ID, type: 0 }),
       {
         applicationId: APPLICATION_ID,
-        botToken: "token",
         getPublicKey: async () => rawPublicKey,
+        enqueue: async () => undefined,
       },
     );
     expect(response.status).toBe(204);
   });
 
-  test("opens a DM and sends one welcome for user installs", async () => {
-    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
-    const fetchImpl: typeof fetch = async (input, init) => {
-      const url = String(input);
-      calls.push({
-        url,
-        body: JSON.parse(String(init?.body)) as Record<string, unknown>,
-      });
-      return Response.json(
-        url.endsWith("/users/@me/channels")
-          ? { id: "dm-channel" }
-          : { id: "message" },
-      );
-    };
+  test("durably enqueues a stable welcome job without calling Discord REST", async () => {
+    const jobs: DiscordInstallWelcomeJob[] = [];
     const response = await handleDiscordEventWebhook(
-      signedRequest({
-        version: 1,
-        application_id: APPLICATION_ID,
-        type: 1,
-        event: {
-          type: "APPLICATION_AUTHORIZED",
-          timestamp: "2026-08-14T09:00:00.000000",
-          data: {
-            integration_type: 1,
-            scopes: ["applications.commands"],
-            user: { id: "498273781589213185", global_name: "shaw" },
-          },
-        },
-      }),
+      signedRequest(userInstallPayload()),
       {
         applicationId: APPLICATION_ID,
-        botToken: "token",
         getPublicKey: async () => rawPublicKey,
-        fetchImpl,
+        enqueue: async (job) => {
+          jobs.push(job);
+        },
       },
     );
+
     expect(response.status).toBe(204);
-    expect(calls).toHaveLength(2);
-    expect(calls[0]?.body).toEqual({ recipient_id: "498273781589213185" });
-    expect(calls[1]?.url).toEndWith("/channels/dm-channel/messages");
-    expect(calls[1]?.body.content).toContain("Hey shaw");
-    expect(calls[1]?.body.enforce_nonce).toBe(true);
-    expect(String(calls[1]?.body.nonce)).toMatch(/^\d+$/);
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]).toMatchObject({
+      eventTimestamp: "2026-08-14T09:00:00.000000",
+      user: { id: "498273781589213185", globalName: "shaw" },
+    });
+    expect(jobs[0]?.id).toMatch(/^[0-9a-f]{64}$/);
   });
 
   test("ignores guild installs", async () => {
     let called = false;
     const response = await handleDiscordEventWebhook(
-      signedRequest({
-        application_id: APPLICATION_ID,
-        type: 1,
-        event: {
-          type: "APPLICATION_AUTHORIZED",
-          timestamp: "2026-08-14T09:00:00.000000",
-          data: { integration_type: 0, user: { id: "user" } },
-        },
-      }),
+      signedRequest(userInstallPayload(0)),
       {
         applicationId: APPLICATION_ID,
-        botToken: "token",
         getPublicKey: async () => rawPublicKey,
-        fetchImpl: async () => {
+        enqueue: async () => {
           called = true;
-          return Response.json({});
         },
       },
     );
     expect(response.status).toBe(204);
     expect(called).toBe(false);
+  });
+
+  test("Hono boundary honors the bot-enabled flag", async () => {
+    let keyResolved = false;
+    const app = createDiscordEventWebhookApp({
+      enabled: false,
+      applicationId: APPLICATION_ID,
+      getPublicKey: async () => {
+        keyResolved = true;
+        return rawPublicKey;
+      },
+      enqueue: async () => undefined,
+    });
+
+    const response = await app.request(signedRequest(userInstallPayload()));
+    expect(response.status).toBe(503);
+    expect(keyResolved).toBe(false);
+  });
+
+  test("Hono boundary ACKs well under three seconds after Redis enqueue", async () => {
+    const app = createDiscordEventWebhookApp({
+      enabled: true,
+      applicationId: APPLICATION_ID,
+      getPublicKey: async () => rawPublicKey,
+      enqueue: async () => undefined,
+    });
+    const startedAt = performance.now();
+    const response = await app.request(signedRequest(userInstallPayload()));
+    expect(response.status).toBe(204);
+    expect(performance.now() - startedAt).toBeLessThan(500);
+  });
+
+  test("Hono boundary fails within the ACK budget when Redis stalls", async () => {
+    const errors: string[] = [];
+    const app = createDiscordEventWebhookApp({
+      enabled: true,
+      applicationId: APPLICATION_ID,
+      getPublicKey: async () => rawPublicKey,
+      enqueue: () => new Promise(() => undefined),
+      logError: (_message, context) => errors.push(context.error),
+    });
+    const startedAt = performance.now();
+    const response = await app.request(signedRequest(userInstallPayload()));
+    const elapsed = performance.now() - startedAt;
+    expect(response.status).toBe(503);
+    expect(elapsed).toBeGreaterThanOrEqual(1_000);
+    expect(elapsed).toBeLessThan(2_500);
+    expect(errors).toEqual(["Discord install welcome enqueue timed out"]);
   });
 
   test("resolves and caches the application public key", async () => {

--- a/packages/cloud/services/gateway-discord/tests/discord-event-webhook.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/discord-event-webhook.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Exercises signed Discord application event webhooks and real REST request
+ * shapes with deterministic cryptographic and network fixtures.
+ */
+import { describe, expect, test } from "bun:test";
+import { generateKeyPairSync, sign } from "node:crypto";
+import {
+  createDiscordPublicKeyResolver,
+  handleDiscordEventWebhook,
+  verifyDiscordEventSignature,
+} from "../src/discord-event-webhook";
+
+const APPLICATION_ID = "1474591626759376967";
+const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+const rawPublicKey = publicKey
+  .export({ format: "der", type: "spki" })
+  .subarray(-32)
+  .toString("hex");
+
+function signedRequest(payload: unknown, valid = true): Request {
+  const body = JSON.stringify(payload);
+  const timestamp = "2026-08-14T09:00:00.000000";
+  const signature = sign(
+    null,
+    Buffer.from(`${timestamp}${body}`),
+    privateKey,
+  ).toString("hex");
+  return new Request("https://gateway.example/discord/event-webhook", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-signature-ed25519": valid ? signature : "00".repeat(64),
+      "x-signature-timestamp": timestamp,
+    },
+    body,
+  });
+}
+
+describe("Discord application event webhook", () => {
+  test("verifies Ed25519 signatures and rejects invalid requests", async () => {
+    const body = JSON.stringify({ type: 0 });
+    const timestamp = "123";
+    const signature = sign(
+      null,
+      Buffer.from(`${timestamp}${body}`),
+      privateKey,
+    ).toString("hex");
+    expect(
+      verifyDiscordEventSignature(body, timestamp, signature, rawPublicKey),
+    ).toBe(true);
+    expect(
+      verifyDiscordEventSignature(
+        body,
+        timestamp,
+        "00".repeat(64),
+        rawPublicKey,
+      ),
+    ).toBe(false);
+
+    const response = await handleDiscordEventWebhook(
+      signedRequest({ type: 0 }, false),
+      {
+        applicationId: APPLICATION_ID,
+        botToken: "token",
+        getPublicKey: async () => rawPublicKey,
+      },
+    );
+    expect(response.status).toBe(401);
+  });
+
+  test("acknowledges Discord endpoint validation pings", async () => {
+    const response = await handleDiscordEventWebhook(
+      signedRequest({ application_id: APPLICATION_ID, type: 0 }),
+      {
+        applicationId: APPLICATION_ID,
+        botToken: "token",
+        getPublicKey: async () => rawPublicKey,
+      },
+    );
+    expect(response.status).toBe(204);
+  });
+
+  test("opens a DM and sends one welcome for user installs", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const fetchImpl: typeof fetch = async (input, init) => {
+      const url = String(input);
+      calls.push({
+        url,
+        body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+      });
+      return Response.json(
+        url.endsWith("/users/@me/channels")
+          ? { id: "dm-channel" }
+          : { id: "message" },
+      );
+    };
+    const response = await handleDiscordEventWebhook(
+      signedRequest({
+        version: 1,
+        application_id: APPLICATION_ID,
+        type: 1,
+        event: {
+          type: "APPLICATION_AUTHORIZED",
+          timestamp: "2026-08-14T09:00:00.000000",
+          data: {
+            integration_type: 1,
+            scopes: ["applications.commands"],
+            user: { id: "498273781589213185", global_name: "shaw" },
+          },
+        },
+      }),
+      {
+        applicationId: APPLICATION_ID,
+        botToken: "token",
+        getPublicKey: async () => rawPublicKey,
+        fetchImpl,
+      },
+    );
+    expect(response.status).toBe(204);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.body).toEqual({ recipient_id: "498273781589213185" });
+    expect(calls[1]?.url).toEndWith("/channels/dm-channel/messages");
+    expect(calls[1]?.body.content).toContain("Hey shaw");
+    expect(calls[1]?.body.enforce_nonce).toBe(true);
+    expect(String(calls[1]?.body.nonce)).toMatch(/^\d+$/);
+  });
+
+  test("ignores guild installs", async () => {
+    let called = false;
+    const response = await handleDiscordEventWebhook(
+      signedRequest({
+        application_id: APPLICATION_ID,
+        type: 1,
+        event: {
+          type: "APPLICATION_AUTHORIZED",
+          timestamp: "2026-08-14T09:00:00.000000",
+          data: { integration_type: 0, user: { id: "user" } },
+        },
+      }),
+      {
+        applicationId: APPLICATION_ID,
+        botToken: "token",
+        getPublicKey: async () => rawPublicKey,
+        fetchImpl: async () => {
+          called = true;
+          return Response.json({});
+        },
+      },
+    );
+    expect(response.status).toBe(204);
+    expect(called).toBe(false);
+  });
+
+  test("resolves and caches the application public key", async () => {
+    let calls = 0;
+    const resolve = createDiscordPublicKeyResolver({
+      botToken: "token",
+      fetchImpl: async () => {
+        calls += 1;
+        return Response.json({ public_key: rawPublicKey });
+      },
+    });
+    expect(await resolve()).toBe(rawPublicKey);
+    expect(await resolve()).toBe(rawPublicKey);
+    expect(calls).toBe(1);
+  });
+
+  test("accepts Discord's live verify_key application field", async () => {
+    const resolve = createDiscordPublicKeyResolver({
+      botToken: "token",
+      fetchImpl: async () => Response.json({ verify_key: rawPublicKey }),
+    });
+    expect(await resolve()).toBe(rawPublicKey);
+  });
+});

--- a/packages/cloud/services/gateway-discord/tests/discord-install-welcome-queue.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/discord-install-welcome-queue.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Exercises durable Discord install-welcome delivery, retry recovery, and
+ * week-long idempotency without a live Redis or Discord account.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  type DiscordInstallWelcomeJob,
+  DiscordInstallWelcomeQueue,
+  type DiscordInstallWelcomeRedis,
+  sendDiscordInstallWelcome,
+} from "../src/discord-install-welcome-queue";
+
+class TestRedis implements DiscordInstallWelcomeRedis {
+  readonly lists = new Map<string, string[]>();
+  readonly values = new Map<string, string>();
+  readonly setTtls: number[] = [];
+  failNextLpush = false;
+
+  async get<T = string>(key: string): Promise<T | null> {
+    return (this.values.get(key) as T | undefined) ?? null;
+  }
+
+  async set(
+    key: string,
+    value: unknown,
+    options?: { ex?: number },
+  ): Promise<string> {
+    this.values.set(key, String(value));
+    if (options?.ex) this.setTtls.push(options.ex);
+    return "OK";
+  }
+
+  async lpush(key: string, ...values: string[]): Promise<number> {
+    if (this.failNextLpush) {
+      this.failNextLpush = false;
+      throw new Error("Redis lpush unavailable");
+    }
+    const list = this.lists.get(key) ?? [];
+    list.unshift(...values);
+    this.lists.set(key, list);
+    return list.length;
+  }
+
+  async lmove(
+    source: string,
+    destination: string,
+    _whereFrom: "left" | "right",
+    _whereTo: "left" | "right",
+  ): Promise<string | null> {
+    const sourceList = this.lists.get(source) ?? [];
+    const value = sourceList.pop() ?? null;
+    if (!value) return null;
+    const destinationList = this.lists.get(destination) ?? [];
+    destinationList.unshift(value);
+    this.lists.set(source, sourceList);
+    this.lists.set(destination, destinationList);
+    return value;
+  }
+
+  async lrem(key: string, count: number, value: string): Promise<number> {
+    const list = this.lists.get(key) ?? [];
+    let remaining = Math.abs(count);
+    let removed = 0;
+    this.lists.set(
+      key,
+      list.filter((entry) => {
+        if (entry !== value || remaining === 0) return true;
+        remaining -= 1;
+        removed += 1;
+        return false;
+      }),
+    );
+    return removed;
+  }
+}
+
+const job: DiscordInstallWelcomeJob = {
+  id: "a".repeat(64),
+  eventTimestamp: "2026-08-14T09:00:00.000000",
+  user: { id: "498273781589213185", globalName: "shaw" },
+};
+
+describe("DiscordInstallWelcomeQueue", () => {
+  test("uses deterministic nonce and disables all allowed mention parsing", async () => {
+    const bodies: Record<string, unknown>[] = [];
+    await sendDiscordInstallWelcome(job, {
+      botToken: "token",
+      fetchImpl: async (input, init) => {
+        bodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        return Response.json(
+          String(input).endsWith("/users/@me/channels")
+            ? { id: "dm-channel" }
+            : { id: "message" },
+        );
+      },
+    });
+
+    expect(bodies[1]).toMatchObject({
+      enforce_nonce: true,
+      allowed_mentions: { parse: [] },
+    });
+    expect(String(bodies[1]?.nonce)).toMatch(/^\d+$/);
+  });
+
+  test("requeues partial REST failure and deduplicates the recovered delivery", async () => {
+    const redis = new TestRedis();
+    let requestCount = 0;
+    let failFirstMessage = true;
+    const queue = new DiscordInstallWelcomeQueue(
+      redis,
+      "token",
+      async (input) => {
+        requestCount += 1;
+        if (String(input).endsWith("/users/@me/channels")) {
+          return Response.json({ id: "dm-channel" });
+        }
+        if (failFirstMessage) {
+          failFirstMessage = false;
+          return Response.json({ message: "temporary" }, { status: 503 });
+        }
+        return Response.json({ id: "message" });
+      },
+    );
+
+    await queue.enqueue(job);
+    expect(await queue.drainOnce()).toBe(true);
+    expect(await queue.drainOnce()).toBe(true);
+    expect(requestCount).toBe(4);
+    expect(redis.setTtls).toEqual([7 * 24 * 60 * 60]);
+
+    await queue.enqueue(job);
+    expect(await queue.drainOnce()).toBe(true);
+    expect(requestCount).toBe(4);
+  });
+
+  test("recovers an abandoned processing claim on startup", async () => {
+    const redis = new TestRedis();
+    redis.lists.set("discord:eliza-app:install-welcome:processing", [
+      JSON.stringify(job),
+    ]);
+    let delivered = false;
+    const queue = new DiscordInstallWelcomeQueue(
+      redis,
+      "token",
+      async (input) => {
+        if (String(input).endsWith("/users/@me/channels")) {
+          return Response.json({ id: "dm-channel" });
+        }
+        delivered = true;
+        return Response.json({ id: "message" });
+      },
+    );
+
+    await queue.start();
+    await queue.stop();
+
+    expect(delivered).toBe(true);
+  });
+
+  test("recovers in-process when requeue itself transiently fails", async () => {
+    const redis = new TestRedis();
+    let failDiscord = true;
+    const queue = new DiscordInstallWelcomeQueue(
+      redis,
+      "token",
+      async (input) => {
+        if (String(input).endsWith("/users/@me/channels")) {
+          return Response.json({ id: "dm-channel" });
+        }
+        if (failDiscord) {
+          failDiscord = false;
+          redis.failNextLpush = true;
+          return Response.json({ message: "temporary" }, { status: 503 });
+        }
+        return Response.json({ id: "message" });
+      },
+    );
+
+    await queue.enqueue(job);
+    await expect(queue.drainOnce()).rejects.toThrow("Redis lpush unavailable");
+    expect(await queue.drainOnce()).toBe(true);
+    expect(redis.setTtls).toEqual([7 * 24 * 60 * 60]);
+  });
+});

--- a/packages/cloud/services/gateway-discord/tests/redis-adapter.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/redis-adapter.test.ts
@@ -48,6 +48,13 @@ describe("UpstashCompatRedis (mock client)", () => {
     await redis.srem("active_pods", "pod-a");
     expect(await redis.smembers("active_pods")).toEqual(["pod-b"]);
 
+    // Atomic list claim + acknowledgement used by install welcome delivery.
+    await redis.lpush("pending", "first", "second");
+    expect(await redis.lmove("pending", "processing", "right", "left")).toBe(
+      "first",
+    );
+    expect(await redis.lrem("processing", 1, "first")).toBe(1);
+
     await redis.quit();
   });
 });


### PR DESCRIPTION
## Relates to

Closes #19504. Relates to #19772. Supersedes #19512.

## What changed

- verifies Discord Ed25519 application-event signatures at a dedicated Hono boundary;
- acknowledges valid user-install events after a durable Redis enqueue, without awaiting Discord REST;
- bounds public-key resolution to 750 ms and Redis enqueue to 1.25 seconds so failures return a retryable 503 inside Discord's three-second acknowledgement budget;
- delivers on the elected Eliza App bot leader with atomic Redis `LMOVE` pending/processing claims, startup and in-process abandoned-claim recovery, and requeue-before-ack failure handling;
- deduplicates for seven days with a Redis delivered marker plus Discord `enforce_nonce`, including the ambiguous case where Discord accepted a message before the worker crashed;
- sends `allowed_mentions: { parse: [] }`, sanitizes errors before logging, and keeps the route/worker disabled unless `ELIZA_APP_DISCORD_BOT_ENABLED=true`;
- documents the optional local `ELIZA_APP_DISCORD_PUBLIC_KEY` configuration.

## Verification

- `bun run --cwd packages/cloud/services/gateway-discord test` — 65 pass, 0 fail.
- `bun run --cwd packages/cloud/services/gateway-discord typecheck` — pass.
- `bun run --cwd packages/cloud/services/gateway-discord lint:check` — pass.
- `bun run --cwd packages/cloud/services/gateway-discord build` — pass.
- `bun run check:agents-claude` — pass, 153 guide pairs identical.
- `git diff --check origin/develop...HEAD` — pass.

The tests cover signature rejection, endpoint-validation PING, guild-install ignore, disabled config, sub-500 ms normal ACK, bounded stalled-Redis failure, stable job identity, exact Discord REST bodies, mention suppression, seven-day deduplication, Discord partial failure, Redis requeue failure, abandoned processing recovery, and the native/mock Redis `LMOVE` contract.

## Risk and limitations

- Delivery requires Redis. If the queue is unavailable, the route returns 503 so Discord retries instead of acknowledging a dropped welcome.
- `ELIZA_APP_DISCORD_PUBLIC_KEY` is recommended. Without it, the first request uses a bounded application lookup; a slow lookup returns 503 and relies on Discord retry.
- The worker starts only on the elected Eliza App bot leader after Discord `ClientReady`; queued jobs remain durable during failover.
- This PR has deterministic boundary/integration tests but has not created a fresh real Discord user install after this repair. The superseded PR records earlier production signature-validation and outbound-DM artifacts; this branch has not been deployed.

## Evidence gate

- UI screenshots/video: N/A — backend-only connector change.
- Frontend logs: N/A — no frontend change.
- LLM trajectory: N/A — deterministic connector delivery; no model call.
- Backend/domain evidence: package gates and exact Redis/Discord protocol tests listed above.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a28e5af88461026f26a1577f0218d24dfea3c1c7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@a28e5af88461026f26a1577f0218d24dfea3c1c7:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex desktop","skill_revision":"elizaOS/eliza@a28e5af88461026f26a1577f0218d24dfea3c1c7:packages/skills/skills/contribute-to-eliza"} -->
