### PR TITLE
fix(ci): remove dead generate:llms call from legacy cloud VPS deploy

### DIFF
--- a/.github/workflows/cloud-deploy-backend.yml
+++ b/.github/workflows/cloud-deploy-backend.yml
@@ -304,7 +304,7 @@ jobs:
             git fetch origin "$BRANCH"
             git checkout -B "$BRANCH" "origin/$BRANCH"
 
-            # Install runtime dependencies and regenerate lightweight assets.
+            # Install runtime dependencies.
             if ! command -v bun >/dev/null 2>&1 || [ "$(bun --version)" != "1.3.14" ]; then
               curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
               export PATH="$BUN_INSTALL/bin:$PATH"
@@ -322,8 +322,18 @@ jobs:
               sleep 10
             done
 
-            bun run generate:llms
-
+            # `bun run generate:llms` used to run here, regenerating
+            # llms.txt/llms-full.txt for the Next.js cloud-frontend docs
+            # pages. #9093 (consolidate cloud-frontend into @elizaos/ui,
+            # delete cloud-frontend) deleted that app and the package.json
+            # script behind it but missed this call site, so the step has
+            # hard-failed (`error: Script not found "generate:llms"`) under
+            # `set -e` any time this legacy opt-in job actually ran. The
+            # artifact has no remaining consumer either: docs.elizacloud.ai
+            # is now a stateless 301 redirect to docs.elizaos.ai
+            # (packages/cloud/docs-redirect), which publishes its own
+            # llms-full.txt independently. Removed rather than re-wired.
+            #
             # The build now runs on GitHub Actions to avoid ENOSPC during
             # `next build` on the VPS. Clear any stale output and leave an empty
             # destination for the streamed artifact.


### PR DESCRIPTION
# Relates to

Closes #19919. `bun run generate:llms` at `.github/workflows/cloud-deploy-backend.yml:325` has no backing `package.json` script anywhere in the repo — it hard-fails the manual, opt-in legacy VPS deploy job (`workflow_dispatch` input `deploy_legacy_vps`, default `false`) any time it's actually dispatched. Root cause: #9093 deleted `packages/cloud-frontend` (and its `generate:llms` script) but missed this one call site, despite that PR's own description claiming it "cleaned all CI/config/script references" in this file.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused verification run locally (see Testing); full `bun run verify` left to PR CI as this change touches only one workflow YAML file.

# Risks

**Trivial, isolated to a single manual/opt-in CI workflow.** The diff is a
one-line removal (`bun run generate:llms`) plus a breadcrumb comment in
`.github/workflows/cloud-deploy-backend.yml`, and a one-word comment edit
directly above it. No package.json, no production code path, no other step
in the job touched. The job this step lives in only runs when someone
explicitly dispatches this workflow with `deploy_legacy_vps: true` — it does
not run on any push, PR, or scheduled trigger.

# Background

## What does this PR do?

Removes the dead `bun run generate:llms` call from the legacy VPS deploy
job's `Prepare VPS checkout` step.

**The mechanism this closes:** `generate:llms` used to regenerate
`llms.txt`/`llms-full.txt` for the old Next.js `packages/cloud-frontend`
docs pages. #9093 deleted `cloud-frontend` and the `package.json` script
behind it; no `package.json` in the repo defines `generate:llms` today, so
this line has failed with `error: Script not found "generate:llms"` under
`set -e` any time this opt-in job actually ran since that merge. Re-wiring
it is not the right fix: the target script,
`packages/cloud/scripts/admin/generate-llms-txt.ts`, still hard-codes
`packages/content` and `apps/frontend/public` as its roots, and neither
directory exists anywhere in this repo (both belonged to the deleted
`cloud-frontend` app). The artifact is also unconsumed: `docs.elizacloud.ai`
is now a stateless redirect Worker to `docs.elizaos.ai`
(`packages/cloud/docs-redirect`), and the live docs site publishes its own
`llms-full.txt` independently (`packages/docs/docs.json`). The one
component that looks like a consumer, `LlmsTxtBadge`, is exported but never
rendered anywhere in the repo. Removed rather than re-wired.

## What kind of change is this?

Bug fix (non-breaking) — a broken step in a manual, opt-in CI workflow, not
a change to any production code path.

# Documentation changes needed?

None; the removed comment line was itself the only documentation of this
step's intent, and it's replaced by a more accurate one explaining the
removal.

# Testing

## Where should a reviewer start?

```bash
bun run generate:llms
node packages/scripts/audit-scripts.mjs
```

## Detailed testing steps

1. `bun run generate:llms` on the unmodified base (`origin/develop`,
   `f4e115a08641164224f8699cf05254c6109f59d9`) reproduces the defect this PR
   fixes: `error: Script not found "generate:llms"`, exit 1 (transcript
   below). Nothing about this PR's diff changes that command's own
   behavior — the fix removes the call site, not the underlying absence of
   the script.
