### PR TITLE
fix(ui): align shell fixtures with core browser stub

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/capture-default-notifications.mjs
+++ b/packages/ui/src/components/shell/__e2e__/capture-default-notifications.mjs
@@ -16,6 +16,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 import { chromium } from "playwright";
+import { FILE_FIXTURE_BOOTSTRAP } from "../../../testing/e2e-runner/fixture-bundle.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const outDir = join(here, "output-notifications");
@@ -141,7 +142,7 @@ const html = `<!doctype html><html><head><meta charset="utf-8">
     repeating-linear-gradient(120deg, rgba(255,255,255,0.06) 0 1px, transparent 1px 24px),
     repeating-linear-gradient(30deg, rgba(255,255,255,0.05) 0 1px, transparent 1px 24px);
   background-attachment:fixed;}</style>
-<script>window.process=window.process||{env:{NODE_ENV:"production"},platform:"browser",cwd:function(){return "/"}};</script>
+<script>${FILE_FIXTURE_BOOTSTRAP}</script>
 </head><body><div id="root"></div><script>${js}</script></body></html>`;
 const htmlPath = join(outDir, "notifications.html");
 await writeFile(htmlPath, html);

--- a/packages/ui/src/components/shell/__e2e__/capture-no-provider-evidence.mjs
+++ b/packages/ui/src/components/shell/__e2e__/capture-no-provider-evidence.mjs
@@ -22,6 +22,7 @@ import {
   stubElizaCore,
   stubNodeBuiltins,
 } from "../../../testing/e2e-runner/esbuild-stubs.ts";
