### PR TITLE
fix(cloud): stop treating operator digest pins as fleet tag drift

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-fleet-candidate-repo.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-fleet-candidate-repo.test.ts
@@ -132,7 +132,8 @@ describe("fleet candidate selection matches default image by repo (#15101)", () 
       dockerImage: `${DEFAULT_REPO}:sha-oldabc`,
       imageDigest: "sha256:stale-1",
     });
-    // Same repo, digest-pinned ref — also a fleet agent.
+    // Same repo, malformed short-hex pseudo-pin — NOT a canonical operator
+    // digest pin (#18030), so it remains an ordinary fleet drift candidate.
     const digestPinned = await seedFleetAgent(organizationId, userId, {
       dockerImage: `${DEFAULT_REPO}@sha256:deadbeef`,
       imageDigest: "sha256:stale-2",
@@ -241,5 +242,126 @@ describe("imageRepoSql matches imageRepo across ref shapes (#15101)", () => {
       );
       expect(row.repo).toBe(imageRepo(ref));
     }
+  });
+});
+
+const NEWER_PIN_DIGEST = `sha256:${"b".repeat(64)}`;
+const TARGET_DIGEST = `sha256:${"a".repeat(64)}`;
+
+describe("operator digest pins are not tag drift (#18030)", () => {
+  test("a canonical @sha256 pin on the default repo is excluded from convergence", async () => {
+    expect(pgliteReady).toBe(true);
+    const { organizationId, userId } = await seedOrgAndUser();
+
+    // Digest-pinned-newer: operator pinned an exact digest (e.g. a canary
+    // build published AFTER the default tag's digest). Pre-fix this row was
+    // selected as drift and auto-downgraded mid-canary.
+    const pinnedNewer = await seedFleetAgent(organizationId, userId, {
+      dockerImage: `${DEFAULT_REPO}@${NEWER_PIN_DIGEST}`,
+      imageDigest: NEWER_PIN_DIGEST,
+    });
+    // Tag-pinned-older: an old TAG is still mutable fleet drift (#15101 scope
+    // survives for tags) — must be selected.
+    const tagPinnedOlder = await seedFleetAgent(organizationId, userId, {
+      dockerImage: `${DEFAULT_REPO}:sha-older`,
+      imageDigest: `sha256:${"c".repeat(64)}`,
+    });
+    // Default-tag row on a stale digest — the ordinary upgrade candidate.
+    const defaultTag = await seedFleetAgent(organizationId, userId, {
+      dockerImage: DEFAULT_IMAGE,
+      imageDigest: `sha256:${"d".repeat(64)}`,
+    });
+
+    const rows = await repo.listRunningWithDigestOtherThan(TARGET_DIGEST, DEFAULT_IMAGE, 50);
+    const ids = new Set(rows.map((r) => r.id));
+
+    expect(ids.has(pinnedNewer)).toBe(false);
+    expect(ids.has(tagPinnedOlder)).toBe(true);
+    expect(ids.has(defaultTag)).toBe(true);
+  });
+
+  test("a pin equal to the target digest still self-heals a stale image_digest column", async () => {
+    expect(pgliteReady).toBe(true);
+    const { organizationId, userId } = await seedOrgAndUser();
+
+    const selfHeal = await seedFleetAgent(organizationId, userId, {
+      dockerImage: `${DEFAULT_REPO}@${TARGET_DIGEST}`,
+      imageDigest: `sha256:${"e".repeat(64)}`,
+    });
+    // Pin equals target AND the column already matches — nothing to do.
+    const converged = await seedFleetAgent(organizationId, userId, {
+      dockerImage: `${DEFAULT_REPO}@${TARGET_DIGEST}`,
+      imageDigest: TARGET_DIGEST,
+    });
+
+    const rows = await repo.listRunningWithDigestOtherThan(TARGET_DIGEST, DEFAULT_IMAGE, 50);
+    const ids = new Set(rows.map((r) => r.id));
+
+    expect(ids.has(selfHeal)).toBe(true);
+    expect(ids.has(converged)).toBe(false);
+  });
+
+  test("malformed pseudo-pins do not earn operator-pin status", async () => {
+    expect(pgliteReady).toBe(true);
+    const { organizationId, userId } = await seedOrgAndUser();
+
+    const shortHex = await seedFleetAgent(organizationId, userId, {
+      dockerImage: `${DEFAULT_REPO}@sha256:deadbeef`,
+      imageDigest: `sha256:${"f".repeat(64)}`,
+    });
+    const doubleAt = await seedFleetAgent(organizationId, userId, {
+      dockerImage: `${DEFAULT_REPO}@@${NEWER_PIN_DIGEST}`,
+      imageDigest: `sha256:${"9".repeat(64)}`,
+    });
+
+    const rows = await repo.listRunningWithDigestOtherThan(TARGET_DIGEST, DEFAULT_IMAGE, 50);
+    const ids = new Set(rows.map((r) => r.id));
+
+    expect(ids.has(shortHex)).toBe(true);
+    expect(ids.has(doubleAt)).toBe(true);
+  });
+
+  test("SQL pin classification agrees with the JS helpers for every ref shape", async () => {
+    expect(pgliteReady).toBe(true);
+    const { isDigestPinnedImage, isDigestPinnedImageSql, pinnedImageDigest, pinnedImageDigestSql } =
+      await import("../../utils/docker-image-ref");
+    const cases = [
+      `${DEFAULT_REPO}@${TARGET_DIGEST}`,
+      `${DEFAULT_REPO}:prod@${TARGET_DIGEST}`,
+      ` ${DEFAULT_REPO}@${TARGET_DIGEST} `,
+      `${DEFAULT_REPO}@sha256:deadbeef`,
+      `${DEFAULT_REPO}@@${TARGET_DIGEST}`,
+      `${DEFAULT_REPO}:prod`,
+      DEFAULT_REPO,
+      `${DEFAULT_REPO}@sha256:${"A".repeat(64)}`,
+    ];
+    for (const ref of cases) {
+      const [row] = await sqlRows<{ pinned: boolean; digest: string }>(
+        dbWrite,
+        sql`SELECT ${isDigestPinnedImageSql(sql`${ref}`)} AS pinned, ${pinnedImageDigestSql(sql`${ref}`)} AS digest`,
+      );
+      expect(row.pinned).toBe(isDigestPinnedImage(ref));
+      if (row.pinned) {
+        expect(row.digest).toBe(pinnedImageDigest(ref) ?? "");
+      }
+    }
+  });
+});
+
+describe("repinImageDigest keeps writeback pairs matched (#18030)", () => {
+  test("re-pins a canonical pin, leaves tags/bare/malformed refs untouched", async () => {
+    const { repinImageDigest } = await import("../../utils/docker-image-ref");
+    const to = TARGET_DIGEST;
+    expect(repinImageDigest(`${DEFAULT_REPO}@${NEWER_PIN_DIGEST}`, to)).toBe(
+      `${DEFAULT_REPO}@${to}`,
+    );
+    expect(repinImageDigest(`${DEFAULT_REPO}:prod@${NEWER_PIN_DIGEST}`, to)).toBe(
+      `${DEFAULT_REPO}:prod@${to}`,
+    );
+    expect(repinImageDigest(`${DEFAULT_REPO}:prod`, to)).toBe(`${DEFAULT_REPO}:prod`);
+    expect(repinImageDigest(DEFAULT_REPO, to)).toBe(DEFAULT_REPO);
+    expect(repinImageDigest(`${DEFAULT_REPO}@sha256:deadbeef`, to)).toBe(
+      `${DEFAULT_REPO}@sha256:deadbeef`,
+    );
   });
 });

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -72,7 +72,12 @@ import {
 } from "../schemas/agent-sandboxes";
 import { dockerNodes } from "../schemas/docker-nodes";
 import { jobs } from "../schemas/jobs";
