### PR TITLE
fix(cloud): prewarm first voice turn

### DIFF
--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -358,6 +358,41 @@ test("prewarm joins cold hydration without writing a conversation turn", async (
   expect(repositoryReads).toBe(1);
 });
 
+test("fresh-room prewarm skips a legacy history query", async () => {
+  repositoryReads = 0;
+  repositoryWrites = 0;
+  repositoryRow = [{ role: "assistant", content: "must not leak" }];
+  const data = new Map<string, unknown>();
+  const background: Promise<unknown>[] = [];
+  const object = new SharedRuntimeConversation(
+    makeState(data, background) as never,
+    {} as never,
+  );
+
+  const response = await object.fetch(
+    new Request("https://shared-runtime.internal/prewarm", {
+      method: "POST",
+      body: JSON.stringify({
+        operation: "prewarm",
+        agentId: AGENT_FIXTURE.id,
+        roomId: "new-phone-call",
+        startEmpty: true,
+      }),
+    }),
+  );
+
+  expect(response.status).toBe(200);
+  await response.arrayBuffer();
+  expect(repositoryReads).toBe(0);
+  expect(repositoryWrites).toBe(0);
+  expect(data.get("conversation")).toMatchObject({
+    agentId: AGENT_FIXTURE.id,
+    channelId: "new-phone-call",
+    history: [],
+    dirty: false,
+  });
+});
+
 test("warm coordinated turns use local history and mirror asynchronously", async () => {
   repositoryReads = 0;
   repositoryWrites = 0;

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -50,7 +50,12 @@ type ConversationRequest =
       rpc: BridgeRequest;
       trustedMessageRole?: "system";
     }
-  | { operation: "prewarm"; agentId: string; roomId: string }
+  | {
+      operation: "prewarm";
+      agentId: string;
+      roomId: string;
+      startEmpty?: boolean;
+    }
   | { operation: "history"; agentId: string; roomId: string }
   | {
       operation: "lifecycle";
@@ -339,9 +344,10 @@ export class SharedRuntimeConversation {
   private async prewarmConversation(
     agentId: string,
     channelId: string,
+    startEmpty: boolean,
   ): Promise<void> {
     try {
-      await this.loadConversation(agentId, channelId, false);
+      await this.loadConversation(agentId, channelId, startEmpty);
     } catch (error) {
       if (!(error instanceof ConversationCacheWarmingError)) throw error;
       const hydration = this.hydration;
@@ -1019,7 +1025,11 @@ export class SharedRuntimeConversation {
       return Response.json({ success: true });
     }
     if (payload.operation === "prewarm") {
-      await this.prewarmConversation(payload.agentId, payload.roomId);
+      await this.prewarmConversation(
+        payload.agentId,
+        payload.roomId,
+        payload.startEmpty === true,
+      );
       return Response.json({ success: true });
     }
     if (payload.operation === "cutover-seal") {

--- a/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.test.ts
@@ -35,11 +35,14 @@ describe("Twilio voice scope prewarm", () => {
       claims,
       env: {} as never,
       executionCtx: { waitUntil: (promise) => waits.push(promise) },
+      freshConversation: true,
       hydrateScope,
     });
 
     await Promise.resolve();
-    expect(hydrateScope).toHaveBeenCalledWith({}, claims, agent);
+    expect(hydrateScope).toHaveBeenCalledWith({}, claims, agent, {
+      freshConversation: true,
+    });
     expect(waits).toEqual([prewarm]);
     releaseHydration?.();
     await prewarm;

--- a/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/prewarm-voice-scope.ts
@@ -16,6 +16,7 @@ type HydrateVoiceScope = (
   env: Bindings,
   claims: InternalElizaConversationFetchClaims,
   preloadedAgent?: SharedRuntimeAgent,
+  options?: { freshConversation?: boolean },
 ) => Promise<void>;
 
 interface ScheduleVoiceScopePrewarmOptions {
@@ -23,6 +24,7 @@ interface ScheduleVoiceScopePrewarmOptions {
   claims: InternalElizaConversationFetchClaims;
   env: Bindings;
   executionCtx: VoicePrewarmExecutionContext;
+  freshConversation?: boolean;
   hydrateScope?: HydrateVoiceScope;
 }
 
@@ -32,6 +34,7 @@ export function scheduleTwilioVoiceScopePrewarm({
   claims,
   env,
   executionCtx,
+  freshConversation,
   hydrateScope,
 }: ScheduleVoiceScopePrewarmOptions): Promise<void> {
   const prewarm = Promise.resolve()
@@ -40,7 +43,7 @@ export function scheduleTwilioVoiceScopePrewarm({
         hydrateScope ??
         (await import("../../../voice/session/lib/voice-agent-scope-hydration"))
           .hydrateVoiceSharedAgentScope;
-      await hydrate(env, claims, agent);
+      await hydrate(env, claims, agent, { freshConversation });
     })
     .catch((error) => {
       // error-policy:J7 this is a latency hint; the media session retains its

--- a/packages/cloud/api/v1/voice/session/__tests__/voice-agent-scope-hydration.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/voice-agent-scope-hydration.test.ts
@@ -61,6 +61,10 @@ const warmInferenceAdmissionSnapshot = mock(async () => undefined);
 mock.module("@/lib/services/inference-admission-snapshot", () => ({
   warmInferenceAdmissionSnapshot,
 }));
+const warmInferenceAdmissionGate = mock(async () => undefined);
+mock.module("@/lib/services/inference-admission-gate", () => ({
+  warmInferenceAdmissionGate,
+}));
 const calculateCost = mock(async () => ({
   inputCost: 0,
   outputCost: 0,
@@ -103,6 +107,7 @@ afterEach(async () => {
   findByIdAndOrg.mockClear();
   findByIdInOrganization.mockClear();
   warmInferenceAdmissionSnapshot.mockClear();
+  warmInferenceAdmissionGate.mockClear();
   calculateCost.mockClear();
   findByIdInOrganization.mockImplementation(async () => linkedCharacter);
 });
@@ -128,6 +133,7 @@ test("one cold hydration warms BOTH the scope gate and the linked character", as
     expect(warmInferenceAdmissionSnapshot).toHaveBeenCalledWith(
       ORGANIZATION_ID,
     );
+    expect(warmInferenceAdmissionGate).toHaveBeenCalledWith(ORGANIZATION_ID);
     expect(calculateCost).toHaveBeenCalledWith(
       "gemma-4-31b",
       "cerebras",
@@ -216,6 +222,43 @@ test("prewarms the call conversation while the fixed greeting is playing", async
     operation: "prewarm",
     agentId: AGENT_ID,
     roomId: CONVERSATION_ID,
+    startEmpty: false,
+  });
+});
+
+test("marks a newly minted phone-call conversation as empty", async () => {
+  const requests: Request[] = [];
+  const voiceEnv = {
+    ...env,
+    SHARED_RUNTIME_CONVERSATIONS: {
+      getByName() {
+        return {
+          async fetch(input: RequestInfo | URL, init?: RequestInit) {
+            requests.push(new Request(input, init));
+            return Response.json({ success: true });
+          },
+        };
+      },
+    },
+  };
+
+  await runWithCloudBindingsAsync(voiceEnv, async () => {
+    await hydrateVoiceSharedAgentScope(
+      voiceEnv as unknown as Parameters<typeof hydrateVoiceSharedAgentScope>[0],
+      claims,
+      sharedAgent as never,
+      { freshConversation: true },
+    );
+  });
+
+  const request = requests[0];
+  if (!request) throw new Error("expected fresh conversation prewarm request");
+  const body = (await request.json()) as unknown;
+  expect(body).toEqual({
+    operation: "prewarm",
+    agentId: AGENT_ID,
+    roomId: CONVERSATION_ID,
+    startEmpty: true,
   });
 });
 

--- a/packages/cloud/api/v1/voice/session/lib/session.ts
+++ b/packages/cloud/api/v1/voice/session/lib/session.ts
@@ -832,6 +832,8 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       clientMessageId?: string;
     } = {},
   ): Promise<void> {
+    const responseStartedAt = this.now();
+    let firstModelTextAt: number | null = null;
     const abort = new AbortController();
     this.llmAbort = abort;
     const phrase = new PhraseAggregator({
@@ -851,6 +853,20 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
       const callbacks: RealtimeTtsStreamCallbacks = {
         onFirstAudio: () => {
           if (this.currentVoiceTurnId !== traceId) return;
+          const firstAudioAt = this.now();
+          logger.info("[voice-session] first-turn latency", {
+            traceId,
+            transcriptChars: transcript.length,
+            firstModelTextMs:
+              firstModelTextAt === null
+                ? null
+                : firstModelTextAt - responseStartedAt,
+            firstAudioMs: firstAudioAt - responseStartedAt,
+            ttsAfterFirstTextMs:
+              firstModelTextAt === null
+                ? null
+                : firstAudioAt - firstModelTextAt,
+          });
           this.state = "speaking";
           this.send({ t: "speaking_start", traceId });
         },
@@ -918,6 +934,7 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
         if (this.currentVoiceTurnId !== traceId) return;
         if (!this.firstLlmTextEmitted) {
           this.firstLlmTextEmitted = true;
+          firstModelTextAt = this.now();
           this.send({ t: "llm_first_text", traceId });
         }
         // Cartesia closes a synthesis context via the FINAL non-empty phrase
@@ -964,6 +981,13 @@ export class VoiceSession implements LiveVoiceSession, VoiceSessionLike {
           ) {
             throw error;
           }
+          logger.info("[voice-session] retrying cold response turn", {
+            traceId,
+            attempt,
+            retryDelayMs: retryDelay,
+            upstreamCode: bridgeError.upstreamCode,
+            elapsedMs: this.now() - responseStartedAt,
+          });
           await new Promise<void>((resolve) => {
             const timeout = setTimeout(resolve, retryDelay);
             abort.signal.addEventListener(

--- a/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
+++ b/packages/cloud/api/v1/voice/session/lib/voice-agent-scope-hydration.ts
@@ -11,6 +11,7 @@ import { userCharactersRepository } from "@/db/repositories/characters";
 import { cache } from "@/lib/cache/client";
 import { CacheKeys, CacheTTL } from "@/lib/cache/keys";
 import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
+import { warmInferenceAdmissionGate } from "@/lib/services/inference-admission-gate";
 import { warmInferenceAdmissionSnapshot } from "@/lib/services/inference-admission-snapshot";
 import { coordinateSharedConversationPrewarm } from "@/lib/services/shared-runtime/conversation-coordinator";
 import type { SharedRuntimeAgent } from "@/lib/services/shared-runtime/shared-runtime-agent";
@@ -22,6 +23,7 @@ export async function hydrateVoiceSharedAgentScope(
   env: Bindings,
   claims: InternalElizaConversationFetchClaims,
   preloadedAgent?: SharedRuntimeAgent,
+  options: { freshConversation?: boolean } = {},
 ): Promise<void> {
   await runWithCloudBindingsAsync(
     env as unknown as Record<string, unknown>,
@@ -128,13 +130,28 @@ export async function hydrateVoiceSharedAgentScope(
               });
             },
           ),
+          warmInferenceAdmissionGate(claims.organizationId).catch((error) => {
+            // error-policy:J7 a cold durable admission gate remains on the
+            // canonical fail-closed retry path if this latency prefill fails.
+            logger.warn(
+              "[voice-scope-hydration] admission gate prefill failed",
+              {
+                agentId: claims.agentId,
+                organizationId: claims.organizationId,
+                error: error instanceof Error ? error.message : String(error),
+              },
+            );
+          }),
         ];
         if (env.SHARED_RUNTIME_CONVERSATIONS) {
           optionalWarmups.push(
             coordinateSharedConversationPrewarm(
               claims.agentId,
               claims.conversationId,
-              { namespace: env.SHARED_RUNTIME_CONVERSATIONS },
+              {
+                namespace: env.SHARED_RUNTIME_CONVERSATIONS,
+                startEmpty: options.freshConversation === true,
+              },
             ).catch((error) => {
               // error-policy:J7 conversation hydration is a latency hint; the
               // real turn retains its typed cache-warming retry fallback.

--- a/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
@@ -345,6 +345,11 @@ function hydrateInferenceAdmissionGate(
   return hydration;
 }
 
+/** Hydrate an organization's durable admission gate before an interactive turn. */
+export async function warmInferenceAdmissionGate(organizationId: string): Promise<void> {
+  await hydrateInferenceAdmissionGate(organizationId, gateStub(organizationId));
+}
+
 function scheduleGateHydration(
   organizationId: string,
   stub: RuntimeDurableObjectStub,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -27,6 +27,8 @@ export interface SharedConversationCoordinatorOptions {
 
 export interface SharedConversationHistoryCoordinatorOptions {
   namespace: RuntimeDurableObjectNamespace;
+  /** A newly minted room has no legacy history and can skip Postgres migration. */
+  startEmpty?: boolean;
 }
 
 export interface SharedConversationLifecycleEvent {
@@ -71,7 +73,12 @@ export async function coordinateSharedConversationPrewarm(
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ operation: "prewarm", agentId, roomId }),
+      body: JSON.stringify({
+        operation: "prewarm",
+        agentId,
+        roomId,
+        startEmpty: options.startEmpty === true,
+      }),
     },
   );
   await requireCoordinatorResponse(response, "conversation prewarm");


### PR DESCRIPTION
## Summary
- initialize newly minted phone-call rooms without a pointless legacy history query
- hydrate the inference admission Durable Object during voice prewarm
- add STT-final to model-text and first-audio timing telemetry

The develop branch already uses persistent personal conversations, so it retains history migration semantics and receives the admission warmup plus timing telemetry.

## Verification
- voice prewarm tests: 2 passed
- voice scope hydration tests: 7 passed
- shared conversation tests: 16 passed
- voice WebSocket lifecycle tests: 58 passed
- cloud API typecheck and Worker dry-run passed