### PR TITLE
fix(core): resolve entity-id redaction placeholders in executed tool args

### DIFF
--- a/packages/core/src/runtime/__tests__/redacted-setting-refs.test.ts
+++ b/packages/core/src/runtime/__tests__/redacted-setting-refs.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Matrix F16 (tj-b6bf03e81193a2): prompts redact settings values as
+ * [REDACTED:<NAME>]; the model copies the placeholder into tool args and
+ * UUID validation rejects it — every tool wanting the admin entity id
+ * failed with "does not match pattern". The resolver substitutes ONLY
+ * entity-id-class placeholders with UUID-shaped setting values, at the
+ * executed-args copy (recorded tool calls keep the placeholder).
+ */
+import { describe, expect, it, vi } from "vitest";
+import { resolveRedactedSettingRefs } from "../execute-planned-tool-call";
+
+const ADMIN_ID = "b961de75-2cf0-06bc-9d61-82f32e752c63";
+
+function runtimeWith(settings: Record<string, string>) {
+	return {
+		getSetting: (key: string) => settings[key],
+		logger: { debug: vi.fn() },
+	};
+}
+
+describe("resolveRedactedSettingRefs (F16)", () => {
+	it("resolves the live failure shape: admin entity id placeholder", () => {
+		const runtime = runtimeWith({ ELIZA_ADMIN_ENTITY_ID: ADMIN_ID });
+		const resolved = resolveRedactedSettingRefs(runtime, {
+			entityId: "[REDACTED:ELIZA_ADMIN_ENTITY_ID]",
+			query: "favorite color",
+		});
+		expect(resolved.entityId).toBe(ADMIN_ID);
+		expect(resolved.query).toBe("favorite color");
+	});
+
+	it("never resolves credential-class placeholders", () => {
+		const runtime = runtimeWith({ OPENAI_API_KEY: "sk-secret" });
+		const args = { token: "[REDACTED:OPENAI_API_KEY]" };
+		expect(resolveRedactedSettingRefs(runtime, args)).toBe(args);
+	});
+
+	it("refuses non-UUID setting values and embedded placeholders", () => {
+		const runtime = runtimeWith({ WEIRD_ENTITY_ID: "not-a-uuid" });
+		const args = {
+			a: "[REDACTED:WEIRD_ENTITY_ID]",
+			b: "prefix [REDACTED:ELIZA_ADMIN_ENTITY_ID] suffix",
+		};
+		const resolved = resolveRedactedSettingRefs(runtime, args);
+		expect(resolved.a).toBe("[REDACTED:WEIRD_ENTITY_ID]");
+		expect(resolved.b).toBe(args.b);
+	});
+});

--- a/packages/core/src/runtime/execute-planned-tool-call.ts
+++ b/packages/core/src/runtime/execute-planned-tool-call.ts
@@ -340,6 +340,50 @@ function runWithMessageTrajectoryContext<T>(
 	);
 }
 
+/**
+ * Resolve prompt-side redaction placeholders the model copied into tool args
+ * (matrix F16, tj-b6bf03e81193a2): settings values are redacted in prompts as
+ * `[REDACTED:<NAME>]`, the model faithfully reproduces the placeholder in an
+ * argument (`entityId: "[REDACTED:ELIZA_ADMIN_ENTITY_ID]"`), and schema/UUID
+ * validation rejects it — every tool wanting the admin entity id fails.
+ *
+ * Deliberately narrow: only full-string placeholders whose setting name ends
+ * in `_ENTITY_ID` (non-credential identifiers) resolve, and only when the
+ * runtime setting exists and is UUID-shaped. Credential-class placeholders
+ * stay unresolved by design — substituting bearer secrets into tool args
+ * would hand them to any tool that echoes its inputs. The broader design
+ * (resolvable redaction aliases) is a flagged follow-up.
+ *
+ * The RECORDED tool call keeps the placeholder (this transforms only the
+ * executed-args copy), so resolved ids never enter trajectories.
+ */
+const REDACTED_ENTITY_REF = /^\[REDACTED:([A-Z0-9_]*_ENTITY_ID)\]$/;
+const UUID_SHAPE =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function resolveRedactedSettingRefs(
+	runtime: Pick<IAgentRuntime, "getSetting" | "logger">,
+	args: Record<string, unknown>,
+): Record<string, unknown> {
+	let changed = false;
+	const resolved: Record<string, unknown> = { ...args };
+	for (const [key, value] of Object.entries(args)) {
+		if (typeof value !== "string") continue;
+		const match = REDACTED_ENTITY_REF.exec(value);
+		if (!match?.[1]) continue;
+		const settingValue = runtime.getSetting(match[1]);
+		if (typeof settingValue === "string" && UUID_SHAPE.test(settingValue)) {
+			resolved[key] = settingValue;
+			changed = true;
+			runtime.logger?.debug?.(
+				{ src: "runtime:tool-args", argument: key, setting: match[1] },
+				"Resolved redaction placeholder in tool argument",
+			);
+		}
+	}
+	return changed ? resolved : args;
+}
+
 export async function executePlannedToolCall(
 	runtime: IAgentRuntime,
 	ctx: ExecutePlannedToolCallContext,
@@ -399,7 +443,10 @@ export async function executePlannedToolCall(
 			dropUndeclaredPlannerWrapperArgs(action, normalizedArgs),
 		),
 	);
-	const validation = validateToolArgs(action, argsForValidation);
+	const validation = validateToolArgs(
+		action,
+		resolveRedactedSettingRefs(runtime, argsForValidation),
+	);
 	if (!validation.valid) {
 		// The planner correlates a corrected retry with this failed operation by
 		// removing only arguments the schema rejected. Keeping this structural


### PR DESCRIPTION
Matrix F16 (tj-b6bf03e81193a2, watchtower's crisp root cause): prompt-side redaction shows `[REDACTED:ELIZA_ADMIN_ENTITY_ID]`, the model copies the placeholder into tool args, UUID validation rejects → memory search dies and the failure paraphrases as "agent id formatting broke". This bites **every** tool argument that wants the admin entity id.

Narrow resolver at the execution seam (`execute-planned-tool-call` arg pipeline): only full-string placeholders whose setting name ends in `_ENTITY_ID`, only when the setting value is UUID-shaped. Credential-class placeholders deliberately stay unresolved (substituting bearer secrets into tool args hands them to any input-echoing tool); the recorded tool call keeps the placeholder so resolved ids never enter trajectories. Broader resolvable-alias design flagged for shaw as follow-up.

Tests: 3/3 incl. the live failure shape + the two refusal contracts; runtime suites 1189/1189; core typecheck PASS. watchtower re-probes the conversation-history search post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:bc686ca9ac8d1da64a0d8088e365d6f96047e4fb -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - tool-arg execution seam; no UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - tool-arg execution seam; no UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - live shape + refusal contracts pinned 3/3; runtime 1189/1189

<!-- evidence-row:backend-logs -->
- [ ] N/A - vitest output in PR body

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - ground truth = tj-b6bf03e81193a2 recorded args; re-probe post-merge

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - artifact is the executed arg substitution + trajectory placeholder preservation
