### PR TITLE
fix(desktop): constrain overlay input hit area

### DIFF
--- a/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts
@@ -4,6 +4,9 @@ import {
   appendChatOverlayShellModeParam,
   computeBottomBarFrame,
   DEFAULT_BOTTOM_BAR_HEIGHT,
+  DEFAULT_BOTTOM_BAR_WIDTH,
+  EXPANDED_BOTTOM_BAR_HEIGHT,
+  EXPANDED_BOTTOM_BAR_WIDTH,
   resolveDesktopShellWindowPresentation,
   shouldReanchorBottomBar,
   shouldStartBottomBar,
@@ -57,16 +60,16 @@ describe("desktop bottom-bar config", () => {
   });
 
   describe("computeBottomBarFrame", () => {
-    it("pins a full-width bar to the bottom of the work area", () => {
+    it("pins a pill-sized hit area to the bottom center of the work area", () => {
       const frame = computeBottomBarFrame({
         x: 0,
         y: 0,
         width: 1920,
         height: 1080,
       });
-      expect(frame.width).toBe(1920);
+      expect(frame.width).toBe(DEFAULT_BOTTOM_BAR_WIDTH);
       expect(frame.height).toBe(DEFAULT_BOTTOM_BAR_HEIGHT);
-      expect(frame.x).toBe(0);
+      expect(frame.x).toBe((1920 - DEFAULT_BOTTOM_BAR_WIDTH) / 2);
       expect(frame.y).toBe(1080 - DEFAULT_BOTTOM_BAR_HEIGHT);
     });
 
@@ -77,18 +80,18 @@ describe("desktop bottom-bar config", () => {
         width: 1440,
         height: 900,
       });
-      expect(frame.x).toBe(1920);
-      expect(frame.width).toBe(1440);
+      expect(frame.x).toBe(1920 + (1440 - DEFAULT_BOTTOM_BAR_WIDTH) / 2);
+      expect(frame.width).toBe(DEFAULT_BOTTOM_BAR_WIDTH);
       expect(frame.y).toBe(24 + 900 - DEFAULT_BOTTOM_BAR_HEIGHT);
     });
 
-    it("applies an optional side margin and custom height", () => {
+    it("centers custom dimensions inside an optional margin", () => {
       const frame = computeBottomBarFrame(
         { x: 0, y: 0, width: 1000, height: 800 },
-        { height: 100, margin: 20 },
+        { width: 600, height: 100, margin: 20 },
       );
-      expect(frame.x).toBe(20);
-      expect(frame.width).toBe(960);
+      expect(frame.x).toBe(200);
+      expect(frame.width).toBe(600);
       expect(frame.height).toBe(100);
       expect(frame.y).toBe(800 - 100 - 20);
     });
@@ -99,6 +102,18 @@ describe("desktop bottom-bar config", () => {
         { height: 1 },
       );
       expect(frame.height).toBe(48);
+    });
+
+    it("constrains the expanded chat hit area instead of spanning the display", () => {
+      expect(
+        computeBottomBarFrame(
+          { x: 0, y: 24, width: 1_440, height: 900 },
+          {
+            width: EXPANDED_BOTTOM_BAR_WIDTH,
+            height: EXPANDED_BOTTOM_BAR_HEIGHT,
+          },
+        ),
+      ).toEqual({ x: 420, y: 104, width: 600, height: 820 });
     });
   });
 

--- a/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts
@@ -106,29 +106,39 @@ export function resolveDesktopShellWindowPresentation(
   };
 }
 
-/** Default bar height — tall enough for the glass composer + a few message lines. */
-export const DEFAULT_BOTTOM_BAR_HEIGHT = 140;
+/** Resting native hit area around the 64×32 visible pill. */
+export const DEFAULT_BOTTOM_BAR_WIDTH = 96;
+export const DEFAULT_BOTTOM_BAR_HEIGHT = 56;
 
-/** Expanded chat window height; remains bottom-anchored above the Dock. */
-export const EXPANDED_BOTTOM_BAR_HEIGHT = 680;
+/** Expanded native hit area around the 560×640 glass panel and bottom pill. */
+export const EXPANDED_BOTTOM_BAR_WIDTH = 600;
+export const EXPANDED_BOTTOM_BAR_HEIGHT = 820;
 
 /**
- * Compute the bottom-bar window frame for a display's usable work area: full
- * usable width, a fixed bar height, pinned to the bottom edge (above the
- * taskbar/dock, which `workArea` already excludes). An optional side margin
- * insets the bar horizontally.
+ * Compute a bottom-centered window frame that is no larger than the visible
+ * pill or expanded chat surface. Keeping the transparent native window narrow
+ * prevents its invisible pixels from stealing pointer and keyboard input from
+ * other applications.
  */
 export function computeBottomBarFrame(
   workArea: ScreenWorkArea,
-  options?: { height?: number; margin?: number },
+  options?: { width?: number; height?: number; margin?: number },
 ): BottomBarFrame {
-  const height = Math.max(
+  const margin = Math.max(0, Math.round(options?.margin ?? 0));
+  const availableHeight = Math.max(1, Math.round(workArea.height) - margin);
+  const requestedHeight = Math.max(
     48,
     Math.round(options?.height ?? DEFAULT_BOTTOM_BAR_HEIGHT),
   );
-  const margin = Math.max(0, Math.round(options?.margin ?? 0));
-  const width = Math.max(1, Math.round(workArea.width) - margin * 2);
-  const x = Math.round(workArea.x) + margin;
+  const height = Math.min(requestedHeight, availableHeight);
+  const availableWidth = Math.max(1, Math.round(workArea.width) - margin * 2);
+  const requestedWidth = Math.max(
+    1,
+    Math.round(options?.width ?? DEFAULT_BOTTOM_BAR_WIDTH),
+  );
+  const width = Math.min(requestedWidth, availableWidth);
+  const x =
+    Math.round(workArea.x) + margin + Math.round((availableWidth - width) / 2);
   const y =
     Math.round(workArea.y) + Math.round(workArea.height) - height - margin;
   return { x, y, width, height };

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -398,10 +398,10 @@ describe("DesktopManager main window controls", () => {
     manager.enableBottomBarReanchor();
 
     await manager.setBottomBarExpanded({ expanded: true });
-    expect(window.setFrame).toHaveBeenLastCalledWith(100, 90, 900, 660);
+    expect(window.setFrame).toHaveBeenLastCalledWith(250, 50, 600, 700);
 
     await manager.setBottomBarExpanded({ expanded: false });
-    expect(window.setFrame).toHaveBeenLastCalledWith(100, 610, 900, 140);
+    expect(window.setFrame).toHaveBeenLastCalledWith(502, 694, 96, 56);
     await manager.dispose();
   });
 

--- a/packages/app-core/platforms/electrobun/src/native/desktop.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop.ts
@@ -47,6 +47,7 @@ import type { DatabaseSnapshot } from "../database";
 import {
   computeBottomBarFrame,
   EXPANDED_BOTTOM_BAR_HEIGHT,
+  EXPANDED_BOTTOM_BAR_WIDTH,
   type ScreenWorkArea,
   shouldReanchorBottomBar,
 } from "../desktop-bottom-bar-config";
@@ -1456,9 +1457,8 @@ X-GNOME-Autostart-enabled=true
     const workArea = this.readPrimaryWorkArea();
     if (!win || !workArea) return;
     const frame = computeBottomBarFrame(workArea, {
-      height: options.expanded
-        ? Math.min(EXPANDED_BOTTOM_BAR_HEIGHT, workArea.height - 40)
-        : undefined,
+      width: options.expanded ? EXPANDED_BOTTOM_BAR_WIDTH : undefined,
+      height: options.expanded ? EXPANDED_BOTTOM_BAR_HEIGHT : undefined,
     });
     win.setFrame(frame.x, frame.y, frame.width, frame.height);
     this.bottomBarWorkArea = workArea;

--- a/packages/ui/src/components/shell/chat-overlay-window-bounds.test.ts
+++ b/packages/ui/src/components/shell/chat-overlay-window-bounds.test.ts
@@ -30,31 +30,31 @@ describe("computeChatOverlayWindowBounds", () => {
   it("clamps an opened overlay to a short primary-display work area", () => {
     expect(
       computeChatOverlayWindowBounds(
-        { x: -80, y: 628, width: 1_512, height: 140 },
+        { x: 635, y: 712, width: 96, height: 56 },
         { x: 0, y: 24, width: 1_366, height: 744 },
         true,
       ),
-    ).toEqual({ x: 0, y: 24, width: 1_366, height: 744 });
+    ).toEqual({ x: 383, y: 24, width: 600, height: 744 });
   });
 
   it("restores the closed bar at the same in-work-area bottom edge", () => {
     expect(
       computeChatOverlayWindowBounds(
-        { x: 0, y: 24, width: 1_366, height: 744 },
+        { x: 383, y: 24, width: 600, height: 744 },
         { x: 0, y: 24, width: 1_366, height: 744 },
         false,
       ),
-    ).toEqual({ x: 0, y: 628, width: 1_366, height: 140 });
+    ).toEqual({ x: 635, y: 712, width: 96, height: 56 });
   });
 });
 
 describe("createChatOverlayWindowBoundsCoordinator", () => {
   it("serializes close behind an in-flight open and leaves the final frame closed", async () => {
     let current: ChatOverlayWindowBounds = {
-      x: 0,
-      y: 760,
-      width: 1_440,
-      height: 140,
+      x: 672,
+      y: 844,
+      width: 96,
+      height: 56,
     };
     const firstSet = deferred<void>();
     const applied: ChatOverlayWindowBounds[] = [];
@@ -84,8 +84,8 @@ describe("createChatOverlayWindowBoundsCoordinator", () => {
 
     firstSet.resolve();
     await coordinator.whenIdle();
-    expect(applied.map((bounds) => bounds.height)).toEqual([820, 140]);
-    expect(current).toEqual({ x: 0, y: 760, width: 1_440, height: 140 });
+    expect(applied.map((bounds) => bounds.height)).toEqual([820, 56]);
+    expect(current).toEqual({ x: 672, y: 844, width: 96, height: 56 });
     expect(onFailure).not.toHaveBeenCalled();
   });
 
@@ -94,7 +94,7 @@ describe("createChatOverlayWindowBoundsCoordinator", () => {
     const firstDisplay = deferred<{
       workArea: ChatOverlayWindowBounds;
     } | null>();
-    const current = { x: 0, y: 760, width: 1_440, height: 140 };
+    const current = { x: 672, y: 844, width: 96, height: 56 };
     const setWindowBounds = vi.fn(async () => {});
     let readCount = 0;
     const coordinator = createChatOverlayWindowBoundsCoordinator({
@@ -128,10 +128,10 @@ describe("createChatOverlayWindowBoundsCoordinator", () => {
     const onFailure = vi.fn();
     const coordinator = createChatOverlayWindowBoundsCoordinator({
       getWindowBounds: async () => ({
-        x: 0,
-        y: 760,
-        width: 1_440,
-        height: 140,
+        x: 672,
+        y: 844,
+        width: 96,
+        height: 56,
       }),
       getPrimaryDisplay: async () => ({
         workArea: { x: 0, y: 0, width: 1_440, height: 900 },

--- a/packages/ui/src/components/shell/chat-overlay-window-bounds.ts
+++ b/packages/ui/src/components/shell/chat-overlay-window-bounds.ts
@@ -32,7 +32,9 @@ export interface ChatOverlayWindowBoundsCoordinator {
   whenIdle: () => Promise<void>;
 }
 
-export const CHAT_OVERLAY_RESTING_WINDOW_HEIGHT = 140;
+export const CHAT_OVERLAY_RESTING_WINDOW_WIDTH = 96;
+export const CHAT_OVERLAY_RESTING_WINDOW_HEIGHT = 56;
+export const CHAT_OVERLAY_EXPANDED_WINDOW_WIDTH = 600;
 export const CHAT_OVERLAY_EXPANDED_WINDOW_HEIGHT = 820;
 
 function assertValidBounds(
@@ -67,9 +69,12 @@ export function computeChatOverlayWindowBounds(
   const requestedHeight = overlayOpen
     ? CHAT_OVERLAY_EXPANDED_WINDOW_HEIGHT
     : CHAT_OVERLAY_RESTING_WINDOW_HEIGHT;
+  const requestedWidth = overlayOpen
+    ? CHAT_OVERLAY_EXPANDED_WINDOW_WIDTH
+    : CHAT_OVERLAY_RESTING_WINDOW_WIDTH;
   const height = Math.min(requestedHeight, workArea.height);
-  const width = Math.min(current.width, workArea.width);
-  const x = clamp(current.x, workArea.x, workArea.x + workArea.width - width);
+  const width = Math.min(requestedWidth, workArea.width);
+  const x = workArea.x + Math.round((workArea.width - width) / 2);
   const bottom = clamp(
     current.y + current.height,
     workArea.y + height,


### PR DESCRIPTION
Fixes #20181

## What changed

- constrain the resting desktop overlay window to the visible 96×56 bottom-center pill
- constrain the expanded overlay to a centered 600×820 chat surface above the pill
- keep native and renderer geometry paths aligned, including work-area origin and clamping
- prevent transparent off-pill pixels from intercepting clicks or keyboard focus in other apps

## Verification

- `bun run verify`: passed (351/351 workspace tasks; repository audits clean)
- focused Vitest: 47/47 passed
- `packages/app-core` and `packages/ui` typechecks: passed
- app visual audit: 219/219 captures passed; 0 broken and 0 needs-work; OCR 0 broken
- packaged Electrobun Playwright E2E: passed
- strict macOS code-sign validation: passed
- Computer Use on the signed packaged app: clicked and typed into TextEdit while the Eliza pill remained running; opened the glass chat from the pill; collapsed it; returned to TextEdit and typed again successfully

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@be430994f76a91de4c0448ee55181ab3f93b3f9a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex/desktop-pill-popup]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@be430994f76a91de4c0448ee55181ab3f93b3f9a:packages/skills/skills/contribute-to-eliza"} -->
