### PR TITLE
fix(cloud): make Worker secret updates version-aware

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -655,15 +655,15 @@ jobs:
               return 0
             fi
             for attempt in 1 2 3; do
-              if printf '%s' "$value" | bunx wrangler secret put "$name" ${{ steps.env.outputs.wrangler_args }}; then
+              if printf '%s' "$value" | bunx wrangler versions secret put "$name" ${{ steps.env.outputs.wrangler_args }}; then
                 return 0
               fi
               if [ "$attempt" -lt 3 ]; then
-                echo "::warning::wrangler secret put $name failed on attempt $attempt; retrying in 10s"
+                echo "::warning::wrangler versions secret put $name failed on attempt $attempt; retrying in 10s"
                 sleep 10
               fi
             done
-            echo "::error::wrangler secret put $name failed after 3 attempts"
+            echo "::error::wrangler versions secret put $name failed after 3 attempts"
             return 1
           }
 
@@ -714,7 +714,7 @@ jobs:
             # absence is success without depending on Wrangler error prose.
             local result
             if ! result=$(node "$CHECKOUT_DIR/packages/cloud/scripts/ensure-worker-secret-absent.mjs" \
-              "$name" ${{ steps.env.outputs.wrangler_args }}); then
+              --versions "$name" ${{ steps.env.outputs.wrangler_args }}); then
               echo "::error::$name is unset but its absence could not be confirmed"
               return 1
             fi
@@ -722,10 +722,10 @@ jobs:
             return 0
           }
 
-          # QA cutover is OFF-FIRST. Secret mutations update the currently
-          # served Worker immediately, so remove the activation bit before
-          # changing any version, signer, or allowlist. If any later config or
-          # code deploy fails, the served feature remains absent.
+          # Build the next Worker version with the QA activation bit absent.
+          # The served gate was already disabled above; version-aware updates
+          # now prepare the new config without deploying stale code between
+          # secret publication and the intentional code cutover.
           STAGING_SESSION_EXCHANGE_ENABLED=""
           export STAGING_SESSION_EXCHANGE_ENABLED
           publish_toggle_secret STAGING_SESSION_EXCHANGE_ENABLED || exit 1
@@ -814,9 +814,9 @@ jobs:
             publish_toggle_secret "$name" || exit 1
           done
 
-          # GitHub and Cloudflare are separate write-only authorities. Verify
-          # the live names only after configured values have had a chance to
-          # create their bindings, but still before any Worker code deploys.
+          # Keep production voice fail-closed against its currently served
+          # credential set. The post-deploy check below verifies the complete
+          # served binding set after the intentional code cutover.
           verify_production_voice_secret_bindings || exit 1
 
       - name: Deploy to Cloudflare Workers
@@ -842,7 +842,7 @@ jobs:
             fi
             echo "::warning::Worker deploy failed after retiring legacy onboarding URL secrets; restoring the staging value."
             for name in ELIZA_ONBOARDING_LOGIN_APP_URL ELIZA_APP_ONBOARDING_LOGIN_APP_URL; do
-              if ! printf '%s' "$STAGING_ONBOARDING_LOGIN_APP_URL" | bunx wrangler secret put "$name" --env staging; then
+              if ! printf '%s' "$STAGING_ONBOARDING_LOGIN_APP_URL" | bunx wrangler versions secret put "$name" --env staging; then
                 echo "::error::Failed to restore legacy staging binding $name; staging onboarding CTA configuration requires operator repair."
               fi
             done
@@ -852,7 +852,7 @@ jobs:
             local name="$1"
             local result
             if ! result=$(node "$CHECKOUT_DIR/packages/cloud/scripts/ensure-worker-secret-absent.mjs" \
-              "$name" --env staging); then
+              --versions "$name" --env staging); then
               echo "::error::Could not retire legacy staging secret binding $name."
               return 1
             fi

--- a/packages/cloud/scripts/__tests__/ensure-worker-secret-absent.test.ts
+++ b/packages/cloud/scripts/__tests__/ensure-worker-secret-absent.test.ts
@@ -65,6 +65,66 @@ describe("ensureWorkerSecretAbsent", () => {
     ]);
   });
 
