### PR TITLE
fix(documents): roll back parent DOCUMENT row when fragment processing fails

### DIFF
--- a/packages/core/src/features/documents/service-orphan-compensation.test.ts
+++ b/packages/core/src/features/documents/service-orphan-compensation.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Proves addDocument leaves no orphaned zero-fragment DOCUMENT row behind
+ * when fragment embedding fails after the parent row is written (#16021).
+ * Integration-backed: a real AgentRuntime over a real PGLite SQL adapter
+ * (plugin-sql); only the embedding model handler is injected, once failing
+ * and once succeeding.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { AgentRuntime } from "../../runtime.ts";
+import { createTestRuntime } from "../../testing/pglite-runtime.ts";
+import type { UUID } from "../../types/index.ts";
+import { ModelType } from "../../types/index.ts";
+import { DocumentService } from "./service.ts";
+
+const DOCUMENT_FRAGMENTS_TABLE = "document_fragments";
+
+const DOC_TEXT = [
+	"Alpha paragraph: refund policy details for the orphan-compensation test.",
+	"Bravo paragraph: service level agreements and uptime commitments listed.",
+	"Charlie paragraph: data retention windows and deletion guarantees noted.",
+].join("\n\n");
+
+let runtime: AgentRuntime;
+let cleanup: () => Promise<void>;
+let service: DocumentService;
+let embedShouldFail = false;
+
+async function fragmentsFor(documentId: string): Promise<number> {
+	const memories = await runtime.getMemories({
+		tableName: DOCUMENT_FRAGMENTS_TABLE,
+		agentId: runtime.agentId,
+		count: 10_000,
+	});
+	return memories.filter(
+		(memory) =>
+			(memory.metadata as { documentId?: string } | undefined)?.documentId ===
+			documentId,
+	).length;
+}
+
+beforeAll(async () => {
+	({ runtime, cleanup } = await createTestRuntime({
+		characterName: "OrphanCompensationAgent",
+		embeddingDimensions: 384,
+	}));
+	// One switchable handler for both embedding routes so the failure mode is
+	// exactly an embed-time provider outage, not a missing model.
+	const embed = async () => {
+		if (embedShouldFail) {
+			throw new Error("injected embedding provider outage");
+		}
+		return Array.from({ length: 384 }, (_, i) => ((i % 7) + 1) / 10);
+	};
+	runtime.registerModel(
+		ModelType.TEXT_EMBEDDING,
+		async () => embed(),
+		"orphan-compensation-test",
+		1_000,
+	);
+	runtime.registerModel(
+		ModelType.TEXT_EMBEDDING_BATCH,
+		async (_runtime, params: { texts?: string[] }) => {
+			const texts = Array.isArray(params.texts) ? params.texts : [];
+			return Promise.all(texts.map(() => embed()));
+		},
+		"orphan-compensation-test",
+		1_000,
+	);
+	service = new DocumentService(runtime);
+}, 180_000);
+
+afterAll(async () => {
+	await cleanup();
+});
+
+describe("addDocument orphan compensation (#16021)", () => {
+	it("removes the parent DOCUMENT row when every fragment fails to embed", async () => {
+		embedShouldFail = true;
+		await expect(
+			service.addDocument({
+				agentId: runtime.agentId,
+				clientDocumentId: "f1600000-0000-4000-8000-000000000001" as UUID,
+				content: DOC_TEXT,
+				contentType: "text/plain",
+				originalFilename: "orphan-fail.txt",
+				worldId: runtime.agentId as UUID,
+				roomId: runtime.agentId as UUID,
+				entityId: runtime.agentId as UUID,
+			}),
+		).rejects.toThrow(/orphan-fail\.txt/);
+
+		// No orphaned zero-fragment DOCUMENT row may survive the failure: the
+		// list surface reads DOCUMENTS_TABLE, so a leftover row is the bug.
+		const documents = await runtime.getMemories({
+			tableName: "documents",
+			agentId: runtime.agentId,
+			count: 10_000,
+		});
+		const orphan = documents.find(
+			(memory) =>
+				(memory.metadata as { title?: string } | undefined)?.title?.includes(
+					"orphan-fail",
+				) ||
+				(typeof memory.content?.text === "string" &&
+					memory.content.text.includes("orphan-compensation test")),
+		);
+		expect(orphan).toBeUndefined();
+	}, 120_000);
+
+	it("keeps the happy path intact: fragments embed and the document persists", async () => {
+		embedShouldFail = false;
+		const result = await service.addDocument({
+			agentId: runtime.agentId,
+			clientDocumentId: "f1600000-0000-4000-8000-000000000002" as UUID,
+			content: DOC_TEXT,
+			contentType: "text/plain",
+			originalFilename: "orphan-success.txt",
+			worldId: runtime.agentId as UUID,
+			roomId: runtime.agentId as UUID,
+			entityId: runtime.agentId as UUID,
+		});
+		expect(result.fragmentCount).toBeGreaterThan(0);
+		const stored = await runtime.getMemoryById(result.clientDocumentId as UUID);
+		expect(stored).not.toBeNull();
+		expect(await fragmentsFor(result.clientDocumentId)).toBe(
+			result.fragmentCount,
+		);
+	}, 120_000);
+
+	it("a retry after the compensated failure succeeds instead of hitting a stale stub", async () => {
+		embedShouldFail = true;
+		await expect(
+			service.addDocument({
+				agentId: runtime.agentId,
+				clientDocumentId: "f1600000-0000-4000-8000-000000000003" as UUID,
+				content: `retry lane ${DOC_TEXT}`,
+				contentType: "text/plain",
+				originalFilename: "orphan-retry.txt",
+				worldId: runtime.agentId as UUID,
+				roomId: runtime.agentId as UUID,
+				entityId: runtime.agentId as UUID,
+			}),
+		).rejects.toThrow();
+
+		embedShouldFail = false;
+		const retried = await service.addDocument({
+			agentId: runtime.agentId,
+			clientDocumentId: "f1600000-0000-4000-8000-000000000003" as UUID,
+			content: `retry lane ${DOC_TEXT}`,
+			contentType: "text/plain",
+			originalFilename: "orphan-retry.txt",
+			worldId: runtime.agentId as UUID,
+			roomId: runtime.agentId as UUID,
+			entityId: runtime.agentId as UUID,
+		});
+		expect(retried.fragmentCount).toBeGreaterThan(0);
+		expect(
+			await runtime.getMemoryById(retried.clientDocumentId as UUID),
+		).not.toBeNull();
+	}, 120_000);
+});

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -1154,19 +1154,46 @@ export class DocumentService extends Service {
 				fragmentCount = fragmentMemories.length;
 			} else {
 				await this.runtime.createMemory(memoryWithScope, DOCUMENTS_TABLE);
-				fragmentCount = await processFragmentsSynchronously({
-					runtime: this.runtime,
-					documentId: clientDocumentId,
-					fullDocumentText: extractedText,
-					agentId,
-					contentType,
-					roomId: roomId || agentId,
-					entityId: targetEntityId,
-					worldId: worldId || agentId,
-					documentTitle: originalFilename,
-					documentMetadata:
-						(documentMemory.metadata as Record<string, unknown>) ?? undefined,
-				});
+				try {
+					fragmentCount = await processFragmentsSynchronously({
+						runtime: this.runtime,
+						documentId: clientDocumentId,
+						fullDocumentText: extractedText,
+						agentId,
+						contentType,
+						roomId: roomId || agentId,
+						entityId: targetEntityId,
+						worldId: worldId || agentId,
+						documentTitle: originalFilename,
+						documentMetadata:
+							(documentMemory.metadata as Record<string, unknown>) ?? undefined,
+					});
+				} catch (fragmentError) {
+					// error-policy:J2 The parent DOCUMENT row was already written; an
+					// embed-time failure here would otherwise leave an orphaned
+					// zero-fragment document visible in lists but unsearchable
+					// (#16021). Compensate by removing the parent (and any partially
+					// persisted fragments) before rethrowing the original failure,
+					// which the outer catch wraps with document identity.
+					await this.compensateFailedIngestion(clientDocumentId);
+					throw fragmentError;
+				}
+				// extractedText is verified non-empty above, so the splitter always
+				// yields at least one chunk — zero saved fragments means every chunk
+				// failed (typically an embed-time provider failure that
+				// processAndSaveFragments counts rather than throws). Surface that as
+				// the failure it is instead of a healthy-looking zero-fragment
+				// document (#16021).
+				if (fragmentCount === 0) {
+					await this.compensateFailedIngestion(clientDocumentId);
+					throw new ElizaError(
+						`All fragments failed processing for ${originalFilename}`,
+						{
+							code: "DOCUMENT_EMBED_FAILED",
+							context: { originalFilename, contentType, clientDocumentId },
+						},
+					);
+				}
 			}
 
 			logger.debug(
@@ -1186,6 +1213,48 @@ export class DocumentService extends Service {
 				context: { originalFilename, contentType },
 				cause: error,
 			});
+		}
+	}
+
+	/**
+	 * Best-effort rollback for a create-path ingestion that failed after the
+	 * parent DOCUMENT row was written: delete any partially persisted fragments,
+	 * then the parent row itself, so failed adds are invisible instead of
+	 * surfacing as zero-fragment orphans (#16021). Cleanup failures are reported
+	 * but never mask the original ingestion error the caller is rethrowing.
+	 */
+	private async compensateFailedIngestion(documentId: UUID): Promise<void> {
+		try {
+			const fragments = await this.runtime.getMemories({
+				tableName: DOCUMENT_FRAGMENTS_TABLE,
+				agentId: this.runtime.agentId,
+				count: 10_000,
+			});
+			for (const fragment of fragments) {
+				if (
+					fragment.id &&
+					(fragment.metadata as DocumentFragmentMemoryMetadata | undefined)
+						?.documentId === documentId
+				) {
+					await this.runtime.deleteMemory(fragment.id);
+				}
+			}
+			await this.runtime.deleteMemory(documentId);
+			logger.warn(
+				`DocumentService: rolled back parent document ${documentId} after fragment processing failed`,
+			);
+		} catch (cleanupError) {
+			// error-policy:J7 Compensation is diagnostic cleanup — the original
+			// fragment-processing failure is the error that must propagate; a
+			// failed rollback degrades to the pre-existing self-heal on retry
+			// (checkExistingDocument deletes zero-fragment stubs).
+			this.runtime.reportError(
+				"DocumentService.compensateFailedIngestion",
+				cleanupError instanceof Error
+					? cleanupError
+					: new Error(String(cleanupError)),
+				{ documentId },
+			);
 		}
 	}
 


