### PR TITLE
fix(discord): promote capability-context correction (#19947)

### DIFF
--- a/packages/cloud/shared/src/lib/services/managed-discord-guild-voice.ts
+++ b/packages/cloud/shared/src/lib/services/managed-discord-guild-voice.ts
@@ -70,8 +70,8 @@ export async function runManagedDiscordGuildTextTurn(
     .trim()
     .slice(0, 80);
   const publicTurn = [
-    `[Public Discord guild text; speaker: ${speaker}.`,
-    "Use only this public guild channel's context. Never reveal or summarize private DM, phone, SMS, or Telegram history.]",
+    `[Public Discord guild channel; speaker: ${speaker}.`,
+    "Use only this public guild channel's context. Never reveal or summarize context from any private transport.]",
     input.message,
   ].join("\n");
   const reply = await sharedRestMessageSend(
@@ -177,7 +177,7 @@ export async function runManagedDiscordGuildVoiceTurn(
   });
   const publicTurn = [
     `[Public Discord guild voice; speaker: ${input.displayName ?? input.discordUsername}.`,
-    "Use only this guild-voice room's context. Never reveal or summarize private DM, phone, SMS, or Telegram history.]",
+    "Use only this guild-voice room's context. Never reveal or summarize context from any private transport.]",
     transcript,
   ].join("\n");
   const reply = await sharedRestMessageSend(

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
@@ -51,4 +51,16 @@ describe("Shared capability wall", () => {
     expect(wall?.reply).toContain("connected voice and messaging channels");
     expect(wall?.reply).not.toContain("Dedicated");
   });
+
+  test.each(["channel", "voice"])(
+    "does not treat trusted public Discord %s context as a communication request",
+    (transport) => {
+      const wrappedTurn = [
+        `[Public Discord guild ${transport}; speaker: shaw.`,
+        "Use only this public guild channel's context. Never reveal or summarize context from any private transport.]",
+        "reply with exactly PONG",
+      ].join("\n");
+      expect(resolveSharedCapabilityWall(wrappedTurn)).toBeNull();
+    },
+  );
 });


### PR DESCRIPTION
Production follow-up to #19953 and develop PR #19954.

Real Discord evidence showed the trusted privacy wrapper's own `text`/`DM` words activated the communications capability wall on every guild turn. This neutralizes those transport labels while preserving public/private isolation and adds exact wrapper regression tests.

Verification:
- focused Shared tests: 32 pass / 0 fail
- Cloud Shared typecheck: pass
- Biome and diff checks: pass
- post-merge live Discord call-and-response pending immediate Worker deploy
