### PR TITLE
feat(cloud): robot-first dedicated-agent placement plus per-agent CPU quota

### DIFF
--- a/packages/cloud/shared/src/lib/config/containers-env.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env.ts
@@ -430,6 +430,27 @@ export const containersEnv = {
     return 3072;
   },
 
+  /**
+   * Per-agent-container `--cpus` ceiling (fractional cores). The CPU analog of
+   * agentContainerMemoryLimitMb (#18485): robot-first placement packs far more
+   * agents per box than the old 4-vCPU cloud nodes, so one busy-looping agent
+   * must be throttled inside its own cgroup instead of starving co-tenants.
+   *
+   * Default: 2 — double the 1-vCPU/agent budget the capacity math is sized
+   * around (DEFAULT_AGENT_VCPU_BUDGET), so a healthy agent can still burst
+   * while a runaway one cannot monopolize a 12-core robot. 0 disables the
+   * ceiling. Clamped to [0, 64]; fractional values are kept.
+   */
+  agentContainerCpuLimit(): number {
+    const env = getCloudAwareEnv();
+    const raw = pick(env.CONTAINERS_AGENT_CPU_LIMIT, env.ELIZA_AGENT_CPU_LIMIT);
+    const parsed = raw ? Number(raw) : Number.NaN;
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      return Math.min(64, parsed);
+    }
+    return 2;
+  },
+
   /** Explicit operator-pinned agent image, without the hardcoded fallback. */
   defaultAgentImageOverride(): string | undefined {
     const env = getCloudAwareEnv();

--- a/packages/cloud/shared/src/lib/services/__tests__/agent-container-security.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/agent-container-security.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  agentCpuUnitsToDockerCpus,
   buildAgentContainerCpuFlags,
   buildAgentContainerMemoryFlags,
   buildAgentContainerSecurityFlags,
@@ -100,5 +101,19 @@ describe("buildAgentContainerCpuFlags — per-agent CPU containment for robot de
     expect(buildAgentContainerCpuFlags(undefined)).toEqual([]);
     expect(buildAgentContainerCpuFlags(-1)).toEqual([]);
     expect(buildAgentContainerCpuFlags(Number.NaN)).toEqual([]);
+  });
+});
+
+describe("agentCpuUnitsToDockerCpus", () => {
+  test("converts the persisted ECS-style unit contract before building Docker flags", () => {
+    expect(agentCpuUnitsToDockerCpus(512)).toBe(0.5);
+    expect(agentCpuUnitsToDockerCpus(1024)).toBe(1);
+    expect(buildAgentContainerCpuFlags(agentCpuUnitsToDockerCpus(2048))).toEqual(["--cpus '2'"]);
+  });
+
+  test("rejects invalid unit values", () => {
+    expect(agentCpuUnitsToDockerCpus(undefined)).toBeUndefined();
+    expect(agentCpuUnitsToDockerCpus(0)).toBeUndefined();
+    expect(agentCpuUnitsToDockerCpus(Number.NaN)).toBeUndefined();
   });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/agent-container-security.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/agent-container-security.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  buildAgentContainerCpuFlags,
   buildAgentContainerMemoryFlags,
   buildAgentContainerSecurityFlags,
 } from "../agent-container-security";
@@ -78,5 +79,26 @@ describe("buildAgentContainerMemoryFlags — per-agent OOM containment (staging 
     expect(buildAgentContainerMemoryFlags(undefined)).toEqual([]);
     expect(buildAgentContainerMemoryFlags(-512)).toEqual([]);
     expect(buildAgentContainerMemoryFlags(Number.NaN)).toEqual([]);
+  });
+});
+
+describe("buildAgentContainerCpuFlags — per-agent CPU containment for robot density (#18485)", () => {
+  test("emits a quoted --cpus quota for a positive limit", () => {
+    expect(buildAgentContainerCpuFlags(2)).toEqual(["--cpus '2'"]);
+  });
+
+  test("keeps fractional cores to two decimals — valid docker input, no float noise", () => {
+    expect(buildAgentContainerCpuFlags(1.5)).toEqual(["--cpus '1.5'"]);
+    expect(buildAgentContainerCpuFlags(0.333333)).toEqual(["--cpus '0.33'"]);
+  });
+
+  test("0 disables the quota entirely (no flags — the explicit opt-out)", () => {
+    expect(buildAgentContainerCpuFlags(0)).toEqual([]);
+  });
+
+  test("undefined / negative / NaN emit no flags rather than a garbage docker arg", () => {
+    expect(buildAgentContainerCpuFlags(undefined)).toEqual([]);
+    expect(buildAgentContainerCpuFlags(-1)).toEqual([]);
+    expect(buildAgentContainerCpuFlags(Number.NaN)).toEqual([]);
   });
 });

