### PR TITLE
fix(cloud): carry voice secret bootstrap to main

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -545,9 +545,9 @@ jobs:
             export VOICE_REALTIME_ELIZA_AUTHORIZATION
           fi
 
-          # Production provider and bridge values are managed Worker secrets,
-          # not GitHub secret material. keep_vars preserves them, and their
-          # binding names are verified against the live Worker before deploy.
+          # Production provider and bridge values remain managed Worker
+          # secrets. A protected-environment value may create or rotate one;
+          # a blank source preserves it, and names are verified before deploy.
 
           # Staging advertises realtime only when the repository variable
           # VOICE_REALTIME_WS_ENABLED is explicitly truthy. Refuse that opt-in
@@ -625,33 +625,6 @@ jobs:
             exit 1
           fi
 
-          if [ "$DEPLOY_ENVIRONMENT" = "production" ] && \
-             is_truthy "$VOICE_REALTIME_WS_ENABLED"; then
-            secret_inventory="$(bunx wrangler@4.100.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
-            printf '%s' "$secret_inventory" | node -e '
-              const fs = require("node:fs");
-              const parsed = JSON.parse(fs.readFileSync(0, "utf8"));
-              const entries = Array.isArray(parsed)
-                ? parsed
-                : Array.isArray(parsed?.result)
-                  ? parsed.result
-                  : [];
-              const present = new Set(entries.map((entry) => entry?.name).filter(Boolean));
-              const required = [
-                "CARTESIA_API_KEY",
-                "VOICE_REALTIME_CARTESIA_VOICE_ID",
-                "VOICE_REALTIME_ELIZA_AUTHORIZATION",
-                "VOICE_REALTIME_ELIZA_ENDPOINT",
-              ];
-              const missing = required.filter((name) => !present.has(name));
-              if (missing.length > 0) {
-                console.error(`::error::Production realtime voice is missing managed Worker secret binding name(s): ${missing.join(" ")}`);
-                process.exit(1);
-              }
-              console.log(`Verified ${required.length} managed production voice secret binding names; values were not read.`);
-            '
-          fi
-
           publish_secret() {
             local name="$1"
             local value="${!name:-}"
@@ -699,6 +672,37 @@ jobs:
             done
             echo "::error::wrangler secret put $name failed after 3 attempts"
             return 1
+          }
+
+          verify_production_voice_secret_bindings() {
+            if [ "$DEPLOY_ENVIRONMENT" != "production" ] || \
+               ! is_truthy "$VOICE_REALTIME_WS_ENABLED"; then
+              return 0
+            fi
+            local secret_inventory
+            secret_inventory="$(bunx wrangler@4.100.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
+            printf '%s' "$secret_inventory" | node -e '
+              const fs = require("node:fs");
+              const parsed = JSON.parse(fs.readFileSync(0, "utf8"));
+              const entries = Array.isArray(parsed)
+                ? parsed
+                : Array.isArray(parsed?.result)
+                  ? parsed.result
+                  : [];
+              const present = new Set(entries.map((entry) => entry?.name).filter(Boolean));
+              const required = [
+                "CARTESIA_API_KEY",
+                "VOICE_REALTIME_CARTESIA_VOICE_ID",
+                "VOICE_REALTIME_ELIZA_AUTHORIZATION",
+                "VOICE_REALTIME_ELIZA_ENDPOINT",
+              ];
+              const missing = required.filter((name) => !present.has(name));
+              if (missing.length > 0) {
+                console.error(`::error::Production realtime voice is missing managed Worker secret binding name(s): ${missing.join(" ")}`);
+                process.exit(1);
+              }
+              console.log(`Verified ${required.length} managed production voice secret binding names; values were not read.`);
+            '
           }
 
           # Like publish_secret, but for values that act as ROUTING TOGGLES
@@ -828,6 +832,11 @@ jobs:
           do
             publish_toggle_secret "$name" || exit 1
           done
+
+          # GitHub and Cloudflare are separate write-only authorities. Verify
+          # the live names only after configured values have had a chance to
+          # create their bindings, but still before any Worker code deploys.
+          verify_production_voice_secret_bindings || exit 1
 
       - name: Deploy to Cloudflare Workers
         if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true'

--- a/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
@@ -51,6 +51,16 @@ const preflight = publishStep.run.slice(
   0,
   publishStep.run.indexOf("# The Worker is the gateway"),
 );
