### PR TITLE
fix(core): parseJSONObjectFromText returns scalars as objects, so quoted agent replies are discarded

### DIFF
--- a/packages/agent/src/actions/grounded-action-reply.quoted-reply.test.ts
+++ b/packages/agent/src/actions/grounded-action-reply.quoted-reply.test.ts
@@ -1,0 +1,74 @@
+/**
+ * The grounded reply path rejects model output that "looks structured" and
+ * falls back to the canonical text. A model reply wrapped in quotation marks
+ * is prose, not structure — and normalizeReplyText exists precisely to strip
+ * those quotes — but it parsed as a JSON string, so the guard discarded it and
+ * the user got boilerplate instead of the grounded answer.
+ *
+ * These cases pin the guard at its real call site: quoted prose is delivered
+ * (normalized), while genuinely structured output still falls back.
+ */
+import type { IAgentRuntime, Memory, State } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { renderGroundedActionReply } from "./grounded-action-reply.ts";
+
+const FALLBACK = "I've handled that.";
+
+function runtimeReturning(modelOutput: string): IAgentRuntime {
+  return {
+    useModel: vi.fn(async () => modelOutput),
+    getMemories: vi.fn(async () => []),
+    character: { name: "TestAgent" },
+  } as unknown as IAgentRuntime;
+}
+
+async function render(modelOutput: string): Promise<string> {
+  return renderGroundedActionReply({
+    runtime: runtimeReturning(modelOutput),
+    message: { content: { text: "add milk" } } as unknown as Memory,
+    state: undefined as unknown as State | undefined,
+    intent: "confirm",
+    domain: "lifeops",
+    scenario: "test",
+    fallback: FALLBACK,
+  });
+}
+
+describe("renderGroundedActionReply — quoted prose is not structured output", () => {
+  it("delivers a double-quoted prose reply, stripped of its quotes", async () => {
+    const out = await render('"Sure — I added milk to your shopping list."');
+    expect(out).toBe("Sure — I added milk to your shopping list.");
+    expect(out).not.toBe(FALLBACK);
+  });
+
+  it("delivers a single-quoted prose reply", async () => {
+    const out = await render("'Added milk.'");
+    expect(out).toBe("Added milk.");
+  });
+
+  it("delivers an unquoted prose reply unchanged", async () => {
+    const out = await render("Added milk to your list.");
+    expect(out).toBe("Added milk to your list.");
+  });
+
+  it("still falls back for a real JSON object reply", async () => {
+    const out = await render('{"response": "Added milk", "confidence": 0.9}');
+    expect(out).toBe(FALLBACK);
+  });
+
+  it("still falls back for a fenced JSON object reply", async () => {
+    const out = await render('```json\n{"response": "Added milk"}\n```');
+    expect(out).toBe(FALLBACK);
+  });
+
+  it("still falls back for schema-key output and XML-ish output", async () => {
+    expect(await render("shouldAct: true\nresponse: Added milk")).toBe(
+      FALLBACK,
+    );
+    expect(await render("<thinking>should I</thinking>")).toBe(FALLBACK);
+  });
+
+  it("still falls back for an empty reply", async () => {
+    expect(await render("   ")).toBe(FALLBACK);
+  });
+});

--- a/packages/core/src/utils.parsing.test.ts
+++ b/packages/core/src/utils.parsing.test.ts
@@ -54,6 +54,16 @@ describe("parseJSONObjectFromText", () => {
 		expect(parseJSONObjectFromText("[1,2,3]")).toBeNull(); // arrays are not objects
 		expect(parseJSONObjectFromText("no json")).toBeNull();
 	});
