### PR TITLE
fix(cloud-shared): app-backup export validates monetization via parseAppMonetizationNumber

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/app-backup-export-validation.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-backup-export-validation.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit test for #20121: AppBackupService.exportApp now validates monetization
+ * fields via parseAppMonetizationNumber, failing closed on NaN/corrupt values.
+ * Pure unit test — no DB required.
+ */
+import { describe, expect, test } from "bun:test";
+import { parseAppMonetizationNumber } from "../app-credit-math";
+
+describe("AppBackupService.exportApp — monetization field validation", () => {
+  test("parseAppMonetizationNumber throws on NaN input", () => {
+    expect(() => parseAppMonetizationNumber("inference_markup_percentage", NaN)).toThrow(
+      /inference_markup_percentage/,
+    );
+    expect(() => parseAppMonetizationNumber("purchase_share_percentage", Number.NaN)).toThrow(
+      /purchase_share_percentage/,
+    );
+  });
+
+  test("parseAppMonetizationNumber throws on Infinity", () => {
+    expect(() => parseAppMonetizationNumber("inference_markup_percentage", Infinity)).toThrow(
+      /inference_markup_percentage/,
+    );
+    expect(() => parseAppMonetizationNumber("purchase_share_percentage", -Infinity)).toThrow(
+      /purchase_share_percentage/,
+    );
+  });
+
+  test("parseAppMonetizationNumber throws on non-numeric strings", () => {
+    expect(() => parseAppMonetizationNumber("inference_markup_percentage", "abc")).toThrow(
+      /inference_markup_percentage/,
+    );
+    expect(() => parseAppMonetizationNumber("purchase_share_percentage", "25junk")).toThrow(
+      /purchase_share_percentage/,
+    );
+  });
+
+  test("parseAppMonetizationNumber accepts valid numbers (including fractional)", () => {
+    // Fractional numbers are accepted (strings with decimals are rejected by regex)
+    expect(
+      parseAppMonetizationNumber("inference_markup_percentage", 25.5, {
+        min: 0,
+        max: 100,
+      }),
+    ).toBe(25.5);
+    expect(
+      parseAppMonetizationNumber("purchase_share_percentage", 40, {
+        min: 0,
+        max: 100,
+      }),
+    ).toBe(40);
+  });
+
+  test("parseAppMonetizationNumber accepts valid decimal strings", () => {
+    expect(
+      parseAppMonetizationNumber("inference_markup_percentage", "25.5", {
+        min: 0,
+        max: 100,
+      }),
+    ).toBe(25.5);
+    expect(
+      parseAppMonetizationNumber("purchase_share_percentage", "40", {
+        min: 0,
+        max: 100,
+      }),
+    ).toBe(40);
+  });
+
+  test("parseAppMonetizationNumber rejects garbage/partial numeric strings", () => {
+    // Garbage and partially-numeric strings fail PLAIN_DECIMAL_RE
+    expect(() => parseAppMonetizationNumber("inference_markup_percentage", "25junk")).toThrow(
+      /inference_markup_percentage/,
+    );
+    expect(() => parseAppMonetizationNumber("purchase_share_percentage", "abc")).toThrow(
+      /purchase_share_percentage/,
+    );
+    expect(() => parseAppMonetizationNumber("inference_markup_percentage", "")).toThrow(
+      /inference_markup_percentage/,
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/app-backup.ts
+++ b/packages/cloud/shared/src/lib/services/app-backup.ts
@@ -13,6 +13,7 @@
 
 import type { App } from "../../db/repositories/apps";
 import { logger } from "../utils/logger";
+import { parseAppMonetizationNumber } from "./app-credit-math";
 import { appCreditsService } from "./app-credits";
 import { appsService } from "./apps";
 
@@ -66,8 +67,16 @@ export class AppBackupService {
       },
       monetization: {
         enabled: app.monetization_enabled,
-        inference_markup_percentage: Number(app.inference_markup_percentage ?? 0),
-        purchase_share_percentage: Number(app.purchase_share_percentage ?? 0),
+        inference_markup_percentage: parseAppMonetizationNumber(
+          "inference_markup_percentage",
+          app.inference_markup_percentage ?? 0,
+          { min: 0, max: 100 },
+        ),
+        purchase_share_percentage: parseAppMonetizationNumber(
+          "purchase_share_percentage",
+          app.purchase_share_percentage ?? 0,
+          { min: 0, max: 100 },
+        ),
       },
       automation: {
         discord: app.discord_automation ?? null,


### PR DESCRIPTION
## Summary

Fixes #20121 — AppBackupService.exportApp bypasses monetization-field validation, silently exports NaN.

## Changes

- `packages/cloud/shared/src/lib/services/app-backup.ts`: Replace raw `Number()` conversion with `parseAppMonetizationNumber` for `inference_markup_percentage` and `purchase_share_percentage`
- `packages/cloud/shared/src/lib/services/__tests__/app-backup-export-validation.test.ts`: New focused unit test (6 cases)

## Validation behavior

| Input | Before | After |
|-------|--------|-------|
| `NaN` | Silent `NaN` in backup JSON | **Throws** `CorruptAppMonetizationNumberError` |
| `Infinity` | Silent `Infinity` | **Throws** |
| `\"abc\"` | Silent `NaN` | **Throws** |
| `\"25junk\"` | Silent `NaN` | **Throws** |
| `""` (empty) | Silent `0` | **Throws** |
| `25` (valid) | `25` | `25` |
| `\"25.5\"` (valid decimal) | `25.5` | `25.5` |
| `40` (valid) | `40` | `40` |

Reuses the exact same validator (`parseAppMonetizationNumber`) that the credit-charging pipeline already uses for these fields (`app-credit-math.ts`), so export now fails closed on the same corrupt input the rest of the system already rejects.

## Checks

- `bun test` — 6/6 pass (unit test)
- `biome check` — clean
- `typecheck` — clean

## Evidence

node scripts/pr-evidence.mjs rows 20151 \
  --row "backend-logs=N/A - deterministic unit tests; test output shown in PR checks" \
  --row "before-screenshots=N/A - no UI change; pure validation/boundary fix" \
  --row "after-screenshots=N/A - no UI change; pure validation/boundary fix" \
  --row "walkthrough-video=N/A - no UI change; pure validation/boundary fix" \
  --row "frontend-logs=N/A - no UI change; pure validation/boundary fix" \
  --row "llm-trajectory=N/A - deterministic unit tests; no LLM execution" \
  --row "domain-artifacts=N/A - pure validation fix; no domain artifacts"

---

## Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `z.ai/glm-5.2`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@1f00ce3dc36d38be482e13b9b542fc8c3c1ac784:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- evidence-head:1f00ce3dc36d38be482e13b9b542fc8c3c1ac784 -->

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic unit tests; test output shown in PR checks

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI change; pure validation/boundary fix

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI change; pure validation/boundary fix

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI change; pure validation/boundary fix

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no UI change; pure validation/boundary fix

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic unit tests; no LLM execution

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure validation fix; no domain artifacts
