### PR TITLE
perf(cloud): render session-cached sign-in options without the discovery roundtrip

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.provider-cache.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.provider-cache.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Verifies StewardLoginSection's session-cached provider fast path (#18256)
+ * under a mocked Steward harness (jsdom). A per-tenant sessionStorage snapshot
+ * of the last provider discovery must render the real option stack immediately
+ * on a repeat SPA load (no "Loading sign-in options…" roundtrip on the
+ * critical path), reconcile with the live fetch when it resolves, and the
+ * completing-callback return leg must not issue a discovery fetch at all. A
+ * corrupt snapshot must fall back to the discovery skeleton, never to a
+ * fake-valid provider set.
+ *
+ * The section module memoizes discovery process-wide (one in-flight promise,
+ * one resolved set), so these tests share a single controlled deferred and run
+ * in a deliberate order: every test before the final one leaves discovery
+ * unresolved (assertions are synchronous or fetch-free), and only the last
+ * test resolves it.
+ */
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const harness = vi.hoisted(() => {
+  let resolveProviders: (value: unknown) => void = () => {};
+  const providersDeferred = new Promise<unknown>((resolve) => {
+    resolveProviders = resolve;
+  });
+  return {
+    hasCallback: false,
+    code: null as string | null,
+    getProvidersCalls: 0,
+    providersDeferred,
+    resolveProviders,
+  };
+});
+
+vi.mock("../../lib/steward-session", () => ({
+  hasStewardOAuthCallbackInUrl: () => harness.hasCallback,
+  consumeStewardCodeFromQuery: () => harness.code,
+  consumeStewardTokensFromHash: () => null,
+  exchangeStewardCodeViaApi: () => new Promise(() => {}),
+  recoverStewardSessionViaCookie: () => Promise.resolve(null),
+  refreshStewardSessionViaCookie: () => Promise.resolve({ ok: true as const }),
+  syncStewardSessionCookie: () => Promise.resolve(),
+}));
+
+vi.mock("@stwd/sdk", () => ({
+  StewardAuth: class {
+    getSession() {
+      return null;
+    }
+    getProviders() {
+      harness.getProvidersCalls += 1;
+      return harness.providersDeferred;
+    }
+    refreshSession() {
+      return Promise.resolve(null);
+    }
+  },
+}));
+
+vi.mock("./passkey-capability", () => ({
+  resolveWebPasskeyCapability: () =>
+    Promise.resolve({ usable: false, reason: "native-without-bridge" }),
+}));
+
+vi.mock("../../../shell/steward-url", () => ({
+  resolveBrowserStewardApiUrl: () => "https://api.example.test",
+}));
+
+vi.mock("../../../shell/steward-config", () => ({
+  configuredStewardTenantId: () => "elizacloud",
+  DEFAULT_STEWARD_TENANT_ID: "elizacloud",
+}));
+
+vi.mock("../../../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, opts?: { defaultValue?: string }) =>
+    opts?.defaultValue ?? _key,
+}));
+
+vi.mock("../../lib/steward-oauth-url", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../lib/steward-oauth-url")
+  >("../../lib/steward-oauth-url");
+  return {
+    ...actual,
+    consumeStewardPkceVerifier: () => undefined,
+    buildStewardOAuthRedirectUri: () => "https://app.example.test/login",
+  };
+});
+
+vi.mock("../../lib/login-return-to", () => ({
+  resolveLoginReturnTo: () => "/cloud",
+  consumePendingOAuthReturnTo: () => null,
+  storePendingOAuthReturnTo: () => undefined,
+}));
+
+import StewardLoginSection from "./steward-login-section";
+
+const CACHE_KEY = "eliza.steward.providers.v1:elizacloud";
+
+const CACHED_PROVIDERS = {
+  passkey: false,
+  email: true,
+  sms: false,
+  siwe: false,
+  siws: false,
+  google: true,
+  discord: true,
+  github: false,
+  twitter: false,
+  oauth: [],
+};
+
+function renderSection(entry: string) {
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <StewardLoginSection />
+    </MemoryRouter>,
+  );
+}
+
+describe("StewardLoginSection — session-cached provider fast path (#18256)", () => {
+  beforeEach(() => {
+    harness.hasCallback = false;
+    harness.code = null;
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    window.sessionStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("falls back to the discovery skeleton on a corrupt snapshot", () => {
+    window.sessionStorage.setItem(CACHE_KEY, "{not json");
+
+    renderSection("/login");
+
+    expect(
+      screen.getByRole("status", { name: "Loading sign-in options" }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("renders cached options immediately while live discovery is still pending", () => {
+    window.sessionStorage.setItem(CACHE_KEY, JSON.stringify(CACHED_PROVIDERS));
+
+    renderSection("/login");
+
+    // No blocking discovery state — the cached stack is live from first render.
+    expect(
+      screen.queryByRole("status", { name: "Loading sign-in options" }),
+    ).toBeNull();
+    expect(screen.getByRole("button", { name: /^Google$/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^GitHub$/i })).toBeNull();
+  });
+
+  it("does not fetch provider discovery on the completing-callback return leg", async () => {
+    harness.hasCallback = true;
+    harness.code = "callback-code";
+    const callsBefore = harness.getProvidersCalls;
+
+    renderSection("/login?code=callback-code");
+
+    await waitFor(() =>
+      expect(screen.getByText("Completing sign-in…")).toBeTruthy(),
+    );
+    expect(harness.getProvidersCalls).toBe(callsBefore);
+  });
+
+  it("reconciles the cached stack with the fetched config when discovery resolves", async () => {
+    window.sessionStorage.setItem(CACHE_KEY, JSON.stringify(CACHED_PROVIDERS));
+
+    renderSection("/login");
+    expect(screen.queryByRole("button", { name: /^GitHub$/i })).toBeNull();
+
+    harness.resolveProviders({ ...CACHED_PROVIDERS, github: true });
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /^GitHub$/i })).toBeTruthy(),
+    );
+    // The successful discovery refreshes the snapshot for the next load.
+    const stored = window.sessionStorage.getItem(CACHE_KEY);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored as string).github).toBe(true);
+  });
+});

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.provider-cache.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.provider-cache.test.tsx
@@ -60,8 +60,7 @@ vi.mock("@stwd/sdk", () => ({
 }));
 
 vi.mock("./passkey-capability", () => ({
-  resolveWebPasskeyCapability: () =>
-    Promise.resolve({ usable: false, reason: "native-without-bridge" }),
+  resolveWebPasskeyCapability: () => new Promise(() => {}),
 }));
 
 vi.mock("../../../shell/steward-url", () => ({
@@ -135,6 +134,25 @@ describe("StewardLoginSection — session-cached provider fast path (#18256)", (
 
   it("falls back to the discovery skeleton on a corrupt snapshot", () => {
     window.sessionStorage.setItem(CACHE_KEY, "{not json");
+
+    renderSection("/login");
+
+    expect(
+      screen.getByRole("status", { name: "Loading sign-in options" }),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("rejects a structurally incomplete or mistyped provider snapshot", () => {
+    window.sessionStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({
+        passkey: false,
+        email: true,
+        google: "true",
+        oauth: [],
+      }),
+    );
 
     renderSection("/login");
 

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -337,21 +337,57 @@ function providersSessionCacheKey(): string {
   return `${PROVIDERS_SESSION_CACHE_PREFIX}:${STEWARD_TENANT_ID}`;
 }
 
+function normalizeSessionCachedProviders(
+  value: unknown,
+): StewardProviders | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  const passkey = record.passkey;
+  const email = record.email;
+  const siwe = record.siwe;
+  const siws = record.siws;
+  const google = record.google;
+  const discord = record.discord;
+  const github = record.github;
+  const twitter = record.twitter;
+  const oauth = record.oauth;
+  if (
+    typeof passkey !== "boolean" ||
+    typeof email !== "boolean" ||
+    typeof siwe !== "boolean" ||
+    typeof siws !== "boolean" ||
+    typeof google !== "boolean" ||
+    typeof discord !== "boolean" ||
+    typeof github !== "boolean" ||
+    typeof twitter !== "boolean" ||
+    !Array.isArray(oauth) ||
+    !oauth.every((provider) => typeof provider === "string") ||
+    (record.sms !== undefined && typeof record.sms !== "boolean")
+  ) {
+    return null;
+  }
+  return {
+    passkey,
+    email,
+    siwe,
+    siws,
+    google,
+    discord,
+    github,
+    twitter,
+    oauth,
+    ...(typeof record.sms === "boolean" ? { sms: record.sms } : {}),
+  };
+}
+
 function readSessionCachedProviders(): StewardProviders | null {
   if (typeof window === "undefined") return null;
   try {
     const raw = window.sessionStorage.getItem(providersSessionCacheKey());
     if (!raw) return null;
-    const parsed: unknown = JSON.parse(raw);
-    if (
-      parsed === null ||
-      typeof parsed !== "object" ||
-      typeof (parsed as StewardProviders).email !== "boolean" ||
-      typeof (parsed as StewardProviders).passkey !== "boolean"
-    ) {
-      return null;
-    }
-    return parsed as StewardProviders;
+    return normalizeSessionCachedProviders(JSON.parse(raw) as unknown);
   } catch (error) {
     // error-policy:J3 a corrupt or inaccessible snapshot is explicitly "no
     // cache" — the section falls back to the discovery skeleton, never to a

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -324,6 +324,58 @@ function describeEmailLoginError(error: unknown, fallback: string): string {
 let cachedStewardProviders: StewardProviders | null = null;
 let stewardProvidersPromise: Promise<StewardProviders> | null = null;
 
+// The provider set is effectively static per deployment, but each SPA load —
+// notably the post-OAuth return leg, a second full cold load — used to block
+// the option stack on a fresh discovery roundtrip ("Loading sign-in options…",
+// #18256). A per-tenant sessionStorage snapshot of the last successful
+// discovery lets repeat loads render the real options immediately; the live
+// fetch still runs and reconciles, so a config change corrects the form as
+// soon as discovery resolves.
+const PROVIDERS_SESSION_CACHE_PREFIX = "eliza.steward.providers.v1";
+
+function providersSessionCacheKey(): string {
+  return `${PROVIDERS_SESSION_CACHE_PREFIX}:${STEWARD_TENANT_ID}`;
+}
+
+function readSessionCachedProviders(): StewardProviders | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(providersSessionCacheKey());
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      typeof (parsed as StewardProviders).email !== "boolean" ||
+      typeof (parsed as StewardProviders).passkey !== "boolean"
+    ) {
+      return null;
+    }
+    return parsed as StewardProviders;
+  } catch (error) {
+    // error-policy:J3 a corrupt or inaccessible snapshot is explicitly "no
+    // cache" — the section falls back to the discovery skeleton, never to a
+    // fake-valid provider set.
+    void error;
+    return null;
+  }
+}
+
+function writeSessionCachedProviders(providers: StewardProviders): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(
+      providersSessionCacheKey(),
+      JSON.stringify(providers),
+    );
+  } catch (error) {
+    // error-policy:J6 the snapshot is a repeat-load accelerator only; when
+    // storage is unavailable (private mode, quota) the next load simply pays
+    // the discovery roundtrip again.
+    void error;
+  }
+}
+
 function loadStewardProviders(auth: {
   getProviders: () => Promise<StewardProviders>;
 }): Promise<StewardProviders> {
@@ -331,6 +383,7 @@ function loadStewardProviders(auth: {
   stewardProvidersPromise ??= auth.getProviders().then((loadedProviders) => {
     cachedStewardProviders = loadedProviders;
     stewardProvidersPromise = null;
+    writeSessionCachedProviders(loadedProviders);
     return loadedProviders;
   });
   return stewardProvidersPromise;
@@ -405,10 +458,16 @@ export default function StewardLoginSection() {
     PLAYWRIGHT_TEST_AUTH_ENABLED ? false : hasStewardOAuthCallbackInUrl(),
   );
   const [providersLoaded, setProvidersLoaded] = useState(
-    PLAYWRIGHT_TEST_AUTH_ENABLED || cachedStewardProviders !== null,
+    () =>
+      PLAYWRIGHT_TEST_AUTH_ENABLED ||
+      cachedStewardProviders !== null ||
+      readSessionCachedProviders() !== null,
   );
   const [providers, setProviders] = useState<StewardProviders>(
-    () => cachedStewardProviders ?? DEFAULT_PROVIDERS,
+    () =>
+      cachedStewardProviders ??
+      readSessionCachedProviders() ??
+      DEFAULT_PROVIDERS,
   );
   const [passkeyCapability, setPasskeyCapability] =
     useState<WebPasskeyCapability | null>(
@@ -429,16 +488,37 @@ export default function StewardLoginSection() {
       setProvidersLoaded(true);
       return;
     }
+    // On the post-OAuth return leg the section shows only the terminal
+    // "completing sign-in" state and then redirects — the options never
+    // render, so a discovery fetch there is pure waste on the critical path
+    // (#18256). If the exchange fails, `completingCallback` clears and this
+    // effect re-runs, so the retry surface still gets live discovery.
+    if (completingCallback) return;
+    let cancelled = false;
     loadStewardProviders(auth)
-      .then(setProviders)
+      .then((loadedProviders) => {
+        if (!cancelled) setProviders(loadedProviders);
+      })
       .catch((providerError: unknown) => {
         stewardProvidersPromise = null;
-        setError(
-          getErrorMessage(providerError, "Steward provider discovery failed"),
-        );
+        if (cancelled) return;
+        // error-policy:J4 with a session-cached provider set already rendered,
+        // a failed background reconcile keeps the usable cached form instead
+        // of blasting an error over working sign-in options; a first-load
+        // failure (nothing rendered yet) still surfaces the error.
+        if (readSessionCachedProviders() === null) {
+          setError(
+            getErrorMessage(providerError, "Steward provider discovery failed"),
+          );
+        }
       })
-      .finally(() => setProvidersLoaded(true));
-  }, [auth]);
+      .finally(() => {
+        if (!cancelled) setProvidersLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [auth, completingCallback]);
 
   useEffect(() => {
     if (PLAYWRIGHT_TEST_AUTH_ENABLED) return;


### PR DESCRIPTION
Fixes remaining item C of #18256 (items A/B landed in #18269).

## What changed

`packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx`:

- **Session-cached provider fast path.** The last successful provider discovery is snapshotted per tenant in `sessionStorage` (`eliza.steward.providers.v1:<tenant>`). Any subsequent SPA load — most importantly the post-Google-OAuth return leg, which is a second full cold load — renders the real option stack immediately instead of blocking on the "Loading sign-in options…" roundtrip. The live fetch still runs and reconciles the form (and refreshes the snapshot) when it resolves, so a deployment config change corrects the options as soon as discovery lands.
- **No discovery fetch on the return leg.** Under the terminal `completingCallback` state the options never render, so the fetch was pure waste on the critical path; it is skipped, and re-armed automatically if the code exchange fails (the retry surface still gets live discovery).
- **Fail-safe snapshot handling.** A corrupt/unreadable snapshot is explicitly "no cache" (falls back to the existing geometry-reserving skeleton — never a fake-valid provider set); a failed background reconcile keeps the usable cached form instead of overlaying an error, while a true first-load discovery failure still surfaces the error.

## Issue items status

- A (pre-hydration shell): already present — the console is served from `packages/app/index.html`, which paints the `eliza-preboot-shell` dark branded shell before hydration (landed via #18269).
- B (reserved geometry): landed in #18269; the geometry contract tests remain untouched and green.
- C (options roundtrip off the critical path): **this PR**.
- D (triple same-URL navigation): investigated; not reproducible statically — the same-URL `framenavigated` events line up with `history.replaceState` calls from callback param stripping, which only fire on callback entries. Left open on the issue for a live trace.

## Tests

- New `steward-login-section.provider-cache.test.tsx`: cached options render with discovery pending, reconcile + snapshot refresh on resolve, no `getProviders` call under completing-callback, corrupt snapshot falls back to the skeleton.
- `bunx vitest run src/cloud/public-pages/pages/login/` — 13 files, **65/65 passed** (includes the existing #18256 loading-geometry contract tests).
- `bun run --cwd packages/ui typecheck` — clean.
- Biome clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:78b360a16e0c8f34f6afb8da10d5d29046bea50a -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20226-pr20226-before-desktop-mobile.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20226-pr20226-exact-after-desktop-mobile.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20226-pr20226-exact-login-rest-hover-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - Renderer-only session cache change; no backend path is modified.

<!-- evidence-row:frontend-logs -->
- [x] [20226-pr20226-exact-frontend-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20226-pr20226-exact-frontend-tests.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No model or planner behavior is involved.

<!-- evidence-row:domain-artifacts -->
- [x] [20226-pr20226-exact-cloud-audit-report.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20226-pr20226-exact-cloud-audit-report.json)

<!-- evidence-row:ocr-review -->
- [x] [20226-pr20226-exact-login-ocr.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20226-pr20226-exact-login-ocr.txt)


