### PR TITLE
fix(cloud): resolve control-plane edge sources

### DIFF
--- a/packages/cloud/services/container-control-plane/tsconfig.json
+++ b/packages/cloud/services/container-control-plane/tsconfig.json
@@ -23,10 +23,16 @@
       "@elizaos/core/*": ["../../../../packages/core/src/*"],
       "@elizaos/logger": ["../../../logger/src/index.ts"],
       "@elizaos/logger/*": ["../../../logger/src/*"],
+      "@elizaos/plugin-scheduling/edge": [
+        "../../../../plugins/plugin-scheduling/src/edge.ts"
+      ],
       "@elizaos/plugin-sql": [
         "../../../../plugins/plugin-sql/src/index.node.ts"
       ],
       "@elizaos/plugin-sql/*": ["../../../../plugins/plugin-sql/src/*"],
+      "@elizaos/plugin-web-search/edge": [
+        "../../../../plugins/plugin-web-search/src/edge.ts"
+      ],
       "drizzle-orm": ["../../../node_modules/drizzle-orm"],
       "drizzle-orm/*": ["../../../node_modules/drizzle-orm/*"],
       "@/*": ["../../../*"]


### PR DESCRIPTION
## What

Fixes the remaining direct-source Cloud Shared typecheck race from #19827. The container control-plane maps `@elizaos/cloud-shared` to source, so TypeScript follows `shared-eliza-runtime.ts` but does not inherit the shared project's path aliases. Map both edge entrypoints to their source files in the consuming project, matching the repaired Cloud API contract.

Without these mappings, a clean root verify can fail with `TS2307` for `@elizaos/plugin-web-search/edge`; scheduling can also resolve only incidentally if another concurrent Turbo task happens to build it first.

## Verification

- Reproduced during `bun install --frozen-lockfile && bun run verify` on `develop` at `67eff933590a`: 328/348 tasks completed before `@elizaos/container-control-plane#typecheck` failed on the missing edge module.
- `bun run --cwd packages/cloud/services/container-control-plane typecheck` — passed.
- `bun run --cwd packages/cloud/services/container-control-plane lint` — passed, 5 files checked.
- `git diff --check` — passed.

Closes #19827.

<!-- evidence-head:61c7b86cface09a90489adbf31f586dd76d61311 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - TypeScript module-resolution metadata only; no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - TypeScript module-resolution metadata only; no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No user-facing runtime flow changes.
<!-- evidence-row:backend-logs -->
- [ ] N/A - TypeScript module-resolution metadata only; exact-head package typecheck and lint pass, and no runtime backend behavior changes.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend runtime change.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No model, prompt, provider, or inference behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No domain artifact changes.
<!-- evidence-row:ocr-review -->
- [ ] N/A - No rendered UI changes.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI / gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`
