### PR TITLE
fix(cloud): serialize X OAuth refresh in a Durable Object

### DIFF
--- a/packages/cloud/api/__tests__/twitter-oauth-coordinator-wrangler.test.ts
+++ b/packages/cloud/api/__tests__/twitter-oauth-coordinator-wrangler.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Pins the deploy-time Durable Object binding for X refresh coordination in
+ * local, staging, and production Worker environments.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const wrangler = readFileSync(
+  new URL("../wrangler.toml", import.meta.url),
+  "utf8",
+);
+
+describe("X OAuth refresh coordinator deployment contract", () => {
+  test("binds one coordinator namespace in every Worker environment", () => {
+    expect(
+      wrangler.match(/name = "TWITTER_OAUTH_REFRESH_COORDINATORS"/g),
+    ).toHaveLength(3);
+    expect(
+      wrangler.match(/class_name = "TwitterOAuthRefreshCoordinator"/g),
+    ).toHaveLength(3);
+  });
+
+  test("registers the Durable Object class migration", () => {
+    expect(wrangler).toContain('tag = "twitter-oauth-refresh-coordinator-v1"');
+    expect(wrangler).toContain(
+      'new_sqlite_classes = ["TwitterOAuthRefreshCoordinator"]',
+    );
+  });
+});

--- a/packages/cloud/api/__tests__/twitter-token-connection-role.test.ts
+++ b/packages/cloud/api/__tests__/twitter-token-connection-role.test.ts
@@ -10,20 +10,23 @@
  */
 
 import { describe, expect, mock, test } from "bun:test";
+import type { Bindings } from "@/types/cloud-worker-env";
 
