### PR TITLE
fix(core): attribute extracted facts to the speaker who stated them

### DIFF
--- a/packages/core/src/runtime/__tests__/facts-and-relationships.test.ts
+++ b/packages/core/src/runtime/__tests__/facts-and-relationships.test.ts
@@ -119,7 +119,9 @@ describe("parseFactsAndRelationshipsOutput", () => {
 				thought: "kept one fact and one rel",
 			}),
 		);
-		expect(result.facts).toEqual(["the user's birthday is 1990-03-05"]);
+		expect(result.facts).toEqual([
+			{ subject: "user", fact: "the user's birthday is 1990-03-05" },
+		]);
 		expect(result.relationships).toEqual([
 			{ subject: "user", predicate: "works_with", object: "Alice" },
 		]);
@@ -138,7 +140,7 @@ describe("parseFactsAndRelationshipsOutput", () => {
 				},
 			],
 		});
-		expect(result.facts).toEqual(["a"]);
+		expect(result.facts).toEqual([{ subject: "user", fact: "a" }]);
 	});
 
 	it("parses AI SDK v5 / Cerebras tool-call shape (toolCalls[0].input)", () => {
@@ -166,7 +168,9 @@ describe("parseFactsAndRelationshipsOutput", () => {
 				},
 			],
 		});
-		expect(result.facts).toEqual(["my dog's name is Jeff"]);
+		expect(result.facts).toEqual([
+			{ subject: "user", fact: "my dog's name is Jeff" },
+		]);
 		expect(result.relationships).toEqual([
 			{ subject: "user", predicate: "has_dog_named", object: "Jeff" },
 		]);
