### PR TITLE
fix(cloud): publish the app row through the cache after monetization mutations

### DIFF
--- a/packages/cloud/api/__tests__/chat-completions-cache-hotpath.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-cache-hotpath.test.ts
@@ -365,12 +365,32 @@ test("cold dependency returns 503 before held hydration completes", async () => 
     throw new Error("chat route joined authoritative cache hydration");
   }
   expect(outcome.response.status).toBe(503);
+  expect(outcome.response.headers.get("Retry-After")).toBe("1");
   expect(background).toContain(hydration.promise);
   expect(generateText).not.toHaveBeenCalled();
   expect(admitAppInferenceCacheOnly).not.toHaveBeenCalled();
   expect(authoritativeAppLookup).not.toHaveBeenCalled();
   hydration.resolve();
   await Promise.all(background);
+});
+
+test("cold rate-limit policy returns a bounded retry contract", async () => {
+  enforceOrgRateLimit.mockRejectedValueOnce(
+    new rateLimitActual.OrgRateLimitCacheNotReadyError("warming", "miss"),
+  );
+  const background: Promise<unknown>[] = [];
+
+  const response = await handleChatCompletionsPOST(request(), {
+    executionCtx: executionCtx(background),
+  });
+
+  expect(response.status).toBe(503);
+  expect(response.headers.get("Retry-After")).toBe("1");
+  expect(await response.json()).toMatchObject({
+    error: { code: "rate_limit_cache_warming" },
+  });
+  expect(cacheOnlyAppLookup).not.toHaveBeenCalled();
+  expect(generateText).not.toHaveBeenCalled();
 });
 
 test("cold optional pool and model catalog hydrate off-path while platform inference dispatches", async () => {
@@ -419,6 +439,7 @@ test("cold pool remains retryable when no platform credential can dispatch", asy
   });
 
   expect(response.status).toBe(503);
+  expect(response.headers.get("Retry-After")).toBe("1");
   expect(await response.json()).toMatchObject({
     error: { code: "inference_dependency_cache_warming" },
   });

--- a/packages/cloud/api/__tests__/messages-iac-fast-path.test.ts
+++ b/packages/cloud/api/__tests__/messages-iac-fast-path.test.ts
@@ -550,6 +550,7 @@ describe("/v1/messages IAC fast path", () => {
     });
 
     expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("1");
     expect(admitAppInferenceCacheOnly).not.toHaveBeenCalled();
     expect(reserveInferenceCredits).not.toHaveBeenCalled();
     expect(generateText).not.toHaveBeenCalled();

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -1400,7 +1400,7 @@ export async function handleChatCompletionsPOST(
                   code: "rate_limit_cache_warming",
                 },
               },
-              { status: 503 },
+              { status: 503, headers: { "Retry-After": "1" } },
             ),
           ),
         );
@@ -1608,7 +1608,7 @@ export async function handleChatCompletionsPOST(
                 code: "inference_dependency_cache_warming",
               },
             },
-            { status: 503 },
+            { status: 503, headers: { "Retry-After": "1" } },
           ),
         ),
       );

--- a/packages/cloud/api/v1/chat/route.ts
+++ b/packages/cloud/api/v1/chat/route.ts
@@ -154,6 +154,7 @@ function retryableWarmingResponse(c: AppContext, area: string): Response {
   return c.json(
     { error: `${area} authorization is warming. Retry shortly.` },
     503,
+    { "Retry-After": "1" },
   );
 }
 

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -716,6 +716,7 @@ app.post("/", async (c) => {
           "api_error",
           "Application authorization cache is warming. Retry shortly.",
           503,
+          { "Retry-After": "1" },
         );
       }
       monetizedApp = appResolution.app;

