### PR TITLE
fix(core): think-residue never defeats envelope parsing or reaches egress

### DIFF
--- a/packages/core/src/runtime/__tests__/evaluator-think-residue.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator-think-residue.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Matrix F18 (tj-b8809c9841cdfd, SEVERE): the evaluator model emitted a
+ * think-token-prefixed fenced envelope — `None</think>```json {…}` — which
+ * defeated fence unwrap, strict parse, AND the leading-fence repair, so the
+ * raw envelope became messageToUser and reached Discord verbatim. Seam 1:
+ * the parser strips everything through the last </think> before envelope
+ * handling. (Seam 2, the egress rejection, is pinned in the planner-loop
+ * suite via isUnsafeUserVisibleText's exported behavior.)
+ */
+import { describe, expect, it } from "vitest";
+import { parseEvaluatorOutput } from "../evaluator";
+
+const F18_RAW =
+	'None</think>```json\n{ "success": true, "decision": "FINISH", "thought": "Documents store is empty.", "messageToUser": "Your documents store is empty." }\n```';
+
+describe("evaluator think-residue stripping (F18)", () => {
+	it("parses the live think-prefixed envelope instead of leaking it", () => {
+		const output = parseEvaluatorOutput(F18_RAW);
+		expect(output.parseError).toBeUndefined();
+		expect(output.decision).toBe("FINISH");
+		expect(output.messageToUser).toBe("Your documents store is empty.");
+	});
+
+	it("still parses plain fenced envelopes", () => {
+		const output = parseEvaluatorOutput(
+			'```json\n{ "success": true, "decision": "FINISH", "thought": "queue drained", "messageToUser": "All finished with the review." }\n```',
+		);
+		expect(output.parseError).toBeUndefined();
+		expect(output.messageToUser).toBe("All finished with the review.");
+	});
+});
+
+import { isUnsafeUserVisibleText } from "../planner-loop";
+
+describe("egress rejection of internals (F18 seam 2)", () => {
+	it("rejects think residue and evaluator envelopes at the last line", () => {
+		expect(isUnsafeUserVisibleText(F18_RAW)).toBe(true);
+		expect(isUnsafeUserVisibleText("prefix</think>anything")).toBe(true);
+		expect(
+			isUnsafeUserVisibleText(
+				'{ "success": false, "decision": "CONTINUE", "thought": "…" }',
+			),
+		).toBe(true);
+	});
+
+	it("passes ordinary prose that merely mentions the words", () => {
+		expect(
+			isUnsafeUserVisibleText(
+				"I think the decision to finish early was a success.",
+			),
+		).toBe(false);
+	});
+});

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -1346,6 +1346,20 @@ function tryParseJson(candidate: string): unknown {
 }
 
 function parseEvaluatorText(text: string): ParsedEvaluatorObject {
+	// Reasoning-token residue defeats every stage below: a reply like
+	// `None</think>\`\`\`json {…}` fails the fence unwrap, the strict parse,
+	// AND the leading-fence repair (which requires the text to START with a
+	// fence) — the raw envelope then leaked verbatim to Discord (live
+	// tj-b8809c9841cdfd, matrix F18). The think contract is unambiguous:
+	// everything before the LAST </think> is reasoning, never output — strip
+	// it before any envelope handling.
+	const thinkEnd = text.lastIndexOf("</think>");
+	const visible =
+		thinkEnd >= 0 ? text.slice(thinkEnd + "</think>".length) : text;
+	return parseEvaluatorVisibleText(visible);
+}
+
+function parseEvaluatorVisibleText(text: string): ParsedEvaluatorObject {
 	const candidate = unwrapJsonFence(text.trim());
 	if (!candidate) {
 		return { object: null, parseError: "empty response" };

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -5416,7 +5416,9 @@ function userSafeFinalMessage(
  */
 export const HANDLED_STEP_FALLBACK_MESSAGE = "I handled the available step.";
 
-function isUnsafeUserVisibleText(value: string | undefined): boolean {
+// Exported for unit coverage of the egress rejection contract (F18):
+// the last-line guard is the deliverable, so tests pin its shapes.
+export function isUnsafeUserVisibleText(value: string | undefined): boolean {
 	if (!value) return false;
 	const text = value.trim();
 	if (!text) return false;
@@ -5425,6 +5427,20 @@ function isUnsafeUserVisibleText(value: string | undefined): boolean {
 		output.kind === "control" ||
 		output.kind === "invalid" ||
 		output.fieldPath.length > 0
+	) {
+		return true;
+	}
+	// Reasoning-token residue and evaluator protocol envelopes are internals,
+	// never replies: a `</think>` anywhere means upstream stripping failed, and
+	// a JSON body carrying the evaluator's decision/success protocol keys is
+	// the verdict envelope itself (live tj-b8809c9841cdfd delivered
+	// `None</think>\`\`\`json {"success": true, "decision": "FINISH"…}` to
+	// Discord when a think-prefixed envelope defeated the parser). Egress is
+	// the last line: reject both shapes regardless of how they got here.
+	if (text.includes("</think>")) return true;
+	if (
+		/"decision"\s*:\s*"(?:FINISH|CONTINUE|NEXT_RECOMMENDED)"/.test(text) &&
+		/"success"\s*:\s*(?:true|false)/.test(text)
 	) {
 		return true;
 	}


### PR DESCRIPTION
Matrix F18 (tj-b8809c9841cdfd, SEVERE — watchtower's supplemental burn): the evaluator emitted `None</think>```json {envelope}` and the raw protocol envelope reached Discord verbatim — the think prefix defeated the fence unwrap, the strict parse, AND the leading-fence repair (which requires a fence at position 0).

Two independent seams (belt + braces): **parser** strips everything through the last `</think>` before envelope handling, so the live shape now parses into its real FINISH verdict with a clean messageToUser; **egress** — `isUnsafeUserVisibleText` structurally rejects think residue and evaluator-envelope protocol shapes so a future parser miss can never ship internals (ordinary prose mentioning the words stays deliverable — pinned).

Live fixture tested through both seams (4/4 new); full runtime suites 1341/1341; core typecheck PASS. watchtower re-probes the documents-store scenario post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:05cdeac33343ed55980f7f6b458cf22ea471ab39 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - parser/egress internals; no UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - parser/egress internals; no UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - live fixture pinned through both seams (4/4); runtime 1341/1341

<!-- evidence-row:backend-logs -->
- [ ] N/A - vitest summaries in PR body

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - ground truth = tj-b8809c9841cdfd raw capture; watchtower re-probes post-merge

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - artifact is the parsed verdict + egress rejection, asserted by tests
