### PR TITLE
fix(core): explicit media-generation asks validate without a pre-selected media context

### DIFF
--- a/packages/core/src/features/advanced-capabilities/actions/generateMedia.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/generateMedia.test.ts
@@ -67,6 +67,49 @@ describe("generateMediaAction availability", () => {
 		).resolves.toBe(false);
 	});
 
+	it("allows an explicit image ask with an IMAGE model even with no media context (F35)", async () => {
+		// The live regression: no options (validate is called without them from
+		// the message service), no pre-selected media/files context — only the
+		// natural-language ask. With an IMAGE model present it must validate, or
+		// the action is dropped from the catalog and the model denies a
+		// capability it has (tj-ec2962758e6a13).
+		const runtime = {
+			getService: () => undefined,
+			getModel: (modelType: string) =>
+				modelType === ModelType.IMAGE ? vi.fn() : undefined,
+		} as never;
+		const imageAsk = {
+			id: "msg",
+			roomId: "room",
+			content: {
+				text: "make me a pixel-art castle image, 64x64 retro game vibe",
+			},
+		} as never;
+
+		await expect(
+			generateMediaAction.validate?.(runtime, imageAsk, undefined),
+		).resolves.toBe(true);
+	});
+
+	it("stays hidden without options, media context, OR an explicit ask", async () => {
+		// A message that merely mentions an image but is not a generation ask,
+		// with no media context and no options, must NOT expose the action.
+		const runtime = {
+			getService: () => undefined,
+			getModel: (modelType: string) =>
+				modelType === ModelType.IMAGE ? vi.fn() : undefined,
+		} as never;
+		const incidental = {
+			id: "msg",
+			roomId: "room",
+			content: { text: "did you see the image i sent earlier?" },
+		} as never;
+
+		await expect(
+			generateMediaAction.validate?.(runtime, incidental, undefined),
+		).resolves.toBe(false);
+	});
+
 	it("allows video when the media service can generate video", async () => {
 		await expect(
 			generateMediaAction.validate?.(

--- a/packages/core/src/features/advanced-capabilities/actions/generateMedia.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/generateMedia.ts
@@ -97,6 +97,22 @@ function readBooleanParam(
 	return typeof value === "boolean" ? value : undefined;
 }
 
+/**
+ * True when the message text is an explicit request to generate a visual or
+ * audio artifact ("make me a pixel-art castle image", "generate a picture of a
+ * lighthouse"). A generation verb must pair with a media-artifact noun so
+ * incidental mentions ("send me the image you saved", "make a plan") never
+ * match. Module-local by design: validate() must not depend on the message
+ * service's Stage-1 heuristics (that is a higher layer).
+ */
+function looksLikeExplicitMediaGenerationRequest(text: string): boolean {
+	const normalized = text.toLowerCase().replace(/\s+/gu, " ").trim();
+	if (!normalized) return false;
+	return /\b(?:generate|make|draw|create|render|paint|produce|design)\b[^.!?]{0,64}\b(?:image|picture|photo|art(?:work)?|illustration|logo|sticker|wallpaper|drawing|painting|meme|gif|video|animation|clip|music|song|audio|sound(?:\s?effect)?|sfx|voice(?:over)?|speech)s?\b/iu.test(
+		normalized,
+	);
+}
+
 function normalizeMediaType(
 	value: unknown,
 ): MediaGenerationMediaType | undefined {
@@ -344,6 +360,19 @@ export const generateMediaAction = {
 
 		const params = readParams(options);
 		if (normalizeMediaType(params.mediaType)) return true;
+
+		// An explicit natural-language generation ask is self-selecting: with a
+		// working generator (canGenerate above) it must not additionally require
+		// a pre-selected media/files context. Requiring one meant a fresh image
+		// ask that Stage-1 classified into "simple"/"general" was dropped from
+		// the catalog entirely, and the model then honestly denied a capability
+		// it has — the same box generated an image an hour earlier only because
+		// that turn already carried a media context (matrix F35,
+		// tj-ec2962758e6a13 vs the 13:27 lighthouse). The context gate still
+		// governs the incidental case (no explicit ask) below.
+		if (looksLikeExplicitMediaGenerationRequest(messageText(message))) {
+			return true;
+		}
 
 		return hasActionContext(message, state, {
 			contexts: [...MEDIA_CONTEXTS],


### PR DESCRIPTION
## Problem

F35 verified still-broken live after #20144 (watchtower re-prove; peer box-side root-cause from `/var/log/milady/bot.log`): "make me a pixel-art castle image, 64x64" → "no image generator here". The box generates images fine — `model:IMAGE=29571ms` earlier the same day (the 850KB lighthouse). The `GENERATE_MEDIA` "no provider configured" debug did **not** fire, so `canGenerate` was true.

Root cause, pinned to `generateMedia.ts` validate(): after the (passing) provider check, validate requires **either** an explicit `mediaType` option (absent — the message service calls `validate(runtime, message, state)` with no options) **or** a pre-selected media/files context. A fresh image ask that Stage-1 classified into `simple`/`general` satisfied neither → validate false → the action was dropped from the retrieval catalog → the planner physically lacked the tool → honest-from-its-view denial. The earlier lighthouse succeeded only because that turn already carried a media context. That context-dependence is the "capability self-belief flip-flop."

`#20144` (my prior fix) emits a deterministic `GENERATE_MEDIA` candidate from Stage-1, but the action's own `validate()` independently gates it out downstream — so the candidate alone couldn't fix it. The fix has to be in validate.

## Fix

`validate()` now also returns true when the message is an **explicit natural-language generation ask** (generation verb + media-artifact noun, module-local regex — no dependency on the message service's Stage-1 layer) **and** a generator is configured. Unchanged:
- The provider gate — an agent with no generator still validates false.
- The context gate — still governs the *incidental* case (a message that mentions media without asking to generate it).
- The explicit-`mediaType`-option early return.

## Evidence

| Row | Result |
| --- | --- |
| Unit tests | `generateMedia.test.ts` 10/10 — 2 new: explicit image ask + IMAGE model + no options/context → validates true (the exact F35 shape); incidental "did you see the image i sent" + IMAGE model + no context → stays false |
| Regression | advanced-capabilities actions 77/77; core `tsc --noEmit` clean; biome clean |
| Ground truth | tj-ec2962758e6a13 (validate-dropped, no GENERATE_MEDIA in 25-row retrieval result) vs the 13:27 lighthouse (media context present); peer confirmed via bot.log that the provider branch did not fire |
| Live re-prove | Queued: pixel-art castle ask on a non-media-context turn (matrix batch-3, watchtower) — pairs with the #20144 candidate to fully close F35 |

Second half of the F35 fix (candidate exposure #20144 + this validate-gate fix). HQ thread: #18309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
