### PR TITLE
fix(macos): keep expanded chat overlay onscreen

### DIFF
--- a/packages/app/test/electrobun-packaged/electrobun-bottom-bar.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/electrobun-bottom-bar.e2e.spec.ts
@@ -69,6 +69,19 @@ test("desktop popup shell exposes the accessible pill, hotkey toggle, and tray l
       expect(bounds.y).toBeGreaterThan(bounds.height);
     }
 
+    // The native shell and tray exist before the renderer/preload RPC is ready.
+    // Shortcut registration is the first renderer-owned shell signal, so wait
+    // for it before issuing DOM eval requests that would otherwise be lost.
+    const interactiveState = await harness.waitForState(
+      (next) =>
+        next.shell.shortcuts.some((shortcut) => shortcut.id === "chat-overlay"),
+      "Expected the popup hotkey to register after the renderer mounted.",
+      30_000,
+    );
+    expect(interactiveState.shell.shortcuts).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "chat-overlay" })]),
+    );
+
     await expect
       .poll(
         () =>
@@ -263,20 +276,58 @@ test("desktop popup shell exposes the accessible pill, hotkey toggle, and tray l
         height: 600,
       });
 
-    const expandedGeometry = await harness.eval<{
-      panelBottom: number;
-      pillTop: number;
-    }>(`(() => {
-      const panel = document.querySelector('[data-testid="shell-assistant-overlay"]');
-      const pill = document.querySelector('[data-testid="shell-home-pill"]');
-      if (!(panel instanceof HTMLElement) || !(pill instanceof HTMLElement)) {
-        throw new Error('expanded chat geometry unavailable');
-      }
-      return {
-        panelBottom: Math.round(panel.getBoundingClientRect().bottom),
-        pillTop: Math.round(pill.getBoundingClientRect().top),
-      };
-    })()`);
+    const readExpandedGeometry = () =>
+      harness.eval<{
+        panelLeft: number;
+        panelRight: number;
+        panelTop: number;
+        panelBottom: number;
+        pillTop: number;
+        viewportHeight: number;
+        viewportWidth: number;
+      }>(`(() => {
+        const panel = document.querySelector('[data-testid="shell-assistant-overlay"]');
+        const pill = document.querySelector('[data-testid="shell-home-pill"]');
+        if (!(panel instanceof HTMLElement) || !(pill instanceof HTMLElement)) {
+          throw new Error('expanded chat geometry unavailable');
+        }
+        return {
+          panelLeft: Math.round(panel.getBoundingClientRect().left),
+          panelRight: Math.round(panel.getBoundingClientRect().right),
+          panelTop: Math.round(panel.getBoundingClientRect().top),
+          panelBottom: Math.round(panel.getBoundingClientRect().bottom),
+          pillTop: Math.round(pill.getBoundingClientRect().top),
+          viewportHeight: Math.round(window.innerHeight),
+          viewportWidth: Math.round(window.innerWidth),
+        };
+      })()`);
+    await expect
+      .poll(async () => {
+        const geometry = await readExpandedGeometry();
+        const expectedTop =
+          geometry.viewportHeight -
+          56 -
+          Math.min(600, geometry.viewportHeight - 80);
+        return geometry.panelTop - expectedTop;
+      })
+      .toBe(0);
+    const expandedGeometry = await readExpandedGeometry();
+    expect(expandedGeometry.panelTop).toBeGreaterThanOrEqual(16);
+    expect(expandedGeometry.panelTop).toBe(
+      expandedGeometry.viewportHeight -
+        56 -
+        Math.min(600, expandedGeometry.viewportHeight - 80),
+    );
+    expect(expandedGeometry.panelLeft).toBeGreaterThanOrEqual(0);
+    expect(expandedGeometry.panelRight).toBeLessThanOrEqual(
+      expandedGeometry.viewportWidth,
+    );
+    expect(
+      Math.abs(
+        (expandedGeometry.panelLeft + expandedGeometry.panelRight) / 2 -
+          expandedGeometry.viewportWidth / 2,
+      ),
+    ).toBeLessThanOrEqual(1);
     expect(expandedGeometry.panelBottom).toBeLessThan(expandedGeometry.pillTop);
     expect(
       expandedGeometry.pillTop - expandedGeometry.panelBottom,
@@ -305,15 +356,6 @@ test("desktop popup shell exposes the accessible pill, hotkey toggle, and tray l
       request: "function",
     });
 
