### PR TITLE
fix(cloud): reject invalid admin container-list limits

### DIFF
--- a/packages/cloud/api/v1/admin/infrastructure/containers/route.test.ts
+++ b/packages/cloud/api/v1/admin/infrastructure/containers/route.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Validates the admin infrastructure container-list query boundary without a database harness.
+ */
+import { describe, expect, test } from "bun:test";
+import { parseContainerListLimit } from "./route";
+
+describe("parseContainerListLimit", () => {
+  test("defaults malformed and non-positive limits instead of forwarding invalid SQL limits", () => {
+    expect(parseContainerListLimit("-1")).toBe(500);
+    expect(parseContainerListLimit("25rows")).toBe(500);
+    expect(parseContainerListLimit("0")).toBe(500);
+  });
+
+  test("preserves valid limits and caps oversized values", () => {
+    expect(parseContainerListLimit("25")).toBe(25);
+    expect(parseContainerListLimit(" 25 ")).toBe(25);
+    expect(parseContainerListLimit("5000")).toBe(2000);
+  });
+});

--- a/packages/cloud/api/v1/admin/infrastructure/containers/route.ts
+++ b/packages/cloud/api/v1/admin/infrastructure/containers/route.ts
@@ -18,11 +18,20 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
+export function parseContainerListLimit(value: string | undefined): number {
+  const normalized = value?.trim();
+  if (!normalized || !/^\d+$/.test(normalized)) return 500;
+
+  const parsed = Number(normalized);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) return 500;
+  return Math.min(parsed, 2000);
+}
+
 app.get("/", async (c) => {
   try {
     await requireAdmin(c);
 
-    const limit = Math.min(parseInt(c.req.query("limit") || "500", 10), 2000);
+    const limit = parseContainerListLimit(c.req.query("limit"));
 
     const rows = await containersRepository.listForAdminInfrastructure(limit);
 


### PR DESCRIPTION
# Relates to

Closes #20140.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] this PR targets `develop` and is branched directly off the current `origin/develop` tip.
- [x] focused package tests and lint pass on the exact head, see Testing below.
- [x] a reviewer can confirm the fix directly against the deterministic unit test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (fix, tests, via AgentRouter proxy), `anthropic/claude-sonnet-5` (independent re-verification)
<!-- attribution-row:client -->
- Agent tooling: `codex` (via AgentRouter proxy), `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] branched directly off the current `origin/develop` tip

# Risks

low. this only tightens `limit` query-param parsing on one admin route; every existing valid limit (digits, 1–2000) behaves identically, and the same `2000` cap is preserved.

# Background

## What does this PR do?

`GET /api/v1/admin/infrastructure/containers` parsed `limit` with `Math.min(parseInt(c.req.query("limit") || "500", 10), 2000)` and forwarded it straight to `containersRepository.listForAdminInfrastructure(limit)`, whose query calls `.limit(limit)` — a real drizzle-orm/SQL `LIMIT` clause. Postgres rejects a negative `LIMIT` at the database level, so `?limit=-1` turns a normal admin list request into an unhandled query failure instead of a bounded page or a clean validation error. The same `parseInt` call also silently accepted a malformed value like `"25rows"` (parses to `25`).

traced reachability before writing this up: confirmed via `packages/cloud/api/src/_router.generated.ts` that this route is mounted at `/api/v1/admin/infrastructure/containers` in the real generated Cloud API router, gated by `requireAdmin` — a live, authenticated admin boundary, not test-only code.

fix: extracted `parseContainerListLimit`, requiring a complete decimal-digit string (rejects `-1`, `25rows`, empty) and a safe integer `>= 1`, defaulting malformed/non-positive values to `500` and capping valid values at `2000` — the same bound as before, just validated before it reaches the query.

## What kind of change is this?

bug fix, non-breaking (every existing valid `limit` — digits within `1–2000` — behaves identically; the default and cap values are unchanged).

# Documentation changes needed?

no, the fix restores a bounded, always-valid `limit` reaching the query, not a new interface.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/admin/infrastructure/containers/route.test.ts` (new file), testing the exported `parseContainerListLimit` helper directly — no database harness needed since the boundary logic is isolated from the route handler.

## Detailed testing steps

```text
$ bun test v1/admin/infrastructure/containers/route.test.ts
2 pass
0 fail
6 expect() calls

$ bunx @biomejs/biome check v1/admin/infrastructure/containers/route.ts v1/admin/infrastructure/containers/route.test.ts
Checked 2 files in 48ms. No fixes applied.
```

mutation-resistance verified independently: restored the function's old body (`Math.min(parseInt(value || "500", 10), 2000)`) in place, kept the new test — 1/2 failed with `Expected: 500, Received: -1`, exactly the boundary the fix closes. Restored the real fix, 2/2 green again.

# Evidence Gate

<!-- evidence-head:c5deb331a4cfeff3d2f7480c39ef6300739d45ea -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes a query-param validation helper, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - this changes a query-param validation helper, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive product flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic unit test, the real transcript is included under domain artifacts.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code or network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real mutation-resistance run, captured directly:
  ```text
  red (old body restored in place, test kept):
  $ bun test v1/admin/infrastructure/containers/route.test.ts
  expect(received).toBe(expected)
  Expected: 500
  Received: -1
  1 pass | 1 fail

  green (real fix restored):
  $ bun test v1/admin/infrastructure/containers/route.test.ts
  2 pass | 0 fail
  ```
  also independently confirmed `Math.min(parseInt("-1", 10), 2000)` really is `-1` and `Math.min(parseInt("25rows", 10), 2000)` really is `25` in a real bun REPL, confirmed `.limit(limit)` in `containers.ts`'s `listForAdminInfrastructure` really is a raw drizzle-orm SQL `LIMIT`, and traced the route's real mount point in the generated router before writing up the reachability claim.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface or visual text changed.

## Known gaps / failures

the package's `typecheck` script fails on `check:worker-bundle`, but independently confirmed this is pre-existing and unrelated: the errors are missing exports (`computeNextCronRunAtMs`, `stableStringify`, `searchKeylessWeb`) from a stale `packages/core/dist/edge/index.edge.js` build artifact, surfaced through `plugin-scheduling` and `plugin-web-search` imports — neither package touched by this PR. Focused test and lint on the touched files are both clean.

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the focused test and lint myself, confirmed the parseInt leniency and the real SQL LIMIT sink directly, traced the route's real mount point, independently confirmed the worker-bundle typecheck failure is pre-existing and unrelated, did my own precise revert-just-the-body mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Contribution skill revision: N/A - direct interactive session, contribute-to-eliza skill not used
Compute receipt: N/A - Slop run-receipt install currently blocked by an unrelated site-deploy-lag issue (deployed skill archive predates recent develop changes)
Attribution status: self-reported
