### PR TITLE
fix(discord): serve guild mentions from Shared Eliza (#19947)

### DIFF
--- a/packages/cloud/api/internal/discord/eliza-app/messages/route.ts
+++ b/packages/cloud/api/internal/discord/eliza-app/messages/route.ts
@@ -3,6 +3,11 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { agentGatewayRouterService } from "@/lib/services/agent-gateway-router";
+import {
+  authorizeManagedDiscordGuildVoice,
+  runManagedDiscordGuildTextTurn,
+} from "@/lib/services/managed-discord-guild-voice";
+import { resolveSharedRuntimeWorkerRequestContext } from "@/lib/services/shared-runtime/resolve-shared-agent";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { requireInternalAuth } from "../../../_auth";
@@ -37,7 +42,48 @@ app.post("/", async (c) => {
         content: body.content,
         sender: body.sender,
       });
-      return c.json(result);
+      if (result.handled || result.reason !== "not_linked") {
+        return c.json(result);
+      }
+
+      // An unbound guild belongs to the managed system bot, not a Dedicated
+      // agent. Only an already-linked canonical owner may use personal Shared
+      // Eliza here, and the public room is isolated from every private channel.
+      const identity = await authorizeManagedDiscordGuildVoice(body.sender.id);
+      if (!identity.allowed || !identity.userId || !identity.organizationId) {
+        return c.json(result);
+      }
+      const worker = resolveSharedRuntimeWorkerRequestContext(c);
+      if ("error" in worker) {
+        return c.json(
+          {
+            success: false,
+            error: worker.error,
+            code: worker.code,
+            retryable: worker.retryable,
+          },
+          worker.status,
+          { "Retry-After": "1" },
+        );
+      }
+      const shared = await runManagedDiscordGuildTextTurn(
+        {
+          discordUserId: body.sender.id,
+          discordUsername: body.sender.username,
+          displayName: body.sender.displayName,
+          guildId: body.guildId,
+          channelId: body.channelId,
+          messageId: body.messageId,
+          message: body.content,
+          userId: identity.userId,
+          organizationId: identity.organizationId,
+        },
+        {
+          namespace: worker.namespace,
+          executionCtx: worker.executionCtx,
+        },
+      );
+      return c.json({ handled: true, ...shared });
     }
 
     const response = await personalSharedMessagesApp.request(

--- a/packages/cloud/shared/src/lib/services/managed-discord-guild-voice.ts
+++ b/packages/cloud/shared/src/lib/services/managed-discord-guild-voice.ts
@@ -1,6 +1,6 @@
 /**
- * Authorizes and executes managed Discord guild-voice turns against personal
- * Shared Eliza while isolating public guild history from private transports.
+ * Authorizes and executes managed Discord guild text and voice turns against
+ * personal Shared Eliza while isolating public guild history from private transports.
  */
 import { ElevenLabsService } from "./elevenlabs";
 import { elizaAppUserService } from "./eliza-app";
@@ -10,7 +10,7 @@ import {
 } from "./managed-discord-guild-voice-policy";
 import {
   personalSharedAgent,
-  personalSharedGuildVoiceRoomId,
+  personalSharedDiscordGuildRoomId,
 } from "./shared-runtime/personal-shared-agent";
 import { sharedRestMessageSend } from "./shared-runtime/shared-rest-adapter";
 
@@ -22,11 +22,75 @@ interface GuildVoiceRuntimeContext {
   elevenLabsEnv: Parameters<typeof ElevenLabsService.fromEnv>[0];
 }
 
+interface GuildTextRuntimeContext {
+  namespace: Parameters<typeof sharedRestMessageSend>[5];
+  executionCtx: Parameters<typeof sharedRestMessageSend>[4];
+}
+
 export async function authorizeManagedDiscordGuildVoice(
   discordUserId: string,
 ): Promise<ManagedDiscordGuildVoiceIdentity> {
   const account = await elizaAppUserService.getByDiscordId(discordUserId);
   return evaluateManagedDiscordGuildVoiceOwner(account);
+}
+
+/** Execute one owner-authorized public guild text turn in an isolated room. */
+export async function runManagedDiscordGuildTextTurn(
+  input: {
+    discordUserId: string;
+    discordUsername: string;
+    displayName?: string;
+    guildId: string;
+    channelId: string;
+    messageId: string;
+    message: string;
+    userId: string;
+    organizationId: string;
+  },
+  context: GuildTextRuntimeContext,
+): Promise<{
+  replyText: string;
+  agentId: string;
+  roomId: string;
+  userId: string;
+  organizationId: string;
+}> {
+  const agent = personalSharedAgent({
+    userId: input.userId,
+    organizationId: input.organizationId,
+  });
+  const roomId = personalSharedDiscordGuildRoomId({
+    agentId: agent.id,
+    discordUserId: input.discordUserId,
+    guildId: input.guildId,
+    channelId: input.channelId,
+  });
+  const speaker = (input.displayName ?? input.discordUsername)
+    .replace(/[\r\n\t]+/g, " ")
+    .trim()
+    .slice(0, 80);
+  const publicTurn = [
+    `[Public Discord guild text; speaker: ${speaker}.`,
+    "Use only this public guild channel's context. Never reveal or summarize private DM, phone, SMS, or Telegram history.]",
+    input.message,
+  ].join("\n");
+  const reply = await sharedRestMessageSend(
+    agent,
+    roomId,
+    publicTurn,
+    agent.agent_name ?? "Eliza",
+    context.executionCtx,
+    context.namespace,
+    `discord-guild:${input.messageId}`,
+    "platform",
+  );
+  return {
+    replyText: reply.text.trim(),
+    agentId: agent.id,
+    roomId,
+    userId: input.userId,
+    organizationId: input.organizationId,
+  };
 }
 
 function decodeCanonicalWav(wavBase64: string): Uint8Array {
@@ -105,7 +169,7 @@ export async function runManagedDiscordGuildVoiceTurn(
     userId: identity.userId,
     organizationId: identity.organizationId,
   });
-  const roomId = personalSharedGuildVoiceRoomId({
+  const roomId = personalSharedDiscordGuildRoomId({
     agentId: agent.id,
     discordUserId: input.discordUserId,
     guildId: input.guildId,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/personal-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/personal-shared-agent.ts
@@ -13,7 +13,7 @@ import { getDefaultElizaCharacterData } from "../../utils/default-eliza-characte
 import type { SharedRuntimeAgent } from "./shared-runtime-agent";
 
 const PERSONAL_SHARED_AGENT_NAMESPACE = "af8f7624-42f8-4da8-bdf1-593b1a0d7f20";
-const PERSONAL_SHARED_GUILD_VOICE_NAMESPACE = "b9ea4ce5-636d-4ec4-bc75-6308188f883f";
+const PERSONAL_SHARED_DISCORD_GUILD_NAMESPACE = "b9ea4ce5-636d-4ec4-bc75-6308188f883f";
 const PERSONAL_SHARED_AGENT_PREFIX = "personal:";
 
 export interface PersonalSharedAccountIdentity {
@@ -37,11 +37,11 @@ export function isPersonalSharedAgentId(value: string): boolean {
 }
 
 /**
- * A public guild voice room must never reuse the owner's private cross-channel
- * room. This stable UUID retains guild-voice continuity without importing DM,
- * phone, SMS, or Telegram history into a room where other people can listen.
+ * A public Discord guild room must never reuse the owner's private cross-channel
+ * room. This stable UUID retains channel continuity without importing DM,
+ * phone, SMS, or Telegram history into a room other members can observe.
  */
-export function personalSharedGuildVoiceRoomId(input: {
+export function personalSharedDiscordGuildRoomId(input: {
   agentId: string;
   discordUserId: string;
   guildId: string;
@@ -49,9 +49,12 @@ export function personalSharedGuildVoiceRoomId(input: {
 }): string {
   return uuidv5(
     [input.agentId, input.discordUserId, input.guildId, input.channelId].join(":"),
-    PERSONAL_SHARED_GUILD_VOICE_NAMESPACE,
+    PERSONAL_SHARED_DISCORD_GUILD_NAMESPACE,
   );
 }
+
+/** Compatibility name retained for existing guild-voice callers. */
+export const personalSharedGuildVoiceRoomId = personalSharedDiscordGuildRoomId;
 
 function localBridgeApiBase(value: string | null): string | null {
   if (!value) return null;

--- a/packages/cloud/shared/src/lib/services/shared-runtime/personal-shared-guild-voice.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/personal-shared-guild-voice.test.ts
@@ -1,8 +1,11 @@
-/** Verifies the deterministic public-room boundary for managed guild voice. */
+/** Verifies the deterministic public-room boundary for managed Discord guild turns. */
 import { describe, expect, test } from "bun:test";
-import { personalSharedGuildVoiceRoomId } from "./personal-shared-agent";
+import {
+  personalSharedDiscordGuildRoomId,
+  personalSharedGuildVoiceRoomId,
+} from "./personal-shared-agent";
 
-describe("personalSharedGuildVoiceRoomId", () => {
+describe("personalSharedDiscordGuildRoomId", () => {
   const base = {
     agentId: "personal:10000000-0000-5000-8000-000000000001",
     discordUserId: "111111111111111",
@@ -11,20 +14,23 @@ describe("personalSharedGuildVoiceRoomId", () => {
   };
 
   test("is stable but cannot collide with the private personal room", () => {
-    const first = personalSharedGuildVoiceRoomId(base);
+    const first = personalSharedDiscordGuildRoomId(base);
+    expect(personalSharedDiscordGuildRoomId(base)).toBe(first);
     expect(personalSharedGuildVoiceRoomId(base)).toBe(first);
     expect(first).toMatch(/^[0-9a-f-]{36}$/);
     expect(first).not.toBe(base.agentId);
   });
 
   test("isolates guilds, channels, and owners", () => {
-    const room = personalSharedGuildVoiceRoomId(base);
-    expect(personalSharedGuildVoiceRoomId({ ...base, guildId: "444444444444444" })).not.toBe(room);
-    expect(personalSharedGuildVoiceRoomId({ ...base, channelId: "555555555555555" })).not.toBe(
+    const room = personalSharedDiscordGuildRoomId(base);
+    expect(personalSharedDiscordGuildRoomId({ ...base, guildId: "444444444444444" })).not.toBe(
       room,
     );
-    expect(personalSharedGuildVoiceRoomId({ ...base, discordUserId: "666666666666666" })).not.toBe(
+    expect(personalSharedDiscordGuildRoomId({ ...base, channelId: "555555555555555" })).not.toBe(
       room,
     );
+    expect(
+      personalSharedDiscordGuildRoomId({ ...base, discordUserId: "666666666666666" }),
+    ).not.toBe(room);
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
@@ -45,4 +45,10 @@ describe("Shared capability wall", () => {
     ).toBeNull();
     expect(resolveSharedCapabilityWall("remind me in two minutes")?.capability).toBe("reminders");
   });
+
+  test("does not falsely claim voice and messaging require Dedicated", () => {
+    const wall = resolveSharedCapabilityWall("call Mom");
+    expect(wall?.reply).toContain("connected voice and messaging channels");
+    expect(wall?.reply).not.toContain("Dedicated");
+  });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
@@ -53,7 +53,7 @@ const RULES: ReadonlyArray<SharedCapabilityWall & { pattern: RegExp }> = [
     pattern:
       /\b(?:(?:can|could|would|will)\s+you\s+)?(?:(?:email|call|text|message|dm)\b(?!\s+(?:this|the|a|an)\s+(?:\w+\s+){0,2}(?:function|method|api|endpoint|class|variable|command)\b)|send\b[\s\S]{0,32}\b(?:email|text|message|dm)\b)/i,
     reply:
-      "Calling or messaging people needs Dedicated. I can draft it here, but Shared can't send email, texts, DMs, or place calls.",
+      "I can talk with you and reply through Eliza's connected voice and messaging channels. I can't initiate a separate call, email, text, or DM to another person from this session.",
   },
   {
     capability: "purchases",


### PR DESCRIPTION
Closes #19947

## Production diagnosis

The managed system bot's guild mentions still used only the legacy Dedicated sandbox binding router. An unbound guild therefore returned `not_linked`, even for the canonical owner whose DM and managed guild-voice paths already use personal Shared Eliza. Separately, the Shared capability wall incorrectly claimed that calling and messaging require Dedicated while Eliza was actively connected over those channels.

## Fix

- Preserve existing Dedicated guild routing whenever it handles the message or rejects a non-owner.
- For an unbound managed guild, authorize only an already-linked canonical organization owner and execute the mention through personal Shared Eliza.
- Store public guild text in the same deterministic guild/channel/owner room family as guild voice, isolated from private DM, phone, SMS, and Telegram history.
- Keep arbitrary guild users from auto-provisioning personal accounts through mentions.
- Replace the false Dedicated warning with the real capability boundary: Eliza can converse over the connected channel but cannot independently contact a third party.

## Verification

- focused Shared tests: 30 pass / 0 fail
- Cloud Shared typecheck: pass
- Cloud API TypeScript compile: pass
- production Worker bundle dry-run: pass (25.0 MiB / 6.1 MiB gzip)
- changed-file Biome: pass
- `git diff --check`: pass

## Evidence

- Before: live production internal Discord route returned `{handled:false,reason:"not_linked"}` for the canonical owner's real guild mention.
- After deployment: pending exact-revision real Discord mention/reply and live model output; will be attached before closeout.
- UI screenshots/video: N/A — backend routing and prompt policy only; no rendered UI changed.
- Native/device evidence: N/A — Discord's real client and provider boundary are the supported target.
