### PR TITLE
fix(infra): enforce additive canonical wildcard plans

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -511,6 +511,62 @@ jobs:
             exit 1
           fi
 
+      - name: Validate additive canonical edge plan
+        if: inputs.component == 'pages-domains' && inputs.operation == 'apply' && inputs.plan_scope == 'canonical-edge-additive'
+        working-directory: ${{ steps.root.outputs.directory }}
+        shell: bash
+        env:
+          TARGET_ENVIRONMENT: ${{ inputs.environment }}
+        run: |
+          set -euo pipefail
+          reviewed_plan="$RUNNER_TEMP/canonical-edge-reviewed-plan.json"
+          terraform show -json selected.tfplan > "$reviewed_plan"
+          node - "$reviewed_plan" <<'NODE'
+          const fs = require("node:fs");
+          const plan = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const siteWildcard = process.env.TARGET_ENVIRONMENT === "production"
+            ? "*.sites.eliza.app"
+            : "*.sites-staging.eliza.app";
+          const packPrefix = 'cloudflare_certificate_pack.canonical_edge[';
+          const dnsPrefix = `cloudflare_dns_record.canonical_edge_wildcard[\"${siteWildcard}|`;
+          const changes = plan.resource_changes ?? [];
+          let packTargets = 0;
+          let dnsTargets = 0;
+          let creates = 0;
+          const failures = [];
+
+          for (const resource of changes) {
+            const actions = resource.change?.actions ?? [];
+            const noOp = actions.length === 1 && actions[0] === "no-op";
+            if (resource.mode !== "managed" || noOp) continue;
+            const isPack = resource.address.startsWith(packPrefix);
+            const isSiteDns = resource.address.startsWith(dnsPrefix);
+            if (!isPack && !isSiteDns) {
+              failures.push(`${resource.address}: out-of-scope action ${actions.join("/")}`);
+              continue;
+            }
+            if (actions.length !== 1 || actions[0] !== "create") {
+              failures.push(`${resource.address}: non-additive action ${actions.join("/")}`);
+              continue;
+            }
+            creates += 1;
+          }
+
+          for (const resource of changes) {
+            if (resource.mode !== "managed") continue;
+            if (resource.address.startsWith(packPrefix)) packTargets += 1;
+            if (resource.address.startsWith(dnsPrefix)) dnsTargets += 1;
+          }
+          if (packTargets === 0) failures.push("no canonical certificate-pack targets");
+          if (dnsTargets === 0) failures.push("no hosted-site wildcard DNS targets");
+          if (creates === 0) failures.push("scope contains no additive resource creation");
+          if (failures.length > 0) {
+            console.error(`::error::Reviewed canonical-edge plan is not additive-only: ${failures.join(", ")}`);
+            process.exit(1);
+          }
+          console.log(`Reviewed additive-only canonical-edge plan (${packTargets} certificate, ${dnsTargets} DNS target(s)).`);
+          NODE
+
       - name: Apply reviewed plan
         if: inputs.operation == 'apply'
         working-directory: ${{ steps.root.outputs.directory }}
@@ -598,20 +654,58 @@ jobs:
         if: inputs.component == 'pages-domains' && inputs.operation == 'apply' && inputs.plan_scope == 'canonical-edge-additive'
         working-directory: ${{ steps.root.outputs.directory }}
         shell: bash
+        env:
+          TARGET_ENVIRONMENT: ${{ inputs.environment }}
         run: |
           set -euo pipefail
-          for attempt in $(seq 1 60); do
-            terraform refresh -no-color -input=false >/dev/null
-            terraform output -json canonical_edge > "$RUNNER_TEMP/canonical-edge.json"
-            if node - "$RUNNER_TEMP/canonical-edge.json" <<'NODE'
+          reviewed_plan="$RUNNER_TEMP/canonical-edge-reviewed-plan.json"
+          mapfile -t refresh_targets < <(
+            node - "$reviewed_plan" <<'NODE'
           const fs = require("node:fs");
-          const canonical = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
-          const records = Object.entries(canonical.dns_records ?? {});
-          const packs = Object.entries(canonical.certificate_packs ?? {});
-          if (records.length === 0) process.exit(1);
-          if (packs.length === 0) process.exit(1);
-          if (records.some(([, record]) => !record.id || record.proxied !== true)) process.exit(1);
-          if (packs.some(([, pack]) => pack.status !== "active")) process.exit(1);
+          const plan = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const siteWildcard = process.env.TARGET_ENVIRONMENT === "production"
+            ? "*.sites.eliza.app"
+            : "*.sites-staging.eliza.app";
+          const prefixes = [
+            "cloudflare_certificate_pack.canonical_edge[",
+            `cloudflare_dns_record.canonical_edge_wildcard[\"${siteWildcard}|`,
+          ];
+          for (const resource of plan.resource_changes ?? []) {
+            if (resource.mode === "managed" && prefixes.some((prefix) => resource.address.startsWith(prefix))) {
+              console.log(resource.address);
+            }
+          }
+          NODE
+          )
+          [ "${#refresh_targets[@]}" -gt 0 ] || { echo "::error::Reviewed plan has no canonical-edge refresh targets"; exit 1; }
+          refresh_args=(-no-color -input=false)
+          for address in "${refresh_targets[@]}"; do
+            refresh_args+=("-target=$address")
+          done
+          for attempt in $(seq 1 60); do
+            terraform refresh "${refresh_args[@]}" >/dev/null
+            terraform output -json canonical_edge > "$RUNNER_TEMP/canonical-edge.json"
+            if node - "$reviewed_plan" "$RUNNER_TEMP/canonical-edge.json" <<'NODE'
+          const fs = require("node:fs");
+          const plan = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const canonical = JSON.parse(fs.readFileSync(process.argv[3], "utf8"));
+          const decodeKey = (address, prefix) => JSON.parse(address.slice(prefix.length, -1));
+          const siteWildcard = process.env.TARGET_ENVIRONMENT === "production"
+            ? "*.sites.eliza.app"
+            : "*.sites-staging.eliza.app";
+          const packPrefix = "cloudflare_certificate_pack.canonical_edge[";
+          const dnsPrefix = "cloudflare_dns_record.canonical_edge_wildcard[";
+          const scopedDnsPrefix = `${dnsPrefix}\"${siteWildcard}|`;
+          const packKeys = [];
+          const dnsKeys = [];
+          for (const resource of plan.resource_changes ?? []) {
+            if (resource.mode !== "managed") continue;
+            if (resource.address.startsWith(packPrefix)) packKeys.push(decodeKey(resource.address, packPrefix));
+            if (resource.address.startsWith(scopedDnsPrefix)) dnsKeys.push(decodeKey(resource.address, dnsPrefix));
+          }
+          if (packKeys.length === 0 || dnsKeys.length === 0) process.exit(1);
+          if (dnsKeys.some((key) => !canonical.dns_records?.[key]?.id || canonical.dns_records[key].proxied !== true)) process.exit(1);
+          if (packKeys.some((key) => canonical.certificate_packs?.[key]?.status !== "active")) process.exit(1);
           NODE
             then
               exit 0
