### PR TITLE
fix(core): reject in-flight action claims on the failure-synthesis egress (F40)

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -14,6 +14,7 @@ import { TrajectoryLimitExceeded } from "../limits";
 import {
 	__renderRoutingHintsBlockForTests,
 	actionResultToPlannerToolResult,
+	FAILED_TOOL_FALLBACK_MESSAGE,
 	PROGRESS_ONLY_ANSWER_REJECT,
 	PROGRESS_ONLY_REPLY_OPENERS_PATTERN,
 	parsePlannerOutput,
@@ -2579,6 +2580,75 @@ describe("v5 planner loop skeleton", () => {
 		expect(result.finalMessage).toBe(
 			"The primary lookup failed on a DNS error; the backup source did return a result.",
 		);
+	});
+
+	it("never ships an in-flight action claim as the failure-synthesis reply (matrix F40)", async () => {
+		// Live shape: the forced failure-aware synthesis pass answered with an
+		// imminent-action promise instead of a diagnosis. The synthesis is the
+		// turn's last model call, so "calling web search now." is a false claim
+		// and must degrade to the generic failed-step sentence.
+		const runtime = {
+			useModel: vi
+				.fn()
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [
+						{
+							id: "call-1",
+							name: "SHELL",
+							arguments: { command: "curl https://stale.example.invalid" },
+						},
+					],
+				})
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [
+						{
+							id: "call-2",
+							name: "SHELL",
+							arguments: { command: "curl https://backup.example.com" },
+						},
+					],
+				})
+				.mockResolvedValueOnce({
+					text: "calling web search now.",
+					toolCalls: [],
+				}),
+		};
+		const executeToolCall = vi
+			.fn()
+			.mockResolvedValueOnce({
+				success: false,
+				text: "command_failed: DNS lookup failed",
+			})
+			.mockResolvedValueOnce({
+				success: true,
+				text: "backup source returned a result",
+			});
+		const evaluate = vi
+			.fn()
+			.mockResolvedValueOnce({
+				success: false,
+				decision: "FINISH" as const,
+				thought: "The first lookup failed, but I forgot to include a reply.",
+			})
+			.mockResolvedValueOnce({
+				success: true,
+				decision: "FINISH" as const,
+				thought: "Done.",
+				messageToUser: "The backup source returned a result.",
+			});
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			tools: [{ name: "SHELL", description: "Run a shell command." }],
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.finalMessage).toBe(FAILED_TOOL_FALLBACK_MESSAGE);
+		expect(result.finalMessage).not.toContain("calling web search");
 	});
 
 	it("does not finish with terminal planner text after tool work when the evaluator asks to continue", async () => {

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -5360,6 +5360,19 @@ function userSafeFailureReport(
 	if (isUnsafeUserVisibleText(candidate)) return undefined;
 	if (isToolMetaNarration(candidate)) return undefined;
 	if (isEchoOfPlannerFacingToolText(candidate, trajectory)) return undefined;
+	// The failure synthesis is the turn's LAST model call — no further tool
+	// work happens — so a diagnosis that instead promises imminent action is a
+	// false claim on the egress leg the in-flight ban did not cover (matrix
+	// F40: forced failure-aware synthesis shipped "calling web search now" as
+	// the final turn text). Progress-shaped openers are screened with the
+	// shared opener vocabulary rather than PROGRESS_ONLY_ANSWER_REJECT: its
+	// final-answer-only extensions ("Okay", "got it") open legitimate failure
+	// diagnoses, and rejecting those would regress #17948's
+	// model-diagnosis-over-generic-fallback contract.
+	if (IN_FLIGHT_ACTION_CLAIM.some((pattern) => pattern.test(candidate))) {
+		return undefined;
+	}
+	if (PROGRESS_ONLY_OPENER_RE.test(candidate)) return undefined;
 	return candidate;
 }
 
@@ -5536,7 +5549,15 @@ function userSafeRefusalCandidate(
 // would be a cycle. The two consumers deliberately extend it differently —
 // see PROGRESS_ONLY_ANSWER_REJECT below.
 export const PROGRESS_ONLY_REPLY_OPENERS_PATTERN =
-	"checking|fetching|gathering|looking (?:up|into)|running|using|spawning|starting|working on|one moment|let me|i(?:'|’)ll|i will";
+	"calling|checking|fetching|gathering|looking (?:up|into)|running|using|spawning|starting|working on|one moment|let me|i(?:'|’)ll|i will";
+
+// Bare opener screen (no final-answer-only extensions) for text where a
+// progress-shaped opener is disqualifying but "Okay, …" openings are
+// legitimate — the failure-report egress (matrix F40).
+const PROGRESS_ONLY_OPENER_RE = new RegExp(
+	`^(?:${PROGRESS_ONLY_REPLY_OPENERS_PATTERN})\\b`,
+	"i",
+);
 
 // Progress/ack-shaped openers that must never be surfaced as a final answer
 // from the required-tool exhaustion path: once the loop gives up, no further


### PR DESCRIPTION
## Problem — matrix F40 (fresh battery pin, composite web scenario)

The forced failure-aware synthesis pass is the turn's **last** model call — no further tool work can happen — yet it shipped **"calling web search now."** as the final turn text. `userSafeFailureReport` screens unsafe markup, meta-narration, and raw-tool-text echoes, but not imminent-action promises. The live shape also slipped both existing in-flight vocabularies: `IN_FLIGHT_ACTION_CLAIM` needs an "I'm"-style prefix, and "calling" was absent from the shared progress-opener pattern.

## Fix

- "calling" joins `PROGRESS_ONLY_REPLY_OPENERS_PATTERN` (the vocabulary already shared with the message service's progress classifier — same family as running/using/spawning/starting).
- A bare-opener screen derived from that pattern + the `IN_FLIGHT_ACTION_CLAIM` set now gate `userSafeFailureReport`. Deliberately **not** `PROGRESS_ONLY_ANSWER_REJECT`: its final-answer-only extensions ("Okay", "got it") legitimately open failure diagnoses, and rejecting those would regress #17948's model-diagnosis-over-generic-fallback contract.
- Rejection degrades to the tool-owned failure text or the generic failed-step sentence — both honest.

## Evidence

| Check | Result |
|---|---|
| new F40 test (live shape → `FAILED_TOOL_FALLBACK_MESSAGE`, never the claim) | ✅ |
| planner-loop suite | 119/119 ✅ |
| shared-pattern consumers (message shortcut-gate 14/14, preserved-tool-result 14/14, runtime-failure-suppression) | ✅ |
| core typecheck | ✅ |
| Biome | ✅ |

Live re-prove rides the next box resync (the composite scenario from tj-ac52e09457b028 goes fully green with #20250 + this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)