### PR TITLE
test(app): align launcher smoke with managed Cloud boundary

### DIFF
--- a/packages/app/test/ui-smoke/launcher-cloud-gating.spec.ts
+++ b/packages/app/test/ui-smoke/launcher-cloud-gating.spec.ts
@@ -7,7 +7,6 @@ import { expect, type Page, type TestInfo, test } from "@playwright/test";
 import {
   installDefaultAppRoutes,
   openAppPath,
-  openSettingsSection,
   seedAppStorage,
 } from "./helpers";
 import { captureScreenshotWithQualityRetry } from "./helpers/screenshot-quality";
@@ -36,9 +35,9 @@ import { saveBrowserVideoArtifact } from "./helpers/video-artifacts";
  * real one, not a mock of it.
  *
  * Capture artifacts are written into Playwright's per-test output directory.
- * The walkthrough test also records a video of the agent-first cloud setup
- * flow: launcher without the tile → Settings → Cloud → Connect → connected →
- * launcher STILL without the tile (My Apps remains the one apps entry).
+ * The walkthrough test also records the local-runtime navigation boundary:
+ * the launcher keeps My Apps as its one apps entry, while Settings omits the
+ * Cloud-only management group reserved for managed Cloud runtime targets.
  */
 
 const VIEWPORTS = [
@@ -218,10 +217,10 @@ test.describe("launcher: one apps tile — cloud-apps never tiles", () => {
     });
   }
 
