### PR TITLE
fix(telegram): handle empty headers and CRLF code blocks in MarkdownV2 conversion

### DIFF
--- a/plugins/plugin-telegram/src/utils.test.ts
+++ b/plugins/plugin-telegram/src/utils.test.ts
@@ -106,12 +106,9 @@ describe("convertMarkdownToTelegram", () => {
       "```shell-session\r\n$ echo ok\r\n```",
       "```shell-session\n$ echo ok\r\n```",
     ],
-  ])(
-    "preserves CRLF fenced code with language tag %s",
-    (input, expected) => {
-      expect(convertMarkdownToTelegram(input)).toBe(expected);
-    },
-  );
+  ])("preserves CRLF fenced code with language tag %s", (input, expected) => {
+    expect(convertMarkdownToTelegram(input)).toBe(expected);
+  });
 
   it("leaves an unterminated fenced block as escaped plain text", () => {
     expect(convertMarkdownToTelegram("```c++\r\nunterminated")).toBe(
@@ -135,10 +132,7 @@ describe("convertMarkdownToTelegram", () => {
       "[deep](https://x.test/a_(b_(c)))",
       "\\[deep\\]\\(https://x\\.test/a\\_\\(b\\_\\(c\\)\\)\\)",
     ],
-    [
-      "[bad](https://x.test/a_(b)",
-      "\\[bad\\]\\(https://x\\.test/a\\_\\(b\\)",
-    ],
+    ["[bad](https://x.test/a_(b)", "\\[bad\\]\\(https://x\\.test/a\\_\\(b\\)"],
     [
       "[outer [inner]](https://x.test)",
       "\\[outer \\[inner\\]\\]\\(https://x\\.test\\)",

--- a/plugins/plugin-telegram/src/utils.test.ts
+++ b/plugins/plugin-telegram/src/utils.test.ts
@@ -106,9 +106,12 @@ describe("convertMarkdownToTelegram", () => {
       "```shell-session\r\n$ echo ok\r\n```",
       "```shell-session\n$ echo ok\r\n```",
     ],
-  ])("preserves CRLF fenced code with language tag %s", (input, expected) => {
-    expect(convertMarkdownToTelegram(input)).toBe(expected);
-  });
+  ])(
+    "preserves CRLF fenced code with language tag %s",
+    (input, expected) => {
+      expect(convertMarkdownToTelegram(input)).toBe(expected);
+    },
+  );
 
   it("leaves an unterminated fenced block as escaped plain text", () => {
     expect(convertMarkdownToTelegram("```c++\r\nunterminated")).toBe(
@@ -140,9 +143,13 @@ describe("convertMarkdownToTelegram", () => {
       "[outer [inner]](https://x.test)",
       "\\[outer \\[inner\\]\\]\\(https://x\\.test\\)",
     ],
-  ])("keeps malformed or nested link boundary %s as plain text", (input, expected) => {
-    expect(convertMarkdownToTelegram(input)).toBe(expected);
-  });
+  ])(
+    "keeps malformed or nested link boundary %s as plain text",
+    (input, expected) => {
+      expect(convertMarkdownToTelegram(input)).toBe(expected);
+    },
+  );
+
   it("resolves nested tokens (inline code inside bold/header) without leaking NUL sentinels", () => {
     const bold = convertMarkdownToTelegram("**bold `code`**");
     expect(bold).toBe("*bold `code`*");

--- a/plugins/plugin-telegram/src/utils.test.ts
+++ b/plugins/plugin-telegram/src/utils.test.ts
@@ -85,6 +85,64 @@ describe("convertMarkdownToTelegram", () => {
     );
   });
 
+  it("drops empty headings without consuming the following line", () => {
+    expect(convertMarkdownToTelegram("# ")).toBe("");
+    expect(convertMarkdownToTelegram("######\t")).toBe("");
+    expect(convertMarkdownToTelegram("before\n### \nafter")).toBe(
+      "before\n\nafter",
+    );
+  });
+
+  it.each([
+    [
+      "```c++\r\nstd::vector<int> xs;\r\n```",
+      "```c++\nstd::vector<int> xs;\r\n```",
+    ],
+    [
+      "```c#\r\nConsole.WriteLine();\r\n```",
+      "```c#\nConsole.WriteLine();\r\n```",
+    ],
+    [
+      "```shell-session\r\n$ echo ok\r\n```",
+      "```shell-session\n$ echo ok\r\n```",
+    ],
+  ])("preserves CRLF fenced code with language tag %s", (input, expected) => {
+    expect(convertMarkdownToTelegram(input)).toBe(expected);
+  });
+
+  it("leaves an unterminated fenced block as escaped plain text", () => {
+    expect(convertMarkdownToTelegram("```c++\r\nunterminated")).toBe(
+      "\\`\\`\\`c\\+\\+\r\nunterminated",
+    );
+  });
+
+  it("keeps balanced URL parentheses inside the Telegram link target", () => {
+    expect(
+      convertMarkdownToTelegram(
+        "[Test](https://en.wikipedia.org/wiki/Test_(assessment))",
+      ),
+    ).toBe("[Test](https://en.wikipedia.org/wiki/Test_(assessment\\))");
+    expect(convertMarkdownToTelegram("[x](https://x.test/a_(b)_(c))")).toBe(
+      "[x](https://x.test/a_(b\\)_(c\\))",
+    );
+  });
+
+  it.each([
+    [
+      "[deep](https://x.test/a_(b_(c)))",
+      "\\[deep\\]\\(https://x\\.test/a\\_\\(b\\_\\(c\\)\\)\\)",
+    ],
+    [
+      "[bad](https://x.test/a_(b)",
+      "\\[bad\\]\\(https://x\\.test/a\\_\\(b\\)",
+    ],
+    [
+      "[outer [inner]](https://x.test)",
+      "\\[outer \\[inner\\]\\]\\(https://x\\.test\\)",
+    ],
+  ])("keeps malformed or nested link boundary %s as plain text", (input, expected) => {
+    expect(convertMarkdownToTelegram(input)).toBe(expected);
+  });
   it("resolves nested tokens (inline code inside bold/header) without leaking NUL sentinels", () => {
     const bold = convertMarkdownToTelegram("**bold `code`**");
     expect(bold).toBe("*bold `code`*");

--- a/plugins/plugin-telegram/src/utils.ts
+++ b/plugins/plugin-telegram/src/utils.ts
@@ -87,9 +87,10 @@ export function convertMarkdownToTelegram(markdown: string): string {
   let converted = markdown;
 
   // 1. Fenced code blocks (```...```)
-  //    Matches an optional language (letters only) and then any content until the closing ```
+  //    Matches an optional language tag (allowing #, +, - for c#, c++, etc.)
+  //    and handles both LF and CRLF line endings (Windows).
   converted = converted.replace(
-    /```(\w+)?\n([\s\S]*?)```/g,
+    /```([^\s`]+)?\r?\n([\s\S]*?)```/g,
     (_match, lang, code) => {
       const escapedCode = escapeCode(code);
       const formatted = `\`\`\`${lang || ""}\n${escapedCode}\`\`\``;
@@ -105,8 +106,10 @@ export function convertMarkdownToTelegram(markdown: string): string {
   });
 
   // 3. Links: [link text](url)
+  //    URL pattern allows one level of balanced parentheses so Wikipedia-style
+  //    links like https://en.wikipedia.org/wiki/Test_(assessment) are not truncated.
   converted = converted.replace(
-    /\[([^\]]+)\]\(([^)]+)\)/g,
+    /\[([^\]]+)\]\(((?:[^()\s]|\([^)]*\))+)\)/g,
     (_match, text, url) => {
       // For link text we escape as plain text.
       const formattedText = escapePlainText(text);
@@ -173,8 +176,13 @@ export function convertMarkdownToTelegram(markdown: string): string {
   converted = converted.replace(
     /^(#{1,6})\s*(.*)$/gm,
     (_match, _hashes, headerContent: string) => {
-      // Remove any trailing whitespace and escape the header text.
-      const formatted = `*${escapePlainText(headerContent.trim())}*`;
+      const trimmed = headerContent.trim();
+      // Empty headers (e.g. "# " or "### \n") would produce "**" which
+      // Telegram rejects as "can't find end of bold entity" (HTTP 400).
+      if (!trimmed) {
+        return "";
+      }
+      const formatted = `*${escapePlainText(trimmed)}*`;
       return storeReplacement(formatted);
     },
   );

--- a/plugins/plugin-telegram/src/utils.ts
+++ b/plugins/plugin-telegram/src/utils.ts
@@ -109,7 +109,7 @@ export function convertMarkdownToTelegram(markdown: string): string {
   //    URL pattern allows one level of balanced parentheses so Wikipedia-style
   //    links like https://en.wikipedia.org/wiki/Test_(assessment) are not truncated.
   converted = converted.replace(
-    /\[([^\]]+)\]\(((?:[^()\s]|\([^)]*\))+)\)/g,
+    /\[([^\]]+)\]\(((?:[^()\s]|\([^()]*\))+)\)/g,
     (_match, text, url) => {
       // For link text we escape as plain text.
       const formattedText = escapePlainText(text);
@@ -174,7 +174,7 @@ export function convertMarkdownToTelegram(markdown: string): string {
   //    to bold text. This avoids unescaped '#' characters (which crash Telegram)
   //    by removing them and wrapping the rest of the line in bold markers.
   converted = converted.replace(
-    /^(#{1,6})\s*(.*)$/gm,
+    /^(#{1,6})[^\S\r\n]*([^\r\n]*)\r?$/gm,
     (_match, _hashes, headerContent: string) => {
       const trimmed = headerContent.trim();
       // Empty headers (e.g. "# " or "### \n") would produce "**" which


### PR DESCRIPTION
## Maintainer repair update  Updated through current `develop` (`f0462b91e7e361d4bc148adec4f83f27cdaa79e6`) at exact head `c0cc020cd62eb024489a85f55d6279ce0139ca2c`:  - bounded empty-heading whitespace to the current line so `### \nafter` cannot consume and bold `after`; - constrained the documented one-level URL grammar so deeper nesting is not partially emitted as a malformed Telegram link; - added committed regressions for empty headings and adjacent lines, CRLF fences with `c++`, `c#`, and `shell-session`, unterminated fences, balanced/sibling URL parentheses, unbalanced URLs, deeper URL nesting, and nested link-text boundaries; - corrected the full contribution skill SHA and checked the explicit N/A evidence rows.  The historical 164-test transcript below predates these committed regressions and is not current-head proof. Hosted exact-head package/root validation and a real Telegram Bot API delivery receipt remain required before merge. <!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->  # Relates to  Self-found — Telegram outbound MarkdownV2 formatting HTTP 400 rejections & CRLF code corruption in `plugins/plugin-telegram/src/utils.ts:91-98` and `173-180`.  Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).  - [x] This PR targets `develop` and is rebased onto the latest `origin/develop`       with zero conflicts (`git fetch origin && git rebase origin/develop`). - [x] `bun install` and `bun run verify` were run after sync, or any failure is       recorded below with the exact unrelated blocker. - [x] A reviewer can confirm the change works without reading the code, from the       evidence attached below.  # Contribution provenance  Declare the actual assistance used for implementation and review. This is self-reported provenance, not a request for chain-of-thought. Never include prompts containing secrets, tokens, private session IDs, or hidden reasoning. Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific enough. Human-only work must say so explicitly.  The row labels below must **not** reuse the terminal eliza.army footer labels (`Client / agent tooling`, `Skill revision` / `Contribution skill revision`, `Attribution status`). Duplicating those strings makes the scoring validator reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->` markers; only the human-readable prefixes changed. After filling these rows, append the standard footer once at the end of the PR body (do not repeat the visible footer lines here).  <!-- contribution-attribution:v1 --> <!-- attribution-row:ai-assistance --> - AI assistance: `yes` <!-- attribution-row:models --> - Model(s) used: `anthropic/claude-fable-5` <!-- attribution-row:client --> - Agent tooling: `claude-code` <!-- attribution-row:skill-revision --> - Skill path: `elizaOS/eliza@f0462b91e7e361d4bc148adec4f83f27cdaa79e6:packages/skills/skills/contribute-to-eliza` <!-- attribution-row:status --> - Provenance status: `self-reported`  # Sync with develop  - [x] Rebased/merged onto the latest `origin/develop`; zero conflicts. - [x] `bun run verify` passes post-sync, or the exact unrelated blocker is       documented in **Known gaps / failures** below.  Updated at `f0462b9` (`Merge pull request #20114 from elizaOS/docs/issue-20092-rate-limit-guidance`): close account limit snapshot residuals (#20065)`): ``` $ git log -n 1 --oneline 18edba38bb fix(cloud): close account limit snapshot residuals (#20065) $ git status On branch fix/telegram-markdown-crlf nothing to commit, working tree clean ```  # Risks  Low. Three minimal regex/header fixes in the pure function `convertMarkdownToTelegram` with no external dependencies. Code fence pattern broadens `\n` to `\r?\n` and `\w+` to `[^\s`]+` to cover CRLF and language tags like `c++`, `c#`, `shell-session` — existing LF + `\w` inputs still match. Link pattern adds one level of balanced parentheses for Wikipedia-style URLs — plain URLs unaffected. Empty header guard returns `""` instead of `"**"` which was previously an HTTP 400. All 164 existing plugin-telegram tests continue to pass; no public API change.  # Background  ## What does this PR do?  Fixes three Telegram Bot API HTTP 400 rejections / corruption bugs in `plugins/plugin-telegram/src/utils.ts:convertMarkdownToTelegram`:  1. **Empty headers produce `**`** — `convertMarkdownToTelegram` replaces headers with `*${headerContent.trim()}*`. An empty header line `# ` or `### \n` yields `**`, which Telegram rejects as `can't parse entities: can't find end of bold entity`. Fix: trim-check and return `""` for empty header content.  2. **CRLF & language tags in code blocks** — regex ` ```(\w+)?\n` requires `\n` immediately after `(\w+)?` — on Windows CRLF (`\r\n`) or language tags containing `#`, `+`, `-` (`c++`, `c#`, `shell-session`) the fence is not recognized and falls through to plain-text escaping, corrupting the block. Fix: ` ```([^\s`]+)?\r?\n`.  3. **URLs with parentheses truncated** — `\[([^\]]+)\]\(([^)]+)\)` stops at the first `)`, truncating `https://en.wikipedia.org/wiki/Test_(assessment)`. Fix: `\[([^\]]+)\]\(((?:[^()\s]|\([^)]*\))+\))` allowing one level of balanced parentheses.  ```diff - /```(\w+)?\n([\s\S]*?)```/g + /```([^\s`]+)?\r?\n([\s\S]*?)```/g  - /\[([^\]]+)\]\(([^)]+)\)/g + /\[([^\]]+)\]\(((?:[^()\s]|\([^)]*\))+)\)/g  - const formatted = `*${escapePlainText(headerContent.trim())}*`; + const trimmed = headerContent.trim(); + if (!trimmed) return ""; + const formatted = `*${escapePlainText(trimmed)}*`; ```  ## What kind of change is this?  Bug fixes (non-breaking change which fixes an issue)  # Documentation changes needed?  My changes do not require a change to the project documentation.  # Testing  ## Where should a reviewer start?  `plugins/plugin-telegram/src/utils.ts` around lines 85–110 (code fence regex) and 175–190 (header handling), plus `plugins/plugin-telegram/src/utils.test.ts`.  ## Detailed testing steps  1. `bun run --cwd plugins/plugin-telegram test` — all 164 tests pass (21 files). 2. Manual regression checks (reproduced via Node `require` of built `dist`):    - `convertMarkdownToTelegram("# ")` → `""` (was `"**"` → HTTP 400)    - `` convertMarkdownToTelegram("```c++\r\ncode\r\n```") `` → preserves fence (was corrupted)    - `convertMarkdownToTelegram("[Test](https://en.wikipedia.org/wiki/Test_(assessment))")` → `"[Test](https://en.wikipedia.org/wiki/Test_(assessment\\))"` (Telegram escapes the inner URL closing parenthesis; the old converter truncated it)    - `convertMarkdownToTelegram("[docs](http://x.com)")` → unchanged (no regression)  # Evidence Gate  Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows` sets this marker from the live PR head; rerun it after every push. <!-- evidence-head:d7e7d0a7b2ea08f462b8ce80ba4aff8f34496d4d -->  Any change testable on the frontend is not mergeable without a video walkthrough, before/after screenshots, and logs. If you did not attach them, say why.  Attach each applicable artifact **inline in this PR** (drag-and-drop into the description or a comment), or write `N/A - <reason>` on the row. Do not leave evidence rows blank. Videos must be **MP4** (GitHub renders them inline); prefer **JPG over PNG** for screenshots. Do not commit evidence files to the repo.  <!-- evidence-row:before-screenshots -->
- [x] N/A - backend Telegram MarkdownV2 converter; no rendered app UI source changed

<!-- evidence-row:after-screenshots -->
- [x] N/A - backend Telegram MarkdownV2 converter; no rendered app UI source changed

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no app UI flow; live Telegram delivery remains an explicit gap

<!-- evidence-row:backend-logs -->
- [x] N/A - exact-head Bot API receipt unavailable without a configured private test chat

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend source or browser request path changed

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [20046-pr20046-validation.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20046-pr20046-validation.txt)

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered app visual surface or visual text changed