+import { FILE_FIXTURE_BOOTSTRAP } from "../../../testing/e2e-runner/fixture-bundle.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, "..", "..", "..", "..", "..", "..");
@@ -44,7 +45,7 @@ const result = await build({
 const js = result.outputFiles[0].text;
 const html = `<!doctype html><html><head><meta charset="utf-8"><title>no-provider evidence</title>
 <script src="https://cdn.tailwindcss.com"></script>
-<script>window.process=window.process||{env:{NODE_ENV:"production"},platform:"browser",cwd:function(){return "/"}};</script>
+<script>${FILE_FIXTURE_BOOTSTRAP}</script>
 <style>html,body{margin:0;height:100%;background:#0a0d16}</style>
 </head><body><div id="root"></div><script>${js}</script></body></html>`;
 const htmlPath = join(outDir, "no-provider.html");

--- a/packages/ui/src/components/shell/__e2e__/capture-no-provider-evidence.mjs
+++ b/packages/ui/src/components/shell/__e2e__/capture-no-provider-evidence.mjs
@@ -14,11 +14,14 @@
  */
 
 import { mkdir, writeFile } from "node:fs/promises";
-import { builtinModules } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 import { chromium } from "playwright";
+import {
+  stubElizaCore,
+  stubNodeBuiltins,
+} from "../../../testing/e2e-runner/esbuild-stubs.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, "..", "..", "..", "..", "..", "..");
@@ -26,76 +29,6 @@ const evidenceDir = join(repoRoot, "test-results", "evidence");
 await mkdir(evidenceDir, { recursive: true });
 const outDir = join(here, "output");
 await mkdir(outDir, { recursive: true });
-
-// --- esbuild stubs (mirror run-chat-sheet-e2e.mjs) --------------------------
-const stubElizaCore = {
-  name: "stub-eliza-core",
-  setup(b) {
-    b.onResolve({ filter: /^@elizaos\/core$/ }, (args) => ({
-      path: args.path,
-      namespace: "eliza-core-stub",
-    }));
-    b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
-      contents: `
-        const noop = new Proxy(() => noop, { get: () => noop });
-        // The wake/provision path (client-cloud.ts) subclasses the real
-        // ElizaError; esbuild's ESM interop copies only this object's own keys,
-        // so a Proxy fallback would surface undefined here and break the
-        // subclass at evaluation time. Export a real class with core's shape so
-        // the fixture bundle exercises the same error type production does.
-        class ElizaError extends Error {
-          constructor(message, options = {}) {
-            super(
-              message,
-              options.cause !== undefined ? { cause: options.cause } : undefined,
-            );
-            this.name = "ElizaError";
-            this.code = options.code;
-            this.context = options.context;
-            this.severity = options.severity;
-            Object.setPrototypeOf(this, new.target.prototype);
-          }
-        }
-        module.exports = new Proxy(
-          {
-            ElizaError,
-            isElizaError: (v) => v instanceof ElizaError,
-            isViewVisible: () => true,
-            dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])),
-            findInteractionRegions: () => [],
-          },
-          { get: (t, p) => (p in t ? t[p] : noop) },
-        );
-      `,
-      loader: "js",
-    }));
-  },
-};
-const nodeBuiltins = new Set([
-  ...builtinModules,
-  ...builtinModules.map((m) => `node:${m}`),
-]);
-const stubNodeBuiltins = {
-  name: "stub-node-builtins",
-  setup(b) {
-    b.onResolve({ filter: /.*/ }, (args) => {
-      const bare = args.path.replace(/^node:/, "").split("/")[0];
-      if (
-        args.path.startsWith("node:") ||
-        nodeBuiltins.has(args.path) ||
-        builtinModules.includes(bare)
-      ) {
-        return { path: args.path, namespace: "node-stub" };
-      }
-      return null;
-    });
-    b.onLoad({ filter: /.*/, namespace: "node-stub" }, () => ({
-      contents:
-        "const n=()=>noop;const noop=new Proxy(n,{get:()=>noop});module.exports=noop;",
-      loader: "js",
-    }));
-  },
-};
 
 const result = await build({
   entryPoints: [join(here, "chat-sheet-fixture.tsx")],
@@ -105,7 +38,7 @@ const result = await build({
   jsx: "automatic",
   loader: { ".tsx": "tsx", ".ts": "ts" },
   define: { "process.env.NODE_ENV": '"production"' },
-  plugins: [stubElizaCore, stubNodeBuiltins],
+  plugins: [stubElizaCore(), stubNodeBuiltins()],
   write: false,
 });
 const js = result.outputFiles[0].text;

--- a/packages/ui/src/components/shell/__e2e__/record-voice-trajectories.mjs
+++ b/packages/ui/src/components/shell/__e2e__/record-voice-trajectories.mjs
@@ -25,6 +25,7 @@ import {
   stubElizaCore,
   stubNodeBuiltins,
 } from "../../../testing/e2e-runner/esbuild-stubs.ts";
+import { FILE_FIXTURE_BOOTSTRAP } from "../../../testing/e2e-runner/fixture-bundle.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
 // The binary .webm video is generated-locally only (gitignored). Durable PNG
@@ -56,7 +57,7 @@ const result = await build({
 const js = result.outputFiles[0].text;
 const html = `<!doctype html><html><head><meta charset="utf-8"><title>voice trajectories</title>
 <script src="https://cdn.tailwindcss.com"></script>
-<script>window.process=window.process||{env:{NODE_ENV:"production"},platform:"browser",cwd:function(){return "/"}};</script>
+<script>${FILE_FIXTURE_BOOTSTRAP}</script>
 <style>html,body{margin:0;height:100%;background:#0a0d16}</style>
 </head><body><div id="root"></div><script>${js}</script></body></html>`;
 const htmlPath = join(outDir, "voice-trajectories.html");

--- a/packages/ui/src/components/shell/__e2e__/record-voice-trajectories.mjs
+++ b/packages/ui/src/components/shell/__e2e__/record-voice-trajectories.mjs
@@ -17,11 +17,14 @@
  */
 
 import { mkdir, rename, writeFile } from "node:fs/promises";
-import { builtinModules } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 import { chromium } from "playwright";
+import {
+  stubElizaCore,
+  stubNodeBuiltins,
+} from "../../../testing/e2e-runner/esbuild-stubs.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
 // The binary .webm video is generated-locally only (gitignored). Durable PNG
@@ -39,75 +42,6 @@ async function snap(name) {
   });
 }
 
-// --- Bundle the fixture (same stubs as run-chat-sheet-e2e.mjs) ------------
-const stubElizaCore = {
-  name: "stub-eliza-core",
-  setup(b) {
-    b.onResolve({ filter: /^@elizaos\/core$/ }, (args) => ({
-      path: args.path,
-      namespace: "eliza-core-stub",
-    }));
-    b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
-      contents: `
-        const noop = new Proxy(() => noop, { get: () => noop });
-        // The wake/provision path (client-cloud.ts) subclasses the real
-        // ElizaError; esbuild's ESM interop copies only this object's own keys,
-        // so a Proxy fallback would surface undefined here and break the
-        // subclass at evaluation time. Export a real class with core's shape so
-        // the fixture bundle exercises the same error type production does.
-        class ElizaError extends Error {
-          constructor(message, options = {}) {
-            super(
-              message,
-              options.cause !== undefined ? { cause: options.cause } : undefined,
-            );
-            this.name = "ElizaError";
-            this.code = options.code;
-            this.context = options.context;
-            this.severity = options.severity;
-            Object.setPrototypeOf(this, new.target.prototype);
-          }
-        }
-        module.exports = new Proxy(
-          {
-            ElizaError,
-            isElizaError: (v) => v instanceof ElizaError,
-            isViewVisible: () => true,
-            dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])),
-            findInteractionRegions: () => [],
-          },
-          { get: (t, p) => (p in t ? t[p] : noop) },
-        );
-      `,
-      loader: "js",
-    }));
-  },
-};
-const nodeBuiltins = new Set([
-  ...builtinModules,
-  ...builtinModules.map((m) => `node:${m}`),
-]);
-const stubNodeBuiltins = {
-  name: "stub-node-builtins",
-  setup(b) {
-    b.onResolve({ filter: /.*/ }, (args) => {
-      const bare = args.path.replace(/^node:/, "").split("/")[0];
-      if (
-        args.path.startsWith("node:") ||
-        nodeBuiltins.has(args.path) ||
-        builtinModules.includes(bare)
-      ) {
-        return { path: args.path, namespace: "node-stub" };
-      }
-      return null;
-    });
-    b.onLoad({ filter: /.*/, namespace: "node-stub" }, () => ({
-      contents:
-        "const n=()=>noop;const noop=new Proxy(n,{get:()=>noop});module.exports=noop;",
-      loader: "js",
-    }));
-  },
-};
 const result = await build({
   entryPoints: [join(here, "chat-sheet-fixture.tsx")],
   bundle: true,
@@ -116,7 +50,7 @@ const result = await build({
   jsx: "automatic",
   loader: { ".tsx": "tsx", ".ts": "ts" },
   define: { "process.env.NODE_ENV": '"production"' },
-  plugins: [stubElizaCore, stubNodeBuiltins],
+  plugins: [stubElizaCore(), stubNodeBuiltins()],
   write: false,
 });
 const js = result.outputFiles[0].text;

--- a/packages/ui/src/components/shell/__e2e__/run-chat-scroll-axis-lock-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-scroll-axis-lock-e2e.mjs
@@ -26,11 +26,14 @@
  */
 
 import { mkdir, writeFile } from "node:fs/promises";
-import { builtinModules } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 import { chromium, webkit } from "playwright";
+import {
+  stubElizaCore,
+  stubNodeBuiltins,
+} from "../../../testing/e2e-runner/esbuild-stubs.ts";
 import { touchDragHold } from "../../../testing/real-touch-gestures.ts";
 
 const ENGINE = process.env.ENGINE === "webkit" ? webkit : chromium;
@@ -47,76 +50,6 @@ function assert(cond, msg) {
   return cond;
 }
 
-// --- same bundle stubs as run-chat-scroll-web-e2e.mjs --------------------
-const stubElizaCore = {
-  name: "stub-eliza-core",
-  setup(b) {
-    b.onResolve({ filter: /^@elizaos\/core$/ }, (args) => ({
-      path: args.path,
-      namespace: "eliza-core-stub",
-    }));
-    b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
-      contents: `
-        const noop = new Proxy(() => noop, { get: () => noop });
-        // The wake/provision path (client-cloud.ts) subclasses the real
-        // ElizaError; esbuild's ESM interop copies only this object's own keys,
-        // so a Proxy fallback would surface undefined here and break the
-        // subclass at evaluation time. Export a real class with core's shape so
-        // the fixture bundle exercises the same error type production does.
-        class ElizaError extends Error {
-          constructor(message, options = {}) {
-            super(
-              message,
-              options.cause !== undefined ? { cause: options.cause } : undefined,
-            );
-            this.name = "ElizaError";
-            this.code = options.code;
-            this.context = options.context;
-            this.severity = options.severity;
-            Object.setPrototypeOf(this, new.target.prototype);
-          }
-        }
-        module.exports = new Proxy(
-          {
-            ElizaError,
-            isElizaError: (v) => v instanceof ElizaError,
-            isViewVisible: () => true,
-            dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])),
-            findInteractionRegions: () => [],
-          },
-          { get: (t, p) => (p in t ? t[p] : noop) },
-        );
-      `,
-      loader: "js",
-    }));
-  },
-};
-const nodeBuiltins = new Set([
-  ...builtinModules,
-  ...builtinModules.map((m) => `node:${m}`),
-]);
-const stubNodeBuiltins = {
-  name: "stub-node-builtins",
-  setup(b) {
-    b.onResolve({ filter: /.*/ }, (args) => {
-      const bare = args.path.replace(/^node:/, "").split("/")[0];
-      if (
-        args.path.startsWith("node:") ||
-        nodeBuiltins.has(args.path) ||
-        builtinModules.includes(bare)
-      ) {
-        return { path: args.path, namespace: "node-stub" };
-      }
-      return null;
-    });
-    b.onLoad({ filter: /.*/, namespace: "node-stub" }, () => ({
-      contents:
-        "const n=()=>noop;const noop=new Proxy(n,{get:()=>noop});module.exports=noop;",
-      loader: "js",
-    }));
-  },
-};
-
 const result = await build({
   entryPoints: [join(here, "chat-sheet-fixture.tsx")],
   bundle: true,
@@ -125,7 +58,7 @@ const result = await build({
   jsx: "automatic",
   loader: { ".tsx": "tsx", ".ts": "ts" },
   define: { "process.env.NODE_ENV": '"production"' },
-  plugins: [stubElizaCore, stubNodeBuiltins],
+  plugins: [stubElizaCore(), stubNodeBuiltins()],
   write: false,
 });
 const js = result.outputFiles[0].text;

--- a/packages/ui/src/components/shell/__e2e__/run-chat-scroll-axis-lock-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-scroll-axis-lock-e2e.mjs
@@ -34,6 +34,7 @@ import {
   stubElizaCore,
   stubNodeBuiltins,
 } from "../../../testing/e2e-runner/esbuild-stubs.ts";
+import { FILE_FIXTURE_BOOTSTRAP } from "../../../testing/e2e-runner/fixture-bundle.ts";
 import { touchDragHold } from "../../../testing/real-touch-gestures.ts";
 
 const ENGINE = process.env.ENGINE === "webkit" ? webkit : chromium;
@@ -64,7 +65,7 @@ const result = await build({
 const js = result.outputFiles[0].text;
 const html = `<!doctype html><html><head><meta charset="utf-8"><title>chat scroll axis lock e2e</title>
 <script src="https://cdn.tailwindcss.com"></script>
-<script>window.process=window.process||{env:{NODE_ENV:"production"},platform:"browser",cwd:function(){return "/"}};</script>
+<script>${FILE_FIXTURE_BOOTSTRAP}</script>
 <style>html,body{margin:0;height:100%;background:#0a0d16}</style>
 </head><body><div id="root"></div><script>${js}</script></body></html>`;
 const htmlPath = join(outDir, "chat-scroll-axis-lock.html");

--- a/packages/ui/src/components/shell/__e2e__/run-chat-scroll-web-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-scroll-web-e2e.mjs
@@ -26,6 +26,7 @@ import {
   stubElizaCore,
   stubNodeBuiltins,
 } from "../../../testing/e2e-runner/esbuild-stubs.ts";
+import { FILE_FIXTURE_BOOTSTRAP } from "../../../testing/e2e-runner/fixture-bundle.ts";
 import { touchDragHold } from "../../../testing/real-touch-gestures.ts";
 
 // `ENGINE=webkit` runs the SAME harness under WebKit — the iOS Safari layout
@@ -60,7 +61,7 @@ const result = await build({
 const js = result.outputFiles[0].text;
 const html = `<!doctype html><html><head><meta charset="utf-8"><title>chat scroll web e2e</title>
 <script src="https://cdn.tailwindcss.com"></script>
-<script>window.process=window.process||{env:{NODE_ENV:"production"},platform:"browser",cwd:function(){return "/"}};</script>
+<script>${FILE_FIXTURE_BOOTSTRAP}</script>
 <style>html,body{margin:0;height:100%;background:#0a0d16}</style>
 </head><body><div id="root"></div><script>${js}</script></body></html>`;
 const htmlPath = join(outDir, "chat-scroll-web.html");

--- a/packages/ui/src/components/shell/__e2e__/run-chat-scroll-web-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-scroll-web-e2e.mjs
@@ -18,11 +18,14 @@
  */
 
 import { mkdir, writeFile } from "node:fs/promises";
-import { builtinModules } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 import { chromium, webkit } from "playwright";
+import {
+  stubElizaCore,
+  stubNodeBuiltins,
+} from "../../../testing/e2e-runner/esbuild-stubs.ts";
 import { touchDragHold } from "../../../testing/real-touch-gestures.ts";
 
 // `ENGINE=webkit` runs the SAME harness under WebKit — the iOS Safari layout
@@ -43,76 +46,6 @@ function assert(cond, msg) {
   return cond;
 }
 
-// --- same bundle stubs as run-chat-sheet-e2e.mjs -------------------------
-const stubElizaCore = {
-  name: "stub-eliza-core",
-  setup(b) {
-    b.onResolve({ filter: /^@elizaos\/core$/ }, (args) => ({
-      path: args.path,
-      namespace: "eliza-core-stub",
-    }));
-    b.onLoad({ filter: /.*/, namespace: "eliza-core-stub" }, () => ({
-      contents: `
-        const noop = new Proxy(() => noop, { get: () => noop });
-        // The wake/provision path (client-cloud.ts) subclasses the real
-        // ElizaError; esbuild's ESM interop copies only this object's own keys,
-        // so a Proxy fallback would surface undefined here and break the
-        // subclass at evaluation time. Export a real class with core's shape so
-        // the fixture bundle exercises the same error type production does.
-        class ElizaError extends Error {
-          constructor(message, options = {}) {
-            super(
-              message,
-              options.cause !== undefined ? { cause: options.cause } : undefined,
-            );
-            this.name = "ElizaError";
-            this.code = options.code;
-            this.context = options.context;
-            this.severity = options.severity;
-            Object.setPrototypeOf(this, new.target.prototype);
-          }
-        }
-        module.exports = new Proxy(
-          {
-            ElizaError,
-            isElizaError: (v) => v instanceof ElizaError,
-            isViewVisible: () => true,
-            dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])),
-            findInteractionRegions: () => [],
-          },
-          { get: (t, p) => (p in t ? t[p] : noop) },
-        );
-      `,
-      loader: "js",
-    }));
-  },
-};
-const nodeBuiltins = new Set([
-  ...builtinModules,
-  ...builtinModules.map((m) => `node:${m}`),
-]);
-const stubNodeBuiltins = {
-  name: "stub-node-builtins",
-  setup(b) {
-    b.onResolve({ filter: /.*/ }, (args) => {
-      const bare = args.path.replace(/^node:/, "").split("/")[0];
-      if (
-        args.path.startsWith("node:") ||
-        nodeBuiltins.has(args.path) ||
-        builtinModules.includes(bare)
-      ) {
-        return { path: args.path, namespace: "node-stub" };
-      }
-      return null;
-    });
-    b.onLoad({ filter: /.*/, namespace: "node-stub" }, () => ({
-      contents:
-        "const n=()=>noop;const noop=new Proxy(n,{get:()=>noop});module.exports=noop;",
-      loader: "js",
-    }));
-  },
-};
-
 const result = await build({
   entryPoints: [join(here, "chat-sheet-fixture.tsx")],
   bundle: true,
@@ -121,7 +54,7 @@ const result = await build({
   jsx: "automatic",
   loader: { ".tsx": "tsx", ".ts": "ts" },
   define: { "process.env.NODE_ENV": '"production"' },
-  plugins: [stubElizaCore, stubNodeBuiltins],
+  plugins: [stubElizaCore(), stubNodeBuiltins()],
   write: false,
 });
 const js = result.outputFiles[0].text;

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-frame-glitch-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-frame-glitch-e2e.mjs
@@ -47,6 +47,7 @@ import {
   stubElizaCore,
   stubNodeBuiltins,
 } from "../../../testing/e2e-runner/esbuild-stubs.ts";
+import { FILE_FIXTURE_BOOTSTRAP } from "../../../testing/e2e-runner/fixture-bundle.ts";
 import { detectFlashes } from "../../../testing/frame-glitch-detect.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -131,7 +132,7 @@ const result = await build({
 const js = result.outputFiles[0].text;
 const html = `<!doctype html><html><head><meta charset="utf-8"><title>chat sheet frame-glitch e2e</title>
 <script src="https://cdn.tailwindcss.com"></script>
-<script>window.process=window.process||{env:{NODE_ENV:"production"},platform:"browser",cwd:function(){return "/"}};</script>
+<script>${FILE_FIXTURE_BOOTSTRAP}</script>
 <style>html,body{margin:0;height:100%;background:#0a0d16}</style>
 </head><body><div id="root"></div><script>${js}</script></body></html>`;
 const htmlPath = join(outDir, "chat-sheet.html");

--- a/packages/ui/src/components/shell/__e2e__/run-home-locale-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-locale-e2e.mjs
@@ -21,6 +21,7 @@ import {
   stubElizaCore,
   stubNodeBuiltins,
 } from "../../../testing/e2e-runner/esbuild-stubs.ts";
+import { FILE_FIXTURE_BOOTSTRAP } from "../../../testing/e2e-runner/fixture-bundle.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const stylesDir = join(here, "../../../styles");
@@ -109,7 +110,7 @@ const html = `<!doctype html><html class="dark"><head><meta charset="utf-8"><tit
 <script src="https://cdn.tailwindcss.com"></script>
 <style>${baseCss}</style><style>${TOKEN_SHIM}</style>
 <style>html,body{margin:0;height:100%}</style>
-<script>window.process=window.process||{env:{NODE_ENV:"production"},platform:"browser",cwd:function(){return "/"}};window.global=window.global||window;</script>
+<script>${FILE_FIXTURE_BOOTSTRAP};window.global=window.global||window;</script>
 </head><body><div id="root"></div><script>${js}</script></body></html>`;
 const htmlPath = join(outDir, "home-locale.html");
 await writeFile(htmlPath, html);

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -198,6 +198,7 @@ const stubElizaCore = {
             isViewVisible: (d, enabled) =>
               isViewKindEnabled(resolveViewKind(d), enabled),
             dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])),
+            stripUnclaimedInteractionMarkup: (text) => text,
             // The attention-mode home notification center (NotificationsHomeCenter)
             // triages each seeded notification by tier, so it needs the REAL
             // priority→tier mapping — a noop reads back "undefined" through

--- a/packages/ui/src/components/shell/__e2e__/run-launcher-loop-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-launcher-loop-e2e.mjs
@@ -37,7 +37,6 @@ import {
   rm,
   writeFile,
 } from "node:fs/promises";
-import { builtinModules } from "node:module";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { chromium } from "playwright";
@@ -217,6 +216,7 @@ const stubElizaCore = {
             isViewVisible: (d, enabled) =>
               isViewKindEnabled(resolveViewKind(d), enabled),
             dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])),
+            stripUnclaimedInteractionMarkup: (text) => text,
             // The fixture defaults to attention mode, so the home notification
             // center (NotificationsHomeCenter) mounts and triages each seeded
             // notification by tier — it needs the REAL priority→tier mapping. A

--- a/packages/ui/src/testing/e2e-runner/esbuild-stubs.test.ts
+++ b/packages/ui/src/testing/e2e-runner/esbuild-stubs.test.ts
@@ -1,19 +1,16 @@
 /**
- * Contract test for the `@elizaos/core` fixture stub: bundles a module that
- * subclasses `ElizaError` through real esbuild with `stubElizaCore()`, then
- * evaluates the output. The stub replaces core's Node graph, but any symbol a
- * fixture actually *uses at evaluation time* must be a working implementation —
- * a Proxy fallback surfaces `undefined` through esbuild's ESM interop, and
- * `class … extends undefined` crashes the whole bundle at load. `client-cloud.ts`
- * subclasses `ElizaError`, so the stub must export a real one rather than force
- * production code to guard its own base class.
+ * Contract tests for the shared shell-fixture stubs bundle representative core
+ * and Node built-in imports through real esbuild, then evaluate the browser
+ * output. Any named symbol reached during bundling or module initialization must
+ * remain a concrete export; a Proxy fallback cannot satisfy esbuild's named ESM
+ * interop and crashes the fixture before the render path runs.
  */
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { build } from "esbuild";
 import { describe, expect, it } from "vitest";
-import { stubElizaCore } from "./esbuild-stubs";
+import { stubElizaCore, stubNodeBuiltins } from "./esbuild-stubs";
 
 async function bundleWithCoreStub(source: string): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), "eliza-core-stub-"));
@@ -31,6 +28,25 @@ async function bundleWithCoreStub(source: string): Promise<string> {
   const output = result.outputFiles?.[0]?.text;
   if (!output)
     throw new Error("esbuild produced no output for the stub bundle");
+  return output;
+}
+
+async function bundleWithNodeStub(source: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "eliza-node-stub-"));
+  const entry = join(root, "entry.mjs");
+  await writeFile(entry, source);
+  const result = await build({
+    entryPoints: [entry],
+    bundle: true,
+    write: false,
+    format: "iife",
+    globalName: "fixture",
+    platform: "browser",
+    plugins: [stubNodeBuiltins()],
+  });
+  const output = result.outputFiles?.[0]?.text;
+  if (!output)
+    throw new Error("esbuild produced no output for the Node stub bundle");
   return output;
 }
 
