### PR TITLE
fix(core): strip app-surface control blocks from the action-retrieval window

### DIFF
--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -14,6 +14,7 @@ import { buildActionCatalog } from "../action-catalog";
 import {
 	parentAliasesForCandidateAction,
 	retrieveActions,
+	stripControlBlockMarkers,
 	tokenizeActionSearchText,
 } from "../action-retrieval";
 
@@ -901,5 +902,61 @@ describe("canonical OWNER_* fallbacks for non-PA topologies", () => {
 		// Direct catalog reference wins; the fallback aliases must not fire.
 		expect(response.query.parentActionHints).toEqual(["OWNER_TODOS"]);
 		expect(response.results[0]).toMatchObject({ name: "OWNER_TODOS" });
+	});
+
+	it("strips app-surface control blocks from text", () => {
+		const text = [
+			"2 scheduled items: water the garden, submit the invoice",
+			"[FOLLOWUPS]",
+			"navigate:/apps/reminders=Open reminders",
+			"prompt:Delete water the garden=Delete water garden",
+			"[/FOLLOWUPS]",
+			"[CHECKLIST]",
+			'{"title":"Cleanup","items":[]}',
+			"[/CHECKLIST]",
+			"connect it first. [CONFIG:google_calendars]",
+		].join("\n");
+		const cleaned = stripControlBlockMarkers(text);
+		expect(cleaned).toContain("water the garden, submit the invoice");
+		expect(cleaned).toContain("connect it first.");
+		for (const leak of [
+			"FOLLOWUPS",
+			"navigate",
+			"/apps/",
+			"prompt:",
+			"CHECKLIST",
+			"CONFIG",
+		]) {
+			expect(cleaned).not.toContain(leak);
+		}
+	});
+
+	it("does not let a leaked control block in the window evict the candidate action (tj-f8bdfafb488900)", () => {
+		const catalog = buildActionCatalog([
+			{
+				name: "OWNER_REMINDERS",
+				description:
+					"Create, list, update, and delete the owner's reminders and scheduled nudges.",
+			},
+			{
+				name: "CLOSE_ALL_VIEWS",
+				description:
+					"Close every open app view. Navigate views, open apps, prompt panels.",
+			},
+		]);
+		const response = retrieveActions({
+			catalog,
+			messageText: "now delete the submit the invoice reminder too",
+			candidateActions: ["OWNER_REMINDERS"],
+			recentConversationText: [
+				"2 scheduled items: water the garden, submit the invoice",
+				"[FOLLOWUPS]\nnavigate:/apps/reminders=Open reminders\nprompt:Delete water the garden=Delete water garden\nprompt:Delete submit the invoice=Delete invoice\n[/FOLLOWUPS]",
+			],
+		});
+
+		// Live failure shape: the leaked navigate/apps/open/prompt vocabulary
+		// out-scored the stage-1 candidate and tiering kept only the view
+		// action. With the window stripped, the candidate stays on top.
+		expect(response.results[0]).toMatchObject({ name: "OWNER_REMINDERS" });
 	});
 });

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -1271,18 +1271,34 @@ function shouldUseRecentConversationForActionSearch(
 	);
 }
 
