### PR TITLE
fix(agent): reject malformed media store byte caps

### DIFF
--- a/packages/agent/src/api/media-store.test.ts
+++ b/packages/agent/src/api/media-store.test.ts
@@ -41,6 +41,8 @@ const {
   readStoredMediaBytes,
   writeStoredMediaFile,
   deleteMediaFile,
+  resolveMediaStoreMaxBytes,
+  DEFAULT_MEDIA_STORE_MAX_BYTES,
 } = await import("./media-store.ts");
 
 function mediaPath(fileName: string): string {
@@ -907,4 +909,63 @@ describe("deleteMediaFile fast-fail (#12265)", () => {
       }
     },
   );
+});
+
+describe("resolveMediaStoreMaxBytes", () => {
+  it("rejects scientific notation, junk, and non-canonical integers as the 2 GiB default", () => {
+    expect(resolveMediaStoreMaxBytes(undefined)).toBe(
+      DEFAULT_MEDIA_STORE_MAX_BYTES,
+    );
+    expect(resolveMediaStoreMaxBytes("")).toBe(DEFAULT_MEDIA_STORE_MAX_BYTES);
+    expect(resolveMediaStoreMaxBytes("   ")).toBe(
+      DEFAULT_MEDIA_STORE_MAX_BYTES,
+    );
+    // Number.parseInt("1e9", 10) === 1 would evict every attachment.
+    expect(resolveMediaStoreMaxBytes("1e9")).toBe(
+      DEFAULT_MEDIA_STORE_MAX_BYTES,
+    );
+    expect(resolveMediaStoreMaxBytes("1e3")).toBe(
+      DEFAULT_MEDIA_STORE_MAX_BYTES,
+    );
+    expect(resolveMediaStoreMaxBytes("8abc")).toBe(
+      DEFAULT_MEDIA_STORE_MAX_BYTES,
+    );
+    expect(resolveMediaStoreMaxBytes("0x10")).toBe(
+      DEFAULT_MEDIA_STORE_MAX_BYTES,
+    );
+    expect(resolveMediaStoreMaxBytes("010")).toBe(
+      DEFAULT_MEDIA_STORE_MAX_BYTES,
+    );
+    expect(resolveMediaStoreMaxBytes("0.4")).toBe(
+      DEFAULT_MEDIA_STORE_MAX_BYTES,
+    );
+    expect(resolveMediaStoreMaxBytes("-5")).toBe(DEFAULT_MEDIA_STORE_MAX_BYTES);
+    expect(resolveMediaStoreMaxBytes("abc")).toBe(
+      DEFAULT_MEDIA_STORE_MAX_BYTES,
+    );
+    expect(resolveMediaStoreMaxBytes("0")).toBe(DEFAULT_MEDIA_STORE_MAX_BYTES);
+    expect(resolveMediaStoreMaxBytes("9007199254740992")).toBe(
+      DEFAULT_MEDIA_STORE_MAX_BYTES,
+    );
+  });
+
+  it("accepts complete positive decimals, including a trimmed value", () => {
+    expect(resolveMediaStoreMaxBytes("1")).toBe(1);
+    expect(resolveMediaStoreMaxBytes("4096")).toBe(4096);
+    expect(resolveMediaStoreMaxBytes("2147483648")).toBe(2147483648);
+    expect(resolveMediaStoreMaxBytes(" 1048576 ")).toBe(1048576);
+  });
+
+  it("does not select a just-persisted attachment for eviction when MAX_BYTES is 1e9", () => {
+    const bytes = Buffer.from("scientific-notation-cap-must-not-evict");
+    const saved = persistMediaBytes(bytes, "image/png");
+    expect(fs.existsSync(mediaPath(saved.fileName))).toBe(true);
+    const cap = resolveMediaStoreMaxBytes("1e9");
+    expect(
+      selectMediaToEvict(
+        [{ name: saved.fileName, size: bytes.length, mtimeMs: 1 }],
+        cap,
+      ),
+    ).toEqual([]);
+  });
 });

--- a/packages/agent/src/api/media-store.ts
+++ b/packages/agent/src/api/media-store.ts
@@ -192,16 +192,34 @@ function extForMime(mimeType: string): string {
 // Size-capped eviction
 // ---------------------------------------------------------------------------
 
-const DEFAULT_MAX_STORE_BYTES = 2 * 1024 * 1024 * 1024; // 2 GB
+export const DEFAULT_MEDIA_STORE_MAX_BYTES = 2 * 1024 * 1024 * 1024; // 2 GB
 const EVICT_INTERVAL_MS = 30_000;
 let lastEvictAt = 0;
 
+/** Complete positive decimal: reject `1e9`, `8abc`, hex, leading zeros, fractions. */
+const CANONICAL_POSITIVE_DECIMAL = /^[1-9]\d*$/;
+
+/**
+ * Resolve `ELIZA_MEDIA_STORE_MAX_BYTES`. Unset/empty/invalid tokens keep the
+ * 2 GiB default so a silent `Number.parseInt("1e9") === 1` cannot evict the
+ * store down to a 1-byte cap.
+ */
+export function resolveMediaStoreMaxBytes(raw: string | undefined): number {
+  if (raw === undefined) return DEFAULT_MEDIA_STORE_MAX_BYTES;
+  const trimmed = raw.trim();
+  if (trimmed === "") return DEFAULT_MEDIA_STORE_MAX_BYTES;
+  if (!CANONICAL_POSITIVE_DECIMAL.test(trimmed)) {
+    return DEFAULT_MEDIA_STORE_MAX_BYTES;
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    return DEFAULT_MEDIA_STORE_MAX_BYTES;
+  }
+  return parsed;
+}
+
 function maxStoreBytes(): number {
-  const raw = process.env.ELIZA_MEDIA_STORE_MAX_BYTES;
-  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
-  return Number.isFinite(parsed) && parsed > 0
-    ? parsed
-    : DEFAULT_MAX_STORE_BYTES;
+  return resolveMediaStoreMaxBytes(process.env.ELIZA_MEDIA_STORE_MAX_BYTES);
 }
 
 export interface MediaFileStat {


### PR DESCRIPTION
# Relates to

Closes #20285.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto current `origin/develop` at `fd89713311b121f93192ae756525f16b17321712` with zero conflicts.
- [x] `bun install --frozen-lockfile` and root `bun run verify` were run after final synchronization.
- [x] A reviewer can reproduce the malformed-cap failure and confirm the repair from the deterministic parser/integration tests and exact-head proof below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- AI provider/model: openai / gpt-5.6-sol; identifier openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Client / agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Contribution skill revision: `elizaOS/eliza@fd89713311b121f93192ae756525f16b17321712:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `fd89713311b121f93192ae756525f16b17321712`; zero conflicts.
- [x] Root `bun run verify` passes at exact PR head `0607ece04a4f5546159846511392151eb25d0097`.

# Risks

Low. The change affects only parsing of `ELIZA_MEDIA_STORE_MAX_BYTES`. Valid canonical positive decimal values preserve their exact numeric meaning. Missing or invalid values preserve the existing 2 GiB default. No storage layout, URL, garbage-collection ordering, or media API contract changes.

# Background

## What does this PR do?

Replaces permissive numeric-prefix parsing for `ELIZA_MEDIA_STORE_MAX_BYTES` with a complete canonical-decimal parser.

The previous `Number.parseInt` path interpreted values such as `1e9` as `1`. A malformed one-byte cap could then select the attachment just persisted for immediate eviction even though persistence returned its served URL.

The resolver now trims outer whitespace, accepts only `/^[1-9]\d*$/`, and requires a positive safe integer. It accepts `1..Number.MAX_SAFE_INTEGER`; exponent notation, suffix junk, hex, fractions, signs, zero, leading zeros, and unsafe integers all fall back to the unchanged 2 GiB default.

## What kind of change is this?

Bug fix (non-breaking configuration hardening).

# Documentation changes needed?

No. This enforces the byte-count environment variable's intended decimal contract and retains the documented/default behavior for missing or invalid configuration.

# Testing

## Where should a reviewer start?

- `packages/agent/src/api/media-store.ts`: `resolveMediaStoreMaxBytes` and the canonical-positive-decimal guard.
- `packages/agent/src/api/media-store.test.ts`: parser table coverage and the regression proving `1e9` cannot evict the just-persisted attachment.

## Detailed testing steps

Run with repository-pinned Bun 1.3.14 and Node 24.15.0:

```bash
bun install --frozen-lockfile
bun run --cwd packages/shared build:i18n
./node_modules/.bin/vitest run --root packages/agent --config packages/agent/vitest.config.ts src/api/media-store.test.ts
bun run --cwd packages/agent typecheck
./node_modules/.bin/biome check packages/agent/src/api/media-store.ts packages/agent/src/api/media-store.test.ts
git diff --check origin/develop...HEAD
bun run verify
```

Observed final results at `0607ece04a4f5546159846511392151eb25d0097`:

- Focused media-store suite: 1 file passed; 63 tests passed.
- Agent typecheck: passed after root verification materialized private workspace outputs.
- Changed-file Biome: 2 files checked; no fixes or errors.
- Diff check: passed.
- Root verification: 351/351 tasks passed, followed by all repository audits; 8,267 test files scanned with 0 focused and 0 orphaned skips.
- Factory proof recorder: exact-head `bun run verify` exit 0.

The complete isolated agent test lane also ran all 419 batches. Four unrelated current-tree batches failed: provider-environment state in `agent-model.test.ts`, character/preset expectation drift, the existing todos `relatedActions` audit, and auth-environment expectations. Neither changed media-store file appears in those failures; the focused 63-test surface and root gate are green.

# Evidence Gate

<!-- evidence-head:0994ca463be0fee0b9d8f710f786fb8d226d42dc -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: N/A - headless server-storage configuration has no rendered surface.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: N/A - headless server-storage configuration has no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [ ] Video walkthrough: N/A - deterministic parser and store tests exercise the complete changed path.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - no service process is required; the real media-store functions are exercised directly in the focused suite.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no frontend or network path changes.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [20288-pr20288-media-store-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20288-pr20288-media-store-tests.log)

<details>
<summary>Final verification transcript</summary>

```text
focused media-store suite: 1 file passed; 63 tests passed
agent typecheck: passed
changed-file biome: Checked 2 files. No fixes applied.
git diff --check origin/develop...HEAD: passed
root verify: 351 successful / 351 total tasks
root verify: [anti-larp] scanned 8267 test files — 0 focused, 0 orphaned skip(s)
root verify: [anti-larp] clean — no focused tests, no untracked skips.
proof-run: recorded PROOF for 0607ece04 — bun run verify (exit 0)
```

</details>

<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review: N/A - no rendered visual surface or text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - the change is a deterministic environment parser and media-store regression, with no model call or agent trajectory.

## Backend + frontend logs

N/A - the focused suite invokes the real parser and media-store garbage-collection path directly; no frontend exists in this scope and no backend process or network request is needed.

## Screenshots (before / after) + video walkthrough

N/A - no UI or rendered output changes.

## Known gaps / failures

The complete agent test lane has four unrelated current-tree failing batches as listed above. The changed 63-test media-store surface, agent typecheck, changed-file Biome, diff check, and exact-head root verification all pass.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/eliza@fd89713311b121f93192ae756525f16b17321712:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [sol-media-store-max-bytes]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"claude-code","skill_revision":"elizaOS/eliza@fd89713311b121f93192ae756525f16b17321712:packages/skills/skills/contribute-to-eliza"} -->

