### PR TITLE
fix(core): correct timeout default isCancel handling in ApprovalService

### DIFF
--- a/packages/core/src/services/approval.test.ts
+++ b/packages/core/src/services/approval.test.ts
@@ -1,20 +1,32 @@
 /**
- * Exercises `ApprovalService.listPendingUserActions`: in-flight async approvals
- * map to canonical `PendingUserAction` records with options, weight, and the
- * self-expiry deadline for timed requests. Runs against a minimal stub runtime.
+ * Exercises ApprovalService pending-action mapping plus the production
+ * timeout and selection cancel classification. Tests drive requestApproval /
+ * handleSelection rather than private handleTimeout injection.
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { IAgentRuntime, UUID } from "../types/index.ts";
 import { PENDING_USER_ACTION_WEIGHT } from "../types/index.ts";
 import { ApprovalService } from "./approval.ts";
 
+const ROOM_A = "00000000-0000-0000-0000-0000000000bb" as UUID;
+const ROOM_B = "00000000-0000-0000-0000-0000000000cc" as UUID;
+
 function createRuntime(): IAgentRuntime {
+	const tasks = new Map<UUID, { id: UUID }>();
 	let counter = 0;
 	return {
 		agentId: "00000000-0000-0000-0000-0000000000aa" as UUID,
 		registerTaskWorker: () => {},
-		createTask: async (): Promise<UUID> =>
-			`00000000-0000-0000-0000-00000000000${++counter}` as UUID,
+		createTask: async (): Promise<UUID> => {
+			const id = `00000000-0000-0000-0000-00000000000${++counter}` as UUID;
+			tasks.set(id, { id });
+			return id;
+		},
+		getTask: async (id: UUID) => tasks.get(id) ?? null,
+		deleteTask: async (id: UUID) => {
+			tasks.delete(id);
+		},
+		reportError: () => {},
 	} as unknown as IAgentRuntime;
 }
 
@@ -29,7 +41,7 @@ describe("ApprovalService.listPendingUserActions", () => {
 		const taskId = await service.requestApprovalAsync({
 			name: "post-tweet",
 			description: "Post this tweet?",
-			roomId: "00000000-0000-0000-0000-0000000000bb" as UUID,
+			roomId: ROOM_A,
 			options: [
 				{ name: "approve", description: "Send it" },
 				{ name: "cancel", description: "Don't send", isCancel: true },
@@ -46,7 +58,7 @@ describe("ApprovalService.listPendingUserActions", () => {
 			kind: "task_approval",
 			source: "approval-service",
 			title: "Post this tweet?",
-			roomId: "00000000-0000-0000-0000-0000000000bb",
+			roomId: ROOM_A,
 			weight: PENDING_USER_ACTION_WEIGHT.task_approval,
 			resolution: {
 				target: "approval_service",
@@ -66,7 +78,7 @@ describe("ApprovalService.listPendingUserActions", () => {
 		await service.requestApprovalAsync({
 			name: "deploy",
 			description: "Ship to prod?",
-			roomId: "00000000-0000-0000-0000-0000000000cc" as UUID,
+			roomId: ROOM_B,
 			options: [{ name: "ship", description: "Ship it" }],
 			timeoutMs: 60_000,
 			timeoutDefault: "ship",
@@ -81,102 +93,217 @@ describe("ApprovalService.listPendingUserActions", () => {
 	});
 });
 
-describe("ApprovalService.handleTimeout fail-closed classification", () => {
-	function createRuntimeWithMocks(): IAgentRuntime {
-		return {
-			agentId: "00000000-0000-0000-0000-0000000000aa" as UUID,
-			registerTaskWorker: () => {},
-			createTask: async (): Promise<UUID> =>
-				`00000000-0000-0000-0000-00000000000${Math.floor(Math.random() * 1000)}` as UUID,
-			getTask: async () => null as unknown as never,
-			deleteTask: async () => {},
-		} as unknown as IAgentRuntime;
-	}
+describe("ApprovalService timeout production path", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
 
-	async function captureHandleTimeout(
-		request: {
-			name: string;
-			options: Array<{ name: string; isCancel?: boolean }>;
-			timeoutDefault?: string;
-		},
-	): Promise<{ success: boolean; cancelled: boolean; selectedOption: string }> {
-		const runtime = createRuntimeWithMocks();
-		const service = new ApprovalService(runtime);
-		const taskId = "00000000-0000-0000-0000-000000000099" as UUID;
-		let captured: {
-			success: boolean;
-			cancelled: boolean;
-			selectedOption: string;
-		} | null = null;
-		(runtime as unknown as Record<string, unknown>).deleteTask = async () => {};
-		(runtime as unknown as Record<string, unknown>).getTask = async () => null as never;
-		// Inject pending entry directly and capture resolve args
-		const pending: {
-			request: typeof request;
-			resolve: (v: {
-				success: boolean;
-				cancelled: boolean;
-				selectedOption: string;
-			}) => void;
-		} = {
-			request: request as never,
-			resolve: (v) => {
-				captured = v;
-			},
-		};
-		(service as unknown as { pendingApprovals: Map<UUID, unknown> }).pendingApprovals.set(
-			taskId,
-			pending as never,
-		);
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		await (service as any).handleTimeout(taskId);
-		if (!captured) throw new Error("handleTimeout did not resolve");
-		return captured;
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	async function settleTimeout(
+		request: Parameters<ApprovalService["requestApproval"]>[0],
+	) {
+		const service = new ApprovalService(createRuntime());
+		const pending = service.requestApproval({
+			...request,
+			description: request.description ?? "timeout case",
+			roomId: request.roomId ?? ROOM_A,
+			timeoutMs: request.timeoutMs ?? 1_000,
+		});
+		await vi.advanceTimersByTimeAsync(request.timeoutMs ?? 1_000);
+		return pending;
 	}
 
 	it("resolves approve with omitted isCancel as success", async () => {
-		const result = await captureHandleTimeout({
-			name: "low-risk",
-			options: [
-				{ name: "approve" },
-				{ name: "cancel", isCancel: true },
-			],
-			timeoutDefault: "approve",
+		await expect(
+			settleTimeout({
+				name: "low-risk",
+				description: "ok?",
+				roomId: ROOM_A,
+				options: [{ name: "approve" }, { name: "cancel", isCancel: true }],
+				timeoutDefault: "approve",
+			}),
+		).resolves.toMatchObject({
+			selectedOption: "approve",
+			success: true,
+			cancelled: false,
+			timedOut: true,
 		});
-		expect(result).toMatchObject({ selectedOption: "approve", success: true, cancelled: false });
 	});
 
 	it("resolves explicit cancel as failure", async () => {
-		const result = await captureHandleTimeout({
-			name: "x",
-			options: [
-				{ name: "approve" },
-				{ name: "cancel", isCancel: true },
-			],
-			timeoutDefault: "cancel",
+		await expect(
+			settleTimeout({
+				name: "x",
+				description: "ok?",
+				roomId: ROOM_A,
+				options: [{ name: "approve" }, { name: "cancel", isCancel: true }],
+				timeoutDefault: "cancel",
+			}),
+		).resolves.toMatchObject({
+			selectedOption: "cancel",
+			success: false,
+			cancelled: true,
+			timedOut: true,
 		});
-		expect(result).toMatchObject({ selectedOption: "cancel", success: false, cancelled: true });
 	});
 
 	it("preserves explicit isCancel:false", async () => {
-		const result = await captureHandleTimeout({
-			name: "x",
-			options: [
-				{ name: "confirm", isCancel: false },
-				{ name: "cancel", isCancel: true },
-			],
-			timeoutDefault: "confirm",
+		await expect(
+			settleTimeout({
+				name: "x",
+				description: "ok?",
+				roomId: ROOM_A,
+				options: [
+					{ name: "confirm", isCancel: false },
+					{ name: "cancel", isCancel: true },
+				],
+				timeoutDefault: "confirm",
+			}),
+		).resolves.toMatchObject({
+			selectedOption: "confirm",
+			success: true,
+			cancelled: false,
+			timedOut: true,
 		});
-		expect(result.success).toBe(true);
-		expect(result.cancelled).toBe(false);
 	});
 
 	it("fail-closes missing/invalid default as cancelled", async () => {
-		const result = await captureHandleTimeout({
-			name: "x",
-			options: [{ name: "approve" }, { name: "cancel", isCancel: true }],
-			timeoutDefault: "typo" as string,
+		await expect(
+			settleTimeout({
+				name: "x",
+				description: "ok?",
+				roomId: ROOM_A,
+				options: [{ name: "approve" }, { name: "cancel", isCancel: true }],
+				timeoutDefault: "typo",
+			}),
+		).resolves.toMatchObject({
+			selectedOption: "typo",
+			success: false,
+			cancelled: true,
+			timedOut: true,
 		});
-		expect(result).toMatchObject({ selectedOption: "typo", success: false, cancelled: true });
+	});
+});
+
+describe("ApprovalService.handleSelection fail-closed classification", () => {
+	async function settleSelection(
+		request: Parameters<ApprovalService["requestApproval"]>[0],
+		selectedOption: string,
+	) {
+		const service = new ApprovalService(createRuntime());
+		const pending = service.requestApproval({
+			...request,
+			description: request.description ?? "selection case",
+			roomId: request.roomId ?? ROOM_A,
+		});
+		let action = service.listPendingUserActions()[0];
+		for (let i = 0; i < 50 && !action; i++) {
+			await Promise.resolve();
+			action = service.listPendingUserActions()[0];
+		}
+		if (!action) throw new Error("approval was not tracked");
+		await service.handleSelection(action.id, selectedOption);
+		return pending;
+	}
+
+	it("resolves approve with omitted isCancel as success", async () => {
+		await expect(
+			settleSelection(
+				{
+					name: "low-risk",
+					description: "ok?",
+					roomId: ROOM_A,
+					options: [{ name: "approve" }, { name: "cancel", isCancel: true }],
+				},
+				"approve",
+			),
+		).resolves.toMatchObject({
+			selectedOption: "approve",
+			success: true,
+			cancelled: false,
+			timedOut: false,
+		});
+	});
+
+	it("resolves explicit cancel as failure", async () => {
+		await expect(
+			settleSelection(
+				{
+					name: "x",
+					description: "ok?",
+					roomId: ROOM_A,
+					options: [{ name: "approve" }, { name: "cancel", isCancel: true }],
+				},
+				"cancel",
+			),
+		).resolves.toMatchObject({
+			selectedOption: "cancel",
+			success: false,
+			cancelled: true,
+			timedOut: false,
+		});
+	});
+
+	it("preserves explicit isCancel:false", async () => {
+		await expect(
+			settleSelection(
+				{
+					name: "x",
+					description: "ok?",
+					roomId: ROOM_A,
+					options: [
+						{ name: "confirm", isCancel: false },
+						{ name: "cancel", isCancel: true },
+					],
+				},
+				"confirm",
+			),
+		).resolves.toMatchObject({
+			selectedOption: "confirm",
+			success: true,
+			cancelled: false,
+			timedOut: false,
+		});
+	});
+
+	it("fail-closes a missing selection as cancelled", async () => {
+		await expect(
+			settleSelection(
+				{
+					name: "x",
+					description: "ok?",
+					roomId: ROOM_A,
+					options: [{ name: "approve" }, { name: "cancel", isCancel: true }],
+				},
+				"typo",
+			),
+		).resolves.toMatchObject({
+			selectedOption: "typo",
+			success: false,
+			cancelled: true,
+			timedOut: false,
+		});
+	});
+
+	it("does not treat an ABORT name as cancel without the typed flag", async () => {
+		await expect(
+			settleSelection(
+				{
+					name: "x",
+					description: "ok?",
+					roomId: ROOM_A,
+					options: [{ name: "ABORT" }, { name: "cancel", isCancel: true }],
+				},
+				"ABORT",
+			),
+		).resolves.toMatchObject({
+			selectedOption: "ABORT",
+			success: true,
+			cancelled: false,
+			timedOut: false,
+		});
 	});
 });

--- a/packages/core/src/services/approval.test.ts
+++ b/packages/core/src/services/approval.test.ts
@@ -80,3 +80,103 @@ describe("ApprovalService.listPendingUserActions", () => {
 		await service.stop();
 	});
 });
+
+describe("ApprovalService.handleTimeout fail-closed classification", () => {
+	function createRuntimeWithMocks(): IAgentRuntime {
+		return {
+			agentId: "00000000-0000-0000-0000-0000000000aa" as UUID,
+			registerTaskWorker: () => {},
+			createTask: async (): Promise<UUID> =>
+				`00000000-0000-0000-0000-00000000000${Math.floor(Math.random() * 1000)}` as UUID,
+			getTask: async () => null as unknown as never,
+			deleteTask: async () => {},
+		} as unknown as IAgentRuntime;
+	}
+
+	async function captureHandleTimeout(
+		request: {
+			name: string;
+			options: Array<{ name: string; isCancel?: boolean }>;
+			timeoutDefault?: string;
+		},
+	): Promise<{ success: boolean; cancelled: boolean; selectedOption: string }> {
+		const runtime = createRuntimeWithMocks();
+		const service = new ApprovalService(runtime);
+		const taskId = "00000000-0000-0000-0000-000000000099" as UUID;
+		let captured: {
+			success: boolean;
+			cancelled: boolean;
+			selectedOption: string;
+		} | null = null;
+		(runtime as unknown as Record<string, unknown>).deleteTask = async () => {};
+		(runtime as unknown as Record<string, unknown>).getTask = async () => null as never;
+		// Inject pending entry directly and capture resolve args
+		const pending: {
+			request: typeof request;
+			resolve: (v: {
+				success: boolean;
+				cancelled: boolean;
+				selectedOption: string;
+			}) => void;
+		} = {
+			request: request as never,
+			resolve: (v) => {
+				captured = v;
+			},
+		};
+		(service as unknown as { pendingApprovals: Map<UUID, unknown> }).pendingApprovals.set(
+			taskId,
+			pending as never,
+		);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		await (service as any).handleTimeout(taskId);
+		if (!captured) throw new Error("handleTimeout did not resolve");
+		return captured;
+	}
+
+	it("resolves approve with omitted isCancel as success", async () => {
+		const result = await captureHandleTimeout({
+			name: "low-risk",
+			options: [
+				{ name: "approve" },
+				{ name: "cancel", isCancel: true },
+			],
+			timeoutDefault: "approve",
+		});
+		expect(result).toMatchObject({ selectedOption: "approve", success: true, cancelled: false });
+	});
+
+	it("resolves explicit cancel as failure", async () => {
+		const result = await captureHandleTimeout({
+			name: "x",
+			options: [
+				{ name: "approve" },
+				{ name: "cancel", isCancel: true },
+			],
+			timeoutDefault: "cancel",
+		});
+		expect(result).toMatchObject({ selectedOption: "cancel", success: false, cancelled: true });
+	});
+
+	it("preserves explicit isCancel:false", async () => {
+		const result = await captureHandleTimeout({
+			name: "x",
+			options: [
+				{ name: "confirm", isCancel: false },
+				{ name: "cancel", isCancel: true },
+			],
+			timeoutDefault: "confirm",
+		});
+		expect(result.success).toBe(true);
+		expect(result.cancelled).toBe(false);
+	});
+
+	it("fail-closes missing/invalid default as cancelled", async () => {
+		const result = await captureHandleTimeout({
+			name: "x",
+			options: [{ name: "approve" }, { name: "cancel", isCancel: true }],
+			timeoutDefault: "typo" as string,
+		});
+		expect(result).toMatchObject({ selectedOption: "typo", success: false, cancelled: true });
+	});
+});

--- a/packages/core/src/services/approval.ts
+++ b/packages/core/src/services/approval.ts
@@ -129,7 +129,7 @@ export const STANDARD_OPTIONS = {
  * Only an existing option whose `isCancel` is explicitly true is a cancel.
  * A missing name fail-closes as cancel. Names such as `ABORT` are not special.
  */
