### PR TITLE
fix(core,telegram): strip dashboard-only markers from connector delivery

### DIFF
--- a/packages/core/src/messaging/interactions/dashboard-markers.ts
+++ b/packages/core/src/messaging/interactions/dashboard-markers.ts
@@ -1,0 +1,34 @@
+/**
+ * Dashboard-only inline markers.
+ *
+ * Some single-line markers in agent reply text are rendered exclusively by the
+ * dashboard chat surface and mean nothing anywhere else — `[CONFIG:<pluginId>]`
+ * becomes a plugin setup card (see packages/ui message-parser-helpers). They
+ * are NOT part of the interaction-block grammar, so `parseInteractionBlocks`
+ * deliberately leaves them in `cleanedText` — which means every non-dashboard
+ * connector that renders from cleanedText leaks them verbatim into chat
+ * (live: `[CONFIG:google_calendars]` delivered raw over api/chat replies,
+ * Finding B at HQ #18309).
+ *
+ * Connectors without a dashboard renderer strip them with
+ * {@link stripDashboardOnlyMarkers} after parsing interaction blocks. The
+ * pattern mirrors the dashboard's own CONFIG_RE exactly so the two surfaces
+ * can never disagree about what constitutes a marker.
+ */
+
+/** Matches `[CONFIG:<pluginId>]` — keep in lockstep with the dashboard's CONFIG_RE. */
+const DASHBOARD_CONFIG_MARKER_RE = /\[CONFIG:([@\w][\w@./:-]*)\]/g;
+
+/**
+ * Remove dashboard-only markers from connector-bound prose. Collapses the
+ * whitespace a removed marker leaves behind so chat output has no orphan
+ * blank lines.
+ */
+export function stripDashboardOnlyMarkers(text: string): string {
+	if (!text || !text.includes("[CONFIG:")) return text;
+	return text
+		.replace(DASHBOARD_CONFIG_MARKER_RE, "")
+		.replace(/[ \t]+\n/g, "\n")
+		.replace(/\n{3,}/g, "\n\n")
+		.trim();
+}

--- a/packages/core/src/messaging/interactions/index.ts
+++ b/packages/core/src/messaging/interactions/index.ts
@@ -9,6 +9,7 @@
  */
 
 export * from "./callback";
+export * from "./dashboard-markers";
 export * from "./layout";
 export * from "./normalize";
 export * from "./parse";

--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -19,6 +19,7 @@ import {
 	isInteractionCallback,
 	MAX_CALLBACK_BYTES,
 } from "./callback";
+import { stripDashboardOnlyMarkers } from "./dashboard-markers";
 import {
 	buildInteractionUrlResolver,
 	FORM_FREE_TEXT_INVITE,
@@ -903,5 +904,24 @@ describe("unclaimed interaction markers never ship as prose", () => {
 	it("leaves block-free ordinary prose byte-identical through the renderer", () => {
 		const text = "i read [the docs] and [section 2] carefully.";
 		expect(renderInteractionsAsPlainText(text).text).toBe(text);
+	});
+});
+
+describe("stripDashboardOnlyMarkers", () => {
+	it("removes CONFIG plugin-card markers and tidies the gap they leave", () => {
+		const input =
+			"You'll need to connect Google Calendar first.\n\n[CONFIG:google_calendars]\n\nThen I can list your events.";
+		expect(stripDashboardOnlyMarkers(input)).toBe(
+			"You'll need to connect Google Calendar first.\n\nThen I can list your events.",
+		);
+	});
+
+	it("leaves ordinary prose and interaction grammar untouched", () => {
+		const untouched =
+			"[FOLLOWUPS]\nnavigate:/apps/reminders=Open reminders\n[/FOLLOWUPS]\nPlain text with [brackets] that are not markers.";
+		expect(stripDashboardOnlyMarkers(untouched)).toBe(untouched);
+		expect(stripDashboardOnlyMarkers("no markers at all")).toBe(
+			"no markers at all",
+		);
 	});
 });

--- a/plugins/plugin-telegram/src/interactions.test.ts
+++ b/plugins/plugin-telegram/src/interactions.test.ts
@@ -114,3 +114,22 @@ describe("renderTelegramInteractions", () => {
     expect(out.text).not.toContain("/forms/");
   });
 });
