### PR TITLE
fix(cloud): deploy Worker secrets atomically

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -94,8 +94,8 @@ jobs:
     name: Deploy API Worker
     # Scope the job to the same GitHub environment as migrate-db so its
     # production-environment secrets — notably STEWARD_PLATFORM_KEYS (#11461) —
-    # are visible to the publish-secrets step. Without this the un-scoped job
-    # only saw repo secrets, so `publish_secret` skipped the key and a redeploy
+    # are visible to the atomic secret-preparation step. Without this the un-scoped job
+    # only saw repo secrets, so secret preparation skipped the key and a redeploy
     # would silently recreate the #11461 tenant-isolation gap (#11937). Mirrors
     # the proven migrate-db declaration exactly (same protection semantics).
     environment: ${{ inputs.target_environment }}
@@ -402,7 +402,8 @@ jobs:
           fi
           echo "Staging session exchange is off before config validation or deploy ($result)."
 
-      - name: Publish Worker AI secrets
+      - name: Prepare Worker secrets for atomic deploy
+        id: worker-secrets
         if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true'
         working-directory: ${{ env.CHECKOUT_DIR }}/packages/cloud/api
         env:
@@ -448,7 +449,7 @@ jobs:
           # deployed Worker always point at the same Whisper host. Without
           # this the Worker falls through to ElevenLabs, whose free-tier quota
           # block surfaces as a persistent 503 on STT (and 502 through the
-          # agent's /api/asr/cloud proxy). Published via publish_toggle_secret:
+          # agent's /api/asr/cloud proxy). Managed via queue_toggle_secret:
           # unset DELETES the Worker secret (presence toggles the route).
           WHISPER_STT_URL: ${{ vars.ELIZA_VOICE_WHISPER_STT_URL }}
           # Optional model pin for the hosted Whisper service (defaults to
@@ -464,7 +465,7 @@ jobs:
           CARTESIA_BATCH_STT_TIMEOUT_MS: ${{ vars.CARTESIA_BATCH_STT_TIMEOUT_MS }}
           # Ed25519 keypair for the signed voice-model catalog —
           # /v1/voice-models/catalog 503s while the signing key is unset
-          # (#13406). publish_secret no-ops with a notice while these are
+          # (#13406). queue_secret no-ops with a notice while these are
           # unset, so they publish on every redeploy once ops adds them.
           ELIZA_VOICE_CATALOG_SIGNING_KEY_BASE64: ${{ secrets.ELIZA_VOICE_CATALOG_SIGNING_KEY_BASE64 }}
           ELIZA_VOICE_CATALOG_PUBLIC_KEY_BASE64: ${{ secrets.ELIZA_VOICE_CATALOG_PUBLIC_KEY_BASE64 }}
@@ -504,7 +505,7 @@ jobs:
           STEWARD_REQUEST_SIGNING_SECRET: ${{ secrets.STEWARD_REQUEST_SIGNING_SECRET }}
           # Platform key the Worker forwards as X-Steward-Platform-Key so per-org
           # sandbox Steward tenants provision instead of collapsing onto the
-          # shared default tenant (#11461). publish_secret no-ops with a notice
+          # shared default tenant (#11461). queue_secret no-ops with a notice
           # while unset, so this is safe before ops adds the GH env secret and
           # keeps it published on every redeploy once they do.
           STEWARD_PLATFORM_KEYS: ${{ secrets.STEWARD_PLATFORM_KEYS }}
