### PR TITLE
fix(core): media-generation asks get a deterministic candidate so capability self-belief stays consistent

### DIFF
--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -1361,4 +1361,44 @@ describe("batch-1 matrix fixes: budget noun + scheduled-item admin (F3/F5)", () 
 			).kind,
 		).not.toBe("owner-work-thread");
 	});
+	it("media-generation asks hint the generator (F35, tj-fcf8c1c21be91f)", () => {
+		const generateMedia = { name: "GENERATE_MEDIA", similes: [], tags: [] };
+		const appAction = {
+			name: "APP",
+			similes: ["LAUNCH_APP"],
+			tags: ["app", "apps"],
+		};
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, appAction, generateMedia],
+				"make me a pixel-art castle image, 64x64 retro game vibe",
+			),
+		).toEqual({ names: ["GENERATE_MEDIA"], kind: "media-generation" });
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, appAction, generateMedia],
+				"generate a picture of a lighthouse at dusk",
+			),
+		).toEqual({ names: ["GENERATE_MEDIA"], kind: "media-generation" });
+		// No generator registered: no candidate, honest chat answer allowed.
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, appAction],
+				"generate a picture of a lighthouse at dusk",
+			),
+		).toEqual({ names: [], kind: null });
+		// Generation verbs without a visual-artifact noun never match.
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, appAction, generateMedia],
+				"create a todo: buy sandpaper",
+			).kind,
+		).not.toBe("media-generation");
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction, appAction, generateMedia],
+				"draw up a plan for the garage",
+			).kind,
+		).not.toBe("media-generation");
+	});
 });

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -388,6 +388,7 @@ export type DirectCurrentRequestCandidateKind =
 	| "owner-reads"
 	| "owner-scheduled-admin"
 	| "owner-work-thread"
+	| "media-generation"
 	| "view-surface"
 	| "view-navigation"
 	| "view-capability"
@@ -672,6 +673,39 @@ function findScheduledAdminActionName(
 	actions: ReadonlyArray<Pick<Action, "name" | "similes">>,
 ): string | undefined {
 	return findAvailableActionName(actions, SCHEDULED_ADMIN_ACTION_NAMES);
+}
+
+const MEDIA_GENERATION_ACTION_NAMES = [
+	"GENERATE_MEDIA",
+	"GENERATE_IMAGE",
+	"CREATE_IMAGE",
+] as const;
+
+/**
+ * Detects an explicit media-generation ask ("make me a pixel-art castle
+ * image", "generate a picture of a lighthouse"). Live regression (matrix
+ * F35, tj-fcf8c1c21be91f): Stage-1 classified a styled image ask as
+ * ["simple"] with no candidates, the planner ran with HANDLE_RESPONSE only,
+ * and the model declared "I don't have an image generator" — an hour after
+ * the same runtime generated and delivered one. Capability self-belief
+ * follows tool exposure, so the deterministic candidate is what keeps the
+ * answer consistent. Generation verbs must pair with a visual-artifact noun:
+ * "create a todo" and "draw up a plan" never match.
+ */
+function looksLikeMediaGenerationRequest(text: string): boolean {
+	const normalized = text.toLowerCase().replace(/\s+/gu, " ").trim();
+	if (!normalized || looksLikeActionExplanationRequest(normalized)) {
+		return false;
+	}
+	return /\b(?:generate|make|draw|create|render|paint|produce)\b[^.!?]{0,60}\b(?:image|picture|photo|art(?:work)?|illustration|logo|sticker|wallpaper|drawing|painting|meme|gif)s?\b/iu.test(
+		normalized,
+	);
+}
+
+function findMediaGenerationActionName(
+	actions: ReadonlyArray<Pick<Action, "name" | "similes">>,
+): string | undefined {
+	return findAvailableActionName(actions, MEDIA_GENERATION_ACTION_NAMES);
 }
 
 const WORK_THREAD_ACTION_NAMES = [
@@ -1021,6 +1055,18 @@ export function inferDirectCurrentRequestCandidateInference(
 		const workThreadAction = findWorkThreadActionName(actions);
 		if (workThreadAction) {
 			return { names: [workThreadAction], kind: "owner-work-thread" };
+		}
+		return EMPTY_DIRECT_CANDIDATE_INFERENCE;
+	}
+	// Media-generation asks: capability self-belief follows tool exposure, so
+	// a Stage-1 drift that leaves the turn tool-less makes the model deny a
+	// capability it demonstrably has (matrix F35). Unlike the owner legs, a
+	// missing surface yields no candidate AND no forced escalation — an agent
+	// genuinely without a generator should answer honestly from chat.
+	if (looksLikeMediaGenerationRequest(messageText)) {
+		const mediaAction = findMediaGenerationActionName(actions);
+		if (mediaAction) {
+			return { names: [mediaAction], kind: "media-generation" };
 		}
 		return EMPTY_DIRECT_CANDIDATE_INFERENCE;
 	}


### PR DESCRIPTION
## Problem

Live finding (F35, nubilio matrix batch 2): "make me a pixel-art castle image, 64x64 retro game vibe" → "I don't have an image generator" — one hour after the same runtime generated and delivered a real 850KB lighthouse JPEG. Watchtower's read: capability self-belief flip-flop.

Ground truth (tj-fcf8c1c21be91f, tj-fb97147009d634): the third confirmed leg of the Stage-1 classification-drift family — the ask classified as `contexts: ["simple"]` with **no candidateActions**, the planner ran with `HANDLE_RESPONSE` only, no media tool was exposed, and the model truthfully-from-its-view denied the capability. The "flip-flop" is exposure flip-flop: the earlier successful turn had GENERATE_MEDIA exposed; this one did not.

## Fix

A media-generation leg in `direct-action-heuristics.ts`, following the merged F31 (#20117) and F27 (#20135) pattern: generation verbs (generate/make/draw/create/render/paint/produce) paired with a visual-artifact noun (image/picture/photo/art/illustration/logo/sticker/wallpaper/drawing/painting/meme/gif) yield the registered generator (`GENERATE_MEDIA` → simile fallbacks) as a deterministic candidate under a new `media-generation` kind. The noun requirement keeps "create a todo" and "draw up a plan" untouched, and with no generator registered the turn yields no candidate — an agent genuinely lacking one still answers honestly from chat (no forced escalation).

## Evidence

| Row | Result |
| --- | --- |
| Unit tests | `direct-action-heuristics.test.ts` 67/67 — new F35 block: both live phrasings, no-generator honest path, verb-without-noun negatives |
| Regression | full `services/message` dir 598/598; core `tsc --noEmit` clean; biome clean |
| Ground truth | Two denial trajectories inspected (ids above): ["simple"], zero candidates, one exposed tool |
| Live re-prove | Queued with the fleet's live driver: styled image ask re-run (matrix batch 3) |

Family status: F31 (#20117) + F27 (#20135) + F35 (this PR) — three legs of the same drift, one structural pattern. HQ receipt thread: #18309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
