### PR TITLE
chore(core): format action retrieval regression test

### DIFF
--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -999,7 +999,8 @@ describe("F21 aliases survive production retrieval topology filtering", () => {
 		const catalog = buildActionCatalog([
 			{
 				name: parentName,
-				description: "A registered runtime surface with no candidate-name overlap.",
+				description:
+					"A registered runtime surface with no candidate-name overlap.",
 			},
 		]);
 		const response = retrieveActions({


### PR DESCRIPTION
## Summary

Formats the action-retrieval regression test that landed unformatted on `develop`, restoring the mandatory repository lint/verify gate. This only wraps one description string and adds the missing final newline; no test or runtime behavior changes.

## Verification

- `bun run --cwd packages/core lint:check` — pass (two pre-existing advisory infos only)
- `bun run verify` — pass, 351/351 Turbo tasks plus all repository audits
- Exact head: `a9ff9e47ed5554d6ae56637f3d234f9798c9d253`
- Base: `ef407d34cde436d3b2088643786cd5eb870ee0e3`

## Provenance

- AI assistance: yes
- Model: OpenAI / gpt-5
- Client: Codex desktop
- Attribution status: self-reported
