### PR TITLE
fix(core): redact configured secrets across shell fragments

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -110,7 +110,7 @@ import { BM25 } from "./search";
 import {
 	locateConfiguredSecretFragmentTaint,
 	type SecretFragment,
-	type SecretFragmentTaint,
+	type SecretFragmentTaintProfile,
 } from "./security/fragment-redaction.js";
 import {
 	authorizeOwnerExclusiveDisclosure,
@@ -329,6 +329,7 @@ import {
 	getActiveRoutingContextsForTurn,
 	shouldIncludeByContext,
 } from "./utils/context-routing";
+import { createHash } from "./utils/crypto-compat";
 import { buildDeterministicSeed, shortStringHash } from "./utils/deterministic";
 import { getNumberEnv } from "./utils/environment";
 import {
@@ -1340,6 +1341,8 @@ export class AgentRuntime implements IAgentRuntime {
 	private embeddingGenerationDisabledReason: string | null = null;
 	/** Once-latch so the embedding-skip warning fires once, not per write. */
 	private embeddingSkipWarned = false;
+	private secretRedactionProfileSignature = "";
+	private secretRedactionProfileRevision = 0;
 	private taskWorkers = new Map<string, TaskWorker>();
 	private sendHandlers = new Map<string, SendHandlerFunction>();
 	private messageConnectors = new Map<string, MessageConnector>();
@@ -11305,11 +11308,27 @@ ${section_end}`;
 
 	locateConfiguredSecretFragmentTaint(
 		fragments: readonly SecretFragment[],
-	): SecretFragmentTaint {
-		return locateConfiguredSecretFragmentTaint(
-			fragments,
-			this.getSecretsForRedaction(),
-		);
+	): SecretFragmentTaintProfile {
+		const secrets = this.getSecretsForRedaction();
+		const signature = createHash("sha256")
+			.update(
+				JSON.stringify(
+					[
+						...new Set(
+							Object.values(secrets).filter((value) => value.length >= 8),
+						),
+					].sort(),
+				),
+			)
+			.digest("hex");
+		if (signature !== this.secretRedactionProfileSignature) {
+			this.secretRedactionProfileSignature = signature;
+			this.secretRedactionProfileRevision += 1;
+		}
+		return {
+			...locateConfiguredSecretFragmentTaint(fragments, secrets),
+			profileRevision: this.secretRedactionProfileRevision,
+		};
 	}
 
 	async clearAllAgentMemories(): Promise<void> {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -108,6 +108,11 @@ import {
 } from "./runtime/turn-controller";
 import { BM25 } from "./search";
 import {
+	locateConfiguredSecretFragmentTaint,
+	type SecretFragment,
+	type SecretFragmentTaint,
+} from "./security/fragment-redaction.js";
+import {
 	authorizeOwnerExclusiveDisclosure,
 	CompositeEntityRecognizer,
 	DEFAULT_PSEUDONYM_BLOCKLIST,
@@ -11296,6 +11301,15 @@ ${section_end}`;
 			return text;
 		}
 		return redactWithSecrets(text, { secrets, applyPatterns: true });
+	}
+
+	locateConfiguredSecretFragmentTaint(
+		fragments: readonly SecretFragment[],
+	): SecretFragmentTaint {
+		return locateConfiguredSecretFragmentTaint(
+			fragments,
+			this.getSecretsForRedaction(),
+		);
 	}
 
 	async clearAllAgentMemories(): Promise<void> {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -109,6 +109,7 @@ import {
 import { BM25 } from "./search";
 import {
 	locateConfiguredSecretFragmentTaint,
+	MIN_CONFIGURED_SECRET_LENGTH,
 	type SecretFragment,
 	type SecretFragmentTaintProfile,
 } from "./security/fragment-redaction.js";
@@ -11315,7 +11316,9 @@ ${section_end}`;
 				JSON.stringify(
 					[
 						...new Set(
-							Object.values(secrets).filter((value) => value.length >= 8),
+							Object.values(secrets).filter(
+								(value) => value.length >= MIN_CONFIGURED_SECRET_LENGTH,
+							),
 						),
 					].sort(),
 				),

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -109,7 +109,6 @@ import {
 import { BM25 } from "./search";
 import {
 	locateConfiguredSecretFragmentTaint,
-	MIN_CONFIGURED_SECRET_LENGTH,
 	type SecretFragment,
 	type SecretFragmentTaintProfile,
 } from "./security/fragment-redaction.js";
@@ -133,7 +132,7 @@ import {
 	trustedDeliveryAudienceCacheKey,
 } from "./security/index.js";
 import { guardOutboundEnvelopeText } from "./security/outbound-envelope-guard.js";
-import { redactWithSecrets } from "./security/redact.js";
+import { MIN_SECRET_LENGTH, redactWithSecrets } from "./security/redact.js";
 import {
 	parseSecretSwapExemptValues,
 	SECRET_SWAP_ENABLED_SETTING,
@@ -11317,7 +11316,7 @@ ${section_end}`;
 					[
 						...new Set(
 							Object.values(secrets).filter(
-								(value) => value.length >= MIN_CONFIGURED_SECRET_LENGTH,
+								(value) => value.length >= MIN_SECRET_LENGTH,
 							),
 						),
 					].sort(),

--- a/packages/core/src/security/fragment-redaction.test.ts
+++ b/packages/core/src/security/fragment-redaction.test.ts
@@ -1,6 +1,8 @@
 /** Verifies configured-secret taint mapping without exposing secret values. */
 
 import { describe, expect, it } from "vitest";
+import { AgentRuntime } from "../runtime.js";
+import type { Character } from "../types/index.js";
 import {
 	locateConfiguredSecretFragmentTaint,
 	type SecretFragment,
@@ -105,7 +107,7 @@ describe("locateConfiguredSecretFragmentTaint", () => {
 			status: "incomplete",
 			reason: "invalid-input",
 			ranges: [],
-			maxSecretLength: 0,
+			maxSecretLength: 9,
 		});
 	});
 
@@ -119,7 +121,7 @@ describe("locateConfiguredSecretFragmentTaint", () => {
 				status: "incomplete",
 				reason: "invalid-input",
 				ranges: [],
-				maxSecretLength: 0,
+				maxSecretLength: 9,
 			});
 		}
 	});
@@ -180,7 +182,49 @@ describe("locateConfiguredSecretFragmentTaint", () => {
 			status: "incomplete",
 			reason: "resource-limit",
 			ranges: [],
+			maxSecretLength: 9,
 		});
