### PR TITLE
fix(core,agent): keep the runtime's own trigger entities out of the owner-disclosure census

### DIFF
--- a/packages/agent/src/triggers/runtime.ts
+++ b/packages/agent/src/triggers/runtime.ts
@@ -480,6 +480,37 @@ async function dispatchPrompt(
       userName: "trigger",
       source: room?.source ?? MESSAGE_SOURCE_TRIGGER_PROMPT,
     });
+    // Self-certifying provenance for the owner-exclusive disclosure census
+    // (#19999): the synthetic author stays a durable room participant after
+    // this turn, so the census must be able to verify — not trust — that it is
+    // runtime-made. The marker holds the triggerId whose hash IS this entity's
+    // id; connector-minted entities derive their ids differently and cannot
+    // reproduce the relationship.
+    try {
+      const authorEntity = await runtime.getEntityById(entityId);
+      const marker = (
+        authorEntity?.metadata as
+          | { triggerEntity?: { triggerId?: unknown } }
+          | undefined
+      )?.triggerEntity;
+      if (authorEntity && marker?.triggerId !== trigger.triggerId) {
+        await runtime.updateEntity({
+          ...authorEntity,
+          metadata: {
+            ...authorEntity.metadata,
+            triggerEntity: { triggerId: trigger.triggerId },
+          },
+        });
+      }
+    } catch (err) {
+      // error-policy:J7 a failed marker write must not block the fire; the
+      // census then keeps this participant and the disclosure gate stays
+      // strict until a later fire re-stamps it.
+      runtime.reportError("TriggerRuntime.entityProvenanceMarker", err, {
+        triggerId: trigger.triggerId,
+        entityId,
+      });
+    }
     const releaseInternalActor = registerRuntimeManagedInternalActor(
       runtime,
       entityId,

--- a/packages/core/src/security/trusted-delivery-audience.test.ts
+++ b/packages/core/src/security/trusted-delivery-audience.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { IAgentRuntime, Memory, Room, UUID } from "../types";
 import { ChannelType } from "../types";
+import { stringToUuid } from "../utils";
 import {
 	attestAuthenticatedApiDeliveryAudience,
 	attestDeliveryAudienceFromCanonicalRoom,
@@ -394,5 +395,138 @@ describe("trusted delivery audience", () => {
 				code: "DELIVERY_AUDIENCE_LOOKUP_FAILED",
 			}),
 		);
+	});
+});
+
+describe("runtime-internal participant census (#19999)", () => {
+	const TRIGGER_ID = "39f2604e-4d3c-4ab3-94c0-ba6e85fe70cb";
+	const TRIGGER_ENTITY = stringToUuid(`trigger-entity:${TRIGGER_ID}`);
+
+	function censusHarness(entities: Map<UUID, { metadata?: unknown }>): {
+		runtime: IAgentRuntime;
+		getEntityById: ReturnType<typeof vi.fn>;
+		setParticipants: (next: UUID[]) => void;
+	} {
+		let participants: UUID[] = [OWNER, AGENT];
+		const getEntityById = vi.fn(async (id: UUID) => {
+			const entry = entities.get(id);
+			if (!entry) {
+				throw new Error(`no entity ${id}`);
+			}
+			return { id, ...entry };
+		});
+		const runtime = {
+			agentId: AGENT,
+			getRoom: vi.fn(async () => ({
+				id: ROOM,
+				agentId: AGENT,
+				type: ChannelType.DM,
+				source: "test",
+			})),
+			getParticipantsForRoom: vi.fn(async () => [...participants]),
+			getEntityById,
+			getSetting: vi.fn((key: string) =>
+				key === "ELIZA_ADMIN_ENTITY_ID" ? OWNER : undefined,
+			),
+			reportError: vi.fn(),
+			logger: {
+				debug: vi.fn(),
+				info: vi.fn(),
+				warn: vi.fn(),
+				error: vi.fn(),
+			},
+		} as unknown as IAgentRuntime;
+		return {
+			runtime,
+			getEntityById,
+			setParticipants: (next) => {
+				participants = next;
+			},
+		};
+	}
+
+	it("a self-certified trigger entity is excluded and owner disclosure survives a fired reminder", async () => {
+		const { runtime, setParticipants } = censusHarness(
+			new Map([
+				[
+					TRIGGER_ENTITY,
+					{ metadata: { triggerEntity: { triggerId: TRIGGER_ID } } },
+				],
+			]),
+		);
+		setParticipants([OWNER, AGENT, TRIGGER_ENTITY]);
+		const turn = message();
+		await attestAuthenticatedApiDeliveryAudience(runtime, turn, {
+			kind: "owner_api_token",
+			principalId: "owner-token",
+		});
+		expect(evaluateOwnerExclusiveDisclosure(turn)).toMatchObject({
+			allowed: true,
+		});
+	});
+
+	it("a forged marker whose triggerId does not hash to the entity id keeps the participant and fails closed", async () => {
+		const { runtime, setParticipants } = censusHarness(
+			new Map([
+				// GUEST claims to be a trigger entity, but no triggerId hashes to
+				// GUEST's id — the census must not take the metadata's word for it.
+				[GUEST, { metadata: { triggerEntity: { triggerId: TRIGGER_ID } } }],
+			]),
+		);
+		setParticipants([OWNER, AGENT, GUEST]);
+		const turn = message();
+		await attestAuthenticatedApiDeliveryAudience(runtime, turn, {
+			kind: "owner_api_token",
+			principalId: "owner-token",
+		});
+		expect(evaluateOwnerExclusiveDisclosure(turn)).toMatchObject({
+			allowed: false,
+			reason: "participant_mismatch",
+		});
+	});
+
+	it("entity lookup failures keep the participant and the gate fails closed", async () => {
+		const { runtime, setParticipants } = censusHarness(new Map());
+		setParticipants([OWNER, AGENT, TRIGGER_ENTITY]);
+		const turn = message();
+		await attestAuthenticatedApiDeliveryAudience(runtime, turn, {
+			kind: "owner_api_token",
+			principalId: "owner-token",
+		});
+		expect(evaluateOwnerExclusiveDisclosure(turn)).toMatchObject({
+			allowed: false,
+			reason: "participant_mismatch",
+		});
+	});
+
+	it("two-participant rooms never pay for entity lookups", async () => {
+		const { runtime, getEntityById } = censusHarness(new Map());
+		const turn = message();
+		await attestAuthenticatedApiDeliveryAudience(runtime, turn, {
+			kind: "owner_api_token",
+			principalId: "owner-token",
+		});
+		expect(getEntityById).not.toHaveBeenCalled();
+		expect(evaluateOwnerExclusiveDisclosure(turn)).toMatchObject({
+			allowed: true,
+		});
+	});
+
+	it("a registered runtime-managed internal actor is excluded without a marker", async () => {
+		const { runtime, setParticipants } = censusHarness(new Map());
+		setParticipants([OWNER, AGENT, GUEST]);
+		const release = registerRuntimeManagedInternalActor(runtime, GUEST);
+		try {
+			const turn = message();
+			await attestAuthenticatedApiDeliveryAudience(runtime, turn, {
+				kind: "owner_api_token",
+				principalId: "owner-token",
+			});
+			expect(evaluateOwnerExclusiveDisclosure(turn)).toMatchObject({
+				allowed: true,
+			});
+		} finally {
+			release();
+		}
 	});
 });

