### PR TITLE
fix(core): enforce maxBytes: 0 as a hard zero-byte cap in media fetch

### DIFF
--- a/packages/core/src/media/fetch.test.ts
+++ b/packages/core/src/media/fetch.test.ts
@@ -67,3 +67,41 @@ describe("fetchRemoteMedia", () => {
 		expect(result.fileName).toBe("report.txt");
 	});
 });
+
+	describe("maxBytes: 0 hard zero-byte cap", () => {
+		function fetchWithMaxBytes(maxBytes: number, body: string) {
+			return fetchRemoteMedia({
+				url: "https://example.com/image.png",
+				maxBytes,
+				lookupFn: async () => [{ address: "93.184.216.34", family: 4 }],
+				pinnedFetchImpl: async () => new Response(Buffer.from(body)),
+			});
+		}
+
+		it("rejects a non-empty body under maxBytes: 0 instead of reading unbounded", async () => {
+			// A truthiness check on maxBytes used to fold 0 into "no cap",
+			// giving callers relying on the documented hard-cap contract an
+			// unbounded read under a zero-byte policy (#19854).
+			await expect(fetchWithMaxBytes(0, "x")).rejects.toMatchObject({
+				code: "max_bytes",
+			});
+		});
+
+		it("admits an empty body under maxBytes: 0", async () => {
+			// 0 is a cap, not a blanket rejection: zero delivered bytes comply.
+			const result = await fetchWithMaxBytes(0, "");
+			expect(result.buffer.length).toBe(0);
+		});
+
+		it("still reads unbounded when maxBytes is omitted", async () => {
+			const result = await fetchRemoteMedia({
+				url: "https://example.com/image.png",
+				lookupFn: async () => [{ address: "93.184.216.34", family: 4 }],
+				pinnedFetchImpl: async () =>
+					new Response(Buffer.from("png"), {
+						headers: { "content-type": "image/png" },
+					}),
+			});
+			expect(result.buffer.toString()).toBe("png");
+		});
+	});

