### PR TITLE
fix(discord): acknowledge voice commands before auth (#19932)

### DIFF
--- a/packages/cloud/services/gateway-discord/src/managed-guild-voice.ts
+++ b/packages/cloud/services/gateway-discord/src/managed-guild-voice.ts
@@ -26,6 +26,7 @@ import {
   Events,
   GatewayIntentBits,
   InteractionContextType,
+  MessageFlags,
   PermissionFlagsBits,
 } from "discord.js";
 import prism from "prism-media";
@@ -231,7 +232,13 @@ export class ManagedGuildVoiceController {
     const command = interaction as ChatInputCommandInteraction;
     if (!command.isChatInputCommand?.() || command.commandName !== "voice")
       return;
+    let acknowledged = false;
     try {
+      // Discord invalidates an unacknowledged interaction after three seconds.
+      // Cloud authorization and guild-member fetches are network I/O, so the
+      // ephemeral acknowledgement must be the first awaited command operation.
+      await command.deferReply({ flags: MessageFlags.Ephemeral });
+      acknowledged = true;
       await this.dispatchCommand(command);
     } catch (error) {
       logger.error("Managed guild voice command failed", {
@@ -239,13 +246,9 @@ export class ManagedGuildVoiceController {
         discordUserId: command.user.id,
         error: error instanceof Error ? error.message : String(error),
       });
-      const payload = {
-        content: "Voice is temporarily unavailable.",
-        ephemeral: true,
-      };
-      if (command.deferred || command.replied)
-        await command.editReply(payload.content);
-      else await command.reply(payload);
+      if (acknowledged || command.deferred || command.replied) {
+        await command.editReply("Voice is temporarily unavailable.");
+      }
     }
   };
 
@@ -253,17 +256,11 @@ export class ManagedGuildVoiceController {
     interaction: ChatInputCommandInteraction,
   ): Promise<void> {
     if (!interaction.guild || !interaction.guildId) {
-      await interaction.reply({
-        content: "Voice controls are server-only.",
-        ephemeral: true,
-      });
+      await interaction.editReply("Voice controls are server-only.");
       return;
     }
     if (!interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)) {
-      await interaction.reply({
-        content: "Manage Server permission is required.",
-        ephemeral: true,
-      });
+      await interaction.editReply("Manage Server permission is required.");
       return;
     }
 
@@ -272,11 +269,9 @@ export class ManagedGuildVoiceController {
       guildId: interaction.guildId,
     });
     if (!authorization.allowed) {
-      await interaction.reply({
-        content:
-          "Only the canonical owner of this Eliza account can control voice.",
-        ephemeral: true,
-      });
+      await interaction.editReply(
+        "Only the canonical owner of this Eliza account can control voice.",
+      );
       return;
     }
 
@@ -284,29 +279,21 @@ export class ManagedGuildVoiceController {
     if (subcommand === "leave") {
       const session = this.sessions.get(interaction.guildId);
       if (!session || session.ownerDiscordUserId !== interaction.user.id) {
-        await interaction.reply({
-          content: "I am not in your voice session.",
-          ephemeral: true,
-        });
+        await interaction.editReply("I am not in your voice session.");
         return;
       }
       this.destroySession(session);
       this.sessions.delete(interaction.guildId);
-      await interaction.reply({
-        content: "Left your voice channel.",
-        ephemeral: true,
-      });
+      await interaction.editReply("Left your voice channel.");
       return;
     }
 
     const member = await interaction.guild.members.fetch(interaction.user.id);
     const channel = member.voice.channel;
     if (!channel?.isVoiceBased() || channel.guild.id !== interaction.guildId) {
-      await interaction.reply({
-        content:
-          "Join a voice channel in this server first, then run `/voice join`.",
-        ephemeral: true,
-      });
+      await interaction.editReply(
+        "Join a voice channel in this server first, then run `/voice join`.",
+      );
       return;
     }
     const botMember = interaction.guild.members.me;
@@ -315,15 +302,12 @@ export class ManagedGuildVoiceController {
       !permissions?.has(PermissionFlagsBits.Connect) ||
       !permissions.has(PermissionFlagsBits.Speak)
     ) {
-      await interaction.reply({
-        content:
-          "I need View Channel, Connect, and Speak permissions in your voice channel.",
-        ephemeral: true,
-      });
+      await interaction.editReply(
+        "I need View Channel, Connect, and Speak permissions in your voice channel.",
+      );
       return;
     }
 
-    await interaction.deferReply({ ephemeral: true });
     const prior = this.sessions.get(interaction.guildId);
     if (prior) this.destroySession(prior);
     const connection = this.join({

--- a/packages/cloud/services/gateway-discord/tests/managed-guild-voice.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/managed-guild-voice.test.ts
@@ -118,10 +118,39 @@ describe("ManagedGuildVoiceController", () => {
     harness.client.emit(Events.InteractionCreate, command.interaction);
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(join).not.toHaveBeenCalled();
-    expect(command.reply).toHaveBeenCalledWith(
-      expect.objectContaining({
-        content: expect.stringContaining("canonical owner"),
-      }),
+    expect(command.deferReply).toHaveBeenCalledTimes(1);
+    expect(command.editReply).toHaveBeenCalledWith(
+      expect.stringContaining("canonical owner"),
+    );
+    await controller.stop();
+  });
+
+  test("acknowledges before delayed Cloud authorization", async () => {
+    const harness = clientHarness();
+    let releaseAuthorization: (() => void) | undefined;
+    const authorize = mock(
+      () =>
+        new Promise<{ allowed: boolean }>((resolve) => {
+          releaseAuthorization = () => resolve({ allowed: false });
+        }),
+    );
+    const controller = new ManagedGuildVoiceController({
+      client: harness.client as never,
+      bridge: { authorize, turn: mock() },
+    });
+    await controller.start();
+    const command = interactionHarness("join");
+    harness.client.emit(Events.InteractionCreate, command.interaction);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(command.deferReply).toHaveBeenCalledTimes(1);
+    expect(authorize).toHaveBeenCalledTimes(1);
+    expect(command.editReply).not.toHaveBeenCalled();
+
+    releaseAuthorization?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(command.editReply).toHaveBeenCalledWith(
+      expect.stringContaining("canonical owner"),
     );
     await controller.stop();
   });


### PR DESCRIPTION
Closes #19932

## Production diagnosis

Railway recorded `Managed guild voice command failed` with `Unknown interaction` for the live `/voice join`. The handler awaited Cloud authorization before acknowledging Discord, so a slow authorization call exceeded Discord’s three-second deadline.

## Fix

- Defer ephemerally as the first awaited operation for every `/voice` command.
- Convert every outcome to `editReply`, preserving authorization and permission checks.
- Use `MessageFlags.Ephemeral` instead of the deprecated boolean.
- Add a delayed-authorization regression proving defer happens first.

## Verification

- gateway tests: 70 pass / 0 fail
- gateway typecheck: pass
- gateway build: pass (736 modules)
- gateway lint/Biome: pass
- AGENTS/CLAUDE parity: pass
- `git diff --check`: pass