### PR TITLE
fix(ui): propagate first-run join cancellation

### DIFF
--- a/packages/ui/src/first-run/first-run-finish.ts
+++ b/packages/ui/src/first-run/first-run-finish.ts
@@ -821,6 +821,7 @@ export async function listOrAutoProvisionCloudAgent(
     },
     cloudApiBase,
     authToken,
+    signal: ports.signal,
     onProgress: (status, detail) => ports.onStatus?.(detail ?? status, status),
   });
   addAgentProfile({

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -1519,10 +1519,14 @@ describe("cloud-only onboarding (runtime chooser off — the production default)
       cloudApiBase: "https://eliza.app",
     });
     // #19511: the bind takes no agent inventory; the account's one personal
-    // Eliza is resolved server-side, so the call shape stays token + base.
+    // Eliza is resolved server-side. The signal lets a bounded first-run
+    // attempt cancel this request without changing that server-side policy.
     expect(
       Object.keys(mocks.client.getPersonalSharedEliza.mock.calls[0][0]).sort(),
-    ).toEqual(["authToken", "cloudApiBase"]);
+    ).toEqual(["authToken", "cloudApiBase", "signal"]);
+    expect(
+      mocks.client.getPersonalSharedEliza.mock.calls[0][0]?.signal,
+    ).toBeInstanceOf(AbortSignal);
     unmount();
   });
 
@@ -2313,6 +2317,72 @@ describe("bounded cloud sign-in wait (#19255)", () => {
       ),
     ).toBe(false);
     localStorage.removeItem("steward_session_token");
+    unmount();
+  });
+
+  it("an attempt aborted during personal-Eliza resolution cannot persist or complete after a retry starts", async () => {
+    vi.useFakeTimers();
+    localStorage.removeItem("eliza:enable-runtime-chooser");
+    localStorage.removeItem("steward_session_token");
+    const personalEliza = {
+      personalElizaId: PERSONAL_ELIZA_ID,
+      agentId: PERSONAL_ELIZA_ID,
+      activeAgentId: PERSONAL_ELIZA_ID,
+      agentName: "Eliza Cloud",
+      apiBase: PERSONAL_ELIZA_API_BASE,
+      runtime: "shared" as const,
+    };
+    const resolveJoin: Array<(value: typeof personalEliza) => void> = [];
+    mocks.client.getPersonalSharedEliza.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveJoin.push(resolve);
+        }),
+    );
+    const spies = seedAppStore({ elizaCloudConnected: false });
+    const { turn, unmount } = renderConductor();
+    await act(async () => vi.advanceTimersByTimeAsync(50));
+
+    // Start A as a visible, already-authenticated entry so its unbounded wait
+    // is the personal-Eliza lookup itself rather than interactive OAuth.
+    localStorage.setItem("steward_session_token", "cloud-token");
+    expect(tryHandleFirstRunAction("__first_run__:runtime:cloud")).toBe(true);
+    await act(async () => vi.advanceTimersByTimeAsync(50));
+    expect(mocks.client.getPersonalSharedEliza).toHaveBeenCalledTimes(1);
+    const signalA = mocks.client.getPersonalSharedEliza.mock.calls[0]?.[0]
+      ?.signal as AbortSignal | undefined;
+    expect(signalA).toBeInstanceOf(AbortSignal);
+    expect(signalA?.aborted).toBe(false);
+
+    // The deadline abandons A and transfers ownership to a retry B.
+    await act(async () => vi.advanceTimersByTimeAsync(90_000));
+    expect(signalA?.aborted).toBe(true);
+    expect(turn("first-run:cloud-login-waiting")?.text).toContain(
+      "didn't finish",
+    );
+    expect(tryHandleFirstRunAction("__first_run__:runtime:cloud")).toBe(true);
+    await act(async () => vi.advanceTimersByTimeAsync(50));
+    expect(mocks.client.getPersonalSharedEliza).toHaveBeenCalledTimes(2);
+
+    // A's network boundary ignores cancellation and resolves late. The
+    // post-await abort checkpoint must stop every persistence/completion side
+    // effect while B remains the current attempt.
+    await act(async () => {
+      resolveJoin[0]?.(personalEliza);
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    expect(spies.completeFirstRun).not.toHaveBeenCalled();
+    expect(localStorage.getItem("elizaos:active-server")).toBeNull();
+
+    // B can still settle normally and is the only attempt allowed to commit.
+    await act(async () => {
+      resolveJoin[1]?.(personalEliza);
+      await vi.advanceTimersByTimeAsync(50);
+    });
+    expect(spies.completeFirstRun).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem("elizaos:active-server")).toContain(
+      PERSONAL_ELIZA_ID,
+    );
     unmount();
   });
 


### PR DESCRIPTION
# Relates to

Relates to #19255. This draft fixes the remaining in-repository cancellation race only; it does **not** close the issue because the Steward GitHub verified-email policy and raw-JSON callback/error-page acceptance gaps still have no durable owner or routed issue.

