### PR TITLE
feat(registry): add plugin-x402-finance

### DIFF
--- a/packages/registry/entries/third-party/plugin-x402-finance.json
+++ b/packages/registry/entries/third-party/plugin-x402-finance.json
@@ -1,0 +1,9 @@
+{
+  "package": "plugin-x402-finance",
+  "repository": "github:lokixc84/x402-finance-api",
+  "kind": "plugin",
+  "description": "Base token safety (honeypot, tax, liquidity) via x402 Finance — $0.04 USDC per call, no API key",
+  "homepage": "https://github.com/lokixc84/x402-finance-api/tree/main/plugin-x402-finance",
+  "version": "1.0.0",
+  "tags": ["x402", "token-safety", "honeypot", "base", "defi", "payments"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -2129,6 +2129,52 @@
       "kind": "plugin",
       "registryKind": "plugin",
       "directory": null
+    },
+    "plugin-x402-finance": {
+      "git": {
+        "repo": "lokixc84/x402-finance-api",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "plugin-x402-finance",
+        "v0": null,
+        "v1": null,
+        "v2": "1.0.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Base token safety (honeypot, tax, liquidity) via x402 Finance — $0.04 USDC per call, no API key",
+      "homepage": "https://github.com/lokixc84/x402-finance-api/tree/main/plugin-x402-finance",
+      "topics": [
+        "x402",
+        "token-safety",
+        "honeypot",
+        "base",
+        "defi",
+        "payments"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
     }
   }
 }


### PR DESCRIPTION
Adds plugin-x402-finance to the third-party registry.

- Package: plugin-x402-finance (npm)
- Base token safety via x402 micropayments ($0.04 USDC)
- Repo: https://github.com/lokixc84/x402-finance-api/tree/main/plugin-x402-finance