### PR TITLE
fix(cloud): minimize runner health metadata

### DIFF
--- a/packages/cloud/services/coding-remote-runner/__tests__/server.test.ts
+++ b/packages/cloud/services/coding-remote-runner/__tests__/server.test.ts
@@ -49,6 +49,13 @@ function request(
 }
 
 describe("coding remote runner HTTP runner", () => {
+  it("keeps public liveness free of workspace and auth metadata", async () => {
+    const response = await handler()(request("/health", {}, false));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+  });
+
   it("requires bearer auth on the remote runner API", async () => {
     const response = await handler()(request("/v1/health", {}, false));
 

--- a/packages/cloud/services/coding-remote-runner/src/index.ts
+++ b/packages/cloud/services/coding-remote-runner/src/index.ts
@@ -239,7 +239,7 @@ async function routeRequest(
   context: RunnerContext,
 ): Promise<Response> {
   if (request.method === "GET" && url.pathname === "/health") {
-    return publicHealthResponse(context.config);
+    return publicHealthResponse();
   }
 
   const routeKey = `${request.method} ${url.pathname}`;
@@ -256,13 +256,8 @@ async function routeRequest(
     : jsonResponse(404, { error: "not found" });
 }
 
-function publicHealthResponse(config: RunnerConfig): Response {
-  return jsonResponse(200, {
-    ok: true,
-    workspaceRoot: config.workspaceRoot,
-    containerWorkspaceRoot: config.containerWorkspaceRoot,
-    authConfigured: Boolean(config.token),
-  });
+function publicHealthResponse(): Response {
+  return jsonResponse(200, { ok: true });
 }
 
 function privateHealthResponse(config: RunnerConfig): Response {


### PR DESCRIPTION
# Relates to

Closes #20058

- [x] This PR targets `develop` and was rebased onto the latest `origin/develop` immediately before push.
- [ ] `bun install` and `bun run verify` complete locally. Focused package checks pass; clean CI is required for the repository-wide gate.
- [x] A reviewer can verify the public response contract from the regression test below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: OpenAI/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop`; zero conflicts at push time.
- [ ] `bun run verify` passes post-sync. CI is required for the full repository graph.

# Risks

Low. The public liveness endpoint keeps the same unauthenticated HTTP 200 contract and `{ "ok": true }` field. Only unnecessary host/container path and auth-configuration metadata are removed. Authenticated `/v1/health` is unchanged.

# Background

## What does this PR do?

Reduces unauthenticated `GET /health` on the coding remote runner to the minimal liveness payload `{ "ok": true }`. The detailed authenticated health endpoint remains unchanged.

Adds a regression test proving the public response contains no workspace paths or authentication configuration.

## What kind of change is this?

Security hardening and information-minimization fix.

# Documentation changes needed?

No. The service guide already describes `/health` as public liveness and `/v1/health` as the authenticated detailed contract.

# Testing

## Where should a reviewer start?

Review `publicHealthResponse` in `packages/cloud/services/coding-remote-runner/src/index.ts`, then the new assertion in `__tests__/server.test.ts`.

## Detailed testing steps

Using Bun 1.3.14:

```powershell
bun test __tests__/server.test.ts --test-name-pattern 'keeps public liveness'
bun test --timeout 30000 __tests__/server.test.ts
bun run --cwd packages/cloud/services/coding-remote-runner typecheck
bunx biome check packages/cloud/services/coding-remote-runner/src/index.ts packages/cloud/services/coding-remote-runner/__tests__/server.test.ts
bun run check:agents-claude
git diff --check origin/develop...HEAD
```

Observed:

- Focused regression: 1 pass, 0 fail.
- Full package suite with a 30-second Windows ceiling: 14 pass, 0 fail.
- Typecheck, Biome, guide parity, and diff checks: pass.

# Evidence Gate

<!-- evidence-head:2fbe1e4691ac9b66f7f1e21edaf22882a3b3e73a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - standalone JSON service; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - standalone JSON service; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive user flow.
<!-- evidence-row:backend-logs -->
- [x] Exact-head coding runner service test output:

<details>
<summary>Bun 1.3.14 package result</summary>

```text
(pass) coding remote runner HTTP runner > keeps public liveness free of workspace and auth metadata
14 pass, 0 fail, 35 expect() calls
Ran 14 tests across 1 file with --timeout 30000.
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, provider, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Public response contract asserted by the exact-head regression:

<details>
<summary>Unauthenticated liveness artifact</summary>

```text
GET /health
HTTP 200
{"ok":true}
workspaceRoot, containerWorkspaceRoot, and authConfigured are absent.
Authenticated /v1/health retains its existing detailed response contract.
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changed.

## Backend + frontend logs

The deterministic handler test asserts the public endpoint returns exactly `{ "ok": true }`. No frontend is involved.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice or audio change.

## Known gaps / failures

The package's unmodified filesystem round-trip test intermittently exceeds Bun's default 5-second test timeout on this heavily loaded Windows checkout. It passed in 1.4 seconds when the full package file was rerun alone with a 30-second ceiling (14/14 passing). Clean Linux CI is required for the default-timeout and repository-wide gates.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no contribution skill used"} -->

# Audit handoff

Ownership trace: Docker `HEALTHCHECK`, the Cloud container health monitor, and the coding-container manifest consume public `/health` only as a successful HTTP status. The agent capability router calls authenticated `/v1/health`, whose detailed capability/path response is unchanged. Source review found no behavior outside the two-file issue scope.

Current verdict: **FIX** (source is acceptable; keep draft until hosted exact-head validation is terminal and the evidence rows can be updated with real run results).