### PR TITLE
fix(plugin-app-control): keep failed interact diagnostics out of the user channel

### DIFF
--- a/plugins/plugin-app-control/src/actions/views-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-management.test.ts
@@ -533,6 +533,107 @@ describe("view management actions", () => {
 		);
 	});
 
+	it("keeps failed interact diagnostics out of the user channel and delivers only verified successes", async () => {
+		const { runtime } = createRuntime();
+		const notesClient = {
+			listViews: vi.fn(async () => [
+				view({
+					id: "notes",
+					label: "Notes",
+					path: "/notes",
+					capabilities: [
+						{
+							id: "create-note",
+							description: "Create a sticky note.",
+							params: {
+								content: {
+									type: "string",
+									description: "Complete note content.",
+									required: true,
+								},
+							},
+						},
+					],
+				}),
+			]),
+			getCurrentView: vi.fn(async () => null),
+		};
+		const action = createViewsAction({
+			client: notesClient,
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		// Catalog miss: the diagnostic stays planner-facing on `text` — no bubble.
+		const catalogMissCallback = vi.fn();
+		const catalogMiss = await action.handler(
+			runtime as never,
+			message("get my todos") as never,
+			undefined,
+			{ action: "interact", view: "notes", capability: "get-todos" },
+			catalogMissCallback,
+		);
+		expect(catalogMiss?.success).toBe(false);
+		expect(catalogMiss?.text).toContain("Cannot invoke capability");
+		expect(catalogMiss?.userFacingText).toBeUndefined();
+		expect(catalogMissCallback).not.toHaveBeenCalled();
+
+		// Loopback failure: the interaction's diagnostic text is likewise never
+		// delivered — the evaluator/grounded-failure path owns the user reply.
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: false,
+			status: 500,
+			json: async () => ({
+				requestId: "notes-create",
+				success: false,
+				error: "view worker crashed",
+			}),
+		} as Response);
+		const failedCallback = vi.fn();
+		const failed = await action.handler(
+			runtime as never,
+			message("make a note") as never,
+			undefined,
+			{
+				action: "interact",
+				view: "notes",
+				capability: "create-note",
+				params: { content: "hello" },
+			},
+			failedCallback,
+		);
+		expect(failed?.success).toBe(false);
+		expect(failed?.userFacingText).toBeUndefined();
+		expect(failed?.transcriptVisibility).toBe("internal");
+		expect(failedCallback).not.toHaveBeenCalled();
+
+		// Verified success still delivers exactly one bubble.
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				requestId: "notes-create",
+				success: true,
+				result: { success: true, text: "Created note “hello”." },
+			}),
+		} as Response);
+		const successCallback = vi.fn();
+		const succeeded = await action.handler(
+			runtime as never,
+			message("make a note saying hello") as never,
+			undefined,
+			{
+				action: "interact",
+				view: "notes",
+				capability: "create-note",
+				params: { content: "hello" },
+			},
+			successCallback,
+		);
+		expect(succeeded?.success).toBe(true);
+		expect(succeeded?.verifiedUserFacing).toBe(true);
+		expect(successCallback).toHaveBeenCalledTimes(1);
+	});
+
 	it("routes Browser view browse aliases through the canonical BROWSER action", async () => {
 		const { runtime } = createRuntime();
 		const browserHandler = vi.fn(async () => ({

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -3161,10 +3161,16 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 							}
 						}
 						if (!viewId || !capability) {
+							// Planner-facing guidance (tool-call syntax a user never types).
+							// Kept on `text` for the replan; never delivered as a chat bubble —
+							// the evaluator owns the user-facing outcome of a failed step.
 							const reply =
 								"Specify view and capability, e.g. action=interact view=wallet capability=get-state, or ask for the current view after navigating.";
-							await callback?.({ text: reply });
-							return { success: false, text: reply };
+							return {
+								success: false,
+								text: reply,
+								transcriptVisibility: "internal",
+							};
 						}
 						const resolvedView =
 							resolvedCapability?.view ?? resolveViewTarget(viewId, views);
@@ -3254,9 +3260,18 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 									}
 								);
 							}
+							// Catalog diagnostics are planner-facing (`text` contract in
+							// planner-types.ts): the planner replans or retries an owner
+							// reader; delivering this as a bubble leaked developer prose
+							// into chat (live tj-1a1dd4704d0293). `internal` also keeps
+							// withViewsUserFacingText from promoting it to userFacingText,
+							// which core's grounded-failure path would otherwise surface.
 							const reply = `Cannot invoke capability "${capability}" on view "${viewId}": the view catalog does not declare that capability.`;
-							await callback?.({ text: reply });
-							return { success: false, text: reply };
+							return {
+								success: false,
+								text: reply,
+								transcriptVisibility: "internal",
+							};
 						}
 						if (!resolvedCapability && standardCapability)
 							capability = standardCapability;
