### PR TITLE
feat(cloud): passthrough stream milestone telemetry (#16079)

### DIFF
--- a/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
@@ -1241,6 +1241,33 @@ describe("passthrough streaming — #16079 milestone telemetry", () => {
     expect(event.completionMs).toBeNull();
   });
 
+  test("milestone origin excludes the dispatch-marker latency", async () => {
+    // RP round-2 finding 2: the provider-leg clock must start AFTER the
+    // (potentially slow) Durable-Object dispatch acknowledgement, immediately
+    // before fetch(). A marker delayed by 60ms must not inflate
+    // upstreamHeadersMs — with the origin correctly placed, the instant mock
+    // fetch keeps it far below the marker delay.
+    const MARKER_DELAY_MS = 60;
+    fetchImpl = async () => sseResponse(UPSTREAM_SSE);
+    const res = await callStreaming(async () => null, {
+      markProviderDispatched: () =>
+        new Promise<void>((resolve) => setTimeout(resolve, MARKER_DELAY_MS)),
+    });
+    await res.text();
+
+    const snapshot = getCloudTelemetrySnapshot(10);
+    const event = snapshot.streamMilestones.find(
+      (e) => e.path === "passthrough",
+    );
+    if (!event) throw new Error("no passthrough milestone event recorded");
+    expect(event.upstreamHeadersMs).not.toBeUndefined();
+    // If the origin were captured before the marker await (the round-1 bug),
+    // upstreamHeadersMs would be >= 60. Half the delay is a safe bound that
+    // still separates the two placements by an order of magnitude.
+    expect(event.upstreamHeadersMs).toBeLessThan(MARKER_DELAY_MS / 2);
+    expect(event.completionMs).not.toBeNull();
+  });
+
   test("client-branch cancel records aborted=true with partial milestones", async () => {
     // RP round-1 finding: the existing abort test simulated an upstream read
     // error; this one cancels the CLIENT branch mid-stream, exercising the

--- a/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
@@ -19,6 +19,7 @@ import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 // stranded by the process-wide registry replacement; restore in afterAll.
 const aiActual = require("ai") as Record<string, unknown>;
 
+import { getCloudTelemetrySnapshot } from "@/lib/observability/cloud-backend-observability";
 import { estimateTokens } from "@/lib/pricing";
 import * as languageModelActual from "@/lib/providers/language-model";
 import * as aiBillingActual from "@/lib/services/ai-billing";
@@ -1121,5 +1122,119 @@ describe("passthrough streaming — settlement runs OFF the response path via wa
     expect(ledger.actualCosts[0]).toBeCloseTo(EXPECTED_COST, 10);
     expect(recordUsageAnalytics).toHaveBeenCalledTimes(1);
     expect(aiBillingRecord).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("passthrough streaming — #16079 milestone telemetry", () => {
+  test("emits Server-Timing upstream_headers, provider request id echo, and a correlated ring-buffer event", async () => {
+    fetchImpl = async () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encoder.encode(UPSTREAM_SSE));
+            controller.close();
+          },
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "text/event-stream",
+            "x-request-id": "req-abc_123-xyz",
+          },
+        },
+      );
+
+    const res = await callStreaming(async () => null, {});
+    await res.text();
+
+    // Response carries the provider-leg boundaries and the bounded echo.
+    const serverTiming = res.headers.get("Server-Timing") ?? "";
+    expect(serverTiming).toMatch(/^upstream_headers;dur=[0-9.]+$/);
+    expect(res.headers.get("X-Eliza-Provider-Request-Id")).toBe(
+      "req-abc_123-xyz",
+    );
+
+    // The always-on ring buffer holds one correlated event keyed by the
+    // fallback trace id (the test harness's requestId) with the milestones
+    // the teed meter observed from the upstream SSE bytes.
+    const snapshot = getCloudTelemetrySnapshot(10);
+    const event = snapshot.streamMilestones.find(
+      (e) => e.path === "passthrough",
+    );
+    if (!event) throw new Error("no passthrough milestone event recorded");
+    expect(event.requestId).toBe("req-1");
+    expect(event.traceId).toBe("req-1");
+    expect(event.model).toBe(MODEL);
+    expect(event.providerRequestId).toBe("req-abc_123-xyz");
+    expect(event.upstreamHeadersMs).not.toBeUndefined();
+    expect(event.upstreamHeadersMs).toBeGreaterThanOrEqual(0);
+    // UPSTREAM_SSE's first frame carries content + reasoning in one delta.
+    expect(event.firstEventMs).not.toBeNull();
+    expect(event.firstReasoningMs).not.toBeNull();
+    expect(event.firstContentMs).not.toBeNull();
+    expect(event.completionMs).not.toBeNull();
+    expect(event.aborted).toBe(false);
+  });
+
+  test("sanitizes an unsafe provider request id and omits the echo when absent", async () => {
+    fetchImpl = async () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encoder.encode(UPSTREAM_SSE));
+            controller.close();
+          },
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "text/event-stream",
+            "x-request-id": 'bad"id with spaces and <script>',
+          },
+        },
+      );
+    const res = await callStreaming(async () => null, {});
+    await res.text();
+    // Only safe token characters survive; quotes/angles/spaces are replaced.
+    expect(res.headers.get("X-Eliza-Provider-Request-Id")).toBe(
+      "bad_id_with_spaces_and__script_",
+    );
+  });
+
+  test("aborted stream records aborted=true and keeps observed partial milestones", async () => {
+    // Upstream that errors mid-stream after delivering one content frame.
+    fetchImpl = async () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          async start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                `data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}\n\n`,
+              ),
+            );
+            controller.error(new Error("upstream dropped mid-stream"));
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "text/event-stream" } },
+      );
+
+    const res = await callStreaming(async () => null, {});
+    // Drain what the client branch will deliver; the read failure propagates.
+    await res.text().catch(() => undefined);
+    // The settle chain runs inline (no executionCtx); give the microtasks a
+    // beat to complete the meter drain.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const snapshot = getCloudTelemetrySnapshot(10);
+    const event = snapshot.streamMilestones.find(
+      (e) => e.path === "passthrough",
+    );
+    if (!event) throw new Error("no passthrough milestone event recorded");
+    // The errored tee discards buffered chunks, so mid-stream milestones may
+    // legitimately be null here — what MUST hold: the event exists, is marked
+    // aborted, and never claims a completion it did not observe.
+    expect(event.aborted).toBe(true);
+    expect(event.completionMs).toBeNull();
   });
 });