+const shellHelpers = publishStep.run.slice(
+  0,
+  publishStep.run.indexOf("# Construct the staging fallback"),
+);
+const secretFunctions = publishStep.run
+  .slice(
+    publishStep.run.indexOf("publish_secret() {"),
+    publishStep.run.indexOf("# Like publish_secret"),
+  )
+  .replaceAll("$" + "{{ steps.env.outputs.wrangler_args }}", "");
 
 // The executed cases run the workflow's VERBATIM preflight bash, which uses
 // bash >= 4 `${1,,}` lowercasing (GitHub's Linux runners). macOS /bin/bash 3.2
@@ -91,6 +101,56 @@ function runPreflight(env: Record<string, string>) {
       STAGING_ELIZACLOUD_API_KEY: "",
       ...env,
     },
+  });
+}
+
+function runProductionVoiceBootstrap(
+  cartesiaApiKey: string,
+  putSucceeds = true,
+) {
+  const initialInventory = JSON.stringify([
+    { name: "VOICE_REALTIME_CARTESIA_VOICE_ID" },
+    { name: "VOICE_REALTIME_ELIZA_AUTHORIZATION" },
+    { name: "VOICE_REALTIME_ELIZA_ENDPOINT" },
+  ]);
+  const completeInventory = JSON.stringify([
+    { name: "CARTESIA_API_KEY" },
+    { name: "VOICE_REALTIME_CARTESIA_VOICE_ID" },
+    { name: "VOICE_REALTIME_ELIZA_AUTHORIZATION" },
+    { name: "VOICE_REALTIME_ELIZA_ENDPOINT" },
+  ]);
+  const script = `${shellHelpers}
+STATE_FILE="$(mktemp)"
+trap 'rm -f "$STATE_FILE"' EXIT
+printf '%s' '${initialInventory}' > "$STATE_FILE"
+bunx() {
+  if [[ "$1" == wrangler* && "$2" == "secret" && "$3" == "put" ]]; then
+    cat >/dev/null
+    if [ "$PUT_SUCCEEDS" != "true" ]; then
+      return 1
+    fi
+    printf '%s' '${completeInventory}' > "$STATE_FILE"
+    return 0
+  fi
+  if [[ "$1" == wrangler* && "$2" == "secret" && "$3" == "list" ]]; then
+    cat "$STATE_FILE"
+    return 0
+  fi
+  return 1
+}
+${secretFunctions}
+DEPLOY_ENVIRONMENT=production
+VOICE_REALTIME_WS_ENABLED=true
+VOICE_BATCH_STT_PROVIDER=""
+CARTESIA_API_KEY=${JSON.stringify(cartesiaApiKey)}
+PUT_SUCCEEDS=${JSON.stringify(String(putSucceeds))}
+sleep() { :; }
+publish_secret CARTESIA_API_KEY || exit 1
+verify_production_voice_secret_bindings || exit 1
+`;
+  return spawnSync(requirePreflightBash(), ["-c", script], {
+    encoding: "utf8",
+    env: process.env,
   });
 }
 
@@ -190,6 +250,13 @@ describe("Cloud CF realtime voice deploy contract", () => {
     expect(publishStep.run).toContain('"VOICE_REALTIME_CARTESIA_VOICE_ID"');
     expect(publishStep.run).toContain('"VOICE_REALTIME_ELIZA_ENDPOINT"');
     expect(publishStep.run).toContain("managed Worker secret binding name(s)");
+    const lastPublish = publishStep.run.lastIndexOf(
+      'publish_toggle_secret "$name" || exit 1',
+    );
+    const productionBindingVerification = publishStep.run.lastIndexOf(
+      "verify_production_voice_secret_bindings || exit 1",
+    );
+    expect(productionBindingVerification).toBeGreaterThan(lastPublish);
     expect(wrangler).not.toContain("VOICE_AMBIENT_ENABLED");
     expect(wrangler).not.toContain("VOICE_AMBIENT_PENDANT_BASE_URL");
   });
