### PR TITLE
fix(agent): salvage mangled UUID filters on memory search instead of failing the call (F16)

### DIFF
--- a/packages/agent/src/actions/memories.test.ts
+++ b/packages/agent/src/actions/memories.test.ts
@@ -267,22 +267,31 @@ describe("MEMORY op:search identity-cluster expansion", () => {
 });
 
 describe("MEMORY uuid validation", () => {
-  it("publishes UUID-only schemas for every model-supplied database id", () => {
-    for (const name of ["entityId", "roomId", "memoryId"]) {
+  it("publishes a UUID-only schema for the destructive memoryId and pattern-free schemas for search filters", () => {
+    // memoryId targets a destructive op, so the schema pattern hard-fails a
+    // mangled id at the validate-tool-args boundary. entityId/roomId are
+    // search *filters*: their patterns were removed (matrix F16,
+    // tj-b0c123243cb39e) so a planner-mangled UUID reaches the handler's
+    // per-op policy instead of failing the whole call.
+    const memoryId = memoryAction.parameters?.find(
+      (candidate) => candidate.name === "memoryId",
+    );
+    expect(memoryId?.schema.pattern).toBeDefined();
+    const pattern = new RegExp(memoryId?.schema.pattern ?? "");
+    expect(pattern.test(ROOM_ID)).toBe(true);
+    expect(pattern.test("general")).toBe(false);
+    for (const name of ["entityId", "roomId"]) {
       const parameter = memoryAction.parameters?.find(
         (candidate) => candidate.name === name,
       );
-      expect(parameter?.schema.pattern).toBeDefined();
-      const pattern = new RegExp(parameter?.schema.pattern ?? "");
-      expect(pattern.test(ROOM_ID)).toBe(true);
-      expect(pattern.test("chat")).toBe(false);
-      expect(pattern.test("general")).toBe(false);
+      expect(parameter?.schema.pattern).toBeUndefined();
     }
   });
 
-  it('handles roomId "general" without running the query or leaking SQL', async () => {
+  it('search ignores roomId "general" with a note, without running the id-filtered query or leaking SQL', async () => {
     // The mock getMemories throws a drizzle-style error (raw SQL included)
-    // for any non-uuid id, so a passing test proves the query never ran.
+    // for any non-uuid id, so a passing test proves the invalid id was
+    // dropped before any query ran with it.
     const { runtime, rows } = makeRuntime();
     seedFact(rows, { text: "nubs plays guitar", entityId: USER_ID });
 
@@ -291,25 +300,38 @@ describe("MEMORY uuid validation", () => {
       roomId: "general",
     });
 
-    expect(result.success).toBe(false);
-    expect((result.data as { error: string }).error).toBe(
-      "MEMORY_INVALID_UUID",
-    );
-    expect(result.text).toContain('roomId "general"');
+    expect(result.success).toBe(true);
+    expect(result.text).toContain('ignored invalid roomId "general"');
     expect(result.text?.toLowerCase()).not.toContain("failed query");
     expect(result.text?.toLowerCase()).not.toContain("select");
   });
 
-  it("handles a partial-uuid entityId on search cleanly", async () => {
+  it("search ignores a mangled dropped-character roomId and still finds rows (matrix F16)", async () => {
+    // Live shape: GLM copied the context roomId and dropped a hex char
+    // (seven-character first segment). The unusable filter is ignored —
+    // searching all rooms is a superset of the intended scope.
+    const { runtime, rows } = makeRuntime();
+    seedFact(rows, { text: "paris weather note", entityId: USER_ID });
+
+    const result = await runAction(runtime, makeMessage(), {
+      action: "search",
+      roomId: "b9db237-57f1-0d75-ae29-d0988d883b78",
+      query: "paris weather",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.text).toContain("ignored invalid roomId");
+    expect(result.text).toContain("paris weather note");
+  });
+
+  it("search ignores a partial-uuid entityId with a note", async () => {
     const { runtime } = makeRuntime();
     const result = await runAction(runtime, makeMessage(), {
       action: "search",
       entityId: "0b8db237",
     });
-    expect(result.success).toBe(false);
-    expect((result.data as { error: string }).error).toBe(
-      "MEMORY_INVALID_UUID",
-    );
+    expect(result.success).toBe(true);
+    expect(result.text).toContain('ignored invalid entityId "0b8db237"');
     expect(result.text?.toLowerCase()).not.toContain("failed query");
   });
 

--- a/packages/agent/src/actions/memories.ts
+++ b/packages/agent/src/actions/memories.ts
@@ -331,17 +331,32 @@ async function doSearch(
 ): Promise<ActionResult> {
   const type =
     params.type && MEMORY_TYPES.includes(params.type) ? params.type : undefined;
+  // Read-only salvage (matrix F16): a mangled planner-copied UUID is an
+  // unusable *filter*, and failing the whole search over it turns a
+  // recoverable turn into a failed one. Searching without the filter is a
+  // superset of the intended scope, so ignore the id and say so in the
+  // result. Destructive ops keep parseUuidParam's hard fail — a mangled id
+  // must never widen a delete's scope.
   const entityParam = parseUuidParam(params.entityId, "entityId");
-  if (!entityParam.ok) return entityParam.result;
   const roomParam = parseUuidParam(params.roomId, "roomId");
-  if (!roomParam.ok) return roomParam.result;
+  const ignoredIdNotes: string[] = [];
+  if (!entityParam.ok) {
+    ignoredIdNotes.push(
+      `ignored invalid entityId "${params.entityId?.trim()}" (searched all entities)`,
+    );
+  }
+  if (!roomParam.ok) {
+    ignoredIdNotes.push(
+      `ignored invalid roomId "${params.roomId?.trim()}" (searched all rooms)`,
+    );
+  }
   const query = params.query?.trim();
   const limit = clampLimit(params.limit, 50);
 
   const scope = {
     type,
-    entityId: entityParam.id,
-    roomId: roomParam.id,
+    entityId: entityParam.ok ? entityParam.id : undefined,
+    roomId: roomParam.ok ? roomParam.id : undefined,
     query,
   };
   const scan = await collectCandidates(runtime, { ...scope, limit });
@@ -366,6 +381,9 @@ async function doSearch(
     success: true,
     text: [
       `${renderNote} (filters: ${describeSearchScope(scope)}).`,
+      ...(ignoredIdNotes.length > 0
+        ? [`Note: ${ignoredIdNotes.join("; ")}.`]
+        : []),
       describeScanWindow(scan),
       ...lines,
     ].join("\n"),
@@ -685,19 +703,25 @@ export const memoryAction: Action = {
       required: false,
       schema: { type: "string" as const, enum: [...MEMORY_TYPES] },
     },
+    // entityId/roomId carry no schema `pattern` on purpose (matrix F16): a
+    // planner-copied UUID arrives mangled often enough (live: a dropped hex
+    // char in the roomId first segment, tj-b0c123243cb39e) that the
+    // validate-tool-args pattern check failed the whole call before the
+    // handler could apply its per-op policy — search salvages by ignoring the
+    // unusable filter, destructive ops still hard-fail via parseUuidParam.
     {
       name: "entityId",
       description:
         "search: optional entity UUID from a previous result. Omit it when no exact UUID is known.",
       required: false,
-      schema: { type: "string" as const, pattern: UUID_SCHEMA_PATTERN },
+      schema: { type: "string" as const },
     },
     {
       name: "roomId",
       description:
         'search: optional room UUID from a previous result. Omit it to search all stored rooms; never pass a source label such as "chat".',
       required: false,
-      schema: { type: "string" as const, pattern: UUID_SCHEMA_PATTERN },
+      schema: { type: "string" as const },
     },
     {
       name: "query",


### PR DESCRIPTION
## Problem — matrix F16, live receipt tj-b0c123243cb39e stage 3

GLM copied the context roomId into MEMORY search args and dropped a hex character (seven-char first segment: `b9db237-…`). The schema's UUID `pattern` hard-failed the whole call at the validate-tool-args boundary — "Argument 'roomId' … does not match pattern" — and derailed the composite turn. Any planner-copied id is a transcription hazard; a read-only *filter* should never kill the call.

## Fix

- `entityId`/`roomId` schemas drop the UUID pattern so the handler's **per-op policy** decides.
- **search** (read-only): an unusable id is ignored with an explicit note in the result text — `ignored invalid roomId "…" (searched all rooms)` — because searching without the filter is a superset of the intended scope. The query still never runs with the invalid id (no SQL leak, pinned by test).
- **destructive ops**: unchanged — `parseUuidParam` still hard-fails (a mangled id must never widen a delete's scope), and `memoryId` keeps its schema pattern.

## Evidence

| Check | Result |
|---|---|
| new tests: exact F16 dropped-char shape (search succeeds + note + rows found), "general" label, partial-uuid entityId, schema-policy pin | ✅ |
| `memories.test.ts` | 23/23 ✅ |
| delete-path hard-fail tests | unchanged, green ✅ |
| Biome | ✅ |
| agent typecheck | my files clean; the runner exits 1 on pre-existing errors in untouched files (generated `optional-plugin-imports`, test harnesses, cross-package refs) — none reference this change |

Live re-prove rides the next box resync (the tj-b0c123243cb39e composite scenario).

🤖 Generated with [Claude Code](https://claude.com/claude-code)