### PR TITLE
fix(cloud): correlate Personal Shared cold failures

### DIFF
--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -1,8 +1,8 @@
 /** Verifies trusted messaging convergence into a platform-funded rowless turn. */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-
 import type { OnboardingChatInput } from "@/lib/services/eliza-app/onboarding-chat";
+import { logger } from "@/lib/utils/logger";
 
 let activeTarget: {
   id: string;
@@ -151,12 +151,20 @@ mock.module("@/lib/services/shared-runtime/resolve-shared-agent", () => ({
 const { default: app } = await import("./route");
 const executionCtx = { waitUntil() {}, passThroughOnException() {}, props: {} };
 
-function request(body: unknown, authorization = "Bearer test-secret") {
+function request(
+  body: unknown,
+  authorization = "Bearer test-secret",
+  traceId = "11111111-1111-4111-8111-111111111111",
+) {
   return app.request(
     "/",
     {
       method: "POST",
-      headers: { authorization, "content-type": "application/json" },
+      headers: {
+        authorization,
+        "content-type": "application/json",
+        "x-eliza-trace-id": traceId,
+      },
       body: JSON.stringify(body),
     },
     {
@@ -246,6 +254,69 @@ describe("personal Shared messaging deliveries", () => {
         chatId: "123456789",
       },
     );
+  });
+
+  test("correlates a Shared failure without logging its sensitive message", async () => {
+    const errorLog = mock(() => undefined);
+    const originalError = logger.error;
+    logger.error = errorLog;
+    const failure = new TypeError("provider body must remain private");
+    sharedRestMessageSend.mockImplementationOnce(async () => {
+      throw failure;
+    });
+
+    try {
+      const response = await request(
+        valid,
+        "Bearer test-secret",
+        "22222222-2222-4222-8222-222222222222",
+      );
+
+      expect(response.status).toBe(500);
+      expect(response.headers.get("x-eliza-failure-stage")).toBe(
+        "shared_runtime",
+      );
+      expect(response.headers.get("x-eliza-failure-name")).toBe("TypeError");
+      expect(errorLog).toHaveBeenCalledWith(
+        "[personal-shared-messaging] delivery failed",
+        {
+          traceId: "22222222-2222-4222-8222-222222222222",
+          stage: "shared_runtime",
+          errorName: "TypeError",
+        },
+      );
+      expect(JSON.stringify(errorLog.mock.calls)).not.toContain(
+        "provider body must remain private",
+      );
+    } finally {
+      logger.error = originalError;
+    }
+  });
+
+  test("redacts an unrecognized error name from headers and logs", async () => {
+    const errorLog = mock(() => undefined);
+    const originalError = logger.error;
+    logger.error = errorLog;
+    const failure = new Error("private");
+    failure.name = "CallerSelectedSecretName";
+    sharedRestMessageSend.mockImplementationOnce(async () => {
+      throw failure;
+    });
+
+    try {
+      const response = await request(valid);
+      expect(response.status).toBe(500);
+      expect(response.headers.get("x-eliza-failure-name")).toBe("OtherError");
+      expect(errorLog).toHaveBeenCalledWith(
+        "[personal-shared-messaging] delivery failed",
+        expect.objectContaining({ errorName: "OtherError" }),
+      );
+      expect(JSON.stringify(errorLog.mock.calls)).not.toContain(
+        "CallerSelectedSecretName",
+      );
+    } finally {
+      logger.error = originalError;
+    }
   });
 
   test("transcribes a Telegram voice note before the Shared turn", async () => {

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import type { AgentSandbox } from "@/db/schemas/agent-sandboxes";
 import { failureResponse, jsonError } from "@/lib/api/cloud-worker-errors";
+import { resolveElizaTraceId } from "@/lib/observability/http-telemetry";
 import { sha256Hex } from "@/lib/oidc/crypto";
 import { findActivePersonalDedicatedTarget } from "@/lib/services/agent-tier-upgrade-target";
 import { elizaAppUserService } from "@/lib/services/eliza-app";
@@ -25,6 +26,37 @@ const MAX_TELEGRAM_VOICE_BYTES = 8 * 1024 * 1024;
 const MAX_TELEGRAM_VOICE_BASE64_LENGTH =
   Math.ceil(MAX_TELEGRAM_VOICE_BYTES / 3) * 4;
 const DEFAULT_WHISPER_MODEL = "Systran/faster-whisper-small";
+const FAILURE_STAGE_HEADER = "X-Eliza-Failure-Stage";
+const FAILURE_NAME_HEADER = "X-Eliza-Failure-Name";
+
+type DeliveryStage =
+  | "authentication"
+  | "validation"
+  | "worker_context"
+  | "account_resolution"
+  | "voice_transcription"
+  | "account_claim"
+  | "dedicated_runtime"
+  | "shared_runtime";
+
+const SAFE_ERROR_NAMES = new Set([
+  "AbortError",
+  "ApiError",
+  "Error",
+  "HTTPException",
+  "InsufficientCreditsError",
+  "RangeError",
+  "RateLimitError",
+  "SharedRuntimeCacheWarmingError",
+  "SharedTurnConflictError",
+  "TimeoutError",
+  "TypeError",
+]);
+
+function safeErrorName(error: unknown): string {
+  const name = error instanceof Error ? error.name : "";
+  return SAFE_ERROR_NAMES.has(name) ? name : "OtherError";
+}
 
 const telegramVoiceNoteSchema = z.object({
   bytesBase64: z.string().min(1).max(MAX_TELEGRAM_VOICE_BASE64_LENGTH),
@@ -160,6 +192,7 @@ async function transcribeTelegramVoiceNote(
 const app = new Hono<AppEnv>();
 
 app.post("/", async (c) => {
+  let stage: DeliveryStage = "authentication";
   try {
     const auth = await requireInternalAuth(c);
     if (auth instanceof Response) return auth;
@@ -171,6 +204,7 @@ app.post("/", async (c) => {
       return jsonError(c, 403, "Forbidden", "access_denied");
     }
 
+    stage = "validation";
     let raw: unknown;
     try {
       raw = await c.req.json();
@@ -207,6 +241,7 @@ app.post("/", async (c) => {
       }
     }
 
+    stage = "worker_context";
     const worker = resolveSharedRuntimeWorkerRequestContext(c);
     if ("error" in worker) {
       return c.json(
@@ -221,6 +256,7 @@ app.post("/", async (c) => {
       );
     }
 
+    stage = "account_resolution";
     const accountStartedAt = performance.now();
     let account: { userId: string; organizationId: string };
     let dedicated:
@@ -273,6 +309,7 @@ app.post("/", async (c) => {
       parsed.data.voiceNote &&
       telegramVoiceBytes
     ) {
+      stage = "voice_transcription";
       // Shared has no authenticated writer into the agent-owned canonical
       // `/api/media/<sha>.<ext>` store. Keep only the transcript in durable
       // conversation history; do not create a parallel R2 media namespace.
@@ -305,6 +342,7 @@ app.post("/", async (c) => {
       parsed.data.platform === "telegram" &&
       /^\/connect(?:@[a-z0-9_]{5,32})?$/i.test(deliveryMessage)
     ) {
+      stage = "account_claim";
       // A new command gets independent expiry while a webhook retry reaches
       // the same session. Reusing the sender's permanent session would make
       // refreshing one claim link revive every expired link for that sender.
@@ -349,6 +387,7 @@ app.post("/", async (c) => {
       );
     }
     if (dedicated) {
+      stage = "dedicated_runtime";
       const dedicatedStartedAt = performance.now();
       const preparation = await preparePersonalDedicatedDelivery(
         dedicated,
@@ -522,6 +561,7 @@ app.post("/", async (c) => {
         },
       });
     }
+    stage = "shared_runtime";
     const sharedStartedAt = performance.now();
     const result = await sharedRestMessageSend(
       agent,
@@ -560,6 +600,18 @@ app.post("/", async (c) => {
     });
   } catch (error) {
     // error-policy:J1 the internal HTTP boundary emits one structured failure.
+    const errorName = safeErrorName(error);
+    const traceId = c.get("traceId") ?? resolveElizaTraceId(c.req.raw.headers);
+    logger.error("[personal-shared-messaging] delivery failed", {
+      traceId,
+      stage,
+      errorName,
+    });
+    // This route is internal-authenticated. Safe classification headers let
+    // the connector correlate a retry without exposing exception messages or
+    // provider/SQL payloads in its logs.
+    c.header(FAILURE_STAGE_HEADER, stage);
+    c.header(FAILURE_NAME_HEADER, errorName);
     return failureResponse(c, error);
   }
 });

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts
@@ -564,6 +564,8 @@ describe("gateway webhook handler e2e routing", () => {
           headers: {
             "Retry-After": "0",
             "Server-Timing": "failed_worker;dur=1234",
+            "X-Eliza-Failure-Stage": "shared_runtime",
+            "X-Eliza-Failure-Name": "TypeError",
           },
         });
       }
@@ -601,6 +603,8 @@ describe("gateway webhook handler e2e routing", () => {
         retryAfterSeconds: 0,
         retryDelayMs: 0,
         cloudServerTiming: "failed_worker;dur=1234",
+        cloudFailureStage: "shared_runtime",
+        cloudFailureName: "TypeError",
       }),
     );
     expect(infoLog).toHaveBeenCalledWith(

--- a/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-handler.ts
@@ -688,6 +688,8 @@ async function sendPersonalSharedReply(
           retryAfterSeconds: null,
           retryDelayMs: 0,
           cloudServerTiming: response.headers.get("Server-Timing"),
+          cloudFailureStage: response.headers.get("X-Eliza-Failure-Stage"),
+          cloudFailureName: response.headers.get("X-Eliza-Failure-Name"),
         });
         authHeader = await reauth();
         continue;
@@ -727,6 +729,8 @@ async function sendPersonalSharedReply(
           : null,
         retryDelayMs,
         cloudServerTiming: response.headers.get("Server-Timing"),
+        cloudFailureStage: response.headers.get("X-Eliza-Failure-Stage"),
+        cloudFailureName: response.headers.get("X-Eliza-Failure-Name"),
       };
       if (response.ok) {
         logger.info("Personal Shared Cloud attempt completed", attemptContext);


### PR DESCRIPTION
## Summary

- preserve a privacy-safe `traceId + stage + allowlisted errorName` receipt when the internal Personal Shared messaging route returns an unknown failure
- return the same safe classification to the authenticated gateway in internal response headers
- include that classification in the already-landed per-attempt retry log

This does not change retry or runtime behavior. It closes the observability gap blocking the exact cold-turn fix.

Relates to #16079.

## Live defect reproduced

- Telegram `QA815-LAT4-20260815220010`, trace `8b335e7d-7590-4ceb-856c-55988d03d151`: first Worker attempt HTTP 500 in 8,600ms, second attempt HTTP 200 in 7,312ms.
- New synthetic staging Telegram identity, trace `d1c22540-314d-4747-8e8d-41eb50994042`: first request HTTP 500 in 9,184ms with only generic `internal_error`; exact replay HTTP 200 in 7,732ms.
- Cloudflare tail could see the route and Durable Object activity, but the route catch emitted no exception receipt.

## Verification

- `bun test packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts` — 22/22
- `bun test packages/cloud/services/gateway-webhook/__tests__/webhook-handler.e2e.test.ts` — 16/16
- `bun run --cwd packages/cloud/api typecheck` — green, including real Wrangler dry bundle
- `bun run --cwd packages/cloud/services/gateway-webhook typecheck` — green
- Biome on all four touched files — green
- `git diff --check` — green

## Privacy review

- no exception message, response body, SQL, provider payload, account identity, or secret is logged
- only a fixed allowlist of known runtime error class names may cross the internal boundary; everything else becomes `OtherError`
- the adversarial test proves a caller-selected error name reaches neither header nor log
- classification headers exist only on this internal-authenticated route

## Evidence matrix

- Real model trajectory: N/A — this PR does not change agent/model behavior; staging replay after protected deploy is the acceptance proof.
- UI screenshots/video: N/A — backend-only observability.
- Backend logs: attached in #16079 live checkpoint; post-deploy safe typed receipt pending protected staging.
