### PR TITLE
fix(cloud): make secret removal idempotent

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -395,19 +395,12 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
           set -euo pipefail
-          for attempt in 1 2 3; do
-            if output=$(bunx wrangler secret delete STAGING_SESSION_EXCHANGE_ENABLED --env staging 2>&1); then
-              echo "Staging session exchange is off before config validation or deploy."
-              exit 0
-            fi
-            if printf '%s' "$output" | grep -qi "not found"; then
-              echo "Staging session exchange was already off before cutover."
-              exit 0
-            fi
-            [ "$attempt" -lt 3 ] && sleep 10
-          done
-          echo "::error::Could not confirm staging session exchange is off before cutover"
-          exit 1
+          if ! result=$(node "$CHECKOUT_DIR/packages/cloud/scripts/ensure-worker-secret-absent.mjs" \
+            STAGING_SESSION_EXCHANGE_ENABLED --env staging); then
+            echo "::error::Could not confirm staging session exchange is off before cutover"
+            exit 1
+          fi
+          echo "Staging session exchange is off before config validation or deploy ($result)."
 
       - name: Publish Worker AI secrets
         if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true'
@@ -713,28 +706,16 @@ jobs:
               publish_secret "$name"
               return $?
             fi
-            # Unset: delete so the Worker falls back to its default path.
-            # Wrangler auto-confirms the prompt in non-interactive CI.
-            # "Binding not found" is success (nothing was published). Any
-            # other failure must FAIL after retries: deploying with a stale
-            # routing toggle is exactly the outage this function prevents.
-            local out
-            for attempt in 1 2 3; do
-              if out=$(bunx wrangler secret delete "$name" ${{ steps.env.outputs.wrangler_args }} 2>&1); then
-                echo "::notice::$name is not configured; deleted any previously published value"
-                return 0
-              fi
-              if printf '%s' "$out" | grep -qi "not found"; then
-                echo "::notice::$name is not configured and not present on the Worker; nothing to do"
-                return 0
-              fi
-              if [ "$attempt" -lt 3 ]; then
-                echo "::warning::wrangler secret delete $name failed on attempt $attempt; retrying in 10s"
-                sleep 10
-              fi
-            done
-            echo "::error::$name is unset but deleting the stale Worker secret failed after 3 attempts: $out"
-            return 1
+            # Unset: use a names-only inventory before and after deletion so
+            # absence is success without depending on Wrangler error prose.
+            local result
+            if ! result=$(node "$CHECKOUT_DIR/packages/cloud/scripts/ensure-worker-secret-absent.mjs" \
+              "$name" ${{ steps.env.outputs.wrangler_args }}); then
+              echo "::error::$name is unset but its absence could not be confirmed"
+              return 1
+            fi
+            echo "::notice::$name is not configured; Worker binding state: $result"
+            return 0
           }
 
           # QA cutover is OFF-FIRST. Secret mutations update the currently
@@ -860,22 +841,19 @@ jobs:
 
           delete_legacy_onboarding_secret() {
             local name="$1"
-            local output=""
-            for attempt in 1 2 3; do
-              if output=$(bunx wrangler secret delete "$name" --env staging 2>&1); then
-                legacy_onboarding_secret_removed=true
-                echo "Retired legacy staging secret binding $name."
-                return 0
-              fi
-              if printf '%s' "$output" | grep -qi "not found"; then
-                echo "Legacy staging secret binding $name is already absent."
-                return 0
-              fi
-              [ "$attempt" -lt 3 ] && sleep 10
-            done
-            printf '%s\n' "$output" >&2
-            echo "::error::Could not retire legacy staging secret binding $name."
-            return 1
+            local result
+            if ! result=$(node "$CHECKOUT_DIR/packages/cloud/scripts/ensure-worker-secret-absent.mjs" \
+              "$name" --env staging); then
+              echo "::error::Could not retire legacy staging secret binding $name."
+              return 1
+            fi
+            if [ "$result" = "removed" ]; then
+              legacy_onboarding_secret_removed=true
+              echo "Retired legacy staging secret binding $name."
+            else
+              echo "Legacy staging secret binding $name is already absent."
+            fi
+            return 0
           }
 
           args=(${{ steps.env.outputs.wrangler_args }} --var ELIZA_DEPLOY_COMMIT:"$GITHUB_SHA" --var VOICE_REALTIME_WS_ENABLED:"$VOICE_REALTIME_WS_ENABLED" --var ELIZA_TTS_FISH_ENABLED:"$ELIZA_TTS_FISH_ENABLED" --var FISH_AUDIO_DATA_GOVERNANCE_APPROVED:"$FISH_AUDIO_DATA_GOVERNANCE_APPROVED" --var FISH_AUDIO_MODEL:"$FISH_AUDIO_MODEL" --var FISH_AUDIO_SAMPLE_RATE:"$FISH_AUDIO_SAMPLE_RATE" --var FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS:"$FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS")
