### PR TITLE
fix(core): never strip-and-send unexecuted pseudo-tag tool markup (F38)

### DIFF
--- a/packages/core/src/runtime/__tests__/evaluator.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator.test.ts
@@ -991,6 +991,26 @@ describe("native tool dialects never recover as the user-facing answer", () => {
 		expect(result.messageToUser ?? "").not.toContain("arg_key");
 	});
 
+	it("does not launder pseudo-tag tool markup into a fabricated effect claim (matrix F38, tj-9129a432454364)", async () => {
+		// Live stage-7 shape: prose claiming the effect beside an UNEXECUTED
+		// `<NOTES_CREATE>{…}</NOTES_CREATE>` invocation. Recovering the prose
+		// would ship "saving note." while no note exists — the strip-and-send
+		// launder. The turn must stay on the replanning path instead.
+		const result = await runWithModelText(
+			'temp is 35°C. saving note.\n\n<NOTES_CREATE>\n{"title": "b50 paris wx", "content": "Paris temperature: 35°C"}\n</NOTES_CREATE>',
+		);
+		expect(result.decision).toBe("CONTINUE");
+		expect(result.messageToUser ?? "").toBe("");
+	});
+
+	it("still recovers prose that merely quotes a short acronym tag", async () => {
+		const result = await runWithModelText(
+			"the <AI> tag in that template is just a label, not markup you need to escape.",
+		);
+		expect(result.decision).toBe("FINISH");
+		expect(result.messageToUser ?? "").toContain("<AI>");
+	});
+
 	it("does not deliver a standalone bare action name + JSON args block", async () => {
 		const result = await runWithModelText(
 			'GET_WEATHER\n{ "location": "Tokyo" }',

--- a/packages/core/src/runtime/__tests__/json-output.test.ts
+++ b/packages/core/src/runtime/__tests__/json-output.test.ts
@@ -7,8 +7,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	containsToolCallShapedMarkup,
 	extractJsonObjects,
 	parseJsonObject,
+	parsePseudoTagToolInvocations,
 	repairJsonStringEscapes,
 	stripJsonStructuralJunkReply,
 } from "../json-output";
@@ -146,5 +148,68 @@ describe("stripJsonStructuralJunkReply — leaked pseudo-tool markup", () => {
 		expect(
 			stripJsonStructuralJunkReply("the <AI> label means artificial"),
 		).toBe("the <AI> label means artificial");
+	});
+});
+
+describe("parsePseudoTagToolInvocations — F38 strip-and-send recovery (tj-9129a432454364)", () => {
+	it("recovers the live stage-7 invocation with its JSON args", () => {
+		const calls = parsePseudoTagToolInvocations(
+			'temp is 35°C. saving note.\n\n<NOTES_CREATE>\n{"title": "b50 paris wx", "content": "Paris temperature: 35°C"}\n</NOTES_CREATE>',
+		);
+		expect(calls).toEqual([
+			{
+				name: "NOTES_CREATE",
+				params: { title: "b50 paris wx", content: "Paris temperature: 35°C" },
+			},
+		]);
+	});
+
+	it("recovers multiple invocations in one reply", () => {
+		const calls = parsePseudoTagToolInvocations(
+			'<NOTES_CREATE>{"title":"a"}</NOTES_CREATE> then <TODOS_CREATE>{"title":"b"}</TODOS_CREATE>',
+		);
+		expect(calls.map((c) => c.name)).toEqual(["NOTES_CREATE", "TODOS_CREATE"]);
+	});
+
+	it("does not fabricate a call from a non-JSON body", () => {
+		expect(
+			parsePseudoTagToolInvocations(
+				"<BROWSE_PAGE>the eliza repo</BROWSE_PAGE>",
+			),
+		).toEqual([]);
+	});
+
+	it("does not fabricate a call from an underscore-less tag or a JSON array body", () => {
+		expect(parsePseudoTagToolInvocations('<HTML>{"a":1}</HTML>')).toEqual([]);
+		expect(
+			parsePseudoTagToolInvocations("<NOTES_CREATE>[1,2]</NOTES_CREATE>"),
+		).toEqual([]);
+	});
+});
+
+describe("containsToolCallShapedMarkup", () => {
+	it("detects native markup, pseudo-tags, and truncated-open forms", () => {
+		expect(
+			containsToolCallShapedMarkup(
+				"<tool_call>WEB_FETCH<arg_key>url</arg_key>",
+			),
+		).toBe(true);
+		expect(
+			containsToolCallShapedMarkup(
+				'saving note. <NOTES_CREATE>{"t":1}</NOTES_CREATE>',
+			),
+		).toBe(true);
+		expect(containsToolCallShapedMarkup("<BROWSE_PAGE><url>x</url>")).toBe(
+			true,
+		);
+	});
+
+	it("leaves ordinary prose and short quoted acronyms alone", () => {
+		expect(
+			containsToolCallShapedMarkup("the <AI> label means artificial"),
+		).toBe(false);
+		expect(containsToolCallShapedMarkup("plain answer, 35°C in paris")).toBe(
+			false,
+		);
 	});
 });

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -30,7 +30,11 @@ import {
 	normalizePromptSegments,
 	renderContextObject,
 } from "./context-renderer";
