### PR TITLE
fix(android): serialize notification refreshes

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -192,7 +192,6 @@ public class ElizaAgentService extends Service {
     private static final long AGENT_BOOT_GRACE_MS = 120_000L;
 
     private final Object processLock = new Object();
-    private final Object notificationLock = new Object();
     private Process agentProcess;
     private Thread stdoutPump;
     private Thread stderrPump;
@@ -200,7 +199,6 @@ public class ElizaAgentService extends Service {
     /** In-process bionic GPU inference host; non-null only when delegating. */
     private volatile ElizaBionicInferenceServer bionicInferenceServer;
     private volatile Thread startWorker;
-    private volatile Thread notificationWorker;
     private volatile boolean shuttingDown;
     private volatile boolean foregroundStartDenied;
     private volatile boolean detachedAgentMode;
@@ -208,6 +206,8 @@ public class ElizaAgentService extends Service {
     private long detachedProbeArmedForLaunchMs;
     private int restartAttempts;
     private volatile String currentStatus = "starting";
+    private final LatestNotificationUpdateWorker notificationUpdates =
+        new LatestNotificationUpdateWorker("ElizaAgent-notification", this::pushNotification);
 
     // Per-boot bearer token for the WebView↔agent loopback. Generated when
     // the service first starts the agent process and cleared on stop.
@@ -3810,21 +3810,7 @@ public class ElizaAgentService extends Service {
     }
 
     private void updateNotification() {
-        synchronized (notificationLock) {
-            if (notificationWorker != null && notificationWorker.isAlive()) {
-                return;
-            }
-            notificationWorker = new Thread(() -> {
-                try {
-                    pushNotification();
-                } finally {
-                    synchronized (notificationLock) {
-                        notificationWorker = null;
-                    }
-                }
-            }, "ElizaAgent-notification");
-            notificationWorker.start();
-        }
+        notificationUpdates.request();
     }
 
     /**

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/GatewayConnectionService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/GatewayConnectionService.java
@@ -51,7 +51,8 @@ public class GatewayConnectionService extends Service {
     public static final String STATUS_RECONNECTING = "reconnecting";
 
     private volatile String currentStatus = STATUS_DISCONNECTED;
-    private volatile Thread notificationWorker;
+    private final LatestNotificationUpdateWorker notificationUpdates =
+        new LatestNotificationUpdateWorker("ElizaGateway-notification", this::pushNotification);
 
     // ── Lifecycle ────────────────────────────────────────────────────────
 
@@ -72,7 +73,7 @@ public class GatewayConnectionService extends Service {
         } else {
             startForeground(NOTIFICATION_ID, notification);
         }
-        updateNotificationAsync();
+        updateNotification();
     }
 
     @Override
@@ -181,20 +182,6 @@ public class GatewayConnectionService extends Service {
             .build();
     }
 
-    private synchronized void updateNotificationAsync() {
-        if (notificationWorker != null && notificationWorker.isAlive()) {
-            return;
-        }
-        notificationWorker = new Thread(() -> {
-            try {
-                updateNotification();
-            } finally {
-                notificationWorker = null;
-            }
-        }, "ElizaGateway-notification");
-        notificationWorker.start();
-    }
-
     private boolean isNotificationStop(Intent intent) {
         return STOP_SOURCE_NOTIFICATION.equals(intent.getStringExtra(EXTRA_STOP_SOURCE));
     }
@@ -213,8 +200,13 @@ public class GatewayConnectionService extends Service {
         }
     }
 
-    /** Push an updated notification to reflect the current connection status. */
+    /** Queue an interactive notification refresh away from the service main thread. */
     private void updateNotification() {
+        notificationUpdates.request();
+    }
+
+    /** Push an updated notification to reflect the current connection status. */
+    private void pushNotification() {
         String title;
         String text;
 

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/LatestNotificationUpdateWorker.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/LatestNotificationUpdateWorker.java
@@ -1,0 +1,65 @@
+/**
+ * Serializes interactive notification refreshes away from Android lifecycle
+ * threads while retaining one replay when state changes during an update.
+ */
+package ai.elizaos.app;
+
+import java.util.Objects;
+
+final class LatestNotificationUpdateWorker {
+    private final Object lock = new Object();
+    private final String threadName;
+    private final Runnable update;
+    private boolean requested;
+    private Thread worker;
+
+    LatestNotificationUpdateWorker(String threadName, Runnable update) {
+        this.threadName = Objects.requireNonNull(threadName, "threadName");
+        this.update = Objects.requireNonNull(update, "update");
+    }
+
+    void request() {
+        synchronized (lock) {
+            requested = true;
+            if (worker == null) {
+                startWorkerLocked();
+            }
+        }
+    }
+
+    private boolean takeRequest() {
+        synchronized (lock) {
+            if (!requested) {
+                return false;
+            }
+            requested = false;
+            return true;
+        }
+    }
+
+    private void startWorkerLocked() {
+        Thread nextWorker = new Thread(this::drain, threadName);
+        worker = nextWorker;
+        try {
+            nextWorker.start();
+        } catch (RuntimeException | Error error) {
+            worker = null;
+            throw error;
+        }
+    }
+
+    private void drain() {
+        try {
+            while (takeRequest()) {
+                update.run();
+            }
+        } finally {
+            synchronized (lock) {
+                worker = null;
+                if (requested) {
+                    startWorkerLocked();
+                }
+            }
+        }
+    }
+}

--- a/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/LatestNotificationUpdateWorkerTest.java
+++ b/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/LatestNotificationUpdateWorkerTest.java
@@ -1,0 +1,95 @@
+/**
+ * Deterministic host-side concurrency coverage for Android notification
+ * refreshes, including caller-thread isolation and latest-state replay.
+ */
+package ai.elizaos.app;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+public class LatestNotificationUpdateWorkerTest {
+    private static final long AWAIT_SECONDS = 5L;
+
+    @Test
+    public void requestRunsTheUpdateAwayFromTheLifecycleCaller() throws Exception {
+        Thread caller = Thread.currentThread();
+        AtomicReference<Thread> updateThread = new AtomicReference<>();
+        CountDownLatch updateStarted = new CountDownLatch(1);
+        CountDownLatch releaseUpdate = new CountDownLatch(1);
+        CountDownLatch updateFinished = new CountDownLatch(1);
+        LatestNotificationUpdateWorker worker = new LatestNotificationUpdateWorker(
+            "notification-test",
+            () -> {
+                updateThread.set(Thread.currentThread());
+                updateStarted.countDown();
+                await(releaseUpdate);
+                updateFinished.countDown();
+            }
+        );
+
+        worker.request();
+
+        assertTrue(updateStarted.await(AWAIT_SECONDS, TimeUnit.SECONDS));
+        assertNotSame(caller, updateThread.get());
+        releaseUpdate.countDown();
+        assertTrue(updateFinished.await(AWAIT_SECONDS, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void requestsDuringAnUpdateCoalesceIntoOneLatestStateReplay() throws Exception {
+        AtomicReference<String> desiredState = new AtomicReference<>("starting");
+        AtomicInteger updateCount = new AtomicInteger();
+        List<String> observedStates = Collections.synchronizedList(new ArrayList<>());
+        CountDownLatch firstUpdateStarted = new CountDownLatch(1);
+        CountDownLatch releaseFirstUpdate = new CountDownLatch(1);
+        CountDownLatch secondUpdateFinished = new CountDownLatch(1);
+        LatestNotificationUpdateWorker worker = new LatestNotificationUpdateWorker(
+            "notification-test",
+            () -> {
+                int invocation = updateCount.incrementAndGet();
+                observedStates.add(desiredState.get());
+                if (invocation == 1) {
+                    firstUpdateStarted.countDown();
+                    await(releaseFirstUpdate);
+                } else if (invocation == 2) {
+                    secondUpdateFinished.countDown();
+                }
+            }
+        );
+
+        worker.request();
+        assertTrue(firstUpdateStarted.await(AWAIT_SECONDS, TimeUnit.SECONDS));
+
+        desiredState.set("running");
+        worker.request();
+        worker.request();
+        releaseFirstUpdate.countDown();
+
+        assertTrue(secondUpdateFinished.await(AWAIT_SECONDS, TimeUnit.SECONDS));
+        assertEquals(2, updateCount.get());
+        assertEquals(Arrays.asList("starting", "running"), observedStates);
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            if (!latch.await(AWAIT_SECONDS, TimeUnit.SECONDS)) {
+                throw new AssertionError("timed out waiting for deterministic test coordination");
+            }
+        } catch (InterruptedException error) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("test coordination interrupted", error);
+        }
+    }
+}

--- a/packages/app-core/scripts/android-periodic-wake-reconciliation.test.mjs
+++ b/packages/app-core/scripts/android-periodic-wake-reconciliation.test.mjs
@@ -178,4 +178,20 @@ describe("Android periodic wake reconciliation (#17874)", () => {
       expect(bootstrapBody).not.toContain("PendingIntent");
     }
   });
+
+  it("queues every interactive notification refresh off the service main thread", () => {
+    for (const name of [
+      "ElizaAgentService.java",
+      "GatewayConnectionService.java",
+    ]) {
+      const service = source(name);
+      const updateBody = service.match(
+        /private void updateNotification\(\) \{([\s\S]*?)\n {4}\}/,
+      )?.[1];
+
+      expect(updateBody).toBeDefined();
+      expect(updateBody).toContain("notificationUpdates.request()");
+      expect(updateBody).not.toContain("pushNotification()");
+    }
+  });
 });


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Related to #17874.

The original periodic-wake issue is already closed as completed after #19112 and #19219. This is a narrow follow-up residual found while validating that Android path; it does not reopen or replace those merged fixes.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest fetched/API-matched `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [ ] A reviewer can confirm the native path works without reading the code. Exact-head host-side proof is below, but current-build physical-device/emulator evidence was not available and remains a pre-merge verification gap.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@5943fce2d548ce74665dc78c871de48067dd8eba:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto fetched and API-matched `origin/develop` at `a542139cba57e580deea0d9ee9e7e0eb3702c7cc`; zero conflicts.
- [x] `bun run verify` passes post-sync on this exact head.

# Risks

Medium. This changes scheduling for two Android foreground-service notification refresh paths. A defect could leave a notification stale or create excess worker threads. The worker serializes updates, retains at most one pending replay, and has deterministic concurrency coverage; the remaining risk is the unexecuted physical Android lifecycle path.

# Background

## What does this PR do?

- Routes every interactive notification refresh in `ElizaAgentService` and `GatewayConnectionService` through a shared package-private worker, keeping notification construction off service lifecycle callers.
- Replays once when state changes during an active refresh, so the final notification observes the latest desired state instead of silently dropping the update.
- Coalesces multiple requests during the active refresh into that single replay.
- Adds deterministic JVM tests for caller-thread isolation and latest-state replay, plus a source contract asserting both services use the worker boundary.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is needed. This is an internal Android service scheduling correction with focused contract coverage.

# Testing

## Where should a reviewer start?

Start with `LatestNotificationUpdateWorkerTest`, then inspect the two service integrations and `android-periodic-wake-reconciliation.test.mjs`.

## Detailed testing steps

All passing results below were captured after the final rebase at head `5943fce2d548ce74665dc78c871de48067dd8eba`.

1. Android source contract:

       bun test packages/app-core/scripts/android-periodic-wake-reconciliation.test.mjs

   Result: 9 passed, 53 expectations, 0 failed.

2. Android host-side JVM concurrency test from `packages/app-core/platforms/android`:

       JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ELIZA_ANDROID_SKIP_FORK_LLAMA_LIB=1 ./gradlew --no-daemon :app:testDebugUnitTest --tests ai.elizaos.app.LatestNotificationUpdateWorkerTest

   Result: Gradle `BUILD SUCCESSFUL`; JUnit XML reports 2 tests, 0 failures, 0 errors, 0 skipped.

3. Owning package gates:

       bun run --cwd packages/app-core typecheck
       bun run --cwd packages/app-core lint:check
       bun run --cwd packages/app-core build

   Result: all passed; lint checked 339 files and build rewrote 109 generated files without leaving a tracked diff.

4. Repository gate:

       bun install
       bun run verify

   Result: passed. The Turbo phase completed 350/350 tasks and the final script, inventory, view-bundle, and skipped-test audits passed.

# Evidence Gate

<!-- evidence-head:5943fce2d548ce74665dc78c871de48067dd8eba -->

This patch changes native scheduling but does not change rendered notification copy or a web/frontend surface. No physical Android device or emulator was available in this environment, so current-build device screenshots, recording, and logcat evidence are explicitly missing.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI source or notification copy changed, and no physical Android device or emulator was available to capture the prior runtime state
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI source or notification copy changed, and no physical Android device or emulator was available to capture the resulting runtime state
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - internal notification scheduling change; no physical Android device or emulator was available for an end-to-end recording
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend route changed; exact-head Gradle and JUnit results are in Testing, but Android logcat was unavailable without a device or emulator
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no web or frontend request, console, network, or rendered state changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no data or domain output changed, and device output was unavailable
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered UI source or visual text changed

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

N/A - no backend or frontend request path changed. Host-side Gradle/JUnit and repository validation results are recorded under Testing. Android logcat is unavailable because no device/emulator was present.

## Screenshots (before / after) + video walkthrough

### Before

N/A - no rendered UI source or notification copy changed; no Android device/emulator was available.

### After

N/A - no rendered UI source or notification copy changed; no Android device/emulator was available.

### Walkthrough video

N/A - no Android device/emulator was available.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changed.

## Known gaps / failures

- Physical Android current-build proof, screenshots, recording, service output, and logcat were not collected because this environment had no device or emulator. This is not a blocker to opening the implementation for review, but it remains a pre-merge native-evidence gap for an independent reviewer or maintainer.
- A first Gradle attempt without `ELIZA_ANDROID_SKIP_FORK_LLAMA_LIB=1` stopped at `:app:copyForkLlamaLib` because the optional fused Android library was absent. The repository-supported skip was then used.
- A second Gradle attempt under the default JDK 17 stopped on class-file major version 65. The exact-head command above was rerun with the available JDK 21 and passed.
- Gradle emitted the existing local warning about a missing pinned debug signing key and used its documented local fallback. It did not affect the host-side unit test.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@5943fce2d548ce74665dc78c871de48067dd8eba:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-17874]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@5943fce2d548ce74665dc78c871de48067dd8eba:packages/skills/skills/contribute-to-eliza"} -->
