### PR TITLE
fix(core): owner-item deletes get a deterministic candidate instead of a fictional surface refusal

### DIFF
--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -1240,4 +1240,71 @@ describe("batch-1 matrix fixes: budget noun + scheduled-item admin (F3/F5)", () 
 			).kind,
 		).not.toBe("owner-scheduled-admin");
 	});
+
+	it("owner-item deletes hint the owning umbrella (F31, tj-f02205ae366226)", () => {
+		const reminders = { name: "OWNER_REMINDERS", similes: [], tags: [] };
+		const alarms = { name: "OWNER_ALARMS", similes: [], tags: [] };
+		const todos = { name: "OWNER_TODOS", similes: [], tags: [] };
+		const appAction = {
+			name: "APP",
+			similes: ["LAUNCH_APP"],
+			tags: ["app", "apps"],
+		};
+		const registered = [viewsAction, appAction, reminders, alarms, todos];
+		// The live F31 shapes: exact-name deletes that Stage-1 classified as
+		// simple chat, producing a fictional "can't delete reminders here — dm
+		// me" surface refusal with no tool exposed.
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				registered,
+				"delete the reminder named water the ficus",
+			),
+		).toEqual({ names: ["OWNER_REMINDERS"], kind: "owner-scheduled-admin" });
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				registered,
+				"delete both water the ficus reminders",
+			),
+		).toEqual({ names: ["OWNER_REMINDERS"], kind: "owner-scheduled-admin" });
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				registered,
+				"cancel the call marco reminder",
+			),
+		).toEqual({ names: ["OWNER_REMINDERS"], kind: "owner-scheduled-admin" });
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				registered,
+				"remove my dentist alarm",
+			),
+		).toEqual({ names: ["OWNER_ALARMS"], kind: "owner-scheduled-admin" });
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				registered,
+				"delete the todo about sandpaper",
+			),
+		).toEqual({ names: ["OWNER_TODOS"], kind: "owner-scheduled-admin" });
+		// Delete verb with no owner surface registered: yield nothing, never
+		// the view/app overlap.
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, appAction],
+				"delete the reminder named water the ficus",
+			),
+		).toEqual({ names: [], kind: null });
+		// Surface-noun asks stay with navigation, and explanation requests stay
+		// chat.
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				registered,
+				"close the reminders tab",
+			).kind,
+		).not.toBe("owner-scheduled-admin");
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				registered,
+				"how do i delete a reminder",
+			).kind,
+		).not.toBe("owner-scheduled-admin");
+	});
 });

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -674,6 +674,48 @@ function findScheduledAdminActionName(
 }
 
 /**
+ * Detects a destructive owner-item operation ("delete the reminder named
+ * water the ficus", "cancel the call marco reminder", "remove my dentist
+ * alarm") and names the owning domain. Live regression (matrix F31,
+ * tj-f02205ae366226 family): Stage-1 classified exact-name reminder deletes
+ * as ["simple"] with no candidates, the turn planned with HANDLE_RESPONSE
+ * only, and the model composed a fictional surface refusal ("can't delete
+ * reminders here — dm me") that then self-reinforced through conversation
+ * history. Deletes are owner mutations on existing data — the same
+ * owner-domain-evidence rule as the other mutation legs — resolved
+ * per-domain through the same preference lists the read leg uses.
+ */
+function detectOwnerItemDeleteDomain(text: string): OwnerLifeReadDomain | null {
+	const normalized = text.toLowerCase().replace(/\s+/gu, " ").trim();
+	if (!normalized || looksLikeActionExplanationRequest(normalized)) {
+		return null;
+	}
+	// Surface-noun asks stay with the navigation legs ("close the reminders
+	// tab" is view work, not a data mutation).
+	if (
+		/\b(?:view|views|page|screen|tab|panel|window|ui|dashboard|app)\b/iu.test(
+			normalized,
+		)
+	) {
+		return null;
+	}
+	if (
+		!/\b(?:delete|remove|cancel|clear|get\s+rid\s+of|stop\s+tracking)\b/iu.test(
+			normalized,
+		)
+	) {
+		return null;
+	}
+	for (const [domain, noun] of OWNER_READ_DOMAIN_NOUNS) {
+		// Finance records have no named-item delete surface; "clear my
+		// spending" is not an item deletion.
+		if (domain === "finances") continue;
+		if (noun.test(normalized)) return domain;
+	}
+	return null;
+}
+
+/**
  * Owner-life domains with a possessive read shape. Each maps to its reader
  * surface in preference order: the personal-assistant umbrella first, then the
  * standalone domain plugin's action names, so lean stacks (one todo owner per
@@ -919,6 +961,22 @@ export function inferDirectCurrentRequestCandidateInference(
 		const scheduledAdminAction = findScheduledAdminActionName(actions);
 		if (scheduledAdminAction) {
 			return { names: [scheduledAdminAction], kind: "owner-scheduled-admin" };
+		}
+		return EMPTY_DIRECT_CANDIDATE_INFERENCE;
+	}
+	// Destructive owner-item operations are owner mutations on existing data.
+	// Stage-1 drift can classify an exact-name delete as simple chat (matrix
+	// F31); the deterministic candidate keeps the turn on the planning path
+	// where the owning umbrella can act, ask, or fail closed on its own
+	// surface. Same no-candidate-on-missing-surface rule as the legs above.
+	const ownerDeleteDomain = detectOwnerItemDeleteDomain(messageText);
+	if (ownerDeleteDomain) {
+		const ownerDeleteAction = findOwnerLifeReadActionName(
+			actions,
+			ownerDeleteDomain,
+		);
+		if (ownerDeleteAction) {
+			return { names: [ownerDeleteAction], kind: "owner-scheduled-admin" };
 		}
 		return EMPTY_DIRECT_CANDIDATE_INFERENCE;
 	}


### PR DESCRIPTION
## Problem

Live finding (F31, nubilio matrix batch 2, regression-grade): exact-name reminder deletes on the api room refuse with "can't delete reminders here — dm me" while creates/updates/reads work. Watchtower's probe cleanup is blocked on stranded reminders.

Ground truth from the live trajectories (tj-f02205ae366226 family): Stage-1 classified "delete the reminder named water the ficus" as `contexts: ["simple"]` with **no candidate actions**, so the planner ran with `HANDLE_RESPONSE` only — no owner tool was ever exposed — and the model composed a fictional surface refusal, which then self-reinforced through conversation history (every later delete refusal quotes the earlier ones). Pre-drift trajectories show the same phrasing getting `["tasks"]` + `candidateActions: ["OWNER_REMINDERS"]` and succeeding. The "dm me" story is a hallucinated explanation, not a real gate: `ChannelType.API` is a DM-class always-respond surface, and `OWNER_OPERATION_VALIDATE` passes there.

The structural gap: `detectOwnerLifeReadDomain` deliberately blocks mutation verbs, deferring to "the write detectors above" — but write detectors exist only for goal writes, routine writes, and the snooze/reschedule admin family. Item **deletes** had no deterministic leg and relied entirely on Stage-1 classification, which drifted.

## Fix

A new owner-item-delete leg in `direct-action-heuristics.ts`, mirroring the merged snooze/reschedule leg (#20064) and the read leg's per-domain resolution: delete/remove/cancel/clear phrasing over an owner-item noun (reminders, alarms, todos, goals, routines) yields the owning umbrella as a deterministic candidate (`kind: "owner-scheduled-admin"`), which the existing SIMPLE-escalation valve promotes onto the planning path. Guards match the sibling legs: surface nouns stay with navigation, explanation requests stay chat, finances excluded, and with no owner surface registered the turn yields no candidate rather than falling through to the view/app overlap.

## Evidence

| Row | Result |
| --- | --- |
| Unit tests | `direct-action-heuristics.test.ts` 63/63 — new F31 block covers the three live refusal phrasings, alarm/todo domains, no-surface, surface-noun, and explanation negatives |
| Regression | full `services/message` dir: 594/594 (551 passed + 43 env-suite passed after core build); core `tsc --noEmit` clean; biome clean |
| Ground truth | Broken vs working trajectory comparison inline above (tj ids); refusal self-reinforcement documented in the F31 receipt at HQ #18309 |
| Live re-prove | Queued with the fleet's live driver: rerun the exact stranded-reminder deletes on the api room (unblocks watchtower's cleanup debt) |

Part of the batch-2 disposition arc (HQ #18309). F27 (WORK_THREAD planner-refusal on api_private) shares the classification-drift class and stays open — this PR fixes the delete family specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
