### PR TITLE
fix(cloud-api): Group H internal Discord messages smoke uses the guild path

### DIFF
--- a/packages/cloud/api/test/e2e/group-h-misc.test.ts
+++ b/packages/cloud/api/test/e2e/group-h-misc.test.ts
@@ -554,6 +554,13 @@ const internalDiscordRoutes: Array<{
     path: "/api/internal/discord/eliza-app/messages",
     method: "POST",
     validBody: {
+      // Guild-path smoke: an unbound test guild resolves to a not_linked
+      // router result (200) with zero harness state. The former no-guild
+      // fixture now delegates to personal-Shared validation, which requires
+      // a NUMERIC Discord user id and a linked personal account — real
+      // account seeding, out of scope for this liveness smoke (the
+      // personal path has its own integration coverage).
+      guildId: "guild-1",
       channelId: "channel-1",
       messageId: "message-1",
       content: "hello",


### PR DESCRIPTION
## Problem

Launch blocker (codex-slop-launch handoff, HQ #18309): every staging/production deploy mutation fails deterministically at the predeploy Worker e2e — `group-h-misc.test.ts:652`, POST `/api/internal/discord/eliza-app/messages`, expected 200 / received 400 (hosted runs 31905786523, 31906463355; gauss's production dispatch 31906316903 carries the same risk on main).

Root cause (from the handoff, confirmed against the route source): the "handler is live" smoke still sends the ancient no-guild fixture with `sender.id: "discord-user-1"`. The route now (correctly, per the merged personal-Shared work) delegates no-guild traffic to personal-Shared validation, which requires a **numeric** Discord user id and a **linked personal account** — a 400 for the stale fixture, deterministically.

## Fix (test-file only; the route and its owner's boundary are untouched)

The smoke moves to the **guild path**: `guildId: "guild-1"` added to the valid fixture. Traced through the route: an unbound guild resolves through `agentGatewayRouterService.routeDiscordMessage` to the `not_linked` result and returns 200 with **zero harness state** — exactly what a liveness smoke should prove (auth gate + schema parse + router delegation live). The personal path's numeric-id/account requirements have their own integration coverage; a liveness smoke must not depend on seeded personal accounts. In-fixture comment documents why for the next reader.

## Evidence

| Row | Result |
| --- | --- |
| Root cause | Handoff receipts (two failed hosted runs, exact cause) + my independent route-source trace: guild branch returns `c.json(result)` (200) for `not_linked` before any personal validation |
| Local e2e | Attempted honestly, twice: the local batch runner's wrangler dev wedged pre-ready on this box (~30 min idle, health never served) — stated plainly rather than claimed. The fix's semantics are source-traced, not run-proved locally |
| Real proving ground | The predeploy "Worker e2e" job gates every deploy and runs exactly this file against the real stack — the next admitted staging run is the live proof, and a wrong fixture can only fail that same gate again (zero production risk; test-only change) |
| Sequencing | After develop merge: immediate cherry-pick PR to main (#20171 pattern) so gauss's production re-dispatch clears the same gate |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