-import { extractJsonObjects, parseJsonObject } from "./json-output";
+import {
+	containsToolCallShapedMarkup,
+	extractJsonObjects,
+	parseJsonObject,
+} from "./json-output";
 import { DEFAULT_MAX_KEPT_STEP_CHARS } from "./limits";
 import {
 	buildModelInputBudget,
@@ -1158,11 +1162,19 @@ function looksLikeUserFacingAnswer(text: string): boolean {
 		return false;
 	}
 	// Native model tool syntax is machine output, never a user-facing answer.
-	// Two dialects need their own screens because neither carries the JSON keys
+	// Three dialects need their own screens because none carries the JSON keys
 	// the guard above matches: XML-style tool markup (<tool_call>/<arg_key>),
-	// and a bare ALL_CAPS action name followed by a JSON args object
-	// ("GET_WEATHER\n{\"location\":\"Tokyo\"}").
-	if (/<\/?(?:tool_call|function_call|arg_key|arg_value)\b/i.test(text)) {
+	// invented `<UPPER_SNAKE>` pseudo-tags, and a bare ALL_CAPS action name
+	// followed by a JSON args object ("GET_WEATHER\n{\"location\":\"Tokyo\"}").
+	// The pseudo-tag screen must run HERE, on the raw text: downstream reply
+	// sanitizers strip the markup, so accepting markup-bearing prose ships the
+	// surviving text as a fabricated effect claim — live matrix F38
+	// (tj-9129a432454364): "temp is 35°C. saving note." delivered while the
+	// `<NOTES_CREATE>{…}</NOTES_CREATE>` beside it was never executed, and the
+	// next turn grounded on the false claim. Declining recovery keeps the turn
+	// on the protocol-failure CONTINUE path, which replans through the real
+	// tool dispatch instead.
+	if (containsToolCallShapedMarkup(text)) {
 		return false;
 	}
 	if (/^\s*[A-Z][A-Z0-9_]{2,}\s*\n\s*\{/.test(text)) {

--- a/packages/core/src/runtime/json-output.ts
+++ b/packages/core/src/runtime/json-output.ts
@@ -251,6 +251,75 @@ export function stringifyForDiagnostics(value: unknown): string {
 }
 
 /**
+ * Tag-name shape of an invented pseudo-tool tag: `_`-bearing OR ≥4 uppercase
+ * chars, case-sensitive, so quoted real acronyms (`<AI>`) stay prose. Single
+ * source of truth shared by the reply stripper below, the planner's embedded
+ * tool-call recovery, and the evaluator's user-facing-answer screen — the
+ * three must agree on what counts as tool markup, or text screened by one is
+ * silently laundered by another (matrix F38, tj-9129a432454364).
+ */
+export const PSEUDO_TOOL_TAG_NAME_SRC =
+	"[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+|[A-Z][A-Z0-9]{3,}";
+
+const PSEUDO_TOOL_TAG_BLOCK_RE = new RegExp(
+	`<(${PSEUDO_TOOL_TAG_NAME_SRC})>[\\s\\S]*?</\\1>`,
+	"g",
+);
+const PSEUDO_TOOL_TAG_OPEN_TAIL_RE = new RegExp(
+	`<(?:${PSEUDO_TOOL_TAG_NAME_SRC})>[\\s\\S]*$`,
+	"g",
+);
+
+/**
+ * Detects tool-call-shaped markup a model emitted as reply text instead of a
+ * structured call: the native `<tool_call>` serialization or an invented
+ * `<UPPER_SNAKE>` pseudo-tag. Text matching this is a tool INTENT, never a
+ * user-facing answer — deliverers must either recover and dispatch the call
+ * or decline the text entirely; stripping the markup and shipping the
+ * surviving prose fabricates an effect claim ("saving note." with no note).
+ */
+export function containsToolCallShapedMarkup(text: string): boolean {
+	return (
+		/<\/?(?:tool_call|function_call|arg_key|arg_value)\b/i.test(text) ||
+		new RegExp(`<(?:${PSEUDO_TOOL_TAG_NAME_SRC})>`).test(text)
+	);
+}
+
+/**
+ * Recover the tool invocations a weak model serialized as
+ * `<ACTION_NAME>{json args}</ACTION_NAME>` pseudo-tags (live:
+ * `<NOTES_CREATE>{"title":…}</NOTES_CREATE>` beside "saving note." prose,
+ * tj-9129a432454364 stage 7 — stripped and never executed). Deliberately
+ * conservative: only `_`-bearing tag names with a parseable JSON-object body
+ * qualify, so an all-caps tag quoted in prose or wrapping non-JSON text never
+ * fabricates a call.
+ */
+export function parsePseudoTagToolInvocations(
+	text: string | undefined,
+): Array<{ name: string; params: Record<string, unknown> }> {
+	if (!text?.includes("<")) return [];
+	const calls: Array<{ name: string; params: Record<string, unknown> }> = [];
+	const blockRe =
+		/<([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)>\s*(\{[\s\S]*?\})\s*<\/\1>/g;
+	for (const match of text.matchAll(blockRe)) {
+		try {
+			const parsed: unknown = JSON.parse(match[2]);
+			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+				calls.push({
+					name: match[1],
+					params: parsed as Record<string, unknown>,
+				});
+			}
+		} catch {
+			// error-policy:J3 a non-JSON body is not a recoverable invocation; the
+			// reply stripper still removes the markup and the evaluator screen
+			// still declines the text, so nothing is fabricated either way.
+		}
+	}
+	return calls;
+}
+
+/**
  * Clean a model-produced reply field before it reaches the user. Removes
  * structural junk that weak models emit as plain text but which is never
  * user-facing content:
@@ -288,11 +357,8 @@ export function stripJsonStructuralJunkReply(value: string): string {
 		// never legitimate reply prose, so strip the paired block and any
 		// truncated-open tail. Case-SENSITIVE + `_`-bearing OR ≥4-char to avoid
 		// touching real acronyms a user might quote (`<AI>` stays).
-		.replace(
-			/<([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+|[A-Z][A-Z0-9]{3,})>[\s\S]*?<\/\1>/g,
-			"",
-		)
-		.replace(/<([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+|[A-Z][A-Z0-9]{3,})>[\s\S]*$/g, "")
+		.replace(PSEUDO_TOOL_TAG_BLOCK_RE, "")
+		.replace(PSEUDO_TOOL_TAG_OPEN_TAIL_RE, "")
 		.trim();
 	if (!cleaned) return "";
 	return /^[\s{}[\]":,]+$/.test(cleaned) ? "" : cleaned;

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -69,6 +69,7 @@ import { runEvaluator } from "./evaluator";
 import {
 	extractJsonObjects,
 	parseJsonObject,
+	parsePseudoTagToolInvocations,
 	stringifyForModel,
 	stripJsonStructuralJunkReply,
 } from "./json-output";
@@ -3310,11 +3311,27 @@ function parseNativeMarkupToolCalls(
 
 /**
  * Recover tool calls a weak model emitted as text — JSON objects first, then
- * the native `<tool_call>` markup — when no structured call was parsed.
+ * the native `<tool_call>` markup, then `<ACTION_NAME>{json}</ACTION_NAME>`
+ * pseudo-tags — when no structured call was parsed. The pseudo-tag dialect
+ * puts the action name in the TAG and only the args in the JSON body, so
+ * neither earlier parser can see it (matrix F38, tj-9129a432454364: a
+ * `<NOTES_CREATE>{…}</NOTES_CREATE>` was stripped from the reply and never
+ * executed).
  */
 function recoverEmbeddedToolCalls(text: string): PlannerToolCall[] {
 	const fromJson = parseEmbeddedToolCalls(text);
-	return fromJson.length > 0 ? fromJson : parseNativeMarkupToolCalls(text);
+	if (fromJson.length > 0) return fromJson;
+	const fromNativeMarkup = parseNativeMarkupToolCalls(text);
+	if (fromNativeMarkup.length > 0) return fromNativeMarkup;
+	const calls: PlannerToolCall[] = [];
+	for (const invocation of parsePseudoTagToolInvocations(text)) {
+		const call = normalizeToolCall({
+			action: invocation.name,
+			parameters: invocation.params,
+		});
+		if (call) calls.push(call);
+	}
+	return calls;
 }
 
 /**


### PR DESCRIPTION
## Problem — matrix F38, live receipt tj-9129a432454364

"check paris weather and save a note" → WEB_SEARCH ran, then GLM emitted the NOTES_CREATE as inline pseudo-tag markup in its evaluator output:

- **Stage 4** (broken `<tool_call>NOTES_CREATE<arg_key>…` variant): correctly rejected — protocolFailure → CONTINUE. ✅ existing behavior
- **Stage 7** (`<NOTES_CREATE>\n{json}\n</NOTES_CREATE>` pseudo-tag variant): the prose-recovery arm (`prose_after_successful_tool`) accepted the text — its dialect screens cover `<tool_call>`/`<arg_key>` and bare ALL_CAPS+JSON but NOT pseudo-tags — then `stripJsonStructuralJunkReply` removed the markup downstream and shipped **"temp is 35°C. saving note."** The note was never created; the next summarize turn doubled down on the false claim.

The strip is what launders the hallucinated call into a confident lie: every screen ran on already-stripped text or never knew the dialect.

## Fix — one shared dialect definition, two legs

**`json-output.ts`** now owns the pseudo-tag dialect: `PSEUDO_TOOL_TAG_NAME_SRC` (single source — the stripper's inline regexes now derive from it), `containsToolCallShapedMarkup` (shared detector: native markup + pseudo-tags), and `parsePseudoTagToolInvocations` (conservative recovery: underscore-bearing tag + parseable JSON-object body only, so `<AI>` quotes and `<HTML>` prose never fabricate a call).

**`evaluator.ts`** — `looksLikeUserFacingAnswer` screens the RAW text with the shared detector before any prose recovery. Markup-bearing text declines recovery → the turn stays on the protocol-failure CONTINUE path that replans through real tool dispatch (exactly what stage 4 did, honestly).

**`planner-loop.ts`** — `recoverEmbeddedToolCalls` gains the pseudo-tag variant as a third fallback (after embedded-JSON and native `<tool_call>` recovery), so the same dialect leaked on the planner path dispatches the intended call instead of dropping it.

## Evidence

| Check | Result |
|---|---|
| new F38 tests: exact stage-7 shape → CONTINUE + empty messageToUser; `<AI>` acronym prose still recovers; recovery parser (live shape, multi-call, non-JSON body, underscore-less tag, array body) | ✅ |
| `json-output.test.ts` + `evaluator.test.ts` | 69/69 ✅ |
| full `src/runtime` sweep | 1368/1370 — the 2 failures are pre-existing develop-red in `facts-and-relationships.test.ts` (#20053's new tests merged after #20109's `{subject,fact}` shape change without rebase-adjusting; untouched by this PR, follow-up PR incoming) |
| `packages/core` typecheck + build:node | ✅ |
| Biome | ✅ |

Live re-prove (battery re-run of the F38 scenario) rides the next box resync — the fix is deterministic-screen-shaped, and the stage-4 CONTINUE path it routes to is already proven in this same trajectory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)