### PR TITLE
fix(cloud-sdk): apply live network timeout to authenticated profile E2E

### DIFF
--- a/packages/cloud/sdk/src/live.e2e.test.ts
+++ b/packages/cloud/sdk/src/live.e2e.test.ts
@@ -179,13 +179,19 @@ liveDescribe("ElizaCloudClient real API e2e: pairing token exchange", () => {
 });
 
 authedDescribe("ElizaCloudClient real API e2e: API-key read paths", () => {
-  it("sets credentials after construction and gets the authenticated profile", async () => {
-    const client = new ElizaCloudClient({ baseUrl, apiBaseUrl });
-    client.setApiKey(apiKey);
-    client.setBearerToken(undefined);
+  it(
+    "sets credentials after construction and gets the authenticated profile",
+    async () => {
+      const client = new ElizaCloudClient({ baseUrl, apiBaseUrl });
+      client.setApiKey(apiKey);
+      client.setBearerToken(undefined);
 
-    await expect(client.getUser()).resolves.toMatchObject({ success: true });
-  });
+      await expect(client.getUser()).resolves.toMatchObject({ success: true });
+    },
+    // Same live endpoint budget as the baseline siblings (#19991): this is a
+    // real network read, and Vitest's 5s default flakes against the live API.
+    LIVE_PUBLIC_ENDPOINT_TIMEOUT_MS,
+  );
 
   it(
     "gets credit balance and summary",


### PR DESCRIPTION
Closes #19991

## What

The authenticated-profile live E2E (`sets credentials after construction and gets the authenticated profile`) was the one baseline live-network test in `packages/cloud/sdk/src/live.e2e.test.ts` without an explicit Vitest timeout — it ran against Vitest's 5s default while its four baseline siblings (`getOpenApiSpec`, CLI login, `listModels`, credits) all pass the established `LIVE_PUBLIC_ENDPOINT_TIMEOUT_MS` (15s) live-network budget. It is a real `getUser()` network read, so cold-path latency intermittently blows the 5s default.

## Evidence

- Failing run: [31879126356 / job 94999231708](https://github.com/elizaOS/eliza/actions/runs/31879126356/job/94999231708) — `Error: Test timed out in 5000ms` at `live.e2e.test.ts:182` while the four other live reads passed; same path timed out in the preceding develop run.
- The fix matches the sibling convention exactly (trailing `it()` timeout arg, same constant): definition `live.e2e.test.ts:73-75`, sibling usages at `:121`, `:145`, `:163`, `:202`.

## An independent investigation pass confirmed (RP Codex, medium reasoning, self-worktreeed from develop `7d669c9cd6`)

1. The failing test is the **only** baseline live test missing the budget; the CI workflow's env flags enable exactly the five baseline tests.
2. Other real-network tests without the budget exist but are opt-in (pairing/containers/generation/relay require extra env flags) and are not enabled by the reported workflow — out of scope here.
3. No suite-level `testTimeout` exists in `vitest.live.config.ts`; the per-test trailing arg is the established convention. No other SDK test file hits real network (all mocked).

## Change

One test, `packages/cloud/sdk/src/live.e2e.test.ts:181`: add `LIVE_PUBLIC_ENDPOINT_TIMEOUT_MS` as the trailing `it()` argument. Assertion and credential-mutation coverage unchanged — only the timeout budget widens.

## Verification

- `bun run --cwd packages/cloud/sdk typecheck` — pass
- `bun run --cwd packages/cloud/sdk lint` — pass (30 files, no fixes)
- `bun run --cwd packages/cloud/sdk test` — 79 pass / 19 skip / 0 fail
- Live suite without env flags: 19 skipped cleanly (parse/transform verified)

## Monitoring

Per the issue: hosted develop Cloud Live E2E will be watched after merge (the 15s budget cannot be fully proven without the hosted runner's network path).

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Contribution skill revision: elizaOS/eliza@75b83886e585a80ab8a47b2024673832a4d3941e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@75b83886e585a80ab8a47b2024673832a4d3941e:packages/skills/skills/contribute-to-eliza"} -->