### PR TITLE
fix(agent): isolate connector health probe failures so one throwing getPollerHealth doesn't blank all connector statuses

### DIFF
--- a/packages/agent/src/api/connector-health.test.ts
+++ b/packages/agent/src/api/connector-health.test.ts
@@ -24,6 +24,35 @@ function createMonitor(service: unknown): ConnectorHealthMonitor {
   });
 }
 
+// Builds a monitor whose discord probe throws (or rejects) while telegram is
+// listed after it and stays healthy, mirroring the #20185 reproduction where a
+// throwing getPollerHealth blanked every connector status after it.
+function createIsolationMonitor(discordProbe: () => unknown): {
+  monitor: ConnectorHealthMonitor;
+  reportError: ReturnType<typeof vi.fn>;
+} {
+  const reportError = vi.fn();
+  const services: Record<string, unknown> = {
+    discord: { getPollerHealth: discordProbe },
+    telegram: { getPollerHealth: () => ({ ok: true, connected: true }) },
+  };
+  const monitor = new ConnectorHealthMonitor({
+    runtime: {
+      getService: vi.fn((name: string) => services[name]),
+      reportError,
+    } as never,
+    config: {
+      connectors: {
+        discord: { enabled: true },
+        telegram: { enabled: true },
+      },
+    },
+    broadcastWs: vi.fn(),
+    intervalMs: 60_000,
+  });
+  return { monitor, reportError };
+}
+
 describe("ConnectorHealthMonitor", () => {
   it("uses the configured canonical connector-health interval", () => {
     expect(resolveConnectorHealthIntervalMs("10000")).toBe(10_000);
@@ -94,5 +123,84 @@ describe("ConnectorHealthMonitor", () => {
     await monitor.check();
 
     expect(monitor.getConnectorStatuses()).toEqual({ telegram: "ok" });
+  });
+
+  it("isolates a synchronously throwing poller probe so later connectors still report", async () => {
+    const { monitor, reportError } = createIsolationMonitor(() => {
+      throw new Error("boom");
+    });
+
+    await expect(monitor.check()).resolves.toBeUndefined();
+
+    // discord throwing must not abort the loop or fabricate an "ok" DTO;
+    // telegram is listed after discord and must still be probed and reported.
+    expect(monitor.getConnectorStatuses()).toEqual({
+      discord: "missing",
+      telegram: "ok",
+    });
+    expect(reportError).toHaveBeenCalledWith(
+      "ConnectorHealthMonitor.probeConnector",
+      expect.any(Error),
+      expect.objectContaining({ connector: "discord" }),
+    );
+  });
+
+  it("isolates a rejected poller-health promise with the same guarantees", async () => {
+    const { monitor } = createIsolationMonitor(() =>
+      Promise.reject(new Error("network down")),
+    );
+
+    await expect(monitor.check()).resolves.toBeUndefined();
+
+    expect(monitor.getConnectorStatuses()).toEqual({
+      discord: "missing",
+      telegram: "ok",
+    });
+  });
+
+  it("never fabricates a healthy status: statuses map is non-empty so health-routes cannot relabel connectors 'configured'", async () => {
+    const { monitor } = createIsolationMonitor(() => {
+      throw new Error("boom");
+    });
+
+    await monitor.check();
+
+    const statuses = monitor.getConnectorStatuses();
+    // health-routes.ts falls back to a blanket fabricated-healthy "configured"
+    // only when this map is empty; a real per-connector state must survive.
+    expect(Object.keys(statuses).length).toBeGreaterThan(0);
+    expect(Object.values(statuses)).not.toContain("configured");
+    expect(statuses.discord).toBe("missing");
+  });
+
+  it("start() does not leak an unhandledRejection when a probe throws", async () => {
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown) => {
+      rejections.push(reason);
+    };
+    process.on("unhandledRejection", onRejection);
+    const setIntervalSpy = vi
+      .spyOn(globalThis, "setInterval")
+      .mockReturnValue({} as ReturnType<typeof setInterval>);
+    try {
+      const { monitor } = createIsolationMonitor(() => {
+        throw new Error("boom");
+      });
+
+      monitor.start();
+
+      // Give the fire-and-forget check() microtasks a chance to settle so any
+      // unhandled rejection would surface before we assert.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(rejections).toEqual([]);
+      expect(monitor.getConnectorStatuses()).toEqual({
+        discord: "missing",
+        telegram: "ok",
+      });
+    } finally {
+      setIntervalSpy.mockRestore();
+      process.off("unhandledRejection", onRejection);
+    }
   });
 });

--- a/packages/agent/src/api/connector-health.ts
+++ b/packages/agent/src/api/connector-health.ts
@@ -6,7 +6,7 @@
  * "missing", broadcasts a system-warning via WebSocket.
  */
 
-import { type AgentRuntime, ElizaError } from "@elizaos/core";
+import { type AgentRuntime, ElizaError, logger } from "@elizaos/core";
 
 export type ConnectorStatus = "ok" | "missing" | "unknown";
 
@@ -123,8 +123,28 @@ export class ConnectorHealthMonitor {
 
   start(): void {
     if (this.timer) return;
-    this.check();
-    this.timer = setInterval(() => this.check(), this.intervalMs);
+    // Fire-and-forget probing must never leak an unhandledRejection: a rejected
+    // cycle would otherwise trip the process crash guards as silent log noise
+    // (J7 — diagnostics must not kill the loop). check() already isolates each
+    // connector, so this .catch() only covers unexpected failures in its own
+    // bookkeeping.
+    void this.check().catch((error: unknown) => {
+      this.reportProbeCycleFailure(error);
+    });
+    this.timer = setInterval(() => {
+      void this.check().catch((error: unknown) => {
+        this.reportProbeCycleFailure(error);
+      });
+    }, this.intervalMs);
+  }
+
+  private reportProbeCycleFailure(error: unknown): void {
+    logger.warn(
+      `[ConnectorHealthMonitor] connector health cycle failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    this.runtime?.reportError?.("ConnectorHealthMonitor.check", error);
   }
 
   stop(): void {
@@ -168,10 +188,32 @@ export class ConnectorHealthMonitor {
     const service = this.runtime.getService(pluginName);
     if (service) {
       if (hasPollerHealthProbe(service)) {
-        const health = await service.getPollerHealth();
-        return health.ok === true && health.connected === true
-          ? "ok"
-          : "missing";
+        // getPollerHealth() is typed to return a value OR a Promise and, per the
+        // repo's fail-fast-inside policy, may throw/reject on an internal or
+        // network error. Isolate it here so an unavailable connector is reported
+        // "missing" (unavailable != healthy) rather than aborting the whole
+        // probe cycle or fabricating an "ok" DTO (J7 + the no-healthy-default
+        // rule).
+        try {
+          const health = await service.getPollerHealth();
+          return health.ok === true && health.connected === true
+            ? "ok"
+            : "missing";
+        } catch (error) {
+          // error-policy:J7 diagnostics must not kill the loop: a throwing
+          // poller probe is reported and the connector treated as missing.
+          logger.warn(
+            `[ConnectorHealthMonitor] ${name} poller health probe failed: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+          this.runtime?.reportError?.(
+            "ConnectorHealthMonitor.probeConnector",
+            error,
+            { connector: name, plugin: pluginName },
+          );
+          return "missing";
+        }
       }
       return "ok";
     }
@@ -191,7 +233,26 @@ export class ConnectorHealthMonitor {
     const configured = this.getConfiguredConnectors();
 
     for (const name of configured) {
-      const newStatus = await this.probeConnector(name);
+      // Per-connector isolation (J7): a failure while probing one connector
+      // must not abort probing the rest, which would leave later connectors
+      // unrecorded and hand health-routes an empty map it relabels a
+      // fabricated-healthy "configured". probeConnector already isolates the
+      // poller probe; this guards any other unexpected throw (e.g. getService).
+      let newStatus: ConnectorStatus;
+      try {
+        newStatus = await this.probeConnector(name);
+      } catch (error) {
+        // error-policy:J7 diagnostics must not kill the loop.
+        logger.warn(
+          `[ConnectorHealthMonitor] ${name} probe failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        this.runtime?.reportError?.("ConnectorHealthMonitor.check", error, {
+          connector: name,
+        });
+        newStatus = "missing";
+      }
       const prevStatus = this.statuses.get(name);
 
       if (newStatus === "missing" && prevStatus !== "missing") {


### PR DESCRIPTION
# Relates to

Closes #20185

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; `bun run verify` was not run to completion on this constrained Raspberry Pi host — see **Known gaps / failures**. Focused package test/typecheck/lint for the touched file all pass and are attached.
- [x] A reviewer can confirm the change works from the evidence attached below (failing-before / passing-after tests + standalone before/after reproduction transcript).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@9ecb8e324444df09e525986425e3be1752e2eb62:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`d1c52624ae`); zero conflicts.
- [ ] `bun run verify` passes post-sync — not run to completion on this host; the unrelated blocker and the focused gates that were run are documented in **Known gaps / failures**.

# Risks

Low. The change is confined to one file (`packages/agent/src/api/connector-health.ts`) with no public API/signature change. It only adds error isolation around an already-`await`ed call, a per-connector guard, and `.catch()` on fire-and-forget cycles. Behavior on the healthy path is unchanged; the failure path now degrades to `"missing"` (unavailable) instead of aborting the probe loop.

# Background

## What does this PR do?

`ConnectorHealthMonitor.probeConnector()` did `await service.getPollerHealth()` with no error isolation, and `check()` looped over connectors with no per-connector guard. `getPollerHealth()` is typed to return a value **or** a Promise and, per the repo's fail-fast-inside policy, may throw/reject on an internal or network error. When it did:

1. `check()` rejected;
2. every connector listed after the throwing one was never probed and never recorded;
3. if the throwing connector was first, the statuses map stayed empty — and `health-routes.ts` (~L571) then relabels **every** configured connector a healthy-looking `"configured"`, a fabricated-healthy DTO that masks the real (possibly disconnected) state.

Additionally `start()` fired `this.check()` and `setInterval(() => this.check())` with no `.catch()`, leaking an `unhandledRejection` every 60s cycle (swallowed as silent log noise by the process crash guards).

This violated the root AGENTS.md **J7** policy ("diagnostics must not kill the loop") and the DTO rule against healthy-looking defaults for unavailable data. The sibling env-parse path (`resolveConnectorHealthIntervalMs`) was already hardened; the runtime probe path was not.

The fix:
- Wraps the poller probe in `try/catch` — on failure it logs via `logger.warn`, reports via `runtime.reportError` (the non-throwing diagnostic boundary), and returns `"missing"` (unavailable ≠ healthy), never fabricating `"ok"`.
- Adds a per-connector guard inside `check()`'s loop as defense-in-depth so any other unexpected throw (e.g. `getService`) cannot abort the rest of the cycle.
- Attaches `.catch()` to the fire-and-forget `this.check()` and the interval callback in `start()`, so a rejected cycle can no longer leak an `unhandledRejection`.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. Behavior is documented inline in the source header/comments and covered by regression tests.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/connector-health.ts` (the fix) and `packages/agent/src/api/connector-health.test.ts` (4 new regression cases). The downstream consumer that fabricates `"configured"` on an empty map is `packages/agent/src/api/health-routes.ts` (~L571).

## Detailed testing steps

```bash
# generate the core i18n keyword data (prebuild dep), then run the focused lane
node packages/shared/scripts/generate-keywords.mjs
bunx --cwd packages/agent vitest run --config vitest.config.ts src/api/connector-health.test.ts
```

New cases:
- a synchronously throwing `getPollerHealth` → `check()` resolves, throwing connector reported `"missing"`, a connector listed **after** it still reported `"ok"`, and `reportError` fired with the connector context;
- a rejected `getPollerHealth` Promise → same isolation;
- statuses map is non-empty and contains no `"configured"` value, so `health-routes.ts` cannot fall back to the blanket fabricated-healthy relabel;
- `start()` with a throwing probe → no `unhandledRejection` is emitted (captured via a `process.on("unhandledRejection", …)` listener across the tick).

# Evidence Gate

<!-- evidence-head:02ec14abb53e10172f837d67099b1ad76fcb3403 -->

Any change testable on the frontend is not mergeable without a video walkthrough, before/after screenshots, and logs. This change has no rendered UI surface (it is a backend health-monitor class); UI rows are `N/A` with reasons.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only change (ConnectorHealthMonitor class); no rendered UI surface touched.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only change; no rendered UI surface touched.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - backend-only change; the user flow is exercised by the attached test + standalone reproduction transcript.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end (structured `[ConnectorHealthMonitor]` WARN lines + `reportError` calls from the standalone reproduction against the real class):
<details><summary>Backend logs / output — standalone ConnectorHealthMonitor reproduction (before/after)</summary>

```
--- AFTER FIX (this PR, HEAD 02ec14a) ---
 Warn  [ConnectorHealthMonitor] discord poller health probe failed: boom
  reportError(ConnectorHealthMonitor.probeConnector): boom {"connector":"discord","plugin":"discord"}
check() threw?: false
statuses after check(): {"discord":"missing","telegram":"ok"}
telegram (listed AFTER discord) probed?: ok
 Warn  [ConnectorHealthMonitor] discord poller health probe failed: boom
  reportError(ConnectorHealthMonitor.probeConnector): boom {"connector":"discord","plugin":"discord"}
unhandledRejection from start(): (none)

--- BEFORE FIX (origin/develop connector-health.ts) ---
  check() REJECTED: boom
check() threw?: true
statuses after check(): {}
telegram (listed AFTER discord) probed?: (NEVER SET - loop aborted)
unhandledRejection from start(): boom
```
</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - backend-only change; no frontend request/response involved.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model behavior changed; this is a connector health-probe error-isolation fix.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts — the failing-before / passing-after regression run (the domain artifact for this fix):
<details><summary>Regression output — new connector-health cases fail before the fix, pass after</summary>

```
--- New cases against UNFIXED origin/develop source (expect failures) ---
 src/api/connector-health.test.ts (20 tests | 4 failed)
   x isolates a synchronously throwing poller probe so later connectors still report
   x isolates a rejected poller-health promise with the same guarantees
   x never fabricates a healthy status: statuses map is non-empty so health-routes cannot relabel 'configured'
   x start() does not leak an unhandledRejection when a probe throws
 Test Files  1 failed (1)
      Tests  4 failed | 16 passed (20)

--- Full lane WITH the fix (expect all pass) ---
 Test Files  1 passed (1)
      Tests  20 passed (20)
```
</details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behavior changed.`

## Backend + frontend logs

Standalone reproduction against the actual `ConnectorHealthMonitor` class (`services = { discord: getPollerHealth throws Error("boom"), telegram: returns {ok:true,connected:true} }`, both connectors enabled):

<details><summary>BEFORE fix (origin/develop source)</summary>

```
check() REJECTED: boom
check() threw?: true
statuses after check(): {}
telegram (listed AFTER discord) probed?: (NEVER SET - loop aborted)
unhandledRejection from start(): boom
```
</details>

<details><summary>AFTER fix (this PR)</summary>

```
 Warn  [ConnectorHealthMonitor] discord poller health probe failed: boom
  reportError(ConnectorHealthMonitor.probeConnector): boom { connector: "discord", plugin: "discord" }
check() threw?: false
statuses after check(): {"discord":"missing","telegram":"ok"}
telegram (listed AFTER discord) probed?: ok
 Warn  [ConnectorHealthMonitor] discord poller health probe failed: boom
  reportError(ConnectorHealthMonitor.probeConnector): boom { connector: "discord", plugin: "discord" }
unhandledRejection from start(): (none)
```
</details>

Frontend logs: `N/A - backend-only change.`

## Screenshots (before / after) + video walkthrough

### Before

`N/A - backend-only change; no rendered UI surface.`

### After

`N/A - backend-only change; no rendered UI surface.`

### Walkthrough video

`N/A - backend-only change; reproduction transcript + tests above are the walkthrough.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- **Failing-before / passing-after test proof.** The 4 new cases fail against unmodified `origin/develop` source and pass with the fix:

<details><summary>New cases against UNFIXED source (4 fail)</summary>

```
 FAIL  src/api/connector-health.test.ts > ConnectorHealthMonitor > start() does not leak an unhandledRejection when a probe throws
AssertionError: expected [ Error: boom ] to deeply equal []
- []
+ [ Error { "message": "boom" } ]

 Test Files  1 failed (1)
      Tests  4 failed | 16 passed (20)
```
</details>

<details><summary>Full lane with the fix (20 pass)</summary>

```
 RUN  v4.1.5 packages/agent

 Test Files  1 passed (1)
      Tests  20 passed (20)
```
</details>

- **`bun run verify` not run to completion.** This runs on a constrained Raspberry Pi host; the full monorepo `verify` gate (workspace-wide build/typecheck/lint across ~7000 packages) is not feasible here in-session. Instead the focused owning-package gates were run and pass for the touched files: the `connector-health` Vitest lane (20/20), and `bunx biome check` on both changed files (clean, "No fixes applied"). A whole-package `tsc --noEmit` surfaced only pre-existing unrelated module-resolution errors from unbuilt sibling workspaces (`@elizaos/cloud-routing`, `@elizaos/plugin-*`) and a pre-existing `es2023` lib issue in `plugin-agent-orchestrator`; none reference the changed files. This is not a blocker for a one-file, no-API-change error-isolation fix.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@9ecb8e324444df09e525986425e3be1752e2eb62:packages/skills/skills/contribute-to-eliza"} -->
