### PR TITLE
fix(core): work-thread lifecycle asks get a deterministic candidate

### DIFF
--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -1319,4 +1319,46 @@ describe("batch-1 matrix fixes: budget noun + scheduled-item admin (F3/F5)", () 
 			).kind,
 		).not.toBe("owner-scheduled-admin");
 	});
+
+	it("work-thread lifecycle asks hint the work-thread surface (F27, tj-ee16a14fea597e)", () => {
+		const workThread = { name: "WORK_THREAD", similes: [], tags: [] };
+		const appAction = {
+			name: "APP",
+			similes: ["LAUNCH_APP"],
+			tags: ["app", "apps"],
+		};
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, appAction, workThread],
+				"start a work thread: plan the garage cleanout",
+			),
+		).toEqual({ names: ["WORK_THREAD"], kind: "owner-work-thread" });
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, appAction, workThread],
+				"resume the kitchen reno work thread",
+			),
+		).toEqual({ names: ["WORK_THREAD"], kind: "owner-work-thread" });
+		// No work-thread surface registered: yield nothing, never the view/app
+		// overlap.
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, appAction],
+				"start a work thread: plan the garage cleanout",
+			),
+		).toEqual({ names: [], kind: null });
+		// Explanations and bare mentions stay chat.
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, appAction, workThread],
+				"what is a work thread",
+			).kind,
+		).not.toBe("owner-work-thread");
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, appAction, workThread],
+				"the work thread idea sounds nice",
+			).kind,
+		).not.toBe("owner-work-thread");
+	});
 });

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -387,6 +387,7 @@ export type DirectCurrentRequestCandidateKind =
 	| "owner-routines"
 	| "owner-reads"
 	| "owner-scheduled-admin"
+	| "owner-work-thread"
 	| "view-surface"
 	| "view-navigation"
 	| "view-capability"
@@ -671,6 +672,38 @@ function findScheduledAdminActionName(
 	actions: ReadonlyArray<Pick<Action, "name" | "similes">>,
 ): string | undefined {
 	return findAvailableActionName(actions, SCHEDULED_ADMIN_ACTION_NAMES);
+}
+
+const WORK_THREAD_ACTION_NAMES = [
+	"WORK_THREAD",
+	"OWNER_TASKS",
+	"WORK_THREADS",
+] as const;
+
+/**
+ * Detects an explicit work-thread lifecycle ask ("start a work thread: plan
+ * the garage cleanout", "resume the kitchen reno work thread"). Live
+ * regression (matrix F27, tj-ee16a14fea597e): Stage-1 classified the ask as
+ * bare ["general"] with no candidates, the planner ran with HANDLE_RESPONSE
+ * only, and the model composed a fictional surface refusal ("can't do that
+ * here — dm me") — the same drift class as the owner-item delete leg. The
+ * phrase "work thread" is the surface's own vocabulary, so the deterministic
+ * candidate is precise.
+ */
+function looksLikeWorkThreadRequest(text: string): boolean {
+	const normalized = text.toLowerCase().replace(/\s+/gu, " ").trim();
+	if (!normalized || looksLikeActionExplanationRequest(normalized)) {
+		return false;
+	}
+	return /\b(?:start|open|kick ?off|begin|resume|continue|pick (?:up|back up))\b[^.!?]{0,40}\bwork[- ]threads?\b/iu.test(
+		normalized,
+	);
+}
+
+function findWorkThreadActionName(
+	actions: ReadonlyArray<Pick<Action, "name" | "similes">>,
+): string | undefined {
+	return findAvailableActionName(actions, WORK_THREAD_ACTION_NAMES);
 }
 
 /**
@@ -977,6 +1010,17 @@ export function inferDirectCurrentRequestCandidateInference(
 		);
 		if (ownerDeleteAction) {
 			return { names: [ownerDeleteAction], kind: "owner-scheduled-admin" };
+		}
+		return EMPTY_DIRECT_CANDIDATE_INFERENCE;
+	}
+	// Work-thread lifecycle asks name the surface's own vocabulary; without a
+	// deterministic candidate Stage-1 drift leaves the turn tool-less and the
+	// model invents a surface refusal (matrix F27). Same
+	// no-candidate-on-missing-surface rule as the legs above.
+	if (looksLikeWorkThreadRequest(messageText)) {
+		const workThreadAction = findWorkThreadActionName(actions);
+		if (workThreadAction) {
+			return { names: [workThreadAction], kind: "owner-work-thread" };
 		}
 		return EMPTY_DIRECT_CANDIDATE_INFERENCE;
 	}


### PR DESCRIPTION
## Problem

Live finding (F27, nubilio matrix batch 2): "start a work thread: plan the garage cleanout" on the api room refused with "can't do that here — dm me" at the planner level, without attempting any tool. Watchtower's read was surface-capability drift; ground truth confirms the same mechanism as F31 (#20117):

- Broken turn (tj-ee16a14fea597e): Stage-1 emitted bare `contexts: ["general"]` with **no candidateActions** → the planner ran with `HANDLE_RESPONSE` only → the surface refusal is a hallucination (no gate exists; work-thread has no DM-only constraint in code).
- Working turn (tj-dee2c1fbb8fc2c, same phrasing pre-drift): `["tasks"]` + `candidateActions: ["OWNER_TASKS", "work_thread"]` → 36 tools exposed including WORK_THREAD → the thread started.

## Fix

A work-thread leg in `direct-action-heuristics.ts`, following #20117's pattern: lifecycle verbs (start/open/kick off/begin/resume/continue/pick up) over the surface's own vocabulary ("work thread") yield the registered work-thread action (`WORK_THREAD` → `OWNER_TASKS` preference order) as a deterministic candidate under a new `owner-work-thread` kind. Existing valve/escalation treatment applies unchanged (owner kinds always escalate; only view-capability overlaps are suppressed). Guards match the sibling legs: explanation requests and bare mentions stay chat; with no work-thread surface registered the turn yields no candidate rather than falling through to the view/app overlap.

## Evidence

| Row | Result |
| --- | --- |
| Unit tests | `direct-action-heuristics.test.ts` 66/66 — new F27 block: both live phrasings, no-surface, explanation and bare-mention negatives |
| Regression | full `services/message` dir 597/597; core `tsc --noEmit` clean; biome clean |
| Ground truth | Broken vs working trajectory comparison above (tj ids) |
| Live re-prove | Queued with the fleet's live driver: re-run the garage-cleanout thread ask on the api room (matrix batch 3) |

Closes the F27 leg of the classification-drift family (F31 = #20117, merged). HQ receipt thread: #18309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