-const getBrokerCredentials = mock(
-  async (_orgId: string, _userId: string, role: "agent" | "owner") => ({
-    authMode: "oauth2" as const,
-    accessToken: `token-for-${role}`,
-    expiresAt: null,
-    scope: null,
-    twitterUserId: null,
-  }),
+const coordinatorFetch = mock(
+  async (_input: RequestInfo | URL, init?: RequestInit) => {
+    const request = JSON.parse(String(init?.body)) as {
+      connectionRole: "agent" | "owner";
+    };
+    return Response.json({
+      auth_mode: "oauth2",
+      access_token: `token-for-${request.connectionRole}`,
+    });
+  },
 );
-
-mock.module("@/lib/services/twitter-automation", () => ({
-  twitterAutomationService: { getBrokerCredentials },
-}));
+const getByName = mock((_name: string) => ({ fetch: coordinatorFetch }));
+const env = {
+  TWITTER_OAUTH_REFRESH_COORDINATORS: { getByName },
+} as unknown as Bindings;
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg: mock(async () => ({
@@ -36,35 +39,47 @@ mock.module("@/lib/auth/workers-hono-auth", () => ({
 const { default: app } = await import("../v1/twitter/token/route");
 
 async function get(path: string): Promise<Response> {
-  return await app.request(path, { method: "GET" });
+  return await app.request(path, { method: "GET" }, env);
 }
 
 describe("GET /api/v1/twitter/token — connectionRole boundary", () => {
   test("missing connectionRole defaults to the agent connection", async () => {
-    getBrokerCredentials.mockClear();
+    coordinatorFetch.mockClear();
+    getByName.mockClear();
     const res = await get("/");
     expect(res.status).toBe(200);
-    expect(getBrokerCredentials.mock.calls[0]?.[2]).toBe("agent");
+    expect(getByName).toHaveBeenCalledWith("org-1:agent");
+    expect(await res.json()).toMatchObject({ access_token: "token-for-agent" });
   });
 
   test("explicit agent and owner pass through exactly", async () => {
-    getBrokerCredentials.mockClear();
+    coordinatorFetch.mockClear();
     expect((await get("/?connectionRole=agent")).status).toBe(200);
-    expect(getBrokerCredentials.mock.calls[0]?.[2]).toBe("agent");
+    expect(
+      JSON.parse(String(coordinatorFetch.mock.calls[0]?.[1]?.body)),
+    ).toMatchObject({
+      organizationId: "org-1",
+      userId: "user-1",
+      connectionRole: "agent",
+    });
 
-    getBrokerCredentials.mockClear();
+    coordinatorFetch.mockClear();
     expect((await get("/?connectionRole=owner")).status).toBe(200);
-    expect(getBrokerCredentials.mock.calls[0]?.[2]).toBe("owner");
+    expect(
+      JSON.parse(String(coordinatorFetch.mock.calls[0]?.[1]?.body)),
+    ).toMatchObject({
+      connectionRole: "owner",
+    });
   });
 
   test("garbage roles are a 400, never a silent owner vend", async () => {
-    getBrokerCredentials.mockClear();
+    coordinatorFetch.mockClear();
     for (const bad of ["admin", "Owner", "OWNER", "agent%20", "root", ""]) {
       const res = await get(`/?connectionRole=${bad}`);
       expect(res.status).toBe(400);
       const body = (await res.json()) as { error?: string };
       expect(body.error).toBe("invalid_connection_role");
     }
-    expect(getBrokerCredentials).not.toHaveBeenCalled();
+    expect(coordinatorFetch).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -12,11 +12,16 @@ import cloudApiWorker, {
   isUnsupportedLegacyWildcardHostname,
   redirectFrontendHost,
   SharedRuntimeConversation,
+  TwitterOAuthRefreshCoordinator,
 } from "./index";
 import { resetProvidersResponseCacheForTests } from "./steward/embedded";
 
 test("exports the shared-runtime conversation Durable Object", () => {
   expect(typeof SharedRuntimeConversation).toBe("function");
+});
+
+test("exports the X OAuth refresh Durable Object", () => {
+  expect(typeof TwitterOAuthRefreshCoordinator).toBe("function");
 });
 
 describe("thin inference entry dispatch", () => {

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -30,6 +30,7 @@ export { InferenceAdmissionGate } from "./inference-admission-gate";
 export { OnboardingSessionCoordinator } from "./onboarding-session-coordinator";
 export { SharedRuntimeConversation } from "./shared-runtime-conversation";
 export { isThinStewardPublicPath } from "./steward/public-paths";
+export { TwitterOAuthRefreshCoordinator } from "./twitter-oauth-refresh-coordinator";
 
 let appPromise: Promise<Hono<AppEnv>> | undefined;
 const inferenceAppPromises = new Map<string, Promise<Hono<AppEnv>>>();

--- a/packages/cloud/api/src/twitter-oauth-refresh-coordinator.test.ts
+++ b/packages/cloud/api/src/twitter-oauth-refresh-coordinator.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Deterministic Durable Object boundary coverage for X credential refresh
+ * serialization. The broker is injected; no provider or database is mocked as
+ * the system under test is the cross-request coordinator itself.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import type { TwitterBrokerCredentials } from "@/lib/services/twitter-automation";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import { TwitterOAuthRefreshCoordinator } from "./twitter-oauth-refresh-coordinator";
+
+function request(role: "agent" | "owner" = "agent"): Request {
+  return new Request("https://twitter-oauth.internal/credentials", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      organizationId: "org-1",
+      userId: "user-1",
+      connectionRole: role,
+    }),
+  });
+}
+
+describe("TwitterOAuthRefreshCoordinator", () => {
+  test("serializes concurrent requests for one Durable Object instance", async () => {
+    let active = 0;
+    let maxActive = 0;
+    let releaseFirst: () => void = () => undefined;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let markFirstEntered: () => void = () => undefined;
+    const firstEntered = new Promise<void>((resolve) => {
+      markFirstEntered = resolve;
+    });
+    let calls = 0;
+    let providerRefreshes = 0;
+    let fresh = false;
+    const getBrokerCredentials = mock(
+      async (): Promise<TwitterBrokerCredentials> => {
+        calls += 1;
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        if (!fresh) {
+          providerRefreshes += 1;
+          markFirstEntered();
+          await firstBlocked;
+          fresh = true;
+        }
+        active -= 1;
+        return {
+          authMode: "oauth2",
+          accessToken: "fresh-token",
+          expiresAt: 123,
+          scope: "tweet.read",
+          twitterUserId: "x-user",
+        };
+      },
+    );
+    const object = new TwitterOAuthRefreshCoordinator(
+      {} as DurableObjectState,
+      {} as AppEnv["Bindings"],
+      { getBrokerCredentials },
+    );
+
+    const first = object.fetch(request());
+    const second = object.fetch(request());
+    await firstEntered;
+    expect(calls).toBe(1);
+    releaseFirst();
+
+    const [firstResponse, secondResponse] = await Promise.all([first, second]);
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(maxActive).toBe(1);
+    expect(calls).toBe(2);
+    expect(providerRefreshes).toBe(1);
+    const secondBody = (await secondResponse.json()) as Record<string, unknown>;
+    expect(secondBody).toEqual({
+      auth_mode: "oauth2",
+      access_token: "fresh-token",
+      expires_at: 123,
+      scopes: "tweet.read",
+      user_id: "x-user",
+    });
+  });
+
+  test("rejects malformed internal requests before reaching the broker", async () => {
+    const getBrokerCredentials = mock(
+      async (): Promise<TwitterBrokerCredentials> => null,
+    );
+    const object = new TwitterOAuthRefreshCoordinator(
+      {} as DurableObjectState,
+      {} as AppEnv["Bindings"],
+      { getBrokerCredentials },
+    );
+    const response = await object.fetch(
+      new Request("https://twitter-oauth.internal/credentials", {
+        method: "POST",
+        body: JSON.stringify({
+          organizationId: "org-1",
+          connectionRole: "agent",
+        }),
+      }),
+    );
+    expect(response.status).toBe(400);
+    expect(getBrokerCredentials).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/src/twitter-oauth-refresh-coordinator.ts
+++ b/packages/cloud/api/src/twitter-oauth-refresh-coordinator.ts
@@ -1,0 +1,154 @@
+/**
+ * Serializes X OAuth credential vending for one organization and connection
+ * role. The Durable Object is the production cross-isolate authority; Worker
+ * KV is eventually consistent and cannot safely lease a single-use token.
+ */
+
+import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
+import {
+  type TwitterBrokerCredentials,
+  twitterAutomationService,
+} from "@/lib/services/twitter-automation";
+import { logger } from "@/lib/utils/logger";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+interface CredentialRequest {
+  organizationId: string;
+  userId: string;
+  connectionRole: "agent" | "owner";
+}
+
+interface TwitterCredentialBroker {
+  getBrokerCredentials(
+    organizationId: string,
+    userId: string,
+    connectionRole: "agent" | "owner",
+  ): Promise<TwitterBrokerCredentials>;
+}
+
+function boundedId(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= 180;
+}
+
+function isCredentialRequest(value: unknown): value is CredentialRequest {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    boundedId(candidate.organizationId) &&
+    boundedId(candidate.userId) &&
+    (candidate.connectionRole === "agent" ||
+      candidate.connectionRole === "owner")
+  );
+}
+
+function publicCredentialResponse(
+  credentials: TwitterBrokerCredentials,
+  connectionRole: "agent" | "owner",
+): Response {
+  if (!credentials) {
+    return Response.json(
+      {
+        error: "no_x_connection",
+        message:
+          "No X (Twitter) connection found for this organization. Connect via the connectors page.",
+        connectionRole,
+      },
+      { status: 404 },
+    );
+  }
+  if (credentials.authMode === "oauth1a") {
+    const values = credentials.credentials;
+    return Response.json({
+      auth_mode: "oauth1" as const,
+      consumer_key: values.TWITTER_API_KEY,
+      consumer_secret: values.TWITTER_API_SECRET_KEY,
+      access_token: values.TWITTER_ACCESS_TOKEN,
+      access_token_secret: values.TWITTER_ACCESS_TOKEN_SECRET,
+      ...(values.TWITTER_USER_ID ? { user_id: values.TWITTER_USER_ID } : {}),
+    });
+  }
+  return Response.json({
+    auth_mode: "oauth2" as const,
+    access_token: credentials.accessToken,
+    ...(credentials.expiresAt !== null
+      ? { expires_at: credentials.expiresAt }
+      : {}),
+    ...(credentials.scope ? { scopes: credentials.scope } : {}),
+    ...(credentials.twitterUserId
+      ? { user_id: credentials.twitterUserId }
+      : {}),
+  });
+}
+
+export class TwitterOAuthRefreshCoordinator {
+  private readonly env: AppEnv["Bindings"];
+  private readonly broker: TwitterCredentialBroker;
+  private operationQueue: Promise<void> = Promise.resolve();
+
+  constructor(
+    _state: DurableObjectState,
+    env: AppEnv["Bindings"],
+    broker: TwitterCredentialBroker = twitterAutomationService,
+  ) {
+    this.env = env;
+    this.broker = broker;
+  }
+
+  private async serialize<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.operationQueue;
+    let release: () => void = () => undefined;
+    this.operationQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    return this.serialize(async () => {
+      try {
+        if (
+          request.method !== "POST" ||
+          new URL(request.url).pathname !== "/credentials"
+        ) {
+          return Response.json({ error: "Not found" }, { status: 404 });
+        }
+        const body: unknown = await request.json();
+        if (!isCredentialRequest(body)) {
+          return Response.json(
+            { error: "Invalid credential request" },
+            { status: 400 },
+          );
+        }
+        const credentials = await runWithCloudBindingsAsync(this.env, () =>
+          this.broker.getBrokerCredentials(
+            body.organizationId,
+            body.userId,
+            body.connectionRole,
+          ),
+        );
+        return publicCredentialResponse(credentials, body.connectionRole);
+      } catch (error) {
+        // error-policy:J1 the internal Durable Object transport boundary emits
+        // an explicit failed response; it never vends a stale credential.
+        logger.error(
+          "[TwitterOAuthRefreshCoordinator] credential vend failed",
+          {
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+        return Response.json(
+          {
+            error: "x_credential_refresh_failed",
+            message: "X credential refresh failed.",
+          },
+          { status: 502 },
+        );
+      }
+    });
+  }
+}

--- a/packages/cloud/api/v1/twitter/token/route.ts
+++ b/packages/cloud/api/v1/twitter/token/route.ts
@@ -2,7 +2,6 @@
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
-import { twitterAutomationService } from "@/lib/services/twitter-automation";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
@@ -64,42 +63,31 @@ app.get("/", async (c) => {
     }
     const role: "agent" | "owner" = requestedRole ?? "agent";
 
-    const broker = await twitterAutomationService.getBrokerCredentials(
-      user.organization_id,
-      user.id,
-      role,
-    );
-
-    if (!broker) {
+    const coordinator = c.env.TWITTER_OAUTH_REFRESH_COORDINATORS;
+    if (!coordinator) {
       return c.json(
         {
-          error: "no_x_connection",
-          message:
-            "No X (Twitter) connection found for this organization. Connect via the connectors page.",
-          connectionRole: role,
+          error: "x_credential_coordinator_unavailable",
+          message: "X credential coordinator is unavailable.",
         },
-        404,
+        503,
       );
     }
-
-    if (broker.authMode === "oauth1a") {
-      const creds = broker.credentials;
-      return c.json({
-        auth_mode: "oauth1" as const,
-        consumer_key: creds.TWITTER_API_KEY,
-        consumer_secret: creds.TWITTER_API_SECRET_KEY,
-        access_token: creds.TWITTER_ACCESS_TOKEN,
-        access_token_secret: creds.TWITTER_ACCESS_TOKEN_SECRET,
-        ...(creds.TWITTER_USER_ID ? { user_id: creds.TWITTER_USER_ID } : {}),
+    const response = await coordinator
+      .getByName(`${user.organization_id}:${role}`)
+      .fetch("https://twitter-oauth.internal/credentials", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          organizationId: user.organization_id,
+          userId: user.id,
+          connectionRole: role,
+        }),
       });
-    }
-
-    return c.json({
-      auth_mode: "oauth2" as const,
-      access_token: broker.accessToken,
-      ...(broker.expiresAt !== null ? { expires_at: broker.expiresAt } : {}),
-      ...(broker.scope ? { scopes: broker.scope } : {}),
-      ...(broker.twitterUserId ? { user_id: broker.twitterUserId } : {}),
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
     });
   } catch (error) {
     return failureResponse(c, error);

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -121,6 +121,10 @@ class_name = "AnonymousChatGate"
 name = "ONBOARDING_SESSIONS"
 class_name = "OnboardingSessionCoordinator"
 
+[[durable_objects.bindings]]
+name = "TWITTER_OAUTH_REFRESH_COORDINATORS"
+class_name = "TwitterOAuthRefreshCoordinator"
+
 [[migrations]]
 tag = "shared-runtime-conversations-v1"
 new_sqlite_classes = ["SharedRuntimeConversation"]
@@ -136,6 +140,10 @@ new_sqlite_classes = ["AnonymousChatGate"]
 [[migrations]]
 tag = "onboarding-session-coordinator-v1"
 new_sqlite_classes = ["OnboardingSessionCoordinator"]
+
+[[migrations]]
+tag = "twitter-oauth-refresh-coordinator-v1"
+new_sqlite_classes = ["TwitterOAuthRefreshCoordinator"]
 
 # General API limits and queues may use Railway Redis via REDIS_URL. Inference
 # routes never connect to it: Cloudflare Rate Limiting bindings protect ingress,
@@ -620,6 +628,10 @@ class_name = "AnonymousChatGate"
 name = "ONBOARDING_SESSIONS"
 class_name = "OnboardingSessionCoordinator"
 
+[[env.staging.durable_objects.bindings]]
+name = "TWITTER_OAUTH_REFRESH_COORDINATORS"
+class_name = "TwitterOAuthRefreshCoordinator"
+
 [[env.staging.ratelimits]]
 name = "GLOBAL_RATE_LIMITER"
 namespace_id = "1615311"
@@ -841,6 +853,10 @@ class_name = "AnonymousChatGate"
 [[env.production.durable_objects.bindings]]
 name = "ONBOARDING_SESSIONS"
 class_name = "OnboardingSessionCoordinator"
+
+[[env.production.durable_objects.bindings]]
+name = "TWITTER_OAUTH_REFRESH_COORDINATORS"
+class_name = "TwitterOAuthRefreshCoordinator"
 
 [[env.production.ratelimits]]
 name = "GLOBAL_RATE_LIMITER"

--- a/packages/cloud/shared/src/lib/services/twitter-automation/index.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/index.error-policy.test.ts
@@ -23,6 +23,8 @@ const oauth2Behavior: {
   requestToken: async () => ({ access_token: "access-tok", scope: "tweet.read tweet.write" }),
 };
 const secretStore: Record<string, string | null> = {};
+const secretWriteOrder: string[] = [];
+let failSecretNames = new Set<string>();
 
 class MockTwitterApi {
   constructor(_config: unknown) {}
@@ -45,6 +47,8 @@ mock.module("../secrets", () => ({
   secretsService: {
     get: async (_org: string, name: string) => secretStore[name] ?? null,
     create: async (args: { name: string; value: string }) => {
+      secretWriteOrder.push(args.name);
+      if (failSecretNames.has(args.name)) throw new Error(`induced failure: ${args.name}`);
       if (secretStore[args.name] != null) {
         throw new Error(`Secret '${args.name}' already exists`);
       }
@@ -55,6 +59,8 @@ mock.module("../secrets", () => ({
         .filter(([, value]) => value != null)
         .map(([name]) => ({ id: name, name })),
     rotate: async (id: string, _org: string, value: string) => {
+      secretWriteOrder.push(id);
+      if (failSecretNames.has(id)) throw new Error(`induced failure: ${id}`);
       secretStore[id] = value;
     },
     delete: async (id: string) => {
@@ -80,6 +86,8 @@ async function loadService() {
 describe("TwitterAutomationService error policy", () => {
   beforeEach(() => {
     for (const key of Object.keys(secretStore)) delete secretStore[key];
+    secretWriteOrder.length = 0;
+    failSecretNames = new Set();
     twitterApiBehavior.me = async () => ({ data: { username: "alice", id: "42" } });
     oauth2Behavior.requestToken = async () => ({
       access_token: "access-tok",
@@ -221,6 +229,29 @@ describe("TwitterAutomationService error policy", () => {
       expect(secretStore.TWITTER_AGENT_OAUTH2_ACCESS_TOKEN).toBe("rotated-tok");
       expect(secretStore.TWITTER_AGENT_OAUTH2_REFRESH_TOKEN).toBe("refresh-2");
       expect(Number(secretStore.TWITTER_AGENT_OAUTH2_EXPIRES_AT)).toBe(result.expiresAt as number);
+    });
+
+    test("persists the rotated refresh token before starting fallible sibling writes", async () => {
+      secretStore.TWITTER_AGENT_OAUTH2_ACCESS_TOKEN = "stale-tok";
+      secretStore.TWITTER_AGENT_OAUTH2_REFRESH_TOKEN = "refresh-1";
+      secretStore.TWITTER_AGENT_OAUTH2_EXPIRES_AT = String(Math.floor(Date.now() / 1000) - 10);
+      failSecretNames = new Set(["TWITTER_AGENT_OAUTH2_ACCESS_TOKEN"]);
+      oauth2Behavior.requestToken = async () => ({
+        access_token: "rotated-tok",
+        refresh_token: "refresh-2",
+        scope: "tweet.read",
+        expires_in: 7200,
+      });
+      const service = await loadService();
+      await expect(service.getBrokerCredentials("org-1", "user-1", "agent")).rejects.toThrow(
+        /induced failure/,
+      );
+
+      expect(secretStore.TWITTER_AGENT_OAUTH2_REFRESH_TOKEN).toBe("refresh-2");
+      const refreshWrite = secretWriteOrder.indexOf("TWITTER_AGENT_OAUTH2_REFRESH_TOKEN");
+      const accessWrite = secretWriteOrder.indexOf("TWITTER_AGENT_OAUTH2_ACCESS_TOKEN");
+      expect(refreshWrite).toBeGreaterThanOrEqual(0);
+      expect(accessWrite).toBeGreaterThan(refreshWrite);
     });
 
     test("a token with no recorded expiry (legacy) forces a refresh rather than vending blind", async () => {

--- a/packages/cloud/shared/src/lib/services/twitter-automation/index.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/index.ts
@@ -87,6 +87,17 @@ function oauth2ExpiryFromLifetime(expiresInSeconds: number | undefined): number 
 /** Refresh this many seconds ahead of the stored expiry so vended tokens outlive transit. */
 const OAUTH2_BROKER_REFRESH_MARGIN_SECONDS = 5 * 60;
 
+export type TwitterBrokerCredentials =
+  | { authMode: "oauth1a"; credentials: Record<string, string> }
+  | {
+      authMode: "oauth2";
+      accessToken: string;
+      expiresAt: number | null;
+      scope: string | null;
+      twitterUserId: string | null;
+    }
+  | null;
+
 function roleSecretName(
   role: OAuthConnectionRole,
   field: keyof typeof TWITTER_SECRET_FIELDS,
@@ -538,6 +549,23 @@ class TwitterAutomationService {
       throw new Error("OAuth 1.0a credentials require a screen name and user ID");
     }
 
+    // A rotated refresh token is single-use authority: once X accepts the
+    // exchange, the previous value cannot recover the account. Persist the new
+    // non-empty refresh token before starting any sibling write so a later
+    // failure cannot retain a new access token while losing its only usable
+    // refresh token. Explicit deletion remains part of the sibling set; it is
+    // not a recoverability improvement and must not run before the new access
+    // tuple is ready.
+    if (authMode === "oauth2" && credentials.refreshToken) {
+      await upsertRoleSecret({
+        organizationId,
+        userId,
+        name: roleSecretName(role, "oauth2RefreshToken"),
+        value: credentials.refreshToken,
+        audit,
+      });
+    }
+
     const writes: Promise<void>[] = [
       screenName
         ? upsertRoleSecret({
@@ -618,17 +646,7 @@ class TwitterAutomationService {
             })
           : deleteRoleSecret(organizationId, role, "oauth2ExpiresAt", audit),
       );
-      if (credentials.refreshToken) {
-        writes.push(
-          upsertRoleSecret({
-            organizationId,
-            userId,
-            name: roleSecretName(role, "oauth2RefreshToken"),
-            value: credentials.refreshToken,
-            audit,
-          }),
-        );
-      } else if (credentials.refreshToken === null) {
+      if (credentials.refreshToken === null) {
         writes.push(deleteRoleSecret(organizationId, role, "oauth2RefreshToken", audit));
       }
     }
@@ -866,17 +884,7 @@ class TwitterAutomationService {
     organizationId: string,
     userId: string,
     connectionRole: OAuthConnectionRole = "agent",
-  ): Promise<
-    | { authMode: "oauth1a"; credentials: Record<string, string> }
-    | {
-        authMode: "oauth2";
-        accessToken: string;
-        expiresAt: number | null;
-        scope: string | null;
-        twitterUserId: string | null;
-      }
-    | null
-  > {
+  ): Promise<TwitterBrokerCredentials> {
     const role = normalizeConnectionRole(connectionRole);
     const stored = await getRoleCredentials(organizationId, role);
 

--- a/packages/cloud/shared/src/lib/services/twitter-automation/oauth2-client.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/oauth2-client.error-policy.test.ts
@@ -54,6 +54,17 @@ describe("requestTwitterOAuth2Token — fail-closed token exchange", () => {
     expect(token.refresh_token).toBe("ref_456");
   });
 
+  test("bounds the provider request with an abort signal", async () => {
+    process.env.TWITTER_CLIENT_ID = "test-client-id";
+    let observedSignal: AbortSignal | null | undefined;
+    globalThis.fetch = (async (_input, init) => {
+      observedSignal = init?.signal;
+      return new Response(JSON.stringify({ access_token: "bounded-token" }), { status: 200 });
+    }) as typeof fetch;
+    await requestTwitterOAuth2Token({ grant_type: "refresh_token" });
+    expect(observedSignal).toBeInstanceOf(AbortSignal);
+  });
+
   test("non-OK status with JSON error body throws with provider detail (failure surfaces)", async () => {
     process.env.TWITTER_CLIENT_ID = "test-client-id";
     stubFetch(

--- a/packages/cloud/shared/src/lib/services/twitter-automation/oauth2-client.ts
+++ b/packages/cloud/shared/src/lib/services/twitter-automation/oauth2-client.ts
@@ -2,6 +2,7 @@
 import { parseJsonErrorBody, parseJsonResponse } from "../../utils/json-parsing";
 
 const TWITTER_OAUTH2_TOKEN_URL = "https://api.x.com/2/oauth2/token";
+export const TWITTER_OAUTH2_TOKEN_TIMEOUT_MS = 20_000;
 
 export interface TwitterOAuth2TokenResponse {
   access_token?: string;
@@ -92,6 +93,7 @@ export async function requestTwitterOAuth2Token(
     method: "POST",
     headers,
     body,
+    signal: AbortSignal.timeout(TWITTER_OAUTH2_TOKEN_TIMEOUT_MS),
   });
 
   if (!response.ok) {

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -95,6 +95,9 @@ export interface Bindings {
   /** One strongly ordered transcript and replay ledger per onboarding session. */
   ONBOARDING_SESSIONS?: RuntimeDurableObjectNamespace;
 
+  /** One strongly ordered X credential refresh coordinator per organization and role. */
+  TWITTER_OAUTH_REFRESH_COORDINATORS?: RuntimeDurableObjectNamespace;
+
   // ---- Cloudflare machine-local protective rate limits ----
   GLOBAL_RATE_LIMITER?: RuntimeRateLimitBinding;
   CHAT_ROUTE_RATE_LIMITER?: RuntimeRateLimitBinding;


### PR DESCRIPTION
Closes #20027. Supersedes #20016.

The original cache lease cannot serialize the shipped Worker path: production and staging prefer Cloudflare KV, whose NX adapter is explicitly non-atomic and eventually consistent. This replacement moves the authority to a Durable Object keyed by organization + connection role.

What changed:

- `/api/v1/twitter/token` authenticates and validates the role, then delegates credential vending to the role-scoped coordinator.
- The coordinator serializes complete broker operations across Worker isolates; the second request rereads the now-fresh stored tuple and does not refresh again.
- A non-empty rotated refresh token is persisted before any fallible sibling secret write starts.
- X token requests carry a 20-second abort deadline.
- Local, staging, and production Worker configs bind the coordinator, with a registered Durable Object migration.
- Public OAuth1/OAuth2/404 response shapes and least-privileged role default are preserved.

Exact-head validation:

- Focused coordinator/route/deploy/service/client suites: PASS (65 tests, including one provider refresh across two serialized requests and partial-write survival)
- `bun run --cwd packages/cloud/shared typecheck` — PASS
- `bun run --cwd packages/cloud/api typecheck` — PASS
- Production Worker dry-run: PASS; `TWITTER_OAUTH_REFRESH_COORDINATORS` resolved
- Staging Worker dry-run: PASS; `TWITTER_OAUTH_REFRESH_COORDINATORS` resolved
- Targeted Biome and `git diff --check` — PASS
- Base root gates immediately before this change: lint 132/132, build 123/123 + view guard 19/19, typecheck 219/219

## Contribution provenance

- AI assistance: yes — architecture review, implementation, tests, and deployment-contract validation.
- Models used: openai/gpt-5.6-sol
- Client / agent tooling: Codex Desktop
- Contribution skill revision: elizaOS/eliza@5c659f232b78792471d260ed8c318d78b605c5f9:packages/skills/skills/contribute-to-eliza
- Attribution status: self-reported

<!-- evidence-head:811c284f7fd426e9e6e5ca118297f6526df2c9e7 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - server-side credential coordination; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - server-side credential coordination; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive surface; concurrency is deterministic in the focused suite.

<!-- evidence-row:backend-logs -->
- [x] Exact-head backend validation transcript: https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20028-backend-validation.log

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model path changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no external domain mutation; production and staging Wrangler dry-runs prove the deployment binding.

— [nubs-review-twitter-refresh]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@5c659f232b78792471d260ed8c318d78b605c5f9:packages/skills/skills/contribute-to-eliza"} -->
