### PR TITLE
fix: keep failed-step diagnostics out of the terminal FINISH fallback

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, expect, it, vi } from "vitest";
 import {
+	latestToolResultText,
 	looksLikeActionEnvelopeJson,
 	looksLikeSpawnEnvelopeJson,
 	runPlannerLoop,
@@ -774,5 +775,78 @@ describe("planner-loop — verified tool text + evaluator prose combine", () => 
 			evaluate,
 		});
 		expect(result.finalMessage).toBe(preview);
+	});
+});
+
+describe("latestToolResultText — failed-step diagnostics stay planner-facing", () => {
+	const trajectoryWith = (
+		steps: PlannerTrajectory["steps"],
+	): PlannerTrajectory => ({
+		context: { id: "ctx" },
+		steps,
+		archivedSteps: [],
+		plannedQueue: [],
+		evaluatorOutputs: [],
+	});
+
+	// The live defect (tj-1a1dd4704d0293): a failed VIEWS interact carried its
+	// catalog diagnostic as userFacingText and the FINISH fallback delivered it
+	// verbatim when the evaluator supplied no messageToUser.
+	it("skips a failed step's text unless it claimed failure authority", () => {
+		const trajectory = trajectoryWith([
+			{
+				iteration: 0,
+				toolCall: { id: "call-1", name: "VIEWS", arguments: {} },
+				result: {
+					success: false as const,
+					text: 'Cannot invoke capability "get-todos" on view "automations".',
+					userFacingText:
+						'Cannot invoke capability "get-todos" on view "automations".',
+				},
+			},
+		]);
+		expect(latestToolResultText(trajectory)).toBeUndefined();
+	});
+
+	it("keeps a failed step's text when the tool claimed failure authority", () => {
+		const owned =
+			"That reminder no longer exists, so there is nothing to delete.";
+		const trajectory = trajectoryWith([
+			{
+				iteration: 0,
+				toolCall: { id: "call-1", name: "OWNER_REMINDERS", arguments: {} },
+				result: {
+					success: false as const,
+					text: owned,
+					userFacingText: owned,
+					verifiedUserFacing: true,
+				},
+			},
+		]);
+		expect(latestToolResultText(trajectory)).toBe(owned);
+	});
+
+	it("falls back past a failed step to an earlier successful step's text", () => {
+		const trajectory = trajectoryWith([
+			{
+				iteration: 0,
+				toolCall: { id: "call-1", name: "CHECK", arguments: {} },
+				result: {
+					success: true as const,
+					text: "raw",
+					userFacingText: "Saved the goal.",
+				},
+			},
+			{
+				iteration: 1,
+				toolCall: { id: "call-2", name: "VIEWS", arguments: {} },
+				result: {
+					success: false as const,
+					text: "diag",
+					userFacingText: "diag",
+				},
+			},
+		]);
+		expect(latestToolResultText(trajectory)).toBe("Saved the goal.");
 	});
 });

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -4011,11 +4011,19 @@ function terminalMessageFromToolCalls(
  * the log into the channel. The contract is structural: tools declare what is
  * safe to show, the framework never guesses by parsing wrapper text.
  */
-function latestToolResultText(
+export function latestToolResultText(
 	trajectory: PlannerTrajectory,
 ): string | undefined {
 	for (const step of [...trajectory.steps].reverse()) {
-		const text = step.result?.userFacingText?.trim();
+		const result = step.result;
+		// A failed step's text is planner-facing diagnostics unless the tool
+		// explicitly claimed failure authority (verifiedUserFacing) — surfacing
+		// it here delivered raw catalog errors verbatim when the evaluator
+		// finished without a messageToUser (live tj-1a1dd4704d0293).
+		if (result?.success === false && result.verifiedUserFacing !== true) {
+			continue;
+		}
+		const text = result?.userFacingText?.trim();
 		if (text) {
 			return text;
 		}


### PR DESCRIPTION
# Relates to

Closes #19864. Builds on the authoring-site repair merged in #19843.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-code (original implementation); openai/gpt-5.6-sol (review, rebase, scope correction, validation, evidence)
<!-- attribution-row:client -->
- Agent tooling: Claude Code; Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@95c456206cc8d111374f3a9f7b59475741701ae5:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] One scoped commit directly atop `95c456206cc8d111374f3a9f7b59475741701ae5` (merged #19843).
- [x] The redundant plugin-app-control wrapper hunk was removed; #19843 already owns that boundary.
- [x] Exact-head tests, core typecheck, Biome, and diff check pass.

# Risks

Low. The change narrows one terminal fallback: unverified failed results are skipped. Verified action-owned failures and earlier successful user-facing results remain eligible and have explicit regressions.

# What changed

When an evaluator finishes without `messageToUser`, `latestToolResultText` walks prior results for a safe fallback. It now ignores `success:false` results unless the tool explicitly set `verifiedUserFacing:true`. This prevents failed catalog/transport diagnostics from becoming the terminal reply while retaining confirmation previews and authoritative failure copy.

# Testing

- `planner-loop-user-facing-text`, `planner-loop-honest-failure`, and `planner-loop-failure-correlation`: 3 files, 62/62 pass.
- `packages/core` typecheck: pass.
- Targeted Biome: pass.
- `git diff --check`: pass.

# Evidence Gate

<!-- evidence-head:8f5539bb42f84407cb1c3e40dec84cb22457bd0f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - planner settlement is a backend/runtime behavior with no rendered UI change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - planner settlement is a backend/runtime behavior with no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual flow; the exact settlement states are captured as domain artifacts and tests.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head validation transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19860-pr19860-backend.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or browser code changed.
<!-- evidence-row:llm-trajectory -->
- [x] [Contributor live-trajectory record and exact-head qualification](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19860-pr19860-trajectory.json)
<!-- evidence-row:domain-artifacts -->
- [x] [Terminal settlement cases](https://github.com/elizaOS/eliza/releases/download/pr-evidence-8/19860-pr19860-domain.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshots or rendered text changed.

# Evidence details

The live nubilio reproduction demonstrates the user-visible failure and the honest post-fix reply. It predates the final rebase and is labeled accordingly. Exact-head deterministic tests separately prove unverified failure suppression, verified failure authority, and fallback to an earlier successful result.

## Known gaps / failures

- Hosted exact-head workflows remain the external gate.
- No exact-final-SHA live trajectory was fabricated.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@95c456206cc8d111374f3a9f7b59475741701ae5:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [nubs-review-pr19860]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@95c456206cc8d111374f3a9f7b59475741701ae5:packages/skills/skills/contribute-to-eliza"} -->
