### PR TITLE
fix(ci): build core before cloud UI fixtures

### DIFF
--- a/.github/workflows/ui-e2e-gate.yml
+++ b/.github/workflows/ui-e2e-gate.yml
@@ -71,6 +71,12 @@ jobs:
       - name: Ensure generated shared i18n data
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
+      # Cloud-backed fixtures load the compiled Workerd surface through
+      # @elizaos/core/edge; source-mode resolution intentionally does not bypass
+      # the edge substitutions and Node-builtin stripping performed here.
+      - name: Build core runtime contract
+        run: bun run build:core
+
       - name: Install Playwright Chromium
         run: PLAYWRIGHT_INSTALL_CWD=packages/ui .github/scripts/install-playwright-browsers.sh chromium
 

--- a/packages/scripts/__tests__/github-action-pinning.test.ts
+++ b/packages/scripts/__tests__/github-action-pinning.test.ts
@@ -15,6 +15,7 @@ type WorkflowStep = {
   if?: string;
   name?: string;
   run?: string;
+  uses?: string;
 };
 
 const smokeBrowserInstallCommand =
@@ -102,6 +103,55 @@ function assertSmokeLanesCoreBootstrap(source: string): void {
   }
   if (e2eIndex < 0 || buildIndex >= e2eIndex) {
     throw new Error("Smoke lanes must build the core contract before E2E");
+  }
+}
+
+function assertUiCoreFixtureCoreBootstrap(source: string): void {
+  const workflow = Bun.YAML.parse(source) as {
+    jobs?: { "ui-core-fixture-e2e"?: { steps?: WorkflowStep[] } };
+  };
+  const steps = workflow.jobs?.["ui-core-fixture-e2e"]?.steps ?? [];
+  const setupIndex = steps.findIndex(
+    (step) =>
+      step.name === "Setup workspace dependencies" &&
+      step.uses === "./.github/actions/setup-bun-workspace",
+  );
+  const generationIndex = steps.findIndex(
+    (step) =>
+      step.name === "Ensure generated shared i18n data" &&
+      step.run === "node packages/app-core/scripts/ensure-shared-i18n-data.mjs",
+  );
+  const buildIndex = steps.findIndex(
+    (step) =>
+      step.name === "Build core runtime contract" &&
+      step.run === "bun run build:core",
+  );
+  const cloudFixtureIndex = steps.findIndex(
+    (step) =>
+      step.name === "Frontend hosting e2e" &&
+      step.run === "bun run --cwd packages/ui test:frontend-hosting-e2e",
+  );
+
+  if (
+    setupIndex < 0 ||
+    generationIndex < 0 ||
+    buildIndex < 0 ||
+    cloudFixtureIndex < 0
+  ) {
+    throw new Error(
+      "UI core fixtures must retain setup, generated data, core build, and cloud E2E steps",
+    );
+  }
+  if (
+    !(
+      setupIndex < generationIndex &&
+      generationIndex < buildIndex &&
+      buildIndex < cloudFixtureIndex
+    )
+  ) {
+    throw new Error(
+      "UI core fixtures must generate data and build the edge contract before cloud E2E",
+    );
   }
 }
 
@@ -279,6 +329,39 @@ describe("GitHub action supply-chain references", () => {
       ),
     ).toThrow(
       "Smoke lanes must build the core contract for cloud and zero-key work",
+    );
+  });
+
+  test("builds the compiled edge contract before cloud-backed UI fixtures", () => {
+    const source = readFileSync(
+      join(githubRoot, "workflows", "ui-e2e-gate.yml"),
+      "utf8",
+    );
+
+    expect(() => assertUiCoreFixtureCoreBootstrap(source)).not.toThrow();
+    expect(() =>
+      assertUiCoreFixtureCoreBootstrap(
+        source.replace(
+          "run: bun run build:core",
+          "run: echo core-build-removed",
+        ),
+      ),
+    ).toThrow(
+      "UI core fixtures must retain setup, generated data, core build, and cloud E2E steps",
+    );
+
+    const buildStep = `      - name: Build core runtime contract
+        run: bun run build:core
+
+`;
+    const afterCloudFixture = source
+      .replace(buildStep, "")
+      .replace(
+        "        run: bun run --cwd packages/ui test:frontend-hosting-e2e\n",
+        (command) => `${command}\n${buildStep}`,
+      );
+    expect(() => assertUiCoreFixtureCoreBootstrap(afterCloudFixture)).toThrow(
+      "UI core fixtures must generate data and build the edge contract before cloud E2E",
     );
   });
 


### PR DESCRIPTION
# Relates to