-    const interactiveState = await harness.waitForState(
-      (next) =>
-        next.shell.shortcuts.some((shortcut) => shortcut.id === "chat-overlay"),
-      "Expected the popup hotkey to register after the renderer mounted.",
-      30_000,
-    );
-    expect(interactiveState.shell.shortcuts).toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: "chat-overlay" })]),
-    );
     await harness.showMainWindow();
     await harness.focusMainWindow();
     if (macSessionLocked) {

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -173,6 +173,12 @@ html.eliza-chat-overlay-shell .shell-assistant-overlay-panel {
   left: 50%;
   width: min(560px, calc(100% - 24px));
   height: min(600px, calc(100% - 80px));
+  /* Tailwind's responsive utilities set the individual `translate` property in
+     a separate generated stylesheet. The scoped important reset must survive
+     cross-asset minification and override that utility before the desktop-only
+     centering transform is applied. */
+  /* biome-ignore lint/complexity/noImportantStyles: cross-asset Tailwind reset */
+  translate: none !important;
   transform: translateX(-50%);
   border-radius: 1.5rem;
   border-color: rgb(255 255 255 / 72%);


### PR DESCRIPTION
# Relates to

Closes #20063.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto `origin/develop@d56b7e98591466ed4b8bc3a29825966a67787a9a` with zero conflicts.
- [x] `bun install` and focused/current-head gates were run after sync. The exact unrelated root-verify blocker is documented below.
- [x] A reviewer can confirm the native behavior from the attached before/after, MP4, geometry, transcript, and logs.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d56b7e98591466ed4b8bc3a29825966a67787a9a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@d56b7e98591466ed4b8bc3a29825966a67787a9a`; zero conflicts.
- [x] Focused gates pass. Exact root `bun run verify` is blocked by an upstream formatter failure in `packages/core/src/runtime/__tests__/action-retrieval.test.ts`, introduced by merged #20077 and byte-identical to `develop`; this two-file PR does not touch Core.

# Risks

Low. The CSS override is scoped to `[data-desktop-shell="chat-overlay"]`; web/mobile AssistantOverlay positioning is unchanged. The test exercises the packaged macOS host, native shortcut/tray bridge, and final post-animation geometry.

# Background

## What does this PR do?

Tailwind's responsive translate utility emits the individual CSS `translate` property. The macOS chat-overlay override changed only `transform`, so the expanded panel retained a vertical `-50%` translation and rendered 300px above its intended position. This patch resets that inherited individual translation in the desktop-shell scope and retains horizontal centering through `transform: translateX(-50%)`.

The packaged regression now waits for the native renderer/shortcut registration and asserts the entire expanded panel is centered, fully inside the native viewport, starts at the expected 24px top margin, and remains separated from the launcher pill.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This repairs existing native desktop behavior and test coverage.

# Testing

## Where should a reviewer start?

- `packages/ui/src/styles/styles.css`
- `packages/app/test/electrobun-packaged/electrobun-bottom-bar.e2e.spec.ts`

## Detailed testing steps

1. Build the dev-signed Electrobun app with `bun run --cwd packages/app-core/platforms/electrobun build`.
2. Run the packaged test with `ELIZA_TEST_PACKAGED_AUTO_BUILD=0` and the built launcher path.
3. Expand the chat overlay and verify panel top `24`, bottom `624`, pill top `640`, and horizontal center in a `1512x680` native viewport.

Current-head results:

- Packaged native regression: `1 passed (4.6s)`.
- `packages/ui` typecheck: pass.
- `packages/app` typecheck: pass.
- Exact two-file Biome: pass.
- `git diff --check HEAD^..HEAD`: pass.
- Pre-final-rebase full app audit with byte-identical patch: `219 passed`; broken `0`, needs-work `0`.
- Root verify on the prior byte-identical candidate completed `351/351` type/lint tasks. Current `develop` now fails its own Core formatter gate as documented below.

# Evidence Gate

<!-- evidence-head:beb747a0f9654323efcd51c396b53c4aded9f028 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20105-issue-20063-before.png)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20105-issue-20063-after.png)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20105-issue-20063-local-runtime-chat.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend route, server state, auth, Cloud, or runtime implementation changed.
<!-- evidence-row:frontend-logs -->
- [x] [20105-issue-20063-frontend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20105-issue-20063-frontend.log)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent action, prompt, provider, or model behavior changed; deterministic local model was used only to prove the real runtime/UI round-trip.
<!-- evidence-row:domain-artifacts -->
- [x] [20105-issue-20063-geometry.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20105-issue-20063-geometry.json)
<!-- evidence-row:ocr-review -->
- [x] [20105-issue-20063-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20105-issue-20063-ocr-review.txt)

# Evidence Details

## Screenshots (before / after) + video walkthrough

The affected surface is the macOS Electrobun `chat-overlay` shell only. Mobile/web is N/A because the selector is explicitly desktop-shell scoped.

- Before: exact `develop` parent app; packaged regression reports stable panel offset `-300px` and the window-only screenshot shows the panel clipped above the native viewport.
- After: dev-signed candidate app; panel top `24`, bottom `624`, pill top `640`, width `560`, height `600` in viewport `1512x680`.
- Walkthrough: real local `AgentRuntime` message round-trip, overlay expansion, and visible response in the corrected native window.

## Backend + frontend logs

No backend implementation changed. The attached frontend/native log is secret-scanned and contains loopback bridge observations only; it records no credential value.

The real local-runtime conversation artifact is attached separately: [conversation JSON](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20105-issue-20063-conversations.json).

## Known gaps / failures

- Exact current-parent root `bun run verify` fails in upstream `packages/core/src/runtime/__tests__/action-retrieval.test.ts` formatting introduced by merged #20077. `bunx @biomejs/biome check` reproduces the same failure on `origin/develop`; this PR changes only the two paths listed above.
- The final rebase added only unrelated `BillingSuccessPage` changes. The candidate binary patch SHA stayed `7afc51bebab9b59a4f3343423ff78d01454f7f010f5ec8c7dfa797c392c83925`, stable patch-id `b6245312ee5ec9b01162f4c4c4b90cf082ab5985`; the packaged regression was rerun after that sync.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@d56b7e98591466ed4b8bc3a29825966a67787a9a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex / apple-native-surface-lane]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@d56b7e98591466ed4b8bc3a29825966a67787a9a:packages/skills/skills/contribute-to-eliza"} -->


