### PR TITLE
fix(cloud): align exempt agent billing status with migrated schema

### DIFF
--- a/packages/cloud/shared/src/db/exempt-billing-status-migration.test.ts
+++ b/packages/cloud/shared/src/db/exempt-billing-status-migration.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Applies migration 0208 against real PGlite rows and proves the historical
+ * billing_status CHECK (added by 0053/0056, table renamed by 0095) starts out
+ * rejecting 'exempt', is widened to the canonical AgentBillingStatus set, stays
+ * closed to unknown statuses, is safe to apply twice, and leaves existing rows
+ * unchanged (#20021). Real migration SQL, no Drizzle schema push.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+
+const MIGRATION_PATH = join(
+  import.meta.dir,
+  "migrations/0208_allow_exempt_agent_billing_status.sql",
+);
+const MIGRATION_SQL = readFileSync(MIGRATION_PATH, "utf8");
+
+const ACTIVE_ID = "00000000-0000-4000-8000-0000000000a1";
+const SUSPENDED_ID = "00000000-0000-4000-8000-0000000000a2";
+const EXEMPT_ID = "00000000-0000-4000-8000-0000000000a3";
+const UNKNOWN_ID = "00000000-0000-4000-8000-0000000000a4";
+
+let client: PGlite | null = null;
+
+afterEach(async () => {
+  if (client) {
+    await client.close();
+    client = null;
+  }
+});
+
+/**
+ * Reproduce the migrated production shape this migration targets: 0053 added
+ * billing_status, 0056 added the CHECK without 'exempt', and 0095 renamed the
+ * table to agent_sandboxes while keeping the historical constraint name.
+ */
+async function seedHistoricalShape(db: PGlite): Promise<void> {
+  await db.exec(`
+    CREATE TABLE "agent_sandboxes" (
+      id UUID PRIMARY KEY,
+      billing_status TEXT NOT NULL DEFAULT 'active'
+    );
+    ALTER TABLE "agent_sandboxes" ADD CONSTRAINT "billing_status_check"
+      CHECK (billing_status IN ('active', 'warning', 'shutdown_pending', 'suspended'));
+    INSERT INTO "agent_sandboxes" (id, billing_status) VALUES
+      ('${ACTIVE_ID}', 'active'),
+      ('${SUSPENDED_ID}', 'suspended');
+  `);
+}
+
+async function insertStatus(db: PGlite, id: string, status: string): Promise<void> {
+  await db.query("INSERT INTO agent_sandboxes (id, billing_status) VALUES ($1, $2)", [id, status]);
+}
+
+async function statusRows(db: PGlite): Promise<Array<{ id: string; billing_status: string }>> {
+  const result = await db.query<{ id: string; billing_status: string }>(
+    "SELECT id, billing_status FROM agent_sandboxes ORDER BY id",
+  );
+  return result.rows;
+}
+
+describe("0208 allow exempt agent billing status (#20021)", () => {
+  test("historical CHECK rejects 'exempt' before the migration", async () => {
+    client = new PGlite();
+    await seedHistoricalShape(client);
+
+    await expect(insertStatus(client, EXEMPT_ID, "exempt")).rejects.toThrow(/billing_status_check/);
+  });
+
+  test("widens the CHECK to 'exempt', keeps unknown statuses out, applies twice, and preserves rows", async () => {
+    client = new PGlite();
+    await seedHistoricalShape(client);
+
+    await client.exec(MIGRATION_SQL);
+    await client.exec(MIGRATION_SQL);
+
+    await insertStatus(client, EXEMPT_ID, "exempt");
+    await expect(insertStatus(client, UNKNOWN_ID, "free-tier")).rejects.toThrow(
+      /billing_status_check/,
+    );
+
+    expect(await statusRows(client)).toEqual([
+      { id: ACTIVE_ID, billing_status: "active" },
+      { id: SUSPENDED_ID, billing_status: "suspended" },
+      { id: EXEMPT_ID, billing_status: "exempt" },
+    ]);
+  });
+
+  test("migration constraint matches the canonical AgentBillingStatus contract exactly", async () => {
+    client = new PGlite();
+    await seedHistoricalShape(client);
+    await client.exec(MIGRATION_SQL);
+
+    // Canonical set from packages/cloud/shared/src/db/schemas/agent-sandboxes.ts.
+    const canonical = ["active", "warning", "suspended", "shutdown_pending", "exempt"];
+    for (const [index, status] of canonical.entries()) {
+      await insertStatus(client, `00000000-0000-4000-8000-0000000000b${index}`, status);
+    }
+
+    const count = await client.query<{ count: string }>(
+      "SELECT count(*)::text AS count FROM agent_sandboxes",
+    );
+    expect(count.rows[0]?.count).toBe(String(2 + canonical.length));
+  });
+});

--- a/packages/cloud/shared/src/db/migrations/0208_allow_exempt_agent_billing_status.sql
+++ b/packages/cloud/shared/src/db/migrations/0208_allow_exempt_agent_billing_status.sql
@@ -1,0 +1,11 @@
+-- Widens the agent billing-status CHECK to include 'exempt', aligning the
+-- migrated database with the canonical AgentBillingStatus TypeScript contract
+-- (packages/cloud/shared/src/db/schemas/agent-sandboxes.ts). Migration 0056
+-- added the constraint before 'exempt' existed, so a canonically migrated
+-- database rejects the zero-charge status the billing code already writes.
+-- 0095 renamed the table but not this constraint, so the historical name is
+-- still "billing_status_check". Drop-then-add keeps reapplication safe.
+
+ALTER TABLE "agent_sandboxes" DROP CONSTRAINT IF EXISTS "billing_status_check";
+ALTER TABLE "agent_sandboxes" ADD CONSTRAINT "billing_status_check"
+  CHECK (billing_status IN ('active', 'warning', 'shutdown_pending', 'suspended', 'exempt'));

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1450,6 +1450,13 @@
       "when": 1787601600000,
       "tag": "0207_todo_mutation_ledger",
       "breakpoints": true
+    },
+    {
+      "idx": 207,
+      "version": "7",
+      "when": 1787688000000,
+      "tag": "0208_allow_exempt_agent_billing_status",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
Fixes #20021

## What

- Appends `packages/cloud/shared/src/db/migrations/0208_allow_exempt_agent_billing_status.sql`: drops the historical `billing_status_check` constraint (added by 0056, name preserved through the 0095 table rename) and re-adds it with the canonical set `active, warning, shutdown_pending, suspended, exempt`, matching `AgentBillingStatus` in `packages/cloud/shared/src/db/schemas/agent-sandboxes.ts:82`. Applied migration 0056 is not edited; the journal change is append-only (idx 207).
- Adds `packages/cloud/shared/src/db/exempt-billing-status-migration.test.ts`, a real PGlite migration-path test (no Drizzle schema push) that reproduces the migrated 0053/0056/0095 shape and proves:
  - inserting `exempt` fails before the migration with the named CHECK;
  - after applying the migration twice (idempotent), `exempt` succeeds, an unknown status still fails, and pre-existing rows survive unchanged;
  - the constraint accepts exactly the canonical five-status contract.

No production writer, billing bypass route, staging mutation, or cutover is added.

Note on numbering: the issue reserved 0208 for #18691, but that issue is an unrelated Discord connector UI item with no migration and no open PR claims 0208; the journal currently ends at 0207, so this lands as the next contiguous entry (the journal registration gate enforces contiguity).

## Verification

- `bun test src/db/exempt-billing-status-migration.test.ts src/db/migration-journal-registration.test.ts` in `packages/cloud/shared`: 6 pass, 0 fail.
- `bun run typecheck` in `packages/cloud/shared`: exit 0.
- Biome check on the new test: clean.

## Contribution provenance

- AI assistance: yes
- AI provider/model: Anthropic / claude-fable-5
- Client / agent tooling: Claude Code
- Attribution status: self-reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:42102c7422510800fc13430c2efe4b97dc77b0c3 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Database migration only; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Database migration only; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - Database migration only; no visual interaction changed.

<!-- evidence-row:backend-logs -->
- [x] [20223-pr-20223-backend-evidence.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20223-pr-20223-backend-evidence.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend runtime behavior changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No model, prompt, or planning behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [20223-pr-20223-domain-evidence.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20223-pr-20223-domain-evidence.txt)

<!-- evidence-row:ocr-review -->
- [ ] N/A - No screenshots or visual text changed.
