### PR TITLE
fix(core): bind owner reads to the possessive domain

### DIFF
--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -180,6 +180,34 @@ emotion: none`;
 	});
 });
 
+describe("owner-read candidate authority", () => {
+	it("replaces an invented Stage-1 VIEWS capability with the proven owner reader", () => {
+		const routed = applyDirectCurrentCandidateBackstopToMessageHandler(
+			{
+				processMessage: "RESPOND",
+				thought: "",
+				plan: {
+					contexts: ["general"],
+					reply: "I'll check that.",
+					simple: false,
+					requiresTool: true,
+					candidateActions: ["VIEWS.get_reminders", "OWNER_FINANCES"],
+				},
+			},
+			{
+				actions: [
+					{ name: "OWNER_REMINDERS" },
+					{ name: "OWNER_FINANCES" },
+					{ name: "VIEWS" },
+				] as Action[],
+				messageText: "Show my reminders about goal planning.",
+			},
+		);
+
+		expect(routed.plan.candidateActions).toEqual(["OWNER_REMINDERS"]);
+	});
+});
+
 describe("reply that QUOTES a field transcript — diagnosis workflow (follow-up to #11712)", () => {
 	// Live regression: a user pastes a leaked `shouldRespond:/replyText:`
 	// transcript into discord and asks the bot to diagnose it (this repo's own

--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -1125,6 +1125,52 @@ describe("VIEWS hijack of answered simple turns (tj-501e594bfb23a7)", () => {
 		expect(routed.plan.candidateActions ?? []).toEqual([]);
 	});
 
+	it("recovers answered VIEWS-overlap reads to the one possessive owner domain", () => {
+		const ownerReaders: Array<Pick<Action, "name" | "similes" | "tags">> = [
+			{ name: "OWNER_TODOS", similes: [], tags: [] },
+			{ name: "OWNER_REMINDERS", similes: [], tags: [] },
+			{ name: "OWNER_FINANCES", similes: [], tags: [] },
+		];
+		for (const [messageText, expected] of [
+			["what's on my todo list? i'd like to know", "OWNER_TODOS"],
+			["show my reminders about goal planning", "OWNER_REMINDERS"],
+			["what are my spending habits?", "OWNER_FINANCES"],
+		] as const) {
+			const routed = messageHandlerFromFieldResult(
+				stageOneAnswered("Let me check."),
+				undefined,
+				{
+					actions: [replyAction, viewsAction, ...ownerReaders],
+					messageText,
+				},
+			);
+
+			expect(routed.plan.simple).toBe(false);
+			expect(routed.plan.requiresTool).toBe(true);
+			expect(routed.plan.candidateActions).toEqual([expected]);
+		}
+	});
+
+	it("keeps mixed owner domains out of the VIEWS recovery path", () => {
+		const routed = messageHandlerFromFieldResult(
+			stageOneAnswered("Which records should I review?"),
+			undefined,
+			{
+				actions: [
+					replyAction,
+					viewsAction,
+					{ name: "OWNER_GOALS", similes: [], tags: [] },
+					{ name: "OWNER_REMINDERS", similes: [], tags: [] },
+				],
+				messageText: "show my goals and reminders",
+			},
+		);
+
+		expect(routed.plan.simple).toBe(true);
+		expect(routed.plan.requiresTool).toBe(false);
+		expect(routed.plan.candidateActions ?? []).toEqual([]);
+	});
+
 	it("suppression is keyed on the answered shape — an unanswered turn still escalates", () => {
 		// A genuine weak capability overlap (settings tag with only directional
 		// operation evidence) keeps the original valve behavior: unanswered

--- a/packages/core/src/__tests__/owner-read-routing.cerebras.test.ts
+++ b/packages/core/src/__tests__/owner-read-routing.cerebras.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Live Cerebras proof that possessive owner reads bind to the noun in the
+ * owning clause. The real PGlite-backed message loop has unrelated owner and
+ * web surfaces available so contextual nouns can challenge the deterministic
+ * routing floor.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+	type Action,
+	ChannelType,
+	createMessageMemory,
+	type HandlerCallback,
+	type Memory,
+	type Plugin,
+	stringToUuid,
+	type UUID,
+} from "../index.ts";
+import {
+	createRealTestRuntime,
+	type RealTestRuntimeResult,
+} from "../testing/index.ts";
+
+interface LiveTrajectoryDetail {
+	metrics?: { finalStatus?: string };
+	steps?: Array<{ llmCalls?: Array<{ response?: string }> }>;
+}
+
+interface LiveTrajectoryService {
+	flushWriteQueue?: (trajectoryId: string) => Promise<void>;
+	getTrajectoryDetail?: (
+		trajectoryId: string,
+	) => Promise<LiveTrajectoryDetail | null>;
+}
+
+function proofAction(name: string): Action {
+	return {
+		name,
+		description: `Deterministic live owner-read proof surface for ${name}.`,
+		validate: async () => true,
+		handler: async () => ({ success: true, text: `${name} selected` }),
+	};
+}
+
+const routingProofPlugin: Plugin = {
+	name: "owner-read-routing-live-proof",
+	description:
+		"Registers private owner readers and adversarial generic surfaces.",
+	actions: [
+		proofAction("OWNER_TODOS"),
+		proofAction("OWNER_REMINDERS"),
+		proofAction("OWNER_FINANCES"),
+		proofAction("VIEWS"),
+		proofAction("WEB_SEARCH"),
+	],
+};
+
+const liveDescribe =
+	process.env.ELIZA_RUN_LIVE_TESTS === "1" &&
+	process.env.CEREBRAS_API_KEY?.trim()
+		? describe
+		: describe.skip;
+
+liveDescribe("possessive owner reads — live Cerebras", () => {
+	let harness: RealTestRuntimeResult;
+
+	beforeAll(async () => {
+		harness = await createRealTestRuntime({
+			characterName: "OwnerReadProofAgent",
+			plugins: [routingProofPlugin],
+			preferredProvider: "openai",
+			withLLM: true,
+		});
+	}, 180_000);
+
+	afterAll(async () => {
+		await harness?.cleanup();
+	});
+
+	async function runTurn(text: string): Promise<string[]> {
+		const roomId = stringToUuid(`owner-read-room:${text}`) as UUID;
+		const entityId = stringToUuid(`owner-read-user:${text}`) as UUID;
+		const worldId = stringToUuid("owner-read-world") as UUID;
+		await harness.runtime.ensureConnection({
+			channelId: roomId,
+			entityId,
+			roomId,
+			worldId,
+			source: "api_private",
+			type: ChannelType.DM,
+			userName: "Owner",
+		});
+		const message: Memory = createMessageMemory({
+			entityId,
+			id: stringToUuid(`owner-read-message:${text}`) as UUID,
+			roomId,
+			content: { channelType: ChannelType.DM, source: "api_private", text },
+		});
+		const callback: HandlerCallback = async () => [];
+		const service = harness.runtime.messageService;
+		if (!service) throw new Error("message service was not initialized");
+		await service.handleMessage(harness.runtime, message, callback, {});
+		const trajectoryId = (message.metadata as { trajectoryId?: unknown } | null)
+			?.trajectoryId;
+		if (typeof trajectoryId !== "string") {
+			throw new Error("live turn did not create a trajectory");
+		}
+		const trajectories = harness.runtime.getService(
+			"trajectories",
+		) as LiveTrajectoryService | null;
+		let trajectory: LiveTrajectoryDetail | null = null;
+		for (let attempt = 0; attempt < 50; attempt += 1) {
+			await trajectories?.flushWriteQueue?.(trajectoryId);
+			trajectory =
+				(await trajectories?.getTrajectoryDetail?.(trajectoryId)) ?? null;
+			if (trajectory?.metrics?.finalStatus === "completed") break;
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		if (!trajectory) throw new Error("live trajectory was not persisted");
+		return (
+			trajectory.steps
+				?.flatMap((step) => step.llmCalls ?? [])
+				.map((call) => call.response)
+				.filter((response): response is string => Boolean(response?.trim())) ??
+			[]
+		);
+	}
+
+	it("keeps contextual nouns from hijacking private owner reads", async () => {
+		const todo = await runTurn("What are my todos?");
+		const reminder = await runTurn("Show my reminders about goal planning.");
+		const finance = await runTurn("Show my finances.");
+		console.log(JSON.stringify({ finance, reminder, todo }, null, 2));
+		expect(todo.some((output) => output.includes("OWNER_TODOS"))).toBe(true);
+		expect(reminder.some((output) => output.includes("OWNER_REMINDERS"))).toBe(
+			true,
+		);
+		expect(finance.some((output) => output.includes("OWNER_FINANCES"))).toBe(
+			true,
+		);
+		expect(reminder.some((output) => output.includes('"VIEWS"'))).toBe(false);
+	}, 240_000);
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -5409,11 +5409,17 @@ export function applyDirectCurrentCandidateBackstopToMessageHandler(
 		return messageHandler;
 	}
 
+	const stageOneCandidateActions =
+		getMessageHandlerCandidateActions(messageHandler);
+	const composedCandidateActions =
+		directCurrentInference.kind === "owner-reads"
+			? directCurrentCandidateActions
+			: uniqueActionNames([
+					...stageOneCandidateActions,
+					...directCurrentCandidateActions,
+				]);
 	const runnableCandidateActions = filterRunnableCandidateActions(
-		uniqueActionNames([
-			...getMessageHandlerCandidateActions(messageHandler),
-			...directCurrentCandidateActions,
-		]),
+		composedCandidateActions,
 		runtimeContext,
 	);
 	if (runnableCandidateActions.length === 0) return messageHandler;
@@ -8127,19 +8133,22 @@ export async function runV5MessageRuntimeStage1(args: {
 		// evaluator that cleared Stage-1 candidates has already established an
 		// authoritative route from richer runtime state, so the generic text
 		// heuristic must not undo that decision.
-		const directPlannerCandidateActions =
-			inferDirectCurrentRequestCandidateActions(
-				args.runtime.actions ?? [],
-				getUserMessageText(args.message) ?? "",
-			);
+		const directPlannerInference = inferDirectCurrentRequestCandidateInference(
+			args.runtime.actions ?? [],
+			getUserMessageText(args.message) ?? "",
+		);
+		const directPlannerCandidateActions = directPlannerInference.names;
 		if (
 			directPlannerCandidateActions.length > 0 &&
 			!responseHandlerEvaluation.candidateActionsClearedByEvaluators
 		) {
-			messageHandler.plan.candidateActions = uniqueActionNames([
-				...getMessageHandlerCandidateActions(messageHandler),
-				...directPlannerCandidateActions,
-			]);
+			messageHandler.plan.candidateActions =
+				directPlannerInference.kind === "owner-reads"
+					? directPlannerCandidateActions
+					: uniqueActionNames([
+							...getMessageHandlerCandidateActions(messageHandler),
+							...directPlannerCandidateActions,
+						]);
 		}
 		const routedResponseHandlerReply = getMessageHandlerReply(messageHandler);
 		let earlyReplyText = actionOwnsResponseHandlerEarlyReply(

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -295,8 +295,18 @@ describe("looksLikeWebSearchRequest", () => {
 	});
 
 	it("respects an explicit do-not-browse negation", () => {
-		expect(looksLikeWebSearchRequest("don't browse the web for this")).toBe(
-			false,
+		for (const text of [
+			"don't browse the web for this",
+			"don’t ever search the web for this",
+			"never, under any circumstances, google this",
+		]) {
+			expect(looksLikeWebSearchRequest(text)).toBe(false);
+		}
+		expect(
+			looksLikeWebSearchRequest("never mind, search the web for elizaOS"),
+		).toBe(true);
+		expect(looksLikeWebSearchRequest("search the web without Google")).toBe(
+			true,
 		);
 	});
 });
@@ -702,28 +712,111 @@ describe("inferDirectCurrentRequestCandidateInference kinds", () => {
 
 	it("covers the other owner-read domains and leaves non-possessive asks alone", () => {
 		const readers: Array<Pick<Action, "name" | "similes" | "tags">> = [
+			{ name: "OWNER_TODOS", similes: [], tags: [] },
+			{ name: "OWNER_GOALS", similes: [], tags: [] },
 			{ name: "OWNER_REMINDERS", similes: [], tags: [] },
 			{ name: "OWNER_ROUTINES", similes: [], tags: [] },
+			{ name: "OWNER_ALARMS", similes: [], tags: [] },
 			{ name: "OWNER_FINANCES", similes: [], tags: [] },
 		];
+		for (const [message, actionName] of [
+			["list my personal todos", "OWNER_TODOS"],
+			["review our shared goals", "OWNER_GOALS"],
+			["what are my reminders for today", "OWNER_REMINDERS"],
+			["show my habits", "OWNER_ROUTINES"],
+			["check my alarms", "OWNER_ALARMS"],
+			["go over my expenses this week", "OWNER_FINANCES"],
+		] as const) {
+			expect(
+				inferDirectCurrentRequestCandidateInference(
+					[viewsAction, ...readers],
+					message,
+				),
+			).toEqual({ names: [actionName], kind: "owner-reads" });
+		}
+
+		// Contextual nouns outside the possessive clause cannot steal the route.
 		expect(
 			inferDirectCurrentRequestCandidateInference(
 				[viewsAction, ...readers],
-				"what are my reminders for today",
+				"show my reminders about goal planning",
 			),
 		).toEqual({ names: ["OWNER_REMINDERS"], kind: "owner-reads" });
 		expect(
 			inferDirectCurrentRequestCandidateInference(
 				[viewsAction, ...readers],
-				"show my habits",
+				"review my goals concerning reminder planning",
 			),
-		).toEqual({ names: ["OWNER_ROUTINES"], kind: "owner-reads" });
+		).toEqual({ names: ["OWNER_GOALS"], kind: "owner-reads" });
+		// The compound phrase names finance data, not the routines surface.
 		expect(
 			inferDirectCurrentRequestCandidateInference(
 				[viewsAction, ...readers],
-				"go over my expenses this week",
+				"what are my spending habits?",
 			),
 		).toEqual({ names: ["OWNER_FINANCES"], kind: "owner-reads" });
+		for (const [message, actionName] of [
+			["show my reminders about today's bitcoin price", "OWNER_REMINDERS"],
+			["review my goals concerning the current stock market", "OWNER_GOALS"],
+			["show my todos about checking the latest weather", "OWNER_TODOS"],
+		] as const) {
+			expect(
+				inferDirectCurrentRequestCandidateInference(
+					[
+						viewsAction,
+						...readers,
+						{ name: "WEB_SEARCH", similes: [], tags: [] },
+					],
+					message,
+				),
+			).toEqual({ names: [actionName], kind: "owner-reads" });
+		}
+
+		// Multiple requested owner domains must not be silently reduced by the
+		// fixed registry order; the planner can clarify or compose readers.
+		for (const message of [
+			"show my goals and reminders",
+			"show my reminders and goals",
+			"review my todos and our routines",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateInference(
+					[viewsAction, ...readers],
+					message,
+				),
+			).toEqual({ names: [], kind: null });
+		}
+
+		// Advice, negation, quotation, and metalinguistic examples mention owner
+		// nouns but do not request private records.
+		for (const message of [
+			"tell me how to organize my todos",
+			"give me advice on my finances",
+			"what are good ways to organize my finances?",
+			"what are effective ways to manage my todos?",
+			"tell me ways to organize my reminders",
+			"show me how i can organize my goals",
+			"what are the best methods for tracking my spending?",
+			"do not show my reminders",
+			"please don't ever show my reminders",
+			"dont show my reminders",
+			"don’t ever show my reminders",
+			"do not ever show my reminders",
+			"do not, under any circumstances, show my reminders",
+			"never again list my todos",
+			"never, ever list my todos",
+			"never please under any circumstances show my reminders",
+			"what happens when I say show my reminders",
+			'write a story where she says "show my goals"',
+			"explain the phrase show my routines",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateInference(
+					[viewsAction, ...readers],
+					message,
+				),
+			).toEqual({ names: [], kind: null });
+		}
 		// No possessive anchor → not an owner read (precision over recall).
 		expect(
 			inferDirectCurrentRequestCandidateInference(
@@ -731,6 +824,60 @@ describe("inferDirectCurrentRequestCandidateInference kinds", () => {
 				"list the reminders",
 			).kind,
 		).not.toBe("owner-reads");
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, ...readers],
+				"what's on my todo list? i'd like to know",
+			),
+		).toEqual({ names: ["OWNER_TODOS"], kind: "owner-reads" });
+		for (const message of [
+			"search the web for ways to organize my finances",
+			"look up advice about my finances",
+			"google tips to manage my spending",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateInference(
+					[
+						viewsAction,
+						...readers,
+						{ name: "WEB_SEARCH", similes: [], tags: [] },
+					],
+					message,
+				),
+			).toEqual({ names: ["WEB_SEARCH"], kind: "web" });
+		}
+		for (const message of [
+			"what are good ways to manage my current stock spending?",
+			"don't show my reminders about today's bitcoin price",
+			"show my goals and reminders about current stock prices",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateInference(
+					[
+						viewsAction,
+						...readers,
+						{ name: "WEB_SEARCH", similes: [], tags: [] },
+					],
+					message,
+				),
+			).toEqual({ names: [], kind: null });
+		}
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, ...readers],
+				"don't browse the web; show my reminders",
+			),
+		).toEqual({ names: ["OWNER_REMINDERS"], kind: "owner-reads" });
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[
+					viewsAction,
+					...readers,
+					{ name: "WEB_SEARCH", similes: [], tags: [] },
+				],
+				"don't show my reminders; search the web for today's bitcoin price",
+			),
+		).toEqual({ names: ["WEB_SEARCH"], kind: "web" });
 		// The existing settings capability contract is untouched.
 		expect(
 			inferDirectCurrentRequestCandidateInference(

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -201,33 +201,40 @@ export function linkShareOwnText(text: string): string {
 		.trim();
 }
 
+const WEB_SEARCH_NEGATION_PATTERN =
+	/\b(?:(?:do\s+not|don['’]?t|never(?!\s+mind\b))\b[^.!?;]{0,64}\b(?:google\b|(?:browse|search|look\s+up|use)\s+(?:the\s+)?(?:web|internet|live prices?|current prices?)\b)|without\b[^.!?;]{0,32}\b(?:brows(?:e|ing)|search(?:ing)?|look(?:ing)?\s+up|us(?:e|ing))\s+(?:the\s+)?(?:web|internet|live prices?|current prices?)\b)/iu;
+const EXPLICIT_WEB_SEARCH_PATTERN =
+	/\b(?:search\s+(?:the\s+)?web|web\s+search|search\s+online|look\s+up|lookup|google|browse\s+(?:the\s+)?web|search\s+(?:the\s+)?internet)\b/iu;
+const INTENT_CLAUSE_BOUNDARY_PATTERN =
+	/\s*(?:;|\b(?:but|however|instead)\b)\s*/iu;
+
+function intentClauses(text: string): string[] {
+	return text
+		.toLowerCase()
+		.split(INTENT_CLAUSE_BOUNDARY_PATTERN)
+		.map((clause) => clause.trim())
+		.filter(Boolean);
+}
+
+function explicitlyAsksWebSearch(text: string): boolean {
+	return intentClauses(text).some(
+		(clause) =>
+			!WEB_SEARCH_NEGATION_PATTERN.test(clause) &&
+			EXPLICIT_WEB_SEARCH_PATTERN.test(clause),
+	);
+}
+
 export function looksLikeWebSearchRequest(text: string): boolean {
-	const normalized = text.toLowerCase();
-	if (!normalized.trim()) {
-		return false;
-	}
-
-	if (
-		/\b(?:do not|don't|dont|without)\s+(?:browse|search|google|look\s+up|use)\s+(?:the\s+)?(?:web|internet|live prices?|current prices?)\b/iu.test(
-			normalized,
-		)
-	) {
-		return false;
-	}
-
-	const explicitlyAsksSearch =
-		/\b(?:search\s+(?:the\s+)?web|web\s+search|search\s+online|look\s+up|lookup|google|browse\s+(?:the\s+)?web|search\s+(?:the\s+)?internet)\b/iu.test(
-			normalized,
-		);
 	const asksCurrentInfo =
-		/\b(?:current|currently|latest|live|real[- ]?time|right now|today|now|rn|atm|up[- ]?to[- ]?date)\b/iu.test(
-			normalized,
-		);
+		/\b(?:current|currently|latest|live|real[- ]?time|right now|today|now|rn|atm|up[- ]?to[- ]?date)\b/iu;
 	const mentionsMarketOrNews =
-		/\b(?:price|prices|quote|btc|bitcoin|eth|ethereum|stock|stocks?|ticker|market|markets?|exchange rate|news|headline|headlines|weather)\b/iu.test(
-			normalized,
-		);
-	return explicitlyAsksSearch || (asksCurrentInfo && mentionsMarketOrNews);
+		/\b(?:price|prices|quote|btc|bitcoin|eth|ethereum|stock|stocks?|ticker|market|markets?|exchange rate|news|headline|headlines|weather)\b/iu;
+	return intentClauses(text).some(
+		(clause) =>
+			!WEB_SEARCH_NEGATION_PATTERN.test(clause) &&
+			(EXPLICIT_WEB_SEARCH_PATTERN.test(clause) ||
+				(asksCurrentInfo.test(clause) && mentionsMarketOrNews.test(clause))),
+	);
 }
 
 export function findAvailableActionName(
@@ -643,6 +650,8 @@ type OwnerLifeReadDomain =
 	| "alarms"
 	| "finances";
 
+const BLOCKED_OWNER_LIFE_READ = Symbol("blocked-owner-life-read");
+
 const OWNER_READ_ACTION_NAMES_BY_DOMAIN: Record<
 	OwnerLifeReadDomain,
 	readonly string[]
@@ -664,6 +673,30 @@ const OWNER_READ_DOMAIN_NOUNS: ReadonlyArray<[OwnerLifeReadDomain, RegExp]> = [
 	["finances", /\b(?:finances|spending|expenses)\b/iu],
 ];
 
+function ownerLifeReadDomainsInPossessiveScopes(
+	normalized: string,
+): Set<OwnerLifeReadDomain> {
+	const domains = new Set<OwnerLifeReadDomain>();
+	for (const match of normalized.matchAll(/\b(?:my|our)\b([^,;.!?]*)/giu)) {
+		const rawScope = match[1] ?? "";
+		const scope =
+			rawScope.split(
+				/\b(?:about|concerning|regarding|for|due|from|on|in|with|where|that|which|because)\b/iu,
+				1,
+			)[0] ?? "";
+		// "Spending habits" names finance data; treating the trailing generic
+		// habit noun as a routine would make registry order decide the surface.
+		const domainScope = scope.replace(
+			/\b(?:finance|financial|spending|expenses?)\s+habits?\b/giu,
+			"finances",
+		);
+		for (const [domain, noun] of OWNER_READ_DOMAIN_NOUNS) {
+			if (noun.test(domainScope)) domains.add(domain);
+		}
+	}
+	return domains;
+}
+
 /**
  * Detects a possessive owner-data READ ("list my personal todos", "what are
  * my reminders for today") — the read-side mirror of the owner-mutation rule
@@ -673,7 +706,9 @@ const OWNER_READ_DOMAIN_NOUNS: ReadonlyArray<[OwnerLifeReadDomain, RegExp]> = [
  * failed on an undeclared get-todos capability). Explicit UI-surface nouns
  * stay with the navigation legs, and advice/organizing questions stay chat.
  */
-function detectOwnerLifeReadDomain(text: string): OwnerLifeReadDomain | null {
+function detectOwnerLifeReadDomain(
+	text: string,
+): OwnerLifeReadDomain | typeof BLOCKED_OWNER_LIFE_READ | null {
 	const normalized = text.toLowerCase().replace(/\s+/gu, " ").trim();
 	if (!normalized) return null;
 	// Surface-noun asks are navigation, owned by the earlier view legs.
@@ -684,13 +719,8 @@ function detectOwnerLifeReadDomain(text: string): OwnerLifeReadDomain | null {
 	) {
 		return null;
 	}
-	// A read needs a possessive anchor; adjectives may sit between it and the
-	// domain noun ("my personal todos", "our shared reminders").
-	const possessiveDomain =
-		/\b(?:my|our)\b(?:\s+\w+){0,2}\s+(?:todos?|to[- ]dos?|todo\s+list|task\s+list|goals?|reminders?|routines?|habits?|alarms?|finances|spending|expenses)\b/iu.test(
-			normalized,
-		);
-	if (!possessiveDomain) return null;
+	const domains = ownerLifeReadDomainsInPossessiveScopes(normalized);
+	if (domains.size === 0) return null;
 	// Mutation shapes belong to the write detectors above (or the model);
 	// "check off"/"mark ... done" are completions, not reads.
 	if (
@@ -700,17 +730,41 @@ function detectOwnerLifeReadDomain(text: string): OwnerLifeReadDomain | null {
 		/\bcheck(?:ed)?\s+off\b/iu.test(normalized) ||
 		/\bmark\b[\s\S]{0,40}\b(?:done|complete|off)\b/iu.test(normalized)
 	) {
-		return null;
+		return BLOCKED_OWNER_LIFE_READ;
+	}
+	// Advice, quoted examples, negated commands, and metalinguistic discussion
+	// mention owner nouns without requesting the underlying private records.
+	if (
+		/\b(?:advice|tips?|suggestions?|recommendations?)\b/iu.test(normalized) ||
+		/\bhow\s+to\b/iu.test(normalized) ||
+		/\bhow\s+(?:do|can|could|should|would)\s+(?:i|we)\b/iu.test(normalized) ||
+		/\b(?:how(?:\s+(?:do|can|could|should|would))?(?:\s+(?:i|we))?|ways?|methods?|approaches?|strategies?)\b[^.!?]{0,80}\b(?:organize|manage|track|plan|improve|handle|structure|prioritize|budget)\w*\b/iu.test(
+			normalized,
+		) ||
+		/\b(?:what|which)\s+should\s+(?:i|we)\b/iu.test(normalized) ||
+		/\b(?:help|teach|guide)\s+(?:me|us)\b/iu.test(normalized) ||
+		/\b(?:when|if)\s+i\s+say\b/iu.test(normalized) ||
+		/\b(?:the\s+)?(?:phrase|sentence|wording|utterance|quote|quoted)\b/iu.test(
+			normalized,
+		) ||
+		/["“][^"”]*\b(?:my|our)\b[^"”]*["”]/u.test(normalized) ||
+		/‘[^’]*\b(?:my|our)\b[^’]*’/u.test(normalized) ||
+		/(?:^|[^\p{L}\p{N}])'[^'\r\n]*\b(?:my|our)\b[^'\r\n]*'(?![\p{L}\p{N}])/u.test(
+			normalized,
+		) ||
+		/\b(?:do\s+not|don['’]?t|never(?!\s+mind\b))\b(?:(?!\b(?:but|however|instead)\b)[^.!?;]){0,96}\b(?:list|show|tell|give|read|check|see|look|review|go\s+over)\b/iu.test(
+			normalized,
+		)
+	) {
+		return BLOCKED_OWNER_LIFE_READ;
 	}
 	const hasReadShape =
 		/\b(?:list|show|what(?:'s|s| is| are)(?:\s+(?:on|in))?|do i have|have i got|any(?:thing)?\s+(?:on|in|left|due)|tell me|give me|read(?:\s+(?:me|out))?|check|see|look at|go over|review)\b/iu.test(
 			normalized,
 		);
 	if (!hasReadShape) return null;
-	for (const [domain, noun] of OWNER_READ_DOMAIN_NOUNS) {
-		if (noun.test(normalized)) return domain;
-	}
-	return null;
+	if (domains.size !== 1) return BLOCKED_OWNER_LIFE_READ;
+	return domains.values().next().value ?? null;
 }
 
 function findOwnerLifeReadActionName(
@@ -825,7 +879,16 @@ export function inferDirectCurrentRequestCandidateInference(
 	// wants the data, and VIEWS can only navigate. With no registered owner
 	// reader the turn yields NO deterministic candidate rather than degrading
 	// into the view catalog.
+	const webLookupActions = looksLikeWebSearchRequest(messageText)
+		? findWebLookupActionNames(actions)
+		: [];
 	const ownerReadDomain = detectOwnerLifeReadDomain(messageText);
+	if (ownerReadDomain === BLOCKED_OWNER_LIFE_READ) {
+		if (explicitlyAsksWebSearch(messageText) && webLookupActions.length > 0) {
+			return { names: webLookupActions, kind: "web" };
+		}
+		return EMPTY_DIRECT_CANDIDATE_INFERENCE;
+	}
 	if (ownerReadDomain) {
 		const ownerReadAction = findOwnerLifeReadActionName(
 			actions,
@@ -843,9 +906,8 @@ export function inferDirectCurrentRequestCandidateInference(
 	if (viewCapabilityAction) {
 		return { names: [viewCapabilityAction], kind: "view-capability" };
 	}
-	if (looksLikeWebSearchRequest(messageText)) {
-		const lookupActions = findWebLookupActionNames(actions);
-		if (lookupActions.length > 0) return { names: lookupActions, kind: "web" };
+	if (webLookupActions.length > 0) {
+		return { names: webLookupActions, kind: "web" };
 	}
 	return EMPTY_DIRECT_CANDIDATE_INFERENCE;
 }


### PR DESCRIPTION
# Relates to

Fixes #19874.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@1bde21d6d8229678f20bbd450f8e49f9fd95f989:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Publication candidate extends the reviewed `origin/develop@431795ce3b9ec98add9309c792a2239343783767` patch without conflicts.
- [x] Exact-head focused tests, core build/typecheck, Biome, diff check, and live Cerebras proof pass.

# Risks

**Medium and fail-closed.** This changes deterministic routing for private owner-life reads. A proven owner-read candidate is now authoritative over an invented Stage-1 `VIEWS` capability; mixed or ambiguous owner domains still remain uncommitted.

# What changed

The original patch binds owner-life reads to the possessive/read clause instead of scanning unrelated nouns across the whole utterance. It keeps advice, how-to, quoted, metalinguistic, negated, and ambiguous language out of private readers, while preserving UI navigation and explicit web lookup.

Exact live testing exposed one deeper composition gap: the heuristic could correctly infer `OWNER_REMINDERS`, but the message pipeline appended it to Stage-1's invented `VIEWS.get_reminders` candidate. The planner could still pick VIEWS. This head therefore makes a proven `owner-reads` inference replace Stage-1 candidates at both candidate-composition seams; other inference kinds retain their existing merge behavior.

A credential-gated real-runtime regression now boots PGlite plus the Cerebras provider and verifies Todo, Reminder-with-contextual-goal-noun, and Finance reads route to their canonical owner actions with VIEWS available as an adversary.

# Testing

Exact publication candidate: `9e335b7e7ded28e0ff397b4db09bf41423c68a15`.

- Direct-action heuristics + message-routing integration: **132/132 passed**.
- Live PGlite AgentRuntime + Cerebras `gpt-oss-120b`: **1/1 passed**; routes were `OWNER_TODOS`, `OWNER_REMINDERS`, and `OWNER_FINANCES`; reminder trajectory contained no VIEWS route.
- `bun run --cwd packages/core build`: passed, including packed edge declaration/runtime verification.
- `bun run --cwd packages/core typecheck`: passed.
- Targeted Biome and `git diff --check`: passed.

# Evidence Gate

<!-- evidence-head:9e335b7e7ded28e0ff397b4db09bf41423c68a15 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend routing-only change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend routing-only change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend routing-only change with no rendered UI surface.
<!-- evidence-row:backend-logs -->
- [x] [Patch-equivalent pre-rebase real-runtime backend log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19939-owner-read-backend-v4.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network code changed.
<!-- evidence-row:llm-trajectory -->
- [x] [Patch-equivalent pre-rebase Cerebras trajectory summary](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19939-owner-read-live-v4.json)
<!-- evidence-row:domain-artifacts -->
- [x] [Exact owner-read route results](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19939-owner-read-domain-v2.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Remaining gate

- Canonical repository CI now validates the integrated `develop` tree after merge; PR branches intentionally have no full hosted matrix.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@1bde21d6d8229678f20bbd450f8e49f9fd95f989:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [gauss]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@1bde21d6d8229678f20bbd450f8e49f9fd95f989:packages/skills/skills/contribute-to-eliza"} -->

