### PR TITLE
fix(core,agent,app-core): render chat style once in canonical v5 prompt and inherit default persona on rename

### DIFF
--- a/packages/agent/src/runtime/build-character-config.test.ts
+++ b/packages/agent/src/runtime/build-character-config.test.ts
@@ -89,18 +89,33 @@ describe("Matrix connector secret/settings boundary", () => {
   });
 });
 
-describe("last-resort character system prompt", () => {
-  it("keeps the configured identity conversational without changing it", () => {
+describe("custom-name persona inheritance", () => {
+  it("inherits the default preset when a custom name matches no preset", () => {
     const character = buildCharacterFromConfig({
       agents: { list: [{ name: "Zzyzx Quorra" }] },
     } as ElizaConfig);
 
-    expect(character.system?.split("\n\n", 1)[0]).toBe(
-      "You are {{name}}, an autonomous AI agent powered by elizaOS.",
-    );
+    // A rename alone must not erase the default operating persona; {{name}}
+    // tokens pick up the custom name at prompt time.
+    expect(character.name).toBe("Zzyzx Quorra");
+    expect(character.system).toContain("You're {{name}}");
+    expect(character.style?.all?.length ?? 0).toBeGreaterThan(0);
+    expect(character.style?.chat?.length ?? 0).toBeGreaterThan(0);
     expect(character.system).not.toMatch(
       /JSON only|Return one JSON object|No prose|fences|markdown/,
     );
+  });
+
+  it("respects an explicit replacement system prompt without preset backfill", () => {
+    const character = buildCharacterFromConfig({
+      agents: {
+        list: [{ name: "Zzyzx Quorra", system: "You are a pirate. Arr." }],
+      },
+    } as ElizaConfig);
+
+    expect(character.system).toContain("You are a pirate. Arr.");
+    expect(character.system).not.toContain("You're {{name}}");
+    expect(character.style).toBeUndefined();
   });
 });
 

--- a/packages/agent/src/runtime/build-character-config.ts
+++ b/packages/agent/src/runtime/build-character-config.ts
@@ -50,11 +50,16 @@ export function buildCharacterFromConfig(config: ElizaConfig): Character {
   // Prefer the UI-level assistant name when it diverges from the bundled
   // preset entry so renames take effect immediately across prompts/logging.
   const configuredName = configuredUiName || configuredAgentName;
+  // A rename alone must not erase the default operating persona: a custom
+  // name that matches no bundled preset still inherits the default preset
+  // (its {{name}} tokens pick up the custom name at prompt time). Only an
+  // explicit replacement system prompt opts the agent out of that
+  // inheritance (#17026).
   const bundledPreset =
     resolveStylePresetById(uiConfig.presetId, language) ??
     resolveStylePresetByAvatarIndex(uiConfig.avatarIndex, language) ??
     resolveStylePresetByName(configuredName, language) ??
-    (configuredName ? undefined : getDefaultStylePreset(language));
+    (agentEntry?.system ? undefined : getDefaultStylePreset(language));
   const name =
     configuredName ??
     bundledPreset?.name ??

--- a/packages/app-core/src/runtime/build-character-from-config.test.ts
+++ b/packages/app-core/src/runtime/build-character-from-config.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests the app-core character builder's persona-inheritance boundary with the
+ * real upstream builder and bundled presets (no mocks): a custom agent name
+ * still inherits the default preset persona, while an explicit replacement
+ * system prompt opts out of preset backfill entirely.
+ */
+import { describe, expect, it } from "vitest";
+import { buildCharacterFromConfig } from "./build-character-from-config";
+
+type BuilderConfig = Parameters<typeof buildCharacterFromConfig>[0];
+
+describe("app-core custom-name persona inheritance", () => {
+  it("inherits the default preset persona and style for a custom name", () => {
+    const character = buildCharacterFromConfig({
+      agents: { list: [{ name: "Zzyzx Quorra" }] },
+    } as BuilderConfig);
+
+    expect(character.name).toBe("Zzyzx Quorra");
+    expect(character.system).toContain("You're {{name}}");
+    expect(character.style?.all?.length ?? 0).toBeGreaterThan(0);
+    expect(character.style?.chat?.length ?? 0).toBeGreaterThan(0);
+    expect(character.adjectives?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it("skips preset backfill when a replacement system prompt is supplied", () => {
+    const character = buildCharacterFromConfig({
+      agents: {
+        list: [{ name: "Zzyzx Quorra", system: "You are a pirate. Arr." }],
+      },
+    } as BuilderConfig);
+
+    expect(character.system).toContain("You are a pirate. Arr.");
+    expect(character.system).not.toContain("You're {{name}}");
+    expect(character.style).toBeUndefined();
+    expect(character.adjectives ?? []).toHaveLength(0);
+  });
+
+  it("keeps explicit preset selection winning over the default fallback", () => {
+    const custom = buildCharacterFromConfig({
+      agents: { list: [{ name: "Zzyzx Quorra" }] },
+      ui: { presetId: "satoshi" },
+    } as BuilderConfig);
+
+    expect(custom.name).toBe("Zzyzx Quorra");
+    expect(custom.system).not.toContain("You're {{name}}");
+  });
+});

--- a/packages/app-core/src/runtime/build-character-from-config.ts
+++ b/packages/app-core/src/runtime/build-character-from-config.ts
@@ -3,8 +3,9 @@
  * layers dashboard branding onto the built character. Normalizes message
  * examples and fills style, adjectives, topics, and post/message examples from
  * the matched bundled style preset (resolved by preset id, avatar index, then
- * name) — but only where both the agent-list entry and the built character
- * leave them unset, so explicit config always wins.
+ * name, falling back to the default preset unless the operator supplied a
+ * replacement system prompt) — but only where both the agent-list entry and
+ * the built character leave them unset, so explicit config always wins.
  */
 import { buildCharacterFromConfig as upstreamBuildCharacterFromConfig } from "@elizaos/agent";
 import {
@@ -35,7 +36,12 @@ function resolveAppPreset(
   if (matchedPreset) {
     return matchedPreset;
   }
-  return name ? undefined : getDefaultStylePreset(language);
+  // Mirror the upstream builder's inheritance rule (#17026): a custom name
+  // without a matching preset still inherits the default preset unless the
+  // operator supplied a replacement system prompt.
+  return config.agents?.list?.[0]?.system
+    ? undefined
+    : getDefaultStylePreset(language);
 }
 
 export function buildCharacterFromConfig(

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -1456,8 +1456,9 @@ describe("runV5MessageRuntimeStage1", () => {
 		expect(systemContent).not.toContain(longDescription);
 		// Compactness ceiling for the DM Stage-1 prompt. Any leaked context
 		// description (~2,500+ chars each) blows far past this; deliberate
-		// template rules only nudge it, so keep the ceiling tight.
-		expect(systemContent.length).toBeLessThan(3_800);
+		// template rules only nudge it, so keep the ceiling tight (currently
+		// ~3.8k rendered).
+		expect(systemContent.length).toBeLessThan(3_850);
 	});
 
 	it("direct-channel prompt grounds capability denials in executable actions and requires fresh tool retries", async () => {

--- a/packages/core/src/__tests__/message-stable-prefix.test.ts
+++ b/packages/core/src/__tests__/message-stable-prefix.test.ts
@@ -64,6 +64,32 @@ describe("renderMessageHandlerStablePrefix", () => {
 		expect(a).toBe(b);
 	});
 
+	it("renders chat style directions exactly once, excluding post style", async () => {
+		const runtime = makeRuntime();
+		(
+			runtime.character as {
+				style?: { all?: string[]; chat?: string[]; post?: string[] };
+			}
+		).style = {
+			all: ["be brief", "no emoji"],
+			chat: ["match their energy"],
+			post: ["one idea per post"],
+		};
+		const prefix = await renderMessageHandlerStablePrefix(runtime, ROOM_ID);
+		expect(prefix.split("# Message Directions for Test Agent").length - 1).toBe(
+			1,
+		);
+		expect(prefix).toContain("be brief");
+		expect(prefix).toContain("match their energy");
+		expect(prefix).not.toContain("one idea per post");
+	});
+
+	it("omits the style block when the character declares no chat style", async () => {
+		const runtime = makeRuntime();
+		const prefix = await renderMessageHandlerStablePrefix(runtime, ROOM_ID);
+		expect(prefix).not.toContain("# Message Directions");
+	});
+
 	it("calls composeState once per render (so providers are sampled)", async () => {
 		const runtime = makeRuntime();
 		await renderMessageHandlerStablePrefix(runtime, ROOM_ID);

--- a/packages/core/src/runtime/__tests__/system-prompt.test.ts
+++ b/packages/core/src/runtime/__tests__/system-prompt.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, it } from "vitest";
 import {
 	buildCanonicalSystemPrompt,
+	buildCharacterStyleDirections,
 	dropDuplicateLeadingSystemMessage,
 	resolveEffectiveSystemPrompt,
 } from "../system-prompt";
@@ -155,5 +156,42 @@ describe("system prompt helpers", () => {
 		expect(dropDuplicateLeadingSystemMessage(messages, "Other.")).toEqual(
 			messages,
 		);
+	});
+});
+
+describe("buildCharacterStyleDirections", () => {
+	it("renders style.all then style.chat once, excluding style.post", () => {
+		const block = buildCharacterStyleDirections({
+			character: {
+				name: "Ada",
+				style: {
+					all: ["be brief", "{{name}} never uses emoji"],
+					chat: ["match their energy"],
+					post: ["one idea per post"],
+				},
+			},
+		});
+
+		expect(block).toBe(
+			[
+				"# Message Directions for Ada",
+				"be brief",
+				"Ada never uses emoji",
+				"match their energy",
+			].join("\n"),
+		);
+		expect(block).not.toContain("one idea per post");
+	});
+
+	it("returns empty when the character declares no chat style", () => {
+		expect(buildCharacterStyleDirections({ character: { name: "Ada" } })).toBe(
+			"",
+		);
+		expect(
+			buildCharacterStyleDirections({
+				character: { name: "Ada", style: { all: [], chat: [] } },
+			}),
+		).toBe("");
+		expect(buildCharacterStyleDirections({ character: null })).toBe("");
 	});
 });

--- a/packages/core/src/runtime/system-prompt.ts
+++ b/packages/core/src/runtime/system-prompt.ts
@@ -3,7 +3,8 @@
  * character's `system` + `bio` (name-token expanded) plus the caller's role, and
  * resolves the effective system prompt from explicit params, a leading `system`
  * chat message, or a fallback — de-duplicating that leading system message when it
- * already matches the resolved prompt.
+ * already matches the resolved prompt. Also renders the character's static chat
+ * style directions for the v5 stable prefix.
  */
 
 import { replaceNameTokens } from "../name-tokens";
@@ -59,6 +60,42 @@ export function buildCanonicalSystemPrompt(args: {
 		.filter(Boolean)
 		.join("\n\n")
 		.trim();
+}
+
+function renderStyleRules(value: unknown): string[] {
+	if (!Array.isArray(value)) {
+		return [];
+	}
+	return value
+		.map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+		.filter(Boolean);
+}
+
+/**
+ * Renders the character's chat-facing style directions (`style.all` +
+ * `style.chat`) as a single self-headed block for the canonical v5 message
+ * pipeline. Computed statically from the character — never through the
+ * per-room CHARACTER provider — so the rendered block is byte-stable and safe
+ * inside the KV-cacheable stable prefix. Returns "" when the character
+ * declares no chat style.
+ */
+export function buildCharacterStyleDirections(args: {
+	character?: Pick<Character, "name" | "style"> | null;
+}): string {
+	const character = args.character;
+	const name =
+		typeof character?.name === "string" && character.name.trim()
+			? character.name.trim()
+			: "the agent";
+	const style = character?.style;
+	const rules = [
+		...renderStyleRules(style?.all),
+		...renderStyleRules(style?.chat),
+	].map((rule) => replaceNameTokens(rule, name));
+	if (rules.length === 0) {
+		return "";
+	}
+	return `# Message Directions for ${name}\n${rules.join("\n")}`;
 }
 
 export function textFromChatMessageContent(content: unknown): string {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -185,7 +185,10 @@ import {
 	runSubPlanner,
 	subPlannerCallDigest,
 } from "../runtime/sub-planner";
-import { buildCanonicalSystemPrompt } from "../runtime/system-prompt";
+import {
+	buildCanonicalSystemPrompt,
+	buildCharacterStyleDirections,
+} from "../runtime/system-prompt";
 import { resolveTraceCorrelationFromEnv } from "../runtime/trace-correlation";
 import {
 	buildProviderAttributionsFromState,
@@ -877,8 +880,9 @@ function alwaysOnResponseStateProviderNames(runtime: IAgentRuntime): string[] {
  *   - ACTIONS / PROVIDERS / ACTION_STATE: meta-listings — the planner sees
  *     actions as native function tools, so a parallel text block is
  *     duplicative and confusing.
- *   - CHARACTER: already rendered via `staticPrefix.systemPrompt` (which
- *     includes system + bio + role) so the text-block CHARACTER provider
+ *   - CHARACTER: identity is already rendered via `staticPrefix.systemPrompt`
+ *     (system + bio + role) and chat style directions via
+ *     `staticPrefix.characterPrompt`, so the text-block CHARACTER provider
  *     would duplicate the same content.
  * RECENT_MESSAGES stays included because Stage 1 needs full prior dialogue
  * text when no structured `recentMessages` array is available from the
@@ -3425,6 +3429,13 @@ async function createV5MessageContextObject(args: {
 		character: args.runtime.character,
 		userRole: args.userRoles?.[0],
 	});
+	// Chat style directions (style.all + style.chat) render exactly once here,
+	// in the stable prefix. Computed statically from the character — not via the
+	// per-room CHARACTER provider — so the KV-cacheable prefix stays
+	// byte-identical across turns (#17026).
+	const characterStyleDirections = buildCharacterStyleDirections({
+		character: args.runtime.character,
+	});
 	// Stage 2 exposes each Action as its own native tool. Per-action specs live
 	// in `events[type=tool]`; the LLM calls each action directly by name. We
 	// also expose the universal terminal-sentinel tools (REPLY / IGNORE / STOP)
@@ -3458,6 +3469,14 @@ async function createV5MessageContextObject(args: {
 						id: "system",
 						label: "system",
 						content: systemPrompt,
+						stable: true,
+					}
+				: undefined,
+			characterPrompt: characterStyleDirections
+				? {
+						id: "character-style",
+						label: "system",
+						content: characterStyleDirections,
 						stable: true,
 					}
 				: undefined,


### PR DESCRIPTION
Refs #17026

## What

The two remaining unimplemented technical items of #17026 (the persona rewrite and the conversational `defaultCharacterSystemTemplate` fallback already landed on develop via #19626 and follow-ups):

1. **style.all/style.chat now reach the canonical v5 chat prompt, exactly once.** The CHARACTER provider is excluded from model context (`MODEL_CONTEXT_PROVIDER_EXCLUSIONS`) and `buildCanonicalSystemPrompt` renders only system+bio+role, so the default persona's chat style directions never reached the v5 spine while the direct-generation REPLY path rendered them via the provider — persona voice differed by call path. New `buildCharacterStyleDirections` (packages/core/src/runtime/system-prompt.ts) renders `style.all` + `style.chat` (never `style.post`) statically from the character into the previously dormant `staticPrefix.characterPrompt` slot in `createV5MessageContextObject`. Computed statically — not via the per-room, `cacheStable:false` CHARACTER provider — so the KV-cacheable stable prefix stays byte-identical; `renderMessageHandlerStablePrefix` parity holds because both paths share the same context-object constructor. The REPLY direct-generation path is unchanged and still renders style once (via the provider), so no path double-renders.

2. **A rename no longer erases the default operating persona.** Both builders — `packages/agent/src/runtime/build-character-config.ts` and its app-core mirror `packages/app-core/src/runtime/build-character-from-config.ts` — previously dropped to a bare generic bio/system when a custom name matched no bundled preset. They now inherit the default preset unless the operator supplies an explicit replacement `system` prompt; `{{name}}` tokens pick up the custom name at prompt time, and explicit preset id/avatar/full-replacement config still wins.

Also bumps the DM Stage-1 compactness ceiling 3800 → 3850: current develop renders 3808 chars, so `message-runtime-stage1.test.ts › uses a compact direct-channel prompt catalog` was already red on a clean `origin/develop` checkout before this change (verified by stashing this diff).

## Tests

- `packages/core`: `src/runtime/__tests__/system-prompt.test.ts` (style block ordering, {{name}} expansion, post exclusion, empty-style omission), `src/__tests__/message-stable-prefix.test.ts` (directions render exactly once in the stable prefix, post style excluded, omitted when no style), `src/__tests__/message-runtime-stage1.test.ts` — **147/147 passed**.
- `packages/agent`: `src/runtime/build-character-config.test.ts` (custom name inherits default persona; explicit replacement system respected without preset backfill) + capability-hints suite — **10/10 passed**.
- `packages/app-core`: new `src/runtime/build-character-from-config.test.ts` (inheritance mirror, replacement opt-out, explicit preset wins) — **3/3 passed** against the real upstream builder and bundled presets, no mocks.
- Typecheck: core clean; agent/app-core show no code errors (local worktree has a partial install; only environmental TS2688 type-lib resolution noise, none in touched code). Biome clean on all touched files.

Live act-vs-ask trajectory capture for the merged persona text remains tracked on the issue thread; this PR delivers the deterministic prompt-composition scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:217ee89759c5b0ba5227eda223465c0541535cc3 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Runtime prompt and character-construction code only; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Runtime prompt and character-construction code only; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No user-facing visual flow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - Exact-head deterministic prompt and character tests plus the 52-workspace dependency build validate this slice.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend request or state surface changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - This PR is the deterministic prompt-composition slice; #17026 remains open for its required live multi-model trajectory acceptance.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - Rendered canonical prompt contents are asserted directly in exact-head tests; #17026 remains open for live action receipts.

<!-- evidence-row:ocr-review -->
- [ ] N/A - No rendered text surface changed.
