### PR TITLE
fix(workflow): type the source validator boundary

### DIFF
--- a/plugins/plugin-workflow/__tests__/unit/smithers-source.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/smithers-source.test.ts
@@ -14,11 +14,12 @@ describe('native Smithers workflow source', () => {
 
   test('rejects missing source, missing default exports, and legacy packages', () => {
     expect(() => validateSmithersSource('')).toThrow('source is required');
-    // A stored record can reach dispatch with no source at all (stale trigger
-    // to a legacy definition); that is the typed error, never a TypeError.
-    expect(() => validateSmithersSource(undefined as unknown as string)).toThrow(
-      'source is required'
-    );
+    // Stored records are untrusted at this boundary. Missing or malformed
+    // source values must become the typed error, never a property-access
+    // TypeError or an unsafe compile-time assertion.
+    for (const source of [undefined, null, 42, {}]) {
+      expect(() => validateSmithersSource(source)).toThrow('source is required');
+    }
     expect(() => validateSmithersSource("import { Smithers } from 'smthrs';")).toThrow(
       'default-export'
     );

--- a/plugins/plugin-workflow/src/services/smithers-runtime.ts
+++ b/plugins/plugin-workflow/src/services/smithers-runtime.ts
@@ -163,7 +163,7 @@ async function linkWorkflowDependency(
   }
 }
 
-export function validateSmithersSource(source: string): void {
+export function validateSmithersSource(source: unknown): void {
   // A stored workflow record can reach dispatch without a source (stale
   // trigger pointing at a legacy or partially-saved definition, live repro:
   // system-device-health-check). That must fail as the typed


### PR DESCRIPTION
Fixes #19928. Follow-up to merged #19914.

## What

`validateSmithersSource` is a persisted-record boundary, so its input is untrusted even though well-formed workflow DTOs declare `source: string`. #19914 added the correct runtime guard but left the validator signature as `string`, forcing its missing-source regression through `undefined as unknown as string`.

This follow-up types the boundary honestly as `unknown` and covers `undefined`, `null`, a number, and an object. Every malformed value reaches the existing typed `SMTHRS_SOURCE_REQUIRED` error instead of a property-access `TypeError`.

## Validation

```text
bunx turbo run build --filter=@elizaos/plugin-workflow...
  85/85 dependency-aware build tasks passed
bun test --isolate __tests__/unit/smithers-source.test.ts
  2 tests, 8 assertions passed
bun run typecheck
  passed
bunx biome check src/services/smithers-runtime.ts __tests__/unit/smithers-source.test.ts
  passed
git diff --check
  passed
```

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e4a0c4f786ccf214d2cb5eb6c85f77c60278ee53:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Evidence Gate

<!-- evidence-head:aa17fc6d50ba94e8a7ef26cad36c3c55a41eea7a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:backend-logs -->
- [x] [19929-pr19929-backend-v2.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19929-pr19929-backend-v2.json)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, provider, model, or agent behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no workflow row is mutated; this patch narrows validation failure behavior for malformed stored input.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@e4a0c4f786ccf214d2cb5eb6c85f77c60278ee53:packages/skills/skills/contribute-to-eliza"} -->