+// App-surface control blocks ([FORM]/[CHOICE]/[FOLLOWUPS]/[TASK]/[CHECKLIST]
+// and single-line [CONFIG:…] markers) travel inline in delivered message text.
+// When a prior turn's reply carried one, its wire vocabulary ("navigate",
+// "apps", "open", "prompt", …) is UI plumbing, not user intent — left in the
+// retrieval window it floods keyword/bm25 scoring toward view/app actions and
+// can evict the stage-1 candidate entirely (live tj-f8bdfafb488900: a reminder
+// delete routed to CLOSE_ALL_VIEWS off a leaked [FOLLOWUPS] block). Strip the
+// blocks from the conversation window before tokenization; the current user
+// message is never stripped.
+const CONTROL_BLOCK_MARKER_RE =
+	/\[[ \t]*(?:FORM|CHOICE[^\]]*|FOLLOWUPS[^\]]*|TASK:[^\]]*|CHECKLIST)[ \t]*\][\s\S]*?\[[ \t]*\/[ \t]*(?:FORM|CHOICE|FOLLOWUPS|TASK|CHECKLIST)[ \t]*\]|\[CONFIG:[^\]]*\]/g;
+
+export function stripControlBlockMarkers(text: string): string {
+	return text.replace(CONTROL_BLOCK_MARKER_RE, " ");
+}
+
 function normalizeTextList(
 	value: string | readonly string[] | undefined,
 ): string[] {
 	if (typeof value === "string") {
-		return [value];
+		return [stripControlBlockMarkers(value).trim()].filter(Boolean);
 	}
 	if (!Array.isArray(value)) {
 		return [];
 	}
 	return value
 		.filter((entry): entry is string => typeof entry === "string")
-		.map((entry) => entry.trim())
+		.map((entry) => stripControlBlockMarkers(entry).trim())
 		.filter(Boolean);
 }
 


### PR DESCRIPTION
Third find from tonight's live daily-driver battery (fleet HQ #18309, watchtower lane; claimed at discussioncomment-18029049).

## Defect (live tj-f8bdfafb488900)
A delivered reply carrying an app-surface control block (`[FOLLOWUPS]…[/FOLLOWUPS]`, `[CHECKLIST]…`, `[CONFIG:…]`) re-enters the NEXT turn's retrieval query through the conversation window. The block's wire vocabulary — `navigate`, `apps`, `open`, `prompt` — is UI plumbing, not user intent, and it floods keyword/bm25 scoring toward view/app actions. Live failure: *"now delete the submit the invoice reminder too"* → stage-1 correctly emitted `candidateActions=["OWNER_REMINDERS"]`, but retrieval's top-5 became CLOSE_ALL_VIEWS / VIEWS / CLOSE_VIEW / APP / PAGE_DELEGATE, OWNER_REMINDERS was evicted from the result set entirely, tierA=[CLOSE_ALL_VIEWS], CLOSE_ALL_VIEWS ran — and the evaluator then claimed the deletion happened (the planned-reply egress guard blocked that fabricated claim; separate finding).

## Fix (structural)
`stripControlBlockMarkers()` removes FORM/CHOICE/FOLLOWUPS/TASK/CHECKLIST blocks and single-line `[CONFIG:…]` markers from conversation-window text before tokenization (in `normalizeTextList`, the window's single choke point). The current user message is never stripped.

## Evidence
| Row | Value |
|---|---|
| tests | `action-retrieval.test.ts` +2: strip unit coverage; adversarial repro of the live failure (leaked FOLLOWUPS block in window + correct candidate → candidate must stay rank 0). File 36/36. |
| llm-trajectory (before) | tj-f8bdfafb488900 — poison tokens visible in `query.tokens` (`followups, navigate, apps, prompt…`), tierA=[CLOSE_ALL_VIEWS] |
| llm-trajectory (after) | live re-probe on the patched box: same anaphoric delete shape → poison tokens `[]`, tierA=[CALENDAR, TRIGGER_*], TRIGGER_DELETE ran, honest 'Deleted "review launch notes".' |
| domain-artifacts | N/A - retrieval-internal change; the query-token before/after in the trajectories is the domain proof |

Remaining halves flagged at HQ for their lanes: candidate-injection in tier narrowing (a stage-1 candidate naming a catalog action should survive any keyword flood), evaluator fabrication sample, and connector-side stripping of control blocks on non-app egress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:356b74eb28f1ea2ab6d87b29c8e4f67c943502fe -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI surface; retrieval-internal fix proven by query-token trajectories

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - single-turn retrieval behavior; trajectory pair carries the full path

<!-- evidence-row:backend-logs -->
- [ ] N/A - trajectory stage records embed the retrieval query, results, and tier decisions

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend in the changed path

<!-- evidence-row:llm-trajectory -->
- [x] [19992-trajectory-before-after.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/19992-trajectory-before-after.json)

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the query-token before/after inside the attached trajectory pair is the domain proof
