### PR TITLE
fix(core): a RESPOND turn that ran tools never ends with zero deliveries

### DIFF
--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -9114,14 +9114,62 @@ export async function runV5MessageRuntimeStage1(args: {
 				strippedPlannedReplyText = source.slice(rawVerified.length).trim();
 			}
 		}
-		const effectiveDeliveredReplyText =
+		let effectiveDeliveredReplyText =
 			strippedPlannedReplyText || effectiveReplyText;
-		const shouldSendPlannedText =
+		let shouldSendPlannedText =
 			Boolean(effectiveReplyText) &&
 			!plannedTextRepeatsEarlyReply &&
 			!plannedTextRepeatsActionReply &&
 			!plannedTextIsRedundantFailureFallback &&
 			!plannedTextRepeatsVerifiedActionDelivery;
+		// NEVER-SILENT INVARIANT (matrix F24/F12, tj-bfe764bf544bed /
+		// tj-fda9d65e8d04b9): a RESPOND turn that executed tools must not end
+		// with zero deliveries. Every suppression above presupposes the user
+		// already received the content through some earlier delivery — when
+		// NOTHING was delivered this turn (no early ack, empty delivered-set)
+		// that premise is false by construction, and an empty
+		// `effectiveReplyText` (a FINISH whose message evaporated in the
+		// safety chain) otherwise ships `responseContent: null`: the runtime
+		// produced a correct answer and the user got silence. Recover with the
+		// best grounded text available and name the failure in the log so the
+		// upstream emptying path is diagnosable instead of invisible.
+		if (
+			!shouldSendPlannedText &&
+			!earlyReplySent &&
+			deliveredVisibleTexts.size === 0 &&
+			actionResults.length > 0
+		) {
+			const recoveredText =
+				effectiveDeliveredReplyText ||
+				stageOneAck ||
+				actionResults
+					.map((result) =>
+						typeof result.userFacingText === "string"
+							? result.userFacingText.trim()
+							: "",
+					)
+					.filter((ownedText) => ownedText.length > 0)
+					.at(-1) ||
+				"I finished working on that but could not compose a clean reply — ask again and I will retry.";
+			args.runtime.logger.warn(
+				{
+					src: "service:message",
+					emptyFinal: !effectiveReplyText,
+					suppressedByEarlyReply: plannedTextRepeatsEarlyReply,
+					suppressedByActionReply: plannedTextRepeatsActionReply,
+					recoveredFrom: effectiveDeliveredReplyText
+						? "plannedText"
+						: stageOneAck
+							? "stageOneAck"
+							: "actionUserFacingText",
+				},
+				"RESPOND turn reached the reply gate with zero deliveries; recovering instead of ending silent",
+			);
+			effectiveReplyText = recoveredText;
+			strippedPlannedReplyText = recoveredText;
+			effectiveDeliveredReplyText = recoveredText;
+			shouldSendPlannedText = true;
+		}
 		// Voice-gate provenance (#14873): the Stage-1 ack has unambiguous model
 		// provenance. A byte-exact canonical action result also needs preservation:
 		// `verifiedUserFacing` promises do-not-paraphrase semantics, so routing that


### PR DESCRIPTION
Matrix F24 + F12 (watchtower's forensics, HQ #18309): correct answers produced, silence delivered. F24 (the PDF turn) ran ingestion + the planner tool and then **zero** `message:delivery:*` segments; F12 delivered only the early ack. The reply gate's suppressions all presuppose an earlier delivery, and an empty `effectiveReplyText` (a FINISH whose message evaporated in the safety chain) fails the gate into `responseContent: null` — with recovery existing only for `success:false` turns.

**The never-silent invariant**: when the gate would decline AND nothing was delivered this turn AND tools ran, recover with the best grounded text (planned text → stage-1 ack → last action userFacingText → honest fallback) and warn with the exact failure shape (`emptyFinal` + suppression flags) so the upstream emptying path becomes diagnosable.

Evidence: message suites 593/593 — the invariant is provably inert on every previously-passing path (it requires the zero-delivery state). Live discriminating proof: watchtower re-runs both recorded turns (batch-2 rows) on next resync; the warn line will also name the true upstream emptier for the root-cause follow-up. Honest note: no synthetic unit test pins the invariant yet — the zero-delivery state needs the full stage-1 harness; follow-up if the live re-probe wants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:e7ff23fa82d4e305632fa00663fd127e832a905c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - reply-gate invariant; no UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - reply-gate invariant; no UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - inert on all passing paths (593/593); fires only in the zero-delivery state

<!-- evidence-row:backend-logs -->
- [ ] N/A - the warn IS part of the deliverable; live capture on re-probe

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - ground truth = timing forensics on tj-bfe764bf544bed + tj-fda9d65e8d04b9; live re-probe = closing evidence

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - artifact is the delivered recovery reply + diagnostic warn
