### PR TITLE
fix(plugin-notes): notes are a stage-1 context, and identical duplicates are one note

### DIFF
--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -6295,6 +6295,21 @@ async function resolveStage1SenderRole(
 	}
 	try {
 		const result = await checkSenderRole(runtime, message);
+		// The resolved role decides the entire action surface for the turn, and
+		// a silent fall to the floor is indistinguishable from an explicit
+		// non-elevated grant without this line. `result === null` means no world
+		// resolved for the message — the most common cause of an owner probe
+		// landing on the floor.
+		runtime.logger.debug(
+			{
+				src: "service:message",
+				entityId: message.entityId,
+				roomId: message.roomId,
+				worldResolved: result !== null,
+				role: result?.role ?? null,
+			},
+			"Stage 1 sender role resolved",
+		);
 		if (result?.role) {
 			return result.role as RoleGateRole;
 		}

--- a/plugins/plugin-notes/src/action.test.ts
+++ b/plugins/plugin-notes/src/action.test.ts
@@ -157,3 +157,34 @@ describe("NOTES operation parsing", () => {
     expect(after.text).toContain("don't have any notes");
   });
 });
+
+describe("identical-duplicate notes", () => {
+  it("deletes every byte-identical copy as one logical note", async () => {
+    const runtime = await harness();
+    for (let i = 0; i < 4; i += 1) {
+      await run(runtime, { action: "create", content: "i need to buy milk" });
+    }
+    await run(runtime, {
+      action: "create",
+      content: "spare key under the mat",
+    });
+
+    const result = await run(runtime, { action: "delete", content: "milk" });
+    expect(result.success).toBe(true);
+    expect(result.text).toContain("removed 4 identical copies");
+
+    const after = await run(runtime, { action: "list" });
+    expect(after.text).not.toContain("milk");
+    expect(after.text).toContain("spare key");
+  });
+
+  it("still refuses genuinely differing matches as ambiguous", async () => {
+    const runtime = await harness();
+    await run(runtime, { action: "create", content: "buy milk at aldi" });
+    await run(runtime, { action: "create", content: "buy milk for the cat" });
+
+    await expect(
+      run(runtime, { action: "delete", content: "milk" }),
+    ).rejects.toMatchObject({ code: "NOTES_AMBIGUOUS_NOTE" });
+  });
+});

