### PR TITLE
fix(cloud): reject malformed ad media Content-Length headers

### DIFF
--- a/packages/cloud/shared/src/lib/services/advertising/media-utils.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/media-utils.error-policy.test.ts
@@ -116,4 +116,51 @@ describe("#13415 — downloadAdMedia surfaces fetch failures, never fabricates a
       /exceeds maximum size/,
     );
   });
+
+  test("malformed Content-Length values fail closed before buffering", async () => {
+    const { downloadAdMedia } = await import("./media-utils");
+    for (const contentLength of ["NaN", "-1", "1.5", "9007199254740992"]) {
+      let buffered = false;
+      safeFetchImpl = async () => {
+        const response = new Response(new Uint8Array([1]), {
+          status: 200,
+          headers: {
+            "content-type": "image/png",
+            "content-length": contentLength,
+          },
+        });
+        const arrayBuffer = response.arrayBuffer.bind(response);
+        response.arrayBuffer = async () => {
+          buffered = true;
+          return arrayBuffer();
+        };
+        return response;
+      };
+      await expect(
+        downloadAdMedia(URL_UNDER_TEST, { maxBytes: 10 }),
+      ).rejects.toThrow(/invalid content-length/i);
+      expect(buffered).toBe(false);
+    }
+  });
+
+  test("a valid safe Content-Length still permits buffering", async () => {
+    let buffered = false;
+    safeFetchImpl = async () => {
+      const response = new Response(new Uint8Array([1]), {
+        status: 200,
+        headers: { "content-type": "image/png", "content-length": "1" },
+      });
+      const arrayBuffer = response.arrayBuffer.bind(response);
+      response.arrayBuffer = async () => {
+        buffered = true;
+        return arrayBuffer();
+      };
+      return response;
+    };
+    const { downloadAdMedia } = await import("./media-utils");
+    await expect(
+      downloadAdMedia(URL_UNDER_TEST, { maxBytes: 10 }),
+    ).resolves.toMatchObject({ bytes: new Uint8Array([1]) });
+    expect(buffered).toBe(true);
+  });
 });

--- a/packages/cloud/shared/src/lib/services/advertising/media-utils.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/media-utils.error-policy.test.ts
@@ -136,9 +136,9 @@ describe("#13415 — downloadAdMedia surfaces fetch failures, never fabricates a
         };
         return response;
       };
-      await expect(
-        downloadAdMedia(URL_UNDER_TEST, { maxBytes: 10 }),
-      ).rejects.toThrow(/invalid content-length/i);
+      await expect(downloadAdMedia(URL_UNDER_TEST, { maxBytes: 10 })).rejects.toThrow(
+        /invalid content-length/i,
+      );
       expect(buffered).toBe(false);
     }
   });
@@ -158,9 +158,9 @@ describe("#13415 — downloadAdMedia surfaces fetch failures, never fabricates a
       return response;
     };
     const { downloadAdMedia } = await import("./media-utils");
-    await expect(
-      downloadAdMedia(URL_UNDER_TEST, { maxBytes: 10 }),
-    ).resolves.toMatchObject({ bytes: new Uint8Array([1]) });
+    await expect(downloadAdMedia(URL_UNDER_TEST, { maxBytes: 10 })).resolves.toMatchObject({
+      bytes: new Uint8Array([1]),
+    });
     expect(buffered).toBe(true);
   });
 });

--- a/packages/cloud/shared/src/lib/services/advertising/media-utils.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/media-utils.ts
@@ -82,9 +82,18 @@ export async function downloadAdMedia(
       throw new Error(`Unsupported ad media content type: ${contentType || "unknown"}`);
     }
 
