### PR TITLE
fix(cloud): profile rejected Headscale map headers

### DIFF
--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -511,6 +511,64 @@ validate_retirable_legacy_vhost() {
         || [ "$legacy_upgrade_map_endings" -ne 1 ] \\
         || [ "$legacy_upgrade_map_unexpected" -ne 0 ]; then
       echo "legacy Headscale vhost has an unexpected upgrade map shape: blocks=$legacy_upgrade_map_blocks defaults=$legacy_upgrade_map_defaults empty-close=$legacy_upgrade_map_closes endings=$legacy_upgrade_map_endings unexpected=$legacy_upgrade_map_unexpected"
+      legacy_upgrade_map_header_profile=$(printf '%s\\n' "$legacy_vhost_source" | awk '
+        function token_form(token, expected, quote, prefix) {
+          quote = substr(token, 1, 1)
+          prefix = ""
+          if (quote == sprintf("%c", 39) || quote == sprintf("%c", 34)) {
+            if (length(token) < 2 || substr(token, length(token), 1) != quote) {
+              return "mismatched-quote"
+            }
+            token = substr(token, 2, length(token) - 2)
+            prefix = "quoted-"
+          }
+          if (token == expected) return prefix "exact"
+          if (token == "$" "{" substr(expected, 2) "}") return prefix "braced-exact"
+          if (token ~ /^[$][[:alpha:]_][[:alnum:]_]*$/ \
+              || token ~ /^[$][{][[:alpha:]_][[:alnum:]_]*[}]$/) {
+            return prefix "other-variable"
+          }
+          return prefix "other"
+        }
+        function inspect_header(normalized, body, fields, count, has_open) {
+          candidates += 1
+          body = normalized
+          sub(/^map[[:space:]]+/, "", body)
+          has_open = body ~ /[{]$/
+          if (has_open) sub(/[[:space:]]*[{]$/, "", body)
+          count = split(body, fields, /[[:space:]]+/)
+          if (candidates == 1) {
+            field_count = count
+            source_form = count >= 1 ? token_form(fields[1], "$http_upgrade") : "missing"
+            target_form = count >= 2 ? token_form(fields[2], "$connection_upgrade") : "missing"
+            extra_fields = count > 2 ? "yes" : "no"
+            brace_form = has_open ? "same-line" : "absent"
+            awaiting_brace_profile = !has_open
+          }
+        }
+        {
+          line = $0
+          sub(/^[[:space:]]+/, "", line)
+          sub(/[[:space:]]+$/, "", line)
+          if (line == "" || line ~ /^#/) next
+          normalized = line
+          gsub(/[[:space:]]+/, " ", normalized)
+          if (awaiting_brace_profile) {
+            brace_form = normalized == "{" ? "following-line" : "absent-or-intervening"
+            awaiting_brace_profile = 0
+          }
+          if (normalized ~ /^map[[:space:]]/) inspect_header(normalized)
+        }
+        END {
+          if (candidates == 1) {
+            printf "candidates=1 fields=%d source-form=%s target-form=%s extra-fields=%s brace=%s\\n", \
+              field_count, source_form, target_form, extra_fields, brace_form
+          } else {
+            printf "candidates=%d\\n", candidates + 0
+          }
+        }
+      ')
+      echo "legacy Headscale upgrade map header profile: $legacy_upgrade_map_header_profile"
       return 1
     fi
     legacy_has_upgrade_map=true

--- a/packages/cloud/services/headscale/DEPLOY.md
+++ b/packages/cloud/services/headscale/DEPLOY.md
@@ -107,9 +107,11 @@ reference remain fail-closed. The inspection reports file metadata,
 SHA-256, directive-name counts, and the validated server-block/name/map shape
 for review without printing directive literal values. If the map is rejected,
 only structural counts are printed so operators can distinguish formatting
-drift from an additional entry without exposing values. Only after that run is
-reviewed may an operator select the retirement operation and supply that exact
-lowercase digest:
+drift from an additional entry without exposing values. A rejected map also
+reports only the candidate count, field count, exact/other/mismatched token-form
+categories, extra-field presence, and brace placement; it never prints a token
+or directive value. Only after that run is reviewed may an operator select the
+retirement operation and supply that exact lowercase digest:
 
 ```bash
 gh workflow run arm-headscale-control-plane.yml --repo elizaOS/eliza \

--- a/packages/scripts/__tests__/headscale-arm-workflow.test.ts
+++ b/packages/scripts/__tests__/headscale-arm-workflow.test.ts
@@ -1072,6 +1072,38 @@ proxy_set_header Connection $connection_upgrade;
     expect(externallyReferenced.stdout).toContain(
       "upgrade-map output is referenced outside the reviewed file",
     );
+  }, 10_000);
+
+  test("profiles rejected map headers without exposing their tokens", () => {
+    const otherOutputVariable = runLegacyVhostValidation({
+      source: expectedLegacySource.replace(
+        "$connection_upgrade",
+        "$headscale_connection_upgrade",
+      ),
+      loadedConfig: expectedLoadedConfig,
+      enforceDirectiveAllowlist: true,
+    });
+    expect(otherOutputVariable.status).not.toBe(0);
+    expect(otherOutputVariable.stdout).toContain(
+      "upgrade map header profile: candidates=1 fields=2 source-form=exact target-form=other-variable extra-fields=no brace=same-line",
+    );
+    expect(otherOutputVariable.stdout).not.toContain(
+      "$headscale_connection_upgrade",
+    );
+
+    const followingLineProfile = runLegacyVhostValidation({
+      source: expectedLegacySource.replace(
+        "map $http_upgrade $connection_upgrade {",
+        "map $http_connection $connection_upgrade\n{",
+      ),
+      loadedConfig: expectedLoadedConfig,
+      enforceDirectiveAllowlist: true,
+    });
+    expect(followingLineProfile.status).not.toBe(0);
+    expect(followingLineProfile.stdout).toContain(
+      "upgrade map header profile: candidates=1 fields=2 source-form=other-variable target-form=exact extra-fields=no brace=following-line",
+    );
+    expect(followingLineProfile.stdout).not.toContain("$http_connection");
   });
 
   test("accepts only the reviewed regular legacy-only two-listener contract", () => {


### PR DESCRIPTION
# Relates to

Relates to #19800.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and exact head `4be5290233c69ea0a98f48f26e2478df1675045b` is directly based on current develop `09105d0651096c350a81cf2f72f77f16b4f5b36c`.
- [x] The change is diagnostic-only: it does not widen retirement acceptance or mutate the host.
- [x] Executable tests prove rejected values never appear in output.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@09105d0651096c350a81cf2f72f77f16b4f5b36c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact current-develop parent.
- [x] Exact-head `TURBO_FORCE=1 bun run verify` passes 350/350 uncached tasks and all repository audits.

# Risks

Low. The patch runs only after the existing strict map validator rejects a reviewed file. It reports categorical structure—candidate count, field count, exact/braced/quoted/other/mismatched token forms, extra-field presence, and brace placement. It never prints a token or directive value. Retirement behavior and every mutation/rollback gate remain unchanged.

# Background

## What does this PR do?

Two protected staging retirements remained fail-closed with the same aggregate map counts after supporting nginx-equivalent quote, braced-variable, and brace-placement layouts. This diagnostic-only classifier lets the read-only protected inspection identify the remaining semantic category before any further acceptance change.

## What kind of change is this?

Bug fix / operational diagnostic (non-breaking).

# Documentation changes needed?

The Headscale runbook documents the privacy-safe header profile emitted on rejection.

# Testing

- Exact-head Headscale workflow suite: 31/31, 391 assertions.
- Node syntax, changed-file Biome, and diff-check: pass.
- Exact-head root verify: 350/350, 0 cached; all audits and anti-larp pass.

# Evidence Gate

<!-- evidence-head:4be5290233c69ea0a98f48f26e2478df1675045b -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - live read-only inspection is post-merge; generated-shell tests prove the diagnostic contract without host access.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the reviewed file remains unchanged at SHA-256 `33a19405371271ce2323cbfcb81814dc39d5ddea651f0af0752b69ca339d9a0c`.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

# Evidence Details

The generated-shell regression rejects other variable names and following-line variants, asserts the categorical profile, and asserts that the original token strings never appear in stdout.

## Known gaps / failures

The diagnostic intentionally does not retire anything. After merge, run `inspect-legacy-vhost` read-only, review the profile, and implement only the exact observed safe contract.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@09105d0651096c350a81cf2f72f77f16b4f5b36c:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@09105d0651096c350a81cf2f72f77f16b4f5b36c:packages/skills/skills/contribute-to-eliza"} -->
