### PR TITLE
test(cloud): prove concurrent verified-phone linking

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/users-promote-phone-personal-account.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/users-promote-phone-personal-account.test.ts
@@ -24,6 +24,33 @@ import { usersRepository } from "../users";
 
 const PGLITE_TIMEOUT = 120_000;
 
+function createStartBarrier(participantCount: number): {
+  arrive: () => Promise<void>;
+  releaseWhenReady: () => Promise<void>;
+} {
+  let release!: () => void;
+  const released = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let signalReady!: () => void;
+  const allReady = new Promise<void>((resolve) => {
+    signalReady = resolve;
+  });
+  let readyCount = 0;
+
+  return {
+    arrive: async () => {
+      readyCount += 1;
+      if (readyCount === participantCount) signalReady();
+      await released;
+    },
+    releaseWhenReady: async () => {
+      await allReady;
+      release();
+    },
+  };
+}
+
 describe("UsersRepository phone identity transactions (real PGlite)", () => {
   let pgliteReady = true;
   let sequence = 0;
@@ -314,6 +341,71 @@ describe("UsersRepository phone identity transactions (real PGlite)", () => {
       phone_number: phoneNumber,
       phone_verified: true,
     });
+  });
+
+  test("converges simultaneous first links for one mature account without duplicating ownership", async () => {
+    const phoneNumber = "+14155550217";
+    const mature = await createMatureUser();
+    const barrier = createStartBarrier(2);
+    const linkFromBarrier = async () => {
+      await barrier.arrive();
+      return usersRepository.linkVerifiedPhone(mature.user.id, phoneNumber);
+    };
+
+    const first = linkFromBarrier();
+    const second = linkFromBarrier();
+    await barrier.releaseWhenReady();
+    const linked = await Promise.all([first, second]);
+
+    expect(linked.map((user) => user?.id)).toEqual([mature.user.id, mature.user.id]);
+    expect(await dbWrite.select().from(users)).toHaveLength(1);
+    expect(await dbWrite.select().from(userIdentities)).toHaveLength(1);
+    const [organization] = await dbWrite.select().from(organizations);
+    expect(organization?.id).toBe(mature.organization.id);
+    expect(await usersRepository.findByPhoneNumberWithOrganization(phoneNumber)).toMatchObject({
+      id: mature.user.id,
+      organization_id: mature.organization.id,
+      phone_number: phoneNumber,
+      phone_verified: true,
+      organization: { id: mature.organization.id },
+    });
+  });
+
+  test("allows exactly one simultaneous claimant and rolls the loser back completely", async () => {
+    const phoneNumber = "+14155550218";
+    const firstClaimant = await createMatureUser();
+    const secondClaimant = await createMatureUser();
+    const barrier = createStartBarrier(2);
+    const linkFromBarrier = async (userId: string) => {
+      await barrier.arrive();
+      return usersRepository.linkVerifiedPhone(userId, phoneNumber);
+    };
+
+    const first = linkFromBarrier(firstClaimant.user.id);
+    const second = linkFromBarrier(secondClaimant.user.id);
+    await barrier.releaseWhenReady();
+    const results = await Promise.allSettled([first, second]);
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    expect(results.filter((result) => result.status === "rejected")).toHaveLength(1);
+    const owner = await usersRepository.findByPhoneNumberWithOrganization(phoneNumber);
+    expect([firstClaimant.user.id, secondClaimant.user.id]).toContain(owner?.id);
+    const loser = owner?.id === firstClaimant.user.id ? secondClaimant : firstClaimant;
+    const [loserCanonical] = await dbWrite.select().from(users).where(eq(users.id, loser.user.id));
+    const [loserProjection] = await dbWrite
+      .select()
+      .from(userIdentities)
+      .where(eq(userIdentities.user_id, loser.user.id));
+    expect(loserCanonical).toMatchObject({ phone_number: null, phone_verified: false });
+    expect(loserProjection).toMatchObject({ phone_number: null, phone_verified: false });
+    expect(await dbWrite.select().from(users)).toHaveLength(2);
+    expect(await dbWrite.select().from(userIdentities)).toHaveLength(2);
+    expect(await dbWrite.select().from(organizations)).toHaveLength(2);
+    expect(owner?.organization?.id).toBe(
+      owner?.id === firstClaimant.user.id
+        ? firstClaimant.organization.id
+        : secondClaimant.organization.id,
+    );
   });
 
   test("repairs a missing mature-account projection while linking its verified phone", async () => {


### PR DESCRIPTION
Fixes #19365. Follow-up to #19838.

## Why

#19838 corrected the verified-phone sync ordering, but it merged after an explicit review block without the issue's concurrent first-link proof. This PR completes that acceptance contract without changing production code.

## What changed

- adds a reusable two-participant start barrier to the real-PGlite phone-identity repository suite;
- proves two simultaneous first links for the same established user both converge onto the existing canonical user, organization, and single identity projection;
- proves two simultaneous different-user claims produce exactly one owner while the losing transaction leaves both its canonical row and identity projection untouched.

These cases pin the transaction and unique-constraint boundary against a future check-then-write regression.

## Verification

Exact head: `b495b75e61f361463c520f75f0db3c2a3c6f79b4`

- real PGlite repository suite: 16 pass / 0 fail / 81 assertions;
- existing Steward sync decision suite: 9 pass / 0 fail / 38 assertions;
- `@elizaos/cloud-shared` typecheck: pass;
- changed-file Biome and `git diff --check`: pass.

The two suites must run in separate Bun processes because the sync suite intentionally replaces the users repository with a module mock; combining it with the real repository suite in one global module registry is not a valid harness.

<!-- evidence-head:99d7f709de22da0c2a8dc41d33050471e6341818 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Test-only backend concurrency proof; no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - Test-only backend concurrency proof; no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No user-facing interaction changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - The exact-head real-PGlite suite directly asserts committed rows and rollback behavior.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend code or runtime changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No model, prompt, provider, or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - The database rows are transient test state and are asserted directly by the real-PGlite suite.
<!-- evidence-row:ocr-review -->
- [ ] N/A - No rendered text changed.

## Contribution provenance

- AI assistance: yes
- AI provider/model: OpenAI / GPT-5 family (exact serving variant not exposed to this session)
- Client / agent tooling: Codex Desktop
- Contribution skill: N/A - no contribution skill was available in this session
- Attribution status: self-reported

