### PR TITLE
fix(cloud): accept reviewed Headscale map overlap

### DIFF
--- a/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
+++ b/packages/cloud/scripts/admin/arm-headscale-control-plane.mjs
@@ -707,8 +707,25 @@ validate_retirable_legacy_vhost() {
   legacy_upgrade_map_external_references=$(printf '%s\\n' \\
     "$legacy_upgrade_map_external_reference_profile" \\
     | awk -F '\\t' '{ count += $2 } END { print count + 0 }')
+  legacy_upgrade_map_managed_references=$(printf '%s\\n' \\
+    "$legacy_upgrade_map_external_reference_profile" \\
+    | awk -F '\\t' -v managed="\${HS_VHOST:-}" \\
+        '$1 == managed { count += $2 } END { print count + 0 }')
+  legacy_upgrade_map_external_path_count=$(printf '%s\\n' \\
+    "$legacy_upgrade_map_external_reference_profile" \\
+    | awk -F '\\t' 'NF == 2 { count += 1 } END { print count + 0 }')
+  # The managed vhost is backed up and replaced before legacy removal, then
+  # this validator runs again. No other loaded owner or reference count is safe.
+  legacy_upgrade_map_has_reviewed_managed_overlap=false
   if [ "$legacy_has_upgrade_map" = "true" ] \\
-      && [ "$legacy_upgrade_map_external_references" -ne 0 ]; then
+      && [ "$legacy_upgrade_map_external_references" -eq 2 ] \\
+      && [ "$legacy_upgrade_map_managed_references" -eq 2 ] \\
+      && [ "$legacy_upgrade_map_external_path_count" -eq 1 ]; then
+    legacy_upgrade_map_has_reviewed_managed_overlap=true
+  fi
+  if [ "$legacy_has_upgrade_map" = "true" ] \\
+      && [ "$legacy_upgrade_map_external_references" -ne 0 ] \\
+      && [ "$legacy_upgrade_map_has_reviewed_managed_overlap" != "true" ]; then
     echo "legacy Headscale upgrade-map output is referenced outside the reviewed file (paths and counts only):"
     printf '%s\\n' "$legacy_upgrade_map_external_reference_profile" \\
       | awk -F '\\t' '{ printf "path=%s references=%d\\n", $1, $2 }'
@@ -1156,6 +1173,7 @@ HS_RETIRABLE_LEGACY_VHOST=${shellQuote(retirableLegacyVhost ?? "")}
 HS_REQUIRE_RETIRABLE_LEGACY_VHOST=true
 HS_ENFORCE_LEGACY_VHOST_DIRECTIVE_ALLOWLIST=false
 HS_REVIEWED_LEGACY_VHOST_SHA256=""
+HS_VHOST=/etc/nginx/conf.d/headscale.conf
 
 if [ -z "$HS_RETIRABLE_LEGACY_VHOST" ] \\
     || ! sudo test -e "$HS_RETIRABLE_LEGACY_VHOST"; then
@@ -1171,9 +1189,9 @@ echo "reviewed-sha256=$legacy_vhost_sha256"
 echo "--- reviewed nginx directive-name inventory (values withheld) ---"
 printf '%s\\n' "$legacy_vhost_directives" | sort | uniq -c
 if [ "$legacy_has_upgrade_map" = "true" ]; then
-  echo "reviewed-upgrade-map=headscale-websocket-v1 external-references=0"
+  echo "reviewed-upgrade-map=headscale-websocket-v1 managed-references=$legacy_upgrade_map_managed_references unmanaged-references=$((legacy_upgrade_map_external_references - legacy_upgrade_map_managed_references))"
 else
-  echo "reviewed-upgrade-map=absent external-references=0"
+  echo "reviewed-upgrade-map=absent managed-references=0 unmanaged-references=0"
 fi
 echo "reviewed-shape=server-blocks:$legacy_server_block_count server-names:$legacy_server_name_count exact-host:$HS_LEGACY_HOST"
 echo "Legacy Headscale vhost passed the read-only retirement preflight"

--- a/packages/cloud/services/headscale/DEPLOY.md
+++ b/packages/cloud/services/headscale/DEPLOY.md
@@ -103,12 +103,16 @@ in balanced single or double quotes, and may place its opening brace on the
 header or the immediately following line. Its empty-string key may use nginx's
 equivalent single or double quotes. The source must be exactly `http_upgrade`;
 the output may use a different valid nginx variable name only when `nginx -T`
-proves it has no reference outside the exact reviewed file. Mismatched quotes,
-an altered source, additional tokens or entries, an intervening header line,
-and every external output reference remain fail-closed. When an external
-reference blocks retirement, the diagnostic reports only its loaded nginx
-config path and reference count; it never prints the variable or directive
-value. The inspection reports file metadata,
+proves it has no reference outside the exact reviewed file, except for the
+reviewed migration overlap of exactly two references in the managed
+`/etc/nginx/conf.d/headscale.conf`. That managed file is transactionally
+replaced with the self-contained canonical vhost before the legacy file is
+removed, and the validator runs again before deletion. Any other path, count,
+or mixed owner remains fail-closed. Mismatched quotes, an altered source,
+additional tokens or entries, and an intervening header line also fail closed.
+When an external reference blocks retirement, the diagnostic reports only its
+loaded nginx config path and reference count; it never prints the variable or
+directive value. The inspection reports file metadata,
 SHA-256, directive-name counts, and the validated server-block/name/map shape
 for review without printing directive literal values. If the map is rejected,
 only structural counts are printed so operators can distinguish formatting

--- a/packages/scripts/__tests__/headscale-arm-workflow.test.ts
+++ b/packages/scripts/__tests__/headscale-arm-workflow.test.ts
@@ -275,6 +275,7 @@ set -euo pipefail
 HS_HOST=headscale-staging.eliza.app
 HS_LEGACY_HOST=headscale-staging.elizacloud.ai
 HS_RETIRABLE_LEGACY_VHOST=${JSON.stringify(legacyVhost)}
+HS_VHOST=/etc/nginx/conf.d/headscale.conf
 HS_REVIEWED_LEGACY_VHOST_SHA256=${JSON.stringify(options.reviewedSha256 ?? "")}
 HS_REQUIRE_RETIRABLE_LEGACY_VHOST=${options.requireFile ? "true" : "false"}
 HS_ENFORCE_LEGACY_VHOST_DIRECTIVE_ALLOWLIST=${options.enforceDirectiveAllowlist ? "true" : "false"}
@@ -816,7 +817,7 @@ server_name headscale-staging.elizacloud.ai;
       "directive-name inventory (values withheld)",
     );
     expect(result.stdout).toContain(
-      "reviewed-upgrade-map=headscale-websocket-v1 external-references=0",
+      "reviewed-upgrade-map=headscale-websocket-v1 managed-references=$legacy_upgrade_map_managed_references unmanaged-references=",
     );
     expect(result.stdout).toContain("reviewed-shape=server-blocks:");
     expect(result.stdout).not.toContain(
@@ -826,6 +827,26 @@ server_name headscale-staging.elizacloud.ai;
     expect(result.stdout).not.toContain("sudo systemctl restart headscale");
     expect(result.stdout).not.toContain("sudo rm -f --");
     expectBashSyntax(result.stdout);
+  });
+
+  test("accepts only the reviewed two-reference managed-vhost overlap", () => {
+    const managedOverlapConfig = expectedLoadedConfig.replace(
+      "server_name headscale-staging.eliza.app headscale-staging.elizacloud.ai;\nserver_name headscale-staging.eliza.app headscale-staging.elizacloud.ai;",
+      `server_name headscale-staging.eliza.app headscale-staging.elizacloud.ai;
+map $http_upgrade $connection_upgrade {
+server_name headscale-staging.eliza.app headscale-staging.elizacloud.ai;
+proxy_set_header Connection $connection_upgrade;`,
+    );
+    const result = runLegacyVhostInspection(
+      expectedLegacySource,
+      managedOverlapConfig,
+    );
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain(
+      "reviewed-upgrade-map=headscale-websocket-v1 managed-references=2 unmanaged-references=0",
+    );
+    expect(result.stdout).not.toContain("$connection_upgrade");
   });
 
   test("withholds every reviewed directive literal from inspection output", () => {
@@ -954,7 +975,7 @@ server {
     );
     expect(inspection.status).toBe(0);
     expect(inspection.stdout).toContain(
-      "reviewed-upgrade-map=headscale-websocket-v1 external-references=0",
+      "reviewed-upgrade-map=headscale-websocket-v1 managed-references=0 unmanaged-references=0",
     );
     expect(inspection.stdout).not.toContain("$connection_upgrade");
 
@@ -1090,6 +1111,43 @@ proxy_set_header Connection $connection_upgrade;
       "path=/etc/nginx/conf.d/unrelated.conf references=1",
     );
     expect(externallyReferenced.stdout).not.toContain("$connection_upgrade");
+
+    const reviewedManagedOverlap = runLegacyVhostValidation({
+      source: expectedLegacySource,
+      loadedConfig: `${expectedLoadedConfig}
+# configuration file /etc/nginx/conf.d/headscale.conf:
+map $http_upgrade $connection_upgrade {
+proxy_set_header Connection $connection_upgrade;
+`,
+      enforceDirectiveAllowlist: true,
+    });
+    expect(reviewedManagedOverlap.status).toBe(0);
+    expect(reviewedManagedOverlap.stdout).toBe("");
+
+    for (const loadedConfig of [
+      `${expectedLoadedConfig}
+# configuration file /etc/nginx/conf.d/headscale.conf:
+proxy_set_header Connection $connection_upgrade;
+`,
+      `${expectedLoadedConfig}
+# configuration file /etc/nginx/conf.d/headscale.conf:
+map $http_upgrade $connection_upgrade {
+proxy_set_header Connection $connection_upgrade;
+# configuration file /etc/nginx/conf.d/unrelated-managed-overlap.conf:
+proxy_set_header Connection $connection_upgrade;
+`,
+    ]) {
+      const invalidManagedOverlap = runLegacyVhostValidation({
+        source: expectedLegacySource,
+        loadedConfig,
+        enforceDirectiveAllowlist: true,
+      });
+      expect(invalidManagedOverlap.status).not.toBe(0);
+      expect(invalidManagedOverlap.stdout).toContain(
+        "upgrade-map output is referenced outside the reviewed file",
+      );
+      expect(invalidManagedOverlap.stdout).not.toContain("$connection_upgrade");
+    }
 
     const customExternalOutputVariable = "$headscale_connection_upgrade";
     const customOutputExternallyReferenced = runLegacyVhostValidation({


### PR DESCRIPTION
# Relates to

Relates to #19800.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Exact head `43e64fc2f0c6e02815a0f667e7a83a1755e84a5a` is rebased directly onto `d7fd800d231738a2dccdc1e21a755d13ddd7af73` with zero conflicts.
- [x] Protected read-only run `31881328975` proved the only external owner is exact managed path `/etc/nginx/conf.d/headscale.conf` with exactly two references.
- [x] No nginx file, service, certificate, DNS record, or public route was mutated by the evidence run.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d7fd800d231738a2dccdc1e21a755d13ddd7af73:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop@d7fd800d231738a2dccdc1e21a755d13ddd7af73`; zero conflicts.
- [x] Full install, focused tests, exact-head Cloud verification, and exact-head root verification pass.

# Risks

Medium and staging-infrastructure-only. Retirement may rewrite the managed Headscale nginx vhost and remove the exact reviewed legacy vhost, but only in the existing transaction with both files backed up and rollback armed through nginx validation/reload, certificate/SNI/health proof, router convergence, daemon env convergence, worker restart, and final liveness. The new exception is deliberately narrower than the live state: exactly one external path, exactly `/etc/nginx/conf.d/headscale.conf`, and exactly two references. Any other count or path still exits before mutation.

# Background

## What does this PR do?

Protected inspection run `31881328975` showed that the legacy vhost's validated websocket-upgrade map output is referenced exactly twice by the managed canonical vhost. That is the expected migration overlap: the transaction backs up and replaces the managed vhost with a self-contained canonical configuration before removing the legacy file, then reruns the validator before deletion.

This patch accepts only that exact reviewed two-reference managed overlap. It continues to reject one reference, three or more references, a second path, an unknown owner, changed legacy bytes, an unreviewed directive, or any ownership/server-name drift.

## What kind of change is this?

Bug fix (non-breaking protected deployment hardening).

# Documentation changes needed?

The Headscale deployment runbook now documents the exact reviewed managed-overlap exception, replacement ordering, revalidation, and remaining fail-closed cases.

# Testing

- Exact-head Headscale workflow suite: 32/32, 412 assertions.
- Exact-head `bun install --frozen-lockfile`: pass, 3,823 installs checked, no changes.
- Exact-head `TURBO_FORCE=1 bun run verify:cloud`: 80/80, 0 cached.
- Exact-head `TURBO_FORCE=1 bun run verify`: 351/351, 0 cached; all repository audits and anti-larp clean.
- Exact-head Node syntax, changed-file Biome, guide parity, and diff-check: pass.

# Evidence Gate

<!-- evidence-head:43e64fc2f0c6e02815a0f667e7a83a1755e84a5a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] [20011-headscale-managed-overlap-inspection-31881328975.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20011-headscale-managed-overlap-inspection-31881328975.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, or agent behavior.
<!-- evidence-row:domain-artifacts -->
- [x] [20011-headscale-managed-overlap-domain-state-31881328975.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20011-headscale-managed-overlap-domain-state-31881328975.log)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

# Evidence Details

The generated-shell suite proves:

- exact managed path + exactly two references passes inspection and retirement validation;
- one managed reference fails;
- managed two plus any second path fails;
- arbitrary external/custom output references still fail without printing variable values;
- managed vhost install precedes legacy deletion and validation reruns between them;
- rollback remains armed through every downstream convergence and liveness gate.

## Known gaps / failures

After merge, the protected staging inspection must re-prove the exact live owner/count contract before retirement. Retirement must then prove exact digest binding, exclusive intended nginx ownership, identical dual-SAN public leaves, both public health endpoints, and downstream service liveness. The Cloudflare pages-domains lane remains independently blocked by insufficient protected token scopes.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@d7fd800d231738a2dccdc1e21a755d13ddd7af73:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@d7fd800d231738a2dccdc1e21a755d13ddd7af73:packages/skills/skills/contribute-to-eliza"} -->
