### PR TITLE
fix(ui): release deferred Cloud model gate

### DIFF
--- a/packages/app/test/ui-smoke/deferred-cloud-model-gate.spec.ts
+++ b/packages/app/test/ui-smoke/deferred-cloud-model-gate.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * Browser regression for a local desktop whose configured Eliza Cloud text
+ * provider registers after the home composer has already mounted.
+ */
+
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import {
+  expectNoPageDiagnostics,
+  installDefaultAppRoutes,
+  installPageDiagnosticsGuard,
+  openAppPath,
+  seedAppStorage,
+} from "./helpers";
+
+test.describe("deferred Eliza Cloud model registration", () => {
+  test.beforeEach(({ page }) => {
+    installPageDiagnosticsGuard(page);
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    await expectNoPageDiagnostics(page, testInfo.title);
+  });
+
+  for (const surface of [
+    { name: "desktop", viewport: { width: 1440, height: 900 } },
+    { name: "mobile", viewport: { width: 390, height: 844 } },
+  ] as const) {
+    test(`${surface.name} releases the stale local-model gate without a reload`, async ({
+      page,
+    }) => {
+      await page.setViewportSize(surface.viewport);
+      await installDefaultAppRoutes(page);
+      await seedAppStorage(page);
+
+      let cloudRegistered = false;
+      let modelConfigReads = 0;
+
+      await page.route("**/api/config", async (route) => {
+        if (route.request().method() !== "GET") {
+          await route.fallback();
+          return;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            meta: { firstRunComplete: true },
+            serviceRouting: {
+              llmText: { backend: "elizacloud", transport: "cloud-proxy" },
+            },
+          }),
+        });
+      });
+
+      await page.route("**/api/models/config", async (route) => {
+        if (route.request().method() !== "GET") {
+          await route.fallback();
+          return;
+        }
+        modelConfigReads += 1;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(
+            cloudRegistered
+              ? {
+                  activeChat: {
+                    provider: "elizacloud",
+                    family: "ELIZAOS_CLOUD",
+                    endpoint: "https://api.eliza.app/v1",
+                  },
+                }
+              : { targets: { small: {}, large: {}, coding: {} } },
+          ),
+        });
+      });
+
+      await page.route("**/api/local-inference/hub", async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            textReadiness: {
+              slots: {
+                TEXT_SMALL: {
+                  slot: "TEXT_SMALL",
+                  assigned: true,
+                  assignedModelId: "eliza-1-2b",
+                  displayName: "Eliza 1 2B",
+                  primaryDownloaded: false,
+                  downloaded: false,
+                  active: false,
+                  ready: false,
+                  state: "missing",
+                  requiredModelIds: ["eliza-1-2b"],
+                  missingModelIds: ["eliza-1-2b"],
+                  installedBytes: 0,
+                  expectedBytes: 0,
+                  download: {
+                    state: "missing",
+                    receivedBytes: 0,
+                    totalBytes: 0,
+                    percent: null,
+                    bytesPerSec: 0,
+                    etaMs: null,
+                    updatedAt: null,
+                    errors: [],
+                  },
+                  errors: [],
+                },
+              },
+            },
+          }),
+        });
+      });
+
+      await page.route(
+        "**/api/local-inference/downloads/stream**",
+        async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: "text/event-stream",
+            body: "",
+          });
+        },
+      );
+
+      await openAppPath(page, "/chat");
+
+      const composer = page.getByTestId("chat-composer-textarea");
+      await expect(composer).toHaveAttribute(
+        "placeholder",
+        /Getting Eliza 1 2B ready/i,
+        {
+          timeout: 30_000,
+        },
+      );
+      await page.getByRole("button", { name: "drag up to open chat" }).click();
+      await expect(composer).toBeEnabled();
+
+      const captureDir = path.join(
+        process.cwd(),
+        "aesthetic-audit-output",
+        "deferred-cloud-model-gate",
+      );
+      mkdirSync(captureDir, { recursive: true });
+      await page.screenshot({
+        path: path.join(captureDir, `${surface.name}-before.png`),
+        fullPage: true,
+      });
+
+      cloudRegistered = true;
+
+      await expect(composer).not.toHaveAttribute(
+        "placeholder",
+        /Getting .* ready/i,
+      );
+      await expect(composer).toBeEnabled();
+      expect(modelConfigReads).toBeGreaterThanOrEqual(2);
+      await page.screenshot({
+        path: path.join(captureDir, `${surface.name}-after.png`),
+        fullPage: true,
+      });
+    });
+  }
+});

