### PR TITLE
fix(connectors): strip dashboard markers at final delivery

### DIFF
--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -652,6 +652,23 @@ describe("renderInteractionsAsPlainText", () => {
 		expect(text).toContain("Tell me what changed.");
 		expect(text).toContain(FORM_FREE_TEXT_INVITE);
 	});
+
+	it("strips dashboard markers contributed by parsed block fallbacks", () => {
+		const taskId = "abc12345-def6-7890-abcd-ef1234567890";
+		expect(
+			renderInteractionsAsPlainText(
+				`[TASK:${taskId}]Ship it [CONFIG:@elizaos/plugin-gmail][/TASK]`,
+			),
+		).toEqual({ text: "Ship it", hadBlocks: true });
+
+		const form = JSON.stringify({
+			title: "Configure account [CONFIG:@elizaos/plugin-gmail]",
+			fields: [{ name: "account", type: "text" }],
+		});
+		const rendered = renderInteractionsAsPlainText(`[FORM]${form}[/FORM]`);
+		expect(rendered.hadBlocks).toBe(true);
+		expect(rendered.text).toBe(`Configure account\n\n${FORM_FREE_TEXT_INVITE}`);
+	});
 });
 
 describe("renderContentInteractionsAsPlainText", () => {
@@ -673,6 +690,21 @@ describe("renderContentInteractionsAsPlainText", () => {
 		expect(text).toBe(
 			"Connect this account.\n\nConnect GitHub to continue\nhttps://oauth.test/consent",
 		);
+	});
+
+	it("strips dashboard markers contributed by typed interactions", () => {
+		const rendered = renderContentInteractionsAsPlainText({
+			text: "Review:",
+			interactions: [
+				{
+					kind: "task",
+					threadId: "task-1",
+					title: "Ship it [CONFIG:@elizaos/plugin-gmail]",
+				},
+			],
+		});
+
+		expect(rendered).toEqual({ text: "Review:\n\nShip it", hadBlocks: true });
 	});
 });
 

--- a/packages/core/src/messaging/interactions/layout.ts
+++ b/packages/core/src/messaging/interactions/layout.ts
@@ -15,6 +15,7 @@ import type {
 } from "../../types/interactions";
 import type { Content } from "../../types/primitives";
 import { encodeReplyCallback } from "./callback";
+import { stripDashboardOnlyMarkers } from "./dashboard-markers";
 import { parseInteractionBlocks } from "./parse";
 
 export interface NeutralButton {
@@ -299,9 +300,11 @@ export function renderInteractionsAsPlainText(
 		.map((block) => toPlainTextFallback(block, opts))
 		.filter((part): part is string => Boolean(part?.trim()));
 	return {
-		text: [cleanedText, ...fallbacks]
-			.filter((part) => part.trim().length > 0)
-			.join("\n\n"),
+		text: stripDashboardOnlyMarkers(
+			[cleanedText, ...fallbacks]
+				.filter((part) => part.trim().length > 0)
+				.join("\n\n"),
+		),
 		hadBlocks: true,
 	};
 }
@@ -328,9 +331,11 @@ export function renderContentInteractionsAsPlainText(
 		.map((block) => toPlainTextFallback(block, opts))
 		.filter((part): part is string => Boolean(part?.trim()));
 	return {
-		text: [cleanedText, ...fallbacks]
-			.filter((part) => part.trim().length > 0)
-			.join("\n\n"),
+		text: stripDashboardOnlyMarkers(
+			[cleanedText, ...fallbacks]
+				.filter((part) => part.trim().length > 0)
+				.join("\n\n"),
+		),
 		hadBlocks: true,
 	};
 }

--- a/plugins/plugin-discord/__tests__/interactions.test.ts
+++ b/plugins/plugin-discord/__tests__/interactions.test.ts
@@ -108,6 +108,16 @@ describe("renderDiscordInteractions", () => {
 		expect(button?.custom_id).toBe("");
 	});
 
+	it("strips dashboard-only markers from parsed fallback prose", () => {
+		const id = "abc12345-def6-7890-abcd-ef1234567890";
+		const out = renderDiscordInteractions({
+			text: `[TASK:${id}]Ship it [CONFIG:@elizaos/plugin-gmail][/TASK]`,
+		} as Content);
+		expect(out.text).toBe("Ship it");
+		expect(out.text).not.toContain("[CONFIG:");
+		expect(out.components).toHaveLength(0);
+	});
+
 	it("caps action rows at the Discord limit of 5", () => {
 		const options = Array.from(
 			{ length: 30 },

--- a/plugins/plugin-discord/interactions.ts
+++ b/plugins/plugin-discord/interactions.ts
@@ -18,6 +18,7 @@ import {
 	type InteractionBlock,
 	type NeutralButton,
 	parseInteractionBlocks,
+	stripDashboardOnlyMarkers,
 	toNeutralLayout,
 } from "@elizaos/core";
 import type { DiscordActionRow, DiscordComponentOptions } from "./types";
@@ -133,9 +134,13 @@ export function renderDiscordInteractions(
 		}
 	}
 
-	const text = [cleanedText, ...extraLines]
-		.filter((s) => s.trim().length > 0)
-		.join("\n\n");
+	// Parsed blocks can add fallback prose after the first cleanup. Apply the
+	// dashboard-only marker boundary to the complete Discord message as well.
+	const text = stripDashboardOnlyMarkers(
+		[cleanedText, ...extraLines]
+			.filter((s) => s.trim().length > 0)
+			.join("\n\n"),
+	);
 	return { text, components: visibleRows, needsFreeTextReply };
 }
 

--- a/plugins/plugin-telegram/src/interactions.test.ts
+++ b/plugins/plugin-telegram/src/interactions.test.ts
@@ -132,4 +132,14 @@ describe("dashboard-only marker stripping (Finding B)", () => {
     expect(rendered.text).toBe("Set up here:");
     expect(rendered.keyboardRows).toHaveLength(0);
   });
+
+  it("strips [CONFIG:…] from fallback prose contributed by a parsed block", () => {
+    const id = "abc12345-def6-7890-abcd-ef1234567890";
+    const rendered = renderTelegramInteractions({
+      text: `[TASK:${id}]Ship it [CONFIG:@elizaos/plugin-gmail][/TASK]`,
+    } as Content);
+    expect(rendered.text).toBe("Ship it");
+    expect(rendered.text).not.toContain("[CONFIG:");
+    expect(rendered.keyboardRows).toHaveLength(0);
+  });
 });