-export function isCancelApprovalOption(
+function isCancelApprovalOption(
 	options: readonly ApprovalOption[] | undefined,
 	selectedName: string,
 ): boolean {

--- a/packages/core/src/services/approval.ts
+++ b/packages/core/src/services/approval.ts
@@ -444,8 +444,8 @@ export class ApprovalService extends Service {
 
 		// Resolve with timeout default or cancel
 		const defaultOption = request.timeoutDefault ?? "cancel";
-		const isCancel =
-			request.options.find((o) => o.name === defaultOption)?.isCancel ?? true;
+		const option = request.options.find((o) => o.name === defaultOption);
+		const isCancel = option ? option.isCancel === true : true;
 
 		pending.resolve({
 			selectedOption: defaultOption,

--- a/packages/core/src/services/approval.ts
+++ b/packages/core/src/services/approval.ts
@@ -125,6 +125,20 @@ export const STANDARD_OPTIONS = {
 } as const;
 
 /**
+ * Typed cancel classification shared by timeout and selection.
+ * Only an existing option whose `isCancel` is explicitly true is a cancel.
+ * A missing name fail-closes as cancel. Names such as `ABORT` are not special.
+ */
+export function isCancelApprovalOption(
+	options: readonly ApprovalOption[] | undefined,
+	selectedName: string,
+): boolean {
+	if (!options) return true;
+	const option = options.find((o) => o.name === selectedName);
+	return option ? option.isCancel === true : true;
+}
+
+/**
  * ApprovalService provides a interface for task-based approvals.
  */
 export class ApprovalService extends Service {
@@ -444,8 +458,7 @@ export class ApprovalService extends Service {
 
 		// Resolve with timeout default or cancel
 		const defaultOption = request.timeoutDefault ?? "cancel";
-		const option = request.options.find((o) => o.name === defaultOption);
-		const isCancel = option ? option.isCancel === true : true;
+		const isCancel = isCancelApprovalOption(request.options, defaultOption);
 
 		pending.resolve({
 			selectedOption: defaultOption,
@@ -488,10 +501,7 @@ export class ApprovalService extends Service {
 		}
 
 		const request = pending?.request;
-		const option = request?.options.find((o) => o.name === selectedOption);
-		const isCancel =
-			option?.isCancel ??
-			(selectedOption === "cancel" || selectedOption === "ABORT");
+		const isCancel = isCancelApprovalOption(request?.options, selectedOption);
 
 		logger.info(
 			{


### PR DESCRIPTION
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6, openai/gpt-5
<!-- attribution-row:client -->
- Agent tooling: Hermes Agent, Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - contribution skill was not used for this repair
<!-- attribution-row:status -->
- Provenance status: self-reported

# Description

Fix ApprovalService cancel classification at both timeout and explicit-selection boundaries. An existing option succeeds unless its typed isCancel flag is true; an unknown or missing option fails closed. Option names such as ABORT have no implicit meaning.

# Root cause

The timeout path treated an existing option with omitted isCancel as cancelled, while the selection path used option names as a fallback and treated unknown selections as success. Those policies disagreed and could either reject a valid default or fabricate approval.

# Changes

- Add one module-private classifier shared by handleTimeout and handleSelection.
- Preserve explicit isCancel true or false on existing options.
- Fail closed when the requested option name is absent.
- Remove the name-based ABORT special case.
- Exercise the real requestApproval timer path and public handleSelection path; no private method injection and no new public API.

# Verification

- Focused ApprovalService suite: 12/12.
- Fail-open missing-option mutation: 2 expected failures covering timeout and selection; restored suite 12/12.
- Core typecheck and changed-file Biome: pass.
- Uncached root verify: 351/351 plus every audit.
- Anti-larp: 8,282 test files, 0 focused, 0 orphaned skips.

# Base verified

Exact head 2065d41c11d6704f41d63f4790539cd7351d0f76 was verified on develop ee8968f3c8666526815f22bf5ddb8a864f975303. Develop later advanced through message-routing and personal-assistant files only; both approval files remained byte-identical.

<!-- evidence-head:2065d41c11d6704f41d63f4790539cd7351d0f76 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only approval classification fix; no rendered UI changes
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only approval classification fix; no rendered UI changes
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual user flow changed
<!-- evidence-row:backend-logs -->
- [x] N/A - production requestApproval timer and handleSelection suite passes 12/12; fail-open mutation turns 2 regressions red; uncached root verify passes 351/351
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network behavior changed
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action, provider, prompt, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] N/A - deterministic ApprovalResult objects are asserted at timer and selection boundaries; no persistence or schema change
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed

# Known gaps

None. Visual, frontend, model, and domain artifacts are inapplicable because this is a backend-only typed classification change.