+
+describe("dashboard-only marker stripping (Finding B)", () => {
+  it("strips [CONFIG:…] from delivered text while native keyboards still render", () => {
+    const rendered = renderTelegramInteractions({
+      text: "Connect your calendar first.\n\n[CONFIG:google_calendars]\n\n[FOLLOWUPS]\nreply:yes=Yes\n[/FOLLOWUPS]",
+    } as never);
+    expect(rendered.text).not.toContain("[CONFIG:");
+    expect(rendered.text).toContain("Connect your calendar first.");
+    expect(rendered.keyboardRows.length).toBeGreaterThan(0);
+  });
+
+  it("strips [CONFIG:…] on the zero-block path too", () => {
+    const rendered = renderTelegramInteractions({
+      text: "Set up here: [CONFIG:@elizaos/plugin-gmail]",
+    } as never);
+    expect(rendered.text).toBe("Set up here:");
+    expect(rendered.keyboardRows).toHaveLength(0);
+  });
+});

--- a/plugins/plugin-telegram/src/interactions.ts
+++ b/plugins/plugin-telegram/src/interactions.ts
@@ -14,6 +14,7 @@ import {
   type InteractionBlock,
   type NeutralButton,
   parseInteractionBlocks,
+  stripDashboardOnlyMarkers,
   toNeutralLayout,
 } from "@elizaos/core";
 import type { InlineKeyboardButton } from "@telegraf/types";
@@ -58,7 +59,13 @@ export function renderTelegramInteractions(
   content: Content,
   opts: TelegramInteractionOptions = {},
 ): TelegramInteractionRender {
-  const { blocks, cleanedText } = parseInteractionBlocks(content.text ?? "");
+  const { blocks, cleanedText: parsedText } = parseInteractionBlocks(
+    content.text ?? "",
+  );
+  // Dashboard-only markers ([CONFIG:…] plugin cards) are outside the
+  // interaction grammar, so the parser leaves them in the prose — strip them
+  // before Telegram delivery (Finding B, HQ #18309).
+  const cleanedText = stripDashboardOnlyMarkers(parsedText);
   if (blocks.length === 0) {
     return {
       text: cleanedText,


### PR DESCRIPTION
Slice 1 of the Finding-B delivery half (HQ #18309, reshaped claim 18029091): `[CONFIG:<pluginId>]` is a dashboard-only plugin-card marker outside the interaction grammar, so `parseInteractionBlocks` leaves it in `cleanedText` and Telegram (which otherwise renders interactions natively via inline keyboards) delivers it raw.

New `stripDashboardOnlyMarkers` in `messaging/interactions` — pattern in lockstep with the dashboard's own `CONFIG_RE` so the two surfaces can never disagree — applied in `renderTelegramInteractions` on both delivery paths. Grammar blocks and keyboards untouched (tests pin both).

Evidence: core interactions 66/66, telegram interactions 10/10 (2 new: strip-with-keyboard, strip-on-zero-block), full telegram suite 162/162 pre-change baseline, core typecheck PASS, telegram grep-clean.

Remaining slices per the reshape: Discord native-render verification (watchtower's box), api-surface plain-render signal (shaw design question).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:eb814d4caca6e25c15a4e79a69df994b3cf23543 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - connector text rendering; no UI surface changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - connector text rendering; no UI surface changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - render paths pinned by 10/10 + 66/66 suites

<!-- evidence-row:backend-logs -->
- [ ] N/A - vitest summaries in PR body

<!-- evidence-row:frontend-logs -->
- [ ] N/A - dashboard rendering untouched (pattern lockstep documented)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic render seam; live Telegram proof rides the staging live-fire once green

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - artifact is delivered chat text, asserted by the render tests