-import { imageRepo, imageRepoSql } from "../utils/docker-image-ref";
+import {
+  imageRepo,
+  imageRepoSql,
+  isDigestPinnedImageSql,
+  pinnedImageDigestSql,
+} from "../utils/docker-image-ref";
 
 export type {
   AgentBackupSnapshotType,
@@ -686,11 +691,26 @@ export class AgentSandboxesRepository {
           )`,
           // Only reconcile agents on the configured default image. Per-agent
           // image overrides are intentional and must not be rolled onto the
-          // global fleet tag. Match on the REPO, not the full ref: a fleet agent
-          // pinned to an older tag or a digest (`…:sha-abc`, `…@sha256:…`) is
-          // still the default image and must be selected, otherwise sha-pinned
-          // default agents never drift back to the current default (#15101).
+          // global fleet tag. Match on the REPO, not the full ref: a fleet
+          // agent pinned to an older TAG (`…:sha-abc`) is still the default
+          // image and must be selected, otherwise tag-pinned default agents
+          // never drift back to the current default (#15101). Explicit digest
+          // pins are handled separately below (#18030).
           sql`(${agentSandboxes.docker_image} IS NULL OR ${imageRepoSql(agentSandboxes.docker_image)} = ${imageRepo(targetImage)})`,
+          // An explicit canonical `@sha256:<64hex>` docker_image is an operator
+          // placement decision, not tag drift (#18030): the reconciler must
+          // never converge a digest-pinned row onto the moving default tag —
+          // that is exactly the mechanism that downgraded a live agent
+          // mid-canary. The #15101 drift-back requirement is hereby scoped to
+          // tag pins only. One exception keeps self-healing: when the pinned
+          // digest IS the configured target digest, selecting the row merely
+          // repairs a stale image_digest column. Malformed pseudo-pins (short
+          // hex, double `@`) do not earn pin status and stay drift candidates.
+          sql`(
+            ${agentSandboxes.docker_image} IS NULL
+            OR NOT ${isDigestPinnedImageSql(agentSandboxes.docker_image)}
+            OR ${pinnedImageDigestSql(agentSandboxes.docker_image)} = ${targetDigest}
+          )`,
           // Skip pool-owned rows (warm pool entries) — they get the new
           // image naturally on next claim, no need to disrupt them.
           sql`${agentSandboxes.pool_status} IS NULL`,

--- a/packages/cloud/shared/src/db/utils/docker-image-ref.ts
+++ b/packages/cloud/shared/src/db/utils/docker-image-ref.ts
@@ -16,6 +16,63 @@
 import { type Column, type SQL, sql } from "drizzle-orm";
 
 /**
+ * Canonical explicit digest pin: `repo[:tag]@sha256:<64 lowercase hex>` with a
+ * single `@`. Anything looser (short hex, uppercase, double `@`) is a malformed
+ * pseudo-pin and deliberately does NOT earn operator-pin status — it stays an
+ * ordinary drift candidate rather than freezing an agent on a typo (#18030).
+ * Keep in lockstep with `DIGEST_PINNED_IMAGE_SQL_PATTERN` below.
+ */
+const DIGEST_PINNED_IMAGE_PATTERN = /^[^@\s]+@sha256:[0-9a-f]{64}$/;
+
+/** Postgres POSIX-regex equivalent of {@link DIGEST_PINNED_IMAGE_PATTERN}. */
+const DIGEST_PINNED_IMAGE_SQL_PATTERN = "^[^@[:space:]]+@sha256:[0-9a-f]{64}$";
+
+/** Whether a docker image ref is a canonical explicit `@sha256` digest pin. */
+export function isDigestPinnedImage(image: string): boolean {
+  return DIGEST_PINNED_IMAGE_PATTERN.test(image.trim());
+}
+
+/**
+ * The `sha256:<hex>` digest of a canonical digest-pinned ref, or null when the
+ * ref is not canonically pinned (including malformed pseudo-pins).
+ */
+export function pinnedImageDigest(image: string): string | null {
+  const trimmed = image.trim();
+  if (!DIGEST_PINNED_IMAGE_PATTERN.test(trimmed)) return null;
+  return trimmed.slice(trimmed.indexOf("@") + 1);
+}
+
+/**
+ * Rewrites the digest of a canonical digest-pinned ref so `docker_image` and
+ * `image_digest` stay a matched pair across a blue/green swap writeback
+ * (#18030). Non-pinned (tag or bare) refs are returned unchanged — their text
+ * does not encode a digest, so no rewrite is needed for consistency.
+ */
+export function repinImageDigest(image: string, digest: string): string {
+  const trimmed = image.trim();
+  if (!DIGEST_PINNED_IMAGE_PATTERN.test(trimmed)) return image;
+  return `${trimmed.slice(0, trimmed.indexOf("@"))}@${digest}`;
+}
+
+/**
+ * Postgres predicate: the stored ref is a canonical explicit digest pin.
+ * Mirrors `isDigestPinnedImage` exactly (whitespace-trimmed, single `@`,
+ * 64 lowercase hex) — the two MUST agree.
+ */
+export function isDigestPinnedImageSql(image: Column | SQL): SQL {
+  return sql`(btrim(${image}) ~ ${DIGEST_PINNED_IMAGE_SQL_PATTERN})`;
+}
+
+/**
+ * Postgres expression yielding the `sha256:<hex>` digest portion of a stored
+ * ref. Only meaningful under {@link isDigestPinnedImageSql}; a canonical pin
+ * has exactly one `@`, so `split_part(..., '@', 2)` is the full digest.
+ */
+export function pinnedImageDigestSql(image: Column | SQL): SQL {
+  return sql`split_part(btrim(${image}), '@', 2)`;
+}
+
+/**
  * The repo portion of a docker image ref (strips the `:tag` / `@digest`).
  *
  * A tag is the segment after the LAST `:` only when it has no `/` after it, so a

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -40,7 +40,7 @@ import {
 } from "../../db/schemas/agent-sandboxes";
 import { dockerNodes } from "../../db/schemas/docker-nodes";
 import { jobs } from "../../db/schemas/jobs";
-import { imageRepo } from "../../db/utils/docker-image-ref";
+import { imageRepo, repinImageDigest } from "../../db/utils/docker-image-ref";
 import type { RuntimeDurableObjectNamespace } from "../../types/cloud-worker-env";
 import { ApiError } from "../api/cloud-worker-errors";
 import { InsufficientCreditsError as InsufficientCreditsApiError } from "../api/errors";
@@ -9132,7 +9132,15 @@ export class ElizaSandboxService {
             bridge_port = ${blueMeta.bridgePort},
             web_ui_port = ${blueMeta.webUiPort},
             headscale_ip = ${blueMeta.headscaleIp ?? null},
-            docker_image = ${adminCanary ? adminCanary.targetImage : current.docker_image},
+            docker_image = ${
+              // A digest-pinned ref is re-pinned to the digest the row now
+              // actually runs, so docker_image and image_digest never become a
+              // mismatched pair (#18030). Tag/bare refs carry no digest text
+              // and are kept verbatim.
+              adminCanary
+                ? adminCanary.targetImage
+                : current.docker_image && repinImageDigest(current.docker_image, toDigest)
+            },
             image_digest = ${toDigest},
             previous_image_digest = ${fromDigest},
             previous_docker_image = ${
@@ -9644,7 +9652,15 @@ export class ElizaSandboxService {
             bridge_port = ${blueMeta.bridgePort},
             web_ui_port = ${blueMeta.webUiPort},
             headscale_ip = ${blueMeta.headscaleIp ?? null},
-            docker_image = ${adminCanary ? adminCanary.targetImage : current.docker_image},
+            docker_image = ${
+              // Downgrade-writeback pairing (#18030): re-pin a digest-pinned
+              // ref onto the digest being rolled back to; otherwise the row
+              // would advertise the abandoned digest in docker_image while
+              // image_digest records the rolled-back one.
+              adminCanary
+                ? adminCanary.targetImage
+                : current.docker_image && repinImageDigest(current.docker_image, toDigest)
+            },
             image_digest = ${toDigest},
             previous_image_digest = NULL,
             previous_docker_image = NULL,


### PR DESCRIPTION
Fixes #18030

## What

`listRunningWithDigestOtherThan` (packages/cloud/shared/src/db/repositories/agent-sandboxes.ts) matched fleet-upgrade candidates by **repo alone**, so an operator-pinned `repo@sha256:<digest>` row on the default repo was selected as tag drift and converged back onto the moving default tag — exactly the mechanism that auto-downgraded a live dedicated agent mid-canary.

- **Pin guard:** canonical `repo[:tag]@sha256:<64 lowercase hex>` refs are excluded from tag-drift convergence (SQL predicate mirrored 1:1 by a TS helper in `docker-image-ref.ts`). The #15101 sha-pinned-drift-back requirement is reconciled by scoping it to **tag** pins only, which still drift back.
- **Self-heal exception:** a pin equal to the configured target digest still selects, so a stale `image_digest` column repairs itself.
- **Malformed pseudo-pins** (short hex, uppercase, double `@`) do not earn operator-pin status and remain ordinary drift candidates.
- **Writeback pairing:** the blue/green upgrade *and* downgrade writebacks in `eliza-sandbox.ts` now re-pin a digest-pinned `docker_image` onto the digest actually written to `image_digest`, so the two columns can no longer end up a mismatched pair.

Known remaining race (disclosed, follow-up scope): a job already queued before a pin appears is not cancelled by this query repair; an execution-time fence is separate lifecycle work (also noted by the prior contributor claim on the issue — this lands the same steady-state slice they could not publish).

## Tests

- `bun test packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-fleet-candidate-repo.test.ts` (real PGlite): 9 pass / 59 assertions — digest-pinned-newer excluded, tag-pinned-older + default-tag selected, target-equal pin self-heals, converged pin skipped, pseudo-pins stay candidates, plus the pre-existing #15101 matrix.
- `bun test packages/cloud/scripts/admin/daemons/provisioning-worker.image-rollout.test.ts`: 4 pass / 0 fail after rebase; the previously disclosed clean-develop entrypoint failure was repaired upstream.
- `bun run --cwd packages/cloud/shared typecheck` clean; Biome clean on all four touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:9b53b95d24370918c5b4df7da77d3b1faa20010c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Backend fleet reconciliation change; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Backend fleet reconciliation change; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No interactive flow; real PGlite and daemon-entrypoint tests exercise the path.

<!-- evidence-row:backend-logs -->
- [ ] N/A - Deterministic PGlite and one-shot daemon tests provide the exact-head execution proof.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend behavior changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No model, prompt, or planner behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No live fleet mutation was performed; database selection and writeback helpers are contract-tested.

<!-- evidence-row:ocr-review -->
- [ ] N/A - No rendered visual surface.

