### PR TITLE
fix(ios): repair Screen Time report traversal and capability contract

### DIFF
--- a/packages/app-core/platforms/ios/App/App/DeviceActivityReportExtension/DeviceActivityReportExtension.swift
+++ b/packages/app-core/platforms/ios/App/App/DeviceActivityReportExtension/DeviceActivityReportExtension.swift
@@ -1,4 +1,12 @@
+/**
+ * Renders privacy-sandboxed DeviceActivity category totals inside the iOS report extension.
+ *
+ * Activity data is consumed and rendered in the extension process and must never be exported
+ * to the host application.
+ */
 import DeviceActivity
+import Foundation
+import ManagedSettings
 import SwiftUI
 
 @main
@@ -12,8 +20,13 @@ struct ElizaDeviceActivityReportExtension: DeviceActivityReportExtension {
 }
 
 private struct ElizaDeviceActivityReportConfiguration {
+    struct CategorySummary {
+        let name: String
+        let totalActivityDuration: TimeInterval
+    }
+
     let title: String
-    let message: String
+    let categorySummaries: [CategorySummary]
 }
 
 @available(iOS 16.0, *)
@@ -24,10 +37,36 @@ private struct ElizaDeviceActivityReportScene: DeviceActivityReportScene {
     func makeConfiguration(
         representing data: DeviceActivityResults<DeviceActivityData>
     ) async -> ElizaDeviceActivityReportConfiguration {
-        _ = data
+        var durationByCategory: [String: TimeInterval] = [:]
+
+        for await activityData in data {
+            for await segment in activityData.activitySegments {
+                for await categoryActivity in segment.categories {
+                    let localizedName = categoryActivity.category.localizedDisplayName?
+                        .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                    let name = localizedName.isEmpty ? "Other" : localizedName
+                    durationByCategory[name, default: 0] += categoryActivity.totalActivityDuration
+                }
+            }
+        }
+
+        let categorySummaries = durationByCategory
+            .map { name, duration in
+                ElizaDeviceActivityReportConfiguration.CategorySummary(
+                    name: name,
+                    totalActivityDuration: duration
+                )
+            }
+            .sorted { left, right in
+                if left.totalActivityDuration == right.totalActivityDuration {
+                    return left.name.localizedCaseInsensitiveCompare(right.name) == .orderedAscending
+                }
+                return left.totalActivityDuration > right.totalActivityDuration
+            }
+
         return ElizaDeviceActivityReportConfiguration(
-            title: "Screen Time",
-            message: "Screen Time activity is available for this report."
+            title: "Screen Time Summary",
+            categorySummaries: categorySummaries
         )
     }
 }
@@ -36,14 +75,39 @@ private struct ElizaDeviceActivityReportView: View {
     let configuration: ElizaDeviceActivityReportConfiguration
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 12) {
             Text(configuration.title)
                 .font(.headline)
-            Text(configuration.message)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+
+            if configuration.categorySummaries.isEmpty {
+                Text("No activity data available for this period.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(configuration.categorySummaries, id: \.name) { summary in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(summary.name)
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        Text(formatDuration(summary.totalActivityDuration))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
         }
         .padding()
+    }
+
+    private func formatDuration(_ duration: TimeInterval) -> String {
+        let wholeSeconds = max(0, Int(duration.rounded(.down)))
+        let hours = wholeSeconds / 3600
+        let minutes = (wholeSeconds % 3600) / 60
+
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        }
+        return "\(minutes)m"
     }
 }
 