--- a/packages/core/src/media/fetch.ts
+++ b/packages/core/src/media/fetch.ts
@@ -172,7 +172,10 @@ function enforceContentLengthLimit(
 	maxBytes?: number,
 ): void {
 	const contentLength = res.headers.get("content-length");
-	if (!maxBytes || !contentLength) {
+	// A zero cap is a valid hard limit, not an omitted one — compare against
+	// undefined explicitly so maxBytes: 0 cannot fall through to the unbounded
+	// read path (#19854).
+	if (maxBytes === undefined || !contentLength) {
 		return;
 	}
 
@@ -250,9 +253,13 @@ export async function fetchRemoteMedia(
 		await throwIfHttpError(res, options.url, finalUrl);
 		enforceContentLengthLimit(res, options.url, options.maxBytes);
 
-		const buffer = options.maxBytes
-			? await readResponseWithLimit(res, options.maxBytes)
-			: Buffer.from(await res.arrayBuffer());
+		// Distinguish an omitted cap (undefined → unbounded read) from an
+		// explicit zero cap (→ readResponseWithLimit enforces the hard
+		// zero-byte policy) — a truthiness check folded both into "no cap".
+		const buffer =
+			options.maxBytes === undefined
+				? Buffer.from(await res.arrayBuffer())
+				: await readResponseWithLimit(res, options.maxBytes);
 		const metadata = await resolveMediaMetadata({
 			res,
 			buffer,


### PR DESCRIPTION
# Relates to

Fixes #19854

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-4-5`
<!-- attribution-row:client -->
- Agent tooling: `ZCode`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts. (Built
      directly on the exact current develop tree via the Git Data API; `fetch.ts`
      was verified unchanged on the merge base before editing.)
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The change only distinguishes an omitted `maxBytes` from an explicit
`maxBytes: 0`; the issue author verified no current caller passes `0` (all use
a named constant or a variable), so no live behavior changes. `undefined`
(omitted) keeps the unbounded read exactly as before; `0` now routes into
`readResponseWithLimit`, which already enforces a zero cap correctly once
selected. No public signature change.

# Background

## What does this PR do?

`enforceContentLengthLimit` and `fetchRemoteMedia` in
`packages/core/src/media/fetch.ts` selected their byte-limit path with a
truthiness check on `maxBytes`, so `maxBytes: 0` was treated the same as an
omitted cap and fell through to the unbounded `arrayBuffer()` read instead of
enforcing the documented hard-cap contract.

Both checks now compare against `undefined` explicitly:

```ts
// enforceContentLengthLimit
if (maxBytes === undefined || !contentLength) return;

// fetchRemoteMedia
const buffer =
  options.maxBytes === undefined
    ? Buffer.from(await res.arrayBuffer())
    : await readResponseWithLimit(res, options.maxBytes);
```

`readResponseWithLimit(res, 0)` already behaves correctly once selected: any
non-zero byte rejects with `MediaFetchError("max_bytes")` (stream cancels as
soon as the total exceeds 0), and an empty body complies — 0 is a cap, not a
blanket rejection.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

```bash
bun test packages/core/src/media/fetch.test.ts
```

## Detailed testing steps

- Run the focused suite above; the three new `maxBytes: 0 hard zero-byte cap`
  tests cover: non-empty body under `maxBytes: 0` rejects with `max_bytes`;
  empty body under `maxBytes: 0` complies; omitted `maxBytes` still reads
  unbounded (no behavior regression).

# Evidence Gate

<!-- evidence-head:5cdf64f33f6ff00f05afe3044d64f56d0646b0f9 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - pure core logic change (media fetch byte-cap selection); no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - pure core logic change (media fetch byte-cap selection); no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow; deterministic unit tests with pinned transport cover the behavior.
<!-- evidence-row:backend-logs -->
- [x] N/A - no runtime/backend service path changed; the deterministic suite below exercises the real code path offline (pinned DNS + injected transport).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response or state change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - pure fetch-helper logic, no DB/memory/wallet/file artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Backend + frontend logs

Focused unit test output (run against the PR head):

```
$ bun test packages/core/src/media/fetch.test.ts

(pass) fetchRemoteMedia > applies timeout signals to guarded fetches [0.53ms]
(pass) fetchRemoteMedia > decodes RFC 5987 filename* with an empty language tag [0.29ms]
(pass) fetchRemoteMedia > decodes RFC 5987 filename* with a language tag [0.27ms]
(pass) fetchRemoteMedia > falls back to plain filename= parsing [0.31ms]
(pass) maxBytes: 0 hard zero-byte cap > rejects a non-empty body under maxBytes: 0 instead of reading unbounded [2.60ms]
(pass) maxBytes: 0 hard zero-byte cap > admits an empty body under maxBytes: 0 [0.24ms]
(pass) maxBytes: 0 hard zero-byte cap > still reads unbounded when maxBytes is omitted [0.41ms]

 7 pass
 0 fail
 8 expect() calls
Ran 7 tests across 1 file. [489.00ms]
```

The exact repro from the issue now rejects as specified:

```ts
await expect(
  fetchRemoteMedia({
    url: "https://example.com/image.png",
    maxBytes: 0,
    lookupFn: async () => [{ address: "93.184.216.34", family: 4 }],
    pinnedFetchImpl: async () => new Response(Buffer.from("x")),
  }),
).rejects.toMatchObject({ code: "max_bytes" }); // passes on this PR head
```

## Screenshots (before / after) + video walkthrough

N/A - pure core logic change, no rendered UI surface.

## Known gaps / failures

Root `bun install` in this environment fails on the `ffmpeg-static` postinstall
script (network timeout fetching the prebuilt binary from GitHub releases), so
the full root `bun run verify` cannot run here. This is unrelated to
`@elizaos/core`'s media fetch: the focused suite above runs and passes with the
workspace dependencies already installed, and the change touches only the
byte-limit branch selection in `fetch.ts` plus its focused tests.