--- a/packages/cloud/shared/src/lib/services/agent-container-security.ts
+++ b/packages/cloud/shared/src/lib/services/agent-container-security.ts
@@ -78,3 +78,9 @@ export function buildAgentContainerCpuFlags(cpus: number | undefined): string[] 
   const value = Math.round(cpus * 100) / 100;
   return [`--cpus ${shellQuote(String(value))}`];
 }
+
+/** Converts the persisted ECS-style CPU unit contract to Docker vCPUs. */
+export function agentCpuUnitsToDockerCpus(cpuUnits: number | undefined): number | undefined {
+  if (!cpuUnits || !Number.isFinite(cpuUnits) || cpuUnits <= 0) return undefined;
+  return cpuUnits / 1024;
+}

--- a/packages/cloud/shared/src/lib/services/agent-container-security.ts
+++ b/packages/cloud/shared/src/lib/services/agent-container-security.ts
@@ -58,3 +58,23 @@ export function buildAgentContainerMemoryFlags(memoryMb: number | undefined): st
   const mb = Math.ceil(memoryMb);
   return [`--memory ${shellQuote(`${mb}m`)}`, `--memory-swap ${shellQuote(`${mb}m`)}`];
 }
+
+/**
+ * Ordered `docker create` CPU flags for a hosted-agent container.
+ *
+ * The `--cpus` analog of {@link buildAgentContainerMemoryFlags} (#18485): agent
+ * containers carry no CPU ceiling, so one runaway agent can monopolize every
+ * core of a shared box. That was survivable on 4-vCPU cloud nodes holding 2-3
+ * agents; robot-first placement packs many more agents per 12-vCPU robot, so a
+ * per-agent CPU ceiling is what makes that density safe. `--cpus` is a hard
+ * cgroup quota, throttling — never killing — the container.
+ *
+ * `cpus <= 0` (or non-finite) disables the ceiling and emits no flags — the
+ * historical behavior, selectable via CONTAINERS_AGENT_CPU_LIMIT=0. Fractional
+ * values are valid docker input and are kept to two decimals.
+ */
+export function buildAgentContainerCpuFlags(cpus: number | undefined): string[] {
+  if (!cpus || !Number.isFinite(cpus) || cpus <= 0) return [];
+  const value = Math.round(cpus * 100) / 100;
+  return [`--cpus ${shellQuote(String(value))}`];
+}