+	});
+
+	it("short-circuits an empty eligible profile before fragment limits", () => {
+		const fragments = Array.from({ length: 257 }, (_, index) => ({
+			source: "stdout",
+			startOffset: index,
+			text: "x",
+		}));
+		expect(
+			locateConfiguredSecretFragmentTaint(fragments, { SHORT: "short" }),
+		).toEqual({ status: "complete", ranges: [], maxSecretLength: 0 });
+	});
+
+	it("returns an opaque revision that changes with the eligible profile", () => {
+		const runtime = new AgentRuntime({
+			character: {
+				name: "fragment-redaction-runtime",
+				settings: { secrets: { SERVICE_TOKEN: SECRET } },
+			} as Character,
+		});
+		const exhausted = runtime.locateConfiguredSecretFragmentTaint(
+			Array.from({ length: 257 }, (_, index) => ({
+				source: "stdout",
+				startOffset: index,
+				text: "x",
+			})),
+		);
+		expect(exhausted).toMatchObject({
+			status: "incomplete",
+			reason: "resource-limit",
+			maxSecretLength: SECRET.length,
+		});
+		expect(JSON.stringify(exhausted)).not.toContain(SECRET);
+
+		const firstRevision = exhausted.profileRevision;
+		runtime.character.settings = {
+			secrets: { SERVICE_TOKEN: "violet73x" },
+		};
+		const rotated = runtime.locateConfiguredSecretFragmentTaint([]);
+		expect(rotated.profileRevision).toBeGreaterThan(firstRevision);
+		expect(JSON.stringify(rotated)).not.toContain("violet73x");
 	});
 
 	it("does not mutate inputs or return configured secret values", () => {

--- a/packages/core/src/security/fragment-redaction.test.ts
+++ b/packages/core/src/security/fragment-redaction.test.ts
@@ -1,0 +1,197 @@
+/** Verifies configured-secret taint mapping without exposing secret values. */
+
+import { describe, expect, it } from "vitest";
+import {
+	locateConfiguredSecretFragmentTaint,
+	type SecretFragment,
+} from "./fragment-redaction.js";
+
+const SECRET = ["mari", "gold9"].join("");
+const SECRETS = { SERVICE_TOKEN: SECRET };
+
+describe("locateConfiguredSecretFragmentTaint", () => {
+	it("maps an exact same-fragment match to absolute source offsets", () => {
+		expect(
+			locateConfiguredSecretFragmentTaint(
+				[{ source: "stdout", startOffset: 40, text: `ok ${SECRET} end` }],
+				SECRETS,
+			),
+		).toEqual({
+			status: "complete",
+			ranges: [{ source: "stdout", startOffset: 43, endOffset: 52 }],
+			maxSecretLength: 9,
+		});
+	});
+
+	it("maps a configured secret split across chunks of one source", () => {
+		expect(
+			locateConfiguredSecretFragmentTaint(
+				[
+					{ source: "stdout", startOffset: 0, text: "mari" },
+					{ source: "stdout", startOffset: 4, text: "gold9" },
+				],
+				SECRETS,
+			).ranges,
+		).toEqual([{ source: "stdout", startOffset: 0, endOffset: 9 }]);
+	});
+
+	it("maps only contributing prefixes across stdout and stderr", () => {
+		expect(
+			locateConfiguredSecretFragmentTaint(
+				[
+					{ source: "stdout", startOffset: 10, text: "mariX" },
+					{ source: "stderr", startOffset: 3, text: "gold9" },
+				],
+				SECRETS,
+			).ranges,
+		).toEqual([
+			{ source: "stderr", startOffset: 3, endOffset: 8 },
+			{ source: "stdout", startOffset: 10, endOffset: 14 },
+		]);
+	});
+
+	it("tracks a secret split across more than two ordered fragments", () => {
+		expect(
+			locateConfiguredSecretFragmentTaint(
+				[
+					{ source: "stdout", startOffset: 0, text: "ma!" },
+					{ source: "stderr", startOffset: 20, text: "ri?" },
+					{ source: "stdout", startOffset: 3, text: "gold9" },
+				],
+				SECRETS,
+			).ranges,
+		).toEqual([
+			{ source: "stderr", startOffset: 20, endOffset: 22 },
+			{ source: "stdout", startOffset: 0, endOffset: 2 },
+			{ source: "stdout", startOffset: 3, endOffset: 8 },
+		]);
+	});
+
+	it("does not skip an unrelated fragment or taint later safe output", () => {
+		const fragments: SecretFragment[] = [
+			{ source: "stdout", startOffset: 0, text: "mari" },
+			{ source: "stderr", startOffset: 0, text: "zzzzzz" },
+			{ source: "stdout", startOffset: 4, text: "gold9" },
+			{ source: "stderr", startOffset: 8, text: "later-safe" },
+		];
+		expect(
+			locateConfiguredSecretFragmentTaint(fragments, SECRETS).ranges,
+		).toEqual([]);
+	});
+
+	it("is order-sensitive", () => {
+		expect(
+			locateConfiguredSecretFragmentTaint(
+				[
+					{ source: "stderr", startOffset: 0, text: "gold9" },
+					{ source: "stdout", startOffset: 0, text: "mari" },
+				],
+				SECRETS,
+			).ranges,
+		).toEqual([]);
+	});
+
+	it("fails closed for invalid fragments", () => {
+		expect(
+			locateConfiguredSecretFragmentTaint(
+				[
+					{ source: "", startOffset: 0, text: SECRET },
+					{ source: "stdout", startOffset: -1, text: SECRET },
+					{ source: "stdout", startOffset: 0, text: "short" },
+				],
+				SECRETS,
+			),
+		).toEqual({
+			status: "incomplete",
+			reason: "invalid-input",
+			ranges: [],
+			maxSecretLength: 0,
+		});
+	});
+
+	it("fails closed without reconnecting sparse or null fragments", () => {
+		const sparse = new Array<SecretFragment>(3);
+		sparse[0] = { source: "stdout", startOffset: 0, text: "mari" };
+		sparse[2] = { source: "stderr", startOffset: 0, text: "gold9" };
+
+		for (const fragments of [sparse, [null] as unknown as SecretFragment[]]) {
+			expect(locateConfiguredSecretFragmentTaint(fragments, SECRETS)).toEqual({
+				status: "incomplete",
+				reason: "invalid-input",
+				ranges: [],
+				maxSecretLength: 0,
+			});
+		}
+	});
+
+	it("fails closed when absolute source ranges cannot remain safe integers", () => {
+		expect(
+			locateConfiguredSecretFragmentTaint(
+				[
+					{
+						source: "stdout",
+						startOffset: Number.MAX_SAFE_INTEGER - 2,
+						text: SECRET,
+					},
+				],
+				SECRETS,
+			),
+		).toMatchObject({
+			status: "incomplete",
+			reason: "invalid-input",
+			ranges: [],
+		});
+	});
+
+	it("ignores configured values below the core floor", () => {
+		expect(
+			locateConfiguredSecretFragmentTaint(
+				[{ source: "stdout", startOffset: 0, text: "short" }],
+				{ SHORT: "short" },
+			),
+		).toEqual({ status: "complete", ranges: [], maxSecretLength: 0 });
+	});
+
+	it("bounds repeated-substring work without recursive expansion", () => {
+		const fragments = Array.from({ length: 32 }, (_, index) => ({
+			source: index % 2 === 0 ? "stdout" : "stderr",
+			startOffset: index * 64,
+			text: "a".repeat(64),
+		}));
+		const startedAt = performance.now();
+		const result = locateConfiguredSecretFragmentTaint(fragments, {
+			TOKEN: "a".repeat(16),
+		});
+
+		expect(result.status).toBe("complete");
+		expect(result.ranges.length).toBeGreaterThan(0);
+		expect(performance.now() - startedAt).toBeLessThan(1_000);
+	});
+
+	it("reports resource exhaustion explicitly", () => {
+		const fragments = Array.from({ length: 257 }, (_, index) => ({
+			source: "stdout",
+			startOffset: index,
+			text: "a",
+		}));
+		expect(
+			locateConfiguredSecretFragmentTaint(fragments, SECRETS),
+		).toMatchObject({
+			status: "incomplete",
+			reason: "resource-limit",
+			ranges: [],
+		});
+	});
+
+	it("does not mutate inputs or return configured secret values", () => {
+		const fragments = [
+			{ source: "stdout", startOffset: 0, text: "mariX" },
+			{ source: "stderr", startOffset: 0, text: "gold9" },
+		] as const;
+		const snapshot = structuredClone(fragments);
+		const result = locateConfiguredSecretFragmentTaint(fragments, SECRETS);
+
+		expect(fragments).toEqual(snapshot);
+		expect(JSON.stringify(result)).not.toContain(SECRET);
+	});
+});

--- a/packages/core/src/security/fragment-redaction.ts
+++ b/packages/core/src/security/fragment-redaction.ts
@@ -1,0 +1,288 @@
+/**
+ * Maps configured-secret matches across ordered diagnostic fragments back to
+ * absolute source ranges. AgentRuntime owns the secret values; callers receive
+ * only taint metadata so stream offsets remain usable without exposing config.
+ */
+
+const MIN_CONFIGURED_SECRET_LENGTH = 8;
+const MAX_FRAGMENT_COUNT = 256;
+const MAX_TOTAL_FRAGMENT_CHARACTERS = 256 * 1024;
+const MAX_CONFIGURED_SECRET_COUNT = 128;
+const MAX_CONFIGURED_SECRET_LENGTH = 32 * 1024;
+const MAX_WORK_UNITS = 2_000_000;
+
+export interface SecretFragment {
+	/** Stable source identity, such as stdout or stderr. */
+	source: string;
+	/** Absolute character offset of text within its source. */
+	startOffset: number;
+	/** Private fragment text inspected by AgentRuntime. */
+	text: string;
+}
+
+export interface SecretTaintRange {
+	source: string;
+	startOffset: number;
+	endOffset: number;
+}
+
+export type SecretFragmentTaint =
+	| {
+			status: "complete";
+			ranges: SecretTaintRange[];
+			maxSecretLength: number;
+	  }
+	| {
+			status: "incomplete";
+			reason: "invalid-input" | "resource-limit";
+			ranges: [];
+			maxSecretLength: number;
+	  };
+
+interface CandidateRange extends SecretTaintRange {
+	fragmentIndex: number;
+}
+
+interface SuccessfulEdge {
+	endSecretOffset: number;
+	occurrences: number[];
+}
+
+interface WorkBudget {
+	remaining: number;
+}
+
+function incomplete(
+	reason: "invalid-input" | "resource-limit",
+	maxSecretLength = 0,
+): SecretFragmentTaint {
+	return { status: "incomplete", reason, ranges: [], maxSecretLength };
+}
+
+function consumeWork(budget: WorkBudget, units = 1): boolean {
+	budget.remaining -= units;
+	return budget.remaining >= 0;
+}
+
+function normalizeFragments(
+	fragments: readonly SecretFragment[],
+): SecretFragment[] | "invalid-input" | "resource-limit" {
+	if (!Array.isArray(fragments)) return "invalid-input";
+	if (fragments.length > MAX_FRAGMENT_COUNT) return "resource-limit";
+	const normalized: SecretFragment[] = [];
+	let totalCharacters = 0;
+	for (let index = 0; index < fragments.length; index++) {
+		if (!(index in fragments)) return "invalid-input";
+		const candidate: unknown = fragments[index];
+		if (!candidate || typeof candidate !== "object") return "invalid-input";
+		const fragment = candidate as Partial<SecretFragment>;
+		if (
+			typeof fragment.source !== "string" ||
+			fragment.source.length === 0 ||
+			!Number.isSafeInteger(fragment.startOffset) ||
+			(fragment.startOffset ?? -1) < 0 ||
+			typeof fragment.text !== "string" ||
+			fragment.text.length === 0 ||
+			!Number.isSafeInteger((fragment.startOffset ?? 0) + fragment.text.length)
+		) {
+			return "invalid-input";
+		}
+		totalCharacters += fragment.text.length;
+		if (totalCharacters > MAX_TOTAL_FRAGMENT_CHARACTERS) {
+			return "resource-limit";
+		}
+		normalized.push({
+			source: fragment.source,
+			startOffset: fragment.startOffset as number,
+			text: fragment.text,
+		});
+	}
+	return normalized;
+}
+
+function configuredSecretValues(
+	secrets: Record<string, string>,
+): string[] | "invalid-input" | "resource-limit" {
+	if (!secrets || typeof secrets !== "object" || Array.isArray(secrets)) {
+		return "invalid-input";
+	}
+	const values = Object.values(secrets);
+	if (values.length > MAX_CONFIGURED_SECRET_COUNT) return "resource-limit";
+	const unique = new Set<string>();
+	for (const value of values) {
+		if (typeof value !== "string") return "invalid-input";
+		if (value.length > MAX_CONFIGURED_SECRET_LENGTH) return "resource-limit";
+		if (value.length >= MIN_CONFIGURED_SECRET_LENGTH) unique.add(value);
+	}
+	return [...unique].sort((left, right) => right.length - left.length);
+}
+
+function occurrences(
+	text: string,
+	needle: string,
+	budget: WorkBudget,
+): number[] | null {
+	if (!consumeWork(budget)) return null;
+	const indexes: number[] = [];
+	let from = 0;
+	while (from <= text.length - needle.length) {
+		const index = text.indexOf(needle, from);
+		if (index < 0) break;
+		if (!consumeWork(budget)) return null;
+		indexes.push(index);
+		from = index + 1;
+	}
+	return indexes;
+}
+
+function rangeKey(range: CandidateRange): string {
+	return `${range.fragmentIndex}:${range.startOffset}:${range.endOffset}`;
+}
+
+function stateKey(fragmentIndex: number, secretOffset: number): string {
+	return `${fragmentIndex}:${secretOffset}`;
+}
+
+/**
+ * Builds the successful suffix graph once, then collects ranges in a second
+ * pass. Repeated substrings therefore cannot recursively expand the same suffix.
+ */
+function findSecretRanges(
+	fragments: readonly SecretFragment[],
+	secret: string,
+	budget: WorkBudget,
+): CandidateRange[] | null {
+	const edges = new Map<string, SuccessfulEdge[]>();
+	for (
+		let fragmentIndex = fragments.length - 1;
+		fragmentIndex >= 0;
+		fragmentIndex--
+	) {
+		const fragment = fragments[fragmentIndex];
+		for (
+			let secretOffset = secret.length - 1;
+			secretOffset >= 0;
+			secretOffset--
+		) {
+			if (!consumeWork(budget)) return null;
+			const successful: SuccessfulEdge[] = [];
+			const maxEnd = Math.min(
+				secret.length,
+				secretOffset + fragment.text.length,
+			);
+			for (let end = secretOffset + 1; end <= maxEnd; end++) {
+				const segment = secret.slice(secretOffset, end);
+				const segmentOccurrences = occurrences(fragment.text, segment, budget);
+				if (!segmentOccurrences) return null;
+				if (segmentOccurrences.length === 0) break;
+				if (
+					end === secret.length ||
+					edges.has(stateKey(fragmentIndex + 1, end))
+				) {
+					successful.push({
+						endSecretOffset: end,
+						occurrences: segmentOccurrences,
+					});
+				}
+			}
+			if (successful.length > 0) {
+				edges.set(stateKey(fragmentIndex, secretOffset), successful);
+			}
+		}
+	}
+
+	const matches = new Map<string, CandidateRange>();
+	const visited = new Set<string>();
+	const pending: Array<[number, number]> = [];
+	for (let start = 0; start < fragments.length; start++) {
+		if (edges.has(stateKey(start, 0))) pending.push([start, 0]);
+	}
+	while (pending.length > 0) {
+		if (!consumeWork(budget)) return null;
+		const [fragmentIndex, secretOffset] = pending.pop() as [number, number];
+		const key = stateKey(fragmentIndex, secretOffset);
+		if (visited.has(key)) continue;
+		visited.add(key);
+		const fragment = fragments[fragmentIndex];
+		for (const edge of edges.get(key) ?? []) {
+			const length = edge.endSecretOffset - secretOffset;
+			for (const index of edge.occurrences) {
+				if (!consumeWork(budget)) return null;
+				const range: CandidateRange = {
+					source: fragment.source,
+					startOffset: fragment.startOffset + index,
+					endOffset: fragment.startOffset + index + length,
+					fragmentIndex,
+				};
+				matches.set(rangeKey(range), range);
+			}
+			if (edge.endSecretOffset < secret.length) {
+				pending.push([fragmentIndex + 1, edge.endSecretOffset]);
+			}
+		}
+	}
+	return [...matches.values()];
+}
+
+function mergeRanges(ranges: readonly CandidateRange[]): SecretTaintRange[] {
+	const sorted = ranges
+		.map(({ source, startOffset, endOffset }) => ({
+			source,
+			startOffset,
+			endOffset,
+		}))
+		.sort(
+			(left, right) =>
+				left.source.localeCompare(right.source) ||
+				left.startOffset - right.startOffset ||
+				left.endOffset - right.endOffset,
+		);
+	const merged: SecretTaintRange[] = [];
+	for (const range of sorted) {
+		const previous = merged.at(-1);
+		if (
+			previous &&
+			previous.source === range.source &&
+			range.startOffset <= previous.endOffset
+		) {
+			previous.endOffset = Math.max(previous.endOffset, range.endOffset);
+			continue;
+		}
+		merged.push({ ...range });
+	}
+	return merged;
+}
+
+/**
+ * Locate configured-secret material across consecutive ordered fragments.
+ *
+ * Each fragment must contribute a non-empty contiguous segment. An incomplete
+ * result is fail-closed: callers suppress output rather than infer safety from
+ * empty ranges.
+ */
+export function locateConfiguredSecretFragmentTaint(
+	fragments: readonly SecretFragment[],
+	secrets: Record<string, string>,
+): SecretFragmentTaint {
+	const normalized = normalizeFragments(fragments);
+	if (typeof normalized === "string") return incomplete(normalized);
+	const values = configuredSecretValues(secrets);
+	if (typeof values === "string") return incomplete(values);
+	const maxSecretLength = values.reduce(
+		(maximum, secret) => Math.max(maximum, secret.length),
+		0,
+	);
+	const availableCharacters = normalized.reduce(
+		(total, fragment) => total + fragment.text.length,
+		0,
+	);
+	const budget: WorkBudget = { remaining: MAX_WORK_UNITS };
+	const ranges: CandidateRange[] = [];
+	for (const secret of values) {
+		if (secret.length > availableCharacters) continue;
+		const found = findSecretRanges(normalized, secret, budget);
+		if (!found) return incomplete("resource-limit", maxSecretLength);
+		ranges.push(...found);
+	}
+	return { status: "complete", ranges: mergeRanges(ranges), maxSecretLength };
+}

--- a/packages/core/src/security/fragment-redaction.ts
+++ b/packages/core/src/security/fragment-redaction.ts
@@ -4,7 +4,8 @@
  * only taint metadata so stream offsets remain usable without exposing config.
  */
 
-export const MIN_CONFIGURED_SECRET_LENGTH = 8;
+import { MIN_SECRET_LENGTH } from "./redact.js";
+
 const MAX_FRAGMENT_COUNT = 256;
 const MAX_TOTAL_FRAGMENT_CHARACTERS = 256 * 1024;
 const MAX_CONFIGURED_SECRET_COUNT = 128;
@@ -117,7 +118,7 @@ function configuredSecretValues(
 	for (const value of values) {
 		if (typeof value !== "string") return "invalid-input";
 		if (value.length > MAX_CONFIGURED_SECRET_LENGTH) return "resource-limit";
-		if (value.length >= MIN_CONFIGURED_SECRET_LENGTH) unique.add(value);
+		if (value.length >= MIN_SECRET_LENGTH) unique.add(value);
 	}
 	return [...unique].sort((left, right) => right.length - left.length);
 }

--- a/packages/core/src/security/fragment-redaction.ts
+++ b/packages/core/src/security/fragment-redaction.ts
@@ -39,6 +39,11 @@ export type SecretFragmentTaint =
 			maxSecretLength: number;
 	  };
 
+export type SecretFragmentTaintProfile = SecretFragmentTaint & {
+	/** Monotonic runtime-local revision; changes never expose secret values. */
+	profileRevision: number;
+};
+
 interface CandidateRange extends SecretTaintRange {
 	fragmentIndex: number;
 }
@@ -264,14 +269,19 @@ export function locateConfiguredSecretFragmentTaint(
 	fragments: readonly SecretFragment[],
 	secrets: Record<string, string>,
 ): SecretFragmentTaint {
-	const normalized = normalizeFragments(fragments);
-	if (typeof normalized === "string") return incomplete(normalized);
 	const values = configuredSecretValues(secrets);
 	if (typeof values === "string") return incomplete(values);
 	const maxSecretLength = values.reduce(
 		(maximum, secret) => Math.max(maximum, secret.length),
 		0,
 	);
+	if (values.length === 0) {
+		return { status: "complete", ranges: [], maxSecretLength: 0 };
+	}
+	const normalized = normalizeFragments(fragments);
+	if (typeof normalized === "string") {
+		return incomplete(normalized, maxSecretLength);
+	}
 	const availableCharacters = normalized.reduce(
 		(total, fragment) => total + fragment.text.length,
 		0,

--- a/packages/core/src/security/fragment-redaction.ts
+++ b/packages/core/src/security/fragment-redaction.ts
@@ -4,7 +4,7 @@
  * only taint metadata so stream offsets remain usable without exposing config.
  */
 
-const MIN_CONFIGURED_SECRET_LENGTH = 8;
+export const MIN_CONFIGURED_SECRET_LENGTH = 8;
 const MAX_FRAGMENT_COUNT = 256;
 const MAX_TOTAL_FRAGMENT_CHARACTERS = 256 * 1024;
 const MAX_CONFIGURED_SECRET_COUNT = 128;

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -14,7 +14,7 @@ const DEFAULT_REDACT_KEEP_END = 4;
 
 // Minimum length for a secret to be considered for redaction
 // Shorter values could cause false positives
-const MIN_SECRET_LENGTH = 8;
+export const MIN_SECRET_LENGTH = 8;
 
 /**
  * Default patterns for detecting sensitive data.

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -1258,7 +1258,7 @@ export interface IAgentRuntime extends RuntimeDatabaseAdapterSurface {
 	 */
 	locateConfiguredSecretFragmentTaint(
 		fragments: readonly import("../security/fragment-redaction").SecretFragment[],
-	): import("../security/fragment-redaction").SecretFragmentTaint;
+	): import("../security/fragment-redaction").SecretFragmentTaintProfile;
 
 	// ========================================================================
 	// Single-item convenience wrappers

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -1251,6 +1251,15 @@ export interface IAgentRuntime extends RuntimeDatabaseAdapterSurface {
 	 */
 	redactSecrets(text: string): string;
 
+	/**
+	 * Locate configured-secret material across ordered diagnostic fragments.
+	 * Every runtime must fail closed through this contract without returning
+	 * configured secret values.
+	 */
+	locateConfiguredSecretFragmentTaint(
+		fragments: readonly import("../security/fragment-redaction").SecretFragment[],
+	): import("../security/fragment-redaction").SecretFragmentTaint;
+
 	// ========================================================================
 	// Single-item convenience wrappers
 	//

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -11,8 +11,10 @@ import * as path from "node:path";
 import { promisify } from "node:util";
 import {
   type ActionResult,
+  AgentRuntime,
   CAPABILITY_ROUTER_SERVICE_TYPE,
   CapabilityError,
+  type Character,
   logger as coreLogger,
   type ElizaCapabilityRouter,
   type IAgentRuntime,
@@ -125,6 +127,75 @@ interface RuntimeOptions {
   configuredSecret?: string;
 }
 
+type RuntimeSecretFragment = Parameters<
+  IAgentRuntime["locateConfiguredSecretFragmentTaint"]
+>[0][number];
+type RuntimeSecretTaint = ReturnType<
+  IAgentRuntime["locateConfiguredSecretFragmentTaint"]
+>;
+
+function locateTestSecretTaint(
+  fragments: readonly RuntimeSecretFragment[],
+  secret: string | undefined,
+): RuntimeSecretTaint {
+  if (!secret || secret.length < 8) {
+    return { status: "complete", ranges: [], maxSecretLength: 0 };
+  }
+  const found: Array<{
+    source: string;
+    startOffset: number;
+    endOffset: number;
+  }> = [];
+  const visit = (
+    fragmentIndex: number,
+    secretOffset: number,
+    path: typeof found,
+  ): void => {
+    const fragment = fragments[fragmentIndex];
+    if (!fragment) return;
+    for (let end = secretOffset + 1; end <= secret.length; end += 1) {
+      const segment = secret.slice(secretOffset, end);
+      let occurrence = fragment.text.indexOf(segment);
+      while (occurrence >= 0) {
+        const nextPath = [
+          ...path,
+          {
+            source: fragment.source,
+            startOffset: fragment.startOffset + occurrence,
+            endOffset: fragment.startOffset + occurrence + segment.length,
+          },
+        ];
+        if (end === secret.length) found.push(...nextPath);
+        else visit(fragmentIndex + 1, end, nextPath);
+        occurrence = fragment.text.indexOf(segment, occurrence + 1);
+      }
+    }
+  };
+  for (let start = 0; start < fragments.length; start += 1) {
+    visit(start, 0, []);
+  }
+  const ranges = found
+    .sort(
+      (left, right) =>
+        left.source.localeCompare(right.source) ||
+        left.startOffset - right.startOffset ||
+        left.endOffset - right.endOffset,
+    )
+    .reduce<typeof found>((merged, range) => {
+      const previous = merged.at(-1);
+      if (
+        previous?.source === range.source &&
+        range.startOffset <= previous.endOffset
+      ) {
+        previous.endOffset = Math.max(previous.endOffset, range.endOffset);
+      } else {
+        merged.push({ ...range });
+      }
+      return merged;
+    }, []);
+  return { status: "complete", ranges, maxSecretLength: secret.length };
+}
+
 function requireActionResult(result: ActionResult | undefined): ActionResult {
   if (!result) throw new Error("Expected SHELL action result");
   return result;
@@ -162,6 +233,10 @@ async function makeRuntime(opts: RuntimeOptions = {}): Promise<{
       opts.configuredSecret
         ? text.replaceAll(opts.configuredSecret, "[REDACTED:TEST_SECRET]")
         : text,
+    ),
+    locateConfiguredSecretFragmentTaint: vi.fn(
+      (fragments: readonly RuntimeSecretFragment[]) =>
+        locateTestSecretTaint(fragments, opts.configuredSecret),
     ),
   } as IAgentRuntime;
 
@@ -2037,7 +2112,304 @@ describeIfPosix("shellAction", () => {
         >
       ).startOffset,
     ).toBe(3);
-    expect(partialPoll.text).toContain("[REDACTED:chunk-boundary]");
+    expect(partialPoll.text).toContain("[REDACTED:configured-secret-fragment]");
+  });
+
+  it("maps a configured secret across ordered stdout and stderr fragments without breaking offsets", async () => {
+    const secret = "marigold9";
+    const { runtime } = await makeRuntime({ configuredSecret: secret });
+    const secretOwner = new AgentRuntime({
+      character: {
+        name: "fragment-redaction-integration",
+        settings: { secrets: { TEST_SECRET: secret } },
+      } as Character,
+    });
+    vi.mocked(runtime.locateConfiguredSecretFragmentTaint).mockImplementation(
+      (fragments: readonly RuntimeSecretFragment[]) =>
+        secretOwner.locateConfiguredSecretFragmentTaint(fragments),
+    );
+    const actor = makeMessage();
+    const command = [
+      "printf '\\x6d\\x61\\x72\\x69X'",
+      "sleep 0.05",
+      "printf '\\x67\\x6f\\x6c\\x64\\x39' >&2",
+      "sleep 0.05",
+      "printf 'later-safe'",
+    ].join("; ");
+    const posts: Array<{ text: string }> = [];
+    const callback = async (content: unknown) => {
+      posts.push(content as { text: string });
+      return [];
+    };
+    const start = requireActionResult(
+      await shellAction.handler?.(
+        runtime,
+        actor,
+        undefined,
+        { action: "start_background", command },
+        callback,
+      ),
+    );
+    expect((start.data as Record<string, unknown>).command).toBe(command);
+    const handle = (start.data as Record<string, unknown>).handle as string;
+    const poll = await pollUntil(
+      runtime,
+      actor,
+      handle,
+      (data) => data.status === "exited",
+    );
+    const data = poll.data as Record<string, unknown>;
+    const stdout = data.stdout as Record<string, unknown>;
+    const stderr = data.stderr as Record<string, unknown>;
+
+    expect(JSON.stringify({ stdout, stderr })).not.toContain("mari");
+    expect(JSON.stringify({ stdout, stderr })).not.toContain("gold9");
+    expect(stdout.text).toContain("[REDACTED:configured-secret-fragment]");
+    expect(stdout.text).toContain("Xlater-safe");
+    expect(stderr.text).toContain("[REDACTED:configured-secret-fragment]");
+    expect(stdout.startOffset).toBe(0);
+    expect(stdout.endOffset).toBe("mariXlater-safe".length);
+    expect(stderr.startOffset).toBe(0);
+    expect(stderr.endOffset).toBe("gold9".length);
+    expect(
+      vi
+        .mocked(runtime.locateConfiguredSecretFragmentTaint)
+        .mock.calls.some(
+          ([fragments]) =>
+            fragments.map((fragment) => fragment.source).join(",") ===
+              "stdout,stderr,stdout" &&
+            fragments[0]?.startOffset === 0 &&
+            fragments[1]?.startOffset === 0 &&
+            fragments[2]?.startOffset === "mariX".length,
+        ),
+    ).toBe(true);
+
+    const repeated = requireActionResult(
+      await shellAction.handler?.(
+        runtime,
+        actor,
+        undefined,
+        {
+          action: "poll_background",
+          handle,
+          stdout_offset: 0,
+          stderr_offset: 0,
+        },
+        callback,
+      ),
+    );
+    expect(repeated.data).toMatchObject({ stdout, stderr });
+    const list = requireActionResult(
+      await shellAction.handler?.(
+        runtime,
+        actor,
+        undefined,
+        { action: "list_background" },
+        callback,
+      ),
+    );
+    expect(JSON.stringify({ repeated, list, posts })).not.toContain("mari");
+    expect(JSON.stringify({ repeated, list, posts })).not.toContain("gold9");
+
+    const afterTaint = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "poll_background",
+        handle,
+        stdout_offset: 4,
+        stderr_offset: 99,
+      }),
+    );
+    const afterData = afterTaint.data as Record<string, unknown>;
+    expect(afterData.stdout).toMatchObject({
+      text: "Xlater-safe",
+      startOffset: 4,
+      endOffset: "mariXlater-safe".length,
+    });
+    expect(afterData.stderr).toMatchObject({
+      text: "",
+      startOffset: "gold9".length,
+      endOffset: "gold9".length,
+    });
+    expect(JSON.stringify(afterTaint)).not.toContain(secret);
+  });
+
+  it("keeps a split configured secret tainted through tiny visible caps", async () => {
+    const secret = "marigold9";
+    const { runtime } = await makeRuntime({
+      configuredSecret: secret,
+      backgroundBufferChars: 5,
+    });
+    const actor = makeMessage();
+    const start = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "start_background",
+        command:
+          "printf '\\x6d\\x61\\x72\\x69X'; sleep 0.05; printf '\\x67\\x6f\\x6c\\x64\\x39' >&2; sleep 0.05; printf 'later-safe'",
+      }),
+    );
+    const handle = (start.data as Record<string, unknown>).handle as string;
+    const poll = await pollUntil(
+      runtime,
+      actor,
+      handle,
+      (data) => data.status === "exited",
+    );
+    const data = poll.data as Record<string, unknown>;
+
+    expect(
+      JSON.stringify({ stdout: data.stdout, stderr: data.stderr }),
+    ).not.toContain("mari");
+    expect(
+      JSON.stringify({ stdout: data.stdout, stderr: data.stderr }),
+    ).not.toContain("gold9");
+    expect(data.stdout).toMatchObject({
+      text: "-safe",
+      startOffset: "mariXlater-safe".length - 5,
+      endOffset: "mariXlater-safe".length,
+    });
+    expect((data.stderr as Record<string, unknown>).text).toContain(
+      "[REDACTED:configured-secret-fragment]",
+    );
+  });
+
+  it("preserves same-stream event boundaries around harmless bytes", async () => {
+    const secret = "marigold9";
+    const { runtime } = await makeRuntime({ configuredSecret: secret });
+    const actor = makeMessage();
+    const start = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "start_background",
+        command:
+          "printf '\\x6d\\x61\\x72\\x69X'; sleep 0.05; printf '\\x67\\x6f\\x6c\\x64\\x39'; sleep 0.05; printf 'later-safe'",
+      }),
+    );
+    const handle = (start.data as Record<string, unknown>).handle as string;
+    const poll = await pollUntil(
+      runtime,
+      actor,
+      handle,
+      (data) => data.status === "exited",
+    );
+    const stdout = (poll.data as Record<string, unknown>).stdout as Record<
+      string,
+      unknown
+    >;
+
+    expect(stdout.startOffset).toBe(0);
+    expect(stdout.endOffset).toBe("mariXgold9later-safe".length);
+    expect(stdout.text).toContain("X");
+    expect(stdout.text).toContain("later-safe");
+    expect(JSON.stringify(stdout)).not.toContain("mari");
+    expect(JSON.stringify(stdout)).not.toContain("gold9");
+    expect(
+      vi
+        .mocked(runtime.locateConfiguredSecretFragmentTaint)
+        .mock.calls.some(
+          ([fragments]) =>
+            fragments.map((fragment) => fragment.source).join(",") ===
+            "stdout,stdout,stdout",
+        ),
+    ).toBe(true);
+  });
+
+  it("taints both public stream presentation orders", async () => {
+    const secret = "marigold9";
+    const { runtime } = await makeRuntime({ configuredSecret: secret });
+    const actor = makeMessage();
+    const start = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "start_background",
+        command:
+          "printf '\\x67\\x6f\\x6c\\x64\\x39' >&2; sleep 0.05; printf '\\x6d\\x61\\x72\\x69X'",
+      }),
+    );
+    const handle = (start.data as Record<string, unknown>).handle as string;
+    const poll = await pollUntil(
+      runtime,
+      actor,
+      handle,
+      (data) => data.status === "exited",
+    );
+    const data = poll.data as Record<string, unknown>;
+    const exposed = JSON.stringify({
+      stdout: data.stdout,
+      stderr: data.stderr,
+    });
+
+    expect(exposed).not.toContain("mari");
+    expect(exposed).not.toContain("gold9");
+    expect((data.stdout as Record<string, unknown>).text).toContain(
+      "[REDACTED:configured-secret-fragment]",
+    );
+    expect((data.stderr as Record<string, unknown>).text).toContain(
+      "[REDACTED:configured-secret-fragment]",
+    );
+  });
+
+  it("fails closed when the runtime cannot complete fragment analysis", async () => {
+    const { runtime } = await makeRuntime();
+    vi.mocked(runtime.locateConfiguredSecretFragmentTaint).mockReturnValue({
+      status: "incomplete",
+      reason: "resource-limit",
+      ranges: [],
+      maxSecretLength: 128,
+    });
+    const actor = makeMessage();
+    const start = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "start_background",
+        command: "printf 'safe-output'",
+      }),
+    );
+    const handle = (start.data as Record<string, unknown>).handle as string;
+    const poll = await pollUntil(
+      runtime,
+      actor,
+      handle,
+      (data) => data.status === "exited",
+    );
+
+    expect(poll.text).toContain("[REDACTED:configured-secret-fragment]");
+    expect(poll.text).not.toContain("safe-output");
+  });
+
+  it("bounds an incomplete scan and releases later safe output", async () => {
+    const { runtime } = await makeRuntime();
+    vi.mocked(runtime.locateConfiguredSecretFragmentTaint).mockImplementation(
+      (fragments: readonly RuntimeSecretFragment[]) =>
+        fragments.some((fragment) => fragment.text.includes("unsafe"))
+          ? {
+              status: "incomplete",
+              reason: "resource-limit",
+              ranges: [],
+              maxSecretLength: 8,
+            }
+          : { status: "complete", ranges: [], maxSecretLength: 8 },
+    );
+    const actor = makeMessage();
+    const start = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "start_background",
+        command:
+          "printf 'unsafe'; sleep 0.05; printf '12345678'; sleep 0.05; printf 'later-safe'",
+      }),
+    );
+    const handle = (start.data as Record<string, unknown>).handle as string;
+    const poll = await pollUntil(
+      runtime,
+      actor,
+      handle,
+      (data) => data.status === "exited",
+    );
+    const stdout = (poll.data as Record<string, unknown>).stdout as Record<
+      string,
+      unknown
+    >;
+
+    expect(stdout.text).toContain("[REDACTED:configured-secret-fragment]");
+    expect(stdout.text).toContain("later-safe");
+    expect(stdout.text).not.toContain("unsafe");
+    expect(stdout.text).not.toContain("12345678");
   });
 
   it("keeps an eviction-split configured secret inside the private overlap", async () => {
@@ -2064,7 +2436,7 @@ describeIfPosix("shellAction", () => {
       unknown
     >;
 
-    expect(stdout.text).toContain("[REDACTED:chunk-boundary]");
+    expect(stdout.text).toContain("[REDACTED:configured-secret-fragment]");
     expect(stdout.startOffset).toBe(30);
     expect(JSON.stringify(poll)).not.toContain(secret);
     expect(JSON.stringify(poll)).not.toContain(secret.slice(4));
@@ -2079,6 +2451,10 @@ describeIfPosix("shellAction", () => {
     };
     vi.mocked(runtime.redactSecrets).mockImplementation((text: string) =>
       text.replaceAll(rotatedSecret, "[REDACTED:ROTATED_SECRET]"),
+    );
+    vi.mocked(runtime.locateConfiguredSecretFragmentTaint).mockImplementation(
+      (fragments: readonly RuntimeSecretFragment[]) =>
+        locateTestSecretTaint(fragments, rotatedSecret),
     );
     const actor = makeMessage();
     const start = requireActionResult(
@@ -2096,8 +2472,67 @@ describeIfPosix("shellAction", () => {
       );
     });
 
-    expect(poll.text).toContain("[REDACTED:chunk-boundary]");
+    expect(poll.text).toContain("[REDACTED:configured-secret-fragment]");
     expect(JSON.stringify(poll)).not.toContain(rotatedSecret.slice(-12));
+  });
+
+  it("rescans retained cross-stream output when a secret rotates before the first poll", async () => {
+    const rotatedSecret = "marigold9";
+    const { runtime, backgroundShell } = await makeRuntime();
+    const actor = makeMessage();
+    const start = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "start_background",
+        command:
+          "printf '\\x6d\\x61\\x72\\x69X'; sleep 0.05; printf '\\x67\\x6f\\x6c\\x64\\x39' >&2",
+      }),
+    );
+    const handle = (start.data as Record<string, unknown>).handle as string;
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      const session = backgroundShell
+        .list(String(actor.roomId))
+        .find((candidate) => candidate.handle === handle);
+      if (session?.status === "exited") break;
+      await delay(25);
+    }
+    expect(
+      backgroundShell
+        .list(String(actor.roomId))
+        .find((candidate) => candidate.handle === handle)?.status,
+    ).toBe("exited");
+
+    runtime.character.settings = {
+      secrets: { ROTATED_SECRET: rotatedSecret },
+    };
+    vi.mocked(runtime.redactSecrets).mockImplementation((text: string) =>
+      text.replaceAll(rotatedSecret, "[REDACTED:ROTATED_SECRET]"),
+    );
+    vi.mocked(runtime.locateConfiguredSecretFragmentTaint).mockImplementation(
+      (fragments: readonly RuntimeSecretFragment[]) =>
+        locateTestSecretTaint(fragments, rotatedSecret),
+    );
+
+    const poll = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "poll_background",
+        handle,
+        stdout_offset: 0,
+        stderr_offset: 0,
+      }),
+    );
+    const data = poll.data as Record<string, unknown>;
+    expect(
+      JSON.stringify({ stdout: data.stdout, stderr: data.stderr }),
+    ).not.toContain("mari");
+    expect(
+      JSON.stringify({ stdout: data.stdout, stderr: data.stderr }),
+    ).not.toContain("gold9");
+    expect((data.stdout as Record<string, unknown>).text).toContain(
+      "[REDACTED:configured-secret-fragment]",
+    );
+    expect((data.stderr as Record<string, unknown>).text).toContain(
+      "[REDACTED:configured-secret-fragment]",
+    );
   });
 });
 

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -2558,6 +2558,78 @@ describeIfPosix("shellAction", () => {
     );
     expect(freshPoll.text).toContain("later-safe");
   });
