### PR TITLE
fix(cloud): preserve imported Cloudflare certificate packs

### DIFF
--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/README.md
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/README.md
@@ -57,6 +57,12 @@ different list. Add a new key, apply it, wait for `active`, verify TLS, and only
 then retire an older generation in a separate reviewed operation. Every pack is
 protected by `prevent_destroy`.
 
+Leave `cloudflare_branding` unset on these immutable resources. Cloudflare's
+order API treats omission as unbranded, while its read API may omit the
+resulting false value. Provider v5 marks an explicit false value as a
+replacement after import, so configuring it would create destructive drift
+without changing the live certificate.
+
 The live staging `*.staging.elizacloud.ai` pack remains at its original resource
 address and is imported separately. Deep legacy `sites` and `tunnel` wildcards
 use additive redirect certificate generations. Their DNS input is explicit so

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/main.tf
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/main.tf
@@ -280,6 +280,11 @@ resource "cloudflare_dns_record" "legacy_redirect_wildcard" {
 # This imported paid pack remains modeled separately from all new packs. Its
 # host inventory must be copied exactly from Cloudflare; prevent_destroy turns
 # accidental replacement into a failed plan rather than a TLS outage.
+#
+# Leave cloudflare_branding unset on every immutable pack. Cloudflare treats an
+# omitted value as unbranded, but its read API can omit the resulting false
+# value. Provider v5 otherwise treats an explicit false after import as a
+# replacement-only change.
 resource "cloudflare_certificate_pack" "staging_agent" {
   count = var.environment == "staging" ? 1 : 0
 
@@ -289,7 +294,6 @@ resource "cloudflare_certificate_pack" "staging_agent" {
   type                  = "advanced"
   validation_method     = "txt"
   validity_days         = 90
-  cloudflare_branding   = false
 
   lifecycle {
     prevent_destroy = true
@@ -308,7 +312,6 @@ resource "cloudflare_certificate_pack" "canonical_edge" {
   type                  = "advanced"
   validation_method     = "txt"
   validity_days         = 90
-  cloudflare_branding   = false
 
   lifecycle {
     prevent_destroy = true
@@ -324,7 +327,6 @@ resource "cloudflare_certificate_pack" "legacy_redirect" {
   type                  = "advanced"
   validation_method     = "txt"
   validity_days         = 90
-  cloudflare_branding   = false
 
   lifecycle {
     prevent_destroy = true

--- a/packages/cloud/infra/tests/terraform-static.test.ts
+++ b/packages/cloud/infra/tests/terraform-static.test.ts
@@ -315,6 +315,8 @@ describe("Cloudflare Pages domain durability", () => {
     );
     expect(main).toContain('type                  = "advanced"');
     expect(main).toContain("prevent_destroy = true");
+    expect(main).not.toMatch(/^\s*cloudflare_branding\s*=/m);
+    expect(readme).toContain("Leave `cloudflare_branding` unset");
     expect(variables).toContain('variable "canonical_edge_wildcard_origins"');
     expect(variables).toContain('variable "canonical_edge_certificate_packs"');
     expect(imports).toContain(


### PR DESCRIPTION
# Relates to

Closes #20173.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto exact current `origin/develop` `625fd5543232a1f2c9d8f7e6a9c8e684877be30d` with zero conflicts.
- [x] `bun install --frozen-lockfile` and exact-head `bun run verify` pass after sync.
- [x] A reviewer can confirm the provider contract from the static regression, Terraform validation, and attached command log.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@3a72ee892ac98d4467e236d4945d73a9e4e8874a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `625fd5543232a1f2c9d8f7e6a9c8e684877be30d`; zero conflicts.
- [x] The PR is a three-file Terraform/docs/test delta.
- [x] Exact-head `TURBO_FORCE=1 bun run verify` passes with 351/351 uncached tasks and all repository audits.

# Risks

Low and fail-closed:

- The fix removes explicit `cloudflare_branding = false` from three imported `cloudflare_certificate_pack` resources. Cloudflare's v5 provider treats the optional field as replacement-sensitive, while the read API can omit the false value; leaving it unset prevents a false replacement without masking other drift.
- `lifecycle.prevent_destroy` remains unchanged on every certificate pack.
- No DNS record, certificate host, certificate authority, validation method, or import identity changes.
- A fresh protected staging plan is required after merge and must still be rejected if it contains any unexpected destroy or replacement.

Rollback is a single-commit revert.

# Background

## What does this PR do?

It prevents imported Cloudflare advanced certificate packs from planning destructive replacement solely because the configuration explicitly set `cloudflare_branding = false` while the provider read path represents the same unbranded state as omitted/null.

The failed protected staging plan correctly stopped at `prevent_destroy`; this patch removes only the unstable optional argument and adds an executable regression that forbids reintroducing it.

## What kind of change is this?

Bug fix (non-breaking infrastructure convergence).

# Documentation changes needed?

The local pages/domains README is updated with the import/provider invariant and the required zero-replacement plan review.

# Testing

## Where should a reviewer start?

1. `packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/main.tf`
2. `packages/cloud/infra/tests/terraform-static.test.ts`
3. `packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/README.md`

## Detailed testing steps

- `bun install --frozen-lockfile` — complete, including the required artifact sync; no source changes.
- `bun test packages/cloud/infra/tests/terraform-static.test.ts` — 56/56 tests, 460 expectations.
- Terraform 1.10.5 `fmt -check` and `validate` with Cloudflare provider 5.21.1 — pass.
- Changed-file Biome — pass with only two pre-existing warning-level template diagnostics in the test file.
- Guide parity — 153/153 pairs pass.
- `git diff --check` — pass.
- Exact-head `TURBO_FORCE=1 bun run verify` — 351/351 tasks, 0 cached; all follow-on audits pass.

# Evidence Gate

<!-- evidence-head:3a72ee892ac98d4467e236d4945d73a9e4e8874a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - Terraform provider configuration has no rendered user interface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Terraform provider configuration has no rendered user interface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or visual behavior changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service code or live service execution changes in this PR.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, model, prompt, or inference behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [20179-cloudflare-cert-pack-evidence-3a72ee8.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20179-cloudflare-cert-pack-evidence-3a72ee8.log)
<!-- evidence-row:ocr-review -->
- [x] N/A - no screenshots or visual surface.

# Evidence Details

## Known gaps / failures

- No infrastructure apply is performed by this PR. After merge, a new protected staging plan must be reviewed for zero destroys/replacements before its exact encrypted artifact may be applied.
- The existing failed plan is evidence of the bug, not evidence that this patch has mutated live infrastructure; `prevent_destroy` stopped it before apply.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@3a72ee892ac98d4467e236d4945d73a9e4e8874a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@3a72ee892ac98d4467e236d4945d73a9e4e8874a:packages/skills/skills/contribute-to-eliza"} -->

