### PR TITLE
fix(security): pin host execution to validated boot PATH

### DIFF
--- a/packages/agent/src/bin.ts
+++ b/packages/agent/src/bin.ts
@@ -17,6 +17,11 @@ import { homedir as _earlyHomedir } from "node:os";
 // `./cli/index.ts`, so this adds no new module to the boot graph; before the
 // alias table is seeded these fall back to the raw ELIZA_ value.
 import { isAndroidMobile, readAliasedEnv } from "@elizaos/shared";
+import { captureHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
+
+// Establish the host executable-search authority before the CLI dynamically
+// imports runtime configuration or any plugin code.
+captureHostExecutionBaseline();
 
 // Enable Node 22.8+'s persistent V8 compile cache before any heavy import so
 // the 2nd+ cold boot skips recompiling the ~70k LOC of transpiled plugin
@@ -58,7 +63,6 @@ import { isAndroidMobile, readAliasedEnv } from "@elizaos/shared";
   }
 })();
 
-import { runAutonomousCli } from "./cli/index.ts";
 import { configureMobileDnsIfNeeded } from "./runtime/mobile-dns.ts";
 
 // Early diagnostic logger for Android: captures errors before the fs shim runs.
@@ -144,6 +148,7 @@ async function bootstrapMobileEntrypoint(): Promise<void> {
   }
 
   _binDebugLog("[bin.ts] pre-runAutonomousCli");
