### PR TITLE
fix(core): reject malformed channel topic limits

### DIFF
--- a/packages/core/src/features/basic-capabilities/channel-topic-search.test.ts
+++ b/packages/core/src/features/basic-capabilities/channel-topic-search.test.ts
@@ -164,6 +164,18 @@ describe("GET /api/channel-topics/search (#8927)", () => {
 		expect((res.body as { count: number }).count).toBe(1);
 	});
 
+	it("falls back to the default limit for a partially numeric value", async () => {
+		const searchTopics = vi.fn(() => HITS);
+		const res = makeRes();
+		await CHANNEL_TOPICS_SEARCH_ROUTE.handler?.(
+			{ query: { q: "stripe", limit: "5junk" } } as never,
+			res as never,
+			runtimeWith({ searchTopics }),
+		);
+		expect(res.code).toBe(200);
+		expect(searchTopics).toHaveBeenCalledWith("stripe", 20);
+	});
+
 	it("returns 400 when q is missing", async () => {
 		const res = makeRes();
 		await CHANNEL_TOPICS_SEARCH_ROUTE.handler?.(

--- a/packages/core/src/features/basic-capabilities/channel-topics-routes.ts
+++ b/packages/core/src/features/basic-capabilities/channel-topics-routes.ts
@@ -31,8 +31,8 @@ export const CHANNEL_TOPICS_SEARCH_ROUTE: Route = {
 			res.status(400).json({ error: "query parameter 'q' is required" });
 			return;
 		}
-		const rawLimit = Number.parseInt(firstQueryValue(req.query?.limit), 10);
-		const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? rawLimit : 20;
+		const rawLimit = Number(firstQueryValue(req.query?.limit));
+		const limit = Number.isInteger(rawLimit) && rawLimit > 0 ? rawLimit : 20;
 		const svc = runtime.getService("channel_topics") as
 			| (TopicSearchService & object)
 			| null;


### PR DESCRIPTION
# Relates to

Closes #20089.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] this PR targets `develop` and is branched directly off the current `origin/develop` tip.
- [x] focused package tests, lint, and typecheck pass on the exact head, see Testing below.
- [x] a reviewer can confirm the fix directly against the deterministic route-handler test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (fix, tests, via AgentRouter proxy), `anthropic/claude-sonnet-5` (independent re-verification)
<!-- attribution-row:client -->
- Agent tooling: `codex` (via AgentRouter proxy), `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] branched directly off the current `origin/develop` tip

# Risks

low. this only tightens `limit` parsing in one search route; every existing valid limit (a positive integer) behaves identically.

# Background

## What does this PR do?

`GET /api/channel-topics/search` parsed its `limit` query parameter with `Number.parseInt(firstQueryValue(req.query?.limit), 10)`. `parseInt` accepts a numeric prefix and ignores trailing garbage, so `limit=5junk` was silently parsed as `5` and passed straight to `ChannelTopicsService.searchTopics`, instead of hitting the route's own invalid-input fallback of `20`. Fractional values (`limit=5.9`) were likewise silently truncated rather than rejected.

confirmed directly:

```text
$ bun -e 'console.log(Number.parseInt("5junk", 10))'
5
```

traced reachability before writing this up: the route is live, not test-only. `CHANNEL_TOPICS_SEARCH_ROUTE` is in `CHANNEL_TOPICS_ROUTES`, included in `createBasicCapabilitiesPlugin`'s `routes` array, constructed by the normal standalone agent boot (`packages/agent/src/runtime/eliza.ts`), and dispatched by `packages/agent/src/api/runtime-plugin-routes.ts` against real URL query values. The route is `public: false`, so a caller needs to pass the agent server's auth gate first, but any authenticated API client can then supply arbitrary query text. No first-party UI caller was found for this specific endpoint, so today's reachability is through authenticated API clients rather than a traced built-in UI flow.

fix: parse with `Number(...)` and accept only when `Number.isInteger(rawLimit) && rawLimit > 0`; anything else (malformed, fractional, non-finite, zero, negative) falls back to the existing default of `20`.

## What kind of change is this?

bug fix, non-breaking (every existing valid `limit` value behaves identically).

# Documentation changes needed?

no, the fix restores the route's own documented fallback behavior rather than changing the interface.

# Testing

## Where should a reviewer start?

`packages/core/src/features/basic-capabilities/channel-topic-search.test.ts`, the new `falls back to the default limit for a partially numeric value` case, then the parsing change in `channel-topics-routes.ts`.

## Detailed testing steps

```text
$ bun test src/features/basic-capabilities/channel-topic-search.test.ts
10 pass
0 fail
30 expect() calls

$ bun run typecheck
Done!  (exit 0)

$ bunx @biomejs/biome check src/features/basic-capabilities/channel-topics-routes.ts src/features/basic-capabilities/channel-topic-search.test.ts
Checked 2 files in 29ms. No fixes applied.
```

mutation-resistance verified independently: reverted just the source fix, kept the new test, reran — 1/10 failed (`searchTopics` called with `5` instead of the expected fallback `20`). restored the fix, 10/10 green again.

# Evidence Gate

<!-- evidence-head:fc88cfceb3451640d4436bd34568d0942ede9c7d -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes an HTTP route's query-parameter parsing, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - this changes an HTTP route's query-parameter parsing, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive product flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic route-handler test, the real transcript is included under domain artifacts.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code or network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real mutation-resistance run, captured directly:
  ```text
  red (source fix reverted, test kept):
  $ bun test src/features/basic-capabilities/channel-topic-search.test.ts
  expect(received).toHaveBeenCalledWith(...expected)
  @@ -2,3 +2,3 @@
     "stripe",
  -  20,
  +  5,
  9 pass | 1 fail

  green (fix restored):
  $ bun test src/features/basic-capabilities/channel-topic-search.test.ts
  10 pass | 0 fail
  ```
  also independently confirmed `Number.parseInt("5junk", 10)` really is `5` in a real bun REPL, and traced the route's live-reachability path through the plugin/runtime dispatch chain before writing this up.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface or visual text changed.

## Known gaps / failures

none in the touched surface. the full `packages/core` test lane has 5 pre-existing failing files unrelated to this change: local HTTP-server tests that can't bind a loopback socket in this sandbox (`listen EPERM`), plus existing assertions in message prompt sizing, guarded streaming, and interaction rendering — none of which touch channel-topics code. The focused suite is green both standalone and inside the package run.

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the focused suite, typecheck, and lint myself, confirmed the parseInt leniency directly, retraced the route's live-reachability chain, did my own revert-and-confirm-red mutation check, opened the governing issue, and pushed via the GitHub Git Data API since `git push` was hanging on this environment)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Contribution skill revision: N/A - direct interactive session, contribute-to-eliza skill not used
Compute receipt: N/A - Slop run-receipt install currently blocked by an unrelated site-deploy-lag issue (deployed skill archive predates recent develop changes)
Attribution status: self-reported
