### PR TITLE
fix(ui): never show billing purchase success before checkout verification

### DIFF
--- a/packages/ui/src/cloud/billing/BillingSuccessPage.test.tsx
+++ b/packages/ui/src/cloud/billing/BillingSuccessPage.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * Exercises the authenticated billing Checkout return component as a
+ * deterministic state machine. Session/auth and the verification mutation are
+ * controlled test seams; the real page decides which user-visible state wins.
+ */
+
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const searchParamsState = vi.hoisted(() => ({
+  current: new URLSearchParams(),
+}));
+
+const sessionState = vi.hoisted(() => ({
+  ready: true,
+  authenticated: true,
+}));
+
+const verifyState = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  isPending: false,
+  isError: false,
+  isSuccess: false,
+  error: null as Error | null,
+  data: undefined as
+    | { success: boolean; balance: number; alreadyApplied: boolean }
+    | undefined,
+}));
+
+vi.mock("react-router-dom", () => ({
+  Link: ({ to, children }: { to: string; children: ReactNode }) => (
+    <a href={to}>{children}</a>
+  ),
+  useSearchParams: () => [searchParamsState.current, vi.fn()],
+}));
+
+vi.mock("@elizaos/ui/cloud-ui", () => ({
+  Button: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Card: ({ children, ...props }: { children: ReactNode }) => (
+    <section {...props}>{children}</section>
+  ),
+  CardContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  CardDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  CardFooter: ({ children }: { children: ReactNode }) => (
+    <footer>{children}</footer>
+  ),
+  CardHeader: ({ children }: { children: ReactNode }) => (
+    <header>{children}</header>
+  ),
+  CardTitle: ({ children }: { children: ReactNode }) => <h1>{children}</h1>,
+  DashboardLoadingState: ({ label }: { label: string }) => (
+    <div role="status" aria-live="polite" aria-label={label} />
+  ),
+}));
+
+vi.mock("../lib/use-session-auth", () => ({
+  useSessionAuth: () => sessionState,
+}));
+
+vi.mock("../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, options?: { defaultValue?: string }) =>
+    options?.defaultValue ?? _key,
+}));
+
+vi.mock("./components/success-client", () => ({
+  CreditBalanceDisplay: () => <div data-testid="credit-balance">$42.00</div>,
+}));
+
+vi.mock("./data/billing-data", () => ({
+  useVerifyCheckout: () => verifyState,
+}));
+
+import BillingSuccessPage from "./BillingSuccessPage";
+
+function renderPage(search = "session_id=cs_paid&from=settings") {
+  searchParamsState.current = new URLSearchParams(search);
+  return render(<BillingSuccessPage />);
+}
+
+function expectNoSuccess(): void {
+  expect(screen.queryByText("Purchase Successful!")).toBeNull();
+  expect(screen.queryByTestId("credit-balance")).toBeNull();
+}
+
+beforeEach(() => {
+  searchParamsState.current = new URLSearchParams();
+  sessionState.ready = true;
+  sessionState.authenticated = true;
+  verifyState.mutate.mockReset();
+  verifyState.isPending = false;
+  verifyState.isError = false;
+  verifyState.isSuccess = false;
+  verifyState.error = null;
+  verifyState.data = undefined;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("BillingSuccessPage checkout verification truth", () => {
+  it("rejects a missing checkout session without starting verification", () => {
+    renderPage("");
+
+    const alert = screen.getByRole("alert");
+    expect(alert.getAttribute("aria-live")).toBe("assertive");
+    expect(alert.textContent).toContain("Payment Issue");
+    expect(alert.textContent).not.toContain("session ID");
+    expect(alert.textContent).not.toContain("Session:");
+    expectNoSuccess();
+    expect(verifyState.mutate).not.toHaveBeenCalled();
+  });
+
+  it("keeps idle verification away from success before the effect settles", () => {
+    renderPage();
+
+    expect(
+      screen.getByRole("status", { name: "Verifying payment" }),
+    ).toBeTruthy();
+    expectNoSuccess();
+    expect(verifyState.mutate).toHaveBeenCalledTimes(1);
+    expect(verifyState.mutate).toHaveBeenCalledWith({
+      sessionId: "cs_paid",
+      from: "settings",
+    });
+  });
+
+  it("keeps pending verification away from success", () => {
+    verifyState.isPending = true;
+    renderPage("session_id=cs_pending");
+
+    expect(
+      screen.getByRole("status", { name: "Verifying payment" }),
+    ).toBeTruthy();
+    expectNoSuccess();
+    expect(verifyState.mutate).toHaveBeenCalledTimes(1);
+    expect(verifyState.mutate).toHaveBeenCalledWith({
+      sessionId: "cs_pending",
+      from: undefined,
+    });
+  });
+
+  it("renders a verification rejection as an announced payment issue", () => {
+    const page = renderPage();
+    verifyState.isError = true;
+    verifyState.error = new Error("Checkout verification failed");
+
+    page.rerender(<BillingSuccessPage />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert.getAttribute("aria-live")).toBe("assertive");
+    expect(alert.textContent).toContain("Checkout verification failed");
+    expectNoSuccess();
+    expect(verifyState.mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a resolved response whose success flag is false", () => {
+    const page = renderPage();
+    verifyState.isSuccess = true;
+    verifyState.data = {
+      success: false,
+      balance: 42,
+      alreadyApplied: false,
+    };
+
+    page.rerender(<BillingSuccessPage />);
+
+    expect(screen.getByRole("alert").textContent).toContain("Payment Issue");
+    expectNoSuccess();
+    expect(verifyState.mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders purchase success only for a verified success payload", () => {
+    const page = renderPage();
+    verifyState.isSuccess = true;
+    verifyState.data = {
+      success: true,
+      balance: 42,
+      alreadyApplied: false,
+    };
+
+    page.rerender(<BillingSuccessPage />);
+
+    expect(screen.getByText("Purchase Successful!")).toBeTruthy();
+    expect(screen.getByTestId("credit-balance")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(verifyState.mutate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/cloud/billing/BillingSuccessPage.tsx
+++ b/packages/ui/src/cloud/billing/BillingSuccessPage.tsx
@@ -55,26 +55,21 @@ export default function BillingSuccessPage() {
     );
   }
 
-  if (sessionId && verify.isPending) {
-    return (
-      <DashboardLoadingState
-        label={t("cloud.billingSuccess.verifyingPayment", {
-          defaultValue: "Verifying payment",
-        })}
-      />
-    );
-  }
+  const verificationFailed =
+    !sessionId ||
+    verify.isError ||
+    (verify.isSuccess && verify.data?.success !== true);
 
-  if (verify.isError) {
+  if (verificationFailed) {
     const message =
-      verify.error instanceof Error
+      sessionId && verify.isError && verify.error instanceof Error
         ? verify.error.message
         : t("cloud.billingSuccess.unableToVerify", {
             defaultValue: "Unable to verify payment",
           });
     return (
       <div className="flex items-center justify-center min-h-[80vh]">
-        <Card className="max-w-md w-full">
+        <Card className="max-w-md w-full" role="alert" aria-live="assertive">
           <CardHeader className="text-center">
             <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-500/10">
               <XCircle className="h-10 w-10 text-red-500" />
@@ -88,20 +83,22 @@ export default function BillingSuccessPage() {
           </CardHeader>
 
           <CardContent className="text-center space-y-4">
-            <p className="text-sm text-muted-foreground">
-              {t("cloud.billingSuccess.contactSupport", {
-                defaultValue:
-                  "If you believe this is an error, please contact support with your session ID.",
-              })}
-            </p>
-            {sessionId && (
-              <p className="text-xs text-muted-foreground bg-muted p-2 rounded-sm">
-                {t("cloud.billingSuccess.sessionLabel", {
-                  sessionId: `${sessionId.substring(0, 20)}...`,
-                  defaultValue: "Session: {{sessionId}}",
-                })}
-              </p>
-            )}
+            {sessionId ? (
+              <>
+                <p className="text-sm text-muted-foreground">
+                  {t("cloud.billingSuccess.contactSupport", {
+                    defaultValue:
+                      "If you believe this is an error, please contact support with your session ID.",
+                  })}
+                </p>
+                <p className="text-xs text-muted-foreground bg-muted p-2 rounded-sm">
+                  {t("cloud.billingSuccess.sessionLabel", {
+                    sessionId: `${sessionId.substring(0, 20)}...`,
+                    defaultValue: "Session: {{sessionId}}",
+                  })}
+                </p>
+              </>
+            ) : null}
           </CardContent>
 
           <CardFooter className="flex flex-col gap-2">
@@ -115,6 +112,16 @@ export default function BillingSuccessPage() {
           </CardFooter>
         </Card>
       </div>
+    );
+  }
+
+  if (!verify.isSuccess) {
+    return (
+      <DashboardLoadingState
+        label={t("cloud.billingSuccess.verifyingPayment", {
+          defaultValue: "Verifying payment",
+        })}
+      />
     );
   }
 


### PR DESCRIPTION
# Relates to

Closes #20075.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`5412fba9b2ed768989cbb1c179ceb522c04602bd`).
- [x] `bun install --frozen-lockfile --ignore-scripts` and `bun run verify` were
      run after sync; the exact unrelated `develop` blocker is recorded below.
- [x] A reviewer can confirm the change without reading the code from the
      exact-state screenshots, walkthrough, logs, and receipts below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@1b813769b36eb312ff319b20c5a6b3b5f09cac99:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `develop@5412fba9b2ed768989cbb1c179ceb522c04602bd`; zero conflicts.
- [x] `bun run verify` was run on the exact PR head. Its unrelated baseline
      failure is documented in **Known gaps / failures** below.

# Risks

Low. The change is confined to the billing checkout-return view. It does not
change billing APIs, provider calls, credit ledgers, payment configuration, or
deployment. The main behavioral risk is showing a loading/error state longer
when a malformed verification response arrives; that is intentional and safer
than displaying an unverified purchase success.

# Background

## What does this PR do?

- Keeps the existing verifying state for idle and pending checkout verification.
- Shows purchase success and mounts the balance component only after
  `data.success === true` on a successful mutation.
- Announces missing-session, transport-error, and resolved-false states with
  `role="alert"` and `aria-live="assertive"`.
- Avoids asking users to provide a session ID when the return URL has no
  session ID.
- Adds a six-case deterministic component suite for missing, idle, pending,
  rejected, resolved-false, and verified-success states.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No project documentation change is needed; this corrects an existing UI state
contract and adds regression coverage.

# Testing

## Where should a reviewer start?

Start with `packages/ui/src/cloud/billing/BillingSuccessPage.test.tsx`, then
compare the before/after evidence for a return URL without `session_id`.

## Detailed testing steps

- `bun run --cwd packages/ui test src/cloud/billing/BillingSuccessPage.test.tsx`
  — 6/6 passed.
- `bun run --cwd packages/ui test src/cloud/billing` — 32/32 passed.
- `bun run --cwd packages/ui typecheck` — passed.
- `bun x @biomejs/biome check packages/ui/src/cloud/billing/BillingSuccessPage.tsx packages/ui/src/cloud/billing/BillingSuccessPage.test.tsx`
  — passed.
- `bun x @biomejs/biome check packages/ui/src` — passed with 8 existing
  `document.cookie` warnings outside this diff.
- `bun run audit:ui-determinism` — passed.
- `bun run audit:focused-tests` — passed (8,218 files scanned; no focused or
  orphaned skipped tests).
- `bun run --cwd packages/app audit:app` — 219 Playwright tests passed; visual
  report 203 good / 13 needs-eyeball / 0 broken / 0 needs-work; OCR 200 verified
  / 16 needs-eyeball / 0 broken.
- Local Playwright checkout fixture — missing-session, verifying,
  resolved-false, and verified-success states captured at desktop; missing and
  verified-success captured at mobile. No payment provider or non-local service
  was contacted.

# Evidence Gate

Evidence matches commit `1b813769b36eb312ff319b20c5a6b3b5f09cac99`.
<!-- evidence-head:1b813769b36eb312ff319b20c5a6b3b5f09cac99 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20100-billing-success-before-contact-sheet.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20100-billing-success-after-contact-sheet.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20100-billing-success-four-state-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - UI-only state gate; no backend, provider, ledger, staging, or production path changed or called.

<!-- evidence-row:frontend-logs -->
- [x] [20100-billing-success-frontend-logs.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20100-billing-success-frontend-logs.json)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [20100-billing-success-state-receipts.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20100-billing-success-state-receipts.json)

<!-- evidence-row:ocr-review -->
- [x] [20100-billing-success-ocr-review.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20100-billing-success-ocr-review.json)

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, prompt, provider, or model behavior changed.

## Backend + frontend logs

Backend: N/A - this is a UI-only state gate with a local stubbed verification
endpoint. Frontend evidence contains the console log (24 info entries, zero
errors) and request/response trace. The missing-session receipt records zero
verification requests; failure and success fixtures record local HTTP 200
responses with different `success` values.

## Screenshots (before / after) + video walkthrough

The before contact sheet shows the previous false success on desktop and mobile
with no `session_id`. The after sheet covers missing-session, verifying,
resolved-false, and verified-success desktop states plus missing/success mobile
states. The H.264 MP4 is 1280×720, 11.20 seconds, and shows the four desktop
states without viewport resize or a boot-splash transition.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

`bun run verify` is red on the exact PR head only because the current
`develop` baseline fails `@elizaos/core#lint:check` on three files outside this
two-file PR:

- `packages/core/src/features/advanced-capabilities/personality/providers/character-gate-notice.ts` (`noUselessStringRaw` info)
- `packages/core/src/features/working-memory/attachmentContext.test.ts` (`useTemplate` info)
- `packages/core/src/runtime/__tests__/action-retrieval.test.ts` (formatter error)

The three files are byte-identical to current `origin/develop`; their SHA-256
values were checked against `git show origin/develop:<path>`. The canonical
`bun run --cwd packages/core lint:check` failure was also reproduced in a clean
detached worktree at current `develop`. All UI-scoped gates listed above pass.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@1b813769b36eb312ff319b20c5a6b3b5f09cac99:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-billing-success-truth]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@1b813769b36eb312ff319b20c5a6b3b5f09cac99:packages/skills/skills/contribute-to-eliza"} -->


