### PR TITLE
fix(core): verified tool text overrides recovered evaluator prose

### DIFF
--- a/packages/core/src/runtime/__tests__/evaluator.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator.test.ts
@@ -475,6 +475,95 @@ df -h / /home
 		);
 	});
 
+	it("verified tool text overrides recovered prose — committed state is authoritative (F30)", async () => {
+		// Live fabrication (tj-e9bdfb8015bc11): OWNER_REMINDERS_REVIEW returned
+		// verified "water the ficus at 10am. then again at 5pm." and the
+		// unparseable evaluator prose invented conversation-history items
+		// ("your 20 pushups and the sandpaper run"). The verified
+		// do-not-paraphrase text must ship, not the prose.
+		const runtime = {
+			useModel: vi.fn(
+				async () =>
+					"your 20 pushups and the sandpaper run. you've got the dentist in two days.",
+			),
+		};
+
+		const result = await runEvaluator({
+			runtime,
+			context: {
+				id: "ctx",
+				staticPrefix: {
+					characterPrompt: { content: "agent_name: Eliza", stable: true },
+				},
+				events: [],
+			},
+			trajectory: {
+				context: { id: "ctx" },
+				steps: [
+					{
+						toolCall: {
+							id: "tool-1",
+							name: "OWNER_REMINDERS_REVIEW",
+							params: {},
+						},
+						result: {
+							success: true,
+							text: "water the ficus at 10am. then again at 5pm.",
+							userFacingText: "water the ficus at 10am. then again at 5pm.",
+							verifiedUserFacing: true,
+						},
+					},
+				],
+				archivedSteps: [],
+				plannedQueue: [],
+				evaluatorOutputs: [],
+			},
+		});
+
+		expect(result.success).toBe(true);
+		expect(result.decision).toBe("FINISH");
+		expect(result.messageToUser).toBe(
+			"water the ficus at 10am. then again at 5pm.",
+		);
+		expect(result.messageToUser).not.toContain("pushups");
+	});
+
+	it("keeps prose recovery for tools without a verified-text claim", async () => {
+		const runtime = {
+			useModel: vi.fn(
+				async () => "The search found three articles about ficus care.",
+			),
+		};
+
+		const result = await runEvaluator({
+			runtime,
+			context: {
+				id: "ctx",
+				staticPrefix: {
+					characterPrompt: { content: "agent_name: Eliza", stable: true },
+				},
+				events: [],
+			},
+			trajectory: {
+				context: { id: "ctx" },
+				steps: [
+					{
+						toolCall: { id: "tool-1", name: "WEB_SEARCH", params: {} },
+						result: { success: true, text: "3 results" },
+					},
+				],
+				archivedSteps: [],
+				plannedQueue: [],
+				evaluatorOutputs: [],
+			},
+		});
+
+		expect(result.decision).toBe("FINISH");
+		expect(result.messageToUser).toBe(
+			"The search found three articles about ficus care.",
+		);
+	});
+
 	it("strips a trailing evaluator JSON envelope from recovered prose", async () => {
 		const runtime = {
 			useModel: vi.fn(

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -852,6 +852,27 @@ function recoverEvaluatorTextOutput(
 		};
 	}
 
+	// Committed state is authoritative over recovered prose: when the turn's
+	// successful tool result carries VERIFIED canonical user-facing text
+	// (do-not-paraphrase contract, #14873), the unparseable evaluator prose is
+	// the least trustworthy artifact in the turn — live matrix F30
+	// (tj-e9bdfb8015bc11): OWNER_REMINDERS_REVIEW returned "water the ficus at
+	// 10am…" verified, and this recovery shipped hallucinated
+	// conversation-history items ("your 20 pushups and the sandpaper run")
+	// instead. Finish with the verified tool text; prose recovery remains for
+	// turns whose tools make no verified-text claim (web search, shell, …).
+	const verifiedToolText = latestVerifiedToolUserFacingText(trajectory);
+	if (verifiedToolText) {
+		return {
+			success: true,
+			decision: "FINISH",
+			thought:
+				"Recovered the turn's answer from the verified tool result; unparseable evaluator prose must not override committed state.",
+			messageToUser: verifiedToolText,
+			raw: { recoverySource: "verified_tool_text_over_prose" },
+		};
+	}
+
 	return {
 		success: true,
 		decision: "FINISH",
@@ -860,6 +881,29 @@ function recoverEvaluatorTextOutput(
 		messageToUser: userFacing,
 		raw: { recoverySource: "prose_after_successful_tool" },
 	};
+}
+
+/**
+ * The most recent successful step whose result carries the verified
+ * do-not-paraphrase user-facing text. Archived steps are deliberately
+ * excluded: only the live turn's surface output is authoritative for the
+ * live turn's reply.
+ */
+function latestVerifiedToolUserFacingText(
+	trajectory: PlannerTrajectory,
+): string | null {
+	for (let index = trajectory.steps.length - 1; index >= 0; index -= 1) {
+		const result = trajectory.steps[index]?.result;
+		if (result?.success !== true || result.verifiedUserFacing !== true) {
+			continue;
+		}
+		const text =
+			typeof result.userFacingText === "string"
+				? result.userFacingText.trim()
+				: "";
+		if (text) return text;
+	}
+	return null;
 }
 
 /**


### PR DESCRIPTION
## Problem

Live matrix F30, upgraded by watchtower to fabrication-grade and directed by nubs: "make committed store state authoritative, not conversation prose/draft previews." The observed fabrication: after the sandpaper todo FAILED to save (F32), "what should I focus on"-class turns replied "your 20 pushups and the sandpaper run…" while the direct todos read was empty.

Ground truth (tj-e9bdfb8015bc11, the originating 19:33 turn): `OWNER_REMINDERS_REVIEW` executed and returned its **verified do-not-paraphrase** text — `"water the ficus at 10am. then again at 5pm."` (`verifiedUserFacing: true`, the #14873 contract). The evaluator model then emitted *unparseable prose* hallucinated from conversation history, and the `prose_after_successful_tool` recovery in `parseEvaluatorOutput` shipped that prose as the final reply — fabricated tracked-work that exists in no store, overriding the verified truth sitting one step earlier in the same trajectory.

(BRIEF itself was exonerated: its loader reads only committed overview records and its narrative prompt contains no conversation history — the fabrication enters at the evaluator recovery layer, which is why it can strike any owner-read turn, not just BRIEF.)

## Fix

The prose recovery now prefers the turn's most recent successful `verifiedUserFacing` tool text over recovered prose (`recoverySource: "verified_tool_text_over_prose"`). Prose recovery is unchanged for tools that make no verified-text claim (web search, shell — the cases the recovery exists for). Archived steps are excluded: only the live turn's surface output is authoritative for the live turn's reply.

Together with #20182 (which removes the orphan draft-receipt source), the F30 fabrication class is closed from both ends: nothing un-committed feeds the reply, and committed verified text cannot be overridden by prose.

## Evidence

| Row | Result |
| --- | --- |
| Unit tests | `evaluator.test.ts` 45/45 — 2 new: the exact live shape (verified review text wins over pushups/sandpaper prose) and the preserved prose path for unverified tools |
| Regression | full `runtime/__tests__` + `planner-happy-path` + `services/message`: 1841/1841; core `tsc --noEmit` clean; biome clean |
| Ground truth | tj-e9bdfb8015bc11 (recovery thought + verified tool result in the same trajectory), 10 downstream tjs quoting the fabricated line in history |
| Live re-prove | Queued (watchtower/peer, post-resync): owner-read turn with fact-rich history → reply must match the tool's verified text |

HQ thread: #18309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
