### PR TITLE
fix(core): planner sees bounded prior dialogue; continuation turns resolve the pending request

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -7026,4 +7026,59 @@ describe("planner prior dialogue and continuation resolution (#17024)", () => {
 		expect(result.kind).toBe("direct_reply");
 		expect(useModelCalls(runtime)).toHaveLength(1);
 	});
+
+	it("does not replay a completed action when the user praises its short reply", async () => {
+		const shellHandler = vi.fn(async () => ({ success: true, text: "" }));
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: "Thanks!",
+			}),
+		]);
+		runtime.actions = [
+			{
+				name: "SHELL",
+				similes: [],
+				description: "Run a local shell command.",
+				parameters: [],
+				examples: [],
+				validate: async () => true,
+				handler: shellHandler,
+			},
+		] as never;
+		const agentId = runtime.agentId;
+		const state = recentState([
+			{
+				id: "00000000-0000-0000-0000-00000000ef01" as UUID,
+				entityId: "00000000-0000-0000-0000-00000000ef11" as UUID,
+				agentId,
+				roomId,
+				createdAt: 1,
+				content: {
+					text: "delete the temporary file with the shell",
+					source: "test",
+				},
+			},
+			{
+				id: "00000000-0000-0000-0000-00000000ef02" as UUID,
+				entityId: agentId,
+				agentId,
+				roomId,
+				createdAt: 2,
+				content: { text: "Done.", source: "test" },
+			},
+		]);
+		runtime.composeState = vi.fn(async () => state);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "that is great" }),
+			state,
+			responseId: "00000000-0000-0000-0000-0000000000c4" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		expect(shellHandler).not.toHaveBeenCalled();
+		expect(useModelCalls(runtime)).toHaveLength(1);
+	});
 });

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -6931,7 +6931,7 @@ describe("planner prior dialogue and continuation resolution (#17024)", () => {
 		const state = recentState([
 			{
 				id: "00000000-0000-0000-0000-00000000ee01" as UUID,
-				entityId: "00000000-0000-0000-0000-00000000ee11" as UUID,
+				entityId: "00000000-0000-0000-0000-000000000002" as UUID,
 				agentId,
 				roomId,
 				createdAt: 1,
@@ -6996,7 +6996,7 @@ describe("planner prior dialogue and continuation resolution (#17024)", () => {
 		const state = recentState([
 			{
 				id: "00000000-0000-0000-0000-00000000ee01" as UUID,
-				entityId: "00000000-0000-0000-0000-00000000ee11" as UUID,
+				entityId: "00000000-0000-0000-0000-000000000002" as UUID,
 				agentId,
 				roomId,
 				createdAt: 1,
@@ -7050,7 +7050,7 @@ describe("planner prior dialogue and continuation resolution (#17024)", () => {
 		const state = recentState([
 			{
 				id: "00000000-0000-0000-0000-00000000ef01" as UUID,
-				entityId: "00000000-0000-0000-0000-00000000ef11" as UUID,
+				entityId: "00000000-0000-0000-0000-000000000002" as UUID,
 				agentId,
 				roomId,
 				createdAt: 1,
@@ -7075,6 +7075,61 @@ describe("planner prior dialogue and continuation resolution (#17024)", () => {
 			message: makeMessage({ text: "that is great" }),
 			state,
 			responseId: "00000000-0000-0000-0000-0000000000c4" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		expect(shellHandler).not.toHaveBeenCalled();
+		expect(useModelCalls(runtime)).toHaveLength(1);
+	});
+
+	it("does not promote another participant's pending request", async () => {
+		const shellHandler = vi.fn(async () => ({ success: true, text: "" }));
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: "What would you like me to do?",
+			}),
+		]);
+		runtime.actions = [
+			{
+				name: "SHELL",
+				similes: [],
+				description: "Run a local shell command.",
+				parameters: [],
+				examples: [],
+				validate: async () => true,
+				handler: shellHandler,
+			},
+		] as never;
+		const agentId = runtime.agentId;
+		const state = recentState([
+			{
+				id: "00000000-0000-0000-0000-00000000ff01" as UUID,
+				entityId: "00000000-0000-0000-0000-00000000ff11" as UUID,
+				agentId,
+				roomId,
+				createdAt: 1,
+				content: {
+					text: "show me disk usage on this server",
+					source: "test",
+				},
+			},
+			{
+				id: "00000000-0000-0000-0000-00000000ff02" as UUID,
+				entityId: agentId,
+				agentId,
+				roomId,
+				createdAt: 2,
+				content: { text: "Should I run it?", source: "test" },
+			},
+		]);
+		runtime.composeState = vi.fn(async () => state);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "go ahead" }),
+			state,
+			responseId: "00000000-0000-0000-0000-0000000000c5" as UUID,
 		});
 
 		expect(result.kind).toBe("direct_reply");

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -4787,7 +4787,16 @@ describe("runV5MessageRuntimeStage1", () => {
 									agentId: "00000000-0000-0000-0000-000000000003" as UUID,
 									roomId: "00000000-0000-0000-0000-000000000004" as UUID,
 									createdAt: 2,
-									content: { text: staleAssistantAnswer },
+									// Tool-derived answers carry their producing action in
+									// content.actions (runtime persists) or
+									// actionCallbackHistory (route persists); the planner
+									// window excludes them by that structural marker, not by
+									// role (#17024), so ordinary assistant questions/previews
+									// stay visible for continuation resolution.
+									content: {
+										text: staleAssistantAnswer,
+										actions: ["CHECK_RUNTIME"],
+									},
 								},
 								currentMessage,
 							],
@@ -6759,5 +6768,262 @@ describe("runV5MessageRuntimeStage1 — engagement addressing gate", () => {
 		}
 		const scopes = reportErrorCalls(runtime).map((call) => call[0]);
 		expect(scopes).toContain("MessageService.resolveAddressees");
+	});
+});
+
+describe("planner prior dialogue and continuation resolution (#17024)", () => {
+	const roomId = "00000000-0000-0000-0000-000000001111" as UUID;
+
+	function recentState(recentMessages: unknown[]): State {
+		return {
+			values: { availableContexts: "simple, general" },
+			data: {
+				providers: {
+					RECENT_MESSAGES: {
+						text: "# Conversation Messages\nprovider text should not render",
+						data: { recentMessages },
+						providerName: "RECENT_MESSAGES",
+					},
+				},
+			},
+			text: "",
+		};
+	}
+
+	it("renders ordinary own replies in the planner context while excluding tool-derived ones", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["general"],
+				replyText: "On it.",
+				extra: { requiresTool: true },
+			}),
+			JSON.stringify({
+				thought: "No tool needed in this fixture.",
+				toolCalls: [],
+				messageToUser: "Done.",
+			}),
+		]);
+		const agentId = runtime.agentId;
+		const state = recentState([
+			{
+				id: "00000000-0000-0000-0000-00000000dd01" as UUID,
+				entityId: "00000000-0000-0000-0000-00000000dd11" as UUID,
+				agentId,
+				roomId,
+				createdAt: 1,
+				content: { text: "whats the btc price", source: "discord" },
+				metadata: {
+					type: "message",
+					sender: { id: "discord-1gig", name: "1gig" },
+				},
+			},
+			{
+				id: "00000000-0000-0000-0000-00000000dd02" as UUID,
+				entityId: agentId,
+				agentId,
+				roomId,
+				createdAt: 2,
+				content: {
+					text: "Do you want that in USD or EUR?",
+					source: "discord",
+				},
+			},
+			{
+				id: "00000000-0000-0000-0000-00000000dd03" as UUID,
+				entityId: agentId,
+				agentId,
+				roomId,
+				createdAt: 3,
+				content: {
+					text: "BTC is around $63,000 right now.",
+					source: "discord",
+					actions: ["WEB_SEARCH"],
+				},
+			},
+			{
+				id: "00000000-0000-0000-0000-00000000dd04" as UUID,
+				entityId: agentId,
+				agentId,
+				roomId,
+				createdAt: 4,
+				content: {
+					text: "ETH is $3,000 right now.",
+					source: "discord",
+					actionCallbackHistory: ["ETH is $3,000 right now."],
+				},
+			},
+		]);
+		runtime.composeState = vi.fn(async () => state);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "in USD please" }),
+			state,
+			responseId: "00000000-0000-0000-0000-0000000000c1" as UUID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		const calls = useModelCalls(runtime);
+		expect(calls[1]?.[0]).toBe(ModelType.ACTION_PLANNER);
+		const plannerParams = calls[1]?.[1] as {
+			messages?: Array<{ role?: string; content?: string | null }>;
+		};
+		const plannerUserContent = plannerParams.messages?.[1]?.content ?? "";
+		// The ordinary own reply — the question a continuation refers to — is
+		// visible and role-tagged.
+		expect(plannerUserContent).toContain(
+			"prior_message:agent:\nTest Agent: Do you want that in USD or EUR?",
+		);
+		// Tool-derived own answers stay out of the planner window (stale-answer
+		// hazard): both the actions-marked and callback-history-marked rows.
+		expect(plannerUserContent).not.toContain("BTC is around $63,000");
+		expect(plannerUserContent).not.toContain("ETH is $3,000");
+		// The planner boundary instruction now covers own-reply staleness.
+		expect(plannerUserContent).toContain("treat every fact in them as stale");
+	});
+
+	it("resolves an explicit continuation turn to the prior user request for candidate inference", async () => {
+		const shellHandler = vi.fn(async () => ({
+			success: true,
+			text: "Filesystem usage: 42%",
+		}));
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: "Sure.",
+			}),
+			{
+				thought: "Run the pending disk-usage request.",
+				toolCalls: [
+					{
+						id: "shell-disk-usage",
+						name: "SHELL",
+						args: { command: "df -h" },
+					},
+				],
+			},
+			JSON.stringify({
+				success: true,
+				decision: "FINISH",
+				thought: "Shell returned the disk usage.",
+				messageToUser: "Filesystem usage is at 42%.",
+			}),
+		]);
+		runtime.actions = [
+			{
+				name: "SHELL",
+				similes: [],
+				description: "Run a local shell command.",
+				parameters: [
+					{
+						name: "command",
+						description: "Command to run",
+						required: true,
+						schema: { type: "string" },
+					},
+				],
+				examples: [],
+				validate: async () => true,
+				handler: shellHandler,
+			},
+		] as never;
+		const agentId = runtime.agentId;
+		const state = recentState([
+			{
+				id: "00000000-0000-0000-0000-00000000ee01" as UUID,
+				entityId: "00000000-0000-0000-0000-00000000ee11" as UUID,
+				agentId,
+				roomId,
+				createdAt: 1,
+				content: {
+					text: "show me disk usage on this server",
+					source: "test",
+				},
+			},
+			{
+				id: "00000000-0000-0000-0000-00000000ee02" as UUID,
+				entityId: agentId,
+				agentId,
+				roomId,
+				createdAt: 2,
+				content: { text: "On it.", source: "test" },
+			},
+		]);
+		runtime.composeState = vi.fn(async () => state);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "finish my request" }),
+			state,
+			responseId: "00000000-0000-0000-0000-0000000000c2" as UUID,
+		});
+
+		// The contentless continuation turn resolved to the pending shell
+		// request, so the turn routes to the planner with the shell candidate
+		// and the shell action actually runs.
+		expect(result.kind).toBe("planned_reply");
+		expect(shellHandler).toHaveBeenCalledTimes(1);
+		const calls = useModelCalls(runtime);
+		expect(calls[1]?.[0]).toBe(ModelType.ACTION_PLANNER);
+		const plannerParams = JSON.stringify(calls[1]?.[1] ?? {});
+		expect(plannerParams).toContain("SHELL");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"Filesystem usage is at 42%.",
+			);
+		}
+	});
+
+	it("does not promote a non-continuation turn from prior history (topic-switch control)", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: "You're welcome!",
+			}),
+		]);
+		runtime.actions = [
+			{
+				name: "SHELL",
+				similes: [],
+				description: "Run a local shell command.",
+				parameters: [],
+				examples: [],
+				validate: async () => true,
+				handler: vi.fn(async () => ({ success: true, text: "" })),
+			},
+		] as never;
+		const agentId = runtime.agentId;
+		const state = recentState([
+			{
+				id: "00000000-0000-0000-0000-00000000ee01" as UUID,
+				entityId: "00000000-0000-0000-0000-00000000ee11" as UUID,
+				agentId,
+				roomId,
+				createdAt: 1,
+				content: {
+					text: "show me disk usage on this server",
+					source: "test",
+				},
+			},
+			{
+				id: "00000000-0000-0000-0000-00000000ee02" as UUID,
+				entityId: agentId,
+				agentId,
+				roomId,
+				createdAt: 2,
+				content: { text: "On it.", source: "test" },
+			},
+		]);
+		runtime.composeState = vi.fn(async () => state);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "thanks, you are great" }),
+			state,
+			responseId: "00000000-0000-0000-0000-0000000000c3" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		expect(useModelCalls(runtime)).toHaveLength(1);
 	});
 });

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -6974,6 +6974,86 @@ describe("planner prior dialogue and continuation resolution (#17024)", () => {
 		}
 	});
 
