### PR TITLE
fix(core): degrade dashboard widget blocks in connector text projection

### DIFF
--- a/packages/core/src/messaging/interactions/dashboard-markers.ts
+++ b/packages/core/src/messaging/interactions/dashboard-markers.ts
@@ -1,33 +1,151 @@
 /**
- * Dashboard-only inline markers.
+ * Dashboard-only markers and widget blocks.
  *
- * Some single-line markers in agent reply text are rendered exclusively by the
- * dashboard chat surface and mean nothing anywhere else — `[CONFIG:<pluginId>]`
- * becomes a plugin setup card (see packages/ui message-parser-helpers). They
- * are NOT part of the interaction-block grammar, so `parseInteractionBlocks`
+ * Part of the reply vocabulary is rendered exclusively by the dashboard chat
+ * surface and means nothing anywhere else: the single-line `[CONFIG:<pluginId>]`
+ * plugin-card and `[BACKGROUND]` wallpaper-picker markers, and the JSON-bodied
+ * `[CHECKLIST]`/`[WORKFLOW]` widget blocks (see packages/ui
+ * message-parser-helpers and the per-widget parsers it collects). None of these
+ * are part of the interaction-block grammar, so `parseInteractionBlocks`
  * deliberately leaves them in `cleanedText` — which means every non-dashboard
  * connector that renders from cleanedText leaks them verbatim into chat
- * (live: `[CONFIG:google_calendars]` delivered raw over api/chat replies,
- * Finding B at HQ #18309).
+ * (live: `[CONFIG:google_calendars]` raw over api/chat replies, Finding B at
+ * HQ #18309; a raw `[CHECKLIST]{json}[/CHECKLIST]` block in an api reply,
+ * tj-578adf524ebb7a).
  *
- * The canonical interaction parser strips them only from its connector-facing
+ * Bare markers are stripped; widget blocks degrade to a plain-text projection
+ * of their content (a checklist keeps its items, a workflow keeps its steps) so
+ * button-less transports lose the widget, not the answer. A malformed widget
+ * body keeps its body text with the bracket markers removed — the same
+ * plain-text fallback the dashboard applies, minus the wire syntax.
+ *
+ * The canonical interaction parser applies this only to its connector-facing
  * `cleanedText`; it never mutates the original content consumed by the
- * dashboard. The pattern mirrors the dashboard's own CONFIG_RE exactly so the
- * two projections agree about what constitutes a marker.
+ * dashboard. Every pattern below mirrors its dashboard counterpart exactly so
+ * the two projections agree about what constitutes a marker.
  */
 
 /** Matches `[CONFIG:<pluginId>]` — keep in lockstep with the dashboard's CONFIG_RE. */
 const DASHBOARD_CONFIG_MARKER_RE = /\[CONFIG:([@\w][\w@./:-]*)\]/g;
 
