### PR TITLE
fix(ui): reverify billing success after checkout context changes

### DIFF
--- a/packages/ui/src/cloud/billing/BillingSuccessPage.test.tsx
+++ b/packages/ui/src/cloud/billing/BillingSuccessPage.test.tsx
@@ -1,40 +1,59 @@
 /**
  * Exercises the authenticated billing Checkout return component as a
- * deterministic state machine. Session/auth and the verification mutation are
- * controlled test seams; the real page decides which user-visible state wins.
+ * deterministic state machine. React Router is real for in-place query
+ * transitions; session/auth and React Query mutation callbacks are controlled
+ * seams while the real page decides which user-visible state wins.
  */
 
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from "@testing-library/react";
-import type { ReactNode } from "react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { type ReactNode, StrictMode, Suspense, startTransition } from "react";
+import {
+  MemoryRouter,
+  type NavigateFunction,
+  useNavigate,
+  useSearchParams,
+} from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-const searchParamsState = vi.hoisted(() => ({
-  current: new URLSearchParams(),
-}));
 
 const sessionState = vi.hoisted(() => ({
   ready: true,
   authenticated: true,
+  user: { id: "user-a", email: "a@example.test" } as {
+    id: string;
+    email: string;
+  } | null,
 }));
 
-const verifyState = vi.hoisted(() => ({
-  mutate: vi.fn(),
-  isPending: false,
-  isError: false,
-  isSuccess: false,
-  error: null as Error | null,
-  data: undefined as
-    | { success: boolean; balance: number; alreadyApplied: boolean }
-    | undefined,
-}));
+const verifyState = vi.hoisted(() => {
+  type Result = {
+    success: boolean;
+    balance: number;
+    alreadyApplied: boolean;
+  };
+  type Request = {
+    input: { sessionId: string; from?: string };
+    callbacks: {
+      onError: (error: unknown) => void;
+      onSuccess: (data: Result) => void;
+    };
+  };
+  const requests: Request[] = [];
+  return {
+    requests,
+    mutate: vi.fn(
+      (input: Request["input"], callbacks: Request["callbacks"]) => {
+        requests.push({ callbacks, input });
+      },
+    ),
+  };
+});
 
