### PR TITLE
fix(cloud): remove repeat Discord account writes

### DIFF
--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -9,7 +9,7 @@ let activeTarget: {
   status: "running" | "sleeping" | "stopped";
   bridge_url?: string;
 } | null = null;
-const resolvePersonalDeliveryByTelegram = mock(async () => ({
+const resolvePersonalDelivery = mock(async () => ({
   userId: "00000000-0000-4000-8000-000000000002",
   organizationId: "00000000-0000-4000-8000-000000000001",
   dedicatedTarget: activeTarget,
@@ -20,11 +20,6 @@ const findOrCreateByPhone = mock(async () => ({
   user: { id: "00000000-0000-4000-8000-000000000012" },
   organization: { id: "00000000-0000-4000-8000-000000000011" },
   isNew: true,
-}));
-const findOrCreateByDiscordId = mock(async () => ({
-  user: { id: "00000000-0000-4000-8000-000000000002" },
-  organization: { id: "00000000-0000-4000-8000-000000000001" },
-  isNew: false,
 }));
 const sharedRestMessageSend = mock(async () => ({ text: "hello from Eliza" }));
 const runOnboardingChat = mock(async (_input: OnboardingChatInput) => ({
@@ -114,9 +109,8 @@ const runtimeExecutionCtx = { waitUntil() {} };
 
 mock.module("@/lib/services/eliza-app", () => ({
   elizaAppUserService: {
-    findOrCreateByDiscordId,
     findOrCreateByPhone,
-    resolvePersonalDeliveryByTelegram,
+    resolvePersonalDelivery,
   },
 }));
 mock.module("@/lib/services/shared-runtime/shared-rest-adapter", () => ({
@@ -195,9 +189,8 @@ const validPhone = {
 describe("personal Shared messaging deliveries", () => {
   beforeEach(() => {
     findOrCreateByPhone.mockClear();
-    findOrCreateByDiscordId.mockClear();
     activeTarget = null;
-    resolvePersonalDeliveryByTelegram.mockClear();
+    resolvePersonalDelivery.mockClear();
     findActivePersonalDedicatedTarget.mockClear();
     sharedRestMessageSend.mockClear();
     runOnboardingChat.mockClear();
@@ -213,7 +206,7 @@ describe("personal Shared messaging deliveries", () => {
 
   test("requires internal gateway authentication", async () => {
     expect((await request(valid, "")).status).toBe(401);
-    expect(resolvePersonalDeliveryByTelegram).not.toHaveBeenCalled();
+    expect(resolvePersonalDelivery).not.toHaveBeenCalled();
   });
 
   test("uses one account-native identity and platform funding", async () => {
@@ -222,7 +215,8 @@ describe("personal Shared messaging deliveries", () => {
     const body = (await response.json()) as {
       data: { identity: { id: string } };
     };
-    expect(resolvePersonalDeliveryByTelegram).toHaveBeenCalledWith({
+    expect(resolvePersonalDelivery).toHaveBeenCalledWith({
+      platform: "telegram",
       telegramId: "123456789",
       username: "nubs",
       displayName: "Nubs",
@@ -317,7 +311,7 @@ describe("personal Shared messaging deliveries", () => {
     });
 
     expect(response.status).toBe(400);
-    expect(resolvePersonalDeliveryByTelegram).not.toHaveBeenCalled();
+    expect(resolvePersonalDelivery).not.toHaveBeenCalled();
     expect(sharedRestMessageSend).not.toHaveBeenCalled();
   });
 
@@ -400,7 +394,7 @@ describe("personal Shared messaging deliveries", () => {
       data: { identity: { id: string }; account: { userId: string } };
     };
     expect(findOrCreateByPhone).toHaveBeenCalledWith("+15551234567");
-    expect(resolvePersonalDeliveryByTelegram).not.toHaveBeenCalled();
+    expect(resolvePersonalDelivery).not.toHaveBeenCalled();
     expect(findActivePersonalDedicatedTarget).toHaveBeenCalledTimes(1);
     expect(body.data.identity.id).toMatch(/^personal:/);
     expect(body.data.account.userId).toBe(
@@ -439,11 +433,14 @@ describe("personal Shared messaging deliveries", () => {
     const body = (await response.json()) as {
       data: { identity: { id: string } };
     };
-    expect(findOrCreateByDiscordId).toHaveBeenCalledWith("123456789012345678", {
+    expect(resolvePersonalDelivery).toHaveBeenCalledWith({
+      platform: "discord",
+      discordId: "123456789012345678",
       username: "shaw",
       globalName: "Shaw",
       avatarUrl: "https://cdn.discordapp.com/avatar.png",
     });
+    expect(findActivePersonalDedicatedTarget).not.toHaveBeenCalled();
     expect(sharedRestMessageSend).toHaveBeenCalledWith(
       expect.objectContaining({ id: body.data.identity.id }),
       body.data.identity.id,
@@ -690,10 +687,17 @@ describe("personal Shared messaging deliveries", () => {
   test.each([
     { ...validPhone, phoneNumber: "15551234567" },
     { ...valid, telegramUserId: "not-a-number" },
+    {
+      platform: "discord",
+      discordUserId: "not-a-snowflake",
+      discordUsername: "shaw",
+      messageId: "discord:invalid",
+      message: "hello",
+    },
     { ...valid, message: "" },
   ])("rejects malformed deliveries before account creation", async (body) => {
     expect((await request(body)).status).toBe(400);
     expect(findOrCreateByPhone).not.toHaveBeenCalled();
-    expect(resolvePersonalDeliveryByTelegram).not.toHaveBeenCalled();
+    expect(resolvePersonalDelivery).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -68,7 +68,10 @@ const sharedMessageSchema = z.discriminatedUnion("platform", [
     ),
   z.object({
     platform: z.literal("discord"),
-    discordUserId: z.string().trim().min(1).max(32),
+    discordUserId: z
+      .string()
+      .trim()
+      .regex(/^\d{1,32}$/),
     discordUsername: z.string().trim().min(1).max(80),
     displayName: z.string().trim().min(1).max(128).optional(),
     avatarUrl: z.string().url().nullable().optional(),
@@ -225,30 +228,30 @@ app.post("/", async (c) => {
       | null
       | undefined;
     if (parsed.data.platform === "telegram") {
-      const delivery =
-        await elizaAppUserService.resolvePersonalDeliveryByTelegram({
-          telegramId: parsed.data.telegramUserId,
-          username: parsed.data.telegramUsername,
-          displayName: parsed.data.displayName,
-        });
+      const delivery = await elizaAppUserService.resolvePersonalDelivery({
+        platform: "telegram",
+        telegramId: parsed.data.telegramUserId,
+        username: parsed.data.telegramUsername,
+        displayName: parsed.data.displayName,
+      });
       account = {
         userId: delivery.userId,
         organizationId: delivery.organizationId,
       };
       dedicated = delivery.dedicatedTarget;
     } else if (parsed.data.platform === "discord") {
-      const discordAccount = await elizaAppUserService.findOrCreateByDiscordId(
-        parsed.data.discordUserId,
-        {
-          username: parsed.data.discordUsername,
-          globalName: parsed.data.displayName,
-          avatarUrl: parsed.data.avatarUrl,
-        },
-      );
+      const delivery = await elizaAppUserService.resolvePersonalDelivery({
+        platform: "discord",
+        discordId: parsed.data.discordUserId,
+        username: parsed.data.discordUsername,
+        globalName: parsed.data.displayName,
+        avatarUrl: parsed.data.avatarUrl,
+      });
       account = {
-        userId: discordAccount.user.id,
-        organizationId: discordAccount.organization.id,
+        userId: delivery.userId,
+        organizationId: delivery.organizationId,
       };
+      dedicated = delivery.dedicatedTarget;
     } else {
       const phoneAccount = await elizaAppUserService.findOrCreateByPhone(
         parsed.data.phoneNumber,

--- a/packages/cloud/shared/src/db/repositories/__tests__/users-converge-phone-telegram-personal-account.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/users-converge-phone-telegram-personal-account.test.ts
@@ -52,7 +52,8 @@ describe("UsersRepository phone + Telegram provisional convergence (real PGlite)
       organizationName: `Phone ${sequence}`,
       organizationSlug: `phone-convergence-${sequence}`,
     });
-    const telegram = await usersRepository.findOrCreateTelegramPersonalAccount({
+    const telegram = await usersRepository.findOrCreateMessagingPersonalAccount({
+      platform: "telegram",
       telegramId,
       telegramUsername: `telegram_${sequence}`,
       telegramFirstName: `Telegram ${sequence}`,

--- a/packages/cloud/shared/src/db/repositories/__tests__/users-promote-telegram-personal-account.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/users-promote-telegram-personal-account.test.ts
@@ -28,7 +28,8 @@ describe("UsersRepository Telegram account promotion (real PGlite)", () => {
 
   const createTelegramAccount = async (telegramId: string) => {
     sequence += 1;
-    return usersRepository.findOrCreateTelegramPersonalAccount({
+    return usersRepository.findOrCreateMessagingPersonalAccount({
+      platform: "telegram",
       telegramId,
       telegramUsername: `telegram_user_${sequence}`,
       telegramFirstName: `Telegram ${sequence}`,

--- a/packages/cloud/shared/src/db/repositories/personal-shared-deliveries.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-deliveries.integration.test.ts
@@ -340,6 +340,36 @@ describe("Discord personal Shared repeat delivery", () => {
     expect(projectionAfter.updated_at).toEqual(projectionBefore.updated_at);
   });
 
+  test("preserves stored optional profile fields when the gateway omits them", async () => {
+    const input = discordInput("814700107");
+    const created = await elizaAppUserService.resolvePersonalDelivery(input);
+
+    const replayed = await elizaAppUserService.resolvePersonalDelivery({
+      platform: "discord",
+      discordId: input.discordId,
+      username: input.username,
+    });
+
+    expect(replayed).toMatchObject({
+      userId: created.userId,
+      organizationId: created.organizationId,
+      resolution: "single-query-repeat",
+    });
+    const [canonical] = await dbWrite.select().from(users).where(eq(users.id, created.userId));
+    const [projection] = await dbWrite
+      .select()
+      .from(userIdentities)
+      .where(eq(userIdentities.user_id, created.userId));
+    expect(canonical).toMatchObject({
+      discord_global_name: input.globalName,
+      discord_avatar_url: input.avatarUrl,
+    });
+    expect(projection).toMatchObject({
+      discord_global_name: input.globalName,
+      discord_avatar_url: input.avatarUrl,
+    });
+  });
+
   test("returns exact Dedicated authority and falls back when another target is newer", async () => {
     const input = discordInput("814700102");
     const account = await elizaAppUserService.resolvePersonalDelivery(input);

--- a/packages/cloud/shared/src/db/repositories/personal-shared-deliveries.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-deliveries.integration.test.ts
@@ -1,7 +1,7 @@
 /**
- * Drives repeat-turn Telegram resolution against the real Drizzle schema on
- * isolated PGlite, including single-statement reuse, exact Dedicated authority,
- * stale-projection repair, and concurrent first contact.
+ * Drives repeat-turn Telegram and Discord resolution against the real Drizzle
+ * schema on isolated PGlite, including single-statement reuse, exact Dedicated
+ * authority, stale-projection repair, and concurrent first contact.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
@@ -22,6 +22,7 @@ import { elizaAppUserService } from "../../lib/services/eliza-app/user-service";
 import { personalSharedAgentId } from "../../lib/services/shared-runtime/personal-shared-agent";
 import { closeDatabaseConnectionsForTests, dbWrite, getPgliteClientForTests } from "../client";
 import { agentSandboxes } from "../schemas/agent-sandboxes";
+import { apiKeys } from "../schemas/api-keys";
 import { organizationBalanceRevisionSequence, organizations } from "../schemas/organizations";
 import { userCharacters } from "../schemas/user-characters";
 import { userIdentities } from "../schemas/user-identities";
@@ -32,10 +33,21 @@ let pgliteReady = true;
 
 function telegramInput(telegramId: string) {
   return {
+    platform: "telegram" as const,
     telegramId,
     username: `user_${telegramId}`,
     firstName: "Nubs",
     displayName: "Nubs",
+  };
+}
+
+function discordInput(discordId: string) {
+  return {
+    platform: "discord" as const,
+    discordId,
+    username: `user_${discordId}`,
+    globalName: "Nubs",
+    avatarUrl: `https://cdn.discordapp.com/avatars/${discordId}/avatar.png`,
   };
 }
 
@@ -71,6 +83,7 @@ beforeAll(async () => {
         userIdentities,
         userCharacters,
         agentSandboxes,
+        apiKeys,
       } as never,
       dbWrite as never,
     );
@@ -87,6 +100,7 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   expect(pgliteReady).toBe(true);
+  await dbWrite.delete(apiKeys);
   await dbWrite.delete(agentSandboxes);
   await dbWrite.delete(userIdentities);
   await dbWrite.delete(users);
@@ -100,7 +114,7 @@ afterAll(async () => {
 describe("Telegram personal Shared repeat delivery", () => {
   test("reuses a converged account in one statement without rewriting identity rows", async () => {
     const input = telegramInput("714700101");
-    const created = await elizaAppUserService.resolvePersonalDeliveryByTelegram(input);
+    const created = await elizaAppUserService.resolvePersonalDelivery(input);
     const [userBefore] = await dbWrite.select().from(users).where(eq(users.id, created.userId));
     const [projectionBefore] = await dbWrite
       .select()
@@ -108,7 +122,7 @@ describe("Telegram personal Shared repeat delivery", () => {
       .where(eq(userIdentities.user_id, created.userId));
 
     const query = spyOn(getPgliteClientForTests(), "query");
-    const replayed = await elizaAppUserService.resolvePersonalDeliveryByTelegram(input);
+    const replayed = await elizaAppUserService.resolvePersonalDelivery(input);
     expect(query).toHaveBeenCalledTimes(1);
     query.mockRestore();
 
@@ -130,7 +144,7 @@ describe("Telegram personal Shared repeat delivery", () => {
 
   test("returns the exact authoritative Dedicated target in the repeat statement", async () => {
     const input = telegramInput("714700102");
-    const account = await elizaAppUserService.resolvePersonalDeliveryByTelegram(input);
+    const account = await elizaAppUserService.resolvePersonalDelivery(input);
     const sourceAgentId = personalSharedAgentId({
       userId: account.userId,
       organizationId: account.organizationId,
@@ -151,7 +165,7 @@ describe("Telegram personal Shared repeat delivery", () => {
       .returning();
 
     const query = spyOn(getPgliteClientForTests(), "query");
-    const replayed = await elizaAppUserService.resolvePersonalDeliveryByTelegram(input);
+    const replayed = await elizaAppUserService.resolvePersonalDelivery(input);
     expect(query).toHaveBeenCalledTimes(1);
     query.mockRestore();
     expect(replayed.dedicatedTarget).toMatchObject({
@@ -162,7 +176,7 @@ describe("Telegram personal Shared repeat delivery", () => {
 
   test("falls back to exact marker authority when another org target is newer", async () => {
     const input = telegramInput("714700105");
-    const account = await elizaAppUserService.resolvePersonalDeliveryByTelegram(input);
+    const account = await elizaAppUserService.resolvePersonalDelivery(input);
     const sourceAgentId = personalSharedAgentId({
       userId: account.userId,
       organizationId: account.organizationId,
@@ -191,7 +205,7 @@ describe("Telegram personal Shared repeat delivery", () => {
     });
 
     const query = spyOn(getPgliteClientForTests(), "query");
-    const replayed = await elizaAppUserService.resolvePersonalDeliveryByTelegram(input);
+    const replayed = await elizaAppUserService.resolvePersonalDelivery(input);
     expect(query).toHaveBeenCalledTimes(2);
     query.mockRestore();
     expect(replayed.resolution).toBe("exact-dedicated-fallback");
@@ -200,13 +214,13 @@ describe("Telegram personal Shared repeat delivery", () => {
 
   test("repairs a stale projection through the sender-locked writer", async () => {
     const input = telegramInput("714700103");
-    const account = await elizaAppUserService.resolvePersonalDeliveryByTelegram(input);
+    const account = await elizaAppUserService.resolvePersonalDelivery(input);
     await dbWrite
       .update(userIdentities)
       .set({ telegram_username: "stale_username" })
       .where(eq(userIdentities.user_id, account.userId));
 
-    const repaired = await elizaAppUserService.resolvePersonalDeliveryByTelegram(input);
+    const repaired = await elizaAppUserService.resolvePersonalDelivery(input);
     expect(repaired.resolution).toBe("locked-create-or-repair");
     const [projection] = await dbWrite
       .select()
@@ -217,9 +231,9 @@ describe("Telegram personal Shared repeat delivery", () => {
 
   test("persists changed Telegram profile metadata through locked repair", async () => {
     const input = telegramInput("714700106");
-    const account = await elizaAppUserService.resolvePersonalDeliveryByTelegram(input);
+    const account = await elizaAppUserService.resolvePersonalDelivery(input);
 
-    const repaired = await elizaAppUserService.resolvePersonalDeliveryByTelegram({
+    const repaired = await elizaAppUserService.resolvePersonalDelivery({
       ...input,
       username: "renamed_user",
       firstName: "Luna",
@@ -243,8 +257,8 @@ describe("Telegram personal Shared repeat delivery", () => {
   test("fails closed when the Telegram projection points at another tenant", async () => {
     const firstInput = telegramInput("714700107");
     const secondInput = telegramInput("714700108");
-    const first = await elizaAppUserService.resolvePersonalDeliveryByTelegram(firstInput);
-    const second = await elizaAppUserService.resolvePersonalDeliveryByTelegram(secondInput);
+    const first = await elizaAppUserService.resolvePersonalDelivery(firstInput);
+    const second = await elizaAppUserService.resolvePersonalDelivery(secondInput);
     const [secondBefore] = await dbWrite.select().from(users).where(eq(users.id, second.userId));
 
     await dbWrite.delete(userIdentities).where(eq(userIdentities.user_id, second.userId));
@@ -253,9 +267,7 @@ describe("Telegram personal Shared repeat delivery", () => {
       .set({ user_id: second.userId })
       .where(eq(userIdentities.user_id, first.userId));
 
-    await expect(
-      elizaAppUserService.resolvePersonalDeliveryByTelegram(firstInput),
-    ).rejects.toMatchObject({
+    await expect(elizaAppUserService.resolvePersonalDelivery(firstInput)).rejects.toMatchObject({
       code: "TELEGRAM_PERSONAL_ACCOUNT_IDENTITY_CONFLICT",
     });
 
@@ -272,8 +284,8 @@ describe("Telegram personal Shared repeat delivery", () => {
   test("concurrent first contacts converge on one zero-credit account", async () => {
     const input = telegramInput("714700104");
     const [first, second] = await Promise.all([
-      elizaAppUserService.resolvePersonalDeliveryByTelegram(input),
-      elizaAppUserService.resolvePersonalDeliveryByTelegram(input),
+      elizaAppUserService.resolvePersonalDelivery(input),
+      elizaAppUserService.resolvePersonalDelivery(input),
     ]);
 
     expect(second.userId).toBe(first.userId);
@@ -294,5 +306,164 @@ describe("Telegram personal Shared repeat delivery", () => {
     expect(projections).toEqual([{ userId: first.userId }]);
     expect(organization).toHaveLength(1);
     expect(Number(organization[0]?.credit_balance)).toBe(0);
+  });
+});
+
+describe("Discord personal Shared repeat delivery", () => {
+  test("reuses a converged account in one statement without rewriting identity rows", async () => {
+    const input = discordInput("814700101");
+    const created = await elizaAppUserService.resolvePersonalDelivery(input);
+    const [userBefore] = await dbWrite.select().from(users).where(eq(users.id, created.userId));
+    const [projectionBefore] = await dbWrite
+      .select()
+      .from(userIdentities)
+      .where(eq(userIdentities.user_id, created.userId));
+
+    const query = spyOn(getPgliteClientForTests(), "query");
+    const replayed = await elizaAppUserService.resolvePersonalDelivery(input);
+    expect(query).toHaveBeenCalledTimes(1);
+    query.mockRestore();
+
+    const [userAfter] = await dbWrite.select().from(users).where(eq(users.id, created.userId));
+    const [projectionAfter] = await dbWrite
+      .select()
+      .from(userIdentities)
+      .where(eq(userIdentities.user_id, created.userId));
+    expect(replayed).toMatchObject({
+      userId: created.userId,
+      organizationId: created.organizationId,
+      dedicatedTarget: null,
+      isNew: false,
+      resolution: "single-query-repeat",
+    });
+    expect(userAfter.updated_at).toEqual(userBefore.updated_at);
+    expect(projectionAfter.updated_at).toEqual(projectionBefore.updated_at);
+  });
+
+  test("returns exact Dedicated authority and falls back when another target is newer", async () => {
+    const input = discordInput("814700102");
+    const account = await elizaAppUserService.resolvePersonalDelivery(input);
+    const sourceAgentId = personalSharedAgentId({
+      userId: account.userId,
+      organizationId: account.organizationId,
+    });
+    const [exact] = await dbWrite
+      .insert(agentSandboxes)
+      .values({
+        organization_id: account.organizationId,
+        user_id: account.userId,
+        execution_tier: "dedicated-always",
+        status: "running",
+        created_at: new Date("2026-08-15T12:00:00.000Z"),
+        agent_config: {
+          [AGENT_UPGRADED_FROM_KEY]: sourceAgentId,
+          [AGENT_PERSONAL_CUTOVER_KEY]: cutoverFor(sourceAgentId),
+        },
+      })
+      .returning();
+
+    const directQuery = spyOn(getPgliteClientForTests(), "query");
+    const direct = await elizaAppUserService.resolvePersonalDelivery(input);
+    expect(directQuery).toHaveBeenCalledTimes(1);
+    directQuery.mockRestore();
+    expect(direct.dedicatedTarget?.id).toBe(exact.id);
+
+    await dbWrite.insert(agentSandboxes).values({
+      organization_id: account.organizationId,
+      user_id: account.userId,
+      execution_tier: "dedicated-always",
+      status: "running",
+      created_at: new Date("2026-08-15T12:01:00.000Z"),
+      agent_config: { [AGENT_UPGRADED_FROM_KEY]: "personal:another-account" },
+    });
+    const fallbackQuery = spyOn(getPgliteClientForTests(), "query");
+    const fallback = await elizaAppUserService.resolvePersonalDelivery(input);
+    expect(fallbackQuery).toHaveBeenCalledTimes(2);
+    fallbackQuery.mockRestore();
+    expect(fallback.resolution).toBe("exact-dedicated-fallback");
+    expect(fallback.dedicatedTarget?.id).toBe(exact.id);
+  });
+
+  test("repairs canonical-only and changed Discord profile projections atomically", async () => {
+    const input = discordInput("814700103");
+    const account = await elizaAppUserService.resolvePersonalDelivery(input);
+    await dbWrite.delete(userIdentities).where(eq(userIdentities.user_id, account.userId));
+
+    const repairedProjection = await elizaAppUserService.resolvePersonalDelivery(input);
+    expect(repairedProjection.resolution).toBe("locked-create-or-repair");
+
+    const changed = {
+      ...input,
+      username: "renamed_user",
+      globalName: "Luna",
+      avatarUrl: null,
+    };
+    const repairedProfile = await elizaAppUserService.resolvePersonalDelivery(changed);
+    expect(repairedProfile.resolution).toBe("locked-create-or-repair");
+    const [canonical] = await dbWrite.select().from(users).where(eq(users.id, account.userId));
+    const [projection] = await dbWrite
+      .select()
+      .from(userIdentities)
+      .where(eq(userIdentities.user_id, account.userId));
+    expect(canonical).toMatchObject({
+      discord_username: "renamed_user",
+      discord_global_name: "Luna",
+      discord_avatar_url: null,
+    });
+    expect(projection).toMatchObject({
+      discord_username: "renamed_user",
+      discord_global_name: "Luna",
+      discord_avatar_url: null,
+    });
+  });
+
+  test("fails closed when the Discord projection points at another tenant", async () => {
+    const firstInput = discordInput("814700104");
+    const secondInput = discordInput("814700105");
+    const first = await elizaAppUserService.resolvePersonalDelivery(firstInput);
+    const second = await elizaAppUserService.resolvePersonalDelivery(secondInput);
+    const [secondBefore] = await dbWrite.select().from(users).where(eq(users.id, second.userId));
+
+    await dbWrite.delete(userIdentities).where(eq(userIdentities.user_id, second.userId));
+    await dbWrite
+      .update(userIdentities)
+      .set({ user_id: second.userId })
+      .where(eq(userIdentities.user_id, first.userId));
+
+    await expect(elizaAppUserService.resolvePersonalDelivery(firstInput)).rejects.toMatchObject({
+      code: "DISCORD_PERSONAL_ACCOUNT_IDENTITY_CONFLICT",
+    });
+    const [secondAfter] = await dbWrite.select().from(users).where(eq(users.id, second.userId));
+    expect(secondAfter).toEqual(secondBefore);
+    expect(first.organizationId).not.toBe(second.organizationId);
+  });
+
+  test("concurrent first contacts converge on one zero-cost account", async () => {
+    const input = discordInput("814700106");
+    const [first, second] = await Promise.all([
+      elizaAppUserService.resolvePersonalDelivery(input),
+      elizaAppUserService.resolvePersonalDelivery(input),
+    ]);
+
+    expect(second.userId).toBe(first.userId);
+    expect(second.organizationId).toBe(first.organizationId);
+    const canonical = await dbWrite
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.discord_id, input.discordId));
+    const projections = await dbWrite
+      .select({ userId: userIdentities.user_id })
+      .from(userIdentities)
+      .where(eq(userIdentities.discord_id, input.discordId));
+    const organization = await dbWrite
+      .select()
+      .from(organizations)
+      .where(eq(organizations.id, first.organizationId));
+    expect(canonical).toEqual([{ id: first.userId }]);
+    expect(projections).toEqual([{ userId: first.userId }]);
+    expect(organization).toHaveLength(1);
+    expect(Number(organization[0]?.credit_balance)).toBe(0);
+    expect(await dbWrite.select().from(apiKeys)).toHaveLength(0);
+    expect(await dbWrite.select().from(agentSandboxes)).toHaveLength(0);
   });
 });

--- a/packages/cloud/shared/src/db/repositories/personal-shared-deliveries.ts
+++ b/packages/cloud/shared/src/db/repositories/personal-shared-deliveries.ts
@@ -1,7 +1,7 @@
 /**
- * Resolves the read-only repeat-turn projection for a Telegram personal Eliza
- * delivery. Only a fully converged canonical identity, lookup projection, and
- * active organization qualifies; every repair or creation case stays on the
+ * Resolves read-only repeat-turn projections for personal Eliza messaging.
+ * Only a fully converged canonical identity, lookup projection, and active
+ * organization qualifies; every repair or creation case stays on the
  * sender-locked users repository path.
  */
 
@@ -15,7 +15,7 @@ import { organizations } from "../schemas/organizations";
 import { userIdentities } from "../schemas/user-identities";
 import { users } from "../schemas/users";
 
-export interface ReusableTelegramPersonalDelivery {
+export interface ReusablePersonalDelivery {
   userId: string;
   organizationId: string;
   dedicatedCandidate: {
@@ -26,7 +26,7 @@ export interface ReusableTelegramPersonalDelivery {
   } | null;
 }
 
-interface ReusableTelegramPersonalDeliveryRow {
+interface ReusablePersonalDeliveryRow {
   user_id: string;
   organization_id: string;
   dedicated_id: string | null;
@@ -36,17 +36,63 @@ interface ReusableTelegramPersonalDeliveryRow {
 }
 
 /**
- * One indexed primary-database statement serves an established Telegram turn.
+ * One indexed primary-database statement serves an established messaging turn.
  * The bounded target candidate avoids a second lookup for the normal one-user
  * organization; callers retain the exact source-marker lookup when another
  * personal target in the organization sorts ahead of this account's target.
  */
-export async function findReusableTelegramPersonalDelivery(params: {
-  telegramId: string;
-  telegramUsername?: string;
-  telegramFirstName?: string;
-}): Promise<ReusableTelegramPersonalDelivery | null> {
-  const [row] = await sqlRows<ReusableTelegramPersonalDeliveryRow>(
+export async function findReusablePersonalDelivery(
+  params:
+    | {
+        platform: "telegram";
+        telegramId: string;
+        telegramUsername?: string;
+        telegramFirstName?: string;
+      }
+    | {
+        platform: "discord";
+        discordId: string;
+        discordUsername: string;
+        discordGlobalName?: string | null;
+        discordAvatarUrl?: string | null;
+      },
+): Promise<ReusablePersonalDelivery | null> {
+  const canonicalIdentity =
+    params.platform === "telegram"
+      ? sql`
+          canonical.telegram_id = ${params.telegramId}
+          AND canonical.telegram_username IS NOT DISTINCT FROM projection.telegram_username
+          AND canonical.telegram_first_name IS NOT DISTINCT FROM projection.telegram_first_name
+          AND (
+            ${params.telegramUsername ?? null}::text IS NULL
+            OR canonical.telegram_username = ${params.telegramUsername ?? null}
+          )
+          AND (
+            ${params.telegramFirstName ?? null}::text IS NULL
+            OR canonical.telegram_first_name = ${params.telegramFirstName ?? null}
+          )
+        `
+      : sql`
+          canonical.discord_id = ${params.discordId}
+          AND canonical.discord_username IS NOT DISTINCT FROM projection.discord_username
+          AND canonical.discord_global_name IS NOT DISTINCT FROM projection.discord_global_name
+          AND canonical.discord_avatar_url IS NOT DISTINCT FROM projection.discord_avatar_url
+          AND canonical.discord_username = ${params.discordUsername}
+          AND (
+            ${params.discordGlobalName === undefined}
+            OR canonical.discord_global_name IS NOT DISTINCT FROM ${params.discordGlobalName ?? null}
+          )
+          AND (
+            ${params.discordAvatarUrl === undefined}
+            OR canonical.discord_avatar_url IS NOT DISTINCT FROM ${params.discordAvatarUrl ?? null}
+          )
+        `;
+  const projectedIdentity =
+    params.platform === "telegram"
+      ? sql`projection.telegram_id = ${params.telegramId}`
+      : sql`projection.discord_id = ${params.discordId}`;
+
+  const [row] = await sqlRows<ReusablePersonalDeliveryRow>(
     dbWrite,
     sql`
       SELECT
@@ -59,19 +105,9 @@ export async function findReusableTelegramPersonalDelivery(params: {
       FROM ${userIdentities} projection
       INNER JOIN ${users} canonical
         ON canonical.id = projection.user_id
-        AND canonical.telegram_id = ${params.telegramId}
+        AND ${canonicalIdentity}
         AND canonical.steward_user_id = projection.steward_user_id
         AND canonical.is_anonymous = projection.is_anonymous
-        AND canonical.telegram_username IS NOT DISTINCT FROM projection.telegram_username
-        AND canonical.telegram_first_name IS NOT DISTINCT FROM projection.telegram_first_name
-        AND (
-          ${params.telegramUsername ?? null}::text IS NULL
-          OR canonical.telegram_username = ${params.telegramUsername ?? null}
-        )
-        AND (
-          ${params.telegramFirstName ?? null}::text IS NULL
-          OR canonical.telegram_first_name = ${params.telegramFirstName ?? null}
-        )
       INNER JOIN ${organizations} organization
         ON organization.id = canonical.organization_id
         AND organization.is_active = TRUE
@@ -88,7 +124,7 @@ export async function findReusableTelegramPersonalDelivery(params: {
         ORDER BY candidate.created_at DESC
         LIMIT 1
       ) dedicated ON TRUE
-      WHERE projection.telegram_id = ${params.telegramId}
+      WHERE ${projectedIdentity}
         AND canonical.deleted_at IS NULL
         AND canonical.is_active = TRUE
         AND canonical.organization_id IS NOT NULL

--- a/packages/cloud/shared/src/db/repositories/users-identity-link.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/users-identity-link.integration.test.ts
@@ -169,9 +169,10 @@ describe("UsersRepository.linkTelegramAndPhoneIdentity", () => {
   });
 });
 
-describe("UsersRepository.findOrCreateTelegramPersonalAccount", () => {
+describe("UsersRepository.findOrCreateMessagingPersonalAccount", () => {
   test("creates one $0 rowless account and reuses it on replay", async () => {
     const input = {
+      platform: "telegram" as const,
       telegramId: "714700001",
       telegramUsername: "elizaisnotabot_user",
       telegramFirstName: "Nubs",
@@ -180,8 +181,8 @@ describe("UsersRepository.findOrCreateTelegramPersonalAccount", () => {
       organizationSlug: "tg-714700001",
     };
 
-    const created = await usersRepository.findOrCreateTelegramPersonalAccount(input);
-    const replayed = await usersRepository.findOrCreateTelegramPersonalAccount({
+    const created = await usersRepository.findOrCreateMessagingPersonalAccount(input);
+    const replayed = await usersRepository.findOrCreateMessagingPersonalAccount({
       ...input,
       displayName: "Nubs Updated",
     });

--- a/packages/cloud/shared/src/db/repositories/users.ts
+++ b/packages/cloud/shared/src/db/repositories/users.ts
@@ -57,11 +57,32 @@ export interface ResolvedIdentity {
   identity?: UserIdentity;
 }
 
-export interface FindOrCreateTelegramPersonalAccountResult {
+export interface FindOrCreateMessagingPersonalAccountResult {
   user: User;
   organization: Organization;
   isNew: boolean;
 }
+
+export type MessagingPersonalAccountParams =
+  | {
+      platform: "telegram";
+      telegramId: string;
+      telegramUsername?: string;
+      telegramFirstName?: string;
+      displayName: string;
+      organizationName: string;
+      organizationSlug: string;
+    }
+  | {
+      platform: "discord";
+      discordId: string;
+      discordUsername: string;
+      discordGlobalName?: string | null;
+      discordAvatarUrl?: string | null;
+      displayName: string;
+      organizationName: string;
+      organizationSlug: string;
+    };
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{12}$/i;
 const EVM_ADDRESS_RE = /^0x[0-9a-f]{40}$/i;
@@ -2009,37 +2030,53 @@ export class UsersRepository {
   }
 
   /**
-   * Creates or reuses the $0 personal account proven by Telegram's signed
-   * webhook boundary. A sender-scoped transaction lock makes concurrent first
-   * updates converge without an agent row or orphan organization.
+   * Creates or reuses the $0 personal account proven by a trusted messaging
+   * boundary. A provider-sender transaction lock makes concurrent first turns
+   * converge without an API key, agent row, or orphan organization.
    */
-  async findOrCreateTelegramPersonalAccount(params: {
-    telegramId: string;
-    telegramUsername?: string;
-    telegramFirstName?: string;
-    displayName: string;
-    organizationName: string;
-    organizationSlug: string;
-  }): Promise<FindOrCreateTelegramPersonalAccountResult> {
+  async findOrCreateMessagingPersonalAccount(
+    params: MessagingPersonalAccountParams,
+  ): Promise<FindOrCreateMessagingPersonalAccountResult> {
+    const senderId = params.platform === "telegram" ? params.telegramId : params.discordId;
+    const identityWhere =
+      params.platform === "telegram"
+        ? eq(userIdentities.telegram_id, senderId)
+        : eq(userIdentities.discord_id, senderId);
+    const canonicalWhere =
+      params.platform === "telegram"
+        ? eq(users.telegram_id, senderId)
+        : eq(users.discord_id, senderId);
+    const identityFields =
+      params.platform === "telegram"
+        ? {
+            telegram_id: senderId,
+            telegram_username: params.telegramUsername,
+            telegram_first_name: params.telegramFirstName,
+          }
+        : {
+            discord_id: senderId,
+            discord_username: params.discordUsername,
+            discord_global_name: params.discordGlobalName,
+            discord_avatar_url: params.discordAvatarUrl,
+          };
+    const label = params.platform === "telegram" ? "Telegram" : "Discord";
+    const errorPrefix = params.platform.toUpperCase();
+
     return dbWrite.transaction(async (tx) => {
       await tx.execute(
-        sql`SELECT pg_advisory_xact_lock(hashtext(${`telegram_personal_account:${params.telegramId}`}))`,
+        sql`SELECT pg_advisory_xact_lock(hashtext(${`${params.platform}_personal_account:${senderId}`}))`,
       );
 
       const [projection] = await tx
         .select({ userId: userIdentities.user_id })
         .from(userIdentities)
-        .where(eq(userIdentities.telegram_id, params.telegramId))
+        .where(identityWhere)
         .limit(1);
-      const [canonical] = await tx
-        .select()
-        .from(users)
-        .where(eq(users.telegram_id, params.telegramId))
-        .limit(1);
+      const [canonical] = await tx.select().from(users).where(canonicalWhere).limit(1);
 
       if (projection && canonical && projection.userId !== canonical.id) {
-        throw new ElizaError("Telegram identity owners disagree", {
-          code: "TELEGRAM_PERSONAL_ACCOUNT_IDENTITY_CONFLICT",
+        throw new ElizaError(`${label} identity owners disagree`, {
+          code: `${errorPrefix}_PERSONAL_ACCOUNT_IDENTITY_CONFLICT`,
           context: { canonicalUserId: canonical.id, projectedUserId: projection.userId },
           severity: "fatal",
         });
@@ -2051,17 +2088,26 @@ export class UsersRepository {
           ? [canonical]
           : [];
       if (projection && !existing) {
-        throw new ElizaError("Telegram identity projection has no canonical owner", {
-          code: "TELEGRAM_PERSONAL_ACCOUNT_IDENTITY_CONFLICT",
+        throw new ElizaError(`${label} identity projection has no canonical owner`, {
+          code: `${errorPrefix}_PERSONAL_ACCOUNT_IDENTITY_CONFLICT`,
           context: { projectedUserId: projection.userId },
           severity: "fatal",
         });
       }
 
       if (existing) {
+        const existingSenderId =
+          params.platform === "telegram" ? existing.telegram_id : existing.discord_id;
+        if (projection && existingSenderId && existingSenderId !== senderId) {
+          throw new ElizaError(`${label} identity projection belongs to another sender`, {
+            code: `${errorPrefix}_PERSONAL_ACCOUNT_IDENTITY_CONFLICT`,
+            context: { projectedUserId: projection.userId },
+            severity: "fatal",
+          });
+        }
         if (existing.deleted_at || !existing.is_active || !existing.organization_id) {
-          throw new ElizaError("Telegram personal account is unavailable", {
-            code: "TELEGRAM_PERSONAL_ACCOUNT_UNAVAILABLE",
+          throw new ElizaError(`${label} personal account is unavailable`, {
+            code: `${errorPrefix}_PERSONAL_ACCOUNT_UNAVAILABLE`,
             context: { userId: existing.id },
             severity: "fatal",
           });
@@ -2072,8 +2118,8 @@ export class UsersRepository {
           .where(eq(organizations.id, existing.organization_id))
           .limit(1);
         if (!organization?.is_active) {
-          throw new ElizaError("Telegram personal account organization is unavailable", {
-            code: "TELEGRAM_PERSONAL_ACCOUNT_UNAVAILABLE",
+          throw new ElizaError(`${label} personal account organization is unavailable`, {
+            code: `${errorPrefix}_PERSONAL_ACCOUNT_UNAVAILABLE`,
             context: { userId: existing.id, organizationId: existing.organization_id },
             severity: "fatal",
           });
@@ -2083,32 +2129,26 @@ export class UsersRepository {
         const [updated] = await tx
           .update(users)
           .set({
-            telegram_id: params.telegramId,
-            telegram_username: params.telegramUsername,
-            telegram_first_name: params.telegramFirstName,
+            ...identityFields,
             name: existing.name ?? params.displayName,
             updated_at: now,
           })
           .where(eq(users.id, existing.id))
           .returning();
-        if (!updated) throw new Error(`Telegram account ${existing.id} disappeared`);
+        if (!updated) throw new Error(`${label} account ${existing.id} disappeared`);
         await tx
           .insert(userIdentities)
           .values({
             user_id: updated.id,
             steward_user_id: updated.steward_user_id,
             is_anonymous: updated.is_anonymous,
-            telegram_id: params.telegramId,
-            telegram_username: params.telegramUsername,
-            telegram_first_name: params.telegramFirstName,
+            ...identityFields,
             updated_at: now,
           })
           .onConflictDoUpdate({
             target: userIdentities.user_id,
             set: {
-              telegram_id: params.telegramId,
-              telegram_username: params.telegramUsername,
-              telegram_first_name: params.telegramFirstName,
+              ...identityFields,
               updated_at: now,
             },
           });
@@ -2123,15 +2163,13 @@ export class UsersRepository {
           credit_balance: "0.00",
         })
         .returning();
-      if (!organization) throw new Error("Failed to create Telegram personal organization");
+      if (!organization) throw new Error(`Failed to create ${label} personal organization`);
 
       const [user] = await tx
         .insert(users)
         .values({
-          steward_user_id: `telegram:${params.telegramId}`,
-          telegram_id: params.telegramId,
-          telegram_username: params.telegramUsername,
-          telegram_first_name: params.telegramFirstName,
+          steward_user_id: `${params.platform}:${senderId}`,
+          ...identityFields,
           name: params.displayName,
           is_anonymous: false,
           organization_id: organization.id,
@@ -2139,14 +2177,12 @@ export class UsersRepository {
           is_active: true,
         })
         .returning();
-      if (!user) throw new Error("Failed to create Telegram personal user");
+      if (!user) throw new Error(`Failed to create ${label} personal user`);
       await tx.insert(userIdentities).values({
         user_id: user.id,
         steward_user_id: user.steward_user_id,
         is_anonymous: false,
-        telegram_id: params.telegramId,
-        telegram_username: params.telegramUsername,
-        telegram_first_name: params.telegramFirstName,
+        ...identityFields,
       });
       return { user, organization, isNew: true };
     });

--- a/packages/cloud/shared/src/lib/services/eliza-app/user-service.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/user-service.ts
@@ -12,7 +12,7 @@
  */
 
 import { organizationsRepository } from "../../../db/repositories/organizations";
-import { findReusableTelegramPersonalDelivery } from "../../../db/repositories/personal-shared-deliveries";
+import { findReusablePersonalDelivery } from "../../../db/repositories/personal-shared-deliveries";
 import { type UserWithOrganization, usersRepository } from "../../../db/repositories/users";
 import type { AgentSandbox } from "../../../db/schemas/agent-sandboxes";
 import type { Organization } from "../../../db/schemas/organizations";
@@ -38,7 +38,7 @@ export interface FindOrCreateResult {
   isNew: boolean;
 }
 
-export interface TelegramPersonalDeliveryResult {
+export interface PersonalDeliveryResult {
   userId: string;
   organizationId: string;
   dedicatedTarget: Pick<AgentSandbox, "id" | "status" | "bridge_url" | "agent_config"> | null;
@@ -172,7 +172,8 @@ class ElizaAppUserService {
       params.firstName?.trim() ||
       params.username?.trim() ||
       "Eliza user";
-    const result = await usersRepository.findOrCreateTelegramPersonalAccount({
+    const result = await usersRepository.findOrCreateMessagingPersonalAccount({
+      platform: "telegram",
       telegramId,
       telegramUsername: params.username?.trim() || undefined,
       telegramFirstName: params.firstName?.trim() || undefined,
@@ -194,37 +195,76 @@ class ElizaAppUserService {
   }
 
   /**
-   * Resolves an established Telegram account and its active runtime in one
-   * read-only statement. Missing, stale, or conflicting projections retain the
-   * existing sender-locked convergence transaction as the only repair writer.
+   * Resolves an established trusted-messaging account and its active runtime
+   * in one read-only statement. Missing, stale, or conflicting projections
+   * retain one sender-locked convergence transaction as the only repair writer.
    */
-  async resolvePersonalDeliveryByTelegram(params: {
-    telegramId: string;
-    username?: string;
-    firstName?: string;
-    displayName?: string;
-  }): Promise<TelegramPersonalDeliveryResult> {
-    const telegramId = params.telegramId.trim();
-    if (!/^\d{1,20}$/.test(telegramId)) {
-      throw new Error("Trusted Telegram transport supplied an invalid sender id");
+  async resolvePersonalDelivery(
+    params:
+      | {
+          platform: "telegram";
+          telegramId: string;
+          username?: string;
+          firstName?: string;
+          displayName?: string;
+        }
+      | {
+          platform: "discord";
+          discordId: string;
+          username: string;
+          globalName?: string | null;
+          avatarUrl?: string | null;
+        },
+  ): Promise<PersonalDeliveryResult> {
+    const senderId =
+      params.platform === "telegram" ? params.telegramId.trim() : params.discordId.trim();
+    const idPattern = params.platform === "telegram" ? /^\d{1,20}$/ : /^\d{1,32}$/;
+    if (!idPattern.test(senderId)) {
+      throw new Error(`Trusted ${params.platform} transport supplied an invalid sender id`);
     }
     const username = params.username?.trim() || undefined;
-    const firstName = params.firstName?.trim() || undefined;
-    const displayName = params.displayName?.trim() || firstName || username || "Eliza user";
+    if (params.platform === "discord" && !username) {
+      throw new Error("Trusted Discord transport supplied an invalid username");
+    }
+    const firstName =
+      params.platform === "telegram" ? params.firstName?.trim() || undefined : undefined;
+    const globalName =
+      params.platform === "discord"
+        ? params.globalName === undefined
+          ? undefined
+          : params.globalName?.trim() || null
+        : undefined;
+    const avatarUrl = params.platform === "discord" ? params.avatarUrl : undefined;
+    const displayName =
+      (params.platform === "telegram" ? params.displayName?.trim() : globalName) ||
+      firstName ||
+      username ||
+      "Eliza user";
 
-    const reusable = await findReusableTelegramPersonalDelivery({
-      telegramId,
-      telegramUsername: username,
-      telegramFirstName: firstName,
-    });
+    const reusable = await findReusablePersonalDelivery(
+      params.platform === "telegram"
+        ? {
+            platform: "telegram",
+            telegramId: senderId,
+            telegramUsername: username,
+            telegramFirstName: firstName,
+          }
+        : {
+            platform: "discord",
+            discordId: senderId,
+            discordUsername: params.username.trim(),
+            discordGlobalName: globalName,
+            discordAvatarUrl: avatarUrl,
+          },
+    );
     if (reusable) {
       const personalAgentId = personalSharedAgentId({
         userId: reusable.userId,
         organizationId: reusable.organizationId,
       });
       const candidate = reusable.dedicatedCandidate;
-      let dedicatedTarget: TelegramPersonalDeliveryResult["dedicatedTarget"] = null;
-      let resolution: TelegramPersonalDeliveryResult["resolution"] = "single-query-repeat";
+      let dedicatedTarget: PersonalDeliveryResult["dedicatedTarget"] = null;
+      let resolution: PersonalDeliveryResult["resolution"] = "single-query-repeat";
       if (candidate) {
         if (readUpgradedFromAgentId(candidate.agent_config) === personalAgentId) {
           dedicatedTarget = isAuthoritativePersonalDedicatedTarget(candidate, personalAgentId)
@@ -238,10 +278,10 @@ class ElizaAppUserService {
           resolution = "exact-dedicated-fallback";
         }
       }
-      logger.info("[ElizaAppUserService] Reused Telegram personal account", {
+      logger.info(`[ElizaAppUserService] Reused ${params.platform} personal account`, {
         userId: reusable.userId,
         organizationId: reusable.organizationId,
-        telegramId,
+        platform: params.platform,
         resolution,
       });
       return {
@@ -253,14 +293,28 @@ class ElizaAppUserService {
       };
     }
 
-    const result = await usersRepository.findOrCreateTelegramPersonalAccount({
-      telegramId,
-      telegramUsername: username,
-      telegramFirstName: firstName,
-      displayName,
-      organizationName: `${displayName}'s Workspace`,
-      organizationSlug: generateSlugFromTelegram(username, telegramId),
-    });
+    const result = await usersRepository.findOrCreateMessagingPersonalAccount(
+      params.platform === "telegram"
+        ? {
+            platform: "telegram",
+            telegramId: senderId,
+            telegramUsername: username,
+            telegramFirstName: firstName,
+            displayName,
+            organizationName: `${displayName}'s Workspace`,
+            organizationSlug: generateSlugFromTelegram(username, senderId),
+          }
+        : {
+            platform: "discord",
+            discordId: senderId,
+            discordUsername: params.username.trim(),
+            discordGlobalName: globalName,
+            discordAvatarUrl: avatarUrl,
+            displayName,
+            organizationName: `${displayName}'s Workspace`,
+            organizationSlug: generateSlugFromDiscord(username, senderId),
+          },
+    );
     const personalAgentId = personalSharedAgentId({
       userId: result.user.id,
       organizationId: result.organization.id,
@@ -271,12 +325,12 @@ class ElizaAppUserService {
     );
     logger.info(
       result.isNew
-        ? "[ElizaAppUserService] Created Telegram personal account"
-        : "[ElizaAppUserService] Repaired Telegram personal account",
+        ? `[ElizaAppUserService] Created ${params.platform} personal account`
+        : `[ElizaAppUserService] Repaired ${params.platform} personal account`,
       {
         userId: result.user.id,
         organizationId: result.organization.id,
-        telegramId,
+        platform: params.platform,
         resolution: "locked-create-or-repair",
       },
     );


### PR DESCRIPTION
Closes #20119.

## Outcome

Discord personal Shared turns now use the same storage-neutral account path as Telegram:

- one indexed primary-database read for a fully converged projection, canonical user, active organization, and bounded Dedicated candidate;
- no repeat writes for a healthy unchanged sender;
- one provider/sender advisory-lock transaction for create or repair;
- zero-credit first contact with no API key or sandbox;
- fail-closed cross-tenant identity ownership;
- the existing two-marker Dedicated authority and exact fallback for ambiguous organizations.

The gateway ordering boundary remains owned by #20033; this PR does not change `GatewayManager` or claim to solve provider ordering.

## Exact candidate and verification

- Base: `0b863b695bddb36708f39bb57a2d0b520f6d19da`
- Head: `21443ad0f9514c3b4c295a86e44476575c6e3473`
- Real isolated PGlite plus route matrix: 33/33 passed, including one-statement/no-timestamp repeat, omitted optional-profile preservation, canonical/profile repair, tenant conflict, concurrent first contact, and exact/ambiguous Dedicated authority.
- Full changed integration group: 58/58 passed.
- `bun run --cwd packages/cloud/shared typecheck`: PASS.
- `bun run --cwd packages/cloud/api typecheck`: PASS, including production Wrangler dry bundle (25,681.02 KiB / gzip 6,230.52 KiB).
- Biome on all nine implementation paths plus the added exact-head regression: PASS.
- `git diff --check`: PASS.

The public pre-change production aggregate in #20119 remains the timing baseline (46 attributable turns; median 5.646s, p90 8.156s). No private message text or credentials are included. A staging deployment was not performed as part of this review.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/slopdotcash@0b863b695bddb36708f39bb57a2d0b520f6d19da:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Evidence Gate

<!-- evidence-head:21443ad0f9514c3b4c295a86e44476575c6e3473 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - server-only identity/account resolution; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - server-only identity/account resolution; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - server-only identity/account resolution; no rendered UI changed.
<!-- evidence-row:backend-logs -->
- [x] Exact-head real-PGlite and route transcript: https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20165-exact-head-backend.log
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - the change ends before Shared runtime/model entry and changes no prompt, action, provider, or model behavior.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head domain receipt: https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20165-exact-head-domain.json — real PGlite rows/receipts through repository and route boundaries; 33/33 passed with tenant, concurrency, no-rewrite, and Dedicated-authority assertions.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

AI provider/model: openai / gpt-5.6-sol  
Client / agent tooling: Codex Desktop  
Contribution skill revision: elizaOS/slopdotcash@0b863b695bddb36708f39bb57a2d0b520f6d19da:skills/contribute-to-eliza  
Attribution status: self-reported  
— [root-discord-shared-account]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"codex-desktop","skill_revision":"elizaOS/slopdotcash@0b863b695bddb36708f39bb57a2d0b520f6d19da:skills/contribute-to-eliza"} -->