@@ -176,11 +180,11 @@ describe("parseFactsAndRelationshipsOutput", () => {
 		const viaArgs = parseFactsAndRelationshipsOutput({
 			toolCalls: [{ args: { facts: ["x"], relationships: [], thought: "" } }],
 		});
-		expect(viaArgs.facts).toEqual(["x"]);
+		expect(viaArgs.facts).toEqual([{ subject: "user", fact: "x" }]);
 		const viaParams = parseFactsAndRelationshipsOutput({
 			toolCalls: [{ params: { facts: ["y"], relationships: [], thought: "" } }],
 		});
-		expect(viaParams.facts).toEqual(["y"]);
+		expect(viaParams.facts).toEqual([{ subject: "user", fact: "y" }]);
 	});
 
 	it("rejects malformed relationship entries instead of silently dropping them", () => {
@@ -273,7 +277,9 @@ describe("runFactsAndRelationshipsStage", () => {
 		);
 
 		// Result parsed and persisted
-		expect(result.parsed.facts).toEqual(["the user's birthday is March 5"]);
+		expect(result.parsed.facts).toEqual([
+			{ subject: "user", fact: "the user's birthday is March 5" },
+		]);
 		expect(result.written.facts).toBe(1);
 		expect(runtime.createMemory).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -769,5 +775,97 @@ describe("runFactsAndRelationshipsStage — voice/text parity (#8786)", () => {
 			text.result.parsed.relationships,
 		);
 		expect(group.result.written).toEqual(text.result.written);
+	});
+});
+
+describe("fact speaker attribution", () => {
+	const runWithFacts = async (
+		facts: unknown[],
+		priorDialogue: Memory[] = [],
+	) => {
+		const runtime = makeRuntime(
+			JSON.stringify({ facts, relationships: [], thought: "attributed" }),
+		);
+		const result = await runFactsAndRelationshipsStage({
+			runtime,
+			message: makeMessage(),
+			state: makeState(),
+			extract: { facts: ["seed candidate"], relationships: [] },
+			priorDialogue,
+		});
+		return { runtime, result };
+	};
+
+	it("persists a fact under the room entity the model attributed it to", async () => {
+		const { runtime } = await runWithFacts([
+			{ subject: "Alice", fact: "Alice's favorite color is crimson" },
+		]);
+		expect(runtime.createMemory).toHaveBeenCalledWith(
+			expect.objectContaining({
+				entityId: "00000000-0000-0000-0000-0000000000a1",
+				content: expect.objectContaining({
+					text: "Alice's favorite color is crimson",
+				}),
+			}),
+			"facts",
+			true,
+		);
+	});
+
+	it("persists subject 'user' under the current message author", async () => {
+		const { runtime } = await runWithFacts([
+			{ subject: "user", fact: "the user's birthday is March 5" },
+		]);
+		expect(runtime.createMemory).toHaveBeenCalledWith(
+			expect.objectContaining({
+				entityId: "00000000-0000-0000-0000-000000000001",
+			}),
+			"facts",
+			true,
+		);
+	});
+
+	it("falls back to the current author when the subject resolves to nobody", async () => {
+		const { runtime } = await runWithFacts([
+			{ subject: "Zoe", fact: "Zoe's timezone is UTC" },
+		]);
+		expect(runtime.createMemory).toHaveBeenCalledWith(
+			expect.objectContaining({
+				entityId: "00000000-0000-0000-0000-000000000001",
+			}),
+			"facts",
+			true,
+		);
+	});
+
+	it("labels prior dialogue lines with the actual speaker, not a collapsed 'user'", async () => {
+		const bobLine: Memory = {
+			id: "00000000-0000-0000-0000-00000000dddd" as UUID,
+			entityId: "00000000-0000-0000-0000-0000000000b2" as UUID,
+			agentId: "00000000-0000-0000-0000-000000000002" as UUID,
+			roomId: "00000000-0000-0000-0000-000000000003" as UUID,
+			content: { text: "my favorite color is teal", source: "test" },
+			createdAt: 0,
+		};
+		const { runtime } = await runWithFacts(
+			[{ subject: "Bob", fact: "Bob's favorite color is teal" }],
+			[bobLine],
+		);
+		const call = runtime.useModel.mock.calls.find(
+			(entry) => entry[0] === ModelType.TEXT_LARGE || entry[0] === "TEXT_LARGE",
+		);
+		const params = call?.[1] as {
+			messages?: Array<{ role: string; content: string }>;
+		};
+		expect(params.messages?.[1]?.content).toContain(
+			"Bob: my favorite color is teal",
+		);
+		expect(runtime.createMemory).toHaveBeenCalledWith(
+			expect.objectContaining({
+				entityId: "00000000-0000-0000-0000-0000000000b2",
+			}),
+			"facts",
+			true,
+		);
 	});
 });

