### PR TITLE
fix(cloud): reject NaN warm-pool smoothing factors

### DIFF
--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-forecast.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-forecast.test.ts
@@ -35,6 +35,9 @@ describe("computeForecast — guards", () => {
     expect(() => computeForecast({ ...base, emaAlpha: 0 })).toThrow(/emaAlpha/);
     expect(() => computeForecast({ ...base, emaAlpha: -0.1 })).toThrow(/emaAlpha/);
     expect(() => computeForecast({ ...base, emaAlpha: 1.5 })).toThrow(/emaAlpha/);
+    expect(() => computeForecast({ ...base, emaAlpha: Number.NaN, bucketCounts: [3] })).toThrow(
+      /emaAlpha/,
+    );
   });
 
   test("accepts the boundary emaAlpha = 1", () => {

--- a/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-forecast.ts
+++ b/packages/cloud/shared/src/lib/services/containers/agent-warm-pool-forecast.ts
@@ -47,7 +47,7 @@ export function computeForecast(input: ForecastInput): ForecastOutput {
   if (input.minPoolSize > input.maxPoolSize) {
     throw new Error("warm-pool: minPoolSize cannot exceed maxPoolSize");
   }
-  if (input.emaAlpha <= 0 || input.emaAlpha > 1) {
+  if (!Number.isFinite(input.emaAlpha) || input.emaAlpha <= 0 || input.emaAlpha > 1) {
     throw new Error("warm-pool: emaAlpha must satisfy 0 < α ≤ 1");
   }
   if (input.leadTimeBuckets < 0) {


### PR DESCRIPTION
# Relates to

Closes #20081.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] this PR targets `develop` and is branched directly off the current `origin/develop` tip.
- [x] focused package tests, lint, and typecheck pass on the exact head, see Testing below.
- [x] a reviewer can confirm the fix directly against the deterministic unit test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (fix, tests, via AgentRouter proxy), `anthropic/claude-sonnet-5` (independent re-verification)
<!-- attribution-row:client -->
- Agent tooling: `codex` (via AgentRouter proxy), `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] branched directly off the current `origin/develop` tip

# Risks

low. this only tightens the `emaAlpha` boundary guard in `computeForecast`; every existing valid alpha (a finite number in `(0, 1]`) behaves identically.

# Background

## What does this PR do?

`computeForecast`'s `emaAlpha` guard used only ordered comparisons (`<= 0`, `> 1`), which are `false` for `NaN`, so a non-finite `emaAlpha` slipped past the boundary check that's supposed to enforce `0 < α ≤ 1`. With a non-empty bucket window, the invalid value then propagates through the EMA accumulation and clamp, returning `{ predictedRate: NaN, targetPoolSize: NaN, observedBuckets: N }` instead of throwing. `WarmPoolManager.snapshot` feeds that target into `decideReplenish`, so a `NaN` alpha would make the manager silently decide to create zero replacement capacity instead of failing closed the way the explicit guard is meant to guarantee.

confirmed directly:

```text
$ bun -e 'console.log(NaN <= 0, NaN > 1)'
false false
```

traced every real construction of `WarmPoolPolicy` in the current codebase before writing this up: `envWarmPoolPolicy()` only overrides `minPoolSize`/`maxPoolSize` from env, and the admin GET route always reads `DEFAULT_WARM_POOL_POLICY.emaAlpha` (hardcoded `0.5`) — there's no admin write path or env var that can currently set `emaAlpha` at all, so this isn't producing wrong pool-sizing decisions in the shipped system today. it's a real gap in an exported validation function whose own error message promises a hard `0 < α ≤ 1` bound, and the doc comment on `envWarmPoolPolicy` already flags `emaAlpha` as heading toward "operator-tunable" — worth closing before it's the first caller-supplied value.

fix: reject non-finite `emaAlpha` before the existing range checks run.

## What kind of change is this?

bug fix, non-breaking (every existing valid `emaAlpha` value behaves identically).

# Documentation changes needed?

no, the fix restores the guard's own documented contract rather than changing the interface.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/containers/agent-warm-pool-forecast.test.ts`, the extended `throws when emaAlpha is out of (0, 1]` case, then the `Number.isFinite` check added to `computeForecast`.

## Detailed testing steps

```text
$ bun test src/lib/services/containers/agent-warm-pool-forecast.test.ts
 15 pass
 0 fail
 28 expect() calls

$ bun run typecheck
Done!  (exit 0)

$ bun run lint:check
Checked 1912 files in 1181ms. No fixes applied.
Found 1 info.   (pre-existing biome schema-version notice, unrelated to this change)
```

mutation-resistance verified independently: reverted just the source fix, kept the new test, reran — 1/15 failed with `Received function did not throw / Received value: { predictedRate: NaN, targetPoolSize: NaN, observedBuckets: 1 }`. restored the fix, 15/15 green again.

# Evidence Gate

<!-- evidence-head:ebc9885a2c88a66e0ba9e63699330b6910447cf0 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes a validation guard's boundary condition, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - this changes a validation guard's boundary condition, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive product flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic unit test, the real transcript is included under domain artifacts.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code or network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real mutation-resistance run, captured directly:
  ```text
  red (source fix reverted, test kept):
  $ bun test src/lib/services/containers/agent-warm-pool-forecast.test.ts
  error: expect(received).toThrow(expected)
  Expected pattern: /emaAlpha/
  Received function did not throw
  Received value: { predictedRate: NaN, targetPoolSize: NaN, observedBuckets: 1 }
  14 pass | 1 fail

  green (fix restored):
  $ bun test src/lib/services/containers/agent-warm-pool-forecast.test.ts
  15 pass | 0 fail
  ```
  also independently confirmed `NaN <= 0` and `NaN > 1` are both `false` in a real bun REPL, and independently traced every `WarmPoolPolicy` construction site in the repo (`envWarmPoolPolicy`, the admin GET route, `DEFAULT_WARM_POOL_POLICY`) to characterize current reachability honestly rather than assume it from the bug shape alone.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface or visual text changed.

## Known gaps / failures

none in the touched suite. the full `packages/cloud/shared` test lane has 6 pre-existing, unrelated failures in `socket-redis-resilience.test.ts` caused by the sandbox forbidding a loopback listening socket (`EPERM`) — unrelated to this change, confirmed by running the focused forecast suite independently (15/15 green).

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the focused suite, typecheck, and lint myself, confirmed the `NaN` comparison behavior directly, traced real `WarmPoolPolicy` callers to characterize reachability, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Contribution skill revision: N/A - direct interactive session, contribute-to-eliza skill not used
Compute receipt: N/A - Slop run-receipt install currently blocked by an unrelated site-deploy-lag issue (deployed skill archive predates recent develop changes)
Attribution status: self-reported
