### PR TITLE
fix(cloud): narrow concurrent phone owner in test

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/users-promote-phone-personal-account.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/users-promote-phone-personal-account.test.ts
@@ -389,8 +389,11 @@ describe("UsersRepository phone identity transactions (real PGlite)", () => {
     expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
     expect(results.filter((result) => result.status === "rejected")).toHaveLength(1);
     const owner = await usersRepository.findByPhoneNumberWithOrganization(phoneNumber);
-    expect([firstClaimant.user.id, secondClaimant.user.id]).toContain(owner?.id);
-    const loser = owner?.id === firstClaimant.user.id ? secondClaimant : firstClaimant;
+    if (!owner) {
+      throw new Error("Expected one concurrent claimant to own the verified phone number");
+    }
+    expect([firstClaimant.user.id, secondClaimant.user.id]).toContain(owner.id);
+    const loser = owner.id === firstClaimant.user.id ? secondClaimant : firstClaimant;
     const [loserCanonical] = await dbWrite.select().from(users).where(eq(users.id, loser.user.id));
     const [loserProjection] = await dbWrite
       .select()


### PR DESCRIPTION
## Summary
- fail explicitly when the concurrent verified-phone test produces no owner
- narrow the owner before asserting its ID, restoring cloud and repository typecheck after #19921

## Verification
- `bun run --cwd packages/cloud/shared typecheck`
- `bun test packages/cloud/shared/src/db/repositories/__tests__/users-promote-phone-personal-account.test.ts` (16/16)
- `bunx @biomejs/biome check packages/cloud/shared/src/db/repositories/__tests__/users-promote-phone-personal-account.test.ts`
- `bun run verify` (350/350 Turbo tasks; all repository audits passed)

## Attribution
Reviewed and repaired with Codex desktop using OpenAI / gpt-5.