### PR TITLE
fix(core,discord): stop owner-aliased authors from overwriting the canonical owner entity identity

### DIFF
--- a/packages/core/src/connection.test.ts
+++ b/packages/core/src/connection.test.ts
@@ -55,4 +55,99 @@ describe("ensureConnection", () => {
 			[secondCallerId]: "connector_admin",
 		});
 	});
+
+	it("preserves the entity's per-source identity when a later connection omits identity fields", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		const agentId = stringToUuid("connection-identity-agent");
+		const ownerEntityId = stringToUuid("connection-identity-owner");
+		const worldId = stringToUuid("connection-identity-world");
+		const base = {
+			agentId,
+			entityId: ownerEntityId,
+			roomId: stringToUuid("connection-identity-room"),
+			worldId,
+			messageServerId: stringToUuid("connection-identity-server"),
+			source: "discord",
+			channelId: "connection-identity-channel",
+		};
+
+		await ensureConnection(adapter, {
+			...base,
+			userId: stringToUuid("owner-wire-id"),
+			name: "Owner Display",
+			userName: "owner_handle",
+		});
+
+		// An owner-aliased author (webhook or alias account) ensures the same
+		// canonical entity without identity fields; the recorded identity and
+		// names must survive untouched.
+		await ensureConnection(adapter, base);
+
+		const [entity] = await adapter.getEntitiesByIds([ownerEntityId]);
+		expect(entity?.metadata?.discord).toEqual({
+			id: stringToUuid("owner-wire-id"),
+			name: "Owner Display",
+			userName: "owner_handle",
+		});
+		expect(entity?.names).toEqual(["Owner Display", "owner_handle"]);
+	});
+
+	it("merges per-source identity field-by-field instead of replacing the record", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		const agentId = stringToUuid("connection-merge-agent");
+		const entityId = stringToUuid("connection-merge-entity");
+		const base = {
+			agentId,
+			entityId,
+			roomId: stringToUuid("connection-merge-room"),
+			worldId: stringToUuid("connection-merge-world"),
+			messageServerId: stringToUuid("connection-merge-server"),
+			source: "discord",
+			channelId: "connection-merge-channel",
+		};
+
+		await ensureConnection(adapter, {
+			...base,
+			userId: stringToUuid("merge-wire-id"),
+			name: "Original Name",
+			userName: "original_handle",
+		});
+		await ensureConnection(adapter, { ...base, name: "Renamed" });
+
+		const [entity] = await adapter.getEntitiesByIds([entityId]);
+		expect(entity?.metadata?.discord).toEqual({
+			id: stringToUuid("merge-wire-id"),
+			name: "Renamed",
+			userName: "original_handle",
+		});
+	});
+
+	it("keeps identity records from different sources side by side", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		const agentId = stringToUuid("connection-sources-agent");
+		const entityId = stringToUuid("connection-sources-entity");
+		const shared = {
+			agentId,
+			entityId,
+			roomId: stringToUuid("connection-sources-room"),
+			worldId: stringToUuid("connection-sources-world"),
+			messageServerId: stringToUuid("connection-sources-server"),
+			channelId: "connection-sources-channel",
+		};
+
+		await ensureConnection(adapter, {
+			...shared,
+			source: "discord",
+			userName: "discord_handle",
+		});
+		await ensureConnection(adapter, {
+			...shared,
+			source: "telegram",
+			userName: "telegram_handle",
+		});
+
+		const [entity] = await adapter.getEntitiesByIds([entityId]);
+		expect(entity?.metadata?.discord).toEqual({ userName: "discord_handle" });
+		expect(entity?.metadata?.telegram).toEqual({ userName: "telegram_handle" });
+	});
 });

--- a/packages/core/src/connection.ts
+++ b/packages/core/src/connection.ts
@@ -40,6 +40,36 @@ export interface EnsureConnectionsResult {
 	createdRoomParticipants: number;
 }
 
