### PR TITLE
fix(desktop): fail fast on inconsistent late workspace builds

### DIFF
--- a/packages/app-core/scripts/copy-runtime-node-modules.coverage.test.ts
+++ b/packages/app-core/scripts/copy-runtime-node-modules.coverage.test.ts
@@ -27,6 +27,7 @@ import {
   assertRequiredBundledPackagesLanded,
   assertTarSafeRuntimePaths,
   copyPackageDir,
+  ensureResolvedWorkspaceRuntimeEntriesBuilt,
   expandWorkspacePattern,
   getRuntimeDependencies,
   getRuntimeDependencyEntries,
@@ -844,6 +845,105 @@ describe("getWorkspacePackageRuntimeCopyEntries", () => {
       expect(
         getWorkspacePackageRuntimeCopyEntries("invalid", sourceDir),
       ).toBeNull();
+    } finally {
+      rmSync(sourceDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("ensureResolvedWorkspaceRuntimeEntriesBuilt", () => {
+  it("builds a source-only workspace package before its runtime export is copied", () => {
+    const sourceDir = mkdtempSync(
+      path.join(process.cwd(), ".copy-runtime-source-only-"),
+    );
+    try {
+      writeFileSync(
+        path.join(sourceDir, "package.json"),
+        JSON.stringify({
+          name: "@elizaos/source-only-runtime",
+          main: "./dist/index.js",
+          scripts: { build: "node build.mjs" },
+        }),
+      );
+      writeFileSync(
+        path.join(sourceDir, "build.mjs"),
+        [
+          'import { mkdirSync, writeFileSync } from "node:fs";',
+          'mkdirSync("dist", { recursive: true });',
+          'writeFileSync("dist/index.js", "export const ready = true;\\n");',
+        ].join("\n"),
+      );
+
+      const packageJsonPath = path.join(sourceDir, "package.json");
+      expect(existsSync(path.join(sourceDir, "dist", "index.js"))).toBe(false);
+
+      ensureResolvedWorkspaceRuntimeEntriesBuilt(
+        "@elizaos/source-only-runtime",
+        { sourceDir, packageJsonPath },
+      );
+
+      expect(existsSync(path.join(sourceDir, "dist", "index.js"))).toBe(true);
+    } finally {
+      rmSync(sourceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails when a workspace build leaves its declared runtime export missing", () => {
+    const sourceDir = mkdtempSync(
+      path.join(process.cwd(), ".copy-runtime-missing-export-"),
+    );
+    try {
+      writeFileSync(
+        path.join(sourceDir, "package.json"),
+        JSON.stringify({
+          name: "@elizaos/missing-runtime",
+          main: "./dist/index.js",
+          scripts: { build: 'node -e "process.exit(0)"' },
+        }),
+      );
+
+      expect(() =>
+        ensureResolvedWorkspaceRuntimeEntriesBuilt("@elizaos/missing-runtime", {
+          sourceDir,
+          packageJsonPath: path.join(sourceDir, "package.json"),
+        }),
+      ).toThrow(
+        /build completed without producing its declared runtime entries/,
+      );
+    } finally {
+      rmSync(sourceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails fast when a workspace build exits non-zero after writing its export", () => {
+    const sourceDir = mkdtempSync(
+      path.join(process.cwd(), ".copy-runtime-failed-build-"),
+    );
+    try {
+      writeFileSync(
+        path.join(sourceDir, "package.json"),
+        JSON.stringify({
+          name: "@elizaos/failed-runtime",
+          main: "./dist/index.js",
+          scripts: { build: "node build.mjs" },
+        }),
+      );
+      writeFileSync(
+        path.join(sourceDir, "build.mjs"),
+        [
+          'import { mkdirSync, writeFileSync } from "node:fs";',
+          'mkdirSync("dist", { recursive: true });',
+          'writeFileSync("dist/index.js", "export const partial = true;\\n");',
+          "process.exit(1);",
+        ].join("\n"),
+      );
+
+      expect(() =>
+        ensureResolvedWorkspaceRuntimeEntriesBuilt("@elizaos/failed-runtime", {
+          sourceDir,
+          packageJsonPath: path.join(sourceDir, "package.json"),
+        }),
+      ).toThrow();
     } finally {
       rmSync(sourceDir, { recursive: true, force: true });
     }

--- a/packages/app-core/scripts/copy-runtime-node-modules.ts
+++ b/packages/app-core/scripts/copy-runtime-node-modules.ts
@@ -42,7 +42,7 @@ type QueueEntry = DependencyEntry & {
   requesterDestDir: string;
 };
 
-type ResolvedPackage = {
+export type ResolvedPackage = {
   packageJsonPath: string;
   sourceDir: string;
 };
@@ -2378,47 +2378,65 @@ function packageHasBuildScript(packageJsonPath: string): boolean {
   }
 }
 
+export function ensureResolvedWorkspaceRuntimeEntriesBuilt(
+  packageName: string,
+  candidate: ResolvedPackage,
+  built: Set<string> = new Set(),
+): void {
+  if (built.has(candidate.sourceDir)) return;
+  if (!isPackageCompatibleWithCurrentPlatform(candidate.packageJsonPath)) {
+    return;
+  }
+  if (!workspacePackageNeedsRuntimeBuild(candidate.packageJsonPath)) {
+    return;
+  }
+  if (!packageHasBuildScript(candidate.packageJsonPath)) {
+    throw new Error(
+      `[runtime-copy] ${packageName} workspace package is missing declared runtime entries and has no build script`,
+    );
+  }
+
+  console.log(
+    `[runtime-copy] building ${packageName} workspace runtime entries`,
+  );
+  execFileSync(resolveBunCommand(), ["run", "build"], {
+    cwd: candidate.sourceDir,
+    env: { ...process.env, FORCE_COLOR: "0" },
+    stdio: "inherit",
+  });
+
+  if (workspacePackageNeedsRuntimeBuild(candidate.packageJsonPath)) {
+    throw new Error(
+      `[runtime-copy] ${packageName} build completed without producing its declared runtime entries`,
+    );
+  }
+  built.add(candidate.sourceDir);
+}
+
 function ensureWorkspaceRuntimeEntriesBuilt(
   packageNames: Iterable<string>,
+  built: Set<string>,
 ): void {
   buildWorkspacePackageIndex();
-  const built = new Set<string>();
 
   for (const packageName of [...new Set(packageNames)].sort()) {
     if (!isPackageNameCompatibleWithCurrentPlatform(packageName)) continue;
-
     for (const candidate of workspacePackageIndex.get(packageName) ?? []) {
-      if (built.has(candidate.sourceDir)) continue;
-      if (!isPackageCompatibleWithCurrentPlatform(candidate.packageJsonPath)) {
-        continue;
-      }
-      if (!workspacePackageNeedsRuntimeBuild(candidate.packageJsonPath)) {
-        continue;
-      }
-      if (!packageHasBuildScript(candidate.packageJsonPath)) {
-        continue;
-      }
-
-      console.log(
-        `[runtime-copy] building ${packageName} workspace runtime entries`,
-      );
-      try {
-        execFileSync(resolveBunCommand(), ["run", "build"], {
-          cwd: candidate.sourceDir,
-          env: { ...process.env, FORCE_COLOR: "0" },
-          stdio: "inherit",
-        });
-      } catch (error) {
-        if (workspacePackageNeedsRuntimeBuild(candidate.packageJsonPath)) {
-          throw error;
-        }
-        console.warn(
-          `[runtime-copy] warning: ${packageName} build exited non-zero after producing required runtime entries; continuing`,
-        );
-      }
-      built.add(candidate.sourceDir);
+      ensureResolvedWorkspaceRuntimeEntriesBuilt(packageName, candidate, built);
     }
   }
+}
+
+function isIndexedWorkspacePackage(
+  packageName: string,
+  resolved: ResolvedPackage,
+): boolean {
+  buildWorkspacePackageIndex();
+  return (workspacePackageIndex.get(packageName) ?? []).some(
+    (candidate) =>
+      candidate.sourceDir === resolved.sourceDir ||
+      candidate.packageJsonPath === resolved.packageJsonPath,
+  );
 }
 
 // Post-copy assertion: missingAlwaysBundled catches resolve failures, but
@@ -2553,7 +2571,11 @@ function main(): void {
         return shouldBundle;
       }),
     );
-    ensureWorkspaceRuntimeEntriesBuilt([...alwaysBundled, ...discovered]);
+    const builtWorkspaceRuntimeEntries = new Set<string>();
+    ensureWorkspaceRuntimeEntriesBuilt(
+      [...alwaysBundled, ...discovered],
+      builtWorkspaceRuntimeEntries,
+    );
     const queue: QueueEntry[] = [...new Set([...alwaysBundled, ...discovered])]
       .sort()
       .map((name) => ({
@@ -2597,6 +2619,14 @@ function main(): void {
         missingAlwaysBundled.delete(name);
         missingDiscovered.delete(name);
         continue;
+      }
+
+      if (isIndexedWorkspacePackage(name, resolved)) {
+        ensureResolvedWorkspaceRuntimeEntriesBuilt(
+          name,
+          resolved,
+          builtWorkspaceRuntimeEntries,
+        );
       }
 
       const resolvedVersion = getPackageVersion(resolved.packageJsonPath);


### PR DESCRIPTION
# Relates to

Fixes #20183.

- [x] Targets `develop`; fetched and rebased onto `origin/develop@ee523cda0a7e` with zero conflicts before final validation.
- [x] `bun install` and exact-head `bun run verify` passed after sync.
- [x] The evidence below exercises the real copy/build process and signed packaged app.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - contribute-to-eliza skill was not available in this session`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@ee523cda0a7e`; zero conflicts.
- [x] Exact-head `bun run verify`: 351/351 uncached tasks; all audits passed; 8,248 test files scanned with 0 focused and 0 orphaned skips.

# Risks

Low. This changes only the desktop packaging boundary. The risk is that a genuinely broken workspace package now stops packaging instead of emitting a superficially complete app; that failure is intentional and actionable.

# Background

## What does this PR do?

The late workspace repair merged in #20054 still accepted two inconsistent states: a nonzero build if it happened to write the currently checked export, and a source-only workspace package with no build script. It also validated package names before the dependency walk instead of the exact resolved workspace candidate being copied.

This PR makes the resolved candidate authoritative. Before copying any indexed workspace package, it checks declared runtime entries, runs its build at most once when needed, and fails immediately when the build is absent, exits nonzero, or succeeds without producing every required entry. There is no retry, catch-and-continue, fabricated default, or timeout-based success path.

## What kind of change is this?

Bug fix (non-breaking packaging correctness and diagnostics).

# Documentation changes needed?

No user-facing documentation change is needed; this tightens an internal build invariant and its executable contract tests.

# Testing

## Where should a reviewer start?

Start with `ensureResolvedWorkspaceRuntimeEntriesBuilt` in `packages/app-core/scripts/copy-runtime-node-modules.ts`, then the three real-process cases at the end of `copy-runtime-node-modules.coverage.test.ts`.

## Detailed testing steps

1. Run `bun test packages/app-core/scripts/copy-runtime-node-modules.coverage.test.ts` (77/77).
2. Delete `plugins/plugin-wallet/dist` and the Electrobun build directory.
3. Run `bun run --cwd packages/app-core/platforms/electrobun build`.
4. Confirm the log contains `[runtime-copy] building @elizaos/plugin-wallet workspace runtime entries`, then `bundled 2139 package(s)`.
5. Confirm the signed app contains `@elizaos/plugin-wallet/dist/diagnostic.js` and its renderer manifest commit is `ab332ed8674f002b82fe2f9b9a8c12ee0549812b`.

Additional exact-head gates:

- `bun run --cwd packages/app-core typecheck`
- Biome on both changed files
- `bun run verify` — 351/351 uncached
- strict `codesign --verify --deep --strict`
- isolated real packaged startup and `/api/health` liveness after 8 seconds

# Evidence Gate

<!-- evidence-head:e784ee9a9cc10b7376bf97cdba47f1d451f957e4 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - packaging-only change has no rendered before-state; real child-process regressions cover the pre-fix failures
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI changed, and the macOS console is locked; automatic unlock failed
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered UI changed; exact-head recorder skipped because the macOS console session is locked
<!-- evidence-row:backend-logs -->
- [x] [20210-eliza-20183-exact-build.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20210-eliza-20183-exact-build.log)
<!-- evidence-row:frontend-logs -->
- [x] [20210-eliza-20183-bottom-bar.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20210-eliza-20183-bottom-bar.log)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] [20210-health.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20210-health.json)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed

# Evidence Details

## Backend + frontend logs

The clean exact-head build started without `plugins/plugin-wallet/dist`, invoked its workspace build during the dependency walk, bundled 2,139 packages, stamped commit `ab332ed8674f`, and produced a strict-valid signed app. The isolated packaged runtime reported `ready=true`, `canRespond=true`, runtime/database `ok`, 10 loaded/0 failed plugins, 38 registered/0 failed services, and passed the 8-second liveness probe.

The exact packaged bottom-bar test reached the expanded UI but failed its current-base geometry assertion by 48 px after 30 seconds. The recent upstream overlay change is outside this PR's two-file diff. The log is attached rather than hidden by retries.

## Screenshots (before / after) + video walkthrough

N/A - this PR has no UI diff. Exact-head capture is additionally unavailable because the host Mac is locked; both the recorder guard and Codex Computer Use confirmed that state.

## Known gaps / failures

- `electrobun-bottom-bar.e2e.spec.ts`: fails on current-base expanded-panel geometry (`expected 0`, `received 48`); unrelated to the runtime-copy files and preserved as evidence.
- `desktop-chat-walkthrough.e2e.spec.ts`: skipped because the macOS console is locked. Automated unlock failed, so no screenshot or MP4 is claimed.
- The first direct health attempt used the shared persistent DB and correctly failed when another desktop process owned it. The authoritative rerun used a fresh `ELIZA_STATE_DIR`, provisioned first-run through the real endpoint, and passed full runtime health and liveness.

# Exact-head refresh after #20234

Rebased onto `develop@ee523cda0a7e`; published head `e784ee9a9cc10b7376bf97cdba47f1d451f957e4`. Full `bun install`, focused real-process coverage (77/77), and root `bun run verify` all pass. A clean exact-head desktop build again removed wallet output, invoked the late workspace build, bundled 2,139 packages, embedded the exact head in both build manifests, and passed strict deep code-signature verification. An isolated packaged launch reached ready/canRespond with runtime and database `ok`, plugins 27 loaded/0 failed, and services 70 registered/0 failed. The locked console also emitted current-base DesktopAuthBridge socket-consumption warnings after health was green; they are retained here and are outside this two-file packaging diff.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - contribute-to-eliza skill was not available in this session
Attribution status: self-reported
— [codex/late-workspace-fail-fast]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - contribute-to-eliza skill was not available in this session"} -->