### PR TITLE
fix(pa): a date-decline answer resumes the parked todo create instead of vanishing

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/lib/lifeops-deferred-draft.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/lib/lifeops-deferred-draft.test.ts
@@ -8,9 +8,26 @@ import type {
 } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {
+  coerceDeferredLifeDraft,
   type DeferredLifeDefinitionDraft,
   deferredOwnerTodoRoutingEvaluator,
+  isExplicitScheduleDecline,
 } from "./lifeops-deferred-draft.js";
+
+function awaitingScheduleDraft(): DeferredLifeDefinitionDraft {
+  return {
+    awaitingField: "schedule",
+    intent: "add a todo: buy sandpaper",
+    operation: "create_definition",
+    createdAt: Date.now(),
+    sourceMessageId: "clarify-message",
+    request: {
+      kind: "task",
+      metadata: { ownerSurface: "OWNER_TODOS" },
+      title: "buy sandpaper",
+    },
+  };
+}
 
 function pendingTodoDraft(): DeferredLifeDefinitionDraft {
   return {
@@ -157,5 +174,77 @@ describe("deferred owner-Todo routing", () => {
         context({ draft: reminderDraft }),
       ),
     ).toBe(false);
+  });
+});
+
+describe("awaiting-schedule drafts (F32)", () => {
+  it("coerce accepts a cadence-less draft only with the awaiting-schedule marker", () => {
+    const parked = coerceDeferredLifeDraft(awaitingScheduleDraft());
+    expect(parked?.operation).toBe("create_definition");
+    expect(
+      parked?.operation === "create_definition"
+        ? parked.awaitingField
+        : undefined,
+    ).toBe("schedule");
+    const malformed = coerceDeferredLifeDraft({
+      ...awaitingScheduleDraft(),
+      awaitingField: undefined,
+    });
+    expect(malformed).toBeNull();
+  });
+
+  it("recognizes explicit date-declines and vetoes cancellations", () => {
+    for (const text of [
+      "no deadline, it's just a general todo",
+      "no due date",
+      "someday",
+      "just a plain todo",
+    ]) {
+      expect(isExplicitScheduleDecline(text)).toBe(true);
+    }
+    for (const text of [
+      "cancel",
+      "never mind, forget it",
+      "it's not a plain todo, make it daily",
+      "what's the weather",
+    ]) {
+      expect(isExplicitScheduleDecline(text)).toBe(false);
+    }
+  });
+
+  it("routes a date-decline answer back through OWNER_TODOS (live F32 shape)", async () => {
+    const input = context({
+      draft: awaitingScheduleDraft(),
+      replyEffectStatus: "non_applied",
+      text: "no deadline, it's just a general todo",
+    });
+    expect(await deferredOwnerTodoRoutingEvaluator.shouldRun(input)).toBe(true);
+    const patch = await deferredOwnerTodoRoutingEvaluator.evaluate(input);
+    expect(patch).toMatchObject({
+      requiresTool: true,
+      addCandidateActions: ["OWNER_TODOS"],
+    });
+  });
+
+  it("does not treat a decline as an answer without an awaiting-schedule draft", async () => {
+    const input = context({
+      draft: pendingTodoDraft(),
+      replyEffectStatus: "non_applied",
+      text: "no deadline, it's just a general todo",
+    });
+    expect(await deferredOwnerTodoRoutingEvaluator.shouldRun(input)).toBe(
+      false,
+    );
+  });
+
+  it("leaves ordinary chat alone while a draft awaits its schedule", async () => {
+    const input = context({
+      draft: awaitingScheduleDraft(),
+      replyEffectStatus: "non_applied",
+      text: "what's the weather like today?",
+    });
+    expect(await deferredOwnerTodoRoutingEvaluator.shouldRun(input)).toBe(
+      false,
+    );
   });
 });

--- a/plugins/plugin-personal-assistant/src/actions/lib/lifeops-deferred-draft.ts
+++ b/plugins/plugin-personal-assistant/src/actions/lib/lifeops-deferred-draft.ts
@@ -62,9 +62,36 @@ export function isExplicitLifeCreateConfirmation(text: string): boolean {
   return false;
 }
 
