### PR TITLE
fix(agent): a one-shot cron reminder reads as one-shot

### DIFF
--- a/packages/agent/src/actions/trigger.test.ts
+++ b/packages/agent/src/actions/trigger.test.ts
@@ -1693,4 +1693,34 @@ describe("one-shot cron reminder confirmation", () => {
     expect(result?.text).not.toContain("every day");
     expect(result?.text).toMatch(/9(:00)?\s?(a\.?m\.?)/i);
   });
+
+  it("describes the persisted occurrence when persistence crosses the cron boundary", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-08-15T08:59:59.000Z"));
+      const { runtime, createdTasks } = makeRuntime({
+        enableAutonomy: false,
+        timeZone: "UTC",
+      });
+      vi.mocked(runtime.createTask).mockImplementation(async (task) => {
+        createdTasks.push(task as CreatedTask);
+        vi.setSystemTime(new Date("2026-08-15T09:00:01.000Z"));
+        return stringToUuid("created-across-cron-boundary");
+      });
+
+      const result = await create(runtime, {
+        instructions: "call the bank",
+        cronExpression: "0 9 * * *",
+        maxRuns: 1,
+      });
+
+      expect(createdTasks[0]?.metadata.trigger?.nextRunAtMs).toBe(
+        Date.parse("2026-08-15T09:00:00.000Z"),
+      );
+      expect(result?.text).toContain("today at 9am");
+      expect(result?.text).not.toContain("tomorrow");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/agent/src/actions/trigger.test.ts
+++ b/packages/agent/src/actions/trigger.test.ts
@@ -1677,3 +1677,20 @@ describe("TRIGGER list — dropped rows are counted, not hidden", () => {
     expect(result.data).toMatchObject({ count: 1, unreadable: 0 });
   });
 });
+
+describe("one-shot cron reminder confirmation", () => {
+  it("describes a maxRuns=1 cron by its next occurrence, never as recurring", async () => {
+    const { runtime } = makeRuntime({ enableAutonomy: false });
+    const result = await create(runtime, {
+      instructions: "call the bank",
+      cronExpression: "0 9 * * *",
+      maxRuns: 1,
+    });
+    expect(result?.success).toBe(true);
+    // The trigger fires once at the next 9am and stops; the confirmation must
+    // read as a one-shot, not a recurrence the trigger cannot have.
+    expect(result?.text).not.toContain("every morning");
+    expect(result?.text).not.toContain("every day");
+    expect(result?.text).toMatch(/9(:00)?\s?(a\.?m\.?)/i);
+  });
+});

