### PR TITLE
test(plugin-calendar): assert the wrapped OAuth completion contract

### DIFF
--- a/plugins/plugin-calendar/src/microsoft/connector-account-provider.test.ts
+++ b/plugins/plugin-calendar/src/microsoft/connector-account-provider.test.ts
@@ -306,7 +306,13 @@ describe("Microsoft connector account provider", () => {
         query: { state: flow.state },
       }),
     ).rejects.toMatchObject({
-      code: "MICROSOFT_OAUTH_SCOPE_ESCALATION",
+      // The account manager persists a terminal failed flow and rethrows the
+      // typed wrapper (error-policy J2); the provider-specific code stays on
+      // the cause chain.
+      code: "CONNECTOR_OAUTH_COMPLETION_FAILED",
+      cause: expect.objectContaining({
+        code: "MICROSOFT_OAUTH_SCOPE_ESCALATION",
+      }),
     });
     expect(await harness.storage.listAccounts("microsoft")).toEqual([]);
     expect(harness.vault.size).toBe(0);
@@ -341,7 +347,13 @@ describe("Microsoft connector account provider", () => {
           query: { state: flow.state },
         }),
       ).rejects.toMatchObject({
-        code: "MICROSOFT_OAUTH_TOKEN_RESPONSE_INVALID",
+        // The account manager persists a terminal failed flow and rethrows the
+        // typed wrapper (error-policy J2); the provider-specific code stays on
+        // the cause chain.
+        code: "CONNECTOR_OAUTH_COMPLETION_FAILED",
+        cause: expect.objectContaining({
+          code: "MICROSOFT_OAUTH_TOKEN_RESPONSE_INVALID",
+        }),
       });
       expect(await harness.storage.listAccounts("microsoft")).toEqual([]);
       expect(harness.vault.size).toBe(0);
@@ -507,7 +519,13 @@ describe("Microsoft connector account provider", () => {
         query: { state: flow.state },
       }),
     ).rejects.toMatchObject({
-      code: "MICROSOFT_OAUTH_NONCE_MISMATCH",
+      // The account manager persists a terminal failed flow and rethrows the
+      // typed wrapper (error-policy J2); the provider-specific code stays on
+      // the cause chain.
+      code: "CONNECTOR_OAUTH_COMPLETION_FAILED",
+      cause: expect.objectContaining({
+        code: "MICROSOFT_OAUTH_NONCE_MISMATCH",
+      }),
     });
     expect(await harness.storage.listAccounts("microsoft")).toEqual([]);
     expect(harness.refs).toEqual([]);
@@ -545,7 +563,13 @@ describe("Microsoft connector account provider", () => {
         query: { state: flow.state },
       }),
     ).rejects.toMatchObject({
-      code: "MICROSOFT_OAUTH_ACCOUNT_IDENTITY_MISMATCH",
+      // The account manager persists a terminal failed flow and rethrows the
+      // typed wrapper (error-policy J2); the provider-specific code stays on
+      // the cause chain.
+      code: "CONNECTOR_OAUTH_COMPLETION_FAILED",
+      cause: expect.objectContaining({
+        code: "MICROSOFT_OAUTH_ACCOUNT_IDENTITY_MISMATCH",
+      }),
     });
     expect(harness.vault.size).toBe(0);
     expect(harness.refs).toEqual([]);
@@ -565,7 +589,13 @@ describe("Microsoft connector account provider", () => {
         query: { state: flow.state },
       }),
     ).rejects.toMatchObject({
-      code: "MICROSOFT_SECRET_WRITER_UNAVAILABLE",
+      // The account manager persists a terminal failed flow and rethrows the
+      // typed wrapper (error-policy J2); the provider-specific code stays on
+      // the cause chain.
+      code: "CONNECTOR_OAUTH_COMPLETION_FAILED",
+      cause: expect.objectContaining({
+        code: "MICROSOFT_SECRET_WRITER_UNAVAILABLE",
+      }),
     });
     const accounts = await harness.storage.listAccounts("microsoft");
     expect(accounts).toHaveLength(1);


### PR DESCRIPTION
## What

Six microsoft connector-account tests fail on clean develop: the account manager now persists a terminal failed flow and rethrows a typed `CONNECTOR_OAUTH_COMPLETION_FAILED` wrapper (error-policy **J2** — the provider-specific failure stays on the cause chain; the persisted flow row carries only the generic public message). The tests still asserted the specific code on the thrown error itself.

They now assert **both halves** of the shipped contract — the wrapper code on the thrown error AND the provider-specific code on `.cause` — which is stronger than before: a wrapper that dropped its cause would now fail.

Flagged by the live-box session during tonight's merge train; the wrapping behavior itself is correct per the J2 comment at the throw site, so this is a test migration, not a code change.

## Evidence

```
BEFORE (clean develop): Tests  6 failed | 13 passed (19)
AFTER:                  Tests  19 passed (19)
full plugin suite:      583 passed | 4 skipped (587)
```

<!-- evidence-head:1d53058220227d222b8a0fc4f38db9e3f03ba008 -->
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- ai-assistance: yes
<!-- attribution-row:models -->
- models: anthropic/claude-opus-4-8
<!-- attribution-row:client -->
- client: Claude Code
<!-- attribution-row:skill-revision -->
- skill-revision: N/A - no packaged skill governed this change
<!-- attribution-row:status -->
- status: self-reported
