### PR TITLE
fix(ui): make workflow empty and run states honest

### DIFF
--- a/packages/app/test/audit/ocr-content-rules.test.ts
+++ b/packages/app/test/audit/ocr-content-rules.test.ts
@@ -82,7 +82,7 @@ describe("positiveExpectationMatches", () => {
       true,
     ],
     ["builtin-tasks", "Tasks No coding tasks yet.", true],
-    ["builtin-automations", "Automations Nothing scheduled yet", true],
+    ["builtin-automations", "Automations No workflows yet", true],
   ])("matches %s semantic readiness for %j", (slug, text, expected) => {
     expect(
       positiveExpectationMatches(normalize(text), expectationFor(slug)),

--- a/packages/app/test/ui-smoke/automations.spec.ts
+++ b/packages/app/test/ui-smoke/automations.spec.ts
@@ -649,7 +649,12 @@ test("automations overview empty state encourages creating tasks and workflows",
   ).toBeVisible();
   await expect(page.getByRole("button", { name: "Prompts" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Workflows" })).toBeVisible();
-  await expect(page.getByText("Nothing scheduled yet")).toBeVisible();
+  await expect(page.getByText("No automations yet")).toBeVisible();
+  await page.getByRole("button", { name: "Workflows" }).click();
+  await expect(page.getByText("No workflows yet")).toBeVisible();
+  await expect(
+    page.getByTestId("automations-empty-state").locator("svg"),
+  ).toBeVisible();
 
   await expect(
     page.getByRole("button", { name: "New automation" }),
@@ -666,7 +671,7 @@ test("automations empty state remains reachable beside chat in short landscape",
   await openAppPath(page, "/automations");
 
   const scrollRegion = page.getByTestId("automations-scroll-region");
-  const headline = page.getByText("Nothing scheduled yet");
+  const headline = page.getByText("No automations yet");
   await expect(scrollRegion).toBeVisible();
   await expect(headline).toBeAttached();
   await page.waitForFunction(
@@ -688,7 +693,7 @@ test("automations empty state remains reachable beside chat in short landscape",
       '[data-testid="automations-scroll-region"]',
     );
     const title = Array.from(document.querySelectorAll<HTMLElement>("p")).find(
-      (element) => element.textContent?.trim() === "Nothing scheduled yet",
+      (element) => element.textContent?.trim() === "No automations yet",
     );
     const empty = document.querySelector<HTMLElement>(
       '[data-testid="automations-empty-state"]',

--- a/packages/app/test/ui-smoke/ocr-view-expectations.ts
+++ b/packages/app/test/ui-smoke/ocr-view-expectations.ts
@@ -126,7 +126,11 @@ export const VIEW_OCR_POLICIES = {
   "builtin-automations": expected({
     requireAll: ["Automations"],
     requireAny: [
-      "Nothing scheduled yet",
+      "No automations yet",
+      "No prompts yet",
+      "No workflows yet",
+      "No active automations",
+      "No inactive automations",
       "Active",
       "Prompts",
       "Tasks",

--- a/packages/ui/src/components/pages/AutomationsFeed.test.tsx
+++ b/packages/ui/src/components/pages/AutomationsFeed.test.tsx
@@ -337,7 +337,7 @@ describe("AutomationsFeed", () => {
     expect(within(header).getByRole("button", { name: /back/i })).toBeTruthy();
   });
 
-  it("shows a designed-empty state with NO create CTA when nothing is scheduled", async () => {
+  it("shows a visual-first, filter-specific empty state with no create CTA", async () => {
     clientMock.listAutomations.mockResolvedValue({
       automations: [],
       summary: {
@@ -354,7 +354,14 @@ describe("AutomationsFeed", () => {
 
     render(<AutomationsFeed />);
 
-    expect(await screen.findByText("Nothing scheduled yet")).toBeTruthy();
+    expect(await screen.findByText("No automations yet")).toBeTruthy();
+    expect(
+      screen.getByTestId("automations-empty-state").querySelector("svg"),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Workflows" }));
+    expect(await screen.findByText("No workflows yet")).toBeTruthy();
+    expect(screen.queryByText("No automations yet")).toBeNull();
     // The empty state is unreachable in practice (a default is seeded on first
     // run); when it does render for the deleted-everything edge it must carry
     // NO create CTA — the agent offers re-creation from chat instead.

--- a/packages/ui/src/components/pages/AutomationsFeed.tsx
+++ b/packages/ui/src/components/pages/AutomationsFeed.tsx
@@ -103,6 +103,30 @@ const FILTER_ICONS: Record<FeedFilter, ReactNode> = {
   active: <Play className="h-3.5 w-3.5" aria-hidden />,
   inactive: <CircleSlash className="h-3.5 w-3.5" aria-hidden />,
 };
+
+const EMPTY_LABELS: Record<FeedFilter, { key: string; defaultLabel: string }> =
+  {
+    all: {
+      key: "automationsfeed.emptyAll",
+      defaultLabel: "No automations yet",
+    },
+    prompts: {
+      key: "automationsfeed.emptyPrompts",
+      defaultLabel: "No prompts yet",
+    },
+    workflows: {
+      key: "automationsfeed.emptyWorkflows",
+      defaultLabel: "No workflows yet",
+    },
+    active: {
+      key: "automationsfeed.emptyActive",
+      defaultLabel: "No active automations",
+    },
+    inactive: {
+      key: "automationsfeed.emptyInactive",
+      defaultLabel: "No inactive automations",
+    },
+  };
 const NEW_AUTOMATION_LINK_ID = "__new__";
 
 /** Namespaces cached rows by the currently selected local or Cloud agent. */
@@ -792,8 +816,8 @@ export function AutomationsFeed({
                 >
                   <AutomationEmptyIllustration />
                   <p className="text-sm font-medium text-txt">
-                    {t("automationsfeed.emptyHeadline", {
-                      defaultValue: "Nothing scheduled yet",
+                    {t(EMPTY_LABELS[filter].key, {
+                      defaultValue: EMPTY_LABELS[filter].defaultLabel,
                     })}
                   </p>
                 </div>

--- a/packages/ui/src/components/pages/WorkflowEditor.test.tsx
+++ b/packages/ui/src/components/pages/WorkflowEditor.test.tsx
@@ -113,6 +113,13 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("WorkflowEditor", () => {
+  it("uses the darker orange hover token for the primary Run control", async () => {
+    render(<WorkflowEditor initial={workflow()} />);
+
+    const runButton = await screen.findByRole("button", { name: "Run" });
+    expect(runButton.className).toContain("hover:bg-accent-muted");
+  });
+
   it("renders native source, visual triggers, and typed widgets", async () => {
     render(<WorkflowEditor initial={workflow()} />);
     expect(screen.getByText("Build digest")).toBeTruthy();

--- a/packages/ui/src/components/pages/WorkflowEditor.tsx
+++ b/packages/ui/src/components/pages/WorkflowEditor.tsx
@@ -569,6 +569,7 @@ export function WorkflowEditor({
           )}
         </Button>
         <Button
+          className="hover:bg-accent-muted"
           size="icon-sm"
           onClick={requestRun}
           disabled={running}


### PR DESCRIPTION
Closes #20006

# Relates to

- #20006
- [x] Targets `develop`, rebased onto `origin/develop@4461590612953ce621c3b41ad3014c4973fcfeee` with zero conflicts.
- [x] `bun install` and `bun run verify` completed after sync.
- [x] The real browser flow and desktop/mobile visual audits are documented below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@4461590612953ce621c3b41ad3014c4973fcfeee`; zero conflicts.
- [x] Full root verification passed twice on the post-change develop lineage: **351/351** Turbo tasks plus all repository audits. The last full receipt was at head `c4b5be227ac2c07e79900d6068de614a28673531`; the final rebase added only merged Cloud passthrough telemetry, after which exact-head UI tests/typecheck/OCR were rerun green.

# Risks

Low. The change only selects truthful copy from the existing filter enum, updates the matching OCR readiness contract, and overrides one button hover token. No API, workflow execution, storage, auth, or error-handling path changes.

# Background

## What does this PR do?

- Replaces the generic “Nothing scheduled yet” empty copy with filter-specific labels, including “No workflows yet” for manual and event-triggered workflows.
- Keeps the illustration-first designed-empty state and no-CTA behavior.
- Makes the Workflow Studio's primary Run control hover with the darker orange `accent-muted` token.
- Updates component, browser, and OCR semantic-readiness regressions for the real UI contract.

## What kind of change is this?

Bug fix (non-breaking UI semantics and visual-state correction).

# Documentation changes needed?

No. This corrects rendered product copy and design-token behavior; public APIs and operator workflows are unchanged.

# Testing

## Where should a reviewer start?

1. Open `/automations` with an empty response.
2. Switch from All to Workflows and confirm the label changes from “No automations yet” to “No workflows yet” while the illustration stays primary.
3. Open `/automations/workflows/new`, hover the orange Run control, and confirm it darkens rather than becoming lighter.

## Detailed testing steps

- Exact final head `6090b036d25c4dc3fa21faca0cd747562afe7525`: focused UI component tests **26/26**, UI typecheck pass, OCR contract **43/43**, diff check clean.
- Real Chromium Automations flow: **4/4** (empty/filter state, short-landscape geometry, task/Smithers source path, event-trigger creation).
- Exact affected Automations audit: **4/4 good**, broken=0, needs-work=0, needs-eyeball=0, hover/density/minimalism failures=0.
- Exact affected Workflow Studio audit: **4/4 good**, broken=0, needs-work=0, needs-eyeball=0, hover/density/minimalism failures=0.
- Root `bun run verify`: **351/351** plus all repository audits (two post-rebase receipts).

# Evidence Gate

<!-- evidence-head:6090b036d25c4dc3fa21faca0cd747562afe7525 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before desktop/mobile full-page screenshots: pending inline upload while this PR is draft.
<!-- evidence-row:after-screenshots -->
- [ ] After desktop/mobile full-page screenshots: pending inline upload while this PR is draft.
<!-- evidence-row:walkthrough-video -->
- [ ] MP4 walkthrough: pending inline upload while this PR is draft.
<!-- evidence-row:backend-logs -->
- [x] N/A - this is a client-only copy/CSS-token change; the deterministic browser fixture returns the unchanged automation payload and no backend implementation fires.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: pending inline attachment while this PR is draft; the audited runs had zero console/page errors.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, scheduled-item, or workflow-execution mutation changes.
<!-- evidence-row:ocr-review -->
- [ ] OCR review artifact: pending inline attachment while this PR is draft; policy test is 43/43 and both affected audits are semantic-ready.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Backend: N/A - client-only copy/token behavior.

Frontend: pending inline upload. Both affected Playwright audits completed without console errors or page errors.

## Screenshots (before / after) + video walkthrough

Artifacts are being uploaded inline before this PR is marked ready.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT change.

## Known gaps / failures

The full `packages/ui` aggregate on then-current develop completed **10,350 passed / 7 skipped / 6 failed**. All six failures reproduce in isolation outside this diff: stale App source-string assertions (2), Memories mutation-ratchet drift (1), JoinPage sign-out cleanup state (1), and existing 5-second timeout failures in the hardcoded-color and WalletConnect tests (2). This PR does not widen those timeouts or hide those failures. Required package typecheck/lint, focused real contracts, browser flow, both affected visual audits, and root verify are green.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-triage]
<!-- eliza-computer-attribution:v1 {"provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
