### PR TITLE
fix(cloud): reject non-numeric-suffixed env values in backup verifier config

### DIFF
--- a/packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts
@@ -332,6 +332,11 @@ describe("readBackupVerifierConfig", () => {
     expect(garbage.batchSize).toBe(10);
     expect(garbage.reVerifyIntervalMs).toBe(24 * 3_600_000);
     expect(garbage.maxDecryptBytesPerCycle).toBe(256 * 1024 * 1024);
+    expect(
+      readBackupVerifierConfig({
+        BACKUP_VERIFICATION_BATCH_SIZE: "7junk",
+      } as NodeJS.ProcessEnv).batchSize,
+    ).toBe(10);
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/agent-backup-verifier.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-verifier.ts
@@ -153,8 +153,10 @@ const CHAIN_LOOKUP_LIMIT = 1000;
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
-  const parsed = Number.parseInt(value, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  const normalized = value.trim();
+  if (!/^\d+$/.test(normalized)) return fallback;
+  const parsed = Number(normalized);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 function parseBooleanDefaultTrue(value: string | undefined): boolean {


### PR DESCRIPTION
# Relates to

Closes #20013.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] this PR targets `develop` and is branched directly off the current `origin/develop` tip.
- [x] focused package tests, lint, and typecheck pass on the exact head, see Testing below.
- [x] a reviewer can confirm the fix directly against the deterministic config-parser test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (fix, tests, via AgentRouter proxy), `anthropic/claude-sonnet-5` (independent re-verification)
<!-- attribution-row:client -->
- Agent tooling: `codex` (via AgentRouter proxy), `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] branched directly off the current `origin/develop` tip

# Risks

low. this only tightens env-var parsing for six operational tunables; every existing valid config value (a bare non-negative integer string, or an unset/empty value) behaves identically.

# Background

## What does this PR do?

`parsePositiveInt` in `agent-backup-verifier.ts` uses `Number.parseInt(value, 10)`, which stops at the first non-digit character instead of rejecting the whole string. `BACKUP_VERIFICATION_BATCH_SIZE="7junk"` parses to `7` and passes the `Number.isFinite(parsed) && parsed > 0` check, silently accepting a malformed value instead of falling back to the documented default.

confirmed directly:

```text
$ bun -e 'console.log(Number.parseInt("7junk", 10))'
7
```

this function gates six real tunables read from env: batch size, reverify interval hours, escalation threshold percent, min systemic sample, max decrypt bytes per cycle, errored alert streak, all real operational knobs for a backup-restorability verification system.

fix: require the whole trimmed string to match `^\d+$` before parsing, and use `Number.isSafeInteger` instead of `Number.isFinite` so an out-of-safe-integer-range digit string can't silently roundtrip through double precision either.

## What kind of change is this?

bug fix, non-breaking (every existing valid env value behaves identically).

# Documentation changes needed?

no, the fix restores the documented "valid positive integer or fall back to default" contract rather than changing the interface.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts`, the new assertion inside `opt-out flag and tunables parse; garbage falls back to defaults`, then the `parsePositiveInt` change itself.

## Detailed testing steps

```text
$ bun run --cwd packages/cloud/shared test -- src/lib/services/agent-backup-verifier.test.ts
34 pass
0 fail

$ bunx @biomejs/biome check packages/cloud/shared/src/lib/services/agent-backup-verifier.ts packages/cloud/shared/src/lib/services/agent-backup-verifier.test.ts
Checked 2 files in 46ms. No fixes applied.

$ bun run --cwd packages/cloud/shared typecheck
(no errors in touched files)
```

mutation-resistance verified independently: reverted just the source fix, kept the new assertion, reran, 33 pass / 1 fail. restored the fix, 34/34 green again.

# Evidence Gate

<!-- evidence-head:5cf78f1b7b71d2ea53ddf9aa5f75db1a2bec7e39 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes an env-var config parser, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - this changes an env-var config parser, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive product flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic unit test, the real transcript is included under domain artifacts.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code or network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real mutation-resistance run, captured directly:
  ```text
  red (source fix reverted, kept the new assertion):
  $ bun run --cwd packages/cloud/shared test -- src/lib/services/agent-backup-verifier.test.ts
  33 pass
  1 fail
  Ran 34 tests across 1 file.

  green (fix restored):
  $ bun run --cwd packages/cloud/shared test -- src/lib/services/agent-backup-verifier.test.ts
  34 pass
  0 fail
  Ran 34 tests across 1 file.
  ```
  confirms the new assertion genuinely detects the `Number.parseInt` leniency regression and the fix closes it, verified independently against the real repo (not just trusting the original transcript). also independently confirmed `Number.parseInt("7junk", 10) === 7` in a real bun REPL before writing this up.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface or visual text changed.

## Known gaps / failures

none. focused test suite (34/34), lint, and typecheck all pass clean on the exact head.

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran tests myself, confirmed the parseInt leniency directly, pushed via the GitHub Contents API since `git push` was stalling on this environment and this session's Codex run lost connection mid-write before it could commit or write its own report)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Contribution skill revision: N/A - direct interactive session, contribute-to-eliza skill not used
Compute receipt: N/A - Slop run-receipt install currently blocked by an unrelated site-deploy-lag issue (deployed skill archive predates recent develop changes)
Attribution status: self-reported