### PR TITLE
fix(core): owner-life reads outrank views routing

### DIFF
--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -634,6 +634,112 @@ describe("inferDirectCurrentRequestCandidateInference kinds", () => {
 		).toEqual({ names: [], kind: null });
 	});
 
+	it("routes possessive owner-data reads to the owner reader, never VIEWS (read-side of fead478cfa)", () => {
+		const todosAction: Pick<Action, "name" | "similes" | "tags"> = {
+			name: "OWNER_TODOS",
+			similes: ["TODOS", "TODO_LIST"],
+			tags: [],
+		};
+		const todosTaggedViews: Pick<Action, "name" | "similes" | "tags"> = {
+			...viewsAction,
+			tags: [...(viewsAction.tags ?? []), "todos"],
+		};
+		// The live hijack shape: a possessive read must select the reader.
+		for (const message of [
+			"list my personal todos",
+			"what are my todos",
+			"show my todo list",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateInference(
+					[todosTaggedViews, todosAction],
+					message,
+				),
+			).toEqual({ names: ["OWNER_TODOS"], kind: "owner-reads" });
+		}
+		// Lean stacks resolve the standalone todo owner (one owner per deployment).
+		const pluginTodosAction: Pick<Action, "name" | "similes" | "tags"> = {
+			name: "TODO",
+			similes: ["TODOS"],
+			tags: [],
+		};
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[todosTaggedViews, pluginTodosAction],
+				"list my personal todos",
+			),
+		).toEqual({ names: ["TODO"], kind: "owner-reads" });
+		// Without any reader the read yields NO candidate — never the view
+		// catalog (that fallthrough was the live "Cannot invoke get-todos" turn).
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[todosTaggedViews],
+				"list my personal todos",
+			),
+		).toEqual({ names: [], kind: null });
+		// Surface-noun asks stay with the navigation legs.
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[todosTaggedViews, todosAction],
+				"open my todos page",
+			).kind,
+		).not.toBe("owner-reads");
+		// Mutations and completions are not reads.
+		for (const message of [
+			"add a todo: buy milk",
+			"check off my todo buy milk",
+			"mark my first todo done",
+			"how should i organize my todos",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateInference(
+					[todosTaggedViews, todosAction],
+					message,
+				).kind,
+			).not.toBe("owner-reads");
+		}
+	});
+
+	it("covers the other owner-read domains and leaves non-possessive asks alone", () => {
+		const readers: Array<Pick<Action, "name" | "similes" | "tags">> = [
+			{ name: "OWNER_REMINDERS", similes: [], tags: [] },
+			{ name: "OWNER_ROUTINES", similes: [], tags: [] },
+			{ name: "OWNER_FINANCES", similes: [], tags: [] },
+		];
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, ...readers],
+				"what are my reminders for today",
+			),
+		).toEqual({ names: ["OWNER_REMINDERS"], kind: "owner-reads" });
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, ...readers],
+				"show my habits",
+			),
+		).toEqual({ names: ["OWNER_ROUTINES"], kind: "owner-reads" });
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, ...readers],
+				"go over my expenses this week",
+			),
+		).toEqual({ names: ["OWNER_FINANCES"], kind: "owner-reads" });
+		// No possessive anchor → not an owner read (precision over recall).
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, ...readers],
+				"list the reminders",
+			).kind,
+		).not.toBe("owner-reads");
+		// The existing settings capability contract is untouched.
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction],
+				"show my settings",
+			),
+		).toEqual({ names: ["VIEWS"], kind: "view-capability" });
+	});
+
 	it("gives owner goal mutations precedence over the views goals tag (#17028)", () => {
 		const goalsAction: Pick<Action, "name" | "similes" | "tags"> = {
 			name: "OWNER_GOALS",

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -356,6 +356,10 @@ export function isShellDirectActionName(
  * - "owner-goals": concrete owner goal create/save/confirm phrasing.
  * - "owner-routines": habit/routine commitment phrasing, including recurring
  *   cadences ("3 times a day") — an owner mutation, never navigation.
+ * - "owner-reads": a possessive owner-data read ("list my personal todos",
+ *   "what are my reminders") — the read-side mirror of the mutation rule
+ *   above: data asks are owner-domain evidence, and VIEWS can only navigate,
+ *   so a registered owner reader outranks the view-capability overlap.
  * - "view-surface": an operation verb PLUS an explicit UI-surface noun
  *   (view/window/panel/app/screen/ui) — strong navigation evidence.
  * - "view-navigation": the message is nothing but a bare registered surface
@@ -372,6 +376,7 @@ export type DirectCurrentRequestCandidateKind =
 	| "settings-write"
 	| "owner-goals"
 	| "owner-routines"
+	| "owner-reads"
 	| "view-surface"
 	| "view-navigation"
 	| "view-capability"
@@ -624,6 +629,100 @@ function findOwnerRoutinesActionName(
 	return findAvailableActionName(actions, OWNER_ROUTINES_ACTION_NAMES);
 }
 
+/**
+ * Owner-life domains with a possessive read shape. Each maps to its reader
+ * surface in preference order: the personal-assistant umbrella first, then the
+ * standalone domain plugin's action names, so lean stacks (one todo owner per
+ * deployment) resolve their reader too.
+ */
+type OwnerLifeReadDomain =
+	| "todos"
+	| "goals"
+	| "reminders"
+	| "routines"
+	| "alarms"
+	| "finances";
+
+const OWNER_READ_ACTION_NAMES_BY_DOMAIN: Record<
+	OwnerLifeReadDomain,
+	readonly string[]
+> = {
+	todos: ["OWNER_TODOS", "TODOS", "TODO", "TODO_LIST", "LIST_TODOS"],
+	goals: OWNER_GOALS_ACTION_NAMES,
+	reminders: ["OWNER_REMINDERS", "REMINDERS", "REMINDER", "LIST_REMINDERS"],
+	routines: OWNER_ROUTINES_ACTION_NAMES,
+	alarms: ["OWNER_ALARMS", "ALARMS", "ALARM"],
+	finances: ["OWNER_FINANCES", "FINANCES"],
+};
+
+const OWNER_READ_DOMAIN_NOUNS: ReadonlyArray<[OwnerLifeReadDomain, RegExp]> = [
+	["todos", /\b(?:todos?|to[- ]dos?|todo\s+list|task\s+list)\b/iu],
+	["goals", /\bgoals?\b/iu],
+	["reminders", /\breminders?\b/iu],
+	["routines", /\b(?:routines?|habits?)\b/iu],
+	["alarms", /\balarms?\b/iu],
+	["finances", /\b(?:finances|spending|expenses)\b/iu],
+];
+
+/**
+ * Detects a possessive owner-data READ ("list my personal todos", "what are
+ * my reminders for today") — the read-side mirror of the owner-mutation rule
+ * (#17028 / fead478cfa): a data ask is owner-domain evidence, and VIEWS can
+ * only navigate, so it must never degrade into the view-capability overlap
+ * (live: "list my personal todos" routed to VIEWS view-disambiguation, then
+ * failed on an undeclared get-todos capability). Explicit UI-surface nouns
+ * stay with the navigation legs, and advice/organizing questions stay chat.
+ */
+function detectOwnerLifeReadDomain(text: string): OwnerLifeReadDomain | null {
+	const normalized = text.toLowerCase().replace(/\s+/gu, " ").trim();
+	if (!normalized) return null;
+	// Surface-noun asks are navigation, owned by the earlier view legs.
+	if (
+		/\b(?:view|views|page|screen|tab|panel|window|ui|dashboard|app)\b/iu.test(
+			normalized,
+		)
+	) {
+		return null;
+	}
+	// A read needs a possessive anchor; adjectives may sit between it and the
+	// domain noun ("my personal todos", "our shared reminders").
+	const possessiveDomain =
+		/\b(?:my|our)\b(?:\s+\w+){0,2}\s+(?:todos?|to[- ]dos?|todo\s+list|task\s+list|goals?|reminders?|routines?|habits?|alarms?|finances|spending|expenses)\b/iu.test(
+			normalized,
+		);
+	if (!possessiveDomain) return null;
+	// Mutation shapes belong to the write detectors above (or the model);
+	// "check off"/"mark ... done" are completions, not reads.
+	if (
+		/\b(?:add|create|set|save|track|make|store|delete|remove|cancel|clear|update|edit|rename|complete|finish|snooze|reschedule)\b/iu.test(
+			normalized,
+		) ||
+		/\bcheck(?:ed)?\s+off\b/iu.test(normalized) ||
+		/\bmark\b[\s\S]{0,40}\b(?:done|complete|off)\b/iu.test(normalized)
+	) {
+		return null;
+	}
+	const hasReadShape =
+		/\b(?:list|show|what(?:'s|s| is| are)(?:\s+(?:on|in))?|do i have|have i got|any(?:thing)?\s+(?:on|in|left|due)|tell me|give me|read(?:\s+(?:me|out))?|check|see|look at|go over|review)\b/iu.test(
+			normalized,
+		);
+	if (!hasReadShape) return null;
+	for (const [domain, noun] of OWNER_READ_DOMAIN_NOUNS) {
+		if (noun.test(normalized)) return domain;
+	}
+	return null;
+}
+
+function findOwnerLifeReadActionName(
+	actions: ReadonlyArray<Pick<Action, "name" | "similes">>,
+	domain: OwnerLifeReadDomain,
+): string | undefined {
+	return findAvailableActionName(
+		actions,
+		OWNER_READ_ACTION_NAMES_BY_DOMAIN[domain],
+	);
+}
+
 export function inferDirectCurrentRequestCandidateActions(
 	actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>,
 	messageText: string,
@@ -718,6 +817,22 @@ export function inferDirectCurrentRequestCandidateInference(
 		const ownerGoalsAction = findOwnerGoalsActionName(actions);
 		if (ownerGoalsAction) {
 			return { names: [ownerGoalsAction], kind: "owner-goals" };
+		}
+		return EMPTY_DIRECT_CANDIDATE_INFERENCE;
+	}
+	// Owner reads outrank the view-capability overlap for the same reason the
+	// mutations above do (read-side of fead478cfa): "list my personal todos"
+	// wants the data, and VIEWS can only navigate. With no registered owner
+	// reader the turn yields NO deterministic candidate rather than degrading
+	// into the view catalog.
+	const ownerReadDomain = detectOwnerLifeReadDomain(messageText);
+	if (ownerReadDomain) {
+		const ownerReadAction = findOwnerLifeReadActionName(
+			actions,
+			ownerReadDomain,
+		);
+		if (ownerReadAction) {
+			return { names: [ownerReadAction], kind: "owner-reads" };
 		}
 		return EMPTY_DIRECT_CANDIDATE_INFERENCE;
 	}

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/candidate-backstop.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/candidate-backstop.ts
@@ -44,6 +44,11 @@ const SCHEDULED_TASK_ACTION_NAMES: readonly string[] = [
   // recovery target (#17028).
   "OWNER_ROUTINES",
   "OWNER_REMINDERS",
+  // Owner todo reads/writes: the matcher already covers "todo" phrasing, and
+  // the recovery path needs the reader as a target so a failed VIEWS detour
+  // on "list my personal todos" can retry the tier-A owner surface instead of
+  // finishing on the failure (read-side of fead478cfa).
+  "OWNER_TODOS",
 ];
 
 /**


### PR DESCRIPTION
## What

Flag 3 of watchtower's three design flags (HQ #18309, delegated ruling): the planner routes possessive owner-data READS ("list my personal todos") to VIEWS via the weak view-capability tag overlap even when a tier-A owner reader is registered, then FINISHes after the VIEWS failure. Shaw's fead478cfa decided this principle for writes ("owner mutations outrank VIEWS routing; VIEWS can only navigate"); this PR is the symmetric read leg. Live evidence that prompt nudges are insufficient: watchtower added an owner-data de-claim to VIEWS_ROUTING_HINT in #19843 and "list my personal todos" still routed to VIEWS.

## How

- **core/direct-action-heuristics**: new `owner-reads` inference kind. Detector requires a possessive anchor (+≤2 adjectives), a read shape, and an owner-life domain noun; excludes explicit UI-surface nouns (navigation legs own those), mutation/completion verbs (write detectors own those), and advice questions. Resolves the tier-A reader per domain — OWNER_TODOS/GOALS/REMINDERS/ROUTINES/ALARMS/FINANCES with standalone-plugin fallbacks (`TODO` etc.) so one-owner-per-deployment lean stacks resolve. Runs before the view-capability leg; with no registered reader the turn yields NO deterministic candidate instead of degrading into the view catalog — identical to the mutation-leg rule.
- **pa/candidate-backstop**: OWNER_TODOS added as a recovery target (shaw's own #17028 seam — he added OWNER_ROUTINES/OWNER_REMINDERS here) so a failed VIEWS detour on a todo turn has the owner surface as a retry/recovery candidate.
- The FINISH-on-failure half of the flag is addressed jointly with #19858 (failure diagnostics are no longer delivered, so the evaluator can no longer treat the failed VIEWS turn as answered).

Deliberately narrow (precision over recall, the #17028 lesson): non-possessive reads ("list the reminders") and health-domain phrasing are left to the model.

## Evidence (head a19bcccebf1fb3230b4e101d9af95c2e7de628ec)

| check | command | result |
| --- | --- | --- |
| heuristics suite | `bunx vitest run .../direct-action-heuristics.test.ts` | 60/60 (2 new read-side blocks: live hijack shape, lean-stack resolution, no-reader→no-candidate, surface-noun/mutation/advice negatives, settings-contract guard) |
| live regression | `bunx vitest run packages/core/src/__tests__/message-routing-live-regression.test.ts` | 69/69 |
| message suites | `bunx vitest run packages/core/src/services/message` | 591/591 (31 files) |
| PA backstop | `bunx vitest run src/lifeops/scheduled-task/candidate-backstop.test.ts` | 7/7 |
| core typecheck | `bun run --cwd packages/core typecheck` | PASS |
| PA typecheck | stash A/B | failures pre-existing on clean develop (env, none in touched file) |

Live-fire: watchtower's box runs "list my personal todos" post-merge (their standing offer at HQ).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:b879dbaa6efa30bcac5e020519f64c382f78d03f -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Stage-1 candidate-inference change; no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Stage-1 candidate-inference change; no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - behavior pinned by 60/60 heuristics suite incl. live hijack shape

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic pre-model heuristics; vitest summaries in Evidence table

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - live-fire on watchtower box post-merge (HQ 18309 standing offer)

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - candidate inference contract, asserted by the new tests


