### PR TITLE
fix(discord): keep managed turns visibly alive

### DIFF
--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -34,6 +34,7 @@ import {
 import {
   deliverManagedReply,
   postManagedAgentMessageWithRetry,
+  withManagedTypingHeartbeat,
 } from "./managed-message-egress";
 import {
   drainAndDeliverGreetings as drainAndDeliverPendingGreetings,
@@ -2373,53 +2374,77 @@ export class GatewayManager {
     content: string,
   ): Promise<void> {
     try {
-      if ("sendTyping" in message.channel) {
-        await message.channel.sendTyping();
-      }
-
       // Egress health (proven dropped-turn class, E2E 2026-08-05): a single
       // transient failure from the routing API must not consume the user's
       // turn. The route is idempotent on `discord:<messageId>`, so bounded
       // retry replays the SAME turn instead of dropping it.
-      const outcome = await postManagedAgentMessageWithRetry({
-        doPost: () =>
-          fetchWithTimeout(
-            `${this.config.elizaCloudUrl}/api/internal/discord/eliza-app/messages`,
-            {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                ...this.getAuthHeader(),
-              },
-              body: JSON.stringify({
-                ...(message.guildId ? { guildId: message.guildId } : {}),
-                channelId: message.channelId,
-                messageId: message.id,
-                content,
-                sender: {
-                  id: message.author.id,
-                  username: message.author.username,
-                  displayName:
-                    message.member?.displayName ??
-                    message.author.globalName ??
-                    undefined,
-                  avatar: message.author.displayAvatarURL() || null,
+      const startedAt = Date.now();
+      const route = () =>
+        postManagedAgentMessageWithRetry({
+          doPost: () =>
+            fetchWithTimeout(
+              `${this.config.elizaCloudUrl}/api/internal/discord/eliza-app/messages`,
+              {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json",
+                  ...this.getAuthHeader(),
                 },
-              }),
-              timeout: EVENT_FORWARD_TIMEOUT_MS,
+                body: JSON.stringify({
+                  ...(message.guildId ? { guildId: message.guildId } : {}),
+                  channelId: message.channelId,
+                  messageId: message.id,
+                  content,
+                  sender: {
+                    id: message.author.id,
+                    username: message.author.username,
+                    displayName:
+                      message.member?.displayName ??
+                      message.author.globalName ??
+                      undefined,
+                    avatar: message.author.displayAvatarURL() || null,
+                  },
+                }),
+                timeout: EVENT_FORWARD_TIMEOUT_MS,
+              },
+            ),
+          refreshAuth: () => this.refreshToken(),
+          onAttemptFailure: ({ attempt, status, error }) => {
+            logger.warn("Managed Agent Discord routing attempt failed", {
+              guildId: message.guildId ?? null,
+              channelId: message.channelId,
+              messageId: message.id,
+              attempt,
+              ...(status !== undefined ? { status } : {}),
+              error: sanitizeError(error),
+            });
+          },
+        });
+      const typingChannel =
+        "sendTyping" in message.channel ? message.channel : null;
+      const outcome = typingChannel
+        ? await withManagedTypingHeartbeat(
+            {
+              sendTyping: () => typingChannel.sendTyping(),
+              onFailure: (error) => {
+                logger.warn("Managed Agent Discord typing heartbeat failed", {
+                  guildId: message.guildId ?? null,
+                  channelId: message.channelId,
+                  messageId: message.id,
+                  error,
+                });
+              },
             },
-          ),
-        refreshAuth: () => this.refreshToken(),
-        onAttemptFailure: ({ attempt, status, error }) => {
-          logger.warn("Managed Agent Discord routing attempt failed", {
-            guildId: message.guildId ?? null,
-            channelId: message.channelId,
-            messageId: message.id,
-            attempt,
-            ...(status !== undefined ? { status } : {}),
-            error: sanitizeError(error),
-          });
-        },
+            route,
+          )
+        : await route();
+      logger.info("Managed Agent Discord routing completed", {
+        guildId: message.guildId ?? null,
+        channelId: message.channelId,
+        messageId: message.id,
+        elapsedMs: Date.now() - startedAt,
+        attempts: outcome.attempts,
+        ok: outcome.ok,
       });
 
       if (!outcome.ok) {

--- a/packages/cloud/services/gateway-discord/src/managed-message-egress.ts
+++ b/packages/cloud/services/gateway-discord/src/managed-message-egress.ts
@@ -50,9 +50,49 @@ export function isRetryableRouteStatus(status: number): boolean {
 
 const DEFAULT_MAX_ATTEMPTS = 4;
 const DEFAULT_BASE_DELAY_MS = 250;
+const DEFAULT_TYPING_REFRESH_MS = 8_000;
 
 function defaultSleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Keep Discord's transient typing state alive while a managed turn runs. */
+export async function withManagedTypingHeartbeat<T>(
+  options: {
+    sendTyping: () => Promise<unknown>;
+    onFailure?: (error: string) => void;
+    intervalMs?: number;
+  },
+  run: () => Promise<T>,
+): Promise<T> {
+  let stopped = false;
+  let pulseInFlight = false;
+  const pulse = async (): Promise<void> => {
+    if (stopped || pulseInFlight) return;
+    pulseInFlight = true;
+    try {
+      await options.sendTyping();
+    } catch (error) {
+      // error-policy:J4 Typing is a user-facing progress hint; its transport
+      // failure must remain visible in diagnostics without consuming the turn.
+      options.onFailure?.(
+        error instanceof Error ? error.message : String(error),
+      );
+    } finally {
+      pulseInFlight = false;
+    }
+  };
+
+  await pulse();
+  const timer = setInterval(() => {
+    void pulse();
+  }, options.intervalMs ?? DEFAULT_TYPING_REFRESH_MS);
+  try {
+    return await run();
+  } finally {
+    stopped = true;
+    clearInterval(timer);
+  }
 }
 
 /**

--- a/packages/cloud/services/gateway-discord/tests/managed-message-egress.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/managed-message-egress.test.ts
@@ -7,6 +7,7 @@ import {
   deliverManagedReply,
   isRetryableRouteStatus,
   postManagedAgentMessageWithRetry,
+  withManagedTypingHeartbeat,
 } from "../src/managed-message-egress";
 
 const noSleep = async () => {};
@@ -220,6 +221,50 @@ describe("isRetryableRouteStatus", () => {
     expect(isRetryableRouteStatus(400)).toBe(false);
     expect(isRetryableRouteStatus(403)).toBe(false);
     expect(isRetryableRouteStatus(404)).toBe(false);
+  });
+});
+
+describe("withManagedTypingHeartbeat", () => {
+  test("refreshes typing until the turn settles and then stops", async () => {
+    let pulses = 0;
+    let release: (() => void) | undefined;
+    const turn = withManagedTypingHeartbeat(
+      {
+        sendTyping: async () => {
+          pulses += 1;
+        },
+        intervalMs: 5,
+      },
+      () =>
+        new Promise<string>((resolve) => {
+          release = () => resolve("done");
+        }),
+    );
+
+    await Bun.sleep(18);
+    expect(pulses).toBeGreaterThanOrEqual(2);
+    release?.();
+    await expect(turn).resolves.toBe("done");
+    const settledPulses = pulses;
+    await Bun.sleep(12);
+    expect(pulses).toBe(settledPulses);
+  });
+
+  test("a typing failure never prevents the managed turn", async () => {
+    const failures: string[] = [];
+    const result = await withManagedTypingHeartbeat(
+      {
+        sendTyping: async () => {
+          throw new Error("Missing Permissions");
+        },
+        onFailure: (error) => failures.push(error),
+        intervalMs: 5,
+      },
+      async () => "reply",
+    );
+
+    expect(result).toBe("reply");
+    expect(failures).toEqual(["Missing Permissions"]);
   });
 });
 


### PR DESCRIPTION
Closes #19957

## Summary
- refresh Discord typing state every 8 seconds while managed inference runs
- never let a typing transport failure consume the actual user turn
- log sanitized route duration, attempts, and outcome

## Verification
- `bun run --cwd packages/cloud/services/gateway-discord test` (72 pass)
- `bun run --cwd packages/cloud/services/gateway-discord typecheck`
- `bun run --cwd packages/cloud/services/gateway-discord build`
- `git diff --check origin/develop...HEAD`

## Live baseline
Production guild and DM call/response both succeed. Observed model-route latency is typically 6–8s with occasional 14–18s turns; this change keeps those turns visibly active and exposes exact timing/retry telemetry.