### PR TITLE
fix(core): normalize trajectory pagination inputs before forwarding

### DIFF
--- a/packages/core/src/features/trajectories/read-routes.test.ts
+++ b/packages/core/src/features/trajectories/read-routes.test.ts
@@ -107,6 +107,34 @@ describe("tryHandleTrajectoryReadRoutes", () => {
 		expect(b.trajectories[1]).toMatchObject({ id: "t2", status: "error" });
 	});
 
+	it("normalizes trajectory pagination before forwarding it", async () => {
+		let receivedLimit: number | undefined;
+		let receivedOffset: number | undefined;
+		const service = {
+			listTrajectories: async (options: {
+				limit?: number;
+				offset?: number;
+			}) => {
+				receivedLimit = options.limit;
+				receivedOffset = options.offset;
+				return { trajectories: [], total: 0 };
+			},
+		};
+		const { res, get } = mockRes();
+		const handled = await tryHandleTrajectoryReadRoutes({
+			pathname: "/api/trajectories",
+			method: "GET",
+			url: url("/api/trajectories?limit=1.5&offset=Infinity"),
+			runtime: runtimeWith(service),
+			res,
+		});
+
+		expect(handled).toBe(true);
+		expect(get().status).toBe(200);
+		expect(receivedLimit).toBe(1);
+		expect(receivedOffset).toBe(0);
+	});
+
 	it("forwards the search param to the SQL reader so only matches return", async () => {
 		const rows = [
 			{ id: "match-1", status: "completed", llmCallCount: 1 },

--- a/packages/core/src/features/trajectories/read-routes.ts
+++ b/packages/core/src/features/trajectories/read-routes.ts
@@ -331,11 +331,17 @@ export async function tryHandleTrajectoryReadRoutes(options: {
 					},
 				);
 			}
-			const limit = Math.min(
-				500,
-				Math.max(1, Number(url.searchParams.get("limit")) || 50),
-			);
-			const offset = Math.max(0, Number(url.searchParams.get("offset")) || 0);
+			const rawLimit = url.searchParams.get("limit");
+			const requestedLimit = rawLimit === null ? Number.NaN : Number(rawLimit);
+			const limit = Number.isFinite(requestedLimit)
+				? Math.min(500, Math.max(1, Math.trunc(requestedLimit)))
+				: 50;
+			const rawOffset = url.searchParams.get("offset");
+			const requestedOffset =
+				rawOffset === null ? Number.NaN : Number(rawOffset);
+			const offset = Number.isFinite(requestedOffset)
+				? Math.max(0, Math.trunc(requestedOffset))
+				: 0;
 			const result = await service.listTrajectories({
 				limit,
 				offset,


### PR DESCRIPTION
# Relates to

Closes #19960.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] this PR targets `develop` and is branched directly off the current `origin/develop` tip.
- [x] focused package tests, lint, and typecheck pass on the exact head, see Testing below.
- [x] a reviewer can confirm the fix directly against the deterministic route-handler test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (fix, tests, verification transcript, via AgentRouter proxy), `anthropic/claude-sonnet-5` (independent re-verification)
<!-- attribution-row:client -->
- Agent tooling: `codex` (via AgentRouter proxy), `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] branched directly off the current `origin/develop` tip

# Risks

low. this only tightens input validation on a read-only listing route; every existing valid pagination request (finite integer or omitted `limit`/`offset` within the documented range) behaves identically.

# Background

## What does this PR do?

`GET /api/trajectories` converts `limit`/`offset` query params with bare `Number(...)` and bounds them with the old `Math.min/Math.max(... || fallback)` pattern, which only catches falsy results (`0`, `NaN`). two real gaps:

- `limit=1.5` passes straight through as a fraction, `Math.max(1, 1.5)` doesn't truncate.
- `offset` has no upper bound at all (only `Math.max(0, ...)`), so `offset=Infinity` reaches `TrajectoriesService.listTrajectories` completely unclamped.

both values get interpolated directly into a raw `LIMIT ${limit} OFFSET ${offset}` SQL clause in `TrajectoriesService.ts`, so accepted query input can turn into an invalid database query instead of a valid bounded pagination request.

checked the two other callers of `listTrajectories` (`skill-items.ts`, an internal call in `TrajectoriesService.ts`), both pass hardcoded literals (`limit: 5`, `limit: 500`), not user input, the HTTP route is the only reachable path for this.

fix: distinguish an absent query param from numeric zero, require `Number.isFinite` before accepting a value (default `limit=50`, `offset=0` otherwise), truncate finite fractional values, keep the existing `1..500` / non-negative bounds.

not touching `TrajectoriesService.listTrajectories`'s own internal clamp in this fix, its `Math.max/Math.min` has the same non-integer-safe gap, but it's unreachable from outside since every internal caller passes safe literals. noted in the issue in case maintainers want defense-in-depth there too.

## What kind of change is this?

bug fix, non-breaking (every existing valid request behaves identically).

# Documentation changes needed?

no, the fix restores the documented `1..500` / non-negative pagination contract rather than changing the interface.

# Testing

## Where should a reviewer start?

`packages/core/src/features/trajectories/read-routes.test.ts`, the new `normalizes trajectory pagination before forwarding it` case, then the finite-check + truncation logic in `read-routes.ts`.

## Detailed testing steps

```text
$ bun run --cwd packages/core test -- src/features/trajectories/read-routes.test.ts
Test Files  1 passed (1)
     Tests  10 passed (10)

$ bunx @biomejs/biome check packages/core/src/features/trajectories/read-routes.ts packages/core/src/features/trajectories/read-routes.test.ts
Checked 2 files in 61ms. No fixes applied.

$ bun run --cwd packages/core typecheck
Done!
exit 0
```

mutation-resistance verified independently: reverted just the source fix, kept the new test, reran, 1/10 failed with `expected 1.5 to be 1` (the fractional-limit case). restored the fix, 10/10 green again.

# Evidence Gate

<!-- evidence-head:2429d0118125e0a5184d6890450688fda0693c34 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes an API route handler and its test, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - this changes an API route handler and its test, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive product flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic unit test with an injected mock service, the real transcript is included under domain artifacts.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code or network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real mutation-resistance run, captured directly:
  ```text
  red (source fix reverted, test kept):
  FAIL read-routes.test.ts > normalizes trajectory pagination before forwarding it
  AssertionError: expected 1.5 to be 1
  Tests  1 failed | 9 passed (10)

  green (fix restored):
  Test Files  1 passed (1)
       Tests  10 passed (10)
  ```
  confirms the new test genuinely detects the fractional-limit / unbounded-offset regression and the fix closes it, verified independently against the real repo (not just trusting the original transcript). also independently confirmed the raw SQL interpolation point (`LIMIT ${limit} OFFSET ${offset}` in `TrajectoriesService.ts`) and that the two other callers of `listTrajectories` pass only hardcoded literals, so the HTTP route is the sole reachable path.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface or visual text changed.

## Known gaps / failures

full `packages/core` test suite wasn't run to a clean pass locally, it includes several long-running/timeout-prone tests in unrelated files (`pinned-fetch.integration.test.ts`, `document-processor-custom-llm.test.ts` — both fail on `listen(127.0.0.1)` sandbox denial; `guarded-stream.test.ts` and `trajectory-recorder.test.ts` have pre-existing unrelated failures) that make a full local run impractical here. the focused file, lint, and typecheck all pass clean on the exact head. requesting hosted CI confirm the full suite.

`TrajectoriesService.listTrajectories`'s own internal clamp (`Math.max(0, options.offset ?? 0)` / `Math.min(500, Math.max(1, options.limit ?? 50))`) has the same non-integer-safe pattern as the route did, but every current internal caller passes hardcoded literals, so it's not reachable from outside. left untouched per minimal-fix scope; noted in #19960 in case maintainers want defense-in-depth there too.

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran tests myself, traced the SQL interpolation and caller blast-radius, pushed via the GitHub Contents API since `git push` was stalling on this environment)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Contribution skill revision: N/A - direct interactive session, contribute-to-eliza skill not used
Compute receipt: N/A - Slop run-receipt install currently blocked by an unrelated site-deploy-lag issue (deployed skill archive predates recent develop changes)
Attribution status: self-reported
