### PR TITLE
fix(scenarios): trust only successful child reports

### DIFF
--- a/packages/scripts/__tests__/run-scenarios-isolated.test.ts
+++ b/packages/scripts/__tests__/run-scenarios-isolated.test.ts
@@ -1,17 +1,140 @@
 /**
- * Regression coverage for the scenario isolation wrapper's repo-root path.
+ * Deterministic process-boundary coverage for the scenario isolation wrapper.
  *
- * Outside workspace test discovery - run via
- *   bun test packages/scripts/__tests__/run-scenarios-isolated.test.ts
+ * A temporary Bun shim emits controlled reports and child exit outcomes without
+ * booting a runtime or requiring model credentials.
  */
 import { expect, test } from "bun:test";
-import { existsSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "../lib/spawn-sync-captured.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, "..", "..", "..");
+const SCRIPT = path.join(
+  REPO_ROOT,
+  "packages",
+  "scripts",
+  "run-scenarios-isolated.mjs",
+);
+
+type ScenarioStatus = "passed" | "failed" | "skipped";
+
+interface FixtureCase {
+  status: ScenarioStatus;
+  exitCode?: number;
+  signal?: NodeJS.Signals;
+}
+
+interface AggregateReport {
+  totals: {
+    passed: number;
+    failed: number;
+    skipped: number;
+    total: number;
+  };
+  scenarios: Array<{ id: string; status: ScenarioStatus }>;
+}
+
+const FAKE_BUN_SOURCE = `#!/usr/bin/env node
+import fs from "node:fs";
+
+const args = process.argv.slice(2);
+const command = args[1];
+const cases = JSON.parse(process.env.ISOLATED_SCENARIO_CASES ?? "{}");
+
+if (command === "list") {
+  process.stdout.write(Object.keys(cases).join("\\n") + "\\n");
+  process.exit(0);
+}
+if (command !== "run") {
+  process.stderr.write("unexpected command: " + String(command) + "\\n");
+  process.exit(2);
+}
+
+const scenarioIndex = args.indexOf("--scenario");
+const reportIndex = args.indexOf("--report");
+const id = args[scenarioIndex + 1];
+const reportPath = args[reportIndex + 1];
+const fixture = cases[id];
+if (!fixture || !reportPath) {
+  process.stderr.write("missing scenario fixture or report path\\n");
+  process.exit(2);
+}
+
+fs.writeFileSync(
+  reportPath,
+  JSON.stringify({
+    providerName: "fixture",
+    scenarios: [{ id, status: fixture.status, durationMs: 1 }],
+  }),
+);
+if (fixture.signal) {
+  process.kill(process.pid, fixture.signal);
+}
+process.exit(fixture.exitCode ?? 0);
+`;
+
+function isolatedTmpReport(id: string): string {
+  return path.join(
+    "/tmp",
+    `scenario-isolated-${id.replace(/[^a-z0-9._-]/gi, "_")}.json`,
+  );
+}
+
+function runFixture(cases: Record<string, FixtureCase>): {
+  result: ReturnType<typeof spawnSync>;
+  report: AggregateReport;
+} {
+  const fixtureRoot = mkdtempSync(
+    path.join(tmpdir(), "scenario-isolation-status-"),
+  );
+  const binDir = path.join(fixtureRoot, "bin");
+  const scenariosDir = path.join(fixtureRoot, "scenarios");
+  const reportPath = path.join(fixtureRoot, "aggregate.json");
+  const fakeBun = path.join(binDir, "bun");
+  const tmpReports = Object.keys(cases).map(isolatedTmpReport);
+
+  try {
+    mkdirSync(binDir);
+    mkdirSync(scenariosDir);
+    writeFileSync(fakeBun, FAKE_BUN_SOURCE);
+    chmodSync(fakeBun, 0o755);
+
+    const result = spawnSync(
+      process.execPath,
+      [SCRIPT, scenariosDir, "--report", reportPath],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          ISOLATED_SCENARIO_CASES: JSON.stringify(cases),
+          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        },
+      },
+    );
+    const report = JSON.parse(
+      readFileSync(reportPath, "utf8"),
+    ) as AggregateReport;
+    return { result, report };
+  } finally {
+    for (const tmpReport of tmpReports) {
+      rmSync(tmpReport, { force: true });
+    }
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+}
 
 test("run-scenarios-isolated resolves the real scenario-runner CLI", () => {
   const result = spawnSync(
@@ -31,4 +154,72 @@ test("run-scenarios-isolated resolves the real scenario-runner CLI", () => {
   );
   expect(paths.cli).not.toContain("packages/eliza/packages");
   expect(existsSync(paths.cli)).toBe(true);
+});
+
+test("a skipped report from an exit-2 child is failed and untrusted", () => {
+  const { result, report } = runFixture({
+    "exit-2-skipped": { status: "skipped", exitCode: 2 },
+  });
+
+  expect(result.status).toBe(1);
+  expect(result.stderr).toContain("exit-2-skipped failed (exit 2)");
+  expect(report.totals).toEqual({
+    passed: 0,
+    failed: 1,
+    skipped: 0,
+    total: 1,
+  });
+  expect(report.scenarios).toEqual([]);
+});
+
+test("a child terminated without an exit status is failed", () => {
+  const { result, report } = runFixture({
+    "signal-skipped": { status: "skipped", signal: "SIGTERM" },
+  });
+
+  expect(result.status).toBe(1);
+  expect(result.stderr).toContain("signal-skipped failed (signal SIGTERM)");
+  expect(report.totals).toEqual({
+    passed: 0,
+    failed: 1,
+    skipped: 0,
+    total: 1,
+  });
+  expect(report.scenarios).toEqual([]);
+});
+
+test("a legitimate skipped report from a zero-exit child remains skipped", () => {
+  const { result, report } = runFixture({
+    "zero-skipped": { status: "skipped", exitCode: 0 },
+  });
+
+  expect(result.status).toBe(0);
+  expect(report.totals).toEqual({
+    passed: 0,
+    failed: 0,
+    skipped: 1,
+    total: 1,
+  });
+  expect(report.scenarios).toEqual([
+    { id: "zero-skipped", status: "skipped", durationMs: 1 },
+  ]);
+});
+
+test("zero-exit pass and fail reports retain their report semantics", () => {
+  const { result, report } = runFixture({
+    "zero-passed": { status: "passed", exitCode: 0 },
+    "zero-failed": { status: "failed", exitCode: 0 },
+  });
+
+  expect(result.status).toBe(1);
+  expect(report.totals).toEqual({
+    passed: 1,
+    failed: 1,
+    skipped: 0,
+    total: 2,
+  });
+  expect(report.scenarios).toEqual([
+    { id: "zero-passed", status: "passed", durationMs: 1 },
+    { id: "zero-failed", status: "failed", durationMs: 1 },
+  ]);
 });

--- a/packages/scripts/run-scenarios-isolated.mjs
+++ b/packages/scripts/run-scenarios-isolated.mjs
@@ -108,6 +108,15 @@ for (const id of ids) {
       env: process.env,
     },
   );
+  if (child.status !== 0) {
+    const cause =
+      child.status === null
+        ? `signal ${child.signal ?? "unknown"}`
+        : `exit ${child.status}`;
+    console.error(`[isolated] ${id} failed (${cause})`);
+    failed += 1;
+    continue;
+  }
   if (!fs.existsSync(tmpReport)) {
     console.error(`[isolated] ${id} produced no report (exit ${child.status})`);
     failed += 1;


### PR DESCRIPTION
# Relates to

Closes #20239.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works without reading the code from the deterministic real-wrapper tests and verification transcript below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@ecb5e6665b83078fe080d2c86db023579d556bdc:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `ecb5e6665b83078fe080d2c86db023579d556bdc`; zero conflicts.
- [x] `bun run verify` passes post-sync at PR head `8f73d45467f5fa36ac162e112aa9ed2b9d0eb462`.

# Risks

Low. The new branch executes only when `spawnSync` reports a nonzero status or signal termination. Zero-exit reports retain the existing passed, failed, and skipped aggregation behavior. Report files from unsuccessful children are deliberately ignored because they may be incomplete or stale.

# Background

## What does this PR do?

Requires each isolated scenario child to exit successfully before its report is parsed and aggregated. Nonzero exits and signal terminations now increment `failed`, print the concrete exit/signal cause, and continue without trusting the report file.

The regression harness invokes the real wrapper process with a temporary fake `bun` executable. The fake child can write deterministic report JSON and then exit 2, terminate via `SIGTERM`, or exit 0. Tests prove unsuccessful children remain failures even when they wrote a `skipped` report, while zero-exit passed/failed/skipped reports preserve their existing semantics.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No documentation change is required. This enforces the existing subprocess success contract at the wrapper boundary.

# Testing

## Where should a reviewer start?

- `packages/scripts/run-scenarios-isolated.mjs`: child-status check before report parsing.
- `packages/scripts/__tests__/run-scenarios-isolated.test.ts`: nonzero, signal, and zero-exit report cases.

## Detailed testing steps

Run with the repository-pinned Bun 1.3.14 and Node 24.15.0:

```bash
bun install --frozen-lockfile
bun test packages/scripts/__tests__/run-scenarios-isolated.test.ts
./node_modules/.bin/biome check packages/scripts/run-scenarios-isolated.mjs packages/scripts/__tests__/run-scenarios-isolated.test.ts
git diff --check origin/develop...HEAD
bun run test:scripts
bun run verify
```

Observed final results:

- Focused real-wrapper suite: 5 passed, 0 failed, 19 assertions.
- Changed-file Biome check: 2 files checked, no fixes required.
- Diff check: passed.
- Complete `test:scripts` lane: passed; the previously observed unrelated timeout case also passed 18/18 in the final run.
- Root verification: passed through the final anti-focused-test audit (8,258 test files; 0 focused; 0 orphaned skips).

# Evidence Gate

<!-- evidence-head:8f73d45467f5fa36ac162e112aa9ed2b9d0eb462 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: N/A - headless subprocess orchestration has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: N/A - headless subprocess orchestration has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] Video walkthrough: N/A - deterministic wrapper behavior has no visual user flow.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - this is a local repository script and does not invoke a backend service.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no frontend or network request is involved.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: deterministic child-process and repository verification transcript.

<details>
<summary>Final verification transcript</summary>

```text
focused run-scenarios-isolated suite: 5 passed, 0 failed, 19 assertions
changed-file biome: Checked 2 files. No fixes applied.
git diff --check origin/develop...HEAD: passed
test:scripts: passed; final timing-sensitive suite 18 passed, 0 failed
root verify: workflow trigger policy passed
root verify: script inventory discovered 192 executable test files
root verify: test-lane membership accounted for every test-bearing package
root verify: [anti-larp] scanned 8258 test files — 0 focused, 0 orphaned skip(s)
root verify: [anti-larp] clean — no focused tests, no untracked skips.
proof-run: recorded PROOF for 8f73d4546 — bun run verify (exit 0)
```

</details>

<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review: N/A - no rendered visual surface or text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - the change repairs local subprocess/report handling and does not alter agent, action, prompt, provider, or model behavior.

## Backend + frontend logs

N/A - the deterministic process harness exercises the real wrapper and child boundary directly without a backend or frontend.

## Screenshots (before / after) + video walkthrough

N/A - no UI or rendered visual surface is changed.

## Known gaps / failures

None. The focused suite, complete script lane, changed-file checks, and exact-head repository verification all pass on the published commit.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/eliza@ecb5e6665b83078fe080d2c86db023579d556bdc:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [sol-scenario-child-status]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"claude-code","skill_revision":"elizaOS/eliza@ecb5e6665b83078fe080d2c86db023579d556bdc:packages/skills/skills/contribute-to-eliza"} -->
