### PR TITLE
ci(cloud): wire the packages/cloud/e2e Playwright suite into CI

### DIFF
--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -179,11 +179,11 @@ jobs:
       - name: Run shared-to-dedicated funnel specs
         run: >-
           bun run cloud:e2e --
-          app-client-onboarding.spec.ts
-          app-client-handoff-success.spec.ts
-          provision.spec.ts
-          onboarding-reprovision.spec.ts
-          shared-to-dedicated-upgrade.spec.ts
+          'app-client-onboarding\.spec\.ts$'
+          'app-client-handoff-success\.spec\.ts$'
+          '(^|/)provision\.spec\.ts$'
+          'onboarding-reprovision\.spec\.ts$'
+          'shared-to-dedicated-upgrade\.spec\.ts$'
       - name: Upload Playwright evidence
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -15,6 +15,8 @@ on:
       - "packages/cloud/routing/**"
       - "packages/cloud/infra/**"
       - "packages/cloud/scripts/**"
+      - "packages/cloud/e2e/**"
+      - "packages/cloud/test-mocks/**"
       - "packages/scripts/test-cloud-run.mjs"
       - "packages/scripts/test-cloud-run-helpers.mjs"
       - "packages/scripts/__tests__/test-cloud-run.test.mjs"
@@ -144,3 +146,52 @@ jobs:
           packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-stuck-provisioning-lock.integration.test.ts
       - name: Run cloud e2e tests
         run: bun run test:cloud:e2e
+
+  # Full-stack Playwright lane (#18474). packages/cloud/e2e boots the real
+  # mock-backed cloud stack (PGlite TCP bridge, Hetzner mock, container
+  # control plane, cloud-api Worker, app frontend) and drives real flows.
+  # The complete suite takes ~12 minutes plus the linked-workspace build, so
+  # this per-push gate runs the explicit shared-to-dedicated funnel subset
+  # (onboarding -> handoff -> provisioning -> upgrade); the remaining specs run
+  # nightly in .github/workflows/monetized-loop-nightly.yml, which executes the
+  # full suite on a schedule. Failures propagate — no continue-on-error.
+  stack-e2e-tests:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    needs: [lint-and-types]
+    env:
+      NODE_ENV: test
+      CI: "true"
+      CLOUD_E2E: "1"
+      MOCK_REDIS: "1"
+      MOCK_HETZNER_LATENCY: "0"
+      MOCK_HETZNER_ACTION_MS: "30"
+      CONTROL_PLANE_TICK_MS: "50"
+      DATABASE_URL: pglite://./.eliza-ci/.pgdata
+      HCLOUD_TOKEN: test-token
+      CONTAINER_CONTROL_PLANE_TOKEN: test-token
+      CRON_SECRET: test-cron-secret
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: ./.github/actions/cloud-setup-test-env
+      - name: Install Playwright browsers
+        run: .github/scripts/install-playwright-browsers.sh chromium
+      - name: Run shared-to-dedicated funnel specs
+        run: >-
+          bun run cloud:e2e --
+          app-client-onboarding.spec.ts
+          app-client-handoff-success.spec.ts
+          provision.spec.ts
+          onboarding-reprovision.spec.ts
+          shared-to-dedicated-upgrade.spec.ts
+      - name: Upload Playwright evidence
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: cloud-stack-e2e-${{ github.run_attempt }}
+          path: |
+            packages/cloud/e2e/test-results
+            packages/cloud/e2e/.logs
+          retention-days: 7
+          include-hidden-files: true
+          if-no-files-found: warn

--- a/.github/workflows/monetized-loop-nightly.yml
+++ b/.github/workflows/monetized-loop-nightly.yml
@@ -1,8 +1,11 @@
 name: Monetized Loop Nightly
 
-# Scheduled keyless coverage for the cloud monetization lifecycle. The same
-# specs run in the PR cloud lane; this schedule catches dependency and service
-# drift even when no cloud-owned path changes.
+# Scheduled keyless coverage for the full packages/cloud/e2e Playwright suite
+# (#18474): monetization lifecycle plus every other stack spec. The PR cloud
+# lane (cloud-tests.yml stack-e2e-tests) runs only the shared-to-dedicated
+# funnel subset for wall-time reasons; this schedule is where the complete
+# suite executes, and it also catches dependency and service drift even when
+# no cloud-owned path changes.
 on:
   schedule:
     - cron: "30 7 * * *"
@@ -19,7 +22,7 @@ jobs:
   monetized-loop:
     name: Monetized loop (mock stack)
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       NODE_ENV: test
       NODE_OPTIONS: --max-old-space-size=4096
@@ -44,11 +47,11 @@ jobs:
       - name: Install Playwright browsers
         run: .github/scripts/install-playwright-browsers.sh chromium
 