@@ -287,6 +354,28 @@ const executedDescribe = GNU_BASH ? describe : describe.skip;
 executedDescribe(
   "Cloud CF realtime voice deploy preflight (executed verbatim)",
   () => {
+    test("bootstraps a missing production Cartesia binding before verifying names", () => {
+      const result = runProductionVoiceBootstrap("cartesia-test");
+      expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+      expect(result.stdout).toContain(
+        "Verified 4 managed production voice secret binding names",
+      );
+    });
+
+    test("fails closed when a missing production binding has no configured source", () => {
+      const result = runProductionVoiceBootstrap(" ");
+      expect(result.status).toBe(1);
+      expect(`${result.stdout}${result.stderr}`).toContain("CARTESIA_API_KEY");
+    });
+
+    test("fails closed when first-time production secret publication fails", () => {
+      const result = runProductionVoiceBootstrap("cartesia-test", false);
+      expect(result.status).toBe(1);
+      expect(`${result.stdout}${result.stderr}`).toContain(
+        "wrangler secret put CARTESIA_API_KEY failed after 3 attempts",
+      );
+    });
+
     test("does not require realtime secrets when staging opt-in is absent", () => {
       const result = runPreflight({
         DEEPGRAM_API_KEY: "",


### PR DESCRIPTION
# Relates to

Fixes #20200. Carries the already-reviewed and merged develop fix from #20208 to `main` for the protected production release.

- [x] This PR targets `main` and is based on exact current `origin/main@eaeb064599f657e94ae13cc3e336fb73ebe20454` with zero conflicts.
- [x] The two-path patch is range-diff equal to merged #20208 and has the same stable patch-id `77167243876bc6bdc21dd2c7ce7cda8ed90c0731`.
- [x] Exact workflow execution and static gates pass; inherited main failures are recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6ab0aa6c9dac6d876e19c4e3a0554eec2ea539de:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with main

- [x] Exact base `origin/main@eaeb064599f657e94ae13cc3e336fb73ebe20454`; zero conflicts.
- [x] `git range-diff 32a09a4a..6bc29e10 eaeb0645..362b3d08` reports exact equality.

# Risks

Low, protected deployment-workflow-only risk. This is the exact reviewed #20208 semantic patch on current `main`: configured protected voice secrets publish through the existing fail-closed helper before names-only binding verification, while deploy remains later and unreachable on blank source, failed publication, or missing postcondition. No application runtime, UI, database, provider, or secret value changes.

# Background

Production run [31906316903](https://github.com/elizaOS/eliza/actions/runs/31906316903) failed before deploy because the workflow verified that `CARTESIA_API_KEY` already existed in the Worker store before reaching the helper capable of creating it. #20208 repaired and merged this on `develop`; production dispatches execute the workflow from `main`, so this narrow promotion is required before the protected rerun.

# Testing

## Where should a reviewer start?

Compare this commit with merged #20208: the range-diff is `=` and the stable patch-id is unchanged. Then verify `verify_production_voice_secret_bindings` follows all publication loops and precedes Worker deploy.

## Detailed testing steps

- Offline read-only Linux container, Bun 1.3.14: exact voice workflow suite 17/17 pass.
- macOS exact voice/staging suites: 12 pass / 9 expected Bash-version skips / 0 fail.
- `bunx biome check packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts` — pass.
- `actionlint .github/workflows/cloud-cf-release.yml` — pass.
- `git diff HEAD^..HEAD --check` — pass.
- `bun run verify` reaches the untouched `main` base's pre-existing Cloud API formatter error; full details are in Known gaps / failures.

# Evidence Gate

<!-- evidence-head:362b3d082359381b2c23baa1f2cc44585d6b809b -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - protected workflow-only change with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - protected workflow-only change with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive or rendered user flow changes.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no application backend path changes; the exact protected GitHub Actions failure is linked above.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code or request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no database, memory, wallet, or generated artifact changes; names-only binding proof belongs to the protected post-merge release.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no visual surface changes.

# Evidence Details

## Backend + frontend logs

Ground truth from protected run [31906316903](https://github.com/elizaOS/eliza/actions/runs/31906316903):

```text
Production realtime voice is missing managed Worker secret binding name(s): CARTESIA_API_KEY
```

Worker deploy/verification was skipped after that failure; production remained unchanged.

## Known gaps / failures

- The exact voice workflow is fully green on Linux (17/17). Nine shell-execution cases skip on macOS because `/bin/bash` 3.2 lacks lowercase expansion; this is an explicit existing test contract.
- The three-suite adjacent macOS command also exposes one inherited `main` assertion failure in untouched `packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts`: it expects production `SHARED_ELIZA_AGENT_RUNTIME="false"`, while parent `main@eaeb0645` already contains `"true"`. This PR changes neither that test nor `wrangler.toml`.
- Exact-head `bun run verify` is blocked by an inherited formatter error in untouched `packages/cloud/api/src/index.test.ts:777`; the same line is present on parent `main@eaeb0645`. Candidate-scoped Biome/actionlint/diff gates are green.
- No production rerun occurred. Release remains gated on exact-head review/merge and protected environment approval.

# Deploy Notes

After merge, claim the production lever in Fleet HQ, dispatch one fresh Cloud CF Release from exact current `main`, and do not cancel unrelated runs. Verify managed binding names without reading values, exact Worker/API health SHA, realtime readiness, and one labeled Telegram round trip.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@6ab0aa6c9dac6d876e19c4e3a0554eec2ea539de:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [gauss-launch]
