### PR TITLE
fix(scripts): accept the skill's v2 attribution marker in every validator

### DIFF
--- a/scripts/audit-ai-workflow-output.mjs
+++ b/scripts/audit-ai-workflow-output.mjs
@@ -28,8 +28,10 @@ const REPOSITORY_RE =
   /^[a-z0-9](?:[a-z0-9_.-]{0,99})\/[a-z0-9](?:[a-z0-9_.-]{0,99})$/i;
 const LOGIN_RE = /^[a-z0-9](?:[a-z0-9-]{0,38})?(?:\[bot\])?$/i;
 const LANE_RE = /^[a-z0-9][a-z0-9-]{1,48}$/i;
+// Accepts both marker generations: the legacy v1 footer and the signed v2
+// run receipt emitted by the published contribute-to-eliza skill.
 const ATTRIBUTION_MARKER_RE =
-  /^<!--\s*eliza-computer-attribution:v1\b[^\r\n]*-->\s*$/im;
+  /^<!--\s*(?:eliza-computer-attribution:v1|elizaos-contribution-attribution:v2)\b[^\r\n]*-->\s*$/im;
 
 function bodyHash(body) {
   return createHash("sha256")

--- a/scripts/check-agent-comment-attribution.mjs
+++ b/scripts/check-agent-comment-attribution.mjs
@@ -12,8 +12,12 @@ import { pathToFileURL } from "node:url";
 const CLAIM_LINE_RE = /^CLAIMING(?:\s+(?:REVIEW|LEVER))?\s*:/i;
 const ATTRIBUTION_DECLARATION_RE =
   /^(?:AI provider\/model\s*:|AI assistance\s*:\s*yes\b|Models?(?:\s+used)?\s*:|Model\(s\)\s+used\s*:|Client\s*\/\s*agent tooling\s*:|Contribution skill revision\s*:)/i;
+// Two marker generations are accepted: the legacy repository footer
+// (eliza-computer-attribution:v1) and the signed run receipt emitted by the
+// published contribute-to-eliza skill (elizaos-contribution-attribution:v2),
+// whose payload is a superset carrying an additional `run` object.
 const ATTRIBUTION_MARKER_LINE_RE =
-  /^<!--\s*eliza-computer-attribution:v1\b[^\r\n]*-->\s*$/i;
+  /^<!--\s*(?:eliza-computer-attribution:v1|elizaos-contribution-attribution:v2)\b[^\r\n]*-->\s*$/i;
 const HUMAN_ONLY_FOOTER_RE =
   /(?:^|\n)AI assistance:\s*no\s*[-\u2013\u2014]\s*human-only (?:claim|comment|review)\s*\nAttribution status:\s*self-reported\s*$/i;
 const NO_AI_VALUE_RE = /^(?:no|none|n\/?a)\s*[-:\u2013\u2014]\s*(\S[\s\S]*?)$/i;
@@ -120,11 +124,12 @@ function markerRecords(source) {
     .map((record) => {
       const raw = record.raw.trim();
       const any = raw.match(
-        /^<!--\s*eliza-computer-attribution:v1\b([\s\S]*?)-->\s*$/i,
+        /^<!--\s*(eliza-computer-attribution:v1|elizaos-contribution-attribution:v2)\b([\s\S]*?)-->\s*$/i,
       );
       if (!any) return null;
+      const version = any[1].toLowerCase().endsWith(":v2") ? 2 : 1;
       const wellFormed = raw.match(
-        /^<!--\s*eliza-computer-attribution:v1\s+(\{[^\r\n]*\})\s*-->\s*$/i,
+        /^<!--\s*(?:eliza-computer-attribution:v1|elizaos-contribution-attribution:v2)\s+(\{[^\r\n]*\})\s*-->\s*$/i,
       );
       const leadingWhitespace =
         record.raw.length - record.raw.trimStart().length;
@@ -132,6 +137,7 @@ function markerRecords(source) {
         end: record.start + leadingWhitespace + raw.length,
         json: wellFormed?.[1] ?? null,
         start: record.start + leadingWhitespace,
+        version,
       };
     })
     .filter((record) => record !== null);
@@ -388,7 +394,7 @@ export function evaluateCommentAttribution(body, options = {}) {
     findings.push({
       id: "marker",
       message:
-        "Exactly one well-formed eliza-computer-attribution:v1 JSON marker must appear.",
+        "Exactly one well-formed eliza-computer-attribution:v1 or elizaos-contribution-attribution:v2 JSON marker must appear.",
     });
   }
 
@@ -476,14 +482,32 @@ export function evaluateCommentAttribution(body, options = {}) {
   }
 
   if (marker && typeof marker === "object" && !Array.isArray(marker)) {
-    const expectedKeys = ["client", "model", "provider", "skill_revision"];
+    // The v2 run receipt adds a signed `run` object; every other key set is
+    // identical across versions so mismatched extras stay rejected.
+    const expectedKeys =
+      markerMatch.version === 2
+        ? ["client", "model", "provider", "run", "skill_revision"]
+        : ["client", "model", "provider", "skill_revision"];
     if (
       Object.keys(marker).sort().join(",") !== expectedKeys.sort().join(",")
     ) {
       findings.push({
         id: "marker-fields",
         message:
-          "The attribution marker must contain only provider, model, client, and skill_revision.",
+          markerMatch.version === 2
+            ? "The v2 attribution marker must contain only provider, model, client, skill_revision, and run."
+            : "The attribution marker must contain only provider, model, client, and skill_revision.",
+      });
+    }
+    if (
+      markerMatch.version === 2 &&
+      (typeof marker.run !== "object" ||
+        marker.run === null ||
+        Array.isArray(marker.run))
+    ) {
+      findings.push({
+        id: "marker-run",
+        message: "The v2 attribution marker run receipt must be an object.",
       });
     }
     if (marker.provider !== providerSlug(provider)) {

--- a/scripts/check-agent-comment-attribution.test.mjs
+++ b/scripts/check-agent-comment-attribution.test.mjs
@@ -33,6 +33,40 @@ Attribution status: self-reported
 <!-- eliza-computer-attribution:v1 ${JSON.stringify(marker)} -->`;
 }
 
+function receiptFooter(overrides = {}, markerOverrides = {}) {
+  const values = {
+    provider: "Anthropic",
+    providerSlug: "anthropic",
+    model: "claude-opus-5",
+    client: "Claude Code",
+    lane: "qa-agent",
+    skillRevision:
+      "elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza",
+    ...overrides,
+  };
+  const marker = {
+    provider: values.providerSlug,
+    model: values.model,
+    client: values.client,
+    skill_revision: values.skillRevision,
+    run: {
+      schema_version: "1",
+      run_id: "0f2c",
+      usage: { total_tokens: 1234 },
+      signature_algorithm: "ed25519",
+      device_signature: "abc123",
+    },
+    ...markerOverrides,
+  };
+  return `AI provider/model: ${values.provider} / ${values.model}
+Client / agent tooling: ${values.client}
+Contribution skill revision: ${values.skillRevision}
+Compute receipt: 1234 project-attributed tokens (exact; device-signed, locally reported)
+Attribution status: self-reported
+— [${values.lane}]
+<!-- elizaos-contribution-attribution:v2 ${JSON.stringify(marker)} -->`;
+}
+
 function workflowMachineFooter(path) {
   const workflow = readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
   const matches = [
@@ -354,6 +388,77 @@ ${machineFooter()}`;
     );
   });
 
+  it("accepts the skill's v2 run-receipt footer (#18457)", () => {
+    const result = evaluateCommentAttribution(
+      `CLAIMING: verified work\n\n${receiptFooter()}`,
+    );
+    assert.equal(
+      result.ok,
+      true,
+      result.findings.map((finding) => finding.message).join("; "),
+    );
+    assert.equal(result.attribution.kind, "machine");
+    assert.equal(result.attribution.model, "claude-opus-5");
+  });
+
+  it("rejects malformed v2 markers, extra fields, and duplicate markers", () => {
+    const missingRun = evaluateCommentAttribution(
+      receiptFooter({}, { run: undefined }),
+      { required: true },
+    );
+    assert.equal(missingRun.ok, false);
+    assert.ok(
+      missingRun.findings.some((finding) => finding.id === "marker-fields"),
+    );
+
+    const scalarRun = evaluateCommentAttribution(
+      receiptFooter({}, { run: "signed" }),
+      { required: true },
+    );
+    assert.equal(scalarRun.ok, false);
+    assert.ok(
+      scalarRun.findings.some((finding) => finding.id === "marker-run"),
+    );
+
+    const extraField = evaluateCommentAttribution(
+      receiptFooter({}, { session_id: "private" }),
+      { required: true },
+    );
+    assert.equal(extraField.ok, false);
+    assert.ok(
+      extraField.findings.some((finding) => finding.id === "marker-fields"),
+    );
+
+    const mismatchedProvider = evaluateCommentAttribution(
+      receiptFooter({ providerSlug: "openai" }),
+      { required: true },
+    );
+    assert.equal(mismatchedProvider.ok, false);
+    assert.ok(
+      mismatchedProvider.findings.some(
+        (finding) => finding.id === "marker-provider",
+      ),
+    );
+
+    const bothMarkers = evaluateCommentAttribution(
+      `${machineFooter()}\n${receiptFooter()}`,
+      { required: true },
+    );
+    assert.equal(bothMarkers.ok, false);
+    assert.ok(bothMarkers.findings.some((finding) => finding.id === "marker"));
+  });
+
+  it("ignores quoted and fenced v2 markers", () => {
+    const quoted = evaluateCommentAttribution(
+      '> <!-- elizaos-contribution-attribution:v2 {"provider":"fake"} -->',
+    );
+    assert.equal(quoted.skipped, true);
+    const fenced = evaluateCommentAttribution(
+      '```text\n<!-- elizaos-contribution-attribution:v2 {"provider":"fake"} -->\n```',
+    );
+    assert.equal(fenced.skipped, true);
+  });
+
   it("rejects incomplete or conflicting human-only declarations", () => {
     assert.equal(
       evaluateCommentAttribution("CLAIMING: work\n\nhuman-only").ok,
@@ -442,5 +547,4 @@ ${machineFooter()}`;
       );
     }
   });
-
 });

--- a/scripts/check-pr-agent-attribution.mjs
+++ b/scripts/check-pr-agent-attribution.mjs
@@ -9,8 +9,15 @@
 import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
+// Two markers satisfy the PR gate: the bare template marker and the signed
+// v2 run-receipt footer the published contribute-to-eliza skill appends. A
+// filled template plus an appended skill footer legitimately carries one of
+// each, so each spelling is limited to one occurrence rather than the pair.
 const ATTRIBUTION_MARKER = "contribution-attribution:v1";
 const ATTRIBUTION_MARKER_RE = /<!--\s*contribution-attribution:v1\s*-->/gi;
+const RECEIPT_MARKER = "elizaos-contribution-attribution:v2";
+const RECEIPT_MARKER_RE =
+  /<!--\s*elizaos-contribution-attribution:v2\b[^\r\n]*?-->/gi;
 const ROW_RE = /<!--\s*attribution-row:([a-z0-9-]+)\s*-->/gi;
 const NO_AI_ASSISTANCE_RE = /^no\s*[-:\u2013\u2014]\s*(\S[\s\S]*?)$/i;
 const NO_AI_DETAIL_RE = /^none\s*[-:\u2013\u2014]\s*(\S[\s\S]*?)$/i;
@@ -175,15 +182,28 @@ export function evaluatePrAttribution(body) {
   );
   const findings = [];
 
-  const markerCount = [...source.matchAll(ATTRIBUTION_MARKER_RE)].length;
-  if (markerCount !== 1) {
+  const templateMarkerCount = [...source.matchAll(ATTRIBUTION_MARKER_RE)]
+    .length;
+  const receiptMarkerCount = [...source.matchAll(RECEIPT_MARKER_RE)].length;
+  if (templateMarkerCount === 0 && receiptMarkerCount === 0) {
     findings.push({
       id: "marker",
-      status: markerCount === 0 ? "missing" : "duplicate",
-      message:
-        markerCount === 0
-          ? `Missing <!-- ${ATTRIBUTION_MARKER} -->.`
-          : `Expected exactly one <!-- ${ATTRIBUTION_MARKER} -->; found ${markerCount}.`,
+      status: "missing",
+      message: `Missing <!-- ${ATTRIBUTION_MARKER} --> or <!-- ${RECEIPT_MARKER} … -->.`,
+    });
+  }
+  if (templateMarkerCount > 1) {
+    findings.push({
+      id: "marker",
+      status: "duplicate",
+      message: `Expected at most one <!-- ${ATTRIBUTION_MARKER} -->; found ${templateMarkerCount}.`,
+    });
+  }
+  if (receiptMarkerCount > 1) {
+    findings.push({
+      id: "marker",
+      status: "duplicate",
+      message: `Expected at most one <!-- ${RECEIPT_MARKER} … -->; found ${receiptMarkerCount}.`,
     });
   }
 

--- a/scripts/check-pr-agent-attribution.test.mjs
+++ b/scripts/check-pr-agent-attribution.test.mjs
@@ -387,6 +387,60 @@ describe("PR agent attribution", () => {
     assert.deepEqual(labelled.attribution.modelIds, ["openai/gpt-5.6-sol"]);
   });
 
+  it("accepts the skill's v2 receipt marker alongside or instead of the bare template marker (#18457)", () => {
+    const receiptFooter = `AI provider/model: anthropic / claude-opus-5
+Client / agent tooling: Claude Code
+Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
+Compute receipt: 1234 project-attributed tokens (exact; device-signed, locally reported)
+Attribution status: self-reported
+— [qa-agent]
+<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-opus-5","client":"Claude Code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"0f2c","device_signature":"abc123"}} -->`;
+
+    // A filled template plus the appended skill footer carries one marker of
+    // each spelling and must pass.
+    const both = evaluatePrAttribution(`${body()}\n\n${receiptFooter}`);
+    assert.equal(
+      both.ok,
+      true,
+      both.findings.map((finding) => finding.message).join("; "),
+    );
+
+    // The v2 receipt alone satisfies the marker requirement when the rows
+    // are present without the bare template marker.
+    const withoutTemplateMarker = body().replace(
+      "<!-- contribution-attribution:v1 -->\n",
+      "",
+    );
+    const v2Only = evaluatePrAttribution(
+      `${withoutTemplateMarker}\n\n${receiptFooter}`,
+    );
+    assert.equal(
+      v2Only.ok,
+      true,
+      v2Only.findings.map((finding) => finding.message).join("; "),
+    );
+
+    // Duplicate v2 receipts are still rejected.
+    const duplicated = evaluatePrAttribution(
+      `${body()}\n\n${receiptFooter}\n${receiptFooter}`,
+    );
+    assert.equal(duplicated.ok, false);
+    assert.ok(
+      duplicated.findings.some(
+        (finding) => finding.id === "marker" && finding.status === "duplicate",
+      ),
+    );
+
+    // Neither marker present still reports missing.
+    const missing = evaluatePrAttribution(withoutTemplateMarker);
+    assert.equal(missing.ok, false);
+    assert.ok(
+      missing.findings.some(
+        (finding) => finding.id === "marker" && finding.status === "missing",
+      ),
+    );
+  });
+
   it("keeps PR template labels free of army terminal-footer collisions (#17855)", () => {
     const templatePath = path.join(
       repositoryRoot,


### PR DESCRIPTION
# Relates to

Fixes #18457

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused validator suites run post-sync (see Testing); root `bun run verify` not run — scripts-only change validated by the owning test suites.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: Claude Code
<!-- attribution-row:skill-revision -->
- Skill path: N/A - direct repository contribution without the contribution skill
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Branched from the latest `origin/develop` (d33ef9c4010); zero conflicts.
- [x] Owning suites pass post-sync (see Testing).

# Risks

Low. Pure widening of accepted marker spellings in three validation scripts plus tests; the v1 contracts are unchanged and covered by the existing suites, which all still pass.

# Background

## What does this PR do?

The published contribute-to-eliza skill (elizaOS/army) appends a signed `elizaos-contribution-attribution:v2` run-receipt footer, but every attribution validator here only accepted v1 spellings — a contributor following the skill literally got a red check on every comment, review, issue, and PR body (#18457, option (a)).

- `scripts/check-agent-comment-attribution.mjs`: marker lines match either spelling; the v2 JSON payload is validated as the documented superset (`provider`, `model`, `client`, `skill_revision` plus a `run` object, verified against the army skill's `run-receipt.mjs` at the revision cited in the issue), with the same visible-footer cross-checks, lane-tag, and terminality rules as v1.
- `scripts/check-pr-agent-attribution.mjs`: the marker requirement is satisfied by the bare template marker, the v2 receipt marker, or one of each (a filled PR template plus an appended skill footer is the normal compliant shape); duplicates of either spelling still fail, and the required `attribution-row:*` rows are unchanged.
- `scripts/audit-ai-workflow-output.mjs`: the snapshot marker regex accepts both generations.

## What kind of change is this?

Bug fix (CI/validation policy mismatch).

# Documentation changes needed?

None — CONTRIBUTING.md describes the v1 footer, which remains fully valid; v2 is accepted additively.

# Testing

## Where should a reviewer start?

`scripts/check-agent-comment-attribution.test.mjs` ("accepts the skill's v2 run-receipt footer") and `scripts/check-pr-agent-attribution.test.mjs` ("accepts the skill's v2 receipt marker alongside or instead of the bare template marker").

## Detailed testing steps

```
node --test scripts/check-agent-comment-attribution.test.mjs scripts/check-pr-agent-attribution.test.mjs
# 39 tests, 39 pass (includes new v2 accept/reject/quoted-fenced/duplicate/missing cases)
node --test scripts/audit-ai-workflow-output.test.mjs
# 16 tests, 16 pass
```

New coverage: v2 footer accepted for comments/claims; v2 marker with missing `run`, scalar `run`, extra fields, or provider mismatch rejected; both-markers-in-one-comment rejected; quoted/fenced v2 markers ignored; PR body passes with template marker + v2 footer, with v2 footer alone, fails on duplicate v2 and on no marker at all.

# Evidence Gate

<!-- evidence-head:f2211b930f53262dbcc17ca7997851b02d989bab -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - CI validation scripts only; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - CI validation scripts only; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - CI validation scripts only; no user flow.
<!-- evidence-row:backend-logs -->
- [x] Deterministic validator test transcript (real `node --test` run at this head):

```
$ node --test scripts/check-agent-comment-attribution.test.mjs scripts/check-pr-agent-attribution.test.mjs
  ✔ accepts the skill's v2 run-receipt footer (#18457) (0.315826ms)
  ✔ rejects malformed v2 markers, extra fields, and duplicate markers (1.260148ms)
  ✔ ignores quoted and fenced v2 markers (0.094958ms)
  ✔ accepts the skill's v2 receipt marker alongside or instead of the bare template marker (#18457) (1.155307ms)
ℹ tests 39
ℹ pass 39
ℹ fail 0
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend involved.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change; deterministic scripts.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the marker verdicts in the backend-logs transcript above are the only domain artifact for a CI-script change.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - deterministic validation scripts; no model call involved.

## Backend + frontend logs

<details><summary>node --test output</summary>

```
scripts/check-agent-comment-attribution.test.mjs + scripts/check-pr-agent-attribution.test.mjs
tests 39 / pass 39 / fail 0
scripts/audit-ai-workflow-output.test.mjs
tests 16 / pass 16 / fail 0
```

Reproduction from the issue now passes: a body carrying the skill-emitted
`<!-- elizaos-contribution-attribution:v2 {...} -->` footer is accepted by
`evaluateCommentAttribution`, while the same body with a mangled payload or a
duplicate marker is still rejected.

</details>

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice surface.

## Known gaps / failures

Root `bun run verify` was not run in this worktree (scripts-only change; the owning suites and Biome on the touched files pass). The related v1-spelling inconsistency between comment and PR validators noted in the issue's "Direction 1" caveat is intentionally left as-is.

---

AI provider/model: anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A - direct repository contribution without the contribution skill
Attribution status: self-reported
— [claude-fable-shaw]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"N/A - direct repository contribution without the contribution skill"} -->
