### PR TITLE
fix(workflow): preserve disabled trigger success state

### DIFF
--- a/packages/agent/src/triggers/runtime.test.ts
+++ b/packages/agent/src/triggers/runtime.test.ts
@@ -546,6 +546,19 @@ describe("executeTriggerTask", () => {
     });
     expect(forced.status).toBe("success");
     expect(handle.dispatchCalls).toHaveLength(1);
+    expect(handle.updatedTasks.at(-1)?.patch.metadata).toMatchObject({
+      trigger: {
+        enabled: false,
+        lastStatus: "success",
+      },
+    });
+    expect(
+      (
+        handle.updatedTasks.at(-1)?.patch.metadata as
+          | { trigger?: { lastError?: string } }
+          | undefined
+      )?.trigger?.lastError,
+    ).toBeUndefined();
   });
 
   it("warns and skips a trigger whose kind is neither workflow nor prompt", async () => {

--- a/packages/agent/src/triggers/runtime.ts
+++ b/packages/agent/src/triggers/runtime.ts
@@ -730,7 +730,18 @@ export async function executeTriggerTask(
   });
 
   let metadataToPersist: TriggerTaskMetadata;
-  if (!nextMetadata) {
+  if (!nextMetadata && !updatedTrigger.enabled) {
+    metadataToPersist = {
+      ...existingMetadata,
+      updatedAt: finishedAt,
+      updateInterval: DISABLED_TRIGGER_INTERVAL_MS,
+      trigger: {
+        ...updatedTrigger,
+        nextRunAtMs: finishedAt + DISABLED_TRIGGER_INTERVAL_MS,
+      },
+      triggerRuns: appendRunRecord(existingMetadata.triggerRuns, runRecord),
+    };
+  } else if (!nextMetadata) {
     metadataToPersist = {
       ...existingMetadata,
       updatedAt: finishedAt,

--- a/plugins/plugin-workflow/__tests__/unit/embedded-workflow-lifecycle.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/embedded-workflow-lifecycle.test.ts
@@ -133,7 +133,7 @@ describe('embedded native workflow lifecycle', () => {
     expect((await service.listWorkflows()).data).toHaveLength(0);
     expect(tasks).toHaveLength(0);
     expect((await service.listWorkflowRevisions('review')).data[0].operation).toBe('delete');
-  });
+  }, 15_000);
 
   test('preserves user-created triggers while synchronizing the owned cron schedule', async () => {
     const { service, tasks, runtime } = await harness();
@@ -176,7 +176,7 @@ describe('embedded native workflow lifecycle', () => {
 
     await service.deleteWorkflow(created.id);
     expect(tasks).toHaveLength(0);
-  });
+  }, 15_000);
 
   test('resumes an unfinished persisted run with its exact workflow version', async () => {
     const { service, client, runtime } = await harness();
@@ -230,5 +230,5 @@ describe('embedded native workflow lifecycle', () => {
     await Bun.sleep(0);
 
     expect(resumedVersions).toEqual([workflow.versionId]);
-  });
+  }, 15_000);
 });


### PR DESCRIPTION
## Summary

- preserves a successful forced run of a disabled workflow trigger without fabricating a next-schedule error
- keeps the trigger disabled and records its run normally
- gives the three real PGLite-backed Smithers lifecycle cases an explicit 15 second bound

Closes #19855.

## Validation

<!-- evidence-head:8e989ddcad867a1c838727d0452830afe719cc97 -->

Exact head: `57b708cc2b1dabacb327b7e0bd2cecfd0b046f86`

- `bun run verify`: 350/350 workspace tasks plus every repository audit passed on the exact head (127 local cache hits).\n- Agent trigger/runtime + trigger action: 94/94 passed through the canonical Vitest harness.
- Native Smithers embedded lifecycle: 3/3 passed against the real PGLite-backed harness.
- `@elizaos/agent` typecheck and read-only lint: passed.
- `@elizaos/plugin-workflow` typecheck and read-only lint: passed.
- `git diff --check`: passed.

## Evidence gate

<!-- evidence-row:before-screenshots -->
- [ ] N/A - scheduler metadata correction and test-harness timeout only; no UI code or rendered state changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI code changed; the persisted metadata regression is asserted directly in the focused test.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interaction flow changed; the exact trigger execution path is exercised in the focused runtime suite.
<!-- evidence-row:backend-logs -->
- [x] [19857-focused-validation-v2.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19857-focused-validation-v2.txt)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - trigger metadata persistence and test timeout do not add or change a model decision.
<!-- evidence-row:domain-artifacts -->
- [x] [19857-trigger-metadata-readback-v2.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19857-trigger-metadata-readback-v2.json)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual surface changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - repository contribution skill was not available in this session
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - repository contribution skill was not available in this session
Attribution status: self-reported
— [codex-workflow-closeout]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - repository contribution skill was not available in this session"} -->


## Rebase review

Rebased without conflicts onto the current `develop`. At the rebased head, the focused Agent trigger suite passes 27/27, the real PGlite-backed workflow lifecycle passes 3/3, and targeted Biome plus diff checks pass. Direct package typechecks now encounter only unrelated current-`develop` baseline failures in optional Agent plugin build outputs and `plugin-workflow/src/trigger-routes.ts`; no changed file reports a type error.