### PR TITLE
fix(plugin-x): make x dm reply egress at-most-once across callback invocations

### DIFF
--- a/plugins/plugin-x/src/direct-messages.test.ts
+++ b/plugins/plugin-x/src/direct-messages.test.ts
@@ -563,4 +563,227 @@ describe("TwitterDirectMessageClient", () => {
     expect(cache.get("twitter/agent/agent-user-id/dm_cursor")).toBe("501");
     await dmClient.stop();
   });
+
+  it("sends exactly one reply when the pipeline invokes the callback repeatedly in one turn", async () => {
+    vi.useFakeTimers();
+    const event = {
+      id: "601",
+      sender_id: "person-1",
+      dm_conversation_id: "conversation-1",
+      text: "say it once",
+      event_type: "MessageCreate",
+    };
+    const cache = new Map<string, string>([
+      ["twitter/agent/agent-user-id/dm_cursor", "600"],
+    ]);
+    const sendDmToParticipant = vi.fn(async () => ({
+      data: { dm_event_id: "reply-601" },
+    }));
+    const callbackResults: Memory[][] = [];
+    // Mirrors a multi-callback turn: two replying actions plus an evaluator
+    // delivery each invoke the same HandlerCallback sequentially.
+    const handleMessage = vi.fn(
+      async (
+        _runtime: IAgentRuntime,
+        _memory: Memory,
+        callback: (response: { text: string }) => Promise<Memory[]>,
+      ) => {
+        callbackResults.push(await callback({ text: "first reply" }));
+        callbackResults.push(await callback({ text: "second reply" }));
+        callbackResults.push(await callback({ text: "evaluator delivery" }));
+      },
+    );
+    const runtime = {
+      agentId: "00000000-0000-0000-0000-000000000001",
+      getCache: async (key: string) => cache.get(key),
+      setCache: async (key: string, value: string) => {
+        cache.set(key, value);
+      },
+      deleteCache: async (key: string) => cache.delete(key),
+      getMemoryById: async () => null,
+      createMemory: vi.fn(async () => undefined),
+      ensureWorldExists: vi.fn(async () => undefined),
+      updateWorld: vi.fn(async () => undefined),
+      ensureRoomExists: vi.fn(async () => undefined),
+      ensureConnection: vi.fn(async () => undefined),
+      messageService: { handleMessage },
+      reportError: vi.fn(),
+      getSetting: vi.fn(() => null),
+    } as unknown as IAgentRuntime;
+    const client = {
+      accountId: "agent",
+      profile: { id: "agent-user-id", username: "elizamakesmagic" },
+      twitterClient: {
+        getV2Client: async () => ({
+          v2: {
+            listDmEvents: async () => ({ events: [event] }),
+            sendDmToParticipant,
+          },
+        }),
+      },
+    } as unknown as ClientBase;
+    const dmClient = new TwitterDirectMessageClient(client, runtime, {
+      TWITTER_DRY_RUN: "false",
+      TWITTER_DM_POLL_INTERVAL_SECONDS: "15",
+    } as unknown as TwitterClientState);
+
+    await dmClient.start();
+    expect(sendDmToParticipant).toHaveBeenCalledTimes(1);
+    expect(sendDmToParticipant).toHaveBeenCalledWith("person-1", {
+      text: "first reply",
+    });
+    expect(callbackResults[1]).toEqual([]);
+    expect(callbackResults[2]).toEqual([]);
+    expect(cache.get("twitter/agent/agent-user-id/dm_cursor")).toBe("601");
+    expect(cache.get("twitter/agent/agent-user-id/dm_settled/601")).toBe(
+      "delivered:reply-601",
+    );
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(sendDmToParticipant).toHaveBeenCalledTimes(1);
+    await dmClient.stop();
+  });
+
+  it("sends exactly one reply across concurrent callback invocations", async () => {
+    vi.useFakeTimers();
+    const event = {
+      id: "701",
+      sender_id: "person-1",
+      dm_conversation_id: "conversation-1",
+      text: "race me",
+      event_type: "MessageCreate",
+    };
+    const cache = new Map<string, string>([
+      ["twitter/agent/agent-user-id/dm_cursor", "700"],
+    ]);
+    const sendDmToParticipant = vi.fn(async () => ({
+      data: { dm_event_id: "reply-701" },
+    }));
+    const handleMessage = vi.fn(
+      async (
+        _runtime: IAgentRuntime,
+        _memory: Memory,
+        callback: (response: { text: string }) => Promise<Memory[]>,
+      ) => {
+        await Promise.all([
+          callback({ text: "parallel one" }),
+          callback({ text: "parallel two" }),
+        ]);
+      },
+    );
+    const runtime = {
+      agentId: "00000000-0000-0000-0000-000000000001",
+      getCache: async (key: string) => cache.get(key),
+      setCache: async (key: string, value: string) => {
+        cache.set(key, value);
+      },
+      deleteCache: async (key: string) => cache.delete(key),
+      getMemoryById: async () => null,
+      createMemory: vi.fn(async () => undefined),
+      ensureWorldExists: vi.fn(async () => undefined),
+      updateWorld: vi.fn(async () => undefined),
+      ensureRoomExists: vi.fn(async () => undefined),
+      ensureConnection: vi.fn(async () => undefined),
+      messageService: { handleMessage },
+      reportError: vi.fn(),
+      getSetting: vi.fn(() => null),
+    } as unknown as IAgentRuntime;
+    const client = {
+      accountId: "agent",
+      profile: { id: "agent-user-id", username: "elizamakesmagic" },
+      twitterClient: {
+        getV2Client: async () => ({
+          v2: {
+            listDmEvents: async () => ({ events: [event] }),
+            sendDmToParticipant,
+          },
+        }),
+      },
+    } as unknown as ClientBase;
+    const dmClient = new TwitterDirectMessageClient(client, runtime, {
+      TWITTER_DRY_RUN: "false",
+      TWITTER_DM_POLL_INTERVAL_SECONDS: "15",
+    } as unknown as TwitterClientState);
+
+    await dmClient.start();
+    expect(sendDmToParticipant).toHaveBeenCalledTimes(1);
+    expect(cache.get("twitter/agent/agent-user-id/dm_cursor")).toBe("701");
+    await dmClient.stop();
+  });
+
+  it("keeps later same-turn invocations suppressed after an explicit rejection and retries next poll", async () => {
+    vi.useFakeTimers();
+    const event = {
+      id: "801",
+      sender_id: "person-1",
+      dm_conversation_id: "conversation-1",
+      text: "reject then retry",
+      event_type: "MessageCreate",
+    };
+    const cache = new Map<string, string>([
+      ["twitter/agent/agent-user-id/dm_cursor", "800"],
+    ]);
+    const sendDmToParticipant = vi
+      .fn()
+      .mockRejectedValueOnce({ status: 403, message: "forbidden" })
+      .mockResolvedValue({ data: { dm_event_id: "reply-801" } });
+    // An explicit rejection reopens the event for the NEXT poll; a second
+    // callback invocation inside the same turn must still not send.
+    const handleMessage = vi.fn(
+      async (
+        _runtime: IAgentRuntime,
+        _memory: Memory,
+        callback: (response: { text: string }) => Promise<Memory[]>,
+      ) => {
+        await callback({ text: "rejected attempt" }).catch(() => []);
+        await callback({ text: "same-turn retry" }).catch(() => []);
+      },
+    );
+    const runtime = {
+      agentId: "00000000-0000-0000-0000-000000000001",
+      getCache: async (key: string) => cache.get(key),
+      setCache: async (key: string, value: string) => {
+        cache.set(key, value);
+      },
+      deleteCache: async (key: string) => cache.delete(key),
+      getMemoryById: async () => null,
+      createMemory: vi.fn(async () => undefined),
+      ensureWorldExists: vi.fn(async () => undefined),
+      updateWorld: vi.fn(async () => undefined),
+      ensureRoomExists: vi.fn(async () => undefined),
+      ensureConnection: vi.fn(async () => undefined),
+      messageService: { handleMessage },
+      reportError: vi.fn(),
+      getSetting: vi.fn(() => null),
+    } as unknown as IAgentRuntime;
+    const client = {
+      accountId: "agent",
+      profile: { id: "agent-user-id", username: "elizamakesmagic" },
+      twitterClient: {
+        getV2Client: async () => ({
+          v2: {
+            listDmEvents: async () => ({ events: [event] }),
+            sendDmToParticipant,
+          },
+        }),
+      },
+    } as unknown as ClientBase;
+    const dmClient = new TwitterDirectMessageClient(client, runtime, {
+      TWITTER_DRY_RUN: "false",
+      TWITTER_DM_POLL_INTERVAL_SECONDS: "15",
+    } as unknown as TwitterClientState);
+
+    await dmClient.start();
+    expect(sendDmToParticipant).toHaveBeenCalledTimes(1);
+    expect(cache.get("twitter/agent/agent-user-id/dm_cursor")).toBe("800");
+    expect(
+      cache.get("twitter/agent/agent-user-id/dm_settled/801"),
+    ).toBeUndefined();
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(sendDmToParticipant).toHaveBeenCalledTimes(2);
+    expect(cache.get("twitter/agent/agent-user-id/dm_cursor")).toBe("801");
+    expect(cache.get("twitter/agent/agent-user-id/dm_settled/801")).toBe(
+      "delivered:reply-801",
+    );
+    await dmClient.stop();
+  });
 });

