### PR TITLE
fix(x): bind identity to credential generations

### DIFF
--- a/plugins/plugin-x/AGENTS.md
+++ b/plugins/plugin-x/AGENTS.md
@@ -16,7 +16,7 @@ Auto-enabled when `config.connectors.x` (or legacy `config.connectors.twitter`) 
 
 **Providers** (registered in `XPlugin.providers`):
 
-- `xIdentityProvider` (`name = "TWITTER_IDENTITY"`) — Makes the agent aware of its own X account: `@username`, screen name (display name), bio, and any configured nicknames. Reads the already-loaded `client.profile` via `XService.getActiveProfile()`; never issues a network call and returns empty context until the X client has authenticated. Nicknames are sourced from the `TWITTER_NICKNAMES` setting plus the character `name`.
+- `xIdentityProvider` (`name = "TWITTER_IDENTITY"`) — Makes the agent aware of its own X account: `@username`, screen name (display name), bio, and any configured nicknames. Reads through credential-aware `XService.refreshActiveProfile()` so broker rotation invalidates stale identity before prompt use; an account that is not loaded returns empty context, while refresh failures surface. Nicknames are sourced from the `TWITTER_NICKNAMES` setting plus the character `name`.
 
 **No actions or evaluators** are registered.
 

--- a/plugins/plugin-x/CLAUDE.md
+++ b/plugins/plugin-x/CLAUDE.md
@@ -16,7 +16,7 @@ Auto-enabled when `config.connectors.x` (or legacy `config.connectors.twitter`) 
 
 **Providers** (registered in `XPlugin.providers`):
 
-- `xIdentityProvider` (`name = "TWITTER_IDENTITY"`) — Makes the agent aware of its own X account: `@username`, screen name (display name), bio, and any configured nicknames. Reads the already-loaded `client.profile` via `XService.getActiveProfile()`; never issues a network call and returns empty context until the X client has authenticated. Nicknames are sourced from the `TWITTER_NICKNAMES` setting plus the character `name`.
+- `xIdentityProvider` (`name = "TWITTER_IDENTITY"`) — Makes the agent aware of its own X account: `@username`, screen name (display name), bio, and any configured nicknames. Reads through credential-aware `XService.refreshActiveProfile()` so broker rotation invalidates stale identity before prompt use; an account that is not loaded returns empty context, while refresh failures surface. Nicknames are sourced from the `TWITTER_NICKNAMES` setting plus the character `name`.
 
 **No actions or evaluators** are registered.
 

--- a/plugins/plugin-x/src/base.ts
+++ b/plugins/plugin-x/src/base.ts
@@ -1,10 +1,7 @@
 /**
- * `ClientBase` — the per-account X/Twitter transport core shared by the plugin's
- * autonomous loops (post, interaction, timeline, discovery) and by the connector
- * handlers on `XService`. Authenticates a twitter-api-v2 `Client` through the
- * resolved auth provider (OAuth 1.0a env-mode or OAuth 2.0 PKCE), caches the
- * agent's own `TwitterProfile`, and fetches home/following timelines, tweets, and
- * search results.
+ * Per-account X transport core shared by autonomous loops and connector handlers.
+ * It authenticates through the selected provider, keeps the public compatibility
+ * profile synchronized with the credential-aware client, and owns timeline state.
  *
  * On `init` it also seeds the runtime with `FEED` rooms and message memories for
  * recent timeline + mention tweets, and tracks the last-checked tweet id (via the
@@ -16,12 +13,14 @@ import {
   ChannelType,
   type Content,
   createUniqueUuid,
+  ElizaError,
   type IAgentRuntime,
   logger,
   type Memory,
   type State,
   type UUID,
 } from "@elizaos/core";
+import type { TwitterApi } from "twitter-api-v2";
 import {
   resolveRequestedXAccountId,
   resolveTwitterAccountConfig,
@@ -73,6 +72,12 @@ export type TwitterProfile = {
   screenName: string;
   bio: string;
   nicknames: string[];
+};
+
+export type TwitterAccountSession = {
+  client: TwitterApi;
+  profile: TwitterProfile;
+  revision: number;
 };
 
 /**
@@ -237,11 +242,35 @@ export class ClientBase {
    */
   accountId = "default";
   lastCheckedTweetId: bigint | null = null;
+  private lastCheckedTweetProfileId: string | null = null;
   temperature = 0.5;
 
   requestQueue: RequestQueue = new RequestQueue();
 
-  profile: TwitterProfile | null = null;
+  private synchronizedProfile: TwitterProfile | null = null;
+  private synchronizedProfileSession: Pick<
+    TwitterAccountSession,
+    "client" | "revision"
+  > | null = null;
+  private readonly publishLegacyIdentity: boolean;
+  private readonly legacyCacheUsernames = new Map<string, string>();
+  private latestCursorWrite: Promise<void> = Promise.resolve();
+
+  get profile(): TwitterProfile | null {
+    if (!this.synchronizedProfile || !this.synchronizedProfileSession) {
+      return this.synchronizedProfile;
+    }
+    return this.twitterClient.isAuthenticatedSessionCurrent(
+      this.synchronizedProfileSession,
+    )
+      ? this.synchronizedProfile
+      : null;
+  }
+
+  set profile(profile: TwitterProfile | null) {
+    this.synchronizedProfile = profile;
+    this.synchronizedProfileSession = null;
+  }
 
   /**
    * Caches a tweet in the database.
@@ -255,7 +284,7 @@ export class ClientBase {
       return;
     }
 
-    this.runtime.setCache<Tweet>(`twitter/tweets/${tweet.id}`, tweet);
+    await this.runtime.setCache<Tweet>(`twitter/tweets/${tweet.id}`, tweet);
   }
 
   /**
@@ -313,7 +342,11 @@ export class ClientBase {
 
   state: TwitterClientState;
 
-  constructor(runtime: IAgentRuntime, state: TwitterClientState) {
+  constructor(
+    runtime: IAgentRuntime,
+    state: TwitterClientState,
+    options: { publishLegacyIdentity?: boolean } = {},
+  ) {
     this.runtime = runtime;
     this.state = state;
     this.accountId = resolveRequestedXAccountId(
@@ -321,14 +354,196 @@ export class ClientBase {
       state,
       state.accountId,
     );
+    this.publishLegacyIdentity = options.publishLegacyIdentity ?? true;
     this.twitterClient = new Client();
   }
 
-  private requireProfile(): TwitterProfile {
-    if (!this.profile) {
-      throw new Error("Twitter profile has not been initialized");
+  identityCacheKey(profile: TwitterProfile, suffix: string): string {
+    return `twitter/${encodeURIComponent(this.accountId)}/${profile.id}/${suffix}`;
+  }
+
+  async getIdentityCache<T>(
+    profile: TwitterProfile,
+    suffix: string,
+  ): Promise<T | undefined> {
+    const key = this.identityCacheKey(profile, suffix);
+    const current = await this.runtime.getCache<T>(key);
+    const legacyUsername = this.legacyCacheUsernames.get(profile.id);
+    if (current !== undefined || !legacyUsername) {
+      return current;
     }
-    return this.profile;
+    const legacy = await this.runtime.getCache<T>(
+      `twitter/${legacyUsername}/${suffix}`,
+    );
+    if (legacy !== undefined) {
+      await this.runtime.setCache(key, legacy);
+    }
+    return legacy;
+  }
+
+  async setIdentityCache<T>(
+    profile: TwitterProfile,
+    suffix: string,
+    value: T,
+    session?: TwitterAccountSession,
+  ): Promise<void> {
+    if (session && !this.isAuthenticatedSessionCurrent(session)) {
+      throw new ElizaError("X credentials rotated before cache persistence", {
+        code: "X_AUTH_SESSION_ROTATED",
+      });
+    }
+    await this.runtime.setCache(this.identityCacheKey(profile, suffix), value);
+    if (session && !this.isAuthenticatedSessionCurrent(session)) {
+      throw new ElizaError("X credentials rotated during cache persistence", {
+        code: "X_AUTH_SESSION_ROTATED",
+      });
+    }
+  }
+
+  private async synchronizeAuthenticatedSession(
+    session: Awaited<ReturnType<Client["getAuthenticatedSession"]>>,
+  ): Promise<TwitterAccountSession> {
+    const profile = session.profile;
+    if (!profile.userId || !profile.username) {
+      throw new ElizaError(
+        "Authenticated Twitter profile is missing id or username",
+        { code: "X_PROFILE_INVALID" },
+      );
+    }
+
+    const nextProfile: TwitterProfile = {
+      id: profile.userId,
+      username: profile.username,
+      screenName: profile.name ?? profile.username,
+      bio: profile.biography || "",
+      nicknames: resolveAgentNicknames(this.runtime, {
+        username: profile.username,
+        screenName: profile.name ?? profile.username,
+      }),
+    };
+    const identityChanged =
+      this.profile?.id !== nextProfile.id ||
+      this.profile.username !== nextProfile.username ||
+      this.profile.screenName !== nextProfile.screenName;
+    if (identityChanged) {
+      this.profile = null;
+    }
+    if (this.lastCheckedTweetProfileId !== nextProfile.id) {
+      this.lastCheckedTweetId = null;
+      this.lastCheckedTweetProfileId = nextProfile.id;
+    }
+
+    const entity = this.publishLegacyIdentity
+      ? await this.runtime.getEntityById(this.runtime.agentId)
+      : null;
+    const entityMetadata = entity?.metadata as
+      | {
+          twitter?: {
+            id?: string;
+            userName?: string;
+            name?: string;
+            [k: string]: unknown;
+          };
+          [k: string]: unknown;
+        }
+      | undefined;
+    const storedIdentity = entityMetadata?.twitter;
+    if (this.publishLegacyIdentity && storedIdentity?.id === nextProfile.id) {
+      this.legacyCacheUsernames.set(
+        nextProfile.id,
+        storedIdentity.userName ?? nextProfile.username,
+      );
+    }
+    if (
+      this.publishLegacyIdentity &&
+      (storedIdentity?.id !== nextProfile.id ||
+        storedIdentity?.userName !== nextProfile.username ||
+        storedIdentity?.name !== nextProfile.screenName)
+    ) {
+      const priorXNames = new Set(
+        [storedIdentity?.userName, storedIdentity?.name]
+          .filter((name): name is string => Boolean(name))
+          .map((name) => name.toLowerCase()),
+      );
+      const canonicalCharacterNames = new Set(
+        [this.runtime.character?.name]
+          .filter((name): name is string => Boolean(name))
+          .map((name) => name.toLowerCase()),
+      );
+      const retainedNames = (entity?.names || []).filter(
+        (name) =>
+          !priorXNames.has(name.toLowerCase()) ||
+          canonicalCharacterNames.has(name.toLowerCase()),
+      );
+      const currentXNames = [nextProfile.screenName, nextProfile.username];
+      await this.runtime.updateEntity({
+        id: this.runtime.agentId,
+        names: [...new Set([...retainedNames, ...currentXNames])],
+        metadata: {
+          ...(entityMetadata || {}),
+          twitter: {
+            ...(storedIdentity || {}),
+            id: nextProfile.id,
+            name: nextProfile.screenName,
+            userName: nextProfile.username,
+          },
+        },
+        agentId: this.runtime.agentId,
+      });
+    }
+
+    if (identityChanged) {
+      const latestCheckedTweetId = await this.getIdentityCache<string>(
+        nextProfile,
+        "latest_checked_tweet_id",
+      );
+      this.lastCheckedTweetProfileId = nextProfile.id;
+      this.lastCheckedTweetId = latestCheckedTweetId
+        ? BigInt(latestCheckedTweetId)
+        : null;
+    }
+    this.synchronizedProfile = nextProfile;
+    this.synchronizedProfileSession = {
+      client: session.client,
+      revision: session.revision,
+    };
+    return {
+      client: session.client,
+      profile: nextProfile,
+      revision: session.revision,
+    };
+  }
+
+  async withAuthenticatedSession<T>(
+    operation: (session: TwitterAccountSession) => Promise<T>,
+  ): Promise<T> {
+    try {
+      return await this.twitterClient.withAuthenticatedSession(
+        async (session) => {
+          const synchronized = await this.twitterClient.withCurrentSession(
+            session,
+            () => this.synchronizeAuthenticatedSession(session),
+          );
+          return operation(synchronized);
+        },
+      );
+    } catch (error) {
+      this.synchronizedProfile = null;
+      this.synchronizedProfileSession = null;
+      throw error;
+    }
+  }
+
+  async getAuthenticatedSession(): Promise<TwitterAccountSession> {
+    return this.withAuthenticatedSession(async (session) => session);
+  }
+
+  isAuthenticatedSessionCurrent(session: TwitterAccountSession): boolean {
+    return this.twitterClient.isAuthenticatedSessionCurrent(session);
+  }
+
+  async getAuthenticatedProfile(): Promise<TwitterProfile> {
+    return (await this.getAuthenticatedSession()).profile;
   }
 
   private hasTweetIdentity(tweet: Tweet): tweet is TweetWithIdentity {
@@ -400,84 +615,21 @@ export class ClientBase {
       );
     }
 
-    // Initialize Twitter profile from the authenticated user
-    const profile = await this.twitterClient.me();
-    if (profile) {
-      logger.log("Twitter user ID:", profile.userId);
-      logger.log("Twitter loaded:", JSON.stringify(profile, null, 10));
+    await this.getAuthenticatedProfile();
 
-      const agentId = this.runtime.agentId;
-
-      const entity = await this.runtime.getEntityById(agentId);
-      const entityMetadata = entity?.metadata as
-        | {
-            twitter?: {
-              userName?: string;
-              name?: string;
-              [k: string]: unknown;
-            };
-            [k: string]: unknown;
-          }
-        | undefined;
-      if (!profile.userId || !profile.username) {
-        throw new Error(
-          "Authenticated Twitter profile is missing id or username",
-        );
-      }
-
-      if (entityMetadata?.twitter?.userName !== profile.username) {
-        logger.log(
-          "Updating Agents known X/twitter handle",
-          profile.username,
-          "was",
-          entityMetadata?.twitter,
-        );
-        const names = [profile.name, profile.username].filter(
-          (name): name is string => typeof name === "string" && name.length > 0,
-        );
-        await this.runtime.updateEntity({
-          id: agentId,
-          names: [...new Set([...(entity?.names || []), ...names])],
-          metadata: {
-            ...(entityMetadata || {}),
-            twitter: {
-              ...(entityMetadata?.twitter || {}),
-              name: profile.name,
-              userName: profile.username,
-            },
-          },
-          agentId,
-        });
-      }
-
-      // Store profile info for use in responses
-      this.profile = {
-        id: profile.userId,
-        username: profile.username, // this is the at
-        screenName: profile.name ?? profile.username, // this is the human readable name
-        bio: profile.biography || "",
-        nicknames: resolveAgentNicknames(this.runtime, {
-          username: profile.username,
-          screenName: profile.name ?? profile.username,
-        }),
-      };
-    } else {
-      throw new Error("Failed to load profile");
-    }
-
-    await this.loadLatestCheckedTweetId();
     await this.populateTimeline();
   }
 
   async fetchOwnPosts(count: number): Promise<Tweet[]> {
-    logger.debug("fetching own posts");
-    const profile = this.requireProfile();
-    const homeTimeline = await this.twitterClient.getUserTweets(
-      profile.id,
-      count,
-    );
-    // homeTimeline.tweets already contains Tweet objects from v2 API, no parsing needed
-    return homeTimeline.tweets;
+    return this.withAuthenticatedSession(async ({ profile }) => {
+      logger.debug("fetching own posts");
+      const homeTimeline = await this.twitterClient.getUserTweets(
+        profile.id,
+        count,
+      );
+      // homeTimeline.tweets already contains Tweet objects from v2 API, no parsing needed
+      return homeTimeline.tweets;
+    });
   }
 
   /**
@@ -502,42 +654,59 @@ export class ClientBase {
     searchMode: SearchMode,
     cursor?: string,
   ): Promise<QueryTweetsResponse> {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
     try {
-      // Sometimes this fails because we are rate limited. in this case, we just need to return an empty array
-      // if we dont get a response in 5 seconds, something is wrong
-      const timeoutPromise = new Promise((resolve) =>
-        setTimeout(() => resolve({ tweets: [] }), 15000),
-      );
-
-      try {
-        const result = await this.requestQueue.add(
-          async () =>
-            await Promise.race([
-              this.twitterClient.fetchSearchTweets(
-                query,
-                maxTweets,
-                searchMode,
-                cursor,
-              ),
-              timeoutPromise,
-            ]),
+      const timeoutPromise = new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(
+          () =>
+            reject(
+              new ElizaError("X search timed out", {
+                code: "X_SEARCH_TIMEOUT",
+              }),
+            ),
+          15_000,
         );
-        return (result ?? { tweets: [] }) as QueryTweetsResponse;
-      } catch (error) {
-        logger.error("Error fetching search tweets:", errorDetail(error));
-        return { tweets: [] };
+      });
+      const result = await this.requestQueue.add(() =>
+        Promise.race([
+          this.twitterClient.fetchSearchTweets(
+            query,
+            maxTweets,
+            searchMode,
+            cursor,
+          ),
+          timeoutPromise,
+        ]),
+      );
+      if (!result) {
+        throw new ElizaError("X search returned no response", {
+          code: "X_SEARCH_RESPONSE_INVALID",
+        });
       }
+      return result as QueryTweetsResponse;
     } catch (error) {
-      logger.error("Error fetching search tweets:", errorDetail(error));
-      return { tweets: [] };
+      if (error instanceof ElizaError) throw error;
+      // error-policy:J2 preserve the provider failure as the cause while adding
+      // the connector operation context expected by agent-facing boundaries.
+      throw new ElizaError("Failed to fetch X search results", {
+        code: "X_SEARCH_FAILED",
+        cause: error,
+      });
+    } finally {
+      if (timeout) clearTimeout(timeout);
     }
   }
 
   private async populateTimeline() {
-    logger.debug("populating timeline...");
-    const profile = this.requireProfile();
+    return this.withAuthenticatedSession(({ profile }) =>
+      this.populateTimelineFor(profile),
+    );
+  }
 
-    const cachedTimeline = await this.getCachedTimeline();
+  private async populateTimelineFor(profile: TwitterProfile) {
+    logger.debug("populating timeline...");
+
+    const cachedTimeline = await this.getCachedTimeline(profile);
     const validCachedTimeline =
       cachedTimeline?.filter((tweet): tweet is TweetWithIdentity =>
         this.hasTweetIdentity(tweet),
@@ -795,8 +964,8 @@ export class ClientBase {
     }
 
     // Cache
-    await this.cacheTimeline(timeline);
-    await this.cacheMentions(mentionsAndInteractions.tweets);
+    await this.cacheTimeline(timeline, profile);
+    await this.cacheMentions(mentionsAndInteractions.tweets, profile);
   }
 
   async saveRequestMessage(message: Memory, _state: State) {
@@ -818,30 +987,77 @@ export class ClientBase {
   }
 
   async loadLatestCheckedTweetId(): Promise<void> {
-    const profile = this.requireProfile();
-    const latestCheckedTweetId = await this.runtime.getCache<string>(
-      `twitter/${profile.username}/latest_checked_tweet_id`,
-    );
-
-    if (latestCheckedTweetId) {
-      this.lastCheckedTweetId = BigInt(latestCheckedTweetId);
-    }
+    await this.withAuthenticatedSession(async (session) => {
+      const { profile } = session;
+      const latestCheckedTweetId = await this.getIdentityCache<string>(
+        profile,
+        "latest_checked_tweet_id",
+      );
+      if (!this.isAuthenticatedSessionCurrent(session)) {
+        throw new ElizaError("X credentials rotated while loading cursor", {
+          code: "X_AUTH_SESSION_ROTATED",
+        });
+      }
+      this.lastCheckedTweetProfileId = profile.id;
+      this.lastCheckedTweetId = latestCheckedTweetId
+        ? BigInt(latestCheckedTweetId)
+        : null;
+    });
   }
 
-  async cacheLatestCheckedTweetId() {
-    if (this.lastCheckedTweetId) {
-      const profile = this.requireProfile();
-      await this.runtime.setCache<string>(
-        `twitter/${profile.username}/latest_checked_tweet_id`,
-        this.lastCheckedTweetId.toString(),
+  async cacheLatestCheckedTweetId(
+    authenticatedProfile?: TwitterProfile,
+  ): Promise<void> {
+    if (!authenticatedProfile) {
+      return this.withAuthenticatedSession(({ profile }) =>
+        this.cacheLatestCheckedTweetId(profile),
       );
     }
+    const profile = authenticatedProfile;
+    const write = this.latestCursorWrite.then(async () => {
+      if (
+        this.lastCheckedTweetId !== null &&
+        this.lastCheckedTweetProfileId === profile.id
+      ) {
+        await this.setIdentityCache(
+          profile,
+          "latest_checked_tweet_id",
+          this.lastCheckedTweetId.toString(),
+        );
+      }
+    });
+    this.latestCursorWrite = write.catch(() => undefined);
+    await write;
   }
 
-  async getCachedTimeline(): Promise<Tweet[] | undefined> {
-    const profile = this.requireProfile();
-    const cached = await this.runtime.getCache<Tweet[]>(
-      `twitter/${profile.username}/timeline`,
+  getLatestCheckedTweetId(profileId: string): bigint | null {
+    return this.lastCheckedTweetProfileId === profileId
+      ? this.lastCheckedTweetId
+      : null;
+  }
+
+  recordLatestCheckedTweetId(profileId: string, tweetId: bigint): void {
+    if (this.profile?.id !== profileId) {
+      return;
+    }
+    if (
+      this.lastCheckedTweetProfileId === profileId &&
+      this.lastCheckedTweetId !== null &&
+      tweetId <= this.lastCheckedTweetId
+    ) {
+      return;
+    }
+    this.lastCheckedTweetProfileId = profileId;
+    this.lastCheckedTweetId = tweetId;
+  }
+
+  async getCachedTimeline(
+    profile?: TwitterProfile,
+  ): Promise<Tweet[] | undefined> {
+    const currentProfile = profile ?? (await this.getAuthenticatedProfile());
+    const cached = await this.getIdentityCache<Tweet[]>(
+      currentProfile,
+      "timeline",
     );
 
     if (!cached) {
@@ -851,20 +1067,14 @@ export class ClientBase {
     return cached;
   }
 
-  async cacheTimeline(timeline: Tweet[]) {
-    const profile = this.requireProfile();
-    await this.runtime.setCache<Tweet[]>(
-      `twitter/${profile.username}/timeline`,
-      timeline,
-    );
+  async cacheTimeline(timeline: Tweet[], profile?: TwitterProfile) {
+    const currentProfile = profile ?? (await this.getAuthenticatedProfile());
+    await this.setIdentityCache(currentProfile, "timeline", timeline);
   }
 
-  async cacheMentions(mentions: Tweet[]) {
-    const profile = this.requireProfile();
-    await this.runtime.setCache<Tweet[]>(
-      `twitter/${profile.username}/mentions`,
-      mentions,
-    );
+  async cacheMentions(mentions: Tweet[], profile?: TwitterProfile) {
+    const currentProfile = profile ?? (await this.getAuthenticatedProfile());
+    await this.setIdentityCache(currentProfile, "mentions", mentions);
   }
 
   async fetchProfile(username: string): Promise<TwitterProfile> {
@@ -903,12 +1113,32 @@ export class ClientBase {
           username,
           screenName: profile.name || characterName,
           bio: profile.biography || characterBio,
-          nicknames: this.profile?.nicknames || [],
+          nicknames: [],
         } satisfies TwitterProfile;
       });
 
       return profile;
     } catch (error) {
+      const candidate =
+        typeof error === "object" && error !== null
+          ? (error as {
+              code?: unknown;
+              status?: unknown;
+              statusCode?: unknown;
+            })
+          : null;
+      const status = [
+        candidate?.code,
+        candidate?.status,
+        candidate?.statusCode,
+      ].find((value): value is number => typeof value === "number");
+      if (status === 404) {
+        throw new ElizaError(`X profile @${username} was not found`, {
+          code: "X_PROFILE_NOT_FOUND",
+          cause: error,
+          context: { username },
+        });
+      }
       logger.error("Error fetching Twitter profile:", errorDetail(error));
       throw error;
     }
@@ -919,20 +1149,21 @@ export class ClientBase {
    */
   async fetchInteractions() {
     try {
-      const username = this.requireProfile().username;
-      // Use fetchSearchTweets to get mentions instead of the non-existent get method
-      const mentionsResponse = await this.requestQueue.add(() =>
-        this.twitterClient.fetchSearchTweets(
-          `@${username}`,
-          100,
-          SearchMode.Latest,
-        ),
-      );
+      return await this.withAuthenticatedSession(async ({ profile }) => {
+        // Use fetchSearchTweets to get mentions instead of the non-existent get method
+        const mentionsResponse = await this.requestQueue.add(() =>
+          this.twitterClient.fetchSearchTweets(
+            `@${profile.username}`,
+            100,
+            SearchMode.Latest,
+          ),
+        );
 
-      // Process tweets directly into the expected interaction format
-      return mentionsResponse.tweets.map((tweet) =>
-        this.formatTweetToInteraction(tweet),
-      );
+        // Process tweets directly into the expected interaction format
+        return mentionsResponse.tweets.map((tweet) =>
+          this.formatTweetToInteraction(tweet),
+        );
+      });
     } catch (error) {
       // error-policy:J7 a mentions/interactions fetch failure must surface to the
       // agent rather than reading as no interactions; degrade to an empty list

--- a/plugins/plugin-x/src/discovery.test.ts
+++ b/plugins/plugin-x/src/discovery.test.ts
@@ -1,0 +1,164 @@
+/** Exercises discovery-cycle session binding and fail-closed read behavior with deterministic provider fakes. */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import type { ClientBase, TwitterAccountSession } from "./base";
+import { TwitterDiscoveryClient } from "./discovery";
+import type { TwitterClientState } from "./types";
+
+type DiscoveryHarness = {
+  runDiscoveryCycle(): Promise<void>;
+  discoverContent(): Promise<{ tweets: unknown[]; accounts: unknown[] }>;
+  discoverFromTopics(): Promise<{ tweets: unknown[]; accounts: unknown[] }>;
+  processAccounts(
+    accounts: unknown[],
+    session: TwitterAccountSession,
+  ): Promise<number>;
+  processTweets(
+    tweets: unknown[],
+    session: TwitterAccountSession,
+  ): Promise<number>;
+};
+
+function makeRuntime(): IAgentRuntime {
+  return {
+    agentId: "agent-1",
+    character: { name: "Agent", topics: ["agents"] },
+    getSetting: () => undefined,
+    reportError: vi.fn(),
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  } as unknown as IAgentRuntime;
+}
+
+function makeClient(current: () => boolean): {
+  client: ClientBase;
+  session: TwitterAccountSession;
+  withAuthenticatedSession: ReturnType<typeof vi.fn>;
+} {
+  const profile = {
+    id: "account-a",
+    username: "account-a",
+    screenName: "Account A",
+    bio: "",
+    nicknames: [],
+  };
+  const api = {};
+  const session = { client: api as never, profile, revision: 1 };
+  const withAuthenticatedSession = vi.fn(
+    async (operation: (value: TwitterAccountSession) => Promise<unknown>) =>
+      operation(session),
+  );
+  return {
+    client: {
+      accountId: "default",
+      twitterClient: api,
+      withAuthenticatedSession,
+      isAuthenticatedSessionCurrent: vi.fn(() => current()),
+    } as unknown as ClientBase,
+    session,
+    withAuthenticatedSession,
+  };
+}
+
+describe("TwitterDiscoveryClient session integrity", () => {
+  it("keeps the read and both processing phases in one authenticated session", async () => {
+    let depth = 0;
+    const { client, session, withAuthenticatedSession } = makeClient(
+      () => true,
+    );
+    withAuthenticatedSession.mockImplementation(
+      async (operation: (value: TwitterAccountSession) => Promise<unknown>) => {
+        depth += 1;
+        try {
+          return await operation(session);
+        } finally {
+          depth -= 1;
+        }
+      },
+    );
+    const discovery = new TwitterDiscoveryClient(
+      client,
+      makeRuntime(),
+      {} as TwitterClientState,
+    ) as unknown as DiscoveryHarness;
+    vi.spyOn(discovery, "discoverContent").mockImplementation(async () => {
+      expect(depth).toBe(1);
+      return { tweets: [], accounts: [] };
+    });
+    vi.spyOn(discovery, "processAccounts").mockImplementation(
+      async (_accounts, captured) => {
+        expect(depth).toBe(1);
+        expect(captured).toBe(session);
+        return 0;
+      },
+    );
+    vi.spyOn(discovery, "processTweets").mockImplementation(
+      async (_tweets, captured) => {
+        expect(depth).toBe(1);
+        expect(captured).toBe(session);
+        return 0;
+      },
+    );
+
+    await discovery.runDiscoveryCycle();
+
+    expect(withAuthenticatedSession).toHaveBeenCalledOnce();
+    expect(depth).toBe(0);
+  });
+
+  it("aborts after a delayed read when the credential generation rotated", async () => {
+    let current = true;
+    let releaseRead!: () => void;
+    const readBlocked = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    const { client } = makeClient(() => current);
+    const discovery = new TwitterDiscoveryClient(
+      client,
+      makeRuntime(),
+      {} as TwitterClientState,
+    ) as unknown as DiscoveryHarness;
+    let readStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      readStarted = resolve;
+    });
+    vi.spyOn(discovery, "discoverContent").mockImplementation(async () => {
+      readStarted();
+      await readBlocked;
+      return { tweets: [], accounts: [] };
+    });
+    const processAccounts = vi.spyOn(discovery, "processAccounts");
+    const processTweets = vi.spyOn(discovery, "processTweets");
+
+    const cycle = discovery.runDiscoveryCycle();
+    await started;
+    current = false;
+    releaseRead();
+
+    await expect(cycle).rejects.toMatchObject({
+      code: "X_AUTH_SESSION_ROTATED",
+    });
+    expect(processAccounts).not.toHaveBeenCalled();
+    expect(processTweets).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a failed discovery source instead of returning zero work", async () => {
+    const { client } = makeClient(() => true);
+    const discovery = new TwitterDiscoveryClient(
+      client,
+      makeRuntime(),
+      {} as TwitterClientState,
+    ) as unknown as DiscoveryHarness;
+    vi.spyOn(discovery, "discoverFromTopics").mockRejectedValue(
+      new Error("provider unavailable"),
+    );
+
+    await expect(discovery.discoverContent()).rejects.toMatchObject({
+      code: "X_DISCOVERY_READ_FAILED",
+    });
+  });
+});