+/** Matches the bare `[BACKGROUND]` picker marker — lockstep with BACKGROUND_RE. */
+const DASHBOARD_BACKGROUND_MARKER_RE = /\[BACKGROUND\]/g;
+
+/** Matches `[CHECKLIST]\n{json}\n[/CHECKLIST]` — lockstep with the dashboard's CHECKLIST_RE. */
+const DASHBOARD_CHECKLIST_BLOCK_RE =
+	/\[CHECKLIST\]\n([\s\S]*?)\n\[\/CHECKLIST\]/g;
+
+/** Matches `[WORKFLOW]\n{json}\n[/WORKFLOW]` — lockstep with the dashboard's WORKFLOW_RE. */
+const DASHBOARD_WORKFLOW_BLOCK_RE = /\[WORKFLOW\]\n([\s\S]*?)\n\[\/WORKFLOW\]/g;
+
+/** Marker glyphs for checklist item statuses (`- [x]` renders as a task list on markdown surfaces). */
+const CHECKLIST_STATUS_GLYPHS: Record<string, string> = {
+	completed: "[x]",
+	in_progress: "[~]",
+	pending: "[ ]",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /**
- * Remove dashboard-only markers from connector-bound prose. Collapses the
- * whitespace a removed marker leaves behind so chat output has no orphan
- * blank lines.
+ * Project a `[CHECKLIST]` JSON body onto plain task-list lines. Returns null
+ * for a body the dashboard would also treat as malformed, so the caller can
+ * apply the shared strip-markers-keep-body fallback.
+ */
+function checklistBodyToPlainText(body: string): string | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(body);
+	} catch {
+		// error-policy:J3 untrusted model output — null signals malformed so the
+		// block degrades to its body text instead of a fake-valid empty list.
+		return null;
+	}
+	if (!isRecord(parsed) || !Array.isArray(parsed.items)) return null;
+	const lines: string[] = [];
+	for (const raw of parsed.items) {
+		if (!isRecord(raw) || typeof raw.content !== "string") continue;
+		const content = raw.content.trim();
+		if (!content) continue;
+		const glyph =
+			typeof raw.status === "string"
+				? (CHECKLIST_STATUS_GLYPHS[raw.status] ??
+					CHECKLIST_STATUS_GLYPHS.pending)
+				: CHECKLIST_STATUS_GLYPHS.pending;
+		lines.push(`- ${glyph} ${content}`);
+	}
+	if (lines.length === 0) return null;
+	const title =
+		typeof parsed.title === "string" && parsed.title.trim().length > 0
+			? `${parsed.title.trim()}:\n`
+			: "";
+	return `${title}${lines.join("\n")}`;
+}
+
+/**
+ * Project a `[WORKFLOW]` JSON body onto numbered step lines with their status.
+ * Null signals malformed, same contract as {@link checklistBodyToPlainText}.
+ */
+function workflowBodyToPlainText(body: string): string | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(body);
+	} catch {
+		// error-policy:J3 untrusted model output — null signals malformed so the
+		// block degrades to its body text instead of a fake-valid empty pipeline.
+		return null;
+	}
+	if (!isRecord(parsed) || !Array.isArray(parsed.steps)) return null;
+	const lines: string[] = [];
+	for (const raw of parsed.steps) {
+		if (!isRecord(raw) || typeof raw.label !== "string") continue;
+		const label = raw.label.trim();
+		if (!label) continue;
+		const status =
+			typeof raw.status === "string" && raw.status.trim().length > 0
+				? raw.status.trim()
+				: "pending";
+		lines.push(`${lines.length + 1}. ${label} — ${status}`);
+	}
+	if (lines.length === 0) return null;
+	const title =
+		typeof parsed.title === "string" && parsed.title.trim().length > 0
+			? `${parsed.title.trim()}:\n`
+			: "";
+	return `${title}${lines.join("\n")}`;
+}
+
+function degradeWidgetBlocks(text: string): string {
+	return text
+		.replace(
+			DASHBOARD_CHECKLIST_BLOCK_RE,
+			(_match, body: string) => checklistBodyToPlainText(body) ?? body.trim(),
+		)
+		.replace(
+			DASHBOARD_WORKFLOW_BLOCK_RE,
+			(_match, body: string) => workflowBodyToPlainText(body) ?? body.trim(),
+		);
+}
+
+/**
+ * Remove dashboard-only markers from connector-bound prose and degrade
+ * dashboard widget blocks to plain text. Collapses the whitespace a removed
+ * marker leaves behind so chat output has no orphan blank lines.
  */
 export function stripDashboardOnlyMarkers(text: string): string {
-	if (!text.includes("[CONFIG:")) return text;
-	return text
+	if (
+		!text.includes("[CONFIG:") &&
+		!text.includes("[BACKGROUND]") &&
+		!text.includes("[CHECKLIST]") &&
+		!text.includes("[WORKFLOW]")
+	) {
+		return text;
+	}
+	return degradeWidgetBlocks(text)
 		.replace(DASHBOARD_CONFIG_MARKER_RE, "")
+		.replace(DASHBOARD_BACKGROUND_MARKER_RE, "")
 		.replace(/[ \t]+\n/g, "\n")
 		.replace(/\n{3,}/g, "\n\n")
 		.trim();

--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -968,4 +968,43 @@ describe("stripDashboardOnlyMarkers", () => {
 		expect(parsed.cleanedText).toBe("Connect it.");
 		expect(renderInteractionsAsPlainText(source).text).not.toContain("CONFIG");
 	});
+
+	it("degrades a [CHECKLIST] block to a plain task list (tj-578adf524ebb7a)", () => {
+		const input =
+			'Working through it now.\n\n[CHECKLIST]\n{"title":"Migration","items":[{"content":"Back up the database","status":"completed"},{"content":"Run the migration","status":"in_progress"},{"content":"Verify downstream consumers"}]}\n[/CHECKLIST]';
+		expect(stripDashboardOnlyMarkers(input)).toBe(
+			"Working through it now.\n\nMigration:\n- [x] Back up the database\n- [~] Run the migration\n- [ ] Verify downstream consumers",
+		);
+	});
+
+	it("degrades a [WORKFLOW] block to numbered steps with status", () => {
+		const input =
+			'[WORKFLOW]\n{"title":"Deploy","steps":[{"label":"Build image","status":"done"},{"label":"Push to registry","status":"running"},{"label":"Roll out"}]}\n[/WORKFLOW]';
+		expect(stripDashboardOnlyMarkers(input)).toBe(
+			"Deploy:\n1. Build image — done\n2. Push to registry — running\n3. Roll out — pending",
+		);
+	});
+
+	it("keeps a malformed widget body as text with the wire markers removed", () => {
+		const input =
+			"Here's the plan.\n[CHECKLIST]\nnot json at all\n[/CHECKLIST]";
+		expect(stripDashboardOnlyMarkers(input)).toBe(
+			"Here's the plan.\nnot json at all",
+		);
+	});
+
+	it("strips the bare [BACKGROUND] picker marker", () => {
+		expect(
+			stripDashboardOnlyMarkers("Pick a wallpaper below.\n\n[BACKGROUND]"),
+		).toBe("Pick a wallpaper below.");
+	});
+
+	it("keeps widget blocks out of the connector plain-text projection", () => {
+		const source =
+			'Status update:\n[CHECKLIST]\n{"items":[{"content":"Ship it","status":"pending"}]}\n[/CHECKLIST]\n[FOLLOWUPS]\nreply:continue=Continue\n[/FOLLOWUPS]';
+		const rendered = renderInteractionsAsPlainText(source).text;
+		expect(rendered).not.toContain("[CHECKLIST]");
+		expect(rendered).not.toContain("{");
+		expect(rendered).toContain("- [ ] Ship it");
+	});
 });


