### PR TITLE
fix(cloud): remove personal Shared cold first-contact retry

### DIFF
--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -9,11 +9,12 @@ let activeTarget: {
   status: "running" | "sleeping" | "stopped";
   bridge_url?: string;
 } | null = null;
+let personalDeliveryIsNew = false;
 const resolvePersonalDelivery = mock(async () => ({
   userId: "00000000-0000-4000-8000-000000000002",
   organizationId: "00000000-0000-4000-8000-000000000001",
   dedicatedTarget: activeTarget,
-  isNew: false,
+  isNew: personalDeliveryIsNew,
   resolution: "single-query-repeat" as const,
 }));
 const findOrCreateByPhone = mock(async () => ({
@@ -22,6 +23,7 @@ const findOrCreateByPhone = mock(async () => ({
   isNew: true,
 }));
 const sharedRestMessageSend = mock(async () => ({ text: "hello from Eliza" }));
+const prewarmPersonalSharedAgentTurnCaches = mock(async () => undefined);
 const runOnboardingChat = mock(async (_input: OnboardingChatInput) => ({
   loginUrl:
     "https://cloud-staging.eliza.app/get-started?onboardingSession=claim-token",
@@ -116,6 +118,9 @@ mock.module("@/lib/services/eliza-app", () => ({
 mock.module("@/lib/services/shared-runtime/shared-rest-adapter", () => ({
   sharedRestMessageSend,
 }));
+mock.module("@/lib/services/shared-runtime/prewarm-shared-agent", () => ({
+  prewarmPersonalSharedAgentTurnCaches,
+}));
 mock.module("@/lib/services/eliza-app/onboarding-chat", () => ({
   runOnboardingChat,
 }));
@@ -198,9 +203,11 @@ describe("personal Shared messaging deliveries", () => {
   beforeEach(() => {
     findOrCreateByPhone.mockClear();
     activeTarget = null;
+    personalDeliveryIsNew = false;
     resolvePersonalDelivery.mockClear();
     findActivePersonalDedicatedTarget.mockClear();
     sharedRestMessageSend.mockClear();
+    prewarmPersonalSharedAgentTurnCaches.mockClear();
     runOnboardingChat.mockClear();
     bridge.mockClear();
     importCanonicalConversation.mockClear();
@@ -256,6 +263,45 @@ describe("personal Shared messaging deliveries", () => {
     );
   });
 
+  test("warms a newly auto-registered personal account before its first turn", async () => {
+    personalDeliveryIsNew = true;
+    const order: string[] = [];
+    prewarmPersonalSharedAgentTurnCaches.mockImplementationOnce(async () => {
+      order.push("prewarm");
+    });
+    sharedRestMessageSend.mockImplementationOnce(async () => {
+      order.push("turn");
+      return { text: "hello from Eliza" };
+    });
+
+    const response = await request({
+      ...valid,
+      telegramUserId: "99008152237",
+      chatId: "99008152237",
+      messageId: "QA815-LAT8-COLD",
+    });
+
+    expect(response.status).toBe(200);
+    expect(prewarmPersonalSharedAgentTurnCaches).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organization_id: "00000000-0000-4000-8000-000000000001",
+        user_id: "00000000-0000-4000-8000-000000000002",
+      }),
+      namespace,
+    );
+    expect(order).toEqual(["prewarm", "turn"]);
+    expect(response.headers.get("server-timing")).toMatch(
+      /^account;dur=\d+\.\d, prewarm;dur=\d+\.\d, shared;dur=\d+\.\d$/,
+    );
+  });
+
+  test("keeps established personal turns on the direct warm path", async () => {
+    const response = await request(valid);
+
+    expect(response.status).toBe(200);
+    expect(prewarmPersonalSharedAgentTurnCaches).not.toHaveBeenCalled();
+  });
+
   test("correlates a Shared failure without logging its sensitive message", async () => {
     const errorLog = mock(() => undefined);
     const originalError = logger.error;
@@ -291,6 +337,35 @@ describe("personal Shared messaging deliveries", () => {
     } finally {
       logger.error = originalError;
     }
+  });
+
+  test("preserves cache warming as a retryable 503 at the internal boundary", async () => {
+    const { SharedRuntimeCacheWarmingError } = await import(
+      "@/lib/services/shared-runtime/shared-runtime-errors"
+    );
+    const warming = new SharedRuntimeCacheWarmingError(
+      "private cold-gate detail",
+    );
+    sharedRestMessageSend.mockImplementationOnce(async () => {
+      throw warming;
+    });
+
+    const response = await request(valid);
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("retry-after")).toBe("1");
+    expect(response.headers.get("x-eliza-failure-stage")).toBe(
+      "shared_runtime",
+    );
+    expect(response.headers.get("x-eliza-failure-name")).toBe(
+      "SharedRuntimeCacheWarmingError",
+    );
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "Shared Eliza is warming. Retry this turn shortly.",
+      code: "service_unavailable",
+      retryable: true,
+    });
   });
 
   test("redacts an unrecognized error name from headers and logs", async () => {

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -13,8 +13,10 @@ import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { preparePersonalDedicatedDelivery } from "@/lib/services/personal-dedicated-delivery";
 import { coordinateSharedHistory } from "@/lib/services/shared-runtime/conversation-coordinator";
 import { personalSharedAgent } from "@/lib/services/shared-runtime/personal-shared-agent";
+import { prewarmPersonalSharedAgentTurnCaches } from "@/lib/services/shared-runtime/prewarm-shared-agent";
 import { resolveSharedRuntimeWorkerRequestContext } from "@/lib/services/shared-runtime/resolve-shared-agent";
 import { sharedRestMessageSend } from "@/lib/services/shared-runtime/shared-rest-adapter";
+import { SharedRuntimeCacheWarmingError } from "@/lib/services/shared-runtime/shared-runtime-errors";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { requireInternalAuth } from "../../../_auth";
@@ -259,6 +261,7 @@ app.post("/", async (c) => {
     stage = "account_resolution";
     const accountStartedAt = performance.now();
     let account: { userId: string; organizationId: string };
+    let isNewPersonalAccount = false;
     let dedicated:
       | Pick<AgentSandbox, "id" | "status" | "bridge_url" | "agent_config">
       | null
@@ -275,6 +278,7 @@ app.post("/", async (c) => {
         organizationId: delivery.organizationId,
       };
       dedicated = delivery.dedicatedTarget;
+      isNewPersonalAccount = delivery.isNew;
     } else if (parsed.data.platform === "discord") {
       const delivery = await elizaAppUserService.resolvePersonalDelivery({
         platform: "discord",
@@ -288,6 +292,7 @@ app.post("/", async (c) => {
         organizationId: delivery.organizationId,
       };
       dedicated = delivery.dedicatedTarget;
+      isNewPersonalAccount = delivery.isNew;
     } else {
       const phoneAccount = await elizaAppUserService.findOrCreateByPhone(
         parsed.data.phoneNumber,
@@ -296,6 +301,7 @@ app.post("/", async (c) => {
         userId: phoneAccount.user.id,
         organizationId: phoneAccount.organization.id,
       };
+      isNewPersonalAccount = phoneAccount.isNew;
     }
     const accountMs = performance.now() - accountStartedAt;
     c.header("Server-Timing", `account;dur=${accountMs.toFixed(1)}`);
@@ -562,6 +568,12 @@ app.post("/", async (c) => {
       });
     }
     stage = "shared_runtime";
+    let prewarmMs: number | undefined;
+    if (isNewPersonalAccount) {
+      const prewarmStartedAt = performance.now();
+      await prewarmPersonalSharedAgentTurnCaches(agent, worker.namespace);
+      prewarmMs = performance.now() - prewarmStartedAt;
+    }
     const sharedStartedAt = performance.now();
     const result = await sharedRestMessageSend(
       agent,
@@ -582,9 +594,9 @@ app.post("/", async (c) => {
     );
     c.header(
       "Server-Timing",
-      `account;dur=${accountMs.toFixed(1)}, shared;dur=${(
-        performance.now() - sharedStartedAt
-      ).toFixed(1)}`,
+      `account;dur=${accountMs.toFixed(1)}, ${
+        prewarmMs === undefined ? "" : `prewarm;dur=${prewarmMs.toFixed(1)}, `
+      }shared;dur=${(performance.now() - sharedStartedAt).toFixed(1)}`,
     );
 
     return c.json({
@@ -612,6 +624,18 @@ app.post("/", async (c) => {
     // provider/SQL payloads in its logs.
     c.header(FAILURE_STAGE_HEADER, stage);
     c.header(FAILURE_NAME_HEADER, errorName);
+    if (error instanceof SharedRuntimeCacheWarmingError) {
+      return c.json(
+        {
+          success: false,
+          error: "Shared Eliza is warming. Retry this turn shortly.",
+          code: "service_unavailable",
+          retryable: true,
+        },
+        503,
+        { "Retry-After": "1" },
+      );
+    }
     return failureResponse(c, error);
   }
 });

--- a/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
@@ -25,6 +25,7 @@ const GATE_BINDING = "INFERENCE_ADMISSION_GATES";
 const GATE_ORIGIN = "https://inference-admission.internal";
 const HYDRATION_GATE_TIMEOUT_MS = 5_000;
 const GATE_OPERATION_TIMEOUT_MS = 1_500;
+const RATE_LIMIT_GATE_TIMEOUT_MS = 5_000;
 const DISPATCH_GATE_TIMEOUT_MS = 1_500;
 const DISPATCH_GATE_MAX_ATTEMPTS = 3;
 
@@ -398,7 +399,10 @@ export async function consumeInferenceRateLimit(params: {
       maxRequests: params.maxRequests,
     },
     undefined,
-    AbortSignal.timeout(GATE_OPERATION_TIMEOUT_MS),
+    // A brand-new organization addresses a brand-new Durable Object. Preserve
+    // the tighter money-mutation deadline above, but allow the lightweight
+    // rate-limit authority to survive genuine Worker/DO cold initialization.
+    AbortSignal.timeout(RATE_LIMIT_GATE_TIMEOUT_MS),
   );
   if (response.status !== 200 && response.status !== 429) {
     throw new InferenceAdmissionGateUnavailableError(

--- a/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.test.ts
@@ -22,7 +22,11 @@ const getById = mock(async (_id: string): Promise<UserCharacter | undefined> => 
 const warmInferenceAdmissionSnapshot = mock(async () => {
   calls.push("admission");
 });
+const warmInferenceAdmissionGate = mock(async () => {
+  calls.push("admission-gate");
+});
 const coordinateSharedHistory = mock(async () => [] as unknown[]);
+const coordinateSharedConversationPrewarm = mock(async () => undefined);
 const seedSharedAgentScopeCache = mock(async () => {
   calls.push("authorization-scope");
 });
@@ -35,7 +39,9 @@ mock.module("../../pricing", () => ({
 }));
 mock.module("../characters/characters", () => ({ charactersService: { getById } }));
 mock.module("../inference-admission-snapshot", () => ({ warmInferenceAdmissionSnapshot }));
+mock.module("../inference-admission-gate", () => ({ warmInferenceAdmissionGate }));
 mock.module("./conversation-coordinator", () => ({
+  coordinateSharedConversationPrewarm,
   coordinateSharedHistory,
 }));
 mock.module("./resolve-shared-agent", () => ({
@@ -48,7 +54,9 @@ mock.module("./run-shared-agent-turn", () => ({
   resolveSharedAgentTurnModel: (preferred?: string) => preferred?.trim() || null,
 }));
 
-const { prewarmSharedAgentTurnCaches } = await import("./prewarm-shared-agent");
+const { prewarmPersonalSharedAgentTurnCaches, prewarmSharedAgentTurnCaches } = await import(
+  "./prewarm-shared-agent"
+);
 
 afterAll(() => {
   mock.module("../../utils/logger", () => realLogger);
@@ -71,8 +79,14 @@ beforeEach(() => {
   getById.mockClear();
   getById.mockImplementation(async () => undefined);
   warmInferenceAdmissionSnapshot.mockClear();
+  warmInferenceAdmissionGate.mockClear();
+  warmInferenceAdmissionGate.mockImplementation(async () => {
+    calls.push("admission-gate");
+  });
   coordinateSharedHistory.mockClear();
   coordinateSharedHistory.mockImplementation(async () => []);
+  coordinateSharedConversationPrewarm.mockClear();
+  coordinateSharedConversationPrewarm.mockImplementation(async () => undefined);
   seedSharedAgentScopeCache.mockClear();
   seedSharedAgentScopeCache.mockImplementation(async () => {
     calls.push("authorization-scope");
@@ -81,6 +95,13 @@ beforeEach(() => {
 });
 
 describe("prewarmSharedAgentTurnCaches model pricing", () => {
+  test("warms the serialized admission gate beside the policy snapshot", async () => {
+    await prewarmSharedAgentTurnCaches(agent({}));
+
+    expect(warmInferenceAdmissionGate).toHaveBeenCalledWith("org-1");
+    expect(warmInferenceAdmissionSnapshot).toHaveBeenCalledWith("org-1");
+  });
+
   test("warms the nested agent_config.character.model pricing pair", async () => {
     await prewarmSharedAgentTurnCaches(
       agent({
@@ -173,6 +194,47 @@ describe("prewarmSharedAgentTurnCaches model pricing", () => {
         agentId: "agent-1",
         organizationId: "org-1",
         leg: "conversation-object",
+        error: error.message,
+      }),
+    );
+  });
+});
+
+describe("prewarmPersonalSharedAgentTurnCaches", () => {
+  test("warms a new personal room and admission gate concurrently", async () => {
+    const namespace = { getByName: mock() } as never;
+    const personalAgent = {
+      id: "personal:user-1:org-1",
+      organization_id: "org-1",
+    };
+
+    await prewarmPersonalSharedAgentTurnCaches(personalAgent, namespace);
+
+    expect(warmInferenceAdmissionGate).toHaveBeenCalledWith("org-1");
+    expect(coordinateSharedConversationPrewarm).toHaveBeenCalledWith(
+      personalAgent.id,
+      personalAgent.id,
+      { namespace, startEmpty: true },
+    );
+  });
+
+  test("keeps a failed personal prewarm observable and lets the typed retry path remain", async () => {
+    const error = new Error("admission gate unavailable");
+    warmInferenceAdmissionGate.mockRejectedValue(error);
+
+    await expect(
+      prewarmPersonalSharedAgentTurnCaches(
+        { id: "personal:user-1:org-1", organization_id: "org-1" },
+        {} as never,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(loggerWarn).toHaveBeenCalledWith(
+      "[shared-runtime prewarm] leg failed; first turn falls back to warming 503s",
+      expect.objectContaining({
+        agentId: "personal:user-1:org-1",
+        organizationId: "org-1",
+        leg: "admission-gate",
         error: error.message,
       }),
     );

--- a/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts
@@ -30,11 +30,16 @@ import type { AgentSandbox } from "../../../db/repositories/agent-sandboxes";
 import type { AppEnv, RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-env";
 import { calculateCost, getProviderFromModel, normalizeModelName } from "../../pricing";
 import { logger } from "../../utils/logger";
+import { warmInferenceAdmissionGate } from "../inference-admission-gate";
 import { warmInferenceAdmissionSnapshot } from "../inference-admission-snapshot";
-import { coordinateSharedHistory } from "./conversation-coordinator";
+import {
+  coordinateSharedConversationPrewarm,
+  coordinateSharedHistory,
+} from "./conversation-coordinator";
 import { seedSharedAgentScopeCache } from "./resolve-shared-agent";
 import { resolveSharedAgentTurnModel } from "./run-shared-agent-turn";
 import { projectSharedAgentCharacter } from "./shared-agent-character";
+import type { SharedRuntimeAgent } from "./shared-runtime-agent";
 
 export interface PrewarmSharedAgentOptions {
   /**
@@ -58,6 +63,28 @@ export interface PrewarmSharedAgentOptions {
   stewardUserId?: string;
 }
 
+interface PrewarmLeg {
+  leg: string;
+  run: Promise<unknown>;
+}
+
+async function settlePrewarmLegs(
+  agent: Pick<SharedRuntimeAgent, "id" | "organization_id">,
+  legs: PrewarmLeg[],
+): Promise<void> {
+  const results = await Promise.allSettled(legs.map(({ run }) => run));
+  results.forEach((result, index) => {
+    if (result.status === "rejected") {
+      logger.warn("[shared-runtime prewarm] leg failed; first turn falls back to warming 503s", {
+        agentId: agent.id,
+        organizationId: agent.organization_id,
+        leg: legs[index].leg,
+        error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+      });
+    }
+  });
+}
+
 /**
  * Hydrate every cache the cache-only shared first turn consults. Resolves when
  * all legs have settled; never rejects (failed legs are logged and the turn
@@ -67,7 +94,15 @@ export async function prewarmSharedAgentTurnCaches(
   agent: AgentSandbox,
   options: PrewarmSharedAgentOptions = {},
 ): Promise<void> {
-  const legs: Array<{ leg: string; run: Promise<unknown> }> = [];
+  const legs: PrewarmLeg[] = [];
+
+  // The admission snapshot carries policy, while the gate is the independent
+  // serialized authority that enforces it. Warming both avoids exchanging a
+  // cache miss for a cold Durable Object timeout on the first turn.
+  legs.push({
+    leg: "admission-gate",
+    run: warmInferenceAdmissionGate(agent.organization_id),
+  });
 
   // 1. Combined admission snapshot: org balance + rate-limit tier. The
   //    projection behind "Billing authorization is warming", "Inference
@@ -129,15 +164,29 @@ export async function prewarmSharedAgentTurnCaches(
     });
   }
 
-  const results = await Promise.allSettled(legs.map(({ run }) => run));
-  results.forEach((result, index) => {
-    if (result.status === "rejected") {
-      logger.warn("[shared-runtime prewarm] leg failed; first turn falls back to warming 503s", {
-        agentId: agent.id,
-        organizationId: agent.organization_id,
-        leg: legs[index].leg,
-        error: result.reason instanceof Error ? result.reason.message : String(result.reason),
-      });
-    }
-  });
+  await settlePrewarmLegs(agent, legs);
+}
+
+/**
+ * Warm the two authorities a newly auto-registered personal agent needs.
+ * Unlike dashboard agent creation, first contact already carries the user's
+ * message, so the route awaits these concurrent legs before dispatching it.
+ */
+export async function prewarmPersonalSharedAgentTurnCaches(
+  agent: Pick<SharedRuntimeAgent, "id" | "organization_id">,
+  namespace: RuntimeDurableObjectNamespace,
+): Promise<void> {
+  await settlePrewarmLegs(agent, [
+    {
+      leg: "admission-gate",
+      run: warmInferenceAdmissionGate(agent.organization_id),
+    },
+    {
+      leg: "conversation-object",
+      run: coordinateSharedConversationPrewarm(agent.id, agent.id, {
+        namespace,
+        startEmpty: true,
+      }),
+    },
+  ]);
 }


### PR DESCRIPTION
# Relates to

Closes #20271. Parent latency observability issue: #16079.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync.
- [ ] A reviewer can confirm the changed live staging path without reading the code. Independent code/runtime-boundary review is complete; exact post-merge protected-staging proof is listed under Known gaps.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/slopdotcash@332dc64deec632ac7746f237f0f30d4aad6050d5:skills/contribute-to-eliza/SKILL.md`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@35f527d21e755182a52caa3a156fbc87df42cc0d`; zero conflicts.
- [x] `bun run verify` passes post-sync: 351/351 Turbo tasks plus all repository audits.

# Risks

Medium. The change awaits two Durable Object warm-up legs only for a newly created Personal Shared account. It keeps the authoritative rate limiter fail-closed, widens only the lightweight rate-limit fetch budget to 5 seconds, and leaves lease, billing, and dispatch mutation deadlines at 1.5 seconds. Established accounts skip the awaited prewarm path.

# Background

## What does this PR do?

- Awaits concurrent conversation/runtime and admission-gate prewarm only for a newly auto-registered personal Shared account.
- Adds the missing admission-gate leg to ordinary Shared-agent creation prewarm.
- Gives only the rate-limit Durable Object operation a 5-second cold-start budget.
- Preserves `SharedRuntimeCacheWarmingError` as a retryable internal 503 with `Retry-After: 1`.
- Emits a distinct `prewarm` `Server-Timing` slice on new first contact.

Rate limiting remains authoritative and fail-closed. No embeddings, memory storage, billing semantics, gateway retry policy, or Dedicated runtime path changes.

## What kind of change is this?

Bug fix: removes the first-contact 500/retry penalty on the shipped Telegram/Discord Personal Shared path.

# Documentation changes needed?

No project-documentation change. This repairs existing Personal Shared orchestration and adds observable timing without changing the public product contract.

# Testing

## Where should a reviewer start?

1. `packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts`
2. `packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts`
3. `packages/cloud/shared/src/lib/services/inference-admission-gate.ts`

Independent exact-head review: https://github.com/elizaOS/eliza/pull/20273#pullrequestreview-4945037531

## Detailed testing steps

Exact head `324392fdb3fbd04261640fa34085e361781414e9`, base `35f527d21e755182a52caa3a156fbc87df42cc0d`:

- Personal Shared route: 25/25, 110 assertions.
- Personal prewarm: 9/9, 19 assertions.
- Shared runtime chat: 28/28, 142 assertions.
- Admission gate unit: 31/31, 182 assertions.
- Real Miniflare admission-gate Durable Object: 5/5, 18 assertions.
- `packages/cloud/shared` typecheck: PASS.
- `packages/cloud/api` typecheck + production Worker dry bundle: PASS.
- Exact five-file Biome + `git diff --check`: PASS.
- Root `bun run verify`: PASS, 351/351 Turbo tasks and all follow-on audits.

# Evidence Gate

<!-- evidence-head:324392fdb3fbd04261640fa34085e361781414e9 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only Worker/Durable Object orchestration; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only Worker/Durable Object orchestration; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend interaction or rendered surface changes in this diff.
<!-- evidence-row:backend-logs -->
- [x] Root-cause backend trace receipts are attached below; exact post-fix staging trace is a protected post-merge gate and will be attached before the lane is closed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, console state, or browser network contract changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt, action, provider selection, model, or model-output semantics change; this patch warms pre-inference authorities only. Personal Shared trajectory persistence is currently disabled.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - this change creates no new persistent domain record; the applicable live artifact is the exact Telegram response and per-attempt Worker trace under Backend logs.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no prompt/model behavior changes. The exact warm control still exercised the real Personal Shared model and returned `PONG-LAT7`; Personal Shared currently discards its per-turn in-memory trajectory adapter, so no durable trajectory viewer ID exists.

## Backend + frontend logs

### Root-cause receipt before this change

- label `QA815-LAT7-COLD-1786838210311`
- trace `9a3d8b2e-19e7-4a6c-b74f-4fd57c8d1b21`
- HTTP 500 after 9.884 seconds
- `account=1510ms; cloud_worker=8135ms; full_app_module_init=0ms`
- typed `shared_runtime / SharedRuntimeCacheWarmingError`
- same-trace `InferenceAdmissionGate /rate-limit` Durable Object request canceled

Exact warm replay:

- trace `b12d9644-f810-4e77-a9b4-2c33ff29fbab`
- HTTP 200 after 6.034 seconds
- `account=179ms; shared=1696ms; cloud_worker=4271ms`
- exact reply `PONG-LAT7`

No frontend logs apply.

## Screenshots (before / after) + video walkthrough

N/A - backend-only diff with no rendered surface.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT change.

## Known gaps / failures

- Exact post-fix proof requires deploying the merged descendant through the protected `develop` staging workflow. The repo has no PR-head staging Worker surface, and this lane will not bypass the protected release with an ad-hoc upload.
- Before lane completion, attach a new cold identity + warm replay with per-attempt status/duration, trace IDs, `Server-Timing`, Shared/model spans, exact reply, and exact deployed Worker/gateway pins.
- Real fresh Telegram registration additionally requires a spare unlinked sender; the primary user account will not be unlinked or replaced.
- The repo guide names `bun run audit:error-policy-ratchet`, but that script is not present in this checkout. Root `bun run verify` passed and includes the current repository audit suite.

# Deploy Notes

Deploy through the canonical protected `Cloud CF Deploy` workflow after maintainer merge. Production is out of scope and remains untouched.
