### PR TITLE
fix(plugin-calendar): the day the user named wins, for lookups and creates

### DIFF
--- a/plugins/plugin-calendar/src/actions/calendar-handler.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.ts
@@ -529,6 +529,23 @@ function isRecurringCalendarEvent(event: LifeOpsCalendarEvent | null): boolean {
   return Boolean(recurringEventIdFrom(event) || recurrenceLinesFrom(event));
 }
 
+/**
+ * An RFC 5545 recurrence line, by shape. The planner smears whatever string it
+ * has on hand into unrelated fields — a plain "add grindlewald standup on
+ * friday at 10am" arrived with the TITLE in `recurrence`, and `parseRecurrenceRule`
+ * threw `Invalid recurrence rule: malformed part "grindlewald standup"`, failing
+ * the whole create for a repetition the user never asked for (live 2026-08-14).
+ *
+ * Validation downstream is correct and stays; the job here is to not hand it
+ * debris. Same stance as the recurrenceScope guard: a junk value means the
+ * field was never set, not that the request is invalid.
+ */
+function looksLikeRecurrenceLine(line: string): boolean {
+  return (
+    /^(?:RRULE|RDATE|EXDATE|EXRULE)[:;]/i.test(line) || /FREQ=/i.test(line)
+  );
+}
+
 function detailRecurrenceLines(
   details: Record<string, unknown> | undefined,
   key = "recurrence",
@@ -537,19 +554,16 @@ function detailRecurrenceLines(
     return undefined;
   }
   const value = details[key];
-  if (typeof value === "string" && value.trim().length > 0) {
-    return [value.trim()];
-  }
-  if (Array.isArray(value)) {
-    const lines = value
-      .filter(
-        (line): line is string =>
-          typeof line === "string" && line.trim().length > 0,
-      )
-      .map((line) => line.trim());
-    return lines.length > 0 ? lines : undefined;
-  }
-  return undefined;
+  const raw =
+    typeof value === "string"
+      ? [value]
+      : Array.isArray(value)
+        ? value.filter((line): line is string => typeof line === "string")
+        : [];
+  const lines = raw
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && looksLikeRecurrenceLine(line));
+  return lines.length > 0 ? lines : undefined;
 }
 
 function buildRecurrenceScopeClarification(args: {
@@ -1121,6 +1135,28 @@ async function finalizeCalendarPlan(args: {
   };
 }
 
+/**
+ * Whether notifying attendees is meaningful for this event at all.
+ *
+ * The outer planner stamps `notifyAttendees: true` onto ordinary mutations —
+ * "cancel my zorblax checkup" arrived with it set, on a solo event with no
+ * attendees. The built-in calendar has no mail path and rejects the flag with a
+ * 400, so a plain cancel died on a field the user never asked for and the reply
+ * claimed the event could not be found (live capture 2026-08-14).
+ *
+ * Same shape as the recurrenceScope guard beside it: honor the flag only when
+ * the resolved target can actually act on it. Notifying nobody is a no-op, not
+ * a conflict.
+ */
+function shouldNotifyAttendees(
+  details: Record<string, unknown> | undefined,
+  targetEvent: { attendees?: unknown } | undefined,
+): boolean {
+  if (detailBoolean(details, "notifyAttendees") !== true) return false;
+  const attendees = targetEvent?.attendees;
+  return Array.isArray(attendees) && attendees.length > 0;
+}
+
 function buildCalendarServiceErrorFallback(
   error: CalendarServiceError,
   intent: string,
@@ -1128,6 +1164,18 @@ function buildCalendarServiceErrorFallback(
   const normalized = normalizeText(error.message);
   if (error.code === "CALENDAR_APPROVAL_GATEWAY_UNAVAILABLE") {
     return "Calendar changes are unavailable because the owner-approval gateway is not running. I did not change the calendar.";
+  }
+  // A permanent capability boundary, not a transient failure: the built-in
+  // calendar has no recurrence engine. The generic copy invited a retry that
+  // can only fail again ("couldn't add that weekly standup … try again." —
+  // live capture), so name the boundary and the one action that lifts it.
+  // Reached only when the event really does have attendees; a spurious flag on
+  // a solo event is dropped before the service call (see shouldNotifyAttendees).
+  if (error.code === "ELIZA_CALENDAR_ATTENDEE_NOTIFICATIONS_UNSUPPORTED") {
+    return "The built-in calendar can't email the other attendees, so I left that one alone. Connect Google Calendar and I'll send the update, or say go ahead without notifying anyone.";
+  }
+  if (error.code === "ELIZA_CALENDAR_RECURRENCE_UNSUPPORTED") {
+    return "Repeating events need a connected calendar — the built-in one only holds single events. Connect Google Calendar and I'll set up the recurring one, or I can add a single event now.";
   }
   if (
     error.code === "CALENDAR_MUTATION_CONTEXT_INCOMPLETE" ||
@@ -1215,10 +1263,21 @@ export function buildCalendarEventDisambiguationFallback(args: {
   action: "update" | "delete";
   candidates: LifeOpsCalendarEvent[];
   titleHint?: string;
+  /**
+   * Zone the candidate times are listed in. Each event otherwise renders in its
+   * own provider zone, so one question mixed "11am pdt" with "1pm utc" (live
+   * capture) and the owner could not tell which appointment was earlier. An
+   * all-day event keeps its own zone: its value is a calendar date, and
+   * re-reading it elsewhere can shift the day.
+   */
+  timeZone?: string;
 }): string {
   const previewLines = args.candidates.slice(0, 3).map((candidate) => {
     const when = formatCalendarEventDateTime(candidate, {
       includeTimeZoneName: true,
+      ...(args.timeZone && !candidate.isAllDay
+        ? { timeZone: args.timeZone }
+        : {}),
     });
     return `- ${candidate.title} (${when})`;
   });
@@ -1819,6 +1878,117 @@ function compareLocalDates(left: LocalDateOnly, right: LocalDateOnly): number {
   return left.day - right.day;
 }
 
+/**
+ * A day word in a mutation request plays one of two roles: it says WHICH event
+ * ("cancel my haircut on friday") or, for an update only, WHERE the event is
+ * going ("move my haircut to friday 2pm"). Only the first role identifies a
+ * target, and English marks the second with a "to" head, so an update's
+ * target-scoped text stops at the first such marker. A delete has no
+ * destination, so all of its text is target-scoped.
+ *
+ * Dropping too much only costs a narrowing opportunity (the handler falls back
+ * to asking, today's behavior); keeping a destination date would retarget the
+ * mutation, so the split is deliberately eager.
+ */
+const CALENDAR_DESTINATION_CLAUSE_PATTERN = /\bto\b/i;
+
+function resolveTargetScopedText(
+  action: "update" | "delete",
+  text: string,
+): string {
+  if (action === "delete") {
+    return text;
+  }
+  const marker = text.search(CALENDAR_DESTINATION_CLAUSE_PATTERN);
+  return marker === -1 ? text : text.slice(0, marker);
+}
+
+/**
+ * The calendar day the user themselves named for the event being mutated, or
+ * null when they named none.
+ *
+ * Live symptom: "cancel my haircut on friday" and "change my haircut on
+ * saturday to 2pm" both answered "found two haircuts … which one?" even though
+ * the user's own words selected exactly one. The mutation branches look events
+ * up across a −1y…+5y window whenever the planner emits no timeMin/timeMax, and
+ * candidates were then filtered by fuzzy title alone, so the stated day — which
+ * the read path already resolves deterministically via
+ * `resolveExplicitCalendarDateWindow` — never reached target resolution.
+ */
+function resolveStatedTargetLocalDate(args: {
+  action: "update" | "delete";
+  texts: (string | undefined)[];
+  timeZone: string;
+}): LocalDateOnly | null {
+  for (const text of args.texts) {
+    if (!text || text.trim().length === 0) {
+      continue;
+    }
+    const scoped = resolveTargetScopedText(args.action, text);
+    const parsed = parseExplicitLocalDate(scoped, args.timeZone);
+    if (parsed) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function calendarEventLocalDate(
+  event: LifeOpsCalendarEvent,
+  timeZone: string,
+): LocalDateOnly {
+  // An all-day event carries a calendar date rather than an instant (see the
+  // all-day occurrence identity in CalendarService), so reading it in another
+  // zone can shift it a day; timed events are compared in the requester's zone
+  // because that is the frame the user said "friday" in.
+  const readZone = (event.isAllDay ? event.timezone : "") || timeZone;
+  const parts = getZonedDateParts(new Date(event.startAt), readZone);
+  return { year: parts.year, month: parts.month, day: parts.day };
+}
+
+/**
+ * The single target-resolution chokepoint for update_event and delete_event:
+ * fuzzy title match, then the day the user actually stated.
+ *
+ * The date pass only ever runs on an already-ambiguous set and only when it
+ * keeps at least one candidate, so it can turn "which one?" into a resolved
+ * target but can never turn a match into a not-found or retarget a unique
+ * match.
+ */
+function resolveCalendarMutationCandidates(args: {
+  action: "update" | "delete";
+  events: LifeOpsCalendarEvent[];
+  titleHint: string | undefined;
+  texts: (string | undefined)[];
+  timeZone: string;
+}): LifeOpsCalendarEvent[] {
+  const titleHint = args.titleHint;
+  const byTitle = titleHint
+    ? args.events.filter((event) =>
+        normalizeText(event.title).includes(normalizeText(titleHint)),
+      )
+    : args.events;
+  if (byTitle.length < 2) {
+    return byTitle;
+  }
+  const statedDate = resolveStatedTargetLocalDate({
+    action: args.action,
+    texts: args.texts,
+    timeZone: args.timeZone,
+  });
+  if (!statedDate) {
+    return byTitle;
+  }
+  const onStatedDate = byTitle.filter(
+    (event) =>
+      compareLocalDates(
+        calendarEventLocalDate(event, args.timeZone),
+        statedDate,
+      ) === 0,
+  );
+  return onStatedDate.length > 0 ? onStatedDate : byTitle;
+}
+
 function resolveCreateEventCalendarTimeZone(
   details: Record<string, unknown> | undefined,
   feed: LifeOpsCalendarFeed | null | undefined,
@@ -1991,6 +2161,70 @@ function chooseSuggestedCreateEventMinute(args: {
   }
 
   return null;
+}
+
+/**
+ * The calendar day the user themselves named for a NEW event outranks the
+ * planner's date arithmetic. Live symptom: "put coffee with dana on my
+ * calendar sunday at 10am", asked on a Saturday, arrived with a startAt on
+ * Monday — the model's weekday math slipped while the user's own word did
+ * not. When the message (or intent) parses to an explicit local date and the
+ * resolved start lands on a different local day, shift start and end onto the
+ * stated day, preserving wall-clock time and duration. No stated date, or a
+ * matching one, changes nothing — a correct planner is a no-op here.
+ */
+function applyStatedDateToCreateRequest(args: {
+  request: CreateLifeOpsCalendarEventRequest;
+  currentMessage: string;
+  intent: string;
+  timeZone: string;
+}): { corrected: boolean; fromLocalDate?: string; toLocalDate?: string } {
+  const startAtIso = args.request.startAt;
+  if (!startAtIso) {
+    return { corrected: false };
+  }
+  const startDate = new Date(startAtIso);
+  if (Number.isNaN(startDate.getTime())) {
+    return { corrected: false };
+  }
+  const stated =
+    parseExplicitLocalDate(args.currentMessage, args.timeZone) ??
+    parseExplicitLocalDate(args.intent, args.timeZone);
+  if (!stated) {
+    return { corrected: false };
+  }
+  const startParts = getZonedDateParts(startDate, args.timeZone);
+  if (
+    startParts.year === stated.year &&
+    startParts.month === stated.month &&
+    startParts.day === stated.day
+  ) {
+    return { corrected: false };
+  }
+  const shifted = buildUtcDateFromLocalParts(args.timeZone, {
+    year: stated.year,
+    month: stated.month,
+    day: stated.day,
+    hour: startParts.hour,
+    minute: startParts.minute,
+    second: startParts.second,
+  });
+  const deltaMs = shifted.getTime() - startDate.getTime();
+  args.request.startAt = shifted.toISOString();
+  if (typeof args.request.endAt === "string") {
+    const endDate = new Date(args.request.endAt);
+    if (!Number.isNaN(endDate.getTime())) {
+      args.request.endAt = new Date(
+        endDate.getTime() + deltaMs,
+      ).toISOString();
+    }
+  }
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return {
+    corrected: true,
+    fromLocalDate: `${startParts.year}-${pad(startParts.month)}-${pad(startParts.day)}`,
+    toLocalDate: `${stated.year}-${pad(stated.month)}-${pad(stated.day)}`,
+  };
 }
 
 function suggestCreateEventStartAt(args: {
@@ -3843,7 +4077,26 @@ const calendarAction: CalendarHandlerAction = {
         detailString(details, "windowPreset") ||
         detailNumber(details, "windowDays"),
     );
+    const llmPlanMutationSubaction =
+      llmPlan.subaction === "create_event" ||
+      llmPlan.subaction === "update_event" ||
+      llmPlan.subaction === "delete_event"
+        ? llmPlan.subaction
+        : null;
+    const explicitReadHint =
+      explicitSubaction === "feed" ||
+      explicitSubaction === "next_event" ||
+      explicitSubaction === "search_events";
+    // The caller's subaction param is a routing-level hint from the outer
+    // planner, which has no calendar instructions; the internal plan is the
+    // domain decision made with the full conversation. A read hint must not
+    // downgrade a planned mutation — the mutation branches run their own
+    // candidate resolution and confirmation gates, so honoring the plan is
+    // safe, while honoring the hint silently no-ops a confirmed request.
     const subaction =
+      (explicitReadHint && llmPlanMutationSubaction
+        ? llmPlanMutationSubaction
+        : null) ??
       explicitSubaction ??
       llmPlan.subaction ??
       (tripWindowIntent ? "trip_window" : null) ??
@@ -4029,6 +4282,15 @@ const calendarAction: CalendarHandlerAction = {
         });
         const { title, resolvedStartAt, resolvedWindowPreset, request } =
           createEventBuild;
+        const statedDateCorrection = applyStatedDateToCreateRequest({
+          request,
+          currentMessage: messageText(message).trim(),
+          intent,
+          timeZone:
+            request.timeZone ??
+            calendarContext.calendarTimeZone ??
+            planningTimeZone,
+        });
         const travelIntent = createEventBuild.travelIntent;
         if (!title) {
           return respond({
@@ -4249,11 +4511,13 @@ const calendarAction: CalendarHandlerAction = {
             }),
             "update",
           );
-          const candidates = titleHint
-            ? feed.events.filter((e) =>
-                normalizeText(e.title).includes(normalizeText(titleHint)),
-              )
-            : feed.events;
+          const candidates = resolveCalendarMutationCandidates({
+            action: "update",
+            events: feed.events,
+            titleHint,
+            texts: [messageText(message), intent],
+            timeZone: resolveCalendarTimeZone(details),
+          });
           if (candidates.length === 0) {
             const fallback = buildCalendarEventNotFoundFallback(
               "update",
@@ -4278,6 +4542,7 @@ const calendarAction: CalendarHandlerAction = {
               action: "update",
               candidates,
               titleHint,
+              timeZone: resolveCalendarTimeZone(details),
             });
             return respond({
               success: false,
@@ -4388,6 +4653,11 @@ const calendarAction: CalendarHandlerAction = {
           fallbackDetails: extractedForUpdate,
           text: `${messageText(message)} ${intent}`,
         });
+        if (!recurrenceScopeForUpdate) {
+          recurrenceScopeForUpdate = lenientRecurrenceScope(
+            extractedForUpdate.recurrenceScope,
+          );
+        }
         // A recurrence-rule change is inherently a series edit.
         if (recurrenceUpdate && !recurrenceScopeForUpdate) {
           recurrenceScopeForUpdate = "series";
@@ -4457,8 +4727,14 @@ const calendarAction: CalendarHandlerAction = {
             targetEvent?.timezone ??
             undefined,
           recurrence: recurrenceUpdate,
-          recurrenceScope: recurrenceScopeForUpdate ?? undefined,
-          notifyAttendees: detailBoolean(details, "notifyAttendees") === true,
+          // Honor a scope only when the target recurs or the update itself
+          // introduces a recurrence rule — the planner emits junk scopes.
+          recurrenceScope:
+            recurrenceScopeForUpdate &&
+            (isRecurringCalendarEvent(targetEvent) || recurrenceUpdate)
+              ? recurrenceScopeForUpdate
+              : undefined,
+          notifyAttendees: shouldNotifyAttendees(details, targetEvent),
         };
         if (targetEvent.provider === ELIZA_CALENDAR_PROVIDER) {
           const expectedProviderVersion = targetEvent.metadata.etag;
@@ -4520,8 +4796,8 @@ const calendarAction: CalendarHandlerAction = {
             approvalState: approval.state,
             request: updateRequest,
             targetEvent,
-            ...(recurrenceScopeForUpdate
-              ? { recurrenceScope: recurrenceScopeForUpdate }
+            ...(updateRequest.recurrenceScope
+              ? { recurrenceScope: updateRequest.recurrenceScope }
               : {}),
           },
         });
@@ -4572,11 +4848,13 @@ const calendarAction: CalendarHandlerAction = {
             }),
             "delete",
           );
-          const candidates = titleHint
-            ? feed.events.filter((e) =>
-                normalizeText(e.title).includes(normalizeText(titleHint)),
-              )
-            : feed.events;
+          const candidates = resolveCalendarMutationCandidates({
+            action: "delete",
+            events: feed.events,
+            titleHint,
+            texts: [messageText(message), intent],
+            timeZone: resolveCalendarTimeZone(details),
+          });
           if (candidates.length === 0) {
             const fallback = buildCalendarEventNotFoundFallback(
               "delete",
@@ -4602,6 +4880,7 @@ const calendarAction: CalendarHandlerAction = {
               action: "delete",
               candidates,
               titleHint,
+              timeZone: resolveCalendarTimeZone(details),
             });
             return respond({
               success: false,
@@ -4696,10 +4975,12 @@ const calendarAction: CalendarHandlerAction = {
           grantId,
           calendarId: targetEvent.calendarId,
           eventId: targetEvent.externalId,
-          ...(recurrenceScopeForDelete
+          // The outer planner stuffs a junk recurrenceScope into every call;
+          // a scope is only meaningful when the resolved target recurs.
+          ...(recurrenceScopeForDelete && isRecurringCalendarEvent(targetEvent)
             ? { recurrenceScope: recurrenceScopeForDelete }
             : {}),
-          notifyAttendees: detailBoolean(details, "notifyAttendees") === true,
+          notifyAttendees: shouldNotifyAttendees(details, targetEvent),
         };
         if (targetEvent.provider === ELIZA_CALENDAR_PROVIDER) {
           const expectedProviderVersion = targetEvent.metadata.etag;

--- a/plugins/plugin-calendar/src/internal/format.ts
+++ b/plugins/plugin-calendar/src/internal/format.ts
@@ -41,10 +41,18 @@ export function formatCalendarEventDateTime(
     includeYear?: boolean;
     includeTimeZoneName?: boolean;
     numericDate?: boolean;
+    /**
+     * Render in this zone instead of the event's own. Callers that list several
+     * events side by side pass one zone so the times are comparable: a mixed
+     * list read "friday aug 14 at 11am pdt and saturday aug 15 at 1pm utc"
+     * (live capture), which asks the owner to do timezone math to compare two
+     * of their own appointments.
+     */
+    timeZone?: string;
   },
 ): string {
   const start = new Date(event.startAt);
-  const timeZone = event.timezone || undefined;
+  const timeZone = options?.timeZone || event.timezone || undefined;
   const currentYear = getCalendarYearForDisplay(new Date(), timeZone);
   const eventYear = getCalendarYearForDisplay(start, timeZone);
   const includeYear = options?.includeYear ?? eventYear !== currentYear;

--- a/plugins/plugin-calendar/test/calendar-action-effect-receipts.test.ts
+++ b/plugins/plugin-calendar/test/calendar-action-effect-receipts.test.ts
@@ -655,6 +655,14 @@ describe("CALENDAR effect receipt settlement", () => {
   });
 
   it("uses timezone-grounded calendar extraction instead of a contradictory outer-planner instant", async () => {
+    // The fixture's extraction says "tomorrow" is Aug 5, which is only
+    // coherent when today is Aug 4 in the event's zone. The stated-day guard
+    // now enforces exactly that coherence at the create boundary, so an
+    // unpinned clock would (correctly) snap the fixture's date to the real
+    // tomorrow and the assertion would drift with the wall clock.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-08-04T19:00:00.000Z"));
+    try {
     const approval = {
       requestId: "calendar-timezone-approval",
       action: "schedule_event" as const,
@@ -738,6 +746,9 @@ describe("CALENDAR effect receipt settlement", () => {
       }),
     );
     expectBoundDelivery(delivered, result);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("reports an authoritative queue replay as a no-op", async () => {

--- a/plugins/plugin-calendar/test/calendar-mutation-stated-day.test.ts
+++ b/plugins/plugin-calendar/test/calendar-mutation-stated-day.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Regression coverage for target resolution on the CALENDAR mutation branches:
+ * a day the user themselves named must narrow the candidate set before the
+ * handler declares the request ambiguous.
+ *
+ * Live capture (2026-08-14): "cancel my haircut on friday" and "change my
+ * haircut on saturday to 2pm" both answered "found two haircuts: friday at 11am
+ * and saturday at 1pm — which one?", turning a one-turn mutation into two even
+ * though the user's own words selected exactly one event. The same reply mixed
+ * zones ("11am pdt" … "1pm utc") because each candidate rendered in its own
+ * provider zone.
+ *
+ * The CalendarService is stubbed (feed fixture + spied mutations) and the fake
+ * runtime has no `useModel`, so replies are the handler's canonical fallback
+ * strings and the planner contributes no time window — exactly the live shape,
+ * where the day survives only in the user's text. The clock is pinned so
+ * "friday"/"saturday" resolve deterministically.
+ */
+
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import type { LifeOpsCalendarEvent } from "@elizaos/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type CalendarActionDeps,
+  createCalendarActionRunner,
+} from "../src/index.js";
+
+/** Wednesday 2026-08-12, 05:00 in America/Los_Angeles. */
+const PINNED_NOW = new Date("2026-08-12T12:00:00.000Z");
+const OWNER_TIME_ZONE = "America/Los_Angeles";
+
+function event(args: {
+  externalId: string;
+  title: string;
+  startAt: string;
+  endAt: string;
+  timezone: string;
+}): LifeOpsCalendarEvent {
+  return {
+    id: `agent-1:google:owner:calendar:primary:${args.externalId}`,
+    externalId: args.externalId,
+    agentId: "agent-1",
+    provider: "google",
+    side: "owner",
+    calendarId: "primary",
+    title: args.title,
+    description: "",
+    location: "",
+    status: "confirmed",
+    startAt: args.startAt,
+    endAt: args.endAt,
+    isAllDay: false,
+    timezone: args.timezone,
+    htmlLink: null,
+    conferenceLink: null,
+    organizer: null,
+    attendees: [],
+    metadata: {},
+    syncedAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    grantId: "connector-account:acct-a",
+  };
+}
+
+/** Friday Aug 14, 11:00 AM PDT. */
+const HAIRCUT_FRIDAY = event({
+  externalId: "evt-fri",
+  title: "Haircut",
+  startAt: "2026-08-14T18:00:00.000Z",
+  endAt: "2026-08-14T18:30:00.000Z",
+  timezone: OWNER_TIME_ZONE,
+});
+
+/** Saturday Aug 15, 1:00 PM UTC — a second source, in a different zone. */
+const HAIRCUT_SATURDAY = event({
+  externalId: "evt-sat",
+  title: "Haircut",
+  startAt: "2026-08-15T13:00:00.000Z",
+  endAt: "2026-08-15T13:30:00.000Z",
+  timezone: "UTC",
+});
+
+function stubService(feedEvents: LifeOpsCalendarEvent[]) {
+  return {
+    getCalendarFeed: vi.fn(async () => ({
+      calendarId: "all",
+      events: feedEvents,
+      source: "cache" as const,
+      state: "complete" as const,
+      sources: [{ status: "fresh" as const }],
+      timeMin: "2025-08-12T00:00:00.000Z",
+      timeMax: "2031-08-12T00:00:00.000Z",
+      syncedAt: null,
+    })),
+    getConditionalCalendarMutationTarget: vi.fn(
+      async (_url: URL, request: { eventId: string }) =>
+        feedEvents.find(
+          (candidate) => candidate.externalId === request.eventId,
+        ) ?? HAIRCUT_FRIDAY,
+    ),
+    deleteCalendarEvent: vi.fn(async () => undefined),
+    updateCalendarEvent: vi.fn(async () => HAIRCUT_SATURDAY),
+    prepareCalendarEventCreate: vi.fn(
+      async (_url: URL, request: Record<string, unknown>) => request,
+    ),
+    scheduleApproval: vi.fn(async () => ({
+      requestId: "approval-schedule",
+      action: "schedule_event" as const,
+      state: "pending" as const,
+      acceptedAt: "2026-08-12T12:00:00.000Z",
+      idempotencyKey: "calendar-approval:schedule",
+      replayed: false,
+      text: "schedule approval queued",
+    })),
+    modifyApproval: vi.fn(async () => ({
+      requestId: "approval-modify",
+      action: "modify_event" as const,
+      state: "pending" as const,
+      acceptedAt: "2026-08-12T12:00:00.000Z",
+      idempotencyKey: "calendar-approval:modify",
+      replayed: false,
+      text: "modify approval queued",
+    })),
+    cancelApproval: vi.fn(async () => ({
+      requestId: "approval-cancel",
+      action: "cancel_event" as const,
+      state: "pending" as const,
+      acceptedAt: "2026-08-12T12:00:00.000Z",
+      idempotencyKey: "calendar-approval:cancel",
+      replayed: false,
+      text: "cancel approval queued",
+    })),
+  };
+}
+
+type StubService = ReturnType<typeof stubService>;
+
+function fakeDeps(service: StubService): CalendarActionDeps {
+  return {
+    runTextModel: vi.fn(async () => null),
+    runJsonModel: vi.fn(async () => null),
+    recentConversationTexts: vi.fn(async () => []),
+    mutationGateway: {
+      schedule: service.scheduleApproval,
+      modify: service.modifyApproval,
+      cancel: service.cancelApproval,
+    },
+  };
+}
+
+function fakeRuntime(service: StubService): IAgentRuntime {
+  return {
+    agentId: "agent-1",
+    logger: {
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+      debug: () => undefined,
+    },
+    getService: (name: string) => (name === "calendar" ? service : null),
+  } as unknown as IAgentRuntime;
+}
+
+function message(text: string): Memory {
+  return {
+    id: "00000000-0000-0000-0000-000000000201",
+    entityId: "00000000-0000-0000-0000-000000000202",
+    roomId: "00000000-0000-0000-0000-000000000203",
+    content: { text },
+  } as unknown as Memory;
+}
+
+async function runHandler(args: {
+  service: StubService;
+  text: string;
+  parameters: Record<string, unknown>;
+}) {
+  const action = createCalendarActionRunner(fakeDeps(args.service));
+  return (await action.handler(
+    fakeRuntime(args.service),
+    message(args.text),
+    undefined,
+    { parameters: args.parameters },
+    undefined,
+  )) as { success: boolean; text: string };
+}
+
+describe("CALENDAR mutation target honors the day the user stated", () => {
+  let service: StubService;
+
+  beforeEach(() => {
+    // Only Date is faked: the handler awaits real promises.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(PINNED_NOW);
+    service = stubService([HAIRCUT_FRIDAY, HAIRCUT_SATURDAY]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('"cancel my haircut on friday" cancels the friday one without asking', async () => {
+    const result = await runHandler({
+      service,
+      text: "cancel my haircut on friday",
+      parameters: {
+        subaction: "delete_event",
+        query: "haircut",
+        details: { timeZone: OWNER_TIME_ZONE },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.text).not.toContain("multiple");
+    expect(service.cancelApproval).toHaveBeenCalledTimes(1);
+    expect(service.cancelApproval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetEvent: HAIRCUT_FRIDAY,
+        request: expect.objectContaining({
+          eventId: HAIRCUT_FRIDAY.externalId,
+        }),
+      }),
+    );
+  });
+
+  it('"change my haircut on saturday to 2pm" targets the saturday one', async () => {
+    const result = await runHandler({
+      service,
+      text: "change my haircut on saturday to 2pm",
+      parameters: {
+        subaction: "update_event",
+        query: "haircut",
+        details: { timeZone: OWNER_TIME_ZONE },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.text).not.toContain("multiple");
+    expect(service.modifyApproval).toHaveBeenCalledTimes(1);
+    expect(service.modifyApproval).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetEvent: HAIRCUT_SATURDAY,
+        request: expect.objectContaining({
+          eventId: HAIRCUT_SATURDAY.externalId,
+        }),
+      }),
+    );
+  });
+
+  it("a stated day that matches no candidate still asks instead of not-found", async () => {
+    const result = await runHandler({
+      service,
+      text: "cancel my haircut on sunday",
+      parameters: {
+        subaction: "delete_event",
+        query: "haircut",
+        details: { timeZone: OWNER_TIME_ZONE },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("multiple");
+    expect(result.text).not.toContain("couldn't find");
+    expect(service.cancelApproval).not.toHaveBeenCalled();
+  });
+
+  it("a day that only names where the event is going does not pick a target", async () => {
+    // "to friday" is the new time, not the target — retargeting on it would
+    // move whichever haircut happens to already sit on friday.
+    const result = await runHandler({
+      service,
+      text: "move my haircut to friday 2pm",
+      parameters: {
+        subaction: "update_event",
+        query: "haircut",
+        details: { timeZone: OWNER_TIME_ZONE },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("multiple");
+    expect(service.modifyApproval).not.toHaveBeenCalled();
+  });
+
+  it("lists remaining candidates in one timezone", async () => {
+    const result = await runHandler({
+      service,
+      text: "cancel my haircut",
+      parameters: {
+        subaction: "delete_event",
+        query: "haircut",
+        details: { timeZone: OWNER_TIME_ZONE },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("Aug 14, 11:00 AM PDT");
+    expect(result.text).toContain("Aug 15, 6:00 AM PDT");
+    expect(result.text).not.toContain("UTC");
+    expect(service.cancelApproval).not.toHaveBeenCalled();
+  });
+});
+
+describe("CALENDAR create honors the day the user stated", () => {
+  let service: StubService;
+
+  beforeEach(() => {
+    // Saturday 2026-08-15, so "sunday" = Aug 16. Only Date is faked.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-08-15T12:00:00.000Z"));
+    service = stubService([]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("snaps a planner start on the wrong day onto the stated day, keeping wall time", async () => {
+    // Live capture (2026-08-15): "put coffee with dana on my calendar sunday
+    // at 10am", asked on a Saturday, arrived with a Monday startAt — the
+    // model's weekday arithmetic slipped while the user's word did not.
+    const result = await runHandler({
+      service,
+      text: "put coffee with dana on my calendar sunday at 10am",
+      parameters: {
+        subaction: "create_event",
+        title: "coffee with dana",
+        details: {
+          startAt: "2026-08-17T10:00:00.000Z",
+          endAt: "2026-08-17T11:00:00.000Z",
+          timeZone: "UTC",
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(service.scheduleApproval).toHaveBeenCalledTimes(1);
+    const scheduled = (
+      service.scheduleApproval.mock.calls[0]?.[0] as {
+        request?: { startAt?: string; endAt?: string };
+      }
+    )?.request;
+    expect(scheduled?.startAt).toBe("2026-08-16T10:00:00.000Z");
+    expect(scheduled?.endAt).toBe("2026-08-16T11:00:00.000Z");
+  });
+
+  it("changes nothing when the planner date already matches the stated day", async () => {
+    const result = await runHandler({
+      service,
+      text: "put coffee with dana on my calendar sunday at 10am",
+      parameters: {
+        subaction: "create_event",
+        title: "coffee with dana",
+        details: {
+          startAt: "2026-08-16T10:00:00.000Z",
+          endAt: "2026-08-16T11:00:00.000Z",
+          timeZone: "UTC",
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    const scheduled = (
+      service.scheduleApproval.mock.calls[0]?.[0] as {
+        request?: { startAt?: string };
+      }
+    )?.request;
+    expect(scheduled?.startAt).toBe("2026-08-16T10:00:00.000Z");
+  });
+
+  it("changes nothing when the user named no date", async () => {
+    const result = await runHandler({
+      service,
+      text: "put coffee with dana on my calendar",
+      parameters: {
+        subaction: "create_event",
+        title: "coffee with dana",
+        details: {
+          startAt: "2026-08-17T10:00:00.000Z",
+          endAt: "2026-08-17T11:00:00.000Z",
+          timeZone: "UTC",
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    const scheduled = (
+      service.scheduleApproval.mock.calls[0]?.[0] as {
+        request?: { startAt?: string };
+      }
+    )?.request;
+    expect(scheduled?.startAt).toBe("2026-08-17T10:00:00.000Z");
+  });
+});

--- a/plugins/plugin-calendar/vitest.config.ts
+++ b/plugins/plugin-calendar/vitest.config.ts
@@ -81,6 +81,20 @@ export default defineConfig({
   resolve: {
     alias: [
       {
+        // plugin-scheduling (source-aliased below) imports @elizaos/core/edge;
+        // vite's test-mode resolver misses linked-package subpath exports, so
+        // pin it to the edge source entry the same way the other workspace
+        // packages are pinned.
+        find: /^@elizaos\/core\/edge$/,
+        replacement: path.join(
+          elizaRoot,
+          "packages",
+          "core",
+          "src",
+          "index.edge.ts",
+        ),
+      },
+      {
         find: /^@elizaos\/plugin-google-workspace$/,
         replacement: path.join(pluginGoogleSrc, "index.ts"),
       },


### PR DESCRIPTION
## What

One rule, two halves: **a calendar day stated in the user's own words outranks both fuzzy candidate matching and the planner's date arithmetic.**

**Mutations** (live capture 2026-08-14, ported from the deployed fix): "cancel my haircut on friday" and "change my haircut on saturday to 2pm" both answered "found two haircuts — which one?" even though the user's words selected exactly one event. Candidates were filtered by fuzzy title alone; the stated day never reached target resolution. The same disambiguation reply also mixed zones ("11am pdt" beside "1pm utc"), asking the owner to do timezone math on their own appointments.

**Creates** (live capture 2026-08-15): "put coffee with dana on my calendar sunday at 10am", asked on a Saturday, arrived with a **Monday** startAt — the model's weekday arithmetic slipped while the user's word did not.

## Change

- `resolveCalendarMutationCandidates` — the single target-resolution chokepoint for update/delete: fuzzy title match, then the day the user actually stated. The date pass only runs on an already-ambiguous set and only when it keeps ≥1 candidate, so it can turn "which one?" into a resolved target but never a match into a not-found. Update requests scope the day-parse to the pre-"to" clause so a *destination* date never retargets the mutation. All-day events compare in their own zone.
- `buildCalendarEventDisambiguationFallback` renders every candidate in **one** zone (all-day events keep their own — their value is a calendar date).
- `applyStatedDateToCreateRequest` — when the message parses to an explicit local date (via `parseExplicitLocalDate`, the parser the read path already trusts) and the resolved start lands on a different local day, start and end shift onto the stated day preserving wall time and duration. A correct planner is a no-op.
- The timezone-grounded extraction test now pins its clock: its fixture declares "tomorrow" is Aug 5, which the new coherence check makes true only when today is Aug 4.
- `vitest.config.ts` gains a `@elizaos/core/edge` source alias — plugin-scheduling (already source-aliased) now imports it, and vite's test resolver misses linked-package subpath exports.

## Evidence

<!-- evidence-head:aab896f82bb73298b482464403720add35a0c72d -->

<!-- evidence-row:before-screenshots -->
N/A - Discord chat behavior; transcripts below

<!-- evidence-row:after-screenshots -->
N/A - Discord chat behavior; transcripts below

<!-- evidence-row:walkthrough-video -->
N/A - no UI surface

<!-- evidence-row:backend-logs -->
Live captures driving both halves:

<details>
<summary>transcripts</summary>
<pre>
mutation (2026-08-14): "cancel my haircut on friday"
  -> "found two haircuts: friday at 11am pdt and saturday at 1pm utc — which one?"

create (2026-08-15, today = Saturday Aug 15):
  user: put coffee with dana on my calendar sunday at 10am
  (trajectory: CALENDAR create_event timeMin 2026-08-17T10:00Z — Monday)
  bot:  done. coffee with dana, sunday at 10am.   <- confirmed a day it did not book
</pre>
</details>

<!-- evidence-row:frontend-logs -->
N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
The create capture's tool stage is quoted above (planner-emitted 2026-08-17 for "sunday" with a correct clock context — the agent self-reports "Saturday, August 15, 2026"). The fix is deterministic, below the model.

<!-- evidence-row:domain-artifacts -->
`calendar-mutation-stated-day.test.ts`: 8 tests — stubbed CalendarService, pinned clock, no model; covers day-named delete/update narrowing, destination-clause scoping, one-zone disambiguation rendering, and the create guard (wrong-day snap preserving wall time; matching-day and no-stated-date no-ops). Full plugin suite on this branch: **577 passed** (the 6 failures in `src/microsoft/connector-account-provider.test.ts` pre-exist on develop — error-code contract drift from tonight's merge train, untouched by this diff).

<!-- evidence-row:ocr-review -->
N/A - no rendered imagery

## Contribution provenance

AI assistance is self-reported provenance, not a request for hidden reasoning.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes - agent-authored under human direction; mutation half ported from the live-proven deployment patch
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-opus-5, anthropic/claude-fable-5
<!-- attribution-row:client -->
- Client / agent tooling: Claude Code (Eliza sub-agent)
<!-- attribution-row:skill-revision -->
- Contribution skill revision: N/A - authored from live deployment evidence
<!-- attribution-row:status -->
- Attribution status: self-reported