@@ -516,6 +517,8 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
+          set -euo pipefail
+
           has_nonblank_value() {
             local value="${1:-}"
             [ -n "${value//[[:space:]]/}" ]
@@ -540,7 +543,7 @@ jobs:
 
           # Production provider and bridge values remain managed Worker
           # secrets. A protected-environment value may create or rotate one;
-          # a blank source preserves it, and names are verified before deploy.
+          # a blank source preserves it, and names are verified after deploy.
 
           # Staging advertises realtime only when the repository variable
           # VOICE_REALTIME_WS_ENABLED is explicitly truthy. Refuse that opt-in
@@ -618,7 +621,10 @@ jobs:
             exit 1
           fi
 
-          publish_secret() {
+          declare -a worker_secret_names=()
+          declare -A queued_worker_secret_names=()
+
+          queue_secret() {
             local name="$1"
             local value="${!name:-}"
             case "$name" in
@@ -654,20 +660,14 @@ jobs:
               echo "::notice::$name is not configured; skipping"
               return 0
             fi
-            for attempt in 1 2 3; do
-              if printf '%s' "$value" | bunx wrangler versions secret put "$name" ${{ steps.env.outputs.wrangler_args }}; then
-                return 0
-              fi
-              if [ "$attempt" -lt 3 ]; then
-                echo "::warning::wrangler versions secret put $name failed on attempt $attempt; retrying in 10s"
-                sleep 10
-              fi
-            done
-            echo "::error::wrangler versions secret put $name failed after 3 attempts"
-            return 1
+            if [ -z "${queued_worker_secret_names[$name]+configured}" ]; then
+              worker_secret_names+=("$name")
+              queued_worker_secret_names["$name"]=true
+            fi
+            return 0
           }
 
-          verify_production_voice_secret_bindings() {
+          verify_production_voice_secret_candidates() {
             if [ "$DEPLOY_ENVIRONMENT" != "production" ] || \
                ! is_truthy "$VOICE_REALTIME_WS_ENABLED"; then
               return 0
@@ -682,32 +682,33 @@ jobs:
                 : Array.isArray(parsed?.result)
                   ? parsed.result
                   : [];
-              const present = new Set(entries.map((entry) => entry?.name).filter(Boolean));
+              const available = new Set(entries.map((entry) => entry?.name).filter(Boolean));
+              for (const name of process.argv.slice(1)) available.add(name);
               const required = [
                 "CARTESIA_API_KEY",
                 "VOICE_REALTIME_CARTESIA_VOICE_ID",
                 "VOICE_REALTIME_ELIZA_AUTHORIZATION",
                 "VOICE_REALTIME_ELIZA_ENDPOINT",
               ];
-              const missing = required.filter((name) => !present.has(name));
+              const missing = required.filter((name) => !available.has(name));
               if (missing.length > 0) {
-                console.error(`::error::Production realtime voice is missing managed Worker secret binding name(s): ${missing.join(" ")}`);
+                console.error(`::error::Production realtime voice cannot be deployed; missing existing or configured Worker binding name(s): ${missing.join(" ")}`);
                 process.exit(1);
               }
-              console.log(`Verified ${required.length} managed production voice secret binding names; values were not read.`);
-            '
+              console.log(`Verified ${required.length} existing or configured production voice binding names; values were not read.`);
+            ' "${worker_secret_names[@]}"
           }
 
-          # Like publish_secret, but for values that act as ROUTING TOGGLES
+          # Like queue_secret, but for values that act as ROUTING TOGGLES
           # (code branches on presence, e.g. `env.WHISPER_STT_URL`). An unset
           # source must DELETE any previously published secret. A plain
           # skip would leave a stale toggle active on the Worker forever
           # (e.g. STT pinned to a dead Whisper host during an outage).
-          publish_toggle_secret() {
+          queue_toggle_secret() {
             local name="$1"
             local value="${!name:-}"
             if [ -n "$value" ]; then
-              publish_secret "$name"
+              queue_secret "$name"
               return $?
             fi
             # Unset: use a names-only inventory before and after deletion so
@@ -728,7 +729,7 @@ jobs:
           # secret publication and the intentional code cutover.
           STAGING_SESSION_EXCHANGE_ENABLED=""
           export STAGING_SESSION_EXCHANGE_ENABLED
-          publish_toggle_secret STAGING_SESSION_EXCHANGE_ENABLED || exit 1
+          queue_toggle_secret STAGING_SESSION_EXCHANGE_ENABLED || exit 1
 
           staging_session_config_names=(
             STAGING_SESSION_EXCHANGE_VERSION
@@ -741,7 +742,7 @@ jobs:
           if [ "$DEPLOY_ENVIRONMENT" = "staging" ] && \
              is_truthy "$STAGING_SESSION_EXCHANGE_DESIRED_ENABLED"; then
             for name in "${staging_session_config_names[@]}"; do
-              publish_toggle_secret "$name" || exit 1
+              queue_toggle_secret "$name" || exit 1
             done
           else
             # Disabled/non-staging environments retain no stale QA signer or
@@ -749,12 +750,12 @@ jobs:
             for name in "${staging_session_config_names[@]}"; do
               printf -v "$name" '%s' ""
               export "${name?}"
-              publish_toggle_secret "$name" || exit 1
+              queue_toggle_secret "$name" || exit 1
             done
           fi
 
-          # Publish only values explicitly configured in this protected GitHub
-          # environment. publish_secret intentionally skips blank values, which
+          # Queue only values explicitly configured in this protected GitHub
+          # environment. queue_secret intentionally skips blank values, which
           # preserves an existing Cloudflare binding that GitHub cannot recover.
           managed_worker_provisioning_secrets=(
             DATABASE_URL
@@ -764,7 +765,7 @@ jobs:
             TUNNEL_HOSTNAME_SIGNING_SECRET
           )
           for name in "${managed_worker_provisioning_secrets[@]}"; do
-            publish_secret "$name" || exit 1
+            queue_secret "$name" || exit 1
           done
 
           for name in \
@@ -795,12 +796,12 @@ jobs:
             OIDC_CLIENTS \
             ELIZA_APP_WEBHOOK_GATEWAY_SECRET
           do
-            publish_secret "$name"
+            queue_secret "$name"
           done
 
           # Routing toggles: presence changes code paths, so unset must delete.
-          # A failed put must fail the step (never deploy with a half-applied
-          # toggle), matching the publish_secret loop's set -e behavior.
+          # A failed removal must fail the step. Configured toggle values join
+          # the exact Worker deploy rather than mutating an earlier version.
           for name in \
             CARTESIA_API_KEY \
             CARTESIA_VOICE_ID \
@@ -811,13 +812,24 @@ jobs:
             CARTESIA_BATCH_STT_TIMEOUT_MS \
             ELIZA_APP_WEBHOOK_GATEWAY_URL
           do
-            publish_toggle_secret "$name" || exit 1
+            queue_toggle_secret "$name" || exit 1
           done
 
-          # Keep production voice fail-closed against its currently served
-          # credential set. The post-deploy check below verifies the complete
-          # served binding set after the intentional code cutover.
-          verify_production_voice_secret_bindings || exit 1
+          # Preserve the production fail-closed boundary without mutating the
+          # active Worker: every required voice name must either already exist
+          # or be queued for the atomic version below.
+          verify_production_voice_secret_candidates || exit 1
+
+          # Wrangler deploy accepts this JSON additively: named values are
+          # committed in the same Worker version as the exact source, while
+          # omitted preserve-only bindings remain untouched. This also recovers
+          # when Cloudflare has an undeployed latest version, where standalone
+          # `wrangler secret put` refuses to proceed.
+          worker_secrets_file="$(node \
+            "$CHECKOUT_DIR/packages/cloud/scripts/worker-secrets-file.mjs" \
+            create "$RUNNER_TEMP" "${worker_secret_names[@]}")"
+          echo "secrets_file=$worker_secrets_file" >> "$GITHUB_OUTPUT"
+          echo "Prepared ${#worker_secret_names[@]} configured Worker bindings for the atomic deploy; values were not printed."
 
       - name: Deploy to Cloudflare Workers
         if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true'
@@ -834,7 +846,9 @@ jobs:
           FISH_AUDIO_MODEL: ${{ vars.FISH_AUDIO_MODEL || 's2.1-pro' }}
           FISH_AUDIO_SAMPLE_RATE: "16000"
           FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS: ${{ vars.FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS || '1500' }}
+          WORKER_SECRETS_FILE: ${{ steps.worker-secrets.outputs.secrets_file }}
         run: |
+          set -euo pipefail
           legacy_onboarding_secret_removed=false
           restore_legacy_onboarding_secrets() {
             if [ "$legacy_onboarding_secret_removed" != "true" ]; then
@@ -865,7 +879,16 @@ jobs:
             return 0
           }
 
-          args=(${{ steps.env.outputs.wrangler_args }} --var ELIZA_DEPLOY_COMMIT:"$GITHUB_SHA" --var VOICE_REALTIME_WS_ENABLED:"$VOICE_REALTIME_WS_ENABLED" --var ELIZA_TTS_FISH_ENABLED:"$ELIZA_TTS_FISH_ENABLED" --var FISH_AUDIO_DATA_GOVERNANCE_APPROVED:"$FISH_AUDIO_DATA_GOVERNANCE_APPROVED" --var FISH_AUDIO_MODEL:"$FISH_AUDIO_MODEL" --var FISH_AUDIO_SAMPLE_RATE:"$FISH_AUDIO_SAMPLE_RATE" --var FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS:"$FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS")
+          if [ -z "${WORKER_SECRETS_FILE:-}" ] || [ ! -f "$WORKER_SECRETS_FILE" ] || [ -L "$WORKER_SECRETS_FILE" ]; then
+            echo "::error::Atomic Worker secrets file is missing or invalid."
+            exit 1
+          fi
+          if [ "$(stat -c '%a' "$WORKER_SECRETS_FILE")" != "600" ]; then
+            echo "::error::Atomic Worker secrets file does not have mode 600."
+            exit 1
+          fi
+
+          args=(${{ steps.env.outputs.wrangler_args }} --secrets-file "$WORKER_SECRETS_FILE" --var ELIZA_DEPLOY_COMMIT:"$GITHUB_SHA" --var VOICE_REALTIME_WS_ENABLED:"$VOICE_REALTIME_WS_ENABLED" --var ELIZA_TTS_FISH_ENABLED:"$ELIZA_TTS_FISH_ENABLED" --var FISH_AUDIO_DATA_GOVERNANCE_APPROVED:"$FISH_AUDIO_DATA_GOVERNANCE_APPROVED" --var FISH_AUDIO_MODEL:"$FISH_AUDIO_MODEL" --var FISH_AUDIO_SAMPLE_RATE:"$FISH_AUDIO_SAMPLE_RATE" --var FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS:"$FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS")
           if [ -n "${KOKORO_TTS_URL:-}" ]; then
             args+=(--var KOKORO_TTS_URL:"$KOKORO_TTS_URL")
           else
@@ -879,12 +902,21 @@ jobs:
           bunx wrangler deploy "${args[@]}"
           trap - ERR
 
+      - name: Remove atomic Worker secrets file
+        if: ${{ always() && steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true' }}
+        run: |
+          set -euo pipefail
+          node "$CHECKOUT_DIR/packages/cloud/scripts/worker-secrets-file.mjs" \
+            remove-all "$RUNNER_TEMP"
+
       - name: Verify required Worker secret binding names
         if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true'
         working-directory: ${{ env.CHECKOUT_DIR }}/packages/cloud/api
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          DEPLOY_ENVIRONMENT: ${{ steps.env.outputs.deploy_environment }}
+          VOICE_REALTIME_WS_ENABLED: ${{ (steps.env.outputs.deploy_environment == 'production' || contains(fromJSON('["1","true","TRUE","True","yes","YES","Yes","on","ON","On"]'), vars.VOICE_REALTIME_WS_ENABLED)) && 'true' || 'false' }}
         run: |
           set -euo pipefail
           secret_inventory="$(bunx wrangler@4.100.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
@@ -912,6 +944,17 @@ jobs:
               "STEWARD_PLATFORM_KEYS",
               "STEWARD_TENANT_API_KEY",
             ];
+            if (
+              process.env.DEPLOY_ENVIRONMENT === "production" &&
+              process.env.VOICE_REALTIME_WS_ENABLED === "true"
+            ) {
+              required.push(
+                "CARTESIA_API_KEY",
+                "VOICE_REALTIME_CARTESIA_VOICE_ID",
+                "VOICE_REALTIME_ELIZA_AUTHORIZATION",
+                "VOICE_REALTIME_ELIZA_ENDPOINT",
+              );
+            }
             const missing = required.filter((name) => !present.has(name));
             if (missing.length > 0) {
               console.error(`::error::Missing required Worker secret binding name(s): ${missing.join(" ")}`);

--- a/packages/cloud/scripts/__tests__/worker-secrets-file.test.ts
+++ b/packages/cloud/scripts/__tests__/worker-secrets-file.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Exercises the runner-private Worker secrets file boundary with real files,
+ * including permissions, value fidelity, validation, and cleanup containment.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "../../../scripts/lib/spawn-sync-captured.mjs";
+import {
+  buildWorkerSecrets,
+  createWorkerSecretsFile,
+  removeWorkerSecretsFile,
+} from "../worker-secrets-file.mjs";
+
+const temporaryDirectories: string[] = [];
+const scriptPath = new URL("../worker-secrets-file.mjs", import.meta.url)
+  .pathname;
+
+function makeTemporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "worker-secrets-file-test-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe("Worker secrets payload", () => {
+  test("preserves exact values without inheriting unnamed environment data", () => {
+    const payload = buildWorkerSecrets(["DATABASE_URL", "OIDC_CLIENTS"], {
+      DATABASE_URL: "postgres://example.test/a?token=sensitive",
+      OIDC_CLIENTS: '{"client":"secret"}',
+      UNNAMED_SECRET: "must-not-be-written",
+    });
+
+    expect(payload).toEqual({
+      DATABASE_URL: "postgres://example.test/a?token=sensitive",
+      OIDC_CLIENTS: '{"client":"secret"}',
+    });
+    expect(JSON.stringify(payload)).not.toContain("must-not-be-written");
+  });
+
+  test("rejects malformed, duplicated, and blank requested names", () => {
+    expect(() => buildWorkerSecrets(["lowercase"], {})).toThrow(
+      "name is invalid",
+    );
+    expect(() =>
+      buildWorkerSecrets(["DATABASE_URL", "DATABASE_URL"], {
+        DATABASE_URL: "configured",
+      }),
+    ).toThrow("duplicated");
+    expect(() =>
+      buildWorkerSecrets(["DATABASE_URL"], { DATABASE_URL: " " }),
+    ).toThrow("missing or blank");
+  });
+});
+
+describe("Worker secrets file lifecycle", () => {
+  test("creates mode-0600 JSON and removes the exact owned file", () => {
+    const runnerTemp = makeTemporaryDirectory();
+    const filePath = createWorkerSecretsFile({
+      runnerTemp,
+      names: ["DATABASE_URL", "OIDC_CLIENTS"],
+      environment: {
+        DATABASE_URL: "postgres://configured",
+        OIDC_CLIENTS: "[]",
+      },
+    });
+
+    expect(
+      filePath.startsWith(`${realpathSync(runnerTemp)}/eliza-worker-secrets-`),
+    ).toBe(true);
+    expect(lstatSync(filePath).mode & 0o777).toBe(0o600);
+    expect(JSON.parse(readFileSync(filePath, "utf8"))).toEqual({
+      DATABASE_URL: "postgres://configured",
+      OIDC_CLIENTS: "[]",
+    });
+
+    removeWorkerSecretsFile({ runnerTemp, filePath });
+    expect(() => lstatSync(filePath)).toThrow();
+    expect(() =>
+      removeWorkerSecretsFile({ runnerTemp, filePath }),
+    ).not.toThrow();
+  });
+
+  test("rejects paths outside the owned naming and directory boundary", () => {
+    const runnerTemp = makeTemporaryDirectory();
+    const otherDirectory = makeTemporaryDirectory();
+    const unrelated = join(runnerTemp, "unrelated.json");
+    writeFileSync(unrelated, "{}", { mode: 0o600 });
+
+    expect(() =>
+      removeWorkerSecretsFile({ runnerTemp, filePath: unrelated }),
+    ).toThrow("outside the owned runner path");
+    expect(() =>
+      removeWorkerSecretsFile({
+        runnerTemp,
+        filePath: join(
+          otherDirectory,
+          "eliza-worker-secrets-00000000-0000-4000-8000-000000000000.json",
+        ),
+      }),
+    ).toThrow("outside the owned runner path");
+  });
+
+  test("does not follow a symlink with an owned-looking name", () => {
+    const runnerTemp = makeTemporaryDirectory();
+    const target = join(runnerTemp, "target.json");
+    const link = join(
+      runnerTemp,
+      "eliza-worker-secrets-00000000-0000-4000-8000-000000000000.json",
+    );
+    writeFileSync(target, "{}", { mode: 0o600 });
+    symlinkSync(target, link);
+
+    expect(() =>
+      removeWorkerSecretsFile({ runnerTemp, filePath: link }),
+    ).toThrow("not an owned regular file");
+    expect(readFileSync(target, "utf8")).toBe("{}");
+  });
+
+  test("removes all owned files without touching unrelated runner files", () => {
+    const runnerTemp = makeTemporaryDirectory();
+    const first = createWorkerSecretsFile({
+      runnerTemp,
+      names: ["DATABASE_URL"],
+      environment: { DATABASE_URL: "first" },
+    });
+    const second = createWorkerSecretsFile({
+      runnerTemp,
+      names: ["OIDC_CLIENTS"],
+      environment: { OIDC_CLIENTS: "second" },
+    });
+    const unrelated = join(runnerTemp, "unrelated.json");
+    writeFileSync(unrelated, "{}", { mode: 0o600 });
+
+    const removed = spawnSync(
+      process.execPath,
+      [scriptPath, "remove-all", runnerTemp],
+      { encoding: "utf8", env: process.env },
+    );
+
+    expect(removed.status, `${removed.stdout}${removed.stderr}`).toBe(0);
+    expect(() => lstatSync(first)).toThrow();
+    expect(() => lstatSync(second)).toThrow();
+    expect(readFileSync(unrelated, "utf8")).toBe("{}");
+  });
+
+  test("executable create and remove expose only the owned path", () => {
+    const runnerTemp = makeTemporaryDirectory();
+    const sensitiveValue = "sensitive-value-must-not-reach-output";
+    const created = spawnSync(
+      process.execPath,
+      [scriptPath, "create", runnerTemp, "DATABASE_URL"],
+      {
+        encoding: "utf8",
+        env: { ...process.env, DATABASE_URL: sensitiveValue },
+      },
+    );
+
+    expect(created.status, `${created.stdout}${created.stderr}`).toBe(0);
+    expect(`${created.stdout}${created.stderr}`).not.toContain(sensitiveValue);
+    const filePath = String(created.stdout).trim();
+    expect(JSON.parse(readFileSync(filePath, "utf8"))).toEqual({
+      DATABASE_URL: sensitiveValue,
+    });
+
+    const removed = spawnSync(
+      process.execPath,
+      [scriptPath, "remove", runnerTemp, filePath],
+      { encoding: "utf8", env: process.env },
+    );
+    expect(removed.status, `${removed.stdout}${removed.stderr}`).toBe(0);
+    expect(`${removed.stdout}${removed.stderr}`).not.toContain(sensitiveValue);
+    expect(() => lstatSync(filePath)).toThrow();
+  });
+});

--- a/packages/cloud/scripts/worker-secrets-file.mjs
+++ b/packages/cloud/scripts/worker-secrets-file.mjs
@@ -1,0 +1,170 @@
+/**
+ * Materializes configured Worker secrets in a runner-private JSON file for an
+ * atomic Wrangler code-and-secrets deployment, then removes only files it owns.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  lstatSync,
+  openSync,
+  readdirSync,
+  realpathSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, isAbsolute, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const SECRET_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+const OWNED_FILE_PATTERN =
+  /^eliza-worker-secrets-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.json$/;
+
+/** Build the exact nonblank string-valued secret payload named by the caller. */
+export function buildWorkerSecrets(names, environment = process.env) {
+  if (!Array.isArray(names)) {
+    throw new Error("Worker secret names must be an array");
+  }
+
+  const secrets = Object.create(null);
+  const seen = new Set();
+  for (const name of names) {
+    if (typeof name !== "string" || !SECRET_NAME_PATTERN.test(name)) {
+      throw new Error("Worker secret name is invalid");
+    }
+    if (seen.has(name)) {
+      throw new Error(`Worker secret name is duplicated: ${name}`);
+    }
+    seen.add(name);
+
+    const value = environment[name];
+    if (typeof value !== "string" || value.trim().length === 0) {
+      throw new Error(`Worker secret ${name} is missing or blank`);
+    }
+    secrets[name] = value;
+  }
+  return secrets;
+}
+
+function resolveRunnerTemp(runnerTemp) {
+  if (typeof runnerTemp !== "string" || !isAbsolute(runnerTemp)) {
+    throw new Error("Runner temp directory must be an absolute path");
+  }
+  const resolved = realpathSync(runnerTemp);
+  if (!lstatSync(resolved).isDirectory()) {
+    throw new Error("Runner temp path is not a directory");
+  }
+  return resolved;
+}
+
+/** Write one mode-0600 JSON file beneath the exact runner temp directory. */
+export function createWorkerSecretsFile({
+  runnerTemp,
+  names,
+  environment = process.env,
+}) {
+  const resolvedRunnerTemp = resolveRunnerTemp(runnerTemp);
+  const secrets = buildWorkerSecrets(names, environment);
+  const outputPath = join(
+    resolvedRunnerTemp,
+    `eliza-worker-secrets-${randomUUID()}.json`,
+  );
+
+  let descriptor;
+  try {
+    descriptor = openSync(outputPath, "wx", 0o600);
+    writeFileSync(descriptor, `${JSON.stringify(secrets)}\n`, {
+      encoding: "utf8",
+    });
+    closeSync(descriptor);
+    descriptor = undefined;
+    chmodSync(outputPath, 0o600);
+    return outputPath;
+  } catch (error) {
+    if (descriptor !== undefined) closeSync(descriptor);
+    try {
+      unlinkSync(outputPath);
+    } catch {
+      // error-policy:J6 Cleanup is best effort after file creation failed.
+    }
+    throw error;
+  }
+}
+
+/** Remove only a regular, non-symlink file created by this module. */
+export function removeWorkerSecretsFile({ runnerTemp, filePath }) {
+  const resolvedRunnerTemp = resolveRunnerTemp(runnerTemp);
+  if (
+    typeof filePath !== "string" ||
+    !isAbsolute(filePath) ||
+    realpathSync(dirname(filePath)) !== resolvedRunnerTemp ||
+    !OWNED_FILE_PATTERN.test(basename(filePath))
+  ) {
+    throw new Error("Worker secrets file is outside the owned runner path");
+  }
+
+  let stat;
+  try {
+    stat = lstatSync(filePath);
+  } catch (error) {
+    if (error && typeof error === "object" && error.code === "ENOENT") return;
+    throw error;
+  }
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error("Worker secrets path is not an owned regular file");
+  }
+  unlinkSync(filePath);
+}
+
+/** Remove every owned Worker-secrets file directly beneath runner temp. */
+export function removeWorkerSecretsFiles({ runnerTemp }) {
+  const resolvedRunnerTemp = resolveRunnerTemp(runnerTemp);
+  for (const entry of readdirSync(resolvedRunnerTemp)) {
+    if (!OWNED_FILE_PATTERN.test(entry)) continue;
+    removeWorkerSecretsFile({
+      runnerTemp: resolvedRunnerTemp,
+      filePath: join(resolvedRunnerTemp, entry),
+    });
+  }
+}
+
+function usage() {
+  throw new Error(
+    "Usage: worker-secrets-file.mjs create <runner-temp> <NAME...> | remove <runner-temp> <file> | remove-all <runner-temp>",
+  );
+}
+
+function main() {
+  const [operation, runnerTemp, ...args] = process.argv.slice(2);
+  if (operation === "create" && runnerTemp && args.length > 0) {
+    process.stdout.write(
+      `${createWorkerSecretsFile({ runnerTemp, names: args })}\n`,
+    );
+    return;
+  }
+  if (operation === "remove" && runnerTemp && args.length === 1) {
+    removeWorkerSecretsFile({ runnerTemp, filePath: args[0] });
+    return;
+  }
+  if (operation === "remove-all" && runnerTemp && args.length === 0) {
+    removeWorkerSecretsFiles({ runnerTemp });
+    return;
+  }
+  usage();
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    main();
+  } catch (error) {
+    // error-policy:J1 The CLI boundary reports only the typed operation failure.
+    process.stderr.write(
+      `${error instanceof Error ? error.message : "Worker secrets file operation failed"}\n`,
+    );
+    process.exitCode = 1;
+  }
+}

--- a/packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Pins the Cloud release workflow to an atomic Worker code-and-secrets deploy,
+ * including private-file ownership, cleanup, and post-deploy name verification.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const repoRoot = new URL("../../../", import.meta.url);
+const source = readFileSync(
+  new URL(".github/workflows/cloud-cf-release.yml", repoRoot),
+  "utf8",
+);
+
+interface WorkflowStep {
+  name?: string;
+  id?: string;
+  if?: string;
+  env?: Record<string, string>;
+  run?: string;
+}
+
+interface Workflow {
+  jobs?: Record<string, { steps?: WorkflowStep[] }>;
+}
+
+const workflow = Bun.YAML.parse(source) as Workflow;
+const steps = workflow.jobs?.["deploy-api"]?.steps ?? [];
+
+function step(name: string): WorkflowStep {
+  const found = steps.find((candidate) => candidate.name === name);
+  if (!found?.run) throw new Error(`Missing executable workflow step: ${name}`);
+  return found;
+}
+
+function index(name: string): number {
+  return steps.findIndex((candidate) => candidate.name === name);
+}
+
+describe("Cloud CF atomic Worker secrets deploy", () => {
+  test("prepares configured values without mutating a pre-deploy Worker version", () => {
+    const prepare = step("Prepare Worker secrets for atomic deploy");
+    expect(prepare.id).toBe("worker-secrets");
+    expect(prepare.run).toContain("declare -a worker_secret_names=()");
+    expect(prepare.run).toContain("queue_secret() {");
+    expect(prepare.run).toContain("queue_toggle_secret() {");
+    expect(prepare.run).toContain("worker-secrets-file.mjs");
+    expect(prepare.run).toContain('create "$RUNNER_TEMP"');
+    expect(prepare.run).toContain('>> "$GITHUB_OUTPUT"');
+    expect(prepare.run).not.toContain("bunx wrangler secret put");
+    expect(prepare.run).not.toContain('echo "$value"');
+    expect(prepare.run).not.toContain("printf '%s' \"$value\"");
+  });
+
+  test("commits the private payload with exact code and cleans it on every outcome", () => {
+    const prepareIndex = index("Prepare Worker secrets for atomic deploy");
+    const deployIndex = index("Deploy to Cloudflare Workers");
+    const cleanupIndex = index("Remove atomic Worker secrets file");
+    const verifyIndex = index("Verify required Worker secret binding names");
+    expect(prepareIndex).toBeGreaterThan(0);
+    expect(deployIndex).toBeGreaterThan(prepareIndex);
+    expect(cleanupIndex).toBe(deployIndex + 1);
+    expect(verifyIndex).toBeGreaterThan(cleanupIndex);
+
+    const deploy = step("Deploy to Cloudflare Workers");
+    expect(deploy.env?.WORKER_SECRETS_FILE).toBe(
+      "$" + "{{ steps.worker-secrets.outputs.secrets_file }}",
+    );
+    expect(deploy.run).toContain('[ ! -f "$WORKER_SECRETS_FILE" ]');
+    expect(deploy.run).toContain('[ -L "$WORKER_SECRETS_FILE" ]');
+    expect(deploy.run).toContain("stat -c '%a'");
+    expect(deploy.run).toContain('--secrets-file "$WORKER_SECRETS_FILE"');
+    expect(deploy.run).toContain("bunx wrangler deploy");
+    expect(deploy.run).toContain('"$' + '{args[@]}"');
+
+    const cleanup = step("Remove atomic Worker secrets file");
+    expect(cleanup.if).toContain("always()");
+    expect(cleanup.if).toContain("steps.cf.outputs.configured == 'true'");
+    expect(cleanup.if).toContain(
+      "steps.freshness.outputs.should_deploy == 'true'",
+    );
+    expect(cleanup.env).toBeUndefined();
+    expect(cleanup.run).toContain("worker-secrets-file.mjs");
+    expect(cleanup.run).toContain('remove-all "$RUNNER_TEMP"');
+  });
+
+  test("preserves omitted bindings and verifies authoritative names after deploy", () => {
+    const prepare = step("Prepare Worker secrets for atomic deploy");
+    expect(prepare.run).toContain(
+      "omitted preserve-only bindings remain untouched",
+    );
+    expect(prepare.run).toContain(
+      'echo "::notice::$name is not configured; skipping"',
+    );
+
+    const verify = step("Verify required Worker secret binding names");
+    expect(verify.run).toContain("wrangler@4.100.0 secret list");
+    expect(verify.run).toContain("values were not read");
+    expect(verify.run).toContain('"DATABASE_URL"');
+    expect(verify.run).toContain('"OIDC_SIGNING_JWKS"');
+    expect(verify.run).toContain('"STEWARD_TENANT_API_KEY"');
+    expect(verify.run).toContain('"VOICE_REALTIME_ELIZA_AUTHORIZATION"');
+  });
+
+  test("keeps post-deploy session activation separate from the atomic payload", () => {
+    const prepare = step("Prepare Worker secrets for atomic deploy");
+    const activation = step(
+      "Activate and verify staging session exchange after deploy proof",
+    );
+    expect(prepare.run).not.toContain(
+      "wrangler secret put STAGING_SESSION_EXCHANGE_ENABLED",
+    );
+    expect(activation.run).toContain(
+      "wrangler secret put STAGING_SESSION_EXCHANGE_ENABLED --env staging",
+    );
+    expect(index("Verify deployed API commit")).toBeLessThan(
+      index("Activate and verify staging session exchange after deploy proof"),
+    );
+  });
+});

--- a/packages/scripts/__tests__/cloud-cf-staging-session-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-staging-session-deploy-workflow.test.ts
@@ -56,7 +56,7 @@ describe("Cloud CF staging session cutover", () => {
     const ordered = [
       "Deploy freshness guard",
       "Disable staging session exchange before cutover",
-      "Publish Worker AI secrets",
+      "Prepare Worker secrets for atomic deploy",
       "Deploy to Cloudflare Workers",
       "Verify deployed API commit",
       "Activate and verify staging session exchange after deploy proof",
@@ -72,15 +72,15 @@ describe("Cloud CF staging session cutover", () => {
     );
     expect(disable.run).not.toContain('grep -qi "not found"');
 
-    const publish = step("Publish Worker AI secrets");
+    const publish = step("Prepare Worker secrets for atomic deploy");
     expect(publish.if).toContain("steps.freshness.outputs.should_deploy");
     expect(publish.run).toContain('STAGING_SESSION_EXCHANGE_ENABLED=""');
     expect(publish.run).toContain(
-      "publish_toggle_secret STAGING_SESSION_EXCHANGE_ENABLED",
+      "queue_toggle_secret STAGING_SESSION_EXCHANGE_ENABLED",
     );
     expect(
       publish.run?.indexOf(
-        "publish_toggle_secret STAGING_SESSION_EXCHANGE_ENABLED",
+        "queue_toggle_secret STAGING_SESSION_EXCHANGE_ENABLED",
       ),
     ).toBeLessThan(
       publish.run?.indexOf("staging_session_config_names=(") ?? -1,
@@ -124,7 +124,7 @@ describe("Cloud CF staging session cutover", () => {
     }
     expect(
       index("Disable staging session exchange before cutover"),
-    ).toBeLessThan(index("Publish Worker AI secrets"));
+    ).toBeLessThan(index("Prepare Worker secrets for atomic deploy"));
   });
 
   test("uses the names-only idempotent helper at every removal boundary", () => {
@@ -132,8 +132,10 @@ describe("Cloud CF staging session cutover", () => {
     expect(
       workflowSource.match(/ensure-worker-secret-absent\.mjs/g),
     ).toHaveLength(4);
-    expect(step("Publish Worker AI secrets").run).toContain('"$name" ');
-    expect(step("Publish Worker AI secrets").run).toContain(
+    expect(step("Prepare Worker secrets for atomic deploy").run).toContain(
+      '"$name" ',
+    );
+    expect(step("Prepare Worker secrets for atomic deploy").run).toContain(
       "steps.env.outputs.wrangler_args",
     );
     expect(step("Deploy to Cloudflare Workers").run).toContain(

--- a/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts
@@ -34,17 +34,23 @@ const workflowSource = read(".github/workflows/cloud-cf-release.yml");
 const workflow = Bun.YAML.parse(workflowSource) as Workflow;
 const entryWorkflow = Bun.YAML.parse(entrySource) as Workflow;
 const publishStep = workflow.jobs?.["deploy-api"]?.steps?.find(
-  (step) => step.name === "Publish Worker AI secrets",
+  (step) => step.name === "Prepare Worker secrets for atomic deploy",
 );
 const deployStep = workflow.jobs?.["deploy-api"]?.steps?.find(
   (step) => step.name === "Deploy to Cloudflare Workers",
 );
+const verifyBindingsStep = workflow.jobs?.["deploy-api"]?.steps?.find(
+  (step) => step.name === "Verify required Worker secret binding names",
+);
 
 if (!publishStep?.run) {
-  throw new Error("Missing Publish Worker AI secrets workflow step");
+  throw new Error("Missing atomic Worker secret preparation workflow step");
 }
 if (!deployStep?.run) {
   throw new Error("Missing Deploy to Cloudflare Workers workflow step");
+}
+if (!verifyBindingsStep?.run) {
+  throw new Error("Missing Worker binding verification workflow step");
 }
 
 const preflight = publishStep.run.slice(
@@ -55,10 +61,10 @@ const shellHelpers = publishStep.run.slice(
   0,
   publishStep.run.indexOf("# Construct the staging fallback"),
 );
-const secretFunctions = publishStep.run
+const productionVoiceCandidateFunction = publishStep.run
   .slice(
-    publishStep.run.indexOf("publish_secret() {"),
-    publishStep.run.indexOf("# Like publish_secret"),
+    publishStep.run.indexOf("verify_production_voice_secret_candidates() {"),
+    publishStep.run.indexOf("# Like queue_secret"),
   )
   .replaceAll("$" + "{{ steps.env.outputs.wrangler_args }}", "");
 
@@ -79,8 +85,9 @@ function requirePreflightBash(): string {
   return GNU_BASH;
 }
 
-function runPreflight(env: Record<string, string>) {
-  return spawnSync(requirePreflightBash(), ["-c", preflight], {
+function runPreflight(env: Record<string, string>, after = "") {
+  return spawnSync(requirePreflightBash(), ["-c", `${preflight}\n${after}`], {
+    cwd: new URL("packages/cloud/api/", repoRoot).pathname,
     encoding: "utf8",
     env: {
       ...process.env,
@@ -98,55 +105,30 @@ function runPreflight(env: Record<string, string>) {
       FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS: "1500",
       VOICE_REALTIME_ELIZA_AUTHORIZATION: "Bearer dedicated-test",
       VOICE_REALTIME_WS_ENABLED: "false",
+      VOICE_BATCH_STT_PROVIDER: "",
       STAGING_ELIZACLOUD_API_KEY: "",
       ...env,
     },
   });
 }
 
-function runProductionVoiceBootstrap(
-  cartesiaApiKey: string,
-  putSucceeds = true,
+function runProductionVoiceCandidateCheck(
+  existingNames: string[],
+  queuedNames: string[],
 ) {
-  const initialInventory = JSON.stringify([
-    { name: "VOICE_REALTIME_CARTESIA_VOICE_ID" },
-    { name: "VOICE_REALTIME_ELIZA_AUTHORIZATION" },
-    { name: "VOICE_REALTIME_ELIZA_ENDPOINT" },
-  ]);
-  const completeInventory = JSON.stringify([
-    { name: "CARTESIA_API_KEY" },
-    { name: "VOICE_REALTIME_CARTESIA_VOICE_ID" },
-    { name: "VOICE_REALTIME_ELIZA_AUTHORIZATION" },
-    { name: "VOICE_REALTIME_ELIZA_ENDPOINT" },
-  ]);
   const script = `${shellHelpers}
-STATE_FILE="$(mktemp)"
-trap 'rm -f "$STATE_FILE"' EXIT
-printf '%s' '${initialInventory}' > "$STATE_FILE"
 bunx() {
-  if [[ "$1" == wrangler* && "$2" == "versions" && "$3" == "secret" && "$4" == "put" ]]; then
-    cat >/dev/null
-    if [ "$PUT_SUCCEEDS" != "true" ]; then
-      return 1
-    fi
-    printf '%s' '${completeInventory}' > "$STATE_FILE"
-    return 0
-  fi
   if [[ "$1" == wrangler* && "$2" == "secret" && "$3" == "list" ]]; then
-    cat "$STATE_FILE"
+    printf '%s' '${JSON.stringify(existingNames.map((name) => ({ name })))}'
     return 0
   fi
   return 1
 }
-${secretFunctions}
 DEPLOY_ENVIRONMENT=production
 VOICE_REALTIME_WS_ENABLED=true
-VOICE_BATCH_STT_PROVIDER=""
-CARTESIA_API_KEY=${JSON.stringify(cartesiaApiKey)}
-PUT_SUCCEEDS=${JSON.stringify(String(putSucceeds))}
-sleep() { :; }
-publish_secret CARTESIA_API_KEY || exit 1
-verify_production_voice_secret_bindings || exit 1
+worker_secret_names=(${queuedNames.map((name) => JSON.stringify(name)).join(" ")})
+${productionVoiceCandidateFunction}
+verify_production_voice_secret_candidates
 `;
   return spawnSync(requirePreflightBash(), ["-c", script], {
     encoding: "utf8",
@@ -247,16 +229,23 @@ describe("Cloud CF realtime voice deploy contract", () => {
     );
     expect(productionVars).not.toContain("VOICE_REALTIME_CARTESIA_VOICE_ID");
     expect(productionVars).not.toContain("VOICE_REALTIME_ELIZA_ENDPOINT");
-    expect(publishStep.run).toContain('"VOICE_REALTIME_CARTESIA_VOICE_ID"');
-    expect(publishStep.run).toContain('"VOICE_REALTIME_ELIZA_ENDPOINT"');
-    expect(publishStep.run).toContain("managed Worker secret binding name(s)");
-    const lastPublish = publishStep.run.lastIndexOf(
-      'publish_toggle_secret "$name" || exit 1',
+    expect(verifyBindingsStep.run).toContain(
+      '"VOICE_REALTIME_CARTESIA_VOICE_ID"',
     );
-    const productionBindingVerification = publishStep.run.lastIndexOf(
-      "verify_production_voice_secret_bindings || exit 1",
+    expect(verifyBindingsStep.run).toContain('"VOICE_REALTIME_ELIZA_ENDPOINT"');
+    expect(verifyBindingsStep.run).toContain(
+      'process.env.DEPLOY_ENVIRONMENT === "production"',
     );
-    expect(productionBindingVerification).toBeGreaterThan(lastPublish);
+    expect(verifyBindingsStep.run).toContain(
+      'process.env.VOICE_REALTIME_WS_ENABLED === "true"',
+    );
+    expect(publishStep.run).toContain(
+      "verify_production_voice_secret_candidates || exit 1",
+    );
+    expect(publishStep.run).toContain(
+      "missing existing or configured Worker binding name(s)",
+    );
+    expect(deployStep.run).toContain('--secrets-file "$WORKER_SECRETS_FILE"');
     expect(wrangler).not.toContain("VOICE_AMBIENT_ENABLED");
     expect(wrangler).not.toContain("VOICE_AMBIENT_PENDANT_BASE_URL");
   });
@@ -354,26 +343,32 @@ const executedDescribe = GNU_BASH ? describe : describe.skip;
 executedDescribe(
   "Cloud CF realtime voice deploy preflight (executed verbatim)",
   () => {
-    test("bootstraps a missing production Cartesia binding before verifying names", () => {
-      const result = runProductionVoiceBootstrap("cartesia-test");
+    test("accepts a configured production voice binding without a pre-deploy write", () => {
+      const result = runProductionVoiceCandidateCheck(
+        [
+          "VOICE_REALTIME_CARTESIA_VOICE_ID",
+          "VOICE_REALTIME_ELIZA_AUTHORIZATION",
+          "VOICE_REALTIME_ELIZA_ENDPOINT",
+        ],
+        ["CARTESIA_API_KEY"],
+      );
       expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
       expect(result.stdout).toContain(
-        "Verified 4 managed production voice secret binding names",
+        "Verified 4 existing or configured production voice binding names",
       );
     });
 
-    test("fails closed when a missing production binding has no configured source", () => {
-      const result = runProductionVoiceBootstrap(" ");
+    test("fails before deploy when a production voice binding is neither existing nor configured", () => {
+      const result = runProductionVoiceCandidateCheck(
+        [
+          "VOICE_REALTIME_CARTESIA_VOICE_ID",
+          "VOICE_REALTIME_ELIZA_AUTHORIZATION",
+          "VOICE_REALTIME_ELIZA_ENDPOINT",
+        ],
+        [],
+      );
       expect(result.status).toBe(1);
       expect(`${result.stdout}${result.stderr}`).toContain("CARTESIA_API_KEY");
-    });
-
-    test("fails closed when first-time production secret publication fails", () => {
-      const result = runProductionVoiceBootstrap("cartesia-test", false);
-      expect(result.status).toBe(1);
-      expect(`${result.stdout}${result.stderr}`).toContain(
-        "wrangler versions secret put CARTESIA_API_KEY failed after 3 attempts",
-      );
     });
 
     test("does not require realtime secrets when staging opt-in is absent", () => {
@@ -478,24 +473,13 @@ executedDescribe(
     });
 
     test("constructs the staging fallback only after truthy opt-in and a nonblank source key", () => {
-      const configured = spawnSync(
-        requirePreflightBash(),
-        [
-          "-c",
-          `${preflight}\nprintf '<%s>' "$VOICE_REALTIME_ELIZA_AUTHORIZATION"`,
-        ],
+      const configured = runPreflight(
         {
-          encoding: "utf8",
-          env: {
-            ...process.env,
-            DEPLOY_ENVIRONMENT: "staging",
-            DEEPGRAM_API_KEY: "deepgram-test",
-            CARTESIA_API_KEY: "cartesia-test",
-            VOICE_REALTIME_WS_ENABLED: "true",
-            VOICE_REALTIME_ELIZA_AUTHORIZATION: "",
-            STAGING_ELIZACLOUD_API_KEY: "stage-cloud-key",
-          },
+          VOICE_REALTIME_WS_ENABLED: "true",
+          VOICE_REALTIME_ELIZA_AUTHORIZATION: "",
+          STAGING_ELIZACLOUD_API_KEY: "stage-cloud-key",
         },
+        `printf '<%s>' "$VOICE_REALTIME_ELIZA_AUTHORIZATION"`,
       );
       expect(configured.status).toBe(0);
       expect(configured.stdout).toBe("<Bearer stage-cloud-key>");

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -585,17 +585,18 @@ describe("canonical cloud deployment environment contract", () => {
     expect(preflight?.run).not.toContain('echo "$value"');
   });
 
-  test("publishes configured shared secrets and preserves absent Worker values", () => {
-    const publish = step(cloud, "deploy-api", "Publish Worker AI secrets");
+  test("queues configured shared secrets and preserves absent Worker values", () => {
+    const publish = step(
+      cloud,
+      "deploy-api",
+      "Prepare Worker secrets for atomic deploy",
+    );
     for (const name of cloudWorkerSecretNames) {
       expect(publish.env?.[name]).toContain("secrets.");
       expect(publish.run).toContain(`\n  ${name}\n`);
     }
     expect(publish.run).toContain("managed_worker_provisioning_secrets=(");
-    expect(publish.run).toContain('publish_secret "$name" || exit 1');
-    expect(publish.run).toContain('bunx wrangler versions secret put "$name"');
-    expect(publish.run).toContain('--versions "$name"');
-    expect(publish.run).not.toContain('bunx wrangler secret put "$name"');
+    expect(publish.run).toContain('queue_secret "$name" || exit 1');
     expect(publish.run).toContain(
       'echo "::notice::$name is not configured; skipping"',
     );


### PR DESCRIPTION
# Relates to

Closes #20254.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can verify the failure mode and the replacement contract from the linked runs and executable workflow tests below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@35f527d21e755182a52caa3a156fbc87df42cc0d:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop` `35f527d21e755182a52caa3a156fbc87df42cc0d`; zero conflicts.
- [x] Final PR head is `fcb405c308d54d7392b0153b7daed59cb7c09163`.
- [x] `bun install --frozen-lockfile` completed with no dependency changes.
- [x] Exact-head `bun run verify` passed: 351/351 Turbo tasks, 0 cached, plus all repository audits.

# Risks

Medium. This changes the protected Cloudflare Worker deployment transaction. Configured secret values are now supplied to the same `wrangler deploy` command that uploads code, while absent protected sources continue to preserve existing Worker bindings. A malformed payload, missing required value, write failure, or deploy failure stops the release. No secret value is printed, no database/schema changes are included, and no frontend/runtime application code changes.

# Background

## What does this PR do?

The staging release exposed a deterministic split-publication failure: publishing Worker secrets before the code cutover could leave Cloudflare's latest version undeployed, causing a later secret operation to fail and preventing the release. The version-aware workaround in #20258 successfully restored staging, but still creates many intermediate Worker versions before the intended code deployment.

This follow-up makes the release one code-and-secret transaction:

- Collects only explicitly configured secret names and writes their exact values to a mode-`0600` JSON file under `RUNNER_TEMP`.
- Passes that file to the canonical `wrangler deploy` through `--secrets-file`, so code and configured secrets become one Worker version/deployment.
- Preserves existing bindings whose protected GitHub source is blank or not yet backfilled.
- Keeps routing-toggle deletion version-aware and separate, including the staging session exchange off-first/activate-after-proof sequence.
- Verifies required Worker binding names after deployment without reading or printing values.
- Removes the owned temporary payload on success, step failure, output-write failure, and job cleanup; unrelated runner files are never removed.

## What kind of change is this?

Bug fix and release hardening. No public API or runtime behavior change.

# Documentation changes needed?

No public documentation change is required. The change is confined to the canonical protected deployment workflow, its private payload helper, and executable contract tests.

# Testing

## Where should a reviewer start?

Start with `cloud-cf-atomic-worker-secrets-workflow.test.ts`, then `worker-secrets-file.test.ts`, and compare the failed staging run with the successful version-aware recovery run linked below. The exact atomic path is deliberately not executed against a live protected environment until this PR is reviewed and merged.

## Detailed testing steps

- `bun test packages/cloud/scripts/__tests__/worker-secrets-file.test.ts packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts packages/scripts/__tests__/cloud-cf-staging-session-deploy-workflow.test.ts packages/scripts/__tests__/cloud-cf-voice-deploy-workflow.test.ts packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts` — passed, 49 tests / 17,431 expectations.
- `bunx actionlint .github/workflows/cloud-cf-release.yml` — passed.
- Changed-file Biome — passed with one existing warning in the literal Terraform fixture at `cloud-deploy-environment-contract.test.ts:395`.
- `git diff --check origin/develop...HEAD` — passed.
- `bun run verify:cloud` — passed, 80/80 tasks.
- `bun run verify` — passed at the exact head/base: 351/351 Turbo tasks, 0 cached; all follow-on audits and anti-larp checks passed.

# Evidence Gate

<!-- evidence-head:fc591c968e8b92365103158f49c845eaa12b7171 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A — this PR has no frontend or rendered-state change.
<!-- evidence-row:after-screenshots -->
- [x] N/A — this PR has no frontend or rendered-state change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A — this PR changes a protected CI deployment transaction, not an interactive UI path.
<!-- evidence-row:backend-logs -->
- [x] [20277-pr20277-exact-focused-gates.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20277-pr20277-exact-focused-gates.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A — no browser or frontend code changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A — no agent, action, provider, prompt, model, or LLM behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [20277-pr20277-exact-atomic-worker-secret-contract.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20277-pr20277-exact-atomic-worker-secret-contract.json)
<!-- evidence-row:ocr-review -->
- [x] N/A — no visual artifact or rendered text changes.

# Evidence Details

## Backend logs

Run 31913376637 reached the Worker release, then failed before code deployment while publishing `DATABASE_URL`; Cloudflare reported that the latest Worker version was not currently deployed. Run 31915158755 used the merged version-aware workaround and completed migration, Worker deployment, exact commit/binding checks, Pages deployment, and staging route verification. The public staging API now serves commit `02299b26be1cbe0116d39f4405de82d0e8a8e948` with `environment: staging`.

## Known gaps / failures

The exact `--secrets-file` transaction has not been dispatched against staging because doing so before review would mutate protected Cloudflare deployment state. The executable tests run the helper lifecycle and assert the exact workflow structure, failure cleanup, omitted-binding preservation, postdeploy names-only verification, voice preflight, and staging session ordering. There are no known source or validation failures.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@35f527d21e755182a52caa3a156fbc87df42cc0d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@35f527d21e755182a52caa3a156fbc87df42cc0d:packages/skills/skills/contribute-to-eliza"} -->