@@ -656,6 +750,7 @@ jobs:
         working-directory: ${{ steps.root.outputs.directory }}
         shell: bash
         run: |
+          rm -f "$RUNNER_TEMP/canonical-edge-reviewed-plan.json"
           if [ -f selected.tfplan ]; then
             shred -u selected.tfplan
           fi

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -23,6 +23,12 @@ on:
         default: plan
         type: choice
         options: [plan, apply, state-rm]
+      plan_scope:
+        description: Resource scope saved into a pages-domains plan
+        required: true
+        default: full
+        type: choice
+        options: [full, canonical-edge-additive]
       state_address:
         description: Exact address for state-rm; ignored otherwise
         required: false
@@ -93,6 +99,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.R2_STATE_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_STATE_SECRET_ACCESS_KEY }}
       TERRAFORM_PLAN_ARTIFACT_PUBLIC_KEY: ${{ vars.TERRAFORM_PLAN_ARTIFACT_PUBLIC_KEY }}
+      TERRAFORM_PLAN_SCOPE: ${{ inputs.plan_scope }}
       TF_VAR_environment: ${{ inputs.environment }}
       TF_VAR_cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       TF_VAR_cloudflare_zone_id: ${{ secrets.APPS_CLOUDFLARE_ZONE_ID || vars.APPS_CLOUDFLARE_ZONE_ID }}
@@ -232,6 +239,7 @@ jobs:
             component: process.env.EXPECTED_COMPONENT,
             environment: process.env.EXPECTED_ENVIRONMENT,
             operation: "plan",
+            planScope: process.env.TERRAFORM_PLAN_SCOPE,
             runId: process.env.EXPECTED_RUN_ID,
             runAttempt: process.env.EXPECTED_RUN_ATTEMPT,
             sourceRef: `refs/heads/${process.env.EXPECTED_ENVIRONMENT === "production" ? "main" : "develop"}`,
@@ -289,6 +297,11 @@ jobs:
           STATE_ADDRESS: ${{ inputs.state_address }}
         run: |
           set -euo pipefail
+          if [ "$TERRAFORM_PLAN_SCOPE" != "full" ]; then
+            [ "${{ inputs.component }}" = "pages-domains" ] || { echo "::error::Scoped plans are supported only for pages-domains"; exit 1; }
+            [ "$TERRAFORM_PLAN_SCOPE" = "canonical-edge-additive" ] || { echo "::error::Unsupported Terraform plan scope"; exit 1; }
+            [ "$OPERATION" != "state-rm" ] || { echo "::error::state-rm does not accept a plan scope"; exit 1; }
+          fi
           [ -n "$AWS_ACCESS_KEY_ID" ] || { echo "::error::R2_STATE_ACCESS_KEY_ID is required"; exit 1; }
           [ -n "$AWS_SECRET_ACCESS_KEY" ] || { echo "::error::R2_STATE_SECRET_ACCESS_KEY is required"; exit 1; }
           if [ "${{ inputs.component }}" = "prod-ops" ]; then
@@ -387,7 +400,29 @@ jobs:
       - name: Plan
         if: inputs.operation == 'plan'
         working-directory: ${{ steps.root.outputs.directory }}
-        run: terraform plan -no-color -input=false -out=selected.tfplan
+        shell: bash
+        run: |
+          set -euo pipefail
+          plan_args=(-no-color -input=false -out=selected.tfplan)
+          if [ "$TERRAFORM_PLAN_SCOPE" = "canonical-edge-additive" ]; then
+            if [ "${{ inputs.environment }}" = "production" ]; then
+              site_wildcard="*.sites.eliza.app"
+            else
+              site_wildcard="*.sites-staging.eliza.app"
+            fi
+            mapfile -t new_pack_keys < <(
+              jq -r 'to_entries[] | select((.value.id // "") == "") | .key' \
+                <<< "$TF_VAR_canonical_edge_certificate_packs"
+            )
+            [ "${#new_pack_keys[@]}" -gt 0 ] || { echo "::error::Canonical-edge scope requires at least one additive certificate generation"; exit 1; }
+            for key in "${new_pack_keys[@]}"; do
+              plan_args+=("-target=cloudflare_certificate_pack.canonical_edge[\"$key\"]")
+            done
+            while IFS= read -r origin; do
+              plan_args+=("-target=cloudflare_dns_record.canonical_edge_wildcard[\"$site_wildcard|$origin\"]")
+            done < <(jq -r '.[]' <<< "$TF_VAR_canonical_edge_wildcard_origins")
+          fi
+          terraform plan "${plan_args[@]}"
 
       - name: Package reviewed plan
         if: inputs.operation == 'plan'
