### PR TITLE
fix: type-guard missing workflow source in validateSmithersSource

### DIFF
--- a/plugins/plugin-workflow/__tests__/unit/smithers-source.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/smithers-source.test.ts
@@ -14,6 +14,11 @@ describe('native Smithers workflow source', () => {
 
   test('rejects missing source, missing default exports, and legacy packages', () => {
     expect(() => validateSmithersSource('')).toThrow('source is required');
+    // A stored record can reach dispatch with no source at all (stale trigger
+    // to a legacy definition); that is the typed error, never a TypeError.
+    expect(() =>
+      validateSmithersSource(undefined as unknown as string)
+    ).toThrow('source is required');
     expect(() => validateSmithersSource("import { Smithers } from 'smthrs';")).toThrow(
       'default-export'
     );

--- a/plugins/plugin-workflow/src/services/smithers-runtime.ts
+++ b/plugins/plugin-workflow/src/services/smithers-runtime.ts
@@ -164,7 +164,11 @@ async function linkWorkflowDependency(
 }
 
 export function validateSmithersSource(source: string): void {
-  const trimmed = source.trim();
+  // A stored workflow record can reach dispatch without a source (stale
+  // trigger pointing at a legacy or partially-saved definition, live repro:
+  // system-device-health-check). That must fail as the typed
+  // SMTHRS_SOURCE_REQUIRED error, not a TypeError on `.trim()`.
+  const trimmed = typeof source === 'string' ? source.trim() : '';
   if (!trimmed)
     throw new ElizaError('Workflow source is required', { code: 'SMTHRS_SOURCE_REQUIRED' });
   if (!/\bfrom\s+['"]smthrs(?:\/[^'"]+)?['"]/.test(trimmed)) {


### PR DESCRIPTION
## What

A stored workflow record can reach dispatch with **no `source` at all** — live repro on nubilio: a stale workflow trigger for `system-device-health-check` (its definition no longer exists in source) failed every scheduled fire with the raw TypeError `undefined is not an object (evaluating 'source.trim')` instead of the validator's own typed `SMTHRS_SOURCE_REQUIRED` error, so the dispatch boundary logged an unactionable message forever.

One-line guard: `typeof source === 'string' ? source.trim() : ''` — the missing-source case now flows as the typed ElizaError the dispatch boundary already handles.

## Evidence

- `smithers-source.test.ts` extended: `undefined` source throws the typed 'source is required' error (2/2 pass)
- Live: repeated `[TRIGGER-RUNTIME] Trigger dispatch failed ... error=undefined is not an object (evaluating 'source.trim')` for taskId c8c49b8c-d1dc-4e17-9ce6-875c5dafcb3e on nubilio (develop@dbeb45a77f4); the stale trigger itself is being cleaned via the runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)