### PR DESCRIPTION
Fixes #16021

## What

`addDocument` wrote the parent DOCUMENT row before `processFragmentsSynchronously`; an embed-time failure then left an orphaned zero-fragment document visible in lists but unsearchable, with only retry-time self-heal (`checkExistingDocument` stub deletion) as recovery.

- On a fragment-processing throw after the parent write, a compensating rollback deletes any partially persisted fragments and the parent row, then rethrows the original failure (existing typed rethrow and `runtime.reportError` paths preserved).
- Zero saved fragments for verified non-empty text now throws a typed `ElizaError(DOCUMENT_EMBED_FAILED)` (with the same rollback) instead of returning a healthy-looking zero-fragment document — `processAndSaveFragments` counts per-chunk embed failures rather than throwing, so this is the common orphan path.
- Rollback failure degrades to the pre-existing retry self-heal and is reported via `runtime.reportError` (`error-policy:J7`).

## Scope note

The issue triage tracks a larger unified atomic create/update revision protocol (with #16111). This PR is the bounded create-path mitigation: failed adds are now invisible instead of orphaned. It does not add transaction semantics; the update path and crash-window atomicity remain for the unified follow-up.

## Tests

- New `packages/core/src/features/documents/service-orphan-compensation.test.ts` — real `AgentRuntime` over real PGLite (plugin-sql), injected embedding-provider outage:
  - embed failure leaves no parent row and no fragments (proven red without the fix: 2 failed / 1 passed; green with it: 3 passed)
  - retry after outage clears ingests cleanly with fragments
- `bun run --cwd packages/core typecheck` clean; Biome clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)