+/**
+ * Explicit date-decline vocabulary for a pending schedule question, aligned
+ * with the extract-task-plan ruling: `unscheduled` applies ONLY when the owner
+ * explicitly declines a date ("no due date", "just a plain todo", "someday").
+ * This routes the answer turn back to the owning action; the LLM plan
+ * extraction still owns mapping the words to the `unscheduled` cadence.
+ */
+const SCHEDULE_DECLINE_CUE_RE =
+  /\b(?:no\s+(?:deadline|due\s*date|date|time(?:\s+needed)?)|without\s+a\s+(?:deadline|date)|just\s+a\s+(?:plain|general|simple|regular)\s+(?:todo|task|item)|someday|whenever|no\s+particular\s+(?:time|date))\b/iu;
+const SCHEDULE_DECLINE_VETO_RE =
+  /\b(?:not\s+(?:a\s+)?(?:plain|general|simple)|never\s*mind|cancel|forget\s+it|don'?t\s+(?:save|add|create))\b/iu;
+
+export function isExplicitScheduleDecline(text: string): boolean {
+  const normalized = text.toLowerCase().replace(/\s+/gu, " ").trim();
+  if (!normalized || SCHEDULE_DECLINE_VETO_RE.test(normalized)) {
+    return false;
+  }
+  return SCHEDULE_DECLINE_CUE_RE.test(normalized);
+}
+
 export type DeferredLifeDefinitionDraft = {
   intent: string;
   operation: "create_definition";
+  /**
+   * Set when the draft was parked by a clarify turn that is still waiting on
+   * one required field. `cadence` may be absent only while this is set — the
+   * owner's next answer supplies it (or explicitly declines a date, which the
+   * extract-task-plan ruling maps to the `unscheduled` cadence).
+   */
+  awaitingField?: "schedule";
   /** Epoch ms when the draft was created. Used for expiry. */
   createdAt?: number;
   /**
@@ -75,7 +102,7 @@ export type DeferredLifeDefinitionDraft = {
    */
   sourceMessageId?: string;
   request: {
-    cadence: LifeOpsCadence;
+    cadence?: LifeOpsCadence;
     description?: string;
     goalRef?: string;
     kind: CreateLifeOpsDefinitionRequest["kind"];
@@ -250,10 +277,15 @@ export function coerceDeferredLifeDraft(
         ? (request.kind as CreateLifeOpsDefinitionRequest["kind"])
         : null;
     const cadence = request.cadence as LifeOpsCadence | undefined;
-    if (!kind || !cadence) {
+    const awaitingField =
+      record.awaitingField === "schedule" ? ("schedule" as const) : undefined;
+    // A cadence-less definition draft is only coherent while a clarify turn
+    // is still waiting on the schedule answer; anything else is malformed.
+    if (!kind || (!cadence && awaitingField !== "schedule")) {
       return null;
     }
     return {
+      awaitingField,
       createdAt,
       intent,
       operation,
@@ -585,7 +617,9 @@ function isDeferredOwnerTodoDraft(
   const ownerSurface = draft.request.metadata?.ownerSurface;
   return (
     ownerSurface === OWNER_TODOS_ACTION ||
-    (ownerSurface === undefined && draft.request.cadence.kind === "unscheduled")
+    (ownerSurface === undefined &&
+      (draft.request.cadence?.kind === "unscheduled" ||
+        draft.awaitingField === "schedule"))
   );
 }
 
@@ -638,22 +672,40 @@ export const deferredOwnerTodoRoutingEvaluator: ResponseHandlerEvaluator = {
     "Routes owner consent or an applied completion claim for a pending Todo draft through OWNER_TODOS before completion text can reach the user.",
   priority: 25,
   async shouldRun(context) {
-    const ownerConfirmedDraft = isExplicitLifeCreateConfirmation(
+    const messageBody =
       typeof context.message.content.text === "string"
         ? context.message.content.text
-        : "",
-    );
+        : "";
+    const ownerConfirmedDraft = isExplicitLifeCreateConfirmation(messageBody);
+    const declinedSchedule = isExplicitScheduleDecline(messageBody);
     if (
       context.messageHandler.processMessage !== "RESPOND" ||
       (context.messageHandler.plan.replyEffectStatus !== "applied" &&
-        !ownerConfirmedDraft) ||
+        !ownerConfirmedDraft &&
+        !declinedSchedule) ||
       !context.runtime.actions.some(
         (action) => action.name === OWNER_TODOS_ACTION,
       )
     ) {
       return false;
     }
-    return (await routedOwnerTodoDraft(context)) !== null;
+    const draft = await routedOwnerTodoDraft(context);
+    if (!draft) {
+      return false;
+    }
+    if (
+      context.messageHandler.plan.replyEffectStatus === "applied" ||
+      ownerConfirmedDraft
+    ) {
+      return true;
+    }
+    // A date-decline is a real ANSWER to the pending schedule question, not
+    // chat: Stage-1 routinely classifies "no deadline, it's just a general
+    // todo" as simple and acks without any tool call, so the parked draft
+    // never persists (live matrix F32, tj-ea2db8b2be106f). Route it back to
+    // the owning action; the LLM plan extraction maps the decline to the
+    // `unscheduled` cadence under its existing ruling.
+    return declinedSchedule && draft.awaitingField === "schedule";
   },
   async evaluate(context) {
     const draft = await routedOwnerTodoDraft(context);
@@ -669,7 +721,9 @@ export const deferredOwnerTodoRoutingEvaluator: ResponseHandlerEvaluator = {
       addParentActionHints: [OWNER_TODOS_ACTION],
       clearReply: true,
       debug: [
-        `pending owner Todo draft "${draft.request.title}" requires a durable OWNER_TODOS result before completion`,
+        draft.awaitingField === "schedule"
+          ? `pending owner Todo draft "${draft.request.title}" received its schedule answer; routing through OWNER_TODOS`
+          : `pending owner Todo draft "${draft.request.title}" requires a durable OWNER_TODOS result before completion`,
       ],
     };
   },

--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -4438,10 +4438,10 @@ async function runLifeOperationHandlerInner(
       }
       const confirmsValidatedUndatedDraft =
         deferredDraftReuseMode === "confirm" &&
-        deferredDefinitionDraft?.request.cadence.kind === "unscheduled";
+        deferredDefinitionDraft?.request.cadence?.kind === "unscheduled";
       if (
         (editingDeferredDefinitionDraft &&
-          deferredDefinitionDraft.request.cadence.kind === "unscheduled" &&
+          deferredDefinitionDraft.request.cadence?.kind === "unscheduled" &&
           textContradictsExplicitUndatedTodo(currentText)) ||
         (cadence?.kind === "unscheduled" &&
           (ownerSurfaceActionName !== "OWNER_TODOS" ||
@@ -4529,6 +4529,41 @@ async function runLifeOperationHandlerInner(
             operation: "create_definition",
           },
         });
+        // Park the answered-so-far request so the owner's next turn (a date,
+        // or an explicit date-decline) can resume THIS create instead of
+        // starting over. Without the parked draft the decline answer had
+        // nothing to resume and persisted nothing (live matrix F32). Scoped
+        // to OWNER_TODOS: only the todos surface accepts the unscheduled
+        // cadence, so only its clarify is answerable by a decline. Never park
+        // on the contradicted-edit path — that branch just INVALIDATED the
+        // prior draft, and writing a fresh one here would clobber the
+        // invalidation and let a later bare confirmation resurrect the
+        // create the contradiction rejected.
+        const scheduleAwaitingDraft: DeferredLifeDraft | null =
+          !editingDeferredDefinitionDraft &&
+          ownerSurfaceActionName === "OWNER_TODOS" &&
+          title
+            ? {
+                awaitingField: "schedule",
+                createdAt: Date.now(),
+                intent,
+                operation: "create_definition",
+                sourceMessageId:
+                  typeof message.id === "string" ? message.id : undefined,
+                request: {
+                  kind: "task",
+                  metadata: definitionMetadata,
+                  title,
+                },
+              }
+            : null;
+        if (scheduleAwaitingDraft) {
+          await writeDeferredLifeDraftCache(
+            runtime,
+            message,
+            scheduleAwaitingDraft,
+          );
+        }
         return {
           success: false as const,
           text,
@@ -4544,6 +4579,9 @@ async function runLifeOperationHandlerInner(
             actionName: ownerSurfaceActionName,
             ...(editingDeferredDefinitionDraft
               ? { lifeDraftInvalidated: true }
+              : {}),
+            ...(scheduleAwaitingDraft
+              ? { lifeDraft: scheduleAwaitingDraft }
               : {}),
             missingField: "schedule",
             requiresConfirmation: true,


### PR DESCRIPTION
## Problem

Live matrix F32, handed to the VPS Claude agents by nubs's explicit direction (HQ #18309): "add a todo: buy sandpaper" → "when's the deadline?" → **"no deadline, it's just a general todo"** → chat ack, zero tool calls, nothing persisted, todos read empty. Ground truth: tj-ef6fef6de8834f (turn 1: `OWNER_TODOS_CREATE` correctly returned `MISSING_DEFINITION_FIELD: schedule`) and tj-ea2db8b2be106f (turn 2: the decline answer classified `["simple"]`, no candidates, no tool call).

Two structural gaps in the canonical LifeOps write path:
1. The schedule-missing clarify branch **parked no draft** — only the preview branch (title+cadence both present) wrote the deferred-draft cache. The answer turn had nothing to resume even if routed.
2. The existing `deferredOwnerTodoRoutingEvaluator` fires only on applied-claims or explicit *confirmations* — a date-decline answer is neither, so Stage-1's misclassification went uncorrected.

## Fix (canonical path preserved; no new parser or scheduling mechanism)

- The schedule-missing clarify now **parks an awaiting-schedule draft** (title/kind/metadata answered so far), scoped to OWNER_TODOS — the only surface whose clarify is answerable by a decline — and **never on the contradicted-edit path**, which just invalidated the prior draft and must stay invalidated (a fresh park there would let a later bare confirmation resurrect the rejected create; pinned by the existing `rejects a contradicted edit` test, which caught exactly that during development).
- `DeferredLifeDefinitionDraft` admits a cadence-less request **only** while `awaitingField: "schedule"` (coercion rejects it otherwise).
- The routing evaluator gains a **decline-answer arm**: an explicit date-decline (vocabulary aligned with the extract-task-plan ruling: "no due date", "no deadline", "just a plain/general todo", "someday"…, with cancel/negation vetoes) while an awaiting-schedule draft is pending routes the turn back through OWNER_TODOS. The LLM plan extraction still owns mapping the words to the `unscheduled` cadence under its existing ruling; the create handler's existing draft-resumption merges title and cadence.

## Evidence

| Row | Result |
| --- | --- |
| Unit tests | `lifeops-deferred-draft.test.ts` 11/11 — 5 new: awaiting-schedule coercion (accept with marker / reject without), decline-cue positives+vetoes, the live F32 decline routes through OWNER_TODOS, decline without an awaiting draft stays chat, ordinary chat while awaiting stays chat |
| Regression | `life-reminder-datetime.test.ts` full 131/131 (including the contradicted-edit invalidation contract); delete-name-guard + review-definitions suites green; PA typecheck clean in touched files; biome clean |
| Ground truth | The two trajectories above; the failed create's `lifeops.owner.create.preview` receipt is the same artifact F30 (BRIEF fabrication) grounds on — this PR removes F32's contribution to that state |
| Live re-prove | Queued (watchtower/peer, post-resync): the exact two-turn sandpaper flow → persisted definition, `cadence.kind="unscheduled"`, zero occurrences, todos read shows it |

Per nubs's scope note this stays within the existing intent authority (#20026 arc) — no competing parser, one clock, one write path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
