### PR TITLE
fix(agent): bundle Android inference boot imports

### DIFF
--- a/packages/agent/src/runtime/boot-hooks.ts
+++ b/packages/agent/src/runtime/boot-hooks.ts
@@ -36,6 +36,21 @@ type BootHookModule = Record<string, unknown>;
 type BootHook = (runtime: AgentRuntime) => void | Promise<void>;
 
 /**
+ * Literal importers for host-owned hooks that must survive mobile bundling.
+ * Registry hooks remain extensible through the dynamic-import fallback below,
+ * but a computed specifier is invisible to Bun and cannot be the only import
+ * path for code embedded in an APK without a node_modules tree.
+ */
+const BUNDLED_BOOT_HOOK_IMPORTERS: Readonly<
+  Record<string, () => Promise<BootHookModule>>
+> = {
+  "@elizaos/plugin-local-inference/runtime": () =>
+    import(
+      "@elizaos/plugin-local-inference/runtime"
+    ) as Promise<BootHookModule>,
+};
+
+/**
  * Host-owned declarations appended when the registry does not supply one for the
  * same id. These are not a duplicate source of truth: a registry declaration
  * always wins, and this only covers the packaged-build case where the registry
@@ -70,9 +85,12 @@ async function loadAndInvokeBootHook(
 ): Promise<void> {
   let module: BootHookModule;
   try {
-    module = (await import(
-      /* webpackIgnore: true */ declaration.specifier
-    )) as BootHookModule;
+    const bundledImporter = BUNDLED_BOOT_HOOK_IMPORTERS[declaration.specifier];
+    module = bundledImporter
+      ? await bundledImporter()
+      : ((await import(
+          /* webpackIgnore: true */ declaration.specifier
+        )) as BootHookModule);
   } catch (error) {
     // error-policy:J4 a host that ships without an optional hook module is a
     // supported deployment, so its absence degrades to "no hook". Anything else,

--- a/packages/agent/src/runtime/mobile-bundle-anchors.test.ts
+++ b/packages/agent/src/runtime/mobile-bundle-anchors.test.ts
@@ -35,8 +35,23 @@ const DEAD_GLOBALS = [
 describe("mobile bundle anchors (no write-only globalThis pinning)", () => {
   const binSource = read("bin.ts");
   const androidSource = read("runtime/android-app-plugins.ts");
+  const bootHooksSource = read("runtime/boot-hooks.ts");
   const mobileBuildScript = readFileSync(
     path.resolve(agentSrc, "..", "scripts", "build-mobile-bundle.mjs"),
+    "utf8",
+  );
+  const localInferenceRuntimeSource = readFileSync(
+    path.resolve(
+      agentSrc,
+      "..",
+      "..",
+      "..",
+      "plugins",
+      "plugin-local-inference",
+      "src",
+      "runtime",
+      "ensure-local-inference-handler.ts",
+    ),
     "utf8",
   );
 
@@ -63,6 +78,21 @@ describe("mobile bundle anchors (no write-only globalThis pinning)", () => {
   it("does not null-stub the AOSP local-inference bootstrap package", () => {
     expect(mobileBuildScript).not.toMatch(
       /"@elizaos\/plugin-native-inference"\s*:\s*path\.join\(\s*stubsDir\s*,\s*"null-plugin\.cjs"\s*\)/,
+    );
+  });
+
+  it("keeps the AOSP native-inference adapter visible to the mobile bundler", () => {
+    expect(localInferenceRuntimeSource).toContain(
+      'import("@elizaos/plugin-native-inference")',
+    );
+    expect(localInferenceRuntimeSource).not.toContain(
+      'new Function("id", "return import(id)")',
+    );
+  });
+
+  it("keeps a literal importer for the local-inference boot hook", () => {
+    expect(bootHooksSource).toMatch(
+      /import\(\s*"@elizaos\/plugin-local-inference\/runtime"\s*\)/,
     );
   });
 });

--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -1353,12 +1353,9 @@ async function tryRegisterAospLlamaLoader(
 ): Promise<boolean> {
 	if (!shouldAttemptAospLlamaLoader()) return false;
 	try {
-		const dynamicImport = new Function("id", "return import(id)") as (
-			id: string,
-		) => Promise<{
+		const mod = (await import("@elizaos/plugin-native-inference")) as {
 			registerAospLlamaLoader?: (r: AgentRuntime) => Promise<boolean> | boolean;
-		}>;
-		const mod = await dynamicImport("@elizaos/plugin-native-inference");
+		};
 		if (typeof mod.registerAospLlamaLoader !== "function") {
 			logger.error(
 				"[local-inference] AOSP llama adapter import resolved but missing registerAospLlamaLoader export",


### PR DESCRIPTION
## Summary

- give the host-owned local-inference boot hook a literal importer so Bun embeds it in mobile bundles
- replace the runtime-generated AOSP native-inference import with a literal dynamic import
- add mobile bundle source contracts for both required Android import edges

Closes #19784.

## Verification

- `bunx biome check packages/agent/src/runtime/boot-hooks.ts packages/agent/src/runtime/mobile-bundle-anchors.test.ts plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts`
- focused Vitest: 3 files, 17 tests passed
- `bun run --cwd packages/agent typecheck`
- `bun run --cwd plugins/plugin-local-inference typecheck`
- `bun packages/agent/scripts/build-mobile-bundle.mjs` (50.58 MB bundle; load smoke passed)
- inspected bundle: both imports compile to bundled initializers rather than unresolved package imports
- rebuilt/re-signed emulator APK payload and booted it on an arm64 Android 15 AOSP emulator

## Android runtime evidence

Before this change the service restarted with `ResolveMessage: Cannot find package '@elizaos/plugin-local-inference'`. After the first import fix, the next computed edge failed on `@elizaos/plugin-native-inference`. With both edges corrected:

- `ElizaAgentService` remains a running foreground service
- Bun completes migrations and boot hooks
- boot-hook time fell from the unresolved-import timeout (~30 seconds) to 13 ms
- the local-agent IPC route kernel reaches ready/server-only mode
- native inference now reaches the real `libelizainference.so` load boundary; the stock debug-signed emulator is limited by its app linker namespace (`libvulkan.so` is not visible), while the platform-signed `/system/priv-app` OS image is the intended Vulkan boundary

The full privileged APK build also completed all 89 workspace prerequisite packages and the corrected Android agent bundle before the local machine ran out of disk while duplicating the web payload. The OS AOSP workflow performs that final packaging on its KVM runner.

— [codex-android-os]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"codex-desktop","skill_revision":"elizaOS/eliza@0d1d208a157707c121caf9785f006d25cc0f83a7:packages/skills/skills/contribute-to-eliza"} -->
