### PR TITLE
fix(ios): preserve remote Mac runtime transport

### DIFF
--- a/packages/app-core/src/api/ios-local-agent-transport.test.ts
+++ b/packages/app-core/src/api/ios-local-agent-transport.test.ts
@@ -423,6 +423,69 @@ describe("iOS local agent transport bridge", () => {
     });
   });
 
+  it.each(["remote-mac", "cloud", "tunnel-to-mobile"])(
+    "keeps port 31337 on the real network transport in %s mode",
+    async (mode) => {
+      vi.stubEnv("VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK", "1");
+      const originalFetch = vi.fn(async () =>
+        Response.json({ source: "mac-runtime" }),
+      );
+      vi.stubGlobal("fetch", originalFetch);
+      vi.stubGlobal("localStorage", {
+        getItem: (key: string) =>
+          key === "eliza:mobile-runtime-mode" ? mode : null,
+      });
+
+      const { installIosLocalAgentFetchBridge, isIosInProcessLocalAgentUrl } =
+        await import("./ios-local-agent-transport");
+      const macRuntimeUrl = "http://127.0.0.1:31337/api/health";
+
+      expect(isIosInProcessLocalAgentUrl(macRuntimeUrl)).toBe(false);
+      installIosLocalAgentFetchBridge();
+      const response = await fetch(macRuntimeUrl);
+
+      await expect(response.json()).resolves.toEqual({
+        source: "mac-runtime",
+      });
+      expect(originalFetch).toHaveBeenCalledOnce();
+      expect(originalFetch).toHaveBeenCalledWith(macRuntimeUrl, undefined);
+      expect(kernelMock.handleIosLocalAgentRequest).not.toHaveBeenCalled();
+    },
+  );
+
+  it("retains port 31337 as the on-device agent in local mode", async () => {
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) =>
+        key === "eliza:mobile-runtime-mode" ? "local" : null,
+    });
+
+    const { isIosInProcessLocalAgentUrl } = await import(
+      "./ios-local-agent-transport"
+    );
+
+    expect(
+      isIosInProcessLocalAgentUrl("http://127.0.0.1:31337/api/health"),
+    ).toBe(true);
+  });
+
+  it.each(["local", "cloud-hybrid"])(
+    "retains native IPC as the on-device agent in %s mode",
+    async (mode) => {
+      vi.stubGlobal("localStorage", {
+        getItem: (key: string) =>
+          key === "eliza:mobile-runtime-mode" ? mode : null,
+      });
+
+      const { isIosInProcessLocalAgentUrl } = await import(
+        "./ios-local-agent-transport"
+      );
+
+      expect(
+        isIosInProcessLocalAgentUrl("eliza-local-agent://ipc/api/health"),
+      ).toBe(true);
+    },
+  );
+
   it("routes iOS IPC local-agent URLs through the same in-process transport", async () => {
     const { iosInProcessAgentTransportForUrl } = await import(
       "./ios-local-agent-transport"

--- a/packages/app-core/src/api/ios-local-agent-transport.ts
+++ b/packages/app-core/src/api/ios-local-agent-transport.ts
@@ -44,10 +44,12 @@ import {
 } from "@elizaos/ui/bridge/eliza-window-bridge";
 import { isStoreBuild } from "@elizaos/ui/build-variant";
 import {
+  isCommittedOnDeviceMobileRuntimeMode,
   isMobileLocalAgentUrl as isConfiguredMobileLocalAgentUrl,
   isMobileLocalAgentIpcUrl,
   MOBILE_LOCAL_AGENT_PORT,
   mobileLocalAgentPathFromUrl,
+  normalizeMobileRuntimeMode,
 } from "@elizaos/ui/first-run/mobile-runtime-mode";
 
 let transport: AgentRequestTransport | null = null;
@@ -380,15 +382,26 @@ function isMobileLocalAgentUrl(value: string): boolean {
 }
 
 /**
+ * Classify the legacy loopback HTTP identity only when the selected runtime
+ * actually owns an on-device agent. In `remote-mac`, loopback port 31337 is
+ * the developer's Mac and must stay on the real network transport.
+ */
+function isIosOnDeviceAgentHttpUrl(value: string): boolean {
+  if (!isMobileLocalAgentUrl(value)) return false;
+  const mode = readRuntimeMode();
+  return mode === null
+    ? canUseIosLocalAgentIpc()
+    : iosRuntimeHasOnDeviceAgent();
+}
+
+/**
  * Whether the selected iOS runtime owns an on-device agent process/runtime.
- * `cloud` is the only pure remote mode. `cloud-hybrid` still runs the bundled
- * agent while routing inference through cloud, and `tunnel-to-mobile` exposes
- * the phone-side agent through a relay for a remote client.
+ * Delegates to the first-run runtime-mode authority so transports cannot drift
+ * from restore and active-server policy.
  */
 function iosRuntimeHasOnDeviceAgent(): boolean {
-  const mode = readRuntimeMode();
-  return (
-    mode === "local" || mode === "cloud-hybrid" || mode === "tunnel-to-mobile"
+  return isCommittedOnDeviceMobileRuntimeMode(
+    normalizeMobileRuntimeMode(readRuntimeMode()),
   );
 }
 
@@ -470,7 +483,7 @@ export function isIosInProcessLocalAgentUrl(url: string): boolean {
     // explicitly outside the in-process transport.
     return false;
   }
-  return isNativeIos() && isMobileLocalAgentUrl(url);
+  return isNativeIos() && isIosOnDeviceAgentHttpUrl(url);
 }
 
 export function isIosInProcessLocalAgentBase(
@@ -1025,7 +1038,7 @@ function shouldBridgeFetchUrl(url: URL): boolean {
       "iOS store/cloud builds block cleartext loopback or private-network requests",
     );
   }
-  if (isMobileLocalAgentUrl(url.toString())) return true;
+  if (isIosOnDeviceAgentHttpUrl(url.toString())) return true;
   if (isNativeIosCloudRuntime()) return false;
   if ((url.pathname || "").startsWith("/api/")) {
     return (

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -42,6 +42,7 @@
       const ipcBase = 'eliza-local-agent://ipc';
       const ipcPathPrefix = `//${ipcHost}`;
       const localAgentPort = '31337';
+      const mobileRuntimeModeStorageKey = 'eliza:mobile-runtime-mode';
 
       // The loopback (127.0.0.1:31337) → native-IPC rewrite below is only
       // correct on a NATIVE Capacitor platform (iOS/Android), where the
@@ -62,6 +63,19 @@
           return p === 'ios' || p === 'android';
         } catch (_) {
           return false;
+        }
+      }
+
+      function nativeModeUsesOnDeviceAgent() {
+        try {
+          const mode = window.localStorage.getItem(mobileRuntimeModeStorageKey);
+          if (mode === 'remote-mac' || mode === 'cloud' || mode === 'tunnel-to-mobile') {
+            return false;
+          }
+          return true;
+        } catch (_) {
+          // error-policy:J4 storage unavailable — preserve native-local compatibility.
+          return true;
         }
       }
 
@@ -87,6 +101,7 @@
           const url = new URL(trimmed, window.location?.href ? window.location.href : 'https://cloud.eliza.app');
           if (
             isNativeCapacitorAgentHost() &&
+            nativeModeUsesOnDeviceAgent() &&
             url.protocol === 'http:' &&
             url.port === localAgentPort &&
             (url.hostname === '127.0.0.1' || url.hostname === 'localhost' || url.hostname === '[::1]' || url.hostname === '::1')

--- a/packages/app/test/index-html-fetch-bridge.test.ts
+++ b/packages/app/test/index-html-fetch-bridge.test.ts
@@ -16,6 +16,8 @@ interface BridgeHarness {
 
 const originalWindowFetch = window.fetch;
 const originalWindowCapacitor = Reflect.get(window, "Capacitor");
+const runtimeModeStorageKey = "eliza:mobile-runtime-mode";
+const originalRuntimeMode = window.localStorage.getItem(runtimeModeStorageKey);
 
 afterEach(() => {
   window.fetch = originalWindowFetch;
@@ -25,6 +27,11 @@ afterEach(() => {
     Reflect.set(window, "Capacitor", originalWindowCapacitor);
   }
   Reflect.deleteProperty(window, "__ELIZA_ANDROID_IPC_FETCH_BRIDGE__");
+  if (originalRuntimeMode === null) {
+    window.localStorage.removeItem(runtimeModeStorageKey);
+  } else {
+    window.localStorage.setItem(runtimeModeStorageKey, originalRuntimeMode);
+  }
 });
 
 function installBridgeScript(): void {
@@ -34,12 +41,15 @@ function installBridgeScript(): void {
     candidate.textContent?.includes("__ELIZA_ANDROID_IPC_FETCH_BRIDGE__"),
   );
   if (!script?.textContent) throw new Error("missing fetch bridge script");
-  // biome-ignore lint/security/noGlobalEval: executes the committed index.html
-  // inline bridge script (trusted build artifact, not user input) to test it.
+  // Executes the committed inline bridge script, never user input.
+  // biome-ignore lint/security/noGlobalEval: the HTML shell is the system under test
   window.eval(script.textContent);
 }
 
-function createHarness(platform: string | (() => string)): BridgeHarness {
+function createHarness(
+  platform: string | (() => string),
+  runtimeMode?: string,
+): BridgeHarness {
   const agentRequest = vi.fn(async () => ({
     status: 201,
     body: "bridged",
@@ -49,6 +59,11 @@ function createHarness(platform: string | (() => string)): BridgeHarness {
     return new this.Response("original", { status: 202 });
   });
   window.fetch = originalFetch as unknown as typeof window.fetch;
+  if (runtimeMode === undefined) {
+    window.localStorage.removeItem(runtimeModeStorageKey);
+  } else {
+    window.localStorage.setItem(runtimeModeStorageKey, runtimeMode);
+  }
   Object.assign(window, {
     Capacitor: {
       getPlatform: typeof platform === "function" ? platform : () => platform,
@@ -94,6 +109,36 @@ describe("index.html local-agent fetch bridge", () => {
       body: null,
     });
   });
+
+  it.each(["remote-mac", "cloud", "tunnel-to-mobile"])(
+    "lets native %s mode reach loopback HTTP directly",
+    async (runtimeMode) => {
+      const { agentRequest, originalFetch } = createHarness("ios", runtimeMode);
+
+      const response = await window.fetch("http://127.0.0.1:31337/api/health");
+
+      expect(await response.text()).toBe("original");
+      expect(originalFetch).toHaveBeenCalledTimes(1);
+      expect(agentRequest).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["local", "cloud-hybrid"])(
+    "keeps native %s mode on Agent.request",
+    async (runtimeMode) => {
+      const { agentRequest, originalFetch } = createHarness("ios", runtimeMode);
+
+      await window.fetch("http://127.0.0.1:31337/api/health");
+
+      expect(originalFetch).not.toHaveBeenCalled();
+      expect(agentRequest).toHaveBeenCalledWith({
+        method: "GET",
+        path: "/api/health",
+        headers: {},
+        body: null,
+      });
+    },
+  );
 
   it("continues to bridge explicit IPC URLs on every platform", async () => {
     const { agentRequest, originalFetch } = createHarness("web");

--- a/packages/ui/src/api/ios-local-agent-transport.test.ts
+++ b/packages/ui/src/api/ios-local-agent-transport.test.ts
@@ -230,4 +230,66 @@ describe("iOS local agent transport (ui copy)", () => {
     await expect(response.json()).resolves.toEqual({ ready: true });
     expect(originalFetch).toHaveBeenCalledTimes(1);
   });
+
+  it.each(["remote-mac", "cloud", "tunnel-to-mobile"])(
+    "keeps port 31337 on the real network transport in %s mode",
+    async (mode) => {
+      vi.stubEnv("VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK", "1");
+      const originalFetch = vi.fn(async () =>
+        Response.json({ source: "mac-runtime" }),
+      );
+      vi.stubGlobal("fetch", originalFetch);
+      vi.stubGlobal("localStorage", {
+        getItem: (key: string) =>
+          key === "eliza:mobile-runtime-mode" ? mode : null,
+      });
+
+      const { installIosLocalAgentFetchBridge, isIosInProcessLocalAgentUrl } =
+        await import("./ios-local-agent-transport");
+      const macRuntimeUrl = "http://127.0.0.1:31337/api/health";
+
+      expect(isIosInProcessLocalAgentUrl(macRuntimeUrl)).toBe(false);
+      installIosLocalAgentFetchBridge();
+      const response = await fetch(macRuntimeUrl);
+
+      await expect(response.json()).resolves.toEqual({
+        source: "mac-runtime",
+      });
+      expect(originalFetch).toHaveBeenCalledOnce();
+      expect(originalFetch).toHaveBeenCalledWith(macRuntimeUrl, undefined);
+    },
+  );
+
+  it("retains port 31337 as the on-device agent in local mode", async () => {
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) =>
+        key === "eliza:mobile-runtime-mode" ? "local" : null,
+    });
+
+    const { isIosInProcessLocalAgentUrl } = await import(
+      "./ios-local-agent-transport"
+    );
+
+    expect(
+      isIosInProcessLocalAgentUrl("http://127.0.0.1:31337/api/health"),
+    ).toBe(true);
+  });
+
+  it.each(["local", "cloud-hybrid"])(
+    "retains native IPC as the on-device agent in %s mode",
+    async (mode) => {
+      vi.stubGlobal("localStorage", {
+        getItem: (key: string) =>
+          key === "eliza:mobile-runtime-mode" ? mode : null,
+      });
+
+      const { isIosInProcessLocalAgentUrl } = await import(
+        "./ios-local-agent-transport"
+      );
+
+      expect(
+        isIosInProcessLocalAgentUrl("eliza-local-agent://ipc/api/health"),
+      ).toBe(true);
+    },
+  );
 });

--- a/packages/ui/src/api/ios-local-agent-transport.ts
+++ b/packages/ui/src/api/ios-local-agent-transport.ts
@@ -11,9 +11,11 @@ import {
 import { isStoreBuild } from "../build-variant";
 import { getBootConfig } from "../config/boot-config";
 import {
+  isCommittedOnDeviceMobileRuntimeMode,
   isMobileLocalAgentUrl as isConfiguredMobileLocalAgentUrl,
   isMobileLocalAgentIpcUrl,
   mobileLocalAgentPathFromUrl,
+  normalizeMobileRuntimeMode,
 } from "../first-run/mobile-runtime-mode";
 import { reportRendererDiagnostic } from "../utils/renderer-diagnostics";
 import {
@@ -606,14 +608,26 @@ function isMobileLocalAgentUrl(value: string): boolean {
 }
 
 /**
+ * Classify the legacy loopback HTTP identity only when the selected runtime
+ * actually owns an on-device agent. In `remote-mac`, loopback port 31337 is
+ * the developer's Mac and must stay on the real network transport.
+ */
+function isIosOnDeviceAgentHttpUrl(value: string): boolean {
+  if (!isMobileLocalAgentUrl(value)) return false;
+  const mode = readRuntimeMode();
+  return mode === null
+    ? canUseIosLocalAgentIpc()
+    : iosRuntimeHasOnDeviceAgent();
+}
+
+/**
  * Whether the selected runtime runs an on-device agent that serves local-agent
- * IPC. `local`, `cloud-hybrid`, and `tunnel-to-mobile` all run the bundled
- * phone-side agent; only pure `cloud` talks exclusively to a remote agent.
+ * IPC. Delegates to the first-run runtime-mode authority so transports cannot
+ * drift from restore and active-server policy.
  */
 function iosRuntimeHasOnDeviceAgent(): boolean {
-  const mode = readRuntimeMode();
-  return (
-    mode === "local" || mode === "cloud-hybrid" || mode === "tunnel-to-mobile"
+  return isCommittedOnDeviceMobileRuntimeMode(
+    normalizeMobileRuntimeMode(readRuntimeMode()),
   );
 }
 
@@ -695,7 +709,7 @@ export function isIosInProcessLocalAgentUrl(url: string): boolean {
     // network policy rather than treating it as an in-process agent URL.
     return false;
   }
-  return isNativeIos() && isMobileLocalAgentUrl(url);
+  return isNativeIos() && isIosOnDeviceAgentHttpUrl(url);
 }
 
 export function isIosInProcessLocalAgentBase(
@@ -1126,7 +1140,7 @@ function shouldBridgeFetchUrl(url: URL): boolean {
       "iOS store/cloud builds block cleartext loopback or private-network requests",
     );
   }
-  if (isMobileLocalAgentUrl(url.toString())) return true;
+  if (isIosOnDeviceAgentHttpUrl(url.toString())) return true;
   if (isNativeIosCloudRuntime()) return false;
   if ((url.pathname || "").startsWith("/api/")) {
     return (


### PR DESCRIPTION
## Summary

- preserve direct HTTP fetches to a Mac-hosted Eliza runtime when iOS uses `remote-mac`, `cloud`, or `tunnel-to-mobile`
- retain native `Agent.request` routing for the bundled `local` and `cloud-hybrid` modes and for explicit `eliza-local-agent://ipc` requests
- apply the same persisted runtime-mode authority in both maintained TypeScript transports and the pre-module HTML fetch bootstrap

Closes #20259.

## Root cause

Three iOS fetch selectors classified every loopback `:31337` URL as the bundled on-device agent. In `remote-mac` mode that intercepted requests before normal networking and produced `iOS local agent request failed: A JavaScript exception occurred`, even though the Mac runtime was healthy.

## User impact

A developer can run Eliza locally on the Mac with a BYO model provider, select the remote-Mac runtime in the local-enabled iOS build, and use the app without Eliza Cloud authentication. Bundled local and cloud-hybrid behavior stays unchanged.

## Verification

- focused Vitest: 55/55 across app, app-core, and UI transport contracts
- `packages/app`, `packages/app-core`, and `packages/ui` typechecks: passed
- exact six-file Biome and `git diff --check`: passed
- root `bun run verify`: passed
- app aesthetic audit: 219/219 passed; 0 broken, 0 needs-work; OCR 0 broken
- iOS local-enabled Simulator build: succeeded, renderer `cc734a4f39bb`
- fresh iPhone Simulator smoke against `http://127.0.0.1:31337`: home/composer reached, direct mixed-content health passed, cold relaunch passed, liveness harness passed
- Mac runtime health: ready/canRespond/runtime/database healthy; real Cerebras chat separately returned the exact requested response

The screenshots and MP4 are captured locally for the draft evidence handoff. No secret values, Cloud credentials, staging, production, or provider-console state were used or changed.

## Scope

Exactly six paths under `packages/app`, `packages/app-core`, and `packages/ui`. No Cloud backend, auth, provisioning, runtime, or `packages/app/src/main.tsx` changes.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/slopdotcash@332dc64deec632ac7746f237f0f30d4aad6050d5:skills/contribute-to-eliza/SKILL.md
Attribution status: self-reported
— [codex / ios-remote-mac-http]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/slopdotcash@332dc64deec632ac7746f237f0f30d4aad6050d5:skills/contribute-to-eliza"} -->