### PR TITLE
fix(core): distinguishable failure replies per turn-failure cause (#17027 AC6)

### DIFF
--- a/packages/core/src/services/__tests__/failure-reply-prompt.test.ts
+++ b/packages/core/src/services/__tests__/failure-reply-prompt.test.ts
@@ -6,11 +6,14 @@
  */
 import { APICallError, RetryError } from "ai";
 import { describe, expect, it } from "vitest";
+import { TrajectoryLimitExceeded } from "../../runtime/limits";
 import { ModelType } from "../../types";
 import {
 	buildFailureReplyPrompt,
+	classifyTurnFailureCause,
 	isModelProviderFallbackError,
 	isRateLimitError,
+	TURN_FAILURE_FALLBACK_REPLIES,
 } from "../message";
 
 /**
@@ -270,6 +273,120 @@ describe("isModelProviderFallbackError", () => {
 				statusCode,
 			});
 			expect(isModelProviderFallbackError(err)).toBe(false);
+		}
+	});
+});
+
+/**
+ * #17027 AC6 — the four terminal turn-failure shapes (missing capability,
+ * planner exhaustion, handler failure, persistence failure) must classify
+ * distinctly and produce visibly different, never-success-shaped replies.
+ */
+describe("classifyTurnFailureCause", () => {
+	it("maps required-tool misses and unavailable-tool retries to capability_unavailable", () => {
+		for (const kind of ["required_tool_misses", "unavailable_tool_calls"]) {
+			expect(
+				classifyTurnFailureCause(
+					new TrajectoryLimitExceeded({
+						kind: kind as never,
+						max: 3,
+						observed: 4,
+					}),
+				),
+			).toBe("capability_unavailable");
+		}
+	});
+
+	it("maps repeated handler failures to execution_failed", () => {
+		expect(
+			classifyTurnFailureCause(
+				new TrajectoryLimitExceeded({
+					kind: "repeated_failures",
+					max: 2,
+					observed: 3,
+				}),
+			),
+		).toBe("execution_failed");
+	});
+
+	it("maps budget exhaustion kinds to planner_exhausted", () => {
+		for (const kind of [
+			"tool_calls",
+			"terminal_only_continuations",
+			"trajectory_token_budget",
+		]) {
+			expect(
+				classifyTurnFailureCause(
+					new TrajectoryLimitExceeded({
+						kind: kind as never,
+						max: 16,
+						observed: 17,
+					}),
+				),
+			).toBe("planner_exhausted");
+		}
+	});
+
+	it("maps CAPABILITY_UNAVAILABLE and *_PERSISTENCE_FAILED codes", () => {
+		const capability = Object.assign(new Error("no fs here"), {
+			code: "CAPABILITY_UNAVAILABLE",
+		});
+		expect(classifyTurnFailureCause(capability)).toBe("capability_unavailable");
+		const persistence = Object.assign(new Error("write failed"), {
+			code: "MESSAGE_OUTBOUND_MEMORY_PERSISTENCE_FAILED",
+		});
+		expect(classifyTurnFailureCause(persistence)).toBe("persistence_failed");
+	});
+
+	it("returns null for unclassified errors and non-errors", () => {
+		expect(classifyTurnFailureCause(new Error("boom"))).toBeNull();
+		expect(classifyTurnFailureCause(undefined)).toBeNull();
+		expect(classifyTurnFailureCause("string failure")).toBeNull();
+	});
+});
+
+describe("buildFailureReplyPrompt turn-failure framing", () => {
+	const RECENT = "@user: track my workouts and check in daily";
+
+	it("frames capability_unavailable as a missing ability with no retry suggestion", () => {
+		const prompt = buildFailureReplyPrompt(RECENT, "capability_unavailable");
+		expect(prompt).toContain("do not have that ability");
+		expect(prompt).toContain("nothing was set up, saved, or changed");
+		expect(prompt).not.toContain("suggest a retry");
+		expect(prompt).toContain("NEVER answer the user's question on the merits");
+	});
+
+	it("frames planner_exhausted, execution_failed, and persistence_failed as NOT completed", () => {
+		for (const cause of [
+			"planner_exhausted",
+			"execution_failed",
+			"persistence_failed",
+		] as const) {
+			const prompt = buildFailureReplyPrompt(RECENT, cause);
+			expect(prompt).toContain("NOT");
+			expect(prompt).toContain(
+				"NEVER claim anything was saved, scheduled, created, updated, or set up",
+			);
+			expect(prompt).toContain("suggest a retry");
+		}
+	});
+
+	it("keeps the generic transient framing when no cause is classified", () => {
+		const prompt = buildFailureReplyPrompt(RECENT, null);
+		expect(prompt).toContain("transient model error");
+		expect(prompt).toBe(buildFailureReplyPrompt(RECENT));
+	});
+});
+
+describe("TURN_FAILURE_FALLBACK_REPLIES", () => {
+	it("gives each cause a distinct reply that denies completion", () => {
+		const texts = Object.values(TURN_FAILURE_FALLBACK_REPLIES);
+		expect(new Set(texts).size).toBe(texts.length);
+		for (const text of texts) {
+			expect(/nothing was saved|not done|did not stick/i.test(text)).toBe(true);
+			expect(/\bI (saved|scheduled|created|set up|updated)\b/i.test(text)).toBe(
+				false,
+			);
 		}
 	});
 });

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -353,11 +353,14 @@ import {
 } from "./message/direct-action-heuristics";
 import {
 	buildFailureReplyPrompt,
+	classifyTurnFailureCause,
 	INSUFFICIENT_CREDITS_REPLY,
 	isAuthError,
 	isInsufficientCreditsError,
 	isRateLimitError,
 	stripReasoningBlocks,
+	TURN_FAILURE_FALLBACK_REPLIES,
+	type TurnFailureCause,
 } from "./message/fallback-reply";
 import {
 	extractGenerateTextContentText,
@@ -1580,6 +1583,7 @@ export function shouldSkipResponseMemoryPersistence(memory: Memory): boolean {
 
 export {
 	buildFailureReplyPrompt,
+	classifyTurnFailureCause,
 	INSUFFICIENT_CREDITS_REPLY,
 	isAuthError,
 	isInsufficientCreditsError,
@@ -1587,6 +1591,8 @@ export {
 	isModelProviderFallbackError,
 	isRateLimitError,
 	stripReasoningBlocks,
+	TURN_FAILURE_FALLBACK_REPLIES,
+	type TurnFailureCause,
 } from "./message/fallback-reply";
 export {
 	type EffectiveMuteState,
@@ -12576,6 +12582,7 @@ export class DefaultMessageService implements IMessageService {
 						state,
 						responseId,
 						"running the native tool message runtime",
+						error,
 					);
 					_usedV5Runtime = true;
 					state = strategyResult.state;
@@ -14057,7 +14064,15 @@ export class DefaultMessageService implements IMessageService {
 		state: State,
 		responseId: UUID,
 		stage: string,
+		cause?: unknown,
 	): Promise<StrategyResult> {
+		// Classify the error that killed the turn so the reply is honest about
+		// WHAT failed (#17027 AC6): missing capability, planner exhaustion,
+		// handler failure, and persistence failure each get a visibly distinct
+		// reply that states the request was NOT completed, instead of one
+		// generic "something went wrong".
+		const turnFailureCause: TurnFailureCause | null =
+			classifyTurnFailureCause(cause);
 		// Short-circuit when no LLM provider is configured at all. The fallback
 		// model loop below would just throw `NoModelProviderConfiguredError` for
 		// every model type and surface a misleading generic failure to the user.
@@ -14076,7 +14091,10 @@ export class DefaultMessageService implements IMessageService {
 			state,
 			message,
 		);
-		const failurePrompt = buildFailureReplyPrompt(recentMessages);
+		const failurePrompt = buildFailureReplyPrompt(
+			recentMessages,
+			turnFailureCause,
+		);
 
 		const attempt = await this.generateFailureReplyText(
 			runtime,
@@ -14116,6 +14134,11 @@ export class DefaultMessageService implements IMessageService {
 				replyText =
 					(typeof tmpl === "function" ? tmpl({ state }) : tmpl) ||
 					"My Eliza Cloud key isn't authorized for inference right now — check that your cloud key is valid and your account has credits, then try again.";
+			} else if (turnFailureCause) {
+				// A classified turn failure gets its cause-specific canned reply
+				// so a missing capability never reads like a transient blip and
+				// no failure shape can be mistaken for a completed request.
+				replyText = TURN_FAILURE_FALLBACK_REPLIES[turnFailureCause];
 			} else {
 				const tmpl = runtime.character.templates?.transientFailureReply;
 				replyText =
@@ -14137,6 +14160,10 @@ export class DefaultMessageService implements IMessageService {
 				attempt.kind === "creditsExhausted"
 					? "insufficient_credits"
 					: "transient_failure",
+			// Additive structural marker (#17027 AC6): downstream consumers and
+			// tests can distinguish WHY the turn failed without parsing reply
+			// prose. Absent when the cause was unclassified.
+			...(turnFailureCause ? { turnFailureCause } : {}),
 			elizaSyntheticFailure: true,
 			transient: true,
 			doNotPersist: true,

--- a/packages/core/src/services/message/fallback-reply.ts
+++ b/packages/core/src/services/message/fallback-reply.ts
@@ -7,6 +7,10 @@
  * status first, falling back to a message-substring scan for status-less errors.
  * buildFailureReplyPrompt shapes the in-character apology (never answering on the
  * merits), and stripReasoningBlocks removes <think> spans from the raw reply.
+ * classifyTurnFailureCause additionally maps the error that terminated a turn
+ * (trajectory exhaustion, missing capability, repeated handler failure,
+ * persistence failure) to a TurnFailureCause so the fallback reply states the
+ * specific failure and never reads as a completed request (#17027 AC6).
  */
 import { ModelType } from "../../types/model";
 
@@ -301,17 +305,127 @@ export function isModelProviderFallbackError(
 	);
 }
 
-export function buildFailureReplyPrompt(recentMessages: string): string {
-	return [
-		"You hit a transient model error and have to send a short user-facing reply.",
+/**
+ * Structural cause of a failed turn, classified from the error that killed the
+ * message runtime. Distinguishes the four terminal shapes issue #17027 AC6
+ * requires to produce visibly different user-facing replies: the agent lacked
+ * the capability, the planner ran out of budget, a step failed while
+ * executing, or the result could not be persisted. `null` means the cause is
+ * unclassified and the generic transient framing applies.
+ */
+export type TurnFailureCause =
+	| "capability_unavailable"
+	| "planner_exhausted"
+	| "execution_failed"
+	| "persistence_failed";
+
+/**
+ * Deterministic last-ditch reply per classified turn-failure cause, used when
+ * every fallback model slot also failed. Each text states plainly that the
+ * request was NOT completed and nothing was saved — a fabricated-success
+ * guardrail, so never soften these into ambiguous acknowledgements.
+ */
+export const TURN_FAILURE_FALLBACK_REPLIES: Record<TurnFailureCause, string> = {
+	capability_unavailable:
+		"I can't do that here, I don't have the ability set up right now. Nothing was saved or changed.",
+	planner_exhausted:
+		"I ran out of room before finishing that, so I stopped without completing it. Nothing was saved or changed. Want me to try again?",
+	execution_failed:
+		"Something failed while I was working on that, so I stopped without completing it. Nothing was saved or changed. Please try again.",
+	persistence_failed:
+		"I couldn't save that, the change did not stick. Treat it as not done and please try again.",
+};
+
+function errorCode(error: unknown): string {
+	const candidate = asErrorObject(error);
+	return candidate && typeof candidate.code === "string" ? candidate.code : "";
+}
+
+/**
+ * Maps the error that terminated a message-runtime turn to a
+ * {@link TurnFailureCause}. Trajectory-limit exhaustion is matched by error
+ * name (not instanceof) so wrapped or cross-realm errors still classify, and
+ * its `kind` splits missing-capability shapes (the planner repeatedly reached
+ * for tools that do not exist or never produced the required tool) from
+ * repeated handler failures and plain budget exhaustion. Persistence failures
+ * are recognized by the `*_PERSISTENCE_FAILED` ElizaError code convention.
+ */
+export function classifyTurnFailureCause(
+	error: unknown,
+): TurnFailureCause | null {
+	if (error instanceof Error && error.name === "TrajectoryLimitExceeded") {
+		const kind = (error as Error & { kind?: unknown }).kind;
+		switch (kind) {
+			case "required_tool_misses":
+			case "unavailable_tool_calls":
+				return "capability_unavailable";
+			case "repeated_failures":
+				return "execution_failed";
+			default:
+				return "planner_exhausted";
+		}
+	}
+	const code = errorCode(error);
+	if (code === "CAPABILITY_UNAVAILABLE") return "capability_unavailable";
+	if (code.includes("PERSISTENCE_FAILED") || code.includes("PERSIST_FAILED")) {
+		return "persistence_failed";
+	}
+	return null;
+}
+
+const TURN_FAILURE_PROMPT_FRAMING: Record<TurnFailureCause, string[]> = {
+	capability_unavailable: [
+		"You could not do what the user asked because you do not have that ability in this environment.",
 		"Write a one or two sentence reply in plain language.",
 		"",
 		"Hard rules:",
+		"- Say plainly that you can't do that here, and that nothing was set up, saved, or changed.",
+	],
+	planner_exhausted: [
+		"You ran out of attempts before completing the user's request. The task was NOT completed and nothing was saved or changed.",
+		"Write a one or two sentence reply in plain language.",
+		"",
+		"Hard rules:",
+		"- Say plainly that the task was not completed and nothing was saved or changed.",
+	],
+	execution_failed: [
+		"A step failed while carrying out the user's request. The task was NOT completed and nothing was saved or changed.",
+		"Write a one or two sentence reply in plain language.",
+		"",
+		"Hard rules:",
+		"- Say plainly that the task failed partway and nothing was saved or changed.",
+	],
+	persistence_failed: [
+		"The user's request could not be saved. The change did not persist, so the task is NOT done.",
+		"Write a one or two sentence reply in plain language.",
+		"",
+		"Hard rules:",
+		"- Say plainly that the change could not be saved and the task is not done.",
+	],
+};
+
+export function buildFailureReplyPrompt(
+	recentMessages: string,
+	cause?: TurnFailureCause | null,
+): string {
+	const framing = cause
+		? TURN_FAILURE_PROMPT_FRAMING[cause]
+		: [
+				"You hit a transient model error and have to send a short user-facing reply.",
+				"Write a one or two sentence reply in plain language.",
+				"",
+				"Hard rules:",
+			];
+	return [
+		...framing,
 		"- Stay in character. Keep your usual voice and tone.",
 		"- NEVER answer the user's question on the merits.",
 		"- The trajectory that would have GROUNDED the answer failed, so do not emit answer-shaped tokens from memory or context.",
 		"- Do not provide a SHA, a count, a price, a date, a status, a file path, or a name as if it were verified.",
-		"- Acknowledge that something went wrong and suggest a retry.",
+		"- NEVER claim anything was saved, scheduled, created, updated, or set up.",
+		cause === "capability_unavailable"
+			? "- Do not suggest retrying; retrying cannot succeed without the missing ability."
+			: "- Acknowledge that something went wrong and suggest a retry.",
 		"- Do not paraphrase or echo the user's question as if you are about to answer it.",
 		"- NEVER mention internal mechanism words such as: planner, action_planner,",
 		"  XML, JSON, schema, structured output, model, retries, sonnet,",


### PR DESCRIPTION
## What

Closes out the remaining structural residual on #17027 (AC6): a turn that dies in the v5 message runtime previously produced one generic "Something went wrong on my end. Please try again." regardless of why it died. Missing capability, planner exhaustion, handler failure, and persistence failure now surface as explicit, distinguishable failure replies that state the request was NOT completed and nothing was saved.

## How

- `packages/core/src/services/message/fallback-reply.ts`
  - new `TurnFailureCause` (`capability_unavailable | planner_exhausted | execution_failed | persistence_failed`) and `classifyTurnFailureCause(error)`:
    - `TrajectoryLimitExceeded` matched by error name (survives wrapping/cross-realm), split by `kind`: `required_tool_misses`/`unavailable_tool_calls` → capability_unavailable (the planner kept reaching for tools that don't exist — the rerouted-but-toolless shape from the original workout transcript), `repeated_failures` → execution_failed, budget kinds → planner_exhausted
    - `CAPABILITY_UNAVAILABLE` and `*_PERSISTENCE_FAILED` error codes matched structurally
  - `buildFailureReplyPrompt(recentMessages, cause?)`: cause-specific framing plus a new always-on hard rule "NEVER claim anything was saved, scheduled, created, updated, or set up"; capability_unavailable drops the retry suggestion (retrying cannot succeed)
  - `TURN_FAILURE_FALLBACK_REPLIES`: deterministic distinct per-cause canned replies when every fallback model slot also fails; each denies completion
- `packages/core/src/services/message.ts`
  - `buildStructuredFailureReply` accepts the error that terminated the turn (threaded from the v5-runtime catch boundary), uses the classified cause for prompt + canned fallback, and stamps an additive `turnFailureCause` marker on the synthetic failure content (existing `failureKind` vocabulary untouched, so chat DTO/recent-messages consumers are unaffected)

Provider-level classification (credits/rate-limit/auth/no-provider) keeps precedence — those causes are about the fallback model loop itself and already have actionable replies.

## Tests

- `bunx vitest run src/services/__tests__/failure-reply-prompt.test.ts` — 29/29 passed (10 new: classifier mapping for all four causes + null cases, per-cause prompt framing, canned-reply distinctness/denial-of-completion)
- `bunx vitest run src/services/message.side-effect-claim.test.ts` — 43/43 passed (real PGLite runtime)
- `bunx vitest run src/services/message.runtime-failure-suppression.test.ts src/services/message.credit-exhaustion-reply.test.ts` — 13/13 passed
- `tsc --noEmit` on packages/core — clean; Biome clean on touched files

## Residual risk

- Classification is boundary-level: causes that never propagate to the v5-runtime catch (e.g. an action failure the planner absorbs and then completes without) are unchanged — they already flow through the receipt-gated REPLY path landed earlier on this issue.
- The remaining #17027 residual after this PR is the live-LLM transcript evidence rows, which need a live-model scenario run and stay with the claimed lane.

Refs #17027

🤖 Generated with [Claude Code](https://claude.com/claude-code)