+
+	it("returns null for scalars, which JSON5 parses as valid JSON", () => {
+		expect(parseJSONObjectFromText("42")).toBeNull();
+		expect(parseJSONObjectFromText("true")).toBeNull();
+		expect(parseJSONObjectFromText("null")).toBeNull();
+		// A model reply wrapped in quotes is a JSON string, not an object.
+		expect(
+			parseJSONObjectFromText('"Sure - I added milk to your shopping list."'),
+		).toBeNull();
+	});
 });
 
 describe("parseBooleanFromText", () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -940,10 +940,13 @@ export function parseJSONObjectFromText(
 ): Record<string, unknown> | null {
 	try {
 		const result = extractAndParseJSONObjectFromText(text);
-		if (!result) {
-			return null;
-		}
-		if (Array.isArray(result)) {
+		// JSON5 parses bare scalars ("42", '"hi"', "true") as valid JSON, and
+		// those are truthy and non-array, so screen on the type itself.
+		if (
+			typeof result !== "object" ||
+			result === null ||
+			Array.isArray(result)
+		) {
 			return null;
 		}
 		return result;


### PR DESCRIPTION
# Relates to

No existing issue — found while reading `packages/core/src/utils.ts`. Reproduction below.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Low.** The change makes one function match its own documented contract, and only for inputs it was never supposed to accept. Objects, fenced ```json blocks, and JSON5 syntax are unaffected; arrays already returned null and still do.

The behaviour change is confined to non-object JSON — `42`, `"hello"`, `true`, `null` now return `null` instead of being handed back typed as `Record<string, unknown>`. Callers that treated a scalar as an object were already reading `undefined` from every field, so the null/retry path they have is the one they wanted.

# Background

## What does this PR do?

`parseJSONObjectFromText` documents "Invalid or **non-object** input returns null" and is typed `Record<string, unknown> | null`, but only screened two cases:

```ts
if (!result) return null;              // falsy
if (Array.isArray(result)) return null; // arrays
return result;                          // <- scalars fall through
```

JSON5 parses bare scalars as valid JSON (`42`, `"hello"`, `true`), and all of them are truthy and non-array, so they were returned as if they were objects.

This PR screens on the type itself.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The type lie is the smaller half. Two call sites use this function as a "did the model leak structured output?" detector:

- `packages/agent/src/actions/grounded-action-reply.ts` — `looksLikeStructuredReply()` does `if (parseJSONObjectFromText(trimmed)) return true;`
- `packages/core/src/services/message.ts` — the `json_shaped_response` check on the character-voice rewrite path

A model reply wrapped in quotation marks is a JSON **string**, so it parsed successfully, the guard fired, and a perfectly good answer was thrown away in favour of the canned fallback. The user gets boilerplate instead of the grounded reply the model actually produced.

Worth noting: the helper immediately above `looksLikeStructuredReply` is

```ts
.replace(/^["'`]+|["'`]+$/g, "")
```

i.e. `normalizeReplyText` exists specifically to strip wrapping quotes — so quoted replies are *expected* input on that path, and the guard above it was rejecting exactly those before normalisation could run. Bare-number and `true`/`false` replies hit the same misfire.

Separately, `runtime.parseStructuredResponse` could hand callers a number or string typed as `Record<string, unknown>`, making every `parsed.field` read silently `undefined` instead of taking the null/retry branch.

# Documentation changes needed?

My changes do not require a change to the project documentation. The existing docstring already describes the behaviour this PR makes true.

# Testing

## Where should a reviewer start?

`packages/core/src/utils.parsing.test.ts` — the new `returns null for scalars` case. Check out this branch, revert only `packages/core/src/utils.ts`, and run the file: it fails. Restore it and it passes.

## Detailed testing steps

```bash
bun install --ignore-scripts
bun test packages/core/src/utils.parsing.test.ts     # 9 pass

git checkout packages/core/src/utils.ts               # revert ONLY the source fix
bun test packages/core/src/utils.parsing.test.ts     # 8 pass, 1 fail
```

Against the unfixed source, the scalar case reports:

```
42 -> number 42
"Sure — I added milk to your shopping list." -> string "Sure — I added milk to your shopping list."
true -> boolean true
```

all three of which should have been `null`.

The existing test in this describe block asserts `parseJSONObjectFromText("[1,2,3]")` is null with the comment "arrays are not objects", but never covered a scalar — which is why the half-done screen looked complete.

# Evidence Gate

<!-- evidence-head:f2332988e551b22c7c31bb8a5630545fd6febafe -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure parser and backend grounded-reply guard; no rendered UI surface changed
<!-- evidence-row:after-screenshots -->
- [ ] N/A - pure parser and backend grounded-reply guard; no rendered UI surface changed
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or visual user flow changed
<!-- evidence-row:backend-logs -->
- [x] [20163-pr20163-exact.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20163-pr20163-exact.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic parser and grounded-reply call-site tests pin exact model-output strings; no provider, prompt, action, or evaluator contract changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - parser and reply renderer produce no persisted domain artifact
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or visual text changed

# Evidence Details

## Real LLM-call trajectory

Replaced with deterministic call-site evidence rather than a live run, because the assertion is about *which* reply text survives the guard and that must be pinned to be checkable:

```
bunx vitest run packages/agent/src/actions/grounded-action-reply.quoted-reply.test.ts

  WITHOUT the utils.ts fix -> Tests  2 failed | 5 passed (7)
      x delivers a double-quoted prose reply, stripped of its quotes
      x delivers a single-quoted prose reply
  WITH the fix             -> Tests  7 passed (7)
```

The two failures are exactly the user-facing symptom (quoted prose discarded for the fallback). The five that pass either way are the guard's real duties — JSON objects, fenced objects, schema-key output, XML-ish output, empty replies — which still fall back, showing the guard was not weakened.

## Backend + frontend logs

`N/A - pure function, no I/O and no log emission.` The behavioural evidence is the before/after transcript under **Detailed testing steps**.

## Screenshots (before / after) + video walkthrough

`N/A - no UI change.`

# Known gaps / failures

- I did not attach an end-to-end agent transcript showing a quoted reply being rescued, because reproducing it needs a live model whose reply happens to be quoted — non-deterministic. The guard's input is shown directly instead: a quoted sentence parses to a string, which is what made `looksLikeStructuredReply` return true.

**`bun run verify` blocker (pre-existing on `develop`, not from this PR).** The repository-wide gate currently fails at:

```
@elizaos/gateway-webhook:typecheck: src/billing.test.ts(8,65): error TS2307:
  Cannot find module '@elizaos/cloud-shared/billing' or its corresponding type declarations.
```

I verified this is unrelated by running the same target on a clean checkout of `origin/develop` (`a83393b090`) with **zero** changes applied:

```
Tasks:    56 successful, 57 total
Failed:   @elizaos/gateway-webhook#typecheck   <- same error, no diff of mine present
```

The packages this PR touches are green at the exact head:

```
bunx turbo run typecheck lint:check --filter=@elizaos/core --filter=@elizaos/agent
Tasks:    60 successful, 60 total
```

I have not touched `gateway-webhook` or `cloud-shared`, and I did not want to tick a "verify passes" box that isn't literally true — hence this section rather than a silent green.


AI provider/model: Anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A - contribution skill not used; repository template and CONTRIBUTING.md read directly from the checkout
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"N/A - contribution skill not used"} -->


