### PR TITLE
fix(app): run Pages workflow contract under Vitest

### DIFF
--- a/packages/app/test/pages-deploy-workflow.test.ts
+++ b/packages/app/test/pages-deploy-workflow.test.ts
@@ -3,12 +3,12 @@
  * Functions worker, exercised without production credentials.
  */
 
-import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { describe, expect, test } from "vitest";
 
 const workflow = readFileSync(
-  join(import.meta.dir, "../../../.github/workflows/cloud-cf-release.yml"),
+  join(import.meta.dirname, "../../../.github/workflows/cloud-cf-release.yml"),
   "utf8",
 );
 


### PR DESCRIPTION
# Relates to

Closes #20177.

# Summary

Runs the Cloudflare Pages deployment workflow contract under the app package's declared Vitest runner.

The file previously imported `bun:test`, so the authoritative Vitest lane failed during collection and executed none of its assertions. Changing only that import exposed a second Bun-specific assumption: `import.meta.dir` is undefined under Vitest. This minimal test-only repair uses Vitest's API and the standard `import.meta.dirname`; it does not change the workflow, production code, or rendered UI.

# Risk

Very low. One test file changes two runner-boundary expressions. The complete app suite and exact-head repository verifier pass.

# Verification

- Required full `bun install`: pass with Bun 1.3.14 / Node 24.15.0 and the complete artifact sync.
- Focused Pages workflow contract: 2/2.
- Full app script suite: 794 passed, 1 intentional skip, 0 failed.
- Full app Vitest suite: 89/89 files, 728/728 tests.
- App typecheck: pass.
- Changed-file Biome and `git diff --check`: pass.
- Exact-head root `bun run verify`: 351/351 tasks and all audits; 8,249 test files scanned with 0 focused tests and 0 orphaned skips.
- Independent #19317 UI regressions remain out of scope and are not hidden by this test-only repair.

# Evidence gate

<!-- evidence-head:8f372eeacfa77683270e6c7474559ec6e8a74c67 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-runner compatibility only; no rendered UI changed
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-runner compatibility only; no rendered UI changed
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive flow changed
<!-- evidence-row:backend-logs -->
- [x] Inline red/control/green runner transcript from the authoritative app Vitest path

<details>
<summary>Three-stage collection and execution evidence</summary>

```text
$ bunx vitest run test/pages-deploy-workflow.test.ts  # original file
FAIL test/pages-deploy-workflow.test.ts: Cannot bundle built-in module "bun:test"
Test Files 1 failed; Tests 0 collected

$ bunx vitest run test/pages-deploy-workflow.test.ts  # Vitest import only
FAIL test/pages-deploy-workflow.test.ts: TypeError: The "path" argument must be of type string; import.meta.dir is undefined
Test Files 1 failed; Tests 0 collected

$ bunx vitest run test/pages-deploy-workflow.test.ts  # final exact head
Test Files 1 passed (1)
Tests 2 passed (2)
Duration 1.56s
```
</details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend or network behavior changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, action, or planner behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistence or domain artifact changed
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered text changed

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - contribute-to-eliza skill was not available in this session`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - contribute-to-eliza skill was not available in this session
Attribution status: self-reported
— [codex-20177-pages-vitest]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - contribute-to-eliza skill was not available in this session"} -->