+
+  it("projects the incomplete marker when a rotated secret equals it", async () => {
+    const marker = "[REDACTED:fragment-scan-incomplete]";
+    const { runtime, backgroundShell } = await makeRuntime();
+    const actor = makeMessage();
+    const start = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "start_background",
+        command: "printf 'retained-output'",
+      }),
+    );
+    const handle = (start.data as Record<string, unknown>).handle as string;
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      const session = backgroundShell
+        .list(String(actor.roomId))
+        .find((candidate) => candidate.handle === handle);
+      if (session?.status === "exited") break;
+      await delay(25);
+    }
+
+    runtime.character.settings = {
+      secrets: { ROTATED_SECRET: marker },
+    };
+    vi.mocked(runtime.redactSecrets).mockImplementation((text: string) =>
+      text.replaceAll(marker, "[REDACTED:ROTATED_SECRET]"),
+    );
+    const poll = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "poll_background",
+        handle,
+        stdout_offset: 0,
+      }),
+    );
+
+    expect(JSON.stringify(poll)).not.toContain(marker);
+    expect(poll.text).toContain("[REDACTED:ROTATED_SECRET]");
+  });
+
+  it("projects the incomplete marker for an oversized secret profile", async () => {
+    const marker = "[REDACTED:fragment-scan-incomplete]";
+    const { runtime } = await makeRuntime();
+    runtime.character.settings = {
+      secrets: Object.fromEntries(
+        Array.from({ length: 129 }, (_, index) => [
+          `SECRET_${index}`,
+          index === 0
+            ? marker
+            : `secret-value-${index.toString().padStart(3, "0")}`,
+        ]),
+      ),
+    };
+    vi.mocked(runtime.redactSecrets).mockImplementation((text: string) =>
+      text.replaceAll(marker, "[REDACTED:PROFILE_SECRET]"),
+    );
+    const actor = makeMessage();
+    const start = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "start_background",
+        command: "printf 'safe-output'",
+      }),
+    );
+    const handle = (start.data as Record<string, unknown>).handle as string;
+    const poll = await pollUntil(
+      runtime,
+      actor,
+      handle,
+      (data) => data.status === "exited",
+    );
+
+    expect(JSON.stringify(poll)).not.toContain(marker);
+    expect(poll.text).toContain("[REDACTED:PROFILE_SECRET]");
+  });
 });
 
 describe("shell timeout operator setting", () => {

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -2052,7 +2052,36 @@ describeIfPosix("shellAction", () => {
         >
       ).startOffset,
     ).toBe(3);
-    expect(partialPoll.text).toContain("[REDACTED:configured-secret-fragment]");
+  });
+
+  it("omits tainted output when the former fragment marker is itself a secret", async () => {
+    const secret = "[REDACTED:configured-secret-fragment]";
+    const { runtime } = await makeRuntime();
+    runtime.character.settings = {
+      secrets: { "configured-secret-fragment": secret },
+    };
+    const actor = makeMessage();
+    const start = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "start_background",
+        command:
+          "printf '[REDACTED:'; sleep 0.05; printf 'configured-secret-fragment]'",
+      }),
+    );
+    const handle = (start.data as Record<string, unknown>).handle as string;
+    const poll = await pollUntil(
+      runtime,
+      actor,
+      handle,
+      (data) => data.status === "exited",
+    );
+    const stdout = (poll.data as Record<string, unknown>).stdout as Record<
+      string,
+      unknown
+    >;
+
+    expect(stdout.text).toBe("");
+    expect(JSON.stringify(poll)).not.toContain(secret);
   });
 
   it("maps a configured secret across ordered stdout and stderr fragments without breaking offsets", async () => {
@@ -2094,9 +2123,8 @@ describeIfPosix("shellAction", () => {
 
     expect(JSON.stringify({ stdout, stderr })).not.toContain("mari");
     expect(JSON.stringify({ stdout, stderr })).not.toContain("gold9");
-    expect(stdout.text).toContain("[REDACTED:configured-secret-fragment]");
-    expect(stdout.text).toContain("Xlater-safe");
-    expect(stderr.text).toContain("[REDACTED:configured-secret-fragment]");
+    expect(stdout.text).toBe("Xlater-safe");
+    expect(stderr.text).toBe("");
     expect(stdout.startOffset).toBe(0);
     expect(stdout.endOffset).toBe("mariXlater-safe".length);
     expect(stderr.startOffset).toBe(0);
@@ -2197,9 +2225,7 @@ describeIfPosix("shellAction", () => {
       startOffset: "mariXlater-safe".length - 5,
       endOffset: "mariXlater-safe".length,
     });
-    expect((data.stderr as Record<string, unknown>).text).toContain(
-      "[REDACTED:configured-secret-fragment]",
-    );
+    expect((data.stderr as Record<string, unknown>).text).toBe("");
   });
 
   it("preserves same-stream event boundaries around harmless bytes", async () => {
@@ -2268,12 +2294,8 @@ describeIfPosix("shellAction", () => {
 
     expect(exposed).not.toContain("mari");
     expect(exposed).not.toContain("gold9");
-    expect((data.stdout as Record<string, unknown>).text).toContain(
-      "[REDACTED:configured-secret-fragment]",
-    );
-    expect((data.stderr as Record<string, unknown>).text).toContain(
-      "[REDACTED:configured-secret-fragment]",
-    );
+    expect((data.stdout as Record<string, unknown>).text).toBe("X");
+    expect((data.stderr as Record<string, unknown>).text).toBe("");
   });
 
   it("fails closed when the runtime cannot complete fragment analysis", async () => {
@@ -2300,7 +2322,10 @@ describeIfPosix("shellAction", () => {
       (data) => data.status === "exited",
     );
 
-    expect(poll.text).toContain("[REDACTED:configured-secret-fragment]");
+    expect(
+      ((poll.data as Record<string, unknown>).stdout as Record<string, unknown>)
+        .text,
+    ).toBe("");
     expect(poll.text).not.toContain("safe-output");
   });
 
@@ -2343,8 +2368,7 @@ describeIfPosix("shellAction", () => {
       unknown
     >;
 
-    expect(stdout.text).toContain("[REDACTED:configured-secret-fragment]");
-    expect(stdout.text).toContain("later-safe");
+    expect(stdout.text).toBe("later-safe");
     expect(stdout.text).not.toContain("unsafe");
     expect(stdout.text).not.toContain("12345678");
   });
@@ -2420,7 +2444,7 @@ describeIfPosix("shellAction", () => {
 
     expect(injectedIncomplete).toBe(true);
     expect(firstStdout).toBe("mari");
-    expect(laterStderr).toContain("[REDACTED:configured-secret-fragment]");
+    expect(laterStderr).toBe("");
     expect(laterStderr).not.toContain("gold9");
     expect(firstStdout + laterStderr).not.toContain("marigold9");
     expect((laterData.stdout as Record<string, unknown>).text).not.toContain(
@@ -2452,7 +2476,7 @@ describeIfPosix("shellAction", () => {
       unknown
     >;
 
-    expect(stdout.text).toContain("[REDACTED:configured-secret-fragment]");
+    expect(stdout.text).toBe("z".repeat(16));
     expect(stdout.startOffset).toBe(30);
     expect(JSON.stringify(poll)).not.toContain(secret);
     expect(JSON.stringify(poll)).not.toContain(secret.slice(4));
@@ -2484,7 +2508,10 @@ describeIfPosix("shellAction", () => {
       );
     });
 
-    expect(poll.text).toContain("[REDACTED:configured-secret-fragment]");
+    expect(
+      ((poll.data as Record<string, unknown>).stdout as Record<string, unknown>)
+        .text,
+    ).toBe("z".repeat(8));
     expect(JSON.stringify(poll)).not.toContain(rotatedSecret.slice(-12));
   });
 
@@ -2535,12 +2562,8 @@ describeIfPosix("shellAction", () => {
     expect(
       JSON.stringify({ stdout: data.stdout, stderr: data.stderr }),
     ).not.toContain("gold9");
-    expect((data.stdout as Record<string, unknown>).text).toContain(
-      "[REDACTED:fragment-scan-incomplete]",
-    );
-    expect((data.stderr as Record<string, unknown>).text).toContain(
-      "[REDACTED:fragment-scan-incomplete]",
-    );
+    expect((data.stdout as Record<string, unknown>).text).toBe("");
+    expect((data.stderr as Record<string, unknown>).text).toBe("");
 
     const freshStart = requireActionResult(
       await shellAction.handler?.(runtime, actor, undefined, {
@@ -2559,7 +2582,7 @@ describeIfPosix("shellAction", () => {
     expect(freshPoll.text).toContain("later-safe");
   });
 
-  it("projects the incomplete marker when a rotated secret equals it", async () => {
+  it("omits invalidated output when a rotated secret equals the former marker", async () => {
     const marker = "[REDACTED:fragment-scan-incomplete]";
     const { runtime, backgroundShell } = await makeRuntime();
     const actor = makeMessage();
@@ -2579,11 +2602,8 @@ describeIfPosix("shellAction", () => {
     }
 
     runtime.character.settings = {
-      secrets: { ROTATED_SECRET: marker },
+      secrets: { "fragment-scan-incomplete": marker },
     };
-    vi.mocked(runtime.redactSecrets).mockImplementation((text: string) =>
-      text.replaceAll(marker, "[REDACTED:ROTATED_SECRET]"),
-    );
     const poll = requireActionResult(
       await shellAction.handler?.(runtime, actor, undefined, {
         action: "poll_background",
@@ -2593,25 +2613,25 @@ describeIfPosix("shellAction", () => {
     );
 
     expect(JSON.stringify(poll)).not.toContain(marker);
-    expect(poll.text).toContain("[REDACTED:ROTATED_SECRET]");
+    expect(
+      ((poll.data as Record<string, unknown>).stdout as Record<string, unknown>)
+        .text,
+    ).toBe("");
   });
 
-  it("projects the incomplete marker for an oversized secret profile", async () => {
+  it("omits output for an oversized profile containing the former marker", async () => {
     const marker = "[REDACTED:fragment-scan-incomplete]";
     const { runtime } = await makeRuntime();
     runtime.character.settings = {
       secrets: Object.fromEntries(
         Array.from({ length: 129 }, (_, index) => [
-          `SECRET_${index}`,
+          index === 0 ? "fragment-scan-incomplete" : `SECRET_${index}`,
           index === 0
             ? marker
             : `secret-value-${index.toString().padStart(3, "0")}`,
         ]),
       ),
     };
-    vi.mocked(runtime.redactSecrets).mockImplementation((text: string) =>
-      text.replaceAll(marker, "[REDACTED:PROFILE_SECRET]"),
-    );
     const actor = makeMessage();
     const start = requireActionResult(
       await shellAction.handler?.(runtime, actor, undefined, {
@@ -2628,7 +2648,10 @@ describeIfPosix("shellAction", () => {
     );
 
     expect(JSON.stringify(poll)).not.toContain(marker);
-    expect(poll.text).toContain("[REDACTED:PROFILE_SECRET]");
+    expect(
+      ((poll.data as Record<string, unknown>).stdout as Record<string, unknown>)
+        .text,
+    ).toBe("");
   });
 });
 

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -137,9 +137,15 @@ type RuntimeSecretTaint = ReturnType<
 function locateTestSecretTaint(
   fragments: readonly RuntimeSecretFragment[],
   secret: string | undefined,
+  profileRevision = 1,
 ): RuntimeSecretTaint {
   if (!secret || secret.length < 8) {
-    return { status: "complete", ranges: [], maxSecretLength: 0 };
+    return {
+      status: "complete",
+      ranges: [],
+      maxSecretLength: 0,
+      profileRevision,
+    };
   }
   const found: Array<{
     source: string;
@@ -193,7 +199,12 @@ function locateTestSecretTaint(
       }
       return merged;
     }, []);
-  return { status: "complete", ranges, maxSecretLength: secret.length };
+  return {
+    status: "complete",
+    ranges,
+    maxSecretLength: secret.length,
+    profileRevision,
+  };
 }
 
 function requireActionResult(result: ActionResult | undefined): ActionResult {
@@ -2353,6 +2364,7 @@ describeIfPosix("shellAction", () => {
       reason: "resource-limit",
       ranges: [],
       maxSecretLength: 128,
+      profileRevision: 1,
     });
     const actor = makeMessage();
     const start = requireActionResult(
@@ -2383,8 +2395,14 @@ describeIfPosix("shellAction", () => {
               reason: "resource-limit",
               ranges: [],
               maxSecretLength: 8,
+              profileRevision: 1,
             }
-          : { status: "complete", ranges: [], maxSecretLength: 8 },
+          : {
+              status: "complete",
+              ranges: [],
+              maxSecretLength: 8,
+              profileRevision: 1,
+            },
     );
     const actor = makeMessage();
     const start = requireActionResult(
@@ -2410,6 +2428,85 @@ describeIfPosix("shellAction", () => {
     expect(stdout.text).toContain("later-safe");
     expect(stdout.text).not.toContain("unsafe");
     expect(stdout.text).not.toContain("12345678");
+  });
+
+  it("does not let one stream consume another stream's recovery window", async () => {
+    const { runtime, backgroundShell } = await makeRuntime();
+    let injectedIncomplete = false;
+    vi.mocked(runtime.locateConfiguredSecretFragmentTaint).mockImplementation(
+      (fragments: readonly RuntimeSecretFragment[]) => {
+        if (
+          !injectedIncomplete &&
+          fragments.some((fragment) => fragment.text.includes("TRIGGER"))
+        ) {
+          injectedIncomplete = true;
+          return {
+            status: "incomplete",
+            reason: "resource-limit",
+            ranges: [],
+            maxSecretLength: 9,
+            profileRevision: 1,
+          };
+        }
+        return {
+          status: "complete",
+          ranges: [],
+          maxSecretLength: 9,
+          profileRevision: 1,
+        };
+      },
+    );
+    const actor = makeMessage();
+    const start = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "start_background",
+        command: [
+          "printf '\\x6d\\x61\\x72\\x69'",
+          "sleep 0.15",
+          "printf 'TRIGGER' >&2",
+          "sleep 0.15",
+          "printf 'yyyyyyyyy'",
+          "sleep 0.15",
+          "printf '\\x67\\x6f\\x6c\\x64\\x39' >&2",
+        ].join("; "),
+      }),
+    );
+    const handle = (start.data as Record<string, unknown>).handle as string;
+    const first = await pollUntil(runtime, actor, handle, (data) => {
+      const stdout = data.stdout as Record<string, unknown> | undefined;
+      const stderr = data.stderr as Record<string, unknown> | undefined;
+      return stdout?.text === "mari" && stderr?.text === "";
+    });
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      const status = backgroundShell
+        .list(String(actor.roomId))
+        .find((candidate) => candidate.handle === handle)?.status;
+      if (status === "exited") break;
+      await delay(25);
+    }
+    const later = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "poll_background",
+        handle,
+        stdout_offset: 4,
+        stderr_offset: 0,
+      }),
+    );
+    const firstStdout = (
+      (first.data as Record<string, unknown>).stdout as Record<string, unknown>
+    ).text as string;
+    const laterData = later.data as Record<string, unknown>;
+    const laterStderr = (laterData.stderr as Record<string, unknown>)
+      .text as string;
+
+    expect(injectedIncomplete).toBe(true);
+    expect(firstStdout).toBe("mari");
+    expect(laterStderr).toContain("[REDACTED:configured-secret-fragment]");
+    expect(laterStderr).not.toContain("gold9");
+    expect(firstStdout + laterStderr).not.toContain("marigold9");
+    expect((laterData.stdout as Record<string, unknown>).text).not.toContain(
+      "yyyyyyyyy",
+    );
   });
 
   it("keeps an eviction-split configured secret inside the private overlap", async () => {
@@ -2454,7 +2551,7 @@ describeIfPosix("shellAction", () => {
     );
     vi.mocked(runtime.locateConfiguredSecretFragmentTaint).mockImplementation(
       (fragments: readonly RuntimeSecretFragment[]) =>
-        locateTestSecretTaint(fragments, rotatedSecret),
+        locateTestSecretTaint(fragments, rotatedSecret, 2),
     );
     const actor = makeMessage();
     const start = requireActionResult(
@@ -2476,7 +2573,7 @@ describeIfPosix("shellAction", () => {
     expect(JSON.stringify(poll)).not.toContain(rotatedSecret.slice(-12));
   });
 
-  it("rescans retained cross-stream output when a secret rotates before the first poll", async () => {
+  it("invalidates retained output on secret rotation and recovers in a fresh session", async () => {
     const rotatedSecret = "marigold9";
     const { runtime, backgroundShell } = await makeRuntime();
     const actor = makeMessage();
@@ -2509,7 +2606,7 @@ describeIfPosix("shellAction", () => {
     );
     vi.mocked(runtime.locateConfiguredSecretFragmentTaint).mockImplementation(
       (fragments: readonly RuntimeSecretFragment[]) =>
-        locateTestSecretTaint(fragments, rotatedSecret),
+        locateTestSecretTaint(fragments, rotatedSecret, 2),
     );
 
     const poll = requireActionResult(
@@ -2528,11 +2625,27 @@ describeIfPosix("shellAction", () => {
       JSON.stringify({ stdout: data.stdout, stderr: data.stderr }),
     ).not.toContain("gold9");
     expect((data.stdout as Record<string, unknown>).text).toContain(
-      "[REDACTED:configured-secret-fragment]",
+      "[REDACTED:fragment-scan-incomplete]",
     );
     expect((data.stderr as Record<string, unknown>).text).toContain(
-      "[REDACTED:configured-secret-fragment]",
+      "[REDACTED:fragment-scan-incomplete]",
     );
+
+    const freshStart = requireActionResult(
+      await shellAction.handler?.(runtime, actor, undefined, {
+        action: "start_background",
+        command: "printf 'later-safe'",
+      }),
+    );
+    const freshHandle = (freshStart.data as Record<string, unknown>)
+      .handle as string;
+    const freshPoll = await pollUntil(
+      runtime,
+      actor,
+      freshHandle,
+      (freshData) => freshData.status === "exited",
+    );
+    expect(freshPoll.text).toContain("later-safe");
   });
 });
 

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -130,82 +130,6 @@ interface RuntimeOptions {
 type RuntimeSecretFragment = Parameters<
   IAgentRuntime["locateConfiguredSecretFragmentTaint"]
 >[0][number];
-type RuntimeSecretTaint = ReturnType<
-  IAgentRuntime["locateConfiguredSecretFragmentTaint"]
->;
-
-function locateTestSecretTaint(
-  fragments: readonly RuntimeSecretFragment[],
-  secret: string | undefined,
-  profileRevision = 1,
-): RuntimeSecretTaint {
-  if (!secret || secret.length < 8) {
-    return {
-      status: "complete",
-      ranges: [],
-      maxSecretLength: 0,
-      profileRevision,
-    };
-  }
-  const found: Array<{
-    source: string;
-    startOffset: number;
-    endOffset: number;
-  }> = [];
-  const visit = (
-    fragmentIndex: number,
-    secretOffset: number,
-    path: typeof found,
-  ): void => {
-    const fragment = fragments[fragmentIndex];
-    if (!fragment) return;
-    for (let end = secretOffset + 1; end <= secret.length; end += 1) {
-      const segment = secret.slice(secretOffset, end);
-      let occurrence = fragment.text.indexOf(segment);
-      while (occurrence >= 0) {
-        const nextPath = [
-          ...path,
-          {
-            source: fragment.source,
-            startOffset: fragment.startOffset + occurrence,
-            endOffset: fragment.startOffset + occurrence + segment.length,
-          },
-        ];
-        if (end === secret.length) found.push(...nextPath);
-        else visit(fragmentIndex + 1, end, nextPath);
-        occurrence = fragment.text.indexOf(segment, occurrence + 1);
-      }
-    }
-  };
-  for (let start = 0; start < fragments.length; start += 1) {
-    visit(start, 0, []);
-  }
-  const ranges = found
-    .sort(
-      (left, right) =>
-        left.source.localeCompare(right.source) ||
-        left.startOffset - right.startOffset ||
-        left.endOffset - right.endOffset,
-    )
-    .reduce<typeof found>((merged, range) => {
-      const previous = merged.at(-1);
-      if (
-        previous?.source === range.source &&
-        range.startOffset <= previous.endOffset
-      ) {
-        previous.endOffset = Math.max(previous.endOffset, range.endOffset);
-      } else {
-        merged.push({ ...range });
-      }
-      return merged;
-    }, []);
-  return {
-    status: "complete",
-    ranges,
-    maxSecretLength: secret.length,
-    profileRevision,
-  };
-}
 
 function requireActionResult(result: ActionResult | undefined): ActionResult {
   if (!result) throw new Error("Expected SHELL action result");
@@ -233,11 +157,16 @@ async function makeRuntime(opts: RuntimeOptions = {}): Promise<{
   }
 
   const services = new Map<string, unknown>();
+  const character = {
+    name: "coding-tools-test",
+    ...(opts.configuredSecret
+      ? { settings: { secrets: { TEST_SECRET: opts.configuredSecret } } }
+      : {}),
+  } as Character;
+  const secretOwner = new AgentRuntime({ character });
   const runtime = {
     agentId: "11111111-1111-1111-1111-111111111111" as UUID,
-    character: opts.configuredSecret
-      ? { settings: { secrets: { TEST_SECRET: opts.configuredSecret } } }
-      : {},
+    character,
     getSetting: vi.fn((key: string) => settings[key]),
     getService: vi.fn(<T>(type: string) => services.get(type) as T | null),
     redactSecrets: vi.fn((text: string) =>
@@ -247,7 +176,7 @@ async function makeRuntime(opts: RuntimeOptions = {}): Promise<{
     ),
     locateConfiguredSecretFragmentTaint: vi.fn(
       (fragments: readonly RuntimeSecretFragment[]) =>
-        locateTestSecretTaint(fragments, opts.configuredSecret),
+        secretOwner.locateConfiguredSecretFragmentTaint(fragments),
     ),
   } as IAgentRuntime;
 
@@ -2129,16 +2058,6 @@ describeIfPosix("shellAction", () => {
   it("maps a configured secret across ordered stdout and stderr fragments without breaking offsets", async () => {
     const secret = "marigold9";
     const { runtime } = await makeRuntime({ configuredSecret: secret });
-    const secretOwner = new AgentRuntime({
-      character: {
-        name: "fragment-redaction-integration",
-        settings: { secrets: { TEST_SECRET: secret } },
-      } as Character,
-    });
-    vi.mocked(runtime.locateConfiguredSecretFragmentTaint).mockImplementation(
-      (fragments: readonly RuntimeSecretFragment[]) =>
-        secretOwner.locateConfiguredSecretFragmentTaint(fragments),
-    );
     const actor = makeMessage();
     const command = [
       "printf '\\x6d\\x61\\x72\\x69X'",
@@ -2549,10 +2468,6 @@ describeIfPosix("shellAction", () => {
     vi.mocked(runtime.redactSecrets).mockImplementation((text: string) =>
       text.replaceAll(rotatedSecret, "[REDACTED:ROTATED_SECRET]"),
     );
-    vi.mocked(runtime.locateConfiguredSecretFragmentTaint).mockImplementation(
-      (fragments: readonly RuntimeSecretFragment[]) =>
-        locateTestSecretTaint(fragments, rotatedSecret, 2),
-    );
     const actor = makeMessage();
     const start = requireActionResult(
       await shellAction.handler?.(runtime, actor, undefined, {
@@ -2603,10 +2518,6 @@ describeIfPosix("shellAction", () => {
     };
     vi.mocked(runtime.redactSecrets).mockImplementation((text: string) =>
       text.replaceAll(rotatedSecret, "[REDACTED:ROTATED_SECRET]"),
-    );
-    vi.mocked(runtime.locateConfiguredSecretFragmentTaint).mockImplementation(
-      (fragments: readonly RuntimeSecretFragment[]) =>
-        locateTestSecretTaint(fragments, rotatedSecret, 2),
     );
 
     const poll = requireActionResult(

--- a/plugins/plugin-coding-tools/src/services/background-shell-service.ts
+++ b/plugins/plugin-coding-tools/src/services/background-shell-service.ts
@@ -2,8 +2,9 @@
  * Per-conversation background shell sessions for long-running coding commands.
  *
  * The service owns child process groups, stable handles, stdin writes, and
- * bounded stdout/stderr buffers. Polling uses absolute character offsets per stream:
- * when a caller asks for an offset older than the retained ring window, the
+ * bounded stdout/stderr buffers. Polling uses absolute character offsets per
+ * stream and projects configured-secret taint across the ordered stream graph.
+ * When a caller asks for an offset older than the retained ring window, the
  * returned chunk starts at the retained floor and reports `truncatedBefore` so
  * the caller can distinguish lost output from an empty incremental read.
  */
@@ -18,10 +19,7 @@ import {
   signalHostProcessGroup,
   startBackgroundShellOnHost,
 } from "../lib/run-shell.js";
-import {
-  redactShellText,
-  resolveShellRedactionOverlapChars,
-} from "../shell/redaction.js";
+import { redactShellText } from "../shell/redaction.js";
 import { BACKGROUND_SHELL_SERVICE, CODING_TOOLS_LOG_PREFIX } from "../types.js";
 
 const DEFAULT_BUFFER_CHARS = 64_000;
@@ -29,6 +27,14 @@ const DEFAULT_KILL_GRACE_MS = 1_500;
 const MAX_WRITE_CHARS = 1_000_000;
 const MAX_SESSIONS_PER_CONVERSATION = 16;
 const MAX_SESSIONS_GLOBAL = 128;
+
+type SecretFragment = Parameters<
+  IAgentRuntime["locateConfiguredSecretFragmentTaint"]
+>[0][number];
+type SecretTaintRange = Extract<
+  ReturnType<IAgentRuntime["locateConfiguredSecretFragmentTaint"]>,
+  { status: "complete" }
+>["ranges"][number];
 
 export interface BackgroundShellChunk {
   text: string;
@@ -82,8 +88,16 @@ interface BackgroundShellSession {
   sandbox: ShellSandboxBackend;
   stdout: StreamRing;
   stderr: StreamRing;
+  redaction: FragmentRedactionState;
   stdinError?: Error;
   killTimer?: NodeJS.Timeout;
+}
+
+interface FragmentRedactionState {
+  fragments: SecretFragment[];
+  ranges: SecretTaintRange[];
+  incomplete: boolean;
+  quarantineCharacters: number;
 }
 
 export class BackgroundShellService extends Service {
@@ -117,13 +131,6 @@ export class BackgroundShellService extends Service {
     this.sessions.clear();
   }
 
-  private getRedactionOverlapChars(): number {
-    // Character secrets can rotate while the service is running. Recompute at
-    // each stream boundary so a newly introduced longer value cannot be split
-    // by an overlap window sized from stale startup configuration.
-    return resolveShellRedactionOverlapChars(this.runtime, this.bufferChars);
-  }
-
   startSession(args: {
     conversationId: string;
     command: string;
@@ -150,34 +157,38 @@ export class BackgroundShellService extends Service {
       sandbox: started.sandbox,
       stdout: emptyRing(),
       stderr: emptyRing(),
+      redaction: emptyFragmentRedactionState(),
     };
     if (!started.process.stdout || !started.process.stderr) {
       signalHostProcessGroup(started.process, "SIGKILL");
       throw new Error("background shell process did not expose output streams");
     }
     started.process.stdout.on("data", (chunk: Buffer) => {
-      appendRing(
-        session.stdout,
+      appendSessionOutput(
+        this.runtime,
+        session,
+        "stdout",
         chunk.toString("utf8"),
         this.bufferChars,
-        this.getRedactionOverlapChars(),
       );
     });
     started.process.stderr.on("data", (chunk: Buffer) => {
-      appendRing(
-        session.stderr,
+      appendSessionOutput(
+        this.runtime,
+        session,
+        "stderr",
         chunk.toString("utf8"),
         this.bufferChars,
-        this.getRedactionOverlapChars(),
       );
     });
     started.process.stdin?.on?.("error", (error: Error) => {
       session.stdinError = error;
-      appendRing(
-        session.stderr,
+      appendSessionOutput(
+        this.runtime,
+        session,
+        "stderr",
         `[stdin unavailable: ${error.message}]`,
         this.bufferChars,
-        this.getRedactionOverlapChars(),
       );
     });
     started.process.on("close", (code, signal) => {
@@ -194,11 +205,12 @@ export class BackgroundShellService extends Service {
       session.exitCode = -1;
       session.signal = null;
       session.endedAt = Date.now();
-      appendRing(
-        session.stderr,
+      appendSessionOutput(
+        this.runtime,
+        session,
+        "stderr",
         error.message,
         this.bufferChars,
-        this.getRedactionOverlapChars(),
       );
     });
     this.sessions.set(handle, session);
@@ -212,10 +224,23 @@ export class BackgroundShellService extends Service {
     stderrOffset?: number;
   }): BackgroundShellPollResult {
     const session = this.requireSession(args.conversationId, args.handle);
+    refreshSessionRedaction(this.runtime, session);
     return {
       ...snapshot(this.runtime, session),
-      stdout: readRing(this.runtime, session.stdout, args.stdoutOffset),
-      stderr: readRing(this.runtime, session.stderr, args.stderrOffset),
+      stdout: readRing(
+        this.runtime,
+        session,
+        "stdout",
+        session.stdout,
+        args.stdoutOffset,
+      ),
+      stderr: readRing(
+        this.runtime,
+        session,
+        "stderr",
+        session.stderr,
+        args.stderrOffset,
+      ),
     };
   }
 
@@ -355,6 +380,159 @@ function emptyRing(): StreamRing {
   return { text: "", startOffset: 0, endOffset: 0, truncatedBefore: 0 };
 }
 
+function emptyFragmentRedactionState(): FragmentRedactionState {
+  return {
+    fragments: [],
+    ranges: [],
+    incomplete: false,
+    quarantineCharacters: 0,
+  };
+}
+
+function appendSessionOutput(
+  runtime: IAgentRuntime,
+  session: BackgroundShellSession,
+  source: "stdout" | "stderr",
+  text: string,
+  cap: number,
+): void {
+  if (!text) return;
+  const ring = session[source];
+  const startOffset = ring.endOffset;
+  const profile = runtime.locateConfiguredSecretFragmentTaint([
+    { source, startOffset, text: "x" },
+  ]);
+  const maxSecretLength = profile.maxSecretLength;
+  appendRing(ring, text, cap, Math.max(cap, maxSecretLength));
+  const quarantinedCharacters = Math.min(
+    session.redaction.quarantineCharacters,
+    text.length,
+  );
+  if (quarantinedCharacters > 0) {
+    session.redaction.ranges = mergeTaintRanges([
+      ...session.redaction.ranges,
+      {
+        source,
+        startOffset,
+        endOffset: startOffset + quarantinedCharacters,
+      },
+    ]);
+    session.redaction.quarantineCharacters -= quarantinedCharacters;
+  }
+  const detectionText = text.slice(quarantinedCharacters);
+  if (detectionText) {
+    session.redaction.fragments.push({
+      source,
+      startOffset: startOffset + quarantinedCharacters,
+      text: detectionText,
+    });
+  }
+  refreshSessionRedaction(runtime, session);
+  pruneDetectionFragments(session);
+}
+
+function refreshSessionRedaction(
+  runtime: IAgentRuntime,
+  session: BackgroundShellSession,
+): void {
+  const analyses = observableFragmentOrders(session.redaction.fragments).map(
+    (fragments) => runtime.locateConfiguredSecretFragmentTaint(fragments),
+  );
+  const incomplete = analyses.find(
+    (analysis) => analysis.status === "incomplete",
+  );
+  if (incomplete) {
+    session.redaction.incomplete = incomplete.maxSecretLength === 0;
+    if (incomplete.maxSecretLength > 0) {
+      session.redaction.ranges = mergeTaintRanges([
+        ...session.redaction.ranges,
+        ...retainedRingRanges(session),
+      ]);
+      session.redaction.fragments = [];
+      session.redaction.quarantineCharacters = Math.max(
+        session.redaction.quarantineCharacters,
+        incomplete.maxSecretLength,
+      );
+    }
+    return;
+  }
+  session.redaction.incomplete = false;
+  session.redaction.ranges = mergeTaintRanges([
+    ...session.redaction.ranges,
+    ...analyses.flatMap((analysis) => analysis.ranges),
+  ]);
+}
+
+function observableFragmentOrders(
+  fragments: readonly SecretFragment[],
+): SecretFragment[][] {
+  const stdout = fragments.filter((fragment) => fragment.source === "stdout");
+  const stderr = fragments.filter((fragment) => fragment.source === "stderr");
+  return [[...fragments], [...stdout, ...stderr], [...stderr, ...stdout]];
+}
+
+function retainedRingRanges(
+  session: BackgroundShellSession,
+): SecretTaintRange[] {
+  return (["stdout", "stderr"] as const).flatMap((source) => {
+    const ring = session[source];
+    return ring.endOffset > ring.startOffset
+      ? [{ source, startOffset: ring.startOffset, endOffset: ring.endOffset }]
+      : [];
+  });
+}
+
+function pruneDetectionFragments(session: BackgroundShellSession): void {
+  const floors = {
+    stdout: session.stdout.startOffset,
+    stderr: session.stderr.startOffset,
+  };
+  session.redaction.fragments = session.redaction.fragments.flatMap(
+    (fragment) => {
+      const floor = floors[fragment.source as keyof typeof floors];
+      if (floor === undefined) return [];
+      const endOffset = fragment.startOffset + fragment.text.length;
+      if (endOffset <= floor) return [];
+      if (fragment.startOffset >= floor) return [fragment];
+      return [
+        {
+          ...fragment,
+          startOffset: floor,
+          text: fragment.text.slice(floor - fragment.startOffset),
+        },
+      ];
+    },
+  );
+  session.redaction.ranges = session.redaction.ranges.filter((range) => {
+    const floor = floors[range.source as keyof typeof floors];
+    return floor !== undefined && range.endOffset > floor;
+  });
+}
+
+function mergeTaintRanges(
+  ranges: readonly SecretTaintRange[],
+): SecretTaintRange[] {
+  const sorted = [...ranges].sort(
+    (left, right) =>
+      left.source.localeCompare(right.source) ||
+      left.startOffset - right.startOffset ||
+      left.endOffset - right.endOffset,
+  );
+  const merged: SecretTaintRange[] = [];
+  for (const range of sorted) {
+    const previous = merged.at(-1);
+    if (
+      previous?.source === range.source &&
+      range.startOffset <= previous.endOffset
+    ) {
+      previous.endOffset = Math.max(previous.endOffset, range.endOffset);
+    } else {
+      merged.push({ ...range });
+    }
+  }
+  return merged;
+}
+
 function appendRing(
   ring: StreamRing,
   text: string,
@@ -375,6 +553,8 @@ function appendRing(
 
 function readRing(
   runtime: IAgentRuntime,
+  session: BackgroundShellSession,
+  source: "stdout" | "stderr",
   ring: StreamRing,
   requestedOffset?: number,
 ): BackgroundShellChunk {
@@ -387,22 +567,65 @@ function readRing(
     Math.max(offset, ring.truncatedBefore),
   );
   const index = start - ring.startOffset;
-  const redactedFull = redactShellText(runtime, ring.text);
-  const redactedPrefix = redactShellText(runtime, ring.text.slice(0, index));
-  // A credential can straddle the requested offset. The retained overlap lets
-  // full-window redaction see across both the logical cap and chunk boundaries;
-  // if replacement changes the prefix, suppress the ambiguous projection
-  // instead of returning either side of the credential.
-  const canSliceAtRequestedOffset = redactedFull.startsWith(redactedPrefix);
-  const text = canSliceAtRequestedOffset
-    ? redactedFull.slice(redactedPrefix.length)
-    : "[REDACTED:chunk-boundary]";
+  const raw = ring.text.slice(index);
+  const text = projectRingText(
+    runtime,
+    session,
+    source,
+    ring,
+    index,
+    start,
+    raw,
+  );
   return {
     text,
     startOffset: start,
     endOffset: ring.endOffset,
     truncatedBefore: ring.truncatedBefore,
   };
+}
+
+function projectRingText(
+  runtime: IAgentRuntime,
+  session: BackgroundShellSession,
+  source: "stdout" | "stderr",
+  ring: StreamRing,
+  index: number,
+  startOffset: number,
+  raw: string,
+): string {
+  if (!raw) return "";
+  if (session.redaction.incomplete) {
+    return "[REDACTED:fragment-scan-incomplete]";
+  }
+  const endOffset = startOffset + raw.length;
+  const ranges = session.redaction.ranges.filter(
+    (range) =>
+      range.source === source &&
+      range.endOffset > startOffset &&
+      range.startOffset < endOffset,
+  );
+  if (ranges.length === 0) {
+    const redactedFull = redactShellText(runtime, ring.text);
+    const redactedPrefix = redactShellText(runtime, ring.text.slice(0, index));
+    return redactedFull.startsWith(redactedPrefix)
+      ? redactedFull.slice(redactedPrefix.length)
+      : "[REDACTED:chunk-boundary]";
+  }
+
+  const pieces: string[] = [];
+  let cursor = startOffset;
+  for (const range of ranges) {
+    const taintStart = Math.max(startOffset, range.startOffset);
+    const taintEnd = Math.min(endOffset, range.endOffset);
+    if (taintStart > cursor) {
+      pieces.push(raw.slice(cursor - startOffset, taintStart - startOffset));
+    }
+    pieces.push("[REDACTED:configured-secret-fragment]");
+    cursor = Math.max(cursor, taintEnd);
+  }
+  if (cursor < endOffset) pieces.push(raw.slice(cursor - startOffset));
+  return redactShellText(runtime, pieces.join(""));
 }
 
 function snapshot(

--- a/plugins/plugin-coding-tools/src/services/background-shell-service.ts
+++ b/plugins/plugin-coding-tools/src/services/background-shell-service.ts
@@ -621,7 +621,7 @@ function projectRingText(
 ): string {
   if (!raw) return "";
   if (session.redaction.incomplete) {
-    return "[REDACTED:fragment-scan-incomplete]";
+    return redactShellText(runtime, "[REDACTED:fragment-scan-incomplete]");
   }
   const endOffset = startOffset + raw.length;
   const ranges = session.redaction.ranges.filter(

--- a/plugins/plugin-coding-tools/src/services/background-shell-service.ts
+++ b/plugins/plugin-coding-tools/src/services/background-shell-service.ts
@@ -97,7 +97,8 @@ interface FragmentRedactionState {
   fragments: SecretFragment[];
   ranges: SecretTaintRange[];
   incomplete: boolean;
-  quarantineCharacters: number;
+  quarantineCharacters: Record<"stdout" | "stderr", number>;
+  profileRevision?: number;
 }
 
 export class BackgroundShellService extends Service {
@@ -385,7 +386,7 @@ function emptyFragmentRedactionState(): FragmentRedactionState {
     fragments: [],
     ranges: [],
     incomplete: false,
-    quarantineCharacters: 0,
+    quarantineCharacters: { stdout: 0, stderr: 0 },
   };
 }
 
@@ -403,9 +404,9 @@ function appendSessionOutput(
     { source, startOffset, text: "x" },
   ]);
   const maxSecretLength = profile.maxSecretLength;
-  appendRing(ring, text, cap, Math.max(cap, maxSecretLength));
+  appendRing(ring, text, cap, maxSecretLength);
   const quarantinedCharacters = Math.min(
-    session.redaction.quarantineCharacters,
+    session.redaction.quarantineCharacters[source],
     text.length,
   );
   if (quarantinedCharacters > 0) {
@@ -417,7 +418,7 @@ function appendSessionOutput(
         endOffset: startOffset + quarantinedCharacters,
       },
     ]);
-    session.redaction.quarantineCharacters -= quarantinedCharacters;
+    session.redaction.quarantineCharacters[source] -= quarantinedCharacters;
   }
   const detectionText = text.slice(quarantinedCharacters);
   if (detectionText) {
@@ -435,9 +436,31 @@ function refreshSessionRedaction(
   runtime: IAgentRuntime,
   session: BackgroundShellSession,
 ): void {
+  if (session.redaction.incomplete) return;
   const analyses = observableFragmentOrders(session.redaction.fragments).map(
     (fragments) => runtime.locateConfiguredSecretFragmentTaint(fragments),
   );
+  const revisions = new Set(
+    analyses.map((analysis) => analysis.profileRevision),
+  );
+  if (revisions.size !== 1) {
+    session.redaction.incomplete = true;
+    return;
+  }
+  const revision = analyses[0]?.profileRevision ?? 0;
+  if (
+    session.redaction.profileRevision !== undefined &&
+    revision !== session.redaction.profileRevision
+  ) {
+    session.redaction.incomplete = true;
+    session.redaction.ranges = mergeTaintRanges([
+      ...session.redaction.ranges,
+      ...retainedRingRanges(session),
+    ]);
+    session.redaction.fragments = [];
+    return;
+  }
+  session.redaction.profileRevision = revision;
   const incomplete = analyses.find(
     (analysis) => analysis.status === "incomplete",
   );
@@ -449,10 +472,12 @@ function refreshSessionRedaction(
         ...retainedRingRanges(session),
       ]);
       session.redaction.fragments = [];
-      session.redaction.quarantineCharacters = Math.max(
-        session.redaction.quarantineCharacters,
-        incomplete.maxSecretLength,
-      );
+      for (const source of ["stdout", "stderr"] as const) {
+        session.redaction.quarantineCharacters[source] = Math.max(
+          session.redaction.quarantineCharacters[source],
+          incomplete.maxSecretLength,
+        );
+      }
     }
     return;
   }

--- a/plugins/plugin-coding-tools/src/services/background-shell-service.ts
+++ b/plugins/plugin-coding-tools/src/services/background-shell-service.ts
@@ -620,9 +620,7 @@ function projectRingText(
   raw: string,
 ): string {
   if (!raw) return "";
-  if (session.redaction.incomplete) {
-    return redactShellText(runtime, "[REDACTED:fragment-scan-incomplete]");
-  }
+  if (session.redaction.incomplete) return "";
   const endOffset = startOffset + raw.length;
   const ranges = session.redaction.ranges.filter(
     (range) =>
@@ -633,9 +631,12 @@ function projectRingText(
   if (ranges.length === 0) {
     const redactedFull = redactShellText(runtime, ring.text);
     const redactedPrefix = redactShellText(runtime, ring.text.slice(0, index));
-    return redactedFull.startsWith(redactedPrefix)
-      ? redactedFull.slice(redactedPrefix.length)
-      : "[REDACTED:chunk-boundary]";
+    return verifyProjectedText(
+      runtime,
+      redactedFull.startsWith(redactedPrefix)
+        ? redactedFull.slice(redactedPrefix.length)
+        : "",
+    );
   }
 
   const pieces: string[] = [];
@@ -646,11 +647,23 @@ function projectRingText(
     if (taintStart > cursor) {
       pieces.push(raw.slice(cursor - startOffset, taintStart - startOffset));
     }
-    pieces.push("[REDACTED:configured-secret-fragment]");
     cursor = Math.max(cursor, taintEnd);
   }
   if (cursor < endOffset) pieces.push(raw.slice(cursor - startOffset));
-  return redactShellText(runtime, pieces.join(""));
+  return verifyProjectedText(
+    runtime,
+    redactShellText(runtime, pieces.join("")),
+  );
+}
+
+function verifyProjectedText(runtime: IAgentRuntime, text: string): string {
+  if (!text) return "";
+  const verification = runtime.locateConfiguredSecretFragmentTaint([
+    { source: "projected", startOffset: 0, text },
+  ]);
+  return verification.status === "complete" && verification.ranges.length === 0
+    ? text
+    : "";
 }
 
 function snapshot(


### PR DESCRIPTION
# Relates to

Fixes #19787.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@1bde21d6d8229678f20bbd450f8e49f9fd95f989:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@95c456206cc8d111374f3a9f7b59475741701ae5`; zero conflicts.
- [x] `bun run verify` passes post-sync: 350/350 workspace tasks successful, followed by all repository audit scripts.

# Risks

**Medium.** This changes the runtime security contract and background-shell public projections. Raw child-process bytes remain private and unchanged, while public stdout/stderr ranges may now omit tainted or unverifiable text. Absolute offsets and truncation metadata remain stable. Secret-profile changes invalidate retained output when the prior bytes cannot be proven safe.

# Background

## What does this PR do?

- Adds a runtime-owned ordered-fragment redaction contract that returns tainted absolute source ranges without returning configured secret values.
- Detects configured secrets spanning adjacent fragments across stdout/stderr in either public presentation order.
- Retains runtime-sized detection overlap based on the longest eligible configured secret and bounds analysis work.
- Integrates the contract into `BackgroundShellService` while preserving raw executor input privately, explicit-offset/idempotent reads, per-stream provenance, and later safe output.
- Fails closed by omitting uncertain or tainted public text; it never emits an in-band redaction marker that could itself equal a configured secret.
- Uses the existing core minimum-secret-length policy as the single source of truth.

## What kind of change is this?

Bug fix (non-breaking security hardening for streaming diagnostics).

# Documentation changes needed?

No project documentation change is required. The new contract is internal to `@elizaos/core` and plugin-coding-tools, with its behavior locked by focused API and integration tests.

# Testing

## Where should a reviewer start?

1. `packages/core/src/security/fragment-redaction.test.ts` for the ordered-fragment/range contract.
2. `plugins/plugin-coding-tools/src/actions/bash.test.ts` for the real `BackgroundShellService` integration and public-surface assertions.
3. `plugins/plugin-coding-tools/src/services/background-shell-service.ts` for the raw-private/projected-public boundary.

## Detailed testing steps

Exact synced head: `fb21814818c33c0bb77870cff758ab7e01e310a8` (tree `aa4dc0ff91cb3002cd6df605aaafde7589eeba6f`).

- Core focused fragment-redaction suite: **15/15 passed**.
- Plugin-coding-tools focused background-shell/action suite: **114/114 passed**.
- Full plugin-coding-tools suite: **36 files / 565 tests passed**.
- `bun run --cwd packages/core typecheck`: passed.
- `bun run --cwd packages/core build`: passed for Node, browser, edge, testing, declarations, and packed edge output.
- `bun run --cwd plugins/plugin-coding-tools typecheck`: passed.
- `bun run --cwd plugins/plugin-coding-tools build`: passed.
- Seven-path Biome check: passed.
- `git diff --check`: passed.
- `bun run verify`: passed, **350/350 workspace tasks** plus repository audits.
- `bun run audit:error-policy-ratchet`: N/A — this script is not present on the pinned base (`Script not found`). The diff adds no empty catches or server-side `console.*` calls.
- Independent exact-head review: **APPROVE**, no P0-P3 findings, after adversarial review and exact range-diff/base-integration verification.

# Evidence Gate

<!-- evidence-head:fb21814818c33c0bb77870cff758ab7e01e310a8 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend/runtime security change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend/runtime security change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend or interactive visual flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no server transport or structured backend logger is changed; actual runtime and BackgroundShellService child-process test output is included in Evidence Details.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request, console, network, or state surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, action selection, provider, evaluator, or model behavior changed; this is a deterministic runtime security boundary.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB row, memory, scheduled task, wallet, chain, generated file, device, or persistent domain artifact is produced.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM call path or model-visible behavior is changed. The security contract is deterministic and exercised at the real runtime/background-shell boundary.

## Backend + frontend logs

The focused and package suites exercised actual `AgentRuntime` fragment analysis and real `BackgroundShellService` child-process output, including:

- same-stream, cross-stream, multi-fragment, reverse-order, and harmless interposed-byte matches;
- tiny visible caps, repeated/future offsets, truncation, and later safe output;
- resource exhaustion, empty/oversized profiles, secret rotation, and fresh-session recovery;
- former-marker and self-referential secret collisions;
- raw executor input preservation and omission of canaries from public poll/list/history/callback/result DTOs.

```text
core fragment-redaction focused: 15 passed / 15
plugin-coding-tools focused: 114 passed / 114
plugin-coding-tools full: 36 files passed / 565 tests passed
root verify: 350 tasks successful / 350 total
independent exact-head review: APPROVE; no P0-P3
```

Frontend logs: N/A - no frontend code or transport is involved.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio surface changed.

## Known gaps / failures

- A full core test invocation on the pre-final-sync equivalent stack reported three unrelated existing failures: compact Stage-1 prompt length (3808 vs 3800), guarded-stream Basic split equivalence, and trajectory-recorder cost (1.1 vs 1.3). None touches the seven changed paths. The exact final synced head subsequently passed root `bun run verify`, package typechecks/builds, focused core tests, and the full plugin-coding-tools suite.
- No real credential was used. All canaries are synthetic by issue design.
- No deployment is required for this library/plugin fix; hosted checks and maintainer review remain required before merge.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@1bde21d6d8229678f20bbd450f8e49f9fd95f989:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [gauss]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@1bde21d6d8229678f20bbd450f8e49f9fd95f989:packages/skills/skills/contribute-to-eliza"} -->