--- a/plugins/plugin-x/src/direct-messages.ts
+++ b/plugins/plugin-x/src/direct-messages.ts
@@ -8,7 +8,8 @@
  * cursor only advances past an event once its reply was delivered, deliberately
  * skipped, or reached an indeterminate provider-egress state. X does not expose
  * an idempotency key for DM sends, so an ambiguous failure after egress starts is
- * retained as an at-most-once tombstone instead of risking a duplicate reply.
+ * retained as an at-most-once tombstone instead of risking a duplicate reply, and
+ * only a turn's first reply-callback invocation may attempt egress at all.
  */
 import {
   ChannelType,
@@ -338,10 +339,25 @@ export class TwitterDirectMessageClient {
     // callback rejection, so settlement below can distinguish "delivered or
     // deliberately silent" from "send failed, retry next poll".
     let deliveryError: unknown = null;
+    let egressAttempted = false;
     const callback: HandlerCallback = async (response: Content) => {
       const text =
         typeof response.text === "string" ? response.text.trim() : "";
       if (!text) return [];
+      // The message pipeline may invoke this callback more than once per turn
+      // (multiple replying actions, evaluator delivery), including
+      // concurrently. The durable settled marker only guards across polls, so
+      // the turn's first egress attempt claims the event synchronously — no
+      // await sits between check and set — and every later invocation is
+      // suppressed. Explicit-rejection recovery stays at the poll level.
+      if (egressAttempted) {
+        logger.warn(
+          { src: "plugin:x", senderId, conversationId, dmEventId: event.id },
+          "Suppressed duplicate X DM reply attempt for one inbound event",
+        );
+        return [];
+      }
+      egressAttempted = true;
       if (this.isDryRun) {
         logger.info(
           { src: "plugin:x", senderId, text },


### PR DESCRIPTION
Closes #19969. Repairs the **duplicate DM egress** P1 from the #19873 post-merge security hold (gauss's enumeration at HQ #18309).

## Defect
`handleInboundMessage` checks the durable `dm_settled` marker once, before handing the inbound memory to `messageService.handleMessage`. The reply callback then writes the `egress_started` no-replay barrier and sends — but nothing stops a second `HandlerCallback` invocation in the same turn (multiple replying actions, evaluator delivery, concurrent invocations) from claiming and sending again. One inbound DM could produce multiple externally visible X replies.

## Fix (structural)
The turn's first egress attempt claims the event via a closure flag set synchronously — no await sits between check and set, so concurrent invocations cannot interleave past it. Every later invocation is suppressed with a warn log and returns `[]`. All existing settlement semantics are unchanged: explicit provider rejection still reopens the event for next-poll retry, ambiguous transport failure still retains the at-most-once tombstone, delivered / settled_without_reply markers unchanged.

## Evidence
| Row | Value |
|---|---|
| tests | `plugins/plugin-x/src/direct-messages.test.ts` — 3 new contract tests: repeated sequential invocations → exactly one send (with delivered marker + cursor advance), concurrent `Promise.all` invocations → exactly one send, explicit 4xx rejection → same-turn retry suppressed + next-poll retry delivers. Full file 9/9. |
| package suite | plugin-x: 23 files passed / 1 skipped, 111 tests passed / 13 skipped (baseline 108 + 3 new) |
| typecheck/lint | `tsc --noEmit` clean; biome `lint:check` clean (79 files) |
| llm-trajectory | N/A - deterministic connector egress path; no model call in the changed surface; contract tests exercise the exact callback protocol the live pipeline uses |
| domain-artifacts | N/A - X DM egress requires a live X account send; the deterministic harness mirrors the production twitter-api-v2 call shape (`sendDmToParticipant`/`sendDmInConversation`) |

Security surface — requesting gauss (fleet, HQ #18309) review per the hold; no self-serve merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
