### PR TITLE
fix(cloud): enable genuine shared runtime in production

### DIFF
--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -761,7 +761,7 @@ describe("cloud-api worker entrypoint", () => {
     expect(productionRoutes).toContain("*.cloud.eliza.app/*");
   });
 
-  test("publishes the genuine Shared runtime as a staging-only rollout", async () => {
+  test("publishes the genuine Shared runtime in staging and production", async () => {
     const config = Bun.TOML.parse(
       await Bun.file(new URL("../wrangler.toml", import.meta.url)).text(),
     ) as {
@@ -774,9 +774,7 @@ describe("cloud-api worker entrypoint", () => {
 
     expect(config.vars?.SHARED_ELIZA_AGENT_RUNTIME).toBe("false");
     expect(config.env?.staging?.vars?.SHARED_ELIZA_AGENT_RUNTIME).toBe("true");
-    expect(config.env?.production?.vars?.SHARED_ELIZA_AGENT_RUNTIME).toBe(
-      "false",
-    );
+    expect(config.env?.production?.vars?.SHARED_ELIZA_AGENT_RUNTIME).toBe("true");
   });
 
   test("binds the global native limiter in every Worker environment and keeps inference routes gate-free", async () => {

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -676,9 +676,9 @@ __dirname = '"/"'
 __filename = '"/worker.js"'
 
 [env.production.vars]
-# Flip only after exact staging voice/runtime evidence for the release SHA.
+# Production uses the genuine Shared Workerd runtime for personal voice.
 NODE_ENV = "production"
-SHARED_ELIZA_AGENT_RUNTIME = "false"
+SHARED_ELIZA_AGENT_RUNTIME = "true"
 THIN_INFERENCE_ENTRY_ENABLED = "true"
 # Apps deploy (Product 2): arms the Worker-side deploy trigger (configureAppsDeployTrigger,
 # bootstrap-app.ts) so POST /api/v1/apps/:id/deploy enqueues a real APP_DEPLOY job instead of


### PR DESCRIPTION
## Summary

- enables the genuine Shared Workerd `AgentRuntime` selector in production
- keeps local/default rollback behavior unchanged
- promotes the already-merged and focused-tested personal phone runtime from #19823

## Proof

- Cloud API configuration test: 33 passed
- Cloud API typecheck: passed
- production Wrangler dry bundle: passed and reports `SHARED_ELIZA_AGENT_RUNTIME="true"`
- #19823 focused proof: 130 assertions across runtime, durable history, voice, Cartesia, reconnect, and barge-in

Production promotion explicitly authorized in the release thread.
