### PR TITLE
fix(cloud): bootstrap voice secret before verification

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -538,9 +538,9 @@ jobs:
             export VOICE_REALTIME_ELIZA_AUTHORIZATION
           fi
 
-          # Production provider and bridge values are managed Worker secrets,
-          # not GitHub secret material. keep_vars preserves them, and their
-          # binding names are verified against the live Worker before deploy.
+          # Production provider and bridge values remain managed Worker
+          # secrets. A protected-environment value may create or rotate one;
+          # a blank source preserves it, and names are verified before deploy.
 
           # Staging advertises realtime only when the repository variable
           # VOICE_REALTIME_WS_ENABLED is explicitly truthy. Refuse that opt-in
@@ -618,33 +618,6 @@ jobs:
             exit 1
           fi
 
-          if [ "$DEPLOY_ENVIRONMENT" = "production" ] && \
-             is_truthy "$VOICE_REALTIME_WS_ENABLED"; then
-            secret_inventory="$(bunx wrangler@4.100.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
-            printf '%s' "$secret_inventory" | node -e '
-              const fs = require("node:fs");
-              const parsed = JSON.parse(fs.readFileSync(0, "utf8"));
-              const entries = Array.isArray(parsed)
-                ? parsed
-                : Array.isArray(parsed?.result)
-                  ? parsed.result
-                  : [];
-              const present = new Set(entries.map((entry) => entry?.name).filter(Boolean));
-              const required = [
-                "CARTESIA_API_KEY",
-                "VOICE_REALTIME_CARTESIA_VOICE_ID",
-                "VOICE_REALTIME_ELIZA_AUTHORIZATION",
-                "VOICE_REALTIME_ELIZA_ENDPOINT",
-              ];
-              const missing = required.filter((name) => !present.has(name));
-              if (missing.length > 0) {
-                console.error(`::error::Production realtime voice is missing managed Worker secret binding name(s): ${missing.join(" ")}`);
-                process.exit(1);
-              }
-              console.log(`Verified ${required.length} managed production voice secret binding names; values were not read.`);
-            '
-          fi
-
           publish_secret() {
             local name="$1"
             local value="${!name:-}"
@@ -692,6 +665,37 @@ jobs:
             done
             echo "::error::wrangler secret put $name failed after 3 attempts"
             return 1
+          }
+
+          verify_production_voice_secret_bindings() {
+            if [ "$DEPLOY_ENVIRONMENT" != "production" ] || \
+               ! is_truthy "$VOICE_REALTIME_WS_ENABLED"; then
+              return 0
+            fi
+            local secret_inventory
+            secret_inventory="$(bunx wrangler@4.100.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
+            printf '%s' "$secret_inventory" | node -e '
+              const fs = require("node:fs");
+              const parsed = JSON.parse(fs.readFileSync(0, "utf8"));
+              const entries = Array.isArray(parsed)
+                ? parsed
+                : Array.isArray(parsed?.result)
+                  ? parsed.result
+                  : [];
+              const present = new Set(entries.map((entry) => entry?.name).filter(Boolean));
+              const required = [
+                "CARTESIA_API_KEY",
+                "VOICE_REALTIME_CARTESIA_VOICE_ID",
+                "VOICE_REALTIME_ELIZA_AUTHORIZATION",
+                "VOICE_REALTIME_ELIZA_ENDPOINT",
+              ];
+              const missing = required.filter((name) => !present.has(name));
+              if (missing.length > 0) {
+                console.error(`::error::Production realtime voice is missing managed Worker secret binding name(s): ${missing.join(" ")}`);
+                process.exit(1);
+              }
+              console.log(`Verified ${required.length} managed production voice secret binding names; values were not read.`);
+            '
           }
 
           # Like publish_secret, but for values that act as ROUTING TOGGLES
@@ -809,6 +813,11 @@ jobs:
           do
             publish_toggle_secret "$name" || exit 1
           done
+
+          # GitHub and Cloudflare are separate write-only authorities. Verify
+          # the live names only after configured values have had a chance to
+          # create their bindings, but still before any Worker code deploys.
+          verify_production_voice_secret_bindings || exit 1
 
       - name: Deploy to Cloudflare Workers
         if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true'

--- a/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
@@ -51,6 +51,16 @@ const preflight = publishStep.run.slice(
   0,
   publishStep.run.indexOf("# The Worker is the gateway"),
 );
+const shellHelpers = publishStep.run.slice(
+  0,
+  publishStep.run.indexOf("# Construct the staging fallback"),
+);
+const secretFunctions = publishStep.run
+  .slice(
+    publishStep.run.indexOf("publish_secret() {"),
+    publishStep.run.indexOf("# Like publish_secret"),
+  )
+  .replaceAll("$" + "{{ steps.env.outputs.wrangler_args }}", "");
 
 // The executed cases run the workflow's VERBATIM preflight bash, which uses
 // bash >= 4 `${1,,}` lowercasing (GitHub's Linux runners). macOS /bin/bash 3.2
