### PR TITLE
fix(core): strip dashboard markers at every connector boundary

### DIFF
--- a/packages/core/src/messaging/interactions/dashboard-markers.ts
+++ b/packages/core/src/messaging/interactions/dashboard-markers.ts
@@ -10,10 +10,10 @@
  * (live: `[CONFIG:google_calendars]` delivered raw over api/chat replies,
  * Finding B at HQ #18309).
  *
- * Connectors without a dashboard renderer strip them with
- * {@link stripDashboardOnlyMarkers} after parsing interaction blocks. The
- * pattern mirrors the dashboard's own CONFIG_RE exactly so the two surfaces
- * can never disagree about what constitutes a marker.
+ * The canonical interaction parser strips them only from its connector-facing
+ * `cleanedText`; it never mutates the original content consumed by the
+ * dashboard. The pattern mirrors the dashboard's own CONFIG_RE exactly so the
+ * two projections agree about what constitutes a marker.
  */
 
 /** Matches `[CONFIG:<pluginId>]` — keep in lockstep with the dashboard's CONFIG_RE. */
@@ -25,7 +25,7 @@ const DASHBOARD_CONFIG_MARKER_RE = /\[CONFIG:([@\w][\w@./:-]*)\]/g;
  * blank lines.
  */
 export function stripDashboardOnlyMarkers(text: string): string {
-	if (!text || !text.includes("[CONFIG:")) return text;
+	if (!text.includes("[CONFIG:")) return text;
 	return text
 		.replace(DASHBOARD_CONFIG_MARKER_RE, "")
 		.replace(/[ \t]+\n/g, "\n")

--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -924,4 +924,13 @@ describe("stripDashboardOnlyMarkers", () => {
 			"no markers at all",
 		);
 	});
+
+	it("is part of the canonical connector text boundary", () => {
+		const source =
+			"Connect it. [CONFIG:google_calendars]\n[FOLLOWUPS]\nreply:yes=Yes\n[/FOLLOWUPS]";
+		const parsed = parseInteractionBlocks(source);
+		expect(parsed.blocks).toHaveLength(1);
+		expect(parsed.cleanedText).toBe("Connect it.");
+		expect(renderInteractionsAsPlainText(source).text).not.toContain("CONFIG");
+	});
 });

--- a/packages/core/src/messaging/interactions/parse.ts
+++ b/packages/core/src/messaging/interactions/parse.ts
@@ -26,6 +26,7 @@ import type {
 	InteractionOption,
 	TaskInteraction,
 } from "../../types/interactions";
+import { stripDashboardOnlyMarkers } from "./dashboard-markers";
 
 /** Hard caps mirroring the dashboard parsers — keep a runaway template safe. */
 export const MAX_FORM_FIELDS = 20;
