### PR TITLE
feat(pa): explicit one-turn undated todo saves immediately

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -3080,6 +3080,7 @@ function shouldRequireLifeCreateConfirmation(args: {
   requestKind?: NativeAppleReminderLikeKind | null;
   cadence?: LifeOpsCadence;
   multiStep?: boolean;
+  explicitUndated?: boolean;
 }): boolean {
   if (args.messageSource === "autonomy") {
     return false;
@@ -3090,6 +3091,20 @@ function shouldRequireLifeCreateConfirmation(args: {
   // the two-phase preview even when extraction resolved a once cadence
   // (#16941 live finding: the exemption over-triggered and wrote pre-consent).
   if (args.requestKind && args.cadence?.kind === "once" && !args.multiStep) {
+    return false;
+  }
+  // #16935 symmetry for undated todos: when the owner's own words state both
+  // halves — the item AND that it has no date ("add a todo: X, no deadline") —
+  // a preview would ask them to confirm exactly what they just said. Scoped to
+  // an EXPLICIT textual no-date statement (the same canonical authority that
+  // guards the unscheduled-cadence wipe), single-step asks only, mirroring the
+  // #16941 over-trigger guard. An extraction-inferred unscheduled cadence
+  // without the explicit statement still previews.
+  if (
+    args.cadence?.kind === "unscheduled" &&
+    args.explicitUndated === true &&
+    !args.multiStep
+  ) {
     return false;
   }
   return !args.confirmed;
@@ -4682,6 +4697,7 @@ async function runLifeOperationHandlerInner(
           requestKind: timedRequestKind,
           cadence: definitionDraft.request.cadence,
           multiStep: llmPlan?.multiStep === true,
+          explicitUndated: textStatesExplicitUndatedTodo(currentText),
         })
       ) {
         const draftLeadSteps = (


### PR DESCRIPTION
#16935 symmetry: cadence unscheduled + textStatesExplicitUndatedTodo(currentText) + !multiStep skips the confirm preview — 'add a todo: oil the hinge, no deadline needed, just a general todo' saves in ONE turn. Closes the battery50c amber; nubs answered the design question by ordering fix-all. Evidence: deferred-draft + undated-intent + review-definitions suites 79/79 on this branch; live one-turn save proven on box (persisted + listed).

Box-carry upstream (same flow as #20219/#20220): authored and live-proven on the box by the watchtower/verify lane under nubs's fix-all order (receipts: HQ 18035333 + the fix-all batch post), cherry-picked with authorship preserved from the live checkout's `resync/nubilio-20260815i`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)