### PR TITLE
fix(cloud): make stream milestone terminals truthful

### DIFF
--- a/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
@@ -1278,13 +1278,16 @@ describe("passthrough streaming — #16079 milestone telemetry", () => {
     await res.text();
 
     const snapshot = getCloudTelemetrySnapshot(10);
-    const event = snapshot.streamMilestones.find((e) => e.path === "passthrough");
+    const event = snapshot.streamMilestones.find(
+      (e) => e.path === "passthrough",
+    );
     if (!event) throw new Error("no passthrough milestone event recorded");
     expect(event.firstEventMs).not.toBeNull();
     expect(event.firstContentMs).not.toBeNull();
     expect(event.completionMs).toBeNull();
     expect(event.aborted).toBe(true);
   });
+
   test("client-branch cancel records aborted=true with partial milestones", async () => {
     // RP round-1 finding: the existing abort test simulated an upstream read
     // error; this one cancels the CLIENT branch mid-stream, exercising the

--- a/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
@@ -6,7 +6,7 @@
  * upstream boundary) and the REAL credit-reservation settler, mirroring
  * chat-completions-streaming-credit-leak. Asserts the fast-path contract:
  * qualifying requests pipe the upstream SSE bytes VERBATIM (no re-encode)
- * while usage is metered from the teed branch and billed through the same
+ * while usage is metered from the backpressured byte path and billed through the same
  * settle chain with the same amounts as the SDK path; non-qualifying requests
  * and flag-off fall through to `streamText` untouched; client aborts cancel
  * the upstream fetch and settle the delivered portion; upstream errors refund
@@ -1156,7 +1156,7 @@ describe("passthrough streaming — #16079 milestone telemetry", () => {
 
     // The always-on ring buffer holds one correlated event keyed by the
     // fallback trace id (the test harness's requestId) with the milestones
-    // the teed meter observed from the upstream SSE bytes.
+    // the meter observed from the upstream SSE bytes.
     const snapshot = getCloudTelemetrySnapshot(10);
     const event = snapshot.streamMilestones.find(
       (e) => e.path === "passthrough",
@@ -1290,7 +1290,7 @@ describe("passthrough streaming — #16079 milestone telemetry", () => {
 
   test("client-branch cancel records aborted=true with partial milestones", async () => {
     // RP round-1 finding: the existing abort test simulated an upstream read
-    // error; this one cancels the CLIENT branch mid-stream, exercising the
+    // error; this one cancels the client stream mid-flight, exercising the
     // cancel() → meterAbortController.abort() path a real disconnect takes.
     const deliveredText = "partial before disconnect";
     const waitUntilPromises: Array<Promise<unknown>> = [];
@@ -1329,11 +1329,59 @@ describe("passthrough streaming — #16079 milestone telemetry", () => {
       (e) => e.path === "passthrough",
     );
     if (!event) throw new Error("no passthrough milestone event recorded");
-    // The client disconnect reached the meter branch: the run is aborted with
+    // The client disconnect reached the meter: the run is aborted with
     // the partial content milestone observed, never a completion.
     expect(event.aborted).toBe(true);
     expect(event.firstContentMs).not.toBeNull();
     expect(event.completionMs).toBeNull();
+  });
+
+  test("a stalled client applies backpressure instead of draining upstream", async () => {
+    const waitUntilPromises: Array<Promise<unknown>> = [];
+    let upstreamPulls = 0;
+    fetchImpl = async () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            upstreamPulls++;
+            controller.enqueue(
+              encoder.encode(
+                `data: {"choices":[{"delta":{"content":"${upstreamPulls}"}}]}\n\n`,
+              ),
+            );
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "text/event-stream" } },
+      );
+
+    const res = await callStreaming(async () => null, {
+      executionCtx: {
+        waitUntil(promise: Promise<unknown>) {
+          waitUntilPromises.push(promise);
+        },
+      },
+    });
+    const reader = res.body?.getReader();
+    if (!reader) throw new Error("expected passthrough response body");
+
+    // The response stream may prefill its single default queue slot, but it
+    // must not let the meter race ahead and drain an unbounded provider stream.
+    for (let index = 0; index < 20; index++) await Promise.resolve();
+    // The upstream source and response stream may each prefill one bounded
+    // queue slot; the count must then remain stable while the client stalls.
+    expect(upstreamPulls).toBeLessThanOrEqual(2);
+    const pullsWhileStalled = upstreamPulls;
+    for (let index = 0; index < 20; index++) await Promise.resolve();
+    expect(upstreamPulls).toBe(pullsWhileStalled);
+
+    await reader.read();
+    for (let index = 0; index < 20; index++) await Promise.resolve();
+    expect(upstreamPulls).toBeLessThanOrEqual(3);
+
+    await reader.cancel(
+      new DOMException("stalled client closed", "AbortError"),
+    );
+    await Promise.all(waitUntilPromises);
   });
 
   test("aborted stream records aborted=true and keeps observed partial milestones", async () => {
@@ -1366,9 +1414,9 @@ describe("passthrough streaming — #16079 milestone telemetry", () => {
       (e) => e.path === "passthrough",
     );
     if (!event) throw new Error("no passthrough milestone event recorded");
-    // The errored tee discards buffered chunks, so mid-stream milestones may
-    // legitimately be null here — what MUST hold: the event exists, is marked
-    // aborted, and never claims a completion it did not observe.
+    // An errored upstream may reject the pending read before its final buffered
+    // chunk reaches the meter, so partial milestones may legitimately be null.
+    // The event must still exist, be aborted, and never claim completion.
     expect(event.aborted).toBe(true);
     expect(event.completionMs).toBeNull();
   });

--- a/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts
@@ -1268,6 +1268,23 @@ describe("passthrough streaming — #16079 milestone telemetry", () => {
     expect(event.completionMs).not.toBeNull();
   });
 
+  test("clean EOF without [DONE] records an incomplete terminal", async () => {
+    fetchImpl = async () =>
+      sseResponse(
+        `data: {"id":"c1","choices":[{"index":0,"delta":{"content":"partial"},"finish_reason":null}],"usage":null}\n\n`,
+      );
+
+    const res = await callStreaming(async () => null, {});
+    await res.text();
+
+    const snapshot = getCloudTelemetrySnapshot(10);
+    const event = snapshot.streamMilestones.find((e) => e.path === "passthrough");
+    if (!event) throw new Error("no passthrough milestone event recorded");
+    expect(event.firstEventMs).not.toBeNull();
+    expect(event.firstContentMs).not.toBeNull();
+    expect(event.completionMs).toBeNull();
+    expect(event.aborted).toBe(true);
+  });
   test("client-branch cancel records aborted=true with partial milestones", async () => {
     // RP round-1 finding: the existing abort test simulated an upstream read
     // error; this one cancels the CLIENT branch mid-stream, exercising the

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -2367,11 +2367,12 @@ function sanitizeProviderRequestId(value: string | null): string | undefined {
  * chat/completions directly with `stream: true` and return the response body
  * piped to the client byte-for-byte — no AI-SDK decode, no per-part
  * processing, no SSE re-encode (the measured ~1.5s TTFB / ~5s total gateway
- * overhead vs ~0.17s / ~0.6s direct). Billing parity comes from
- * `response.body.tee()`: one branch goes to the client untouched while the
- * other is read in the background (via the same settleOffResponsePath seam as
- * the SDK path) to extract the terminal usage frame + delivered text for the
- * EXISTING settle chain (billUsage → settleReservation → analytics → audit).
+ * overhead vs ~0.17s / ~0.6s direct). A backpressured pass-through reads one
+ * upstream chunk only when the client branch pulls, sends that same chunk
+ * through the billing meter, then enqueues it byte-for-byte for the client.
+ * The meter extracts the terminal usage frame + delivered text for the EXISTING
+ * settle chain (billUsage → settleReservation → analytics → audit) without a
+ * faster `tee()` branch buffering an unbounded slow-client queue.
  *
  * Returns null when the fast path does not apply (flag off, non-qualifying
  * request, no direct upstream) — callers fall through to streamText. Runs
@@ -2582,44 +2583,59 @@ async function tryPassthroughStreamingRequest(params: {
   const providerRequestId = sanitizeProviderRequestId(
     upstreamResponse.headers.get("x-request-id"),
   );
-  const [clientBranch, meterBranch] = upstreamResponse.body.tee();
   const meterAbortController = new AbortController();
-  const clientReader = clientBranch.getReader();
-  const cancelAwareClientBranch = new ReadableStream<Uint8Array>({
+  const meterChannel = new TransformStream<Uint8Array, Uint8Array>();
+  const meterWriter = meterChannel.writable.getWriter();
+  const upstreamReader = upstreamResponse.body.getReader();
+  const tailPromise = readPassthroughStreamTail(
+    meterChannel.readable,
+    meterAbortController.signal,
+    // #16079: milestones measured from the provider fetch dispatch.
+    { startedAt: upstreamFetchStartedAt },
+  );
+  let settlementTask: Promise<void> | undefined;
+  const backpressuredClientStream = new ReadableStream<Uint8Array>({
     async pull(controller) {
       try {
-        const { done, value } = await clientReader.read();
+        const { done, value } = await upstreamReader.read();
         if (done) {
+          await meterWriter.close();
+          // Tests and non-Worker callers have no waitUntil lifetime. Preserve
+          // their inline-settlement contract at EOF without delaying any
+          // preceding streamed bytes.
+          if (!params.executionCtx) await settlementTask;
           controller.close();
         } else {
+          // Await metering before enqueueing the exact same chunk. Upstream is
+          // therefore driven by client demand, with at most the readable's
+          // bounded queue ahead of a slow consumer.
+          await meterWriter.write(value);
           controller.enqueue(value);
         }
       } catch (error) {
         // error-policy:J1 translate upstream read failure to the client stream.
+        meterAbortController.abort(error);
+        await meterWriter.abort(error).catch(() => undefined);
         controller.error(error);
       }
     },
     async cancel(reason) {
-      // A tee keeps the upstream alive until both branches stop. Explicitly
-      // stop the metering branch when the client disconnects so billing can
-      // settle the observed partial output inside Cloudflare's waitUntil window.
+      // Stop both the upstream and meter when the client disconnects so billing
+      // settles the observed partial output inside Cloudflare's waitUntil window.
       meterAbortController.abort(reason);
-      await clientReader.cancel(reason);
+      await Promise.allSettled([
+        upstreamReader.cancel(reason),
+        meterWriter.abort(reason),
+      ]);
     },
   });
   const billingPrompt = buildChatPromptForBilling(request);
 
-  // Meter + settle on the teed branch, OFF the response path when a Workers
-  // executionCtx exists (the same seam the SDK path defers its settlement
-  // through); inline for tests / non-Worker callers — tee buffers the client
-  // branch, so inline draining never deadlocks the response.
-  await settleOffResponsePath(params.executionCtx, async () => {
-    const tail = await readPassthroughStreamTail(
-      meterBranch,
-      meterAbortController.signal,
-      // #16079: milestones measured from the provider fetch dispatch.
-      { startedAt: upstreamFetchStartedAt },
-    );
+  // Meter + settle OFF the response path. The tail cannot resolve until client
+  // demand has driven the pass-through stream to completion, so awaiting this
+  // task before returning the Response would deadlock non-Worker callers.
+  settlementTask = settleOffResponsePath(params.executionCtx, async () => {
+    const tail = await tailPromise;
     // Always-on correlated milestone record (#16079): the ring buffer is read
     // back via the admin cloud-observability endpoint, so unlike logger.info
     // it survives without VERBOSE_LOGGING. Bounded fields only.
@@ -2748,10 +2764,17 @@ async function tryPassthroughStreamingRequest(params: {
       "[Chat Completions] Passthrough stream ended without usage frame; settled from estimates",
       { model, readAborted: tail.readError !== null, sawDone: tail.sawDone },
     );
+  }).catch((error) => {
+    // error-policy:J7 settlement diagnostics must not create an unhandled
+    // rejection after the response has begun streaming.
+    logger.error("[Chat Completions] Passthrough settlement task failed", {
+      model,
+      error: error instanceof Error ? error.message : String(error),
+    });
   });
 
   return addCorsHeaders(
-    new Response(cancelAwareClientBranch, {
+    new Response(backpressuredClientStream, {
       status: 200,
       headers: {
         "Content-Type": "text/event-stream",
@@ -2812,7 +2835,7 @@ async function handleStreamingRequest(
 ) {
   // #15428 pass-through fast path: qualifying plain streamed chat against a
   // direct OpenAI-compatible upstream pipes the provider bytes straight
-  // through (zero decode/re-encode) and meters a teed branch into the same
+  // through (zero decode/re-encode) and meters the backpressured byte path into the same
   // billing chain. Anything the pipe cannot represent — pooled BYO keys,
   // Anthropic CoT provider options, provider-native web search, tools,
   // response_format, multimodal content — takes the streamText path below,
@@ -3832,7 +3855,7 @@ export const __billingBranchTestHooks = {
 /**
  * Test-only seam for the pass-through streaming fast path (#15428): the
  * qualification predicate and the upstream-status mapping, unit-tested
- * directly; the pipe/tee/settle behavior itself is driven through
+ * directly; the pass-through stream and settle behavior itself is driven through
  * `handleStreamingRequest` with a mocked global fetch in
  * `__tests__/chat-completions-passthrough-streaming.test.ts`.
  */

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -2634,9 +2634,9 @@ async function tryPassthroughStreamingRequest(params: {
       firstReasoningMs: tail.milestones.firstReasoningMs,
       firstContentMs: tail.milestones.firstContentMs,
       completionMs: tail.milestones.completionMs,
-      // An in-stream SSE error frame is an upstream-reported failure: record
-      // it as not-completed rather than a healthy run (#16079).
-      aborted: tail.readError !== null || tail.sawErrorFrame,
+      // A read failure, provider error frame, or clean EOF without the required
+      // `[DONE]` marker is incomplete; none may masquerade as healthy.
+      aborted: tail.readError !== null || tail.sawErrorFrame || !tail.sawDone,
       createdAt: new Date().toISOString(),
     });
     if (tail.usage) {

--- a/packages/cloud/shared/src/lib/observability/cloud-backend-observability.ts
+++ b/packages/cloud/shared/src/lib/observability/cloud-backend-observability.ts
@@ -59,8 +59,8 @@ export interface CloudStreamMilestoneTelemetry {
   firstContentMs: number | null;
   completionMs: number | null;
   /**
-   * Stream ended via client abort, read failure, or an in-stream provider
-   * error frame — observed during the stream or its teardown. NOT mutually
+   * Stream ended via client abort, read failure, in-stream provider error, or
+   * clean EOF without `[DONE]`. NOT mutually
    * exclusive with `completionMs`: a provider that emitted `[DONE]` before a
    * client disconnect completed, and both facts are recorded (#16079).
    */

--- a/packages/cloud/shared/src/lib/observability/cloud-backend-observability.ts
+++ b/packages/cloud/shared/src/lib/observability/cloud-backend-observability.ts
@@ -60,8 +60,8 @@ export interface CloudStreamMilestoneTelemetry {
   completionMs: number | null;
   /**
    * Stream ended via client abort, read failure, in-stream provider error, or
-   * clean EOF without `[DONE]`. NOT mutually
-   * exclusive with `completionMs`: a provider that emitted `[DONE]` before a
+   * clean EOF without `[DONE]`. This is not mutually exclusive with
+   * `completionMs`: a provider that emitted `[DONE]` before a
    * client disconnect completed, and both facts are recorded (#16079).
    */
   aborted: boolean;

--- a/packages/cloud/shared/src/lib/services/__tests__/inference-passthrough-milestones.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/inference-passthrough-milestones.test.ts
@@ -133,14 +133,14 @@ describe("readPassthroughStreamTail — milestones (#16079)", () => {
     expect(tail.milestones.firstEventMs).toBe(4);
   });
 
-  test("malformed frames never produce milestones", async () => {
+  test("a malformed data frame still records the first SSE event", async () => {
     const clock = scriptedClock(0, 2);
     const tail = await readWithClock(
       [`data: not-json\n\n`, `: comment line\n\n`, `data: [DONE]\n\n`],
       0,
       clock,
     );
-    expect(tail.milestones.firstEventMs).toBeNull();
+    expect(tail.milestones.firstEventMs).toBe(2);
     expect(tail.milestones.completionMs).toBe(6);
   });
 
@@ -184,15 +184,28 @@ describe("readPassthroughStreamTail — milestones (#16079)", () => {
       firstEventMs: null,
       firstReasoningMs: null,
       firstContentMs: null,
-      completionMs: 42,
+      completionMs: null,
     };
     expect(tail.milestones).toEqual(allNull);
   });
 
-  test("defaults: startedAt/now resolve to performance.now when omitted", async () => {
+  test("clean EOF without [DONE] remains explicitly incomplete", async () => {
+    const clock = scriptedClock(0, 5);
+    const tail = await readWithClock(
+      [`data: {"id":"c1","choices":[{"delta":{"content":"partial"}}]}\n\n`],
+      0,
+      clock,
+    );
+    expect(tail.sawDone).toBe(false);
+    expect(tail.milestones.firstEventMs).toBe(5);
+    expect(tail.milestones.firstContentMs).toBe(5);
+    expect(tail.milestones.completionMs).toBeNull();
+  });
+
+  test("defaults: startedAt/now resolve to a receiver-safe performance clock", async () => {
     const tail = await readPassthroughStreamTail(sseStream([`data: [DONE]\n\n`]));
-    // No crash, milestone fields present and completion observed.
-    expect(tail.milestones.firstEventMs).toBeNull();
+    // No crash, and the transport event plus protocol completion are observed.
+    expect(typeof tail.milestones.firstEventMs).toBe("number");
     expect(typeof tail.milestones.completionMs).toBe("number");
     expect(tail.milestones.completionMs).not.toBeNull();
   });

--- a/packages/cloud/shared/src/lib/services/inference-passthrough.ts
+++ b/packages/cloud/shared/src/lib/services/inference-passthrough.ts
@@ -8,14 +8,14 @@
  * decode/re-encode pipeline, not the provider. For requests that need NO
  * transformation (plain streaming chat against an OpenAI-compatible upstream,
  * no tools / response_format / web search), the route can instead pipe the
- * upstream response body straight to the client and meter a teed copy in the
- * background.
+ * upstream response body straight to the client and meter the same
+ * backpressured byte path in the background.
  *
  * This module owns the pieces that are independent of the route:
  *   - the `INFERENCE_PASSTHROUGH_STREAMING` flag (default OFF — same
  *     soak-then-cutover discipline as the #9899 INFERENCE_* flags; flag off is
  *     byte-identical to today),
- *   - the background meter: an SSE reader for the teed branch that extracts
+ *   - the background meter: an SSE reader for the pass-through channel that extracts
  *     the terminal `stream_options.include_usage` usage frame plus the
  *     delivered text, which the route feeds into the EXISTING billing settle
  *     chain (billUsage → settleReservation → analytics → audit),
@@ -23,12 +23,12 @@
  *     first SSE frame, the first reasoning delta, the first visible content
  *     delta, and stream completion were observed, so one correlated trace can
  *     assign provider-side latency instead of collapsing it into "gateway
- *     time". Milestones are measured at the meter branch against an injected
+ *     time". Milestones are measured at the meter channel against an injected
  *     monotonic origin (the route pins it to the provider fetch start); they
  *     bound when the upstream made each frame available, not when a specific
  *     client received it.
  *
- * The qualification predicate and the upstream fetch/tee orchestration live in
+ * The qualification predicate and upstream stream orchestration live in
  * the chat-completions route (they depend on route-local billing helpers); the
  * upstream resolution lives in providers/language-model.ts (provider
  * knowledge).
@@ -50,7 +50,7 @@ export function isPassthroughStreamingEnabled(env: StringEnv = getCloudAwareEnv(
 /**
  * Sibling flag for the non-streaming embeddings pipe (#15512). Same soak
  * discipline and rollback shape as the streaming flag; embeddings are simpler
- * (single JSON response, no tee) so the two roll out independently.
+ * (single JSON response, no streaming meter) so the two roll out independently.
  */
 export function isPassthroughEmbeddingsEnabled(env: StringEnv = getCloudAwareEnv()): boolean {
   return (env.INFERENCE_PASSTHROUGH_EMBEDDINGS ?? "").trim() === "true";
@@ -69,7 +69,7 @@ export interface PassthroughUsage {
 }
 
 /**
- * Stream milestones observed on the teed branch (#16079). `null` means the
+ * Stream milestones observed by the pass-through meter (#16079). `null` means the
  * boundary was never observed (no such frame arrived, or the read failed
  * first) — absence is reported as absence, never as zero.
  */
@@ -84,7 +84,7 @@ export interface PassthroughStreamMilestones {
   completionMs: number | null;
 }
 
-/** What the background meter observed on the teed upstream branch. */
+/** What the background meter observed on the upstream byte path. */
 export interface PassthroughStreamTail {
   /** Last usage frame seen (OpenAI contract: the terminal frame before [DONE]). */
   usage: PassthroughUsage | null;
@@ -153,7 +153,7 @@ function roundedElapsed(now: () => number, origin: number): number {
 }
 
 /**
- * Drain one tee branch of the upstream SSE response and report what it
+ * Drain the metering channel of an upstream SSE response and report what it
  * carried. This is the billing meter, so it must never throw: a read failure
  * (client abort propagated to the upstream fetch, upstream drop) is returned
  * as `readError` with everything observed up to that point intact, and the
@@ -164,9 +164,9 @@ function roundedElapsed(now: () => number, origin: number): number {
  *
  * Milestone timestamps (#16079) are taken when a frame is PARSED, using
  * `startedAt` as the monotonic origin and the injectable `now` clock (tests
- * pin both). The tee delivers both branches at the reader's pace, so these
- * timestamps bound the upstream's frame availability; they are not proof of
- * exactly when the client branch delivered the same bytes.
+ * pin both). The route writes each chunk here before enqueueing that same chunk
+ * for the client, so these timestamps bound frame availability but are not
+ * proof of exactly when the client consumed the bytes.
  */
 export async function readPassthroughStreamTail(
   stream: ReadableStream<Uint8Array>,

--- a/packages/cloud/shared/src/lib/services/inference-passthrough.ts
+++ b/packages/cloud/shared/src/lib/services/inference-passthrough.ts
@@ -228,7 +228,6 @@ export async function readPassthroughStreamTail(
       usage?: SseUsageRecord | null;
       error?: unknown;
     };
-
     if (record.error !== undefined && record.error !== null) {
       tail.sawErrorFrame = true;
       // An error frame parsed AFTER [DONE] revokes that completion (#16079):

--- a/packages/cloud/shared/src/lib/services/inference-passthrough.ts
+++ b/packages/cloud/shared/src/lib/services/inference-passthrough.ts
@@ -74,13 +74,13 @@ export interface PassthroughUsage {
  * first) — absence is reported as absence, never as zero.
  */
 export interface PassthroughStreamMilestones {
-  /** First successfully parsed JSON `data:` frame (malformed frames and `[DONE]` do not count). */
+  /** First non-empty SSE `data:` event, even when its payload is malformed or `[DONE]`. */
   firstEventMs: number | null;
   /** First delta carrying reasoning (`reasoning`, `reasoning_content`, or `thinking`). */
   firstReasoningMs: number | null;
   /** First delta carrying visible `content` text. */
   firstContentMs: number | null;
-  /** Reader observed stream termination (upstream close or `[DONE]`). */
+  /** Provider emitted `[DONE]`; clean EOF alone is not protocol completion. */
   completionMs: number | null;
 }
 
@@ -178,7 +178,7 @@ export async function readPassthroughStreamTail(
     now?: () => number;
   } = {},
 ): Promise<PassthroughStreamTail> {
-  const now = options.now ?? performance.now;
+  const now = options.now ?? (() => performance.now());
   const startedAt = options.startedAt ?? now();
   const decoder = new TextDecoder();
   const tail: PassthroughStreamTail = {
@@ -200,6 +200,9 @@ export async function readPassthroughStreamTail(
     if (!line.startsWith("data:")) return;
     const payload = line.slice("data:".length).trim();
     if (!payload) return;
+    // The first-SSE boundary is transport-level: a malformed provider payload
+    // is still a real data event and must not disappear from latency telemetry.
+    tail.milestones.firstEventMs ??= roundedElapsed(now, startedAt);
     if (payload === "[DONE]") {
       tail.sawDone = true;
       // [DONE] IS the provider's completion marker (#16079): record it now
@@ -225,7 +228,7 @@ export async function readPassthroughStreamTail(
       usage?: SseUsageRecord | null;
       error?: unknown;
     };
-    tail.milestones.firstEventMs ??= roundedElapsed(now, startedAt);
+
     if (record.error !== undefined && record.error !== null) {
       tail.sawErrorFrame = true;
       // An error frame parsed AFTER [DONE] revokes that completion (#16079):
@@ -287,17 +290,9 @@ export async function readPassthroughStreamTail(
     }
     buffer += decoder.decode();
     if (buffer) handleLine(buffer);
-    // Normal termination (upstream close, with or without [DONE]) still counts
-    // as observed completion; abort/error paths fall through with the
-    // milestone left null so they cannot masquerade as a completed stream.
-    // `??=` — NOT assignment — so a completion already recorded at [DONE]
-    // parse time keeps the [DONE] boundary even when the provider delays the
-    // connection close after it (#16079). An in-stream SSE error frame is NOT
-    // completion: the provider reported failure mid-stream and the stream must
-    // not be recorded as if it ran to a healthy end.
-    if (tail.readError === null && !tail.sawErrorFrame) {
-      tail.milestones.completionMs ??= roundedElapsed(now, startedAt);
-    }
+    // A clean transport EOF is not the OpenAI-compatible completion boundary.
+    // Only `[DONE]` establishes protocol completion; callers classify an EOF
+    // without it as incomplete even when the stream itself closed cleanly.
   } catch (error) {
     // error-policy:J7 metering must not kill the settle chain — the route
     // observes the failure via readError and settles the delivered portion.


### PR DESCRIPTION
# Relates to

Fixes #20032. Follow-up to merged #20018 and partial progress on #16079.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Rebased onto current `origin/develop` (`bc7c4e6b5aa6e5acf0f480a35f2c33cd59916521`) with zero conflicts.
- [x] Focused stream suites, both cloud package checks, the production Worker dry-run, and `bun run verify` pass at the exact head.
- [ ] A deployed staging Worker route, billing settlement, and ring-buffer event still require explicit deployment authorization and remain merge-blocking.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Client / agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill revision: `elizaOS/eliza@35257f04a7f05e70785d7265362047026c7c4b27:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Exact repair head is rebased onto `origin/develop`.
- [x] `bun run verify` passed 351/351 workspace tasks and every repository audit.
- [ ] Recheck/rebase immediately before any authorized staging exercise or merge.

# Risks

Moderate until the staging proof is captured. This code reads the billing meter path of live provider streams, so terminal classification and backpressure affect telemetry and settlement. The repaired implementation now reads upstream only with client demand and has a slow-reader regression proving pulls remain bounded.

# Background

## What does this PR do?

- Calls the default monotonic clock through a receiver-safe closure instead of detaching `performance.now`.
- Records `firstEventMs` at the first non-empty SSE `data:` event before JSON parsing, so malformed provider payloads remain visible as transport events.
- Treats only `[DONE]` as protocol completion. Clean EOF without `[DONE]` leaves `completionMs` null and records `aborted: true`.
- Adds deterministic meter and route regressions for malformed events, `[DONE]`-only streams, clean incomplete EOF, client cancellation, and stalled-client backpressure.
- Replaces the unbounded faster `ReadableStream.tee()` meter branch with a demand-driven metering channel that preserves exact response bytes.

## What kind of change is this?

Bug fix for post-merge telemetry and billing-terminal correctness.

# Documentation changes needed?

The telemetry contract comments are updated inline. No user-facing documentation changes.

# Testing

## Where should a reviewer start?

- `packages/cloud/shared/src/lib/services/inference-passthrough.ts`
- `packages/cloud/shared/src/lib/services/__tests__/inference-passthrough-milestones.test.ts`
- `packages/cloud/api/__tests__/chat-completions-passthrough-streaming.test.ts`

## Detailed testing steps

Exact-head validation ran the 60-test focused stream matrix, cloud shared/API typechecks and lint, production Worker bundle dry-run, and the complete repository verify gate. A real Cerebras SSE stream was consumed by the exact-head meter; only the deployed staging route remains outstanding.

# Evidence Gate

<!-- evidence-head:9b1eaf2a4546ad4a78ace55a99684c2fad533813 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only Worker stream handling; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only Worker stream handling; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive UI surface.
<!-- evidence-row:backend-logs -->
- [x] [20037-pr20037-backend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20037-pr20037-backend.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser state changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, model selection, or agent behavior changed; this is transport telemetry and settlement classification.
<!-- evidence-row:domain-artifacts -->
- [x] [20037-pr20037-live-cerebras.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20037-pr20037-live-cerebras.log)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A for agent behavior: no prompt or model-selection path changed. The attached domain artifact records an exact-head real Cerebras SSE stream as transport evidence.

## Backend + frontend logs

Backend focused tests, package checks, Worker dry-run, root verification, and live provider evidence are attached. The deployed staging Worker route is pending explicit authorization and remains merge-blocking. Frontend: N/A - no frontend surface.

## Screenshots (before / after) + video walkthrough

N/A - backend-only.

## Known gaps / failures

- The backpressure blocker is resolved and covered by a stalled-reader regression.
- The exact-head local meter consumed a real Cerebras SSE stream successfully.
- A live Cloudflare staging Worker route, billing settlement, and correlated ring-buffer event are still pending because deployment requires explicit authorization.
- Keep the PR draft and do not merge until that deployed evidence is captured.

— [codex-stream-telemetry-repair]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@35257f04a7f05e70785d7265362047026c7c4b27:packages/skills/skills/contribute-to-eliza"} -->

