### PR TITLE
fix(agent): gate Cloud inference on usable credentials

### DIFF
--- a/packages/agent/src/runtime/eliza-cloud-config.test.ts
+++ b/packages/agent/src/runtime/eliza-cloud-config.test.ts
@@ -5,7 +5,8 @@
  * that prevents stale vault/config keys from clobbering live cloud settings
  * (#11038). Asserts env mutations directly; no live cloud calls.
  */
-import { logger } from "@elizaos/core";
+import { type IAgentRuntime, logger } from "@elizaos/core";
+import { registerTextInferenceModels } from "@elizaos/plugin-elizacloud";
 import { resolveElizaCloudTopology } from "@elizaos/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ElizaConfig } from "../config/config.ts";
@@ -131,6 +132,50 @@ describe("applyCloudConfigToEnv cloud-container embeddings (#8769)", () => {
     expect(process.env.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBeUndefined();
     expect(process.env.ELIZAOS_CLOUD_USE_INFERENCE).toBeUndefined();
     expect(process.env.ELIZAOS_CLOUD_ENABLED).toBeUndefined();
+  });
+});
+
+describe("unsigned Cloud inference fallback (#20045)", () => {
+  it("keeps Cloud chat handlers unregistered until a credential can serve them", () => {
+    const config: ElizaConfig = {
+      serviceRouting: {
+        llmText: {
+          backend: "elizacloud",
+          transport: "cloud-proxy",
+        },
+      },
+    } as ElizaConfig;
+
+    applyCloudConfigToEnv(config);
+
+    const registered: string[] = [];
+    const runtime = {
+      getSetting: (key: string) => process.env[key],
+      registerModel: (modelType: string) => registered.push(modelType),
+    } as unknown as IAgentRuntime;
+    registerTextInferenceModels(runtime);
+
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBeUndefined();
+    expect(process.env.ELIZAOS_CLOUD_USE_INFERENCE).toBe("false");
+    expect(process.env.ELIZAOS_CLOUD_ENABLED).toBe("true");
+    expect(registered).toEqual([]);
+  });
+
+  it("enables Cloud inference when config.env provides the usable credential", () => {
+    const config: ElizaConfig = {
+      serviceRouting: {
+        llmText: {
+          backend: "elizacloud",
+          transport: "cloud-proxy",
+        },
+      },
+      env: { vars: { ELIZAOS_CLOUD_API_KEY: "cloud-test" } },
+    } as ElizaConfig;
+
+    applyCloudConfigToEnv(config);
+
+    expect(process.env.ELIZAOS_CLOUD_API_KEY).toBe("cloud-test");
+    expect(process.env.ELIZAOS_CLOUD_USE_INFERENCE).toBe("true");
   });
 });
 

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -2265,8 +2265,19 @@ export function applyCloudConfigToEnv(config: ElizaConfig): void {
   // Cloud inference is selected from the canonical first-run connection, not
   // just from raw cloud flags. This keeps linked cloud auth from re-enabling
   // Eliza Cloud after the user has switched to a local or remote provider.
-  const effectivelyEnabled = topology.services.inference || isCloudContainer;
+  const inferenceConfigured = topology.services.inference || isCloudContainer;
   const shouldLoadCloudPlugin = topology.shouldLoadPlugin || isCloudContainer;
+  const configuredCloudApiKey = trimCloudCredential(cloud?.apiKey);
+  const effectiveCloudApiKey =
+    configuredCloudApiKey ??
+    readEffectiveCloudCredential(config, "ELIZAOS_CLOUD_API_KEY");
+  // Declared routing is intent, not proof that the selected handler can serve.
+  // A provisioned Cloud container owns its runtime route; every other host must
+  // have the actual credential that plugin-elizacloud will use before Cloud can
+  // register the high-priority chat-brain handlers.
+  const inferenceAvailable =
+    isCloudContainer ||
+    (topology.services.inference && Boolean(effectiveCloudApiKey));
 
   const setCloudUsageEnv = (key: string, enabled: boolean): void => {
     if (enabled) {
@@ -2279,7 +2290,7 @@ export function applyCloudConfigToEnv(config: ElizaConfig): void {
   if (isElizaSettingsDebugEnabled()) {
     const c = (cloud ?? {}) as Record<string, unknown>;
     logger.debug(
-      `[eliza][settings][runtime] applyCloudConfigToEnv inference=${effectivelyEnabled} shouldLoadPlugin=${shouldLoadCloudPlugin} isCloudContainer=${isCloudContainer} cloud=${JSON.stringify(settingsDebugCloudSummary(c))}`,
+      `[eliza][settings][runtime] applyCloudConfigToEnv inferenceConfigured=${inferenceConfigured} inferenceAvailable=${inferenceAvailable} shouldLoadPlugin=${shouldLoadCloudPlugin} isCloudContainer=${isCloudContainer} cloud=${JSON.stringify(settingsDebugCloudSummary(c))}`,
     );
   }
 
@@ -2292,7 +2303,7 @@ export function applyCloudConfigToEnv(config: ElizaConfig): void {
   // when inference is off (the old behavior) was indistinguishable from "no
   // policy", so the plugin could never load capability-only — the host nuked
   // the API key instead and lost image generation as collateral (#10819).
-  if (effectivelyEnabled) {
+  if (inferenceAvailable) {
     process.env.ELIZAOS_CLOUD_USE_INFERENCE = "true";
   } else if (shouldLoadCloudPlugin) {
     process.env.ELIZAOS_CLOUD_USE_INFERENCE = "false";
@@ -2362,17 +2373,13 @@ export function applyCloudConfigToEnv(config: ElizaConfig): void {
   }
   setCloudUsageEnv("ELIZAOS_CLOUD_USE_RPC", topology.services.rpc);
 
-  if (effectivelyEnabled) {
+  if (inferenceConfigured) {
     process.env.ELIZAOS_CLOUD_ENABLED = "true";
   } else {
     delete process.env.ELIZAOS_CLOUD_ENABLED;
   }
 
   if (shouldLoadCloudPlugin) {
-    const configuredCloudApiKey = trimCloudCredential(cloud?.apiKey);
-    const effectiveCloudApiKey =
-      configuredCloudApiKey ??
-      readEffectiveCloudCredential(config, "ELIZAOS_CLOUD_API_KEY");
     const configuredCloudBaseUrl = trimEnvString(cloud?.baseUrl);
     const effectiveCloudBaseUrl =
       configuredCloudBaseUrl ??
@@ -2452,7 +2459,7 @@ export function applyCloudConfigToEnv(config: ElizaConfig): void {
         mega?: string;
       }
     | undefined;
-  if (effectivelyEnabled) {
+  if (inferenceAvailable) {
     const nano =
       llmText?.nanoModel ||
       models?.nano ||

--- a/packages/agent/src/runtime/plugin-collector-mode-policy.test.ts
+++ b/packages/agent/src/runtime/plugin-collector-mode-policy.test.ts
@@ -88,6 +88,58 @@ describe("collectPluginNames runtime mode provider policy", () => {
     expect(names.has("@elizaos/plugin-local-inference")).toBe(false);
   });
 
+  it("keeps local inference available for unsigned Cloud text intent", () => {
+    const config: ElizaConfig = {
+      serviceRouting: {
+        llmText: {
+          backend: "elizacloud",
+          transport: "cloud-proxy",
+        },
+      },
+    } as ElizaConfig;
+
+    const names = collectPluginNames(config);
+
+    expect(names.has("@elizaos/plugin-elizacloud")).toBe(true);
+    expect(names.has("@elizaos/plugin-local-inference")).toBe(true);
+  });
+
+  it("lets a usable env credential make Cloud the exclusive text provider", () => {
+    process.env.ELIZAOS_CLOUD_API_KEY = "cloud-test";
+    const config: ElizaConfig = {
+      serviceRouting: {
+        llmText: {
+          backend: "elizacloud",
+          transport: "cloud-proxy",
+        },
+      },
+    } as ElizaConfig;
+
+    const names = collectPluginNames(config);
+
+    expect(names.has("@elizaos/plugin-elizacloud")).toBe(true);
+    expect(names.has("@elizaos/plugin-local-inference")).toBe(false);
+  });
+
+  it.each(["[REDACTED]", "vault://providers.elizacloud.api-key"])(
+    "does not treat %s as a serving credential",
+    (unresolvedCredential) => {
+      process.env.ELIZAOS_CLOUD_API_KEY = unresolvedCredential;
+      const config: ElizaConfig = {
+        serviceRouting: {
+          llmText: {
+            backend: "elizacloud",
+            transport: "cloud-proxy",
+          },
+        },
+      } as ElizaConfig;
+
+      const names = collectPluginNames(config);
+
+      expect(names.has("@elizaos/plugin-local-inference")).toBe(true);
+    },
+  );
+
   it("keeps a direct Cerebras text provider beside Cloud capabilities", () => {
     process.env.CEREBRAS_API_KEY = "csk-test";
     process.env.OLLAMA_BASE_URL = "http://127.0.0.1:11434";

--- a/packages/agent/src/runtime/plugin-collector.ts
+++ b/packages/agent/src/runtime/plugin-collector.ts
@@ -126,6 +126,16 @@ function resolveGitpathologistRepoRoot(): string {
   return path.resolve(cwd);
 }
 
+function isUsableCloudApiKey(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  return (
+    trimmed.length > 0 &&
+    trimmed.toUpperCase() !== "[REDACTED]" &&
+    !trimmed.startsWith("vault://")
+  );
+}
+
 function gitpathologistRequested(config: ElizaConfig): boolean {
   const agentEntry = config.agents?.list?.[0];
   const fromEntry = agentEntry?.gitpathologist;
@@ -455,17 +465,25 @@ export function collectPluginNames(
   const cloudEffectivelyEnabled =
     resolveCloudPluginRequirement(cloudTopology, cloudPluginRequestedByEnv) ||
     isCloudContainer;
-  // cloudHandlesInference gates whether the cloud plugin *replaces* direct
-  // provider plugins for model calls.  Cloud containers that go through the
-  // steward proxy (OPENAI_BASE_URL → host.docker.internal) need plugin-openai
-  // to stay loaded, so only claim inference when the topology explicitly says
-  // so OR the container has a direct cloud API key for elizacloud inference.
-  const cloudHandlesInference =
-    cloudTopology.services.inference ||
-    (isCloudContainer && Boolean(process.env.ELIZAOS_CLOUD_API_KEY?.trim()));
   const _configEnv = config.env as
     | (Record<string, unknown> & { vars?: Record<string, unknown> })
     | undefined;
+  const hasUsableCloudApiKey = [
+    process.env.ELIZAOS_CLOUD_API_KEY,
+    config.cloud?.apiKey,
+    _configEnv?.ELIZAOS_CLOUD_API_KEY,
+    _configEnv?.vars?.ELIZAOS_CLOUD_API_KEY,
+  ].some(isUsableCloudApiKey);
+  // cloudHandlesInference gates whether the cloud plugin *replaces* direct
+  // provider plugins for model calls. Configured Cloud intent is insufficient:
+  // without the credential used by plugin-elizacloud, removing the fallback
+  // providers leaves only an unservable priority-50 Cloud route (#20045).
+  // Provisioned containers own their repaired Cloud runtime route even before
+  // host env projection; ordinary hosts require the usable credential itself.
+  const cloudHandlesInference =
+    (cloudTopology.services.inference &&
+      (hasUsableCloudApiKey || isCloudContainer)) ||
+    (isCloudContainer && hasUsableCloudApiKey);
   const pluginEntries = (config.plugins as Record<string, unknown> | undefined)
     ?.entries as Record<string, { enabled?: boolean }> | undefined;
 


### PR DESCRIPTION
# Relates to

Addresses #20045. This is the narrow post-merge repair for the remaining host-registration regression documented on #20148.

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop@6ab0aa6c9dac6d876e19c4e3a0554eec2ea539de` with zero conflicts.
- [x] `bun install` and the required validation were run. The exact-head focused gates are green; the full `bun run verify` result and final unrelated develop delta are documented below.
- [x] A reviewer can confirm the changed startup contract from the before/after registration evidence and focused integration tests below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6ab0aa6c9dac6d876e19c4e3a0554eec2ea539de:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@6ab0aa6c9dac6d876e19c4e3a0554eec2ea539de`; zero conflicts.
- [x] Exact final head reran 97 focused tests, agent typecheck, exact Biome, and diff-check. Full `bun run verify` passed on the patch-identical immediately preceding head; the final develop-only delta touched Cloud Group H and coding/personal-assistant files, with zero overlap with these four agent-runtime paths.

# Risks

Low-to-medium. The change affects startup admission for Cloud text inference. It deliberately preserves Cloud plugin loading for account/sign-in and non-text capabilities, preserves provisioned-container behavior, and keeps direct/local text providers when an ordinary host has Cloud routing intent but no usable Cloud API key.

# Background

## What does this PR do?

It separates declared Cloud routing intent from actual serving capability:

- `ELIZAOS_CLOUD_USE_INFERENCE=true` is projected only when the runtime is a provisioned Cloud container or a usable Cloud credential is available.
- Redacted and `vault://` placeholders do not count as credentials.
- Cloud model aliases are not projected when the Cloud text route cannot serve.
- The Cloud plugin may still load for sign-in and other capabilities while local/direct providers remain available for text inference.

Before this fix, a configured `cloud-proxy` route with no linked credential registered seven priority-50 Cloud text/planner handlers even though the startup warning claimed fallback. It also removed the direct/local provider surfaces that were supposed to handle that fallback.

## Root cause

The host treated topology configuration as proof that Cloud inference was usable. The plugin collector used the same intent signal to remove fallback providers. Handler registration therefore disagreed with the credential boundary.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This aligns runtime behavior with the existing warning and provider-state contract; it does not add a public configuration surface.

# Testing

## Where should a reviewer start?

1. `packages/agent/src/runtime/eliza-cloud-config.test.ts` — real host env projection plus real Cloud model registration.
2. `packages/agent/src/runtime/plugin-collector-mode-policy.test.ts` — Cloud surface stays loaded while local fallback is retained until a usable key exists.
3. `packages/agent/src/runtime/eliza.ts` and `plugin-collector.ts` — the two matching admission gates.

## Detailed testing steps

- Exact final head `8f5af7d39698e4923ada9d13140443e884ad2c9f`:
  - 7 focused Vitest files: **97/97 passed**.
  - `bun run --cwd packages/agent typecheck`: passed.
  - exact four-file Biome check: passed.
  - `git diff --check HEAD^..HEAD`: passed.
- Full `bun run verify`: passed on patch-identical head `a862f07ff382b0ec7ecfe727da7fbf2f0f2fad34` (**351/351** workspace typecheck tasks plus repository audits). The final rebase adds only upstream `6ab0aa6c9da` / `41cf1981e18`, touching Cloud Group H and coding/personal-assistant paths; exact-head focused gates were rerun afterward.

### Real host-registration evidence

Same config in both cases: Cloud-proxy text route, Cloud enabled, no usable Cloud API key.

Before (merged develop behavior):

```json
{"useInference":"true","cloudEnabled":"true","cloudKey":null,"registeredCount":7}
```

After (this PR):

```json
{"useInference":"false","cloudEnabled":"true","cloudKey":null,"registeredCount":0}
```

Collector result after the repair:

```json
{"cloud":true,"local":true}
```

# Evidence Gate

<!-- evidence-head:8f5af7d39698e4923ada9d13140443e884ad2c9f -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - startup/runtime policy change with no rendered UI diff.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - startup/runtime policy change with no rendered UI diff.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: N/A - no rendered interaction changed.
<!-- evidence-row:backend-logs -->
- [x] Backend evidence: exact before/after host-registration output; the focused test invokes the real `applyCloudConfigToEnv` and `registerTextInferenceModels` seam.

<details>
<summary>Host registration transcript</summary>

```text
before: {"useInference":"true","cloudEnabled":"true","cloudKey":null,"registeredCount":7}
after:  {"useInference":"false","cloudEnabled":"true","cloudKey":null,"registeredCount":0}
collector after: {"cloud":true,"local":true}
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - the repaired behavior is denial of unavailable Cloud model registration before any model call; no prompt or model-output behavior changes. The real registration seam is exercised directly instead.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no database, memory, scheduling, wallet, or generated artifact changes.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered UI surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - this startup credential-admission fix prevents an unavailable provider from registering. It does not change model prompts or model output; the observable artifact is the handler registry count shown above.

## Backend + frontend logs

Backend/startup registration output is included above. Frontend logs are N/A because no frontend code runs in this path.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI changes.

## Known gaps / failures

- An initial direct package `test -- <files>` invocation used the package batch wrapper, which ignores file arguments and attempted the broad lane before all optional dependency artifacts were built. It was replaced with the repository Vitest config and the exact seven-file 97-test run above.
- The exact final head did not repeat the entire 2+ minute root verification after the last unrelated develop advance. The patch-identical prior head passed full verify; the final upstream delta has zero overlap with the four changed paths, and all proportional exact-head gates were rerun.
- No staging, production, provider-console, credential, or deployment mutation was performed.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@6ab0aa6c9dac6d876e19c4e3a0554eec2ea539de:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-provider-credential-gate]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@6ab0aa6c9dac6d876e19c4e3a0554eec2ea539de:packages/skills/skills/contribute-to-eliza"} -->