@@ -100,5 +116,20 @@ describe("stubElizaCore", () => {
     )() as string;
 
     expect(evaluated).toBe("fixture reply");
+  });
+});
+
+describe("stubNodeBuiltins", () => {
+  it("exports the concrete host identity used during route preference initialization", async () => {
+    const bundle = await bundleWithNodeStub(`
+      import { hostname } from "node:os";
+      export const observed = hostname();
+    `);
+
+    const evaluated = new Function(
+      `${bundle}; return fixture.observed;`,
+    )() as string;
+
+    expect(evaluated).toBe("eliza-browser-fixture");
   });
 });

--- a/packages/ui/src/testing/e2e-runner/esbuild-stubs.ts
+++ b/packages/ui/src/testing/e2e-runner/esbuild-stubs.ts
@@ -95,6 +95,7 @@ export default anyfn;
 export const createRequire = () => anyfn;
 export const homedir = anyfn;
 export const tmpdir = anyfn;
+export const hostname = () => "eliza-browser-fixture";
 export const platform = anyfn;
 export const isAbsolute = anyfn;
 export const join = anyfn;

--- a/packages/ui/src/testing/e2e-runner/fixture-bundle.test.ts
+++ b/packages/ui/src/testing/e2e-runner/fixture-bundle.test.ts
@@ -69,6 +69,8 @@ describe("fixture bundle", () => {
     expect(cdn).toContain('<html class="dark">');
     expect(cdn).toContain("cdn.tailwindcss.com");
     expect(cdn).toContain("window.process=");
+    expect(cdn).toContain("/api/runtime/mode");
+    expect(cdn).toContain('deploymentRuntime:"local"');
     expect(cdn).toContain("background:#16121c");
 
     const compiled = buildFixtureHtml({

--- a/packages/ui/src/testing/e2e-runner/fixture-bundle.ts
+++ b/packages/ui/src/testing/e2e-runner/fixture-bundle.ts
@@ -86,7 +86,27 @@ export interface FixtureHtmlOptions {
   background?: string;
 }
 
-const PROCESS_SHIM = `<script>window.process=window.process||{env:{NODE_ENV:"production"},platform:"browser",cwd:function(){return "/"}};</script>`;
+/**
+ * Bootstrap static `file://` fixtures with the browser globals their render
+ * graph expects. Runtime-mode discovery is advisory in production, but an
+ * attempted relative fetch on a file origin emits a browser console error
+ * before its fallback can run, so answer that owned endpoint explicitly.
+ */
+export const FILE_FIXTURE_BOOTSTRAP = `window.process=window.process||{env:{NODE_ENV:"production"},platform:"browser",cwd:function(){return "/"}};
+(function(){
+  const realFetch=window.fetch.bind(window);
+  window.fetch=function(input,init){
+    const raw=typeof input==="string"?input:input instanceof URL?input.href:input.url;
+    let pathname=raw;
+    try{pathname=new URL(raw,window.location.href).pathname;}catch{}
+    if(pathname==="/api/runtime/mode"){
+      return Promise.resolve(new Response(JSON.stringify({mode:"local",deploymentRuntime:"local",isRemoteController:false,remoteApiBaseConfigured:false}),{status:200,headers:{"content-type":"application/json"}}));
+    }
+    return realFetch(input,init);
+  };
+})();`;
+
+const PROCESS_SHIM = `<script>${FILE_FIXTURE_BOOTSTRAP}</script>`;
 
 /** Wrap bundled fixture JS in the shared static HTML skeleton. */
 export function buildFixtureHtml({

--- a/packages/ui/src/testing/e2e-runner/index.ts
+++ b/packages/ui/src/testing/e2e-runner/index.ts
@@ -25,6 +25,7 @@ export {
   bundleFixture,
   type CompileTailwindThemeOptions,
   compileTailwindTheme,
+  FILE_FIXTURE_BOOTSTRAP,
   type FixtureHtmlOptions,
   type WriteFixturePageOptions,
   writeFixturePage,


### PR DESCRIPTION
Closes #20155

## Outcome

Repairs the recurring Chat shell gestures failure caused by isolated browser fixtures drifting from the UI render-path contract. The first chat interaction can now call stripUnclaimedInteractionMarkup without crashing React and unmounting the sheet.

Generic chat fixtures now use the tested shared core/node esbuild stubs. Specialized Home and launcher fixtures retain their domain-specific core behavior and explicitly preserve unclaimed interaction text. This removes 288 copied lines while keeping the special cases visible.

Current develop also added a named node:os hostname import and advisory runtime-mode discovery to the fixture graph. The shared Node stub now exposes a deterministic hostname, and every static file fixture uses one bootstrap that answers the owned runtime-mode endpoint without file-origin console noise.

## Root cause

The hosted failure appeared as a three-second geometry timeout in real-touch-gestures.ts. Direct reproduction showed the preceding interaction threw `(0, import_core51.stripUnclaimedInteractionMarkup) is not a function`; React then removed the target. This was a fixture contract failure, not runner capacity or gesture timing.

## Validation

- bun install — pinned workspace, no dependency changes.
- bun run verify — 351/351 tasks plus all repository audits passed.
- Shared fixture contract tests — 8/8 passed.
- UI typecheck — passed.
- Chat-scroll Chromium — 10 consecutive full real-touch runs passed.
- Chat-scroll axis-lock — Chromium and WebKit passed.
- Home-screen real-browser E2E — passed, including mobile/desktop layout, gestures, screenshots, and frame budget.
- Launcher loop — passed 500 real touch actions.
- No-provider evidence capture — passed.
- Voice trajectory capture — passed.

## Evidence

- Before screenshots: N/A — test-infrastructure-only change; no rendered production pixels changed.
- After screenshots: N/A — test-infrastructure-only change; affected fixture screenshots were generated and manually reviewed by their passing runners.
- Walkthrough video: Home and launcher-loop WebM recordings generated and reviewed; voice trajectory recording generated successfully. Not attached because production UI is unchanged.
- Backend logs: N/A — no backend path changed.
- Frontend logs: all touched fixture runners passed without page errors after the repair.
- LLM trajectory: N/A — no model, prompt, provider, planner, or agent behavior changed.
- Domain artifacts: 10 deterministic chat-scroll logs, Chromium/WebKit axis-lock output, Home screenshots/video, launcher fuzz video, no-provider screenshots, and voice video generated locally and reviewed; evidence artifacts are intentionally uncommitted.
- OCR review: N/A — no production visual change.

## Risk

Low. Production runtime code is unchanged. The change centralizes generic browser-only fixture stubs and adds one named render helper to two specialized stubs.

<!-- evidence-head:a5708bfea6db6e2d4c98025adebc197c54aee53f -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no production UI or rendered styles changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no production UI or rendered styles changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test-infrastructure-only repair; affected real-browser runners generated and passed their local recordings

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend path changed

<!-- evidence-row:frontend-logs -->
- [ ] N/A - production frontend and network behavior are unchanged; real-browser fixture assertions and zero page errors are recorded in Validation

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, planner, or agent behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - fixture-only browser stub maintenance; no production domain artifact changed

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@2a3eca15a633541ed7da0035f48310ba5a5f9551:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-triage]
<!-- eliza-computer-attribution:v1 {"provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@2a3eca15a633541ed7da0035f48310ba5a5f9551:packages/skills/skills/contribute-to-eliza"} -->