### PR TITLE
test(agent): cross provider record byte budget

### DIFF
--- a/packages/agent/src/runtime/trajectory-steps.test.ts
+++ b/packages/agent/src/runtime/trajectory-steps.test.ts
@@ -502,7 +502,16 @@ describe("trajectory_steps dedicated table", () => {
       "test",
     );
     trajectory.steps[0]?.providerAccesses.push({
-      data: { payload: "x".repeat(1_100_000) },
+      // Each string is truncated independently before the record-wide budget
+      // is applied. Twenty fields ensure optional data really exhausts that
+      // global budget; restoring data-first normalization must then starve the
+      // required provider fields and make this SQL round trip fail.
+      data: Object.fromEntries(
+        Array.from({ length: 20 }, (_, index) => [
+          `payload-${index}`,
+          "x".repeat(70_000),
+        ]),
+      ),
       providerId: "provider-budget",
       providerName: "KNOWLEDGE",
       timestamp: 1_700_000_000_000,


### PR DESCRIPTION
# Relates to

Closes #19783.

- [x] This PR targets `develop` and was rebased onto `origin/develop` with zero conflicts before exact-head validation.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the changed contract from the attached focused-test and mutation evidence.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop`; zero conflicts.
- [x] Exact head `2c39d2dce9406f2bae7f55333073d25cdd935d67` passes `bun run verify`.

# Risks

Low. This changes one deterministic regression fixture and no production source. The fixture now crosses the record-wide byte budget after per-string truncation, so it detects a data-first normalization regression that the prior single-string payload could not reach.

# Background

## What does this PR do?

Builds oversized provider metadata from twenty independently truncated fields. Their aggregate size exhausts the global provider-record budget, making the test prove that required provider fields are serialized before optional `data`.

## What kind of change is this?

Bug-fix regression coverage; non-breaking and test-only.

# Documentation changes needed?

No. Public behavior and documentation are unchanged.

# Testing

## Where should a reviewer start?

Review the provider byte-budget case in `packages/agent/src/runtime/trajectory-steps.test.ts`, then inspect the attached verification log.

## Detailed testing steps

1. Run the focused Agent Vitest file and confirm 17/17 pass.
2. Review the mutation result: restoring data-first normalization makes the target test fail with `TRAJECTORY_ROW_INVALID` at `providerAccesses[0].providerId`.
3. Confirm the exact head passes Agent typecheck, lint, build, and root `bun run verify` (350/350 plus every audit).

# Evidence Gate

<!-- evidence-head:2c39d2dce9406f2bae7f55333073d25cdd935d67 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - deterministic test-only change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - deterministic test-only change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or user-visible flow changed
<!-- evidence-row:backend-logs -->
- [ ] N/A - no production backend path changed; the deterministic persistence round trip and mutation proof are attached as the domain artifact
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend behavior, request, or state changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent behavior, action, prompt, provider implementation, or model path changed
<!-- evidence-row:domain-artifacts -->
- [x] [19962-19783-verification.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19962-19783-verification.log)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed

# Evidence Details

The focused test exercises the actual trajectory persistence round trip. The deliberate production-order mutation causes exactly the target regression to fail, showing the new fixture crosses the global record budget and protects required provider fields.

## Known gaps / failures

Screenshots, video, frontend logs, OCR, and a live-LLM trajectory are inapplicable because this PR changes only a deterministic persistence regression fixture. Production source and behavior are unchanged.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— Codex
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no contribution skill used"} -->


