### PR TITLE
perf(cloud): expose Shared gateway retry latency

### DIFF
--- a/packages/cloud/services/gateway-webhook/__tests__/telegram-voice-note.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/telegram-voice-note.test.ts
@@ -10,6 +10,7 @@ function update(voice: Record<string, unknown>) {
     update_id: 101,
     message: {
       message_id: 7,
+      date: 1_786_827_000,
       from: { id: 42, first_name: "Ada" },
       chat: { id: 42, type: "private" },
       voice,
@@ -34,6 +35,7 @@ describe("Telegram voice notes", () => {
     );
     expect(event).toMatchObject({
       messageId: "101",
+      providerSentAtMs: 1_786_827_000_000,
       text: "",
       voiceNote: {
         fileId: "voice-file-1",

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
@@ -413,6 +413,7 @@ describe("gateway webhook handler e2e routing", () => {
       senderId: "123456789",
       senderName: "Ada",
       text: "what should I focus on today?",
+      providerSentAtMs: Date.now() - 2_000,
       rawPayload: {},
     };
     const sendReply = mock(async () => undefined);
@@ -429,15 +430,18 @@ describe("gateway webhook handler e2e routing", () => {
       () => undefined,
     );
     let sharedBody: Record<string, unknown> | null = null;
+    let sharedTraceId: string | null = null;
     globalThis.fetch = mock(async (input, init) => {
-      const url = String(input);
+      const request = new Request(input, init);
+      const url = request.url;
       if (url.endsWith("/api/internal/identity/resolve")) {
         return new Response(JSON.stringify({ error: "not found" }), {
           status: 404,
         });
       }
       if (url.endsWith("/api/internal/eliza-app/personal-shared/messages")) {
-        sharedBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        sharedTraceId = request.headers.get("x-eliza-trace-id");
+        sharedBody = (await request.json()) as Record<string, unknown>;
         return new Response(
           JSON.stringify({
             data: { reply: "start with the launch checklist" },
@@ -457,6 +461,9 @@ describe("gateway webhook handler e2e routing", () => {
     const response = await handleWebhook(
       new Request("https://gateway.example/webhook/eliza-app/telegram", {
         method: "POST",
+        headers: {
+          "x-eliza-trace-id": "11111111-1111-4111-8111-111111111111",
+        },
         body: "{}",
       }),
       adapter,
@@ -469,6 +476,7 @@ describe("gateway webhook handler e2e routing", () => {
     );
 
     expect(response.status).toBe(200);
+    expect(sharedTraceId).toBe("11111111-1111-4111-8111-111111111111");
     expect(sharedBody).toEqual({
       platform: "telegram",
       project: "eliza-app",
@@ -484,15 +492,134 @@ describe("gateway webhook handler e2e routing", () => {
       "start with the launch checklist",
     );
     expect(completionLog).toHaveBeenCalledWith(
+      "Personal Shared Cloud attempt completed",
+      expect.objectContaining({
+        traceId: "11111111-1111-4111-8111-111111111111",
+        attempt: 1,
+        maxAttempts: 3,
+        status: 200,
+        retryable: false,
+        retryDelayMs: null,
+        cloudServerTiming: "account;dur=5.2, shared;dur=17.8",
+      }),
+    );
+    expect(completionLog).toHaveBeenCalledWith(
       "Personal Eliza connector message completed",
       expect.objectContaining({
         project: "eliza-app",
         platform: "telegram",
         messageId: "update-personal-1",
+        traceId: "11111111-1111-4111-8111-111111111111",
+        providerToGatewayMs: expect.any(Number),
         cloudMs: expect.any(Number),
+        cloudAttempts: 1,
         cloudServerTiming: "account;dur=5.2, shared;dur=17.8",
         egressMs: expect.any(Number),
         totalMs: expect.any(Number),
+      }),
+    );
+  });
+
+  test("correlates every retry and preserves prior Cloud timing", async () => {
+    process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
+    const traceId = "22222222-2222-4222-8222-222222222222";
+    const event: ChatEvent = {
+      platform: "telegram",
+      messageId: "update-attempt-trace",
+      chatId: "chat-1",
+      chatType: "private",
+      senderId: "123456789",
+      senderName: "Ada",
+      text: "trace this turn",
+      providerSentAtMs: Date.now() - 1_000,
+      rawPayload: {},
+    };
+    const adapter: PlatformAdapter = {
+      platform: "telegram",
+      getDedupeScope: () => "scope",
+      verifyWebhook: mock(async () => true),
+      extractEvent: mock(async () => event),
+      sendTypingIndicator: mock(async () => undefined),
+      sendReply: mock(async () => undefined),
+    };
+    const redis = new MemoryRedis();
+    const infoLog = spyOn(logger, "info").mockImplementation(() => undefined);
+    const warnLog = spyOn(logger, "warn").mockImplementation(() => undefined);
+    const forwardedTraceIds: Array<string | null> = [];
+    let attempt = 0;
+    globalThis.fetch = mock(async (input, init) => {
+      const request = new Request(input, init);
+      if (
+        !request.url.endsWith(
+          "/api/internal/eliza-app/personal-shared/messages",
+        )
+      ) {
+        throw new Error(`unexpected request: ${request.url}`);
+      }
+      forwardedTraceIds.push(request.headers.get("x-eliza-trace-id"));
+      attempt += 1;
+      if (attempt === 1) {
+        return new Response("cold failure", {
+          status: 503,
+          headers: {
+            "Retry-After": "0",
+            "Server-Timing": "failed_worker;dur=1234",
+          },
+        });
+      }
+      return Response.json(
+        { data: { reply: "retried successfully" } },
+        { headers: { "Server-Timing": "account;dur=4, shared;dur=20" } },
+      );
+    }) as typeof fetch;
+
+    const response = await handleWebhook(
+      new Request("https://gateway.example/webhook/eliza-app/telegram", {
+        method: "POST",
+        headers: { "X-Eliza-Trace-Id": traceId },
+        body: "{}",
+      }),
+      adapter,
+      {
+        redis,
+        cloudBaseUrl: "https://api.elizacloud.ai",
+        getAuthHeader: () => ({ Authorization: "Bearer internal-secret" }),
+      },
+      "eliza-app",
+    );
+
+    expect(response.status).toBe(200);
+    expect(forwardedTraceIds).toEqual([traceId, traceId]);
+    expect(warnLog).toHaveBeenCalledWith(
+      "Personal Shared Cloud attempt failed",
+      expect.objectContaining({
+        traceId,
+        attempt: 1,
+        status: 503,
+        retryable: true,
+        retryReason: "status",
+        retryAfterSeconds: 0,
+        retryDelayMs: 0,
+        cloudServerTiming: "failed_worker;dur=1234",
+      }),
+    );
+    expect(infoLog).toHaveBeenCalledWith(
+      "Personal Shared Cloud attempt completed",
+      expect.objectContaining({
+        traceId,
+        attempt: 2,
+        status: 200,
+        retryable: false,
+        retryDelayMs: null,
+        cloudServerTiming: "account;dur=4, shared;dur=20",
+      }),
+    );
+    expect(infoLog).toHaveBeenCalledWith(
+      "Personal Eliza connector message completed",
+      expect.objectContaining({
+        traceId,
+        providerToGatewayMs: expect.any(Number),
+        cloudAttempts: 2,
       }),
     );
   });

--- a/packages/cloud/services/gateway-webhook/src/adapters/telegram.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/telegram.ts
@@ -132,6 +132,7 @@ function splitMessage(text: string, maxLength = MAX_MESSAGE_LENGTH): string[] {
 
 interface TelegramMessage {
   message_id: number;
+  date?: number;
   from?: {
     id: number;
     first_name: string;
@@ -280,6 +281,11 @@ export const telegramAdapter: PlatformAdapter = {
       senderName: message.from?.first_name,
       text,
       isCommand: text.startsWith("/"),
+      ...(typeof message.date === "number" &&
+      Number.isInteger(message.date) &&
+      message.date > 0
+        ? { providerSentAtMs: message.date * 1_000 }
+        : {}),
       rawPayload: update,
       ...(voice
         ? {

--- a/packages/cloud/services/gateway-webhook/src/adapters/types.ts
+++ b/packages/cloud/services/gateway-webhook/src/adapters/types.ts
@@ -14,6 +14,8 @@ export interface ChatEvent {
   senderName?: string;
   text: string;
   isCommand?: boolean;
+  /** Provider-accepted message time, used only for coarse ingress latency. */
+  providerSentAtMs?: number;
   mediaUrls?: string[];
   /** Provider-owned voice-note metadata; never contains an authenticated URL. */
   voiceNote?: {

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -29,6 +29,10 @@ const TELEGRAM_EGRESS_STARTED = "egress_started";
 const TELEGRAM_DELIVERED = "delivered";
 const TELEGRAM_TYPING_REFRESH_MS = 4_000;
 const PERSONAL_SHARED_VOICE_TIMEOUT_MS = 90_000;
+const ELIZA_TRACE_ID_HEADER = "X-Eliza-Trace-Id";
+const OPAQUE_TRACE_ID =
+  /^(?:[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
+const ZERO_TRACE_ID = "0".repeat(32);
 
 class TelegramEgressAlreadyClaimedError extends Error {
   override readonly name = "TelegramEgressAlreadyClaimedError";
@@ -47,8 +51,26 @@ interface HandlerDeps {
 
 interface PersonalSharedDeliveryTiming {
   cloudMs: number;
+  cloudAttempts: number;
   egressMs: number;
   cloudServerTiming: string | null;
+}
+
+interface MessageTraceContext {
+  traceId: string;
+  gatewayReceivedAtMs: number;
+}
+
+function resolveTraceId(request: Request): string {
+  const supplied = request.headers.get(ELIZA_TRACE_ID_HEADER)?.trim();
+  if (
+    supplied &&
+    OPAQUE_TRACE_ID.test(supplied) &&
+    supplied.toLowerCase() !== ZERO_TRACE_ID
+  ) {
+    return supplied.toLowerCase();
+  }
+  return crypto.randomUUID();
 }
 
 export async function handleWebhook(
@@ -58,6 +80,10 @@ export async function handleWebhook(
   project: string,
   agentId?: string,
 ): Promise<Response> {
+  const trace: MessageTraceContext = {
+    traceId: resolveTraceId(request),
+    gatewayReceivedAtMs: Date.now(),
+  };
   const { redis, cloudBaseUrl, getAuthHeader } = deps;
   const reauth = deps.reacquireAuthHeader ?? reacquireAuthHeader;
   const authHeader = getAuthHeader();
@@ -161,6 +187,7 @@ export async function handleWebhook(
         event,
         deps,
         project,
+        trace,
         agentId,
         async () => {
           // Write the no-replay barrier before the Bot API call. A crash or
@@ -221,13 +248,14 @@ export async function handleWebhook(
 
   // ── Async phase: identity → forward → reply (runs in background) ──
 
-  processMessage(adapter, config, event, deps, project, agentId).catch(
+  processMessage(adapter, config, event, deps, project, trace, agentId).catch(
     async (err) => {
       logger.error("Background message processing failed", {
         error: err instanceof Error ? err.message : String(err),
         project,
         platform: adapter.platform,
         messageId: event.messageId,
+        traceId: trace.traceId,
       });
       if (err instanceof PersonalSharedPreEgressError) {
         try {
@@ -273,6 +301,7 @@ async function processMessage(
   event: ChatEvent,
   deps: HandlerDeps,
   project: string,
+  trace: MessageTraceContext,
   explicitAgentId?: string,
   beforeEgress?: () => Promise<void>,
 ): Promise<void> {
@@ -296,13 +325,20 @@ async function processMessage(
         event,
         deps,
         project,
+        trace.traceId,
         beforeEgress,
       );
       logger.info("Personal Eliza connector message completed", {
         project,
         platform: adapter.platform,
         messageId: event.messageId,
+        traceId: trace.traceId,
+        providerToGatewayMs:
+          event.providerSentAtMs === undefined
+            ? null
+            : trace.gatewayReceivedAtMs - event.providerSentAtMs,
         cloudMs: timing.cloudMs,
+        cloudAttempts: timing.cloudAttempts,
         cloudServerTiming: timing.cloudServerTiming,
         egressMs: timing.egressMs,
         totalMs: Date.now() - startedAt,
@@ -340,6 +376,7 @@ async function processMessage(
       event,
       deps,
       project,
+      trace.traceId,
       beforeEgress,
     );
     return;
@@ -396,6 +433,7 @@ async function processMessage(
       event,
       deps,
       project,
+      trace.traceId,
       beforeEgress,
     );
     return;
@@ -548,6 +586,7 @@ async function sendUnlinkedReply(
   event: ChatEvent,
   deps: HandlerDeps,
   project: string,
+  traceId: string,
   beforeEgress?: () => Promise<void>,
 ): Promise<void> {
   if (
@@ -561,6 +600,7 @@ async function sendUnlinkedReply(
       event,
       deps,
       project,
+      traceId,
       beforeEgress,
     );
     return;
@@ -574,6 +614,7 @@ async function sendPersonalSharedReply(
   event: ChatEvent,
   deps: HandlerDeps,
   project: string,
+  traceId: string,
   beforeEgress?: () => Promise<void>,
 ): Promise<PersonalSharedDeliveryTiming> {
   const { cloudBaseUrl, getAuthHeader } = deps;
@@ -594,7 +635,11 @@ async function sendPersonalSharedReply(
   const postMessage = (authHeader: Record<string, string>) =>
     fetch(`${cloudBaseUrl}/api/internal/eliza-app/personal-shared/messages`, {
       method: "POST",
-      headers: { "Content-Type": "application/json", ...authHeader },
+      headers: {
+        "Content-Type": "application/json",
+        [ELIZA_TRACE_ID_HEADER]: traceId,
+        ...authHeader,
+      },
       body: JSON.stringify(
         adapter.platform === "telegram"
           ? {
@@ -622,10 +667,28 @@ async function sendPersonalSharedReply(
   let authHeader: Record<string, string> = getAuthHeader();
   let response: Response | null = null;
   let lastTransportError: unknown;
+  let attemptsUsed = 0;
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    attemptsUsed = attempt;
+    const attemptStartedAt = Date.now();
     try {
       response = await postMessage(authHeader);
       if (response.status === 401 && attempt < maxAttempts) {
+        logger.warn("Personal Shared Cloud attempt requires fresh auth", {
+          traceId,
+          project,
+          platform: adapter.platform,
+          messageId: event.messageId,
+          attempt,
+          maxAttempts,
+          durationMs: Date.now() - attemptStartedAt,
+          status: response.status,
+          retryable: true,
+          retryReason: "auth_refresh",
+          retryAfterSeconds: null,
+          retryDelayMs: 0,
+          cloudServerTiming: response.headers.get("Server-Timing"),
+        });
         authHeader = await reauth();
         continue;
       }
@@ -634,26 +697,68 @@ async function sendPersonalSharedReply(
         response.status === 425 ||
         response.status === 429 ||
         response.status >= 500;
-      if (response.ok || !retryable || attempt === maxAttempts) {
-        break;
+      const shouldRetry =
+        !response.ok && retryable && attempt < maxAttempts && !voiceNote;
+      const retryAfterSeconds = Number.parseInt(
+        response.headers.get("Retry-After") ?? "",
+        10,
+      );
+      const retryDelayMs = shouldRetry
+        ? Number.isFinite(retryAfterSeconds)
+          ? Math.min(
+              Math.max(retryAfterSeconds, 0) * 1_000,
+              PERSONAL_SHARED_RETRY_DELAY_CAP_MS,
+            )
+          : 200 * attempt
+        : null;
+      const attemptContext = {
+        traceId,
+        project,
+        platform: adapter.platform,
+        messageId: event.messageId,
+        attempt,
+        maxAttempts,
+        durationMs: Date.now() - attemptStartedAt,
+        status: response.status,
+        retryable,
+        retryReason: shouldRetry ? "status" : null,
+        retryAfterSeconds: Number.isFinite(retryAfterSeconds)
+          ? retryAfterSeconds
+          : null,
+        retryDelayMs,
+        cloudServerTiming: response.headers.get("Server-Timing"),
+      };
+      if (response.ok) {
+        logger.info("Personal Shared Cloud attempt completed", attemptContext);
+      } else {
+        logger.warn("Personal Shared Cloud attempt failed", attemptContext);
       }
-      if (voiceNote) break;
+      if (!shouldRetry || retryDelayMs === null) break;
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
     } catch (error) {
       response = null;
       lastTransportError = error;
-      if (voiceNote || attempt === maxAttempts) break;
+      const shouldRetry = !voiceNote && attempt < maxAttempts;
+      const retryDelayMs = shouldRetry ? 200 * attempt : null;
+      logger.warn("Personal Shared Cloud attempt transport failed", {
+        traceId,
+        project,
+        platform: adapter.platform,
+        messageId: event.messageId,
+        attempt,
+        maxAttempts,
+        durationMs: Date.now() - attemptStartedAt,
+        status: null,
+        retryable: shouldRetry,
+        retryReason: shouldRetry ? "transport" : null,
+        retryAfterSeconds: null,
+        retryDelayMs,
+        cloudServerTiming: null,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      if (!shouldRetry || retryDelayMs === null) break;
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
     }
-    const retryAfterSeconds = Number.parseInt(
-      response?.headers.get("Retry-After") ?? "",
-      10,
-    );
-    const retryDelayMs = Number.isFinite(retryAfterSeconds)
-      ? Math.min(
-          Math.max(retryAfterSeconds, 0) * 1_000,
-          PERSONAL_SHARED_RETRY_DELAY_CAP_MS,
-        )
-      : 200 * attempt;
-    await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
   }
   if (!response) {
     throw new PersonalSharedPreEgressError(
@@ -688,13 +793,19 @@ async function sendPersonalSharedReply(
   // Empty is the agent's deliberate shouldRespond=no result. It is a
   // successful turn with no provider egress, not a malformed response.
   if (reply.length === 0) {
-    return { cloudMs, egressMs: 0, cloudServerTiming };
+    return {
+      cloudMs,
+      cloudAttempts: attemptsUsed,
+      egressMs: 0,
+      cloudServerTiming,
+    };
   }
   const egressStartedAt = Date.now();
   await beforeEgress?.();
   await adapter.sendReply(config, event, reply);
   return {
     cloudMs,
+    cloudAttempts: attemptsUsed,
     egressMs: Date.now() - egressStartedAt,
     cloudServerTiming,
   };


### PR DESCRIPTION
Closes the gateway portion of #16079.

## What changed

- Propagates one validated opaque `X-Eliza-Trace-Id` across every gateway-to-Cloud attempt for a Shared turn.
- Logs every successful, status-failed, auth-refresh, and transport-failed attempt with duration, status, retry reason/delay, `Retry-After`, and the attempt's `Server-Timing`.
- Records Telegram's provider timestamp so the completion log exposes coarse provider-to-gateway ingress time.
- Preserves the existing retry, voice-note, egress-claim, and webhook-ack behavior.

## Why

The real staging probes behind #16079 showed 27.426s and 27.396s Telegram turns, while the final Shared runtime span was about 2s. The current gateway aggregates its whole retry loop into `cloudMs` and retains only the final response timing, hiding whether the missing cold-path time is an earlier 5xx, retry delay, transport failure, or successful-request bootstrap. This change makes those alternatives directly distinguishable without enabling embeddings or durable trajectory retention.

## Verification

- `bun run --cwd packages/cloud/services/gateway-webhook typecheck`
- `bun run --cwd packages/cloud/services/gateway-webhook test` — 143/143 tests, 391 assertions
- `bun run --cwd packages/cloud/services/gateway-webhook build` — 190 modules, 1.1 MB Node bundle
- Biome on all five changed files
- `git diff origin/develop --check`

The focused real-boundary-shaped test proves a 503 followed by a 200 keeps the same trace id and retains the failed attempt's timing. Staging deployment and labeled Telegram cold/warm receipts will be attached after merge because the protected gateway dispatcher intentionally deploys staging from `develop` only. Production is out of scope.

## Evidence matrix

- Backend structured logs: pending protected staging deploy
- Real Telegram provider round trip: pending protected staging deploy
- Real model trajectory: N/A — Shared trajectories are disabled and this gateway-only change does not alter model behavior
- UI screenshots/video: N/A — no UI change
- Frontend console/network: N/A — no frontend change

<!-- evidence-head:7748d78ca16291b331ec6311c8554f947b666930 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend gateway observability only; no UI surface changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend gateway observability only; no UI surface changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual user flow changed

<!-- evidence-row:backend-logs -->
- [x] [20206-pr20206-backend.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20206-pr20206-backend.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser runtime changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - gateway retry telemetry does not change model or planner behavior

<!-- evidence-row:domain-artifacts -->
- [x] [20206-pr20206-retry-contract.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20206-pr20206-retry-contract.txt)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual text changed
