### PR TITLE
fix: mark VIEWS diagnostic failures internal and gate the interact guidance site

### DIFF
--- a/plugins/plugin-app-control/src/actions/views-loopback-auth.integration.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-loopback-auth.integration.test.ts
@@ -512,6 +512,9 @@ describe("authenticated view loopback requests", () => {
 		expect(result).toMatchObject({
 			success: false,
 			text: 'Cannot invoke capability "undeclared-capability" on view "tasks": the view catalog does not declare that capability.',
+			// Marked internal so core's transcript-visibility resolver can spot
+			// an evaluator echo of the diagnostic.
+			transcriptVisibility: "internal",
 		});
 		expect(result).not.toHaveProperty("turnComplete");
 		expect(result).not.toHaveProperty("userFacingText");

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -3165,10 +3165,15 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 							}
 						}
 						if (!viewId || !capability) {
-							const reply =
-								"Specify view and capability, e.g. action=interact view=wallet capability=get-state, or ask for the current view after navigating.";
-							await callback?.({ text: reply });
-							return { success: false, text: reply };
+							// Planner-facing tool syntax, not a chat reply — return it to
+							// the planner without a user callback and mark it internal so
+							// core's transcript-visibility resolver can spot an evaluator
+							// echo of it.
+							return {
+								success: false,
+								text: "Specify view and capability, e.g. action=interact view=wallet capability=get-state, or ask for the current view after navigating.",
+								transcriptVisibility: "internal",
+							};
 						}
 						const resolvedView =
 							resolvedCapability?.view ?? resolveViewTarget(viewId, views);
@@ -3264,6 +3269,7 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 							return {
 								success: false,
 								text: `Cannot invoke capability "${capability}" on view "${viewId}": the view catalog does not declare that capability.`,
+								transcriptVisibility: "internal",
 							};
 						}
 						if (!resolvedCapability && standardCapability)
@@ -3278,6 +3284,7 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 								return {
 									success: false,
 									text: `Refusing destructive capability on view "${viewId}": ${correction.reason}. Please rephrase with explicit, unambiguous intent.`,
+									transcriptVisibility: "internal",
 								};
 							}
 							if (
@@ -3305,9 +3312,11 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 										viewGate,
 									);
 						if (!viewAllowed && authorizedView) {
-							const reply = `The ${authorizedView.label} view is not available to this caller.`;
-							await callback?.({ text: reply });
-							return { success: false, text: reply };
+							return {
+								success: false,
+								text: `The ${authorizedView.label} view is not available to this caller.`,
+								transcriptVisibility: "internal",
+							};
 						}
 						const paramsResolution = readCapabilityParams(
 							actionOptions,
@@ -3318,6 +3327,7 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 							return {
 								success: false,
 								text: `Cannot invoke capability "${capability}" on view "${viewId}": ${paramsResolution.error}.`,
+								transcriptVisibility: "internal",
 							};
 						}
 						const params = paramsResolution.params;


### PR DESCRIPTION
## What

Follow-up to the merged #19860, folding in the two bits shaw's closure of #19858 flagged for this lane:

1. The interact arm's **missing-view/capability guidance site** still callback-delivered planner-facing tool syntax as a chat bubble: `Specify view and capability, e.g. action=interact view=wallet capability=get-state, ...`. It now returns to the planner like the other failure sites.
2. The diagnostic failure returns carried **no `transcriptVisibility: "internal"` marker**, so core's `resolveActionResultTranscriptVisibility` could not identify an evaluator echo of them. All five diagnostic failure returns (guidance, catalog-denial, destructive-reject, caller-authz denial, params-resolution) are now marked internal.

## Evidence

- `views-loopback-auth.integration.test.ts` 7/7 with a new assertion that the catalog-denial result carries `transcriptVisibility: "internal"` (real-TCP harness)
- Applied to the live nubilio box (dist rebuilt, bot restarted) as part of the ongoing owner-battery lane — no diagnostic text delivered in subsequent probes

🤖 Generated with [Claude Code](https://claude.com/claude-code)