### PR TITLE
fix(core): auth-param redaction lookahead must not fire on token68 padding

### DIFF
--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -156,6 +156,17 @@ describe("redactSensitiveText (pattern detection)", () => {
 		expect(output).not.toContain(response);
 	});
 
+	it("masks quoted Digest auth params with RFC boundary whitespace", () => {
+		const username = ["private", "-user"].join("");
+		const response = ["6629fae49393", "a05397450978507c4ef1"].join("");
+		const input = `Authorization: Digest username = "${username}", realm = "restricted", response = "${response}"`;
+		const output = redactSensitiveText(input);
+		expect(output).toContain("Authorization: Digest ");
+		expect(output).not.toContain(username);
+		expect(output).not.toContain("restricted");
+		expect(output).not.toContain(response);
+	});
+
 	it("does not rewrite invalid header-shaped prose", () => {
 		for (const line of [
 			"Authorization: required for this endpoint",

--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -156,6 +156,33 @@ describe("redactSensitiveText (pattern detection)", () => {
 		expect(output).not.toContain(response);
 	});
 
+	it("masks unquoted Digest auth params with RFC boundary whitespace", () => {
+		const username = ["private", "-user"].join("");
+		const response = ["6629fae49393", "a05397450978507c4ef1"].join("");
+		const input = `Authorization: Digest username = ${username}, realm = restricted, response = ${response}`;
+		const output = redactSensitiveText(input);
+		expect(output).toContain("Authorization: Digest ");
+		expect(output).not.toContain(username);
+		expect(output).not.toContain("restricted");
+		expect(output).not.toContain(response);
+	});
+
+	it("keeps token68 padding out of the auth-param branch for both padding widths", () => {
+		// One- and two-"=" padded token68 credentials followed by prose: the
+		// auth-param branch must not consume the prose to end-of-line (that
+		// divergence is what broke whole-buffer vs guarded-stream equivalence).
+		// Value-exact masking of the token itself is owned by the secret-swap
+		// session in the streaming path, not this pattern table.
+		const doublePad = ["dXNlcjpwYXNz", "d29yZDEyMw=="].join("");
+		const singlePad = ["dXNlcjpwYXNzd2", "9yZDEyMw="].join("");
+		for (const token of [doublePad, singlePad]) {
+			const output = redactSensitiveText(
+				`Header Authorization: Basic ${token} end of line.`,
+			);
+			expect(output).toContain(" end of line.");
+		}
+	});
+
 	it("masks quoted Digest auth params with RFC boundary whitespace", () => {
 		const username = ["private", "-user"].join("");
 		const response = ["6629fae49393", "a05397450978507c4ef1"].join("");

--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -167,6 +167,21 @@ describe("redactSensitiveText (pattern detection)", () => {
 		expect(output).not.toContain(response);
 	});
 
+	it("masks unquoted auth params with boundary whitespace only after equals", () => {
+		const username = ["private", "-user"].join("");
+		const response = ["6629fae49393", "a05397450978507c4ef1"].join("");
+		for (const input of [
+			`Authorization: Digest username= ${username}`,
+			`Authorization: Digest username= ${username}, realm= restricted, response= ${response}`,
+		]) {
+			const output = redactSensitiveText(input);
+			expect(output).toContain("Authorization: Digest ");
+			expect(output).not.toContain(username);
+			expect(output).not.toContain("restricted");
+			expect(output).not.toContain(response);
+		}
+	});
+
 	it("keeps token68 padding out of the auth-param branch for both padding widths", () => {
 		// One- and two-"=" padded token68 credentials followed by prose: the
 		// auth-param branch must not consume the prose to end-of-line (that

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -35,8 +35,13 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
 	// "Authorization: required for this endpoint" from being partially masked.
 	// Bearer keeps its floor-free rule for compatibility with short service
 	// values in env-style `*_AUTHORIZATION` output.
+	// The auth-param lookahead requires a value character after the "=": a
+	// token68 with "=" padding ("Basic dXNlcjpw...Mw==") otherwise satisfies
+	// the param shape and the rule consumes trailing prose to end-of-line,
+	// diverging from the streaming scanner's value-exact redaction
+	// (guarded-stream split-equivalence).
 	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*Bearer\s+([A-Za-z0-9._\-+=/~]+)`,
-	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z][A-Za-z0-9-]*)[ \t]+((?=[A-Za-z][A-Za-z0-9!#$%&'*+.^_|~-]*[ \t]*=)[^\r\n]+)(?=[\r\n]|$)`,
+	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z][A-Za-z0-9-]*)[ \t]+((?=[A-Za-z][A-Za-z0-9!#$%&'*+.^_|~-]*=[^=\s])[^\r\n]+)(?=[\r\n]|$)`,
 	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z][A-Za-z0-9-]*)[ \t]+([A-Za-z0-9._~+/\-]{8,}={0,})(?=[\r\n]|$)`,
 	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z0-9._~+/\-]{18,}={0,})(?=[\r\n]|$)`,
 	String.raw`\bBearer\s+([A-Za-z0-9._\-+=]{18,})\b`,

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -35,13 +35,18 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
 	// "Authorization: required for this endpoint" from being partially masked.
 	// Bearer keeps its floor-free rule for compatibility with short service
 	// values in env-style `*_AUTHORIZATION` output.
-	// The auth-param lookahead requires a value character after the "=": a
-	// token68 with "=" padding ("Basic dXNlcjpw...Mw==") otherwise satisfies
-	// the param shape and the rule consumes trailing prose to end-of-line,
-	// diverging from the streaming scanner's value-exact redaction
-	// (guarded-stream split-equivalence).
+	// The auth-param lookahead must accept RFC 9110 BWS around "=" for both
+	// quoted and unquoted values while never letting token68 "=" padding
+	// ("Basic dXNlcjpw...Mw==" or a single "=" before prose) enter the branch —
+	// otherwise the rule consumes trailing prose to end-of-line and diverges
+	// from the streaming scanner's value-exact redaction (guarded-stream
+	// split-equivalence). The structural distinguisher: auth-param BWS appears
+	// BEFORE the "=" (`name = value`), while padding is always glued to its
+	// token — so a glued "=" only accepts an immediate value char or a quoted
+	// value, and BWS'd values (quoted or unquoted) require whitespace before
+	// the "=" too.
 	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*Bearer\s+([A-Za-z0-9._\-+=/~]+)`,
-	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z][A-Za-z0-9-]*)[ \t]+((?=[A-Za-z][A-Za-z0-9!#$%&'*+.^_|~-]*[ \t]*=(?:[^=\s]|[ \t]+"))[^\r\n]+)(?=[\r\n]|$)`,
+	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z][A-Za-z0-9-]*)[ \t]+((?=[A-Za-z][A-Za-z0-9!#$%&'*+.^_|~-]*(?:=(?:[^=\s]|[ \t]+")|[ \t]+=[ \t]*[^=\s]))[^\r\n]+)(?=[\r\n]|$)`,
 	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z][A-Za-z0-9-]*)[ \t]+([A-Za-z0-9._~+/\-]{8,}={0,})(?=[\r\n]|$)`,
 	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z0-9._~+/\-]{18,}={0,})(?=[\r\n]|$)`,
 	String.raw`\bBearer\s+([A-Za-z0-9._\-+=]{18,})\b`,

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -41,7 +41,7 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
 	// diverging from the streaming scanner's value-exact redaction
 	// (guarded-stream split-equivalence).
 	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*Bearer\s+([A-Za-z0-9._\-+=/~]+)`,
-	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z][A-Za-z0-9-]*)[ \t]+((?=[A-Za-z][A-Za-z0-9!#$%&'*+.^_|~-]*=[^=\s])[^\r\n]+)(?=[\r\n]|$)`,
+	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z][A-Za-z0-9-]*)[ \t]+((?=[A-Za-z][A-Za-z0-9!#$%&'*+.^_|~-]*[ \t]*=(?:[^=\s]|[ \t]+"))[^\r\n]+)(?=[\r\n]|$)`,
 	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z][A-Za-z0-9-]*)[ \t]+([A-Za-z0-9._~+/\-]{8,}={0,})(?=[\r\n]|$)`,
 	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z0-9._~+/\-]{18,}={0,})(?=[\r\n]|$)`,
 	String.raw`\bBearer\s+([A-Za-z0-9._\-+=]{18,})\b`,

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -42,11 +42,12 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
 	// from the streaming scanner's value-exact redaction (guarded-stream
 	// split-equivalence). The structural distinguisher: auth-param BWS appears
 	// BEFORE the "=" (`name = value`), while padding is always glued to its
-	// token — so a glued "=" only accepts an immediate value char or a quoted
-	// value, and BWS'd values (quoted or unquoted) require whitespace before
-	// the "=" too.
+	// token — so a glued "=" accepts an immediate value char, a quoted value,
+	// or one complete unquoted token followed by a comma/end-of-line. That last
+	// boundary preserves valid `name= value` BWS without treating the first word
+	// of `token68= trailing prose` as a parameter value.
 	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*Bearer\s+([A-Za-z0-9._\-+=/~]+)`,
-	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z][A-Za-z0-9-]*)[ \t]+((?=[A-Za-z][A-Za-z0-9!#$%&'*+.^_|~-]*(?:=(?:[^=\s]|[ \t]+")|[ \t]+=[ \t]*[^=\s]))[^\r\n]+)(?=[\r\n]|$)`,
+	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z][A-Za-z0-9-]*)[ \t]+((?=[A-Za-z][A-Za-z0-9!#$%&'*+.^_|~-]*(?:=(?:[^=\s]|[ \t]+"|[ \t]+[^=\s,]+(?=[ \t]*(?:,|$)))|[ \t]+=[ \t]*[^=\s]))[^\r\n]+)(?=[\r\n]|$)`,
 	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z][A-Za-z0-9-]*)[ \t]+([A-Za-z0-9._~+/\-]{8,}={0,})(?=[\r\n]|$)`,
 	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z0-9._~+/\-]{18,}={0,})(?=[\r\n]|$)`,
 	String.raw`\bBearer\s+([A-Za-z0-9._\-+=]{18,})\b`,


### PR DESCRIPTION
## Problem

Whole-buffer and streaming redaction disagreed on padded HTTP token68 credentials followed by prose. The auth-param detector mistook the first base64 padding `=` for a parameter assignment and swallowed the remainder of the line.

## Fix

Require a real auth-param value after `=` so padded token68 falls through to value-exact scanning. Preserve RFC boundary whitespace before the assignment and before quoted values; otherwise valid Digest headers such as `username = "private"` could escape redaction.

Part of the develop-red repair claim (HQ #18309, discussioncomment-18031964); companion test-repair PR: #20126.

## Exact-head validation

- `bun test packages/core/src/security/redact.test.ts packages/core/src/security/guarded-stream.test.ts` — PASS, 44/44 tests and 31,731 assertions.
- Adversarial quoted Digest boundary-whitespace regression — PASS; username, realm, and response are absent after redaction.
- Basic token68 split-equivalence fixtures, including padded short and long credentials followed by prose — PASS.
- `bun run --cwd packages/core typecheck` — PASS.
- Targeted Biome and `git diff --check` — PASS.

## Contribution provenance

- AI assistance: yes — original implementation was declared as Claude Code-assisted by the contributor; the security review, RFC-whitespace correction, adversarial test, and validation were performed with `openai/gpt-5.6-sol`.
- Models used: `openai/gpt-5.6-sol`; original Claude model identifier was not exposed and is not inferred.
- Client / agent tooling: Codex Desktop (review/refactor); Claude Code (original contributor declaration).
- Contribution skill revision: `elizaOS/eliza@8b694f6e16fb400997954cb65ef412ce53b7e65f:packages/skills/skills/contribute-to-eliza`
- Attribution status: self-reported

<!-- evidence-head:a84dbc0d23d7c97bec6207628ef7a6b241ced169 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - security redaction has no rendered UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - security redaction has no rendered UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive surface; behavior is covered by deterministic split-equivalence tests.

<!-- evidence-row:backend-logs -->
- [x] [20128-.tmp-20128-validation.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20128-.tmp-20128-validation.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model path changed.

<!-- evidence-row:domain-artifacts -->
- [x] [20128-.tmp-20128-domain.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20128-.tmp-20128-domain.txt)

— [nubs-review-redaction]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@8b694f6e16fb400997954cb65ef412ce53b7e65f:packages/skills/skills/contribute-to-eliza"} -->


