### PR TITLE
fix(ui): make pay-as-you-go load failures retryable

### DIFF
--- a/packages/ui/src/cloud/billing/components/pay-as-you-go-card.test.tsx
+++ b/packages/ui/src/cloud/billing/components/pay-as-you-go-card.test.tsx
@@ -1,30 +1,58 @@
 /**
- * Renders PayAsYouGoCard through SettingsSwitchRow and asserts load plus
- * toggle persist. jsdom, mocked billing settings API.
+ * Exercises PayAsYouGoCard loading, retry, stale-result, unmount, and
+ * optimistic-save boundaries in deterministic jsdom with a mocked HTTP client.
  */
 // @vitest-environment jsdom
 
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
   screen,
   waitFor,
 } from "@testing-library/react";
+import { StrictMode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const apiMock = vi.hoisted(() => vi.fn());
+const toastMocks = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
 
 vi.mock("../../lib/api-client", () => ({
   api: apiMock,
-  ApiError: class ApiError extends Error {},
 }));
 
 vi.mock("sonner", () => ({
-  toast: { success: vi.fn(), error: vi.fn() },
+  toast: toastMocks,
 }));
 
 import { PayAsYouGoCard } from "./pay-as-you-go-card";
+
+interface BillingSettingsPayload {
+  settings: { payAsYouGoFromEarnings: boolean };
+}
+
+function settings(payAsYouGoFromEarnings: boolean): BillingSettingsPayload {
+  return { settings: { payAsYouGoFromEarnings } };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function isChecked(toggle: HTMLElement): boolean {
+  const value =
+    toggle.getAttribute("data-state") ?? toggle.getAttribute("aria-checked");
+  return value === "checked" || value === "true";
+}
 
 afterEach(() => {
   cleanup();
@@ -32,31 +60,159 @@ afterEach(() => {
 
 beforeEach(() => {
   apiMock.mockReset();
+  toastMocks.success.mockReset();
+  toastMocks.error.mockReset();
 });
 
 describe("PayAsYouGoCard", () => {
-  it("loads the existing switch without BrandCard chrome", async () => {
-    apiMock.mockResolvedValueOnce({
-      settings: { payAsYouGoFromEarnings: true },
-    });
+  it("announces initial loading without rendering a switch", async () => {
+    const loadRequest = deferred<BillingSettingsPayload>();
+    apiMock.mockImplementationOnce(() => loadRequest.promise);
 
     render(<PayAsYouGoCard />);
 
-    expect(screen.getByText("Pay hosting from earnings")).toBeTruthy();
-    expect(
-      screen.getByText("Use my app earnings to pay container hosting"),
-    ).toBeTruthy();
+    const status = screen.getByRole("status", {
+      name: "Loading pay-as-you-go setting",
+    });
+    expect(status.getAttribute("aria-busy")).toBe("true");
+    expect(status.querySelector("svg")?.getAttribute("aria-hidden")).toBe(
+      "true",
+    );
+    expect(screen.queryByRole("switch")).toBeNull();
+
+    await act(async () => {
+      loadRequest.resolve(settings(true));
+      await loadRequest.promise;
+    });
+    expect(await screen.findByRole("switch")).toBeTruthy();
+  });
+
+  it("renders a generic alert and 44px retry action when loading rejects", async () => {
+    apiMock.mockRejectedValueOnce(new Error("private backend detail"));
+
+    render(<PayAsYouGoCard />);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Couldn't load this billing setting");
+    expect(alert.textContent).toContain("Check your connection and retry");
+    expect(alert.textContent).not.toContain("private backend detail");
+    expect(screen.queryByRole("switch")).toBeNull();
+
+    const retry = screen.getByRole("button", { name: "Retry" });
+    expect(retry).toHaveProperty("disabled", false);
+    expect(retry.getAttribute("aria-busy")).toBe("false");
+    expect(retry.getAttribute("type")).toBe("button");
+    expect(retry.className).toContain("min-h-touch");
+
+    const baseStyles = readFileSync(
+      join(process.cwd(), "src/styles/base.css"),
+      "utf8",
+    );
+    const touchTargetRem = Number(
+      baseStyles.match(/--min-touch-target:\s*([\d.]+)rem/)?.[1],
+    );
+    expect(touchTargetRem * 16).toBe(44);
+  });
+
+  it("keeps one retry alert busy and disabled, then restores backend false", async () => {
+    const retryRequest = deferred<BillingSettingsPayload>();
+    apiMock
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockImplementationOnce(() => retryRequest.promise);
+
+    render(<PayAsYouGoCard />);
+    const alert = await screen.findByRole("alert");
+    const retry = screen.getByRole("button", { name: "Retry" });
+
+    fireEvent.click(retry);
+    fireEvent.click(retry);
+
+    expect(apiMock).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole("alert")).toBe(alert);
+    expect(retry).toHaveProperty("disabled", true);
+    expect(retry.getAttribute("aria-busy")).toBe("true");
+    expect(screen.queryByRole("switch")).toBeNull();
+
+    await act(async () => {
+      retryRequest.resolve(settings(false));
+      await retryRequest.promise;
+    });
+
     const toggle = await screen.findByRole("switch");
-    expect(
-      toggle.getAttribute("data-state") ?? toggle.getAttribute("aria-checked"),
-    ).toMatch(/checked|true/);
+    expect(isChecked(toggle)).toBe(false);
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("preserves an initial backend false value instead of applying the default", async () => {
+    apiMock.mockResolvedValueOnce(settings(false));
+
+    render(<PayAsYouGoCard />);
+
+    const toggle = await screen.findByRole("switch");
+    expect(isChecked(toggle)).toBe(false);
     expect(apiMock).toHaveBeenCalledWith("/api/v1/billing/settings");
   });
 
-  it("PUTs the next value when the switch is toggled", async () => {
+  it("fails closed when the response omits the boolean setting", async () => {
+    apiMock.mockResolvedValueOnce({ settings: {} });
+
+    render(<PayAsYouGoCard />);
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(screen.queryByRole("switch")).toBeNull();
+  });
+
+  it("ignores a stale load failure after its replacement succeeds", async () => {
+    const staleRequest = deferred<BillingSettingsPayload>();
+    const activeRequest = deferred<BillingSettingsPayload>();
     apiMock
-      .mockResolvedValueOnce({ settings: { payAsYouGoFromEarnings: true } })
-      .mockResolvedValueOnce({});
+      .mockImplementationOnce(() => staleRequest.promise)
+      .mockImplementationOnce(() => activeRequest.promise);
+
+    render(
+      <StrictMode>
+        <PayAsYouGoCard />
+      </StrictMode>,
+    );
+    await waitFor(() => expect(apiMock).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      activeRequest.resolve(settings(false));
+      await activeRequest.promise;
+    });
+    const toggle = await screen.findByRole("switch");
+    expect(isChecked(toggle)).toBe(false);
+
+    await act(async () => {
+      staleRequest.reject(new Error("late initial failure"));
+      await expect(staleRequest.promise).rejects.toThrow(
+        "late initial failure",
+      );
+    });
+    expect(isChecked(toggle)).toBe(false);
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("ignores a load result delivered after unmount", async () => {
+    const loadRequest = deferred<BillingSettingsPayload>();
+    apiMock.mockImplementationOnce(() => loadRequest.promise);
+    const view = render(<PayAsYouGoCard />);
+
+    expect(
+      screen.getByRole("status", { name: "Loading pay-as-you-go setting" }),
+    ).toBeTruthy();
+    view.unmount();
+
+    await act(async () => {
+      loadRequest.resolve(settings(true));
+      await loadRequest.promise;
+    });
+    expect(apiMock).toHaveBeenCalledTimes(1);
+    expect(toastMocks.success).not.toHaveBeenCalled();
+  });
+
+  it("PUTs the next value when the switch is toggled", async () => {
+    apiMock.mockResolvedValueOnce(settings(true)).mockResolvedValueOnce({});
 
     render(<PayAsYouGoCard />);
     const toggle = await screen.findByRole("switch");
@@ -68,5 +224,69 @@ describe("PayAsYouGoCard", () => {
         json: { payAsYouGoFromEarnings: false },
       });
     });
+    await waitFor(() => expect(isChecked(toggle)).toBe(false));
+    expect(toastMocks.success).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses a reentrant save before React commits the busy state", async () => {
+    const firstSave = deferred<unknown>();
+    let saveCalls = 0;
+    apiMock.mockImplementation((_, options?: { method?: string }) => {
+      if (options?.method !== "PUT") return Promise.resolve(settings(false));
+      saveCalls += 1;
+      return saveCalls === 1
+        ? firstSave.promise
+        : Promise.reject(new Error("second save must not run"));
+    });
+
+    render(<PayAsYouGoCard />);
+    const toggle = await screen.findByRole("switch");
+    expect(isChecked(toggle)).toBe(false);
+
+    act(() => {
+      toggle.click();
+      toggle.click();
+    });
+
+    expect(saveCalls).toBe(1);
+    expect(apiMock).toHaveBeenCalledTimes(2);
+    expect(isChecked(toggle)).toBe(true);
+
+    await act(async () => {
+      firstSave.resolve({});
+      await firstSave.promise;
+    });
+
+    expect(isChecked(toggle)).toBe(true);
+    expect(toastMocks.success).toHaveBeenCalledTimes(1);
+    expect(toastMocks.error).not.toHaveBeenCalled();
+  });
+
+  it("rolls a failed save back to the confirmed false value", async () => {
+    const saveRequest = deferred<unknown>();
+    apiMock
+      .mockResolvedValueOnce(settings(false))
+      .mockImplementationOnce(() => saveRequest.promise);
+
+    render(<PayAsYouGoCard />);
+    const toggle = await screen.findByRole("switch");
+    expect(isChecked(toggle)).toBe(false);
+
+    fireEvent.click(toggle);
+    await waitFor(() => expect(apiMock).toHaveBeenCalledTimes(2));
+    expect(isChecked(toggle)).toBe(true);
+    expect(toggle).toHaveProperty("disabled", true);
+
+    await act(async () => {
+      saveRequest.reject(new Error("private save detail"));
+      await expect(saveRequest.promise).rejects.toThrow("private save detail");
+    });
+
+    await waitFor(() => expect(isChecked(toggle)).toBe(false));
+    expect(toggle).toHaveProperty("disabled", false);
+    expect(toastMocks.error).toHaveBeenCalledWith(
+      "We couldn't save this billing setting. Your previous setting was restored.",
+    );
+    expect(toastMocks.success).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/cloud/billing/components/pay-as-you-go-card.tsx
+++ b/packages/ui/src/cloud/billing/components/pay-as-you-go-card.tsx
@@ -11,8 +11,8 @@
 
 "use client";
 
-import { Coins, Loader2 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { Coins, Loader2, RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { SettingsSwitchRow } from "../../../components/settings/settings-agent-rows";
 import {
@@ -20,59 +20,185 @@ import {
   SettingsRow,
   SettingsStack,
 } from "../../../components/settings/settings-layout";
-import { ApiError, api } from "../../lib/api-client";
+import { Button } from "../../../components/ui/button";
+import { api } from "../../lib/api-client";
 
 const ENDPOINT = "/api/v1/billing/settings";
+const LOAD_ERROR_MESSAGE =
+  "Your current setting is unavailable. Check your connection and retry.";
+const SAVE_ERROR_MESSAGE =
+  "We couldn't save this billing setting. Your previous setting was restored.";
 
 interface BillingSettingsResponse {
-  settings?: { payAsYouGoFromEarnings?: boolean };
+  settings: { payAsYouGoFromEarnings: boolean };
 }
 
 export function PayAsYouGoCard() {
   const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadFailed, setLoadFailed] = useState(false);
   const [saving, setSaving] = useState(false);
+  const mountedRef = useRef(false);
+  const loadInFlightRef = useRef(false);
+  const saveInFlightRef = useRef(false);
+  const loadGenerationRef = useRef(0);
+  const saveGenerationRef = useRef(0);
+  const confirmedEnabledRef = useRef<boolean | null>(null);
 
   const load = useCallback(async () => {
-    const data = await api<BillingSettingsResponse>(ENDPOINT);
-    setEnabled(Boolean(data.settings?.payAsYouGoFromEarnings ?? true));
+    if (loadInFlightRef.current) return;
+
+    loadInFlightRef.current = true;
+    const generation = ++loadGenerationRef.current;
+    setLoading(true);
+
+    try {
+      const data = await api<BillingSettingsResponse>(ENDPOINT);
+      const next = data.settings?.payAsYouGoFromEarnings;
+      if (typeof next !== "boolean") {
+        throw new TypeError("Billing settings response omitted pay-as-you-go");
+      }
+      if (!mountedRef.current || generation !== loadGenerationRef.current) {
+        return;
+      }
+
+      confirmedEnabledRef.current = next;
+      setEnabled(next);
+      setLoadFailed(false);
+    } catch {
+      if (!mountedRef.current || generation !== loadGenerationRef.current) {
+        return;
+      }
+      // error-policy:J4 designated settings UI boundary keeps transport and malformed-response failures visibly unavailable and retryable.
+      confirmedEnabledRef.current = null;
+      setEnabled(null);
+      setLoadFailed(true);
+    } finally {
+      if (generation === loadGenerationRef.current) {
+        loadInFlightRef.current = false;
+        if (mountedRef.current) setLoading(false);
+      }
+    }
   }, []);
 
   useEffect(() => {
+    mountedRef.current = true;
     void load();
+    return () => {
+      mountedRef.current = false;
+      loadGenerationRef.current += 1;
+      saveGenerationRef.current += 1;
+      loadInFlightRef.current = false;
+      saveInFlightRef.current = false;
+    };
   }, [load]);
 
   const handleToggle = async (next: boolean) => {
+    if (saveInFlightRef.current) return;
+    const previous = confirmedEnabledRef.current;
+    if (previous === null) return;
+
+    saveInFlightRef.current = true;
+    const generation = ++saveGenerationRef.current;
     setSaving(true);
-    const previous = enabled;
     setEnabled(next);
     try {
       await api(ENDPOINT, {
         method: "PUT",
         json: { payAsYouGoFromEarnings: next },
       });
+      if (!mountedRef.current || generation !== saveGenerationRef.current) {
+        return;
+      }
+
+      confirmedEnabledRef.current = next;
       toast.success(
         next
           ? "Earnings will pay container hosting before credits"
           : "Hosting will only use credits — earnings preserved for cashout",
       );
-    } catch (error) {
+    } catch {
+      if (!mountedRef.current || generation !== saveGenerationRef.current) {
+        return;
+      }
+      // error-policy:J4 designated settings UI boundary restores the confirmed value after any transport failure and notifies.
       setEnabled(previous);
-      toast.error(error instanceof ApiError ? error.message : "Failed to save");
+      toast.error(SAVE_ERROR_MESSAGE);
     } finally {
-      setSaving(false);
+      if (mountedRef.current && generation === saveGenerationRef.current) {
+        saveInFlightRef.current = false;
+        setSaving(false);
+      }
     }
   };
+
+  const label = "Use my app earnings to pay container hosting";
+  const description =
+    "When on, daily container bills are paid from your redeemable earnings first, then from credits. When off, hosting bills come purely from credits and your earnings stay untouched (cashout only).";
 
   return (
     <SettingsStack data-testid="cloud-pay-as-you-go">
       <SettingsGroup title="Pay hosting from earnings">
-        {enabled === null ? (
+        {loadFailed ? (
+          <div
+            role="alert"
+            aria-labelledby="cloud-payg-load-error-title"
+            aria-describedby="cloud-payg-load-error-description"
+            className="rounded-sm border border-danger/30 bg-danger/10 px-3"
+          >
+            <SettingsRow
+              icon={Coins}
+              iconClassName="text-danger"
+              label={
+                <span id="cloud-payg-load-error-title">
+                  Couldn't load this billing setting
+                </span>
+              }
+              description={
+                <span id="cloud-payg-load-error-description">
+                  {LOAD_ERROR_MESSAGE}
+                </span>
+              }
+              control={
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="min-h-touch"
+                  disabled={loading}
+                  aria-busy={loading}
+                  onClick={() => void load()}
+                >
+                  {loading ? (
+                    <Loader2
+                      className="animate-spin motion-reduce:animate-none"
+                      aria-hidden="true"
+                    />
+                  ) : (
+                    <RefreshCw aria-hidden="true" />
+                  )}
+                  Retry
+                </Button>
+              }
+            />
+          </div>
+        ) : loading || enabled === null ? (
           <SettingsRow
             icon={Coins}
-            label="Use my app earnings to pay container hosting"
-            description="When on, daily container bills are paid from your redeemable earnings first, then from credits. When off, hosting bills come purely from credits and your earnings stay untouched (cashout only)."
+            label={label}
+            description={description}
             control={
-              <Loader2 className="h-5 w-5 shrink-0 animate-spin text-muted" />
+              <span
+                className="flex min-h-11 min-w-11 items-center justify-center"
+                role="status"
+                aria-busy="true"
+                aria-label="Loading pay-as-you-go setting"
+              >
+                <Loader2
+                  className="h-5 w-5 shrink-0 animate-spin text-muted motion-reduce:animate-none"
+                  aria-hidden="true"
+                />
+              </span>
             }
           />
         ) : (
@@ -80,8 +206,8 @@ export function PayAsYouGoCard() {
             agentId="cloud-billing-pay-as-you-go"
             group="cloud-billing"
             icon={Coins}
-            label="Use my app earnings to pay container hosting"
-            description="When on, daily container bills are paid from your redeemable earnings first, then from credits. When off, hosting bills come purely from credits and your earnings stay untouched (cashout only)."
+            label={label}
+            description={description}
             checked={enabled}
             disabled={saving}
             onCheckedChange={(next) => void handleToggle(next)}


### PR DESCRIPTION
# Relates to

Fixes #20120.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c7a1d61345d3a24a34589dd0f62ffd0f628d0715:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The change is isolated to the pay-as-you-go settings card and its jsdom
tests. A malformed or failed GET now fails closed instead of inventing a switch
value. Async generations fence late load/save results, and a synchronous save
lock prevents duplicate PUTs before React commits the busy state. No billing
API, payment provider, subscription, staging, or production path changes.

# Background

## What does this PR do?

- Replaces the permanent spinner after a billing-settings load failure with a
  named `role="alert"` and a 44px Retry control.
- Keeps the alert visible while a retry is busy, disables duplicate retries,
  and never renders a switch until the API returns an actual boolean.
- Preserves both backend `true` and `false`, ignores stale/unmounted load
  results, and rolls a failed optimistic save back to the confirmed value.
- Acquires the save guard synchronously so two switch callbacks in one React
  turn cannot issue conflicting PUTs.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

My changes do not require a project-documentation change; this corrects an
existing settings interaction without changing the API or user-facing policy.

# Testing

## Where should a reviewer start?

Start with
`packages/ui/src/cloud/billing/components/pay-as-you-go-card.test.tsx`, then
review the state boundary in
`packages/ui/src/cloud/billing/components/pay-as-you-go-card.tsx`.

## Detailed testing steps

- `bun run --cwd packages/ui test -- src/cloud/billing/components/pay-as-you-go-card.test.tsx`
  — 10/10 tests pass.
- `bun run --cwd packages/ui test -- src/cloud/billing`
  — 40/40 billing UI tests pass across six files.
- `bun run --cwd packages/ui typecheck` — passes.
- `bunx @biomejs/biome check packages/ui/src/cloud/billing/components/pay-as-you-go-card.tsx packages/ui/src/cloud/billing/components/pay-as-you-go-card.test.tsx`
  — passes.
- `bun run audit:ui-determinism` — passes.
- `git diff --check` — passes.
- `bun run evidence:doctor` — required OCR, FFmpeg/FFprobe, and Playwright
  Chromium dependencies are available.
- Exact-head renderer build — passes; 9,752 modules and 1,322 assets, with
  `playwrightTestAuth: true` recorded in the renderer manifest.
- Bounded real-route Chromium evidence harness — 2/2 passes (desktop and
  mobile), covering load error → Retry → backend `false`; harness removed.
- Packaged OCR review — passes; both composites are nonblank and contain the
  expected failure/recovery copy.
- Focused accessibility assertions cover the live alert, named keyboard-native
  Retry button, busy/disabled duplicate suppression, hidden switch on failure,
  and the repository's 44px touch-target token.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:43b25201be3e807ce2e80a50638e19586874445d -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20139-before-error-desktop-mobile-clean.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20139-after-recovered-false-desktop-mobile-clean.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20139-payg-error-retry-desktop-mobile-clean.mp4
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - this two-file client-state change does not alter or
  exercise a server, payment-provider, database, or deployment path.
<!-- evidence-row:frontend-logs -->
- [x] [20139-frontend-log-clean.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20139-frontend-log-clean.json)
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model
  behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no database rows, payments, wallets, domains,
  generated files, or other domain state changes.
<!-- evidence-row:ocr-review -->
- [x] [20139-ocr-review-clean.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20139-ocr-review-clean.json)

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model changes.

## Backend + frontend logs

- Backend: N/A - no backend path changed or fired for this client-only patch.
- Frontend: the bounded real-route Playwright harness passed 2/2 on Chromium
  (desktop 1440×900 and mobile 390×844). It recorded the initial 503, the shared
  settings GET, the Retry GET, and the asserted error/hidden-switch/recovered-
  false transitions. The shared success fixture supplies valid `payAsYouGo`,
  `autoTopUp`, and `limits` fields; both runs recorded zero `pageerror`, zero
  request failure, and zero unexpected `console.error`. The only allowed browser
  error is the deliberately injected 503 itself. The harness was evidence-only
  and was removed before upload.

## Screenshots (before / after) + video walkthrough

The stable rows above contain real full-page desktop/mobile failure and recovery
frames plus a GitHub-renderable H.264 walkthrough of the same bounded flow.
Packaged Tesseract independently found the failure title, Retry, and recovered
setting label, with nonblank frames and mean confidence 0.76/0.80.

The renderer manifest and both frontend receipts name the exact live PR head
`43b25201be3e807ce2e80a50638e19586874445d` (build ID
`3171eaf5e6a3218f56cbe71a79fc74ee2dfbb2bea68936336efb891ad45ebfff`).
The repository evidence-head marker is set to that same commit.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changes.

## Known gaps / failures

- `bun run verify` was not run end to end. The focused billing suites, UI
  typecheck, targeted Biome, determinism audit, and diff check all pass on the
  exact PR head.
- Running the billing suite under the host's unsupported Node 25.5.0 surfaces a
  dependency `punycode` deprecation as unexpected console output in the unchanged
  wallet test. On the repository-pinned Node 24.15.0, all 40/40 billing tests
  pass; all final receipts below use that pinned runtime.
- `bun run audit:test-integrity:no-vi-mocks` reports the repository-wide known
  baseline (21,408 matches); its script explicitly documents that the lint is
  expected to fail the whole repository today. This patch adds no production
  mock and uses the existing Vitest mock convention in the component test.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@c7a1d61345d3a24a34589dd0f62ffd0f628d0715:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-billing-payg-load-error]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@c7a1d61345d3a24a34589dd0f62ffd0f628d0715:packages/skills/skills/contribute-to-eliza"} -->

