### PR TITLE
fix(discord): expose voice controls as subcommands

### DIFF
--- a/packages/cloud/services/gateway-discord/src/managed-guild-voice.ts
+++ b/packages/cloud/services/gateway-discord/src/managed-guild-voice.ts
@@ -51,14 +51,14 @@ export const MANAGED_VOICE_COMMAND = {
   defaultMemberPermissions: PermissionFlagsBits.ManageGuild,
   options: [
     {
-      name: "mode",
-      description: "Join or leave voice",
-      type: ApplicationCommandOptionType.String,
-      required: true,
-      choices: [
-        { name: "join", value: "join" },
-        { name: "leave", value: "leave" },
-      ],
+      name: "join",
+      description: "Join your current voice channel",
+      type: ApplicationCommandOptionType.Subcommand,
+    },
+    {
+      name: "leave",
+      description: "Leave your voice channel",
+      type: ApplicationCommandOptionType.Subcommand,
     },
   ],
 } as const;
@@ -280,8 +280,8 @@ export class ManagedGuildVoiceController {
       return;
     }
 
-    const mode = interaction.options.getString("mode", true);
-    if (mode === "leave") {
+    const subcommand = interaction.options.getSubcommand(true);
+    if (subcommand === "leave") {
       const session = this.sessions.get(interaction.guildId);
       if (!session || session.ownerDiscordUserId !== interaction.user.id) {
         await interaction.reply({
@@ -304,7 +304,7 @@ export class ManagedGuildVoiceController {
     if (!channel?.isVoiceBased() || channel.guild.id !== interaction.guildId) {
       await interaction.reply({
         content:
-          "Join a voice channel in this server first, then run `/voice mode:join`.",
+          "Join a voice channel in this server first, then run `/voice join`.",
         ephemeral: true,
       });
       return;

--- a/packages/cloud/services/gateway-discord/tests/managed-guild-voice.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/managed-guild-voice.test.ts
@@ -36,7 +36,7 @@ function clientHarness() {
 }
 
 function interactionHarness(
-  mode: "join" | "leave",
+  subcommand: "join" | "leave",
   userId = "111111111111111",
 ) {
   const reply = mock(async () => undefined);
@@ -68,7 +68,7 @@ function interactionHarness(
         has: (permission: bigint) =>
           permission === PermissionFlagsBits.ManageGuild,
       },
-      options: { getString: () => mode },
+      options: { getSubcommand: () => subcommand },
       reply,
       deferReply,
       editReply,
@@ -95,6 +95,10 @@ describe("ManagedGuildVoiceController", () => {
     await controller.start();
     expect(harness.create).toHaveBeenCalledTimes(1);
     expect(harness.create.mock.calls[0]?.[0]).toEqual(MANAGED_VOICE_COMMAND);
+    expect(MANAGED_VOICE_COMMAND.options.map((option) => option.name)).toEqual([
+      "join",
+      "leave",
+    ]);
     await controller.stop();
   });
 


### PR DESCRIPTION
Closes #19826.

Changes the managed guild voice command from `/voice mode:join|leave` to native Discord subcommands: `/voice join` and `/voice leave`. The authorization and channel-isolation boundaries are unchanged.

Validation:
- gateway-discord typecheck
- gateway-discord tests: 69 pass, 0 fail, 202 assertions
- gateway-discord build: 736 modules
- focused managed voice tests: 4 pass
- Biome changed files
- git diff --check