### PR TITLE
chore(scripts): remove stale env-layers.test.mjs exclusion that outlived its merged repair (#19803)

### DIFF
--- a/packages/scripts/__tests__/audit-scripts-inventory.test.ts
+++ b/packages/scripts/__tests__/audit-scripts-inventory.test.ts
@@ -128,11 +128,6 @@ describe("script inventory: packages/app surface (issue #10200)", () => {
         reason:
           "2/24 tests parse docs/testing/hitl-identity-slots.md, deleted from the tree; lifeops-owner repair tracked in #19448",
       },
-      {
-        file: "scripts/lifeops/env-layers.test.mjs",
-        reason:
-          "1/14 tests pin a stale layered-env consumer list; lifeops-owner repair tracked in #19448",
-      },
     ]);
     expect(inv.summary.totalScriptTests).toBe(inv.scriptTests.discoveredCount);
   });

--- a/packages/scripts/__tests__/script-test-inventory.test.ts
+++ b/packages/scripts/__tests__/script-test-inventory.test.ts
@@ -923,11 +923,6 @@ jobs:
         reason:
           "2/24 tests parse docs/testing/hitl-identity-slots.md, deleted from the tree; lifeops-owner repair tracked in #19448",
       },
-      {
-        file: "scripts/lifeops/env-layers.test.mjs",
-        reason:
-          "1/14 tests pin a stale layered-env consumer list; lifeops-owner repair tracked in #19448",
-      },
     ]);
     expect(
       result.files.some(

--- a/packages/scripts/lib/script-test-inventory.mjs
+++ b/packages/scripts/lib/script-test-inventory.mjs
@@ -64,10 +64,6 @@ export const SCRIPT_TEST_EXCLUSIONS = new Map([
     "scripts/lifeops/connector-paths.test.mjs",
     "2/24 tests parse docs/testing/hitl-identity-slots.md, deleted from the tree; lifeops-owner repair tracked in #19448",
   ],
-  [
-    "scripts/lifeops/env-layers.test.mjs",
-    "1/14 tests pin a stale layered-env consumer list; lifeops-owner repair tracked in #19448",
-  ],
 ]);
 
 function compareText(left, right) {


### PR DESCRIPTION
# Relates to

Closes #19803. Discharges the removal contract recorded in PR #19498
(*"Once this repair lands, its exclusion for `scripts/lifeops/env-layers.test.mjs`
must be removed."*). The issue reporter posted a self-claim on #19803 but never
opened a PR (verified via `gh pr list`); this treats that claim as stale and
acknowledges it here.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` attempted after sync; it is blocked on this machine by an
      environment `minimumReleaseAge` policy for unrelated recently-published
      deps (`pg@^8.23.0`, `smthrs@0.34.0`) — see **Known gaps / failures**. The
      focused package suites, the real inventory builder, Biome check, and the
      previously-excluded suite were all run and are recorded below.
- [x] A reviewer can confirm the change works from the transcripts attached
      below without reading the code.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a06854fd66217b25b23def810734ac8b77208de2:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`5fde9ff885`); zero conflicts.
- [ ] `bun run verify` could not run fully — `bun install` is blocked by the
      machine's `minimumReleaseAge` supply-chain policy on unrelated recent
      dependency versions. The relevant lane suites were run directly instead;
      see **Known gaps / failures**.

# Risks

Low. The change removes a single stale exclusion entry and its two mirrored test
expectations. The only behavioral effect is that the required `test:scripts`
lane now executes `scripts/lifeops/env-layers.test.mjs` (already passing 14/14).
No production/runtime code is touched.

# Background

## What does this PR do?

The `SCRIPT_TEST_EXCLUSIONS` map in
`packages/scripts/lib/script-test-inventory.mjs` still excluded
`scripts/lifeops/env-layers.test.mjs` from the required `test:scripts` CI lane.
That exclusion existed only because one test in the suite pinned a stale
layered-env consumer list. PR #19498 repaired the suite in place — the failing
test was rewritten to *"surviving HITL consumers import the shared layered env
module"* — so the whole suite (14/14) now passes. The exclusion machinery's
invariant is that an entry exists **iff** its repair is unmerged, so this stale
entry made the required lane silently skip a passing suite.

This PR removes only the `env-layers.test.mjs` entry from three places that pin
it:

1. `packages/scripts/lib/script-test-inventory.mjs` — the `SCRIPT_TEST_EXCLUSIONS`
   map (key + reason).
2. `packages/scripts/__tests__/script-test-inventory.test.ts` — the
   `result.excluded` expectation.
3. `packages/scripts/__tests__/audit-scripts-inventory.test.ts` — the
   `inv.scriptTests.excluded` expectation.

The `federated-agent-charter-conformance` (#19517), `connector-paths` (#19523),
and permanent `release-verdaccio` exclusions are deliberately left untouched.
Result: excluded count drops 4 → 3 and `env-layers.test.mjs` now flows into the
executing lane.

## What kind of change is this?

Improvements (removes a stale CI-lane exclusion; restores required coverage).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Run the two inventory suites and the previously-excluded suite from repo root;
the diff is 14 deletions across 3 files.

## Detailed testing steps

```bash
bun test packages/scripts/__tests__/script-test-inventory.test.ts
bun test packages/scripts/__tests__/audit-scripts-inventory.test.ts
bun test scripts/lifeops/env-layers.test.mjs
```

# Evidence Gate

<!-- evidence-head:0c0112f89d02997cd5a196b3d44d22db5ddab3dd -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI surface; scripts-only exclusion-map and test-expectation change.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI surface; scripts-only exclusion-map and test-expectation change.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow; CI-lane inventory change proven by test transcripts in the PR body.
<!-- evidence-row:backend-logs -->
- [ ] N/A - scripts-only change with no server runtime; real lane/inventory transcripts are in the PR body Evidence Details.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend; scripts-only change.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the computed inventory is shown inline in the PR body (excluded 4->3, env-layers in executing lane).
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

Scripts-only change; no server/frontend runtime. The evidence below is the real
test-lane and inventory-builder output.

**Diff scope (exactly one exclusion entry removed, 3 files):**

```
$ git diff origin/develop --stat
 packages/scripts/__tests__/audit-scripts-inventory.test.ts | 5 -----
 packages/scripts/__tests__/script-test-inventory.test.ts   | 5 -----
 packages/scripts/lib/script-test-inventory.mjs             | 4 ----
 3 files changed, 14 deletions(-)
```

<details><summary>(a) both inventory suites pass with the edited expected arrays</summary>

```
$ bun test packages/scripts/__tests__/script-test-inventory.test.ts
 15 pass
 0 fail
 643 expect() calls
Ran 15 tests across 1 file. [1077.00ms]

$ bun test packages/scripts/__tests__/audit-scripts-inventory.test.ts
 14 pass
 0 fail
 291 expect() calls
Ran 14 tests across 1 file. [7.64s]

# combined re-run on the rebased head (0c0112f8):
$ bun test packages/scripts/__tests__/script-test-inventory.test.ts packages/scripts/__tests__/audit-scripts-inventory.test.ts
(pass) packages/scripts executable-test inventory > the real repository has one executing lane for every discovered test [102.47ms]
 29 pass
 0 fail
Ran 29 tests across 2 files. [7.59s]
```

</details>

<details><summary>(b) the previously-excluded suite now passes 14/14 on the runtime the lane uses (bun)</summary>

```
$ bun test scripts/lifeops/env-layers.test.mjs
(pass) parseDotenv handles comments, export prefix, quotes, and CRLF
(pass) mergeEnvLayers: first (highest-precedence) definition wins, sources attributed
(pass) upsertEnvContent replaces in place, preserves comments, appends new keys
(pass) upsertEnvContent on empty text emits just the entries
(pass) loadLayeredEnv merges process > repo > home and reports layers
(pass) loadLayeredEnv: missing files are graceful
(pass) applyLayeredEnvToProcess hydrates only keys the process does not define
(pass) fresh linked worktree with empty repo .env uses home-scoped secrets, not main checkout .env
(pass) listPresent attributes each source and never returns values
(pass) writeSecret creates the home file with mode 600 and upserts on re-save
(pass) writeSecret writes the repo layer when scoped
(pass) saveEnvVar remains a compatibility wrapper for existing dashboard callers
(pass) writeSecret rejects invalid keys, multi-line values, and bad scopes
(pass) surviving HITL consumers import the shared layered env module
 14 pass
 0 fail
Ran 14 tests across 1 file. [300.00ms]
```

</details>

<details><summary>(c) real inventory builder: excluded 4→3, discoveredCount up by 1, env-layers now in the executing lane</summary>

```
$ node -e 'import("./packages/scripts/lib/script-test-inventory.mjs").then((m) => { const inv = m.buildScriptTestInventory(); ... })'
discoveredCount: 185
excludedCount: 3
env-layers in executing files: true
env-layers in excluded: false
excluded files: [
  'packages/scripts/__tests__/release-verdaccio.integration.test.ts',
  'scripts/federated-agent-charter-conformance.test.mjs',
  'scripts/lifeops/connector-paths.test.mjs'
]
```

Note: the inventory's `discoveredCount` counts *executing* files, so it rises by
exactly 1 (the newly-included `env-layers.test.mjs`); the three inventory-suite
assertions guard `discoveredCount > 90`, which still holds. The other three
exclusions (`release-verdaccio`, `federated-agent-charter-conformance`,
`connector-paths`) are unchanged.

</details>

<details><summary>Biome lint on the three changed files (2.5.7, cached CLI)</summary>

```
$ biome check packages/scripts/lib/script-test-inventory.mjs \
    packages/scripts/__tests__/script-test-inventory.test.ts \
    packages/scripts/__tests__/audit-scripts-inventory.test.ts
Checked 3 files in 71ms. No fixes applied.
```

</details>

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI surface.`

### After

`N/A - no UI surface.`

### Walkthrough video

`N/A - no user-facing flow; CI-lane change proven by transcripts above.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Known gaps / failures

- `bun install` and the full `bun run verify` gate could **not** run on this
  machine: an environment-level `minimumReleaseAge` (604800s) supply-chain
  policy blocks unrelated recently-published dependency versions
  (`pg@^8.23.0`, `smthrs@0.34.0`), which aborts the workspace install. This is
  a machine policy, not a defect introduced by this PR, and is unrelated to the
  scripts inventory change. To run the affected suites I provisioned only the
  needed, already-cached, long-established dependencies (`yaml@2.9.0`,
  `saxes@6.0.0`, `xmlchars@2.2.0`, `typescript@6.0.3`) from the local Bun cache
  and ran the lane suites directly (transcripts above). A CI runner with an
  unrestricted install will execute `bun run verify` normally.
- Full-repo `typecheck`/`lint:check` via Turbo require the complete workspace
  install (same blocker). The change is a pure array-element deletion with no
  type-surface change; Biome `check` passes on all three files (above).

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@a06854fd66217b25b23def810734ac8b77208de2:packages/skills/skills/contribute-to-eliza"} -->

