### PR TITLE
fix(ci): align cloud secret tests with versioned writes

### DIFF
--- a/packages/scripts/__tests__/cloud-cf-onboarding-login-url-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-onboarding-login-url-workflow.test.ts
@@ -41,7 +41,7 @@ describe("staging onboarding login URL deployment", () => {
   test("restores the known staging value when deployment fails after deletion", () => {
     expect(workflow).toContain("trap restore_legacy_onboarding_secrets ERR");
     expect(workflow).toContain(
-      'printf \'%s\' "$STAGING_ONBOARDING_LOGIN_APP_URL" | bunx wrangler secret put "$name" --env staging',
+      'printf \'%s\' "$STAGING_ONBOARDING_LOGIN_APP_URL" | bunx wrangler versions secret put "$name" --env staging',
     );
     expect(workflow).toContain("trap - ERR");
   });

--- a/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
@@ -124,7 +124,7 @@ STATE_FILE="$(mktemp)"
 trap 'rm -f "$STATE_FILE"' EXIT
 printf '%s' '${initialInventory}' > "$STATE_FILE"
 bunx() {
-  if [[ "$1" == wrangler* && "$2" == "secret" && "$3" == "put" ]]; then
+  if [[ "$1" == wrangler* && "$2" == "versions" && "$3" == "secret" && "$4" == "put" ]]; then
     cat >/dev/null
     if [ "$PUT_SUCCEEDS" != "true" ]; then
       return 1
@@ -372,7 +372,7 @@ executedDescribe(
       const result = runProductionVoiceBootstrap("cartesia-test", false);
       expect(result.status).toBe(1);
       expect(`${result.stdout}${result.stderr}`).toContain(
-        "wrangler secret put CARTESIA_API_KEY failed after 3 attempts",
+        "wrangler versions secret put CARTESIA_API_KEY failed after 3 attempts",
       );
     });
 


### PR DESCRIPTION
# Relates to

Closes #20263

- [x] Targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` pass after sync.
- [x] The executed contracts and exact command output below let reviewers verify the repair without reading implementation code.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `97f4833335e67ba6764a51cbca46059f20840402`; zero conflicts.
- [x] `bun run verify` passes post-sync. The concurrent core formatting repair in #20268 is included in this base; its duplicate local commit was dropped during rebase.

# Risks

Low. Production workflow behavior is unchanged. This only updates stale executed-test command models to the already-landed version-aware Wrangler contract.

# Background

## What does this PR do?

- Updates the production voice bootstrap harness to recognize `wrangler versions secret put` and pins its version-aware failure diagnostic.
- Updates the onboarding rollback contract to require version-aware restoration.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is needed; this repairs executable deployment contracts.

# Testing

## Where should a reviewer start?

Run the two focused cloud workflow tests, then the canonical scripts and root verification gates.

## Detailed testing steps

- `bun test packages/scripts/__tests__/cloud-cf-onboarding-login-url-workflow.test.ts packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts` — 20 pass, 0 fail.
- `bun run test:scripts` — 2,314 tests, 26,907 assertions, 0 failures across 193 files.
- `bun run verify` — 351/351 Turbo tasks; all audits pass; 8,264 test files scanned with 0 focused and 0 orphaned skips.
- `bun install --frozen-lockfile` — 3,823 installs checked, no changes.
- Biome on both touched files — no errors (one pre-existing warning in the onboarding test's literal Bash expression).
- `git diff --check` — pass.

# Evidence Gate

<!-- evidence-head:4d5d7149688f6b1528f10066b77b032b107c6b9a -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime path changed; the real executed workflow Bash harness and repository gates are the affected path.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, model call, provider, action, or routing behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact changes; canonical JUnit evidence is summarized in Testing and hosted checks exercise the same lane.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no model behavior changed.

## Backend + frontend logs

N/A - no backend or frontend product path changed. The executed deployment-contract output and repository verification results are summarized above.

## Screenshots (before / after) + video walkthrough

N/A - no rendered UI surface changed.

## Audio / voice walkthrough

N/A - the test concerns deployment-time binding publication only; no voice runtime or media behavior changed.

## Known gaps / failures

None. The post-merge scripts failure on current `develop` was reproduced locally and the exact affected aggregate lane and root gate pass.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-workflow]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
