### PR TITLE
fix(core): promote short progress-shaped simple-path acks to planning

### DIFF
--- a/packages/core/src/runtime/__tests__/message-handler.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler.test.ts
@@ -238,6 +238,39 @@ describe("v5 message handler routing", () => {
 		}
 	});
 
+
+	it("promotes a short progress-shaped ack on the pure-simple path to planning", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "checking paris weather now",
+				contexts: ["simple"],
+				candidateActionNames: [],
+			}),
+		);
+		expect(parsed).not.toBeNull();
+		if (!parsed) return;
+		const route = routeMessageHandlerOutput(parsed);
+		expect(route.type).toBe("planning_needed");
+		if (route.type === "planning_needed") {
+			expect(route.contexts).toEqual(["general"]);
+		}
+	});
+
+	it("keeps a conversational let-me-know close as a final reply", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "let me know if you need anything else",
+				contexts: ["simple"],
+				candidateActionNames: [],
+			}),
+		);
+		expect(parsed).not.toBeNull();
+		if (!parsed) return;
+		expect(routeMessageHandlerOutput(parsed).type).toBe("final_reply");
+	});
+
 	it("does not force planning for explanatory gerunds that are substantive answers", () => {
 		const parsed = parseMessageHandlerOutput(
 			JSON.stringify({

--- a/packages/core/src/runtime/message-handler.ts
+++ b/packages/core/src/runtime/message-handler.ts
@@ -13,6 +13,19 @@ import type {
 import type { AgentContext } from "../types/contexts";
 import { normalizeTopics } from "./builtin-field-evaluators";
 import { parseJsonObject, stripJsonStructuralJunkReply } from "./json-output";
+/** Simple-path promotion trigger for progress-shaped acks. A deliberate
+ * SUBSET of planner-loop's PROGRESS_ONLY_REPLY_OPENERS_PATTERN: action-verb
+ * openers only — bare "I'll"/"I will" shapes are routinely legitimate final
+ * replies, and "let me know …" is the widget-reply-safe conversational close
+ * (same negative lookahead as WIDGET_REPLY_IN_FLIGHT_CLAIM). Paired with a
+ * length cap because an in-flight ack is by nature brief while a substantive
+ * answer that merely OPENS with a gerund runs long ("Checking accounts are
+ * bank accounts designed for …" must stay a final reply). */
+const SIMPLE_PATH_PROGRESS_ACK_RE = new RegExp(
+	"^(?:checking|fetching|gathering|looking (?:up|into)|running|using|spawning|starting|working on|one moment|on it\\b|let me (?!know\\b))",
+	"i",
+);
+const SIMPLE_PATH_PROGRESS_ACK_MAX_LENGTH = 64;
 import {
 	looksLikeRawFieldTranscript,
 	parseFieldTranscript,
@@ -315,9 +328,32 @@ export function routeMessageHandlerOutput(
 	}
 
 	if (nonSimpleContexts.length === 0) {
+		const reply = getMessageHandlerReply(output);
+		// A progress-shaped reply on the pure-simple path is a self-contradiction:
+		// "checking paris weather now" promises tool work, and the simple path
+		// runs no tools — shipping it as the WHOLE turn is the bare-ack class
+		// (nothing else ever happens). Stage 1 sometimes emits this shape with
+		// NEITHER requiresTool NOR candidateActions set (live: a two-tool
+		// "check the weather in paris and save a note" turn classified
+		// contexts=["simple"], reply="checking paris weather now", no promotion
+		// trigger fired, user got the ack and nothing else). The reply text
+		// itself is the reliable signal — promote to planning exactly like the
+		// candidateActions contradiction above. Narrow opener set only:
+		// "got it"/"okay" style acknowledgements are legitimate final replies
+		// (memory-store turns) and must not promote.
+		if (
+			reply.length <= SIMPLE_PATH_PROGRESS_ACK_MAX_LENGTH &&
+			SIMPLE_PATH_PROGRESS_ACK_RE.test(reply)
+		) {
+			return {
+				type: "planning_needed",
+				output,
+				contexts: ["general"],
+			};
+		}
 		return {
 			type: "final_reply",
-			reply: getMessageHandlerReply(output),
+			reply,
 			output,
 		};
 	}


### PR DESCRIPTION
Short progress-shaped acks ('checking…', 'on it') on the simple path shipped as final turn text with no follow-through. Promote them to the planning path so the promised work actually runs. Evidence: message-handler suite 25/25 on this branch; live-proven on box.

Box-carry upstream (same flow as #20219/#20220): authored and live-proven on the box by the watchtower/verify lane under nubs's fix-all order (receipts: HQ 18035333 + the fix-all batch post), cherry-picked with authorship preserved from the live checkout's `resync/nubilio-20260815i`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)