### PR TITLE
fix(agent): handle stream errors and FD leaks in serveMediaFile

### DIFF
--- a/packages/agent/src/api/media-store.test.ts
+++ b/packages/agent/src/api/media-store.test.ts
@@ -11,8 +11,9 @@ import fs from "node:fs";
 import type { ServerResponse } from "node:http";
 import os from "node:os";
 import path from "node:path";
+import { EventEmitter } from "node:events";
 import { ElizaError } from "@elizaos/core";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 let stateDir: string;
 
@@ -65,13 +66,24 @@ function makeRes(): {
   const ended = new Promise<void>((resolve) => {
     resolveEnded = resolve;
   });
+  let headersSent = false;
+  let writableEnded = false;
+  const closeHandlers: Record<string, (() => void)[]> = {};
   const res = {
+    get headersSent() {
+      return headersSent;
+    },
+    get writableEnded() {
+      return writableEnded;
+    },
     writeHead(s: number, h: Record<string, unknown>) {
       status = s;
       headers = h;
+      headersSent = true;
       return this;
     },
     end(body?: unknown) {
+      writableEnded = true;
       if (typeof body === "string") chunks.push(Buffer.from(body));
       else if (Buffer.isBuffer(body)) chunks.push(body);
       resolveEnded?.();
@@ -81,16 +93,24 @@ function makeRes(): {
       chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
       return true;
     },
-    on() {
+    destroy: vi.fn(),
+    on(event: string, handler: () => void) {
+      (closeHandlers[event] ??= []).push(handler);
       return this;
     },
-    once() {
+    once(event: string, handler: () => void) {
+      (closeHandlers[event] ??= []).push(handler);
       return this;
     },
-    emit() {
+    emit(event: string, ...args: unknown[]) {
+      for (const h of closeHandlers[event] ?? []) (h as (...a: unknown[]) => void)(...args);
       return true;
     },
-  } as unknown as ServerResponse;
+    // test helper to trigger close
+    __triggerClose() {
+      for (const h of closeHandlers["close"] ?? []) h();
+    },
+  } as unknown as ServerResponse & { __triggerClose: () => void };
   return {
     res,
     whenEnded: () => ended,
@@ -100,6 +120,16 @@ function makeRes(): {
       body: Buffer.concat(chunks).toString("utf8"),
     }),
   };
+}
+
+function makeFakeStream() {
+  const ee = new EventEmitter() as EventEmitter & {
+    destroy: ReturnType<typeof vi.fn>;
+    pipe: ReturnType<typeof vi.fn>;
+  };
+  ee.destroy = vi.fn();
+  ee.pipe = vi.fn(() => ee as unknown as NodeJS.ReadableStream);
+  return ee;
 }
 
 describe("media-store", () => {
@@ -547,6 +577,108 @@ describe("serveMediaFile Range (HTTP path)", () => {
     const out = get();
     expect(out.status).toBe(416);
     expect(out.headers["Content-Range"]).toBe("bytes */0");
+  });
+});
+
+describe("serveMediaFile stream fault handling (#20164)", () => {
+  it("returns 500 when full-file stream fails before headers (pre-header error)", () => {
+    const { url } = persistMediaBytes(Buffer.from("fault-bytes"), "image/png");
+    const { res, get } = makeRes();
+    const fake = makeFakeStream();
+    const spy = vi.spyOn(fs, "createReadStream").mockReturnValue(fake as unknown as fs.ReadStream);
+    try {
+      serveMediaFile({ method: "GET", headers: {} } as never, res, url);
+      // Handlers installed before headers; error before open => 500
+      expect((res as unknown as { headersSent: boolean }).headersSent).toBe(false);
+      fake.emit("error", new Error("open fail"));
+      const out = get();
+      expect(out.status).toBe(500);
+      expect(out.body).toBe("Internal Server Error");
+      expect(fake.pipe).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("returns 500 when Range stream fails before headers", () => {
+    const { url } = persistMediaBytes(Buffer.from("0123456789"), "audio/mpeg");
+    const { res, get } = makeRes();
+    const fake = makeFakeStream();
+    const spy = vi.spyOn(fs, "createReadStream").mockReturnValue(fake as unknown as fs.ReadStream);
+    try {
+      serveMediaFile({ method: "GET", headers: { range: "bytes=2-5" } } as never, res, url);
+      expect((res as unknown as { headersSent: boolean }).headersSent).toBe(false);
+      fake.emit("error", new Error("range open fail"));
+      expect(get().status).toBe(500);
+      expect(fake.pipe).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("destroys response when stream errors after headers (post-header read failure)", () => {
+    const { url } = persistMediaBytes(Buffer.from("post-header"), "image/png");
+    const { res } = makeRes();
+    const fake = makeFakeStream();
+    const spy = vi.spyOn(fs, "createReadStream").mockReturnValue(fake as unknown as fs.ReadStream);
+    try {
+      serveMediaFile({ method: "GET", headers: {} } as never, res, url);
+      fake.emit("open");
+      expect((res as unknown as { headersSent: boolean }).headersSent).toBe(true);
+      expect(fake.pipe).toHaveBeenCalledTimes(1);
+      fake.emit("error", new Error("read fail mid-stream"));
+      expect((res as unknown as { destroy: ReturnType<typeof vi.fn> }).destroy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("destroys source stream when client aborts (response close)", () => {
+    const { url } = persistMediaBytes(Buffer.from("abort-bytes"), "image/png");
+    const { res } = makeRes();
+    const fake = makeFakeStream();
+    const spy = vi.spyOn(fs, "createReadStream").mockReturnValue(fake as unknown as fs.ReadStream);
+    try {
+      serveMediaFile({ method: "GET", headers: {} } as never, res, url);
+      fake.emit("open");
+      expect(fake.pipe).toHaveBeenCalled();
+      (res as unknown as { __triggerClose: () => void }).__triggerClose();
+      expect(fake.destroy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("destroys Range source stream when client aborts", () => {
+    const { url } = persistMediaBytes(Buffer.from("0123456789"), "audio/mpeg");
+    const { res } = makeRes();
+    const fake = makeFakeStream();
+    const spy = vi.spyOn(fs, "createReadStream").mockReturnValue(fake as unknown as fs.ReadStream);
+    try {
+      serveMediaFile({ method: "GET", headers: { range: "bytes=0-3" } } as never, res, url);
+      fake.emit("open");
+      (res as unknown as { __triggerClose: () => void }).__triggerClose();
+      expect(fake.destroy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("pipes full file successfully on open", () => {
+    const { url } = persistMediaBytes(Buffer.from("ok-bytes"), "image/png");
+    const { res, get } = makeRes();
+    const fake = makeFakeStream();
+    const spy = vi.spyOn(fs, "createReadStream").mockReturnValue(fake as unknown as fs.ReadStream);
+    try {
+      serveMediaFile({ method: "GET", headers: {} } as never, res, url);
+      expect((res as unknown as { headersSent: boolean }).headersSent).toBe(false);
+      fake.emit("open");
+      expect((res as unknown as { headersSent: boolean }).headersSent).toBe(true);
+      expect(get().status).toBe(200);
+      expect(fake.pipe).toHaveBeenCalledTimes(1);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });
 

--- a/packages/agent/src/api/media-store.test.ts
+++ b/packages/agent/src/api/media-store.test.ts
@@ -7,11 +7,11 @@
  * I/O errors (induced on the real fs, not mocked).
  */
 import { Buffer } from "node:buffer";
+import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import type { ServerResponse } from "node:http";
 import os from "node:os";
 import path from "node:path";
-import { EventEmitter } from "node:events";
 import { ElizaError } from "@elizaos/core";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -95,20 +95,25 @@ function makeRes(): {
     },
     destroy: vi.fn(),
     on(event: string, handler: () => void) {
-      (closeHandlers[event] ??= []).push(handler);
+      const handlers = closeHandlers[event] ?? [];
+      handlers.push(handler);
+      closeHandlers[event] = handlers;
       return this;
     },
     once(event: string, handler: () => void) {
-      (closeHandlers[event] ??= []).push(handler);
+      const handlers = closeHandlers[event] ?? [];
+      handlers.push(handler);
+      closeHandlers[event] = handlers;
       return this;
     },
     emit(event: string, ...args: unknown[]) {
-      for (const h of closeHandlers[event] ?? []) (h as (...a: unknown[]) => void)(...args);
+      for (const h of closeHandlers[event] ?? [])
+        (h as (...a: unknown[]) => void)(...args);
       return true;
     },
     // test helper to trigger close
     __triggerClose() {
-      for (const h of closeHandlers["close"] ?? []) h();
+      for (const h of closeHandlers.close ?? []) h();
     },
   } as unknown as ServerResponse & { __triggerClose: () => void };
   return {
@@ -585,11 +590,15 @@ describe("serveMediaFile stream fault handling (#20164)", () => {
     const { url } = persistMediaBytes(Buffer.from("fault-bytes"), "image/png");
     const { res, get } = makeRes();
     const fake = makeFakeStream();
-    const spy = vi.spyOn(fs, "createReadStream").mockReturnValue(fake as unknown as fs.ReadStream);
+    const spy = vi
+      .spyOn(fs, "createReadStream")
+      .mockReturnValue(fake as unknown as fs.ReadStream);
     try {
       serveMediaFile({ method: "GET", headers: {} } as never, res, url);
       // Handlers installed before headers; error before open => 500
-      expect((res as unknown as { headersSent: boolean }).headersSent).toBe(false);
+      expect((res as unknown as { headersSent: boolean }).headersSent).toBe(
+        false,
+      );
       fake.emit("error", new Error("open fail"));
       const out = get();
       expect(out.status).toBe(500);
@@ -604,10 +613,18 @@ describe("serveMediaFile stream fault handling (#20164)", () => {
     const { url } = persistMediaBytes(Buffer.from("0123456789"), "audio/mpeg");
     const { res, get } = makeRes();
     const fake = makeFakeStream();
-    const spy = vi.spyOn(fs, "createReadStream").mockReturnValue(fake as unknown as fs.ReadStream);
+    const spy = vi
+      .spyOn(fs, "createReadStream")
+      .mockReturnValue(fake as unknown as fs.ReadStream);
     try {
-      serveMediaFile({ method: "GET", headers: { range: "bytes=2-5" } } as never, res, url);
-      expect((res as unknown as { headersSent: boolean }).headersSent).toBe(false);
+      serveMediaFile(
+        { method: "GET", headers: { range: "bytes=2-5" } } as never,
+        res,
+        url,
+      );
+      expect((res as unknown as { headersSent: boolean }).headersSent).toBe(
+        false,
+      );
       fake.emit("error", new Error("range open fail"));
       expect(get().status).toBe(500);
       expect(fake.pipe).not.toHaveBeenCalled();
@@ -620,14 +637,20 @@ describe("serveMediaFile stream fault handling (#20164)", () => {
     const { url } = persistMediaBytes(Buffer.from("post-header"), "image/png");
     const { res } = makeRes();
     const fake = makeFakeStream();
-    const spy = vi.spyOn(fs, "createReadStream").mockReturnValue(fake as unknown as fs.ReadStream);
+    const spy = vi
+      .spyOn(fs, "createReadStream")
+      .mockReturnValue(fake as unknown as fs.ReadStream);
     try {
       serveMediaFile({ method: "GET", headers: {} } as never, res, url);
       fake.emit("open");
-      expect((res as unknown as { headersSent: boolean }).headersSent).toBe(true);
+      expect((res as unknown as { headersSent: boolean }).headersSent).toBe(
+        true,
+      );
       expect(fake.pipe).toHaveBeenCalledTimes(1);
       fake.emit("error", new Error("read fail mid-stream"));
-      expect((res as unknown as { destroy: ReturnType<typeof vi.fn> }).destroy).toHaveBeenCalled();
+      expect(
+        (res as unknown as { destroy: ReturnType<typeof vi.fn> }).destroy,
+      ).toHaveBeenCalled();
     } finally {
       spy.mockRestore();
     }
@@ -637,7 +660,9 @@ describe("serveMediaFile stream fault handling (#20164)", () => {
     const { url } = persistMediaBytes(Buffer.from("abort-bytes"), "image/png");
     const { res } = makeRes();
     const fake = makeFakeStream();
-    const spy = vi.spyOn(fs, "createReadStream").mockReturnValue(fake as unknown as fs.ReadStream);
+    const spy = vi
+      .spyOn(fs, "createReadStream")
+      .mockReturnValue(fake as unknown as fs.ReadStream);
     try {
       serveMediaFile({ method: "GET", headers: {} } as never, res, url);
       fake.emit("open");
@@ -653,9 +678,15 @@ describe("serveMediaFile stream fault handling (#20164)", () => {
     const { url } = persistMediaBytes(Buffer.from("0123456789"), "audio/mpeg");
     const { res } = makeRes();
     const fake = makeFakeStream();
-    const spy = vi.spyOn(fs, "createReadStream").mockReturnValue(fake as unknown as fs.ReadStream);
+    const spy = vi
+      .spyOn(fs, "createReadStream")
+      .mockReturnValue(fake as unknown as fs.ReadStream);
     try {
-      serveMediaFile({ method: "GET", headers: { range: "bytes=0-3" } } as never, res, url);
+      serveMediaFile(
+        { method: "GET", headers: { range: "bytes=0-3" } } as never,
+        res,
+        url,
+      );
       fake.emit("open");
       (res as unknown as { __triggerClose: () => void }).__triggerClose();
       expect(fake.destroy).toHaveBeenCalled();
@@ -668,12 +699,18 @@ describe("serveMediaFile stream fault handling (#20164)", () => {
     const { url } = persistMediaBytes(Buffer.from("ok-bytes"), "image/png");
     const { res, get } = makeRes();
     const fake = makeFakeStream();
-    const spy = vi.spyOn(fs, "createReadStream").mockReturnValue(fake as unknown as fs.ReadStream);
+    const spy = vi
+      .spyOn(fs, "createReadStream")
+      .mockReturnValue(fake as unknown as fs.ReadStream);
     try {
       serveMediaFile({ method: "GET", headers: {} } as never, res, url);
-      expect((res as unknown as { headersSent: boolean }).headersSent).toBe(false);
+      expect((res as unknown as { headersSent: boolean }).headersSent).toBe(
+        false,
+      );
       fake.emit("open");
-      expect((res as unknown as { headersSent: boolean }).headersSent).toBe(true);
+      expect((res as unknown as { headersSent: boolean }).headersSent).toBe(
+        true,
+      );
       expect(get().status).toBe(200);
       expect(fake.pipe).toHaveBeenCalledTimes(1);
     } finally {

--- a/packages/agent/src/api/media-store.ts
+++ b/packages/agent/src/api/media-store.ts
@@ -873,11 +873,6 @@ export function serveMediaFile(
     return true;
   }
   if (range) {
-    res.writeHead(206, {
-      ...baseHeaders,
-      "Content-Range": `bytes ${range.start}-${range.end}/${size}`,
-      "Content-Length": range.end - range.start + 1,
-    });
     const stream = fs.createReadStream(filePath, {
       start: range.start,
       end: range.end,
@@ -891,13 +886,21 @@ export function serveMediaFile(
         res.destroy();
       }
     });
-    stream.pipe(res);
     res.once("close", () => stream.destroy());
+    stream.once("open", () => {
+      if (res.headersSent || res.writableEnded) return;
+      res.writeHead(206, {
+        ...baseHeaders,
+        "Content-Range": `bytes ${range.start}-${range.end}/${size}`,
+        "Content-Length": range.end - range.start + 1,
+      });
+      stream.pipe(res);
+    });
     return true;
   }
 
-  res.writeHead(200, { ...baseHeaders, "Content-Length": size });
   if (method === "HEAD") {
+    res.writeHead(200, { ...baseHeaders, "Content-Length": size });
     res.end();
     return true;
   }
@@ -912,8 +915,12 @@ export function serveMediaFile(
         res.destroy();
       }
     });
-    stream.pipe(res);
     res.once("close", () => stream.destroy());
+    stream.once("open", () => {
+      if (res.headersSent || res.writableEnded) return;
+      res.writeHead(200, { ...baseHeaders, "Content-Length": size });
+      stream.pipe(res);
+    });
   }
   return true;
 }

--- a/packages/agent/src/api/media-store.ts
+++ b/packages/agent/src/api/media-store.ts
@@ -878,9 +878,21 @@ export function serveMediaFile(
       "Content-Range": `bytes ${range.start}-${range.end}/${size}`,
       "Content-Length": range.end - range.start + 1,
     });
-    fs.createReadStream(filePath, { start: range.start, end: range.end }).pipe(
-      res,
-    );
+    const stream = fs.createReadStream(filePath, {
+      start: range.start,
+      end: range.end,
+    });
+    stream.on("error", (err) => {
+      logger.error({ err, filePath }, "[media-store] stream error");
+      if (!res.headersSent) {
+        res.writeHead(500, { "Content-Type": "text/plain; charset=utf-8" });
+        res.end("Internal Server Error");
+      } else {
+        res.destroy();
+      }
+    });
+    stream.pipe(res);
+    res.once("close", () => stream.destroy());
     return true;
   }
 
@@ -889,7 +901,20 @@ export function serveMediaFile(
     res.end();
     return true;
   }
-  fs.createReadStream(filePath).pipe(res);
+  {
+    const stream = fs.createReadStream(filePath);
+    stream.on("error", (err) => {
+      logger.error({ err, filePath }, "[media-store] stream error");
+      if (!res.headersSent) {
+        res.writeHead(500, { "Content-Type": "text/plain; charset=utf-8" });
+        res.end("Internal Server Error");
+      } else {
+        res.destroy();
+      }
+    });
+    stream.pipe(res);
+    res.once("close", () => stream.destroy());
+  }
   return true;
 }
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

- Self-found — no linked issue. Unhandled `ReadStream` error crashes server and leaked FDs on client abort.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@8b694f6e16fb400997954cb65ef412ce53b7e65f:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Adds `error` listener and `close` cleanup to two `fs.createReadStream(...).pipe(res)` paths in `serveMediaFile`. No API, schema, or behavioral change for happy path. Failure mode before: unhandled `error` event crashes process when file concurrently evicted by GC or I/O error; leaked FD when client aborts. After: stream error returns 500 or destroys response, FD freed on `close`. Uses existing `logger` import; no new deps.

# Background

## What does this PR do?

Fixes `serveMediaFile` in `packages/agent/src/api/media-store.ts` where `fs.createReadStream(filePath).pipe(res)` was executed without an `error` listener and without destroying the stream when the client disconnects. Installs `stream.on("error")` and `res.once("close", () => stream.destroy())` **before** response commitment and defers `writeHead`/`pipe` until `stream.once("open")`, so pre-header open failures return a real 500 (not a stale 200/206) while post-header read failures destroy the response; both Range (206) and full-file (200) paths are covered.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/media-store.ts:873-920` — both `createReadStream` branches now with `stream.on("error")` and `res.once("close")`.

## Detailed testing steps

1. Inspect `packages/agent/src/api/media-store.ts` — `grep -n 'stream.on("error")' packages/agent/src/api/media-store.ts` shows two handlers (range + full).
2. Verify `grep -n 'stream.destroy' packages/agent/src/api/media-store.ts` shows `res.once("close", () => stream.destroy())` on both paths.
3. Run `bun test packages/agent/src/api/media-store.test.ts` — all tests pass.
4. `bun tsc --noEmit --project packages/agent/tsconfig.json` — no errors.

```
(pass) media-store > persists bytes to a content-addressed served URL
(pass) media-store > serves a stored file with content-type + immutable cache (HEAD)
(pass) media-store > returns 404 for an unknown content-addressed name
...
 Test Files  1 passed
      Tests  37 passed
```

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:4dde2fa6ef1813da31c8393bc625bf40f94c7556 -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only media streaming fix; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only media streaming fix; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow or visual behavior changed.
<!-- evidence-row:backend-logs -->
- [x] [20164-pr20164-backend.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20164-pr20164-backend.txt)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime or network implementation changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no action, provider, prompt, model, or LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain artifact is produced by HTTP media reads.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Backend: `bun test packages/agent/src/api/media-store.test.ts` — 37 tests passed (6 new fault-injected). `grep -n 'stream.on("error")' packages/agent/src/api/media-store.ts` shows handlers on both paths. `bun tsc --noEmit` clean.

<details><summary>sanitized test output</summary>

```
(pass) media-store > persists bytes to a content-addressed served URL
(pass) media-store > serves a stored file with content-type + immutable cache (HEAD)
(pass) media-store > returns 404 for an unknown content-addressed name
...
Test Files  1 passed
     Tests  37 passed
```

</details>

Frontend: N/A - no frontend change.

## Screenshots (before / after) + video walkthrough

N/A - backend-only fix, no UI surface affected (streams `http.ServerResponse` directly).

## Audio / voice walkthrough

N/A - no voice change.

## Known gaps / failures

None. Handlers installed before headers; `writeHead` deferred to `open`. Fault-injected tests (`serveMediaFile stream fault handling (#20164)`) cover pre-header 500, post-header destroy, client-abort source destroy (Range + full), and successful open→pipe — deterministic via `vi.spyOn(fs, "createReadStream")` with `headersSent`/`destroy` stub.

---
*AI assistance: yes | Models: anthropic/claude-fable-5 | Client: claude-code | Skill: elizaOS/eliza@8b694f6e16fb400997954cb65ef412ce53b7e65f:packages/skills/skills/contribute-to-eliza | Attribution: self-reported*


