### PR TITLE
fix(ci): align UI Story Gate with develop-only trigger policy

### DIFF
--- a/.github/workflows/ui-story-gate.yml
+++ b/.github/workflows/ui-story-gate.yml
@@ -5,11 +5,6 @@ name: UI Story Gate
 # aggregate job remains fail-closed when a shard is cancelled or incomplete.
 
 on:
-  pull_request:
-    branches: [develop]
-    paths:
-      - "packages/ui/**"
-      - ".github/workflows/ui-story-gate.yml"
   push:
     branches: [develop]
     paths:
@@ -18,7 +13,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ui-story-gate-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ui-story-gate-${{ github.ref || github.run_id }}
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
# Relates to

Closes #20230.

# Summary

Restores the repository's develop-only heavy-workflow policy after #19672 added a forbidden `pull_request` trigger to UI Story Gate.

The Story Gate still runs for relevant pushes to `develop` and explicit manual dispatch. Its concurrency key no longer references pull-request-only event data. No Story Gate shard, aggregate, timeout, evidence, or fail-closed behavior changes.

# Verification

- Full `bun install`: pass with Bun 1.3.14 and complete artifact sync.
- Workflow-trigger policy contract: 11/11.
- Story Gate workflow contract: 3/3.
- Checked-in trigger audit: 48 workflows / 18 develop-push surfaces.
- actionlint and `git diff --check`: pass.
- Exact-head root `bun run verify`: 351/351 tasks and all audits; 8,257 test files scanned with 0 focused and 0 orphaned skips.
- Existing hosted Story Gate develop proof: catalog, all 8 shards, and fail-closed aggregate green: https://github.com/elizaOS/eliza/actions/runs/31910377536
- A second independently produced implementation was patch-identical (`git patch-id --stable` `021d0ff22b9081f1821973d30e58046f6713194f`) and independently passed the same exact-head root gate.

# Risk

Very low. One workflow loses only the prohibited PR event and its dead PR-only concurrency expression. Post-merge and manual execution remain intact.

# Evidence gate

<!-- evidence-head:36ad68b60bcfc92b49deaeb8fdb2b481f21445b6 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - workflow scheduling only; no rendered UI changes
<!-- evidence-row:after-screenshots -->
- [ ] N/A - workflow scheduling only; no rendered UI changes
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive product flow changes
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend or runtime behavior changes
<!-- evidence-row:frontend-logs -->
- [ ] N/A - scheduling-only change; the retained Story Gate hosted run is linked in verification
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, action, or planner behavior changes
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - workflow trigger configuration has no persisted domain artifact
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered text changes

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - contribute-to-eliza skill was not available in this session`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - contribute-to-eliza skill was not available in this session
Attribution status: self-reported
— [codex/20230-ui-story-trigger-policy]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - contribute-to-eliza skill was not available in this session"} -->