### PR DESCRIPTION
## Problem

`[CHECKLIST]`/`[WORKFLOW]` JSON blocks and the bare `[BACKGROUND]` marker are dashboard-only vocabulary — taught to the model by the `uiWidgets` provider (`packages/agent/src/providers/ui-catalog.ts`, DM/API-channel gated by design) and rendered by the packages/ui widget parsers. They are NOT interaction-grammar blocks, so `parseInteractionBlocks` leaves them in connector-facing `cleanedText`, and every button-less surface delivers them raw.

**Live leak**: trajectory `tj-578adf524ebb7a` — a raw `[CHECKLIST]{json}[/CHECKLIST]` block delivered verbatim in an api chat reply while the turn's GENERATE_MEDIA action succeeded. Same F2 family as the `[CONFIG:google_calendars]` leak (Finding B, HQ #18309) fixed at this exact boundary.

## Fix

`stripDashboardOnlyMarkers` (the canonical connector text boundary, already applied by `parseInteractionBlocks` cleanedText, `renderInteractionsAsPlainText`, the api chat mirror, Discord, and Telegram) now:
- degrades `[CHECKLIST]` bodies to plain task-list lines (`- [x] / - [~] / - [ ]` + optional title),
- degrades `[WORKFLOW]` bodies to numbered step lines with status,
- strips the bare `[BACKGROUND]` picker marker (same treatment as `[CONFIG:]`),
- keeps a malformed widget body as its body text minus the wire brackets — mirroring the dashboard's own malformed-body plain-text fallback.

Regexes are byte-for-byte lockstep with the dashboard parsers (`CHECKLIST_RE`/`WORKFLOW_RE`/`BACKGROUND_RE`) with lockstep comments, per the established `CONFIG_RE` pattern. The dashboard is untouched — it renders original content, never cleanedText.

## Evidence

| Check | Result |
|---|---|
| core interactions suite (5 new tests incl. the tj repro shape) | 74/74 ✅ |
| agent `chat-surface-text.test.ts` (api-route consumer) | 3/3 ✅ |
| agent `ui-widgets.budget` + `ui-catalog.followups` lockstep | 13/13 ✅ |
| plugin-discord `interactions.test.ts` | 17/17 ✅ |
| `packages/core` typecheck + build:node | ✅ |
| Biome on touched files | ✅ |

Note: an initial full agent-package sweep reported 6 failed batches — that run was contaminated by a branch switch in the same worktree while it executed; the direct-consumer suites above were re-run clean on the final branch state. Telegram consumes the same shared function through `plugin-telegram/src/interactions.ts` (no test file references this boundary there).

Live re-prove on the box follows the next resync (castle scenario: media-generation turn that previously carried the checklist block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)