@@ -91,6 +101,56 @@ function runPreflight(env: Record<string, string>) {
       STAGING_ELIZACLOUD_API_KEY: "",
       ...env,
     },
+  });
+}
+
+function runProductionVoiceBootstrap(
+  cartesiaApiKey: string,
+  putSucceeds = true,
+) {
+  const initialInventory = JSON.stringify([
+    { name: "VOICE_REALTIME_CARTESIA_VOICE_ID" },
+    { name: "VOICE_REALTIME_ELIZA_AUTHORIZATION" },
+    { name: "VOICE_REALTIME_ELIZA_ENDPOINT" },
+  ]);
+  const completeInventory = JSON.stringify([
+    { name: "CARTESIA_API_KEY" },
+    { name: "VOICE_REALTIME_CARTESIA_VOICE_ID" },
+    { name: "VOICE_REALTIME_ELIZA_AUTHORIZATION" },
+    { name: "VOICE_REALTIME_ELIZA_ENDPOINT" },
+  ]);
+  const script = `${shellHelpers}
+STATE_FILE="$(mktemp)"
+trap 'rm -f "$STATE_FILE"' EXIT
+printf '%s' '${initialInventory}' > "$STATE_FILE"
+bunx() {
+  if [[ "$1" == wrangler* && "$2" == "secret" && "$3" == "put" ]]; then
+    cat >/dev/null
+    if [ "$PUT_SUCCEEDS" != "true" ]; then
+      return 1
+    fi
+    printf '%s' '${completeInventory}' > "$STATE_FILE"
+    return 0
+  fi
+  if [[ "$1" == wrangler* && "$2" == "secret" && "$3" == "list" ]]; then
+    cat "$STATE_FILE"
+    return 0
+  fi
+  return 1
+}
+${secretFunctions}
+DEPLOY_ENVIRONMENT=production
+VOICE_REALTIME_WS_ENABLED=true
+VOICE_BATCH_STT_PROVIDER=""
+CARTESIA_API_KEY=${JSON.stringify(cartesiaApiKey)}
+PUT_SUCCEEDS=${JSON.stringify(String(putSucceeds))}
+sleep() { :; }
+publish_secret CARTESIA_API_KEY || exit 1
+verify_production_voice_secret_bindings || exit 1
+`;
+  return spawnSync(requirePreflightBash(), ["-c", script], {
+    encoding: "utf8",
+    env: process.env,
   });
 }
 
@@ -190,6 +250,13 @@ describe("Cloud CF realtime voice deploy contract", () => {
     expect(publishStep.run).toContain('"VOICE_REALTIME_CARTESIA_VOICE_ID"');
     expect(publishStep.run).toContain('"VOICE_REALTIME_ELIZA_ENDPOINT"');
     expect(publishStep.run).toContain("managed Worker secret binding name(s)");
+    const lastPublish = publishStep.run.lastIndexOf(
+      'publish_toggle_secret "$name" || exit 1',
+    );
+    const productionBindingVerification = publishStep.run.lastIndexOf(
+      "verify_production_voice_secret_bindings || exit 1",
+    );
+    expect(productionBindingVerification).toBeGreaterThan(lastPublish);
     expect(wrangler).not.toContain("VOICE_AMBIENT_ENABLED");
     expect(wrangler).not.toContain("VOICE_AMBIENT_PENDANT_BASE_URL");
   });