--- a/plugins/plugin-native-mobile-signals/README.md
+++ b/plugins/plugin-native-mobile-signals/README.md
@@ -22,6 +22,15 @@ In browser environments a web fallback is provided using `document.visibilitySta
 | Screen time / usage | DeviceActivity + FamilyControls | `PACKAGE_USAGE_STATS` | No |
 | Background refresh | Not available (foreground monitoring only) | Not available | No |
 
+## Screen-time capability status
+
+| Capability | iOS | Android | Web |
+|---|---|---|---|
+| `reportAvailable` | `true` only when FamilyControls is authorized and the report extension is bundled | Mirrors Usage Access | `false` |
+| `coarseSummaryAvailable` | `false`; category totals render only inside Apple's privacy-sandboxed report extension | Mirrors Usage Access and the host-readable foreground-time summary | `false` |
+| `thresholdEventsAvailable` | `false` until a typed threshold is scheduled and handled | `false` | `false` |
+| `rawUsageExportAvailable` | `false`; raw per-app usage cannot leave the report extension | `false` | `false` |
+
 ## Installation
 
 ```bash

--- a/plugins/plugin-native-mobile-signals/ios/Sources/MobileSignalsHealthContract/ScreenTimeCapabilityPolicy.swift
+++ b/plugins/plugin-native-mobile-signals/ios/Sources/MobileSignalsHealthContract/ScreenTimeCapabilityPolicy.swift
@@ -1,0 +1,32 @@
+/**
+ * Defines the host-readable iOS Screen Time capability boundary without Apple-only SDK imports.
+ */
+import Foundation
+
+public struct ScreenTimeCapabilityStatus: Equatable, Sendable {
+    public let reportAvailable: Bool
+    public let coarseSummaryAvailable: Bool
+    public let thresholdEventsAvailable: Bool
+    public let rawUsageExportAvailable: Bool
+}
+
+public enum ScreenTimeCapabilityPolicy {
+    /**
+     * Computes the capabilities that the host application may truthfully consume.
+     *
+     * DeviceActivity report data remains inside the report extension. A bundled, authorized
+     * report therefore enables only the in-extension report surface. Host-readable summaries,
+     * threshold events, and raw exports remain unavailable until lawful producers exist.
+     */
+    public static func status(
+        reportExtensionAvailable: Bool,
+        authorizationStatus: String
+    ) -> ScreenTimeCapabilityStatus {
+        ScreenTimeCapabilityStatus(
+            reportAvailable: reportExtensionAvailable && authorizationStatus == "approved",
+            coarseSummaryAvailable: false,
+            thresholdEventsAvailable: false,
+            rawUsageExportAvailable: false
+        )
+    }
+}

--- a/plugins/plugin-native-mobile-signals/ios/Sources/MobileSignalsPlugin/ScreenTimeSupport.swift
+++ b/plugins/plugin-native-mobile-signals/ios/Sources/MobileSignalsPlugin/ScreenTimeSupport.swift
@@ -1,3 +1,9 @@
+/**
+ * Reports the iOS Screen Time permission and capability boundary to the Capacitor bridge.
+ *
+ * Host-readable capability flags are derived by ScreenTimeCapabilityPolicy; DeviceActivity
+ * report content remains confined to the report extension.
+ */
 import FamilyControls
 import DeviceActivity
 import Foundation
@@ -50,8 +56,10 @@ enum ScreenTimeSupport {
         let provisioningReason: Any = provisioningSatisfied
             ? NSNull()
             : (entitlementInspection.reason ?? reason)
-        let reportAvailable = extensionInspection.report && authorizationStatus == "approved"
-        let thresholdEventsAvailable = extensionInspection.monitor && authorizationStatus == "approved"
+        let capabilities = ScreenTimeCapabilityPolicy.status(
+            reportExtensionAvailable: extensionInspection.report,
+            authorizationStatus: authorizationStatus
+        )
 
         return [
             "supported": provisioningSatisfied || entitlementInspection.inspected == "not-inspectable",
@@ -86,10 +94,10 @@ enum ScreenTimeSupport {
                 "inspected": extensionInspection.inspected,
                 "bundles": extensionInspection.bundles,
             ],
-            "reportAvailable": reportAvailable,
-            "coarseSummaryAvailable": reportAvailable,
-            "thresholdEventsAvailable": thresholdEventsAvailable,
-            "rawUsageExportAvailable": false,
+            "reportAvailable": capabilities.reportAvailable,
+            "coarseSummaryAvailable": capabilities.coarseSummaryAvailable,
+            "thresholdEventsAvailable": capabilities.thresholdEventsAvailable,
+            "rawUsageExportAvailable": capabilities.rawUsageExportAvailable,
             "reason": reason,
         ]
     }

