### PR TITLE
fix(cloud): select Worker-compatible JWT denylist backend

### DIFF
--- a/packages/cloud/shared/src/lib/auth/jwt-internal-denylist.ts
+++ b/packages/cloud/shared/src/lib/auth/jwt-internal-denylist.ts
@@ -32,7 +32,8 @@
  * case {@link isDenylistConfigured} returns `false`; the verifier documents and
  * enforces this by skipping the (impossible) denylist read instead of failing
  * every request. Deployments that require same-hour single-token revocation
- * MUST configure Redis (`REDIS_URL` or `KV_REST_API_*`).
+ * MUST configure a runtime-compatible Redis backend: `REDIS_URL` on Node, or
+ * `KV_REST_API_*` / `UPSTASH_REDIS_REST_*` in Cloudflare Workers.
  */
 
 import {
@@ -40,6 +41,7 @@ import {
   type CompatibleRedis,
   hasRedisConfig,
   isCloudflareWorkerRuntime,
+  type RedisFactoryEnvSource,
 } from "../cache/redis-factory";
 import { logger } from "../utils/logger";
 
@@ -63,13 +65,33 @@ function denylistKey(jti: string): string {
 let cachedRedis: CompatibleRedis | null = null;
 
 /**
+ * Select only Redis transports that the current runtime can actually use.
+ * Production Workers may inherit Railway's TCP `REDIS_URL`, but workerd cannot
+ * reliably reach that external socket. Treating it as a usable revocation
+ * store rejects every otherwise-valid internal token. REST Redis remains
+ * available and fail-closed in Workers; Node keeps the normal TCP-first
+ * factory resolution.
+ */
+function getDenylistRedisEnv(): RedisFactoryEnvSource {
+  if (!isCloudflareWorkerRuntime()) return process.env;
+
+  return {
+    MOCK_REDIS: process.env.MOCK_REDIS,
+    KV_REST_API_URL: process.env.KV_REST_API_URL,
+    KV_REST_API_TOKEN: process.env.KV_REST_API_TOKEN,
+    UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+    UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
+  };
+}
+
+/**
  * Resolve the Redis client. On Workers a client is built per call (a cached TCP
  * socket belongs to the request that opened it); on Node the client is cached.
  * Mirrors the pattern in `middleware/rate-limit-redis`.
  */
 function getRedis(): CompatibleRedis | null {
   if (!isCloudflareWorkerRuntime() && cachedRedis) return cachedRedis;
-  const client = buildRedisClient();
+  const client = buildRedisClient(getDenylistRedisEnv());
   if (client && !isCloudflareWorkerRuntime()) cachedRedis = client;
   return client;
 }
@@ -79,7 +101,7 @@ function getRedis(): CompatibleRedis | null {
  * supported. When `false`, revocation falls back to key-rotation + TTL only.
  */
 export function isDenylistConfigured(): boolean {
-  return hasRedisConfig();
+  return hasRedisConfig(getDenylistRedisEnv());
 }
 
 /**

--- a/packages/cloud/shared/src/lib/auth/jwt-internal.test.ts
+++ b/packages/cloud/shared/src/lib/auth/jwt-internal.test.ts
@@ -30,12 +30,21 @@ function makeKeys() {
 const KEYS = makeKeys();
 
 const denylistStore = new Map<string, string>();
-let denylistConfigured = true;
 let denylistGetError: Error | null = null;
+let workerRuntime = false;
+let lastRedisEnv: Record<string, string | undefined> | undefined;
+
+function hasConfiguredRedis(env: Record<string, string | undefined>): boolean {
+  if (env.MOCK_REDIS === "1" || env.REDIS_URL) return true;
+  const restUrl = env.KV_REST_API_URL || env.UPSTASH_REDIS_REST_URL;
+  const restToken = env.KV_REST_API_TOKEN || env.UPSTASH_REDIS_REST_TOKEN;
+  return Boolean(restUrl && restToken);
+}
 
 mock.module("../cache/redis-factory", () => ({
-  buildRedisClient: () => {
-    if (!denylistConfigured) return null;
+  buildRedisClient: (env: Record<string, string | undefined> = process.env) => {
+    lastRedisEnv = env;
+    if (!hasConfiguredRedis(env)) return null;
     return {
       async get(key: string) {
         if (denylistGetError) throw denylistGetError;
@@ -50,8 +59,9 @@ mock.module("../cache/redis-factory", () => ({
       },
     };
   },
-  hasRedisConfig: () => denylistConfigured,
-  isCloudflareWorkerRuntime: () => false,
+  hasRedisConfig: (env: Record<string, string | undefined> = process.env) =>
+    hasConfiguredRedis(env),
+  isCloudflareWorkerRuntime: () => workerRuntime,
 }));
 
 mock.module("../utils/logger", () => ({
@@ -70,8 +80,9 @@ describe("internal JWT jti revocation denylist (#12879)", () => {
     process.env.JWT_SIGNING_KEY_ID = "test";
     process.env.MOCK_REDIS = "1";
     denylistStore.clear();
-    denylistConfigured = true;
     denylistGetError = null;
+    workerRuntime = false;
+    lastRedisEnv = undefined;
     denylistMod.__resetDenylistClientForTests();
     setSystemTime();
   });
@@ -84,6 +95,9 @@ describe("internal JWT jti revocation denylist (#12879)", () => {
     delete process.env.REDIS_URL;
     delete process.env.KV_REST_API_URL;
     delete process.env.KV_REST_API_TOKEN;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    workerRuntime = false;
     setSystemTime();
   });
 
@@ -173,7 +187,6 @@ describe("internal JWT jti revocation denylist (#12879)", () => {
       delete process.env.REDIS_URL;
       delete process.env.KV_REST_API_URL;
       delete process.env.KV_REST_API_TOKEN;
-      denylistConfigured = false;
       denylistMod.__resetDenylistClientForTests();
     });
 
@@ -191,6 +204,55 @@ describe("internal JWT jti revocation denylist (#12879)", () => {
       await expect(mod.revokeInternalToken("some-jti", undefined)).rejects.toThrow(
         /no Redis backend configured/i,
       );
+    });
+  });
+
+  describe("runtime-compatible denylist transport selection", () => {
+    test("ignores TCP REDIS_URL in Workers and uses key rotation plus TTL", async () => {
+      delete process.env.MOCK_REDIS;
+      process.env.REDIS_URL = "redis://railway.internal:6379";
+      workerRuntime = true;
+      denylistMod.__resetDenylistClientForTests();
+
+      expect(mod.isDenylistConfigured()).toBe(false);
+      const { access_token } = await mod.signInternalToken({ subject: "worker-tcp-only" });
+      const result = await mod.verifyInternalToken(access_token);
+
+      expect(result.valid).toBe(true);
+      expect(lastRedisEnv?.REDIS_URL).toBeUndefined();
+    });
+
+    test("uses REST Redis in Workers and remains fail-closed on read errors", async () => {
+      delete process.env.MOCK_REDIS;
+      process.env.REDIS_URL = "redis://railway.internal:6379";
+      process.env.KV_REST_API_URL = "https://redis-rest.example.test";
+      process.env.KV_REST_API_TOKEN = "test-token";
+      workerRuntime = true;
+      denylistGetError = new Error("REST Redis unavailable");
+      denylistMod.__resetDenylistClientForTests();
+
+      expect(mod.isDenylistConfigured()).toBe(true);
+      const { access_token } = await mod.signInternalToken({ subject: "worker-rest" });
+
+      await expect(mod.verifyInternalToken(access_token)).rejects.toThrow(
+        /REST Redis unavailable/i,
+      );
+      expect(lastRedisEnv?.REDIS_URL).toBeUndefined();
+      expect(lastRedisEnv?.KV_REST_API_URL).toBe("https://redis-rest.example.test");
+    });
+
+    test("keeps TCP REDIS_URL available to Node services", async () => {
+      delete process.env.MOCK_REDIS;
+      process.env.REDIS_URL = "redis://railway.internal:6379";
+      workerRuntime = false;
+      denylistMod.__resetDenylistClientForTests();
+
+      expect(mod.isDenylistConfigured()).toBe(true);
+      const { access_token } = await mod.signInternalToken({ subject: "node-tcp" });
+      const result = await mod.verifyInternalToken(access_token);
+
+      expect(result.valid).toBe(true);
+      expect(lastRedisEnv?.REDIS_URL).toBe("redis://railway.internal:6379");
     });
   });
 });


### PR DESCRIPTION
Closes #19871

## What changed
- exclude raw TCP `REDIS_URL` from internal-JWT denylist selection inside Cloudflare Workers
- retain REST Redis denylisting and fail-closed read behavior in Workers
- retain TCP-first Redis behavior in Node services
- use the existing documented short-lived-token/signing-key-rotation model when no runtime-compatible denylist exists

## Evidence
- `bun test packages/cloud/shared/src/lib/auth/jwt-internal.test.ts` — 11 pass, 0 fail
- `bun run --cwd packages/cloud/shared typecheck` — pass
- changed-file Biome — pass
- `git diff --check` — pass
- full shared suite entered an unrelated pre-existing workflow contract failure: `scripts/messaging-gateway-preflight.test.mjs` expects a removed `github.event_name != pull_request` step in `cloud-gateway-discord.yml`

## Production incident
The production Worker currently verifies the gateway token cryptographically (ES256/kid/issuer/audience are valid) but returns 401 from the denylist read because it selects an inherited Railway TCP Redis URL. After promotion, live proof will cover token mint, token refresh, and the Discord voice authorization boundary.

<!-- evidence-head:866e6df6fb161b2e44bdaa158815cef8b9d6a37f -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Backend-only internal authentication transport selection; no rendered UI changes.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Backend-only internal authentication transport selection; no rendered UI changes.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No user-facing interactive flow changes.

<!-- evidence-row:backend-logs -->
- [ ] N/A - Exact-head 11-case JWT suite covers Worker TCP exclusion, REST fail-closed behavior, Node TCP behavior, revocation, expiry, and key-rotation degradation; protected live promotion is the post-merge rollout gate.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend runtime change.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No model, prompt, provider, or inference behavior changes.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No generated artifact; exact-head JWT verification results are asserted directly by the focused suite.

<!-- evidence-row:ocr-review -->
- [ ] N/A - No rendered UI changes.
