### PR TITLE
fix(cloud-shared): reject malformed SIGNUP_CODES_JSON bonus values

### DIFF
--- a/packages/cloud/shared/src/lib/services/signup-code.test.ts
+++ b/packages/cloud/shared/src/lib/services/signup-code.test.ts
@@ -1,9 +1,6 @@
 /**
- * Strict parsing coverage for SIGNUP_CODES_JSON bonus values (#20132):
- * parseFloat accepted numeric prefixes ("25credits" -> 25) and returned
- * Infinity for "Infinity", which passed the isNaN-only guard. The defensive
- * string branch must accept only complete canonical positive decimals, and
- * non-finite shapes must never reach the codes map.
+ * Exercises signup-code configuration parsing and cached lookup with mocked
+ * credit persistence dependencies.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -22,7 +19,7 @@ mock.module("../utils/logger", () => ({
   logger: { warn: () => {}, error: () => {}, info: () => {}, debug: () => {} },
 }));
 
-const { getBonusForCode, resetSignupCodesCacheForTests } = await import(
+const { getBonusForCode, parseSignupCodeBonus, resetSignupCodesCacheForTests } = await import(
   "./signup-code.ts"
 );
 
@@ -35,7 +32,7 @@ beforeEach(() => {
   resetSignupCodesCacheForTests();
 });
 
-describe("SIGNUP_CODES_JSON strict bonus parsing (#20132)", () => {
+describe("SIGNUP_CODES_JSON strict bonus parsing", () => {
   test("prefix-garbage and non-canonical string values are rejected", () => {
     setEnvCodes({
       prefix: "25credits",
@@ -76,13 +73,10 @@ describe("SIGNUP_CODES_JSON strict bonus parsing (#20132)", () => {
   });
 
   test("non-finite numeric values are rejected even on the number branch", () => {
-    // JSON.parse cannot produce Infinity, but the defensive guard must not
-    // rely on that: the map never carries a non-finite grant.
-    setEnvCodes({ inf: Number.POSITIVE_INFINITY, nan: Number.NaN, neg: -5, ok: 30 });
-    expect(getBonusForCode("inf")).toBeUndefined();
-    expect(getBonusForCode("nan")).toBeUndefined();
-    expect(getBonusForCode("neg")).toBeUndefined();
-    expect(getBonusForCode("ok")).toBe(30);
+    expect(parseSignupCodeBonus(Number.POSITIVE_INFINITY)).toBeNull();
+    expect(parseSignupCodeBonus(Number.NaN)).toBeNull();
+    expect(parseSignupCodeBonus(-5)).toBeNull();
+    expect(parseSignupCodeBonus(30)).toBe(30);
   });
 
   test("codes are matched case- and whitespace-insensitively", () => {

--- a/packages/cloud/shared/src/lib/services/signup-code.test.ts
+++ b/packages/cloud/shared/src/lib/services/signup-code.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Strict parsing coverage for SIGNUP_CODES_JSON bonus values (#20132):
+ * parseFloat accepted numeric prefixes ("25credits" -> 25) and returned
+ * Infinity for "Infinity", which passed the isNaN-only guard. The defensive
+ * string branch must accept only complete canonical positive decimals, and
+ * non-finite shapes must never reach the codes map.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// The module pulls service/repository dependencies that are irrelevant to
+// parsing; mock them so the import chain stays offline and deterministic.
+mock.module("../../db/repositories/credit-transactions", () => ({
+  creditTransactionsRepository: {
+    hasSignupCodeBonus: async () => false,
+    recordTransaction: async () => ({}),
+  },
+}));
+mock.module("./credits", () => ({
+  creditsService: { addCredits: async () => ({}) },
+}));
+mock.module("../utils/logger", () => ({
+  logger: { warn: () => {}, error: () => {}, info: () => {}, debug: () => {} },
+}));
+
+const { getBonusForCode, resetSignupCodesCacheForTests } = await import(
+  "./signup-code.ts"
+);
+
+function setEnvCodes(entries: Record<string, unknown>): void {
+  process.env.SIGNUP_CODES_JSON = JSON.stringify({ codes: entries });
+  resetSignupCodesCacheForTests();
+}
+
+beforeEach(() => {
+  resetSignupCodesCacheForTests();
+});
+
+describe("SIGNUP_CODES_JSON strict bonus parsing (#20132)", () => {
+  test("prefix-garbage and non-canonical string values are rejected", () => {
+    setEnvCodes({
+      prefix: "25credits",
+      exponent: "1e2",
+      hex: "0x10",
+      signed: "+25",
+      leadingdot: ".5",
+      trailingdot: "25.",
+      infinity: "Infinity",
+      nanword: "NaN",
+      negative: "-25",
+      zero: "0",
+      empty: "",
+    });
+    for (const code of [
+      "prefix",
+      "exponent",
+      "hex",
+      "signed",
+      "leadingdot",
+      "trailingdot",
+      "infinity",
+      "nanword",
+      "negative",
+      "zero",
+      "empty",
+    ]) {
+      expect(getBonusForCode(code)).toBeUndefined();
+    }
+  });
+
+  test("canonical integer and decimal string values are accepted", () => {
+    setEnvCodes({ welcome: "25", launch: "12.50", big: "1000", padded: " 7.5 " });
+    expect(getBonusForCode("WELCOME")).toBe(25);
+    expect(getBonusForCode("launch")).toBe(12.5);
+    expect(getBonusForCode("BIG")).toBe(1000);
+    expect(getBonusForCode("padded")).toBe(7.5);
+  });
+
+  test("non-finite numeric values are rejected even on the number branch", () => {
+    // JSON.parse cannot produce Infinity, but the defensive guard must not
+    // rely on that: the map never carries a non-finite grant.
+    setEnvCodes({ inf: Number.POSITIVE_INFINITY, nan: Number.NaN, neg: -5, ok: 30 });
+    expect(getBonusForCode("inf")).toBeUndefined();
+    expect(getBonusForCode("nan")).toBeUndefined();
+    expect(getBonusForCode("neg")).toBeUndefined();
+    expect(getBonusForCode("ok")).toBe(30);
+  });
+
+  test("codes are matched case- and whitespace-insensitively", () => {
+    setEnvCodes({ launch: "25" });
+    expect(getBonusForCode("  LAUNCH  ")).toBe(25);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/signup-code.ts
+++ b/packages/cloud/shared/src/lib/services/signup-code.ts
@@ -19,7 +19,20 @@ export const ERRORS = {
 };
 
 interface SignupCodesConfig {
-  codes?: Record<string, number>;
+  codes?: Record<string, unknown>;
+}
+
+/** Parse one configured grant without accepting numeric prefixes or non-finite values. */
+export function parseSignupCodeBonus(amount: unknown): number | null {
+  let parsed: number;
+  if (typeof amount === "number") {
+    parsed = amount;
+  } else {
+    const raw = String(amount).trim();
+    if (!/^\d+(?:\.\d+)?$/.test(raw)) return null;
+    parsed = Number(raw);
+  }
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
 }
 
 /** WHY default "{}": App must run when env is unset; no codes = feature disabled. */
