### PR TITLE
fix(core): bind owner-life reads to the requested possessive domain

### DIFF
--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -740,6 +740,110 @@ describe("inferDirectCurrentRequestCandidateInference kinds", () => {
 		).toEqual({ names: ["VIEWS"], kind: "view-capability" });
 	});
 
+	it("binds the owner-read domain to the possessive clause, not the whole utterance (#19874)", () => {
+		const readers: Array<Pick<Action, "name" | "similes" | "tags">> = [
+			{ name: "OWNER_TODOS", similes: [], tags: [] },
+			{ name: "OWNER_GOALS", similes: [], tags: [] },
+			{ name: "OWNER_REMINDERS", similes: [], tags: [] },
+			{ name: "OWNER_ROUTINES", similes: [], tags: [] },
+			{ name: "OWNER_ALARMS", similes: [], tags: [] },
+			{ name: "OWNER_FINANCES", similes: [], tags: [] },
+		];
+		const all = [viewsAction, ...readers];
+		// The #19874 headline case: the possessive target is `my reminders`;
+		// "goal planning" past the clause boundary is context, not a request.
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				all,
+				"show my reminders about goal planning",
+			),
+		).toEqual({ names: ["OWNER_REMINDERS"], kind: "owner-reads" });
+		// One valid request per owner domain, including possessive adjectives.
+		for (const [message, reader] of [
+			["list my personal todos", "OWNER_TODOS"],
+			["show my own goals", "OWNER_GOALS"],
+			["what are our shared reminders", "OWNER_REMINDERS"],
+			["go over my daily routines", "OWNER_ROUTINES"],
+			["check my alarms", "OWNER_ALARMS"],
+			["show my spending this month", "OWNER_FINANCES"],
+		] as const) {
+			expect(inferDirectCurrentRequestCandidateInference(all, message)).toEqual(
+				{ names: [reader], kind: "owner-reads" },
+			);
+		}
+	});
+
+	it("treats mixed or multi-domain owner asks as non-deterministic, never registry order (#19874)", () => {
+		const readers: Array<Pick<Action, "name" | "similes" | "tags">> = [
+			{ name: "OWNER_GOALS", similes: [], tags: [] },
+			{ name: "OWNER_REMINDERS", similes: [], tags: [] },
+			{ name: "OWNER_ROUTINES", similes: [], tags: [] },
+			{ name: "OWNER_FINANCES", similes: [], tags: [] },
+		];
+		// Both orders: neither Goals-first (registry order) nor Reminders-first
+		// may win — the planner clarifies or composes, and the ask must not
+		// degrade into the view catalog either.
+		for (const message of [
+			"show my goals and reminders",
+			"show my reminders and goals",
+			"what are my spending habits?",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateInference(
+					[viewsAction, ...readers],
+					message,
+				),
+			).toEqual({ names: [], kind: null });
+		}
+		// A single available reader must still never be silently chosen for a
+		// multi-domain ask (the VIEWS-failure recovery shape).
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, { name: "OWNER_GOALS", similes: [], tags: [] }],
+				"show my goals and reminders",
+			),
+		).toEqual({ names: [], kind: null });
+		// While the same recovery still selects the correct reader when exactly
+		// one domain is requested.
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, { name: "OWNER_REMINDERS", similes: [], tags: [] }],
+				"show my reminders about goal planning",
+			),
+		).toEqual({ names: ["OWNER_REMINDERS"], kind: "owner-reads" });
+	});
+
+	it("keeps advice, how-to, quoted, negated, and metalinguistic shapes out of owner reads (#19874)", () => {
+		const readers: Array<Pick<Action, "name" | "similes" | "tags">> = [
+			{ name: "OWNER_TODOS", similes: [], tags: [] },
+			{ name: "OWNER_REMINDERS", similes: [], tags: [] },
+			{ name: "OWNER_FINANCES", similes: [], tags: [] },
+		];
+		for (const message of [
+			"tell me how to organize my todos",
+			"give me advice on my finances",
+			"help me prioritize my todos",
+			'explain what "show my reminders" does',
+			"what does 'list my todos' mean",
+			"don't show my reminders yet",
+			"what does my todo list mean",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateInference(
+					[viewsAction, ...readers],
+					message,
+				).kind,
+			).not.toBe("owner-reads");
+		}
+		// The broad read verbs still work when the ask is a genuine data read.
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, ...readers],
+				"tell me my reminders",
+			),
+		).toEqual({ names: ["OWNER_REMINDERS"], kind: "owner-reads" });
+	});
+
 	it("gives owner goal mutations precedence over the views goals tag (#17028)", () => {
 		const goalsAction: Pick<Action, "name" | "similes" | "tags"> = {
 			name: "OWNER_GOALS",

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -665,6 +665,53 @@ const OWNER_READ_DOMAIN_NOUNS: ReadonlyArray<[OwnerLifeReadDomain, RegExp]> = [
 ];
 
 /**
+ * Clause boundary for a possessive owner read: tokens that shift the sentence
+ * from the possessed noun into surrounding context ("my reminders ABOUT goal
+ * planning" — everything after `about` describes the reminders, it is not a
+ * second requested surface). Conjunctions and plain adjectives deliberately
+ * continue the clause so "my goals and reminders" proves BOTH domains and is
+ * surfaced as ambiguous rather than silently resolved by registry order.
+ * `to` stays a continuation so "my to dos" survives tokenization.
+ */
+const OWNER_READ_CLAUSE_STOP_TOKEN =
+	/^(?:about|regarding|concerning|re|on|for|from|at|in|with|without|during|before|after|since|into|by|around|over|under|toward|towards|via|per|vs|versus|than|when|while|if|because|so|then|that|which|who|where|why|how)$/u;
+
+const OWNER_READ_CLAUSE_MAX_TOKENS = 8;
+
+/**
+ * Collects every owner-life domain noun that appears inside a possessive
+ * clause — the `my`/`our` anchor plus the words it still governs — rather than
+ * anywhere in the utterance. This is what binds domain selection to the
+ * possessive target (#19874): contextual nouns past a clause boundary
+ * ("… about goal planning") never vote.
+ */
+function collectPossessiveOwnerReadDomains(
+	normalized: string,
+): Set<OwnerLifeReadDomain> {
+	const domains = new Set<OwnerLifeReadDomain>();
+	const anchor = /\b(?:my|our)\b/gu;
+	for (
+		let match = anchor.exec(normalized);
+		match !== null;
+		match = anchor.exec(normalized)
+	) {
+		let rest = normalized.slice(match.index + match[0].length);
+		let clause = "";
+		for (let taken = 0; taken < OWNER_READ_CLAUSE_MAX_TOKENS; taken++) {
+			const token = /^[\s,]+([a-z][\w'-]*)/u.exec(rest);
+			if (!token) break;
+			if (OWNER_READ_CLAUSE_STOP_TOKEN.test(token[1])) break;
+			clause += ` ${token[1]}`;
+			rest = rest.slice(token[0].length);
+		}
+		for (const [domain, noun] of OWNER_READ_DOMAIN_NOUNS) {
+			if (noun.test(clause)) domains.add(domain);
+		}
+	}
+	return domains;
+}
+
+/**
  * Detects a possessive owner-data READ ("list my personal todos", "what are
  * my reminders for today") — the read-side mirror of the owner-mutation rule
  * (#17028 / fead478cfa): a data ask is owner-domain evidence, and VIEWS can
@@ -672,10 +719,25 @@ const OWNER_READ_DOMAIN_NOUNS: ReadonlyArray<[OwnerLifeReadDomain, RegExp]> = [
  * (live: "list my personal todos" routed to VIEWS view-disambiguation, then
  * failed on an undeclared get-todos capability). Explicit UI-surface nouns
  * stay with the navigation legs, and advice/organizing questions stay chat.
+ *
+ * Domain selection is bound to the possessive clause (#19874): only nouns the
+ * `my`/`our` anchor still governs count, exactly one proven domain routes
+ * deterministically, and a mixed ask ("my goals and reminders", "my spending
+ * habits") returns `"ambiguous"` so the planner can clarify or compose readers
+ * — never a registry-order guess, and never the view catalog.
  */
-function detectOwnerLifeReadDomain(text: string): OwnerLifeReadDomain | null {
-	const normalized = text.toLowerCase().replace(/\s+/gu, " ").trim();
+function detectOwnerLifeReadDomain(
+	text: string,
+): OwnerLifeReadDomain | "ambiguous" | null {
+	let normalized = text.toLowerCase().replace(/\s+/gu, " ").trim();
 	if (!normalized) return null;
+	// Quoted wording is mention, not use: "explain what 'show my todos' does"
+	// must not anchor a read, so quoted spans never reach the matchers. A
+	// straight single quote only counts when it opens after a boundary and
+	// closes before one — contractions ("what's", "don't") are not quotes.
+	normalized = normalized
+		.replace(/"[^"]*"|“[^”]*”|‘[^’]*’/gu, " ")
+		.replace(/(?:^|\s)'[^']*'(?=\s|$|[.,!?;:])/gu, " ");
 	// Surface-noun asks are navigation, owned by the earlier view legs.
 	if (
 		/\b(?:view|views|page|screen|tab|panel|window|ui|dashboard|app)\b/iu.test(
@@ -684,13 +746,26 @@ function detectOwnerLifeReadDomain(text: string): OwnerLifeReadDomain | null {
 	) {
 		return null;
 	}
-	// A read needs a possessive anchor; adjectives may sit between it and the
-	// domain noun ("my personal todos", "our shared reminders").
-	const possessiveDomain =
-		/\b(?:my|our)\b(?:\s+\w+){0,2}\s+(?:todos?|to[- ]dos?|todo\s+list|task\s+list|goals?|reminders?|routines?|habits?|alarms?|finances|spending|expenses)\b/iu.test(
+	// Advice, how-to, organizing, explanatory, and metalinguistic shapes are
+	// conversation about the data, not requests for it — they stay with chat
+	// even when a broad read verb ("tell me", "give me") is present.
+	if (
+		/\b(?:how\s+(?:do|to|can|could|should|would)|advice|advise|tips?|suggest\w*|recommend\w*|organi[sz]\w*|prioriti[sz]\w*|manag\w*|improve|improving|explain|definition|meaning)\b/iu.test(
 			normalized,
-		);
-	if (!possessiveDomain) return null;
+		) ||
+		/\bwhat\s+does\b[\s\S]{0,60}\bmean\b/iu.test(normalized) ||
+		/\bhelp\s+me\b/iu.test(normalized)
+	) {
+		return null;
+	}
+	// Negated reads are not reads.
+	if (
+		/\b(?:don't|do\s+not|never|stop|quit|no\s+need\s+to)\s+(?:show|list|read|tell|give|check|display|go\s+over|review)\b/iu.test(
+			normalized,
+		)
+	) {
+		return null;
+	}
 	// Mutation shapes belong to the write detectors above (or the model);
 	// "check off"/"mark ... done" are completions, not reads.
 	if (
@@ -707,9 +782,10 @@ function detectOwnerLifeReadDomain(text: string): OwnerLifeReadDomain | null {
 			normalized,
 		);
 	if (!hasReadShape) return null;
-	for (const [domain, noun] of OWNER_READ_DOMAIN_NOUNS) {
-		if (noun.test(normalized)) return domain;
-	}
+	const domains = collectPossessiveOwnerReadDomains(normalized);
+	if (domains.size === 0) return null;
+	if (domains.size > 1) return "ambiguous";
+	for (const domain of domains) return domain;
 	return null;
 }
 
@@ -826,6 +902,13 @@ export function inferDirectCurrentRequestCandidateInference(
 	// reader the turn yields NO deterministic candidate rather than degrading
 	// into the view catalog.
 	const ownerReadDomain = detectOwnerLifeReadDomain(messageText);
+	if (ownerReadDomain === "ambiguous") {
+		// A mixed owner ask ("my goals and reminders") proves the owner intent
+		// but not a single surface. Deterministically picking one would drop the
+		// rest, so the turn yields NO candidate — the planner clarifies or
+		// composes readers, and the ask never degrades into the view catalog.
+		return EMPTY_DIRECT_CANDIDATE_INFERENCE;
+	}
 	if (ownerReadDomain) {
 		const ownerReadAction = findOwnerLifeReadActionName(
 			actions,


### PR DESCRIPTION
# Relates to

Fixes #19874

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and the focused verification below were run after sync.
- [x] A reviewer can confirm the change works without reading the code from the deterministic matrix below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Risks

Low and precision-directional. Every change makes the deterministic router *more* conservative: contextual nouns can no longer vote, multi-domain asks yield no candidate instead of a registry-order guess, and advice/quoted/negated shapes fall back to the model. Single-domain reads that routed correctly before still route to the same reader (pinned for all six domains).

# Background

## What does this PR do?

`detectOwnerLifeReadDomain()` (added in #19865) proved that *some* possessive domain existed, then independently scanned every domain noun in the whole utterance in a fixed registry order. Per #19874 that deterministically selects the wrong surface:

- `show my reminders about goal planning` → OWNER_GOALS (contextual "goal" outranks the possessed "reminders")
- `what are my spending habits?` → OWNER_ROUTINES ("habits" precedes "finances" in the registry)
- `show my goals and reminders` → silently Goals, Reminders dropped
- `tell me how to organize my todos` / `give me advice on my finances` → routed into owner data readers

The fix:

- **Possessive-clause extraction** — a new `collectPossessiveOwnerReadDomains()` walks the tokens each `my`/`our` anchor still governs, stopping at context-shifting boundaries (`about`, `for`, `on`, …) while conjunctions and adjectives continue the clause. Only nouns inside the clause vote. `show my reminders about goal planning` now proves exactly `reminders`.
- **Exactly-one-domain routing** — one proven domain routes deterministically; zero falls through as before; two or more return `"ambiguous"`, and the call site yields NO candidate so the planner clarifies or composes readers. Registry order can never decide, in either noun order, and an ambiguous owner ask can never degrade into the view catalog (even when only one reader happens to be registered).
- **Advice/meta exclusion** — how-to, advice/tips/suggest/recommend, organizing/prioritizing/managing, explain/meaning/"what does … mean", quoted wording (straight+curly quotes stripped as mention-not-use, with contractions like `what's` preserved), and negated read verbs all stay with chat. `tell me my reminders` still reads.

VIEWS behavior is untouched: surface-noun asks stay with navigation, and a single-domain read with no registered reader still yields no candidate rather than VIEWS.

## What kind of change is this?

Bug fix (non-breaking) in the deterministic Stage-1 candidate router.

# Documentation changes needed?

No — the module documents the clause-binding contract in place.

# Testing

## Where should a reviewer start?

`packages/core/src/services/message/direct-action-heuristics.ts` (`collectPossessiveOwnerReadDomains`, the rewritten `detectOwnerLifeReadDomain`, and the `"ambiguous"` arm at the call site), then the three new test blocks.

## Detailed testing steps

```bash
cd packages/core
node ../scripts/run-vitest.mjs run src/services/message/direct-action-heuristics.test.ts
node ../scripts/run-vitest.mjs run src/__tests__/message-routing-live-regression.test.ts \
  src/runtime/__tests__/candidate-action-backstop.test.ts \
  src/runtime/__tests__/message-handler-bogus-candidates.test.ts
bun run --cwd packages/core typecheck
```

# Evidence Gate

<!-- evidence-head:63ce7e05d8eb0b5053f94945bc466b038e10846b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - deterministic Stage-1 router heuristics; no rendered UI surface changed

<!-- evidence-row:after-screenshots -->
- [x] N/A - deterministic Stage-1 router heuristics; no rendered UI surface changed

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive flow changed; the routing contract is pinned by the exact-input matrix below

<!-- evidence-row:backend-logs -->
- [x] Focused suites + typecheck transcript
```text
$ node ../scripts/run-vitest.mjs run src/services/message/direct-action-heuristics.test.ts
 Test Files  1 passed (1)
      Tests  63 passed (63)
$ node ../scripts/run-vitest.mjs run src/runtime/__tests__/candidate-action-backstop.test.ts src/runtime/__tests__/message-handler-bogus-candidates.test.ts
      Tests  45 passed (45)
$ node ../scripts/run-vitest.mjs run src/__tests__/message-routing-live-regression.test.ts
      Tests  69 passed (69)
$ bun run --cwd packages/core typecheck
Done!
$ bunx biome check <changed files>
Checked 2 files. No fixes applied.
```
Note: `bun run --cwd plugins/plugin-personal-assistant typecheck` fails on current develop at `src/lifeops/service-normalize-task.ts(413,16)` (`"unscheduled"` not assignable) — pre-existing and unrelated (this PR touches only `packages/core`; the error is a plugin-internal literal assignment, likely the #19881 domain).

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or browser behavior changed

<!-- evidence-row:llm-trajectory -->
- [x] N/A - the change is the deterministic pre-model router; no model, prompt, or provider behavior changed. The issue's live-proof ask (Todo/Reminder reads through the owner-private path) requires a hosted agent stack not available in this environment — the deterministic matrix pins the exact routing decisions those live turns would exercise, and the live capture remains open for a maintainer or follow-up with stack access.

<!-- evidence-row:domain-artifacts -->
- [x] Exact-input routing matrix (the domain artifact for a deterministic router)
```text
"show my reminders about goal planning"      -> OWNER_REMINDERS   (was: OWNER_GOALS)
"show my goals and reminders"                -> no candidate      (was: OWNER_GOALS, Reminders dropped)
"show my reminders and goals"                -> no candidate      (order-independent)
"what are my spending habits?"               -> no candidate      (was: OWNER_ROUTINES by registry order)
"tell me how to organize my todos"           -> chat              (was: owner reader)
"give me advice on my finances"              -> chat              (was: owner reader)
"explain what \"show my reminders\" does     -> chat              (quoted = mention, not use)
"don't show my reminders yet"                -> chat              (negated)
"list my personal todos"                     -> OWNER_TODOS        (unchanged)
"what are our shared reminders"              -> OWNER_REMINDERS    (possessive adjective)
"go over my daily routines"                  -> OWNER_ROUTINES     (unchanged)
"check my alarms"                            -> OWNER_ALARMS       (unchanged)
"show my spending this month"                -> OWNER_FINANCES     (unchanged)
"tell me my reminders"                       -> OWNER_REMINDERS    (broad verb kept for real reads)
ambiguous ask + only OWNER_GOALS registered  -> no candidate       (never silently picks the one available)
All pinned by the 63-test suite transcript in backend-logs.
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-eliza
Attribution status: self-reported
— [isfinne]
<!-- slop-contribution-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/slopdotcash@1bde21d6d8229678f20bbd450f8e49f9fd95f989:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01M026D2N5MX0K2N2VG8MPPW6H","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-15T07:50:24.165Z","completed_at":"2026-08-15T07:57:13.054Z","skill_sha256":"9466c79e848fb10aa61a256937f4cff2db2e6e5a6c3ea912b86b1bb491fa0e96","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAeFx8j9RLDmaq09rhK6xiWpvzDAe3NrViWEwZglIdrK8","device_key_id":"70bd3811c55418d8d795eff5cfcad01f317f0deaa3b7adde455b0bc825b5892a","device_signature":"NniY5Rcw_NFt6zpv8txvEaNiDHNp5tdjJWSAUenvq5-JW-pX88vdfndZbTkyYFiJDXL6qo4Z2gxZniJOolCdAQ"}} -->