2. `git diff` on this head confirms the one-line removal, the breadcrumb
   comment, and the one-word comment edit are the entire change (transcript
   below).
3. A YAML parse of the edited workflow (via the repo's own `yaml` package)
   confirms the file still parses, the `deploy` job and its steps are
   intact, and the `Prepare VPS checkout` step's script no longer contains
   an executable `bun run generate:llms` line (transcript below).
4. `node packages/scripts/audit-scripts.mjs` — exit 0, unaffected (this
   gate covers `package.json` scripts, not workflow YAML, but confirms the
   change didn't orphan or break any script wiring).

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:ae50ca930bf395e45752c4bcd16a60c61ae8eec3 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots — `N/A - CI workflow YAML change; no rendered UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots — `N/A - same reason as the before row.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough — `N/A - no user-facing flow; the change is a CI step removal.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs — `N/A - no server runs; the job this step lives in is manual/opt-in and out of scope to dispatch for this PR.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs — `N/A - no frontend code runs.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory — `N/A - no agent, action, provider, prompt, or model behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the defect reproduction, the diff, and the
      post-change YAML/step-content check, all captured on this exact head:

<details>
<summary>1. bun run generate:llms — reproduces the defect on this head (script absence is unchanged by this PR)</summary>

```
$ bun run generate:llms
error: Script not found "generate:llms"
EXIT CODE: 1
```
</details>

<details>
<summary>2. git diff — the entire change</summary>

```diff
--- a/.github/workflows/cloud-deploy-backend.yml
+++ b/.github/workflows/cloud-deploy-backend.yml
@@ -304,7 +304,7 @@ jobs:
             git fetch origin "$BRANCH"
             git checkout -B "$BRANCH" "origin/$BRANCH"
 
-            # Install runtime dependencies and regenerate lightweight assets.
+            # Install runtime dependencies.
             if ! command -v bun >/dev/null 2>&1 || [ "$(bun --version)" != "1.3.14" ]; then
               curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
               export PATH="$BUN_INSTALL/bin:$PATH"
@@ -322,8 +322,18 @@ jobs:
               sleep 10
             done
 
-            bun run generate:llms
-
+            # `bun run generate:llms` used to run here, regenerating
+            # llms.txt/llms-full.txt for the Next.js cloud-frontend docs
+            # pages. #9093 (consolidate cloud-frontend into @elizaos/ui,
+            # delete cloud-frontend) deleted that app and the package.json
+            # script behind it but missed this call site, so the step has
+            # hard-failed (`error: Script not found "generate:llms"`) under
+            # `set -e` any time this legacy opt-in job actually ran. The
+            # artifact has no remaining consumer either: docs.elizacloud.ai
+            # is now a stateless 301 redirect to docs.elizaos.ai
+            # (packages/cloud/docs-redirect), which publishes its own
+            # llms-full.txt independently. Removed rather than re-wired.
+            #
             # The build now runs on GitHub Actions to avoid ENOSPC during
             # `next build` on the VPS. Clear any stale output and leave an empty
             # destination for the streamed artifact.
```
</details>

<details>
<summary>3. Post-change YAML parse + step-content check</summary>

```
YAML parse: OK
jobs: [ 'determine-env', 'migrate-db', 'deploy' ]
executable `bun run generate:llms` line present? false
comment mentioning it for context present? true
bun install still present? true
next-build mkdir still present? true
```
</details>

<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review — `N/A - no rendered visual surface in the diff.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent, action, provider, prompt, or model behavior changes.`

## Backend + frontend logs

`N/A - no live deployment in scope; the job this step lives in is manual/
opt-in (workflow_dispatch, deploy_legacy_vps default false) and dispatching
it is outside this PR's scope. The command-level transcript above is the
executable proof of both the defect and the fix.`

## Screenshots (before / after) + video walkthrough

`N/A - no rendered UI surface in the diff.`

## Audio / voice walkthrough

`N/A - no voice path is touched.`

## Known gaps / failures

- **Full `bun run verify` was not run locally on this head.** The change is
  a single-line removal plus comments in one workflow YAML file with no
  package.json, source, or test surface touched; the proportional local
  evidence is the defect reproduction, the full diff, and the YAML/step
  validation above, all run end to end on this exact head. `node
  packages/scripts/audit-scripts.mjs` (unaffected but relevant to CI
  script-wiring integrity) also passed locally, exit 0. If any CI lane reds,
  I will fix or record it here.
- This PR does not attempt to repair the legacy VPS deploy job beyond the
  verified `generate:llms` defect. In the course of investigating this
  issue, the `Upload prebuilt Next output` step later in the same job
  appears to reference a `.next-build` directory that nothing in this job
  populates on the GitHub Actions runner (no `next build` step exists
  anywhere in this workflow) — a second, separate defect in the same
  opt-in job. Left out of scope here to keep this fix to the one verified,
  proven defect; flagging for a follow-up issue.

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Attribution status: self-reported
— [nxn-claude-code]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->
