### PR TITLE
fix(shared): keep negated recurrence clauses bounded

### DIFF
--- a/packages/agent/src/actions/trigger.test.ts
+++ b/packages/agent/src/actions/trigger.test.ts
@@ -1884,6 +1884,21 @@ describe("sprayed one-shot cap on an explicit recurrence", () => {
     expect(createdTasks[0]?.metadata.trigger?.maxRuns).toBe(1);
   });
 
+  it("keeps maxRuns=1 when cadence words remain inside a negated clause", async () => {
+    const { runtime, createdTasks } = makeRuntime({ enableAutonomy: false });
+    const result = await create(
+      runtime,
+      {
+        instructions: "call the bank",
+        cronExpression: "0 9 * * 1",
+        maxRuns: 1,
+      },
+      "do not repeat this every week",
+    );
+    expect(result?.success).toBe(true);
+    expect(createdTasks[0]?.metadata.trigger?.maxRuns).toBe(1);
+  });
+
   it("keeps maxRuns=1 when the text has only a time-of-day window phrase", async () => {
     // "in the morning" is a WINDOW, not a recurrence — a one-shot reminder
     // must not become an unbounded daily cron because of it.

--- a/packages/shared/src/i18n/recurrence-markers.test.ts
+++ b/packages/shared/src/i18n/recurrence-markers.test.ts
@@ -34,6 +34,12 @@ describe("textStatesExplicitRecurrence", () => {
     expect(
       textStatesExplicitRecurrence("not recurring, make it weekly instead"),
     ).toBe(true);
+    expect(
+      textStatesExplicitRecurrence(
+        "do not repeat daily; actually make it weekly",
+      ),
+    ).toBe(true);
+    expect(textStatesExplicitRecurrence("毎日ではない、毎週にして")).toBe(true);
     expect(textStatesExplicitRecurrence("weekly, actually just once")).toBe(
       false,
     );
@@ -53,6 +59,16 @@ describe("textStatesExplicitRecurrence", () => {
         "user: no, just once\nassistant: should this be weekly?",
       ),
     ).toBe(false);
+    for (const text of [
+      "do not repeat every week",
+      "don't repeat this every week",
+      "never repeat every day",
+      "not recurring every month",
+      "no recurrence every year",
+      "繰り返さない毎週",
+    ]) {
+      expect(textStatesExplicitRecurrence(text)).toBe(false);
+    }
   });
 
   it("ignores role-labelled non-user text", () => {

--- a/packages/shared/src/i18n/recurrence-markers.ts
+++ b/packages/shared/src/i18n/recurrence-markers.ts
@@ -85,11 +85,12 @@ const NAME_LIKE_RECURRENCE_PATTERNS: readonly RegExp[] = [
 // week" remains recurring because the one-shot expression is followed by a
 // cadence unit.
 const ONE_SHOT_DIRECTIVE_PATTERNS: readonly RegExp[] = [
-  /\b(?:not|no|never)\s+(?:a\s+)?(?:recurr(?:ing|ence)|repeat(?:ed|ing)?|every|each)\b/i,
-  /\b(?:do\s+not|don't)\s+repeat\b/i,
+  /\b(?:not|no|never)\s+(?:a\s+)?(?:recurr(?:ing|ence)|repeat(?:ed|ing)?|every|each)\b(?:(?![,.;!?]|\b(?:but|rather|instead|actually|make\s+it)\b)[\s\S])*/i,
+  /\b(?:do\s+not|don't)\s+repeat\b(?:(?![,.;!?]|\b(?:but|rather|instead|actually|make\s+it)\b)[\s\S])*/i,
   /\b(?:just|only)\s+(?:once|one\s+time)\b(?!\s+(?:a|per|each|every)\s+(?:day|week|month|year))/i,
   /\b(?:once|one\s+time)\s+only\b/i,
-  /(?:一度だけ|1回だけ|繰り返さない|毎日ではない)/,
+  /(?:一度だけ|1回だけ)/,
+  /(?:繰り返さない|毎日ではない)(?:(?![、。！？]|(?:代わり|むしろ|実際には))[\s\S])*/,
 ];
 
 type IntentMarker = {

--- a/plugins/plugin-calendar/src/actions/calendar-handler.recurrence-guard.test.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.recurrence-guard.test.ts
@@ -140,6 +140,18 @@ describe("buildCreateEventRequest recurrence authority", () => {
     expect(built.request.startAt).toBe("2026-08-17T10:00:00.000Z");
   });
 
+  it("drops an RRULE nested inside a negated recurrence clause", () => {
+    const built = buildCreateEventRequest({
+      details: { title: "standup", recurrence: plannerRecurrence },
+      extractedDetails: { recurrence: plannerRecurrence },
+      explicitTitle: "standup",
+      inferredTitle: "weekly standup",
+      recurrenceGuardTexts: ["do not repeat this every week"],
+    });
+
+    expect(built.request.recurrence).toBeUndefined();
+  });
+
   it("keeps outer-planner recurrence when the current user states cadence", () => {
     const built = buildCreateEventRequest({
       details: { title: "standup", recurrence: plannerRecurrence },


### PR DESCRIPTION
# Relates to

Corrective follow-up to merged #19978 / #19977. Exact reviewed source head: `eb14286357deaed01b279a30908cfbce2c5a8c07`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and was rebased onto exact `origin/develop@09105d0651096c350a81cf2f72f77f16b4f5b36c` with zero conflicts.
- [x] Protected focused tests, mutation checks, Biome, and diff-check were run after sync. The source-mode package typecheck harness blocker is recorded below.
- [x] The regression is independently reproducible from the evidence and tests below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop@09105d0651096c350a81cf2f72f77f16b4f5b36c`; zero conflicts.
- [ ] Full `bun run verify` was not run for this four-file focused follow-up. Protected production-path suites and Biome pass; the exact source-mode typecheck blocker is documented below.

# Risks

Low and safety-biased. A negated recurrence clause is extended only to its clause/correction boundary. Explicit later corrections after punctuation or words such as `but`, `instead`, `actually`, and `make it` continue to win. Japanese negative clauses use equivalent punctuation/correction boundaries.

# Background

## What does this PR do?

#19978 correctly introduced ordered positive/one-shot intent, but its negative marker ended immediately after `do not repeat` / `not recurring`. A positive cadence token later in the same negated clause was therefore treated as a later correction:

```text
do not repeat every week       -> recurring (incorrect)
don't repeat this every week   -> recurring (incorrect)
never repeat every day         -> recurring (incorrect)
繰り返さない毎週               -> recurring (incorrect)
```

That production effect removed Trigger's `maxRuns: 1` cap and admitted planner RRULEs in Calendar. This patch scopes the negative marker through the current clause while preserving real later corrections such as:

```text
not every day, every week instead
do not repeat daily; actually make it weekly
毎日ではない、毎週にして
```

## What kind of change is this?

Bug fix / agent-action safety hardening.

# Documentation changes needed?

No public documentation change is needed; the accepted/rejected grammar is covered by first-party tests.

# Testing

## Where should a reviewer start?

- `packages/shared/src/i18n/recurrence-markers.ts`
- `packages/shared/src/i18n/recurrence-markers.test.ts`
- `plugins/plugin-calendar/src/actions/calendar-handler.recurrence-guard.test.ts`
- `packages/agent/src/actions/trigger.test.ts`

## Detailed testing steps

Protected no-network, read-only-root Docker runs:

```text
Shared recurrence markers       10/10 passed
Calendar recurrence guard       13/13 passed
Agent Trigger                    77/77 passed
Total                           100/100 passed
Focused Biome                    4 files clean
```

Mutation proof: restoring #19978's short negation spans caused all three intended production layers to fail:

- shared recurrence helper: negated-clause case returned `true`;
- Calendar: planner RRULE remained present;
- Trigger: `maxRuns: 1` became `undefined`.

# Evidence Gate

<!-- evidence-head:6a862b0cc364f7d4f97695af0cca24255c93ebc3 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend deterministic contract only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend deterministic contract only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual or interactive frontend path changed.
<!-- evidence-row:backend-logs -->
- [x] Protected exact-head test summaries and mutation results are included above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend/network source changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model prompt/provider/call changed; this is the deterministic user-text authorization boundary.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - first-party tests assert the selected recurrence, Calendar RRULE, and Trigger cap directly; no production row should be created during review.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no prompt/provider change. Deterministic adversarial owner text is the relevant reproducible evidence.

## Backend + frontend logs

Backend: protected Vitest and mutation summaries above. Frontend: N/A.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice/audio change.

## Known gaps / failures

A protected source-mode `tsc -p packages/shared/tsconfig.build.json --noEmit` attempt could not resolve existing workspace aliases such as `@elizaos/core` and `@elizaos/core/client-public` in the bounded mount, producing broad unrelated source-graph errors. This is a harness blocker, not a touched-file failure. The exact production helper and both consumers pass 100 focused tests, mutation proof, Biome, and `git diff --check`.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Hermes Agent
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [hermes-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Hermes Agent","skill_revision":"N/A - no repository contribution skill used","attribution_status":"self-reported"} -->
