### PR TITLE
fix(ui): simplify empty workflow states

### DIFF
--- a/packages/app/test/ui-smoke/automations.spec.ts
+++ b/packages/app/test/ui-smoke/automations.spec.ts
@@ -651,6 +651,13 @@ test("automations overview empty state encourages creating tasks and workflows",
   await expect(page.getByRole("button", { name: "Workflows" })).toBeVisible();
   await expect(page.getByText("Nothing scheduled yet")).toBeVisible();
 
+  await page.getByRole("button", { name: "Workflows" }).click();
+  await expect(page.getByTestId("automations-empty-state")).toHaveAttribute(
+    "aria-label",
+    "No workflows",
+  );
+  await expect(page.getByText("No workflows")).toHaveClass(/sr-only/);
+
   await expect(
     page.getByRole("button", { name: "New automation" }),
   ).toBeVisible();

--- a/packages/ui/src/components/pages/AutomationsFeed.test.tsx
+++ b/packages/ui/src/components/pages/AutomationsFeed.test.tsx
@@ -363,6 +363,13 @@ describe("AutomationsFeed", () => {
     ).toBeNull();
     expect(screen.queryByRole("button", { name: /create/i })).toBeNull();
     expect(screen.queryByRole("button", { name: "New" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Workflows" }));
+    const workflowEmptyLabel = await screen.findByText("No workflows");
+    expect(workflowEmptyLabel.classList.contains("sr-only")).toBe(true);
+    expect(
+      screen.getByTestId("automations-empty-state").getAttribute("aria-label"),
+    ).toBe("No workflows");
   });
 
   it("renders an explicit unavailable state when the workflow service is disabled", async () => {

--- a/packages/ui/src/components/pages/AutomationsFeed.tsx
+++ b/packages/ui/src/components/pages/AutomationsFeed.tsx
@@ -639,6 +639,13 @@ export function AutomationsFeed({
     );
   }
 
+  const workflowOnlyEmpty = filter === "workflows";
+  const emptyStateLabel = workflowOnlyEmpty
+    ? t("automationsfeed.emptyWorkflows", { defaultValue: "No workflows" })
+    : t("automationsfeed.emptyHeadline", {
+        defaultValue: "Nothing scheduled yet",
+      });
+
   const feedContent = (
     <ShellViewAgentSurface viewId="automations">
       <div
@@ -788,13 +795,19 @@ export function AutomationsFeed({
                 // to re-create a workflow from chat instead.
                 <div
                   data-testid="automations-empty-state"
+                  role="status"
+                  aria-label={workflowOnlyEmpty ? emptyStateLabel : undefined}
                   className="flex flex-col items-center gap-5 px-6 py-14 text-center [@media(orientation:landscape)_and_(max-height:520px)]:gap-2 [@media(orientation:landscape)_and_(max-height:520px)]:px-4 [@media(orientation:landscape)_and_(max-height:520px)]:py-3"
                 >
                   <AutomationEmptyIllustration />
-                  <p className="text-sm font-medium text-txt">
-                    {t("automationsfeed.emptyHeadline", {
-                      defaultValue: "Nothing scheduled yet",
-                    })}
+                  <p
+                    className={
+                      workflowOnlyEmpty
+                        ? "sr-only"
+                        : "text-sm font-medium text-txt"
+                    }
+                  >
+                    {emptyStateLabel}
                   </p>
                 </div>
               ) : (

--- a/packages/ui/src/components/pages/WorkflowEditor.test.tsx
+++ b/packages/ui/src/components/pages/WorkflowEditor.test.tsx
@@ -174,7 +174,9 @@ describe("WorkflowEditor", () => {
 
   it("persists a new workflow before starting its first run", async () => {
     render(<WorkflowEditor />);
-    fireEvent.click(screen.getByRole("button", { name: "Run" }));
+    const runButton = screen.getByRole("button", { name: "Run" });
+    expect(runButton.className).toContain("hover:bg-accent/85");
+    fireEvent.click(runButton);
     await waitFor(() =>
       expect(api.createWorkflowDefinition).toHaveBeenCalledTimes(1),
     );

--- a/packages/ui/src/components/pages/WorkflowEditor.tsx
+++ b/packages/ui/src/components/pages/WorkflowEditor.tsx
@@ -569,6 +569,7 @@ export function WorkflowEditor({
           )}
         </Button>
         <Button
+          className="hover:bg-accent/85"
           size="icon-sm"
           onClick={requestRun}
           disabled={running}

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -5959,6 +5959,7 @@
   "automationsfeed.new": "New",
   "automationsfeed.empty": "No automations yet.",
   "automationsfeed.emptyHeadline": "Nothing scheduled yet",
+  "automationsfeed.emptyWorkflows": "No workflows",
   "automationsfeed.emptySub": "Ask in chat to set up a workflow and it will run here.",
   "automationsfeed.runError": "Failed to run automation.",
   "automationsfeed.workflow": "Workflow",

--- a/packages/ui/src/i18n/locales/ko.json
+++ b/packages/ui/src/i18n/locales/ko.json
@@ -7386,6 +7386,7 @@
   "desktop.tray.testNotification.body": "렌더러 트레이 작업이 연결되어 응답 중입니다.",
   "accounts.provider.cerebrasApi": "Cerebras API",
   "automationsfeed.emptyHeadline": "아직 예약된 항목이 없어요",
+  "automationsfeed.emptyWorkflows": "워크플로우 없음",
   "automationsfeed.emptySub": "채팅에서 워크플로우를 설정해 달라고 요청하면 여기에서 실행돼요.",
   "bootstrapstep.startOver": "다시 시작",
   "chat.attachmentsKeptDroppedMixed": "{{kept}}개 유지, {{dropped}}개 제외 ({{tooLarge}}개가 {{maxMb}}MB 초과, {{overCount}}개가 개수 제한 초과)",


### PR DESCRIPTION
## Summary

Closes #20006.

- Makes the Workflows-only empty state illustration-first, with no visible explanatory copy and a concise screen-reader status.
- Keeps the generic Automations empty state truthful for scheduled items.
- Gives the orange Run control the required darker-orange hover state.
- Adds component and browser regressions for the semantic empty state and hover contract.

## Validation

Exact source and rebased branch evidence:

- `bun install` — clean, no dependency changes.
- Focused Biome — 7/7 files clean.
- UI component tests — 25/25 passed.
- UI typecheck — passed.
- Scoped Automations Playwright — 4/4 passed.
- Real local Smithers workflow E2E — passed creation, event trigger, activation, execution, output inspection, manual rerun, and reload persistence.
- `bun run verify` — 351/351 package tasks plus all repository audits passed.
- `bun run --cwd packages/app audit:app` — 219/219 captures passed; 216 findings with broken=0, needs-work=0, minimalism=0, hover=0, density=0; OCR verified 200, broken=0.

## Design review

The changed surfaces were inspected directly in desktop, mobile portrait, mobile landscape, and iPad portrait states. The workflow list remains icon-forward with generous whitespace. The new Workflow Studio keeps one centered Run node, compact icon controls, and a full canvas. The Workflows-only empty state now communicates visually while preserving `role=status` and the localized `No workflows` accessible name.

## Evidence gate

<!-- evidence-head:3309e67ae545 -->

- Before screenshots: reviewed against the previous Workflows-filter state; visible copy incorrectly described manual and event workflows as scheduled.
- After screenshots: generated and manually reviewed for desktop and mobile Automations and Workflow Studio states.
- Walkthrough video: the real local Playwright journey exercised the complete workflow lifecycle; video was disabled for the final deterministic rerun after an earlier recorded browser review.
- Backend logs: real local workflow plugin boot, migration, create, trigger, run, and persistence path passed.
- Frontend logs: scoped browser suite passed; only post-success temporary-stack teardown proxy noise was observed after the API exited.
- LLM trajectory: N/A — no prompt, model, provider, or planner behavior changed.
- Domain artifacts: real persisted workflow definition and execution history were reloaded successfully.
- OCR review: 216 views, 200 verified, 16 human-eyeball only, 0 broken.

## Risk

Low. The production change is limited to empty-state presentation, accessibility naming, and one hover class. Existing non-workflow empty behavior is retained. All real workflow execution contracts remain unchanged.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A — no contribution skill used
Attribution status: self-reported
— [codex-triage]
<!-- eliza-computer-attribution:v1 {"provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A","status":"self-reported"} -->