--- a/packages/core/src/security/trusted-delivery-audience.test.ts
+++ b/packages/core/src/security/trusted-delivery-audience.test.ts
@@ -512,6 +512,28 @@ describe("runtime-internal participant census (#19999)", () => {
 		});
 	});
 
+	it("execution-time revalidation applies the same census filter as attestation", async () => {
+		const { runtime, setParticipants } = censusHarness(
+			new Map([
+				[
+					TRIGGER_ENTITY,
+					{ metadata: { triggerEntity: { triggerId: TRIGGER_ID } } },
+				],
+			]),
+		);
+		setParticipants([OWNER, AGENT, TRIGGER_ENTITY]);
+		const turn = message();
+		await attestAuthenticatedApiDeliveryAudience(runtime, turn, {
+			kind: "owner_api_token",
+			principalId: "owner-token",
+		});
+		// Without the revalidation-side filter this fails audience_changed: the
+		// attested census is filtered while the recheck would see the raw room.
+		await expect(
+			revalidateOwnerExclusiveDisclosure(runtime, turn),
+		).resolves.toMatchObject({ allowed: true });
+	});
+
 	it("a registered runtime-managed internal actor is excluded without a marker", async () => {
 		const { runtime, setParticipants } = censusHarness(new Map());
 		setParticipants([OWNER, AGENT, GUEST]);

--- a/packages/core/src/security/trusted-delivery-audience.test.ts
+++ b/packages/core/src/security/trusted-delivery-audience.test.ts
@@ -405,9 +405,13 @@ describe("runtime-internal participant census (#19999)", () => {
 	function censusHarness(entities: Map<UUID, { metadata?: unknown }>): {
 		runtime: IAgentRuntime;
 		getEntityById: ReturnType<typeof vi.fn>;
+		reportError: ReturnType<typeof vi.fn>;
+		setType: (next: ChannelType) => void;
 		setParticipants: (next: UUID[]) => void;
 	} {
+		let roomType = ChannelType.DM;
 		let participants: UUID[] = [OWNER, AGENT];
+		const reportError = vi.fn();
 		const getEntityById = vi.fn(async (id: UUID) => {
 			const entry = entities.get(id);
 			if (!entry) {
@@ -420,7 +424,7 @@ describe("runtime-internal participant census (#19999)", () => {
 			getRoom: vi.fn(async () => ({
 				id: ROOM,
 				agentId: AGENT,
-				type: ChannelType.DM,
+				type: roomType,
 				source: "test",
 			})),
 			getParticipantsForRoom: vi.fn(async () => [...participants]),
@@ -428,7 +432,7 @@ describe("runtime-internal participant census (#19999)", () => {
 			getSetting: vi.fn((key: string) =>
 				key === "ELIZA_ADMIN_ENTITY_ID" ? OWNER : undefined,
 			),
-			reportError: vi.fn(),
+			reportError,
 			logger: {
 				debug: vi.fn(),
 				info: vi.fn(),
@@ -439,6 +443,10 @@ describe("runtime-internal participant census (#19999)", () => {
 		return {
 			runtime,
 			getEntityById,
+			reportError,
+			setType: (next) => {
+				roomType = next;
+			},
 			setParticipants: (next) => {
 				participants = next;
 			},
@@ -485,8 +493,8 @@ describe("runtime-internal participant census (#19999)", () => {
 		});
 	});
 
-	it("entity lookup failures keep the participant and the gate fails closed", async () => {
-		const { runtime, setParticipants } = censusHarness(new Map());
+	it("entity lookup failures are reported, keep the participant, and fail closed", async () => {
+		const { runtime, reportError, setParticipants } = censusHarness(new Map());
 		setParticipants([OWNER, AGENT, TRIGGER_ENTITY]);
 		const turn = message();
 		await attestAuthenticatedApiDeliveryAudience(runtime, turn, {
@@ -496,6 +504,33 @@ describe("runtime-internal participant census (#19999)", () => {
 		expect(evaluateOwnerExclusiveDisclosure(turn)).toMatchObject({
 			allowed: false,
 			reason: "participant_mismatch",
+		});
+		expect(reportError).toHaveBeenCalledTimes(1);
+		expect(reportError).toHaveBeenCalledWith(
+			"TrustedDeliveryAudience.filterRuntimeInternalParticipants",
+			expect.objectContaining({
+				code: "DELIVERY_AUDIENCE_ENTITY_LOOKUP_FAILED",
+			}),
+		);
+	});
+
+	it("a large non-owner group turn performs no participant entity reads", async () => {
+		const { runtime, getEntityById, setParticipants, setType } = censusHarness(
+			new Map(),
+		);
+		setType(ChannelType.GROUP);
+		setParticipants([
+			AGENT,
+			OWNER,
+			...Array.from({ length: 1_000 }, (_, index) =>
+				stringToUuid(`large-group-participant:${index}`),
+			),
+		]);
+		const turn = message({ entityId: GUEST });
+		await attestDeliveryAudienceFromCanonicalRoom(runtime, turn);
+		expect(getEntityById).not.toHaveBeenCalled();
+		expect(evaluateOwnerExclusiveDisclosure(turn)).toMatchObject({
+			allowed: false,
 		});
 	});
 

--- a/packages/core/src/security/trusted-delivery-audience.ts
+++ b/packages/core/src/security/trusted-delivery-audience.ts
@@ -196,33 +196,33 @@ function normalizeTtlMs(ttlMs: number | undefined): number {
 }
 
 /**
- * Drop the runtime's own synthetic actors from a room's participant census
- * before it becomes audience evidence. Trigger fires join their per-trigger
- * entity (`stringToUuid("trigger-entity:" + triggerId)`) to the originating
- * room as a durable participant, so the first reminder that fires in an owner
- * DM permanently inflates the census past two and kills owner-exclusive
- * disclosure there (#19999). Exclusion is self-certifying, never name-based:
- * an entity is dropped only when its stored `metadata.triggerEntity.triggerId`
- * recomputes to its own id (connector-minted entities derive their ids
- * differently and cannot write this metadata), or when it is registered as a
- * runtime-managed internal actor in this process. Entity lookups that fail
- * keep the participant — the gate fails closed. Rooms already at two
- * participants skip the lookup entirely.
+ * Drop the runtime's own synthetic actors from a disclosure candidate's
+ * participant census before it becomes audience evidence. Trigger fires join
+ * their per-trigger entity (`stringToUuid("trigger-entity:" + triggerId)`) to
+ * the originating room as a durable participant. Persisted marker reads are
+ * enabled only for an owner-private candidate; shared and external turns can
+ * never pass this gate and must not pay one entity read per room member.
+ * Exclusion is self-certifying, never name-based. An unreadable entity stays
+ * in the census and the storage failure is reported, so the gate fails closed.
  */
 async function filterRuntimeInternalParticipants(
 	runtime: IAgentRuntime,
 	participants: readonly UUID[],
+	verifyPersistedMarkers: boolean,
 ): Promise<UUID[]> {
-	if (participants.length <= 2) {
-		return [...participants];
+	const processLocalFiltered = participants.filter(
+		(participantId) =>
+			participantId === runtime.agentId ||
+			!isRuntimeManagedInternalActor(runtime, participantId),
+	);
+	if (!verifyPersistedMarkers || processLocalFiltered.length <= 2) {
+		return processLocalFiltered;
 	}
+	const lookupFailures: unknown[] = [];
 	const kept = await Promise.all(
-		participants.map(async (participantId) => {
+		processLocalFiltered.map(async (participantId) => {
 			if (participantId === runtime.agentId) {
 				return participantId;
-			}
-			if (isRuntimeManagedInternalActor(runtime, participantId)) {
-				return null;
 			}
 			try {
 				const entity = await runtime.getEntityById(participantId);
@@ -238,14 +238,27 @@ async function filterRuntimeInternalParticipants(
 				) {
 					return null;
 				}
-			} catch {
-				// error-policy:J3 an unreadable entity stays in the census; the
-				// disclosure gate then fails closed on the inflated count rather
-				// than opening on unverified membership.
+			} catch (cause) {
+				lookupFailures.push(cause);
 			}
 			return participantId;
 		}),
 	);
+	if (lookupFailures.length > 0) {
+		// error-policy:J4 an entity-storage failure keeps every unreadable
+		// participant and degrades owner-private surfaces to unavailable.
+		runtime.reportError(
+			"TrustedDeliveryAudience.filterRuntimeInternalParticipants",
+			new ElizaError(
+				"Could not verify runtime-internal delivery-audience participants.",
+				{
+					code: "DELIVERY_AUDIENCE_ENTITY_LOOKUP_FAILED",
+					cause: lookupFailures[0],
+					context: { failureCount: lookupFailures.length },
+				},
+			),
+		);
+	}
 	return kept.filter((id): id is UUID => id !== null);
 }
 
@@ -391,12 +404,18 @@ export async function attestDeliveryAudienceFromCanonicalRoom(
 		runtime.getParticipantsForRoom(message.roomId),
 		resolveCanonicalOwnerIdForMessage(runtime, message),
 	]);
+	const kind = classifyCanonicalRoom(room?.type);
+	const ownerPrivateCandidate =
+		canonicalOwnerEntityId !== null &&
+		message.entityId === canonicalOwnerEntityId &&
+		(kind === "direct" || kind === "voice_private");
 	const participants = await filterRuntimeInternalParticipants(
 		runtime,
 		rawParticipants,
+		ownerPrivateCandidate,
 	);
 	const audience = createAudience({
-		kind: classifyCanonicalRoom(room?.type),
+		kind,
 		provenance: "canonical_room",
 		actorEntityId: message.entityId,
 		canonicalOwnerEntityId,
@@ -426,12 +445,17 @@ export async function attestAuthenticatedApiDeliveryAudience(
 		resolveCanonicalOwnerIdForMessage(runtime, message),
 		runtime.getParticipantsForRoom(message.roomId),
 	]);
+	const ownerPrincipal =
+		principal.kind === "owner_session" || principal.kind === "owner_api_token";
+	const ownerPrivateCandidate =
+		ownerPrincipal &&
+		canonicalOwnerEntityId !== null &&
+		message.entityId === canonicalOwnerEntityId;
 	const participants = await filterRuntimeInternalParticipants(
 		runtime,
 		rawParticipants,
+		ownerPrivateCandidate,
 	);
-	const ownerPrincipal =
-		principal.kind === "owner_session" || principal.kind === "owner_api_token";
 	const audience = createAudience({
 		kind: ownerPrincipal ? "api_private" : "api_external",
 		provenance: ownerPrincipal ? "authenticated_owner_api" : "service_gateway",
@@ -663,6 +687,7 @@ export async function revalidateOwnerExclusiveDisclosure(
 		const participants = await filterRuntimeInternalParticipants(
 			runtime,
 			rawParticipants,
+			initial.basis === OWNER_PRIVATE_DESTINATION_DISCLOSURE_BASIS,
 		);
 		const room =
 			initial.audience.provenance === "canonical_room"

--- a/packages/core/src/security/trusted-delivery-audience.ts
+++ b/packages/core/src/security/trusted-delivery-audience.ts
@@ -22,6 +22,7 @@
 
 import { ElizaError } from "../errors";
 import { resolveCanonicalOwnerIdForMessage } from "../roles";
+import { stringToUuid } from "../utils";
 import type { DisclosureGate } from "../types/components";
 import type { Memory } from "../types/memory";
 import { ChannelType, type UUID } from "../types/primitives";
@@ -194,6 +195,60 @@ function normalizeTtlMs(ttlMs: number | undefined): number {
 	return Math.floor(ttlMs);
 }
 
+/**
+ * Drop the runtime's own synthetic actors from a room's participant census
+ * before it becomes audience evidence. Trigger fires join their per-trigger
+ * entity (`stringToUuid("trigger-entity:" + triggerId)`) to the originating
+ * room as a durable participant, so the first reminder that fires in an owner
+ * DM permanently inflates the census past two and kills owner-exclusive
+ * disclosure there (#19999). Exclusion is self-certifying, never name-based:
+ * an entity is dropped only when its stored `metadata.triggerEntity.triggerId`
+ * recomputes to its own id (connector-minted entities derive their ids
+ * differently and cannot write this metadata), or when it is registered as a
+ * runtime-managed internal actor in this process. Entity lookups that fail
+ * keep the participant — the gate fails closed. Rooms already at two
+ * participants skip the lookup entirely.
+ */
+async function filterRuntimeInternalParticipants(
+	runtime: IAgentRuntime,
+	participants: readonly UUID[],
+): Promise<UUID[]> {
+	if (participants.length <= 2) {
+		return [...participants];
+	}
+	const kept = await Promise.all(
+		participants.map(async (participantId) => {
+			if (participantId === runtime.agentId) {
+				return participantId;
+			}
+			if (isRuntimeManagedInternalActor(runtime, participantId)) {
+				return null;
+			}
+			try {
+				const entity = await runtime.getEntityById(participantId);
+				const marker = (
+					entity?.metadata as
+						| { triggerEntity?: { triggerId?: unknown } }
+						| undefined
+				)?.triggerEntity;
+				if (
+					typeof marker?.triggerId === "string" &&
+					marker.triggerId.length > 0 &&
+					stringToUuid(`trigger-entity:${marker.triggerId}`) === participantId
+				) {
+					return null;
+				}
+			} catch {
+				// error-policy:J3 an unreadable entity stays in the census; the
+				// disclosure gate then fails closed on the inflated count rather
+				// than opening on unverified membership.
+			}
+			return participantId;
+		}),
+	);
+	return kept.filter((id): id is UUID => id !== null);
+}
+
 function canonicalParticipants(participants: readonly UUID[]): UUID[] {
 	return [
 		...new Set(participants.filter((id) => typeof id === "string" && id)),
@@ -331,11 +386,15 @@ export async function attestDeliveryAudienceFromCanonicalRoom(
 	options: { nowMs?: number; ttlMs?: number } = {},
 ): Promise<TrustedDeliveryAudience> {
 	const nowMs = options.nowMs ?? Date.now();
-	const [room, participants, canonicalOwnerEntityId] = await Promise.all([
+	const [room, rawParticipants, canonicalOwnerEntityId] = await Promise.all([
 		runtime.getRoom(message.roomId),
 		runtime.getParticipantsForRoom(message.roomId),
 		resolveCanonicalOwnerIdForMessage(runtime, message),
 	]);
+	const participants = await filterRuntimeInternalParticipants(
+		runtime,
+		rawParticipants,
+	);
 	const audience = createAudience({
 		kind: classifyCanonicalRoom(room?.type),
 		provenance: "canonical_room",
@@ -363,10 +422,14 @@ export async function attestAuthenticatedApiDeliveryAudience(
 	options: { nowMs?: number; ttlMs?: number } = {},
 ): Promise<TrustedDeliveryAudience> {
 	const nowMs = options.nowMs ?? Date.now();
-	const [canonicalOwnerEntityId, participants] = await Promise.all([
+	const [canonicalOwnerEntityId, rawParticipants] = await Promise.all([
 		resolveCanonicalOwnerIdForMessage(runtime, message),
 		runtime.getParticipantsForRoom(message.roomId),
 	]);
+	const participants = await filterRuntimeInternalParticipants(
+		runtime,
+		rawParticipants,
+	);
 	const ownerPrincipal =
 		principal.kind === "owner_session" || principal.kind === "owner_api_token";
 	const audience = createAudience({

--- a/packages/core/src/security/trusted-delivery-audience.ts
+++ b/packages/core/src/security/trusted-delivery-audience.ts
@@ -210,12 +210,15 @@ async function filterRuntimeInternalParticipants(
 	participants: readonly UUID[],
 	verifyPersistedMarkers: boolean,
 ): Promise<UUID[]> {
+	if (!verifyPersistedMarkers) {
+		return [...participants];
+	}
 	const processLocalFiltered = participants.filter(
 		(participantId) =>
 			participantId === runtime.agentId ||
 			!isRuntimeManagedInternalActor(runtime, participantId),
 	);
-	if (!verifyPersistedMarkers || processLocalFiltered.length <= 2) {
+	if (processLocalFiltered.length <= 2) {
 		return processLocalFiltered;
 	}
 	const lookupFailures: unknown[] = [];

--- a/packages/core/src/security/trusted-delivery-audience.ts
+++ b/packages/core/src/security/trusted-delivery-audience.ts
@@ -22,11 +22,11 @@
 
 import { ElizaError } from "../errors";
 import { resolveCanonicalOwnerIdForMessage } from "../roles";
-import { stringToUuid } from "../utils";
 import type { DisclosureGate } from "../types/components";
 import type { Memory } from "../types/memory";
 import { ChannelType, type UUID } from "../types/primitives";
 import type { IAgentRuntime } from "../types/runtime";
+import { stringToUuid } from "../utils";
 
 const trustedDeliveryAudienceBrand: unique symbol = Symbol(
 	"eliza.trusted-delivery-audience.brand",
@@ -653,10 +653,17 @@ export async function revalidateOwnerExclusiveDisclosure(
 	if (!initial.allowed) return initial;
 
 	try {
-		const [participants, canonicalOwnerEntityId] = await Promise.all([
+		const [rawParticipants, canonicalOwnerEntityId] = await Promise.all([
 			runtime.getParticipantsForRoom(message.roomId),
 			resolveCanonicalOwnerIdForMessage(runtime, message),
 		]);
+		// The attested census excluded runtime-internal synthetic actors, so the
+		// revalidation must compare like with like — otherwise a room that ever
+		// hosted a trigger fire flips every later check to audience_changed.
+		const participants = await filterRuntimeInternalParticipants(
+			runtime,
+			rawParticipants,
+		);
 		const room =
 			initial.audience.provenance === "canonical_room"
 				? await runtime.getRoom(message.roomId)


### PR DESCRIPTION
Closes #19999 (launch-critical). Built under nubs's production-go directive; **security-surface review requested from gauss before merge** — this touches the owner-privacy boundary.

## Defect
A trigger fire joins its synthetic per-trigger author entity (`stringToUuid("trigger-entity:" + triggerId)`) to the originating room as a durable participant. The owner-exclusive disclosure gate requires exactly two participants (owner + agent), so **the first reminder that fires in an owner DM permanently kills every owner-life tool in that room** from the next turn on. Live-diagnosed via the #20001 rejection observability: `Owner-private disclosure denied: participant_mismatch` on every owner candidate after the fire; two orphaned trigger entities ("flip the record", "sip water") were inflating the census on the nubilio box.

## Fix — self-certifying census exclusion, fail-closed
1. **Attestation** (`filterRuntimeInternalParticipants`): a participant is dropped from the census only when its stored `metadata.triggerEntity.triggerId` **recomputes to its own entity id** (connector-minted entities derive ids differently and cannot write this metadata), or when it is registered as a runtime-managed internal actor in-process (the autonomy-entity class). Entity lookups that fail keep the participant — the gate fails closed. Rooms already at two participants skip the lookup entirely (the common case pays nothing).
2. **Execution-time revalidation** applies the same filter — otherwise the filtered attestation never matches the raw recheck and every execution dies `audience_changed` (found live; pinned by test).
3. **Trigger runtime** stamps the marker at fire time (J7 on failure: the fire proceeds and the gate stays strict until re-stamped).

## Security analysis
- **Never name-based**: a user named "trigger" is NOT excluded; forging the exclusion requires an entity whose UUID equals `stringToUuid("trigger-entity:" + X)` for an X the attacker can also write into that entity's runtime-managed metadata — connector entity creation can do neither. An adversarial test pins the forged-marker case (marker present, hash mismatch → participant kept → `participant_mismatch`).
- Fail-closed everywhere: lookup errors, missing markers, and unverifiable ids all keep the participant and keep the gate strict.

## Evidence (live nubilio box, poisoned room `ade45c15…`)
| | |
|---|---|
| before | owner tools dead since the 10:23Z fire: tierA never contains OWNER_*; `participant_mismatch` on every owner candidate; census debug showed 4 raw participants incl. both orphaned trigger entities |
| after commit 1 | exposure restored (tierA=[OWNER_TODOS…]) but execution failed `audience_changed` — the revalidation gap, now commit 2 |
| after commit 2 | **full resurrection**: `list my goals` → OWNER_GOALS_REVIEW success:true → "one goal. learn spanish needs attention." — data intact, honest read, in the exact room that was dead all morning |
| tests | trusted-delivery-audience.test.ts 27/27 (6 new: self-certified exclusion, forged marker, lookup failure, ≤2 fast path, registry exclusion, revalidation parity); agent triggers/runtime.test.ts 27/27 |
| cleanup | already-orphaned entities (deleted triggers) were marked via a stopped-bot single-client metadata backfill using their log-recovered triggerIds — the same self-certifying shape; a general backfill utility can follow if wanted |

## Reviewer repair (a476a27)
- Persisted trigger-marker reads now run only for canonical owner DM/voice-private candidates and authenticated owner API candidates. Shared/group/channel and service-gateway turns retain the raw census and perform zero per-member entity reads.
- Marker lookup failures retain unreadable participants, report one structured `DELIVERY_AUDIENCE_ENTITY_LOOKUP_FAILED` diagnostic per filtering pass, and therefore keep the disclosure gate closed.
- Added a 1,000-participant non-owner group regression proving zero `getEntityById` calls, plus an explicit failure/reporting/participant-retention security regression.
- Hosted exact-head CI and Tests are linked in the handoff comment. Merge remains blocked on terminal green gates and independent security approval.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@35257f04a7f05e70785d7265362047026c7c4b27:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-pr-repair]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@35257f04a7f05e70785d7265362047026c7c4b27:packages/skills/skills/contribute-to-eliza"} -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:fc88dd7b24d426fc228478a148ed5d67a8daa84e -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI surface; disclosure-gate behavior proven by trajectories and gate logs

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - single-turn gate behavior

<!-- evidence-row:backend-logs -->
- [ ] N/A - gate rejection lines quoted in PR body (participant_mismatch via #20001 observability; audience_changed at the revalidation seam)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend in the changed path

<!-- evidence-row:llm-trajectory -->
- [x] [20049-trajectory-before-after.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20049-trajectory-before-after.json)

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - domain proof is the resurrection read in the previously poisoned room: OWNER_GOALS_REVIEW success with intact goal data, attached in llm-trajectory


