### PR TITLE
fix(orchestrator): baseline untracked paths at spawn so the residuals gate does not block lived-in workdirs

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -3048,6 +3048,16 @@ describe("residualsSpawnBaseline — spawn-time metadata classification", () => 
     ).toEqual({ baselineDirtyPaths: ["a.ts", "b.ts"] });
   });
 
+  it("parses the untracked-at-spawn baseline, dropping non-string entries", () => {
+    expect(
+      residualsSpawnBaseline({
+        metadata: {
+          codingBaselineUntracked: ["notes/", 42, "scratch.txt", ""],
+        },
+      }),
+    ).toEqual({ baselineUntrackedPaths: ["notes/", "scratch.txt"] });
+  });
+
   it("classifies a route-mapped, non-isolated workdir as shared", () => {
     expect(
       residualsSpawnBaseline({ metadata: { workdirRouteId: "agent-home" } }),

--- a/plugins/plugin-agent-orchestrator/src/__tests__/completion-residuals.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/completion-residuals.test.ts
@@ -538,13 +538,65 @@ describe("collectCompletionResiduals — spawn-time baseline + shared route work
     expect(residual?.items).toEqual(["?? run-output.ts"]);
   });
 
-  it("never exempts an untracked path via the baseline (spawn baseline is tracked-only)", async () => {
+  it("never exempts an untracked path via the tracked-dirty baseline", async () => {
     const { workdir } = makeRepo();
     writeFileSync(join(workdir, "untracked.ts"), "export {};\n");
     const result = await collectCompletionResiduals({
       workdir,
       repoExpected: true,
       baselineDirtyPaths: ["untracked.ts"],
+    });
+    expect(result.status).toBe("residuals");
+  });
+
+  it("does not count untracked paths already present at spawn (lived-in workdir)", async () => {
+    const { workdir } = makeRepo();
+    writeFileSync(join(workdir, "pre-existing.txt"), "before spawn\n");
+    const result = await collectCompletionResiduals({
+      workdir,
+      repoExpected: true,
+      baselineUntrackedPaths: ["pre-existing.txt"],
+    });
+    expect(result.status).toBe("clean");
+    expect(result.residuals).toEqual([]);
+  });
+
+  it("still counts untracked paths that appear after spawn", async () => {
+    const { workdir } = makeRepo();
+    writeFileSync(join(workdir, "pre-existing.txt"), "before spawn\n");
+    writeFileSync(join(workdir, "new-work.ts"), "export {};\n");
+    const result = await collectCompletionResiduals({
+      workdir,
+      repoExpected: true,
+      baselineUntrackedPaths: ["pre-existing.txt"],
+    });
+    expect(result.status).toBe("residuals");
+    const residual = result.residuals.find(
+      (row) => row.kind === "uncommitted_changes",
+    );
+    expect(residual?.items).toEqual(["?? new-work.ts"]);
+  });
+
+  it("exempts a wholly-untracked directory via its collapsed porcelain path", async () => {
+    const { workdir } = makeRepo();
+    mkdirSync(join(workdir, "notes"));
+    writeFileSync(join(workdir, "notes", "old.md"), "before spawn\n");
+    const result = await collectCompletionResiduals({
+      workdir,
+      repoExpected: true,
+      baselineUntrackedPaths: ["notes/"],
+    });
+    expect(result.status).toBe("clean");
+  });
+
+  it("still counts a baseline-untracked path the worker staged (no longer ??)", async () => {
+    const { workdir } = makeRepo();
+    writeFileSync(join(workdir, "pre-existing.txt"), "before spawn\n");
+    git(workdir, "add", "pre-existing.txt");
+    const result = await collectCompletionResiduals({
+      workdir,
+      repoExpected: true,
+      baselineUntrackedPaths: ["pre-existing.txt"],
     });
     expect(result.status).toBe("residuals");
   });

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -133,7 +133,11 @@ import {
   type SpawnResult,
   TERMINAL_SESSION_STATUSES,
 } from "./types.js";
-import { captureBaselineDirty, captureBaselineSha } from "./workspace-diff.js";
+import {
+  captureBaselineDirty,
+  captureBaselineSha,
+  captureBaselineUntracked,
+} from "./workspace-diff.js";
 import {
   getSharedWorkspaceRegistry,
   resolveDiskBudgetConfig,
@@ -1762,6 +1766,7 @@ export class AcpService extends Service {
       // own edit/write tool-call paths.
       const baselineSha = await captureBaselineSha(workdir);
       const baselineDirty = await captureBaselineDirty(workdir);
+      const baselineUntracked = await captureBaselineUntracked(workdir);
 
       // Give each concurrent ACP session its own copied git index so sequential
       // commits in the SAME worktree never drop another session's staged tree.
@@ -1839,6 +1844,9 @@ export class AcpService extends Service {
         ...(baselineSha ? { codingBaselineSha: baselineSha } : {}),
         ...(baselineSha && baselineDirty.length > 0
           ? { codingBaselineDirty: baselineDirty }
+          : {}),
+        ...(baselineSha && baselineUntracked.length > 0
+          ? { codingBaselineUntracked: baselineUntracked }
           : {}),
         ...(gitIndexIsolation?.metadata ?? {}),
         ...(resolvedAccount ? { account: resolvedAccount.meta } : {}),

--- a/plugins/plugin-agent-orchestrator/src/services/completion-residuals.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/completion-residuals.ts
@@ -129,8 +129,19 @@ export interface CompletionResidualsInput {
    * `codingBaselineDirty`, captured by `AcpService.spawnSession` as
    * `git diff --name-only HEAD`). The uncommitted-changes leg subtracts them:
    * pre-existing churn was not produced by this run. Tracked modifications
-   * only — untracked paths are never baseline-exempt. */
+   * only — untracked exemptions come from `baselineUntrackedPaths`. */
   baselineDirtyPaths?: readonly string[];
+  /** Untracked paths already present when the reporting session spawned
+   * (session metadata `codingBaselineUntracked`, captured by
+   * `AcpService.spawnSession` from `git status --porcelain` `??` lines). A
+   * lived-in workdir (a home-dir cwd, a shared checkout) carries untracked
+   * files no sub-agent created; without this baseline they read as this run's
+   * leftover work and block every completion there forever. Only paths present
+   * at spawn are exempt — an untracked path that APPEARS after spawn is
+   * genuinely new work and still counts. Caveat: git collapses a
+   * wholly-untracked directory to one `dir/` line, so new files inside a
+   * directory that was already untracked at spawn ride its exemption. */
+  baselineUntrackedPaths?: readonly string[];
   /** True when the session ran in a SHARED, route-mapped app checkout
    * (`TASK_AGENT_WORKDIR_ROUTES`) rather than a task-provisioned workspace.
    * A shared checkout carries dirt and unpushed commits from before the run
@@ -209,8 +220,8 @@ function ownedArtifactsByPath(
 /** Whether a porcelain line names only paths that were ALREADY dirty when the
  * session spawned. The spawn baseline (`codingBaselineDirty`) records tracked
  * modifications only (`git diff --name-only HEAD`), so untracked (`??`) lines
- * never match — a path untracked at completion is genuinely new work. A rename
- * line is exempt only when BOTH sides were baseline-dirty. */
+ * never match — those are judged against the untracked baseline instead. A
+ * rename line is exempt only when BOTH sides were baseline-dirty. */
 function isBaselineDirtyLine(
   line: string,
   baselineDirtyPaths: ReadonlySet<string>,
@@ -220,6 +231,22 @@ function isBaselineDirtyLine(
   const paths = porcelainPaths(line);
   return (
     paths.length > 0 && paths.every((path) => baselineDirtyPaths.has(path))
+  );
+}
+
+/** Whether an untracked (`??`) porcelain line names only paths that were
+ * already untracked when the session spawned (see `baselineUntrackedPaths`).
+ * Non-`??` lines never match: a baseline-untracked path that became TRACKED
+ * dirty (the worker staged or committed over it) is this run's work. */
+function isBaselineUntrackedLine(
+  line: string,
+  baselineUntrackedPaths: ReadonlySet<string>,
+): boolean {
+  if (baselineUntrackedPaths.size === 0) return false;
+  if (!line.startsWith("?? ")) return false;
+  const paths = porcelainPaths(line);
+  return (
+    paths.length > 0 && paths.every((path) => baselineUntrackedPaths.has(path))
   );
 }
 
@@ -395,6 +422,11 @@ export async function collectCompletionResiduals(
         .map((path) => path.trim())
         .filter((path) => path.length > 0),
     );
+    const baselineUntrackedPaths = new Set(
+      (input.baselineUntrackedPaths ?? [])
+        .map((path) => path.trim())
+        .filter((path) => path.length > 0),
+    );
     const dirty = status.stdout
       .split("\n")
       .map((line) => line.trimEnd())
@@ -407,7 +439,8 @@ export async function collectCompletionResiduals(
             orchestratorOwnedArtifacts,
           ),
       )
-      .filter((line) => !isBaselineDirtyLine(line, baselineDirtyPaths));
+      .filter((line) => !isBaselineDirtyLine(line, baselineDirtyPaths))
+      .filter((line) => !isBaselineUntrackedLine(line, baselineUntrackedPaths));
     if (dirty.length > 0) {
       residuals.push({
         kind: "uncommitted_changes",

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -708,8 +708,9 @@ export function residualsOrchestratorOwnedArtifacts(
 /** Spawn-time residuals context, parsed structurally from the reporting
  * session's metadata — every key is orchestrator-stamped at spawn
  * (`AcpService.spawnSession` / the TASKS spawn path), never worker-writable.
- * `codingBaselineDirty` (tracked files already dirty at spawn) becomes the
- * gate's pre-existing-churn baseline; a `workdirRouteId` on a NON-isolated
+ * `codingBaselineDirty` (tracked files already dirty at spawn) and
+ * `codingBaselineUntracked` (untracked paths already present at spawn) become
+ * the gate's pre-existing-churn baselines; a `workdirRouteId` on a NON-isolated
  * session marks a shared route-mapped app checkout
  * (`TASK_AGENT_WORKDIR_ROUTES`, e.g. agent-home) whose git state is shared
  * across tasks and must not block every completion there. Absent/foreign
@@ -717,11 +718,19 @@ export function residualsOrchestratorOwnedArtifacts(
  * direct unit coverage. */
 export function residualsSpawnBaseline(
   session: Pick<OrchestratorTaskSession, "metadata"> | undefined,
-): Pick<CompletionResidualsInput, "baselineDirtyPaths" | "sharedRouteWorkdir"> {
+): Pick<
+  CompletionResidualsInput,
+  "baselineDirtyPaths" | "baselineUntrackedPaths" | "sharedRouteWorkdir"
+> {
   const meta = session?.metadata;
   if (!isRecord(meta)) return {};
   const baselineDirtyPaths = Array.isArray(meta.codingBaselineDirty)
     ? meta.codingBaselineDirty.filter(
+        (path): path is string => typeof path === "string" && path.length > 0,
+      )
+    : [];
+  const baselineUntrackedPaths = Array.isArray(meta.codingBaselineUntracked)
+    ? meta.codingBaselineUntracked.filter(
         (path): path is string => typeof path === "string" && path.length > 0,
       )
     : [];
@@ -731,6 +740,7 @@ export function residualsSpawnBaseline(
     meta[ACP_METADATA_ISOLATED_WORKDIR] !== true;
   return {
     ...(baselineDirtyPaths.length > 0 ? { baselineDirtyPaths } : {}),
+    ...(baselineUntrackedPaths.length > 0 ? { baselineUntrackedPaths } : {}),
     ...(sharedRouteWorkdir ? { sharedRouteWorkdir: true } : {}),
   };
 }

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts
@@ -159,6 +159,25 @@ export async function captureBaselineDirty(workdir: string): Promise<string[]> {
 }
 
 /**
+ * Untracked paths already present in the workspace at spawn time, in the same
+ * collapsed representation `git status --porcelain` reports them (`dir/` for a
+ * wholly-untracked directory). A lived-in workdir (a home-dir cwd, a shared
+ * checkout) carries untracked files no sub-agent created; without this
+ * baseline the completion-residuals gate counts them as this run's leftover
+ * work and blocks every completion there forever.
+ */
+export async function captureBaselineUntracked(
+  workdir: string,
+): Promise<string[]> {
+  if (!(await isWorkTree(workdir))) return [];
+  return ((await git(workdir, ["status", "--porcelain"])) ?? "")
+    .split("\n")
+    .filter((line) => line.startsWith("?? "))
+    .map((line) => line.slice(3).trim())
+    .filter((line) => line.length > 0);
+}
+
+/**
  * Parse `git diff --name-status` output into the set of affected paths. Renames
  * appear as `R100\told\tnew` — the post-rename path is what changed, so take
  * the last tab-separated field for every status.


### PR DESCRIPTION
Upstreamed from the live test box (watchtower's resync-h carries; authorship preserved; handoff at HQ #18309).

**Live receipt (box)**: task 54eb69f7 — 31 pre-existing untracked paths in a lived-in workdir false-blocked the completion residuals gate and the task was reaped as interrupted. Post-fix, untracked paths present AT SPAWN are baselined and only NEW residuals gate completion.

**Local verification**: orchestrator unit lane on the carried branch: 1959/1961 with the 2 failures being the pre-existing `does NOT falsely promote the minted task…(real service)` env-dependent test, which fails identically on clean develop in this environment (verified) — zero new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)