### PR TITLE
fix(notes,app-control): fence name-translated note deletions on the user's words

### DIFF
--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -3330,7 +3330,16 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 								transcriptVisibility: "internal",
 							};
 						}
-						const params = paramsResolution.params;
+						let params = paramsResolution.params;
+						// Destructive capabilities get the user's original words so the
+						// owning surface can fence name-translated targets (matrix F4:
+						// the planner translated "wifi credentials" into the stored
+						// title "wifi password" and delete-note removed a note the user
+						// never named). Injected only for delete-shaped capabilities so
+						// read/update param schemas stay untouched.
+						if (/^delete-/.test(normalizeCapabilityKey(capability)) && text) {
+							params = { ...params, ownerText: text };
+						}
 						const timeoutMs =
 							typeof actionOptions?.timeoutMs === "number" &&
 							actionOptions.timeoutMs > 0

--- a/plugins/plugin-notes/src/delete-name-fence.test.ts
+++ b/plugins/plugin-notes/src/delete-name-fence.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Matrix F4 (tj-a6b65b4576ad86): the planner translated the user's
+ * "wifi credentials" into the stored title "wifi password" (it had the note
+ * list in prior-turn context), so delete-note removed a note the user never
+ * named — via an EXACT-title lookup no fuzzy guard could catch. The fence:
+ * when the caller supplies the user's original words, the resolved title
+ * must appear in them or the delete fails structurally and the reply asks.
+ */
+import { describe, expect, it } from "vitest";
+import { NotesService } from "./service";
+
+async function seeded(): Promise<NotesService> {
+  const service = new NotesService();
+  await service.createNoteWithCommit({
+    title: "wifi password",
+    body: "hunter2-not-really",
+    color: "yellow",
+  });
+  return service;
+}
+
+describe("delete-note owner-text fence", () => {
+  it("blocks a name-translated delete and names the near-miss", async () => {
+    const service = await seeded();
+    await expect(
+      service.deleteNoteByLookupWithCommit("title", "wifi password", {
+        requireTitleInText: "delete the wifi credentials note",
+      }),
+    ).rejects.toMatchObject({ code: "NOTES_DELETE_NAME_MISMATCH" });
+    expect(service.snapshot().notes).toHaveLength(1);
+  });
+
+  it("deletes when the user actually named the note", async () => {
+    const service = await seeded();
+    const removed = await service.deleteNoteByLookupWithCommit(
+      "title",
+      "wifi password",
+      { requireTitleInText: "delete the wifi password note" },
+    );
+    expect(removed.value.title).toBe("wifi password");
+    expect(service.snapshot().notes).toHaveLength(0);
+  });
+
+  it("keeps historical behavior when no owner text is supplied", async () => {
+    const service = await seeded();
+    const removed = await service.deleteNoteByLookupWithCommit(
+      "title",
+      "wifi password",
+    );
+    expect(removed.value.title).toBe("wifi password");
+  });
+});

