### PR TITLE
fix(ci): order edge builds before typecheck (#19812)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -243,10 +243,15 @@
       "outputs": []
     },
     "@elizaos/cloud-api#typecheck": {
+      "dependsOn": ["@elizaos/cloud-shared#typecheck"],
       "outputs": []
     },
     "@elizaos/cloud-shared#typecheck": {
-      "dependsOn": ["@elizaos/plugin-cloud-apps#build"],
+      "dependsOn": [
+        "@elizaos/plugin-cloud-apps#build",
+        "@elizaos/plugin-scheduling#build",
+        "@elizaos/plugin-web-search#build"
+      ],
       "outputs": []
     },
     "@elizaos/plugin-discord#typecheck": {
@@ -254,7 +259,7 @@
       "outputs": []
     },
     "@elizaos/plugin-calendar#typecheck": {
-      "dependsOn": [],
+      "dependsOn": ["@elizaos/plugin-scheduling#build"],
       "outputs": []
     },
     "@elizaos/plugin-personal-assistant#typecheck": {


### PR DESCRIPTION
# Relates to

Fixes #19812.

- [x] Targets develop and is rebased onto origin/develop 3c3ad0c9a0bb6fedae259f1beb944b7ca48c6960 with zero conflicts.
- [x] bun install --frozen-lockfile completed after sync.
- [x] A reviewer can verify the clean dependency graph from the commands below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: OpenAI/gpt-5
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@598190498d2d67f045082faf3382160b39991759:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto origin/develop 3c3ad0c9a0bb6fedae259f1beb944b7ca48c6960; zero conflicts.
- [ ] Full bun run verify currently reaches and fails an unrelated UI fixture type error introduced by merged #19754; that defect is being repaired separately. The affected clean Turbo subgraph is green.

# Risks

Low. This changes only Turbo ordering for three existing typecheck overrides. It does not change runtime code. cloud-api is serialized behind cloud-shared typecheck so the shared package owns and proves its edge dependencies before the recursive consumer check begins.

# Background

## What does this PR do?

- Makes cloud-shared typecheck wait for the three directly declared package builds whose exported declarations its source consumes.
- Makes cloud-api typecheck wait for cloud-shared typecheck, preserving the ownership boundary instead of adding phantom transitive build edges.
- Makes calendar typecheck wait for its declared scheduling dependency build.

## What kind of change is this?

Bug fix to clean-checkout CI orchestration.

# Documentation changes needed?

No. The repository dependency graph is the executable contract.

# Testing

## Where should a reviewer start?

Review turbo.json task overrides and issue #19812.

## Detailed testing steps

1. Remove generated dist output for core, plugin-scheduling, and plugin-web-search with packages/scripts/rm-path-recursive.mjs.
2. Run node packages/scripts/audit-turbo-build-deps.mjs.
3. Run node packages/scripts/run-turbo.mjs run typecheck --filter=@elizaos/cloud-api --filter=@elizaos/plugin-calendar --concurrency=8 --force.
4. Confirm all 11 tasks pass from a clean producer state, including calendar, cloud-shared, cloud-api, and the Worker bundle dry-run.

Observed post-rebase: 11 successful, 11 total; clean forced run completed successfully.

# Evidence Gate

<!-- evidence-head:997fe264bd49c9e028cb63380ac32af1624b48ca -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI orchestration has no rendered surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI orchestration has no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow changed.
<!-- evidence-row:backend-logs -->
- [x] The forced Turbo output records producer builds completing before consumer typechecks and all 11 tasks passing.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database or persistent domain state changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model behavior changed.

## Backend + frontend logs

The clean forced subgraph produced 11 successful tasks, including the cloud-api Wrangler production dry-run.

## Screenshots (before / after) + video walkthrough

N/A - configuration-only change.

## Audio / voice walkthrough

N/A - no audio path changed.

## Known gaps / failures

Full bun run verify reaches an unrelated TypeScript error in packages/ui/src/first-run/use-first-run-conductor.test.ts:304. Merged PR #19754 left a stale getPersonalSharedEliza mock result containing created, immediately followed by the correct personal-Eliza result. This PR does not touch UI; a focused corrective PR is being prepared so the repository-wide gate can become green.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@598190498d2d67f045082faf3382160b39991759:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-pr-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex desktop","skill_revision":"elizaOS/eliza@598190498d2d67f045082faf3382160b39991759:packages/skills/skills/contribute-to-eliza"} -->