-  test.describe("cloud setup walkthrough (recorded)", () => {
+  test.describe("local runtime boundary walkthrough (recorded)", () => {
     // `test.use({ video })` is not allowed inside a describe group, so the
     // walkthrough records through its own context (recordVideo) instead.
-    test("connect flow keeps My Apps as the one apps tile", async ({
+    test("local runtime hides Cloud management and keeps one apps tile", async ({
       browser,
     }, testInfo) => {
       const context = await browser.newContext({
@@ -238,43 +237,35 @@ test.describe("launcher: one apps tile — cloud-apps never tiles", () => {
       await expect(cloudTile(page)).toHaveCount(0);
       await screenshot(page, testInfo, "walkthrough-1-launcher-disconnected");
 
-      // Agent-first cloud setup: Settings → Cloud → Overview → Connect Cloud.
-      // (The cloud group's overview section registers with defaultLabel
-      // "Overview" and defaultTitle "Eliza Cloud" — settings-sections.ts.)
+      // Cloud management belongs only to managed Cloud targets. Local and VPS
+      // runtimes must not expose its group, Overview, or Agents destinations.
       await openAppPath(page, "/settings");
-      await openSettingsSection(page, /^Overview$/);
-      const connectButton = page.getByRole("button", {
-        name: /Connect Cloud|Connect Eliza Cloud/i,
+      await expect(page.getByTestId("settings-shell")).toBeVisible({
+        timeout: 60_000,
       });
-      await expect(connectButton.first()).toBeVisible({ timeout: 30_000 });
-      await screenshot(page, testInfo, "walkthrough-2-settings-cloud-section");
-
-      // Completing the (stubbed) login flips the backend status; the UI must
-      // observe it through its own status poll — the same signal a real
-      // device-code/Steward completion produces.
-      state.connected = true;
-      await connectButton.first().click();
       await expect(
-        page.getByRole("button", { name: /Open Eliza Cloud/i }).first(),
-      ).toBeVisible({ timeout: 60_000 });
+        page.getByTestId("desktop-settings-group-cloud"),
+      ).toHaveCount(0);
       await expect(
-        page.getByRole("button", { name: /Open Eliza Cloud/i }).first(),
-      ).toContainText("Cloud connected");
+        page.getByTestId("desktop-settings-item-cloud-overview"),
+      ).toHaveCount(0);
+      await expect(
+        page.getByTestId("desktop-settings-item-cloud-agents"),
+      ).toHaveCount(0);
       await screenshot(
         page,
         testInfo,
-        "walkthrough-3-settings-cloud-connected",
+        "walkthrough-2-local-settings-without-cloud-management",
       );
 
       await openAppPath(page, "/views");
       await expect(page.getByTestId("launcher")).toBeVisible({
         timeout: 60_000,
       });
-      // Connecting cloud must NOT grow a second apps tile: the studio lives
-      // inside My Apps, so the grid still shows only the My Apps entry.
+      // Navigating through local Settings must not change launcher curation.
       await expect(myAppsTile(page)).toBeVisible({ timeout: 30_000 });
       await expect(cloudTile(page)).toHaveCount(0);
-      await screenshot(page, testInfo, "walkthrough-4-launcher-connected");
+      await screenshot(page, testInfo, "walkthrough-3-local-launcher-return");
 
       // Persist the recording next to the screenshots.
       const video = page.video();
@@ -283,25 +274,27 @@ test.describe("launcher: one apps tile — cloud-apps never tiles", () => {
         const artifact = await saveBrowserVideoArtifact({
           video,
           testInfo,
-          basename: "cloud-setup-walkthrough",
+          basename: "local-cloud-boundary-walkthrough",
         });
-        await testInfo.attach("cloud setup walkthrough", {
+        await testInfo.attach("local Cloud boundary walkthrough", {
           path: artifact.path,
           contentType: artifact.contentType,
         });
-        const notePath = testInfo.outputPath("cloud-setup-walkthrough.txt");
+        const notePath = testInfo.outputPath(
+          "local-cloud-boundary-walkthrough.txt",
+        );
         await writeFile(
           notePath,
           [
-            "Recorded by launcher-cloud-gating.spec.ts (cloud setup walkthrough).",
-            "Flow: launcher without cloud-apps tile → Settings → Eliza Cloud →",
-            "Connect Cloud → status flips connected → launcher still shows only",
+            "Recorded by launcher-cloud-gating.spec.ts (local Cloud boundary).",
+            "Flow: local launcher with My Apps as its single apps tile → Settings",
+            "without the managed-only Cloud group → launcher still shows only",
             "the My Apps tile (the studio lives inside My Apps).",
             "",
             "Repro: bun run --cwd packages/app test:e2e -- --project=chromium test/ui-smoke/launcher-cloud-gating.spec.ts",
           ].join("\n"),
         );
-        await testInfo.attach("cloud setup walkthrough notes", {
+        await testInfo.attach("local Cloud boundary walkthrough notes", {
           path: notePath,
           contentType: "text/plain",
         });

--- a/packages/app/test/ui-smoke/launcher-cloud-gating.spec.ts
+++ b/packages/app/test/ui-smoke/launcher-cloud-gating.spec.ts
@@ -234,6 +234,7 @@ test.describe("launcher: one apps tile — cloud-apps never tiles", () => {
       const page = await context.newPage();
       const state: CloudStatusState = { connected: false };
       await bootLauncher(page, { width: 1280, height: 800 }, state);
+      await expect(myAppsTile(page)).toBeVisible({ timeout: 30_000 });
       await expect(cloudTile(page)).toHaveCount(0);
       await screenshot(page, testInfo, "walkthrough-1-launcher-disconnected");
 
@@ -243,6 +244,12 @@ test.describe("launcher: one apps tile — cloud-apps never tiles", () => {
       await expect(page.getByTestId("settings-shell")).toBeVisible({
         timeout: 60_000,
       });
+      await expect(
+        page.getByTestId("desktop-settings-navigation"),
+      ).toBeVisible();
+      await expect(
+        page.getByTestId("desktop-settings-item-identity"),
+      ).toBeVisible();
       await expect(
         page.getByTestId("desktop-settings-group-cloud"),
       ).toHaveCount(0);


### PR DESCRIPTION
# Relates to

Bounded launcher subtask of #19307. This PR intentionally does not close the broader smoke-inventory issue.

- [x] Targets `develop`; rebased without conflicts onto `fd89713311b121f93192ae756525f16b17321712`.
- [x] Pinned Node `v24.15.0`, Bun `1.3.14`, and Playwright `1.61.1` used for final validation.
- [x] `bun install --frozen-lockfile` and exact-head `bun run verify` completed successfully.
- [x] Exact-head raw Playwright JSON, traces, desktop/mobile screenshots, MP4, app-audit report, and OCR output are public below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact published head `15850034e3210cd1ee21bbe4b878e25389c0c713` is rebased directly on `develop@fd89713311b121f93192ae756525f16b17321712`.
- [x] The final install, focused suites, Chromium capture, app audit/OCR, and root verification all ran on that exact tree.

# Risks

Low. This changes one Playwright smoke contract and no production source. Positive My Apps, desktop Settings rail, and Identity anchors prevent the negative Cloud assertions from passing against a missing or mobile Settings surface.

# Background

## What does this PR do?

The bounded launcher walkthrough expected a local runtime to expose Settings → Cloud → Overview and simulate connecting Cloud. Product consolidation reserves that management group for managed Cloud runtime targets, so the test asserted retired behavior.

The replacement real-Chromium contract proves that a local runtime:

- shows My Apps before entering Settings;
- mounts the real desktop Settings navigation and local Identity destination;
- exposes no Cloud group, Overview item, or Agents item; and
- returns to a launcher that still has My Apps as its single apps tile.

The existing desktop/mobile Cloud-active and Cloud-inactive launcher cases remain intact.

## What kind of change is this?

Bug fix to the app smoke-test contract; no production UI or runtime behavior changes.

# Testing

## Where should a reviewer start?

Review `packages/app/test/ui-smoke/launcher-cloud-gating.spec.ts`, then inspect the raw Playwright JSON and trace bundle linked below.

## Detailed exact-head results

- Head/base: `15850034e3210cd1ee21bbe4b878e25389c0c713` / `fd89713311b121f93192ae756525f16b17321712`.
- Toolchain: Node `v24.15.0`; Bun `1.3.14`; Playwright `1.61.1`.
- Focused Chromium: 5/5 passed in 28.2s; skipped=0, unexpected=0, flaky=0.
- Focused Settings contracts: 2 files, 17/17 passed.
- App audit: 219/219; 216 findings; broken=0; needs-work=0; minimalism/ratchet/hover/density failures=0.
- Packaged OCR: 216 views; 200 verified; broken=0.
- Root verify: 351/351 workspace tasks plus every audit.
- Anti-larp: 8,267 test files; 0 focused; 0 orphaned skips.
- `git diff --check`: clean; worktree clean after generated output cleanup.

The first audit attempt hit host ENOSPC while writing one capture after reporting broken=0/needs-work=0. A clean full rerun then passed 219/219 plus OCR; only that successful rerun is cited as authoritative evidence.

# Evidence Gate

<!-- evidence-head:15850034e3210cd1ee21bbe4b878e25389c0c713 -->

<!-- evidence-row:before-screenshots -->
- [x] ![exact-head launcher before Settings](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19924-pinned-launcher-before.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![exact-head local Settings without Cloud management](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19924-pinned-settings-after.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] [Exact-head MP4 walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19924-pinned-local-boundary.mp4)
<!-- evidence-row:backend-logs -->
- [ ] N/A - test-contract-only repair; backend behavior and requests are unchanged.
<!-- evidence-row:frontend-logs -->
- [x] [Raw Playwright JSON report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19924-pinned-playwright-report.json) and [all five raw traces](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19924-pinned-playwright-raw-traces.zip)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head app-audit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19924-pinned-app-audit-report.json) and [verification manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19924-pinned-verification.md)
<!-- evidence-row:ocr-review -->
- [x] [Exact-head packaged OCR report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19924-pinned-ocr-triage.json)

# Evidence details

The raw JSON retains all five test results plus screenshot, video, and trace attachment names. The walkthrough has an inspectable [contact sheet](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19924-pinned-video-contact.jpg); separate [mobile inactive](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19924-pinned-mobile-inactive.jpg), [mobile active](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19924-pinned-mobile-active.jpg), and [launcher return](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19924-pinned-launcher-return.jpg) captures are also provided.

No hosted PR jobs are expected for this branch under current repository policy: canonical workflows run on `develop` pushes, and `develop-pr.yml` is reusable-only. The exact head must therefore be judged from the public raw evidence, full local gates, branch-protection merge state, and an independent current-head review.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— Codex
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no contribution skill used"} -->
