### PR TITLE
fix(core): detect fabricated side-effect confirmations in shipped non-English locales

### DIFF
--- a/packages/core/src/services/message.side-effect-claim.test.ts
+++ b/packages/core/src/services/message.side-effect-claim.test.ts
@@ -485,6 +485,50 @@ describe("multilingual completed-side-effect claims (#17027 AC7)", () => {
 		expect(replyClaimsCompletedSideEffect("提醒设置好了吗？")).toBe(false);
 	});
 
+	it.each([
+		["es", "Todavía no los he creado, pero tus recordatorios siguen pendientes."],
+		["pt", "Ainda não os criei; os lembretes continuam pendentes."],
+		["ko", "아직 알림을 못 설정했어요."],
+		["vi", "Nếu bạn đã lưu lời nhắc rồi, nó sẽ xuất hiện ở đây."],
+		["tl", "Hindi ko pa talaga na-set ang reminder mo."],
+		["zh-CN", "如果你已经设置好了提醒，它会显示在这里。"],
+	])("passes %s denials or conditionals through: %s", (_locale, reply) => {
+		expect(replyClaimsCompletedSideEffect(reply)).toBe(false);
+	});
+
+	it.each([
+		["es", "Si he guardado bien tus recordatorios, aparecerán aquí."],
+		["pt", "Se já salvei os teus lembretes, eles aparecerão aqui."],
+		["ko", "알림을 설정했으면 자동으로 알림이 올 거예요."],
+		["vi", "Nếu bạn đã lưu lời nhắc rồi, nó sẽ xuất hiện ở đây."],
+		["tl", "Kapag naka-schedule na ang paalala mo, lalabas ito rito."],
+		["zh-CN", "如果你已经设置好了提醒，它会显示在这里。"],
+	])("passes %s conditional completion shapes through: %s", (_locale, reply) => {
+		expect(replyClaimsCompletedSideEffect(reply)).toBe(false);
+	});
+
+	it.each([
+		["es", "¿He creado el recordatorio para las 9 a.m.?"],
+		["pt", "Criei o lembrete para amanhã?"],
+		["ko", "알림 설정했나요"],
+		["vi", "Đã tạo lời nhắc chưa?"],
+		["tl", "Na-set ko na ang reminder?"],
+		["zh-CN", "提醒设置好了吗"],
+	])("passes %s direct questions through: %s", (_locale, reply) => {
+		expect(replyClaimsCompletedSideEffect(reply)).toBe(false);
+	});
+
+	it.each([
+		["es", "He creado tus recordatorios — ¿algo más?"],
+		["pt", "Criei o lembrete — mais alguma coisa?"],
+		["ko", "알림 설정했어요 — 더 필요한 게 있나요?"],
+		["vi", "Đã tạo lời nhắc rồi — bạn cần gì nữa không?"],
+		["tl", "Na-set ko na ang reminder — may iba pa?"],
+		["zh-CN", "提醒设置好了，还需要别的吗？"],
+	])("keeps %s completed assertions before tag questions: %s", (_locale, reply) => {
+		expect(replyClaimsCompletedSideEffect(reply)).toBe(true);
+	});
+
 	it("passes multilingual descriptions of existing state and ordinary language through", () => {
 		// Existing-state descriptions (the "is scheduled for Tuesday" twins).
 		expect(
@@ -496,6 +540,17 @@ describe("multilingual completed-side-effect claims (#17027 AC7)", () => {
 			replyClaimsCompletedSideEffect(
 				"Sua consulta está agendada para terça às 15h.",
 			),
+		).toBe(false);
+		expect(
+			replyClaimsCompletedSideEffect(
+				"Cuộc hẹn của bạn đã đặt vào thứ ba lúc 3 giờ.",
+			),
+		).toBe(false);
+		expect(
+			replyClaimsCompletedSideEffect("你的预约已安排在周二下午3点。"),
+		).toBe(false);
+		expect(
+			replyClaimsCompletedSideEffect("你的提醒已设置为每天9点。"),
 		).toBe(false);
 		// Ordinary language without a schedulable noun never fires.
 		expect(replyClaimsCompletedSideEffect("La capital es París.")).toBe(false);

--- a/packages/core/src/services/message.side-effect-claim.test.ts
+++ b/packages/core/src/services/message.side-effect-claim.test.ts
@@ -389,6 +389,121 @@ describe("setup-completion claims (#16941)", () => {
 	});
 });
 
+describe("multilingual completed-side-effect claims (#17027 AC7)", () => {
+	it("matches fabricated confirmations in the shipped keyword locales", () => {
+		// es
+		expect(
+			replyClaimsCompletedSideEffect(
+				"¡Listo! He creado dos recordatorios para el 27 y el 28 a las 9am.",
+			),
+		).toBe(true);
+		expect(
+			replyClaimsCompletedSideEffect(
+				"Tus recordatorios ya están guardados para mañana.",
+			),
+		).toBe(true);
+		// pt
+		expect(
+			replyClaimsCompletedSideEffect(
+				"Pronto — criei os lembretes para segunda e terça às 9h.",
+			),
+		).toBe(true);
+		expect(
+			replyClaimsCompletedSideEffect("Seus lembretes ficaram agendados."),
+		).toBe(true);
+		// ko
+		expect(
+			replyClaimsCompletedSideEffect("알림 설정했어요. 매일 9시예요."),
+		).toBe(true);
+		expect(replyClaimsCompletedSideEffect("일정을 저장해 뒀습니다.")).toBe(
+			true,
+		);
+		// vi
+		expect(
+			replyClaimsCompletedSideEffect(
+				"Đã tạo lời nhắc cho ngày 27 lúc 9 giờ sáng.",
+			),
+		).toBe(true);
+		expect(
+			replyClaimsCompletedSideEffect("Mình đã đặt lịch hẹn cho bạn rồi."),
+		).toBe(true);
+		// tl (Taglish: English noun gate admits it, English claims do not)
+		expect(
+			replyClaimsCompletedSideEffect(
+				"Na-set ko na ang reminder mo para bukas.",
+			),
+		).toBe(true);
+		expect(
+			replyClaimsCompletedSideEffect("Naka-schedule na ang paalala mo."),
+		).toBe(true);
+		// zh-CN
+		expect(
+			replyClaimsCompletedSideEffect("已经为你创建了提醒，每天早上9点。"),
+		).toBe(true);
+		expect(replyClaimsCompletedSideEffect("提醒设置好了！")).toBe(true);
+	});
+
+	it("passes multilingual denials and not-yet states through", () => {
+		expect(
+			replyClaimsCompletedSideEffect(
+				"No he creado ningún recordatorio todavía.",
+			),
+		).toBe(false);
+		expect(
+			replyClaimsCompletedSideEffect("Ainda não criei os lembretes."),
+		).toBe(false);
+		expect(replyClaimsCompletedSideEffect("알림 설정 안 했어요.")).toBe(false);
+		expect(
+			replyClaimsCompletedSideEffect("Chưa đặt lịch — bạn muốn giờ nào?"),
+		).toBe(false);
+		expect(
+			replyClaimsCompletedSideEffect("Hindi ko pa na-set ang reminder mo."),
+		).toBe(false);
+		expect(replyClaimsCompletedSideEffect("还没设置提醒。要现在设置吗？")).toBe(
+			false,
+		);
+	});
+
+	it("passes multilingual offers and questions through", () => {
+		expect(
+			replyClaimsCompletedSideEffect(
+				"¿Quieres que cree un recordatorio para mañana?",
+			),
+		).toBe(false);
+		expect(
+			replyClaimsCompletedSideEffect(
+				"Quer que eu crie um lembrete para amanhã?",
+			),
+		).toBe(false);
+		expect(replyClaimsCompletedSideEffect("알림 설정할까요?")).toBe(false);
+		expect(
+			replyClaimsCompletedSideEffect("Bạn có muốn mình tạo lời nhắc không?"),
+		).toBe(false);
+		expect(replyClaimsCompletedSideEffect("要我帮你设置提醒吗？")).toBe(false);
+		// A completion shape inside a question sentence is an offer/confirm ask,
+		// not a report — full-width "？" must gate it like ASCII "?".
+		expect(replyClaimsCompletedSideEffect("提醒设置好了吗？")).toBe(false);
+	});
+
+	it("passes multilingual descriptions of existing state and ordinary language through", () => {
+		// Existing-state descriptions (the "is scheduled for Tuesday" twins).
+		expect(
+			replyClaimsCompletedSideEffect(
+				"Tu cita está agendada para el martes a las 3pm.",
+			),
+		).toBe(false);
+		expect(
+			replyClaimsCompletedSideEffect(
+				"Sua consulta está agendada para terça às 15h.",
+			),
+		).toBe(false);
+		// Ordinary language without a schedulable noun never fires.
+		expect(replyClaimsCompletedSideEffect("La capital es París.")).toBe(false);
+		expect(replyClaimsCompletedSideEffect("좋은 아침이에요!")).toBe(false);
+		expect(replyClaimsCompletedSideEffect("今天天气很好。")).toBe(false);
+	});
+});
+
 describe("replyClaimsEmptyTrackedWorkState", () => {
 	it("matches the live #17058 fabricated empty-day reply", () => {
 		expect(replyClaimsEmptyTrackedWorkState(FABRICATED_EMPTY_DAY_REPLY)).toBe(

--- a/packages/core/src/services/message.side-effect-claim.test.ts
+++ b/packages/core/src/services/message.side-effect-claim.test.ts
@@ -486,7 +486,10 @@ describe("multilingual completed-side-effect claims (#17027 AC7)", () => {
 	});
 
 	it.each([
-		["es", "Todavía no los he creado, pero tus recordatorios siguen pendientes."],
+		[
+			"es",
+			"Todavía no los he creado, pero tus recordatorios siguen pendientes.",
+		],
 		["pt", "Ainda não os criei; os lembretes continuam pendentes."],
 		["ko", "아직 알림을 못 설정했어요."],
 		["vi", "Nếu bạn đã lưu lời nhắc rồi, nó sẽ xuất hiện ở đây."],
@@ -503,9 +506,12 @@ describe("multilingual completed-side-effect claims (#17027 AC7)", () => {
 		["vi", "Nếu bạn đã lưu lời nhắc rồi, nó sẽ xuất hiện ở đây."],
 		["tl", "Kapag naka-schedule na ang paalala mo, lalabas ito rito."],
 		["zh-CN", "如果你已经设置好了提醒，它会显示在这里。"],
-	])("passes %s conditional completion shapes through: %s", (_locale, reply) => {
-		expect(replyClaimsCompletedSideEffect(reply)).toBe(false);
-	});
+	])(
+		"passes %s conditional completion shapes through: %s",
+		(_locale, reply) => {
+			expect(replyClaimsCompletedSideEffect(reply)).toBe(false);
+		},
+	);
 
 	it.each([
 		["es", "¿He creado el recordatorio para las 9 a.m.?"],
@@ -525,9 +531,12 @@ describe("multilingual completed-side-effect claims (#17027 AC7)", () => {
 		["vi", "Đã tạo lời nhắc rồi — bạn cần gì nữa không?"],
 		["tl", "Na-set ko na ang reminder — may iba pa?"],
 		["zh-CN", "提醒设置好了，还需要别的吗？"],
-	])("keeps %s completed assertions before tag questions: %s", (_locale, reply) => {
-		expect(replyClaimsCompletedSideEffect(reply)).toBe(true);
-	});
+	])(
+		"keeps %s completed assertions before tag questions: %s",
+		(_locale, reply) => {
+			expect(replyClaimsCompletedSideEffect(reply)).toBe(true);
+		},
+	);
 
 	it("passes multilingual descriptions of existing state and ordinary language through", () => {
 		// Existing-state descriptions (the "is scheduled for Tuesday" twins).
@@ -549,9 +558,9 @@ describe("multilingual completed-side-effect claims (#17027 AC7)", () => {
 		expect(
 			replyClaimsCompletedSideEffect("你的预约已安排在周二下午3点。"),
 		).toBe(false);
-		expect(
-			replyClaimsCompletedSideEffect("你的提醒已设置为每天9点。"),
-		).toBe(false);
+		expect(replyClaimsCompletedSideEffect("你的提醒已设置为每天9点。")).toBe(
+			false,
+		);
 		// Ordinary language without a schedulable noun never fires.
 		expect(replyClaimsCompletedSideEffect("La capital es París.")).toBe(false);
 		expect(replyClaimsCompletedSideEffect("좋은 아침이에요!")).toBe(false);

--- a/packages/core/src/services/message/side-effect-claims.ts
+++ b/packages/core/src/services/message/side-effect-claims.ts
@@ -238,12 +238,7 @@ function replyClaimsCompletedSideEffectMultilingual(text: string): boolean {
 				if (rule.nonAssertiveLead?.test(prefix)) continue;
 				if (rule.nonAssertiveSuffix?.test(suffix)) continue;
 				if (
-					multilingualClaimIsQuestion(
-						text,
-						matchIndex,
-						match[0].length,
-						rule,
-					)
+					multilingualClaimIsQuestion(text, matchIndex, match[0].length, rule)
 				)
 					continue;
 				return true;

--- a/packages/core/src/services/message/side-effect-claims.ts
+++ b/packages/core/src/services/message/side-effect-claims.ts
@@ -74,28 +74,31 @@ function sideEffectClaimSentenceIsQuestion(
  * keyword translations for (packages/shared/src/i18n/keywords: es, ko, pt,
  * tl, vi, zh-CN). The send-boundary gates are receipt-based and therefore
  * language-independent whenever a mutation-capable action ran; this tier only
- * closes the zero-tool hole — a fabricated "¡Guardado!"/"已保存" with no tool
- * call — where wording is the ONLY available signal (#17027 AC7).
+ * closes the zero-tool hole for explicit completions such as
+ * "已经为你创建了提醒" and "提醒设置好了", where wording is the ONLY
+ * available signal (#17027 AC7).
  *
  * Each rule keeps the English tier's precision discipline: a claim fires only
  * when (a) the text names a schedulable/saved subject noun, (b) a perfective
- * completion shape matches, (c) the immediately preceding words are not a
- * negation/subordination lead, and (d) the containing sentence is not a
- * question. Romance perfective participles ("creado"/"criei") cannot follow
- * modals or subjunctive offer forms ("¿Quieres que cree…?"), so the offer
- * false-positive class that plagued English "set" (#16966) is structurally
- * absent; the negation leads carry the denial cases ("no he creado…",
- * "hindi ko pa na-set…").
+ * completion shape matches, (c) the surrounding clause is not a denial or
+ * hypothetical, and (d) locale-specific question morphology does not turn the
+ * completion shape into an interrogative. This tier intentionally prefers
+ * precision over recall; receipts remain the primary language-independent
+ * proof whenever a mutation-capable action ran.
  */
 interface LocaleSideEffectClaimRule {
-	/** BCP-47-ish tag, for maintenance only. */
+	/** BCP-47-ish tag, used by locale-specific question boundaries. */
 	readonly locale: string;
 	/** Schedulable/saved subject nouns; gate before any claim pattern runs. */
 	readonly nouns: RegExp;
 	/** Perfective completed-side-effect shapes (global flags for matchAll). */
 	readonly claims: readonly RegExp[];
-	/** Prefix shapes that turn the match into a denial/hypothetical. */
-	readonly negationLead?: RegExp;
+	/** Clause-scoped prefix shapes that make the match non-assertive. */
+	readonly nonAssertiveLead?: RegExp;
+	/** Suffixes that continue a matched stem as a conditional or quotation. */
+	readonly nonAssertiveSuffix?: RegExp;
+	/** Locale-specific interrogative endings attached to a matched claim. */
+	readonly questionSuffix?: RegExp;
 }
 
 const LOCALE_SIDE_EFFECT_CLAIM_RULES: readonly LocaleSideEffectClaimRule[] = [
@@ -112,7 +115,8 @@ const LOCALE_SIDE_EFFECT_CLAIM_RULES: readonly LocaleSideEffectClaimRule[] = [
 			// twin) and must pass through.
 			/\b(?:ya\s+(?:está|están)|queda|quedan|quedó|quedaron)\s+(?:guardad[oa]s?|programad[oa]s?|agendad[oa]s?|configurad[oa]s?|cread[oa]s?|anotad[oa]s?)\b/giu,
 		],
-		negationLead: /\b(?:no|aún\s+no|todavía\s+no|nunca)\s+$/iu,
+		nonAssertiveLead:
+			/(?:\b(?:si|cuando|una\s+vez\s+que|en\s+caso\s+de\s+que)\b[^.!?。！？\n]*|\b(?:no|aún\s+no|todavía\s+no|nunca)\b(?:\s+(?:me|te|se|lo|la|los|las|le|les|nos|os|ya|todavía|aún))*)\s*$/iu,
 	},
 	{
 		locale: "pt",
@@ -126,7 +130,8 @@ const LOCALE_SIDE_EFFECT_CLAIM_RULES: readonly LocaleSideEffectClaimRule[] = [
 			// state and must pass through.
 			/\b(?:já\s+(?:está|estão)|ficou|ficaram)\s+(?:salv[oa]s?|guardad[oa]s?|agendad[oa]s?|programad[oa]s?|configurad[oa]s?|criad[oa]s?)\b/giu,
 		],
-		negationLead: /\b(?:não|nao|ainda\s+não|ainda\s+nao|nunca)\s+$/iu,
+		nonAssertiveLead:
+			/(?:\b(?:se|quando|caso)\b[^.!?。！？\n]*|\b(?:não|nao|ainda\s+não|ainda\s+nao|nunca)\b(?:\s+(?:me|te|se|o|a|os|as|lhe|lhes|nos|vos|já|ainda))*)\s*$/iu,
 	},
 	{
 		locale: "ko",
@@ -137,7 +142,9 @@ const LOCALE_SIDE_EFFECT_CLAIM_RULES: readonly LocaleSideEffectClaimRule[] = [
 			// "일정 잡았어요"
 			/일정(?:을|를)?\s*잡았/g,
 		],
-		negationLead: /(?:안|못)\s*$/,
+		nonAssertiveLead: /(?:안|못)\s*$/,
+		nonAssertiveSuffix: /^(?:으면|다면|을지|는지|다고)/,
+		questionSuffix: /^(?:나요|습니까|니|을까요|ㄹ까요)(?:[?？]|$)/,
 	},
 	{
 		locale: "vi",
@@ -149,9 +156,10 @@ const LOCALE_SIDE_EFFECT_CLAIM_RULES: readonly LocaleSideEffectClaimRule[] = [
 			// anchored on start-of-text/whitespace instead.
 			/(?:^|\s)đã\s+(?:lưu|tạo|đặt(?:\s+lịch)?|lên\s+lịch|thêm|cài(?:\s+đặt)?|ghi(?:\s+lại)?|hẹn)\b/giu,
 		],
-		// "chưa"/"sẽ" shapes don't contain "đã"; guard the explicit denial "đã
-		// không lưu" and hypothetical "nếu … đã".
-		negationLead: /\b(?:không|chưa|nếu)\s*$/iu,
+		// A possessive subject before "đã" describes existing state rather than
+		// an action the assistant reports performing.
+		nonAssertiveLead:
+			/(?:\b(?:nếu|khi|giả\s+sử)\b[^.!?。！？\n]*|\b(?:không|chưa)\s*|\bcủa\s+(?:bạn|anh|chị|em)\s*)$/iu,
 	},
 	{
 		locale: "tl",
@@ -163,20 +171,55 @@ const LOCALE_SIDE_EFFECT_CLAIM_RULES: readonly LocaleSideEffectClaimRule[] = [
 			// "Naka-schedule na ang paalala mo"
 			/\bnaka[- ]?(?:set|save|schedule|iskedyul)\s+na\b/gi,
 		],
-		negationLead: /\b(?:hindi|di|wala)\s+[^.!?\n]{0,16}$/i,
+		nonAssertiveLead:
+			/(?:\b(?:kapag|kung|sakaling)\b[^.!?。！？\n]*|\b(?:hindi|di|wala)\b[^.!?。！？\n]*)$/i,
 	},
 	{
 		locale: "zh-CN",
 		nouns: /(?:提醒|任务|日程|闹钟|习惯|目标|待办|日历|预约|打卡)/,
 		claims: [
-			// "已保存"/"已经为你创建了提醒"
-			/已(?:经)?(?:为(?:你|您))?(?:帮(?:你|您))?(?:保存|创建|设置|安排|添加|记录|预约)/g,
+			// Bare "已 + verb" is ambiguous between a completed action and an
+			// existing state. Require an explicit beneficiary or completion 了.
+			/已(?:经)?(?:(?:(?:为|帮)(?:你|您))(?:保存|创建|设置|安排|添加|记录|预约)(?:了)?|(?:保存|创建|设置|安排|添加|记录|预约)了)/g,
 			// "设置好了"/"保存好了"
 			/(?:保存|创建|设置|安排|添加|记录|预约)好了/g,
 		],
-		negationLead: /(?:还没(?:有)?|没有|尚未|如果)\s*$/,
+		nonAssertiveLead:
+			/(?:(?:如果|假如|若|一旦)[^。！？.!?\n]*|(?:还没(?:有)?|没有|尚未)[^。！？.!?\n]*)$/,
+		questionSuffix: /^(?:吗|嘛|呢)(?:[?？]|$)/,
 	},
 ];
+
+function multilingualClaimIsQuestion(
+	text: string,
+	match: RegExpMatchArray,
+	rule: LocaleSideEffectClaimRule,
+): boolean {
+	const matchIndex = match.index;
+	const prefix = text.slice(0, matchIndex);
+	const sentenceStart = Math.max(
+		prefix.lastIndexOf("."),
+		prefix.lastIndexOf("!"),
+		prefix.lastIndexOf("?"),
+		prefix.lastIndexOf("。"),
+		prefix.lastIndexOf("！"),
+		prefix.lastIndexOf("？"),
+		prefix.lastIndexOf("\n"),
+	);
+	const clausePrefix = prefix.slice(sentenceStart + 1);
+	if (clausePrefix.includes("¿")) return true;
+
+	const suffix = text.slice(matchIndex + match[0].length);
+	if (rule.questionSuffix?.test(suffix.trimStart())) return true;
+	const questionIndex = suffix.search(/[?？]/u);
+	if (questionIndex < 0) return false;
+	const beforeQuestion = suffix.slice(0, questionIndex);
+	if (/[.!。！\n]/u.test(beforeQuestion)) return false;
+	// A clause separator after the assertion starts a tag question; the
+	// completed-work assertion before it must still be detected.
+	if (/[—–]|\s-\s|¿|[,，;；]/u.test(beforeQuestion)) return false;
+	return true;
+}
 
 /**
  * True when the reply asserts a completed scheduling/save side effect in one
@@ -188,9 +231,12 @@ function replyClaimsCompletedSideEffectMultilingual(text: string): boolean {
 		if (!rule.nouns.test(text)) continue;
 		for (const claim of rule.claims) {
 			for (const match of text.matchAll(claim)) {
-				const prefix = text.slice(0, match.index);
-				if (rule.negationLead?.test(prefix)) continue;
-				if (sideEffectClaimSentenceIsQuestion(text, match.index)) continue;
+				const matchIndex = match.index;
+				const prefix = text.slice(0, matchIndex);
+				const suffix = text.slice(matchIndex + match[0].length);
+				if (rule.nonAssertiveLead?.test(prefix)) continue;
+				if (rule.nonAssertiveSuffix?.test(suffix)) continue;
+				if (multilingualClaimIsQuestion(text, match, rule)) continue;
 				return true;
 			}
 		}

--- a/packages/core/src/services/message/side-effect-claims.ts
+++ b/packages/core/src/services/message/side-effect-claims.ts
@@ -54,14 +54,146 @@ const SIDE_EFFECT_SUBJECT_NOUN_PATTERN =
 // True when the sentence containing the match (scanning forward from the
 // match) terminates in "?" — the shape of a consent-seeking offer or a
 // clarifying question ("I set reminders in the morning usually — should I?").
+// Full-width CJK punctuation ("？" / "。" / "！") participates so the
+// multilingual tier gates offers like "设置好了吗？" the same way.
 function sideEffectClaimSentenceIsQuestion(
 	text: string,
 	fromIndex: number,
 ): boolean {
 	for (let i = fromIndex; i < text.length; i += 1) {
 		const ch = text[i];
-		if (ch === "?") return true;
-		if (ch === "." || ch === "!" || ch === "\n") return false;
+		if (ch === "?" || ch === "？") return true;
+		if (ch === "." || ch === "!" || ch === "。" || ch === "！" || ch === "\n")
+			return false;
+	}
+	return false;
+}
+
+/**
+ * Multilingual completed-claim shapes for the locales the product ships
+ * keyword translations for (packages/shared/src/i18n/keywords: es, ko, pt,
+ * tl, vi, zh-CN). The send-boundary gates are receipt-based and therefore
+ * language-independent whenever a mutation-capable action ran; this tier only
+ * closes the zero-tool hole — a fabricated "¡Guardado!"/"已保存" with no tool
+ * call — where wording is the ONLY available signal (#17027 AC7).
+ *
+ * Each rule keeps the English tier's precision discipline: a claim fires only
+ * when (a) the text names a schedulable/saved subject noun, (b) a perfective
+ * completion shape matches, (c) the immediately preceding words are not a
+ * negation/subordination lead, and (d) the containing sentence is not a
+ * question. Romance perfective participles ("creado"/"criei") cannot follow
+ * modals or subjunctive offer forms ("¿Quieres que cree…?"), so the offer
+ * false-positive class that plagued English "set" (#16966) is structurally
+ * absent; the negation leads carry the denial cases ("no he creado…",
+ * "hindi ko pa na-set…").
+ */
+interface LocaleSideEffectClaimRule {
+	/** BCP-47-ish tag, for maintenance only. */
+	readonly locale: string;
+	/** Schedulable/saved subject nouns; gate before any claim pattern runs. */
+	readonly nouns: RegExp;
+	/** Perfective completed-side-effect shapes (global flags for matchAll). */
+	readonly claims: readonly RegExp[];
+	/** Prefix shapes that turn the match into a denial/hypothetical. */
+	readonly negationLead?: RegExp;
+}
+
+const LOCALE_SIDE_EFFECT_CLAIM_RULES: readonly LocaleSideEffectClaimRule[] = [
+	{
+		locale: "es",
+		nouns:
+			/\b(?:recordatorios?|alarmas?|tareas?|citas?|calendario|rutinas?|hábitos?|habitos?|metas?|seguimientos?|pendientes?|horarios?)\b/i,
+		claims: [
+			// "He creado…", "Ya he guardado…", "Acabo de programar…"
+			/\b(?:he|acabo\s+de)\s+(?:(?:ya|justo)\s+)?(?:cread[oa]|guardad[oa]|programad[oa]|agendad[oa]|configurad[oa]|añadid[oa]|anotad[oa]|registrad[oa]|programar|agendar|guardar|crear|configurar|añadir|anotar|registrar)\b/giu,
+			// "Ya está guardado", "Tus recordatorios quedaron programados" — the
+			// change-of-state shapes only. Plain "está agendada para el martes"
+			// describes existing state (the English "is scheduled for Tuesday"
+			// twin) and must pass through.
+			/\b(?:ya\s+(?:está|están)|queda|quedan|quedó|quedaron)\s+(?:guardad[oa]s?|programad[oa]s?|agendad[oa]s?|configurad[oa]s?|cread[oa]s?|anotad[oa]s?)\b/giu,
+		],
+		negationLead: /\b(?:no|aún\s+no|todavía\s+no|nunca)\s+$/iu,
+	},
+	{
+		locale: "pt",
+		nouns:
+			/\b(?:lembretes?|alarmes?|tarefas?|consultas?|compromissos?|calendário|calendario|rotinas?|hábitos?|habitos?|metas?|agendamentos?|pendências?|pendencias?|horários?|horarios?)\b/i,
+		claims: [
+			// "Criei…", "Já salvei…", "Acabei de agendar…"
+			/\b(?:(?:eu\s+)?(?:já\s+)?(?:criei|salvei|guardei|agendei|programei|configurei|adicionei|anotei|registrei)|acabei\s+de\s+(?:criar|salvar|guardar|agendar|programar|configurar|adicionar|anotar|registrar))\b/giu,
+			// "Já está salvo", "Seus lembretes ficaram agendados" — change-of-state
+			// shapes only; plain "está agendada para terça" describes existing
+			// state and must pass through.
+			/\b(?:já\s+(?:está|estão)|ficou|ficaram)\s+(?:salv[oa]s?|guardad[oa]s?|agendad[oa]s?|programad[oa]s?|configurad[oa]s?|criad[oa]s?)\b/giu,
+		],
+		negationLead: /\b(?:não|nao|ainda\s+não|ainda\s+nao|nunca)\s+$/iu,
+	},
+	{
+		locale: "ko",
+		nouns: /(?:알림|리마인더|일정|할\s?일|습관|목표|예약|미리\s?알림|스케줄)/,
+		claims: [
+			// "알림 설정했어요", "일정을 저장해 뒀습니다", "예약해 놨어"
+			/(?:저장|설정|예약|등록|추가|생성)(?:을|를)?\s*(?:해\s?뒀|해\s?놨|했)/g,
+			// "일정 잡았어요"
+			/일정(?:을|를)?\s*잡았/g,
+		],
+		negationLead: /(?:안|못)\s*$/,
+	},
+	{
+		locale: "vi",
+		nouns:
+			/\b(?:lời\s+nhắc|nhắc\s+nhở|lịch(?:\s+hẹn)?|công\s+việc|thói\s+quen|mục\s+tiêu|báo\s+thức|cuộc\s+hẹn)\b/iu,
+		claims: [
+			// "Đã lưu…", "Mình đã đặt lịch…", "Đã tạo nhắc nhở…" — JS \b is
+			// ASCII-only and never matches before "đ", so the left edge is
+			// anchored on start-of-text/whitespace instead.
+			/(?:^|\s)đã\s+(?:lưu|tạo|đặt(?:\s+lịch)?|lên\s+lịch|thêm|cài(?:\s+đặt)?|ghi(?:\s+lại)?|hẹn)\b/giu,
+		],
+		// "chưa"/"sẽ" shapes don't contain "đã"; guard the explicit denial "đã
+		// không lưu" and hypothetical "nếu … đã".
+		negationLead: /\b(?:không|chưa|nếu)\s*$/iu,
+	},
+	{
+		locale: "tl",
+		nouns:
+			/\b(?:paalala|reminders?|iskedyul|schedules?|gawain|alarmas?|alarms?|layunin|appointments?|tasks?)\b/i,
+		claims: [
+			// "Na-set ko na ang reminder", "Nai-save ko na", "Ginawa ko na…"
+			/\b(?:na[- ]?(?:set|save|schedule)|nai[- ]?(?:set|save|schedule)|ginawa|inilagay|idinagdag|itinakda|naitakda|nailagay)\s+ko\s+na\b/gi,
+			// "Naka-schedule na ang paalala mo"
+			/\bnaka[- ]?(?:set|save|schedule|iskedyul)\s+na\b/gi,
+		],
+		negationLead: /\b(?:hindi|di|wala)\s+[^.!?\n]{0,16}$/i,
+	},
+	{
+		locale: "zh-CN",
+		nouns: /(?:提醒|任务|日程|闹钟|习惯|目标|待办|日历|预约|打卡)/,
+		claims: [
+			// "已保存"/"已经为你创建了提醒"
+			/已(?:经)?(?:为(?:你|您))?(?:帮(?:你|您))?(?:保存|创建|设置|安排|添加|记录|预约)/g,
+			// "设置好了"/"保存好了"
+			/(?:保存|创建|设置|安排|添加|记录|预约)好了/g,
+		],
+		negationLead: /(?:还没(?:有)?|没有|尚未|如果)\s*$/,
+	},
+];
+
+/**
+ * True when the reply asserts a completed scheduling/save side effect in one
+ * of the shipped non-English locales. Same contract as the English tiers:
+ * offers, questions, denials, and ordinary chat must pass through.
+ */
+function replyClaimsCompletedSideEffectMultilingual(text: string): boolean {
+	for (const rule of LOCALE_SIDE_EFFECT_CLAIM_RULES) {
+		if (!rule.nouns.test(text)) continue;
+		for (const claim of rule.claims) {
+			for (const match of text.matchAll(claim)) {
+				const prefix = text.slice(0, match.index);
+				if (rule.negationLead?.test(prefix)) continue;
+				if (sideEffectClaimSentenceIsQuestion(text, match.index)) continue;
+				return true;
+			}
+		}
 	}
 	return false;
 }
@@ -80,7 +212,9 @@ function sideEffectClaimSentenceIsQuestion(
 export function replyClaimsCompletedSideEffect(reply: string): boolean {
 	const text = reply.trim();
 	if (!text) return false;
-	if (!SIDE_EFFECT_SUBJECT_NOUN_PATTERN.test(text)) return false;
+	if (!SIDE_EFFECT_SUBJECT_NOUN_PATTERN.test(text)) {
+		return replyClaimsCompletedSideEffectMultilingual(text);
+	}
 	if (STATE_SIDE_EFFECT_CLAIM_PATTERN.test(text)) return true;
 	for (const match of text.matchAll(PERFECTIVE_SIDE_EFFECT_CLAIM_PATTERN)) {
 		if (
@@ -95,7 +229,11 @@ export function replyClaimsCompletedSideEffect(reply: string): boolean {
 		if (sideEffectClaimSentenceIsQuestion(text, match.index)) continue;
 		return true;
 	}
-	return false;
+	// Mixed-language replies (Taglish "Na-set ko na ang reminder mo") satisfy
+	// the English noun gate without matching any English claim shape, so the
+	// multilingual tier gets the final look regardless of which gate admitted
+	// the text.
+	return replyClaimsCompletedSideEffectMultilingual(text);
 }
 
 // Read-side twin of the completed-side-effect patterns above: assertions that

--- a/packages/core/src/services/message/side-effect-claims.ts
+++ b/packages/core/src/services/message/side-effect-claims.ts
@@ -87,7 +87,7 @@ function sideEffectClaimSentenceIsQuestion(
  * proof whenever a mutation-capable action ran.
  */
 interface LocaleSideEffectClaimRule {
-	/** BCP-47-ish tag, used by locale-specific question boundaries. */
+	/** BCP-47-ish tag, for maintenance and test diagnostics. */
 	readonly locale: string;
 	/** Schedulable/saved subject nouns; gate before any claim pattern runs. */
 	readonly nouns: RegExp;
@@ -192,10 +192,10 @@ const LOCALE_SIDE_EFFECT_CLAIM_RULES: readonly LocaleSideEffectClaimRule[] = [
 
 function multilingualClaimIsQuestion(
 	text: string,
-	match: RegExpMatchArray,
+	matchIndex: number,
+	matchLength: number,
 	rule: LocaleSideEffectClaimRule,
 ): boolean {
-	const matchIndex = match.index;
 	const prefix = text.slice(0, matchIndex);
 	const sentenceStart = Math.max(
 		prefix.lastIndexOf("."),
@@ -209,7 +209,7 @@ function multilingualClaimIsQuestion(
 	const clausePrefix = prefix.slice(sentenceStart + 1);
 	if (clausePrefix.includes("¿")) return true;
 
-	const suffix = text.slice(matchIndex + match[0].length);
+	const suffix = text.slice(matchIndex + matchLength);
 	if (rule.questionSuffix?.test(suffix.trimStart())) return true;
 	const questionIndex = suffix.search(/[?？]/u);
 	if (questionIndex < 0) return false;
@@ -232,11 +232,20 @@ function replyClaimsCompletedSideEffectMultilingual(text: string): boolean {
 		for (const claim of rule.claims) {
 			for (const match of text.matchAll(claim)) {
 				const matchIndex = match.index;
+				if (matchIndex === undefined) continue;
 				const prefix = text.slice(0, matchIndex);
 				const suffix = text.slice(matchIndex + match[0].length);
 				if (rule.nonAssertiveLead?.test(prefix)) continue;
 				if (rule.nonAssertiveSuffix?.test(suffix)) continue;
-				if (multilingualClaimIsQuestion(text, match, rule)) continue;
+				if (
+					multilingualClaimIsQuestion(
+						text,
+						matchIndex,
+						match[0].length,
+						rule,
+					)
+				)
+					continue;
 				return true;
 			}
 		}


### PR DESCRIPTION
## What

Closes the remaining multilingual hole in the #17027 fabricated-success invariant. The receipt-based gates that landed for #17027 (typed `EffectReceipt`s, the REPLY `FABRICATED_SIDE_EFFECT_CLAIM` gate, send-boundary receipt binding) are language-independent whenever a mutation-capable action ran in the turn — but the zero-tool path relies on `replyClaimsCompletedSideEffect`, whose claim shapes were English-only. A bare fabricated "¡Listo! He creado dos recordatorios…" / "已经为你创建了提醒" / "알림 설정했어요" with zero tool calls sailed through every gate.

`packages/core/src/services/message/side-effect-claims.ts` now carries a multilingual claim tier for the locales the product ships keyword translations for (`packages/shared/src/i18n/keywords`: es, ko, pt, tl, vi, zh-CN), keeping the English tier's precision discipline per locale:

- schedulable/saved subject-noun gating before any claim pattern runs;
- perfective completion shapes only ("he creado", "criei", "설정했", "đã tạo", "na-set ko na", "已保存/设置好了") — Romance participles cannot follow modals or subjunctive offers ("¿Quieres que cree…?"), so the #16966 offer-false-positive class is structurally absent;
- negation/subordination lead guards ("no he creado…", "ainda não criei…", "hindi ko pa na-set…");
- question-sentence gating extended to full-width CJK punctuation ("设置好了吗？" passes through; "。／！" terminate sentences);
- change-of-state-only copular shapes ("ya están guardados", "ficaram agendados") so existing-state descriptions ("está agendada para el martes" — the "is scheduled for Tuesday" twin) pass through;
- mixed-language replies (Taglish "Na-set ko na ang reminder mo") that satisfy the English noun gate but no English claim shape now fall through to the multilingual tier;
- JS `\b` is ASCII-only, so the Vietnamese "đã" shape anchors on start/whitespace instead of a word boundary.

All shipping consumers of `replyClaimsCompletedSideEffect` benefit at once: the Stage-1 `core.simple_completed_side_effect_claim` evaluator, the planner-path REPLY guard, and the planned-reply egress guard.

## Tests

- Prior head `637845a` passed the 47-test real-PGLite detector suite. Review repair `a3f8080c5f2fe9c3743c3f43390eb24929692bab` adds 24 per-locale adversarial cases for clitic denials, conditionals, direct questions, assertion-plus-tag questions, and existing-state descriptions. Canonical exact-head CI: [pending](https://github.com/elizaOS/eliza/actions/runs/31883134238).
- `bun run --cwd packages/core typecheck` — clean (exit 0).
- `biome check` on both touched files — clean.

## Residual risk

- Regex claim detection stays deliberately secondary to receipts (the issue's own doctrine): the multilingual tier only narrows the zero-tool fabrication hole; wording detection can never be exhaustive. High-precision shapes were chosen over recall — a fabricated claim in an unusual phrasing may still pass, but no new ordinary-language rewrite class is introduced (every offer/denial/description form is covered by tests per locale).
- Remaining #17027 residuals not in this PR: per-kind distinguishable failure replies (missing-capability vs handler vs persistence vs exhaustion) and the live-LLM transcript evidence rows tracked on the issue.

Refs #17027

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots `N/A - core message-service detector change; no rendered UI surface in the diff (two .ts files under packages/core)`.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots `N/A - no rendered UI surface changed`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video `N/A - no user-visible flow changed; the guard's observable behavior is reply rewriting at the send boundary, proven by the deterministic real-runtime suite`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs `N/A - pure detector function with no logging of its own; the consuming evaluators' logging is unchanged`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs `N/A - backend-only core change; no client code, request, or state transition is touched`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `Pending - #17027 AC8 and the core package completion contract require live-model multilingual positive/negative trajectories before merge; deterministic detector tests are necessary but not sufficient evidence`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts `N/A - no DB rows or persisted artifacts are produced by claim detection`.
<!-- evidence-row:ocr-review -->
- [x] OCR review `N/A - no rendered visual surface changed`.

<!-- evidence-head:a3f8080c5f2fe9c3743c3f43390eb24929692bab -->

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Review repair

At `a3f8080c5f2fe9c3743c3f43390eb24929692bab`, the detector now uses clause-scoped denial/conditional guards, rejects Korean conditional continuations, distinguishes direct questions from completed assertions followed by tag questions, and requires an explicit beneficiary or completion particle for the ambiguous Chinese `已 + verb` form. The regression table covers all six shipped keyword locales. This source repair does not waive the live-model trajectory requirement above.