### PR TITLE
fix(tools): make WEB_SEARCH/WEB_FETCH reachable from the web context

### DIFF
--- a/plugins/plugin-coding-tools/src/actions/web-fetch.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-fetch.test.ts
@@ -77,6 +77,19 @@ describe("coding-tools WEB_FETCH", () => {
     __resetWebHttpTestOverrides();
   });
 
+  it("is reachable from web turns without widening its admin role gate", () => {
+    expect(webFetchAction.contexts).toEqual([
+      "code",
+      "terminal",
+      "automation",
+      "web",
+    ]);
+    expect(webFetchAction.contextGate).toEqual({
+      anyOf: ["code", "terminal", "automation", "web"],
+    });
+    expect(webFetchAction.roleGate).toEqual({ minRole: "ADMIN" });
+  });
+
   it("advertises exact live endpoints as the fresh-data path", () => {
     expect(webFetchAction.routingHint).toContain("live NOW-values");
     expect(webFetchAction.routingHint).toContain("api.coingecko.com");

--- a/plugins/plugin-coding-tools/src/actions/web-fetch.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-fetch.ts
@@ -132,8 +132,14 @@ function extractBody(
 
 export const webFetchAction: Action = {
   name: "WEB_FETCH",
-  contexts: [...CODING_TOOLS_CONTEXTS],
-  contextGate: { anyOf: [...CODING_TOOLS_CONTEXTS] },
+  // "web" belongs alongside the coding contexts: stage-1's routing vocabulary
+  // names `web` for live-lookup turns, and an action literally named
+  // WEB_SEARCH/WEB_FETCH being unreachable from the `web` context left
+  // candidate-less web turns with no web tool on the planner surface
+  // (observed live: a weather+note composite surfaced only the CONTACT
+  // family).
+  contexts: [...CODING_TOOLS_CONTEXTS, "web"],
+  contextGate: { anyOf: [...CODING_TOOLS_CONTEXTS, "web"] },
   roleGate: { minRole: "ADMIN" },
   similes: ["LOOKUP_WEB", "WEB_LOOKUP", "FETCH_URL", "HTTP_GET", "GET_URL"],
   routingHint:

--- a/plugins/plugin-coding-tools/src/actions/web-search.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-search.test.ts
@@ -89,6 +89,19 @@ describe("coding-tools WEB_SEARCH", () => {
     vi.unstubAllGlobals();
   });
 
+  it("is reachable from web turns without widening its admin role gate", () => {
+    expect(webSearchAction.contexts).toEqual([
+      "code",
+      "terminal",
+      "automation",
+      "web",
+    ]);
+    expect(webSearchAction.contextGate).toEqual({
+      anyOf: ["code", "terminal", "automation", "web"],
+    });
+    expect(webSearchAction.roleGate).toEqual({ minRole: "ADMIN" });
+  });
+
   it("keeps discovery in search while routing constructable live values to fetch", () => {
     expect(webSearchAction.routingHint).toContain("open-ended external info");
     expect(webSearchAction.routingHint).toContain("live NOW-value");

--- a/plugins/plugin-coding-tools/src/actions/web-search.ts
+++ b/plugins/plugin-coding-tools/src/actions/web-search.ts
@@ -51,8 +51,14 @@ export function isCodingWebSearchEnabled(): boolean {
 
 export const webSearchAction: Action = {
   name: "WEB_SEARCH",
-  contexts: [...CODING_TOOLS_CONTEXTS],
-  contextGate: { anyOf: [...CODING_TOOLS_CONTEXTS] },
+  // "web" belongs alongside the coding contexts: stage-1's routing vocabulary
+  // names `web` for live-lookup turns, and an action literally named
+  // WEB_SEARCH/WEB_FETCH being unreachable from the `web` context left
+  // candidate-less web turns with no web tool on the planner surface
+  // (observed live: a weather+note composite surfaced only the CONTACT
+  // family).
+  contexts: [...CODING_TOOLS_CONTEXTS, "web"],
+  contextGate: { anyOf: [...CODING_TOOLS_CONTEXTS, "web"] },
   roleGate: { minRole: "ADMIN" },
   similes: ["SEARCH_WEB", "WEB_QUERY", "FIND_ONLINE", "SEARCH_INTERNET"],
   routingHint:


### PR DESCRIPTION
WEB_SEARCH/WEB_FETCH validate gates missed the Stage-1 `web` context, leaving composite live-web asks without either web action on the coding-tools planner surface.

## Evidence provenance

- Evidence head: `9a90b56a7a5edc89c93cab6595a55783c772e62a`
- Base: `origin/develop` at `09df2333430b8e497aa58491c9de0ccf68e6df17`
- Supersedes the original PR head `6a2640c68a2aeb863fbd1921b1d323833597f462` with focused contract tests and a clean replay onto current `develop`.
- The branch was merged concurrently at `2026-08-15T23:24:39Z`, before the handoff could transition it to draft. The live trajectory and CI evidence below remain outstanding post-merge.

## What changed

- Adds the canonical `web` context to both coding-tools `WEB_SEARCH` and `WEB_FETCH` declarations and their explicit `contextGate.anyOf` lists.
- Preserves the existing `ADMIN` minimum-role gate, coding-tools opt-in registration, capability kill switches, bounded results, and hardened SSRF/redirect checks.
- Adds focused assertions that both actions are reachable from `web` while retaining their coding contexts and `ADMIN` gate.

The sibling server-runtime web actions are not duplicated by this change: runtime registration already skips its fallback when a loaded plugin provides the same action name.

## Exact-head validation

- Focused coding-tools web action suite: 21 passed, 0 failed
- `bun run --cwd plugins/plugin-coding-tools typecheck`: passed
- Biome over the four changed files: passed, no fixes
- `git diff --check origin/develop...HEAD`: passed
- Manual unified-gate probe: `ADMIN + web` and `ADMIN + code` admitted; `MEMBER + web` and `ADMIN + simple` rejected for both actions

## Outstanding post-merge evidence

- Exact-head live-model trajectory showing Stage 1 selects `web`, WEB_SEARCH/WEB_FETCH reaches the candidate/tool surface, and the selected action executes successfully for an authorized actor.
- Inspectable tool result and final answer from the real supported integration path.
- Required GitHub CI checks green on this evidence head (GitHub reported no checks when it merged).

No deployment was performed while preparing this handoff.
