### PR TITLE
fix(cloud): accept equivalent Headscale map layouts

### DIFF
--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -389,6 +389,8 @@ validate_retirable_legacy_vhost() {
         printf "line %d: hash token in active syntax\\n", NR
         next
       }
+      gsub(/[$][{]http_upgrade[}]/, "$http_upgrade", line)
+      gsub(/[$][{]connection_upgrade[}]/, "$connection_upgrade", line)
       semicolons = gsub(/;/, ";", line)
       opens = gsub(/[{]/, "{", line)
       closes = gsub(/[}]/, "}", line)
@@ -423,12 +425,30 @@ validate_retirable_legacy_vhost() {
   ')
   legacy_upgrade_map_shape=$(printf '%s\\n' "$legacy_vhost_source" | awk '
     function is_exact_map_token(token, expected, quote) {
-      if (token == expected) return 1
-      if (length(token) != length(expected) + 2) return 0
       quote = substr(token, 1, 1)
-      if (quote != sprintf("%c", 39) && quote != sprintf("%c", 34)) return 0
-      if (substr(token, length(token), 1) != quote) return 0
-      return substr(token, 2, length(token) - 2) == expected
+      if (quote == sprintf("%c", 39) || quote == sprintf("%c", 34)) {
+        if (length(token) < 2 || substr(token, length(token), 1) != quote) return 0
+        token = substr(token, 2, length(token) - 2)
+      }
+      return token == expected \
+        || token == "$" "{" substr(expected, 2) "}"
+    }
+    function inspect_map_header(normalized, body, fields, count, has_open) {
+      body = normalized
+      sub(/^map[[:space:]]+/, "", body)
+      has_open = body ~ /[{]$/
+      if (has_open) sub(/[[:space:]]*[{]$/, "", body)
+      count = split(body, fields, /[[:space:]]+/)
+      if (count != 2 \
+          || !is_exact_map_token(fields[1], "$http_upgrade") \
+          || !is_exact_map_token(fields[2], "$connection_upgrade")) return 0
+      if (has_open) {
+        blocks += 1
+        in_upgrade_map = 1
+      } else {
+        awaiting_upgrade_map_open = 1
+      }
+      return 1
     }
     {
       line = $0
@@ -437,6 +457,16 @@ validate_retirable_legacy_vhost() {
       if (line == "" || line ~ /^#/) next
       normalized = line
       gsub(/[[:space:]]+/, " ", normalized)
+      if (awaiting_upgrade_map_open) {
+        if (normalized == "{") {
+          blocks += 1
+          in_upgrade_map = 1
+        } else {
+          unexpected += 1
+        }
+        awaiting_upgrade_map_open = 0
+        next
+      }
       if (in_upgrade_map) {
         if (normalized == "default upgrade;") {
           defaults += 1
@@ -452,15 +482,7 @@ validate_retirable_legacy_vhost() {
         next
       }
       if (normalized ~ /^map[[:space:]]/) {
-        map_field_count = split(normalized, map_fields, /[[:space:]]+/)
-        if (map_field_count == 4 \
-            && map_fields[1] == "map" \
-            && is_exact_map_token(map_fields[2], "$http_upgrade") \
-            && is_exact_map_token(map_fields[3], "$connection_upgrade") \
-            && map_fields[4] == "{") {
-          blocks += 1
-          in_upgrade_map = 1
-        } else {
+        if (!inspect_map_header(normalized)) {
           unexpected += 1
         }
       } else if (normalized ~ /^default[[:space:]]/) {
@@ -469,6 +491,7 @@ validate_retirable_legacy_vhost() {
     }
     END {
       if (in_upgrade_map) unexpected += 1
+      if (awaiting_upgrade_map_open) unexpected += 1
       printf "%d %d %d %d %d\\n", blocks + 0, defaults + 0, closes + 0, endings + 0, unexpected + 0
     }
   ')

--- a/packages/cloud/services/headscale/DEPLOY.md
+++ b/packages/cloud/services/headscale/DEPLOY.md
@@ -98,10 +98,12 @@ gh workflow run arm-headscale-control-plane.yml --repo elizaOS/eliza \
 The inspection requires a regular, root-owned, non-group/world-writable file,
 exactly two server blocks that name only `headscale-staging.elizacloud.ai`, and
 exactly two loaded nginx owners from that path. A file-local websocket upgrade
-map may wrap each exact map variable in balanced single or double quotes and
-may spell its empty-string key with nginx's equivalent single or double quotes.
-Mismatched quotes, different variables, additional tokens or entries, and any
-external reference remain fail-closed. The inspection reports file metadata,
+map may use nginx's exact `$variable` or `${variable}` spelling, may wrap either
+in balanced single or double quotes, and may place its opening brace on the
+header or the immediately following line. Its empty-string key may use nginx's
+equivalent single or double quotes. Mismatched quotes, different variables,
+additional tokens or entries, an intervening header line, and any external
+reference remain fail-closed. The inspection reports file metadata,
 SHA-256, directive-name counts, and the validated server-block/name/map shape
 for review without printing directive literal values. If the map is rejected,
 only structural counts are printed so operators can distinguish formatting

--- a/packages/scripts/__tests__/headscale-arm-workflow.test.ts
+++ b/packages/scripts/__tests__/headscale-arm-workflow.test.ts
@@ -976,9 +976,15 @@ server {
     });
     expect(doubleQuotedValid.status).toBe(0);
 
+    const bracedHttpUpgrade = ["$", "{http_upgrade}"].join("");
+    const bracedConnectionUpgrade = ["$", "{connection_upgrade}"].join("");
     for (const quotedHeader of [
       'map "$http_upgrade" "$connection_upgrade" {',
       "map '$http_upgrade' '$connection_upgrade' {",
+      `map ${bracedHttpUpgrade} ${bracedConnectionUpgrade} {`,
+      `map "${bracedHttpUpgrade}" "${bracedConnectionUpgrade}" {`,
+      "map $http_upgrade $connection_upgrade\n{",
+      `map '${bracedHttpUpgrade}' $connection_upgrade\n{`,
     ]) {
       const quotedHeaderValid = runLegacyVhostValidation({
         source: expectedLegacySource.replace(
@@ -991,7 +997,11 @@ server {
         ),
         enforceDirectiveAllowlist: true,
       });
-      expect(quotedHeaderValid.status).toBe(0);
+      expect([
+        quotedHeader,
+        quotedHeaderValid.status,
+        quotedHeaderValid.stdout,
+      ]).toEqual([quotedHeader, 0, ""]);
     }
 
     for (const source of [
@@ -1020,6 +1030,18 @@ server {
         "map $http_upgrade $connection_upgrade {",
         'map "$http_upgrade" "$connection_upgrade" extra {',
       ),
+      expectedLegacySource.replace(
+        "map $http_upgrade $connection_upgrade {",
+        `map ${["$", "{http_connection}"].join("")} ${bracedConnectionUpgrade} {`,
+      ),
+      expectedLegacySource.replace(
+        "map $http_upgrade $connection_upgrade {",
+        "map $http_upgrade $connection_upgrade\ninclude private.conf;\n{",
+      ),
+      expectedLegacySource.replace(
+        "map $http_upgrade $connection_upgrade {",
+        "map $http_upgrade $connection_upgrade",
+      ),
     ]) {
       const invalid = runLegacyVhostValidation({
         source,
@@ -1027,10 +1049,14 @@ server {
         enforceDirectiveAllowlist: true,
       });
       expect(invalid.status).not.toBe(0);
-      expect(invalid.stdout).toContain("unexpected upgrade map shape");
       expect(invalid.stdout).toMatch(
-        /blocks=\d+ defaults=\d+ empty-close=\d+ endings=\d+ unexpected=\d+/u,
+        /unexpected upgrade map shape|unsupported dense directive syntax/u,
       );
+      if (invalid.stdout.includes("unexpected upgrade map shape")) {
+        expect(invalid.stdout).toMatch(
+          /blocks=\d+ defaults=\d+ empty-close=\d+ endings=\d+ unexpected=\d+/u,
+        );
+      }
       expect(invalid.stdout).not.toContain("$connection_upgrade");
     }
 


### PR DESCRIPTION
# Relates to

Relates to #19800.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop`. Exact head `f457784cc71b1c1e87832b1f87e40223db85fdc8` was tested atop `84f4b1308cac9f93cde95ea79e0ff6f63ecbe09a`; current develop `7139cf165a178d1970a0f663ab03d6b8ff386f07` changes no PR path and `git merge-tree --write-tree HEAD origin/develop` is clean.
- [x] Full install prerequisites are present in the isolated worktree; exact-head cloud and root verification both pass.
- [x] The executable generated-shell regression covers exact equivalent layouts and adversarial near-misses without exposing nginx directive values.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@84f4b1308cac9f93cde95ea79e0ff6f63ecbe09a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] The tested head is conflict-free; the later develop delta is path-disjoint and has a clean synthetic merge.
- [x] Exact-head root verification passes: 350/350 Turbo tasks, 0 cached, followed by every repository audit and an 8,188-file clean anti-larp scan.

# Risks

Low and staging-infrastructure-only. The parser accepts only the two exact upgrade-map variables, in nginx's `$variable` or `${variable}` spelling, optionally balanced-quoted, with the opening brace on the header or immediately following line. Different variables, mismatched quotes, extra tokens, intervening directives, extra map entries, dense syntax, external references, or unrelated directives remain fail-closed. Digest, file ownership/mode, server/listener, rollback, SAN, and health gates are unchanged.

# Background

## What does this PR do?

Protected run `31878472597` at the prior quote-only fix still failed before mutation with `blocks=0 defaults=0 empty-close=0 endings=0 unexpected=2`. That proves the live valid nginx map header uses another equivalent layout. This patch handles the remaining exact grammar variants—braced variables and a following-line opening brace—without converting the validator into a permissive nginx parser. It updates the runbook and executable regression.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

The Headscale deployment runbook now documents the exact accepted variable and brace-layout contract.

# Testing

## Where should a reviewer start?

Run `bun test packages/scripts/__tests__/headscale-arm-workflow.test.ts` and inspect the `retires only the isolated standard Headscale websocket upgrade map` case.

## Detailed testing steps

- Exact-head `bun test packages/scripts/__tests__/headscale-arm-workflow.test.ts` — 30/30, 383 assertions.
- Exact-head `bun run verify:cloud` — 78/78, 0 cached.
- Exact-head `TURBO_FORCE=1 bun run verify` — 350/350, 0 cached; all follow-on audits pass.
- Node syntax, changed-file Biome, and `git diff --check` — pass.

# Evidence Gate

<!-- evidence-head:f457784cc71b1c1e87832b1f87e40223db85fdc8 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - protected nginx control-plane parsing has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - protected nginx control-plane parsing has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or rendered user flow changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live retirement is run from an unmerged PR; generated-shell execution is the safe pre-merge proof and the protected post-merge run supplies the host transaction log.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model or agent behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the reviewed target remains `/etc/nginx/conf.d/headscale-staging.conf` at SHA-256 `33a19405371271ce2323cbfcb81814dc39d5ddea651f0af0752b69ca339d9a0c`; failed runs performed no mutation.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

# Evidence Details

## Backend + frontend logs

The deterministic harness executes the generated remote shell against raw/braced, single/double-quoted, same-line/following-line exact headers. It proves altered variables, mismatched quotes, extra tokens, intervening directives, and missing braces fail closed while values remain private.

## Known gaps / failures

No known code or test gap. The live staging transaction is deliberately post-merge and must prove the exact file retirement, exclusive intended nginx ownership, identical dual-SAN public leaves, and both canonical and legacy `/health` endpoints.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@84f4b1308cac9f93cde95ea79e0ff6f63ecbe09a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@84f4b1308cac9f93cde95ea79e0ff6f63ecbe09a:packages/skills/skills/contribute-to-eliza"} -->
