### PR TITLE
fix(core): parse Authorization credentials completely

### DIFF
--- a/packages/core/src/security/guarded-stream.test.ts
+++ b/packages/core/src/security/guarded-stream.test.ts
@@ -133,10 +133,11 @@ const VALID_SSN = "123 45 6789";
 const PEM_KEY =
 	"-----BEGIN PRIVATE KEY-----\nMIIBVAIBADANBgkqhkiG9w0BAQEFAASCAT4w\nggE6AgEAAkEAqwArU3\n-----END PRIVATE KEY-----";
 
-// HTTP Basic auth: base64("user:password123"). redact.ts covers Bearer but not
-// Basic, so this only redacts via the `basic-auth-header` detector's
-// `Authorization:` anchor — the anchor the streaming guard must hold intact.
+// HTTP Basic auth: base64("user:password123"). The streaming guard must retain
+// the Authorization anchor with its credential until the line boundary because
+// neither detector can classify a partial field value safely.
 const BASIC_B64 = "dXNlcjpwYXNzd29yZDEyMw==";
+const AUTH_PARAM_SECRET = ["private", "-user"].join("");
 const LONG_ANCHORED_VALUE = Array.from(
 	{ length: 96 },
 	(_, i) => `tok${i.toString(36)}A1b2C3d4E5f6`,
@@ -334,6 +335,43 @@ async function buildFixtures(): Promise<Fixture[]> {
 			rawSecrets: [BASIC_B64],
 			rawPii: [],
 			equivalence: true,
+		},
+		{
+			name: "HTTP Basic auth token followed by one diagnostic word",
+			text: `Header Authorization: Basic ${BASIC_B64} trailing`,
+			factory: async () => ({ secret: secretSessionWith(), pii: null }),
+			rawSecrets: [BASIC_B64],
+			rawPii: [],
+			equivalence: true,
+		},
+		{
+			name: "extension auth-param list with complete token grammar",
+			text: `Header Authorization: 1Custom 1user=${AUTH_PARAM_SECRET}, realm="restricted,zone"\nDone.`,
+			factory: async () => ({ secret: secretSessionWith(), pii: null }),
+			rawSecrets: [AUTH_PARAM_SECRET, "restricted,zone"],
+			rawPii: [],
+			equivalence: true,
+		},
+		{
+			name: "malformed auth-param assignment fails toward masking",
+			text: `Header Authorization: Digest username="${AUTH_PARAM_SECRET}, realm=restricted\nDone.`,
+			factory: async () => ({ secret: secretSessionWith(), pii: null }),
+			rawSecrets: [AUTH_PARAM_SECRET, "restricted"],
+			rawPii: [],
+			equivalence: true,
+		},
+		{
+			name: "long extension auth-param list beyond the opener window",
+			text: `Header Proxy-Authorization: Custom _user="${LONG_ANCHORED_VALUE}", realm=restricted\nDone.`,
+			factory: async () => ({ secret: secretSessionWith(), pii: null }),
+			rawSecrets: [LONG_ANCHORED_VALUE, "restricted"],
+			rawPii: [],
+			equivalence: true,
+			chunkings: (text) =>
+				targetedLongChunkings(text, [
+					"Proxy-Authorization:",
+					LONG_ANCHORED_VALUE,
+				]),
 		},
 		{
 			name: "long HTTP Basic auth header (anchor more than opener window behind value)",

--- a/packages/core/src/security/guarded-stream.ts
+++ b/packages/core/src/security/guarded-stream.ts
@@ -16,9 +16,11 @@
  * GuardedStreamScanner.findSafeCut} therefore holds back (a) a base window sized to
  * the longest known value/surrogate so a partial known value at the tail is never
  * emitted, and (b) any trailing region that matches an in-progress multi-token
- * secret/PII shape. Held text is released as soon as a following token proves the
- * shape complete, or at {@link GuardedStreamScanner.flush} (end of stream), whose
- * held-tail-drop-on-abort behaviour matches the old buffer exactly.
+ * secret/PII shape. An Authorization line is held from its field-name anchor to
+ * the line boundary because its RFC token/auth-param classification cannot be
+ * known from a partial chunk. Held text is released as soon as a following token
+ * proves the shape complete, or at {@link GuardedStreamScanner.flush} (end of
+ * stream), whose held-tail-drop-on-abort behaviour matches the old buffer exactly.
  *
  * Accepted semantic delta vs whole-buffer substitution: streaming cannot
  * retro-redact. A secret whose ONLY detectable form appears late in the reply
@@ -71,23 +73,17 @@ const OPENER_PATTERNS: readonly RegExp[] = [
 	// (so the buffer detector `"key"\s*:\s*"([^"]+)"` matches the emitted piece)
 	// rather than inside a multi-word value.
 	/"(?:apiKey|token|secret|password|passwd|accessToken|refreshToken|mnemonic|seedPhrase|passphrase|privateKey|credential)"\s*(?::\s*(?:"[^"]*(?:"[^\s]*)?)?)?$/i,
-	// Authorization Bearer/Basic header, token still arriving.
-	/(?:Authorization\s*[:=]\s*)?(?:Bearer|Basic)\s+[A-Za-z0-9._+/=-]*$/i,
-	// `Authorization` anchor held through the ENTIRE streaming header, from before
-	// the scheme discriminator arrives (`Authorization:`), across a partial scheme
-	// (`Authorization: B`), and through the value (`Authorization: Basic <b64>`).
-	// The `basic-auth-header` detector needs the `Authorization:` anchor to fire;
-	// without this hold `snapToWhitespace` releases `"Authorization: "` the moment it
-	// ends in a space — orphaning the later `"Basic <b64>"`, which has no anchor and
-	// is emitted in the clear. The scheme is optional and the value charclass is
-	// letter-inclusive, so a partial scheme is covered; a trailing whitespace ends
-	// the value and releases the whole header contiguously for detection. (redact.ts
-	// carries a standalone `\bBearer …` pattern, so Bearer survives without an
-	// anchor; Basic has none — hence the anchored hold rather than a Basic pattern.)
-	/\bAuthorization\s*[:=]?\s*(?:Bearer|Basic)?\s*[A-Za-z0-9._+/=-]*$/i,
 	// CLI credential flag, value still arriving.
 	/--(?:api[-_]?key|token|secret|password|passwd)(?:[=\s]+(?:["']?[^\s"']*)?)?$/i,
 ];
+
+// A partial line cannot distinguish token68 padding from RFC auth-param BWS.
+// Hold the field name (including whitespace before its delimiter) and every
+// byte after the delimiter until CR/LF or flush gives the shared detector the
+// complete credential. The alternative without a delimiter protects a chunk
+// ending at `Authorization ` without trapping ordinary following prose.
+const AUTHORIZATION_HEADER_TAIL =
+	/\b(?:Proxy-)?Authorization(?:[ \t]*(?::|=)[^\r\n]*|[ \t]*)$/i;
 
 /** Safety bound on the grouped-number left-walk; hitting it holds everything (safe). */
 const GROUPED_RUN_SCAN_LIMIT = 512;
@@ -400,14 +396,22 @@ export class GuardedStreamScanner {
 
 	/**
 	 * If the prefix ending at `cut` ends with an in-progress secret opener (`KEY=`,
-	 * JSON field, `Bearer`/`Basic`, CLI flag), hold from the opener start. The fast
-	 * path scans the bounded suffix; the long-token fallback extends left from the
-	 * current value token so a 512+ byte value cannot orphan its anchor before the
-	 * detector sees the complete assignment/header/flag.
+	 * JSON field, CLI flag), hold from the opener start. Authorization is handled
+	 * from the current line's true start before the bounded scan because auth-param
+	 * lists can exceed the suffix window and contain whitespace. The long-token
+	 * fallback extends left from other current values so a 512+ byte token cannot
+	 * orphan its anchor before the detector sees the complete assignment or flag.
 	 */
 	private openerTailStart(cut: number): number {
 		const p = this.pending;
 		const end = Math.min(cut, p.length);
+		const lineStart =
+			Math.max(p.lastIndexOf("\n", end - 1), p.lastIndexOf("\r", end - 1)) + 1;
+		const authorization = AUTHORIZATION_HEADER_TAIL.exec(
+			p.slice(lineStart, end),
+		);
+		if (authorization) return lineStart + authorization.index;
+
 		const matchStart = (base: number): number => {
 			const tail = p.slice(base, end);
 			let start = end;

--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -326,6 +326,16 @@ describe("redactSensitiveText (pattern detection)", () => {
 		expect(redactSensitiveText("Authorization: abcdefgh abcdefgh")).toBe(
 			"Authorization: abcdefgh ***",
 		);
+		for (const whitespace of [" ", "\t"]) {
+			expect(
+				redactSensitiveText(`Authorization: abcdefgh abcdefgh${whitespace}`),
+			).toBe(`Authorization: abcdefgh ***${whitespace}`);
+			expect(
+				redactSensitiveText(
+					`Proxy-Authorization: abcdefgh abcdefgh${whitespace}`,
+				),
+			).toBe(`Proxy-Authorization: abcdefgh ***${whitespace}`);
+		}
 	});
 
 	it("masks AWS credential identifiers without storing scanner fixtures", () => {

--- a/packages/core/src/security/redact.test.ts
+++ b/packages/core/src/security/redact.test.ts
@@ -182,6 +182,109 @@ describe("redactSensitiveText (pattern detection)", () => {
 		}
 	});
 
+	it("accepts the complete RFC token grammar for schemes and auth-param names", () => {
+		const secret = ["private", "-user"].join("");
+		const tokenInitials = [
+			"0",
+			"!",
+			"#",
+			"$",
+			"%",
+			"&",
+			"'",
+			"*",
+			"+",
+			"-",
+			".",
+			"^",
+			"_",
+			"`",
+			"|",
+			"~",
+		];
+		for (const initial of tokenInitials) {
+			const input = `Authorization: ${initial}Custom ${initial}user=${secret}, realm=restricted`;
+			const output = redactSensitiveText(input);
+			expect(output).not.toContain(secret);
+			expect(output).not.toContain("restricted");
+		}
+		const proxy = redactSensitiveText(
+			`Proxy-Authorization: _Custom 1user=${secret}, realm=restricted`,
+		);
+		expect(proxy).not.toContain(secret);
+		expect(proxy).not.toContain("restricted");
+	});
+
+	it("masks token and quoted auth-param values for every BWS permutation", () => {
+		const secret = ["private", "-user"].join("");
+		const assignments = [
+			`username=${secret}`,
+			`username =${secret}`,
+			`username= ${secret}`,
+			`username = ${secret}`,
+			`username="${secret}"`,
+			`username ="${secret}"`,
+			`username= "${secret}"`,
+			`username = "${secret}"`,
+		];
+		for (const assignment of assignments) {
+			const output = redactSensitiveText(
+				`Authorization: Digest ${assignment}, realm=restricted`,
+			);
+			expect(output).not.toContain(secret);
+			expect(output).not.toContain("restricted");
+		}
+		const tokenValue = "!#$%&'*+-.^_`|~09AZaz";
+		const tokenOutput = redactSensitiveText(
+			`Authorization: Digest username=${tokenValue}, realm=restricted`,
+		);
+		expect(tokenOutput).not.toContain(tokenValue);
+		expect(tokenOutput).not.toContain("restricted");
+	});
+
+	it("parses quoted commas and escaped quotes inside auth-param values", () => {
+		const secret = ["private", ",zone", '\\"two'].join("");
+		const output = redactSensitiveText(
+			`Authorization: Digest username="${secret}", realm="restricted,west"`,
+		);
+		expect(output).not.toContain(secret);
+		expect(output).not.toContain("restricted,west");
+	});
+
+	it("tolerates empty list elements without exposing auth-param values", () => {
+		const secret = ["private", "-user"].join("");
+		const output = redactSensitiveText(
+			`Authorization: Digest , , username=${secret},, realm=restricted,`,
+		);
+		expect(output).not.toContain(secret);
+		expect(output).not.toContain("restricted");
+	});
+
+	it("fails toward masking for a malformed auth-param assignment", () => {
+		const secret = ["private", "-user"].join("");
+		const output = redactSensitiveText(
+			`Authorization: Digest username="${secret}, realm=restricted`,
+		);
+		expect(output).not.toContain(secret);
+		expect(output).not.toContain("restricted");
+	});
+
+	it("masks only a Basic token68 value when diagnostic prose follows", () => {
+		const tokens = [
+			["dXNlcjpwYXNzd2", "9yZDEyMw="].join(""),
+			["dXNlcjpwYXNz", "d29yZDEyMw=="].join(""),
+		];
+		for (const token of tokens) {
+			for (const prose of ["trailing", "trailing diagnostic prose"]) {
+				const output = redactSensitiveText(
+					`Authorization: Basic ${token} ${prose}`,
+				);
+				expect(output).not.toContain(token);
+				expect(output.endsWith(` ${prose}`)).toBe(true);
+			}
+		}
+	});
+
 	it("keeps token68 padding out of the auth-param branch for both padding widths", () => {
 		// One- and two-"=" padded token68 credentials followed by prose: the
 		// auth-param branch must not consume the prose to end-of-line (that

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -47,8 +47,8 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
 	// short service values in env-style `*_AUTHORIZATION` output.
 	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*Bearer\s+([A-Za-z0-9._\-+=/~]+)`,
 	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*Basic[ \t]+(${HTTP_TOKEN68_PATTERN})(?=[ \t]|[\r\n]|$)`,
-	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*(${HTTP_TOKEN_PATTERN})[ \t]+(${HTTP_AUTH_PARAM_LIST_PATTERN})${HTTP_BWS_PATTERN}(?=[\r\n]|$)`,
-	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*(${HTTP_TOKEN_PATTERN})[ \t]+(${HTTP_TOKEN68_PATTERN})${HTTP_BWS_PATTERN}(?=[\r\n]|$)`,
+	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*(${HTTP_TOKEN_PATTERN})[ \t]+(${HTTP_AUTH_PARAM_LIST_PATTERN})(?=${HTTP_BWS_PATTERN}(?:[\r\n]|$))`,
+	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*(${HTTP_TOKEN_PATTERN})[ \t]+(${HTTP_TOKEN68_PATTERN})(?=${HTTP_BWS_PATTERN}(?:[\r\n]|$))`,
 	// Once a non-Basic/Bearer credential has the unambiguous `token BWS =`
 	// assignment opener, malformed quoting or a truncated list must fail toward
 	// masking rather than leave a likely credential in diagnostics.

--- a/packages/core/src/security/redact.ts
+++ b/packages/core/src/security/redact.ts
@@ -16,6 +16,16 @@ const DEFAULT_REDACT_KEEP_END = 4;
 // Shorter values could cause false positives
 export const MIN_SECRET_LENGTH = 8;
 
+// RFC 9110 §5.6.2 and §11.2. Keeping these grammar fragments together makes
+// Authorization classification one authority for both direct redaction and
+// SecretSwapSession, which compiles this module's exported default patterns.
+const HTTP_TOKEN_PATTERN = "[!#$%&'*+\\-.^_`|~0-9A-Za-z]+";
+const HTTP_BWS_PATTERN = String.raw`[ \t]*`;
+const HTTP_QUOTED_STRING_PATTERN = String.raw`"(?:[\t\x20\x21\x23-\x5B\x5D-\x7E\x80-\xFF]|\\[\t\x20-\x7E\x80-\xFF])*"`;
+const HTTP_AUTH_PARAM_PATTERN = `${HTTP_TOKEN_PATTERN}${HTTP_BWS_PATTERN}=${HTTP_BWS_PATTERN}(?:${HTTP_TOKEN_PATTERN}|${HTTP_QUOTED_STRING_PATTERN})`;
+const HTTP_AUTH_PARAM_LIST_PATTERN = `(?:,${HTTP_BWS_PATTERN})*${HTTP_AUTH_PARAM_PATTERN}(?:${HTTP_BWS_PATTERN},${HTTP_BWS_PATTERN}(?:${HTTP_AUTH_PARAM_PATTERN})?)*`;
+const HTTP_TOKEN68_PATTERN = String.raw`[A-Za-z0-9._~+/\-]+={0,}`;
+
 /**
  * Default patterns for detecting sensitive data.
  * Matches common formats for API keys, tokens, passwords, etc.
@@ -27,28 +37,22 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
 	String.raw`"(?:apiKey|token|secret|password|passwd|accessToken|refreshToken|mnemonic|seedPhrase|passphrase|privateKey|credential)"\s*:\s*"([^"]+)"`,
 	// CLI flags (space-separated and --flag=value forms).
 	String.raw`--(?:api[-_]?key|token|secret|password|passwd)(?:\s+|=)(["']?)([^\s"']+)\1`,
-	// Authorization headers. RFC 7235 credentials are either one token68 value
-	// or a comma-separated auth-param list. Match the complete credential
-	// remainder rather than naming schemes: Basic, Digest, Proxy-Authorization,
-	// and extension schemes all carry reusable authentication material. The
-	// line boundary prevents an invalid prose sentence such as
-	// "Authorization: required for this endpoint" from being partially masked.
-	// Bearer keeps its floor-free rule for compatibility with short service
-	// values in env-style `*_AUTHORIZATION` output.
-	// The auth-param lookahead must accept RFC 9110 BWS around "=" for both
-	// quoted and unquoted values while never letting token68 "=" padding
-	// ("Basic dXNlcjpw...Mw==" or a single "=" before prose) enter the branch —
-	// otherwise the rule consumes trailing prose to end-of-line and diverges
-	// from the streaming scanner's value-exact redaction (guarded-stream
-	// split-equivalence). The structural distinguisher: auth-param BWS appears
-	// BEFORE the "=" (`name = value`), while padding is always glued to its
-	// token — so a glued "=" accepts an immediate value char, a quoted value,
-	// or one complete unquoted token followed by a comma/end-of-line. That last
-	// boundary preserves valid `name= value` BWS without treating the first word
-	// of `token68= trailing prose` as a parameter value.
+	// Authorization credentials are either one token68 value or a complete
+	// comma-separated auth-param list. Basic is classified first because its
+	// trailing `=` is token68 padding, not an auth-param assignment; this also
+	// lets diagnostic prose follow a Basic credential without being swallowed.
+	// Extension schemes then use the complete RFC token/quoted-string grammar.
+	// Line boundaries keep invalid prose such as "Authorization: required for
+	// this endpoint" unchanged. Bearer retains its floor-free compatibility for
+	// short service values in env-style `*_AUTHORIZATION` output.
 	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*Bearer\s+([A-Za-z0-9._\-+=/~]+)`,
-	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z][A-Za-z0-9-]*)[ \t]+((?=[A-Za-z][A-Za-z0-9!#$%&'*+.^_|~-]*(?:=(?:[^=\s]|[ \t]+"|[ \t]+[^=\s,]+(?=[ \t]*(?:,|$)))|[ \t]+=[ \t]*[^=\s]))[^\r\n]+)(?=[\r\n]|$)`,
-	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z][A-Za-z0-9-]*)[ \t]+([A-Za-z0-9._~+/\-]{8,}={0,})(?=[\r\n]|$)`,
+	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*Basic[ \t]+(${HTTP_TOKEN68_PATTERN})(?=[ \t]|[\r\n]|$)`,
+	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*(${HTTP_TOKEN_PATTERN})[ \t]+(${HTTP_AUTH_PARAM_LIST_PATTERN})${HTTP_BWS_PATTERN}(?=[\r\n]|$)`,
+	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*(${HTTP_TOKEN_PATTERN})[ \t]+(${HTTP_TOKEN68_PATTERN})${HTTP_BWS_PATTERN}(?=[\r\n]|$)`,
+	// Once a non-Basic/Bearer credential has the unambiguous `token BWS =`
+	// assignment opener, malformed quoting or a truncated list must fail toward
+	// masking rather than leave a likely credential in diagnostics.
+	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*(?!(?:Basic|Bearer)(?:[ \t]|$))(${HTTP_TOKEN_PATTERN})[ \t]+((?=${HTTP_TOKEN_PATTERN}${HTTP_BWS_PATTERN}=)[^\r\n]+)(?=[\r\n]|$)`,
 	String.raw`(?:Proxy-)?Authorization\s*[:=]\s*([A-Za-z0-9._~+/\-]{18,}={0,})(?=[\r\n]|$)`,
 	String.raw`\bBearer\s+([A-Za-z0-9._\-+=]{18,})\b`,
 	// URI userinfo. Mask the complete userinfo component (user:password,


### PR DESCRIPTION
# Relates to

Closes #20152.

- [x] This PR targets `develop` and is rebased onto exact `origin/develop@7d925bef1f80aa1a2194743cf9658e5880248bc3` with zero conflicts.
- [x] `bun install --frozen-lockfile --ignore-scripts` and `bun run verify` passed after sync.
- [x] The synthetic Authorization matrix and stream-equivalence tests below let a reviewer confirm the repair without exercising any real credential.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/slopdotcash@332dc64deec632ac7746f237f0f30d4aad6050d5:skills/contribute-to-eliza/SKILL.md`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop@7d925bef1f80aa1a2194743cf9658e5880248bc3`; zero conflicts, and range-diff against the prior candidate is byte-equivalent.
- [x] `bun run verify` passed post-sync: 351/351 Turbo tasks and 8,234 test files scanned with zero focused/orphaned skips.
- [x] The final candidate includes trailing SP/HTAB regressions for repeated extension-scheme credentials; the credential capture remains the exact replacement tail.

# Risks

Medium, security-sensitive but narrowly bounded. The change replaces overlapping Authorization lookaheads with one RFC-derived grammar shared by direct redaction and `SecretSwapSession`, and makes streaming hold an incomplete Authorization line until it can be classified. Valid auth-param and token68 credentials are masked; malformed assignment-shaped credentials deliberately fail toward masking. Ordinary non-credential prose remains unchanged.

# Background

## What does this PR do?

The prior Authorization redaction repair was merged immediately before its terminal security HOLD arrived. That merge still leaked valid RFC 9110 auth-param lists when a scheme or parameter name began with a digit or token punctuation, and it over-redacted a padded Basic token followed by one diagnostic word.

This repair:

- implements the complete RFC token, quoted-string, BWS, auth-param-list, and token68 grammar in the existing default redaction authority;
- classifies Basic token68 before auth-param assignments so padding never consumes following diagnostic prose;
- fails toward masking once a malformed non-Basic/Bearer assignment opener is unambiguous;
- retains incomplete `Authorization` and `Proxy-Authorization` lines in the streaming scanner until CR/LF or flush, including lists longer than the prior 512-byte opener window;
- proves direct-buffer and every-split/per-character stream equivalence across the adversarial matrix.

## What kind of change is this?

Bug fix (security hardening, non-breaking).

# Documentation changes needed?

No public documentation change is required. The corrected RFC and streaming invariants are documented at the implementation boundary and pinned by tests.

# Testing

## Where should a reviewer start?

1. `packages/core/src/security/redact.test.ts` — complete token-initial, BWS, quoting, malformed-input, and Basic-padding matrix.
2. `packages/core/src/security/guarded-stream.test.ts` — every split position, per-character chunks, malformed lists, extension schemes, and >512-byte headers.
3. `packages/core/src/security/redact.ts` and `guarded-stream.ts` — single shared redaction grammar and single streaming hold invariant; no parallel parser or wrapper.

## Detailed testing steps

- `bunx vitest run src/security --coverage=false` — **32 files / 494 tests passed** on exact head.
- `bun run --cwd packages/core test` — **532 files / 6,125 tests passed**, 2 files and 3 tests intentionally skipped.
- `bun run --cwd packages/core typecheck` — passed.
- `bun run --cwd packages/core build` — Node/browser/edge/testing bundles, declarations, and packed `@elizaos/core/edge` import proof passed.
- `bunx @biomejs/biome check <four exact paths>` — passed.
- `git diff --check` — passed.
- `bun run verify` — **351/351 Turbo tasks passed**; anti-larp scanned **8,234 files** with zero focused/orphaned skips.
- Adversarial ~100k-character malformed Authorization probes completed in 18ms/2ms/2ms; no regex hang.
- The documented `audit:error-policy-ratchet` script is absent on this exact develop; a manual touched-file scan found no new empty catch or server `console.*` use.

# Evidence Gate

<!-- evidence-head:0215bee60b5c9430e1b770bfdcf87e12402fdc6b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI or visual source changed; this is a Core text-redaction boundary.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI or visual source changed; exact synthetic outputs and stream equivalence are the applicable proof.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - there is no user-interface flow for the security parser.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend transport or service behavior changed; the real exported Core redactor and streaming scanner are exercised directly.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend source, network request, or client state changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, planner, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB row, memory, scheduled task, wallet state, or generated domain artifact is produced by a pure redaction function.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic Core security parsing only; invoking a model would not exercise the changed authority.

## Backend + frontend logs

N/A - no transport boundary or frontend changed. The exact-source security and full-package test summaries are recorded in **Testing**.

## Screenshots (before / after) + video walkthrough

N/A - no UI surface changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT surface changed.

## Known gaps / failures

No known product gap. `audit:error-policy-ratchet` is not defined on the exact base; the repository-wide `bun run verify`, exact Biome/diff checks, and manual touched-file ratchet are green.

# Deploy Notes

No migration, secret, configuration, or manual deployment step. Ship through the normal `develop` release pipeline after independent security review.

## Database changes

None.

## Deployment instructions

None beyond the normal release pipeline.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/slopdotcash@332dc64deec632ac7746f237f0f30d4aad6050d5:skills/contribute-to-eliza/SKILL.md
Attribution status: self-reported
— [root-redact-auth-param-parser]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/slopdotcash@332dc64deec632ac7746f237f0f30d4aad6050d5:skills/contribute-to-eliza/SKILL.md"} -->

