### PR TITLE
fix(core): log why an explicit stage-1 candidate was rejected at exposure

### DIFF
--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -67,7 +67,7 @@ import {
 	buildActionCatalog,
 	type LocalizedActionExampleResolver,
 } from "../runtime/action-catalog";
-import { canActionRun } from "../runtime/action-gate";
+import { actionGateFailure, canActionRun } from "../runtime/action-gate";
 import {
 	parentAliasesForCandidateAction,
 	retrieveActions,
@@ -2692,6 +2692,7 @@ async function collectV5PlannerCandidateActions(args: {
 		action: Action,
 		parentActionName?: string,
 		activeContexts: readonly AgentContext[] | undefined = args.selectedContexts,
+		explicitCandidateName?: string,
 	): Promise<boolean> => {
 		const normalizedName = normalizeActionIdentifier(action.name);
 		if (!normalizedName || seen.has(normalizedName)) {
@@ -2700,13 +2701,31 @@ async function collectV5PlannerCandidateActions(args: {
 		// One gate for exposure and execution (#12087 Item 9): private-action gate
 		// (private actions never reach the planner on a user turn) + ACTION_ROLE_POLICY
 		// + contextGate + roleGate, all via the shared chokepoint.
-		if (
-			!canActionRun(action, {
-				message: args.message,
-				activeContexts,
-				userRoles: args.userRoles,
-			})
-		) {
+		//
+		// For EXPLICIT stage-1 candidates the rejection must be observable:
+		// dropping the one action stage-1 named leaves the planner improvising
+		// with unrelated tools, and a silent drop is undiagnosable from
+		// trajectories (live: a poisoned disclosure census killed every
+		// owner-life candidate in a DM for a full morning with zero log lines —
+		// issue #19999). The every-action loop stays quiet; benign rejections
+		// there are the normal case.
+		const gateFailure = actionGateFailure(action, {
+			message: args.message,
+			activeContexts,
+			userRoles: args.userRoles,
+		});
+		if (gateFailure !== undefined) {
+			if (explicitCandidateName) {
+				logger.warn(
+					{
+						src: "service:message",
+						action: action.name,
+						candidate: explicitCandidateName,
+						gate: gateFailure,
+					},
+					"Explicit stage-1 candidate rejected at the action gate",
+				);
+			}
 			return false;
 		}
 		try {
@@ -2718,6 +2737,17 @@ async function collectV5PlannerCandidateActions(args: {
 				},
 			);
 			if (!accountPolicy.allowed) {
+				if (explicitCandidateName) {
+					logger.warn(
+						{
+							src: "service:message",
+							action: action.name,
+							candidate: explicitCandidateName,
+							gate: "connector-account-policy",
+						},
+						"Explicit stage-1 candidate rejected by connector account policy",
+					);
+				}
 				return false;
 			}
 			if (action.validate) {
@@ -2727,6 +2757,17 @@ async function collectV5PlannerCandidateActions(args: {
 					args.state,
 				);
 				if (!valid) {
+					if (explicitCandidateName) {
+						logger.warn(
+							{
+								src: "service:message",
+								action: action.name,
+								candidate: explicitCandidateName,
+								gate: "validate-returned-false",
+							},
+							"Explicit stage-1 candidate rejected by action validate()",
+						);
+					}
 					return false;
 				}
 			}
@@ -2775,6 +2816,7 @@ async function collectV5PlannerCandidateActions(args: {
 				action,
 				undefined,
 				mergeAgentContexts(args.selectedContexts, action.contexts),
+				candidateName,
 			);
 		}
 	}

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2657,7 +2657,10 @@ type V5PlannerActionSurface = {
 	summary: V5PlannerActionSurfaceSummary;
 };
 
-async function collectV5PlannerCandidateActions(args: {
+// Exported for unit coverage of the candidate-rejection log contract
+// (#20001): the warn IS the deliverable, so tests pin that a rejected or
+// unresolvable explicit candidate produces the structured reason.
+export async function collectV5PlannerCandidateActions(args: {
 	runtime: IAgentRuntime;
 	message: Memory;
 	state: State;
@@ -2811,6 +2814,21 @@ async function collectV5PlannerCandidateActions(args: {
 			: parentAliasesForCandidateAction(candidateName)
 					.map((alias) => resolveRuntimeAction(actionLookup, alias))
 					.filter((action): action is Action => action !== undefined);
+		if (resolved.length === 0) {
+			// The plumbing-class observable: stage-1 named a candidate that binds
+			// to NO runtime action even after the alias fallback. Without this
+			// line that gap is indistinguishable from a gate rejection when
+			// reading trajectories (#19999 triage had to rule it out by hand).
+			logger.warn(
+				{
+					src: "service:message",
+					candidate: candidateName,
+					gate: "resolved-to-no-runtime-action",
+				},
+				"Explicit stage-1 candidate resolved to no runtime action",
+			);
+			continue;
+		}
 		for (const action of resolved) {
 			await appendIfAllowed(
 				action,

--- a/packages/core/src/services/message/candidate-rejection-observability.test.ts
+++ b/packages/core/src/services/message/candidate-rejection-observability.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Pins the candidate-rejection log contract (#20001): when an EXPLICIT
+ * stage-1 candidate is dropped at exposure, the structured warn with the
+ * preserved gate reason is the deliverable — an unpinned log dies silently in
+ * the next refactor. Live motivation: the poisoned owner-exclusive disclosure
+ * census (#19999) killed every owner-life candidate in a DM with zero log
+ * lines across four trajectories.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "../../logger";
+import type { Action, IAgentRuntime, Memory, State } from "../../types";
+import { collectV5PlannerCandidateActions } from "../message";
+
+const message = {
+	id: "00000000-0000-0000-0000-000000000001",
+	entityId: "00000000-0000-0000-0000-000000000002",
+	roomId: "00000000-0000-0000-0000-000000000003",
+	content: { text: "list my reminders" },
+} as unknown as Memory;
+
+function runtimeWith(actions: Action[]): IAgentRuntime {
+	return {
+		actions,
+		agentId: "00000000-0000-0000-0000-000000000009",
+		reportError: vi.fn(),
+		getSetting: () => undefined,
+		getService: () => null,
+	} as unknown as IAgentRuntime;
+}
+
+describe("explicit candidate rejection observability", () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+	});
+	afterEach(() => {
+		warnSpy.mockRestore();
+	});
+
+	it("warns with the preserved gate reason when an explicit candidate is gate-rejected", async () => {
+		const gated: Action = {
+			name: "OWNER_REMINDERS",
+			description: "owner reminders",
+			// Role gate the anonymous test caller cannot satisfy — rejection
+			// flows through actionGateFailure with a reason string.
+			roleGate: { minRole: "OWNER" },
+			validate: async () => true,
+			handler: async () => ({ success: true }),
+		} as unknown as Action;
+
+		const selected = await collectV5PlannerCandidateActions({
+			runtime: runtimeWith([gated]),
+			message,
+			state: {} as State,
+			candidateActions: ["OWNER_REMINDERS"],
+			userRoles: [],
+		});
+
+		expect(selected.map((a) => a.name)).not.toContain("OWNER_REMINDERS");
+		const call = warnSpy.mock.calls.find(
+			([fields]) =>
+				(fields as { candidate?: string }).candidate === "OWNER_REMINDERS",
+		);
+		expect(call).toBeDefined();
+		expect((call?.[0] as { gate?: string }).gate).toMatch(/not allowed/);
+	});
+
+	it("warns when an explicit candidate resolves to no runtime action", async () => {
+		const selected = await collectV5PlannerCandidateActions({
+			runtime: runtimeWith([]),
+			message,
+			state: {} as State,
+			candidateActions: ["TOTALLY_UNKNOWN_ACTION"],
+			userRoles: [],
+		});
+
+		expect(selected).toHaveLength(0);
+		const call = warnSpy.mock.calls.find(
+			([fields]) =>
+				(fields as { candidate?: string }).candidate ===
+				"TOTALLY_UNKNOWN_ACTION",
+		);
+		expect(call).toBeDefined();
+		expect((call?.[0] as { gate?: string }).gate).toBe(
+			"resolved-to-no-runtime-action",
+		);
+	});
+});


### PR DESCRIPTION
Upstreams watchtower's live instrumentation (HQ 18029214) as a structural seam. `collectV5PlannerCandidateActions` dropped explicit stage-1 candidates silently on all three rejection branches (action gate via the reason-discarding boolean wrapper, connector account policy, `validate()` false). Live cost: the poisoned disclosure census (#19999) killed every owner-life candidate in a DM all morning with zero log lines — four trajectories, undiagnosable until a hot-patch named the gate.

Now explicit candidates warn with the preserved `actionGateFailure` reason + candidate provenance; the every-action loop stays quiet (benign rejections are normal there). Behavior unchanged — same rejections, now observable. Same principle as #19972.

Evidence: message suites 591/591 (31 files), core typecheck PASS, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:a1b93e0916ce881f1f70bdc2c36d393a8831bc15 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - log-only observability; no UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - log-only observability; no UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - contract pinned by new unit tests (2) + 593/593 message suites

<!-- evidence-row:backend-logs -->
- [ ] N/A - the change IS the log; contract now pinned by tests per review

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - tj-class evidence is the four silent-drop trajectories in #19999

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - artifact is the structured warn, asserted by the new tests

