### PR TITLE
fix(x): bind authentication to credential generations

### DIFF
--- a/plugins/plugin-x/src/client/auth.test.ts
+++ b/plugins/plugin-x/src/client/auth.test.ts
@@ -940,6 +940,90 @@ describe("TwitterAuth credential rotation", () => {
     expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledTimes(2);
   });
 
+  it("streams authenticated generators one provider step at a time and closes on cancellation", async () => {
+    twitterApiHarness.profiles.push(user("account-a"));
+    const client = new Client();
+    client.updateAuth(new TwitterAuth(rotatingBroker(oauth1()).provider));
+    await expect(client.me()).resolves.toMatchObject({ userId: "account-a" });
+
+    const source = {
+      next: vi
+        .fn<() => Promise<IteratorResult<string>>>()
+        .mockResolvedValueOnce({ done: false, value: "first" })
+        .mockResolvedValueOnce({ done: false, value: "second" }),
+      return: vi.fn(async () => ({
+        done: true as const,
+        value: undefined,
+      })),
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+    const generator = (
+      client as unknown as {
+        authenticatedGenerator<T>(
+          operation: (auth: TwitterAuth) => AsyncIterable<T>,
+        ): AsyncGenerator<T, void>;
+      }
+    ).authenticatedGenerator(() => source);
+
+    await expect(generator.next()).resolves.toEqual({
+      done: false,
+      value: "first",
+    });
+    expect(source.next).toHaveBeenCalledOnce();
+
+    await generator.return();
+
+    expect(source.next).toHaveBeenCalledOnce();
+    expect(source.return).toHaveBeenCalledOnce();
+  });
+
+  it("stops an authenticated generator before another page after credentials rotate", async () => {
+    twitterApiHarness.profiles.push(user("account-a"), user("account-b"));
+    const client = new Client();
+    client.updateAuth(new TwitterAuth(rotatingBroker(oauth1()).provider));
+    await expect(client.me()).resolves.toMatchObject({ userId: "account-a" });
+
+    const source = {
+      next: vi
+        .fn<() => Promise<IteratorResult<string>>>()
+        .mockResolvedValueOnce({ done: false, value: "account-a-page" })
+        .mockResolvedValueOnce({ done: false, value: "stale-page" }),
+      return: vi.fn(async () => ({
+        done: true as const,
+        value: undefined,
+      })),
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+    const generator = (
+      client as unknown as {
+        authenticatedGenerator<T>(
+          operation: (auth: TwitterAuth) => AsyncIterable<T>,
+        ): AsyncGenerator<T, void>;
+      }
+    ).authenticatedGenerator(() => source);
+
+    await expect(generator.next()).resolves.toEqual({
+      done: false,
+      value: "account-a-page",
+    });
+    client.updateAuth(
+      new TwitterAuth(
+        rotatingBroker(oauth1({ accessSecret: "account-b-secret" })).provider,
+      ),
+    );
+    await expect(client.me()).resolves.toMatchObject({ userId: "account-b" });
+
+    await expect(generator.next()).rejects.toMatchObject({
+      code: "X_AUTH_SESSION_ROTATED",
+    });
+    expect(source.next).toHaveBeenCalledOnce();
+    expect(source.return).toHaveBeenCalledOnce();
+  });
+
   it("keeps nested public provider calls on the active Client session", async () => {
     twitterApiHarness.profiles.push(user("account-a"));
     const client = new Client();

--- a/plugins/plugin-x/src/client/auth.test.ts
+++ b/plugins/plugin-x/src/client/auth.test.ts
@@ -1,0 +1,1040 @@
+/**
+ * Exercises the production X credential-to-client/profile boundary with a
+ * deterministic twitter-api-v2 constructor and rotating broker generations.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type AuthenticatedTwitterSession, TwitterAuth } from "./auth";
+import type {
+  BrokerAuthCredentials,
+  TwitterBrokerProvider,
+} from "./auth-providers/types";
+import { Client } from "./client";
+
+const twitterApiHarness = vi.hoisted(() => {
+  type ProfileResult =
+    | Record<string, unknown>
+    | Promise<Record<string, unknown>>;
+  type TwitterApiHarnessValue = {
+    v2: {
+      me: ReturnType<typeof vi.fn>;
+      tweet: ReturnType<typeof vi.fn>;
+      user: ReturnType<typeof vi.fn>;
+    };
+  };
+  const profiles: Array<ProfileResult | (() => ProfileResult)> = [];
+  const constructorFailures: unknown[] = [];
+  const instances: Array<{
+    credentials: unknown;
+    me: ReturnType<typeof vi.fn>;
+    tweet: ReturnType<typeof vi.fn>;
+    user: ReturnType<typeof vi.fn>;
+    value: TwitterApiHarnessValue;
+  }> = [];
+  const twitterApiConstructor = vi.fn(function TwitterApiMock(
+    credentials: unknown,
+  ) {
+    if (constructorFailures.length > 0) {
+      throw constructorFailures.shift();
+    }
+    const profile = profiles[instances.length];
+    if (!profile) {
+      throw new Error("TwitterApiMock profile was not configured");
+    }
+    const me = vi.fn(async () => ({
+      data: await (typeof profile === "function" ? profile() : profile),
+    }));
+    const instanceNumber = instances.length + 1;
+    const tweet = vi.fn(async () => ({
+      data: { id: `tweet-${instanceNumber}`, text: "" },
+    }));
+    const user = vi.fn(async () => ({
+      data: {
+        id: `profile-${instanceNumber}`,
+        username: `screen-${instanceNumber}`,
+      },
+    }));
+    const value = { v2: { me, tweet, user } };
+    instances.push({ credentials, me, tweet, user, value });
+    return value;
+  });
+
+  return {
+    constructorFailures,
+    instances,
+    profiles,
+    twitterApiConstructor,
+  };
+});
+
+vi.mock("twitter-api-v2", () => ({
+  TwitterApi: twitterApiHarness.twitterApiConstructor,
+}));
+
+type OAuth1Credentials = Extract<BrokerAuthCredentials, { mode: "oauth1" }>;
+
+function oauth1(
+  overrides: Partial<Omit<OAuth1Credentials, "mode">> = {},
+): OAuth1Credentials {
+  return {
+    mode: "oauth1",
+    appKey: "app-key-one",
+    appSecret: "app-secret-one",
+    accessToken: "shared-access-token",
+    accessSecret: "access-secret-one",
+    ...overrides,
+  };
+}
+
+function user(id: string) {
+  return {
+    id,
+    username: `user-${id}`,
+    name: `User ${id}`,
+    description: `Profile ${id}`,
+    profile_image_url: `https://example.com/${id}.jpg`,
+    public_metrics: { followers_count: 1, following_count: 2 },
+    verified: false,
+    location: "",
+    created_at: "2026-08-15T00:00:00.000Z",
+  };
+}
+
+function rotatingBroker(initial: BrokerAuthCredentials) {
+  let credentials = initial;
+  const getBrokerCredentials = vi.fn(async () => credentials);
+  const provider: TwitterBrokerProvider = {
+    mode: "broker",
+    getAccessToken: async () => credentials.accessToken,
+    getBrokerCredentials,
+  };
+
+  return {
+    getBrokerCredentials,
+    provider,
+    rotate(next: BrokerAuthCredentials) {
+      credentials = next;
+    },
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((onResolve, onReject) => {
+    resolve = onResolve;
+    reject = onReject;
+  });
+  return { promise, reject, resolve };
+}
+
+beforeEach(() => {
+  twitterApiHarness.twitterApiConstructor.mockClear();
+  twitterApiHarness.constructorFailures.length = 0;
+  twitterApiHarness.instances.length = 0;
+  twitterApiHarness.profiles.length = 0;
+});
+
+describe("TwitterAuth credential rotation", () => {
+  it("rebuilds for every OAuth1 secret or app credential change with the same access token", async () => {
+    twitterApiHarness.profiles.push(
+      user("one"),
+      user("two"),
+      user("three"),
+      user("four"),
+    );
+    const broker = rotatingBroker(oauth1());
+    const auth = new TwitterAuth(broker.provider);
+
+    const clients = [await auth.getV2Client()];
+    broker.rotate(oauth1({ appKey: "app-key-two" }));
+    clients.push(await auth.getV2Client());
+    broker.rotate(
+      oauth1({ appKey: "app-key-two", appSecret: "app-secret-two" }),
+    );
+    clients.push(await auth.getV2Client());
+    broker.rotate(
+      oauth1({
+        appKey: "app-key-two",
+        appSecret: "app-secret-two",
+        accessSecret: "access-secret-two",
+      }),
+    );
+    clients.push(await auth.getV2Client());
+
+    expect(new Set(clients).size).toBe(4);
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledTimes(4);
+    expect(
+      twitterApiHarness.instances.map(({ credentials }) => credentials),
+    ).toEqual([
+      expect.objectContaining({
+        appKey: "app-key-one",
+        appSecret: "app-secret-one",
+        accessSecret: "access-secret-one",
+        accessToken: "shared-access-token",
+      }),
+      expect.objectContaining({ appKey: "app-key-two" }),
+      expect.objectContaining({ appSecret: "app-secret-two" }),
+      expect.objectContaining({ accessSecret: "access-secret-two" }),
+    ]);
+  });
+
+  it("rebuilds when the broker changes OAuth mode without changing the access token", async () => {
+    twitterApiHarness.profiles.push(user("oauth1"), user("oauth2"));
+    const broker = rotatingBroker(oauth1());
+    const auth = new TwitterAuth(broker.provider);
+
+    const oauth1Client = await auth.getV2Client();
+    broker.rotate({ mode: "oauth2", accessToken: "shared-access-token" });
+    const oauth2Client = await auth.getV2Client();
+
+    expect(oauth2Client).not.toBe(oauth1Client);
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ accessToken: "shared-access-token" }),
+    );
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenNthCalledWith(
+      2,
+      "shared-access-token",
+    );
+  });
+
+  it("rebuilds when an OAuth2 broker rotates the access token without changing mode", async () => {
+    twitterApiHarness.profiles.push(user("oauth2-one"), user("oauth2-two"));
+    const broker = rotatingBroker({
+      mode: "oauth2",
+      accessToken: "oauth2-token-one",
+    });
+    const auth = new TwitterAuth(broker.provider);
+
+    const firstClient = await auth.getV2Client();
+    await expect(auth.me()).resolves.toMatchObject({ userId: "oauth2-one" });
+
+    broker.rotate({ mode: "oauth2", accessToken: "oauth2-token-two" });
+    const secondClient = await auth.getV2Client();
+    await expect(auth.me()).resolves.toMatchObject({ userId: "oauth2-two" });
+
+    expect(secondClient).not.toBe(firstClient);
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenNthCalledWith(
+      1,
+      "oauth2-token-one",
+    );
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenNthCalledWith(
+      2,
+      "oauth2-token-two",
+    );
+  });
+
+  it("invalidates the cached profile on rotation but reuses it for identical credentials", async () => {
+    twitterApiHarness.profiles.push(user("old-account"), user("new-account"));
+    const broker = rotatingBroker(oauth1());
+    const auth = new TwitterAuth(broker.provider);
+
+    await expect(auth.me()).resolves.toMatchObject({ userId: "old-account" });
+    await expect(auth.me()).resolves.toMatchObject({ userId: "old-account" });
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledTimes(1);
+    expect(twitterApiHarness.instances[0]?.me).toHaveBeenCalledTimes(1);
+
+    broker.rotate(oauth1({ accessSecret: "access-secret-two" }));
+    await expect(auth.me()).resolves.toMatchObject({ userId: "new-account" });
+
+    expect(broker.getBrokerCredentials).toHaveBeenCalledTimes(3);
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledTimes(2);
+    expect(twitterApiHarness.instances[0]?.me).toHaveBeenCalledTimes(1);
+    expect(twitterApiHarness.instances[1]?.me).toHaveBeenCalledTimes(1);
+  });
+
+  it("stores only a fixed-length digest for credential equality", async () => {
+    twitterApiHarness.profiles.push(user("one"));
+    const credentials = oauth1();
+    const auth = new TwitterAuth(rotatingBroker(credentials).provider);
+
+    await auth.getV2Client();
+
+    const fingerprint = (
+      auth as unknown as { generation?: { fingerprint?: string } }
+    ).generation?.fingerprint;
+    expect(fingerprint).toMatch(/^[a-f0-9]{64}$/);
+    for (const secret of [
+      credentials.appKey,
+      credentials.appSecret,
+      credentials.accessToken,
+      credentials.accessSecret,
+    ]) {
+      expect(fingerprint).not.toContain(secret);
+    }
+  });
+
+  it("serializes concurrent initialization and profile loading", async () => {
+    twitterApiHarness.profiles.push(user("one"));
+    const broker = rotatingBroker(oauth1());
+    const auth = new TwitterAuth(broker.provider);
+
+    const clients = await Promise.all([
+      auth.getV2Client(),
+      auth.getV2Client(),
+      auth.getV2Client(),
+    ]);
+    expect(new Set(clients).size).toBe(1);
+    expect(broker.getBrokerCredentials).toHaveBeenCalledTimes(2);
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledOnce();
+
+    const profiles = await Promise.all([auth.me(), auth.me()]);
+    expect(profiles).toEqual([
+      expect.objectContaining({ userId: "one" }),
+      expect.objectContaining({ userId: "one" }),
+    ]);
+    expect(twitterApiHarness.instances[0]?.me).toHaveBeenCalledOnce();
+  });
+
+  it("revalidates a follower when the broker changes during first initialization", async () => {
+    const firstCredentials = deferred<BrokerAuthCredentials>();
+    const getBrokerCredentials = vi
+      .fn<() => Promise<BrokerAuthCredentials>>()
+      .mockImplementationOnce(() => firstCredentials.promise)
+      .mockResolvedValue(oauth1({ accessSecret: "account-c-secret" }));
+    const provider: TwitterBrokerProvider = {
+      mode: "broker",
+      getAccessToken: async () => "shared-access-token",
+      getBrokerCredentials,
+    };
+    twitterApiHarness.profiles.push(user("account-b"), user("account-c"));
+    const auth = new TwitterAuth(provider);
+
+    const pendingB = auth.me();
+    await vi.waitFor(() => expect(getBrokerCredentials).toHaveBeenCalledOnce());
+    const accountCCall = auth.me();
+    firstCredentials.resolve(oauth1({ accessSecret: "account-b-secret" }));
+
+    await expect(pendingB).resolves.toMatchObject({ userId: "account-c" });
+    await expect(accountCCall).resolves.toMatchObject({ userId: "account-c" });
+    expect(getBrokerCredentials).toHaveBeenCalledTimes(2);
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledTimes(2);
+    expect(twitterApiHarness.instances[0]?.me).not.toHaveBeenCalled();
+    expect(twitterApiHarness.instances[1]?.me).toHaveBeenCalledOnce();
+  });
+
+  it("never resurrects a profile that resolves after rotation", async () => {
+    const oldProfile = deferred<Record<string, unknown>>();
+    twitterApiHarness.profiles.push(oldProfile.promise, user("new-account"));
+    const broker = rotatingBroker(oauth1());
+    const auth = new TwitterAuth(broker.provider);
+
+    const startedBeforeRotation = auth.me();
+    await vi.waitFor(() =>
+      expect(twitterApiHarness.instances[0]?.me).toHaveBeenCalledOnce(),
+    );
+
+    broker.rotate(oauth1({ accessSecret: "rotated-secret" }));
+    const current = auth.me();
+    await expect(current).resolves.toMatchObject({ userId: "new-account" });
+
+    oldProfile.resolve(user("old-account"));
+    await expect(startedBeforeRotation).resolves.toMatchObject({
+      userId: "new-account",
+    });
+    expect(twitterApiHarness.instances[0]?.me).toHaveBeenCalledOnce();
+    expect(twitterApiHarness.instances[1]?.me).toHaveBeenCalledOnce();
+  });
+
+  it("ignores a stale profile failure after rotation", async () => {
+    const oldProfile = deferred<Record<string, unknown>>();
+    twitterApiHarness.profiles.push(oldProfile.promise, user("new-account"));
+    const broker = rotatingBroker(oauth1());
+    const auth = new TwitterAuth(broker.provider);
+
+    const startedBeforeRotation = auth.me();
+    await vi.waitFor(() =>
+      expect(twitterApiHarness.instances[0]?.me).toHaveBeenCalledOnce(),
+    );
+    broker.rotate(oauth1({ accessSecret: "rotated-secret" }));
+    await expect(auth.me()).resolves.toMatchObject({ userId: "new-account" });
+
+    oldProfile.reject(new Error("old credential rejected"));
+    await expect(startedBeforeRotation).resolves.toMatchObject({
+      userId: "new-account",
+    });
+  });
+
+  it("drains an active generation before admitting a rotated broker generation without replaying the operation", async () => {
+    twitterApiHarness.profiles.push(user("account-a"), user("account-b"));
+    const broker = rotatingBroker(oauth1());
+    const auth = new TwitterAuth(broker.provider);
+    const operationStarted = deferred<void>();
+    const finishOperation = deferred<void>();
+    const failure = new Error("local persistence failed after the X write");
+    const operation = vi.fn(async (session: AuthenticatedTwitterSession) => {
+      operationStarted.resolve();
+      await finishOperation.promise;
+      const nestedProfile = await auth.withAuthenticatedSession(
+        async (nestedSession) => nestedSession.profile.userId,
+      );
+      expect(nestedProfile).toBe("account-a");
+      const pinnedClient = await auth.withCurrentSession(session, () =>
+        auth.getV2Client(),
+      );
+      expect(pinnedClient).toBe(session.client);
+      throw failure;
+    });
+
+    const accountAOperation = auth.withAuthenticatedSession(operation);
+    await operationStarted.promise;
+
+    broker.rotate(oauth1({ accessSecret: "account-b-secret" }));
+    const accountBProfile = auth.me();
+    await vi.waitFor(() =>
+      expect(broker.getBrokerCredentials).toHaveBeenCalledTimes(2),
+    );
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledOnce();
+
+    finishOperation.resolve();
+    await expect(accountAOperation).rejects.toBe(failure);
+    await expect(accountBProfile).resolves.toMatchObject({
+      userId: "account-b",
+    });
+    expect(operation).toHaveBeenCalledOnce();
+    expect(operation.mock.calls[0]?.[0]).toMatchObject({
+      profile: { userId: "account-a" },
+    });
+  });
+
+  it("revalidates a pending A-to-B rotation so a later caller observes broker generation C", async () => {
+    twitterApiHarness.profiles.push(
+      user("account-a"),
+      user("account-b"),
+      user("account-c"),
+    );
+    const broker = rotatingBroker(oauth1());
+    const auth = new TwitterAuth(broker.provider);
+    const operationStarted = deferred<void>();
+    const finishOperation = deferred<void>();
+    const accountAOperation = auth.withAuthenticatedSession(async (session) => {
+      operationStarted.resolve();
+      await finishOperation.promise;
+      return session.profile.userId;
+    });
+    await operationStarted.promise;
+
+    broker.rotate(oauth1({ accessSecret: "account-b-secret" }));
+    const pendingB = auth.me();
+    await vi.waitFor(() =>
+      expect(broker.getBrokerCredentials).toHaveBeenCalledTimes(2),
+    );
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledOnce();
+
+    broker.rotate(oauth1({ accessSecret: "account-c-secret" }));
+    const accountCCall = auth.me();
+    finishOperation.resolve();
+
+    await expect(accountAOperation).resolves.toBe("account-a");
+    await expect(pendingB).resolves.toMatchObject({ userId: "account-c" });
+    await expect(accountCCall).resolves.toMatchObject({ userId: "account-c" });
+    expect(broker.getBrokerCredentials).toHaveBeenCalledTimes(3);
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledTimes(3);
+    expect(twitterApiHarness.instances[1]?.me).not.toHaveBeenCalled();
+    expect(twitterApiHarness.instances[2]?.me).toHaveBeenCalledOnce();
+  });
+
+  it("revokes a detached child pin after the outer session releases", async () => {
+    twitterApiHarness.profiles.push(user("account-a"), user("account-b"));
+    const broker = rotatingBroker(oauth1());
+    const auth = new TwitterAuth(broker.provider);
+    const resumeDetachedChild = deferred<void>();
+    const detachedOperation = vi.fn(
+      async (session: AuthenticatedTwitterSession) => session,
+    );
+    let detachedChild!: Promise<AuthenticatedTwitterSession>;
+    let accountAClient: unknown;
+
+    await expect(
+      auth.withAuthenticatedSession(async (session) => {
+        accountAClient = session.client;
+        detachedChild = (async () => {
+          await resumeDetachedChild.promise;
+          return auth.withAuthenticatedSession(detachedOperation);
+        })();
+        return session.profile.userId;
+      }),
+    ).resolves.toBe("account-a");
+
+    broker.rotate(oauth1({ accessSecret: "account-b-secret" }));
+    await expect(auth.me()).resolves.toMatchObject({ userId: "account-b" });
+    resumeDetachedChild.resolve();
+
+    await expect(detachedChild).resolves.toMatchObject({
+      profile: { userId: "account-b" },
+    });
+    expect((await detachedChild).client).not.toBe(accountAClient);
+    expect(detachedOperation).toHaveBeenCalledOnce();
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledTimes(2);
+  });
+
+  it("prevents ABA profile resurrection with credential generations", async () => {
+    const firstA = deferred<Record<string, unknown>>();
+    twitterApiHarness.profiles.push(
+      firstA.promise,
+      user("account-b"),
+      user("account-a-current"),
+    );
+    const credentialsA = oauth1();
+    const broker = rotatingBroker(credentialsA);
+    const auth = new TwitterAuth(broker.provider);
+
+    const staleA = auth.me();
+    await vi.waitFor(() =>
+      expect(twitterApiHarness.instances[0]?.me).toHaveBeenCalledOnce(),
+    );
+    broker.rotate(oauth1({ accessSecret: "account-b-secret" }));
+    await expect(auth.me()).resolves.toMatchObject({ userId: "account-b" });
+    broker.rotate(credentialsA);
+    await expect(auth.me()).resolves.toMatchObject({
+      userId: "account-a-current",
+    });
+
+    firstA.resolve(user("account-a-stale"));
+    await expect(staleA).resolves.toMatchObject({
+      userId: "account-a-current",
+    });
+  });
+
+  it("retries a current-generation profile failure without exposing credential text", async () => {
+    const profile = vi
+      .fn<() => Promise<Record<string, unknown>>>()
+      .mockRejectedValueOnce(new Error("access-secret-one rejected"))
+      .mockResolvedValueOnce(user("recovered"));
+    twitterApiHarness.profiles.push(profile);
+    const auth = new TwitterAuth(rotatingBroker(oauth1()).provider);
+
+    const firstError = await auth.me().catch((error: unknown) => error);
+    expect(firstError).toMatchObject({ code: "X_ME_FETCH_FAILED" });
+    expect(String((firstError as Error).message)).not.toContain(
+      "access-secret-one",
+    );
+    expect((firstError as Error & { cause?: unknown }).cause).toBeUndefined();
+    expect(JSON.stringify(firstError)).not.toContain("access-secret-one");
+    await expect(auth.me()).resolves.toMatchObject({ userId: "recovered" });
+    expect(twitterApiHarness.instances[0]?.me).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    { label: "401", fields: { code: 401 } },
+    { label: "provider auth marker", fields: { code: 400, isAuthError: true } },
+  ])(
+    "classifies an X $label profile response as rejected credentials without retaining provider details",
+    async ({ fields }) => {
+      const providerError = Object.assign(
+        new Error("access-secret-one rejected"),
+        fields,
+      );
+      twitterApiHarness.profiles.push(() => Promise.reject(providerError));
+      const auth = new TwitterAuth(rotatingBroker(oauth1()).provider);
+
+      const error = await auth.me().catch((cause: unknown) => cause);
+
+      expect(error).toMatchObject({ code: "X_AUTH_REJECTED" });
+      expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+      expect(JSON.stringify(error)).not.toContain("access-secret-one");
+    },
+  );
+
+  it("does not misclassify a non-auth 403 response as rejected credentials", async () => {
+    const providerError = Object.assign(
+      new Error("access-secret-one client forbidden"),
+      { code: 403, isAuthError: false },
+    );
+    twitterApiHarness.profiles.push(() => Promise.reject(providerError));
+    const auth = new TwitterAuth(rotatingBroker(oauth1()).provider);
+
+    const error = await auth.me().catch((cause: unknown) => cause);
+
+    expect(error).toMatchObject({ code: "X_ME_FETCH_FAILED" });
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+    expect(JSON.stringify(error)).not.toContain("access-secret-one");
+  });
+
+  it("keeps rate limits and provider outages distinct from credential rejection", async () => {
+    const providerError = Object.assign(
+      new Error("access-secret-one provider overloaded"),
+      { code: 429 },
+    );
+    twitterApiHarness.profiles.push(() => Promise.reject(providerError));
+    const auth = new TwitterAuth(rotatingBroker(oauth1()).provider);
+
+    const error = await auth.me().catch((cause: unknown) => cause);
+    expect(error).toMatchObject({ code: "X_ME_FETCH_FAILED" });
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+    expect(String((error as Error).message)).not.toContain("access-secret-one");
+    expect(JSON.stringify(error)).not.toContain("access-secret-one");
+  });
+
+  it("clears a rejected initialization flight so the next call can retry", async () => {
+    twitterApiHarness.profiles.push(user("one"));
+    const getBrokerCredentials = vi
+      .fn<() => Promise<BrokerAuthCredentials>>()
+      .mockRejectedValueOnce(new Error("broker unavailable"))
+      .mockResolvedValueOnce(oauth1());
+    const provider: TwitterBrokerProvider = {
+      mode: "broker",
+      getAccessToken: async () => "shared-access-token",
+      getBrokerCredentials,
+    };
+    const auth = new TwitterAuth(provider);
+
+    const initializationError = await auth
+      .getV2Client()
+      .catch((error: unknown) => error);
+    expect(initializationError).toMatchObject({
+      code: "X_AUTH_INITIALIZATION_FAILED",
+      message: "Failed to resolve X credentials",
+    });
+    expect(
+      (initializationError as Error & { cause?: unknown }).cause,
+    ).toBeUndefined();
+    expect(JSON.stringify(initializationError)).not.toContain(
+      "broker unavailable",
+    );
+    await expect(auth.getV2Client()).resolves.toBeDefined();
+    expect(getBrokerCredentials).toHaveBeenCalledTimes(2);
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledOnce();
+  });
+
+  it("sanitizes twitter-api-v2 constructor failures without retaining credentials", async () => {
+    const secret = "constructor-secret-access-token";
+    twitterApiHarness.constructorFailures.push(
+      new Error(`twitter-api-v2 rejected ${secret}`),
+    );
+    const auth = new TwitterAuth(
+      rotatingBroker(oauth1({ accessToken: secret })).provider,
+    );
+
+    const initializationError = await auth
+      .getV2Client()
+      .catch((error: unknown) => error);
+
+    expect(initializationError).toMatchObject({
+      code: "X_AUTH_INITIALIZATION_FAILED",
+      message: "Failed to initialize X API client",
+    });
+    expect(
+      (initializationError as Error & { cause?: unknown }).cause,
+    ).toBeUndefined();
+    expect(String((initializationError as Error).message)).not.toContain(
+      secret,
+    );
+    expect(JSON.stringify(initializationError)).not.toContain(secret);
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledOnce();
+    expect(twitterApiHarness.instances).toHaveLength(0);
+  });
+
+  it("revokes account A before a rotated account-B constructor failure and recovers on retry", async () => {
+    const secret = "account-b-constructor-secret";
+    twitterApiHarness.profiles.push(user("account-a"), user("account-b"));
+    const broker = rotatingBroker(oauth1());
+    const auth = new TwitterAuth(broker.provider);
+    const accountASession = await auth.getAuthenticatedSession();
+    expect(auth.isAuthenticatedSessionCurrent(accountASession)).toBe(true);
+
+    broker.rotate(
+      oauth1({ accessSecret: secret, accessToken: "account-b-token" }),
+    );
+    twitterApiHarness.constructorFailures.push(
+      new Error(`twitter-api-v2 rejected ${secret}`),
+    );
+    const rotationError = await auth.me().catch((error: unknown) => error);
+
+    expect(rotationError).toMatchObject({
+      code: "X_AUTH_INITIALIZATION_FAILED",
+      message: "Failed to initialize X API client",
+    });
+    expect(
+      (rotationError as Error & { cause?: unknown }).cause,
+    ).toBeUndefined();
+    expect(JSON.stringify(rotationError)).not.toContain(secret);
+    expect(auth.isAuthenticatedSessionCurrent(accountASession)).toBe(false);
+    expect(auth.hasToken()).toBe(false);
+    expect(
+      (
+        auth as unknown as {
+          generation?: unknown;
+          profileCache?: unknown;
+        }
+      ).generation,
+    ).toBeUndefined();
+    expect(
+      (auth as unknown as { profileCache?: unknown }).profileCache,
+    ).toBeUndefined();
+
+    await expect(auth.me()).resolves.toMatchObject({ userId: "account-b" });
+    expect(auth.hasToken()).toBe(true);
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledTimes(3);
+    expect(twitterApiHarness.instances[0]?.me).toHaveBeenCalledOnce();
+    expect(twitterApiHarness.instances[1]?.me).toHaveBeenCalledOnce();
+  });
+
+  it("cannot construct a client after logout wins credential resolution", async () => {
+    const credentials = deferred<BrokerAuthCredentials>();
+    const provider: TwitterBrokerProvider = {
+      mode: "broker",
+      getAccessToken: async () => "shared-access-token",
+      getBrokerCredentials: vi.fn(() => credentials.promise),
+    };
+    const auth = new TwitterAuth(provider);
+
+    const initialization = auth.getV2Client();
+    await vi.waitFor(() =>
+      expect(provider.getBrokerCredentials).toHaveBeenCalledOnce(),
+    );
+    await auth.logout();
+    credentials.resolve(oauth1());
+
+    await expect(initialization).rejects.toThrow(
+      "Twitter API client not initialized",
+    );
+    expect(twitterApiHarness.twitterApiConstructor).not.toHaveBeenCalled();
+  });
+
+  it("cannot return or cache a profile after logout wins profile resolution", async () => {
+    const profile = deferred<Record<string, unknown>>();
+    twitterApiHarness.profiles.push(profile.promise);
+    const auth = new TwitterAuth(rotatingBroker(oauth1()).provider);
+
+    const pendingProfile = auth.me();
+    await vi.waitFor(() =>
+      expect(twitterApiHarness.instances[0]?.me).toHaveBeenCalledOnce(),
+    );
+    await auth.logout();
+    profile.resolve(user("stale"));
+
+    await expect(pendingProfile).rejects.toThrow(
+      "Twitter API client not initialized",
+    );
+    await expect(auth.me()).rejects.toThrow(
+      "Twitter API client not initialized",
+    );
+  });
+
+  it("public Client.logout invalidates its TwitterAuth", async () => {
+    twitterApiHarness.profiles.push(user("one"));
+    const auth = new TwitterAuth(rotatingBroker(oauth1()).provider);
+    const client = new Client();
+    client.updateAuth(auth);
+
+    await client.getV2Client();
+    await client.logout();
+
+    expect(client.getAuth()).toBeNull();
+    expect(client.isAuthenticated()).toBe(false);
+    await expect(auth.getV2Client()).rejects.toThrow(
+      "Twitter API client not initialized",
+    );
+    await expect(client.getV2Client()).rejects.toThrow("Not authenticated");
+  });
+
+  it("public Client.authenticate installs one verified auth session", async () => {
+    twitterApiHarness.profiles.push(user("verified"));
+    const broker = rotatingBroker(oauth1());
+    const client = new Client();
+
+    await client.authenticate(broker.provider);
+
+    expect(client.getAuth()).toBeInstanceOf(TwitterAuth);
+    expect(client.isAuthenticated()).toBe(true);
+    await expect(client.me()).resolves.toMatchObject({ userId: "verified" });
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledOnce();
+    expect(twitterApiHarness.instances[0]?.me).toHaveBeenCalledOnce();
+  });
+
+  it("public Client.authenticate rejects sanitized verification failures and leaves no auth installed", async () => {
+    const secret = "authenticate-secret-access-token";
+    const providerError = Object.assign(new Error(`X rejected ${secret}`), {
+      code: 401,
+    });
+    twitterApiHarness.profiles.push(() => Promise.reject(providerError));
+    const broker = rotatingBroker(oauth1({ accessToken: secret }));
+    const client = new Client();
+
+    const error = await client
+      .authenticate(broker.provider)
+      .catch((cause: unknown) => cause);
+
+    expect(error).toMatchObject({ code: "X_AUTH_REJECTED" });
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+    expect(JSON.stringify(error)).not.toContain(secret);
+    expect(client.getAuth()).toBeNull();
+    expect(client.isAuthenticated()).toBe(false);
+    await expect(client.getV2Client()).rejects.toThrow("Not authenticated");
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledOnce();
+    expect(twitterApiHarness.instances[0]?.me).toHaveBeenCalledOnce();
+  });
+
+  it("rejects logout and invalidation inside its own session without hanging or mutating it", async () => {
+    twitterApiHarness.profiles.push(user("one"));
+    const auth = new TwitterAuth(rotatingBroker(oauth1()).provider);
+
+    const result = await auth.withAuthenticatedSession(async (session) => {
+      expect(() => auth.invalidate()).toThrowError(
+        expect.objectContaining({
+          code: "X_AUTH_REPLACEMENT_DURING_SESSION",
+        }),
+      );
+      await expect(auth.logout()).rejects.toMatchObject({
+        code: "X_AUTH_REPLACEMENT_DURING_SESSION",
+      });
+      expect(auth.isAuthenticatedSessionCurrent(session)).toBe(true);
+      return session.profile.userId;
+    });
+
+    expect(result).toBe("one");
+    await expect(auth.me()).resolves.toMatchObject({ userId: "one" });
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledOnce();
+  });
+
+  it("invalidates the prior TwitterAuth when Client credentials are replaced", async () => {
+    twitterApiHarness.profiles.push(user("old"), user("new"));
+    const oldAuth = new TwitterAuth(rotatingBroker(oauth1()).provider);
+    const newAuth = new TwitterAuth(
+      rotatingBroker(oauth1({ accessSecret: "new-secret" })).provider,
+    );
+    const client = new Client();
+    client.updateAuth(oldAuth);
+    await expect(client.me()).resolves.toMatchObject({ userId: "old" });
+
+    client.updateAuth(newAuth);
+
+    await expect(oldAuth.getV2Client()).rejects.toMatchObject({
+      code: "X_AUTH_NOT_INITIALIZED",
+    });
+    await expect(client.me()).resolves.toMatchObject({ userId: "new" });
+  });
+
+  it("waits for an active account-A operation before constructing replacement account B", async () => {
+    twitterApiHarness.profiles.push(user("account-a"), user("account-b"));
+    const accountAAuth = new TwitterAuth(rotatingBroker(oauth1()).provider);
+    const accountBBroker = rotatingBroker(
+      oauth1({ accessSecret: "account-b-secret" }),
+    );
+    const accountBAuth = new TwitterAuth(accountBBroker.provider);
+    const client = new Client();
+    client.updateAuth(accountAAuth);
+    const operationStarted = deferred<void>();
+    const finishOperation = deferred<void>();
+
+    const accountAOperation = client.withAuthenticatedSession(
+      async (session) => {
+        operationStarted.resolve();
+        await finishOperation.promise;
+        return session.profile.userId;
+      },
+    );
+    await operationStarted.promise;
+
+    client.updateAuth(accountBAuth);
+    const accountBProfile = client.me();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(accountBBroker.getBrokerCredentials).not.toHaveBeenCalled();
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledOnce();
+
+    finishOperation.resolve();
+    await expect(accountAOperation).resolves.toBe("account-a");
+    await expect(accountBProfile).resolves.toMatchObject({
+      userId: "account-b",
+    });
+    expect(accountBBroker.getBrokerCredentials).toHaveBeenCalledOnce();
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledTimes(2);
+  });
+
+  it("drains an in-flight account-A tweet before activating account B and does not replay the write", async () => {
+    twitterApiHarness.profiles.push(user("account-a"), user("account-b"));
+    const accountAAuth = new TwitterAuth(rotatingBroker(oauth1()).provider);
+    const accountBBroker = rotatingBroker(
+      oauth1({ accessSecret: "account-b-secret" }),
+    );
+    const accountBAuth = new TwitterAuth(accountBBroker.provider);
+    const client = new Client();
+    client.updateAuth(accountAAuth);
+    await expect(client.me()).resolves.toMatchObject({ userId: "account-a" });
+
+    const accountATweet = deferred<{
+      data: { id: string; text: string };
+    }>();
+    twitterApiHarness.instances[0]?.tweet.mockImplementationOnce(
+      () => accountATweet.promise,
+    );
+    const pendingTweet = client.sendTweet("from-account-a");
+    await vi.waitFor(() =>
+      expect(twitterApiHarness.instances[0]?.tweet).toHaveBeenCalledOnce(),
+    );
+
+    client.updateAuth(accountBAuth);
+    const accountBProfile = client.me();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(accountBBroker.getBrokerCredentials).not.toHaveBeenCalled();
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledOnce();
+
+    accountATweet.resolve({
+      data: { id: "tweet-account-a", text: "from-account-a" },
+    });
+    await expect(pendingTweet).resolves.toMatchObject({
+      data: { data: { id: "tweet-account-a" } },
+    });
+    await expect(accountBProfile).resolves.toMatchObject({
+      userId: "account-b",
+    });
+    await expect(client.sendTweet("from-account-b")).resolves.toMatchObject({
+      data: { data: { id: "tweet-2" } },
+    });
+
+    expect(twitterApiHarness.instances[0]?.tweet).toHaveBeenCalledOnce();
+    expect(twitterApiHarness.instances[1]?.tweet).toHaveBeenCalledOnce();
+    expect(accountBBroker.getBrokerCredentials).toHaveBeenCalledTimes(2);
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledTimes(2);
+  });
+
+  it("drains an in-flight account-A read before activating account B", async () => {
+    twitterApiHarness.profiles.push(user("account-a"), user("account-b"));
+    const accountAAuth = new TwitterAuth(rotatingBroker(oauth1()).provider);
+    const accountBBroker = rotatingBroker(
+      oauth1({ accessSecret: "account-b-secret" }),
+    );
+    const accountBAuth = new TwitterAuth(accountBBroker.provider);
+    const client = new Client();
+    client.updateAuth(accountAAuth);
+    await expect(client.me()).resolves.toMatchObject({ userId: "account-a" });
+
+    const accountAUser = deferred<{
+      data: { id: string; username: string };
+    }>();
+    twitterApiHarness.instances[0]?.user.mockImplementationOnce(
+      () => accountAUser.promise,
+    );
+    const pendingRead = client.getScreenNameByUserId("target-user");
+    await vi.waitFor(() =>
+      expect(twitterApiHarness.instances[0]?.user).toHaveBeenCalledOnce(),
+    );
+
+    client.updateAuth(accountBAuth);
+    const accountBProfile = client.me();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(accountBBroker.getBrokerCredentials).not.toHaveBeenCalled();
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledOnce();
+
+    accountAUser.resolve({
+      data: { id: "target-user", username: "screen-account-a" },
+    });
+    await expect(pendingRead).resolves.toBe("screen-account-a");
+    await expect(accountBProfile).resolves.toMatchObject({
+      userId: "account-b",
+    });
+    await expect(client.getScreenNameByUserId("target-user")).resolves.toBe(
+      "screen-2",
+    );
+
+    expect(twitterApiHarness.instances[0]?.user).toHaveBeenCalledOnce();
+    expect(twitterApiHarness.instances[1]?.user).toHaveBeenCalledOnce();
+    expect(accountBBroker.getBrokerCredentials).toHaveBeenCalledTimes(2);
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps nested public provider calls on the active Client session", async () => {
+    twitterApiHarness.profiles.push(user("account-a"));
+    const client = new Client();
+    client.updateAuth(new TwitterAuth(rotatingBroker(oauth1()).provider));
+
+    const result = await client.withAuthenticatedSession(async (session) => {
+      expect(session.profile.userId).toBe("account-a");
+      return client.sendTweet("nested-account-a");
+    });
+
+    expect(result).toMatchObject({ data: { data: { id: "tweet-1" } } });
+    expect(twitterApiHarness.instances[0]?.tweet).toHaveBeenCalledOnce();
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledOnce();
+  });
+
+  it("revokes a detached Client auth pin and permits replacement plus logout after outer release", async () => {
+    twitterApiHarness.profiles.push(user("account-a"), user("account-b"));
+    const accountAAuth = new TwitterAuth(rotatingBroker(oauth1()).provider);
+    const accountBAuth = new TwitterAuth(
+      rotatingBroker(oauth1({ accessSecret: "account-b-secret" })).provider,
+    );
+    const accountCAuth = new TwitterAuth(
+      rotatingBroker(oauth1({ accessSecret: "account-c-secret" })).provider,
+    );
+    const client = new Client();
+    client.updateAuth(accountAAuth);
+    const resumeDetachedChild = deferred<void>();
+    const detachedOperation = vi.fn(
+      async (session: AuthenticatedTwitterSession) => session,
+    );
+    let detachedChild!: Promise<AuthenticatedTwitterSession>;
+
+    await expect(
+      client.withAuthenticatedSession(async (session) => {
+        const nestedProfile = await client.withAuthenticatedSession(
+          async (nestedSession) => nestedSession.profile.userId,
+        );
+        expect(nestedProfile).toBe("account-a");
+        detachedChild = (async () => {
+          await resumeDetachedChild.promise;
+          const currentSession =
+            await client.withAuthenticatedSession(detachedOperation);
+          client.updateAuth(accountCAuth);
+          await client.logout();
+          return currentSession;
+        })();
+        return session.profile.userId;
+      }),
+    ).resolves.toBe("account-a");
+
+    client.updateAuth(accountBAuth);
+    await expect(client.me()).resolves.toMatchObject({ userId: "account-b" });
+    resumeDetachedChild.resolve();
+
+    await expect(detachedChild).resolves.toMatchObject({
+      profile: { userId: "account-b" },
+    });
+    expect(detachedOperation).toHaveBeenCalledOnce();
+    expect(client.getAuth()).toBeNull();
+    await expect(client.getV2Client()).rejects.toThrow("Not authenticated");
+    await expect(accountCAuth.getV2Client()).rejects.toMatchObject({
+      code: "X_AUTH_NOT_INITIALIZED",
+    });
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates nested session access when an in-flight Client operation replaces account A with B", async () => {
+    twitterApiHarness.profiles.push(user("account-a"), user("account-b"));
+    const accountAAuth = new TwitterAuth(rotatingBroker(oauth1()).provider);
+    const accountBAuth = new TwitterAuth(
+      rotatingBroker(oauth1({ accessSecret: "account-b-secret" })).provider,
+    );
+    const client = new Client();
+    client.updateAuth(accountAAuth);
+    const operationStarted = deferred<void>();
+    const resumeOperation = deferred<void>();
+    const nestedOperation = vi.fn(
+      async (session: AuthenticatedTwitterSession) => session.profile.userId,
+    );
+    const operation = client.withAuthenticatedSession(async (session) => {
+      expect(session.profile.userId).toBe("account-a");
+      operationStarted.resolve();
+      await resumeOperation.promise;
+      return client.withAuthenticatedSession(nestedOperation);
+    });
+    await operationStarted.promise;
+
+    client.updateAuth(accountBAuth);
+    resumeOperation.resolve();
+
+    await expect(operation).rejects.toMatchObject({
+      code: "X_AUTH_NOT_INITIALIZED",
+    });
+    expect(nestedOperation).not.toHaveBeenCalled();
+    await expect(client.me()).resolves.toMatchObject({ userId: "account-b" });
+    expect(twitterApiHarness.twitterApiConstructor).toHaveBeenCalledTimes(2);
+  });
+});

--- a/plugins/plugin-x/src/client/auth.ts
+++ b/plugins/plugin-x/src/client/auth.ts
@@ -1,30 +1,91 @@
 /**
- * `TwitterAuth` — lazily materializes a twitter-api-v2 `TwitterApi` from a
- * `TwitterAuthProvider`, transparently supporting both auth modes: OAuth 1.0a
- * (built from the provider's four static credentials) and OAuth 2.0 user-context
- * (a Bearer access token that is refreshed when the provider hands back a new one).
- * Caches the authenticated `me()` profile and is the object `Client.getV2Client()`
- * hands the raw v2 client from.
+ * Authenticates X API calls across static, PKCE, and managed broker credentials.
+ * The complete effective credential tuple identifies the cached client; changing
+ * any OAuth field or mode discards the authenticated profile before reuse.
  */
+import { AsyncLocalStorage } from "node:async_hooks";
+import { createHmac, randomBytes } from "node:crypto";
 import { ElizaError, logger } from "@elizaos/core";
 import { TwitterApi } from "twitter-api-v2";
 import type {
+  BrokerAuthCredentials,
   TwitterAuthProvider,
   TwitterBrokerProvider,
   TwitterOAuth1Provider,
 } from "./auth-providers/types";
 import type { Profile } from "./profile";
 
+function credentialFingerprint(
+  key: Buffer,
+  providerMode: TwitterAuthProvider["mode"],
+  credentials: BrokerAuthCredentials,
+): string {
+  const values =
+    credentials.mode === "oauth1"
+      ? [
+          providerMode,
+          credentials.mode,
+          credentials.appKey,
+          credentials.appSecret,
+          credentials.accessToken,
+          credentials.accessSecret,
+        ]
+      : [providerMode, credentials.mode, credentials.accessToken];
+  const hash = createHmac("sha256", key);
+  for (const value of values) {
+    hash.update(String(Buffer.byteLength(value, "utf8")));
+    hash.update(":");
+    hash.update(value);
+  }
+  return hash.digest("hex");
+}
+
+function isCredentialRejection(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const candidate = error as { code?: unknown; isAuthError?: unknown };
+  return candidate.isAuthError === true || candidate.code === 401;
+}
+
+type ClientGeneration = {
+  id: number;
+  fingerprint: string;
+  client: TwitterApi;
+};
+
+type SessionContext = {
+  generation: ClientGeneration;
+  active: boolean;
+};
+
+export type AuthenticatedTwitterSession = {
+  client: TwitterApi;
+  profile: Profile;
+  revision: number;
+};
+
 /**
  * Twitter API v2 authentication using developer credentials
  */
 export class TwitterAuth {
-  private v2Client: TwitterApi | null = null;
+  private generation?: ClientGeneration;
+  private nextGeneration = 0;
+  private lifecycle = 0;
   private authenticated = false;
-  private profile?: Profile;
   private loggedOut = false;
-
-  private lastAccessToken?: string;
+  private activation: Promise<void> = Promise.resolve();
+  private activeSessions = 0;
+  private admissionBarrier?: { promise: Promise<void>; resolve: () => void };
+  private sessionDrain?: { promise: Promise<void>; resolve: () => void };
+  private readonly fingerprintKey = randomBytes(32);
+  private generationGate: Promise<void> = Promise.resolve();
+  private readonly sessionContext = new AsyncLocalStorage<SessionContext>();
+  private initialization?: {
+    lifecycle: number;
+    promise: Promise<ClientGeneration>;
+    state: { revalidationRequested: boolean };
+  };
+  private profileCache?: { generation: number; profile: Profile };
+  private readonly profileLoads = new Map<number, Promise<Profile>>();
 
   constructor(private readonly provider: TwitterAuthProvider) {
     if (this.isOAuth1Provider(provider)) {
@@ -42,112 +103,175 @@ export class TwitterAuth {
     return typeof candidate.getBrokerCredentials === "function";
   }
 
-  private async ensureClientInitialized(): Promise<void> {
-    if (this.loggedOut) {
-      throw new Error("Twitter API client not initialized");
-    }
+  private async resolveCredentials(): Promise<BrokerAuthCredentials> {
     if (this.isBrokerProvider(this.provider)) {
-      const credentials = await this.provider.getBrokerCredentials();
-      if (credentials.mode === "oauth1") {
-        if (this.v2Client && this.lastAccessToken === credentials.accessToken)
-          return;
-        this.v2Client = new TwitterApi({
-          appKey: credentials.appKey,
-          appSecret: credentials.appSecret,
-          accessToken: credentials.accessToken,
-          accessSecret: credentials.accessSecret,
-        });
-        this.lastAccessToken = credentials.accessToken;
-      } else if (
-        !this.v2Client ||
-        this.lastAccessToken !== credentials.accessToken
-      ) {
-        this.v2Client = new TwitterApi(credentials.accessToken);
-        this.lastAccessToken = credentials.accessToken;
-      }
-      this.authenticated = true;
-      return;
+      return this.provider.getBrokerCredentials();
     }
     if (this.isOAuth1Provider(this.provider)) {
-      if (this.v2Client) return;
-      const creds = await this.provider.getOAuth1Credentials();
-      this.v2Client = new TwitterApi({
-        appKey: creds.appKey,
-        appSecret: creds.appSecret,
-        accessToken: creds.accessToken,
-        accessSecret: creds.accessSecret,
-      });
-      this.authenticated = true;
-      this.lastAccessToken = creds.accessToken;
-      return;
+      return {
+        mode: "oauth1",
+        ...(await this.provider.getOAuth1Credentials()),
+      };
     }
-
-    const token = await this.provider.getAccessToken();
-    if (!this.v2Client || this.lastAccessToken !== token) {
-      // OAuth2 user context token: Bearer token
-      this.v2Client = new TwitterApi(token);
-      this.authenticated = true;
-      this.lastAccessToken = token;
-    }
+    return {
+      mode: "oauth2",
+      accessToken: await this.provider.getAccessToken(),
+    };
   }
 
-  /**
-   * Get the Twitter API v2 client
-   */
-  async getV2Client(): Promise<TwitterApi> {
-    await this.ensureClientInitialized();
-    if (!this.v2Client) {
-      throw new Error("Twitter API client not initialized");
-    }
-    return this.v2Client;
-  }
-
-  /**
-   * Check if authenticated
-   */
-  async isLoggedIn(): Promise<boolean> {
-    // error-policy:J4 availability probe — this method's contract is a boolean
-    // "are we authenticated" answer, so any init/verify failure is the designed
-    // false, not a masked read. Callers that need the failure call me() instead.
+  private async initializeClient(lifecycle: number): Promise<ClientGeneration> {
+    this.assertActiveLifecycle(lifecycle);
+    let credentials: BrokerAuthCredentials;
+    // error-policy:J1 provider boundary translates potentially secret-bearing
+    // credential resolution failures into one safe connector error.
     try {
-      await this.ensureClientInitialized();
+      credentials = await this.resolveCredentials();
     } catch {
-      return false;
+      throw new ElizaError("Failed to resolve X credentials", {
+        code: "X_AUTH_INITIALIZATION_FAILED",
+      });
     }
-    if (!this.authenticated || !this.v2Client) {
-      return false;
-    }
+    const fingerprint = credentialFingerprint(
+      this.fingerprintKey,
+      this.provider.mode,
+      credentials,
+    );
+    const preparation = await this.runGenerationExclusive(async () => {
+      this.assertActiveLifecycle(lifecycle);
+      if (this.generation?.fingerprint === fingerprint) {
+        return { current: this.generation };
+      }
+      return { releaseAdmission: this.closeSessionAdmission() };
+    });
+    if (preparation.current) return preparation.current;
 
     try {
-      // Verify credentials by getting current user
-      const me = await this.v2Client.v2.me();
-      return !!me.data;
-    } catch (error) {
-      // error-policy:J4 availability probe — a failed verify means "not logged
-      // in" for this boolean; log for diagnostics and report the designed false.
-      logger.debug(
-        { error: error instanceof Error ? error.message : String(error) },
-        "[X.TwitterAuth] credential verification failed; reporting not-logged-in",
-      );
-      return false;
+      await this.waitForSessions();
+      return await this.runGenerationExclusive(async () => {
+        this.assertActiveLifecycle(lifecycle);
+        if (this.generation?.fingerprint === fingerprint) {
+          return this.generation;
+        }
+        // Once a different tuple owns admission, the previous identity is no
+        // longer valid even if constructing the replacement client fails.
+        this.generation = undefined;
+        this.profileCache = undefined;
+        this.profileLoads.clear();
+        this.authenticated = false;
+        let client: TwitterApi;
+        // error-policy:J1 the library constructor may echo credential values in
+        // validation errors, so this boundary deliberately drops its payload.
+        try {
+          client =
+            credentials.mode === "oauth1"
+              ? new TwitterApi({
+                  appKey: credentials.appKey,
+                  appSecret: credentials.appSecret,
+                  accessToken: credentials.accessToken,
+                  accessSecret: credentials.accessSecret,
+                })
+              : new TwitterApi(credentials.accessToken);
+        } catch {
+          throw new ElizaError("Failed to initialize X API client", {
+            code: "X_AUTH_INITIALIZATION_FAILED",
+          });
+        }
+        const generation = {
+          id: ++this.nextGeneration,
+          fingerprint,
+          client,
+        };
+        this.generation = generation;
+        this.authenticated = true;
+        return generation;
+      });
+    } finally {
+      preparation.releaseAdmission?.();
+    }
+  }
+  private assertActiveLifecycle(lifecycle: number): void {
+    if (this.loggedOut || this.lifecycle !== lifecycle) {
+      throw new ElizaError("Twitter API client not initialized", {
+        code: "X_AUTH_NOT_INITIALIZED",
+      });
     }
   }
 
-  /**
-   * Get current user profile
-   */
-  async me(): Promise<Profile | undefined> {
-    if (this.profile) {
-      return this.profile;
-    }
+  private isCurrent(generation: ClientGeneration): boolean {
+    return !this.loggedOut && this.generation === generation;
+  }
 
-    await this.ensureClientInitialized();
-    if (!this.v2Client) {
-      throw new Error("Not authenticated");
-    }
-
+  private async runGenerationExclusive<T>(
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const previous = this.generationGate;
+    let release: () => void = () => undefined;
+    this.generationGate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
     try {
-      const { data: user } = await this.v2Client.v2.me({
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  private async ensureClientInitialized(): Promise<ClientGeneration> {
+    await this.activation;
+    const context = this.sessionContext.getStore();
+    if (context?.active) {
+      if (this.loggedOut) {
+        throw new ElizaError("Twitter API client not initialized", {
+          code: "X_AUTH_NOT_INITIALIZED",
+        });
+      }
+      return context.generation;
+    }
+    if (this.loggedOut) {
+      throw new ElizaError("Twitter API client not initialized", {
+        code: "X_AUTH_NOT_INITIALIZED",
+      });
+    }
+    const lifecycle = this.lifecycle;
+    if (this.initialization?.lifecycle === lifecycle) {
+      // Providers expose no credential revision, so a follower may represent a
+      // newer tuple even during first initialization. Followers share one
+      // subsequent read; identical tuples still reuse the client and profile.
+      this.initialization.state.revalidationRequested = true;
+      return this.initialization.promise;
+    }
+
+    const state = { revalidationRequested: false };
+    const promise = this.runInitializationFlight(lifecycle, state);
+    const initialization = { lifecycle, promise, state };
+    this.initialization = initialization;
+    try {
+      return await promise;
+    } finally {
+      if (this.initialization === initialization) {
+        this.initialization = undefined;
+      }
+    }
+  }
+
+  private async runInitializationFlight(
+    lifecycle: number,
+    state: { revalidationRequested: boolean },
+  ): Promise<ClientGeneration> {
+    let generation: ClientGeneration;
+    do {
+      state.revalidationRequested = false;
+      generation = await this.initializeClient(lifecycle);
+    } while (state.revalidationRequested);
+    return generation;
+  }
+
+  private async fetchProfile(client: TwitterApi): Promise<Profile> {
+    // error-policy:J1 X API boundary classifies credential rejection while
+    // stripping provider payloads, tokens, and transport details.
+    try {
+      const { data: user } = await client.v2.me({
         "user.fields": [
           "id",
           "name",
@@ -161,7 +285,7 @@ export class TwitterAuth {
         ],
       });
 
-      this.profile = {
+      return {
         userId: user.id,
         username: user.username,
         name: user.name,
@@ -173,25 +297,260 @@ export class TwitterAuth {
         location: user.location || "",
         joined: user.created_at ? new Date(user.created_at) : undefined,
       };
-
-      return this.profile;
     } catch (error) {
+      if (isCredentialRejection(error)) {
+        throw new ElizaError("X rejected the authenticated credentials", {
+          code: "X_AUTH_REJECTED",
+        });
+      }
       throw new ElizaError("Failed to fetch authenticated user profile", {
         code: "X_ME_FETCH_FAILED",
-        cause: error,
       });
     }
+  }
+
+  private profileFor(generation: ClientGeneration): Promise<Profile> {
+    if (this.profileCache?.generation === generation.id) {
+      return Promise.resolve(this.profileCache.profile);
+    }
+
+    const activeLoad = this.profileLoads.get(generation.id);
+    if (activeLoad) {
+      return activeLoad;
+    }
+
+    let load: Promise<Profile>;
+    load = this.fetchProfile(generation.client)
+      .then((profile) => {
+        if (this.isCurrent(generation)) {
+          this.profileCache = { generation: generation.id, profile };
+        }
+        return profile;
+      })
+      .finally(() => {
+        if (this.profileLoads.get(generation.id) === load) {
+          this.profileLoads.delete(generation.id);
+        }
+      });
+    this.profileLoads.set(generation.id, load);
+    return load;
+  }
+
+  /**
+   * Get the Twitter API v2 client
+   */
+  async getV2Client(): Promise<TwitterApi> {
+    return (await this.ensureClientInitialized()).client;
+  }
+
+  /**
+   * Check if authenticated
+   */
+  async isLoggedIn(): Promise<boolean> {
+    // error-policy:J4 availability probe — this method's contract is a boolean
+    // "are we authenticated" answer, so any init/verify failure is the designed
+    // false, not a masked read. Callers that need the failure call me() instead.
+    try {
+      return await this.withAuthenticatedSession(
+        async (session) =>
+          typeof session.profile.userId === "string" &&
+          session.profile.userId.length > 0,
+      );
+    } catch {
+      // error-policy:J4 initialization failures are represented by the same
+      // not-logged-in result; callers that need the cause use me().
+      logger.debug(
+        "[X.TwitterAuth] credential verification failed; reporting not-logged-in",
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Get current user profile
+   */
+  async me(): Promise<Profile | undefined> {
+    return (await this.getAuthenticatedSession()).profile;
+  }
+
+  async getAuthenticatedSession(): Promise<AuthenticatedTwitterSession> {
+    return this.withAuthenticatedSession(async (session) => session);
+  }
+
+  async withAuthenticatedSession<T>(
+    operation: (session: AuthenticatedTwitterSession) => Promise<T>,
+  ): Promise<T> {
+    const context = this.sessionContext.getStore();
+    if (context?.active) {
+      if (this.loggedOut) {
+        throw new ElizaError("Twitter API client not initialized", {
+          code: "X_AUTH_NOT_INITIALIZED",
+        });
+      }
+      const profile = await this.profileFor(context.generation);
+      if (context.active) {
+        if (this.loggedOut) {
+          throw new ElizaError("Twitter API client not initialized", {
+            code: "X_AUTH_NOT_INITIALIZED",
+          });
+        }
+        return operation({
+          client: context.generation.client,
+          profile,
+          revision: context.generation.id,
+        });
+      }
+    }
+
+    while (true) {
+      const generation = await this.ensureClientInitialized();
+      let profile: Profile;
+      // error-policy:J7 a superseded generation's profile failure is observed
+      // by the current-generation retry; current failures still propagate.
+      try {
+        profile = await this.profileFor(generation);
+      } catch (error) {
+        if (this.isCurrent(generation)) throw error;
+        continue;
+      }
+      if (!this.isCurrent(generation)) continue;
+      const release = await this.acquireSession(generation);
+      if (!release) continue;
+      const activeContext: SessionContext = { generation, active: true };
+      try {
+        return await this.sessionContext.run(activeContext, () =>
+          operation({
+            client: generation.client,
+            profile,
+            revision: generation.id,
+          }),
+        );
+      } finally {
+        activeContext.active = false;
+        release();
+      }
+    }
+  }
+
+  isAuthenticatedSessionCurrent(
+    session: Pick<AuthenticatedTwitterSession, "client" | "revision">,
+  ): boolean {
+    return (
+      !this.loggedOut &&
+      this.generation?.id === session.revision &&
+      this.generation.client === session.client
+    );
+  }
+
+  async withCurrentSession<T>(
+    session: Pick<AuthenticatedTwitterSession, "client" | "revision">,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    return this.runGenerationExclusive(async () => {
+      if (!this.isAuthenticatedSessionCurrent(session)) {
+        throw new ElizaError("X credentials rotated during identity refresh", {
+          code: "X_AUTH_SESSION_ROTATED",
+        });
+      }
+      const result = await operation();
+      if (!this.isAuthenticatedSessionCurrent(session)) {
+        throw new ElizaError("X credentials rotated during identity refresh", {
+          code: "X_AUTH_SESSION_ROTATED",
+        });
+      }
+      return result;
+    });
+  }
+
+  /** Invalidates this credential object before a Client replaces it. */
+  invalidate(): void {
+    if (this.sessionContext.getStore()?.active) {
+      throw new ElizaError(
+        "Cannot replace X credentials inside an authenticated operation",
+        { code: "X_AUTH_REPLACEMENT_DURING_SESSION" },
+      );
+    }
+    if (this.loggedOut) return;
+    this.loggedOut = true;
+    this.lifecycle += 1;
+    this.generation = undefined;
+    this.authenticated = false;
+    this.initialization = undefined;
+    this.profileCache = undefined;
+    this.profileLoads.clear();
+    this.fingerprintKey.fill(0);
+  }
+
+  private closeSessionAdmission(): () => void {
+    if (this.admissionBarrier) {
+      throw new ElizaError("X credential rotation is already in progress", {
+        code: "X_AUTH_ROTATION_CONFLICT",
+      });
+    }
+    let resolve!: () => void;
+    const promise = new Promise<void>((onResolve) => {
+      resolve = onResolve;
+    });
+    const barrier = { promise, resolve };
+    this.admissionBarrier = barrier;
+    return () => {
+      if (this.admissionBarrier !== barrier) return;
+      this.admissionBarrier = undefined;
+      barrier.resolve();
+    };
+  }
+
+  private async acquireSession(
+    generation: ClientGeneration,
+  ): Promise<(() => void) | undefined> {
+    while (this.admissionBarrier) {
+      await this.admissionBarrier.promise;
+    }
+    if (this.loggedOut) {
+      throw new ElizaError("Twitter API client not initialized", {
+        code: "X_AUTH_NOT_INITIALIZED",
+      });
+    }
+    if (!this.isCurrent(generation)) return undefined;
+    this.activeSessions += 1;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.activeSessions -= 1;
+      if (this.activeSessions === 0 && this.sessionDrain) {
+        this.sessionDrain.resolve();
+        this.sessionDrain = undefined;
+      }
+    };
+  }
+
+  private waitForSessions(): Promise<void> {
+    if (this.activeSessions === 0) return Promise.resolve();
+    if (!this.sessionDrain) {
+      let resolve!: () => void;
+      const promise = new Promise<void>((onResolve) => {
+        resolve = onResolve;
+      });
+      this.sessionDrain = { promise, resolve };
+    }
+    return this.sessionDrain.promise;
+  }
+
+  /** Defers this credential object's first use until the prior auth is quiescent. */
+  deferUntil(barrier: Promise<void>): void {
+    this.activation = Promise.all([this.activation, barrier]).then(
+      () => undefined,
+    );
   }
 
   /**
    * Logout (clear credentials)
    */
   async logout(): Promise<void> {
-    this.v2Client = null;
-    this.authenticated = false;
-    this.profile = undefined;
-    this.lastAccessToken = undefined;
-    this.loggedOut = true;
+    this.invalidate();
+    await Promise.all([this.activation, this.waitForSessions()]);
+    await this.runGenerationExclusive(async () => undefined);
   }
 
   hasToken(): boolean {

--- a/plugins/plugin-x/src/client/client.ts
+++ b/plugins/plugin-x/src/client/client.ts
@@ -175,16 +175,52 @@ export class Client {
   ): AsyncGenerator<T, void> {
     const client = this;
     return (async function* () {
-      // Public generator limits are bounded. Collecting under one lease avoids
-      // mixing account generations between lazily fetched pages.
-      const values = await client.withAuthenticatedSession(async () => {
-        const collected: T[] = [];
-        for await (const value of operation(client.requireAuth())) {
-          collected.push(value);
+      let iterator: AsyncIterator<T> | undefined;
+      let iteratorSession:
+        | Pick<
+            Awaited<ReturnType<TwitterAuth["getAuthenticatedSession"]>>,
+            "client" | "revision"
+          >
+        | undefined;
+      let completed = false;
+
+      try {
+        while (true) {
+          // One provider step holds one credential lease. This preserves
+          // streaming and lets consumer cancellation or credential rotation
+          // stop pagination between pages instead of draining the full source.
+          const result = await client.withAuthenticatedSession(
+            async (currentSession) => {
+              if (!iterator) {
+                iteratorSession = currentSession;
+                iterator = operation(client.requireAuth())[
+                  Symbol.asyncIterator
+                ]();
+              } else if (
+                !iteratorSession ||
+                iteratorSession.client !== currentSession.client ||
+                iteratorSession.revision !== currentSession.revision
+              ) {
+                throw new ElizaError(
+                  "X credentials rotated while an authenticated iterator was active",
+                  { code: "X_AUTH_SESSION_ROTATED" },
+                );
+              }
+              return iterator.next();
+            },
+          );
+
+          if (result.done) {
+            completed = true;
+            return;
+          }
+          yield result.value;
         }
-        return collected;
-      });
-      yield* values;
+      } finally {
+        if (!completed && iterator?.return) {
+          await iterator.return();
+        }
+      }
     })();
   }
 

--- a/plugins/plugin-x/src/client/client.ts
+++ b/plugins/plugin-x/src/client/client.ts
@@ -9,7 +9,8 @@
  * with caching and runtime-memory bookkeeping.
  */
 
-import { logger } from "@elizaos/core";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { ElizaError, logger } from "@elizaos/core";
 import type {
   TTweetv2Expansion,
   TTweetv2MediaField,
@@ -18,6 +19,7 @@ import type {
   TTweetv2TweetField,
   TTweetv2UserField,
 } from "twitter-api-v2";
+import { normalizeXReceiptId } from "../utils/provider-receipt";
 import type {
   FetchTransformOptions,
   QueryProfilesResponse,
@@ -105,12 +107,18 @@ export interface ClientOptions {
   transform: Partial<FetchTransformOptions>;
 }
 
+type ClientAuthContext = {
+  auth: TwitterAuth;
+  active: boolean;
+};
+
 /**
  * An interface to Twitter's API v2.
  * - Reusing Client objects is recommended to minimize the time spent authenticating unnecessarily.
  */
 export class Client {
   private auth?: TwitterAuth;
+  private readonly authContext = new AsyncLocalStorage<ClientAuthContext>();
 
   /**
    * Creates a new Client object.
@@ -119,18 +127,88 @@ export class Client {
   constructor(readonly _options?: Partial<ClientOptions>) {}
 
   private requireAuth(): TwitterAuth {
-    if (!this.auth) {
+    const context = this.authContext.getStore();
+    const auth = (context?.active ? context.auth : undefined) ?? this.auth;
+    if (!auth) {
       throw new Error("Not authenticated");
     }
-    return this.auth;
+    return auth;
   }
 
   /**
    * Returns the authenticated API v2 client for connector-level capabilities
    * that are not yet wrapped by this class, such as DM event polling.
+   * @deprecated Raw clients cannot retain a replacement lease. Run provider
+   * work inside {@link withAuthenticatedSession} instead.
    */
   public async getV2Client() {
     return this.requireAuth().getV2Client();
+  }
+
+  /**
+   * Returns a point-in-time profile and API client snapshot.
+   * @deprecated Use {@link withAuthenticatedSession} so the lease covers work.
+   */
+  public async getAuthenticatedSession() {
+    return this.requireAuth().getAuthenticatedSession();
+  }
+
+  /** Keeps credential resolution pinned while an identity-sensitive operation runs. */
+  public async withAuthenticatedSession<T>(
+    operation: (
+      session: Awaited<ReturnType<TwitterAuth["getAuthenticatedSession"]>>,
+    ) => Promise<T>,
+  ): Promise<T> {
+    const auth = this.requireAuth();
+    return auth.withAuthenticatedSession(async (session) => {
+      const context: ClientAuthContext = { auth, active: true };
+      try {
+        return await this.authContext.run(context, () => operation(session));
+      } finally {
+        context.active = false;
+      }
+    });
+  }
+
+  private authenticatedGenerator<T>(
+    operation: (auth: TwitterAuth) => AsyncIterable<T>,
+  ): AsyncGenerator<T, void> {
+    const client = this;
+    return (async function* () {
+      // Public generator limits are bounded. Collecting under one lease avoids
+      // mixing account generations between lazily fetched pages.
+      const values = await client.withAuthenticatedSession(async () => {
+        const collected: T[] = [];
+        for await (const value of operation(client.requireAuth())) {
+          collected.push(value);
+        }
+        return collected;
+      });
+      yield* values;
+    })();
+  }
+
+  /** Checks whether a captured session is still the active credential generation. */
+  public isAuthenticatedSessionCurrent(
+    session: Pick<
+      Awaited<ReturnType<TwitterAuth["getAuthenticatedSession"]>>,
+      "client" | "revision"
+    >,
+  ): boolean {
+    const context = this.authContext.getStore();
+    const auth = (context?.active ? context.auth : undefined) ?? this.auth;
+    return auth ? auth.isAuthenticatedSessionCurrent(session) : false;
+  }
+
+  /** Publishes derived identity only while its credential generation is current. */
+  public async withCurrentSession<T>(
+    session: Pick<
+      Awaited<ReturnType<TwitterAuth["getAuthenticatedSession"]>>,
+      "client" | "revision"
+    >,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    return this.requireAuth().withCurrentSession(session, operation);
   }
 
   /**
@@ -139,8 +217,10 @@ export class Client {
    * @returns The requested {@link Profile}.
    */
   public async getProfile(username: string): Promise<Profile> {
-    const res = await getProfile(username, this.requireAuth());
-    return this.handleResponse(res);
+    return this.withAuthenticatedSession(async () => {
+      const res = await getProfile(username, this.requireAuth());
+      return this.handleResponse(res);
+    });
   }
 
   /**
@@ -149,8 +229,10 @@ export class Client {
    * @returns The ID of the corresponding account.
    */
   public async getEntityIdByScreenName(screenName: string): Promise<string> {
-    const res = await getEntityIdByScreenName(screenName, this.requireAuth());
-    return this.handleResponse(res);
+    return this.withAuthenticatedSession(async () => {
+      const res = await getEntityIdByScreenName(screenName, this.requireAuth());
+      return this.handleResponse(res);
+    });
   }
 
   /**
@@ -159,8 +241,10 @@ export class Client {
    * @returns The screen name of the corresponding account.
    */
   public async getScreenNameByUserId(userId: string): Promise<string> {
-    const response = await getScreenNameByUserId(userId, this.requireAuth());
-    return this.handleResponse(response);
+    return this.withAuthenticatedSession(async () => {
+      const response = await getScreenNameByUserId(userId, this.requireAuth());
+      return this.handleResponse(response);
+    });
   }
 
   /**
@@ -176,7 +260,9 @@ export class Client {
     maxTweets: number,
     searchMode: SearchMode = SearchMode.Top,
   ): AsyncGenerator<Tweet, void> {
-    return searchTweets(query, maxTweets, searchMode, this.requireAuth());
+    return this.authenticatedGenerator((auth) =>
+      searchTweets(query, maxTweets, searchMode, auth),
+    );
   }
 
   /**
@@ -189,7 +275,9 @@ export class Client {
     query: string,
     maxProfiles: number,
   ): AsyncGenerator<Profile, void> {
-    return searchProfiles(query, maxProfiles, this.requireAuth());
+    return this.authenticatedGenerator((auth) =>
+      searchProfiles(query, maxProfiles, auth),
+    );
   }
 
   /**
@@ -207,24 +295,25 @@ export class Client {
     searchMode: SearchMode,
     _cursor?: string,
   ): Promise<QueryTweetsResponse> {
-    // Use the generator and collect results
-    const tweets: Tweet[] = [];
-    const generator = searchTweets(
-      query,
-      maxTweets,
-      searchMode,
-      this.requireAuth(),
-    );
+    return this.withAuthenticatedSession(async () => {
+      const tweets: Tweet[] = [];
+      const generator = searchTweets(
+        query,
+        maxTweets,
+        searchMode,
+        this.requireAuth(),
+      );
 
-    for await (const tweet of generator) {
-      tweets.push(tweet);
-    }
+      for await (const tweet of generator) {
+        tweets.push(tweet);
+      }
 
-    return {
-      tweets,
-      // v2 API doesn't provide cursor-based pagination for search
-      next: undefined,
-    };
+      return {
+        tweets,
+        // v2 API doesn't provide cursor-based pagination for search
+        next: undefined,
+      };
+    });
   }
 
   /**
@@ -239,19 +328,20 @@ export class Client {
     maxProfiles: number,
     _cursor?: string,
   ): Promise<QueryProfilesResponse> {
-    // Use the generator and collect results
-    const profiles: Profile[] = [];
-    const generator = searchProfiles(query, maxProfiles, this.requireAuth());
+    return this.withAuthenticatedSession(async () => {
+      const profiles: Profile[] = [];
+      const generator = searchProfiles(query, maxProfiles, this.requireAuth());
 
-    for await (const profile of generator) {
-      profiles.push(profile);
-    }
+      for await (const profile of generator) {
+        profiles.push(profile);
+      }
 
-    return {
-      profiles,
-      // v2 API doesn't provide cursor-based pagination for search
-      next: undefined,
-    };
+      return {
+        profiles,
+        // v2 API doesn't provide cursor-based pagination for search
+        next: undefined,
+      };
+    });
   }
 
   /**
@@ -266,7 +356,9 @@ export class Client {
     maxTweets: number,
     cursor?: string,
   ): Promise<QueryTweetsResponse> {
-    return fetchListTweets(listId, maxTweets, cursor, this.requireAuth());
+    return this.withAuthenticatedSession(() =>
+      fetchListTweets(listId, maxTweets, cursor, this.requireAuth()),
+    );
   }
 
   /**
@@ -279,7 +371,9 @@ export class Client {
     userId: string,
     maxProfiles: number,
   ): AsyncGenerator<Profile, void> {
-    return getFollowing(userId, maxProfiles, this.requireAuth());
+    return this.authenticatedGenerator((auth) =>
+      getFollowing(userId, maxProfiles, auth),
+    );
   }
 
   /**
@@ -292,7 +386,9 @@ export class Client {
     userId: string,
     maxProfiles: number,
   ): AsyncGenerator<Profile, void> {
-    return getFollowers(userId, maxProfiles, this.requireAuth());
+    return this.authenticatedGenerator((auth) =>
+      getFollowers(userId, maxProfiles, auth),
+    );
   }
 
   /**
@@ -307,11 +403,8 @@ export class Client {
     maxProfiles: number,
     cursor?: string,
   ): Promise<QueryProfilesResponse> {
-    return fetchProfileFollowing(
-      userId,
-      maxProfiles,
-      this.requireAuth(),
-      cursor,
+    return this.withAuthenticatedSession(() =>
+      fetchProfileFollowing(userId, maxProfiles, this.requireAuth(), cursor),
     );
   }
 
@@ -327,11 +420,8 @@ export class Client {
     maxProfiles: number,
     cursor?: string,
   ): Promise<QueryProfilesResponse> {
-    return fetchProfileFollowers(
-      userId,
-      maxProfiles,
-      this.requireAuth(),
-      cursor,
+    return this.withAuthenticatedSession(() =>
+      fetchProfileFollowers(userId, maxProfiles, this.requireAuth(), cursor),
     );
   }
 
@@ -346,37 +436,39 @@ export class Client {
     count: number,
     _seenTweetIds: string[],
   ): Promise<Tweet[]> {
-    const client = await this.requireAuth().getV2Client();
+    return this.withAuthenticatedSession(async () => {
+      const client = await this.requireAuth().getV2Client();
 
-    const timeline = await client.v2.homeTimeline({
-      max_results: Math.min(count, 100),
-      "tweet.fields": [
-        "id",
-        "text",
-        "created_at",
-        "author_id",
-        "referenced_tweets",
-        "entities",
-        "public_metrics",
-        "attachments",
-        "conversation_id",
-      ],
-      "user.fields": ["id", "name", "username", "profile_image_url"],
-      "media.fields": ["url", "preview_image_url", "type"],
-      expansions: [
-        "author_id",
-        "attachments.media_keys",
-        "referenced_tweets.id",
-      ],
+      const timeline = await client.v2.homeTimeline({
+        max_results: Math.min(count, 100),
+        "tweet.fields": [
+          "id",
+          "text",
+          "created_at",
+          "author_id",
+          "referenced_tweets",
+          "entities",
+          "public_metrics",
+          "attachments",
+          "conversation_id",
+        ],
+        "user.fields": ["id", "name", "username", "profile_image_url"],
+        "media.fields": ["url", "preview_image_url", "type"],
+        expansions: [
+          "author_id",
+          "attachments.media_keys",
+          "referenced_tweets.id",
+        ],
+      });
+
+      const tweets: Tweet[] = [];
+      for await (const tweet of timeline) {
+        tweets.push(parseTweetV2ToV1(tweet, timeline.includes));
+        if (tweets.length >= count) break;
+      }
+
+      return tweets;
     });
-
-    const tweets: Tweet[] = [];
-    for await (const tweet of timeline) {
-      tweets.push(parseTweetV2ToV1(tweet, timeline.includes));
-      if (tweets.length >= count) break;
-    }
-
-    return tweets;
   }
 
   /**
@@ -400,71 +492,68 @@ export class Client {
     maxTweets = 200,
     cursor?: string,
   ): Promise<{ tweets: Tweet[]; next?: string }> {
-    const client = await this.requireAuth().getV2Client();
+    return this.withAuthenticatedSession(async () => {
+      const client = await this.requireAuth().getV2Client();
 
-    const response = await client.v2.userTimeline(userId, {
-      max_results: Math.min(maxTweets, 100),
-      "tweet.fields": [
-        "id",
-        "text",
-        "created_at",
-        "author_id",
-        "referenced_tweets",
-        "entities",
-        "public_metrics",
-        "attachments",
-        "conversation_id",
-      ],
-      "user.fields": ["id", "name", "username", "profile_image_url"],
-      "media.fields": ["url", "preview_image_url", "type"],
-      expansions: [
-        "author_id",
-        "attachments.media_keys",
-        "referenced_tweets.id",
-      ],
-      pagination_token: cursor,
+      const response = await client.v2.userTimeline(userId, {
+        max_results: Math.min(maxTweets, 100),
+        "tweet.fields": [
+          "id",
+          "text",
+          "created_at",
+          "author_id",
+          "referenced_tweets",
+          "entities",
+          "public_metrics",
+          "attachments",
+          "conversation_id",
+        ],
+        "user.fields": ["id", "name", "username", "profile_image_url"],
+        "media.fields": ["url", "preview_image_url", "type"],
+        expansions: [
+          "author_id",
+          "attachments.media_keys",
+          "referenced_tweets.id",
+        ],
+        pagination_token: cursor,
+      });
+
+      const tweets: Tweet[] = [];
+      for await (const tweet of response) {
+        tweets.push(parseTweetV2ToV1(tweet, response.includes));
+        if (tweets.length >= maxTweets) break;
+      }
+
+      return {
+        tweets,
+        next: response.meta?.next_token,
+      };
     });
-
-    const tweets: Tweet[] = [];
-    for await (const tweet of response) {
-      tweets.push(parseTweetV2ToV1(tweet, response.includes));
-      if (tweets.length >= maxTweets) break;
-    }
-
-    return {
-      tweets,
-      next: response.meta?.next_token,
-    };
   }
 
   async *getUserTweetsIterator(
     userId: string,
     maxTweets = 200,
   ): AsyncGenerator<Tweet, void> {
-    let cursor: string | undefined;
-    let retrievedTweets = 0;
+    const tweets = await this.withAuthenticatedSession(async () => {
+      const collected: Tweet[] = [];
+      let cursor: string | undefined;
 
-    while (retrievedTweets < maxTweets) {
-      const response = await this.getUserTweets(
-        userId,
-        maxTweets - retrievedTweets,
-        cursor,
-      );
-
-      for (const tweet of response.tweets) {
-        yield tweet;
-        retrievedTweets++;
-        if (retrievedTweets >= maxTweets) {
-          break;
-        }
+      while (collected.length < maxTweets) {
+        const response = await this.getUserTweets(
+          userId,
+          maxTweets - collected.length,
+          cursor,
+        );
+        collected.push(
+          ...response.tweets.slice(0, maxTweets - collected.length),
+        );
+        cursor = response.next;
+        if (!cursor) break;
       }
-
-      cursor = response.next;
-
-      if (!cursor) {
-        break;
-      }
-    }
+      return collected;
+    });
+    yield* tweets;
   }
 
   /**
@@ -485,7 +574,9 @@ export class Client {
    * @returns An {@link AsyncGenerator} of tweets from the provided user.
    */
   public getTweets(user: string, maxTweets = 200): AsyncGenerator<Tweet> {
-    return getTweets(user, maxTweets, this.requireAuth());
+    return this.authenticatedGenerator((auth) =>
+      getTweets(user, maxTweets, auth),
+    );
   }
 
   /**
@@ -498,7 +589,9 @@ export class Client {
     userId: string,
     maxTweets = 200,
   ): AsyncGenerator<Tweet, void> {
-    return getTweetsByUserId(userId, maxTweets, this.requireAuth());
+    return this.authenticatedGenerator((auth) =>
+      getTweetsByUserId(userId, maxTweets, auth),
+    );
   }
 
   /**
@@ -519,8 +612,10 @@ export class Client {
     mediaData: Buffer,
     options: { mimeType: string },
   ): Promise<string> {
-    const twitterApiClient = await this.requireAuth().getV2Client();
-    return await twitterApiClient.v1.uploadMedia(mediaData, options);
+    return this.withAuthenticatedSession(async () => {
+      const twitterApiClient = await this.requireAuth().getV2Client();
+      return await twitterApiClient.v1.uploadMedia(mediaData, options);
+    });
   }
 
   async sendTweet(
@@ -536,13 +631,15 @@ export class Client {
     if (text.toLowerCase().startsWith("error:")) {
       throw new Error(`Error sending tweet: ${text}`);
     }
-    return await createCreateTweetRequest(
-      text,
-      this.requireAuth(),
-      replyToTweetId,
-      mediaData,
-      hideLinkPreview,
-      mediaIds,
+    return this.withAuthenticatedSession(() =>
+      createCreateTweetRequest(
+        text,
+        this.requireAuth(),
+        replyToTweetId,
+        mediaData,
+        hideLinkPreview,
+        mediaIds,
+      ),
     );
   }
 
@@ -557,11 +654,13 @@ export class Client {
     if (text.toLowerCase().startsWith("error:")) {
       throw new Error(`Error sending note tweet: ${text}`);
     }
-    return await createCreateNoteTweetRequest(
-      text,
-      this.requireAuth(),
-      replyToTweetId,
-      mediaData,
+    return this.withAuthenticatedSession(() =>
+      createCreateNoteTweetRequest(
+        text,
+        this.requireAuth(),
+        replyToTweetId,
+        mediaData,
+      ),
     );
   }
 
@@ -577,11 +676,13 @@ export class Client {
     replyToTweetId?: string,
     mediaData?: { data: Buffer; mediaType: string }[],
   ) {
-    return await createCreateLongTweetRequest(
-      text,
-      this.requireAuth(),
-      replyToTweetId,
-      mediaData,
+    return this.withAuthenticatedSession(() =>
+      createCreateLongTweetRequest(
+        text,
+        this.requireAuth(),
+        replyToTweetId,
+        mediaData,
+      ),
     );
   }
 
@@ -600,11 +701,13 @@ export class Client {
       poll?: PollData;
     },
   ) {
-    return await createCreateTweetRequestV2(
-      text,
-      this.requireAuth(),
-      replyToTweetId,
-      options,
+    return this.withAuthenticatedSession(() =>
+      createCreateTweetRequestV2(
+        text,
+        this.requireAuth(),
+        replyToTweetId,
+        options,
+      ),
     );
   }
 
@@ -618,7 +721,9 @@ export class Client {
     user: string,
     maxTweets = 200,
   ): AsyncGenerator<Tweet> {
-    return getTweetsAndReplies(user, maxTweets, this.requireAuth());
+    return this.authenticatedGenerator((auth) =>
+      getTweetsAndReplies(user, maxTweets, auth),
+    );
   }
 
   /**
@@ -631,7 +736,9 @@ export class Client {
     userId: string,
     maxTweets = 200,
   ): AsyncGenerator<Tweet, void> {
-    return getTweetsAndRepliesByUserId(userId, maxTweets, this.requireAuth());
+    return this.authenticatedGenerator((auth) =>
+      getTweetsAndRepliesByUserId(userId, maxTweets, auth),
+    );
   }
 
   /**
@@ -691,7 +798,9 @@ export class Client {
     includeRetweets = false,
     max = 200,
   ): Promise<Tweet | null | undefined> {
-    return getLatestTweet(user, includeRetweets, max, this.requireAuth());
+    return this.withAuthenticatedSession(() =>
+      getLatestTweet(user, includeRetweets, max, this.requireAuth()),
+    );
   }
 
   /**
@@ -700,7 +809,9 @@ export class Client {
    * @returns The {@link Tweet} object, or `null` if it couldn't be fetched.
    */
   public getTweet(id: string): Promise<Tweet | null> {
-    return getTweet(id, this.requireAuth());
+    return this.withAuthenticatedSession(() =>
+      getTweet(id, this.requireAuth()),
+    );
   }
 
   /**
@@ -728,7 +839,9 @@ export class Client {
       placeFields?: TTweetv2PlaceField[];
     } = defaultOptions,
   ): Promise<Tweet | null> {
-    return await getTweetV2(id, this.requireAuth(), options);
+    return this.withAuthenticatedSession(() =>
+      getTweetV2(id, this.requireAuth(), options),
+    );
   }
 
   /**
@@ -756,7 +869,9 @@ export class Client {
       placeFields?: TTweetv2PlaceField[];
     } = defaultOptions,
   ): Promise<Tweet[]> {
-    return await getTweetsV2(ids, this.requireAuth(), options);
+    return this.withAuthenticatedSession(() =>
+      getTweetsV2(ids, this.requireAuth(), options),
+    );
   }
 
   /**
@@ -764,20 +879,39 @@ export class Client {
    * @param auth The new authentication.
    */
   public updateAuth(auth: TwitterAuth) {
+    if (this.auth === auth) return;
+    if (this.authContext.getStore()?.active) {
+      throw new ElizaError(
+        "Cannot replace X credentials inside an authenticated operation",
+        { code: "X_AUTH_REPLACEMENT_DURING_SESSION" },
+      );
+    }
+    const priorLogout = this.auth?.logout() ?? Promise.resolve();
+    auth.deferUntil(priorLogout);
     this.auth = auth;
   }
 
   public async authenticate(provider: TwitterAuthProvider): Promise<void> {
-    this.auth = new TwitterAuth(provider);
-    // Force initialization early to surface misconfiguration quickly.
-    // isLoggedIn is itself an availability probe (returns false, never rejects),
-    // so no swallowing wrapper is needed here.
-    await this.requireAuth().isLoggedIn();
+    const auth = new TwitterAuth(provider);
+    this.updateAuth(auth);
+    try {
+      await auth.getAuthenticatedSession();
+    } catch (error) {
+      // error-policy:J1 failed public authentication leaves no unusable auth
+      // installed and preserves the sanitized connector error for the caller.
+      if (this.auth === auth) {
+        this.auth = undefined;
+      }
+      await auth.logout();
+      throw error;
+    }
   }
 
   /**
    * Get current authentication credentials
    * @returns {TwitterAuth | null} Current authentication or null if not authenticated
+   * @deprecated Use {@link isAuthenticated} for state or
+   * {@link withAuthenticatedSession} for credential-bound work.
    */
   public getAuth(): TwitterAuth | null {
     return this.auth ?? null;
@@ -847,18 +981,20 @@ export class Client {
         accessSecret: resolvedAccessSecret,
       }),
     };
-    this.auth = new TwitterAuth(provider);
+    this.updateAuth(new TwitterAuth(provider));
   }
 
-  /**
-   * Log out of Twitter.
-   * Note: With API v2, logout is not applicable as we use API credentials.
-   */
+  /** Invalidates the local authenticated client and all derived identity. */
   public async logout(): Promise<void> {
-    // With API v2 credentials, there's no logout process.
-    logger.warn(
-      "[X.Client] Logout is not applicable when using Twitter API v2 credentials",
-    );
+    if (this.authContext.getStore()?.active) {
+      throw new ElizaError(
+        "Cannot log out X credentials inside an authenticated operation",
+        { code: "X_AUTH_REPLACEMENT_DURING_SESSION" },
+      );
+    }
+    const auth = this.auth;
+    this.auth = undefined;
+    await auth?.logout();
   }
 
   /**
@@ -875,11 +1011,13 @@ export class Client {
       mediaData: { data: Buffer; mediaType: string }[];
     },
   ) {
-    return await createQuoteTweetRequest(
-      text,
-      quotedTweetId,
-      this.requireAuth(),
-      options?.mediaData,
+    return this.withAuthenticatedSession(() =>
+      createQuoteTweetRequest(
+        text,
+        quotedTweetId,
+        this.requireAuth(),
+        options?.mediaData,
+      ),
     );
   }
 
@@ -891,7 +1029,9 @@ export class Client {
   public async deleteTweet(
     tweetId: string,
   ): Promise<Awaited<ReturnType<typeof deleteTweet>>> {
-    return await deleteTweet(tweetId, this.requireAuth());
+    return this.withAuthenticatedSession(() =>
+      deleteTweet(tweetId, this.requireAuth()),
+    );
   }
 
   /**
@@ -900,8 +1040,9 @@ export class Client {
    * @returns A promise that resolves when the tweet is liked.
    */
   public async likeTweet(tweetId: string): Promise<void> {
-    // Call the likeTweet function from tweets.ts
-    await likeTweet(tweetId, this.requireAuth());
+    await this.withAuthenticatedSession(() =>
+      likeTweet(tweetId, this.requireAuth()),
+    );
   }
 
   /**
@@ -910,7 +1051,9 @@ export class Client {
    * @returns A promise that resolves when the tweet is unliked.
    */
   public async unlikeTweet(tweetId: string): Promise<void> {
-    await unlikeTweet(tweetId, this.requireAuth());
+    await this.withAuthenticatedSession(() =>
+      unlikeTweet(tweetId, this.requireAuth()),
+    );
   }
 
   /**
@@ -919,8 +1062,9 @@ export class Client {
    * @returns A promise that resolves when the tweet is retweeted.
    */
   public async retweet(tweetId: string): Promise<void> {
-    // Call the retweet function from tweets.ts
-    await retweet(tweetId, this.requireAuth());
+    await this.withAuthenticatedSession(() =>
+      retweet(tweetId, this.requireAuth()),
+    );
   }
 
   /**
@@ -929,7 +1073,9 @@ export class Client {
    * @returns A promise that resolves when the tweet is unretweeted.
    */
   public async unretweet(tweetId: string): Promise<void> {
-    await unretweet(tweetId, this.requireAuth());
+    await this.withAuthenticatedSession(() =>
+      unretweet(tweetId, this.requireAuth()),
+    );
   }
 
   /**
@@ -938,8 +1084,9 @@ export class Client {
    * @returns A promise that resolves when the user is followed.
    */
   public async followUser(userName: string): Promise<void> {
-    // Call the followUser function from relationships.ts
-    await followUser(userName, this.requireAuth());
+    await this.withAuthenticatedSession(() =>
+      followUser(userName, this.requireAuth()),
+    );
   }
 
   /**
@@ -950,26 +1097,29 @@ export class Client {
    * @returns Array of DM conversations
    */
   public async getDirectMessageConversations(userId: string, cursor?: string) {
-    const client = await this.requireAuth().getV2Client();
-    const options: NonNullable<Parameters<typeof client.v2.listDmEvents>[0]> = {
-      "dm_event.fields": [
-        "id",
-        "text",
-        "event_type",
-        "created_at",
-        "sender_id",
-        "dm_conversation_id",
-        "participant_ids",
-      ],
-      event_types: ["MessageCreate"],
-      ...(cursor ? { pagination_token: cursor } : {}),
-    };
+    return this.withAuthenticatedSession(async () => {
+      const client = await this.requireAuth().getV2Client();
+      const options: NonNullable<Parameters<typeof client.v2.listDmEvents>[0]> =
+        {
+          "dm_event.fields": [
+            "id",
+            "text",
+            "event_type",
+            "created_at",
+            "sender_id",
+            "dm_conversation_id",
+            "participant_ids",
+          ],
+          event_types: ["MessageCreate"],
+          ...(cursor ? { pagination_token: cursor } : {}),
+        };
 
-    const timeline = userId
-      ? await client.v2.listDmEventsWithParticipant(userId, options)
-      : await client.v2.listDmEvents(options);
+      const timeline = userId
+        ? await client.v2.listDmEventsWithParticipant(userId, options)
+        : await client.v2.listDmEvents(options);
 
-    return { conversations: timeline.events ?? [] };
+      return { conversations: timeline.events ?? [] };
+    });
   }
 
   /**
@@ -980,10 +1130,14 @@ export class Client {
    * @returns The response from the Twitter API
    */
   public async sendDirectMessage(conversationId: string, text: string) {
-    const client = await this.requireAuth().getV2Client();
-    const data = await client.v2.sendDmInConversation(conversationId, { text });
+    return this.withAuthenticatedSession(async () => {
+      const client = await this.requireAuth().getV2Client();
+      const data = await client.v2.sendDmInConversation(conversationId, {
+        text,
+      });
 
-    return { id: data.dm_event_id, data };
+      return { id: normalizeXReceiptId(data.dm_event_id), data };
+    });
   }
 
   private handleResponse<T>(res: RequestApiResult<T>): T {
@@ -1000,7 +1154,9 @@ export class Client {
    * @returns An array of users (retweeters).
    */
   public async getRetweetersOfTweet(tweetId: string): Promise<Retweeter[]> {
-    return await getAllRetweeters(tweetId, this.requireAuth());
+    return this.withAuthenticatedSession(() =>
+      getAllRetweeters(tweetId, this.requireAuth()),
+    );
   }
 
   /**
@@ -1013,31 +1169,35 @@ export class Client {
     tweetId: string,
     maxQuotes: number = 100,
   ): Promise<Tweet[]> {
-    const allQuotes: Tweet[] = [];
+    return this.withAuthenticatedSession(async () => {
+      const allQuotes: Tweet[] = [];
+      let cursor: string | undefined;
+      let totalFetched = 0;
 
-    let cursor: string | undefined;
-    let totalFetched = 0;
+      while (totalFetched < maxQuotes) {
+        const batchSize = Math.min(40, maxQuotes - totalFetched);
+        const page = await this.fetchQuotedTweetsPage(
+          tweetId,
+          batchSize,
+          cursor,
+        );
 
-    while (totalFetched < maxQuotes) {
-      const batchSize = Math.min(40, maxQuotes - totalFetched);
-      const page = await this.fetchQuotedTweetsPage(tweetId, batchSize, cursor);
+        if (page.tweets.length === 0) {
+          break;
+        }
 
-      if (page.tweets.length === 0) {
-        break;
+        allQuotes.push(...page.tweets);
+        totalFetched += page.tweets.length;
+
+        if (!page.next) {
+          break;
+        }
+
+        cursor = page.next;
       }
 
-      allQuotes.push(...page.tweets);
-      totalFetched += page.tweets.length;
-
-      // Check if there's a next page
-      if (!page.next) {
-        break;
-      }
-
-      cursor = page.next;
-    }
-
-    return allQuotes.slice(0, maxQuotes);
+      return allQuotes.slice(0, maxQuotes);
+    });
   }
 
   /**
@@ -1053,23 +1213,25 @@ export class Client {
     maxQuotes: number = 40,
     _cursor?: string,
   ): Promise<QueryTweetsResponse> {
-    const quotes: Tweet[] = [];
-    let count = 0;
+    return this.withAuthenticatedSession(async () => {
+      const quotes: Tweet[] = [];
+      let count = 0;
 
-    // searchQuotedTweets doesn't support cursor, so we'll collect all quotes up to maxQuotes
-    for await (const quote of searchQuotedTweets(
-      tweetId,
-      maxQuotes,
-      this.requireAuth(),
-    )) {
-      quotes.push(quote);
-      count++;
-      if (count >= maxQuotes) break;
-    }
+      for await (const quote of searchQuotedTweets(
+        tweetId,
+        maxQuotes,
+        this.requireAuth(),
+      )) {
+        quotes.push(quote);
+        count++;
+        if (count >= maxQuotes) break;
+      }
 
-    return {
-      tweets: quotes,
-      next: undefined, // Twitter API v2 doesn't provide cursor for quote search
-    };
+      return {
+        tweets: quotes,
+        // Twitter API v2 doesn't provide a cursor for quote search.
+        next: undefined,
+      };
+    });
   }
 }

--- a/plugins/plugin-x/src/client/direct-messages.test.ts
+++ b/plugins/plugin-x/src/client/direct-messages.test.ts
@@ -4,8 +4,25 @@ import { Client } from "./client";
 
 function createClient(v2: Record<string, unknown>) {
   const client = new Client();
+  const session = {
+    client: { v2 },
+    profile: {
+      id: "bot-user",
+      username: "bot",
+      screenName: "Bot",
+      bio: "",
+      nicknames: [],
+    },
+    revision: 1,
+  };
   client.updateAuth({
     getV2Client: async () => ({ v2 }),
+    getAuthenticatedSession: async () => session,
+    withAuthenticatedSession: async (operation: (value: unknown) => unknown) =>
+      operation(session),
+    isAuthenticatedSessionCurrent: () => true,
+    deferUntil: () => undefined,
+    logout: async () => undefined,
   } as never);
 
   return client;
@@ -73,5 +90,18 @@ describe("Client direct messages", () => {
         dm_event_id: "event-1",
       },
     });
+  });
+
+  it("never exposes whitespace as a direct-message receipt id", async () => {
+    const sendDmInConversation = vi.fn().mockResolvedValue({
+      dm_conversation_id: "conversation-1",
+      dm_event_id: "   ",
+    });
+    const client = createClient({ sendDmInConversation });
+
+    const result = await client.sendDirectMessage("conversation-1", "hello");
+
+    expect(result.id).toBeUndefined();
+    expect(sendDmInConversation).toHaveBeenCalledOnce();
   });
 });

--- a/plugins/plugin-x/src/direct-messages.test.ts
+++ b/plugins/plugin-x/src/direct-messages.test.ts
@@ -8,8 +8,39 @@
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ClientBase } from "./base";
+import type { AuthenticatedTwitterSession } from "./client/auth";
 import { TwitterDirectMessageClient } from "./direct-messages";
 import type { TwitterClientState } from "./types";
+
+function authenticatedTwitterClient(
+  userId: string,
+  v2: object,
+  isCurrent: () => boolean = () => true,
+) {
+  const session = {
+    client: { v2 },
+    profile: {
+      userId,
+      username: "elizamakesmagic",
+      location: "",
+    },
+    revision: 1,
+  } as unknown as AuthenticatedTwitterSession;
+  return {
+    withAuthenticatedSession: async <T>(
+      operation: (active: AuthenticatedTwitterSession) => Promise<T>,
+    ): Promise<T> => operation(session),
+    isAuthenticatedSessionCurrent: () => isCurrent(),
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
 
 afterEach(() => {
   vi.useRealTimers();
@@ -73,12 +104,11 @@ describe("TwitterDirectMessageClient", () => {
     } as unknown as IAgentRuntime;
     const client = {
       accountId: "agent",
-      profile: { id: "222", username: "elizamakesmagic" },
-      twitterClient: {
-        getV2Client: async () => ({
-          v2: { listDmEvents, sendDmToParticipant },
-        }),
-      },
+      profile: { id: "stale-profile", username: "stale-user" },
+      twitterClient: authenticatedTwitterClient("222", {
+        listDmEvents,
+        sendDmToParticipant,
+      }),
     } as unknown as ClientBase;
     const dmClient = new TwitterDirectMessageClient(client, runtime, {
       TWITTER_DRY_RUN: "false",
@@ -111,6 +141,87 @@ describe("TwitterDirectMessageClient", () => {
       text: "Your next event is at 2 PM.",
     });
     expect(cache.get("twitter/agent/222/dm_cursor")).toBe("501");
+    await dmClient.stop();
+  });
+
+  it("does not send or advance the cursor when credentials rotate during personal routing", async () => {
+    vi.useFakeTimers();
+    const route = deferred<Response>();
+    const fetchMock = vi.fn(() => route.promise);
+    vi.stubGlobal("fetch", fetchMock);
+    const event = {
+      id: "601",
+      sender_id: "111",
+      dm_conversation_id: "conversation-1",
+      text: "private question",
+      event_type: "MessageCreate",
+    };
+    const sendA = vi.fn();
+    const sendB = vi.fn();
+    const cache = new Map<string, string>([
+      ["twitter/agent/account-a/dm_cursor", "600"],
+    ]);
+    const runtime = {
+      agentId: "00000000-0000-0000-0000-000000000001",
+      getCache: async (key: string) => cache.get(key),
+      setCache: async (key: string, value: string) => {
+        cache.set(key, value);
+      },
+      deleteCache: async (key: string) => cache.delete(key),
+      getMemoryById: async () => null,
+      createMemory: vi.fn(async () => undefined),
+      ensureWorldExists: vi.fn(async () => undefined),
+      updateWorld: vi.fn(async () => undefined),
+      ensureRoomExists: vi.fn(async () => undefined),
+      ensureConnection: vi.fn(async () => undefined),
+      messageService: { handleMessage: vi.fn() },
+      reportError: vi.fn(),
+      getSetting: vi.fn((key: string) =>
+        key === "TWITTER_BROKER_TOKEN" ? "test-broker-token" : null,
+      ),
+    } as unknown as IAgentRuntime;
+    let current = true;
+    const client = {
+      accountId: "agent",
+      profile: { id: "account-b", username: "stale-account-b" },
+      twitterClient: authenticatedTwitterClient(
+        "account-a",
+        {
+          listDmEvents: async () => ({ events: [event] }),
+          sendDmToParticipant: sendA,
+        },
+        () => current,
+      ),
+    } as unknown as ClientBase;
+    const dmClient = new TwitterDirectMessageClient(client, runtime, {
+      TWITTER_DRY_RUN: "false",
+      TWITTER_DM_POLL_INTERVAL_SECONDS: "15",
+      TWITTER_PERSONAL_DM_ROUTER_URL:
+        "https://cloud.eliza.app/api/v1/twitter/personal-message",
+    });
+
+    const start = dmClient.start();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    current = false;
+    route.resolve(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: { reply: "should not cross accounts" },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    await start;
+
+    expect(sendA).not.toHaveBeenCalled();
+    expect(sendB).not.toHaveBeenCalled();
+    expect(cache.get("twitter/agent/account-a/dm_cursor")).toBe("600");
+    expect(runtime.reportError).toHaveBeenCalledWith(
+      "XDirectMessages.poll",
+      expect.objectContaining({ code: "X_AUTH_SESSION_ROTATED" }),
+      { accountId: "agent" },
+    );
     await dmClient.stop();
   });
 
@@ -201,11 +312,10 @@ describe("TwitterDirectMessageClient", () => {
     const client = {
       accountId: "agent",
       profile: { id: "agent-user-id", username: "elizamakesmagic" },
-      twitterClient: {
-        getV2Client: async () => ({
-          v2: { listDmEvents, sendDmToParticipant },
-        }),
-      },
+      twitterClient: authenticatedTwitterClient("agent-user-id", {
+        listDmEvents,
+        sendDmToParticipant,
+      }),
     } as unknown as ClientBase;
     const state = {
       TWITTER_DRY_RUN: "false",
@@ -326,11 +436,10 @@ describe("TwitterDirectMessageClient", () => {
     const client = {
       accountId: "agent",
       profile: { id: "agent-user-id", username: "elizamakesmagic" },
-      twitterClient: {
-        getV2Client: async () => ({
-          v2: { listDmEvents, sendDmToParticipant },
-        }),
-      },
+      twitterClient: authenticatedTwitterClient("agent-user-id", {
+        listDmEvents,
+        sendDmToParticipant,
+      }),
     } as unknown as ClientBase;
     const state = {
       TWITTER_DRY_RUN: "false",
@@ -404,11 +513,10 @@ describe("TwitterDirectMessageClient", () => {
     const client = {
       accountId: "agent",
       profile: { id: "agent-user-id", username: "elizamakesmagic" },
-      twitterClient: {
-        getV2Client: async () => ({
-          v2: { listDmEvents, sendDmToParticipant },
-        }),
-      },
+      twitterClient: authenticatedTwitterClient("agent-user-id", {
+        listDmEvents,
+        sendDmToParticipant,
+      }),
     } as unknown as ClientBase;
     const state = {
       TWITTER_DRY_RUN: "false",
@@ -498,11 +606,10 @@ describe("TwitterDirectMessageClient", () => {
     const client = {
       accountId: "agent",
       profile: { id: "agent-user-id", username: "elizamakesmagic" },
-      twitterClient: {
-        getV2Client: async () => ({
-          v2: { listDmEvents: async () => paginator, sendDmToParticipant },
-        }),
-      },
+      twitterClient: authenticatedTwitterClient("agent-user-id", {
+        listDmEvents: async () => paginator,
+        sendDmToParticipant,
+      }),
     } as unknown as ClientBase;
     const dmClient = new TwitterDirectMessageClient(client, runtime, {
       TWITTER_DRY_RUN: "false",
@@ -567,14 +674,10 @@ describe("TwitterDirectMessageClient", () => {
     const client = {
       accountId: "agent",
       profile: { id: "agent-user-id", username: "elizamakesmagic" },
-      twitterClient: {
-        getV2Client: async () => ({
-          v2: {
-            listDmEvents: async () => ({ events: [event] }),
-            sendDmToParticipant,
-          },
-        }),
-      },
+      twitterClient: authenticatedTwitterClient("agent-user-id", {
+        listDmEvents: async () => ({ events: [event] }),
+        sendDmToParticipant,
+      }),
     } as unknown as ClientBase;
     const dmClient = new TwitterDirectMessageClient(client, runtime, {
       TWITTER_DRY_RUN: "false",
@@ -639,14 +742,10 @@ describe("TwitterDirectMessageClient", () => {
     const client = {
       accountId: "agent",
       profile: { id: "agent-user-id", username: "elizamakesmagic" },
-      twitterClient: {
-        getV2Client: async () => ({
-          v2: {
-            listDmEvents: async () => ({ events: [event] }),
-            sendDmToParticipant,
-          },
-        }),
-      },
+      twitterClient: authenticatedTwitterClient("agent-user-id", {
+        listDmEvents: async () => ({ events: [event] }),
+        sendDmToParticipant,
+      }),
     } as unknown as ClientBase;
     const dmClient = new TwitterDirectMessageClient(client, runtime, {
       TWITTER_DRY_RUN: "false",
@@ -711,14 +810,10 @@ describe("TwitterDirectMessageClient", () => {
     const client = {
       accountId: "agent",
       profile: { id: "agent-user-id", username: "elizamakesmagic" },
-      twitterClient: {
-        getV2Client: async () => ({
-          v2: {
-            listDmEvents: async () => ({ events: [event] }),
-            sendDmToParticipant,
-          },
-        }),
-      },
+      twitterClient: authenticatedTwitterClient("agent-user-id", {
+        listDmEvents: async () => ({ events: [event] }),
+        sendDmToParticipant,
+      }),
     } as unknown as ClientBase;
     const dmClient = new TwitterDirectMessageClient(client, runtime, {
       TWITTER_DRY_RUN: "false",
@@ -788,14 +883,10 @@ describe("TwitterDirectMessageClient", () => {
     const client = {
       accountId: "agent",
       profile: { id: "agent-user-id", username: "elizamakesmagic" },
-      twitterClient: {
-        getV2Client: async () => ({
-          v2: {
-            listDmEvents: async () => ({ events: [event] }),
-            sendDmToParticipant,
-          },
-        }),
-      },
+      twitterClient: authenticatedTwitterClient("agent-user-id", {
+        listDmEvents: async () => ({ events: [event] }),
+        sendDmToParticipant,
+      }),
     } as unknown as ClientBase;
     const dmClient = new TwitterDirectMessageClient(client, runtime, {
       TWITTER_DRY_RUN: "false",
@@ -856,14 +947,10 @@ describe("TwitterDirectMessageClient", () => {
     const client = {
       accountId: "agent",
       profile: { id: "agent-user-id", username: "elizamakesmagic" },
-      twitterClient: {
-        getV2Client: async () => ({
-          v2: {
-            listDmEvents: async () => ({ events: [event] }),
-            sendDmToParticipant,
-          },
-        }),
-      },
+      twitterClient: authenticatedTwitterClient("agent-user-id", {
+        listDmEvents: async () => ({ events: [event] }),
+        sendDmToParticipant,
+      }),
     } as unknown as ClientBase;
     const dmClient = new TwitterDirectMessageClient(client, runtime, {
       TWITTER_DRY_RUN: "false",

--- a/plugins/plugin-x/src/direct-messages.ts
+++ b/plugins/plugin-x/src/direct-messages.ts
@@ -15,14 +15,17 @@ import {
   ChannelType,
   type Content,
   createUniqueUuid,
+  ElizaError,
   type HandlerCallback,
   type IAgentRuntime,
   logger,
   type Memory,
 } from "@elizaos/core";
 import type { ClientBase } from "./base";
+import type { AuthenticatedTwitterSession } from "./client/auth";
 import type { TwitterClientState } from "./types";
 import { createMemorySafe, reconcileTwitterWorld } from "./utils/memory";
+import { normalizeXReceiptId } from "./utils/provider-receipt";
 import { getSetting } from "./utils/settings";
 
 interface DirectMessageEvent {
@@ -198,17 +201,27 @@ export class TwitterDirectMessageClient {
   }
 
   private async processNewMessages(): Promise<void> {
-    const profile = this.client.profile;
-    if (!profile?.id) {
-      throw new Error("X DM polling requires an authenticated profile.");
+    await this.client.twitterClient.withAuthenticatedSession((session) =>
+      this.processNewMessagesForSession(session),
+    );
+  }
+
+  private async processNewMessagesForSession(
+    session: AuthenticatedTwitterSession,
+  ): Promise<void> {
+    const ownUserId = session.profile.userId;
+    if (!ownUserId) {
+      throw new ElizaError(
+        "X DM polling requires an authenticated profile identifier",
+        { code: "X_ME_FETCH_FAILED" },
+      );
     }
 
-    const stateKeyPrefix = `twitter/${this.client.accountId}/${profile.id}`;
+    const stateKeyPrefix = `twitter/${this.client.accountId}/${ownUserId}`;
     const cursorKey = `${stateKeyPrefix}/dm_cursor`;
     const cursor = (await this.runtime.getCache<string>(cursorKey)) ?? "";
 
-    const api = await this.client.twitterClient.getV2Client();
-    const page = (await api.v2.listDmEvents({
+    const page = (await session.client.v2.listDmEvents({
       max_results: 50,
       "dm_event.fields": [
         "id",
@@ -261,6 +274,7 @@ export class TwitterDirectMessageClient {
     const events = collectEvents().sort((left, right) =>
       compareEventIds(left.id, right.id),
     );
+    this.assertSessionCurrent(session, "while direct messages were being read");
     if (events.length === 0) return;
 
     const newestId = events[events.length - 1]?.id;
@@ -284,7 +298,7 @@ export class TwitterDirectMessageClient {
       }
       if (
         !event.sender_id ||
-        event.sender_id === profile.id ||
+        event.sender_id === ownUserId ||
         !event.text?.trim()
       ) {
         await this.runtime.setCache(cursorKey, event.id);
@@ -297,7 +311,10 @@ export class TwitterDirectMessageClient {
         event as DirectMessageEvent & { id: string; sender_id: string },
         users.get(event.sender_id),
         stateKeyPrefix,
+        session,
+        ownUserId,
       );
+      this.assertSessionCurrent(session, "before advancing the DM cursor");
       await this.runtime.setCache(cursorKey, event.id);
     }
   }
@@ -306,6 +323,8 @@ export class TwitterDirectMessageClient {
     event: DirectMessageEvent & { id: string; sender_id: string },
     user: { id: string; username?: string; name?: string } | undefined,
     stateKeyPrefix: string,
+    session: AuthenticatedTwitterSession,
+    ownUserId: string,
   ): Promise<void> {
     // Delivery settlement is tracked separately from inbound-memory existence:
     // the marker is written only after the reply round-trip finished, so a
@@ -416,6 +435,10 @@ export class TwitterDirectMessageClient {
         return [];
       }
       egressAttempted = true;
+      this.assertSessionCurrent(
+        session,
+        "before the direct-message reply was sent",
+      );
       if (this.isDryRun) {
         logger.info(
           { src: "plugin:x", senderId, text },
@@ -424,18 +447,31 @@ export class TwitterDirectMessageClient {
         return [];
       }
 
-      const api = await this.client.twitterClient.getV2Client();
       const isGroup = (event.participant_ids?.length ?? 0) > 2;
       let sent: unknown;
       // X's DM create endpoints do not accept an idempotency key. Persist a
       // no-replay barrier before the request so a crash, timeout, or receipt
       // persistence failure cannot cause a second externally visible reply.
       // An explicit provider rejection clears the barrier below and may retry.
-      await this.runtime.setCache(settledKey, "egress_started");
+      try {
+        await this.runtime.setCache(settledKey, "egress_started");
+      } catch (error) {
+        deliveryError = error;
+        throw error;
+      }
+      if (!this.isSessionCurrent(session)) {
+        await this.runtime.deleteCache(settledKey);
+        deliveryError = this.sessionRotationError(
+          "before the direct-message reply was sent",
+        );
+        throw deliveryError;
+      }
       try {
         sent = isGroup
-          ? await api.v2.sendDmInConversation(conversationId, { text })
-          : await api.v2.sendDmToParticipant(senderId, { text });
+          ? await session.client.v2.sendDmInConversation(conversationId, {
+              text,
+            })
+          : await session.client.v2.sendDmToParticipant(senderId, { text });
       } catch (error) {
         // error-policy:J2 explicit HTTP rejection proves X did not accept the
         // send, so reopen it for a later retry. Transport failures are
@@ -452,7 +488,9 @@ export class TwitterDirectMessageClient {
         data?: { dm_event_id?: string };
         dm_event_id?: string;
       };
-      const sentId = sentResult.data?.dm_event_id ?? sentResult.dm_event_id;
+      const sentId = normalizeXReceiptId(
+        sentResult.data?.dm_event_id ?? sentResult.dm_event_id,
+      );
       await this.runtime.setCache(
         settledKey,
         sentId ? `delivered:${sentId}` : "delivered",
@@ -509,9 +547,13 @@ export class TwitterDirectMessageClient {
 
     const personalRouterUrl = this.personalDmRouterUrl();
     if (personalRouterUrl) {
+      this.assertSessionCurrent(
+        session,
+        "before the direct message was routed",
+      );
       await createMemorySafe(this.runtime, inboundMemory, "messages");
       const reply = await this.routePersonalDm({
-        recipientTwitterUserId: this.client.profile?.id ?? "",
+        recipientTwitterUserId: ownUserId,
         senderTwitterUserId: senderId,
         senderUsername: username,
         displayName,
@@ -535,8 +577,28 @@ export class TwitterDirectMessageClient {
         ? deliveryError
         : new Error(String(deliveryError));
     }
+    this.assertSessionCurrent(session, "before the direct message was settled");
     if (!(await this.runtime.getCache<string>(settledKey))) {
       await this.runtime.setCache(settledKey, "settled_without_reply");
+    }
+  }
+
+  private isSessionCurrent(session: AuthenticatedTwitterSession): boolean {
+    return this.client.twitterClient.isAuthenticatedSessionCurrent(session);
+  }
+
+  private sessionRotationError(phase: string): ElizaError {
+    return new ElizaError(`X credentials rotated ${phase}`, {
+      code: "X_AUTH_SESSION_ROTATED",
+    });
+  }
+
+  private assertSessionCurrent(
+    session: AuthenticatedTwitterSession,
+    phase: string,
+  ): void {
+    if (!this.isSessionCurrent(session)) {
+      throw this.sessionRotationError(phase);
     }
   }
 }

--- a/plugins/plugin-x/src/services/x.service.test.ts
+++ b/plugins/plugin-x/src/services/x.service.test.ts
@@ -1,6 +1,8 @@
 /** Unit tests for X account status and trusted multi-account connector routing. Network clients are deterministic fakes. */
 import type { Content, IAgentRuntime, TargetInfo } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
+import type { ClientBase } from "../base";
+import type { AuthenticatedTwitterSession } from "../client/auth";
 import type { TwitterClientState } from "../types";
 import { TwitterClientInstance, XService } from "./x.service";
 
@@ -23,6 +25,22 @@ function runtimeWithSettings(settings: Record<string, string>): IAgentRuntime {
 
 function serviceWithRuntime(settings: Record<string, string>): XService {
   return new XService(runtimeWithSettings(settings));
+}
+
+function dmSession(userId: string, v2: object): AuthenticatedTwitterSession {
+  return {
+    client: { v2 },
+    profile: { userId, username: `user-${userId}`, location: "" },
+    revision: 1,
+  } as unknown as AuthenticatedTwitterSession;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
 }
 
 describe("XService account status", () => {
@@ -263,28 +281,29 @@ describe("XService trusted account routing", () => {
   it("ignores spoofed content account metadata in the unscoped send handler", async () => {
     const runtime = runtimeWithSettings({});
     const service = new XService(runtime);
+    const sendDmToParticipant = vi.fn(async () => ({ dm_event_id: "dm-1" }));
+    const session = dmSession("current-user", { sendDmToParticipant });
+    const withAuthenticatedSession = vi.fn(
+      async <T>(
+        operation: (active: AuthenticatedTwitterSession) => Promise<T>,
+      ) => operation(session),
+    );
+    const base = {
+      twitterClient: {
+        withAuthenticatedSession,
+        isAuthenticatedSessionCurrent: () => true,
+      },
+    } as unknown as ClientBase;
     const getClient = vi
       .spyOn(
         service as unknown as {
           getTwitterClientForAccount: (accountId: unknown) => Promise<{
-            client: Record<string, never>;
+            client: ClientBase;
           }>;
         },
         "getTwitterClientForAccount",
       )
-      .mockResolvedValue({ client: {} });
-    const sendXDirectMessage = vi
-      .spyOn(
-        service as unknown as {
-          sendXDirectMessage: (
-            accountId: string,
-            recipient: string,
-            text: string,
-          ) => Promise<{ messageId: string | null }>;
-        },
-        "sendXDirectMessage",
-      )
-      .mockResolvedValue({ messageId: "dm-1" });
+      .mockResolvedValue({ client: base });
 
     await service.handleSendMessage(
       runtime,
@@ -296,10 +315,213 @@ describe("XService trusted account routing", () => {
     );
 
     expect(getClient).toHaveBeenCalledWith("default");
-    expect(sendXDirectMessage).toHaveBeenCalledWith(
-      "default",
-      "123456",
-      "hello",
+    expect(withAuthenticatedSession).toHaveBeenCalledOnce();
+    expect(sendDmToParticipant).toHaveBeenCalledWith("123456", {
+      text: "hello",
+    });
+  });
+
+  it("keeps DM recipient lookup and send inside one authenticated session", async () => {
+    const runtime = runtimeWithSettings({});
+    const service = new XService(runtime);
+    let sessionActive = false;
+    const sendDmToParticipant = vi.fn(async () => {
+      expect(sessionActive).toBe(true);
+      return { dm_event_id: "dm-bound" };
+    });
+    const session = dmSession("account-a", { sendDmToParticipant });
+    const fetchProfile = vi.fn(async () => {
+      expect(sessionActive).toBe(true);
+      return { id: "987654" };
+    });
+    const withAuthenticatedSession = vi.fn(
+      async <T>(
+        operation: (active: AuthenticatedTwitterSession) => Promise<T>,
+      ) => {
+        sessionActive = true;
+        try {
+          return await operation(session);
+        } finally {
+          sessionActive = false;
+        }
+      },
     );
+    const base = {
+      fetchProfile,
+      twitterClient: {
+        withAuthenticatedSession,
+        isAuthenticatedSessionCurrent: () => true,
+      },
+    } as unknown as ClientBase;
+    vi.spyOn(
+      service as unknown as {
+        getTwitterClientForAccount: () => Promise<{ client: ClientBase }>;
+      },
+      "getTwitterClientForAccount",
+    ).mockResolvedValue({ client: base });
+
+    await service.handleSendMessage(
+      runtime,
+      {
+        source: "x",
+        metadata: { xUsername: "alice" },
+      } as TargetInfo,
+      { text: "hello alice" } as Content,
+    );
+
+    expect(withAuthenticatedSession).toHaveBeenCalledOnce();
+    expect(fetchProfile).toHaveBeenCalledWith("alice");
+    expect(sendDmToParticipant).toHaveBeenCalledWith("987654", {
+      text: "hello alice",
+    });
+  });
+
+  it("does not send after credentials rotate during DM recipient lookup", async () => {
+    const runtime = runtimeWithSettings({});
+    const service = new XService(runtime);
+    let current = true;
+    const profile = deferred<{ id: string }>();
+    const sendA = vi.fn();
+    const sendB = vi.fn();
+    const session = dmSession("account-a", { sendDmToParticipant: sendA });
+    const base = {
+      fetchProfile: vi.fn(() => profile.promise),
+      twitterClient: {
+        withAuthenticatedSession: async <T>(
+          operation: (active: AuthenticatedTwitterSession) => Promise<T>,
+        ) => operation(session),
+        isAuthenticatedSessionCurrent: () => current,
+      },
+    } as unknown as ClientBase;
+    vi.spyOn(
+      service as unknown as {
+        getTwitterClientForAccount: () => Promise<{ client: ClientBase }>;
+      },
+      "getTwitterClientForAccount",
+    ).mockResolvedValue({ client: base });
+
+    const send = service.handleSendMessage(
+      runtime,
+      {
+        source: "x",
+        metadata: { xUsername: "alice" },
+      } as TargetInfo,
+      { text: "do not cross accounts" } as Content,
+    );
+    await vi.waitFor(() => expect(base.fetchProfile).toHaveBeenCalledOnce());
+    current = false;
+    profile.resolve({ id: "987654" });
+
+    await expect(send).rejects.toMatchObject({
+      code: "X_AUTH_SESSION_ROTATED",
+    });
+    expect(sendA).not.toHaveBeenCalled();
+    expect(sendB).not.toHaveBeenCalled();
+  });
+
+  it("keeps conversation DM sends inside one authenticated session", async () => {
+    const runtime = runtimeWithSettings({});
+    const service = new XService(runtime);
+    let sessionActive = false;
+    const sendDmInConversation = vi.fn(async () => {
+      expect(sessionActive).toBe(true);
+      return { dm_event_id: "conversation-reply" };
+    });
+    const session = dmSession("account-a", { sendDmInConversation });
+    const withAuthenticatedSession = vi.fn(
+      async <T>(
+        operation: (active: AuthenticatedTwitterSession) => Promise<T>,
+      ) => {
+        sessionActive = true;
+        try {
+          return await operation(session);
+        } finally {
+          sessionActive = false;
+        }
+      },
+    );
+    const base = {
+      twitterClient: {
+        withAuthenticatedSession,
+        isAuthenticatedSessionCurrent: () => true,
+      },
+    } as unknown as ClientBase;
+    vi.spyOn(
+      service as unknown as {
+        getTwitterClientForAccount: () => Promise<{ client: ClientBase }>;
+      },
+      "getTwitterClientForAccount",
+    ).mockResolvedValue({ client: base });
+
+    await expect(
+      service.sendDirectMessageToConversationForAccount("account-a", {
+        conversationId: "conversation-1",
+        text: "hello group",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      status: 201,
+      messageId: "conversation-reply",
+    });
+    expect(withAuthenticatedSession).toHaveBeenCalledOnce();
+    expect(sendDmInConversation).toHaveBeenCalledWith("conversation-1", {
+      text: "hello group",
+    });
+  });
+
+  it("classifies recent DMs with the captured session profile", async () => {
+    const runtime = runtimeWithSettings({});
+    const service = new XService(runtime);
+    async function* events() {
+      yield {
+        id: "1",
+        sender_id: "current-user",
+        participant_ids: ["current-user", "alice"],
+        text: "outbound",
+      };
+      yield {
+        id: "2",
+        sender_id: "alice",
+        participant_ids: ["current-user", "alice"],
+        text: "inbound",
+      };
+    }
+    const iterator = Object.assign(events(), {
+      includes: {
+        users: [
+          { id: "current-user", username: "current" },
+          { id: "alice", username: "alice" },
+        ],
+      },
+    });
+    const session = dmSession("current-user", {
+      listDmEvents: vi.fn(async () => iterator),
+    });
+    const base = {
+      profile: { id: "stale-user", username: "stale" },
+      twitterClient: {
+        withAuthenticatedSession: async <T>(
+          operation: (active: AuthenticatedTwitterSession) => Promise<T>,
+        ) => operation(session),
+        isAuthenticatedSessionCurrent: () => true,
+      },
+    } as unknown as ClientBase;
+    vi.spyOn(
+      service as unknown as {
+        getTwitterClientForAccount: () => Promise<{ client: ClientBase }>;
+      },
+      "getTwitterClientForAccount",
+    ).mockResolvedValue({ client: base });
+
+    const messages = await (
+      service as unknown as {
+        listRecentDirectMessages: (
+          accountId: string,
+          limit: number,
+        ) => Promise<Array<{ isInbound: boolean }>>;
+      }
+    ).listRecentDirectMessages("account-a", 10);
+
+    expect(messages.map((message) => message.isInbound)).toEqual([false, true]);
   });
 });

--- a/plugins/plugin-x/src/services/x.service.test.ts
+++ b/plugins/plugin-x/src/services/x.service.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { ClientBase } from "../base";
 import type { AuthenticatedTwitterSession } from "../client/auth";
 import type { TwitterClientState } from "../types";
+import { TwitterPostService } from "./PostService";
 import { TwitterClientInstance, XService } from "./x.service";
 
 function asRuntime<T extends object>(runtime: T): IAgentRuntime & T {
@@ -319,6 +320,47 @@ describe("XService trusted account routing", () => {
     expect(sendDmToParticipant).toHaveBeenCalledWith("123456", {
       text: "hello",
     });
+  });
+
+  it("ignores spoofed content account metadata in the post handler", async () => {
+    const runtime = runtimeWithSettings({});
+    const service = new XService(runtime);
+    const base = { profile: null } as unknown as ClientBase;
+    const getClient = vi
+      .spyOn(
+        service as unknown as {
+          getTwitterClientForAccount: (accountId: unknown) => Promise<{
+            client: ClientBase;
+          }>;
+        },
+        "getTwitterClientForAccount",
+      )
+      .mockResolvedValue({ client: base });
+    vi.spyOn(TwitterPostService.prototype, "createPost").mockResolvedValue({
+      id: "post-1",
+      agentId: runtime.agentId,
+      roomId: "room-1" as never,
+      userId: "account-owner",
+      username: "account-owner",
+      text: "hello",
+      timestamp: 1,
+    });
+
+    await service.handleSendPost(
+      runtime,
+      {
+        text: "hello",
+        accountId: "attacker",
+        metadata: { accountId: "attacker" },
+      } as Content,
+      {
+        runtime,
+        source: "x",
+        accountId: "trusted",
+      },
+    );
+
+    expect(getClient).toHaveBeenCalledWith("trusted");
   });
 
   it("keeps DM recipient lookup and send inside one authenticated session", async () => {

--- a/plugins/plugin-x/src/services/x.service.ts
+++ b/plugins/plugin-x/src/services/x.service.ts
@@ -16,6 +16,7 @@ import {
   ChannelType,
   type Content,
   createUniqueUuid,
+  ElizaError,
   type IAgentRuntime,
   logger,
   type Memory,
@@ -34,6 +35,7 @@ import {
   resolveRequestedXAccountId,
   resolveTwitterAccountConfig,
 } from "../client/accounts.js";
+import type { AuthenticatedTwitterSession } from "../client/auth.js";
 import { SearchMode } from "../client/index.js";
 import { materializeEnvAccountIfMissing } from "../connector-account-provider.js";
 import { TwitterDirectMessageClient } from "../direct-messages";
@@ -43,6 +45,7 @@ import { TwitterInteractionClient } from "../interactions";
 import { TwitterPostClient } from "../post";
 import { TwitterTimelineClient } from "../timeline";
 import type { ITwitterClient, TwitterClientState } from "../types";
+import { normalizeXReceiptId } from "../utils/provider-receipt";
 import { getSetting } from "../utils/settings";
 import { getEpochMs } from "../utils/time";
 import { TwitterPostService } from "./PostService";
@@ -673,33 +676,32 @@ export class XService extends Service {
         ? (metadata as Record<string, unknown>)
         : undefined;
     const accountId = this.resolveAccountId(target.accountId);
-    const client = await this.getTwitterClientForAccount(accountId);
-    const recipient = await this.resolveDmRecipient(
-      (typeof metadataRecord?.xUserId === "string"
-        ? metadataRecord.xUserId
-        : undefined) ??
-        (typeof metadataRecord?.twitterUserId === "string"
-          ? metadataRecord.twitterUserId
+    await this.withDmSession(accountId, async (base, session) => {
+      const recipient = await this.resolveDmRecipient(
+        (typeof metadataRecord?.xUserId === "string"
+          ? metadataRecord.xUserId
           : undefined) ??
-        (typeof metadataRecord?.xUsername === "string"
-          ? metadataRecord.xUsername
-          : undefined) ??
-        (typeof metadataRecord?.twitterUsername === "string"
-          ? metadataRecord.twitterUsername
-          : undefined) ??
-        (typeof target.entityId === "string" ? target.entityId : undefined) ??
-        target.channelId ??
-        target.threadId,
-      client.client,
-    );
-
-    if (!recipient) {
-      throw new Error(
-        "X DM connector requires a resolvable recipient user id.",
+          (typeof metadataRecord?.twitterUserId === "string"
+            ? metadataRecord.twitterUserId
+            : undefined) ??
+          (typeof metadataRecord?.xUsername === "string"
+            ? metadataRecord.xUsername
+            : undefined) ??
+          (typeof metadataRecord?.twitterUsername === "string"
+            ? metadataRecord.twitterUsername
+            : undefined) ??
+          (typeof target.entityId === "string" ? target.entityId : undefined) ??
+          target.channelId ??
+          target.threadId,
+        base,
       );
-    }
-
-    await this.sendXDirectMessage(accountId, recipient, text);
+      if (!recipient) {
+        throw new Error(
+          "X DM connector requires a resolvable recipient user id.",
+        );
+      }
+      await this.sendXDirectMessage(base, session, recipient, text);
+    });
   }
 
   async sendDirectMessageForAccount(
@@ -711,18 +713,18 @@ export class XService extends Service {
       throw new Error("X DM connector requires non-empty text content.");
     }
 
-    const client = await this.getTwitterClientForAccount(accountId);
-    const recipient = await this.resolveDmRecipient(
-      params.participantId,
-      client.client,
-    );
-    if (!recipient) {
-      throw new Error(
-        "X DM connector requires a resolvable recipient user id.",
+    const sent = await this.withDmSession(accountId, async (base, session) => {
+      const recipient = await this.resolveDmRecipient(
+        params.participantId,
+        base,
       );
-    }
-
-    const sent = await this.sendXDirectMessage(accountId, recipient, text);
+      if (!recipient) {
+        throw new Error(
+          "X DM connector requires a resolvable recipient user id.",
+        );
+      }
+      return this.sendXDirectMessage(base, session, recipient, text);
+    });
     return {
       ok: true,
       status: 201,
@@ -892,25 +894,16 @@ export class XService extends Service {
     accountId: string,
     params: { conversationId: string; text: string },
   ): Promise<{ ok: true; status: number; messageId: string | null }> {
-    const client = await this.getV2DmClient(accountId);
-    const sender = client.v2 as typeof client.v2 & {
-      sendDmToConversation?: (
-        conversationId: string,
-        body: { text: string },
-      ) => Promise<{ data?: { dm_event_id?: string } }>;
-    };
-    if (typeof sender.sendDmToConversation !== "function") {
-      throw new Error(
-        "X v2 client does not expose sendDmToConversation; conversation DM send requires plugin-x DM conversation support.",
-      );
-    }
-    const result = await sender.sendDmToConversation(params.conversationId, {
-      text: params.text,
+    const result = await this.withDmSession(accountId, (base, session) => {
+      this.assertDmSessionCurrent(base, session);
+      return session.client.v2.sendDmInConversation(params.conversationId, {
+        text: params.text,
+      });
     });
     return {
       ok: true,
       status: 201,
-      messageId: result.data?.dm_event_id ?? null,
+      messageId: normalizeXReceiptId(result.dm_event_id) ?? null,
     };
   }
 
@@ -1210,62 +1203,41 @@ export class XService extends Service {
     };
   }
 
-  private async getV2DmClient(accountId?: string): Promise<{
-    v2: {
-      sendDmToParticipant?: (
-        participantId: string,
-        body: { text: string },
-      ) => Promise<{ data?: { dm_event_id?: string } }>;
-      listDmEvents?: (opts: Record<string, unknown>) => AsyncIterable<{
-        id?: string;
-        sender_id?: string;
-        dm_conversation_id?: string;
-        recipient_id?: string;
-        participant_ids?: string[];
-        text?: string;
-        created_at?: string;
-        event_type?: string;
-      }> & {
-        includes?: { users?: Array<{ id: string; username?: string }> };
-      };
-    };
-  }> {
-    const base = (await this.getTwitterClientForAccount(accountId)).client;
-    return (await base.twitterClient.getV2Client()) as unknown as {
-      v2: {
-        sendDmToParticipant?: (
-          participantId: string,
-          body: { text: string },
-        ) => Promise<{ data?: { dm_event_id?: string } }>;
-        listDmEvents?: (opts: Record<string, unknown>) => AsyncIterable<{
-          id?: string;
-          sender_id?: string;
-          dm_conversation_id?: string;
-          recipient_id?: string;
-          participant_ids?: string[];
-          text?: string;
-          created_at?: string;
-          event_type?: string;
-        }> & {
-          includes?: { users?: Array<{ id: string; username?: string }> };
-        };
-      };
-    };
-  }
-
   private async sendXDirectMessage(
-    accountId: string,
+    base: ClientBase,
+    session: AuthenticatedTwitterSession,
     recipient: string,
     text: string,
   ): Promise<{ messageId: string | null }> {
-    const client = await this.getV2DmClient(accountId);
-    if (!client.v2.sendDmToParticipant) {
-      throw new Error(
-        "X v2 client does not expose sendDmToParticipant; DM send requires DM API scopes.",
-      );
+    this.assertDmSessionCurrent(base, session);
+    const result = await session.client.v2.sendDmToParticipant(recipient, {
+      text,
+    });
+    return { messageId: normalizeXReceiptId(result.dm_event_id) ?? null };
+  }
+
+  private async withDmSession<T>(
+    accountId: string | undefined,
+    operation: (
+      base: ClientBase,
+      session: AuthenticatedTwitterSession,
+    ) => Promise<T>,
+  ): Promise<T> {
+    const base = (await this.getTwitterClientForAccount(accountId)).client;
+    return base.twitterClient.withAuthenticatedSession((session) =>
+      operation(base, session),
+    );
+  }
+
+  private assertDmSessionCurrent(
+    base: ClientBase,
+    session: AuthenticatedTwitterSession,
+  ): void {
+    if (!base.twitterClient.isAuthenticatedSessionCurrent(session)) {
+      throw new ElizaError("X credentials rotated before direct-message send", {
+        code: "X_AUTH_SESSION_ROTATED",
+      });
     }
-    const result = await client.v2.sendDmToParticipant(recipient, { text });
-    return { messageId: result.data?.dm_event_id ?? null };
   }
 
   private async resolveDmRecipient(
@@ -1308,69 +1280,72 @@ export class XService extends Service {
       participantIds: string[];
     }>
   > {
-    const base = (await this.getTwitterClientForAccount(accountId)).client;
-    const client = await this.getV2DmClient(accountId);
-    const ownUserId = base.profile?.id ?? null;
-    const iterator = client.v2.listDmEvents?.({
-      max_results: Math.min(Math.max(1, limit), 50),
-      "dm_event.fields": [
-        "id",
-        "created_at",
-        "dm_conversation_id",
-        "sender_id",
-        "text",
-        "event_type",
-        "participant_ids",
-      ],
-      "user.fields": ["id", "username"],
-      expansions: ["sender_id"],
-      event_types: ["MessageCreate"],
-    });
-    if (!iterator) {
-      return [];
-    }
-
-    const usernameMap = new Map<string, string>();
-    for (const user of iterator.includes?.users ?? []) {
-      if (user.id && user.username) {
-        usernameMap.set(user.id, user.username);
+    return this.withDmSession(accountId, async (base, session) => {
+      const ownUserId = session.profile.userId;
+      if (!ownUserId) {
+        throw new ElizaError(
+          "X direct-message history requires an authenticated profile identifier",
+          { code: "X_ME_FETCH_FAILED" },
+        );
       }
-    }
-
-    const messages: Array<{
-      id: string;
-      conversationId: string;
-      senderId: string;
-      senderUsername: string | null;
-      text: string;
-      createdAt: string | null;
-      isInbound: boolean;
-      participantIds: string[];
-    }> = [];
-    for await (const event of iterator) {
-      if (event.event_type && event.event_type !== "MessageCreate") {
-        continue;
-      }
-      messages.push({
-        id: event.id ?? "",
-        conversationId: event.dm_conversation_id ?? event.id ?? "",
-        senderId: event.sender_id ?? "",
-        senderUsername: event.sender_id
-          ? (usernameMap.get(event.sender_id) ?? null)
-          : null,
-        text: event.text ?? "",
-        createdAt: event.created_at ?? null,
-        isInbound:
-          ownUserId && event.sender_id ? event.sender_id !== ownUserId : true,
-        participantIds: Array.isArray(event.participant_ids)
-          ? event.participant_ids
-          : [],
+      const iterator = await session.client.v2.listDmEvents({
+        max_results: Math.min(Math.max(1, limit), 50),
+        "dm_event.fields": [
+          "id",
+          "created_at",
+          "dm_conversation_id",
+          "sender_id",
+          "text",
+          "event_type",
+          "participant_ids",
+        ],
+        "user.fields": ["id", "username"],
+        expansions: ["sender_id"],
+        event_types: ["MessageCreate"],
       });
-      if (messages.length >= limit) {
-        break;
+
+      const usernameMap = new Map<string, string>();
+      for (const user of iterator.includes?.users ?? []) {
+        if (user.id && user.username) {
+          usernameMap.set(user.id, user.username);
+        }
       }
-    }
-    return messages;
+
+      const messages: Array<{
+        id: string;
+        conversationId: string;
+        senderId: string;
+        senderUsername: string | null;
+        text: string;
+        createdAt: string | null;
+        isInbound: boolean;
+        participantIds: string[];
+      }> = [];
+      for await (const event of iterator) {
+        if (event.event_type && event.event_type !== "MessageCreate") {
+          continue;
+        }
+        messages.push({
+          id: event.id ?? "",
+          conversationId: event.dm_conversation_id ?? event.id ?? "",
+          senderId: event.sender_id ?? "",
+          senderUsername: event.sender_id
+            ? (usernameMap.get(event.sender_id) ?? null)
+            : null,
+          text: event.text ?? "",
+          createdAt: event.created_at ?? null,
+          isInbound: event.sender_id ? event.sender_id !== ownUserId : true,
+          participantIds: Array.isArray(event.participant_ids)
+            ? event.participant_ids
+            : [],
+        });
+        if (messages.length >= limit) {
+          break;
+        }
+      }
+      this.assertDmSessionCurrent(base, session);
+      return messages;
+    });
   }
 
   /**

--- a/plugins/plugin-x/src/services/x.service.ts
+++ b/plugins/plugin-x/src/services/x.service.ts
@@ -782,7 +782,6 @@ export class XService extends Service {
       context?.accountId,
       context?.target,
       context?.metadata,
-      content,
     );
     const base = (await this.getTwitterClientForAccount(accountId)).client;
 

--- a/plugins/plugin-x/src/utils/provider-receipt.test.ts
+++ b/plugins/plugin-x/src/utils/provider-receipt.test.ts
@@ -1,0 +1,57 @@
+/** Deterministic coverage for accepted X write response shapes and invalid identifiers. */
+import { describe, expect, it, vi } from "vitest";
+import {
+  extractXWriteReceiptId,
+  normalizeXReceiptId,
+} from "./provider-receipt";
+
+describe("X write receipt extraction", () => {
+  it.each([
+    [{ id: " direct " }, "direct"],
+    [{ data: { id: "nested" } }, "nested"],
+    [{ data: { data: { id: "deep" } } }, "deep"],
+    [{ rest_id: "rest" }, "rest"],
+    [
+      {
+        data: {
+          create_tweet: { tweet_results: { result: { rest_id: "graph" } } },
+        },
+      },
+      "graph",
+    ],
+  ])("extracts a non-empty id from %o", async (response, expected) => {
+    await expect(extractXWriteReceiptId(response)).resolves.toBe(expected);
+  });
+
+  it("reads a cloned response body without consuming the original", async () => {
+    const originalJson = vi.fn();
+    const cloneJson = vi.fn(async () => ({ data: { id: "from-body" } }));
+    const response = {
+      bodyUsed: false,
+      json: originalJson,
+      clone: vi.fn(() => ({ json: cloneJson })),
+    };
+
+    await expect(extractXWriteReceiptId(response)).resolves.toBe("from-body");
+    expect(response.clone).toHaveBeenCalledOnce();
+    expect(cloneJson).toHaveBeenCalledOnce();
+    expect(originalJson).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, null, "", "   ", 123])(
+    "rejects unusable id %o",
+    (value) => {
+      expect(normalizeXReceiptId(value)).toBeUndefined();
+    },
+  );
+
+  it("returns an explicit missing receipt for an unreadable body", async () => {
+    await expect(
+      extractXWriteReceiptId({
+        json: vi.fn(async () => {
+          throw new Error("malformed body");
+        }),
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/plugins/plugin-x/src/utils/provider-receipt.ts
+++ b/plugins/plugin-x/src/utils/provider-receipt.ts
@@ -1,0 +1,73 @@
+/**
+ * Extracts a non-empty provider message identifier from the response shapes
+ * returned by twitter-api-v2 without consuming a live Response body in place.
+ */
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readPath(value: unknown, path: readonly string[]): unknown {
+  let current = value;
+  for (const key of path) {
+    const record = asRecord(current);
+    if (!record) return undefined;
+    current = record[key];
+  }
+  return current;
+}
+
+export function normalizeXReceiptId(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const id = value.trim();
+  return id.length > 0 ? id : undefined;
+}
+
+function extractSynchronousId(result: unknown): string | undefined {
+  const paths = [
+    ["id"],
+    ["data", "id"],
+    ["data", "data", "id"],
+    ["rest_id"],
+    ["data", "create_tweet", "tweet_results", "result", "rest_id"],
+    ["data", "create_tweet", "tweet_results", "result", "id"],
+    ["data", "data", "create_tweet", "tweet_results", "result", "rest_id"],
+    ["data", "data", "create_tweet", "tweet_results", "result", "id"],
+  ] as const;
+
+  for (const path of paths) {
+    const id = normalizeXReceiptId(readPath(result, path));
+    if (id) return id;
+  }
+  return undefined;
+}
+
+export async function extractXWriteReceiptId(
+  result: unknown,
+): Promise<string | undefined> {
+  const direct = extractSynchronousId(result);
+  if (direct) return direct;
+
+  const record = asRecord(result);
+  if (!record) return undefined;
+
+  let bodySource: unknown = result;
+  if (typeof record.clone === "function") {
+    if (record.bodyUsed === true) return undefined;
+    bodySource = (record.clone as () => unknown)();
+  }
+
+  const bodyRecord = asRecord(bodySource);
+  if (!bodyRecord || typeof bodyRecord.json !== "function") return undefined;
+
+  try {
+    const body = await (bodyRecord.json as () => Promise<unknown>)();
+    return extractSynchronousId(body);
+  } catch {
+    // error-policy:J3 An unreadable provider body is an explicit missing
+    // receipt; callers surface a non-retriable indeterminate outcome.
+    return undefined;
+  }
+}


### PR DESCRIPTION
# Relates to

- Part 1 of #19968
- Comparison/integration draft: #20035
- Fleet split receipt: https://github.com/elizaOS/eliza/discussions/18309#discussioncomment-18031253

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto exact `origin/develop@f8135bffe31a75581a97be3566798b90c606677f` with zero conflicts.
- [x] `bun install --frozen-lockfile` and full root `bun run verify` pass on the exact rebased head.
- [x] A reviewer can confirm the bounded credential-generation behavior from the deterministic adversarial suite and package gates below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/slopdotcash@332dc64deec632ac7746f237f0f30d4aad6050d5:skills/contribute-to-eliza/SKILL.md`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop@f8135bffe31a75581a97be3566798b90c606677f`; zero conflicts.
- [x] Exact-head package gates and full root `bun run verify` pass.

# Risks

Medium. This changes authentication concurrency, makes every public X client I/O method hold a counted credential-generation lease, and binds production DM reads and writes to the captured current identity. A mistake could block credential rotation or let an old account finish work after a replacement. The adversarial tests cover concurrent initialization, tuple/mode rotation, ABA, detached async contexts, logout/replacement races, secret-bearing failures, and delayed public reads/writes.

# Background

## What does this PR do?

This is the reviewed authentication and direct-message security slice extracted from #20035:

- fingerprints the complete effective OAuth tuple without persisting or logging credential values;
- invalidates cached identity before a changed tuple can be reused;
- serializes generation admission while draining already-admitted operations;
- keeps awaited nested work pinned and prevents detached async contexts from retaining an expired account;
- makes public Client reads, writes, pagination, generators, media, and DMs hold one authenticated lease;
- fails public authentication closed and normalizes provider receipt IDs;
- deprecates raw client/session escape hatches without removing them;
- streams paginated public generators one provider step at a time and aborts between pages after rotation;
- binds live DM polling, current-profile filtering, recipient resolution, participant/conversation sends, and history reads to one authenticated session.

It intentionally excludes broader ClientBase legacy-entity and non-DM cursor partitioning plus autonomous interaction/settlement slices. It relates to #19968 but does not close it.

## What kind of change is this?

Bug fix / security hardening.

# Documentation changes needed?

No public setup or configuration changes. The existing package guide already describes broker, OAuth1, and OAuth2 modes; this slice changes their runtime safety contract and carries caller-facing JSDoc on the affected APIs.

# Testing

## Where should a reviewer start?

- `plugins/plugin-x/src/client/auth.test.ts`
- `plugins/plugin-x/src/client/auth.ts`
- `plugins/plugin-x/src/client/client.ts`
- `plugins/plugin-x/src/direct-messages.test.ts`
- `plugins/plugin-x/src/services/x.service.test.ts`
- `plugins/plugin-x/src/utils/provider-receipt.test.ts`

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-x test
bun run --cwd plugins/plugin-x typecheck
bun run --cwd plugins/plugin-x lint:check
bun run --cwd plugins/plugin-x build
git diff origin/develop...HEAD --check
bun run verify
```

Exact rebased results:

- plugin-X: 25 test files passed, 1 credential-gated live suite skipped; 167 passed, 13 live-X skipped.
- plugin-X typecheck: pass.
- plugin-X Biome: 82 files checked, pass.
- plugin-X production ESM + DTS build: pass.
- diff check: pass.
- root verify: pass — 351/351 Turbo tasks; anti-larp scan 8,230 test files, 0 focused and 0 orphaned skips.

# Evidence Gate

<!-- evidence-head:dc395a13c75f222c76b7be945a924bd759bc0651 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - authentication backend only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - authentication backend only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual or interactive frontend flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - production X credentials are outside this lane; no live provider call was authorized.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no action, provider, prompt, planner, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Deterministic credential-generation/session artifacts are recorded below.

<details>
<summary>Exact credential-generation domain receipt</summary>

```text
A -> B with the same access token and a changed OAuth1 secret: the client rebuilds and profile A is invalidated before B can publish.
A -> B -> C while initialization is in flight: coalesced waiters resolve C, the intermediate B profile never publishes, and the callback is not replayed.
A detached async child resumed after its A lease ends: it resolves the current B client/profile; expired A cannot egress after replacement.
A paginated provider iterator yields immediately, closes on cancellation, and cannot fetch another stale-A page after rotation.
A DM poll or connector send paused during routing/recipient lookup aborts before X egress and leaves the durable cursor unchanged after rotation.
```

</details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model-facing behavior changed.

## Backend + frontend logs

N/A - no production X credential access was authorized. The exact production auth boundary is driven deterministically with broker/provider fakes; real X mention/DM proof remains the owner-authorized gate in parent #19444.

## Screenshots (before / after) + video walkthrough

N/A - backend-only authentication/session change.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT surface changed.

## Known gaps / failures

- The 13 live-X tests remain skipped because this lane is not authorized to read or use production X credentials. Parent #19444 owns the real-provider acceptance run.
- #19968 remains open for the remaining bounded slices and independent exact-head review.
- This PR remains draft until fresh exact-head hosted checks and reviewer disposition complete; no source blocker is currently known.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/slopdotcash@332dc64deec632ac7746f237f0f30d4aad6050d5:skills/contribute-to-eliza/SKILL.md
Attribution status: self-reported
— [codex-slop-launch]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/slopdotcash@332dc64deec632ac7746f237f0f30d4aad6050d5:skills/contribute-to-eliza/SKILL.md"} -->


