### PR TITLE
fix(cloud-api): carry the Group H guild-path smoke to main

### DIFF
--- a/packages/cloud/api/test/e2e/group-h-misc.test.ts
+++ b/packages/cloud/api/test/e2e/group-h-misc.test.ts
@@ -554,6 +554,13 @@ const internalDiscordRoutes: Array<{
     path: "/api/internal/discord/eliza-app/messages",
     method: "POST",
     validBody: {
+      // Guild-path smoke: an unbound test guild resolves to a not_linked
+      // router result (200) with zero harness state. The former no-guild
+      // fixture now delegates to personal-Shared validation, which requires
+      // a NUMERIC Discord user id and a linked personal account — real
+      // account seeding, out of scope for this liveness smoke (the
+      // personal path has its own integration coverage).
+      guildId: "guild-1",
       channelId: "channel-1",
       messageId: "message-1",
       content: "hello",


### PR DESCRIPTION
Byte-identical cherry-pick of the develop fix (#20197, merged) onto main. Main carries the same stale no-guild fixture, so any production Cloud CF run dies at the predeploy Worker e2e exactly as staging did (codex-slop-launch's assessment; gauss's dispatch 31906316903 is exposed right now). Same pattern as #20171: test-only, provenance-pure, unblocks the production re-dispatch.

Full root-cause + evidence: #20197. HQ thread: #18309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)