### PR TITLE
fix(desktop): navigate an open settings window

### DIFF
--- a/packages/app-core/platforms/electrobun/src/surface-windows.test.ts
+++ b/packages/app-core/platforms/electrobun/src/surface-windows.test.ts
@@ -139,6 +139,29 @@ describe("SurfaceWindowManager app windows", () => {
     expect(fixture.manager.listWindows("settings")).toEqual([first]);
   });
 
+  it("navigates an already-open settings window to the requested tab instead of just focusing it (#19996)", async () => {
+    const fixture = createFixture();
+
+    await fixture.manager.openSettingsWindow("open-settings-voice");
+    const window = fixture.created[0];
+    expect(window).toBeDefined();
+    expect(window?.webview.loadURL).not.toHaveBeenCalled();
+
+    // Menu action while the window is already open: the section must change.
+    await fixture.manager.openSettingsWindow("open-settings-permissions");
+
+    expect(fixture.created).toHaveLength(1);
+    expect(window?.webview.loadURL).toHaveBeenCalledWith(
+      "http://127.0.0.1:5173/?shell=settings&tab=permissions",
+    );
+    expect(window?.focus).toHaveBeenCalled();
+
+    // No tab hint (plain "Settings Window" menu item): focus only, no reload.
+    window?.webview.loadURL.mockClear();
+    await fixture.manager.openSettingsWindow();
+    expect(window?.webview.loadURL).not.toHaveBeenCalled();
+  });
+
   it("opens browser surfaces with browse query encoding and ignores browse for non-browser surfaces", async () => {
     const fixture = createFixture();
 

--- a/packages/app-core/platforms/electrobun/src/surface-windows.ts
+++ b/packages/app-core/platforms/electrobun/src/surface-windows.ts
@@ -232,6 +232,17 @@ export class SurfaceWindowManager {
       (entry) => entry.surface === "settings",
     );
     if (existing) {
+      // A tab hint on an already-open Settings window must navigate the
+      // window to the requested section — the menu items ("Voice Controls",
+      // "Permissions", "Cloud Settings", …) all route through here, and
+      // merely re-focusing left the stale section on screen (#19996).
+      const normalizedTab = normalizeSettingsTabHint(tabHint);
+      if (normalizedTab && existing.window.webview.loadURL) {
+        const rendererUrl = await this.resolveRendererUrlFn();
+        existing.window.webview.loadURL(
+          buildSurfaceWindowRendererUrl(rendererUrl, "settings", normalizedTab),
+        );
+      }
       existing.window.focus();
       return this.toSnapshot(existing);
     }


### PR DESCRIPTION
## Summary

The packaged-runtime fixes originally carried by this PR were superseded by and merged through #20024. This branch is restacked on current `develop` and now retains only the independent native-window bug found during that work:

When the Settings window was already open, `openSettingsWindow(tabHint)` ignored a new tab hint and only focused stale content. Desktop menu commands such as Voice Controls and Permissions therefore reopened the same window on the wrong section. The existing window now navigates to the requested Settings URL before it is focused; a plain Settings Window command remains focus-only.

## Scope and risk

- Two files in the Electrobun surface-window owner.
- No renderer source, API, schema, dependency, or package-policy change.
- Settings remains a singleton; the change only updates its URL when a non-empty tab hint is supplied.

## Validation

Exact head: `2ab08ea6c422`

- Focused surface-window test: 1 file / 10 tests passed.
- Full Electrobun suite: 71 files / 514 tests passed.
- Electrobun typecheck and lint passed.
- `packages/app` visual audit: 219/219 passed; zero broken, needs-work, hover, or density failures. All four Settings captures were manually inspected.
- Exact-head macOS arm64 desktop package built and signed successfully after moving an unrelated ignored Swift `.build` cache out of the runtime-copy scan, then restoring it.
- Packaged desktop lane: 11 passed, 1 skipped, 1 did not run, and 1 unrelated repeatable failure because the headless notification test expected `document.hasFocus() === true` while the visible renderer reported `false`.
- Direct packaged-artifact check: Desktop → Voice Controls opened one `Eliza Settings` window at `?shell=settings&tab=voice`; Desktop → Permissions reused that same window and changed it to `?shell=settings&tab=permissions`.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `zai/glm-5.3`, `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`, `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: original contribution `elizaOS/eliza@75b83886e585a80ab8a47b2024673832a4d3941e:packages/skills/skills/contribute-to-eliza`; maintainer restack/review on current `develop`
<!-- attribution-row:status -->
- Provenance status: self-reported

## Evidence Gate

<!-- evidence-head:2ab08ea6c422462457740b036fecd852b63cf5e5 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered pixels or layout changed; this is native window navigation state
<!-- evidence-row:after-screenshots -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20060-builtin-settings.png
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no animation or rendered flow changed; the real packaged navigation receipt is attached under domain artifacts
<!-- evidence-row:backend-logs -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20060-pr-20060-validation.txt
<!-- evidence-row:frontend-logs -->
- [x] N/A - no renderer source or network contract changed
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic native window routing; no model, prompt, provider, or agent action changed
<!-- evidence-row:domain-artifacts -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20060-pr-20060-packaged-settings-receipt.txt
<!-- evidence-row:ocr-review -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20060-ocr-triage.json

Closes #19996 follow-up.