@@ -404,12 +439,13 @@ jobs:
             --arg component "$COMPONENT" \
             --arg environment "$TARGET_ENVIRONMENT" \
             --arg operation "plan" \
+            --arg planScope "$TERRAFORM_PLAN_SCOPE" \
             --arg runId "$GITHUB_RUN_ID" \
             --arg runAttempt "$GITHUB_RUN_ATTEMPT" \
             --arg sourceRef "$GITHUB_REF" \
             --arg sourceSha "$GITHUB_SHA" \
             --arg planSha256 "$plan_digest" \
-            '{component:$component,environment:$environment,operation:$operation,runId:$runId,runAttempt:$runAttempt,sourceRef:$sourceRef,sourceSha:$sourceSha,planSha256:$planSha256}' \
+            '{component:$component,environment:$environment,operation:$operation,planScope:$planScope,runId:$runId,runAttempt:$runAttempt,sourceRef:$sourceRef,sourceSha:$sourceSha,planSha256:$planSha256}' \
             > "$artifact_dir/plan-metadata.json"
           node "$GITHUB_WORKSPACE/packages/scripts/terraform-plan-envelope.mjs" \
             encrypt \
@@ -436,6 +472,7 @@ jobs:
         run: |
           {
             echo "### Protected Terraform plan"
+            echo "- Scope: $TERRAFORM_PLAN_SCOPE"
             echo "- Run id: $GITHUB_RUN_ID"
             echo "- Run attempt: $GITHUB_RUN_ATTEMPT"
             echo "- Artifact id: $ARTIFACT_ID"
@@ -479,8 +516,8 @@ jobs:
         working-directory: ${{ steps.root.outputs.directory }}
         run: terraform apply -no-color -input=false selected.tfplan
 
-      - name: Verify Pages domain and certificate state
-        if: inputs.component == 'pages-domains' && inputs.operation == 'apply'
+      - name: Verify full Pages domain and certificate state
+        if: inputs.component == 'pages-domains' && inputs.operation == 'apply' && inputs.plan_scope == 'full'
         working-directory: ${{ steps.root.outputs.directory }}
         run: |
           terraform output -json pages_domains > "$RUNNER_TEMP/pages-domains.json"
@@ -557,9 +594,51 @@ jobs:
             "$RUNNER_TEMP/redirect-dns.json" \
             "$RUNNER_TEMP/legacy-certificate-packs.json"
 
+      - name: Verify additive canonical edge state
+        if: inputs.component == 'pages-domains' && inputs.operation == 'apply' && inputs.plan_scope == 'canonical-edge-additive'
+        working-directory: ${{ steps.root.outputs.directory }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 60); do
+            terraform refresh -no-color -input=false >/dev/null
+            terraform output -json canonical_edge > "$RUNNER_TEMP/canonical-edge.json"
+            if node - "$RUNNER_TEMP/canonical-edge.json" <<'NODE'
+          const fs = require("node:fs");
+          const canonical = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const records = Object.entries(canonical.dns_records ?? {});
+          const packs = Object.entries(canonical.certificate_packs ?? {});
+          if (records.length === 0) process.exit(1);
+          if (packs.length === 0) process.exit(1);
+          if (records.some(([, record]) => !record.id || record.proxied !== true)) process.exit(1);
+          if (packs.some(([, pack]) => pack.status !== "active")) process.exit(1);
+          NODE
+            then
+              exit 0
+            fi
+            if [ "$attempt" = "60" ]; then
+              echo "::error::Canonical wildcard DNS or certificate packs did not become active"
+              exit 1
+            fi
+            sleep 10
+          done
+
       - name: Verify staging agent wildcard TLS
         if: inputs.component == 'pages-domains' && inputs.operation == 'apply' && inputs.environment == 'staging'
         run: curl --silent --show-error --output /dev/null https://terraform-probe.cloud-staging.eliza.app/api/health
+
+      - name: Verify canonical wildcard TLS
+        if: inputs.component == 'pages-domains' && inputs.operation == 'apply' && inputs.plan_scope == 'canonical-edge-additive'
+        shell: bash
+        env:
+          AGENT_PROBE: ${{ inputs.environment == 'production' && 'terraform-probe.cloud.eliza.app' || 'terraform-probe.cloud-staging.eliza.app' }}
+          SITE_PROBE: ${{ inputs.environment == 'production' && 'terraform-probe.sites.eliza.app' || 'terraform-probe.sites-staging.eliza.app' }}
+        run: |
+          set -euo pipefail
+          for host in "$AGENT_PROBE" "$SITE_PROBE"; do
+            curl --silent --show-error --connect-timeout 10 --max-time 20 \
+              --output /dev/null "https://$host/"
+          done
 
       - name: Verify live environment routing
         if: inputs.component == 'pages-domains' && inputs.operation == 'apply'

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -423,6 +423,12 @@ jobs:
             done < <(jq -r '.[]' <<< "$TF_VAR_canonical_edge_wildcard_origins")
           fi
           terraform plan "${plan_args[@]}"
+          if [ "$TERRAFORM_PLAN_SCOPE" = "canonical-edge-additive" ]; then
+            reviewed_plan="$RUNNER_TEMP/canonical-edge-reviewed-plan.json"
+            terraform show -json selected.tfplan > "$reviewed_plan"
+            node "$GITHUB_WORKSPACE/packages/scripts/validate-terraform-canonical-edge-additive-plan.mjs" \
+              "$reviewed_plan" "${{ inputs.environment }}"
+          fi
 
       - name: Package reviewed plan
         if: inputs.operation == 'plan'
@@ -486,6 +492,9 @@ jobs:
         working-directory: ${{ steps.root.outputs.directory }}
         shell: bash
         run: |
+          if [ -f "$RUNNER_TEMP/canonical-edge-reviewed-plan.json" ]; then
+            shred -u "$RUNNER_TEMP/canonical-edge-reviewed-plan.json"
+          fi
           if [ -f selected.tfplan ]; then
             shred -u selected.tfplan
           fi
@@ -521,55 +530,8 @@ jobs:
           set -euo pipefail
           reviewed_plan="$RUNNER_TEMP/canonical-edge-reviewed-plan.json"
           terraform show -json selected.tfplan > "$reviewed_plan"
-          node - "$reviewed_plan" <<'NODE'
-          const fs = require("node:fs");
-          const plan = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
-          const siteWildcard = process.env.TARGET_ENVIRONMENT === "production"
-            ? "*.sites.eliza.app"
-            : "*.sites-staging.eliza.app";
-          const packPrefix = 'cloudflare_certificate_pack.canonical_edge[';
-          const dnsPrefix = `cloudflare_dns_record.canonical_edge_wildcard[\"${siteWildcard}|`;
-          const changes = plan.resource_changes ?? [];
-          let packTargets = 0;
-          let dnsTargets = 0;
-          let creates = 0;
-          const failures = [];
-
-          for (const resource of changes) {
-            const actions = resource.change?.actions ?? [];
-            if (resource.change?.importing) {
-              failures.push(`${resource.address}: import is not additive infrastructure creation`);
-              continue;
-            }
-            const noOp = actions.length === 1 && actions[0] === "no-op";
-            if (resource.mode !== "managed" || noOp) continue;
-            const isPack = resource.address.startsWith(packPrefix);
-            const isSiteDns = resource.address.startsWith(dnsPrefix);
-            if (!isPack && !isSiteDns) {
-              failures.push(`${resource.address}: out-of-scope action ${actions.join("/")}`);
-              continue;
-            }
-            if (actions.length !== 1 || actions[0] !== "create") {
-              failures.push(`${resource.address}: non-additive action ${actions.join("/")}`);
-              continue;
-            }
-            creates += 1;
-          }
-
-          for (const resource of changes) {
-            if (resource.mode !== "managed") continue;
-            if (resource.address.startsWith(packPrefix)) packTargets += 1;
-            if (resource.address.startsWith(dnsPrefix)) dnsTargets += 1;
-          }
-          if (packTargets === 0) failures.push("no canonical certificate-pack targets");
-          if (dnsTargets === 0) failures.push("no hosted-site wildcard DNS targets");
-          if (creates === 0) failures.push("scope contains no additive resource creation");
-          if (failures.length > 0) {
-            console.error(`::error::Reviewed canonical-edge plan is not additive-only: ${failures.join(", ")}`);
-            process.exit(1);
-          }
-          console.log(`Reviewed additive-only canonical-edge plan (${packTargets} certificate, ${dnsTargets} DNS target(s)).`);
-          NODE
+          node "$GITHUB_WORKSPACE/packages/scripts/validate-terraform-canonical-edge-additive-plan.mjs" \
+            "$reviewed_plan" "$TARGET_ENVIRONMENT"
 
       - name: Apply reviewed plan
         if: inputs.operation == 'apply'
@@ -754,7 +716,9 @@ jobs:
         working-directory: ${{ steps.root.outputs.directory }}
         shell: bash
         run: |
-          rm -f "$RUNNER_TEMP/canonical-edge-reviewed-plan.json"
+          if [ -f "$RUNNER_TEMP/canonical-edge-reviewed-plan.json" ]; then
+            shred -u "$RUNNER_TEMP/canonical-edge-reviewed-plan.json"
+          fi
           if [ -f selected.tfplan ]; then
             shred -u selected.tfplan
           fi

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -537,6 +537,10 @@ jobs:
 
           for (const resource of changes) {
             const actions = resource.change?.actions ?? [];
+            if (resource.change?.importing) {
+              failures.push(`${resource.address}: import is not additive infrastructure creation`);
+              continue;
+            }
             const noOp = actions.length === 1 && actions[0] === "no-op";
             if (resource.mode !== "managed" || noOp) continue;
             const isPack = resource.address.startsWith(packPrefix);

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/README.md
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/README.md
@@ -186,6 +186,13 @@ protected GitHub Environment variables rather than committing live values.
    DNS-only Railway tunnel records, new canonical Pages bindings, and only
    additive certificate creation. Stop on any DNS or certificate destroy,
    replace, duplicate-create, or unexpected content change.
+   When unrelated adopted resources are not ready to converge, select
+   `plan_scope=canonical-edge-additive`. That scope targets only new
+   `cloudflare_certificate_pack.canonical_edge` generations without an import
+   id and the current environment's hosted-site wildcard DNS instances. The
+   scope is authenticated in the artifact metadata and must match the apply
+   dispatch. Use `full` for ordinary convergence. Never use a scoped plan to
+   conceal destructive drift in either targeted resource family.
 5. Deploy the staging Worker routes before converting legacy site/tunnel DNS to
    proxied redirect ingress. Dispatch `operation=apply` with the exact successful
    plan run id, run attempt, artifact id, and service digest copied from that

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/README.md
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/README.md
@@ -191,12 +191,12 @@ protected GitHub Environment variables rather than committing live values.
    `cloudflare_certificate_pack.canonical_edge` generations without an import
    id and the current environment's hosted-site wildcard DNS instances. The
    scope is authenticated in the artifact metadata and must match the apply
-   dispatch. Before apply, the workflow rejects every actionable resource
-   outside those families and every update, delete, or replacement inside
-   them. Its activation polling refreshes only the exact addresses from that
-   reviewed plan, so unrelated observations are not written into state. Use
-   `full` for ordinary convergence. Never use a scoped plan to conceal
-   destructive drift in either targeted resource family.
+   dispatch. Before packaging and again before apply, the workflow rejects
+   every actionable resource outside those families and every update, delete,
+   or replacement inside them. Its activation polling refreshes only the exact
+   addresses from that reviewed plan, so unrelated observations are not
+   written into state. Use `full` for ordinary convergence. Never use a scoped
+   plan to conceal destructive drift in either targeted resource family.
 5. Deploy the staging Worker routes before converting legacy site/tunnel DNS to
    proxied redirect ingress. Dispatch `operation=apply` with the exact successful
    plan run id, run attempt, artifact id, and service digest copied from that

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/README.md
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/README.md
@@ -191,8 +191,12 @@ protected GitHub Environment variables rather than committing live values.
    `cloudflare_certificate_pack.canonical_edge` generations without an import
    id and the current environment's hosted-site wildcard DNS instances. The
    scope is authenticated in the artifact metadata and must match the apply
-   dispatch. Use `full` for ordinary convergence. Never use a scoped plan to
-   conceal destructive drift in either targeted resource family.
+   dispatch. Before apply, the workflow rejects every actionable resource
+   outside those families and every update, delete, or replacement inside
+   them. Its activation polling refreshes only the exact addresses from that
+   reviewed plan, so unrelated observations are not written into state. Use
+   `full` for ordinary convergence. Never use a scoped plan to conceal
+   destructive drift in either targeted resource family.
 5. Deploy the staging Worker routes before converting legacy site/tunnel DNS to
    proxied redirect ingress. Dispatch `operation=apply` with the exact successful
    plan run id, run attempt, artifact id, and service digest copied from that

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -263,6 +263,9 @@ describe("canonical cloud deployment environment contract", () => {
     expect(plan.run).toContain("terraform plan");
     const packagePlan = step(infra, "terraform", "Package reviewed plan");
     expect(packagePlan.run).toContain("sha256sum selected.tfplan");
+    expect(packagePlan.run).toContain(
+      '--arg planScope "$TERRAFORM_PLAN_SCOPE"',
+    );
     expect(packagePlan.run).toContain("plan-metadata.json");
     expect(packagePlan.run).toContain("selected.tfplan.enc");
     expect(packagePlan.run).toContain("terraform-plan-envelope.mjs");
@@ -306,6 +309,9 @@ describe("canonical cloud deployment environment contract", () => {
       "Reviewed artifact contains a plaintext Terraform plan",
     );
     expect(validateArtifact.run).toContain("EXPECTED_SOURCE_SHA");
+    expect(validateArtifact.run).toContain(
+      "planScope: process.env.TERRAFORM_PLAN_SCOPE",
+    );
     const decrypt = step(infra, "terraform", "Decrypt reviewed plan");
     expect(decrypt.run).toContain("terraform-plan-envelope.mjs");
     expect(decrypt.run).toContain("actual_digest");
@@ -335,6 +341,43 @@ describe("canonical cloud deployment environment contract", () => {
     expect(infraSource).not.toContain(
       "$RUNNER_TEMP/terraform-plan-artifact/selected.tfplan\n",
     );
+  });
+
+  test("can isolate additive canonical wildcard resources from unrelated Pages drift", () => {
+    const validate = step(
+      infra,
+      "terraform",
+      "Validate credentials and state operation",
+    );
+    expect(validate.run).toContain(
+      '[ "$' + '{{ inputs.component }}" = "pages-domains" ]',
+    );
+    expect(validate.run).toContain(
+      '[ "$TERRAFORM_PLAN_SCOPE" = "canonical-edge-additive" ]',
+    );
+    expect(validate.run).toContain('[ "$OPERATION" != "state-rm" ]');
+
+    const plan = step(infra, "terraform", "Plan");
+    expect(plan.run).toContain('select((.value.id // "") == "")');
+    expect(plan.run).toContain(
+      '"-target=cloudflare_certificate_pack.canonical_edge[\\"$key\\"]"',
+    );
+    expect(plan.run).toContain('site_wildcard="*.sites.eliza.app"');
+    expect(plan.run).toContain('site_wildcard="*.sites-staging.eliza.app"');
+    expect(plan.run).toContain(
+      '"-target=cloudflare_dns_record.canonical_edge_wildcard[\\"$site_wildcard|$origin\\"]"',
+    );
+    expect(plan.run).not.toContain("legacy_redirect");
+    expect(plan.run).not.toContain("cloudflare_dns_record.pages");
+
+    const scopedVerification = step(
+      infra,
+      "terraform",
+      "Verify additive canonical edge state",
+    );
+    expect(scopedVerification.run).toContain("terraform refresh");
+    expect(scopedVerification.run).toContain("canonical.certificate_packs");
+    expect(scopedVerification.run).not.toContain("legacy_certificate_packs");
   });
 
   test("derives Terraform deploy branches from the selected environment", () => {
@@ -394,7 +437,7 @@ describe("canonical cloud deployment environment contract", () => {
     const outputCheck = step(
       infra,
       "terraform",
-      "Verify Pages domain and certificate state",
+      "Verify full Pages domain and certificate state",
     );
     for (const output of [
       "pages_domains",

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -370,14 +370,49 @@ describe("canonical cloud deployment environment contract", () => {
     expect(plan.run).not.toContain("legacy_redirect");
     expect(plan.run).not.toContain("cloudflare_dns_record.pages");
 
+    const scopedPlanValidation = step(
+      infra,
+      "terraform",
+      "Validate additive canonical edge plan",
+    );
+    expect(scopedPlanValidation.run).toContain(
+      "terraform show -json selected.tfplan",
+    );
+    expect(scopedPlanValidation.run).toContain(
+      'actions[0] !== "create"',
+    );
+    expect(scopedPlanValidation.run).toContain("out-of-scope action");
+    expect(scopedPlanValidation.run).toContain("non-additive action");
+    expect(scopedPlanValidation.run).toContain(
+      "scope contains no additive resource creation",
+    );
+
     const scopedVerification = step(
       infra,
       "terraform",
       "Verify additive canonical edge state",
     );
-    expect(scopedVerification.run).toContain("terraform refresh");
+    expect(scopedVerification.run).toContain(
+      'terraform refresh "${refresh_args[@]}"',
+    );
+    expect(scopedVerification.run).toContain('refresh_args+=("-target=$address")');
+    expect(scopedVerification.run).not.toContain(
+      "terraform refresh -no-color -input=false",
+    );
+    expect(scopedVerification.run).toContain(
+      "canonical-edge-reviewed-plan.json",
+    );
     expect(scopedVerification.run).toContain("canonical.certificate_packs");
     expect(scopedVerification.run).not.toContain("legacy_certificate_packs");
+
+    const cleanup = step(
+      infra,
+      "terraform",
+      "Remove plaintext reviewed plan",
+    );
+    expect(cleanup.run).toContain(
+      'rm -f "$RUNNER_TEMP/canonical-edge-reviewed-plan.json"',
+    );
   });
 
   test("derives Terraform deploy branches from the selected environment", () => {

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -367,6 +367,10 @@ describe("canonical cloud deployment environment contract", () => {
     expect(plan.run).toContain(
       '"-target=cloudflare_dns_record.canonical_edge_wildcard[\\"$site_wildcard|$origin\\"]"',
     );
+    expect(plan.run).toContain("terraform show -json selected.tfplan");
+    expect(plan.run).toContain(
+      "validate-terraform-canonical-edge-additive-plan.mjs",
+    );
     expect(plan.run).not.toContain("legacy_redirect");
     expect(plan.run).not.toContain("cloudflare_dns_record.pages");
 
@@ -379,12 +383,7 @@ describe("canonical cloud deployment environment contract", () => {
       "terraform show -json selected.tfplan",
     );
     expect(scopedPlanValidation.run).toContain(
-      'actions[0] !== "create"',
-    );
-    expect(scopedPlanValidation.run).toContain("out-of-scope action");
-    expect(scopedPlanValidation.run).toContain("non-additive action");
-    expect(scopedPlanValidation.run).toContain(
-      "scope contains no additive resource creation",
+      "validate-terraform-canonical-edge-additive-plan.mjs",
     );
 
     const scopedVerification = step(
@@ -395,7 +394,9 @@ describe("canonical cloud deployment environment contract", () => {
     expect(scopedVerification.run).toContain(
       'terraform refresh "${refresh_args[@]}"',
     );
-    expect(scopedVerification.run).toContain('refresh_args+=("-target=$address")');
+    expect(scopedVerification.run).toContain(
+      'refresh_args+=("-target=$address")',
+    );
     expect(scopedVerification.run).not.toContain(
       "terraform refresh -no-color -input=false",
     );
@@ -405,13 +406,17 @@ describe("canonical cloud deployment environment contract", () => {
     expect(scopedVerification.run).toContain("canonical.certificate_packs");
     expect(scopedVerification.run).not.toContain("legacy_certificate_packs");
 
-    const cleanup = step(
+    const cleanup = step(infra, "terraform", "Remove plaintext reviewed plan");
+    expect(cleanup.run).toContain(
+      'shred -u "$RUNNER_TEMP/canonical-edge-reviewed-plan.json"',
+    );
+    const planCleanup = step(
       infra,
       "terraform",
-      "Remove plaintext reviewed plan",
+      "Remove plaintext planned state",
     );
-    expect(cleanup.run).toContain(
-      'rm -f "$RUNNER_TEMP/canonical-edge-reviewed-plan.json"',
+    expect(planCleanup.run).toContain(
+      'shred -u "$RUNNER_TEMP/canonical-edge-reviewed-plan.json"',
     );
   });
 

--- a/packages/scripts/__tests__/terraform-additive-plan-workflow.test.ts
+++ b/packages/scripts/__tests__/terraform-additive-plan-workflow.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Executes the Infrastructure workflow's additive-plan validator against
+ * deterministic Terraform JSON fixtures without contacting a backend.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+interface WorkflowStep {
+  name?: string;
+  run?: string;
+}
+
+interface Workflow {
+  jobs?: { terraform?: { steps?: WorkflowStep[] } };
+}
+
+const repoRoot = new URL("../../../", import.meta.url);
+const workflow = Bun.YAML.parse(
+  await Bun.file(new URL(".github/workflows/infra.yml", repoRoot)).text(),
+) as Workflow;
+const validator = workflow.jobs?.terraform?.steps?.find(
+  (step) => step.name === "Validate additive canonical edge plan",
+)?.run;
+
+if (!validator) {
+  throw new Error("Infrastructure workflow has no additive-plan validator");
+}
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+function resource(address: string, actions: string[]) {
+  return { address, mode: "managed", change: { actions } };
+}
+
+function runValidator(resourceChanges: ReturnType<typeof resource>[]) {
+  const directory = mkdtempSync(join(tmpdir(), "terraform-additive-plan-"));
+  temporaryDirectories.push(directory);
+  const fixturePath = join(directory, "plan.json");
+  const terraformPath = join(directory, "terraform");
+  writeFileSync(fixturePath, JSON.stringify({ resource_changes: resourceChanges }));
+  writeFileSync(
+    terraformPath,
+    '#!/usr/bin/env bash\nset -euo pipefail\n[ "$1" = "show" ]\ncat "$PLAN_FIXTURE"\n',
+  );
+  chmodSync(terraformPath, 0o700);
+  return Bun.spawnSync(["bash", "-c", validator], {
+    cwd: directory,
+    env: {
+      ...process.env,
+      PATH: `${directory}:${process.env.PATH ?? ""}`,
+      PLAN_FIXTURE: fixturePath,
+      RUNNER_TEMP: directory,
+      TARGET_ENVIRONMENT: "staging",
+    },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+}
+
+describe("canonical-edge additive Terraform plan workflow", () => {
+  const certificate =
+    'cloudflare_certificate_pack.canonical_edge["generation-2"]';
+  const siteDns =
+    'cloudflare_dns_record.canonical_edge_wildcard["*.sites-staging.eliza.app|203.0.113.10"]';
+
+  test("accepts only create/no-op changes in the reviewed resource families", () => {
+    const result = runValidator([
+      resource(certificate, ["create"]),
+      resource(siteDns, ["no-op"]),
+    ]);
+    expect(result.exitCode).toBe(0);
+  });
+
+  test.each([
+    ["update", resource(siteDns, ["update"])],
+    ["replacement", resource(certificate, ["delete", "create"])],
+    [
+      "out-of-scope creation",
+      resource('cloudflare_dns_record.pages["marketing"]', ["create"]),
+    ],
+  ])("rejects %s", (_label, invalidChange) => {
+    const result = runValidator([
+      resource(certificate, ["create"]),
+      resource(siteDns, ["no-op"]),
+      invalidChange,
+    ]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toContain("not additive-only");
+  });
+
+  test("rejects a vacuous target set with no creation", () => {
+    const result = runValidator([
+      resource(certificate, ["no-op"]),
+      resource(siteDns, ["no-op"]),
+    ]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toContain(
+      "scope contains no additive resource creation",
+    );
+  });
+});

--- a/packages/scripts/__tests__/terraform-additive-plan-workflow.test.ts
+++ b/packages/scripts/__tests__/terraform-additive-plan-workflow.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 interface WorkflowStep {
   name?: string;
@@ -63,6 +64,7 @@ function runValidator(resourceChanges: ReturnType<typeof resource>[]) {
     env: {
       ...process.env,
       PATH: `${directory}:${process.env.PATH ?? ""}`,
+      GITHUB_WORKSPACE: fileURLToPath(repoRoot).replace(/\/$/, ""),
       PLAN_FIXTURE: fixturePath,
       RUNNER_TEMP: directory,
       TARGET_ENVIRONMENT: "staging",

--- a/packages/scripts/__tests__/terraform-additive-plan-workflow.test.ts
+++ b/packages/scripts/__tests__/terraform-additive-plan-workflow.test.ts
@@ -36,8 +36,12 @@ afterEach(() => {
   }
 });
 
-function resource(address: string, actions: string[]) {
-  return { address, mode: "managed", change: { actions } };
+function resource(
+  address: string,
+  actions: string[],
+  options: { importing?: { id: string } } = {},
+) {
+  return { address, mode: "managed", change: { actions, ...options } };
 }
 
 function runValidator(resourceChanges: ReturnType<typeof resource>[]) {
@@ -45,7 +49,10 @@ function runValidator(resourceChanges: ReturnType<typeof resource>[]) {
   temporaryDirectories.push(directory);
   const fixturePath = join(directory, "plan.json");
   const terraformPath = join(directory, "terraform");
-  writeFileSync(fixturePath, JSON.stringify({ resource_changes: resourceChanges }));
+  writeFileSync(
+    fixturePath,
+    JSON.stringify({ resource_changes: resourceChanges }),
+  );
   writeFileSync(
     terraformPath,
     '#!/usr/bin/env bash\nset -euo pipefail\n[ "$1" = "show" ]\ncat "$PLAN_FIXTURE"\n',
@@ -85,6 +92,16 @@ describe("canonical-edge additive Terraform plan workflow", () => {
     [
       "out-of-scope creation",
       resource('cloudflare_dns_record.pages["marketing"]', ["create"]),
+    ],
+    [
+      "in-scope import",
+      resource(siteDns, ["no-op"], { importing: { id: "existing-record" } }),
+    ],
+    [
+      "out-of-scope import",
+      resource('cloudflare_dns_record.pages["marketing"]', ["no-op"], {
+        importing: { id: "existing-record" },
+      }),
     ],
   ])("rejects %s", (_label, invalidChange) => {
     const result = runValidator([

--- a/packages/scripts/validate-terraform-canonical-edge-additive-plan.mjs
+++ b/packages/scripts/validate-terraform-canonical-edge-additive-plan.mjs
@@ -1,0 +1,92 @@
+/**
+ * Validates that a reviewed Terraform plan mutates only additive canonical
+ * wildcard certificate and hosted-site DNS resources for one environment.
+ */
+
+import { readFileSync } from "node:fs";
+import process from "node:process";
+
+export function validateCanonicalEdgeAdditivePlan(plan, environment) {
+  if (environment !== "staging" && environment !== "production") {
+    return [`unsupported environment: ${environment}`];
+  }
+  const siteWildcard =
+    environment === "production"
+      ? "*.sites.eliza.app"
+      : "*.sites-staging.eliza.app";
+  const packPrefix = "cloudflare_certificate_pack.canonical_edge[";
+  const dnsPrefix = `cloudflare_dns_record.canonical_edge_wildcard["${siteWildcard}|`;
+  const changes = plan.resource_changes ?? [];
+  let packTargets = 0;
+  let dnsTargets = 0;
+  let creates = 0;
+  const failures = [];
+
+  for (const resource of changes) {
+    const actions = resource.change?.actions ?? [];
+    if (resource.change?.importing) {
+      failures.push(
+        `${resource.address}: import is not additive infrastructure creation`,
+      );
+      continue;
+    }
+    const noOp = actions.length === 1 && actions[0] === "no-op";
+    if (resource.mode !== "managed" || noOp) continue;
+    const isPack = resource.address.startsWith(packPrefix);
+    const isSiteDns = resource.address.startsWith(dnsPrefix);
+    if (!isPack && !isSiteDns) {
+      failures.push(
+        `${resource.address}: out-of-scope action ${actions.join("/")}`,
+      );
+      continue;
+    }
+    if (actions.length !== 1 || actions[0] !== "create") {
+      failures.push(
+        `${resource.address}: non-additive action ${actions.join("/")}`,
+      );
+      continue;
+    }
+    creates += 1;
+  }
+
+  for (const resource of changes) {
+    if (resource.mode !== "managed") continue;
+    if (resource.address.startsWith(packPrefix)) packTargets += 1;
+    if (resource.address.startsWith(dnsPrefix)) dnsTargets += 1;
+  }
+  if (packTargets === 0) failures.push("no canonical certificate-pack targets");
+  if (dnsTargets === 0) failures.push("no hosted-site wildcard DNS targets");
+  if (creates === 0)
+    failures.push("scope contains no additive resource creation");
+  return failures;
+}
+
+function main() {
+  const [planPath, environment] = process.argv.slice(2);
+  if (!planPath || !environment) {
+    console.error(
+      "::error::Usage: validate-terraform-canonical-edge-additive-plan.mjs <plan-json> <staging|production>",
+    );
+    process.exitCode = 1;
+    return;
+  }
+  try {
+    const plan = JSON.parse(readFileSync(planPath, "utf8"));
+    const failures = validateCanonicalEdgeAdditivePlan(plan, environment);
+    if (failures.length > 0) {
+      console.error(
+        `::error::Reviewed canonical-edge plan is not additive-only: ${failures.join(", ")}`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    console.log("Reviewed additive-only canonical-edge plan.");
+  } catch (error) {
+    console.error(
+      `::error::Unable to validate reviewed canonical-edge plan: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();


### PR DESCRIPTION
Tracks #19627.

## Summary

- adds a `canonical-edge-additive` Pages-domain Terraform scope for narrowly creating the missing canonical wildcard certificate/DNS resources;
- authenticates the selected scope in reviewed-plan metadata so apply must select the exact reviewed scope;
- validates the decrypted saved plan before apply and rejects imports, updates, deletes, replacements, out-of-scope actions, and vacuous no-create plans;
- derives post-apply refresh and state verification targets from the exact reviewed plan, preventing unrelated Pages drift from being written into remote state; and
- preserves full live routing verification after apply.

The PR requires independent review before merge. The protected plan/apply and live infrastructure evidence listed below are post-merge operator gates; no apply is authorized by making this PR review-ready.

## Why

The exact-current-main production plan in run 31912024590 correctly exposed unrelated legacy drift: 23 imports, 19 changes, and a forced tunnel-DNS replacement. Applying that full plan would violate #19627's additive-only safety boundary.

Terraform `-target` alone is not an additive guarantee: a targeted resource may still plan an update, delete, or replacement, and an unscoped `terraform refresh` writes observations for unrelated resources into state. This stack closes both gaps mechanically before the protected apply boundary.

The exceptional scope permits only:

- `cloudflare_certificate_pack.canonical_edge[...]` resources selected as new generations;
- the current environment's `*.sites.eliza.app` or `*.sites-staging.eliza.app` wildcard DNS instances; and
- `create` or `no-op` actions, with at least one actual creation and no Terraform import metadata.

Existing managed-agent wildcard DNS, Pages bindings, legacy redirects, Railway tunnel records, canonical service records, every import, and every update/delete/replace action remain outside the scope. [Terraform plan JSON records imports independently as `change.importing`](https://developer.hashicorp.com/terraform/internals/json-format), so the validator rejects that field before treating `no-op` resources as inert.

## Sync with develop

- [x] Exact head: `0b8abb1690d21028de5bcd8c1ba429689e77f6ee`.
- [x] Rebased conflict-free onto `origin/develop@6799165963a2457cc80cce47af6c5a2edb0672f4`.
- [x] Range-diff confirms the original scope patch and additive-safety repair are patch-identical after rebase.
- [x] No Terraform apply, deployment, environment approval, or external-state mutation was performed during review/handoff.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6799165963a2457cc80cce47af6c5a2edb0672f4:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

## Risk and security boundary

High-consequence but tightly scoped. The workflow can mutate protected Cloudflare infrastructure only after the existing environment approval and encrypted reviewed-plan handoff. The new pre-apply validator fails closed if the saved plan contains any actionable resource outside the two allowed families or any non-create action. Post-apply polling targets only addresses recovered from that validated saved plan; it never performs a whole-root refresh.

Full convergence remains the default. This scope must not be used to conceal destructive drift, which remains visible in the separately reviewed full plan.

## Exact-head validation

- `bun test packages/scripts/__tests__/terraform-additive-plan-workflow.test.ts packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts packages/cloud/infra/tests/terraform-static.test.ts` — `44` pass, `0` fail, `481` expectations.
- The real workflow validator harness accepts create/no-op and rejects update, replacement, out-of-scope creation, in-scope import, out-of-scope import, and a vacuous no-create plan.
- `actionlint .github/workflows/infra.yml` — pass.
- Both modified workflow shell steps extracted from parsed YAML and checked with `bash -n` — pass.
- Exact changed-file Biome and `git diff --check` — pass.
- A full root `bun run verify` was reported on the original patch before the safety repair. It was not rerun on this exact rebased head; only the exact proportional gates above are claimed here.

## Operator verification after merge

1. Dispatch a fresh protected `pages-domains` plan from the canonical source with `plan_scope=canonical-edge-additive`.
2. Inspect the plan and exact artifact identity; the workflow must also pass the additive action validator.
3. Apply only the bound reviewed artifact through the protected environment.
4. Capture targeted resource activation, wildcard TLS, and full environment-routing results.
5. Keep the PR/issue evidence explicit if any external resource remains pending or inactive.

## Evidence Gate

<!-- evidence-head:85c724f5637d7062ae6992d240267d3a9dce7f96 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI surface changed.
<!-- evidence-row:backend-logs -->
- [x] [20238-pr20238-backend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20238-pr20238-backend.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [20238-pr20238-domain-artifacts.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20238-pr20238-domain-artifacts.log)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual text changed.

## Known gaps

- Repository workflows intentionally do not run on `develop` pull requests; exact-head local workflow-contract checks are recorded above.
- No live Terraform plan/apply was dispatched during this review.
- No production or staging environment was approved or mutated.

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@6799165963a2457cc80cce47af6c5a2edb0672f4:packages/skills/skills/contribute-to-eliza"} -->
