### PR TITLE
test(core): align trajectory-recorder cost expectation with canonical cerebras rates

### DIFF
--- a/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
+++ b/packages/core/src/runtime/__tests__/trajectory-recorder.test.ts
@@ -520,8 +520,11 @@ describe("JsonFileTrajectoryRecorder", () => {
 		await recorder.endTrajectory(id, "finished");
 
 		const trajectory = await recorder.load(id);
-		expect(trajectory?.stages[0]?.model?.costUsd).toBeCloseTo(1.3, 6);
-		expect(trajectory?.metrics.totalCostUsd).toBeCloseTo(1.3, 6);
+		// 1M in @ $0.35 + 1M out @ $0.75 — the canonical Cerebras rates in
+		// features/trajectories/pricing.ts (aligned 2026-08-14; this expectation
+		// was missed when the table moved off the old 1.30 total).
+		expect(trajectory?.stages[0]?.model?.costUsd).toBeCloseTo(1.1, 6);
+		expect(trajectory?.metrics.totalCostUsd).toBeCloseTo(1.1, 6);
 	});
 
 	it("tags every LLM step with priceTableId when cost is annotated", async () => {


### PR DESCRIPTION
One-expectation fix: the 2026-08-14 Cerebras pricing alignment (73a1601ea5) set gpt-oss-120b to 0.35/0.75 per 1M and updated pricing.test.ts, but missed this suite's hardcoded 1.30 — the test's 1M-in + 1M-out fixture prices to 1.10 under the canonical table. Found by the composed post-merge QA sweep (9 parallel lanes over tonight's merges; this was the only real develop defect — everything else green or verified environmental). Suite: 55/55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:ba802ab14a35935ab9b3c300b4a0ee48d403ba0d -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - single test-expectation alignment; no UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - single test-expectation alignment; no UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - 55/55 suite result in PR body

<!-- evidence-row:backend-logs -->
- [ ] N/A - vitest summary in PR body

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - test-only change; no runtime path

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the artifact is the canonical pricing table already on develop
