### PR TITLE
fix(runtime): make model switching deterministic and race-safe

### DIFF
--- a/packages/agent/src/actions/self-api-loopback-auth.integration.test.ts
+++ b/packages/agent/src/actions/self-api-loopback-auth.integration.test.ts
@@ -144,8 +144,7 @@ async function startProtectedSelfApi(expectedToken: string): Promise<{
       }
       if (
         request.method === "POST" &&
-        (request.pathname === "/api/local-inference/routing/preferred" ||
-          request.pathname === "/api/local-inference/routing/policy")
+        request.pathname === "/api/local-inference/routing/text"
       ) {
         sendJson(res, 200, { ok: true });
         return;
@@ -312,10 +311,7 @@ describe("authenticated agent self-API callers", () => {
       "/api/config/reload",
       "/api/browser-bridge/companions",
       "/api/terminal/run",
-      "/api/local-inference/routing/preferred",
-      "/api/local-inference/routing/policy",
-      "/api/local-inference/routing/preferred",
-      "/api/local-inference/routing/policy",
+      "/api/local-inference/routing/text",
     ]);
     expect(
       authenticated.every(

--- a/packages/agent/src/api/runtime-switch-routes.test.ts
+++ b/packages/agent/src/api/runtime-switch-routes.test.ts
@@ -85,11 +85,7 @@ async function flushUntil(predicate: () => boolean, tries = 50): Promise<void> {
 describe("POST /api/runtime/model-switch", () => {
   it("switches to cloud: flips both text slots and broadcasts shell:model-switch", async () => {
     const loop = fakeLoopback({
-      "POST /api/local-inference/routing/preferred": {
-        status: 200,
-        body: { preferences: {} },
-      },
-      "POST /api/local-inference/routing/policy": {
+      "POST /api/local-inference/routing/text": {
         status: 200,
         body: { preferences: {} },
       },
@@ -103,13 +99,14 @@ describe("POST /api/runtime/model-switch", () => {
 
     expect(await handleRuntimeSwitchRoutes(ctx)).toBe(true);
 
-    const preferredCalls = loop.calls.filter(
-      (c) => c.path === "/api/local-inference/routing/preferred",
+    const routingCalls = loop.calls.filter(
+      (c) => c.path === "/api/local-inference/routing/text",
     );
-    expect(preferredCalls).toHaveLength(2); // TEXT_SMALL + TEXT_LARGE
-    expect(preferredCalls.every((c) => c.body?.provider === "elizacloud")).toBe(
-      true,
-    );
+    expect(routingCalls).toEqual([
+      expect.objectContaining({
+        body: { provider: "elizacloud", policy: "manual" },
+      }),
+    ]);
 
     expect(broadcastWs).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -130,11 +127,7 @@ describe("POST /api/runtime/model-switch", () => {
         status: 200,
         body: { assignments: { TEXT_LARGE: "eliza-1-2b" } },
       },
-      "POST /api/local-inference/routing/preferred": {
-        status: 200,
-        body: { preferences: {} },
-      },
-      "POST /api/local-inference/routing/policy": {
+      "POST /api/local-inference/routing/text": {
         status: 200,
         body: { preferences: {} },
       },
@@ -161,6 +154,12 @@ describe("POST /api/runtime/model-switch", () => {
     expect(
       loop.calls.some((c) => c.path === "/api/local-inference/downloads"),
     ).toBe(false);
+    expect(loop.calls.map((call) => call.path)).toEqual([
+      "/api/local-inference/assignments",
+      "/api/local-inference/installed",
+      "/api/local-inference/active",
+      "/api/local-inference/routing/text",
+    ]);
     expect(broadcastWs).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "shell:model-switch",
@@ -181,11 +180,7 @@ describe("POST /api/runtime/model-switch", () => {
         status: 200,
         body: { assignments: {} },
       },
-      "POST /api/local-inference/routing/preferred": {
-        status: 200,
-        body: { preferences: {} },
-      },
-      "POST /api/local-inference/routing/policy": {
+      "POST /api/local-inference/routing/text": {
         status: 200,
         body: { preferences: {} },
       },
@@ -212,6 +207,12 @@ describe("POST /api/runtime/model-switch", () => {
     expect(
       loop.calls.some((c) => c.path === "/api/local-inference/active"),
     ).toBe(false);
+    expect(loop.calls.map((call) => call.path)).toEqual([
+      "/api/local-inference/assignments",
+      "/api/local-inference/installed",
+      "/api/local-inference/downloads",
+      "/api/local-inference/routing/text",
+    ]);
     expect(broadcastWs).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "shell:model-switch",
@@ -268,7 +269,7 @@ describe("POST /api/runtime/model-switch", () => {
 
   it("returns 502 when a local-inference route fails", async () => {
     const loop = fakeLoopback({
-      "POST /api/local-inference/routing/preferred": {
+      "POST /api/local-inference/routing/text": {
         status: 500,
         body: { error: "disk full" },
       },
@@ -287,20 +288,56 @@ describe("POST /api/runtime/model-switch", () => {
     );
   });
 
+  it("does not publish local routing when activation admission fails", async () => {
+    const loop = fakeLoopback({
+      "POST /api/local-inference/assignments": {
+        status: 200,
+        body: { assignments: { TEXT_LARGE: "eliza-1-2b" } },
+      },
+      "GET /api/local-inference/installed": {
+        status: 200,
+        body: { models: [{ id: "eliza-1-2b" }] },
+      },
+      "POST /api/local-inference/active": {
+        status: 200,
+        body: { status: "error", error: "candidate model rejected" },
+      },
+    });
+    const { ctx, error } = makeCtx(
+      "POST",
+      "/api/runtime/model-switch",
+      { target: "local", model: "eliza-1-2b" },
+      loop.fetch,
+    );
+
+    expect(await handleRuntimeSwitchRoutes(ctx)).toBe(true);
+
+    expect(error).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.stringContaining("Model switch failed"),
+      502,
+    );
+    expect(
+      loop.calls.some(
+        (call) => call.path === "/api/local-inference/routing/text",
+      ),
+    ).toBe(false);
+  });
+
   it("serializes concurrent callers so text-slot routing cannot interleave", async () => {
     const calls: Array<{ path: string; body: Body | null }> = [];
-    let releaseFirstPreferred: (() => void) | undefined;
-    const firstPreferredBlocked = new Promise<void>((resolve) => {
-      releaseFirstPreferred = resolve;
+    let releaseFirstRouting: (() => void) | undefined;
+    const firstRoutingBlocked = new Promise<void>((resolve) => {
+      releaseFirstRouting = resolve;
     });
-    let preferredCount = 0;
+    let routingCount = 0;
     const fetchImpl = (async (url: string | URL, init?: RequestInit) => {
       const path = new URL(String(url)).pathname;
       const body = init?.body ? (JSON.parse(String(init.body)) as Body) : null;
       calls.push({ path, body });
-      if (path === "/api/local-inference/routing/preferred") {
-        preferredCount += 1;
-        if (preferredCount === 1) await firstPreferredBlocked;
+      if (path === "/api/local-inference/routing/text") {
+        routingCount += 1;
+        if (routingCount === 1) await firstRoutingBlocked;
       }
       if (path === "/api/local-inference/installed") {
         return Response.json({ models: [] });
@@ -327,27 +364,22 @@ describe("POST /api/runtime/model-switch", () => {
     );
 
     const cloudResult = handleRuntimeSwitchRoutes(cloud.ctx);
-    await flushUntil(() => preferredCount === 1);
+    await flushUntil(() => routingCount === 1);
     const localResult = handleRuntimeSwitchRoutes(local.ctx);
     await flushUntil(() => calls.length > 1, 10);
     expect(calls).toEqual([
       {
-        path: "/api/local-inference/routing/preferred",
-        body: { slot: "TEXT_SMALL", provider: "elizacloud" },
+        path: "/api/local-inference/routing/text",
+        body: { provider: "elizacloud", policy: "manual" },
       },
     ]);
 
-    releaseFirstPreferred?.();
+    releaseFirstRouting?.();
     await Promise.all([cloudResult, localResult]);
-    const preferredProviders = calls
-      .filter((call) => call.path === "/api/local-inference/routing/preferred")
+    const routedProviders = calls
+      .filter((call) => call.path === "/api/local-inference/routing/text")
       .map((call) => call.body?.provider);
-    expect(preferredProviders).toEqual([
-      "elizacloud",
-      "elizacloud",
-      "eliza-local-inference",
-      "eliza-local-inference",
-    ]);
+    expect(routedProviders).toEqual(["elizacloud", "eliza-local-inference"]);
     expect(cloud.json).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ ok: true, target: "cloud" }),

--- a/packages/agent/src/api/runtime-switch-routes.test.ts
+++ b/packages/agent/src/api/runtime-switch-routes.test.ts
@@ -286,6 +286,77 @@ describe("POST /api/runtime/model-switch", () => {
       502,
     );
   });
+
+  it("serializes concurrent callers so text-slot routing cannot interleave", async () => {
+    const calls: Array<{ path: string; body: Body | null }> = [];
+    let releaseFirstPreferred: (() => void) | undefined;
+    const firstPreferredBlocked = new Promise<void>((resolve) => {
+      releaseFirstPreferred = resolve;
+    });
+    let preferredCount = 0;
+    const fetchImpl = (async (url: string | URL, init?: RequestInit) => {
+      const path = new URL(String(url)).pathname;
+      const body = init?.body ? (JSON.parse(String(init.body)) as Body) : null;
+      calls.push({ path, body });
+      if (path === "/api/local-inference/routing/preferred") {
+        preferredCount += 1;
+        if (preferredCount === 1) await firstPreferredBlocked;
+      }
+      if (path === "/api/local-inference/installed") {
+        return Response.json({ models: [] });
+      }
+      if (path === "/api/local-inference/downloads") {
+        return Response.json(
+          { job: { modelId: "eliza-1-2b" } },
+          { status: 202 },
+        );
+      }
+      return Response.json({ ok: true });
+    }) as typeof fetch;
+    const cloud = makeCtx(
+      "POST",
+      "/api/runtime/model-switch",
+      { target: "cloud" },
+      fetchImpl,
+    );
+    const local = makeCtx(
+      "POST",
+      "/api/runtime/model-switch",
+      { target: "local", model: "eliza-1-2b" },
+      fetchImpl,
+    );
+
+    const cloudResult = handleRuntimeSwitchRoutes(cloud.ctx);
+    await flushUntil(() => preferredCount === 1);
+    const localResult = handleRuntimeSwitchRoutes(local.ctx);
+    await flushUntil(() => calls.length > 1, 10);
+    expect(calls).toEqual([
+      {
+        path: "/api/local-inference/routing/preferred",
+        body: { slot: "TEXT_SMALL", provider: "elizacloud" },
+      },
+    ]);
+
+    releaseFirstPreferred?.();
+    await Promise.all([cloudResult, localResult]);
+    const preferredProviders = calls
+      .filter((call) => call.path === "/api/local-inference/routing/preferred")
+      .map((call) => call.body?.provider);
+    expect(preferredProviders).toEqual([
+      "elizacloud",
+      "elizacloud",
+      "eliza-local-inference",
+      "eliza-local-inference",
+    ]);
+    expect(cloud.json).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ ok: true, target: "cloud" }),
+    );
+    expect(local.json).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ ok: true, target: "local" }),
+    );
+  });
 });
 
 describe("POST /api/runtime/agent-switch", () => {

--- a/packages/agent/src/api/runtime-switch-routes.ts
+++ b/packages/agent/src/api/runtime-switch-routes.ts
@@ -58,6 +58,23 @@ const LOCAL_TEXT_PROVIDER: ProviderId = "eliza-local-inference";
 const CLOUD_TEXT_PROVIDER: ProviderId = "elizacloud";
 
 const PREFIX = "/api/runtime";
+let modelSwitchOperation: Promise<void> | undefined;
+
+async function withModelSwitchLock<T>(operation: () => Promise<T>): Promise<T> {
+  const previous = modelSwitchOperation;
+  let release: () => void = () => undefined;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  modelSwitchOperation = current;
+  if (previous) await previous;
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (modelSwitchOperation === current) modelSwitchOperation = undefined;
+  }
+}
 
 /** How long the model-load call may take before the switch reports an error. */
 const ACTIVE_LOAD_TIMEOUT_MS = 120_000;
@@ -375,16 +392,17 @@ export async function handleRuntimeSwitchRoutes(
     }
 
     try {
-      const result =
+      const result = await withModelSwitchLock(async () =>
         target === "local"
-          ? await switchToLocal(
+          ? switchToLocal(
               fetchImpl,
               await resolveLocalModelId(fetchImpl, requestedModel),
             )
-          : await switchToCloud(
+          : switchToCloud(
               fetchImpl,
               requestedModel ?? DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
-            );
+            ),
+      );
 
       logger.info(
         {

--- a/packages/agent/src/api/runtime-switch-routes.ts
+++ b/packages/agent/src/api/runtime-switch-routes.ts
@@ -45,7 +45,6 @@ import {
   findCatalogModel,
   type ProviderId,
   readJsonBody,
-  TEXT_GENERATION_SLOTS,
 } from "@elizaos/shared";
 import { PendingRequestMap } from "./pending-request-map.ts";
 
@@ -192,27 +191,16 @@ async function applyTextRouting(
   fetchImpl: typeof fetch,
   provider: ProviderId,
 ): Promise<void> {
-  // `preferredProvider` is only honoured under the "manual" policy
-  // (plugin-local-inference routing-policy.ts), so both are set per text slot.
-  for (const slot of TEXT_GENERATION_SLOTS) {
-    const preferred = await loopbackJson(
-      fetchImpl,
-      "POST",
-      "/api/local-inference/routing/preferred",
-      { slot, provider },
-    );
-    if (!preferred.ok) {
-      throw new Error(`routing/preferred ${slot} returned ${preferred.status}`);
-    }
-    const policy = await loopbackJson(
-      fetchImpl,
-      "POST",
-      "/api/local-inference/routing/policy",
-      { slot, policy: "manual" },
-    );
-    if (!policy.ok) {
-      throw new Error(`routing/policy ${slot} returned ${policy.status}`);
-    }
+  // Provider and policy for both text slots become visible in one canonical
+  // routing transaction; no request can observe a half-switched model stack.
+  const routing = await loopbackJson(
+    fetchImpl,
+    "POST",
+    "/api/local-inference/routing/text",
+    { provider, policy: "manual" },
+  );
+  if (!routing.ok) {
+    throw new Error(`routing/text returned ${routing.status}`);
   }
 }
 
@@ -259,8 +247,6 @@ async function switchToLocal(
         : `assignments returned ${assignment.status}`,
     );
   }
-  await applyTextRouting(fetchImpl, LOCAL_TEXT_PROVIDER);
-
   if (await isModelInstalled(fetchImpl, modelId)) {
     const active = await loopbackJson(
       fetchImpl,
@@ -278,6 +264,14 @@ async function switchToLocal(
     }
     const status: ModelSwitchStatus =
       active.body?.status === "ready" ? "ready" : "loading";
+    if (active.body?.status !== "ready" && active.body?.status !== "loading") {
+      throw new Error(
+        typeof active.body?.error === "string"
+          ? active.body.error
+          : "active model did not enter a serving state",
+      );
+    }
+    await applyTextRouting(fetchImpl, LOCAL_TEXT_PROVIDER);
     return { ok: true, target: "local", model: modelId, displayName, status };
   }
 
@@ -294,6 +288,7 @@ async function switchToLocal(
         : `downloads returned ${download.status}`,
     );
   }
+  await applyTextRouting(fetchImpl, LOCAL_TEXT_PROVIDER);
   return {
     ok: true,
     target: "local",

--- a/packages/agent/src/services/remote-plugin-adapter.test.ts
+++ b/packages/agent/src/services/remote-plugin-adapter.test.ts
@@ -36,6 +36,7 @@ import {
   type PluginCallAppBridgeResult,
   type PluginOwnership,
   type RemotePluginModuleManifest,
+  runResponseHandlerEvaluators,
   type Service,
   type UUID,
 } from "@elizaos/core";
@@ -1204,6 +1205,103 @@ describe("remote plugin adapter", () => {
       message:
         'Remote plugin "remote-response-handler" responseHandler.REMOTE_RESPONSE_HANDLER.evaluate returned invalid patch field "addCandidateActions".',
     });
+  });
+
+  it("limits remote deterministic response-handler calls to actions owned by the same module", async () => {
+    let deterministicAction = "REMOTE_DEMO";
+    const router = makeRouter({
+      shouldRunResponseHandlerEvaluator: async () => ({ shouldRun: true }),
+      evaluateResponseHandlerEvaluator: async () => ({
+        patch: {
+          clearReply: true,
+          clearCandidateActions: true,
+          deterministicToolCall: { name: deterministicAction },
+        },
+      }),
+    });
+    const plugin = createRemoteCapabilityPlugin({
+      id: "remote-response-handler",
+      name: "@remote/response-handler",
+      actions: [
+        {
+          name: "REMOTE_DEMO",
+          description: "Run the module-owned remote action.",
+        },
+      ],
+      responseHandlerEvaluators: [
+        {
+          name: "REMOTE_RESPONSE_HANDLER",
+          description: "Remote response handler.",
+        },
+      ],
+    });
+    const evaluator = plugin.responseHandlerEvaluators?.[0];
+    expect(evaluator?.deterministicActions).toEqual(["REMOTE_DEMO"]);
+
+    const reportError = vi.fn();
+    const runtime = makeRuntime(router, {
+      actions: plugin.actions ?? [],
+      responseHandlerEvaluators: evaluator ? [evaluator] : [],
+      reportError,
+      logger: { warn: vi.fn(), debug: vi.fn() } as never,
+    });
+    const run = (messageHandler: {
+      processMessage: "RESPOND";
+      thought: string;
+      plan: {
+        contexts: string[];
+        reply: string;
+        candidateActions: string[];
+      };
+    }) =>
+      runResponseHandlerEvaluators({
+        runtime,
+        message: { content: { text: "run it" } } as never,
+        state: {} as never,
+        messageHandler: messageHandler as never,
+        availableContexts: [],
+      });
+
+    const allowedHandler = {
+      processMessage: "RESPOND" as const,
+      thought: "base",
+      plan: {
+        contexts: ["general"],
+        reply: "base reply",
+        candidateActions: ["BASE"],
+      },
+    };
+    const allowed = await run(allowedHandler);
+    expect(allowedHandler.plan).toMatchObject({
+      deterministicToolCall: { name: "REMOTE_DEMO" },
+    });
+    expect(allowed.errors).toEqual([]);
+
+    deterministicAction = "VIEWS";
+    const deniedHandler = {
+      processMessage: "RESPOND" as const,
+      thought: "base",
+      plan: {
+        contexts: ["general"],
+        reply: "base reply",
+        candidateActions: ["BASE"],
+      },
+    };
+    const denied = await run(deniedHandler);
+    expect(deniedHandler.plan).toEqual({
+      contexts: ["general"],
+      reply: "base reply",
+      candidateActions: ["BASE"],
+    });
+    expect(denied.candidateActionsClearedByEvaluators).toBe(false);
+    expect(denied.errors).toEqual([
+      {
+        evaluatorName: "REMOTE_RESPONSE_HANDLER",
+        error:
+          'Response-handler evaluator "REMOTE_RESPONSE_HANDLER" is not allowed to select deterministic action "VIEWS"',
+      },
+    ]);
+    expect(reportError).toHaveBeenCalledOnce();
   });
 
   it("rejects missing remote app diagnostics instead of using an empty fallback", async () => {

--- a/packages/agent/src/services/remote-plugin-adapter.ts
+++ b/packages/agent/src/services/remote-plugin-adapter.ts
@@ -377,6 +377,7 @@ export function createRemoteCapabilityPlugin(
       name: evaluator.name,
       description: evaluator.description,
       priority: evaluator.priority,
+      deterministicActions: (module.actions ?? []).map((action) => action.name),
       shouldRun: async (context) =>
         (
           await requireCapabilityRouter(

--- a/packages/app-core/test/helpers/live-agent-test.ts
+++ b/packages/app-core/test/helpers/live-agent-test.ts
@@ -49,6 +49,8 @@ export interface LiveAgentTestOptions {
   systemPrompt?: string;
   /** Plugins to load in addition to the provider plugin. Workspace path or bare specifier. */
   extraPlugins?: Array<string | { path: string; name?: string }>;
+  /** Effective sender role for authorization-sensitive live action tests. */
+  senderRole?: "OWNER" | "ADMIN" | "USER" | "GUEST";
 }
 
 export interface LiveAgentHarness {
@@ -103,7 +105,7 @@ const PROVIDER_CONFIG: Record<LiveProviderId, ProviderConfig> = {
     defaultRequiredEnv: ["OPENROUTER_API_KEY"],
   },
   ollama: {
-    pluginPath: "../../../../plugins/plugin-ollama/index.ts",
+    pluginPath: "../../../../plugins/plugin-zerollama/index.ts",
     bareSpecifier: "@elizaos/plugin-zerollama",
     pluginExportNames: ["ollamaPlugin", "default"],
     defaultRequiredEnv: ["OLLAMA_API_ENDPOINT"],
@@ -504,8 +506,24 @@ export async function buildLiveHarness(
   applyProviderSettings(runtime, provider);
   await runtime.initialize();
 
+  const userEntityId = randomUUID() as UUID;
   const worldId = randomUUID() as UUID;
-  await runtime.createWorld({ id: worldId, name: "live-world", agentId });
+  await runtime.createWorld({
+    id: worldId,
+    name: "live-world",
+    agentId,
+    ...(opts.senderRole
+      ? {
+          metadata: {
+            ...(opts.senderRole === "OWNER"
+              ? { ownership: { ownerId: userEntityId } }
+              : {}),
+            roles: { [userEntityId]: opts.senderRole },
+            roleSources: { [userEntityId]: "manual" },
+          },
+        }
+      : {}),
+  });
   const roomId = randomUUID() as UUID;
   await runtime.ensureRoomExists({
     id: roomId,
@@ -516,7 +534,6 @@ export async function buildLiveHarness(
   });
   await runtime.ensureParticipantInRoom(agentId, roomId);
 
-  const userEntityId = randomUUID() as UUID;
   await runtime.createEntity({
     id: userEntityId,
     names: ["LiveTester"],

--- a/packages/app-core/test/live-agent/settings-shell-toggle.live.e2e.test.ts
+++ b/packages/app-core/test/live-agent/settings-shell-toggle.live.e2e.test.ts
@@ -17,13 +17,13 @@
 import { appendFileSync, writeFileSync } from "node:fs";
 import type { Action, Plugin } from "@elizaos/core";
 import {
-	appControlPlugin,
-	createSettingsAction,
+  appControlPlugin,
+  createSettingsAction,
 } from "@elizaos/plugin-app-control";
 import { afterAll, beforeAll, describe, expect } from "vitest";
 import { itIf } from "../helpers/conditional-tests.ts";
-import { selectLiveProvider } from "../helpers/live-provider";
 import { ConversationHarness } from "../helpers/conversation-harness.js";
+import { selectLiveProvider } from "../helpers/live-provider";
 import { createRealTestRuntime } from "../helpers/real-runtime.ts";
 
 const liveModelTestsEnabled = process.env.ELIZA_LIVE_TEST === "1";
@@ -34,153 +34,175 @@ const OUT = "/tmp/settings-live-trajectory.txt";
 const log = (s: string) => appendFileSync(OUT, `${s}\n`);
 
 interface CapturedRoute {
-	method: string;
-	path: string;
-	body: unknown;
+  method: string;
+  path: string;
+  body: unknown;
 }
 
 function normalize(name: string): string {
-	return name.trim().toUpperCase().replace(/_/g, "");
+  return name.trim().toUpperCase().replace(/_/g, "");
 }
 
 describe("SETTINGS live-model selection (#14364)", () => {
-	let runtime: Awaited<ReturnType<typeof createRealTestRuntime>>["runtime"];
-	let cleanup: () => Promise<void>;
-	const routeCalls: CapturedRoute[] = [];
+  let runtime: Awaited<ReturnType<typeof createRealTestRuntime>>["runtime"];
+  let cleanup: () => Promise<void>;
+  const routeCalls: CapturedRoute[] = [];
 
-	beforeAll(async () => {
-		if (!canRun) return;
-		writeFileSync(OUT, "");
-		// Match the acceptance bar's model: Cerebras gemma-4-31b.
-		process.env.OPENAI_SMALL_MODEL ??= "gemma-4-31b";
-		process.env.OPENAI_LARGE_MODEL ??= "gemma-4-31b";
-		process.env.LOG_LEVEL = process.env.ELIZA_E2E_LOG_LEVEL ?? "error";
-		process.env.ELIZA_DISABLE_TRAJECTORY_LOGGING = "1";
-		process.env.ELIZA_DISABLE_PROACTIVE_AGENT = "1";
+  beforeAll(async () => {
+    if (!canRun) return;
+    writeFileSync(OUT, "");
+    // Match the acceptance bar's model: Cerebras gemma-4-31b.
+    process.env.OPENAI_SMALL_MODEL ??= "gemma-4-31b";
+    process.env.OPENAI_LARGE_MODEL ??= "gemma-4-31b";
+    process.env.LOG_LEVEL = process.env.ELIZA_E2E_LOG_LEVEL ?? "error";
+    process.env.ELIZA_DISABLE_TRAJECTORY_LOGGING = "1";
+    process.env.ELIZA_DISABLE_PROACTIVE_AGENT = "1";
 
-		// Swap SETTINGS for one whose backend route is captured (no live server).
-		const settingsWithCapture = createSettingsAction({
-			routeFetch: async (request) => {
-				routeCalls.push({
-					method: request.method,
-					path: request.path,
-					body: request.body,
-				});
-				return { ok: true };
-			},
-		});
-		const testPlugin: Plugin = {
-			...appControlPlugin,
-			name: `${appControlPlugin.name}-live-settings-test`,
-			actions: (appControlPlugin.actions ?? []).map((action: Action) =>
-				action.name === "SETTINGS" ? settingsWithCapture : action,
-			),
-		};
+    // Swap SETTINGS for one whose backend route is captured (no live server).
+    const settingsWithCapture = createSettingsAction({
+      routeFetch: async (request) => {
+        routeCalls.push({
+          method: request.method,
+          path: request.path,
+          body: request.body,
+        });
+        return { ok: true };
+      },
+    });
+    const testPlugin: Plugin = {
+      ...appControlPlugin,
+      name: `${appControlPlugin.name}-live-settings-test`,
+      actions: (appControlPlugin.actions ?? []).map((action: Action) =>
+        action.name === "SETTINGS" ? settingsWithCapture : action,
+      ),
+    };
 
-		const result = await createRealTestRuntime({
-			withLLM: true,
-			preferredProvider: provider?.name,
-			characterName: "SettingsLiveAgent",
-			plugins: [testPlugin],
-		});
-		runtime = result.runtime;
-		cleanup = result.cleanup;
+    const result = await createRealTestRuntime({
+      withLLM: true,
+      preferredProvider: provider?.name,
+      characterName: "SettingsLiveAgent",
+      plugins: [testPlugin],
+    });
+    runtime = result.runtime;
+    cleanup = result.cleanup;
 
-		log(`provider=${result.providerName} model=${result.providerConfig?.largeModel}`);
-		log(
-			`registered actions: ${runtime.actions.map((a) => a.name).sort().join(", ")}`,
-		);
-	}, 240_000);
+    log(
+      `provider=${result.providerName} model=${result.providerConfig?.largeModel}`,
+    );
+    log(
+      `registered actions: ${runtime.actions
+        .map((a) => a.name)
+        .sort()
+        .join(", ")}`,
+    );
+  }, 240_000);
 
-	afterAll(async () => {
-		if (cleanup) await cleanup();
-	}, 60_000);
+  afterAll(async () => {
+    if (cleanup) await cleanup();
+  }, 60_000);
 
-	async function selectionFor(
-		prompt: string,
-	): Promise<{ started: string[]; completed: string[]; reply: string }> {
-		const h = new ConversationHarness(runtime, { userName: "Owner" });
-		await h.setup();
-		h.spy.reset();
-		routeCalls.length = 0;
-		try {
-			const turn = await h.send(prompt);
-			const started = h.spy.getStartedCalls().map((c) => c.actionName);
-			const completed = h.spy.getCompletedCalls().map((c) => c.actionName);
-			log(`\nPROMPT: ${JSON.stringify(prompt)}`);
-			log(`  started:   ${started.join(", ") || "(none)"}`);
-			log(`  completed: ${completed.join(", ") || "(none)"}`);
-			log(`  routeCalls: ${JSON.stringify(routeCalls)}`);
-			log(`  reply: ${JSON.stringify(turn.responseText.slice(0, 300))}`);
-			return { started, completed, reply: turn.responseText };
-		} finally {
-			await h.cleanup();
-		}
-	}
+  async function selectionFor(
+    prompt: string,
+  ): Promise<{ started: string[]; completed: string[]; reply: string }> {
+    const h = new ConversationHarness(runtime, { userName: "Owner" });
+    await h.setup();
+    h.spy.reset();
+    routeCalls.length = 0;
+    try {
+      const turn = await h.send(prompt);
+      const started = h.spy.getStartedCalls().map((c) => c.actionName);
+      const completed = h.spy.getCompletedCalls().map((c) => c.actionName);
+      log(`\nPROMPT: ${JSON.stringify(prompt)}`);
+      log(`  started:   ${started.join(", ") || "(none)"}`);
+      log(`  completed: ${completed.join(", ") || "(none)"}`);
+      log(`  routeCalls: ${JSON.stringify(routeCalls)}`);
+      log(`  reply: ${JSON.stringify(turn.responseText.slice(0, 300))}`);
+      return { started, completed, reply: turn.responseText };
+    } finally {
+      await h.cleanup();
+    }
+  }
 
-	itIf(canRun)(
-		"selects SETTINGS and drives the shell route for 'disable shell access for the agent'",
-		async () => {
-			const { started, completed } = await selectionFor(
-				"disable shell access for the agent",
-			);
-			const all = [...started, ...completed].map(normalize);
-			expect(
-				all.includes(normalize("SETTINGS")),
-				`Expected SETTINGS selected. started=${started.join(",")} completed=${completed.join(",")}`,
-			).toBe(true);
-			const shellWrites = routeCalls.filter(
-				(r) => r.method === "PUT" && r.path === "/api/permissions/shell",
-			);
-			expect(
-				shellWrites.length,
-				`Expected a PUT /api/permissions/shell. routeCalls=${JSON.stringify(routeCalls)}`,
-			).toBeGreaterThanOrEqual(1);
-			expect(shellWrites[0].body).toMatchObject({ enabled: false });
-		},
-		180_000,
-	);
+  itIf(canRun)(
+    "selects SETTINGS and drives the shell route for 'disable shell access for the agent'",
+    async () => {
+      const { started, completed } = await selectionFor(
+        "disable shell access for the agent",
+      );
+      const all = [...started, ...completed].map(normalize);
+      expect(
+        all.includes(normalize("SETTINGS")),
+        `Expected SETTINGS selected. started=${started.join(",")} completed=${completed.join(",")}`,
+      ).toBe(true);
+      const shellWrites = routeCalls.filter(
+        (r) => r.method === "PUT" && r.path === "/api/permissions/shell",
+      );
+      expect(
+        shellWrites.length,
+        `Expected a PUT /api/permissions/shell. routeCalls=${JSON.stringify(routeCalls)}`,
+      ).toBeGreaterThanOrEqual(1);
+      expect(shellWrites[0].body).toMatchObject({ enabled: false });
+    },
+    180_000,
+  );
 
-	itIf(canRun)(
-		"selects SETTINGS for 'turn off shell permissions'",
-		async () => {
-			// The planner is only reached when Stage-1 routes the turn to it; a live
-			// model occasionally short-circuits a terse toggle to a bare reply. Retry
-			// with escalating explicitness (repo convention) — the assertion is that
-			// when the turn reaches the planner, SETTINGS is the selected action.
-			const prompts = [
-				"turn off shell permissions",
-				"change my permissions: turn off shell access",
-				"use the settings action to turn off the shell permission",
-			];
-			const attempts: string[] = [];
-			for (const prompt of prompts) {
-				const { started, completed } = await selectionFor(prompt);
-				const all = [...started, ...completed].map(normalize);
-				if (all.includes(normalize("SETTINGS"))) return;
-				attempts.push(
-					`${JSON.stringify(prompt)} => started=${started.join(",") || "(none)"} completed=${completed.join(",") || "(none)"}`,
-				);
-			}
-			expect(false, `SETTINGS never selected.\n${attempts.join("\n")}`).toBe(
-				true,
-			);
-		},
-		240_000,
-	);
+  itIf(canRun)(
+    "selects SETTINGS for 'turn off shell permissions'",
+    async () => {
+      // The planner is only reached when Stage-1 routes the turn to it; a live
+      // model occasionally short-circuits a terse toggle to a bare reply. Retry
+      // with escalating explicitness (repo convention) — the assertion is that
+      // when the turn reaches the planner, SETTINGS is the selected action.
+      const prompts = [
+        "turn off shell permissions",
+        "change my permissions: turn off shell access",
+        "use the settings action to turn off the shell permission",
+      ];
+      const attempts: string[] = [];
+      for (const prompt of prompts) {
+        const { started, completed } = await selectionFor(prompt);
+        const all = [...started, ...completed].map(normalize);
+        if (all.includes(normalize("SETTINGS"))) return;
+        attempts.push(
+          `${JSON.stringify(prompt)} => started=${started.join(",") || "(none)"} completed=${completed.join(",") || "(none)"}`,
+        );
+      }
+      expect(false, `SETTINGS never selected.\n${attempts.join("\n")}`).toBe(
+        true,
+      );
+    },
+    240_000,
+  );
 
-	itIf(canRun)(
-		"still routes 'switch to eliza cloud inference' to MODEL_SWITCH (no shadowing)",
-		async () => {
-			const { started, completed } = await selectionFor(
-				"switch my model to eliza cloud inference",
-			);
-			const all = [...started, ...completed].map(normalize);
-			expect(
-				all.includes(normalize("MODEL_SWITCH")),
-				`Expected MODEL_SWITCH selected, not shadowed by SETTINGS. started=${started.join(",")} completed=${completed.join(",")}`,
-			).toBe(true);
-		},
-		180_000,
-	);
+  itIf(canRun)(
+    "still routes 'switch to eliza cloud inference' to MODEL_SWITCH (no shadowing)",
+    async () => {
+      const { started, completed } = await selectionFor(
+        "switch my model to eliza cloud inference",
+      );
+      const all = [...started, ...completed].map(normalize);
+      expect(
+        all.includes(normalize("MODEL_SWITCH")),
+        `Expected MODEL_SWITCH selected, not shadowed by SETTINGS. started=${started.join(",")} completed=${completed.join(",")}`,
+      ).toBe(true);
+    },
+    180_000,
+  );
+
+  itIf(canRun)(
+    "routes a preference-shaped model switch to MODEL_SWITCH for safe disambiguation",
+    async () => {
+      const { started, completed, reply } = await selectionFor(
+        "switch to the faster model",
+      );
+      const all = [...started, ...completed].map(normalize);
+      expect(
+        all.includes(normalize("MODEL_SWITCH")),
+        `Expected MODEL_SWITCH selected, not SETTINGS. started=${started.join(",")} completed=${completed.join(",")}`,
+      ).toBe(true);
+      expect(all).not.toContain(normalize("SETTINGS"));
+      expect(reply).toMatch(/local model|Eliza Cloud/i);
+    },
+    180_000,
+  );
 });

--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -1098,6 +1098,7 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		const deterministicViewEvaluator = {
 			name: "test.force_failed_view",
 			priority: 10,
+			deterministicActions: ["VIEWS"],
 			shouldRun: () => true,
 			evaluate: () => ({
 				requiresTool: true,
@@ -1376,6 +1377,7 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		const deterministicViewEvaluator = {
 			name: "test.force_deterministic_view",
 			priority: 10,
+			deterministicActions: ["VIEWS"],
 			shouldRun: () => true,
 			evaluate: () => ({
 				requiresTool: true,
@@ -1447,6 +1449,7 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		const evaluator = {
 			name: "test.owner_deterministic_call",
 			priority: 10,
+			deterministicActions: ["OWNER_CONTROL"],
 			shouldRun: () => true,
 			evaluate: () => ({
 				requiresTool: true,
@@ -1505,6 +1508,7 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		const evaluator = {
 			name: "test.non_owner_deterministic_call",
 			priority: 10,
+			deterministicActions: ["OWNER_CONTROL"],
 			shouldRun: () => true,
 			evaluate: () => ({
 				requiresTool: true,
@@ -1558,6 +1562,7 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		const evaluator = {
 			name: "test.throwing_deterministic_call",
 			priority: 10,
+			deterministicActions: ["UNSAFE_CONTROL"],
 			shouldRun: () => true,
 			evaluate: () => ({
 				requiresTool: true,

--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -1550,6 +1550,110 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		}
 	});
 
+	it("fails a deterministic call outside the action context without invoking it", async () => {
+		let calls = 0;
+		const settingsAction = makeMockAction({
+			name: "SETTINGS_ONLY",
+			contexts: ["settings"],
+			contextGate: { anyOf: ["settings"] },
+			handler: async () => {
+				calls++;
+				return { success: true, text: "should not run" };
+			},
+		});
+		const evaluator = {
+			name: "test.out_of_context_deterministic_call",
+			priority: 10,
+			deterministicActions: ["SETTINGS_ONLY"],
+			shouldRun: () => true,
+			evaluate: () => ({
+				requiresTool: true,
+				clearReply: true,
+				deterministicToolCall: { name: "SETTINGS_ONLY" },
+			}),
+		} satisfies import("../runtime/response-handler-evaluators").ResponseHandlerEvaluator;
+		const runtime = makeRuntime({
+			actions: [settingsAction],
+			responseHandlerEvaluators: [evaluator],
+			responses: [
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: stage1Response({ contexts: ["general"] }),
+				},
+			],
+		});
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("change a setting"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		expect(calls).toBe(0);
+		expect(getCalls(runtime).map((call) => call.modelType)).toEqual([
+			ModelType.RESPONSE_HANDLER,
+		]);
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.actionResults).toMatchObject([{ success: false }]);
+			expect(result.result.responseContent?.text).toBe(
+				NO_REPORTABLE_TOOL_OUTCOME_MESSAGE,
+			);
+		}
+	});
+
+	it("returns a verified deterministic failure without requiring a callback", async () => {
+		const refusal = "I couldn't switch the model: no provider.";
+		const action = makeMockAction({
+			name: "MODEL_SWITCH",
+			handler: async () => ({
+				success: false,
+				text: refusal,
+				userFacingText: refusal,
+				verifiedUserFacing: true,
+				turnComplete: true,
+			}),
+		});
+		const evaluator = {
+			name: "test.failed_model_switch",
+			priority: 10,
+			deterministicActions: ["MODEL_SWITCH"],
+			shouldRun: () => true,
+			evaluate: () => ({
+				requiresTool: true,
+				clearReply: true,
+				deterministicToolCall: { name: "MODEL_SWITCH" },
+			}),
+		} satisfies import("../runtime/response-handler-evaluators").ResponseHandlerEvaluator;
+		const runtime = makeRuntime({
+			actions: [action],
+			responseHandlerEvaluators: [evaluator],
+			responses: [
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: stage1Response({ contexts: ["general"] }),
+				},
+			],
+		});
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("switch models"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		expect(getCalls(runtime).map((call) => call.modelType)).toEqual([
+			ModelType.RESPONSE_HANDLER,
+		]);
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(refusal);
+			expect(result.result.actionResults).toMatchObject([{ success: false }]);
+		}
+	});
+
 	it("keeps thrown deterministic action diagnostics and control envelopes out of user prose", async () => {
 		const internalDiagnostic =
 			'{"actions":["DELETE_ALL"],"thought":"operator stack trace"}';

--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "../runtime/builtin-field-evaluators";
 import { ResponseHandlerFieldRegistry } from "../runtime/response-handler-field-registry";
 import {
+	NO_REPORTABLE_TOOL_OUTCOME_MESSAGE,
 	runV5MessageRuntimeStage1,
 	wrapSingleTurnVisibleCallback,
 } from "../services/message";
@@ -204,6 +205,7 @@ function makeMockAction(opts: {
 		schema: { type: "string" | "number" | "boolean" | "object" | "array" };
 	}>;
 	tags?: string[];
+	roleGate?: Action["roleGate"];
 	suppressActionResultClipboard?: boolean;
 	suppressEarlyReply?: boolean;
 	suppressPostActionContinuation?: boolean;
@@ -217,6 +219,7 @@ function makeMockAction(opts: {
 		validate: async () => true,
 		handler: opts.handler,
 		...(opts.tags ? { tags: opts.tags } : {}),
+		...(opts.roleGate ? { roleGate: opts.roleGate } : {}),
 		...(opts.subActions ? { subActions: opts.subActions } : {}),
 		...(opts.contexts ? { contexts: opts.contexts } : {}),
 		...(opts.suppressActionResultClipboard
@@ -1118,25 +1121,8 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 					}),
 				},
 				{
-					expectModelType: ModelType.ACTION_PLANNER,
-					body: {
-						text: "",
-						toolCalls: [
-							{
-								id: "view-call",
-								name: "VIEWS",
-								args: { action: "show", view: "home" },
-							},
-						],
-					},
-				},
-				{
 					expectModelType: ModelType.TEXT_SMALL,
 					body: JSON.stringify({ response: voicedFailure }),
-				},
-				{
-					expectModelType: ModelType.RESPONSE_HANDLER,
-					body: '{"action":"show","view":"notes"}',
 				},
 			],
 		});
@@ -1168,9 +1154,7 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		}
 		expect(getCalls(runtime).map((call) => call.modelType)).toEqual([
 			ModelType.RESPONSE_HANDLER,
-			ModelType.ACTION_PLANNER,
 			ModelType.TEXT_SMALL,
-			ModelType.RESPONSE_HANDLER,
 		]);
 	});
 
@@ -1415,28 +1399,6 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 						thought: "The view switch is deterministic.",
 					}),
 				},
-				{
-					expectModelType: ModelType.ACTION_PLANNER,
-					body: {
-						text: "Opening Notes.",
-						toolCalls: [
-							{
-								id: "view-call",
-								name: "VIEWS",
-								args: { action: "show", view: "notes" },
-							},
-						],
-					},
-				},
-				{
-					expectModelType: ModelType.RESPONSE_HANDLER,
-					body: JSON.stringify({
-						success: true,
-						decision: "FINISH",
-						thought: "The view is open.",
-						messageToUser: "Opened Notes.",
-					}),
-				},
 			],
 		});
 
@@ -1451,6 +1413,189 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		expect(earlyReply).not.toHaveBeenCalled();
 		expect(viewCalls).toBe(1);
 		expect(result.kind).toBe("planned_reply");
+		expect(getCalls(runtime).map((call) => call.modelType)).toEqual([
+			ModelType.RESPONSE_HANDLER,
+		]);
+		const trajectory = readRecordedTrajectories(String(AGENT_ID))[0] as {
+			stages: Array<{
+				kind: string;
+				tool?: { name: string; success: boolean };
+			}>;
+		};
+		expect(
+			trajectory.stages.find(
+				(stage) => stage.kind === "tool" && stage.tool?.name === "VIEWS",
+			),
+		).toMatchObject({ tool: { name: "VIEWS", success: true } });
+	});
+
+	it("executes an owner-only deterministic call through the canonical gates without planning", async () => {
+		let calls = 0;
+		const ownerAction = makeMockAction({
+			name: "OWNER_CONTROL",
+			roleGate: { minRole: "OWNER" },
+			handler: async () => {
+				calls++;
+				return {
+					success: true,
+					text: "Owner control applied.",
+					userFacingText: "Owner control applied.",
+					verifiedUserFacing: true,
+				};
+			},
+		});
+		const evaluator = {
+			name: "test.owner_deterministic_call",
+			priority: 10,
+			shouldRun: () => true,
+			evaluate: () => ({
+				requiresTool: true,
+				clearReply: true,
+				deterministicToolCall: { name: "OWNER_CONTROL" },
+			}),
+		} satisfies import("../runtime/response-handler-evaluators").ResponseHandlerEvaluator;
+		const runtime = makeRuntime({
+			actions: [ownerAction],
+			responseHandlerEvaluators: [evaluator],
+			responses: [
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: stage1Response({
+						contexts: ["general"],
+						replyText: "Applying owner control.",
+					}),
+				},
+			],
+		});
+		const ownerMessage = {
+			...makeMessage("apply owner control"),
+			entityId: AGENT_ID,
+		};
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: ownerMessage,
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		expect(calls).toBe(1);
+		expect(getCalls(runtime).map((call) => call.modelType)).toEqual([
+			ModelType.RESPONSE_HANDLER,
+		]);
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"Owner control applied.",
+			);
+			expect(result.result.actionResults).toMatchObject([{ success: true }]);
+		}
+	});
+
+	it("fails a non-owner deterministic call closed without invoking the action or planner", async () => {
+		let calls = 0;
+		const ownerAction = makeMockAction({
+			name: "OWNER_CONTROL",
+			roleGate: { minRole: "OWNER" },
+			handler: async () => {
+				calls++;
+				return { success: true, text: "should not run" };
+			},
+		});
+		const evaluator = {
+			name: "test.non_owner_deterministic_call",
+			priority: 10,
+			shouldRun: () => true,
+			evaluate: () => ({
+				requiresTool: true,
+				clearReply: true,
+				deterministicToolCall: { name: "OWNER_CONTROL" },
+			}),
+		} satisfies import("../runtime/response-handler-evaluators").ResponseHandlerEvaluator;
+		const runtime = makeRuntime({
+			actions: [ownerAction],
+			responseHandlerEvaluators: [evaluator],
+			responses: [
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: stage1Response({ contexts: ["general"] }),
+				},
+			],
+		});
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("apply owner control"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		expect(calls).toBe(0);
+		expect(getCalls(runtime).map((call) => call.modelType)).toEqual([
+			ModelType.RESPONSE_HANDLER,
+		]);
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.actionResults).toMatchObject([{ success: false }]);
+			expect(result.result.responseContent?.text).toBe(
+				NO_REPORTABLE_TOOL_OUTCOME_MESSAGE,
+			);
+			expect(result.result.responseContent?.text).not.toMatch(
+				/owner|role|permission/i,
+			);
+		}
+	});
+
+	it("keeps thrown deterministic action diagnostics and control envelopes out of user prose", async () => {
+		const internalDiagnostic =
+			'{"actions":["DELETE_ALL"],"thought":"operator stack trace"}';
+		const unsafeAction = makeMockAction({
+			name: "UNSAFE_CONTROL",
+			handler: async () => {
+				throw new Error(internalDiagnostic);
+			},
+		});
+		const evaluator = {
+			name: "test.throwing_deterministic_call",
+			priority: 10,
+			shouldRun: () => true,
+			evaluate: () => ({
+				requiresTool: true,
+				clearReply: true,
+				deterministicToolCall: { name: "UNSAFE_CONTROL" },
+			}),
+		} satisfies import("../runtime/response-handler-evaluators").ResponseHandlerEvaluator;
+		const runtime = makeRuntime({
+			actions: [unsafeAction],
+			responseHandlerEvaluators: [evaluator],
+			responses: [
+				{
+					expectModelType: ModelType.RESPONSE_HANDLER,
+					body: stage1Response({ contexts: ["general"] }),
+				},
+			],
+		});
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("run the unsafe control"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		expect(getCalls(runtime).map((call) => call.modelType)).toEqual([
+			ModelType.RESPONSE_HANDLER,
+		]);
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.actionResults).toMatchObject([{ success: false }]);
+			expect(result.result.responseContent?.text).toBe(
+				NO_REPORTABLE_TOOL_OUTCOME_MESSAGE,
+			);
+			expect(result.result.responseContent?.text).not.toContain(
+				internalDiagnostic,
+			);
+		}
 	});
 
 	it("keeps the Stage 1 reply when mixed candidates do not share response ownership", async () => {

--- a/packages/core/src/runtime/__tests__/response-handler-evaluators.test.ts
+++ b/packages/core/src/runtime/__tests__/response-handler-evaluators.test.ts
@@ -5,7 +5,7 @@
  * order, isolates individual evaluator failures, and reports applied patches.
  * Synthetic evaluators over a stub runtime; no model.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { MessageHandlerResult } from "../../types/components";
 import type { Memory } from "../../types/memory";
 import type { IAgentRuntime } from "../../types/runtime";
@@ -15,9 +15,12 @@ import {
 	runResponseHandlerEvaluators,
 } from "../response-handler-evaluators";
 
-function runtimeWith(evaluators: ResponseHandlerEvaluator[]): IAgentRuntime {
+function runtimeWith(
+	evaluators: ResponseHandlerEvaluator[],
+	reportError: IAgentRuntime["reportError"] = () => undefined,
+): IAgentRuntime {
 	return {
-		reportError: () => undefined,
+		reportError,
 		agentId: "00000000-0000-0000-0000-000000000001",
 		responseHandlerEvaluators: evaluators,
 		logger: { warn: () => undefined, debug: () => undefined },
@@ -50,6 +53,7 @@ describe("response-handler evaluators", () => {
 				{
 					name: "threads",
 					priority: 10,
+					deterministicActions: ["LIFEOPS_THREAD_CONTROL"],
 					shouldRun: () => true,
 					evaluate: () => ({
 						requiresTool: true,
@@ -101,6 +105,69 @@ describe("response-handler evaluators", () => {
 		expect(result.appliedPatches[0]?.changed).toContain(
 			"deterministicToolCall:set",
 		);
+	});
+
+	it("rejects a disallowed deterministic call before any patch side effects and continues", async () => {
+		const messageHandler = handler();
+		messageHandler.plan.candidateActions = ["old_action"];
+		messageHandler.plan.parentActionHints = ["OLD_ACTION"];
+		const reportError = vi.fn();
+		const result = await runResponseHandlerEvaluators({
+			runtime: runtimeWith(
+				[
+					{
+						name: "denied",
+						priority: 10,
+						deterministicActions: ["APP"],
+						shouldRun: () => true,
+						evaluate: () => ({
+							requiresTool: true,
+							setContexts: ["general"],
+							clearReply: true,
+							clearCandidateActions: true,
+							addCandidateActions: ["VIEWS"],
+							clearParentActionHints: true,
+							deterministicToolCall: { name: "VIEWS" },
+						}),
+					},
+					{
+						name: "later",
+						priority: 20,
+						shouldRun: () => true,
+						evaluate: () => ({ addCandidateActions: ["SAFE"] }),
+					},
+				],
+				reportError,
+			),
+			message,
+			state,
+			messageHandler,
+			availableContexts: [{ id: "general" }],
+		});
+
+		expect(messageHandler).toEqual({
+			processMessage: "RESPOND",
+			thought: "route",
+			plan: {
+				contexts: ["simple"],
+				reply: "ok",
+				candidateActions: ["old_action", "SAFE"],
+				parentActionHints: ["OLD_ACTION"],
+			},
+		});
+		expect(result.activeEvaluators).toEqual(["denied", "later"]);
+		expect(result.appliedPatches).toHaveLength(1);
+		expect(result.appliedPatches[0]?.evaluatorName).toBe("later");
+		expect(result.candidateActionsAddedByEvaluators).toEqual(["SAFE"]);
+		expect(result.candidateActionsClearedByEvaluators).toBe(false);
+		expect(result.errors).toEqual([
+			{
+				evaluatorName: "denied",
+				error:
+					'Response-handler evaluator "denied" is not allowed to select deterministic action "VIEWS"',
+			},
+		]);
+		expect(reportError).toHaveBeenCalledOnce();
 	});
 
 	it("orders patchers and isolates failures", async () => {

--- a/packages/core/src/runtime/response-handler-evaluators.ts
+++ b/packages/core/src/runtime/response-handler-evaluators.ts
@@ -4,6 +4,8 @@
  * actions, parent-action hints, deterministic tool call, reply — in priority
  * order and collecting a per-evaluator trace of what changed.
  */
+
+import { ElizaError } from "../errors";
 import type {
 	MessageHandlerAction,
 	MessageHandlerDeterministicToolCall,
@@ -49,6 +51,8 @@ export interface ResponseHandlerEvaluator {
 	name: string;
 	description?: string;
 	priority?: number;
+	/** Exact action names this evaluator may select for deterministic execution. */
+	deterministicActions?: readonly string[];
 	shouldRun(
 		context: ResponseHandlerEvaluatorContext,
 	): boolean | Promise<boolean>;
@@ -114,6 +118,31 @@ function normalizeDeterministicToolCall(
 			? { ...toolCall.params }
 			: undefined;
 	return params ? { name, params } : { name };
+}
+
+function assertDeterministicToolCallAllowed(
+	evaluator: ResponseHandlerEvaluator,
+	patch: ResponseHandlerPatch,
+): void {
+	const toolCall = normalizeDeterministicToolCall(patch.deterministicToolCall);
+	if (!toolCall) return;
+
+	const requested = toolCall.name.toLowerCase();
+	const allowed = uniqueStrings(evaluator.deterministicActions).some(
+		(actionName) => actionName.toLowerCase() === requested,
+	);
+	if (!allowed) {
+		throw new ElizaError(
+			`Response-handler evaluator "${evaluator.name}" is not allowed to select deterministic action "${toolCall.name}"`,
+			{
+				code: "RESPONSE_HANDLER_DETERMINISTIC_ACTION_DENIED",
+				context: {
+					evaluator: evaluator.name,
+					requestedAction: toolCall.name,
+				},
+			},
+		);
+	}
 }
 
 function availableContextSet(
@@ -281,6 +310,7 @@ export async function runResponseHandlerEvaluators(args: {
 			if (!patch) {
 				continue;
 			}
+			assertDeterministicToolCallAllowed(evaluator, patch);
 			if (patch.clearCandidateActions === true) {
 				result.candidateActionsClearedByEvaluators = true;
 			}

--- a/packages/core/src/services/__tests__/message-v5-executor-context.test.ts
+++ b/packages/core/src/services/__tests__/message-v5-executor-context.test.ts
@@ -99,13 +99,25 @@ describe("v5 planner executor context", () => {
 		expect(callback).toHaveBeenCalledWith({ text: widgetText }, "APP");
 	});
 
-	it("keeps the v5 execution call site on the shared context builder", () => {
+	it("keeps both deterministic and planned v5 execution on the shared context builder", () => {
 		const source = readFileSync(
 			new URL("../message.ts", import.meta.url),
 			"utf8",
 		);
-		expect(source.match(/executorCtx:\s*buildV5ExecutorContext/g)).toHaveLength(
-			1,
+		const deterministicExecutor = source.slice(
+			source.indexOf("const invokeDeterministicToolCall"),
+			source.indexOf("const invokeDeterministicToolCall") + 12_000,
 		);
+		const plannerExecutor = source.slice(
+			source.indexOf("executeToolCall: (toolCall, ctx)"),
+			source.indexOf("executeToolCall: (toolCall, ctx)") + 5_000,
+		);
+		expect(source.match(/executorCtx:\s*buildV5ExecutorContext/g)).toHaveLength(
+			2,
+		);
+		expect(deterministicExecutor).toMatch(
+			/executorCtx:\s*buildV5ExecutorContext/,
+		);
+		expect(plannerExecutor).toMatch(/executorCtx:\s*buildV5ExecutorContext/);
 	});
 });

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -148,6 +148,7 @@ import {
 	FAILED_TOOL_FALLBACK_MESSAGE,
 	isTerminalPlannerToolName,
 	type PlannerLoopParams,
+	type PlannerLoopResult,
 	type PlannerRuntime,
 	type PlannerToolCall,
 	type PlannerToolResult,
@@ -195,9 +196,11 @@ import {
 	flattenTrajectoryMessages,
 } from "../runtime/trajectory-provider-attribution";
 import {
+	captureToolStageIO,
 	createJsonFileTrajectoryRecorder,
 	finalizeTrajectoryRecording,
 	isTrajectoryRecordingEnabled,
+	type RecordedStage,
 	type TrajectoryRecorder,
 } from "../runtime/trajectory-recorder";
 import { TurnAbortedError } from "../runtime/turn-controller";
@@ -8604,6 +8607,148 @@ export async function runV5MessageRuntimeStage1(args: {
 			result: PlannerToolResult;
 		}> = [];
 
+		const invokeDeterministicToolCall =
+			async (): Promise<PlannerLoopResult> => {
+				const selected = messageHandler.plan.deterministicToolCall;
+				if (!selected) {
+					throw new Error(
+						"Deterministic tool execution requires a selected call",
+					);
+				}
+				const actionLookup = buildRuntimeActionLookup(args.runtime);
+				const action = resolveRuntimeAction(actionLookup, selected.name);
+				const toolCall: PlannerToolCall = {
+					id: `response-handler:${normalizeActionIdentifier(action?.name ?? selected.name)}`,
+					name: action?.name ?? selected.name,
+					...(selected.params ? { params: selected.params } : {}),
+				};
+				const startedAt = Date.now();
+				let callbackDelivered = false;
+				const deterministicCallback: HandlerCallback | undefined =
+					recordingCallback
+						? async (...callbackArgs) => {
+								callbackDelivered = true;
+								return recordingCallback(...callbackArgs);
+							}
+						: undefined;
+				let result: PlannerToolResult;
+				try {
+					result = trackSettledPlannerToolResult(
+						settledPlannerToolResults,
+						toolCall.name,
+						await executeV5PlannedToolCall({
+							runtime: args.runtime,
+							toolCall,
+							plannerContext: plannerContextAfterEarlyReply,
+							executorCtx: buildV5ExecutorContext({
+								message: args.message,
+								state: plannerState,
+								selectedContexts,
+								senderRole,
+								previousResults: [],
+								...(deterministicCallback
+									? { callback: deterministicCallback }
+									: {}),
+							}),
+							plannerRuntime,
+							executorOptions: {
+								// The evaluator selected one exact action. Keep that single-action
+								// surface while the canonical executor rechecks role, context,
+								// private-action, argument, account, and validate gates.
+								actions: action ? [action] : [],
+								...(args.onSettledActionResult
+									? { onSettledResult: args.onSettledActionResult }
+									: {}),
+							},
+							evaluatorEffects,
+							recorder,
+							trajectoryId,
+							plannerLoopConfig: args.plannerLoopConfig,
+						}),
+					);
+				} catch (error) {
+					// error-policy:J1 Match the planner loop's tool boundary: a handler or
+					// sub-planner throw becomes one explicit failed result for the normal
+					// reply/error path rather than falling through to a second planner call.
+					result = trackSettledPlannerToolResult(
+						settledPlannerToolResults,
+						toolCall.name,
+						{
+							success: false,
+							error,
+							text: error instanceof Error ? error.message : String(error),
+						},
+					);
+				}
+				const endedAt = Date.now();
+				if (recorder && trajectoryId) {
+					try {
+						const input = selected.params ?? {};
+						const io = captureToolStageIO({
+							input,
+							output: result,
+							error: result.error,
+						});
+						const stage: RecordedStage = {
+							stageId: `stage-tool-${toolCall.name}-${startedAt}`,
+							kind: "tool",
+							startedAt,
+							endedAt,
+							latencyMs: endedAt - startedAt,
+							tool: {
+								name: toolCall.name,
+								args: input,
+								result,
+								success: result.success,
+								durationMs: endedAt - startedAt,
+								description: action?.description,
+								input: io.input,
+								output: io.output,
+								errorText: io.errorText,
+								truncated: io.truncated,
+							},
+						};
+						await recorder.recordStage(trajectoryId, stage);
+					} catch (error) {
+						// error-policy:J7 Trajectory persistence is diagnostic and cannot
+						// change the already-settled deterministic action result.
+						args.runtime.reportError(
+							"MessageService.recordDeterministicTool",
+							error,
+							{ trajectoryId, tool: toolCall.name },
+						);
+						args.runtime.logger.warn(
+							{
+								src: "service:message",
+								err: error instanceof Error ? error.message : String(error),
+								trajectoryId,
+								tool: toolCall.name,
+							},
+							"Failed to record deterministic tool stage",
+						);
+					}
+				}
+
+				const reportableResultText = result.userFacingText?.trim();
+				const finalMessage =
+					!callbackDelivered &&
+					reportableResultText &&
+					(result.success === true || result.verifiedUserFacing === true)
+						? reportableResultText
+						: undefined;
+				return {
+					status: "finished",
+					trajectory: {
+						context: plannerContextAfterEarlyReply,
+						steps: [{ iteration: 0, toolCall, result }],
+						archivedSteps: [],
+						plannedQueue: [],
+						evaluatorOutputs: [],
+					},
+					...(finalMessage ? { finalMessage } : {}),
+				};
+			};
+
 		const invokePlannerLoop = (
 			loopContext: typeof plannerContextAfterEarlyReply,
 		) =>
@@ -8725,7 +8870,12 @@ export async function runV5MessageRuntimeStage1(args: {
 
 		let plannerResult: Awaited<ReturnType<typeof invokePlannerLoop>>;
 		try {
-			plannerResult = await invokePlannerLoop(plannerContextAfterEarlyReply);
+			plannerResult = messageHandler.plan.deterministicToolCall
+				? await timeInferenceSpan(
+						"actions:response-handler-deterministic-tool",
+						invokeDeterministicToolCall,
+					)
+				: await invokePlannerLoop(plannerContextAfterEarlyReply);
 		} catch (error) {
 			const preservedAnswer = prePatchStageOneReplyIsUngroundedAppliedClaim
 				? undefined
@@ -8957,6 +9107,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		const preservedAnswerFallback =
 			!plannedText &&
 			!suppressesPlannerReply &&
+			!messageHandler.plan.deterministicToolCall &&
 			prePatchStageOneReply &&
 			!prePatchStageOneReplyIsUngroundedAppliedClaim &&
 			!PROGRESS_ONLY_ANSWER_REJECT.test(prePatchStageOneReply.trim()) &&

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -6482,6 +6482,13 @@ interface ExecuteV5PlannedToolCallParams {
 	recorder?: TrajectoryRecorder;
 	trajectoryId?: string;
 	plannerLoopConfig?: PlannerLoopParams["config"];
+	/**
+	 * Normal planner selection may activate the selected action's routing
+	 * contexts after that action was surfaced through the context-filtered tool
+	 * set. Deterministic evaluator calls have no such planner-surface proof and
+	 * must retain the turn's original contexts for the canonical gate.
+	 */
+	activateActionContexts?: boolean;
 }
 
 interface BuildV5ExecutorContextParams {
@@ -6557,15 +6564,26 @@ async function executeV5PlannedToolCall(
 	const action = executionActions.find(
 		(candidate) => candidate.name === toolCall.name,
 	);
-	const executorCtx = action
-		? {
-				...args.executorCtx,
-				activeContexts: mergeAgentContexts(
-					args.executorCtx.activeContexts,
-					action.contexts,
-				),
-			}
-		: args.executorCtx;
+	const executorCtx =
+		action && args.activateActionContexts !== false
+			? {
+					...args.executorCtx,
+					activeContexts: mergeAgentContexts(
+						args.executorCtx.activeContexts,
+						action.contexts,
+					),
+				}
+			: args.executorCtx;
+	if (
+		action &&
+		actionHasSubActions(action) &&
+		args.activateActionContexts === false
+	) {
+		const gateFailure = actionGateFailure(action, executorCtx);
+		if (gateFailure) {
+			return { success: false, error: gateFailure, text: gateFailure };
+		}
+	}
 
 	const hasDispatcherActionParameter =
 		plannerToolCallHasActionParameter(toolCall);
@@ -8664,6 +8682,7 @@ export async function runV5MessageRuntimeStage1(args: {
 							recorder,
 							trajectoryId,
 							plannerLoopConfig: args.plannerLoopConfig,
+							activateActionContexts: false,
 						}),
 					);
 				} catch (error) {

--- a/packages/shared/src/local-inference/routing-preferences.test.ts
+++ b/packages/shared/src/local-inference/routing-preferences.test.ts
@@ -1,16 +1,29 @@
 /**
- * Covers the local/cloud routing-policy union: that ROUTING_POLICIES exposes
- * local-only, cloud-only, and auto with no duplicates, that
- * DEFAULT_ROUTING_POLICY is a member, and that the isRoutingPolicy type guard
- * accepts every member and rejects non-members. Pure Vitest over the exported
- * constants.
+ * Covers the routing-policy union and the real filesystem transaction used by
+ * local inference. Persistence tests use isolated state directories and real
+ * Bun child processes to exercise cross-process exclusion, stale recovery,
+ * strict corruption handling, and atomic two-slot publication.
  */
-import { describe, expect, it } from "vitest";
+import { spawn } from "node:child_process";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  rm,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import { hostname, tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   DEFAULT_ROUTING_POLICY,
   isRoutingPolicy,
   ROUTING_POLICIES,
   type RoutingPolicy,
+  readRoutingPreferences,
+  setTextRouting,
 } from "./routing-preferences.js";
 
 describe("routing policy union", () => {
@@ -37,4 +50,167 @@ describe("routing policy union", () => {
     expect(isRoutingPolicy(undefined)).toBe(false);
     expect(isRoutingPolicy(42)).toBe(false);
   });
+});
+
+describe("routing preference persistence", () => {
+  const previousStateDir = process.env.ELIZA_STATE_DIR;
+  let stateDir = "";
+
+  beforeEach(async () => {
+    stateDir = await mkdtemp(path.join(tmpdir(), "routing-preferences-"));
+    process.env.ELIZA_STATE_DIR = stateDir;
+  });
+
+  afterEach(async () => {
+    if (previousStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+    else process.env.ELIZA_STATE_DIR = previousStateDir;
+    await rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("publishes both text slots as one routing state", async () => {
+    const snapshots: Array<Awaited<ReturnType<typeof readRoutingPreferences>>> =
+      [];
+    const writes = Array.from({ length: 20 }, (_, index) =>
+      setTextRouting(index % 2 === 0 ? "elizacloud" : "eliza-local-inference"),
+    );
+    let complete = false;
+    const allWrites = Promise.all(writes).then((result) => {
+      complete = true;
+      return result;
+    });
+    while (!complete && snapshots.length < 100) {
+      snapshots.push(await readRoutingPreferences());
+    }
+    await allWrites;
+
+    for (const snapshot of snapshots) {
+      const small = snapshot.preferredProvider.TEXT_SMALL;
+      const large = snapshot.preferredProvider.TEXT_LARGE;
+      expect(small === undefined || small === large).toBe(true);
+      expect(snapshot.policy.TEXT_SMALL).toBe(snapshot.policy.TEXT_LARGE);
+    }
+  });
+
+  it("rejects corrupt persisted state instead of replacing it", async () => {
+    const root = path.join(stateDir, "local-inference");
+    await mkdir(root, { recursive: true });
+    await writeFile(path.join(root, "routing.json"), "{not-json", "utf8");
+
+    await expect(setTextRouting("elizacloud")).rejects.toThrow(/not JSON/);
+    await expect(readRoutingPreferences()).rejects.toThrow(/not JSON/);
+  });
+
+  it("recovers a stale lock owned by a dead local process", async () => {
+    const root = path.join(stateDir, "local-inference");
+    const lockPath = path.join(root, "routing.json.lock");
+    await mkdir(root, { recursive: true });
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        id: "dead-owner",
+        pid: 2_147_483_647,
+        hostname: hostname(),
+        createdAt: Date.now() - 120_000,
+      }),
+      "utf8",
+    );
+    const stale = new Date(Date.now() - 120_000);
+    await utimes(lockPath, stale, stale);
+
+    await expect(setTextRouting("elizacloud")).resolves.toMatchObject({
+      preferredProvider: {
+        TEXT_SMALL: "elizacloud",
+        TEXT_LARGE: "elizacloud",
+      },
+    });
+  });
+
+  it("recovers a stale empty lock left before owner-token publication", async () => {
+    const root = path.join(stateDir, "local-inference");
+    const lockPath = path.join(root, "routing.json.lock");
+    await mkdir(root, { recursive: true });
+    await writeFile(lockPath, "", "utf8");
+    const stale = new Date(Date.now() - 120_000);
+    await utimes(lockPath, stale, stale);
+
+    await expect(
+      setTextRouting("eliza-local-inference"),
+    ).resolves.toMatchObject({
+      preferredProvider: {
+        TEXT_SMALL: "eliza-local-inference",
+        TEXT_LARGE: "eliza-local-inference",
+      },
+    });
+  });
+
+  it("preserves every update from synchronized child processes", async () => {
+    const slots = [
+      "TEXT_SMALL",
+      "TEXT_LARGE",
+      "TEXT_EMBEDDING",
+      "TEXT_TO_SPEECH",
+      "TRANSCRIPTION",
+    ] as const;
+    const barrierDir = path.join(stateDir, "barrier");
+    const goPath = path.join(barrierDir, "go");
+    await mkdir(barrierDir, { recursive: true });
+    const moduleUrl = pathToFileURL(
+      path.join(import.meta.dirname, "routing-preferences.ts"),
+    ).href;
+
+    const children = slots.map((slot, index) => {
+      const readyPath = path.join(barrierDir, `ready-${index}`);
+      const script = `
+        import { existsSync, writeFileSync } from "node:fs";
+        import { setPreferredProvider } from ${JSON.stringify(moduleUrl)};
+        writeFileSync(${JSON.stringify(readyPath)}, "ready");
+        while (!existsSync(${JSON.stringify(goPath)})) {
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+        }
+        await setPreferredProvider(${JSON.stringify(slot)}, ${JSON.stringify(`provider-${index}`)});
+      `;
+      return spawn("bun", ["--conditions=eliza-source", "-e", script], {
+        env: { ...process.env, ELIZA_STATE_DIR: stateDir },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    });
+
+    for (let attempt = 0; attempt < 500; attempt++) {
+      const ready = await Promise.all(
+        slots.map(async (_, index) => {
+          try {
+            await access(path.join(barrierDir, `ready-${index}`));
+            return true;
+          } catch {
+            return false;
+          }
+        }),
+      );
+      if (ready.every(Boolean)) break;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    await writeFile(goPath, "go", "utf8");
+
+    await Promise.all(
+      children.map(
+        (child) =>
+          new Promise<void>((resolve, reject) => {
+            let stderr = "";
+            child.stderr?.on("data", (chunk) => {
+              stderr += String(chunk);
+            });
+            child.once("error", reject);
+            child.once("exit", (code) => {
+              if (code === 0) resolve();
+              else reject(new Error(`routing child exited ${code}: ${stderr}`));
+            });
+          }),
+      ),
+    );
+
+    const preferences = await readRoutingPreferences();
+    for (const [index, slot] of slots.entries()) {
+      expect(preferences.preferredProvider[slot]).toBe(`provider-${index}`);
+    }
+  }, 20_000);
 });

--- a/packages/shared/src/local-inference/routing-preferences.ts
+++ b/packages/shared/src/local-inference/routing-preferences.ts
@@ -8,10 +8,16 @@
  * rather than replacing it.
  */
 
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
+import { hostname } from "node:os";
 import path from "node:path";
 import { localInferenceRoot } from "./paths.js";
-import type { AgentModelSlot } from "./types.js";
+import {
+  AGENT_MODEL_SLOTS,
+  type AgentModelSlot,
+  TEXT_GENERATION_SLOTS,
+} from "./types.js";
 
 export type RoutingPolicy =
   | "manual"
@@ -72,7 +78,13 @@ interface RoutingFile {
   preferences: RoutingPreferences;
 }
 
-const EMPTY: RoutingPreferences = { preferredProvider: {}, policy: {} };
+const LOCK_RETRY_MS = 20;
+const LOCK_ACQUIRE_TIMEOUT_MS = 5_000;
+const LOCK_STALE_MS = 30_000;
+
+function emptyPreferences(): RoutingPreferences {
+  return { preferredProvider: {}, policy: {} };
+}
 
 function routingPath(): string {
   return path.join(localInferenceRoot(), "routing.json");
@@ -82,62 +94,306 @@ async function ensureRoot(): Promise<void> {
   await fs.mkdir(localInferenceRoot(), { recursive: true });
 }
 
-export async function readRoutingPreferences(): Promise<RoutingPreferences> {
-  try {
-    const raw = await fs.readFile(routingPath(), "utf8");
-    const parsed = JSON.parse(raw) as RoutingFile;
-    if (parsed?.version !== 1 || !parsed.preferences) return EMPTY;
-    return {
-      preferredProvider: parsed.preferences.preferredProvider,
-      policy: parsed.preferences.policy,
-    };
-  } catch {
-    return EMPTY;
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function errorCode(error: unknown): string | undefined {
+  return isRecord(error) && typeof error.code === "string"
+    ? error.code
+    : undefined;
+}
+
+function parseRoutingRecord<T extends string>(
+  value: unknown,
+  field: string,
+  validateValue: (entry: unknown) => entry is T,
+): Partial<Record<AgentModelSlot, T>> {
+  if (!isRecord(value)) {
+    throw new Error(`Invalid routing preferences: ${field} must be an object`);
   }
+  const parsed: Partial<Record<AgentModelSlot, T>> = {};
+  for (const [slot, entry] of Object.entries(value)) {
+    if (!AGENT_MODEL_SLOTS.includes(slot as AgentModelSlot)) {
+      throw new Error(
+        `Invalid routing preferences: unknown model slot ${slot}`,
+      );
+    }
+    if (!validateValue(entry)) {
+      throw new Error(
+        `Invalid routing preferences: ${field}.${slot} has an invalid value`,
+      );
+    }
+    parsed[slot as AgentModelSlot] = entry;
+  }
+  return parsed;
+}
+
+function parseRoutingFile(raw: string): RoutingPreferences {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (cause) {
+    // error-policy:J3 corrupt persisted JSON is an explicit invalid state.
+    throw new Error("Invalid routing preferences: routing.json is not JSON", {
+      cause,
+    });
+  }
+  if (
+    !isRecord(parsed) ||
+    parsed.version !== 1 ||
+    !isRecord(parsed.preferences)
+  ) {
+    throw new Error("Invalid routing preferences: unsupported file shape");
+  }
+  return {
+    preferredProvider: parseRoutingRecord(
+      parsed.preferences.preferredProvider,
+      "preferredProvider",
+      (entry): entry is string =>
+        typeof entry === "string" && entry.trim().length > 0,
+    ),
+    policy: parseRoutingRecord(
+      parsed.preferences.policy,
+      "policy",
+      isRoutingPolicy,
+    ),
+  };
+}
+
+function validateRoutingPreferences(
+  prefs: RoutingPreferences,
+): RoutingPreferences {
+  return parseRoutingFile(JSON.stringify({ version: 1, preferences: prefs }));
+}
+
+async function readRoutingPreferencesStrict(): Promise<RoutingPreferences> {
+  try {
+    return parseRoutingFile(await fs.readFile(routingPath(), "utf8"));
+  } catch (error) {
+    // error-policy:J3 a missing file is the one valid empty state; corrupt or
+    // unreadable persisted routing must fail closed instead of being replaced.
+    if (errorCode(error) === "ENOENT") return emptyPreferences();
+    throw error;
+  }
+}
+
+async function writeRoutingPreferencesAtomic(
+  prefs: RoutingPreferences,
+): Promise<void> {
+  const target = routingPath();
+  const payload: RoutingFile = {
+    version: 1,
+    preferences: validateRoutingPreferences(prefs),
+  };
+  const tmp = path.join(
+    path.dirname(target),
+    `.${path.basename(target)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  try {
+    await fs.writeFile(tmp, `${JSON.stringify(payload, null, 2)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await fs.rename(tmp, target);
+  } catch (error) {
+    // error-policy:J6 temp cleanup is best-effort; the primary write failure is
+    // preserved and unique temp names make an orphan harmless to later writes.
+    await fs.rm(tmp, { force: true }).catch(() => undefined);
+    throw error;
+  }
+}
+
+interface LockOwner {
+  id: string;
+  pid: number;
+  hostname: string;
+  createdAt: number;
+}
+
+function parseLockOwner(raw: string): LockOwner | null {
+  try {
+    const parsed = JSON.parse(raw) as Partial<LockOwner>;
+    if (
+      typeof parsed.id !== "string" ||
+      typeof parsed.pid !== "number" ||
+      !Number.isInteger(parsed.pid) ||
+      typeof parsed.hostname !== "string" ||
+      typeof parsed.createdAt !== "number"
+    ) {
+      return null;
+    }
+    return parsed as LockOwner;
+  } catch {
+    // error-policy:J3 a malformed owner token is invalid lock metadata; stale
+    // recovery handles it only after the full age threshold.
+    return null;
+  }
+}
+
+function lockOwnerIsAlive(owner: LockOwner): boolean {
+  if (owner.hostname !== hostname()) return true;
+  try {
+    process.kill(owner.pid, 0);
+    return true;
+  } catch (error) {
+    // error-policy:J3 ESRCH is the only trusted proof that a local owner died.
+    return errorCode(error) !== "ESRCH";
+  }
+}
+
+async function removeLockIfTokenMatches(
+  lockPath: string,
+  token: string,
+): Promise<void> {
+  try {
+    if ((await fs.readFile(lockPath, "utf8")) === token) {
+      await fs.rm(lockPath, { force: true });
+    }
+  } catch (error) {
+    // error-policy:J6 lock teardown is best-effort; ENOENT means another stale
+    // recovery already removed it, while any leak is bounded by stale recovery.
+    if (errorCode(error) !== "ENOENT") return;
+  }
+}
+
+async function tryRecoverStaleLock(lockPath: string): Promise<boolean> {
+  try {
+    const [token, stat] = await Promise.all([
+      fs.readFile(lockPath, "utf8"),
+      fs.stat(lockPath),
+    ]);
+    if (Date.now() - stat.mtimeMs < LOCK_STALE_MS) return false;
+    const owner = parseLockOwner(token);
+    // An empty/malformed token is the crash window between O_EXCL creation and
+    // owner publication. Age plus token-matched removal makes it reclaimable
+    // without deleting a newer contender's lock.
+    if (owner && lockOwnerIsAlive(owner)) return false;
+    await removeLockIfTokenMatches(lockPath, token);
+    return true;
+  } catch (error) {
+    // error-policy:J3 the lock disappearing between contention checks is a
+    // successful retry signal; other filesystem failures are real failures.
+    if (errorCode(error) === "ENOENT") return true;
+    throw error;
+  }
+}
+
+async function withRoutingLock<T>(operation: () => Promise<T>): Promise<T> {
+  await ensureRoot();
+  const lockPath = `${routingPath()}.lock`;
+  const deadline = Date.now() + LOCK_ACQUIRE_TIMEOUT_MS;
+  let handle: Awaited<ReturnType<typeof fs.open>> | undefined;
+  let token = "";
+  while (!handle) {
+    let pending: Awaited<ReturnType<typeof fs.open>> | undefined;
+    try {
+      pending = await fs.open(lockPath, "wx", 0o600);
+      token = JSON.stringify({
+        id: randomUUID(),
+        pid: process.pid,
+        hostname: hostname(),
+        createdAt: Date.now(),
+      } satisfies LockOwner);
+      await pending.writeFile(token, "utf8");
+      handle = pending;
+    } catch (error) {
+      if (pending) {
+        // error-policy:J6 a partially-created lock belongs to this failed
+        // acquisition and is removed without masking its primary error.
+        await pending.close().catch(() => undefined);
+        await fs.rm(lockPath, { force: true }).catch(() => undefined);
+      }
+      if (errorCode(error) !== "EEXIST") throw error;
+      if (await tryRecoverStaleLock(lockPath)) continue;
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `Timed out after ${LOCK_ACQUIRE_TIMEOUT_MS}ms waiting for routing lock`,
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, LOCK_RETRY_MS));
+    }
+  }
+  try {
+    return await operation();
+  } finally {
+    try {
+      await handle.close();
+    } finally {
+      await removeLockIfTokenMatches(lockPath, token);
+    }
+  }
+}
+
+/** Serialize one strict read-modify-write transaction across local processes. */
+export async function updateRoutingPreferences(
+  update: (current: RoutingPreferences) => RoutingPreferences,
+): Promise<RoutingPreferences> {
+  return withRoutingLock(async () => {
+    const next = validateRoutingPreferences(
+      update(await readRoutingPreferencesStrict()),
+    );
+    await writeRoutingPreferencesAtomic(next);
+    return next;
+  });
+}
+
+export async function readRoutingPreferences(): Promise<RoutingPreferences> {
+  return readRoutingPreferencesStrict();
 }
 
 export async function writeRoutingPreferences(
   prefs: RoutingPreferences,
 ): Promise<void> {
-  await ensureRoot();
-  const payload: RoutingFile = { version: 1, preferences: prefs };
-  const tmp = `${routingPath()}.tmp`;
-  await fs.writeFile(tmp, JSON.stringify(payload, null, 2), "utf8");
-  await fs.rename(tmp, routingPath());
+  await withRoutingLock(async () => writeRoutingPreferencesAtomic(prefs));
 }
 
 export async function setPreferredProvider(
   slot: AgentModelSlot,
   provider: string | null,
 ): Promise<RoutingPreferences> {
-  const current = await readRoutingPreferences();
-  const next: RoutingPreferences = {
-    preferredProvider: { ...current.preferredProvider },
-    policy: { ...current.policy },
-  };
-  if (provider) {
-    next.preferredProvider[slot] = provider;
-  } else {
-    delete next.preferredProvider[slot];
-  }
-  await writeRoutingPreferences(next);
-  return next;
+  return updateRoutingPreferences((current) => {
+    const next: RoutingPreferences = {
+      preferredProvider: { ...current.preferredProvider },
+      policy: { ...current.policy },
+    };
+    if (provider) next.preferredProvider[slot] = provider;
+    else delete next.preferredProvider[slot];
+    return next;
+  });
 }
 
 export async function setPolicy(
   slot: AgentModelSlot,
   policy: RoutingPolicy | null,
 ): Promise<RoutingPreferences> {
-  const current = await readRoutingPreferences();
-  const next: RoutingPreferences = {
-    preferredProvider: { ...current.preferredProvider },
-    policy: { ...current.policy },
-  };
-  if (policy) {
-    next.policy[slot] = policy;
-  } else {
-    delete next.policy[slot];
-  }
-  await writeRoutingPreferences(next);
-  return next;
+  return updateRoutingPreferences((current) => {
+    const next: RoutingPreferences = {
+      preferredProvider: { ...current.preferredProvider },
+      policy: { ...current.policy },
+    };
+    if (policy) next.policy[slot] = policy;
+    else delete next.policy[slot];
+    return next;
+  });
+}
+
+/** Atomically publish one provider/policy pair for both text-generation slots. */
+export async function setTextRouting(
+  provider: string | null,
+  policy: RoutingPolicy | null = "manual",
+): Promise<RoutingPreferences> {
+  return updateRoutingPreferences((current) => {
+    const next: RoutingPreferences = {
+      preferredProvider: { ...current.preferredProvider },
+      policy: { ...current.policy },
+    };
+    for (const slot of TEXT_GENERATION_SLOTS) {
+      if (provider) next.preferredProvider[slot] = provider;
+      else delete next.preferredProvider[slot];
+      if (policy) next.policy[slot] = policy;
+      else delete next.policy[slot];
+    }
+    return next;
+  });
 }

--- a/plugins/plugin-app-control/src/actions/model-switch.test.ts
+++ b/plugins/plugin-app-control/src/actions/model-switch.test.ts
@@ -10,22 +10,60 @@ import type {
 	Memory,
 	RoleGate,
 	RoleGateRole,
+	Task,
+	UUID,
 } from "@elizaos/core";
 import { satisfiesRoleGate } from "@elizaos/core";
 import { DEFAULT_ELIZA_CLOUD_TEXT_MODEL } from "@elizaos/shared";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	createModelSwitchAction,
 	inferModelSwitchRequest,
+	isModelSwitchIntent,
 	type ModelSwitchFn,
 	type ModelSwitchOutcome,
 	sanctionedModelError,
 } from "./model-switch.ts";
 
-const runtime = {} as IAgentRuntime;
+const pendingTasks: Task[] = [];
+const runtime = {
+	agentId: "agent-1" as UUID,
+	getTasks: vi.fn(
+		async ({
+			roomId,
+			tags,
+			agentIds,
+		}: {
+			roomId?: UUID;
+			tags?: string[];
+			agentIds: UUID[];
+		}) =>
+			pendingTasks.filter(
+				(task) =>
+					(!roomId || task.roomId === roomId) &&
+					task.agentId !== undefined &&
+					agentIds.includes(task.agentId) &&
+					(!tags || tags.every((tag) => task.tags?.includes(tag))),
+			),
+	),
+	createTask: vi.fn(async (task: Task) => {
+		const id = `task-${pendingTasks.length + 1}` as UUID;
+		pendingTasks.push({ ...task, id });
+		return id;
+	}),
+	deleteTask: vi.fn(async (id: UUID) => {
+		const index = pendingTasks.findIndex((task) => task.id === id);
+		if (index >= 0) pendingTasks.splice(index, 1);
+	}),
+} as unknown as IAgentRuntime;
 
-function message(text: string): Memory {
-	return { content: { text } } as Memory;
+beforeEach(() => {
+	pendingTasks.splice(0);
+	vi.clearAllMocks();
+});
+
+function message(text: string, roomId = "room-1" as UUID): Memory {
+	return { roomId, content: { text } } as Memory;
 }
 
 function captureCallback(): {
@@ -88,6 +126,23 @@ describe("inferModelSwitchRequest", () => {
 	});
 });
 
+describe("isModelSwitchIntent", () => {
+	it("recognizes preference-shaped and ambiguous model-switch asks", () => {
+		expect(isModelSwitchIntent("switch to the faster model")).toBe(true);
+		expect(isModelSwitchIntent("switch model between local and cloud")).toBe(
+			true,
+		);
+	});
+
+	it("does not claim model questions or generic settings asks", () => {
+		expect(isModelSwitchIntent("what model are you using?")).toBe(false);
+		expect(isModelSwitchIntent("open model settings")).toBe(false);
+		expect(isModelSwitchIntent("switch to high-contrast-dark-mode")).toBe(
+			false,
+		);
+	});
+});
+
 describe("sanctionedModelError", () => {
 	it("rejects a non-curated local id", () => {
 		expect(sanctionedModelError("local", "llama-3-8b")).toMatch(
@@ -121,15 +176,18 @@ describe("MODEL_SWITCH handler", () => {
 		return { action: createModelSwitchAction({ switchModel }), switchModel };
 	}
 
-	it("validates only messages that name a switch target", async () => {
+	it("validates explicit and preference-shaped switch requests", async () => {
 		const { action: a } = action({ ok: true });
 		expect(await a.validate(runtime, message("use the local model"))).toBe(
 			true,
 		);
+		expect(
+			await a.validate(runtime, message("switch to the faster model")),
+		).toBe(true);
 		expect(await a.validate(runtime, message("hi"))).toBe(false);
 	});
 
-	it("declares an OWNER role gate and required target param", () => {
+	it("declares an OWNER role gate and optional sanctioned target param", () => {
 		// #16172 gap 3: MODEL_SWITCH flips the GLOBAL inference backend, so it must
 		// be OWNER-gated (matching the owner-only `/model local|cloud` slash write
 		// and the sibling AGENT_SWITCH action). A planner-routed guest message must
@@ -137,8 +195,226 @@ describe("MODEL_SWITCH handler", () => {
 		const { action: a } = action({ ok: true });
 		expect(a.roleGate).toEqual({ minRole: "OWNER" });
 		const target = a.parameters?.find((p) => p.name === "target");
-		expect(target?.required).toBe(true);
+		expect(target?.required).toBe(false);
 		expect(target?.schema).toMatchObject({ enum: ["local", "cloud"] });
+	});
+
+	it("asks for a target instead of trusting a planner guess", async () => {
+		const { action: a, switchModel } = action({ ok: true });
+		const { callback, texts } = captureCallback();
+		const result = await a.handler(
+			runtime,
+			message("switch to the faster model"),
+			undefined,
+			{ target: "cloud" },
+			callback,
+		);
+		expect(switchModel).not.toHaveBeenCalled();
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({ awaitingTarget: true });
+		expect(texts[0]).toMatch(/local model|Eliza Cloud/);
+		expect(runtime.createTask).toHaveBeenCalledTimes(1);
+		expect(pendingTasks[0]?.agentId).toBe(runtime.agentId);
+	});
+
+	it("does not let a matching planner option resolve ambiguous user text", async () => {
+		const { action: a, switchModel } = action({ ok: true });
+		const { callback } = captureCallback();
+		const result = await a.handler(
+			runtime,
+			message("switch model between local and cloud"),
+			undefined,
+			{ target: "cloud" },
+			callback,
+		);
+		expect(switchModel).not.toHaveBeenCalled();
+		expect(result?.values).toMatchObject({ awaitingTarget: true });
+		expect(runtime.createTask).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not let a planner invent a model tier for an explicit target", async () => {
+		const { action: a, switchModel } = action({
+			ok: true,
+			target: "local",
+		});
+		const { callback } = captureCallback();
+		await a.handler(
+			runtime,
+			message("switch to the local model"),
+			undefined,
+			{ target: "local", model: "eliza-1-4b" },
+			callback,
+		);
+		expect(switchModel).toHaveBeenCalledWith({ target: "local" });
+	});
+
+	it("consumes a persisted target choice on a real second action turn", async () => {
+		const { action: a, switchModel } = action({
+			ok: true,
+			target: "cloud",
+		});
+		const first = captureCallback();
+		await a.handler(
+			runtime,
+			message("switch to the faster model"),
+			undefined,
+			{ target: "local" },
+			first.callback,
+		);
+		expect(await a.validate(runtime, message("cloud"))).toBe(true);
+
+		const second = captureCallback();
+		const result = await a.handler(
+			runtime,
+			message("cloud"),
+			undefined,
+			{ target: "local" },
+			second.callback,
+		);
+		expect(switchModel).toHaveBeenCalledTimes(1);
+		expect(switchModel).toHaveBeenCalledWith({ target: "cloud" });
+		expect(result?.success).toBe(true);
+		expect(runtime.deleteTask).toHaveBeenCalledTimes(1);
+		expect(await a.validate(runtime, message("cloud"))).toBe(false);
+	});
+
+	it("clears a consumed target choice when the route refuses the switch", async () => {
+		const { action: a, switchModel } = action({
+			ok: false,
+			error: "no provider",
+		});
+		await a.handler(runtime, message("switch to the faster model"));
+
+		const result = await a.handler(runtime, message("cloud"));
+
+		expect(result?.success).toBe(false);
+		expect(switchModel).toHaveBeenCalledTimes(1);
+		expect(pendingTasks).toHaveLength(0);
+		expect(await a.validate(runtime, message("cloud"))).toBe(false);
+	});
+
+	it("clears a consumed target choice when the route throws", async () => {
+		const { action: a, switchModel } = action(new Error("ECONNREFUSED"));
+		await a.handler(runtime, message("switch to the faster model"));
+
+		const result = await a.handler(runtime, message("local"));
+
+		expect(result?.success).toBe(false);
+		expect(switchModel).toHaveBeenCalledTimes(1);
+		expect(pendingTasks).toHaveLength(0);
+	});
+
+	it("does not switch when the pending choice cannot be claimed", async () => {
+		const { action: a, switchModel } = action({ ok: true, target: "cloud" });
+		await a.handler(runtime, message("switch to the faster model"));
+		vi.mocked(runtime.deleteTask).mockRejectedValueOnce(
+			new Error("task store unavailable"),
+		);
+		const { callback, texts } = captureCallback();
+
+		const result = await a.handler(
+			runtime,
+			message("cloud"),
+			undefined,
+			undefined,
+			callback,
+		);
+
+		expect(result?.success).toBe(false);
+		expect(switchModel).not.toHaveBeenCalled();
+		expect(pendingTasks).toHaveLength(1);
+		expect(texts[0]).toMatch(/didn't switch anything/);
+	});
+
+	it("serializes concurrent targetless asks into one pending choice", async () => {
+		const { action: a, switchModel } = action({ ok: true });
+
+		await Promise.all([
+			a.handler(runtime, message("switch to the faster model")),
+			a.handler(runtime, message("switch model between local and cloud")),
+		]);
+
+		expect(runtime.createTask).toHaveBeenCalledTimes(1);
+		expect(pendingTasks).toHaveLength(1);
+		expect(switchModel).not.toHaveBeenCalled();
+	});
+
+	it("clears every duplicate pending choice before switching", async () => {
+		const { action: a, switchModel } = action({ ok: true, target: "cloud" });
+		const duplicate = {
+			name: "MODEL_SWITCH target choice",
+			description: "Awaiting an explicit target",
+			agentId: runtime.agentId,
+			roomId: "room-1" as UUID,
+			tags: ["MODEL_SWITCH_TARGET_CHOICE", "AWAITING_CHOICE"],
+			metadata: { choiceActionName: "MODEL_SWITCH" },
+		};
+		await runtime.createTask(duplicate);
+		await runtime.createTask(duplicate);
+
+		const result = await a.handler(runtime, message("use cloud inference"));
+
+		expect(result?.success).toBe(true);
+		expect(runtime.deleteTask).toHaveBeenCalledTimes(2);
+		expect(pendingTasks).toHaveLength(0);
+		expect(switchModel).toHaveBeenCalledTimes(1);
+	});
+
+	it("allows only one concurrent answer to consume a pending choice", async () => {
+		let resolveSwitch: ((outcome: ModelSwitchOutcome) => void) | undefined;
+		const switchModel = vi.fn(
+			() =>
+				new Promise<ModelSwitchOutcome>((resolve) => {
+					resolveSwitch = resolve;
+				}),
+		);
+		const a = createModelSwitchAction({ switchModel });
+		await a.handler(runtime, message("switch to the faster model"));
+
+		const localResult = a.handler(runtime, message("local"));
+		await vi.waitFor(() => expect(switchModel).toHaveBeenCalledTimes(1));
+		const cloudResult = a.handler(runtime, message("cloud"));
+		resolveSwitch?.({ ok: true, target: "local" });
+
+		const [first, second] = await Promise.all([localResult, cloudResult]);
+		expect(first?.success).toBe(true);
+		expect(second?.success).toBe(false);
+		expect(second?.text).toMatch(/no longer pending/);
+		expect(switchModel).toHaveBeenCalledTimes(1);
+		expect(pendingTasks).toHaveLength(0);
+	});
+
+	it("serializes global model switches across different rooms", async () => {
+		let resolveFirst: ((outcome: ModelSwitchOutcome) => void) | undefined;
+		const switchModel = vi
+			.fn<ModelSwitchFn>()
+			.mockImplementationOnce(
+				() =>
+					new Promise<ModelSwitchOutcome>((resolve) => {
+						resolveFirst = resolve;
+					}),
+			)
+			.mockResolvedValueOnce({ ok: true, target: "cloud" });
+		const a = createModelSwitchAction({ switchModel });
+
+		const localResult = a.handler(
+			runtime,
+			message("use the local model", "room-1" as UUID),
+		);
+		await vi.waitFor(() => expect(switchModel).toHaveBeenCalledTimes(1));
+		const cloudResult = a.handler(
+			runtime,
+			message("use cloud inference", "room-2" as UUID),
+		);
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(switchModel).toHaveBeenCalledTimes(1);
+
+		resolveFirst?.({ ok: true, target: "local" });
+		const [first, second] = await Promise.all([localResult, cloudResult]);
+		expect(first?.success).toBe(true);
+		expect(second?.success).toBe(true);
+		expect(switchModel).toHaveBeenNthCalledWith(1, { target: "local" });
+		expect(switchModel).toHaveBeenNthCalledWith(2, { target: "cloud" });
 	});
 
 	it("narrates a cloud switch", async () => {

--- a/plugins/plugin-app-control/src/actions/model-switch.test.ts
+++ b/plugins/plugin-app-control/src/actions/model-switch.test.ts
@@ -469,7 +469,13 @@ describe("MODEL_SWITCH handler", () => {
 			callback,
 		);
 		expect(switchModel).not.toHaveBeenCalled();
-		expect(result?.success).toBe(false);
+		expect(result).toMatchObject({
+			success: false,
+			userFacingText: expect.stringMatching(/sanctioned on-device model/),
+			verifiedUserFacing: true,
+			turnComplete: true,
+		});
+		expect(callback).toHaveBeenCalledTimes(1);
 		expect(texts[0]).toMatch(/sanctioned on-device model/);
 	});
 
@@ -483,7 +489,13 @@ describe("MODEL_SWITCH handler", () => {
 			{ target: "cloud" },
 			callback,
 		);
-		expect(result?.success).toBe(false);
+		expect(result).toMatchObject({
+			success: false,
+			userFacingText: expect.stringMatching(/no provider/),
+			verifiedUserFacing: true,
+			turnComplete: true,
+		});
+		expect(callback).toHaveBeenCalledTimes(1);
 		expect(texts[0]).toMatch(/no provider/);
 	});
 
@@ -497,7 +509,13 @@ describe("MODEL_SWITCH handler", () => {
 			{ target: "local" },
 			callback,
 		);
-		expect(result?.success).toBe(false);
+		expect(result).toMatchObject({
+			success: false,
+			userFacingText: expect.stringMatching(/ECONNREFUSED/),
+			verifiedUserFacing: true,
+			turnComplete: true,
+		});
+		expect(callback).toHaveBeenCalledTimes(1);
 		expect(texts[0]).toMatch(/ECONNREFUSED/);
 	});
 });

--- a/plugins/plugin-app-control/src/actions/model-switch.ts
+++ b/plugins/plugin-app-control/src/actions/model-switch.ts
@@ -19,6 +19,7 @@ import type {
 	IAgentRuntime,
 	Memory,
 	State,
+	UUID,
 } from "@elizaos/core";
 import { logger } from "@elizaos/core";
 import {
@@ -52,6 +53,31 @@ export interface ModelSwitchActionDeps {
 }
 
 const REQUEST_TIMEOUT_MS = 150_000;
+export const MODEL_SWITCH_TARGET_CHOICE_TAG = "MODEL_SWITCH_TARGET_CHOICE";
+const AWAITING_CHOICE_TAG = "AWAITING_CHOICE";
+const modelSwitchAgentOperations = new Map<UUID, Promise<void>>();
+
+async function withModelSwitchAgentLock<T>(
+	runtime: IAgentRuntime,
+	operation: () => Promise<T>,
+): Promise<T> {
+	const key = runtime.agentId;
+	const previous = modelSwitchAgentOperations.get(key);
+	let release: () => void = () => undefined;
+	const current = new Promise<void>((resolve) => {
+		release = resolve;
+	});
+	modelSwitchAgentOperations.set(key, current);
+	if (previous) await previous;
+	try {
+		return await operation();
+	} finally {
+		release();
+		if (modelSwitchAgentOperations.get(key) === current) {
+			modelSwitchAgentOperations.delete(key);
+		}
+	}
+}
 
 async function defaultSwitchModel(request: {
 	target: ModelSwitchTarget;
@@ -107,7 +133,46 @@ const SWITCH_VERB_RE = /\b(switch|use|change|move|go|run|swap)\b/i;
 // satisfy the noun requirement without the word "model".
 const MODEL_NOUN_RE =
 	/\b(model|inference|llm|eliza[\s-]?1|gemma|eliza\s?cloud|on[\s-]?device)\b/i;
-const MODEL_ID_RE = /\beliza-1-[a-z0-9-]+\b/i;
+const MODEL_ID_RE = /\b[a-z][a-z0-9]*(?:-[a-z0-9]+){2,}\b/i;
+
+type ParsedModelSwitchIntent =
+	| { kind: "request"; request: { target: ModelSwitchTarget; model?: string } }
+	| { kind: "needs-target" };
+
+function parseModelSwitchIntent(text: string): ParsedModelSwitchIntent | null {
+	const trimmed = text.trim();
+	if (!trimmed || !SWITCH_VERB_RE.test(trimmed)) return null;
+
+	const model = MODEL_ID_RE.exec(trimmed)?.[0]?.toLowerCase();
+	const namesInference =
+		MODEL_NOUN_RE.test(trimmed) ||
+		LOCAL_TARGET_RE.test(trimmed) ||
+		CLOUD_TARGET_RE.test(trimmed);
+	if (!namesInference) return null;
+
+	const wantsLocal =
+		LOCAL_TARGET_RE.test(trimmed) || Boolean(model?.startsWith("eliza-1-"));
+	const wantsCloud = CLOUD_TARGET_RE.test(trimmed);
+	if (wantsLocal === wantsCloud) return { kind: "needs-target" };
+
+	return {
+		kind: "request",
+		request: {
+			target: wantsCloud ? "cloud" : "local",
+			...(model ? { model } : {}),
+		},
+	};
+}
+
+/**
+ * Whether the user is asking to change inference, even when they have not yet
+ * named a sanctioned target. The action must remain exposed for that shape so
+ * its handler can ask for the missing target instead of letting SETTINGS
+ * shadow the dedicated model authority.
+ */
+export function isModelSwitchIntent(text: string): boolean {
+	return parseModelSwitchIntent(text) !== null;
+}
 
 /**
  * Deterministic target/model extraction from an explicit option or the
@@ -118,31 +183,72 @@ export function inferModelSwitchRequest(
 	text: string,
 	options?: Record<string, unknown>,
 ): { target: ModelSwitchTarget; model?: string } | null {
-	const explicitTarget = readStringOption(options, "target")?.toLowerCase();
-	const explicitModel = readStringOption(options, "model") ?? undefined;
-	if (explicitTarget === "local" || explicitTarget === "cloud") {
+	const trimmed = text.trim();
+	if (!trimmed) {
+		const explicitTarget = readStringOption(options, "target")?.toLowerCase();
+		const explicitModel = readStringOption(options, "model") ?? undefined;
+		if (explicitTarget !== "local" && explicitTarget !== "cloud") return null;
 		return {
 			target: explicitTarget,
 			...(explicitModel && { model: explicitModel }),
 		};
 	}
+	const parsed = parseModelSwitchIntent(trimmed);
+	return parsed?.kind === "request" ? parsed.request : null;
+}
 
-	const trimmed = text.trim();
-	if (!trimmed) return null;
-	const model = explicitModel ?? MODEL_ID_RE.exec(trimmed)?.[0]?.toLowerCase();
+export function isModelSwitchTargetChoice(text: string): boolean {
+	return /^(?:local|cloud)$/i.test(text.trim());
+}
 
-	// A named Eliza-1 tier implies the local target even without the word
-	// "local" ("switch to eliza-1-4b").
-	const wantsLocal = LOCAL_TARGET_RE.test(trimmed) || Boolean(model);
-	const wantsCloud = CLOUD_TARGET_RE.test(trimmed);
-	if (wantsLocal === wantsCloud) return null; // ambiguous or absent
-	if (!SWITCH_VERB_RE.test(trimmed) || !MODEL_NOUN_RE.test(trimmed))
-		return null;
+async function findPendingModelSwitchTargets(
+	runtime: IAgentRuntime,
+	roomId: UUID,
+) {
+	const tasks = await runtime.getTasks({
+		roomId,
+		tags: [MODEL_SWITCH_TARGET_CHOICE_TAG],
+		agentIds: [runtime.agentId],
+	});
+	return tasks.filter(
+		(task) => task.metadata?.choiceActionName === "MODEL_SWITCH" && task.id,
+	);
+}
 
-	return {
-		target: wantsCloud ? "cloud" : "local",
-		...(model ? { model } : {}),
-	};
+export async function hasPendingModelSwitchTarget(
+	runtime: IAgentRuntime,
+	roomId: UUID,
+): Promise<boolean> {
+	return (await findPendingModelSwitchTargets(runtime, roomId)).length > 0;
+}
+
+async function persistPendingModelSwitchTarget(
+	runtime: IAgentRuntime,
+	roomId: UUID,
+): Promise<void> {
+	if (await hasPendingModelSwitchTarget(runtime, roomId)) return;
+	await runtime.createTask({
+		name: "MODEL_SWITCH target choice",
+		description: "Awaiting an explicit local or cloud inference target",
+		agentId: runtime.agentId,
+		roomId,
+		tags: [MODEL_SWITCH_TARGET_CHOICE_TAG, AWAITING_CHOICE_TAG],
+		metadata: {
+			options: [
+				{ name: "local", description: "Run inference on this device" },
+				{ name: "cloud", description: "Run inference in Eliza Cloud" },
+			],
+			choiceActionName: "MODEL_SWITCH",
+		},
+	});
+}
+
+async function clearPendingModelSwitchTarget(
+	runtime: IAgentRuntime,
+	roomId: UUID,
+): Promise<void> {
+	const pending = await findPendingModelSwitchTargets(runtime, roomId);
+	await Promise.all(pending.map((task) => runtime.deleteTask(task.id as UUID)));
 }
 
 /**
@@ -217,8 +323,8 @@ export function createModelSwitchAction(
 			{
 				name: "target",
 				description:
-					"Where text inference should run: local (on-device Eliza-1) or cloud (Eliza Cloud).",
-				required: true,
+					"Where text inference should run: local (on-device Eliza-1) or cloud (Eliza Cloud). Omit when the user has not named a target; the action will ask them to choose without changing anything.",
+				required: false,
 				schema: { type: "string", enum: ["local", "cloud"] },
 			},
 			{
@@ -231,61 +337,145 @@ export function createModelSwitchAction(
 		],
 
 		validate: async (
-			_runtime: IAgentRuntime,
+			runtime: IAgentRuntime,
 			message: Memory,
 		): Promise<boolean> => {
+			const text = userRequestMessageText(message);
+			if (isModelSwitchIntent(text)) return true;
 			return (
-				inferModelSwitchRequest(userRequestMessageText(message), undefined) !==
-				null
+				isModelSwitchTargetChoice(text) &&
+				(await hasPendingModelSwitchTarget(runtime, message.roomId))
 			);
 		},
 
 		handler: async (
-			_runtime: IAgentRuntime,
+			runtime: IAgentRuntime,
 			message: Memory,
 			_state?: State,
 			options?: Record<string, unknown>,
 			callback?: HandlerCallback,
-		): Promise<ActionResult> => {
-			const request = inferModelSwitchRequest(
-				userRequestMessageText(message),
-				options,
-			);
-			if (!request) {
-				// The ask IS the turn's complete answer: verified + turnComplete
-				// make the callback the sole delivery instead of double-messaging
-				// with the evaluator; the un-resolved state stays in values.
-				const reply =
-					'Tell me where to run inference — "switch to the local model" or "use Eliza Cloud". You can also name a tier, e.g. "use eliza-1-4b".';
-				await callback?.({ text: reply });
-				return {
-					success: true,
-					text: "No inference target named; asked the user where to run inference.",
-					userFacingText: reply,
-					verifiedUserFacing: true,
-					turnComplete: true,
-					values: { awaitingTarget: true },
-				};
-			}
+		): Promise<ActionResult> =>
+			withModelSwitchAgentLock(runtime, async () => {
+				const userText = userRequestMessageText(message);
+				const isTargetChoice = isModelSwitchTargetChoice(userText);
+				const pendingTargets = await findPendingModelSwitchTargets(
+					runtime,
+					message.roomId,
+				);
+				if (isTargetChoice && pendingTargets.length === 0) {
+					const reply =
+						'That model choice is no longer pending. Tell me the full switch you want, such as "switch to the local model" or "use Eliza Cloud".';
+					await callback?.({ text: reply });
+					return {
+						success: false,
+						text: reply,
+						userFacingText: reply,
+						verifiedUserFacing: true,
+						turnComplete: true,
+					};
+				}
+				const request = isTargetChoice
+					? { target: userText.trim().toLowerCase() as ModelSwitchTarget }
+					: inferModelSwitchRequest(userText, options);
+				if (!request) {
+					await persistPendingModelSwitchTarget(runtime, message.roomId);
+					// The ask IS the turn's complete answer: verified + turnComplete
+					// make the callback the sole delivery instead of double-messaging
+					// with the evaluator; the un-resolved state stays in values.
+					const reply =
+						'Tell me where to run inference — "switch to the local model" or "use Eliza Cloud". You can also name a tier, e.g. "use eliza-1-4b".';
+					await callback?.({ text: reply });
+					return {
+						success: true,
+						text: "No inference target named; asked the user where to run inference.",
+						userFacingText: reply,
+						verifiedUserFacing: true,
+						turnComplete: true,
+						values: { awaitingTarget: true },
+					};
+				}
 
-			const refusal = sanctionedModelError(request.target, request.model);
-			if (refusal) {
-				await callback?.({ text: refusal });
-				return {
-					success: false,
-					text: refusal,
-					values: { target: request.target, model: request.model },
-				};
-			}
+				if (pendingTargets.length > 0) {
+					try {
+						await clearPendingModelSwitchTarget(runtime, message.roomId);
+					} catch (err) {
+						// error-policy:J4 A task-store failure becomes a visible refusal
+						// before the global inference backend can be mutated.
+						const messageText =
+							err instanceof Error ? err.message : String(err);
+						logger.error(
+							`[plugin-app-control] MODEL_SWITCH could not claim pending choice: ${messageText}`,
+						);
+						const reply =
+							"I couldn't safely record that model choice, so I didn't switch anything. Please try again.";
+						await callback?.({ text: reply });
+						return {
+							success: false,
+							text: reply,
+							userFacingText: reply,
+							verifiedUserFacing: true,
+							turnComplete: true,
+						};
+					}
+				}
 
-			logger.info(
-				`[plugin-app-control] MODEL_SWITCH target=${request.target}${request.model ? ` model=${request.model}` : ""}`,
-			);
+				const refusal = sanctionedModelError(request.target, request.model);
+				if (refusal) {
+					await callback?.({ text: refusal });
+					return {
+						success: false,
+						text: refusal,
+						values: { target: request.target, model: request.model },
+					};
+				}
 
-			try {
-				const outcome = await switchModel(request);
-				if (!outcome.ok) {
-					const reply = `I couldn't switch the model: ${outcome.error ?? "unknown error"}.`;
+				logger.info(
+					`[plugin-app-control] MODEL_SWITCH target=${request.target}${request.model ? ` model=${request.model}` : ""}`,
+				);
+
+				try {
+					const outcome = await switchModel(request);
+					if (!outcome.ok) {
+						const reply = `I couldn't switch the model: ${outcome.error ?? "unknown error"}.`;
+						await callback?.({ text: reply });
+						return {
+							success: false,
+							text: reply,
+							values: { target: request.target, model: request.model },
+						};
+					}
+					const reply = narrate(outcome);
+					await callback?.({ text: reply });
+					// The switch confirmation is the complete answer to a
+					// single-operation turn: verified + turnComplete make the callback
+					// the sole delivery instead of double-messaging with the evaluator.
+					return {
+						success: true,
+						text: reply,
+						userFacingText: reply,
+						verifiedUserFacing: true,
+						turnComplete: true,
+						values: {
+							target: outcome.target ?? request.target,
+							model: outcome.model,
+							status: outcome.status,
+						},
+						data: {
+							target: outcome.target ?? request.target,
+							model: outcome.model,
+							displayName: outcome.displayName,
+							status: outcome.status,
+							...(outcome.downloadSizeGb !== undefined
+								? { downloadSizeGb: outcome.downloadSizeGb }
+								: {}),
+						},
+					};
+				} catch (err) {
+					const messageText = err instanceof Error ? err.message : String(err);
+					logger.error(
+						`[plugin-app-control] MODEL_SWITCH failed: ${messageText}`,
+					);
+					const reply = `I couldn't switch the model: ${messageText}.`;
 					await callback?.({ text: reply });
 					return {
 						success: false,
@@ -293,46 +483,7 @@ export function createModelSwitchAction(
 						values: { target: request.target, model: request.model },
 					};
 				}
-				const reply = narrate(outcome);
-				await callback?.({ text: reply });
-				// The switch confirmation is the complete answer to a
-				// single-operation turn: verified + turnComplete make the callback
-				// the sole delivery instead of double-messaging with the evaluator.
-				return {
-					success: true,
-					text: reply,
-					userFacingText: reply,
-					verifiedUserFacing: true,
-					turnComplete: true,
-					values: {
-						target: outcome.target ?? request.target,
-						model: outcome.model,
-						status: outcome.status,
-					},
-					data: {
-						target: outcome.target ?? request.target,
-						model: outcome.model,
-						displayName: outcome.displayName,
-						status: outcome.status,
-						...(outcome.downloadSizeGb !== undefined
-							? { downloadSizeGb: outcome.downloadSizeGb }
-							: {}),
-					},
-				};
-			} catch (err) {
-				const messageText = err instanceof Error ? err.message : String(err);
-				logger.error(
-					`[plugin-app-control] MODEL_SWITCH failed: ${messageText}`,
-				);
-				const reply = `I couldn't switch the model: ${messageText}.`;
-				await callback?.({ text: reply });
-				return {
-					success: false,
-					text: reply,
-					values: { target: request.target, model: request.model },
-				};
-			}
-		},
+			}),
 	};
 }
 

--- a/plugins/plugin-app-control/src/actions/model-switch.ts
+++ b/plugins/plugin-app-control/src/actions/model-switch.ts
@@ -425,6 +425,9 @@ export function createModelSwitchAction(
 					return {
 						success: false,
 						text: refusal,
+						userFacingText: refusal,
+						verifiedUserFacing: true,
+						turnComplete: true,
 						values: { target: request.target, model: request.model },
 					};
 				}
@@ -441,6 +444,9 @@ export function createModelSwitchAction(
 						return {
 							success: false,
 							text: reply,
+							userFacingText: reply,
+							verifiedUserFacing: true,
+							turnComplete: true,
 							values: { target: request.target, model: request.model },
 						};
 					}
@@ -480,6 +486,9 @@ export function createModelSwitchAction(
 					return {
 						success: false,
 						text: reply,
+						userFacingText: reply,
+						verifiedUserFacing: true,
+						turnComplete: true,
 						values: { target: request.target, model: request.model },
 					};
 				}

--- a/plugins/plugin-app-control/src/actions/settings-routing.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings-routing.test.ts
@@ -156,4 +156,13 @@ describe("SETTINGS is discoverable for un-actioned settings writes (#14364)", ()
 		});
 		expect(exposedParents(tiered)).toContain("MODEL_SWITCH");
 	});
+
+	it("exposes MODEL_SWITCH for a preference-shaped request that needs disambiguation", () => {
+		const { tiered } = routeTurn({
+			messageText: "switch to the faster model",
+			candidateActions: ["SWITCH_MODEL", "UPDATE_SETTINGS"],
+			selectedContexts: ["settings"],
+		});
+		expect(exposedParents(tiered)).toContain("MODEL_SWITCH");
+	});
 });

--- a/plugins/plugin-app-control/src/actions/views-loopback-auth.integration.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-loopback-auth.integration.test.ts
@@ -529,7 +529,12 @@ describe("authenticated view loopback requests", () => {
 		process.env.ELIZA_PORT = String(server.port);
 		process.env.ELIZA_API_TOKEN = token;
 
-		const runtime = { agentId: "agent-1" } as never;
+		const runtime = {
+			agentId: "agent-1",
+			getTasks: async () => [],
+			createTask: async () => "task-1",
+			deleteTask: async () => undefined,
+		} as never;
 		const message = (text: string) =>
 			({
 				entityId: "user-1",

--- a/plugins/plugin-app-control/src/evaluators/create-choice-shortcut.test.ts
+++ b/plugins/plugin-app-control/src/evaluators/create-choice-shortcut.test.ts
@@ -104,6 +104,14 @@ function modelSwitchIntent(roomId = "room-1") {
 }
 
 describe("createChoiceShortcutEvaluator", () => {
+	it("declares only its owned deterministic actions", () => {
+		expect(createChoiceShortcutEvaluator.deterministicActions).toEqual([
+			"APP",
+			"MODEL_SWITCH",
+			"VIEWS",
+		]);
+	});
+
 	it("forces a pending APP create choice reply through APP", async () => {
 		const ctx = context("cancel", [appIntent()]);
 

--- a/plugins/plugin-app-control/src/evaluators/create-choice-shortcut.test.ts
+++ b/plugins/plugin-app-control/src/evaluators/create-choice-shortcut.test.ts
@@ -141,6 +141,85 @@ describe("createChoiceShortcutEvaluator", () => {
 		);
 	});
 
+	it("routes an ambiguous model-switch request before a planner can narrate", async () => {
+		const tasks: Task[] = [];
+		const switchModel = vi.fn(async () => ({
+			ok: true,
+			target: "cloud" as const,
+		}));
+		const action = createModelSwitchAction({ switchModel });
+		const runtime = {
+			agentId: "agent-1" as UUID,
+			actions: [action],
+			getTasks: vi.fn(async ({ roomId, tags, agentIds }) =>
+				tasks.filter(
+					(task) =>
+						(!roomId || task.roomId === roomId) &&
+						task.agentId !== undefined &&
+						agentIds.includes(task.agentId) &&
+						(!tags || tags.every((tag) => task.tags?.includes(tag))),
+				),
+			),
+			createTask: vi.fn(async (task: Task) => {
+				const id = "model-switch-task" as UUID;
+				tasks.push({ ...task, id });
+				return id;
+			}),
+			deleteTask: vi.fn(async () => undefined),
+		} as unknown as IAgentRuntime;
+		const ctx = context("switch to the faster model", [], [action]);
+		ctx.runtime = runtime;
+
+		expect(await createChoiceShortcutEvaluator.shouldRun(ctx)).toBe(true);
+		const shortcut = await createChoiceShortcutEvaluator.evaluate(ctx);
+		expect(shortcut?.deterministicToolCall).toEqual({
+			name: "MODEL_SWITCH",
+			params: {},
+		});
+
+		const result = await action.handler(
+			runtime,
+			ctx.message,
+			ctx.state,
+			shortcut?.deterministicToolCall?.params,
+		);
+		expect(result?.values).toMatchObject({ awaitingTarget: true });
+		expect(switchModel).not.toHaveBeenCalled();
+		expect(tasks).toHaveLength(1);
+	});
+
+	it("routes an explicit model-switch request with the user-authored target", async () => {
+		const ctx = context("use the local model", []);
+
+		expect(await createChoiceShortcutEvaluator.shouldRun(ctx)).toBe(true);
+		expect(
+			(await createChoiceShortcutEvaluator.evaluate(ctx))
+				?.deterministicToolCall,
+		).toEqual({ name: "MODEL_SWITCH", params: { target: "local" } });
+	});
+
+	it("does not claim model questions, unrelated settings, or stopped turns", async () => {
+		for (const text of [
+			"what model are you using?",
+			"change notification-sound-volume",
+		]) {
+			const ctx = context(text, []);
+			expect(await createChoiceShortcutEvaluator.shouldRun(ctx)).toBe(false);
+		}
+		const stopped = context("switch to the local model", []);
+		stopped.messageHandler.processMessage = "STOP";
+		expect(await createChoiceShortcutEvaluator.shouldRun(stopped)).toBe(false);
+
+		const unregistered = context(
+			"switch to the local model",
+			[],
+			[{ name: "APP" }],
+		);
+		expect(await createChoiceShortcutEvaluator.shouldRun(unregistered)).toBe(
+			false,
+		);
+	});
+
 	it("routes a persisted MODEL_SWITCH clarification through the real two-turn action flow", async () => {
 		const tasks: Task[] = [];
 		const switchModel = vi.fn(async () => ({

--- a/plugins/plugin-app-control/src/evaluators/create-choice-shortcut.test.ts
+++ b/plugins/plugin-app-control/src/evaluators/create-choice-shortcut.test.ts
@@ -1,13 +1,23 @@
 /**
- * Tests deterministic routing for pending create [CHOICE] replies.
+ * Tests deterministic routing for persisted app-control choices.
  */
 
-import type { ResponseHandlerEvaluatorContext } from "@elizaos/core";
+import type {
+	IAgentRuntime,
+	Memory,
+	ResponseHandlerEvaluatorContext,
+	Task,
+	UUID,
+} from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {
 	APP_CREATE_INTENT_TAG,
 	type IntentTaskMetadata,
 } from "../actions/app-create.js";
+import {
+	createModelSwitchAction,
+	MODEL_SWITCH_TARGET_CHOICE_TAG,
+} from "../actions/model-switch.js";
 import { VIEWS_CREATE_INTENT_TAG } from "../actions/views-create.js";
 import { createChoiceShortcutEvaluator } from "./create-choice-shortcut.js";
 
@@ -19,17 +29,25 @@ function context(
 	text: string,
 	tasks: Array<{
 		id: string;
+		roomId?: string;
 		tags: string[];
 		metadata: Record<string, unknown>;
 	}>,
-	actions = [{ name: "APP" }, { name: "VIEWS" }],
+	actions = [{ name: "APP" }, { name: "MODEL_SWITCH" }, { name: "VIEWS" }],
 ): ResponseHandlerEvaluatorContext {
 	return {
 		runtime: {
 			agentId: "agent-1",
 			actions,
-			getTasks: vi.fn(async ({ tags }: { tags?: string[] }) =>
-				tasks.filter((task) => tags?.every((tag) => task.tags.includes(tag))),
+			getTasks: vi.fn(
+				async ({ roomId, tags }: { roomId?: string; tags?: string[] }) =>
+					tasks.filter(
+						(task) =>
+							(!roomId ||
+								task.roomId === roomId ||
+								task.metadata.roomId === roomId) &&
+							(!tags || tags.every((tag) => task.tags.includes(tag))),
+					),
 			),
 		},
 		message: message(text),
@@ -70,6 +88,21 @@ function viewsIntent(roomId = "room-1") {
 	};
 }
 
+function modelSwitchIntent(roomId = "room-1") {
+	return {
+		id: "model-switch-intent-1",
+		roomId,
+		tags: [MODEL_SWITCH_TARGET_CHOICE_TAG, "AWAITING_CHOICE"],
+		metadata: {
+			choiceActionName: "MODEL_SWITCH",
+			options: [
+				{ name: "local", description: "Run locally" },
+				{ name: "cloud", description: "Run in Eliza Cloud" },
+			],
+		},
+	};
+}
+
 describe("createChoiceShortcutEvaluator", () => {
 	it("forces a pending APP create choice reply through APP", async () => {
 		const ctx = context("cancel", [appIntent()]);
@@ -105,6 +138,76 @@ describe("createChoiceShortcutEvaluator", () => {
 					params: { action: "create", choice: "edit-1" },
 				},
 			}),
+		);
+	});
+
+	it("routes a persisted MODEL_SWITCH clarification through the real two-turn action flow", async () => {
+		const tasks: Task[] = [];
+		const switchModel = vi.fn(async () => ({
+			ok: true,
+			target: "cloud" as const,
+		}));
+		const action = createModelSwitchAction({ switchModel });
+		const runtime = {
+			agentId: "agent-1" as UUID,
+			actions: [action],
+			getTasks: vi.fn(async ({ roomId, tags, agentIds }) =>
+				tasks.filter(
+					(task) =>
+						(!roomId || task.roomId === roomId) &&
+						task.agentId !== undefined &&
+						agentIds.includes(task.agentId) &&
+						(!tags || tags.every((tag) => task.tags?.includes(tag))),
+				),
+			),
+			createTask: vi.fn(async (task: Task) => {
+				const id = "model-switch-task" as UUID;
+				tasks.push({ ...task, id });
+				return id;
+			}),
+			deleteTask: vi.fn(async (id: UUID) => {
+				const index = tasks.findIndex((task) => task.id === id);
+				if (index >= 0) tasks.splice(index, 1);
+			}),
+		} as unknown as IAgentRuntime;
+		const first = message("switch to the faster model") as Memory;
+		await action.handler(runtime, first, undefined, { target: "cloud" });
+		expect(tasks).toHaveLength(1);
+
+		const ctx = context("cloud", [], [action]);
+		ctx.runtime = runtime;
+		expect(await createChoiceShortcutEvaluator.shouldRun(ctx)).toBe(true);
+		const patch = await createChoiceShortcutEvaluator.evaluate(ctx);
+		expect(patch?.deterministicToolCall).toEqual({
+			name: "MODEL_SWITCH",
+			params: { target: "cloud" },
+		});
+
+		const second = message("cloud") as Memory;
+		expect(await action.validate(runtime, second)).toBe(true);
+		await action.handler(
+			runtime,
+			second,
+			undefined,
+			patch?.deterministicToolCall?.params,
+		);
+		expect(switchModel).toHaveBeenCalledTimes(1);
+		expect(switchModel).toHaveBeenCalledWith({ target: "cloud" });
+		expect(tasks).toHaveLength(0);
+	});
+
+	it("routes a model target only while that room has a pending choice", async () => {
+		const ctx = context("local", [modelSwitchIntent()]);
+		expect(await createChoiceShortcutEvaluator.shouldRun(ctx)).toBe(true);
+		expect(
+			(await createChoiceShortcutEvaluator.evaluate(ctx))
+				?.deterministicToolCall,
+		).toEqual({ name: "MODEL_SWITCH", params: { target: "local" } });
+
+		const unrelatedRoom = context("local", [modelSwitchIntent()]);
+		unrelatedRoom.message.roomId = "room-2" as UUID;
+		expect(await createChoiceShortcutEvaluator.shouldRun(unrelatedRoom)).toBe(
+			false,
 		);
 	});
 

--- a/plugins/plugin-app-control/src/evaluators/create-choice-shortcut.ts
+++ b/plugins/plugin-app-control/src/evaluators/create-choice-shortcut.ts
@@ -17,6 +17,8 @@ import {
 } from "../actions/app-create.js";
 import {
 	hasPendingModelSwitchTarget,
+	inferModelSwitchRequest,
+	isModelSwitchIntent,
 	isModelSwitchTargetChoice,
 } from "../actions/model-switch.js";
 import { hasPendingViewsCreateIntent } from "../actions/views-create.js";
@@ -26,6 +28,15 @@ const APP_ACTION_NAME = "APP";
 const MODEL_SWITCH_ACTION_NAME = "MODEL_SWITCH";
 const VIEWS_ACTION_NAME = "VIEWS";
 const GENERAL_CONTEXT = "general";
+
+interface ChoiceShortcut {
+	actionName:
+		| typeof APP_ACTION_NAME
+		| typeof MODEL_SWITCH_ACTION_NAME
+		| typeof VIEWS_ACTION_NAME;
+	params: Record<string, string>;
+	debug: string;
+}
 
 function messageText(context: ResponseHandlerEvaluatorContext): string {
 	// Security-unwrapped user words — a choice reply ("cancel", "edit-1") must
@@ -49,16 +60,22 @@ function hasRegisteredAction(
 	);
 }
 
-async function resolvePendingChoiceAction(
+async function resolveChoiceShortcut(
 	context: ResponseHandlerEvaluatorContext,
-): Promise<
-	| typeof APP_ACTION_NAME
-	| typeof MODEL_SWITCH_ACTION_NAME
-	| typeof VIEWS_ACTION_NAME
-	| null
-> {
+): Promise<ChoiceShortcut | null> {
 	if (context.messageHandler.processMessage === "STOP") return null;
 	const choice = messageText(context).trim();
+	if (
+		hasRegisteredAction(context, MODEL_SWITCH_ACTION_NAME) &&
+		isModelSwitchIntent(choice)
+	) {
+		const request = inferModelSwitchRequest(choice);
+		return {
+			actionName: MODEL_SWITCH_ACTION_NAME,
+			params: request ?? {},
+			debug: `explicit model-switch request "${choice}" routed deterministically`,
+		};
+	}
 	const id = roomId(context);
 	const appChoice = isAppCreateChoiceReply(choice);
 	const modelChoice = isModelSwitchTargetChoice(choice);
@@ -82,39 +99,40 @@ async function resolvePendingChoiceAction(
 	if (appPending) pending.push(APP_ACTION_NAME);
 	if (viewsPending) pending.push(VIEWS_ACTION_NAME);
 	if (modelPending) pending.push(MODEL_SWITCH_ACTION_NAME);
-	return pending.length === 1 ? pending[0] : null;
+	if (pending.length !== 1) return null;
+	const actionName = pending[0];
+	return {
+		actionName,
+		params:
+			actionName === MODEL_SWITCH_ACTION_NAME
+				? { target: choice.toLowerCase() }
+				: { action: "create", choice },
+		debug: `pending ${actionName} choice "${choice}" routed deterministically`,
+	};
 }
 
 export const createChoiceShortcutEvaluator: ResponseHandlerEvaluator = {
 	name: "app-control.create-choice-shortcut",
 	description:
-		"Deterministically routes app-control choice replies back through the action that persisted the pending choice.",
+		"Deterministically routes explicit model-switch requests and app-control choice replies through their owning action.",
 	priority: 12,
-	shouldRun: async (context) =>
-		(await resolvePendingChoiceAction(context)) !== null,
+	shouldRun: async (context) => (await resolveChoiceShortcut(context)) !== null,
 	evaluate: async (context) => {
-		const actionName = await resolvePendingChoiceAction(context);
-		if (!actionName) return undefined;
-		const choice = messageText(context).trim().toLowerCase();
-		const params: Record<string, string> =
-			actionName === MODEL_SWITCH_ACTION_NAME
-				? { target: choice }
-				: { action: "create", choice };
+		const shortcut = await resolveChoiceShortcut(context);
+		if (!shortcut) return undefined;
 		return {
 			requiresTool: true,
 			clearReply: true,
 			clearCandidateActions: true,
-			addCandidateActions: [actionName],
+			addCandidateActions: [shortcut.actionName],
 			clearParentActionHints: true,
-			addParentActionHints: [actionName],
+			addParentActionHints: [shortcut.actionName],
 			addContexts: [GENERAL_CONTEXT],
 			deterministicToolCall: {
-				name: actionName,
-				params,
+				name: shortcut.actionName,
+				params: shortcut.params,
 			},
-			debug: [
-				`pending ${actionName} choice "${choice}" routed deterministically`,
-			],
+			debug: [shortcut.debug],
 		};
 	},
 };

--- a/plugins/plugin-app-control/src/evaluators/create-choice-shortcut.ts
+++ b/plugins/plugin-app-control/src/evaluators/create-choice-shortcut.ts
@@ -116,6 +116,11 @@ export const createChoiceShortcutEvaluator: ResponseHandlerEvaluator = {
 	description:
 		"Deterministically routes explicit model-switch requests and app-control choice replies through their owning action.",
 	priority: 12,
+	deterministicActions: [
+		APP_ACTION_NAME,
+		MODEL_SWITCH_ACTION_NAME,
+		VIEWS_ACTION_NAME,
+	],
 	shouldRun: async (context) => (await resolveChoiceShortcut(context)) !== null,
 	evaluate: async (context) => {
 		const shortcut = await resolveChoiceShortcut(context);

--- a/plugins/plugin-app-control/src/evaluators/create-choice-shortcut.ts
+++ b/plugins/plugin-app-control/src/evaluators/create-choice-shortcut.ts
@@ -1,9 +1,9 @@
 /**
- * Deterministic response-handler shortcut for APP/VIEWS create choice replies.
+ * Deterministic response-handler shortcut for persisted app-control choices.
  *
- * The create flows persist a pending intent task after showing a [CHOICE] block.
- * A later bare reply like "cancel" or "edit-1" is therefore domain input, not
- * a chat message to paraphrase. Force it back through the owning action so the
+ * App/view creation and model-target clarification persist room-scoped
+ * AWAITING_CHOICE tasks. A later bare reply is therefore domain input, not a
+ * chat message to paraphrase. Force it back through the owning action so the
  * model cannot answer with REPLY and leave the task stranded.
  */
 
@@ -15,10 +15,15 @@ import {
 	hasPendingIntent,
 	isChoiceReply as isAppCreateChoiceReply,
 } from "../actions/app-create.js";
+import {
+	hasPendingModelSwitchTarget,
+	isModelSwitchTargetChoice,
+} from "../actions/model-switch.js";
 import { hasPendingViewsCreateIntent } from "../actions/views-create.js";
 import { userRequestMessageText } from "../params.js";
 
 const APP_ACTION_NAME = "APP";
+const MODEL_SWITCH_ACTION_NAME = "MODEL_SWITCH";
 const VIEWS_ACTION_NAME = "VIEWS";
 const GENERAL_CONTEXT = "general";
 
@@ -46,27 +51,44 @@ function hasRegisteredAction(
 
 async function resolvePendingChoiceAction(
 	context: ResponseHandlerEvaluatorContext,
-): Promise<typeof APP_ACTION_NAME | typeof VIEWS_ACTION_NAME | null> {
+): Promise<
+	| typeof APP_ACTION_NAME
+	| typeof MODEL_SWITCH_ACTION_NAME
+	| typeof VIEWS_ACTION_NAME
+	| null
+> {
 	if (context.messageHandler.processMessage === "STOP") return null;
 	const choice = messageText(context).trim();
-	if (!isAppCreateChoiceReply(choice)) return null;
 	const id = roomId(context);
-	const [appPending, viewsPending] = await Promise.all([
-		hasRegisteredAction(context, APP_ACTION_NAME)
+	const appChoice = isAppCreateChoiceReply(choice);
+	const modelChoice = isModelSwitchTargetChoice(choice);
+	if (!appChoice && !modelChoice) return null;
+	const [appPending, viewsPending, modelPending] = await Promise.all([
+		appChoice && hasRegisteredAction(context, APP_ACTION_NAME)
 			? hasPendingIntent(context.runtime, id)
 			: Promise.resolve(false),
-		hasRegisteredAction(context, VIEWS_ACTION_NAME)
+		appChoice && hasRegisteredAction(context, VIEWS_ACTION_NAME)
 			? hasPendingViewsCreateIntent(context.runtime, id)
 			: Promise.resolve(false),
+		modelChoice && hasRegisteredAction(context, MODEL_SWITCH_ACTION_NAME)
+			? hasPendingModelSwitchTarget(context.runtime, id)
+			: Promise.resolve(false),
 	]);
-	if (appPending === viewsPending) return null;
-	return appPending ? APP_ACTION_NAME : VIEWS_ACTION_NAME;
+	const pending: Array<
+		| typeof APP_ACTION_NAME
+		| typeof MODEL_SWITCH_ACTION_NAME
+		| typeof VIEWS_ACTION_NAME
+	> = [];
+	if (appPending) pending.push(APP_ACTION_NAME);
+	if (viewsPending) pending.push(VIEWS_ACTION_NAME);
+	if (modelPending) pending.push(MODEL_SWITCH_ACTION_NAME);
+	return pending.length === 1 ? pending[0] : null;
 }
 
 export const createChoiceShortcutEvaluator: ResponseHandlerEvaluator = {
 	name: "app-control.create-choice-shortcut",
 	description:
-		"Deterministically routes APP/VIEWS create [CHOICE] replies back through the pending create action.",
+		"Deterministically routes app-control choice replies back through the action that persisted the pending choice.",
 	priority: 12,
 	shouldRun: async (context) =>
 		(await resolvePendingChoiceAction(context)) !== null,
@@ -74,6 +96,10 @@ export const createChoiceShortcutEvaluator: ResponseHandlerEvaluator = {
 		const actionName = await resolvePendingChoiceAction(context);
 		if (!actionName) return undefined;
 		const choice = messageText(context).trim().toLowerCase();
+		const params: Record<string, string> =
+			actionName === MODEL_SWITCH_ACTION_NAME
+				? { target: choice }
+				: { action: "create", choice };
 		return {
 			requiresTool: true,
 			clearReply: true,
@@ -84,10 +110,10 @@ export const createChoiceShortcutEvaluator: ResponseHandlerEvaluator = {
 			addContexts: [GENERAL_CONTEXT],
 			deterministicToolCall: {
 				name: actionName,
-				params: { action: "create", choice },
+				params,
 			},
 			debug: [
-				`pending ${actionName} create choice "${choice}" routed deterministically`,
+				`pending ${actionName} choice "${choice}" routed deterministically`,
 			],
 		};
 	},

--- a/plugins/plugin-app-control/src/evaluators/view-command-shortcut.test.ts
+++ b/plugins/plugin-app-control/src/evaluators/view-command-shortcut.test.ts
@@ -47,6 +47,12 @@ async function run(text: string, opts = {}) {
 }
 
 describe("viewCommandShortcutEvaluator — forces VIEWS on explicit commands", () => {
+	it("declares VIEWS as its only deterministic action", () => {
+		expect(viewCommandShortcutEvaluator.deterministicActions).toEqual([
+			"VIEWS",
+		]);
+	});
+
 	const commands: Array<[text: string, view: string]> = [
 		["settings", "settings"],
 		["open settings", "settings"],

--- a/plugins/plugin-app-control/src/evaluators/view-command-shortcut.ts
+++ b/plugins/plugin-app-control/src/evaluators/view-command-shortcut.ts
@@ -43,6 +43,7 @@ export const viewCommandShortcutEvaluator: ResponseHandlerEvaluator = {
 	// Run before core.simple_registered_action_request (20) so deterministic view
 	// intents never get captured by a broader coding/domain action first.
 	priority: 10,
+	deterministicActions: [VIEWS_ACTION_NAME],
 	shouldRun: (context) => shouldShortcut(context) !== null,
 	evaluate: (context) => {
 		const viewId = shouldShortcut(context);

--- a/plugins/plugin-app-control/src/evaluators/view-followup-routing.test.ts
+++ b/plugins/plugin-app-control/src/evaluators/view-followup-routing.test.ts
@@ -92,6 +92,12 @@ describe("viewFollowupRoutingEvaluator", () => {
 		vi.restoreAllMocks();
 	});
 
+	it("declares VIEWS as its only deterministic action", () => {
+		expect(viewFollowupRoutingEvaluator.deterministicActions).toEqual([
+			"VIEWS",
+		]);
+	});
+
 	it("routes a content-bearing un-named follow-up through VIEWS", async () => {
 		mockLoopback({ viewId: "notes" });
 		const ctx = context("can you make another one saying wake me at 3am");

--- a/plugins/plugin-app-control/src/evaluators/view-followup-routing.ts
+++ b/plugins/plugin-app-control/src/evaluators/view-followup-routing.ts
@@ -174,6 +174,7 @@ export const viewFollowupRoutingEvaluator: ResponseHandlerEvaluator = {
 	// generic tasks, so replace the candidate surface only after the active view
 	// proves it owns the requested capability.
 	priority: 10,
+	deterministicActions: [VIEWS_ACTION_NAME],
 	shouldRun: (context) => shouldConsiderViewFollowup(context) !== null,
 	evaluate: async (context) => {
 		const family = shouldConsiderViewFollowup(context);

--- a/plugins/plugin-local-inference/src/local-inference-routes.test.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.test.ts
@@ -8,6 +8,10 @@ import type http from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
+import {
+	readRoutingPreferences,
+	writeRoutingPreferences,
+} from "@elizaos/shared/local-inference/routing-preferences";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 function freshActiveState() {
@@ -156,6 +160,7 @@ import {
 	getLocalInferenceActiveModelId,
 	getLocalInferenceActiveSnapshot,
 	getLocalInferenceChatStatus,
+	handleLocalInferenceChatCommand,
 	handleLocalInferenceRoutes,
 	reauthorizeRedirectHeaders,
 } from "./local-inference-routes.js";
@@ -229,6 +234,62 @@ function writeInstalledModel(id: string): string {
 	return modelPath;
 }
 
+describe("POST /api/local-inference/routing/text", () => {
+	beforeEach(() => {
+		tempStateDir = mkdtempSync(path.join(tmpdir(), "eliza-routing-routes-"));
+		process.env.ELIZA_STATE_DIR = tempStateDir;
+	});
+
+	afterEach(() => {
+		if (tempStateDir) {
+			rmSync(tempStateDir, { recursive: true, force: true });
+			tempStateDir = null;
+		}
+		if (originalStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+		else process.env.ELIZA_STATE_DIR = originalStateDir;
+	});
+
+	it("publishes provider and policy for both text slots in one request", async () => {
+		const req = makeJsonRequest("POST", "/api/local-inference/routing/text", {
+			provider: "elizacloud",
+			policy: "manual",
+		});
+		const res = makeJsonResponse();
+
+		await expect(handleLocalInferenceRoutes(req, res)).resolves.toBe(true);
+
+		expect(res.statusCode).toBe(200);
+		await expect(readRoutingPreferences()).resolves.toMatchObject({
+			preferredProvider: {
+				TEXT_SMALL: "elizacloud",
+				TEXT_LARGE: "elizacloud",
+			},
+			policy: { TEXT_SMALL: "manual", TEXT_LARGE: "manual" },
+		});
+	});
+
+	it("rejects invalid input without changing either text slot", async () => {
+		await writeRoutingPreferences({
+			preferredProvider: {
+				TEXT_SMALL: "eliza-local-inference",
+				TEXT_LARGE: "eliza-local-inference",
+			},
+			policy: { TEXT_SMALL: "manual", TEXT_LARGE: "manual" },
+		});
+		const before = await readRoutingPreferences();
+		const req = makeJsonRequest("POST", "/api/local-inference/routing/text", {
+			provider: "elizacloud",
+			policy: "sometimes",
+		});
+		const res = makeJsonResponse();
+
+		await expect(handleLocalInferenceRoutes(req, res)).resolves.toBe(true);
+
+		expect(res.statusCode).toBe(400);
+		await expect(readRoutingPreferences()).resolves.toEqual(before);
+	});
+});
+
 describe("local inference chat status", () => {
 	beforeEach(() => {
 		if (tempStateDir) {
@@ -295,6 +356,33 @@ describe("local inference chat status", () => {
 		});
 		expect(status.text).toContain("Model: eliza-1-2b.");
 		expect(status.text).not.toMatch(/none is loaded|waiting to be activated/i);
+	});
+
+	it("does not publish local routing when chat-command activation fails", async () => {
+		writeInstalledModel("eliza-1-2b");
+		await writeRoutingPreferences({
+			preferredProvider: {
+				TEXT_SMALL: "elizacloud",
+				TEXT_LARGE: "elizacloud",
+			},
+			policy: { TEXT_SMALL: "manual", TEXT_LARGE: "manual" },
+		});
+		bridgeMock.loadMobileDeviceBridgeModel.mockRejectedValueOnce(
+			new Error("activation refused"),
+		);
+
+		await expect(
+			handleLocalInferenceChatCommand("use_local", "use eliza-1-2b"),
+		).resolves.toMatchObject({
+			localInference: { status: "failed", error: "activation refused" },
+		});
+
+		await expect(readRoutingPreferences()).resolves.toMatchObject({
+			preferredProvider: {
+				TEXT_SMALL: "elizacloud",
+				TEXT_LARGE: "elizacloud",
+			},
+		});
 	});
 
 	it("uses the AOSP active marker when the native APK loader has the chat model open", async () => {

--- a/plugins/plugin-local-inference/src/local-inference-routes.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.ts
@@ -23,16 +23,26 @@ import {
 	sendJsonError,
 } from "@elizaos/core";
 import {
+	AGENT_MODEL_SLOTS,
+	type AgentModelSlot,
 	buildHuggingFaceResolveUrl,
 	isMobilePlatform,
+	isRoutingPolicy,
+	ROUTING_POLICIES,
+	type RoutingPreferences,
 	resolveHubAuthHeaders,
 	MODEL_CATALOG as SHARED_MODEL_CATALOG,
 	type CatalogModel as SharedCatalogModel,
 } from "@elizaos/shared";
 import {
+	readRoutingPreferences,
+	setPolicy,
+	setPreferredProvider,
+	setTextRouting,
+} from "@elizaos/shared/local-inference/routing-preferences";
+import {
 	LOCAL_INFERENCE_MODEL_TYPES,
 	LOCAL_INFERENCE_PROVIDER_ID,
-	LOCAL_INFERENCE_TEXT_MODEL_TYPES,
 } from "./provider.js";
 import { classifyDeviceTier } from "./services/device-tier.js";
 import {
@@ -225,16 +235,6 @@ type Assignments = Partial<
 	Record<(typeof LOCAL_INFERENCE_MODEL_TYPES)[number], string>
 >;
 
-interface RoutingPreferences {
-	preferredProvider: Record<string, string>;
-	policy: Record<string, string>;
-}
-
-interface RoutingPreferencesFile {
-	version: number;
-	preferences: RoutingPreferences;
-}
-
 let activeModelState: {
 	modelId: string | null;
 	loadedAt: string | null;
@@ -379,10 +379,6 @@ function registryPath(): string {
 
 function assignmentsPath(): string {
 	return path.join(localInferenceRoot(), "assignments.json");
-}
-
-function routingPath(): string {
-	return path.join(localInferenceRoot(), "routing.json");
 }
 
 function aospActivePath(): string {
@@ -625,16 +621,6 @@ async function writeAssignments(
 ): Promise<Assignments> {
 	await writeJsonFile(assignmentsPath(), { version: 1, assignments });
 	return assignments;
-}
-
-function defaultRoutingPreferences(): RoutingPreferencesFile {
-	return {
-		version: 1,
-		preferences: {
-			preferredProvider: {},
-			policy: {},
-		},
-	};
 }
 
 async function assignModel(
@@ -1079,16 +1065,7 @@ async function resolveDefaultChatModel(
 }
 
 async function setRoutingForChat(provider: string): Promise<void> {
-	const current = await readJsonFile<RoutingPreferencesFile>(
-		routingPath(),
-		defaultRoutingPreferences(),
-	);
-	const preferences = current.preferences;
-	for (const slot of LOCAL_INFERENCE_TEXT_MODEL_TYPES) {
-		preferences.preferredProvider[slot] = provider;
-		preferences.policy[slot] = "manual";
-	}
-	await writeJsonFile(routingPath(), { version: 1, preferences });
+	await setTextRouting(provider, "manual");
 }
 
 async function activateInstalledModel(
@@ -1248,17 +1225,21 @@ export async function handleLocalInferenceChatCommand(
 	}
 
 	if (intent === "use_local") {
-		await setRoutingForChat("capacitor-llama");
 		const installed = await installedSnapshot();
 		const requested = await resolveDefaultChatModel(prompt);
 		const installedModel = installed.find(
 			(entry) => entry.id === requested?.id,
 		);
 		if (installedModel) {
-			return activateInstalledModel(installedModel);
+			const result = await activateInstalledModel(installedModel);
+			if (result.localInference.status === "ready") {
+				await setRoutingForChat("capacitor-llama");
+			}
+			return result;
 		}
 		if (requested) {
 			const job = await startDownload(requested.id);
+			await setRoutingForChat("capacitor-llama");
 			return buildLocalInferenceChatResult(
 				{
 					intent: "download",
@@ -1440,41 +1421,38 @@ export async function applyLocalInferenceManagementMutation(
 			});
 		}
 		case "set_policy": {
-			const slot = requireSlot(input.slot, input.op);
-			const current = await readJsonFile<RoutingPreferencesFile>(
-				routingPath(),
-				defaultRoutingPreferences(),
-			);
-			if (typeof input.policy === "string" && input.policy.trim()) {
-				current.preferences.policy[slot] = input.policy.trim();
-			} else {
-				delete current.preferences.policy[slot];
+			const slot = requireSlot(input.slot, input.op) as AgentModelSlot;
+			if (!AGENT_MODEL_SLOTS.includes(slot)) {
+				throw new Error(`Unknown local-inference routing slot: ${slot}`);
 			}
-			await writeJsonFile(routingPath(), current);
+			const rawPolicy = input.policy?.trim() || null;
+			if (rawPolicy !== null && !isRoutingPolicy(rawPolicy)) {
+				throw new Error(
+					`Routing policy must be one of ${ROUTING_POLICIES.join(", ")}`,
+				);
+			}
+			const preferences = await setPolicy(slot, rawPolicy);
 			return {
 				op: input.op,
 				slot,
-				policy: current.preferences.policy[slot] ?? null,
-				preferences: current.preferences,
+				policy: preferences.policy[slot] ?? null,
+				preferences,
 			};
 		}
 		case "set_preferred_provider": {
-			const slot = requireSlot(input.slot, input.op);
-			const current = await readJsonFile<RoutingPreferencesFile>(
-				routingPath(),
-				defaultRoutingPreferences(),
-			);
-			if (typeof input.provider === "string" && input.provider.trim()) {
-				current.preferences.preferredProvider[slot] = input.provider.trim();
-			} else {
-				delete current.preferences.preferredProvider[slot];
+			const slot = requireSlot(input.slot, input.op) as AgentModelSlot;
+			if (!AGENT_MODEL_SLOTS.includes(slot)) {
+				throw new Error(`Unknown local-inference routing slot: ${slot}`);
 			}
-			await writeJsonFile(routingPath(), current);
+			const preferences = await setPreferredProvider(
+				slot,
+				input.provider?.trim() || null,
+			);
 			return {
 				op: input.op,
 				slot,
-				provider: current.preferences.preferredProvider[slot] ?? null,
-				preferences: current.preferences,
+				provider: preferences.preferredProvider[slot] ?? null,
+				preferences,
 			};
 		}
 		case "set_assignment": {
@@ -1720,10 +1698,7 @@ export async function handleLocalInferenceRoutes(
 		return true;
 	}
 	if (method === "GET" && pathname === "/api/local-inference/routing") {
-		const preferences = await readJsonFile<RoutingPreferencesFile>(
-			routingPath(),
-			defaultRoutingPreferences(),
-		);
+		const preferences = await readRoutingPreferences();
 		sendJson(res, {
 			registrations: LOCAL_INFERENCE_MODEL_TYPES.map((modelType) => ({
 				modelType,
@@ -1731,8 +1706,32 @@ export async function handleLocalInferenceRoutes(
 				priority: 0,
 				registeredAt: new Date().toISOString(),
 			})),
-			preferences: preferences.preferences,
+			preferences,
 		});
+		return true;
+	}
+	if (method === "POST" && pathname === "/api/local-inference/routing/text") {
+		const body = await readJsonBody<Record<string, unknown>>(req, res);
+		if (!body) return true;
+		const provider =
+			typeof body.provider === "string" && body.provider.trim().length > 0
+				? body.provider.trim()
+				: null;
+		if (!provider) {
+			sendJsonError(res, "provider is required");
+			return true;
+		}
+		const policy = body.policy ?? "manual";
+		if (!isRoutingPolicy(policy)) {
+			sendJsonError(
+				res,
+				`policy must be one of ${ROUTING_POLICIES.join(", ")}`,
+				400,
+			);
+			return true;
+		}
+		const preferences = await setTextRouting(provider, policy);
+		sendJson(res, { preferences });
 		return true;
 	}
 	if (
@@ -1745,24 +1744,29 @@ export async function handleLocalInferenceRoutes(
 			sendJsonError(res, "slot is required");
 			return true;
 		}
-		const current = await readJsonFile<RoutingPreferencesFile>(
-			routingPath(),
-			defaultRoutingPreferences(),
-		);
-		const preferences = current.preferences;
-		const slot = body.slot;
-		if (pathname.endsWith("/preferred")) {
-			if (typeof body.provider === "string" && body.provider.trim()) {
-				preferences.preferredProvider[slot] = body.provider.trim();
-			} else {
-				delete preferences.preferredProvider[slot];
-			}
-		} else if (typeof body.policy === "string" && body.policy.trim()) {
-			preferences.policy[slot] = body.policy.trim();
-		} else {
-			delete preferences.policy[slot];
+		const slot = body.slot as AgentModelSlot;
+		if (!AGENT_MODEL_SLOTS.includes(slot)) {
+			sendJsonError(res, "slot must be a valid AgentModelSlot");
+			return true;
 		}
-		await writeJsonFile(routingPath(), { version: 1, preferences });
+		let preferences: Awaited<ReturnType<typeof setPolicy>>;
+		if (pathname.endsWith("/preferred")) {
+			preferences = await setPreferredProvider(
+				slot,
+				typeof body.provider === "string" && body.provider.trim()
+					? body.provider.trim()
+					: null,
+			);
+		} else if (body.policy === null || isRoutingPolicy(body.policy)) {
+			preferences = await setPolicy(slot, body.policy);
+		} else {
+			sendJsonError(
+				res,
+				`policy must be one of ${ROUTING_POLICIES.join(", ")} or null`,
+				400,
+			);
+			return true;
+		}
 		sendJson(res, { preferences });
 		return true;
 	}

--- a/plugins/plugin-local-inference/src/routes/local-inference-compat-routes.test.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-compat-routes.test.ts
@@ -13,6 +13,7 @@ import type { CompatRuntimeState } from "./compat-helpers";
 // ── mocks ──────────────────────────────────────────────────────────────
 
 const setActiveMock = vi.fn();
+const setTextRoutingMock = vi.fn();
 
 vi.mock("@elizaos/core", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("@elizaos/core")>();
@@ -92,9 +93,32 @@ vi.mock("../services/providers", () => ({
 }));
 
 vi.mock("../services/routing-preferences", () => ({
+	isRoutingPolicy: (value: unknown) =>
+		typeof value === "string" &&
+		[
+			"manual",
+			"auto",
+			"local-only",
+			"cloud-only",
+			"cheapest",
+			"fastest",
+			"prefer-local",
+			"round-robin",
+		].includes(value),
 	readRoutingPreferences: vi.fn(async () => ({})),
+	ROUTING_POLICIES: [
+		"manual",
+		"auto",
+		"local-only",
+		"cloud-only",
+		"cheapest",
+		"fastest",
+		"prefer-local",
+		"round-robin",
+	],
 	setPolicy: vi.fn(),
 	setPreferredProvider: vi.fn(),
+	setTextRouting: setTextRoutingMock,
 }));
 
 const STATE: CompatRuntimeState = {
@@ -139,11 +163,12 @@ function fakeReq(opts: {
 	method: string;
 	pathname: string;
 	body?: unknown;
+	headers?: http.IncomingHttpHeaders;
 }): http.IncomingMessage {
 	const req = new http.IncomingMessage(new Socket());
 	req.method = opts.method;
 	req.url = opts.pathname;
-	req.headers = { host: "localhost:2138" };
+	req.headers = { host: "localhost:2138", ...opts.headers };
 	Object.defineProperty(req.socket, "remoteAddress", {
 		value: "127.0.0.1",
 		configurable: true,
@@ -153,6 +178,88 @@ function fakeReq(opts: {
 	}
 	return req;
 }
+
+describe("POST /api/local-inference/routing/text", () => {
+	const previousApiToken = process.env.ELIZA_API_TOKEN;
+
+	beforeAll(async () => {
+		handleLocalInferenceCompatRoutes = (
+			await import("./local-inference-compat-routes")
+		).handleLocalInferenceCompatRoutes;
+	}, 120_000);
+
+	afterEach(() => {
+		setTextRoutingMock.mockReset();
+		if (previousApiToken === undefined) delete process.env.ELIZA_API_TOKEN;
+		else process.env.ELIZA_API_TOKEN = previousApiToken;
+	});
+
+	it("publishes both text slots through one authenticated mutation", async () => {
+		process.env.ELIZA_API_TOKEN = "route-secret";
+		setTextRoutingMock.mockResolvedValue({
+			preferredProvider: {
+				TEXT_SMALL: "elizacloud",
+				TEXT_LARGE: "elizacloud",
+			},
+			policy: { TEXT_SMALL: "manual", TEXT_LARGE: "manual" },
+		});
+		const res = fakeRes();
+
+		await handleLocalInferenceCompatRoutes(
+			fakeReq({
+				method: "POST",
+				pathname: "/api/local-inference/routing/text",
+				body: { provider: "elizacloud", policy: "manual" },
+				headers: {
+					authorization: "Bearer route-secret",
+					origin: "https://untrusted.example",
+				},
+			}),
+			res.res,
+			STATE,
+		);
+
+		expect(res.status()).toBe(200);
+		expect(setTextRoutingMock).toHaveBeenCalledOnce();
+		expect(setTextRoutingMock).toHaveBeenCalledWith("elizacloud", "manual");
+	});
+
+	it("rejects an unauthenticated bulk mutation before touching storage", async () => {
+		process.env.ELIZA_API_TOKEN = "route-secret";
+		const res = fakeRes();
+
+		await handleLocalInferenceCompatRoutes(
+			fakeReq({
+				method: "POST",
+				pathname: "/api/local-inference/routing/text",
+				body: { provider: "elizacloud", policy: "manual" },
+				headers: { origin: "https://untrusted.example" },
+			}),
+			res.res,
+			STATE,
+		);
+
+		expect(res.status()).toBe(401);
+		expect(setTextRoutingMock).not.toHaveBeenCalled();
+	});
+
+	it("rejects an invalid policy without a partial write", async () => {
+		const res = fakeRes();
+
+		await handleLocalInferenceCompatRoutes(
+			fakeReq({
+				method: "POST",
+				pathname: "/api/local-inference/routing/text",
+				body: { provider: "elizacloud", policy: "sometimes" },
+			}),
+			res.res,
+			STATE,
+		);
+
+		expect(res.status()).toBe(400);
+		expect(setTextRoutingMock).not.toHaveBeenCalled();
+	});
+});
 
 // ── tests ──────────────────────────────────────────────────────────────
 

--- a/plugins/plugin-local-inference/src/routes/local-inference-compat-routes.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-compat-routes.ts
@@ -35,6 +35,7 @@ import {
 	readRoutingPreferences,
 	setPolicy,
 	setPreferredProvider,
+	setTextRouting,
 } from "../services/routing-preferences";
 import { localInferenceService } from "../services/service";
 import { readSystemMemory } from "../services/system-memory";
@@ -450,6 +451,38 @@ export async function handleLocalInferenceCompatRoutes(
 				res,
 				500,
 				err instanceof Error ? err.message : "Failed to read routing state",
+			);
+		}
+		return true;
+	}
+
+	// ── POST: atomically route both text-generation slots ───────────────
+	if (method === "POST" && pathname === "/api/local-inference/routing/text") {
+		if (!ensureCompatSensitiveRouteAuthorized(req, res)) return true;
+		const body = await readCompatJsonBody(req, res);
+		if (!body) return true;
+		const provider = stringBody(body, "provider");
+		if (!provider) {
+			sendJsonErrorResponse(res, 400, "provider is required");
+			return true;
+		}
+		const policy = body.policy ?? "manual";
+		if (!isRoutingPolicy(policy)) {
+			sendJsonErrorResponse(
+				res,
+				400,
+				`policy must be one of ${ROUTING_POLICIES.join(", ")}`,
+			);
+			return true;
+		}
+		try {
+			const prefs = await setTextRouting(provider, policy);
+			sendJsonResponse(res, 200, { preferences: prefs });
+		} catch (err) {
+			sendJsonErrorResponse(
+				res,
+				500,
+				err instanceof Error ? err.message : "Failed to write text routing",
 			);
 		}
 		return true;

--- a/plugins/plugin-local-inference/src/services/routing-preferences.ts
+++ b/plugins/plugin-local-inference/src/services/routing-preferences.ts
@@ -13,5 +13,7 @@ export {
 	readRoutingPreferences,
 	setPolicy,
 	setPreferredProvider,
+	setTextRouting,
+	updateRoutingPreferences,
 	writeRoutingPreferences,
 } from "@elizaos/shared/local-inference/routing-preferences";

--- a/plugins/plugin-local-inference/src/services/service.test.ts
+++ b/plugins/plugin-local-inference/src/services/service.test.ts
@@ -223,6 +223,36 @@ describe("LocalInferenceService activation prewarm", () => {
 			},
 		});
 	});
+
+	it("atomically upgrades legacy local slots without overwriting explicit providers", async () => {
+		const service = new LocalInferenceService();
+		const installed = makeInstalledModel("eliza-1-test");
+
+		await writeRoutingPreferences({
+			preferredProvider: {
+				TEXT_SMALL: "capacitor-llama",
+				TEXT_LARGE: "anthropic",
+			},
+			policy: {
+				TEXT_SMALL: "prefer-local",
+				TEXT_LARGE: "manual",
+			},
+		});
+		vi.spyOn(service, "getInstalled").mockResolvedValue([installed]);
+		vi.spyOn(ActiveModelCoordinator.prototype, "switchTo").mockResolvedValue(
+			readyState(installed.id),
+		);
+
+		await service.setActive(null, installed.id);
+
+		await expect(readRoutingPreferences()).resolves.toMatchObject({
+			preferredProvider: {
+				TEXT_SMALL: "eliza-local-inference",
+				TEXT_LARGE: "anthropic",
+			},
+			policy: { TEXT_SMALL: "manual", TEXT_LARGE: "manual" },
+		});
+	});
 });
 
 describe("LocalInferenceService image-gen GPU vendor detection (#10727)", () => {

--- a/plugins/plugin-local-inference/src/services/service.ts
+++ b/plugins/plugin-local-inference/src/services/service.ts
@@ -68,8 +68,7 @@ import {
 } from "./registry";
 import {
 	type RoutingPreferences,
-	readRoutingPreferences,
-	writeRoutingPreferences,
+	updateRoutingPreferences,
 } from "./routing-preferences";
 import type {
 	ActiveModelState,
@@ -116,29 +115,20 @@ function shouldRouteActivatedModelToLocal(
 }
 
 async function routeActivatedModelToLocalText(): Promise<void> {
-	const current = await readRoutingPreferences();
-	const next: RoutingPreferences = {
-		preferredProvider: { ...current.preferredProvider },
-		policy: { ...current.policy },
-	};
-	let changed = false;
-
-	for (const slot of ACTIVATED_TEXT_ROUTING_SLOTS) {
-		const provider = next.preferredProvider[slot];
-		if (!shouldRouteActivatedModelToLocal(provider)) continue;
-		if (provider !== LOCAL_INFERENCE_PROVIDER_ID) {
+	await updateRoutingPreferences((current) => {
+		const next: RoutingPreferences = {
+			preferredProvider: { ...current.preferredProvider },
+			policy: { ...current.policy },
+		};
+		for (const slot of ACTIVATED_TEXT_ROUTING_SLOTS) {
+			if (!shouldRouteActivatedModelToLocal(next.preferredProvider[slot])) {
+				continue;
+			}
 			next.preferredProvider[slot] = LOCAL_INFERENCE_PROVIDER_ID;
-			changed = true;
-		}
-		if (next.policy[slot] !== "manual") {
 			next.policy[slot] = "manual";
-			changed = true;
 		}
-	}
-
-	if (changed) {
-		await writeRoutingPreferences(next);
-	}
+		return next;
+	});
 }
 
 export class LocalInferenceService {


### PR DESCRIPTION
# Relates to

Fixes #20112. Live finding F36 retrieved `MODEL_SWITCH` for “switch to the faster model,” but the action disappeared before planning and Settings answered instead.

# Exact candidate

- Head: `4c27e6b4636b28f2440ace2349d03d2a114f0fc0`
- Parent/current develop at publication: `37b1a38230ec2a03f7b16f7775f994d6d36b8104`
- Worktree: clean

# What changed

- Preference-shaped requests route to `MODEL_SWITCH`; ambiguous requests persist one room-scoped local/cloud choice, and planner options cannot authorize a switch that the user did not request.
- Response-handler deterministic calls execute without an `ACTION_PLANNER` round trip, but only after an exact evaluator-owned action allowlist check. Remote evaluator allowlists are derived from actions owned by that same remote module.
- Rejected evaluator calls contribute none of their coordinated patch. Deterministic execution preserves the turn’s original contexts and reuses the canonical role, context, private-action, argument, account, validation, callback, lifecycle, and trajectory boundaries.
- `MODEL_SWITCH` success and expected failure outcomes are verified user-facing results on callback and callback-free transports, with single-delivery behavior.
- Text routing is owned by one cross-process filesystem transaction: strict persisted-state parsing, bounded `O_EXCL` lock acquisition, dead/malformed stale-lock recovery, token-owned release, unique `0600` temp file, and atomic rename.
- One authenticated `/api/local-inference/routing/text` write publishes provider plus manual policy for both text slots. Local activation/download admission completes before routing becomes visible; a rejected activation does not alter routing.
- All official local-inference writers now use the canonical transaction rather than duplicate read/copy/write implementations.

No frontend, Cloud, billing, connector, database-schema, wallet, or deployment contract changed.

# Review map

1. `packages/core/src/runtime/response-handler-evaluators.ts` — evaluator-owned deterministic action admission and whole-patch rejection.
2. `packages/core/src/services/message.ts` — canonical deterministic execution with original-context preservation.
3. `packages/shared/src/local-inference/routing-preferences.ts` — cross-process transaction and atomic text-pair publication.
4. `packages/agent/src/api/runtime-switch-routes.ts` — activation-before-publication and one bulk routing call.
5. `plugins/plugin-local-inference/src/local-inference-routes.ts` plus compat routes — both route authorities use the same persistence owner.
6. `plugins/plugin-app-control/src/actions/model-switch.ts` — user authority, pending choice, and truthful single-delivery results.

# Testing

Exact current head:

- Focused cross-package matrix: **10 files / 194 passed / 3 credential-gated skipped**.
- Local-inference route/service matrix: **3 files / 36 passed**.
- Shared routing transaction: **9/9 passed**, including five synchronized Bun processes, atomic read snapshots, corrupt-state refusal, dead-owner recovery, and the pre-token crash window.
- Real TCP self-API auth integration: **4/4 passed**.
- plugin-app-control full suite: **51 files / 1,829 tests passed**.
- Core, agent, shared, plugin-app-control, and plugin-local-inference typechecks: **passed**.
- Core Node/browser/edge/testing/declaration/packed-edge build, agent build, shared build, plugin-app-control build/views bundle, and plugin-local-inference build: **passed**.
- Biome on all **31 changed files** and `git diff --check`: **passed**.

Broad baseline classification:

- Shared full suite: 1,566 passed; unrelated existing `@elizaos/core/edge` alias failure plus five preset lowercase-copy assertions failed.
- plugin-local-inference full suite: 1,539 passed / 32 skipped; the known package Vitest alias rewrites `@elizaos/core/client-public` as `index.node.ts/client-public`. The exact changed-path suites pass under the repository root resolver and under a temporary exact-deep-alias config; no temp config is retained.
- Core and agent full sweeps were started after the focused/build gates; their terminal result is tracked in the PR workflow rather than represented as green here.

## Real model proof

The original exact behavioral patch was exercised through the real message pipeline against local Ollama `qwen3.6-coder-best:latest`:

```text
PROMPT: "switch to the faster model"
started:   MODEL_SWITCH
completed: MODEL_SWITCH
routeCalls: []
reply: "Tell me where to run inference — \"switch to the local model\" or \"use Eliza Cloud\"."
```

That behavior-bearing code is unchanged in the final candidate. The subsequent commits harden rejected evaluator provenance/context cases and routing persistence; those exact-head boundaries are covered by deterministic adversarial and real-filesystem tests above. No cloud credential or real routing mutation was used.

# Risks and coordination

Medium: this changes agent-global inference-routing admission and a core deterministic execution seam. It deliberately does **not** claim whole-switch atomicity across assignment, model activation/download, and routing; assignment/activation remain their existing authorities. The repaired guarantee is that routing itself is cross-process serializable and both text slots publish together only after local admission.

# Evidence Gate

<!-- evidence-head:4c27e6b4636b28f2440ace2349d03d2a114f0fc0 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI or visual source changed; this is a runtime/action/persistence boundary.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI or visual source changed; exact runtime outputs are covered below.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered interaction changed; the real-model trajectory is the applicable behavior artifact.
<!-- evidence-row:backend-logs -->
- [x] [20129-exact-head-backend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20129-exact-head-backend.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend source, browser state, or client network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] [Sanitized real local-model trajectory](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20129-pr20129-live-trajectory.json) from the behavior-bearing patch; final hardening is exact-head deterministic and filesystem tested as described above.
<!-- evidence-row:domain-artifacts -->
- [x] [20129-exact-head-routing-artifact.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20129-exact-head-routing-artifact.json)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual text changed.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@37b1a38230ec2a03f7b16f7775f994d6d36b8104:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@37b1a38230ec2a03f7b16f7775f994d6d36b8104:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [root-model-switch-routing]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@37b1a38230ec2a03f7b16f7775f994d6d36b8104:packages/skills/skills/contribute-to-eliza"} -->