@@ -41,29 +54,13 @@ function loadCodes(): Map<string, number> {
   for (const [code, amount] of Object.entries(codes)) {
     const normalized = code?.trim().toLowerCase();
     if (!normalized) continue;
-    // The documented contract declares `amount` as a number; the string
-    // branch is a defensive sanity check on malformed JSON and must be
-    // strict — parseFloat accepts a numeric prefix ("25credits" -> 25) and
-    // returns Infinity for "Infinity", which then passes an isNaN-only
-    // guard and could reach addCredits as a non-finite grant (#20132).
-    // Require a complete canonical non-negative decimal string and accept
-    // only finite positive values on both branches.
-    let num: number;
-    if (typeof amount === "number") {
-      num = amount;
-    } else {
-      const raw = String(amount).trim();
-      if (!/^\d+(?:\.\d+)?$/.test(raw)) continue;
-      num = Number(raw);
-    }
-    if (Number.isFinite(num) && num > 0) {
-      map.set(normalized, num);
-    }
+    const bonus = parseSignupCodeBonus(amount);
+    if (bonus !== null) map.set(normalized, bonus);
   }
   return map;
 }
 
-/** Test hook: the codes map is cached per process; tests need to re-read env. */
+/** Clear the process cache so deterministic tests can reload environment input. */
 export function resetSignupCodesCacheForTests(): void {
   cachedCodes = null;
 }