+	it("still resolves an approval continuation after a planner-terminal STOP ack (#20324 review)", async () => {
+		const shellHandler = vi.fn(async () => ({
+			success: true,
+			text: "Filesystem usage: 42%",
+		}));
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: "Sure.",
+			}),
+			{
+				thought: "Run the pending disk-usage request.",
+				toolCalls: [
+					{
+						id: "shell-disk-usage-stop",
+						name: "SHELL",
+						args: { command: "df -h" },
+					},
+				],
+			},
+			JSON.stringify({
+				success: true,
+				decision: "FINISH",
+				thought: "Shell returned the disk usage.",
+				messageToUser: "Filesystem usage is at 42%.",
+			}),
+		]);
+		runtime.actions = [
+			{
+				name: "SHELL",
+				similes: [],
+				description: "Run a local shell command.",
+				parameters: [
+					{
+						name: "command",
+						description: "Command to run",
+						required: true,
+						schema: { type: "string" },
+					},
+				],
+				examples: [],
+				validate: async () => true,
+				handler: shellHandler,
+			},
+		] as never;
+		const agentId = runtime.agentId;
+		const state = recentState([
+			{
+				id: "00000000-0000-0000-0000-00000000ee11" as UUID,
+				entityId: "00000000-0000-0000-0000-000000000002" as UUID,
+				agentId,
+				roomId,
+				createdAt: 1,
+				content: {
+					text: "show me disk usage on this server",
+					source: "test",
+				},
+			},
+			{
+				id: "00000000-0000-0000-0000-00000000ee12" as UUID,
+				entityId: agentId,
+				agentId,
+				roomId,
+				createdAt: 2,
+				content: { text: "On it.", source: "test", actions: ["STOP"] },
+			},
+		]);
+		runtime.composeState = vi.fn(async () => state);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "that is good" }),
+			state,
+			responseId: "00000000-0000-0000-0000-0000000000c6" as UUID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		expect(shellHandler).toHaveBeenCalledTimes(1);
+	});
+
 	it("does not promote a non-continuation turn from prior history (topic-switch control)", async () => {
 		const runtime = makeRuntime([
 			stage1Response({

--- a/packages/core/src/__tests__/planner-continuation.live.test.ts
+++ b/packages/core/src/__tests__/planner-continuation.live.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Exercises continuation resolution through the real Cerebras-backed,
+ * PGlite-backed message loop. The live harness proves directive and approval
+ * turns execute the pending tool while an unrelated topic switch does not.
+ */
+
+import { writeFile } from "node:fs/promises";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+	ChannelType,
+	createMessageMemory,
+	type HandlerCallback,
+	type Memory,
+	stringToUuid,
+	type UUID,
+} from "../index.ts";
+import {
+	createRealTestRuntime,
+	type RealTestRuntimeResult,
+} from "../testing/index.ts";
+
+interface LiveTrajectoryDetail {
+	metrics?: { finalStatus?: string };
+	steps?: Array<{
+		llmCalls?: Array<{
+			provider?: string;
+			response?: string;
+		}>;
+	}>;
+}
+
+interface LiveTrajectoryService {
+	flushWriteQueue?: (trajectoryId: string) => Promise<void>;
+	getTrajectoryDetail?: (
+		trajectoryId: string,
+	) => Promise<LiveTrajectoryDetail | null>;
+}
+
+const liveDescribe =
+	process.env.ELIZA_RUN_LIVE_TESTS === "1" &&
+	process.env.CEREBRAS_API_KEY?.trim()
+		? describe
+		: describe.skip;
+
+liveDescribe("planner continuation — live Cerebras message loop", () => {
+	let harness: RealTestRuntimeResult;
+	const toolCalls = vi.fn(async (_runtime, _message, _state, _options) => ({
+		success: true,
+		text: "Filesystem usage: 42%",
+	}));
+	const webCalls = vi.fn(async (_runtime, _message, _state, _options) => ({
+		success: true,
+		text: "Tokyo is 24°C with clear skies.",
+	}));
+	const evidence: Array<Record<string, unknown>> = [];
+
+	beforeAll(async () => {
+		harness = await createRealTestRuntime({
+			characterName: "ContinuationProofAgent",
+			withLLM: true,
+			preferredProvider: "openai",
+		});
+		if (harness.providerConfig?.baseUrl !== "https://api.cerebras.ai/v1") {
+			throw new Error("Live continuation proof requires the Cerebras provider");
+		}
+		harness.runtime.registerAction({
+			name: "SHELL",
+			similes: ["RUN_SHELL_COMMAND"],
+			description: "Run a local shell command and return its output.",
+			tags: ["shell-direct"],
+			contextGate: {},
+			roleGate: {},
+			parameters: [
+				{
+					name: "command",
+					description: "The shell command to run",
+					required: true,
+					schema: { type: "string" },
+				},
+			],
+			examples: [],
+			validate: async () => true,
+			handler: toolCalls,
+		});
+		harness.runtime.registerAction({
+			name: "WEB_SEARCH",
+			similes: ["SEARCH_WEB"],
+			description: "Search the web for current information.",
+			tags: ["web-search"],
+			contextGate: {},
+			roleGate: {},
+			parameters: [
+				{
+					name: "query",
+					description: "The web search query",
+					required: true,
+					schema: { type: "string" },
+				},
+			],
+			examples: [],
+			validate: async () => true,
+			handler: webCalls,
+		});
+	}, 180_000);
+
+	afterAll(async () => {
+		const evidencePath = process.env.PR20227_EVIDENCE_PATH?.trim();
+		if (evidencePath) {
+			await writeFile(
+				evidencePath,
+				`${JSON.stringify(
+					{
+						provider: harness.providerName,
+						baseUrl: harness.providerConfig?.baseUrl,
+						model: harness.providerConfig?.model,
+						evidence,
+					},
+					null,
+					2,
+				)}\n`,
+			);
+		}
+		await harness?.cleanup();
+	});
+
+	async function runTurn(params: {
+		caseName: string;
+		assistantActions?: string[];
+		currentText: string;
+	}) {
+		const roomId = stringToUuid(`continuation-room:${params.caseName}`) as UUID;
+		const worldId = stringToUuid(
+			`continuation-world:${params.caseName}`,
+		) as UUID;
+		const senderId = stringToUuid(
+			`continuation-sender:${params.caseName}`,
+		) as UUID;
+		await harness.runtime.ensureConnection({
+			entityId: senderId,
+			roomId,
+			worldId,
+			userName: "Continuation requester",
+			source: "test",
+			channelId: roomId,
+			type: ChannelType.DM,
+		});
+
+		const priorUser = createMessageMemory({
+			id: stringToUuid(`continuation-prior-user:${params.caseName}`) as UUID,
+			entityId: senderId,
+			roomId,
+			createdAt: 1,
+			content: {
+				text: "show me disk usage on this server",
+				source: "test",
+				channelType: ChannelType.DM,
+			},
+		});
+		const priorAssistant = createMessageMemory({
+			id: stringToUuid(`continuation-prior-agent:${params.caseName}`) as UUID,
+			entityId: harness.runtime.agentId,
+			roomId,
+			createdAt: 2,
+			content: {
+				text: "On it when you are ready.",
+				source: "test",
+				channelType: ChannelType.DM,
+				actions: params.assistantActions,
+			},
+		});
+		await harness.runtime.createMemory(priorUser, "messages");
+		await harness.runtime.createMemory(priorAssistant, "messages");
+
+		const message: Memory = createMessageMemory({
+			id: stringToUuid(`continuation-current:${params.caseName}`) as UUID,
+			entityId: senderId,
+			roomId,
+			createdAt: 3,
+			content: {
+				text: params.currentText,
+				source: "test",
+				channelType: ChannelType.DM,
+			},
+		});
+		const delivered: string[] = [];
+		const callback: HandlerCallback = async (content) => {
+			if (typeof content.text === "string" && content.text.trim()) {
+				delivered.push(content.text);
+			}
+			return [];
+		};
+		const service = harness.runtime.messageService;
+		if (!service) throw new Error("message service was not initialized");
+		const toolCallsBefore = toolCalls.mock.calls.length;
+		const webCallsBefore = webCalls.mock.calls.length;
+		const result = await service.handleMessage(
+			harness.runtime,
+			message,
+			callback,
+			{},
+		);
+
+		const trajectoryId = (message.metadata as { trajectoryId?: unknown } | null)
+			?.trajectoryId;
+		if (typeof trajectoryId !== "string" || !trajectoryId.trim()) {
+			throw new Error("live continuation turn did not create a trajectory");
+		}
+		const trajectoryService = harness.runtime.getService(
+			"trajectories",
+		) as LiveTrajectoryService | null;
+		if (typeof trajectoryService?.getTrajectoryDetail !== "function") {
+			throw new Error(
+				"live continuation turn has no readable trajectory service",
+			);
+		}
+		let trajectory: LiveTrajectoryDetail | null = null;
+		for (let attempt = 0; attempt < 50; attempt += 1) {
+			await trajectoryService.flushWriteQueue?.(trajectoryId);
+			trajectory = await trajectoryService.getTrajectoryDetail(trajectoryId);
+			if (trajectory?.metrics?.finalStatus === "completed") break;
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		if (!trajectory)
+			throw new Error("live continuation trajectory was not persisted");
+		const modelResponses =
+			trajectory.steps
+				?.flatMap((step) => step.llmCalls ?? [])
+				.map((call) => ({
+					provider: call.provider,
+					response: call.response,
+				}))
+				.filter((call) => Boolean(call.response?.trim())) ?? [];
+		const record = {
+			caseName: params.caseName,
+			priorUser: priorUser.content,
+			priorAssistant: priorAssistant.content,
+			currentText: params.currentText,
+			shellToolCalls: toolCalls.mock.calls.length - toolCallsBefore,
+			webToolCalls: webCalls.mock.calls.length - webCallsBefore,
+			delivered,
+			responseContent: result.responseContent,
+			trajectoryStatus: trajectory.metrics?.finalStatus,
+			modelResponses,
+		};
+		evidence.push(record);
+		return record;
+	}
+
+	it("executes directive and STOP-approved continuations without replaying on a topic switch", async () => {
+		const directive = await runTurn({
+			caseName: "directive",
+			currentText: "finish my request",
+		});
+		expect(directive.trajectoryStatus).toBe("completed");
+		expect(directive.modelResponses.length).toBeGreaterThan(0);
+		expect(directive.shellToolCalls).toBe(1);
+		expect(directive.webToolCalls).toBe(0);
+
+		const approvalAfterStop = await runTurn({
+			caseName: "approval-after-stop",
+			assistantActions: ["STOP"],
+			currentText: "that is good",
+		});
+		expect(approvalAfterStop.trajectoryStatus).toBe("completed");
+		expect(approvalAfterStop.modelResponses.length).toBeGreaterThan(0);
+		expect(approvalAfterStop.shellToolCalls).toBe(1);
+		expect(approvalAfterStop.webToolCalls).toBe(0);
+
+		const topicSwitch = await runTurn({
+			caseName: "topic-switch",
+			currentText: "What is the weather in Tokyo right now?",
+		});
+		expect(topicSwitch.trajectoryStatus).toBe("completed");
+		expect(topicSwitch.modelResponses.length).toBeGreaterThan(0);
+		expect(topicSwitch.shellToolCalls).toBe(0);
+		expect(topicSwitch.webToolCalls).toBe(1);
+	}, 300_000);
+});

--- a/packages/core/src/action-names.test.ts
+++ b/packages/core/src/action-names.test.ts
@@ -6,9 +6,11 @@
 import { describe, expect, it } from "vitest";
 import {
 	IGNORE_ACTION_NAME,
+	isReservedNonToolActionName,
 	NON_EXECUTABLE_RESPONSE_ACTION_NAMES,
 	NONE_ACTION_NAME,
 	REPLY_ACTION_NAME,
+	STOP_ACTION_NAME,
 } from "./action-names";
 
 describe("action name contracts", () => {
@@ -18,5 +20,18 @@ describe("action name contracts", () => {
 			NONE_ACTION_NAME,
 			IGNORE_ACTION_NAME,
 		]);
+	});
+
+	it("treats the exported envelope and planner-terminal STOP as non-tools", () => {
+		for (const name of [
+			...NON_EXECUTABLE_RESPONSE_ACTION_NAMES,
+			STOP_ACTION_NAME,
+			"stop",
+			"RE_PLY",
+		]) {
+			expect(isReservedNonToolActionName(name)).toBe(true);
+		}
+		expect(isReservedNonToolActionName("SHELL")).toBe(false);
+		expect(isReservedNonToolActionName("CONTINUE")).toBe(false);
 	});
 });

--- a/packages/core/src/action-names.ts
+++ b/packages/core/src/action-names.ts
@@ -7,9 +7,28 @@
 export const REPLY_ACTION_NAME = "REPLY";
 export const NONE_ACTION_NAME = "NONE";
 export const IGNORE_ACTION_NAME = "IGNORE";
+export const STOP_ACTION_NAME = "STOP";
 
 export const NON_EXECUTABLE_RESPONSE_ACTION_NAMES = [
 	REPLY_ACTION_NAME,
 	NONE_ACTION_NAME,
 	IGNORE_ACTION_NAME,
 ] as const;
+
+/**
+ * Protocol names that are not completed tools. Continuation resolution must
+ * agree with the planner: REPLY/NONE/IGNORE are the exported non-executable
+ * envelope, and STOP is the extra planner terminal
+ * (`isTerminalPlannerToolName`) — not a side-effecting result.
+ */
+export function isReservedNonToolActionName(name: string): boolean {
+	const normalized = name.toUpperCase().replace(/_/g, "");
+	if (
+		(NON_EXECUTABLE_RESPONSE_ACTION_NAMES as readonly string[]).some(
+			(entry) => entry.toUpperCase().replace(/_/g, "") === normalized,
+		)
+	) {
+		return true;
+	}
+	return normalized === STOP_ACTION_NAME;
+}

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -356,6 +356,7 @@ import {
 	looksLikeLocalShellRequest,
 	looksLikeWebSearchRequest,
 	normalizeActionIdentifier,
+	resolveExplicitContinuationRequestText,
 } from "./message/direct-action-heuristics";
 import {
 	buildFailureReplyPrompt,
@@ -2264,12 +2265,57 @@ function priorDialogueContent(text: string, speaker?: string): string {
 	return `${speaker}: ${text}`;
 }
 
+/**
+ * How many of the agent's own prior turns the tool-planner context renders.
+ * Enough to cover the pending question/preview plus a short back-and-forth,
+ * small enough to keep the stale-answer surface and token cost bounded.
+ */
+const PLANNER_MAX_OWN_REPLY_TURNS = 4;
+
+/**
+ * Structural marker for an assistant memory whose text is a tool-derived
+ * answer rather than plain dialogue: it carries merged action-callback
+ * history, or its recorded actions include a real tool (anything beyond the
+ * reply/none envelope). The planner context excludes these rows so a stale
+ * tool-derived answer is never parroted in place of a fresh tool run.
+ */
+function isToolDerivedAssistantContent(content: Memory["content"]): boolean {
+	if (!content || typeof content !== "object") return false;
+	const callbackHistory = (content as { actionCallbackHistory?: unknown })
+		.actionCallbackHistory;
+	if (Array.isArray(callbackHistory) && callbackHistory.length > 0) {
+		return true;
+	}
+	const actions = (content as { actions?: unknown }).actions;
+	if (!Array.isArray(actions)) return false;
+	return actions.some((action) => {
+		if (typeof action !== "string") return false;
+		const normalized = normalizeActionIdentifier(action);
+		return (
+			normalized.length > 0 &&
+			normalized !== "REPLY" &&
+			normalized !== "NONE" &&
+			normalized !== "IGNORE"
+		);
+	});
+}
+
 function appendPriorDialogueEvents(
 	events: ContextEvent[],
 	runtime: IAgentRuntime,
 	state: State,
 	currentMessage: Memory,
-	options?: { includeOwnReplies?: boolean },
+	options?: {
+		includeOwnReplies?: boolean;
+		/**
+		 * Planner mode: keep ordinary own replies (questions, previews, acks —
+		 * what "yes"/"finish it" refers to) while excluding tool-derived own
+		 * answers structurally (stale-answer hazard) and bounding how many own
+		 * turns render.
+		 */
+		excludeToolDerivedOwnReplies?: boolean;
+		maxOwnReplies?: number;
+	},
 ): void {
 	const includeOwnReplies = options?.includeOwnReplies ?? false;
 	const providers = state.data?.providers;
@@ -2297,12 +2343,19 @@ function appendPriorDialogueEvents(
 			// (role-tagged prior_message:agent below): the current_turn_boundary
 			// contract tells the model these blocks are its only chat-recall
 			// source, so dropping its own turns made it confabulate about what it
-			// previously said. The tool planner opts out (includeOwnReplies=false)
-			// because a planner that sees its own stale tool-derived answer
-			// parrots it instead of running the fresh check. The artifact guards
+			// previously said. The tool planner keeps ordinary own dialogue too
+			// (the question/preview a continuation turn refers to) but excludes
+			// tool-derived own answers structurally so it never parrots a stale
+			// tool result instead of running the fresh check. The artifact guards
 			// below still strip non-dialogue agent output for every sender.
-			if (!includeOwnReplies && m.entityId === runtime.agentId) {
-				return false;
+			if (m.entityId === runtime.agentId) {
+				if (!includeOwnReplies) return false;
+				if (
+					options?.excludeToolDerivedOwnReplies === true &&
+					isToolDerivedAssistantContent(m.content)
+				) {
+					return false;
+				}
 			}
 			if (
 				typeof m.content?.source === "string" &&
@@ -2329,6 +2382,20 @@ function appendPriorDialogueEvents(
 			return text.length > 0;
 		})
 		.sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0));
+	// Bound how many of the agent's own turns render (newest win): the planner
+	// needs the immediate question/preview a continuation refers to, not the
+	// agent's whole side of a long conversation.
+	const maxOwnReplies = options?.maxOwnReplies;
+	if (maxOwnReplies !== undefined) {
+		let ownRepliesKept = 0;
+		for (let index = dialogue.length - 1; index >= 0; index--) {
+			if (dialogue[index]?.entityId !== runtime.agentId) continue;
+			ownRepliesKept++;
+			if (ownRepliesKept > maxOwnReplies) {
+				dialogue.splice(index, 1);
+			}
+		}
+	}
 	for (const memory of dialogue) {
 		const text = getUserMessageText(memory);
 		if (!text) continue;
@@ -2503,20 +2570,52 @@ function looksLikePriorDialogueArtifact(text: string): boolean {
 	);
 }
 
-function hasStructuredRecentMessagesProvider(state: State): boolean {
-	const providers = state.data?.providers;
+function getStructuredRecentMessages(
+	state: State | undefined,
+): Memory[] | null {
+	const providers = state?.data?.providers;
 	if (!providers || typeof providers !== "object") {
-		return false;
+		return null;
 	}
 	const recent = (providers as Record<string, unknown>).RECENT_MESSAGES;
 	if (!recent || typeof recent !== "object") {
-		return false;
+		return null;
 	}
 	const data = (recent as { data?: unknown }).data;
-	return Boolean(
-		data &&
-			typeof data === "object" &&
-			Array.isArray((data as { recentMessages?: unknown }).recentMessages),
+	const recentMessages =
+		data && typeof data === "object" && "recentMessages" in data
+			? (data as { recentMessages?: unknown }).recentMessages
+			: undefined;
+	return Array.isArray(recentMessages) ? (recentMessages as Memory[]) : null;
+}
+
+function hasStructuredRecentMessagesProvider(state: State): boolean {
+	return getStructuredRecentMessages(state) !== null;
+}
+
+/**
+ * Resolves an explicit continuation turn ("finish my request", "that is
+ * good") to the nearest prior user request from the composed RECENT_MESSAGES
+ * window so candidate inference reruns against the request the turn refers
+ * to. Returns null for every non-continuation turn (topic switches, fresh
+ * asks, and turns without structured history are untouched); the resolved
+ * text feeds ONLY action-candidate inference — the prompt keeps the user's
+ * literal message.
+ */
+function resolveContinuationInferenceMessageText(
+	runtime: IAgentRuntime,
+	message: Memory,
+	state: State | undefined,
+): string | null {
+	const currentText = getUserMessageText(message);
+	if (!currentText?.trim()) return null;
+	const recentMessages = getStructuredRecentMessages(state);
+	if (!recentMessages) return null;
+	return resolveExplicitContinuationRequestText(
+		currentText,
+		recentMessages,
+		runtime.agentId,
+		message.id,
 	);
 }
 
@@ -3364,10 +3463,18 @@ async function createV5MessageContextObject(args: {
 
 	appendPriorDialogueEvents(events, args.runtime, args.state, args.message, {
 		// The response handler needs the agent's own prior turns for grounded
-		// chat recall ("did you tell me X?"); the tool planner must not see its
-		// own stale tool-derived answers or it answers from them instead of
-		// executing the fresh check the user asked for.
-		includeOwnReplies: !args.includeTools,
+		// chat recall ("did you tell me X?"). The tool planner needs the
+		// ordinary ones too — the question/preview a continuation turn ("finish
+		// it", "that is good") refers to — but role-wide inclusion resurrects
+		// the stale-answer hazard, so the planner's window is bounded and
+		// excludes tool-derived own answers structurally.
+		includeOwnReplies: true,
+		...(args.includeTools
+			? {
+					excludeToolDerivedOwnReplies: true,
+					maxOwnReplies: PLANNER_MAX_OWN_REPLY_TURNS,
+				}
+			: {}),
 	});
 
 	// Contexts are routing taxonomy, not proof that a handler exists. Promise
@@ -3409,7 +3516,7 @@ async function createV5MessageContextObject(args: {
 		source: "message-service",
 		stable: false,
 		content: args.includeTools
-			? "current_turn_boundary: Plan and execute only the final message:user. Prior messages and reply_reference are context for resolving references, never pending commands. Stage 1 already decided this turn needs tools; use current tool results for live data and side effects, and never claim work that no tool result proves."
+			? 'current_turn_boundary: Plan and execute only the final message:user. Prior messages and reply_reference are context for resolving references, never pending commands. The prior_message:agent blocks are your own earlier replies, shown only so you can resolve what a continuation like "finish it", "yes", or "that is good" refers to — treat every fact in them as stale. Stage 1 already decided this turn needs tools; use current tool results for live data and side effects, never answer by repeating a prior reply in place of executing the fresh check, and never claim work that no tool result proves.'
 			: 'current_turn_boundary: The prior_message blocks above are context only. If a reply_reference block follows, it is the platform message that the final message:user is replying to; use it only to resolve references such as this/that/it. Execute and answer only the final message:user below. Do not merge separate prior requests into the current task unless the final message explicitly references them. Exception for visible-context recall: when the final message asks a recall question about what was said in this conversation (who mentioned X, did anyone bring up Y, what did I say about Z, what was the last message, did you yourself say W), you may scan the prior_message blocks above and answer from what is literally visible there. This recall exception covers only what was literally SAID in the visible chat. It does NOT cover the user\'s tracked work: a recap, status, or what-did-I-get-done ask about their todos, tasks, reminders, habits, goals, notes, or day ("recap my day", "what\'s left today", "did I finish everything", "how did I do this week") is a live tasks lookup, not chat recall — route it to the tasks tools and answer from what they return; never report an empty or missing day from the visible window alone.' +
 				// Only the chat-recall context renders the agent's own prior turns;
 				// the tool-planner context deliberately omits them (stale-answer
@@ -4132,7 +4239,7 @@ export const BUILTIN_RESPONSE_HANDLER_EVALUATORS: readonly ResponseHandlerEvalua
 			description:
 				"Promotes simple-path replies to planning when the current user request matches a registered action's metadata.",
 			priority: 20,
-			shouldRun: ({ message, messageHandler, runtime }) => {
+			shouldRun: ({ message, messageHandler, runtime, state }) => {
 				if (messageHandler.processMessage !== "RESPOND") return false;
 				if (messageHandler.plan.requiresTool === true) return false;
 				// A sub-agent completion relay is owned by the sub-agent-completion
@@ -4149,9 +4256,15 @@ export const BUILTIN_RESPONSE_HANDLER_EVALUATORS: readonly ResponseHandlerEvalua
 				if (nonSimpleContexts.length > 0) return false;
 				const text = getUserMessageText(message);
 				if (!text?.trim()) return false;
+				// A continuation turn ("finish it", "that is good") has no
+				// inferable intent of its own — rerun inference on the resolved
+				// nearest prior user request instead.
+				const inferenceText =
+					resolveContinuationInferenceMessageText(runtime, message, state) ??
+					text;
 				const inference = inferDirectCurrentRequestCandidateInference(
 					runtime.actions ?? [],
-					text,
+					inferenceText,
 				);
 				if (inference.names.length === 0) return false;
 				// Same escalation valve as messageHandlerFromFieldResult: this
@@ -4165,11 +4278,14 @@ export const BUILTIN_RESPONSE_HANDLER_EVALUATORS: readonly ResponseHandlerEvalua
 					stageOneCandidateActions: messageHandler.plan.candidateActions ?? [],
 				});
 			},
-			evaluate: ({ message, messageHandler, runtime }) => {
+			evaluate: ({ message, messageHandler, runtime, state }) => {
 				const text = getUserMessageText(message) ?? "";
+				const inferenceText =
+					resolveContinuationInferenceMessageText(runtime, message, state) ??
+					text;
 				const inference = inferDirectCurrentRequestCandidateInference(
 					runtime.actions ?? [],
-					text,
+					inferenceText,
 				);
 				const candidateActions = shouldSuppressInferredCandidateEscalation({
 					inference,
@@ -7810,6 +7926,27 @@ export async function runV5MessageRuntimeStage1(args: {
 			ModelType.RESPONSE_HANDLER,
 		);
 		const rawFieldParsed = extractMessageHandlerRawParsed(rawMessageHandler);
+		// An explicit continuation turn ("finish my request", "that is good")
+		// carries no inferable intent of its own, so candidate inference runs on
+		// the nearest pending prior user request instead. The substitution feeds
+		// only routing heuristics — prompts keep the literal user text.
+		const continuationResolvedMessageText =
+			resolveContinuationInferenceMessageText(
+				args.runtime,
+				args.message,
+				args.state,
+			);
+		const inferenceMessageText =
+			continuationResolvedMessageText ?? getUserMessageText(args.message);
+		if (continuationResolvedMessageText) {
+			args.runtime.logger?.debug?.(
+				{
+					src: "service:message",
+					resolvedRequest: continuationResolvedMessageText.slice(0, 200),
+				},
+				"[message] continuation turn resolved to prior user request for candidate inference",
+			);
+		}
 		let fieldRunResult: ResponseHandlerFieldRunResult | null = null;
 		let messageHandler: MessageHandlerResult | null = null;
 		if (rawFieldParsed) {
@@ -7830,7 +7967,7 @@ export async function runV5MessageRuntimeStage1(args: {
 				fieldRunResult,
 				{
 					actions: args.runtime.actions,
-					messageText: getUserMessageText(args.message),
+					messageText: inferenceMessageText,
 					candidateBackstopRules: getCandidateActionBackstopRules(args.runtime),
 					subAgentCompletionRelay: isSubAgentCompletionArtifact(args.message),
 				},
@@ -7839,7 +7976,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		if (!messageHandler) {
 			messageHandler = parseMessageHandlerModelOutput(rawMessageHandler, {
 				actions: args.runtime.actions,
-				messageText: getUserMessageText(args.message),
+				messageText: inferenceMessageText,
 				subAgentCompletionRelay: isSubAgentCompletionArtifact(args.message),
 			});
 		}
@@ -7881,7 +8018,7 @@ export async function runV5MessageRuntimeStage1(args: {
 			messageHandler = synthesizePlannerFallbackFromStage1Failure({
 				reason: stage1FailureReason,
 				actions: args.runtime.actions,
-				messageText: getUserMessageText(args.message),
+				messageText: inferenceMessageText,
 			});
 			args.runtime.logger?.warn?.(
 				{
@@ -8333,7 +8470,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		// heuristic must not undo that decision.
 		const directPlannerInference = inferDirectCurrentRequestCandidateInference(
 			args.runtime.actions ?? [],
-			getUserMessageText(args.message) ?? "",
+			inferenceMessageText ?? "",
 		);
 		const directPlannerCandidateActions = directPlannerInference.names;
 		if (

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -351,6 +351,7 @@ import {
 	inferLocalShellCommandFromMessageText,
 	inferWebSearchQueryFromMessageText,
 	isShellDirectActionName,
+	isToolDerivedAssistantContent,
 	LEGACY_CODING_DELEGATION_ACTION_NAMES,
 	looksLikeBareLinkShare,
 	looksLikeLocalShellRequest,
@@ -2279,27 +2280,6 @@ const PLANNER_MAX_OWN_REPLY_TURNS = 4;
  * reply/none envelope). The planner context excludes these rows so a stale
  * tool-derived answer is never parroted in place of a fresh tool run.
  */
-function isToolDerivedAssistantContent(content: Memory["content"]): boolean {
-	if (!content || typeof content !== "object") return false;
-	const callbackHistory = (content as { actionCallbackHistory?: unknown })
-		.actionCallbackHistory;
-	if (Array.isArray(callbackHistory) && callbackHistory.length > 0) {
-		return true;
-	}
-	const actions = (content as { actions?: unknown }).actions;
-	if (!Array.isArray(actions)) return false;
-	return actions.some((action) => {
-		if (typeof action !== "string") return false;
-		const normalized = normalizeActionIdentifier(action);
-		return (
-			normalized.length > 0 &&
-			normalized !== "REPLY" &&
-			normalized !== "NONE" &&
-			normalized !== "IGNORE"
-		);
-	});
-}
-
 function appendPriorDialogueEvents(
 	events: ContextEvent[],
 	runtime: IAgentRuntime,
@@ -2615,6 +2595,7 @@ function resolveContinuationInferenceMessageText(
 		currentText,
 		recentMessages,
 		runtime.agentId,
+		message.entityId,
 		message.id,
 	);
 }

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -7940,10 +7940,7 @@ export async function runV5MessageRuntimeStage1(args: {
 			continuationResolvedMessageText ?? getUserMessageText(args.message);
 		if (continuationResolvedMessageText) {
 			args.runtime.logger?.debug?.(
-				{
-					src: "service:message",
-					resolvedRequest: continuationResolvedMessageText.slice(0, 200),
-				},
+				{ src: "service:message" },
 				"[message] continuation turn resolved to prior user request for candidate inference",
 			);
 		}

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -1508,10 +1508,13 @@ describe("classifyExplicitContinuationTurn", () => {
 
 describe("resolveExplicitContinuationRequestText", () => {
 	const AGENT_ID = "00000000-0000-0000-0000-0000000000aa";
+	const USER_ID = "00000000-0000-0000-0000-0000000000bb";
+	const OTHER_USER_ID = "00000000-0000-0000-0000-0000000000cc";
 	const room = (
 		entries: Array<{
 			id: string;
 			agent?: boolean;
+			entity?: string;
 			text: string;
 			createdAt: number;
 			callbacks?: string[];
@@ -1520,7 +1523,7 @@ describe("resolveExplicitContinuationRequestText", () => {
 	) =>
 		entries.map((entry) => ({
 			id: entry.id,
-			entityId: entry.agent ? AGENT_ID : "00000000-0000-0000-0000-0000000000bb",
+			entityId: entry.agent ? AGENT_ID : (entry.entity ?? USER_ID),
 			createdAt: entry.createdAt,
 			content: {
 				text: entry.text,
@@ -1543,6 +1546,7 @@ describe("resolveExplicitContinuationRequestText", () => {
 				{ id: "m3", text: "finish my request", createdAt: 3 },
 			]),
 			AGENT_ID,
+			USER_ID,
 			"m3",
 		);
 		expect(resolved).toBe("track a 30 minute run for me");
@@ -1556,6 +1560,7 @@ describe("resolveExplicitContinuationRequestText", () => {
 				{ id: "m2", agent: true, text: "On it.", createdAt: 2 },
 			]),
 			AGENT_ID,
+			USER_ID,
 		);
 		expect(pending).toBe("run ls in my home directory");
 
@@ -1572,6 +1577,7 @@ describe("resolveExplicitContinuationRequestText", () => {
 				},
 			]),
 			AGENT_ID,
+			USER_ID,
 		);
 		expect(delivered).toBe(null);
 	});
@@ -1584,6 +1590,7 @@ describe("resolveExplicitContinuationRequestText", () => {
 				{ id: "m2", agent: true, text: "Done.", createdAt: 2 },
 			]),
 			AGENT_ID,
+			USER_ID,
 		);
 		expect(resolved).toBe(null);
 	});
@@ -1597,6 +1604,7 @@ describe("resolveExplicitContinuationRequestText", () => {
 				{ id: "m3", text: "delete the temporary file", createdAt: 3 },
 			]),
 			AGENT_ID,
+			USER_ID,
 		);
 		expect(resolved).toBe(null);
 	});
@@ -1615,6 +1623,7 @@ describe("resolveExplicitContinuationRequestText", () => {
 				},
 			]),
 			AGENT_ID,
+			USER_ID,
 		);
 		expect(resolved).toBe(null);
 	});
@@ -1625,10 +1634,16 @@ describe("resolveExplicitContinuationRequestText", () => {
 				"what's the weather in tokyo?",
 				room([{ id: "m1", text: "track a run", createdAt: 1 }]),
 				AGENT_ID,
+				USER_ID,
 			),
 		).toBe(null);
 		expect(
-			resolveExplicitContinuationRequestText("finish it", [], AGENT_ID),
+			resolveExplicitContinuationRequestText(
+				"finish it",
+				[],
+				AGENT_ID,
+				USER_ID,
+			),
 		).toBe(null);
 	});
 
@@ -1643,8 +1658,37 @@ describe("resolveExplicitContinuationRequestText", () => {
 				{ id: "m5", text: "finish it", createdAt: 5 },
 			]),
 			AGENT_ID,
+			USER_ID,
 			"m5",
 		);
 		expect(resolved).toBe("run df -h on the server");
+	});
+
+	it("never resolves another participant's request", () => {
+		const messages = room([
+			{
+				id: "m1",
+				entity: OTHER_USER_ID,
+				text: "delete my deployment",
+				createdAt: 1,
+			},
+			{ id: "m2", agent: true, text: "Should I delete it?", createdAt: 2 },
+		]);
+		expect(
+			resolveExplicitContinuationRequestText(
+				"go ahead",
+				messages,
+				AGENT_ID,
+				USER_ID,
+			),
+		).toBe(null);
+		expect(
+			resolveExplicitContinuationRequestText(
+				"go ahead",
+				messages,
+				AGENT_ID,
+				OTHER_USER_ID,
+			),
+		).toBe("delete my deployment");
 	});
 });

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -1515,6 +1515,7 @@ describe("resolveExplicitContinuationRequestText", () => {
 			text: string;
 			createdAt: number;
 			callbacks?: string[];
+			actions?: string[];
 		}>,
 	) =>
 		entries.map((entry) => ({
@@ -1524,6 +1525,7 @@ describe("resolveExplicitContinuationRequestText", () => {
 			content: {
 				text: entry.text,
 				...(entry.callbacks ? { actionCallbackHistory: entry.callbacks } : {}),
+				...(entry.actions ? { actions: entry.actions } : {}),
 			},
 		}));
 
@@ -1572,6 +1574,49 @@ describe("resolveExplicitContinuationRequestText", () => {
 			AGENT_ID,
 		);
 		expect(delivered).toBe(null);
+	});
+
+	it("does not treat a short completed reply as pending approval", () => {
+		const resolved = resolveExplicitContinuationRequestText(
+			"that is great",
+			room([
+				{ id: "m1", text: "delete the temporary file", createdAt: 1 },
+				{ id: "m2", agent: true, text: "Done.", createdAt: 2 },
+			]),
+			AGENT_ID,
+		);
+		expect(resolved).toBe(null);
+	});
+
+	it("does not approve a new user request against an older assistant turn", () => {
+		const resolved = resolveExplicitContinuationRequestText(
+			"yes",
+			room([
+				{ id: "m1", text: "show my files", createdAt: 1 },
+				{ id: "m2", agent: true, text: "Want me to continue?", createdAt: 2 },
+				{ id: "m3", text: "delete the temporary file", createdAt: 3 },
+			]),
+			AGENT_ID,
+		);
+		expect(resolved).toBe(null);
+	});
+
+	it("does not approve an assistant turn marked as tool-derived", () => {
+		const resolved = resolveExplicitContinuationRequestText(
+			"sounds good",
+			room([
+				{ id: "m1", text: "show my files", createdAt: 1 },
+				{
+					id: "m2",
+					agent: true,
+					text: "On it.",
+					createdAt: 2,
+					actions: ["SHELL"],
+				},
+			]),
+			AGENT_ID,
+		);
+		expect(resolved).toBe(null);
 	});
 
 	it("returns null for non-continuation turns and empty history", () => {

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import type { Action } from "../../types/components";
 import {
+	classifyExplicitContinuationTurn,
 	findAvailableActionName,
 	findCodingDelegationActionName,
 	findShellDirectActionName,
@@ -21,6 +22,7 @@ import {
 	looksLikeBareLinkShare,
 	looksLikeLocalShellRequest,
 	looksLikeWebSearchRequest,
+	resolveExplicitContinuationRequestText,
 } from "./direct-action-heuristics.ts";
 
 /** The exact processed-content shape Discord produces for a shared link with a
@@ -1457,5 +1459,147 @@ describe("batch-1 matrix fixes: budget noun + scheduled-item admin (F3/F5)", () 
 				"draw up a plan for the garage",
 			).kind,
 		).not.toBe("media-generation");
+	});
+});
+describe("classifyExplicitContinuationTurn", () => {
+	it("classifies directive continuations", () => {
+		expect(classifyExplicitContinuationTurn("finish my request")).toBe(
+			"directive",
+		);
+		expect(classifyExplicitContinuationTurn("Finish it.")).toBe("directive");
+		expect(classifyExplicitContinuationTurn("continue")).toBe("directive");
+		expect(classifyExplicitContinuationTurn("ok, go ahead")).toBe("directive");
+		expect(classifyExplicitContinuationTurn("yes please do it")).toBe(
+			"directive",
+		);
+		expect(classifyExplicitContinuationTurn("keep going")).toBe("directive");
+	});
+
+	it("classifies approval continuations", () => {
+		expect(classifyExplicitContinuationTurn("that is good")).toBe("approval");
+		expect(classifyExplicitContinuationTurn("that's good, go ahead")).toBe(
+			"approval",
+		);
+		expect(classifyExplicitContinuationTurn("yes")).toBe("approval");
+		expect(classifyExplicitContinuationTurn("sounds good")).toBe("approval");
+		expect(classifyExplicitContinuationTurn("that works")).toBe("approval");
+	});
+
+	it("rejects ordinary chat, topic switches, and questions", () => {
+		expect(classifyExplicitContinuationTurn("that is a good question")).toBe(
+			null,
+		);
+		expect(
+			classifyExplicitContinuationTurn("how tall is the eiffel tower?"),
+		).toBe(null);
+		expect(
+			classifyExplicitContinuationTurn("finish my sandwich and tell me a joke"),
+		).toBe(null);
+		expect(classifyExplicitContinuationTurn("good morning")).toBe(null);
+		expect(classifyExplicitContinuationTurn("is that good?")).toBe(null);
+		expect(classifyExplicitContinuationTurn("")).toBe(null);
+		expect(
+			classifyExplicitContinuationTurn(
+				"that is good but now let's talk about the weather in tokyo instead",
+			),
+		).toBe(null);
+	});
+});
+
+describe("resolveExplicitContinuationRequestText", () => {
+	const AGENT_ID = "00000000-0000-0000-0000-0000000000aa";
+	const room = (
+		entries: Array<{
+			id: string;
+			agent?: boolean;
+			text: string;
+			createdAt: number;
+			callbacks?: string[];
+		}>,
+	) =>
+		entries.map((entry) => ({
+			id: entry.id,
+			entityId: entry.agent ? AGENT_ID : "00000000-0000-0000-0000-0000000000bb",
+			createdAt: entry.createdAt,
+			content: {
+				text: entry.text,
+				...(entry.callbacks ? { actionCallbackHistory: entry.callbacks } : {}),
+			},
+		}));
+
+	it("resolves a directive continuation to the nearest prior user request", () => {
+		const resolved = resolveExplicitContinuationRequestText(
+			"finish my request",
+			room([
+				{ id: "m1", text: "track a 30 minute run for me", createdAt: 1 },
+				{
+					id: "m2",
+					agent: true,
+					text: "Want me to log it as cardio?",
+					createdAt: 2,
+				},
+				{ id: "m3", text: "finish my request", createdAt: 3 },
+			]),
+			AGENT_ID,
+			"m3",
+		);
+		expect(resolved).toBe("track a 30 minute run for me");
+	});
+
+	it("resolves an approval turn only while the agent's last reply looks pending", () => {
+		const pending = resolveExplicitContinuationRequestText(
+			"that is good",
+			room([
+				{ id: "m1", text: "run ls in my home directory", createdAt: 1 },
+				{ id: "m2", agent: true, text: "On it.", createdAt: 2 },
+			]),
+			AGENT_ID,
+		);
+		expect(pending).toBe("run ls in my home directory");
+
+		const delivered = resolveExplicitContinuationRequestText(
+			"that is good",
+			room([
+				{ id: "m1", text: "run ls in my home directory", createdAt: 1 },
+				{
+					id: "m2",
+					agent: true,
+					text: "Here are your files: a.txt b.txt",
+					createdAt: 2,
+					callbacks: ["Here are your files: a.txt b.txt"],
+				},
+			]),
+			AGENT_ID,
+		);
+		expect(delivered).toBe(null);
+	});
+
+	it("returns null for non-continuation turns and empty history", () => {
+		expect(
+			resolveExplicitContinuationRequestText(
+				"what's the weather in tokyo?",
+				room([{ id: "m1", text: "track a run", createdAt: 1 }]),
+				AGENT_ID,
+			),
+		).toBe(null);
+		expect(
+			resolveExplicitContinuationRequestText("finish it", [], AGENT_ID),
+		).toBe(null);
+	});
+
+	it("skips prior continuation turns instead of chaining them", () => {
+		const resolved = resolveExplicitContinuationRequestText(
+			"finish it",
+			room([
+				{ id: "m1", text: "run df -h on the server", createdAt: 1 },
+				{ id: "m2", agent: true, text: "Should I run it now?", createdAt: 2 },
+				{ id: "m3", text: "go ahead", createdAt: 3 },
+				{ id: "m4", agent: true, text: "Working on it.", createdAt: 4 },
+				{ id: "m5", text: "finish it", createdAt: 5 },
+			]),
+			AGENT_ID,
+			"m5",
+		);
+		expect(resolved).toBe("run df -h on the server");
 	});
 });

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -18,6 +18,7 @@ import {
 	inferDirectCurrentRequestCandidateActions,
 	inferDirectCurrentRequestCandidateInference,
 	isShellDirectActionName,
+	isToolDerivedAssistantContent,
 	linkShareOwnText,
 	looksLikeBareLinkShare,
 	looksLikeLocalShellRequest,
@@ -1690,5 +1691,47 @@ describe("resolveExplicitContinuationRequestText", () => {
 				OTHER_USER_ID,
 			),
 		).toBe("delete my deployment");
+	});
+
+	it("does not treat planner-terminal STOP as a completed tool (#20324 review)", () => {
+		expect(isToolDerivedAssistantContent({ actions: ["STOP"] })).toBe(false);
+		expect(isToolDerivedAssistantContent({ actions: ["REPLY"] })).toBe(false);
+		expect(
+			isToolDerivedAssistantContent({ actions: ["DELETE_DEPLOYMENT"] }),
+		).toBe(true);
+		expect(
+			resolveExplicitContinuationRequestText(
+				"that is good",
+				room([
+					{ id: "m1", text: "run ls in my home directory", createdAt: 1 },
+					{
+						id: "m2",
+						agent: true,
+						text: "On it.",
+						createdAt: 2,
+						actions: ["STOP"],
+					},
+				]),
+				AGENT_ID,
+				USER_ID,
+			),
+		).toBe("run ls in my home directory");
+		expect(
+			resolveExplicitContinuationRequestText(
+				"that is good",
+				room([
+					{ id: "m1", text: "run ls in my home directory", createdAt: 1 },
+					{
+						id: "m2",
+						agent: true,
+						text: "Done.",
+						createdAt: 2,
+						actions: ["SHELL"],
+					},
+				]),
+				AGENT_ID,
+				USER_ID,
+			),
+		).toBe(null);
 	});
 });

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -1720,3 +1720,164 @@ export function inferWebSearchQueryFromMessageText(
 
 	return query.length > 0 ? query : messageText.trim();
 }
+
+/**
+ * Minimal structural view of a recent-message memory used by continuation
+ * resolution. Kept local so the heuristics module stays free of the full
+ * Memory type; callers pass provider-shaped rows (state RECENT_MESSAGES data).
+ */
+export type ContinuationDialogueEntry = {
+	id?: string;
+	entityId?: string;
+	createdAt?: number;
+	content?: {
+		text?: unknown;
+		type?: unknown;
+		source?: unknown;
+		actionCallbackHistory?: unknown;
+		metadata?: unknown;
+	};
+};
+
+const CONTINUATION_LEAD_IN =
+	"(?:ok(?:ay)?|yes|yep|yeah|sure|alright|great|perfect)?[,.!]?\\s*(?:please\\s+)?";
+
+// Directive continuations explicitly tell the agent to keep working; they are
+// contentless by construction (no domain nouns survive the anchored match), so
+// substituting the resolved prior request for candidate inference cannot mask
+// a fresh ask.
+const CONTINUATION_DIRECTIVE_RE = new RegExp(
+	`^${CONTINUATION_LEAD_IN}(?:(?:finish|complete|continue|resume)(?:\\s+(?:up|it|that|this|(?:my|the|that|this)\\s+(?:request|task|work|job)|what\\s+you\\s+were\\s+doing|where\\s+you\\s+left\\s+off))?|go\\s+ahead|do\\s+it|proceed|keep\\s+going|carry\\s+on|make\\s+it\\s+so)(?:\\s+(?:please|then|now))?$`,
+	"iu",
+);
+
+// Approval continuations accept a pending question/preview ("that is good",
+// bare "yes"). They only resolve when the agent's latest visible turn still
+// looks pending — an ack or a question — so praise after a delivered result
+// does not re-trigger the finished request.
+const CONTINUATION_APPROVAL_RE = new RegExp(
+	`^${CONTINUATION_LEAD_IN}(?:yes|yep|yeah|(?:that|this|it)(?:'s|\\s+is)?\\s+(?:good|great|perfect|fine|right|correct)|(?:that|this|it)\\s+works|sounds\\s+good|looks\\s+good)(?:\\s*[,.!]?\\s*(?:please\\s+)?(?:go\\s+ahead|do\\s+it|proceed|finish(?:\\s+it)?|continue|thanks?|thank\\s+you))?$`,
+	"iu",
+);
+
+function normalizeContinuationText(text: string): string {
+	return text
+		.trim()
+		.replace(/[.!…]+$/u, "")
+		.replace(/\s+/gu, " ");
+}
+
+export type ExplicitContinuationKind = "directive" | "approval";
+
+/**
+ * Classifies a turn that carries no request of its own and only tells the
+ * agent to proceed with (or approves) earlier work. Anchored whole-message
+ * matches with a short length cap keep ordinary chat ("that is a good
+ * question", topic switches) out.
+ */
+export function classifyExplicitContinuationTurn(
+	text: string,
+): ExplicitContinuationKind | null {
+	const normalized = normalizeContinuationText(text);
+	if (normalized.length === 0 || normalized.length > 60) return null;
+	if (normalized.includes("?")) return null;
+	if (CONTINUATION_DIRECTIVE_RE.test(normalized)) return "directive";
+	if (CONTINUATION_APPROVAL_RE.test(normalized)) return "approval";
+	return null;
+}
+
+export function looksLikeExplicitContinuationTurn(text: string): boolean {
+	return classifyExplicitContinuationTurn(text) !== null;
+}
+
+function continuationEntryText(entry: ContinuationDialogueEntry): string {
+	return typeof entry.content?.text === "string"
+		? entry.content.text.trim()
+		: "";
+}
+
+function isContinuationDialogueArtifact(
+	entry: ContinuationDialogueEntry,
+): boolean {
+	const content = entry.content;
+	if (!content || typeof content !== "object") return true;
+	if (content.type === "action_result") return true;
+	if (
+		typeof content.source === "string" &&
+		content.source.includes("sub-agent")
+	) {
+		return true;
+	}
+	const metadata = content.metadata;
+	if (
+		metadata &&
+		typeof metadata === "object" &&
+		(metadata as { subAgent?: unknown }).subAgent === true
+	) {
+		return true;
+	}
+	return false;
+}
+
+const CONTINUATION_LOOKBACK_ENTRIES = 12;
+const PENDING_ASSISTANT_TURN_MAX_CHARS = 160;
+
+/**
+ * Resolves an explicit continuation turn ("finish my request", "that is
+ * good") to the nearest prior user request so candidate inference can rerun
+ * on the request the user is actually referring to. Deterministic and
+ * conservative: non-continuation turns resolve to nothing (topic switches are
+ * untouched), approval turns additionally require the agent's latest visible
+ * reply to still look pending (a question or a short ack without tool-result
+ * callbacks), and the resolved text is the single nearest prior user request
+ * — prior requests are never concatenated together or onto the current turn.
+ */
+export function resolveExplicitContinuationRequestText(
+	currentText: string,
+	recentMessages: ReadonlyArray<ContinuationDialogueEntry>,
+	agentId: string,
+	currentMessageId?: string,
+): string | null {
+	const kind = classifyExplicitContinuationTurn(currentText);
+	if (!kind) return null;
+	const ordered = [...recentMessages]
+		.filter((entry) => {
+			if (!entry || typeof entry !== "object") return false;
+			if (currentMessageId && entry.id === currentMessageId) return false;
+			return continuationEntryText(entry).length > 0;
+		})
+		.sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0))
+		.slice(-CONTINUATION_LOOKBACK_ENTRIES);
+
+	if (kind === "approval") {
+		const lastAssistant = [...ordered]
+			.reverse()
+			.find((entry) => entry.entityId === agentId);
+		if (!lastAssistant || isContinuationDialogueArtifact(lastAssistant)) {
+			return null;
+		}
+		const callbacks = lastAssistant.content?.actionCallbackHistory;
+		if (Array.isArray(callbacks) && callbacks.length > 0) return null;
+		const lastText = continuationEntryText(lastAssistant);
+		const looksPending =
+			lastText.endsWith("?") ||
+			lastText.length <= PENDING_ASSISTANT_TURN_MAX_CHARS;
+		if (!looksPending) return null;
+	}
+
+	for (let index = ordered.length - 1; index >= 0; index--) {
+		const entry = ordered[index];
+		if (!entry || entry.entityId === agentId) continue;
+		if (isContinuationDialogueArtifact(entry)) continue;
+		const text = continuationEntryText(entry);
+		if (text.length === 0) continue;
+		if (classifyExplicitContinuationTurn(text) !== null) continue;
+		if (
+			normalizeContinuationText(text) === normalizeContinuationText(currentText)
+		) {
+			continue;
+		}
+		return text;
+	}
+	return null;
+}

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -1734,6 +1734,7 @@ export type ContinuationDialogueEntry = {
 		text?: unknown;
 		type?: unknown;
 		source?: unknown;
+		actions?: unknown;
 		actionCallbackHistory?: unknown;
 		metadata?: unknown;
 	};
@@ -1803,6 +1804,18 @@ function isContinuationDialogueArtifact(
 	if (!content || typeof content !== "object") return true;
 	if (content.type === "action_result") return true;
 	if (
+		Array.isArray(content.actions) &&
+		content.actions.some(
+			(action) =>
+				typeof action === "string" &&
+				!["REPLY", "NONE", "IGNORE"].includes(
+					normalizeActionIdentifier(action),
+				),
+		)
+	) {
+		return true;
+	}
+	if (
 		typeof content.source === "string" &&
 		content.source.includes("sub-agent")
 	) {
@@ -1821,6 +1834,14 @@ function isContinuationDialogueArtifact(
 
 const CONTINUATION_LOOKBACK_ENTRIES = 12;
 const PENDING_ASSISTANT_TURN_MAX_CHARS = 160;
+
+function looksLikePendingAssistantTurn(text: string): boolean {
+	if (text.endsWith("?")) return true;
+	if (text.length > PENDING_ASSISTANT_TURN_MAX_CHARS) return false;
+	return /^(?:(?:ok(?:ay)?|sure|great)[,.!]?\s+)?(?:on it|working on it|ready (?:to proceed|when you are)|(?:i\s+(?:can|could|will)|i['’]ll)\b)/iu.test(
+		text,
+	);
+}
 
 /**
  * Resolves an explicit continuation turn ("finish my request", "that is
@@ -1850,19 +1871,21 @@ export function resolveExplicitContinuationRequestText(
 		.slice(-CONTINUATION_LOOKBACK_ENTRIES);
 
 	if (kind === "approval") {
-		const lastAssistant = [...ordered]
-			.reverse()
-			.find((entry) => entry.entityId === agentId);
-		if (!lastAssistant || isContinuationDialogueArtifact(lastAssistant)) {
+		// Approval must answer the immediately preceding visible assistant turn.
+		// Looking farther back can authorize a newer user request that the agent
+		// never previewed or asked permission to execute.
+		const lastAssistant = ordered.at(-1);
+		if (
+			!lastAssistant ||
+			lastAssistant.entityId !== agentId ||
+			isContinuationDialogueArtifact(lastAssistant)
+		) {
 			return null;
 		}
 		const callbacks = lastAssistant.content?.actionCallbackHistory;
 		if (Array.isArray(callbacks) && callbacks.length > 0) return null;
 		const lastText = continuationEntryText(lastAssistant);
-		const looksPending =
-			lastText.endsWith("?") ||
-			lastText.length <= PENDING_ASSISTANT_TURN_MAX_CHARS;
-		if (!looksPending) return null;
+		if (!looksLikePendingAssistantTurn(lastText)) return null;
 	}
 
 	for (let index = ordered.length - 1; index >= 0; index--) {

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -7,6 +7,7 @@
  * simply yields no candidate. Also derives a concrete shell command or web-search
  * query from the message text.
  */
+import { isReservedNonToolActionName } from "../../action-names";
 import type { Action } from "../../types/components";
 
 export interface DirectActionInferenceHooks {
@@ -1744,6 +1745,9 @@ export type ContinuationDialogueEntry = {
  * Identifies assistant text derived from a tool execution rather than ordinary
  * dialogue. Planner context and continuation resolution share this predicate
  * so either persisted provenance shape closes the completed-action replay path.
+ * Envelope membership comes from `isReservedNonToolActionName` so STOP stays
+ * a planner terminal, not a delivered tool, and new
+ * `NON_EXECUTABLE_RESPONSE_ACTION_NAMES` members cannot silently drift.
  */
 export function isToolDerivedAssistantContent(
 	content: ContinuationDialogueEntry["content"],
@@ -1759,12 +1763,7 @@ export function isToolDerivedAssistantContent(
 	return content.actions.some((action) => {
 		if (typeof action !== "string") return false;
 		const normalized = normalizeActionIdentifier(action);
-		return (
-			normalized.length > 0 &&
-			normalized !== "REPLY" &&
-			normalized !== "NONE" &&
-			normalized !== "IGNORE"
-		);
+		return normalized.length > 0 && !isReservedNonToolActionName(normalized);
 	});
 }
 

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -1740,6 +1740,34 @@ export type ContinuationDialogueEntry = {
 	};
 };
 
+/**
+ * Identifies assistant text derived from a tool execution rather than ordinary
+ * dialogue. Planner context and continuation resolution share this predicate
+ * so either persisted provenance shape closes the completed-action replay path.
+ */
+export function isToolDerivedAssistantContent(
+	content: ContinuationDialogueEntry["content"],
+): boolean {
+	if (!content || typeof content !== "object") return false;
+	if (
+		Array.isArray(content.actionCallbackHistory) &&
+		content.actionCallbackHistory.length > 0
+	) {
+		return true;
+	}
+	if (!Array.isArray(content.actions)) return false;
+	return content.actions.some((action) => {
+		if (typeof action !== "string") return false;
+		const normalized = normalizeActionIdentifier(action);
+		return (
+			normalized.length > 0 &&
+			normalized !== "REPLY" &&
+			normalized !== "NONE" &&
+			normalized !== "IGNORE"
+		);
+	});
+}
+
 const CONTINUATION_LEAD_IN =
 	"(?:ok(?:ay)?|yes|yep|yeah|sure|alright|great|perfect)?[,.!]?\\s*(?:please\\s+)?";
 
@@ -1803,18 +1831,7 @@ function isContinuationDialogueArtifact(
 	const content = entry.content;
 	if (!content || typeof content !== "object") return true;
 	if (content.type === "action_result") return true;
-	if (
-		Array.isArray(content.actions) &&
-		content.actions.some(
-			(action) =>
-				typeof action === "string" &&
-				!["REPLY", "NONE", "IGNORE"].includes(
-					normalizeActionIdentifier(action),
-				),
-		)
-	) {
-		return true;
-	}
+	if (isToolDerivedAssistantContent(content)) return true;
 	if (
 		typeof content.source === "string" &&
 		content.source.includes("sub-agent")
@@ -1850,15 +1867,18 @@ function looksLikePendingAssistantTurn(text: string): boolean {
  * conservative: non-continuation turns resolve to nothing (topic switches are
  * untouched), approval turns additionally require the agent's latest visible
  * reply to still look pending (a question or a short ack without tool-result
- * callbacks), and the resolved text is the single nearest prior user request
- * — prior requests are never concatenated together or onto the current turn.
+ * callbacks), and the resolved text is the single nearest prior request from
+ * the current speaker — shared-room requests from other participants are never
+ * selected or concatenated onto the current turn.
  */
 export function resolveExplicitContinuationRequestText(
 	currentText: string,
 	recentMessages: ReadonlyArray<ContinuationDialogueEntry>,
 	agentId: string,
+	requesterEntityId: string,
 	currentMessageId?: string,
 ): string | null {
+	if (!requesterEntityId || requesterEntityId === agentId) return null;
 	const kind = classifyExplicitContinuationTurn(currentText);
 	if (!kind) return null;
 	const ordered = [...recentMessages]
@@ -1890,7 +1910,7 @@ export function resolveExplicitContinuationRequestText(
 
 	for (let index = ordered.length - 1; index >= 0; index--) {
 		const entry = ordered[index];
-		if (!entry || entry.entityId === agentId) continue;
+		if (!entry || entry.entityId !== requesterEntityId) continue;
 		if (isContinuationDialogueArtifact(entry)) continue;
 		const text = continuationEntryText(entry);
 		if (text.length === 0) continue;


### PR DESCRIPTION
## What

Finishes the two remaining gaps of #17024 and absorbs the STOP-envelope repair from #20366.

### Bounded planner dialogue

`createV5MessageContextObject` now includes at most the four newest ordinary assistant replies so continuation turns can resolve their referent. Tool-derived replies remain structurally excluded through action callback history or real tool action names, and the planner prompt marks all prior facts as stale.

### Deterministic continuation resolution

The direct-action heuristics now distinguish conservative, whole-message continuation directives from approvals. They resolve only the nearest prior user request; approval additionally requires the latest visible agent reply to remain pending. Requester identity is bound, so another participant cannot continue someone else's request. Topic switches remain independent requests.

### STOP remains a non-tool envelope

The canonical `STOP` action name is centralized and treated as planner-terminal metadata, not evidence of a completed tool-derived reply. An approval following a pending reply marked `STOP` can therefore continue the request, while real tool-derived results still cannot replay it.

### Live trajectory proof

The key-gated integration test uses the real runtime, PGlite persistence, plugin-openai through Cerebras, and persisted prior user/assistant turns. It proves three paths:

1. `finish my request` executes the pending SHELL action exactly once.
2. `that is good` after a pending `STOP` reply executes SHELL exactly once.
3. A Tokyo weather topic switch executes WEB_SEARCH exactly once and never replays SHELL.

## Validation

- Focused action-name, direct-heuristic, and Stage-1 suites: **223 passed** across 3 files.
- Broad recent-messages/message-runtime lane: **679 passed** across 32 files.
- Live Cerebras/PGlite trajectory: **1 passed**, 12 assertions.
- Core typecheck and Node/browser/edge/testing/declaration builds: passed.
- Biome on all 7 touched files: passed.
- Root `bun run verify`: **351/351 tasks successful**.
- Exact base: `09ca1a7c2b2e7bccedd6a8e33a4bf279209f8ec6`.
- Exact head: `1feb4044978416812bb3400d3afb40f51caac696`.

## Residual risk

- Planner prompt bytes change for tool turns that have recent ordinary assistant replies; the four-turn bound limits token and cache impact.
- Continuation phrases are intentionally conservative. Unrecognized phrasings fall through to normal planner behavior instead of risking false-positive replay.

Fixes #17024

<!-- evidence-head:1feb4044978416812bb3400d3afb40f51caac696 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend message-routing change; no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend message-routing change; no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual interaction surface changed

<!-- evidence-row:backend-logs -->
- [x] [20227-pr20227-verify.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20227-pr20227-verify.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend path changed

<!-- evidence-row:llm-trajectory -->
- [x] [20227-pr20227-live-continuation-exact-1feb4044.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20227-pr20227-live-continuation-exact-1feb4044.json)

<!-- evidence-row:domain-artifacts -->
- [x] [20227-pr20227-validation-1feb4044.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20227-pr20227-validation-1feb4044.md)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed
