### PR TITLE
fix(cloud): carry single-document managed login to main

### DIFF
--- a/packages/app/src/public-web-entry.test.tsx
+++ b/packages/app/src/public-web-entry.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Verifies the public renderer hands authenticated navigation to the full app
+ * in the same browser document. The full renderer module is deterministic and
+ * the public shell is reduced to its catch-all element.
+ */
+// @vitest-environment jsdom
+
+import { waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const handoff = vi.hoisted(() => ({ fullAppLoads: 0 }));
+
+vi.mock("@elizaos/ui/cloud/register-public", () => ({
+  registerPublicCloudSurfaces: vi.fn(),
+}));
+vi.mock("@elizaos/ui/cloud/shell/CloudRouterShell", () => ({
+  CloudRouterShell: ({ appElement }: { appElement: React.ReactNode }) =>
+    appElement,
+}));
+vi.mock("./sw-registration", () => ({
+  registerViewServiceWorker: vi.fn(),
+}));
+vi.mock("./main", () => {
+  handoff.fullAppLoads += 1;
+  const root = document.getElementById("root");
+  if (root) root.textContent = "Full app mounted";
+  return {};
+});
+
+describe("public renderer full-app handoff", () => {
+  beforeEach(() => {
+    handoff.fullAppLoads = 0;
+    document.documentElement.dataset.documentIdentity = "original";
+    document.body.innerHTML = '<div id="root"></div>';
+  });
+
+  it("loads the full renderer once without replacing the document", async () => {
+    const originalDocument = document;
+    await import("./public-web-entry");
+    if (document.readyState === "loading") {
+      document.dispatchEvent(new Event("DOMContentLoaded"));
+    }
+
+    await waitFor(() => expect(handoff.fullAppLoads).toBe(1));
+    expect(document).toBe(originalDocument);
+    expect(document.documentElement.dataset.documentIdentity).toBe("original");
+    expect(document.getElementById("root")?.textContent).toBe(
+      "Full app mounted",
+    );
+  });
+});

--- a/packages/app/src/public-web-entry.tsx
+++ b/packages/app/src/public-web-entry.tsx
@@ -1,8 +1,8 @@
 /**
  * Mounts only the Cloud public/auth/marketing route shell for a cold hosted
- * public URL. The full application entry remains behind a document reload when
- * client-side navigation leaves that route table, so none of its native,
- * bridge, plugin, or agent-dashboard imports enter anonymous `/login`.
+ * public URL. The full application graph stays out of anonymous `/login`, then
+ * loads into the same document when client-side navigation leaves that route
+ * table so successful authentication does not reboot the browser page.
  */
 
 import "@elizaos/ui/styles";
@@ -13,7 +13,7 @@ import { CloudRouterShell } from "@elizaos/ui/cloud/shell/CloudRouterShell";
 import { ErrorBoundary } from "@elizaos/ui/components/ui/error-boundary";
 import * as React from "react";
 import { lazy, Suspense, useEffect } from "react";
-import { createRoot } from "react-dom/client";
+import { createRoot, type Root } from "react-dom/client";
 import { renderBootFailure } from "./boot-failure";
 import { seedPublicWebBootConfig } from "./public-web-boot-config";
 import { registerViewServiceWorker } from "./sw-registration";
@@ -23,14 +23,32 @@ const MarketingDownloadsPage = lazy(
   () => import("@homepage/embedded-downloads"),
 );
 
+let publicRoot: Root | null = null;
+let fullAppHandoffStarted = false;
+
+async function handoffToFullApp(): Promise<void> {
+  if (fullAppHandoffStarted) return;
+  fullAppHandoffStarted = true;
+
+  // React must finish the current effect before its root is removed. The full
+  // renderer's side-effect entry then mounts into the now-empty #root without
+  // replacing the document, history, or service-worker-controlled client.
+  await Promise.resolve();
+  publicRoot?.unmount();
+  publicRoot = null;
+  await import("./main");
+}
+
 /**
  * A public-route link can navigate into the application without reloading the
- * document. Reload once at that catch-all so `entry.ts` selects the full boot
- * for the new, non-public pathname.
+ * document. Swap renderer roots at that catch-all while preserving the same
+ * browser document and navigation history.
  */
 function FullAppHandoff(): React.JSX.Element {
   useEffect(() => {
-    window.location.reload();
+    // error-policy:J1 renderer handoff boundary — a failed full-app import
+    // renders the established actionable recovery card.
+    void handoffToFullApp().catch(renderBootFailure);
   }, []);
   return (
     <main
@@ -50,7 +68,8 @@ function mountPublicWebEntry(): void {
   seedPublicWebBootConfig();
   registerViewServiceWorker();
   registerPublicCloudSurfaces();
-  createRoot(rootElement).render(
+  publicRoot = createRoot(rootElement);
+  publicRoot.render(
     <ErrorBoundary>
       <React.StrictMode>
         <Suspense fallback={null}>

--- a/packages/app/src/sw-registration.test.ts
+++ b/packages/app/src/sw-registration.test.ts
@@ -4,8 +4,11 @@
  * becomes a second navigation owner; the real worker owns the one safe refresh.
  */
 
-import { describe, expect, it, vi } from "vitest";
-import { wireServiceWorkerUpdateActivation } from "./sw-registration";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  registerViewServiceWorker,
+  wireServiceWorkerUpdateActivation,
+} from "./sw-registration";
 
 interface ListenerStore {
   registration: Map<string, EventListener>;
@@ -51,6 +54,10 @@ function makeHarness({
 }
 
 describe("service-worker update activation", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("does not activate an installing worker on its first installation", () => {
     const { listeners, messages, worker } = makeHarness({
       hasController: false,
@@ -83,5 +90,24 @@ describe("service-worker update activation", () => {
     const { serviceWorkers } = makeHarness({ hasController: true });
 
     expect(serviceWorkers.addEventListener).not.toHaveBeenCalled();
+  });
+
+  it("registers once when the public shell hands the same document to the full app", async () => {
+    vi.stubEnv("PROD", true);
+    const registration = {
+      waiting: null,
+      installing: null,
+      scope: "/",
+      addEventListener: vi.fn(),
+    } as unknown as ServiceWorkerRegistration;
+    const register = vi.fn(async () => registration);
+    Object.defineProperty(navigator, "serviceWorker", {
+      configurable: true,
+      value: { controller: null, register },
+    });
+
+    registerViewServiceWorker();
+    registerViewServiceWorker();
+    await vi.waitFor(() => expect(register).toHaveBeenCalledOnce());
   });
 });

--- a/packages/app/src/sw-registration.ts
+++ b/packages/app/src/sw-registration.ts
@@ -36,6 +36,8 @@ function isElectrobunHost(): boolean {
   );
 }
 
+let registrationStarted = false;
+
 /**
  * When a NEW service worker reaches `installed` while an existing controller is
  * present, a fresh renderer was just deployed. Tell the waiting worker to take
@@ -88,6 +90,8 @@ export function registerViewServiceWorker(): void {
   if (!("serviceWorker" in navigator)) return;
   if (isCapacitorNative()) return;
   if (isElectrobunHost()) return;
+  if (registrationStarted) return;
+  registrationStarted = true;
 
   navigator.serviceWorker
     .register("/sw.js", { scope: "/" })

--- a/packages/app/src/web-entry-policy.test.ts
+++ b/packages/app/src/web-entry-policy.test.ts
@@ -104,6 +104,8 @@ describe("hosted public renderer entry policy", () => {
     expect(entrySource).toContain('import("./public-web-entry")');
     expect(entrySource).toContain('import("./main")');
     expect(publicEntrySource).not.toMatch(/from\s+["']\.\/main["']/);
+    expect(publicEntrySource).toContain('import("./main")');
+    expect(publicEntrySource).not.toContain("window.location.reload()");
     expect(publicEntrySource).toContain("seedPublicWebBootConfig");
   });
 

--- a/packages/app/test/ui-smoke/managed-login-stability.spec.ts
+++ b/packages/app/test/ui-smoke/managed-login-stability.spec.ts
@@ -7,6 +7,7 @@
 
 import { writeFile } from "node:fs/promises";
 import { expect, type Page, test } from "@playwright/test";
+import { installDefaultAppRoutes } from "./helpers";
 
 const PROVIDERS = {
   passkey: false,
@@ -22,6 +23,10 @@ const PROVIDERS = {
 };
 
 const STABILITY_WINDOW_MS = 5_500;
+const TEST_AUTH_ENABLED =
+  process.env.VITE_PLAYWRIGHT_TEST_AUTH === "true" ||
+  process.env.NEXT_PUBLIC_PLAYWRIGHT_TEST_AUTH === "true";
+const PERSONAL_ID = "personal:11111111-1111-5111-8111-111111111111";
 const SURFACES = [
   { name: "desktop", viewport: { width: 1440, height: 900 } },
   { name: "mobile", viewport: { width: 390, height: 844 } },
@@ -52,6 +57,147 @@ async function installManagedOriginProxy(
   });
 
   return managed.origin;
+}
+
+for (const surface of SURFACES) {
+  test(`authenticated login handoff mounts chat in the same document (${surface.name})`, async ({
+    page,
+    baseURL,
+  }, testInfo) => {
+    test.skip(
+      !TEST_AUTH_ENABLED,
+      "requires VITE_PLAYWRIGHT_TEST_AUTH=true in the renderer build",
+    );
+    if (!baseURL) throw new Error("Playwright baseURL is required");
+    await page.setViewportSize(surface.viewport);
+    const managedOrigin = await installManagedOriginProxy(page, baseURL);
+    await installDefaultAppRoutes(page);
+    const documentRequests: string[] = [];
+    const pageErrors: string[] = [];
+    const requestFailures: string[] = [];
+    const consoleMessages: Array<{ type: string; text: string }> = [];
+    let personalRequests = 0;
+    let releasePersonal: (() => void) | undefined;
+    const personalGate = new Promise<void>((resolve) => {
+      releasePersonal = resolve;
+    });
+    const jwtPart = (value: unknown) =>
+      Buffer.from(JSON.stringify(value)).toString("base64url");
+    const stewardToken = `${jwtPart({ alg: "none", typ: "JWT" })}.${jwtPart({
+      userId: "22222222-2222-4222-8222-222222222222",
+      email: "managed-handoff@test.local",
+      exp: Math.floor(Date.now() / 1000) + 3_600,
+    })}.sig`;
+
+    page.on("request", (request) => {
+      if (
+        request.isNavigationRequest() &&
+        request.frame() === page.mainFrame()
+      ) {
+        documentRequests.push(request.url());
+      }
+    });
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+    page.on("requestfailed", (request) => {
+      requestFailures.push(
+        `${request.method()} ${request.url()} ${request.failure()?.errorText ?? "unknown"}`,
+      );
+    });
+    page.on("console", (message) => {
+      consoleMessages.push({ type: message.type(), text: message.text() });
+    });
+    await page.context().addCookies([
+      {
+        name: "eliza-test-auth",
+        value: "1",
+        domain: "cloud.eliza.app",
+        path: "/",
+        sameSite: "Lax",
+      },
+    ]);
+    await page.addInitScript((token) => {
+      localStorage.setItem("steward_session_token", token);
+    }, stewardToken);
+    await page.route("**/api/v1/eliza/agents", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, data: [] }),
+      });
+    });
+    await page.route("**/api/v1/eliza/personal", async (route) => {
+      personalRequests += 1;
+      await personalGate;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: {
+            identity: {
+              id: PERSONAL_ID,
+              displayName: "Eliza",
+              runtime: "shared",
+              activeAgentId: "22222222-2222-4222-8222-222222222222",
+              apiBase: managedOrigin,
+            },
+          },
+        }),
+      });
+    });
+
+    await page.goto(`${managedOrigin}/join`);
+    await expect(page.getByText(/Opening your personal Eliza/)).toBeVisible();
+    await page.evaluate(() => {
+      document.documentElement.dataset.loginDocument = "survived";
+    });
+    releasePersonal?.();
+
+    await expect.poll(() => personalRequests).toBeGreaterThanOrEqual(1);
+    await expect(page.locator("html")).toHaveAttribute(
+      "data-login-document",
+      "survived",
+    );
+    await expect(page).toHaveURL(`${managedOrigin}/`);
+    await expect(page.getByTestId("home-screen")).toBeVisible({
+      timeout: 15_000,
+    });
+    await page.waitForTimeout(1_000);
+
+    expect(documentRequests).toHaveLength(1);
+    expect(new URL(documentRequests[0]).pathname).toBe("/join");
+    expect(pageErrors).toEqual([]);
+    expect(requestFailures).toEqual([]);
+
+    if (process.env.E2E_RECORD === "1") {
+      await page.screenshot({
+        path: testInfo.outputPath(
+          `${surface.name}-authenticated-same-document.png`,
+        ),
+        fullPage: true,
+      });
+      await writeFile(
+        testInfo.outputPath(`${surface.name}-authenticated-observations.json`),
+        `${JSON.stringify(
+          {
+            head: process.env.GITHUB_SHA ?? "local-exact-head",
+            entryPath: "/join",
+            finalUrl: page.url(),
+            documentRequests,
+            personalRequests,
+            pageErrors,
+            requestFailures,
+            consoleMessages,
+            documentMarker: await page
+              .locator("html")
+              .getAttribute("data-login-document"),
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    }
+  });
 }
 
 for (const surface of SURFACES) {

--- a/packages/ui/src/cloud/app-mode/AppModeEntryRoute.test.tsx
+++ b/packages/ui/src/cloud/app-mode/AppModeEntryRoute.test.tsx
@@ -352,16 +352,15 @@ describe("AppModeEntryRoute — rowless personal entry", () => {
     expect(assignedUrls).toEqual([]);
   });
 
-  it("fresh browser, clean account → authoritative binding persisted, then one clean-boot reload", async () => {
+  it("fresh browser, clean account → authoritative binding persists and chat mounts without a document reload", async () => {
     signIn();
     stubNetwork({ agents: agentsOk([]), personal: personalOk() });
     renderEntry();
 
-    await waitFor(() => expect(assignedUrls).toEqual(["/"]));
+    expect(await screen.findByTestId("agent-app")).toBeTruthy();
     expect(loadPersistedActiveServer()?.id).toBe(`cloud:${PERSONAL_ID}`);
     expect(screen.queryByTestId("join-page")).toBeNull();
-    // Chat must boot from the clean reload, not from the stale in-page boot.
-    expect(screen.queryByTestId("agent-app")).toBeNull();
+    expect(assignedUrls).toEqual([]);
   });
 
   it("stale cross-account binding is repaired to the authenticated identity before any boot", async () => {
@@ -370,9 +369,9 @@ describe("AppModeEntryRoute — rowless personal entry", () => {
     stubNetwork({ agents: agentsOk([]), personal: personalOk() });
     renderEntry();
 
-    await waitFor(() => expect(assignedUrls).toEqual(["/"]));
+    expect(await screen.findByTestId("agent-app")).toBeTruthy();
     expect(loadPersistedActiveServer()?.id).toBe(`cloud:${PERSONAL_ID}`);
-    expect(screen.queryByTestId("agent-app")).toBeNull();
+    expect(assignedUrls).toEqual([]);
   });
 
   it("an invalid identity response → /join, never a wrong-runtime chat boot", async () => {

--- a/packages/ui/src/cloud/app-mode/AppModeEntryRoute.tsx
+++ b/packages/ui/src/cloud/app-mode/AppModeEntryRoute.tsx
@@ -31,8 +31,8 @@ import {
   redirectToSsoBridge,
   shouldAutoBridgeToSso,
 } from "../sso-bridge/sso-bridge";
-import { appModeNavigation, decideAppModeRoute } from "./app-mode";
-import { personalEntryBindingId, usePersonalEntry } from "./use-personal-entry";
+import { decideAppModeRoute } from "./app-mode";
+import { usePersonalEntry } from "./use-personal-entry";
 
 function EntryNotice({
   label,
@@ -65,42 +65,13 @@ export function AppModeEntryRoute({
   // Rowless personal entry: with zero sandbox rows the personal Eliza is the
   // account's runtime, so entry resolves + persists its authoritative binding
   // instead of bouncing to /join (the /join → / → /join loop this fixes).
-  // The binding snapshot is taken once, before the resolver can overwrite it,
-  // so a repaired/created binding is distinguishable from a matching one.
   const rowlessEntry =
     ready &&
     authenticated &&
     !isCloudManagementPath &&
     agentsQuery.data !== undefined &&
     agentsQuery.data.length === 0;
-  const initialBindingIdRef = useRef<string | null | undefined>(undefined);
-  if (initialBindingIdRef.current === undefined) {
-    const persisted = loadPersistedActiveServer();
-    initialBindingIdRef.current =
-      persisted?.kind === "cloud" ? persisted.id : null;
-  }
   const personalEntry = usePersonalEntry(rowlessEntry);
-  // A binding the resolver just created or repaired must boot from a clean
-  // page load (the startup coordinator restores persisted connections at
-  // boot — same reason /join hard-navigates). Single-shot per mount; replaces
-  // with the current URL so deep links survive the reload.
-  const resolvedBindingId = personalEntry.data
-    ? personalEntryBindingId(personalEntry.data)
-    : null;
-  const bindingRepaired =
-    rowlessEntry &&
-    resolvedBindingId !== null &&
-    initialBindingIdRef.current !== resolvedBindingId &&
-    // Reload only helps when the repaired binding actually persisted; with
-    // storage unavailable a reload would recur forever, so entry renders the
-    // in-memory-configured client instead.
-    loadPersistedActiveServer()?.id === resolvedBindingId;
-  const rebootRef = useRef(false);
-  useEffect(() => {
-    if (!bindingRepaired || rebootRef.current) return;
-    rebootRef.current = true;
-    appModeNavigation.replace(`${location.pathname}${location.search}`);
-  }, [bindingRepaired, location]);
 
   // Unauthenticated visits may ride the cross-host SSO bridge instead of the
   // local login: when the domain-wide session marker says the auth origin
@@ -180,7 +151,7 @@ export function AppModeEntryRoute({
       if (personalEntry.isError) {
         return <Navigate to="/join" replace />;
       }
-      if (personalEntry.data === undefined || bindingRepaired) {
+      if (personalEntry.data === undefined) {
         return <EntryNotice label="Opening your Eliza" />;
       }
       return <>{appElement}</>;

--- a/packages/ui/src/cloud/join/JoinPage.sso-handoff.test.tsx
+++ b/packages/ui/src/cloud/join/JoinPage.sso-handoff.test.tsx
@@ -96,7 +96,8 @@ describe("JoinPage managed-app SSO handoff", () => {
     render(<JoinPage />);
 
     await waitFor(() => expect(runJoinFlowMock).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(assignedUrls).toEqual(["/"]));
+    expect((await screen.findByTestId("navigate")).textContent).toBe("/");
+    expect(assignedUrls).toEqual([]);
     expect(replacedUrls).toEqual([]);
   });
 });

--- a/packages/ui/src/cloud/join/JoinPage.tsx
+++ b/packages/ui/src/cloud/join/JoinPage.tsx
@@ -2,8 +2,8 @@
  * Post-login landing that opens the account-native personal Eliza in chat.
  *
  * After Steward login the page resolves the account-native rowless Shared
- * Eliza, persists its Cloud binding, then hard-navigates to chat. A full
- * navigation lets startup restore the new binding from a clean boot.
+ * Eliza, persists its Cloud binding, then transitions to chat in the current
+ * document. The configured client and persisted binding are already ready.
  *
  * Signed-out app-host visitors first restore a live apex session through the
  * PKCE SSO bridge, or fall back to `/login?returnTo=/join` when no apex session
@@ -93,11 +93,10 @@ export default function JoinPage(): React.JSX.Element {
         });
         controller.signal.throwIfAborted();
         setPhase("ready");
-        // Hard navigation to chat home so the startup coordinator restores the
-        // just-persisted cloud connection from a clean boot. `void result` keeps
-        // the resolved agent in scope for future telemetry without unused-var noise.
+        // The flow has configured the in-memory client and persisted the exact
+        // binding, so chat can mount without replacing the browser document.
+        // `void result` keeps the resolved identity available for telemetry.
         void result;
-        if (typeof window !== "undefined") appModeNavigation.assign("/");
       } catch (err) {
         if (controller.signal.aborted) return;
         setError(describeJoinError(err));
@@ -184,6 +183,10 @@ export default function JoinPage(): React.JSX.Element {
   // Signed out → send to login, returning here once authenticated.
   if (session.ready && !session.authenticated && ssoBridging === false) {
     return <Navigate to="/login?returnTo=/join" replace />;
+  }
+
+  if (phase === "ready") {
+    return <Navigate to="/" replace />;
   }
 
   return (


### PR DESCRIPTION
# Relates to

Closes #20278. Carries the already-reviewed and merged develop fix from #20160 to `main` for the protected production release.

- [x] This PR targets `main` and is based on exact current `origin/main@50384568ea0155b870635404c3f38d09b395d445` with zero conflicts.
- [x] The ten-path patch is range-diff equal to merged #20160 and has the same stable patch-id `f2cb9b5adf096ee340303ed8ab86f1a5cd2bb00d`.
- [x] The exact production candidate passes focused UI tests, real Chromium navigation contracts, and the complete app visual audit.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@64eb8d61b667fbf364eeb13fb041f9ca79b582d0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with main

- [x] Exact base `origin/main@50384568ea0155b870635404c3f38d09b395d445`; zero conflicts.
- [x] `git range-diff 8e9bbed2^..8e9bbed2 50384568..64eb8d61` reports exact equality.
- [x] Stable patch-id is unchanged: `f2cb9b5adf096ee340303ed8ab86f1a5cd2bb00d`.

# Risks

Medium, narrowly scoped to browser startup/navigation ownership:

- The public renderer unmounts and imports the full renderer in the same document instead of calling `window.location.reload()`.
- Fresh or repaired personal bindings render the app directly instead of forcing another hard navigation.
- Successful `/join` completion uses declarative SPA navigation.
- Service-worker registration is idempotent when both public and full renderers execute in one document; deploy-time refresh ownership remains with the service worker.

Rollback is a single-commit revert. Cross-origin OAuth/SSO handoffs and service-worker activation navigation are intentionally unchanged.

# Background

Production `cloud.eliza.app` still serves `main@50384568`, which does not contain merged #20160. The old production code can hard-reload across managed sign-in, binding resolution, and join completion. This promotion removes that authenticated reload chain while preserving the existing document, DOM/history state, and service-worker client.

The original parent reproduction records two main-frame documents (`/join`, then `/`) and a lost DOM marker. This exact `main` candidate records one `/join` document, marker survival, zero page/request failures, and a visible home surface on desktop and mobile. Signed-out `/` and `/login?intent=launch` also remain on one login document for a 5.5-second stability window at both viewports.

# Testing

## Where should a reviewer start?

1. `packages/app/test/ui-smoke/managed-login-stability.spec.ts`
2. `packages/app/src/public-web-entry.tsx`
3. `packages/ui/src/cloud/app-mode/AppModeEntryRoute.tsx`
4. `packages/ui/src/cloud/join/JoinPage.tsx`

## Detailed testing steps

- `bun install --frozen-lockfile` — 3,823 installs checked across 4,121 packages, no changes.
- Focused Vitest: 58/58 across public entry, SW registration, entry policy, app-mode routing, join handoff, and join flow.
- Exact Chromium: 6/6 authenticated/signed-out desktop/mobile stability cases; repeated with recording enabled, 6/6.
- Authenticated desktop/mobile: exactly one main-frame document request, surviving DOM marker, zero page errors, zero request failures.
- Signed-out desktop/mobile: `/` and `/login?intent=launch` remain stable for 5.5 seconds with one main-frame document request.
- `bun run --cwd packages/app audit:app`: 219/219; broken=0, needs-work=0, hover/density/minimalism failures=0.
- Packaged OCR: 216 views; verified=200, broken=0, regressions=0, needs-eyeball=16.
- `TURBO_FORCE=1 bun run verify` reaches an inherited formatter error in untouched `packages/cloud/api/src/index.test.ts`; the candidate and parent blobs are byte-identical. See Known gaps / failures.

# Evidence Gate

<!-- evidence-head:64eb8d61b667fbf364eeb13fb041f9ca79b582d0 -->

<!-- evidence-row:before-screenshots -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20160-before-desktop.jpg
<!-- evidence-row:after-screenshots -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20283-desktop-authenticated-same-document.png
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20283-managed-login-desktop-single-document.mp4
<!-- evidence-row:backend-logs -->
- [x] N/A - no server/backend route changes; the affected path is browser navigation and API boundaries are deterministic fixtures.
<!-- evidence-row:frontend-logs -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20283-desktop-authenticated-observations.json
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20283-managed-login-navigation-matrix.json
<!-- evidence-row:ocr-review -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20283-ocr-triage.json

# Evidence Details

## Frontend navigation observations

No observations contain cookies, tokens, credentials, or response bodies.

- Authenticated same-document flow: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20283-desktop-authenticated-observations.json) · [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20283-mobile-authenticated-observations.json)
- Signed-out launch stability: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20283-desktop-frontend-observations.json) · [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20283-mobile-frontend-observations.json)
- Consolidated six-case result: [navigation matrix](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20283-managed-login-navigation-matrix.json)

## Screenshots and walkthroughs

- Original parent reproduction: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20160-before-desktop.jpg) · [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20160-before-mobile.jpg)
- Exact `main` candidate, authenticated: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20283-desktop-authenticated-same-document.png) · [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20283-mobile-authenticated-same-document.png)
- Exact `main` candidate, signed out: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20283-desktop-stable-login.png) · [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20283-mobile-stable-login.png)
- Exact `main` candidate walkthrough: [desktop MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20283-managed-login-desktop-single-document.mp4) · [mobile MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20283-managed-login-mobile-single-document.mp4)
- Exact audit OCR: [216-view triage JSON](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20283-ocr-triage.json)

## Known gaps / failures

- Live production remains on `main@50384568`; this code PR does not claim a production deployment or authenticated live-session proof.
- The in-app browser controller timed out before it could provide reliable live-session telemetry, so that timeout is not classified as an app reload. Navigation-count proof comes from the exact real-Chromium harness.
- Exact-head root verification is blocked by the untouched `main` base formatter defect at `packages/cloud/api/src/index.test.ts:777`. Direct Cloud API lint reproduces the same single error, and `git hash-object` confirms the candidate blob equals `origin/main` (`b9688efd419a...`). Candidate-scoped UI, browser, visual, type, lint, and diff gates are green.
- Production release remains gated on exact-head review/merge, protected approval, exact served commit verification, and a clean-browser authenticated acceptance pass.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@64eb8d61b667fbf364eeb13fb041f9ca79b582d0:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@64eb8d61b667fbf364eeb13fb041f9ca79b582d0:packages/skills/skills/contribute-to-eliza"} -->
