### PR TITLE
fix(cloud-api): log why an internal service token was rejected

### DIFF
--- a/packages/cloud/api/internal/_auth.ts
+++ b/packages/cloud/api/internal/_auth.ts
@@ -5,6 +5,7 @@ import {
   extractBearerToken,
   verifyInternalToken,
 } from "@/lib/auth/jwt-internal";
+import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 export interface InternalServiceAuth {
@@ -45,7 +46,17 @@ export async function requireInternalAuth(
       podName: verified.payload.sub,
       service: verified.payload.service,
     };
-  } catch {
+  } catch (error) {
+    // Rejection stays fail-closed (denylist store errors reject the token by
+    // design), but the REASON must reach the logs: a swallowed error makes a
+    // revocation-store outage indistinguishable from a bad token (live:
+    // staging's Telegram live-fire 401'd here for hours with signature-valid
+    // tokens before the Redis REST denylist read was isolated as the cause —
+    // by elimination, because nothing logged it). Message only, never the
+    // token or its claims.
+    logger.warn("[internal-auth] internal token rejected", {
+      reason: error instanceof Error ? error.message : String(error),
+    });
     return jsonError(c, 401, "Unauthorized", "authentication_required");
   }
 }


### PR DESCRIPTION
One-catch fix on the internal service-auth boundary: `requireInternalAuth` swallowed every verification error into a bare 401, so a revocation-store outage is indistinguishable from a bad token in worker logs. Live cost tonight: the staging Telegram live-fire 401'd with signature-valid JWTs and codex-shared-eliza had to isolate the failing Redis REST denylist read **by elimination** (JWKS-verified token + fresh JTIs + bound KV secrets ⇒ only the fail-closed `isJtiRevoked` branch left) because nothing logged the reason.

Behavior unchanged — rejection stays fail-closed per the denylist design. The rejection reason (error message only, never the token or claims) now reaches the logs, so the NEXT staging tail names the actual store failure instead of requiring a deduction chain.

Evidence: cloud-api typecheck PASS, biome clean; log-only diff inside an existing catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:cf0ab7901ff3f6c9fbac12c61f34fcf866cd5387 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - log-only change inside existing catch; no UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - log-only change inside existing catch; no UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - one-catch diff; behavior unchanged (fail-closed)

<!-- evidence-row:backend-logs -->
- [ ] N/A - the change IS the backend log; staging tail post-deploy is the domain proof

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model path

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - artifact is the logged rejection reason; verified on next staging deploy tail
