### PR TITLE
fix(core): degrade model-invented [LINK:] pseudo-markers to real links

### DIFF
--- a/packages/core/src/services/message/outbound-sanitize.test.ts
+++ b/packages/core/src/services/message/outbound-sanitize.test.ts
@@ -337,6 +337,41 @@ describe("model-invented [LINK:] pseudo-markers", () => {
 		).toBe("see https://example.com/x for details");
 	});
 
+	it("degrades marker names case-insensitively", () => {
+		expect(sanitizeOutboundText("[link:https://example.com/x](lower)")).toBe(
+			"[lower](https://example.com/x)",
+		);
+		expect(sanitizeOutboundText("[LiNk:https://example.com/y]")).toBe(
+			"https://example.com/y",
+		);
+	});
+
+	it("preserves balanced parentheses in labels and destinations", () => {
+		expect(
+			sanitizeOutboundText(
+				"[LINK:https://example.com/a_(b)](Release notes (August))",
+			),
+		).toBe("[Release notes (August)](https://example.com/a_\\(b\\))");
+	});
+
+	it("escapes label delimiters so they cannot replace the http destination", () => {
+		expect(
+			sanitizeOutboundText(
+				"[LINK:https://safe.example](x](javascript:alert(1)))",
+			),
+		).toBe("[x\\](javascript:alert(1))](https://safe.example)");
+	});
+
+	it("leaves malformed or non-http pseudo-links unchanged", () => {
+		for (const text of [
+			"[LINK:javascript:alert(1)](bad)",
+			"[LINK:https://example.com](unclosed",
+			"[LINK:not a url]",
+		]) {
+			expect(sanitizeOutboundText(text)).toBe(text);
+		}
+	});
+
 	it("degrades an empty-label pseudo-link to its URL", () => {
 		expect(sanitizeOutboundText("go [LINK:https://example.com/y]()")).toBe(
 			"go https://example.com/y",

--- a/packages/core/src/services/message/outbound-sanitize.test.ts
+++ b/packages/core/src/services/message/outbound-sanitize.test.ts
@@ -321,3 +321,37 @@ describe("sanitizeOutboundText — pass-through and idempotence", () => {
 		}
 	});
 });
+
+describe("model-invented [LINK:] pseudo-markers", () => {
+	it("degrades a labeled pseudo-link to a real markdown link", () => {
+		expect(
+			sanitizeOutboundText(
+				"news here. [LINK:https://example.com/a-story](IBM x OpenAI) more.",
+			),
+		).toBe("news here. [IBM x OpenAI](https://example.com/a-story) more.");
+	});
+
+	it("degrades a bare pseudo-link to its URL", () => {
+		expect(
+			sanitizeOutboundText("see [LINK:https://example.com/x] for details"),
+		).toBe("see https://example.com/x for details");
+	});
+
+	it("degrades an empty-label pseudo-link to its URL", () => {
+		expect(sanitizeOutboundText("go [LINK:https://example.com/y]()")).toBe(
+			"go https://example.com/y",
+		);
+	});
+
+	it("leaves real markdown links and bracketed prose untouched", () => {
+		const text = "[a real link](https://example.com) and [LINKAGE:notes] stay";
+		expect(sanitizeOutboundText(text)).toBe(text);
+	});
+
+	it("is idempotent over pseudo-link degrades", () => {
+		const once = sanitizeOutboundText(
+			"[LINK:https://example.com/a](A) and [LINK:https://example.com/b]",
+		);
+		expect(sanitizeOutboundText(once)).toBe(once);
+	});
+});

--- a/packages/core/src/services/message/outbound-sanitize.ts
+++ b/packages/core/src/services/message/outbound-sanitize.ts
@@ -83,8 +83,17 @@ const CODE_SENTINEL_PREFIX = "\x00CB";
  * documentation examples of the syntax survive. Idempotent — sanitizing
  * already-sanitized text is a no-op.
  */