@@ -287,6 +354,28 @@ const executedDescribe = GNU_BASH ? describe : describe.skip;
 executedDescribe(
   "Cloud CF realtime voice deploy preflight (executed verbatim)",
   () => {
+    test("bootstraps a missing production Cartesia binding before verifying names", () => {
+      const result = runProductionVoiceBootstrap("cartesia-test");
+      expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain(
+        "Verified 4 managed production voice secret binding names",
+      );
+    });
+
+    test("fails closed when a missing production binding has no configured source", () => {
+      const result = runProductionVoiceBootstrap(" ");
+      expect(result.status).toBe(1);
+      expect(`${result.stdout}${result.stderr}`).toContain("CARTESIA_API_KEY");
+    });
+
+    test("fails closed when first-time production secret publication fails", () => {
+      const result = runProductionVoiceBootstrap("cartesia-test", false);
+      expect(result.status).toBe(1);
+      expect(`${result.stdout}${result.stderr}`).toContain(
+        "wrangler secret put CARTESIA_API_KEY failed after 3 attempts",
+      );
+    });
+
     test("does not require realtime secrets when staging opt-in is absent", () => {
       const result = runPreflight({
         DEEPGRAM_API_KEY: "",


### PR DESCRIPTION
# Relates to

Fixes #20200.

- [x] This PR targets `develop` and is rebased onto exact `origin/develop@32a09a4aa0f3e925d22bb344478743893e6e3523` with zero conflicts.
- [x] `bun run install:light` and exact-head `bun run verify` passed after sync.
- [x] The evidence below lets a reviewer confirm the ordering and fail-closed behavior without deploying production.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@32a09a4aa0f3e925d22bb344478743893e6e3523:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop@32a09a4aa0f3e925d22bb344478743893e6e3523`; zero conflicts.
- [x] `bun run verify` passed on the patch-identical pre-refresh head `402064ec9ecc7bb82cfac938d2535b9f5f17f03a` (351/351 tasks plus all repository audits). Exact refreshed head `6bc29e101b114424e0566d43a346db6b404accc8` reran 44 workflow/secret tests, actionlint, Biome, and diff-check; all pass.

# Risks

Low, deployment-workflow-only risk. The patch changes ordering inside the protected Cloudflare Worker release job: configured secret values are published through the existing fail-closed helper before the job verifies the names-only managed-secret inventory. A failed publication, blank required source, or missing postcondition still stops before Worker deploy. No runtime, UI, database, gateway, or secret value is changed by this PR.

# Background

## What does this PR do?

Production run [31906316903](https://github.com/elizaOS/eliza/actions/runs/31906316903) had a nonblank protected `CARTESIA_API_KEY`, but failed before deploy because the workflow required that binding to already exist in the Worker secret store before reaching its `wrangler secret put` loop. This made first-time bootstrap impossible.

This PR publishes configured production voice secrets first, then verifies the required managed binding names. It adds an executed-verbatim shell harness proving first-time Cartesia bootstrap succeeds while blank sources and failed Wrangler publication remain fail-closed.

## What kind of change is this?

Bug fix (non-breaking deployment-workflow correction).

# Documentation changes needed?

No documentation change is needed. This restores the behavior already described by the protected release workflow: GitHub environment secrets are the write-only source for managed Worker bindings.

# Testing

## Where should a reviewer start?

1. `.github/workflows/cloud-cf-release.yml`: confirm `verify_production_voice_secret_bindings` runs after every `publish_secret` loop and before `Deploy to Cloudflare Workers`.
2. `packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts`: confirm the tests extract and execute the workflow helpers verbatim against a names-only Wrangler state file.

## Detailed testing steps

- Patch-identical pre-refresh `bun run verify` — 351/351 tasks, all audits green.
- Exact refreshed head `bun test packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts packages/scripts/__tests__/cloud-cf-staging-session-deploy-workflow.test.ts packages/cloud/scripts/__tests__/ensure-worker-secret-absent.test.ts packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts` — 44 pass / 0 fail.
- Offline read-only Linux container, Bun 1.3.14: exact voice suite 17/17 pass, including all executed-verbatim shell tests.
- `bunx biome check packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts` — pass.
- `actionlint .github/workflows/cloud-cf-release.yml` — pass.
- `git diff HEAD^..HEAD --check` — pass.

# Evidence Gate

<!-- evidence-head:6bc29e101b114424e0566d43a346db6b404accc8 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - protected workflow-only change with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - protected workflow-only change with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive or rendered user flow changes.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no application backend path changes; the exact protected GitHub Actions failure and run URL are preserved in Evidence Details
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code or request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, wallet, or generated artifact is changed; names-only managed-binding proof belongs to the protected post-merge release
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - deployment workflow only.

## Backend + frontend logs

Ground truth from protected production run [31906316903](https://github.com/elizaOS/eliza/actions/runs/31906316903):

```text
Production realtime voice is missing managed Worker secret binding name(s): CARTESIA_API_KEY
```

The run passed protected approvals, migrations, Worker build/verification/e2e, credential checks, freshness guard, and routing contract, then failed before Worker deploy. Production remained unchanged.

Frontend logs: N/A - no frontend path.

## Screenshots (before / after) + video walkthrough

N/A - workflow-only change.

## Audio / voice walkthrough

N/A - this PR changes release bootstrap ordering, not voice runtime behavior. A real labeled channel probe belongs to the protected post-merge release proof.

## Known gaps / failures

- The macOS host lacks Bash 4 lowercase expansion, so nine executed-verbatim shell cases skip there by contract; all nine run and pass in the offline read-only Bun 1.3.14 Linux container (17/17 suite total).
- `audit:error-policy-ratchet` is not defined on this base; no verdict is claimed for that absent script. The diff contains no production TypeScript/JavaScript error handlers.
- No production rerun occurred from this branch. Release remains gated on exact-head review, merge to `develop`, promotion to `main`, protected approvals, and post-deploy health/channel proof.

# Deploy Notes

After review and merge, promote the exact patch to `main` through a separate PR. Dispatch one fresh protected production release from current `main`; do not reuse or cancel unrelated runs. Verify the managed binding by name only, Worker/API health SHA, realtime readiness, and one labeled Telegram round trip.

— [gauss-launch]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@32a09a4aa0f3e925d22bb344478743893e6e3523:packages/skills/skills/contribute-to-eliza"} -->