-    const contentLength = Number(response.headers.get("content-length") ?? 0);
-    if (contentLength > maxBytes) {
-      throw new Error(`Ad media exceeds maximum size of ${maxBytes} bytes`);
+    const rawContentLength = response.headers.get("content-length");
+    if (rawContentLength !== null) {
+      if (!/^\d+$/.test(rawContentLength)) {
+        throw new Error("Invalid content-length header for ad media");
+      }
+      const contentLength = Number(rawContentLength);
+      if (!Number.isSafeInteger(contentLength)) {
+        throw new Error("Invalid content-length header for ad media");
+      }
+      if (contentLength > maxBytes) {
+        throw new Error(`Ad media exceeds maximum size of ${maxBytes} bytes`);
+      }
     }
 
     const bytes = new Uint8Array(await response.arrayBuffer());

--- a/packages/cloud/shared/src/lib/services/advertising/media-utils.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/media-utils.ts
@@ -1,4 +1,6 @@
-// Coordinates cloud service media utils behavior behind route handlers.
+/**
+ * Downloads advertising media through the SSRF-safe transport and enforces trusted byte bounds.
+ */
 import { assertSafeOutboundUrl } from "../../security/outbound-url";
 import { safeFetch } from "../../security/safe-fetch";
 


### PR DESCRIPTION
# Relates to

Closes #20107.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] this PR targets `develop` and is branched directly off the current `origin/develop` tip.
- [x] focused package tests, lint, and typecheck pass on the exact head, see Testing below.
- [x] a reviewer can confirm the fix directly against the deterministic error-policy test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (fix, tests, via AgentRouter proxy), `anthropic/claude-sonnet-5` (independent re-verification)
<!-- attribution-row:client -->
- Agent tooling: `codex` (via AgentRouter proxy), `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] branched directly off the current `origin/develop` tip

# Risks

low. this only tightens `Content-Length` parsing in one media-download helper; every existing valid header value (ASCII digits within `maxBytes`) behaves identically, and missing headers still fall through to the existing post-buffer check unchanged.

# Background

## What does this PR do?

`downloadAdMedia` converted the `Content-Length` response header with `Number(response.headers.get("content-length") ?? 0)` and only rejected values greater than `maxBytes`. A malformed header (e.g. a literal `Content-Length: NaN`) converts to `NaN`; every ordered comparison with `NaN` is `false`, so `NaN > maxBytes` never trips and the function proceeds to buffer the full response via `response.arrayBuffer()` before any size check has actually run. The check exists specifically to fail closed *before* buffering — a malformed header silently disables it.

traced the live path before writing this up: authenticated clients `POST` to `packages/cloud/api/v1/advertising/accounts/[id]/media/route.ts`, which flows through `advertisingService.uploadMedia` into the Google/Meta/LinkedIn/X/Snap provider implementations, all of which call `downloadAdMedia(input.url, ...)`. `safeFetch` fetches the remote response, so the **remote media host** controls the returned `Content-Length` header — a caller can't set it directly, but can point the URL at a server they control. The existing post-buffer byte-length check still catches an actually-oversized body after the fact, but the pre-buffer fail-closed check is bypassable with a single malformed header value, forcing full buffering of an arbitrary response before any size validation runs.

fix: when `Content-Length` is present, require it to match `/^\d+$/` (ASCII decimal digits only) and be a JS safe integer before comparing against `maxBytes`; reject otherwise, before `response.arrayBuffer()` is called. Missing headers remain supported (falls through to the existing post-buffer check), matching current behavior.

## What kind of change is this?

bug fix, non-breaking (every existing valid `Content-Length` value behaves identically; missing-header behavior is unchanged).

# Documentation changes needed?

no, the fix restores the helper's own fail-closed-before-buffering intent rather than changing the interface.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/advertising/media-utils.error-policy.test.ts`, the new `a malformed Content-Length header fails closed before buffering` case, then the header validation added to `downloadAdMedia`.

## Detailed testing steps

```text
$ bun test src/lib/services/advertising/media-utils.error-policy.test.ts
9 pass
0 fail
14 expect() calls

$ bun run typecheck
Done!  (exit 0)

$ bunx @biomejs/biome check src/lib/services/advertising/media-utils.ts src/lib/services/advertising/media-utils.error-policy.test.ts
Checked 2 files in 32ms. No fixes applied.
```

The new test wraps `response.arrayBuffer` to record whether it was ever called, and asserts it was **not** — proving the malformed header is rejected before buffering, not just eventually caught after the fact.

mutation-resistance verified independently: reverted just the source fix, kept the new test, reran — 1/9 failed with `Expected promise that rejects / Received promise that resolved`, confirming the malformed header really did sail through and buffer successfully pre-fix. restored the fix, 9/9 green again.

# Evidence Gate

<!-- evidence-head:b088dc53119634d05a5a6fe550ee600a785a2f58 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - internal media-download validation; no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - internal media-download validation; no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic backend helper has no interactive user flow
<!-- evidence-row:backend-logs -->
- [ ] N/A - no service process is required; the real helper is exercised directly
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend source or request path changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, provider selection, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] [20108-pr20108-validation.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20108-pr20108-validation.txt)

  green (fix restored):
  $ bun test src/lib/services/advertising/media-utils.error-policy.test.ts
  9 pass | 0 fail
  ```
  also independently confirmed `Number("NaN")` really is `NaN` and `NaN > 10` really is `false` in a real bun REPL, and independently traced the live reachability path from the upload route through all five ad-provider implementations before writing up the reachability claim.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or visual text changed

## Known gaps / failures

none in the touched surface. the full `packages/cloud/shared` test lane has pre-existing, unrelated failures in `socket-redis-resilience.test.ts` caused by the sandbox forbidding a loopback listening socket (`EPERM`) — confirmed unrelated by running the focused advertising suite independently (9/9 green).

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the focused suite, typecheck, and lint myself, confirmed the NaN comparison behavior directly, retraced the live reachability chain through all five ad providers, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Contribution skill revision: N/A - direct interactive session, contribute-to-eliza skill not used
Compute receipt: N/A - Slop run-receipt install currently blocked by an unrelated site-deploy-lag issue (deployed skill archive predates recent develop changes)
Attribution status: self-reported

