### PR TITLE
fix(cloud): inspect equivalent Headscale upgrade maps

### DIFF
--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -432,7 +432,8 @@ validate_retirable_legacy_vhost() {
       if (in_upgrade_map) {
         if (normalized == "default upgrade;") {
           defaults += 1
-        } else if (normalized == "\\047\\047 close;") {
+        } else if (normalized == "\\047\\047 close;" \
+            || normalized == "\\042\\042 close;") {
           closes += 1
         } else if (normalized == "}") {
           endings += 1
@@ -473,7 +474,7 @@ validate_retirable_legacy_vhost() {
         || [ "$legacy_upgrade_map_closes" -ne 1 ] \\
         || [ "$legacy_upgrade_map_endings" -ne 1 ] \\
         || [ "$legacy_upgrade_map_unexpected" -ne 0 ]; then
-      echo "legacy Headscale vhost has an unexpected upgrade map shape"
+      echo "legacy Headscale vhost has an unexpected upgrade map shape: blocks=$legacy_upgrade_map_blocks defaults=$legacy_upgrade_map_defaults empty-close=$legacy_upgrade_map_closes endings=$legacy_upgrade_map_endings unexpected=$legacy_upgrade_map_unexpected"
       return 1
     fi
     legacy_has_upgrade_map=true

--- a/packages/cloud/services/headscale/DEPLOY.md
+++ b/packages/cloud/services/headscale/DEPLOY.md
@@ -97,11 +97,16 @@ gh workflow run arm-headscale-control-plane.yml --repo elizaOS/eliza \
 
 The inspection requires a regular, root-owned, non-group/world-writable file,
 exactly two server blocks that name only `headscale-staging.elizacloud.ai`, and
-exactly two loaded nginx owners from that path. It reports file metadata,
-SHA-256, directive-name counts, and the validated server-block/name shape for
-review without printing directive literal values. Only after that run is
-reviewed may an operator select the retirement operation and supply that exact
-lowercase digest:
+exactly two loaded nginx owners from that path. A file-local websocket upgrade
+map may spell its empty-string key with nginx's equivalent single or double
+quotes, but every other map token and any external reference remain
+fail-closed. The inspection reports file metadata, SHA-256, directive-name
+counts, and the validated server-block/name/map shape for review without
+printing directive literal values. If the map is rejected, only structural
+counts are printed so operators can distinguish formatting drift from an
+additional entry without exposing values. Only after that run is reviewed may
+an operator select the retirement operation and supply that exact lowercase
+digest:
 
 ```bash
 gh workflow run arm-headscale-control-plane.yml --repo elizaOS/eliza \

--- a/packages/scripts/__tests__/headscale-arm-workflow.test.ts
+++ b/packages/scripts/__tests__/headscale-arm-workflow.test.ts
@@ -965,6 +965,17 @@ server {
     });
     expect(valid.status).toBe(0);
 
+    const doubleQuotedEmptyKey = expectedLegacySource.replace(
+      "''      close;",
+      '""      close;',
+    );
+    const doubleQuotedValid = runLegacyVhostValidation({
+      source: doubleQuotedEmptyKey,
+      loadedConfig: expectedLoadedConfig.replace("'' close;", '"" close;'),
+      enforceDirectiveAllowlist: true,
+    });
+    expect(doubleQuotedValid.status).toBe(0);
+
     for (const source of [
       expectedLegacySource.replace("$http_upgrade", "$http_connection"),
       expectedLegacySource.replace("$connection_upgrade", "$shared_upgrade"),
@@ -975,6 +986,10 @@ server {
         "  ''      close;",
         "  ''      close;\n  ''      close;",
       ),
+      expectedLegacySource.replace(
+        "  ''      close;",
+        "  ''      close;\n  \"\"      close;",
+      ),
     ]) {
       const invalid = runLegacyVhostValidation({
         source,
@@ -983,6 +998,10 @@ server {
       });
       expect(invalid.status).not.toBe(0);
       expect(invalid.stdout).toContain("unexpected upgrade map shape");
+      expect(invalid.stdout).toMatch(
+        /blocks=\d+ defaults=\d+ empty-close=\d+ endings=\d+ unexpected=\d+/u,
+      );
+      expect(invalid.stdout).not.toContain("$connection_upgrade");
     }
 
     const externallyReferenced = runLegacyVhostValidation({


### PR DESCRIPTION
# Relates to

Closes #19800.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop`. It was rebased without conflicts onto `1e487ed5a35bf193819a1fc7f2a2d7800e4ba100`; the subsequent current-develop advance to `ac4125fcb013c3f1f7600f71fd35cf3750f422bd` changes no PR path and `git merge-tree --write-tree origin/develop HEAD` is clean.
- [x] `bun install` completed earlier in this isolated worktree and exact-head `bun run verify` passed after the final rebase.
- [x] The executable regression and the prior protected inspection output let a reviewer confirm the exact live shape without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@ac4125fcb013c3f1f7600f71fd35cf3750f422bd:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Final rebase was conflict-free; the newer two-commit develop delta is path-disjoint and has a clean synthetic merge.
- [x] Exact-head `bun run verify` passes: 350/350 Turbo tasks, 0 cached, followed by every repository audit and an 8,175-file clean anti-larp scan.

# Risks

Low, staging infrastructure only. The patch widens one already reviewed nginx map-key spelling from single-quoted empty string to nginx's equivalent double-quoted empty string. Every other map token, external reference, file digest, ownership, mode, directive, server-name, listener, SAN, rollback, and public-health gate remains fail-closed. The protected retirement still binds the exact inspected SHA-256 and remains staging-only.

# Background

## What does this PR do?

The protected Headscale staging retirement correctly rejected the discovered legacy vhost because its standard websocket upgrade map used `"" close;` instead of `'' close;`. This patch accepts those two nginx-equivalent empty-string spellings, keeps duplicate or additional entries rejected, and emits only structural counts when the map shape is invalid. It also updates the operator runbook and executable regression.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

The Headscale deployment runbook is updated with the exact accepted map contract and privacy-preserving diagnostic behavior.

# Testing

## Where should a reviewer start?

Run `bun test packages/scripts/__tests__/headscale-arm-workflow.test.ts` and review the `retires only the isolated standard Headscale websocket upgrade map` case.

## Detailed testing steps

- `bun test packages/scripts/__tests__/headscale-arm-workflow.test.ts` — 30/30 tests, 342 assertions.
- `node --check packages/cloud/scripts/admin/arm-headscale-control-plane.mjs` — pass.
- `bunx biome check packages/cloud/scripts/admin/arm-headscale-control-plane.mjs packages/scripts/__tests__/headscale-arm-workflow.test.ts` — pass.
- `bun run verify:cloud` on the immediately preceding patch-equivalent rebase — 78/78, 0 cached.
- Exact final head `bun run verify` — 350/350, 0 cached; all follow-on audits and anti-larp pass.
- `git diff --check origin/develop...HEAD` — pass.

# Evidence Gate

<!-- evidence-head:d85d05e2a54cdeffa39fde3db9faf0853e10c523 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - protected nginx control-plane parsing has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - protected nginx control-plane parsing has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or rendered user flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live retirement is run from an unmerged PR; the executable generated-shell regression is the safe end-to-end proof, and the protected post-merge run will provide the real host transaction log.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the change intentionally does not mutate the host before merge; the prior read-only inspection already bound `/etc/nginx/conf.d/headscale-staging.conf` to SHA-256 `33a19405371271ce2323cbfcb81814dc39d5ddea651f0af0752b69ca339d9a0c`.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model path changed.

## Backend + frontend logs

The deterministic harness executes the generated remote shell against the reviewed legacy source shape. It proves single- and double-quoted empty keys succeed, duplicate/mutated entries fail with structural counts, no directive values leak, the exact digest/owner/listener contract remains enforced, and rollback stays armed through downstream convergence.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface.

## Audio / voice walkthrough

N/A - no audio or voice behavior.

## Known gaps / failures

No code or test gap. The live staging retirement is deliberately deferred until this reviewed patch is merged; the protected run must then prove exclusive intended nginx ownership, identical dual-SAN public leaves, and both canonical and legacy `/health` endpoints before the release train proceeds.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@ac4125fcb013c3f1f7600f71fd35cf3750f422bd:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@ac4125fcb013c3f1f7600f71fd35cf3750f422bd:packages/skills/skills/contribute-to-eliza"} -->