--- a/plugins/plugin-native-mobile-signals/ios/Tests/MobileSignalsHealthContractTests/ScreenTimeCapabilityPolicyTests.swift
+++ b/plugins/plugin-native-mobile-signals/ios/Tests/MobileSignalsHealthContractTests/ScreenTimeCapabilityPolicyTests.swift
@@ -1,0 +1,53 @@
+/**
+ * Verifies the deterministic iOS Screen Time capability policy without Apple framework mocks.
+ */
+import XCTest
+@testable import MobileSignalsHealthContract
+
+final class ScreenTimeCapabilityPolicyTests: XCTestCase {
+    func testAuthorizedBundledReportEnablesOnlyTheReportSurface() {
+        let status = ScreenTimeCapabilityPolicy.status(
+            reportExtensionAvailable: true,
+            authorizationStatus: "approved"
+        )
+
+        XCTAssertTrue(status.reportAvailable)
+        XCTAssertFalse(status.coarseSummaryAvailable)
+        XCTAssertFalse(status.thresholdEventsAvailable)
+        XCTAssertFalse(status.rawUsageExportAvailable)
+    }
+
+    func testReportRequiresBothAuthorizationAndTheBundledExtension() {
+        XCTAssertFalse(
+            ScreenTimeCapabilityPolicy.status(
+                reportExtensionAvailable: false,
+                authorizationStatus: "approved"
+            ).reportAvailable
+        )
+
+        for authorizationStatus in ["denied", "not-determined", "unavailable"] {
+            XCTAssertFalse(
+                ScreenTimeCapabilityPolicy.status(
+                    reportExtensionAvailable: true,
+                    authorizationStatus: authorizationStatus
+                ).reportAvailable,
+                "Unexpected report capability for \(authorizationStatus)"
+            )
+        }
+    }
+
+    func testHostReadableCapabilitiesRemainUnavailableForEveryInput() {
+        for reportExtensionAvailable in [false, true] {
+            for authorizationStatus in ["approved", "denied", "not-determined", "unavailable"] {
+                let status = ScreenTimeCapabilityPolicy.status(
+                    reportExtensionAvailable: reportExtensionAvailable,
+                    authorizationStatus: authorizationStatus
+                )
+
+                XCTAssertFalse(status.coarseSummaryAvailable)
+                XCTAssertFalse(status.thresholdEventsAvailable)
+                XCTAssertFalse(status.rawUsageExportAvailable)
+            }
+        }
+    }
+}

--- a/plugins/plugin-native-mobile-signals/src/definitions.ts
+++ b/plugins/plugin-native-mobile-signals/src/definitions.ts
@@ -117,10 +117,22 @@ export interface MobileSignalsScreenTimeStatus {
       path: string;
     }>;
   };
+  /**
+   * Whether the platform's screen-time report surface is currently usable.
+   * On iOS this means an authorized, bundled DeviceActivity report extension;
+   * on Android it means Usage Access is granted for the host summary.
+   */
   reportAvailable: boolean;
-  /** Coarse, in-extension-rendered category summaries are available (no raw export). */
+  /**
+   * Whether the host can read a coarse usage summary. This is always `false`
+   * on iOS because DeviceActivity report data stays inside the extension, but
+   * Android reports `true` after Usage Access is granted.
+   */
   coarseSummaryAvailable: boolean;