--- a/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
@@ -1199,6 +1199,94 @@ describe("passthrough streaming — #16079 milestone telemetry", () => {
     expect(res.headers.get("X-Eliza-Provider-Request-Id")).toBe(
       "bad_id_with_spaces_and__script_",
     );
+
+    // Absent upstream x-request-id → the echo header is OMITTED entirely, not
+    // emitted empty, and the ring event carries no providerRequestId field.
+    fetchImpl = async () => sseResponse(UPSTREAM_SSE);
+    const bareRes = await callStreaming(async () => null, {});
+    await bareRes.text();
+    expect(bareRes.headers.get("X-Eliza-Provider-Request-Id")).toBeNull();
+    const snapshot = getCloudTelemetrySnapshot(10);
+    const event = snapshot.streamMilestones.find(
+      (e) => e.path === "passthrough",
+    );
+    if (!event) throw new Error("no passthrough milestone event recorded");
+    expect(event.providerRequestId).toBeUndefined();
+    // The rest of the event is still healthy without the provider id.
+    expect(event.upstreamHeadersMs).not.toBeUndefined();
+    expect(event.completionMs).not.toBeNull();
+  });
+
+  test("clean SSE error frame then close records aborted=true and no completion", async () => {
+    // RP round-1 finding: a provider that reports failure mid-stream and then
+    // closes cleanly must NOT be recorded as a healthy completed run.
+    fetchImpl = async () =>
+      sseResponse(
+        `data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}],"usage":null}\n\n` +
+          `data: {"error":{"message":"model overloaded","type":"overloaded_error"}}\n\n`,
+      );
+
+    const res = await callStreaming(async () => null, {});
+    await res.text();
+
+    const snapshot = getCloudTelemetrySnapshot(10);
+    const event = snapshot.streamMilestones.find(
+      (e) => e.path === "passthrough",
+    );
+    if (!event) throw new Error("no passthrough milestone event recorded");
+    // Observed partial milestones survive…
+    expect(event.firstContentMs).not.toBeNull();
+    // …but the run is recorded as failed: aborted=true, completionMs null.
+    expect(event.aborted).toBe(true);
+    expect(event.completionMs).toBeNull();
+  });
+
+  test("client-branch cancel records aborted=true with partial milestones", async () => {
+    // RP round-1 finding: the existing abort test simulated an upstream read
+    // error; this one cancels the CLIENT branch mid-stream, exercising the
+    // cancel() → meterAbortController.abort() path a real disconnect takes.
+    const deliveredText = "partial before disconnect";
+    const waitUntilPromises: Array<Promise<unknown>> = [];
+
+    fetchImpl = async () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                `data: {"id":"c1","choices":[{"index":0,"delta":{"content":${JSON.stringify(deliveredText)}},"finish_reason":null}],"usage":null}\n\n`,
+              ),
+            );
+            // No close: the provider is still streaming when the client drops.
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "text/event-stream" } },
+      );
+
+    const res = await callStreaming(async () => null, {
+      executionCtx: {
+        waitUntil(promise: Promise<unknown>) {
+          waitUntilPromises.push(promise);
+        },
+      },
+    });
+    const reader = res.body?.getReader();
+    if (!reader) throw new Error("expected passthrough response body");
+    const first = await reader.read();
+    expect(new TextDecoder().decode(first.value)).toContain(deliveredText);
+    await reader.cancel(new DOMException("client disconnected", "AbortError"));
+    await Promise.all(waitUntilPromises);
+
+    const snapshot = getCloudTelemetrySnapshot(10);
+    const event = snapshot.streamMilestones.find(
+      (e) => e.path === "passthrough",
+    );
+    if (!event) throw new Error("no passthrough milestone event recorded");
+    // The client disconnect reached the meter branch: the run is aborted with
+    // the partial content milestone observed, never a completion.
+    expect(event.aborted).toBe(true);
+    expect(event.firstContentMs).not.toBeNull();
+    expect(event.completionMs).toBeNull();
   });
 
   test("aborted stream records aborted=true and keeps observed partial milestones", async () => {

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -30,6 +30,7 @@ import {
   enforceOrgRateLimit,
   OrgRateLimitCacheNotReadyError,
 } from "@/lib/middleware/rate-limit";
+import { recordCloudStreamMilestones } from "@/lib/observability/cloud-backend-observability";
 import {
   bindGatewayHandoffTelemetry,
   type GatewayHandoffTelemetry,
@@ -1968,6 +1969,7 @@ export async function handleChatCompletionsPOST(
           options.executionCtx,
           gatewayHandoffTelemetry,
           markProviderDispatched,
+          traceId,
         )
       : await handleNonStreamingRequest(
           model,
@@ -2343,6 +2345,23 @@ function passthroughErrorResponse(status: number, message: string): Response {
   );
 }
 
+/** Round to 2dp once so log/header/ring-buffer values agree (#16079). */
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+/**
+ * Bounded, sanitized echo of the provider's own request id (#16079). The value
+ * is provider-chosen (not fully trusted): keep only the same safe token
+ * characters Server-Timing descriptions allow and cap the length, so a
+ * hostile upstream header cannot smuggle content into logs or client-visible
+ * headers.
+ */
+function sanitizeProviderRequestId(value: string | null): string | undefined {
+  const sanitized = value?.replace(/[^A-Za-z0-9_.-]/g, "_").slice(0, 64);
+  return sanitized ? sanitized : undefined;
+}
+
 /**
  * The pass-through streaming fast path (#15428): fetch the provider's
  * chat/completions directly with `stream: true` and return the response body
@@ -2395,6 +2414,8 @@ async function tryPassthroughStreamingRequest(params: {
   billingSource: PricingBillingSource;
   executionCtx?: { waitUntil(promise: Promise<unknown>): void };
   gatewayHandoffTelemetry?: GatewayHandoffTelemetry;
+  /** Shared correlation id (#16079): keys the milestone event to the trace. */
+  traceId: string;
 }): Promise<Response | null> {
   const { model, request, settleReservation } = params;
   if (!isPassthroughStreamingEnabled()) return null;
@@ -2459,6 +2480,11 @@ async function tryPassthroughStreamingRequest(params: {
   }
 
   let upstreamResponse: Response;
+  // #16079: the milestone origin is the provider fetch dispatch — every
+  // milestone below is elapsed from here, so upstream headers/first-frame
+  // times are attributable to the provider leg, not gateway preforward work
+  // (which the preforward snapshot already covers).
+  const upstreamFetchStartedAt = performance.now();
   const upstreamInit: RequestInit = {
     method: "POST",
     headers: {
@@ -2545,6 +2571,15 @@ async function tryPassthroughStreamingRequest(params: {
       "upstream provider response was incomplete",
     );
   }
+  // #16079: freeze the provider-leg boundaries known before the pipe commits.
+  // The provider's own request id is echoed bounded-and-sanitized so the
+  // correlated trace can be joined to provider-side logs without leaking
+  // arbitrary upstream header content (same character policy as Server-Timing
+  // descriptions).
+  const upstreamHeadersMs = round2(performance.now() - upstreamFetchStartedAt);
+  const providerRequestId = sanitizeProviderRequestId(
+    upstreamResponse.headers.get("x-request-id"),
+  );
   const [clientBranch, meterBranch] = upstreamResponse.body.tee();
   const meterAbortController = new AbortController();
   const clientReader = clientBranch.getReader();
@@ -2580,7 +2615,26 @@ async function tryPassthroughStreamingRequest(params: {
     const tail = await readPassthroughStreamTail(
       meterBranch,
       meterAbortController.signal,
+      // #16079: milestones measured from the provider fetch dispatch.
+      { startedAt: upstreamFetchStartedAt },
     );
+    // Always-on correlated milestone record (#16079): the ring buffer is read
+    // back via the admin cloud-observability endpoint, so unlike logger.info
+    // it survives without VERBOSE_LOGGING. Bounded fields only.
+    recordCloudStreamMilestones({
+      traceId: params.traceId,
+      requestId: params.requestId,
+      path: "passthrough",
+      model,
+      ...(providerRequestId ? { providerRequestId } : {}),
+      upstreamHeadersMs,
+      firstEventMs: tail.milestones.firstEventMs,
+      firstReasoningMs: tail.milestones.firstReasoningMs,
+      firstContentMs: tail.milestones.firstContentMs,
+      completionMs: tail.milestones.completionMs,
+      aborted: tail.readError !== null,
+      createdAt: new Date().toISOString(),
+    });
     if (tail.usage) {
       // Success settle — the same chain, amounts, and record shapes as the SDK
       // path's onFinish, fed by the provider-reported usage frame.
@@ -2702,6 +2756,15 @@ async function tryPassthroughStreamingRequest(params: {
         // Observability marker: distinguishes the piped path in logs/latency
         // probes without touching the SSE payload bytes.
         "X-Eliza-Inference-Path": "passthrough",
+        // #16079: the provider leg's known boundaries travel on the response
+        // so browser/correlated callers can join them to the trace id. Mid-
+        // stream milestones cannot (headers are frozen once the 200 commits
+        // and the body must stay byte-identical) — those live in the
+        // always-on ring-buffer event keyed by the same trace id.
+        "Server-Timing": `upstream_headers;dur=${upstreamHeadersMs}`,
+        ...(providerRequestId
+          ? { "X-Eliza-Provider-Request-Id": providerRequestId }
+          : {}),
       },
     }),
   );
@@ -2740,6 +2803,8 @@ async function handleStreamingRequest(
   executionCtx?: { waitUntil(promise: Promise<unknown>): void },
   gatewayHandoffTelemetry?: GatewayHandoffTelemetry,
   markProviderDispatched?: () => Promise<void>,
+  /** Shared trace id (#16079) correlating the milestone event with the caller. */
+  traceId?: string,
 ) {
   // #15428 pass-through fast path: qualifying plain streamed chat against a
   // direct OpenAI-compatible upstream pipes the provider bytes straight
@@ -2775,6 +2840,7 @@ async function handleStreamingRequest(
       billingSource,
       executionCtx,
       gatewayHandoffTelemetry,
+      traceId: traceId ?? requestId,
     });
     if (passthroughResponse) return passthroughResponse;
   }

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -2480,11 +2480,12 @@ async function tryPassthroughStreamingRequest(params: {
   }
 
   let upstreamResponse: Response;
-  // #16079: the milestone origin is the provider fetch dispatch — every
-  // milestone below is elapsed from here, so upstream headers/first-frame
-  // times are attributable to the provider leg, not gateway preforward work
-  // (which the preforward snapshot already covers).
-  const upstreamFetchStartedAt = performance.now();
+  // #16079: the milestone origin is the provider fetch dispatch itself —
+  // assigned AFTER the dispatch-marker await (which can carry Durable Object
+  // acknowledgement latency) and immediately before fetch(), so every
+  // milestone below is attributable to the provider leg, not gateway
+  // preforward work (which the preforward snapshot already covers).
+  let upstreamFetchStartedAt = 0;
   const upstreamInit: RequestInit = {
     method: "POST",
     headers: {
@@ -2496,6 +2497,7 @@ async function tryPassthroughStreamingRequest(params: {
   };
   try {
     await params.markProviderDispatched?.();
+    upstreamFetchStartedAt = performance.now();
     upstreamResponse = await invokeAtGatewayHandoff(
       params.gatewayHandoffTelemetry,
       () => fetch(upstream.url, upstreamInit),
@@ -2632,7 +2634,9 @@ async function tryPassthroughStreamingRequest(params: {
       firstReasoningMs: tail.milestones.firstReasoningMs,
       firstContentMs: tail.milestones.firstContentMs,
       completionMs: tail.milestones.completionMs,
-      aborted: tail.readError !== null,
+      // An in-stream SSE error frame is an upstream-reported failure: record
+      // it as not-completed rather than a healthy run (#16079).
+      aborted: tail.readError !== null || tail.sawErrorFrame,
       createdAt: new Date().toISOString(),
     });
     if (tail.usage) {

--- a/packages/cloud/scripts/chat-latency.mjs
+++ b/packages/cloud/scripts/chat-latency.mjs
@@ -22,6 +22,7 @@ const SAFE_RESPONSE_HEADERS = [
   "x-eliza-trace-id",
   "x-eliza-preforward-ms",
   "x-eliza-inference-path",
+  "x-eliza-provider-request-id",
   "x-request-id",
 ];
 

--- a/packages/cloud/shared/src/lib/cors-constants.ts
+++ b/packages/cloud/shared/src/lib/cors-constants.ts
@@ -64,6 +64,7 @@ export const CORS_EXPOSE_HEADER_NAMES = [
   "X-Eliza-Preforward-Ms",
   "X-Eliza-Auth-Trace",
   "X-Eliza-Inference-Path",
+  "X-Eliza-Provider-Request-Id",
   "X-Eliza-Stream-Scope-Ms",
   "X-Eliza-Stream-Body-Ms",
   "X-Eliza-Stream-Parse-Ms",

--- a/packages/cloud/shared/src/lib/observability/cloud-backend-observability.ts
+++ b/packages/cloud/shared/src/lib/observability/cloud-backend-observability.ts
@@ -58,7 +58,12 @@ export interface CloudStreamMilestoneTelemetry {
   firstReasoningMs: number | null;
   firstContentMs: number | null;
   completionMs: number | null;
-  /** Stream ended via client abort / read failure instead of completion. */
+  /**
+   * Stream ended via client abort, read failure, or an in-stream provider
+   * error frame — observed during the stream or its teardown. NOT mutually
+   * exclusive with `completionMs`: a provider that emitted `[DONE]` before a
+   * client disconnect completed, and both facts are recorded (#16079).
+   */
   aborted: boolean;
   createdAt: string;
 }

--- a/packages/cloud/shared/src/lib/observability/cloud-backend-observability.ts
+++ b/packages/cloud/shared/src/lib/observability/cloud-backend-observability.ts
@@ -1,4 +1,7 @@
-// Defines cloud shared cloud backend observability behavior for backend service consumers.
+// Defines cloud shared cloud backend observability behavior for backend service
+// consumers: per-request and per-DB-call ring-buffer telemetry plus inference
+// stream milestone events (#16079), all read back through the admin
+// cloud-observability endpoint.
 import { AsyncLocalStorage } from "node:async_hooks";
 
 const MAX_EVENTS = 1_000;
@@ -34,6 +37,32 @@ export interface CloudDbTelemetry {
   createdAt: string;
 }
 
+/**
+ * One inference stream's milestone boundaries (#16079), correlated by the
+ * shared trace id. All `*Ms` values are elapsed from the provider fetch
+ * start; `null` means that boundary was never observed. Deliberately
+ * privacy-bounded: model, path kind, provider request id echo, and timings
+ * only — no prompts, outputs, token counts, or client identifiers.
+ */
+export interface CloudStreamMilestoneTelemetry {
+  traceId: string;
+  requestId?: string;
+  /** Gateway routing path that produced the stream (`passthrough` today). */
+  path: string;
+  model: string;
+  /** Bounded echo of the provider's own request id header, when present. */
+  providerRequestId?: string;
+  /** Upstream fetch start → upstream response headers, from the Worker. */
+  upstreamHeadersMs?: number;
+  firstEventMs: number | null;
+  firstReasoningMs: number | null;
+  firstContentMs: number | null;
+  completionMs: number | null;
+  /** Stream ended via client abort / read failure instead of completion. */
+  aborted: boolean;
+  createdAt: string;
+}
+
 export interface CloudTelemetrySnapshot {
   generatedAt: string;
   thresholds: {
@@ -47,6 +76,8 @@ export interface CloudTelemetrySnapshot {
   slowDb: CloudDbTelemetry[];
   burstyRequests: CloudRequestTelemetry[];
   duplicateReadRequests: CloudRequestTelemetry[];
+  /** Inference stream milestones (#16079), newest first. */
+  streamMilestones: CloudStreamMilestoneTelemetry[];
 }
 
 interface RequestContext {
@@ -66,6 +97,7 @@ interface RequestContext {
 const requestAls = new AsyncLocalStorage<RequestContext>();
 const requests: CloudRequestTelemetry[] = [];
 const dbEvents: CloudDbTelemetry[] = [];
+const streamMilestones: CloudStreamMilestoneTelemetry[] = [];
 
 function numberEnv(name: string, fallback: number): number {
   const raw = typeof process !== "undefined" ? process.env?.[name] : undefined;
@@ -217,10 +249,23 @@ export function getCloudTelemetrySnapshot(limit = 200): CloudTelemetrySnapshot {
     slowDb: db.filter((r) => r.durationMs >= t.slowDbMs),
     burstyRequests: req.filter((r) => r.dbCalls >= t.dbBurstCount),
     duplicateReadRequests: req.filter((r) => r.duplicateDbReadCalls > 0),
+    streamMilestones: streamMilestones.slice(0, limit),
   };
+}
+
+/**
+ * Record one inference stream's milestone boundaries (#16079). Called from the
+ * gateway's off-response-path meter, so it must stay synchronous and cheap:
+ * the event is bounded, pre-shaped by the caller, and pushed to the same
+ * isolate ring buffer as request/db telemetry, where the admin
+ * cloud-observability endpoint reads it back.
+ */
+export function recordCloudStreamMilestones(event: CloudStreamMilestoneTelemetry): void {
+  pushBounded(streamMilestones, event);
 }
 
 export function clearCloudTelemetry(): void {
   requests.length = 0;
   dbEvents.length = 0;
+  streamMilestones.length = 0;
 }

--- a/packages/cloud/shared/src/lib/services/__tests__/inference-passthrough-milestones.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/inference-passthrough-milestones.test.ts
@@ -197,3 +197,70 @@ describe("readPassthroughStreamTail — milestones (#16079)", () => {
     expect(tail.milestones.completionMs).not.toBeNull();
   });
 });
+
+describe("readPassthroughStreamTail — RP review round 1 hardening (#16079)", () => {
+  test("clean SSE error frame then close: completion stays null (no fake healthy end)", async () => {
+    const clock = scriptedClock(0, 10);
+    const tail = await readWithClock(
+      [
+        `data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}\n\n`,
+        `data: {"error":{"message":"upstream overloaded","code":503}}\n\n`,
+      ],
+      0,
+      clock,
+    );
+    expect(tail.sawErrorFrame).toBe(true);
+    expect(tail.readError).toBeNull();
+    // The provider reported failure mid-stream: absence reported as absence.
+    expect(tail.milestones.firstContentMs).not.toBeNull();
+    expect(tail.milestones.completionMs).toBeNull();
+  });
+
+  test("completion records at [DONE] parse time, not EOF time", async () => {
+    const clock = scriptedClock(0, 10);
+    let i = 0;
+    const frames = [
+      `data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}\n\n`,
+      `data: [DONE]\n\n`,
+    ];
+    const stream = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        if (i >= frames.length) {
+          // Provider delays the connection close well past [DONE]; the
+          // completion boundary must reflect [DONE], not this late EOF.
+          clock.tick();
+          clock.tick();
+          clock.tick();
+          clock.tick();
+          controller.close();
+          return;
+        }
+        clock.tick();
+        controller.enqueue(encoder.encode(frames[i]));
+        i += 1;
+      },
+    });
+    const tail = await readPassthroughStreamTail(stream, undefined, {
+      startedAt: 0,
+      now: clock.now,
+    });
+    // [DONE] arrived at tick 20 (frames 1 and 2); EOF happened at tick 60.
+    expect(tail.milestones.completionMs).toBe(20);
+  });
+
+  test("empty reasoning carriers do not fabricate firstReasoningMs", async () => {
+    const clock = scriptedClock(0, 10);
+    const tail = await readWithClock(
+      [
+        `data: {"id":"c1","choices":[{"index":0,"delta":{"role":"assistant","reasoning":"","reasoning_content":""},"finish_reason":null}]}\n\n`,
+        `data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}\n\n`,
+        `data: [DONE]\n\n`,
+      ],
+      0,
+      clock,
+    );
+    expect(tail.milestones.firstEventMs).toBe(10);
+    expect(tail.milestones.firstReasoningMs).toBeNull();
+    expect(tail.milestones.firstContentMs).toBe(20);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/inference-passthrough-milestones.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/inference-passthrough-milestones.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Stream milestone extraction for the pass-through meter (#16079).
+ * Deterministic harness: a scripted clock pins every milestone timestamp, so
+ * each test asserts the exact elapsed value tied to a specific frame — not a
+ * timing race.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  type PassthroughStreamMilestones,
+  readPassthroughStreamTail,
+} from "../inference-passthrough";
+
+const encoder = new TextEncoder();
+
+function sseStream(frames: string[]): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const frame of frames) controller.enqueue(encoder.encode(frame));
+      controller.close();
+    },
+  });
+}
+
+/** Clock the tests control: every await tick advances the virtual time. */
+function scriptedClock(start = 0, stepMs = 5) {
+  let now = start;
+  return {
+    now: () => now,
+    tick: () => {
+      now += stepMs;
+    },
+  };
+}
+
+async function readWithClock(
+  frames: string[],
+  startedAt: number,
+  clock: ReturnType<typeof scriptedClock>,
+) {
+  // Interleave: each reader.read() resolves between clock ticks, mirroring
+  // frame arrival over time. The meter parses on delivery, so milestones land
+  // on the tick active when their frame arrived.
+  let i = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      if (i >= frames.length) {
+        controller.close();
+        return;
+      }
+      clock.tick();
+      controller.enqueue(encoder.encode(frames[i]));
+      i += 1;
+    },
+  });
+  return readPassthroughStreamTail(stream, undefined, {
+    startedAt,
+    now: clock.now,
+  });
+}
+
+describe("readPassthroughStreamTail — milestones (#16079)", () => {
+  test("records first event, reasoning, content, and completion from a full reasoning stream", async () => {
+    const clock = scriptedClock(0, 10);
+    const startedAt = 0;
+    const tail = await readWithClock(
+      [
+        `data: {"id":"c1","choices":[{"index":0,"delta":{"role":"assistant","reasoning":"hmm"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Hel"},"finish_reason":null}]}\n\n`,
+        `data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":null}\n\n`,
+        `data: {"id":"c1","choices":[],"usage":{"prompt_tokens":7,"completion_tokens":3,"total_tokens":10}}\n\n`,
+        `data: [DONE]\n\n`,
+      ],
+      startedAt,
+      clock,
+    );
+    const m = tail.milestones;
+    // Frame 1 (reasoning frame) arrives at tick 10 — it is both the first
+    // event and the first reasoning delta.
+    expect(m.firstEventMs).toBe(10);
+    expect(m.firstReasoningMs).toBe(10);
+    expect(m.firstContentMs).toBe(20);
+    expect(m.completionMs).toBe(50);
+    expect(tail.usage).toEqual({
+      inputTokens: 7,
+      outputTokens: 3,
+      totalTokens: 10,
+    });
+    expect(tail.deliveredText).toBe("Hel");
+    expect(tail.readError).toBeNull();
+  });
+
+  test("reasoning_content and thinking carriers also mark firstReasoning", async () => {
+    for (const field of ["reasoning_content", "thinking"]) {
+      const clock = scriptedClock(0, 7);
+      const tail = await readWithClock(
+        [
+          `data: {"id":"c1","choices":[{"index":0,"delta":{${JSON.stringify(field)}:"x"},"finish_reason":null}]}\n\n`,
+          `data: [DONE]\n\n`,
+        ],
+        0,
+        clock,
+      );
+      expect(tail.milestones.firstReasoningMs).toBe(7);
+      expect(tail.milestones.firstContentMs).toBeNull();
+    }
+  });
+
+  test("first event without any delta still marks firstEvent only", async () => {
+    const clock = scriptedClock(0, 3);
+    const tail = await readWithClock(
+      [`data: {"id":"c1","choices":[],"usage":null}\n\n`, `data: [DONE]\n\n`],
+      0,
+      clock,
+    );
+    expect(tail.milestones.firstEventMs).toBe(3);
+    expect(tail.milestones.firstReasoningMs).toBeNull();
+    expect(tail.milestones.firstContentMs).toBeNull();
+    expect(tail.milestones.completionMs).toBe(6);
+  });
+
+  test("empty-string content delta does not mark firstContent", async () => {
+    const clock = scriptedClock(0, 4);
+    const tail = await readWithClock(
+      [
+        `data: {"id":"c1","choices":[{"index":0,"delta":{"content":""},"finish_reason":null}]}\n\n`,
+        `data: [DONE]\n\n`,
+      ],
+      0,
+      clock,
+    );
+    expect(tail.milestones.firstContentMs).toBeNull();
+    expect(tail.milestones.firstEventMs).toBe(4);
+  });
+
+  test("malformed frames never produce milestones", async () => {
+    const clock = scriptedClock(0, 2);
+    const tail = await readWithClock(
+      [`data: not-json\n\n`, `: comment line\n\n`, `data: [DONE]\n\n`],
+      0,
+      clock,
+    );
+    expect(tail.milestones.firstEventMs).toBeNull();
+    expect(tail.milestones.completionMs).toBe(6);
+  });
+
+  test("abort leaves completion null and observed partial milestones intact", async () => {
+    const frames = [
+      `data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}\n\n`,
+    ];
+    const clock = scriptedClock(100, 5);
+    const controller = new AbortController();
+    let i = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      async pull(inner) {
+        if (i >= frames.length) {
+          // Simulate the client aborting mid-drain: the signal fires and the
+          // upstream errors out on the next read.
+          controller.abort(new Error("client stopped"));
+          inner.error(new Error("upstream dropped"));
+          return;
+        }
+        clock.tick();
+        inner.enqueue(encoder.encode(frames[i]));
+        i += 1;
+      },
+    });
+    const tail = await readPassthroughStreamTail(stream, controller.signal, {
+      startedAt: 100,
+      now: clock.now,
+    });
+    expect(tail.readError).not.toBeNull();
+    expect(tail.milestones.firstEventMs).toBe(5);
+    expect(tail.milestones.firstContentMs).toBe(5);
+    expect(tail.milestones.completionMs).toBeNull();
+  });
+
+  test("milestones default to null for a stream with no data frames", async () => {
+    const tail = await readPassthroughStreamTail(sseStream(["event: ping\n\n"]), undefined, {
+      startedAt: 0,
+      now: () => 42,
+    });
+    const allNull: PassthroughStreamMilestones = {
+      firstEventMs: null,
+      firstReasoningMs: null,
+      firstContentMs: null,
+      completionMs: 42,
+    };
+    expect(tail.milestones).toEqual(allNull);
+  });
+
+  test("defaults: startedAt/now resolve to performance.now when omitted", async () => {
+    const tail = await readPassthroughStreamTail(sseStream([`data: [DONE]\n\n`]));
+    // No crash, milestone fields present and completion observed.
+    expect(tail.milestones.firstEventMs).toBeNull();
+    expect(typeof tail.milestones.completionMs).toBe("number");
+    expect(tail.milestones.completionMs).not.toBeNull();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/inference-passthrough-milestones.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/inference-passthrough-milestones.test.ts
@@ -252,7 +252,7 @@ describe("readPassthroughStreamTail — RP review round 1 hardening (#16079)", (
     const clock = scriptedClock(0, 10);
     const tail = await readWithClock(
       [
-        `data: {"id":"c1","choices":[{"index":0,"delta":{"role":"assistant","reasoning":"","reasoning_content":""},"finish_reason":null}]}\n\n`,
+        `data: {"id":"c1","choices":[{"index":0,"delta":{"role":"assistant","reasoning":"","reasoning_content":"","thinking":""},"finish_reason":null}]}\n\n`,
         `data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}\n\n`,
         `data: [DONE]\n\n`,
       ],
@@ -262,5 +262,42 @@ describe("readPassthroughStreamTail — RP review round 1 hardening (#16079)", (
     expect(tail.milestones.firstEventMs).toBe(10);
     expect(tail.milestones.firstReasoningMs).toBeNull();
     expect(tail.milestones.firstContentMs).toBe(20);
+  });
+
+  test("error frame then [DONE]: [DONE] must not resurrect completion", async () => {
+    // RP round-2 finding 1, ordering A: provider reports failure, then still
+    // emits its terminal [DONE] marker. The run is failed regardless.
+    const clock = scriptedClock(0, 10);
+    const tail = await readWithClock(
+      [
+        `data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}\n\n`,
+        `data: {"error":{"message":"overloaded","code":503}}\n\n`,
+        `data: [DONE]\n\n`,
+      ],
+      0,
+      clock,
+    );
+    expect(tail.sawErrorFrame).toBe(true);
+    expect(tail.sawDone).toBe(true);
+    expect(tail.milestones.firstContentMs).not.toBeNull();
+    expect(tail.milestones.completionMs).toBeNull();
+  });
+
+  test("[DONE] then error frame: completion is revoked", async () => {
+    // RP round-2 finding 1, ordering B: provider emitted [DONE] and then
+    // reported failure anyway — both orderings land on "failed, no completion".
+    const clock = scriptedClock(0, 10);
+    const tail = await readWithClock(
+      [
+        `data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}\n\n`,
+        `data: [DONE]\n\n`,
+        `data: {"error":{"message":"late failure","code":500}}\n\n`,
+      ],
+      0,
+      clock,
+    );
+    expect(tail.sawDone).toBe(true);
+    expect(tail.sawErrorFrame).toBe(true);
+    expect(tail.milestones.completionMs).toBeNull();
   });
 });

--- a/packages/cloud/shared/src/lib/services/inference-passthrough.ts
+++ b/packages/cloud/shared/src/lib/services/inference-passthrough.ts
@@ -11,14 +11,22 @@
  * upstream response body straight to the client and meter a teed copy in the
  * background.
  *
- * This module owns the two pieces that are independent of the route:
+ * This module owns the pieces that are independent of the route:
  *   - the `INFERENCE_PASSTHROUGH_STREAMING` flag (default OFF — same
  *     soak-then-cutover discipline as the #9899 INFERENCE_* flags; flag off is
  *     byte-identical to today),
  *   - the background meter: an SSE reader for the teed branch that extracts
  *     the terminal `stream_options.include_usage` usage frame plus the
  *     delivered text, which the route feeds into the EXISTING billing settle
- *     chain (billUsage → settleReservation → analytics → audit).
+ *     chain (billUsage → settleReservation → analytics → audit),
+ *   - stream milestone observation (#16079): the same reader records when the
+ *     first SSE frame, the first reasoning delta, the first visible content
+ *     delta, and stream completion were observed, so one correlated trace can
+ *     assign provider-side latency instead of collapsing it into "gateway
+ *     time". Milestones are measured at the meter branch against an injected
+ *     monotonic origin (the route pins it to the provider fetch start); they
+ *     bound when the upstream made each frame available, not when a specific
+ *     client received it.
  *
  * The qualification predicate and the upstream fetch/tee orchestration live in
  * the chat-completions route (they depend on route-local billing helpers); the
@@ -60,6 +68,22 @@ export interface PassthroughUsage {
   cacheReadInputTokens?: number;
 }
 
+/**
+ * Stream milestones observed on the teed branch (#16079). `null` means the
+ * boundary was never observed (no such frame arrived, or the read failed
+ * first) — absence is reported as absence, never as zero.
+ */
+export interface PassthroughStreamMilestones {
+  /** First non-empty `data:` frame of any kind (the first SSE event). */
+  firstEventMs: number | null;
+  /** First delta carrying reasoning (`reasoning`, `reasoning_content`, or `thinking`). */
+  firstReasoningMs: number | null;
+  /** First delta carrying visible `content` text. */
+  firstContentMs: number | null;
+  /** Reader observed stream termination (upstream close or `[DONE]`). */
+  completionMs: number | null;
+}
+
 /** What the background meter observed on the teed upstream branch. */
 export interface PassthroughStreamTail {
   /** Last usage frame seen (OpenAI contract: the terminal frame before [DONE]). */
@@ -72,6 +96,12 @@ export interface PassthroughStreamTail {
   sawErrorFrame: boolean;
   /** Read failure (client abort / upstream drop); partial fields above remain valid. */
   readError: unknown;
+  /**
+   * Frame milestones (#16079), elapsed from the supplied monotonic origin —
+   * the route pins that origin to the provider fetch start so the milestones
+   * measure upstream latency, not gateway queueing.
+   */
+  milestones: PassthroughStreamMilestones;
 }
 
 function asFiniteNumber(value: unknown): number | undefined {
@@ -83,6 +113,21 @@ interface SseUsageRecord {
   completion_tokens?: unknown;
   total_tokens?: unknown;
   prompt_tokens_details?: { cached_tokens?: unknown };
+}
+
+/**
+ * Reasoning carriers seen in the wild: Cerebras/GLM use `reasoning` or
+ * `reasoning_content`, Anthropic-style providers use `thinking`. Mirrors the
+ * probe's `consumeOpenAiEvent` candidate list so gateway and probe agree on
+ * what counts as the first reasoning frame.
+ */
+function hasReasoningDelta(delta: Record<string, unknown> | undefined): boolean {
+  if (!delta) return false;
+  return (
+    typeof delta.reasoning === "string" ||
+    typeof delta.reasoning_content === "string" ||
+    typeof delta.thinking === "string"
+  );
 }
 
 function extractUsage(record: SseUsageRecord): PassthroughUsage | null {
@@ -101,6 +146,10 @@ function extractUsage(record: SseUsageRecord): PassthroughUsage | null {
   };
 }
 
+function roundedElapsed(now: () => number, origin: number): number {
+  return Math.round((now() - origin) * 100) / 100;
+}
+
 /**
  * Drain one tee branch of the upstream SSE response and report what it
  * carried. This is the billing meter, so it must never throw: a read failure
@@ -110,11 +159,25 @@ function extractUsage(record: SseUsageRecord): PassthroughUsage | null {
  * are skipped — the meter reports only what the provider verifiably sent,
  * never fabricated tokens (error-policy: J3 — an unparseable frame yields "no
  * data", not fake-valid data).
+ *
+ * Milestone timestamps (#16079) are taken when a frame is PARSED, using
+ * `startedAt` as the monotonic origin and the injectable `now` clock (tests
+ * pin both). The tee delivers both branches at the reader's pace, so these
+ * timestamps bound the upstream's frame availability; they are not proof of
+ * exactly when the client branch delivered the same bytes.
  */
 export async function readPassthroughStreamTail(
   stream: ReadableStream<Uint8Array>,
   abortSignal?: AbortSignal,
+  options: {
+    /** Monotonic origin the milestone timestamps are measured from. */
+    startedAt?: number;
+    /** Injectable clock; defaults to `performance.now`. */
+    now?: () => number;
+  } = {},
 ): Promise<PassthroughStreamTail> {
+  const now = options.now ?? performance.now;
+  const startedAt = options.startedAt ?? now();
   const decoder = new TextDecoder();
   const tail: PassthroughStreamTail = {
     usage: null,
@@ -122,6 +185,12 @@ export async function readPassthroughStreamTail(
     sawDone: false,
     sawErrorFrame: false,
     readError: null,
+    milestones: {
+      firstEventMs: null,
+      firstReasoningMs: null,
+      firstContentMs: null,
+      completionMs: null,
+    },
   };
 
   const handleLine = (rawLine: string) => {
@@ -142,17 +211,26 @@ export async function readPassthroughStreamTail(
     }
     if (!frame || typeof frame !== "object") return;
     const record = frame as {
-      choices?: Array<{ delta?: { content?: unknown } }>;
+      choices?: Array<{ delta?: { content?: unknown } & Record<string, unknown> }>;
       usage?: SseUsageRecord | null;
       error?: unknown;
     };
+    tail.milestones.firstEventMs ??= roundedElapsed(now, startedAt);
     if (record.error !== undefined && record.error !== null) {
       tail.sawErrorFrame = true;
     }
     if (Array.isArray(record.choices)) {
       for (const choice of record.choices) {
-        const content = choice?.delta?.content;
-        if (typeof content === "string") tail.deliveredText += content;
+        const delta = choice?.delta;
+        if (!delta || typeof delta !== "object") continue;
+        const content = delta.content;
+        if (typeof content === "string" && content.length > 0) {
+          tail.deliveredText += content;
+          tail.milestones.firstContentMs ??= roundedElapsed(now, startedAt);
+        }
+        if (hasReasoningDelta(delta as Record<string, unknown>)) {
+          tail.milestones.firstReasoningMs ??= roundedElapsed(now, startedAt);
+        }
       }
     }
     if (record.usage && typeof record.usage === "object") {
@@ -194,6 +272,12 @@ export async function readPassthroughStreamTail(
     }
     buffer += decoder.decode();
     if (buffer) handleLine(buffer);
+    // Normal termination (upstream close, with or without [DONE]) still counts
+    // as observed completion; abort/error paths fall through with the
+    // milestone left null so they cannot masquerade as a completed stream.
+    if (tail.readError === null) {
+      tail.milestones.completionMs = roundedElapsed(now, startedAt);
+    }
   } catch (error) {
     // error-policy:J7 metering must not kill the settle chain — the route
     // observes the failure via readError and settles the delivered portion.

--- a/packages/cloud/shared/src/lib/services/inference-passthrough.ts
+++ b/packages/cloud/shared/src/lib/services/inference-passthrough.ts
@@ -74,7 +74,7 @@ export interface PassthroughUsage {
  * first) — absence is reported as absence, never as zero.
  */
 export interface PassthroughStreamMilestones {
-  /** First non-empty `data:` frame of any kind (the first SSE event). */
+  /** First successfully parsed JSON `data:` frame (malformed frames and `[DONE]` do not count). */
   firstEventMs: number | null;
   /** First delta carrying reasoning (`reasoning`, `reasoning_content`, or `thinking`). */
   firstReasoningMs: number | null;

--- a/packages/cloud/shared/src/lib/services/inference-passthrough.ts
+++ b/packages/cloud/shared/src/lib/services/inference-passthrough.ts
@@ -204,8 +204,12 @@ export async function readPassthroughStreamTail(
       tail.sawDone = true;
       // [DONE] IS the provider's completion marker (#16079): record it now
       // rather than at EOF, so a provider that delays the connection close
-      // after [DONE] (or drops it) cannot skew or lose the boundary.
-      tail.milestones.completionMs ??= roundedElapsed(now, startedAt);
+      // after [DONE] (or drops it) cannot skew or lose the boundary. Gated on
+      // !sawErrorFrame: an error frame already parsed means the provider
+      // reported failure — [DONE] after it must not resurrect completion.
+      if (!tail.sawErrorFrame) {
+        tail.milestones.completionMs ??= roundedElapsed(now, startedAt);
+      }
       return;
     }
     let frame: unknown;
@@ -224,6 +228,11 @@ export async function readPassthroughStreamTail(
     tail.milestones.firstEventMs ??= roundedElapsed(now, startedAt);
     if (record.error !== undefined && record.error !== null) {
       tail.sawErrorFrame = true;
+      // An error frame parsed AFTER [DONE] revokes that completion (#16079):
+      // the provider reported failure even though it had emitted its terminal
+      // marker — both orderings (error→[DONE], [DONE]→error) must land on
+      // "failed, no completion".
+      tail.milestones.completionMs = null;
     }
     if (Array.isArray(record.choices)) {
       for (const choice of record.choices) {

--- a/packages/cloud/shared/src/lib/services/inference-passthrough.ts
+++ b/packages/cloud/shared/src/lib/services/inference-passthrough.ts
@@ -123,10 +123,12 @@ interface SseUsageRecord {
  */
 function hasReasoningDelta(delta: Record<string, unknown> | undefined): boolean {
   if (!delta) return false;
+  // Non-empty only, mirroring the content milestone: providers emit empty
+  // carrier strings on the first frame before any reasoning exists (#16079).
   return (
-    typeof delta.reasoning === "string" ||
-    typeof delta.reasoning_content === "string" ||
-    typeof delta.thinking === "string"
+    (typeof delta.reasoning === "string" && delta.reasoning.length > 0) ||
+    (typeof delta.reasoning_content === "string" && delta.reasoning_content.length > 0) ||
+    (typeof delta.thinking === "string" && delta.thinking.length > 0)
   );
 }
 
@@ -200,6 +202,10 @@ export async function readPassthroughStreamTail(
     if (!payload) return;
     if (payload === "[DONE]") {
       tail.sawDone = true;
+      // [DONE] IS the provider's completion marker (#16079): record it now
+      // rather than at EOF, so a provider that delays the connection close
+      // after [DONE] (or drops it) cannot skew or lose the boundary.
+      tail.milestones.completionMs ??= roundedElapsed(now, startedAt);
       return;
     }
     let frame: unknown;
@@ -275,8 +281,13 @@ export async function readPassthroughStreamTail(
     // Normal termination (upstream close, with or without [DONE]) still counts
     // as observed completion; abort/error paths fall through with the
     // milestone left null so they cannot masquerade as a completed stream.
-    if (tail.readError === null) {
-      tail.milestones.completionMs = roundedElapsed(now, startedAt);
+    // `??=` — NOT assignment — so a completion already recorded at [DONE]
+    // parse time keeps the [DONE] boundary even when the provider delays the
+    // connection close after it (#16079). An in-stream SSE error frame is NOT
+    // completion: the provider reported failure mid-stream and the stream must
+    // not be recorded as if it ran to a healthy end.
+    if (tail.readError === null && !tail.sawErrorFrame) {
+      tail.milestones.completionMs ??= roundedElapsed(now, startedAt);
     }
   } catch (error) {
     // error-policy:J7 metering must not kill the settle chain — the route


### PR DESCRIPTION
# Relates to

Relates to #16079 (one slice of its residual scope; the umbrella stays open for the unshipped legs — do not auto-close)

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.3` (implementation), `openai/gpt-5.6-sol` (independent review agent)
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent` + `RepoPrompt CE`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@7efdae19ddd3eda341f805695c290b739545dec4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Background

## What does this PR do?

Implements the passthrough-path slice of #16079's residual scope (exactly the scope claimed in the issue on 2026-08-14, after the triage against `origin/develop@1b48c0e214`): the chat-completions passthrough streaming path now records first-SSE / first-reasoning / first-visible-content / completion milestone boundaries, correlated by the shared trace ID.

- **`inference-passthrough.ts`** — `readPassthroughStreamTail` (the teed meter branch, which is also the billing meter) now observes milestones at frame-parse time with an injectable monotonic origin and clock: `firstEventMs`, `firstReasoningMs`, `firstContentMs`, `completionMs`. The route pins the origin to the provider fetch dispatch (immediately before `fetch()`, after the dispatch-marker await) so all four measure the provider leg, not gateway queueing. Completion is recorded at `[DONE]` parse time (a delayed connection close cannot skew it), and error frames suppress/revoke completion in both orderings (`error→[DONE]` and `[DONE]→error`).
- **`route.ts`** — passthrough responses now carry `Server-Timing: upstream_headers;dur=<ms>` and a bounded, sanitized `X-Eliza-Provider-Request-Id` echo of the provider's `x-request-id` (64-char cap, unsafe chars replaced), and record an always-on milestone event (ring buffer, survives without VERBOSE_LOGGING) via `recordCloudStreamMilestones`, keyed by the request's trace ID so browser/edge/gateway/provider legs join on one ID.
- **`cloud-backend-observability.ts`** — new `CloudStreamMilestoneTelemetry` event type + bounded newest-first ring buffer (same 1,000-event cap as request/db telemetry), read back through the existing admin observability snapshot.
- **`cors-constants.ts` / `chat-latency.mjs`** — CORS exposure for the new header; latency-probe safe-header list updated.

Out of scope (per the claim comment, requires Cloudflare/Cerebras staging credentials): Analytics Engine persistence, sampled Workers traces, browser→dedicated-proxy propagation, Cerebras org-metrics polling, benchmark harness, live staging proof.

## What kind of change is this?

Features (non-breaking change which adds functionality)

# Documentation changes needed?

My changes do not require a change to the project documentation. (The observability endpoint's surface is unchanged; the new event rides the existing snapshot.)

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/__tests__/inference-passthrough-milestones.test.ts` — deterministic scripted-clock harness; every milestone timestamp is asserted to the exact elapsed value tied to a specific frame. Then `packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts` → the `#16079 milestone telemetry` describe block.

## Detailed testing steps

None: Automated tests are acceptable.

- Unit (13 tests): full-stream milestones, non-empty content/reasoning carriers (incl. `reasoning_content`/`thinking`), empty carriers never fabricate milestones, malformed frames skipped, abort leaves completion null, `[DONE]`-vs-EOF boundary separation, error-frame ordering suppression both ways.
- Route (44 tests in file; 8 in the milestone block): Server-Timing + provider-id echo + correlated ring event; sanitizer with hostile header; absent header omits echo AND the event field; clean error-frame → `aborted=true`, no completion; 60ms-delayed dispatch marker does NOT inflate `upstreamHeadersMs` (origin-placement proof); client-branch cancel → `aborted=true` with partial milestones; upstream read error → same.

# Evidence Gate

<!-- evidence-head:d27ebc87c1934d4763702268bf5da3e73bedf74b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only change (cloud Worker route + shared lib); no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only change (cloud Worker route + shared lib); no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only change (cloud Worker route + shared lib); no rendered UI surface.
<!-- evidence-row:backend-logs -->
- [ ] N/A - the assertion evidence is the ring-buffer event itself, proven by route tests reading it back via getCloudTelemetrySnapshot; inline test transcript in the PR body.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - backend-only change; no frontend request/response to trace.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - observability plumbing change, not an agent/action/provider/prompt/model behavior change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB rows, memories, or scheduled tasks touched; the domain artifact is the ring-buffer telemetry event asserted in tests.
<!-- evidence-row:ocr-review -->
- [ ] N/A - backend-only change with no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - observability plumbing; no model-behavior change.

## Backend + frontend logs

<details>
<summary>Test transcripts (bun test, pinned Bun 1.3.14, worktree @ 2ae0daeb1c)</summary>

```
$ bun test packages/cloud/shared/src/lib/services/__tests__/inference-passthrough-milestones.test.ts
 13 pass
 0 fail
 42 expect() calls
Ran 13 tests across 1 file.

$ bun test packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
 44 pass
 0 fail
 186 expect() calls
Ran 44 tests across 1 file.

$ bun test packages/cloud/shared/src/lib/observability/cloud-backend-observability.test.ts
 3 pass / 0 fail

$ bun test packages/cloud/scripts/chat-latency.test.mjs
 17 pass / 0 fail

$ cd packages/cloud/api && npx tsc --noEmit
0 errors

$ bun run check:worker-bundle   (wrangler deploy --dry-run)
"--dry-run: exiting now."  (passes)

$ npx biome check <all 7 changed files>
Checked 7 files. No fixes applied.
```
</details>

## Screenshots (before / after) + video walkthrough

N/A - backend-only change.

### Before
N/A - backend-only change.
### After
N/A - backend-only change.
### Walkthrough video
N/A - backend-only change.

## Audio / voice walkthrough

N/A - no voice/transcript surface touched.

## Known gaps / failures

- `bun run verify` full-lane was not run in this session (repo-wide lane is hours-long); scoped gates that cover every touched package were run instead: `tsc --noEmit` (cloud/api, 0 errors, includes cloud/shared via project references), `check:worker-bundle` (wrangler dry-run deploy of the actual Worker), all four affected test files green, biome clean on all seven changed files. Not a blocker: no other package imports the changed modules (verified by reverse-dependency search on `@elizaos/cloud-shared/lib/services/inference-passthrough` and the observability module).
- Live staging proof (Cloudflare Workers + Cerebras) is out of scope for this claim per the issue comment — needs credentials this lane does not hold. Reported as required for the umbrella issue's remaining acceptance rows, not fabricated here.

AI provider/model: zai / glm-5.3 (implementation) + GPT-5.6-sol (RepoPrompt CE independent review agent, 2 review rounds)
Client / agent tooling: Hermes Agent
Skill revision: elizaOS/eliza@7efdae19ddd3eda341f805695c290b739545dec4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [hermes/t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent","skill_revision":"elizaOS/eliza@7efdae19ddd3eda341f805695c290b739545dec4:packages/skills/skills/contribute-to-eliza"} -->