@@ -388,7 +389,12 @@ export function stripUnclaimedInteractionMarkup(text: string): string {
 export function parseInteractionBlocks(text: string): ParsedInteractions {
 	const regions = findInteractionRegions(text);
 	if (regions.length === 0) {
-		return { blocks: [], cleanedText: stripUnclaimedInteractionMarkup(text) };
+		return {
+			blocks: [],
+			cleanedText: stripDashboardOnlyMarkers(
+				stripUnclaimedInteractionMarkup(text),
+			),
+		};
 	}
 	const blocks: InteractionBlock[] = [];
 	const parts: string[] = [];
@@ -399,9 +405,11 @@ export function parseInteractionBlocks(text: string): ParsedInteractions {
 		cursor = r.end;
 	}
 	if (cursor < text.length) parts.push(text.slice(cursor));
-	const cleanedText = stripUnclaimedInteractionMarkup(parts.join(""))
-		.replace(/\n{3,}/g, "\n\n")
-		.trim();
+	const cleanedText = stripDashboardOnlyMarkers(
+		stripUnclaimedInteractionMarkup(parts.join(""))
+			.replace(/\n{3,}/g, "\n\n")
+			.trim(),
+	);
 	return { blocks, cleanedText };
 }
 

--- a/plugins/plugin-discord/__tests__/interactions.test.ts
+++ b/plugins/plugin-discord/__tests__/interactions.test.ts
@@ -40,6 +40,20 @@ describe("renderDiscordInteractions", () => {
 		expect(out.components[0]?.components[0]?.label).toBe("More");
 	});
 
+	it("strips dashboard-only config cards with and without native controls", () => {
+		const interactive = renderDiscordInteractions({
+			text: "Connect it. [CONFIG:google_calendars]\n[FOLLOWUPS]\nreply:yes=Yes\n[/FOLLOWUPS]",
+		} as Content);
+		expect(interactive.text).toBe("Connect it.");
+		expect(interactive.components).toHaveLength(1);
+
+		const plain = renderDiscordInteractions({
+			text: "Set up here: [CONFIG:@elizaos/plugin-gmail]",
+		} as Content);
+		expect(plain.text).toBe("Set up here:");
+		expect(plain.components).toEqual([]);
+	});
+
 	it("renders a choice block as a button action row and strips the marker", () => {
 		const content: Content = {
 			text: "Approve?\n[CHOICE:approve id=c1]\nyes=Yes, ship it\nno=Cancel\n[/CHOICE]",

--- a/plugins/plugin-telegram/src/interactions.ts
+++ b/plugins/plugin-telegram/src/interactions.ts
@@ -14,7 +14,6 @@ import {
   type InteractionBlock,
   type NeutralButton,
   parseInteractionBlocks,
-  stripDashboardOnlyMarkers,
   toNeutralLayout,
 } from "@elizaos/core";
 import type { InlineKeyboardButton } from "@telegraf/types";
@@ -59,13 +58,7 @@ export function renderTelegramInteractions(
   content: Content,
   opts: TelegramInteractionOptions = {},
 ): TelegramInteractionRender {
-  const { blocks, cleanedText: parsedText } = parseInteractionBlocks(
-    content.text ?? "",
-  );
-  // Dashboard-only markers ([CONFIG:…] plugin cards) are outside the
-  // interaction grammar, so the parser leaves them in the prose — strip them
-  // before Telegram delivery (Finding B, HQ #18309).
-  const cleanedText = stripDashboardOnlyMarkers(parsedText);
+  const { blocks, cleanedText } = parseInteractionBlocks(content.text ?? "");
   if (blocks.length === 0) {
     return {
       text: cleanedText,


### PR DESCRIPTION
## Summary

- move #19998's Telegram-only `[CONFIG:…]` cleanup into the canonical connector-facing interaction parser
- cover Discord, Telegram, and plain-text delivery on both zero-block and native-control paths
- preserve original content for the dashboard's setup-card renderer

Closes #20004

## Exact candidate

- HEAD: `c15b1bb90d3aea7640b25320384af2cdb065b809`
- tree: `20f11fe13a11a637f9d22e3a36f19496e81231cc`
- base: `bb30bb02256bbf268942837fc39f18d4a55591ca`
- 5 intended paths

## Validation

- core interaction suite: **67/67 PASS**
- Telegram renderer suite: **10/10 PASS**
- Discord renderer suite: **16/16 PASS**
- core, Telegram, and Discord typechecks: **PASS**
- full core Node/browser/edge/testing build plus packed edge import: **PASS**
- targeted Biome and `git diff --check`: **PASS**

## Evidence Gate

<!-- evidence-head:c15b1bb90d3aea7640b25320384af2cdb065b809 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - connector text projection has no rendered repository UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - connector text projection has no rendered repository UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic transport rendering is exercised directly by the three focused suites.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service or request boundary changes; focused renderer transcripts are summarized above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - dashboard content remains intentionally unchanged.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, provider, action, or evaluator behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the domain artifact is deterministic delivered text, asserted for core, Telegram, and Discord.
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshot or visual text artifact applies.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@bb30bb02256bbf268942837fc39f18d4a55591ca:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex Desktop  
Contribution skill revision: elizaOS/eliza@bb30bb02256bbf268942837fc39f18d4a55591ca:packages/skills/skills/contribute-to-eliza  
Attribution status: self-reported  
— [codex-nubs-shared-followup]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@bb30bb02256bbf268942837fc39f18d4a55591ca:packages/skills/skills/contribute-to-eliza"} -->
