### PR TITLE
fix(ios): report Screen Time capabilities truthfully

### DIFF
--- a/packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj
+++ b/packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj
@@ -31,6 +31,10 @@
 		DAMON000100000000000002 /* DeviceActivityMonitorExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = DAMON000100000000000101 /* DeviceActivityMonitorExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		DAREP000100000000000001 /* DeviceActivityReportExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAREP000100000000000102 /* DeviceActivityReportExtension.swift */; };
 		DAREP000100000000000002 /* DeviceActivityReportExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = DAREP000100000000000101 /* DeviceActivityReportExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		DAREP000100000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DAREP000100000000000105 /* Localizable.xcstrings */; };
+		DAREP000100000000000004 /* ScreenTimeReportModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAREP000100000000000106 /* ScreenTimeReportModel.swift */; };
+		AUIT00010000000000000011 /* ScreenTimeReportModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAREP000100000000000106 /* ScreenTimeReportModel.swift */; };
+		AUIT00010000000000000013 /* ScreenTimeReportModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUIT00010000000000000012 /* ScreenTimeReportModelTests.swift */; };
 		EWDG00010000000000000001 /* ElizaWidgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = EWDG00010000000000000102 /* ElizaWidgets.swift */; };
 		EWDG00010000000000000002 /* ElizaWidgets.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = EWDG00010000000000000101 /* ElizaWidgets.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		EWDG00010000000000000003 /* ElizaWidgetControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = EWDG00010000000000000105 /* ElizaWidgetControls.swift */; };
@@ -154,6 +158,9 @@
 		DAREP000100000000000102 /* DeviceActivityReportExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceActivityReportExtension.swift; sourceTree = "<group>"; };
 		DAREP000100000000000103 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DAREP000100000000000104 /* DeviceActivityReportExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DeviceActivityReportExtension.entitlements; sourceTree = "<group>"; };
+		DAREP000100000000000105 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		DAREP000100000000000106 /* ScreenTimeReportModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenTimeReportModel.swift; sourceTree = "<group>"; };
+		AUIT00010000000000000012 /* ScreenTimeReportModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenTimeReportModelTests.swift; sourceTree = "<group>"; };
 		EWDG00010000000000000101 /* ElizaWidgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ElizaWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		EWDG00010000000000000102 /* ElizaWidgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElizaWidgets.swift; sourceTree = "<group>"; };
 		EWDG00010000000000000103 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -342,6 +349,8 @@
 				DAREP000100000000000102 /* DeviceActivityReportExtension.swift */,
 				DAREP000100000000000103 /* Info.plist */,
 				DAREP000100000000000104 /* DeviceActivityReportExtension.entitlements */,
+				DAREP000100000000000105 /* Localizable.xcstrings */,
+				DAREP000100000000000106 /* ScreenTimeReportModel.swift */,
 			);
 			path = DeviceActivityReportExtension;
 			sourceTree = "<group>";
@@ -382,6 +391,7 @@
 				AUIT0001000000000000000C /* DeviceLifecycleUITests.swift */,
 				AUIT0001000000000000000E /* ChatFailureStrings.generated.swift */,
 				AUIT00010000000000000010 /* DeviceExtensionSurfaceUITests.swift */,
+				AUIT00010000000000000012 /* ScreenTimeReportModelTests.swift */,
 			);
 			path = AppUITests;
 			sourceTree = "<group>";
@@ -619,6 +629,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DAREP000100000000000003 /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -743,6 +754,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DAREP000100000000000001 /* DeviceActivityReportExtension.swift in Sources */,
+				DAREP000100000000000004 /* ScreenTimeReportModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -758,6 +770,8 @@
 				AUIT0001000000000000000B /* DeviceLifecycleUITests.swift in Sources */,
 				AUIT0001000000000000000D /* ChatFailureStrings.generated.swift in Sources */,
 				AUIT0001000000000000000F /* DeviceExtensionSurfaceUITests.swift in Sources */,
+				AUIT00010000000000000011 /* ScreenTimeReportModel.swift in Sources */,
+				AUIT00010000000000000013 /* ScreenTimeReportModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/app-core/platforms/ios/App/App/DeviceActivityReportExtension/DeviceActivityReportExtension.swift
+++ b/packages/app-core/platforms/ios/App/App/DeviceActivityReportExtension/DeviceActivityReportExtension.swift
@@ -1,4 +1,9 @@
+/**
+ * Renders authorized Screen Time activity entirely inside Apple's report
+ * extension sandbox. No activity values cross into the host app or network.
+ */
 import DeviceActivity
+import Foundation
 import SwiftUI
 
 @main
@@ -12,8 +17,8 @@ struct ElizaDeviceActivityReportExtension: DeviceActivityReportExtension {
 }
 
 private struct ElizaDeviceActivityReportConfiguration {
-    let title: String
-    let message: String
+    let totalDuration: TimeInterval
+    let categories: [ScreenTimeCategoryDuration]
 }
 
 @available(iOS 16.0, *)
@@ -24,26 +29,88 @@ private struct ElizaDeviceActivityReportScene: DeviceActivityReportScene {
     func makeConfiguration(
         representing data: DeviceActivityResults<DeviceActivityData>
     ) async -> ElizaDeviceActivityReportConfiguration {
-        _ = data
+        var totalDuration: TimeInterval = 0
+        var durationsByCategory: [String: TimeInterval] = [:]
+
+        for await deviceActivity in data {
+            for await segment in deviceActivity.activitySegments {
+                totalDuration += segment.totalActivityDuration
+                for await categoryActivity in segment.categories {
+                    guard categoryActivity.totalActivityDuration > 0 else { continue }
+                    let name = categoryActivity.category.localizedDisplayName?
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    let displayName = name.flatMap { $0.isEmpty ? nil : $0 }
+                        ?? String(localized: "Other")
+                    durationsByCategory[displayName, default: 0] +=
+                        categoryActivity.totalActivityDuration
+                }
+            }
+        }
+
         return ElizaDeviceActivityReportConfiguration(
-            title: "Screen Time",
-            message: "Screen Time activity is available for this report."
+            totalDuration: totalDuration,
+            categories: ScreenTimeReportModel.topCategories(from: durationsByCategory)
         )
     }
 }
 
+@available(iOS 16.0, *)
 private struct ElizaDeviceActivityReportView: View {
     let configuration: ElizaDeviceActivityReportConfiguration
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(configuration.title)
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Screen Time")
                 .font(.headline)
-            Text(configuration.message)
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
+                .accessibilityAddTraits(.isHeader)
+
+            if configuration.totalDuration > 0 {
+                Text(Self.format(configuration.totalDuration))
+                    .font(.title2.weight(.semibold))
+                    .accessibilityLabel(
+                        String(
+                            format: String(localized: "Total activity: %@"),
+                            Self.format(configuration.totalDuration)
+                        )
+                    )
+
+                if !configuration.categories.isEmpty {
+                    Text("Top categories")
+                        .font(.subheadline.weight(.semibold))
+                        .accessibilityAddTraits(.isHeader)
+                    ForEach(configuration.categories) { category in
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Text(category.name)
+                                    .lineLimit(1)
+                                Spacer()
+                                Text(Self.format(category.duration))
+                                    .foregroundStyle(.secondary)
+                            }
+                            ProgressView(
+                                value: category.duration,
+                                total: max(configuration.totalDuration, 1)
+                            )
+                            .tint(.orange)
+                        }
+                        .accessibilityElement(children: .combine)
+                    }
+                }
+            } else {
+                Text("No Screen Time activity is available for this period.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
         }
         .padding()
+    }
+
+    private static func format(_ duration: TimeInterval) -> String {
+        ScreenTimeReportModel.formatDuration(
+            duration,
+            locale: .current,
+            lessThanMinute: String(localized: "Less than a minute")
+        )
     }
 }
 

