### PR TITLE
feat(cloud): collapse wallet sign-in behind More options; stop advertising unusable passkeys (#19212 D)

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/login-section-skeleton.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-section-skeleton.tsx
@@ -8,8 +8,8 @@
  * responsive grids), so the card keeps one height and position across states.
  *
  * The skeleton mirrors the fully-enabled provider layout (email field,
- * passkey/magic-link row, OAuth grid, wallet grid) — the effective shape of the
- * production tenants. A tenant with fewer providers gets a loading card
+ * passkey/magic-link row, OAuth grid, collapsed wallet toggle) — the effective
+ * shape of the production tenants. A tenant with fewer providers gets a loading card
  * slightly taller than its final form rather than a mid-load jump.
  */
 
@@ -63,13 +63,8 @@ export function LoginOptionsSkeleton({
         <GhostRow animated={animated} className="h-touch" />
         <GhostRow animated={animated} className="h-touch sm:col-span-2" />
       </div>
-      {/* "or sign in with a wallet" divider row. */}
-      <GhostRow animated={animated} className="mx-auto h-4 w-32" />
-      {/* EVM + Solana wallet row. */}
-      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-        <GhostRow animated={animated} className="h-touch" />
-        <GhostRow animated={animated} className="h-touch" />
-      </div>
+      {/* Collapsed "More options" wallet toggle row (#19212 subtask D). */}
+      <GhostRow animated={animated} className="h-touch w-full" />
     </div>
   );
 }

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.loading-geometry.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.loading-geometry.test.tsx
@@ -83,9 +83,10 @@ vi.mock("../../lib/login-return-to", () => ({
 import StewardLoginSection from "./steward-login-section";
 
 // The skeleton's 44px rows: email input, passkey + magic-link, three OAuth
-// buttons (Google/Discord/GitHub), two wallet buttons. Must track the
-// fully-enabled option stack in login-section-skeleton.tsx.
-const SKELETON_TOUCH_ROWS = 8;
+// buttons (Google/Discord/GitHub), one collapsed "More options" wallet toggle
+// (#19212 subtask D). Must track the fully-enabled option stack in
+// login-section-skeleton.tsx.
+const SKELETON_TOUCH_ROWS = 7;
 
 function countTouchRows(scope: HTMLElement): number {
   return scope.querySelectorAll(".h-touch").length;

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.passkey-capability.test.tsx
@@ -197,11 +197,10 @@ describe("StewardLoginSection passkey capability gating", () => {
     expect(screen.queryByRole("button", { name: /Passkey/i })).toBeNull();
     expect(screen.getByRole("button", { name: /Magic Link/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Google/i })).toBeTruthy();
-    expect(
-      screen.getByText(
-        "Passkey sign-in is not available here. Use Google, Discord, or Magic Link, or open this sign-in link on another device.",
-      ),
-    ).toBeTruthy();
+    // #19212 subtask D: an unusable passkey is not advertised at all — no
+    // "unavailable" banner, no capability chatter, just the working options.
+    expect(screen.queryByText(/Passkey sign-in is not available/i)).toBeNull();
+    expect(screen.queryByText(/Checking passkey availability/i)).toBeNull();
 
     fireEvent.change(input, { target: { value: "person@example.com" } });
     fireEvent.keyDown(input, { key: "Enter" });

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -378,6 +378,9 @@ export default function StewardLoginSection() {
   // Wallet libs mount only on intent: the first wallet-button click renders
   // the (lazy) providers + buttons and auto-starts that wallet's flow.
   const [walletButtonsMounted, setWalletButtonsMounted] = useState(false);
+  // Wallet options render collapsed behind "More options" so email remains the
+  // single primary credential on first paint (#19212 subtask D).
+  const [walletOptionsExpanded, setWalletOptionsExpanded] = useState(false);
   const [autoStartWallet, setAutoStartWallet] = useState<WalletKind | null>(
     null,
   );
@@ -1503,24 +1506,13 @@ export default function StewardLoginSection() {
         )}
       </div>
 
-      {showPasskey ? (
+      {/* When the host cannot use passkeys the option simply does not exist:
+          no capability banner, no "checking" chatter — email stays the one
+          primary path (#19212 subtask D). */}
+      {showPasskey && (
         <p className="text-center text-xs text-muted">
           {t("cloud.login.signupHint", {
             defaultValue: "New here? Passkey sets up your account in seconds.",
-          })}
-        </p>
-      ) : passkeyCapability === null ? (
-        <p className="text-center text-xs text-muted" role="status">
-          {t("cloud.login.checkingPasskey", {
-            defaultValue:
-              "Checking passkey availability. You can continue with Magic Link or another sign-in method now.",
-          })}
-        </p>
-      ) : (
-        <p className="text-center text-xs text-muted">
-          {t("cloud.login.passkeyUnavailable", {
-            defaultValue:
-              "Passkey sign-in is not available here. Use Google, Discord, or Magic Link, or open this sign-in link on another device.",
           })}
         </p>
       )}
@@ -1635,7 +1627,23 @@ export default function StewardLoginSection() {
         </div>
       )}
 
-      {showWallets && (
+      {/* Wallet sign-in is a secondary path: it stays collapsed behind a
+          single "More options" toggle so the first screen keeps email as the
+          only primary credential (#19212 subtask D). */}
+      {showWallets && !walletOptionsExpanded && (
+        <Button
+          variant="ghost"
+          type="button"
+          onClick={() => setWalletOptionsExpanded(true)}
+          disabled={isLoading}
+          aria-expanded={false}
+          className="hosted-signin-focus-emphasis flex w-full min-h-touch items-center justify-center rounded-md px-3 text-sm font-medium text-muted transition-colors hover:text-txt active:scale-[0.98] disabled:pointer-events-none disabled:opacity-50"
+        >
+          {t("cloud.login.moreOptions", { defaultValue: "More options" })}
+        </Button>
+      )}
+
+      {showWallets && walletOptionsExpanded && (
         <>
           <div className="flex items-center gap-3">
             <div className="h-px flex-1 bg-border" />

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet.test.tsx
@@ -136,23 +136,43 @@ describe("StewardLoginSection — wallet sign-in gating (SIWE/SIWS port)", () =>
     vi.clearAllMocks();
   });
 
-  it("renders the wallet divider + both chain intent buttons when siwe AND siws are served", async () => {
+  it("collapses served wallets behind More options, expanding to the divider + both chain intent buttons", {
+    timeout: 15000,
+  }, async () => {
     providerFlags.siwe = true;
     providerFlags.siws = true;
 
     await renderSection();
+
+    // #19212 subtask D: wallets are a secondary path — first paint shows only
+    // the More options toggle, never the wallet buttons themselves.
+    const toggle = await screen.findByRole("button", {
+      name: /More options/i,
+    });
+    expect(screen.queryByText("or sign in with a wallet")).toBeNull();
+    expect(screen.queryByRole("button", { name: /EVM wallet/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Solana wallet/i })).toBeNull();
+
+    fireEvent.click(toggle);
 
     await waitFor(() =>
       expect(screen.getByText("or sign in with a wallet")).toBeTruthy(),
     );
     expect(screen.getByRole("button", { name: /EVM wallet/i })).toBeTruthy();
     expect(screen.getByRole("button", { name: /Solana wallet/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /More options/i })).toBeNull();
   });
 
-  it("renders only the served chain's button (siwe only → EVM, no Solana)", async () => {
+  it("expands to only the served chain's button (siwe only → EVM, no Solana)", {
+    timeout: 15000,
+  }, async () => {
     providerFlags.siwe = true;
 
     await renderSection();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /More options/i }),
+    );
 
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /EVM wallet/i })).toBeTruthy(),
@@ -167,6 +187,7 @@ describe("StewardLoginSection — wallet sign-in gating (SIWE/SIWS port)", () =>
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /Google/i })).toBeTruthy(),
     );
+    expect(screen.queryByRole("button", { name: /More options/i })).toBeNull();
     expect(screen.queryByText("or sign in with a wallet")).toBeNull();
     expect(screen.queryByRole("button", { name: /EVM wallet/i })).toBeNull();
     expect(screen.queryByRole("button", { name: /Solana wallet/i })).toBeNull();


### PR DESCRIPTION
Part of #19212 (subtask D — first-screen hierarchy). Deliberately **not** `Fixes`: subtasks B and E remain open on the epic.

## What

`packages/ui/src/cloud/public-pages/pages/login/`:

- **Wallets behind More options**: the SIWE/SIWS section no longer renders on first paint. When Steward serves wallet providers, a single ghost "More options" toggle appears; expanding it reveals the existing "or sign in with a wallet" divider and per-chain intent buttons (lazy wallet libs still mount only on chain-button click). Email remains the sole primary credential on the resting screen.
- **No passkey advertising on unsupported hosts**: the "Passkey sign-in is not available here…" banner and the "Checking passkey availability…" status line are gone. An unusable passkey capability now renders nothing — the option simply does not exist (the QA table in the issue lists that banner as a defect).
- **Skeleton geometry** (`login-section-skeleton.tsx`): mirrors the collapsed layout (one toggle row instead of divider + two wallet rows), keeping the reserved-frame no-jump contract; `SKELETON_TOUCH_ROWS` updated 8 → 7.

## Status of the other prioritized subtasks (already on develop)

- **A (email↔UI contract)**: `steward-login-section.tsx` renders the six-digit-code entry and code copy **only** when the Steward challenge carries a companion `challengeId`/`pollSecret` (`hasCompanionCode`); link-only challenges get link-only copy. The #16373 drift is structurally fixed.
- **C (waiting + recovery)**: status polling maps consumed/expired/locked/invalid to distinct recoverable states, resend has a cooldown, expiry is auto-detected client-side, and the expired/consumed callback path lands back on the form with "sign in again below" — no brick wall.

## Tests

```
bunx vitest run src/cloud/public-pages/pages/login   (packages/ui)
 Test Files  12 passed (12)
      Tests  61 passed (61)
```

- `steward-login-section.wallet.test.tsx`: rewritten gating cases — collapsed by default (no divider/chain buttons), expand reveals served chains only, no toggle when no wallet provider is served.
- `steward-login-section.passkey-capability.test.tsx`: now asserts the unavailable/checking passkey copy is **absent** while Magic Link keeps Enter-key priority.
- `steward-login-section.loading-geometry.test.tsx`: skeleton row count tracks the collapsed layout.

`bun run --cwd packages/ui typecheck` clean; biome clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)