### PR TITLE
fix(cloud): preserve Workerd upgrades through full-app telemetry

### DIFF
--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import cloudApiWorker, {
+  decorateFullAppDispatchResponse,
   getFrontendAliasApiProxyTarget,
   getFrontendAliasProxyTarget,
   getGeneratedAgentId,
@@ -23,6 +24,22 @@ test("exports the shared-runtime conversation Durable Object", () => {
 
 test("exports the X OAuth refresh Durable Object", () => {
   expect(typeof TwitterOAuthRefreshCoordinator).toBe("function");
+});
+
+test("preserves Workerd WebSocket upgrade responses without rewrapping", () => {
+  const upgrade = {
+    status: 101,
+    webSocket: { accepted: true },
+  } as unknown as Response;
+
+  expect(
+    decorateFullAppDispatchResponse(
+      upgrade,
+      "11111111-1111-4111-8111-111111111111",
+      12,
+      8,
+    ),
+  ).toBe(upgrade);
 });
 
 test("dispatches provider webhooks without full-app bootstrap", async () => {

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -25,6 +25,7 @@ import {
   resolveElizaTraceId,
   setHttpTelemetryHeaders,
 } from "@/lib/observability/http-telemetry";
+import { shouldDecorateHttpTelemetryStatus } from "@/lib/observability/http-telemetry-hono";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { serveBlobHostRequest } from "./blob-host";
@@ -181,6 +182,29 @@ async function getApp(): Promise<Hono<AppEnv>> {
   return appPromise;
 }
 
+/** Preserve Workerd upgrade responses; rebuilding one drops its `webSocket` extension. */
+export function decorateFullAppDispatchResponse(
+  response: Response,
+  traceId: string,
+  dispatchMs: number,
+  moduleInitMs: number | null,
+): Response {
+  if (!shouldDecorateHttpTelemetryStatus(response.status)) return response;
+
+  const responseHeaders = new Headers(response.headers);
+  setHttpTelemetryHeaders(responseHeaders, traceId, [
+    { name: "full_app_dispatch", durationMs: dispatchMs },
+    ...(moduleInitMs === null
+      ? []
+      : [{ name: "full_app_module_init", durationMs: moduleInitMs }]),
+  ]);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: responseHeaders,
+  });
+}
+
 async function dispatchFullApp(
   request: Request,
   env: AppEnv["Bindings"],
@@ -201,18 +225,12 @@ async function dispatchFullApp(
     const response = await app.fetch(tracedRequest, env, ctx);
     status = response.status;
     const dispatchMs = Math.round((performance.now() - startedAt) * 100) / 100;
-    const responseHeaders = new Headers(response.headers);
-    setHttpTelemetryHeaders(responseHeaders, traceId, [
-      { name: "full_app_dispatch", durationMs: dispatchMs },
-      ...(!moduleWasInitialized
-        ? [{ name: "full_app_module_init", durationMs: moduleInitMs }]
-        : []),
-    ]);
-    return new Response(response.body, {
-      status,
-      statusText: response.statusText,
-      headers: responseHeaders,
-    });
+    return decorateFullAppDispatchResponse(
+      response,
+      traceId,
+      dispatchMs,
+      moduleWasInitialized ? null : moduleInitMs,
+    );
   } finally {
     const durationMs = Math.round((performance.now() - startedAt) * 100) / 100;
     const logContext = {


### PR DESCRIPTION
Closes #20207.

# Relates to

- #20207

- [x] Targets `develop` and is a single commit directly atop `origin/develop@a3b9d16e62540e11bfe5b007cf2c5d0c8ed308d7`.
- [x] Exact-head Cloud API tests, typecheck, production dry bundle, pinned-Workerd E2E, Biome, and diff checks pass.
- [x] A reviewer can confirm the real status-101 upgrade from the attached Workerd transcript.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a3b9d16e62540e11bfe5b007cf2c5d0c8ed308d7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Direct child of the latest `origin/develop` at publication; zero conflicts.
- [x] Proportionate exact-head gates pass.

# Risks

Low. The change only bypasses telemetry decoration for status 101, matching the existing inner middleware contract. Normal HTTP responses retain all full-app trace and `Server-Timing` decoration.

# Background

## What does this PR do?

The full-app telemetry wrapper merged with #20196 rebuilt every Hono response. Workerd WebSocket upgrades carry a non-standard `webSocket` extension; reconstructing the response drops that endpoint and standard `Response` constructors reject status 101.

This patch centralizes full-app decoration, returns status-101 responses by identity, and retains telemetry wrapping for ordinary responses. The regression uses an upgrade-shaped response with a sentinel endpoint, while the pinned-Workerd Group D E2E drives the complete real voice WebSocket handshake and protocol close.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This restores the already-documented Workerd upgrade invariant.

# Testing

## Where should a reviewer start?

1. `packages/cloud/api/src/index.ts` — `decorateFullAppDispatchResponse`.
2. `packages/cloud/api/src/index.test.ts` — identity-preserving status-101 regression.
3. The attached pinned-Workerd Group D transcript.

## Detailed testing steps

- Cloud API index suite: all assertions reached green, including the new upgrade identity regression and existing cold/warm full-app telemetry contracts.
- `E2E_ONLY=group-d-ai-media bun run --cwd packages/cloud/api test:e2e`: pass; real local Workerd returns a connected 101 upgrade, required headers, protocol error frame, and 1008 close.
- `bun run --cwd packages/cloud/api typecheck`: pass.
- Production Wrangler dry bundle: pass (`~25.7 MiB`, `~6.24 MiB` gzip).
- Exact two-file Biome and `git diff --check`: pass.

# Evidence Gate

<!-- evidence-head:acafea91f6bb385f9441e2966d48a6e149640654 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:backend-logs -->
- [x] [20209-20207-workerd-websocket-e2e.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20209-20207-workerd-websocket-e2e.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend surface or browser state changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - transport response preservation occurs after handler execution and changes no prompt, model, action, provider, or agent behavior.
<!-- evidence-row:domain-artifacts -->
- [x] [20209-20207-websocket-domain-artifact.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20209-20207-websocket-domain-artifact.log)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text or rendered UI surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - this patch preserves a Workerd response extension at the outer HTTP boundary and does not alter model behavior.

## Backend + frontend logs

The exact-head pinned-Workerd E2E transcript will be linked in the evidence rows. Frontend logs are N/A.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI changes.

## Known gaps / failures

- The direct Bun index test process retains broad full-app handles after completing its assertions; the observed test assertions were green, and the canonical pinned-Workerd E2E exits cleanly. This patch does not introduce the retained handles.
- No staging or production deployment was performed or required.

— [nubs-shared-telemetry-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@a3b9d16e62540e11bfe5b007cf2c5d0c8ed308d7:packages/skills/skills/contribute-to-eliza"} -->