--- a/packages/cloud/shared/src/lib/services/app-credits-monetization-write-through.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-credits-monetization-write-through.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Proves a monetization-settings mutation publishes the fresh app row through
+ * the shared cache instead of manufacturing a cold cache-only miss, so the
+ * Worker's very next inference for the app is admitted rather than answered
+ * with a warming 503 (#17007). Repositories are mocked; the cache client,
+ * hydration generation fence, and apps/app-credits services are real.
+ */
+
+process.env.CACHE_BACKEND = "memory";
+process.env.CACHE_ENABLED = "true";
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { App } from "../../db/repositories/apps";
+
+let appRows = new Map<string, App>();
+let appReads = 0;
+let onFindById: ((id: string) => void) | null = null;
+
+mock.module("../../db/repositories/apps", () => ({
+  appsRepository: {
+    findById: async (id: string) => {
+      appReads += 1;
+      onFindById?.(id);
+      return appRows.get(id);
+    },
+    update: async (id: string, changes: Partial<App>) => {
+      const row = appRows.get(id);
+      if (!row) throw new Error(`no app row ${id}`);
+      appRows.set(id, { ...row, ...changes });
+    },
+  },
+  withAppCacheFence: async <T>(_appId: string, operation: (tx: unknown) => Promise<T>) =>
+    await operation({}),
+  withAppCacheFences: async <T>(
+    _identity: { appId?: string; apiKeyId?: string | null; slug?: string | null },
+    operation: (tx: unknown) => Promise<T>,
+  ) => await operation({}),
+}));
+
+mock.module("../../db/repositories/app-earnings", () => ({
+  appEarningsRepository: {
+    getOrCreate: async () => ({}),
+  },
+}));
+
+mock.module("../../db/repositories/organizations", () => ({
+  organizationsRepository: {},
+}));
+
+mock.module("../../db/repositories/users", () => ({
+  usersRepository: {},
+}));
+
+mock.module("./credits", () => ({
+  APP_CHAT_RESERVATION_SETTLEMENT_MARKER: "app-chat-settlement",
+  creditsService: {},
+  InsufficientCreditsError: class InsufficientCreditsError extends Error {},
+  MIN_RESERVATION: 0.0001,
+}));
+
+mock.module("./redeemable-earnings", () => ({
+  redeemableEarningsService: {},
+}));
+
+mock.module("./api-keys", () => ({
+  apiKeysService: {},
+}));
+
+mock.module("./managed-domains", () => ({
+  managedDomainsService: {},
+}));
+
+const { cache } = await import("../cache/client");
+const { CacheKeys, CacheTTL } = await import("../cache/keys");
+const { invalidateInferenceAppByIdState } = await import("./inference-app-memory-cache");
+const { appsService } = await import("./apps");
+const { appCreditsService } = await import("./app-credits");
+
+let sequence = 0;
+
+function app(overrides: Partial<App> = {}): App {
+  const id = `app-${++sequence}`;
+  return {
+    id,
+    name: id,
+    slug: id,
+    organization_id: "org-1",
+    created_by_user_id: "user-1",
+    app_url: "https://app.example",
+    monetization_enabled: false,
+    review_status: "approved",
+    ...overrides,
+  } as App;
+}
+
+beforeEach(() => {
+  appRows = new Map();
+  appReads = 0;
+  onFindById = null;
+});
+
+describe("updateMonetizationSettings cache publication", () => {
+  test("writes the updated row through so the next cache-only read is ready", async () => {
+    const row = app();
+    appRows.set(row.id, row);
+    invalidateInferenceAppByIdState(row.id);
+    await cache.del(CacheKeys.app.byId(row.id));
+
+    await appCreditsService.updateMonetizationSettings(row.id, {
+      monetizationEnabled: true,
+    });
+
+    const readsAfterMutation = appReads;
+    const resolution = await appsService.getByIdCacheOnly(row.id);
+    expect(resolution.kind).toBe("ready");
+    if (resolution.kind !== "ready") throw new Error("unreachable");
+    expect(resolution.app?.monetization_enabled).toBe(true);
+    // The cache-only read consumed the mutation's publication — no warming
+    // round-trip and no additional authoritative read.
+    expect(appReads).toBe(readsAfterMutation);
+
+    const monetized = await appsService.getAuthorizedMonetizedAppForUserCacheOnly(row.id, {
+      id: "user-2",
+      organization_id: "org-2",
+    });
+    expect(monetized).toEqual({ kind: "ready", app: appRows.get(row.id) ?? null });
+  });
+
+  test("evicts derived markup and slug keys on mutation", async () => {
+    const row = app({ monetization_enabled: true });
+    appRows.set(row.id, row);
+    invalidateInferenceAppByIdState(row.id);
+    await cache.set(CacheKeys.app.costMarkup(row.id), { stale: true }, CacheTTL.app.byId);
+    await cache.set(CacheKeys.app.bySlug(row.slug), row, CacheTTL.app.bySlug);
+
+    await appCreditsService.updateMonetizationSettings(row.id, {
+      inferenceMarkupPercentage: 25,
+    });
+
+    expect(await cache.get(CacheKeys.app.costMarkup(row.id))).toBeFalsy();
+    expect(await cache.get(CacheKeys.app.bySlug(row.slug))).toBeFalsy();
+    const published = await cache.get<App>(CacheKeys.app.byId(row.id));
+    expect(published?.inference_markup_percentage).toBe(25);
+  });
+
+  test("a superseded generation never republishes its stale row", async () => {
+    const row = app();
+    appRows.set(row.id, row);
+    invalidateInferenceAppByIdState(row.id);
+    await cache.del(CacheKeys.app.byId(row.id));
+
+    // The mutation reads the row twice: once before the update (slug lookup)
+    // and once inside the fenced publication. Interfere on the second read to
+    // simulate a concurrent mutation landing between the publication's
+    // authoritative read and its cache write.
+    let findByIdCalls = 0;
+    onFindById = (id) => {
+      if (id !== row.id) return;
+      findByIdCalls += 1;
+      if (findByIdCalls === 2) {
+        invalidateInferenceAppByIdState(row.id);
+      }
+    };
+
+    await appCreditsService.updateMonetizationSettings(row.id, {
+      monetizationEnabled: true,
+    });
+
+    expect(await cache.get(CacheKeys.app.byId(row.id))).toBeFalsy();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/app-credits-monetization-write-through.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-credits-monetization-write-through.test.ts
@@ -14,23 +14,26 @@ import type { App } from "../../db/repositories/apps";
 
 let appRows = new Map<string, App>();
 let appReads = 0;
-let onFindById: ((id: string) => void) | null = null;
+let onFence: ((id: string) => void) | null = null;
 
 mock.module("../../db/repositories/apps", () => ({
   appsRepository: {
     findById: async (id: string) => {
       appReads += 1;
-      onFindById?.(id);
       return appRows.get(id);
     },
     update: async (id: string, changes: Partial<App>) => {
       const row = appRows.get(id);
       if (!row) throw new Error(`no app row ${id}`);
-      appRows.set(id, { ...row, ...changes });
+      const updated = { ...row, ...changes };
+      appRows.set(id, updated);
+      return updated;
     },
   },
-  withAppCacheFence: async <T>(_appId: string, operation: (tx: unknown) => Promise<T>) =>
-    await operation({}),
+  withAppCacheFence: async <T>(appId: string, operation: (tx: unknown) => Promise<T>) => {
+    onFence?.(appId);
+    return await operation({});
+  },
   withAppCacheFences: async <T>(
     _identity: { appId?: string; apiKeyId?: string | null; slug?: string | null },
     operation: (tx: unknown) => Promise<T>,
@@ -96,7 +99,7 @@ function app(overrides: Partial<App> = {}): App {
 beforeEach(() => {
   appRows = new Map();
   appReads = 0;
-  onFindById = null;
+  onFence = null;
 });
 
 describe("updateMonetizationSettings cache publication", () => {
@@ -115,9 +118,10 @@ describe("updateMonetizationSettings cache publication", () => {
     expect(resolution.kind).toBe("ready");
     if (resolution.kind !== "ready") throw new Error("unreachable");
     expect(resolution.app?.monetization_enabled).toBe(true);
-    // The cache-only read consumed the mutation's publication — no warming
-    // round-trip and no additional authoritative read.
-    expect(appReads).toBe(readsAfterMutation);
+    // The primary row returned by update was published directly. Neither the
+    // mutation nor the cache-only read needed a replica/read-intent round-trip.
+    expect(readsAfterMutation).toBe(0);
+    expect(appReads).toBe(0);
 
     const monetized = await appsService.getAuthorizedMonetizedAppForUserCacheOnly(row.id, {
       id: "user-2",
@@ -149,15 +153,10 @@ describe("updateMonetizationSettings cache publication", () => {
     invalidateInferenceAppByIdState(row.id);
     await cache.del(CacheKeys.app.byId(row.id));
 
-    // The mutation reads the row twice: once before the update (slug lookup)
-    // and once inside the fenced publication. Interfere on the second read to
-    // simulate a concurrent mutation landing between the publication's
-    // authoritative read and its cache write.
-    let findByIdCalls = 0;
-    onFindById = (id) => {
-      if (id !== row.id) return;
-      findByIdCalls += 1;
-      if (findByIdCalls === 2) {
+    // Interfere after the publisher captured its generation but before it
+    // enters the durable cache fence.
+    onFence = (id) => {
+      if (id === row.id) {
         invalidateInferenceAppByIdState(row.id);
       }
     };

--- a/packages/cloud/shared/src/lib/services/app-credits.ts
+++ b/packages/cloud/shared/src/lib/services/app-credits.ts
@@ -4,6 +4,7 @@
 
 import Decimal from "decimal.js";
 import { appEarningsRepository } from "../../db/repositories/app-earnings";
+import * as appsRepositoryModule from "../../db/repositories/apps";
 import { type App, appsRepository } from "../../db/repositories/apps";
 import { organizationsRepository } from "../../db/repositories/organizations";
 import { usersRepository } from "../../db/repositories/users";
@@ -20,11 +21,6 @@ import {
 } from "./app-credit-math";
 import { APP_USAGE_PROJECTION_VERSION } from "./app-usage-projections";
 import {
-  getAppByIdHydrationGeneration,
-  invalidateInferenceAppByIdState,
-  setInferenceAppById,
-} from "./inference-app-memory-cache";
-import {
   APP_CHAT_RESERVATION_SETTLEMENT_MARKER,
   type CreditReconciliationResult,
   type CreditReservation,
@@ -32,6 +28,11 @@ import {
   InsufficientCreditsError,
   MIN_RESERVATION,
 } from "./credits";
+import {
+  getAppByIdHydrationGeneration,
+  invalidateInferenceAppByIdState,
+  setInferenceAppById,
+} from "./inference-app-memory-cache";
 import { redeemableEarningsService } from "./redeemable-earnings";
 
 /**
@@ -82,25 +83,35 @@ interface NoneMarker {
  * cache access avoids a circular dependency on appsService — both modules sit
  * in the same layer and share the fence via inference-app-memory-cache.
  */
-async function publishAppCacheAfterMutation(appId: string, slug?: string): Promise<void> {
+async function publishAppCacheAfterMutation(
+  appId: string,
+  updated: App | undefined,
+): Promise<void> {
   invalidateInferenceAppByIdState(appId);
   const generation = getAppByIdHydrationGeneration(appId);
-  const derivedEvictions: Promise<void>[] = [cache.del(CacheKeys.app.costMarkup(appId))];
-  if (slug) {
-    derivedEvictions.push(cache.del(CacheKeys.app.bySlug(slug)));
-  }
-  const [updated] = await Promise.all([appsRepository.findById(appId), ...derivedEvictions]);
-  if (getAppByIdHydrationGeneration(appId) !== generation) {
-    // A concurrent mutation superseded this publication; its own write-through
-    // or eviction owns the cached state now.
-    return;
-  }
-  if (updated) {
+  await appsRepositoryModule.withAppCacheFence(appId, async () => {
+    const derivedEvictions: Promise<void>[] = [cache.del(CacheKeys.app.costMarkup(appId))];
+    if (updated?.slug) {
+      derivedEvictions.push(cache.del(CacheKeys.app.bySlug(updated.slug)));
+    }
+    await Promise.all(derivedEvictions);
+    if (getAppByIdHydrationGeneration(appId) !== generation) {
+      // A concurrent mutation superseded this publication; its own
+      // write-through or eviction owns the cached state now.
+      return;
+    }
+    if (!updated) {
+      await cache.del(CacheKeys.app.byId(appId));
+      return;
+    }
+
     await cache.set(CacheKeys.app.byId(appId), updated, CacheTTL.app.byId);
-    setInferenceAppById(appId, updated);
-  } else {
-    await cache.del(CacheKeys.app.byId(appId));
-  }
+    // The shared-cache write yielded. Recheck before restoring the process LRU
+    // so an invalidation that landed during that await cannot be undone.
+    if (getAppByIdHydrationGeneration(appId) === generation) {
+      setInferenceAppById(appId, updated);
+    }
+  });
 }
 
 function parseOrgCreditBalance(value: string | number | null | undefined): number {
@@ -1869,10 +1880,7 @@ export class AppCreditsService {
       throw new Error("Purchase share must be between 0% and 100%");
     }
 
-    // Read existing slug before update so we can evict the bySlug cache entry too.
-    const existing = await appsRepository.findById(appId);
-
-    await appsRepository.update(appId, {
+    const updated = await appsRepository.update(appId, {
       ...(settings.monetizationEnabled !== undefined && {
         monetization_enabled: settings.monetizationEnabled,
       }),
@@ -1888,7 +1896,7 @@ export class AppCreditsService {
     // every inference via calculateCostWithMarkup(). Write the updated row
     // through (fenced) so the toggle takes effect immediately without
     // manufacturing a cold cache-only miss on the very next inference.
-    await publishAppCacheAfterMutation(appId, existing?.slug ?? undefined);
+    await publishAppCacheAfterMutation(appId, updated);
 
     // When enabling monetization, ensure earnings record exists
     // This prevents null state when viewing earnings dashboard

--- a/packages/cloud/shared/src/lib/services/app-credits.ts
+++ b/packages/cloud/shared/src/lib/services/app-credits.ts
@@ -20,6 +20,11 @@ import {
 } from "./app-credit-math";
 import { APP_USAGE_PROJECTION_VERSION } from "./app-usage-projections";
 import {
+  getAppByIdHydrationGeneration,
+  invalidateInferenceAppByIdState,
+  setInferenceAppById,
+} from "./inference-app-memory-cache";
+import {
   APP_CHAT_RESERVATION_SETTLEMENT_MARKER,
   type CreditReconciliationResult,
   type CreditReservation,
@@ -67,20 +72,35 @@ interface NoneMarker {
 }
 
 /**
- * Invalidate the cached app row + markup config after a mutation that touches
- * fields read on the LLM hot path (monetization toggle, markup %, earnings
- * counters, etc.). Direct cache.del to avoid a circular dependency on
- * appsService — both modules sit in the same layer.
+ * Publish the authoritative app row after a mutation that touches fields read
+ * on the LLM hot path (monetization toggle, markup %). A bare eviction here
+ * manufactured a cold cache-only miss: the Worker's next inference for the app
+ * returned a warming 503 even though the mutation had authoritative state in
+ * hand (#17007). The mutation therefore writes the fresh post-commit row
+ * through under the hydration generation fence; derived keys (costMarkup,
+ * bySlug) are still evicted and rehydrate lazily off the hot path. Direct
+ * cache access avoids a circular dependency on appsService — both modules sit
+ * in the same layer and share the fence via inference-app-memory-cache.
  */
-async function invalidateAppCacheKeys(appId: string, slug?: string): Promise<void> {
-  const promises: Promise<void>[] = [
-    cache.del(CacheKeys.app.byId(appId)),
-    cache.del(CacheKeys.app.costMarkup(appId)),
-  ];
+async function publishAppCacheAfterMutation(appId: string, slug?: string): Promise<void> {
+  invalidateInferenceAppByIdState(appId);
+  const generation = getAppByIdHydrationGeneration(appId);
+  const derivedEvictions: Promise<void>[] = [cache.del(CacheKeys.app.costMarkup(appId))];
   if (slug) {
-    promises.push(cache.del(CacheKeys.app.bySlug(slug)));
+    derivedEvictions.push(cache.del(CacheKeys.app.bySlug(slug)));
   }
-  await Promise.all(promises);
+  const [updated] = await Promise.all([appsRepository.findById(appId), ...derivedEvictions]);
+  if (getAppByIdHydrationGeneration(appId) !== generation) {
+    // A concurrent mutation superseded this publication; its own write-through
+    // or eviction owns the cached state now.
+    return;
+  }
+  if (updated) {
+    await cache.set(CacheKeys.app.byId(appId), updated, CacheTTL.app.byId);
+    setInferenceAppById(appId, updated);
+  } else {
+    await cache.del(CacheKeys.app.byId(appId));
+  }
 }
 
 function parseOrgCreditBalance(value: string | number | null | undefined): number {
@@ -1865,9 +1885,10 @@ export class AppCreditsService {
     });
 
     // Critical: monetization config is read by /v1/messages and /v1/chat/* on
-    // every inference via calculateCostWithMarkup(). Evict the cached app row
-    // and the markup-config cache so the toggle takes effect immediately.
-    await invalidateAppCacheKeys(appId, existing?.slug ?? undefined);
+    // every inference via calculateCostWithMarkup(). Write the updated row
+    // through (fenced) so the toggle takes effect immediately without
+    // manufacturing a cold cache-only miss on the very next inference.
+    await publishAppCacheAfterMutation(appId, existing?.slug ?? undefined);
 
     // When enabling monetization, ensure earnings record exists
     // This prevents null state when viewing earnings dashboard


### PR DESCRIPTION
## Summary

The bulk of #17007 (delegating `/v1/chat/completions` organization admission to `admitOrganizationInference`, deleting the inline refusal/sync-reserve gate, and giving `calculateCost` cache-only + `executionCtx` semantics on the Worker path) already landed on `develop` via #17076 and the hot-path follow-ups — verified at `packages/cloud/api/v1/chat/completions/route.ts:1812` (shared admission), `:1269/:1377/:1763` (`cacheOnly` pricing), with typed `AiPricingCacheWarmingError` handling.

This PR fixes the residual regression pinned in the issue thread: the deterministic keyless monetized-journey 503.

- **Root cause:** `updateMonetizationSettings` evicted `CacheKeys.app.byId`, so the Worker's very next cache-only inference (`getAuthorizedMonetizedAppForUserCacheOnly`) hit a manufactured cold miss and returned `Application authorization cache is warming` — with no `Retry-After`.
- **Fix:** the mutation now publishes the fresh post-commit app row through the shared cache and the in-isolate LRU under the existing hydration-generation fence in `inference-app-memory-cache.ts` (a superseded generation never republishes a stale row). Derived markup/slug keys still evict and rehydrate lazily off the hot path. No synchronous DB fallback was added to cache-only admission.
- **Retry contract:** every inference cache-warming 503 now carries `Retry-After: 1` (`/v1/messages` app-authorization branch, `/v1/chat` `retryableWarmingResponse`, `/v1/chat/completions` rate-limit and dependency warming branches), matching the adjacent org-rate-limit warming response.

## Tests

- New `packages/cloud/shared/src/lib/services/app-credits-monetization-write-through.test.ts` (real cache client + generation fence; repositories mocked): 3 pass — post-mutation cache-only read is `ready` with zero extra authoritative reads; derived keys evicted; superseded generation never republishes.
- `packages/cloud/e2e/tests/monetized-mock-llm-journey.spec.ts` **unchanged** through the real Worker/PGlite/mock-Redis stack: 1 passed — end-user debited `$0.000372`, creator redeemable `0 → 0.0001`, `app_earnings 0 → 0.0001` (real reservation/charge/creator-earning rows).
- Regression suites (bun, isolated per file): `app-credits-ledger` 31 pass, `app-credits-idempotency` 19 pass, `app-review-rejection-cuts-monetization` 3 pass (real PGlite), `app-inference-admission` 12 pass, `organization-inference-admission` 13 pass, `chat-completions-cache-hotpath` 5 pass, `chat-cache-hotpath` 6 pass, `embeddings-cache-hotpath` 7 pass.
- `tsc --noEmit` clean in `packages/cloud/shared` and `packages/cloud/api`.

Fixes #17007

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:bfae95498e68869dffe8ed72daff7f4fc212cd88 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Backend cache and billing admission path; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Backend cache and billing admission path; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - No visual interaction changed.

<!-- evidence-row:backend-logs -->
- [x] [20228-pr-20228-backend-evidence.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20228-pr-20228-backend-evidence.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - No frontend runtime path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - The full-stack provider is deterministic mock LLM; no prompt or planner behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [20228-pr-20228-domain-evidence.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20228-pr-20228-domain-evidence.txt)

<!-- evidence-row:ocr-review -->
- [ ] N/A - No screenshots or visual text changed.