+/** Model-invented `[LINK:<url>](label)` / `[LINK:<url>]` pseudo-markers. No
+ * surface defines or renders a LINK marker — the model conflates the
+ * dashboard marker family with markdown links (observed live: api news
+ * replies carrying `[LINK:https://…](label)` verbatim). Degrade to a real
+ * markdown link / bare URL so the link survives instead of leaking wire
+ * syntax. */
+const PSEUDO_LINK_LABELED_RE = /\[LINK:(https?:\/\/[^\]\s]+)\]\(([^)]*)\)/gi;
+const PSEUDO_LINK_BARE_RE = /\[LINK:(https?:\/\/[^\]\s]+)\]/gi;
+
 export function sanitizeOutboundText(text: string): string {
-	if (!text || !QUICK_TAG_RE.test(text)) {
+	if (!text || (!QUICK_TAG_RE.test(text) && !text.includes("[LINK:"))) {
 		return text;
 	}
 
@@ -99,6 +108,13 @@ export function sanitizeOutboundText(text: string): string {
 	processed = processed.replace(INLINE_CODE_RE, saveSpan);
 
 	processed = processed.replace(SELF_CLOSING_ARTIFACTS_RE, "");
+
+	processed = processed.replace(
+		PSEUDO_LINK_LABELED_RE,
+		(_match, url: string, label: string) =>
+			label.trim().length > 0 ? `[${label.trim()}](${url})` : url,
+	);
+	processed = processed.replace(PSEUDO_LINK_BARE_RE, "$1");
 
 	for (const tag of MACHINE_SYNTAX_TAGS) {
 		const paired = new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)<\\/${tag}>`, "gi");

--- a/packages/core/src/services/message/outbound-sanitize.ts
+++ b/packages/core/src/services/message/outbound-sanitize.ts
@@ -75,6 +75,85 @@ const INLINE_CODE_RE = /(`+)[^`\n]+?\1(?!`)/g;
 // NUL-marker on the wire.
 const CODE_SENTINEL_PREFIX = "\x00CB";
 
+const PSEUDO_LINK_START_RE = /\[LINK:/gi;
+
+function isValidPseudoLinkUrl(url: string): boolean {
+	if (/\s/.test(url)) return false;
+	try {
+		const protocol = new URL(url).protocol;
+		return protocol === "http:" || protocol === "https:";
+	} catch {
+		// error-policy:J3 model-authored pseudo-link URLs fail closed.
+		return false;
+	}
+}
+
+function findBalancedLabelEnd(text: string, start: number): number | undefined {
+	let depth = 1;
+	for (let index = start; index < text.length; index++) {
+		if (text[index] === "\\") {
+			index++;
+			continue;
+		}
+		if (text[index] === "(") depth++;
+		if (text[index] !== ")") continue;
+		depth--;
+		if (depth === 0) return index;
+	}
+	return undefined;
+}
+
+function formatPseudoLink(url: string, label: string | undefined): string {
+	if (!label?.trim()) return url;
+	const safeLabel = label.trim().replace(/\\|\[|\]/g, "\\$&");
+	const safeDestination = url
+		.replace(/\\/g, "%5C")
+		.replace(/</g, "%3C")
+		.replace(/>/g, "%3E")
+		.replace(/[()]/g, "\\$&");
+	return `[${safeLabel}](${safeDestination})`;
+}
+
+/**
+ * Degrade model-invented `[LINK:<url>](label)` / `[LINK:<url>]` markers to
+ * ordinary Markdown without allowing label delimiters to change the link
+ * destination. Parentheses in labels are balanced because generated titles
+ * commonly contain them; malformed markers remain visible instead of being
+ * partially rewritten.
+ */
+function degradePseudoLinks(text: string): string {
+	let output = "";
+	let cursor = 0;
+	PSEUDO_LINK_START_RE.lastIndex = 0;
+	for (
+		let match = PSEUDO_LINK_START_RE.exec(text);
+		match;
+		match = PSEUDO_LINK_START_RE.exec(text)
+	) {
+		const markerStart = match.index;
+		const urlStart = PSEUDO_LINK_START_RE.lastIndex;
+		const urlEnd = text.indexOf("]", urlStart);
+		if (urlEnd < 0) break;
+		const url = text.slice(urlStart, urlEnd);
+		if (!isValidPseudoLinkUrl(url)) continue;
+
+		let markerEnd = urlEnd + 1;
+		let label: string | undefined;
+		if (text[markerEnd] === "(") {
+			const labelEnd = findBalancedLabelEnd(text, markerEnd + 1);
+			if (labelEnd === undefined) continue;
+			label = text.slice(markerEnd + 1, labelEnd);
+			markerEnd = labelEnd + 1;
+		}
+
+		output += text.slice(cursor, markerStart);
+		output += formatPseudoLink(url, label);
+		cursor = markerEnd;
+		PSEUDO_LINK_START_RE.lastIndex = markerEnd;
+	}
+	return cursor === 0 ? text : output + text.slice(cursor);
+}
+
 /**
  * Strip machine syntax from outbound agent text. Paired tags are removed with
  * their contents; an unclosed tag is removed to end-of-text (the live-observed
@@ -83,19 +162,11 @@ const CODE_SENTINEL_PREFIX = "\x00CB";
  * documentation examples of the syntax survive. Idempotent — sanitizing
  * already-sanitized text is a no-op.
  */
-/** Model-invented `[LINK:<url>](label)` / `[LINK:<url>]` pseudo-markers. No
- * surface defines or renders a LINK marker — the model conflates the
- * dashboard marker family with markdown links (observed live: api news
- * replies carrying `[LINK:https://…](label)` verbatim). Degrade to a real
- * markdown link / bare URL so the link survives instead of leaking wire
- * syntax. */
-const PSEUDO_LINK_LABELED_RE = /\[LINK:(https?:\/\/[^\]\s]+)\]\(([^)]*)\)/gi;
-const PSEUDO_LINK_BARE_RE = /\[LINK:(https?:\/\/[^\]\s]+)\]/gi;
-
 export function sanitizeOutboundText(text: string): string {
-	if (!text || (!QUICK_TAG_RE.test(text) && !text.includes("[LINK:"))) {
+	if (!text || (!QUICK_TAG_RE.test(text) && !PSEUDO_LINK_START_RE.test(text))) {
 		return text;
 	}
+	PSEUDO_LINK_START_RE.lastIndex = 0;
 
 	const codeSpans: string[] = [];
 	const saveSpan = (match: string): string => {
@@ -109,12 +180,7 @@ export function sanitizeOutboundText(text: string): string {
 
 	processed = processed.replace(SELF_CLOSING_ARTIFACTS_RE, "");
 
-	processed = processed.replace(
-		PSEUDO_LINK_LABELED_RE,
-		(_match, url: string, label: string) =>
-			label.trim().length > 0 ? `[${label.trim()}](${url})` : url,
-	);
-	processed = processed.replace(PSEUDO_LINK_BARE_RE, "$1");
+	processed = degradePseudoLinks(processed);
 
 	for (const tag of MACHINE_SYNTAX_TAGS) {
 		const paired = new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)<\\/${tag}>`, "gi");


### PR DESCRIPTION
Model-invented `[LINK:<url>](label)` and `[LINK:<url>]` pseudo-markers could reach API and connector replies as raw wire-like syntax. This change degrades valid markers to ordinary Markdown links or bare URLs at the shared outbound boundary.

## Evidence provenance

- Evidence head: `77c3d9aee85259cfe8ec8710f14be0662756e675`
- Base: `origin/develop` at `09df2333430b8e497aa58491c9de0ccf68e6df17`
- Supersedes the original PR head `e2544d64319c62c32896364670087cea1bcf8897`, whose flat regex corrupted balanced parenthetical labels and could let label delimiters change Markdown structure.
- The branch was merged concurrently at `2026-08-15T23:24:28Z`, before the handoff could transition it to draft. The API/connector and CI evidence below remain outstanding post-merge.

## What changed

- Recognizes marker names case-insensitively without a case-sensitive fast-path bypass.
- Uses a bounded synchronous scanner that validates `http:`/`https:` URLs, balances escaped/nested label parentheses, and leaves malformed or non-http markers unchanged.
- Escapes Markdown label delimiters and destination-sensitive characters so model-authored label text cannot replace the validated HTTP destination.
- Preserves the existing fenced-code/inline-code shielding, machine-syntax stripping, trimming, and idempotence behavior.
- Adds adversarial coverage for mixed-case markers, balanced parentheses, delimiter injection, malformed markers, non-http schemes, code preservation, and repeated sanitization.

The app chat surface renders message prose as plain text, so this normalization does not introduce a new app Markdown renderer. It benefits raw API output, Markdown-aware connectors, and bare-URL autolinking.

## Exact-head validation

- Focused outbound-sanitizer suite: 38 passed, 0 failed
- `bun run --cwd packages/core typecheck`: passed
- Biome over both changed files: passed, no fixes
- `git diff --check origin/develop...HEAD`: passed

## Outstanding post-merge evidence

- Exact-head raw API response proving labeled and bare pseudo-markers degrade as specified without changing surrounding prose.
- Exact-head supported connector reproduction proving the link is delivered/rendered correctly, including a parenthetical title and an adversarial delimiter label.
- Required GitHub CI checks green on this evidence head (GitHub reported no checks when it merged).

No deployment was performed while preparing this handoff.