+  test("uses version-aware inventory and deletion before a code deploy", async () => {
+    const calls: string[][] = [];
+    const outputs = [
+      JSON.stringify([
+        { id: "older", number: 8 },
+        { id: "before", number: 10 },
+        { id: "oldest", number: 3 },
+      ]),
+      JSON.stringify({
+        resources: {
+          bindings: [
+            { name: "STAGING_SESSION_EXCHANGE_ENABLED", type: "secret_text" },
+            { name: "PLAIN_VALUE", type: "plain_text" },
+          ],
+        },
+      }),
+      "",
+      JSON.stringify([{ id: "after", number: 11 }]),
+      JSON.stringify({ resources: { bindings: [] } }),
+    ];
+    const result = await ensureWorkerSecretAbsent({
+      name: "STAGING_SESSION_EXCHANGE_ENABLED",
+      wranglerArgs: ["--env", "staging"],
+      versioned: true,
+      run: async (args: string[]) => {
+        calls.push(args);
+        return outputs.shift() ?? "[]";
+      },
+      sleep: async () => {},
+    });
+
+    expect(result).toBe("removed");
+    expect(calls).toEqual([
+      ["versions", "list", "--env", "staging", "--json"],
+      ["versions", "view", "before", "--env", "staging", "--json"],
+      [
+        "versions",
+        "secret",
+        "delete",
+        "STAGING_SESSION_EXCHANGE_ENABLED",
+        "--env",
+        "staging",
+      ],
+      ["versions", "list", "--env", "staging", "--json"],
+      ["versions", "view", "after", "--env", "staging", "--json"],
+    ]);
+  });
+
+  test("fails closed when the latest version inventory is malformed", async () => {
+    await expect(
+      ensureWorkerSecretAbsent({
+        name: "STAGING_SESSION_EXCHANGE_ENABLED",
+        versioned: true,
+        attempts: 1,
+        run: async () => JSON.stringify([]),
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow("Could not confirm Worker secret");
+  });
+
   test("owns an ambiguous delete when the retry proves absence", async () => {
     const calls: string[][] = [];
     const result = await ensureWorkerSecretAbsent({

--- a/packages/cloud/scripts/ensure-worker-secret-absent.mjs
+++ b/packages/cloud/scripts/ensure-worker-secret-absent.mjs
@@ -1,7 +1,8 @@
 /**
  * Removes one Cloudflare Worker secret by inspecting the names-only Wrangler
- * inventory before and after deletion. The command is intentionally
- * idempotent and never depends on provider error prose or reads secret values.
+ * inventory before and after deletion. It can target either the deployed
+ * configuration or the latest version prepared for a later code deployment;
+ * neither mode depends on provider error prose or reads secret values.
  */
 
 import { execFile } from "node:child_process";
@@ -35,6 +36,41 @@ export function parseWorkerSecretNames(output) {
   return names;
 }
 
+function parseLatestWorkerVersion(output) {
+  const parsed = JSON.parse(output);
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error("Wrangler version inventory was empty or invalid");
+  }
+  const versions = parsed.map((entry) => {
+    if (
+      entry === null ||
+      typeof entry !== "object" ||
+      typeof entry.id !== "string" ||
+      entry.id.length === 0 ||
+      !Number.isInteger(entry.number)
+    ) {
+      throw new Error("Wrangler version inventory contained an invalid entry");
+    }
+    return entry;
+  });
+  return versions.reduce((latest, entry) =>
+    entry.number > latest.number ? entry : latest,
+  );
+}
+
+function parseWorkerVersionSecretNames(output) {
+  const parsed = JSON.parse(output);
+  const bindings = parsed?.resources?.bindings;
+  if (!Array.isArray(bindings)) {
+    throw new Error("Wrangler version bindings were missing or invalid");
+  }
+  return parseWorkerSecretNames(
+    JSON.stringify(
+      bindings.filter((binding) => binding?.type === "secret_text"),
+    ),
+  );
+}
+
 /** Restrict passthrough arguments to Wrangler's optional environment selector. */
 export function validateWranglerEnvironmentArgs(args) {
   if (args.length === 0) return [];
@@ -64,6 +100,7 @@ async function runWrangler(args) {
 export async function ensureWorkerSecretAbsent({
   name,
   wranglerArgs = [],
+  versioned = false,
   attempts = 3,
   retryDelayMs = 10_000,
   run = runWrangler,
@@ -73,26 +110,44 @@ export async function ensureWorkerSecretAbsent({
     throw new Error("Worker secret name is invalid");
   }
   const validatedArgs = validateWranglerEnvironmentArgs(wranglerArgs);
+  if (typeof versioned !== "boolean") {
+    throw new Error("Versioned secret mode must be boolean");
+  }
   if (!Number.isInteger(attempts) || attempts < 1) {
     throw new Error("Attempts must be a positive integer");
   }
 
   let deletionAttempted = false;
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    try {
-      const before = parseWorkerSecretNames(
+  const readSecretNames = async () => {
+    if (!versioned) {
+      return parseWorkerSecretNames(
         await run(["secret", "list", ...validatedArgs, "--format", "json"]),
       );
+    }
+    const latest = parseLatestWorkerVersion(
+      await run(["versions", "list", ...validatedArgs, "--json"]),
+    );
+    return parseWorkerVersionSecretNames(
+      await run(["versions", "view", latest.id, ...validatedArgs, "--json"]),
+    );
+  };
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const before = await readSecretNames();
       if (!before.has(name)) {
         return deletionAttempted ? "removed" : "already-absent";
       }
 
       deletionAttempted = true;
-      await run(["secret", "delete", name, ...validatedArgs]);
+      await run([
+        ...(versioned ? ["versions"] : []),
+        "secret",
+        "delete",
+        name,
+        ...validatedArgs,
+      ]);
 
-      const after = parseWorkerSecretNames(
-        await run(["secret", "list", ...validatedArgs, "--format", "json"]),
-      );
+      const after = await readSecretNames();
       if (!after.has(name)) return "removed";
     } catch {
       // error-policy:J1 The CLI boundary retries without exposing provider output.
@@ -105,9 +160,16 @@ export async function ensureWorkerSecretAbsent({
 }
 
 async function main() {
-  const [name, ...wranglerArgs] = process.argv.slice(2);
+  const args = process.argv.slice(2);
+  const versioned = args[0] === "--versions";
+  if (versioned) args.shift();
+  const [name, ...wranglerArgs] = args;
   if (!name) throw new Error("Worker secret name is required");
-  const result = await ensureWorkerSecretAbsent({ name, wranglerArgs });
+  const result = await ensureWorkerSecretAbsent({
+    name,
+    wranglerArgs,
+    versioned,
+  });
   process.stdout.write(`${result}\n`);
 }
 

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -593,6 +593,9 @@ describe("canonical cloud deployment environment contract", () => {
     }
     expect(publish.run).toContain("managed_worker_provisioning_secrets=(");
     expect(publish.run).toContain('publish_secret "$name" || exit 1');
+    expect(publish.run).toContain('bunx wrangler versions secret put "$name"');
+    expect(publish.run).toContain('--versions "$name"');
+    expect(publish.run).not.toContain('bunx wrangler secret put "$name"');
     expect(publish.run).toContain(
       'echo "::notice::$name is not configured; skipping"',
     );


### PR DESCRIPTION
Fixes #20253

## Ground truth

Protected staging run 31913376637 passed Worker verification, E2E, and build, then failed before deploy on DATABASE_URL. Cloudflare rejected wrangler secret put because the latest Worker version was not currently deployed. Manual run 31913441042 attempt 2 reached the same deterministic step and was cancelled without a Worker cutover.

## Change

- prepare configured and toggle secrets with wrangler versions secret put/delete before the code cutover
- inspect the latest Worker version by numeric version number and verify names-only secret bindings before and after deletion
- lock version-aware publication into the canonical cloud deployment contract test
- keep the served staging session gate disabled before preparation and preserve the separate post-deploy activation proof
- keep production untouched

## Evidence

- exact head: aff71e3a78f3bf2cb720f239ae993aad03945c57
- rebased onto develop caa74ba6f1f5ae610027f562aa6076cd3acb446f; intervening files were disjoint
- 25/25 focused tests, 303 assertions
- actionlint cloud-cf-release workflow: pass
- Biome on changed scripts/tests: pass with one pre-existing warning at cloud-deploy-environment-contract.test.ts:395
- git diff --check: pass
- read-only live Wrangler shape: staging latest version 8368 exposed resources.bindings with 213 secret_text names; no values read
- repository guide advertises audit:error-policy-ratchet, but that script is absent from current root package scripts; not claimed as run

No production deployment or secret-value read was performed.