### PR TITLE
fix(cloud): link unowned verified phone to existing Steward user

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/users-promote-phone-personal-account.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/users-promote-phone-personal-account.test.ts
@@ -357,6 +357,29 @@ describe("UsersRepository phone identity transactions (real PGlite)", () => {
     });
   });
 
+  test("treats the subject's own mature account as a promotion conflict, so sync must link instead", async () => {
+    const phoneNumber = "+14155550216";
+    const mature = await createMatureUser();
+
+    // No synthetic phone account exists; the subject already owns a canonical
+    // row. Promotion cannot distinguish the caller from a hostile claimant
+    // here, so Steward sync resolves the subject first and links the unowned
+    // verified phone through linkVerifiedPhone (#19365).
+    const result = await usersRepository.promotePhonePersonalAccountToSteward({
+      phoneNumber,
+      stewardUserId: mature.user.steward_user_id,
+    });
+    expect(result).toEqual({ status: "steward_subject_owned_by_other_user" });
+
+    const linked = await usersRepository.linkVerifiedPhone(mature.user.id, phoneNumber);
+    expect(linked).toMatchObject({ phone_number: phoneNumber, phone_verified: true });
+    const [projection] = await dbWrite
+      .select()
+      .from(userIdentities)
+      .where(eq(userIdentities.user_id, mature.user.id));
+    expect(projection).toMatchObject({ phone_number: phoneNumber, phone_verified: true });
+  });
+
   test("rolls back when another mature account already owns the verified phone", async () => {
     const phoneNumber = "+14155550214";
     const owner = await createMatureUser();

--- a/packages/cloud/shared/src/lib/steward-sync-verified-phone-link.test.ts
+++ b/packages/cloud/shared/src/lib/steward-sync-verified-phone-link.test.ts
@@ -169,7 +169,8 @@ beforeEach(() => {
   phoneLinkConflict = false;
   findPendingPhoneTelegramPersonalAccountConvergence.mockReset();
   findPendingPhoneTelegramPersonalAccountConvergence.mockResolvedValue({ status: "not_found" });
-  promotePhonePersonalAccountToSteward.mockClear();
+  promotePhonePersonalAccountToSteward.mockReset();
+  promotePhonePersonalAccountToSteward.mockResolvedValue({ status: "not_found" });
   linkVerifiedPhone.mockClear();
 });
 
@@ -281,6 +282,63 @@ describe("syncUserFromSteward verified-phone mature-account convergence", () => 
     });
     expect(emailUser.steward_user_id).toBe("legacy-subject");
     expect(callsFor("upsertStewardIdentity")).toHaveLength(0);
+  });
+
+  test("links an unowned verified phone to the existing Steward subject without attempting promotion", async () => {
+    emailUser = matureUser({ steward_user_id: "steward-existing" });
+    // Real repository behavior for this state: the subject already owns a
+    // canonical row, so promotion would misreport it as owned by another user
+    // and 409 the first verified-phone session (#19365).
+    promotePhonePersonalAccountToSteward.mockResolvedValue({
+      status: "steward_subject_owned_by_other_user" as never,
+    });
+
+    const result = await syncUserFromSteward({
+      stewardUserId: "steward-existing",
+      verifiedPhone: PHONE,
+    });
+
+    expect(result.id).toBe("mature-user");
+    expect(result.phone_number).toBe(PHONE);
+    expect(result.phone_verified).toBe(true);
+    expect(promotePhonePersonalAccountToSteward).not.toHaveBeenCalled();
+    expect(callsFor("linkVerifiedPhone")).toEqual([["mature-user", PHONE]]);
+  });
+
+  test("repeats the existing-subject phone link idempotently on retry", async () => {
+    emailUser = matureUser({ steward_user_id: "steward-existing" });
+    promotePhonePersonalAccountToSteward.mockResolvedValue({
+      status: "steward_subject_owned_by_other_user" as never,
+    });
+    const params = { stewardUserId: "steward-existing", verifiedPhone: PHONE };
+
+    const first = await syncUserFromSteward(params);
+    const retry = await syncUserFromSteward(params);
+
+    expect(first.id).toBe("mature-user");
+    expect(retry.id).toBe("mature-user");
+    expect(promotePhonePersonalAccountToSteward).not.toHaveBeenCalled();
+    expect(callsFor("create")).toHaveLength(0);
+    expect(callsFor("linkVerifiedPhone")).toEqual([
+      ["mature-user", PHONE],
+      ["mature-user", PHONE],
+    ]);
+  });
+
+  test("fails closed for an existing subject when another account owns the phone", async () => {
+    emailUser = matureUser({ steward_user_id: "steward-existing" });
+    phoneLinkConflict = true;
+
+    await expect(
+      syncUserFromSteward({
+        stewardUserId: "steward-existing",
+        verifiedPhone: PHONE,
+      }),
+    ).rejects.toMatchObject<Partial<InstanceType<typeof StewardPhoneAccountConflictError>>>({
+      reason: "verified_phone_unique_conflict",
+    });
+    expect(emailUser).toMatchObject({ phone_number: null, phone_verified: false });
+    expect(promotePhonePersonalAccountToSteward).not.toHaveBeenCalled();
   });
 
   test("links the verified phone in unique-conflict recovery before returning the mature row", async () => {

--- a/packages/cloud/shared/src/lib/steward-sync.ts
+++ b/packages/cloud/shared/src/lib/steward-sync.ts
@@ -595,10 +595,19 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
     }
   }
 
