### PR TITLE
fix(cloud-ui): make public payment page expiry- and navigation-safe

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.test.tsx
@@ -350,6 +350,41 @@ describe("PaymentRequestPage public DTO contract", () => {
     );
   });
 
+  it("does not navigate when checkout revalidation resolves after unmount", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("location", { assign, href: "https://eliza.example/pay" });
+    const checkout = deferred<{
+      success: boolean;
+      paymentRequest: ReturnType<typeof publicPaymentRequest>;
+    }>();
+
+    apiMock
+      .mockResolvedValueOnce({
+        success: true,
+        paymentRequest: publicPaymentRequest(),
+      })
+      .mockReturnValueOnce(checkout.promise);
+
+    const { unmount } = render(<PaymentRequestPage />);
+    const button = await screen.findByRole("button", {
+      name: /pay with wallet/i,
+    });
+    fireEvent.click(button);
+    unmount();
+
+    await act(async () => {
+      checkout.resolve({
+        success: true,
+        paymentRequest: publicPaymentRequest({
+          hostedUrl: "https://example.com/checkout/must-not-open",
+        }),
+      });
+      await checkout.promise;
+    });
+
+    expect(assign).not.toHaveBeenCalled();
+  });
+
   it("blocks navigation when revalidation returns a malformed deadline", async () => {
     const assign = vi.fn();
     vi.stubGlobal("location", { assign, href: "https://eliza.example/pay" });

--- a/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.test.tsx
@@ -1,7 +1,20 @@
-/** Verifies the public payment request page against the server DTO contract. */
+/**
+ * Verifies the public payment request page against the server DTO contract:
+ * generation-keyed loads (an out-of-order stale response cannot overwrite the
+ * current route), deadline-derived Pay eligibility that flips as time passes,
+ * pre-checkout server revalidation, and user-facing provider labels. Uses a
+ * jsdom harness with the API client and router mocked; component is real.
+ */
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type { ComponentProps, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -49,19 +62,22 @@ vi.mock("../../../../components/ui/button", () => ({
 
 import PaymentRequestPage from "./payment-request-page";
 
-function publicPaymentRequest(
-  overrides: Partial<{
-    provider: "stripe" | "oxapay" | "x402" | "wallet_native";
-    status:
-      | "pending"
-      | "delivered"
-      | "settled"
-      | "expired"
-      | "canceled"
-      | "failed";
-    hostedUrl: string | null;
-  }> = {},
-) {
+type PublicOverrides = Partial<{
+  id: string;
+  provider: "stripe" | "oxapay" | "x402" | "wallet_native";
+  status:
+    | "pending"
+    | "delivered"
+    | "settled"
+    | "expired"
+    | "canceled"
+    | "failed";
+  amountCents: number;
+  expiresAt: string | null;
+  hostedUrl: string | null;
+}>;
+
+function publicPaymentRequest(overrides: PublicOverrides = {}) {
   return {
     id: "payreq-test-1",
     provider: "wallet_native" as const,
@@ -75,15 +91,28 @@ function publicPaymentRequest(
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("PaymentRequestPage public DTO contract", () => {
-  afterEach(() => cleanup());
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
 
   beforeEach(() => {
     apiMock.mockReset();
     paramsRef.current = { paymentRequestId: "payreq-test-1" };
   });
 
-  it("renders wallet_native and allows checkout for delivered requests", async () => {
+  it("renders wallet_native through the user-facing label and allows checkout for delivered requests", async () => {
     apiMock.mockResolvedValue({
       success: true,
       paymentRequest: publicPaymentRequest(),
@@ -92,9 +121,10 @@ describe("PaymentRequestPage public DTO contract", () => {
     render(<PaymentRequestPage />);
 
     const button = await screen.findByRole("button", {
-      name: /pay with wallet_native/i,
+      name: /pay with wallet/i,
     });
     expect((button as HTMLButtonElement).disabled).toBe(false);
+    expect(screen.queryByText(/wallet_native/)).toBeNull();
   });
 
   it("renders canceled requests as terminal and keeps checkout disabled", async () => {
@@ -112,9 +142,177 @@ describe("PaymentRequestPage public DTO contract", () => {
     expect(
       (
         screen.getByRole("button", {
-          name: /pay with wallet_native/i,
+          name: /pay with wallet/i,
         }) as HTMLButtonElement
       ).disabled,
     ).toBe(true);
+  });
+
+  it("ignores a stale out-of-order response for a previous route (A resolves after B)", async () => {
+    const loadA = deferred<{ success: boolean; paymentRequest: unknown }>();
+    const loadB = deferred<{ success: boolean; paymentRequest: unknown }>();
+    apiMock.mockImplementation((path: string) =>
+      path.includes("payreq-a") ? loadA.promise : loadB.promise,
+    );
+
+    paramsRef.current = { paymentRequestId: "payreq-a" };
+    const { rerender } = render(<PaymentRequestPage />);
+
+    paramsRef.current = { paymentRequestId: "payreq-b" };
+    rerender(<PaymentRequestPage />);
+
+    await act(async () => {
+      loadB.resolve({
+        success: true,
+        paymentRequest: publicPaymentRequest({
+          id: "payreq-b",
+          provider: "stripe",
+          amountCents: 2500,
+        }),
+      });
+    });
+    await screen.findByText("$25.00");
+
+    // Give the stale resolution a chance to (incorrectly) commit.
+    await act(async () => {
+      loadA.resolve({
+        success: true,
+        paymentRequest: publicPaymentRequest({
+          id: "payreq-a",
+          provider: "oxapay",
+          amountCents: 111,
+        }),
+      });
+      await new Promise((res) => setTimeout(res, 20));
+    });
+
+    expect(screen.getByText("$25.00")).toBeTruthy();
+    expect(screen.queryByText("$1.11")).toBeNull();
+    expect(screen.getByText("#payreq-b")).toBeTruthy();
+  });
+
+  it("disables Pay when the deadline has already passed even if status is payable", async () => {
+    apiMock.mockResolvedValue({
+      success: true,
+      paymentRequest: publicPaymentRequest({
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+      }),
+    });
+
+    render(<PaymentRequestPage />);
+
+    expect(await screen.findByText("Expired")).toBeTruthy();
+    expect(
+      (
+        screen.getByRole("button", {
+          name: /pay with wallet/i,
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+
+  it("flips Pay to disabled when the deadline passes while the page is open", async () => {
+    apiMock.mockResolvedValue({
+      success: true,
+      paymentRequest: publicPaymentRequest({
+        expiresAt: new Date(Date.now() + 250).toISOString(),
+      }),
+    });
+
+    render(<PaymentRequestPage />);
+
+    const button = (await screen.findByRole("button", {
+      name: /pay with wallet/i,
+    })) as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+
+    await waitFor(() => expect(button.disabled).toBe(true), {
+      timeout: 3_000,
+    });
+    expect(screen.getByText("Expired")).toBeTruthy();
+  });
+
+  it("revalidates before checkout and blocks navigation when the request settled", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("location", { assign, href: "https://eliza.example/pay" });
+
+    apiMock
+      .mockResolvedValueOnce({
+        success: true,
+        paymentRequest: publicPaymentRequest(),
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        paymentRequest: publicPaymentRequest({ status: "settled" }),
+      });
+
+    render(<PaymentRequestPage />);
+
+    const button = await screen.findByRole("button", {
+      name: /pay with wallet/i,
+    });
+    fireEvent.click(button);
+
+    expect(await screen.findByText("Paid")).toBeTruthy();
+    expect(assign).not.toHaveBeenCalled();
+    expect(apiMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("revalidates before checkout and navigates to the fresh hosted URL", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("location", { assign, href: "https://eliza.example/pay" });
+
+    apiMock
+      .mockResolvedValueOnce({
+        success: true,
+        paymentRequest: publicPaymentRequest({
+          hostedUrl: "https://example.com/checkout/stale",
+        }),
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        paymentRequest: publicPaymentRequest({
+          hostedUrl: "https://example.com/checkout/fresh",
+        }),
+      });
+
+    render(<PaymentRequestPage />);
+
+    const button = await screen.findByRole("button", {
+      name: /pay with wallet/i,
+    });
+    fireEvent.click(button);
+
+    await waitFor(() =>
+      expect(assign).toHaveBeenCalledWith("https://example.com/checkout/fresh"),
+    );
+  });
+
+  it("blocks navigation when revalidation reports the deadline has passed", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("location", { assign, href: "https://eliza.example/pay" });
+
+    apiMock
+      .mockResolvedValueOnce({
+        success: true,
+        paymentRequest: publicPaymentRequest(),
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        paymentRequest: publicPaymentRequest({
+          expiresAt: new Date(Date.now() - 1_000).toISOString(),
+        }),
+      });
+
+    render(<PaymentRequestPage />);
+
+    const button = await screen.findByRole("button", {
+      name: /pay with wallet/i,
+    });
+    fireEvent.click(button);
+
+    expect(await screen.findByText("Expired")).toBeTruthy();
+    expect(assign).not.toHaveBeenCalled();
+    expect((button as HTMLButtonElement).disabled).toBe(true);
   });
 });

--- a/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.test.tsx
@@ -1,9 +1,10 @@
 /**
  * Verifies the public payment request page against the server DTO contract:
  * generation-keyed loads (an out-of-order stale response cannot overwrite the
- * current route), deadline-derived Pay eligibility that flips as time passes,
- * pre-checkout server revalidation, and user-facing provider labels. Uses a
- * jsdom harness with the API client and router mocked; component is real.
+ * current route), deadline-derived Pay eligibility that rejects malformed
+ * values and re-arms long timers, pre-checkout server revalidation, and
+ * user-facing provider labels. The component is real; the API client and
+ * router are mocked under jsdom.
  */
 // @vitest-environment jsdom
 
@@ -105,6 +106,7 @@ describe("PaymentRequestPage public DTO contract", () => {
   afterEach(() => {
     cleanup();
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   beforeEach(() => {
@@ -211,6 +213,66 @@ describe("PaymentRequestPage public DTO contract", () => {
     ).toBe(true);
   });
 
+  it("fails closed and renders an explicit error for a malformed expiry date", async () => {
+    apiMock.mockResolvedValue({
+      success: true,
+      paymentRequest: publicPaymentRequest({ expiresAt: "not-a-date" }),
+    });
+
+    render(<PaymentRequestPage />);
+
+    expect(await screen.findByText("Invalid expiry date")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "This payment request has an invalid expiry date and cannot be paid.",
+      ),
+    ).toBeTruthy();
+    expect(
+      (
+        screen.getByRole("button", {
+          name: /pay with wallet/i,
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+
+  it("re-arms timers beyond the browser delay limit until the real deadline", async () => {
+    const browserTimerLimitMs = 2 ** 31 - 1;
+    const startMs = Date.UTC(2030, 0, 1);
+    const deadlineMs = startMs + browserTimerLimitMs + 60_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(startMs);
+    apiMock.mockResolvedValue({
+      success: true,
+      paymentRequest: publicPaymentRequest({
+        expiresAt: new Date(deadlineMs).toISOString(),
+      }),
+    });
+
+    render(<PaymentRequestPage />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const button = screen.getByRole("button", {
+      name: /pay with wallet/i,
+    }) as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+
+    await act(async () => {
+      vi.advanceTimersByTime(browserTimerLimitMs);
+    });
+    expect(button.disabled).toBe(false);
+    expect(screen.queryByText("Expired")).toBeNull();
+    expect(vi.getTimerCount()).toBe(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(60_001);
+    });
+    expect(button.disabled).toBe(true);
+    expect(screen.getByText("Expired")).toBeTruthy();
+  });
+
   it("flips Pay to disabled when the deadline passes while the page is open", async () => {
     apiMock.mockResolvedValue({
       success: true,
@@ -286,6 +348,32 @@ describe("PaymentRequestPage public DTO contract", () => {
     await waitFor(() =>
       expect(assign).toHaveBeenCalledWith("https://example.com/checkout/fresh"),
     );
+  });
+
+  it("blocks navigation when revalidation returns a malformed deadline", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("location", { assign, href: "https://eliza.example/pay" });
+
+    apiMock
+      .mockResolvedValueOnce({
+        success: true,
+        paymentRequest: publicPaymentRequest(),
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        paymentRequest: publicPaymentRequest({ expiresAt: "not-a-date" }),
+      });
+
+    render(<PaymentRequestPage />);
+
+    const button = await screen.findByRole("button", {
+      name: /pay with wallet/i,
+    });
+    fireEvent.click(button);
+
+    expect(await screen.findByText("Invalid expiry date")).toBeTruthy();
+    expect(assign).not.toHaveBeenCalled();
+    expect((button as HTMLButtonElement).disabled).toBe(true);
   });
 
   it("blocks navigation when revalidation reports the deadline has passed", async () => {

--- a/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.tsx
@@ -4,10 +4,16 @@
  * Reads the redacted public view from /api/v1/payment-requests/:id?public=1 and
  * presents a single "Pay" button that delegates to the provider's checkout.
  * Renders WITHOUT the app shell chrome.
+ *
+ * Loads are generation-keyed and aborted on route change so an out-of-order
+ * response for a previous request id can never overwrite the current route's
+ * amount, status, or checkout destination. Pay eligibility is derived from
+ * both status and the request deadline, re-evaluated as the deadline passes,
+ * and revalidated against the server immediately before checkout navigation.
  */
 
 import { AlertCircle, CreditCard, Loader2 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { Button } from "../../../../components/ui/button";
 import { ApiError, api } from "../../../lib/api-client";
@@ -41,6 +47,32 @@ interface PublicResponse {
   paymentRequest: PublicPaymentRequest;
 }
 
+/** User-facing names for provider storage identifiers; raw enum values never render. */
+const PROVIDER_LABELS: Record<
+  PaymentProvider,
+  { key: string; defaultValue: string }
+> = {
+  stripe: {
+    key: "cloud.paymentRequest.provider.stripe",
+    defaultValue: "Stripe",
+  },
+  oxapay: {
+    key: "cloud.paymentRequest.provider.oxapay",
+    defaultValue: "OxaPay",
+  },
+  x402: { key: "cloud.paymentRequest.provider.x402", defaultValue: "x402" },
+  wallet_native: {
+    key: "cloud.paymentRequest.provider.walletNative",
+    defaultValue: "Wallet",
+  },
+};
+
+function providerLabel(provider: PaymentProvider, t: TFn): string {
+  const entry = PROVIDER_LABELS[provider];
+  if (!entry) return String(provider);
+  return t(entry.key, { defaultValue: entry.defaultValue });
+}
+
 function formatAmount(amountCents: number, currency: string): string {
   try {
     return new Intl.NumberFormat("en-US", {
@@ -62,9 +94,34 @@ function formatDate(value: string | null): string | null {
   }).format(new Date(value));
 }
 
-function normalizeError(error: unknown, t: TFn): string {
-  if (error instanceof ApiError) return error.message;
-  if (error instanceof Error) return error.message;
+/** True once a parseable deadline is at or before `nowMs`; requests without a deadline never pass it. */
+function isDeadlinePassed(expiresAt: string | null, nowMs: number): boolean {
+  if (!expiresAt) return false;
+  const deadline = Date.parse(expiresAt);
+  return Number.isFinite(deadline) && deadline <= nowMs;
+}
+
+function isPayableStatus(status: PaymentRequestStatus): boolean {
+  return status === "pending" || status === "delivered";
+}
+
+/**
+ * Raw page-error state; the user-facing message is derived at render time so
+ * effects never need the (render-scoped) translator in their dependency list.
+ */
+type PageError =
+  | { kind: "request-failed"; cause: unknown }
+  | { kind: "no-checkout-url" };
+
+function errorMessage(error: PageError, t: TFn): string {
+  if (error.kind === "no-checkout-url") {
+    return t("cloud.paymentRequest.noCheckoutUrl", {
+      defaultValue: "This payment request has no hosted checkout URL yet.",
+    });
+  }
+  const { cause } = error;
+  if (cause instanceof ApiError) return cause.message;
+  if (cause instanceof Error) return cause.message;
   return t("cloud.paymentRequest.unableToLoad", {
     defaultValue: "Unable to load payment request.",
   });
@@ -76,8 +133,12 @@ export default function PaymentRequestPage() {
   const [paymentRequest, setPaymentRequest] =
     useState<PublicPaymentRequest | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<PageError | null>(null);
   const [isPaying, setIsPaying] = useState(false);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  // Monotonic key: only the latest load (or a checkout revalidation started
+  // under it) may commit state, so stale responses cannot cross routes.
+  const loadGenerationRef = useRef(0);
 
   usePageTitle(
     t("cloud.paymentRequest.metaTitle", {
@@ -85,49 +146,111 @@ export default function PaymentRequestPage() {
     }),
   );
 
-  const load = useCallback(async () => {
-    if (!paymentRequestId) {
-      setError(
-        t("cloud.paymentRequest.missingId", {
-          defaultValue: "Missing payment request id.",
-        }),
-      );
-      setIsLoading(false);
-      return;
-    }
-    setIsLoading(true);
-    setError(null);
-    try {
-      const response = await api<PublicResponse>(
-        `/api/v1/payment-requests/${encodeURIComponent(paymentRequestId)}?public=1`,
-        { skipAuth: true },
-      );
-      setPaymentRequest(response.paymentRequest);
-    } catch (loadError) {
-      setError(normalizeError(loadError, t));
-    } finally {
-      setIsLoading(false);
-    }
-  }, [paymentRequestId, t]);
+  const fetchPublicRequest = useCallback(
+    (id: string, signal?: AbortSignal) =>
+      api<PublicResponse>(
+        `/api/v1/payment-requests/${encodeURIComponent(id)}?public=1`,
+        { skipAuth: true, signal },
+      ),
+    [],
+  );
 
   useEffect(() => {
-    load();
-  }, [load]);
-
-  const beginCheckout = () => {
-    if (!paymentRequest) return;
-    const url = paymentRequest.hostedUrl;
-    if (!url) {
-      setError(
-        t("cloud.paymentRequest.noCheckoutUrl", {
-          defaultValue: "This payment request has no hosted checkout URL yet.",
-        }),
-      );
+    const generation = ++loadGenerationRef.current;
+    if (!paymentRequestId) {
+      setPaymentRequest(null);
+      setIsLoading(false);
       return;
     }
+    const controller = new AbortController();
+    setPaymentRequest(null);
+    setIsLoading(true);
+    setError(null);
+    setIsPaying(false);
+    (async () => {
+      try {
+        const response = await fetchPublicRequest(
+          paymentRequestId,
+          controller.signal,
+        );
+        if (loadGenerationRef.current !== generation) return;
+        setPaymentRequest(response.paymentRequest);
+        setNowMs(Date.now());
+      } catch (loadError) {
+        // error-policy:J4 — an aborted or superseded load is not this route's
+        // failure; only the current generation surfaces a visible error state.
+        if (
+          controller.signal.aborted ||
+          loadGenerationRef.current !== generation
+        ) {
+          return;
+        }
+        setError({ kind: "request-failed", cause: loadError });
+      } finally {
+        if (
+          !controller.signal.aborted &&
+          loadGenerationRef.current === generation
+        ) {
+          setIsLoading(false);
+        }
+      }
+    })();
+    return () => controller.abort();
+  }, [paymentRequestId, fetchPublicRequest]);
+
+  // Re-evaluate eligibility exactly when the deadline passes so an open tab
+  // cannot keep a stale enabled Pay button across the request's expiry.
+  const expiresAt = paymentRequest?.expiresAt ?? null;
+  useEffect(() => {
+    if (!expiresAt) return;
+    const deadline = Date.parse(expiresAt);
+    if (!Number.isFinite(deadline)) return;
+    const delay = deadline - Date.now();
+    if (delay <= 0) return;
+    // setTimeout clamps delays above 2^31-1; cap so far-future deadlines
+    // never fire immediately (they are re-armed on any reload anyway).
+    const timer = window.setTimeout(
+      () => setNowMs(Date.now()),
+      Math.min(delay + 1, 2 ** 31 - 1),
+    );
+    return () => window.clearTimeout(timer);
+  }, [expiresAt]);
+
+  const beginCheckout = useCallback(async () => {
+    if (!paymentRequest || !paymentRequestId || isPaying) return;
     setIsPaying(true);
-    window.location.assign(url);
-  };
+    setError(null);
+    const generation = loadGenerationRef.current;
+    try {
+      // Revalidate against the server immediately before navigation: the
+      // request may have settled, been canceled, or expired since page load.
+      const response = await fetchPublicRequest(paymentRequestId);
+      if (loadGenerationRef.current !== generation) return;
+      const fresh = response.paymentRequest;
+      const freshNow = Date.now();
+      setPaymentRequest(fresh);
+      setNowMs(freshNow);
+      const payable =
+        isPayableStatus(fresh.status) &&
+        !isDeadlinePassed(fresh.expiresAt, freshNow);
+      if (!payable) {
+        setIsPaying(false);
+        return;
+      }
+      if (!fresh.hostedUrl) {
+        setIsPaying(false);
+        setError({ kind: "no-checkout-url" });
+        return;
+      }
+      window.location.assign(fresh.hostedUrl);
+    } catch (checkoutError) {
+      // error-policy:J4 — a failed pre-checkout revalidation blocks navigation
+      // and is rendered as a visible page error, never a silent redirect.
+      if (loadGenerationRef.current !== generation) return;
+      setIsPaying(false);
+      setError({ kind: "request-failed", cause: checkoutError });
+    }
+  }, [paymentRequest, paymentRequestId, isPaying, fetchPublicRequest]);
 
   if (isLoading) {
     return (
@@ -150,10 +273,15 @@ export default function PaymentRequestPage() {
                 })}
               </h1>
               <p className="mt-1 text-sm text-muted">
-                {error ||
-                  t("cloud.paymentRequest.linkUnavailable", {
-                    defaultValue: "This payment link is unavailable.",
-                  })}
+                {!paymentRequestId
+                  ? t("cloud.paymentRequest.missingId", {
+                      defaultValue: "Missing payment request id.",
+                    })
+                  : error
+                    ? errorMessage(error, t)
+                    : t("cloud.paymentRequest.linkUnavailable", {
+                        defaultValue: "This payment link is unavailable.",
+                      })}
               </p>
             </div>
           </div>
@@ -171,16 +299,19 @@ export default function PaymentRequestPage() {
   }
 
   const isPaid = paymentRequest.status === "settled";
+  const deadlinePassed = isDeadlinePassed(paymentRequest.expiresAt, nowMs);
   const isExpired =
     paymentRequest.status === "expired" ||
     paymentRequest.status === "canceled" ||
-    paymentRequest.status === "failed";
+    paymentRequest.status === "failed" ||
+    (isPayableStatus(paymentRequest.status) && deadlinePassed);
   const canPay =
-    (paymentRequest.status === "pending" ||
-      paymentRequest.status === "delivered") &&
+    isPayableStatus(paymentRequest.status) &&
+    !deadlinePassed &&
     Boolean(paymentRequest.hostedUrl);
   const expiresLabel = formatDate(paymentRequest.expiresAt);
   const shortId = paymentRequest.id.slice(0, 8);
+  const provider = providerLabel(paymentRequest.provider, t);
 
   return (
     <div className="theme-cloud min-h-[100dvh] bg-bg px-4 py-8 text-txt sm:px-6 lg:px-8">
@@ -233,7 +364,7 @@ export default function PaymentRequestPage() {
           {error && (
             <div className="mt-7 flex items-center gap-3 border border-destructive/30 bg-destructive-subtle p-3 text-sm text-txt">
               <AlertCircle className="h-5 w-5 shrink-0 text-destructive" />
-              <span>{error}</span>
+              <span>{errorMessage(error, t)}</span>
             </div>
           )}
 
@@ -256,7 +387,7 @@ export default function PaymentRequestPage() {
                       defaultValue: "Already paid",
                     })
                   : t("cloud.paymentRequest.payWith", {
-                      provider: paymentRequest.provider,
+                      provider,
                       defaultValue: "Pay with {{provider}}",
                     })}
               </span>
@@ -265,7 +396,7 @@ export default function PaymentRequestPage() {
 
           <div className="mt-6 flex items-center justify-between border-t border-border pt-4 text-xs text-muted">
             <span>#{shortId}</span>
-            <span>{paymentRequest.provider}</span>
+            <span>{provider}</span>
           </div>
         </section>
       </main>

--- a/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.tsx
@@ -84,21 +84,34 @@ function formatAmount(amountCents: number, currency: string): string {
   }
 }
 
-function formatDate(value: string | null): string | null {
-  if (!value) return null;
+type Deadline =
+  | { kind: "none" }
+  | { kind: "invalid" }
+  | { kind: "valid"; valueMs: number };
+
+const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
+
+/** Parses the server deadline without turning malformed input into a payable request. */
+function parseDeadline(value: string | null): Deadline {
+  if (value === null) return { kind: "none" };
+  const valueMs = Date.parse(value);
+  return Number.isFinite(valueMs)
+    ? { kind: "valid", valueMs }
+    : { kind: "invalid" };
+}
+
+function formatDeadline(deadline: Deadline): string | null {
+  if (deadline.kind !== "valid") return null;
   return new Intl.DateTimeFormat("en-US", {
     month: "short",
     day: "numeric",
     hour: "numeric",
     minute: "2-digit",
-  }).format(new Date(value));
+  }).format(new Date(deadline.valueMs));
 }
 
-/** True once a parseable deadline is at or before `nowMs`; requests without a deadline never pass it. */
-function isDeadlinePassed(expiresAt: string | null, nowMs: number): boolean {
-  if (!expiresAt) return false;
-  const deadline = Date.parse(expiresAt);
-  return Number.isFinite(deadline) && deadline <= nowMs;
+function isDeadlinePassed(deadline: Deadline, nowMs: number): boolean {
+  return deadline.kind === "valid" && deadline.valueMs <= nowMs;
 }
 
 function isPayableStatus(status: PaymentRequestStatus): boolean {
@@ -111,9 +124,16 @@ function isPayableStatus(status: PaymentRequestStatus): boolean {
  */
 type PageError =
   | { kind: "request-failed"; cause: unknown }
-  | { kind: "no-checkout-url" };
+  | { kind: "no-checkout-url" }
+  | { kind: "invalid-deadline" };
 
 function errorMessage(error: PageError, t: TFn): string {
+  if (error.kind === "invalid-deadline") {
+    return t("cloud.paymentRequest.invalidExpiry", {
+      defaultValue:
+        "This payment request has an invalid expiry date and cannot be paid.",
+    });
+  }
   if (error.kind === "no-checkout-url") {
     return t("cloud.paymentRequest.noCheckoutUrl", {
       defaultValue: "This payment request has no hosted checkout URL yet.",
@@ -202,18 +222,28 @@ export default function PaymentRequestPage() {
   // cannot keep a stale enabled Pay button across the request's expiry.
   const expiresAt = paymentRequest?.expiresAt ?? null;
   useEffect(() => {
-    if (!expiresAt) return;
-    const deadline = Date.parse(expiresAt);
-    if (!Number.isFinite(deadline)) return;
-    const delay = deadline - Date.now();
-    if (delay <= 0) return;
-    // setTimeout clamps delays above 2^31-1; cap so far-future deadlines
-    // never fire immediately (they are re-armed on any reload anyway).
-    const timer = window.setTimeout(
-      () => setNowMs(Date.now()),
-      Math.min(delay + 1, 2 ** 31 - 1),
-    );
-    return () => window.clearTimeout(timer);
+    const deadline = parseDeadline(expiresAt);
+    if (deadline.kind !== "valid") return;
+
+    let timer: number | undefined;
+    const armTimer = () => {
+      const remainingMs = deadline.valueMs - Date.now();
+      if (remainingMs <= 0) {
+        setNowMs(Date.now());
+        return;
+      }
+      // Browser timers cannot represent delays above 2^31-1 ms. Wake at that
+      // boundary and re-arm until the actual deadline rather than expiring early.
+      timer = window.setTimeout(
+        armTimer,
+        Math.min(remainingMs + 1, MAX_TIMER_DELAY_MS),
+      );
+    };
+
+    armTimer();
+    return () => {
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
   }, [expiresAt]);
 
   const beginCheckout = useCallback(async () => {
@@ -230,9 +260,11 @@ export default function PaymentRequestPage() {
       const freshNow = Date.now();
       setPaymentRequest(fresh);
       setNowMs(freshNow);
+      const freshDeadline = parseDeadline(fresh.expiresAt);
       const payable =
         isPayableStatus(fresh.status) &&
-        !isDeadlinePassed(fresh.expiresAt, freshNow);
+        freshDeadline.kind !== "invalid" &&
+        !isDeadlinePassed(freshDeadline, freshNow);
       if (!payable) {
         setIsPaying(false);
         return;
@@ -299,7 +331,10 @@ export default function PaymentRequestPage() {
   }
 
   const isPaid = paymentRequest.status === "settled";
-  const deadlinePassed = isDeadlinePassed(paymentRequest.expiresAt, nowMs);
+  const deadline = parseDeadline(paymentRequest.expiresAt);
+  const deadlinePassed = isDeadlinePassed(deadline, nowMs);
+  const hasInvalidPayableDeadline =
+    isPayableStatus(paymentRequest.status) && deadline.kind === "invalid";
   const isExpired =
     paymentRequest.status === "expired" ||
     paymentRequest.status === "canceled" ||
@@ -307,11 +342,15 @@ export default function PaymentRequestPage() {
     (isPayableStatus(paymentRequest.status) && deadlinePassed);
   const canPay =
     isPayableStatus(paymentRequest.status) &&
+    !hasInvalidPayableDeadline &&
     !deadlinePassed &&
     Boolean(paymentRequest.hostedUrl);
-  const expiresLabel = formatDate(paymentRequest.expiresAt);
+  const expiresLabel = formatDeadline(deadline);
   const shortId = paymentRequest.id.slice(0, 8);
   const provider = providerLabel(paymentRequest.provider, t);
+  const displayedError: PageError | null = hasInvalidPayableDeadline
+    ? { kind: "invalid-deadline" }
+    : error;
 
   return (
     <div className="theme-cloud min-h-[100dvh] bg-bg px-4 py-8 text-txt sm:px-6 lg:px-8">
@@ -333,26 +372,30 @@ export default function PaymentRequestPage() {
             <div className="mt-3 text-sm text-muted">
               {isPaid
                 ? t("cloud.paymentRequest.paid", { defaultValue: "Paid" })
-                : isExpired
-                  ? paymentRequest.status === "canceled"
-                    ? t("cloud.paymentRequest.cancelled", {
-                        defaultValue: "Cancelled",
-                      })
-                    : paymentRequest.status === "failed"
-                      ? t("cloud.paymentRequest.failed", {
-                          defaultValue: "Failed",
+                : hasInvalidPayableDeadline
+                  ? t("cloud.paymentRequest.invalidExpiryShort", {
+                      defaultValue: "Invalid expiry date",
+                    })
+                  : isExpired
+                    ? paymentRequest.status === "canceled"
+                      ? t("cloud.paymentRequest.cancelled", {
+                          defaultValue: "Cancelled",
                         })
-                      : t("cloud.paymentRequest.expired", {
-                          defaultValue: "Expired",
+                      : paymentRequest.status === "failed"
+                        ? t("cloud.paymentRequest.failed", {
+                            defaultValue: "Failed",
+                          })
+                        : t("cloud.paymentRequest.expired", {
+                            defaultValue: "Expired",
+                          })
+                    : expiresLabel
+                      ? t("cloud.paymentRequest.pendingExpires", {
+                          date: expiresLabel,
+                          defaultValue: "Pending - expires {{date}}",
                         })
-                  : expiresLabel
-                    ? t("cloud.paymentRequest.pendingExpires", {
-                        date: expiresLabel,
-                        defaultValue: "Pending - expires {{date}}",
-                      })
-                    : t("cloud.paymentRequest.pending", {
-                        defaultValue: "Pending",
-                      })}
+                      : t("cloud.paymentRequest.pending", {
+                          defaultValue: "Pending",
+                        })}
             </div>
             {paymentRequest.reason && (
               <p className="mt-3 max-w-md text-sm text-muted-strong">
@@ -361,10 +404,10 @@ export default function PaymentRequestPage() {
             )}
           </div>
 
-          {error && (
+          {displayedError && (
             <div className="mt-7 flex items-center gap-3 border border-destructive/30 bg-destructive-subtle p-3 text-sm text-txt">
               <AlertCircle className="h-5 w-5 shrink-0 text-destructive" />
-              <span>{errorMessage(error, t)}</span>
+              <span>{errorMessage(displayedError, t)}</span>
             </div>
           )}
 

--- a/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.tsx
@@ -215,7 +215,16 @@ export default function PaymentRequestPage() {
         }
       }
     })();
-    return () => controller.abort();
+    return () => {
+      controller.abort();
+      // Route replacement increments this again in the next effect. A plain
+      // unmount has no next effect, so invalidate the generation here as well
+      // to prevent an in-flight checkout revalidation from navigating after
+      // the user has already left this page.
+      if (loadGenerationRef.current === generation) {
+        loadGenerationRef.current += 1;
+      }
+    };
   }, [paymentRequestId, fetchPublicRequest]);
 
   // Re-evaluate eligibility exactly when the deadline passes so an open tab

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -6774,6 +6774,8 @@
   "cloud.paymentRequest.cancelled": "Cancelled",
   "cloud.paymentRequest.failed": "Failed",
   "cloud.paymentRequest.expired": "Expired",
+  "cloud.paymentRequest.invalidExpiry": "This payment request has an invalid expiry date and cannot be paid.",
+  "cloud.paymentRequest.invalidExpiryShort": "Invalid expiry date",
   "cloud.paymentRequest.pendingExpires": "Pending - expires {{date}}",
   "cloud.paymentRequest.pending": "Pending",
   "cloud.paymentRequest.alreadyPaid": "Already paid",


### PR DESCRIPTION
## What

Client-side remainder of #18814 (the server-side atomic settle/expire transitional core already landed in #19227; provider checkout-lifetime binding and webhook semantics remain with that PR's author per their follow-up note).

On the hosted public payment-request page (`packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.tsx`):

- **Generation-keyed, aborted loads** — each route load bumps a monotonic generation and carries an AbortController; a stale response (or error) for request A can no longer overwrite request B's amount, status, or hosted checkout URL, so a Pay click cannot redirect to the wrong request.
- **Deadline-derived Pay eligibility** — `canPay` now requires an unpassed `expiresAt` in addition to a payable status; a timer re-evaluates eligibility exactly when the deadline passes so an open tab flips to Expired/disabled instead of staying payable.
- **Pre-checkout revalidation** — clicking Pay refetches the request and only navigates when the fresh response is still payable, unexpired, and has a hosted URL; otherwise the page re-renders the authoritative state (Paid/Expired/Cancelled) and never navigates.
- **User-facing provider labels** — `wallet_native`/`oxapay`/`stripe`/`x402` render through an i18n label mapping ("Wallet", "OxaPay", "Stripe", "x402"); raw storage enum values no longer appear in the UI.
- Error state is now a typed discriminated value normalized at render time (keeps effects' dependency lists stable and the message translator render-scoped).

## Tests

`bun run --cwd packages/ui test -- payment-request-page` — **8 passed** (jsdom, real component; router/API mocked):
- deterministic A→B out-of-order regression (stale A response resolved after B cannot commit)
- expired-by-deadline renders Expired with Pay disabled even when status is payable
- deadline passing while the page is open flips Pay to disabled
- pre-checkout revalidation blocks navigation on settled and on expired responses, navigates to the fresh hosted URL otherwise
- provider label mapping (no raw `wallet_native` text)

`bun run --cwd packages/ui typecheck` — clean.
Biome check on touched files — clean.

## Residual risk

Binding provider checkout-session expiry to the request deadline and webhook duplicate/race semantics are server-side and deliberately out of scope here (deferred follow-up of #19227 per its author). The page still trusts the server DTO's `expiresAt`; client clock skew can only make the page more conservative at navigation time because the final authority is the pre-checkout server revalidation plus the atomic server transition.

Part of #18814

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:2c60bbfbcfbf1a781f80d6f3af38162fbfbe14d6 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19820-before-states.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19820-after-exact-head.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19820-walkthrough-exact-head.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - client-only packages/ui payment-page change; no server, API, or backend path changed

<!-- evidence-row:frontend-logs -->
- [x] [19820-frontend-exact-head.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19820-frontend-exact-head.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic UI state machine with no model invocation or prompt behavior

<!-- evidence-row:domain-artifacts -->
- [x] [19820-cloud-audit-report.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19820-cloud-audit-report.json)

<!-- evidence-row:ocr-review -->
- [x] [19820-ocr-review-exact-head.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19820-ocr-review-exact-head.txt)



