### PR TITLE
fix(ui): redirect retired dashboard agent list and detail routes

### DIFF
--- a/packages/ui/src/cloud/shell/CloudRouterShell.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.tsx
@@ -86,6 +86,11 @@ export const LEGACY_DASHBOARD_REDIRECTS: ReadonlyArray<{
   { from: "dashboard/containers", to: "/cloud/agents" },
   { from: "dashboard/containers/:id", to: "/cloud/agents/:id" },
   { from: "dashboard/containers/agents/:id", to: "/cloud/agents/:id" },
+  // Agent list + detail moved with the consolidation; the edge middleware
+  // covers production domains, these cover in-app and self-hosted navigations
+  // (the same dual coverage containers/:id already has).
+  { from: "dashboard/agents", to: "/cloud/agents" },
+  { from: "dashboard/agents/:id", to: "/cloud/agents/:id" },
   // Real chat lives in the app, not the dashboard; old chat deep links
   // redirect back to the agent detail page.
   { from: "dashboard/agents/:id/chat", to: "/cloud/agents/:id" },


### PR DESCRIPTION
## What

The dashboard→/cloud consolidation left the two most-linked routes out of the shell's redirect table: `dashboard/agents` and `dashboard/agents/:id` — only the `/chat` variant redirected. The edge middleware covers the production domains, but in-app navigations and self-hosted setups dead-ended old agent deep links at the app shell ("Booting up…" forever). `containers/:id` already has this dual edge+shell coverage; agents now matches it. Found while migrating `agent-detail-invalid-date-capture.spec.ts` in #19751.

## Evidence Gate

<!-- evidence-head:d73a27ec3323ffd94414d301e5eb28e5e9eff93c -->

<!-- evidence-row:before-screenshots -->
- [x] Before this PR the retired URL never leaves the boot shell — captured in #19751's failing-run artifact (page snapshot shows only "Eliza / Booting up…", `agent-detail-invalid-date--03ceb.../error-context.md`). The route dead-ends, so there is no page to screenshot beyond that shell state.
<!-- evidence-row:after-screenshots -->
- [x] Real browser, retired URL entered directly, full-page:
  - desktop detail: https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/pr19791-detail-desktop.png
  - mobile detail: https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/pr19791-detail-mobile.png
  - desktop list: https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/pr19791-list-desktop.png
  - mobile list: https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/pr19791-list-mobile.png
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/pr19791-walkthrough.mp4 — `/dashboard/agents/agent-smoke-1` → redirect → detail page renders → `/dashboard/agents` → redirect → agents list (desktop run, Playwright-recorded)
<!-- evidence-row:backend-logs -->
- [x] The shell suite's parity test substitutes `:id` and checks EVERY table entry against the shared edge contract, so both new entries are contract-verified automatically:
```
$ bun x vitest run src/cloud/shell/CloudRouterShell.test.tsx
 Test Files  1 passed (1)
      Tests  19 passed (19)
parity exercised: /dashboard/agents -> /cloud/agents
                  /dashboard/agents/agent-7 -> /cloud/agents/agent-7
```
<!-- evidence-row:frontend-logs -->
- [x] Capture spec asserts the URL transition and the rendered agent name before screenshotting:
```
page.goto('/dashboard/agents/agent-smoke-1') -> waitForURL(/\/cloud\/agents\/agent-smoke-1/) OK
waitForSelector('text=Smoke Agent') OK  (both viewports; 2 passed, 2.4m)
```
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic route normalization; no model behavior involved
<!-- evidence-row:domain-artifacts -->
- [x] The rendered detail page IS the artifact, inspected manually in both captures: "Smoke Agent · running", stat tiles (Status/Database/Cost/Created/Last Heartbeat all populated, no "Invalid Date"), Overview/Wallet/Transactions/Policies tabs, Agent Actions and Backups panels — identical to navigating the canonical URL directly.
<!-- evidence-row:ocr-review -->
- [x] Visually reviewed all four captures' text: headings, tab labels, stat values, and button labels are crisp and correctly spelled at both viewports; the only truncation is the pre-existing mobile stat-grid clipping of "Connected" at 390px, unchanged by this PR (redirect-only diff).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- ai-assistance: yes
<!-- attribution-row:models -->
- models: anthropic/claude-opus-4-8
<!-- attribution-row:client -->
- client: Claude Code
<!-- attribution-row:skill-revision -->
- skill-revision: N/A - no packaged skill governed this change
<!-- attribution-row:status -->
- status: self-reported
