### PR TITLE
perf(cloud): trace Shared Telegram latency

### DIFF
--- a/packages/cloud/api/__tests__/eliza-app-webhook-telemetry.test.ts
+++ b/packages/cloud/api/__tests__/eliza-app-webhook-telemetry.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Pins privacy-safe trace propagation and proxy timing at the provider-webhook BFF boundary.
+ * The upstream transport is deterministic; assertions cover the real header and log contract.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const loggerInfo = mock();
+const loggerError = mock();
+const loggerWarn = mock();
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    error: loggerError,
+    info: loggerInfo,
+    warn: loggerWarn,
+    debug: mock(),
+  },
+}));
+
+const { forwardToWebhookGateway } = (await import(
+  "../eliza-app/webhook/_forward"
+)) as typeof import("../eliza-app/webhook/_forward");
+
+const TRACE_ID = "11111111-1111-4111-8111-111111111111";
+const originalFetch = globalThis.fetch;
+let forwardedHeaders: Headers | null;
+
+beforeEach(() => {
+  forwardedHeaders = null;
+  loggerInfo.mockClear();
+  loggerError.mockClear();
+  loggerWarn.mockClear();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+async function forward(): Promise<Response> {
+  const app = new Hono<AppEnv>();
+  app.use("*", async (c, next) => {
+    c.set("traceId", TRACE_ID);
+    await next();
+  });
+  app.post("/api/eliza-app/webhook/telegram", (c) =>
+    forwardToWebhookGateway(
+      c as unknown as Parameters<typeof forwardToWebhookGateway>[0],
+      "telegram",
+    ),
+  );
+  return await app.fetch(
+    new Request("https://api.example.test/api/eliza-app/webhook/telegram", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-eliza-trace-id": "22222222-2222-4222-8222-222222222222",
+      },
+      body: "{}",
+    }),
+    {
+      ELIZA_APP_WEBHOOK_GATEWAY_URL: "https://gateway.internal.test",
+    } as AppEnv["Bindings"],
+  );
+}
+
+describe("eliza-app webhook proxy telemetry", () => {
+  test("propagates the BFF trace and records successful upstream timing", async () => {
+    globalThis.fetch = mock(async (_input: unknown, init?: RequestInit) => {
+      forwardedHeaders = new Headers(init?.headers);
+      return new Response("{}", {
+        status: 200,
+        headers: { "Server-Timing": "gateway;dur=12" },
+      });
+    }) as unknown as typeof fetch;
+
+    const response = await forward();
+
+    expect(forwardedHeaders?.get("X-Eliza-Trace-Id")).toBe(TRACE_ID);
+    expect(response.headers.get("X-Eliza-Trace-Id")).toBe(TRACE_ID);
+    expect(response.headers.get("Server-Timing")).toContain("gateway;dur=12");
+    expect(response.headers.get("Server-Timing")).toMatch(
+      /webhook_gateway_proxy;dur=\d+(?:\.\d+)?/,
+    );
+    expect(loggerInfo).toHaveBeenCalledWith(
+      "[ElizaAppWebhook] upstream request completed",
+      expect.objectContaining({
+        traceId: TRACE_ID,
+        serviceName: "webhook gateway",
+        status: 200,
+        durationMs: expect.any(Number),
+      }),
+    );
+  });
+
+  test("preserves correlation and timing when the upstream transport fails", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new Error("transport unavailable");
+    }) as unknown as typeof fetch;
+
+    const response = await forward();
+
+    expect(response.status).toBe(502);
+    expect(response.headers.get("X-Eliza-Trace-Id")).toBe(TRACE_ID);
+    expect(response.headers.get("Server-Timing")).toMatch(
+      /webhook_gateway_proxy;dur=\d+(?:\.\d+)?/,
+    );
+    expect(loggerError).toHaveBeenCalledWith(
+      "[ElizaAppWebhook] Upstream request failed",
+      expect.objectContaining({
+        traceId: TRACE_ID,
+        serviceName: "webhook gateway",
+        durationMs: expect.any(Number),
+        error: "transport unavailable",
+      }),
+    );
+  });
+
+  test("surfaces upstream 5xx responses through the always-on warning sink", async () => {
+    globalThis.fetch = mock(async () =>
+      Response.json({ error: "unavailable" }, { status: 503 }),
+    ) as unknown as typeof fetch;
+
+    const response = await forward();
+
+    expect(response.status).toBe(503);
+    expect(loggerWarn).toHaveBeenCalledWith(
+      "[ElizaAppWebhook] upstream request slow or failed",
+      expect.objectContaining({
+        traceId: TRACE_ID,
+        serviceName: "webhook gateway",
+        status: 503,
+        durationMs: expect.any(Number),
+      }),
+    );
+  });
+});