--- a/packages/cloud/shared/src/lib/services/docker-node-manager-robot-first.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager-robot-first.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Robot-first placement tests (#18485).
+ *
+ * The drift these pin, measured on prod 2026-08-12: dedicated agents overflow
+ * onto autoscaled Hetzner Cloud CCX33s at ~€35/agent-slot/mo while
+ * hand-registered robot boxes carry the identical workload at ~€3-4.5/slot,
+ * because getAvailableNode sorted on free slots alone and a freshly bought
+ * cloud node always looks emptiest. These tests drive the REAL manager with a
+ * stubbed SSH client + repository (same harness as the memory-admission
+ * tests), plus pure-function coverage of the fleet classifier and comparator.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as realDockerNodesNs from "../../db/repositories/docker-nodes";
+import type { DockerNode } from "../../db/schemas/docker-nodes";
+import * as realLoggerNs from "../utils/logger";
+import * as realDockerNodeWorkloadsNs from "./docker-node-workloads";
+import * as realDockerSshNs from "./docker-ssh";
+
+const realDockerNodes = { ...realDockerNodesNs };
+const realDockerNodeWorkloads = { ...realDockerNodeWorkloadsNs };
+const realDockerSsh = { ...realDockerSshNs };
+const realLogger = { ...realLoggerNs };
+
+let enabledNodes: DockerNode[] = [];
+let allocatedByNodeId: Record<string, number> = {};
+
+mock.module("../utils/logger", () => ({
+  ...realLogger,
+  logger: { info: () => {}, debug: () => {}, error: () => {}, warn: () => {} },
+}));
+
+mock.module("../../db/repositories/docker-nodes", () => ({
+  dockerNodesRepository: {
+    findEnabled: () => Promise.resolve(enabledNodes),
+    findPlaceable: () => Promise.resolve(enabledNodes),
+    updateStatus: () => Promise.resolve(),
+    setHostKeyFingerprint: () => Promise.resolve(),
+  },
+}));
+
+mock.module("./docker-node-workloads", () => ({
+  countAllocatedWorkloadsOnNode: (nodeId: string) =>
+    Promise.resolve(allocatedByNodeId[nodeId] ?? 0),
+}));
+
+/** Alive, not IO-starved: readiness passes so only ordering is under test. */
+const HEALTHY_PROBE = [
+  "GH4Y:2NWO:testdockerid|x86_64",
+  "---IO-PRESSURE---",
+  "some avg10=1.02 avg60=0.98 avg300=1.11 total=499893023295",
+  "full avg10=0.87 avg60=0.79 avg300=0.81 total=457451749125",
+].join("\n");
+
+mock.module("./docker-ssh", () => ({
+  DockerSSHClient: {
+    getClient: () => ({
+      connect: () => Promise.resolve(),
+      exec: () => Promise.resolve(HEALTHY_PROBE),
+    }),
+  },
+}));
+
+afterAll(() => {
+  mock.module("../../db/repositories/docker-nodes", () => realDockerNodes);
+  mock.module("./docker-node-workloads", () => realDockerNodeWorkloads);
+  mock.module("./docker-ssh", () => realDockerSsh);
+  mock.module("../utils/logger", () => realLogger);
+});
+
+import {
+  comparePlacementCandidates,
+  DockerNodeManager,
+  isRobotFleetNode,
+} from "./docker-node-manager";
+
+function node(nodeId: string, metadata: Record<string, unknown>, capacity = 4): DockerNode {
+  return {
+    id: `${nodeId}-uuid`,
+    node_id: nodeId,
+    hostname: `${nodeId}.example`,
+    ssh_port: 22,
+    capacity,
+    enabled: true,
+    status: "healthy",
+    allocated_count: 0,
+    last_health_check: null,
+    ssh_user: "root",
+    host_key_fingerprint: "SHA256:test",
+    metadata,
+    created_at: new Date("2026-01-01T00:00:00.000Z"),
+    updated_at: new Date("2026-01-01T00:00:00.000Z"),
+  };
+}
+
+const AUTOSCALED_META = {
+  provider: "hetzner-cloud",
+  autoscaled: true,
+  location: "fsn1",
+};
+
+beforeEach(() => {
+  enabledNodes = [];
+  allocatedByNodeId = {};
+});
+
+describe("isRobotFleetNode", () => {
+  test("explicit metadata.fleet wins in both directions", () => {
+    expect(isRobotFleetNode(node("r", { fleet: "robot", location: "fsn1" }))).toBe(true);
+    expect(isRobotFleetNode(node("c", { fleet: "cloud" }))).toBe(false);
+  });
+
+  test("autoscaled cloud nodes are never robot", () => {
+    expect(isRobotFleetNode(node("c", AUTOSCALED_META))).toBe(false);
+  });
+
+  test("a location string marks cloud even without the autoscaled flag", () => {
+    expect(isRobotFleetNode(node("c", { location: "nbg1" }))).toBe(false);
+  });
+
+  test("hand-registered nodes with neither marker are robot", () => {
+    expect(isRobotFleetNode(node("r", {}))).toBe(true);
+  });
+});
+
+describe("comparePlacementCandidates", () => {
+  const robot = (id: string, available: number) => ({ node: node(id, {}), available });
+  const cloud = (id: string, available: number) => ({
+    node: node(id, AUTOSCALED_META),
+    available,
+  });
+
+  test("a robot with fewer free slots outranks a cloud node with more", () => {
+    const sorted = [cloud("cloud-1", 7), robot("robot-1", 1)].sort(comparePlacementCandidates);
+    expect(sorted.map((c) => c.node.node_id)).toEqual(["robot-1", "cloud-1"]);
+  });
+
+  test("within a fleet the least-loaded (most free slots) node still wins", () => {
+    const sorted = [
+      robot("robot-tight", 1),
+      cloud("cloud-tight", 2),
+      robot("robot-roomy", 5),
+      cloud("cloud-roomy", 6),
+    ].sort(comparePlacementCandidates);
+    expect(sorted.map((c) => c.node.node_id)).toEqual([
+      "robot-roomy",
+      "robot-tight",
+      "cloud-roomy",
+      "cloud-tight",
+    ]);
+  });
+
+  test("equal fleet and equal availability compare as equal (stable order)", () => {
+    expect(comparePlacementCandidates(robot("a", 3), robot("b", 3))).toBe(0);
+  });
+});
+
+describe("getAvailableNode robot-first selection", () => {
+  test("prefers a nearly-full robot over an empty autoscaled cloud node", async () => {
+    const robot = node("eliza-prod-robot-2", { fleet: "robot" }, 11);
+    const cloud = node("eliza-core-autoscaled", AUTOSCALED_META, 8);
+    enabledNodes = [cloud, robot];
+    allocatedByNodeId = { "eliza-prod-robot-2": 10, "eliza-core-autoscaled": 0 };
+
+    const selected = await DockerNodeManager.getInstance().getAvailableNode();
+
+    expect(selected?.node_id).toBe("eliza-prod-robot-2");
+  });
+
+  test("falls back to cloud only when every robot is full", async () => {
+    const robot = node("eliza-prod-robot-3", {}, 4);
+    const cloud = node("eliza-core-autoscaled", AUTOSCALED_META, 8);
+    enabledNodes = [robot, cloud];
+    allocatedByNodeId = { "eliza-prod-robot-3": 4, "eliza-core-autoscaled": 2 };
+
+    const selected = await DockerNodeManager.getInstance().getAvailableNode();
+
+    expect(selected?.node_id).toBe("eliza-core-autoscaled");
+  });
+
+  test("keeps excludeNodeId semantics across fleets", async () => {
+    const robotA = node("robot-a", {}, 4);
+    const robotB = node("robot-b", {}, 4);
+    enabledNodes = [robotA, robotB];
+    allocatedByNodeId = { "robot-a": 0, "robot-b": 3 };
+
+    const selected = await DockerNodeManager.getInstance().getAvailableNode({
+      excludeNodeId: "robot-a",
+    });
+
+    expect(selected?.node_id).toBe("robot-b");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.ts
@@ -550,6 +550,44 @@ function isAutoscaledNode(node: DockerNode): boolean {
   return meta.provider === "hetzner-cloud" && meta.autoscaled === true;
 }
 
+/**
+ * Whether a node belongs to the hand-registered robot (auction/dedicated)
+ * fleet rather than the autoscaled cloud fleet.
+ *
+ * Explicit `metadata.fleet` wins when present ("robot" vs anything else).
+ * Otherwise the discriminator is the one the scheduler already relies on
+ * (hetzner-client/scheduling.ts findNodeInLocation): only Cloud-provisioned
+ * nodes carry `metadata.location`, so an autoscaled flag or a location string
+ * marks cloud, and a hand-registered node without either is robot.
+ */
+export function isRobotFleetNode(node: DockerNode): boolean {
+  const meta = node.metadata as Record<string, unknown> | null | undefined;
+  if (meta && typeof meta === "object") {
+    if (typeof meta.fleet === "string") return meta.fleet === "robot";
+    if (isAutoscaledNode(node)) return false;
+    if (typeof meta.location === "string" && meta.location.length > 0) return false;
+  }
+  return true;
+}
+
+/**
+ * Placement ordering (#18485): robot slots cost ~€3-4.5/agent/mo against
+ * ~€35/agent/mo on autoscaled cloud, and the workload is identical on both, so
+ * every dedicated agent placed on cloud while a robot has a real free slot is
+ * pure drift. Robot-fleet candidates come first; within a fleet the existing
+ * least-loaded order (most free slots first) is preserved, which also serves
+ * as the tie-break between equal fleets.
+ */
+export function comparePlacementCandidates(
+  a: { node: DockerNode; available: number },
+  b: { node: DockerNode; available: number },
+): number {
+  const fleetRankA = isRobotFleetNode(a.node) ? 0 : 1;
+  const fleetRankB = isRobotFleetNode(b.node) ? 0 : 1;
+  if (fleetRankA !== fleetRankB) return fleetRankA - fleetRankB;
+  return b.available - a.available;
+}
+
 function prePullPidFile(marker: string): string {
   return `${PREPULL_PID_DIR}/eliza-prepull-${marker}.pid`;
 }
@@ -632,7 +670,10 @@ export class DockerNodeManager {
   // ---- Node Selection ---------------------------------------------------
 
   /**
-   * Find the least-loaded healthy node with available capacity.
+   * Find the best healthy node with available capacity: robot-fleet nodes
+   * first (see {@link comparePlacementCandidates}), least-loaded within a
+   * fleet. Sticky-volume pinning and location matching happen in the callers
+   * (hetzner-client/scheduling.ts) before this fallback is consulted.
    * Returns null if no capacity is available.
    */
   async getAvailableNode(options: NodeSelectionOptions = {}): Promise<DockerNode | null> {
@@ -652,7 +693,7 @@ export class DockerNodeManager {
     )
       .filter((candidate) => candidate.available > 0)
       .filter((candidate) => candidate.node.node_id !== options.excludeNodeId)
-      .sort((a, b) => b.available - a.available);
+      .sort(comparePlacementCandidates);
 
     const compatibleCandidates = candidates.filter((candidate) => {
       if (isNodeMetadataCompatible(candidate.node, options.requiredPlatform)) {

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -23,6 +23,7 @@ import { resolveServerStewardApiUrlFromEnv } from "../steward-url";
 import { logger } from "../utils/logger";
 import { withTimeout } from "../utils/with-timeout";
 import {
+  buildAgentContainerCpuFlags,
   buildAgentContainerMemoryFlags,
   buildAgentContainerSecurityFlags,
 } from "./agent-container-security";
@@ -1498,6 +1499,14 @@ export class DockerSandboxProvider implements SandboxProvider {
         // env-tunable fleet default applies so a boot-looping agent can never
         // OOM-starve its co-tenants again (staging fleet incident 2026-08-05).
         ...buildAgentContainerMemoryFlags(containerMemoryMb),
+        // Per-container CPU quota (see buildAgentContainerCpuFlags, #18485):
+        // an explicit per-agent `container.cpu` wins; otherwise the
+        // env-tunable fleet default applies so robot-density placement stays
+        // safe — a busy-looping agent is throttled inside its own cgroup
+        // instead of starving every co-tenant on a shared robot box.
+        ...buildAgentContainerCpuFlags(
+          config.container?.cpu ?? containersEnv.agentContainerCpuLimit(),
+        ),
         // Escape-hardening (#12230/#12302): drop ALL kernel capabilities, forbid
         // privilege escalation, and bound the process count — then, under
         // headscale only, re-add exactly NET_ADMIN + /dev/net/tun for the VPN.

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -23,6 +23,7 @@ import { resolveServerStewardApiUrlFromEnv } from "../steward-url";
 import { logger } from "../utils/logger";
 import { withTimeout } from "../utils/with-timeout";
 import {
+  agentCpuUnitsToDockerCpus,
   buildAgentContainerCpuFlags,
   buildAgentContainerMemoryFlags,
   buildAgentContainerSecurityFlags,
@@ -1505,7 +1506,9 @@ export class DockerSandboxProvider implements SandboxProvider {
         // safe — a busy-looping agent is throttled inside its own cgroup
         // instead of starving every co-tenant on a shared robot box.
         ...buildAgentContainerCpuFlags(
-          config.container?.cpu ?? containersEnv.agentContainerCpuLimit(),
+          config.container?.cpu !== undefined
+            ? agentCpuUnitsToDockerCpus(config.container.cpu)
+            : containersEnv.agentContainerCpuLimit(),
         ),
         // Escape-hardening (#12230/#12302): drop ALL kernel capabilities, forbid
         // privilege escalation, and bound the process count — then, under

--- a/packages/cloud/shared/src/lib/services/sandbox-provider-types.ts
+++ b/packages/cloud/shared/src/lib/services/sandbox-provider-types.ts
@@ -133,6 +133,7 @@ export interface SandboxHandle {
 export interface SandboxContainerLaunchConfig {
   projectName?: string;
   port?: number;
+  /** ECS-style CPU units; 1024 units equal one vCPU. */
   cpu?: number;
   memoryMb?: number;
   desiredCount?: number;


### PR DESCRIPTION
Fixes #18485

## What

- **Robot-first placement** in `DockerNodeManager.getAvailableNode` (`packages/cloud/shared/src/lib/services/docker-node-manager.ts`): candidates are now ranked by a new `comparePlacementCandidates` — robot-fleet nodes (`metadata.fleet === "robot"`, or hand-registered nodes lacking both the autoscaled marker and a `metadata.location` string, the same discriminator `hetzner-client/scheduling.ts` already relies on) win over autoscaled cloud nodes whenever a real free slot exists; within a fleet the existing least-loaded (most-free-slots) ordering is preserved, and it is also the cross-fleet tie-break. Sticky-volume pinning and location matching live in the callers and are untouched.
- **`--cpus` analog of the #17795 memory cap** at the same seam: `buildAgentContainerCpuFlags` in `agent-container-security.ts`, wired into `docker-sandbox-provider.ts` container creation, defaulting from new `containersEnv.agentContainerCpuLimit()` (`CONTAINERS_AGENT_CPU_LIMIT` / `ELIZA_AGENT_CPU_LIMIT`, default 2 fractional cores, `0` disables). This makes robot density safe: a busy-looping agent throttles in its own cgroup instead of monopolizing a 12-vCPU robot.

## Explicitly left to ops (for the fleet owner)

Per the issue triage these are receipts, not this PR's ask:
- draining the leaked/overflow cloud rows already provisioned (seventh autoscaled node etc.)
- warm-pool gating and the autoscale capacity raise
- registering `eliza-staging-robot-1` (and role/tier/environment columns — claimed separately on the issue)
- the procurement runbook

## Tests

- `bun test src/lib/services/docker-node-manager-robot-first.test.ts` — 10 pass: classifier direction tests, comparator sort order + tie-breaks, and real-`DockerNodeManager` selection through the stubbed SSH/repository harness (nearly-full robot beats empty cloud node; falls back to cloud only when robots are full; `excludeNodeId` preserved).
- `bun test src/lib/services/__tests__/agent-container-security.test.ts` — 13 pass (incl. new `--cpus` quota flag cases: positive, fractional rounding, 0-disables, garbage inputs emit nothing).
- Independent review fixed the persisted CPU-unit boundary: agent `container.cpu` uses ECS units (1024 = 1 vCPU), which are now converted before Docker `--cpus`; regression coverage pins 512 = 0.5 vCPU and 2048 = 2 vCPU.
- Adjacent regression lanes: `docker-node-manager-memory-admission`, `placement-breaker`, `placement-state`, `capacity-derivation`, `docker-sandbox-placement-fallback`, `app-docker-cmd` — 66 pass, 0 fail.
- `bun run typecheck` in `packages/cloud/shared` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:5a119eee2e5075b76bbc8f403921f1a07d4b0a32 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Backend placement and container resource-control change; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Backend placement and container resource-control change; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No interactive flow; real node-manager and Docker command tests exercise the behavior.

<!-- evidence-row:backend-logs -->
- [ ] N/A - Exact-head deterministic placement, quota, and adjacent regression suites provide execution proof.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend behavior changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No model, prompt, or planner behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No live fleet mutation was authorized; placement decisions and Docker flags are contract-tested.

<!-- evidence-row:ocr-review -->
- [ ] N/A - No rendered visual surface.