--- a/packages/ui/src/api/client-local-inference.test.ts
+++ b/packages/ui/src/api/client-local-inference.test.ts
@@ -1,11 +1,16 @@
 /**
- * Unit coverage for device-tier classification from a hardware probe. Pure
- * function, no harness.
+ * Covers local-inference client policy helpers: deterministic device-tier
+ * classification and the real fetch boundary for atomic text routing.
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { HardwareProbe } from "../services/local-inference/types";
+import { ElizaClient } from "./client-base";
 import { classifyDeviceTierFromProbe } from "./client-local-inference";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function probe(overrides: Partial<HardwareProbe>): HardwareProbe {
   return {
@@ -96,5 +101,28 @@ describe("classifyDeviceTierFromProbe", () => {
     );
     expect(result.tier).toBe("POOR");
     expect(result.mobile).toBe(true);
+  });
+});
+
+describe("setLocalInferenceTextRouting", () => {
+  it("publishes both text slots through one atomic request", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ preferences: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const client = new ElizaClient("http://127.0.0.1:31337", "token");
+
+    await client.setLocalInferenceTextRouting("elizacloud", "manual");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(String(url)).toContain("/api/local-inference/routing/text");
+    expect(init).toMatchObject({ method: "POST" });
+    expect(JSON.parse(String(init?.body))).toEqual({
+      provider: "elizacloud",
+      policy: "manual",
+    });
   });
 });

--- a/packages/ui/src/api/client-local-inference.ts
+++ b/packages/ui/src/api/client-local-inference.ts
@@ -175,6 +175,10 @@ declare module "./client-base" {
       slot: AgentModelSlot,
       provider: string | null,
     ): Promise<{ preferences: RoutingPreferences }>;
+    setLocalInferenceTextRouting(
+      provider: string,
+      policy?: RoutingPolicy,
+    ): Promise<{ preferences: RoutingPreferences }>;
     setLocalInferencePolicy(
       slot: AgentModelSlot,
       policy: RoutingPolicy | null,
@@ -376,6 +380,17 @@ ElizaClient.prototype.setLocalInferencePreferredProvider = async function (
   return this.fetch("/api/local-inference/routing/preferred", {
     method: "POST",
     body: JSON.stringify({ slot, provider }),
+  });
+};
+
+ElizaClient.prototype.setLocalInferenceTextRouting = async function (
+  this: ElizaClient,
+  provider: string,
+  policy: RoutingPolicy = "manual",
+) {
+  return this.fetch("/api/local-inference/routing/text", {
+    method: "POST",
+    body: JSON.stringify({ provider, policy }),
   });
 };
 

--- a/packages/ui/src/components/local-inference/useHomeModelStatus.test.tsx
+++ b/packages/ui/src/components/local-inference/useHomeModelStatus.test.tsx
@@ -3,8 +3,8 @@
 
 /**
  * Unit coverage for the home-surface model-status hook: it stays `not-required`
- * for cloud/remote/unauthenticated runtimes and derives readiness from the hub
- * fetch. Runtime-mode and the API client are mocked (jsdom, no network).
+ * for external runtimes, tracks local readiness, and releases a stale local
+ * gate after deferred Cloud registration. Network seams are mocked in jsdom.
  */
 
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
@@ -29,6 +29,7 @@ const runtimeModeMock = vi.hoisted(() => ({
 const clientMock = vi.hoisted(() => ({
   getBaseUrl: vi.fn(() => "http://127.0.0.1:31337"),
   getModelsConfig: vi.fn(),
+  getConfig: vi.fn(),
   getLocalInferenceHub: vi.fn(),
 }));
 
@@ -104,6 +105,11 @@ function setRuntimeMode(mode: "loading" | "local" | "cloud" | "remote") {
 beforeEach(() => {
   clientMock.getBaseUrl.mockReturnValue("http://127.0.0.1:31337");
   clientMock.getModelsConfig.mockResolvedValue({});
+  clientMock.getConfig.mockResolvedValue({
+    serviceRouting: {
+      llmText: { backend: "ollama", transport: "direct" },
+    },
+  });
   clientMock.getLocalInferenceHub.mockResolvedValue(emptyHub);
   eventSourceMock.openEventSource.mockClear();
   authMock.authenticated = true;
@@ -160,6 +166,68 @@ describe("useHomeModelStatus", () => {
     expect(clientMock.getModelsConfig).toHaveBeenCalledTimes(1);
     expect(clientMock.getLocalInferenceHub).not.toHaveBeenCalled();
     expect(eventSourceMock.openEventSource).not.toHaveBeenCalled();
+  });
+
+  it("clears a stale local gate after deferred Eliza Cloud registration", async () => {
+    clientMock.getModelsConfig.mockResolvedValueOnce({}).mockResolvedValue({
+      activeChat: {
+        provider: "elizacloud",
+        family: "ELIZAOS_CLOUD",
+        endpoint: "https://api.eliza.app/v1",
+      },
+    });
+    clientMock.getConfig.mockResolvedValue({
+      serviceRouting: {
+        llmText: { backend: "elizacloud", transport: "cloud-proxy" },
+      },
+    });
+    clientMock.getLocalInferenceHub.mockResolvedValue({
+      textReadiness: {
+        slots: {
+          TEXT_SMALL: {
+            status: "missing",
+            modelId: "eliza-1-2b",
+            modelName: "eliza-1-2b",
+          },
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useHomeModelStatus());
+
+    await waitFor(
+      () => {
+        expect(clientMock.getModelsConfig).toHaveBeenCalledTimes(2);
+      },
+      { timeout: 2_500 },
+    );
+    expect(result.current.kind).toBe("not-required");
+    expect(result.current.blocksSend).toBe(false);
+    const stream = eventSourceMock.openEventSource.mock.results[0]?.value;
+    expect(stream?.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed and stops local tracking when the deferred route probe fails", async () => {
+    clientMock.getModelsConfig
+      .mockResolvedValueOnce({})
+      .mockRejectedValue(new Error("route unavailable"));
+    clientMock.getConfig.mockResolvedValue({
+      serviceRouting: {
+        llmText: { backend: "elizacloud", transport: "cloud-proxy" },
+      },
+    });
+
+    const { result } = renderHook(() => useHomeModelStatus());
+
+    await waitFor(
+      () => {
+        expect(result.current.kind).toBe("error");
+      },
+      { timeout: 2_500 },
+    );
+    expect(result.current.blocksSend).toBe(true);
+    const stream = eventSourceMock.openEventSource.mock.results[0]?.value;
+    expect(stream?.close).toHaveBeenCalledTimes(1);
   });
 
   it("surfaces a routing probe failure instead of inventing local readiness", async () => {

--- a/packages/ui/src/components/local-inference/useHomeModelStatus.test.tsx
+++ b/packages/ui/src/components/local-inference/useHomeModelStatus.test.tsx
@@ -185,15 +185,41 @@ describe("useHomeModelStatus", () => {
       textReadiness: {
         slots: {
           TEXT_SMALL: {
-            status: "missing",
-            modelId: "eliza-1-2b",
-            modelName: "eliza-1-2b",
+            slot: "TEXT_SMALL",
+            assigned: true,
+            assignedModelId: "eliza-1-2b",
+            displayName: "Eliza 1 2B",
+            primaryDownloaded: false,
+            downloaded: false,
+            active: false,
+            ready: false,
+            state: "missing",
+            requiredModelIds: ["eliza-1-2b"],
+            missingModelIds: ["eliza-1-2b"],
+            installedBytes: 0,
+            expectedBytes: 0,
+            download: {
+              state: "missing",
+              receivedBytes: 0,
+              totalBytes: 0,
+              percent: null,
+              bytesPerSec: 0,
+              etaMs: null,
+              updatedAt: null,
+              errors: [],
+            },
+            errors: [],
           },
         },
       },
     });
 
     const { result } = renderHook(() => useHomeModelStatus());
+
+    await waitFor(() => {
+      expect(result.current.kind).toBe("missing");
+      expect(result.current.blocksSend).toBe(true);
+    });
 
     await waitFor(
       () => {

--- a/packages/ui/src/components/local-inference/useHomeModelStatus.ts
+++ b/packages/ui/src/components/local-inference/useHomeModelStatus.ts
@@ -4,6 +4,7 @@
  * model placement are separate: a local agent may still send text to Cerebras.
  */
 
+import { normalizeServiceRoutingConfig } from "@elizaos/shared";
 import { useEffect, useRef, useState } from "react";
 
 import { client } from "../../api";
@@ -37,6 +38,8 @@ const ROUTING_STATUS_ERROR: HomeModelStatus = {
   errors: ["Could not verify the active text model provider."],
 };
 
+const CLOUD_ROUTE_RECHECK_MS = 1_000;
+
 function appendTokenParam(url: string): string {
   const token = getElizaApiToken()?.trim();
   if (!token) return url;
@@ -59,6 +62,7 @@ function supportsLocalInferenceStatus(): boolean {
 export function useHomeModelStatus(): HomeModelStatus {
   const [status, setStatus] = useState<HomeModelStatus>(NOT_REQUIRED);
   const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const routingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const runtimeMode = useRuntimeMode();
   // Auth gate (#11084): the shell mounts this hook before the auth probe
   // resolves, so the download SSE stream + hub fetches must stay dormant until
@@ -80,6 +84,51 @@ export function useHomeModelStatus(): HomeModelStatus {
 
     let cancelled = false;
     let eventSource: ReturnType<typeof openEventSource> = null;
+    let activeRouteResolved = false;
+
+    const stopLocalStatusTracking = (nextStatus: HomeModelStatus) => {
+      activeRouteResolved = true;
+      if (refreshTimerRef.current) {
+        clearTimeout(refreshTimerRef.current);
+        refreshTimerRef.current = null;
+      }
+      if (routingTimerRef.current) {
+        clearTimeout(routingTimerRef.current);
+        routingTimerRef.current = null;
+      }
+      eventSource?.close();
+      eventSource = null;
+      if (!cancelled) setStatus(nextStatus);
+    };
+
+    const probeActiveRoute = async (): Promise<
+      "active" | "pending" | "error"
+    > => {
+      try {
+        const modelConfig = await client.getModelsConfig();
+        if (cancelled) return "pending";
+        if (modelConfig.activeChat) {
+          stopLocalStatusTracking(NOT_REQUIRED);
+          return "active";
+        }
+        return "pending";
+      } catch {
+        // error-policy:J4 The composer distinguishes an unavailable routing
+        // probe from both a healthy external route and local-model readiness.
+        stopLocalStatusTracking(ROUTING_STATUS_ERROR);
+        return "error";
+      }
+    };
+
+    const scheduleCloudRouteRecheck = () => {
+      if (cancelled || activeRouteResolved || routingTimerRef.current) return;
+      routingTimerRef.current = setTimeout(() => {
+        routingTimerRef.current = null;
+        void probeActiveRoute().then((result) => {
+          if (result === "pending") scheduleCloudRouteRecheck();
+        });
+      }, CLOUD_ROUTE_RECHECK_MS);
+    };
 
     const refresh = async () => {
       if (!supportsLocalInferenceStatus()) {
@@ -88,24 +137,34 @@ export function useHomeModelStatus(): HomeModelStatus {
       }
       try {
         const hub = await client.getLocalInferenceHub();
-        if (!cancelled) setStatus(deriveHomeModelStatus(hub.textReadiness));
+        if (!cancelled && !activeRouteResolved) {
+          setStatus(deriveHomeModelStatus(hub.textReadiness));
+        }
       } catch {
         // Keep the last good status; the stream will trigger another refresh.
       }
     };
 
     const start = async () => {
+      const routeState = await probeActiveRoute();
+      if (routeState !== "pending" || cancelled) return;
+
       try {
-        const modelConfig = await client.getModelsConfig();
+        const config = await client.getConfig();
         if (cancelled) return;
-        if (modelConfig.activeChat) {
-          setStatus(NOT_REQUIRED);
-          return;
+        const textRoute = normalizeServiceRoutingConfig(
+          config.serviceRouting,
+        )?.llmText;
+        if (
+          textRoute?.backend === "elizacloud" &&
+          textRoute.transport === "cloud-proxy"
+        ) {
+          scheduleCloudRouteRecheck();
         }
       } catch {
-        // error-policy:J4 The composer distinguishes an unavailable routing
-        // probe from both a healthy external route and local-model readiness.
-        if (!cancelled) setStatus(ROUTING_STATUS_ERROR);
+        // error-policy:J4 Without the configured-route snapshot the composer
+        // cannot safely decide whether local readiness is relevant.
+        stopLocalStatusTracking(ROUTING_STATUS_ERROR);
         return;
       }
 
@@ -132,7 +191,14 @@ export function useHomeModelStatus(): HomeModelStatus {
 
     return () => {
       cancelled = true;
-      if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
+      if (refreshTimerRef.current) {
+        clearTimeout(refreshTimerRef.current);
+        refreshTimerRef.current = null;
+      }
+      if (routingTimerRef.current) {
+        clearTimeout(routingTimerRef.current);
+        routingTimerRef.current = null;
+      }
       eventSource?.close();
     };
   }, [

--- a/packages/ui/src/first-run/use-model-status-conductor.test.ts
+++ b/packages/ui/src/first-run/use-model-status-conductor.test.ts
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
     setLocalInferencePreferredProvider: vi.fn(async () => ({
       preferences: {},
     })),
+    setLocalInferenceTextRouting: vi.fn(async () => ({ preferences: {} })),
   },
 }));
 
@@ -139,18 +140,20 @@ describe("useModelStatusConductor", () => {
     unmount();
   });
 
-  it("switch-cloud → routes both text slots to elizacloud", async () => {
+  it("switch-cloud → atomically routes both text slots to elizacloud", async () => {
     const { card, unmount } = renderConductor(DOWNLOADING);
     await waitFor(() => expect(card()).toBeTruthy());
     tryHandleModelAction("__model__:switch-cloud");
     await waitFor(() =>
-      expect(
-        mocks.client.setLocalInferencePreferredProvider,
-      ).toHaveBeenCalledWith("TEXT_LARGE", "elizacloud"),
+      expect(mocks.client.setLocalInferenceTextRouting).toHaveBeenCalledWith(
+        "elizacloud",
+        "manual",
+      ),
     );
+    expect(mocks.client.setLocalInferenceTextRouting).toHaveBeenCalledTimes(1);
     expect(
       mocks.client.setLocalInferencePreferredProvider,
-    ).toHaveBeenCalledWith("TEXT_SMALL", "elizacloud");
+    ).not.toHaveBeenCalled();
     expect(card()?.text).toContain("Eliza Cloud");
     unmount();
   });

--- a/packages/ui/src/first-run/use-model-status-conductor.ts
+++ b/packages/ui/src/first-run/use-model-status-conductor.ts
@@ -21,7 +21,6 @@ import type { ConversationMessage } from "../api";
 import { client } from "../api";
 import { useShellControllerContext } from "../components/shell/ShellControllerContext.hooks";
 import type { HomeModelStatus } from "../services/local-inference/home-model-status";
-import { TEXT_GENERATION_SLOTS } from "../services/local-inference/types";
 import { useConversationMessages } from "../state/ConversationMessagesContext.hooks";
 import {
   MODEL_ACTION_PREFIX,
@@ -243,11 +242,8 @@ export function useModelStatusConductor(status: HomeModelStatus): void {
           choices: [],
         });
         busyRef.current = true;
-        void Promise.all(
-          TEXT_GENERATION_SLOTS.map((slot) =>
-            client.setLocalInferencePreferredProvider(slot, "elizacloud"),
-          ),
-        )
+        void client
+          .setLocalInferenceTextRouting("elizacloud", "manual")
           // error-policy:J4 — a failed provider switch is surfaced as a card.
           .catch((err: unknown) => {
             pinOverride({


### PR DESCRIPTION
# Relates to

Closes #20178.

Supersedes #20205 after independent review found that its fixed retry schedule permanently stopped checking after 15.75 seconds and it lacked the issue-required desktop/mobile walkthrough evidence.

# Summary

Releases the deferred local-model startup gate when the authoritative text route changes to `elizacloud/cloud-proxy`, without requiring a reload.

The UI now treats `/api/models/config` as the authoritative route source. While startup has not selected an active route, it rechecks without overlapping requests; once Cloud is selected it stops local readiness timers and streams immediately. Local routes do not poll, and route/config failures remain visibly failed rather than being presented as success.

The local-inference client also exposes the existing atomic text-routing endpoint, and the conductor uses that single mutation instead of separate chat and embedding writes.

# Risk

Low to moderate. The change is limited to startup route observation and the existing routing client boundary. The recheck runs only while the route is unresolved, never overlaps, and is cleaned up on route resolution, failure, or unmount. Local-only startup behavior is unchanged.

# Verification

- Required full `bun install`: pass with Bun 1.3.14 / Node 24.15.0 and complete artifact sync.
- UI focused hook/client/conductor tests: 25/25.
- plugin-local-inference real server route tests: 33/33.
- Browser renderer regression: 2/2 at desktop 1440x900 and mobile 390x844.
- UI typecheck: pass.
- Changed-file Biome and `git diff --check`: pass.
- App audit: 219/219 captures reviewed; broken=0, needs-work=0; OCR broken=0.
- Exact-head root `bun run verify`: 351/351 tasks plus every audit; 8,265 test files, 0 focused tests, 0 orphaned skips.

# Evidence gate

<!-- evidence-head:84234ccb9211102bd7dc47588181ea818e8f9b97 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20244-before-desktop-mobile.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20244-after-desktop-mobile.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20244-desktop-mobile-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - browser regression uses deterministic mocked startup APIs; the real atomic server route is covered by 33/33 route tests
<!-- evidence-row:frontend-logs -->
- [x] [20244-frontend-diagnostics.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20244-frontend-diagnostics.txt)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, action, or planner behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistence or domain artifact changed
<!-- evidence-row:ocr-review -->
- [x] [20244-ocr-report.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20244-ocr-report.txt)

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - contribute-to-eliza skill was not available in this session`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - contribute-to-eliza skill was not available in this session
Attribution status: self-reported
— [codex-20178-cloud-gate]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - contribute-to-eliza skill was not available in this session"} -->