Root verification is currently blocked by the unrelated current-`develop` Core formatter regression in the exact file owned by #20050; details and baseline reproduction are below. This PR must remain draft until root verification is green.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop` and is rebased onto current `origin/develop` (`8b694f6e16fb400997954cb65ef412ce53b7e65f`) with zero conflicts.
- [x] Pinned `bun install --frozen-lockfile` and `bun run verify` were run after sync; the exact unrelated root blocker is recorded below.
- [x] Focused behavior, type, lint, full app capture, and OCR evidence are recorded below.
- [ ] Ready for review/merge — blocked until root `bun run verify` passes.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@8b694f6e16fb400997954cb65ef412ce53b7e65f:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Fresh open-PR and path-overlap checks found no owner touching `first-run-finish.ts`, the conductor regression, or `runJoinFlow`.
- [x] Rebased onto `origin/develop@8b694f6e16fb400997954cb65ef412ce53b7e65f`; zero conflicts.
- [x] No app/UI content changed upstream between the successful audit base and the final rebase.
- [x] Root verify outcome and clean-baseline reproduction are recorded under **Known gaps / failures**.

# Risks

Low and narrowly scoped. The conductor already owns an `AbortController`, and `runJoinFlow` already accepts an `AbortSignal` with pre/post-network abort checkpoints. This patch supplies the missing `signal: ports.signal` handoff. The main risk is cancellation ordering, covered by a real conductor race that resolves an abandoned request after retry ownership transfers.

# Background

## What does this PR do?

The 90-second first-run deadline could abandon attempt A and allow retry B, but `listOrAutoProvisionCloudAgent` did not pass A's signal into `runJoinFlow`. If the personal-Eliza lookup resolved late, A could still persist the active server and complete onboarding underneath B.

The change:

1. Passes the conductor's `AbortSignal` into `runJoinFlow`.
2. Adds a deterministic conductor regression that holds A inside personal-Eliza resolution, expires A, starts B, resolves A late, and proves A commits no persistence/completion side effects while B can still commit exactly once.
3. Updates the existing exact request-shape assertion to require the signal.

No route, DTO, CSS, component layout, or rendered pixel changes.

# Testing

Pinned runtime: Bun 1.3.14 and Node 24.15.0.

- `bun install --frozen-lockfile` — exit 0; official 971 MiB artifact bundle verified and synced.
- Focused three-file UI suite (`use-first-run-conductor`, deadline helper, `runJoinFlow`) — exit 0; 75/75 tests passed.
- New race regression before production fix — exit 1 as intended because the request signal was `undefined`.
- Same race regression after fix — exit 0.
- `bun run --cwd packages/ui typecheck` — exit 0.
- `bun run --cwd packages/ui lint:check` — exit 0; eight pre-existing `document.cookie` warnings outside the changed files.
- `bun run --cwd packages/app audit:app` — final retry exit 0:
  - Capture: 219/219 Playwright cases passed.
  - DOM verdicts: 203 good, 13 needs-eyeball, 0 needs-work, 0 broken; zero minimalism, hover, and density failures.
  - OCR: 200 verified, 16 needs-eyeball, 0 broken, 0 regressions.
  - No needs-eyeball entry intersects first-run, login, cloud auth, or the relevant chat surface. The chat desktop, mobile portrait/landscape, and iPad captures are all `good` and were manually inspected.
- `bun run verify` — exit 1 at the unrelated inherited `@elizaos/core#lint:check` formatter error described below.

# Evidence Gate

<!-- evidence-head:33fdd45dda3eb39d773bff6bc55eee97e31facc4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - behavior-only cancellation propagation; no rendered pixels changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no visual delta. The mandatory all-view app audit passed and relevant chat captures were manually inspected.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - the deterministic late-network race is not human-timing reproducible and produces no new visual state; the conductor regression exercises the complete ownership transition.
<!-- evidence-row:backend-logs -->
- [x] N/A - client first-run orchestration only; no backend implementation changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser-console or network-log artifact applies because the patch changes no rendered or transport surface; focused Vitest, typecheck, lint, Playwright, DOM, and OCR results are recorded in Testing.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model, planner, provider, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no durable domain artifact is produced; the regression directly asserts active-server and first-run persistence for the abandoned and retry attempts.
<!-- evidence-row:ocr-review -->
- [x] Packaged OCR reviewed 216 views: 200 verified, 16 explicit semantic exemptions, 0 broken, 0 regressions.

# Known gaps / failures

## Root verify baseline blocker

`bun run verify` reached the 141-package typecheck/lint phase and exited 1 at `@elizaos/core#lint:check`. The sole error is formatter drift in `packages/core/src/runtime/__tests__/action-retrieval.test.ts` around line 1002 and EOF, the exact file tracked/owned by #20050. Two other Core diagnostics were informational and did not fail the check.

A clean detached worktree at current `origin/develop@8b694f6e16fb400997954cb65ef412ce53b7e65f` reproduces the identical error:

```text
$ biome check packages/core/src/runtime/__tests__/action-retrieval.test.ts
... action-retrieval.test.ts format ...
Formatter would wrap the long description at ~1002 and normalize EOF.
Checked 1 file ... Found 1 error.
exit 1
```

This PR does not edit Core. Root verification did not reach its later sequential audit commands after Turbo stopped on this baseline failure, so this draft is intentionally not ready.

## Remaining #19255 acceptance gaps

This patch does not claim ownership of the separate deployed Steward defects:

- GitHub OAuth verified/private email sourcing and policy.
- Raw-JSON callback failure page and explicit recovery routing.

No durable issue/project item or acknowledged owner was found for those exact gaps during the final overlap audit. #19255 should remain open until they are routed and verified.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@8b694f6e16fb400997954cb65ef412ce53b7e65f:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [issue-19255]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@8b694f6e16fb400997954cb65ef412ce53b7e65f:packages/skills/skills/contribute-to-eliza"} -->

