### PR TITLE
fix(cloud): type TTS byte responses without BodyInit double assertions

### DIFF
--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -303,7 +303,7 @@ async function __hono_POST(c: AppContext) {
             logger.info(
               `[Voice TTS API] Kokoro first-line cache HIT (${cached.byteSize}B, hits=${cached.hitCount}, voice=${kokoroVoice}) — no upstream request`,
             );
-            return new Response(cached.bytes as unknown as BodyInit, {
+            return new Response(cached.bytes, {
               status: 200,
               headers: {
                 "Content-Type": cached.contentType,
@@ -383,7 +383,7 @@ async function __hono_POST(c: AppContext) {
             );
           });
 
-        return new Response(bytes as unknown as BodyInit, {
+        return new Response(bytes, {
           status: 200,
           headers: {
             "Content-Type": kokoroContentType,
@@ -467,7 +467,7 @@ async function __hono_POST(c: AppContext) {
           logger.info(
             `[Voice TTS API] first-line cache HIT (${cacheScope}, ${cached.byteSize}B, hits=${cached.hitCount})`,
           );
-          return new Response(cached.bytes as unknown as BodyInit, {
+          return new Response(cached.bytes, {
             headers: {
               "Content-Type": cached.contentType,
               "Cache-Control": "no-cache",
@@ -523,7 +523,7 @@ async function __hono_POST(c: AppContext) {
           logger.info(
             `[Voice TTS API] WAV first-line cache HIT (${cached.byteSize}B, hits=${cached.hitCount})`,
           );
-          return new Response(cached.bytes as unknown as BodyInit, {
+          return new Response(cached.bytes, {
             headers: {
               "Content-Type": "audio/wav",
               "Cache-Control": "no-cache",

--- a/packages/cloud/shared/src/lib/services/tts-first-line-cache.ts
+++ b/packages/cloud/shared/src/lib/services/tts-first-line-cache.ts
@@ -86,7 +86,9 @@ export interface CloudFirstLineCacheKey {
 }
 
 export interface CloudFirstLineCacheEntry extends CloudFirstLineCacheKey {
-  bytes: Uint8Array;
+  /** Owned copy backed by a plain ArrayBuffer so callers can hand it straight
+   * to `Response` without asserting away SharedArrayBuffer possibilities. */
+  bytes: Uint8Array<ArrayBuffer>;
   rawText: string;
   contentType: string;
   durationMs: number;
@@ -192,7 +194,7 @@ export function shouldBypassCloudFirstLineCache(args: {
 // R2 read + write helpers
 // ---------------------------------------------------------------------------
 
-async function r2GetBytes(blobKey: string): Promise<Uint8Array | null> {
+async function r2GetBytes(blobKey: string): Promise<Uint8Array<ArrayBuffer> | null> {
   const bucket = getRuntimeR2Bucket();
   if (!bucket) return null;
   try {


### PR DESCRIPTION
Part of #16003 (final code residual; the issue stays open only for the external live-route/device acceptance evidence).

## What

- `packages/cloud/shared/src/lib/services/tts-first-line-cache.ts`: `CloudFirstLineCacheEntry.bytes` and `r2GetBytes()` are now typed `Uint8Array<ArrayBuffer>`, matching what the runtime actually produces (R2 `arrayBuffer()` and `TextEncoder.encode`).
- `packages/cloud/api/v1/voice/tts/route.ts`: the four cache-hit / Kokoro cache-miss byte responses pass their bytes to `Response` directly; all `as unknown as BodyInit` double assertions are removed (zero remaining in `packages/cloud`).

Context: the bounded two-copy PCM16→WAV encoder, 16 MiB ceilings for both Cartesia and ElevenLabs, owned-chunk copies, byte-rate bounds, cancel/read-failure error preservation, and route-level WAV/refund/no-bill/no-cache coverage already landed on develop (893f7404b16, 79802763779). This closes the last standards-typed-body item from the issue triage.

## Tests

- `packages/cloud/api` TTS route suites in isolation: cartesia-synthesis 8/8, kokoro-first-line-cache 15/15, provider-selection 8/8, route-provider-selection 16/16 (all pass; the aggregated single-process `bun test __tests__` run has a pre-existing cross-file module-mock error on clean develop, identical before/after this change).
- `packages/cloud/shared`: pcm16-wav 9/9, tts-first-line-cache 8/8.
- `bun run typecheck` in both `packages/cloud/shared` and `packages/cloud/api` (includes Worker bundle dry-run): pass.
- Biome check on both changed files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:e3db3c21124f64fcf84935020eaa1092bf0d6869 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Backend-only byte typing change with no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Backend-only byte typing change with no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No interactive or user-facing flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - Static byte-body typing only; exact-head shared/API typechecks and Worker dry-run passed without invoking a live TTS provider.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend or browser request surface changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No prompt, model, provider selection, or inference behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No database, cache-key, audio encoding, billing, or durable artifact behavior changed.

<!-- evidence-row:ocr-review -->
- [ ] N/A - No rendered visual text changed.
