### PR TITLE
fix(cloud): converge replacement-cleanup fences on attempt-label drift

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-replacement-cleanup.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-replacement-cleanup.test.ts
@@ -38,6 +38,12 @@ const CONTAINER_NAME = "agent-11111111-1111-4111-8111-111111111111";
 const ATTEMPT_ID = "33333333-3333-4333-8333-333333333333";
 const CONTAINER_ID = "a".repeat(64);
 const REGISTRATION_STARTED_AT = "2026-07-23T00:05:00.000Z";
+const CONTAINER_CREATED_AT = "2026-07-23T00:10:00.000000000Z";
+const CONTAINER_CREATED_AT_MS = Date.parse("2026-07-23T00:10:00.000Z");
+
+function inspectLine(id: string, attempt: string, name = CONTAINER_NAME): string {
+  return `${id}|${attempt}|/${name}|${CONTAINER_CREATED_AT}\n`;
+}
 
 function headscaleNode(id: string, name: string, createdAt: string): HeadscaleNode {
   return {
@@ -200,7 +206,7 @@ describe("DockerSandboxProvider replacement cleanup", () => {
     const findNode = stubNodeLookup();
     const { commands } = stubSsh(async (command) => {
       if (command.startsWith("docker inspect")) {
-        return `${CONTAINER_ID}|${ATTEMPT_ID}\n`;
+        return inspectLine(CONTAINER_ID, ATTEMPT_ID);
       }
       return "";
     });
@@ -226,11 +232,13 @@ describe("DockerSandboxProvider replacement cleanup", () => {
     expect(decrement).not.toHaveBeenCalled();
   });
 
-  test("refuses to touch a same-name occupant with a different attempt label", async () => {
+  test("refuses a same-name label mismatch inside the converge grace window", async () => {
     stubNodeLookup();
-    const { commands } = stubSsh(async () => `${CONTAINER_ID}|another-attempt\n`);
+    const { commands } = stubSsh(async () => inspectLine(CONTAINER_ID, "another-attempt"));
     const deleteVpn = spyOn(headscaleClient, "deleteNode").mockResolvedValue();
-    const provider = replacementProvider();
+    const provider = replacementProvider({
+      now: () => CONTAINER_CREATED_AT_MS + 30 * 60 * 1000,
+    });
 
     const error = await provider
       .stopOnSpecificNodeForReplacement(
@@ -251,10 +259,63 @@ describe("DockerSandboxProvider replacement cleanup", () => {
     expect(deleteVpn).not.toHaveBeenCalled();
   });
 
+  test("converges a same-name label mismatch past the grace window via id+name identity", async () => {
+    stubNodeLookup();
+    const { commands } = stubSsh(async (command) => {
+      if (command.startsWith("docker inspect")) {
+        return inspectLine(CONTAINER_ID, "another-attempt");
+      }
+      return "";
+    });
+    const deleteVpn = spyOn(headscaleClient, "deleteNode").mockResolvedValue();
+    const decrement = spyOn(dockerNodesRepository, "decrementAllocated").mockResolvedValue();
+    const provider = replacementProvider({
+      now: () => CONTAINER_CREATED_AT_MS + 2 * 60 * 60 * 1000,
+    });
+
+    await provider.stopOnSpecificNodeForReplacement(
+      NODE.node_id,
+      CONTAINER_NAME,
+      "vpn-node-converge",
+      replacementIdentity(),
+    );
+
+    expect(commands.slice(1)).toEqual([
+      `docker stop -t 10 '${CONTAINER_ID}'`,
+      `docker rm -f '${CONTAINER_ID}'`,
+    ]);
+    expect(deleteVpn).toHaveBeenCalledWith("vpn-node-converge");
+    expect(decrement).not.toHaveBeenCalled();
+  });
+
+  test("keeps failing closed past the grace window when the observed name differs", async () => {
+    stubNodeLookup();
+    const { commands } = stubSsh(async () =>
+      inspectLine(CONTAINER_ID, "another-attempt", "agent-someone-else"),
+    );
+    const deleteVpn = spyOn(headscaleClient, "deleteNode").mockResolvedValue();
+    const provider = replacementProvider({
+      now: () => CONTAINER_CREATED_AT_MS + 2 * 60 * 60 * 1000,
+    });
+
+    const error = await provider
+      .stopOnSpecificNodeForReplacement(
+        NODE.node_id,
+        CONTAINER_NAME,
+        "vpn-node-name-drift",
+        replacementIdentity(),
+      )
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(SandboxReplacementCleanupUnresolvedError);
+    expect(commands).toHaveLength(1);
+    expect(deleteVpn).not.toHaveBeenCalled();
+  });
+
   test("bounds an id-less stale fence when the name belongs to a newer attempt", async () => {
     stubNodeLookup();
     const newerContainerId = "b".repeat(64);
-    const { commands } = stubSsh(async () => `${newerContainerId}|newer-attempt\n`);
+    const { commands } = stubSsh(async () => inspectLine(newerContainerId, "newer-attempt"));
     const deleteVpn = spyOn(headscaleClient, "deleteNode").mockResolvedValue();
     const provider = replacementProvider();
 
@@ -277,7 +338,7 @@ describe("DockerSandboxProvider replacement cleanup", () => {
   test("refuses cleanup when Docker's inspected id differs from the persisted id", async () => {
     stubNodeLookup();
     const otherId = "b".repeat(64);
-    const { commands } = stubSsh(async () => `${otherId}|${ATTEMPT_ID}\n`);
+    const { commands } = stubSsh(async () => inspectLine(otherId, ATTEMPT_ID));
     const provider = replacementProvider();
 
     await expect(
@@ -317,7 +378,7 @@ describe("DockerSandboxProvider replacement cleanup", () => {
     stubNodeLookup();
     const { commands } = stubSsh(async (command) => {
       if (command.startsWith("docker inspect")) {
-        return `${CONTAINER_ID}|${ATTEMPT_ID}\n`;
+        return inspectLine(CONTAINER_ID, ATTEMPT_ID);
       }
       if (command.startsWith("docker rm")) {
         throw new Error(

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -174,6 +174,11 @@ const REPLACEMENT_ATTEMPT_LABEL = "ai.elizaos.replacement-attempt";
 const REPLACEMENT_VPN_SETTLE_OBSERVATIONS = 4;
 const REPLACEMENT_VPN_SETTLE_INTERVAL_MS = 750;
 const REPLACEMENT_VPN_CLOCK_SKEW_ALLOWANCE_MS = 30_000;
+// Converge window for an id-verified container whose attempt label drifted
+// from the fence record (#18032): the immutable Docker id plus a matching
+// deterministic name identify the fenced target beyond doubt, but a young
+// container is still retained in case a concurrent lifecycle op is mid-write.
+const REPLACEMENT_LABEL_MISMATCH_RETIRE_GRACE_MS = 60 * 60 * 1000;
 
 class ReplacementPlacementPersistenceError extends Error {
   constructor(cause: unknown) {
@@ -2210,7 +2215,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       node.host_key_fingerprint ?? undefined,
       node.ssh_user ?? DEFAULT_SSH_USERNAME,
     );
-    const format = `{{.Id}}|{{index .Config.Labels "${REPLACEMENT_ATTEMPT_LABEL}"}}`;
+    const format = `{{.Id}}|{{index .Config.Labels "${REPLACEMENT_ATTEMPT_LABEL}"}}|{{.Name}}|{{.Created}}`;
     // When Docker returned the create id before a later phase failed, inspect
     // that immutable object directly. A same-name replacement can never make
     // the old id look present or authorize deleting the newer occupant.
@@ -2240,14 +2245,16 @@ export class DockerSandboxProvider implements SandboxProvider {
         `[docker-sandbox] Cannot verify replacement identity for ${locator.containerName}: expected one inspect record`,
       );
     }
-    const separator = lines[0]!.indexOf("|");
-    if (separator <= 0) {
+    const fields = lines[0]!.split("|");
+    if (fields.length !== 4 || fields[0]!.trim().length === 0) {
       throw new Error(
         `[docker-sandbox] Cannot verify replacement identity for ${locator.containerName}: malformed inspect record`,
       );
     }
-    const containerId = lines[0]!.slice(0, separator).trim();
-    const attemptId = lines[0]!.slice(separator + 1).trim();
+    const containerId = fields[0]!.trim();
+    const attemptId = fields[1]!.trim();
+    const observedName = fields[2]!.trim().replace(/^\//, "");
+    const observedCreatedAt = Date.parse(fields[3]!.trim());
     if (!/^[a-f0-9]{12,64}$/i.test(containerId)) {
       throw new Error(
         `[docker-sandbox] Cannot verify replacement identity for ${locator.containerName}: invalid Docker id`,
@@ -2272,6 +2279,33 @@ export class DockerSandboxProvider implements SandboxProvider {
           },
         );
         return null;
+      }
+      // With an immutable id the inspect was addressed at the exact persisted
+      // object, so a label mismatch cannot be a name reuse — it is attempt-id
+      // drift between the fence row and the container's create-time label
+      // (#18032). Refusing forever wedges the agent out of every exclusive
+      // lifecycle job, so converge once identity is proven by the stronger
+      // signals: the id matches the fence record, the deterministic name
+      // matches, and the container is old enough that no concurrent
+      // replacement attempt can still be mid-write.
+      if (
+        dockerContainerIdsMatch(locator.containerId, containerId) &&
+        observedName === locator.containerName &&
+        Number.isFinite(observedCreatedAt) &&
+        this.now() - observedCreatedAt >= REPLACEMENT_LABEL_MISMATCH_RETIRE_GRACE_MS
+      ) {
+        logger.warn(
+          "[docker-sandbox] Replacement attempt label drifted from the fence record; converging via id+name identity past the grace window",
+          {
+            nodeId: locator.nodeId,
+            containerName: locator.containerName,
+            containerId,
+            expectedAttemptId: locator.replacementAttemptId,
+            observedAttemptId: attemptId || null,
+            containerAgeMs: this.now() - observedCreatedAt,
+          },
+        );
+        return containerId;
       }
       throw new Error(
         `[docker-sandbox] Replacement attempt label mismatch for ${locator.containerName}`,


### PR DESCRIPTION
## What

Fixes #18032.

The replacement-cleanup sweep on eliza-core-prod-1 has been failing every cycle with `[docker-sandbox] Replacement attempt label mismatch` for the same agents: the fence row's recorded attempt id no longer matches the on-node container's attempt label, `resolveReplacementContainerForCleanup` refuses fail-closed, and the fenced agents are blocked from every exclusive lifecycle job (upgrade/suspend/delete) forever.

## Change

`packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts`:

- The cleanup inspect now captures `{{.Id}}|{{label}}|{{.Name}}|{{.Created}}` in one round trip.
- On an attempt-label mismatch **with a persisted container id** (the inspect is addressed at the exact immutable object, so name reuse is impossible), the resolver converges when the stronger identity signals hold: the Docker id matches the fence record, the deterministic container name matches, and the container is older than a 1-hour grace window (`REPLACEMENT_LABEL_MISMATCH_RETIRE_GRACE_MS`). It logs the drift and retires the container, letting the fence clear on the normal retirement path.
- A container younger than the grace window, or one whose observed name differs from the fence record, keeps the historical fail-closed refusal. The existing id-less name-reuse converge (retain occupant, treat target as absent) is unchanged.

## Tests

`packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-replacement-cleanup.test.ts`:
- label-match retirement (existing, updated to the 4-field inspect record)
- label-mismatch-same-name **inside** grace → still refused (`SandboxReplacementCleanupUnresolvedError`)
- label-mismatch-same-name **past** grace → converges: `docker stop`/`rm -f` on the exact id, VPN cleaned, capacity untouched
- name-reused-by-newer-attempt (id-less fence) → unchanged bounded converge
- observed-name drift past grace → still fail-closed

Ran: `bun test shared/src/lib/services/__tests__/docker-sandbox-replacement-cleanup.test.ts` in `packages/cloud` — **21 pass / 0 fail**. `tsc --noEmit` in `packages/cloud/shared` reports no errors in the touched files; Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:e3707a2100f8f18f381b0c836de0afaf9486ebb0 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Backend-only replacement cleanup; no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - Backend-only replacement cleanup; no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No user-facing interactive flow changes.
<!-- evidence-row:backend-logs -->
- [ ] N/A - The exact-head 21-case cleanup suite exercises the SSH command/logging path deterministically; production node mutation is intentionally outside PR review.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend runtime change.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No model, prompt, provider, or inference behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No generated domain artifact; exact-head tests verify retained and retired container identities, VPN cleanup, and untouched capacity.
<!-- evidence-row:ocr-review -->
- [ ] N/A - No rendered UI changes.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI / gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`