--- a/packages/app-core/platforms/ios/App/App/DeviceActivityReportExtension/Localizable.xcstrings
+++ b/packages/app-core/platforms/ios/App/App/DeviceActivityReportExtension/Localizable.xcstrings
@@ -1,0 +1,12 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "Less than a minute" : { "localizations" : { "es" : { "stringUnit" : { "state" : "translated", "value" : "Menos de un minuto" } } } },
+    "No Screen Time activity is available for this period." : { "localizations" : { "es" : { "stringUnit" : { "state" : "translated", "value" : "No hay actividad de Tiempo de uso disponible para este periodo." } } } },
+    "Other" : { "localizations" : { "es" : { "stringUnit" : { "state" : "translated", "value" : "Otros" } } } },
+    "Screen Time" : { "localizations" : { "es" : { "stringUnit" : { "state" : "translated", "value" : "Tiempo de uso" } } } },
+    "Top categories" : { "localizations" : { "es" : { "stringUnit" : { "state" : "translated", "value" : "Categorías principales" } } } },
+    "Total activity: %@" : { "localizations" : { "es" : { "stringUnit" : { "state" : "translated", "value" : "Actividad total: %@" } } } }
+  },
+  "version" : "1.0"
+}

--- a/packages/app-core/platforms/ios/App/App/DeviceActivityReportExtension/ScreenTimeReportModel.swift
+++ b/packages/app-core/platforms/ios/App/App/DeviceActivityReportExtension/ScreenTimeReportModel.swift
@@ -1,0 +1,47 @@
+/**
+ * Reduces and formats private Screen Time aggregates without depending on
+ * DeviceActivity, so the report behavior can be executed in native tests.
+ */
+import Foundation
+
+struct ScreenTimeCategoryDuration: Equatable, Identifiable {
+    let name: String
+    let duration: TimeInterval
+
+    var id: String { name }
+}
+
+enum ScreenTimeReportModel {
+    static func topCategories(
+        from durationsByCategory: [String: TimeInterval],
+        limit: Int = 5
+    ) -> [ScreenTimeCategoryDuration] {
+        durationsByCategory
+            .filter { $0.value > 0 }
+            .map { ScreenTimeCategoryDuration(name: $0.key, duration: $0.value) }
+            .sorted {
+                if $0.duration != $1.duration { return $0.duration > $1.duration }
+                return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+            }
+            .prefix(max(limit, 0))
+            .map { $0 }
+    }
+
+    static func formatDuration(
+        _ duration: TimeInterval,
+        locale: Locale,
+        lessThanMinute: String
+    ) -> String {
+        guard duration >= 60 else { return lessThanMinute }
+
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = duration >= 3_600 ? [.hour, .minute] : [.minute]
+        formatter.unitsStyle = .abbreviated
+        formatter.maximumUnitCount = 2
+        formatter.zeroFormattingBehavior = .dropAll
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.locale = locale
+        formatter.calendar = calendar
+        return formatter.string(from: duration) ?? lessThanMinute
+    }
+}

--- a/packages/app-core/platforms/ios/App/AppUITests/ScreenTimeReportModelTests.swift
+++ b/packages/app-core/platforms/ios/App/AppUITests/ScreenTimeReportModelTests.swift
@@ -1,0 +1,40 @@
+/**
+ * Executes the private Screen Time report reducer and formatter without
+ * requesting Family Controls authorization or exporting activity data.
+ */
+import XCTest
+
+final class ScreenTimeReportModelTests: XCTestCase {
+    func testSubMinuteDurationIsNotRoundedUp() {
+        XCTAssertEqual(
+            ScreenTimeReportModel.formatDuration(
+                59,
+                locale: Locale(identifier: "en_US"),
+                lessThanMinute: "Less than a minute"
+            ),
+            "Less than a minute"
+        )
+        let oneMinute = ScreenTimeReportModel.formatDuration(
+            60,
+            locale: Locale(identifier: "en_US"),
+            lessThanMinute: "Less than a minute"
+        )
+        XCTAssertNotEqual(oneMinute, "Less than a minute")
+        XCTAssertTrue(oneMinute.contains("1"))
+    }
+
+    func testTopCategoriesArePositiveOrderedAndBounded() {
+        let result = ScreenTimeReportModel.topCategories(from: [
+            "Work": 300,
+            "Social": 180,
+            "Audio": 180,
+            "Travel": 60,
+            "Reading": 30,
+            "Games": 10,
+            "Ignored": 0,
+        ])
+
+        XCTAssertEqual(result.map(\.name), ["Work", "Audio", "Social", "Travel", "Reading"])
+        XCTAssertEqual(result.map(\.duration), [300, 180, 180, 60, 30])
+    }
+}

--- a/packages/app/test/ios-app-intents-registration.test.ts
+++ b/packages/app/test/ios-app-intents-registration.test.ts
@@ -46,6 +46,13 @@ const liveActivityBridgeSwift = readFileSync(
   path.join(iosAppRoot, "App/ElizaLiveActivityBridge.swift"),
   "utf8",
 );
