### PR TITLE
fix(cloud-api): admin container-list strict limit parsing

### DIFF
--- a/packages/cloud/api/__tests__/admin-infrastructure-containers-limit.test.ts
+++ b/packages/cloud/api/__tests__/admin-infrastructure-containers-limit.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Exercises the admin infrastructure containers route trust boundary: strict
+ * positive-integer limit parsing before the list query, so a client-supplied
+ * negative or malformed value can never become a rejected SQL `LIMIT` clause.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const listForAdminInfrastructure = mock(async () => []);
+const requireAdmin = mock(async () => ({
+  id: "00000000-0000-4000-8000-000000000001",
+  organization_id: "00000000-0000-4000-8000-000000000002",
+  role: "super_admin",
+}));
+
+mock.module("@/db/repositories/containers", () => ({
+  containersRepository: { listForAdminInfrastructure },
+}));
+mock.module("@/lib/auth/workers-hono-auth", () => ({ requireAdmin }));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock(() => undefined) },
+}));
+
+const route = (await import("../v1/admin/infrastructure/containers/route"))
+  .default;
+const app = new Hono().route("/api/v1/admin/infrastructure/containers", route);
+
+function listContainers(query = "") {
+  return app.request(`/api/v1/admin/infrastructure/containers${query}`);
+}
+
+describe("GET /api/v1/admin/infrastructure/containers limit parsing", () => {
+  beforeEach(() => {
+    requireAdmin.mockClear();
+    listForAdminInfrastructure.mockClear();
+    listForAdminInfrastructure.mockResolvedValue([]);
+  });
+
+  test("defaults to 500 when limit is absent", async () => {
+    const response = await listContainers();
+    expect(response.status).toBe(200);
+    expect(listForAdminInfrastructure).toHaveBeenCalledWith(500);
+  });
+
+  test.each([1, 500, 2000])(
+    "passes a valid positive integer of %i through the cap",
+    async (limit) => {
+      const response = await listContainers(`?limit=${limit}`);
+      expect(response.status).toBe(200);
+      expect(listForAdminInfrastructure).toHaveBeenCalledWith(limit);
+    },
+  );
+
+  test("caps a valid positive integer above 2000 at 2000", async () => {
+    const response = await listContainers("?limit=5000");
+    expect(response.status).toBe(200);
+    expect(listForAdminInfrastructure).toHaveBeenCalledWith(2000);
+  });
+
+  test.each([
+    ["empty", ""],
+    ["negative", "-1"],
+    ["zero", "0"],
+    ["malformed prefix", "25rows"],
+    ["fractional", "1.5"],
+    ["exponent form", "2e3"],
+    ["non-finite", "Infinity"],
+    ["unsafe integer", "9007199254740992"],
+  ])(
+    "defaults %s limits to 500 without failing the query",
+    async (_name, limit) => {
+      const response = await listContainers(
+        `?limit=${encodeURIComponent(limit)}`,
+      );
+      expect(response.status).toBe(200);
+      expect(listForAdminInfrastructure).toHaveBeenCalledWith(500);
+    },
+  );
+});

--- a/packages/cloud/api/v1/admin/infrastructure/containers/route.ts
+++ b/packages/cloud/api/v1/admin/infrastructure/containers/route.ts
@@ -9,6 +9,7 @@
  * Requires admin role.
  */
 
+import { parsePositiveInteger } from "@elizaos/shared/utils/number-parsing";
 import { Hono } from "hono";
 import { containersRepository } from "@/db/repositories/containers";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
@@ -22,7 +23,10 @@ app.get("/", async (c) => {
   try {
     await requireAdmin(c);
 
-    const limit = Math.min(parseInt(c.req.query("limit") || "500", 10), 2000);
+    const limit = Math.min(
+      parsePositiveInteger(c.req.query("limit"), 500),
+      2000,
+    );
 
     const rows = await containersRepository.listForAdminInfrastructure(limit);
 


### PR DESCRIPTION
## Summary

Fixes #20140 — Admin container-list endpoint 500s on a negative limit query param.

## Changes

- `packages/cloud/api/v1/admin/infrastructure/containers/route.ts`: Replace raw `parseInt` + `Math.min` with `parsePositiveInteger` from `@elizaos/shared/utils/number-parsing`
- `packages/cloud/api/__tests__/admin-infrastructure-containers-limit.test.ts`: New focused unit test (13 cases)

## Validation behavior

| Input | Before | After |
|-------|--------|-------|
| absent | 500 | 500 |
| `500` | 500 | 500 |
| `2000` | 2000 | 2000 |
| `5000` | 2000 (cap) | 2000 (cap) |
| `-1` | **500 → Postgres error** | 500 (rejected → fallback) |
| `0` | **0 → Postgres error** | 500 (rejected → fallback) |
| `25rows` | 25 (silent truncate) | 500 (rejected → fallback) |
| `1.5` | 1 (silent floor) | 500 (rejected → fallback) |
| `2e3` | 2000 | 500 (rejected → fallback) |
| `Infinity` | `Infinity` → Postgres error | 500 (rejected → fallback) |
| `9007199254740992` (unsafe) | unsafe int | 500 (rejected → fallback) |

All malformed/non-positive values now default to `500` before reaching the DB layer. Valid positive integers pass through the existing `2000` cap.

## Checks

- `bun test` — 13/13 pass
- `biome check` — clean
- `typecheck` — only pre-existing unrelated error in `staging-session-exchange.test.ts` (missing `jose` module)

## Evidence

node scripts/pr-evidence.mjs rows 20146 \
  --row "backend-logs=N/A - deterministic unit tests; test output shown in PR checks" \
  --row "before-screenshots=N/A - no UI change; pure validation/boundary fix" \
  --row "after-screenshots=N/A - no UI change; pure validation/boundary fix" \
  --row "walkthrough-video=N/A - no UI change; pure validation/boundary fix" \
  --row "frontend-logs=N/A - no UI change; pure validation/boundary fix" \
  --row "llm-trajectory=N/A - deterministic unit tests; no LLM execution" \
  --row "domain-artifacts=N/A - pure validation fix; no domain artifacts"

---

## Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `z.ai/glm-5.2`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@b1145f8e8ad375401374b1e0b1d7250ed55b066c:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- evidence-head:71748b16887055a26c647cb5d8d84416415a1951 -->

<!-- evidence-row:backend-logs -->
- [x] [20146-pr20146-backend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20146-pr20146-backend-logs.txt)

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend admin query validation with no rendered frontend surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend admin query validation with no rendered frontend surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no frontend flow; the real Hono route is exercised by deterministic tests

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend or browser network path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, action, or evaluator behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure query validation with no durable artifact production

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed
