### PR TITLE
fix: resolve todo-family stage-1 candidates and keep VIEWS failure diagnostics off chat

### DIFF
--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -709,6 +709,68 @@ describe("action catalogue and retrieval", () => {
 		]);
 	});
 
+	// Todo-shaped invented names must hint both todo owners: the
+	// personal-assistant umbrella and plugin-todos' TODO parent. Deployments
+	// load one or the other; the resolver keeps whichever is registered.
+	it("hints todo candidates at OWNER_TODOS and TODO", () => {
+		for (const candidate of [
+			"ADD_TODO",
+			"CREATE_TODO",
+			"TODO_CREATE",
+			"TODO_ADD",
+			"NEW_TODO",
+			"SAVE_TODO",
+			"TODOS",
+			"TODO_LIST",
+			"LIST_TODOS",
+			"GET_TODOS",
+			"SHOW_TODOS",
+			"READ_TODOS",
+			"USER_TODOS_READ",
+			"COMPLETE_TODO",
+			"TODO_COMPLETE",
+			"DELETE_TODO",
+			"REMOVE_TODO",
+		]) {
+			expect(parentAliasesForCandidateAction(candidate)).toEqual([
+				"OWNER_TODOS",
+				"TODO",
+			]);
+		}
+		// Bare TODO hints only the owner umbrella: when plugin-todos is loaded
+		// its TODO action resolves directly by name before aliases apply.
+		expect(parentAliasesForCandidateAction("TODO")).toEqual(["OWNER_TODOS"]);
+	});
+
+	it("hints alarm candidates at OWNER_ALARMS and TRIGGER", () => {
+		for (const candidate of [
+			"ADD_ALARM",
+			"SET_ALARM",
+			"CREATE_ALARM",
+			"ALARM_CREATE",
+			"WAKE_ME_UP",
+		]) {
+			expect(parentAliasesForCandidateAction(candidate)).toEqual([
+				"OWNER_ALARMS",
+				"TRIGGER",
+			]);
+		}
+	});
+
+	it("hints finance candidates at OWNER_FINANCES", () => {
+		for (const candidate of [
+			"FINANCE",
+			"SPENDING",
+			"SPENDING_SUMMARY",
+			"BUDGET",
+			"EXPENSES",
+		]) {
+			expect(parentAliasesForCandidateAction(candidate)).toEqual([
+				"OWNER_FINANCES",
+			]);
+		}
+	});
+
 	it("leaves non-permission candidates off the SETTINGS parent", () => {
 		// A bare person-scoped access revoke is BLOCK, not a settings write; view /
 		// app surface candidates keep their existing VIEWS/APP hints untouched.

--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -717,6 +717,7 @@ describe("action catalogue and retrieval", () => {
 			"ADD_TODO",
 			"CREATE_TODO",
 			"TODO_CREATE",
+			"TODOS_CREATE",
 			"TODO_ADD",
 			"NEW_TODO",
 			"SAVE_TODO",
@@ -742,6 +743,54 @@ describe("action catalogue and retrieval", () => {
 		expect(parentAliasesForCandidateAction("TODO")).toEqual(["OWNER_TODOS"]);
 	});
 
+	it("retains both registered todo owners through production retrieval", () => {
+		const catalog = buildActionCatalog([
+			{
+				name: "OWNER_TODOS",
+				description: "Manage the owner's private LifeOps todos.",
+			},
+			{
+				name: "TODO",
+				description: "Manage the current user's standalone todo list.",
+			},
+		]);
+
+		for (const candidate of ["CREATE_TODO", "TODOS_CREATE"]) {
+			const response = retrieveActions({
+				catalog,
+				messageText: "add a todo to buy milk",
+				candidateActions: [candidate],
+			});
+
+			expect(response.query.parentActionHints).toEqual(["OWNER_TODOS", "TODO"]);
+			expect(response.results.map((result) => result.name)).toEqual(
+				expect.arrayContaining(["OWNER_TODOS", "TODO"]),
+			);
+		}
+	});
+
+	it("does not route non-financial budget language to owner finances", () => {
+		const catalog = buildActionCatalog([
+			{
+				name: "OWNER_FINANCES",
+				description: "Manage the owner's private financial records.",
+			},
+			{
+				name: "REPLY",
+				description:
+					"Reply to the user within the requested response constraints.",
+			},
+		]);
+		const response = retrieveActions({
+			catalog,
+			messageText: "keep this response within the token budget",
+			candidateActions: ["BUDGET"],
+		});
+
+		expect(response.query.parentActionHints).not.toContain("OWNER_FINANCES");
+		expect(response.results[0]?.name).toBe("REPLY");
+	});
+
 	it("hints alarm candidates at OWNER_ALARMS and TRIGGER", () => {
 		for (const candidate of [
 			"ADD_ALARM",
@@ -762,7 +811,6 @@ describe("action catalogue and retrieval", () => {
 			"FINANCE",
 			"SPENDING",
 			"SPENDING_SUMMARY",
-			"BUDGET",
 			"EXPENSES",
 		]) {
 			expect(parentAliasesForCandidateAction(candidate)).toEqual([

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -195,6 +195,7 @@ const CANDIDATE_ACTION_PARENT_ALIASES: Record<string, readonly string[]> = {
 	TODOS: ["OWNER_TODOS", "TODO"],
 	TODO_ADD: ["OWNER_TODOS", "TODO"],
 	TODO_CREATE: ["OWNER_TODOS", "TODO"],
+	TODOS_CREATE: ["OWNER_TODOS", "TODO"],
 	NEW_TODO: ["OWNER_TODOS", "TODO"],
 	SAVE_TODO: ["OWNER_TODOS", "TODO"],
 	TODO_LIST: ["OWNER_TODOS", "TODO"],
@@ -219,7 +220,6 @@ const CANDIDATE_ACTION_PARENT_ALIASES: Record<string, readonly string[]> = {
 	FINANCE: ["OWNER_FINANCES"],
 	SPENDING: ["OWNER_FINANCES"],
 	SPENDING_SUMMARY: ["OWNER_FINANCES"],
-	BUDGET: ["OWNER_FINANCES"],
 	EXPENSES: ["OWNER_FINANCES"],
 	// Habit/reminder-shaped candidates hint BOTH the owner-life umbrella and the
 	// always-registered TRIGGER scheduler. Stage-1 routinely invents these names
@@ -373,11 +373,14 @@ export function retrieveActions(
 		...candidateActions.filter((actionName) =>
 			catalogParentNames.has(normalizeActionName(actionName)),
 		),
-		...candidateActions.flatMap((actionName) =>
-			candidateNamespaceParentExists(input.catalog.parents, actionName)
+		...candidateActions.flatMap((actionName) => {
+			const explicitAliases =
+				explicitParentAliasesForCandidateAction(actionName);
+			if (explicitAliases.length > 0) return explicitAliases;
+			return candidateNamespaceParentExists(input.catalog.parents, actionName)
 				? []
-				: parentAliasesForCandidateAction(actionName),
-		),
+				: parentAliasesForCandidateAction(actionName);
+		}),
 		// Stage-1 routinely hints an action by one of its similes — the canonical
 		// documented example is candidateActions=["BASH"] for the SHELL parent
 		// (message-handler.ts). Similes feed the fuzzy search text but carry no
@@ -996,10 +999,8 @@ function dedupeNormalizedStrings(values: string[] | undefined): string[] {
 
 export function parentAliasesForCandidateAction(actionName: string): string[] {
 	const normalized = normalizeActionName(actionName);
-	const explicit = CANDIDATE_ACTION_PARENT_ALIASES[normalized];
-	if (explicit) {
-		return [...explicit];
-	}
+	const explicit = explicitParentAliasesForCandidateAction(normalized);
+	if (explicit.length > 0) return explicit;
 	// Permission/access management is SETTINGS (grant/revoke an app's fs/net
 	// namespace, OS permission requests, shell access) — never view navigation.
 	// Checked before the view/app surface heuristics because Stage-1 invents
@@ -1023,6 +1024,11 @@ export function parentAliasesForCandidateAction(actionName: string): string[] {
 		aliases.push("APP");
 	}
 	return aliases;
+}
+
+function explicitParentAliasesForCandidateAction(actionName: string): string[] {
+	const normalized = normalizeActionName(actionName);
+	return [...(CANDIDATE_ACTION_PARENT_ALIASES[normalized] ?? [])];
 }
 
 const APP_SURFACE_TOKENS = new Set([

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -179,6 +179,48 @@ const COMPRESS_MODE_TOP_K_CAP = 8;
 // arbitrate from the exposed descriptions (#9950).
 const CANDIDATE_ACTION_PARENT_ALIASES: Record<string, readonly string[]> = {
 	ADD_GOAL: ["OWNER_GOALS"],
+	// Todo-shaped candidates hint BOTH todo owners: the personal-assistant
+	// umbrella and plugin-todos' TODO parent. Deployments load one or the
+	// other; the resolver keeps whichever is registered. Without these the
+	// names Stage-1 actually emits ("add a todo: buy milk" → CREATE_TODO,
+	// "what todos do i have" → USER_TODOS_READ, live trajectories
+	// tj-060255231afe39 / tj-06105af841e1c1) resolve to nothing — the
+	// candidate narrow then dropped every todo tool and the planner
+	// improvised (replayed a stale OWNER_GOALS create; invented a VIEWS
+	// "get-todos" capability that errored). Same class as the habit/goal
+	// aliases above (#10722).
+	ADD_TODO: ["OWNER_TODOS", "TODO"],
+	CREATE_TODO: ["OWNER_TODOS", "TODO"],
+	TODO: ["OWNER_TODOS"],
+	TODOS: ["OWNER_TODOS", "TODO"],
+	TODO_ADD: ["OWNER_TODOS", "TODO"],
+	TODO_CREATE: ["OWNER_TODOS", "TODO"],
+	NEW_TODO: ["OWNER_TODOS", "TODO"],
+	SAVE_TODO: ["OWNER_TODOS", "TODO"],
+	TODO_LIST: ["OWNER_TODOS", "TODO"],
+	LIST_TODOS: ["OWNER_TODOS", "TODO"],
+	GET_TODOS: ["OWNER_TODOS", "TODO"],
+	SHOW_TODOS: ["OWNER_TODOS", "TODO"],
+	READ_TODOS: ["OWNER_TODOS", "TODO"],
+	USER_TODOS_READ: ["OWNER_TODOS", "TODO"],
+	COMPLETE_TODO: ["OWNER_TODOS", "TODO"],
+	TODO_COMPLETE: ["OWNER_TODOS", "TODO"],
+	DELETE_TODO: ["OWNER_TODOS", "TODO"],
+	REMOVE_TODO: ["OWNER_TODOS", "TODO"],
+	// Alarm-shaped candidates: same dual hint as reminders/habits — the
+	// owner umbrella plus the always-registered TRIGGER scheduler.
+	ADD_ALARM: ["OWNER_ALARMS", "TRIGGER"],
+	SET_ALARM: ["OWNER_ALARMS", "TRIGGER"],
+	CREATE_ALARM: ["OWNER_ALARMS", "TRIGGER"],
+	ALARM_CREATE: ["OWNER_ALARMS", "TRIGGER"],
+	WAKE_ME_UP: ["OWNER_ALARMS", "TRIGGER"],
+	// Finance-shaped candidates: OWNER_FINANCES declares only one simile
+	// ("FINANCES"), so the common Stage-1 inventions need explicit hints.
+	FINANCE: ["OWNER_FINANCES"],
+	SPENDING: ["OWNER_FINANCES"],
+	SPENDING_SUMMARY: ["OWNER_FINANCES"],
+	BUDGET: ["OWNER_FINANCES"],
+	EXPENSES: ["OWNER_FINANCES"],
 	// Habit/reminder-shaped candidates hint BOTH the owner-life umbrella and the
 	// always-registered TRIGGER scheduler. Stage-1 routinely invents these names
 	// ("can u help me to brush my teeth everyday" → SET_HABIT), and on

--- a/plugins/plugin-app-control/src/actions/views-loopback-auth.integration.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-loopback-auth.integration.test.ts
@@ -514,6 +514,7 @@ describe("authenticated view loopback requests", () => {
 			text: 'Cannot invoke capability "undeclared-capability" on view "tasks": the view catalog does not declare that capability.',
 		});
 		expect(result).not.toHaveProperty("turnComplete");
+		expect(result).not.toHaveProperty("userFacingText");
 		expect(
 			(result as { verifiedUserFacing?: boolean }).verifiedUserFacing,
 		).not.toBe(true);

--- a/plugins/plugin-app-control/src/actions/views-loopback-auth.integration.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-loopback-auth.integration.test.ts
@@ -195,6 +195,12 @@ async function startAuthenticatedViewsServer(
 					});
 					return;
 				}
+				if (interactionBody.capability === "undeclared-capability") {
+					sendJson(res, 400, {
+						error: "the view catalog does not declare that capability",
+					});
+					return;
+				}
 				sendJson(res, 200, { success: true, text: "interaction complete" });
 				return;
 			}
@@ -469,6 +475,48 @@ describe("authenticated view loopback requests", () => {
 				viewType: "gui",
 			}),
 		});
+	});
+
+	it("keeps a failed view interaction's diagnostic off the user callback", async () => {
+		const token = "views-interaction-failure-token";
+		const server = await startAuthenticatedViewsServer(token);
+		process.env.ELIZA_PORT = String(server.port);
+		process.env.ELIZA_API_TOKEN = token;
+
+		const callbackTexts: string[] = [];
+		const result = await createViewsAction({
+			hasOwnerAccess: async () => true,
+		}).handler(
+			{ agentId: "agent-1" } as never,
+			{
+				entityId: "user-1",
+				roomId: "room-1",
+				agentId: "agent-1",
+				content: { text: "list my todos" },
+			} as never,
+			undefined,
+			{
+				action: "interact",
+				view: "tasks",
+				capability: "undeclared-capability",
+			},
+			async (content) => {
+				if (content.text) callbackTexts.push(content.text);
+				return [];
+			},
+		);
+
+		// The catalog diagnostic goes back to the planner via the result; the
+		// user-facing callback stays silent so the model can phrase the failure.
+		expect(callbackTexts).toEqual([]);
+		expect(result).toMatchObject({
+			success: false,
+			text: 'Cannot invoke capability "undeclared-capability" on view "tasks": the view catalog does not declare that capability.',
+		});
+		expect(result).not.toHaveProperty("turnComplete");
+		expect(
+			(result as { verifiedUserFacing?: boolean }).verifiedUserFacing,
+		).not.toBe(true);
 	});
 
 	it("authenticates every Node-side loopback caller", async () => {

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -3254,9 +3254,13 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 									}
 								);
 							}
-							const reply = `Cannot invoke capability "${capability}" on view "${viewId}": the view catalog does not declare that capability.`;
-							await callback?.({ text: reply });
-							return { success: false, text: reply };
+							// Catalog diagnostics return to the planner via the result,
+							// never straight to the user (same policy as the HTTP
+							// interaction failure below).
+							return {
+								success: false,
+								text: `Cannot invoke capability "${capability}" on view "${viewId}": the view catalog does not declare that capability.`,
+							};
 						}
 						if (!resolvedCapability && standardCapability)
 							capability = standardCapability;
@@ -3267,9 +3271,10 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 								text,
 							);
 							if (correction.kind === "reject") {
-								const reply = `Refusing destructive capability on view "${viewId}": ${correction.reason}. Please rephrase with explicit, unambiguous intent.`;
-								await callback?.({ text: reply });
-								return { success: false, text: reply };
+								return {
+									success: false,
+									text: `Refusing destructive capability on view "${viewId}": ${correction.reason}. Please rephrase with explicit, unambiguous intent.`,
+								};
 							}
 							if (
 								correction.capability.id !== resolvedCapability.capability.id
@@ -3306,9 +3311,10 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 							text,
 						);
 						if (!paramsResolution.ok) {
-							const reply = `Cannot invoke capability "${capability}" on view "${viewId}": ${paramsResolution.error}.`;
-							await callback?.({ text: reply });
-							return { success: false, text: reply };
+							return {
+								success: false,
+								text: `Cannot invoke capability "${capability}" on view "${viewId}": ${paramsResolution.error}.`,
+							};
 						}
 						const params = paramsResolution.params;
 						const timeoutMs =
@@ -3331,7 +3337,12 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 						const effectContract = interaction.success
 							? readViewInteractionEffectContract(interaction.result)
 							: undefined;
-						await callback?.({ text: resultText });
+						// Failure text is a catalog-internal diagnostic ("Cannot invoke
+						// capability X on view Y") — it goes back to the planner via the
+						// result, never straight to the user.
+						if (interaction.success) {
+							await callback?.({ text: resultText });
+						}
 						return {
 							success: interaction.success,
 							text: resultText,

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -2371,6 +2371,9 @@ async function runViewsLayout({
 }
 
 function withViewsUserFacingText(result: ActionResult): ActionResult {
+	if (result.success !== true && result.userFacingText === undefined) {
+		return result;
+	}
 	if (
 		result.transcriptVisibility === "internal" &&
 		result.userFacingText === undefined

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -2400,6 +2400,7 @@ const VIEWS_ROUTING_HINT = [
 	"Close/hide means VIEWS action=close, never delete/remove.",
 	"Listing, launching, or restarting installed applications uses APP; only opening the apps/views page uses VIEWS.",
 	"Changing a settings or permission value uses SETTINGS; VIEWS only opens the Settings surface.",
+	"Reading or changing the owner's todos, goals, reminders, routines, alarms, health, or finances uses the OWNER_* actions; VIEWS only opens those surfaces and never returns that data.",
 ].join(" ");
 
 export function createViewsAction(deps: ViewsActionDeps = {}): Action {

--- a/plugins/plugin-app-control/vitest.config.ts
+++ b/plugins/plugin-app-control/vitest.config.ts
@@ -153,6 +153,14 @@ export default defineConfig({
 				find: /^@elizaos\/core\/(.*)\.js$/,
 				replacement: path.join(coreSrc, "$1.ts"),
 			},
+			// Bare subpath exports must be pinned before the plain string alias
+			// below: a string alias rewrites "@elizaos/core/client-public" to
+			// "<coreSrc>/index.node.ts/client-public" (ENOTDIR) instead of the
+			// subpath source module.
+			{
+				find: /^@elizaos\/core\/client-public$/,
+				replacement: path.join(coreSrc, "client-public.ts"),
+			},
 			{
 				find: "@elizaos/core",
 				replacement: path.join(coreSrc, "index.node.ts"),


### PR DESCRIPTION
# Relates to

Closes #19856.

- [x] Targets `develop` and is rebased onto `dab35f5182c1cae05fe705dcfd2c7eae59dd7860` with zero conflicts.
- [x] Exercises the real action catalog/retrieval path rather than only the alias helper.
- [x] Keeps raw VIEWS diagnostics off both the callback and `userFacingText` channel.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-code (original implementation); openai/gpt-5.6-sol (review, repair, validation, evidence)
<!-- attribution-row:client -->
- Agent tooling: Claude Code; Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@dab35f5182c1cae05fe705dcfd2c7eae59dd7860:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto the latest `origin/develop` at repair time; zero conflicts.
- [x] Exact-head focused tests, both owning-package typechecks, targeted Biome, diff check, and the complete app-control test suite pass.

# Risks

Low to medium. This changes Stage-1 action retrieval for an explicit alias table and the user-projection behavior of failed VIEWS interactions. The production-path tests include a dual-owner catalog and a non-financial false-positive adversary.

# Background

## What does this PR do?

- retains both `OWNER_TODOS` and `TODO` when Stage-1 emits todo-shaped candidates and both registered parents exist;
- includes the observed `TODOS_CREATE` spelling;
- routes alarm-shaped candidates to `OWNER_ALARMS` + `TRIGGER` and unambiguous finance candidates to `OWNER_FINANCES`;
- deliberately excludes bare `BUDGET`, which also describes model/token constraints;
- returns failed VIEWS interaction diagnostics to the planner without callback delivery or `userFacingText` promotion;
- pins the `@elizaos/core/client-public` Vitest subpath before the broad core alias.

## Root-cause repair after review

The original test called `parentAliasesForCandidateAction()` directly, but production skipped aliases whenever a registered namespace parent matched. The final implementation gives configured aliases precedence over that heuristic short-circuit and proves the behavior through `buildActionCatalog()` + `retrieveActions()`. The VIEWS wrapper also previously reconstructed `userFacingText` after the interact branch omitted its callback; failed results without an explicit user projection now remain planner-only.

# Testing

- Core action retrieval: 30/30 pass.
- Authenticated VIEWS real-TCP boundary: 7/7 pass.
- Complete plugin-app-control suite: 51 files, 1,807/1,807 pass.
- `packages/core` typecheck: pass.
- `plugin-app-control` typecheck: pass.
- Targeted Biome (all five PR paths): pass.
- `git diff --check`: pass.

# Evidence Gate

<!-- evidence-head:0918b0984f0afd3ac1393f6708da0085a26ff3b4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - runtime retrieval and server-side action settlement have no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - runtime retrieval and server-side action settlement have no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual interaction flow changes; the VIEWS test exercises the authenticated real-TCP loopback boundary.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head validation transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19843-pr19843-backend-v3.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or browser bundle changes.
<!-- evidence-row:llm-trajectory -->
- [x] [Contributor live-trajectory review and exact-head qualification](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19843-pr19843-trajectory-review-v3.json)
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head retrieval and settlement artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19843-pr19843-domain-v3.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshots or rendered text changed.

# Evidence details

The contributor's live nubilio trajectories capture the original bad routing and the repaired `OWNER_TODOS_CREATE` behavior. They predate the final branch refresh and are labeled accordingly. Exact-head deterministic evidence now covers the previously missing production interaction: both todo owners remain in the retrieved result with both parents registered; token-budget prose does not expose private finance; an undeclared VIEWS capability produces neither callback text nor `userFacingText`.

## Known gaps / failures

- Hosted exact-head workflows are the remaining external gate after the branch refresh.
- No exact-final-SHA live-model trajectory was fabricated; the linked trajectory review distinguishes the contributor's live run from the final deterministic regression.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@dab35f5182c1cae05fe705dcfd2c7eae59dd7860:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [nubs-review-pr19843]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@dab35f5182c1cae05fe705dcfd2c7eae59dd7860:packages/skills/skills/contribute-to-eliza"} -->