+const screenTimeReportSwift = readFileSync(
+  path.join(
+    iosAppRoot,
+    "App/DeviceActivityReportExtension/DeviceActivityReportExtension.swift",
+  ),
+  "utf8",
+);
 interface StringCatalogEntry {
   localizations?: Record<
     string,
@@ -63,6 +70,15 @@ interface StringCatalog {
 
 const localizableCatalog = JSON.parse(
   readFileSync(path.join(iosAppRoot, "App/Localizable.xcstrings"), "utf8"),
+) as StringCatalog;
+const screenTimeReportCatalog = JSON.parse(
+  readFileSync(
+    path.join(
+      iosAppRoot,
+      "App/DeviceActivityReportExtension/Localizable.xcstrings",
+    ),
+    "utf8",
+  ),
 ) as StringCatalog;
 function parseAppleStrings(source: string): Map<string, string> {
   return new Map(
@@ -363,6 +379,74 @@ describe("native assistant entry contracts", () => {
         new RegExp(`isa = PBXBuildFile; fileRef = ${shortcutsFileRef} `, "g"),
       )?.length,
     ).toBe(1);
+
+    const screenTimeReportModelFileRef = "DAREP000100000000000106";
+    expect(
+      pbxproj.match(
+        new RegExp(
+          `isa = PBXBuildFile; fileRef = ${screenTimeReportModelFileRef} `,
+          "g",
+        ),
+      )?.length,
+    ).toBe(2);
+    expect(pbxproj).toContain("ScreenTimeReportModelTests.swift in Sources");
+
+    const screenTimeCatalogFileRef = "DAREP000100000000000105";
+    expect(pbxproj).toContain(
+      `${screenTimeCatalogFileRef} /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };`,
+    );
+    expect(
+      pbxproj.match(
+        new RegExp(
+          `isa = PBXBuildFile; fileRef = ${screenTimeCatalogFileRef} `,
+          "g",
+        ),
+      )?.length,
+    ).toBe(1);
+  });
+
+  it("renders localized Screen Time results only inside the report extension", () => {
+    expect(screenTimeReportSwift).toContain("for await deviceActivity in data");
+    expect(screenTimeReportSwift).toContain(
+      "for await segment in deviceActivity.activitySegments",
+    );
+    expect(screenTimeReportSwift).toContain(
+      "for await categoryActivity in segment.categories",
+    );
+    expect(screenTimeReportSwift).not.toContain(
+      "Screen Time activity is available for this report.",
+    );
+    expect(screenTimeReportSwift).not.toMatch(
+      /UserDefaults|URLSession|appGroup|containerURL/,
+    );
+    expect(screenTimeReportSwift).toContain(
+      "ScreenTimeReportModel.topCategories(from: durationsByCategory)",
+    );
+    expect(screenTimeReportSwift).toContain(
+      "ScreenTimeReportModel.formatDuration(",
+    );
+    expect(
+      screenTimeReportSwift.match(/accessibilityAddTraits\(\.isHeader\)/g)
+        ?.length,
+    ).toBe(2);
+
+    const requiredKeys = [
+      "Screen Time",
+      "Top categories",
+      "Other",
+      "Less than a minute",
+      "No Screen Time activity is available for this period.",
+      "Total activity: %@",
+    ];
+    expect(screenTimeReportCatalog.sourceLanguage).toBe("en");
+    expect(Object.keys(screenTimeReportCatalog.strings).sort()).toEqual(
+      [...requiredKeys].sort(),
+    );
+    for (const key of requiredKeys) {
+      expect(
+        screenTimeReportCatalog.strings[key]?.localizations?.es?.stringUnit,
+      ).toEqual({ state: "translated", value: expect.any(String) });
+    }
   });
 
   it("builds the ElizaWidgets extension target with widget + controls sources", () => {

--- a/packages/ui/src/platform/mobile-permissions-client.test.ts
+++ b/packages/ui/src/platform/mobile-permissions-client.test.ts
@@ -177,6 +177,13 @@ describe("createMobileSignalsPermissionsRegistry", () => {
             status: "not-determined",
             canRequest: false,
           },
+          android: {
+            usageAccessGranted: false,
+            packageUsageStatsPermissionDeclared: true,
+            canOpenUsageAccessSettings: true,
+            foregroundEventsAvailable: false,
+            totalTimeForegroundMs: null,
+          },
           reason: "Enable Usage Access in Android Settings.",
         },
       }),
@@ -189,6 +196,74 @@ describe("createMobileSignalsPermissionsRegistry", () => {
     });
 
     expect(native.openSettings).toHaveBeenCalled();
+    expect(native.requestPermissions).not.toHaveBeenCalled();
+  });
+
+  it("does not report unavailable iOS Screen Time as granted", async () => {
+    const native = plugin(
+      permissions({
+        screenTime: {
+          ...permissions().screenTime,
+          authorization: {
+            status: "approved",
+            canRequest: false,
+          },
+          provisioning: {
+            satisfied: false,
+            inspected: "not-inspectable",
+            reason:
+              "iOS entitlement inspection is handled by build validation and provisioning profile checks.",
+          },
+          reason: null,
+        },
+      }),
+    );
+    const registry = createMobileSignalsPermissionsRegistry(native);
+
+    await expect(registry.check("screentime")).resolves.toMatchObject({
+      id: "screentime",
+      status: "restricted",
+      canRequest: false,
+      restrictedReason: "os_policy",
+    });
+  });
+
+  it("does not open settings for unavailable iOS Screen Time", async () => {
+    const native = plugin(
+      permissions({
+        screenTime: {
+          ...permissions().screenTime,
+          authorization: {
+            status: "approved",
+            canRequest: false,
+          },
+          reason: null,
+        },
+        setupActions: [
+          {
+            id: "screen_time_authorization",
+            label: "Screen Time",
+            status: "unavailable",
+            canRequest: false,
+            canOpenSettings: false,
+            settingsTarget: "screenTime",
+            reason: null,
+          },
+        ],
+      }),
+    );
+    const registry = createMobileSignalsPermissionsRegistry(native);
+
+    const state = await registry.request("screentime", {
+      reason: "Read usage summaries.",
+      feature: { app: "lifeops", action: "usage.read" },
+    });
+
+    expect(state).toMatchObject({
+      status: "restricted",
+      canRequest: false,
+    });
+    expect(native.openSettings).not.toHaveBeenCalled();
     expect(native.requestPermissions).not.toHaveBeenCalled();
   });
 

--- a/packages/ui/src/platform/mobile-permissions-client.ts
+++ b/packages/ui/src/platform/mobile-permissions-client.ts
@@ -326,6 +326,24 @@ function stateFromScreenTime(
     "android_usage_access",
   ]);
   const authorizationStatus = screenTime.authorization.status;
