### PR TITLE
fix(cloud): stream personal phone calls through Eliza runtime

### DIFF
--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -761,6 +761,24 @@ describe("cloud-api worker entrypoint", () => {
     expect(productionRoutes).toContain("*.cloud.eliza.app/*");
   });
 
+  test("publishes the genuine Shared runtime as a staging-only rollout", async () => {
+    const config = Bun.TOML.parse(
+      await Bun.file(new URL("../wrangler.toml", import.meta.url)).text(),
+    ) as {
+      vars?: { SHARED_ELIZA_AGENT_RUNTIME?: string };
+      env?: {
+        staging?: { vars?: { SHARED_ELIZA_AGENT_RUNTIME?: string } };
+        production?: { vars?: { SHARED_ELIZA_AGENT_RUNTIME?: string } };
+      };
+    };
+
+    expect(config.vars?.SHARED_ELIZA_AGENT_RUNTIME).toBe("false");
+    expect(config.env?.staging?.vars?.SHARED_ELIZA_AGENT_RUNTIME).toBe("true");
+    expect(config.env?.production?.vars?.SHARED_ELIZA_AGENT_RUNTIME).toBe(
+      "false",
+    );
+  });
+
   test("binds the global native limiter in every Worker environment and keeps inference routes gate-free", async () => {
     type RateLimitBinding = {
       name?: string;

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -357,10 +357,18 @@ export class SharedRuntimeConversation {
       throw new Error("Conversation prewarm failed to hydrate history.");
     }
     await this.runWithBindings(async () => {
-      await Promise.all([
+      const imports: Promise<unknown>[] = [
         import("@/lib/services/shared-runtime/shared-runtime-chat"),
         import("@/lib/services/shared-runtime/cached-agent-dates"),
-      ]);
+      ];
+      if (this.env.SHARED_ELIZA_AGENT_RUNTIME === "true") {
+        imports.push(
+          import("@/lib/services/shared-runtime/shared-eliza-runtime").then(
+            ({ prewarmSharedElizaRuntime }) => prewarmSharedElizaRuntime(),
+          ),
+        );
+      }
+      await Promise.all(imports);
     });
   }
 

--- a/packages/cloud/api/tsconfig.json
+++ b/packages/cloud/api/tsconfig.json
@@ -36,7 +36,7 @@
       "@elizaos/cloud-sdk": ["../sdk/src/index.ts"],
       "@elizaos/cloud-sdk/*": ["../sdk/src/*"],
       "@elizaos/cloud-routing": ["../routing/src/index.ts"],
-      "@elizaos/core/edge": ["../../../packages/core/dist/edge/index.edge"],
+      "@elizaos/core/edge": ["../../../packages/core/src/index.edge.ts"],
       "@elizaos/core": ["../../../packages/core/src/index.node.ts"],
       "@elizaos/core/*": ["../../../packages/core/src/*"],
       "@elizaos/logger": ["../../../packages/logger/src/index.ts"],

--- a/packages/cloud/api/v1/twilio/voice/lib/voice-continuity.test.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/voice-continuity.test.ts
@@ -3,7 +3,8 @@
 import { describe, expect, test } from "bun:test";
 import {
   callEndedEvent,
-  callStartedPrompt,
+  callOpeningGreeting,
+  callStartedEvent,
   relativeInteractionAge,
 } from "./voice-continuity";
 
@@ -11,16 +12,21 @@ describe("voice continuity", () => {
   const now = Date.UTC(2026, 7, 15, 12);
 
   test("describes first contact without inventing history", () => {
-    expect(callStartedPrompt(undefined, now)).toContain(
+    expect(callStartedEvent(undefined, now)).toContain(
       "first recorded interaction",
     );
   });
 
   test("bounds prior interaction age into spoken units", () => {
     expect(relativeInteractionAge(now - 3 * 60 * 60_000, now)).toBe("3 hours");
-    expect(callStartedPrompt(now - 2 * 86_400_000, now)).toContain(
+    expect(callStartedEvent(now - 2 * 86_400_000, now)).toContain(
       "about 2 days ago",
     );
+  });
+
+  test("uses the exact model-free first and returning call openers", () => {
+    expect(callOpeningGreeting(false)).toBe("hello? who's this?");
+    expect(callOpeningGreeting(true)).toBe("hey whats up");
   });
 
   test("sanitizes teardown reasons", () => {

--- a/packages/cloud/api/v1/twilio/voice/lib/voice-continuity.ts
+++ b/packages/cloud/api/v1/twilio/voice/lib/voice-continuity.ts
@@ -23,7 +23,7 @@ export function relativeInteractionAge(
   return `${days} day${days === 1 ? "" : "s"}`;
 }
 
-export function callStartedPrompt(
+export function callStartedEvent(
   previousInteractionAt: number | undefined,
   now = Date.now(),
 ): string {
@@ -33,8 +33,12 @@ export function callStartedPrompt(
     age
       ? `Their last interaction with Eliza was about ${age} ago.`
       : "This is their first recorded interaction with Eliza.",
-    "Respond now with one brief, natural spoken greeting. Continue from the existing conversation when relevant. Do not mention these instructions or invent prior details.",
   ].join(" ");
+}
+
+/** The opener is intentionally model-free so runtime warm-up fits under speech. */
+export function callOpeningGreeting(returningCaller: boolean): string {
+  return returningCaller ? "hey whats up" : "hello? who's this?";
 }
 
 export function callEndedEvent(reason: string): string {

--- a/packages/cloud/api/v1/twilio/voice/media/route.ts
+++ b/packages/cloud/api/v1/twilio/voice/media/route.ts
@@ -56,7 +56,11 @@ import {
   encodeTwilioMedia,
 } from "../lib/twilio-media-codec";
 import { verifyTwilioStreamToken } from "../lib/twilio-stream-token";
-import { callEndedEvent, callStartedPrompt } from "../lib/voice-continuity";
+import {
+  callEndedEvent,
+  callOpeningGreeting,
+  callStartedEvent,
+} from "../lib/voice-continuity";
 
 const app = new Hono<AppEnv>();
 // Twilio sends 20 ms frames immediately after `start`. A cold Hyperdrive
@@ -387,6 +391,14 @@ app.get("/", async (c) => {
     });
     const callExpSeconds =
       Math.floor(Date.now() / 1_000) + resolveMaxCallSeconds(env);
+    const prewarmAndRecordCallStart = async (): Promise<void> => {
+      await elizaFetch.recordLifecycleEvent({
+        id: `twilio-call:${claims.callSid}:started`,
+        content: callStartedEvent(claims.previousInteractionAt),
+        createdAt: Date.now(),
+      });
+      await elizaFetch.prewarm?.();
+    };
     session = new VoiceSession({
       sessionId: claims.sessionId,
       jti: claims.jti,
@@ -410,9 +422,8 @@ app.get("/", async (c) => {
       elizaAuthorization,
       elizaModel: resolveElizaModel(env),
       fetchImpl: elizaFetch,
-      prewarmElizaContext: elizaFetch.prewarm,
-      openingPrompt: callStartedPrompt(claims.previousInteractionAt),
-      openingClientMessageId: `twilio-call:${claims.callSid}:started`,
+      prewarmElizaContext: prewarmAndRecordCallStart,
+      openingGreeting: callOpeningGreeting(claims.returningCaller),
       usageStore,
       usageLimits: resolveVoiceUsageLimits(env),
       isRevoked: (jti) =>

--- a/packages/cloud/api/v1/voice/session/__tests__/internal-eliza-cache-hotpath.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/internal-eliza-cache-hotpath.test.ts
@@ -127,6 +127,7 @@ test("real cache + canonical coordinator dispatch performs no response-path DB w
     operation: "prewarm",
     agentId: AGENT_ID,
     roomId: CONVERSATION_ID,
+    startEmpty: false,
   });
   expect(JSON.parse(String(coordinatorCalls[1]?.init?.body))).toMatchObject({
     operation: "stream",

--- a/packages/cloud/api/v1/voice/session/__tests__/ws-route-upgrade.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/ws-route-upgrade.test.ts
@@ -9,6 +9,7 @@ import {
   mock,
   test,
 } from "bun:test";
+import * as realCore from "@elizaos/core";
 import { Hono } from "hono";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -37,6 +38,7 @@ let durableStoreValue: unknown = { kind: "durable" };
 let binaryTypeWritable = true;
 
 mock.module("@elizaos/core", () => ({
+  ...realCore,
   isSensitiveKeyName: () => false,
   redactLogArgs: (a: unknown) => a,
 }));

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -160,6 +160,7 @@ new_sqlite_classes = ["OnboardingSessionCoordinator"]
 # Vars (non-secret build/runtime config — the rest live as wrangler secrets)
 # -----------------------------------------------------------------------------
 [vars]
+# Local/default deployments retain the direct-model control unless explicitly opted in.
 NODE_ENV = "production"
 SHARED_ELIZA_AGENT_RUNTIME = "false"
 NEXT_PUBLIC_APP_URL = "https://cloud.eliza.app"
@@ -427,6 +428,7 @@ __dirname = '"/"'
 __filename = '"/worker.js"'
 
 [env.staging.vars]
+# Protected staging proves the genuine Workerd AgentRuntime before production promotion.
 NODE_ENV = "production"
 SHARED_ELIZA_AGENT_RUNTIME = "true"
 # Apps (Product 2): wire the real deploy trigger so POST /api/v1/apps/:id/deploy
@@ -674,6 +676,7 @@ __dirname = '"/"'
 __filename = '"/worker.js"'
 
 [env.production.vars]
+# Flip only after exact staging voice/runtime evidence for the release SHA.
 NODE_ENV = "production"
 SHARED_ELIZA_AGENT_RUNTIME = "false"
 THIN_INFERENCE_ENTRY_ENABLED = "true"

--- a/packages/cloud/services/container-control-plane/tsconfig.json
+++ b/packages/cloud/services/container-control-plane/tsconfig.json
@@ -19,6 +19,7 @@
       "@/types/*": ["../../shared/src/types/*"],
       "@elizaos/cloud-shared": ["../../shared/src/index.ts"],
       "@elizaos/cloud-shared/*": ["../../shared/src/*"],
+      "@elizaos/core/edge": ["../../../../packages/core/src/index.edge.ts"],
       "@elizaos/core": ["../../../../packages/core/src/index.node.ts"],
       "@elizaos/core/*": ["../../../../packages/core/src/*"],
       "@elizaos/logger": ["../../../logger/src/index.ts"],

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -450,6 +450,21 @@ export async function runSharedAgentTurnStream(
     };
   }
 
+  if (input.execution?.engine === "eliza-runtime") {
+    const { runSharedElizaRuntimeTurnStream } = await import("./shared-eliza-runtime");
+    return await runSharedElizaRuntimeTurnStream({
+      ...input,
+      character: {
+        ...input.character,
+        system: buildSystemPrompt(input.character, {
+          reminders: false,
+        }),
+      },
+      agentKey: input.execution.agentKey,
+      model: modelId,
+    });
+  }
+
   try {
     const model = getInteractiveCerebrasLanguageModel(modelId);
     const system = buildSystemPrompt(input.character, {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -43,6 +43,182 @@ afterEach(() => {
 });
 
 describe("Shared Eliza Workerd runtime", () => {
+  test("prewarms the genuine runtime kernel without dispatching inference", async () => {
+    const { prewarmSharedElizaRuntime } = await import("./shared-eliza-runtime");
+    let providerCalls = 0;
+    globalThis.fetch = (async () => {
+      providerCalls += 1;
+      throw new Error("Runtime prewarm must not contact Cerebras");
+    }) as typeof fetch;
+
+    await Promise.all([prewarmSharedElizaRuntime(), prewarmSharedElizaRuntime()]);
+
+    expect(providerCalls).toBe(0);
+  });
+
+  test("streams HANDLE_RESPONSE reply text through the genuine runtime", async () => {
+    const requests: Array<Record<string, unknown>> = [];
+    globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+      requests.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      const argumentsText = JSON.stringify({
+        shouldRespond: "RESPOND",
+        thought: "The genuine runtime streamed this turn.",
+        contexts: ["simple"],
+        intents: [],
+        candidateActionNames: [],
+        replyText: "hello from streaming Eliza",
+        replyEffectStatus: "none",
+        facts: [],
+        relationships: [],
+        addressedTo: [],
+      });
+      const body =
+        `data: ${JSON.stringify({
+          id: "chatcmpl-shared-runtime-stream",
+          object: "chat.completion.chunk",
+          created: 0,
+          model: "gemma-4-31b",
+          choices: [
+            {
+              index: 0,
+              delta: {
+                role: "assistant",
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "shared-handle-response-stream",
+                    type: "function",
+                    function: {
+                      name: "HANDLE_RESPONSE",
+                      arguments: argumentsText.slice(0, 48),
+                    },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        })}\n\n` +
+        `data: ${JSON.stringify({
+          id: "chatcmpl-shared-runtime-stream",
+          object: "chat.completion.chunk",
+          created: 0,
+          model: "gemma-4-31b",
+          choices: [
+            {
+              index: 0,
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    function: { arguments: argumentsText.slice(48) },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        })}\n\n` +
+        `data: ${JSON.stringify({
+          id: "chatcmpl-shared-runtime-stream",
+          object: "chat.completion.chunk",
+          created: 0,
+          model: "gemma-4-31b",
+          choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }],
+          usage: { prompt_tokens: 41, completion_tokens: 17, total_tokens: 58 },
+        })}\n\n` +
+        "data: [DONE]\n\n";
+      return new Response(body, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }) as typeof fetch;
+
+    const { runSharedAgentTurnStream } = await import("./run-shared-agent-turn");
+    let dispatches = 0;
+    const result = await runSharedAgentTurnStream({
+      character: {
+        name: "Shared Eliza",
+        system: "You are Eliza.",
+        model: "gemma-4-31b",
+      },
+      history: [],
+      message: "say hello",
+      messageIds: {
+        user: "c92f5aaa-59ce-40a6-994b-e9e16dc85198",
+        assistant: "f492130b-2fc6-4b2b-bdca-51f441b0483d",
+      },
+      onProviderDispatch: async () => {
+        dispatches += 1;
+      },
+      execution: {
+        engine: "eliza-runtime",
+        agentKey: "personal:39e40424-28eb-41fc-8844-63d16e84e14f",
+      },
+    });
+    const parts = [];
+    for await (const part of result.parts ?? []) parts.push(part);
+
+    expect(
+      parts
+        .filter((part) => part.type === "text-delta")
+        .map((part) => part.text)
+        .join(""),
+    ).toBe("hello from streaming Eliza");
+    expect(parts.at(-1)).toMatchObject({
+      type: "finish",
+      text: "hello from streaming Eliza",
+    });
+    expect(dispatches).toBe(1);
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({ stream: true });
+  });
+
+  test("aborts the genuine runtime provider stream before barge-in can emit text", async () => {
+    const providerStarted = Promise.withResolvers<AbortSignal>();
+    globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal;
+      if (!signal) throw new Error("Expected the runtime provider abort signal");
+      providerStarted.resolve(signal);
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            signal.addEventListener(
+              "abort",
+              () => controller.error(signal.reason ?? new DOMException("Aborted", "AbortError")),
+              { once: true },
+            );
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "text/event-stream" } },
+      );
+    }) as typeof fetch;
+
+    const { runSharedAgentTurnStream } = await import("./run-shared-agent-turn");
+    const result = await runSharedAgentTurnStream({
+      character: {
+        name: "Shared Eliza",
+        system: "You are Eliza.",
+        model: "gemma-4-31b",
+      },
+      history: [],
+      message: "do not finish this turn",
+      execution: {
+        engine: "eliza-runtime",
+        agentKey: "personal:39e40424-28eb-41fc-8844-63d16e84e14f",
+      },
+    });
+    const iterator = result.parts?.[Symbol.asyncIterator]();
+    if (!iterator || !result.cancel) throw new Error("Expected a cancellable runtime stream");
+    const nextPart = iterator.next();
+    const providerSignal = await providerStarted.promise;
+
+    await result.cancel("confirmed caller speech");
+
+    expect(providerSignal.aborted).toBe(true);
+    await expect(nextPart).rejects.toThrow();
+  });
+
   test("runs HANDLE_RESPONSE through AgentRuntime and preserves native usage", async () => {
     const requests: Array<Record<string, unknown>> = [];
     globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -14,17 +14,30 @@ import {
   InMemoryDatabaseAdapter,
   ModelType,
   type Plugin,
+  type StreamingContext,
+  setStreamingContextManager,
   stringToUuid,
+  type TextStreamResult,
   type ToolChoice,
   type ToolDefinition,
 } from "@elizaos/core/edge";
 import { createSharedRemindersEdgePlugin } from "@elizaos/plugin-scheduling/edge";
 import { webSearchEdgeAction, webSearchEdgePlugin } from "@elizaos/plugin-web-search/edge";
-import { generateText, type JSONSchema7, jsonSchema, type ModelMessage, type ToolSet } from "ai";
+import {
+  generateText,
+  type JSONSchema7,
+  jsonSchema,
+  type ModelMessage,
+  streamText,
+  type ToolSet,
+} from "ai";
 import { getInteractiveCerebrasLanguageModel } from "../../providers/language-model";
+import { logger } from "../../utils/logger";
 import type {
   RunSharedAgentTurnInput,
   RunSharedAgentTurnResult,
+  RunSharedAgentTurnStreamResult,
+  SharedAgentTurnStreamPart,
   SharedAgentTurnUsage,
   SharedTurnMessage,
 } from "./run-shared-agent-turn";
@@ -37,6 +50,134 @@ type NativeTextModelResult = string & {
   usage: SharedAgentTurnUsage;
   providerMetadata: { modelName: string };
 };
+
+let edgeStreamingContextReady: Promise<void> | undefined;
+let sharedRuntimeKernelReady: Promise<AgentRuntime> | undefined;
+
+async function ensureEdgeStreamingContext(): Promise<void> {
+  edgeStreamingContextReady ??= import("node:async_hooks").then(({ AsyncLocalStorage }) => {
+    const storage = new AsyncLocalStorage<StreamingContext | undefined>();
+    setStreamingContextManager({
+      run: <T>(context: StreamingContext | undefined, fn: () => T): T => storage.run(context, fn),
+      active: () => storage.getStore(),
+    });
+  });
+  await edgeStreamingContextReady;
+}
+
+function prewarmModelHandler(): never {
+  throw new Error("Shared runtime prewarm must not dispatch inference");
+}
+
+function sharedModelPlugin(
+  handler: (
+    runtime: IAgentRuntime,
+    params: GenerateTextParams,
+  ) => Promise<string | NativeTextModelResult | TextStreamResult>,
+): Plugin {
+  return {
+    name: "shared-cerebras-model",
+    description: "Platform-funded text generation for the Shared Workerd runtime.",
+    models: {
+      [ModelType.RESPONSE_HANDLER]: handler,
+      [ModelType.ACTION_PLANNER]: handler,
+      [ModelType.TEXT_SMALL]: handler,
+      [ModelType.TEXT_LARGE]: handler,
+    },
+    modelMetadata: {
+      [ModelType.RESPONSE_HANDLER]: { streamable: true },
+      [ModelType.ACTION_PLANNER]: { streamable: true },
+      [ModelType.TEXT_SMALL]: { streamable: true },
+      [ModelType.TEXT_LARGE]: { streamable: true },
+    },
+  };
+}
+
+function createRuntime(options: {
+  agentKey: string;
+  adapter: InMemoryDatabaseAdapter;
+  character: RunSharedAgentTurnInput["character"];
+  modelPlugin: Plugin;
+  reminderPlugin?: Plugin;
+}): AgentRuntime {
+  return new AgentRuntime({
+    agentId: stringToUuid(options.agentKey),
+    character: {
+      name: options.character.name,
+      system: options.character.system,
+      bio: options.character.bio ?? [],
+      plugins: [],
+      settings: {
+        ELIZA_CANONICAL_LLM_TEXT_ENABLED: true,
+        ELIZA_CANONICAL_EMBEDDINGS_ENABLED: false,
+      },
+    },
+    adapter: options.adapter,
+    plugins: [
+      options.modelPlugin,
+      webSearchEdgePlugin,
+      ...(options.reminderPlugin ? [options.reminderPlugin] : []),
+    ],
+    logLevel: "error",
+    actionPlanning: true,
+    checkShouldRespond: false,
+    enableAutonomy: false,
+    enableDocuments: false,
+    enableRelationships: false,
+    enableTrajectories: false,
+  });
+}
+
+/** Pays one-time Workerd runtime initialization before the first live user turn. */
+export async function prewarmSharedElizaRuntime(): Promise<void> {
+  await ensureEdgeStreamingContext();
+  sharedRuntimeKernelReady ??= (async () => {
+    const runtime = createRuntime({
+      agentKey: "shared-runtime-kernel-prewarm",
+      adapter: new InMemoryDatabaseAdapter(),
+      character: {
+        name: "Shared Eliza",
+        system: "Shared runtime initialization prewarm.",
+      },
+      modelPlugin: sharedModelPlugin(async () => prewarmModelHandler()),
+    });
+    try {
+      await runtime.initialize({ skipMigrations: true });
+      if (!runtime.actions.some((action) => action.name === webSearchEdgeAction.name)) {
+        throw new Error("Eliza Shared runtime prewarm omitted its WEB_SEARCH action");
+      }
+      // Retain this state-free runtime for the isolate lifetime. Several core
+      // services finish their asynchronous start just after initialize();
+      // stopping immediately races those starts, while waiting on optional
+      // service names adds their full load timeout to every cold phone call.
+      return runtime;
+    } catch (error) {
+      try {
+        await runtime.stop();
+      } catch (teardownError) {
+        // error-policy:J6 failed prewarm owns this disposable runtime, so its
+        // teardown cannot replace the initialization failure reported upstream.
+        logger.warn("[shared-eliza-runtime] failed prewarm stop failed", {
+          error: teardownError instanceof Error ? teardownError.message : String(teardownError),
+        });
+      }
+      try {
+        await runtime.close();
+      } catch (teardownError) {
+        // error-policy:J6 failed prewarm owns this disposable runtime, so its
+        // teardown cannot replace the initialization failure reported upstream.
+        logger.warn("[shared-eliza-runtime] failed prewarm close failed", {
+          error: teardownError instanceof Error ? teardownError.message : String(teardownError),
+        });
+      }
+      throw error;
+    }
+  })().catch((error) => {
+    sharedRuntimeKernelReady = undefined;
+    throw error;
+  });
+  await sharedRuntimeKernelReady;
+}
 
 function modelToolChoice(
   choice: ToolChoice | undefined,
@@ -101,9 +242,11 @@ function runtimeMemoryId(message: SharedTurnMessage, index: number) {
   );
 }
 
-export async function runSharedElizaRuntimeTurn(
+async function executeSharedElizaRuntimeTurn(
   input: RunSharedAgentTurnInput & { agentKey: string; model: string },
+  onStreamChunk?: (chunk: string) => void | Promise<void>,
 ): Promise<RunSharedAgentTurnResult> {
+  await ensureEdgeStreamingContext();
   const adapter = new InMemoryDatabaseAdapter();
   let providerDispatched = false;
   let usage: SharedAgentTurnUsage | undefined;
@@ -112,12 +255,12 @@ export async function runSharedElizaRuntimeTurn(
   const modelHandler = async (
     _runtime: IAgentRuntime,
     params: GenerateTextParams,
-  ): Promise<string | NativeTextModelResult> => {
+  ): Promise<string | NativeTextModelResult | TextStreamResult> => {
     if (!providerDispatched) {
       providerDispatched = true;
       await input.onProviderDispatch?.();
     }
-    const result = await generateText({
+    const generation = {
       model,
       maxRetries: 0,
       allowSystemInMessages: true,
@@ -130,6 +273,49 @@ export async function runSharedElizaRuntimeTurn(
       ...(typeof params.temperature === "number" ? { temperature: params.temperature } : {}),
       ...(typeof params.topP === "number" ? { topP: params.topP } : {}),
       ...(params.signal ? { abortSignal: params.signal } : {}),
+    };
+    if (onStreamChunk && params.stream === true) {
+      const result = streamText(generation);
+      const textStream = (async function* (): AsyncIterable<string> {
+        if (params.streamStructured === true) {
+          for await (const part of result.fullStream) {
+            const record = part as {
+              type: string;
+              delta?: string;
+              inputTextDelta?: string;
+            };
+            const chunk =
+              record.type === "tool-input-delta"
+                ? (record.inputTextDelta ?? record.delta)
+                : undefined;
+            if (chunk) yield chunk;
+          }
+          return;
+        }
+        for await (const chunk of result.textStream) yield chunk;
+      })();
+      const streamUsage = Promise.resolve(result.totalUsage).then((value) => {
+        const normalized = normalizeUsage(value);
+        usage = addUsage(usage, normalized);
+        return normalized;
+      });
+      return {
+        textStream,
+        text: Promise.resolve(result.text),
+        toolCalls: Promise.resolve(result.toolCalls).then((calls) =>
+          calls.map((call) => ({
+            id: call.toolCallId,
+            name: call.toolName,
+            arguments: call.input,
+          })),
+        ),
+        finishReason: Promise.resolve(result.finishReason),
+        usage: streamUsage,
+        providerMetadata: { modelName: input.model },
+      } as TextStreamResult;
+    }
+    const result = await generateText({
+      ...generation,
     });
     usage = addUsage(usage, normalizeUsage(result.usage));
     if (result.toolCalls.length === 0) {
@@ -148,16 +334,7 @@ export async function runSharedElizaRuntimeTurn(
     } as NativeTextModelResult;
   };
 
-  const modelPlugin: Plugin = {
-    name: "shared-cerebras-model",
-    description: "Platform-funded text generation for the Shared Workerd runtime.",
-    models: {
-      [ModelType.RESPONSE_HANDLER]: modelHandler,
-      [ModelType.ACTION_PLANNER]: modelHandler,
-      [ModelType.TEXT_SMALL]: modelHandler,
-      [ModelType.TEXT_LARGE]: modelHandler,
-    },
-  };
+  const modelPlugin = sharedModelPlugin(modelHandler);
   const reminderPlugin = input.execution?.reminders
     ? createSharedRemindersEdgePlugin({
         runner: input.execution.reminders.runner,
@@ -165,27 +342,12 @@ export async function runSharedElizaRuntimeTurn(
         delivery: input.execution.reminders.delivery,
       })
     : undefined;
-  const runtime = new AgentRuntime({
-    agentId: stringToUuid(input.agentKey),
-    character: {
-      name: input.character.name,
-      system: input.character.system,
-      bio: input.character.bio ?? [],
-      plugins: [],
-      settings: {
-        ELIZA_CANONICAL_LLM_TEXT_ENABLED: true,
-        ELIZA_CANONICAL_EMBEDDINGS_ENABLED: false,
-      },
-    },
+  const runtime = createRuntime({
+    agentKey: input.agentKey,
     adapter,
-    plugins: [modelPlugin, webSearchEdgePlugin, ...(reminderPlugin ? [reminderPlugin] : [])],
-    logLevel: "error",
-    actionPlanning: true,
-    checkShouldRespond: false,
-    enableAutonomy: false,
-    enableDocuments: false,
-    enableRelationships: false,
-    enableTrajectories: false,
+    character: input.character,
+    modelPlugin,
+    reminderPlugin,
   });
 
   try {
@@ -250,7 +412,12 @@ export async function runSharedElizaRuntimeTurn(
         if (content.text?.trim()) delivered.push(content.text.trim());
         return [];
       },
-      input.abortSignal ? { abortSignal: input.abortSignal } : undefined,
+      input.abortSignal || onStreamChunk
+        ? {
+            ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
+            ...(onStreamChunk ? { onStreamChunk } : {}),
+          }
+        : undefined,
     );
     const reply = result?.responseContent?.text?.trim() || delivered.at(-1)?.trim() || "";
     if (!result?.didRespond || !reply) {
@@ -273,4 +440,106 @@ export async function runSharedElizaRuntimeTurn(
     await runtime.stop();
     await runtime.close();
   }
+}
+
+export async function runSharedElizaRuntimeTurn(
+  input: RunSharedAgentTurnInput & { agentKey: string; model: string },
+): Promise<RunSharedAgentTurnResult> {
+  return await executeSharedElizaRuntimeTurn(input);
+}
+
+function isRuntimeControlChunk(chunk: string): boolean {
+  if (!chunk.startsWith("{")) return false;
+  try {
+    const value = JSON.parse(chunk) as { type?: unknown };
+    return (
+      value.type === "tool_call" ||
+      value.type === "tool_result" ||
+      value.type === "evaluation" ||
+      value.type === "context_event"
+    );
+  } catch {
+    // A partial structured reply is visible text, not a complete control event.
+    return false;
+  }
+}
+
+export async function runSharedElizaRuntimeTurnStream(
+  input: RunSharedAgentTurnInput & { agentKey: string; model: string },
+): Promise<RunSharedAgentTurnStreamResult> {
+  const controller = new AbortController();
+  const abortFromCaller = () => controller.abort(input.abortSignal?.reason);
+  if (input.abortSignal?.aborted) abortFromCaller();
+  else input.abortSignal?.addEventListener("abort", abortFromCaller, { once: true });
+
+  const queued: SharedAgentTurnStreamPart[] = [];
+  let wake: (() => void) | undefined;
+  let terminalError: unknown;
+  let terminal = false;
+  let emittedText = "";
+  const signalQueue = () => {
+    wake?.();
+    wake = undefined;
+  };
+  const push = (part: SharedAgentTurnStreamPart) => {
+    if (terminal) return;
+    queued.push(part);
+    signalQueue();
+  };
+
+  const completion = executeSharedElizaRuntimeTurn(
+    { ...input, abortSignal: controller.signal },
+    async (chunk) => {
+      if (!controller.signal.aborted && !isRuntimeControlChunk(chunk)) {
+        emittedText += chunk;
+        push({ type: "text-delta", text: chunk });
+      }
+    },
+  )
+    .then((result) => {
+      if (!controller.signal.aborted) {
+        if (!result.reply.startsWith(emittedText)) {
+          throw new Error("Eliza Shared runtime reply diverged from streamed text");
+        }
+        const remainingText = result.reply.slice(emittedText.length);
+        if (remainingText) push({ type: "text-delta", text: remainingText });
+      }
+      push({ type: "finish", text: result.reply, usage: result.usage });
+      terminal = true;
+      signalQueue();
+    })
+    .catch((error) => {
+      terminalError = error;
+      terminal = true;
+      signalQueue();
+    })
+    .finally(() => {
+      input.abortSignal?.removeEventListener("abort", abortFromCaller);
+    });
+
+  const parts = (async function* (): AsyncIterable<SharedAgentTurnStreamPart> {
+    for (;;) {
+      while (queued.length > 0) {
+        const next = queued.shift();
+        if (next) yield next;
+      }
+      if (terminal) {
+        if (terminalError) throw terminalError;
+        return;
+      }
+      await new Promise<void>((resolve) => {
+        wake = resolve;
+      });
+    }
+  })();
+
+  return {
+    model: input.model,
+    degraded: false,
+    parts,
+    cancel: async (reason) => {
+      controller.abort(reason);
+      void completion;
+    },
+  };
 }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -993,6 +993,14 @@ export class SharedRuntimeChatService {
         messageRole,
         messageIds,
         onProviderDispatch: billing?.markProviderDispatched,
+        ...(options.executionEngine === "eliza-runtime"
+          ? {
+              execution: {
+                engine: "eliza-runtime" as const,
+                agentKey: agent.id,
+              },
+            }
+          : {}),
       });
     } catch (error) {
       detachRequestAbort();

--- a/packages/cloud/shared/tsconfig.json
+++ b/packages/cloud/shared/tsconfig.json
@@ -30,7 +30,7 @@
       "@elizaos/cloud-sdk/*": ["../sdk/src/*"],
       "@elizaos/plugin-sql": ["../../../plugins/plugin-sql/src/index.ts"],
       "@elizaos/plugin-sql/*": ["../../../plugins/plugin-sql/src/*"],
-      "@elizaos/core/edge": ["../../../packages/core/dist/edge/index.edge"],
+      "@elizaos/core/edge": ["../../../packages/core/src/index.edge.ts"],
       "@elizaos/core": ["../../../packages/core/src/index.node.ts"],
       "@elizaos/core/*": ["../../../packages/core/src/*"],
       "@elizaos/logger": ["../../logger/src/index.ts"],


### PR DESCRIPTION
## Summary

Follow-up to merged Shared-runtime PR #19811. This closes the phone-specific gap while keeping production behind the existing selector until exact-SHA staging voice proof exists.

- routes selected Shared SSE turns through the genuine Workerd `AgentRuntime` instead of the direct-model fallback
- registers the edge model handlers as stream-capable and adapts native streamed tool-call arguments into validated `replyText`
- propagates confirmed-speech barge-in cancellation through the runtime to the provider before further audio can escape
- uses the exact model-free opener `hello? who's this?` for first contact and `hey whats up` for returning callers
- records `call.started` durably and initializes the real runtime kernel during authenticated inbound prewarm, overlapping call setup, greeting, and caller speech
- keeps one deterministic personal conversation Durable Object per verified user across phone and private channels
- preserves the full durable transcript while bounding hot model context to recent plus relevant history
- source-resolves the edge graph for all Cloud TypeScript consumers
- enables the selector on protected staging only; production remains `false`

## Scale and continuity contract

- verified phone identity resolves to the same deterministic personal agent and private room used by app/private-message channels
- separate users map to separate Durable Objects; one user's turns serialize in order without one global object becoming a 100k-user bottleneck
- raw realtime audio stays on the voice WebSocket; only completed turns/history enter the conversation object
- runtime prewarm is isolate-scoped and state-free; user state remains in the per-user Durable Object

## Exact-head proof

Head: `2d3db0a9eb0d`, rebased on current `develop` after #19811 and #19833.

- 130 focused assertions PASS on the exact rebased head across genuine AgentRuntime execution, native tool use, durable hydration/history/concurrency, exact phone continuity, Cartesia incremental speech, reconnects, cancellation, and barge-in silence
- genuine-runtime tests PASS for streamed `HANDLE_RESPONSE`, provider abort before post-barge-in text, native usage, `WEB_SEARCH`, and `REMINDERS`
- runtime-kernel prewarm test proves concurrent prewarm is inference-free
- Cloud Shared typecheck: PASS
- Cloud API typecheck and production Wrangler dry bundle: PASS; dry bundle reports `SHARED_ELIZA_AGENT_RUNTIME="false"`
- container-control-plane typecheck: PASS on the exact rebased head
- `git diff --check`: PASS
- earlier root `bun run verify` reached 262 successful tasks before an unrelated `gateway-discord` missing-dependency failure (`@discordjs/voice`, `prism-media`)

## Rollout gate

Merge this staging-only change to `develop`, wait for the canonical protected-staging deployment of that exact merge SHA, then capture live phone evidence for first-turn timing, returning-history continuity, interruption silence, reconnect, and concurrent callers. Production promotion should be a separate selector change after that evidence; this PR does not mutate production.

Issue: #19772
