### PR TITLE
fix(personal-assistant): preserve ready cadence narrowing

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -4619,7 +4619,7 @@ async function runLifeOperationHandlerInner(
                 multiStep: llmPlan?.multiStep === true,
               }),
             });
-      const definitionDraft: DeferredLifeDefinitionDraft = {
+      const definitionDraft = {
         intent,
         operation: "create_definition",
         createdAt: editingDeferredDefinitionDraft
@@ -4671,7 +4671,7 @@ async function runLifeOperationHandlerInner(
               | CreateLifeOpsDefinitionRequest["websiteAccess"]
               | undefined) ?? deferredDefinitionDraft?.request.websiteAccess,
         },
-      };
+      } satisfies DeferredLifeDefinitionDraft;
       if (
         shouldRequireLifeCreateConfirmation({
           confirmed: createConfirmed,


### PR DESCRIPTION
## Summary

- preserve the concrete save-ready draft type after the existing missing-cadence early return
- check the object against `DeferredLifeDefinitionDraft` with `satisfies` instead of widening its required cadence back to optional
- restore current-`develop` personal-assistant and root typecheck without a cast, fallback cadence, or runtime behavior change

Fixes #20187

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Why

#20182 correctly allows cadence-less drafts only while `awaitingField: "schedule"`. The create handler already returns when cadence is absent, but its explicit union annotation widened the later save-ready draft and broke three required-cadence call sites. `satisfies` validates the public shape while retaining the narrower inferred object type.

## Verification

Exact head: `28cbaa62916812dffe1dcdb105521e2f6a42a830`

- `bun install` — PASS (Bun 1.3.14; required 971 MiB artifact bundle verified and synced)
- `bun run --cwd plugins/plugin-personal-assistant typecheck` — PASS
- `bun test plugins/plugin-personal-assistant/src/actions/lib/lifeops-deferred-draft.test.ts` — PASS (11/11)
- `bunx --bun biome check plugins/plugin-personal-assistant/src/actions/life.ts` — PASS
- `git diff --check origin/develop..HEAD` — PASS
- `bun run verify` — PASS (351/351 tasks; 8,243 test files audited; 0 focused; 0 orphaned skips)

## Evidence matrix

| Evidence | Result |
| --- | --- |
| Behavioral | Existing awaiting-schedule and deferred owner-Todo contract suite passes 11/11, including cadence-less drafts only with the schedule marker. |
| Type/build | Package typecheck and full root verify pass on the exact head. |
| UI screenshots / video | N/A — type-only narrowing; emitted runtime behavior and rendered UI are unchanged. |
| Backend / console logs | N/A — no transport, server, or UI behavior changed. Command results above are the directly affected evidence. |
| Live model trajectory | N/A — no prompt, model, routing, or action behavior changed. |

<!-- evidence-head:28cbaa62916812dffe1dcdb105521e2f6a42a830 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - type-only narrowing; no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - type-only narrowing; no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible runtime behavior changed

<!-- evidence-row:backend-logs -->
- [ ] N/A - compile-time type preservation only; exact package and root command results are documented above

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend request, response, or state path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, model, routing, or action behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, scheduled item, wallet, file, or other domain output changed

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - contribute-to-eliza skill was not available in this session
Attribution status: self-reported
— [codex/lifeops-cadence-narrowing]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - contribute-to-eliza skill was not available in this session"} -->