Closes #20010.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto exact current `origin/develop@d7fd800d231738a2dccdc1e21a755d13ddd7af73` with zero conflicts.
- [x] `bun run verify` passed after sync.
- [x] A reviewer can confirm the change works without reading the code from the hosted failure, unchanged real fixture run, workflow contract, and independent review below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/slopdotcash@332dc64deec632ac7746f237f0f30d4aad6050d5:skills/contribute-to-eliza/SKILL.md`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact head `69b1fcc6319e8d9b1d9e6d42d0eae0a417812401` is 0 behind / 1 ahead of current `origin/develop@d7fd800d231738a2dccdc1e21a755d13ddd7af73`.
- [x] `bun run verify` passes post-sync: 351/351 build/typecheck tasks plus repository audits.

# Risks

Low and explicit. The UI core fixture now pays one canonical `build:core` before cloud-backed browser work; recent clean runs take roughly 2m25s–2m38s. That cost is required because `@elizaos/core/edge` is intentionally compiled-only: the build applies Workerd substitutions and Node-builtin postprocessing. The workflow contains no duplicate core build.

# Background

## What does this PR do?

The clean UI cloud fixture installed workspace source and then booted Cloud API without first creating the compiled `@elizaos/core/edge` artifact imported by `@elizaos/shared/todo-cutover`. Hosted run [31881075993 / job 95003607517](https://github.com/elizaOS/eliza/actions/runs/31881075993/job/95003607517) failed with `Cannot find @elizaos/core/edge`.

This change runs canonical `bun run build:core` after generated shared i18n data and before frontend-hosting E2E. A workflow regression locks that exact order and rejects a missing, replaced, or late build step.

It deliberately does **not** add an `eliza-source` condition to `@elizaos/core/edge`; raw source would bypass the production edge artifact contract.

## What kind of change is this?

Bug fix (non-breaking CI/build-order correction).

# Documentation changes needed?

No product documentation change is needed; this changes only workflow ordering and its executable contract test.

# Testing

## Where should a reviewer start?

1. `.github/workflows/ui-e2e-gate.yml`
2. `packages/scripts/__tests__/github-action-pinning.test.ts`
3. Hosted pre-fix failure linked above

## Detailed testing steps

- Pre-fix clean installed checkout, after generated i18n: unchanged `bun run --cwd packages/ui test:frontend-hosting-e2e` failed while booting Cloud API because compiled-only `@elizaos/core/edge` was absent.
- Post-fix exact head:
  - `bun run build:core` — PASS, 58/58 tasks, including packaged edge import verification.
  - `bun test packages/scripts/__tests__/github-action-pinning.test.ts packages/core/src/__tests__/runtime-barrel.test.ts` — PASS, 19/19 tests and 58 assertions.
  - unchanged `bun run --cwd packages/ui test:frontend-hosting-e2e` — ALL GREEN in 71.84s across real PGlite migration, Cloud API, SIWE, publish/activate/rollback/delete/outage/recovery, 13 screenshots, and video.
  - `bun run verify` — PASS, 351/351 build/typecheck tasks and all repository audits.
  - focused Biome and `git diff --check` — PASS.
- Independent exact-head review: PASS, no P0–P3 findings; compiled-only edge guard, ordering, adversarial regression, cost, no-swap, and error-policy boundaries checked.

# Evidence Gate

<!-- evidence-head:69b1fcc6319e8d9b1d9e6d42d0eae0a417812401 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow/test-only diff; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow/test-only diff; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow changed; the unchanged real fixture emitted a video and 13 screenshots that were manually reviewed locally.
<!-- evidence-row:backend-logs -->
- [ ] N/A - workflow/test-only change; the hosted pre-fix job and exact post-fix command summaries are linked in Evidence Details
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/state behavior changed; unchanged real browser E2E passed its full publish/rollback/outage matrix.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no domain data behavior changed; real PGlite fixture lifecycle passed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual source changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

<details>
<summary>Exact-head result summary</summary>

```text
build:core: 58 successful / 58 total
workflow + edge contract: 19 pass / 0 fail / 58 assertions
frontend-hosting-e2e: ALL GREEN (71.84s)
verify: 351 successful / 351 total
independent review: PASS; no P0-P3
```

The post-fix E2E exercised real PGlite, Cloud API boot, SIWE, the real app, browser publish/activate/rollback/delete, outage, and recovery. Every generated screenshot and the recording were manually inspected.

</details>

## Screenshots (before / after) + video walkthrough

N/A - the diff changes workflow ordering and its contract test only.

## Audio / voice walkthrough

N/A - no voice, audio, transcript, TTS, or STT change.

## Known gaps / failures

`bun run audit:error-policy-ratchet` is not present on this exact `develop`; no production source, catch, logging, or error boundary changes are in the diff. The binding full `bun run verify` gate passed.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/slopdotcash@332dc64deec632ac7746f237f0f30d4aad6050d5
Attribution status: self-reported
— [codex-triage]
<!-- eliza-computer-attribution:v1 {"provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"332dc64deec632ac7746f237f0f30d4aad6050d5","status":"self-reported"} -->

