### PR TITLE
fix(ci): remove dead generate:llms call from legacy VPS deploy

### DIFF
--- a/.github/workflows/cloud-deploy-backend.yml
+++ b/.github/workflows/cloud-deploy-backend.yml
@@ -304,7 +304,7 @@ jobs:
             git fetch origin "$BRANCH"
             git checkout -B "$BRANCH" "origin/$BRANCH"
 
-            # Install runtime dependencies and regenerate lightweight assets.
+            # Install runtime dependencies.
             if ! command -v bun >/dev/null 2>&1 || [ "$(bun --version)" != "1.3.14" ]; then
               curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.14"
               export PATH="$BUN_INSTALL/bin:$PATH"
@@ -322,7 +322,7 @@ jobs:
               sleep 10
             done
 
-            bun run generate:llms
+            # No llms.txt regeneration here: nothing in this repository defines or consumes that script.
 
             # The build now runs on GitHub Actions to avoid ENOSPC during
             # `next build` on the VPS. Clear any stale output and leave an empty


### PR DESCRIPTION
# Relates to

Fixes #19919

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-4-5`
<!-- attribution-row:client -->
- Agent tooling: `ZCode`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`09d4787c`); zero conflicts.
- [x] See **Known gaps / failures** for the root-verify environment blocker
      (unrelated to this workflow-only change).

# Risks

Low. Workflow-only change to a manual, opt-in (`workflow_dispatch`, default
`deploy_legacy_vps=false`) deploy job: it removes a call that already fails
unconditionally (`error: Script not found "generate:llms"`) and cannot succeed
again — no `package.json` in the repository exposes a `generate:llms` script,
and the `packages/content` / `apps/frontend/public` roots the surviving
generator (`packages/cloud/scripts/admin/generate-llms-txt.ts`) hard-codes were
removed with the `cloud-frontend` app in #9093. No package.json, no production
code path, no other job or step is touched.

# Background

## What does this PR do?

Removes the dead `bun run generate:llms` invocation from the `Prepare VPS
checkout` step of the `deploy` job in
`.github/workflows/cloud-deploy-backend.yml`, plus the now-stale
"and regenerate lightweight assets" half of the comment above it, replacing the
call site with a breadcrumb comment explaining why it was removed rather than
re-wired (per the issue's fix proposal).

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

The single-file diff: one line removed, one comment trimmed, one breadcrumb
comment added, nothing else.

## Detailed testing steps

- Confirm `bun run generate:llms` no longer appears anywhere in the workflow
  (grep below).
- Confirm the YAML still parses and the `deploy` job/step structure is
  otherwise unchanged (parse check below).

# Evidence Gate

<!-- evidence-head:d3075953e3086fc4396bae0763b9017a6a78fde2 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI workflow-only change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI workflow-only change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow; a manual opt-in deploy job's shell script is edited, verified below by grep + YAML structural parse.
<!-- evidence-row:backend-logs -->
- [x] N/A - the failing behavior is quoted verbatim in the issue (`error: Script not found "generate:llms"`, EXIT CODE: 1); this PR removes the invocation so that failure mode no longer exists. The job itself is opt-in and requires a real VPS + secrets to dispatch, which no contributor can exercise from a fork.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response or state change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - workflow YAML edit only, no DB/memory/wallet/file artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Backend + frontend logs

Verification run against the PR head file:

```
$ grep -c "bun run generate:llms" .github/workflows/cloud-deploy-backend.yml
0                                   # call site fully removed

$ grep -n "Install runtime dependencies" .github/workflows/cloud-deploy-backend.yml
307:            # Install runtime dependencies.   # stale half removed

$ bun -e "const yaml=require('yaml');const fs=require('fs');
  const doc=yaml.parse(fs.readFileSync('.github/workflows/cloud-deploy-backend.yml','utf8'));
  const job=doc.jobs.deploy;
  if(!job||!job.steps)throw new Error('deploy job structure missing');
  console.log('YAML parses OK; deploy job has',job.steps.length,'steps')"
YAML parses OK; deploy job has 11 steps
```

Breadcrumb left at the removed call site (single present-tense invariant, per the repository comment policy):

```yaml
            # No llms.txt regeneration here: nothing in this repository defines or consumes that script.
```

## Screenshots (before / after) + video walkthrough

N/A - CI workflow-only change, no rendered UI surface.

## Known gaps / failures

- Root `bun install` in this environment fails on the `ffmpeg-static`
  postinstall script (network timeout fetching the prebuilt binary), so the
  full root `bun run verify` cannot run here. A workflow-only edit cannot
  affect package build/test/typecheck outcomes; the YAML structural check above
  covers the acceptance criteria.
- Dispatching the actual opt-in `deploy` job end-to-end requires a provisioned
  VPS with repository secrets, which is maintainer-only; the fix is the removal
  of an unconditionally failing command, so there is no success path to
  demonstrate beyond the job no longer invoking it.

## Review-requested evidence (exact head)

```
$ node packages/scripts/audit-scripts.mjs
(no output, exit=0)

$ bun -e "<yaml parse + invocation scan on the workflow file>"
YAML parses OK; deploy job has 11 steps; runnable generate:llms invocations: 0
```

AI provider/model: anthropic / claude-sonnet-4-5
Client / agent tooling: ZCode
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-sonnet-4-5","client":"ZCode"} -->

## Hosted verification status (exact head d3075953)

Local exact-head verification is green and was independently reproduced by the
reviewer (audit-scripts OK, YAML parses, 11 deploy steps, zero runnable
`generate:llms` invocations, conflict-free merge tree). A hosted CI result for
this head requires maintainer action: this PR edits `.github/workflows/*` from
a fork, so GitHub's workflow-file protection holds all checks in "awaiting
approval" — the branch reports `no checks` until a maintainer approves the
workflow run (the same workflow-scoped authority noted in the first review for
landing). Requesting that approval; no production-code amendment is pending
unless the hosted run surfaces a defect.