+  // ── 1. Existing user by steward_user_id ──────────────────────────────
+  // The canonical subject is resolved before phone-account promotion:
+  // promotion claims only a synthetic `phone:<E.164>` account for a subject
+  // with no canonical row, so attempting it for an established user would
+  // misread the subject's own account as `steward_subject_owned_by_other_user`
+  // and 409 the first verified-phone session (#19365). An existing user links
+  // the unowned verified phone through the existing-user path below instead.
+  let user = claimedTelegramUser ?? (await usersService.getByStewardId(stewardUserId));
+
   // A signed inbound text creates a phone-only personal account before any
   // browser session exists. SMS login may claim only that exact synthetic
   // account. Stable user/org ids keep its Shared history attached.
-  if (verifiedPhone && !claimedTelegramUser) {
+  if (verifiedPhone && !user) {
     const promotion = await usersRepository.promotePhonePersonalAccountToSteward({
       phoneNumber: verifiedPhone,
       stewardUserId,
@@ -625,9 +634,6 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
       throw new StewardPhoneAccountConflictError(promotion.status);
     }
   }
-
-  // ── 1. Existing user by steward_user_id ──────────────────────────────
-  let user = claimedTelegramUser ?? (await usersService.getByStewardId(stewardUserId));
 
   if (user) {
     // Telegram promotion updates canonical and projected ownership in one


### PR DESCRIPTION
Fixes #19365

## Problem

The first verified-phone Steward session for an existing Cloud user returned HTTP 409 `verified_phone_conflict`. `syncUserFromSteward` attempted `promotePhonePersonalAccountToSteward` before resolving the canonical subject; the promotion transaction sees the subject's own canonical row (with no synthetic `phone:<E.164>` account to claim) and reports `steward_subject_owned_by_other_user`, which the sync translated into a phone-account conflict.

## Fix

`packages/cloud/shared/src/lib/steward-sync.ts`: resolve the canonical Steward subject (`getByStewardId`) before the phone-account promotion block and gate promotion on the subject having **no** canonical account. An existing user with an independently bearer-verified, unowned phone now flows through the existing-user `linkVerifiedPhoneForStewardSync` path, which links phone ownership on the canonical user and the identity projection in one transaction and preserves the user's organization. Phones owned by any other account (mature/guest/provisional) remain fail-closed conflicts with no partial mutation — the unique-violation rollback contract in `usersRepository.linkVerifiedPhone` is unchanged.

## Tests

- `src/lib/steward-sync-verified-phone-link.test.ts` — 3 new decision-tree regressions: existing-subject + unowned-phone success (promotion mock returns the real repo's `steward_subject_owned_by_other_user` for this state, so the test fails on the pre-fix ordering), retry idempotency (no duplicate account, repeated link is idempotent), different-owner fail-closed conflict with no phone mutation. Also hardened the promotion mock reset so per-test resolved values cannot leak.
- `src/db/repositories/__tests__/users-promote-phone-personal-account.test.ts` — new real-PGlite test pinning the repository contract the fix depends on: an unowned phone + subject-owned canonical row is a promotion conflict, and `linkVerifiedPhone` links both canonical and projection rows for that same state.

Results (worktree on `origin/develop` a196699f8ec):
- `bun test src/lib/steward-sync` → 45 pass / 0 fail (9 files)
- `bun test src/db/repositories/__tests__/users-promote-phone-personal-account.test.ts` → 14 pass / 0 fail (real PGlite)
- `tsc --noEmit -p packages/cloud/shared/tsconfig.json` → clean
- `biome check` on touched files → clean

Note: #19365 carried a >24h-old claim comment with no PR opened; proceeding per stale-claim guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:941e68ea3a56de2d9e373c22652a8c5481d03a2c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Backend-only identity synchronization; no rendered UI changes.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Backend-only identity synchronization; no rendered UI changes.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No user-facing interactive flow changes.

<!-- evidence-row:backend-logs -->
- [ ] N/A - Exact-head deterministic and real-PGlite suites exercise the sync/repository boundary; no production user mutation is appropriate during review.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend runtime change.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No model, prompt, provider, or inference behavior changes.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No generated artifact; exact-head real-PGlite tests verify canonical and identity-projection linkage plus rollback.

<!-- evidence-row:ocr-review -->
- [ ] N/A - No rendered UI changes.
