### PR TITLE
fix: model-inferred cadence needs the user's own recurrence words

### DIFF
--- a/packages/agent/src/actions/trigger.test.ts
+++ b/packages/agent/src/actions/trigger.test.ts
@@ -1723,20 +1723,68 @@ describe("TRIGGER list — dropped rows are counted, not hidden", () => {
   });
 });
 
+describe("sprayed one-shot cap on an explicit recurrence", () => {
+  it("drops maxRuns=1 when the user's own words state a repeating cadence", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    // Field-spraying planners answering "every morning" emit the cron AND a
+    // derived one-shot maxRuns:1 echo; the user's stated cadence wins.
+    const result = await create(
+      runtime,
+      {
+        instructions: "do 20 pushups",
+        cronExpression: "0 8 * * *",
+        maxRuns: 1,
+      },
+      "do 20 pushups every morning at 8am",
+    );
+    expect(result?.success).toBe(true);
+    const trigger = (
+      createdTasks[0]?.metadata as { trigger?: { maxRuns?: number } }
+    )?.trigger;
+    expect(trigger?.maxRuns).toBeUndefined();
+  });
+
+  it("keeps maxRuns=1 when the text states no recurrence", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const result = await create(
+      runtime,
+      {
+        instructions: "call the bank",
+        cronExpression: "0 9 * * *",
+        maxRuns: 1,
+      },
+      "remind me to call the bank at 9am",
+    );
+    expect(result?.success).toBe(true);
+    const trigger = (
+      createdTasks[0]?.metadata as { trigger?: { maxRuns?: number } }
+    )?.trigger;
+    expect(trigger?.maxRuns).toBe(1);
+  });
+});
+
 describe("one-shot cron reminder confirmation", () => {
   it("describes a maxRuns=1 cron by its next occurrence, never as recurring", async () => {
-    const { runtime } = makeRuntime({ enableAutonomy: false });
-    const result = await create(runtime, {
-      instructions: "call the bank",
-      cronExpression: "0 9 * * *",
-      maxRuns: 1,
-    });
-    expect(result?.success).toBe(true);
-    // The trigger fires once at the next 9am and stops; the confirmation must
-    // read as a one-shot, not a recurrence the trigger cannot have.
-    expect(result?.text).not.toContain("every morning");
-    expect(result?.text).not.toContain("every day");
-    expect(result?.text).toMatch(/9(:00)?\s?(a\.?m\.?)/i);
+    // Pin the clock well before 9am: within an hour of the fire the
+    // humanizer legitimately says "in NN minutes" instead of naming 9am.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-15T03:00:00.000Z"));
+    try {
+      const { runtime } = makeRuntime({ enableAutonomy: false });
+      const result = await create(runtime, {
+        instructions: "call the bank",
+        cronExpression: "0 9 * * *",
+        maxRuns: 1,
+      });
+      expect(result?.success).toBe(true);
+      // The trigger fires once at the next 9am and stops; the confirmation must
+      // read as a one-shot, not a recurrence the trigger cannot have.
+      expect(result?.text).not.toContain("every morning");
+      expect(result?.text).not.toContain("every day");
+      expect(result?.text).toMatch(/9(:00)?\s?(a\.?m\.?)/i);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("describes the persisted occurrence when persistence crosses the cron boundary", async () => {

--- a/packages/agent/src/actions/trigger.test.ts
+++ b/packages/agent/src/actions/trigger.test.ts
@@ -1744,6 +1744,44 @@ describe("sprayed one-shot cap on an explicit recurrence", () => {
     expect(trigger?.maxRuns).toBeUndefined();
   });
 
+  it("drops the cap on a bare weekday recurrence ('every tuesday')", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const result = await create(
+      runtime,
+      {
+        instructions: "take out recycling",
+        cronExpression: "0 8 * * 2",
+        maxRuns: 1,
+      },
+      "take out recycling every tuesday at 8am",
+    );
+    expect(result?.success).toBe(true);
+    const trigger = (
+      createdTasks[0]?.metadata as { trigger?: { maxRuns?: number } }
+    )?.trigger;
+    expect(trigger?.maxRuns).toBeUndefined();
+  });
+
+  it("keeps maxRuns=1 when the text has only a time-of-day window phrase", async () => {
+    // "in the morning" is a WINDOW, not a recurrence — a one-shot reminder
+    // must not become an unbounded daily cron because of it.
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const result = await create(
+      runtime,
+      {
+        instructions: "call mom",
+        cronExpression: "0 9 * * *",
+        maxRuns: 1,
+      },
+      "remind me to call mom in the morning",
+    );
+    expect(result?.success).toBe(true);
+    const trigger = (
+      createdTasks[0]?.metadata as { trigger?: { maxRuns?: number } }
+    )?.trigger;
+    expect(trigger?.maxRuns).toBe(1);
+  });
+
   it("keeps maxRuns=1 when the text states no recurrence", async () => {
     const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
     const result = await create(

--- a/packages/agent/src/actions/trigger.test.ts
+++ b/packages/agent/src/actions/trigger.test.ts
@@ -1836,6 +1836,54 @@ describe("sprayed one-shot cap on an explicit recurrence", () => {
     expect(trigger?.maxRuns).toBeUndefined();
   });
 
+  it("drops maxRuns=1 for explicit Japanese recurrence", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const result = await create(
+      runtime,
+      {
+        instructions: "水を飲む",
+        cronExpression: "0 9 * * *",
+        maxRuns: 1,
+      },
+      "毎日午前9時に水を飲むようにリマインドして",
+    );
+    expect(result?.success).toBe(true);
+    const trigger = (
+      createdTasks[0]?.metadata as { trigger?: { maxRuns?: number } }
+    )?.trigger;
+    expect(trigger?.maxRuns).toBeUndefined();
+  });
+
+  it("drops maxRuns=1 for explicit numeric cadence", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const result = await create(
+      runtime,
+      {
+        instructions: "check the queue",
+        cronExpression: "*/15 * * * *",
+        maxRuns: 1,
+      },
+      "check the queue every 15 minutes",
+    );
+    expect(result?.success).toBe(true);
+    expect(createdTasks[0]?.metadata.trigger?.maxRuns).toBeUndefined();
+  });
+
+  it("keeps maxRuns=1 when the current user negates recurrence", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const result = await create(
+      runtime,
+      {
+        instructions: "call the bank",
+        cronExpression: "0 9 * * *",
+        maxRuns: 1,
+      },
+      "remind me tomorrow, not every day",
+    );
+    expect(result?.success).toBe(true);
+    expect(createdTasks[0]?.metadata.trigger?.maxRuns).toBe(1);
+  });
+
   it("keeps maxRuns=1 when the text has only a time-of-day window phrase", async () => {
     // "in the morning" is a WINDOW, not a recurrence — a one-shot reminder
     // must not become an unbounded daily cron because of it.
@@ -1882,7 +1930,10 @@ describe("one-shot cron reminder confirmation", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-08-15T03:00:00.000Z"));
     try {
-      const { runtime } = makeRuntime({ enableAutonomy: false });
+      const { runtime } = makeRuntime({
+        enableAutonomy: false,
+        timeZone: "UTC",
+      });
       const result = await create(runtime, {
         instructions: "call the bank",
         cronExpression: "0 9 * * *",

--- a/packages/agent/src/actions/trigger.test.ts
+++ b/packages/agent/src/actions/trigger.test.ts
@@ -1723,6 +1723,80 @@ describe("TRIGGER list — dropped rows are counted, not hidden", () => {
   });
 });
 
+describe("trigger reference id/name mismatch guard", () => {
+  it("refuses to delete when taskId resolves to a different trigger than named", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const created = await create(
+      runtime,
+      {
+        instructions: "do 20 pushups",
+        cronExpression: "0 8 * * *",
+      },
+      "do 20 pushups every morning at 8am",
+    );
+    expect(created?.success).toBe(true);
+    // The default harness's createTask does not attach ids; materialize the
+    // stored task with one so the id-based reference path is exercised.
+    (runtime as unknown as { deleteTask: unknown }).deleteTask = vi.fn(
+      async () => undefined,
+    );
+    const storedTask = { ...createdTasks[0], id: stringToUuid("pushups-task") };
+    const taskId = String(storedTask.id);
+    (
+      runtime.getTask as unknown as { mockResolvedValue: (v: unknown) => void }
+    ).mockResolvedValue(storedTask);
+    // Live repro shape: the planner paired the pushups task id with the
+    // orchid's name; the delete must fail structurally, not fire.
+    const result = await triggerAction.handler(
+      runtime,
+      makeMessage("no, just once tomorrow morning"),
+      undefined,
+      {
+        parameters: {
+          action: "delete",
+          taskId,
+          displayName: "water the orchid",
+        },
+      },
+    );
+    expect(result?.success).toBe(false);
+    expect(result?.data).toMatchObject({ error: "TRIGGER_REF_MISMATCH" });
+    expect(runtime.deleteTask).not.toHaveBeenCalled();
+  });
+
+  it("deletes when the stated name matches the resolved trigger", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const created = await create(
+      runtime,
+      { instructions: "do 20 pushups", cronExpression: "0 8 * * *" },
+      "do 20 pushups every morning at 8am",
+    );
+    expect(created?.success).toBe(true);
+    (runtime as unknown as { deleteTask: unknown }).deleteTask = vi.fn(
+      async () => undefined,
+    );
+    const storedTask = { ...createdTasks[0], id: stringToUuid("pushups-task") };
+    const taskId = String(storedTask.id);
+    (
+      runtime.getTask as unknown as { mockResolvedValue: (v: unknown) => void }
+    ).mockResolvedValue(storedTask);
+    const result = await triggerAction.handler(
+      runtime,
+      makeMessage("delete the pushups trigger"),
+      undefined,
+      {
+        parameters: {
+          action: "delete",
+          taskId,
+          displayName: "pushups",
+        },
+      },
+    );
+    expect(result?.success).toBe(true);
+    expect(runtime.deleteTask).toHaveBeenCalled();
+  });
+});
+
 describe("sprayed one-shot cap on an explicit recurrence", () => {
   it("drops maxRuns=1 when the user's own words state a repeating cadence", async () => {
     const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });

--- a/packages/agent/src/actions/trigger.ts
+++ b/packages/agent/src/actions/trigger.ts
@@ -401,7 +401,40 @@ async function resolveTriggerRef(
   const taskId = readUuid(params.taskId);
   if (taskId) {
     const loaded = await loadTriggerTask(runtime, taskId);
-    if (loaded) return loaded;
+    if (loaded) {
+      // For ops where displayName is a REFERENCE (not a payload — update
+      // renames through it), a planner-supplied id must agree with the
+      // planner-supplied name. Context id/name mis-pairing is real: a live
+      // turn deleted the "pushups every morning" trigger while naming
+      // "water the orchid" because the id short-circuited unchecked.
+      const referenceName =
+        op === "delete" || op === "run" || op === "toggle"
+          ? readString(params.displayName)
+          : undefined;
+      if (referenceName) {
+        const normalize = (value: string) =>
+          value
+            .toLowerCase()
+            .replace(/^trigger:\s*/, "")
+            .trim();
+        const actual = normalize(loaded.trigger.displayName);
+        const stated = normalize(referenceName);
+        if (
+          stated &&
+          actual &&
+          !actual.includes(stated) &&
+          !stated.includes(actual)
+        ) {
+          return failed(
+            op,
+            `taskId resolves to "${displayLabel(loaded.trigger.displayName)}", not "${referenceName}". Not ${op === "delete" ? "deleting" : op === "run" ? "running" : "toggling"} — re-check the id or refer to the trigger by name only.`,
+            "TRIGGER_REF_MISMATCH",
+            { taskId: String(loaded.task.id) },
+          );
+        }
+      }
+      return loaded;
+    }
   }
   const rawId = readString(params.taskId);
   const querySource =

--- a/packages/agent/src/actions/trigger.ts
+++ b/packages/agent/src/actions/trigger.ts
@@ -38,7 +38,7 @@ import {
   type UUID,
   validateUuid,
 } from "@elizaos/core";
-import { findKeywordTermMatch } from "@elizaos/shared";
+import { textStatesExplicitRecurrence } from "@elizaos/shared";
 import {
   describeCronSchedule,
   describeIntervalMs,
@@ -59,7 +59,6 @@ import {
   parseScheduledAtIso,
 } from "../triggers/scheduling.ts";
 import type { TriggerTaskMetadata } from "../triggers/types.ts";
-import { getContextSignalTerms } from "./context-signal-lexicon.ts";
 
 type AutonomyRoomService = {
   getAutonomousRoomId?(): UUID;
@@ -581,17 +580,10 @@ async function opCreate(
   // A field-spraying planner answering "pushups every morning at 8am" emits
   // the cron AND maxRuns:1 from its derived one-shot echo, silently turning a
   // routine into a single fire. When the user's own words state a repeating
-  // cadence, the recurrence wins and the sprayed one-shot cap is dropped.
-  if (
-    maxRuns === 1 &&
-    cronExpression &&
-    findKeywordTermMatch(
-      text,
-      getContextSignalTerms("lifeops_cadence", "strong", {
-        includeAllLocales: true,
-      }),
-    ) !== undefined
-  ) {
+  // cadence (explicit-recurrence markers only — time-of-day window phrases
+  // like "in the morning" appear in one-shot asks and must NOT drop the cap),
+  // the recurrence wins and the sprayed one-shot cap is dropped.
+  if (maxRuns === 1 && cronExpression && textStatesExplicitRecurrence(text)) {
     maxRuns = undefined;
   }
 

--- a/packages/agent/src/actions/trigger.ts
+++ b/packages/agent/src/actions/trigger.ts
@@ -38,7 +38,7 @@ import {
   type UUID,
   validateUuid,
 } from "@elizaos/core";
-
+import { findKeywordTermMatch } from "@elizaos/shared";
 import {
   describeCronSchedule,
   describeIntervalMs,
@@ -59,6 +59,7 @@ import {
   parseScheduledAtIso,
 } from "../triggers/scheduling.ts";
 import type { TriggerTaskMetadata } from "../triggers/types.ts";
+import { getContextSignalTerms } from "./context-signal-lexicon.ts";
 
 type AutonomyRoomService = {
   getAutonomousRoomId?(): UUID;
@@ -576,7 +577,23 @@ async function opCreate(
   const intervalMs = normalizeTriggerIntervalMs(
     parsedIntervalMs ?? DEFAULT_INTERVAL_MS,
   );
-  const maxRuns = parsePositiveInt(params.maxRuns);
+  let maxRuns = parsePositiveInt(params.maxRuns);
+  // A field-spraying planner answering "pushups every morning at 8am" emits
+  // the cron AND maxRuns:1 from its derived one-shot echo, silently turning a
+  // routine into a single fire. When the user's own words state a repeating
+  // cadence, the recurrence wins and the sprayed one-shot cap is dropped.
+  if (
+    maxRuns === 1 &&
+    cronExpression &&
+    findKeywordTermMatch(
+      text,
+      getContextSignalTerms("lifeops_cadence", "strong", {
+        includeAllLocales: true,
+      }),
+    ) !== undefined
+  ) {
+    maxRuns = undefined;
+  }
 
   if (triggerType === "once") {
     const atMs = scheduledAtIso ? parseScheduledAtIso(scheduledAtIso) : null;

--- a/packages/shared/src/i18n/recurrence-markers.test.ts
+++ b/packages/shared/src/i18n/recurrence-markers.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  selectUserAuthorizedRecurrence,
+  textStatesExplicitRecurrence,
+} from "./recurrence-markers.ts";
+
+describe("textStatesExplicitRecurrence", () => {
+  it("accepts explicit Japanese recurrence in the shipped ja locale", () => {
+    expect(
+      textStatesExplicitRecurrence("毎日午前9時に水を飲むようにリマインドして"),
+    ).toBe(true);
+    expect(
+      textStatesExplicitRecurrence("毎週月曜日の午前10時にスタンドアップ"),
+    ).toBe(true);
+    expect(textStatesExplicitRecurrence("毎月1日に家賃を支払う")).toBe(true);
+    expect(textStatesExplicitRecurrence("週に一回バックアップする")).toBe(true);
+  });
+
+  it("accepts numeric English cadence", () => {
+    expect(textStatesExplicitRecurrence("back up every 2 days")).toBe(true);
+    expect(textStatesExplicitRecurrence("check every 15 minutes")).toBe(true);
+  });
+
+  it("lets current one-shot corrections outrank recurrence words", () => {
+    expect(
+      textStatesExplicitRecurrence("remind me tomorrow, not every day"),
+    ).toBe(false);
+    expect(
+      textStatesExplicitRecurrence(
+        "schedule standup Monday, not recurring, just once",
+      ),
+    ).toBe(false);
+    expect(
+      textStatesExplicitRecurrence(
+        "user: no, just once\nassistant: should this be weekly?",
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores role-labelled non-user text", () => {
+    expect(
+      textStatesExplicitRecurrence("assistant: should this be weekly?"),
+    ).toBe(false);
+    expect(
+      textStatesExplicitRecurrence("user: make it weekly\nassistant: okay"),
+    ).toBe(true);
+  });
+
+  it("rejects Japanese one-shot windows and name-like cadence words", () => {
+    expect(
+      textStatesExplicitRecurrence("明日の朝、歯医者の予定を追加して"),
+    ).toBe(false);
+    expect(
+      textStatesExplicitRecurrence("毎日新聞の取材を明日の朝に追加して"),
+    ).toBe(false);
+    expect(
+      textStatesExplicitRecurrence("毎日放送との会議を金曜日に追加して"),
+    ).toBe(false);
+  });
+});
+
+describe("selectUserAuthorizedRecurrence", () => {
+  const outerPlanner = ["RRULE:FREQ=WEEKLY;BYDAY=MO"];
+  const extracted = ["RRULE:FREQ=DAILY"];
+
+  it("drops every model-authored source for a one-off request", () => {
+    expect(
+      selectUserAuthorizedRecurrence(
+        ["add to my calendar: standup monday at 10am"],
+        [outerPlanner, extracted],
+      ),
+    ).toBeUndefined();
+  });
+
+  it("drops every source when the current user negates recurrence", () => {
+    expect(
+      selectUserAuthorizedRecurrence(
+        ["user: no, just once\nassistant: should this be weekly?"],
+        [outerPlanner, extracted],
+      ),
+    ).toBeUndefined();
+  });
+
+  it("returns the first source in caller precedence for explicit cadence", () => {
+    expect(
+      selectUserAuthorizedRecurrence(
+        ["schedule standup every monday at 10am"],
+        [outerPlanner, extracted],
+      ),
+    ).toEqual(outerPlanner);
+  });
+});

--- a/packages/shared/src/i18n/recurrence-markers.ts
+++ b/packages/shared/src/i18n/recurrence-markers.ts
@@ -14,7 +14,7 @@
 
 const ASCII_RECURRENCE_PATTERNS: readonly RegExp[] = [
   // en: every/each anchored to a schedule noun within the phrase
-  /\b(?:every|each)\s+(?:other\s+)?(?:day|week|month|year|morning|afternoon|evening|night|hour|weekday|weekend|mon(?:day)?|tues?(?:day)?|wed(?:nesday)?|thur?s?(?:day)?|fri(?:day)?|sat(?:urday)?|sun(?:day)?)s?\b/i,
+  /\b(?:every|each)\s+(?:(?:other|\d+)\s+)?(?:second|minute|hour|day|week|month|year|morning|afternoon|evening|night|weekday|weekend|mon(?:day)?|tues?(?:day)?|wed(?:nesday)?|thur?s?(?:day)?|fri(?:day)?|sat(?:urday)?|sun(?:day)?)s?\b/i,
   // "daily"/es "diario" match lowercase only: title-cased uses are names
   // ("Daily Planet interview", "comprar el Diario") — the review's observed
   // false-positive class.
@@ -67,23 +67,85 @@ const CJK_RECURRENCE_MARKERS: readonly string[] = [
   "격주",
 ];
 
+// Japanese is a shipped UI locale. Keep name-like newspaper/broadcaster uses
+// out while accepting productive "every" and interval/count constructions.
+const JAPANESE_RECURRENCE_PATTERNS: readonly RegExp[] = [
+  /毎日(?!新聞|放送)/,
+  /毎(?:週|月|年|朝|晩|夜|回|曜日)/,
+  /(?:隔週|隔月|隔年)/,
+  /(?:日|週|月|年)に(?:一|1|二|2|三|3)(?:度|回)/,
+  /(?:一|1|二|2|三|3)(?:日|週|か月|ヶ月|年)ごと/,
+];
+
+// A current-turn one-shot correction outranks cadence words in that same
+// user-authored text. This is intentionally safety-biased: retaining a
+// one-shot cap or dropping an RRULE is reversible; silently creating an
+// unbounded recurrence is not.
+const ONE_SHOT_PRECEDENCE_PATTERNS: readonly RegExp[] = [
+  /\b(?:not|no|never)\s+(?:a\s+)?(?:recurr(?:ing|ence)|repeat(?:ed|ing)?|every|each)\b/i,
+  /\b(?:do\s+not|don't)\s+repeat\b/i,
+  /\b(?:just|only)\s+(?:once|one\s+time)\b/i,
+  /\b(?:once|one\s+time)\s+only\b/i,
+  /(?:一度だけ|1回だけ|繰り返さない|毎日ではない)/,
+];
+
+function authoritativeSegments(text: string): string[] {
+  return text
+    .split(/\n+/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .flatMap((line) => {
+      const roleMatch = line.match(
+        /^(user|owner|assistant|agent|system)\s*:\s*(.*)$/i,
+      );
+      if (!roleMatch) return [line];
+      const role = roleMatch[1]?.toLowerCase();
+      return role === "user" || role === "owner" ? [roleMatch[2] ?? ""] : [];
+    });
+}
+
 /**
- * True when any of the provided texts states a repeating cadence in the
- * user's own words. Pass every text the turn can ground recurrence in — the
- * raw user message, the planner intent, and the recent-conversation window a
- * clarify round-trip carries ("make it weekly" answered in a prior turn).
+ * True when authoritative user-authored text states a repeating cadence.
+ * Role-labelled assistant/system text is ignored, and an explicit one-shot
+ * correction in the same input takes precedence over recurrence keywords.
  */
 export function textStatesExplicitRecurrence(
   ...texts: ReadonlyArray<string | null | undefined>
 ): boolean {
-  for (const text of texts) {
-    if (typeof text !== "string" || !text.trim()) continue;
+  const segments = texts.flatMap((text) =>
+    typeof text === "string" ? authoritativeSegments(text) : [],
+  );
+  if (
+    segments.some((text) =>
+      ONE_SHOT_PRECEDENCE_PATTERNS.some((pattern) => pattern.test(text)),
+    )
+  ) {
+    return false;
+  }
+
+  for (const text of segments) {
     if (ASCII_RECURRENCE_PATTERNS.some((pattern) => pattern.test(text))) {
       return true;
     }
     if (CJK_RECURRENCE_MARKERS.some((marker) => text.includes(marker))) {
       return true;
     }
+    if (JAPANESE_RECURRENCE_PATTERNS.some((pattern) => pattern.test(text))) {
+      return true;
+    }
   }
   return false;
+}
+
+/**
+ * Returns the first model-authored recurrence source only when authoritative
+ * user text explicitly permits recurrence. Callers provide sources in their
+ * existing precedence order (outer planner, domain extraction, fallback).
+ */
+export function selectUserAuthorizedRecurrence<T>(
+  authoritativeTexts: ReadonlyArray<string | null | undefined>,
+  sources: ReadonlyArray<T | null | undefined>,
+): T | undefined {
+  if (!textStatesExplicitRecurrence(...authoritativeTexts)) return undefined;
+  return sources.find((source): source is T => source != null);
 }

--- a/packages/shared/src/i18n/recurrence-markers.ts
+++ b/packages/shared/src/i18n/recurrence-markers.ts
@@ -1,0 +1,89 @@
+/**
+ * Explicit-recurrence detection for cadence guards: does the user's own text
+ * state a REPEATING schedule? This is deliberately narrower than the
+ * `lifeops_cadence` keyword doc — that doc also carries time-of-day WINDOW
+ * phrases ("in the morning", "before bed", "after work") used for window
+ * extraction, and a window phrase in a one-shot ask ("remind me to call mom
+ * in the morning") is not a recurrence statement. Guards that consumed the
+ * full doc flipped both ways: one-shot reminders lost their run cap and
+ * one-off calendar events kept model-invented RRULEs.
+ *
+ * ASCII languages match on word boundaries with schedule-noun anchoring so
+ * quantifier uses ("invite every member") stay out; CJK matches by substring.
+ */
+
+const ASCII_RECURRENCE_PATTERNS: readonly RegExp[] = [
+  // en: every/each anchored to a schedule noun within the phrase
+  /\b(?:every|each)\s+(?:other\s+)?(?:day|week|month|year|morning|afternoon|evening|night|hour|weekday|weekend|mon(?:day)?|tues?(?:day)?|wed(?:nesday)?|thur?s?(?:day)?|fri(?:day)?|sat(?:urday)?|sun(?:day)?)s?\b/i,
+  // "daily"/es "diario" match lowercase only: title-cased uses are names
+  // ("Daily Planet interview", "comprar el Diario") — the review's observed
+  // false-positive class.
+  /\bdaily\b/,
+  /\b(?:weekly|monthly|nightly|hourly|yearly|annually|quarterly|biweekly|fortnightly)\b/i,
+  /\brepeat(?:s|ing)\b|\brecurring\b|\brecurs?\b/i,
+  /\b(?:once|twice|thrice|\d+\s*times)\s+(?:a|per|each|every)\s+(?:day|week|month|year)\b/i,
+  /\bper\s+(?:day|week|month|year)\b/i,
+  /\b(?:on\s+)?(?:mondays|tuesdays|wednesdays|thursdays|fridays|saturdays|sundays)\b/i,
+  /\b(?:weekdays|weekends)\b/i,
+  // es: cada / todos los / todas las + schedule noun; adjective forms
+  /\b(?:cada|todos\s+los|todas\s+las)\s+(?:d[ií]as?|semanas?|mes(?:es)?|años?|mañanas?|noches?|tardes?|lunes|martes|mi[eé]rcoles|jueves|viernes|s[aá]bados?|domingos?)\b/i,
+  /\bdiario\b/,
+  /\b(?:diaria(?:mente)?|semanal(?:mente)?|mensual(?:mente)?|anual(?:mente)?)\b/i,
+  /\blos\s+(?:lunes|martes|mi[eé]rcoles|jueves|viernes|s[aá]bados|domingos)\b/i,
+  /\buna\s+vez\s+(?:a\s+la|por)\s+semana\b/i,
+  // pt: cada / todos os / todas as + schedule noun; adjective forms
+  /\b(?:cada|todos\s+os|todas\s+as)\s+(?:dias?|semanas?|m[eê]s(?:es)?|anos?|manh[aã]s?|noites?|tardes?|segundas?|ter[cç]as?|quartas?|quintas?|sextas?|s[aá]bados?|domingos?)\b/i,
+  /\b(?:diariamente|semanal(?:mente)?|mensal(?:mente)?|anual(?:mente)?)\b/i,
+  /\b(?:toda|todo)\s+(?:semana|m[eê]s|ano|segunda|ter[cç]a|quarta|quinta|sexta|s[aá]bado|domingo)\b/i,
+  /\buma\s+vez\s+por\s+(?:semana|m[eê]s)\b/i,
+  // vi: mỗi / hàng + schedule noun
+  /(?:mỗi|hàng|hằng)\s*(?:ngày|tuần|tháng|năm|sáng|tối|chiều)/i,
+  // tl: reduplicated schedule nouns and "tuwing"
+  /\b(?:araw-araw|linggo-linggo|buwan-buwan|taon-taon|gabi-gabi|tuwing|bawat\s+(?:araw|linggo|buwan|taon))\b/i,
+];
+
+// CJK repetition markers — substring matches (no word boundaries).
+const CJK_RECURRENCE_MARKERS: readonly string[] = [
+  // zh-CN
+  "每天",
+  "每日",
+  "每周",
+  "每星期",
+  "每个星期",
+  "每月",
+  "每个月",
+  "每年",
+  "天天",
+  "周一到周五",
+  "一周一次",
+  "每逢",
+  // ko — 마다 is the productive "every" suffix
+  "마다",
+  "매일",
+  "매주",
+  "매월",
+  "매달",
+  "매년",
+  "격주",
+];
+
+/**
+ * True when any of the provided texts states a repeating cadence in the
+ * user's own words. Pass every text the turn can ground recurrence in — the
+ * raw user message, the planner intent, and the recent-conversation window a
+ * clarify round-trip carries ("make it weekly" answered in a prior turn).
+ */
+export function textStatesExplicitRecurrence(
+  ...texts: ReadonlyArray<string | null | undefined>
+): boolean {
+  for (const text of texts) {
+    if (typeof text !== "string" || !text.trim()) continue;
+    if (ASCII_RECURRENCE_PATTERNS.some((pattern) => pattern.test(text))) {
+      return true;
+    }
+    if (CJK_RECURRENCE_MARKERS.some((marker) => text.includes(marker))) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -264,7 +264,10 @@ export * from "./format-error.js";
 // Canonical UI language codes + BCP-47 normalization (React-free) so Node
 // route handlers can normalize `Accept-Language` without the renderer.
 export * from "./i18n/language.js";
-export { textStatesExplicitRecurrence } from "./i18n/recurrence-markers.js";
+export {
+  selectUserAuthorizedRecurrence,
+  textStatesExplicitRecurrence,
+} from "./i18n/recurrence-markers.js";
 // Knowledge-graph primitives — canonical Entity/Relationship types + the
 // identity-merge engine. Dependency-free; the DB-backed stores stay in
 // @elizaos/plugin-personal-assistant.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -264,6 +264,7 @@ export * from "./format-error.js";
 // Canonical UI language codes + BCP-47 normalization (React-free) so Node
 // route handlers can normalize `Accept-Language` without the renderer.
 export * from "./i18n/language.js";
+export { textStatesExplicitRecurrence } from "./i18n/recurrence-markers.js";
 // Knowledge-graph primitives — canonical Entity/Relationship types + the
 // identity-merge engine. Dependency-free; the DB-backed stores stay in
 // @elizaos/plugin-personal-assistant.

--- a/plugins/plugin-calendar/src/actions/calendar-handler.recurrence-guard.test.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.recurrence-guard.test.ts
@@ -1,7 +1,9 @@
 /**
  * Deterministic coverage for the explicit-recurrence guard on model-inferred
- * RRULEs: cadence-flavored event nouns ("standup") must not become repeating
- * events unless the user's own words state a repeating cadence.
+ * RRULEs: cadence-flavored event nouns ("standup") and time-of-day window
+ * phrases ("in the morning") must not become repeating events; explicit
+ * recurrence in any supported language must keep them, including recurrence
+ * stated in a prior clarify turn carried via the conversation window.
  */
 import { describe, expect, it } from "vitest";
 import { intentStatesRecurrence } from "./calendar-handler.js";
@@ -19,7 +21,38 @@ describe("intentStatesRecurrence", () => {
     expect(intentStatesRecurrence("lunch with sam friday")).toBe(false);
   });
 
-  it("accepts explicit recurrence phrasings", () => {
+  it("rejects time-of-day window phrases in one-shot asks", () => {
+    // Window phrases live in the lifeops_cadence doc for WINDOW extraction;
+    // they are not recurrence statements and must not open the gate.
+    expect(intentStatesRecurrence("remind me to call mom in the morning")).toBe(
+      false,
+    );
+    expect(intentStatesRecurrence("dentist tomorrow in the morning")).toBe(
+      false,
+    );
+    expect(intentStatesRecurrence("take out the trash before bed")).toBe(false);
+    expect(intentStatesRecurrence("gym after work today")).toBe(false);
+  });
+
+  it("rejects name-like cadence words (title-cased daily/diario)", () => {
+    expect(
+      intentStatesRecurrence("Daily Planet interview tomorrow at 3pm"),
+    ).toBe(false);
+    expect(intentStatesRecurrence("recuérdame comprar el Diario mañana")).toBe(
+      false,
+    );
+  });
+
+  it("rejects quantifier uses of every/each", () => {
+    expect(
+      intentStatesRecurrence("invite every member to the launch party"),
+    ).toBe(false);
+    expect(
+      intentStatesRecurrence("add each attendee to the meeting invite"),
+    ).toBe(false);
+  });
+
+  it("accepts explicit English recurrence phrasings", () => {
     expect(intentStatesRecurrence("standup every monday at 10am")).toBe(true);
     expect(intentStatesRecurrence("gym weekly on wednesdays")).toBe(true);
     expect(intentStatesRecurrence("water the plants daily at 9")).toBe(true);
@@ -27,10 +60,40 @@ describe("intentStatesRecurrence", () => {
     expect(intentStatesRecurrence("recurring rent payment on the 1st")).toBe(
       true,
     );
+    expect(intentStatesRecurrence("yoga on tuesdays")).toBe(true);
+    expect(intentStatesRecurrence("review twice a week")).toBe(true);
+    expect(intentStatesRecurrence("standup every other friday")).toBe(true);
+    expect(intentStatesRecurrence("backup runs nightly")).toBe(true);
+  });
+
+  it("accepts explicit recurrence in the shipped locales", () => {
+    expect(intentStatesRecurrence("reunión cada lunes a las 10")).toBe(true);
+    expect(intentStatesRecurrence("gimnasio todos los martes")).toBe(true);
+    expect(intentStatesRecurrence("academia todas as segundas")).toBe(true);
+    expect(intentStatesRecurrence("họp mỗi tuần")).toBe(true);
+    expect(intentStatesRecurrence("simba araw-araw")).toBe(true);
+    expect(intentStatesRecurrence("每周一开站会")).toBe(true);
+    expect(intentStatesRecurrence("天天锻炼")).toBe(true);
+    expect(intentStatesRecurrence("월요일마다 스탠드업")).toBe(true);
+    expect(intentStatesRecurrence("매주 회의")).toBe(true);
+    expect(intentStatesRecurrence("gimnasio los martes a las 10")).toBe(true);
+    expect(intentStatesRecurrence("una vez a la semana yoga")).toBe(true);
+    expect(intentStatesRecurrence("toda segunda tem reunião")).toBe(true);
+    expect(intentStatesRecurrence("周一到周五提醒我吃药")).toBe(true);
+  });
+
+  it("grounds recurrence in any provided text (multi-turn clarify)", () => {
+    // "confirm" alone says nothing; the prior turn's "make it weekly" arrives
+    // via the recent-conversation window and keeps the stated recurrence.
+    expect(intentStatesRecurrence("confirm")).toBe(false);
+    expect(
+      intentStatesRecurrence("confirm", "user: make it weekly\nagent: ok"),
+    ).toBe(true);
   });
 
   it("is empty-safe", () => {
     expect(intentStatesRecurrence("")).toBe(false);
     expect(intentStatesRecurrence("   ")).toBe(false);
+    expect(intentStatesRecurrence(undefined, null, "")).toBe(false);
   });
 });

--- a/plugins/plugin-calendar/src/actions/calendar-handler.recurrence-guard.test.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.recurrence-guard.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Deterministic coverage for the explicit-recurrence guard on model-inferred
+ * RRULEs: cadence-flavored event nouns ("standup") must not become repeating
+ * events unless the user's own words state a repeating cadence.
+ */
+import { describe, expect, it } from "vitest";
+import { intentStatesRecurrence } from "./calendar-handler.js";
+
+describe("intentStatesRecurrence", () => {
+  it("rejects one-off asks with cadence-flavored nouns", () => {
+    // Live repro: the extraction model emitted RRULE:FREQ=WEEKLY;BYDAY=MO for
+    // this exact ask and the built-in calendar hard-400'd on recurrence.
+    expect(
+      intentStatesRecurrence("add to my calendar: standup monday at 10am"),
+    ).toBe(false);
+    expect(intentStatesRecurrence("dentist appointment tomorrow at 3pm")).toBe(
+      false,
+    );
+    expect(intentStatesRecurrence("lunch with sam friday")).toBe(false);
+  });
+
+  it("accepts explicit recurrence phrasings", () => {
+    expect(intentStatesRecurrence("standup every monday at 10am")).toBe(true);
+    expect(intentStatesRecurrence("gym weekly on wednesdays")).toBe(true);
+    expect(intentStatesRecurrence("water the plants daily at 9")).toBe(true);
+    expect(intentStatesRecurrence("team sync, repeats each friday")).toBe(true);
+    expect(intentStatesRecurrence("recurring rent payment on the 1st")).toBe(
+      true,
+    );
+  });
+
+  it("is empty-safe", () => {
+    expect(intentStatesRecurrence("")).toBe(false);
+    expect(intentStatesRecurrence("   ")).toBe(false);
+  });
+});

--- a/plugins/plugin-calendar/src/actions/calendar-handler.recurrence-guard.test.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.recurrence-guard.test.ts
@@ -2,11 +2,14 @@
  * Deterministic coverage for the explicit-recurrence guard on model-inferred
  * RRULEs: cadence-flavored event nouns ("standup") and time-of-day window
  * phrases ("in the morning") must not become repeating events; explicit
- * recurrence in any supported language must keep them, including recurrence
- * stated in a prior clarify turn carried via the conversation window.
+ * recurrence in any supported language must keep them. Every model-authored
+ * recurrence source is gated by current authoritative user text.
  */
 import { describe, expect, it } from "vitest";
-import { intentStatesRecurrence } from "./calendar-handler.js";
+import {
+  buildCreateEventRequest,
+  intentStatesRecurrence,
+} from "./calendar-handler.js";
 
 describe("intentStatesRecurrence", () => {
   it("rejects one-off asks with cadence-flavored nouns", () => {
@@ -80,20 +83,86 @@ describe("intentStatesRecurrence", () => {
     expect(intentStatesRecurrence("una vez a la semana yoga")).toBe(true);
     expect(intentStatesRecurrence("toda segunda tem reunião")).toBe(true);
     expect(intentStatesRecurrence("周一到周五提醒我吃药")).toBe(true);
+    expect(intentStatesRecurrence("毎週月曜日の午前10時にスタンドアップ")).toBe(
+      true,
+    );
   });
 
-  it("grounds recurrence in any provided text (multi-turn clarify)", () => {
-    // "confirm" alone says nothing; the prior turn's "make it weekly" arrives
-    // via the recent-conversation window and keeps the stated recurrence.
-    expect(intentStatesRecurrence("confirm")).toBe(false);
+  it("rejects Japanese one-shot windows and name-like cadence words", () => {
+    expect(intentStatesRecurrence("明日の朝、歯医者の予定を追加して")).toBe(
+      false,
+    );
+    expect(intentStatesRecurrence("毎日新聞の取材を明日の朝に追加して")).toBe(
+      false,
+    );
+  });
+
+  it("rejects negated recurrence and non-user role text", () => {
+    expect(intentStatesRecurrence("remind me tomorrow, not every day")).toBe(
+      false,
+    );
     expect(
-      intentStatesRecurrence("confirm", "user: make it weekly\nagent: ok"),
-    ).toBe(true);
+      intentStatesRecurrence(
+        "schedule standup Monday, not recurring, just once",
+      ),
+    ).toBe(false);
+    expect(intentStatesRecurrence("assistant: should this be weekly?")).toBe(
+      false,
+    );
+    expect(intentStatesRecurrence("back up every 2 days")).toBe(true);
+    expect(intentStatesRecurrence("check every 15 minutes")).toBe(true);
   });
 
   it("is empty-safe", () => {
     expect(intentStatesRecurrence("")).toBe(false);
     expect(intentStatesRecurrence("   ")).toBe(false);
     expect(intentStatesRecurrence(undefined, null, "")).toBe(false);
+  });
+});
+
+describe("buildCreateEventRequest recurrence authority", () => {
+  const plannerRecurrence = ["RRULE:FREQ=WEEKLY;BYDAY=MO"];
+
+  it("drops an outer-planner RRULE for a one-off raw user request", () => {
+    const built = buildCreateEventRequest({
+      details: {
+        title: "standup",
+        startAt: "2026-08-17T10:00:00.000Z",
+        recurrence: plannerRecurrence,
+      },
+      extractedDetails: {},
+      explicitTitle: "standup",
+      inferredTitle: "standup",
+      recurrenceGuardTexts: ["add to my calendar: standup monday at 10am"],
+    });
+
+    expect(built.request.recurrence).toBeUndefined();
+    expect(built.request.startAt).toBe("2026-08-17T10:00:00.000Z");
+  });
+
+  it("keeps outer-planner recurrence when the current user states cadence", () => {
+    const built = buildCreateEventRequest({
+      details: { title: "standup", recurrence: plannerRecurrence },
+      extractedDetails: {},
+      explicitTitle: "standup",
+      inferredTitle: "standup",
+      recurrenceGuardTexts: ["schedule standup every monday at 10am"],
+    });
+
+    expect(built.request.recurrence).toEqual(plannerRecurrence);
+  });
+
+  it("does not let planner or assistant text open the gate", () => {
+    const built = buildCreateEventRequest({
+      details: { title: "standup", recurrence: plannerRecurrence },
+      extractedDetails: { recurrence: plannerRecurrence },
+      explicitTitle: "standup",
+      inferredTitle: "weekly standup",
+      recurrenceGuardTexts: [
+        "user: no, just once\nassistant: should this be weekly?",
+      ],
+    });
+
+    expect(built.request.recurrence).toBeUndefined();
   });
 });

--- a/plugins/plugin-calendar/src/actions/calendar-handler.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.ts
@@ -38,10 +38,7 @@ import type {
   LifeOpsCalendarRecurrenceScope,
   LifeOpsNextCalendarEventContext,
 } from "@elizaos/shared";
-import {
-  findKeywordTermMatch,
-  getValidationKeywordTerms,
-} from "@elizaos/shared";
+import { textStatesExplicitRecurrence } from "@elizaos/shared";
 import { isAppleCalendarGrant } from "../apple-calendar.js";
 import { CALENDAR_DETAILS_PARAMETER_SCHEMA } from "../calendar-action-schema.js";
 import {
@@ -2841,23 +2838,15 @@ function resolveCreateEventDurationMinutes(args: {
 }
 
 /**
- * True when the user's own words state a repeating cadence. Backed by the
- * multilingual lifeops_cadence lexicon plus the bare recurrence markers the
- * lexicon's window-phrases do not cover ("every monday", "repeats", "recurring").
+ * True when any of the turn's texts states a repeating cadence in the user's
+ * own words. Delegates to the shared explicit-recurrence markers — repetition
+ * words only, never time-of-day window phrases, which appear in one-shot asks
+ * ("dentist tomorrow in the morning") and must not open the recurrence gate.
  */
-export function intentStatesRecurrence(intent: string): boolean {
-  if (!intent.trim()) return false;
-  if (/\b(?:every|each|repeat(?:s|ing)?|recurring|recurs?)\b/i.test(intent)) {
-    return true;
-  }
-  return (
-    findKeywordTermMatch(
-      intent,
-      getValidationKeywordTerms("contextSignal.lifeops_cadence.strong", {
-        includeAllLocales: true,
-      }),
-    ) !== undefined
-  );
+export function intentStatesRecurrence(
+  ...texts: ReadonlyArray<string | null | undefined>
+): boolean {
+  return textStatesExplicitRecurrence(...texts);
 }
 
 type CreateEventRequestBuildArgs = {
@@ -2868,6 +2857,13 @@ type CreateEventRequestBuildArgs = {
   intent: string;
   fallbackRequest?: CreateLifeOpsCalendarEventRequest;
   preferExtractedDetails?: boolean;
+  /**
+   * Texts the recurrence guard grounds in: the raw user message (the planner
+   * intent can be a paraphrase) and the recent-conversation window, so a
+   * clarify round-trip ("make it weekly" answered a turn earlier) keeps its
+   * stated recurrence. The intent itself is always checked too.
+   */
+  recurrenceGuardTexts?: ReadonlyArray<string | null | undefined>;
 };
 
 type CreateEventRequestBuildResult = {
@@ -3010,7 +3006,10 @@ function buildCreateEventRequest(
   // and the turn lectures about providers instead of creating the event.
   // Model-inferred recurrence therefore requires an explicit recurrence term
   // in the user's own words; planner-structured recurrence stays trusted.
-  const extractedRecurrence = intentStatesRecurrence(args.intent)
+  const extractedRecurrence = intentStatesRecurrence(
+    args.intent,
+    ...(args.recurrenceGuardTexts ?? []),
+  )
     ? detailRecurrenceLines(args.extractedDetails)
     : undefined;
   const recurrence = args.preferExtractedDetails
@@ -4306,6 +4305,10 @@ const calendarAction: CalendarHandlerAction = {
           explicitTitle,
           inferredTitle,
           intent,
+          recurrenceGuardTexts: [
+            messageText(message),
+            formatCreateEventRecentConversation(state),
+          ],
           // The outer planner identifies CALENDAR and supplies hints; this
           // domain-specific extraction has the authoritative calendar context,
           // timezone, and local-date anchors needed to normalize wall time.

--- a/plugins/plugin-calendar/src/actions/calendar-handler.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.ts
@@ -38,7 +38,10 @@ import type {
   LifeOpsCalendarRecurrenceScope,
   LifeOpsNextCalendarEventContext,
 } from "@elizaos/shared";
-import { textStatesExplicitRecurrence } from "@elizaos/shared";
+import {
+  selectUserAuthorizedRecurrence,
+  textStatesExplicitRecurrence,
+} from "@elizaos/shared";
 import { isAppleCalendarGrant } from "../apple-calendar.js";
 import { CALENDAR_DETAILS_PARAMETER_SCHEMA } from "../calendar-action-schema.js";
 import {
@@ -2838,10 +2841,10 @@ function resolveCreateEventDurationMinutes(args: {
 }
 
 /**
- * True when any of the turn's texts states a repeating cadence in the user's
- * own words. Delegates to the shared explicit-recurrence markers — repetition
- * words only, never time-of-day window phrases, which appear in one-shot asks
- * ("dentist tomorrow in the morning") and must not open the recurrence gate.
+ * True when authoritative user-authored text states a repeating cadence.
+ * Delegates to the shared explicit-recurrence markers — repetition words only,
+ * never planner/assistant prose or time-of-day window phrases, which appear in
+ * one-shot asks ("dentist tomorrow in the morning") and must not open the gate.
  */
 export function intentStatesRecurrence(
   ...texts: ReadonlyArray<string | null | undefined>
@@ -2854,14 +2857,12 @@ type CreateEventRequestBuildArgs = {
   extractedDetails: Record<string, unknown>;
   explicitTitle: string | undefined;
   inferredTitle: string | undefined;
-  intent: string;
   fallbackRequest?: CreateLifeOpsCalendarEventRequest;
   preferExtractedDetails?: boolean;
   /**
-   * Texts the recurrence guard grounds in: the raw user message (the planner
-   * intent can be a paraphrase) and the recent-conversation window, so a
-   * clarify round-trip ("make it weekly" answered a turn earlier) keeps its
-   * stated recurrence. The intent itself is always checked too.
+   * Authoritative user-authored text for the recurrence guard. Planner intent,
+   * structured details, and assistant/system history must never authorize an
+   * RRULE the current user did not request.
    */
   recurrenceGuardTexts?: ReadonlyArray<string | null | undefined>;
 };
@@ -2909,7 +2910,7 @@ function pickCreateEventStringField(
     : (explicit ?? extracted ?? fallback);
 }
 
-function buildCreateEventRequest(
+export function buildCreateEventRequest(
   args: CreateEventRequestBuildArgs,
 ): CreateEventRequestBuildResult {
   const extractedTitle = detailString(args.extractedDetails, "title");
@@ -3004,21 +3005,25 @@ function buildCreateEventRequest(
   // RRULE:FREQ=WEEKLY;BYDAY=MO) even though the user asked for one event; on
   // the built-in calendar that hard-400s (ELIZA_CALENDAR_RECURRENCE_UNSUPPORTED)
   // and the turn lectures about providers instead of creating the event.
-  // Model-inferred recurrence therefore requires an explicit recurrence term
-  // in the user's own words; planner-structured recurrence stays trusted.
-  const extractedRecurrence = intentStatesRecurrence(
-    args.intent,
-    ...(args.recurrenceGuardTexts ?? []),
-  )
-    ? detailRecurrenceLines(args.extractedDetails)
-    : undefined;
-  const recurrence = args.preferExtractedDetails
-    ? (extractedRecurrence ??
-      explicitRecurrence ??
-      args.fallbackRequest?.recurrence)
-    : (explicitRecurrence ??
-      extractedRecurrence ??
-      args.fallbackRequest?.recurrence);
+  // Every recurrence source here is model-authored: `details` comes from the
+  // outer planner, `extractedDetails` from the domain extractor, and fallback
+  // requests from an earlier model-built attempt. Gate all of them on current
+  // authoritative user text so planner disagreement cannot create recurrence.
+  const extractedRecurrence = detailRecurrenceLines(args.extractedDetails);
+  const recurrence = selectUserAuthorizedRecurrence(
+    args.recurrenceGuardTexts ?? [],
+    args.preferExtractedDetails
+      ? [
+          extractedRecurrence,
+          explicitRecurrence,
+          args.fallbackRequest?.recurrence,
+        ]
+      : [
+          explicitRecurrence,
+          extractedRecurrence,
+          args.fallbackRequest?.recurrence,
+        ],
+  );
 
   return {
     title,
@@ -4304,11 +4309,7 @@ const calendarAction: CalendarHandlerAction = {
           extractedDetails,
           explicitTitle,
           inferredTitle,
-          intent,
-          recurrenceGuardTexts: [
-            messageText(message),
-            formatCreateEventRecentConversation(state),
-          ],
+          recurrenceGuardTexts: [messageText(message)],
           // The outer planner identifies CALENDAR and supplies hints; this
           // domain-specific extraction has the authoritative calendar context,
           // timezone, and local-date anchors needed to normalize wall time.

--- a/plugins/plugin-calendar/src/actions/calendar-handler.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.ts
@@ -38,6 +38,10 @@ import type {
   LifeOpsCalendarRecurrenceScope,
   LifeOpsNextCalendarEventContext,
 } from "@elizaos/shared";
+import {
+  findKeywordTermMatch,
+  getValidationKeywordTerms,
+} from "@elizaos/shared";
 import { isAppleCalendarGrant } from "../apple-calendar.js";
 import { CALENDAR_DETAILS_PARAMETER_SCHEMA } from "../calendar-action-schema.js";
 import {
@@ -2836,6 +2840,26 @@ function resolveCreateEventDurationMinutes(args: {
   return undefined;
 }
 
+/**
+ * True when the user's own words state a repeating cadence. Backed by the
+ * multilingual lifeops_cadence lexicon plus the bare recurrence markers the
+ * lexicon's window-phrases do not cover ("every monday", "repeats", "recurring").
+ */
+export function intentStatesRecurrence(intent: string): boolean {
+  if (!intent.trim()) return false;
+  if (/\b(?:every|each|repeat(?:s|ing)?|recurring|recurs?)\b/i.test(intent)) {
+    return true;
+  }
+  return (
+    findKeywordTermMatch(
+      intent,
+      getValidationKeywordTerms("contextSignal.lifeops_cadence.strong", {
+        includeAllLocales: true,
+      }),
+    ) !== undefined
+  );
+}
+
 type CreateEventRequestBuildArgs = {
   details: Record<string, unknown> | undefined;
   extractedDetails: Record<string, unknown>;
@@ -2979,7 +3003,16 @@ function buildCreateEventRequest(
     }) ?? null;
 
   const explicitRecurrence = detailRecurrenceLines(args.details);
-  const extractedRecurrence = detailRecurrenceLines(args.extractedDetails);
+  // The extraction model routinely infers weekly recurrence from
+  // cadence-flavored event nouns ("standup monday at 10am" →
+  // RRULE:FREQ=WEEKLY;BYDAY=MO) even though the user asked for one event; on
+  // the built-in calendar that hard-400s (ELIZA_CALENDAR_RECURRENCE_UNSUPPORTED)
+  // and the turn lectures about providers instead of creating the event.
+  // Model-inferred recurrence therefore requires an explicit recurrence term
+  // in the user's own words; planner-structured recurrence stays trusted.
+  const extractedRecurrence = intentStatesRecurrence(args.intent)
+    ? detailRecurrenceLines(args.extractedDetails)
+    : undefined;
   const recurrence = args.preferExtractedDetails
     ? (extractedRecurrence ??
       explicitRecurrence ??


### PR DESCRIPTION
## What

Two guards of the same class — a model-inferred repetition must be backed by the user's own words — both live-reproed on nubilio tonight:

**Calendar**: "add to my calendar: standup monday at 10am" → the extraction model emitted `RRULE:FREQ=WEEKLY;BYDAY=MO` from the cadence-flavored noun *standup*, the built-in calendar hard-400'd (`ELIZA_CALENDAR_RECURRENCE_UNSUPPORTED`), and the delivered reply lectured "built-in calendar doesn't do repeating events. connect google calendar…" instead of creating the single Monday event the user asked for (nubs pasted this exchange asking why it was broken). Model-inferred recurrence now requires an explicit recurrence term in the intent — the multilingual `lifeops_cadence` strong lexicon plus bare `every/each/repeat(s|ing)/recurring` markers. Planner-structured `details.recurrence` stays trusted.

**Trigger**: re-lands the cadence guard that previously lived only on the live box — a field-spraying planner answering "pushups every morning at 8am" emits the cron AND `maxRuns:1` from its derived one-shot echo, silently turning a routine into a single fire. When the user's words state a repeating cadence, the sprayed cap is dropped.

Also pins the clock in the pre-existing one-shot-cron describe test, which failed whenever the wall clock was within an hour of the asserted 9am fire ("in 41 minutes" contains no "9am").

## Evidence

- `calendar-handler.recurrence-guard.test.ts` (new): 3/3 — the exact live repro rejects inferred recurrence; "every monday" / "weekly" / "repeats each friday" keep it; empty-safe
- `trigger.test.ts`: 69/69 with 2 new cases (sprayed cap dropped on explicit cadence; kept on a dateless one-shot) and the clock-pinned pre-existing test
- `plugin-calendar` + `packages/agent` typecheck clean; Biome clean on all four files
- Live trajectory of the failure: `tj-6884b88a6d80f6` (planner passed correct Monday date; create still failed on inferred recurrence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)