--- a/plugins/plugin-notes/src/interact.ts
+++ b/plugins/plugin-notes/src/interact.ts
@@ -350,18 +350,24 @@ async function dispatchCapability(
     );
   }
   if (capability === "delete-note") {
-    assertOnlyParams(params, ["id", "query", "title"]);
+    assertOnlyParams(params, ["id", "query", "title", "ownerText"]);
     const target = parseLookupTarget(params, capability, [
       "id",
       "query",
       "title",
     ]);
+    // The user's original words, injected by the VIEWS dispatcher for
+    // destructive capabilities. Id-selected deletes skip the fence (ids come
+    // from structured contexts, not name translation).
+    const ownerText =
+      typeof params.ownerText === "string" ? params.ownerText : undefined;
     const removed =
       target.selector === "id"
         ? await service.deleteNoteWithCommit(target.value)
         : await service.deleteNoteByLookupWithCommit(
             target.selector,
             target.value,
+            { requireTitleInText: ownerText },
           );
     const { value: note, snapshot, removedIds } = removed;
     return mutationSuccess(

--- a/plugins/plugin-notes/src/service.ts
+++ b/plugins/plugin-notes/src/service.ts
@@ -49,7 +49,10 @@ function normalizedLookup(value: string): string {
 }
 
 function lookupError(
-  code: "NOTES_NOT_FOUND" | "NOTES_AMBIGUOUS_NOTE",
+  code:
+    | "NOTES_NOT_FOUND"
+    | "NOTES_AMBIGUOUS_NOTE"
+    | "NOTES_DELETE_NAME_MISMATCH",
   selector: NoteLookupSelector,
   value: string,
   candidates: StickyNote[],
@@ -58,9 +61,11 @@ function lookupError(
   return new ElizaError(
     code === "NOTES_NOT_FOUND"
       ? `No sticky note matches "${target}".`
-      : `"${target}" matches multiple sticky notes: ${candidates
-          .map((note) => `${note.title} (${note.color})`)
-          .join(", ")}.`,
+      : code === "NOTES_DELETE_NAME_MISMATCH"
+        ? `The closest note is "${candidates[0]?.title ?? target}" — that isn't what you named, so nothing was deleted. Delete it?`
+        : `"${target}" matches multiple sticky notes: ${candidates
+            .map((note) => `${note.title} (${note.color})`)
+            .join(", ")}.`,
     {
       code,
       context: {
@@ -437,6 +442,7 @@ export class NotesService extends Service {
   async deleteNoteByLookupWithCommit(
     selector: NoteLookupSelector,
     value: string,
+    options?: { requireTitleInText?: string },
   ): Promise<{
     value: StickyNote;
     snapshot: NotesSnapshot;
@@ -452,6 +458,25 @@ export class NotesService extends Service {
           code: "NOTES_NOTE_RESOLUTION_FAILED",
           severity: "fatal",
         });
+      }
+      // Destructive-op name fence (matrix F4, tj-a6b65b4576ad86): the
+      // planner may translate the user's words into a stored title from
+      // prior-turn context ("wifi credentials" → title "wifi password"), so
+      // even an EXACT-title lookup can name a note the user never said.
+      // When the caller supplies the user's original text, the resolved
+      // title must appear in it — otherwise fail structurally so the reply
+      // ASKS with the candidate title instead of deleting a translation.
+      // Sibling of TRIGGER_REF_MISMATCH and the lifeops #20057 guard.
+      if (
+        typeof options?.requireTitleInText === "string" &&
+        options.requireTitleInText.trim().length > 0 &&
+        !normalizedLookup(options.requireTitleInText).includes(
+          normalizedLookup(existing.title),
+        )
+      ) {
+        throw lookupError("NOTES_DELETE_NAME_MISMATCH", selector, value, [
+          existing,
+        ]);
       }
       // Deleting "the note" deletes every byte-identical copy: duplicates are
       // one logical note, and leaving three identical survivors after "delete


### PR DESCRIPTION
Matrix F4 (tj-a6b65b4576ad86): `delete the wifi credentials note` deleted **"wifi password"**. Ground truth from the recorded params flipped the design: the planner had translated the user's words into the exact stored title (note list in prior-turn context), so the service ran a clean exact-title lookup — the fuzzy guard I originally planned would have been dead code.

The working fence is #20057's other half applied to this surface: the VIEWS dispatcher injects the user's original text (`ownerText`) into delete-shaped capability params, and the notes service verifies the resolved title appears in those words **inside the delete transaction** — else it fails structurally (`NOTES_DELETE_NAME_MISMATCH`) naming the near-miss so the reply asks ("The closest note is 'wifi password' — that isn't what you named, so nothing was deleted. Delete it?"). Id-selected deletes skip the fence; callers without ownerText keep historical behavior.

Third surface of the wrong-item delete class closed: trigger (#19950) → lifeops (#20057) → notes. Tests 3/3 (translated-delete blocked + survivor, genuine-name delete, compatibility); notes 85/85; app-control interact 71/71. watchtower re-probes scenario 10 post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:01d0791579d0b226d7b1cf9480c324d4e135e78f -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - service transaction fence; no UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - service transaction fence; no UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - recorded attack shape pinned in 3/3 fence tests

<!-- evidence-row:backend-logs -->
- [ ] N/A - vitest summaries in PR body

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - ground truth = tj-a6b65b4576ad86 recorded params; watchtower re-probes scenario 10 post-merge

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - artifact is the surviving note + mismatch error, asserted in-transaction
