### PR TITLE
fix(core): ship stage-1's grounded decline when the planner surface is terminal-only

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -4448,3 +4448,82 @@ describe("tool-turn reply guarantee (#16935)", () => {
 		);
 	});
 });
+
+describe("terminal-only tool surface short-circuit", () => {
+	const terminalOnlyTools = [
+		{ name: "REPLY", description: "Reply to the user." },
+		{ name: "IGNORE", description: "Ignore the message." },
+		{ name: "STOP", description: "Stop the conversation." },
+	];
+	const baseContext = {
+		id: "ctx",
+		staticPrefix: {
+			characterPrompt: { content: "agent_name: Eliza", stable: true },
+		},
+		events: [
+			{
+				id: "msg",
+				type: "message" as const,
+				message: {
+					role: "user" as const,
+					content: { text: "send a text message to my mom" },
+				},
+			},
+		],
+	};
+
+	it("ships the answer-shaped stage-1 decline without a model call", async () => {
+		const runtime = { useModel: vi.fn(), getService: vi.fn(() => null) };
+		const result = await runPlannerLoop({
+			runtime,
+			context: baseContext,
+			tools: terminalOnlyTools,
+			stageOneReplyText:
+				"can't do that from here. i don't have phone/sms access configured.",
+			executeToolCall: vi.fn(),
+			evaluate: vi.fn(),
+		});
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(
+			"can't do that from here. i don't have phone/sms access configured.",
+		);
+		expect(runtime.useModel).not.toHaveBeenCalled();
+	});
+
+	it("still runs the loop when the stage-1 draft is not answer-shaped", async () => {
+		const runtime = {
+			useModel: vi.fn(async () => ({
+				text: '{"success":true,"decision":"FINISH","thought":"done","messageToUser":"nothing to run here."}',
+			})),
+			getService: vi.fn(() => null),
+		};
+		const result = await runPlannerLoop({
+			runtime,
+			context: baseContext,
+			tools: terminalOnlyTools,
+			stageOneReplyText: "On it.",
+			executeToolCall: vi.fn(),
+			evaluate: vi.fn(),
+		});
+		expect(runtime.useModel).toHaveBeenCalled();
+		expect(result.status).toBe("finished");
+	});
+
+	it("does not short-circuit the deliberate no-tools planning mode", async () => {
+		const runtime = {
+			useModel: vi.fn(async () => ({
+				text: '{"success":true,"decision":"FINISH","thought":"done","messageToUser":"the capital is ulaanbaatar."}',
+			})),
+			getService: vi.fn(() => null),
+		};
+		await runPlannerLoop({
+			runtime,
+			context: baseContext,
+			stageOneReplyText:
+				"can't do that from here. i don't have phone/sms access configured.",
+			executeToolCall: vi.fn(),
+			evaluate: vi.fn(),
+		});
+		expect(runtime.useModel).toHaveBeenCalled();
+	});
+});

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -394,6 +394,41 @@ async function runPlannerLoopIterations(
 	const requireNonTerminalToolCall =
 		(params.requireNonTerminalToolCall === true || codingMode) &&
 		hasExposedNonTerminalTool(params.tools);
+	// A PRESENT but terminal-only surface (REPLY/IGNORE/STOP and nothing else)
+	// means every stage-1 candidate failed to resolve to a runnable action —
+	// the turn has zero capability. Running a planner round anyway hands a
+	// fresh model call the chance to improvise around the missing capability:
+	// observed live ("send a text to my mom"), stage-1 drafted an honest
+	// "no phone/sms access configured" decline and the terminal-only round
+	// replaced it with "need your mom's phone number or iMessage handle" — an
+	// ask implying a surface this runtime does not have. When stage-1 already
+	// produced an answer-shaped reply, ship it and skip the round entirely
+	// (grounded decline + one model call saved). An undefined/empty tools
+	// param stays on the normal path — that is the deliberate no-actions-gated
+	// planning mode, not a failed resolution — and an ack-shaped stage-1 draft
+	// falls through so the loop can still produce a real answer.
+	if (
+		params.tools !== undefined &&
+		params.tools.length > 0 &&
+		!hasExposedNonTerminalTool(params.tools)
+	) {
+		const stageOneDecline = userSafeCapturedAnswerCandidate(
+			params.stageOneReplyText,
+		);
+		if (stageOneDecline !== undefined) {
+			return {
+				status: "finished",
+				trajectory: {
+					context: plannerContext,
+					steps: [],
+					archivedSteps: [],
+					plannedQueue: [],
+					evaluatorOutputs: [],
+				},
+				finalMessage: stageOneDecline,
+			};
+		}
+	}
 	// Stage 1's own answer for this turn, shape-guarded once up front. Consulted
 	// only when the required-tool gate exhausts without a captured refusal — the
 	// ground-truth answer Stage 1 already produced beats the caller's generic


### PR DESCRIPTION
When every stage-1 candidate fails to resolve (planner surface = REPLY/IGNORE/STOP only) and stage-1 drafted an answer-shaped reply, ship the grounded draft and skip the planner round — kills the improv-around-missing-capability class (live: honest 'no sms access' draft replaced by 'need your mom's phone number'). Also saves one model call per such turn. Evidence: planner-loop suite 121/121 on this branch; live re-probe on box post-fix returned the honest decline.

Box-carry upstream (same flow as #20219/#20220): authored and live-proven on the box by the watchtower/verify lane under nubs's fix-all order (receipts: HQ 18035333 + the fix-all batch post), cherry-picked with authorship preserved from the live checkout's `resync/nubilio-20260815i`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)