### PR TITLE
fix(training): preserve harvest resume paths

### DIFF
--- a/scripts/training-harvest/harvest-runner.mjs
+++ b/scripts/training-harvest/harvest-runner.mjs
@@ -170,7 +170,7 @@ function discoverScenarioIds(dirRel, providerEnv) {
 
 /** Run one scenario id, capturing report + native jsonl + verdict. */
 function runScenario(dirRel, id, providerEnv) {
-  const itemDir = path.join(HARVEST_ROOT, "scenario", slug(dirRel), slug(id));
+  const itemDir = scenarioItemPath(HARVEST_ROOT, dirRel, id);
   mkdirSync(itemDir, { recursive: true });
   const reportPath = path.join(itemDir, "report.json");
   const runDir = path.join(itemDir, "run");
@@ -232,7 +232,7 @@ function runScenario(dirRel, id, providerEnv) {
       .filter((l) => l.trim()).length;
   }
   writeFileSync(
-    path.join(itemDir, "verdict.json"),
+    scenarioItemPath(HARVEST_ROOT, dirRel, id, "verdict.json"),
     JSON.stringify(verdict, null, 2),
   );
   return verdict;
@@ -240,6 +240,17 @@ function runScenario(dirRel, id, providerEnv) {
 
 function slug(s) {
   return s.replace(/[^a-zA-Z0-9._-]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+/** Resolve one scenario item's canonical harvest path and optional child. */
+export function scenarioItemPath(harvestRoot, dirRel, id, ...children) {
+  return path.join(
+    harvestRoot,
+    "scenario",
+    slug(dirRel),
+    slug(id),
+    ...children,
+  );
 }
 
 function main() {
@@ -283,13 +294,12 @@ function main() {
   for (let gi = 0; gi < allItems.length; gi += 1) {
     if (SHARD_N > 1 && gi % SHARD_N !== SHARD_I) continue; // not this shard
     if (LIMIT && ran >= LIMIT) break;
-    ran += 1;
     const { dir, id } = allItems[gi];
     if (RESUME) {
-      const doneMarker = path.join(
+      const doneMarker = scenarioItemPath(
         HARVEST_ROOT,
-        slug(dir),
-        slug(id),
+        dir,
+        id,
         "verdict.json",
       );
       if (existsSync(doneMarker)) {
@@ -297,6 +307,7 @@ function main() {
         continue;
       }
     }
+    ran += 1;
     if (DRY_RUN) {
       summary.items.push({ dir, id, gi, planned: true });
       console.log(`[dry-run] would harvest scenario ${dir} :: ${id}`);

--- a/scripts/training-harvest/harvest-runner.test.mjs
+++ b/scripts/training-harvest/harvest-runner.test.mjs
@@ -5,11 +5,178 @@
  */
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
-import { parseHarvestLimit } from "./harvest-runner.mjs";
+import * as harvestRunner from "./harvest-runner.mjs";
 
 const runner = fileURLToPath(new URL("./harvest-runner.mjs", import.meta.url));
+const { parseHarvestLimit } = harvestRunner;
+
+function createDryRunFixture(t) {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "eliza harvest resume "));
+  t.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+  const binDir = path.join(tempDir, "bin");
+  mkdirSync(binDir);
+  const fakeBunBody = `#!/usr/bin/env node
+const { mkdirSync, writeFileSync } = require("node:fs");
+const path = require("node:path");
+const args = process.argv.slice(2);
+if (args.includes("list")) {
+  process.stdout.write("completed-A\\nunfinished-B\\n");
+} else if (args.includes("run")) {
+  const value = (name) => args[args.indexOf(name) + 1];
+  const reportPath = value("--report");
+  const nativePath = value("--export-native");
+  const id = value("--scenario");
+  mkdirSync(path.dirname(reportPath), { recursive: true });
+  writeFileSync(
+    reportPath,
+    JSON.stringify({ scenarios: [{ id, status: "passed", judgeScore: 1 }] }),
+  );
+  writeFileSync(nativePath, "{}\\n");
+} else {
+  process.exitCode = 2;
+}
+`;
+  if (process.platform === "win32") {
+    const fakeBunScript = path.join(binDir, "fake-bun.cjs");
+    writeFileSync(fakeBunScript, fakeBunBody);
+    writeFileSync(
+      path.join(binDir, "bun.cmd"),
+      `@echo off\r\n"${process.execPath}" "${fakeBunScript}" %*\r\n`,
+    );
+  } else {
+    writeFileSync(path.join(binDir, "bun"), fakeBunBody, { mode: 0o755 });
+  }
+
+  const manifestPath = path.join(tempDir, "manifest.json");
+  writeFileSync(
+    manifestPath,
+    JSON.stringify({
+      families: { scenario: { items: [{ dir: "fixture-dir" }] } },
+    }),
+  );
+
+  const env = {
+    PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+  };
+  for (const key of ["ComSpec", "PATHEXT", "SystemRoot"]) {
+    if (process.env[key]) env[key] = process.env[key];
+  }
+
+  return {
+    env,
+    harvestRoot: path.join(tempDir, "harvest"),
+    manifestPath,
+  };
+}
+
+function runFixture(fixture, ...args) {
+  return spawnSync(
+    process.execPath,
+    [
+      runner,
+      "--deterministic",
+      "--manifest",
+      fixture.manifestPath,
+      "--harvest-root",
+      fixture.harvestRoot,
+      "--limit",
+      "1",
+      ...args,
+    ],
+    { encoding: "utf8", env: fixture.env },
+  );
+}
+
+test("scenario writes and resume checks share the canonical marker path", (t) => {
+  const fixture = createDryRunFixture(t);
+  const itemDir = path.join(
+    fixture.harvestRoot,
+    "scenario",
+    "fixture-dir",
+    "completed-A",
+  );
+  const verdictPath = path.join(itemDir, "verdict.json");
+  assert.equal(typeof harvestRunner.scenarioItemPath, "function");
+  assert.equal(
+    harvestRunner.scenarioItemPath(
+      fixture.harvestRoot,
+      "fixture-dir",
+      "completed-A",
+      "verdict.json",
+    ),
+    verdictPath,
+  );
+
+  const firstRun = runFixture(fixture);
+  assert.equal(firstRun.status, 0, firstRun.stderr);
+  assert.equal(existsSync(verdictPath), true);
+  const verdict = JSON.parse(readFileSync(verdictPath, "utf8"));
+  assert.equal(verdict.status, "passed");
+  assert.equal(verdict.rows, 1);
+  assert.equal(verdict.judgeScore, 1);
+  assert.equal(verdict.reportPath, path.join(itemDir, "report.json"));
+  assert.equal(verdict.nativePath, path.join(itemDir, "native.jsonl"));
+
+  const resumedRun = runFixture(fixture, "--resume", "--dry-run");
+  assert.equal(resumedRun.status, 0, resumedRun.stderr);
+  assert.match(
+    resumedRun.stdout,
+    /\[resume\] skip \(already harvested\) fixture-dir :: completed-A/,
+  );
+});
+
+test("resume limit budgets unfinished scenarios rather than completed entries", (t) => {
+  const fixture = createDryRunFixture(t);
+  const completedMarker = path.join(
+    fixture.harvestRoot,
+    "scenario",
+    "fixture-dir",
+    "completed-A",
+  );
+  mkdirSync(completedMarker, { recursive: true });
+  writeFileSync(path.join(completedMarker, "verdict.json"), "{}");
+
+  const result = runFixture(fixture, "--resume", "--dry-run");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    result.stdout,
+    /\[resume\] skip \(already harvested\) fixture-dir :: completed-A/,
+  );
+  assert.match(
+    result.stdout,
+    /\[dry-run\] would harvest scenario fixture-dir :: unfinished-B/,
+  );
+  assert.doesNotMatch(
+    result.stdout,
+    /\[dry-run\] would harvest scenario fixture-dir :: completed-A/,
+  );
+});
+
+test("limit without resume retains the first-entry execution contract", (t) => {
+  const fixture = createDryRunFixture(t);
+  const result = runFixture(fixture, "--dry-run");
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(
+    result.stdout,
+    /\[dry-run\] would harvest scenario fixture-dir :: completed-A/,
+  );
+  assert.doesNotMatch(result.stdout, /unfinished-B|\[resume\]/);
+});
 
 test("parseHarvestLimit accepts the unlimited sentinel and safe bounds", () => {
   assert.equal(parseHarvestLimit("0"), 0);


### PR DESCRIPTION
# Relates to

Closes #20235.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works without reading the code from the deterministic child-process regression tests and verification transcript below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@ee523cda0a7ebd387339ad713ceaa7484e011c4a:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `35f527d21e755182a52caa3a156fbc87df42cc0d`; zero conflicts.
- [x] `bun run verify` passes post-sync at PR head `3faf94da8d9fe14343085240dbcb5de9e51e2127`.

# Risks

Low. The change is confined to scenario-item path construction and resume accounting in the Stage 2 training-harvest driver. It preserves the existing slug function, artifact layout, sharding order, dry-run output, and non-resume limit behavior.

# Background

## What does this PR do?

Adds one canonical `scenarioItemPath()` helper and uses it for the scenario execution directory, verdict write, and `--resume` marker lookup. It also moves `ran += 1` after the resume skip so completed items do not consume `--limit`.

The regression harness drives the real harvest-runner process through a temporary manifest and local fake `bun` boundary. It proves that a real run writes the canonical marker, a subsequent resume finds that exact marker, completed A does not consume `--resume --limit 1` ahead of unfinished B, and non-resume `--limit 1` still selects A.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No documentation change is required. The documented artifact tree already includes the `scenario/` family segment; the implementation now uses that existing layout consistently.

# Testing

## Where should a reviewer start?

- `scripts/training-harvest/harvest-runner.mjs`: `scenarioItemPath()`, `runScenario()`, and the resume loop.
- `scripts/training-harvest/harvest-runner.test.mjs`: canonical marker, resume-limit, and non-resume limit process tests.

## Detailed testing steps

Run with the repository-pinned Bun 1.3.14 and Node 24.15.0:

```bash
bun install --frozen-lockfile
node --test scripts/training-harvest/harvest-runner.test.mjs scripts/training-harvest/bench-e2e-harvest-runner.test.mjs
./node_modules/.bin/biome check scripts/training-harvest/harvest-runner.mjs scripts/training-harvest/harvest-runner.test.mjs
git diff --check origin/develop...HEAD
bun run verify
```

Observed final results:

- Complete scenario + E2E harvest-runner suite: 15 passed, 0 failed.
- Changed-file Biome check: 2 files checked, no fixes required.
- Diff check: passed.
- Root verification: passed through the final anti-focused-test audit (8,266 test files; 0 focused; 0 orphaned skips).

# Evidence Gate

<!-- evidence-head:3faf94da8d9fe14343085240dbcb5de9e51e2127 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: N/A - headless harvest control flow has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: N/A - headless harvest control flow has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] Video walkthrough: N/A - deterministic process behavior has no visual user flow.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - this is a local build/training script and does not invoke a backend service.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no frontend or network request is involved.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: deterministic child-process and repository verification transcript.

<details>
<summary>Final verification transcript</summary>

```text
scenario + E2E harvest-runner suite: 15 passed, 0 failed
changed-file biome: Checked 2 files. No fixes applied.
git diff --check origin/develop...HEAD: passed
root verify: workflow trigger policy passed
root verify: script inventory discovered 192 executable test files
root verify: test-lane membership accounted for every test-bearing package
root verify: [anti-larp] scanned 8266 test files — 0 focused, 0 orphaned skip(s)
root verify: [anti-larp] clean — no focused tests, no untracked skips.
proof-run: recorded PROOF for 3faf94da8 — bun run verify (exit 0)
```

</details>

<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review: N/A - no rendered visual surface or text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - the change repairs local filesystem/control-flow behavior and does not alter agent, action, prompt, provider, or model behavior.

## Backend + frontend logs

N/A - the runner is a local Stage 2 training tool. The deterministic child-process tests exercise the changed CLI path directly without a backend or frontend.

## Screenshots (before / after) + video walkthrough

N/A - no UI or rendered visual surface is changed.

## Known gaps / failures

None. The focused suite, changed-file checks, and exact-head repository verification all pass on the published commit.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/eliza@ee523cda0a7ebd387339ad713ceaa7484e011c4a:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [sol-training-harvest-resume]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"claude-code","skill_revision":"elizaOS/eliza@ee523cda0a7ebd387339ad713ceaa7484e011c4a:packages/skills/skills/contribute-to-eliza"} -->