--- a/plugins/plugin-notes/src/action.ts
+++ b/plugins/plugin-notes/src/action.ts
@@ -95,6 +95,7 @@ function committed(text: string, data: Record<string, unknown>): ActionResult {
 
 export const notesAction: Action = {
   name: "NOTES",
+  contexts: ["notes", "general"],
   similes: [
     "NOTE",
     "TAKE_NOTE",
@@ -200,9 +201,16 @@ export const notesAction: Action = {
         "query",
         content,
       );
-      const text = `deleted the note: ${describe(removed.value)}`;
+      const text =
+        removed.removedCount > 1
+          ? `deleted the note: ${describe(removed.value)} (removed ${removed.removedCount} identical copies)`
+          : `deleted the note: ${describe(removed.value)}`;
       await deliver(text);
-      return committed(text, { op, noteId: removed.value.id });
+      return committed(text, {
+        op,
+        noteId: removed.value.id,
+        removedCount: removed.removedCount,
+      });
     }
 
     const replacement = readString(params.body) ?? readString(params.newText);

--- a/plugins/plugin-notes/src/plugin.ts
+++ b/plugins/plugin-notes/src/plugin.ts
@@ -4,7 +4,7 @@
  * interaction transport to the shared VIEWS system.
  */
 
-import type { Plugin } from "@elizaos/core";
+import type { ContextDefinition, Plugin } from "@elizaos/core";
 import { notesAction } from "./action.js";
 import { NOTES_CAPABILITIES } from "./capabilities.js";
 import { serverInteract } from "./interact.js";
@@ -12,10 +12,33 @@ import { notesProvider } from "./provider.js";
 import { notesRoutes } from "./routes.js";
 import { NotesService } from "./service.js";
 
+/**
+ * Stage 1 classifies a turn into registered CONTEXTS, not actions: a context
+ * the taxonomy lacks is a request Stage 1 cannot name, however well the action
+ * itself advertises. Without this entry, "what notes do i have?" classified
+ * into documents/contacts/memory and the NOTES action was never a candidate —
+ * the read then honestly reported an absence from the wrong store.
+ */
+const NOTES_CONTEXT: ContextDefinition = {
+  id: "notes",
+  label: "Notes",
+  description:
+    "The user's saved notes — short facts and reminders-to-self they asked to write down ('note that…', 'jot this down') and read back ('what notes do i have', 'do i have a note about…', 'what did my note say'). Covers reading, searching, updating, and deleting those notes. A note is not a long-form document, not a todo, and not a calendar event; a notes read must never classify as documents, contacts, or memory.",
+  descriptionCompressed:
+    "User's saved notes: write down, read back, search, update, delete",
+  sensitivity: "personal",
+  cacheScope: "agent",
+  roleGate: { minRole: "USER" },
+};
+
 export const notesPlugin: Plugin = {
   name: "@elizaos/plugin-notes",
   description:
     "Managed Cloud Notes view with durable agent-driven CRUD and view switching.",
+  contexts: ["notes"],
+  async init(_config, runtime) {
+    runtime.contexts.tryRegister(NOTES_CONTEXT);
+  },
   actions: [notesAction],
   providers: [notesProvider],
   services: [NotesService],

--- a/plugins/plugin-notes/src/service.ts
+++ b/plugins/plugin-notes/src/service.ts
@@ -74,6 +74,11 @@ function lookupError(
   );
 }
 
+/** Identity key for copies with exactly the same user-visible content. */
+function noteContentKey(note: StickyNote): string {
+  return `${note.title}\0${note.body}`;
+}
+
 function resolveNoteIndex(
   notes: StickyNote[],
   selector: NoteLookupSelector,
@@ -94,7 +99,15 @@ function resolveNoteIndex(
   if (candidates.length === 0) {
     throw lookupError("NOTES_NOT_FOUND", selector, value, []);
   }
-  if (candidates.length > 1) {
+  // Ambiguity exists only between notes a user could tell apart. Multiple
+  // byte-identical copies (the duplicate-create case) are one logical note:
+  // asking "which one?" has no answerable form, and refusing made identical
+  // duplicates permanently unaddressable through chat. Differing matches keep
+  // the explicit ambiguity error.
+  if (
+    candidates.length > 1 &&
+    new Set(candidates.map(({ note }) => noteContentKey(note))).size > 1
+  ) {
     throw lookupError(
       "NOTES_AMBIGUOUS_NOTE",
       selector,
@@ -314,7 +327,12 @@ export class NotesService extends Service {
   async deleteNoteByLookupWithCommit(
     selector: NoteLookupSelector,
     value: string,
-  ): Promise<{ value: StickyNote; snapshot: NotesSnapshot }> {
+  ): Promise<{
+    value: StickyNote;
+    snapshot: NotesSnapshot;
+    removedCount: number;
+  }> {
+    let removedCount = 0;
     const transaction = await this.store.transact((draft) => {
       const index = resolveNoteIndex(draft.notes, selector, value);
       const existing = draft.notes[index];
@@ -324,11 +342,17 @@ export class NotesService extends Service {
           severity: "fatal",
         });
       }
-      draft.notes.splice(index, 1);
+      // Deleting "the note" deletes every byte-identical copy: duplicates are
+      // one logical note, and leaving three identical survivors after "delete
+      // the milk note" contradicts what the deletion just confirmed.
+      const key = noteContentKey(existing);
+      const kept = draft.notes.filter((note) => noteContentKey(note) !== key);
+      removedCount = draft.notes.length - kept.length;
+      draft.notes = kept;
       return existing;
     });
     await this.emitStateUpdated(transaction.snapshot, "note:deleted");
-    return transaction;
+    return { ...transaction, removedCount };
   }
 
   async clearNotesWithCommit(): Promise<{


### PR DESCRIPTION
## What

Two structural gaps that made notes unreliable in chat, both live-verified on the nubilio deployment tonight:

1. **"what notes do i have?" could not route to notes at all.** Stage 1 classifies a turn into registered **contexts**, not actions — and no `notes` context existed in the taxonomy, so the turn classified into documents/contacts/memory and honestly reported absence from the wrong store. The `documents` context even disclaims notes. However well the NOTES action advertises itself (similes, routingHint), an unregistered context is a request Stage 1 cannot name.
2. **Byte-identical duplicate notes were permanently unaddressable.** Lookup threw `NOTES_AMBIGUOUS_NOTE` for multiple matches even when every match was the same text — an ambiguity with no answerable form ("which copy?" has no user-visible difference). Live shape: "i found 4 milk notes, but the tools can't delete duplicates when they share the same text."

## Change

- The plugin registers a `notes` `ContextDefinition` at init (`runtime.contexts.tryRegister`) — the supported extension seam the runtime seeds before plugins register — and the NOTES action scopes to `["notes", "general"]`.
- `resolveNoteIndex` treats multiple byte-identical candidates as one logical note; genuinely differing matches keep the explicit ambiguity error. `deleteNoteByLookupWithCommit` collapses every identical copy and reports it honestly ("removed N identical copies").
- Rides along: a debug log in `resolveStage1SenderRole` naming the resolved role and whether a world resolved — the silent fall to the role floor was indistinguishable from an explicit non-elevated grant, which cost tonight's owner-role diagnosis an hour.

## Evidence

<!-- evidence-head:06b9120d1b101a6aa1ffc333412b6bb21eb11b8c -->

<!-- evidence-row:before-screenshots -->
N/A - Discord chat behavior; transcript evidence below

<!-- evidence-row:after-screenshots -->
N/A - Discord chat behavior; transcript evidence below

<!-- evidence-row:walkthrough-video -->
N/A - no UI surface

<!-- evidence-row:backend-logs -->
Live before/after on the nubilio deployment (test channel, same store):

<details>
<summary>before — the read never reaches notes</summary>
<pre>
user: what notes do i have?
bot:  checking. use action=read on one of these contacts, or searching
      documents if you meant text files. which one?
</pre>
</details>

<details>
<summary>after — context registered (same restart cycle, same store)</summary>
<pre>
user: what notes do i have?
bot:  your notes: - spare key is under the mat - the wifi router is behind
      the tv - i need to buy milk - …
user: do i have any notes about the plumber?
bot:  you don't have any notes about "plumber".
user: delete my milk note
bot:  deleted the note: i need to buy milk (removed 2 identical copies)
</pre>
</details>

<!-- evidence-row:frontend-logs -->
N/A - no frontend surface in this change

<!-- evidence-row:llm-trajectory -->
Trajectory for the failing read shows Stage 1 candidates `["LIST_DOCUMENTS"]` and a `CONTACT_SEARCH` tool call — notes never nameable. Post-fix turns route to NOTES (transcript above is the delivered output of those turns).

<!-- evidence-row:domain-artifacts -->
Plugin suite on this branch: **9 files, 77 passed**, including two new pins: identical-copy delete collapses all copies and lists none after; differing matches still throw `NOTES_AMBIGUOUS_NOTE`.

<!-- evidence-row:ocr-review -->
N/A - no rendered text or imagery

## Contribution provenance

AI assistance is self-reported provenance, not a request for hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes - agent-authored under human direction, root-caused and verified on the live deployment
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code (Eliza sub-agent)
<!-- attribution-row:skill-revision -->
- Contribution skill revision: N/A - authored from live deployment evidence
<!-- attribution-row:status -->
- Attribution status: self-reported