--- a/packages/core/src/runtime/facts-and-relationships.ts
+++ b/packages/core/src/runtime/facts-and-relationships.ts
@@ -62,7 +62,15 @@ export const factsAndRelationshipsSchema: JSONSchema = {
 	properties: {
 		facts: {
 			type: "array",
-			items: { type: "string" },
+			items: {
+				type: "object",
+				additionalProperties: false,
+				properties: {
+					subject: { type: "string" },
+					fact: { type: "string" },
+				},
+				required: ["subject", "fact"],
+			},
 		},
 		relationships: {
 			type: "array",
@@ -100,14 +108,23 @@ rules:
 - drop candidates that are speculative, agent-generated, or not stated by the user
 - drop credentials, API keys, passwords, raw tokens, and other secrets; never persist their values
 - drop synthetic summaries, compaction artifacts, generic chat filler, and one-off task requests
+- each kept fact is an object { subject, fact }: subject names WHO the fact is about
+- subject must be the speaker who stated the fact about themselves — use their name exactly as shown in recent_conversation or room_entities, preferring the UUID when room_entities shows one; use "user" ONLY when the fact is about the author of current_message
+- never attribute one speaker's fact to a different speaker; if the speaker cannot be identified, drop the fact
 - normalize entity names to match the names already used in existing relationships or room entities when possible (do not invent new aliases)
 - when an entity UUID is shown in room_entities, prefer that UUID for relationship subject/object; otherwise use the canonical display name
 - relationships use snake_case predicates ("works_with", "lives_in", "manages")
 - if every candidate is a duplicate, return empty arrays
 - thought is a one-line internal note about the dedup decision`;
 
+/** A validated fact paired with the speaker it belongs to. */
+export interface ExtractedFactWithSubject {
+	subject: string;
+	fact: string;
+}
+
 export interface FactsAndRelationshipsResult {
-	facts: string[];
+	facts: ExtractedFactWithSubject[];
 	relationships: MessageHandlerExtractedRelationship[];
 	thought: string;
 }
@@ -256,10 +273,24 @@ function buildFactsStageMessages(args: BuildMessagesArgs): ChatMessage[] {
 
 	const userBlocks: string[] = [];
 
+	// Label each line with the actual speaker so the model can attribute facts
+	// to the right participant. Collapsing every human to "user" made facts
+	// stated by one speaker attributable to whoever spoke next in shared rooms.
+	const nameByEntityId = new Map<string, string>();
+	for (const entity of args.roomEntities) {
+		const name = entity.names.find((n) => n.trim().length > 0);
+		if (entity.id && name) nameByEntityId.set(entity.id, name);
+	}
+	const speakerLabel = (entityId: string): string =>
+		entityId === args.runtime.agentId
+			? "agent"
+			: entityId === args.message.entityId
+				? "user"
+				: (nameByEntityId.get(entityId) ?? "user");
 	const dialogueLines = args.priorDialogue
 		.filter((memory) => !isSyntheticMemory(memory))
 		.map((memory) => {
-			const role = memory.entityId === args.runtime.agentId ? "agent" : "user";
+			const role = speakerLabel(memory.entityId);
 			const text =
 				typeof memory.content.text === "string" ? memory.content.text : "";
 			return text ? `${role}: ${args.runtime.redactSecrets(text)}` : "";
@@ -526,7 +557,6 @@ export function parseFactsAndRelationshipsOutput(
 	}
 	if (
 		!Array.isArray(parsed.facts) ||
-		!parsed.facts.every((entry) => typeof entry === "string") ||
 		!Array.isArray(parsed.relationships) ||
 		typeof parsed.thought !== "string"
 	) {
@@ -535,7 +565,29 @@ export function parseFactsAndRelationshipsOutput(
 		});
 	}
 
-	const facts = parsed.facts.map((entry) => entry.trim()).filter(Boolean);
+	const facts = parsed.facts
+		.map((entry, index): ExtractedFactWithSubject => {
+			// Providers that ignore strict tool schemas occasionally emit the
+			// pre-attribution plain-string shape; those degrade to the current
+			// speaker ("user"), which matches the old behavior exactly.
+			if (typeof entry === "string") {
+				return { subject: "user", fact: entry.trim() };
+			}
+			if (!entry || typeof entry !== "object") {
+				throw new ElizaError("Facts model returned a malformed fact", {
+					code: "FACTS_MODEL_OUTPUT_SCHEMA_INVALID",
+					context: { factIndex: index },
+				});
+			}
+			const record = entry as Record<string, unknown>;
+			const fact = typeof record.fact === "string" ? record.fact.trim() : "";
+			const subject =
+				typeof record.subject === "string" && record.subject.trim()
+					? record.subject.trim()
+					: "user";
+			return { subject, fact };
+		})
+		.filter((entry) => entry.fact.length > 0);
 	const relationships = parsed.relationships.map(
 		(entry, index): MessageHandlerExtractedRelationship => {
 			if (!entry || typeof entry !== "object") {
@@ -610,13 +662,24 @@ async function persistFactsAndRelationships(
 	let relationshipsWritten = 0;
 
 	if (parsed.facts.length > 0 && typeof runtime.createMemory === "function") {
-		for (const factText of parsed.facts) {
-			const sanitized = sanitizePersistedFact(runtime, factText);
+		for (const factEntry of parsed.facts) {
+			const sanitized = sanitizePersistedFact(runtime, factEntry.fact);
 			if (!sanitized) continue;
 			const keywords = buildFactKeywordsForStorage(sanitized);
+			// Facts belong to the speaker the model attributed them to, resolved
+			// through the same room-entity grounding relationships use. Stamping
+			// message.entityId unconditionally credited every extracted fact to
+			// the current speaker, crossing facts between users in shared rooms.
+			const factEntityId =
+				resolveRelationshipEntityId(
+					factEntry.subject,
+					roomEntities,
+					runtime,
+					message,
+				) ?? message.entityId;
 			await runtime.createMemory(
 				{
-					entityId: message.entityId,
+					entityId: factEntityId,
 					agentId: runtime.agentId,
 					roomId: message.roomId,
 					content: { text: sanitized, type: "fact" },

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -9377,7 +9377,13 @@ async function recordFactsAndRelationshipsStage(args: {
 		const candidates = extractCandidatesForRecording(result);
 		const kept = result?.parsed
 			? {
-					facts: result.parsed.facts,
+					// The trajectory contract records facts as strings; the speaker
+					// attribution is rendered inline so replays can audit it.
+					facts: result.parsed.facts.map((fact) =>
+						fact.subject && fact.subject !== "user"
+							? `[${fact.subject}] ${fact.fact}`
+							: fact.fact,
+					),
 					relationships: result.parsed.relationships,
 				}
 			: { facts: [], relationships: [] };


### PR DESCRIPTION
## Problem

Live finding (F19 leg 2, nubilio test matrix): a bystander guild member's entity carried 45 facts belonging to the owner's test battery, including verbatim probe facts like "user's favorite color is crimson".

Mechanism, confirmed in code: the Stage-1 facts prompt collapses every human participant to the literal role `user` (`role = entityId === agentId ? "agent" : "user"` — no speaker identity in `recent_conversation`), and `persistFactsAndRelationships` stamps every kept fact with `entityId: message.entityId` — the *current* speaker. In any multi-user room, whoever speaks after a fact-rich exchange inherits the other participants' facts as durable memory attributed to them. Relationships already resolve subject/object through `roomEntities` grounding; facts never got the same treatment.

## Fix

Structural, mirroring the existing relationship resolver:

- `recent_conversation` lines are labeled with the actual speaker's name (from the same room-entity grounding), `user` reserved for the author of `current_message`.
- Kept facts become `{ subject, fact }` in the strict validation tool schema, with instructions to name who each fact is about and to drop facts whose speaker cannot be identified.
- Persistence resolves `subject` via `resolveRelationshipEntityId` (UUID → name → `user`/`agent` shortcuts), falling back to `message.entityId`.
- Plain-string fact items from schema-lax providers degrade to the previous current-speaker behavior — no new failure mode.
- The trajectory record keeps its `facts: string[]` contract with attribution rendered inline (`[Alice] …`), so replay tooling is unaffected.

## Evidence

| Row | Result |
| --- | --- |
| Unit tests | `facts-and-relationships.test.ts` 26/26 — 4 new: subject→room-entity attribution, `user`→current author, unresolvable-subject fallback, speaker-labeled dialogue lines (Bob's line renders `Bob: …` and Bob's fact persists under Bob's entity) |
| Regression | trajectory-recorder tests 55/55; core `tsc --noEmit` clean |
| Ground truth | Crossed-fact records from the live box (entity/fact ids in HQ #18309 F19 receipt); prediction for the record pull: crossed facts sit in a shared room where the entity's owner spoke after fact-rich turns |
| Live re-prove | Queued with the fleet's live driver: two-speaker room probe, assert fact rows land on the stating speaker's entity (matrix batch 3) |

Part of the F19 entity-attribution arc (HQ #18309). Companion PR #20104 fixes the other leg (owner-aliased authors overwriting the canonical owner entity's identity metadata).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
