### PR TITLE
fix(auth): use base64url for JWT payload decoding

### DIFF
--- a/packages/auth/src/oauth-flow.ts
+++ b/packages/auth/src/oauth-flow.ts
@@ -686,7 +686,7 @@ function extractCodexAccountId(accessToken: string): string | null {
     if (parts.length !== 3) return null;
     const payload = parts[1];
     const decoded = JSON.parse(
-      Buffer.from(payload, "base64").toString("utf-8"),
+      Buffer.from(payload, "base64url").toString("utf-8"),
     ) as Record<string, unknown>;
     const claim = decoded["https://api.openai.com/auth"];
     if (!claim || typeof claim !== "object") return null;


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

- Self-found — no linked issue. Consistent sibling fix: `extractJwtEmail` already uses `base64url`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@8b694f6e16fb400997954cb65ef412ce53b7e65f:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Single-line change: `"base64"` → `"base64url"` in `extractCodexAccountId`. Aligns with existing correct usage in `extractJwtEmail` in the same file. No API, schema, or behavioral change beyond correctly decoding JWT payloads that contain `-`/`_` characters. Failure mode before was silent `null` return; after, correctly returns account id.

# Background

## What does this PR do?

Fixes `extractCodexAccountId` in `packages/auth/src/oauth-flow.ts:689` to decode the JWT payload with `base64url` instead of `base64`. JWTs are base64url-encoded; payloads containing `-` or `_` (common in UUIDs) were corrupted under standard base64, causing `JSON.parse` to throw and the function to silently return `null`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/auth/src/oauth-flow.ts:686-705` — `extractCodexAccountId` and `extractJwtEmail` for comparison.

## Detailed testing steps

1. Inspect `packages/auth/src/oauth-flow.ts:689` — confirms `Buffer.from(payload, "base64url")`.
2. Verify `grep -n base64 packages/auth/src/oauth-flow.ts` shows only `base64url` (both functions).
3. Run `bun run --cwd packages/auth test` — 148 tests pass.

```
 Test Files  11 passed (11)
      Tests  148 passed (148)
   Duration  6.61s
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:eabb1aa72552ae7547c2de954acd67311cb3b733 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - backend-only fix, no UI surface affected`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - backend-only fix, no UI surface affected`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - backend-only fix, no UI surface affected`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - single-line encoding fix verified by unit tests; grep confirms base64url at both decode sites`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - backend-only fix, no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no agent/action/provider/prompt/model change`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories, scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or marked `N/A - no domain artifacts produced`.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review output is attached for UI changes, or marked `N/A - no rendered visual surface`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Backend: `bun run --cwd packages/auth test` — 11 files, 148 tests passed (sanitized). Grep confirms no remaining `base64` (non-url) decode in file.

Frontend: N/A - no frontend change.

## Screenshots (before / after) + video walkthrough

N/A - backend-only fix, no UI surface affected.

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

None. Single-line encoding fix; all 148 auth tests pass.

---
*AI assistance: yes | Models: anthropic/claude-fable-5 | Client: claude-code | Skill: elizaOS/eliza@8b694f6e16fb400997954cb65ef412ce53b7e65f:packages/skills/skills/contribute-to-eliza | Attribution: self-reported*
