### PR TITLE
fix(personal-assistant): harden undated Todo intent

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/lib/extract-life-operation.ts
+++ b/plugins/plugin-personal-assistant/src/actions/lib/extract-life-operation.ts
@@ -13,6 +13,7 @@ import {
 } from "@elizaos/core";
 import { getRecentMessagesData } from "@elizaos/shared";
 import { resolveContextWindow } from "../../lifeops/defaults.js";
+import { UNDATED_TODO_EXTRACTION_GUIDANCE } from "./undated-todo-intent.js";
 
 export const LIFE_OPERATION_VALUES = [
   "create",
@@ -177,6 +178,11 @@ const REPLY_ONLY_OPERATION_PLAN: ExtractedLifeOperationPlan = {
   shouldAct: false,
 };
 
+const UNDATED_TODO_OPERATION_GUIDANCE = [
+  UNDATED_TODO_EXTRACTION_GUIDANCE,
+  'When that explicit undated-Todo authority applies, use operation="create", set shouldAct=true, and do not list "schedule" as missing.',
+].join("\n");
+
 function promptText(value: string): string {
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : "(empty)";
@@ -222,6 +228,8 @@ function buildRepairPrompt(args: {
     "  missing: list of missing fields from title, schedule, target, goal, phone_number, reminder_intensity, details",
     "",
     "Do not add prose, markdown, code fences, or any other format.",
+    "",
+    UNDATED_TODO_OPERATION_GUIDANCE,
     "",
     `Allowed operations: ${LIFE_OPERATION_VALUES.join(", ")}, or null`,
     `Current request: ${promptText(args.currentMessage)}`,
@@ -284,6 +292,7 @@ async function recoverCoreLifeOperationWithLlm(args: {
     "snooze is for deferring or postponing something to later.",
     "query_overview is for asking what is still left, active, or remaining today.",
     "Use null only when the request is casual chat or not a core LifeOps action.",
+    UNDATED_TODO_OPERATION_GUIDANCE,
     "",
     "Return ONLY a JSON object with exactly these fields:",
     "  operation: create, complete, snooze, query_overview, or null",
@@ -345,6 +354,7 @@ export async function extractLifeOperationWithLlm(args: {
     "Requests with concrete routine content and interpretable cadence are actionable even when some fields are implied.",
     "Treat requests like weekdays after lunch, during the day, every morning, tomorrow at 9, set an alarm for 7 am, and remind me about my Invisalign as specific enough to act on now.",
     "A deadline phrase on a reminder — 'by the 20th', 'before Friday', 'due on the 28th' — IS a schedule: never list schedule as missing for it. Default the nudge to a day or two before the deadline (or the morning it is due) rather than asking the owner for an exact time.",
+    UNDATED_TODO_OPERATION_GUIDANCE,
     "A goal horizon like this year, this month, by June, or before my trip does not create a routine cadence by itself.",
     "Use create with a goal-flavored intent for aspirations with a target or horizon unless the user explicitly asks for reminders, recurrence, or a routine schedule.",
     "",

--- a/plugins/plugin-personal-assistant/src/actions/lib/extract-task-plan.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/lib/extract-task-plan.test.ts
@@ -11,7 +11,11 @@
 
 import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
-import { extractTaskCreatePlanWithLlm } from "./extract-task-plan.js";
+import {
+  extractTaskCreatePlanWithLlm,
+  textExplicitlyLeavesScheduleUnspecified,
+  textStatesExplicitSchedule,
+} from "./extract-task-plan.js";
 
 function makeRuntime(respond: (prompt: string) => string): IAgentRuntime {
   return {
@@ -48,6 +52,49 @@ const BASE_PLAN_JSON = {
   dueWeekday: null,
   dueInMinutes: null,
 };
+
+describe("textExplicitlyLeavesScheduleUnspecified", () => {
+  it.each([
+    "Remind me to call Mom, but I have not said when.",
+    "Remind me to call Mom. I haven't specified the time yet.",
+    "Create the reminder without saying when.",
+    "No date or time specified yet for this reminder.",
+    "Don't guess a schedule. Ask me when.",
+  ])("keeps an explicitly withheld schedule unresolved: %s", (text) => {
+    expect(textExplicitlyLeavesScheduleUnspecified(text)).toBe(true);
+  });
+
+  it.each([
+    "Remind me to call Mom tomorrow at 9.",
+    "I hadn't said when before, but use Friday at noon.",
+    "Don't guess a time; use next Monday.",
+    "No time was specified in the draft. Make it every morning instead.",
+    "Remind me to renew the registration by the 20th.",
+  ])(
+    "lets a later concrete schedule override earlier uncertainty: %s",
+    (text) => {
+      expect(textExplicitlyLeavesScheduleUnspecified(text)).toBe(false);
+    },
+  );
+});
+
+describe("textStatesExplicitSchedule", () => {
+  it.each([
+    "Use Friday.",
+    "Make it tomorrow at 9.",
+    "Use the 20th.",
+    "Set it every morning.",
+  ])("recognizes current-turn schedule authority: %s", (text) => {
+    expect(textStatesExplicitSchedule(text)).toBe(true);
+  });
+
+  it.each(["Yes, save it now.", "Confirm that draft.", "Looks good."])(
+    "does not treat save timing as the item's schedule: %s",
+    (text) => {
+      expect(textStatesExplicitSchedule(text)).toBe(false);
+    },
+  );
+});
 
 describe("extractTaskCreatePlanWithLlm datetime fields", () => {
   it("keeps dueWeekday and timeOfDay for a weekday reminder", async () => {

--- a/plugins/plugin-personal-assistant/src/actions/lib/extract-task-plan.ts
+++ b/plugins/plugin-personal-assistant/src/actions/lib/extract-task-plan.ts
@@ -20,6 +20,10 @@ import {
   runWithTrajectoryPurpose,
 } from "@elizaos/core";
 import {
+  normalizeKeywordMatchText,
+  textStatesExplicitRecurrence,
+} from "@elizaos/shared";
+import {
   LIFEOPS_REMINDER_INTENSITIES,
   type LifeOpsReminderIntensity,
 } from "../../contracts/index.js";
@@ -29,6 +33,7 @@ import {
 } from "../../lifeops/defaults.js";
 import { normalizeExplicitTimeZoneToken } from "../../lifeops/time/timezone.js";
 import { getZonedDateParts } from "../../lifeops/time.js";
+import { UNDATED_TODO_EXTRACTION_GUIDANCE } from "./undated-todo-intent.js";
 
 // ── Types ─────────────────────────────────────────────
 
@@ -92,6 +97,47 @@ const VALID_REQUEST_KINDS = new Set(["alarm", "reminder"]);
 const VALID_CREATE_PLAN_MODES = new Set(["create", "respond"]);
 const DEFAULT_CREATE_PLAN_RESPONSE =
   "Restate the reminder in one sentence with the task and timing.";
+
+const UNSPECIFIED_SCHEDULE_DIRECTIVE_SOURCE = [
+  String.raw`\bi\s+(?:(?:have|had)\s+not|haven['’]?t|hadn['’]?t|did\s+not|didn['’]?t|still\s+(?:have|need)\s+to)\s+(?:say|said|specify|specified|give|given|decide|decided)\s+(?:when|the\s+(?:date|day|time|timing|schedule))\b`,
+  String.raw`\bwithout\s+(?:saying|specifying|giving|deciding)\s+(?:when|the\s+(?:date|day|time|timing|schedule))\b`,
+  String.raw`\bno\s+(?:date|day|time|timing|schedule)(?:\s*(?:or|and|\/)\s*(?:date|day|time|timing|schedule))*(?:\s+(?:yet|provided|specified|given|decided|set))?\b`,
+  String.raw`\b(?:the\s+)?(?:date|day|time|timing|schedule)\s+(?:is\s+)?(?:not|isn['’]?t)\s+(?:provided|specified|given|decided|set)\b`,
+  String.raw`\b(?:do\s+not|don['’]?t)\s+(?:guess|pick|infer|assume|invent|choose|make\s+up)\s+(?:a\s+|the\s+)?(?:date|day|time|timing|schedule)\b`,
+  String.raw`\bask\s+me\s+(?:when|for\s+(?:a\s+|the\s+)?(?:date|day|time|timing|schedule))\b`,
+].join("|");
+
+const EXPLICIT_ONE_SHOT_SCHEDULE_RE =
+  /\b(?:today|tomorrow|tonight|this\s+(?:morning|afternoon|evening|weekend|week|month)|next\s+(?:day|week|month|weekend|monday|tuesday|wednesday|thursday|friday|saturday|sunday)|monday|tuesday|wednesday|thursday|friday|saturday|sunday|morning|afternoon|evening|noon|midnight|january|february|march|april|may|june|july|august|september|october|november|december)\b|\b(?:at|around|by|before|after)\s+\d{1,2}(?::\d{2})?\s*(?:a\.?m\.?|p\.?m\.?)?\b|\b(?:on|by|before|after)?\s*(?:the\s+)?\d{1,2}(?:st|nd|rd|th)\b|\bin\s+\d+\s+(?:minutes?|hours?|days?|weeks?|months?)\b|\b\d{1,2}[/-]\d{1,2}(?:[/-]\d{2,4})?\b/iu;
+
+/** True when the current owner text itself supplies a schedule. */
+export function textStatesExplicitSchedule(text: string): boolean {
+  const normalized = normalizeKeywordMatchText(text);
+  return (
+    textStatesExplicitRecurrence(normalized) ||
+    EXPLICIT_ONE_SHOT_SCHEDULE_RE.test(normalized)
+  );
+}
+
+/**
+ * True when the owner explicitly says a schedule is still unknown or tells
+ * the agent not to invent one. A later concrete time directive wins, so a
+ * correction such as "I had not said when; use Friday" remains actionable.
+ */
+export function textExplicitlyLeavesScheduleUnspecified(text: string): boolean {
+  const normalized = normalizeKeywordMatchText(text);
+  const matches = [
+    ...normalized.matchAll(
+      new RegExp(UNSPECIFIED_SCHEDULE_DIRECTIVE_SOURCE, "giu"),
+    ),
+  ];
+  const directive = matches.at(-1);
+  if (!directive || directive.index === undefined) {
+    return false;
+  }
+  const suffix = normalized.slice(directive.index + directive[0].length);
+  return !textStatesExplicitSchedule(suffix);
+}
 
 const EMPTY_TASK_CREATE_PLAN: ExtractedTaskCreatePlan = {
   mode: "respond",
@@ -170,7 +216,7 @@ function buildExtractionPrompt(
     "- title: short name for the task (2-5 words)",
     "- description: brief description if the user provided context",
     '- cadenceKind: one of "unscheduled", "once", "daily", "weekly", "times_per_day", "interval"',
-    '  - "unscheduled" — ONLY when the user explicitly declines a date or schedule for this item ("no due date", "no time needed", "just a plain todo", "someday"). A merely omitted date is NOT unscheduled — keep asking via mode="respond" as before.',
+    UNDATED_TODO_EXTRACTION_GUIDANCE,
     '  - "once" — a specific dated and/or timed event that happens a single time (e.g. "april 17 at 8pm", "tomorrow at 9", "set an alarm for 7am")',
     '  - "daily" — happens every day, typically with one time or window (e.g. "every morning", "every night")',
     '  - "weekly" — happens on specific weekdays (e.g. "every Sunday", "Mon/Wed/Fri")',
@@ -178,6 +224,7 @@ function buildExtractionPrompt(
     '  - "interval" — happens every N minutes/hours (e.g. "every 2 hours")',
     '  If the request names a specific calendar date OR a specific wall-clock time without a recurrence word, pick "once".',
     '  A deadline phrase IS a dated "once" task: "by the 20th" / "before Friday" / "due on the 28th" means cadenceKind="once" with the deadline as its date (dueDate for a named date, dueWeekday for a weekday). Never use mode="respond" to ask for an exact time on a deadline ask — the owner already gave the date that matters.',
+    '  If the owner explicitly says they have not provided the date/time yet or tells you not to guess one, choose mode="respond", leave cadenceKind and every due/time field null, and ask when. Never invent a default schedule against that instruction.',
     "- windows: list of time windows like [morning, night, afternoon, evening]",
     "- weekdays: list of weekday numbers (0=Sun, 1=Mon, ..., 6=Sat) for weekly tasks",
     '- timeOfDay: specific time in HH:MM 24h format like "15:00" or "08:30" if mentioned',
@@ -370,6 +417,8 @@ function buildRepairPrompt(args: {
     'mode must be "create" or "respond".',
     "If mode is respond, include a short clarifying response.",
     "If mode is create, response must be null.",
+    "",
+    UNDATED_TODO_EXTRACTION_GUIDANCE,
     "",
     `User request: ${promptText(args.intent)}`,
     "Recent conversation:",

--- a/plugins/plugin-personal-assistant/src/actions/lib/lifeops-deferred-draft.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/lib/lifeops-deferred-draft.test.ts
@@ -121,6 +121,22 @@ describe("deferred owner-Todo routing", () => {
     ).toBe(false);
   });
 
+  it("routes an applied neutral claim only for repair, not as owner consent", async () => {
+    const input = context({
+      draft: pendingTodoDraft(),
+      replyEffectStatus: "applied",
+      text: "Maybe later.",
+    });
+
+    expect(await deferredOwnerTodoRoutingEvaluator.shouldRun(input)).toBe(true);
+    expect(
+      await deferredOwnerTodoRoutingEvaluator.evaluate(input),
+    ).toMatchObject({
+      clearReply: true,
+      addCandidateActions: ["OWNER_TODOS"],
+    });
+  });
+
   it("requires both a pending draft and the registered owner action", async () => {
     expect(await deferredOwnerTodoRoutingEvaluator.shouldRun(context())).toBe(
       false,

--- a/plugins/plugin-personal-assistant/src/actions/lib/lifeops-deferred-draft.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/lib/lifeops-deferred-draft.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Verifies that a pending owner-Todo draft cannot bypass its durable action
+ * when Stage 1 claims the save already happened.
+ */
+import type {
+  IAgentRuntime,
+  ResponseHandlerEvaluatorContext,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type DeferredLifeDefinitionDraft,
+  deferredOwnerTodoRoutingEvaluator,
+} from "./lifeops-deferred-draft.js";
+
+function pendingTodoDraft(): DeferredLifeDefinitionDraft {
+  return {
+    intent: "Add buy oat milk with no due date",
+    operation: "create_definition",
+    createdAt: Date.now(),
+    sourceMessageId: "preview-message",
+    request: {
+      cadence: { kind: "unscheduled" },
+      kind: "task",
+      metadata: { ownerSurface: "OWNER_TODOS" },
+      reminderPlan: null,
+      title: "Buy oat milk",
+    },
+  };
+}
+
+function context(
+  args: {
+    draft?: DeferredLifeDefinitionDraft;
+    replyEffectStatus?: "applied" | "non_applied";
+    actionName?: string;
+    text?: string;
+  } = {},
+): ResponseHandlerEvaluatorContext {
+  const draft = args.draft;
+  return {
+    runtime: {
+      actions: [{ name: args.actionName ?? "OWNER_TODOS" }],
+      getCache: vi.fn(async () => null),
+    } as unknown as IAgentRuntime,
+    message: {
+      content: { text: args.text ?? "Yes, save that todo." },
+      entityId: "owner-entity",
+      roomId: "owner-room",
+    },
+    state: draft
+      ? {
+          data: {
+            actionResults: [
+              {
+                success: false,
+                data: {
+                  actionName: "OWNER_TODOS",
+                  deferred: true,
+                  lifeDraft: draft,
+                  requiresConfirmation: true,
+                  saved: false,
+                },
+              },
+            ],
+          },
+        }
+      : {},
+    availableContexts: [{ id: "simple" }, { id: "tasks" }],
+    messageHandler: {
+      processMessage: "RESPOND",
+      plan: {
+        candidateActions: [],
+        contexts: ["tasks"],
+        reply: "Saved the todo.",
+        replyEffectStatus: args.replyEffectStatus ?? "applied",
+      },
+      thought: "The owner confirmed the draft.",
+    },
+  } as unknown as ResponseHandlerEvaluatorContext;
+}
+
+describe("deferred owner-Todo routing", () => {
+  it("replaces an ungrounded completion with the exact owner action", async () => {
+    const input = context({ draft: pendingTodoDraft() });
+
+    expect(await deferredOwnerTodoRoutingEvaluator.shouldRun(input)).toBe(true);
+    expect(await deferredOwnerTodoRoutingEvaluator.evaluate(input)).toEqual({
+      requiresTool: true,
+      addContexts: ["tasks"],
+      clearCandidateActions: true,
+      addCandidateActions: ["OWNER_TODOS"],
+      clearParentActionHints: true,
+      addParentActionHints: ["OWNER_TODOS"],
+      clearReply: true,
+      debug: [
+        'pending owner Todo draft "Buy oat milk" requires a durable OWNER_TODOS result before completion',
+      ],
+    });
+  });
+
+  it("routes explicit owner consent even when Stage 1 omits the completion claim", async () => {
+    expect(
+      await deferredOwnerTodoRoutingEvaluator.shouldRun(
+        context({
+          draft: pendingTodoDraft(),
+          replyEffectStatus: "non_applied",
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not intercept a non-applied neutral follow-up", async () => {
+    expect(
+      await deferredOwnerTodoRoutingEvaluator.shouldRun(
+        context({
+          draft: pendingTodoDraft(),
+          replyEffectStatus: "non_applied",
+          text: "Maybe later.",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("requires both a pending draft and the registered owner action", async () => {
+    expect(await deferredOwnerTodoRoutingEvaluator.shouldRun(context())).toBe(
+      false,
+    );
+    expect(
+      await deferredOwnerTodoRoutingEvaluator.shouldRun(
+        context({ draft: pendingTodoDraft(), actionName: "REPLY" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not reroute a reminder draft through the Todo store", async () => {
+    const reminderDraft = pendingTodoDraft();
+    reminderDraft.request.metadata = { ownerSurface: "OWNER_REMINDERS" };
+
+    expect(
+      await deferredOwnerTodoRoutingEvaluator.shouldRun(
+        context({ draft: reminderDraft }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/actions/lib/lifeops-deferred-draft.ts
+++ b/plugins/plugin-personal-assistant/src/actions/lib/lifeops-deferred-draft.ts
@@ -7,7 +7,14 @@
  * `lifeDraft`; this module owns the parsing, expiry, and reuse-mode
  * decision so the umbrella action can stay focused on dispatch.
  */
-import type { ActionResult, IAgentRuntime, Memory, State } from "@elizaos/core";
+import type {
+  ActionResult,
+  IAgentRuntime,
+  Memory,
+  ResponseHandlerEvaluator,
+  ResponseHandlerEvaluatorContext,
+  State,
+} from "@elizaos/core";
 import {
   ModelType,
   parseJsonModelRecord,
@@ -27,6 +34,33 @@ export const DRAFT_EXPIRY_MS = 5 * 60 * 1000;
 /** Maximum conversation turns before a deferred draft expires. */
 export const DRAFT_MAX_TURNS = 3;
 const DEFERRED_LIFE_DRAFT_CACHE_PREFIX = "lifeops:deferred-draft";
+
+const LIFE_CONFIRMATION_VETO_RE =
+  /\b(?:no|not|don t|do not|cancel|hold off|wait|later|change)\b/u;
+const LIFE_CONFIRMATION_CUE_RE =
+  /\b(?:ok|okay|yes|yep|yeah|sure|confirm|confirmed|approve|approved|save it|save that|save this|save the goal|set it|lock it in|do it|looks good|that works|go ahead)\b/u;
+
+/**
+ * Detects owner consent to persist a previewed LifeOps draft. Consent is
+ * sentence-scoped so an unrelated negated clause cannot veto a clear approval,
+ * while a negation in the approving sentence still fails closed.
+ */
+export function isExplicitLifeCreateConfirmation(text: string): boolean {
+  const sentences = text.split(/(?<=[.!?])\s+|\n+/u);
+  for (const sentence of sentences) {
+    const normalized = sentence
+      .toLowerCase()
+      .replace(/[^\p{L}\p{N}]+/gu, " ")
+      .trim();
+    if (!normalized || LIFE_CONFIRMATION_VETO_RE.test(normalized)) {
+      continue;
+    }
+    if (LIFE_CONFIRMATION_CUE_RE.test(normalized)) {
+      return true;
+    }
+  }
+  return false;
+}
 
 export type DeferredLifeDefinitionDraft = {
   intent: string;
@@ -77,6 +111,11 @@ export type DeferredLifeDraft =
   | DeferredLifeDefinitionDraft
   | DeferredLifeGoalDraft;
 
+export type DeferredLifeDraftCacheState =
+  | { kind: "draft"; draft: DeferredLifeDraft }
+  | { kind: "invalidated" }
+  | { kind: "none" };
+
 export type DeferredLifeDraftReuseMode = "confirm" | "edit";
 export type DeferredLifeDraftFollowupMode =
   | DeferredLifeDraftReuseMode
@@ -99,10 +138,34 @@ export async function readDeferredLifeDraftCache(
   runtime: IAgentRuntime,
   message: Memory,
 ): Promise<DeferredLifeDraft | null> {
+  const state = await readDeferredLifeDraftCacheState(runtime, message);
+  return state.kind === "draft" ? state.draft : null;
+}
+
+export async function readDeferredLifeDraftCacheState(
+  runtime: IAgentRuntime,
+  message: Memory,
+): Promise<DeferredLifeDraftCacheState> {
   const stored = await asCacheRuntime(runtime).getCache<unknown>(
     deferredLifeDraftCacheKey(runtime, message),
   );
-  return coerceDeferredLifeDraft(stored);
+  const draft = coerceDeferredLifeDraft(stored);
+  if (draft) {
+    return { kind: "draft", draft };
+  }
+  if (stored && typeof stored === "object") {
+    const record = stored as Record<string, unknown>;
+    const createdAt =
+      typeof record.createdAt === "number" ? record.createdAt : NaN;
+    if (
+      record.invalidated === true &&
+      Number.isFinite(createdAt) &&
+      Date.now() - createdAt < DRAFT_EXPIRY_MS
+    ) {
+      return { kind: "invalidated" };
+    }
+  }
+  return { kind: "none" };
 }
 
 export async function writeDeferredLifeDraftCache(
@@ -129,6 +192,22 @@ export async function clearDeferredLifeDraftCache(
 ): Promise<void> {
   await asCacheRuntime(runtime).deleteCache(
     deferredLifeDraftCacheKey(runtime, message),
+  );
+}
+
+export async function invalidateDeferredLifeDraftCache(
+  runtime: IAgentRuntime,
+  message: Memory,
+): Promise<void> {
+  await asCacheRuntime(runtime).setCache(
+    deferredLifeDraftCacheKey(runtime, message),
+    {
+      invalidated: true,
+      createdAt: Date.now(),
+      ...(message.id !== undefined && message.id !== null
+        ? { sourceMessageId: String(message.id) }
+        : {}),
+    },
   );
 }
 
@@ -417,14 +496,22 @@ export function countTurnsSinceLatestDeferredLifeDraft(
   return turns;
 }
 
-export function latestDeferredLifeDraft(
+type LatestDeferredLifeDraftState =
+  | { kind: "draft"; draft: DeferredLifeDraft }
+  | { kind: "invalidated" }
+  | { kind: "none" };
+
+function latestDeferredLifeDraftState(
   state: State | undefined,
-): DeferredLifeDraft | null {
+): LatestDeferredLifeDraftState {
   for (const result of [...stateActionResults(state)].reverse()) {
     const resultData =
       result.data && typeof result.data === "object"
         ? (result.data as Record<string, unknown>)
         : null;
+    if (resultData?.lifeDraftInvalidated === true) {
+      return { kind: "invalidated" };
+    }
     const completedCreate =
       result.success &&
       resultData &&
@@ -432,17 +519,32 @@ export function latestDeferredLifeDraft(
       ((resultData.definition && typeof resultData.definition === "object") ||
         (resultData.goal && typeof resultData.goal === "object"));
     if (completedCreate) {
-      return null;
+      return { kind: "none" };
     }
 
     const candidate = coerceDeferredLifeDraft(result.data?.lifeDraft);
     if (candidate) {
-      return candidate;
+      return { kind: "draft", draft: candidate };
     }
   }
 
   const messageDrafts = stateMessageDrafts(state);
-  return messageDrafts.at(-1) ?? null;
+  const draft = messageDrafts.at(-1);
+  return draft ? { kind: "draft", draft } : { kind: "none" };
+}
+
+export function latestDeferredLifeDraft(
+  state: State | undefined,
+): DeferredLifeDraft | null {
+  const latest = latestDeferredLifeDraftState(state);
+  return latest.kind === "draft" ? latest.draft : null;
+}
+
+/** True while the newest deferred-draft terminal marker rejects stale consent. */
+export function latestDeferredLifeDraftIsInvalidated(
+  state: State | undefined,
+): boolean {
+  return latestDeferredLifeDraftState(state).kind === "invalidated";
 }
 
 export function deferredLifeDraftExpiryReason(args: {
@@ -467,6 +569,111 @@ export function deferredLifeDraftExpiryReason(args: {
   }
   return null;
 }
+
+const OWNER_TODOS_ACTION = "OWNER_TODOS";
+
+function isDeferredOwnerTodoDraft(
+  draft: DeferredLifeDraft | null,
+): draft is DeferredLifeDefinitionDraft {
+  if (
+    draft?.operation !== "create_definition" ||
+    draft.request.kind !== "task"
+  ) {
+    return false;
+  }
+
+  const ownerSurface = draft.request.metadata?.ownerSurface;
+  return (
+    ownerSurface === OWNER_TODOS_ACTION ||
+    (ownerSurface === undefined && draft.request.cadence.kind === "unscheduled")
+  );
+}
+
+async function deferredOwnerTodoDraft(
+  context: ResponseHandlerEvaluatorContext,
+): Promise<DeferredLifeDefinitionDraft | null> {
+  const stateDraft = latestDeferredLifeDraft(context.state);
+  const draft =
+    stateDraft ??
+    (await readDeferredLifeDraftCache(context.runtime, context.message));
+  if (!isDeferredOwnerTodoDraft(draft)) {
+    return null;
+  }
+
+  const turnsSinceDraft = stateDraft
+    ? (countTurnsSinceLatestDeferredLifeDraft(context.state) ?? 0) + 1
+    : undefined;
+  return deferredLifeDraftExpiryReason({ draft, turnsSinceDraft }) === null
+    ? draft
+    : null;
+}
+
+// The runtime calls shouldRun() and evaluate() with the same context object.
+// Retaining the promise weakly avoids a second persistent-cache read on the
+// confirmation turn without extending the draft's lifetime.
+const deferredOwnerTodoDraftByContext = new WeakMap<
+  ResponseHandlerEvaluatorContext,
+  Promise<DeferredLifeDefinitionDraft | null>
+>();
+
+function routedOwnerTodoDraft(
+  context: ResponseHandlerEvaluatorContext,
+): Promise<DeferredLifeDefinitionDraft | null> {
+  const existing = deferredOwnerTodoDraftByContext.get(context);
+  if (existing) {
+    return existing;
+  }
+  const pending = deferredOwnerTodoDraft(context);
+  deferredOwnerTodoDraftByContext.set(context, pending);
+  return pending;
+}
+
+/**
+ * Keeps an acknowledged owner-Todo draft on its durable action path when the
+ * Stage-1 model omits the owning action or claims the save already completed.
+ */
+export const deferredOwnerTodoRoutingEvaluator: ResponseHandlerEvaluator = {
+  name: "lifeops.deferred-owner-todo-routing",
+  description:
+    "Routes owner consent or an applied completion claim for a pending Todo draft through OWNER_TODOS before completion text can reach the user.",
+  priority: 25,
+  async shouldRun(context) {
+    const ownerConfirmedDraft = isExplicitLifeCreateConfirmation(
+      typeof context.message.content.text === "string"
+        ? context.message.content.text
+        : "",
+    );
+    if (
+      context.messageHandler.processMessage !== "RESPOND" ||
+      (context.messageHandler.plan.replyEffectStatus !== "applied" &&
+        !ownerConfirmedDraft) ||
+      !context.runtime.actions.some(
+        (action) => action.name === OWNER_TODOS_ACTION,
+      )
+    ) {
+      return false;
+    }
+    return (await routedOwnerTodoDraft(context)) !== null;
+  },
+  async evaluate(context) {
+    const draft = await routedOwnerTodoDraft(context);
+    if (!draft) {
+      return undefined;
+    }
+    return {
+      requiresTool: true,
+      addContexts: ["tasks"],
+      clearCandidateActions: true,
+      addCandidateActions: [OWNER_TODOS_ACTION],
+      clearParentActionHints: true,
+      addParentActionHints: [OWNER_TODOS_ACTION],
+      clearReply: true,
+      debug: [
+        `pending owner Todo draft "${draft.request.title}" requires a durable OWNER_TODOS result before completion`,
+      ],
+    };
+  },
+};
 
 function formatPromptRecord(value: unknown): string {
   if (value === null || value === undefined) {

--- a/plugins/plugin-personal-assistant/src/actions/lib/undated-todo-intent.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/lib/undated-todo-intent.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Deterministic multilingual coverage for the owner-authority policy that
+ * permits unscheduled Todo writes and supplies the matching extraction prompt.
+ */
+
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { extractLifeOperationWithLlm } from "./extract-life-operation.js";
+import { extractTaskCreatePlanWithLlm } from "./extract-task-plan.js";
+import {
+  textContradictsExplicitUndatedTodo,
+  textStatesExplicitUndatedTodo,
+  UNDATED_TODO_EXTRACTION_GUIDANCE,
+} from "./undated-todo-intent.js";
+
+const EXPLICIT_UNDATED_REQUESTS = [
+  ["English no-date", "add buy milk with no due date"],
+  ["English undated", "add buy milk as an undated task"],
+  ["English someday", "add buy milk someday"],
+  ["Spanish", "añade comprar leche sin fecha"],
+  ["Portuguese", "adicionar comprar leite sem prazo"],
+  ["Chinese", "添加买牛奶，没有截止日期"],
+  ["Japanese", "牛乳を買う、期限なし"],
+  ["Korean", "우유 사기, 마감일 없이"],
+  ["Vietnamese", "thêm việc mua sữa không có ngày đến hạn"],
+  ["Tagalog", "idagdag ang bumili ng gatas, walang takdang petsa"],
+] as const;
+
+const CONTRADICTORY_REQUESTS = [
+  ["English weekday", "add buy milk with no due date, but Friday"],
+  ["English bare weekday", "add buy milk with no due date Friday"],
+  ["English next weekday", "add buy milk someday next Friday"],
+  ["Spanish weekday", "añade comprar leche sin fecha, pero el lunes"],
+  ["Spanish bare weekday", "añade comprar leche sin fecha el lunes"],
+  [
+    "Portuguese weekday",
+    "adicionar comprar leite sem prazo, mas na segunda-feira",
+  ],
+  [
+    "Portuguese bare weekday",
+    "adicionar comprar leite sem prazo na segunda-feira",
+  ],
+  ["Portuguese tomorrow", "adicionar comprar leite sem prazo, mas amanhã"],
+  ["Chinese weekday", "添加买牛奶，没有截止日期，但周一"],
+  ["Chinese bare weekday", "添加买牛奶，没有截止日期周一"],
+  ["Japanese weekday", "牛乳を買う、期限なし、でも月曜日"],
+  ["Japanese bare weekday", "牛乳を買う、期限なし月曜日"],
+  ["Korean weekday", "우유 사기, 마감일 없이, 하지만 월요일"],
+  ["Korean bare weekday", "우유 사기, 마감일 없이 월요일"],
+  [
+    "Vietnamese weekday",
+    "thêm việc mua sữa không có ngày đến hạn, nhưng thứ hai",
+  ],
+  [
+    "Vietnamese bare weekday",
+    "thêm việc mua sữa không có ngày đến hạn thứ hai",
+  ],
+  [
+    "Tagalog weekday",
+    "idagdag ang bumili ng gatas, walang takdang petsa, pero sa Lunes",
+  ],
+  [
+    "Tagalog bare weekday",
+    "idagdag ang bumili ng gatas, walang takdang petsa sa Lunes",
+  ],
+  ["relative date", "add buy milk someday in two weeks"],
+  ["recurrence", "add buy milk with no due date, every Monday"],
+] as const;
+
+const NEGATED_REQUESTS = [
+  ["English ASCII apostrophe", "don't leave buy milk with no due date"],
+  ["English curly apostrophe", "don’t leave buy milk with no due date"],
+  [
+    "English long clause",
+    "do not make the older imported backlog item with its long explanatory metadata and all of its historical labels and archival notes and inherited context a plain todo",
+  ],
+  ["Spanish", "no dejes comprar leche sin fecha"],
+  ["Portuguese", "não deixe comprar leite sem prazo"],
+  ["Chinese", "不要把买牛奶设成没有截止日期"],
+  ["Japanese", "期限なしにはしないで"],
+  ["Korean", "마감일 없이 만들지 마"],
+  ["Vietnamese", "đừng để việc mua sữa không có ngày đến hạn"],
+  ["Tagalog", "huwag gawing walang takdang petsa ang pagbili ng gatas"],
+] as const;
+
+describe("textStatesExplicitUndatedTodo", () => {
+  it.each(EXPLICIT_UNDATED_REQUESTS)(
+    "accepts explicit undated authority in %s",
+    (_caseName, text) => {
+      expect(textStatesExplicitUndatedTodo(text)).toBe(true);
+    },
+  );
+
+  it.each(CONTRADICTORY_REQUESTS)(
+    "rejects a schedule contradiction in %s",
+    (_caseName, text) => {
+      expect(textStatesExplicitUndatedTodo(text)).toBe(false);
+      expect(textContradictsExplicitUndatedTodo(text)).toBe(true);
+    },
+  );
+
+  it.each(NEGATED_REQUESTS)(
+    "rejects negated undated wording in %s",
+    (_caseName, text) => {
+      expect(textStatesExplicitUndatedTodo(text)).toBe(false);
+      expect(textContradictsExplicitUndatedTodo(text)).toBe(false);
+    },
+  );
+
+  it.each([
+    "add buy milk as a todo",
+    "add buy milk tomorrow as a todo",
+    "whenever, end of the month",
+  ])("rejects omitted no-date authority in %p", (text) => {
+    expect(textStatesExplicitUndatedTodo(text)).toBe(false);
+  });
+
+  it.each([
+    "add tomorrow's agenda with no due date",
+    "add Tomorrow, and Tomorrow, and Tomorrow to my reading list with no due date",
+    "add Weekly Review with no due date",
+    "add Daily Stoic reading with no due date",
+  ])("does not treat a temporal title noun as a schedule in %p", (text) => {
+    expect(textStatesExplicitUndatedTodo(text)).toBe(true);
+  });
+
+  it.each([
+    "Friday; actually add buy milk with no due date",
+    "add buy milk with no due date, but Friday; actually no due date",
+    "add buy milk tomorrow at 9; actually make it no due date",
+    "don't make the old item a plain todo. Add buy milk with no due date.",
+    "add buy milk with no due date; not Friday",
+    "add buy milk with no due date; call it Friday",
+    "add buy milk with no due date; call it “Friday”",
+    "add a todo with no due date; call it Weekly Review",
+  ])("honors the last authoritative directive in %p", (text) => {
+    expect(textStatesExplicitUndatedTodo(text)).toBe(true);
+  });
+
+  it("lets a final negated no-date directive revoke an earlier allowance", () => {
+    expect(
+      textStatesExplicitUndatedTodo(
+        "Add buy milk with no due date; actually don't leave it with no due date.",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("undated Todo extraction guidance", () => {
+  it("reaches the task planner primary and repair prompts", async () => {
+    const prompts: string[] = [];
+    const runtime = {
+      useModel: vi.fn(async (_modelType: unknown, args: { prompt: string }) => {
+        prompts.push(args.prompt);
+        return prompts.length === 1
+          ? "invalid"
+          : JSON.stringify({
+              cadenceKind: "unscheduled",
+              mode: "create",
+              requestKind: "todo",
+              response: null,
+              title: "Buy milk",
+            });
+      }),
+      logger: {
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+      reportError: vi.fn(),
+    } as unknown as IAgentRuntime;
+
+    const result = await extractTaskCreatePlanWithLlm({
+      runtime,
+      intent: "add buy milk with no due date",
+      state: undefined,
+      now: new Date("2026-07-01T18:00:00Z"),
+      timeZone: "America/Denver",
+    });
+
+    expect(result).toMatchObject({
+      cadenceKind: "unscheduled",
+      mode: "create",
+      title: "Buy milk",
+    });
+    expect(prompts).toHaveLength(2);
+    for (const prompt of prompts) {
+      expect(prompt).toContain(UNDATED_TODO_EXTRACTION_GUIDANCE);
+      expect(prompt.match(/"unscheduled" — ONLY/g)).toHaveLength(1);
+      expect(prompt).toContain("English: no due date / someday");
+      expect(prompt).toContain("Tagalog: walang takdang petsa");
+    }
+  });
+
+  it("reaches the operation classifier primary, repair, and recovery prompts", async () => {
+    const prompts: string[] = [];
+    const runtime = {
+      useModel: vi.fn(async (_modelType: unknown, args: { prompt: string }) => {
+        prompts.push(args.prompt);
+        return args.prompt.startsWith("Recover the core LifeOps intent")
+          ? JSON.stringify({
+              operation: "create",
+              confidence: 1,
+              shouldAct: true,
+              missing: [],
+            })
+          : "invalid";
+      }),
+      logger: {
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
+      reportError: vi.fn(),
+    } as unknown as IAgentRuntime;
+    const message = {
+      content: { text: "add buy milk with no due date" },
+    } as Memory;
+
+    const result = await extractLifeOperationWithLlm({
+      runtime,
+      message,
+      state: undefined,
+      intent: "add buy milk with no due date",
+    });
+
+    expect(result).toMatchObject({ operation: "create", shouldAct: true });
+    expect(prompts).toHaveLength(3);
+    for (const prompt of prompts) {
+      expect(prompt).toContain(UNDATED_TODO_EXTRACTION_GUIDANCE);
+    }
+  });
+});

--- a/plugins/plugin-personal-assistant/src/actions/lib/undated-todo-intent.ts
+++ b/plugins/plugin-personal-assistant/src/actions/lib/undated-todo-intent.ts
@@ -1,0 +1,426 @@
+/**
+ * Canonical owner-authority policy for creating a Todo without a schedule.
+ * Deterministic action validation and every LifeOps extraction prompt consume
+ * this ordered multilingual policy so later corrections win and model wording
+ * cannot drift from the write boundary.
+ */
+
+import {
+  normalizeKeywordMatchText,
+  textStatesExplicitRecurrence,
+  UI_LANGUAGES,
+  type UiLanguage,
+} from "@elizaos/shared";
+
+type PhraseSpec = {
+  value: string;
+  wordBounded?: boolean;
+};
+
+type TextSpan = {
+  start: number;
+  end: number;
+};
+
+type UndatedDirective = TextSpan & {
+  kind: "allow" | "deny";
+};
+
+type LocalePolicy = {
+  label: string;
+  explicitPhrases: readonly PhraseSpec[];
+  promptExample: string;
+  negationBefore: readonly RegExp[];
+  negationAfter: readonly RegExp[];
+  scheduleMarkers: readonly RegExp[];
+  negatedScheduleSpans: readonly RegExp[];
+};
+
+const LATIN_WEEKDAYS =
+  "monday|tuesday|wednesday|thursday|friday|saturday|sunday";
+const ENGLISH_TEMPORAL_NAMES = `today|tomorrow|tonight|${LATIN_WEEKDAYS}`;
+const DIRECTIVE_GAP = "[^,.!?;:。！？；，、]*";
+
+const POLICY_BY_LANGUAGE: Record<UiLanguage, LocalePolicy> = {
+  en: {
+    label: "English",
+    explicitPhrases: [
+      { value: "no due date", wordBounded: true },
+      { value: "no date", wordBounded: true },
+      { value: "without a due date", wordBounded: true },
+      { value: "without due date", wordBounded: true },
+      { value: "no schedule", wordBounded: true },
+      { value: "no scheduled time", wordBounded: true },
+      { value: "no time needed", wordBounded: true },
+      { value: "no required time", wordBounded: true },
+      { value: "plain todo", wordBounded: true },
+      { value: "plain task", wordBounded: true },
+      { value: "undated todo", wordBounded: true },
+      { value: "undated task", wordBounded: true },
+      { value: "unscheduled todo", wordBounded: true },
+      { value: "unscheduled task", wordBounded: true },
+      { value: "just a todo", wordBounded: true },
+      { value: "just a task", wordBounded: true },
+      { value: "someday", wordBounded: true },
+    ],
+    promptExample: "no due date / someday",
+    negationBefore: [
+      /\b(?:not|never)\s+(?:an?\s+)?$/u,
+      new RegExp(
+        `\\b(?:do not|don't|don’t|dont)\\s+(?:leave|make|save|add|create|keep)\\b${DIRECTIVE_GAP}$`,
+        "u",
+      ),
+    ],
+    negationAfter: [],
+    scheduleMarkers: [
+      new RegExp(
+        `\\b(?:${ENGLISH_TEMPORAL_NAMES}|next\\s+(?:day|week|month|year|${LATIN_WEEKDAYS}))\\b`,
+        "u",
+      ),
+      /\b(?:at|by|on)\s+\d{1,2}(?::\d{2})?\s*(?:a\.?m\.?|p\.?m\.?)?\b/u,
+      /\b\d{1,2}(?::\d{2})\s*(?:a\.?m\.?|p\.?m\.?)?\b/u,
+      /\b\d{1,2}\s*(?:a\.?m\.?|p\.?m\.?)\b/u,
+      /\bin\s+(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten|a|an)\s+(?:minutes?|hours?|days?|weeks?|months?|years?)\b/u,
+      /\b(?:at|by|before|after)\s+(?:the\s+)?(?:start|beginning|middle|end)\s+of\s+(?:the\s+|this\s+|next\s+)?(?:day|week|month|year)\b/u,
+      /\b(?:before|after)\s+(?:the\s+)?(?:meeting|game|work|school|lunch|dinner|appointment|trip|flight|event)\b/u,
+      new RegExp(
+        `\\b(?:a|one|two|three|four|five|six|seven|eight|nine|ten|\\d+)\\s+(?:days?|weeks?|months?|years?)\\s+from\\s+(?:today|tomorrow|${LATIN_WEEKDAYS})\\b`,
+        "u",
+      ),
+      /\b\d{4}-\d{2}-\d{2}\b/u,
+      /\b\d{1,2}[/-]\d{1,2}(?:[/-]\d{2,4})?\b/u,
+    ],
+    negatedScheduleSpans: [
+      new RegExp(
+        `\\b(?:not|never)\\s+(?:on\\s+)?(?:${ENGLISH_TEMPORAL_NAMES}|next\\s+(?:${LATIN_WEEKDAYS}|day|week|month|year))\\b`,
+        "u",
+      ),
+    ],
+  },
+  es: {
+    label: "Spanish",
+    explicitPhrases: [
+      { value: "sin fecha", wordBounded: true },
+      { value: "sin plazo", wordBounded: true },
+      { value: "sin horario", wordBounded: true },
+    ],
+    promptExample: "sin fecha",
+    negationBefore: [
+      new RegExp(
+        `\\bno\\s+(?:lo\\s+)?(?:dejes?|dejar|hagas?|hacer|crees?|crear|guardes?|guardar)\\b${DIRECTIVE_GAP}$`,
+        "u",
+      ),
+    ],
+    negationAfter: [],
+    scheduleMarkers: [
+      /\b(?:hoy|mañana|esta noche|próxim[oa]\s+(?:día|semana|mes|año)|lunes|martes|miércoles|miercoles|jueves|viernes|sábado|sabado|domingo)\b/u,
+      /\b(?:a las?|dentro de)\s+(?:\d+|un[oa]?|dos|tres|cuatro|cinco|seis|siete|ocho|nueve|diez)(?:\s+(?:minutos?|horas?|días?|semanas?|meses?|años?))?/u,
+    ],
+    negatedScheduleSpans: [
+      /\b(?:no|nunca)\s+(?:el\s+)?(?:hoy|mañana|lunes|martes|miércoles|miercoles|jueves|viernes|sábado|sabado|domingo)\b/u,
+    ],
+  },
+  pt: {
+    label: "Portuguese",
+    explicitPhrases: [
+      { value: "sem data", wordBounded: true },
+      { value: "sem prazo", wordBounded: true },
+      { value: "sem horário", wordBounded: true },
+      { value: "sem horario", wordBounded: true },
+    ],
+    promptExample: "sem prazo",
+    negationBefore: [
+      new RegExp(
+        `\\b(?:não|nao)\\s+(?:o\\s+)?(?:deixe|deixar|faça|faca|fazer|crie|criar|guarde|guardar)\\b${DIRECTIVE_GAP}$`,
+        "u",
+      ),
+    ],
+    negationAfter: [],
+    scheduleMarkers: [
+      /(?<![\p{L}\p{N}_])(?:hoje|amanhã|amanha|esta noite|próxim[oa]\s+(?:dia|semana|mês|mes|ano)|segunda-feira|terça-feira|terca-feira|quarta-feira|quinta-feira|sexta-feira|sábado|sabado|domingo)(?![\p{L}\p{N}_])/u,
+      /(?<![\p{L}\p{N}_])(?:às?|dentro de)\s+(?:\d+|um|uma|dois|duas|três|tres|quatro|cinco|seis|sete|oito|nove|dez)(?:\s+(?:minutos?|horas?|dias?|semanas?|meses?|anos?))?(?![\p{L}\p{N}_])/u,
+    ],
+    negatedScheduleSpans: [
+      /(?<![\p{L}\p{N}_])(?:não|nao|nunca)\s+(?:na?|no)?\s*(?:hoje|amanhã|amanha|segunda-feira|terça-feira|terca-feira|quarta-feira|quinta-feira|sexta-feira|sábado|sabado|domingo)(?![\p{L}\p{N}_])/u,
+    ],
+  },
+  "zh-CN": {
+    label: "Chinese",
+    explicitPhrases: [
+      { value: "没有截止日期" },
+      { value: "沒有截止日期" },
+      { value: "无截止日期" },
+      { value: "無截止日期" },
+      { value: "没有到期日" },
+      { value: "沒有到期日" },
+      { value: "没有日期" },
+      { value: "沒有日期" },
+      { value: "没有时间" },
+      { value: "沒有時間" },
+      { value: "没有日程" },
+      { value: "沒有日程" },
+    ],
+    promptExample: "没有截止日期",
+    negationBefore: [new RegExp(`(?:不要|别|別)${DIRECTIVE_GAP}$`, "u")],
+    negationAfter: [],
+    scheduleMarkers: [
+      /(?:今天|明天|今晚|周[一二三四五六日天]|星期[一二三四五六日天])/u,
+      /(?:\d{1,2}|[一二三四五六七八九十]+)(?:点|點)/u,
+      /(?:在|过|過)\s*(?:\d+|[一二三四五六七八九十]+)\s*(?:分钟|分鐘|小时|小時|天|周|週|个月|個月|年)(?:后|後)/u,
+    ],
+    negatedScheduleSpans: [
+      /(?:不是|不要|别在|別在|不在)\s*(?:今天|明天|今晚|周[一二三四五六日天]|星期[一二三四五六日天])/u,
+    ],
+  },
+  ja: {
+    label: "Japanese",
+    explicitPhrases: [
+      { value: "期限なし" },
+      { value: "期限はなし" },
+      { value: "締め切りなし" },
+      { value: "締め切りはなし" },
+      { value: "日付なし" },
+      { value: "日付はなし" },
+      { value: "予定なし" },
+      { value: "予定はなし" },
+    ],
+    promptExample: "期限なし",
+    negationBefore: [],
+    negationAfter: [/^\s*(?:には?|では?)?しないで/u],
+    scheduleMarkers: [
+      /(?:今日|明日|今夜|(?:月|火|水|木|金|土|日)曜日)/u,
+      /(?:\d{1,2}|[一二三四五六七八九十]+)時/u,
+      /(?:\d+|[一二三四五六七八九十]+)(?:分|時間|日|週間|か月|ヶ月|年)後/u,
+    ],
+    negatedScheduleSpans: [
+      /(?:(?:月|火|水|木|金|土|日)曜日|今日|明日)(?:ではない|じゃない)/u,
+    ],
+  },
+  ko: {
+    label: "Korean",
+    explicitPhrases: [
+      { value: "마감일 없이" },
+      { value: "날짜 없이" },
+      { value: "일정 없이" },
+    ],
+    promptExample: "마감일 없이",
+    negationBefore: [],
+    negationAfter: [/^\s*(?:만들지|하지|두지)\s*마/u],
+    scheduleMarkers: [
+      /(?:오늘|내일|오늘 밤|(?:월|화|수|목|금|토|일)요일)/u,
+      /(?:\d{1,2}|[일이삼사오육칠팔구십]+)시/u,
+      /(?:\d+|[일이삼사오육칠팔구십]+)\s*(?:분|시간|일|주|개월|년)\s*후/u,
+    ],
+    negatedScheduleSpans: [
+      /(?:(?:월|화|수|목|금|토|일)요일|오늘|내일)(?:이|가)?\s*아니/u,
+    ],
+  },
+  vi: {
+    label: "Vietnamese",
+    explicitPhrases: [
+      { value: "không có ngày đến hạn", wordBounded: true },
+      { value: "khong co ngay den han", wordBounded: true },
+      { value: "không ngày đến hạn", wordBounded: true },
+      { value: "khong ngay den han", wordBounded: true },
+      { value: "không có lịch", wordBounded: true },
+      { value: "khong co lich", wordBounded: true },
+    ],
+    promptExample: "không có ngày đến hạn",
+    negationBefore: [
+      new RegExp(
+        `(?:^|\\s)(?:đừng|dung)\\s+(?:để|de|làm|lam|tạo|tao)(?:\\s|$)${DIRECTIVE_GAP}$`,
+        "u",
+      ),
+    ],
+    negationAfter: [],
+    scheduleMarkers: [
+      /\b(?:hôm nay|hom nay|ngày mai|ngay mai|tối nay|toi nay|tuần tới|tuan toi|tháng tới|thang toi|năm tới|nam toi)\b/u,
+      /\b(?:thứ|thu)\s+(?:hai|ba|tư|tu|năm|nam|sáu|sau|bảy|bay|chủ nhật|chu nhat)\b/u,
+      /\b(?:lúc|luc)\s*\d{1,2}\s*(?:giờ|gio)\b/u,
+      /\b(?:trong|sau)\s+(?:\d+|một|mot|hai|ba|bốn|bon|năm|nam|sáu|sau|bảy|bay|tám|tam|chín|chin|mười|muoi)\s+(?:phút|phut|giờ|gio|ngày|ngay|tuần|tuan|tháng|thang|năm|nam)\b/u,
+    ],
+    negatedScheduleSpans: [
+      /\b(?:không|khong)\s+(?:phải|phai)\s+(?:(?:vào|vao)\s+)?(?:(?:thứ|thu)\s+(?:hai|ba|tư|tu|năm|nam|sáu|sau|bảy|bay|chủ nhật|chu nhat)|hôm nay|hom nay|ngày mai|ngay mai)\b/u,
+    ],
+  },
+  tl: {
+    label: "Tagalog",
+    explicitPhrases: [
+      { value: "walang takdang petsa", wordBounded: true },
+      { value: "walang iskedyul", wordBounded: true },
+    ],
+    promptExample: "walang takdang petsa",
+    negationBefore: [
+      new RegExp(
+        `\\b(?:huwag|wag)\\s+(?:gawing|ilagay|iwan|lumikha)\\b${DIRECTIVE_GAP}$`,
+        "u",
+      ),
+    ],
+    negationAfter: [],
+    scheduleMarkers: [
+      /\b(?:ngayon|bukas|mamayang gabi|sa susunod na\s+(?:araw|linggo|buwan|taon))\b/u,
+      /\b(?:lunes|martes|miyerkules|huwebes|biyernes|sabado|linggo)\b/u,
+      /\balas\s+\d{1,2}\b/u,
+      /\bsa loob ng\s+(?:\d+|isa|dalawa|tatlo|apat|lima|anim|pito|walo|siyam|sampu)\s+(?:minuto|oras|araw|linggo|buwan|taon)\b/u,
+    ],
+    negatedScheduleSpans: [
+      /\b(?:hindi|huwag|wag)\s+(?:sa\s+)?(?:ngayon|bukas|lunes|martes|miyerkules|huwebes|biyernes|sabado|linggo)\b/u,
+    ],
+  },
+};
+
+const LOCALE_POLICIES = UI_LANGUAGES.map(
+  (language) => POLICY_BY_LANGUAGE[language],
+);
+
+function isWordCharacter(value: string | undefined): boolean {
+  return value !== undefined && /[\p{L}\p{N}_]/u.test(value);
+}
+
+function phraseMatches(text: string, phrase: PhraseSpec): TextSpan[] {
+  const needle = normalizeKeywordMatchText(phrase.value);
+  const matches: TextSpan[] = [];
+  let offset = 0;
+  while (offset <= text.length - needle.length) {
+    const start = text.indexOf(needle, offset);
+    if (start < 0) break;
+    const end = start + needle.length;
+    if (
+      phrase.wordBounded !== true ||
+      (!isWordCharacter(text[start - 1]) && !isWordCharacter(text[end]))
+    ) {
+      matches.push({ start, end });
+    }
+    offset = start + Math.max(needle.length, 1);
+  }
+  return matches;
+}
+
+function patternSpans(text: string, pattern: RegExp): TextSpan[] {
+  const flags = pattern.flags.includes("g")
+    ? pattern.flags
+    : `${pattern.flags}g`;
+  const matcher = new RegExp(pattern.source, flags);
+  return Array.from(text.matchAll(matcher), (match) => ({
+    start: match.index ?? 0,
+    end: (match.index ?? 0) + match[0].length,
+  }));
+}
+
+function negatedDirective(
+  text: string,
+  positive: TextSpan,
+  policy: LocalePolicy,
+): UndatedDirective | null {
+  const before = text.slice(0, positive.start);
+  const prefix = policy.negationBefore
+    .flatMap((pattern) => patternSpans(before, pattern))
+    .filter((span) => span.end === before.length)
+    .sort((left, right) => right.start - left.start)[0];
+  const after = text.slice(positive.end);
+  const suffix = policy.negationAfter
+    .flatMap((pattern) => patternSpans(after, pattern))
+    .filter((span) => span.start === 0)
+    .sort((left, right) => right.end - left.end)[0];
+  if (!prefix && !suffix) return null;
+  return {
+    kind: "deny",
+    start: prefix?.start ?? positive.start,
+    end: positive.end + (suffix?.end ?? 0),
+  };
+}
+
+function orderedUndatedDirectives(text: string): UndatedDirective[] {
+  const directives = LOCALE_POLICIES.flatMap((policy) =>
+    policy.explicitPhrases.flatMap((phrase) =>
+      phraseMatches(text, phrase).map(
+        (positive) =>
+          negatedDirective(text, positive, policy) ?? {
+            ...positive,
+            kind: "allow" as const,
+          },
+      ),
+    ),
+  );
+  return directives.sort(
+    (left, right) => left.start - right.start || left.end - right.end,
+  );
+}
+
+function maskSpans(text: string, spans: readonly TextSpan[]): string {
+  if (spans.length === 0) return text;
+  const characters = text.split("");
+  for (const span of spans) {
+    for (let index = span.start; index < span.end; index += 1) {
+      characters[index] = " ";
+    }
+  }
+  return characters.join("");
+}
+
+const TITLE_SCHEDULE_SPANS = [
+  new RegExp(
+    `\\b(?:call|name|title|label)\\s+(?:it|this|that|the\\s+(?:todo|task|item))?\\s*(?:as\\s+|called\\s+|titled\\s+)?["'“”‘’]?(?:${ENGLISH_TEMPORAL_NAMES}|daily|weekly|monthly|yearly)\\b`,
+    "u",
+  ),
+  new RegExp(
+    `\\b(?:called|named|titled|labelled|labeled)\\s+["'“”‘’]?(?:${ENGLISH_TEMPORAL_NAMES}|daily|weekly|monthly|yearly)\\b`,
+    "u",
+  ),
+] as const;
+
+function suffixStatesSchedule(text: string): boolean {
+  const exceptionSpans = [
+    ...TITLE_SCHEDULE_SPANS.flatMap((pattern) => patternSpans(text, pattern)),
+    ...LOCALE_POLICIES.flatMap((policy) =>
+      policy.negatedScheduleSpans.flatMap((pattern) =>
+        patternSpans(text, pattern),
+      ),
+    ),
+  ];
+  const authoritative = maskSpans(text, exceptionSpans);
+  if (textStatesExplicitRecurrence(authoritative)) return true;
+  return LOCALE_POLICIES.some((policy) =>
+    policy.scheduleMarkers.some(
+      (pattern) => patternSpans(authoritative, pattern).length > 0,
+    ),
+  );
+}
+
+type UndatedTodoDirectiveState =
+  | "absent"
+  | "explicit"
+  | "scheduled_after_explicit";
+
+function undatedTodoDirectiveState(text: string): UndatedTodoDirectiveState {
+  const normalized = normalizeKeywordMatchText(text);
+  if (!normalized) return "absent";
+  const directive = orderedUndatedDirectives(normalized).at(-1);
+  if (!directive || directive.kind === "deny") return "absent";
+  return suffixStatesSchedule(normalized.slice(directive.end))
+    ? "scheduled_after_explicit"
+    : "explicit";
+}
+
+/** True only when the owner's last no-date directive survives later schedule text. */
+export function textStatesExplicitUndatedTodo(text: string): boolean {
+  return undatedTodoDirectiveState(text) === "explicit";
+}
+
+/** True when a schedule after the final explicit no-date directive contradicts it. */
+export function textContradictsExplicitUndatedTodo(text: string): boolean {
+  return undatedTodoDirectiveState(text) === "scheduled_after_explicit";
+}
+
+const PROMPT_EXAMPLES = LOCALE_POLICIES.map(
+  (policy) => `${policy.label}: ${policy.promptExample}`,
+).join("; ");
+
+/** Prompt contract derived from the same locale catalog used at the write boundary. */
+export const UNDATED_TODO_EXTRACTION_GUIDANCE = [
+  '  - "unscheduled" — ONLY when the user explicitly declines a date or schedule for this Todo.',
+  `    Explicit examples by locale: ${PROMPT_EXAMPLES}.`,
+  "    Interpret corrections in order: the last explicit no-date or negated no-date directive wins.",
+  "    After the final no-date directive, any non-negated date, weekday, time, recurrence, or relative offset means the Todo is scheduled. A merely omitted date is not unscheduled.",
+  "    Temporal words in the Todo title are not a schedule (for example, a title named Tomorrow followed by an explicit no-date request).",
+].join("\n");

--- a/plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts
@@ -16,6 +16,7 @@ import type {
   HandlerOptions,
   IAgentRuntime,
   Memory,
+  State,
   UUID,
 } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -33,6 +34,10 @@ import {
   writeRecentLifeSaveCache,
 } from "./lib/lifeops-deferred-draft.js";
 import {
+  textContradictsExplicitUndatedTodo,
+  textStatesExplicitUndatedTodo,
+} from "./lib/undated-todo-intent.js";
+import {
   applyLeadUpReminderShape,
   buildCadenceFromLlmParams,
   buildCadenceFromUpdateFields,
@@ -43,7 +48,6 @@ import {
   resolveOnceDueAt,
   runLifeConnectedQuery,
   runLifeOperationHandler,
-  textStatesExplicitUnscheduled,
   wantsEarlierReminderNudge,
 } from "./life.js";
 
@@ -785,6 +789,7 @@ describe("explicit unscheduled owner authority", () => {
   it.each([
     "add buy milk with no due date",
     "add buy milk as an undated task",
+    "add buy milk someday",
     "añade comprar leche sin fecha",
     "adicionar comprar leite sem prazo",
     "添加买牛奶，没有截止日期",
@@ -793,13 +798,14 @@ describe("explicit unscheduled owner authority", () => {
     "thêm việc mua sữa không có ngày đến hạn",
     "idagdag ang bumili ng gatas, walang takdang petsa",
   ])("accepts an explicit no-date phrase in %p", (text) => {
-    expect(textStatesExplicitUnscheduled(text)).toBe(true);
+    expect(textStatesExplicitUndatedTodo(text)).toBe(true);
   });
 
   it.each(MULTILINGUAL_CONTRADICTORY_UNSCHEDULED_TEXTS)(
     "rejects contradictory explicit scheduling in %s",
     (_language, text) => {
-      expect(textStatesExplicitUnscheduled(text)).toBe(false);
+      expect(textStatesExplicitUndatedTodo(text)).toBe(false);
+      expect(textContradictsExplicitUndatedTodo(text)).toBe(true);
     },
   );
 
@@ -821,7 +827,7 @@ describe("explicit unscheduled owner authority", () => {
     "không có ngày đến hạn, nhưng ngày mai",
     "walang takdang petsa, pero bukas",
   ])("rejects omitted or contradicted no-date authority in %p", (text) => {
-    expect(textStatesExplicitUnscheduled(text)).toBe(false);
+    expect(textStatesExplicitUndatedTodo(text)).toBe(false);
   });
 });
 
@@ -857,7 +863,12 @@ describe("runLifeOperationHandler clarification contract", () => {
 
     expect(preview).toMatchObject({
       success: false,
-      data: { deferred: true, saved: false, requiresConfirmation: true },
+      data: {
+        deferred: true,
+        saved: false,
+        requiresConfirmation: true,
+        lifeDraft: { request: { reminderPlan: null } },
+      },
     });
     expect(serviceState.createCalls).toHaveLength(0);
 
@@ -883,8 +894,267 @@ describe("runLifeOperationHandler clarification contract", () => {
       expect.objectContaining({
         kind: "task",
         cadence: { kind: "unscheduled" },
+        reminderPlan: null,
       }),
     ]);
+  });
+
+  it("does not treat a future confirmation clause as current consent", async () => {
+    const ownerText =
+      "Create a personal todo titled Buy oat milk. It has no due date or reminder. Preview it first and do not save until I confirm.";
+    const runtime = makeRuntime((prompt) => {
+      if (prompt.includes("create_definition request")) {
+        return taskPlanJson({
+          requestKind: "todo",
+          title: "Buy oat milk",
+          cadenceKind: "unscheduled",
+        });
+      }
+      return "";
+    });
+
+    const result = await runLifeOperationHandler(
+      runtime,
+      makeMessage(ownerText),
+      undefined,
+      {
+        parameters: {
+          action: "create",
+          confirmed: true,
+          intent: ownerText,
+          ownerSurface: "OWNER_TODOS",
+        },
+      } as HandlerOptions,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      data: { deferred: true, saved: false, requiresConfirmation: true },
+    });
+    expect(serviceState.createCalls).toHaveLength(0);
+  });
+
+  it.each([
+    "Add tomorrow's agenda with no due date.",
+    "Add Tomorrow, and Tomorrow, and Tomorrow to my reading list with no due date.",
+  ])(
+    "keeps temporal title nouns distinct from a real schedule in %p",
+    async (ownerText) => {
+      const runtime = makeRuntime((prompt) => {
+        if (prompt.includes("create_definition request")) {
+          return taskPlanJson({
+            requestKind: "todo",
+            title: "Reading list item",
+            cadenceKind: "unscheduled",
+          });
+        }
+        return "";
+      });
+
+      const result = await runLifeOperationHandler(
+        runtime,
+        makeMessage(ownerText),
+        undefined,
+        {
+          parameters: {
+            action: "create",
+            intent: ownerText,
+            ownerSurface: "OWNER_TODOS",
+          },
+        } as HandlerOptions,
+      );
+
+      expect(result).toMatchObject({
+        success: false,
+        data: { deferred: true, saved: false, requiresConfirmation: true },
+      });
+      expect(serviceState.createCalls).toHaveLength(0);
+    },
+  );
+
+  it("rejects a contradicted edit even when extraction resolves the later date", async () => {
+    const runtime = makeRuntime((prompt) => {
+      if (
+        prompt.includes(
+          "Decide how the assistant should interpret the user's follow-up",
+        )
+      ) {
+        return JSON.stringify({ mode: "edit" });
+      }
+      if (prompt.includes("create_definition request")) {
+        if (prompt.includes("Keep it with no due date, but Friday")) {
+          return taskPlanJson({
+            requestKind: "todo",
+            title: "Buy oat milk",
+            cadenceKind: "once",
+            dueWeekday: 5,
+          });
+        }
+        if (
+          prompt.includes(
+            "Yes, confirm and save the edited Book dentist visit task now",
+          )
+        ) {
+          return taskPlanJson({
+            requestKind: "todo",
+            title: "Book dentist visit",
+            cadenceKind: "weekly",
+            weekdays: [5],
+            windows: ["morning"],
+          });
+        }
+        return taskPlanJson({
+          requestKind: "todo",
+          title: "Buy oat milk",
+          cadenceKind: "unscheduled",
+        });
+      }
+      return "";
+    });
+
+    const preview = await runLifeOperationHandler(
+      runtime,
+      makeMessage("Add buy milk with no due date."),
+      undefined,
+      {
+        parameters: {
+          action: "create",
+          intent: "Add buy milk with no due date.",
+          ownerSurface: "OWNER_TODOS",
+        },
+      } as HandlerOptions,
+    );
+    expect(preview).toMatchObject({
+      success: false,
+      data: { deferred: true, saved: false, requiresConfirmation: true },
+    });
+
+    const edit = await runLifeOperationHandler(
+      runtime,
+      {
+        ...makeMessage("Keep it with no due date, but Friday."),
+        id: "00000000-0000-0000-0000-000000000006",
+      } as Memory,
+      { data: { actionResults: [preview] } } as unknown as State,
+      {
+        parameters: {
+          action: "create",
+          confirmed: true,
+          intent: "Keep it with no due date, but Friday.",
+          ownerSurface: "OWNER_TODOS",
+          details: { confirmed: true },
+        },
+      } as HandlerOptions,
+    );
+
+    expect(edit).toMatchObject({
+      success: false,
+      values: {
+        error: "MISSING_DEFINITION_FIELD",
+        missingField: "schedule",
+      },
+      data: { lifeDraftInvalidated: true },
+    });
+
+    const confirmation = await runLifeOperationHandler(
+      runtime,
+      {
+        ...makeMessage(
+          "Yes, confirm and save the edited Book dentist visit task now.",
+        ),
+        id: "00000000-0000-0000-0000-000000000008",
+      } as Memory,
+      undefined,
+      {
+        parameters: {
+          action: "create",
+          confirmed: true,
+          intent:
+            "Yes, confirm and save the edited Book dentist visit task now.",
+          ownerSurface: "OWNER_TODOS",
+        },
+      } as HandlerOptions,
+    );
+
+    expect(confirmation).toMatchObject({
+      success: false,
+      values: {
+        error: "MISSING_DEFINITION_FIELD",
+        missingField: "schedule",
+      },
+    });
+    expect(serviceState.createCalls).toHaveLength(0);
+  });
+
+  it("keeps a valid explicit undated edit as a preview without writing", async () => {
+    const runtime = makeRuntime((prompt) => {
+      if (
+        prompt.includes(
+          "Decide how the assistant should interpret the user's follow-up",
+        )
+      ) {
+        return JSON.stringify({ mode: "edit" });
+      }
+      if (prompt.includes("create_definition request")) {
+        return taskPlanJson({
+          requestKind: "todo",
+          title: "Buy oat milk",
+          cadenceKind: "unscheduled",
+        });
+      }
+      return "";
+    });
+
+    const preview = await runLifeOperationHandler(
+      runtime,
+      makeMessage("Add buy milk with no due date."),
+      undefined,
+      {
+        parameters: {
+          action: "create",
+          intent: "Add buy milk with no due date.",
+          ownerSurface: "OWNER_TODOS",
+        },
+      } as HandlerOptions,
+    );
+    expect(preview).toMatchObject({
+      success: false,
+      data: { deferred: true, saved: false, requiresConfirmation: true },
+    });
+
+    const edit = await runLifeOperationHandler(
+      runtime,
+      {
+        ...makeMessage("Rename it Buy oat milk, still no due date."),
+        id: "00000000-0000-0000-0000-000000000007",
+      } as Memory,
+      undefined,
+      {
+        parameters: {
+          action: "create",
+          intent: "Rename it Buy oat milk, still no due date.",
+          ownerSurface: "OWNER_TODOS",
+          title: "Buy oat milk",
+        },
+      } as HandlerOptions,
+    );
+
+    expect(edit).toMatchObject({
+      success: false,
+      data: {
+        deferred: true,
+        saved: false,
+        requiresConfirmation: true,
+        lifeDraft: {
+          request: {
+            cadence: { kind: "unscheduled" },
+            reminderPlan: null,
+            title: "Buy oat milk",
+          },
+        },
+      },
+    });
+    expect(serviceState.createCalls).toHaveLength(0);
   });
 
   it.each([
@@ -1114,6 +1384,51 @@ describe("runLifeOperationHandler clarification contract", () => {
       },
     });
     expect(retry.effectReceipts).toEqual(result.effectReceipts);
+    expect(serviceState.createCalls).toHaveLength(0);
+  });
+
+  it("rejects a model-invented date when the owner explicitly withheld timing", async () => {
+    const runtime = makeRuntime((prompt) => {
+      if (prompt.includes("create_definition request")) {
+        return taskPlanJson({
+          requestKind: "reminder",
+          title: "Call Mom",
+          cadenceKind: "once",
+          dueInDays: 1,
+          timeOfDay: "09:00",
+        });
+      }
+      return "When should it happen?";
+    });
+    const ownerText = "Remind me to call Mom, but I have not said when.";
+
+    const result = await runLifeOperationHandler(
+      runtime,
+      makeMessage(ownerText),
+      undefined,
+      {
+        parameters: {
+          action: "create",
+          intent: ownerText,
+          ownerSurface: "OWNER_REMINDERS",
+          title: "Call Mom",
+        },
+      } as HandlerOptions,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      values: {
+        error: "MISSING_DEFINITION_FIELD",
+        missingField: "schedule",
+        awaitingUserInput: true,
+      },
+      data: {
+        actionName: "OWNER_REMINDERS",
+        missingField: "schedule",
+        awaitingUserInput: true,
+      },
+    });
     expect(serviceState.createCalls).toHaveLength(0);
   });
 });
@@ -2251,6 +2566,36 @@ describe("runLifeOperationHandler consent gate (#16941)", () => {
       "00000000-0000-0000-0000-000000000011",
       CHILD_ASK,
     );
+
+    const preview = await runLifeOperationHandler(runtime, message, undefined, {
+      parameters: { action: "create_reminder", intent: CHILD_ASK },
+    } as HandlerOptions);
+    expect(preview.success).toBe(false);
+    expect(serviceState.createCalls).toHaveLength(0);
+
+    const recall = await runLifeOperationHandler(runtime, message, undefined, {
+      parameters: {
+        action: "create_reminder",
+        intent: CHILD_ASK,
+        confirmed: true,
+      },
+    } as HandlerOptions);
+
+    expect(recall.success).toBe(false);
+    expect(serviceState.createCalls).toHaveLength(0);
+    expect(recall.data).toMatchObject({
+      deferred: true,
+      saved: false,
+      requiresConfirmation: true,
+    });
+  });
+
+  it("fails closed when a same-turn re-call has no stable message id", async () => {
+    // Some connector/runtime boundaries do not carry Memory.id into the action
+    // invocation. An absent id cannot prove the cached preview came from an
+    // earlier owner turn, so planner-confirmed reuse must remain a preview.
+    const runtime = routineRuntime();
+    const message = makeMessage(CHILD_ASK);
 
     const preview = await runLifeOperationHandler(runtime, message, undefined, {
       parameters: { action: "create_reminder", intent: CHILD_ASK },

--- a/plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts
@@ -1367,8 +1367,8 @@ describe("runLifeOperationHandler clarification contract", () => {
 
     expect(result).toMatchObject({
       success: false,
-      text: "When should it happen?",
-      userFacingText: "When should it happen?",
+      text: clarification,
+      userFacingText: clarification,
       values: {
         success: false,
         error: "MISSING_DEFINITION_FIELD",
@@ -2620,9 +2620,9 @@ describe("runLifeOperationHandler consent gate (#16941)", () => {
     });
   });
 
-  it("honors planner confirmed:true against a draft previewed on an earlier message", async () => {
-    // A prior-turn draft means the owner actually saw the preview; a muted
-    // acknowledgement ("mhm") plus the planner flag may then save.
+  it("rejects planner confirmed:true without deterministic current-turn consent", async () => {
+    // A prior-turn draft proves a preview exists, not that neutral current
+    // text authorizes the write. The planner cannot turn "mhm" into consent.
     const runtime = routineRuntime();
 
     const preview = await runLifeOperationHandler(
@@ -2649,8 +2649,13 @@ describe("runLifeOperationHandler consent gate (#16941)", () => {
       } as HandlerOptions,
     );
 
-    expect(confirm.success).toBe(true);
-    expect(serviceState.createCalls).toHaveLength(1);
+    expect(confirm.success).toBe(false);
+    expect(serviceState.createCalls).toHaveLength(0);
+    expect(confirm.data).toMatchObject({
+      deferred: true,
+      saved: false,
+      requiresConfirmation: true,
+    });
   });
 });
 

--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -4205,21 +4205,11 @@ async function runLifeOperationHandlerInner(
     params.title ??
     routedParams?.target ??
     routedParams?.title;
-  // Planner-asserted `confirmed` is only real consent when the owner has
-  // actually seen a preview: either the current owner text is an explicit
-  // yes, or a draft previewed on an EARLIER message is still pending.
-  // Observed live (#16941, child-morning-routine): after previewing a daily
-  // routine, the planner immediately re-called create with confirmed:true in
-  // the same turn — saving a routine the child never approved — then told the
-  // child nothing was saved, and the real confirm turn duplicated the row.
-  const plannerAssertedConfirmed =
-    params.confirmed === true || detailBoolean(details, "confirmed") === true;
+  // Consent must come from the owner's current text. A pending draft proves
+  // only that a preview exists; neither a planner `confirmed:true` field nor a
+  // Stage-1 applied-effect claim can authorize the consequential write.
   const createConfirmed =
-    deferredDraftReuseMode === "confirm" ||
-    explicitCreateConfirmation ||
-    (plannerAssertedConfirmed &&
-      draftIsFromPriorTurn &&
-      deferredDraftReuseMode !== "edit");
+    deferredDraftReuseMode === "confirm" || explicitCreateConfirmation;
 
   try {
     const createDefinition = async () => {

--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -98,6 +98,8 @@ import {
 import {
   type ExtractedTaskParams,
   extractTaskCreatePlanWithLlm,
+  textExplicitlyLeavesScheduleUnspecified,
+  textStatesExplicitSchedule,
 } from "./lib/extract-task-plan.js";
 import {
   type ExtractedUpdateFields,
@@ -114,9 +116,12 @@ import {
   type DeferredLifeGoalDraft,
   deferredLifeDraftExpiryReason,
   extractDeferredLifeDraftFollowupWithLlm,
+  invalidateDeferredLifeDraftCache,
+  isExplicitLifeCreateConfirmation,
   isLifeSaveRetraction,
   latestDeferredLifeDraft,
-  readDeferredLifeDraftCache,
+  latestDeferredLifeDraftIsInvalidated,
+  readDeferredLifeDraftCacheState,
   readRecentLifeSaveCache,
   writeDeferredLifeDraftCache,
   writeRecentLifeSaveCache,
@@ -125,6 +130,10 @@ import {
   applyOwnerPolicyConfigureEscalation,
   applyOwnerPolicySetReminder,
 } from "./lib/owner-policy-writes.js";
+import {
+  textContradictsExplicitUndatedTodo,
+  textStatesExplicitUndatedTodo,
+} from "./lib/undated-todo-intent.js";
 
 // ── Types ─────────────────────────────────────────────
 
@@ -519,6 +528,7 @@ async function routeLifeSubaction(args: {
 function resolveDeferredLifeDraftReuseMode(args: {
   details: Record<string, unknown> | undefined;
   draft: DeferredLifeDraft | null;
+  draftIsFromPriorTurn: boolean;
   explicitConfirmation?: boolean;
   explicitOperation: LifeOperation | undefined;
   llmMode?: DeferredLifeDraftFollowupMode;
@@ -533,8 +543,12 @@ function resolveDeferredLifeDraftReuseMode(args: {
     return null;
   }
 
-  if (detailBoolean(args.details, "confirmed") === true) {
-    return "confirm";
+  // A planner can call the same action more than once while settling one
+  // message. Only an explicit owner confirmation may reuse a draft whose
+  // source turn cannot be proven older; planner flags and classifications are
+  // never evidence that the owner saw the preview.
+  if (!args.draftIsFromPriorTurn && args.explicitConfirmation !== true) {
+    return null;
   }
 
   const explicitOperation = args.explicitOperation
@@ -548,44 +562,24 @@ function resolveDeferredLifeDraftReuseMode(args: {
     return null;
   }
 
+  // Substantive follow-up text wins over planner-authored confirmation flags.
+  // Otherwise “keep it undated, but Friday” can be treated as approval and
+  // persist a changed schedule the owner has never previewed.
+  if (args.llmMode === "edit") {
+    return "edit";
+  }
+
   if (args.explicitConfirmation === true) {
     return "confirm";
   }
 
-  if (args.llmMode === "confirm" || args.llmMode === "edit") {
-    return args.llmMode;
+  if (
+    args.llmMode === "confirm" ||
+    detailBoolean(args.details, "confirmed") === true
+  ) {
+    return "confirm";
   }
   return null;
-}
-
-const LIFE_CONFIRMATION_VETO_RE =
-  /\b(?:no|not|don t|do not|cancel|hold off|wait|later|change)\b/u;
-const LIFE_CONFIRMATION_CUE_RE =
-  /\b(?:ok|okay|yes|yep|yeah|sure|confirm|confirmed|approve|approved|save it|save that|save this|save the goal|set it|lock it in|do it|looks good|that works|go ahead)\b/u;
-
-// Sentence-scoped on purpose: a message-wide negation veto turned "yes lock
-// it in! and can it bug me before friday too, not just friday morning" into
-// a non-confirmation, so three consecutive confirmed creates previewed and
-// nothing persisted (#16941 live). A sentence that carries its own negation
-// ("don't save that one") still never counts as consent.
-function isExplicitLifeCreateConfirmation(text: string): boolean {
-  const sentences = text.split(/(?<=[.!?])\s+|\n+/u);
-  for (const sentence of sentences) {
-    const normalized = sentence
-      .toLowerCase()
-      .replace(/[^\p{L}\p{N}]+/gu, " ")
-      .trim();
-    if (!normalized) {
-      continue;
-    }
-    if (LIFE_CONFIRMATION_VETO_RE.test(normalized)) {
-      continue;
-    }
-    if (LIFE_CONFIRMATION_CUE_RE.test(normalized)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 // A confirmation is "bare" when stripping the yes-cues and politeness filler
@@ -2374,64 +2368,6 @@ function normalizeCadenceDetail(value: unknown): LifeOpsCadence | undefined {
   return undefined;
 }
 
-const EXPLICIT_SCHEDULED_TODO_PATTERNS = [
-  /\b(?:today|tomorrow|tonight|next (?:day|week|month|year|monday|tuesday|wednesday|thursday|friday|saturday|sunday))\b/i,
-  /\b(?:at|by|on)\s+(?:\d{1,2}(?::\d{2})?\s*(?:a\.?m\.?|p\.?m\.?)?|monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/i,
-  /\bin\s+(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten|a|an)\s+(?:minutes?|hours?|days?|weeks?|months?|years?)\b/i,
-  /\b(?:at|by|before|after)\s+(?:the\s+)?(?:start|beginning|middle|end)\s+of\s+(?:the\s+|this\s+|next\s+)?(?:day|week|month|year)\b/i,
-  /\b(?:before|after)\s+(?:the\s+)?(?:meeting|game|work|school|lunch|dinner|appointment|trip|flight|event)\b/i,
-  /\b(?:a|one|two|three|four|five|six|seven|eight|nine|ten|\d+)\s+(?:days?|weeks?|months?|years?)\s+from\s+(?:today|tomorrow|monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/i,
-  /\b(?:every|each|daily|weekly|monthly|yearly)\b/i,
-  /\b\d{4}-\d{2}-\d{2}\b/,
-  /(?:hoy|mañana|esta noche|próxim[oa] (?:día|semana|mes|año)|cada (?:día|semana|mes|año)|diariamente|semanalmente|mensualmente|anualmente)/i,
-  /(?:a las?|dentro de)\s+(?:\d+|un[oa]?|dos|tres|cuatro|cinco|seis|siete|ocho|nueve|diez)(?:\s+(?:minutos?|horas?|días?|semanas?|meses?|años?))?/i,
-  /(?:hoje|amanhã|esta noite|próxim[oa] (?:dia|semana|m[eê]s|ano)|cada (?:dia|semana|m[eê]s|ano)|diariamente|semanalmente|mensalmente|anualmente)/i,
-  /(?:às?|dentro de)\s+(?:\d+|um|uma|dois|duas|tr[eê]s|quatro|cinco|seis|sete|oito|nove|dez)(?:\s+(?:minutos?|horas?|dias?|semanas?|meses?|anos?))?/i,
-  /(?:今天|明天|今晚|每天|每周|每週|每月|每年)/,
-  /(?:今日|明日|今夜|毎日|毎週|毎月|毎年)/,
-  /(?:오늘|내일|오늘 밤|매일|매주|매월|매년)/,
-  /(?:hôm nay|hom nay|ngày mai|ngay mai|tối nay|toi nay|tuần tới|tuan toi|tháng tới|thang toi|năm tới|nam toi|mỗi ngày|moi ngay|hàng tuần|hang tuan|hàng tháng|hang thang|hàng năm|hang nam)/i,
-  /(?:lúc|luc)\s*\d{1,2}\s*(?:giờ|gio)|(?:trong|sau)\s+(?:\d+|một|mot|hai|ba|bốn|bon|năm|nam|sáu|sau|bảy|bay|tám|tam|chín|chin|mười|muoi)\s+(?:phút|phut|giờ|gio|ngày|ngay|tuần|tuan|tháng|thang|năm|nam)/i,
-  /(?:ngayon|bukas|mamayang gabi|sa susunod na (?:araw|linggo|buwan|taon)|araw-araw|lingguhan|buwan-buwan|taun-taon)/i,
-  /(?:alas\s+\d{1,2}|sa loob ng\s+(?:\d+|isa|dalawa|tatlo|apat|lima|anim|pito|walo|siyam|sampu)\s+(?:minuto|oras|araw|linggo|buwan|taon))/i,
-] as const;
-
-const NEGATED_UNSCHEDULED_PATTERNS = [
-  /\b(?:not|never)\s+(?:an?\s+)?(?:plain|undated|unscheduled)\s+(?:todo|task|item)\b/i,
-  /\b(?:do not|don't|dont)\s+(?:make|save|add|create)(?:\s+it)?\s+(?:as\s+)?(?:an?\s+)?(?:plain|undated|unscheduled)\s+(?:todo|task|item)\b/i,
-] as const;
-
-const EXPLICIT_UNSCHEDULED_PATTERNS = [
-  /\bno (?:due )?date\b/i,
-  /\bwithout (?:a )?(?:due )?date\b/i,
-  /\bno (?:schedule|scheduled time|time needed|required time)\b/i,
-  /\b(?:plain|undated|unscheduled) (?:todo|task|item)\b/i,
-  /\bjust (?:a )?(?:plain )?(?:todo|task)\b/i,
-  /\b(?:sin fecha|sin plazo|sin horario)\b/i,
-  /\b(?:sem data|sem prazo|sem hor[aá]rio)\b/i,
-  /(?:没有|沒有|无|無)(?:截止日期|到期日|日期|时间|時間|日程)/,
-  /(?:期限|締め切り|日付|予定)(?:は)?なし/,
-  /(?:마감일|날짜|일정) 없이/,
-  /(?:không|khong) (?:có |co )?(?:ngày đến hạn|ngay den han|lịch|lich)/i,
-  /(?:walang takdang petsa|walang iskedyul)/i,
-] as const;
-
-/** Require current user-authored text before trusting model-only no-date shape. */
-export function textStatesExplicitUnscheduled(text: string): boolean {
-  const normalized = normalizeLifeInputText(text);
-  if (
-    EXPLICIT_SCHEDULED_TODO_PATTERNS.some((pattern) =>
-      pattern.test(normalized),
-    ) ||
-    NEGATED_UNSCHEDULED_PATTERNS.some((pattern) => pattern.test(normalized))
-  ) {
-    return false;
-  }
-  return EXPLICIT_UNSCHEDULED_PATTERNS.some((pattern) =>
-    pattern.test(normalized),
-  );
-}
-
 /**
  * Convert LLM-extracted params into a typed LifeOpsCadence.
  * Returns null when the LLM output is insufficient to construct a
@@ -3864,12 +3800,28 @@ async function runLifeOperationHandlerInner(
   );
   const details = params.details;
   const stateDeferredDraft = latestDeferredLifeDraft(state);
-  const cachedDeferredDraft = stateDeferredDraft
-    ? null
-    : await readDeferredLifeDraftCache(runtime, message);
+  const cachedDeferredDraftState = await readDeferredLifeDraftCacheState(
+    runtime,
+    message,
+  );
+  const cachedDeferredDraft =
+    cachedDeferredDraftState.kind === "draft"
+      ? cachedDeferredDraftState.draft
+      : null;
   const deferredDraft = stateDeferredDraft ?? cachedDeferredDraft;
+  const deferredDraftIsInvalidated =
+    deferredDraft === null &&
+    (latestDeferredLifeDraftIsInvalidated(state) ||
+      cachedDeferredDraftState.kind === "invalidated");
   const explicitCreateConfirmation =
     isExplicitLifeCreateConfirmation(currentText);
+  const currentMessageId =
+    message.id !== undefined && message.id !== null ? String(message.id) : "";
+  const draftSourceMessageId = deferredDraft?.sourceMessageId?.trim() ?? "";
+  const draftIsFromPriorTurn =
+    currentMessageId.length > 0 &&
+    draftSourceMessageId.length > 0 &&
+    draftSourceMessageId !== currentMessageId;
   const turnsSinceDraft =
     deferredDraft != null
       ? (countTurnsSinceLatestDeferredLifeDraft(state) ?? 0) + 1
@@ -3898,7 +3850,7 @@ async function runLifeOperationHandlerInner(
     turnsSinceDraft,
   });
   if (draftExpiryReason && deferredDraftFollowupMode === "confirm") {
-    await clearDeferredLifeDraftCache(runtime, message);
+    await invalidateDeferredLifeDraftCache(runtime, message);
     const fallback =
       "That LifeOps draft expired. Please restate it and I'll preview it again.";
     return {
@@ -3917,7 +3869,7 @@ async function runLifeOperationHandlerInner(
     };
   }
   if (deferredDraftFollowupMode === "cancel") {
-    await clearDeferredLifeDraftCache(runtime, message);
+    await invalidateDeferredLifeDraftCache(runtime, message);
     const fallback = "Okay, I won't save it yet.";
     return {
       success: true,
@@ -4030,6 +3982,7 @@ async function runLifeOperationHandlerInner(
   const deferredDraftReuseMode = resolveDeferredLifeDraftReuseMode({
     details,
     draft: deferredDraft,
+    draftIsFromPriorTurn,
     explicitConfirmation: explicitCreateConfirmation,
     explicitOperation: explicitSubaction,
     llmMode: deferredDraftFollowupMode,
@@ -4261,17 +4214,12 @@ async function runLifeOperationHandlerInner(
   // child nothing was saved, and the real confirm turn duplicated the row.
   const plannerAssertedConfirmed =
     params.confirmed === true || detailBoolean(details, "confirmed") === true;
-  const currentMessageId =
-    message.id !== undefined && message.id !== null ? String(message.id) : "";
-  const priorTurnDraftPending =
-    deferredDraft != null &&
-    (deferredDraft.sourceMessageId === undefined ||
-      currentMessageId === "" ||
-      deferredDraft.sourceMessageId !== currentMessageId);
   const createConfirmed =
     deferredDraftReuseMode === "confirm" ||
     explicitCreateConfirmation ||
-    (plannerAssertedConfirmed && priorTurnDraftPending);
+    (plannerAssertedConfirmed &&
+      draftIsFromPriorTurn &&
+      deferredDraftReuseMode !== "edit");
 
   try {
     const createDefinition = async () => {
@@ -4313,6 +4261,36 @@ async function runLifeOperationHandlerInner(
       const explicitMetadata = detailObject(details, "metadata") as
         | Record<string, unknown>
         | undefined;
+      const rejectsStaleInvalidatedDraftConfirmation =
+        deferredDraftIsInvalidated &&
+        explicitCreateConfirmation &&
+        !textStatesExplicitUndatedTodo(currentText) &&
+        !textStatesExplicitSchedule(currentText);
+      if (rejectsStaleInvalidatedDraftConfirmation) {
+        await invalidateDeferredLifeDraftCache(runtime, message);
+        const text =
+          "That draft is no longer active. Restate what you want saved, including its timing or that it has no due date.";
+        return {
+          success: false as const,
+          text,
+          userFacingText: text,
+          verifiedUserFacing: true,
+          values: {
+            success: false,
+            error: "MISSING_DEFINITION_FIELD",
+            missingField: "schedule",
+            requiresConfirmation: true,
+            awaitingUserInput: true,
+          },
+          data: {
+            actionName: ownerSurfaceActionName,
+            lifeDraftInvalidated: true,
+            missingField: "schedule",
+            requiresConfirmation: true,
+            awaitingUserInput: true,
+          },
+        };
+      }
 
       // Owner's stored timezone fact (travel-aware), used as the fallback zone
       // for a conversational create when no zone was stated out loud and no
@@ -4455,12 +4433,35 @@ async function runLifeOperationHandlerInner(
             deferredDefinitionDraft?.request.timezone ??
             windowPolicy?.timezone,
         ) ?? ownerFactTimeZone;
+      const ownerDefinitionAction = ownerDefinitionSurface(
+        ownerSurfaceActionName,
+      );
       if (
-        cadence?.kind === "unscheduled" &&
-        (ownerSurfaceActionName !== "OWNER_TODOS" ||
-          (!reuseDeferredDraft && !textStatesExplicitUnscheduled(currentText)))
+        ownerDefinitionAction !== null &&
+        ownerDefinitionAction !== "OWNER_TODOS" &&
+        textExplicitlyLeavesScheduleUnspecified(currentText)
       ) {
         cadence = undefined;
+        if (editingDeferredDefinitionDraft) {
+          await invalidateDeferredLifeDraftCache(runtime, message);
+        }
+      }
+      const confirmsValidatedUndatedDraft =
+        deferredDraftReuseMode === "confirm" &&
+        deferredDefinitionDraft?.request.cadence.kind === "unscheduled";
+      if (
+        (editingDeferredDefinitionDraft &&
+          deferredDefinitionDraft.request.cadence.kind === "unscheduled" &&
+          textContradictsExplicitUndatedTodo(currentText)) ||
+        (cadence?.kind === "unscheduled" &&
+          (ownerSurfaceActionName !== "OWNER_TODOS" ||
+            (!confirmsValidatedUndatedDraft &&
+              !textStatesExplicitUndatedTodo(currentText))))
+      ) {
+        cadence = undefined;
+        if (editingDeferredDefinitionDraft) {
+          await invalidateDeferredLifeDraftCache(runtime, message);
+        }
       }
       const timedRequestKind = llmRequestKind;
       const nativeAppleMetadata =
@@ -4551,6 +4552,9 @@ async function runLifeOperationHandlerInner(
           },
           data: {
             actionName: ownerSurfaceActionName,
+            ...(editingDeferredDefinitionDraft
+              ? { lifeDraftInvalidated: true }
+              : {}),
             missingField: "schedule",
             requiresConfirmation: true,
             awaitingUserInput: true,
@@ -4567,23 +4571,26 @@ async function runLifeOperationHandlerInner(
           | CreateLifeOpsDefinitionRequest["kind"]
           | undefined) ??
         (ownerSurfaceActionName === "OWNER_TODOS" ? "task" : "habit");
-      const leadShaped = applyLeadUpReminderShape({
-        cadence,
-        plan:
-          (detailObject(details, "reminderPlan") as
-            | CreateLifeOpsDefinitionRequest["reminderPlan"]
-            | undefined) ??
-          deferredDefinitionDraft?.request.reminderPlan ??
-          buildDefaultReminderPlan(`${title} reminder`),
-        ownerText: messageText(message),
-        title,
-        milestones: resolveMilestoneLabels({
-          details,
-          intent,
-          ownerText: messageText(message),
-          multiStep: llmPlan?.multiStep === true,
-        }),
-      });
+      const leadShaped =
+        cadence.kind === "unscheduled"
+          ? { cadence, plan: null }
+          : applyLeadUpReminderShape({
+              cadence,
+              plan:
+                (detailObject(details, "reminderPlan") as
+                  | CreateLifeOpsDefinitionRequest["reminderPlan"]
+                  | undefined) ??
+                deferredDefinitionDraft?.request.reminderPlan ??
+                buildDefaultReminderPlan(`${title} reminder`),
+              ownerText: messageText(message),
+              title,
+              milestones: resolveMilestoneLabels({
+                details,
+                intent,
+                ownerText: messageText(message),
+                multiStep: llmPlan?.multiStep === true,
+              }),
+            });
       const definitionDraft: DeferredLifeDefinitionDraft = {
         intent,
         operation: "create_definition",

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/definitions-service.unscheduled.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/definitions-service.unscheduled.test.ts
@@ -73,6 +73,8 @@ describe("DefinitionsDomain unscheduled cadence boundary", () => {
       kind: "task",
       title: "Undated task",
     });
+    expect(repository.createDefinition).toHaveBeenCalledTimes(1);
+    expect(repository.createDefinition).toHaveBeenCalledWith(result.definition);
     expect(deps.refreshDefinitionOccurrences).toHaveBeenCalledWith(
       expect.objectContaining({
         cadence: { kind: "unscheduled" },
@@ -83,7 +85,35 @@ describe("DefinitionsDomain unscheduled cadence boundary", () => {
       "00000000-0000-0000-0000-000000000001",
       result.definition.id,
     );
-    expect(result.performance).toBeDefined();
+    expect(result.performance).toEqual({
+      lastCompletedAt: null,
+      lastSkippedAt: null,
+      lastActivityAt: null,
+      totalScheduledCount: 0,
+      totalCompletedCount: 0,
+      totalSkippedCount: 0,
+      totalPendingCount: 0,
+      currentOccurrenceStreak: 0,
+      bestOccurrenceStreak: 0,
+      currentPerfectDayStreak: 0,
+      bestPerfectDayStreak: 0,
+      last7Days: {
+        scheduledCount: 0,
+        completedCount: 0,
+        skippedCount: 0,
+        pendingCount: 0,
+        completionRate: 0,
+        perfectDayCount: 0,
+      },
+      last30Days: {
+        scheduledCount: 0,
+        completedCount: 0,
+        skippedCount: 0,
+        pendingCount: 0,
+        completionRate: 0,
+        perfectDayCount: 0,
+      },
+    });
   });
 
   it.each(["habit", "routine"] as const)(

--- a/plugins/plugin-personal-assistant/src/lifeops/todos/direct-routing.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/todos/direct-routing.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Covers the plugin-owned routing boundary that makes an undated Todo preview
+ * execute the real owner action instead of trusting model-authored preview text.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  createUndatedOwnerTodoDirectRoutingRule,
+  looksLikeExplicitUndatedOwnerTodoRequest,
+} from "./direct-routing";
+
+describe("undated owner Todo direct routing", () => {
+  it.each([
+    "Create a personal todo titled Buy oat milk. It has no due date or reminder. Preview it first and do not save until I confirm.",
+    "Add a task called Renew passport someday and preview it first.",
+    "Crea una tarea llamada Comprar leche sin fecha y muéstrame una vista previa.",
+    "Crie uma tarefa chamada Comprar leite sem prazo e mostre uma prévia.",
+    "创建一个叫买牛奶的待办事项，没有截止日期，先预览。",
+    "牛乳を買うというタスクを期限なしで作成し、先にプレビューして。",
+    "우유 사기라는 할 일을 마감일 없이 만들고 먼저 미리 보기 해줘.",
+    "Tạo việc cần làm tên Mua sữa không có ngày đến hạn và xem trước.",
+    "Gumawa ng gawain na Bumili ng gatas na walang takdang petsa at i-preview muna.",
+  ])("routes an explicit undated Todo write or preview: %s", (text) => {
+    expect(looksLikeExplicitUndatedOwnerTodoRequest(text)).toBe(true);
+  });
+
+  it.each([
+    "Explain what an undated todo is.",
+    "Create a calendar event with no due date.",
+    "Don't create a todo with no due date.",
+    "Create a todo with no due date, but schedule it Friday.",
+    "What todos do I have?",
+    "Alice created a task without a due date.",
+  ])(
+    "does not claim adjacent, negated, scheduled, or read-only intent: %s",
+    (text) => {
+      expect(looksLikeExplicitUndatedOwnerTodoRequest(text)).toBe(false);
+    },
+  );
+
+  it("targets the owner Todo action behind structural execution gates", () => {
+    expect(createUndatedOwnerTodoDirectRoutingRule()).toMatchObject({
+      id: "lifeops.owner-todo-undated-create",
+      actionNames: ["OWNER_TODOS"],
+      requiredActionTags: expect.arrayContaining([
+        "domain:reminders",
+        "capability:write",
+        "effect:receipt-required",
+      ]),
+      contexts: ["tasks", "todos", "productivity"],
+    });
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/todos/direct-routing.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/todos/direct-routing.ts
@@ -1,0 +1,59 @@
+/**
+ * Declares the deterministic boundary for an explicitly undated owner Todo.
+ * The canonical undated-intent policy decides schedule semantics; this module
+ * only establishes that the current message asks to create or preview a Todo.
+ * Core still enforces role, capability, connector, and action validation gates.
+ */
+
+import type { DirectActionRoutingRule } from "@elizaos/core";
+import { textStatesExplicitUndatedTodo } from "../../actions/lib/undated-todo-intent.js";
+
+const TODO_NOUN_PATTERNS: readonly RegExp[] = [
+  /\b(?:todo|to-do|task|checklist item)\b/iu,
+  /\b(?:tarea|pendiente)\b/iu,
+  /\b(?:tarefa|afazer)\b/iu,
+  /(?:待办事项|待辦事項|任务|任務)/u,
+  /(?:タスク|やること)/u,
+  /(?:할 일|작업)/u,
+  /\b(?:việc cần làm|nhiệm vụ)\b/iu,
+  /\b(?:gawain|dapat gawin)\b/iu,
+];
+
+const TODO_WRITE_OR_PREVIEW_PATTERNS: readonly RegExp[] = [
+  /\b(?:add|create|make|save|draft|preview|set up)\b/iu,
+  /\b(?:añad(?:e|ir)|agreg(?:a|ar)|cre(?:a|ar)|guard(?:a|ar)|vista previa)\b/iu,
+  /\b(?:adicion(?:a|ar)|cri(?:a|ar)|salv(?:a|ar)|prévia|visualizar)\b/iu,
+  /(?:添加|新增|创建|建立|预览|預覽|保存|儲存)/u,
+  /(?:追加|作成|作って|プレビュー|保存)/u,
+  /(?:추가|만들|생성|미리 보기|저장)/u,
+  /\b(?:thêm|tạo|xem trước|lưu)\b/iu,
+  /\b(?:idagdag|gumawa|likhain|i-preview|i-save)\b/iu,
+];
+
+export function looksLikeExplicitUndatedOwnerTodoRequest(
+  text: string,
+): boolean {
+  const normalized = text.trim();
+  return (
+    normalized.length > 0 &&
+    TODO_NOUN_PATTERNS.some((pattern) => pattern.test(normalized)) &&
+    TODO_WRITE_OR_PREVIEW_PATTERNS.some((pattern) =>
+      pattern.test(normalized),
+    ) &&
+    textStatesExplicitUndatedTodo(normalized)
+  );
+}
+
+export function createUndatedOwnerTodoDirectRoutingRule(): DirectActionRoutingRule {
+  return {
+    id: "lifeops.owner-todo-undated-create",
+    actionNames: ["OWNER_TODOS"],
+    requiredActionTags: [
+      "domain:reminders",
+      "capability:write",
+      "effect:receipt-required",
+    ],
+    contexts: ["tasks", "todos", "productivity"],
+    matches: looksLikeExplicitUndatedOwnerTodoRequest,
+  };
+}

--- a/plugins/plugin-personal-assistant/src/plugin.init-scheduler-identity.test.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.init-scheduler-identity.test.ts
@@ -7,7 +7,13 @@
  * than a hand-rolled fragment. The dynamic Google connector import is stubbed so
  * init runs without the optional third-party plugin present.
  */
-import type { IAgentRuntime, Plugin, TaskWorker, UUID } from "@elizaos/core";
+import {
+  getDirectActionRoutingRules,
+  type IAgentRuntime,
+  type Plugin,
+  type TaskWorker,
+  type UUID,
+} from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Isolate PA's own init wiring (registries, workers, policies, the scheduler
@@ -108,6 +114,21 @@ describe("personalAssistantPlugin.init scheduler identity", () => {
     } else {
       process.env.ELIZA_DISABLE_LIFEOPS_SCHEDULER = originalEnv;
     }
+  });
+
+  it("registers first-turn action routes before plugin discovery yields", async () => {
+    const { runtime } = createRecordingRuntime();
+
+    const initialization = personalAssistantPlugin.init?.({}, runtime);
+
+    expect(getDirectActionRoutingRules(runtime).map((rule) => rule.id)).toEqual(
+      expect.arrayContaining([
+        "lifeops.owner-todo-undated-create",
+        "lifeops.owner-reminder-create",
+        "lifeops.tracked-work-recap",
+      ]),
+    );
+    await initialization;
   });
 
   it("registers the LifeOps worker identity even when the scheduler is disabled", async () => {

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -71,6 +71,7 @@ import { credentialsAction } from "./actions/credentials.js";
 import { ownerDocumentsAction } from "./actions/document.js";
 import { entityAction } from "./actions/entity.js";
 import { householdCoordinationAction } from "./actions/household-coordination.js";
+import { deferredOwnerTodoRoutingEvaluator } from "./actions/lib/lifeops-deferred-draft.js";
 import {
   ownerAlarmsAction,
   ownerFinancesAction,
@@ -239,6 +240,7 @@ import {
   createActivitySignalBus,
   registerActivitySignalBus,
 } from "./lifeops/signals/bus.js";
+import { createUndatedOwnerTodoDirectRoutingRule } from "./lifeops/todos/direct-routing.js";
 import { threadOpsFieldEvaluator } from "./lifeops/work-threads/field-evaluator-thread-ops.js";
 import { isDarwin } from "./platform/host.js";
 import { browserBridgeProvider } from "./provider.js";
@@ -784,7 +786,10 @@ const rawPersonalAssistantPlugin: Plugin = {
     // registerLifeOpsScheduledTaskRunnerDeps(runtime) in init() instead, so
     // there is exactly one runner service per runtime.
   ],
-  responseHandlerEvaluators: [ownerProfileExtractionEvaluator],
+  responseHandlerEvaluators: [
+    deferredOwnerTodoRoutingEvaluator,
+    ownerProfileExtractionEvaluator,
+  ],
   responseHandlerFieldEvaluators: [threadOpsFieldEvaluator],
   // Post-turn evaluators join the runtime's single merged SMALL-model
   // evaluation call (EvaluatorService) — no extra model round-trip per turn.
@@ -854,6 +859,26 @@ const rawPersonalAssistantPlugin: Plugin = {
       handleMeetingTranscriptFinalized(
         payload as EventPayload & MeetingTranscriptFinalizedPayload,
       ),
+    );
+
+    // These registries participate in the first inbound turn. Establish them
+    // before plugin discovery yields so a newly ready runtime cannot briefly
+    // answer an actionable request as plain chat.
+    registerCandidateActionBackstopRule(
+      runtime,
+      createScheduledTaskCandidateBackstopRule(),
+    );
+    registerDirectActionRoutingRule(
+      runtime,
+      createTrackedWorkRecapDirectRoutingRule(),
+    );
+    registerDirectActionRoutingRule(
+      runtime,
+      createOwnerReminderDirectRoutingRule(),
+    );
+    registerDirectActionRoutingRule(
+      runtime,
+      createUndatedOwnerTodoDirectRoutingRule(),
     );
 
     // When LIFEOPS_USE_MOCKOON=1, redirect every external connector base URL
@@ -1031,21 +1056,6 @@ const rawPersonalAssistantPlugin: Plugin = {
     // confirms via CHOOSE_OPTION (issue #10723).
     registerOwnerSendApprovalWorker(runtime);
     registerSendPolicy(runtime, createOwnerSendPolicy());
-    // Candidate-action backstop: protect LifeOps scheduled-task candidates from
-    // the core coding-delegation backstop on genuine scheduled-task turns.
-    registerCandidateActionBackstopRule(
-      runtime,
-      createScheduledTaskCandidateBackstopRule(),
-    );
-    registerDirectActionRoutingRule(
-      runtime,
-      createTrackedWorkRecapDirectRoutingRule(),
-    );
-    registerDirectActionRoutingRule(
-      runtime,
-      createOwnerReminderDirectRoutingRule(),
-    );
-
     // First-party adapters backed by LifeOps services. Gmail and X replace the
     // core default adapters so MESSAGE triage operations operate on real
     // connected data.

--- a/plugins/plugin-personal-assistant/test/helpers/lifeops-live-harness.ts
+++ b/plugins/plugin-personal-assistant/test/helpers/lifeops-live-harness.ts
@@ -216,10 +216,17 @@ function resolveCerebrasModelEnv(): Record<string, string> {
     smallModel;
 
   return {
+    CEREBRAS_MODEL: largeModel,
     OPENAI_SMALL_MODEL: smallModel,
     OPENAI_LARGE_MODEL: largeModel,
+    OPENAI_MEDIUM_MODEL: largeModel,
+    OPENAI_ACTION_PLANNER_MODEL: largeModel,
+    OPENAI_PLANNER_MODEL: largeModel,
     SMALL_MODEL: smallModel,
     LARGE_MODEL: largeModel,
+    MEDIUM_MODEL: largeModel,
+    ACTION_PLANNER_MODEL: largeModel,
+    PLANNER_MODEL: largeModel,
   };
 }
 
@@ -672,9 +679,11 @@ export async function startLifeOpsLiveRuntime(options?: {
             : {}),
           allow: [
             ...new Set(
-              [...basePluginsWithoutProviders, selectedProvider.plugin].filter(
-                (entry): entry is string => typeof entry === "string",
-              ),
+              [
+                ...basePluginsWithoutProviders,
+                "@elizaos/plugin-personal-assistant",
+                selectedProvider.plugin,
+              ].filter((entry): entry is string => typeof entry === "string"),
             ),
           ],
         },
@@ -719,6 +728,11 @@ export async function startLifeOpsLiveRuntime(options?: {
       PGLITE_DATA_DIR: pgliteDir,
       ELIZA_PORT: String(apiPort),
       ELIZA_API_PORT: String(apiPort),
+      // The child runs under NODE_ENV=test, where trajectory persistence is
+      // intentionally default-off. Live evidence needs the canonical operator
+      // opt-in so the assertions inspect the same durable rows the runtime UI
+      // and API expose instead of relying only on the provider wire capture.
+      ELIZA_TRAJECTORY_LOGGING: "1",
       ENABLE_AUTONOMY: "false",
       ELIZA_DISABLE_PROACTIVE_AGENT: "1",
       ALLOW_NO_DATABASE: "",
@@ -740,11 +754,34 @@ export async function startLifeOpsLiveRuntime(options?: {
     Math.max(1, bootDeadlineMs - Date.now());
 
   try {
-    await waitForJsonPredicate<{ ready?: boolean; runtime?: string }>(
+    const health = await waitForJsonPredicate<{
+      ready?: boolean;
+      runtime?: string;
+      deferredBoot?: {
+        settled?: boolean;
+        phases?: Record<string, "pending" | "complete" | "failed">;
+      };
+    }>(
       `http://127.0.0.1:${apiPort}/api/health`,
-      (value) => value.ready === true && value.runtime === "ok",
+      (value) =>
+        value.ready === true &&
+        value.runtime === "ok" &&
+        value.deferredBoot?.settled === true,
       remainingBootTimeMs(),
     );
+    if (!health.deferredBoot?.phases) {
+      throw new Error("Live runtime health omitted deferred boot phases");
+    }
+    const failedDeferredPhases = Object.entries(
+      health.deferredBoot.phases,
+    ).filter(([, status]) => status === "failed");
+    if (failedDeferredPhases.length > 0) {
+      throw new Error(
+        `Live runtime deferred boot failed: ${failedDeferredPhases
+          .map(([phase]) => phase)
+          .join(", ")}`,
+      );
+    }
     await waitForJsonPredicate<{ trajectories?: unknown[] }>(
       `http://127.0.0.1:${apiPort}/api/trajectories?limit=1`,
       (value) => Array.isArray(value.trajectories),

--- a/plugins/plugin-personal-assistant/test/undated-owner-todo.cerebras.live.e2e.test.ts
+++ b/plugins/plugin-personal-assistant/test/undated-owner-todo.cerebras.live.e2e.test.ts
@@ -1,16 +1,23 @@
 /**
  * Live Cerebras proof for the owner-todo cadence boundary. The test boots the
- * real LifeOps runtime, drives both requests through chat, records their model
- * trajectories, and verifies neither preview mutates definition state. The
- * deterministic handler suite owns preview-confirm persistence coverage.
+ * real LifeOps runtime and inspects its actual PGlite definition, occurrence,
+ * and trajectory ledgers so a model-only reply cannot masquerade as proof.
  */
 
-import { afterAll, beforeAll, expect, it } from "vitest";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, expect, it } from "vitest";
 import { describeIf } from "../../../packages/app-core/test/helpers/conditional-tests.ts";
 import {
   createConversation,
   req,
 } from "../../../packages/app-core/test/helpers/http.ts";
+import {
+  type CapturedWireCall,
+  type CerebrasWireCapture,
+  startCerebrasWireCapture,
+  writeCerebrasEvidenceArtifacts,
+} from "../../plugin-openai/__tests__/helpers/cerebras-wire-capture.ts";
 import {
   assertNoProviderIssue,
   LIVE_CHAT_TEST_TIMEOUT_MS,
@@ -20,40 +27,384 @@ import {
   type StartedLifeOpsLiveRuntime,
   selectLifeOpsLiveProvider,
   startLifeOpsLiveRuntime,
+  waitForDefinitionByTitle,
 } from "./helpers/lifeops-live-harness.ts";
 
 const selectedProvider = await selectLifeOpsLiveProvider();
 const suiteEnabled =
   LIVE_TESTS_ENABLED && selectedProvider?.name === "cerebras";
 
+const DEFINITION_LEDGER = {
+  schema: "app_lifeops",
+  table: "life_task_definitions",
+  orderBy: ["created_at", "id"],
+} as const;
+
+const OCCURRENCE_LEDGER = {
+  schema: "app_lifeops",
+  table: "life_task_occurrences",
+  orderBy: ["definition_id", "occurrence_key", "id"],
+} as const;
+
+const TRAJECTORY_LEDGER = {
+  schema: "public",
+  table: "trajectories",
+  orderBy: ["created_at", "id"],
+} as const;
+
+type SqlRow = Record<string, unknown>;
+type CapturedTrajectory = {
+  turnName: string;
+  input: string;
+  response: string;
+  trajectoryId: string;
+  row: SqlRow;
+  wireCalls: CapturedWireCall[];
+};
+
+function normalizeEvidenceText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function containsText(value: unknown, expected: string): boolean {
+  if (typeof value === "string") {
+    return normalizeEvidenceText(value).includes(
+      normalizeEvidenceText(expected),
+    );
+  }
+  if (Array.isArray(value)) {
+    return value.some((entry) => containsText(entry, expected));
+  }
+  if (value && typeof value === "object") {
+    return Object.values(value).some((entry) => containsText(entry, expected));
+  }
+  return false;
+}
+
+function parseTrajectorySteps(row: SqlRow): unknown[] {
+  const raw = row.steps_json;
+  const parsed = typeof raw === "string" ? JSON.parse(raw) : raw;
+  if (!Array.isArray(parsed)) {
+    throw new Error(`Trajectory ${String(row.id)} has invalid steps_json`);
+  }
+  return parsed;
+}
+
+function parsedWireRequest(call: CapturedWireCall): Record<string, unknown> {
+  const parsed = call.request?.parsedBody;
+  if (
+    parsed?.kind !== "json" ||
+    !parsed.value ||
+    typeof parsed.value !== "object" ||
+    Array.isArray(parsed.value)
+  ) {
+    throw new Error(`Wire call ${call.id} has no JSON request body`);
+  }
+  return parsed.value as Record<string, unknown>;
+}
+
+function isModelWireCall(call: CapturedWireCall): boolean {
+  const parsed = call.request?.parsedBody;
+  return (
+    parsed?.kind === "json" &&
+    !!parsed.value &&
+    typeof parsed.value === "object" &&
+    !Array.isArray(parsed.value) &&
+    typeof (parsed.value as { model?: unknown }).model === "string" &&
+    (parsed.value as { model: string }).model.trim().length > 0
+  );
+}
+
+async function readOnlyRows(
+  runtime: StartedLifeOpsLiveRuntime,
+  ledger: {
+    schema: string;
+    table: string;
+    orderBy: readonly string[];
+  },
+): Promise<SqlRow[]> {
+  const apiToken = process.env.ELIZA_API_TOKEN?.trim();
+  const query = new URLSearchParams({
+    schema: ledger.schema,
+    limit: "500",
+  });
+  const response = await req(
+    runtime.port,
+    "GET",
+    `/api/database/tables/${encodeURIComponent(ledger.table)}/rows?${query.toString()}`,
+    undefined,
+    apiToken ? { Authorization: `Bearer ${apiToken}` } : undefined,
+    { timeoutMs: 30_000 },
+  );
+  if (response.status !== 200) {
+    throw new Error(
+      `Read-only evidence query failed (${response.status}): ${JSON.stringify(response.data)}`,
+    );
+  }
+  if (
+    !Array.isArray(response.data.columns) ||
+    !Array.isArray(response.data.rows)
+  ) {
+    throw new Error(
+      "Read-only evidence query returned an invalid result shape",
+    );
+  }
+  const rows = response.data.rows.filter(
+    (row): row is SqlRow =>
+      !!row && typeof row === "object" && !Array.isArray(row),
+  );
+  expect(response.data.total).toBe(rows.length);
+  return rows.toSorted((left, right) => {
+    for (const column of ledger.orderBy) {
+      const comparison = String(left[column] ?? "").localeCompare(
+        String(right[column] ?? ""),
+      );
+      if (comparison !== 0) return comparison;
+    }
+    return 0;
+  });
+}
+
+async function waitForTurnTrajectory(
+  runtime: StartedLifeOpsLiveRuntime,
+  priorIds: ReadonlySet<string>,
+  input: string,
+  wireCapture: CerebrasWireCapture,
+  wireStartIndex: number,
+): Promise<Omit<CapturedTrajectory, "turnName" | "input" | "response">> {
+  const deadline = Date.now() + 120_000;
+  let latestCandidateSummary: Array<Record<string, unknown>> = [];
+  while (Date.now() < deadline) {
+    const rows = await readOnlyRows(runtime, TRAJECTORY_LEDGER);
+    latestCandidateSummary = rows
+      .filter((row) => {
+        const trajectoryId = String(row.id ?? "");
+        return trajectoryId.length > 0 && !priorIds.has(trajectoryId);
+      })
+      .map((row) => {
+        const steps = parseTrajectorySteps(row);
+        return {
+          id: row.id,
+          status: row.status,
+          source: row.source,
+          llmCallCount: row.llm_call_count,
+          stepCount: row.step_count,
+          parsedStepCount: steps.length,
+          containsExpectedInput: containsText(steps, input),
+          rowKeys: Object.keys(row).sort(),
+        };
+      });
+    for (const row of rows) {
+      const trajectoryId = String(row.id ?? "");
+      if (
+        !trajectoryId ||
+        priorIds.has(trajectoryId) ||
+        row.status !== "completed"
+      ) {
+        continue;
+      }
+      const wireCalls = wireCapture.calls.slice(wireStartIndex);
+      if (
+        wireCalls.length === 0 ||
+        wireCalls.some((call) => call.completedAt === undefined)
+      ) {
+        continue;
+      }
+      const modelWireCalls = wireCalls.filter(isModelWireCall);
+      expect(modelWireCalls.length).toBeGreaterThan(0);
+      expect(
+        modelWireCalls.some((call) =>
+          containsText(parsedWireRequest(call), input),
+        ),
+      ).toBe(true);
+      for (const call of wireCalls) {
+        expect(call.response?.body?.byteLength ?? 0).toBeGreaterThan(0);
+        expect(call.transport.outcome).toBe("complete");
+        expect(call.durationMs).toBeGreaterThanOrEqual(0);
+      }
+      for (const call of modelWireCalls) {
+        expect(call.request?.method).toBe("POST");
+        expect(call.response?.status).toBe(200);
+      }
+      return { trajectoryId, row, wireCalls };
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  throw new Error(
+    `Timed out waiting for trajectory for: ${input}\nCandidates: ${JSON.stringify(latestCandidateSummary, null, 2)}\n${runtime.getLogTail()}`,
+  );
+}
+
+async function writeLiveEvidence(args: {
+  trajectories: CapturedTrajectory[];
+  domain: Record<string, unknown>;
+  logTails: Array<{ turnName: string; logTail: string }>;
+}): Promise<void> {
+  const artifactDir = process.env.ELIZA_LIVE_TEST_ARTIFACT_DIR?.trim();
+  if (!artifactDir) return;
+  await mkdir(artifactDir, { recursive: true });
+  const llmCallsPath =
+    process.env.ELIZA_LIVE_TEST_LLM_CALLS_JSONL?.trim() ??
+    path.join(artifactDir, "llm-calls.jsonl");
+  const modelCalls = args.trajectories.flatMap((trajectory) =>
+    trajectory.wireCalls.filter(isModelWireCall).map((wireCall) => ({
+      turnName: trajectory.turnName,
+      input: trajectory.input,
+      response: trajectory.response,
+      trajectoryId: trajectory.trajectoryId,
+      wireCallId: wireCall.id,
+      durationMs: wireCall.durationMs,
+      request: parsedWireRequest(wireCall),
+      providerResponse:
+        wireCall.response?.parsedBody ?? wireCall.response?.body?.utf8,
+    })),
+  );
+  const trajectorySummary = args.trajectories.map(
+    ({ wireCalls, ...trajectory }) => ({
+      ...trajectory,
+      wireCalls: wireCalls.map((wireCall) => ({
+        id: wireCall.id,
+        startedAt: wireCall.startedAt,
+        completedAt: wireCall.completedAt,
+        durationMs: wireCall.durationMs,
+        requestSha256: wireCall.request?.body.sha256,
+        responseSha256: wireCall.response?.body?.sha256,
+        responseStatus: wireCall.response?.status,
+        transportOutcome: wireCall.transport.outcome,
+      })),
+    }),
+  );
+  const cerebrasKey = process.env.CEREBRAS_API_KEY?.trim();
+  if (!cerebrasKey) {
+    throw new Error("Cerebras key disappeared before evidence sanitization");
+  }
+  await Promise.all([
+    writeCerebrasEvidenceArtifacts({
+      artifactDirectory: artifactDir,
+      trajectoryPath: llmCallsPath,
+      calls: args.trajectories.flatMap((trajectory) => trajectory.wireCalls),
+      trajectories: modelCalls,
+      receipts: [
+        {
+          name: "undated-owner-todo-domain-proof",
+          definitionRowCount: Array.isArray(
+            args.domain.definitionRowsAfterConfirm,
+          )
+            ? args.domain.definitionRowsAfterConfirm.length
+            : null,
+          occurrenceRowCount: Array.isArray(
+            args.domain.occurrenceRowsAfterConfirm,
+          )
+            ? args.domain.occurrenceRowsAfterConfirm.length
+            : null,
+        },
+      ],
+      secrets: [cerebrasKey],
+      metadata: {
+        issue: 20026,
+        evidenceHead: process.env.ELIZA_LIVE_EVIDENCE_HEAD ?? "local",
+        provider: "cerebras",
+        transport: "credential-redacted-loopback-wire-capture",
+      },
+    }),
+    writeFile(
+      path.join(artifactDir, "trajectory-proof.raw.json"),
+      `${JSON.stringify(trajectorySummary, null, 2)}\n`,
+    ),
+    writeFile(
+      path.join(artifactDir, "domain-proof.raw.json"),
+      `${JSON.stringify(args.domain, null, 2)}\n`,
+    ),
+    writeFile(
+      path.join(artifactDir, "backend-log-tails.raw.log"),
+      `${args.logTails
+        .map(({ turnName, logTail }) => `## ${turnName}\n${logTail}`)
+        .join("\n\n")}\n`,
+    ),
+  ]);
+}
+
 describeIf(suiteEnabled)("Live: undated owner-todo boundary", () => {
   let runtime: StartedLifeOpsLiveRuntime;
+  let wireCapture: CerebrasWireCapture;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     if (!selectedProvider)
       throw new Error("Cerebras provider was not selected");
-    runtime = await startLifeOpsLiveRuntime({ selectedProvider });
+    wireCapture = await startCerebrasWireCapture();
+    try {
+      runtime = await startLifeOpsLiveRuntime({
+        selectedProvider: {
+          ...selectedProvider,
+          env: {
+            ...selectedProvider.env,
+            OPENAI_BASE_URL: wireCapture.baseUrl,
+            CEREBRAS_BASE_URL: wireCapture.baseUrl,
+          },
+        },
+      });
+    } catch (error) {
+      await wireCapture.close();
+      throw error;
+    }
   }, LIVE_RUNTIME_BOOT_TIMEOUT_MS + 30_000);
 
-  afterAll(async () => {
-    await runtime?.close();
+  afterEach(async () => {
+    const results = await Promise.allSettled([
+      runtime?.close(),
+      wireCapture?.close(),
+    ]);
+    const failures = results.flatMap((result) =>
+      result.status === "rejected" ? [result.reason] : [],
+    );
+    if (failures.length > 0) {
+      throw new AggregateError(failures, "Live evidence teardown failed");
+    }
   });
 
   it(
-    "previews an undated todo but refuses an undated reminder",
+    "persists one plain Todo and rejects contradictory undated writes",
     async () => {
       const { conversationId } = await createConversation(runtime.port, {
         title: "Undated owner todo proof",
       });
+      const trajectories: CapturedTrajectory[] = [];
+      const logTails: Array<{ turnName: string; logTail: string }> = [];
+      const runTrackedTurn = async (
+        input: string,
+        turnName: string,
+      ): Promise<string> => {
+        const priorTrajectoryIds = new Set(
+          (await readOnlyRows(runtime, TRAJECTORY_LEDGER)).map((row) =>
+            String(row.id ?? ""),
+          ),
+        );
+        const wireStartIndex = wireCapture.calls.length;
+        const response = await postLiveConversationMessage(
+          runtime,
+          conversationId,
+          input,
+          turnName,
+        );
+        assertNoProviderIssue(turnName, response, runtime);
+        const trajectory = await waitForTurnTrajectory(
+          runtime,
+          priorTrajectoryIds,
+          input,
+          wireCapture,
+          wireStartIndex,
+        );
+        trajectories.push({ turnName, input, response, ...trajectory });
+        logTails.push({ turnName, logTail: runtime.getLogTail() });
+        return response;
+      };
+
       const todoRequest =
         "Create a personal todo titled Buy oat milk. It has no due date or reminder. Preview it first and do not save until I confirm.";
-      const todoPreview = await postLiveConversationMessage(
-        runtime,
-        conversationId,
+      const todoPreview = await runTrackedTurn(
         todoRequest,
         "undated todo preview",
       );
-      assertNoProviderIssue("undated todo preview", todoPreview, runtime);
 
       const beforeConfirm = await req(
         runtime.port,
@@ -62,44 +413,372 @@ describeIf(suiteEnabled)("Live: undated owner-todo boundary", () => {
       );
       expect(beforeConfirm.status).toBe(200);
       expect(todoPreview).toMatch(/oat milk|todo/i);
-
-      const reminderRequest =
-        "Remind me to call Mom, but I have not said when.";
-      const reminderResponse = await postLiveConversationMessage(
+      const definitionRowsAfterPreview = await readOnlyRows(
         runtime,
-        conversationId,
-        reminderRequest,
-        "unscheduled reminder",
+        DEFINITION_LEDGER,
       );
-      assertNoProviderIssue("unscheduled reminder", reminderResponse, runtime);
-      if (!/when|what time|date|day|schedule/i.test(reminderResponse)) {
+      const prematurelySavedTodos = definitionRowsAfterPreview.filter(
+        (row) => row.title === "Buy oat milk",
+      );
+      if (prematurelySavedTodos.length > 0) {
+        await writeLiveEvidence({
+          trajectories,
+          logTails,
+          domain: {
+            failure: "preview_persisted_before_owner_confirmation",
+            todoPreview,
+            prematurelySavedTodos,
+            definitionRowsAfterPreview,
+          },
+        });
         throw new Error(
-          `unscheduled reminder did not ask for timing: ${reminderResponse}\n${runtime.getLogTail()}`,
+          `Todo preview persisted before owner confirmation: ${todoPreview}\n${runtime.getLogTail()}`,
         );
       }
 
+      const confirmRequest =
+        "Yes, save the Buy oat milk todo exactly as previewed.";
+      const todoConfirmation = await runTrackedTurn(
+        confirmRequest,
+        "undated todo confirm",
+      );
+      if (!/oat milk|saved|todo/i.test(todoConfirmation)) {
+        throw new Error(
+          `Todo confirmation returned an unexpected reply: ${todoConfirmation}\n${runtime.getLogTail()}`,
+        );
+      }
+      const confirmationTrajectory = trajectories.at(-1);
+      expect(confirmationTrajectory?.wireCalls.length).toBeGreaterThan(0);
+      const immediateDefinitionRows = await readOnlyRows(
+        runtime,
+        DEFINITION_LEDGER,
+      );
+      if (
+        !immediateDefinitionRows.some((row) => row.title === "Buy oat milk")
+      ) {
+        await writeLiveEvidence({
+          trajectories,
+          logTails,
+          domain: {
+            failure: "confirmation_claimed_saved_without_row",
+            definitionRowsAfterPreview,
+            immediateDefinitionRows,
+          },
+        });
+        throw new Error(
+          `Todo confirmation returned without a durable row: ${todoConfirmation}\nmodels=${JSON.stringify(
+            confirmationTrajectory?.wireCalls
+              .filter(isModelWireCall)
+              .map((call) => parsedWireRequest(call).model),
+          )}\n${runtime.getLogTail()}`,
+        );
+      }
+
+      const savedTodo = await waitForDefinitionByTitle(
+        runtime.port,
+        "Buy oat milk",
+        (entry) =>
+          (entry.definition?.cadence as { kind?: string } | undefined)?.kind ===
+            "unscheduled" && entry.reminderPlan === null,
+      );
+      const savedTodoId = String(savedTodo.definition?.id ?? "");
+      expect(savedTodoId.length).toBeGreaterThan(0);
+      const exactTodo = await req(
+        runtime.port,
+        "GET",
+        `/api/lifeops/definitions/${encodeURIComponent(savedTodoId)}`,
+      );
+      expect(exactTodo.status).toBe(200);
+      expect(exactTodo.data).toMatchObject({
+        definition: {
+          id: savedTodoId,
+          kind: "task",
+          title: "Buy oat milk",
+          status: "active",
+          cadence: { kind: "unscheduled" },
+          reminderPlanId: null,
+          source: "chat",
+        },
+        reminderPlan: null,
+      });
+      expect(exactTodo.data.performance).toEqual({
+        lastCompletedAt: null,
+        lastSkippedAt: null,
+        lastActivityAt: null,
+        totalScheduledCount: 0,
+        totalCompletedCount: 0,
+        totalSkippedCount: 0,
+        totalPendingCount: 0,
+        currentOccurrenceStreak: 0,
+        bestOccurrenceStreak: 0,
+        currentPerfectDayStreak: 0,
+        bestPerfectDayStreak: 0,
+        last7Days: {
+          scheduledCount: 0,
+          completedCount: 0,
+          skippedCount: 0,
+          pendingCount: 0,
+          completionRate: 0,
+          perfectDayCount: 0,
+        },
+        last30Days: {
+          scheduledCount: 0,
+          completedCount: 0,
+          skippedCount: 0,
+          pendingCount: 0,
+          completionRate: 0,
+          perfectDayCount: 0,
+        },
+      });
+      const todoOverview = await req(
+        runtime.port,
+        "GET",
+        "/api/lifeops/overview",
+      );
+      expect(todoOverview.status).toBe(200);
+      const definitionRowsAfterConfirm = await readOnlyRows(
+        runtime,
+        DEFINITION_LEDGER,
+      );
+      const exactPersistedRows = definitionRowsAfterConfirm.filter(
+        (row) => row.id === savedTodoId,
+      );
+      expect(exactPersistedRows).toHaveLength(1);
+      expect(exactPersistedRows[0]).toMatchObject({
+        id: savedTodoId,
+        kind: "task",
+        title: "Buy oat milk",
+        status: "active",
+        reminder_plan_id: null,
+        source: "chat",
+      });
+      expect(JSON.parse(String(exactPersistedRows[0]?.cadence_json))).toEqual({
+        kind: "unscheduled",
+      });
+      const occurrenceRowsAfterConfirm = await readOnlyRows(
+        runtime,
+        OCCURRENCE_LEDGER,
+      );
+      expect(
+        occurrenceRowsAfterConfirm.filter(
+          (row) => row.definition_id === savedTodoId,
+        ),
+      ).toEqual([]);
+      const savedTodoOccurrenceIds = Array.isArray(
+        todoOverview.data.occurrences,
+      )
+        ? todoOverview.data.occurrences
+            .filter(
+              (occurrence: { definitionId?: string }) =>
+                occurrence.definitionId === savedTodoId,
+            )
+            .map((occurrence: { id?: string }) => String(occurrence.id ?? ""))
+        : [];
+      expect(savedTodoOccurrenceIds).toEqual([]);
+
+      const editedTitle = "Book dentist visit";
+      const editPreviewRequest = `Create a personal todo titled ${editedTitle}. It has no due date. Preview it first and do not save until I confirm.`;
+      const editPreview = await runTrackedTurn(
+        editPreviewRequest,
+        "contradictory edit preview",
+      );
+      const beforeEdit = await req(
+        runtime.port,
+        "GET",
+        "/api/lifeops/definitions",
+      );
+      expect(beforeEdit.status).toBe(200);
+
+      const contradictoryEditRequest = "Keep it with no due date, but Friday.";
+      const contradictoryEdit = await runTrackedTurn(
+        contradictoryEditRequest,
+        "contradictory undated edit",
+      );
+      const afterEdit = await req(
+        runtime.port,
+        "GET",
+        "/api/lifeops/definitions",
+      );
+      expect(afterEdit.status).toBe(200);
+      const beforeEditIds = Array.isArray(beforeEdit.data.definitions)
+        ? beforeEdit.data.definitions
+            .map(
+              (entry: { definition?: { id?: string } }) => entry.definition?.id,
+            )
+            .toSorted()
+        : [];
+      const afterEditIds = Array.isArray(afterEdit.data.definitions)
+        ? afterEdit.data.definitions
+            .map(
+              (entry: { definition?: { id?: string } }) => entry.definition?.id,
+            )
+            .toSorted()
+        : [];
+      if (JSON.stringify(afterEditIds) !== JSON.stringify(beforeEditIds)) {
+        const definitionRowsAfterContradictoryEdit = await readOnlyRows(
+          runtime,
+          DEFINITION_LEDGER,
+        );
+        await writeLiveEvidence({
+          trajectories,
+          logTails,
+          domain: {
+            failure: "contradictory_edit_persisted_before_confirmation",
+            editPreview,
+            contradictoryEdit,
+            beforeEditIds,
+            afterEditIds,
+            definitionRowsAfterContradictoryEdit,
+          },
+        });
+        throw new Error(
+          `Contradictory Todo edit changed durable rows before confirmation: ${contradictoryEdit}\n${runtime.getLogTail()}`,
+        );
+      }
+      expect(
+        Array.isArray(afterEdit.data.definitions) &&
+          afterEdit.data.definitions.some(
+            (entry: {
+              definition?: { title?: string; cadence?: { kind?: string } };
+            }) =>
+              entry.definition?.title === editedTitle &&
+              entry.definition.cadence?.kind === "unscheduled",
+          ),
+      ).toBe(false);
+
+      const contradictoryConfirmRequest =
+        "Yes, confirm and save the edited Book dentist visit task now.";
+      const contradictoryConfirmation = await runTrackedTurn(
+        contradictoryConfirmRequest,
+        "contradictory edit confirm",
+      );
+      const contradictoryConfirmTrajectory = trajectories.at(-1);
+      expect(contradictoryConfirmTrajectory?.wireCalls.length).toBeGreaterThan(
+        0,
+      );
+      const definitionRowsAfterContradictoryConfirm = await readOnlyRows(
+        runtime,
+        DEFINITION_LEDGER,
+      );
+      expect(
+        definitionRowsAfterContradictoryConfirm.filter(
+          (row) => row.title === editedTitle,
+        ),
+      ).toEqual([]);
+      const afterContradictoryConfirmation = await req(
+        runtime.port,
+        "GET",
+        "/api/lifeops/definitions",
+      );
+      expect(afterContradictoryConfirmation.status).toBe(200);
+      expect(
+        Array.isArray(afterContradictoryConfirmation.data.definitions) &&
+          afterContradictoryConfirmation.data.definitions.some(
+            (entry: {
+              definition?: { title?: string; cadence?: { kind?: string } };
+            }) =>
+              entry.definition?.title === editedTitle &&
+              entry.definition.cadence?.kind === "unscheduled",
+          ),
+      ).toBe(false);
+
+      const reminderRequest =
+        "Remind me to call Mom, but I have not said when.";
+      const reminderResponse = await runTrackedTurn(
+        reminderRequest,
+        "unscheduled reminder",
+      );
       const afterReminder = await req(
         runtime.port,
         "GET",
         "/api/lifeops/definitions",
       );
       expect(afterReminder.status).toBe(200);
+      const definitionRowsAfterReminder = await readOnlyRows(
+        runtime,
+        DEFINITION_LEDGER,
+      );
+      const reminderAskedForTiming = /when|what time|date|day|schedule/i.test(
+        reminderResponse,
+      );
+      const reminderPreservedRows =
+        JSON.stringify(definitionRowsAfterReminder) ===
+        JSON.stringify(definitionRowsAfterContradictoryConfirm);
+      if (!reminderAskedForTiming || !reminderPreservedRows) {
+        await writeLiveEvidence({
+          trajectories,
+          logTails,
+          domain: {
+            failure: "unscheduled_reminder_invented_timing",
+            reminderRequest,
+            reminderResponse,
+            definitionRowsBeforeReminder:
+              definitionRowsAfterContradictoryConfirm,
+            definitionRowsAfterReminder,
+          },
+        });
+        throw new Error(
+          `unscheduled reminder did not ask for timing: ${reminderResponse}\n${runtime.getLogTail()}`,
+        );
+      }
       const definitions = Array.isArray(afterReminder.data.definitions)
         ? afterReminder.data.definitions
         : [];
-      expect(definitions).toEqual(beforeConfirm.data.definitions);
+      expect(definitions).toEqual(
+        afterContradictoryConfirmation.data.definitions,
+      );
+      expect(definitionRowsAfterReminder).toEqual(
+        definitionRowsAfterContradictoryConfirm,
+      );
+
+      await writeLiveEvidence({
+        trajectories,
+        logTails,
+        domain: {
+          exactTodo: exactTodo.data,
+          todoOverview: todoOverview.data,
+          definitionRowsAfterPreview,
+          definitionRowsAfterConfirm,
+          occurrenceRowsAfterConfirm,
+          definitionRowsAfterContradictoryConfirm,
+          definitionRowsAfterReminder,
+        },
+      });
 
       console.log(
         JSON.stringify(
           {
-            model: "gpt-oss-120b",
             provider: runtime.providerName,
-            input: [todoRequest, reminderRequest],
+            input: [
+              todoRequest,
+              confirmRequest,
+              editPreviewRequest,
+              contradictoryEditRequest,
+              contradictoryConfirmRequest,
+              reminderRequest,
+            ],
             output: {
               todoPreview,
+              todoConfirmation,
+              exactTodo: exactTodo.data,
+              todoOverview: todoOverview.data,
+              savedTodoOccurrenceIds,
+              persistedTodoCount: exactPersistedRows.length,
+              persistedOccurrenceCount: occurrenceRowsAfterConfirm.filter(
+                (row) => row.definition_id === savedTodoId,
+              ).length,
+              trajectoryCount: trajectories.length,
+              llmCallCount: trajectories.reduce(
+                (total, trajectory) => total + trajectory.wireCalls.length,
+                0,
+              ),
+              editPreview,
+              contradictoryEdit,
+              contradictoryConfirmation,
               reminderResponse,
-              definitionsBefore: beforeConfirm.data.definitions,
+              definitionsBeforeConfirm: beforeConfirm.data.definitions,
               definitionsAfter: definitions,
+              runtimeLogTail: runtime.getLogTail(),
             },
           },
           null,
@@ -107,6 +786,8 @@ describeIf(suiteEnabled)("Live: undated owner-todo boundary", () => {
         ),
       );
     },
-    LIVE_CHAT_TEST_TIMEOUT_MS,
+    // Six separately tracked turns must leave room for evidence serialization
+    // when the live provider applies sustained backpressure.
+    LIVE_CHAT_TEST_TIMEOUT_MS * 3,
   );
 });


### PR DESCRIPTION
# Relates to

Fixes #20026.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works without reading the code from the
      exact-head live Cerebras trajectory, backend logs, and real PGlite rows.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/slopdotcash@332dc64deec632ac7746f237f0f30d4aad6050d5:skills/contribute-to-eliza/SKILL.md`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact current `origin/develop`; zero conflicts and no open
      PR touches any of the sixteen changed paths.
- [x] `bun run verify` passes post-sync.

# Risks

Medium. This changes multilingual intent authority and deferred-draft state for
LifeOps Todos. The risk is bounded by ordered-directive tests across all eight
locale families, real persistence assertions, and a live-model create/edit/
confirm/reminder proof. It adds no database migration or deployment step.

# Background

## What does this PR do?

- Replaces the duplicated whole-message regex with one canonical ordered,
  locale-aware undated-Todo policy shared by routing, deterministic validation,
  and extraction guidance.
- Accepts explicit undated intent such as `someday`, while later dates,
  weekdays, recurrence, or time clauses win as scheduled intent.
- Rejects negated no-date wording and multilingual contradictions across
  English, Spanish, Portuguese, Chinese, Japanese, Korean, Vietnamese, and
  Tagalog without confusing temporal nouns inside Todo titles for schedules.
- Revalidates deferred edits and writes a durable invalidation tombstone so a
  later bare confirmation cannot resurrect a rejected draft.
- Routes explicit owner Todos deterministically and leaves reminder requests
  without timing on the reminder path, which asks the owner when instead of
  inventing a date.
- Upgrades persistence and live tests to prove the real repository write,
  zero scheduled occurrences, full provider wire requests/responses, completed
  trajectory-ledger rows, and durable domain rows.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No separate documentation change is needed. The canonical extraction guidance
and in-code public policy are updated together, and no public API or operator
workflow changes.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-personal-assistant/src/actions/lib/undated-todo-intent.ts`
2. `plugins/plugin-personal-assistant/src/actions/life.ts`
3. `plugins/plugin-personal-assistant/src/actions/lib/lifeops-deferred-draft.ts`
4. `plugins/plugin-personal-assistant/test/undated-owner-todo.cerebras.live.e2e.test.ts`

## Detailed testing steps

- `bun run verify` — full monorepo verification, 351/351 Turbo tasks.
- Full personal-assistant package suite — 225 files, 1,957 passed, 6
  intentional skips, 0 failures.
- Package build, typecheck, and lint — pass.
- Focused undated policy, handler, deferred-draft, persistence, direct-routing,
  and extraction suites — pass.
- Exact-head live test against direct Cerebras `gemma-4-31b` and the real
  file-backed PGlite runtime — pass with retries disabled.

# Evidence Gate

<!-- evidence-head:12acd9bb23d5ea187b33dd548da2672dfc4fa0f6 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI files or visual surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI files or visual surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this is a runtime/action correction with no rendered UI flow.
<!-- evidence-row:backend-logs -->
- [x] [20150-backend-log-tails.raw.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20150-12acd9bb-backend.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path or client state changed.
<!-- evidence-row:llm-trajectory -->
- [x] [20150-trajectory-review.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20150-12acd9bb-trajectory-summary.json)
<!-- evidence-row:domain-artifacts -->
- [x] [20150-domain-proof.raw.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20150-12acd9bb-domain-proof.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

## Real LLM-call trajectory

Exact-head direct Cerebras `gemma-4-31b` proof with retries disabled. Six user
turns exercise preview, confirmed persistence, contradictory deferred edit,
post-invalidation confirmation, and a reminder missing timing. The attached
wire/trajectory artifacts preserve model requests, raw responses, action
results, timings, and transport outcomes with credentials redacted. All 54
direct provider calls completed with HTTP 200; the final run took 58.4 seconds.

## Backend + frontend logs

The attached backend log tail shows the genuine AgentRuntime, LifeOps services,
repository write, and shutdown path. Frontend logs are N/A because no frontend
surface or request path changed.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI files or visual behavior changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT surface changed.

## Known gaps / failures

No known product gaps. Three diagnostic runs reached the post-assertion evidence
phase but exposed that this six-turn test's explicit five- and ten-minute
budgets could expire under sustained provider backpressure. The test now carries
a fifteen-minute budget; the final exact-head run still disables retries and its
complete artifacts are the evidence attached here.

# Deploy Notes

No database migration, secret, provider configuration, or manual deployment
step. Deploy through the normal `develop` release pipeline.

## Database changes

None.

## Deployment instructions

None beyond the normal release pipeline.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/slopdotcash@332dc64deec632ac7746f237f0f30d4aad6050d5:skills/contribute-to-eliza/SKILL.md
Attribution status: self-reported
— [codex-shared-eliza]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/slopdotcash@332dc64deec632ac7746f237f0f30d4aad6050d5:skills/contribute-to-eliza/SKILL.md"} -->






