### PR TITLE
fix(orchestrator): ground async spawn results so the planner cannot fabricate sub-agent output

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
@@ -115,7 +115,7 @@ describe("TASKS:spawn_agent", () => {
       cb,
     );
     expect(result?.success).toBe(true);
-    expect(result?.text).toBe("");
+    expect(result?.text).toContain("result is NOT available yet");
     expect(cb).not.toHaveBeenCalled();
     expect(result?.continueChain).toBe(false);
     expect(result?.data).toMatchObject({
@@ -333,7 +333,7 @@ describe("TASKS:spawn_agent", () => {
     );
 
     expect(result?.success).toBe(true);
-    expect(result?.text).toBe("");
+    expect(result?.text).toContain("result is NOT available yet");
     expect(result?.data).toMatchObject({ deferredUserReply: true });
     expect(cb).not.toHaveBeenCalled();
   });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
@@ -115,7 +115,7 @@ describe("TASKS:spawn_agent", () => {
       cb,
     );
     expect(result?.success).toBe(true);
-    expect(result?.text).toContain("result is NOT available yet");
+    expect(result?.text).toContain("result is not available yet");
     expect(cb).not.toHaveBeenCalled();
     expect(result?.continueChain).toBe(false);
     expect(result?.data).toMatchObject({
@@ -333,7 +333,7 @@ describe("TASKS:spawn_agent", () => {
     );
 
     expect(result?.success).toBe(true);
-    expect(result?.text).toContain("result is NOT available yet");
+    expect(result?.text).toContain("result is not available yet");
     expect(result?.data).toMatchObject({ deferredUserReply: true });
     expect(cb).not.toHaveBeenCalled();
   });

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -1437,7 +1437,7 @@ async function runCreate(
   const successfulResults = laneOutcome.results;
   return {
     success: true,
-    text: `Created ${successfulResults.length} task-agent lanes.`,
+    text: `Created ${successfulResults.length} task-agent lanes. They run asynchronously and no lane result is available yet — results arrive later as follow-up messages. Tell the user the agents are working; never state, guess, or invent their output in this turn.`,
     data: {
       waveId: plan.waveId,
       agents: successfulResults.flatMap((result) =>
@@ -2020,12 +2020,14 @@ async function runSpawnAgent(
       })}`,
     );
 
-    // No text ack here. The orchestrator's progress hook owns user-visible
-    // status updates; emitting "On it" duplicates that and (worse) surfaces
-    // the planner's hallucinated messageToUser via the bootstrap REPLY path.
+    // Planner-facing grounding, not a user ack (the orchestrator's progress
+    // hook owns user-visible status). An empty text here left the finish pass
+    // with nothing to relay for an async spawn, and it answered the user's
+    // question from thin air instead (observed live: fabricated `bun
+    // --version` output). State the pending contract explicitly.
     return {
       success: true,
-      text: "",
+      text: `Sub-agent "${label}" (${session.agentType}) dispatched; it runs asynchronously and its result is NOT available yet — it arrives later as a follow-up message. Tell the user the agent is working. Never state, guess, or invent the sub-agent's output in this turn.`,
       // Terminate the planner loop after the first spawn fires.
       //
       // TASKS_SPAWN_AGENT is fire-and-forget: the action returns the

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -1437,7 +1437,7 @@ async function runCreate(
   const successfulResults = laneOutcome.results;
   return {
     success: true,
-    text: `Created ${successfulResults.length} task-agent lanes. They run asynchronously and no lane result is available yet — results arrive later as follow-up messages. Tell the user the agents are working; never state, guess, or invent their output in this turn.`,
+    text: `Created ${successfulResults.length} task-agent lanes. They are working asynchronously — no lane result is available yet; results will arrive as follow-up messages.`,
     data: {
       waveId: plan.waveId,
       agents: successfulResults.flatMap((result) =>
@@ -2020,14 +2020,16 @@ async function runSpawnAgent(
       })}`,
     );
 
-    // Planner-facing grounding, not a user ack (the orchestrator's progress
-    // hook owns user-visible status). An empty text here left the finish pass
-    // with nothing to relay for an async spawn, and it answered the user's
-    // question from thin air instead (observed live: fabricated `bun
-    // --version` output). State the pending contract explicitly.
+    // An empty text here left the planner finish with nothing to relay for an
+    // async spawn, and it answered the user's question from thin air instead
+    // (observed live: fabricated `bun --version` output). State the pending
+    // contract as a plain status: it grounds the finish pass AND reads
+    // correctly if a transport falls back to this text verbatim (the api
+    // response path does when no callback fired), so no planner-directed
+    // imperatives here.
     return {
       success: true,
-      text: `Sub-agent "${label}" (${session.agentType}) dispatched; it runs asynchronously and its result is NOT available yet — it arrives later as a follow-up message. Tell the user the agent is working. Never state, guess, or invent the sub-agent's output in this turn.`,
+      text: `Spawned coding sub-agent "${label}" (${session.agentType}). It is working asynchronously — its result is not available yet and will arrive as a follow-up message.`,
       // Terminate the planner loop after the first spawn fires.
       //
       // TASKS_SPAWN_AGENT is fire-and-forget: the action returns the


### PR DESCRIPTION
Upstreamed from the live test box (watchtower's resync-h carries; commits cherry-picked with authorship preserved; carry handoff at HQ #18309). Two paired commits — the second makes the grounded status text user-presentable because the api transport falls back to ActionResult.text verbatim when no callback fired; shipping the first alone regresses UX.

**Live receipts (box)**: bun-version probe tj-1fe7ef7a84b6de — the spawn tool returned EMPTY text and the planner FINISH invented "bun 1.1.38"; post-fix the status text is grounded and the api fallback presents cleanly.

**Local verification**: `__tests__/unit/spawn-agent.test.ts` 19/19 on the carried branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)