--- a/plugins/plugin-x/src/discovery.ts
+++ b/plugins/plugin-x/src/discovery.ts
@@ -7,12 +7,13 @@
  */
 import {
   createUniqueUuid,
+  ElizaError,
   type IAgentRuntime,
   logger,
   type Memory,
   ModelType,
 } from "@elizaos/core";
-import type { ClientBase } from "./base";
+import type { ClientBase, TwitterAccountSession } from "./base";
 import type { Client, Tweet } from "./client/index";
 import { SearchMode } from "./client/index";
 import { getRandomInterval } from "./environment";
@@ -71,11 +72,8 @@ function isDiscoveryTweet(tweet: Tweet): tweet is DiscoveryTweet {
   );
 }
 
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
 export class TwitterDiscoveryClient {
+  private client: ClientBase;
   private twitterClient: Client;
   private runtime: IAgentRuntime;
   private accountId: string;
@@ -88,6 +86,7 @@ export class TwitterDiscoveryClient {
     runtime: IAgentRuntime,
     state: TwitterClientState,
   ) {
+    this.client = client;
     this.twitterClient = client.twitterClient;
     this.runtime = runtime;
     this.accountId = client.accountId;
@@ -238,7 +237,9 @@ export class TwitterDiscoveryClient {
       try {
         await this.runDiscoveryCycle();
       } catch (error) {
-        logger.error("Discovery cycle error:", errorMessage(error));
+        // error-policy:J7 the scheduler remains alive, while the failed cycle
+        // is surfaced to the agent and owner rather than recorded as success.
+        this.runtime.reportError("XDiscoveryClient.cycle", error);
       }
 
       // Run discovery every 20-40 minutes (with variance)
@@ -266,9 +267,16 @@ export class TwitterDiscoveryClient {
   }
 
   private async runDiscoveryCycle() {
+    return this.client.withAuthenticatedSession((session) =>
+      this.runDiscoveryCycleForSession(session),
+    );
+  }
+
+  private async runDiscoveryCycleForSession(session: TwitterAccountSession) {
     logger.info("Starting Twitter discovery cycle...");
 
     const discoveries = await this.discoverContent();
+    this.assertCurrentSession(session);
     const { tweets, accounts } = discoveries;
 
     logger.info(
@@ -276,10 +284,10 @@ export class TwitterDiscoveryClient {
     );
 
     // Process discovered accounts (follow high-quality ones)
-    const followedCount = await this.processAccounts(accounts);
+    const followedCount = await this.processAccounts(accounts, session);
 
     // Process discovered tweets (engage with relevant ones)
-    const engagementCount = await this.processTweets(tweets);
+    const engagementCount = await this.processTweets(tweets, session);
 
     logger.info(
       `Discovery cycle complete: ${followedCount} follows, ${engagementCount} engagements`,
@@ -303,7 +311,12 @@ export class TwitterDiscoveryClient {
         allAccounts.set(acc.user.id, acc);
       }
     } catch (error) {
-      logger.error("Failed to discover from topics:", errorMessage(error));
+      // error-policy:J2 A failed source cannot be represented as an empty
+      // successful cycle, so preserve the source and fail the scheduler run.
+      throw new ElizaError("X topic discovery failed", {
+        code: "X_DISCOVERY_READ_FAILED",
+        cause: error,
+      });
     }
 
     // 2. Discover from conversation threads
@@ -314,7 +327,11 @@ export class TwitterDiscoveryClient {
         allAccounts.set(acc.user.id, acc);
       }
     } catch (error) {
-      logger.error("Failed to discover from threads:", errorMessage(error));
+      // error-policy:J2 See the topic-source boundary above.
+      throw new ElizaError("X thread discovery failed", {
+        code: "X_DISCOVERY_READ_FAILED",
+        cause: error,
+      });
     }
 
     // 3. Discover from popular accounts in our topics
@@ -325,10 +342,11 @@ export class TwitterDiscoveryClient {
         allAccounts.set(acc.user.id, acc);
       }
     } catch (error) {
-      logger.error(
-        "Failed to discover from popular accounts:",
-        errorMessage(error),
-      );
+      // error-policy:J2 See the topic-source boundary above.
+      throw new ElizaError("X account discovery failed", {
+        code: "X_DISCOVERY_READ_FAILED",
+        cause: error,
+      });
     }
 
     // Sort by relevance score
@@ -445,7 +463,13 @@ export class TwitterDiscoveryClient {
           }
         }
       } catch (error) {
-        logger.error(`Failed to search topic ${topic}:`, errorMessage(error));
+        // error-policy:J2 Keep a provider failure distinct from a topic that
+        // legitimately produced no candidates.
+        throw new ElizaError(`X discovery search failed for topic ${topic}`, {
+          code: "X_DISCOVERY_READ_FAILED",
+          cause: error,
+          context: { topic },
+        });
       }
     }
 
@@ -503,7 +527,12 @@ export class TwitterDiscoveryClient {
         }
       }
     } catch (error) {
-      logger.error("Failed to discover threads:", errorMessage(error));
+      // error-policy:J2 Keep a provider failure distinct from an empty thread
+      // search result.
+      throw new ElizaError("X conversation discovery failed", {
+        code: "X_DISCOVERY_READ_FAILED",
+        cause: error,
+      });
     }
 
     return { tweets, accounts: Array.from(accounts.values()) };
@@ -564,9 +593,15 @@ export class TwitterDiscoveryClient {
           }
         }
       } catch (error) {
-        logger.error(
-          `Failed to discover popular accounts for ${topic}:`,
-          errorMessage(error),
+        // error-policy:J2 Keep a provider failure distinct from a topic with
+        // no qualifying accounts.
+        throw new ElizaError(
+          `X popular-account discovery failed for topic ${topic}`,
+          {
+            code: "X_DISCOVERY_READ_FAILED",
+            cause: error,
+            context: { topic },
+          },
         );
       }
     }
@@ -661,7 +696,10 @@ export class TwitterDiscoveryClient {
     };
   }
 