+  const { runAutonomousCli } = await import("./cli/index.ts");
   await runAutonomousCli();
 }
 

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -21,6 +21,7 @@ import path from "node:path";
 import process from "node:process";
 import * as readline from "node:readline";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { captureHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
 import { runBootHooks } from "./boot-hooks.ts";
 import {
   type BootContext,
@@ -3985,6 +3986,9 @@ function ensureChatLogListenerAttached(): void {
 export async function startEliza(
   opts?: StartElizaOptions,
 ): Promise<AgentRuntime | undefined> {
+  // Programmatic hosts bypass bin.ts, so establish the same one-shot authority
+  // before config loading and static plugin registration here as well.
+  captureHostExecutionBaseline();
   opts?.abortSignal?.throwIfAborted();
   const bootContext =
     opts?.bootContext ?? createBootContext({ observePhase: opts?.onBootPhase });

--- a/packages/agent/src/services/sandbox-engine-env.test.ts
+++ b/packages/agent/src/services/sandbox-engine-env.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Verifies the real Docker/Apple Container argv contract without invoking a
+ * container daemon. Both engines share this builder, so environment parity is
+ * tested at the process boundary rather than through an engine mock.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildContainerExecArgs } from "./sandbox-engine.ts";
+
+describe("container exec environment forwarding", () => {
+  it("forwards explicit environment values for Docker and Apple Container", () => {
+    expect(
+      buildContainerExecArgs({
+        containerId: "sandbox-1",
+        command: "git status",
+        workdir: "/workspace",
+        env: { SAFE: "yes", EMPTY: "" },
+      }),
+    ).toEqual([
+      "exec",
+      "-w",
+      "/workspace",
+      "-e",
+      "SAFE=yes",
+      "-e",
+      "EMPTY=",
+      "sandbox-1",
+      "git",
+      "status",
+    ]);
+  });
+
+  it("does not add host environment flags when no overlay is supplied", () => {
+    expect(
+      buildContainerExecArgs({
+        containerId: "sandbox-1",
+        command: "env",
+      }),
+    ).toEqual(["exec", "sandbox-1", "env"]);
+  });
+});

--- a/packages/agent/src/services/sandbox-engine.ts
+++ b/packages/agent/src/services/sandbox-engine.ts
@@ -2,7 +2,11 @@
 
 import { execFileSync, spawn } from "node:child_process";
 import { arch, platform } from "node:os";
-import { logger } from "@elizaos/core";
+import { logger, sanitizeSpawnEnv } from "@elizaos/core";
+import {
+  applyHostExecutionBaseline,
+  resolveHostExecutable,
+} from "@elizaos/shared/host-execution-env";
 
 export type SandboxEngineType = "docker" | "apple-container" | "auto";
 
@@ -46,6 +50,10 @@ type ExecCommandResult = {
   stdin?: string;
 };
 
+function hostEngineEnv(): NodeJS.ProcessEnv {
+  return applyHostExecutionBaseline(sanitizeSpawnEnv(process.env));
+}
+
 function appendMountArgs(
   args: string[],
   mounts: Array<{ host: string; container: string; readonly: boolean }>,
@@ -77,6 +85,7 @@ function listContainersFromBinary(binary: string, prefix: string): string[] {
         encoding: "utf-8",
         timeout: 10_000,
         stdio: ["ignore", "pipe", "ignore"],
+        env: hostEngineEnv(),
       },
     );
     return output
@@ -94,6 +103,7 @@ function checkHealthWithBinary(binary: string, id: string): Promise<boolean> {
       encoding: "utf-8",
       timeout: 5000,
       stdio: ["ignore", "pipe", "ignore"],
+      env: hostEngineEnv(),
     }).trim();
     return Promise.resolve(result === "healthy");
   } catch {
@@ -139,7 +149,10 @@ async function runExecInContainer(
   const { binary, args, timeoutMs, stdin } = opts;
   const start = Date.now();
   return new Promise<ContainerExecResult>((resolve) => {
-    const proc = spawn(binary, args, { stdio: ["pipe", "pipe", "pipe"] });
+    const proc = spawn(binary, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: hostEngineEnv(),
+    });
 
     let stdout = "";
     let stderr = "";
@@ -305,6 +318,15 @@ function parseContainerCommand(command: string): string[] {
   return args;
 }
 
+export function buildContainerExecArgs(opts: ContainerExecOptions): string[] {
+  const args = ["exec"];
+  if (opts.workdir) args.push("-w", opts.workdir);
+  if (opts.env) appendEnvArgs(args, opts.env);
+  const commandArgs = parseContainerCommand(opts.command);
+  args.push(opts.containerId, ...commandArgs);
+  return args;
+}
+
 export interface EngineInfo {
   type: SandboxEngineType;
   available: boolean;
@@ -332,9 +354,25 @@ export interface ISandboxEngine {
 export class DockerEngine implements ISandboxEngine {
   readonly engineType: SandboxEngineType = "docker";
 
+  private binary(): string | undefined {
+    return resolveHostExecutable("docker");
+  }
+
+  private requiredBinary(): string {
+    const binary = this.binary();
+    if (!binary) throw new Error("Docker executable unavailable");
+    return binary;
+  }
+
   isAvailable(): boolean {
     try {
-      execFileSync("docker", ["info"], { stdio: "ignore", timeout: 10000 });
+      const binary = this.binary();
+      if (!binary) return false;
+      execFileSync(binary, ["info"], {
+        stdio: "ignore",
+        timeout: 10000,
+        env: hostEngineEnv(),
+      });
       return true;
     } catch {
       return false;
@@ -344,9 +382,12 @@ export class DockerEngine implements ISandboxEngine {
   getInfo(): EngineInfo {
     let version = "unknown";
     try {
-      version = execFileSync("docker", ["--version"], {
+      const binary = this.binary();
+      if (!binary) throw new Error("Docker executable unavailable");
+      version = execFileSync(binary, ["--version"], {
         encoding: "utf-8",
         timeout: 5000,
+        env: hostEngineEnv(),
       }).trim();
     } catch {
       // ignore
@@ -392,9 +433,11 @@ export class DockerEngine implements ISandboxEngine {
 
     args.push(opts.image);
 
-    const output = execFileSync("docker", args, {
+    const binary = this.requiredBinary();
+    const output = execFileSync(binary, args, {
       encoding: "utf-8",
       timeout: 60000,
+      env: hostEngineEnv(),
     }).trim();
 
     return output.substring(0, 12);
@@ -403,15 +446,9 @@ export class DockerEngine implements ISandboxEngine {
   async execInContainer(
     opts: ContainerExecOptions,
   ): Promise<ContainerExecResult> {
-    const args = ["exec"];
-    if (opts.workdir) args.push("-w", opts.workdir);
-    if (opts.env) {
-      appendEnvArgs(args, opts.env);
-    }
-    const commandArgs = parseContainerCommand(opts.command);
-    args.push(opts.containerId, ...commandArgs);
+    const args = buildContainerExecArgs(opts);
     return runExecInContainer({
-      binary: "docker",
+      binary: this.requiredBinary(),
       args,
       timeoutMs: opts.timeoutMs,
       stdin: opts.stdin,
@@ -420,9 +457,10 @@ export class DockerEngine implements ISandboxEngine {
 
   async stopContainer(id: string): Promise<void> {
     try {
-      execFileSync("docker", ["stop", id], {
+      execFileSync(this.requiredBinary(), ["stop", id], {
         timeout: 15000,
         stdio: "ignore",
+        env: hostEngineEnv(),
       });
     } catch (error) {
       // error-policy:J6 teardown continues so callers can remove remaining resources.
@@ -432,9 +470,10 @@ export class DockerEngine implements ISandboxEngine {
 
   async removeContainer(id: string): Promise<void> {
     try {
-      execFileSync("docker", ["rm", "-f", id], {
+      execFileSync(this.requiredBinary(), ["rm", "-f", id], {
         timeout: 10000,
         stdio: "ignore",
+        env: hostEngineEnv(),
       });
     } catch (error) {
       // error-policy:J6 teardown continues so callers can remove remaining resources.
@@ -445,12 +484,13 @@ export class DockerEngine implements ISandboxEngine {
   isContainerRunning(id: string): boolean {
     try {
       const result = execFileSync(
-        "docker",
+        this.requiredBinary(),
         ["inspect", "-f", "{{.State.Running}}", id],
         {
           encoding: "utf-8",
           timeout: 5000,
           stdio: ["ignore", "pipe", "ignore"],
+          env: hostEngineEnv(),
         },
       ).trim();
       return result === "true";
@@ -461,9 +501,10 @@ export class DockerEngine implements ISandboxEngine {
 
   imageExists(image: string): boolean {
     try {
-      execFileSync("docker", ["image", "inspect", image], {
+      execFileSync(this.requiredBinary(), ["image", "inspect", image], {
         stdio: "ignore",
         timeout: 10000,
+        env: hostEngineEnv(),
       });
       return true;
     } catch {
@@ -472,26 +513,30 @@ export class DockerEngine implements ISandboxEngine {
   }
 
   async pullImage(image: string): Promise<void> {
-    execFileSync("docker", ["pull", image], {
+    execFileSync(this.requiredBinary(), ["pull", image], {
       stdio: ["ignore", "pipe", "pipe"],
       timeout: 300000,
+      env: hostEngineEnv(),
     });
   }
 
   listContainers(prefix: string): string[] {
-    return listContainersFromBinary("docker", prefix);
+    const binary = this.binary();
+    return binary ? listContainersFromBinary(binary, prefix) : [];
   }
 
   async healthCheck(id: string): Promise<boolean> {
-    return checkHealthWithBinary("docker", id);
+    const binary = this.binary();
+    return binary ? checkHealthWithBinary(binary, id) : false;
   }
 
   private getDockerContext(): string {
     try {
-      return execFileSync("docker", ["context", "show"], {
+      return execFileSync(this.requiredBinary(), ["context", "show"], {
         encoding: "utf-8",
         timeout: 5000,
         stdio: ["ignore", "pipe", "ignore"],
+        env: hostEngineEnv(),
       }).trim();
     } catch {
       return "default";
@@ -502,11 +547,24 @@ export class DockerEngine implements ISandboxEngine {
 export class AppleContainerEngine implements ISandboxEngine {
   readonly engineType: SandboxEngineType = "apple-container";
 
+  private binary(): string | undefined {
+    return resolveHostExecutable("container");
+  }
+
+  private requiredBinary(): string {
+    const binary = this.binary();
+    if (!binary) throw new Error("Apple Container executable unavailable");
+    return binary;
+  }
+
   isAvailable(): boolean {
     try {
-      execFileSync("container", ["--version"], {
+      const binary = this.binary();
+      if (!binary) return false;
+      execFileSync(binary, ["--version"], {
         stdio: "ignore",
         timeout: 5000,
+        env: hostEngineEnv(),
       });
       return true;
     } catch (error) {
@@ -514,9 +572,12 @@ export class AppleContainerEngine implements ISandboxEngine {
         return false;
       }
       try {
-        execFileSync("container", ["help"], {
+        const binary = this.binary();
+        if (!binary) return false;
+        execFileSync(binary, ["help"], {
           stdio: "ignore",
           timeout: 5000,
+          env: hostEngineEnv(),
         });
         return true;
       } catch {
@@ -528,9 +589,12 @@ export class AppleContainerEngine implements ISandboxEngine {
   getInfo(): EngineInfo {
     let version = "unknown";
     try {
-      version = execFileSync("container", ["--version"], {
+      const binary = this.binary();
+      if (!binary) throw new Error("Apple Container executable unavailable");
+      version = execFileSync(binary, ["--version"], {
         encoding: "utf-8",
         timeout: 5000,
+        env: hostEngineEnv(),
       }).trim();
     } catch {
       // ignore
@@ -561,9 +625,15 @@ export class AppleContainerEngine implements ISandboxEngine {
     // Spawn as a background process (non-blocking) instead of execSync.
     // Apple Container doesn't support `-d`; we use spawn with detached + unref.
     return new Promise<string>((resolve, reject) => {
-      const proc = spawn("container", args, {
+      const binary = this.binary();
+      if (!binary) {
+        reject(new Error("Apple Container executable unavailable"));
+        return;
+      }
+      const proc = spawn(binary, args, {
         stdio: ["pipe", "pipe", "pipe"],
         detached: true,
+        env: hostEngineEnv(),
       });
 
       // Collect initial output for error detection
@@ -602,12 +672,9 @@ export class AppleContainerEngine implements ISandboxEngine {
   async execInContainer(
     opts: ContainerExecOptions,
   ): Promise<ContainerExecResult> {
-    const args = ["exec"];
-    if (opts.workdir) args.push("-w", opts.workdir);
-    const commandArgs = parseContainerCommand(opts.command);
-    args.push(opts.containerId, ...commandArgs);
+    const args = buildContainerExecArgs(opts);
     return runExecInContainer({
-      binary: "container",
+      binary: this.requiredBinary(),
       args,
       timeoutMs: opts.timeoutMs,
       stdin: opts.stdin,
@@ -616,9 +683,10 @@ export class AppleContainerEngine implements ISandboxEngine {
 
   async stopContainer(id: string): Promise<void> {
     try {
-      execFileSync("container", ["stop", id], {
+      execFileSync(this.requiredBinary(), ["stop", id], {
         timeout: 15000,
         stdio: "ignore",
+        env: hostEngineEnv(),
       });
     } catch (error) {
       // error-policy:J6 teardown continues so callers can remove remaining resources.
@@ -632,9 +700,10 @@ export class AppleContainerEngine implements ISandboxEngine {
   async removeContainer(id: string): Promise<void> {
     // Apple Container uses --rm by default; explicit remove for safety
     try {
-      execFileSync("container", ["rm", id], {
+      execFileSync(this.requiredBinary(), ["rm", id], {
         timeout: 10000,
         stdio: "ignore",
+        env: hostEngineEnv(),
       });
     } catch (error) {
       // error-policy:J6 teardown continues so callers can remove remaining resources.
@@ -647,9 +716,10 @@ export class AppleContainerEngine implements ISandboxEngine {
 
   isContainerRunning(id: string): boolean {
     try {
-      execFileSync("container", ["inspect", id], {
+      execFileSync(this.requiredBinary(), ["inspect", id], {
         stdio: "ignore",
         timeout: 5000,
+        env: hostEngineEnv(),
       });
       return true;
     } catch {
@@ -659,9 +729,10 @@ export class AppleContainerEngine implements ISandboxEngine {
 
   imageExists(image: string): boolean {
     try {
-      execFileSync("container", ["image", "inspect", image], {
+      execFileSync(this.requiredBinary(), ["image", "inspect", image], {
         stdio: "ignore",
         timeout: 10000,
+        env: hostEngineEnv(),
       });
       return true;
     } catch {
@@ -670,18 +741,21 @@ export class AppleContainerEngine implements ISandboxEngine {
   }
 
   async pullImage(image: string): Promise<void> {
-    execFileSync("container", ["pull", image], {
+    execFileSync(this.requiredBinary(), ["pull", image], {
       stdio: ["ignore", "pipe", "pipe"],
       timeout: 300000,
+      env: hostEngineEnv(),
     });
   }
 
   listContainers(prefix: string): string[] {
-    return listContainersFromBinary("container", prefix);
+    const binary = this.binary();
+    return binary ? listContainersFromBinary(binary, prefix) : [];
   }
 
   async healthCheck(id: string): Promise<boolean> {
-    return checkHealthWithBinary("container", id);
+    const binary = this.binary();
+    return binary ? checkHealthWithBinary(binary, id) : false;
   }
 }
 

--- a/packages/agent/src/services/shell-execution-router.test.ts
+++ b/packages/agent/src/services/shell-execution-router.test.ts
@@ -109,6 +109,23 @@ describe("runShell", () => {
     expect(result.stdout).toBe(getHostExecutionBaseline().path);
   });
 
+  it("rejects an executable absolute path outside the boot PATH authority", async () => {
+    if (process.platform === "win32") return;
+    const executable = path.join(tmpDir, "outside-path");
+    await fsp.writeFile(executable, "#!/bin/sh\nexit 0\n");
+    await fsp.chmod(executable, 0o755);
+
+    const result = await runShell({
+      command: executable,
+      args: [],
+      toolName: "test:absolute-path-authority",
+      timeoutMs: 5_000,
+    });
+
+    expect(result.exitCode).toBe(-1);
+    expect(result.stderr).toContain("outside the boot PATH authority");
+  });
+
   it("strips dangerous spawn env vars from the host child, passes benign ones", async () => {
     const result = await runShell({
       command: process.execPath,

--- a/packages/agent/src/services/shell-execution-router.test.ts
+++ b/packages/agent/src/services/shell-execution-router.test.ts
@@ -7,6 +7,10 @@
 import fsp from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import {
+  captureHostExecutionBaseline,
+  getHostExecutionBaseline,
+} from "@elizaos/shared/host-execution-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetShellRouterBrokerForTests,
@@ -19,6 +23,7 @@ const MODE_ENV_KEYS = [
   "RUNTIME_MODE",
   "LOCAL_RUNTIME_MODE",
   "ELIZA_PLATFORM",
+  "PATH",
 ] as const;
 
 describe("runShell", () => {
@@ -29,6 +34,7 @@ describe("runShell", () => {
   let oldStateDir: string | undefined;
 
   beforeEach(async () => {
+    captureHostExecutionBaseline();
     tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "agent-shell-router-"));
     oldStateDir = process.env.ELIZA_STATE_DIR;
     process.env.ELIZA_STATE_DIR = tmpDir;
@@ -86,6 +92,21 @@ describe("runShell", () => {
     });
     expect(result.sandbox).toBe("host");
     expect(result.stdout).toBe("hello\n");
+  });
+
+  it("resolves a real bare host command only through the captured PATH", async () => {
+    const executableName = path.basename(process.execPath);
+    process.env.PATH = "/tmp/runtime-controlled-bin";
+
+    const result = await runShell({
+      command: executableName,
+      args: ["-e", "process.stdout.write(process.env.PATH ?? '')"],
+      toolName: "test:boot-path",
+      timeoutMs: 5_000,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe(getHostExecutionBaseline().path);
   });
 
   it("strips dangerous spawn env vars from the host child, passes benign ones", async () => {
@@ -195,6 +216,45 @@ describe("runShell", () => {
     expect(result.sandbox).toBe("docker");
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe("ok");
+  });
+
+  it("local-safe preserves container-native env with and without a hostile host-style overlay", async () => {
+    process.env.ELIZA_RUNTIME_MODE = "local-safe";
+    const run = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      stdout: "ok",
+      stderr: "",
+      durationMs: 1,
+      executedInSandbox: true,
+    });
+    const fakeManager = { run, engineType: "docker" };
+
+    await runShell(
+      {
+        command: "env",
+        args: [],
+        toolName: "test:safe-native-env",
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: deliberate fake for unit test
+      { sandboxManager: fakeManager as any },
+    );
+    await runShell(
+      {
+        command: "env",
+        args: [],
+        env: {
+          PATH: "/host/bin",
+          HOME: "/host/home",
+          SHELL: "/host/shell",
+        },
+        toolName: "test:safe-host-env",
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: deliberate fake for unit test
+      { sandboxManager: fakeManager as any },
+    );
+
+    expect(run.mock.calls[0]?.[0].env).toBeUndefined();
+    expect(run.mock.calls[1]?.[0].env).toEqual({});
   });
 
   it("local-safe routes through SandboxManager on Windows when a backend is available", async () => {

--- a/packages/agent/src/services/shell-execution-router.ts
+++ b/packages/agent/src/services/shell-execution-router.ts
@@ -26,6 +26,10 @@ import {
   type RuntimeExecutionMode,
   resolveRuntimeExecutionMode,
 } from "@elizaos/shared";
+import {
+  applyHostExecutionBaseline,
+  resolveHostExecutable,
+} from "@elizaos/shared/host-execution-env";
 import { CapabilityBroker } from "./capability-broker.ts";
 import type { SandboxManager } from "./sandbox-manager.ts";
 import { isVfsUri, runVfsBuiltinShell } from "./vfs-builtin-shell.ts";
@@ -148,6 +152,10 @@ function sanitizeChildEnv(env: Record<string, string>): Record<string, string> {
   return out;
 }
 
+function hostChildEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return applyHostExecutionBaseline(sanitizeSpawnEnv(env));
+}
+
 async function runOnHost(req: ShellRequest): Promise<ShellResult> {
   const start = Date.now();
   return await new Promise<ShellResult>((resolve) => {
@@ -161,9 +169,20 @@ async function runOnHost(req: ShellRequest): Promise<ShellResult> {
     // trust boundary.
     const mergedEnv =
       req.env != null ? { ...process.env, ...req.env } : { ...process.env };
-    const child = spawn(req.command, req.args.slice(), {
+    const executable = resolveHostExecutable(req.command);
+    if (!executable) {
+      resolve({
+        exitCode: -1,
+        stdout: "",
+        stderr: `[shell-router] executable is outside the boot PATH authority or unavailable: ${req.command}`,
+        durationMs: Date.now() - start,
+        sandbox: "host",
+      });
+      return;
+    }
+    const child = spawn(executable, req.args.slice(), {
       cwd: req.cwd,
-      env: sanitizeChildEnv(mergedEnv as Record<string, string>),
+      env: hostChildEnv(mergedEnv),
       detached: useDetachedProcessGroup,
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -213,6 +213,16 @@
       "import": "./dist/restart.js",
       "default": "./dist/restart.js"
     },
+    "./host-execution-env": {
+      "types": "./dist/host-execution-env.d.ts",
+      "eliza-source": {
+        "types": "./src/host-execution-env.ts",
+        "import": "./src/host-execution-env.ts",
+        "default": "./src/host-execution-env.ts"
+      },
+      "import": "./dist/host-execution-env.js",
+      "default": "./dist/host-execution-env.js"
+    },
     "./sandbox-registry": {
       "types": "./dist/sandbox-registry.d.ts",
       "eliza-source": {

--- a/packages/shared/src/host-execution-env.fixture.ts
+++ b/packages/shared/src/host-execution-env.fixture.ts
@@ -1,0 +1,10 @@
+/** Fresh-process harness for proving that post-capture PATH writes do not replace boot authority. */
+
+import {
+  captureHostExecutionBaseline,
+  getHostExecutionBaseline,
+} from "./host-execution-env.ts";
+
+captureHostExecutionBaseline();
+process.env.PATH = process.env.ELIZA_TEST_MUTATED_PATH;
+process.stdout.write(JSON.stringify(getHostExecutionBaseline()));

--- a/packages/shared/src/host-execution-env.test.ts
+++ b/packages/shared/src/host-execution-env.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Exercises the explicit host executable authority with deterministic,
+ * process-local boot captures; no runtime configuration or plugin mocks are
+ * involved.
+ */
+
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  applyHostExecutionBaseline,
+  captureHostExecutionBaseline,
+  createHostExecutionBaseline,
+  getHostExecutionBaseline,
+  validateHostExecutionPath,
+} from "./host-execution-env.ts";
+
+describe("host execution boot baseline", () => {
+  it("captures before a later PATH write in a fresh process", () => {
+    const bootPath = process.env.PATH;
+    expect(bootPath).toBeTruthy();
+    const fixture = fileURLToPath(
+      new URL("./host-execution-env.fixture.ts", import.meta.url),
+    );
+    const stdout = execFileSync(process.execPath, [fixture], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: bootPath,
+        ELIZA_TEST_MUTATED_PATH: "/tmp/plugin-controlled-bin",
+      },
+    });
+    expect(JSON.parse(stdout)).toEqual({ path: bootPath });
+  });
+
+  it("keeps a fresh process capture after later environment mutation", () => {
+    const bootPath =
+      path.delimiter === ";" ? "C:\\Windows\\System32" : "/usr/bin:/bin";
+    captureHostExecutionBaseline({ PATH: bootPath });
+    const later = captureHostExecutionBaseline({ PATH: "/tmp/plugin-bin" });
+    expect(later.path).toBe(bootPath);
+    expect(getHostExecutionBaseline().path).toBe(bootPath);
+  });
+
+  it("fails closed for absent, relative, empty-entry, and NUL paths", () => {
+    expect(validateHostExecutionPath(undefined)).toBeUndefined();
+    expect(validateHostExecutionPath("relative/bin")).toBeUndefined();
+    expect(validateHostExecutionPath(`/bin${path.delimiter}`)).toBeUndefined();
+    expect(validateHostExecutionPath("/bin\0/tmp")).toBeUndefined();
+  });
+
+  it("accepts the Windows Path casing but rejects ambiguous case variants", () => {
+    expect(
+      createHostExecutionBaseline({ Path: "C:\\Windows\\System32" }, "win32")
+        .path,
+    ).toBe("C:\\Windows\\System32");
+    expect(
+      createHostExecutionBaseline(
+        { PATH: "C:\\Windows", Path: "C:\\Tools" },
+        "win32",
+      ).path,
+    ).toBeUndefined();
+  });
+
+  it("adds only PATH to an already-sanitized environment", () => {
+    const bootPath = getHostExecutionBaseline().path;
+    expect(
+      applyHostExecutionBaseline({ Path: "/tmp/late", SAFE: "yes" }),
+    ).toEqual({ PATH: bootPath, SAFE: "yes" });
+  });
+});

--- a/packages/shared/src/host-execution-env.test.ts
+++ b/packages/shared/src/host-execution-env.test.ts
@@ -5,6 +5,8 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -13,6 +15,7 @@ import {
   captureHostExecutionBaseline,
   createHostExecutionBaseline,
   getHostExecutionBaseline,
+  resolveHostExecutable,
   validateHostExecutionPath,
 } from "./host-execution-env.ts";
 
@@ -37,8 +40,10 @@ describe("host execution boot baseline", () => {
   it("keeps a fresh process capture after later environment mutation", () => {
     const bootPath =
       path.delimiter === ";" ? "C:\\Windows\\System32" : "/usr/bin:/bin";
-    captureHostExecutionBaseline({ PATH: bootPath });
-    const later = captureHostExecutionBaseline({ PATH: "/tmp/plugin-bin" });
+    process.env.PATH = bootPath;
+    captureHostExecutionBaseline();
+    process.env.PATH = "/tmp/plugin-bin";
+    const later = captureHostExecutionBaseline();
     expect(later.path).toBe(bootPath);
     expect(getHostExecutionBaseline().path).toBe(bootPath);
   });
@@ -68,5 +73,19 @@ describe("host execution boot baseline", () => {
     expect(
       applyHostExecutionBaseline({ Path: "/tmp/late", SAFE: "yes" }),
     ).toEqual({ PATH: bootPath, SAFE: "yes" });
+  });
+
+  it("rejects executable paths outside the captured PATH directories", () => {
+    if (process.platform === "win32") return;
+    const tempDir = mkdtempSync(path.join(os.tmpdir(), "host-authority-"));
+    const executable = path.join(tempDir, "outside-path");
+    try {
+      writeFileSync(executable, "#!/bin/sh\nexit 0\n");
+      chmodSync(executable, 0o755);
+      expect(resolveHostExecutable(executable)).toBeUndefined();
+      expect(resolveHostExecutable("/bin/sh")).toBe("/bin/sh");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/shared/src/host-execution-env.ts
+++ b/packages/shared/src/host-execution-env.ts
@@ -55,12 +55,9 @@ export function createHostExecutionBaseline(
 }
 
 /** Capture once. Later calls cannot replace the boot authority. */
-export function captureHostExecutionBaseline(
-  env: NodeJS.ProcessEnv = process.env,
-  platform: NodeJS.Platform = process.platform,
-): HostExecutionBaseline {
+export function captureHostExecutionBaseline(): HostExecutionBaseline {
   if (capturedBaseline) return capturedBaseline;
-  capturedBaseline = createHostExecutionBaseline(env, platform);
+  capturedBaseline = createHostExecutionBaseline(process.env);
   return capturedBaseline;
 }
 
@@ -88,11 +85,21 @@ export function resolveHostExecutable(nameOrPath: string): string | undefined {
   const trimmed = nameOrPath.trim();
   if (!trimmed || trimmed.includes("\0")) return undefined;
   const candidates: string[] = [];
+  const baseline = getHostExecutionBaseline();
+  const authorityDirectories =
+    baseline.path?.split(path.delimiter).map((entry) => path.resolve(entry)) ??
+    [];
   if (path.isAbsolute(trimmed)) {
-    candidates.push(trimmed);
+    const candidate = path.resolve(trimmed);
+    const candidateDirectory = path.dirname(candidate);
+    const isAuthorized = authorityDirectories.some((directory) =>
+      process.platform === "win32"
+        ? directory.toLowerCase() === candidateDirectory.toLowerCase()
+        : directory === candidateDirectory,
+    );
+    if (isAuthorized) candidates.push(candidate);
   } else if (!trimmed.includes("/") && !trimmed.includes("\\")) {
-    const baseline = getHostExecutionBaseline();
-    for (const entry of baseline.path?.split(path.delimiter) ?? []) {
+    for (const entry of authorityDirectories) {
       candidates.push(path.join(entry, trimmed));
       if (process.platform === "win32" && path.extname(trimmed) === "") {
         candidates.push(path.join(entry, `${trimmed}.exe`));

--- a/packages/shared/src/host-execution-env.ts
+++ b/packages/shared/src/host-execution-env.ts
@@ -1,0 +1,112 @@
+/**
+ * Owns the process-wide executable-search authority captured by a Node host
+ * before runtime configuration or plugins can mutate `process.env`. Host
+ * process launchers consume this narrow PATH baseline; sandbox launchers do
+ * not, because containers must retain their image-native environment.
+ */
+
+import { accessSync, constants } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+export interface HostExecutionBaseline {
+  readonly path?: string;
+}
+
+let capturedBaseline: HostExecutionBaseline | undefined;
+
+function pathValueForPlatform(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): string | undefined {
+  if (platform !== "win32") return env.PATH;
+  const entries = Object.entries(env).filter(
+    ([key, value]) => key.toUpperCase() === "PATH" && value !== undefined,
+  );
+  return entries.length === 1 ? entries[0]?.[1] : undefined;
+}
+
+export function validateHostExecutionPath(
+  value: string | undefined,
+  platform: NodeJS.Platform = process.platform,
+): string | undefined {
+  if (!value || value.includes("\0")) return undefined;
+  const pathApi = platform === "win32" ? path.win32 : path.posix;
+  const entries = value.split(pathApi.delimiter);
+  if (
+    entries.length === 0 ||
+    entries.some((entry) => entry.length === 0 || !pathApi.isAbsolute(entry))
+  ) {
+    return undefined;
+  }
+  return value;
+}
+
+export function createHostExecutionBaseline(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform = process.platform,
+): HostExecutionBaseline {
+  return Object.freeze({
+    path: validateHostExecutionPath(
+      pathValueForPlatform(env, platform),
+      platform,
+    ),
+  });
+}
+
+/** Capture once. Later calls cannot replace the boot authority. */
+export function captureHostExecutionBaseline(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): HostExecutionBaseline {
+  if (capturedBaseline) return capturedBaseline;
+  capturedBaseline = createHostExecutionBaseline(env, platform);
+  return capturedBaseline;
+}
+
+export function getHostExecutionBaseline(): HostExecutionBaseline {
+  return capturedBaseline ?? Object.freeze({});
+}
+
+/**
+ * Add only the captured PATH to an already-sanitized host child environment.
+ * Case variants are removed so Windows cannot retain a second mutable value.
+ */
+export function applyHostExecutionBaseline(
+  env: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  const out: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (key.toUpperCase() !== "PATH") out[key] = value;
+  }
+  const baseline = getHostExecutionBaseline();
+  if (baseline.path) out.PATH = baseline.path;
+  return out;
+}
+
+export function resolveHostExecutable(nameOrPath: string): string | undefined {
+  const trimmed = nameOrPath.trim();
+  if (!trimmed || trimmed.includes("\0")) return undefined;
+  const candidates: string[] = [];
+  if (path.isAbsolute(trimmed)) {
+    candidates.push(trimmed);
+  } else if (!trimmed.includes("/") && !trimmed.includes("\\")) {
+    const baseline = getHostExecutionBaseline();
+    for (const entry of baseline.path?.split(path.delimiter) ?? []) {
+      candidates.push(path.join(entry, trimmed));
+      if (process.platform === "win32" && path.extname(trimmed) === "") {
+        candidates.push(path.join(entry, `${trimmed}.exe`));
+        candidates.push(path.join(entry, `${trimmed}.cmd`));
+      }
+    }
+  }
+  for (const candidate of candidates) {
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // error-policy:J3 executable probing returns an explicit absence.
+    }
+  }
+  return undefined;
+}

--- a/plugins/plugin-coding-tools/src/lib/run-shell.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/run-shell.test.ts
@@ -5,6 +5,7 @@ import {
   type IAgentRuntime,
   UnavailableCapabilityRouter,
 } from "@elizaos/core";
+import { captureHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { runShell } from "./run-shell.js";
 
@@ -14,6 +15,9 @@ const ENV_KEYS = [
   "ELIZA_RUNTIME_MODE",
   "RUNTIME_MODE",
   "LOCAL_RUNTIME_MODE",
+  "PATH",
+  "HOME",
+  "SHELL",
 ] as const;
 
 let savedEnv: Record<string, string | undefined>;
@@ -25,6 +29,7 @@ beforeEach(() => {
     process,
     "platform",
   );
+  captureHostExecutionBaseline();
 });
 
 afterEach(() => {
@@ -174,5 +179,26 @@ describe("plugin-coding-tools runShell local-safe sandbox routing", () => {
       sandbox: "docker",
       timedOut: false,
     });
+  });
+});
+
+describe("plugin-coding-tools host execution authority", () => {
+  it("uses the captured PATH without forwarding mutable PATH, HOME, or SHELL", async () => {
+    const bootPath = process.env.PATH;
+    process.env.ELIZA_RUNTIME_MODE = "local-yolo";
+    process.env.PATH = "/tmp/runtime-bin";
+    process.env.HOME = "/tmp/runtime-home";
+    process.env.SHELL = "/tmp/runtime-shell";
+
+    const result = await runShell({ getService: () => null } as IAgentRuntime, {
+      command: "printf '%s' \"$PATH|$HOME|$SHELL\"",
+      cwd: process.cwd(),
+      timeoutMs: 10_000,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.split("|")[0]).toBe(bootPath);
+    expect(result.stdout).not.toContain("/tmp/runtime-home");
+    expect(result.stdout).not.toContain("/tmp/runtime-shell");
   });
 });

--- a/plugins/plugin-coding-tools/src/lib/run-shell.ts
+++ b/plugins/plugin-coding-tools/src/lib/run-shell.ts
@@ -27,7 +27,10 @@ import {
   sanitizeSpawnEnv,
 } from "@elizaos/core";
 import { resolveRuntimeExecutionMode } from "@elizaos/shared";
-import { applyHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
+import {
+  applyHostExecutionBaseline,
+  resolveHostExecutable,
+} from "@elizaos/shared/host-execution-env";
 import {
   detectTerminalSupport,
   missingToolForCommand,
@@ -520,15 +523,7 @@ function resolveExecutableForHost(
   name: string,
   fallback: string,
 ): string | undefined {
-  const pathEntries = (process.env.PATH ?? "")
-    .split(importPath.delimiter)
-    .filter(Boolean);
-  for (const entry of pathEntries) {
-    const candidate = importPath.join(entry, name);
-    if (existsSync(candidate)) return candidate;
-  }
-  if (existsSync(fallback)) return fallback;
-  return undefined;
+  return resolveHostExecutable(name) ?? resolveHostExecutable(fallback);
 }
 
 function runOnHostWithShell(

--- a/plugins/plugin-coding-tools/src/lib/run-shell.ts
+++ b/plugins/plugin-coding-tools/src/lib/run-shell.ts
@@ -24,8 +24,10 @@ import {
   CapabilityError,
   getCapabilityRouter,
   type IAgentRuntime,
+  sanitizeSpawnEnv,
 } from "@elizaos/core";
 import { resolveRuntimeExecutionMode } from "@elizaos/shared";
+import { applyHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
 import {
   detectTerminalSupport,
   missingToolForCommand,
@@ -137,6 +139,10 @@ function toSandboxWorkdir(cwd: string): string | undefined {
 }
 
 const STREAM_CAP_CHARS = 30_000;
+
+function hostSpawnEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return applyHostExecutionBaseline(sanitizeSpawnEnv(env));
+}
 
 function shellArgsForCommand(shell: {
   command: string;
@@ -491,7 +497,7 @@ export function startBackgroundShellOnHost(
     command: shell.command,
     args: [...shellArgsForCommand(shell), opts.command],
     cwd: opts.cwd,
-    env: opts.env ?? process.env,
+    env: hostSpawnEnv(opts.env ?? process.env),
     stdin: "pipe",
     detached: useProcessGroup,
   });
@@ -716,6 +722,6 @@ export async function runShell(
     command: opts.command,
     cwd: opts.cwd,
     timeoutMs: opts.timeoutMs,
-    env: process.env,
+    env: hostSpawnEnv(process.env),
   });
 }

--- a/plugins/plugin-coding-tools/src/lib/terminal-capabilities.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/terminal-capabilities.test.ts
@@ -2,7 +2,8 @@
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { captureHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   detectTerminalSupport,
   missingToolForCommand,
@@ -26,12 +27,23 @@ const ENV_KEYS = [
 let savedEnv: Record<string, string | undefined>;
 let tempDir = "";
 
-beforeEach(() => {
+beforeAll(() => {
   savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
   tempDir = mkdtempSync(path.join(tmpdir(), "ct-cap-"));
+  process.env.PATH = tempDir;
+  captureHostExecutionBaseline();
 });
 
-afterEach(() => {
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  process.env.PATH = tempDir;
+});
+
+afterAll(() => {
   for (const key of ENV_KEYS) {
     const value = savedEnv[key];
     if (value === undefined) delete process.env[key];
@@ -48,10 +60,10 @@ function executable(name: string): string {
 }
 
 describe("coding-tools terminal capability detection", () => {
-  it("uses CODING_TOOLS_SHELL for Android shell selection", () => {
-    const shell = executable("aosp-sh");
+  it("ignores mutable shell overrides and selects from the boot PATH", () => {
+    const shell = executable("sh");
     process.env.ELIZA_PLATFORM = "android";
-    process.env.CODING_TOOLS_SHELL = shell;
+    process.env.CODING_TOOLS_SHELL = executable("aosp-sh");
     process.env.SHELL = "/definitely/missing";
     process.env.PATH = tempDir;
 
@@ -59,7 +71,7 @@ describe("coding-tools terminal capability detection", () => {
 
     expect(resolved.available).toBe(true);
     expect(resolved.command).toBe(shell);
-    expect(resolved.source).toBe("env:CODING_TOOLS_SHELL");
+    expect(resolved.source).toBe("candidate");
   });
 
   it("detects Android PATH binaries without invoking which", () => {

--- a/plugins/plugin-coding-tools/src/lib/terminal-capabilities.ts
+++ b/plugins/plugin-coding-tools/src/lib/terminal-capabilities.ts
@@ -8,6 +8,7 @@
 import { accessSync, constants } from "node:fs";
 import path from "node:path";
 import { readAliasedEnv } from "@elizaos/shared";
+import { resolveHostExecutable } from "@elizaos/shared/host-execution-env";
 
 export const CODING_TOOL_NAMES = [
   "sh",
@@ -48,8 +49,6 @@ export interface TerminalSupport {
   message?: string;
 }
 
-const ANDROID_PATH_ENTRIES = ["/system/bin", "/system/xbin", "/vendor/bin"];
-
 export function isAndroidRuntime(): boolean {
   return (
     readAliasedEnv("ELIZA_PLATFORM")?.toLowerCase() === "android" ||
@@ -86,19 +85,6 @@ export function isAospTerminalRuntime(): boolean {
   return isAndroidRuntime() && isTruthyEnv(process.env.ELIZA_AOSP_BUILD);
 }
 
-function pathEntries(): string[] {
-  const entries = (process.env.PATH ?? "")
-    .split(path.delimiter)
-    .map((entry) => entry.trim())
-    .filter(Boolean);
-  if (isAndroidRuntime()) {
-    for (const entry of ANDROID_PATH_ENTRIES) {
-      if (!entries.includes(entry)) entries.push(entry);
-    }
-  }
-  return entries;
-}
-
 function canExecute(filePath: string): boolean {
   try {
     accessSync(filePath, constants.X_OK);
@@ -113,14 +99,10 @@ function canExecute(filePath: string): boolean {
 export function resolveExecutable(nameOrPath: string): string | undefined {
   const trimmed = nameOrPath.trim();
   if (!trimmed) return undefined;
-  if (trimmed.includes("/") || path.isAbsolute(trimmed)) {
+  if (path.isAbsolute(trimmed)) {
     return canExecute(trimmed) ? trimmed : undefined;
   }
-  for (const entry of pathEntries()) {
-    const candidate = path.join(entry, trimmed);
-    if (canExecute(candidate)) return candidate;
-  }
-  return undefined;
+  return resolveHostExecutable(trimmed);
 }
 
 function firstExecutable(candidates: readonly string[]): string | undefined {
@@ -132,25 +114,6 @@ function firstExecutable(candidates: readonly string[]): string | undefined {
 }
 
 export function resolveHostShell(): ResolvedShell {
-  const explicitEntries = [
-    ["CODING_TOOLS_SHELL", process.env.CODING_TOOLS_SHELL] as const,
-    ["SHELL", process.env.SHELL] as const,
-  ];
-  for (const [key, raw] of explicitEntries) {
-    const value = raw?.trim();
-    if (!value) continue;
-    const resolved = resolveExecutable(value);
-    if (resolved) {
-      return {
-        command: resolved,
-        args: ["-c"],
-        available: true,
-        source:
-          key === "CODING_TOOLS_SHELL" ? "env:CODING_TOOLS_SHELL" : "env:SHELL",
-      };
-    }
-  }
-
   if (process.platform === "win32") {
     return {
       command: "powershell.exe",

--- a/plugins/plugin-coding-tools/src/lib/terminal-capabilities.ts
+++ b/plugins/plugin-coding-tools/src/lib/terminal-capabilities.ts
@@ -5,7 +5,6 @@
  * the SHELL action and run-shell to decide what can execute and to produce
  * missing-tool messages.
  */
-import { accessSync, constants } from "node:fs";
 import path from "node:path";
 import { readAliasedEnv } from "@elizaos/shared";
 import { resolveHostExecutable } from "@elizaos/shared/host-execution-env";
@@ -85,23 +84,9 @@ export function isAospTerminalRuntime(): boolean {
   return isAndroidRuntime() && isTruthyEnv(process.env.ELIZA_AOSP_BUILD);
 }
 
-function canExecute(filePath: string): boolean {
-  try {
-    accessSync(filePath, constants.X_OK);
-    return true;
-  } catch {
-    // error-policy:J3 existence/permission probe; an access failure means the
-    // path is absent or not executable — false is the expected-miss signal.
-    return false;
-  }
-}
-
 export function resolveExecutable(nameOrPath: string): string | undefined {
   const trimmed = nameOrPath.trim();
   if (!trimmed) return undefined;
-  if (path.isAbsolute(trimmed)) {
-    return canExecute(trimmed) ? trimmed : undefined;
-  }
   return resolveHostExecutable(trimmed);
 }
 
@@ -142,8 +127,8 @@ export function resolveHostShell(): ResolvedShell {
     available: false,
     source: "fallback",
     warning: isAndroidRuntime()
-      ? "No executable POSIX shell was detected. Android direct/AOSP local-yolo builds must expose /system/bin/sh or set CODING_TOOLS_SHELL to an executable shell."
-      : "No executable shell was detected. Set SHELL or CODING_TOOLS_SHELL to an executable shell.",
+      ? "No boot-authorized POSIX shell was detected. Android direct/AOSP local-yolo builds must include /system/bin or another shell directory in the boot PATH."
+      : "No boot-authorized shell was detected. Ensure the boot PATH contains an executable shell.",
   };
 }
 

--- a/plugins/plugin-coding-tools/src/shell/__tests__/terminal-capabilities.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/__tests__/terminal-capabilities.test.ts
@@ -6,7 +6,8 @@
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { captureHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   detectTerminalSupport,
   missingTerminalToolForCommand,
@@ -30,12 +31,23 @@ const ENV_KEYS = [
 let savedEnv: Record<string, string | undefined>;
 let tempDir = "";
 
-beforeEach(() => {
+beforeAll(() => {
   savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
   tempDir = mkdtempSync(path.join(tmpdir(), "shell-cap-"));
+  process.env.PATH = tempDir;
+  captureHostExecutionBaseline();
 });
 
-afterEach(() => {
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = savedEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  process.env.PATH = tempDir;
+});
+
+afterAll(() => {
   for (const key of ENV_KEYS) {
     const value = savedEnv[key];
     if (value === undefined) delete process.env[key];
@@ -52,10 +64,10 @@ function executable(name: string): string {
 }
 
 describe("shell terminal capability detection", () => {
-  it("uses the Android service shell override when present", () => {
-    const shell = executable("aosp-sh");
+  it("ignores mutable shell overrides and selects from the boot PATH", () => {
+    const shell = executable("sh");
     process.env.ELIZA_PLATFORM = "android";
-    process.env.CODING_TOOLS_SHELL = shell;
+    process.env.CODING_TOOLS_SHELL = executable("aosp-sh");
     process.env.SHELL = "/definitely/missing";
     process.env.PATH = tempDir;
 
@@ -63,7 +75,7 @@ describe("shell terminal capability detection", () => {
 
     expect(resolved.available).toBe(true);
     expect(resolved.shell).toBe(shell);
-    expect(resolved.source).toBe("env:CODING_TOOLS_SHELL");
+    expect(resolved.source).toBe("candidate");
   });
 
   it("detects missing known tools before spawning", () => {

--- a/plugins/plugin-coding-tools/src/shell/utils/processQueue.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/processQueue.ts
@@ -16,6 +16,10 @@ import process from "node:process";
 import { promisify } from "node:util";
 import { sanitizeSpawnEnv } from "@elizaos/core";
 import { resolveRuntimeExecutionMode } from "@elizaos/shared";
+import {
+  applyHostExecutionBaseline,
+  resolveHostExecutable,
+} from "@elizaos/shared/host-execution-env";
 
 // ============================================================================
 // Command Lanes
@@ -39,6 +43,10 @@ export type CommandLane = (typeof CommandLane)[keyof typeof CommandLane];
 // ============================================================================
 
 const execFileAsync = promisify(execFile);
+
+function hostSpawnEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return applyHostExecutionBaseline(sanitizeSpawnEnv(env));
+}
 
 /**
  * Resolves a command for Windows compatibility.
@@ -93,11 +101,17 @@ export async function runExec(
           maxBuffer: opts.maxBuffer,
           encoding: "utf8" as const,
         };
-  const { stdout, stderr } = await execFileAsync(
-    resolveCommand(command),
-    args,
-    options,
-  );
+  const requestedCommand = resolveCommand(command);
+  const executable = resolveHostExecutable(requestedCommand);
+  if (!executable) {
+    throw new Error(
+      `[shell] executable is outside the boot PATH authority or unavailable: ${requestedCommand}`,
+    );
+  }
+  const { stdout, stderr } = await execFileAsync(executable, args, {
+    ...options,
+    env: hostSpawnEnv(process.env),
+  });
   return { stdout, stderr };
 }
 
@@ -165,10 +179,7 @@ export async function runCommandWithTimeout(
   })();
 
   const merged = env ? { ...process.env, ...env } : { ...process.env };
-  const resolvedEnv = sanitizeSpawnEnv(merged) as Record<
-    string,
-    string | undefined
-  >;
+  const resolvedEnv = hostSpawnEnv(merged);
   if (shouldSuppressNpmFund) {
     if (resolvedEnv.NPM_CONFIG_FUND == null) {
       resolvedEnv.NPM_CONFIG_FUND = "false";
@@ -179,7 +190,14 @@ export async function runCommandWithTimeout(
   }
 
   const stdio = resolveCommandStdio({ hasInput, preferInherit: true });
-  const child = spawn(resolveCommand(argv[0]), argv.slice(1), {
+  const requestedCommand = resolveCommand(argv[0]);
+  const executable = resolveHostExecutable(requestedCommand);
+  if (!executable) {
+    throw new Error(
+      `[shell] executable is outside the boot PATH authority or unavailable: ${requestedCommand}`,
+    );
+  }
+  const child = spawn(executable, argv.slice(1), {
     stdio,
     cwd,
     env: resolvedEnv,

--- a/plugins/plugin-coding-tools/src/shell/utils/terminalCapabilities.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/terminalCapabilities.ts
@@ -3,7 +3,6 @@
  * whether a usable terminal/shell exists in the environment, resolves the shell
  * and executables to run, and reports the missing tool for a given command.
  */
-import fs from "node:fs";
 import path from "node:path";
 
 import { readAliasedEnv } from "@elizaos/shared";
@@ -84,23 +83,9 @@ export function isAospTerminalRuntime(): boolean {
   return isAndroidRuntime() && isTruthyEnv(process.env.ELIZA_AOSP_BUILD);
 }
 
-function executableExists(candidate: string): boolean {
-  try {
-    fs.accessSync(candidate, fs.constants.X_OK);
-    return true;
-  } catch {
-    // error-policy:J3 existence/permission probe; access failure means the
-    // candidate is absent or not executable — false is the expected miss.
-    return false;
-  }
-}
-
 export function resolveExecutable(nameOrPath: string): string | undefined {
   const trimmed = nameOrPath.trim();
   if (!trimmed) return undefined;
-  if (path.isAbsolute(trimmed)) {
-    return executableExists(trimmed) ? trimmed : undefined;
-  }
   return resolveHostExecutable(trimmed);
 }
 
@@ -132,8 +117,8 @@ export function resolveTerminalShell(): ShellResolution {
     available: false,
     source: "fallback",
     warning: isAndroidRuntime()
-      ? "No executable POSIX shell was detected. Android direct/AOSP local-yolo builds must expose /system/bin/sh or set CODING_TOOLS_SHELL to an executable shell."
-      : "No executable POSIX shell was detected. Set SHELL or CODING_TOOLS_SHELL to an executable shell.",
+      ? "No boot-authorized POSIX shell was detected. Android direct/AOSP local-yolo builds must include /system/bin or another shell directory in the boot PATH."
+      : "No boot-authorized POSIX shell was detected. Ensure the boot PATH contains an executable shell.",
   };
 }
 

--- a/plugins/plugin-coding-tools/src/shell/utils/terminalCapabilities.ts
+++ b/plugins/plugin-coding-tools/src/shell/utils/terminalCapabilities.ts
@@ -7,6 +7,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { readAliasedEnv } from "@elizaos/shared";
+import { resolveHostExecutable } from "@elizaos/shared/host-execution-env";
 
 export const TERMINAL_TOOL_NAMES = [
   "sh",
@@ -46,8 +47,6 @@ export interface TerminalSupport {
   reason?: TerminalUnsupportedReason;
   message?: string;
 }
-
-const ANDROID_PATH_ENTRIES = ["/system/bin", "/system/xbin", "/vendor/bin"];
 
 export function isAndroidRuntime(): boolean {
   return (
@@ -96,30 +95,13 @@ function executableExists(candidate: string): boolean {
   }
 }
 
-function pathEntries(): string[] {
-  const entries = (process.env.PATH ?? "")
-    .split(path.delimiter)
-    .map((entry) => entry.trim())
-    .filter(Boolean);
-  if (isAndroidRuntime()) {
-    for (const entry of ANDROID_PATH_ENTRIES) {
-      if (!entries.includes(entry)) entries.push(entry);
-    }
-  }
-  return entries;
-}
-
 export function resolveExecutable(nameOrPath: string): string | undefined {
   const trimmed = nameOrPath.trim();
   if (!trimmed) return undefined;
-  if (trimmed.includes("/") || path.isAbsolute(trimmed)) {
+  if (path.isAbsolute(trimmed)) {
     return executableExists(trimmed) ? trimmed : undefined;
   }
-  for (const entry of pathEntries()) {
-    const candidate = path.join(entry, trimmed);
-    if (executableExists(candidate)) return candidate;
-  }
-  return undefined;
+  return resolveHostExecutable(trimmed);
 }
 
 function firstExecutable(candidates: readonly string[]): string | undefined {
@@ -131,25 +113,6 @@ function firstExecutable(candidates: readonly string[]): string | undefined {
 }
 
 export function resolveTerminalShell(): ShellResolution {
-  const explicitEntries = [
-    ["CODING_TOOLS_SHELL", process.env.CODING_TOOLS_SHELL] as const,
-    ["SHELL", process.env.SHELL] as const,
-  ];
-  for (const [key, raw] of explicitEntries) {
-    const value = raw?.trim();
-    if (!value) continue;
-    const resolved = resolveExecutable(value);
-    if (resolved) {
-      return {
-        shell: resolved,
-        args: ["-c"],
-        available: true,
-        source:
-          key === "CODING_TOOLS_SHELL" ? "env:CODING_TOOLS_SHELL" : "env:SHELL",
-      };
-    }
-  }
-
   const candidates = isAndroidRuntime()
     ? ["/system/bin/sh", "sh"]
     : ["/bin/bash", "bash", "/bin/sh", "sh"];

--- a/plugins/plugin-coding-tools/vitest.config.ts
+++ b/plugins/plugin-coding-tools/vitest.config.ts
@@ -29,6 +29,10 @@ export default defineConfig({
         find: /^@elizaos\/shared$/,
         replacement: path.join(repoRoot, "packages/shared/src/index.ts"),
       },
+      {
+        find: /^@elizaos\/shared\/(.+)$/,
+        replacement: path.join(repoRoot, "packages/shared/src/$1.ts"),
+      },
     ],
     conditions: ["node"],
   },


### PR DESCRIPTION
**SECURITY SURFACE — keep draft until independent security review, hosted checks, and exact-head evidence complete. Do not self-merge.**

## What changed

This replaces the module-load PATH/HOME/SHELL restoration with an explicit host-execution authority:

- `sanitizeSpawnEnv` remains pure and unchanged.
- The agent binary captures a one-shot, validated host PATH before dynamically importing CLI/runtime configuration or plugins. Programmatic `startEliza` hosts capture before config loading and plugin registration.
- Host process launchers sanitize the full environment and then add only the captured PATH. HOME, SHELL, loader/interpreter variables, and later PATH mutations are not forwarded.
- Bare host commands plus Docker and Apple Container CLIs resolve through the captured PATH rather than mutable `process.env.PATH`.
- Local-safe sandbox commands remain overlay-only, preserving the container image's native PATH/HOME/SHELL instead of injecting host values.
- Apple `container exec` now forwards explicit environment overlays with the same `-e KEY=value` contract as Docker.
- Coding-tools foreground, background, and queued host execution use the same boundary.

PATH validation fails closed for missing values, NULs, relative/empty entries, and ambiguous Windows case variants. The one-shot state has no public reset or replacement hook.

## Root cause and behavior

The prior sanitizer correctly blocked PATH/HOME/SHELL to close config-to-env-to-spawn injection, but host commands then lost user toolchains. Restoring all three from a module-load snapshot mixed policy with process state, leaked HOME/SHELL into sandboxes, and depended on import timing. This version separates the boundaries: host execution receives only boot-authorized PATH; containers keep their own native environment.

## Exact-head local validation

- Exact head: `9d9ddf529baed494edcdbbc5d8d6bd71c27db88f`
- Rebased onto: `origin/develop@ecb5e6665b83078fe080d2c86db023579d556bdc`
- 107 focused tests passed:
  - host baseline: 5 (including a real fresh-process pre/post capture)
  - unchanged core spawn policy: 55
  - agent router/container/bin/mobile: 30
  - coding-tools host/capability paths: 17
- `@elizaos/shared`, `@elizaos/agent`, and `@elizaos/plugin-coding-tools` typechecks passed.
- All three affected package builds passed.
- Exact-file Biome and `git diff --check` passed.
- A no-HOME host Docker CLI context probe succeeded (`desktop-linux`). No container workload or deployment was performed.

Hosted checks and protected/live evidence are still pending; the PR intentionally remains draft.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - repository guides only`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Evidence Gate

<!-- evidence-head:049c8f6cf9869df71bce554546e09fcab81e25a8 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - Node host/sandbox execution policy; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - Node host/sandbox execution policy; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive surface changed.
<!-- evidence-row:backend-logs -->
- [x] [20221-pr20221-backend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20221-pr20221-backend.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, action, provider, or evaluator behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, connector, wallet, or external domain artifact changed; the contract is the child-process environment and container argv.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text changed.

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"repository-guides-only"} -->

