### PR TITLE
perf(cloud): remove repeat Telegram account writes

### DIFF
--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -4,10 +4,17 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import type { OnboardingChatInput } from "@/lib/services/eliza-app/onboarding-chat";
 
-const findOrCreateByTelegram = mock(async () => ({
-  user: { id: "00000000-0000-4000-8000-000000000002" },
-  organization: { id: "00000000-0000-4000-8000-000000000001" },
-  isNew: true,
+let activeTarget: {
+  id: string;
+  status: "running" | "sleeping" | "stopped";
+  bridge_url?: string;
+} | null = null;
+const resolvePersonalDeliveryByTelegram = mock(async () => ({
+  userId: "00000000-0000-4000-8000-000000000002",
+  organizationId: "00000000-0000-4000-8000-000000000001",
+  dedicatedTarget: activeTarget,
+  isNew: false,
+  resolution: "single-query-repeat" as const,
 }));
 const findOrCreateByPhone = mock(async () => ({
   user: { id: "00000000-0000-4000-8000-000000000012" },
@@ -24,11 +31,6 @@ const runOnboardingChat = mock(async (_input: OnboardingChatInput) => ({
   loginUrl:
     "https://cloud-staging.eliza.app/get-started?onboardingSession=claim-token",
 }));
-let activeTarget: {
-  id: string;
-  status: "running" | "sleeping" | "stopped";
-  bridge_url?: string;
-} | null = null;
 const findActivePersonalDedicatedTarget = mock(async () => activeTarget);
 let creditGateResult: { allowed: boolean; balance: number; error?: string } = {
   allowed: true,
@@ -114,7 +116,7 @@ mock.module("@/lib/services/eliza-app", () => ({
   elizaAppUserService: {
     findOrCreateByDiscordId,
     findOrCreateByPhone,
-    findOrCreateByTelegram,
+    resolvePersonalDeliveryByTelegram,
   },
 }));
 mock.module("@/lib/services/shared-runtime/shared-rest-adapter", () => ({
@@ -195,7 +197,7 @@ describe("personal Shared messaging deliveries", () => {
     findOrCreateByPhone.mockClear();
     findOrCreateByDiscordId.mockClear();
     activeTarget = null;
-    findOrCreateByTelegram.mockClear();
+    resolvePersonalDeliveryByTelegram.mockClear();
     findActivePersonalDedicatedTarget.mockClear();
     sharedRestMessageSend.mockClear();
     runOnboardingChat.mockClear();
@@ -211,7 +213,7 @@ describe("personal Shared messaging deliveries", () => {
 
   test("requires internal gateway authentication", async () => {
     expect((await request(valid, "")).status).toBe(401);
-    expect(findOrCreateByTelegram).not.toHaveBeenCalled();
+    expect(resolvePersonalDeliveryByTelegram).not.toHaveBeenCalled();
   });
 
   test("uses one account-native identity and platform funding", async () => {
@@ -220,11 +222,15 @@ describe("personal Shared messaging deliveries", () => {
     const body = (await response.json()) as {
       data: { identity: { id: string } };
     };
-    expect(findOrCreateByTelegram).toHaveBeenCalledWith({
+    expect(resolvePersonalDeliveryByTelegram).toHaveBeenCalledWith({
       telegramId: "123456789",
       username: "nubs",
       displayName: "Nubs",
     });
+    expect(findActivePersonalDedicatedTarget).not.toHaveBeenCalled();
+    expect(response.headers.get("server-timing")).toMatch(
+      /^account;dur=\d+\.\d, shared;dur=\d+\.\d$/,
+    );
     expect(body.data.identity.id).toMatch(/^personal:/);
     expect(sharedRestMessageSend).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -311,7 +317,7 @@ describe("personal Shared messaging deliveries", () => {
     });
 
     expect(response.status).toBe(400);
-    expect(findOrCreateByTelegram).not.toHaveBeenCalled();
+    expect(resolvePersonalDeliveryByTelegram).not.toHaveBeenCalled();
     expect(sharedRestMessageSend).not.toHaveBeenCalled();
   });
 
@@ -394,7 +400,8 @@ describe("personal Shared messaging deliveries", () => {
       data: { identity: { id: string }; account: { userId: string } };
     };
     expect(findOrCreateByPhone).toHaveBeenCalledWith("+15551234567");
-    expect(findOrCreateByTelegram).not.toHaveBeenCalled();
+    expect(resolvePersonalDeliveryByTelegram).not.toHaveBeenCalled();
+    expect(findActivePersonalDedicatedTarget).toHaveBeenCalledTimes(1);
     expect(body.data.identity.id).toMatch(/^personal:/);
     expect(body.data.account.userId).toBe(
       "00000000-0000-4000-8000-000000000012",
@@ -471,6 +478,10 @@ describe("personal Shared messaging deliveries", () => {
       },
     });
     expect(sharedRestMessageSend).not.toHaveBeenCalled();
+    expect(findActivePersonalDedicatedTarget).not.toHaveBeenCalled();
+    expect(response.headers.get("server-timing")).toMatch(
+      /^account;dur=\d+\.\d, dedicated;dur=\d+\.\d$/,
+    );
     expect(bridge).toHaveBeenCalledWith(
       "00000000-0000-4000-8000-000000000020",
       "00000000-0000-4000-8000-000000000001",
@@ -683,6 +694,6 @@ describe("personal Shared messaging deliveries", () => {
   ])("rejects malformed deliveries before account creation", async (body) => {
     expect((await request(body)).status).toBe(400);
     expect(findOrCreateByPhone).not.toHaveBeenCalled();
-    expect(findOrCreateByTelegram).not.toHaveBeenCalled();
+    expect(resolvePersonalDeliveryByTelegram).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -2,6 +2,7 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
+import type { AgentSandbox } from "@/db/schemas/agent-sandboxes";
 import { failureResponse, jsonError } from "@/lib/api/cloud-worker-errors";
 import { sha256Hex } from "@/lib/oidc/crypto";
 import { findActivePersonalDedicatedTarget } from "@/lib/services/agent-tier-upgrade-target";
@@ -217,28 +218,51 @@ app.post("/", async (c) => {
       );
     }
 
-    const account =
-      parsed.data.platform === "telegram"
-        ? await elizaAppUserService.findOrCreateByTelegram({
-            telegramId: parsed.data.telegramUserId,
-            username: parsed.data.telegramUsername,
-            displayName: parsed.data.displayName,
-          })
-        : parsed.data.platform === "discord"
-          ? await elizaAppUserService.findOrCreateByDiscordId(
-              parsed.data.discordUserId,
-              {
-                username: parsed.data.discordUsername,
-                globalName: parsed.data.displayName,
-                avatarUrl: parsed.data.avatarUrl,
-              },
-            )
-          : await elizaAppUserService.findOrCreateByPhone(
-              parsed.data.phoneNumber,
-            );
+    const accountStartedAt = performance.now();
+    let account: { userId: string; organizationId: string };
+    let dedicated:
+      | Pick<AgentSandbox, "id" | "status" | "bridge_url" | "agent_config">
+      | null
+      | undefined;
+    if (parsed.data.platform === "telegram") {
+      const delivery =
+        await elizaAppUserService.resolvePersonalDeliveryByTelegram({
+          telegramId: parsed.data.telegramUserId,
+          username: parsed.data.telegramUsername,
+          displayName: parsed.data.displayName,
+        });
+      account = {
+        userId: delivery.userId,
+        organizationId: delivery.organizationId,
+      };
+      dedicated = delivery.dedicatedTarget;
+    } else if (parsed.data.platform === "discord") {
+      const discordAccount = await elizaAppUserService.findOrCreateByDiscordId(
+        parsed.data.discordUserId,
+        {
+          username: parsed.data.discordUsername,
+          globalName: parsed.data.displayName,
+          avatarUrl: parsed.data.avatarUrl,
+        },
+      );
+      account = {
+        userId: discordAccount.user.id,
+        organizationId: discordAccount.organization.id,
+      };
+    } else {
+      const phoneAccount = await elizaAppUserService.findOrCreateByPhone(
+        parsed.data.phoneNumber,
+      );
+      account = {
+        userId: phoneAccount.user.id,
+        organizationId: phoneAccount.organization.id,
+      };
+    }
+    const accountMs = performance.now() - accountStartedAt;
+    c.header("Server-Timing", `account;dur=${accountMs.toFixed(1)}`);
     const agent = personalSharedAgent({
-      userId: account.user.id,
-      organizationId: account.organization.id,
+      userId: account.userId,
+      organizationId: account.organizationId,
     });
     let deliveryMessage = parsed.data.message;
     if (
@@ -262,7 +286,7 @@ app.post("/", async (c) => {
         {
           durationSeconds: parsed.data.voiceNote.durationSeconds,
           sizeBytes: parsed.data.voiceNote.sizeBytes,
-          userId: account.user.id,
+          userId: account.userId,
         },
       );
     }
@@ -293,8 +317,8 @@ app.post("/", async (c) => {
           parsed.data.telegramUsername ??
           parsed.data.telegramUserId,
         authenticatedUser: {
-          userId: account.user.id,
-          organizationId: account.organization.id,
+          userId: account.userId,
+          organizationId: account.organizationId,
           telegramId: parsed.data.telegramUserId,
         },
         trustedPlatformIdentity: true,
@@ -308,23 +332,26 @@ app.post("/", async (c) => {
         data: {
           identity: { id: agent.id, runtime: "shared" as const },
           account: {
-            userId: account.user.id,
-            organizationId: account.organization.id,
+            userId: account.userId,
+            organizationId: account.organizationId,
           },
           reply: `Sign in to connect this Telegram chat to your Eliza account: ${loginUrl.toString()}`,
         },
       });
     }
-    const dedicated = await findActivePersonalDedicatedTarget(
-      account.organization.id,
-      agent.id,
-    );
+    if (dedicated === undefined) {
+      dedicated = await findActivePersonalDedicatedTarget(
+        account.organizationId,
+        agent.id,
+      );
+    }
     if (dedicated) {
+      const dedicatedStartedAt = performance.now();
       const preparation = await preparePersonalDedicatedDelivery(
         dedicated,
         {
-          organizationId: account.organization.id,
-          userId: account.user.id,
+          organizationId: account.organizationId,
+          userId: account.userId,
         },
         c.env,
         worker.executionCtx,
@@ -382,7 +409,7 @@ app.post("/", async (c) => {
           roomId: agent.id,
           conversationId: agent.id,
           canonicalBridgeBase: dedicated.bridge_url,
-          userId: account.user.id,
+          userId: account.userId,
           clientMessageId: parsed.data.messageId,
           platformName: parsed.data.platform,
           source: parsed.data.platform,
@@ -400,7 +427,7 @@ app.post("/", async (c) => {
       };
       let response = await elizaSandboxService.bridge(
         dedicated.id,
-        account.organization.id,
+        account.organizationId,
         bridgeRequest,
       );
       if (response.error?.message === "Bridge returned HTTP 404") {
@@ -432,7 +459,7 @@ app.post("/", async (c) => {
           importMessages.length === importableHistory.length
             ? await elizaSandboxService.importCanonicalConversation(
                 dedicated.id,
-                account.organization.id,
+                account.organizationId,
                 agent.id,
                 importMessages,
               )
@@ -440,7 +467,7 @@ app.post("/", async (c) => {
         if (!receipt && importMessages.length > 0) {
           receipt = await elizaSandboxService.importCanonicalConversation(
             dedicated.id,
-            account.organization.id,
+            account.organizationId,
             agent.id,
             [],
           );
@@ -448,7 +475,7 @@ app.post("/", async (c) => {
         if (receipt) {
           response = await elizaSandboxService.bridge(
             dedicated.id,
-            account.organization.id,
+            account.organizationId,
             bridgeRequest,
           );
         }
@@ -470,6 +497,12 @@ app.post("/", async (c) => {
           "service_unavailable",
         );
       }
+      c.header(
+        "Server-Timing",
+        `account;dur=${accountMs.toFixed(1)}, dedicated;dur=${(
+          performance.now() - dedicatedStartedAt
+        ).toFixed(1)}`,
+      );
       return c.json({
         success: true,
         data: {
@@ -479,13 +512,14 @@ app.post("/", async (c) => {
             activeAgentId: dedicated.id,
           },
           account: {
-            userId: account.user.id,
-            organizationId: account.organization.id,
+            userId: account.userId,
+            organizationId: account.organizationId,
           },
           reply: result.text,
         },
       });
     }
+    const sharedStartedAt = performance.now();
     const result = await sharedRestMessageSend(
       agent,
       agent.id,
@@ -503,14 +537,20 @@ app.post("/", async (c) => {
           }
         : undefined,
     );
+    c.header(
+      "Server-Timing",
+      `account;dur=${accountMs.toFixed(1)}, shared;dur=${(
+        performance.now() - sharedStartedAt
+      ).toFixed(1)}`,
+    );
 
     return c.json({
       success: true,
       data: {
         identity: { id: agent.id, runtime: "shared" as const },
         account: {
-          userId: account.user.id,
-          organizationId: account.organization.id,
+          userId: account.userId,
+          organizationId: account.organizationId,
         },
         reply: result.text,
       },

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
@@ -1,10 +1,11 @@
 /** Exercises gateway webhook routing with deterministic cloud-service fixtures. */
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import type {
   ChatEvent,
   PlatformAdapter,
   WebhookConfig,
 } from "../src/adapters/types";
+import { logger } from "../src/logger";
 import type { GatewayRedis } from "../src/redis";
 import { handleWebhook } from "../src/webhook-handler";
 
@@ -424,6 +425,9 @@ describe("gateway webhook handler e2e routing", () => {
       sendReply,
     };
     const redis = new MemoryRedis();
+    const completionLog = spyOn(logger, "info").mockImplementation(
+      () => undefined,
+    );
     let sharedBody: Record<string, unknown> | null = null;
     globalThis.fetch = mock(async (input, init) => {
       const url = String(input);
@@ -440,7 +444,10 @@ describe("gateway webhook handler e2e routing", () => {
           }),
           {
             status: 200,
-            headers: { "content-type": "application/json" },
+            headers: {
+              "content-type": "application/json",
+              "server-timing": "account;dur=5.2, shared;dur=17.8",
+            },
           },
         );
       }
@@ -475,6 +482,18 @@ describe("gateway webhook handler e2e routing", () => {
       expect.anything(),
       event,
       "start with the launch checklist",
+    );
+    expect(completionLog).toHaveBeenCalledWith(
+      "Personal Eliza connector message completed",
+      expect.objectContaining({
+        project: "eliza-app",
+        platform: "telegram",
+        messageId: "update-personal-1",
+        cloudMs: expect.any(Number),
+        cloudServerTiming: "account;dur=5.2, shared;dur=17.8",
+        egressMs: expect.any(Number),
+        totalMs: expect.any(Number),
+      }),
     );
   });
 

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -45,6 +45,12 @@ interface HandlerDeps {
   reacquireAuthHeader?: () => Promise<Record<string, string>>;
 }
 
+interface PersonalSharedDeliveryTiming {
+  cloudMs: number;
+  egressMs: number;
+  cloudServerTiming: string | null;
+}
+
 export async function handleWebhook(
   request: Request,
   adapter: PlatformAdapter,
@@ -284,7 +290,7 @@ async function processMessage(
   if (!explicitAgentId && isPersonalElizaTransport(adapter.platform)) {
     const stopTyping = beginTypingFeedback(adapter, config, event);
     try {
-      await sendPersonalSharedReply(
+      const timing = await sendPersonalSharedReply(
         adapter,
         config,
         event,
@@ -296,6 +302,9 @@ async function processMessage(
         project,
         platform: adapter.platform,
         messageId: event.messageId,
+        cloudMs: timing.cloudMs,
+        cloudServerTiming: timing.cloudServerTiming,
+        egressMs: timing.egressMs,
         totalMs: Date.now() - startedAt,
       });
     } finally {
@@ -566,7 +575,7 @@ async function sendPersonalSharedReply(
   deps: HandlerDeps,
   project: string,
   beforeEgress?: () => Promise<void>,
-): Promise<void> {
+): Promise<PersonalSharedDeliveryTiming> {
   const { cloudBaseUrl, getAuthHeader } = deps;
   const reauth = deps.reacquireAuthHeader ?? reacquireAuthHeader;
   const voiceNote = event.voiceNote
@@ -577,6 +586,7 @@ async function sendPersonalSharedReply(
       "connector cannot resolve the supplied voice note",
     );
   }
+  const cloudStartedAt = Date.now();
   // Voice turns can spend most of the 120-second processing lease in STT + the
   // model. Only a stale-auth retry is safe inline; provider/transport failures
   // reopen the webhook for Telegram's durable retry instead of overlapping it.
@@ -663,7 +673,9 @@ async function sendPersonalSharedReply(
       `personal Shared chat failed (${response.status}) ${diagnostics}`,
     );
   }
+  const cloudServerTiming = response.headers.get("Server-Timing");
   const body: unknown = await response.json();
+  const cloudMs = Date.now() - cloudStartedAt;
   const reply =
     body && typeof body === "object" && "data" in body
       ? (body.data as { reply?: unknown } | null)?.reply
@@ -675,9 +687,17 @@ async function sendPersonalSharedReply(
   }
   // Empty is the agent's deliberate shouldRespond=no result. It is a
   // successful turn with no provider egress, not a malformed response.
-  if (reply.length === 0) return;
+  if (reply.length === 0) {
+    return { cloudMs, egressMs: 0, cloudServerTiming };
+  }
+  const egressStartedAt = Date.now();
   await beforeEgress?.();
   await adapter.sendReply(config, event, reply);
+  return {
+    cloudMs,
+    egressMs: Date.now() - egressStartedAt,
+    cloudServerTiming,
+  };
 }
 
 async function sendOnboardingReply(

--- a/packages/cloud/shared/src/db/repositories/personal-shared-deliveries.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-deliveries.integration.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Drives repeat-turn Telegram resolution against the real Drizzle schema on
+ * isolated PGlite, including single-statement reuse, exact Dedicated authority,
+ * stale-projection repair, and concurrent first contact.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+import { pushSchema } from "drizzle-kit/api";
+import { eq } from "drizzle-orm";
+import {
+  AGENT_PERSONAL_CUTOVER_KEY,
+  AGENT_UPGRADED_FROM_KEY,
+} from "../../lib/services/eliza-agent-config";
+import { elizaAppUserService } from "../../lib/services/eliza-app/user-service";
+import { personalSharedAgentId } from "../../lib/services/shared-runtime/personal-shared-agent";
+import { closeDatabaseConnectionsForTests, dbWrite, getPgliteClientForTests } from "../client";
+import { agentSandboxes } from "../schemas/agent-sandboxes";
+import { organizationBalanceRevisionSequence, organizations } from "../schemas/organizations";
+import { userCharacters } from "../schemas/user-characters";
+import { userIdentities } from "../schemas/user-identities";
+import { users } from "../schemas/users";
+
+const PGLITE_TIMEOUT = 60_000;
+let pgliteReady = true;
+
+function telegramInput(telegramId: string) {
+  return {
+    telegramId,
+    username: `user_${telegramId}`,
+    firstName: "Nubs",
+    displayName: "Nubs",
+  };
+}
+
+function cutoverFor(sourceAgentId: string) {
+  return {
+    mode: "dedicated" as const,
+    sourceAgentId,
+    conversationId: sourceAgentId,
+    cutoverToken: `cutover-${sourceAgentId}`,
+    sharedMessageCount: 4,
+    sharedScheduledTaskCount: 0,
+    sharedTodoCount: 0,
+    sharedTodoMutationCount: 0,
+    sharedTodoDigest: "0".repeat(64),
+    activatedAt: "2026-08-15T12:00:00.000Z",
+  };
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.warn(
+      "[personal-shared-deliveries.integration.test] isolated PGlite is required; refusing to mutate an ambient Postgres database.",
+    );
+    return;
+  }
+  try {
+    const { apply } = await pushSchema(
+      {
+        organizationBalanceRevisionSequence,
+        organizations,
+        users,
+        userIdentities,
+        userCharacters,
+        agentSandboxes,
+      } as never,
+      dbWrite as never,
+    );
+    await apply();
+  } catch (error) {
+    // error-policy:J1 The test boundary records schema setup failure and every case fails loudly.
+    pgliteReady = false;
+    console.error(
+      "[personal-shared-deliveries.integration.test] PGlite schema setup failed.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+beforeEach(async () => {
+  expect(pgliteReady).toBe(true);
+  await dbWrite.delete(agentSandboxes);
+  await dbWrite.delete(userIdentities);
+  await dbWrite.delete(users);
+  await dbWrite.delete(organizations);
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+describe("Telegram personal Shared repeat delivery", () => {
+  test("reuses a converged account in one statement without rewriting identity rows", async () => {
+    const input = telegramInput("714700101");
+    const created = await elizaAppUserService.resolvePersonalDeliveryByTelegram(input);
+    const [userBefore] = await dbWrite.select().from(users).where(eq(users.id, created.userId));
+    const [projectionBefore] = await dbWrite
+      .select()
+      .from(userIdentities)
+      .where(eq(userIdentities.user_id, created.userId));
+
+    const query = spyOn(getPgliteClientForTests(), "query");
+    const replayed = await elizaAppUserService.resolvePersonalDeliveryByTelegram(input);
+    expect(query).toHaveBeenCalledTimes(1);
+    query.mockRestore();
+
+    const [userAfter] = await dbWrite.select().from(users).where(eq(users.id, created.userId));
+    const [projectionAfter] = await dbWrite
+      .select()
+      .from(userIdentities)
+      .where(eq(userIdentities.user_id, created.userId));
+    expect(replayed).toMatchObject({
+      userId: created.userId,
+      organizationId: created.organizationId,
+      dedicatedTarget: null,
+      isNew: false,
+      resolution: "single-query-repeat",
+    });
+    expect(userAfter.updated_at).toEqual(userBefore.updated_at);
+    expect(projectionAfter.updated_at).toEqual(projectionBefore.updated_at);
+  });
+
+  test("returns the exact authoritative Dedicated target in the repeat statement", async () => {
+    const input = telegramInput("714700102");
+    const account = await elizaAppUserService.resolvePersonalDeliveryByTelegram(input);
+    const sourceAgentId = personalSharedAgentId({
+      userId: account.userId,
+      organizationId: account.organizationId,
+    });
+    const [target] = await dbWrite
+      .insert(agentSandboxes)
+      .values({
+        organization_id: account.organizationId,
+        user_id: account.userId,
+        execution_tier: "dedicated-always",
+        status: "running",
+        bridge_url: "http://127.0.0.1:9876/api/compat/agents/sandbox",
+        agent_config: {
+          [AGENT_UPGRADED_FROM_KEY]: sourceAgentId,
+          [AGENT_PERSONAL_CUTOVER_KEY]: cutoverFor(sourceAgentId),
+        },
+      })
+      .returning();
+
+    const query = spyOn(getPgliteClientForTests(), "query");
+    const replayed = await elizaAppUserService.resolvePersonalDeliveryByTelegram(input);
+    expect(query).toHaveBeenCalledTimes(1);
+    query.mockRestore();
+    expect(replayed.dedicatedTarget).toMatchObject({
+      id: target.id,
+      status: "running",
+    });
+  });
+
+  test("falls back to exact marker authority when another org target is newer", async () => {
+    const input = telegramInput("714700105");
+    const account = await elizaAppUserService.resolvePersonalDeliveryByTelegram(input);
+    const sourceAgentId = personalSharedAgentId({
+      userId: account.userId,
+      organizationId: account.organizationId,
+    });
+    const [exact] = await dbWrite
+      .insert(agentSandboxes)
+      .values({
+        organization_id: account.organizationId,
+        user_id: account.userId,
+        execution_tier: "dedicated-always",
+        status: "running",
+        created_at: new Date("2026-08-15T12:00:00.000Z"),
+        agent_config: {
+          [AGENT_UPGRADED_FROM_KEY]: sourceAgentId,
+          [AGENT_PERSONAL_CUTOVER_KEY]: cutoverFor(sourceAgentId),
+        },
+      })
+      .returning();
+    await dbWrite.insert(agentSandboxes).values({
+      organization_id: account.organizationId,
+      user_id: account.userId,
+      execution_tier: "dedicated-always",
+      status: "running",
+      created_at: new Date("2026-08-15T12:01:00.000Z"),
+      agent_config: { [AGENT_UPGRADED_FROM_KEY]: "personal:another-account" },
+    });
+
+    const query = spyOn(getPgliteClientForTests(), "query");
+    const replayed = await elizaAppUserService.resolvePersonalDeliveryByTelegram(input);
+    expect(query).toHaveBeenCalledTimes(2);
+    query.mockRestore();
+    expect(replayed.resolution).toBe("exact-dedicated-fallback");
+    expect(replayed.dedicatedTarget?.id).toBe(exact.id);
+  });
+
+  test("repairs a stale projection through the sender-locked writer", async () => {
+    const input = telegramInput("714700103");
+    const account = await elizaAppUserService.resolvePersonalDeliveryByTelegram(input);
+    await dbWrite
+      .update(userIdentities)
+      .set({ telegram_username: "stale_username" })
+      .where(eq(userIdentities.user_id, account.userId));
+
+    const repaired = await elizaAppUserService.resolvePersonalDeliveryByTelegram(input);
+    expect(repaired.resolution).toBe("locked-create-or-repair");
+    const [projection] = await dbWrite
+      .select()
+      .from(userIdentities)
+      .where(eq(userIdentities.user_id, account.userId));
+    expect(projection.telegram_username).toBe(input.username);
+  });
+
+  test("persists changed Telegram profile metadata through locked repair", async () => {
+    const input = telegramInput("714700106");
+    const account = await elizaAppUserService.resolvePersonalDeliveryByTelegram(input);
+
+    const repaired = await elizaAppUserService.resolvePersonalDeliveryByTelegram({
+      ...input,
+      username: "renamed_user",
+      firstName: "Luna",
+    });
+    expect(repaired).toMatchObject({
+      userId: account.userId,
+      organizationId: account.organizationId,
+      resolution: "locked-create-or-repair",
+    });
+    const [canonical] = await dbWrite.select().from(users).where(eq(users.id, account.userId));
+    const [projection] = await dbWrite
+      .select()
+      .from(userIdentities)
+      .where(eq(userIdentities.user_id, account.userId));
+    expect(canonical.telegram_username).toBe("renamed_user");
+    expect(canonical.telegram_first_name).toBe("Luna");
+    expect(projection.telegram_username).toBe("renamed_user");
+    expect(projection.telegram_first_name).toBe("Luna");
+  });
+
+  test("fails closed when the Telegram projection points at another tenant", async () => {
+    const firstInput = telegramInput("714700107");
+    const secondInput = telegramInput("714700108");
+    const first = await elizaAppUserService.resolvePersonalDeliveryByTelegram(firstInput);
+    const second = await elizaAppUserService.resolvePersonalDeliveryByTelegram(secondInput);
+    const [secondBefore] = await dbWrite.select().from(users).where(eq(users.id, second.userId));
+
+    await dbWrite.delete(userIdentities).where(eq(userIdentities.user_id, second.userId));
+    await dbWrite
+      .update(userIdentities)
+      .set({ user_id: second.userId })
+      .where(eq(userIdentities.user_id, first.userId));
+
+    await expect(
+      elizaAppUserService.resolvePersonalDeliveryByTelegram(firstInput),
+    ).rejects.toMatchObject({
+      code: "TELEGRAM_PERSONAL_ACCOUNT_IDENTITY_CONFLICT",
+    });
+
+    const [secondAfter] = await dbWrite.select().from(users).where(eq(users.id, second.userId));
+    const [conflictingProjection] = await dbWrite
+      .select()
+      .from(userIdentities)
+      .where(eq(userIdentities.telegram_id, firstInput.telegramId));
+    expect(secondAfter).toEqual(secondBefore);
+    expect(conflictingProjection.user_id).toBe(second.userId);
+    expect(first.organizationId).not.toBe(second.organizationId);
+  });
+
+  test("concurrent first contacts converge on one zero-credit account", async () => {
+    const input = telegramInput("714700104");
+    const [first, second] = await Promise.all([
+      elizaAppUserService.resolvePersonalDeliveryByTelegram(input),
+      elizaAppUserService.resolvePersonalDeliveryByTelegram(input),
+    ]);
+
+    expect(second.userId).toBe(first.userId);
+    expect(second.organizationId).toBe(first.organizationId);
+    const canonical = await dbWrite
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.telegram_id, input.telegramId));
+    const projections = await dbWrite
+      .select({ userId: userIdentities.user_id })
+      .from(userIdentities)
+      .where(eq(userIdentities.telegram_id, input.telegramId));
+    const organization = await dbWrite
+      .select()
+      .from(organizations)
+      .where(eq(organizations.id, first.organizationId));
+    expect(canonical).toEqual([{ id: first.userId }]);
+    expect(projections).toEqual([{ userId: first.userId }]);
+    expect(organization).toHaveLength(1);
+    expect(Number(organization[0]?.credit_balance)).toBe(0);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/personal-shared-deliveries.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-deliveries.ts
@@ -1,0 +1,120 @@
+/**
+ * Resolves the read-only repeat-turn projection for a Telegram personal Eliza
+ * delivery. Only a fully converged canonical identity, lookup projection, and
+ * active organization qualifies; every repair or creation case stays on the
+ * sender-locked users repository path.
+ */
+
+import { sql } from "drizzle-orm";
+import { AGENT_UPGRADED_FROM_KEY } from "../../lib/services/eliza-agent-config";
+import { sqlRows } from "../execute-helpers";
+import { dbWrite } from "../helpers";
+import type { AgentSandboxStatus } from "../schemas/agent-sandboxes";
+import { agentSandboxes } from "../schemas/agent-sandboxes";
+import { organizations } from "../schemas/organizations";
+import { userIdentities } from "../schemas/user-identities";
+import { users } from "../schemas/users";
+
+export interface ReusableTelegramPersonalDelivery {
+  userId: string;
+  organizationId: string;
+  dedicatedCandidate: {
+    id: string;
+    status: AgentSandboxStatus;
+    bridge_url: string | null;
+    agent_config: Record<string, unknown> | null;
+  } | null;
+}
+
+interface ReusableTelegramPersonalDeliveryRow {
+  user_id: string;
+  organization_id: string;
+  dedicated_id: string | null;
+  dedicated_status: AgentSandboxStatus | null;
+  dedicated_bridge_url: string | null;
+  dedicated_agent_config: Record<string, unknown> | null;
+}
+
+/**
+ * One indexed primary-database statement serves an established Telegram turn.
+ * The bounded target candidate avoids a second lookup for the normal one-user
+ * organization; callers retain the exact source-marker lookup when another
+ * personal target in the organization sorts ahead of this account's target.
+ */
+export async function findReusableTelegramPersonalDelivery(params: {
+  telegramId: string;
+  telegramUsername?: string;
+  telegramFirstName?: string;
+}): Promise<ReusableTelegramPersonalDelivery | null> {
+  const [row] = await sqlRows<ReusableTelegramPersonalDeliveryRow>(
+    dbWrite,
+    sql`
+      SELECT
+        canonical.id AS user_id,
+        organization.id AS organization_id,
+        dedicated.id AS dedicated_id,
+        dedicated.status AS dedicated_status,
+        dedicated.bridge_url AS dedicated_bridge_url,
+        dedicated.agent_config AS dedicated_agent_config
+      FROM ${userIdentities} projection
+      INNER JOIN ${users} canonical
+        ON canonical.id = projection.user_id
+        AND canonical.telegram_id = ${params.telegramId}
+        AND canonical.steward_user_id = projection.steward_user_id
+        AND canonical.is_anonymous = projection.is_anonymous
+        AND canonical.telegram_username IS NOT DISTINCT FROM projection.telegram_username
+        AND canonical.telegram_first_name IS NOT DISTINCT FROM projection.telegram_first_name
+        AND (
+          ${params.telegramUsername ?? null}::text IS NULL
+          OR canonical.telegram_username = ${params.telegramUsername ?? null}
+        )
+        AND (
+          ${params.telegramFirstName ?? null}::text IS NULL
+          OR canonical.telegram_first_name = ${params.telegramFirstName ?? null}
+        )
+      INNER JOIN ${organizations} organization
+        ON organization.id = canonical.organization_id
+        AND organization.is_active = TRUE
+      LEFT JOIN LATERAL (
+        SELECT
+          candidate.id,
+          candidate.status,
+          candidate.bridge_url,
+          candidate.agent_config
+        FROM ${agentSandboxes} candidate
+        WHERE candidate.organization_id = organization.id
+          AND candidate.execution_tier = 'dedicated-always'
+          AND candidate.agent_config ->> ${AGENT_UPGRADED_FROM_KEY} LIKE ${"personal:%"}
+        ORDER BY candidate.created_at DESC
+        LIMIT 1
+      ) dedicated ON TRUE
+      WHERE projection.telegram_id = ${params.telegramId}
+        AND canonical.deleted_at IS NULL
+        AND canonical.is_active = TRUE
+        AND canonical.organization_id IS NOT NULL
+      LIMIT 1
+    `,
+  );
+
+  if (!row) return null;
+  if (!row.dedicated_id) {
+    return {
+      userId: row.user_id,
+      organizationId: row.organization_id,
+      dedicatedCandidate: null,
+    };
+  }
+  if (!row.dedicated_status) {
+    throw new Error(`Dedicated target ${row.dedicated_id} has no lifecycle status`);
+  }
+  return {
+    userId: row.user_id,
+    organizationId: row.organization_id,
+    dedicatedCandidate: {
+      id: row.dedicated_id,
+      status: row.dedicated_status,
+      bridge_url: row.dedicated_bridge_url,
+      agent_config: row.dedicated_agent_config,
+    },
+  };
+}

--- a/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.ts
+++ b/packages/cloud/shared/src/lib/services/agent-tier-upgrade-target.ts
@@ -55,6 +55,7 @@ import {
   AGENT_PERSONAL_CUTOVER_KEY,
   AGENT_UPGRADED_FROM_KEY,
   readPersonalElizaCutover,
+  readUpgradedFromAgentId,
 } from "./eliza-agent-config";
 import {
   configureElizaLifecycleTransaction,
@@ -163,8 +164,19 @@ export async function findActivePersonalDedicatedTarget(
     .orderBy(desc(agentSandboxes.created_at))
     .limit(1);
   if (!target) return null;
-  const cutover = readPersonalElizaCutover(target.agent_config as Record<string, unknown> | null);
-  return cutover?.sourceAgentId === sourceAgentId ? target : null;
+  return isAuthoritativePersonalDedicatedTarget(target, sourceAgentId) ? target : null;
+}
+
+/** One source of truth for the two server-owned markers that activate cutover. */
+export function isAuthoritativePersonalDedicatedTarget(
+  target: Pick<AgentSandbox, "agent_config">,
+  sourceAgentId: string,
+): boolean {
+  const agentConfig = target.agent_config as Record<string, unknown> | null;
+  return (
+    readUpgradedFromAgentId(agentConfig) === sourceAgentId &&
+    readPersonalElizaCutover(agentConfig)?.sourceAgentId === sourceAgentId
+  );
 }
 
 /**

--- a/packages/cloud/shared/src/lib/services/eliza-app/user-service.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/user-service.ts
@@ -12,7 +12,9 @@
  */
 
 import { organizationsRepository } from "../../../db/repositories/organizations";
+import { findReusableTelegramPersonalDelivery } from "../../../db/repositories/personal-shared-deliveries";
 import { type UserWithOrganization, usersRepository } from "../../../db/repositories/users";
+import type { AgentSandbox } from "../../../db/schemas/agent-sandboxes";
 import type { Organization } from "../../../db/schemas/organizations";
 import type { NewUser, User } from "../../../db/schemas/users";
 import { SIGNUP_CREDIT_POLICY } from "../../signup-credits";
@@ -20,7 +22,13 @@ import { isUniqueConstraintError } from "../../utils/db-errors";
 import { isValidEmail, maskEmailForLogging } from "../../utils/email-validation";
 import { logger } from "../../utils/logger";
 import { isValidE164, normalizePhoneNumber } from "../../utils/phone-normalization";
+import {
+  findActivePersonalDedicatedTarget,
+  isAuthoritativePersonalDedicatedTarget,
+} from "../agent-tier-upgrade-target";
 import { apiKeysService } from "../api-keys";
+import { readUpgradedFromAgentId } from "../eliza-agent-config";
+import { personalSharedAgentId } from "../shared-runtime/personal-shared-agent";
 import { redeemSignupCode } from "../signup-code";
 import type { TelegramAuthData } from "./telegram-auth";
 
@@ -28,6 +36,14 @@ export interface FindOrCreateResult {
   user: User;
   organization: Organization;
   isNew: boolean;
+}
+
+export interface TelegramPersonalDeliveryResult {
+  userId: string;
+  organizationId: string;
+  dedicatedTarget: Pick<AgentSandbox, "id" | "status" | "bridge_url" | "agent_config"> | null;
+  isNew: boolean;
+  resolution: "single-query-repeat" | "exact-dedicated-fallback" | "locked-create-or-repair";
 }
 
 function generateSlugFromTelegram(username?: string, telegramId?: string): string {
@@ -175,6 +191,102 @@ class ElizaAppUserService {
       },
     );
     return result;
+  }
+
+  /**
+   * Resolves an established Telegram account and its active runtime in one
+   * read-only statement. Missing, stale, or conflicting projections retain the
+   * existing sender-locked convergence transaction as the only repair writer.
+   */
+  async resolvePersonalDeliveryByTelegram(params: {
+    telegramId: string;
+    username?: string;
+    firstName?: string;
+    displayName?: string;
+  }): Promise<TelegramPersonalDeliveryResult> {
+    const telegramId = params.telegramId.trim();
+    if (!/^\d{1,20}$/.test(telegramId)) {
+      throw new Error("Trusted Telegram transport supplied an invalid sender id");
+    }
+    const username = params.username?.trim() || undefined;
+    const firstName = params.firstName?.trim() || undefined;
+    const displayName = params.displayName?.trim() || firstName || username || "Eliza user";
+
+    const reusable = await findReusableTelegramPersonalDelivery({
+      telegramId,
+      telegramUsername: username,
+      telegramFirstName: firstName,
+    });
+    if (reusable) {
+      const personalAgentId = personalSharedAgentId({
+        userId: reusable.userId,
+        organizationId: reusable.organizationId,
+      });
+      const candidate = reusable.dedicatedCandidate;
+      let dedicatedTarget: TelegramPersonalDeliveryResult["dedicatedTarget"] = null;
+      let resolution: TelegramPersonalDeliveryResult["resolution"] = "single-query-repeat";
+      if (candidate) {
+        if (readUpgradedFromAgentId(candidate.agent_config) === personalAgentId) {
+          dedicatedTarget = isAuthoritativePersonalDedicatedTarget(candidate, personalAgentId)
+            ? candidate
+            : null;
+        } else {
+          dedicatedTarget = await findActivePersonalDedicatedTarget(
+            reusable.organizationId,
+            personalAgentId,
+          );
+          resolution = "exact-dedicated-fallback";
+        }
+      }
+      logger.info("[ElizaAppUserService] Reused Telegram personal account", {
+        userId: reusable.userId,
+        organizationId: reusable.organizationId,
+        telegramId,
+        resolution,
+      });
+      return {
+        userId: reusable.userId,
+        organizationId: reusable.organizationId,
+        dedicatedTarget,
+        isNew: false,
+        resolution,
+      };
+    }
+
+    const result = await usersRepository.findOrCreateTelegramPersonalAccount({
+      telegramId,
+      telegramUsername: username,
+      telegramFirstName: firstName,
+      displayName,
+      organizationName: `${displayName}'s Workspace`,
+      organizationSlug: generateSlugFromTelegram(username, telegramId),
+    });
+    const personalAgentId = personalSharedAgentId({
+      userId: result.user.id,
+      organizationId: result.organization.id,
+    });
+    const dedicatedTarget = await findActivePersonalDedicatedTarget(
+      result.organization.id,
+      personalAgentId,
+    );
+    logger.info(
+      result.isNew
+        ? "[ElizaAppUserService] Created Telegram personal account"
+        : "[ElizaAppUserService] Repaired Telegram personal account",
+      {
+        userId: result.user.id,
+        organizationId: result.organization.id,
+        telegramId,
+        resolution: "locked-create-or-repair",
+      },
+    );
+    return {
+      userId: result.user.id,
+      organizationId: result.organization.id,
+      dedicatedTarget,
+      isNew: result.isNew,
+      resolution: "locked-create-or-repair",
+    };
   }
 
   /**


### PR DESCRIPTION
# Relates to

Closes #20095.

Definition of Done: full standard in [CONTRIBUTING.md](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto exact `origin/develop@f6166101e66ada5a38fb6c3ea825efd1aa28be80` with zero conflicts.
- [x] `bun install --frozen-lockfile --ignore-scripts` and exact-head root `bun run verify` completed successfully.
- [x] Exact-head staging Telegram timing and routing proof completed on the candidate Worker and gateway.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/slopdotcash@332dc64deec632ac7746f237f0f30d4aad6050d5:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts; ahead 1 / behind 0.
- [x] Candidate head: `96f6fcd0c800e9ee33188070e67a7d74d22b04b8`.
- [x] Root `bun run verify`: PASS, including 351/351 Turbo tasks and the final 8,220-file anti-larp scan with 0 focused tests / 0 orphaned skips.

# Risks

Medium. This changes the trusted Telegram personal-delivery account-resolution hot path and returns a pre-resolved Dedicated target. It fails closed to the existing sender-locked writer on every missing, stale, conflicting, or ambiguous state. There is no schema, cache, authentication, billing, provider, model, or cutover mutation.

# Background

Established Telegram turns currently repeat the entire first-contact transaction and a second Dedicated-target query. A pinned warm staging turn spent about 2.083 seconds before entering the Shared conversation Durable Object, while Telegram egress took 286ms.

## What does this PR do?

- Resolves a fully converged Telegram identity, canonical user, active organization, and bounded latest personal Dedicated candidate in one indexed read.
- Preserves the existing sender advisory lock and convergence writer as the only creation/repair path.
- Consolidates the two server-owned Dedicated cutover markers into one authority predicate.
- Avoids the second Dedicated query on the normal Telegram path.
- Emits `Server-Timing` for account plus Shared/Dedicated work.
- Records gateway cloud time, raw Server-Timing, egress time, and total time without message text or secrets.

## What kind of change is this?

Performance improvement with fail-closed correctness hardening and observability.

# Documentation changes needed?

No user-facing documentation change. The production comments and issue describe the one-query invariant and fallback boundary.

# Testing

## Where should a reviewer start?

1. `packages/cloud/shared/src/db/repositories/personal-shared-deliveries.ts`
2. `packages/cloud/shared/src/lib/services/eliza-app/user-service.ts`
3. `packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts`
4. `packages/cloud/services/gateway-webhook/src/webhook-handler.ts`

## Detailed testing steps

All commands ran on exact head `96f6fcd0c800e9ee33188070e67a7d74d22b04b8` after the final rebase.

- Real isolated PGlite: 7/7, 33 assertions. Proves one-statement repeat, no `updated_at` rewrite, exact Dedicated authority, ambiguous-target exact fallback, stale/profile repair, cross-tenant conflict rollback, and concurrent first-contact convergence at $0.
- Personal Shared route: 19/19, 86 assertions.
- Gateway webhook E2E: 15/15, 81 assertions.
- Personal-message delivery: 2/2 PASS.
- Upgrade-tier/cutover authority: 16/16, 155 assertions.
- `packages/cloud/shared` typecheck: PASS.
- `packages/cloud/api` typecheck plus production Wrangler dry bundle: PASS, 25,668.93 KiB / 6,227.88 KiB gzip.
- Gateway typecheck and production build: PASS.
- Biome exact eight paths: PASS.
- `git diff --check`: PASS.
- Root `bun run verify`: PASS (351/351 Turbo tasks; 8,220 test files scanned; 0 focused tests; 0 orphaned skips).
- Manual diff-scoped error-policy check: no added empty catch and no added server `console.*`.
- Exact-head staging Worker deployment `8c19e508-ad1e-4170-8c33-a9256be17b64` serves commit `96f6fcd0c800e9ee33188070e67a7d74d22b04b8` at version `fe7b477a-671f-4d49-b1d0-fe4daf5c92de` (100%).
- Exact-head staging gateway deployment `383c5951-2021-424a-931e-605abff0f7a5` is SUCCESS/RUNNING at image `sha256:88b3e406c513f94327071d8f64c388d0bc1da143688336a816c9876171b6b861`.
- Four fresh Telegram turns produced four unique completions and one reply each. Account timing was 96, 152, 134, and 117ms (mean 124.8ms); Telegram egress was 281, 283, 292, and 288ms (mean 286ms).
- All four responses routed to Shared, proven by the exact `shared;dur=...` Server-Timing stage; no Dedicated stage appeared. The same window has 0 gateway errors, warnings, retries, duplicate markers, or uncertain-egress markers.
- Telegram Bot API after the probes: canonical staging webhook URL and `pending_update_count=0`. The retained `last_error` field is historical and predates this candidate window.

# Evidence Gate

<!-- evidence-head:96f6fcd0c800e9ee33188070e67a7d74d22b04b8 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered frontend source changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered frontend source changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered frontend source changed.
<!-- evidence-row:backend-logs -->
- [x] [20111-pr20111-backend-logs.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20111-pr20111-backend-logs.json)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or browser-network surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, planner, action, provider, or model-routing behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [20111-pr20111-domain-artifacts.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20111-pr20111-domain-artifacts.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Backend + domain evidence

The exact-head real-DB suite proves the one-statement/no-write repeat invariant, stale-profile fallback, and tenant safety. The same exact head was then deployed to the staging Worker and gateway and exercised through the real Telegram bot.

| Telegram message | account | Shared | cloud response body | Telegram egress | total |
| --- | ---: | ---: | ---: | ---: | ---: |
| `532027183` | 96ms | 1,126ms | 15,271ms | 281ms | 15,553ms |
| `532027184` | 152ms | 940ms | 5,545ms | 283ms | 5,828ms |
| `532027185` | 134ms | 2,478ms | 7,131ms | 292ms | 7,423ms |
| `532027186` | 117ms | 2,225ms | 7,360ms | 288ms | 7,648ms |

The former warm trace spent about 2.083 seconds in pre-DO account/target setup. The changed account boundary is now 96–152ms on four managed turns, while Telegram egress remains about 286ms. Every response carried `shared;dur`, proving the expected rowless Shared route; the local real-DB proof supplies the exact one-query/no-write invariant that managed staging cannot expose without privileged database access.

This does **not** claim that full reply latency is solved. The managed cloud body still varied from 5.545 to 15.271 seconds. Exact Worker tail on the final turn bounded the stateless route at 5.840s, Shared conversation DO at 1.923s, and admission gate DO at 0.634s. Provider/runtime timing is intentionally a separate follow-up (#20127); this PR removes only the repeated account/database work.

## Screenshots and video

N/A - no visual/UI surface changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- End-to-end Telegram latency still varies (5.828–15.553s in this proof). This PR removes the repeated account/database work; #20127 adds provider/runtime attribution for the remaining time.
- The managed Worker suppresses info logs unless `VERBOSE_LOGGING=true`; therefore the exact `single-query-repeat` label is proven by the production-equivalent PGlite query audit, while managed routing is proven by Server-Timing.
- The documented root `audit:error-policy-ratchet` script is absent on this exact base; the diff-scoped equivalent found no added empty catch or server console call.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/slopdotcash@332dc64deec632ac7746f237f0f30d4aad6050d5:skills/contribute-to-eliza
Attribution status: self-reported
— [root-shared-runtime]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/slopdotcash@332dc64deec632ac7746f237f0f30d4aad6050d5:skills/contribute-to-eliza"} -->



