### PR TITLE
fix(test): pin @elizaos/core/edge for configs that source-alias scheduling

### DIFF
--- a/packages/app-core/vitest.config.ts
+++ b/packages/app-core/vitest.config.ts
@@ -365,6 +365,13 @@ export default defineConfig({
         replacement: `${toVitePath(appTaskCoordinatorSrc)}/$1`,
       },
       {
+        // plugin-scheduling (source-aliased below) imports @elizaos/core/edge;
+        // vite's test-mode resolver misses linked-package subpath exports, so
+        // pin it to the edge source entry (mirrors plugin-calendar, #19815).
+        find: /^@elizaos\/core\/edge$/,
+        replacement: path.join(monorepoRoot, "packages/core/src/index.edge.ts"),
+      },
+      {
         find: /^@elizaos\/plugin-scheduling$/,
         replacement: path.join(pluginSchedulingSrc, "index.ts"),
       },

--- a/plugins/plugin-health/vitest.config.ts
+++ b/plugins/plugin-health/vitest.config.ts
@@ -14,6 +14,15 @@ const sharedSrc = fileURLToPath(
 // (ENOTDIR). Each subpath must resolve to its own source module instead.
 const aliases = [
   {
+    // plugin-scheduling (source-aliased below) imports @elizaos/core/edge;
+    // vite's test-mode resolver misses linked-package subpath exports, so pin
+    // it to the edge source entry (mirrors plugin-calendar after #19815).
+    find: /^@elizaos\/core\/edge$/,
+    replacement: fileURLToPath(
+      new URL("../../packages/core/src/index.edge.ts", import.meta.url),
+    ),
+  },
+  {
     find: /^@elizaos\/shared$/,
     replacement: `${sharedSrc}/index.ts`,
   },


### PR DESCRIPTION
## What

The workerd arc gave plugin-scheduling an `@elizaos/core/edge` import, and vite's test-mode resolver misses linked-package subpath exports — so every vitest config that source-aliases plugin-scheduling fails at collection. #19815 repaired plugin-calendar; this applies the identical pin to the remaining two configs with the pattern (found by sweep: `grep -rln 'plugin-scheduling/src' */vitest.config.ts`).

## Evidence

```
plugin-health BEFORE: Error: Cannot find package '@elizaos/core/edge'
  imported from plugins/plugin-scheduling/src/scheduled-task/runner.ts
  Test Files  1 failed | 34 passed
plugin-health AFTER:
  Test Files  35 passed | 4 skipped (39)
       Tests  188 passed | 4 skipped (192)
app-core: config loads and runs clean (probe test passes); no
  scheduling-adjacent tests exist there yet - the pin prevents the same
  breakage when one lands.
```

Cleanup of my own arc's fallout, flagged by the live-box session.

<!-- evidence-head:d865377b791a9476db53d58880f31e1baf2bac43 -->
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- ai-assistance: yes
<!-- attribution-row:models -->
- models: anthropic/claude-opus-4-8
<!-- attribution-row:client -->
- client: Claude Code
<!-- attribution-row:skill-revision -->
- skill-revision: N/A - no packaged skill governed this change
<!-- attribution-row:status -->
- status: self-reported