+  const hasUsableCapability =
+    screenTime.reportAvailable ||
+    screenTime.coarseSummaryAvailable ||
+    screenTime.thresholdEventsAvailable;
+
+  if (!screenTime.android && !hasUsableCapability) {
+    return defaultMobileState(
+      "screentime",
+      screenTime.supported ? "restricted" : "not-applicable",
+      {
+        canRequest: false,
+        restrictedReason: screenTime.supported
+          ? "os_policy"
+          : "platform_unsupported",
+        reason: screenTime.reason ?? action?.reason ?? undefined,
+      },
+    );
+  }
 
   if (authorizationStatus === "approved") {
     return defaultMobileState("screentime", "granted", {
@@ -860,8 +878,14 @@ export function createMobileSignalsPermissionsRegistry(
           typeof plugin.requestPermissions === "function"
         ) {
           await plugin.requestPermissions({ target: "screenTime" });
-        } else {
+        } else if (
+          current.status === "denied" ||
+          current.status === "not-determined" ||
+          current.status === "limited"
+        ) {
           await openMobilePermissionSettings(id, plugin);
+        } else {
+          requestedState = current;
         }
       } else if (
         id === "usage-access" ||

--- a/plugins/plugin-native-mobile-signals/AGENTS.md
+++ b/plugins/plugin-native-mobile-signals/AGENTS.md
@@ -86,10 +86,20 @@ Screen Time / DeviceActivity features require additional entitlements and Xcode 
 
 1. `App.entitlements` contains `com.apple.developer.family-controls`.
 2. Xcode project sets `CODE_SIGN_ENTITLEMENTS = App/App.entitlements`.
-3. `DeviceActivityMonitorExtension` and `DeviceActivityReportExtension` app-extension targets exist and are embedded.
-4. `ElizaosCapacitorMobileSignals.podspec` links `FamilyControls` and `DeviceActivity` frameworks.
+3. Both DeviceActivity extensions have the Family Controls entitlement and their targets select the matching entitlement files.
+4. `DeviceActivityMonitorExtension` and `DeviceActivityReportExtension` app-extension targets exist and are embedded.
+5. `ElizaosCapacitorMobileSignals.podspec` links `FamilyControls` and `DeviceActivity` frameworks.
 
 Without these, `screenTime.supported` will be `false` and `screenTime.authorization.status` will be `"unavailable"`.
+
+Apple provides DeviceActivity results only inside the sandboxed report
+extension. The extension contains a real private aggregate, but the current
+host has no `DeviceActivityReport` presenter, so `reportAvailable` remains
+`false`. It may become true only when the host presents the matching report
+context. `coarseSummaryAvailable`, `thresholdEventsAvailable`, and
+`rawUsageExportAvailable` must remain `false` until a lawful host producer or a
+concrete scheduled threshold-event signal exists. Never move report data
+through app groups or the network.
 
 ## Android requirements
 
@@ -115,6 +125,7 @@ Extend `MobileSignalsSnapshot` or `MobileSignalsHealthSnapshot` in `src/definiti
 - **Instrumented test (issue #9967).** The `PACKAGE_USAGE_STATS` reads (AppOps `GET_USAGE_STATS` check + `UsageStatsManager.queryUsageStats`) live in `UsageStatsReader`; the plugin delegates to it (single source) so an on-device `androidTest` can drive the real provider. The permission is special-access, so the harness grants it host-side (`appops set <pkg> android:get_usage_stats allow`) and the usage tests `Assume`-skip when absent — verified positive on an API-34 emulator (real foreground-usage history).
 - This is a **Capacitor plugin**, not an elizaOS action/provider/service plugin. There is no `Plugin` object registered with `AgentRuntime`. It is consumed by a Capacitor-enabled mobile/web app.
 - The web fallback (`src/web.ts`) always returns `status: "not-applicable"` for `checkPermissions` and `false` for health capabilities. Do not add health data to the web path.
+- `reportAvailable` requires a bundled authorized extension and a real host presenter. Current iOS report, summary, and threshold-event flags are false.
 - `rawUsageExportAvailable` is permanently `false` in `MobileSignalsScreenTimeStatus` — this is intentional (Apple does not expose raw usage export).
 - On iOS, Screen Time features require Apple's restricted `com.apple.developer.family-controls` entitlement, which must be provisioned by Apple. The `validate:ios-screen-time` script is the canonical check.
 - `dist/` is committed for publishing but should be regenerated via `build` before any release.

--- a/plugins/plugin-native-mobile-signals/CLAUDE.md
+++ b/plugins/plugin-native-mobile-signals/CLAUDE.md
@@ -86,10 +86,20 @@ Screen Time / DeviceActivity features require additional entitlements and Xcode 
 
 1. `App.entitlements` contains `com.apple.developer.family-controls`.
 2. Xcode project sets `CODE_SIGN_ENTITLEMENTS = App/App.entitlements`.
-3. `DeviceActivityMonitorExtension` and `DeviceActivityReportExtension` app-extension targets exist and are embedded.
-4. `ElizaosCapacitorMobileSignals.podspec` links `FamilyControls` and `DeviceActivity` frameworks.
+3. Both DeviceActivity extensions have the Family Controls entitlement and their targets select the matching entitlement files.
+4. `DeviceActivityMonitorExtension` and `DeviceActivityReportExtension` app-extension targets exist and are embedded.
+5. `ElizaosCapacitorMobileSignals.podspec` links `FamilyControls` and `DeviceActivity` frameworks.
 
 Without these, `screenTime.supported` will be `false` and `screenTime.authorization.status` will be `"unavailable"`.
+
+Apple provides DeviceActivity results only inside the sandboxed report
+extension. The extension contains a real private aggregate, but the current
+host has no `DeviceActivityReport` presenter, so `reportAvailable` remains
+`false`. It may become true only when the host presents the matching report
+context. `coarseSummaryAvailable`, `thresholdEventsAvailable`, and
+`rawUsageExportAvailable` must remain `false` until a lawful host producer or a
+concrete scheduled threshold-event signal exists. Never move report data
+through app groups or the network.
 
 ## Android requirements
 
@@ -115,6 +125,7 @@ Extend `MobileSignalsSnapshot` or `MobileSignalsHealthSnapshot` in `src/definiti
 - **Instrumented test (issue #9967).** The `PACKAGE_USAGE_STATS` reads (AppOps `GET_USAGE_STATS` check + `UsageStatsManager.queryUsageStats`) live in `UsageStatsReader`; the plugin delegates to it (single source) so an on-device `androidTest` can drive the real provider. The permission is special-access, so the harness grants it host-side (`appops set <pkg> android:get_usage_stats allow`) and the usage tests `Assume`-skip when absent — verified positive on an API-34 emulator (real foreground-usage history).
 - This is a **Capacitor plugin**, not an elizaOS action/provider/service plugin. There is no `Plugin` object registered with `AgentRuntime`. It is consumed by a Capacitor-enabled mobile/web app.
 - The web fallback (`src/web.ts`) always returns `status: "not-applicable"` for `checkPermissions` and `false` for health capabilities. Do not add health data to the web path.
+- `reportAvailable` requires a bundled authorized extension and a real host presenter. Current iOS report, summary, and threshold-event flags are false.
 - `rawUsageExportAvailable` is permanently `false` in `MobileSignalsScreenTimeStatus` — this is intentional (Apple does not expose raw usage export).
 - On iOS, Screen Time features require Apple's restricted `com.apple.developer.family-controls` entitlement, which must be provisioned by Apple. The `validate:ios-screen-time` script is the canonical check.
 - `dist/` is committed for publishing but should be regenerated via `build` before any release.

--- a/plugins/plugin-native-mobile-signals/README.md
+++ b/plugins/plugin-native-mobile-signals/README.md
@@ -19,7 +19,7 @@ In browser environments a web fallback is provided using `document.visibilitySta
 | Device state (active/idle/locked) | Yes | Yes | Partial (visibility/focus only) |
 | Battery on/off charging | Yes | Yes | Yes (Battery Status API) |
 | Sleep stage / biometrics | HealthKit | Health Connect | No |
-| Screen time / usage | DeviceActivity + FamilyControls | `PACKAGE_USAGE_STATS` | No |
+| Screen time / usage | Privacy-preserving in-extension DeviceActivity report | `PACKAGE_USAGE_STATS` | No |
 | Background refresh | Not available (foreground monitoring only) | Not available | No |
 
 ## Installation
@@ -83,6 +83,16 @@ Screen Time features additionally require:
 - `DeviceActivityMonitorExtension` and `DeviceActivityReportExtension` app-extension targets in the Xcode project.
 - The `FamilyControls` and `DeviceActivity` frameworks linked via the podspec.
 
+Apple supplies Screen Time usage only to the sandboxed report extension. The
+extension contains a private on-device summary, but the current host does not
+yet present `DeviceActivityReport`, and it cannot move those values into the
+Capacitor host, an app group, or a network request. Consequently the iOS status
+keeps `reportAvailable`, `coarseSummaryAvailable`, `thresholdEventsAvailable`,
+and `rawUsageExportAvailable` `false`. `reportAvailable` may become true only
+after the host presents the matching report context. Threshold availability
+must stay false until the app schedules a concrete `DeviceActivityEvent` and
+handles its callback through a typed signal path.
+
 Validate the iOS build wiring:
 
 ```bash
@@ -114,7 +124,6 @@ await MobileSignals.openSettings({ target: "usageAccess" });
 ## Platform notes
 
 - **Node (desktop):** No native integration. The web fallback applies.
-- **iOS:** Full support. Requires Xcode target with correct entitlements for screen time features.
+- **iOS:** Device state and HealthKit snapshots are supported. A private Screen Time report extension is bundled, but no host report presenter, host-readable usage export, or configured threshold event ships yet.
 - **Android:** Full support for device state and Health Connect. Usage stats require manual user grant via settings.
 - **Web:** Graceful fallback only. Health and screen-time capabilities are unavailable.
-

--- a/plugins/plugin-native-mobile-signals/ios/Sources/MobileSignalsHealthContract/ScreenTimeCapabilityPolicy.swift
+++ b/plugins/plugin-native-mobile-signals/ios/Sources/MobileSignalsHealthContract/ScreenTimeCapabilityPolicy.swift
@@ -1,0 +1,12 @@
+/**
+ * Defines which Screen Time capabilities the host may truthfully advertise.
+ * DeviceActivity report data remains inside Apple's report-extension sandbox;
+ * monitor events become available only after a concrete schedule is installed.
+ */
+public enum ScreenTimeCapabilityPolicy {
+    public static let authorizationRequestAvailable = false
+    public static let reportAvailable = false
+    public static let coarseSummaryAvailable = false
+    public static let thresholdEventsAvailable = false
+    public static let rawUsageExportAvailable = false
+}

--- a/plugins/plugin-native-mobile-signals/ios/Sources/MobileSignalsPlugin/MobileSignalsPlugin.swift
+++ b/plugins/plugin-native-mobile-signals/ios/Sources/MobileSignalsPlugin/MobileSignalsPlugin.swift
@@ -99,7 +99,9 @@ public class MobileSignalsPlugin: CAPPlugin, CAPBridgedPlugin {
     @objc public override func requestPermissions(_ call: CAPPluginCall) {
         let target = call.getString("target") ?? "all"
         if target == "screenTime" {
-            resolvePermissionAfterScreenTimeRequest(call)
+            buildPermissionResult { result in
+                call.resolve(result)
+            }
             return
         }
         if target == "notifications" {
@@ -107,15 +109,13 @@ public class MobileSignalsPlugin: CAPPlugin, CAPBridgedPlugin {
             return
         }
 
-        let shouldRequestScreenTime = target != "health"
         let types = requestedHealthTypes()
         guard !types.isEmpty else {
             resolvePermissionResult(
                 call,
                 status: "not-applicable",
                 canRequest: false,
-                reason: "HealthKit sleep and biometric types are unavailable on this device.",
-                requestScreenTime: shouldRequestScreenTime
+                reason: "HealthKit sleep and biometric types are unavailable on this device."
             )
             return
         }
@@ -131,8 +131,7 @@ public class MobileSignalsPlugin: CAPPlugin, CAPBridgedPlugin {
                 }
                 self.resolvePermissionResult(
                     call,
-                    reason: healthReason,
-                    requestScreenTime: shouldRequestScreenTime
+                    reason: healthReason
                 )
             }
         }
@@ -533,55 +532,18 @@ public class MobileSignalsPlugin: CAPPlugin, CAPBridgedPlugin {
     private func mobileSignalsCapabilities() -> [String: Any] {
         [
             "health": HKHealthStore.isHealthDataAvailable(),
-            "screenTime": true,
+            "screenTime": false,
             "notifications": true,
             "settings": true,
         ]
-    }
-
-    private func resolvePermissionAfterScreenTimeRequest(
-        _ call: CAPPluginCall,
-        status: String? = nil,
-        canRequest: Bool? = nil,
-        reason: String? = nil
-    ) {
-        ScreenTimeSupport.requestAuthorizationIfAvailable { [weak self] screenTimeReason in
-            guard let self = self else { return }
-            self.buildPermissionResult(
-                status: status,
-                canRequest: canRequest,
-                reason: reason
-            ) { result in
-                var next = result
-                if let screenTimeReason {
-                    if let existingReason = next["reason"] as? String, !existingReason.isEmpty {
-                        next["reason"] = "\(existingReason) \(screenTimeReason)"
-                    } else {
-                        next["reason"] = screenTimeReason
-                    }
-                }
-                call.resolve(next)
-            }
-        }
     }
 
     private func resolvePermissionResult(
         _ call: CAPPluginCall,
         status: String? = nil,
         canRequest: Bool? = nil,
-        reason: String? = nil,
-        requestScreenTime: Bool
+        reason: String? = nil
     ) {
-        if requestScreenTime {
-            resolvePermissionAfterScreenTimeRequest(
-                call,
-                status: status,
-                canRequest: canRequest,
-                reason: reason
-            )
-            return
-        }
-
         buildPermissionResult(
             status: status,
             canRequest: canRequest,
@@ -598,11 +560,6 @@ public class MobileSignalsPlugin: CAPPlugin, CAPBridgedPlugin {
         notification: NotificationPermissionCapture
     ) -> [[String: Any]] {
         let healthReady = healthStatus == "granted"
-        let authorization = screenTimeStatus["authorization"] as? [String: Any] ?? [:]
-        let screenTimeAuthStatus = authorization["status"] as? String ?? "unavailable"
-        let screenTimeCanRequest = authorization["canRequest"] as? Bool ?? false
-        let screenTimeSupported = screenTimeStatus["supported"] as? Bool ?? false
-        let screenTimeReady = screenTimeAuthStatus == "approved"
         let screenTimeReason = screenTimeStatus["reason"] ?? NSNull()
         let notificationsReady = notification.status == "granted"
 
@@ -623,13 +580,11 @@ public class MobileSignalsPlugin: CAPPlugin, CAPBridgedPlugin {
             [
                 "id": "screen_time_authorization",
                 "label": "Screen Time",
-                "status": screenTimeReady
-                    ? "ready"
-                    : (screenTimeSupported ? "needs-action" : "unavailable"),
-                "canRequest": screenTimeCanRequest,
-                "canOpenSettings": true,
+                "status": "unavailable",
+                "canRequest": false,
+                "canOpenSettings": false,
                 "settingsTarget": "screenTime",
-                "reason": screenTimeReady ? NSNull() : screenTimeReason,
+                "reason": screenTimeReason,
             ],
             [
                 "id": "local_network",

--- a/plugins/plugin-native-mobile-signals/ios/Sources/MobileSignalsPlugin/ScreenTimeSupport.swift
+++ b/plugins/plugin-native-mobile-signals/ios/Sources/MobileSignalsPlugin/ScreenTimeSupport.swift
@@ -1,3 +1,7 @@
+/**
+ * Inspects iOS Screen Time provisioning and exposes only capabilities that the
+ * app process can actually use without crossing Apple's extension sandbox.
+ */
 import FamilyControls
 import DeviceActivity
 import Foundation
@@ -34,7 +38,7 @@ enum ScreenTimeSupport {
         }
     }
 
-    static func buildStatus(reasonOverride: String? = nil) -> [String: Any] {
+    static func buildStatus() -> [String: Any] {
         let entitlementInspection = inspectEntitlements()
         let extensionInspection = inspectBundledExtensions()
         let familyControlsEnabled = entitlementInspection.familyControls
@@ -42,17 +46,18 @@ enum ScreenTimeSupport {
         let authorizationStatus = authorizationStatusString()
         let provisioningSatisfied = entitlementInspection.satisfied
 
-        let reason = reasonOverride ?? derivedReason(
+        let reason = derivedReason(
             familyControlsEnabled: authorizationEntitlementAvailable,
-            authorizationStatus: authorizationStatus,
             extensionInspection: extensionInspection
         )
-        let provisioningReason: Any = provisioningSatisfied
-            ? NSNull()
-            : (entitlementInspection.reason ?? reason)
-        let reportAvailable = extensionInspection.report && authorizationStatus == "approved"
-        let thresholdEventsAvailable = extensionInspection.monitor && authorizationStatus == "approved"
-
+        let provisioningReason: Any
+        if provisioningSatisfied {
+            provisioningReason = NSNull()
+        } else if let unavailableReason = entitlementInspection.reason ?? reason {
+            provisioningReason = unavailableReason
+        } else {
+            provisioningReason = NSNull()
+        }
         return [
             "supported": provisioningSatisfied || entitlementInspection.inspected == "not-inspectable",
             "requirements": [
@@ -75,10 +80,7 @@ enum ScreenTimeSupport {
             ],
             "authorization": [
                 "status": authorizationStatus,
-                "canRequest": canRequestAuthorization(
-                    familyControlsEnabled: authorizationEntitlementAvailable,
-                    authorizationStatus: authorizationStatus
-                ),
+                "canRequest": ScreenTimeCapabilityPolicy.authorizationRequestAvailable,
             ],
             "extensions": [
                 "deviceActivityReportExtension": extensionInspection.report,
@@ -86,53 +88,12 @@ enum ScreenTimeSupport {
                 "inspected": extensionInspection.inspected,
                 "bundles": extensionInspection.bundles,
             ],
-            "reportAvailable": reportAvailable,
-            "coarseSummaryAvailable": reportAvailable,
-            "thresholdEventsAvailable": thresholdEventsAvailable,
-            "rawUsageExportAvailable": false,
-            "reason": reason,
+            "reportAvailable": ScreenTimeCapabilityPolicy.reportAvailable,
+            "coarseSummaryAvailable": ScreenTimeCapabilityPolicy.coarseSummaryAvailable,
+            "thresholdEventsAvailable": ScreenTimeCapabilityPolicy.thresholdEventsAvailable,
+            "rawUsageExportAvailable": ScreenTimeCapabilityPolicy.rawUsageExportAvailable,
+            "reason": reason ?? NSNull(),
         ]
-    }
-
-    static func requestAuthorizationIfAvailable(
-        completion: @escaping (String?) -> Void
-    ) {
-        let entitlementInspection = inspectEntitlements()
-        let authorizationStatus = authorizationStatusString()
-        guard canRequestAuthorization(
-            familyControlsEnabled: entitlementInspection.canAttemptAuthorization,
-            authorizationStatus: authorizationStatus
-        ) else {
-            DispatchQueue.main.async {
-                completion(nil)
-            }
-            return
-        }
-
-        if #available(iOS 16.0, *) {
-            Task { @MainActor in
-                do {
-                    try await AuthorizationCenter.shared.requestAuthorization(for: .individual)
-                    completion(nil)
-                } catch {
-                    completion("Screen Time authorization request failed: \(error.localizedDescription)")
-                }
-            }
-            return
-        }
-
-        DispatchQueue.main.async {
-            AuthorizationCenter.shared.requestAuthorization { result in
-                DispatchQueue.main.async {
-                    switch result {
-                    case .success:
-                        completion(nil)
-                    case .failure(let error):
-                        completion("Screen Time authorization request failed: \(error.localizedDescription)")
-                    }
-                }
-            }
-        }
     }
 
     private static func authorizationStatusString() -> String {
@@ -157,18 +118,10 @@ enum ScreenTimeSupport {
         }
     }
 
-    private static func canRequestAuthorization(
-        familyControlsEnabled: Bool,
-        authorizationStatus: String
-    ) -> Bool {
-        familyControlsEnabled && authorizationStatus == "not-determined"
-    }
-
     private static func derivedReason(
         familyControlsEnabled: Bool,
-        authorizationStatus: String,
         extensionInspection: ExtensionInspection
-    ) -> String {
+    ) -> String? {
         if !familyControlsEnabled {
             return "Family Controls entitlement is missing from the app bundle."
         }
@@ -181,13 +134,7 @@ enum ScreenTimeSupport {
             }
             return "DeviceActivity monitor extension is not bundled with the app."
         }
-        if authorizationStatus == "not-determined" {
-            return "Screen Time authorization has not been granted yet."
-        }
-        if authorizationStatus == "denied" {
-            return "Screen Time authorization was denied on this device."
-        }
-        return "Screen Time DeviceActivity support is available."
+        return nil
     }
 
     private static func inspectBundledExtensions() -> ExtensionInspection {

--- a/plugins/plugin-native-mobile-signals/ios/Tests/MobileSignalsHealthContractTests/ScreenTimeCapabilityPolicyTests.swift
+++ b/plugins/plugin-native-mobile-signals/ios/Tests/MobileSignalsHealthContractTests/ScreenTimeCapabilityPolicyTests.swift
@@ -1,0 +1,16 @@
+/**
+ * Verifies the host-visible Screen Time capability policy independently of
+ * entitlement availability and the DeviceActivity extension process.
+ */
+import XCTest
+@testable import MobileSignalsHealthContract
+
+final class ScreenTimeCapabilityPolicyTests: XCTestCase {
+    func testHostDoesNotAdvertiseSandboxedOrUnimplementedData() {
+        XCTAssertFalse(ScreenTimeCapabilityPolicy.authorizationRequestAvailable)
+        XCTAssertFalse(ScreenTimeCapabilityPolicy.reportAvailable)
+        XCTAssertFalse(ScreenTimeCapabilityPolicy.coarseSummaryAvailable)
+        XCTAssertFalse(ScreenTimeCapabilityPolicy.thresholdEventsAvailable)
+        XCTAssertFalse(ScreenTimeCapabilityPolicy.rawUsageExportAvailable)
+    }
+}

--- a/plugins/plugin-native-mobile-signals/scripts/validate-ios-screen-time.mjs
+++ b/plugins/plugin-native-mobile-signals/scripts/validate-ios-screen-time.mjs
@@ -1,4 +1,8 @@
 #!/usr/bin/env node
+/**
+ * Validates the native iOS Screen Time entitlements, extension targets, and
+ * plugin framework wiring against either the current repository or fixtures.
+ */
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
@@ -7,7 +11,7 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pluginRoot = path.resolve(__dirname, "..");
-const defaultRepoRoot = path.resolve(pluginRoot, "..", "..", "..");
+const defaultRepoRoot = path.resolve(pluginRoot, "..", "..");
 
 export const IOS_SCREEN_TIME_REQUIREMENTS = Object.freeze({
   entitlements: Object.freeze({
@@ -21,6 +25,20 @@ export const IOS_SCREEN_TIME_REQUIREMENTS = Object.freeze({
   extensionTargets: Object.freeze({
     deviceActivityMonitor: "DeviceActivityMonitorExtension",
     deviceActivityReport: "DeviceActivityReportExtension",
+  }),
+  extensionBundleIdentifiers: Object.freeze({
+    deviceActivityMonitor: "ai.elizaos.app.DeviceActivityMonitorExtension",
+    deviceActivityReport: "ai.elizaos.app.DeviceActivityReportExtension",
+  }),
+  extensionEntitlementsRelativePaths: Object.freeze({
+    deviceActivityMonitor: path.join(
+      "DeviceActivityMonitorExtension",
+      "DeviceActivityMonitorExtension.entitlements",
+    ),
+    deviceActivityReport: path.join(
+      "DeviceActivityReportExtension",
+      "DeviceActivityReportExtension.entitlements",
+    ),
   }),
   appEntitlementsRelativePath: path.join("App", "App.entitlements"),
 });
@@ -60,9 +78,8 @@ export function defaultIosScreenTimeValidationPaths({
     ),
     podspecPath: path.join(
       repoRootValue,
-      "packages",
-      "native-plugins",
-      "mobile-signals",
+      "plugins",
+      "plugin-native-mobile-signals",
       "ElizaosCapacitorMobileSignals.podspec",
     ),
   };
@@ -110,6 +127,31 @@ function extractDictAfterKey(plist, key) {
   const keyEnd = findKeyEnd(plist, key);
   if (keyEnd === -1) return null;
   return extractNextDict(plist, keyEnd);
+}
+
+function extractBalancedBlock(source, openingBraceIndex) {
+  let depth = 0;
+  for (let index = openingBraceIndex; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}") depth -= 1;
+    if (depth === 0) return source.slice(openingBraceIndex, index + 1);
+  }
+  return null;
+}
+
+function extractPbxBuildSettingsBlocks(project) {
+  const marker = "buildSettings = {";
+  const blocks = [];
+  let searchFrom = 0;
+  for (;;) {
+    const markerIndex = project.indexOf(marker, searchFrom);
+    if (markerIndex === -1) return blocks;
+    const openingBraceIndex = project.indexOf("{", markerIndex);
+    const block = extractBalancedBlock(project, openingBraceIndex);
+    if (!block) return blocks;
+    blocks.push(block);
+    searchFrom = openingBraceIndex + block.length;
+  }
 }
 
 function plistStringValue(plist, key, { enclosingKey } = {}) {
@@ -267,6 +309,78 @@ export function validateIosScreenTimeBuildWiring(options = {}) {
     );
   } catch (error) {
     addCheck(checks, "xcode-entitlements-build-setting", false, error.message);
+  }
+
+  try {
+    const invalidExtensions = Object.entries(
+      IOS_SCREEN_TIME_REQUIREMENTS.extensionEntitlementsRelativePaths,
+    ).flatMap(([key, relativePath]) => {
+      const entitlementPath = path.join(appRootPath, relativePath);
+      const entitlements = readRequiredText(
+        entitlementPath,
+        `${IOS_SCREEN_TIME_REQUIREMENTS.extensionTargets[key]} entitlements`,
+      );
+      return missingRequiredEntitlements(entitlements).map(
+        (entitlement) => `${relativePath}: ${entitlement}`,
+      );
+    });
+    addCheck(
+      checks,
+      "deviceactivity-extension-entitlements",
+      invalidExtensions.length === 0,
+      invalidExtensions.length === 0
+        ? "DeviceActivity extensions include the Family Controls entitlement."
+        : `DeviceActivity extension entitlements are missing required keys: ${invalidExtensions.join(
+            ", ",
+          )}.`,
+    );
+  } catch (error) {
+    addCheck(
+      checks,
+      "deviceactivity-extension-entitlements",
+      false,
+      error.message,
+    );
+  }
+
+  try {
+    const project = readRequiredText(projectPath, "Xcode project");
+    const buildSettingsBlocks = extractPbxBuildSettingsBlocks(project);
+    const invalidTargets = Object.entries(
+      IOS_SCREEN_TIME_REQUIREMENTS.extensionEntitlementsRelativePaths,
+    ).flatMap(([key, relativePath]) => {
+      const bundleIdentifier =
+        IOS_SCREEN_TIME_REQUIREMENTS.extensionBundleIdentifiers[key];
+      const targetBlocks = buildSettingsBlocks.filter((block) =>
+        block.includes(`PRODUCT_BUNDLE_IDENTIFIER = ${bundleIdentifier};`),
+      );
+      const expected = `CODE_SIGN_ENTITLEMENTS = App/${relativePath};`;
+      if (targetBlocks.length === 0) {
+        return [
+          `${IOS_SCREEN_TIME_REQUIREMENTS.extensionTargets[key]}: no build settings found`,
+        ];
+      }
+      return targetBlocks.some((block) => !block.includes(expected))
+        ? [`${IOS_SCREEN_TIME_REQUIREMENTS.extensionTargets[key]}: ${expected}`]
+        : [];
+    });
+    addCheck(
+      checks,
+      "xcode-deviceactivity-extension-entitlements-build-settings",
+      invalidTargets.length === 0,
+      invalidTargets.length === 0
+        ? "Xcode project signs each DeviceActivity extension with its matching entitlement file."
+        : `Xcode project has invalid DeviceActivity target entitlement settings: ${invalidTargets.join(
+            ", ",
+          )}.`,
+    );
+  } catch (error) {
+    addCheck(
+      checks,
+      "xcode-deviceactivity-extension-entitlements-build-settings",
+      false,
+      error.message,
+    );
   }
 
   try {

--- a/plugins/plugin-native-mobile-signals/scripts/validate-ios-screen-time.test.mjs
+++ b/plugins/plugin-native-mobile-signals/scripts/validate-ios-screen-time.test.mjs
@@ -1,13 +1,22 @@
+/**
+ * Exercises the Screen Time native-wiring validator with deterministic
+ * fixtures and pins its default paths to the current repository layout.
+ */
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, test } from "vitest";
 import {
+  defaultIosScreenTimeValidationPaths,
   IOS_SCREEN_TIME_REQUIREMENTS,
   validateIosScreenTimeBuildWiring,
 } from "./validate-ios-screen-time.mjs";
 
 const tempRoots = [];
+const scriptsRoot = path.dirname(fileURLToPath(import.meta.url));
+const pluginRoot = path.resolve(scriptsRoot, "..");
+const repoRoot = path.resolve(pluginRoot, "..", "..");
 
 function makeTempRoot() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "ios-screen-time-"));
@@ -48,7 +57,15 @@ end`,
     ? `DA_MON /* ${IOS_SCREEN_TIME_REQUIREMENTS.extensionTargets.deviceActivityMonitor} */;
 DA_REP /* ${IOS_SCREEN_TIME_REQUIREMENTS.extensionTargets.deviceActivityReport} */;
 ${IOS_SCREEN_TIME_REQUIREMENTS.extensionTargets.deviceActivityMonitor}.appex;
-${IOS_SCREEN_TIME_REQUIREMENTS.extensionTargets.deviceActivityReport}.appex;`
+${IOS_SCREEN_TIME_REQUIREMENTS.extensionTargets.deviceActivityReport}.appex;
+buildSettings = {
+  CODE_SIGN_ENTITLEMENTS = App/${IOS_SCREEN_TIME_REQUIREMENTS.extensionEntitlementsRelativePaths.deviceActivityMonitor};
+  PRODUCT_BUNDLE_IDENTIFIER = ${IOS_SCREEN_TIME_REQUIREMENTS.extensionBundleIdentifiers.deviceActivityMonitor};
+};
+buildSettings = {
+  CODE_SIGN_ENTITLEMENTS = App/${IOS_SCREEN_TIME_REQUIREMENTS.extensionEntitlementsRelativePaths.deviceActivityReport};
+  PRODUCT_BUNDLE_IDENTIFIER = ${IOS_SCREEN_TIME_REQUIREMENTS.extensionBundleIdentifiers.deviceActivityReport};
+};`
     : "";
   writeFile(
     projectPath,
@@ -67,9 +84,27 @@ ${targetText}`,
       "DeviceActivityReportExtension",
       IOS_SCREEN_TIME_REQUIREMENTS.extensionPoints.deviceActivityReport,
     );
+    for (const relativePath of Object.values(
+      IOS_SCREEN_TIME_REQUIREMENTS.extensionEntitlementsRelativePaths,
+    )) {
+      writeFamilyControlsEntitlements(path.join(appRoot, relativePath));
+    }
   }
 
   return { appRootPath: appRoot, entitlementsPath, projectPath, podspecPath };
+}
+
+function writeFamilyControlsEntitlements(filePath) {
+  writeFile(
+    filePath,
+    `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>${IOS_SCREEN_TIME_REQUIREMENTS.entitlements.familyControls}</key>
+  <true/>
+</dict>
+</plist>`,
+  );
 }
 
 function writeExtensionInfo(appRoot, name, extensionPoint) {
@@ -95,6 +130,22 @@ afterEach(() => {
 });
 
 describe("validateIosScreenTimeBuildWiring", () => {
+  test("resolves the current repository and plugin podspec by default", () => {
+    const paths = defaultIosScreenTimeValidationPaths();
+
+    expect(paths.projectPath).toBe(
+      path.join(
+        repoRoot,
+        "packages/app-core/platforms/ios/App/App.xcodeproj/project.pbxproj",
+      ),
+    );
+    expect(paths.podspecPath).toBe(
+      path.join(pluginRoot, "ElizaosCapacitorMobileSignals.podspec"),
+    );
+    expect(fs.existsSync(paths.projectPath)).toBe(true);
+    expect(fs.existsSync(paths.podspecPath)).toBe(true);
+  });
+
   test("passes when app entitlements, frameworks, extension plists, and project products are present", () => {
     const result = validateIosScreenTimeBuildWiring(
       writeFixture({ includeExtensions: true }),
@@ -104,6 +155,53 @@ describe("validateIosScreenTimeBuildWiring", () => {
     expect(result.failures).toEqual([]);
     expect(result.checks.map((check) => check.id)).toContain(
       "deviceactivity-extension-info-plists",
+    );
+    expect(result.checks.map((check) => check.id)).toContain(
+      "deviceactivity-extension-entitlements",
+    );
+    expect(result.checks.map((check) => check.id)).toContain(
+      "xcode-deviceactivity-extension-entitlements-build-settings",
+    );
+  });
+
+  test("fails when a DeviceActivity extension lacks Family Controls", () => {
+    const fixture = writeFixture({ includeExtensions: true });
+    writeFile(
+      path.join(
+        fixture.appRootPath,
+        IOS_SCREEN_TIME_REQUIREMENTS.extensionEntitlementsRelativePaths
+          .deviceActivityReport,
+      ),
+      `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict></dict></plist>`,
+    );
+
+    const result = validateIosScreenTimeBuildWiring(fixture);
+
+    expect(result.ok).toBe(false);
+    expect(result.failures.map((failure) => failure.id)).toContain(
+      "deviceactivity-extension-entitlements",
+    );
+  });
+
+  test("fails when an extension entitlement setting is assigned to the wrong target", () => {
+    const fixture = writeFixture({ includeExtensions: true });
+    const project = fs.readFileSync(fixture.projectPath, "utf8");
+    const monitorSetting = `CODE_SIGN_ENTITLEMENTS = App/${IOS_SCREEN_TIME_REQUIREMENTS.extensionEntitlementsRelativePaths.deviceActivityMonitor};`;
+    const reportSetting = `CODE_SIGN_ENTITLEMENTS = App/${IOS_SCREEN_TIME_REQUIREMENTS.extensionEntitlementsRelativePaths.deviceActivityReport};`;
+    fs.writeFileSync(
+      fixture.projectPath,
+      project
+        .replace(monitorSetting, "SWAPPED_EXTENSION_ENTITLEMENT")
+        .replace(reportSetting, monitorSetting)
+        .replace("SWAPPED_EXTENSION_ENTITLEMENT", reportSetting),
+    );
+
+    const result = validateIosScreenTimeBuildWiring(fixture);
+
+    expect(result.ok).toBe(false);
+    expect(result.failures.map((failure) => failure.id)).toContain(
+      "xcode-deviceactivity-extension-entitlements-build-settings",
     );
   });
 
@@ -118,6 +216,8 @@ describe("validateIosScreenTimeBuildWiring", () => {
         "deviceactivity-extension-info-plists",
         "xcode-deviceactivity-extension-targets",
         "xcode-deviceactivity-embedded-products",
+        "deviceactivity-extension-entitlements",
+        "xcode-deviceactivity-extension-entitlements-build-settings",
       ]),
     );
   });

--- a/plugins/plugin-native-mobile-signals/src/definitions.ts
+++ b/plugins/plugin-native-mobile-signals/src/definitions.ts
@@ -117,19 +117,19 @@ export interface MobileSignalsScreenTimeStatus {
       path: string;
     }>;
   };
+  /** A host-presented authorized report extension can render activity in its sandbox. */
   reportAvailable: boolean;
-  /** Coarse, in-extension-rendered category summaries are available (no raw export). */
+  /** Coarse category totals are available to the host process. False on current iOS. */
   coarseSummaryAvailable: boolean;
-  /** `DeviceActivityMonitor` threshold-crossing events are available. */
+  /** Configured `DeviceActivityMonitor` threshold events reach the host signal path. */
   thresholdEventsAvailable: boolean;
   /**
    * Permanently `false` — a platform constraint, not a TODO. Apple's
    * DeviceActivity / FamilyControls model (iOS 15+) forbids exporting raw
-   * per-app usage to the host app: usage is only readable inside a rendered
-   * `DeviceActivityReport` extension (never exfiltrated) plus
-   * `DeviceActivityMonitor` threshold events. Host-side mobile screen-time is
-   * therefore scoped to coarse summaries + threshold events; there is no
-   * macOS-style per-window dwell on iOS. See issue #9970.
+   * per-app usage to the host app: usage is readable only inside a sandboxed
+   * `DeviceActivityReport` extension. The current iOS host therefore exposes
+   * neither usage totals nor threshold events; Android's UsageStats path keeps
+   * its separate host-readable summary. See issues #9970 and #20007.
    */
   rawUsageExportAvailable: false;
   android?: {


### PR DESCRIPTION
## Summary

Makes the iOS Screen Time surface truthful and build-verifiable instead of advertising host-readable activity data that Apple's privacy-sandboxed Device Activity report extension does not expose to the Capacitor host.

- Render category totals inside the `DeviceActivityReportExtension`, traversing Apple's real multi-segment data shape.
- Centralize the host capability result so the TypeScript bridge reports only what the host can actually read.
- Add localized empty/report copy and deterministic aggregation coverage.
- Validate the app, monitor extension, and report extension entitlements, signing settings, products, and embedding.
- Keep Android's legitimate host-readable coarse-summary contract intact.

This is the current-develop, fully validated superset of the older six-path draft #20044 and supersedes it without overwriting its history.

Closes #20007.

## Root cause

The previous implementation conflated two authorities: authorization for Apple's Family Controls framework and availability of Screen Time data to the host process. On iOS, usage details remain inside the privacy-sandboxed Device Activity report extension. The host bridge therefore advertised data it could not actually return, while the report extension used a static placeholder instead of aggregating the real `DeviceActivityData` hierarchy.

## User impact

Users no longer see a false promise that Eliza can read a coarse Screen Time summary in the host app. When Screen Time is authorized, the native report extension owns the privacy-preserving category presentation; unsupported or unavailable states remain explicit.

## Verification

- App contract Vitest: 20/20 passed.
- UI mobile-permissions Vitest: 18/18 passed.
- Screen Time validator tests: 5/5 passed, 15 assertions.
- Swift contract tests: 11/11 passed.
- `packages/app`, `packages/ui`, and `plugin-native-mobile-signals` typechecks passed.
- Exact Biome check and `git diff --check` passed.
- `validate:ios-screen-time` passed every source/project/entitlement check; provisioning-profile inspection was correctly skipped because no distribution profile was supplied.
- Exact-head generic iOS Simulator build passed, including `DeviceActivityReportExtension.appex` embedded-binary validation and the cloud artifact audit.
- App aesthetic audit: 218/219 tests passed. The sole strict failure is inherited and outside this PR: `plugin-cloud-gui` has four low-readable-character verdicts; this PR changes no Cloud GUI path.
- Root `bun run verify`: 260/349 tasks completed before the sole terminal failure in untouched `packages/cloud/services/gateway-webhook/src/billing.test.ts`, which cannot resolve `@elizaos/cloud-shared/billing` on current develop. This PR changes no Cloud package.

## Evidence

### evidence-row:before-screenshots

N/A — the defect is a native capability-contract mismatch; the generic simulator cannot supply authorized Screen Time usage data.

### evidence-row:after-screenshots

Pending physical-device Family Controls evidence. The exact-head simulator build and native aggregation tests are complete; the PR remains draft until a signed device can provide real authorized report data.

### evidence-row:walkthrough-video

Pending the same signed physical-device Screen Time session.

### evidence-row:backend-logs

N/A — no backend path changes.

### evidence-row:frontend-logs

Exact-head Xcode build completed with `** BUILD SUCCEEDED **`; all embedded extensions validated and the cloud artifact audit passed.

### evidence-row:llm-trajectory

N/A — no model, prompt, provider, action, or agent behavior changes.

### evidence-row:domain-artifacts

Exact head: `20f97f7dc3d2f77eb59d7752c2a7e42c2f280b7d`

Tree: `9b13fac7162995713876956aab7e699f31f16285`

Base: `c931e185d4caa2f3ec95f959cb7db8230a30b0fb`

Binary patch SHA-256: `4d837994a32bfdae3adfa5cf70597e8cb1842cb4a5ebf3c892553023bf22bfa3`

Stable patch-id: `3c79cc29894785fce2355c8e4fc391177fd7b880`

### evidence-row:ocr-review

N/A until signed physical-device report capture is available.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c931e185d4caa2f3ec95f959cb7db8230a30b0fb:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

— [codex / apple-native-surface-lane]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@c931e185d4caa2f3ec95f959cb7db8230a30b0fb:packages/skills/skills/contribute-to-eliza"} -->
