### PR TITLE
fix(app-core): keep desktop renderer Vite on Node

### DIFF
--- a/packages/app-core/scripts/lib/dev-ui-vite.mjs
+++ b/packages/app-core/scripts/lib/dev-ui-vite.mjs
@@ -8,15 +8,24 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
+import { resolveNodeExecPath } from "../run-node-runtime.mjs";
 
 export function resolveViteCommand({
   appDir,
   force = false,
-  nodePath = process.execPath,
+  nodePath,
   port,
   viteArgs = [],
 }) {
-  if (!nodePath) {
+  const resolvedNodePath =
+    nodePath === undefined
+      ? resolveNodeExecPath({
+          currentExecPath: process.execPath,
+          explicitNodePath: process.env.ELIZA_NODE_PATH,
+          platform: process.platform,
+        })
+      : nodePath;
+  if (!resolvedNodePath) {
     throw new Error("Node.js is required to run the Vite dev server.");
   }
   const viteCli = path.join(appDir, "node_modules", "vite", "bin", "vite.js");
@@ -40,5 +49,5 @@ export function resolveViteCommand({
   if (force) args.push("--force");
   if (port !== undefined) args.push("--port", String(port));
   args.push(...viteArgs);
-  return { command: nodePath, args };
+  return { command: resolvedNodePath, args };
 }

--- a/packages/app-core/scripts/lib/dev-ui-vite.test.mjs
+++ b/packages/app-core/scripts/lib/dev-ui-vite.test.mjs
@@ -1,7 +1,8 @@
 /** Verifies the development Vite subprocess uses the direct TypeScript config loader. */
 
+import { spawnSync } from "node:child_process";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { expect, test } from "vitest";
 import { resolveViteCommand } from "./dev-ui-vite.mjs";
 
@@ -28,4 +29,32 @@ test("resolveViteCommand uses workspace source while skipping config bundling", 
     "--port",
     "2138",
   ]);
+});
+
+test("resolveViteCommand stays Node-backed when its caller runs under Bun", () => {
+  const helperUrl = pathToFileURL(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "dev-ui-vite.mjs"),
+  ).href;
+  const script = `
+    import { resolveViteCommand } from ${JSON.stringify(helperUrl)};
+    const resolved = resolveViteCommand({ appDir: ${JSON.stringify(appDir)} });
+    process.stdout.write(resolved.command);
+  `;
+  const resolution = spawnSync("bun", ["--eval", script], {
+    encoding: "utf8",
+    env: { ...process.env, ELIZA_NODE_PATH: "" },
+  });
+
+  expect(resolution.status, resolution.stderr).toBe(0);
+  const nodePath = resolution.stdout.trim();
+  const runtime = spawnSync(
+    nodePath,
+    [
+      "--eval",
+      "process.stdout.write(process.versions.bun ? 'bun' : 'node:' + process.versions.node)",
+    ],
+    { encoding: "utf8" },
+  );
+  expect(runtime.status, runtime.stderr).toBe(0);
+  expect(runtime.stdout).toMatch(/^node:24\./);
 });


### PR DESCRIPTION
# Relates to

Closes #20043.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` passed after sync.
- [x] A reviewer can confirm the change from the tests and native evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@167179bff607249f4af236d37d15a68c69ea609e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@167179bff607249f4af236d37d15a68c69ea609e`; zero conflicts.
- [x] `bun run verify` passes post-sync: 351/351 Turbo tasks plus all repository audits.

# Risks

Low. The change only selects the repository's already-canonical validated Node 24 executable for the Vite child process. Explicit `nodePath` injection remains supported. A focused real-Bun regression test covers the broken caller environment.

# Background

## What does this PR do?

The documented macOS local-development command runs the orchestration script under Bun. The Vite helper previously defaulted to `process.execPath`, so it launched Vite under Bun and failed before Electrobun could open. This PR resolves the Vite child through the canonical Node-runtime resolver and proves that a real Bun caller receives Node 24.

This unblocks local macOS development against a local AgentRuntime/API with no Cloud-auth dependency. It does not bypass production auth or change Cloud behavior.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. The existing documented command becomes functional; no public configuration or CLI syntax changes.

# Testing

## Where should a reviewer start?

- `packages/app-core/scripts/lib/dev-ui-vite.mjs`
- `packages/app-core/scripts/lib/dev-ui-vite.test.mjs`

## Detailed testing steps

1. `bun run --cwd packages/app-core vitest run scripts/lib/dev-ui-vite.test.mjs scripts/run-node-runtime.test.mjs` — 22/22.
2. `node --test packages/app/scripts/lib/dev-vite-command.test.mjs` — 11/11.
3. `bun run --cwd packages/app-core typecheck` — pass.
4. `bunx biome check packages/app-core/scripts/lib/dev-ui-vite.mjs packages/app-core/scripts/lib/dev-ui-vite.test.mjs` — pass.
5. `bun run verify` — pass, 351/351 Turbo tasks plus repository audits.
6. Real current-source macOS proof: local AgentRuntime/API on `127.0.0.1:31437`, dev-signed Electrobun build, renderer connected in external-runtime mode, native shortcut hide/show, SSE reply, and persisted conversation.
7. Proportional platform proof already completed on iPhone 17 simulator/iOS 26.5: full local Bun runtime, real SSE/persistence, 11 app tests and iOS E2E green. This is simulator/dev proof, not App Store or physical-device proof.

# Evidence Gate

<!-- evidence-head:b687b1ad96e592e02077100209a99b1c4ee99cb4 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - the broken revision aborts before the native app or renderer opens, so there is no truthful before surface to capture.
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20059-video-frame-restored.png)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20059-native-shortcut-local-runtime.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend route or server behavior changes in this PR.
<!-- evidence-row:frontend-logs -->
- [x] [20059-frontend-desktop-clean.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20059-frontend-desktop-clean.log)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, or model behavior changes; the end-to-end plumbing proof intentionally used the deterministic local model.
<!-- evidence-row:domain-artifacts -->
- [x] [20059-conversation-persistence.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20059-conversation-persistence.json)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered UI source changes; the native screenshot and video were manually inspected for private content and behavior.

# Evidence Details

Exact-head evidence is attached in the gate rows above. Native shell state: https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20059-native-shell-state.json

## Real LLM-call trajectory

N/A - this is a process-launcher fix. A deterministic local model proves the runtime/SSE/persistence path without conflating model quality with launcher correctness.

## Backend + frontend logs

Frontend/native logs will be attached inline. No backend implementation changed.

## Screenshots (before / after) + video walkthrough

Before: N/A because the old process fails before the app opens.

After and walkthrough: current-source, dev-signed macOS Electrobun app connected to the local AgentRuntime. The recording shows the native global shortcut hiding and restoring the app. The chat transcript itself persisted end to end; a separately observed offscreen expanded-transcript layout defect is explicitly out of this two-file launcher scope and will be filed/fixed separately.

## Known gaps / failures

- The first root verifier was interrupted by a Codex Desktop restart; the exact rebased head was rerun from scratch and passed.
- A direct app-core typecheck in the fresh worktree initially lacked built workspace declarations. `bun run build` established the declared workspace artifacts; the exact post-rebase app-core typecheck and full root verifier both pass.
- iOS evidence is simulator/dev-only, not physical-device or App Store review proof.
- No signed contribution receipt is claimed. Provenance is self-reported.

— [codex / apple-native-surface-lane]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@167179bff607249f4af236d37d15a68c69ea609e:packages/skills/skills/contribute-to-eliza"} -->





