### PR TITLE
fix(cloud): shorten inbound voice critical path

### DIFF
--- a/packages/cloud/api/v1/twilio/voice/inbound/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/inbound/route.ts
@@ -57,6 +57,7 @@ function resolvePublicUrl(c: AppContext): URL {
 }
 
 app.post("/", async (c) => {
+  const requestStartedAt = Date.now();
   const rawBody = await c.req.text();
   const params = Object.fromEntries(new URLSearchParams(rawBody));
   const parsed = TwilioVoicePayloadSchema.safeParse(params);
@@ -120,6 +121,7 @@ app.post("/", async (c) => {
       headers: { "Content-Type": "text/xml" },
     });
   }
+  const targetResolvedAt = Date.now();
 
   const id = randomUUID();
   const conversationId = randomUUID();
@@ -143,56 +145,83 @@ app.post("/", async (c) => {
       error: error instanceof Error ? error.message : String(error),
     });
   }
-  const [priorCall] = await dbRead
-    .select({ id: twilioInboundCalls.id })
-    .from(twilioInboundCalls)
-    .where(
-      and(
-        or(
-          and(
-            eq(twilioInboundCalls.from_number, callerNumber),
-            eq(twilioInboundCalls.to_number, publicLineNumber),
+  const priorCallPromise = Promise.resolve(
+    dbRead
+      .select({ id: twilioInboundCalls.id })
+      .from(twilioInboundCalls)
+      .where(
+        and(
+          or(
+            and(
+              eq(twilioInboundCalls.from_number, callerNumber),
+              eq(twilioInboundCalls.to_number, publicLineNumber),
+            ),
+            and(
+              eq(twilioInboundCalls.from_number, publicLineNumber),
+              eq(twilioInboundCalls.to_number, callerNumber),
+            ),
           ),
-          and(
-            eq(twilioInboundCalls.from_number, publicLineNumber),
-            eq(twilioInboundCalls.to_number, callerNumber),
-          ),
+          eq(twilioInboundCalls.agent_id, phoneNumber.agentId),
         ),
-        eq(twilioInboundCalls.agent_id, phoneNumber.agentId),
-      ),
-    )
-    .limit(1);
-  const rawPayload = await offloadJsonField<Record<string, string>>({
+      )
+      .limit(1),
+  );
+  const rawPayloadPromise = offloadJsonField<Record<string, string>>({
     namespace: ObjectNamespaces.TwilioInboundPayloads,
-    organizationId: phoneNumber?.organizationId ?? "twilio",
+    organizationId: phoneNumber.organizationId,
     objectId: id,
     field: "raw_payload",
     createdAt: new Date(),
     value: params,
     inlineValueWhenOffloaded: {},
   });
-  await dbWrite
-    .insert(twilioInboundCalls)
-    .values({
-      id,
-      call_sid: event.CallSid,
-      account_sid: event.AccountSid,
-      from_number: normalizedFrom,
-      to_number: normalizedTo,
-      call_status: event.CallStatus,
-      agent_id: phoneNumber?.agentId ?? null,
-      raw_payload: rawPayload.value ?? {},
-      raw_payload_storage: rawPayload.storage,
-      raw_payload_key: rawPayload.key,
+  const recordCall = Promise.all([rawPayloadPromise, priorCallPromise])
+    .then(([rawPayload]) =>
+      dbWrite
+        .insert(twilioInboundCalls)
+        .values({
+          id,
+          call_sid: event.CallSid,
+          account_sid: event.AccountSid,
+          from_number: normalizedFrom,
+          to_number: normalizedTo,
+          call_status: event.CallStatus,
+          agent_id: phoneNumber.agentId,
+          raw_payload: rawPayload.value ?? {},
+          raw_payload_storage: rawPayload.storage,
+          raw_payload_key: rawPayload.key,
+        })
+        .onConflictDoNothing({ target: twilioInboundCalls.call_sid }),
+    )
+    .then(() => {
+      logger.info("[twilio-voice-inbound] recorded realtime call", {
+        callSid: event.CallSid,
+        from: normalizedFrom,
+        to: normalizedTo,
+        agentId: phoneNumber.agentId,
+        persistenceMs: Date.now() - requestStartedAt,
+      });
     })
-    .onConflictDoNothing({ target: twilioInboundCalls.call_sid });
-
-  logger.info("[twilio-voice-inbound] recorded realtime call", {
-    callSid: event.CallSid,
-    from: normalizedFrom,
-    to: normalizedTo,
-    agentId: phoneNumber?.agentId,
-  });
+    .catch((error) => {
+      // error-policy:J7 call audit persistence is diagnostic and must not delay
+      // the live TwiML response; report any background failure explicitly.
+      logger.warn("[twilio-voice-inbound] call persistence failed", {
+        callSid: event.CallSid,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  const [priorCall] = await priorCallPromise;
+  const callerResolvedAt = Date.now();
+  try {
+    c.executionCtx.waitUntil(recordCall);
+  } catch (error) {
+    // error-policy:J7 a local/test context may lack a Worker lifetime; the
+    // already-contained persistence promise remains best-effort in-process.
+    logger.warn("[twilio-voice-inbound] call persistence wait unavailable", {
+      callSid: event.CallSid,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 
   const minted = await mintTwilioStreamToken(
     {
@@ -213,6 +242,15 @@ app.post("/", async (c) => {
     sessionId: minted.claims.sessionId,
     jti: minted.claims.jti,
     expSeconds: minted.claims.exp,
+  });
+  const responseReadyAt = Date.now();
+  logger.info("[twilio-voice-inbound] realtime TwiML ready", {
+    callSid: event.CallSid,
+    returningCaller: Boolean(priorCall),
+    targetMs: targetResolvedAt - requestStartedAt,
+    callerLookupMs: callerResolvedAt - targetResolvedAt,
+    tokenAndDirectoryMs: responseReadyAt - callerResolvedAt,
+    totalMs: responseReadyAt - requestStartedAt,
   });
   publicUrl.pathname = "/api/v1/twilio/voice/media";
   publicUrl.search = "";

--- a/packages/cloud/api/v1/voice/session/__tests__/voice-agent-scope-hydration.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/voice-agent-scope-hydration.test.ts
@@ -61,6 +61,19 @@ const warmInferenceAdmissionSnapshot = mock(async () => undefined);
 mock.module("@/lib/services/inference-admission-snapshot", () => ({
   warmInferenceAdmissionSnapshot,
 }));
+const calculateCost = mock(async () => ({
+  inputCost: 0,
+  outputCost: 0,
+  totalCost: 0,
+}));
+mock.module("@/lib/pricing", () => ({
+  calculateCost,
+  getProviderFromModel: () => "cerebras",
+  normalizeModelName: (model: string) => model.replace(/^cerebras\//, ""),
+}));
+mock.module("@/lib/voice-session/config", () => ({
+  resolveElizaModel: () => "cerebras/gemma-4-31b",
+}));
 
 const { cache } = await import("@/lib/cache/client");
 const { CacheKeys } = await import("@/lib/cache/keys");
@@ -90,6 +103,7 @@ afterEach(async () => {
   findByIdAndOrg.mockClear();
   findByIdInOrganization.mockClear();
   warmInferenceAdmissionSnapshot.mockClear();
+  calculateCost.mockClear();
   findByIdInOrganization.mockImplementation(async () => linkedCharacter);
 });
 
@@ -113,6 +127,13 @@ test("one cold hydration warms BOTH the scope gate and the linked character", as
     );
     expect(warmInferenceAdmissionSnapshot).toHaveBeenCalledWith(
       ORGANIZATION_ID,
+    );
+    expect(calculateCost).toHaveBeenCalledWith(
+      "gemma-4-31b",
+      "cerebras",
+      1,
+      1,
+      "bitrouter",
     );
   });
 });

--- a/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
+++ b/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
@@ -56,16 +56,35 @@ export async function hydrateVoiceSharedAgentScope(
         // hydration makes the next turn fully serviceable.
         const characterId = agent.character_id;
         const hydrateCharacter = async (): Promise<void> => {
-          if (!characterId) return;
-          const cacheKey = `character:data:${characterId}`;
-          if (await cache.get(cacheKey)) return;
-          const character =
-            await userCharactersRepository.findByIdInOrganization(
-              characterId,
-              claims.organizationId,
-            );
-          if (!character) return;
-          await cache.set(cacheKey, character, CacheTTL.agent.characterData);
+          if (characterId) {
+            const cacheKey = `character:data:${characterId}`;
+            if (await cache.get(cacheKey)) return;
+            const linked =
+              await userCharactersRepository.findByIdInOrganization(
+                characterId,
+                claims.organizationId,
+              );
+            if (linked) {
+              await cache.set(cacheKey, linked, CacheTTL.agent.characterData);
+            }
+          }
+        };
+        const warmVoiceModelPricing = async (): Promise<void> => {
+          const [pricing, voiceConfig] = await Promise.all([
+            import("@/lib/pricing"),
+            import("@/lib/voice-session/config"),
+          ]);
+          const { calculateCost, getProviderFromModel, normalizeModelName } =
+            pricing;
+          const { resolveElizaModel } = voiceConfig;
+          const model = resolveElizaModel(env);
+          await calculateCost(
+            normalizeModelName(model),
+            getProviderFromModel(model),
+            1,
+            1,
+            "bitrouter",
+          );
         };
 
         // Publish the authorization gate as soon as the authoritative agent
@@ -89,6 +108,14 @@ export async function hydrateVoiceSharedAgentScope(
             logger.warn("[voice-scope-hydration] character prefill failed", {
               agentId: claims.agentId,
               characterId,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }),
+          warmVoiceModelPricing().catch((error) => {
+            // error-policy:J7 pricing hydration is latency-only; the first turn
+            // retains the canonical typed cache-warming retry fallback.
+            logger.warn("[voice-scope-hydration] pricing prefill failed", {
+              agentId: claims.agentId,
               error: error instanceof Error ? error.message : String(error),
             });
           }),


### PR DESCRIPTION
Production promotion of #19797.

Moves call-audit persistence off the inbound TwiML path, parallelizes independent first-call lookups, warms pricing during the greeting, and adds stage-level latency telemetry.

Verified with focused voice tests, cloud API typecheck, and production Worker dry-run.