### PR TITLE
test(core): prove exact-boundary splitter contract

### DIFF
--- a/packages/core/src/utils/recursive-character-text-splitter.test.ts
+++ b/packages/core/src/utils/recursive-character-text-splitter.test.ts
@@ -159,6 +159,26 @@ describe("splitText", () => {
 		expect(await splitter.splitText("aa bb cc")).toEqual(["aa bb", "cc"]);
 	});
 
+	it("keeps an exact-boundary split whole under an async non-additive metric", async () => {
+		const measuredLength = async (text: string): Promise<number> =>
+			text === "aa bb" ? 4 : text.length;
+		const splitter = new RecursiveCharacterTextSplitter({
+			chunkSize: 4,
+			chunkOverlap: 1,
+			separators: ["|", " ", ""],
+			keepSeparator: false,
+			lengthFunction: measuredLength,
+		});
+
+		// The complete first segment is valid at the exact boundary. Recursing
+		// into its finer separator would measure the pieces independently and
+		// fragment the observable output even though the supplied metric accepts it.
+		const chunks = await splitter.splitText("aa bb|cc");
+		expect(chunks).toEqual(["aa bb", "cc"]);
+		for (const chunk of chunks) {
+			expect(await measuredLength(chunk)).toBeLessThanOrEqual(4);
+		}
+	});
 	it("measures dropped separators with the custom length function", async () => {
 		const weightedLength = async (text: string) =>
 			Array.from(text).reduce(

--- a/packages/core/src/utils/recursive-character-text-splitter.test.ts
+++ b/packages/core/src/utils/recursive-character-text-splitter.test.ts
@@ -179,6 +179,7 @@ describe("splitText", () => {
 			expect(await measuredLength(chunk)).toBeLessThanOrEqual(4);
 		}
 	});
+
 	it("measures dropped separators with the custom length function", async () => {
 		const weightedLength = async (text: string) =>
 			Array.from(text).reduce(


### PR DESCRIPTION
## Summary

Adds the mutation-resistant proof requested by #20038 for the exact-boundary operator merged in #20030.

The supported `lengthFunction` is asynchronous and need not be additive (token metrics are context-sensitive). The new regression supplies a metric where the complete first segment measures exactly `chunkSize`, while recursively measuring its finer pieces would fragment the observable output. The intended `<=` path returns:

```ts
["aa bb", "cc"]
```

Restoring `<` forces recursive descent and returns:

```ts
["aa", "bb", "cc"]
```

This proves a user-observable partition contract instead of checking an implementation detail or merely exercising the same output under both operators.

Closes #20038.
Related: #20030.

## Scope

- one focused test in `recursive-character-text-splitter.test.ts`
- exact boundary (`4`), async custom length function, non-additive measurement, dropped outer/finer separators, and non-zero overlap
- existing suite already retains explicit empty-input, separator, overlap, async length, and invariant controls
- no production source change or speculative behavior broadening

## Validation

This branch was authored through static source analysis only; untrusted branch code was not executed locally.

| Evidence | Status |
| --- | --- |
| Base `develop` | `8ec0f3856f759be6990d22d68fe10e8bd03d7f36` |
| Exact test head | `8026b5a22972145334bb052e9e9ca03fbc77363c` |
| Mutation analysis (`<`) | output deterministically changes from `["aa bb", "cc"]` to `["aa", "bb", "cc"]` |
| Hosted CI | dispatch pending |
| Core focused tests / typecheck / Biome / root verify | must pass on exact head before merge |
| UI evidence | N/A — deterministic core utility test only |

## Contribution provenance

| Field | Value |
| --- | --- |
| AI assistance | Yes |
| Provider / model | OpenAI / gpt-5.6-sol |
| Client / agent tooling | Codex desktop |
| Contribution skill revision | `elizaOS/eliza@35257f04a7f05e70785d7265362047026c7c4b27:packages/skills/skills/contribute-to-eliza` |
| Attribution status | self-reported |

— [codex-splitter-boundary-proof]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"elizaOS/eliza@35257f04a7f05e70785d7265362047026c7c4b27:packages/skills/skills/contribute-to-eliza"} -->