+/**
+ * One-level-deep merge for entity metadata keyed by connection source. A
+ * top-level replace is how an owner-aliased author's fields used to overwrite
+ * the canonical owner entity's identity record: each per-source object must
+ * merge field-by-field, not swap wholesale, so a connection that omits a field
+ * preserves what a previous connection wrote.
+ */
+function mergeEntitySourceMetadata(
+	existing: Metadata,
+	incoming: Record<string, unknown>,
+): Metadata {
+	const merged: Record<string, unknown> = { ...existing };
+	for (const [key, value] of Object.entries(incoming)) {
+		const prior = merged[key];
+		if (
+			prior !== null &&
+			typeof prior === "object" &&
+			!Array.isArray(prior) &&
+			value !== null &&
+			typeof value === "object" &&
+			!Array.isArray(value)
+		) {
+			merged[key] = { ...prior, ...value };
+		} else {
+			merged[key] = value;
+		}
+	}
+	return merged as Metadata;
+}
+
 /** WHY: World is required for room hierarchy; derive a stable worldId from messageServerId when not provided. */
 function resolveWorldId(
 	worldId: UUID | undefined,
@@ -94,11 +124,21 @@ export async function ensureConnections(
 			continue;
 		}
 		ent.names = [...new Set([...ent.names, ...names])].filter(Boolean);
-		ent.metadata[source] = {
-			id: c.userId,
-			name: c.name,
-			userName: c.userName,
-		};
+		// A connection contributes identity fields; it does not own the entity's
+		// per-source identity record. Connectors that alias several platform
+		// identities onto one canonical entity (e.g. Discord owner aliases)
+		// deliberately omit these fields, and an omitted field must never blank
+		// or replace what an earlier, genuine connection recorded.
+		const sourceRecord: Record<string, JsonValue> = {};
+		if (c.userId !== undefined) sourceRecord.id = c.userId;
+		if (c.name !== undefined) sourceRecord.name = c.name;
+		if (c.userName !== undefined) sourceRecord.userName = c.userName;
+		if (Object.keys(sourceRecord).length > 0) {
+			ent.metadata[source] = {
+				...(ent.metadata[source] as Record<string, JsonValue> | undefined),
+				...sourceRecord,
+			};
+		}
 
 		const world: World = {
 			id: worldId,
@@ -155,9 +195,12 @@ export async function ensureConnections(
 		const names = existing
 			? [...new Set([...(existing.names || []), ...v.names])].filter(Boolean)
 			: v.names;
-		const metadata = (
-			existing ? { ...existing.metadata, ...v.metadata } : v.metadata
-		) as Metadata;
+		const metadata = existing
+			? mergeEntitySourceMetadata(
+					(existing.metadata ?? {}) as Metadata,
+					v.metadata,
+				)
+			: (v.metadata as Metadata);
 		entities.push({
 			id: v.entityId,
 			names,

--- a/plugins/plugin-discord/__tests__/canonical-provenance-envelope.real.test.ts
+++ b/plugins/plugin-discord/__tests__/canonical-provenance-envelope.real.test.ts
@@ -610,6 +610,7 @@ describe("canonical provenance envelope", () => {
 			runtime: runtime as unknown as HistoryServiceInternals["runtime"],
 			messageManager: undefined,
 			resolveDiscordEntityId: (userId: string) => id(`discord-${userId}`),
+			isOwnerAliasedDiscordUser: () => false,
 			getChannelType: async () => ChannelType.GROUP,
 			isGuildTextBasedChannel: (c): c is never => Boolean(c),
 		};

--- a/plugins/plugin-discord/__tests__/identity.test.ts
+++ b/plugins/plugin-discord/__tests__/identity.test.ts
@@ -4,12 +4,16 @@
  * Discord user is collapsed to the canonical owner entity or kept auditable as
  * their own connector identity.
  */
+
+import { createUniqueUuid } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
 	buildDiscordWorldMetadata,
 	extractDiscordOwnerUserIds,
 	extractDiscordTeamAdminUserIds,
+	isAliasedDiscordEntityId,
 	parseDiscordOwnerUserIds,
+	resolveDiscordRuntimeEntityId,
 } from "../identity.ts";
 
 /**
@@ -191,5 +195,53 @@ describe("buildDiscordWorldMetadata", () => {
 		expect(metadata?.roleSources?.[guildOwnerEntityId as string]).toBe(
 			"connector_admin",
 		);
+	});
+});
+
+describe("isAliasedDiscordEntityId", () => {
+	const runtime = {
+		agentId: "00000000-0000-0000-0000-000000000001",
+		character: { name: "Agent" },
+		getSetting: (key: string) =>
+			key === "ELIZA_ADMIN_ENTITY_ID"
+				? "11111111-1111-1111-1111-111111111111"
+				: undefined,
+	} as never;
+
+	it("flags a user whose resolution was substituted by the owner alias list", () => {
+		const resolved = resolveDiscordRuntimeEntityId(runtime, SNOWFLAKE_B, [
+			SNOWFLAKE_B,
+		]);
+		expect(resolved).toBe("11111111-1111-1111-1111-111111111111");
+		expect(isAliasedDiscordEntityId(runtime, SNOWFLAKE_B, resolved)).toBe(true);
+	});
+
+	it("does not flag a user whose entity id derives from their own snowflake", () => {
+		const resolved = resolveDiscordRuntimeEntityId(runtime, SNOWFLAKE_A, [
+			SNOWFLAKE_B,
+		]);
+		expect(resolved).toBe(createUniqueUuid(runtime, SNOWFLAKE_A));
+		expect(isAliasedDiscordEntityId(runtime, SNOWFLAKE_A, resolved)).toBe(
+			false,
+		);
+	});
+
+	it("does not flag the owner when the canonical entity is their own derived id", () => {
+		const ownDerived = createUniqueUuid(runtime, SNOWFLAKE_C);
+		const selfCanonicalRuntime = {
+			agentId: "00000000-0000-0000-0000-000000000001",
+			character: { name: "Agent" },
+			getSetting: (key: string) =>
+				key === "ELIZA_ADMIN_ENTITY_ID" ? ownDerived : undefined,
+		} as never;
+		const resolved = resolveDiscordRuntimeEntityId(
+			selfCanonicalRuntime,
+			SNOWFLAKE_C,
+			[SNOWFLAKE_C],
+		);
+		expect(resolved).toBe(ownDerived);
+		expect(
+			isAliasedDiscordEntityId(selfCanonicalRuntime, SNOWFLAKE_C, resolved),
+		).toBe(false);
 	});
 });

--- a/plugins/plugin-discord/__tests__/interaction-dispatch-coverage.test.ts
+++ b/plugins/plugin-discord/__tests__/interaction-dispatch-coverage.test.ts
@@ -31,6 +31,7 @@ function makeService(overrides: Record<string, unknown> = {}) {
 			(id: string) =>
 				`00000000-0000-0000-0000-${id.slice(-12).padStart(12, "0")}`,
 		),
+		isOwnerAliasedDiscordUser: vi.fn(() => false),
 		getChannelType: vi.fn(async () => "GROUP"),
 		registerSlashCommands: vi.fn(),
 		refreshOwnerDiscordUserIds: vi.fn(),

--- a/plugins/plugin-discord/__tests__/owner-alias-entity-write.test.ts
+++ b/plugins/plugin-discord/__tests__/owner-alias-entity-write.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Drives an owner-aliased Discord author through the REAL history-backfill
+ * entity construction (`ensureConnectionsForMessages`) with the real alias
+ * predicate wired the way `DiscordService` wires it, and inspects the entity
+ * records handed to `runtime.ensureConnections` — proving the canonical owner
+ * entity is created bare (no wire identity) while a normal author's entity
+ * carries full Discord identity. Deterministic: stubbed discord.js message
+ * shapes and a capturing runtime; no gateway or DB.
+ */
+import { createUniqueUuid, type Entity } from "@elizaos/core";
+import type { Message } from "discord.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+	ensureConnectionsForMessages,
+	type HistoryServiceInternals,
+} from "../discord-history";
+import {
+	isAliasedDiscordEntityId,
+	resolveDiscordRuntimeEntityId,
+} from "../identity";
+
+const CANONICAL_OWNER = "11111111-1111-1111-1111-111111111111";
+const WEBHOOK_ID = "990000000000000001";
+const MEMBER_ID = "990000000000000002";
+
+function makeRuntime() {
+	const ensureConnections = vi.fn().mockResolvedValue(undefined);
+	const runtime = {
+		agentId: "00000000-0000-0000-0000-000000000002",
+		character: { name: "Agent" },
+		getSetting: (key: string) =>
+			key === "ELIZA_ADMIN_ENTITY_ID" ? CANONICAL_OWNER : undefined,
+		ensureConnections,
+		logger: {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		},
+	};
+	return { runtime, ensureConnections };
+}
+
+function makeService(
+	runtime: ReturnType<typeof makeRuntime>["runtime"],
+	ownerIds: string[],
+): HistoryServiceInternals {
+	// The same wiring DiscordService.resolveDiscordEntityId /
+	// isOwnerAliasedDiscordUser use — the REAL predicate, not a stub.
+	const resolve = (userId: string) =>
+		resolveDiscordRuntimeEntityId(
+			runtime as never,
+			userId,
+			ownerIds,
+		) as ReturnType<HistoryServiceInternals["resolveDiscordEntityId"]>;
+	return {
+		accountId: "discord-account-1",
+		client: {} as HistoryServiceInternals["client"],
+		runtime: runtime as unknown as HistoryServiceInternals["runtime"],
+		messageManager: undefined,
+		resolveDiscordEntityId: resolve,
+		isOwnerAliasedDiscordUser: (userId: string) =>
+			isAliasedDiscordEntityId(runtime as never, userId, resolve(userId)),
+		getChannelType: vi.fn().mockResolvedValue("GROUP"),
+		isGuildTextBasedChannel: vi.fn() as never,
+	};
+}
+
+function makeMessage(authorId: string, username: string): Message {
+	return {
+		author: {
+			id: authorId,
+			username,
+			globalName: `${username}-global`,
+			displayAvatarURL: () => `https://cdn.example/${username}.png`,
+		},
+		member: { displayName: `${username}-nick` },
+		channel: { id: "880000000000000001" },
+		guild: {
+			id: "870000000000000001",
+			name: "Test Guild",
+			ownerId: "860000000000000001",
+		},
+	} as unknown as Message;
+}
+
+describe("owner-aliased backfill entity writes", () => {
+	it("creates the canonical owner entity bare while a normal author keeps full identity", async () => {
+		const { runtime, ensureConnections } = makeRuntime();
+		const service = makeService(runtime, [WEBHOOK_ID]);
+
+		await ensureConnectionsForMessages(service, [
+			makeMessage(WEBHOOK_ID, "sneaky-webhook"),
+			makeMessage(MEMBER_ID, "alice"),
+		]);
+
+		expect(ensureConnections).toHaveBeenCalledTimes(1);
+		const entities = ensureConnections.mock.calls[0][0] as Entity[];
+		const canonical = entities.find((e) => e.id === CANONICAL_OWNER);
+		const member = entities.find(
+			(e) => e.id === createUniqueUuid(runtime as never, MEMBER_ID),
+		);
+
+		// The aliased author still yields an entity record (message rows must
+		// link) but contributes ZERO wire identity to the canonical entity.
+		expect(canonical).toBeDefined();
+		expect(canonical?.names).toEqual([]);
+		expect(canonical?.metadata).toEqual({});
+		expect(JSON.stringify(canonical)).not.toContain("sneaky-webhook");
+
+		// A normal author's entity carries the full Discord identity.
+		expect(member?.names).toContain("alice");
+		expect(member?.metadata?.discord).toMatchObject({
+			id: MEMBER_ID,
+			userName: "alice",
+		});
+	});
+
+	it("suppresses the genuine owner's wire identity too when the canonical entity is a configured UUID (policy)", async () => {
+		const { runtime, ensureConnections } = makeRuntime();
+		// The genuine application owner is in the alias list, and the canonical
+		// entity is a configured UUID (not their derived id): configuration owns
+		// the canonical identity, so even the genuine owner's wire identity is
+		// suppressed — there is no principled winner among collapsing wire
+		// identities, and last-writer-wins is the corruption being prevented.
+		const service = makeService(runtime, [MEMBER_ID]);
+
+		await ensureConnectionsForMessages(service, [
+			makeMessage(MEMBER_ID, "genuine-owner"),
+		]);
+
+		const entities = ensureConnections.mock.calls[0][0] as Entity[];
+		expect(entities).toHaveLength(1);
+		expect(entities[0]?.id).toBe(CANONICAL_OWNER);
+		expect(entities[0]?.names).toEqual([]);
+		expect(entities[0]?.metadata).toEqual({});
+	});
+
+	it("keeps full identity for an owner whose canonical entity IS their derived id", async () => {
+		const { ensureConnections } = makeRuntime();
+		const runtime = {
+			agentId: "00000000-0000-0000-0000-000000000002",
+			character: { name: "Agent" },
+			getSetting: () => undefined,
+			ensureConnections,
+			logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+		};
+		const derived = createUniqueUuid(runtime as never, MEMBER_ID);
+		const selfCanonicalRuntime = {
+			...runtime,
+			getSetting: (key: string) =>
+				key === "ELIZA_ADMIN_ENTITY_ID" ? derived : undefined,
+		};
+		const service = makeService(selfCanonicalRuntime as never, [MEMBER_ID]);
+
+		await ensureConnectionsForMessages(service, [
+			makeMessage(MEMBER_ID, "self-owner"),
+		]);
+
+		const entities = ensureConnections.mock.calls[0][0] as Entity[];
+		expect(entities[0]?.id).toBe(derived);
+		expect(entities[0]?.names).toContain("self-owner");
+		expect(entities[0]?.metadata?.discord).toMatchObject({ id: MEMBER_ID });
+	});
+});

--- a/plugins/plugin-discord/actions/messageConnector.test.ts
+++ b/plugins/plugin-discord/actions/messageConnector.test.ts
@@ -258,6 +258,7 @@ describe("Discord message connector adapter", () => {
 				client: {} as HistoryServiceInternals["client"],
 				resolveDiscordEntityId: (userId: string) =>
 					`00000000-0000-0000-0000-${userId.slice(-12)}`,
+				isOwnerAliasedDiscordUser: () => false,
 				getChannelType: vi.fn().mockResolvedValue("GROUP"),
 				isGuildTextBasedChannel: vi.fn(),
 			},

--- a/plugins/plugin-discord/discord-history.ts
+++ b/plugins/plugin-discord/discord-history.ts
@@ -64,6 +64,7 @@ export interface HistoryServiceInternals {
 	messageManager: MessageManager | undefined;
 
 	resolveDiscordEntityId(userId: string): UUID;
+	isOwnerAliasedDiscordUser(userId: string): boolean;
 	getChannelType(channel: Channel): Promise<ChannelType>;
 	isGuildTextBasedChannel(
 		channel: Channel | null,
@@ -529,6 +530,18 @@ export async function ensureConnectionsForMessages(
 
 		const entities = Array.from(uniqueAuthors.entries()).map(
 			([authorId, message]) => {
+				const entityId = service.resolveDiscordEntityId(authorId);
+				// Owner-aliased authors (webhooks/alias accounts) resolve to the
+				// canonical owner entity; backfill must still create that entity so
+				// message rows link, but must not seed it with the alias's identity.
+				if (service.isOwnerAliasedDiscordUser(authorId)) {
+					return {
+						id: entityId,
+						names: [],
+						metadata: {},
+						agentId: service.runtime.agentId,
+					};
+				}
 				const userName = message.author.username;
 				const name =
 					(message.member &&
@@ -542,7 +555,7 @@ export async function ensureConnectionsForMessages(
 						: undefined) ??
 					userName;
 				return {
-					id: service.resolveDiscordEntityId(authorId),
+					id: entityId,
 					names: [userName, name].filter(
 						(n): n is string => typeof n === "string" && n.length > 0,
 					),

--- a/plugins/plugin-discord/discord-interactions.ts
+++ b/plugins/plugin-discord/discord-interactions.ts
@@ -71,6 +71,7 @@ export interface InteractionServiceInternals {
 	clientReadyPromise: Promise<void> | null;
 
 	resolveDiscordEntityId(userId: string): UUID;
+	isOwnerAliasedDiscordUser(userId: string): boolean;
 	getChannelType(channel: Channel): Promise<ChannelType>;
 	registerSlashCommands(commands: DiscordSlashCommand[]): Promise<void>;
 	refreshOwnerDiscordUserIds(client: DiscordClient): Promise<void>;
@@ -431,6 +432,50 @@ export async function buildStandardizedRooms(
 }
 
 /**
+ * Entity record for a guild member sync. Owner-aliased members resolve to the
+ * canonical owner entity, whose identity belongs to the owner: they contribute
+ * a bare entity reference (so create-only sync still links participants)
+ * instead of writing the alias account's display identity onto that entity.
+ */
+function buildMemberEntity(
+	service: InteractionServiceInternals,
+	member: GuildMember,
+): Entity {
+	const entityId = service.resolveDiscordEntityId(member.id);
+	if (service.isOwnerAliasedDiscordUser(member.id)) {
+		return {
+			id: entityId,
+			names: [],
+			agentId: service.runtime.agentId,
+			metadata: {},
+		};
+	}
+	const tag = member.user.bot
+		? `${member.user.username}#${member.user.discriminator}`
+		: member.user.username;
+	return {
+		id: entityId,
+		names: Array.from(
+			new Set(
+				[
+					member.user.username,
+					member.displayName,
+					member.user.globalName,
+				].filter(Boolean) as string[],
+			),
+		),
+		agentId: service.runtime.agentId,
+		metadata: buildDiscordEntityMetadata(
+			member.id,
+			tag,
+			member.displayName || member.user.username,
+			member.user.globalName ?? undefined,
+			member.user.displayAvatarURL(),
+		),
+	};
+}
+
+/**
  * Builds a standardized list of users (entities) from Discord guild members.
  */
 export async function buildStandardizedUsers(
@@ -454,31 +499,8 @@ export async function buildStandardizedUsers(
 
 		try {
 			for (const [, member] of guild.members.cache) {
-				const tag = member.user.bot
-					? `${member.user.username}#${member.user.discriminator}`
-					: member.user.username;
-
 				if (member.id !== botId) {
-					entities.push({
-						id: service.resolveDiscordEntityId(member.id),
-						names: Array.from(
-							new Set(
-								[
-									member.user.username,
-									member.displayName,
-									member.user.globalName,
-								].filter(Boolean) as string[],
-							),
-						),
-						agentId: service.runtime.agentId,
-						metadata: buildDiscordEntityMetadata(
-							member.id,
-							tag,
-							member.displayName || member.user.username,
-							member.user.globalName ?? undefined,
-							member.user.displayAvatarURL(),
-						),
-					});
+					entities.push(buildMemberEntity(service, member));
 				}
 			}
 
@@ -497,30 +519,7 @@ export async function buildStandardizedUsers(
 					if (member.id !== botId) {
 						const entityId = service.resolveDiscordEntityId(member.id);
 						if (!entities.some((u) => u.id === entityId)) {
-							const tag = member.user.bot
-								? `${member.user.username}#${member.user.discriminator}`
-								: member.user.username;
-
-							entities.push({
-								id: entityId,
-								names: Array.from(
-									new Set(
-										[
-											member.user.username,
-											member.displayName,
-											member.user.globalName,
-										].filter(Boolean) as string[],
-									),
-								),
-								agentId: service.runtime.agentId,
-								metadata: buildDiscordEntityMetadata(
-									member.id,
-									tag,
-									member.displayName || member.user.username,
-									member.user.globalName ?? undefined,
-									member.user.displayAvatarURL(),
-								),
-							});
+							entities.push(buildMemberEntity(service, member));
 						}
 					}
 				}
@@ -545,30 +544,7 @@ export async function buildStandardizedUsers(
 
 			for (const [, member] of members) {
 				if (member.id !== botId) {
-					const tag = member.user.bot
-						? `${member.user.username}#${member.user.discriminator}`
-						: member.user.username;
-
-					entities.push({
-						id: service.resolveDiscordEntityId(member.id),
-						names: Array.from(
-							new Set(
-								[
-									member.user.username,
-									member.displayName,
-									member.user.globalName,
-								].filter(Boolean) as string[],
-							),
-						),
-						agentId: service.runtime.agentId,
-						metadata: buildDiscordEntityMetadata(
-							member.id,
-							tag,
-							member.displayName || member.user.username,
-							member.user.globalName ?? undefined,
-							member.user.displayAvatarURL(),
-						),
-					});
+					entities.push(buildMemberEntity(service, member));
 				}
 			}
 		} catch (error) {

--- a/plugins/plugin-discord/identity.ts
+++ b/plugins/plugin-discord/identity.ts
@@ -85,9 +85,18 @@ export function resolveDiscordRuntimeEntityId(
 /**
  * True when a resolved runtime entity id was substituted for this Discord user
  * rather than derived from it — i.e. the user reached the canonical owner
- * entity through the owner alias list. Aliased authors act with the owner's
- * standing, but their wire identity (webhook or alias account) must never be
- * written onto the canonical entity's identity metadata.
+ * entity through the owner alias list.
+ *
+ * POLICY: the canonical owner entity's identity metadata is
+ * configuration-owned, never wire-derived. EVERY substituted resolution is
+ * suppressed from contributing display identity — webhooks, secondary alias
+ * accounts, AND the genuine application owner when `ELIZA_ADMIN_ENTITY_ID` is
+ * a configured UUID rather than that owner's own derived id. Suppressing the
+ * genuine owner here is deliberate: when several wire identities collapse
+ * onto one configured entity there is no principled winner, and
+ * last-writer-wins is exactly the corruption this predicate exists to stop.
+ * An owner whose canonical entity IS their derived id (no substitution) keeps
+ * contributing identity normally.
  */
 export function isAliasedDiscordEntityId(
 	runtime: IAgentRuntime,

--- a/plugins/plugin-discord/identity.ts
+++ b/plugins/plugin-discord/identity.ts
@@ -82,6 +82,21 @@ export function resolveDiscordRuntimeEntityId(
 	return createUniqueUuid(runtime, userId);
 }
 
+/**
+ * True when a resolved runtime entity id was substituted for this Discord user
+ * rather than derived from it — i.e. the user reached the canonical owner
+ * entity through the owner alias list. Aliased authors act with the owner's
+ * standing, but their wire identity (webhook or alias account) must never be
+ * written onto the canonical entity's identity metadata.
+ */
+export function isAliasedDiscordEntityId(
+	runtime: IAgentRuntime,
+	userId: string,
+	resolvedEntityId: string,
+): boolean {
+	return resolvedEntityId !== createUniqueUuid(runtime, userId);
+}
+
 export function extractDiscordOwnerUserIds(application: unknown): string[] {
 	const applicationRecord = asRecord(application);
 	if (!applicationRecord) {

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -70,7 +70,10 @@ import {
 	sweepExpiredCoordinationSlots,
 	verifySpeakerLease,
 } from "./group-coordination";
-import { buildDiscordWorldMetadata } from "./identity";
+import {
+	buildDiscordWorldMetadata,
+	isAliasedDiscordEntityId,
+} from "./identity";
 import { formatInboundEnvelope } from "./inbound-envelope";
 import { buildDiscordReplyPayload } from "./interactions";
 import {
@@ -1609,12 +1612,22 @@ export class MessageManager {
 			}
 			inboundMemoryId = newMessage.id;
 
+			// Owner-aliased authors (ELIZA_DISCORD_OWNER_USER_IDS_JSON) resolve to
+			// the canonical owner entity while the wire author is someone else — a
+			// webhook or a deliberate alias account. Attaching that author's
+			// name/userName/id here rewrote the canonical entity's identity record
+			// to whichever alias spoke last, so identity fields are attached only
+			// when the entity id actually derives from this author.
+			const aliasedAuthor = isAliasedDiscordEntityId(
+				this.runtime,
+				message.author.id,
+				newMessage.entityId,
+			);
 			await this.runtime.ensureConnection({
 				entityId: newMessage.entityId,
 				roomId,
 				roomName,
-				userName,
-				name,
+				...(aliasedAuthor ? {} : { userName, name }),
 				source: "discord",
 				channelId: message.channel.id,
 				// Convert Discord snowflake to UUID (see service.ts header for why stringToUuid not asUUID)
@@ -1624,8 +1637,9 @@ export class MessageManager {
 				type,
 				worldId,
 				worldName: message.guild?.name,
-				// Preserve the raw Discord user id in source metadata for role and allowlist checks.
-				userId: message.author.id as UUID,
+				// Preserve the raw Discord user id in source metadata for role and
+				// allowlist checks — but only when it is the entity's own id.
+				...(aliasedAuthor ? {} : { userId: message.author.id as UUID }),
 				metadata: {
 					...buildDiscordWorldMetadata(
 						this.runtime,

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -144,6 +144,7 @@ import { getDiscordSettings } from "./environment";
 import {
 	extractDiscordOwnerUserIds,
 	extractDiscordTeamAdminUserIds,
+	isAliasedDiscordEntityId,
 	parseDiscordOwnerUserIds,
 	resolveDiscordRuntimeEntityId,
 	resolveElizaOwnerEntityId,
@@ -1330,6 +1331,8 @@ export class DiscordService extends Service implements IDiscordService {
 				parent.isVoiceChannelClaimed(guildId, channelId),
 			resolveDiscordEntityId: (userId: string) =>
 				parent.resolveDiscordEntityId(userId),
+			isOwnerAliasedDiscordUser: (userId: string) =>
+				parent.isOwnerAliasedDiscordUser(userId),
 			getChannelType: (channel: Channel) => parent.getChannelType(channel),
 			isGuildTextBasedChannel,
 			buildMemoryFromMessage: (
@@ -3975,6 +3978,20 @@ export class DiscordService extends Service implements IDiscordService {
 			userId,
 			this.ownerDiscordUserIds,
 		) as UUID;
+	}
+
+	/**
+	 * True when the Discord user reaches the canonical owner entity through the
+	 * owner alias list rather than through its own derived entity id. Aliased
+	 * identities must never contribute display names or metadata to the
+	 * canonical entity.
+	 */
+	public isOwnerAliasedDiscordUser(userId: string): boolean {
+		return isAliasedDiscordEntityId(
+			this.runtime,
+			userId,
+			this.resolveDiscordEntityId(userId),
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Problem

Discord owner aliases intentionally resolve several wire identities to one canonical owner entity. The connector then wrote each alias's display name, username, and raw Discord ID into that canonical entity, while core replaced the per-source metadata record wholesale. Whichever alias spoke last could therefore overwrite the owner's canonical identity.

Part of the F19 entity-attribution arc tracked under #18309.

## Root fix

- Core connection reconciliation now builds source identity records only from defined fields and merges those source records field-by-field. A bare or partial connection can no longer blank previously established identity.
- Discord identifies every substituted owner resolution by comparing it with the wire user's derived entity ID.
- Live ingestion, guild synchronization, and history backfill still establish participants/entities for an alias but contribute no wire-derived identity to the canonical owner.
- A canonical owner that is the genuine wire user's own derived ID continues to receive normal identity metadata.
- The branch is rebuilt on current develop and contains only the intended core/Discord paths plus the full-suite fixture correction found during review.

## Exact-head validation

- Focused core/identity/real-backfill matrix: 25/25 tests, 52 assertions.
- Full `plugin-discord` suite: 79 files, 630/630 tests.
- Core and Discord package typechecks: PASS.
- Targeted Biome (12 changed paths) and `git diff --check`: PASS.

## Contribution provenance

- AI assistance: yes — original implementation was declared as Claude Code-assisted by the contributor; review, current-develop rebase, full-suite fixture repair, validation, and evidence remediation used `openai/gpt-5.6-sol`.
- Models used: `openai/gpt-5.6-sol`; the original Claude model identifier was not exposed and is not inferred.
- Client / agent tooling: Codex Desktop (review/refactor); Claude Code (original contributor declaration).
- Contribution skill revision: `elizaOS/eliza@a047cdd18c5a:packages/skills/skills/contribute-to-eliza`
- Attribution status: self-reported

<!-- evidence-head:28f7aeec70ce04d01c1cf38b7e7dfa15f3a782cc -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend entity metadata only; no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend entity metadata only; no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive surface; the connector-to-entity boundary is exercised deterministically.

<!-- evidence-row:backend-logs -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20104-.tmp-20104-validation.log

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no provider, prompt, model, action, or evaluator behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20104-.tmp-20104-domain.txt

— [nubs-review-owner-alias]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@a047cdd18c5a:packages/skills/skills/contribute-to-eliza"} -->