--- a/plugins/plugin-telegram/src/interactions.ts
+++ b/plugins/plugin-telegram/src/interactions.ts
@@ -14,6 +14,7 @@ import {
   type InteractionBlock,
   type NeutralButton,
   parseInteractionBlocks,
+  stripDashboardOnlyMarkers,
   toNeutralLayout,
 } from "@elizaos/core";
 import type { InlineKeyboardButton } from "@telegraf/types";
@@ -93,8 +94,13 @@ export function renderTelegramInteractions(
     if (!producedButton && layout.text) extraLines.push(layout.text);
   }
 
-  const text = [cleanedText, ...extraLines]
-    .filter((s) => s.trim().length > 0)
-    .join("\n\n");
+  // A buttonless block can contribute fallback prose after parsing (for
+  // example, a task title). Strip again at the final delivery boundary so a
+  // marker nested inside that block cannot bypass the parsed-text cleanup.
+  const text = stripDashboardOnlyMarkers(
+    [cleanedText, ...extraLines]
+      .filter((s) => s.trim().length > 0)
+      .join("\n\n"),
+  );
   return { text, keyboardRows, needsFreeTextReply };
 }


### PR DESCRIPTION
# Relates to

Direct post-merge corrective follow-up to #19998 and #20005.

- Reviewed #19998 source head: `eb814d4caca6e25c15a4e79a69df994b3cf23543`
- Absorbed canonical parser cleanup: #20005 at `c15b1bb90d3aea7640b25320384af2cdb065b809`
- Current base: `develop@4636c94ca80fde77b40ab1c26013c61f8b336b56`

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Rebased after #20005 merged; duplicate zero-block/parser cleanup removed.
- [x] Remaining parsed-block fallback bypass reproduced and fixed for Telegram and Discord.
- [x] Protected exact-tree tests, independent mutations, focused Biome, and diff-check pass.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] One focused commit directly on `develop@4636c94ca80fde77b40ab1c26013c61f8b336b56`.
- [ ] Full `bun run verify` was not rerun; protected focused production suites and static gates are recorded below.

# Risks

Low and fail-closed. The shared marker helper remains a whole-message boundary, including its intentional trim behavior. Interaction parsing, callbacks, native buttons, and dashboard parsing are unchanged.

# Background

## What does this PR do?

#20005 correctly moved dashboard-marker cleanup into the canonical connector-facing parser, covering plain/zero-block connector prose and the prose outside parsed controls.

A marker nested **inside** a valid block is not part of parser `cleanedText`. A buttonless block can add its own fallback prose after parsing; for example:

```text
[TASK:abc12345-def6-7890-abcd-ef1234567890]Ship it [CONFIG:@elizaos/plugin-gmail][/TASK]
```

On #20005 this still delivers verbatim as:

```text
Ship it [CONFIG:@elizaos/plugin-gmail]
```

This PR applies the existing shared whole-message helper once more to the fully assembled Telegram and Discord text and pins the bypass independently on both connectors.

## API/chat trace

`packages/agent/src/api/chat-routes.ts` assembles `finalText`, mirrors it into `responseContent.text`, and returns it to the client. The dashboard consumes `[CONFIG:…]` as widget data through its matching `CONFIG_RE`; stripping the marker unconditionally server-side would remove the setup card the dashboard requires.

This PR therefore does **not** claim to close the plain API-consumer protocol question. That surface needs an explicit negotiated/plain-render contract or typed presentation signal so dashboard clients retain widget data while plain clients receive rendered prose.

## What kind of change is this?

Bug fix and regression coverage.

# Documentation changes needed?

No public documentation change. The whole-message-only helper contract and API/dashboard distinction are documented in code/PR context.

# Testing

Protected no-network, read-only-root Docker runs on the rebased exact tree:

```text
packages/core interactions                         67 passed
plugin-telegram interactions                       11 passed
plugin-discord interactions                        17 passed
Total                                               95 passed
Focused Biome                                        4 files clean
git diff --check                                     clean
```

Mutation proof after #20005:

- restoring Telegram's pre-fix final assembly fails the nested parsed-fallback regression;
- restoring Discord's pre-fix final assembly independently fails its nested parsed-fallback regression.

# Evidence Gate

<!-- evidence-head:cf9c6cf3fde23fb0cce4c86f0ced61c3a2942485 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - connector text projection; no rendered dashboard UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - connector text projection; no rendered dashboard UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic native-render seams are covered by production-path tests.
<!-- evidence-row:backend-logs -->
- [x] Protected test and mutation summaries are included above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend source changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic connector rendering after model output.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - delivered text/components are asserted directly.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

# Known gaps / failures

- The API/plain-consumer contract remains a separate design question; no unsafe server-wide strip is claimed.
- Full repository verification was not run in the bounded review harness.
- Hosted checks must report independently for this exact head.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Hermes Agent
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [hermes-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Hermes Agent","skill_revision":"N/A - no repository contribution skill used","attribution_status":"self-reported"} -->
