### PR TITLE
fix(cli): reject infinite migration memory window

### DIFF
--- a/packages/elizaos/src/commands/migrate-agent.ts
+++ b/packages/elizaos/src/commands/migrate-agent.ts
@@ -93,7 +93,7 @@ export async function migrateAgent(opts: MigrateAgentOptions): Promise<void> {
 
   const firewall = opts.noFirewall ? false : (opts.firewall ?? true);
   const memoryDays = opts.memoryDays ? Number(opts.memoryDays) : 14;
-  if (Number.isNaN(memoryDays) || memoryDays < 0) {
+  if (!Number.isFinite(memoryDays) || memoryDays < 0) {
     fail("--memory-days must be a non-negative number.");
   }
 

--- a/packages/elizaos/src/migrate/migrate.test.ts
+++ b/packages/elizaos/src/migrate/migrate.test.ts
@@ -632,7 +632,7 @@ describe("oc home-format variants (cross-version)", () => {
   });
 });
 
-describe("migrate-agent --json stdout purity (GAP E)", () => {
+describe("migrate-agent command behavior", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -664,5 +664,27 @@ describe("migrate-agent --json stdout purity (GAP E)", () => {
     expect(parsed.memoryCount).toBeGreaterThan(0);
     expect(parsed.summary).toHaveProperty("sqliteStores");
     expect(parsed.summary).toHaveProperty("warnings");
+  });
+
+  it("rejects a non-finite --memory-days value", async () => {
+    let err = "";
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+      err += String(chunk);
+      return true;
+    });
+    vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+
+    await expect(
+      migrateAgent({
+        from: FIXTURE,
+        agentId: "tess",
+        memoryDays: "Infinity",
+        dryRun: true,
+        json: true,
+      }),
+    ).rejects.toThrow("process.exit called");
+    expect(err).toContain("--memory-days must be a non-negative number.");
   });
 });


### PR DESCRIPTION
# Relates to

Closes #19971.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] this PR targets `develop` and is branched directly off the current `origin/develop` tip.
- [x] focused package tests, lint, and typecheck pass on the exact head, see Testing below.
- [x] a reviewer can confirm the fix directly against the deterministic CLI command test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (fix, tests, verification transcript, via AgentRouter proxy), `anthropic/claude-sonnet-5` (independent re-verification)
<!-- attribution-row:client -->
- Agent tooling: `codex` (via AgentRouter proxy), `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] branched directly off the current `origin/develop` tip

# Risks

low. this only tightens boundary validation on a CLI flag; every existing valid `--memory-days` value (finite, non-negative) behaves identically.

# Background

## What does this PR do?

`elizaos migrate-agent --memory-days Infinity` currently gets accepted, the boundary check only rejects `NaN` and negative values (`Number.isNaN(memoryDays) || memoryDays < 0`), and `Number("Infinity")` is neither.

that value flows straight through to `memory-tiering.ts`'s cutoff calculation: `const cutoff = now - opts.memoryDays * DAY_MS` becomes `now - Infinity = -Infinity`. every real daily log's timestamp satisfies `date >= cutoff` at that point, so every historical log gets flat-seeded as `CURRENT` instead of falling into the older-history bucket, misclassifying an agent's entire memory history as recent.

reproduced against the fixture (which contains a 2024 daily log) before writing the fix:

```text
memoryDays: "Infinity" -> counts: { CURRENT: 3, LONGTERM: 2, SELF: 1, MARKER: 0 }, dailyLogsTotal: 2
```

the 2024 log should not be flat-seeded as current.

fix: reject via `!Number.isFinite(memoryDays)` instead of `Number.isNaN(memoryDays)`, catching both positive and negative infinity while leaving every existing finite-value validation path (including the non-negative check) unchanged.

## What kind of change is this?

bug fix, non-breaking (every existing valid `--memory-days` value behaves identically).

# Documentation changes needed?

no, the fix restores the documented non-negative-number contract rather than changing the interface.

# Testing

## Where should a reviewer start?

`packages/elizaos/src/migrate/migrate.test.ts`, the new `rejects a non-finite --memory-days value` case, then the one-line validation change in `migrate-agent.ts`.

## Detailed testing steps

```text
$ bun run --cwd packages/elizaos test -- src/migrate/migrate.test.ts -t "rejects a non-finite --memory-days value"
Test Files  1 passed (1)
     Tests  1 passed | 23 skipped (24)

$ bun run --cwd packages/elizaos test
Test Files  14 passed (14)
     Tests  108 passed (108)

$ bun run --cwd packages/elizaos typecheck
exit 0

$ bunx @biomejs/biome check packages/elizaos/src/commands/migrate-agent.ts packages/elizaos/src/migrate/migrate.test.ts
Checked 2 files in 64ms. No fixes applied.

$ node packages/elizaos/dist/cli.js migrate-agent --from <fixture> --agent-id tess --memory-days Infinity --dry-run --json
--memory-days must be a non-negative number.
exit=1
```

mutation-resistance verified independently: reverted just the source fix, kept the new test, reran, failed with `promise resolved "undefined" instead of rejecting`. restored the fix, passed again.

# Evidence Gate

<!-- evidence-head:9aa291313a50cef5e1623f9435cd01756539d908 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes a CLI command's input validation, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - this changes a CLI command's input validation, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive product flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic CLI command test, the real transcript is included under domain artifacts.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code or network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real mutation-resistance run plus a real built-CLI invocation, captured directly:
  ```text
  red (source fix reverted, test kept):
  AssertionError: promise resolved "undefined" instead of rejecting
  Tests  1 failed | 23 skipped (24)

  green (fix restored):
  Test Files  1 passed (1)
       Tests  1 passed | 23 skipped (24)

  built CLI, real invocation:
  $ node packages/elizaos/dist/cli.js migrate-agent --from <fixture> --agent-id tess --memory-days Infinity --dry-run --json
  --memory-days must be a non-negative number.
  exit=1
  ```
  confirms the new test genuinely detects the infinite-memory-days regression, the fix closes it, and the real built CLI rejects the case end to end. also independently traced the full reachability chain (CLI flag -> migrateAgent -> memory-tiering.ts cutoff calculation -> per-log classification) to confirm the misclassification is real, not just a validation nicety.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface or visual text changed.

## Known gaps / failures

full packaged-smoke test (`test:packaged`) wasn't run to completion locally, the host npm cache has root-owned files (unrelated environment issue) and, after working around that, the global-install phase needs real network access to the npm registry which this sandbox doesn't have. the focused test suite, full package test suite (108/108), typecheck, lint, and a real built-CLI invocation all pass clean on the exact head. requesting hosted CI confirm the packaged smoke test.

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran tests myself, traced the full cutoff-calculation reachability chain, pushed via the GitHub Contents API since `git push` was stalling on this environment)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Contribution skill revision: N/A - direct interactive session, contribute-to-eliza skill not used
Compute receipt: N/A - Slop run-receipt install currently blocked by an unrelated site-deploy-lag issue (deployed skill archive predates recent develop changes)
Attribution status: self-reported
