### PR TITLE
fix(cloud): reject malformed signup code bonuses

### DIFF
--- a/packages/cloud/shared/src/lib/services/signup-code.test.ts
+++ b/packages/cloud/shared/src/lib/services/signup-code.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Signup-code configuration tests exercise the real environment parser with isolated module caches.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+const originalSignupCodesJson = process.env.SIGNUP_CODES_JSON;
+
+afterEach(() => {
+  if (originalSignupCodesJson === undefined) {
+    delete process.env.SIGNUP_CODES_JSON;
+  } else {
+    process.env.SIGNUP_CODES_JSON = originalSignupCodesJson;
+  }
+});
+
+describe("signup-code configuration", () => {
+  test("rejects partially numeric bonus amounts", async () => {
+    process.env.SIGNUP_CODES_JSON = JSON.stringify({
+      codes: { launch: "25credits", infinite: "Infinity", valid: "25" },
+    });
+
+    const { getBonusForCode } = await import("./signup-code?invalid-partial-amount");
+
+    expect(getBonusForCode("launch")).toBeUndefined();
+    expect(getBonusForCode("infinite")).toBeUndefined();
+    expect(getBonusForCode("valid")).toBe(25);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/signup-code.ts
+++ b/packages/cloud/shared/src/lib/services/signup-code.ts
@@ -41,8 +41,8 @@ function loadCodes(): Map<string, number> {
   for (const [code, amount] of Object.entries(codes)) {
     const normalized = code?.trim().toLowerCase();
     if (!normalized) continue;
-    const num = typeof amount === "number" ? amount : parseFloat(String(amount));
-    if (!isNaN(num) && num > 0) {
+    const num = typeof amount === "number" ? amount : Number(amount);
+    if (Number.isFinite(num) && num > 0) {
       map.set(normalized, num);
     }
   }


### PR DESCRIPTION
# Relates to

Closes #20132.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] this PR targets `develop` and is branched directly off the current `origin/develop` tip.
- [x] focused package tests, lint, and typecheck pass on the exact head, see Testing below.
- [x] a reviewer can confirm the fix directly against the deterministic config-parsing test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (fix, tests, via AgentRouter proxy), `anthropic/claude-sonnet-5` (independent re-verification)
<!-- attribution-row:client -->
- Agent tooling: `codex` (via AgentRouter proxy), `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] branched directly off the current `origin/develop` tip

# Risks

low. this only tightens the fallback numeric-coercion branch for `SIGNUP_CODES_JSON` bonus values; every existing valid entry (a real `number` in the JSON, or a fully-numeric string) behaves identically.

# Background

## What does this PR do?

`loadCodes()` converts `SIGNUP_CODES_JSON` bonus values with `parseFloat(String(amount))` when the JSON value isn't already a `number`, guarded by `!isNaN(num) && num > 0`. `parseFloat` accepts a numeric prefix and ignores trailing garbage, so a malformed value like `"25credits"` becomes a valid `$25` bonus. Worse, `parseFloat("Infinity")` returns `Infinity`, and `isNaN(Infinity)` is `false`, so the literal string `"Infinity"` also passes — a misconfigured env value could reach `creditsService.addCredits` as a non-finite credit grant.

The documented config shape (`SignupCodesConfig.codes?: Record<string, number>`, per the file's own doc comment) declares `amount` as a `number` — a string value is already outside the documented contract, so this fallback branch exists purely as a defensive sanity check on malformed JSON, and that check was too lenient.

confirmed directly:

```text
$ bun -e 'console.log(parseFloat("25credits"), isNaN(parseFloat("25credits")))'
25 false
$ bun -e 'console.log(parseFloat("Infinity"), isNaN(parseFloat("Infinity")))'
Infinity false
```

traced reachability before writing this up: both real callers of `redeemSignupCode` were confirmed — the authenticated `packages/cloud/api/signup-code/redeem/route.ts` (user-submitted code) and `eliza-app/user-service.ts` (new account creation). The malformed amount originates in operator config rather than direct user input, but any operator typo or malformed deploy would silently enable a real code and grant the parsed (garbage or infinite) amount to any eligible authenticated caller who redeems it.

fix: whole-string `Number(...)` conversion (rejects any non-numeric trailing content) combined with `Number.isFinite(num) && num > 0` (rejects `Infinity`/`NaN`) before caching a code.

## What kind of change is this?

bug fix, non-breaking (every existing valid entry — a JSON `number`, or a fully-numeric string — behaves identically).

# Documentation changes needed?

no, the fix makes the fallback coercion match the config's own already-documented `number` contract.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/signup-code.test.ts` (new file), the `rejects partially numeric bonus amounts` case, then the `Number(...)`/`Number.isFinite` change in `loadCodes()`.

## Detailed testing steps

```text
$ bun test src/lib/services/signup-code.test.ts
1 pass
0 fail
3 expect() calls

$ bun run typecheck
Done!  (exit 0)

$ bunx @biomejs/biome check src/lib/services/signup-code.ts src/lib/services/signup-code.test.ts
Checked 2 files in 31ms. No fixes applied.
```

The test covers all three cases in one pass: `"25credits"` → rejected (`undefined`), `"Infinity"` → rejected (`undefined`), `"25"` → still accepted (`25`). It uses a query-string module-cache-buster (`./signup-code?invalid-partial-amount`) because `loadCodes()`'s result is intentionally cached once per process (`WHY cache: Env is read once per process` — documented in the source), so a fresh import is required to exercise a different `SIGNUP_CODES_JSON` value per test run.

mutation-resistance verified independently: reverted just the source fix, kept the new test, reran — failed with `Received: 25` where `undefined` was expected, confirming `"25credits"` really did parse to a usable bonus pre-fix. restored the fix, 1/1 green again.

# Evidence Gate

<!-- evidence-head:f8c4e2d4a3492966ddc0c537de8fd852917d8f53 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes an internal config-parsing helper, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - this changes an internal config-parsing helper, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive product flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic config-parsing test, the real transcript is included under domain artifacts.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code or network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real mutation-resistance run, captured directly:
  ```text
  red (source fix reverted, test kept):
  $ bun test src/lib/services/signup-code.test.ts
  expect(received).toBeUndefined()
  Received: 25
  0 pass | 1 fail

  green (fix restored):
  $ bun test src/lib/services/signup-code.test.ts
  1 pass | 0 fail
  ```
  also independently confirmed `parseFloat("25credits")` and `parseFloat("Infinity")` both produce non-NaN values that pass the old guard, in a real bun REPL, and traced both real `redeemSignupCode` callers before writing up the reachability claim.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface or visual text changed.

## Known gaps / failures

none in the touched surface. full focused suite green (1/1), typecheck clean, lint clean.

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the focused test, typecheck, and lint myself, confirmed the parseFloat leniency for both malformed cases directly, retraced both real caller paths, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Contribution skill revision: N/A - direct interactive session, contribute-to-eliza skill not used
Compute receipt: N/A - Slop run-receipt install currently blocked by an unrelated site-deploy-lag issue (deployed skill archive predates recent develop changes)
Attribution status: self-reported
