### PR TITLE
fix(ci): restore zero-key scheduling contracts

### DIFF
--- a/packages/scripts/__tests__/vitest-source-aliases.test.ts
+++ b/packages/scripts/__tests__/vitest-source-aliases.test.ts
@@ -34,6 +34,10 @@ describe("workspace source aliases", () => {
     const aliases = buildWorkspaceSourceAliases(workspaceRepoRoot);
     const cases = [
       {
+        specifier: "@elizaos/core/edge",
+        target: "packages/core/src/index.edge.ts",
+      },
+      {
         specifier: "@elizaos/core/security/mcp-server-config",
         target: "packages/core/src/security/mcp-server-config.ts",
       },

--- a/packages/scripts/vitest/source-aliases.ts
+++ b/packages/scripts/vitest/source-aliases.ts
@@ -4,8 +4,9 @@
  * Booting a real PGLite-backed AgentRuntime requires every workspace
  * `@elizaos/*` package to resolve to its TypeScript source (independent of
  * build order), plus the core and SQL subpath specials the runtime touches:
- * `@elizaos/core/testing`, `@elizaos/core/node`, `@elizaos/core/connectors`,
- * and `@elizaos/plugin-sql` (the node entry). Package exports that declare an
+ * `@elizaos/core/testing`, `@elizaos/core/node`, `@elizaos/core/edge`,
+ * `@elizaos/core/connectors`, and `@elizaos/plugin-sql` (the node entry).
+ * Package exports that declare an
  * exact `eliza-source` condition contribute their own source aliases, including
  * provider-owned endpoint diagnostics that otherwise require prebuilt dist.
  * Shared and per-plugin real-runtime configs need this, and so does
@@ -158,8 +159,8 @@ function collectWorkspacePackageDirs(root: string, maxDepth = 4): string[] {
 
 /**
  * Build the full alias list for a real-runtime consumer. Explicit entries
- * (`@elizaos/core/testing`, `@elizaos/core/node`, `@elizaos/core/connectors`,
- * `@elizaos/plugin-sql`) are
+ * (`@elizaos/core/testing`, `@elizaos/core/node`, `@elizaos/core/edge`,
+ * `@elizaos/core/connectors`, `@elizaos/plugin-sql`) are
  * placed first so they win over the generic per-package rules (Vite is
  * first-match).
  */
@@ -213,6 +214,10 @@ export function buildWorkspaceSourceAliases(
     {
       find: /^@elizaos\/core\/node$/,
       replacement: path.join(repoRoot, "packages/core/src/index.node.ts"),
+    },
+    {
+      find: /^@elizaos\/core\/edge$/,
+      replacement: path.join(repoRoot, "packages/core/src/index.edge.ts"),
     },
     {
       find: /^@elizaos\/core\/roles$/,

--- a/plugins/plugin-discord/__tests__/connector-loop.real.test.ts
+++ b/plugins/plugin-discord/__tests__/connector-loop.real.test.ts
@@ -275,6 +275,9 @@ async function driveDiscordTurn(options: {
 			ownerDiscordUserIds,
 			accountPool: { get: () => null, getDefault: () => null },
 			turnDrainRegistry: createTurnDrainRegistry(),
+			// Object.create skips the service's class-field initializer. Keep this
+			// real-prototype harness aligned with constructor-created instances.
+			dmRegistries: new Map(),
 			// The shutdown cordon field is a constructor-initialized class field;
 			// `Object.create` skips the constructor, and `admitInboundMessage`
 			// treats anything other than exactly `null` as a closed ingress, so

--- a/plugins/plugin-personal-assistant/src/lifeops/repository.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository.ts
@@ -7779,7 +7779,7 @@ export class LifeOpsRepository {
         ${sqlQuote(now)},
         ${sqlQuote(now)}
       )
-      ON CONFLICT (id) DO UPDATE SET
+      ON CONFLICT (agent_id, id) DO UPDATE SET
         kind = EXCLUDED.kind,
         prompt_instructions = EXCLUDED.prompt_instructions,
         context_request_json = EXCLUDED.context_request_json,

--- a/plugins/plugin-personal-assistant/test/repository-domain-crud.test.ts
+++ b/plugins/plugin-personal-assistant/test/repository-domain-crud.test.ts
@@ -658,7 +658,26 @@ describe("LifeOpsRepository domain CRUD", () => {
     );
     expect(
       await repository.getScheduledTask(runtime.agentId, "task-crud-1"),
-    ).toMatchObject({ taskId: "task-crud-1" });
+    ).toMatchObject({
+      taskId: "task-crud-1",
+      promptInstructions: "Remind the owner",
+    });
+    const secondAgentId = crypto.randomUUID();
+    await repository.upsertScheduledTask(
+      secondAgentId,
+      {
+        ...scheduledTask,
+        agentId: secondAgentId,
+        promptInstructions: "Remind the second owner",
+      } as never,
+      { nextFireAtIso: LATER },
+    );
+    expect(
+      await repository.getScheduledTask(secondAgentId, "task-crud-1"),
+    ).toMatchObject({ promptInstructions: "Remind the second owner" });
+    expect(
+      await repository.getScheduledTask(runtime.agentId, "task-crud-1"),
+    ).toMatchObject({ promptInstructions: "Remind the owner" });
     expect(
       await repository.listScheduledTasks(runtime.agentId, {
         kind: "reminder",

--- a/plugins/plugin-personal-assistant/vitest.config.ts
+++ b/plugins/plugin-personal-assistant/vitest.config.ts
@@ -269,6 +269,16 @@ export default defineConfig({
         ),
       },
       {
+        find: /^@elizaos\/core\/edge$/,
+        replacement: path.join(
+          elizaRoot,
+          "packages",
+          "core",
+          "src",
+          "index.edge.ts",
+        ),
+      },
+      {
         find: /^@elizaos\/vault$/,
         replacement: path.join(
           elizaRoot,


### PR DESCRIPTION
# Relates to

Closes #19976. Follow-up repair from the post-merge `develop` Tests workflow for #19931.

- [x] Targets `develop` and was rebased onto `origin/develop` at `7139cf165a178d1970a0f663ab03d6b8ff386f07` with zero conflicts.
- [x] `bun install`, focused real-runtime/PGLite tests, `bun run test:scripts`, and `bun run verify` pass on the exact head.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill was invoked`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. The production change only aligns the scheduled-task upsert conflict target with the existing tenant-owned `(agent_id, id)` primary key. The remaining changes repair source-mode and prototype-harness test setup.

# Background

## What does this PR do?

- Resolves `@elizaos/core/edge` from source in shared real-runtime aliases and the personal-assistant package config, independent of prebuilt `dist` output.
- Initializes Discord's constructor-owned DM registry in the real-prototype connector harness.
- Changes scheduled-task upserts from `ON CONFLICT (id)` to `ON CONFLICT (agent_id, id)` and proves identical task IDs remain isolated across agent tenants.

## What kind of change is this?

Bug fix and deterministic test-infrastructure repair.

# Documentation changes needed?

No. Public behavior and configuration are unchanged.

# Testing

## Where should a reviewer start?

Start with the composite-key change and cross-tenant assertion, then inspect the exact-head real-runtime logs.

## Detailed testing steps

1. `bun test packages/scripts/__tests__/vitest-source-aliases.test.ts`
2. `bun run --cwd packages/scenario-runner test -- src/runtime-factory.test.ts`
3. `bun run --cwd plugins/plugin-discord test:real-runtime`
4. `bun run --cwd plugins/plugin-personal-assistant test -- test/repository-domain-crud.test.ts`
5. `bun run test:scripts`
6. `bun run verify`

# Evidence Gate

<!-- evidence-head:2d7a1a5ce8753b208813e1b3fac30c626e6656ea -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI files changed
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI files changed
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow changed
<!-- evidence-row:backend-logs -->
- [x] [script inventory](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19976-script-inventory-2d7a1a5.json), [JUnit](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19976-script-junit-2d7a1a5.xml), [scripts log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19976-script-tests-2d7a1a5.log), and [root verify log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19976-root-verify-2d7a1a5.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request, response, or state path changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, planner, provider, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] [scenario runtime](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19976-runtime-factory-2d7a1a5.log), [Discord real-runtime](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19976-discord-real-2d7a1a5.log), and [scheduled-task repository CRUD](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19976-repository-crud-2d7a1a5.log)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed

# Evidence Details

## Known gaps / failures

The originating merge run also reported Cloud Live E2E timeouts against the remote API. Those network/service timeouts are independent of this deterministic source-resolution, harness, and scheduling repair.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex desktop
Contribution skill revision: N/A
Attribution status: self-reported
— [codex-workflow]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex desktop","skill_revision":"N/A"} -->
