### PR TITLE
fix(cloud-apps): narrow cloud inventory routing and single-reply delivery

### DIFF
--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -1156,13 +1156,44 @@ describe("cloud-apps surface request inference", () => {
 		}
 	});
 
-	it("falls back to local APP when no cloud-apps action is registered", () => {
+	it("never degrades a cloud-qualified ask to local APP when no cloud-apps action is registered (#17363)", () => {
 		expect(
 			inferDirectCurrentRequestCandidateActions(
 				[viewsAction, appAction],
 				"list my cloud apps",
 			),
-		).toEqual(["VIEWS", "APP"]);
+		).toEqual(["VIEWS"]);
+	});
+
+	it("leaves cloud lifecycle/mutation asks to the full planner (#17363)", () => {
+		for (const message of [
+			"launch my cloud app",
+			"delete my deployed app",
+			"open the cloud app settings",
+			"create a new cloud app",
+			"deploy my app to the cloud",
+			"restart the hosted app",
+		]) {
+			const candidates = inferDirectCurrentRequestCandidateActions(
+				[viewsAction, appAction, cloudAppsAction],
+				message,
+			);
+			expect(candidates).not.toContain("LIST_CLOUD_APPS");
+			expect(candidates).not.toContain("APP");
+		}
+	});
+
+	it("leaves compound cloud inventory turns to the full planner (#17363)", () => {
+		for (const message of [
+			"list my cloud apps and then delete the old one",
+			"show my cloud apps; also check my agents",
+		]) {
+			const candidates = inferDirectCurrentRequestCandidateActions(
+				[viewsAction, appAction, cloudAppsAction],
+				message,
+			);
+			expect(candidates).not.toContain("LIST_CLOUD_APPS");
+		}
 	});
 
 	it("resolves the cloud action by simile when the canonical name differs", () => {

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -1383,13 +1383,74 @@ const CLOUD_APP_QUALIFIER_TOKENS: ReadonlySet<string> = new Set<string>([
 	"HOSTED",
 ]);
 
+// Lifecycle/mutation verbs that disqualify an app-shaped ask from the
+// read-only cloud inventory surface (#17363). "launch my cloud app" or
+// "delete the deployed app" must stay with the full planner (and the
+// lifecycle-owning actions it arbitrates), never be pinned to
+// LIST_CLOUD_APPS by the incidental cloud qualifier. Compared in
+// singular-normalized token space.
+const APP_LIFECYCLE_VERB_TOKENS: ReadonlySet<string> = new Set<string>([
+	"LAUNCH",
+	"OPEN",
+	"START",
+	"RUN",
+	"STOP",
+	"CLOSE",
+	"KILL",
+	"RESTART",
+	"DELETE",
+	"REMOVE",
+	"UNINSTALL",
+	"INSTALL",
+	"CREATE",
+	"MAKE",
+	"BUILD",
+	"DEPLOY",
+	"REDEPLOY",
+	"PUBLISH",
+	"UPDATE",
+	"EDIT",
+	"RENAME",
+	"CONFIGURE",
+	"SETTING",
+]);
+
+// Positive inventory evidence: at least one of these must appear for a
+// cloud-qualified app ask to be treated as a read-only inventory request.
+const APP_INVENTORY_EVIDENCE_TOKENS: ReadonlySet<string> = new Set<string>([
+	"LIST",
+	"SHOW",
+	"WHAT",
+	"WHICH",
+	"SEE",
+	"VIEW",
+	"DISPLAY",
+	"GET",
+	"HAVE",
+	"MY",
+	"MINE",
+	"INVENTORY",
+]);
+
+// Multi-clause connectives: a compound turn ("list my cloud apps and then
+// delete the old one") carries more than one request, so the deterministic
+// inventory pin must yield to the full planner (#17363).
+const COMPOUND_APP_REQUEST_PATTERN =
+	/\b(?:and|then|also|after(?:wards)?|next|plus)\b|;/iu;
+
 // Resolve the app action an app-shaped message targets. A cloud qualifier next
 // to the APP token pins the ask to the user's hosted Eliza Cloud apps, where
 // the local app-control action is wrong by its own routing contract — without
 // this the cloud-apps action is never on the planner surface and the local APP
-// action wins by forfeit. Falls back to the local app-control surface when no
-// cloud-apps action is registered, so those runtimes keep their previous
-// candidates.
+// action wins by forfeit.
+//
+// The cloud pin is deliberately narrow (#17363): only a single-clause,
+// read-only inventory request qualifies. Lifecycle/mutation verbs and
+// compound turns yield NO deterministic app candidate — the full planner
+// arbitrates them — and a cloud-qualified ask never degrades to the
+// local-device app-control action, whether the cloud action is absent or the
+// ask is lifecycle-shaped: local installed-app inventory would silently
+// answer a question about hosted Eliza Cloud apps.
 function findAppActionNameForAppRequest(
 	actions: ReadonlyArray<Pick<Action, "name" | "similes">>,
 	messageText: string,
@@ -1401,11 +1462,12 @@ function findAppActionNameForAppRequest(
 		return undefined;
 	}
 	if (tokens.some((token) => CLOUD_APP_QUALIFIER_TOKENS.has(token))) {
-		const cloudAppsAction = findAvailableActionName(
-			actions,
-			CLOUD_APPS_ACTION_NAMES,
-		);
-		if (cloudAppsAction) return cloudAppsAction;
+		const isSingleClauseInventoryAsk =
+			!tokens.some((token) => APP_LIFECYCLE_VERB_TOKENS.has(token)) &&
+			tokens.some((token) => APP_INVENTORY_EVIDENCE_TOKENS.has(token)) &&
+			!COMPOUND_APP_REQUEST_PATTERN.test(messageText);
+		if (!isSingleClauseInventoryAsk) return undefined;
+		return findAvailableActionName(actions, CLOUD_APPS_ACTION_NAMES);
 	}
 	return findAvailableActionName(actions, APP_CONTROL_ACTION_NAMES);
 }

--- a/packages/scenario-runner/test/scenarios/cloud-apps-read-core.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/cloud-apps-read-core.scenario.ts
@@ -1,5 +1,5 @@
 /**
- * Live-lane scenario: a real LLM answers "what apps do I have?" against the
+ * Live-lane scenario: a real LLM answers "what apps do I have on eliza cloud?" against the
  * Eliza Cloud Apps read surface. Needs live model credentials (live-only lane).
  */
 import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
@@ -43,7 +43,7 @@ function expectCloudAppsListResult(ctx: ScenarioContext): string | undefined {
  * Live trajectory for the Eliza Cloud Apps read-core (#10218).
  *
  * FOLLOW-UP EVIDENCE — lane: "live-only". This needs BOTH a live model (to route
- * "what apps do I have?" to LIST_CLOUD_APPS) AND a real `ELIZAOS_CLOUD_API_KEY`
+ * "what apps do I have on eliza cloud?" to LIST_CLOUD_APPS) AND a real `ELIZAOS_CLOUD_API_KEY`
  * (so `client.listApps()` reaches Eliza Cloud). It is intentionally excluded
  * from the keyless `pr-deterministic` lane: LIST_CLOUD_APPS calls the Cloud API,
  * which cannot be satisfied by a proxy fixture. Run it manually with a key:
@@ -58,7 +58,7 @@ function expectCloudAppsListResult(ctx: ScenarioContext): string | undefined {
 export default scenario({
   id: "cloud-apps-read-core",
   lane: "live-only",
-  title: "Eliza Cloud Apps read-core: what apps do I have?",
+  title: "Eliza Cloud Apps read-core: what apps do I have on eliza cloud?",
   domain: "cloud-apps",
   status: "active",
   requires: {
@@ -68,7 +68,7 @@ export default scenario({
     {
       kind: "message",
       name: "user asks for their cloud apps",
-      text: "what apps do I have?",
+      text: "what apps do I have on eliza cloud?",
     },
   ],
   finalChecks: [

--- a/plugins/plugin-cloud-apps/__tests__/list-cloud-apps.test.ts
+++ b/plugins/plugin-cloud-apps/__tests__/list-cloud-apps.test.ts
@@ -140,9 +140,11 @@ describe("LIST_CLOUD_APPS", () => {
           .count,
       ).toBe(0);
       expect(cb.calls[0]?.text).toContain("haven't created any apps");
-      // The canned empty message is not a verified terminal answer — the
-      // evaluator still runs and may add guidance (e.g. how to create one).
-      expect(result?.turnComplete).toBeUndefined();
+      // The empty inventory IS the complete answer (#17363): verified +
+      // turnComplete keep the evaluator from paraphrasing the delivered
+      // callback text into a second user-visible bubble.
+      expect(result?.verifiedUserFacing).toBe(true);
+      expect(result?.turnComplete).toBe(true);
     });
 
     it("degrades gracefully when no Cloud API key is configured", async () => {
@@ -161,6 +163,11 @@ describe("LIST_CLOUD_APPS", () => {
           .reason,
       ).toBe("no_key");
       expect(cb.calls[0]?.text).toContain("no Cloud API key");
+      // A sole handled failure that already delivered its explanation owns
+      // the turn (#17363): success stays false while verified + turnComplete
+      // let the terminal failure gate end it with exactly one reply.
+      expect(result?.verifiedUserFacing).toBe(true);
+      expect(result?.turnComplete).toBe(true);
     });
 
     it("handles a Cloud API error without throwing", async () => {
@@ -181,6 +188,9 @@ describe("LIST_CLOUD_APPS", () => {
           .reason,
       ).toBe("error");
       expect(cb.calls[0]?.text).toContain("couldn't fetch");
+      // Same single-delivery contract as the no-key path (#17363).
+      expect(result?.verifiedUserFacing).toBe(true);
+      expect(result?.turnComplete).toBe(true);
     });
 
     it("does not translate a callback failure into an API error", async () => {
@@ -209,5 +219,26 @@ describe("LIST_CLOUD_APPS", () => {
       expect(delivered[0]).toContain("Delivered Once");
       expect(delivered[0]).not.toContain("Cloud API returned an error");
     });
+  });
+});
+
+// #17363: generic aliases (MY_APPS, GET_APPS, WHAT_APPS_DO_I_HAVE, MY_SITES)
+// collide with local installed-app ownership; every routing alias must stay
+// explicitly cloud/deployed/hosted-qualified.
+describe("LIST_CLOUD_APPS aliases stay cloud-specific", () => {
+  it("carries no generic installed-app alias", () => {
+    const generic = [
+      "MY_APPS",
+      "GET_APPS",
+      "WHAT_APPS_DO_I_HAVE",
+      "MY_SITES",
+      "LIST_APPS",
+    ];
+    for (const alias of generic) {
+      expect(listCloudAppsAction.similes ?? []).not.toContain(alias);
+    }
+    for (const alias of listCloudAppsAction.similes ?? []) {
+      expect(/CLOUD|DEPLOYED|HOSTED|ELIZA/.test(alias)).toBe(true);
+    }
   });
 });

--- a/plugins/plugin-cloud-apps/src/actions/list-cloud-apps.ts
+++ b/plugins/plugin-cloud-apps/src/actions/list-cloud-apps.ts
@@ -32,23 +32,26 @@ export const listCloudAppsAction: Action = {
   name: "LIST_CLOUD_APPS",
   // "LIST_APPS" is deliberately NOT claimed: plugin-app-control's APP action
   // owns it for device-installed apps, and a simile claimed by two parents is
-  // dropped from routing as ambiguous (#16561).
+  // dropped from routing as ambiguous (#16561). Every simile stays explicitly
+  // cloud-qualified (#17363): generic aliases like MY_APPS / GET_APPS /
+  // WHAT_APPS_DO_I_HAVE collide with local installed-app ownership and let an
+  // ambiguous "my apps" turn land on the cloud inventory.
   similes: [
-    "MY_APPS",
-    "GET_APPS",
-    "WHAT_APPS_DO_I_HAVE",
     "MY_CLOUD_APPS",
     "CLOUD_APPS",
+    "GET_CLOUD_APPS",
+    "WHAT_CLOUD_APPS_DO_I_HAVE",
     "LIST_ELIZA_CLOUD_APPS",
     "MY_DEPLOYED_APPS",
-    "MY_SITES",
+    "MY_HOSTED_APPS",
+    "MY_CLOUD_SITES",
   ],
   description:
     "List the Eliza Cloud apps the user owns — the hosted apps and sites they created or deployed on Eliza Cloud (name, URL, deployment status, and credits/earnings when present). Use when the user asks what apps they have, to see their apps, their cloud apps, or the sites/apps they've made or deployed. Not for apps installed or running on this device.",
   descriptionCompressed:
     "List the user's Eliza Cloud apps (name/url/status); not locally installed apps.",
   routingHint:
-    "The user's own Eliza Cloud apps -> LIST_CLOUD_APPS. 'List my apps', 'my cloud apps', 'what apps do I have on eliza cloud', 'sites/apps I've made or deployed' is LIST_CLOUD_APPS; apps installed or running on this device are APP (NOT this action).",
+    "The user's own Eliza Cloud apps -> LIST_CLOUD_APPS. 'List my cloud apps', 'my deployed apps', 'what apps do I have on eliza cloud' is LIST_CLOUD_APPS; a generic 'list my apps' and apps installed or running on this device are APP (NOT this action). Read-only inventory: launching, opening, deleting, creating, or deploying an app is never this action.",
   // Read-only inventory lookup; safe on any user turn. "general" mirrors the
   // APP action's rationale (#9950): Stage-1 routinely classifies unambiguous
   // app asks ("list my cloud apps") as general context; without it this
@@ -75,6 +78,12 @@ export const listCloudAppsAction: Action = {
         success: false,
         text: "No Eliza Cloud API key configured.",
         userFacingText: NO_KEY_MESSAGE,
+        // A sole handled failure whose callback text IS the complete honest
+        // outcome: verified + turnComplete let the terminal failure gate end
+        // the turn with exactly one reply instead of an evaluator paraphrase
+        // re-delivering it (#17363).
+        verifiedUserFacing: true,
+        turnComplete: true,
         data: { reason: "no_key" },
       };
     }
@@ -91,6 +100,9 @@ export const listCloudAppsAction: Action = {
         success: false,
         text: "Failed to list Eliza Cloud apps.",
         userFacingText: ERROR_MESSAGE,
+        // Same single-delivery contract as the no-key path (#17363).
+        verifiedUserFacing: true,
+        turnComplete: true,
         error: err instanceof Error ? err : new Error(String(err)),
         data: { reason: "error" },
       };
@@ -103,6 +115,11 @@ export const listCloudAppsAction: Action = {
         success: true,
         text: "User has no Eliza Cloud apps.",
         userFacingText: EMPTY_MESSAGE,
+        // The empty inventory IS the complete answer: verified + turnComplete
+        // keep the evaluator from paraphrasing the already-delivered callback
+        // text into a second bubble (#17363).
+        verifiedUserFacing: true,
+        turnComplete: true,
         data: { count: 0, apps: [] },
       };
     }
@@ -138,7 +155,10 @@ export const listCloudAppsAction: Action = {
 
   examples: [
     [
-      { name: "{{user}}", content: { text: "what apps do I have?" } },
+      {
+        name: "{{user}}",
+        content: { text: "what apps do I have on eliza cloud?" },
+      },
       {
         name: "{{agent}}",
         content: {


### PR DESCRIPTION
## Summary

Focused repair of the over-broad direct routing merged in #17330 (Fixes #17363).

- **Routing narrowed**: the deterministic cloud-apps pin in `packages/core/src/services/message/direct-action-heuristics.ts` now fires only on a single-clause, read-only, explicitly cloud-qualified inventory ask. Lifecycle/mutation verbs (launch, open, delete, create, deploy, restart, ...) and compound turns (`and then`, `;`, ...) yield no deterministic app candidate — the full planner arbitrates them.
- **No silent degrade**: a cloud-qualified ask never falls back to the local-device `APP` action, whether the cloud action is absent or the ask is lifecycle-shaped.
- **Aliases stay cloud-specific**: `LIST_CLOUD_APPS` drops `MY_APPS` / `GET_APPS` / `WHAT_APPS_DO_I_HAVE` / `MY_SITES`; every remaining simile is explicitly cloud/deployed/hosted qualified, and a regression test asserts it stays that way. Local `APP` retains generic installed-app language.
- **Exactly one reply per outcome**: empty, missing-key, and API-error results stamp `verifiedUserFacing` + `turnComplete` so the existing terminal gates (`tryGateEvaluator` / `tryGateVerifiedFailure`, already on develop) deliver the callback text as the sole user-visible reply instead of an evaluator paraphrase. `success: false` is preserved on the failure paths, and the gates' own preconditions keep queued multi-tool turns untruncated.
- The live-only scenario prompt disambiguates to "what apps do I have on eliza cloud?" since the bare phrase is local-device inventory after the ownership split.

Note: the core terminal-failure gate itself (sole verified handled failure may end the turn with `success:false`) already landed on develop; this PR completes the plugin/heuristic side of #17363's acceptance list.

## Verification

- `packages/core` — `vitest run src/services/message/direct-action-heuristics.test.ts`: 62 passed (includes new no-degrade, lifecycle-verb, and compound-turn regressions).
- `plugins/plugin-cloud-apps` — full package suite: 363 passed (includes new alias-vocabulary and turnComplete/verifiedUserFacing outcome assertions; existing callback-boundary loopback integration suite still green).
- `bun run typecheck` in both packages: clean. Biome clean on touched files.
- Rebased onto current `origin/develop` with focused tests re-run green.

**Draft disclosure (per issue acceptance):** the live model + real Cloud inventory trajectory is not attached — it requires the live-only scenario lane (`cloud-apps-read-core`) with a live planner model plus a real `ELIZAOS_CLOUD_API_KEY`, which this environment did not exercise. All other acceptance rows are covered deterministically above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)