### PR TITLE
docs(actions): sync generated runtime catalog

### DIFF
--- a/packages/docs/action-catalog.md
+++ b/packages/docs/action-catalog.md
@@ -15,7 +15,7 @@ This catalog is generated from `packages/prompts/specs/**` by `bun run --cwd pac
 - **Plugin overlay actions:** 11
 - **Canonical providers:** 23
 - **Core providers:** 23
-- **Registered runtime actions:** 167
+- **Registered runtime actions:** 168
 
 ## Actions
 
@@ -466,6 +466,7 @@ list. Regenerate this document after changing the registered action surface.
 - `PROXY_STATUS` — `plugins/plugin-anthropic-proxy/src/actions/proxy-status.action.ts`
 - `REDACT_TRANSCRIPT` — `plugins/plugin-local-inference/src/actions/transcript-permissioning.ts`
 - `REGENERATE_APP_API_KEY` — `plugins/plugin-cloud-apps/src/actions/regenerate-app-api-key.ts`
+- `REMINDERS` — `plugins/plugin-scheduling/src/shared-reminders.ts`
 - `RESOLVE_REFERENT` — `plugins/plugin-personal-assistant/src/actions/resolve-referent.ts`
 - `RESOLVE_REQUEST` — `plugins/plugin-personal-assistant/src/actions/resolve-request.ts`
 - `RETRIEVE_CHILD_AGENT_RESULTS` — `packages/core/src/features/sub-agent-credentials/actions/retrieve-child-agent-results.ts`
@@ -510,7 +511,7 @@ list. Regenerate this document after changing the registered action surface.
 - `VOICE_CALL` — `plugins/plugin-personal-assistant/src/actions/voice-call.ts`
 - `WALLET` — `plugins/plugin-wallet/src/chains/wallet-action.ts`
 - `WEB_FETCH` — `plugins/plugin-coding-tools/src/actions/web-fetch.ts`
-- `WEB_SEARCH` — `plugins/plugin-coding-tools/src/actions/web-search.ts`
+- `WEB_SEARCH` — `plugins/plugin-coding-tools/src/actions/web-search.ts`, `plugins/plugin-web-search/src/edge.ts`
 - `WINDOW` — `plugins/plugin-computeruse/src/actions/window.ts`
 - `WITHDRAW_APP_EARNINGS` — `plugins/plugin-cloud-apps/src/actions/withdraw-app-earnings.ts`
 - `WORK_THREAD` — `plugins/plugin-personal-assistant/src/actions/work-thread.ts`


### PR DESCRIPTION
Closes #20022.

Regenerates the authoritative action catalog after the Shared `REMINDERS` action and edge `WEB_SEARCH` implementation entered the runtime graph. This is the exact output of `bun run --cwd packages/prompts build:action-docs`; no generator or runtime source changed.

Validation:

- `bun run --cwd packages/prompts build:action-docs` — PASS and idempotent
- `git diff --check` — PASS
- exact base root `bun run lint` — 132/132 tasks
- exact base root `bun run build` — 123/123 tasks; view bundle guard 19/19
- exact base root `bun run typecheck` — 219/219 tasks

## Contribution provenance

- AI assistance: yes — scoped diagnosis, generation, validation, and PR preparation.
- Models used: openai/gpt-5.6-sol
- Client / agent tooling: Codex Desktop
- Contribution skill revision: elizaOS/eliza@d7fd800d231738a2dccdc1e21a755d13ddd7af73:packages/skills/skills/contribute-to-eliza
- Attribution status: self-reported

<!-- evidence-head:5ba948dd74f746bf5bb2534ee2ac708c698fa7ae -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - generated Markdown reference only; no rendered product surface changes.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - generated Markdown reference only; exact diff is the review artifact.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive behavior changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime changed; generator and root gate results are listed above.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no external domain state; the generated Markdown file in the sole PR diff is the complete artifact.

— [nubs-review-action-catalog]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@d7fd800d231738a2dccdc1e21a755d13ddd7af73:packages/skills/skills/contribute-to-eliza"} -->