-  private async processAccounts(accounts: ScoredAccount[]): Promise<number> {
+  private async processAccounts(
+    accounts: ScoredAccount[],
+    session: TwitterAccountSession,
+  ): Promise<number> {
     let followedCount = 0;
 
     // Sort accounts by combined quality and relevance score
@@ -702,7 +740,7 @@ export class TwitterDiscoveryClient {
               `relevance: ${scoredAccount.relevanceScore.toFixed(2)})`,
           );
         } else {
-          // Follow the account
+          this.assertCurrentSession(session);
           await this.twitterClient.followUser(scoredAccount.user.id);
 
           logger.info(
@@ -720,9 +758,16 @@ export class TwitterDiscoveryClient {
         // Add a delay to avoid rate limits
         await this.delay(2000 + Math.random() * 3000);
       } catch (error) {
-        logger.error(
-          `Failed to follow @${scoredAccount.user.username}:`,
-          errorMessage(error),
+        if (this.isSessionRotation(error)) throw error;
+        // error-policy:J2 The cycle boundary owns reporting; aborting prevents
+        // a provider failure from being summarized as successful work.
+        throw new ElizaError(
+          `X discovery failed to follow @${scoredAccount.user.username}`,
+          {
+            code: "X_DISCOVERY_EFFECT_FAILED",
+            cause: error,
+            context: { userId: scoredAccount.user.id },
+          },
         );
       }
     }
@@ -730,7 +775,10 @@ export class TwitterDiscoveryClient {
     return followedCount;
   }
 
-  private async processTweets(tweets: ScoredTweet[]): Promise<number> {
+  private async processTweets(
+    tweets: ScoredTweet[],
+    session: TwitterAccountSession,
+  ): Promise<number> {
     let engagementCount = 0;
 
     for (const scoredTweet of tweets) {
@@ -759,6 +807,7 @@ export class TwitterDiscoveryClient {
                 `[DRY RUN] Would like tweet: ${scoredTweet.tweet.id} (score: ${scoredTweet.relevanceScore.toFixed(2)})`,
               );
             } else {
+              this.assertCurrentSession(session);
               await this.twitterClient.likeTweet(scoredTweet.tweet.id);
               logger.info(
                 `Liked tweet: ${scoredTweet.tweet.id} (score: ${scoredTweet.relevanceScore.toFixed(2)})`,
@@ -773,6 +822,7 @@ export class TwitterDiscoveryClient {
                 `[DRY RUN] Would reply to tweet ${scoredTweet.tweet.id} with: "${replyText}"`,
               );
             } else {
+              this.assertCurrentSession(session);
               await this.twitterClient.sendTweet(
                 replyText,
                 scoredTweet.tweet.id,
@@ -789,6 +839,7 @@ export class TwitterDiscoveryClient {
                 `[DRY RUN] Would quote tweet ${scoredTweet.tweet.id} with: "${quoteText}"`,
               );
             } else {
+              this.assertCurrentSession(session);
               await this.twitterClient.sendQuoteTweet(
                 quoteText,
                 scoredTweet.tweet.id,
@@ -810,6 +861,7 @@ export class TwitterDiscoveryClient {
         // Add delay to avoid rate limits
         await this.delay(3000 + Math.random() * 5000);
       } catch (error) {
+        if (this.isSessionRotation(error)) throw error;
         const message =
           error instanceof Error
             ? error.message
@@ -825,22 +877,41 @@ export class TwitterDiscoveryClient {
           // Still save to memory to avoid retrying
           await this.saveEngagementMemory(scoredTweet.tweet, "skip");
         } else if (message.includes("429")) {
-          logger.warn(
-            `Rate limit (429) hit while engaging with tweet ${scoredTweet.tweet.id}. ` +
-              `Pausing engagement cycle.`,
-          );
-          // Break out of the loop on rate limit
-          break;
+          // error-policy:J2 A rate-limited cycle is not a successful partial
+          // cycle; preserve the source error for retry policy at the boundary.
+          throw new ElizaError("X discovery was rate limited", {
+            code: "X_DISCOVERY_RATE_LIMITED",
+            cause: error,
+            context: { tweetId: scoredTweet.tweet.id },
+          });
         } else {
-          logger.error(
-            `Failed to engage with tweet ${scoredTweet.tweet.id}:`,
-            errorMessage(error),
-          );
+          // error-policy:J2 The cycle boundary owns reporting; aborting keeps
+          // a provider failure distinguishable from an ignored candidate.
+          throw new ElizaError("X discovery engagement failed", {
+            code: "X_DISCOVERY_EFFECT_FAILED",
+            cause: error,
+            context: { tweetId: scoredTweet.tweet.id },
+          });
         }
       }
     }
 
     return engagementCount;
+  }
+
+  private assertCurrentSession(session: TwitterAccountSession): void {
+    if (!this.client.isAuthenticatedSessionCurrent(session)) {
+      throw new ElizaError("X credentials rotated during discovery", {
+        code: "X_AUTH_SESSION_ROTATED",
+      });
+    }
+  }
+
+  private isSessionRotation(error: unknown): boolean {
+    return (
+      error instanceof ElizaError &&
+      ["X_AUTH_NOT_INITIALIZED", "X_AUTH_SESSION_ROTATED"].includes(error.code)
+    );
   }
 
   private async checkIfFollowing(userId: string): Promise<boolean> {
@@ -970,11 +1041,13 @@ Quote tweet:`;
         `[Discovery] Saved ${engagementType} memory for tweet ${tweet.id}`,
       );
     } catch (error) {
-      logger.error(
-        `[Discovery] Failed to save engagement memory:`,
-        errorMessage(error),
-      );
-      // Don't throw - just log the error
+      // error-policy:J7 The provider may already have accepted the engagement,
+      // so receipt loss is reported without replaying the external effect.
+      this.runtime.reportError("XDiscovery.engagementReceipt", error, {
+        accountId: this.accountId,
+        tweetId: tweet.id,
+        engagementType,
+      });
     }
   }
 
@@ -1012,11 +1085,12 @@ Quote tweet:`;
       await createMemorySafe(this.runtime, memory, "messages");
       logger.debug(`[Discovery] Saved follow memory for @${user.username}`);
     } catch (error) {
-      logger.error(
-        `[Discovery] Failed to save follow memory:`,
-        errorMessage(error),
-      );
-      // Don't throw - just log the error
+      // error-policy:J7 The provider may already have accepted the follow, so
+      // receipt loss is reported without replaying the external effect.
+      this.runtime.reportError("XDiscovery.followReceipt", error, {
+        accountId: this.accountId,
+        userId: user.id,
+      });
     }
   }
 

--- a/plugins/plugin-x/src/identity-provider.test.ts
+++ b/plugins/plugin-x/src/identity-provider.test.ts
@@ -1,11 +1,11 @@
-/** Unit tests for `xIdentityProvider`, asserting the identity context rendered from a supplied `TwitterProfile`; no network. */
+/** Verifies prompt identity uses the service's current authenticated profile and propagates refresh failures. */
 import type { IAgentRuntime, Memory, State } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import type { TwitterProfile } from "./base";
 import { xIdentityProvider } from "./identity-provider";
 
 function makeRuntime(profile: TwitterProfile | null): IAgentRuntime {
-  const service = { getActiveProfile: () => profile };
+  const service = { refreshActiveProfile: async () => profile };
   return {
     getService: (serviceType: string) => (serviceType === "x" ? service : null),
   } as unknown as IAgentRuntime;
@@ -90,5 +90,19 @@ describe("TWITTER_IDENTITY provider", () => {
 
     expect(result.text).toBe("");
     expect(result.data?.twitterProfile).toBeNull();
+  });
+
+  it("does not fall back to stale prompt identity when refresh fails", async () => {
+    const runtime = {
+      getService: () => ({
+        refreshActiveProfile: async () => {
+          throw new Error("broker identity unavailable");
+        },
+      }),
+    } as unknown as IAgentRuntime;
+
+    await expect(
+      xIdentityProvider.get(runtime, EMPTY_MESSAGE, EMPTY_STATE),
+    ).rejects.toThrow("broker identity unavailable");
   });
 });

--- a/plugins/plugin-x/src/identity-provider.ts
+++ b/plugins/plugin-x/src/identity-provider.ts
@@ -7,9 +7,9 @@
  * handle (via the `{{twitterUserName}}` template variable) and no awareness of
  * its bio, display name, or nicknames at all.
  *
- * Reads the already-loaded profile from `XService.getActiveProfile()`; it never
- * triggers a network call and returns empty context when the X client has not
- * finished authenticating.
+ * Reads through `XService.refreshActiveProfile()` so managed credential rotation
+ * invalidates the profile before it enters prompt context. An unloaded account
+ * returns empty context; refresh failures remain observable.
  */
 
 import type {
@@ -55,7 +55,7 @@ export const xIdentityProvider: Provider = {
     _state: State,
   ): Promise<ProviderResult> => {
     const service = runtime.getService<XService>(X_SERVICE_TYPE);
-    const profile = service?.getActiveProfile() ?? null;
+    const profile = service ? await service.refreshActiveProfile() : null;
 
     if (!profile) {
       return {

--- a/plugins/plugin-x/src/interactions-account-metadata.test.ts
+++ b/plugins/plugin-x/src/interactions-account-metadata.test.ts
@@ -37,12 +37,60 @@ function createRuntime(settings: Record<string, string> = {}) {
 }
 
 function createClient(accountId = "secondary"): ClientBase {
-  return {
+  let lastCheckedTweetId: bigint | null = null;
+  const identityCache = new Map<string, unknown>();
+  const authenticatedProfile = {
+    id: "bot-user",
+    username: "bot",
+    screenName: "Bot",
+    bio: "",
+    nicknames: [],
+  };
+  const client = {
     accountId,
-    lastCheckedTweetId: null,
+    get lastCheckedTweetId() {
+      return lastCheckedTweetId;
+    },
+    set lastCheckedTweetId(value: bigint | null) {
+      lastCheckedTweetId = value;
+    },
     profile: { id: "bot-user", username: "bot" },
+    getAuthenticatedProfile: vi.fn(async () => authenticatedProfile),
     twitterClient: { getTweetsV2: vi.fn(async () => []) },
-  } as unknown as ClientBase;
+    withAuthenticatedSession: vi.fn(
+      async (
+        operation: (session: {
+          client: unknown;
+          profile: typeof authenticatedProfile;
+          revision: number;
+        }) => Promise<unknown>,
+      ) =>
+        operation({
+          client: client.twitterClient,
+          profile: await client.getAuthenticatedProfile(),
+          revision: 1,
+        }),
+    ),
+    isAuthenticatedSessionCurrent: vi.fn(() => true),
+    identityCacheKey: (profile: { id: string }, suffix: string) =>
+      `twitter/${accountId}/${profile.id}/${suffix}`,
+    getIdentityCache: vi.fn(async (profile: { id: string }, suffix: string) =>
+      identityCache.get(`twitter/${accountId}/${profile.id}/${suffix}`),
+    ),
+    setIdentityCache: vi.fn(
+      async (profile: { id: string }, suffix: string, value: unknown) => {
+        identityCache.set(
+          `twitter/${accountId}/${profile.id}/${suffix}`,
+          value,
+        );
+      },
+    ),
+    getLatestCheckedTweetId: vi.fn(() => lastCheckedTweetId),
+    recordLatestCheckedTweetId: vi.fn((_profileId: string, id: bigint) => {
+      lastCheckedTweetId = id;
+    }),
+  };
+  return client as unknown as ClientBase;
 }
 
 function tweet(overrides: Partial<Tweet> = {}): Tweet {
@@ -126,5 +174,48 @@ describe("Twitter interaction processing", () => {
     expect(world?.metadata?.ownership?.ownerId).toBe(connection?.entityId);
     expect(world?.metadata?.ownership?.ownerId).not.toBe("user-1");
     expect(clientBase.lastCheckedTweetId).toBe(300n);
+  });
+
+  it("filters self mentions and advances the cursor using refreshed identity", async () => {
+    const runtime = createRuntime();
+    const clientBase = createClient();
+    clientBase.profile = {
+      id: "account-a",
+      username: "stale-a",
+      screenName: "Stale A",
+      bio: "",
+      nicknames: [],
+    };
+    vi.mocked(clientBase.getAuthenticatedProfile).mockResolvedValue({
+      id: "account-b",
+      username: "current-b",
+      screenName: "Current B",
+      bio: "",
+      nicknames: [],
+    });
+    const client = new TwitterInteractionClient(
+      clientBase,
+      runtime,
+      {} as TwitterClientState,
+    );
+    const handleTweet = vi
+      .spyOn(client, "handleTweet")
+      .mockResolvedValue({ text: "reply", actions: ["REPLY"] });
+
+    await client.processMentionTweets([
+      tweet({ id: "400", userId: "account-b", username: "current-b" }),
+      tweet({ id: "401", userId: "person-1", username: "alice" }),
+    ]);
+
+    expect(handleTweet).toHaveBeenCalledOnce();
+    expect(handleTweet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tweet: expect.objectContaining({ id: "401" }),
+      }),
+    );
+    expect(clientBase.recordLatestCheckedTweetId).toHaveBeenCalledWith(
+      "account-b",
+      401n,
+    );
   });
 });

--- a/plugins/plugin-x/src/interactions-search-actions.test.ts
+++ b/plugins/plugin-x/src/interactions-search-actions.test.ts
@@ -21,6 +21,7 @@ function createRuntime(
   modelResponse: string,
   settings: Record<string, string> = {},
 ) {
+  const cache = new Map<string, unknown>();
   return asRuntime({
     agentId: "agent-1" as UUID,
     character: { name: "Agent", templates: {} },
@@ -31,11 +32,17 @@ function createRuntime(
     ensureRoomExists: vi.fn(async () => undefined),
     ensureWorldExists: vi.fn(async () => undefined),
     updateWorld: vi.fn(async () => undefined),
-    getCache: vi.fn(async () => undefined),
-    setCache: vi.fn(async () => undefined),
+    cache,
+    getCache: vi.fn(async (key: string) => cache.get(key)),
+    setCache: vi.fn(async (key: string, value: unknown) => {
+      cache.set(key, value);
+      return true;
+    }),
+    deleteCache: vi.fn(async (key: string) => cache.delete(key)),
     getMemoryById: vi.fn(async () => null),
     getMemories: vi.fn(async () => []),
     getSetting: vi.fn((key: string) => settings[key]),
+    reportError: vi.fn(),
     useModel: vi.fn(async () => modelResponse),
     logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     messageService: {
@@ -51,16 +58,67 @@ interface TwitterClientMock {
   getTweetsV2: ReturnType<typeof vi.fn>;
 }
 
-function createClient(twitterClient: TwitterClientMock): ClientBase {
-  return {
+function createClient(
+  twitterClient: TwitterClientMock,
+  runtime: ReturnType<typeof createRuntime>,
+): ClientBase {
+  let lastCheckedTweetId: bigint | null = null;
+  const authenticatedProfile = {
+    id: "bot-user",
+    username: "bot",
+    screenName: "Bot",
+    bio: "",
+    nicknames: [],
+  };
+  const client = {
     accountId: "default",
-    lastCheckedTweetId: null,
+    runtime,
+    get lastCheckedTweetId() {
+      return lastCheckedTweetId;
+    },
+    set lastCheckedTweetId(value: bigint | null) {
+      lastCheckedTweetId = value;
+    },
     profile: { id: "bot-user", username: "bot" },
+    getAuthenticatedProfile: vi.fn(async () => authenticatedProfile),
+    withAuthenticatedSession: vi.fn(
+      async (
+        operation: (session: {
+          client: TwitterClientMock;
+          profile: typeof authenticatedProfile;
+          revision: number;
+        }) => Promise<unknown>,
+      ) =>
+        operation({
+          client: twitterClient,
+          profile: authenticatedProfile,
+          revision: 1,
+        }),
+    ),
+    getLatestCheckedTweetId: vi.fn(() => lastCheckedTweetId),
+    recordLatestCheckedTweetId: vi.fn((_profileId: string, id: bigint) => {
+      lastCheckedTweetId = id;
+    }),
+    cacheLatestCheckedTweetId: vi.fn(async () => undefined),
+    isAuthenticatedSessionCurrent: vi.fn(() => true),
+    identityCacheKey: vi.fn(
+      (profile: typeof authenticatedProfile, suffix: string) =>
+        `twitter/default/${profile.id}/${suffix}`,
+    ),
+    getIdentityCache: vi.fn(
+      (profile: typeof authenticatedProfile, suffix: string) =>
+        runtime.getCache(`twitter/default/${profile.id}/${suffix}`),
+    ),
+    setIdentityCache: vi.fn(
+      (profile: typeof authenticatedProfile, suffix: string, value: unknown) =>
+        runtime.setCache(`twitter/default/${profile.id}/${suffix}`, value),
+    ),
     twitterClient,
     requestQueue: { add: <T>(fn: () => Promise<T>) => fn() },
     fetchSearchTweets: vi.fn(),
     fetchHomeTimeline: vi.fn(async () => []),
-  } as unknown as ClientBase;
+  };
+  return client as unknown as ClientBase;
 }
 
 function tweet(overrides: Partial<Tweet> = {}): Tweet {
@@ -120,7 +178,7 @@ describe("Twitter search engagement actions", () => {
       TWITTER_TARGET_USERS: "alice",
     });
     const twitterClient = createTwitterClientMock();
-    const clientBase = createClient(twitterClient);
+    const clientBase = createClient(twitterClient, runtime);
     const client = new TwitterInteractionClient(
       clientBase,
       runtime,
@@ -132,6 +190,7 @@ describe("Twitter search engagement actions", () => {
     expect(twitterClient.likeTweet).toHaveBeenCalledWith("500");
     expect(twitterClient.retweet).toHaveBeenCalledWith("500");
     expect(twitterClient.sendQuoteTweet).not.toHaveBeenCalled();
+    expect(runtime.reportError).not.toHaveBeenCalled();
   });
 
   it("quote tweets a search-discovered tweet with generated commentary", async () => {
@@ -144,7 +203,7 @@ describe("Twitter search engagement actions", () => {
       .mockResolvedValueOnce("[QUOTE]")
       .mockResolvedValueOnce('{"post":"sharp take, agreed"}');
     const twitterClient = createTwitterClientMock();
-    const clientBase = createClient(twitterClient);
+    const clientBase = createClient(twitterClient, runtime);
     const client = new TwitterInteractionClient(
       clientBase,
       runtime,
@@ -159,6 +218,7 @@ describe("Twitter search engagement actions", () => {
     );
     expect(twitterClient.likeTweet).not.toHaveBeenCalled();
     expect(twitterClient.retweet).not.toHaveBeenCalled();
+    expect(runtime.reportError).not.toHaveBeenCalled();
   });
 
   it("takes no engagement action when the model selects none", async () => {
@@ -167,7 +227,7 @@ describe("Twitter search engagement actions", () => {
       TWITTER_TARGET_USERS: "alice",
     });
     const twitterClient = createTwitterClientMock();
-    const clientBase = createClient(twitterClient);
+    const clientBase = createClient(twitterClient, runtime);
     const client = new TwitterInteractionClient(
       clientBase,
       runtime,
@@ -179,6 +239,7 @@ describe("Twitter search engagement actions", () => {
     expect(twitterClient.likeTweet).not.toHaveBeenCalled();
     expect(twitterClient.retweet).not.toHaveBeenCalled();
     expect(twitterClient.sendQuoteTweet).not.toHaveBeenCalled();
+    expect(runtime.reportError).not.toHaveBeenCalled();
   });
 
   it("simulates like / retweet / quote in dry-run mode", async () => {
@@ -191,7 +252,7 @@ describe("Twitter search engagement actions", () => {
       .mockResolvedValueOnce("[LIKE]\n[RETWEET]\n[QUOTE]")
       .mockResolvedValueOnce('{"post":"sharp take, agreed"}');
     const twitterClient = createTwitterClientMock();
-    const clientBase = createClient(twitterClient);
+    const clientBase = createClient(twitterClient, runtime);
     const client = new TwitterInteractionClient(
       clientBase,
       runtime,
@@ -203,5 +264,39 @@ describe("Twitter search engagement actions", () => {
     expect(twitterClient.likeTweet).not.toHaveBeenCalled();
     expect(twitterClient.retweet).not.toHaveBeenCalled();
     expect(twitterClient.sendQuoteTweet).not.toHaveBeenCalled();
+    expect(runtime.reportError).not.toHaveBeenCalled();
+  });
+
+  it("does not act or mark a search result processed after the authenticated account rotates", async () => {
+    let resolveDecision!: (value: string) => void;
+    const decision = new Promise<string>((resolve) => {
+      resolveDecision = resolve;
+    });
+    const runtime = createRuntime("", {
+      TWITTER_ENABLE_REPLIES: "false",
+      TWITTER_TARGET_USERS: "alice",
+    });
+    runtime.useModel.mockImplementationOnce(() => decision);
+    const twitterClient = createTwitterClientMock();
+    const clientBase = createClient(twitterClient, runtime);
+    const current = vi.mocked(clientBase.isAuthenticatedSessionCurrent);
+    const client = new TwitterInteractionClient(
+      clientBase,
+      runtime,
+      {} as TwitterClientState,
+    );
+
+    const run = runTargetUserEngagement(client, clientBase, tweet());
+    await vi.waitFor(() => expect(runtime.useModel).toHaveBeenCalledOnce());
+    current.mockReturnValue(false);
+    resolveDecision("[LIKE]");
+    await run;
+
+    expect(twitterClient.likeTweet).not.toHaveBeenCalled();
+    expect(runtime.createMemory).not.toHaveBeenCalled();
+    expect(runtime.reportError).toHaveBeenCalledWith(
+      "XInteractionClient.handleInteractions",
+      expect.objectContaining({ code: "X_AUTH_SESSION_ROTATED" }),
+    );
   });
 });

--- a/plugins/plugin-x/src/interactions.ts
+++ b/plugins/plugin-x/src/interactions.ts
@@ -11,6 +11,7 @@ import {
   type Content,
   composePromptFromState,
   createUniqueUuid,
+  ElizaError,
   EventType,
   type HandlerCallback,
   type IAgentRuntime,
@@ -20,7 +21,7 @@ import {
   ModelType,
   parseJSONObjectFromText,
 } from "@elizaos/core";
-import type { ClientBase } from "./base";
+import type { ClientBase, TwitterAccountSession, TwitterProfile } from "./base";
 import { SearchMode } from "./client/index";
 import type { Tweet as ClientTweet } from "./client/tweets";
 import {
@@ -62,6 +63,13 @@ type ProcessableTweet = ClientTweet & {
   timestamp: number;
   thread: ClientTweet[];
 };
+
+function isSessionRotationError(error: unknown): boolean {
+  return (
+    error instanceof ElizaError &&
+    ["X_AUTH_NOT_INITIALIZED", "X_AUTH_SESSION_ROTATED"].includes(error.code)
+  );
+}
 
 export function normalizeTweet(tweet: ClientTweet): ProcessableTweet | null {
   if (
@@ -240,77 +248,80 @@ export class TwitterInteractionClient {
   async handleTwitterInteractions() {
     logger.log("Checking Twitter interactions");
 
-    const twitterUsername = this.client.profile?.username;
-
     try {
-      // Check for mentions first (replies enabled by default)
-      const repliesEnabled =
-        (getSetting(this.runtime, "TWITTER_ENABLE_REPLIES") ??
-          process.env.TWITTER_ENABLE_REPLIES) !== "false";
+      await this.client.withAuthenticatedSession(async (session) => {
+        const { profile } = session;
+        // Check for mentions first (replies enabled by default)
+        const repliesEnabled =
+          (getSetting(this.runtime, "TWITTER_ENABLE_REPLIES") ??
+            process.env.TWITTER_ENABLE_REPLIES) !== "false";
 
-      if (repliesEnabled && twitterUsername) {
-        await this.handleMentions(twitterUsername);
-      } else if (repliesEnabled) {
-        logger.warn(
-          "Skipping Twitter mentions: profile username is unavailable",
-        );
-      }
+        if (repliesEnabled) {
+          await this.handleMentions(session);
+        }
 
-      // Check target users' posts for autonomous engagement
-      const targetUsersConfig =
-        ((getSetting(this.runtime, "TWITTER_TARGET_USERS") ??
-          process.env.TWITTER_TARGET_USERS) as string) || "";
+        // Check target users' posts for autonomous engagement
+        const targetUsersConfig =
+          ((getSetting(this.runtime, "TWITTER_TARGET_USERS") ??
+            process.env.TWITTER_TARGET_USERS) as string) || "";
 
-      if (targetUsersConfig?.trim()) {
-        await this.handleTargetUserPosts(targetUsersConfig);
-      }
+        if (targetUsersConfig?.trim()) {
+          await this.handleTargetUserPosts(targetUsersConfig, session);
+        }
 
-      // Save the latest checked tweet ID to the file
-      await this.client.cacheLatestCheckedTweetId();
-
-      logger.log("Finished checking Twitter interactions");
+        await this.client.cacheLatestCheckedTweetId(profile);
+        logger.log("Finished checking Twitter interactions");
+      });
     } catch (error) {
-      logger.error("Error handling Twitter interactions:", errorMessage(error));
+      this.runtime.reportError("XInteractionClient.handleInteractions", error);
     }
   }
 
   /**
    * Handle mentions and replies
    */
-  private async handleMentions(twitterUsername: string) {
-    try {
-      // Check for mentions
-      const cursorKey = `twitter/${twitterUsername}/mention_cursor`;
-      const cachedCursor =
-        (await this.runtime.getCache<string>(cursorKey)) ?? "";
+  private async handleMentions(session: TwitterAccountSession) {
+    const { profile } = session;
+    const twitterUsername = profile.username;
+    const cachedCursor =
+      (await this.client.getIdentityCache<string>(profile, "mention_cursor")) ??
+      "";
 
-      const searchResult = await this.client.fetchSearchTweets(
-        `@${twitterUsername}`,
-        20,
-        SearchMode.Latest,
-        String(cachedCursor),
+    const searchResult = await this.client.fetchSearchTweets(
+      `@${twitterUsername}`,
+      20,
+      SearchMode.Latest,
+      String(cachedCursor),
+    );
+
+    const mentionCandidates = searchResult.tweets;
+
+    await this.processMentionTweetsForSession(mentionCandidates, session);
+    this.assertCurrentSession(session);
+    if (mentionCandidates.length > 0 && searchResult.previous) {
+      await this.client.setIdentityCache(
+        profile,
+        "mention_cursor",
+        searchResult.previous,
+        session,
       );
-
-      const mentionCandidates = searchResult.tweets;
-
-      // If we got tweets and there's a valid cursor, cache it
-      if (mentionCandidates.length > 0 && searchResult.previous) {
-        await this.runtime.setCache(cursorKey, searchResult.previous);
-      } else if (!searchResult.previous && !searchResult.next) {
-        // If both previous and next are missing, clear the outdated cursor
-        await this.runtime.setCache(cursorKey, "");
-      }
-
-      await this.processMentionTweets(mentionCandidates);
-    } catch (error) {
-      logger.error("Error handling mentions:", errorMessage(error));
+    } else if (!searchResult.previous && !searchResult.next) {
+      await this.client.setIdentityCache(
+        profile,
+        "mention_cursor",
+        "",
+        session,
+      );
     }
   }
 
   /**
    * Handle autonomous engagement with target users' posts
    */
-  private async handleTargetUserPosts(targetUsersConfig: string) {
+  private async handleTargetUserPosts(
+    targetUsersConfig: string,
+    session: TwitterAccountSession,
+  ) {
     try {
       const targetUsers = getTargetUsers(targetUsersConfig);
 
@@ -344,9 +355,11 @@ export class TwitterInteractionClient {
             await this.processTargetUserTweets(
               searchResult.tweets,
               normalizedUsername,
+              session,
             );
           }
         } catch (error) {
+          if (isSessionRotationError(error)) throw error;
           logger.error(
             `Error searching posts from @${targetUser}:`,
             errorMessage(error),
@@ -356,9 +369,10 @@ export class TwitterInteractionClient {
 
       // If wildcard is configured, also check timeline for any interesting posts
       if (targetUsersConfig.includes("*")) {
-        await this.processTimelineForEngagement();
+        await this.processTimelineForEngagement(session);
       }
     } catch (error) {
+      if (isSessionRotationError(error)) throw error;
       logger.error("Error handling target user posts:", errorMessage(error));
     }
   }
@@ -369,6 +383,7 @@ export class TwitterInteractionClient {
   private async processTargetUserTweets(
     tweets: ClientTweet[],
     username: string,
+    session: TwitterAccountSession,
   ) {
     const maxEngagementsPerRun = normalizePositiveInteger(
       getSetting(this.runtime, "TWITTER_MAX_ENGAGEMENTS_PER_RUN") ??
@@ -410,13 +425,10 @@ export class TwitterInteractionClient {
           `Engaging with tweet from @${username}: ${tweet.text.substring(0, 50)}...`,
         );
 
-        // Create necessary context for the tweet
-        await this.ensureTweetContext(tweet);
-
-        // Execute the chosen actions (like / retweet / quote / reply)
-        const engaged = await this.engageWithTweet(tweet, actions);
+        const engaged = await this.engageWithTweet(tweet, actions, session);
 
         if (engaged) {
+          await this.ensureTweetContext(tweet);
           engagementCount++;
         }
       }
@@ -426,7 +438,7 @@ export class TwitterInteractionClient {
   /**
    * Process timeline for engagement when wildcard is configured
    */
-  private async processTimelineForEngagement() {
+  private async processTimelineForEngagement(session: TwitterAccountSession) {
     try {
       let timelineTweets: ClientTweet[];
       try {
@@ -458,9 +470,10 @@ export class TwitterInteractionClient {
         logger.info(
           `Found ${relevantTweets.length} relevant tweets from timeline`,
         );
-        await this.processTargetUserTweets(relevantTweets, "timeline");
+        await this.processTargetUserTweets(relevantTweets, "timeline", session);
       }
     } catch (error) {
+      if (isSessionRotationError(error)) throw error;
       logger.error(
         "Error processing timeline for engagement:",
         errorMessage(error),
@@ -593,26 +606,24 @@ Choose any combination of [LIKE], [RETWEET], [QUOTE], and [REPLY] that are appro
   private async engageWithTweet(
     tweet: ProcessableTweet,
     actions: ActionResponse,
+    session: TwitterAccountSession,
   ): Promise<boolean> {
     let engaged = false;
 
     if (actions.like) {
-      await this.handleLikeAction(tweet);
-      engaged = true;
+      engaged = (await this.handleLikeAction(tweet, session)) || engaged;
     }
 
     if (actions.retweet) {
-      await this.handleRetweetAction(tweet);
-      engaged = true;
+      engaged = (await this.handleRetweetAction(tweet, session)) || engaged;
     }
 
     if (actions.quote) {
-      await this.handleQuoteAction(tweet);
-      engaged = true;
+      engaged = (await this.handleQuoteAction(tweet, session)) || engaged;
     }
 
     if (actions.reply) {
-      const replied = await this.handleReplyAction(tweet);
+      const replied = await this.handleReplyAction(tweet, session);
       engaged = engaged || replied;
     }
 
@@ -622,39 +633,62 @@ Choose any combination of [LIKE], [RETWEET], [QUOTE], and [REPLY] that are appro
   /**
    * Like a search-discovered tweet.
    */
-  private async handleLikeAction(tweet: ProcessableTweet): Promise<void> {
+  private async handleLikeAction(
+    tweet: ProcessableTweet,
+    session: TwitterAccountSession,
+  ): Promise<boolean> {
     try {
       if (this.isDryRun) {
         logger.info(`[DRY RUN] Would have liked tweet ${tweet.id}`);
-        return;
+        return true;
       }
+      this.assertCurrentSession(session);
       await this.client.twitterClient.likeTweet(tweet.id);
       logger.info(`Liked tweet ${tweet.id}`);
+      return true;
     } catch (error) {
-      logger.error(`Error liking tweet ${tweet.id}:`, errorMessage(error));
+      if (isSessionRotationError(error)) throw error;
+      throw new ElizaError("X like action failed", {
+        code: "X_INTERACTION_ACTION_FAILED",
+        cause: error,
+        context: { tweetId: tweet.id, action: "like" },
+      });
     }
   }
 
   /**
    * Retweet a search-discovered tweet.
    */
-  private async handleRetweetAction(tweet: ProcessableTweet): Promise<void> {
+  private async handleRetweetAction(
+    tweet: ProcessableTweet,
+    session: TwitterAccountSession,
+  ): Promise<boolean> {
     try {
       if (this.isDryRun) {
         logger.info(`[DRY RUN] Would have retweeted tweet ${tweet.id}`);
-        return;
+        return true;
       }
+      this.assertCurrentSession(session);
       await this.client.twitterClient.retweet(tweet.id);
       logger.info(`Retweeted tweet ${tweet.id}`);
+      return true;
     } catch (error) {
-      logger.error(`Error retweeting tweet ${tweet.id}:`, errorMessage(error));
+      if (isSessionRotationError(error)) throw error;
+      throw new ElizaError("X retweet action failed", {
+        code: "X_INTERACTION_ACTION_FAILED",
+        cause: error,
+        context: { tweetId: tweet.id, action: "retweet" },
+      });
     }
   }
 
   /**
    * Quote a search-discovered tweet with model-generated commentary.
    */
-  private async handleQuoteAction(tweet: ProcessableTweet): Promise<void> {
+  private async handleQuoteAction(
+    tweet: ProcessableTweet,
+    session: TwitterAccountSession,
+  ): Promise<boolean> {
     try {
       const message = this.buildTweetMessage(tweet);
       const state = await this.runtime.composeState(message);
@@ -682,22 +716,29 @@ ${tweet.text}`;
       const post = responseObject.post;
       if (typeof post !== "string" || post.trim().length === 0) {
         logger.warn(`No quote text generated for tweet ${tweet.id}`);
-        return;
+        return false;
       }
 
       if (this.isDryRun) {
         logger.info(
           `[DRY RUN] Would have quoted tweet ${tweet.id} with: ${post}`,
         );
-        return;
+        return true;
       }
 
+      this.assertCurrentSession(session);
       await this.client.requestQueue.add(() =>
         this.client.twitterClient.sendQuoteTweet(post, tweet.id),
       );
       logger.info(`Quoted tweet ${tweet.id}`);
+      return true;
     } catch (error) {
-      logger.error(`Error quoting tweet ${tweet.id}:`, errorMessage(error));
+      if (isSessionRotationError(error)) throw error;
+      throw new ElizaError("X quote action failed", {
+        code: "X_INTERACTION_ACTION_FAILED",
+        cause: error,
+        context: { tweetId: tweet.id, action: "quote" },
+      });
     }
   }
 
@@ -706,20 +747,37 @@ ${tweet.text}`;
    *
    * @returns `true` if a reply was produced.
    */
-  private async handleReplyAction(tweet: ProcessableTweet): Promise<boolean> {
+  private async handleReplyAction(
+    tweet: ProcessableTweet,
+    session: TwitterAccountSession,
+  ): Promise<boolean> {
     try {
+      this.assertCurrentSession(session);
       const message = this.buildTweetMessage(tweet);
 
       const result = await this.handleTweet({
         tweet,
         message,
         thread: tweet.thread || [tweet],
+        session,
       });
 
       return Boolean(result.text && result.text.length > 0);
     } catch (error) {
-      logger.error("Error engaging with tweet:", errorMessage(error));
-      return false;
+      if (isSessionRotationError(error)) throw error;
+      throw new ElizaError("X reply action failed", {
+        code: "X_INTERACTION_ACTION_FAILED",
+        cause: error,
+        context: { tweetId: tweet.id, action: "reply" },
+      });
+    }
+  }
+
+  private assertCurrentSession(session: TwitterAccountSession): void {
+    if (!this.client.isAuthenticatedSessionCurrent(session)) {
+      throw new ElizaError("X credentials rotated during interaction", {
+        code: "X_AUTH_SESSION_ROTATED",
+      });
     }
   }
 
@@ -733,7 +791,29 @@ ${tweet.text}`;
    *
    * Note: MENTION_RECEIVED event emission is currently disabled.
    */
-  async processMentionTweets(mentionCandidates: ClientTweet[]) {
+  async processMentionTweets(
+    mentionCandidates: ClientTweet[],
+    authenticatedProfile?: TwitterProfile,
+  ): Promise<void> {
+    return this.client.withAuthenticatedSession(async (session) => {
+      if (
+        authenticatedProfile &&
+        authenticatedProfile.id !== session.profile.id
+      ) {
+        throw new ElizaError(
+          "Authenticated X profile changed before mention processing",
+          { code: "X_AUTH_SESSION_ROTATED" },
+        );
+      }
+      await this.processMentionTweetsForSession(mentionCandidates, session);
+    });
+  }
+
+  private async processMentionTweetsForSession(
+    mentionCandidates: ClientTweet[],
+    session: TwitterAccountSession,
+  ): Promise<void> {
+    const profile = session.profile;
     logger.log(
       "Completed checking mentioned tweets:",
       mentionCandidates.length.toString(),
@@ -741,7 +821,7 @@ ${tweet.text}`;
     let uniqueTweetCandidates = mentionCandidates
       .map((tweet) => normalizeTweet(tweet))
       .filter((tweet): tweet is ProcessableTweet => tweet !== null);
-    const profileId = this.client.profile?.id;
+    const profileId = profile.id;
 
     // Sort tweet candidates by ID in ascending order
     uniqueTweetCandidates = uniqueTweetCandidates
@@ -854,20 +934,14 @@ ${tweet.text}`;
 
     // for each tweet candidate, handle the tweet
     for (const tweet of tweetsToProcess) {
+      const lastCheckedTweetId = this.client.getLatestCheckedTweetId(profileId);
       if (
-        !this.client.lastCheckedTweetId ||
-        BigInt(tweet.id) > this.client.lastCheckedTweetId
+        lastCheckedTweetId === null ||
+        BigInt(tweet.id) > lastCheckedTweetId
       ) {
         // Generate the tweetId UUID the same way it's done in handleTweet
         const tweetId = createUniqueUuid(this.runtime, tweet.id);
-
-        // Check if we've already processed this tweet
-        const existingResponse = await this.runtime.getMemoryById(tweetId);
-
-        if (existingResponse) {
-          logger.log(`Already responded to tweet ${tweet.id}, skipping`);
-          continue;
-        }
+        const existingInbound = await this.runtime.getMemoryById(tweetId);
 
         // Also check if we've already responded to this tweet (for chunked responses)
         // by looking for any memory with inReplyTo pointing to this tweet
@@ -952,7 +1026,7 @@ ${tweet.text}`;
         });
 
         // 3. Create a memory for the tweet
-        const memory: Memory = {
+        const memory: Memory = existingInbound ?? {
           id: tweetId,
           entityId,
           content: {
@@ -972,11 +1046,13 @@ ${tweet.text}`;
           createdAt: tweet.timestamp,
         };
 
-        logger.log("Saving tweet memory...");
-        await createMemorySafe(this.runtime, memory, "messages");
+        if (!existingInbound) {
+          logger.log("Saving tweet memory...");
+          await createMemorySafe(this.runtime, memory, "messages");
+        }
 
         // Handle thread-specific events
-        if (tweet.thread && tweet.thread.length > 0) {
+        if (!existingInbound && tweet.thread && tweet.thread.length > 0) {
           const threadStartId = tweet.thread[0]?.id ?? tweet.id;
           const threadMemoryId = createUniqueUuid(
             this.runtime,
@@ -1012,14 +1088,16 @@ ${tweet.text}`;
           }
         }
 
+        this.assertCurrentSession(session);
         await this.handleTweet({
           tweet,
           message: memory,
           thread: tweet.thread,
+          session,
         });
 
-        // Update the last checked tweet ID after processing each tweet
-        this.client.lastCheckedTweetId = BigInt(tweet.id);
+        this.assertCurrentSession(session);
+        this.client.recordLatestCheckedTweetId(profileId, BigInt(tweet.id));
       }
     }
   }
@@ -1212,10 +1290,12 @@ ${tweet.text}`;
     tweet,
     message,
     thread,
+    session,
   }: {
     tweet: ClientTweet;
     message: Memory;
     thread: ClientTweet[];
+    session?: TwitterAccountSession;
   }) {
     const normalizedTweet = normalizeTweet(tweet);
     if (!normalizedTweet) {
@@ -1232,78 +1312,94 @@ ${tweet.text}`;
       return { text: "", actions: ["IGNORE"] };
     }
 
+    let deliveryError: unknown = null;
+    let egressAttempted = false;
+
     // Create a callback for handling the response
     const callback: HandlerCallback = async (
       response: Content,
       tweetId?: string,
     ) => {
+      if (!response.text) {
+        logger.warn("No text content in response, skipping tweet reply");
+        return [];
+      }
+
+      if (egressAttempted) {
+        logger.warn(
+          `Suppressed duplicate reply attempt for mention ${tweet.id}`,
+        );
+        return [];
+      }
+      egressAttempted = true;
+
+      const tweetToReplyTo = tweetId || tweet.id;
+
+      if (this.isDryRun) {
+        logger.info(
+          `[DRY RUN] Would have replied to ${tweet.username} with: ${response.text}`,
+        );
+        return [];
+      }
+
+      logger.info(`Replying to tweet ${tweetToReplyTo}`);
       try {
-        if (!response.text) {
-          logger.warn("No text content in response, skipping tweet reply");
-          return [];
-        }
-
-        const tweetToReplyTo = tweetId || tweet.id;
-
-        if (this.isDryRun) {
-          logger.info(
-            `[DRY RUN] Would have replied to ${tweet.username} with: ${response.text}`,
-          );
-          return [];
-        }
-
-        logger.info(`Replying to tweet ${tweetToReplyTo}`);
-
-        // Create the actual tweet using the Twitter API through the client
-        const tweetResult = await sendTweet(
+        if (session) this.assertCurrentSession(session);
+      } catch (error) {
+        deliveryError = error;
+        throw error;
+      }
+      let tweetResult: Awaited<ReturnType<typeof sendTweet>>;
+      try {
+        tweetResult = await sendTweet(
           this.client,
           response.text,
           [],
           tweetToReplyTo,
         );
-
-        if (!tweetResult) {
-          throw new Error("Failed to get tweet result from response");
-        }
-
-        // Create memory for our response
-        const responseId = createUniqueUuid(this.runtime, tweetResult.id);
-        const responseMemory: Memory = {
-          id: responseId,
-          entityId: this.runtime.agentId,
-          agentId: this.runtime.agentId,
-          roomId: message.roomId,
-          content: {
-            ...response,
-            source: "twitter",
-            inReplyTo: message.id,
-          },
-          metadata: {
-            type: "message",
-            source: "twitter",
-            accountId: this.client.accountId,
-            provider: "twitter",
-            fromBot: true,
-            messageIdFull: tweetResult.id,
-            twitter: {
-              accountId: this.client.accountId,
-              tweetId: tweetResult.id,
-              inReplyTo: tweetToReplyTo,
-            },
-          } satisfies Memory["metadata"],
-          createdAt: Date.now(),
-        };
-
-        await createMemorySafe(this.runtime, responseMemory, "messages");
-
-        return [responseMemory];
       } catch (error) {
-        // error-policy:J7 the reply was already sent; a failure recording its
-        // memory must surface to the agent rather than vanishing. Degrade to no
-        // recorded memory after reporting.
-        this.runtime.reportError("XInteractions.replyCallback", error);
-        return [];
+        deliveryError = error;
+        throw error;
       }
+
+      if (!tweetResult) {
+        throw new Error("Failed to get tweet result from response");
+      }
+      const responseId = createUniqueUuid(this.runtime, tweetResult.id);
+      const responseMemory: Memory = {
+        id: responseId,
+        entityId: this.runtime.agentId,
+        agentId: this.runtime.agentId,
+        roomId: message.roomId,
+        content: {
+          ...response,
+          source: "twitter",
+          inReplyTo: message.id,
+        },
+        metadata: {
+          type: "message",
+          source: "twitter",
+          accountId: this.client.accountId,
+          provider: "twitter",
+          fromBot: true,
+          messageIdFull: tweetResult.id,
+          twitter: {
+            accountId: this.client.accountId,
+            tweetId: tweetResult.id,
+            inReplyTo: tweetToReplyTo,
+          },
+        } satisfies Memory["metadata"],
+        createdAt: Date.now(),
+      };
+
+      try {
+        await createMemorySafe(this.runtime, responseMemory, "messages");
+      } catch (error) {
+        // error-policy:J7 X accepted the reply already, so persistence failure
+        // is reported without retrying the external side effect.
+        this.runtime.reportError("XInteractions.replyCallback", error);
+      }
+      return [responseMemory];
     };
 
     const twitterUserId = normalizedTweet.userId;
@@ -1339,8 +1435,9 @@ ${tweet.text}`;
 
     // Check if messageService is available
     if (!this.runtime.messageService) {
-      logger.error("messageService is not available - cannot process mention");
-      return { text: "", actions: ["IGNORE"] };
+      throw new ElizaError("X mention processing requires messageService", {
+        code: "X_MESSAGE_SERVICE_UNAVAILABLE",
+      });
     }
 
     // Process message through message service
@@ -1349,6 +1446,12 @@ ${tweet.text}`;
       message,
       callback,
     );
+
+    if (deliveryError) {
+      throw deliveryError instanceof Error
+        ? deliveryError
+        : new Error(String(deliveryError));
+    }
 
     // Extract response for Twitter posting
     const response = result.responseMessages || [];

--- a/plugins/plugin-x/src/post.ts
+++ b/plugins/plugin-x/src/post.ts
@@ -16,7 +16,7 @@ import {
   type UUID,
   withStandaloneTrajectory,
 } from "@elizaos/core";
-import type { ClientBase } from "./base";
+import type { ClientBase, TwitterProfile } from "./base";
 import { getRandomInterval } from "./environment";
 import type { TwitterClientState } from "./types";
 import { getSetting } from "./utils/settings";
@@ -173,24 +173,35 @@ export class TwitterPostClient {
    * @returns {Promise<boolean>} true if tweet was posted successfully
    */
   async generateNewTweet(): Promise<boolean> {
-    return await withStandaloneTrajectory(
-      this.runtime,
-      {
-        source: "plugin-x:auto-post",
-        metadata: {
-          platform: "x",
-          kind: "public_post_generation",
-          username: this.client.profile?.username,
-        },
-      },
-      async () => {
-        setTrajectoryPurpose("background");
-        return await this.generateNewTweetInner();
-      },
-    );
+    try {
+      return await this.client.withAuthenticatedSession(async ({ profile }) =>
+        withStandaloneTrajectory(
+          this.runtime,
+          {
+            source: "plugin-x:auto-post",
+            metadata: {
+              platform: "x",
+              kind: "public_post_generation",
+              username: profile.username,
+            },
+          },
+          async () => {
+            setTrajectoryPurpose("background");
+            return await this.generateNewTweetInner(profile);
+          },
+        ),
+      );
+    } catch (error) {
+      // error-policy:J7 background post generation must report identity and
+      // trajectory failures without terminating the autonomous scheduler.
+      this.runtime.reportError("XPostClient.generateNewTweet", error);
+      return false;
+    }
   }
 
-  private async generateNewTweetInner(): Promise<boolean> {
+  private async generateNewTweetInner(
+    profile: TwitterProfile,
+  ): Promise<boolean> {
     logger.info("Attempting to generate new tweet...");
 
     // Prevent concurrent posting
@@ -203,21 +214,14 @@ export class TwitterPostClient {
 
     try {
       // Create the timeline room ID for storing the post
-      const userId = this.client.profile?.id;
-      if (!userId) {
-        logger.error("Cannot generate tweet: Twitter profile not available");
-        this.isPosting = false; // Reset flag
-        return false;
-      }
+      const userId = profile.id;
 
-      logger.info(
-        `Generating tweet for user: ${this.client.profile?.username} (${userId})`,
-      );
+      logger.info(`Generating tweet for user: ${profile.username} (${userId})`);
 
       // Create standardized world and room IDs
       const worldId = createUniqueUuid(this.runtime, userId) as UUID;
       const roomId = createUniqueUuid(this.runtime, `${userId}-home`) as UUID;
-      const username = this.client.profile?.username || "unknown";
+      const username = profile.username;
       let posted = false;
 
       const callback = createTwitterPostCallback({

--- a/plugins/plugin-x/src/services/MessageService.ts
+++ b/plugins/plugin-x/src/services/MessageService.ts
@@ -3,9 +3,10 @@
  * messages, sending and listing DMs through `ClientBase`. Backs the message
  * connector handlers and the LifeOps DM adapter.
  */
-import { createUniqueUuid, logger, type UUID } from "@elizaos/core";
+import { createUniqueUuid, ElizaError, logger, type UUID } from "@elizaos/core";
 import type { ClientBase } from "../base";
 import { SearchMode } from "../client";
+import { extractXWriteReceiptId } from "../utils/provider-receipt";
 import { getEpochMs } from "../utils/time";
 import {
   type GetMessagesOptions,
@@ -22,156 +23,125 @@ export class TwitterMessageService implements IMessageService {
     return error instanceof Error ? error.message : String(error);
   }
 
-  private extractRestId(result: unknown): string | undefined {
-    const r = result as {
-      rest_id?: unknown;
-      data?: {
-        create_tweet?: { tweet_results?: { result?: { rest_id?: unknown } } };
-        data?: {
-          create_tweet?: { tweet_results?: { result?: { rest_id?: unknown } } };
-        };
-      };
-    } | null;
-    const candidate =
-      r?.rest_id ??
-      r?.data?.create_tweet?.tweet_results?.result?.rest_id ??
-      r?.data?.data?.create_tweet?.tweet_results?.result?.rest_id;
-    return typeof candidate === "string" ? candidate : undefined;
-  }
-
-  private async extractResultId(result: unknown): Promise<string | undefined> {
-    const r = result as {
-      id?: unknown;
-      data?: { id?: unknown; data?: { id?: unknown } };
-      json?: unknown;
-    } | null;
-    const direct = r?.id ?? r?.data?.id ?? r?.data?.data?.id;
-    if (typeof direct === "string") return direct;
-    const restId = this.extractRestId(result);
-    if (restId) return restId;
-
-    if (r && typeof r.json === "function") {
-      try {
-        const body = (await (r.json as () => Promise<unknown>)()) as {
-          id?: unknown;
-          data?: { id?: unknown; data?: { id?: unknown } };
-        } | null;
-        const viaBody = body?.id ?? body?.data?.id ?? body?.data?.data?.id;
-        if (typeof viaBody === "string") return viaBody;
-        return this.extractRestId(body);
-      } catch {
-        return undefined;
-      }
-    }
-
-    return undefined;
-  }
-
   async getMessages(options: GetMessagesOptions): Promise<Message[]> {
     try {
-      // Twitter doesn't have a direct way to get messages by room ID
-      // We'll need to use search to find related tweets/DMs
-      const username = this.client.profile?.username;
-      if (!username) {
-        logger.error("No Twitter profile available");
-        return [];
-      }
+      return await this.client.withAuthenticatedSession(async ({ profile }) => {
+        // Twitter doesn't have a direct way to get messages by room ID
+        // We'll need to use search to find related tweets/DMs
+        const searchResult = await this.client.fetchSearchTweets(
+          `@${profile.username}`,
+          options.limit || 20,
+          SearchMode.Latest,
+        );
 
-      // Search for mentions and replies
-      const searchResult = await this.client.fetchSearchTweets(
-        `@${username}`,
-        options.limit || 20,
-        SearchMode.Latest,
-      );
-
-      const messages: Message[] = searchResult.tweets.flatMap((tweet) => {
-        // Normalize once per row; rows without a usable identity or timestamp
-        // fail closed instead of surfacing as fresh messages (#18965).
-        const timestamp = getEpochMs(tweet.timestamp);
-        if (typeof tweet.id !== "string" || timestamp === undefined) return [];
-        const tweetId = tweet.id;
-        const conversationId = tweet.conversationId ?? tweetId;
-        if (options.roomId) {
-          const tweetRoomId = createUniqueUuid(
-            this.client.runtime,
-            conversationId,
-          );
-          if (tweetRoomId !== options.roomId) return [];
-        }
-        return [
-          {
-            id: tweetId,
-            agentId: this.client.runtime.agentId,
-            roomId: createUniqueUuid(this.client.runtime, conversationId),
-            userId: tweet.userId ?? "",
-            username: tweet.username ?? "",
-            text: tweet.text ?? "",
-            type: tweet.inReplyToStatusId
-              ? MessageType.REPLY
-              : MessageType.MENTION,
-            timestamp,
-            inReplyTo: tweet.inReplyToStatusId,
-            metadata: {
-              tweetId,
-              permanentUrl: tweet.permanentUrl,
+        const messages: Message[] = searchResult.tweets.flatMap((tweet) => {
+          // Normalize once per row; rows without a usable identity or timestamp
+          // fail closed instead of surfacing as fresh messages (#18965).
+          const timestamp = getEpochMs(tweet.timestamp);
+          if (typeof tweet.id !== "string" || timestamp === undefined)
+            return [];
+          const tweetId = tweet.id;
+          const conversationId = tweet.conversationId ?? tweetId;
+          if (options.roomId) {
+            const tweetRoomId = createUniqueUuid(
+              this.client.runtime,
+              conversationId,
+            );
+            if (tweetRoomId !== options.roomId) return [];
+          }
+          return [
+            {
+              id: tweetId,
+              agentId: this.client.runtime.agentId,
+              roomId: createUniqueUuid(this.client.runtime, conversationId),
+              userId: tweet.userId ?? "",
+              username: tweet.username ?? "",
+              text: tweet.text ?? "",
+              type: tweet.inReplyToStatusId
+                ? MessageType.REPLY
+                : MessageType.MENTION,
+              timestamp,
+              inReplyTo: tweet.inReplyToStatusId,
+              metadata: {
+                tweetId,
+                permanentUrl: tweet.permanentUrl,
+              },
             },
-          },
-        ];
-      });
+          ];
+        });
 
-      return messages;
+        return messages;
+      });
     } catch (error) {
-      // error-policy:J7 a DM fetch failure must surface to the agent (RECENT_ERRORS)
-      // rather than reading as an empty inbox; degrade to no messages after reporting.
+      // error-policy:J7 Report the connector failure to the agent, then keep it
+      // distinct from a legitimately empty inbox.
       this.client.runtime.reportError("XMessageService.getMessages", error);
-      return [];
+      throw error;
     }
   }
 
   async sendMessage(options: SendMessageOptions): Promise<Message> {
-    try {
-      let result: unknown;
+    return this.client.withAuthenticatedSession(async (session) => {
+      const { profile } = session;
+      try {
+        let result: unknown;
+        if (!this.client.isAuthenticatedSessionCurrent(session)) {
+          throw new ElizaError("X credentials rotated before message egress", {
+            code: "X_AUTH_SESSION_ROTATED",
+          });
+        }
 
-      if (options.type === MessageType.DIRECT_MESSAGE) {
-        // Send direct message using the roomId as conversationId
-        result = await this.client.twitterClient.sendDirectMessage(
-          options.roomId.toString(),
-          options.text,
-        );
-      } else {
-        // Send tweet (reply, mention, or regular post)
-        result = await this.client.twitterClient.sendTweet(
-          options.text,
-          options.replyToId,
-        );
+        if (options.type === MessageType.DIRECT_MESSAGE) {
+          // Send direct message using the roomId as conversationId
+          result = await this.client.twitterClient.sendDirectMessage(
+            options.roomId.toString(),
+            options.text,
+          );
+        } else {
+          // Send tweet (reply, mention, or regular post)
+          result = await this.client.twitterClient.sendTweet(
+            options.text,
+            options.replyToId,
+          );
+        }
+
+        const extractedId = await extractXWriteReceiptId(result);
+        if (!extractedId) {
+          throw new ElizaError(
+            "X accepted the message but returned no usable receipt; do not retry blindly",
+            {
+              code: "X_MESSAGE_RECEIPT_INDETERMINATE",
+              context: {
+                accountId: this.client.accountId,
+                providerAccepted: true,
+                retrySafe: false,
+              },
+            },
+          );
+        }
+
+        const message: Message = {
+          id: extractedId,
+          agentId: options.agentId,
+          roomId: options.roomId,
+          userId: profile.id,
+          username: profile.username,
+          text: options.text,
+          type: options.type,
+          timestamp: Date.now(),
+          inReplyTo: options.replyToId,
+          metadata: {
+            ...options.metadata,
+            result,
+          },
+        };
+
+        return message;
+      } catch (error) {
+        logger.error("Error sending message:", this.errorDetail(error));
+        throw error;
       }
-
-      const extractedId = await this.extractResultId(result);
-      const resultId = (result as { id?: unknown } | null)?.id;
-      const messageId =
-        extractedId ?? (typeof resultId === "string" ? resultId : "");
-
-      const message: Message = {
-        id: messageId,
-        agentId: options.agentId,
-        roomId: options.roomId,
-        userId: this.client.profile?.id || "",
-        username: this.client.profile?.username || "",
-        text: options.text,
-        type: options.type,
-        timestamp: Date.now(),
-        inReplyTo: options.replyToId,
-        metadata: {
-          ...options.metadata,
-          result,
-        },
-      };
-
-      return message;
-    } catch (error) {
-      logger.error("Error sending message:", this.errorDetail(error));
-      throw error;
-    }
+    });
   }
 
   async deleteMessage(messageId: string, _agentId: UUID): Promise<void> {
@@ -212,10 +182,10 @@ export class TwitterMessageService implements IMessageService {
 
       return message;
     } catch (error) {
-      // error-policy:J7 a message-fetch failure must surface to the agent rather
-      // than reading as "no such message"; degrade to null after reporting.
+      // error-policy:J7 Report the connector failure to the agent, then keep it
+      // distinct from the legitimate null returned for a missing message.
       this.client.runtime.reportError("XMessageService.getMessage", error);
-      return null;
+      throw error;
     }
   }
 

--- a/plugins/plugin-x/src/services/PostService.test.ts
+++ b/plugins/plugin-x/src/services/PostService.test.ts
@@ -1,10 +1,39 @@
-/** Unit tests for `TwitterPostService` inverse actions (unlike / unrepost), driving a mocked Twitter client. */
+/** Verifies post effects, identity attribution, and fail-closed provider boundaries through deterministic X client fakes. */
 import type { UUID } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ClientBase } from "../base";
+import type {
+  ClientBase,
+  TwitterAccountSession,
+  TwitterProfile,
+} from "../base";
 import { TwitterPostService } from "./PostService";
 
-describe("TwitterPostService inverse post actions", () => {
+const AGENT_ID = "00000000-0000-0000-0000-000000000001" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-000000000002" as UUID;
+
+const CURRENT_PROFILE: TwitterProfile = {
+  id: "account-b",
+  username: "current-b",
+  screenName: "Current B",
+  bio: "",
+  nicknames: [],
+};
+
+function withSession(
+  profile: TwitterProfile,
+  client: object,
+): Pick<
+  ClientBase,
+  "withAuthenticatedSession" | "isAuthenticatedSessionCurrent"
+> {
+  const session = { client, profile, revision: 2 } as TwitterAccountSession;
+  return {
+    withAuthenticatedSession: async (operation) => operation(session),
+    isAuthenticatedSessionCurrent: () => true,
+  };
+}
+
+describe("TwitterPostService", () => {
   const unlikeTweet = vi.fn();
   const unretweet = vi.fn();
   let service: TwitterPostService;
@@ -21,43 +50,192 @@ describe("TwitterPostService inverse post actions", () => {
   });
 
   it("unlikes posts through the Twitter client", async () => {
-    await service.unlikePost(
-      "tweet-1",
-      "00000000-0000-0000-0000-000000000001" as UUID,
-    );
+    await service.unlikePost("tweet-1", AGENT_ID);
 
     expect(unlikeTweet).toHaveBeenCalledWith("tweet-1");
   });
 
   it("removes reposts through the Twitter client", async () => {
-    await service.unrepost(
-      "tweet-2",
-      "00000000-0000-0000-0000-000000000001" as UUID,
-    );
+    await service.unrepost("tweet-2", AGENT_ID);
 
     expect(unretweet).toHaveBeenCalledWith("tweet-2");
   });
 
-  it("surfaces a getPosts fetch failure via reportError instead of silently returning []", async () => {
+  it("reports and rejects getPosts provider failures", async () => {
+    const providerError = new Error("twitter 429 rate limited");
     const reportError = vi.fn();
-    const getUserTweets = vi
-      .fn()
-      .mockRejectedValue(new Error("twitter 429 rate limited"));
+    const getUserTweets = vi.fn().mockRejectedValue(providerError);
     const failing = new TwitterPostService({
       runtime: { reportError },
       twitterClient: { getUserTweets },
     } as unknown as ClientBase);
 
-    const posts = await failing.getPosts({
-      agentId: "00000000-0000-0000-0000-000000000001" as UUID,
-      userId: "123",
-      limit: 5,
-    });
-
-    expect(posts).toEqual([]);
+    await expect(
+      failing.getPosts({
+        agentId: AGENT_ID,
+        userId: "123",
+        limit: 5,
+      }),
+    ).rejects.toBe(providerError);
     expect(reportError).toHaveBeenCalledWith(
       "XPostService.getPosts",
-      expect.any(Error),
+      providerError,
     );
+  });
+
+  it("keeps a legitimate empty provider result distinct from failure", async () => {
+    const reportError = vi.fn();
+    const getUserTweets = vi.fn(async () => ({ tweets: [] }));
+    const empty = new TwitterPostService({
+      runtime: { reportError },
+      twitterClient: { getUserTweets },
+    } as unknown as ClientBase);
+
+    await expect(
+      empty.getPosts({
+        agentId: AGENT_ID,
+        userId: "123",
+        limit: 5,
+      }),
+    ).resolves.toEqual([]);
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it("reports and rejects mention provider failures", async () => {
+    const providerError = new Error("search transport unavailable");
+    const reportError = vi.fn();
+    const fetchSearchTweets = vi.fn().mockRejectedValue(providerError);
+    const failing = new TwitterPostService({
+      runtime: { reportError },
+      ...withSession(CURRENT_PROFILE, {}),
+      fetchSearchTweets,
+    } as unknown as ClientBase);
+
+    await expect(failing.getMentions(AGENT_ID)).rejects.toBe(providerError);
+    expect(reportError).toHaveBeenCalledWith(
+      "XPostService.getMentions",
+      providerError,
+    );
+  });
+
+  it("uses the admitted profile for created-post attribution", async () => {
+    const sendTweet = vi.fn(async () => ({ data: { id: "tweet-b" } }));
+    const sessionBoundary = withSession(CURRENT_PROFILE, {});
+    const withAuthenticatedSession = vi.spyOn(
+      sessionBoundary,
+      "withAuthenticatedSession",
+    );
+    const current = new TwitterPostService({
+      profile: { id: "account-a", username: "stale-a" },
+      ...sessionBoundary,
+      twitterClient: { sendTweet },
+    } as unknown as ClientBase);
+
+    const post = await current.createPost({
+      agentId: AGENT_ID,
+      roomId: ROOM_ID,
+      text: "hello from b",
+    });
+
+    expect(withAuthenticatedSession).toHaveBeenCalledOnce();
+    expect(post).toMatchObject({
+      id: "tweet-b",
+      userId: "account-b",
+      username: "current-b",
+    });
+  });
+
+  it("surfaces an accepted post without a receipt as non-retriable and indeterminate", async () => {
+    const sendTweet = vi.fn(async () => ({ data: { id: "   " } }));
+    const current = new TwitterPostService({
+      accountId: "default",
+      ...withSession(CURRENT_PROFILE, {}),
+      twitterClient: { sendTweet },
+    } as unknown as ClientBase);
+
+    await expect(
+      current.createPost({
+        agentId: AGENT_ID,
+        roomId: ROOM_ID,
+        text: "provider accepted this request",
+      }),
+    ).rejects.toMatchObject({
+      code: "X_POST_RECEIPT_INDETERMINATE",
+      context: {
+        accountId: "default",
+        providerAccepted: true,
+        retrySafe: false,
+      },
+    });
+    expect(sendTweet).toHaveBeenCalledOnce();
+  });
+
+  it("queries mentions with the admitted username", async () => {
+    const fetchSearchTweets = vi.fn(async () => ({ tweets: [] }));
+    const current = new TwitterPostService({
+      profile: { id: "account-a", username: "stale-a" },
+      runtime: { reportError: vi.fn() },
+      ...withSession(CURRENT_PROFILE, {}),
+      fetchSearchTweets,
+    } as unknown as ClientBase);
+
+    await current.getMentions(AGENT_ID);
+
+    expect(fetchSearchTweets).toHaveBeenCalledWith(
+      "@current-b",
+      20,
+      expect.anything(),
+      undefined,
+    );
+  });
+
+  it("refuses a post when the caller profile and admitted session differ", async () => {
+    const sendTweet = vi.fn();
+    const current = new TwitterPostService({
+      ...withSession(CURRENT_PROFILE, {}),
+      twitterClient: { sendTweet },
+    } as unknown as ClientBase);
+
+    await expect(
+      current.createPost(
+        {
+          agentId: AGENT_ID,
+          roomId: ROOM_ID,
+          text: "must not cross accounts",
+        },
+        { ...CURRENT_PROFILE, id: "account-a" },
+      ),
+    ).rejects.toMatchObject({ code: "X_AUTH_SESSION_ROTATED" });
+    expect(sendTweet).not.toHaveBeenCalled();
+  });
+
+  it("aborts publication when the second requested media upload fails", async () => {
+    const uploadFailure = new Error("second upload rejected");
+    const uploadMedia = vi
+      .fn()
+      .mockResolvedValueOnce("media-1")
+      .mockRejectedValueOnce(uploadFailure);
+    const sendTweet = vi.fn();
+    const current = new TwitterPostService({
+      ...withSession(CURRENT_PROFILE, {}),
+      twitterClient: { uploadMedia, sendTweet },
+    } as unknown as ClientBase);
+
+    await expect(
+      current.createPost({
+        agentId: AGENT_ID,
+        roomId: ROOM_ID,
+        text: "both attachments are required",
+        media: [
+          { data: Buffer.from("first"), type: "image/png" },
+          { data: Buffer.from("second"), type: "image/jpeg" },
+        ],
+      }),
+    ).rejects.toMatchObject({
+      code: "X_MEDIA_UPLOAD_FAILED",
+      cause: uploadFailure,
+    });
+    expect(uploadMedia).toHaveBeenCalledTimes(2);
+    expect(sendTweet).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-x/src/services/PostService.ts
+++ b/plugins/plugin-x/src/services/PostService.ts
@@ -3,9 +3,10 @@
  * covering create/get posts, mention retrieval, and like/retweet plus their
  * inverses through `ClientBase`. Backs the post connector handlers on `XService`.
  */
-import { createUniqueUuid, logger, type UUID } from "@elizaos/core";
-import type { ClientBase } from "../base";
+import { createUniqueUuid, ElizaError, logger, type UUID } from "@elizaos/core";
+import type { ClientBase, TwitterProfile } from "../base";
 import { SearchMode } from "../client";
+import { extractXWriteReceiptId } from "../utils/provider-receipt";
 import { getEpochMs } from "../utils/time";
 import type {
   CreatePostOptions,
@@ -21,171 +22,122 @@ export class TwitterPostService implements IPostService {
     return error instanceof Error ? error.message : String(error);
   }
 
-  private async safeParseJsonResponse(
-    result: unknown,
-  ): Promise<unknown | undefined> {
-    try {
-      const asRecord = (v: unknown): Record<string, unknown> =>
-        typeof v === "object" && v !== null
-          ? (v as Record<string, unknown>)
-          : {};
-      const recordResult = asRecord(result);
-
-      if (typeof recordResult.clone === "function") {
-        // If body is already used, clone() may throw; guard defensively.
-        if (recordResult.bodyUsed === true) return undefined;
-        const cloned = (recordResult.clone as () => unknown)();
-        const clonedRecord = asRecord(cloned);
-        if (typeof clonedRecord.json === "function") {
-          return await (clonedRecord.json as () => Promise<unknown>)();
-        }
-        return undefined;
+  async createPost(
+    options: CreatePostOptions,
+    authenticatedProfile?: TwitterProfile,
+  ): Promise<Post> {
+    return this.client.withAuthenticatedSession(async (session) => {
+      const { profile } = session;
+      if (authenticatedProfile && authenticatedProfile.id !== profile.id) {
+        throw new ElizaError(
+          "Authenticated X profile changed before the post was admitted",
+          { code: "X_AUTH_SESSION_ROTATED" },
+        );
       }
+      try {
+        // Handle media uploads if needed
+        const mediaIds: string[] = [];
 
-      // Non-Response shapes (e.g. our internal wrappers) may expose json()
-      // but do not consume streams.
-      if (typeof recordResult.json === "function") {
-        return await (recordResult.json as () => Promise<unknown>)();
-      }
-      return undefined;
-    } catch {
-      return undefined;
-    }
-  }
+        if (options.media && options.media.length > 0) {
+          logger.info(`Uploading ${options.media.length} media file(s)...`);
 
-  private extractRestId(result: unknown): string | undefined {
-    const r = result as {
-      rest_id?: unknown;
-      data?: {
-        create_tweet?: { tweet_results?: { result?: { rest_id?: unknown } } };
-        data?: {
-          create_tweet?: { tweet_results?: { result?: { rest_id?: unknown } } };
-        };
-      };
-    } | null;
-    const candidate =
-      r?.rest_id ??
-      r?.data?.create_tweet?.tweet_results?.result?.rest_id ??
-      r?.data?.data?.create_tweet?.tweet_results?.result?.rest_id;
-    return typeof candidate === "string" ? candidate : undefined;
-  }
+          for (const media of options.media) {
+            try {
+              // Upload media using Twitter API v1 (v2 doesn't support media upload yet)
+              const mediaId = await this.client.twitterClient.uploadMedia(
+                media.data,
+                {
+                  mimeType: media.type,
+                },
+              );
 
-  private async extractTweetId(result: unknown): Promise<string | undefined> {
-    const r = result as {
-      id?: unknown;
-      data?: { id?: unknown; data?: { id?: unknown } };
-      json?: unknown;
-    } | null;
-    const direct = r?.id ?? r?.data?.id ?? r?.data?.data?.id;
-    if (typeof direct === "string") return direct;
-    const restId = this.extractRestId(result);
-    if (restId) return restId;
-
-    if (r && typeof r.json === "function") {
-      const body = (await this.safeParseJsonResponse(result)) as {
-        id?: unknown;
-        data?: { id?: unknown; data?: { id?: unknown } };
-      } | null;
-      const viaBody = body?.id ?? body?.data?.id ?? body?.data?.data?.id;
-      if (typeof viaBody === "string") return viaBody;
-      return this.extractRestId(body);
-    }
-
-    return undefined;
-  }
-
-  async createPost(options: CreatePostOptions): Promise<Post> {
-    try {
-      // Handle media uploads if needed
-      const mediaIds: string[] = [];
-
-      if (options.media && options.media.length > 0) {
-        logger.info(`Uploading ${options.media.length} media file(s)...`);
-
-        for (const media of options.media) {
-          try {
-            // Upload media using Twitter API v1 (v2 doesn't support media upload yet)
-            const mediaId = await this.client.twitterClient.uploadMedia(
-              media.data,
-              {
-                mimeType: media.type,
-              },
-            );
-
-            mediaIds.push(mediaId);
-            logger.info(`Media uploaded successfully. Media ID: ${mediaId}`);
-          } catch (error) {
-            logger.error("Error uploading media:", this.errorDetail(error));
-            // Continue with other media files even if one fails
+              mediaIds.push(mediaId);
+              logger.info(`Media uploaded successfully. Media ID: ${mediaId}`);
+            } catch (error) {
+              // error-policy:J2 Publishing without every requested attachment
+              // would silently change an irreversible external effect.
+              throw new ElizaError("X media upload failed", {
+                code: "X_MEDIA_UPLOAD_FAILED",
+                cause: error,
+                context: { mimeType: media.type },
+              });
+            }
           }
+
+          logger.info(
+            `Successfully uploaded ${mediaIds.length}/${options.media.length} media file(s)`,
+          );
         }
 
-        logger.info(
-          `Successfully uploaded ${mediaIds.length}/${options.media.length} media file(s)`,
-        );
+        if (!this.client.isAuthenticatedSessionCurrent(session)) {
+          throw new ElizaError("X credentials rotated before post egress", {
+            code: "X_AUTH_SESSION_ROTATED",
+          });
+        }
+        const result =
+          mediaIds.length > 0
+            ? await this.client.twitterClient.sendTweet(
+                options.text,
+                options.inReplyTo,
+                options.media?.map((m) => ({
+                  data: m.data,
+                  mediaType: m.type,
+                })),
+                false, // hideLinkPreview
+                mediaIds, // Pass uploaded media IDs
+              )
+            : await this.client.twitterClient.sendTweet(
+                options.text,
+                options.inReplyTo,
+              );
+
+        const tweetId = await extractXWriteReceiptId(result);
+        if (!tweetId) {
+          logger.error(
+            `Twitter createPost: provider accepted the request without a usable receipt (reply=${options.inReplyTo ? "yes" : "no"}, textLength=${options.text.length})`,
+          );
+          throw new ElizaError(
+            "X accepted the post but returned no usable receipt; do not retry blindly",
+            {
+              code: "X_POST_RECEIPT_INDETERMINATE",
+              context: {
+                accountId: this.client.accountId,
+                providerAccepted: true,
+                retrySafe: false,
+              },
+            },
+          );
+        }
+
+        const post: Post = {
+          id: tweetId,
+          agentId: options.agentId,
+          roomId: options.roomId,
+          userId: profile.id,
+          username: profile.username,
+          text: options.text,
+          timestamp: Date.now(),
+          inReplyTo: options.inReplyTo,
+          quotedPostId: options.quotedPostId,
+          metrics: {
+            likes: 0,
+            reposts: 0,
+            replies: 0,
+            quotes: 0,
+            views: 0,
+          },
+          media: [],
+          metadata: {
+            raw: result,
+          },
+        };
+
+        return post;
+      } catch (error) {
+        logger.error("Error creating post:", this.errorDetail(error));
+        throw error;
       }
-
-      const result =
-        mediaIds.length > 0
-          ? await this.client.twitterClient.sendTweet(
-              options.text,
-              options.inReplyTo,
-              options.media?.map((m) => ({
-                data: m.data,
-                mediaType: m.type,
-              })),
-              false, // hideLinkPreview
-              mediaIds, // Pass uploaded media IDs
-            )
-          : await this.client.twitterClient.sendTweet(
-              options.text,
-              options.inReplyTo,
-            );
-
-      const tweetId = await this.extractTweetId(result);
-      if (!tweetId) {
-        const safeResult =
-          typeof result === "string"
-            ? result
-            : JSON.stringify(result, null, 2).slice(0, 8000);
-        logger.error(
-          `Twitter createPost: could not extract tweet id from API result ${JSON.stringify(
-            { inReplyTo: options.inReplyTo, textLength: options.text?.length },
-          )} ${safeResult}`,
-        );
-        throw new Error(
-          "Twitter createPost failed: could not extract tweet id from API response. See logs for raw response.",
-        );
-      }
-
-      const post: Post = {
-        id: tweetId,
-        agentId: options.agentId,
-        roomId: options.roomId,
-        userId: this.client.profile?.id || "",
-        username: this.client.profile?.username || "",
-        text: options.text,
-        timestamp: Date.now(),
-        inReplyTo: options.inReplyTo,
-        quotedPostId: options.quotedPostId,
-        metrics: {
-          likes: 0,
-          reposts: 0,
-          replies: 0,
-          quotes: 0,
-          views: 0,
-        },
-        media: [],
-        metadata: {
-          raw: result,
-        },
-      };
-
-      return post;
-    } catch (error) {
-      logger.error("Error creating post:", this.errorDetail(error));
-      throw error;
-    }
+    });
   }
 
   async deletePost(postId: string, _agentId: UUID): Promise<void> {
@@ -240,10 +192,10 @@ export class TwitterPostService implements IPostService {
 
       return post;
     } catch (error) {
-      // error-policy:J7 a post-fetch failure must surface to the agent rather than
-      // reading as "no such post"; degrade to null after reporting.
+      // error-policy:J7 Report the connector failure to the agent, then keep it
+      // distinct from the legitimate null returned for a missing post.
       this.client.runtime.reportError("XPostService.getPost", error);
-      return null;
+      throw error;
     }
   }
 
@@ -311,10 +263,10 @@ export class TwitterPostService implements IPostService {
 
       return posts;
     } catch (error) {
-      // error-policy:J7 a posts-fetch failure must surface to the agent rather than
-      // reading as an empty timeline; degrade to no posts after reporting.
+      // error-policy:J7 Report the connector failure to the agent, then keep it
+      // distinct from a legitimately empty timeline.
       this.client.runtime.reportError("XPostService.getPosts", error);
-      return [];
+      throw error;
     }
   }
 
@@ -341,65 +293,62 @@ export class TwitterPostService implements IPostService {
     options?: Partial<GetPostsOptions>,
   ): Promise<Post[]> {
     try {
-      const username = this.client.profile?.username;
-      if (!username) {
-        logger.error("No Twitter profile available");
-        return [];
-      }
+      return await this.client.withAuthenticatedSession(async ({ profile }) => {
+        const searchResult = await this.client.fetchSearchTweets(
+          `@${profile.username}`,
+          options?.limit || 20,
+          SearchMode.Latest,
+          options?.before,
+        );
 
-      const searchResult = await this.client.fetchSearchTweets(
-        `@${username}`,
-        options?.limit || 20,
-        SearchMode.Latest,
-        options?.before,
-      );
+        const posts: Post[] = searchResult.tweets.flatMap((tweet) => {
+          // Normalize once per row; rows without a usable identity or timestamp
+          // fail closed instead of surfacing as fresh mentions (#18965).
+          const timestamp = getEpochMs(tweet.timestamp);
+          if (typeof tweet.id !== "string" || timestamp === undefined)
+            return [];
+          const tweetId = tweet.id;
+          return [
+            {
+              id: tweetId,
+              agentId: agentId,
+              roomId: createUniqueUuid(
+                this.client.runtime,
+                tweet.conversationId || tweetId,
+              ),
+              userId: tweet.userId ?? "",
+              username: tweet.username ?? "",
+              text: tweet.text ?? "",
+              timestamp,
+              metrics: {
+                likes: tweet.likes || 0,
+                reposts: tweet.retweets || 0,
+                replies: tweet.replies || 0,
+                quotes: tweet.quotes || 0,
+                views: tweet.views || 0,
+              },
+              media:
+                tweet.photos?.map((photo) => ({
+                  type: "image" as const,
+                  url: photo.url,
+                  metadata: { id: photo.id },
+                })) || [],
+              metadata: {
+                conversationId: tweet.conversationId,
+                permanentUrl: tweet.permanentUrl,
+                isMention: true,
+              },
+            },
+          ];
+        });
 
-      const posts: Post[] = searchResult.tweets.flatMap((tweet) => {
-        // Normalize once per row; rows without a usable identity or timestamp
-        // fail closed instead of surfacing as fresh mentions (#18965).
-        const timestamp = getEpochMs(tweet.timestamp);
-        if (typeof tweet.id !== "string" || timestamp === undefined) return [];
-        const tweetId = tweet.id;
-        return [
-          {
-            id: tweetId,
-            agentId: agentId,
-            roomId: createUniqueUuid(
-              this.client.runtime,
-              tweet.conversationId || tweetId,
-            ),
-            userId: tweet.userId ?? "",
-            username: tweet.username ?? "",
-            text: tweet.text ?? "",
-            timestamp,
-            metrics: {
-              likes: tweet.likes || 0,
-              reposts: tweet.retweets || 0,
-              replies: tweet.replies || 0,
-              quotes: tweet.quotes || 0,
-              views: tweet.views || 0,
-            },
-            media:
-              tweet.photos?.map((photo) => ({
-                type: "image" as const,
-                url: photo.url,
-                metadata: { id: photo.id },
-              })) || [],
-            metadata: {
-              conversationId: tweet.conversationId,
-              permanentUrl: tweet.permanentUrl,
-              isMention: true,
-            },
-          },
-        ];
+        return posts;
       });
-
-      return posts;
     } catch (error) {
-      // error-policy:J7 a mentions-fetch failure must surface to the agent rather
-      // than reading as no mentions; degrade to an empty list after reporting.
+      // error-policy:J7 Report the connector failure to the agent, then keep it
+      // distinct from a legitimately empty mention list.
       this.client.runtime.reportError("XPostService.getMentions", error);
-      return [];
+      throw error;
     }
   }
 

--- a/plugins/plugin-x/src/services/base-credential-identity.test.ts
+++ b/plugins/plugin-x/src/services/base-credential-identity.test.ts
@@ -1,0 +1,276 @@
+/** Deterministic tests for credential-bound X identity publication and cursor migration. */
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ClientBase, type TwitterProfile } from "../base";
+import type { TwitterClientState } from "../types";
+
+type RawProfile = {
+  userId: string;
+  username: string;
+  name: string;
+  biography: string;
+};
+
+const CURRENT_PROFILE: TwitterProfile = {
+  id: "account-b",
+  username: "current-b",
+  screenName: "Current B",
+  bio: "",
+  nicknames: [],
+};
+
+function asRuntime<T extends object>(runtime: T): IAgentRuntime & T {
+  return runtime as IAgentRuntime & T;
+}
+
+function attachRawSession(
+  base: ClientBase,
+  profile: RawProfile,
+  options: {
+    apiClient?: object;
+    revision?: number;
+    isCurrent?: () => boolean;
+  } = {},
+): void {
+  const apiClient = options.apiClient ?? {};
+  const revision = options.revision ?? 1;
+  base.twitterClient = {
+    withAuthenticatedSession: vi.fn(
+      async (
+        operation: (session: {
+          client: object;
+          profile: RawProfile;
+          revision: number;
+        }) => Promise<unknown>,
+      ) => operation({ client: apiClient, profile, revision }),
+    ),
+    withCurrentSession: vi.fn(
+      async (_session: unknown, operation: () => Promise<unknown>) =>
+        operation(),
+    ),
+    isAuthenticatedSessionCurrent: vi.fn(options.isCurrent ?? (() => true)),
+  } as unknown as ClientBase["twitterClient"];
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("ClientBase authenticated identity", () => {
+  it("publishes only the default account while a secondary account keeps local identity and cursor state", async () => {
+    let entity = {
+      id: "agent-1",
+      names: ["Agent"],
+      metadata: {},
+      agentId: "agent-1",
+    };
+    const getEntityById = vi.fn(async () => entity);
+    const updateEntity = vi.fn(async (next: typeof entity) => {
+      entity = next;
+    });
+    const getCache = vi.fn(async (key: string) =>
+      key === "twitter/secondary/secondary-user/latest_checked_tweet_id"
+        ? "88"
+        : undefined,
+    );
+    const runtime = asRuntime({
+      agentId: "agent-1",
+      character: { name: "Agent" },
+      getSetting: () => undefined,
+      getEntityById,
+      updateEntity,
+      getCache,
+      setCache: vi.fn(),
+    });
+
+    const defaultClient = new ClientBase(runtime, {
+      accountId: "default",
+    } as TwitterClientState);
+    attachRawSession(defaultClient, {
+      userId: "default-user",
+      username: "default-name",
+      name: "Default Name",
+      biography: "default bio",
+    });
+    await expect(
+      defaultClient.getAuthenticatedProfile(),
+    ).resolves.toMatchObject({ id: "default-user", username: "default-name" });
+    expect(getEntityById).toHaveBeenCalledOnce();
+    expect(updateEntity).toHaveBeenCalledOnce();
+    expect(entity).toMatchObject({
+      metadata: {
+        twitter: {
+          id: "default-user",
+          userName: "default-name",
+          name: "Default Name",
+        },
+      },
+    });
+
+    getEntityById.mockClear();
+    updateEntity.mockClear();
+    const secondaryClient = new ClientBase(
+      runtime,
+      { accountId: "secondary" } as TwitterClientState,
+      { publishLegacyIdentity: false },
+    );
+    attachRawSession(secondaryClient, {
+      userId: "secondary-user",
+      username: "secondary-name",
+      name: "Secondary Name",
+      biography: "secondary bio",
+    });
+
+    await expect(
+      secondaryClient.getAuthenticatedProfile(),
+    ).resolves.toMatchObject({
+      id: "secondary-user",
+      username: "secondary-name",
+    });
+    expect(secondaryClient.profile).toMatchObject({ id: "secondary-user" });
+    expect(secondaryClient.lastCheckedTweetId).toBe(88n);
+    expect(getEntityById).not.toHaveBeenCalled();
+    expect(updateEntity).not.toHaveBeenCalled();
+    expect(getCache).toHaveBeenCalledWith(
+      "twitter/secondary/secondary-user/latest_checked_tweet_id",
+    );
+    expect(defaultClient.identityCacheKey(CURRENT_PROFILE, "cursor")).toBe(
+      "twitter/default/account-b/cursor",
+    );
+    expect(secondaryClient.identityCacheKey(CURRENT_PROFILE, "cursor")).toBe(
+      "twitter/secondary/account-b/cursor",
+    );
+  });
+
+  it("migrates a same-user cursor from the prior username into the canonical account-and-id key", async () => {
+    const canonicalKey = "twitter/default/same-user/latest_checked_tweet_id";
+    const legacyKey = "twitter/old-name/latest_checked_tweet_id";
+    const entity = {
+      id: "agent-1",
+      names: ["Agent", "Old Name", "old-name"],
+      metadata: {
+        twitter: {
+          id: "same-user",
+          userName: "old-name",
+          name: "Old Name",
+        },
+      },
+      agentId: "agent-1",
+    };
+    const getCache = vi.fn(async (key: string) =>
+      key === legacyKey ? "42" : undefined,
+    );
+    const setCache = vi.fn();
+    const runtime = asRuntime({
+      agentId: "agent-1",
+      character: { name: "Agent" },
+      getSetting: () => undefined,
+      getEntityById: vi.fn(async () => entity),
+      updateEntity: vi.fn(),
+      getCache,
+      setCache,
+    });
+    const client = new ClientBase(runtime, {
+      accountId: "default",
+    } as TwitterClientState);
+    attachRawSession(client, {
+      userId: "same-user",
+      username: "new-name",
+      name: "New Name",
+      biography: "",
+    });
+
+    await client.getAuthenticatedProfile();
+
+    expect(getCache).toHaveBeenCalledWith(canonicalKey);
+    expect(getCache).toHaveBeenCalledWith(legacyKey);
+    expect(setCache).toHaveBeenCalledWith(canonicalKey, "42");
+    expect(client.lastCheckedTweetId).toBe(42n);
+  });
+
+  it("clears its compatibility profile after any authenticated refresh failure", async () => {
+    const entity = {
+      id: "agent-1",
+      names: ["Agent", "Current B", "current-b"],
+      metadata: {
+        twitter: {
+          id: "account-b",
+          userName: "current-b",
+          name: "Current B",
+        },
+      },
+      agentId: "agent-1",
+    };
+    const runtime = asRuntime({
+      agentId: "agent-1",
+      character: { name: "Agent" },
+      getSetting: () => undefined,
+      getEntityById: vi.fn(async () => entity),
+      updateEntity: vi.fn(),
+      getCache: vi.fn(async () => undefined),
+      setCache: vi.fn(),
+    });
+    const client = new ClientBase(runtime, {
+      accountId: "default",
+    } as TwitterClientState);
+    attachRawSession(client, {
+      userId: "account-b",
+      username: "current-b",
+      name: "Current B",
+      biography: "",
+    });
+    await client.getAuthenticatedProfile();
+    expect(client.profile).toMatchObject({ id: "account-b" });
+
+    const refreshFailure = new ElizaError("profile provider unavailable", {
+      code: "X_ME_FETCH_FAILED",
+    });
+    client.twitterClient.withAuthenticatedSession = vi.fn(async () => {
+      throw refreshFailure;
+    });
+
+    await expect(client.getAuthenticatedProfile()).rejects.toBe(refreshFailure);
+    expect(client.profile).toBeNull();
+  });
+
+  it("does not publish a new account after durable identity metadata fails to update", async () => {
+    const entity = {
+      id: "agent-1",
+      names: ["Agent", "Account A", "account-a"],
+      metadata: {
+        twitter: {
+          id: "account-a",
+          userName: "account-a",
+          name: "Account A",
+        },
+      },
+      agentId: "agent-1",
+    };
+    const updateFailure = new Error("entity store unavailable");
+    const runtime = asRuntime({
+      agentId: "agent-1",
+      character: { name: "Agent" },
+      getSetting: () => undefined,
+      getEntityById: vi.fn(async () => entity),
+      updateEntity: vi.fn(async () => {
+        throw updateFailure;
+      }),
+      getCache: vi.fn(async () => undefined),
+      setCache: vi.fn(),
+    });
+    const client = new ClientBase(runtime, {
+      accountId: "default",
+    } as TwitterClientState);
+    attachRawSession(client, {
+      userId: "account-b",
+      username: "account-b",
+      name: "Account B",
+      biography: "B",
+    });
+
+    await expect(client.getAuthenticatedProfile()).rejects.toBe(updateFailure);
+    expect(client.profile).toBeNull();
+    expect(entity).toMatchObject({
+      names: ["Agent", "Account A", "account-a"],
+      metadata: { twitter: { id: "account-a" } },
+    });
+  });
+});

--- a/plugins/plugin-x/src/services/timestamp-boundaries.test.ts
+++ b/plugins/plugin-x/src/services/timestamp-boundaries.test.ts
@@ -45,15 +45,32 @@ function rawTweet(overrides: Record<string, unknown> = {}) {
 }
 
 function createClient(overrides: Record<string, unknown> = {}): ClientBase {
-  return {
+  const client = {
     accountId: "default",
     runtime: createRuntime(),
     profile: { id: "bot-user", username: "bot" },
+    getAuthenticatedProfile: vi.fn(async () => ({
+      id: "bot-user",
+      username: "bot",
+      screenName: "Bot",
+      bio: "",
+      nicknames: [],
+    })),
     twitterClient: {},
+    isAuthenticatedSessionCurrent: vi.fn(() => true),
     fetchSearchTweets: vi.fn(),
     fetchHomeTimeline: vi.fn(async () => []),
     ...overrides,
   } as unknown as ClientBase;
+  if (!("withAuthenticatedSession" in overrides)) {
+    client.withAuthenticatedSession = async (operation) =>
+      operation({
+        client: client.twitterClient as never,
+        profile: await client.getAuthenticatedProfile(),
+        revision: 1,
+      });
+  }
+  return client;
 }
 
 describe("TwitterPostService mixed valid+corrupt collections (#18965)", () => {
@@ -118,6 +135,68 @@ describe("TwitterMessageService mixed valid+corrupt collections (#18965)", () =>
     expect(messages.map((m) => m.id)).toEqual(["valid-1"]);
     expect(messages[0].timestamp).toBe(VALID_MS);
     expect(messages[0].type).toBe(MessageType.REPLY);
+  });
+
+  it("uses refreshed identity for mention queries and outbound attribution", async () => {
+    const fetchSearchTweets = vi.fn(async () => ({ tweets: [] }));
+    const sendTweet = vi.fn(async () => ({ id: "message-b" }));
+    const client = createClient({
+      profile: { id: "account-a", username: "stale-a" },
+      getAuthenticatedProfile: vi.fn(async () => ({
+        id: "account-b",
+        username: "current-b",
+        screenName: "Current B",
+        bio: "",
+        nicknames: [],
+      })),
+      fetchSearchTweets,
+      twitterClient: { sendTweet },
+    });
+    const service = new TwitterMessageService(client);
+
+    await service.getMessages({ roomId: undefined as unknown as UUID });
+    const sent = await service.sendMessage({
+      agentId: "00000000-0000-0000-0000-000000000001" as UUID,
+      roomId: "00000000-0000-0000-0000-000000000002" as UUID,
+      text: "hello",
+      type: MessageType.POST,
+    });
+
+    expect(fetchSearchTweets).toHaveBeenCalledWith(
+      "@current-b",
+      20,
+      expect.anything(),
+    );
+    expect(sent).toMatchObject({
+      id: "message-b",
+      userId: "account-b",
+      username: "current-b",
+    });
+  });
+
+  it("never fabricates a successful id when an accepted message has no receipt", async () => {
+    const sendTweet = vi.fn(async () => ({ data: { id: "   " } }));
+    const client = createClient({
+      twitterClient: { sendTweet },
+    });
+    const service = new TwitterMessageService(client);
+
+    await expect(
+      service.sendMessage({
+        agentId: "00000000-0000-0000-0000-000000000001" as UUID,
+        roomId: "00000000-0000-0000-0000-000000000002" as UUID,
+        text: "provider accepted this request",
+        type: MessageType.POST,
+      }),
+    ).rejects.toMatchObject({
+      code: "X_MESSAGE_RECEIPT_INDETERMINATE",
+      context: {
+        accountId: "default",
+        providerAccepted: true,
+        retrySafe: false,
+      },
+    });
+    expect(sendTweet).toHaveBeenCalledOnce();
   });
 });
 

--- a/plugins/plugin-x/src/services/x.service.test.ts
+++ b/plugins/plugin-x/src/services/x.service.test.ts
@@ -209,6 +209,20 @@ describe("XService trusted account routing", () => {
     const runtime = runtimeWithSettings({});
     const service = new XService(runtime);
     const fetchHomeTimeline = vi.fn(async () => []);
+    const profile = {
+      id: "secondary-user",
+      username: "secondary-user",
+      screenName: "Secondary User",
+      bio: "",
+      nicknames: [],
+    };
+    const withAuthenticatedSession = async <T>(
+      operation: (session: {
+        client: never;
+        profile: typeof profile;
+        revision: number;
+      }) => Promise<T>,
+    ) => operation({ client: {} as never, profile, revision: 1 });
     const getClient = vi
       .spyOn(
         service as unknown as {
@@ -216,13 +230,14 @@ describe("XService trusted account routing", () => {
             client: {
               fetchHomeTimeline: typeof fetchHomeTimeline;
               runtime: IAgentRuntime;
+              withAuthenticatedSession: typeof withAuthenticatedSession;
             };
           }>;
         },
         "getTwitterClientForAccount",
       )
       .mockResolvedValue({
-        client: { fetchHomeTimeline, runtime },
+        client: { fetchHomeTimeline, runtime, withAuthenticatedSession },
       });
 
     await service.fetchConnectorFeed(
@@ -246,18 +261,35 @@ describe("XService trusted account routing", () => {
     const runtime = runtimeWithSettings({});
     const service = new XService(runtime);
     const fetchSearchTweets = vi.fn(async () => ({ tweets: [] }));
+    const profile = {
+      id: "secondary-user",
+      username: "secondary-user",
+      screenName: "Secondary User",
+      bio: "",
+      nicknames: [],
+    };
+    const withAuthenticatedSession = async <T>(
+      operation: (session: {
+        client: never;
+        profile: typeof profile;
+        revision: number;
+      }) => Promise<T>,
+    ) => operation({ client: {} as never, profile, revision: 1 });
     const getClient = vi
       .spyOn(
         service as unknown as {
           getTwitterClientForAccount: (accountId: unknown) => Promise<{
             client: {
               fetchSearchTweets: typeof fetchSearchTweets;
+              withAuthenticatedSession: typeof withAuthenticatedSession;
             };
           }>;
         },
         "getTwitterClientForAccount",
       )
-      .mockResolvedValue({ client: { fetchSearchTweets } });
+      .mockResolvedValue({
+        client: { fetchSearchTweets, withAuthenticatedSession },
+      });
 
     await service.searchConnectorPosts(
       {
@@ -325,7 +357,23 @@ describe("XService trusted account routing", () => {
   it("ignores spoofed content account metadata in the post handler", async () => {
     const runtime = runtimeWithSettings({});
     const service = new XService(runtime);
-    const base = { profile: null } as unknown as ClientBase;
+    const profile = {
+      id: "account-owner",
+      username: "account-owner",
+      screenName: "Account Owner",
+      bio: "",
+      nicknames: [],
+    };
+    const base = {
+      profile,
+      withAuthenticatedSession: async <T>(
+        operation: (session: {
+          client: never;
+          profile: typeof profile;
+          revision: number;
+        }) => Promise<T>,
+      ) => operation({ client: {} as never, profile, revision: 1 }),
+    } as unknown as ClientBase;
     const getClient = vi
       .spyOn(
         service as unknown as {

--- a/plugins/plugin-x/src/services/x.service.ts
+++ b/plugins/plugin-x/src/services/x.service.ts
@@ -495,8 +495,36 @@ export class XService extends Service {
     const loadedClient =
       this.accountClients.get(accountId) ??
       (this.twitterClient?.accountId === accountId ? this.twitterClient : null);
-    const profile = loadedClient?.client.profile;
     const { capabilities, scopes } = capabilitiesForXAuthState(state);
+    let profile: TwitterProfile | null = null;
+    if (loadedClient) {
+      try {
+        profile = await loadedClient.client.getAuthenticatedProfile();
+      } catch (error) {
+        // error-policy:J4 account status translates an authentication refresh
+        // failure into the explicit needs-reauth state rather than stale identity.
+        if (
+          !(error instanceof ElizaError) ||
+          !["X_AUTH_REJECTED", "X_AUTH_NOT_INITIALIZED"].includes(error.code)
+        ) {
+          throw error;
+        }
+        logger.warn(
+          { accountId },
+          "[XService] Authenticated profile refresh failed",
+        );
+        return {
+          accountId,
+          configured: true,
+          connected: false,
+          reason: "needs_reauth",
+          identity: null,
+          grantedCapabilities: [],
+          grantedScopes: [],
+          authMode,
+        };
+      }
+    }
     return {
       accountId,
       configured: true,
@@ -529,6 +557,16 @@ export class XService extends Service {
       this.accountClients.get(accountId) ??
       (this.twitterClient?.accountId === accountId ? this.twitterClient : null);
     return loadedClient?.client.profile ?? null;
+  }
+
+  async refreshActiveProfile(
+    accountIdInput: string = this.defaultAccountId,
+  ): Promise<TwitterProfile | null> {
+    const accountId = this.resolveAccountId(accountIdInput);
+    const loadedClient =
+      this.accountClients.get(accountId) ??
+      (this.twitterClient?.accountId === accountId ? this.twitterClient : null);
+    return loadedClient ? loadedClient.client.getAuthenticatedProfile() : null;
   }
 
   private async startAutonomousClients(
@@ -784,34 +822,39 @@ export class XService extends Service {
       context?.metadata,
     );
     const base = (await this.getTwitterClientForAccount(accountId)).client;
+    return base.withAuthenticatedSession(async ({ profile }) => {
+      const replyToTweetId = readContentString(content, [
+        "replyToTweetId",
+        "replyTo",
+        "inReplyToTweetId",
+      ]);
+      const postService = new TwitterPostService(base);
+      const post = await postService.createPost(
+        {
+          agentId: runtime.agentId,
+          roomId: createUniqueUuid(
+            runtime,
+            `x:${accountId}:feed:${profile.id}`,
+          ),
+          text,
+          ...(replyToTweetId ? { inReplyTo: replyToTweetId } : {}),
+        },
+        profile,
+      );
 
-    const replyToTweetId = readContentString(content, [
-      "replyToTweetId",
-      "replyTo",
-      "inReplyToTweetId",
-    ]);
-    const postService = new TwitterPostService(base);
-    const post = await postService.createPost({
-      agentId: runtime.agentId,
-      roomId: createUniqueUuid(
-        runtime,
-        `x:${accountId}:feed:${base.profile?.id ?? runtime.agentId}`,
-      ),
-      text,
-      ...(replyToTweetId ? { inReplyTo: replyToTweetId } : {}),
-    });
-
-    return this.buildXPostMemory(runtime, {
-      id: post.id,
-      userId: post.userId || runtime.agentId,
-      username: post.username || base.profile?.username || "agent",
-      text: post.text,
-      createdAt: post.timestamp,
-      inReplyTo: post.inReplyTo,
-      roomId: post.roomId,
-      metadata: post.metadata,
-      metrics: post.metrics,
-      accountId,
+      return this.buildXPostMemory(runtime, {
+        id: post.id,
+        userId: post.userId,
+        username: post.username,
+        text: post.text,
+        createdAt: post.timestamp,
+        inReplyTo: post.inReplyTo,
+        roomId: post.roomId,
+        metadata: post.metadata,
+        metrics: post.metrics,
+        accountId,
+        ownUserId: profile.id,
+      });
     });
   }
 
@@ -948,33 +991,40 @@ export class XService extends Service {
         ? context.target.entityId
         : undefined);
 
-    const posts =
-      params.feed === "mentions"
-        ? await postService.getMentions(runtime.agentId, {
-            limit,
-            before: params.cursor,
-          })
-        : await postService.getPosts({
-            agentId: runtime.agentId,
-            ...(targetUserId ? { userId: targetUserId } : {}),
-            limit,
-            before: params.cursor,
-          });
+    return base.withAuthenticatedSession(async ({ profile }) => {
+      const posts =
+        params.feed === "mentions"
+          ? await postService.getMentions(runtime.agentId, {
+              limit,
+              before: params.cursor,
+            })
+          : await postService.getPosts({
+              agentId: runtime.agentId,
+              ...(targetUserId ? { userId: targetUserId } : {}),
+              limit,
+              before: params.cursor,
+            });
 
-    return posts.map((post) =>
-      this.buildXPostMemory(runtime, {
-        id: post.id,
-        userId: post.userId,
-        username: post.username,
-        text: post.text,
-        createdAt: post.timestamp,
-        inReplyTo: post.inReplyTo,
-        roomId: post.roomId,
-        metadata: post.metadata,
-        metrics: post.metrics,
-        accountId,
-      }),
-    );
+      return posts.map((post) =>
+        this.buildXPostMemory(runtime, {
+          id: post.id,
+          userId: post.userId,
+          username: post.username,
+          text: post.text,
+          createdAt: post.timestamp,
+          inReplyTo: post.inReplyTo,
+          roomId: post.roomId,
+          metadata: post.metadata,
+          metrics: post.metrics,
+          accountId,
+          ownUserId: profile.id,
+          conversationId:
+            typeof post.metadata?.conversationId === "string"
+              ? post.metadata.conversationId
+              : post.id,
+        }),
+      );
+    });
   }
 
   async searchConnectorPosts(
@@ -993,40 +1043,44 @@ export class XService extends Service {
       context.metadata,
     );
     const base = (await this.getTwitterClientForAccount(accountId)).client;
-    const result = await base.fetchSearchTweets(
-      query,
-      clampLimit(params.limit, 20, 100),
-      SearchMode.Latest,
-      params.cursor,
-    );
-    return result.tweets.flatMap((tweet) => {
-      // Normalize once per row: a present-but-unusable timestamp fails the
-      // row closed instead of surfacing a healthy-looking memory with an
-      // undefined or "now" creation time (#18965).
-      const createdAt = getEpochMs(tweet.timestamp);
-      if (createdAt === undefined) {
-        logger.debug(
-          `X searchPosts: skipping tweet ${tweet.id ?? "unknown"} with unusable timestamp`,
-        );
-        return [];
-      }
-      return [
-        this.buildXPostMemory(runtime, {
-          id: tweet.id ?? "unknown",
-          userId: tweet.userId ?? "unknown",
-          username: tweet.username ?? undefined,
-          text: tweet.text ?? "",
-          createdAt,
-          inReplyTo: tweet.inReplyToStatusId,
-          metrics: {
-            likes: tweet.likes,
-            reposts: tweet.retweets,
-            replies: tweet.replies,
-            quotes: tweet.quotes,
-          },
-          accountId,
-        }),
-      ];
+    return base.withAuthenticatedSession(async ({ profile }) => {
+      const result = await base.fetchSearchTweets(
+        query,
+        clampLimit(params.limit, 20, 100),
+        SearchMode.Latest,
+        params.cursor,
+      );
+      return result.tweets.flatMap((tweet) => {
+        // Normalize once per row: a present-but-unusable timestamp fails the
+        // row closed instead of surfacing a healthy-looking memory with an
+        // undefined or "now" creation time (#18965).
+        const createdAt = getEpochMs(tweet.timestamp);
+        if (createdAt === undefined) {
+          logger.debug(
+            `X searchPosts: skipping tweet ${tweet.id ?? "unknown"} with unusable timestamp`,
+          );
+          return [];
+        }
+        return [
+          this.buildXPostMemory(runtime, {
+            id: tweet.id ?? "unknown",
+            userId: tweet.userId ?? "unknown",
+            username: tweet.username ?? undefined,
+            text: tweet.text ?? "",
+            createdAt,
+            inReplyTo: tweet.inReplyToStatusId,
+            conversationId: tweet.conversationId ?? tweet.id,
+            metrics: {
+              likes: tweet.likes,
+              reposts: tweet.retweets,
+              replies: tweet.replies,
+              quotes: tweet.quotes,
+            },
+            accountId,
+            ownUserId: profile.id,
+          }),
+        ];
+      });
     });
   }
 
@@ -1366,6 +1420,8 @@ export class XService extends Service {
       metrics?: unknown;
       metadata?: Record<string, unknown>;
       accountId?: string;
+      ownUserId?: string;
+      conversationId?: string;
     },
   ): Memory {
     const accountId = normalizeXAccountId(
@@ -1373,13 +1429,16 @@ export class XService extends Service {
     );
     const authorId = post.userId || "unknown";
     const createdAt = post.createdAt;
-    const entityId =
-      authorId === runtime.agentId
-        ? runtime.agentId
-        : createUniqueUuid(runtime, `x:user:${authorId}`);
+    const isOwn = Boolean(post.ownUserId && authorId === post.ownUserId);
+    const entityId = isOwn
+      ? runtime.agentId
+      : createUniqueUuid(runtime, `x:user:${authorId}`);
     const roomId =
       post.roomId ??
-      createUniqueUuid(runtime, `x:${accountId}:feed:${authorId}`);
+      createUniqueUuid(
+        runtime,
+        `x:${accountId}:feed:${post.conversationId ?? authorId}`,
+      );
     const url = post.username
       ? `https://x.com/${post.username}/status/${post.id}`
       : `https://x.com/i/web/status/${post.id}`;
@@ -1405,7 +1464,7 @@ export class XService extends Service {
         accountId,
         provider: "x",
         timestamp: createdAt,
-        fromBot: entityId === runtime.agentId,
+        fromBot: isOwn,
         messageIdFull: post.id,
         chatType: ChannelType.FEED,
         sender: {

--- a/plugins/plugin-x/src/timeline.test.ts
+++ b/plugins/plugin-x/src/timeline.test.ts
@@ -1,4 +1,4 @@
-/** Unit tests for `TwitterTimelineClient.describeTweetMedia`: photo/video interpretation via IMAGE_DESCRIPTION, empty-media and missing-model paths, and per-media failure tolerance; mocked runtime. */
+/** Verifies timeline media interpretation and current-account self filtering with deterministic client fakes. */
 import {
   type IAgentRuntime,
   ModelType,
@@ -10,12 +10,42 @@ import type { Client, Tweet } from "./client/index";
 import { TwitterTimelineClient } from "./timeline";
 import type { TwitterClientState } from "./types";
 
-function makeClient(): ClientBase {
-  return {
+function makeClient(overrides: Record<string, unknown> = {}): ClientBase {
+  const identityCache = new Map<string, unknown>();
+  const client = {
     twitterClient: {} as Client,
     accountId: "default",
-    profile: { username: "agent" },
+    profile: { id: "agent", username: "agent" },
+    getAuthenticatedProfile: async () => ({
+      id: "agent",
+      username: "agent",
+      screenName: "Agent",
+      bio: "",
+      nicknames: [],
+    }),
+    isAuthenticatedSessionCurrent: () => true,
+    identityCacheKey: (profile: { id: string }, suffix: string) =>
+      `twitter/default/${profile.id}/${suffix}`,
+    getIdentityCache: async (profile: { id: string }, suffix: string) =>
+      identityCache.get(`twitter/default/${profile.id}/${suffix}`),
+    setIdentityCache: async (
+      profile: { id: string },
+      suffix: string,
+      value: unknown,
+    ) => {
+      identityCache.set(`twitter/default/${profile.id}/${suffix}`, value);
+    },
+    ...overrides,
   } as unknown as ClientBase;
+  if (!("withAuthenticatedSession" in overrides)) {
+    client.withAuthenticatedSession = async (operation) =>
+      operation({
+        client: client.twitterClient as never,
+        profile: await client.getAuthenticatedProfile(),
+        revision: 1,
+      });
+  }
+  return client;
 }
 
 function makeRuntime(overrides: Partial<IAgentRuntime>): IAgentRuntime {
@@ -166,5 +196,184 @@ describe("TwitterTimelineClient.describeTweetMedia", () => {
     expect(result).toContain("a cat sitting on a keyboard");
     // The second image failed, so only one description survives.
     expect(result.match(/^- /gm)?.length).toBe(1);
+  });
+});
+
+describe("TwitterTimelineClient.getTimeline", () => {
+  it("filters the current account by user id after identity rotation", async () => {
+    const fetchHomeTimeline = vi.fn(async () => [
+      makeTweet({
+        id: "current-self",
+        userId: "account-b",
+        username: "renamed-current-b",
+      }),
+      makeTweet({
+        id: "former-self",
+        userId: "account-a",
+        username: "stale-a",
+      }),
+      makeTweet({ id: "external", userId: "person-1" }),
+    ]);
+    const runtime = makeRuntime({});
+    const client = new TwitterTimelineClient(
+      makeClient({
+        profile: { id: "account-a", username: "stale-a" },
+        getAuthenticatedProfile: async () => ({
+          id: "account-b",
+          username: "current-b",
+          screenName: "Current B",
+          bio: "",
+          nicknames: [],
+        }),
+        twitterClient: { fetchHomeTimeline },
+      }),
+      runtime,
+      {} as TwitterClientState,
+    );
+
+    const tweets = await client.getTimeline(20);
+
+    expect(tweets.map((tweet) => tweet.id)).toEqual([
+      "former-self",
+      "external",
+    ]);
+  });
+});
+
+describe("TwitterTimelineClient.handleTimeline", () => {
+  function actionRuntime(overrides: Partial<IAgentRuntime> = {}) {
+    return makeRuntime({
+      getModel: (() => undefined) as IAgentRuntime["getModel"],
+      getMemoryById: vi.fn(async () => null),
+      composeState: vi.fn(async () => ({ values: {}, data: {}, text: "" })),
+      useModel: vi.fn(
+        async () => "[LIKE]",
+      ) as unknown as IAgentRuntime["useModel"],
+      ensureRoomExists: vi.fn(async () => undefined),
+      createMemory: vi.fn(async () => undefined),
+      ensureWorldExists: vi.fn(async () => undefined),
+      updateWorld: vi.fn(async () => undefined),
+      ensureConnection: vi.fn(async () => undefined),
+      reportError: vi.fn(),
+      ...overrides,
+    });
+  }
+
+  it("keeps timeline reads, model decisions, and effects inside one authenticated session", async () => {
+    let sessionDepth = 0;
+    const phases: string[] = [];
+    const profile = {
+      id: "account-a",
+      username: "account-a",
+      screenName: "Account A",
+      bio: "",
+      nicknames: [],
+    };
+    const fetchHomeTimeline = vi.fn(async () => {
+      expect(sessionDepth).toBe(1);
+      phases.push("read");
+      return [makeTweet({ id: "candidate", userId: "person-1" })];
+    });
+    const likeTweet = vi.fn(async () => {
+      expect(sessionDepth).toBe(1);
+      phases.push("effect");
+    });
+    const twitterClient = { fetchHomeTimeline, likeTweet };
+    const session = { client: twitterClient as never, profile, revision: 1 };
+    const withAuthenticatedSession = vi.fn(
+      async (operation: (captured: typeof session) => Promise<unknown>) => {
+        sessionDepth += 1;
+        try {
+          return await operation(session);
+        } finally {
+          sessionDepth -= 1;
+        }
+      },
+    );
+    const runtime = actionRuntime({
+      getMemoryById: vi.fn(async () => {
+        expect(sessionDepth).toBe(1);
+        return null;
+      }),
+      composeState: vi.fn(async () => {
+        expect(sessionDepth).toBe(1);
+        return { values: {}, data: {}, text: "" };
+      }),
+      useModel: vi.fn(async () => {
+        expect(sessionDepth).toBe(1);
+        phases.push("model");
+        return "[LIKE]";
+      }) as unknown as IAgentRuntime["useModel"],
+    });
+    const client = makeClient({
+      twitterClient,
+      withAuthenticatedSession,
+      isAuthenticatedSessionCurrent: () => true,
+    });
+
+    await new TwitterTimelineClient(
+      client,
+      runtime,
+      {} as TwitterClientState,
+    ).handleTimeline();
+
+    expect(withAuthenticatedSession).toHaveBeenCalledOnce();
+    expect(phases).toEqual(["read", "model", "effect"]);
+    expect(likeTweet).toHaveBeenCalledWith("candidate");
+    expect(sessionDepth).toBe(0);
+  });
+
+  it("does not execute an account B effect for a timeline read under account A", async () => {
+    let current = true;
+    let markModelStarted!: () => void;
+    let releaseModel!: (value: string) => void;
+    const modelStarted = new Promise<void>((resolve) => {
+      markModelStarted = resolve;
+    });
+    const modelResult = new Promise<string>((resolve) => {
+      releaseModel = resolve;
+    });
+    const profile = {
+      id: "account-a",
+      username: "account-a",
+      screenName: "Account A",
+      bio: "",
+      nicknames: [],
+    };
+    const likeTweet = vi.fn();
+    const twitterClient = {
+      fetchHomeTimeline: vi.fn(async () => [
+        makeTweet({ id: "candidate", userId: "person-1" }),
+      ]),
+      likeTweet,
+    };
+    const session = { client: twitterClient as never, profile, revision: 1 };
+    const runtime = actionRuntime({
+      useModel: vi.fn(async () => {
+        markModelStarted();
+        return modelResult;
+      }) as unknown as IAgentRuntime["useModel"],
+    });
+    const client = makeClient({
+      twitterClient,
+      withAuthenticatedSession: async (
+        operation: (captured: typeof session) => Promise<unknown>,
+      ) => operation(session),
+      isAuthenticatedSessionCurrent: () => current,
+    });
+    const processing = new TwitterTimelineClient(
+      client,
+      runtime,
+      {} as TwitterClientState,
+    ).handleTimeline();
+    await modelStarted;
+
+    current = false;
+    releaseModel("[LIKE]");
+
+    await expect(processing).rejects.toMatchObject({
+      code: "X_AUTH_SESSION_ROTATED",
+    });
+    expect(likeTweet).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-x/src/timeline.ts
+++ b/plugins/plugin-x/src/timeline.ts
@@ -9,6 +9,7 @@ import {
   ChannelType,
   composePromptFromState,
   createUniqueUuid,
+  ElizaError,
   type IAgentRuntime,
   logger,
   type Memory,
@@ -17,7 +18,7 @@ import {
   type State,
   type UUID,
 } from "@elizaos/core";
-import type { ClientBase } from "./base";
+import type { ClientBase, TwitterAccountSession, TwitterProfile } from "./base";
 import type { Client, Tweet } from "./client/index";
 import {
   quoteTweetTemplate,
@@ -95,6 +96,13 @@ function normalizeTweet(tweet: Tweet): ActionableTweet | null {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function isSessionRotation(error: unknown): boolean {
+  return (
+    error instanceof ElizaError &&
+    ["X_AUTH_NOT_INITIALIZED", "X_AUTH_SESSION_ROTATED"].includes(error.code)
+  );
 }
 
 /**
@@ -183,7 +191,11 @@ export class TwitterTimelineClient {
         `Timeline client will check every ${engagementIntervalMinutes} minutes`,
       );
 
-      this.handleTimeline();
+      // error-policy:J5 the scheduled promise is observed here; failures are
+      // reported through the runtime because no caller awaits this loop.
+      void this.handleTimeline().catch((error: unknown) => {
+        this.runtime.reportError("XTimelineClient.handleTimeline", error);
+      });
 
       if (this.isRunning) {
         setTimeout(handleTwitterTimelineLoop, actionInterval);
@@ -198,17 +210,24 @@ export class TwitterTimelineClient {
   }
 
   async getTimeline(count: number): Promise<ActionableTweet[]> {
-    const twitterUsername = this.client.profile?.username;
+    return this.client.withAuthenticatedSession(({ profile }) =>
+      this.getTimelineForProfile(count, profile),
+    );
+  }
+
+  private async getTimelineForProfile(
+    count: number,
+    profile: TwitterProfile,
+  ): Promise<ActionableTweet[]> {
     const homeTimeline =
       this.timelineType === TIMELINE_TYPE.Following
         ? await this.twitterClient.fetchFollowingTimeline(count, [])
         : await this.twitterClient.fetchHomeTimeline(count, []);
 
-    // The timeline methods now return Tweet objects directly from v2 API
     return homeTimeline
       .map((tweet) => normalizeTweet(tweet))
       .filter((tweet): tweet is ActionableTweet => tweet !== null)
-      .filter((tweet) => tweet.username !== twitterUsername); // do not perform action on self-tweets
+      .filter((tweet) => tweet.userId !== profile.id);
   }
 
   /**
@@ -294,9 +313,18 @@ export class TwitterTimelineClient {
   }
 
   async handleTimeline() {
+    return this.client.withAuthenticatedSession((session) =>
+      this.handleTimelineForProfile(session.profile, session),
+    );
+  }
+
+  private async handleTimelineForProfile(
+    profile: TwitterProfile,
+    session: TwitterAccountSession,
+  ) {
     logger.info("Starting Twitter timeline processing...");
 
-    const tweets = await this.getTimeline(20);
+    const tweets = await this.getTimelineForProfile(20, profile);
     logger.info(`Fetched ${tweets.length} tweets from timeline`);
 
     // Use max engagements per run from environment
@@ -414,12 +442,13 @@ Choose any combination of [LIKE], [RETWEET], [QUOTE], and [REPLY] that are appro
       logger.info(`Actions to execute:\n${actionSummary.join("\n")}`);
     }
 
-    await this.processTimelineActions(prioritizedTweets);
+    await this.processTimelineActions(prioritizedTweets, session);
     logger.info("Timeline processing complete");
   }
 
   private async processTimelineActions(
     tweetDecisions: TweetDecision[],
+    session: TwitterAccountSession,
   ): Promise<
     {
       tweetId: string;
@@ -476,8 +505,6 @@ Choose any combination of [LIKE], [RETWEET], [QUOTE], and [REPLY] that are appro
         createdAt: tweet.timestamp,
       };
 
-      await createMemorySafe(this.runtime, tweetMemory, "messages");
-
       try {
         // ensure world and rooms, connections, and worlds are created
         const userId = tweet.userId;
@@ -487,35 +514,57 @@ Choose any combination of [LIKE], [RETWEET], [QUOTE], and [REPLY] that are appro
         await this.ensureTweetWorldContext(tweet, roomId, worldId, entityId);
 
         if (actionResponse.like) {
-          await this.handleLikeAction(tweet);
-          executedActions.push("like");
+          this.assertCurrentSession(session);
+          if (await this.handleLikeAction(tweet, session)) {
+            executedActions.push("like");
+          }
         }
 
         if (actionResponse.retweet) {
-          await this.handleRetweetAction(tweet);
-          executedActions.push("retweet");
+          this.assertCurrentSession(session);
+          if (await this.handleRetweetAction(tweet, session)) {
+            executedActions.push("retweet");
+          }
         }
 
         if (actionResponse.quote) {
-          await this.handleQuoteAction(tweet, mediaDescriptions);
-          executedActions.push("quote");
+          if (await this.handleQuoteAction(tweet, mediaDescriptions, session)) {
+            executedActions.push("quote");
+          }
         }
 
         if (actionResponse.reply) {
-          await this.handleReplyAction(tweet, mediaDescriptions);
-          executedActions.push("reply");
+          if (await this.handleReplyAction(tweet, mediaDescriptions, session)) {
+            executedActions.push("reply");
+          }
         }
 
+        if (executedActions.length > 0) {
+          await createMemorySafe(this.runtime, tweetMemory, "messages");
+        }
         results.push({ tweetId: tweet.id, actionResponse, executedActions });
       } catch (error) {
-        logger.error(
-          `Error processing actions for tweet ${tweet.id}:`,
-          errorMessage(error),
-        );
+        if (isSessionRotation(error)) throw error;
+        // error-policy:J2 The scheduled-loop boundary reports the failed cycle;
+        // retain the tweet identity instead of fabricating a partial success.
+        throw new ElizaError("X timeline action failed", {
+          code: "X_TIMELINE_ACTION_FAILED",
+          cause: error,
+          context: { tweetId: tweet.id },
+        });
       }
     }
 
     return results;
+  }
+
+  private assertCurrentSession(session: TwitterAccountSession): void {
+    if (!this.client.isAuthenticatedSessionCurrent(session)) {
+      throw new ElizaError(
+        "X credentials rotated before a timeline action was executed",
+        { code: "X_AUTH_SESSION_ROTATED" },
+      );
+    }
   }
 
   private async ensureTweetWorldContext(
@@ -524,54 +573,52 @@ Choose any combination of [LIKE], [RETWEET], [QUOTE], and [REPLY] that are appro
     _worldId: UUID,
     _entityId: UUID,
   ) {
-    try {
-      // Use the utility function for consistency
-      await ensureTwitterContext(this.runtime, {
-        accountId: this.client.accountId,
-        userId: tweet.userId,
-        username: tweet.username,
-        name: tweet.name,
-        conversationId: tweet.conversationId,
-      });
-    } catch (error) {
-      logger.error(
-        `Failed to ensure context for tweet ${tweet.id}:`,
-        errorMessage(error),
-      );
-      // Don't fail the entire timeline processing
-    }
+    await ensureTwitterContext(this.runtime, {
+      accountId: this.client.accountId,
+      userId: tweet.userId,
+      username: tweet.username,
+      name: tweet.name,
+      conversationId: tweet.conversationId,
+    });
   }
 
-  async handleLikeAction(tweet: ActionableTweet) {
-    try {
-      if (this.isDryRun) {
-        logger.log(`[DRY RUN] Would have liked tweet ${tweet.id}`);
-        return;
-      }
-      await this.twitterClient.likeTweet(tweet.id);
-      logger.log(`Liked tweet ${tweet.id}`);
-    } catch (error) {
-      logger.error(`Error liking tweet ${tweet.id}:`, errorMessage(error));
+  async handleLikeAction(
+    tweet: ActionableTweet,
+    session?: TwitterAccountSession,
+  ): Promise<boolean> {
+    if (this.isDryRun) {
+      logger.log(`[DRY RUN] Would have liked tweet ${tweet.id}`);
+      return true;
     }
+    if (session) {
+      this.assertCurrentSession(session);
+    }
+    await this.twitterClient.likeTweet(tweet.id);
+    logger.log(`Liked tweet ${tweet.id}`);
+    return true;
   }
 
-  async handleRetweetAction(tweet: ActionableTweet) {
-    try {
-      if (this.isDryRun) {
-        logger.log(`[DRY RUN] Would have retweeted tweet ${tweet.id}`);
-        return;
-      }
-      await this.twitterClient.retweet(tweet.id);
-      logger.log(`Retweeted tweet ${tweet.id}`);
-    } catch (error) {
-      logger.error(`Error retweeting tweet ${tweet.id}:`, errorMessage(error));
+  async handleRetweetAction(
+    tweet: ActionableTweet,
+    session?: TwitterAccountSession,
+  ): Promise<boolean> {
+    if (this.isDryRun) {
+      logger.log(`[DRY RUN] Would have retweeted tweet ${tweet.id}`);
+      return true;
     }
+    if (session) {
+      this.assertCurrentSession(session);
+    }
+    await this.twitterClient.retweet(tweet.id);
+    logger.log(`Retweeted tweet ${tweet.id}`);
+    return true;
   }
 
   async handleQuoteAction(
     tweet: ActionableTweet,
     mediaDescriptions: string = "",
-  ) {
+    session?: TwitterAccountSession,
+  ): Promise<boolean> {
     try {
       const message = this.formMessage(this.runtime, tweet);
 
@@ -602,77 +649,96 @@ ${tweet.text}${mediaDescriptions}`;
           logger.log(
             `[DRY RUN] Would have quoted tweet ${tweet.id} with: ${responseObject.post}`,
           );
-          return;
+          return true;
         }
 
-        const result = await this.client.requestQueue.add(
-          async () =>
-            await this.twitterClient.sendQuoteTweet(
+        const sendQuote = () =>
+          this.client.requestQueue.add(async () => {
+            if (session) this.assertCurrentSession(session);
+            return await this.twitterClient.sendQuoteTweet(
               String(responseObject.post),
               tweet.id,
-            ),
-        );
+            );
+          });
+        const result = await sendQuote();
 
-        const resultWithJson = result as { json: () => Promise<unknown> };
-        const body = (await resultWithJson.json()) as {
-          id?: string;
-          data?: {
+        try {
+          const resultWithJson = result as { json: () => Promise<unknown> };
+          const body = (await resultWithJson.json()) as {
             id?: string;
-            create_tweet?: {
-              tweet_results?: { result?: { id?: string } };
+            data?: {
+              id?: string;
+              create_tweet?: {
+                tweet_results?: { result?: { id?: string } };
+              };
             };
-          };
-        } | null;
-
-        const tweetResult =
-          body?.data?.create_tweet?.tweet_results?.result || body?.data || body;
-        if (tweetResult) {
+          } | null;
+          const tweetResult =
+            body?.data?.create_tweet?.tweet_results?.result ||
+            body?.data ||
+            body;
+          const tweetId = tweetResult?.id;
+          if (!tweetId) {
+            throw new ElizaError("X returned no usable quote-tweet receipt", {
+              code: "X_POST_RESPONSE_INVALID",
+            });
+          }
           logger.log("Successfully posted quote tweet");
-        } else {
-          logger.error("Quote tweet creation failed:", JSON.stringify(body));
-        }
-
-        // Create memory for our response
-        const tweetId = tweetResult?.id || Date.now().toString();
-        const responseId = createUniqueUuid(this.runtime, tweetId);
-        const responseMemory: Memory = {
-          id: responseId,
-          entityId: this.runtime.agentId,
-          agentId: this.runtime.agentId,
-          roomId: message.roomId,
-          content: {
-            ...responseObject,
-            source: "twitter",
-            inReplyTo: message.id,
-          },
-          metadata: {
-            type: "message",
-            source: "twitter",
-            accountId: this.client.accountId,
-            provider: "twitter",
-            fromBot: true,
-            messageIdFull: tweetId,
-            twitter: {
-              accountId: this.client.accountId,
-              tweetId,
-              inReplyTo: tweet.id,
+          const responseMemory: Memory = {
+            id: createUniqueUuid(this.runtime, tweetId),
+            entityId: this.runtime.agentId,
+            agentId: this.runtime.agentId,
+            roomId: message.roomId,
+            content: {
+              ...responseObject,
+              source: "twitter",
+              inReplyTo: message.id,
             },
-          } satisfies Memory["metadata"],
-          createdAt: Date.now(),
-        };
-
-        // Save the response to memory with error handling
-        await createMemorySafe(this.runtime, responseMemory, "messages");
+            metadata: {
+              type: "message",
+              source: "twitter",
+              accountId: this.client.accountId,
+              provider: "twitter",
+              fromBot: true,
+              messageIdFull: tweetId,
+              twitter: {
+                accountId: this.client.accountId,
+                tweetId,
+                inReplyTo: tweet.id,
+              },
+            } satisfies Memory["metadata"],
+            createdAt: Date.now(),
+          };
+          await createMemorySafe(this.runtime, responseMemory, "messages");
+        } catch (error) {
+          // error-policy:J7 X already accepted the quote, so replaying the
+          // action would duplicate an external effect. Report receipt loss and
+          // settle the source tweet as processed.
+          this.runtime.reportError("XTimeline.quoteReceipt", error, {
+            accountId: this.client.accountId,
+            tweetId: tweet.id,
+          });
+        }
+        return true;
       }
+      return false;
     } catch (error) {
-      logger.error("Error in quote tweet generation:", errorMessage(error));
+      if (isSessionRotation(error)) throw error;
+      // error-policy:J2 The scheduled-loop boundary reports model and provider
+      // failures; returning false would mislabel a broken action as IGNORE.
+      throw new ElizaError("X quote-tweet action failed", {
+        code: "X_TIMELINE_ACTION_FAILED",
+        cause: error,
+        context: { tweetId: tweet.id },
+      });
     }
   }
 
   async handleReplyAction(
     tweet: ActionableTweet,
     mediaDescriptions: string = "",
-  ) {
+    session?: TwitterAccountSession,
+  ): Promise<boolean> {
     try {
       const message = this.formMessage(this.runtime, tweet);
 
@@ -703,53 +769,66 @@ ${tweet.text}${mediaDescriptions}`;
           logger.log(
             `[DRY RUN] Would have replied to tweet ${tweet.id} with: ${responseObject.post}`,
           );
-          return;
+          return true;
         }
 
-        const result = await sendTweet(
-          this.client,
-          String(responseObject.post),
-          [],
-          tweet.id,
-        );
+        const sendReply = () =>
+          sendTweet(this.client, String(responseObject.post), [], tweet.id);
+        if (session) this.assertCurrentSession(session);
+        const result = await sendReply();
 
         if (result) {
           logger.log("Successfully posted reply tweet");
 
-          // Create memory for our response
-          const responseId = createUniqueUuid(this.runtime, result.id);
-          const responseMemory: Memory = {
-            id: responseId,
-            entityId: this.runtime.agentId,
-            agentId: this.runtime.agentId,
-            roomId: message.roomId,
-            content: {
-              ...responseObject,
-              source: "twitter",
-              inReplyTo: message.id,
-            },
-            metadata: {
-              type: "message",
-              source: "twitter",
-              accountId: this.client.accountId,
-              provider: "twitter",
-              fromBot: true,
-              messageIdFull: result.id,
-              twitter: {
-                accountId: this.client.accountId,
-                tweetId: result.id,
-                inReplyTo: tweet.id,
+          try {
+            const responseMemory: Memory = {
+              id: createUniqueUuid(this.runtime, result.id),
+              entityId: this.runtime.agentId,
+              agentId: this.runtime.agentId,
+              roomId: message.roomId,
+              content: {
+                ...responseObject,
+                source: "twitter",
+                inReplyTo: message.id,
               },
-            } satisfies Memory["metadata"],
-            createdAt: Date.now(),
-          };
-
-          // Save the response to memory with error handling
-          await createMemorySafe(this.runtime, responseMemory, "messages");
+              metadata: {
+                type: "message",
+                source: "twitter",
+                accountId: this.client.accountId,
+                provider: "twitter",
+                fromBot: true,
+                messageIdFull: result.id,
+                twitter: {
+                  accountId: this.client.accountId,
+                  tweetId: result.id,
+                  inReplyTo: tweet.id,
+                },
+              } satisfies Memory["metadata"],
+              createdAt: Date.now(),
+            };
+            await createMemorySafe(this.runtime, responseMemory, "messages");
+          } catch (error) {
+            // error-policy:J7 X already accepted the reply; surface local
+            // receipt loss without turning a successful egress into a retry.
+            this.runtime.reportError("XTimeline.replyReceipt", error, {
+              accountId: this.client.accountId,
+              tweetId: tweet.id,
+              replyId: result.id,
+            });
+          }
+          return true;
         }
       }
+      return false;
     } catch (error) {
-      logger.error("Error in reply tweet generation:", errorMessage(error));
+      if (isSessionRotation(error)) throw error;
+      // error-policy:J2 The scheduled-loop boundary reports model and provider
+      // failures; returning false would mislabel a broken action as IGNORE.
+      throw new ElizaError("X reply action failed", {
+        code: "X_TIMELINE_ACTION_FAILED",
+        cause: error,
+        context: { tweetId: tweet.id },
+      });
     }
   }
 }

--- a/plugins/plugin-x/src/utils.test.ts
+++ b/plugins/plugin-x/src/utils.test.ts
@@ -1,33 +1,250 @@
-/** Unit tests for `sendTweet`, covering that a published tweet is returned even when post-publish local cache bookkeeping fails; mocked client. */
+/** Verifies accepted X sends remain single-shot while account-bound cursor and cache receipts stay monotonic across rotation. */
+import type { IAgentRuntime, UUID } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
-import type { ClientBase } from "./base";
-import { sendTweet } from "./utils";
+import { ClientBase, type TwitterProfile } from "./base";
+import type { TwitterClientState } from "./types";
+import { sendChunkedTweet, sendTweet } from "./utils";
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((onResolve) => {
+    resolve = onResolve;
+  });
+  return { promise, resolve };
+}
+
+function profile(id: string): TwitterProfile {
+  return {
+    id,
+    username: id,
+    screenName: id,
+    bio: "",
+    nicknames: [],
+  };
+}
 
 describe("sendTweet", () => {
   it("returns the accepted tweet when local cache bookkeeping fails after publish", async () => {
-    const client = {
-      lastCheckedTweetId: null,
-      twitterClient: {
-        sendTweet: vi.fn().mockResolvedValue({
-          data: {
-            data: {
-              id: "123",
-              text: "hello",
-            },
-          },
-        }),
-      },
-      cacheLatestCheckedTweetId: vi
-        .fn()
-        .mockRejectedValue(new Error("cache unavailable")),
-      cacheTweet: vi.fn(),
-    } as unknown as ClientBase;
+    const authenticatedProfile = profile("account-a");
+    const reportError = vi.fn();
+    const setCache = vi.fn(async (key: string) => {
+      if (key.endsWith("latest_checked_tweet_id")) {
+        throw new Error("cache unavailable");
+      }
+    });
+    const runtime = {
+      agentId: "agent-1",
+      character: { name: "Agent" },
+      getSetting: () => undefined,
+      getCache: vi.fn(async () => undefined),
+      setCache,
+      reportError,
+    } as unknown as IAgentRuntime;
+    const client = new ClientBase(runtime, {} as TwitterClientState);
+    const send = vi.fn().mockResolvedValue({
+      data: { data: { id: "123", text: "hello" } },
+    });
+    client.profile = authenticatedProfile;
+    client.twitterClient = {
+      sendTweet: send,
+    } as unknown as ClientBase["twitterClient"];
+    client.withAuthenticatedSession = async (operation) =>
+      operation({
+        client: {} as never,
+        profile: authenticatedProfile,
+        revision: 1,
+      });
+    client.isAuthenticatedSessionCurrent = () => true;
 
     await expect(sendTweet(client, "hello")).resolves.toMatchObject({
       id: "123",
       text: "hello",
     });
-    expect(client.twitterClient.sendTweet).toHaveBeenCalledTimes(1);
-    expect(client.cacheLatestCheckedTweetId).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(setCache).toHaveBeenCalledWith(
+      "twitter/default/account-a/latest_checked_tweet_id",
+      "123",
+    );
+    expect(reportError).toHaveBeenCalledWith(
+      "X.sendTweet.localReceipt",
+      expect.any(Error),
+      { accountId: "default", tweetId: "123" },
+    );
+    expect(
+      setCache.mock.calls.some(([key]) => String(key) === "twitter/tweets/123"),
+    ).toBe(false);
+  });
+
+  it("does not let a delayed account A receipt overwrite account B's cursor", async () => {
+    const accepted = deferred<{
+      data: { data: { id: string; text: string } };
+    }>();
+    const setCache = vi.fn(async () => undefined);
+    const runtime = {
+      agentId: "agent-1",
+      character: { name: "Agent" },
+      getSetting: () => undefined,
+      setCache,
+      getCache: vi.fn(async () => undefined),
+      reportError: vi.fn(),
+    } as unknown as IAgentRuntime;
+    const client = new ClientBase(runtime, {} as TwitterClientState);
+    const accountA = profile("account-a");
+    const accountB = profile("account-b");
+    client.profile = accountA;
+    client.twitterClient = {
+      sendTweet: vi.fn(() => accepted.promise),
+    } as unknown as ClientBase["twitterClient"];
+    client.withAuthenticatedSession = async (operation) =>
+      operation({ client: {} as never, profile: accountA, revision: 1 });
+    client.isAuthenticatedSessionCurrent = () => true;
+
+    const pending = sendTweet(client, "sent by A");
+    await vi.waitFor(() =>
+      expect(client.twitterClient.sendTweet).toHaveBeenCalledOnce(),
+    );
+
+    client.profile = accountB;
+    client.recordLatestCheckedTweetId(accountB.id, 50n);
+    await client.cacheLatestCheckedTweetId(accountB);
+    setCache.mockClear();
+    accepted.resolve({ data: { data: { id: "100", text: "sent by A" } } });
+
+    await expect(pending).resolves.toMatchObject({ id: "100" });
+    expect(client.getLatestCheckedTweetId(accountB.id)).toBe(50n);
+    expect(client.getLatestCheckedTweetId(accountA.id)).toBeNull();
+    expect(
+      setCache.mock.calls.some(([key]) =>
+        String(key).endsWith("latest_checked_tweet_id"),
+      ),
+    ).toBe(false);
+    expect(setCache).toHaveBeenCalledWith(
+      "twitter/tweets/100",
+      expect.objectContaining({
+        id: "100",
+        userId: "account-a",
+        username: "account-a",
+      }),
+    );
+  });
+
+  it("never regresses a same-account cursor when sends settle out of order", () => {
+    const runtime = {
+      agentId: "agent-1",
+      character: { name: "Agent" },
+      getSetting: () => undefined,
+    } as unknown as IAgentRuntime;
+    const client = new ClientBase(runtime, {} as TwitterClientState);
+    client.profile = profile("account-a");
+
+    client.recordLatestCheckedTweetId("account-a", 102n);
+    client.recordLatestCheckedTweetId("account-a", 101n);
+
+    expect(client.getLatestCheckedTweetId("account-a")).toBe(102n);
+  });
+
+  it("keeps a chunked thread on one captured session and captured profile", async () => {
+    const runtime = {
+      agentId: "00000000-0000-0000-0000-000000000001" as UUID,
+      character: { name: "Agent" },
+      getSetting: () => undefined,
+      getCache: vi.fn(async () => undefined),
+      setCache: vi.fn(async () => undefined),
+      reportError: vi.fn(),
+    } as unknown as IAgentRuntime;
+    const client = new ClientBase(runtime, {} as TwitterClientState);
+    const capturedProfile = {
+      ...profile("account-a"),
+      username: "captured-a",
+    };
+    const session = {
+      client: {} as never,
+      profile: capturedProfile,
+      revision: 1,
+    };
+    let activeSession = false;
+    let rootSessionCount = 0;
+    client.withAuthenticatedSession = async (operation) => {
+      if (activeSession) return operation(session);
+      rootSessionCount += 1;
+      activeSession = true;
+      try {
+        return await operation(session);
+      } finally {
+        activeSession = false;
+      }
+    };
+    client.isAuthenticatedSessionCurrent = () => true;
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({ data: { data: { id: "201", text: "first" } } })
+      .mockResolvedValueOnce({ data: { data: { id: "202", text: "second" } } });
+    client.twitterClient = {
+      sendTweet: send,
+    } as unknown as ClientBase["twitterClient"];
+
+    const memories = await sendChunkedTweet(
+      client,
+      { text: `${"a".repeat(280)}\n\n${"b".repeat(20)}` },
+      "00000000-0000-0000-0000-000000000002" as UUID,
+      "stale-caller-username",
+      "parent",
+    );
+
+    expect(rootSessionCount).toBe(1);
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send.mock.calls[0]?.[1]).toBe("parent");
+    expect(send.mock.calls[1]?.[1]).toBe("201");
+    expect(memories.map((memory) => memory.content.url)).toEqual([
+      "https://x.com/captured-a/status/201",
+      "https://x.com/captured-a/status/202",
+    ]);
+  });
+
+  it("aborts a chunked thread before another egress when its captured session rotates", async () => {
+    const runtime = {
+      agentId: "00000000-0000-0000-0000-000000000001" as UUID,
+      character: { name: "Agent" },
+      getSetting: () => undefined,
+      getCache: vi.fn(async () => undefined),
+      setCache: vi.fn(async () => undefined),
+      reportError: vi.fn(),
+    } as unknown as IAgentRuntime;
+    const client = new ClientBase(runtime, {} as TwitterClientState);
+    const session = {
+      client: {} as never,
+      profile: profile("account-a"),
+      revision: 1,
+    };
+    let activeSession = false;
+    client.withAuthenticatedSession = async (operation) => {
+      if (activeSession) return operation(session);
+      activeSession = true;
+      try {
+        return await operation(session);
+      } finally {
+        activeSession = false;
+      }
+    };
+    let current = true;
+    client.isAuthenticatedSessionCurrent = () => current;
+    const send = vi.fn(async () => {
+      current = false;
+      return { data: { data: { id: "301", text: "first" } } };
+    });
+    client.twitterClient = {
+      sendTweet: send,
+    } as unknown as ClientBase["twitterClient"];
+
+    await expect(
+      sendChunkedTweet(
+        client,
+        { text: `${"a".repeat(280)}\n\n${"b".repeat(20)}` },
+        "00000000-0000-0000-0000-000000000002" as UUID,
+        "account-b",
+        "parent",
+      ),
+    ).rejects.toMatchObject({ code: "X_AUTH_SESSION_ROTATED" });
+    expect(send).toHaveBeenCalledTimes(1);
   });
 });

--- a/plugins/plugin-x/src/utils.ts
+++ b/plugins/plugin-x/src/utils.ts
@@ -11,6 +11,7 @@ import type { Media } from "@elizaos/core";
 import {
   type Content,
   createUniqueUuid,
+  ElizaError,
   fetchWithSsrfGuard,
   logger,
   type Memory,
@@ -21,6 +22,7 @@ import type { ClientBase } from "./base";
 import type { Tweet } from "./client";
 import { TWEET_MAX_LENGTH } from "./constants";
 import type { ActionResponse, MediaData } from "./types";
+import { normalizeXReceiptId } from "./utils/provider-receipt";
 
 /**
  * Minimal shape we rely on from the Twitter v2 send-tweet response after
@@ -147,14 +149,14 @@ export async function sendStandardTweet(
   tweetId?: string,
   mediaData?: MediaData[],
 ) {
-  const standardTweetResult = await client.twitterClient.sendTweet(
-    content,
-    tweetId,
-    mediaData,
-  );
-
-  // The result is already the response object
-  return standardTweetResult;
+  return client.withAuthenticatedSession(async (session) => {
+    if (!client.isAuthenticatedSessionCurrent(session)) {
+      throw new ElizaError("X credentials rotated before post egress", {
+        code: "X_AUTH_SESSION_ROTATED",
+      });
+    }
+    return client.twitterClient.sendTweet(content, tweetId, mediaData);
+  });
 }
 
 type SendTweetResponse = Awaited<
@@ -173,8 +175,9 @@ function unwrapSentTweet(response: SendTweetResponse): SentTweet | undefined {
 
   if (inner && typeof inner === "object" && "id" in inner) {
     const candidate = inner as { id: unknown };
-    if (typeof candidate.id === "string") {
-      return inner as SentTweet;
+    const id = normalizeXReceiptId(candidate.id);
+    if (id) {
+      return { ...(inner as Record<string, unknown>), id } as SentTweet;
     }
   }
   return undefined;
@@ -187,15 +190,19 @@ export async function sendTweet(
   tweetToReplyTo?: string,
   mediaIds?: string[],
 ): Promise<SentTweet> {
-  const isNoteTweet = text.length > TWEET_MAX_LENGTH;
-  const postText = isNoteTweet
-    ? truncateToCompleteSentence(text, TWEET_MAX_LENGTH)
-    : text;
+  return client.withAuthenticatedSession(async (session) => {
+    const { profile } = session;
+    const isNoteTweet = text.length > TWEET_MAX_LENGTH;
+    const postText = isNoteTweet
+      ? truncateToCompleteSentence(text, TWEET_MAX_LENGTH)
+      : text;
 
-  let result: SendTweetResponse;
-
-  try {
-    result = await client.twitterClient.sendTweet(
+    if (!client.isAuthenticatedSessionCurrent(session)) {
+      throw new ElizaError("X credentials rotated before post egress", {
+        code: "X_AUTH_SESSION_ROTATED",
+      });
+    }
+    const result: SendTweetResponse = await client.twitterClient.sendTweet(
       postText,
       tweetToReplyTo,
       mediaData,
@@ -203,51 +210,45 @@ export async function sendTweet(
       mediaIds,
     );
     logger.info("Successfully posted Tweet");
-  } catch (error) {
-    logger.error("Error posting Tweet:", errorDetail(error));
-    throw error;
-  }
 
-  const tweetResult = unwrapSentTweet(result);
-  if (!tweetResult) {
-    logger.error("No valid response from Twitter API");
-    throw new Error("Failed to send tweet - no valid response");
-  }
-
-  try {
-    if (
-      client.lastCheckedTweetId === null ||
-      client.lastCheckedTweetId < BigInt(tweetResult.id)
-    ) {
-      client.lastCheckedTweetId = BigInt(tweetResult.id);
+    const tweetResult = unwrapSentTweet(result);
+    if (!tweetResult) {
+      throw new ElizaError("X returned no usable post receipt", {
+        code: "X_POST_RESPONSE_INVALID",
+      });
     }
-    await client.cacheLatestCheckedTweetId();
 
-    await client.cacheTweet({
-      ...tweetResult,
-      userId: "",
-      username: "",
-      name: "",
-      conversationId: tweetResult.id,
-      timestamp: Date.now(),
-      photos: [],
-      mentions: [],
-      hashtags: [],
-      urls: [],
-      videos: [],
-      thread: [],
-      permanentUrl: "",
-    });
+    try {
+      client.recordLatestCheckedTweetId(profile.id, BigInt(tweetResult.id));
+      await client.cacheLatestCheckedTweetId(profile);
+      await client.cacheTweet({
+        ...tweetResult,
+        userId: profile.id,
+        username: profile.username,
+        name: profile.screenName,
+        conversationId: tweetResult.id,
+        timestamp: Date.now(),
+        photos: [],
+        mentions: [],
+        hashtags: [],
+        urls: [],
+        videos: [],
+        thread: [],
+        permanentUrl: `https://x.com/${profile.username}/status/${tweetResult.id}`,
+      });
+      logger.info("Successfully posted a tweet", tweetResult.id);
+    } catch (error) {
+      // error-policy:J7 X already accepted the post, so retrying would duplicate
+      // an external effect. Surface the local receipt failure and return the
+      // accepted provider result exactly once.
+      client.runtime.reportError("X.sendTweet.localReceipt", error, {
+        accountId: client.accountId,
+        tweetId: tweetResult.id,
+      });
+    }
 
-    logger.info("Successfully posted a tweet", tweetResult.id);
-  } catch (error) {
-    logger.error(
-      "Tweet posted, but failed to update local tweet cache:",
-      errorDetail(error),
-    );
-  }
-
-  return tweetResult;
+    return tweetResult;
+  });
 }
 
 /**
@@ -264,77 +265,70 @@ export async function sendChunkedTweet(
   client: ClientBase,
   content: Content,
   roomId: UUID,
-  twitterUsername: string,
+  _twitterUsername: string,
   inReplyTo: string,
 ): Promise<Memory[]> {
-  const messages: Memory[] = [];
-  const chunks = splitTweetContent(content.text ?? "", TWEET_MAX_LENGTH);
+  return client.withAuthenticatedSession(async (session) => {
+    const messages: Memory[] = [];
+    const chunks = splitTweetContent(content.text ?? "", TWEET_MAX_LENGTH);
+    let previousTweetId = inReplyTo;
 
-  let previousTweetId = inReplyTo;
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i];
+      if (chunk === undefined) continue;
+      const tweetContent = `${chunk}`;
+      logger.debug(`Sending tweet ${i + 1}/${chunks.length}: ${tweetContent}`);
 
-  for (let i = 0; i < chunks.length; i++) {
-    const chunk = chunks[i];
-    if (chunk === undefined) continue;
-    const _isLastChunk = i === chunks.length - 1;
+      try {
+        let mediaData: MediaData[] = [];
+        if (content.attachments && content.attachments.length > 0) {
+          mediaData = await fetchMediaData(content.attachments);
+        }
+        if (!client.isAuthenticatedSessionCurrent(session)) {
+          throw new ElizaError("X credentials rotated during thread egress", {
+            code: "X_AUTH_SESSION_ROTATED",
+          });
+        }
+        const result = await sendTweet(
+          client,
+          tweetContent,
+          mediaData,
+          previousTweetId,
+        );
+        const tweetResult =
+          typeof result.data === "object" && result.data !== null
+            ? result.data
+            : result;
 
-    // Add the tweet number to the beginning of each chunk
-    const tweetContent = `${chunk}`;
-
-    logger.debug(`Sending tweet ${i + 1}/${chunks.length}: ${tweetContent}`);
-
-    try {
-      // Convert Media[] to MediaData[] if needed
-      let mediaData: MediaData[] = [];
-      if (content.attachments && content.attachments.length > 0) {
-        mediaData = await fetchMediaData(content.attachments);
+        if (
+          typeof tweetResult === "object" &&
+          tweetResult !== null &&
+          "id" in tweetResult &&
+          typeof tweetResult.id === "string"
+        ) {
+          const tweetId = tweetResult.id;
+          messages.push({
+            id: createUniqueUuid(client.runtime, tweetId),
+            entityId: client.runtime.agentId,
+            content: {
+              text: chunk,
+              url: `https://x.com/${session.profile.username}/status/${tweetId}`,
+              source: "twitter",
+            },
+            agentId: client.runtime.agentId,
+            roomId,
+            createdAt: Date.now(),
+          });
+          previousTweetId = tweetId;
+        }
+      } catch (error) {
+        logger.error(`Error sending chunk ${i + 1}:`, errorDetail(error));
+        throw error;
       }
-
-      const result = await sendTweet(
-        client,
-        tweetContent,
-        mediaData,
-        previousTweetId,
-      );
-
-      const body = result;
-
-      // Twitter API v2 response format
-      const tweetResult =
-        typeof body.data === "object" && body.data !== null ? body.data : body;
-
-      // if we have a response
-      if (
-        typeof tweetResult === "object" &&
-        tweetResult !== null &&
-        "id" in tweetResult &&
-        typeof tweetResult.id === "string"
-      ) {
-        const tweetId = tweetResult.id;
-        const permanentUrl = `https://x.com/${twitterUsername}/status/${tweetId}`;
-
-        const memory: Memory = {
-          id: createUniqueUuid(client.runtime, tweetId),
-          entityId: client.runtime.agentId,
-          content: {
-            text: chunk,
-            url: permanentUrl,
-            source: "twitter",
-          },
-          agentId: client.runtime.agentId,
-          roomId,
-          createdAt: Date.now(),
-        };
-
-        messages.push(memory);
-        previousTweetId = tweetId;
-      }
-    } catch (error) {
-      logger.error(`Error sending chunk ${i + 1}:`, errorDetail(error));
-      throw error;
     }
-  }
 
-  return messages;
+    return messages;
+  });
 }
 
 /**

--- a/plugins/plugin-x/src/utils/error-handler.ts
+++ b/plugins/plugin-x/src/utils/error-handler.ts
@@ -35,6 +35,8 @@ export class TwitterError extends Error {
 interface ProbableErrorShape {
   message?: unknown;
   code?: unknown;
+  status?: unknown;
+  data?: { status?: unknown };
   response?: { status?: unknown };
 }
 
@@ -53,9 +55,16 @@ function errorMessage(error: unknown): string {
 function errorCode(error: unknown): number | undefined {
   const probed = probeError(error);
   if (typeof probed.code === "number") return probed.code;
-  const status = probed.response?.status;
+  const status =
+    probed.data?.status ?? probed.response?.status ?? probed.status;
   if (typeof status === "number") return status;
   return undefined;
+}
+
+/** A concrete 4xx response proves the provider rejected the write pre-acceptance. */
+export function isExplicitTwitterRejection(error: unknown): boolean {
+  const status = errorCode(error);
+  return status !== undefined && status >= 400 && status < 500;
 }
 
 export function getErrorType(error: unknown): TwitterErrorType {

--- a/plugins/plugin-x/src/utils/memory.test.ts
+++ b/plugins/plugin-x/src/utils/memory.test.ts
@@ -56,14 +56,17 @@ describe("Twitter memory utilities", () => {
     expect(createMemory).toHaveBeenCalledTimes(2);
   });
 
-  it("falls back to unprocessed when tweet lookup storage fails", async () => {
+  it("surfaces tweet lookup storage failures instead of permitting replay", async () => {
+    const storageFailure = new Error("storage unavailable");
     const runtime = runtimeWithStorage({
       getMemoryById: vi.fn(async () => {
-        throw new Error("storage unavailable");
+        throw storageFailure;
       }),
     });
 
-    await expect(isTweetProcessed(runtime, "tweet-1")).resolves.toBe(false);
+    await expect(isTweetProcessed(runtime, "tweet-1")).rejects.toBe(
+      storageFailure,
+    );
   });
 
   it("stores the canonical entity UUID as the Twitter world owner", async () => {

--- a/plugins/plugin-x/src/utils/memory.ts
+++ b/plugins/plugin-x/src/utils/memory.ts
@@ -229,41 +229,36 @@ export async function isTweetProcessed(
   runtime: IAgentRuntime,
   tweetId: string,
 ): Promise<boolean> {
-  try {
-    const memoryId = createUniqueUuid(runtime, tweetId);
-    const memory = await runtime.getMemoryById(memoryId);
-    return !!memory;
-  } catch (error) {
-    logger.debug(
-      `Error checking if tweet ${tweetId} is processed:`,
-      errorDetail(error),
-    );
-    return false;
-  }
+  const memoryId = createUniqueUuid(runtime, tweetId);
+  const memory = await runtime.getMemoryById(memoryId);
+  return !!memory;
 }
 
 /**
  * Gets recent tweets to check for duplicates
  */
+export type TwitterCacheIdentity =
+  | string
+  | { accountId: string; profileId: string };
+
+function recentTweetsCacheKey(identity: TwitterCacheIdentity): string {
+  return typeof identity === "string"
+    ? `twitter/${identity}/recentTweets`
+    : `twitter/${encodeURIComponent(identity.accountId)}/${identity.profileId}/recentTweets`;
+}
+
 export async function getRecentTweets(
   runtime: IAgentRuntime,
-  username: string,
+  identity: TwitterCacheIdentity,
   _count: number = 10,
 ): Promise<string[]> {
-  try {
-    const cacheKey = `twitter/${username}/recentTweets`;
-    const cached = await runtime.getCache<string[]>(cacheKey);
-
-    if (cached && Array.isArray(cached)) {
-      return cached;
-    }
-
-    // If no cache, return empty array
-    return [];
-  } catch (error) {
-    logger.debug("Error getting recent tweets from cache:", errorDetail(error));
-    return [];
+  const cached = await runtime.getCache<string[]>(
+    recentTweetsCacheKey(identity),
+  );
+  if (cached && Array.isArray(cached)) {
+    return cached;
   }
+  return [];
 }
 
 /**
@@ -271,24 +266,14 @@ export async function getRecentTweets(
  */
 export async function addToRecentTweets(
   runtime: IAgentRuntime,
-  username: string,
+  identity: TwitterCacheIdentity,
   tweetText: string,
   maxRecent: number = 10,
 ): Promise<void> {
-  try {
-    const cacheKey = `twitter/${username}/recentTweets`;
-    const recent = await getRecentTweets(runtime, username, maxRecent);
-
-    // Add new tweet to the beginning
-    recent.unshift(tweetText);
-
-    // Keep only the most recent tweets
-    const trimmed = recent.slice(0, maxRecent);
-
-    await runtime.setCache(cacheKey, trimmed);
-  } catch (error) {
-    logger.debug("Error updating recent tweets cache:", errorDetail(error));
-  }
+  const cacheKey = recentTweetsCacheKey(identity);
+  const recent = await getRecentTweets(runtime, identity, maxRecent);
+  recent.unshift(tweetText);
+  await runtime.setCache(cacheKey, recent.slice(0, maxRecent));
 }
 
 function normalizeTweetForDuplicateCheck(text: string): string {
@@ -319,46 +304,33 @@ function tweetTokenSimilarity(a: string, b: string): number {
  */
 export async function isDuplicateTweet(
   runtime: IAgentRuntime,
-  username: string,
+  identity: TwitterCacheIdentity,
   tweetText: string,
   similarityThreshold: number = 0.9,
 ): Promise<boolean> {
-  try {
-    const recentTweets = await getRecentTweets(runtime, username);
+  const recentTweets = await getRecentTweets(runtime, identity);
+  if (recentTweets.includes(tweetText)) {
+    return true;
+  }
 
-    // Exact match check
-    if (recentTweets.includes(tweetText)) {
+  const normalizedNew = normalizeTweetForDuplicateCheck(tweetText);
+  for (const recent of recentTweets) {
+    const normalizedRecent = normalizeTweetForDuplicateCheck(recent);
+    if (normalizedNew === normalizedRecent) {
       return true;
     }
-
-    const normalizedNew = normalizeTweetForDuplicateCheck(tweetText);
-    for (const recent of recentTweets) {
-      const normalizedRecent = normalizeTweetForDuplicateCheck(recent);
-
-      // Check if tweets are very similar (e.g., only differ by punctuation)
-      if (normalizedNew === normalizedRecent) {
-        return true;
-      }
-
-      // Check if one is a substring of the other (common with truncation)
-      if (
-        normalizedNew.includes(normalizedRecent) ||
-        normalizedRecent.includes(normalizedNew)
-      ) {
-        return true;
-      }
-
-      if (
-        tweetTokenSimilarity(normalizedNew, normalizedRecent) >=
-        similarityThreshold
-      ) {
-        return true;
-      }
+    if (
+      normalizedNew.includes(normalizedRecent) ||
+      normalizedRecent.includes(normalizedNew)
+    ) {
+      return true;
     }
-
-    return false;
-  } catch (error) {
-    logger.debug("Error checking for duplicate tweets:", errorDetail(error));
-    return false;
+    if (
+      tweetTokenSimilarity(normalizedNew, normalizedRecent) >=
+      similarityThreshold
+    ) {
+      return true;
+    }
   }
+  return false;
 }

--- a/plugins/plugin-x/src/utils/twitter-post-callback.test.ts
+++ b/plugins/plugin-x/src/utils/twitter-post-callback.test.ts
@@ -1,12 +1,19 @@
-/** Unit tests for `createTwitterPostCallback`: dry-run skip, duplicate suppression, normalized-length posting, and returned memory even when persistence fails after publish; mocked client. */
-import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+/** Unit tests for generated X post admission, credential-bound identity, bounded duplicate state, and receipt persistence; mocked provider client. */
+import {
+  ElizaError,
+  type IAgentRuntime,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClientBase } from "../base";
+import { addToRecentTweets, getRecentTweets, isDuplicateTweet } from "./memory";
 import { createTwitterPostCallback } from "./twitter-post-callback";
 
 const AGENT_ID = "00000000-0000-0000-0000-000000000001" as UUID;
 const ROOM_ID = "00000000-0000-0000-0000-000000000002" as UUID;
 const X_MAX_POST_LENGTH = 280;
+const RECENT_TWEETS_KEY = "twitter/default/twitter-user-1/recentTweets";
 
 function makeRuntime(overrides: Partial<IAgentRuntime> = {}): IAgentRuntime & {
   cache: Map<string, unknown>;
@@ -31,6 +38,8 @@ function makeRuntime(overrides: Partial<IAgentRuntime> = {}): IAgentRuntime & {
     setCache: vi.fn(async (key: string, value: unknown) => {
       cache.set(key, value);
     }),
+    deleteCache: vi.fn(async (key: string) => cache.delete(key)),
+    reportError: vi.fn(),
     ensureWorldExists: vi.fn(async () => undefined),
     updateWorld: vi.fn(async () => undefined),
     ensureRoomExists: vi.fn(async () => undefined),
@@ -46,9 +55,26 @@ function makeRuntime(overrides: Partial<IAgentRuntime> = {}): IAgentRuntime & {
 }
 
 function makeClient(): ClientBase {
+  const profile = {
+    id: "twitter-user-1",
+    username: "agent",
+    screenName: "Agent",
+    bio: "",
+    nicknames: [],
+  };
   return {
     accountId: "default",
     lastCheckedTweetId: null,
+    runtime: { reportError: vi.fn() },
+    profile,
+    withAuthenticatedSession: async (
+      operation: (session: {
+        client: unknown;
+        profile: typeof profile;
+        revision: number;
+      }) => Promise<unknown>,
+    ) => operation({ client: {}, profile, revision: 1 }),
+    isAuthenticatedSessionCurrent: () => true,
     twitterClient: {
       sendTweet: vi.fn().mockImplementation(async (text: string) => ({
         data: {
@@ -60,6 +86,7 @@ function makeClient(): ClientBase {
       })),
     },
     cacheLatestCheckedTweetId: vi.fn(async () => undefined),
+    recordLatestCheckedTweetId: vi.fn(),
     cacheTweet: vi.fn(async () => undefined),
   } as unknown as ClientBase;
 }
@@ -104,7 +131,7 @@ describe("createTwitterPostCallback", () => {
 
   it("skips duplicate generated tweets", async () => {
     const runtime = makeRuntime();
-    runtime.cache.set("twitter/agent/recentTweets", ["duplicate text"]);
+    runtime.cache.set(RECENT_TWEETS_KEY, ["duplicate text"]);
     const client = makeClient();
     const callback = makeCallback({ client, runtime });
 
@@ -128,9 +155,7 @@ describe("createTwitterPostCallback", () => {
       false,
       [],
     );
-    expect(runtime.cache.get("twitter/agent/recentTweets")).toEqual([
-      "new post text",
-    ]);
+    expect(runtime.cache.get(RECENT_TWEETS_KEY)).toEqual(["new post text"]);
     expect(runtime.createMemory).toHaveBeenCalledTimes(1);
     expect(memories).toHaveLength(1);
     expect(memories[0]?.content?.text).toBe("new post text");
@@ -147,12 +172,100 @@ describe("createTwitterPostCallback", () => {
     const callback = makeCallback({ client, runtime, onPosted });
 
     await expect(callback({ text: "new post text" })).resolves.toEqual([]);
+    const laterCallback = makeCallback({ client, runtime, onPosted });
+    await expect(laterCallback({ text: "new post text" })).resolves.toEqual([]);
 
     expect(onPosted).toHaveBeenCalledTimes(1);
     expect(client.twitterClient.sendTweet).toHaveBeenCalledTimes(1);
-    expect(runtime.cache.get("twitter/agent/recentTweets")).toEqual([
-      "new post text",
+    expect(runtime.cache.get(RECENT_TWEETS_KEY)).toEqual(["new post text"]);
+  });
+
+  it("sends once for concurrent calls on one callback but permits the same text after recent history expires", async () => {
+    const runtime = makeRuntime();
+    const client = makeClient();
+    const firstCallback = makeCallback({ client, runtime });
+
+    const firstResults = await Promise.all([
+      firstCallback({ text: "gm" }),
+      firstCallback({ text: "gm" }),
     ]);
+
+    expect(client.twitterClient.sendTweet).toHaveBeenCalledTimes(1);
+    expect(firstResults.map((result) => result.length).sort()).toEqual([0, 1]);
+    await expect(
+      firstCallback({ text: "a second callback output" }),
+    ).resolves.toEqual([]);
+    expect(client.twitterClient.sendTweet).toHaveBeenCalledTimes(1);
+    expect(
+      [...runtime.cache.keys()].filter((key) => key.includes("/post_settled/")),
+    ).toEqual([]);
+
+    // The bounded recent-history cache is the duplicate authority after a
+    // successful receipt. A later generation may reuse the text once it ages.
+    runtime.cache.delete(RECENT_TWEETS_KEY);
+    const laterCallback = makeCallback({ client, runtime });
+    await expect(laterCallback({ text: "gm" })).resolves.toHaveLength(1);
+
+    expect(client.twitterClient.sendTweet).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears an explicit provider rejection so a later generation can retry", async () => {
+    const runtime = makeRuntime();
+    const client = makeClient();
+    const providerSend = vi.mocked(client.twitterClient.sendTweet);
+    providerSend
+      .mockRejectedValueOnce({ status: 403, message: "forbidden" })
+      .mockResolvedValue({
+        data: { data: { id: "124", text: "retryable post" } },
+      });
+    const rejectedCallback = makeCallback({ client, runtime });
+
+    await expect(
+      rejectedCallback({ text: "retryable post" }),
+    ).rejects.toMatchObject({ status: 403 });
+    await expect(rejectedCallback({ text: "retryable post" })).resolves.toEqual(
+      [],
+    );
+    expect(
+      [...runtime.cache.keys()].filter((key) => key.includes("/post_settled/")),
+    ).toEqual([]);
+
+    const retryCallback = makeCallback({ client, runtime });
+    await expect(
+      retryCallback({ text: "retryable post" }),
+    ).resolves.toHaveLength(1);
+    expect(providerSend).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears the pre-egress barrier when authentication rotates before the provider call", async () => {
+    const runtime = makeRuntime();
+    const client = makeClient();
+    const originalSession = client.withAuthenticatedSession.bind(client);
+    let admissionCount = 0;
+    client.withAuthenticatedSession = vi.fn(async (operation) => {
+      admissionCount += 1;
+      if (admissionCount === 2) {
+        throw new ElizaError("session rotated", {
+          code: "X_AUTH_SESSION_ROTATED",
+        });
+      }
+      return originalSession(operation);
+    }) as ClientBase["withAuthenticatedSession"];
+    const rotatedCallback = makeCallback({ client, runtime });
+
+    await expect(
+      rotatedCallback({ text: "identity-bound post" }),
+    ).rejects.toMatchObject({ code: "X_AUTH_SESSION_ROTATED" });
+    expect(client.twitterClient.sendTweet).not.toHaveBeenCalled();
+    expect(
+      [...runtime.cache.keys()].filter((key) => key.includes("/post_settled/")),
+    ).toEqual([]);
+
+    const retryCallback = makeCallback({ client, runtime });
+    await expect(
+      retryCallback({ text: "identity-bound post" }),
+    ).resolves.toHaveLength(1);
+    expect(client.twitterClient.sendTweet).toHaveBeenCalledTimes(1);
   });
 
   it("checks duplicates and posts with the normalized X-length text", async () => {
@@ -164,11 +277,33 @@ describe("createTwitterPostCallback", () => {
     await callback({ text: longText });
 
     expect(client.twitterClient.sendTweet).toHaveBeenCalledTimes(1);
-    const recentTweets = runtime.cache.get("twitter/agent/recentTweets") as
+    const recentTweets = runtime.cache.get(RECENT_TWEETS_KEY) as
       | string[]
       | undefined;
     expect(recentTweets).toHaveLength(1);
     expect(typeof recentTweets?.[0]).toBe("string");
     expect(recentTweets?.[0]?.length).toBeLessThanOrEqual(X_MAX_POST_LENGTH);
+  });
+
+  it("partitions recent-post duplicate state by account and profile identity", async () => {
+    const runtime = makeRuntime();
+    const accountA = { accountId: "account-a", profileId: "profile-1" };
+    const accountB = { accountId: "account-b", profileId: "profile-1" };
+
+    await addToRecentTweets(runtime, accountA, "same visible username post");
+
+    await expect(
+      isDuplicateTweet(runtime, accountA, "same visible username post"),
+    ).resolves.toBe(true);
+    await expect(
+      isDuplicateTweet(runtime, accountB, "same visible username post"),
+    ).resolves.toBe(false);
+    await expect(getRecentTweets(runtime, accountB)).resolves.toEqual([]);
+    expect(
+      runtime.cache.get("twitter/account-a/profile-1/recentTweets"),
+    ).toEqual(["same visible username post"]);
+    expect(
+      runtime.cache.get("twitter/account-b/profile-1/recentTweets"),
+    ).toBeUndefined();
   });
 });

--- a/plugins/plugin-x/src/utils/twitter-post-callback.ts
+++ b/plugins/plugin-x/src/utils/twitter-post-callback.ts
@@ -9,6 +9,7 @@ import {
   ChannelType,
   type Content,
   createUniqueUuid,
+  ElizaError,
   type HandlerCallback,
   type IAgentRuntime,
   type Memory,
@@ -63,7 +64,7 @@ export function createTwitterPostCallback({
   state,
   roomId,
   userId,
-  username,
+  username: _username,
   onPosted,
 }: {
   client: ClientBase;
@@ -77,6 +78,7 @@ export function createTwitterPostCallback({
   const isDryRun = parseBooleanFromText(
     state?.TWITTER_DRY_RUN ?? getSetting(runtime, "TWITTER_DRY_RUN"),
   );
+  let egressAttempted = false;
 
   const callback: HandlerCallback = async (
     content: Content,
@@ -103,73 +105,118 @@ export function createTwitterPostCallback({
         return [];
       }
 
-      const isDuplicate = await isDuplicateTweet(runtime, username, postText);
-      if (isDuplicate) {
-        runtime.logger.info("[Twitter] Skipping duplicate generated tweet");
-        return [];
-      }
-
-      const result = await sendTweet(client, postText, [], undefined, []);
-      const postedText = result.text?.trim() || postText;
-      runtime.logger.info(
-        `[Twitter] Tweet posted successfully! ID: ${result.id}`,
-      );
-      onPosted?.();
-      await addToRecentTweets(runtime, username, postedText);
-
-      try {
-        const context = await ensureTwitterContext(runtime, {
-          accountId: client.accountId,
-          userId,
-          username,
-          conversationId: `${userId}-home`,
-        });
-
-        const postedMemory: Memory = {
-          id: createUniqueUuid(runtime, result.id),
-          entityId: runtime.agentId,
-          agentId: runtime.agentId,
-          roomId: context.roomId || roomId,
-          content: {
-            ...content,
-            text: postedText,
-            source: "twitter",
-            channelType: ChannelType.FEED,
-            type: "post",
-            metadata: {
-              accountId: client.accountId,
-              tweetId: result.id,
-              postedAt: Date.now(),
-            },
-          },
-          metadata: {
-            type: "message",
-            source: "twitter",
-            accountId: client.accountId,
-            provider: "twitter",
-            messageIdFull: result.id,
-            chatType: ChannelType.FEED,
-            fromBot: true,
-          } satisfies Memory["metadata"],
-          createdAt: Date.now(),
-        };
-
-        await createMemorySafe(runtime, postedMemory, "messages");
-
-        return [postedMemory];
-      } catch (error) {
-        runtime.logger.error(
-          "[Twitter] Tweet posted, but failed to save tweet memory:",
-          errorMessage(error),
+      if (egressAttempted) {
+        runtime.logger.warn(
+          "[Twitter] Suppressed duplicate generated-post callback egress",
         );
         return [];
       }
+      egressAttempted = true;
+
+      return client.withAuthenticatedSession(async (session) => {
+        if (session.profile.id !== userId) {
+          throw new ElizaError(
+            "X profile changed before the generated post was admitted",
+            { code: "X_AUTH_SESSION_ROTATED" },
+          );
+        }
+
+        const cacheIdentity = {
+          accountId: client.accountId,
+          profileId: session.profile.id,
+        };
+        const isDuplicate = await isDuplicateTweet(
+          runtime,
+          cacheIdentity,
+          postText,
+        );
+        if (isDuplicate) {
+          runtime.logger.info("[Twitter] Skipping duplicate generated tweet");
+          return [];
+        }
+        const result = await sendTweet(client, postText, [], undefined, []);
+        const postedText = result.text?.trim() || postText;
+        runtime.logger.info(
+          `[Twitter] Tweet posted successfully! ID: ${result.id}`,
+        );
+        try {
+          onPosted?.();
+        } catch (error) {
+          // error-policy:J7 X already accepted the post; the scheduler's
+          // notification callback must not convert delivery into a retry.
+          runtime.reportError("XPostCallback.notificationReceipt", error, {
+            accountId: client.accountId,
+            tweetId: result.id,
+          });
+        }
+
+        try {
+          await addToRecentTweets(runtime, cacheIdentity, postedText);
+        } catch (error) {
+          // error-policy:J7 X already accepted the post; local duplicate
+          // history failure must be visible without replaying provider egress.
+          runtime.reportError("XPostCallback.localReceipt", error, {
+            accountId: client.accountId,
+            tweetId: result.id,
+          });
+        }
+
+        try {
+          const context = await ensureTwitterContext(runtime, {
+            accountId: client.accountId,
+            userId: session.profile.id,
+            username: session.profile.username,
+            conversationId: `${session.profile.id}-home`,
+          });
+
+          const postedMemory: Memory = {
+            id: createUniqueUuid(runtime, result.id),
+            entityId: runtime.agentId,
+            agentId: runtime.agentId,
+            roomId: context.roomId || roomId,
+            content: {
+              ...content,
+              text: postedText,
+              source: "twitter",
+              channelType: ChannelType.FEED,
+              type: "post",
+              metadata: {
+                accountId: client.accountId,
+                tweetId: result.id,
+                postedAt: Date.now(),
+              },
+            },
+            metadata: {
+              type: "message",
+              source: "twitter",
+              accountId: client.accountId,
+              provider: "twitter",
+              messageIdFull: result.id,
+              chatType: ChannelType.FEED,
+              fromBot: true,
+            } satisfies Memory["metadata"],
+            createdAt: Date.now(),
+          };
+
+          await createMemorySafe(runtime, postedMemory, "messages");
+
+          return [postedMemory];
+        } catch (error) {
+          // error-policy:J7 X already accepted the post; surface local memory
+          // loss without returning an error that could cause duplicate egress.
+          runtime.reportError("XPostCallback.memoryReceipt", error, {
+            accountId: client.accountId,
+            tweetId: result.id,
+          });
+          return [];
+        }
+      });
     } catch (error) {
       runtime.logger.error(
         "[Twitter] Error in post generated callback:",
         errorMessage(error),
       );
-      return [];
+      throw error;
     }
   };
 


### PR DESCRIPTION
# Relates to

Closes #19968.
Builds on merged authentication/session foundation #20087.
Parent live-provider acceptance: #19444.

- [x] Targets `develop` and is a single commit on exact `origin/develop@01dc3862fb7c74ab43f87e357e8e890732f9a68c`.
- [x] Independent review removed the original process-local settlement layer instead of claiming cross-process durability.
- [x] Package tests, typecheck, build, Biome, guide parity, and diff check pass.
- [ ] Authorized live-X acceptance remains owned by #19444; this PR does not access production credentials.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@ac4125fcb013c3f1f7600f71fd35cf3750f422bd:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- Exact base: `01dc3862fb7c74ab43f87e357e8e890732f9a68c`
- Exact head: `d1af8e01a2033207d42a85a7a5e2b0b5b1484486`
- One commit, 27 plugin-X paths, no dependency or deployment changes.

# Risks

This is a high-sensitivity connector identity change. A credential rotation must not leave autonomous work, feed attribution, prompt identity, or cursor state attached to the prior X account. The refactor keeps #20087's counted per-operation authentication leases, rejects stale generations before side effects or cache writes, partitions state by connector account plus immutable X profile ID, and publishes legacy singleton identity only for the default account.

The original draft also bundled process-local action-settlement tombstones. Those are deliberately excluded: they lacked a distributed CAS and could either duplicate across replicas or silently lose work after a crash between tombstone creation and provider egress.

# Background

## What does this PR do?

- Synchronizes `ClientBase` identity from the active authenticated credential generation and clears compatibility identity on refresh failure.
- Partitions timelines, mentions, recent-post history, and interaction cursors by configured account plus immutable X profile ID, with bounded migration from eligible legacy username keys.
- Prevents secondary accounts from overwriting the agent's legacy singleton entity identity.
- Carries fresh profiles through post, discovery, interaction, timeline, feed, search, and identity-provider paths.
- Marks own-post memories from the admitted profile ID rather than a startup snapshot.
- Preserves #20087's per-`next()` streaming lease behavior and trusted post/DM account routing.
- Excludes the unsafe action-settlement implementation and its claims.

## What kind of change is this?

Bug fix and security hardening for managed X credential rotation and multi-account attribution.

# Documentation changes needed?

Package-local `CLAUDE.md` and `AGENTS.md` remain byte-identical and document credential-aware identity refresh.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-x/src/base.ts`
2. `plugins/plugin-x/src/services/base-credential-identity.test.ts`
3. `plugins/plugin-x/src/interactions-account-metadata.test.ts`
4. `plugins/plugin-x/src/timeline.test.ts`
5. `plugins/plugin-x/src/utils/twitter-post-callback.test.ts`
6. `plugins/plugin-x/src/services/x.service.test.ts`

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-x test
bun run --cwd plugins/plugin-x typecheck
bun run --cwd plugins/plugin-x build
bunx @biomejs/biome check plugins/plugin-x/src plugins/plugin-x/CLAUDE.md plugins/plugin-x/AGENTS.md
bun run check:agents-claude
git diff --check origin/develop...HEAD
```

Exact local results:

- Vitest: 27 files passed, 1 credential-gated live suite skipped; 197 passed, 13 skipped.
- Typecheck: pass.
- ESM and declaration build: pass.
- Biome: 77 paths clean.
- CLAUDE/AGENTS parity: pass.
- Diff check: pass.

# Evidence Gate

<!-- evidence-head:d1af8e01a2033207d42a85a7a5e2b0b5b1484486 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend connector/authentication change with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend connector/authentication change with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend or device interaction changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - production X credentials are intentionally unavailable in this lane; deterministic provider-boundary tests are transcribed above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, planner, or model policy changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - credential generations and cache-key partitions are asserted in deterministic package tests; no external domain was mutated.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM-facing behavior changed.

## Backend + frontend logs

The exact commands and results above exercise credential replacement, stale-profile invalidation, cursor migration, account isolation, current-profile filtering, post/feed/search attribution, and rotation during delayed reads. Frontend logs are N/A.

## Known gaps / failures

- Thirteen real-X tests remain credential-gated. Parent #19444 owns authorized live-provider acceptance.
- This PR does not claim cross-process action settlement or exactly-once provider delivery.
- No UI, LLM, wallet, payout, deployment, or production mutation was performed.

# Deploy notes

No migration or configuration step. Deploy with the normal plugin-X release after parent #19444's authorized live-provider acceptance.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@ac4125fcb013c3f1f7600f71fd35cf3750f422bd:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-shared-eliza]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@ac4125fcb013c3f1f7600f71fd35cf3750f422bd:packages/skills/skills/contribute-to-eliza"} -->