-  /** `DeviceActivityMonitor` threshold-crossing events are available. */
+  /**
+   * Whether a native producer schedules and handles typed threshold events.
+   * The current iOS, Android, and web implementations all report `false`.
+   */
   thresholdEventsAvailable: boolean;
   /**
    * Permanently `false` — a platform constraint, not a TODO. Apple's
@@ -128,7 +140,7 @@ export interface MobileSignalsScreenTimeStatus {
    * per-app usage to the host app: usage is only readable inside a rendered
    * `DeviceActivityReport` extension (never exfiltrated) plus
    * `DeviceActivityMonitor` threshold events. Host-side mobile screen-time is
-   * therefore scoped to coarse summaries + threshold events; there is no
+   * therefore scoped to the in-extension report surface only on iOS; there is no
    * macOS-style per-window dwell on iOS. See issue #9970.
    */
   rawUsageExportAvailable: false;


### PR DESCRIPTION
## Summary

Restores the corrected Screen Time implementation after #20031 was reverted by #20042, and supersedes the original #20019 implementation.

- Traverse Apple's actual `DeviceActivityData.activitySegments -> ActivitySegment.categories` shape.
- Aggregate category totals across segments and render `ActivityCategory.localizedDisplayName` inside the privacy-sandboxed report extension.
- Replace duplicated capability constants with one tested `ScreenTimeCapabilityPolicy` result consumed by the iOS bridge.
- Restore the shared TypeScript contract to `boolean` where Android legitimately reports host-readable coarse summaries after Usage Access is granted.
- Restore the removed background-refresh documentation row and document iOS, Android, and web semantics separately.

Refs #20007.

## Why this is draft

The source repair is intentionally not merge-ready. It still requires an exact-head canonical iOS simulator/Xcode build, Screen Time extension wiring validation, and current native visual/manual evidence. No local PR code was checked out or executed during this repair.

## Static verification

- `git diff --check` on exact commit `b815bd97065251fb920ffb8b89932c7ebe66f1b8`: pass
- Restacked as one commit directly on current develop 20ade92d3d8553347b2d58322ec1e9d1815888ae; the six corrected file blobs are byte-identical to the prior reviewed draft head and no unrelated files differ.
- Apple API shape checked against the official `DeviceActivityData.activitySegments`, `ActivitySegment.categories`, `CategoryActivity.category`, `CategoryActivity.totalActivityDuration`, and `ActivityCategory.localizedDisplayName` documentation.

## Required before ready

- [ ] Hosted exact-head repository validation
- [ ] `swift test` for `MobileSignalsHealthContract`
- [ ] `bun run --cwd plugins/plugin-native-mobile-signals validate:ios-screen-time`
- [ ] Canonical iOS simulator/Xcode build of the app plus report extension
- [ ] Exercise authorized data, empty data, and multi-segment aggregation in the real report extension
- [ ] Inspect current simulator screenshots/video/logs and app audit output

## Evidence

### evidence-row:before-screenshots
Pending - capture the current iOS simulator report surface before this corrective commit.

### evidence-row:after-screenshots
Pending - capture the repaired report with localized categories and the empty state on the exact built revision.

### evidence-row:walkthrough-video
Pending - record the authorized report flow and period changes on the canonical simulator build.

### evidence-row:backend-logs
N/A - this corrective PR does not change a backend path.

### evidence-row:frontend-logs
Pending - attach simulator/Xcode console logs for report extension configuration and rendering.

### evidence-row:llm-trajectory
N/A - no model, prompt, provider, action, or agent behavior changes.

### evidence-row:domain-artifacts
Pending - attach the exact-head Xcode build result and Screen Time wiring validator output.

### evidence-row:ocr-review
Pending - inspect the after screenshots for localized category labels, durations, and the designed empty state.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@35257f04a7f05e70785d7265362047026c7c4b27:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

— [codex-pr-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@35257f04a7f05e70785d7265362047026c7c4b27:packages/skills/skills/contribute-to-eliza"} -->