-      - name: Run monetization lifecycle
-        run: >-
-          bun run cloud:e2e --
-          monetized-full-loop.spec.ts
-          monetized-mock-llm-journey.spec.ts
+      # The full suite (33 specs) measured ~12 minutes of Playwright wall time
+      # locally on top of the linked-workspace build; the 30-minute historical
+      # budget for two specs becomes 60 for the whole lane.
+      - name: Run full cloud stack e2e suite
+        run: bun run cloud:e2e
 
       - name: Upload Playwright evidence
         if: always()

--- a/packages/scripts/__tests__/cloud-stack-e2e-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-stack-e2e-workflow.test.ts
@@ -1,0 +1,50 @@
+/** Guards the split between the focused cloud stack gate and the full nightly suite. */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const repoRoot = new URL("../../../", import.meta.url);
+
+interface WorkflowStep {
+  name?: string;
+  run?: string;
+}
+
+interface Workflow {
+  jobs?: Record<string, { steps?: WorkflowStep[] }>;
+}
+
+function readWorkflow(path: string): Workflow {
+  const source = readFileSync(new URL(path, repoRoot), "utf8");
+  return Bun.YAML.parse(source) as Workflow;
+}
+
+function runStep(workflow: Workflow, job: string, name: string): string {
+  const run = workflow.jobs?.[job]?.steps?.find((step) => step.name === name)?.run;
+  if (!run) throw new Error(`Missing ${job} workflow step: ${name}`);
+  return run;
+}
+
+describe("cloud stack e2e workflow split", () => {
+  test("the develop gate selects exactly named funnel files", () => {
+    const run = runStep(
+      readWorkflow(".github/workflows/cloud-tests.yml"),
+      "stack-e2e-tests",
+      "Run shared-to-dedicated funnel specs",
+    );
+
+    expect(run).toContain("'(^|/)provision\\.spec\\.ts$'");
+    expect(run).not.toContain("\n          provision.spec.ts");
+    expect(run.match(/\\\.spec\\\.ts\$/g)).toHaveLength(5);
+  });
+
+  test("the nightly lane runs the unfiltered suite", () => {
+    const run = runStep(
+      readWorkflow(".github/workflows/monetized-loop-nightly.yml"),
+      "monetized-loop",
+      "Run full cloud stack e2e suite",
+    );
+
+    expect(run.trim()).toBe("bun run cloud:e2e");
+  });
+});


### PR DESCRIPTION
## What

The packages/cloud/e2e Playwright suite — the specs proving the shared-to-dedicated funnel — has never run in CI: `test:cloud:e2e` resolves to packages/cloud/api's lane, only two specs ran nightly, and `packages/cloud/e2e/**` was absent from every trigger filter (#18474).

- **cloud-tests.yml**: adds `packages/cloud/e2e/**` and `packages/cloud/test-mocks/**` to the trigger paths, and a new `stack-e2e-tests` job that boots the real mock-backed stack (PGlite TCP bridge, Hetzner mock, container control plane, cloud-api Worker, app frontend) and runs the explicit shared-to-dedicated funnel subset: `app-client-onboarding`, `app-client-handoff-success`, `provision`, `onboarding-reprovision`, `shared-to-dedicated-upgrade`. Failures propagate — no `continue-on-error`. Playwright evidence uploads on failure.
- **monetized-loop-nightly.yml**: the nightly job now runs the **full** 33-spec suite (previously just the two monetization specs) on a 60-minute budget; the split is documented in both workflows. The full suite measured ~12 minutes of Playwright wall time locally on top of the linked-workspace build, too heavy for every push, hence the subset/nightly split.

Rebased onto current develop, adapting to the develop-only trigger policy (5a3c892868c removed `pull_request` triggers from this workflow): the new job runs on develop pushes touching cloud paths and via `workflow_dispatch`.

## Tests

- `python3 yaml.safe_load` on both workflows: pass.
- `actionlint` on both workflows: clean.
- All five subset spec files verified present in `packages/cloud/e2e/tests/`; `cloud:e2e` root script verified (`bun run --cwd packages/cloud/e2e test`).

## Residual risk

- The first CI run may surface the known `app-client-handoff-success.spec.ts` timeout on develop; per the issue that is to be triaged as its own follow-up, not silenced here.
- Wall time on GitHub-hosted runners may differ from the local measurement; the job has a 35-minute timeout and the nightly 60.

Fixes #18474

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:e32ae14dcd466ea3c1d8664961e490f2843d598e -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - workflow-only change with no rendered product UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - workflow-only change with no rendered product UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - workflow-only change; the real stack flow is captured in the domain log

<!-- evidence-row:backend-logs -->
- [x] [20217-pr20217-backend-v2.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20217-pr20217-backend-v2.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend production code changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic mock-backed CI orchestration with no live model behavior change

<!-- evidence-row:domain-artifacts -->
- [x] [20217-pr20217-domain-artifacts.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20217-pr20217-domain-artifacts.log)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual or document artifact changed


