### PR TITLE
fix(elizaos): reject capability-router timeouts above the reliable timer bound

### DIFF
--- a/packages/elizaos/src/commands/capability-router.test.ts
+++ b/packages/elizaos/src/commands/capability-router.test.ts
@@ -226,6 +226,42 @@ describe("runCapabilityRouterConnect", () => {
     },
   );
 
+  // #20071: digits-only values above the double-precision timer bound parse to
+  // Infinity, and JSON.stringify serializes Infinity as null over the wire —
+  // the CLI must reject them locally with a message naming the supported bound.
+  it.each([
+    "2147483648", // one above Node's maximum reliable timer delay
+    "9".repeat(400), // digits-only, parses to Infinity
+    "9007199254740993", // beyond Number.MAX_SAFE_INTEGER
+  ])("rejects request timeout %s above the reliable timer bound before calling the API", async (requestTimeoutMs) => {
+    const fetchMock = mockFetch({ success: true });
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const code = await runCapabilityRouterConnect({
+      endpointUrl: "https://capability.example.test",
+      requestTimeoutMs,
+    });
+
+    expect(code).toBe(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(error.mock.calls[0]?.[0]).toContain(
+      "no greater than 2147483647 ms",
+    );
+  });
+
+  it("accepts the exact 2147483647 ms timer bound", async () => {
+    const fetchMock = mockFetch({ success: true });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const code = await runCapabilityRouterConnect({
+      endpointUrl: "https://capability.example.test",
+      requestTimeoutMs: "2147483647",
+    });
+
+    expect(code).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("surfaces API errors without leaking request tokens", async () => {
     mockFetch({ error: "Unauthorized" }, 401);
     const error = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/packages/elizaos/src/commands/capability-router.ts
+++ b/packages/elizaos/src/commands/capability-router.ts
@@ -252,6 +252,9 @@ function normalizeBaseUrl(
   }
 }
 
+/** Node's maximum reliable timer delay; larger delays misbehave (clamp to 1ms). */
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
 function parsePositiveInteger(
   value: string | undefined,
   label: string,
@@ -261,7 +264,18 @@ function parsePositiveInteger(
   if (!/^[1-9]\d*$/.test(normalized)) {
     return new Error(`${label} must be a positive integer.`);
   }
-  return Number(normalized);
+  const parsed = Number(normalized);
+  // A digits-only string can still exceed the double-precision timer bound
+  // (Number("9".repeat(400)) === Infinity), and JSON.stringify serializes
+  // Infinity as null over the wire — the agent route then rejects the null
+  // payload with a message that hides the real cause (#20071). Reject above
+  // Node's reliable timer delay with a message naming the supported bound.
+  if (!Number.isSafeInteger(parsed) || parsed > MAX_TIMER_DELAY_MS) {
+    return new Error(
+      `${label} must be a positive integer no greater than ${MAX_TIMER_DELAY_MS} ms (the maximum reliable timer delay).`,
+    );
+  }
+  return parsed;
 }
 
 function normalizeStringList(values: string[] | undefined): string[] {


### PR DESCRIPTION
# Relates to

Fixes #20071

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] `bun run verify` was NOT run in this environment — the exact unrelated
      blocker is recorded in **Known gaps / failures** below.
- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      (`fbf90d22`) with zero conflicts.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-4-5`
<!-- attribution-row:client -->
- Agent tooling: `ZCode`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused suite + changed-file Biome pass post-sync (output below).

# Risks

Low. `parsePositiveInteger` is private to `capability-router.ts` and gates only
the three timeout CLI flags. Canonical digits-only values at or below
2,147,483,647 — including the exact bound — behave exactly as before; values
above it, or digit strings that exceed double precision, now fail locally with
a message naming the supported bound instead of silently serializing as `null`
over the wire and confusing the operator with the agent route's generic 400.

# Background

## What does this PR do?

`parsePositiveInteger` in `packages/elizaos/src/commands/capability-router.ts`
returns `Number(normalized)` with no upper bound after the positive-integer
grammar check. `Number("9".repeat(400))` is `Infinity`, and `JSON.stringify`
serializes `Infinity` as `null`, so the CLI sent a payload whose timeout
differed from what the user typed, and the agent route rejected the `null` with
`requestTimeoutMs must be a positive integer.` — an error that hides the real
cause (#20071).

Per the issue's proposal, values above Node's maximum reliable timer delay
(`2_147_483_647`) are now rejected before any network request:

```ts
const parsed = Number(normalized);
if (!Number.isSafeInteger(parsed) || parsed > MAX_TIMER_DELAY_MS) {
  return new Error(
    `${label} must be a positive integer no greater than ${MAX_TIMER_DELAY_MS} ms (the maximum reliable timer delay).`,
  );
}
```

The shared parser covers `--request-timeout-ms`, `--provision-timeout-ms`, and
`--poll-interval-ms` consistently.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

```bash
bun test packages/elizaos/src/commands/capability-router.test.ts
```

## Detailed testing steps

New regressions follow the file's existing mock-fetch pattern:
- `2147483648` (one above the bound), `"9".repeat(400)` (digits-only →
  `Infinity`), and `9007199254740993` (beyond `Number.MAX_SAFE_INTEGER`) each
  exit 1 with the bound-naming message **before** any fetch call;
- the exact `2147483647` bound is accepted and performs exactly one fetch.

# Evidence Gate

<!-- evidence-head:a088a231749d88f5391d20806da4ce6deb9c41c7 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CLI flag parsing change; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CLI flag parsing change; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow; deterministic unit tests with a mocked transport cover the behavior.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live backend path changed; the suite drives the real command path with fetch mocked, proving the rejection happens before the request.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response or state change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - pure CLI parsing; no DB/memory/wallet artifacts.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Backend + frontend logs

Focused unit test output (run against the PR head):

```
$ bun test packages/elizaos/src/commands/capability-router.test.ts

 25 pass
  0 fail
 72 expect() calls
Ran 25 tests across 1 file. [47.00ms]
```

All 21 pre-existing command regressions stay green (direct-endpoint and Cloud
provisioning payloads, ephemeral connections, option validation, the
non-decimal timeout table, API-error token redaction, malformed-JSON handling),
plus the four new #20071 cases.

Changed-file Biome passes clean (`bunx biome check` exit=0 on both files).

The issue's own repro is inverted on this head:
`requestTimeoutMs: "9".repeat(400)` now exits 1 with
`...no greater than 2147483647 ms (the maximum reliable timer delay).` and
performs no fetch, instead of sending `requestTimeoutMs: null` over the wire.

## Screenshots (before / after) + video walkthrough

N/A - CLI flag parsing change, no rendered UI surface.

## Known gaps / failures

Root `bun install` in this environment fails on the `ffmpeg-static` postinstall
script (network timeout fetching the prebuilt binary), so the full root
`bun run verify` cannot run here. Unrelated to `packages/elizaos`: the focused
command suite runs and passes against the already-installed workspace
dependencies, and the production diff is one private parser function plus its
colocated tests.
