### PR TITLE
fix(cloud): accept quoted Headscale map variables

### DIFF
--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -422,6 +422,14 @@ validate_retirable_legacy_vhost() {
     }
   ')
   legacy_upgrade_map_shape=$(printf '%s\\n' "$legacy_vhost_source" | awk '
+    function is_exact_map_token(token, expected, quote) {
+      if (token == expected) return 1
+      if (length(token) != length(expected) + 2) return 0
+      quote = substr(token, 1, 1)
+      if (quote != sprintf("%c", 39) && quote != sprintf("%c", 34)) return 0
+      if (substr(token, length(token), 1) != quote) return 0
+      return substr(token, 2, length(token) - 2) == expected
+    }
     {
       line = $0
       sub(/^[[:space:]]+/, "", line)
@@ -444,7 +452,12 @@ validate_retirable_legacy_vhost() {
         next
       }
       if (normalized ~ /^map[[:space:]]/) {
-        if (normalized == "map $http_upgrade $connection_upgrade {") {
+        map_field_count = split(normalized, map_fields, /[[:space:]]+/)
+        if (map_field_count == 4 \
+            && map_fields[1] == "map" \
+            && is_exact_map_token(map_fields[2], "$http_upgrade") \
+            && is_exact_map_token(map_fields[3], "$connection_upgrade") \
+            && map_fields[4] == "{") {
           blocks += 1
           in_upgrade_map = 1
         } else {

--- a/packages/cloud/services/headscale/DEPLOY.md
+++ b/packages/cloud/services/headscale/DEPLOY.md
@@ -98,15 +98,16 @@ gh workflow run arm-headscale-control-plane.yml --repo elizaOS/eliza \
 The inspection requires a regular, root-owned, non-group/world-writable file,
 exactly two server blocks that name only `headscale-staging.elizacloud.ai`, and
 exactly two loaded nginx owners from that path. A file-local websocket upgrade
-map may spell its empty-string key with nginx's equivalent single or double
-quotes, but every other map token and any external reference remain
-fail-closed. The inspection reports file metadata, SHA-256, directive-name
-counts, and the validated server-block/name/map shape for review without
-printing directive literal values. If the map is rejected, only structural
-counts are printed so operators can distinguish formatting drift from an
-additional entry without exposing values. Only after that run is reviewed may
-an operator select the retirement operation and supply that exact lowercase
-digest:
+map may wrap each exact map variable in balanced single or double quotes and
+may spell its empty-string key with nginx's equivalent single or double quotes.
+Mismatched quotes, different variables, additional tokens or entries, and any
+external reference remain fail-closed. The inspection reports file metadata,
+SHA-256, directive-name counts, and the validated server-block/name/map shape
+for review without printing directive literal values. If the map is rejected,
+only structural counts are printed so operators can distinguish formatting
+drift from an additional entry without exposing values. Only after that run is
+reviewed may an operator select the retirement operation and supply that exact
+lowercase digest:
 
 ```bash
 gh workflow run arm-headscale-control-plane.yml --repo elizaOS/eliza \

--- a/packages/scripts/__tests__/headscale-arm-workflow.test.ts
+++ b/packages/scripts/__tests__/headscale-arm-workflow.test.ts
@@ -976,6 +976,24 @@ server {
     });
     expect(doubleQuotedValid.status).toBe(0);
 
+    for (const quotedHeader of [
+      'map "$http_upgrade" "$connection_upgrade" {',
+      "map '$http_upgrade' '$connection_upgrade' {",
+    ]) {
+      const quotedHeaderValid = runLegacyVhostValidation({
+        source: expectedLegacySource.replace(
+          "map $http_upgrade $connection_upgrade {",
+          quotedHeader,
+        ),
+        loadedConfig: expectedLoadedConfig.replace(
+          "map $http_upgrade $connection_upgrade {",
+          quotedHeader,
+        ),
+        enforceDirectiveAllowlist: true,
+      });
+      expect(quotedHeaderValid.status).toBe(0);
+    }
+
     for (const source of [
       expectedLegacySource.replace("$http_upgrade", "$http_connection"),
       expectedLegacySource.replace("$connection_upgrade", "$shared_upgrade"),
@@ -989,6 +1007,18 @@ server {
       expectedLegacySource.replace(
         "  ''      close;",
         "  ''      close;\n  \"\"      close;",
+      ),
+      expectedLegacySource.replace(
+        "map $http_upgrade $connection_upgrade {",
+        'map "$http_upgrade\' "$connection_upgrade" {',
+      ),
+      expectedLegacySource.replace(
+        "map $http_upgrade $connection_upgrade {",
+        'map "$http_connection" "$connection_upgrade" {',
+      ),
+      expectedLegacySource.replace(
+        "map $http_upgrade $connection_upgrade {",
+        'map "$http_upgrade" "$connection_upgrade" extra {',
       ),
     ]) {
       const invalid = runLegacyVhostValidation({


### PR DESCRIPTION
# Relates to

Relates to #19800.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop`. Exact head `c8cc8f4d12855d616d1b90b31919fdcdabb3c357` was rebased without conflicts onto `22858969b41831362e990d23203e60732706a10d`; current develop `39cb6da21e4f81d594cc912350fc039a14d9a171` changes no PR path and `git merge-tree --write-tree HEAD origin/develop` is clean.
- [x] Full install prerequisites were already completed in the isolated worktree and exact-head `TURBO_FORCE=1 bun run verify` passed after the final rebase.
- [x] The executable generated-shell regression covers valid and adversarial quote forms without exposing reviewed nginx directive values.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@22858969b41831362e990d23203e60732706a10d:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Final tested rebase was conflict-free. The later develop delta is path-disjoint and has a clean synthetic merge.
- [x] Exact-head root verification passes: 350/350 Turbo tasks, 0 cached, followed by every repository audit and an 8,182-file clean anti-larp scan.

# Risks

Low and staging-infrastructure-only. The patch accepts balanced single- or double-quoted spellings of the two exact nginx map-variable tokens. Different variables, mismatched quotes, added tokens, added directives, different keys, external references, and all other shape changes still fail closed. File SHA-256, ownership, mode, server-name, listener, SAN, rollback, and public-health gates are unchanged.

# Background

## What does this PR do?

The protected staging retirement at run `31877029334` failed closed with `blocks=0 ... unexpected=2`, proving that the live legacy vhost quotes the websocket map header variables rather than only the already-supported empty-string key. This patch accepts nginx-equivalent balanced quoting for the exact `$http_upgrade` and `$connection_upgrade` tokens, updates the runbook, and adds executable positive and adversarial regressions.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

The Headscale deployment runbook now documents the exact accepted map-header spellings and the intentionally narrow fail-closed contract.

# Testing

## Where should a reviewer start?

Run `bun test packages/scripts/__tests__/headscale-arm-workflow.test.ts` and review the `retires only the isolated standard Headscale websocket upgrade map` case.

## Detailed testing steps

- Exact-head `bun test packages/scripts/__tests__/headscale-arm-workflow.test.ts` — 30/30 tests, 361 assertions.
- `node --check packages/cloud/scripts/admin/arm-headscale-control-plane.mjs` — pass.
- `bunx biome check packages/cloud/scripts/admin/arm-headscale-control-plane.mjs packages/scripts/__tests__/headscale-arm-workflow.test.ts` — pass.
- Exact-head `TURBO_FORCE=1 bun run verify` — 350/350 tasks, 0 cached; all follow-on audits and anti-larp pass.
- `git diff --check origin/develop...HEAD` — pass at the exact tested rebase.

# Evidence Gate

<!-- evidence-head:c8cc8f4d12855d616d1b90b31919fdcdabb3c357 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - protected nginx control-plane parsing has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - protected nginx control-plane parsing has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or rendered user flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live retirement is run from an unmerged PR; the executable generated-shell regression is the safe pre-merge end-to-end proof, and protected post-merge execution provides the real host transaction log.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the patch intentionally does not mutate the host before merge; the reviewed target remains `/etc/nginx/conf.d/headscale-staging.conf` at SHA-256 `33a19405371271ce2323cbfcb81814dc39d5ddea651f0af0752b69ca339d9a0c`.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Backend + frontend logs

The deterministic harness executes the generated remote shell against quoted and unquoted exact map headers. It proves balanced single/double quotes succeed, mismatched quotes/wrong variables/extra tokens fail, directive values remain private, and the exact digest/owner/listener/rollback contracts remain enforced.

## Known gaps / failures

No known code or test gap. The live staging retirement is deliberately post-merge; it must prove exclusive intended nginx ownership, identical dual-SAN public leaves, and both canonical and legacy `/health` endpoints before the release train proceeds.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@22858969b41831362e990d23203e60732706a10d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@22858969b41831362e990d23203e60732706a10d:packages/skills/skills/contribute-to-eliza"} -->
