### PR TITLE
fix(core): distinguish capability gaps from planner exhaustion

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-failurekind-roundtrip.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-failurekind-roundtrip.test.ts
@@ -350,13 +350,15 @@ describe("conversation failureKind round-trip", () => {
     "missing_capability",
     "persistence_error",
     "planner_exhaustion",
+    "generation_timeout",
   ] as const)(
     "GET /messages preserves the %s structured runtime cause",
     async (failureKind:
       | "handler_error"
       | "missing_capability"
       | "persistence_error"
-      | "planner_exhaustion") => {
+      | "planner_exhaustion"
+      | "generation_timeout") => {
       const state = createState([
         userMemory(),
         assistantMemory({ text: "Structured failure.", failureKind }),
@@ -438,13 +440,15 @@ describe("conversation failureKind round-trip", () => {
     "missing_capability",
     "persistence_error",
     "planner_exhaustion",
+    "generation_timeout",
   ] as const)(
     "non-streaming JSON accepts the %s durable outcome discriminator",
     async (failureKind:
       | "handler_error"
       | "missing_capability"
       | "persistence_error"
-      | "planner_exhaustion") => {
+      | "planner_exhaustion"
+      | "generation_timeout") => {
       generateResult = { failureKind };
       const state = createState();
       const { ctx, captured } = createCtx(

--- a/packages/agent/src/api/__tests__/conversation-failurekind-roundtrip.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-failurekind-roundtrip.test.ts
@@ -345,6 +345,38 @@ describe("conversation failureKind round-trip", () => {
     expect(assistant?.failureKind).toBe("insufficient_credits");
   });
 
+  it.each([
+    "handler_error",
+    "missing_capability",
+    "persistence_error",
+    "planner_exhaustion",
+  ] as const)(
+    "GET /messages preserves the %s structured runtime cause",
+    async (failureKind:
+      | "handler_error"
+      | "missing_capability"
+      | "persistence_error"
+      | "planner_exhaustion") => {
+      const state = createState([
+        userMemory(),
+        assistantMemory({ text: "Structured failure.", failureKind }),
+      ]);
+      const { ctx, captured } = createCtx(
+        "GET",
+        "/api/conversations/conv-1/messages",
+        state,
+      );
+
+      await handleConversationRoutes(ctx);
+
+      const payload = captured.payload as {
+        messages: Array<{ role: string; failureKind?: string }>;
+      };
+      const assistant = payload.messages.find((m) => m.role === "assistant");
+      expect(assistant?.failureKind).toBe(failureKind);
+    },
+  );
+
   it("GET /messages omits failureKind for a normal (successful) turn", async () => {
     const state = createState([
       userMemory(),
@@ -400,6 +432,33 @@ describe("conversation failureKind round-trip", () => {
     const payload = captured.payload as { failureKind?: string };
     expect(payload.failureKind).toBe("insufficient_credits");
   });
+
+  it.each([
+    "handler_error",
+    "missing_capability",
+    "persistence_error",
+    "planner_exhaustion",
+  ] as const)(
+    "non-streaming JSON accepts the %s durable outcome discriminator",
+    async (failureKind:
+      | "handler_error"
+      | "missing_capability"
+      | "persistence_error"
+      | "planner_exhaustion") => {
+      generateResult = { failureKind };
+      const state = createState();
+      const { ctx, captured } = createCtx(
+        "POST",
+        "/api/conversations/conv-1/messages",
+        state,
+      );
+
+      await handleConversationRoutes(ctx);
+
+      const payload = captured.payload as { failureKind?: string };
+      expect(payload.failureKind).toBe(failureKind);
+    },
+  );
 });
 
 describe("conversation transcript visibility round-trip", () => {

--- a/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
@@ -649,16 +649,21 @@ function createMixedPersistedTransientMessageService(
   } satisfies NonNullable<AgentRuntime["messageService"]>;
 }
 
-function createEphemeralReplyMessageService(): NonNullable<
-  AgentRuntime["messageService"]
-> {
+function createEphemeralReplyMessageService(
+  failureKind:
+    | "rate_limited"
+    | "handler_error"
+    | "missing_capability"
+    | "persistence_error"
+    | "planner_exhaustion" = "rate_limited",
+): NonNullable<AgentRuntime["messageService"]> {
   return {
     async handleMessage() {
       const content = {
         text: "Temporary provider failure.",
-        transient: true,
+        transient: failureKind === "rate_limited",
         doNotPersist: true,
-        failureKind: "rate_limited" as const,
+        failureKind,
       };
       return {
         didRespond: true,
@@ -2018,6 +2023,36 @@ describe("conversation stream SSE contract (#10712)", () => {
     expect(done).not.toHaveProperty("messageId");
     expect(persistAssistantConversationMemory).not.toHaveBeenCalled();
   });
+
+  it.each([
+    "handler_error",
+    "missing_capability",
+    "persistence_error",
+    "planner_exhaustion",
+  ] as const)(
+    "preserves the %s discriminator in the direct chat DTO",
+    async (failureKind:
+      | "handler_error"
+      | "missing_capability"
+      | "persistence_error"
+      | "planner_exhaustion") => {
+      const { ctx, record } = createCtx(
+        createEphemeralReplyMessageService(failureKind),
+      );
+
+      await handleConversationRoutes(ctx);
+
+      const done = parseSsePayloads(record.writes).find(
+        (payload) => payload.type === "done",
+      );
+      expect(done).toMatchObject({
+        type: "done",
+        assistantEphemeral: true,
+        failureKind,
+      });
+      expect(persistAssistantConversationMemory).not.toHaveBeenCalled();
+    },
+  );
 
   it("delivers a post-SSE-init failure as a structured SSE error frame, not an HTTP error", async () => {
     const { ctx, record, useModel } = createCtx();

--- a/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
@@ -655,7 +655,8 @@ function createEphemeralReplyMessageService(
     | "handler_error"
     | "missing_capability"
     | "persistence_error"
-    | "planner_exhaustion" = "rate_limited",
+    | "planner_exhaustion"
+    | "generation_timeout" = "rate_limited",
 ): NonNullable<AgentRuntime["messageService"]> {
   return {
     async handleMessage() {
@@ -2029,13 +2030,15 @@ describe("conversation stream SSE contract (#10712)", () => {
     "missing_capability",
     "persistence_error",
     "planner_exhaustion",
+    "generation_timeout",
   ] as const)(
     "preserves the %s discriminator in the direct chat DTO",
     async (failureKind:
       | "handler_error"
       | "missing_capability"
       | "persistence_error"
-      | "planner_exhaustion") => {
+      | "planner_exhaustion"
+      | "generation_timeout") => {
       const { ctx, record } = createCtx(
         createEphemeralReplyMessageService(failureKind),
       );

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -4198,8 +4198,12 @@ async function generateChatResponseWithTiming(
           : undefined;
     const failureKind =
       rawFailureKind === "insufficient_credits" ||
+      rawFailureKind === "handler_error" ||
       rawFailureKind === "local_inference" ||
+      rawFailureKind === "missing_capability" ||
       rawFailureKind === "no_provider" ||
+      rawFailureKind === "persistence_error" ||
+      rawFailureKind === "planner_exhaustion" ||
       rawFailureKind === "provider_issue" ||
       rawFailureKind === "rate_limited"
         ? rawFailureKind

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -71,6 +71,7 @@ import {
   extractAssistantReplyText,
   isLinkedAccountProviderId,
   normalizeCharacterLanguage,
+  parseChatFailureKind,
   readAliasedEnv,
   resolveStreamingUpdate,
 } from "@elizaos/shared";
@@ -4196,18 +4197,7 @@ async function generateChatResponseWithTiming(
         : typeof responseMetadata?.chatFailureKind === "string"
           ? responseMetadata.chatFailureKind
           : undefined;
-    const failureKind =
-      rawFailureKind === "insufficient_credits" ||
-      rawFailureKind === "handler_error" ||
-      rawFailureKind === "local_inference" ||
-      rawFailureKind === "missing_capability" ||
-      rawFailureKind === "no_provider" ||
-      rawFailureKind === "persistence_error" ||
-      rawFailureKind === "planner_exhaustion" ||
-      rawFailureKind === "provider_issue" ||
-      rawFailureKind === "rate_limited"
-        ? rawFailureKind
-        : undefined;
+    const failureKind = parseChatFailureKind(rawFailureKind);
 
     const thought =
       typeof responseContent?.thought === "string" &&

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -1411,6 +1411,10 @@ function parseDurableConversationChatOutcome(
       outcome.failureKind !== "no_provider" &&
       outcome.failureKind !== "provider_issue" &&
       outcome.failureKind !== "rate_limited" &&
+      outcome.failureKind !== "missing_capability" &&
+      outcome.failureKind !== "handler_error" &&
+      outcome.failureKind !== "persistence_error" &&
+      outcome.failureKind !== "planner_exhaustion" &&
       outcome.failureKind !== "local_inference") ||
     (outcome.accountConnect !== undefined &&
       normalizeAccountConnectRequest(outcome.accountConnect) === null) ||
@@ -1513,6 +1517,10 @@ function buildRecoveredConversationChatOutcome(
     content.failureKind === "no_provider" ||
     content.failureKind === "provider_issue" ||
     content.failureKind === "rate_limited" ||
+    content.failureKind === "missing_capability" ||
+    content.failureKind === "handler_error" ||
+    content.failureKind === "persistence_error" ||
+    content.failureKind === "planner_exhaustion" ||
     content.failureKind === "local_inference"
       ? content.failureKind
       : undefined;

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -53,11 +53,13 @@ import {
 } from "@elizaos/plugin-scheduling";
 import type { ChatFailureKind } from "@elizaos/shared";
 import {
+  isChatFailureKind,
   PatchConversationRequestSchema,
   PostConversationCleanupEmptyRequestSchema,
   PostConversationRequestSchema,
   PostConversationTruncateRequestSchema,
   PostSeedMessagesRequestSchema,
+  parseChatFailureKind,
   parsePositiveInteger,
 } from "@elizaos/shared";
 import {
@@ -1407,15 +1409,7 @@ function parseDurableConversationChatOutcome(
       (!Array.isArray(outcome.actionResults) ||
         !outcome.actionResults.every(isDurableChatActionResult))) ||
     (outcome.failureKind !== undefined &&
-      outcome.failureKind !== "insufficient_credits" &&
-      outcome.failureKind !== "missing_capability" &&
-      outcome.failureKind !== "no_provider" &&
-      outcome.failureKind !== "planner_exhaustion" &&
-      outcome.failureKind !== "provider_issue" &&
-      outcome.failureKind !== "rate_limited" &&
-      outcome.failureKind !== "handler_error" &&
-      outcome.failureKind !== "persistence_error" &&
-      outcome.failureKind !== "local_inference") ||
+      !isChatFailureKind(outcome.failureKind)) ||
     (outcome.accountConnect !== undefined &&
       normalizeAccountConnectRequest(outcome.accountConnect) === null) ||
     (outcome.localInference !== undefined &&
@@ -1512,18 +1506,7 @@ function buildRecoveredConversationChatOutcome(
   agentName: string,
 ): ChatMessageIdOutcome {
   const content = memory.content as Content;
-  const failureKind =
-    content.failureKind === "insufficient_credits" ||
-    content.failureKind === "missing_capability" ||
-    content.failureKind === "no_provider" ||
-    content.failureKind === "planner_exhaustion" ||
-    content.failureKind === "provider_issue" ||
-    content.failureKind === "rate_limited" ||
-    content.failureKind === "handler_error" ||
-    content.failureKind === "persistence_error" ||
-    content.failureKind === "local_inference"
-      ? content.failureKind
-      : undefined;
+  const failureKind = parseChatFailureKind(content.failureKind);
   const accountConnect = normalizeAccountConnectRequest(content.accountConnect);
   const localInference =
     content.localInference && typeof content.localInference === "object"
@@ -2988,18 +2971,7 @@ export async function handleConversationRoutes(
               : typeof meta?.chatFailureKind === "string"
                 ? meta.chatFailureKind
                 : undefined;
-          const failureKind: ChatFailureKind | undefined =
-            rawFailureKind === "insufficient_credits" ||
-            rawFailureKind === "handler_error" ||
-            rawFailureKind === "missing_capability" ||
-            rawFailureKind === "no_provider" ||
-            rawFailureKind === "persistence_error" ||
-            rawFailureKind === "planner_exhaustion" ||
-            rawFailureKind === "provider_issue" ||
-            rawFailureKind === "rate_limited" ||
-            rawFailureKind === "local_inference"
-              ? rawFailureKind
-              : undefined;
+          const failureKind = parseChatFailureKind(rawFailureKind);
           // The CONNECT_ACCOUNT action stamps `content.accountConnect` on the
           // assistant memory. Validate + round-trip it so the inline
           // AddAccountDialog entry point survives the GET /messages replace.

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -1408,13 +1408,13 @@ function parseDurableConversationChatOutcome(
         !outcome.actionResults.every(isDurableChatActionResult))) ||
     (outcome.failureKind !== undefined &&
       outcome.failureKind !== "insufficient_credits" &&
+      outcome.failureKind !== "missing_capability" &&
       outcome.failureKind !== "no_provider" &&
+      outcome.failureKind !== "planner_exhaustion" &&
       outcome.failureKind !== "provider_issue" &&
       outcome.failureKind !== "rate_limited" &&
-      outcome.failureKind !== "missing_capability" &&
       outcome.failureKind !== "handler_error" &&
       outcome.failureKind !== "persistence_error" &&
-      outcome.failureKind !== "planner_exhaustion" &&
       outcome.failureKind !== "local_inference") ||
     (outcome.accountConnect !== undefined &&
       normalizeAccountConnectRequest(outcome.accountConnect) === null) ||
@@ -1514,13 +1514,13 @@ function buildRecoveredConversationChatOutcome(
   const content = memory.content as Content;
   const failureKind =
     content.failureKind === "insufficient_credits" ||
+    content.failureKind === "missing_capability" ||
     content.failureKind === "no_provider" ||
+    content.failureKind === "planner_exhaustion" ||
     content.failureKind === "provider_issue" ||
     content.failureKind === "rate_limited" ||
-    content.failureKind === "missing_capability" ||
     content.failureKind === "handler_error" ||
     content.failureKind === "persistence_error" ||
-    content.failureKind === "planner_exhaustion" ||
     content.failureKind === "local_inference"
       ? content.failureKind
       : undefined;
@@ -2990,7 +2990,11 @@ export async function handleConversationRoutes(
                 : undefined;
           const failureKind: ChatFailureKind | undefined =
             rawFailureKind === "insufficient_credits" ||
+            rawFailureKind === "handler_error" ||
+            rawFailureKind === "missing_capability" ||
             rawFailureKind === "no_provider" ||
+            rawFailureKind === "persistence_error" ||
+            rawFailureKind === "planner_exhaustion" ||
             rawFailureKind === "provider_issue" ||
             rawFailureKind === "rate_limited" ||
             rawFailureKind === "local_inference"

--- a/packages/core/src/contracts/first-run-options.ts
+++ b/packages/core/src/contracts/first-run-options.ts
@@ -50,6 +50,10 @@ export interface CharacterFailureTemplates {
 	insufficientCreditsReply?: string;
 	/** No LLM provider plugin is registered at all. */
 	noModelProviderReply?: string;
+	/** A required capability is not registered in this runtime. */
+	missingCapabilityFailureReply?: string;
+	/** The planner exhausted its bounded attempts before completing the task. */
+	plannerExhaustionFailureReply?: string;
 	/** Provider is throttling; retrying shortly should succeed. */
 	rateLimitedReply?: string;
 	/** Any other failure once every model call has already failed. */

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.test.ts
@@ -216,11 +216,27 @@ describe("recentMessagesProvider", () => {
 				elizaSyntheticFailure: true,
 				chatFailureKind: "provider_issue",
 			}),
+			makeMemory(
+				"msg-6",
+				AGENT_ID,
+				"Capability unavailable.",
+				"client_chat",
+				6000,
+				{ failureKind: "missing_capability" },
+			),
+			makeMemory(
+				"msg-7",
+				AGENT_ID,
+				"Attempts exhausted.",
+				"client_chat",
+				7000,
+				{ failureKind: "planner_exhaustion" },
+			),
 		];
 
 		const result = await recentMessagesProvider.get(
 			makeRuntime(memories),
-			makeMemory("current", USER_ID, "next task", "client_chat", 6000),
+			makeMemory("current", USER_ID, "next task", "client_chat", 8000),
 			{ values: {}, data: {}, text: "" },
 		);
 
@@ -230,6 +246,8 @@ describe("recentMessagesProvider", () => {
 		expect(result.text).not.toContain("Agent: Sorry");
 		expect(result.text).not.toContain("Something went wrong");
 		expect(result.text).not.toContain("Retrying...");
+		expect(result.text).not.toContain("Capability unavailable.");
+		expect(result.text).not.toContain("Attempts exhausted.");
 	});
 
 	it("dedupes repeated assistant messages within one assistant run", async () => {

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
@@ -72,6 +72,10 @@ const SYNTHETIC_ASSISTANT_FAILURE_KINDS = new Set([
 	"insufficient_credits",
 	"no_response",
 	"transient_failure",
+	"missing_capability",
+	"handler_error",
+	"persistence_error",
+	"planner_exhaustion",
 ]);
 const RECALL_REFERENTIAL_PATTERNS = [
 	/\bwhat\s+(?:did|was|were)\s+(?:i|we|you)\b.*\b(?:ask|say|tell|compute|calculate|mention|discuss|talk(?:ed)?\s+about)\b/i,

--- a/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
+++ b/packages/core/src/features/basic-capabilities/providers/recentMessages.ts
@@ -67,15 +67,15 @@ const SYNTHETIC_ASSISTANT_FAILURE_TEXTS = new Set([
 ]);
 const SYNTHETIC_ASSISTANT_FAILURE_KINDS = new Set([
 	"provider_issue",
+	"missing_capability",
+	"planner_exhaustion",
 	"local_inference",
 	"no_provider",
 	"insufficient_credits",
 	"no_response",
 	"transient_failure",
-	"missing_capability",
 	"handler_error",
 	"persistence_error",
-	"planner_exhaustion",
 ]);
 const RECALL_REFERENTIAL_PATTERNS = [
 	/\bwhat\s+(?:did|was|were)\s+(?:i|we|you)\b.*\b(?:ask|say|tell|compute|calculate|mention|discuss|talk(?:ed)?\s+about)\b/i,

--- a/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
+++ b/packages/core/src/runtime/__tests__/execute-planned-tool-call.test.ts
@@ -123,7 +123,60 @@ describe("executePlannedToolCall", () => {
 
 		expect(result.success).toBe(false);
 		expect(result.error).toBe("Action not found: search_documents");
+		expect(result.failureProvenance).toEqual({
+			kind: "missing_capability",
+			boundary: "capability",
+			code: "ACTION_NOT_FOUND",
+			retryable: false,
+		});
 		expect(handler).not.toHaveBeenCalled();
+	});
+
+	it("carries handler and persistence provenance from their boundaries", async () => {
+		const thrown = await executePlannedToolCall(
+			makeRuntime([
+				makeAction({
+					name: "THROWING_ACTION",
+					handler: async () => {
+						throw new Error("handler exploded");
+					},
+				}),
+			]),
+			{ message: makeMessage() },
+			{ name: "THROWING_ACTION", params: {} },
+		);
+		expect(thrown.failureProvenance).toEqual({
+			kind: "handler_error",
+			boundary: "handler",
+			code: "ACTION_HANDLER_FAILED",
+			retryable: true,
+		});
+
+		const persistence = await executePlannedToolCall(
+			makeRuntime([
+				makeAction({
+					name: "PERSIST_ACTION",
+					handler: async () => ({
+						success: false,
+						error: "database rejected the write",
+						failureProvenance: {
+							kind: "persistence_error" as const,
+							boundary: "persistence" as const,
+							code: "TEST_WRITE_FAILED",
+							retryable: true,
+						},
+					}),
+				}),
+			]),
+			{ message: makeMessage() },
+			{ name: "PERSIST_ACTION", params: {} },
+		);
+		expect(persistence.failureProvenance).toEqual({
+			kind: "persistence_error",
+			boundary: "persistence",
+			code: "TEST_WRITE_FAILED",
+			retryable: true,
+		});
 	});
 
 	it("rejects invalid native tool arguments before invoking the handler", async () => {

--- a/packages/core/src/runtime/action-handler-settlement.ts
+++ b/packages/core/src/runtime/action-handler-settlement.ts
@@ -9,6 +9,11 @@
 
 import { ElizaError } from "../errors";
 import { runWithSuppressedModelStream } from "../streaming-context";
+import {
+	normalizeActionFailureProvenance,
+	readActionFailureProvenance,
+	type ActionFailureProvenance,
+} from "../types/action-failure";
 import type {
 	Action,
 	ActionResult,
@@ -122,6 +127,15 @@ export function normalizeActionResult(
 			: normalizeUserFacingEffectReceiptIds(
 					rawResult.userFacingEffectReceiptIds,
 				);
+	const failureProvenance =
+		rawResult.failureProvenance === undefined
+			? undefined
+			: normalizeActionFailureProvenance(rawResult.failureProvenance);
+	if (rawResult.success !== false && failureProvenance !== undefined) {
+		return invalidActionResult(
+			"Successful ActionResult values cannot carry failureProvenance.",
+		);
+	}
 
 	return {
 		...rawResult,
@@ -129,6 +143,9 @@ export function normalizeActionResult(
 		...(effectReceipts !== undefined ? { effectReceipts } : {}),
 		...(userFacingEffectReceiptIds !== undefined
 			? { userFacingEffectReceiptIds }
+			: {}),
+		...(failureProvenance !== undefined
+			? { failureProvenance }
 			: {}),
 		data: {
 			...resultData,
@@ -144,11 +161,13 @@ export function actionFailureResult(
 	actionName: string,
 	message: string,
 	extraData: Record<string, unknown> = {},
+	failureProvenance?: ActionFailureProvenance,
 ): ActionResult {
 	return {
 		success: false,
 		text: message,
 		error: message,
+		...(failureProvenance ? { failureProvenance } : {}),
 		data: {
 			...extraData,
 			actionName,
@@ -345,10 +364,19 @@ export async function settleActionHandler(
 		if (options.handlerError === "rethrow") {
 			throw error;
 		}
+		const failureProvenance =
+			readActionFailureProvenance(error) ??
+			({
+				kind: "handler_error",
+				boundary: "handler",
+				code: "ACTION_HANDLER_FAILED",
+				retryable: true,
+			} satisfies ActionFailureProvenance);
 		return actionFailureResult(
 			options.action.name,
 			stringifyActionError(error),
 			{ error },
+			failureProvenance,
 		);
 	}
 	if (isObjectRecord(rawResult)) {
@@ -395,12 +423,22 @@ export async function settleActionHandler(
 		if (options.handlerError === "rethrow") {
 			throw error;
 		}
-		return actionFailureResult(options.action.name, error.message, {
-			error,
-			outcomeUnknown: true,
-			retryable: false,
-			reconciliationRequired: true,
-		});
+		return actionFailureResult(
+			options.action.name,
+			error.message,
+			{
+				error,
+				outcomeUnknown: true,
+				retryable: false,
+				reconciliationRequired: true,
+			},
+			{
+				kind: "handler_error",
+				boundary: "handler",
+				code: "ACTION_RESULT_INVALID_AFTER_HANDLER",
+				retryable: false,
+			},
+		);
 	}
 
 	for (const buffered of bufferedCallbacks) {

--- a/packages/core/src/runtime/action-handler-settlement.ts
+++ b/packages/core/src/runtime/action-handler-settlement.ts
@@ -9,11 +9,6 @@
 
 import { ElizaError } from "../errors";
 import { runWithSuppressedModelStream } from "../streaming-context";
-import {
-	normalizeActionFailureProvenance,
-	readActionFailureProvenance,
-	type ActionFailureProvenance,
-} from "../types/action-failure";
 import type {
 	Action,
 	ActionResult,
@@ -22,6 +17,11 @@ import type {
 	IAgentRuntime,
 	Memory,
 } from "../types";
+import {
+	type ActionFailureProvenance,
+	normalizeActionFailureProvenance,
+	readActionFailureProvenance,
+} from "../types/action-failure";
 import {
 	normalizeEffectReceipts,
 	normalizeUserFacingEffectReceiptIds,
@@ -144,9 +144,7 @@ export function normalizeActionResult(
 		...(userFacingEffectReceiptIds !== undefined
 			? { userFacingEffectReceiptIds }
 			: {}),
-		...(failureProvenance !== undefined
-			? { failureProvenance }
-			: {}),
+		...(failureProvenance !== undefined ? { failureProvenance } : {}),
 		data: {
 			...resultData,
 			// The executor, not an action-owned payload, is authoritative about

--- a/packages/core/src/runtime/execute-planned-tool-call.ts
+++ b/packages/core/src/runtime/execute-planned-tool-call.ts
@@ -200,6 +200,9 @@ export function projectActionResultForClipboard(
 					userFacingEffectReceiptIds: result.userFacingEffectReceiptIds,
 				}
 			: {}),
+		...(result.failureProvenance !== undefined
+			? { failureProvenance: result.failureProvenance }
+			: {}),
 		...(Object.keys(safeControlData).length > 0
 			? { data: safeControlData }
 			: {}),
@@ -235,6 +238,9 @@ function projectSettledResultForObserver(
 		success: projected.success,
 		...(projected.effectReceipts !== undefined
 			? { effectReceipts: projected.effectReceipts }
+			: {}),
+		...(projected.failureProvenance !== undefined
+			? { failureProvenance: projected.failureProvenance }
 			: {}),
 		data: controlData,
 		...(projected.turnComplete !== undefined
@@ -402,7 +408,17 @@ export async function executePlannedToolCall(
 		return emitToolResult(
 			toolCall,
 			redactDiagnosticText,
-			failureResult(toolCall.name, `Action not found: ${toolCall.name}`),
+			failureResult(
+				toolCall.name,
+				`Action not found: ${toolCall.name}`,
+				{},
+				{
+					kind: "missing_capability",
+					boundary: "capability",
+					code: "ACTION_NOT_FOUND",
+					retryable: false,
+				},
+			),
 		);
 	}
 
@@ -507,7 +523,17 @@ export async function executePlannedToolCall(
 			return emitToolResult(
 				toolCall,
 				redactDiagnosticText,
-				failureResult(action.name, stringifyError(error), { error }),
+				failureResult(
+					action.name,
+					stringifyError(error),
+					{ error },
+					{
+						kind: "handler_error",
+						boundary: "handler",
+						code: "ACTION_VALIDATION_FAILED",
+						retryable: true,
+					},
+				),
 			);
 		}
 		if (!valid) {
@@ -517,6 +543,13 @@ export async function executePlannedToolCall(
 				failureResult(
 					action.name,
 					`Action ${action.name} is not available for the current state`,
+					{},
+					{
+						kind: "missing_capability",
+						boundary: "capability",
+						code: "ACTION_UNAVAILABLE",
+						retryable: false,
+					},
 				),
 			);
 		}

--- a/packages/core/src/runtime/limits.ts
+++ b/packages/core/src/runtime/limits.ts
@@ -5,6 +5,8 @@
  * `TrajectoryLimitExceeded` error, and the assert/count helpers that stop a
  * runaway or stuck planner from burning a turn.
  */
+import type { ActionFailureProvenance } from "../types/action-failure";
+
 export interface ChainingLoopConfig {
 	/** Maximum tool calls executed during one planner loop. */
 	maxToolCalls: number;
@@ -134,12 +136,14 @@ export class TrajectoryLimitExceeded extends Error {
 	readonly kind: TrajectoryLimitKind;
 	readonly max: number;
 	readonly observed: number;
+	readonly failureProvenance?: ActionFailureProvenance;
 
 	constructor(params: {
 		kind: TrajectoryLimitKind;
 		max: number;
 		observed: number;
 		message?: string;
+		failureProvenance?: ActionFailureProvenance;
 	}) {
 		super(
 			params.message ??
@@ -149,6 +153,7 @@ export class TrajectoryLimitExceeded extends Error {
 		this.kind = params.kind;
 		this.max = params.max;
 		this.observed = params.observed;
+		this.failureProvenance = params.failureProvenance;
 	}
 }
 
@@ -179,6 +184,7 @@ export interface FailureLike {
 	error?: unknown;
 	success?: boolean;
 	repeatKey?: string;
+	failureProvenance?: ActionFailureProvenance;
 }
 
 export function getFailureSignature(failure: FailureLike): string | null {
@@ -235,6 +241,7 @@ export function assertRepeatedFailureLimit(params: {
 			kind: "repeated_failures",
 			max: params.maxRepeatedFailures,
 			observed,
+			failureProvenance: params.latestFailure.failureProvenance,
 			message: `Repeated tool failure limit exceeded for ${getFailureSignature(
 				params.latestFailure,
 			)}`,

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -3023,6 +3023,7 @@ async function executeQueuedToolCall(params: {
 		toolName: params.toolCall.name,
 		success: result.success,
 		error: projectToolDiagnosticValue(failureError, redactDiagnosticText),
+		failureProvenance: result.failureProvenance,
 		repeatKey: isParameterValidationFailure
 			? "parameter_validation"
 			: toolFailureRepeatKey(params.toolCall),
@@ -5693,6 +5694,7 @@ export function actionResultToPlannerToolResult(
 		userFacingEffectReceiptIds: result.userFacingEffectReceiptIds,
 		data: Object.keys(data).length > 0 ? data : undefined,
 		error: result.error,
+		failureProvenance: result.failureProvenance,
 		turnComplete: result.turnComplete,
 		continueChain: result.continueChain,
 	};

--- a/packages/core/src/runtime/planner-types.ts
+++ b/packages/core/src/runtime/planner-types.ts
@@ -4,6 +4,7 @@
  * parameter and result envelopes. Consumed by planner-loop, the evaluator, and
  * the message handler that drives them.
  */
+import type { ActionFailureProvenance } from "../types/action-failure";
 import type { EvaluationResult } from "../types/components";
 import type { ContextObject } from "../types/context-object";
 import type { EffectReceipt } from "../types/effects";
@@ -167,6 +168,8 @@ export interface PlannerToolResult {
 	summary?: string;
 	data?: Record<string, unknown>;
 	error?: unknown;
+	/** Typed boundary provenance retained through planner retry exhaustion. */
+	failureProvenance?: ActionFailureProvenance;
 	/**
 	 * Action-owned completion signal that is honored only for a single executed
 	 * tool after the plan queue drains and the successful result carries verified

--- a/packages/core/src/services/__tests__/failure-reply-prompt.test.ts
+++ b/packages/core/src/services/__tests__/failure-reply-prompt.test.ts
@@ -155,10 +155,9 @@ describe("classifyStructuredFailureCause", () => {
 		expect(classifyStructuredFailureCause(error)).toBe("missing_capability");
 	});
 
-	it("maps budget-style trajectory limits to planner_exhaustion", () => {
+	it("maps every non-causal trajectory limit to planner_exhaustion", () => {
 		for (const kind of [
 			"tool_calls",
-			"repeated_failures",
 			"terminal_only_continuations",
 			"trajectory_token_budget",
 		] as const) {
@@ -169,6 +168,44 @@ describe("classifyStructuredFailureCause", () => {
 			});
 			expect(classifyStructuredFailureCause(error)).toBe("planner_exhaustion");
 		}
+	});
+
+	it("uses repeated action-failure provenance instead of collapsing it", () => {
+		const handler = new TrajectoryLimitExceeded({
+			kind: "repeated_failures",
+			max: 2,
+			observed: 3,
+			failureProvenance: {
+				kind: "handler_error",
+				boundary: "handler",
+				code: "HANDLER_FAILED",
+				retryable: true,
+			},
+		});
+		const persistence = new TrajectoryLimitExceeded({
+			kind: "repeated_failures",
+			max: 2,
+			observed: 3,
+			failureProvenance: {
+				kind: "persistence_error",
+				boundary: "persistence",
+				code: "WRITE_FAILED",
+				retryable: true,
+			},
+		});
+		expect(classifyStructuredFailureCause(handler)).toBe("handler_error");
+		expect(classifyStructuredFailureCause(persistence)).toBe(
+			"persistence_error",
+		);
+		expect(
+			classifyStructuredFailureCause(
+				new TrajectoryLimitExceeded({
+					kind: "repeated_failures",
+					max: 2,
+					observed: 3,
+				}),
+			),
+		).toBe("planner_exhaustion");
 	});
 
 	it("maps arbitrary errors and non-errors to transient", () => {
@@ -198,6 +235,15 @@ describe("buildFailureReplyPrompt per-cause variants", () => {
 		expect(prompt).toContain("suggest a retry");
 	});
 
+	it("handler and persistence variants name different failed boundaries", () => {
+		const handler = buildFailureReplyPrompt(RECENT, "handler_error");
+		const persistence = buildFailureReplyPrompt(RECENT, "persistence_error");
+		expect(handler).toContain("An action failed");
+		expect(handler).toContain("was not completed");
+		expect(persistence).toContain("could not be saved");
+		expect(persistence).toContain("must not be described as completed");
+	});
+
 	it("explicit transient matches the default prompt byte-for-byte", () => {
 		expect(buildFailureReplyPrompt(RECENT, "transient")).toBe(
 			buildFailureReplyPrompt(RECENT),
@@ -207,6 +253,8 @@ describe("buildFailureReplyPrompt per-cause variants", () => {
 	it("every variant keeps the never-answer-on-the-merits rule", () => {
 		for (const cause of [
 			"missing_capability",
+			"handler_error",
+			"persistence_error",
 			"planner_exhaustion",
 			"transient",
 		] as const) {

--- a/packages/core/src/services/__tests__/failure-reply-prompt.test.ts
+++ b/packages/core/src/services/__tests__/failure-reply-prompt.test.ts
@@ -137,13 +137,13 @@ describe("buildFailureReplyPrompt", () => {
  * that killed the runtime, never from prose.
  */
 describe("classifyStructuredFailureCause", () => {
-	it("maps required_tool_misses to missing_capability", () => {
+	it("maps required_tool_misses to planner_exhaustion", () => {
 		const error = new TrajectoryLimitExceeded({
 			kind: "required_tool_misses",
 			max: 3,
 			observed: 4,
 		});
-		expect(classifyStructuredFailureCause(error)).toBe("missing_capability");
+		expect(classifyStructuredFailureCause(error)).toBe("planner_exhaustion");
 	});
 
 	it("maps unavailable_tool_calls to missing_capability", () => {

--- a/packages/core/src/services/__tests__/failure-reply-prompt.test.ts
+++ b/packages/core/src/services/__tests__/failure-reply-prompt.test.ts
@@ -6,9 +6,11 @@
  */
 import { APICallError, RetryError } from "ai";
 import { describe, expect, it } from "vitest";
+import { TrajectoryLimitExceeded } from "../../runtime/limits";
 import { ModelType } from "../../types";
 import {
 	buildFailureReplyPrompt,
+	classifyStructuredFailureCause,
 	isModelProviderFallbackError,
 	isRateLimitError,
 } from "../message";
@@ -125,6 +127,95 @@ describe("buildFailureReplyPrompt", () => {
 		const prompt = buildFailureReplyPrompt(RECENT);
 		expect(prompt.endsWith("Reply:")).toBe(true);
 		expect(prompt).not.toContain("```");
+	});
+});
+
+/**
+ * #17027 AC6 — distinguishable failure causes. A missing capability, planner
+ * exhaustion, and a transient provider blip must produce distinguishable
+ * user-facing replies; the cause is classified structurally from the error
+ * that killed the runtime, never from prose.
+ */
+describe("classifyStructuredFailureCause", () => {
+	it("maps required_tool_misses to missing_capability", () => {
+		const error = new TrajectoryLimitExceeded({
+			kind: "required_tool_misses",
+			max: 3,
+			observed: 4,
+		});
+		expect(classifyStructuredFailureCause(error)).toBe("missing_capability");
+	});
+
+	it("maps unavailable_tool_calls to missing_capability", () => {
+		const error = new TrajectoryLimitExceeded({
+			kind: "unavailable_tool_calls",
+			max: 3,
+			observed: 4,
+		});
+		expect(classifyStructuredFailureCause(error)).toBe("missing_capability");
+	});
+
+	it("maps budget-style trajectory limits to planner_exhaustion", () => {
+		for (const kind of [
+			"tool_calls",
+			"repeated_failures",
+			"terminal_only_continuations",
+			"trajectory_token_budget",
+		] as const) {
+			const error = new TrajectoryLimitExceeded({
+				kind,
+				max: 16,
+				observed: 17,
+			});
+			expect(classifyStructuredFailureCause(error)).toBe("planner_exhaustion");
+		}
+	});
+
+	it("maps arbitrary errors and non-errors to transient", () => {
+		expect(classifyStructuredFailureCause(new Error("ECONNRESET"))).toBe(
+			"transient",
+		);
+		expect(classifyStructuredFailureCause("boom")).toBe("transient");
+		expect(classifyStructuredFailureCause(undefined)).toBe("transient");
+	});
+});
+
+describe("buildFailureReplyPrompt per-cause variants", () => {
+	const RECENT = "@user: track my daily pushups";
+
+	it("missing_capability names the gap and forbids a retry promise", () => {
+		const prompt = buildFailureReplyPrompt(RECENT, "missing_capability");
+		expect(prompt).toContain("capability which is not available");
+		expect(prompt).toContain("not able to do that here right now");
+		expect(prompt).toContain("Do NOT claim it was done");
+		expect(prompt).not.toContain("suggest a retry");
+	});
+
+	it("planner_exhaustion admits the request was not finished", () => {
+		const prompt = buildFailureReplyPrompt(RECENT, "planner_exhaustion");
+		expect(prompt).toContain("ran out of attempts");
+		expect(prompt).toContain("could not finish the request");
+		expect(prompt).toContain("suggest a retry");
+	});
+
+	it("explicit transient matches the default prompt byte-for-byte", () => {
+		expect(buildFailureReplyPrompt(RECENT, "transient")).toBe(
+			buildFailureReplyPrompt(RECENT),
+		);
+	});
+
+	it("every variant keeps the never-answer-on-the-merits rule", () => {
+		for (const cause of [
+			"missing_capability",
+			"planner_exhaustion",
+			"transient",
+		] as const) {
+			const prompt = buildFailureReplyPrompt(RECENT, cause);
+			expect(prompt).toContain(
+				"NEVER answer the user's question on the merits",
+			);
+			expect(prompt.endsWith("Reply:")).toBe(true);
+		}
 	});
 });
 

--- a/packages/core/src/services/message.character-failure-templates.test.ts
+++ b/packages/core/src/services/message.character-failure-templates.test.ts
@@ -316,21 +316,32 @@ describe("character failure templates on the connector delivery path", () => {
 		});
 	}
 
-	it.each([
-		["missing capability", missingCapabilityError],
-		["planner exhaustion", plannerExhaustionError],
-	] as const)(
-		"keeps the character voice for %s through transientFailureReply compatibility",
-		async (_label: string, makeError: () => Error) => {
-			const visibleTexts = await runTurn(makeError(), {
-				templates: {
-					transientFailureReply: TEMPLATES.transientFailureReply,
-				},
-			});
+	it("never uses transientFailureReply for a missing capability", async () => {
+		// Permanent gap: only the dedicated key or the built-in capability
+		// copy may ship. Legacy transient voice ("try again") must not leak.
+		const visibleTexts = await runTurn(missingCapabilityError(), {
+			templates: {
+				transientFailureReply: TEMPLATES.transientFailureReply,
+			},
+		});
 
-			expect(visibleTexts).toEqual([TEMPLATES.transientFailureReply]);
-		},
-	);
+		expect(visibleTexts).toHaveLength(1);
+		expect(visibleTexts[0]).not.toBe(TEMPLATES.transientFailureReply);
+		expect(visibleTexts[0]?.toLowerCase()).not.toMatch(
+			/\btry (that )?again\b|\bin a moment\b/,
+		);
+		expect(visibleTexts[0]?.toLowerCase()).toMatch(/capability|can't|cannot/);
+	});
+
+	it("keeps the character voice for planner exhaustion through transientFailureReply compatibility", async () => {
+		const visibleTexts = await runTurn(plannerExhaustionError(), {
+			templates: {
+				transientFailureReply: TEMPLATES.transientFailureReply,
+			},
+		});
+
+		expect(visibleTexts).toEqual([TEMPLATES.transientFailureReply]);
+	});
 
 	it("keeps the framework insufficient-credits default reachable", async () => {
 		// Guards the fallback expression itself: if `|| INSUFFICIENT_CREDITS_REPLY`

--- a/packages/core/src/services/message.character-failure-templates.test.ts
+++ b/packages/core/src/services/message.character-failure-templates.test.ts
@@ -1,5 +1,5 @@
 /**
- * Proves the five `character.templates.*Reply` keys are genuinely wired: when
+ * Proves the seven `character.templates.*Reply` keys are genuinely wired: when
  * every model call fails, the connector delivery path must emit the
  * character's own string instead of the voice-neutral framework default, so a
  * persona does not visibly break at the worst possible moment.
@@ -22,6 +22,7 @@ import { v4 } from "uuid";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CharacterFailureTemplates } from "../contracts/first-run-options";
 import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "../runtime/builtin-field-evaluators";
+import { TrajectoryLimitExceeded } from "../runtime/limits";
 import { ResponseHandlerFieldRegistry } from "../runtime/response-handler-field-registry";
 import { TurnControllerRegistry } from "../runtime/turn-controller";
 import { createMockRuntime } from "../testing/mock-runtime";
@@ -50,7 +51,9 @@ const RUN_ID = "00000000-0000-0000-0000-00000000002d" as UUID;
 const TEMPLATES = {
 	authFailedReply: "sentinel: my key isn't being accepted.",
 	insufficientCreditsReply: "sentinel: my provider is out of credits.",
+	missingCapabilityFailureReply: "sentinel: i cannot use that capability here.",
 	noModelProviderReply: "sentinel: i have no model provider yet.",
+	plannerExhaustionFailureReply: "sentinel: i could not finish in time.",
 	rateLimitedReply: "sentinel: my provider is throttling me.",
 	transientFailureReply: "sentinel: something broke on my end.",
 } satisfies Required<CharacterFailureTemplates>;
@@ -76,6 +79,22 @@ function authError(): Error {
 
 function transientError(): Error {
 	return new Error("socket hang up");
+}
+
+function missingCapabilityError(): Error {
+	return new TrajectoryLimitExceeded({
+		kind: "unavailable_tool_calls",
+		max: 3,
+		observed: 4,
+	});
+}
+
+function plannerExhaustionError(): Error {
+	return new TrajectoryLimitExceeded({
+		kind: "required_tool_misses",
+		max: 3,
+		observed: 4,
+	});
 }
 
 function makeMessage(overrides: Partial<Content> = {}): Memory {
@@ -197,7 +216,7 @@ async function runTurn(
 
 /**
  * Each row is one failure classification, its triggering error, and the
- * template key the runtime must read for it. Driving all five off one table
+ * template key the runtime must read for it. Driving all seven off one table
  * makes an unwired key impossible to miss.
  */
 const CASES = [
@@ -223,6 +242,18 @@ const CASES = [
 		kind: "other transient failure",
 		key: "transientFailureReply",
 		error: transientError,
+		options: {},
+	},
+	{
+		kind: "missing capability",
+		key: "missingCapabilityFailureReply",
+		error: missingCapabilityError,
+		options: {},
+	},
+	{
+		kind: "planner exhaustion",
+		key: "plannerExhaustionFailureReply",
+		error: plannerExhaustionError,
 		options: {},
 	},
 	{
@@ -284,6 +315,22 @@ describe("character failure templates on the connector delivery path", () => {
 			}
 		});
 	}
+
+	it.each([
+		["missing capability", missingCapabilityError],
+		["planner exhaustion", plannerExhaustionError],
+	] as const)(
+		"keeps the character voice for %s through transientFailureReply compatibility",
+		async (_label: string, makeError: () => Error) => {
+			const visibleTexts = await runTurn(makeError(), {
+				templates: {
+					transientFailureReply: TEMPLATES.transientFailureReply,
+				},
+			});
+
+			expect(visibleTexts).toEqual([TEMPLATES.transientFailureReply]);
+		},
+	);
 
 	it("keeps the framework insufficient-credits default reachable", async () => {
 		// Guards the fallback expression itself: if `|| INSUFFICIENT_CREDITS_REPLY`

--- a/packages/core/src/services/message.credit-exhaustion-reply.test.ts
+++ b/packages/core/src/services/message.credit-exhaustion-reply.test.ts
@@ -18,6 +18,7 @@
 import { v4 } from "uuid";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "../runtime/builtin-field-evaluators";
+import { TrajectoryLimitExceeded } from "../runtime/limits";
 import { ResponseHandlerFieldRegistry } from "../runtime/response-handler-field-registry";
 import { TurnControllerRegistry } from "../runtime/turn-controller";
 import { createMockRuntime } from "../testing/mock-runtime";
@@ -80,7 +81,11 @@ function makeState(): State {
 	return { values: {}, data: {}, text: "" };
 }
 
-function makeFailingRuntime(room: Room, failure: Error): IAgentRuntime {
+function makeFailingRuntime(
+	room: Room,
+	failure: Error,
+	templates: Record<string, string> = {},
+): IAgentRuntime {
 	const responseHandlerFieldRegistry = new ResponseHandlerFieldRegistry();
 	for (const evaluator of BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS) {
 		responseHandlerFieldRegistry.register(evaluator);
@@ -90,6 +95,7 @@ function makeFailingRuntime(room: Room, failure: Error): IAgentRuntime {
 		character: {
 			name: "Remilio",
 			bio: "test agent",
+			templates,
 		},
 		logger: {
 			debug: vi.fn(),
@@ -142,8 +148,13 @@ function makeRoom(type: ChannelType): Room {
 	} as Room;
 }
 
-async function runTurn(message: Memory, room: Room, failure: Error) {
-	const runtime = makeFailingRuntime(room, failure);
+async function runTurn(
+	message: Memory,
+	room: Room,
+	failure: Error,
+	templates: Record<string, string> = {},
+) {
+	const runtime = makeFailingRuntime(room, failure, templates);
 	const service = new DefaultMessageService();
 	const deliveries: Content[] = [];
 	const result = await service.handleMessage(
@@ -241,4 +252,141 @@ describe("connector turn failing on 402 credit exhaustion", () => {
 		expect(visibleTexts).toHaveLength(1);
 		expect(visibleTexts[0]).toBe(INSUFFICIENT_CREDITS_REPLY);
 	});
+
+	it.each([
+		{
+			label: "authentication failure",
+			failure: Object.assign(new Error("Invalid API key"), { status: 401 }),
+			failureKind: "provider_issue",
+			transient: false,
+		},
+		{
+			label: "provider throttling",
+			failure: Object.assign(new Error("Rate limit exceeded"), { status: 429 }),
+			failureKind: "rate_limited",
+			transient: true,
+		},
+	])(
+		"marks $label with accurate transient semantics",
+		async ({
+			failure,
+			failureKind,
+			transient,
+		}: {
+			failure: Error;
+			failureKind: string;
+			transient: boolean;
+		}) => {
+			const { deliveries } = await runTurn(
+				makeMessage(),
+				makeRoom(ChannelType.GROUP),
+				failure,
+			);
+			const reply = deliveries.find(
+				(content) => content.elizaSyntheticFailure === true,
+			);
+			expect(reply).toMatchObject({
+				failureKind,
+				transient,
+				doNotPersist: true,
+			});
+		},
+	);
+});
+
+describe("structured trajectory failure connector boundary", () => {
+	beforeEach(() => {
+		vi.stubEnv("ELIZA_TRAJECTORY_RECORDING", "0");
+	});
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it.each([
+		{
+			kind: "required_tool_misses" as const,
+			failureKind: "planner_exhaustion",
+			transient: false,
+			text: /ran out of attempts/i,
+		},
+		{
+			kind: "unavailable_tool_calls" as const,
+			failureKind: "missing_capability",
+			transient: false,
+			text: /capability.*isn't available/i,
+		},
+	])(
+		"delivers $kind as $failureKind with accurate persistence metadata",
+		async ({
+			kind,
+			failureKind,
+			transient,
+			text,
+		}: {
+			kind: "required_tool_misses" | "unavailable_tool_calls";
+			failureKind: string;
+			transient: boolean;
+			text: RegExp;
+		}) => {
+			const failure = new TrajectoryLimitExceeded({
+				kind,
+				max: 3,
+				observed: 4,
+			});
+			const { runtime, deliveries } = await runTurn(
+				makeMessage(),
+				makeRoom(ChannelType.GROUP),
+				failure,
+			);
+
+			const reply = deliveries.find(
+				(content) => content.elizaSyntheticFailure === true,
+			);
+			expect(reply).toMatchObject({
+				failureKind,
+				transient,
+				doNotPersist: true,
+			});
+			expect(reply?.text).toMatch(text);
+			expect(runtime.reportError).toHaveBeenCalledWith(
+				"MessageService.v5Runtime",
+				failure,
+				expect.objectContaining({ roomId: ROOM }),
+			);
+		},
+	);
+
+	it.each([
+		[
+			"missingCapabilityFailureReply",
+			"unavailable_tool_calls",
+			"No puedo usar esa capacidad aquí.",
+		],
+		[
+			"plannerExhaustionFailureReply",
+			"required_tool_misses",
+			"No pude terminar a tiempo. Inténtalo de nuevo.",
+		],
+	] as const)(
+		"uses the character %s override for localization",
+		async (templateKey:
+			| "missingCapabilityFailureReply"
+			| "plannerExhaustionFailureReply", kind:
+			| "unavailable_tool_calls"
+			| "required_tool_misses", localizedReply: string) => {
+			const failure = new TrajectoryLimitExceeded({
+				kind,
+				max: 3,
+				observed: 4,
+			});
+			const { visibleTexts } = await runTurn(
+				makeMessage(),
+				makeRoom(ChannelType.GROUP),
+				failure,
+				{ [templateKey]: localizedReply },
+			);
+
+			expect(visibleTexts).toEqual([localizedReply]);
+		},
+	);
 });

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -359,10 +359,12 @@ import {
 } from "./message/direct-action-heuristics";
 import {
 	buildFailureReplyPrompt,
+	classifyStructuredFailureCause,
 	INSUFFICIENT_CREDITS_REPLY,
 	isAuthError,
 	isInsufficientCreditsError,
 	isRateLimitError,
+	type StructuredFailureCause,
 	stripReasoningBlocks,
 } from "./message/fallback-reply";
 import {
@@ -1587,12 +1589,14 @@ export function shouldSkipResponseMemoryPersistence(memory: Memory): boolean {
 
 export {
 	buildFailureReplyPrompt,
+	classifyStructuredFailureCause,
 	INSUFFICIENT_CREDITS_REPLY,
 	isAuthError,
 	isInsufficientCreditsError,
 	isInsufficientCreditsMessage,
 	isModelProviderFallbackError,
 	isRateLimitError,
+	type StructuredFailureCause,
 	stripReasoningBlocks,
 } from "./message/fallback-reply";
 export {
@@ -12894,12 +12898,26 @@ export class DefaultMessageService implements IMessageService {
 				if (failureGate.addressed || stage1DecidedRespond) {
 					shouldRespondToMessage = true;
 					terminalDecision = null;
+					// Distinguish WHY the runtime died so the failure reply names
+					// the real condition: a capability that was never invocable is
+					// not a transient blip and must not read like one (#17027 AC6).
+					const failureCause = classifyStructuredFailureCause(error);
+					runtime.logger.info(
+						{
+							src: "service:message",
+							agentId: runtime.agentId,
+							roomId: message.roomId,
+							failureCause,
+						},
+						"MessageService: structured failure reply cause classified",
+					);
 					strategyResult = await this.buildStructuredFailureReply(
 						runtime,
 						message,
 						state,
 						responseId,
 						"running the native tool message runtime",
+						failureCause,
 					);
 					_usedV5Runtime = true;
 					state = strategyResult.state;
@@ -14381,6 +14399,7 @@ export class DefaultMessageService implements IMessageService {
 		state: State,
 		responseId: UUID,
 		stage: string,
+		cause: StructuredFailureCause = "transient",
 	): Promise<StrategyResult> {
 		// Short-circuit when no LLM provider is configured at all. The fallback
 		// model loop below would just throw `NoModelProviderConfiguredError` for
@@ -14400,7 +14419,7 @@ export class DefaultMessageService implements IMessageService {
 			state,
 			message,
 		);
-		const failurePrompt = buildFailureReplyPrompt(recentMessages);
+		const failurePrompt = buildFailureReplyPrompt(recentMessages, cause);
 
 		const attempt = await this.generateFailureReplyText(
 			runtime,
@@ -14440,6 +14459,15 @@ export class DefaultMessageService implements IMessageService {
 				replyText =
 					(typeof tmpl === "function" ? tmpl({ state }) : tmpl) ||
 					"My Eliza Cloud key isn't authorized for inference right now — check that your cloud key is valid and your account has credits, then try again.";
+			} else if (cause === "missing_capability") {
+				// Not transient: retrying cannot succeed until the capability is
+				// enabled, so the default names the gap instead of inviting a
+				// retry (#17027 AC6).
+				replyText =
+					"I can't do that here right now - it needs a capability that isn't available in this setup.";
+			} else if (cause === "planner_exhaustion") {
+				replyText =
+					"I ran out of attempts before I could finish that. Nothing was completed - please try again.";
 			} else {
 				const tmpl = runtime.character.templates?.transientFailureReply;
 				replyText =

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -14482,15 +14482,25 @@ export class DefaultMessageService implements IMessageService {
 		// up — so the synthetic reply carries the structural kind downstream
 		// consumers already key on (chat DTO failureKind gate, recent-messages
 		// synthetic-failure filter) instead of masquerading as a blip.
+		const failureKind =
+			attempt.kind === "creditsExhausted"
+				? "insufficient_credits"
+				: attempt.kind === "rateLimited"
+					? "rate_limited"
+					: attempt.kind === "authFailed"
+						? "provider_issue"
+						: cause === "transient"
+							? "transient_failure"
+							: cause;
 		const responseContent: Content = {
-			thought: `Handle a temporary reply failure during ${stage}.`,
+			thought: `Handle a ${cause} reply failure during ${stage}.`,
 			actions: ["REPLY"],
-			failureKind:
-				attempt.kind === "creditsExhausted"
-					? "insufficient_credits"
-					: "transient_failure",
+			failureKind,
 			elizaSyntheticFailure: true,
-			transient: true,
+			transient:
+				failureKind === "transient_failure" ||
+				failureKind === "rate_limited" ||
+				failureKind === "provider_issue",
 			doNotPersist: true,
 			text: replyText,
 			responseId,

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -13062,6 +13062,9 @@ export class DefaultMessageService implements IMessageService {
 				result = strategyResult;
 			} else {
 				_usedV5Runtime = true;
+				// No thrown trajectory error reaches this fallback-only branch, so
+				// there is no structural capability/exhaustion cause to preserve.
+				// Keep the default generic transient classification.
 				result = await this.buildStructuredFailureReply(
 					runtime,
 					message,
@@ -14463,10 +14466,22 @@ export class DefaultMessageService implements IMessageService {
 				// Not transient: retrying cannot succeed until the capability is
 				// enabled, so the default names the gap instead of inviting a
 				// retry (#17027 AC6).
+				const tmpl = runtime.character.templates?.missingCapabilityFailureReply;
+				const fallbackTmpl = runtime.character.templates?.transientFailureReply;
 				replyText =
+					(typeof tmpl === "function" ? tmpl({ state }) : tmpl) ||
+					(typeof fallbackTmpl === "function"
+						? fallbackTmpl({ state })
+						: fallbackTmpl) ||
 					"I can't do that here right now - it needs a capability that isn't available in this setup.";
 			} else if (cause === "planner_exhaustion") {
+				const tmpl = runtime.character.templates?.plannerExhaustionFailureReply;
+				const fallbackTmpl = runtime.character.templates?.transientFailureReply;
 				replyText =
+					(typeof tmpl === "function" ? tmpl({ state }) : tmpl) ||
+					(typeof fallbackTmpl === "function"
+						? fallbackTmpl({ state })
+						: fallbackTmpl) ||
 					"I ran out of attempts before I could finish that. Nothing was completed - please try again.";
 			} else {
 				const tmpl = runtime.character.templates?.transientFailureReply;
@@ -14478,10 +14493,12 @@ export class DefaultMessageService implements IMessageService {
 
 		replyText = truncateToCompleteSentence(replyText.trim(), 2000);
 
-		// Credit exhaustion is not transient — it persists until the user tops
-		// up — so the synthetic reply carries the structural kind downstream
-		// consumers already key on (chat DTO failureKind gate, recent-messages
-		// synthetic-failure filter) instead of masquerading as a blip.
+		// Preserve the terminal cause at the delivery boundary. Provider failures
+		// encountered while generating the apology take precedence because the
+		// canned reply describes that condition. Capability, action, persistence,
+		// auth, and credit failures remain stable until their cause changes;
+		// throttling, planner exhaustion, and generic infrastructure failures can
+		// be retried without presenting a durable success record.
 		const failureKind =
 			attempt.kind === "creditsExhausted"
 				? "insufficient_credits"
@@ -14498,9 +14515,7 @@ export class DefaultMessageService implements IMessageService {
 			failureKind,
 			elizaSyntheticFailure: true,
 			transient:
-				failureKind === "transient_failure" ||
-				failureKind === "rate_limited" ||
-				failureKind === "provider_issue",
+				failureKind === "transient_failure" || failureKind === "rate_limited",
 			doNotPersist: true,
 			text: replyText,
 			responseId,

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -14463,18 +14463,19 @@ export class DefaultMessageService implements IMessageService {
 					(typeof tmpl === "function" ? tmpl({ state }) : tmpl) ||
 					"My Eliza Cloud key isn't authorized for inference right now — check that your cloud key is valid and your account has credits, then try again.";
 			} else if (cause === "missing_capability") {
-				// Not transient: retrying cannot succeed until the capability is
-				// enabled, so the default names the gap instead of inviting a
-				// retry (#17027 AC6).
+				// Permanent gap: never fall through to transientFailureReply
+				// ("try again in a moment") — that copy invites a retry that
+				// cannot succeed until the capability is enabled (#17027 AC6).
+				// Dedicated template when present; otherwise the built-in
+				// capability-unavailable default.
 				const tmpl = runtime.character.templates?.missingCapabilityFailureReply;
-				const fallbackTmpl = runtime.character.templates?.transientFailureReply;
 				replyText =
 					(typeof tmpl === "function" ? tmpl({ state }) : tmpl) ||
-					(typeof fallbackTmpl === "function"
-						? fallbackTmpl({ state })
-						: fallbackTmpl) ||
 					"I can't do that here right now - it needs a capability that isn't available in this setup.";
 			} else if (cause === "planner_exhaustion") {
+				// Retryable budget exhaustion. Dedicated template first; the
+				// legacy transientFailureReply remains a voice-compatible
+				// fallback only for this recoverable class.
 				const tmpl = runtime.character.templates?.plannerExhaustionFailureReply;
 				const fallbackTmpl = runtime.character.templates?.transientFailureReply;
 				replyText =

--- a/packages/core/src/services/message/fallback-reply.ts
+++ b/packages/core/src/services/message/fallback-reply.ts
@@ -9,6 +9,7 @@
  * merits), and stripReasoningBlocks removes <think> spans from the raw reply.
  */
 import { TrajectoryLimitExceeded } from "../../runtime/limits";
+import { readActionFailureProvenance } from "../../types/action-failure";
 import { ModelType } from "../../types/model";
 
 type ErrorWithStatus = {
@@ -319,6 +320,8 @@ export function isModelProviderFallbackError(
  */
 export type StructuredFailureCause =
 	| "missing_capability"
+	| "handler_error"
+	| "persistence_error"
 	| "planner_exhaustion"
 	| "transient";
 
@@ -334,17 +337,36 @@ export function classifyStructuredFailureCause(
 	error: unknown,
 ): StructuredFailureCause {
 	if (error instanceof TrajectoryLimitExceeded) {
-		return error.kind === "required_tool_misses" ||
-			error.kind === "unavailable_tool_calls"
-			? "missing_capability"
-			: "planner_exhaustion";
+		switch (error.kind) {
+			case "required_tool_misses":
+			case "unavailable_tool_calls":
+				return "missing_capability";
+			case "repeated_failures":
+				return error.failureProvenance?.kind ?? "planner_exhaustion";
+			case "tool_calls":
+			case "terminal_only_continuations":
+			case "trajectory_token_budget":
+				return "planner_exhaustion";
+			default: {
+				const exhaustive: never = error.kind;
+				return exhaustive;
+			}
+		}
 	}
-	return "transient";
+	return readActionFailureProvenance(error)?.kind ?? "transient";
 }
 
 const FAILURE_PROMPT_CAUSE_LINES: Record<StructuredFailureCause, string[]> = {
 	missing_capability: [
 		"The user asked for something that needs a capability which is not available in this setup, so the request could not be carried out.",
+		"Write a one or two sentence reply in plain language.",
+	],
+	handler_error: [
+		"An action failed while carrying out the user's request, so the request was not completed.",
+		"Write a one or two sentence reply in plain language.",
+	],
+	persistence_error: [
+		"The requested change reached its persistence boundary but could not be saved, so it must not be described as completed.",
 		"Write a one or two sentence reply in plain language.",
 	],
 	planner_exhaustion: [
@@ -361,6 +383,10 @@ const FAILURE_PROMPT_CAUSE_RETRY_RULE: Record<StructuredFailureCause, string> =
 	{
 		missing_capability:
 			"- Tell the user plainly that you are not able to do that here right now. Do NOT claim it was done, and do not promise to retry - retrying cannot succeed until the capability is enabled.",
+		handler_error:
+			"- Tell the user that the action failed and was not completed. Do not claim success; suggest a retry only if appropriate.",
+		persistence_error:
+			"- Tell the user that the change could not be saved and was not completed. Do not claim success; suggest a retry.",
 		planner_exhaustion:
 			"- Acknowledge that you could not finish the request and suggest a retry.",
 		transient: "- Acknowledge that something went wrong and suggest a retry.",

--- a/packages/core/src/services/message/fallback-reply.ts
+++ b/packages/core/src/services/message/fallback-reply.ts
@@ -8,6 +8,7 @@
  * buildFailureReplyPrompt shapes the in-character apology (never answering on the
  * merits), and stripReasoningBlocks removes <think> spans from the raw reply.
  */
+import { TrajectoryLimitExceeded } from "../../runtime/limits";
 import { ModelType } from "../../types/model";
 
 type ErrorWithStatus = {
@@ -301,17 +302,83 @@ export function isModelProviderFallbackError(
 	);
 }
 
-export function buildFailureReplyPrompt(recentMessages: string): string {
-	return [
+/**
+ * Why the turn ended on the structured-failure path, classified from the
+ * error that killed the runtime (#17027 AC6). Distinguishable causes get
+ * distinguishable user-facing replies instead of one generic
+ * "something flaked" template:
+ *
+ * - `missing_capability` — the planner required a tool it could never call
+ *   (the tool was requested but not exposed, or the requirement exhausted
+ *   without a single valid call). Retrying cannot help; the honest reply
+ *   names the gap.
+ * - `planner_exhaustion` — the planner ran out of budget (tool calls,
+ *   repeated failures, token budget) before finishing. Retrying may help.
+ * - `transient` — a model/provider/infrastructure error; the pre-existing
+ *   generic path.
+ */
+export type StructuredFailureCause =
+	| "missing_capability"
+	| "planner_exhaustion"
+	| "transient";
+
+/**
+ * Classify the error that aborted the message runtime into a
+ * `StructuredFailureCause`. Trajectory-limit aborts are the only errors
+ * that structurally identify their cause today: `required_tool_misses` and
+ * `unavailable_tool_calls` mean the turn demanded a capability that was
+ * never successfully invocable, while the remaining limit kinds mean the
+ * planner exhausted its budget mid-task. Everything else stays `transient`.
+ */
+export function classifyStructuredFailureCause(
+	error: unknown,
+): StructuredFailureCause {
+	if (error instanceof TrajectoryLimitExceeded) {
+		return error.kind === "required_tool_misses" ||
+			error.kind === "unavailable_tool_calls"
+			? "missing_capability"
+			: "planner_exhaustion";
+	}
+	return "transient";
+}
+
+const FAILURE_PROMPT_CAUSE_LINES: Record<StructuredFailureCause, string[]> = {
+	missing_capability: [
+		"The user asked for something that needs a capability which is not available in this setup, so the request could not be carried out.",
+		"Write a one or two sentence reply in plain language.",
+	],
+	planner_exhaustion: [
+		"You ran out of attempts while working on the user's request and could not finish it.",
+		"Write a one or two sentence reply in plain language.",
+	],
+	transient: [
 		"You hit a transient model error and have to send a short user-facing reply.",
 		"Write a one or two sentence reply in plain language.",
+	],
+};
+
+const FAILURE_PROMPT_CAUSE_RETRY_RULE: Record<StructuredFailureCause, string> =
+	{
+		missing_capability:
+			"- Tell the user plainly that you are not able to do that here right now. Do NOT claim it was done, and do not promise to retry - retrying cannot succeed until the capability is enabled.",
+		planner_exhaustion:
+			"- Acknowledge that you could not finish the request and suggest a retry.",
+		transient: "- Acknowledge that something went wrong and suggest a retry.",
+	};
+
+export function buildFailureReplyPrompt(
+	recentMessages: string,
+	cause: StructuredFailureCause = "transient",
+): string {
+	return [
+		...FAILURE_PROMPT_CAUSE_LINES[cause],
 		"",
 		"Hard rules:",
 		"- Stay in character. Keep your usual voice and tone.",
 		"- NEVER answer the user's question on the merits.",
 		"- The trajectory that would have GROUNDED the answer failed, so do not emit answer-shaped tokens from memory or context.",
 		"- Do not provide a SHA, a count, a price, a date, a status, a file path, or a name as if it were verified.",
-		"- Acknowledge that something went wrong and suggest a retry.",
+		FAILURE_PROMPT_CAUSE_RETRY_RULE[cause],
 		"- Do not paraphrase or echo the user's question as if you are about to answer it.",
 		"- NEVER mention internal mechanism words such as: planner, action_planner,",
 		"  XML, JSON, schema, structured output, model, retries, sonnet,",

--- a/packages/core/src/services/message/fallback-reply.ts
+++ b/packages/core/src/services/message/fallback-reply.ts
@@ -309,10 +309,9 @@ export function isModelProviderFallbackError(
  * distinguishable user-facing replies instead of one generic
  * "something flaked" template:
  *
- * - `missing_capability` — the planner required a tool it could never call
- *   (the tool was requested but not exposed, or the requirement exhausted
- *   without a single valid call). Retrying cannot help; the honest reply
- *   names the gap.
+ * - `missing_capability` — the planner requested a tool which was not
+ *   registered or otherwise invocable in this runtime. Retrying cannot help;
+ *   the honest reply names the gap.
  * - `planner_exhaustion` — the planner ran out of budget (tool calls,
  *   repeated failures, token budget) before finishing. Retrying may help.
  * - `transient` — a model/provider/infrastructure error; the pre-existing
@@ -328,10 +327,11 @@ export type StructuredFailureCause =
 /**
  * Classify the error that aborted the message runtime into a
  * `StructuredFailureCause`. Trajectory-limit aborts are the only errors
- * that structurally identify their cause today: `required_tool_misses` and
- * `unavailable_tool_calls` mean the turn demanded a capability that was
- * never successfully invocable, while the remaining limit kinds mean the
- * planner exhausted its budget mid-task. Everything else stays `transient`.
+ * that structurally identify their cause today. Only
+ * `unavailable_tool_calls` proves a capability is absent. A
+ * `required_tool_misses` limit can occur with a registered tool when the model
+ * repeatedly emits no usable call, so it is planner exhaustion and retryable.
+ * Everything else stays `transient`.
  */
 export function classifyStructuredFailureCause(
 	error: unknown,
@@ -339,6 +339,7 @@ export function classifyStructuredFailureCause(
 	if (error instanceof TrajectoryLimitExceeded) {
 		switch (error.kind) {
 			case "required_tool_misses":
+				return "planner_exhaustion";
 			case "unavailable_tool_calls":
 				return "missing_capability";
 			case "repeated_failures":

--- a/packages/core/src/types/action-failure.ts
+++ b/packages/core/src/types/action-failure.ts
@@ -1,0 +1,127 @@
+/**
+ * Defines the structural provenance attached to failed action results. The
+ * planner carries this metadata through retry exhaustion so the final failure
+ * boundary can distinguish capability, handler, and persistence failures
+ * without parsing error prose.
+ */
+
+export type ActionFailureKind =
+	| "missing_capability"
+	| "handler_error"
+	| "persistence_error";
+
+export type ActionFailureProvenance =
+	| {
+			kind: "missing_capability";
+			boundary: "capability";
+			code: string;
+			retryable: false;
+	  }
+	| {
+			kind: "handler_error";
+			boundary: "handler";
+			code: string;
+			retryable: boolean;
+	  }
+	| {
+			kind: "persistence_error";
+			boundary: "persistence";
+			code: string;
+			retryable: boolean;
+	  };
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	return value !== null && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+/** Validate action-owned failure metadata before it enters a planner trace. */
+export function normalizeActionFailureProvenance(
+	value: unknown,
+): ActionFailureProvenance {
+	const record = asRecord(value);
+	if (!record) {
+		throw new TypeError("ActionResult.failureProvenance must be an object.");
+	}
+	const code =
+		typeof record.code === "string" && record.code.trim().length > 0
+			? record.code.trim()
+			: null;
+	if (!code) {
+		throw new TypeError(
+			"ActionResult.failureProvenance.code must be a non-empty string.",
+		);
+	}
+	if (typeof record.retryable !== "boolean") {
+		throw new TypeError(
+			"ActionResult.failureProvenance.retryable must be a boolean.",
+		);
+	}
+
+	switch (record.kind) {
+		case "missing_capability":
+			if (record.boundary !== "capability" || record.retryable !== false) {
+				throw new TypeError(
+					"missing_capability provenance must use the capability boundary and retryable:false.",
+				);
+			}
+			return {
+				kind: "missing_capability",
+				boundary: "capability",
+				code,
+				retryable: false,
+			};
+		case "handler_error":
+			if (record.boundary !== "handler") {
+				throw new TypeError(
+					"handler_error provenance must use the handler boundary.",
+				);
+			}
+			return {
+				kind: "handler_error",
+				boundary: "handler",
+				code,
+				retryable: record.retryable,
+			};
+		case "persistence_error":
+			if (record.boundary !== "persistence") {
+				throw new TypeError(
+					"persistence_error provenance must use the persistence boundary.",
+				);
+			}
+			return {
+				kind: "persistence_error",
+				boundary: "persistence",
+				code,
+				retryable: record.retryable,
+			};
+		default:
+			throw new TypeError(
+				"ActionResult.failureProvenance.kind is not supported.",
+			);
+	}
+}
+
+/**
+ * Read provenance from a thrown boundary error. Persistence adapters can attach
+ * it directly or under ElizaError.context; malformed lookalikes fail closed and
+ * are treated as ordinary handler errors by the settlement boundary.
+ */
+export function readActionFailureProvenance(
+	error: unknown,
+): ActionFailureProvenance | null {
+	const record = asRecord(error);
+	if (!record) return null;
+	const context = asRecord(record.context);
+	const candidate =
+		record.failureProvenance ?? context?.failureProvenance ?? undefined;
+	if (candidate === undefined) return null;
+	try {
+		return normalizeActionFailureProvenance(candidate);
+	} catch {
+		// error-policy:J3 malformed thrown metadata is untrusted input. The
+		// caller classifies the original exception as a handler error instead.
+		return null;
+	}
+}

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -5,6 +5,7 @@
  * action modes, message-handler plan/extract results). The heart of the
  * action/provider surface that the message loop dispatches against.
  */
+import type { ActionFailureProvenance } from "./action-failure";
 import type { ConnectorAccountPolicy } from "./connector-account-policy";
 import type {
 	AgentContext,
@@ -945,6 +946,13 @@ export interface ActionResult {
 	 * receipt from this turn.
 	 */
 	userFacingEffectReceiptIds?: readonly string[];
+
+	/**
+	 * Structural origin of a failed action. Persistence code sets this at its
+	 * commit boundary; the runtime sets it when capability lookup or a handler
+	 * throws. It must be absent on successful results.
+	 */
+	failureProvenance?: ActionFailureProvenance;
 
 	/** Values to merge into the state */
 	values?: Record<string, ProviderValue>;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -16,6 +16,7 @@ export {
 	parseKeyValueXml, // audit:allowlist - retained for cloud/ XML evaluators; new prompts must use JSON
 } from "../utils";
 export * from "./access-context";
+export * from "./action-failure";
 export * from "./agent";
 // Channel configuration types for plugins
 export * from "./channel-config";

--- a/packages/shared/src/contracts/chat.test.ts
+++ b/packages/shared/src/contracts/chat.test.ts
@@ -49,16 +49,20 @@ describe("ChatTurnStatus contract", () => {
 });
 
 describe("ChatFailureKind contract", () => {
-  it("covers exactly the six turn-failure discriminators", () => {
+  it("covers exactly the ten turn-failure discriminators", () => {
     const kinds: ChatFailureKind[] = [
       "insufficient_credits",
+      "missing_capability",
       "no_provider",
+      "planner_exhaustion",
       "provider_issue",
       "generation_timeout",
       "rate_limited",
+      "handler_error",
+      "persistence_error",
       "local_inference",
     ];
     expect(new Set(kinds).size).toBe(kinds.length);
-    expect(kinds).toHaveLength(6);
+    expect(kinds).toHaveLength(10);
   });
 });

--- a/packages/shared/src/contracts/chat.test.ts
+++ b/packages/shared/src/contracts/chat.test.ts
@@ -11,7 +11,15 @@ import type {
   ChatFailureKind as RootChatFailureKind,
   ChatTurnStatus as RootChatTurnStatus,
 } from "../index.js";
-import type { ChatFailureKind, ChatTurnStatus } from "./chat.js";
+import {
+  CHAT_FAILURE_KINDS,
+  type ChatFailureKind,
+  type ChatTurnStatus,
+  isChatFailureKind,
+  isRetryableChatFailureKind,
+  parseChatFailureKind,
+  RETRYABLE_CHAT_FAILURE_KINDS,
+} from "./chat.js";
 
 // Compile-time proof the root barrel re-exports the same declaration: a
 // mismatch on either side is a type error, not a silent divergence.
@@ -50,7 +58,10 @@ describe("ChatTurnStatus contract", () => {
 
 describe("ChatFailureKind contract", () => {
   it("covers exactly the ten turn-failure discriminators", () => {
-    const kinds: ChatFailureKind[] = [
+    const kinds: ChatFailureKind[] = [...CHAT_FAILURE_KINDS];
+    expect(new Set(kinds).size).toBe(kinds.length);
+    expect(kinds).toHaveLength(10);
+    expect(kinds).toEqual([
       "insufficient_credits",
       "missing_capability",
       "no_provider",
@@ -61,8 +72,35 @@ describe("ChatFailureKind contract", () => {
       "handler_error",
       "persistence_error",
       "local_inference",
-    ];
-    expect(new Set(kinds).size).toBe(kinds.length);
-    expect(kinds).toHaveLength(10);
+    ]);
+  });
+
+  it("validates every public kind and rejects unknowns", () => {
+    for (const kind of CHAT_FAILURE_KINDS) {
+      expect(isChatFailureKind(kind)).toBe(true);
+      expect(parseChatFailureKind(kind)).toBe(kind);
+    }
+    expect(isChatFailureKind("transient_failure")).toBe(false);
+    expect(isChatFailureKind("not_a_kind")).toBe(false);
+    expect(parseChatFailureKind("generation_timeout")).toBe(
+      "generation_timeout",
+    );
+    expect(parseChatFailureKind(undefined)).toBeUndefined();
+  });
+
+  it("marks only recoverable kinds retryable for UI contracts", () => {
+    const expectedRetryable = new Set<ChatFailureKind>([
+      ...RETRYABLE_CHAT_FAILURE_KINDS,
+    ]);
+    for (const kind of CHAT_FAILURE_KINDS) {
+      expect(isRetryableChatFailureKind(kind)).toBe(
+        expectedRetryable.has(kind),
+      );
+    }
+    expect(isRetryableChatFailureKind("planner_exhaustion")).toBe(true);
+    expect(isRetryableChatFailureKind("generation_timeout")).toBe(true);
+    expect(isRetryableChatFailureKind("missing_capability")).toBe(false);
+    expect(isRetryableChatFailureKind("no_provider")).toBe(false);
+    expect(isRetryableChatFailureKind("insufficient_credits")).toBe(false);
   });
 });

--- a/packages/shared/src/contracts/chat.ts
+++ b/packages/shared/src/contracts/chat.ts
@@ -70,19 +70,74 @@ export interface ChatToolCallEvent {
 }
 
 /**
+ * Exhaustive public turn-failure discriminators. Agent transport allowlists,
+ * history reconstruction, durable outcome validation, and UI retry gates must
+ * all derive from this single table so a new kind cannot ship half-wired.
+ *
+ * - `insufficient_credits` — billing/quota; do not retry as-is.
+ * - `missing_capability` — tool/capability absent; retry cannot help.
+ * - `no_provider` — no model configured; UX gate, not a chat retry.
+ * - `planner_exhaustion` — budget/attempt limit with tools present; retry may help.
+ * - `provider_issue` — provider/auth/infrastructure; often retryable.
+ * - `generation_timeout` — turn wall-clock expired; retryable.
+ * - `rate_limited` — throttle; retryable after a pause.
+ * - `handler_error` — action handler failed; not a generic Retry affordance.
+ * - `persistence_error` — save boundary failed; not a generic Retry affordance.
+ * - `local_inference` — local model path issue; may recover after load/retry.
+ */
+export const CHAT_FAILURE_KINDS = [
+  "insufficient_credits",
+  "missing_capability",
+  "no_provider",
+  "planner_exhaustion",
+  "provider_issue",
+  "generation_timeout",
+  "rate_limited",
+  "handler_error",
+  "persistence_error",
+  "local_inference",
+] as const;
+
+/**
  * Discriminator the conversation route includes in its 200 response so the
  * renderer can distinguish "provider configured but throwing" from "no
  * provider configured at all" — the latter is a UX gate ("Connect a
  * provider"), not a chat reply.
  */
-export type ChatFailureKind =
-  | "insufficient_credits"
-  | "missing_capability"
-  | "no_provider"
-  | "planner_exhaustion"
-  | "provider_issue"
-  | "generation_timeout"
-  | "rate_limited"
-  | "handler_error"
-  | "persistence_error"
-  | "local_inference";
+export type ChatFailureKind = (typeof CHAT_FAILURE_KINDS)[number];
+
+/**
+ * Failure kinds for which a one-tap Retry (resend preceding user turn) is a
+ * truthful affordance. Permanent configuration/billing/capability gaps and
+ * specialized action/persistence failures stay off this list so the UI does
+ * not invite a loop that cannot succeed.
+ */
+export const RETRYABLE_CHAT_FAILURE_KINDS = [
+  "provider_issue",
+  "rate_limited",
+  "local_inference",
+  "planner_exhaustion",
+  "generation_timeout",
+] as const satisfies readonly ChatFailureKind[];
+
+const CHAT_FAILURE_KIND_SET: ReadonlySet<string> = new Set(CHAT_FAILURE_KINDS);
+const RETRYABLE_CHAT_FAILURE_KIND_SET: ReadonlySet<string> = new Set(
+  RETRYABLE_CHAT_FAILURE_KINDS,
+);
+
+/** Exhaustive runtime validator for wire/transport failure discriminators. */
+export function isChatFailureKind(value: unknown): value is ChatFailureKind {
+  return typeof value === "string" && CHAT_FAILURE_KIND_SET.has(value);
+}
+
+/** Narrow unknown transport payloads to a public `ChatFailureKind` or drop. */
+export function parseChatFailureKind(
+  value: unknown,
+): ChatFailureKind | undefined {
+  return isChatFailureKind(value) ? value : undefined;
+}
+
+/** Whether UI surfaces should offer Retry for this structured failure. */
+export function isRetryableChatFailureKind(kind: ChatFailureKind): boolean {
+  return RETRYABLE_CHAT_FAILURE_KIND_SET.has(kind);
+}

--- a/packages/shared/src/contracts/chat.ts
+++ b/packages/shared/src/contracts/chat.ts
@@ -77,12 +77,12 @@ export interface ChatToolCallEvent {
  */
 export type ChatFailureKind =
   | "insufficient_credits"
+  | "missing_capability"
   | "no_provider"
+  | "planner_exhaustion"
   | "provider_issue"
   | "generation_timeout"
   | "rate_limited"
-  | "missing_capability"
   | "handler_error"
   | "persistence_error"
-  | "planner_exhaustion"
   | "local_inference";

--- a/packages/shared/src/contracts/chat.ts
+++ b/packages/shared/src/contracts/chat.ts
@@ -81,4 +81,8 @@ export type ChatFailureKind =
   | "provider_issue"
   | "generation_timeout"
   | "rate_limited"
+  | "missing_capability"
+  | "handler_error"
+  | "persistence_error"
+  | "planner_exhaustion"
   | "local_inference";

--- a/packages/shared/src/contracts/first-run-options.ts
+++ b/packages/shared/src/contracts/first-run-options.ts
@@ -50,6 +50,10 @@ export interface CharacterFailureTemplates {
   insufficientCreditsReply?: string;
   /** No LLM provider plugin is registered at all. */
   noModelProviderReply?: string;
+  /** A required capability is not registered in this runtime. */
+  missingCapabilityFailureReply?: string;
+  /** The planner exhausted its bounded attempts before completing the task. */
+  plannerExhaustionFailureReply?: string;
   /** Provider is throttling; retrying shortly should succeed. */
   rateLimitedReply?: string;
   /** Any other failure once every model call has already failed. */

--- a/packages/ui/src/api/client-types-chat.ts
+++ b/packages/ui/src/api/client-types-chat.ts
@@ -4,12 +4,12 @@
  * surface, re-exported through client-types.ts.
  */
 
+import type { LinkedAccountProviderId } from "@elizaos/shared";
 import type {
   ChatFailureKind,
   ChatToolCallEvent,
   ChatTurnStatus,
-  LinkedAccountProviderId,
-} from "@elizaos/shared";
+} from "@elizaos/shared/contracts/chat";
 import type { NativeToolCallEvent } from "./client-types-cloud";
 import type {
   ConversationMetadata,

--- a/packages/ui/src/api/client-types-chat.ts
+++ b/packages/ui/src/api/client-types-chat.ts
@@ -9,7 +9,7 @@ import type {
   ChatFailureKind,
   ChatToolCallEvent,
   ChatTurnStatus,
-} from "@elizaos/shared/contracts/chat";
+} from "@elizaos/shared/contracts";
 import type { NativeToolCallEvent } from "./client-types-cloud";
 import type {
   ConversationMetadata,

--- a/packages/ui/src/components/chat/MessageContent.interactions.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.interactions.test.tsx
@@ -195,4 +195,29 @@ describe("MessageContent non-bytes interaction rendering", () => {
     fireEvent.click(cta);
     expect(setTab).toHaveBeenCalledWith("settings");
   });
+
+  it("renders Retry for planner exhaustion and invokes the canonical retry handler", () => {
+    const handleChatRetry = vi.fn();
+    const appValue = {
+      t: (key: string, vars?: Record<string, unknown>) =>
+        String(vars?.defaultValue ?? key),
+      sendActionMessage: vi.fn(),
+      handleChatRetry,
+    } as never;
+    __setAppValueForTests(appValue);
+    render(
+      <AppContext.Provider value={appValue}>
+        <MessageContent
+          message={assistant({
+            id: "planner-failure",
+            failureKind: "planner_exhaustion",
+            text: "I ran out of attempts. Please try again.",
+          })}
+        />
+      </AppContext.Provider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(handleChatRetry).toHaveBeenCalledWith("planner-failure");
+  });
 });

--- a/packages/ui/src/components/chat/MessageContent.stories.tsx
+++ b/packages/ui/src/components/chat/MessageContent.stories.tsx
@@ -117,6 +117,16 @@ export const RateLimitedRetry: Story = {
   },
 };
 
+/** Planner exhaustion is recoverable and offers the same one-tap Retry. */
+export const PlannerExhaustionRetry: Story = {
+  args: {
+    message: makeMessage({
+      text: "I ran out of planning attempts before I could finish. Please try again.",
+      failureKind: "planner_exhaustion",
+    }),
+  },
+};
+
 /** Local-inference `downloading` status shows the warn banner + progress CTA. */
 export const LocalModelDownloading: Story = {
   args: {

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -15,7 +15,7 @@
  */
 
 import { stripUnclaimedInteractionMarkup } from "@elizaos/core";
-import { isRetryableChatFailureKind } from "@elizaos/shared/contracts/chat";
+import { isRetryableChatFailureKind } from "@elizaos/shared/contracts";
 import {
   type FormEvent,
   memo,

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -15,6 +15,7 @@
  */
 
 import { stripUnclaimedInteractionMarkup } from "@elizaos/core";
+import { isRetryableChatFailureKind } from "@elizaos/shared/contracts/chat";
 import {
   type FormEvent,
   memo,
@@ -1469,15 +1470,11 @@ export function MessageContent({
     );
   }
 
-  // Transient server failures (the agent was rate-limited or the provider had a
-  // hiccup) render the graceful message plus a one-tap Retry that resends the
-  // preceding user turn, so a stalled turn isn't a dead end the user has to
-  // retype. `no_provider`/`insufficient_credits` are excluded — a retry can't
-  // fix those (they have their own Settings / billing affordances).
-  if (
-    message.failureKind === "rate_limited" ||
-    message.failureKind === "provider_issue"
-  ) {
+  // Transient / recoverable server failures render the graceful message plus a
+  // one-tap Retry that resends the preceding user turn. Permanent gates
+  // (`no_provider`, `insufficient_credits`, `missing_capability`) stay off the
+  // shared retry contract in `@elizaos/shared`.
+  if (message.failureKind && isRetryableChatFailureKind(message.failureKind)) {
     return (
       <div className="border border-warn/30 bg-warn/5 rounded-sm p-3 text-sm">
         <div className="text-muted whitespace-pre-wrap mb-2">

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -15,6 +15,8 @@
  * deliberately excluded from that check (see `enterOnMount`).
  * Presentation only — actions are delegated to callbacks.
  */
+
+import { isRetryableChatFailureKind } from "@elizaos/shared/contracts/chat";
 import { Check, LoaderCircle, RotateCcw, Sparkles, X } from "lucide-react";
 import { motion } from "motion/react";
 import type * as React from "react";
@@ -979,13 +981,13 @@ export const ChatMessage = memo(function ChatMessage({
       isAssistant && messageHasInteractiveWidget(message.text);
     const bubbleInteractive = hasActions && !isEditing && !hasInteractiveWidget;
     // A recoverable assistant failure gets a one-tap Retry that re-sends the
-    // preceding user turn. `no_provider` (the overlay's own Settings gate) and
-    // `insufficient_credits` are excluded: a retry can't fix those.
+    // preceding user turn. Permanent gates stay on the shared non-retry
+    // contract (`no_provider`, credits, missing capability).
     const canRetry =
       isAssistant &&
       !!onRetry &&
-      (message.failureKind === "rate_limited" ||
-        message.failureKind === "provider_issue");
+      !!message.failureKind &&
+      isRetryableChatFailureKind(message.failureKind);
 
     const toggleRevealed = () => {
       if (!hasActions || isEditing) return;

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -16,7 +16,7 @@
  * Presentation only — actions are delegated to callbacks.
  */
 
-import { isRetryableChatFailureKind } from "@elizaos/shared/contracts/chat";
+import { isRetryableChatFailureKind } from "@elizaos/shared/contracts";
 import { Check, LoaderCircle, RotateCcw, Sparkles, X } from "lucide-react";
 import { motion } from "motion/react";
 import type * as React from "react";

--- a/packages/ui/src/components/shell/ChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.test.tsx
@@ -5022,7 +5022,7 @@ describe("ChatOverlay — routed OS-intent composer prefill (#9148, #16441)", ()
     expect(toggleHandsFree).not.toHaveBeenCalled();
   });
 
-  it("shows Retry on a recoverable failed assistant turn and re-sends the preceding user turn", () => {
+  it("shows Retry on planner exhaustion and re-sends the preceding user turn", () => {
     const controller = makeController({
       messages: [
         {
@@ -5036,7 +5036,7 @@ describe("ChatOverlay — routed OS-intent composer prefill (#9148, #16441)", ()
           role: "assistant",
           content: "",
           createdAt: 2,
-          failureKind: "rate_limited",
+          failureKind: "planner_exhaustion",
         },
       ],
     } as unknown as Partial<ShellController>);

--- a/packages/ui/src/native-transcript/chat-event-adapter.ts
+++ b/packages/ui/src/native-transcript/chat-event-adapter.ts
@@ -4,7 +4,7 @@
  * text and serialized tool detail as display payload only.
  */
 
-import { isRetryableChatFailureKind } from "@elizaos/shared/contracts/chat";
+import { isRetryableChatFailureKind } from "@elizaos/shared/contracts";
 import type { ChatFailureKind, ChatToolCallEvent } from "../api";
 import { publishNativeTranscriptEvent } from "./transport";
 

--- a/packages/ui/src/native-transcript/chat-event-adapter.ts
+++ b/packages/ui/src/native-transcript/chat-event-adapter.ts
@@ -4,20 +4,15 @@
  * text and serialized tool detail as display payload only.
  */
 
+import { isRetryableChatFailureKind } from "@elizaos/shared/contracts/chat";
 import type { ChatFailureKind, ChatToolCallEvent } from "../api";
 import { publishNativeTranscriptEvent } from "./transport";
-
-const RETRYABLE_CHAT_FAILURES: ReadonlySet<ChatFailureKind> = new Set([
-  "provider_issue",
-  "rate_limited",
-  "local_inference",
-]);
 
 /** Whether retry can plausibly resolve a structured chat failure as-is. */
 export function isNativeChatFailureRetryable(
   failureKind: ChatFailureKind,
 ): boolean {
-  return RETRYABLE_CHAT_FAILURES.has(failureKind);
+  return isRetryableChatFailureKind(failureKind);
 }
 
 function toolDetail(event: ChatToolCallEvent): string | undefined {

--- a/packages/ui/src/native-transcript/transport.test.ts
+++ b/packages/ui/src/native-transcript/transport.test.ts
@@ -131,8 +131,13 @@ describe("native transcript producer transport", () => {
     ["provider_issue", true],
     ["rate_limited", true],
     ["local_inference", true],
+    ["planner_exhaustion", true],
+    ["generation_timeout", true],
     ["no_provider", false],
     ["insufficient_credits", false],
+    ["missing_capability", false],
+    ["handler_error", false],
+    ["persistence_error", false],
   ] as const)("maps %s retryability truthfully", (failureKind, retryable) => {
     expect(isNativeChatFailureRetryable(failureKind)).toBe(retryable);
   });


### PR DESCRIPTION
# Relates to

Stacked repair for #19944 at exact source head `4e77fff6583a9aaa698010318f1c4bb32a287ce9`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Reclassifies registered-tool planner exhaustion separately from genuine capability absence.
- [x] Preserves every structured failure discriminator through connector, direct-chat, durable-result, and history-read boundaries.
- [x] Adds character-template compatibility and mutation-sensitive production-path regressions.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`, `xai/grok-4.5`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent (multi-agent)`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no repository contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] One focused commit directly stacked on #19944 exact head `4e77fff6583a9aaa698010318f1c4bb32a287ce9`.
- [ ] Hosted checks must report independently for this exact repair head.

# Risks

Moderate contract-surface change. The repair extends the public `ChatFailureKind` discriminator set and transport allowlists, but does not change successful-turn behavior. Structured failure replies remain non-persistent; only genuinely temporary provider/rate-limit failures carry `transient: true`.

# Background

## What does this PR do?

#19944's latest head adds action-failure provenance, but still classifies `required_tool_misses` as `missing_capability`. A registered tool can reach that limit when the planner repeatedly emits no usable tool call, so telling the user the capability is absent is inaccurate.

This repair:

- maps `required_tool_misses` to `planner_exhaustion` while retaining `unavailable_tool_calls` as `missing_capability`;
- preserves the latest source head's `handler_error` and `persistence_error` provenance;
- carries all four structured kinds through direct chat SSE, conversation durable outcomes, and `GET /messages` reconstruction;
- keeps capability, action, persistence, authentication, and credit failures non-transient while rate limits and generic infrastructure failures remain transient;
- supports `missingCapabilityFailureReply` and `plannerExhaustionFailureReply`, with `transientFailureReply` as a backward-compatible fallback;
- filters all structured synthetic failures from recent dialogue context.

## What kind of change is this?

Bug fix and public failure-contract completion.

# Documentation changes needed?

No user-facing documentation change. The new template keys are documented inline in the first-run character contracts.

# Testing

Protected no-network Docker, read-only source and shared dependencies, Node 24:

```text
core failure/classification/delivery/history suites       82 passed
shared ChatFailureKind contract                            3 passed
agent direct-chat + conversation round-trip suites         61 passed
Focused total                                              146 passed
Biome                                                       15 files clean
git diff --check                                            clean
```

Exact-head mutation proof:

- remapping `required_tool_misses` back to `missing_capability` failed 3 classification/delivery/localization assertions;
- marking authentication/provider-configuration failures transient failed the connector metadata regression;
- removing the four structured DTO/history allowlist members failed 8 direct-chat and `GET /messages` transport assertions.

Package-wide typecheck attempts were harness-limited by unavailable generated workspace/cloud/plugin declarations (`@elizaos/cloud-routing`, capacitor bridge, Drizzle, and related optional packages); no typecheck-green claim is made. Focused Vitest transform/runtime checks and Biome are clean.

# Evidence Gate

<!-- evidence-head:765605b2de206a284d50d9d8dda72092b28400a5 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20034-chat-messagecontent--planner-exhaustion-before.png)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20034-chat-messagecontent--planner-exhaustion-retry.png)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20034-pr20034-planner-retry.mp4
<!-- evidence-row:backend-logs -->
- [x] [20034-pr20034-backend-verification.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20034-pr20034-backend-verification.txt)

```text
core failure/classification/delivery/history suites: 82 passed
agent direct-chat and conversation round-trip suites: 61 passed
exact-head mutations: 3 classification, 1 transient, and 8 transport assertions failed as intended
```
</details>
<!-- evidence-row:frontend-logs -->
- [x] [20034-pr20034-frontend-audit.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20034-pr20034-frontend-audit.txt)
<!-- evidence-row:llm-trajectory -->
- [x] [20034-pr20034-live-trajectory.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20034-pr20034-live-trajectory.json)
<!-- evidence-row:domain-artifacts -->
- [x] [20034-pr20034-domain-contract.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20034-pr20034-domain-contract.txt)

```text
connector callbacks preserve failureKind, transient, doNotPersist, and localized reply text
direct-chat SSE done frames preserve all four structured public discriminators without durable ids
conversation durable outcomes and GET /messages reconstruction preserve the same discriminators
```
</details>
<!-- evidence-row:ocr-review -->
- [x] [20034-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20034-ocr-triage.json)

# Known gaps / failures

- No live-provider trajectory was captured because contributor code was executed only in a no-network, no-credentials sandbox.
- Full package typechecks remain dependency-graph/harness limited as described above.
- Hosted checks must report for this exact repair head; no hosted-green claim is made.

AI provider/model: openai / gpt-5.6-sol; xai / grok-4.5
Client / agent tooling: Hermes Agent (multi-agent)
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [hermes-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai+xai","model":"gpt-5.6-sol+grok-4.5","client":"Hermes Agent (multi-agent)","skill_revision":"N/A - no repository contribution skill used","attribution_status":"self-reported"} -->

