### PR TITLE
fix(plugin-personal-assistant): match the scheduled-task upsert to the composite primary key

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/repository.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository.ts
@@ -7779,7 +7779,7 @@ export class LifeOpsRepository {
         ${sqlQuote(now)},
         ${sqlQuote(now)}
       )
-      ON CONFLICT (id) DO UPDATE SET
+      ON CONFLICT (agent_id, id) DO UPDATE SET
         kind = EXCLUDED.kind,
         prompt_instructions = EXCLUDED.prompt_instructions,
         context_request_json = EXCLUDED.context_request_json,

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
@@ -138,7 +138,12 @@ export interface ProcessScheduledTaskInboundMessageResult {
 }
 
 function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  if (!(error instanceof Error)) return String(error);
+  // Storage failures wrap the driver error in `cause`; without it the logged
+  // message stops at the truncated SQL preamble and hides the real reason.
+  const cause =
+    error.cause instanceof Error ? ` | cause: ${error.cause.message}` : "";
+  return `${error.message.split("\n")[0]}${cause}`;
 }
 
 function shouldRecordPendingPrompt(task: ScheduledTask): boolean {

--- a/plugins/plugin-personal-assistant/src/lifeops/schema.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/schema.ts
@@ -1758,7 +1758,11 @@ export const lifeBlockRules = appLifeopsPgSchema.table("life_block_rules", {
 export const lifeScheduledTasks = appLifeopsPgSchema.table(
   "life_scheduled_tasks",
   {
-    id: text("id").primaryKey(),
+    // The tenant-owned composite primary key (agent_id, id) is declared in the
+    // table config below and must match plugin-scheduling's migration
+    // (ensureTenantOwnedTaskPrimaryKey); a single-column PK here lets tests
+    // pass against a shape the migrated live table does not have.
+    id: text("id").notNull(),
     agentId: text("agent_id").notNull(),
     kind: text("kind").notNull(),
     promptInstructions: text("prompt_instructions").notNull(),
@@ -1796,6 +1800,7 @@ export const lifeScheduledTasks = appLifeopsPgSchema.table(
     updatedAt: text("updated_at").notNull(),
   },
   (t) => [
+    primaryKey({ columns: [t.agentId, t.id] }),
     unique().on(t.agentId, t.idempotencyKey),
     index("idx_life_scheduled_tasks_agent_kind").on(t.agentId, t.kind),
     index("idx_life_scheduled_tasks_subject").on(


### PR DESCRIPTION
Found live on the nubilio daily-driver box during the post-resync battery (fleet goal criterion 4): **timed reminders routed through the lifeops path silently never fire** on any deployment whose database has been migrated by plugin-scheduling's `ensureTenantOwnedTaskPrimaryKey`.

## Defect
- plugin-scheduling's migration makes `app_scheduling.life_scheduled_tasks` **PRIMARY KEY (agent_id, id)** (both the fresh-create DDL and the migrate-existing path).
- The lifeops repository's `upsertScheduledTask` raw SQL still targeted **`ON CONFLICT (id)`**. Postgres requires the conflict target to match a unique constraint, so every upsert fails with *"there is no unique or exclusion constraint matching the ON CONFLICT specification"* (captured live via a cause-chain log patch — the scheduler's warn truncated the driver cause).
- Consequences on a migrated deployment: OWNER_REMINDERS one-off reminders never materialize into the runner store (no fire, no error surfaced to the user), and the completion-timeout writer warns on every scheduler tick (`[lifeops-scheduled-task] completion timeout failed …`).
- **Why every suite stayed green:** the package's drizzle schema still declared the pre-migration single-column PK, so tests built a table shape the migrated live table does not have — `ON CONFLICT (id)` worked in tests only. plugin-scheduling's own store already uses `ON CONFLICT (agent_id, id)`; the lifeops repository was the only laggard.

## Fix
1. `repository.ts`: conflict target → `ON CONFLICT (agent_id, id)` (the INSERT already writes `agent_id`; every other statement on this table already filters by `agent_id`).
2. `schema.ts`: align the drizzle declaration to the composite key (`primaryKey({ columns: [agentId, id] })`) so the existing scheduler/repository suites exercise the real shape from now on.

## Evidence (live box, develop tip + this patch)
- Before: constraint-cause captured on every tick; `/api/lifeops/scheduled-tasks` shows pack tasks only — user reminders never materialized (kettle/stretch reminders created, listed by OWNER_REMINDERS, absent from the runner, never fired).
- After: cause-line count frozen (no new failures since the fixed build booted); live fire verification comment to follow on this PR.

Fleet HQ #18309 (watchtower lane). Related follow-up under discussion: stage-1 routes "remind me in N minutes" stochastically to TRIGGER_CREATE (fires) vs OWNER_REMINDERS_CREATE (lifeops) — this PR fixes the broken half rather than re-routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:ebc0c20dd3eebc284e0cd8152bcebcd31544484a -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI surface; scheduler/storage defect proven by live logs and store reads

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - non-visual storage fix

<!-- evidence-row:backend-logs -->
- [ ] N/A - cause line quoted verbatim in PR body: 'there is no unique or exclusion constraint matching the ON CONFLICT specification' captured on the live box via the cause-chain warn in this PR

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend in the changed path

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-behavior change; the defect is a raw SQL conflict target; live fire verification comment follows on the PR

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - domain proof is the live scheduler store read (/api/lifeops/scheduled-tasks pack-only before fix) plus frozen error count after fix; fire receipt to follow
