### PR TITLE
fix(deploy): carry .railwayignore to main so production gateway deploys clear the upload wall

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1015,7 +1015,10 @@ waifu.fun/
 # perf-gate e2e artifacts (overlay-scroll + conversation-swipe video + screenshots)
 /packages/ui/src/components/shell/__e2e__/output-perf-gate-e2e/
 railway.json
-.railwayignore
+# .railwayignore is deliberately TRACKED: the root-context `railway up`
+# deploys (gateway-webhook / tunnel-proxy) upload the working tree, and the
+# checked-in exclusions keep 600MB+ of hardware/OS artifact trees out of the
+# archive (upload died outright at ~1GB — staging run 31877865041).
 .dockerignore
 packages/ui/src/components/shell/__e2e__/output-fused-wake-integration/
 

--- a/.railwayignore
+++ b/.railwayignore
@@ -1,0 +1,24 @@
+# Railway upload exclusions for the repo-root `railway up` deploys
+# (deploy-gateway-webhook.yml / deploy-tunnel-proxy.yml write a root
+# railway.toml and upload the working tree from the repo root).
+#
+# The tracked tree grew from ~435MB to ~1GB when hardware/OS lanes landed
+# their build artifacts (xcframework binaries, live-build chroot bundles,
+# KiCad STEP exports, robot meshes, benchmark corpora). `railway up` began
+# failing before Railway even created a deployment — the archive upload
+# itself died (live: staging gateway deploy run 31877865041, 2026-08-15).
+#
+# Every Railway-deployed service's Dockerfile COPYs only from
+# packages/cloud/**, packages/core, packages/logger, packages/prompts and
+# workspace manifests — none of the trees below are ever part of a Railway
+# build context, so excluding them cannot change any image. This file is
+# about UPLOAD size only; repo-level artifact policy (LFS/releases) is a
+# separate decision.
+packages/native/bun-runtime/artifacts/
+packages/os/
+packages/chip/
+packages/robot/
+packages/benchmarks/
+# Test/e2e media and local tooling caches — likewise never in a Railway build.
+**/node_modules/.cache/
+.turbo/


### PR DESCRIPTION
## Problem

Production Telegram is down behind a stale Railway gateway (HQ #18309 incident thread). The recovery dispatch (run 31903098602, main@222d8f7) failed at "Deploy exact gateway-webhook source" in ~11s with no deployment id — and the fleet's root-cause is **branch skew**: `main` does not contain `.railwayignore`, so the repo-root `railway up` hits the ~1GB tracked-tree upload wall that #19980 already fixed on develop (live proof there: staging gateway deploy run 31877865041 failed identically before the fix, deployed clean after).

## Fix

Cherry-pick of the exact develop commit `2c5e9aec91` (#19980) onto main: adds the tracked `.railwayignore` (upload-size-only exclusions of hardware/OS artifact trees; none are in any Railway build context — every Railway Dockerfile COPYs only from packages/cloud/**, core, logger, prompts) and the one-line `.gitignore` carve-out that keeps the file tracked. Zero runtime code.

## Evidence

| Row | Result |
| --- | --- |
| Provenance | byte-identical cherry-pick of merged develop commit 2c5e9aec91 (#19980); 2 files, +28/−1 |
| Live proof (develop) | staging gateway deploys failed at upload pre-#19980, green post — same workflow, same failure signature as the production run |
| Production failure matched | run 31903098602 step 8: exit 1 before any Railway deployment id, consistent with archive-upload death |
| Unblocks | re-dispatch of Deploy Gateway Webhook (production) by the latency lane → restores production Telegram |

Part of the production Telegram incident chain (HQ #18309). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
