### PR TITLE
fix(core): repair six develop unit reds — never-silent carve-outs, stage-1 assert drift, FORM fixture

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -1283,7 +1283,10 @@ describe("runV5MessageRuntimeStage1", () => {
 			}
 		).messages?.[0];
 		expect(String(systemMessage?.content ?? "")).toContain(
-			"goals -> tasks + OWNER_GOALS, never work threads",
+			"goals -> tasks + OWNER_GOALS",
+		);
+		expect(String(systemMessage?.content ?? "")).toContain(
+			"never work threads and never VIEWS",
 		);
 	});
 
@@ -1457,8 +1460,9 @@ describe("runV5MessageRuntimeStage1", () => {
 		// Compactness ceiling for the DM Stage-1 prompt. Any leaked context
 		// description (~2,500+ chars each) blows far past this; deliberate
 		// template rules only nudge it, so keep the ceiling tight (currently
-		// ~3.8k rendered).
-		expect(systemContent.length).toBeLessThan(3_850);
+		// ~4.1k rendered after the #19863 owner-life routing floor named every
+		// umbrella).
+		expect(systemContent.length).toBeLessThan(4_300);
 	});
 
 	it("direct-channel prompt grounds capability denials in executable actions and requires fresh tool retries", async () => {

--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -665,7 +665,10 @@ describe("renderInteractionsAsPlainText", () => {
 			title: "Configure account [CONFIG:@elizaos/plugin-gmail]",
 			fields: [{ name: "account", type: "text" }],
 		});
-		const rendered = renderInteractionsAsPlainText(`[FORM]${form}[/FORM]`);
+		// The documented block form requires newlines around the JSON body
+		// (parse.ts header; the malformed-marker containment regex deliberately
+		// rejects inline bodies).
+		const rendered = renderInteractionsAsPlainText(`[FORM]\n${form}\n[/FORM]`);
 		expect(rendered.hadBlocks).toBe(true);
 		expect(rendered.text).toBe(`Configure account\n\n${FORM_FREE_TEXT_INVITE}`);
 	});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -9133,10 +9133,17 @@ export async function runV5MessageRuntimeStage1(args: {
 		// produced a correct answer and the user got silence. Recover with the
 		// best grounded text available and name the failure in the log so the
 		// upstream emptying path is diagnosable instead of invisible.
+		// Two states are NOT recoverable silence: a synchronously delivered
+		// media deliverable is a delivery even though it never enters the
+		// visible-TEXT set, and deliberate silence (suppressPlannerReply
+		// terminals, ambient IGNORE after tool work) is a contract this
+		// invariant must honor, not a failure for it to "fix" into filler.
 		if (
 			!shouldSendPlannedText &&
 			!earlyReplySent &&
+			!suppressesPlannerReply &&
 			deliveredVisibleTexts.size === 0 &&
+			deliveredMediaUrls.length === 0 &&
 			actionResults.length > 0
 		) {
 			const recoveredText =


### PR DESCRIPTION
## Problem

develop's unit lane carries 7 red tests that have been invisible under the CI cancel storm (zero successful `CI` runs in the last 100 — 52 cancelled by push-concurrency waves, 13 failures). Claimed at HQ #18309 (discussioncomment-18031964). This PR repairs six at their real causes; the seventh (guarded-stream split-equivalence) is a redaction-pattern collision from `c1afd4bd7b` and ships separately for security review.

## Fixes

**Never-silent recovery collateral (mine, #20083 — 3 tests).** The recovery guard treated "zero visible TEXTS" as "zero deliveries", so it resurrected stage-1 acks over a synchronously delivered media deliverable (`message-answer-clobber-rescue`) and overrode deliberate-silence contracts — suppressPlannerReply terminals (`message-runtime-stage1`) and ambient IGNORE after tool work (`planner-happy-path`). The guard now also requires `deliveredMediaUrls` empty and `!suppressesPlannerReply`, both computed upstream. The F24/F12 recovery behavior on genuinely-silent RESPOND turns is unchanged.

**Stale stage-1 asserts (#19863 template expansion — 2 tests).** The routing floor deliberately expanded the owner-life rule (the sibling tier test asserts the new text and passes) and moved the DM prompt from ~3.8k to ~4.1k rendered: the short-form substring assert and the 3,850-char ceiling were never updated. Asserts now track the shipped template (ceiling 4,300 with the same leak-detection intent — a single leaked context description is ~2,500+ chars).

**Born-broken FORM fixture (#20003 — 1 test).** The test asserted an inline `[FORM]{json}[/FORM]` body; the documented block format requires newlines and the malformed-marker containment regex (`efb3a9d8c3`, a day older than the test) deliberately rejects inline bodies. Fixture updated to the documented shape; the marker-stripping behavior under test is unchanged and covered.

## Evidence

| Row | Result |
| --- | --- |
| Before | 7 failed on clean `origin/develop` (verified on an untouched baseline branch, identical set) |
| After | `src/__tests__` + `src/messaging/interactions` + `src/services/message`: 1297 passed / 2 skipped / 0 failed |
| Typecheck/format | core `tsc --noEmit` clean; biome clean |
| Remaining red | `guarded-stream.test.ts` split-equivalence — root cause named at HQ (auth-param lookahead in `c1afd4bd7b` false-fires on token68 `==` padding, buffer vs stream disagree); flagged for gauss/shaw, fix PR to follow |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