@@ -1067,18 +1045,11 @@ jobs:
           expected_enabled="$STAGING_SESSION_EXCHANGE_DESIRED_ENABLED"
 
           rollback_gate() {
-            local output
-            for attempt in 1 2 3; do
-              if output=$(bunx wrangler secret delete STAGING_SESSION_EXCHANGE_ENABLED --env staging 2>&1); then
-                echo "Staging session exchange activation is off."
-                return 0
-              fi
-              if printf '%s' "$output" | grep -qi "not found"; then
-                echo "Staging session exchange activation was already off."
-                return 0
-              fi
-              [ "$attempt" -lt 3 ] && sleep 10
-            done
+            if node "$CHECKOUT_DIR/packages/cloud/scripts/ensure-worker-secret-absent.mjs" \
+              STAGING_SESSION_EXCHANGE_ENABLED --env staging >/dev/null; then
+              echo "Staging session exchange activation is off."
+              return 0
+            fi
             return 1
           }
 

--- a/packages/cloud/scripts/__tests__/ensure-worker-secret-absent.test.ts
+++ b/packages/cloud/scripts/__tests__/ensure-worker-secret-absent.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Exercises the names-only Worker-secret removal boundary with an injected
+ * Wrangler runner, including already-absent, verified deletion, and failures.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  ensureWorkerSecretAbsent,
+  parseWorkerSecretNames,
+  validateWranglerEnvironmentArgs,
+} from "../ensure-worker-secret-absent.mjs";
+
+describe("ensureWorkerSecretAbsent", () => {
+  test("accepts an already-absent binding without issuing a delete", async () => {
+    const calls: string[][] = [];
+    const result = await ensureWorkerSecretAbsent({
+      name: "STAGING_SESSION_EXCHANGE_ENABLED",
+      wranglerArgs: ["--env", "staging"],
+      run: async (args: string[]) => {
+        calls.push(args);
+        return JSON.stringify([
+          { name: "OTHER_SECRET", type: "secret_text" },
+          { name: "mixedCaseSecret", type: "secret_text" },
+        ]);
+      },
+      sleep: async () => {},
+    });
+
+    expect(result).toBe("already-absent");
+    expect(calls).toEqual([
+      ["secret", "list", "--env", "staging", "--format", "json"],
+    ]);
+  });
+
+  test("deletes a present binding and verifies the names-only inventory", async () => {
+    const calls: string[][] = [];
+    const outputs = [
+      JSON.stringify([
+        { name: "STAGING_SESSION_EXCHANGE_ENABLED", type: "secret_text" },
+      ]),
+      "",
+      "[]",
+    ];
+    const result = await ensureWorkerSecretAbsent({
+      name: "STAGING_SESSION_EXCHANGE_ENABLED",
+      wranglerArgs: ["--env", "staging"],
+      run: async (args: string[]) => {
+        calls.push(args);
+        return outputs.shift() ?? "[]";
+      },
+      sleep: async () => {},
+    });
+
+    expect(result).toBe("removed");
+    expect(calls).toEqual([
+      ["secret", "list", "--env", "staging", "--format", "json"],
+      [
+        "secret",
+        "delete",
+        "STAGING_SESSION_EXCHANGE_ENABLED",
+        "--env",
+        "staging",
+      ],
+      ["secret", "list", "--env", "staging", "--format", "json"],
+    ]);
+  });
+
+  test("owns an ambiguous delete when the retry proves absence", async () => {
+    const calls: string[][] = [];
+    const result = await ensureWorkerSecretAbsent({
+      name: "STAGING_SESSION_EXCHANGE_ENABLED",
+      attempts: 2,
+      retryDelayMs: 0,
+      run: async (args: string[]) => {
+        calls.push(args);
+        if (calls.length === 1) {
+          return JSON.stringify([{ name: "STAGING_SESSION_EXCHANGE_ENABLED" }]);
+        }
+        if (calls.length === 2) throw new Error("provider changed the prose");
+        return "[]";
+      },
+      sleep: async () => {},
+    });
+
+    expect(result).toBe("removed");
+    expect(calls).toHaveLength(3);
+  });
+
+  test("fails closed after bounded inventory failures without leaking output", async () => {
+    const leaked = "sensitive-provider-diagnostic";
+    const sleeps: number[] = [];
+    await expect(
+      ensureWorkerSecretAbsent({
+        name: "STAGING_SESSION_EXCHANGE_ENABLED",
+        attempts: 3,
+        retryDelayMs: 7,
+        run: async () => {
+          throw new Error(leaked);
+        },
+        sleep: async (delay: number) => {
+          sleeps.push(delay);
+        },
+      }),
+    ).rejects.toThrow("Could not confirm Worker secret");
+    expect(sleeps).toEqual([7, 7]);
+    try {
+      await ensureWorkerSecretAbsent({
+        name: "STAGING_SESSION_EXCHANGE_ENABLED",
+        attempts: 1,
+        run: async () => {
+          throw new Error(leaked);
+        },
+      });
+    } catch (error) {
+      expect(String(error)).not.toContain(leaked);
+    }
+  });
+});
+
+describe("Worker secret inventory validation", () => {
+  test("rejects malformed inventories instead of fabricating absence", () => {
+    expect(() => parseWorkerSecretNames("{}")).toThrow(
+      "inventory was not an array",
+    );
+    expect(() => parseWorkerSecretNames('[{"type":"secret_text"}]')).toThrow(
+      "invalid name",
+    );
+  });
+
+  test("accepts only an optional exact Wrangler environment selector", () => {
+    expect(validateWranglerEnvironmentArgs([])).toEqual([]);
+    expect(validateWranglerEnvironmentArgs(["--env", "staging"])).toEqual([
+      "--env",
+      "staging",
+    ]);
+    expect(() => validateWranglerEnvironmentArgs(["--config", "x"])).toThrow(
+      "--env selector",
+    );
+  });
+});

