### PR TITLE
fix(core): enforce a zero-byte media fetch limit

### DIFF
--- a/packages/core/src/media/fetch.test.ts
+++ b/packages/core/src/media/fetch.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for `fetchRemoteMedia`, the SSRF-guarded remote-media fetch: timeout
- * signal propagation and RFC 5987 `Content-Disposition` filename decoding.
+ * signal propagation, byte limits, and RFC 5987 `Content-Disposition`
+ * filename decoding.
  * Deterministic — DNS resolution and transport are injected through the
  * `lookupFn` + `pinnedFetchImpl` pair (the production pinned shape), no network.
  */
@@ -8,6 +9,17 @@ import { describe, expect, it } from "vitest";
 import { fetchRemoteMedia } from "./fetch.ts";
 
 describe("fetchRemoteMedia", () => {
+	it("enforces a zero-byte response limit", async () => {
+		const request = fetchRemoteMedia({
+			url: "https://example.com/image.png",
+			maxBytes: 0,
+			lookupFn: async () => [{ address: "93.184.216.34", family: 4 }],
+			pinnedFetchImpl: async () => new Response(Buffer.from("x")),
+		});
+
+		await expect(request).rejects.toMatchObject({ code: "max_bytes" });
+	});
+
 	it("applies timeout signals to guarded fetches", async () => {
 		let sawAbortSignal = false;
 		const result = await fetchRemoteMedia({

--- a/packages/core/src/media/fetch.ts
+++ b/packages/core/src/media/fetch.ts
@@ -172,7 +172,7 @@ function enforceContentLengthLimit(
 	maxBytes?: number,
 ): void {
 	const contentLength = res.headers.get("content-length");
-	if (!maxBytes || !contentLength) {
+	if (maxBytes === undefined || !contentLength) {
 		return;
 	}
 
@@ -250,9 +250,10 @@ export async function fetchRemoteMedia(
 		await throwIfHttpError(res, options.url, finalUrl);
 		enforceContentLengthLimit(res, options.url, options.maxBytes);
 
-		const buffer = options.maxBytes
-			? await readResponseWithLimit(res, options.maxBytes)
-			: Buffer.from(await res.arrayBuffer());
+		const buffer =
+			options.maxBytes !== undefined
+				? await readResponseWithLimit(res, options.maxBytes)
+				: Buffer.from(await res.arrayBuffer());
 		const metadata = await resolveMediaMetadata({
 			res,
 			buffer,


### PR DESCRIPTION
# Relates to

Closes #19854.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] this PR targets `develop` and is branched directly off the current `origin/develop` tip.
- [x] focused package tests, lint, and typecheck pass on the exact head, see Testing below.
- [x] a reviewer can confirm the fix directly against the deterministic pinned-transport test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (fix, tests, verification transcript), `anthropic/claude-sonnet-5` (independent re-verification, blob push)
<!-- attribution-row:client -->
- Agent tooling: `codex` (via AgentRouter proxy), `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] branched directly off the current `origin/develop` tip

# Risks

low. this only tightens a boundary check that currently affects zero live callers, see below.

# Background

## What does this PR do?

`enforceContentLengthLimit` and `fetchRemoteMedia` in `packages/core/src/media/fetch.ts` both select their byte-limit path with a truthiness check on `maxBytes`, so `maxBytes: 0` gets treated the same as an omitted cap and falls through to the unbounded `arrayBuffer()` read instead of enforcing a hard zero-byte reject.

concrete failure before the fix: a one-byte response with `maxBytes: 0` resolves successfully with the full buffer instead of throwing `MediaFetchError` with code `max_bytes`. a caller relying on the documented hard-cap contract to reject everything under a zero-byte policy gets an unbounded read instead.

checked every current caller of `fetchRemoteMedia` (`attachments.ts`, `readAttachmentAction.ts`, `attachmentContext.ts`, `message.ts`, `media-runtime.ts`, `background-routes.ts`), none pass `0` today, all use a named constant or pass through a variable. so this changes no existing behavior, it only closes a contract gap the `maxBytes?: number` type signature explicitly allows.

fix: distinguish an omitted cap from a zero cap explicitly (`maxBytes === undefined`) in both boundary checks.

## What kind of change is this?

bug fix, non-breaking (no live caller currently passes `maxBytes: 0`).

# Documentation changes needed?

no, the fix restores documented behavior rather than changing the interface.

# Testing

## Where should a reviewer start?

`packages/core/src/media/fetch.test.ts`, the new `enforces a zero-byte response limit` case, then the two truthiness-to-`undefined`-check diffs in `fetch.ts`.

## Detailed testing steps

```text
$ bun run --cwd packages/core test -- src/media/fetch.test.ts
Test Files  1 passed (1)
     Tests  5 passed (5)

$ bunx @biomejs/biome check packages/core/src/media/fetch.ts packages/core/src/media/fetch.test.ts
Checked 2 files in 30ms. No fixes applied.

$ bun run --cwd packages/core typecheck
Done!
exit 0
```

mutation-resistance verified independently: reverted just the two source lines back to their truthiness checks, kept the new test, reran, 1/5 failed with the expected `promise resolved instead of rejecting` mismatch. restored the fix, 5/5 green again.

# Evidence Gate

<!-- evidence-head:fe16fe7973e5dd7e1b8aa3ec2c2df3da1ae77c2d -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes a core fetch utility and its test, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - this changes a core fetch utility and its test, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive product flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic unit test, the real transcript is included under domain artifacts.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code or network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real mutation-resistance run, captured directly:
  ```text
  red (source fix reverted, test kept):
  FAIL src/media/fetch.test.ts > fetchRemoteMedia > enforces a zero-byte response limit
  AssertionError: promise resolved "{ buffer: Buffer[ 120 ], ... }" instead of rejecting
  Tests  1 failed | 4 passed (5)

  green (fix restored):
  Test Files  1 passed (1)
       Tests  5 passed (5)

  confirms the new test genuinely detects the maxBytes: 0 regression and
  the fix closes it, verified independently against the real repo (not
  just trusting the original transcript).
  ```
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface or visual text changed.

## Known gaps / failures

full `packages/core` test suite wasn't run to completion locally, it includes several long-running/timeout-prone tests in unrelated files (`document-processor-custom-llm.test.ts` and others) that make a full local run impractical here. the focused file, lint, and typecheck all pass clean on the exact head. requesting hosted CI confirm the full suite.

AI provider/model: openai / gpt-5.6-sol (fix, tests); anthropic / claude-sonnet-5 (independent re-verification, push)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Contribution skill revision: N/A - direct interactive session, contribute-to-eliza skill not used
Compute receipt: N/A - Slop run-receipt install currently blocked by an unrelated site-deploy-lag issue (deployed skill archive predates recent develop changes)
Attribution status: self-reported