--- a/packages/agent/src/actions/trigger.ts
+++ b/packages/agent/src/actions/trigger.ts
@@ -52,6 +52,7 @@ import {
 } from "../triggers/runtime.ts";
 import {
   buildTriggerMetadata,
+  computeNextCronRunAtMs,
   DISABLED_TRIGGER_INTERVAL_MS,
   normalizeTriggerIntervalMs,
   parseCronExpression,
@@ -331,6 +332,26 @@ function describeSchedule(
       ? describeOnceAt(t.scheduledAtIso, nowMs, messageTimeZone)
       : null;
     return friendly ?? "soon";
+  }
+  // A cron trigger capped at one run IS a one-shot: it fires at the next
+  // occurrence and never again. Describing it by its cron shape ("every
+  // morning at 9am") reports a recurrence the trigger cannot have — the live
+  // shape: "remind me tomorrow at 9am" confirmed back as "every morning".
+  if (t.maxRuns === 1 && t.cronExpression) {
+    const nextMs = computeNextCronRunAtMs(
+      t.cronExpression,
+      nowMs,
+      t.timezone ?? messageTimeZone,
+    );
+    const friendly =
+      nextMs !== null
+        ? describeOnceAt(
+            new Date(nextMs).toISOString(),
+            nowMs,
+            messageTimeZone,
+          )
+        : null;
+    if (friendly) return friendly;
   }
   if (!t.timezone || t.timezone !== messageTimeZone) {
     return "on its saved recurring schedule";

--- a/packages/agent/src/actions/trigger.ts
+++ b/packages/agent/src/actions/trigger.ts
@@ -320,6 +320,7 @@ function describeSchedule(
   t: TriggerConfig,
   messageTimeZone: string,
   nowMs = Date.now(),
+  persistedNextRunAtMs?: number,
 ): string {
   if (t.triggerType === "interval") {
     return (
@@ -338,18 +339,16 @@ function describeSchedule(
   // morning at 9am") reports a recurrence the trigger cannot have — the live
   // shape: "remind me tomorrow at 9am" confirmed back as "every morning".
   if (t.maxRuns === 1 && t.cronExpression) {
-    const nextMs = computeNextCronRunAtMs(
-      t.cronExpression,
-      nowMs,
-      t.timezone ?? messageTimeZone,
-    );
+    const nextMs =
+      persistedNextRunAtMs ??
+      computeNextCronRunAtMs(
+        t.cronExpression,
+        nowMs,
+        t.timezone ?? messageTimeZone,
+      );
     const friendly =
       nextMs !== null
-        ? describeOnceAt(
-            new Date(nextMs).toISOString(),
-            nowMs,
-            messageTimeZone,
-          )
+        ? describeOnceAt(new Date(nextMs).toISOString(), nowMs, messageTimeZone)
         : null;
     if (friendly) return friendly;
   }
@@ -783,7 +782,12 @@ async function opCreate(
   // A prompt trigger IS a reminder to the person who asked for it; a workflow
   // trigger is a scheduled job. Either way the schedule reads as a human
   // phrase — the machine forms live in `data` below.
-  const schedule = describeSchedule(triggerConfig, messageTimeZone);
+  const schedule = describeSchedule(
+    triggerConfig,
+    messageTimeZone,
+    Date.now(),
+    metadata.trigger?.nextRunAtMs,
+  );
   const label = displayLabel(displayName);
   return okCommitted(
     "create",
@@ -915,6 +919,8 @@ async function opUpdate(
     `Updated "${displayLabel(next.displayName)}" — ${describeSchedule(
       next,
       messageTimeZone,
+      Date.now(),
+      metadata.trigger?.nextRunAtMs,
     )}.`,
     triggerReceipt("update", String(task.id), { key: null }),
     {


### PR DESCRIPTION
## What

"remind me tomorrow at 9am to call the bank" was confirmed back as **"Reminder set: 'call the bank' — every morning at 9am."** The planner encodes such reminders as a cron trigger (`0 9 * * *`) with `maxRuns: 1` — a valid one-shot encoding that fires once at the next occurrence and stops — but `describeSchedule` rendered the cron shape and ignored the cap, reporting a recurrence the trigger cannot have.

## Change

When `maxRuns === 1` and a cron expression is present, describe the **next occurrence** the way a once trigger reads ("tomorrow at 9am"), computed via the existing `computeNextCronRunAtMs` + `describeOnceAt` helpers. Recurring triggers are unchanged.

## Evidence

<!-- evidence-head:72ee4f6679ee6f016021ecb7e482a38bf78f23c8 -->

<!-- evidence-row:before-screenshots -->
N/A - Discord chat text; transcript below

<!-- evidence-row:after-screenshots -->
N/A - Discord chat text; transcript below

<!-- evidence-row:walkthrough-video -->
N/A - no UI surface

<!-- evidence-row:backend-logs -->
Live before/after on the nubilio deployment:

<details>
<summary>transcripts</summary>
<pre>
before: user: remind me tomorrow at 9am to call the bank
        bot:  Reminder set: "call the bank" — every morning at 9am.
        (trajectory: TRIGGER_CREATE cron "0 9 * * *", maxRuns: 1)

after:  user: remind me tomorrow at 9am to water the garden
        bot:  Reminder set: "water the garden" — tomorrow at 9am.
</pre>
</details>

<!-- evidence-row:frontend-logs -->
N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
The before-trajectory's tool stage is quoted above (cron + maxRuns:1); the fix is deterministic rendering below the model.

<!-- evidence-row:domain-artifacts -->
New test pins the contract (maxRuns=1 cron → next-occurrence phrasing, never "every morning"/"every day"); trigger suite **65/65** on this branch.

<!-- evidence-row:ocr-review -->
N/A - no rendered imagery

## Contribution provenance

AI assistance is self-reported provenance, not a request for hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes - agent-authored under human direction, live-verified
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code (Eliza sub-agent)
<!-- attribution-row:skill-revision -->
- Contribution skill revision: N/A - authored from live deployment evidence
<!-- attribution-row:status -->
- Attribution status: self-reported