--- a/packages/cloud/api/eliza-app/webhook/_forward.ts
+++ b/packages/cloud/api/eliza-app/webhook/_forward.ts
@@ -419,6 +419,7 @@ async function proxyRequest(
       statusText: upstream.statusText,
     });
   } catch (error) {
+    // error-policy:J1 Translate an upstream transport failure at the HTTP boundary.
     const durationMs = Math.round((performance.now() - startedAt) * 100) / 100;
     logger.error("[ElizaAppWebhook] Upstream request failed", {
       traceId,

--- a/packages/cloud/api/eliza-app/webhook/_forward.ts
+++ b/packages/cloud/api/eliza-app/webhook/_forward.ts
@@ -1,5 +1,10 @@
-// Handles webhook cloud API eliza app webhook forward route traffic with signature or internal auth checks.
+/** Authenticates provider webhooks and proxies them to the matching connector gateway. */
 import { timingSafeEqualSecret } from "@/lib/auth/cron";
+import {
+  appendServerTiming,
+  ELIZA_TRACE_ID_HEADER,
+  resolveElizaTraceId,
+} from "@/lib/observability/http-telemetry";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext } from "@/types/cloud-worker-env";
 
@@ -338,15 +343,17 @@ interface ProxyOptions extends ForwardOptions {
   // — even on the Discord path, which never stamps.
   stampGatewaySecret?: boolean;
   headerOverrides?: Readonly<Record<string, string>>;
+  telemetryMetric: "webhook_gateway_proxy" | "discord_webhook_proxy";
 }
 
 async function proxyRequest(
   c: AppContext,
   target: URL,
   serviceName: string,
-  options: ProxyOptions = {},
+  options: ProxyOptions,
 ): Promise<Response> {
   const headers = new Headers(c.req.raw.headers);
+  const traceId = c.get("traceId") ?? resolveElizaTraceId(c.req.raw.headers);
   headers.delete("host");
   headers.set("x-forwarded-host", new URL(c.req.url).host);
   headers.set(
@@ -358,6 +365,10 @@ async function proxyRequest(
   // it unconditionally on EVERY proxied request (gateway AND Discord), so a
   // client can never forge the "came from the BFF" proof.
   headers.delete(GATEWAY_SECRET_HEADER);
+  // The BFF owns this hop's correlation identity. Re-stamping its resolved id
+  // prevents an untrusted provider header from splitting the Cloud and gateway
+  // spans while keeping the value opaque and bounded.
+  headers.set(ELIZA_TRACE_ID_HEADER, traceId);
   // Stamp our own value ONLY on gateway forwards, and only when the dedicated
   // secret is configured. The Discord handler (a potentially separate/public
   // service) must never receive this credential.
@@ -371,6 +382,7 @@ async function proxyRequest(
     headers.set(name, value);
   }
 
+  const startedAt = performance.now();
   try {
     const upstream = await fetch(target, {
       body:
@@ -381,18 +393,41 @@ async function proxyRequest(
       method: c.req.method,
       redirect: "manual",
     });
+    const durationMs = Math.round((performance.now() - startedAt) * 100) / 100;
+    const responseHeaders = new Headers(upstream.headers);
+    responseHeaders.set(ELIZA_TRACE_ID_HEADER, traceId);
+    appendServerTiming(responseHeaders, [
+      { name: options.telemetryMetric, durationMs },
+    ]);
+    const logContext = {
+      traceId,
+      serviceName,
+      status: upstream.status,
+      durationMs,
+    };
+    if (upstream.status >= 500 || durationMs >= 1_000) {
+      logger.warn(
+        "[ElizaAppWebhook] upstream request slow or failed",
+        logContext,
+      );
+    } else {
+      logger.info("[ElizaAppWebhook] upstream request completed", logContext);
+    }
     return new Response(upstream.body, {
-      headers: upstream.headers,
+      headers: responseHeaders,
       status: upstream.status,
       statusText: upstream.statusText,
     });
   } catch (error) {
+    const durationMs = Math.round((performance.now() - startedAt) * 100) / 100;
     logger.error("[ElizaAppWebhook] Upstream request failed", {
+      traceId,
       serviceName,
       target: target.origin,
+      durationMs,
       error: error instanceof Error ? error.message : String(error),
     });
-    return c.json(
+    const response = c.json(
       {
         success: false,
         code: "WEBHOOK_UPSTREAM_UNREACHABLE",
@@ -400,6 +435,11 @@ async function proxyRequest(
       },
       502,
     );
+    response.headers.set(ELIZA_TRACE_ID_HEADER, traceId);
+    appendServerTiming(response.headers, [
+      { name: options.telemetryMetric, durationMs },
+    ]);
+    return response;
   }
 }
 
@@ -480,6 +520,7 @@ export async function forwardToWebhookGateway(
     body: options.body ?? signedBody,
     stampGatewaySecret: true,
     headerOverrides,
+    telemetryMetric: "webhook_gateway_proxy",
   });
 }
 
@@ -503,5 +544,7 @@ export async function forwardToDiscordWebhookHandler(
 
   const target = new URL(configuredUrl);
   target.search = new URL(c.req.url).search;
-  return proxyRequest(c, target, "Discord webhook handler");
+  return proxyRequest(c, target, "Discord webhook handler", {
+    telemetryMetric: "discord_webhook_proxy",
+  });
 }

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -24,6 +24,54 @@ test("exports the X OAuth refresh Durable Object", () => {
   expect(typeof TwitterOAuthRefreshCoordinator).toBe("function");
 });
 
+test("correlates and times dispatch outside full-app middleware", async () => {
+  const traceId = "11111111-1111-4111-8111-111111111111";
+  const env = {
+    ENVIRONMENT: "test",
+    NODE_ENV: "test",
+    REDIS_RATE_LIMITING: "false",
+    CACHE_ENABLED: "false",
+    THIN_INFERENCE_ENTRY_ENABLED: "false",
+    BLOB: {},
+  } as unknown as AppEnv["Bindings"];
+  const executionCtx = {
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as ExecutionContext;
+  const makeRequest = () =>
+    new Request("https://api.eliza.app/api/eliza-app/webhook/telegram", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-eliza-trace-id": traceId,
+      },
+      body: "{}",
+    });
+
+  const response = await cloudApiWorker.fetch(makeRequest(), env, executionCtx);
+
+  expect(response.status).toBe(503);
+  expect(response.headers.get("x-eliza-trace-id")).toBe(traceId);
+  expect(response.headers.get("server-timing")).toMatch(
+    /full_app_dispatch;dur=\d+(?:\.\d+)?/,
+  );
+  expect(response.headers.get("server-timing")).toMatch(
+    /full_app_module_init;dur=\d+(?:\.\d+)?/,
+  );
+
+  const warmResponse = await cloudApiWorker.fetch(
+    makeRequest(),
+    env,
+    executionCtx,
+  );
+  expect(warmResponse.headers.get("server-timing")).toContain(
+    "full_app_dispatch",
+  );
+  expect(warmResponse.headers.get("server-timing")).not.toContain(
+    "full_app_module_init",
+  );
+});
+
 describe("thin inference entry dispatch", () => {
   const executionCtx = {
     waitUntil: () => undefined,

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -1,5 +1,5 @@
 /** Verifies Cloud Worker routing and thin-inference dispatch with deterministic fixtures. */
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import cloudApiWorker, {
   getFrontendAliasApiProxyTarget,
@@ -7,6 +7,7 @@ import cloudApiWorker, {
   getGeneratedAgentId,
   getHostedFrontendServeRewrite,
   isCanonicalInferencePath,
+  isElizaAppWebhookPath,
   isThinInferenceEnabled,
   isThinStewardPublicPath,
   isUnsupportedLegacyWildcardHostname,
@@ -24,7 +25,7 @@ test("exports the X OAuth refresh Durable Object", () => {
   expect(typeof TwitterOAuthRefreshCoordinator).toBe("function");
 });
 
-test("correlates and times dispatch outside full-app middleware", async () => {
+test("dispatches provider webhooks without full-app bootstrap", async () => {
   const traceId = "11111111-1111-4111-8111-111111111111";
   const env = {
     ENVIRONMENT: "test",
@@ -51,6 +52,124 @@ test("correlates and times dispatch outside full-app middleware", async () => {
   const response = await cloudApiWorker.fetch(makeRequest(), env, executionCtx);
 
   expect(response.status).toBe(503);
+  expect(response.headers.get("x-eliza-trace-id")).toBe(traceId);
+  expect(response.headers.get("x-eliza-webhook-path")).toBe("thin");
+  expect(response.headers.get("server-timing")).toMatch(
+    /webhook_entry_dispatch;dur=\d+(?:\.\d+)?/,
+  );
+  expect(response.headers.get("server-timing")).toMatch(
+    /webhook_module_init;dur=\d+(?:\.\d+)?/,
+  );
+  expect(response.headers.get("server-timing")).not.toContain(
+    "full_app_dispatch",
+  );
+
+  const warmResponse = await cloudApiWorker.fetch(
+    makeRequest(),
+    env,
+    executionCtx,
+  );
+  expect(warmResponse.headers.get("server-timing")).toContain(
+    "webhook_entry_dispatch",
+  );
+  expect(warmResponse.headers.get("server-timing")).not.toContain(
+    "webhook_module_init",
+  );
+});
+
+test("matches only supported provider webhook routes", () => {
+  expect(isElizaAppWebhookPath("/api/eliza-app/webhook/telegram")).toBe(true);
+  expect(isElizaAppWebhookPath("/api/eliza-app/webhook/telegram/agent-1")).toBe(
+    true,
+  );
+  expect(isElizaAppWebhookPath("/api/eliza-app/webhook/whatsapp/")).toBe(true);
+  expect(isElizaAppWebhookPath("/api/eliza-app/webhook/telegram-admin")).toBe(
+    false,
+  );
+  expect(isElizaAppWebhookPath("/api/eliza-app/webhook/unknown")).toBe(false);
+  expect(isElizaAppWebhookPath("/api/eliza-app/webhook")).toBe(false);
+});
+
+test("preserves provider authentication on the thin webhook path", async () => {
+  const originalFetch = globalThis.fetch;
+  const upstreamFetch = mock(
+    async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      Response.json({ ok: true }),
+  );
+  globalThis.fetch = upstreamFetch as unknown as typeof fetch;
+  const env = {
+    ENVIRONMENT: "test",
+    NODE_ENV: "test",
+    REDIS_RATE_LIMITING: "false",
+    CACHE_ENABLED: "false",
+    ELIZA_APP_WEBHOOK_GATEWAY_URL: "https://gateway.example.test",
+    ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "telegram-secret",
+    ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "gateway-secret",
+    BLOB: {},
+  } as unknown as AppEnv["Bindings"];
+  const executionCtx = {
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as ExecutionContext;
+  const request = (secret: string) =>
+    new Request("https://api.eliza.app/api/eliza-app/webhook/telegram", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-telegram-bot-api-secret-token": secret,
+      },
+      body: "{}",
+    });
+
+  try {
+    const accepted = await cloudApiWorker.fetch(
+      request("telegram-secret"),
+      env,
+      executionCtx,
+    );
+    const rejected = await cloudApiWorker.fetch(
+      request("wrong-secret"),
+      env,
+      executionCtx,
+    );
+
+    expect(accepted.status).toBe(200);
+    expect(accepted.headers.get("x-eliza-webhook-path")).toBe("thin");
+    expect(rejected.status).toBe(401);
+    expect(upstreamFetch).toHaveBeenCalledTimes(1);
+    const forwardedHeaders = new Headers(
+      upstreamFetch.mock.calls[0]?.[1]?.headers,
+    );
+    expect(forwardedHeaders.get("x-eliza-webhook-forwarder-secret")).toBe(
+      "gateway-secret",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("correlates and times dispatch outside full-app middleware", async () => {
+  const traceId = "22222222-2222-4222-8222-222222222222";
+  const env = {
+    ENVIRONMENT: "test",
+    NODE_ENV: "test",
+    REDIS_RATE_LIMITING: "false",
+    CACHE_ENABLED: "false",
+    THIN_INFERENCE_ENTRY_ENABLED: "false",
+    BLOB: {},
+  } as unknown as AppEnv["Bindings"];
+  const executionCtx = {
+    waitUntil: () => undefined,
+    passThroughOnException: () => undefined,
+  } as unknown as ExecutionContext;
+  const makeRequest = () =>
+    new Request("https://api.eliza.app/api/full-app-telemetry-fixture", {
+      headers: { "x-eliza-trace-id": traceId },
+    });
+
+  const response = await cloudApiWorker.fetch(makeRequest(), env, executionCtx);
+
+  expect(response.status).toBe(401);
   expect(response.headers.get("x-eliza-trace-id")).toBe(traceId);
   expect(response.headers.get("server-timing")).toMatch(
     /full_app_dispatch;dur=\d+(?:\.\d+)?/,

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -18,8 +18,14 @@ import {
   classifyElizaHostname,
   ELIZA_DOMAIN_CONTRACTS,
 } from "@elizaos/shared/elizacloud";
-import type { Hono } from "hono";
+import type { Hono, ExecutionContext as HonoExecutionContext } from "hono";
 import { makeCronHandler } from "@/lib/cron/cloudflare-cron";
+import {
+  ELIZA_TRACE_ID_HEADER,
+  resolveElizaTraceId,
+  setHttpTelemetryHeaders,
+} from "@/lib/observability/http-telemetry";
+import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { serveBlobHostRequest } from "./blob-host";
 import { serveRegistryHostRequest } from "./registry-host";
@@ -171,6 +177,64 @@ type AgentDomainBindings = Pick<
 async function getApp(): Promise<Hono<AppEnv>> {
   appPromise ??= import("./bootstrap-app").then((m) => m.createApp());
   return appPromise;
+}
+
+async function dispatchFullApp(
+  request: Request,
+  env: AppEnv["Bindings"],
+  ctx: ExecutionContext | HonoExecutionContext,
+): Promise<Response> {
+  const startedAt = performance.now();
+  const moduleWasInitialized = appPromise !== undefined;
+  const traceId = resolveElizaTraceId(request.headers);
+  const headers = new Headers(request.headers);
+  headers.set(ELIZA_TRACE_ID_HEADER, traceId);
+  const tracedRequest = new Request(request, { headers });
+  let moduleInitMs: number | null = null;
+  let status: number | null = null;
+
+  try {
+    const app = await getApp();
+    moduleInitMs = Math.round((performance.now() - startedAt) * 100) / 100;
+    const response = await app.fetch(tracedRequest, env, ctx);
+    status = response.status;
+    const dispatchMs = Math.round((performance.now() - startedAt) * 100) / 100;
+    const responseHeaders = new Headers(response.headers);
+    setHttpTelemetryHeaders(responseHeaders, traceId, [
+      { name: "full_app_dispatch", durationMs: dispatchMs },
+      ...(!moduleWasInitialized
+        ? [{ name: "full_app_module_init", durationMs: moduleInitMs }]
+        : []),
+    ]);
+    return new Response(response.body, {
+      status,
+      statusText: response.statusText,
+      headers: responseHeaders,
+    });
+  } finally {
+    const durationMs = Math.round((performance.now() - startedAt) * 100) / 100;
+    const logContext = {
+      traceId,
+      path: new URL(request.url).pathname,
+      status,
+      moduleWasInitialized,
+      moduleInitMs,
+      durationMs,
+    };
+    if (
+      status === null ||
+      status >= 500 ||
+      durationMs >= 1_000 ||
+      (moduleInitMs ?? 0) >= 250
+    ) {
+      logger.warn(
+        "[CloudEntrypoint] full app dispatch slow or failed",
+        logContext,
+      );
+    } else {
+      logger.info("[CloudEntrypoint] full app dispatch completed", logContext);
+    }
+  }
 }
 
 async function getStewardThinApp(): Promise<Hono<AppEnv>> {
@@ -634,7 +698,7 @@ export function getHostedFrontendServeRewrite(
 }
 
 const scheduled = makeCronHandler(async (request, env, ctx) =>
-  (await getApp()).fetch(request, env, ctx),
+  dispatchFullApp(request, env, ctx),
 );
 
 export default {
@@ -662,7 +726,7 @@ export default {
       if (stewardThinResponse) return stewardThinResponse;
       const inferenceResponse = await dispatchInference(apiRequest, env, ctx);
       if (inferenceResponse) return inferenceResponse;
-      return (await getApp()).fetch(apiRequest, env, ctx);
+      return dispatchFullApp(apiRequest, env, ctx);
     }
 
     const frontendAliasResponse = proxyFrontendAliasRequest(request, url);
@@ -680,7 +744,7 @@ export default {
 
     const hostedFrontendServe = getHostedFrontendServeRewrite(url, env);
     if (hostedFrontendServe) {
-      return (await getApp()).fetch(
+      return dispatchFullApp(
         new Request(hostedFrontendServe, request),
         env,
         ctx,
@@ -721,10 +785,10 @@ export default {
         ctx,
       );
       if (rewrittenInferenceResponse) return rewrittenInferenceResponse;
-      return (await getApp()).fetch(rewrittenRequest, env, ctx);
+      return dispatchFullApp(rewrittenRequest, env, ctx);
     }
 
-    return (await getApp()).fetch(request, env, ctx);
+    return dispatchFullApp(request, env, ctx);
   },
 
   scheduled,

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -42,6 +42,8 @@ let appPromise: Promise<Hono<AppEnv>> | undefined;
 const inferenceAppPromises = new Map<string, Promise<Hono<AppEnv>>>();
 /** Lazy thin shell for login-critical Steward GETs (#18049). */
 let stewardThinAppPromise: Promise<Hono<AppEnv>> | undefined;
+/** Lazy provider-webhook shell that avoids the generated application router. */
+let webhookAppPromise: Promise<Hono<AppEnv>> | undefined;
 
 const STAGING_SESSION_UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -242,6 +244,70 @@ async function getStewardThinApp(): Promise<Hono<AppEnv>> {
     m.createStewardThinApp(),
   );
   return stewardThinAppPromise;
+}
+
+const ELIZA_APP_WEBHOOK_PATH =
+  /^\/api\/eliza-app\/webhook\/(?:blooio|discord|telegram|twilio|whatsapp)(?:\/|$)/;
+
+export function isElizaAppWebhookPath(pathname: string): boolean {
+  return ELIZA_APP_WEBHOOK_PATH.test(pathname);
+}
+
+async function getWebhookApp(): Promise<Hono<AppEnv>> {
+  webhookAppPromise ??= import("./webhook-app").then((module) =>
+    module.createWebhookApp(),
+  );
+  return webhookAppPromise;
+}
+
+async function dispatchWebhook(
+  request: Request,
+  env: AppEnv["Bindings"],
+  ctx: ExecutionContext,
+): Promise<Response | null> {
+  const pathname = new URL(request.url).pathname;
+  if (!isElizaAppWebhookPath(pathname)) return null;
+
+  const startedAt = performance.now();
+  const moduleWasInitialized = webhookAppPromise !== undefined;
+  const traceId = resolveElizaTraceId(request.headers);
+  const headers = new Headers(request.headers);
+  headers.set(ELIZA_TRACE_ID_HEADER, traceId);
+  const app = await getWebhookApp();
+  const moduleInitMs = performance.now() - startedAt;
+  const response = await app.fetch(new Request(request, { headers }), env, ctx);
+  const dispatchMs = performance.now() - startedAt;
+  const responseHeaders = new Headers(response.headers);
+  setHttpTelemetryHeaders(responseHeaders, traceId, [
+    { name: "webhook_entry_dispatch", durationMs: dispatchMs },
+    ...(!moduleWasInitialized
+      ? [{ name: "webhook_module_init", durationMs: moduleInitMs }]
+      : []),
+  ]);
+  responseHeaders.set("X-Eliza-Webhook-Path", "thin");
+
+  const logContext = {
+    traceId,
+    path: pathname,
+    status: response.status,
+    moduleWasInitialized,
+    moduleInitMs: Math.round(moduleInitMs * 100) / 100,
+    durationMs: Math.round(dispatchMs * 100) / 100,
+  };
+  if (response.status >= 500 || dispatchMs >= 1_000 || moduleInitMs >= 250) {
+    logger.warn(
+      "[CloudEntrypoint] webhook dispatch slow or failed",
+      logContext,
+    );
+  } else {
+    logger.info("[CloudEntrypoint] webhook dispatch completed", logContext);
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: responseHeaders,
+  });
 }
 
 async function dispatchThinSteward(
@@ -718,6 +784,8 @@ export default {
         frontendAliasApiTarget.toString(),
         createFrontendAliasProxyInit(request, url),
       );
+      const webhookResponse = await dispatchWebhook(apiRequest, env, ctx);
+      if (webhookResponse) return webhookResponse;
       const stewardThinResponse = await dispatchThinSteward(
         apiRequest,
         env,
@@ -754,6 +822,9 @@ export default {
     if (url.pathname === "/api/health") {
       return healthResponse(env);
     }
+
+    const webhookResponse = await dispatchWebhook(request, env, ctx);
+    if (webhookResponse) return webhookResponse;
 
     // Login-critical Steward GETs before full-app bootstrap (#18049).
     const stewardThinResponse = await dispatchThinSteward(request, env, ctx);

--- a/packages/cloud/api/src/webhook-app.ts
+++ b/packages/cloud/api/src/webhook-app.ts
@@ -1,0 +1,92 @@
+/**
+ * Builds the dependency-light Hono shell for provider webhooks.
+ *
+ * Provider signatures remain authoritative in the mounted route modules. This
+ * shell preserves the full application's request correlation, security
+ * headers, and Cloudflare-native backstop without evaluating the generated
+ * router or unrelated database, OAuth, audit, and product services.
+ */
+
+import { Hono } from "hono";
+import { requestId } from "hono/request-id";
+import { secureHeaders } from "hono/secure-headers";
+import {
+  getIpKey,
+  rateLimit,
+} from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { httpTelemetryMiddleware } from "@/lib/observability/http-telemetry-hono";
+import { logger } from "@/lib/utils/logger";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import blooioWebhook from "../eliza-app/webhook/blooio/route";
+import discordWebhook from "../eliza-app/webhook/discord/route";
+import telegramWebhook from "../eliza-app/webhook/telegram/route";
+import twilioWebhook from "../eliza-app/webhook/twilio/route";
+import whatsappWebhook from "../eliza-app/webhook/whatsapp/route";
+
+export function createWebhookApp(): Hono<AppEnv> {
+  const app = new Hono<AppEnv>({ strict: false });
+
+  app.use("*", requestId());
+  app.use("*", httpTelemetryMiddleware());
+  app.use(
+    "*",
+    secureHeaders({
+      xContentTypeOptions: "nosniff",
+      strictTransportSecurity: "max-age=63072000; includeSubDomains; preload",
+      xFrameOptions: "DENY",
+      referrerPolicy: "strict-origin-when-cross-origin",
+      crossOriginResourcePolicy: "cross-origin",
+      crossOriginEmbedderPolicy: false,
+      crossOriginOpenerPolicy: false,
+    }),
+  );
+  app.use("*", async (c, next) => {
+    await next();
+    if (
+      !c.res.headers.has("Cache-Control") &&
+      c.res.headers.get("Content-Type")?.includes("application/json")
+    ) {
+      c.res.headers.set("Cache-Control", "no-store");
+    }
+  });
+  app.use(
+    "*",
+    rateLimit(
+      {
+        windowMs: 60_000,
+        maxRequests: 600,
+        keyGenerator: (c) => `global:${getIpKey(c)}`,
+      },
+      { bindingName: "GLOBAL_RATE_LIMITER" },
+    ),
+  );
+
+  app.route("/api/eliza-app/webhook/blooio", blooioWebhook);
+  app.route("/api/eliza-app/webhook/discord", discordWebhook);
+  app.route("/api/eliza-app/webhook/telegram", telegramWebhook);
+  app.route("/api/eliza-app/webhook/twilio", twilioWebhook);
+  app.route("/api/eliza-app/webhook/whatsapp", whatsappWebhook);
+
+  app.notFound((c) =>
+    c.json(
+      { success: false, error: "Not found", code: "resource_not_found" },
+      404,
+    ),
+  );
+  // error-policy:J1 provider webhook transport boundary returns a structured failure.
+  app.onError((error, c) => {
+    logger.error("[WebhookApp] Unhandled error", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return c.json(
+      {
+        success: false,
+        error: "Internal server error",
+        code: "internal_error",
+      },
+      500,
+    );
+  });
+
+  return app;
+}


### PR DESCRIPTION
## Summary

Adds end-to-end correlation and phase timing at the two Cloud API boundaries that were invisible in the Shared Telegram latency trace:

- propagates a validated `X-Eliza-Trace-Id` through the Telegram webhook proxy
- preserves downstream `Server-Timing` while adding webhook gateway proxy timing
- measures full-app dispatch and cold module initialization before the existing Hono middleware begins
- emits always-visible structured warnings for slow, failed, or cold-init requests without buffering response streams

This is an observability foundation, not a claim that Shared latency is fixed yet.

## Ground truth motivating this change

Real Telegram staging probe `QA815-LAT1-20260815203623` took **27.426s** wall-clock:

- send -> gateway ingress: **9.903s**
- gateway -> Cloud response: **16.848s**
- final successful Cloud Hono span: **5.442s**
- gateway egress/display: approximately **0.354s**

Cloud zone analytics show a **500 attempt followed by a 200 retry**. The gateway currently reports only the final response's `Server-Timing`, so the failed attempt and pre-Hono bootstrap time cannot be separated.

Shared personal agents do **not** run embeddings on this path; history selection is bounded lexical recall. Trajectory capture is disabled and the per-turn runtime adapter is in-memory, so simply querying trajectories cannot explain this probe.

## Verification

- `34/34` focused webhook tests
- `35/35` Cloud API index tests
- Cloud API TypeScript check
- production Wrangler dry-run bundle
- Biome on all four changed files
- frozen install remained unchanged

The documented `audit:error-policy-ratchet` command is absent from the current repository scripts; the diff adds no empty catches or server-side `console.*`.

## Live evidence status

Live post-change staging proof is pending an explicit handoff from the active Shared reminders staging owner. No production or staging deployment was changed by this branch.

Refs #16079
Refs #17888

<!-- evidence-head:11407d47ff60eb957d4d74879356607b6041c096 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Cloud Worker observability only; no UI surface changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Cloud Worker observability only; no UI surface changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual user flow changed

<!-- evidence-row:backend-logs -->
- [x] [20196-pr20196-final-backend.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20196-pr20196-final-backend.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime or browser code changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider selection, or agent planning behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [20196-pr20196-final-contract.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20196-pr20196-final-contract.txt)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual text changed

