### PR TITLE
fix(cloud): retire file-local Headscale upgrade maps

### DIFF
--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -424,24 +424,35 @@ validate_retirable_legacy_vhost() {
     }
   ')
   legacy_upgrade_map_shape=$(printf '%s\\n' "$legacy_vhost_source" | awk '
-    function is_exact_map_token(token, expected, quote) {
+    function normalize_map_variable(token, quote, name) {
       quote = substr(token, 1, 1)
       if (quote == sprintf("%c", 39) || quote == sprintf("%c", 34)) {
-        if (length(token) < 2 || substr(token, length(token), 1) != quote) return 0
+        if (length(token) < 2 || substr(token, length(token), 1) != quote) return ""
         token = substr(token, 2, length(token) - 2)
       }
-      return token == expected \
-        || token == "$" "{" substr(expected, 2) "}"
+      if (token ~ /^[$][[:alpha:]_][[:alnum:]_]*$/) return token
+      if (token ~ /^[$][{][[:alpha:]_][[:alnum:]_]*[}]$/) {
+        name = token
+        sub(/^[$][{]/, "", name)
+        sub(/[}]$/, "", name)
+        return "$" name
+      }
+      return ""
     }
-    function inspect_map_header(normalized, body, fields, count, has_open) {
+    function is_exact_map_source(token) {
+      return normalize_map_variable(token) == "$http_upgrade"
+    }
+    function inspect_map_header(normalized, body, fields, count, has_open, output) {
       body = normalized
       sub(/^map[[:space:]]+/, "", body)
       has_open = body ~ /[{]$/
       if (has_open) sub(/[[:space:]]*[{]$/, "", body)
       count = split(body, fields, /[[:space:]]+/)
+      output = count >= 2 ? normalize_map_variable(fields[2]) : ""
       if (count != 2 \
-          || !is_exact_map_token(fields[1], "$http_upgrade") \
-          || !is_exact_map_token(fields[2], "$connection_upgrade")) return 0
+          || !is_exact_map_source(fields[1]) \
+          || output == "") return 0
+      upgrade_map_output_variable = output
       if (has_open) {
         blocks += 1
         in_upgrade_map = 1
@@ -492,12 +503,13 @@ validate_retirable_legacy_vhost() {
     END {
       if (in_upgrade_map) unexpected += 1
       if (awaiting_upgrade_map_open) unexpected += 1
-      printf "%d %d %d %d %d\\n", blocks + 0, defaults + 0, closes + 0, endings + 0, unexpected + 0
+      printf "%d %d %d %d %d %s\\n", blocks + 0, defaults + 0, closes + 0, endings + 0, unexpected + 0, upgrade_map_output_variable
     }
   ')
+  legacy_upgrade_map_output_variable=
   read -r legacy_upgrade_map_blocks legacy_upgrade_map_defaults \\
     legacy_upgrade_map_closes legacy_upgrade_map_endings \\
-    legacy_upgrade_map_unexpected \\
+    legacy_upgrade_map_unexpected legacy_upgrade_map_output_variable \\
     <<<"$legacy_upgrade_map_shape"
   legacy_has_upgrade_map=false
   if [ "$legacy_upgrade_map_blocks" -ne 0 ] \\
@@ -509,7 +521,8 @@ validate_retirable_legacy_vhost() {
         || [ "$legacy_upgrade_map_defaults" -ne 1 ] \\
         || [ "$legacy_upgrade_map_closes" -ne 1 ] \\
         || [ "$legacy_upgrade_map_endings" -ne 1 ] \\
-        || [ "$legacy_upgrade_map_unexpected" -ne 0 ]; then
+        || [ "$legacy_upgrade_map_unexpected" -ne 0 ] \\
+        || [ -z "$legacy_upgrade_map_output_variable" ]; then
       echo "legacy Headscale vhost has an unexpected upgrade map shape: blocks=$legacy_upgrade_map_blocks defaults=$legacy_upgrade_map_defaults empty-close=$legacy_upgrade_map_closes endings=$legacy_upgrade_map_endings unexpected=$legacy_upgrade_map_unexpected"
       legacy_upgrade_map_header_profile=$(printf '%s\\n' "$legacy_vhost_source" | awk '
         function token_form(token, expected, quote, prefix) {
@@ -668,15 +681,21 @@ validate_retirable_legacy_vhost() {
     return 1
   fi
   legacy_upgrade_map_external_references=$(printf '%s\\n' "$loaded_nginx_config" \\
-    | awk -v target="$HS_RETIRABLE_LEGACY_VHOST" '
+    | awk -v target="$HS_RETIRABLE_LEGACY_VHOST" \\
+        -v map_output="$legacy_upgrade_map_output_variable" '
+      BEGIN {
+        map_output_name = substr(map_output, 2)
+        plain_output_pattern = "[$]" map_output_name "([^[:alnum:]_]|$)"
+        braced_output_pattern = "[$][{]" map_output_name "[}]"
+      }
       /^# configuration file / {
         config_file = $0
         sub(/^# configuration file /, "", config_file)
         sub(/:$/, "", config_file)
         next
       }
-      config_file != target \\
-          && $0 ~ /[$]connection_upgrade([^[:alnum:]_]|$)/ { count += 1 }
+      map_output != "" && config_file != target \\
+          && ($0 ~ plain_output_pattern || $0 ~ braced_output_pattern) { count += 1 }
       END { print count + 0 }
     ')
   if [ "$legacy_has_upgrade_map" = "true" ] \\

--- a/packages/cloud/services/headscale/DEPLOY.md
+++ b/packages/cloud/services/headscale/DEPLOY.md
@@ -101,9 +101,11 @@ exactly two loaded nginx owners from that path. A file-local websocket upgrade
 map may use nginx's exact `$variable` or `${variable}` spelling, may wrap either
 in balanced single or double quotes, and may place its opening brace on the
 header or the immediately following line. Its empty-string key may use nginx's
-equivalent single or double quotes. Mismatched quotes, different variables,
-additional tokens or entries, an intervening header line, and any external
-reference remain fail-closed. The inspection reports file metadata,
+equivalent single or double quotes. The source must be exactly `http_upgrade`;
+the output may use a different valid nginx variable name only when `nginx -T`
+proves it has no reference outside the exact reviewed file. Mismatched quotes,
+an altered source, additional tokens or entries, an intervening header line,
+and every external output reference remain fail-closed. The inspection reports file metadata,
 SHA-256, directive-name counts, and the validated server-block/name/map shape
 for review without printing directive literal values. If the map is rejected,
 only structural counts are printed so operators can distinguish formatting

--- a/packages/scripts/__tests__/headscale-arm-workflow.test.ts
+++ b/packages/scripts/__tests__/headscale-arm-workflow.test.ts
@@ -1004,9 +1004,23 @@ server {
       ]).toEqual([quotedHeader, 0, ""]);
     }
 
+    const customOutputVariable = "$headscale_connection_upgrade";
+    const customOutputValid = runLegacyVhostValidation({
+      source: expectedLegacySource.replace(
+        "$connection_upgrade",
+        customOutputVariable,
+      ),
+      loadedConfig: expectedLoadedConfig.replaceAll(
+        "$connection_upgrade",
+        customOutputVariable,
+      ),
+      enforceDirectiveAllowlist: true,
+    });
+    expect(customOutputValid.status).toBe(0);
+    expect(customOutputValid.stdout).toBe("");
+
     for (const source of [
       expectedLegacySource.replace("$http_upgrade", "$http_connection"),
-      expectedLegacySource.replace("$connection_upgrade", "$shared_upgrade"),
       expectedLegacySource.replace("default upgrade;", "default close;"),
       expectedLegacySource.replace("''      close;", "''      upgrade;"),
       expectedLegacySource.replace("  ''      close;\n", ""),
@@ -1072,20 +1086,39 @@ proxy_set_header Connection $connection_upgrade;
     expect(externallyReferenced.stdout).toContain(
       "upgrade-map output is referenced outside the reviewed file",
     );
+
+    const customExternalOutputVariable = "$headscale_connection_upgrade";
+    const customOutputExternallyReferenced = runLegacyVhostValidation({
+      source: expectedLegacySource.replace(
+        "$connection_upgrade",
+        customExternalOutputVariable,
+      ),
+      loadedConfig: `${expectedLoadedConfig.replaceAll("$connection_upgrade", customExternalOutputVariable)}
+# configuration file /etc/nginx/conf.d/unrelated-custom.conf:
+proxy_set_header Connection ${customExternalOutputVariable};
+`,
+      enforceDirectiveAllowlist: true,
+    });
+    expect(customOutputExternallyReferenced.status).not.toBe(0);
+    expect(customOutputExternallyReferenced.stdout).toContain(
+      "upgrade-map output is referenced outside the reviewed file",
+    );
+    expect(customOutputExternallyReferenced.stdout).not.toContain(
+      customExternalOutputVariable,
+    );
   }, 10_000);
 
   test("profiles rejected map headers without exposing their tokens", () => {
     const otherOutputVariable = runLegacyVhostValidation({
-      source: expectedLegacySource.replace(
-        "$connection_upgrade",
-        "$headscale_connection_upgrade",
-      ),
+      source: expectedLegacySource
+        .replace("$http_upgrade", "$http_connection")
+        .replace("$connection_upgrade", "$headscale_connection_upgrade"),
       loadedConfig: expectedLoadedConfig,
       enforceDirectiveAllowlist: true,
     });
     expect(otherOutputVariable.status).not.toBe(0);
     expect(otherOutputVariable.stdout).toContain(
-      "upgrade map header profile: candidates=1 fields=2 source-form=exact target-form=other-variable extra-fields=no brace=same-line",
+      "upgrade map header profile: candidates=1 fields=2 source-form=other-variable target-form=other-variable extra-fields=no brace=same-line",
     );
     expect(otherOutputVariable.stdout).not.toContain(
       "$headscale_connection_upgrade",


### PR DESCRIPTION
# Relates to

Relates to #19800.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Exact head `4865dfca0b982ef7ba0a1d183f8c1bc56a7b02ea` was tested atop `e7f5d9f068b669e10b4e995b22984432dce79d51`; current develop `7d669c9cd67f225e076295d4d90fe694a7fd23fe` changes no PR path and has a clean merge-tree.
- [x] The accepted contract is based on read-only live inspection run `31879434169`, not inference.
- [x] The dynamic output variable is normalized to a strict nginx identifier and must have zero loaded references outside the exact reviewed file.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e7f5d9f068b669e10b4e995b22984432dce79d51:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Tested head is conflict-free; later develop change is path-disjoint and synthetic merge succeeds.
- [x] Exact-head cloud verify is 78/78 uncached and root verify is 350/350 uncached with all audits clean.

# Risks

Low and staging-infrastructure-only. The map source remains exactly normalized `$http_upgrade`. The output may be a different valid nginx variable name, but the loaded `nginx -T` configuration is dynamically searched for both `$name` and `${name}` forms and retirement fails if any reference exists outside the reviewed file. All map entries, directives, file digest/ownership/mode, server/listener ownership, rollback, SAN, and public-health gates remain strict.

# Background

## What does this PR do?

Read-only protected inspection proved the live header is exactly one two-field map with the expected source and a different valid output variable. This patch normalizes that output identifier, carries it through the shape proof, and replaces the hard-coded external-reference search with a safe dynamic boundary-aware search. It therefore accepts the observed file-local behavior without accepting an unknown shared dependency.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

The Headscale runbook now documents the file-local output-variable ownership rule.

# Testing

- Exact-head Headscale workflow suite: 31/31, 393 assertions.
- Exact-head `bun run verify:cloud`: 78/78, 0 cached.
- Exact-head `TURBO_FORCE=1 bun run verify`: 350/350, 0 cached, all follow-on audits clean.
- Node syntax, changed-file Biome, and diff-check: pass.

# Evidence Gate

<!-- evidence-head:4865dfca0b982ef7ba0a1d183f8c1bc56a7b02ea -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - protected post-merge execution supplies the live transaction; executable generated-shell tests prove pre-merge behavior.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - read-only inspection run `31879434169` bound the unchanged reviewed file and reported `source-form=exact target-form=other-variable` without exposing either value.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

# Evidence Details

The generated-shell harness proves a custom file-local output succeeds, the same output referenced from another loaded config fails, raw and braced references are boundary-matched, and the custom variable name never appears in failure output.

## Known gaps / failures

No known code/test gap. Post-merge protected retirement must still prove exact retirement, exclusive intended nginx ownership, identical dual-SAN public leaves, and both health endpoints.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@e7f5d9f068b669e10b4e995b22984432dce79d51:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@e7f5d9f068b669e10b4e995b22984432dce79d51:packages/skills/skills/contribute-to-eliza"} -->
