### PR TITLE
fix(core): hasFirstSentence returns false for a single complete sentence, so short voice replies produce no audio

### DIFF
--- a/packages/core/src/utils/text-splitting.test.ts
+++ b/packages/core/src/utils/text-splitting.test.ts
@@ -5,7 +5,7 @@
  * mid-abbreviation.
  */
 import { describe, expect, it } from "vitest";
-import { extractFirstSentence } from "./text-splitting.ts";
+import { extractFirstSentence, hasFirstSentence } from "./text-splitting.ts";
 
 describe("extractFirstSentence", () => {
 	it("does not split inside dotted abbreviations (e.g. / i.e.)", () => {
@@ -64,5 +64,30 @@ describe("extractFirstSentence", () => {
 		const r = extractFirstSentence("No boundary here");
 		expect(r.first).toBe("No boundary here");
 		expect(r.rest).toBe("");
+	});
+});
+
+describe("hasFirstSentence", () => {
+	it("reports true when the whole text is one complete sentence", () => {
+		// A boundary at end-of-string leaves `rest` empty, so keying off `rest`
+		// reported false and the streaming voice path never fired.
+		expect(hasFirstSentence("Sure, I added milk to your shopping list.")).toBe(
+			true,
+		);
+		expect(hasFirstSentence("Did that work?")).toBe(true);
+		expect(hasFirstSentence("Done!")).toBe(true);
+	});
+
+	it("still reports true when more text follows the first sentence", () => {
+		expect(hasFirstSentence("One. Two.")).toBe(true);
+	});
+
+	it("reports false for an incomplete fragment", () => {
+		expect(hasFirstSentence("Sure, I added")).toBe(false);
+		expect(hasFirstSentence("")).toBe(false);
+	});
+
+	it("is not fooled by an abbreviation mid-fragment", () => {
+		expect(hasFirstSentence("See e.g. the")).toBe(false);
 	});
 });

--- a/packages/core/src/utils/text-splitting.ts
+++ b/packages/core/src/utils/text-splitting.ts
@@ -5,6 +5,8 @@
 export function extractFirstSentence(text: string): {
 	first: string;
 	rest: string;
+	/** Whether a sentence boundary was actually found in `text`. */
+	complete: boolean;
 } {
 	// Regex for finding sentence boundaries.
 	// Looks for a period, question mark, or exclamation mark followed by a space or end of string.
@@ -76,10 +78,10 @@ export function extractFirstSentence(text: string): {
 	if (boundaryIndex !== -1) {
 		const first = text.substring(0, boundaryIndex).trim();
 		const rest = text.substring(boundaryIndex).trim();
-		return { first, rest };
+		return { first, rest, complete: true };
 	}
 
-	return { first: text.trim(), rest: "" };
+	return { first: text.trim(), rest: "", complete: false };
 }
 
 /**
@@ -87,6 +89,8 @@ export function extractFirstSentence(text: string): {
  * Useful for streaming to know when to call extractFirstSentence.
  */
 export function hasFirstSentence(text: string): boolean {
-	const { rest } = extractFirstSentence(text);
-	return rest.length > 0;
+	// A boundary at the end of the text still completes a sentence, so this
+	// cannot key off `rest`: a reply that is exactly one sentence leaves it
+	// empty and would report false.
+	return extractFirstSentence(text).complete;
 }


### PR DESCRIPTION
# Relates to

No existing issue — found while reading `packages/core/src/utils/text-splitting.ts`. Reproduction below.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Low-to-medium**, and worth a careful look because it turns a code path back **on**.

`hasFirstSentence` currently under-reports, so the streaming voice path is skipped more often than intended. After this change it fires for single-sentence replies, which is the intended behaviour but means those turns now perform a TTS call they were silently skipping. No call signature changes; `extractFirstSentence` gains one additional field and its existing `first`/`rest` values are untouched.

# Background

## What does this PR do?

`hasFirstSentence` reports whether the text contains a complete first sentence. It inferred that from the leftover text:

```ts
const { rest } = extractFirstSentence(text);
return rest.length > 0;
```

But `extractFirstSentence` finds a boundary at a terminator followed by whitespace **or end of string**. For a reply that is exactly one sentence, the boundary IS found and `rest` is empty — so the function returned `false` for text that is a complete sentence:

```
extract -> {"first":"Sure, I added milk to your shopping list.","rest":""}
hasFirstSentence -> false
```

`extractFirstSentence` now reports whether a boundary was found, and `hasFirstSentence` returns that.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

In `packages/core/src/services/message.ts` the streaming voice path is gated on this function:

```ts
!firstSentenceSent && accumulated !== undefined && hasFirstSentence(streamText)
    -> speak first sentence; firstSentenceSent = true
```

and the post-stream "speak the remainder" block is gated on the flag that only that branch sets:

```ts
if (firstSentenceSent && result.responseContent?.text) { ... }
```

When the whole reply is a single sentence, `rest` is empty at every accumulation step, so `firstSentenceSent` never flips and **neither** delivery runs — the turn produces no audio at all. Short replies ("Done!", "Did that work?", a one-line confirmation) are exactly the common case in a voice conversation.

`hasFirstSentence` has no test coverage today: `text-splitting.test.ts` imports only `extractFirstSentence`, and every case it exercises is multi-sentence — precisely where this defect is invisible.

# Documentation changes needed?

My changes do not require a change to the project documentation. The function's existing doc comment ("Checks if the text likely contains a complete first sentence") already describes the behaviour this PR makes true.

# Testing

## Where should a reviewer start?

`packages/core/src/utils/text-splitting.test.ts` — the new `hasFirstSentence` describe block. Check out this branch, revert only `packages/core/src/utils/text-splitting.ts`, and run the file: the single-sentence case fails.

## Detailed testing steps

```bash
bun install --ignore-scripts
bun test packages/core/src/utils/text-splitting.test.ts     # 9 pass

git checkout packages/core/src/utils/text-splitting.ts       # revert ONLY the source fix
bun test packages/core/src/utils/text-splitting.test.ts     # 8 pass, 1 fail
```

Against the unfixed source:

```
(fail) hasFirstSentence > reports true when the whole text is one complete sentence
```

New cases cover: a single statement, question and exclamation; multi-sentence (unchanged); an incomplete fragment and empty string (still false); and a fragment ending in an abbreviation ("See e.g. the") staying false, so the existing abbreviation handling is pinned.

# Evidence Gate

<!-- evidence-head:f6d1b66fab1075ba44a02396c30168e9bf446752 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; this is a pure string function in packages/core.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; this is a pure string function in packages/core.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - the user-visible effect is audio presence in a live voice session, which needs configured TTS credentials I do not have; the gating predicate is demonstrated directly in the test output above.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the changed function performs no I/O and emits no log lines; the bun test transcript above exercises the real exported function.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involvement.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt or model behaviour is changed; this is a sentence-boundary predicate.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - produces no DB rows, memories, tasks, files or on-chain output.`
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - see the llm-trajectory row above.`

## Backend + frontend logs

`N/A - pure function, no I/O and no log emission.` Behavioural evidence is the before/after transcript under **Detailed testing steps**, plus the two gates quoted under **Why**.

## Screenshots (before / after) + video walkthrough

`N/A - no UI change.`

# Known gaps / failures

- I could not attach a recording of a voice turn producing audio, because that needs configured cloud-TTS credentials I do not have. What is demonstrated instead is the predicate both gates depend on, plus the two gate expressions in `message.ts` that consume it. If a maintainer with a voice-enabled environment can confirm a single-sentence reply now speaks, that would close the loop.

**`bun run verify` blocker (pre-existing on `develop`, not from this PR).** The repository-wide gate currently fails at:

```
@elizaos/gateway-webhook:typecheck: src/billing.test.ts(8,65): error TS2307:
  Cannot find module '@elizaos/cloud-shared/billing' or its corresponding type declarations.
```

I verified this is unrelated by running the same target on a clean checkout of `origin/develop` (`a83393b090`) with **zero** changes applied:

```
Tasks:    56 successful, 57 total
Failed:   @elizaos/gateway-webhook#typecheck   <- same error, no diff of mine present
```

The packages this PR touches are green at the exact head:

```
bunx turbo run typecheck lint:check --filter=@elizaos/core --filter=@elizaos/agent
Tasks:    60 successful, 60 total
```

I have not touched `gateway-webhook` or `cloud-shared`, and I did not want to tick a "verify passes" box that isn't literally true — hence this section rather than a silent green.


AI provider/model: Anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A - contribution skill not used; repository template and CONTRIBUTING.md read directly from the checkout
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"N/A - contribution skill not used"} -->