--- a/packages/cloud/scripts/ensure-worker-secret-absent.mjs
+++ b/packages/cloud/scripts/ensure-worker-secret-absent.mjs
@@ -1,0 +1,125 @@
+/**
+ * Removes one Cloudflare Worker secret by inspecting the names-only Wrangler
+ * inventory before and after deletion. The command is intentionally
+ * idempotent and never depends on provider error prose or reads secret values.
+ */
+
+import { execFile } from "node:child_process";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const SECRET_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+const INVENTORY_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const ENVIRONMENT_PATTERN = /^[a-z][a-z0-9-]*$/;
+
+/** Parse Wrangler's names-only JSON response into a set of binding names. */
+export function parseWorkerSecretNames(output) {
+  const parsed = JSON.parse(output);
+  if (!Array.isArray(parsed)) {
+    throw new Error("Wrangler secret inventory was not an array");
+  }
+
+  const names = new Set();
+  for (const entry of parsed) {
+    if (
+      entry === null ||
+      typeof entry !== "object" ||
+      typeof entry.name !== "string" ||
+      !INVENTORY_NAME_PATTERN.test(entry.name)
+    ) {
+      throw new Error("Wrangler secret inventory contained an invalid name");
+    }
+    names.add(entry.name);
+  }
+  return names;
+}
+
+/** Restrict passthrough arguments to Wrangler's optional environment selector. */
+export function validateWranglerEnvironmentArgs(args) {
+  if (args.length === 0) return [];
+  if (
+    args.length !== 2 ||
+    args[0] !== "--env" ||
+    !ENVIRONMENT_PATTERN.test(args[1])
+  ) {
+    throw new Error("Expected no Wrangler arguments or one --env selector");
+  }
+  return [...args];
+}
+
+async function runWrangler(args) {
+  const result = await execFileAsync("bunx", ["wrangler@4.100.0", ...args], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
+  return result.stdout;
+}
+
+/**
+ * Confirm that `name` is absent, returning whether this invocation may have
+ * removed it. Any ambiguous deletion is treated as removal for rollback
+ * ownership if a later names-only inventory proves the binding absent.
+ */
+export async function ensureWorkerSecretAbsent({
+  name,
+  wranglerArgs = [],
+  attempts = 3,
+  retryDelayMs = 10_000,
+  run = runWrangler,
+  sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay)),
+}) {
+  if (!SECRET_NAME_PATTERN.test(name)) {
+    throw new Error("Worker secret name is invalid");
+  }
+  const validatedArgs = validateWranglerEnvironmentArgs(wranglerArgs);
+  if (!Number.isInteger(attempts) || attempts < 1) {
+    throw new Error("Attempts must be a positive integer");
+  }
+
+  let deletionAttempted = false;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const before = parseWorkerSecretNames(
+        await run(["secret", "list", ...validatedArgs, "--format", "json"]),
+      );
+      if (!before.has(name)) {
+        return deletionAttempted ? "removed" : "already-absent";
+      }
+
+      deletionAttempted = true;
+      await run(["secret", "delete", name, ...validatedArgs]);
+
+      const after = parseWorkerSecretNames(
+        await run(["secret", "list", ...validatedArgs, "--format", "json"]),
+      );
+      if (!after.has(name)) return "removed";
+    } catch {
+      // error-policy:J1 The CLI boundary retries without exposing provider output.
+    }
+
+    if (attempt < attempts) await sleep(retryDelayMs);
+  }
+
+  throw new Error(`Could not confirm Worker secret ${name} is absent`);
+}
+
+async function main() {
+  const [name, ...wranglerArgs] = process.argv.slice(2);
+  if (!name) throw new Error("Worker secret name is required");
+  const result = await ensureWorkerSecretAbsent({ name, wranglerArgs });
+  process.stdout.write(`${result}\n`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    // error-policy:J1 The executable boundary reports only the typed operation failure.
+    process.stderr.write(
+      `${error instanceof Error ? error.message : "Worker secret removal failed"}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/packages/scripts/__tests__/cloud-cf-staging-session-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-staging-session-deploy-workflow.test.ts
@@ -66,9 +66,11 @@ describe("Cloud CF staging session cutover", () => {
 
     const disable = step("Disable staging session exchange before cutover");
     expect(disable.if).toContain("steps.freshness.outputs.should_deploy");
+    expect(disable.run).toContain("ensure-worker-secret-absent.mjs");
     expect(disable.run).toContain(
-      "wrangler secret delete STAGING_SESSION_EXCHANGE_ENABLED --env staging",
+      "STAGING_SESSION_EXCHANGE_ENABLED --env staging",
     );
+    expect(disable.run).not.toContain('grep -qi "not found"');
 
     const publish = step("Publish Worker AI secrets");
     expect(publish.if).toContain("steps.freshness.outputs.should_deploy");
@@ -93,9 +95,8 @@ describe("Cloud CF staging session cutover", () => {
     );
     expect(activation.run).toContain("trap rollback_on_unproven_exit EXIT");
     expect(activation.run).toContain("status?.ready !== true");
-    expect(activation.run).toContain(
-      "wrangler secret delete STAGING_SESSION_EXCHANGE_ENABLED --env staging",
-    );
+    expect(activation.run).toContain("ensure-worker-secret-absent.mjs");
+    expect(activation.run).not.toContain('grep -qi "not found"');
     expect(
       activation.run?.indexOf(
         "wrangler secret put STAGING_SESSION_EXCHANGE_ENABLED --env staging",
@@ -124,6 +125,20 @@ describe("Cloud CF staging session cutover", () => {
     expect(
       index("Disable staging session exchange before cutover"),
     ).toBeLessThan(index("Publish Worker AI secrets"));
+  });
+
+  test("uses the names-only idempotent helper at every removal boundary", () => {
+    expect(workflowSource).not.toContain("wrangler secret delete");
+    expect(
+      workflowSource.match(/ensure-worker-secret-absent\.mjs/g),
+    ).toHaveLength(4);
+    expect(step("Publish Worker AI secrets").run).toContain('"$name" ');
+    expect(step("Publish Worker AI secrets").run).toContain(
+      "steps.env.outputs.wrangler_args",
+    );
+    expect(step("Deploy to Cloudflare Workers").run).toContain(
+      '"$name" --env staging',
+    );
   });
 
   test("requires the dedicated v1 signer and accepts exact UUID lists", () => {


### PR DESCRIPTION
# Relates to

Fixes #20189.

- [x] This PR targets `develop`; its verified parent is `cc6b751f70a01c4354567af9669eddc1189d405e`, and the two subsequently fetched `develop` commits have zero changed-path intersection.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] The executable names-only inventory tests below let a reviewer verify the behavior without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d1c52624aef5a3d9623e35791d6a379a6d326c0e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased without conflicts immediately before exact verification. The later `6ab0aa6c9dac6d876e19c4e3a0554eec2ea539de` advance changes only Group H smoke/coding-tool and personal-assistant test configuration paths; intersection with this PR's four paths is empty.
- [x] Exact-head `bun run verify` passes 351/351. A preceding forced-cache-bypass run also passed 351/351 with 0 cached tasks.

# Risks

Low. The workflow now depends on Wrangler's documented names-only JSON inventory instead of provider error prose. It fails closed on malformed inventories, list/delete failures, or inability to prove final absence. No secret value is read or printed.

# Background

## What does this PR do?

It makes every Cloud release kill-switch removal idempotent. An already-absent Worker secret is success; a present secret is deleted and then verified absent. The helper retries boundedly, validates its target and environment arguments, and never exposes provider diagnostics.

The prior release loop called `wrangler secret delete` directly and guessed success from an English `not found` substring. Current Wrangler used different prose, so staging failed before Worker or Pages deployment even though the kill switch was already safely absent.

## What kind of change is this?

Bug fix (non-breaking release-workflow correction).

# Documentation changes needed?

No product documentation change is needed. The workflow and executable contract tests are the authoritative release contract.

# Testing

## Where should a reviewer start?

Run the focused three-file suite. It covers absent, present, ambiguous deletion, bounded failure, environment argument validation, all four workflow call sites, and the surrounding deployment environment contract.

## Detailed testing steps

- `bun test packages/cloud/scripts/__tests__/ensure-worker-secret-absent.test.ts packages/scripts/__tests__/cloud-cf-staging-session-deploy-workflow.test.ts packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts` — PASS, 27/27 tests and 326 assertions.
- `bun run verify:cloud` — PASS, 80/80 tasks.
- `bunx actionlint .github/workflows/cloud-cf-release.yml` — PASS.
- changed-file Biome and `git diff --check` — PASS.
- `TURBO_FORCE=1 bun run verify` — PASS, 351/351 tasks, 0 cached, all repository audits clean.
- final exact-head `bun run verify` — PASS, 351/351 tasks, all repository audits clean.

# Evidence Gate

<!-- evidence-head:3560002f2d895774bc51292ccbff0008f76226af -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow and Node helper only; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow and Node helper only; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive or rendered flow changes in this code PR.
<!-- evidence-row:backend-logs -->
- [x] N/A - the real protected Cloudflare mutation is intentionally deferred until this workflow fix merges; deterministic executable output is summarized above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, model, or inference behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, provider, or generated domain state is changed by the PR; the focused executable contract results are listed above.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no model-facing behavior changes.

## Backend + frontend logs

The PR performs no provider mutation. After merge, the newest exact-current staging Cloud release must prove the already-absent kill switch passes and the Worker/Pages deployment completes.

## Screenshots (before / after) + video walkthrough

N/A - workflow/helper-only change.

## Known gaps / failures

No code or validation failures remain. Live Cloudflare proof cannot precede merge because the protected workflow must run from `develop`; that post-merge run is the deployment acceptance step.

# Deploy Notes

Use only the newest eligible `develop` Cloud CF run at approval time. Do not approve older waiting runs, because the admission gate intentionally skips stale releases.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@d1c52624aef5a3d9623e35791d6a379a6d326c0e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@d1c52624aef5a3d9623e35791d6a379a6d326c0e:packages/skills/skills/contribute-to-eliza"} -->
