### PR TITLE
fix(core): align facts toolCalls-priority tests with the speaker-attribution shape

### DIFF
--- a/packages/core/src/runtime/__tests__/facts-and-relationships.test.ts
+++ b/packages/core/src/runtime/__tests__/facts-and-relationships.test.ts
@@ -191,7 +191,9 @@ describe("parseFactsAndRelationshipsOutput", () => {
 				},
 			],
 		});
-		expect(result.facts).toEqual(["Alice lives in Paris"]);
+		expect(result.facts).toEqual([
+			{ subject: "user", fact: "Alice lives in Paris" },
+		]);
 	});
 
 	it("falls back to text when the tool call carries no usable args", () => {
@@ -199,7 +201,7 @@ describe("parseFactsAndRelationshipsOutput", () => {
 			text: '{"facts":["b"],"relationships":[],"thought":"t"}',
 			toolCalls: [{ type: "tool-call" }],
 		});
-		expect(result.facts).toEqual(["b"]);
+		expect(result.facts).toEqual([{ subject: "user", fact: "b" }]);
 	});
 
 	it("parses tool-call args under `args` and `params` keys too", () => {


### PR DESCRIPTION
## Problem

develop is red on `facts-and-relationships.test.ts` (2 tests): #20053 (prefer toolCalls over conversational preamble text — an older PR) merged **after** #20109 changed the facts contract from plain strings to `{subject, fact}` records, without rebase-adjusting its two new expectations. Merge skew, invisible because PR branches run no repo CI.

## Fix

Test-expectation-only change (2 lines): the runtime code already honors both contracts — string facts from tool-call args normalize with the default `"user"` subject, exactly what the received values showed. As the author of #20109 I can confirm this is the intended shape.

## Evidence

`facts-and-relationships.test.ts` 28/28 ✅ · Biome ✅ · no source files touched.

Found while sweeping `src/runtime` for #20240 (F38) — the sweep is 1370/1370 with both PRs applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)