-vi.mock("react-router-dom", () => ({
-  Link: ({ to, children }: { to: string; children: ReactNode }) => (
-    <a href={to}>{children}</a>
-  ),
-  useSearchParams: () => [searchParamsState.current, vi.fn()],
+const renderState = vi.hoisted(() => ({
+  balance: vi.fn(),
+  suspensions: vi.fn(),
+  successTitle: vi.fn(),
 }));
 
 vi.mock("@elizaos/ui/cloud-ui", () => ({
@@ -50,7 +69,10 @@ vi.mock("@elizaos/ui/cloud-ui", () => ({
   CardHeader: ({ children }: { children: ReactNode }) => (
     <header>{children}</header>
   ),
-  CardTitle: ({ children }: { children: ReactNode }) => <h1>{children}</h1>,
+  CardTitle: ({ children }: { children: ReactNode }) => {
+    if (children === "Purchase Successful!") renderState.successTitle();
+    return <h1>{children}</h1>;
+  },
   DashboardLoadingState: ({ label }: { label: string }) => (
     <div role="status" aria-live="polite" aria-label={label} />
   ),
@@ -66,7 +88,10 @@ vi.mock("../shell/CloudI18nProvider", () => ({
 }));
 
 vi.mock("./components/success-client", () => ({
-  CreditBalanceDisplay: () => <div data-testid="credit-balance">$42.00</div>,
+  CreditBalanceDisplay: () => {
+    renderState.balance();
+    return <div data-testid="credit-balance">$42.00</div>;
+  },
 }));
 
 vi.mock("./data/billing-data", () => ({
@@ -75,9 +100,48 @@ vi.mock("./data/billing-data", () => ({
 
 import BillingSuccessPage from "./BillingSuccessPage";
 
+let navigate: NavigateFunction | null = null;
+const suspendedForever = new Promise<never>(() => undefined);
+
+function SuspendAfterBilling() {
+  const [params] = useSearchParams();
+  if (params.get("suspend") === "1") {
+    renderState.suspensions();
+    throw suspendedForever;
+  }
+  return null;
+}
+
+function BillingSuccessRoute() {
+  navigate = useNavigate();
+  return (
+    <>
+      <BillingSuccessPage />
+      <SuspendAfterBilling />
+    </>
+  );
+}
+
+function pageTree(search: string) {
+  const suffix = search ? `?${search}` : "";
+  return (
+    <MemoryRouter initialEntries={[`/cloud/billing/success${suffix}`]}>
+      <Suspense fallback={<div>Suspended transition</div>}>
+        <BillingSuccessRoute />
+      </Suspense>
+    </MemoryRouter>
+  );
+}
+
 function renderPage(search = "session_id=cs_paid&from=settings") {
-  searchParamsState.current = new URLSearchParams(search);
-  return render(<BillingSuccessPage />);
+  return render(pageTree(search));
+}
+
+function navigatePage(search: string): void {
+  const navigateNow = navigate;
+  if (!navigateNow) throw new Error("Billing success router is not mounted");
+  const suffix = search ? `?${search}` : "";
+  act(() => navigateNow(`/cloud/billing/success${suffix}`));
 }
 
 function expectNoSuccess(): void {
@@ -85,16 +149,49 @@ function expectNoSuccess(): void {
   expect(screen.queryByTestId("credit-balance")).toBeNull();
 }
 
+function resolveRequest(
+  index: number,
+  data: { success: boolean; balance: number; alreadyApplied: boolean },
+): void {
+  const request = verifyState.requests[index];
+  if (!request) throw new Error(`Missing verification request ${index}`);
+  act(() => request.callbacks.onSuccess(data));
+}
+
+function resolveRuntimePayload(index: number, data: unknown): void {
+  const request = verifyState.requests[index];
+  if (!request) throw new Error(`Missing verification request ${index}`);
+  act(() => request.callbacks.onSuccess(data as never));
+}
+
+function rejectRequest(index: number, error: Error): void {
+  const request = verifyState.requests[index];
+  if (!request) throw new Error(`Missing verification request ${index}`);
+  act(() => request.callbacks.onError(error));
+}
+
+async function expectRequestCount(count: number): Promise<void> {
+  await waitFor(() => {
+    expect(verifyState.mutate).toHaveBeenCalledTimes(count);
+  });
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
 beforeEach(() => {
-  searchParamsState.current = new URLSearchParams();
+  navigate = null;
   sessionState.ready = true;
   sessionState.authenticated = true;
-  verifyState.mutate.mockReset();
-  verifyState.isPending = false;
-  verifyState.isError = false;
-  verifyState.isSuccess = false;
-  verifyState.error = null;
-  verifyState.data = undefined;
+  sessionState.user = { id: "user-a", email: "a@example.test" };
+  verifyState.mutate.mockClear();
+  verifyState.requests.splice(0);
+  renderState.balance.mockClear();
+  renderState.suspensions.mockClear();
+  renderState.successTitle.mockClear();
 });
 
 afterEach(() => {
@@ -114,41 +211,52 @@ describe("BillingSuccessPage checkout verification truth", () => {
     expect(verifyState.mutate).not.toHaveBeenCalled();
   });
 
-  it("keeps idle verification away from success before the effect settles", () => {
+  it("keeps idle verification away from success before the effect settles", async () => {
     renderPage();
 
     expect(
       screen.getByRole("status", { name: "Verifying payment" }),
     ).toBeTruthy();
     expectNoSuccess();
-    expect(verifyState.mutate).toHaveBeenCalledTimes(1);
-    expect(verifyState.mutate).toHaveBeenCalledWith({
+    await expectRequestCount(1);
+    expect(verifyState.requests[0]?.input).toEqual({
       sessionId: "cs_paid",
       from: "settings",
     });
   });
 
-  it("keeps pending verification away from success", () => {
-    verifyState.isPending = true;
-    renderPage("session_id=cs_pending");
+  it("keeps pending verification away from success", async () => {
+    const page = renderPage("session_id=cs_pending");
+    page.rerender(pageTree("session_id=cs_pending"));
 
     expect(
       screen.getByRole("status", { name: "Verifying payment" }),
     ).toBeTruthy();
     expectNoSuccess();
-    expect(verifyState.mutate).toHaveBeenCalledTimes(1);
-    expect(verifyState.mutate).toHaveBeenCalledWith({
+    await expectRequestCount(1);
+    expect(verifyState.requests[0]?.input).toEqual({
       sessionId: "cs_pending",
       from: undefined,
     });
   });
 
-  it("renders a verification rejection as an announced payment issue", () => {
-    const page = renderPage();
-    verifyState.isError = true;
-    verifyState.error = new Error("Checkout verification failed");
+  it("starts one verification through StrictMode effect replay", async () => {
+    render(<StrictMode>{pageTree("session_id=cs_strict")}</StrictMode>);
 
-    page.rerender(<BillingSuccessPage />);
+    await expectRequestCount(1);
+    await flushMicrotasks();
+
+    expect(verifyState.mutate).toHaveBeenCalledTimes(1);
+    expect(verifyState.requests[0]?.input).toEqual({
+      sessionId: "cs_strict",
+      from: undefined,
+    });
+  });
+
+  it("renders a verification rejection as an announced payment issue", async () => {
+    renderPage();
+    await expectRequestCount(1);
+    rejectRequest(0, new Error("Checkout verification failed"));
 
     const alert = screen.getByRole("alert");
     expect(alert.getAttribute("aria-live")).toBe("assertive");
@@ -157,36 +265,306 @@ describe("BillingSuccessPage checkout verification truth", () => {
     expect(verifyState.mutate).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects a resolved response whose success flag is false", () => {
-    const page = renderPage();
-    verifyState.isSuccess = true;
-    verifyState.data = {
+  it("rejects a resolved response whose success flag is false", async () => {
+    renderPage();
+    await expectRequestCount(1);
+    resolveRequest(0, {
       success: false,
       balance: 42,
       alreadyApplied: false,
-    };
-
-    page.rerender(<BillingSuccessPage />);
+    });
 
     expect(screen.getByRole("alert").textContent).toContain("Payment Issue");
     expectNoSuccess();
     expect(verifyState.mutate).toHaveBeenCalledTimes(1);
   });
 
-  it("renders purchase success only for a verified success payload", () => {
-    const page = renderPage();
-    verifyState.isSuccess = true;
-    verifyState.data = {
+  it.each([
+    ["null", null],
+    ["a primitive", "verified"],
+    ["a malformed object", { success: "true" }],
+  ])(
+    "rejects %s returned by a successful HTTP callback",
+    async (_label, data) => {
+      renderPage();
+      await expectRequestCount(1);
+
+      resolveRuntimePayload(0, data);
+
+      expect(screen.getByRole("alert").textContent).toContain("Payment Issue");
+      expectNoSuccess();
+      expect(verifyState.mutate).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("renders purchase success only for a verified success payload", async () => {
+    renderPage();
+    await expectRequestCount(1);
+    resolveRequest(0, {
       success: true,
       balance: 42,
       alreadyApplied: false,
-    };
-
-    page.rerender(<BillingSuccessPage />);
+    });
 
     expect(screen.getByText("Purchase Successful!")).toBeTruthy();
     expect(screen.getByTestId("credit-balance")).toBeTruthy();
     expect(screen.queryByRole("alert")).toBeNull();
     expect(verifyState.mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts verification when a missing query gains a checkout session", async () => {
+    renderPage("");
+
+    navigatePage("session_id=cs_arrived&from=settings");
+
+    expect(
+      screen.getByRole("status", { name: "Verifying payment" }),
+    ).toBeTruthy();
+    expectNoSuccess();
+    await expectRequestCount(1);
+    expect(verifyState.requests[0]?.input).toEqual({
+      sessionId: "cs_arrived",
+      from: "settings",
+    });
+  });
+
+  it("never reuses success when the same session returns after a missing query", async () => {
+    renderPage("session_id=cs_returning&from=settings");
+    await expectRequestCount(1);
+    resolveRequest(0, {
+      success: true,
+      balance: 42,
+      alreadyApplied: false,
+    });
+    expect(screen.getByText("Purchase Successful!")).toBeTruthy();
+
+    renderState.balance.mockClear();
+    renderState.successTitle.mockClear();
+    navigatePage("");
+    expect(screen.getByRole("alert")).toBeTruthy();
+    expectNoSuccess();
+
+    navigatePage("session_id=cs_returning&from=settings");
+    expect(
+      screen.getByRole("status", { name: "Verifying payment" }),
+    ).toBeTruthy();
+    expectNoSuccess();
+    expect(renderState.successTitle).not.toHaveBeenCalled();
+    expect(renderState.balance).not.toHaveBeenCalled();
+    await expectRequestCount(2);
+
+    resolveRequest(1, {
+      success: true,
+      balance: 42,
+      alreadyApplied: false,
+    });
+    expect(screen.getByText("Purchase Successful!")).toBeTruthy();
+    expect(renderState.successTitle).toHaveBeenCalled();
+    expect(renderState.balance).toHaveBeenCalled();
+  });
+
+  it("keeps the committed verification live when a route transition is abandoned", async () => {
+    renderPage("session_id=cs_transition&from=settings");
+    await expectRequestCount(1);
+    resolveRequest(0, {
+      success: true,
+      balance: 42,
+      alreadyApplied: false,
+    });
+    expect(screen.getByText("Purchase Successful!")).toBeTruthy();
+
+    const navigateNow = navigate;
+    if (!navigateNow) throw new Error("Billing success router is not mounted");
+    act(() => {
+      startTransition(() => {
+        navigateNow("/cloud/billing/success?suspend=1");
+      });
+    });
+    await waitFor(() => {
+      expect(renderState.suspensions).toHaveBeenCalled();
+    });
+
+    expect(screen.getByText("Purchase Successful!")).toBeTruthy();
+    expect(screen.getByTestId("credit-balance")).toBeTruthy();
+    expect(verifyState.mutate).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      navigateNow(
+        "/cloud/billing/success?session_id=cs_transition&from=settings&resume=1",
+      );
+    });
+    await flushMicrotasks();
+
+    expect(screen.getByText("Purchase Successful!")).toBeTruthy();
+    expect(
+      screen.queryByRole("status", { name: "Verifying payment" }),
+    ).toBeNull();
+    expect(verifyState.mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("never reuses success when the same user logs back in", async () => {
+    const page = renderPage("session_id=cs_reauth&from=settings");
+    await expectRequestCount(1);
+    resolveRequest(0, {
+      success: true,
+      balance: 42,
+      alreadyApplied: false,
+    });
+    expect(screen.getByText("Purchase Successful!")).toBeTruthy();
+
+    renderState.balance.mockClear();
+    renderState.successTitle.mockClear();
+    sessionState.authenticated = false;
+    sessionState.user = null;
+    page.rerender(pageTree("session_id=cs_reauth&from=settings"));
+    expect(screen.getByRole("status", { name: "Loading" })).toBeTruthy();
+    expectNoSuccess();
+
+    sessionState.authenticated = true;
+    sessionState.user = { id: "user-a", email: "a@example.test" };
+    page.rerender(pageTree("session_id=cs_reauth&from=settings"));
+    expect(
+      screen.getByRole("status", { name: "Verifying payment" }),
+    ).toBeTruthy();
+    expectNoSuccess();
+    expect(renderState.successTitle).not.toHaveBeenCalled();
+    expect(renderState.balance).not.toHaveBeenCalled();
+    await expectRequestCount(2);
+
+    resolveRequest(1, {
+      success: true,
+      balance: 42,
+      alreadyApplied: false,
+    });
+    expect(screen.getByText("Purchase Successful!")).toBeTruthy();
+  });
+
+  it("reverifies when the checkout session changes without remounting", async () => {
+    renderPage("session_id=cs_a&from=settings");
+    await expectRequestCount(1);
+    resolveRequest(0, {
+      success: true,
+      balance: 42,
+      alreadyApplied: false,
+    });
+    expect(screen.getByText("Purchase Successful!")).toBeTruthy();
+
+    navigatePage("session_id=cs_b&from=settings");
+
+    expect(
+      screen.getByRole("status", { name: "Verifying payment" }),
+    ).toBeTruthy();
+    expectNoSuccess();
+    await expectRequestCount(2);
+    expect(verifyState.requests[1]?.input).toEqual({
+      sessionId: "cs_b",
+      from: "settings",
+    });
+  });
+
+  it("reverifies when the authenticated user changes without remounting", async () => {
+    const page = renderPage("session_id=cs_paid&from=settings");
+    await expectRequestCount(1);
+    resolveRequest(0, {
+      success: true,
+      balance: 42,
+      alreadyApplied: false,
+    });
+    expect(screen.getByText("Purchase Successful!")).toBeTruthy();
+
+    sessionState.user = { id: "user-b", email: "b@example.test" };
+    page.rerender(pageTree("session_id=cs_paid&from=settings"));
+
+    expect(
+      screen.getByRole("status", { name: "Verifying payment" }),
+    ).toBeTruthy();
+    expectNoSuccess();
+    await expectRequestCount(2);
+  });
+
+  it("reverifies when the checkout source changes without remounting", async () => {
+    renderPage("session_id=cs_paid&from=settings");
+    await expectRequestCount(1);
+    resolveRequest(0, {
+      success: true,
+      balance: 42,
+      alreadyApplied: false,
+    });
+
+    navigatePage("session_id=cs_paid");
+
+    expect(
+      screen.getByRole("status", { name: "Verifying payment" }),
+    ).toBeTruthy();
+    expectNoSuccess();
+    await expectRequestCount(2);
+    expect(verifyState.requests[1]?.input).toEqual({
+      sessionId: "cs_paid",
+      from: undefined,
+    });
+  });
+
+  it("does not reverify when unrecognized source values change", async () => {
+    renderPage("session_id=cs_paid&from=foo");
+    await expectRequestCount(1);
+    resolveRequest(0, {
+      success: true,
+      balance: 42,
+      alreadyApplied: false,
+    });
+
+    navigatePage("session_id=cs_paid&from=bar");
+    await flushMicrotasks();
+
+    expect(screen.getByText("Purchase Successful!")).toBeTruthy();
+    expect(verifyState.mutate).toHaveBeenCalledTimes(1);
+    expect(verifyState.requests[0]?.input).toEqual({
+      sessionId: "cs_paid",
+      from: undefined,
+    });
+  });
+
+  it("ignores an old session completion after a newer verification settles", async () => {
+    renderPage("session_id=cs_a&from=settings");
+    await expectRequestCount(1);
+    navigatePage("session_id=cs_b&from=settings");
+    await expectRequestCount(2);
+
+    resolveRequest(1, {
+      success: false,
+      balance: 42,
+      alreadyApplied: false,
+    });
+    expect(screen.getByRole("alert").textContent).toContain("Payment Issue");
+    expectNoSuccess();
+
+    resolveRequest(0, {
+      success: true,
+      balance: 99,
+      alreadyApplied: false,
+    });
+    expect(screen.getByRole("alert").textContent).toContain("Payment Issue");
+    expectNoSuccess();
+  });
+
+  it("invalidates verification callbacks when the page unmounts", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    try {
+      const page = renderPage("session_id=cs_abandoned&from=settings");
+      await expectRequestCount(1);
+
+      page.unmount();
+      resolveRequest(0, {
+        success: true,
+        balance: 99,
+        alreadyApplied: false,
+      });
+
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });

--- a/packages/ui/src/cloud/billing/BillingSuccessPage.tsx
+++ b/packages/ui/src/cloud/billing/BillingSuccessPage.tsx
@@ -19,103 +19,200 @@ import {
   DashboardLoadingState,
 } from "@elizaos/ui/cloud-ui";
 import { ArrowRight, CheckCircle, XCircle } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { useSessionAuth } from "../lib/use-session-auth";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import { CreditBalanceDisplay } from "./components/success-client";
 import { useVerifyCheckout } from "./data/billing-data";
 
-export default function BillingSuccessPage() {
-  const t = useCloudT();
-  const session = useSessionAuth();
-  const [params] = useSearchParams();
-  const fromSettings = params.get("from") === "settings";
-  const sessionId = params.get("session_id") ?? undefined;
+type VerificationState =
+  | { generation: number; key: string; status: "pending" }
+  | { generation: number; key: string; status: "verified" }
+  | { generation: number; key: string; status: "rejected" }
+  | { error: unknown; generation: number; key: string; status: "error" };
 
-  const verify = useVerifyCheckout();
-  const triggered = useRef(false);
+interface VerificationRequest {
+  generation: number;
+  key: string;
+}
+
+function isVerifiedCheckoutOutcome(data: unknown): boolean {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    (data as { success?: unknown }).success === true
+  );
+}
+
+function PaymentIssue({
+  error,
+  sessionId,
+}: {
+  error?: unknown;
+  sessionId?: string;
+}) {
+  const t = useCloudT();
+  const message =
+    error instanceof Error
+      ? error.message
+      : t("cloud.billingSuccess.unableToVerify", {
+          defaultValue: "Unable to verify payment",
+        });
+
+  return (
+    <div className="flex items-center justify-center min-h-[80vh]">
+      <Card className="max-w-md w-full" role="alert" aria-live="assertive">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-500/10">
+            <XCircle className="h-10 w-10 text-red-500" />
+          </div>
+          <CardTitle className="text-2xl">
+            {t("cloud.billingSuccess.paymentIssue", {
+              defaultValue: "Payment Issue",
+            })}
+          </CardTitle>
+          <CardDescription>{message}</CardDescription>
+        </CardHeader>
+
+        <CardContent className="text-center space-y-4">
+          {sessionId ? (
+            <>
+              <p className="text-sm text-muted-foreground">
+                {t("cloud.billingSuccess.contactSupport", {
+                  defaultValue:
+                    "If you believe this is an error, please contact support with your session ID.",
+                })}
+              </p>
+              <p className="text-xs text-muted-foreground bg-muted p-2 rounded-sm">
+                {t("cloud.billingSuccess.sessionLabel", {
+                  sessionId: `${sessionId.substring(0, 20)}...`,
+                  defaultValue: "Session: {{sessionId}}",
+                })}
+              </p>
+            </>
+          ) : null}
+        </CardContent>
+
+        <CardFooter className="flex flex-col gap-2">
+          <Button asChild variant="outline" className="w-full">
+            <Link to="/settings#cloud-billing">
+              {t("cloud.billingSuccess.backToBilling", {
+                defaultValue: "Back to Billing",
+              })}
+            </Link>
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}
+
+function BillingVerificationAttempt({
+  checkoutSource,
+  sessionId,
+  verificationKey,
+}: {
+  checkoutSource?: "settings";
+  sessionId: string;
+  verificationKey: string;
+}) {
+  const t = useCloudT();
+
+  const { mutate: verifyCheckout } = useVerifyCheckout();
+  const [verification, setVerification] = useState<VerificationState>({
+    generation: 0,
+    key: verificationKey,
+    status: "pending",
+  });
+  const activeRequest = useRef<VerificationRequest | null>(null);
+  const nextGeneration = useRef(0);
 
   useEffect(() => {
-    if (!session.ready || !session.authenticated) return;
-    if (!sessionId) return;
-    if (triggered.current) return;
-    triggered.current = true;
-    verify.mutate({
-      sessionId,
-      from: fromSettings ? "settings" : undefined,
+    if (activeRequest.current?.key === verificationKey) return;
+
+    const request = {
+      generation: ++nextGeneration.current,
+      key: verificationKey,
+    };
+    activeRequest.current = request;
+    setVerification({
+      generation: request.generation,
+      key: verificationKey,
+      status: "pending",
     });
-  }, [session.ready, session.authenticated, sessionId, fromSettings, verify]);
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (
+        cancelled ||
+        activeRequest.current?.generation !== request.generation
+      ) {
+        return;
+      }
+      verifyCheckout(
+        { from: checkoutSource, sessionId },
+        {
+          onError: (error) => {
+            if (activeRequest.current?.generation !== request.generation)
+              return;
+            setVerification((current) =>
+              current?.key === request.key &&
+              current.generation === request.generation
+                ? {
+                    error,
+                    generation: request.generation,
+                    key: request.key,
+                    status: "error",
+                  }
+                : current,
+            );
+          },
+          onSuccess: (data) => {
+            if (activeRequest.current?.generation !== request.generation)
+              return;
+            setVerification((current) =>
+              current?.key === request.key &&
+              current.generation === request.generation
+                ? isVerifiedCheckoutOutcome(data)
+                  ? {
+                      generation: request.generation,
+                      key: request.key,
+                      status: "verified",
+                    }
+                  : {
+                      generation: request.generation,
+                      key: request.key,
+                      status: "rejected",
+                    }
+                : current,
+            );
+          },
+        },
+      );
+    });
 
-  if (!session.ready || !session.authenticated) {
-    return (
-      <DashboardLoadingState
-        label={t("cloud.billingSuccess.loading", { defaultValue: "Loading" })}
-      />
-    );
-  }
+    return () => {
+      cancelled = true;
+      if (activeRequest.current?.generation === request.generation) {
+        activeRequest.current = null;
+      }
+    };
+  }, [checkoutSource, sessionId, verificationKey, verifyCheckout]);
 
+  const currentVerification = verification;
   const verificationFailed =
-    !sessionId ||
-    verify.isError ||
-    (verify.isSuccess && verify.data?.success !== true);
+    currentVerification?.status === "error" ||
+    currentVerification?.status === "rejected";
 
   if (verificationFailed) {
-    const message =
-      sessionId && verify.isError && verify.error instanceof Error
-        ? verify.error.message
-        : t("cloud.billingSuccess.unableToVerify", {
-            defaultValue: "Unable to verify payment",
-          });
-    return (
-      <div className="flex items-center justify-center min-h-[80vh]">
-        <Card className="max-w-md w-full" role="alert" aria-live="assertive">
-          <CardHeader className="text-center">
-            <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-500/10">
-              <XCircle className="h-10 w-10 text-red-500" />
-            </div>
-            <CardTitle className="text-2xl">
-              {t("cloud.billingSuccess.paymentIssue", {
-                defaultValue: "Payment Issue",
-              })}
-            </CardTitle>
-            <CardDescription>{message}</CardDescription>
-          </CardHeader>
-
-          <CardContent className="text-center space-y-4">
-            {sessionId ? (
-              <>
-                <p className="text-sm text-muted-foreground">
-                  {t("cloud.billingSuccess.contactSupport", {
-                    defaultValue:
-                      "If you believe this is an error, please contact support with your session ID.",
-                  })}
-                </p>
-                <p className="text-xs text-muted-foreground bg-muted p-2 rounded-sm">
-                  {t("cloud.billingSuccess.sessionLabel", {
-                    sessionId: `${sessionId.substring(0, 20)}...`,
-                    defaultValue: "Session: {{sessionId}}",
-                  })}
-                </p>
-              </>
-            ) : null}
-          </CardContent>
-
-          <CardFooter className="flex flex-col gap-2">
-            <Button asChild variant="outline" className="w-full">
-              <Link to="/settings#cloud-billing">
-                {t("cloud.billingSuccess.backToBilling", {
-                  defaultValue: "Back to Billing",
-                })}
-              </Link>
-            </Button>
-          </CardFooter>
-        </Card>
-      </div>
-    );
+    const error =
+      currentVerification?.status === "error"
+        ? currentVerification.error
+        : undefined;
+    return <PaymentIssue error={error} sessionId={sessionId} />;
   }
 
-  if (!verify.isSuccess) {
+  if (currentVerification?.status !== "verified") {
     return (
       <DashboardLoadingState
         label={t("cloud.billingSuccess.verifyingPayment", {
@@ -173,5 +270,40 @@ export default function BillingSuccessPage() {
         </CardFooter>
       </Card>
     </div>
+  );
+}
+
+export default function BillingSuccessPage() {
+  const t = useCloudT();
+  const session = useSessionAuth();
+  const [params] = useSearchParams();
+  const checkoutSource =
+    params.get("from") === "settings" ? "settings" : undefined;
+  const sessionId = params.get("session_id") ?? undefined;
+  const userId = session.user?.id || null;
+
+  if (!session.ready || !session.authenticated || !userId) {
+    return (
+      <DashboardLoadingState
+        label={t("cloud.billingSuccess.loading", { defaultValue: "Loading" })}
+      />
+    );
+  }
+
+  if (!sessionId) return <PaymentIssue />;
+
+  const verificationKey = JSON.stringify([
+    userId,
+    sessionId,
+    checkoutSource ?? null,
+  ]);
+
+  return (
+    <BillingVerificationAttempt
+      key={verificationKey}
+      checkoutSource={checkoutSource}
+      sessionId={sessionId}
+      verificationKey={verificationKey}
+    />
   );
 }


### PR DESCRIPTION
# Relates to

Relates to #20075. Follow-up repair for the post-merge finding on #20100.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Dependencies were installed from the lockfile and `bun run verify` passed after the final sync.
- [x] A reviewer can confirm the change from the exact-head browser evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6da03dd64ccbc643756fdfbc4250dc73b189be78:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `c7a1d61345d3a24a34589dd0f62ffd0f628d0715`, the latest `origin/develop` at push time; zero conflicts.
- [x] `bun run verify` passes post-sync on the canonical Node 24 / Bun 1.3.14 toolchain.

# Risks

Low. The change is limited to the billing-success route and its colocated component test. A keyed verification-attempt child remounts only when the effective request identity changes (authenticated user id, `session_id`, or normalized `from=settings` source). It does not change checkout creation, the verification API, balances, ledgers, provider calls, credentials, deployment, staging, or production resources.

# Background

The fresh-mount truthfulness matrix merged in #20100, but React Router can reuse the mounted component when only search parameters change. A successful result for checkout session A could therefore remain visible after in-place navigation to unverified session B; the same stale-result risk existed when authenticated identity changed.

## What does this PR do?

- Keys a verification-attempt child to the authenticated user id, `session_id`, and normalized request source actually sent to the API. A committed key change mounts a fresh pending attempt; a concurrent render that is suspended and abandoned cannot mutate the committed attempt.
- Keeps every mutable request/generation ref inside committed effects and callbacks; render performs no ref mutation.
- Invalidates the old generation during effect cleanup/unmount, and requires both key and generation to match before a callback can settle state, so late A cannot overwrite B or update an unmounted attempt.
- Uses a deliberately narrow runtime outcome discriminator: only a non-null object whose `success` field is exactly `true` is accepted. This is not complete DTO validation; null, primitive, malformed, and resolved-false 2xx payloads fail closed to `Payment Issue`.
- Adds real-router and React Query-compatible callback regressions for missing→A, A→B, user A→B, success X→missing→X, logout/login as the same user, effective source changes, stale A completion after B, unmount cleanup, StrictMode, invalid runtime payloads, and an interrupted React 19 transition that renders the billing route before suspending, while retaining the original six states.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This corrects existing billing-success behavior and does not alter a public API or documented workflow.

# Testing

## Where should a reviewer start?

Start with `packages/ui/src/cloud/billing/BillingSuccessPage.test.tsx`, especially the suspended/interrupted transition, same-X re-entry, in-place session, identity, stale-completion, and malformed-payload cases. Then inspect the keyed child and effect-only generation fence in `BillingSuccessPage.tsx`.

## Detailed testing steps

Exact Node `v24.15.0` / Bun `1.3.14` receipts:

- Focused component regression: 20/20 passed.
- Entire `src/cloud/billing` suite: 46/46 passed across 6 files.
- UI TypeScript: `tsc --noEmit -p tsconfig.json` passed.
- Targeted Biome check on both changed files passed.
- `bun run audit:ui-determinism` passed with the existing baseline (`render-time=36`, `deferred=280`, `module=210`; no new finding).

Post-sync canonical toolchain receipt (Node `v24.15.0` / Bun `1.3.14`):

- `bun run verify` passed: 351/351 Turbo tasks and every subsequent repository audit passed.
- `git diff --check HEAD^..HEAD` passed.
- Final tracked diff is exactly the two billing-success files.

Browser evidence uses the shipped app renderer, Cloud shell/auth restoration, React Router, React Query, and the actual billing-success component. Only the deterministic HTTP boundary was stubbed; no payment provider or live ledger was contacted.

# Evidence Gate

<!-- evidence-head:6da03dd64ccbc643756fdfbc4250dc73b189be78 -->

“Before” provenance: the original capture ran on base `fac7dc69ecc45321b467b674fbe93b85f3f320e7` after substituting and byte-verifying the pre-fix `BillingSuccessPage.tsx` blob from `ef407d34cde436d3b2088643786cd5eb870ee0e3`. Same-key, malformed-payload, and abandoned-render follow-ups were identified by independent review of prior draft heads through `b6843033b1d786620a43ec8d1cdec2fb92d39be5`. “After” provenance: exact live PR head `6da03dd64ccbc643756fdfbc4250dc73b189be78`.

<!-- evidence-row:before-screenshots -->
- [x] ![before baseline desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20138-before-desktop-stale-success.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after same session X re-entry verifying desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20138-after-desktop-same-x-reentry-verifying-6da03dd6.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20138-after-walkthrough-6da03dd6.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - frontend-only state repair; no backend or provider code path changed or was invoked.
<!-- evidence-row:frontend-logs -->
- [x] [after-frontend-network-state-6da03dd6.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20138-after-frontend-network-state-6da03dd6.json)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB, ledger, wallet, on-chain, memory, task, or generated domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] OCR review: [ocr-manifest-6da03dd6.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20138-ocr-manifest-6da03dd6.json)

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

Backend: N/A - this is a frontend-only state repair, and the evidence deliberately does not contact a provider, ledger, staging, or production service.

Frontend: [exact-head repaired network/state receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20138-after-frontend-network-state-6da03dd6.json) records the actual router URL, every verification POST/response, accessible pending state, rendered headings/balance, stale-callback ordering, every MutationObserver sample during same-X re-entry, null-payload rejection, and zero page errors. The [original baseline receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20138-before-frontend-network-state.json) records stale A success at the B URL with no B POST.

## Screenshots (before / after) + video walkthrough

### Before

- [Desktop baseline](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20138-before-desktop-stale-success.jpg)
- [Mobile baseline](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20138-before-mobile-stale-success.jpg)

Both captures show session A's stale successful purchase and `$42.00` balance still rendered at the session B URL, with no B verification POST.

### After

- [Desktop, B pending](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20138-after-desktop-session-b-verifying-6da03dd6.jpg)
- [Mobile, B pending](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20138-after-mobile-session-b-verifying-6da03dd6.jpg)
- [Desktop, late A ignored after B settles false](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20138-after-desktop-stale-a-ignored-6da03dd6.jpg)
- [Mobile, late A ignored after B settles false](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20138-after-mobile-stale-a-ignored-6da03dd6.jpg)
- [Desktop, same X re-entry pending](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20138-after-desktop-same-x-reentry-verifying-6da03dd6.jpg)
- [Mobile, same X re-entry pending](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20138-after-mobile-same-x-reentry-verifying-6da03dd6.jpg)
- [Desktop, null 2xx payload rejected](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20138-after-desktop-null-payload-rejected-6da03dd6.jpg)
- [Mobile, null 2xx payload rejected](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20138-after-mobile-null-payload-rejected-6da03dd6.jpg)

The pending captures contain the accessible `role=status` / `aria-label="Verifying payment"` state with success and balance absent. The final captures retain B's `Payment Issue` after the late successful A callback and render `Payment Issue` for a JSON `null` 2xx payload without a page error.

### Walkthrough video

[Exact-head walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20138-after-walkthrough-6da03dd6.mp4) — H.264/yuv420p, 800×450, 5.08 seconds. It walks through A success → B pending/failure → late A ignored → X success → missing key → same-X pending → null payload rejected.

## OCR visual-text review

- [Receipt and manual visual readback](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20138-evidence-receipt-6da03dd6.md)
- [Packaged OCR manifest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20138-ocr-manifest-6da03dd6.json)

Tesseract processed 9/9 images with 0 failures. Manual inspection also confirmed responsive, unclipped desktop/mobile layouts and the pending skeleton's accessible label. The frontend receipt proves every observed same-X intermediate render omitted both success and balance.

## Audio / voice walkthrough

N/A - no audio, voice, transcript, TTS, or STT surface changed.

## Known gaps / failures

- No known code or test gap. The exact head passed focused, billing, typecheck, Biome, determinism, browser, evidence, and complete repository verification gates on Node 24.15.0 / Bun 1.3.14.
- Browser evidence uses a deterministic verification HTTP boundary so it can force the adversarial A/B race, same-key re-entry, and malformed payload without a payment or ledger mutation. It still exercises the real shipped renderer, Cloud shell/auth restoration, React Router, React Query mutation, and component state path.
- The abandoned concurrent render is covered separately by the deterministic React 19 Suspense/startTransition regression because a shipped BrowserRouter capture cannot inject a suspending sibling without changing application code. That regression renders the billing page before suspension, interrupts back to X, proves exactly one request, and proves X never becomes stuck verifying.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@6da03dd64ccbc643756fdfbc4250dc73b189be78:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-billing-success-truth]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@6da03dd64ccbc643756fdfbc4250dc73b189be78:packages/skills/skills/contribute-to-eliza"} -->