--- a/packages/cloud/shared/src/lib/services/signup-code.ts
+++ b/packages/cloud/shared/src/lib/services/signup-code.ts
@@ -41,12 +41,31 @@ function loadCodes(): Map<string, number> {
   for (const [code, amount] of Object.entries(codes)) {
     const normalized = code?.trim().toLowerCase();
     if (!normalized) continue;
-    const num = typeof amount === "number" ? amount : parseFloat(String(amount));
-    if (!isNaN(num) && num > 0) {
+    // The documented contract declares `amount` as a number; the string
+    // branch is a defensive sanity check on malformed JSON and must be
+    // strict — parseFloat accepts a numeric prefix ("25credits" -> 25) and
+    // returns Infinity for "Infinity", which then passes an isNaN-only
+    // guard and could reach addCredits as a non-finite grant (#20132).
+    // Require a complete canonical non-negative decimal string and accept
+    // only finite positive values on both branches.
+    let num: number;
+    if (typeof amount === "number") {
+      num = amount;
+    } else {
+      const raw = String(amount).trim();
+      if (!/^\d+(?:\.\d+)?$/.test(raw)) continue;
+      num = Number(raw);
+    }
+    if (Number.isFinite(num) && num > 0) {
       map.set(normalized, num);
     }
   }
   return map;
+}
+
+/** Test hook: the codes map is cached per process; tests need to re-read env. */
+export function resetSignupCodesCacheForTests(): void {
+  cachedCodes = null;
 }
 
 /** WHY cache: Env is read once per process; no need to re-parse on every redeem. */


### PR DESCRIPTION
# Relates to

Fixes #20132

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [ ] `bun run verify` was NOT run in this environment — the exact unrelated
      blocker is recorded in **Known gaps / failures** below.
- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      (`fac7dc69`) with zero conflicts.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-sonnet-4-5`
<!-- attribution-row:client -->
- Agent tooling: `ZCode`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Focused suite + changed-file Biome pass post-sync (output below).

# Risks

Low. The change tightens the defensive string branch of `loadCodes()` only:
documented-contract numeric values (finite, positive) and canonical decimal
strings (including edge-padded ones) behave exactly as before; prefix-garbage
(`"25credits"`), exponent/hex/sign/leading-dot/trailing-dot forms, `"Infinity"`,
`"NaN"`, zero, and negatives now fall out of the codes map instead of becoming
credit grants. Both real `redeemSignupCode` callers route through
`getBonusForCode`, so rejected codes simply stop redeeming — the documented
feature-disabled behavior for invalid config.

# Background

## What does this PR do?

`loadCodes()` in `packages/cloud/shared/src/lib/services/signup-code.ts`
converted `SIGNUP_CODES_JSON` bonus values with
`parseFloat(String(amount))` guarded only by `!isNaN(num) && num > 0`.
`parseFloat` accepts a numeric prefix (`"25credits"` → 25) and returns
`Infinity` for `"Infinity"` (which is not NaN), so malformed env values could
become real or non-finite credit grants through
`creditsService.addCredits` (#20132).

The string branch now requires a complete canonical decimal
(`/^\d+(?:\.\d+)?$/` after trim) and both branches gate on
`Number.isFinite(num) && num > 0`. A `resetSignupCodesCacheForTests()` hook
(exported, matching the existing `resetKmsClientForTests` convention) lets
tests drive the per-process env cache.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

```bash
bun test packages/cloud/shared/src/lib/services/signup-code.test.ts
```

## Detailed testing steps

Four deterministic suites drive the real env → parse → `getBonusForCode`
path with the service/repository dependencies mocked offline:
- rejection table: `25credits`, `1e2`, `0x10`, `+25`, `.5`, `25.`,
  `Infinity`, `NaN`, `-25`, `0`, `""`;
- acceptance: canonical integers/decimals and edge-padded `" 7.5 "`;
- non-finite numbers (`Infinity`/`NaN`) and negatives rejected on the number
  branch too, finite positive accepted;
- case-/whitespace-insensitive code matching preserved.

# Evidence Gate

<!-- evidence-head:a0143efe59d3e4324c1843659cc0d3042c07e9ca -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend environment parsing change with no rendered frontend surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend environment parsing change with no rendered frontend surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow; deterministic tests exercise parsing and cached lookup
<!-- evidence-row:backend-logs -->
- [x] [20137-pr20137-backend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20137-pr20137-backend-logs.txt)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend or browser network path changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, action, or evaluator behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure configuration parsing with no durable artifact production
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed

# Evidence Details

## Backend + frontend logs

Focused unit test output (run against the PR head):

```
$ bun test packages/cloud/shared/src/lib/services/signup-code.test.ts

 4 pass
 0 fail
 20 expect() calls
Ran 4 tests across 1 file. [366.00ms]
```

Changed-file Biome passes clean (`bunx biome check` exit=0 on both files).

The issue's direct confirmations invert on this head:
`parseFloat("25credits")`-shaped values no longer produce a `$25` bonus, and
`"Infinity"` never reaches the codes map (both verified through
`getBonusForCode` in the rejection table above).

## Screenshots (before / after) + video walkthrough

N/A - backend env-config parsing change, no rendered UI surface.

## Known gaps / failures

Root `bun install` in this environment fails on the `ffmpeg-static` postinstall
script (network timeout fetching the prebuilt binary), so the full root
`bun run verify` cannot run here. Unrelated to this change: the focused suite
runs against the already-installed workspace dependencies with the heavy
service imports mocked, and the production diff is one parser branch plus a
test hook in `signup-code.ts` and its new colocated test file.