@@ -3306,9 +3321,13 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 							text,
 						);
 						if (!paramsResolution.ok) {
+							// Same contract as the catalog-miss above: planner-facing only.
 							const reply = `Cannot invoke capability "${capability}" on view "${viewId}": ${paramsResolution.error}.`;
-							await callback?.({ text: reply });
-							return { success: false, text: reply };
+							return {
+								success: false,
+								text: reply,
+								transcriptVisibility: "internal",
+							};
 						}
 						const params = paramsResolution.params;
 						const timeoutMs =
@@ -3331,7 +3350,15 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 						const effectContract = interaction.success
 							? readViewInteractionEffectContract(interaction.result)
 							: undefined;
-						await callback?.({ text: resultText });
+						// Deliver only verified successes. A failed interaction's text is
+						// the loopback diagnostic — planner-facing by contract — and
+						// delivering it produced the two-bubble leak (diagnostic bubble,
+						// then the evaluator's recovery reply). On failure the result
+						// carries no userFacingText, so the evaluator/grounded-failure
+						// path owns the single honest user reply.
+						if (interaction.success) {
+							await callback?.({ text: resultText });
+						}
 						return {
 							success: interaction.success,
 							text: resultText,
@@ -3341,7 +3368,7 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 										verifiedUserFacing: true,
 										turnComplete: true,
 									}
-								: {}),
+								: { transcriptVisibility: "internal" as const }),
 							...(effectContract ?? {}),
 							values: {
 								mode: "interact",

--- a/plugins/plugin-app-control/vitest.config.ts
+++ b/plugins/plugin-app-control/vitest.config.ts
@@ -154,6 +154,13 @@ export default defineConfig({
 				replacement: path.join(coreSrc, "$1.ts"),
 			},
 			{
+				// Extensionless subpath export; must precede the bare entry below,
+				// which would otherwise prefix-rewrite it into a path inside
+				// index.node.ts.
+				find: "@elizaos/core/client-public",
+				replacement: path.join(coreSrc, "client-public.ts"),
+			},
+			{
 				find: "@elizaos/core",
 				replacement: path.join(coreSrc, "index.node.ts"),
 			},


### PR DESCRIPTION
## What

A failed `VIEWS action=interact` delivered its loopback/catalog diagnostic verbatim as a chat bubble AND `withViewsUserFacingText` promoted the same diagnostic to `userFacingText`, so core's grounded-failure path surfaced developer prose to the user — live tj-1a1dd4704d0293 delivered `Cannot invoke capability "get-todos" on view "todos": the view catalog does not declare that capability.` followed by the evaluator's recovery reply (two bubbles, first one leaked).

Fleet context: flag 2 of watchtower's three design flags (HQ #18309), greenlit under the delegated ruling — this is the structural fix at the authoring site, per the `result.text` planner-facing contract in `planner-types.ts` ("tools declare what is safe to show, the framework never guesses").

## How

- The four planner-facing diagnostic sites in the interact path (missing view/capability syntax guidance, catalog miss, param-resolution failure, failed loopback interaction) now: keep the diagnostic on `result.text` for the replan, mark it `transcriptVisibility: "internal"` (so the userFacingText promotion wrapper leaves it alone), and skip callback delivery.
- Callback delivery on interact now happens only for verified successes.
- User-appropriate failure replies (browser gating, view-not-available, destructive-refusal rephrase ask) keep their delivery and promotion unchanged.
- vitest config: pins `@elizaos/core/client-public` before the bare `@elizaos/core` alias (same prefix-swallow class as #19817).

## Evidence (head 00fd43818f37896c6b77c5685c00af93af351708)

| check | command | result |
| --- | --- | --- |
| targeted specs | `bunx vitest run .../views-management.test.ts .../views-action-ownership.repro.test.ts` | 72/72 pass, incl. new regression "keeps failed interact diagnostics out of the user channel and delivers only verified successes" |
| full plugin suite | `bun run --cwd plugins/plugin-app-control test` | 51 files, 1807/1807 pass |
| lint | `bun run --cwd plugins/plugin-app-control lint` | clean, no fixes |
| typecheck | `bun run --cwd plugins/plugin-app-control typecheck` | my files clean; sole residual error is pre-existing on clean develop (`@elizaos/capacitor-bun-runtime` absent in worktree, verified via stash A/B) |
| surface files | none — no .tsx behavior change (test file only) | N/A |

Live-fire follow-up: watchtower re-runs the todos probe on its box once this lands (its lane, its repro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:00fd43818f37896c6b77c5685c00af93af351708 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - plugin action-result contract change; no UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - plugin action-result contract change; no UI surface touched

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - behavior pinned by new vitest regression (72/72 targeted, 1807/1807 plugin suite)

<!-- evidence-row:backend-logs -->
- [ ] N/A - vitest run output summarized in Evidence table; no server boot involved

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - live-fire verification delegated to watchtower box post-merge (HQ 18309, tj-1a1dd4704d0293 repro recipe)

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - domain artifact is the ActionResult contract itself, asserted by the new regression test
