### PR TITLE
fix(cloud): restore gateway webhook image build

### DIFF
--- a/packages/cloud/services/gateway-webhook/Dockerfile
+++ b/packages/cloud/services/gateway-webhook/Dockerfile
@@ -10,7 +10,7 @@
 #   docker build -f packages/cloud/services/gateway-webhook/Dockerfile .
 #
 # The deps stage writes a pruned workspace root containing just this service and
-# the one package it needs, so `bun install` resolves the workspace link without
+# the workspace packages it needs, so `bun install` resolves every link without
 # installing the whole monorepo (32 packages rather than several thousand).
 
 # BUN_BASE selects the Bun base image. Default targets linux/amd64 + linux/arm64
@@ -34,7 +34,10 @@ ARG SERVICE_DIR
 ARG COMMON_DIR
 COPY ${SERVICE_DIR}/package.json ${SERVICE_DIR}/
 COPY ${COMMON_DIR}/package.json ${COMMON_DIR}/
-RUN printf '{"name":"gateway-webhook-build","private":true,"workspaces":["packages/cloud/services/*"]}\n' > package.json \
+# Production dependency resolution must not traverse test-only workspace links;
+# doing so would require vendoring cloud-shared's entire transitive workspace.
+RUN bun -e 'const path = Bun.argv.at(-1); const manifest = await Bun.file(path).json(); delete manifest.devDependencies; await Bun.write(path, JSON.stringify(manifest));' "${SERVICE_DIR}/package.json" \
+    && printf '{"name":"gateway-webhook-build","private":true,"workspaces":["packages/cloud/services/*"]}\n' > package.json \
     && bun install --production
 
 # Build stage

--- a/packages/cloud/services/gateway-webhook/__tests__/dockerfile-workspace-context.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/dockerfile-workspace-context.test.ts
@@ -25,6 +25,7 @@ const LOCKFILE_BLIND = new Set<string>();
 interface ServiceBuild {
   name: string;
   workspaceDeps: string[];
+  devWorkspaceDeps: string[];
   dockerfile: string;
 }
 
@@ -37,14 +38,19 @@ function servicesWithDockerfiles(): ServiceBuild[] {
 
     const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
       dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
     };
     const workspaceDeps = Object.entries(manifest.dependencies ?? {})
+      .filter(([, range]) => range.startsWith("workspace:"))
+      .map(([dep]) => dep);
+    const devWorkspaceDeps = Object.entries(manifest.devDependencies ?? {})
       .filter(([, range]) => range.startsWith("workspace:"))
       .map(([dep]) => dep);
 
     found.push({
       name,
       workspaceDeps,
+      devWorkspaceDeps,
       dockerfile: readFileSync(dockerfilePath, "utf8"),
     });
   }
@@ -130,6 +136,19 @@ describe("service Dockerfiles can resolve their workspace dependencies", () => {
       );
       expect(gateway?.dockerfile).toContain("packages/cloud/services/_common");
     }
+  });
+
+  test("gateway-webhook prunes build-only workspace links before production install", () => {
+    const gateway = services.find(
+      (service) => service.name === "gateway-webhook",
+    );
+    expect(gateway?.devWorkspaceDeps).toContain("@elizaos/cloud-shared");
+    const pruneAt = gateway?.dockerfile.indexOf(
+      "delete manifest.devDependencies",
+    );
+    const installAt = gateway?.dockerfile.indexOf("bun install --production");
+    expect(pruneAt).toBeGreaterThan(-1);
+    expect(installAt).toBeGreaterThan(pruneAt ?? Number.MAX_SAFE_INTEGER);
   });
 
   for (const service of services.filter((s) => s.workspaceDeps.length > 0)) {


### PR DESCRIPTION
Closes #20211.

## What changed

- Removes build-only `devDependencies` from the copied, image-local gateway manifest before the production install.
- Leaves the tracked package manifest untouched and keeps the pruned image workspace limited to the service plus its real runtime workspace dependency.
- Extends the Docker contract test to detect build-only workspace links and require pruning before `bun install --production`.

## Ground truth / root cause

Protected staging gateway run [31909985138](https://github.com/elizaOS/eliza/actions/runs/31909985138) created Railway deployment `dac5e560-5c8e-4329-91cb-bcc93faf8a94`, which failed before cutover with:

```text
error: Workspace dependency "@elizaos/cloud-shared" not found
```

PR #20184 added `@elizaos/cloud-shared: workspace:*` as a test-only dev dependency. Bun still resolves workspace membership during the production install, while the pruned Docker context intentionally does not include test-only workspaces. Copying `cloud-shared` is not an appropriate fix: its manifest recursively requires nine additional workspaces despite none being needed to build or run this service.

The existing contract test inspected runtime dependencies only, so the prior tree passed 143/143 gateway tests while the real image failed.

## Verification

- Pre-fix Docker contract shape: **2 failures**, both naming the missing `@elizaos/cloud-shared` / absent production pruning.
- Post-fix Docker contract: **9/9**.
- Full gateway suite: **144/144**, 394 assertions.
- Gateway typecheck: pass.
- Exact test-file Biome and diff check: pass.
- Real root-context image build: pass; 188 modules, 1.1 MB service bundle, tagged locally as `gateway-webhook:latency-fix`.

## Evidence matrix

- Backend logs: linked failed protected run plus successful root-context Docker transcript above.
- Domain artifact: built local Docker image.
- Real Telegram round trip: pending protected staging deploy after landing; this build-only fix does not alter message behavior.
- Model trajectory: N/A — no runtime/model code changed.
- UI evidence: N/A — no UI changed.

Production remains out of scope.


# Exact-head review refresh

- Rebased onto `origin/develop@d63dce5b65e9a6ee057c687de116b1e4a11816d8` with zero conflicts.
- Exact head: `56d1bcb7b06d442d58fd360f9747e28d5cc9ad7f`.
- Reviewer rerun: Docker contract 9/9, full gateway 144/144, package typecheck, exact-file Biome, and diff check all pass.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes` (review, rebase, validation, and evidence remediation; Nubs source authorship unchanged)
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d63dce5b65e9a6ee057c687de116b1e4a11816d8:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Evidence Gate

<!-- evidence-head:56d1bcb7b06d442d58fd360f9747e28d5cc9ad7f -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - build-only Docker packaging change; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - build-only Docker packaging change; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive flow changed.
<!-- evidence-row:backend-logs -->
- [x] [20214-exact-head-validation-v2.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20214-exact-head-validation-v2.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, or provider behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [20214-docker-domain-artifact.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20214-docker-domain-artifact.log)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text changed.

— [nubs-gateway-image-review]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@d63dce5b65e9a6ee057c687de116b1e4a11816d8:packages/skills/skills/contribute-to-eliza"} -->




