### PR TITLE
fix(cloud-ui): abort checkout after unmount and reject null expiry

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.test.tsx
@@ -1,7 +1,20 @@
-/** Verifies the public payment request page against the server DTO contract. */
+/**
+ * Verifies the public payment request page against the server DTO contract:
+ * generation-keyed loads (an out-of-order stale response cannot overwrite the
+ * current route), deadline-derived Pay eligibility that flips as time passes,
+ * pre-checkout server revalidation, and user-facing provider labels. Uses a
+ * jsdom harness with the API client and router mocked; component is real.
+ */
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import type { ComponentProps, ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -49,19 +62,22 @@ vi.mock("../../../../components/ui/button", () => ({
 
 import PaymentRequestPage from "./payment-request-page";
 
-function publicPaymentRequest(
-  overrides: Partial<{
-    provider: "stripe" | "oxapay" | "x402" | "wallet_native";
-    status:
-      | "pending"
-      | "delivered"
-      | "settled"
-      | "expired"
-      | "canceled"
-      | "failed";
-    hostedUrl: string | null;
-  }> = {},
-) {
+type PublicOverrides = Partial<{
+  id: string;
+  provider: "stripe" | "oxapay" | "x402" | "wallet_native";
+  status:
+    | "pending"
+    | "delivered"
+    | "settled"
+    | "expired"
+    | "canceled"
+    | "failed";
+  amountCents: number;
+  expiresAt: string | null;
+  hostedUrl: string | null;
+}>;
+
+function publicPaymentRequest(overrides: PublicOverrides = {}) {
   return {
     id: "payreq-test-1",
     provider: "wallet_native" as const,
@@ -75,15 +91,28 @@ function publicPaymentRequest(
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("PaymentRequestPage public DTO contract", () => {
-  afterEach(() => cleanup());
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
 
   beforeEach(() => {
     apiMock.mockReset();
     paramsRef.current = { paymentRequestId: "payreq-test-1" };
   });
 
-  it("renders wallet_native and allows checkout for delivered requests", async () => {
+  it("renders wallet_native through the user-facing label and allows checkout for delivered requests", async () => {
     apiMock.mockResolvedValue({
       success: true,
       paymentRequest: publicPaymentRequest(),
@@ -92,9 +121,10 @@ describe("PaymentRequestPage public DTO contract", () => {
     render(<PaymentRequestPage />);
 
     const button = await screen.findByRole("button", {
-      name: /pay with wallet_native/i,
+      name: /pay with wallet/i,
     });
     expect((button as HTMLButtonElement).disabled).toBe(false);
+    expect(screen.queryByText(/wallet_native/)).toBeNull();
   });
 
   it("renders canceled requests as terminal and keeps checkout disabled", async () => {
@@ -112,9 +142,177 @@ describe("PaymentRequestPage public DTO contract", () => {
     expect(
       (
         screen.getByRole("button", {
-          name: /pay with wallet_native/i,
+          name: /pay with wallet/i,
         }) as HTMLButtonElement
       ).disabled,
     ).toBe(true);
+  });
+
+  it("ignores a stale out-of-order response for a previous route (A resolves after B)", async () => {
+    const loadA = deferred<{ success: boolean; paymentRequest: unknown }>();
+    const loadB = deferred<{ success: boolean; paymentRequest: unknown }>();
+    apiMock.mockImplementation((path: string) =>
+      path.includes("payreq-a") ? loadA.promise : loadB.promise,
+    );
+
+    paramsRef.current = { paymentRequestId: "payreq-a" };
+    const { rerender } = render(<PaymentRequestPage />);
+
+    paramsRef.current = { paymentRequestId: "payreq-b" };
+    rerender(<PaymentRequestPage />);
+
+    await act(async () => {
+      loadB.resolve({
+        success: true,
+        paymentRequest: publicPaymentRequest({
+          id: "payreq-b",
+          provider: "stripe",
+          amountCents: 2500,
+        }),
+      });
+    });
+    await screen.findByText("$25.00");
+
+    // Give the stale resolution a chance to (incorrectly) commit.
+    await act(async () => {
+      loadA.resolve({
+        success: true,
+        paymentRequest: publicPaymentRequest({
+          id: "payreq-a",
+          provider: "oxapay",
+          amountCents: 111,
+        }),
+      });
+      await new Promise((res) => setTimeout(res, 20));
+    });
+
+    expect(screen.getByText("$25.00")).toBeTruthy();
+    expect(screen.queryByText("$1.11")).toBeNull();
+    expect(screen.getByText("#payreq-b")).toBeTruthy();
+  });
+
+  it("disables Pay when the deadline has already passed even if status is payable", async () => {
+    apiMock.mockResolvedValue({
+      success: true,
+      paymentRequest: publicPaymentRequest({
+        expiresAt: new Date(Date.now() - 60_000).toISOString(),
+      }),
+    });
+
+    render(<PaymentRequestPage />);
+
+    expect(await screen.findByText("Expired")).toBeTruthy();
+    expect(
+      (
+        screen.getByRole("button", {
+          name: /pay with wallet/i,
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+
+  it("flips Pay to disabled when the deadline passes while the page is open", async () => {
+    apiMock.mockResolvedValue({
+      success: true,
+      paymentRequest: publicPaymentRequest({
+        expiresAt: new Date(Date.now() + 250).toISOString(),
+      }),
+    });
+
+    render(<PaymentRequestPage />);
+
+    const button = (await screen.findByRole("button", {
+      name: /pay with wallet/i,
+    })) as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+
+    await waitFor(() => expect(button.disabled).toBe(true), {
+      timeout: 3_000,
+    });
+    expect(screen.getByText("Expired")).toBeTruthy();
+  });
+
+  it("revalidates before checkout and blocks navigation when the request settled", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("location", { assign, href: "https://eliza.example/pay" });
+
+    apiMock
+      .mockResolvedValueOnce({
+        success: true,
+        paymentRequest: publicPaymentRequest(),
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        paymentRequest: publicPaymentRequest({ status: "settled" }),
+      });
+
+    render(<PaymentRequestPage />);
+
+    const button = await screen.findByRole("button", {
+      name: /pay with wallet/i,
+    });
+    fireEvent.click(button);
+
+    expect(await screen.findByText("Paid")).toBeTruthy();
+    expect(assign).not.toHaveBeenCalled();
+    expect(apiMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("revalidates before checkout and navigates to the fresh hosted URL", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("location", { assign, href: "https://eliza.example/pay" });
+
+    apiMock
+      .mockResolvedValueOnce({
+        success: true,
+        paymentRequest: publicPaymentRequest({
+          hostedUrl: "https://example.com/checkout/stale",
+        }),
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        paymentRequest: publicPaymentRequest({
+          hostedUrl: "https://example.com/checkout/fresh",
+        }),
+      });
+
+    render(<PaymentRequestPage />);
+
+    const button = await screen.findByRole("button", {
+      name: /pay with wallet/i,
+    });
+    fireEvent.click(button);
+
+    await waitFor(() =>
+      expect(assign).toHaveBeenCalledWith("https://example.com/checkout/fresh"),
+    );
+  });
+
+  it("blocks navigation when revalidation reports the deadline has passed", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("location", { assign, href: "https://eliza.example/pay" });
+
+    apiMock
+      .mockResolvedValueOnce({
+        success: true,
+        paymentRequest: publicPaymentRequest(),
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        paymentRequest: publicPaymentRequest({
+          expiresAt: new Date(Date.now() - 1_000).toISOString(),
+        }),
+      });
+
+    render(<PaymentRequestPage />);
+
+    const button = await screen.findByRole("button", {
+      name: /pay with wallet/i,
+    });
+    fireEvent.click(button);
+
+    expect(await screen.findByText("Expired")).toBeTruthy();
+    expect(assign).not.toHaveBeenCalled();
+    expect((button as HTMLButtonElement).disabled).toBe(true);
   });
 });

--- a/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.test.tsx
@@ -403,4 +403,147 @@ describe("PaymentRequestPage public DTO contract", () => {
     expect(assign).not.toHaveBeenCalled();
     expect((button as HTMLButtonElement).disabled).toBe(true);
   });
+
+  it("fails closed and disables Pay when expiresAt is null", async () => {
+    apiMock.mockResolvedValue({
+      success: true,
+      paymentRequest: publicPaymentRequest({ expiresAt: null }),
+    });
+
+    render(<PaymentRequestPage />);
+
+    expect(await screen.findByText("Invalid expiry date")).toBeTruthy();
+    expect(
+      (
+        screen.getByRole("button", {
+          name: /pay with wallet/i,
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+
+  it("blocks checkout navigation when revalidation returns a null deadline", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("location", { assign, href: "https://eliza.example/pay" });
+
+    apiMock
+      .mockResolvedValueOnce({
+        success: true,
+        paymentRequest: publicPaymentRequest(),
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        paymentRequest: publicPaymentRequest({ expiresAt: null }),
+      });
+
+    render(<PaymentRequestPage />);
+
+    const button = await screen.findByRole("button", {
+      name: /pay with wallet/i,
+    });
+    fireEvent.click(button);
+
+    expect(await screen.findByText("Invalid expiry date")).toBeTruthy();
+    expect(assign).not.toHaveBeenCalled();
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("does not navigate after Pay is clicked and the page unmounts", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("location", { assign, href: "https://eliza.example/pay" });
+    const checkout = deferred<{
+      success: boolean;
+      paymentRequest: ReturnType<typeof publicPaymentRequest>;
+    }>();
+
+    apiMock
+      .mockResolvedValueOnce({
+        success: true,
+        paymentRequest: publicPaymentRequest(),
+      })
+      .mockImplementationOnce(() => checkout.promise);
+
+    const { unmount } = render(<PaymentRequestPage />);
+    const button = await screen.findByRole("button", {
+      name: /pay with wallet/i,
+    });
+    fireEvent.click(button);
+    unmount();
+
+    await act(async () => {
+      checkout.resolve({
+        success: true,
+        paymentRequest: publicPaymentRequest({
+          hostedUrl: "https://example.com/checkout/late",
+        }),
+      });
+      await Promise.resolve();
+    });
+
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  it("does not navigate when checkout completes after a route change", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("location", { assign, href: "https://eliza.example/pay" });
+    const checkoutA = deferred<{
+      success: boolean;
+      paymentRequest: ReturnType<typeof publicPaymentRequest>;
+    }>();
+    const loadB = deferred<{
+      success: boolean;
+      paymentRequest: ReturnType<typeof publicPaymentRequest>;
+    }>();
+
+    apiMock.mockImplementation((path: string) => {
+      if (path.includes("payreq-a") && apiMock.mock.calls.length > 1) {
+        return checkoutA.promise;
+      }
+      if (path.includes("payreq-b")) return loadB.promise;
+      return Promise.resolve({
+        success: true,
+        paymentRequest: publicPaymentRequest({
+          id: "payreq-a",
+          hostedUrl: "https://example.com/checkout/stale-a",
+        }),
+      });
+    });
+
+    paramsRef.current = { paymentRequestId: "payreq-a" };
+    const { rerender } = render(<PaymentRequestPage />);
+    const button = await screen.findByRole("button", {
+      name: /pay with wallet/i,
+    });
+    fireEvent.click(button);
+
+    paramsRef.current = { paymentRequestId: "payreq-b" };
+    rerender(<PaymentRequestPage />);
+
+    await act(async () => {
+      loadB.resolve({
+        success: true,
+        paymentRequest: publicPaymentRequest({
+          id: "payreq-b",
+          provider: "stripe",
+          amountCents: 2500,
+          hostedUrl: "https://example.com/checkout/b",
+        }),
+      });
+    });
+    await screen.findByText("$25.00");
+
+    await act(async () => {
+      checkoutA.resolve({
+        success: true,
+        paymentRequest: publicPaymentRequest({
+          id: "payreq-a",
+          hostedUrl: "https://example.com/checkout/late",
+        }),
+      });
+      await Promise.resolve();
+    });
+
+    expect(assign).not.toHaveBeenCalled();
+    expect(screen.getByText("$25.00")).toBeTruthy();
+  });
 });

--- a/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.test.tsx
@@ -1,9 +1,10 @@
 /**
  * Verifies the public payment request page against the server DTO contract:
  * generation-keyed loads (an out-of-order stale response cannot overwrite the
- * current route), deadline-derived Pay eligibility that flips as time passes,
- * pre-checkout server revalidation, and user-facing provider labels. Uses a
- * jsdom harness with the API client and router mocked; component is real.
+ * current route), deadline-derived Pay eligibility that rejects malformed
+ * values and re-arms long timers, pre-checkout server revalidation, and
+ * user-facing provider labels. The component is real; the API client and
+ * router are mocked under jsdom.
  */
 // @vitest-environment jsdom
 
@@ -105,6 +106,7 @@ describe("PaymentRequestPage public DTO contract", () => {
   afterEach(() => {
     cleanup();
     vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   beforeEach(() => {
@@ -211,6 +213,66 @@ describe("PaymentRequestPage public DTO contract", () => {
     ).toBe(true);
   });
 
+  it("fails closed and renders an explicit error for a malformed expiry date", async () => {
+    apiMock.mockResolvedValue({
+      success: true,
+      paymentRequest: publicPaymentRequest({ expiresAt: "not-a-date" }),
+    });
+
+    render(<PaymentRequestPage />);
+
+    expect(await screen.findByText("Invalid expiry date")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "This payment request has an invalid expiry date and cannot be paid.",
+      ),
+    ).toBeTruthy();
+    expect(
+      (
+        screen.getByRole("button", {
+          name: /pay with wallet/i,
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+
+  it("re-arms timers beyond the browser delay limit until the real deadline", async () => {
+    const browserTimerLimitMs = 2 ** 31 - 1;
+    const startMs = Date.UTC(2030, 0, 1);
+    const deadlineMs = startMs + browserTimerLimitMs + 60_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(startMs);
+    apiMock.mockResolvedValue({
+      success: true,
+      paymentRequest: publicPaymentRequest({
+        expiresAt: new Date(deadlineMs).toISOString(),
+      }),
+    });
+
+    render(<PaymentRequestPage />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const button = screen.getByRole("button", {
+      name: /pay with wallet/i,
+    }) as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+
+    await act(async () => {
+      vi.advanceTimersByTime(browserTimerLimitMs);
+    });
+    expect(button.disabled).toBe(false);
+    expect(screen.queryByText("Expired")).toBeNull();
+    expect(vi.getTimerCount()).toBe(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(60_001);
+    });
+    expect(button.disabled).toBe(true);
+    expect(screen.getByText("Expired")).toBeTruthy();
+  });
+
   it("flips Pay to disabled when the deadline passes while the page is open", async () => {
     apiMock.mockResolvedValue({
       success: true,
@@ -286,6 +348,32 @@ describe("PaymentRequestPage public DTO contract", () => {
     await waitFor(() =>
       expect(assign).toHaveBeenCalledWith("https://example.com/checkout/fresh"),
     );
+  });
+
+  it("blocks navigation when revalidation returns a malformed deadline", async () => {
+    const assign = vi.fn();
+    vi.stubGlobal("location", { assign, href: "https://eliza.example/pay" });
+
+    apiMock
+      .mockResolvedValueOnce({
+        success: true,
+        paymentRequest: publicPaymentRequest(),
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        paymentRequest: publicPaymentRequest({ expiresAt: "not-a-date" }),
+      });
+
+    render(<PaymentRequestPage />);
+
+    const button = await screen.findByRole("button", {
+      name: /pay with wallet/i,
+    });
+    fireEvent.click(button);
+
+    expect(await screen.findByText("Invalid expiry date")).toBeTruthy();
+    expect(assign).not.toHaveBeenCalled();
+    expect((button as HTMLButtonElement).disabled).toBe(true);
   });
 
   it("blocks navigation when revalidation reports the deadline has passed", async () => {

--- a/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.tsx
@@ -4,10 +4,16 @@
  * Reads the redacted public view from /api/v1/payment-requests/:id?public=1 and
  * presents a single "Pay" button that delegates to the provider's checkout.
  * Renders WITHOUT the app shell chrome.
+ *
+ * Loads are generation-keyed and aborted on route change so an out-of-order
+ * response for a previous request id can never overwrite the current route's
+ * amount, status, or checkout destination. Pay eligibility is derived from
+ * both status and the request deadline, re-evaluated as the deadline passes,
+ * and revalidated against the server immediately before checkout navigation.
  */
 
 import { AlertCircle, CreditCard, Loader2 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { Button } from "../../../../components/ui/button";
 import { ApiError, api } from "../../../lib/api-client";
@@ -41,6 +47,32 @@ interface PublicResponse {
   paymentRequest: PublicPaymentRequest;
 }
 
+/** User-facing names for provider storage identifiers; raw enum values never render. */
+const PROVIDER_LABELS: Record<
+  PaymentProvider,
+  { key: string; defaultValue: string }
+> = {
+  stripe: {
+    key: "cloud.paymentRequest.provider.stripe",
+    defaultValue: "Stripe",
+  },
+  oxapay: {
+    key: "cloud.paymentRequest.provider.oxapay",
+    defaultValue: "OxaPay",
+  },
+  x402: { key: "cloud.paymentRequest.provider.x402", defaultValue: "x402" },
+  wallet_native: {
+    key: "cloud.paymentRequest.provider.walletNative",
+    defaultValue: "Wallet",
+  },
+};
+
+function providerLabel(provider: PaymentProvider, t: TFn): string {
+  const entry = PROVIDER_LABELS[provider];
+  if (!entry) return String(provider);
+  return t(entry.key, { defaultValue: entry.defaultValue });
+}
+
 function formatAmount(amountCents: number, currency: string): string {
   try {
     return new Intl.NumberFormat("en-US", {
@@ -62,9 +94,34 @@ function formatDate(value: string | null): string | null {
   }).format(new Date(value));
 }
 
-function normalizeError(error: unknown, t: TFn): string {
-  if (error instanceof ApiError) return error.message;
-  if (error instanceof Error) return error.message;
+/** True once a parseable deadline is at or before `nowMs`; requests without a deadline never pass it. */
+function isDeadlinePassed(expiresAt: string | null, nowMs: number): boolean {
+  if (!expiresAt) return false;
+  const deadline = Date.parse(expiresAt);
+  return Number.isFinite(deadline) && deadline <= nowMs;
+}
+
+function isPayableStatus(status: PaymentRequestStatus): boolean {
+  return status === "pending" || status === "delivered";
+}
+
+/**
+ * Raw page-error state; the user-facing message is derived at render time so
+ * effects never need the (render-scoped) translator in their dependency list.
+ */
+type PageError =
+  | { kind: "request-failed"; cause: unknown }
+  | { kind: "no-checkout-url" };
+
+function errorMessage(error: PageError, t: TFn): string {
+  if (error.kind === "no-checkout-url") {
+    return t("cloud.paymentRequest.noCheckoutUrl", {
+      defaultValue: "This payment request has no hosted checkout URL yet.",
+    });
+  }
+  const { cause } = error;
+  if (cause instanceof ApiError) return cause.message;
+  if (cause instanceof Error) return cause.message;
   return t("cloud.paymentRequest.unableToLoad", {
     defaultValue: "Unable to load payment request.",
   });
@@ -76,8 +133,12 @@ export default function PaymentRequestPage() {
   const [paymentRequest, setPaymentRequest] =
     useState<PublicPaymentRequest | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<PageError | null>(null);
   const [isPaying, setIsPaying] = useState(false);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  // Monotonic key: only the latest load (or a checkout revalidation started
+  // under it) may commit state, so stale responses cannot cross routes.
+  const loadGenerationRef = useRef(0);
 
   usePageTitle(
     t("cloud.paymentRequest.metaTitle", {
@@ -85,49 +146,111 @@ export default function PaymentRequestPage() {
     }),
   );
 
-  const load = useCallback(async () => {
-    if (!paymentRequestId) {
-      setError(
-        t("cloud.paymentRequest.missingId", {
-          defaultValue: "Missing payment request id.",
-        }),
-      );
-      setIsLoading(false);
-      return;
-    }
-    setIsLoading(true);
-    setError(null);
-    try {
-      const response = await api<PublicResponse>(
-        `/api/v1/payment-requests/${encodeURIComponent(paymentRequestId)}?public=1`,
-        { skipAuth: true },
-      );
-      setPaymentRequest(response.paymentRequest);
-    } catch (loadError) {
-      setError(normalizeError(loadError, t));
-    } finally {
-      setIsLoading(false);
-    }
-  }, [paymentRequestId, t]);
+  const fetchPublicRequest = useCallback(
+    (id: string, signal?: AbortSignal) =>
+      api<PublicResponse>(
+        `/api/v1/payment-requests/${encodeURIComponent(id)}?public=1`,
+        { skipAuth: true, signal },
+      ),
+    [],
+  );
 
   useEffect(() => {
-    load();
-  }, [load]);
-
-  const beginCheckout = () => {
-    if (!paymentRequest) return;
-    const url = paymentRequest.hostedUrl;
-    if (!url) {
-      setError(
-        t("cloud.paymentRequest.noCheckoutUrl", {
-          defaultValue: "This payment request has no hosted checkout URL yet.",
-        }),
-      );
+    const generation = ++loadGenerationRef.current;
+    if (!paymentRequestId) {
+      setPaymentRequest(null);
+      setIsLoading(false);
       return;
     }
+    const controller = new AbortController();
+    setPaymentRequest(null);
+    setIsLoading(true);
+    setError(null);
+    setIsPaying(false);
+    (async () => {
+      try {
+        const response = await fetchPublicRequest(
+          paymentRequestId,
+          controller.signal,
+        );
+        if (loadGenerationRef.current !== generation) return;
+        setPaymentRequest(response.paymentRequest);
+        setNowMs(Date.now());
+      } catch (loadError) {
+        // error-policy:J4 — an aborted or superseded load is not this route's
+        // failure; only the current generation surfaces a visible error state.
+        if (
+          controller.signal.aborted ||
+          loadGenerationRef.current !== generation
+        ) {
+          return;
+        }
+        setError({ kind: "request-failed", cause: loadError });
+      } finally {
+        if (
+          !controller.signal.aborted &&
+          loadGenerationRef.current === generation
+        ) {
+          setIsLoading(false);
+        }
+      }
+    })();
+    return () => controller.abort();
+  }, [paymentRequestId, fetchPublicRequest]);
+
+  // Re-evaluate eligibility exactly when the deadline passes so an open tab
+  // cannot keep a stale enabled Pay button across the request's expiry.
+  const expiresAt = paymentRequest?.expiresAt ?? null;
+  useEffect(() => {
+    if (!expiresAt) return;
+    const deadline = Date.parse(expiresAt);
+    if (!Number.isFinite(deadline)) return;
+    const delay = deadline - Date.now();
+    if (delay <= 0) return;
+    // setTimeout clamps delays above 2^31-1; cap so far-future deadlines
+    // never fire immediately (they are re-armed on any reload anyway).
+    const timer = window.setTimeout(
+      () => setNowMs(Date.now()),
+      Math.min(delay + 1, 2 ** 31 - 1),
+    );
+    return () => window.clearTimeout(timer);
+  }, [expiresAt]);
+
+  const beginCheckout = useCallback(async () => {
+    if (!paymentRequest || !paymentRequestId || isPaying) return;
     setIsPaying(true);
-    window.location.assign(url);
-  };
+    setError(null);
+    const generation = loadGenerationRef.current;
+    try {
+      // Revalidate against the server immediately before navigation: the
+      // request may have settled, been canceled, or expired since page load.
+      const response = await fetchPublicRequest(paymentRequestId);
+      if (loadGenerationRef.current !== generation) return;
+      const fresh = response.paymentRequest;
+      const freshNow = Date.now();
+      setPaymentRequest(fresh);
+      setNowMs(freshNow);
+      const payable =
+        isPayableStatus(fresh.status) &&
+        !isDeadlinePassed(fresh.expiresAt, freshNow);
+      if (!payable) {
+        setIsPaying(false);
+        return;
+      }
+      if (!fresh.hostedUrl) {
+        setIsPaying(false);
+        setError({ kind: "no-checkout-url" });
+        return;
+      }
+      window.location.assign(fresh.hostedUrl);
+    } catch (checkoutError) {
+      // error-policy:J4 — a failed pre-checkout revalidation blocks navigation
+      // and is rendered as a visible page error, never a silent redirect.
+      if (loadGenerationRef.current !== generation) return;
+      setIsPaying(false);
+      setError({ kind: "request-failed", cause: checkoutError });
+    }
+  }, [paymentRequest, paymentRequestId, isPaying, fetchPublicRequest]);
 
   if (isLoading) {
     return (
@@ -150,10 +273,15 @@ export default function PaymentRequestPage() {
                 })}
               </h1>
               <p className="mt-1 text-sm text-muted">
-                {error ||
-                  t("cloud.paymentRequest.linkUnavailable", {
-                    defaultValue: "This payment link is unavailable.",
-                  })}
+                {!paymentRequestId
+                  ? t("cloud.paymentRequest.missingId", {
+                      defaultValue: "Missing payment request id.",
+                    })
+                  : error
+                    ? errorMessage(error, t)
+                    : t("cloud.paymentRequest.linkUnavailable", {
+                        defaultValue: "This payment link is unavailable.",
+                      })}
               </p>
             </div>
           </div>
@@ -171,16 +299,19 @@ export default function PaymentRequestPage() {
   }
 
   const isPaid = paymentRequest.status === "settled";
+  const deadlinePassed = isDeadlinePassed(paymentRequest.expiresAt, nowMs);
   const isExpired =
     paymentRequest.status === "expired" ||
     paymentRequest.status === "canceled" ||
-    paymentRequest.status === "failed";
+    paymentRequest.status === "failed" ||
+    (isPayableStatus(paymentRequest.status) && deadlinePassed);
   const canPay =
-    (paymentRequest.status === "pending" ||
-      paymentRequest.status === "delivered") &&
+    isPayableStatus(paymentRequest.status) &&
+    !deadlinePassed &&
     Boolean(paymentRequest.hostedUrl);
   const expiresLabel = formatDate(paymentRequest.expiresAt);
   const shortId = paymentRequest.id.slice(0, 8);
+  const provider = providerLabel(paymentRequest.provider, t);
 
   return (
     <div className="theme-cloud min-h-[100dvh] bg-bg px-4 py-8 text-txt sm:px-6 lg:px-8">
@@ -233,7 +364,7 @@ export default function PaymentRequestPage() {
           {error && (
             <div className="mt-7 flex items-center gap-3 border border-destructive/30 bg-destructive-subtle p-3 text-sm text-txt">
               <AlertCircle className="h-5 w-5 shrink-0 text-destructive" />
-              <span>{error}</span>
+              <span>{errorMessage(error, t)}</span>
             </div>
           )}
 
@@ -256,7 +387,7 @@ export default function PaymentRequestPage() {
                       defaultValue: "Already paid",
                     })
                   : t("cloud.paymentRequest.payWith", {
-                      provider: paymentRequest.provider,
+                      provider,
                       defaultValue: "Pay with {{provider}}",
                     })}
               </span>
@@ -265,7 +396,7 @@ export default function PaymentRequestPage() {
 
           <div className="mt-6 flex items-center justify-between border-t border-border pt-4 text-xs text-muted">
             <span>#{shortId}</span>
-            <span>{paymentRequest.provider}</span>
+            <span>{provider}</span>
           </div>
         </section>
       </main>

--- a/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.tsx
@@ -91,9 +91,9 @@ type Deadline =
 
 const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
 
-/** Parses the server deadline without turning malformed input into a payable request. */
+/** Parses the server deadline without turning missing or malformed input into a payable request. */
 function parseDeadline(value: string | null): Deadline {
-  if (value === null) return { kind: "none" };
+  if (value === null) return { kind: "invalid" };
   const valueMs = Date.parse(value);
   return Number.isFinite(valueMs)
     ? { kind: "valid", valueMs }
@@ -112,6 +112,10 @@ function formatDeadline(deadline: Deadline): string | null {
 
 function isDeadlinePassed(deadline: Deadline, nowMs: number): boolean {
   return deadline.kind === "valid" && deadline.valueMs <= nowMs;
+}
+
+function hasPaymentAuthority(deadline: Deadline, nowMs: number): boolean {
+  return deadline.kind === "valid" && deadline.valueMs > nowMs;
 }
 
 function isPayableStatus(status: PaymentRequestStatus): boolean {
@@ -159,6 +163,7 @@ export default function PaymentRequestPage() {
   // Monotonic key: only the latest load (or a checkout revalidation started
   // under it) may commit state, so stale responses cannot cross routes.
   const loadGenerationRef = useRef(0);
+  const checkoutControllerRef = useRef<AbortController | null>(null);
 
   usePageTitle(
     t("cloud.paymentRequest.metaTitle", {
@@ -177,12 +182,19 @@ export default function PaymentRequestPage() {
 
   useEffect(() => {
     const generation = ++loadGenerationRef.current;
+    const controller = new AbortController();
+    const invalidate = () => {
+      controller.abort();
+      checkoutControllerRef.current?.abort();
+      if (loadGenerationRef.current === generation) {
+        loadGenerationRef.current += 1;
+      }
+    };
     if (!paymentRequestId) {
       setPaymentRequest(null);
       setIsLoading(false);
-      return;
+      return invalidate;
     }
-    const controller = new AbortController();
     setPaymentRequest(null);
     setIsLoading(true);
     setError(null);
@@ -215,7 +227,7 @@ export default function PaymentRequestPage() {
         }
       }
     })();
-    return () => controller.abort();
+    return invalidate;
   }, [paymentRequestId, fetchPublicRequest]);
 
   // Re-evaluate eligibility exactly when the deadline passes so an open tab
@@ -250,12 +262,21 @@ export default function PaymentRequestPage() {
     if (!paymentRequest || !paymentRequestId || isPaying) return;
     setIsPaying(true);
     setError(null);
+    checkoutControllerRef.current?.abort();
+    const checkoutController = new AbortController();
+    checkoutControllerRef.current = checkoutController;
     const generation = loadGenerationRef.current;
+    const checkoutStillLive = () =>
+      !checkoutController.signal.aborted &&
+      loadGenerationRef.current === generation;
     try {
       // Revalidate against the server immediately before navigation: the
       // request may have settled, been canceled, or expired since page load.
-      const response = await fetchPublicRequest(paymentRequestId);
-      if (loadGenerationRef.current !== generation) return;
+      const response = await fetchPublicRequest(
+        paymentRequestId,
+        checkoutController.signal,
+      );
+      if (!checkoutStillLive()) return;
       const fresh = response.paymentRequest;
       const freshNow = Date.now();
       setPaymentRequest(fresh);
@@ -263,8 +284,7 @@ export default function PaymentRequestPage() {
       const freshDeadline = parseDeadline(fresh.expiresAt);
       const payable =
         isPayableStatus(fresh.status) &&
-        freshDeadline.kind !== "invalid" &&
-        !isDeadlinePassed(freshDeadline, freshNow);
+        hasPaymentAuthority(freshDeadline, freshNow);
       if (!payable) {
         setIsPaying(false);
         return;
@@ -274,11 +294,12 @@ export default function PaymentRequestPage() {
         setError({ kind: "no-checkout-url" });
         return;
       }
+      if (!checkoutStillLive()) return;
       window.location.assign(fresh.hostedUrl);
     } catch (checkoutError) {
       // error-policy:J4 — a failed pre-checkout revalidation blocks navigation
       // and is rendered as a visible page error, never a silent redirect.
-      if (loadGenerationRef.current !== generation) return;
+      if (!checkoutStillLive()) return;
       setIsPaying(false);
       setError({ kind: "request-failed", cause: checkoutError });
     }
@@ -342,8 +363,7 @@ export default function PaymentRequestPage() {
     (isPayableStatus(paymentRequest.status) && deadlinePassed);
   const canPay =
     isPayableStatus(paymentRequest.status) &&
-    !hasInvalidPayableDeadline &&
-    !deadlinePassed &&
+    hasPaymentAuthority(deadline, nowMs) &&
     Boolean(paymentRequest.hostedUrl);
   const expiresLabel = formatDeadline(deadline);
   const shortId = paymentRequest.id.slice(0, 8);

--- a/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.tsx
@@ -84,21 +84,34 @@ function formatAmount(amountCents: number, currency: string): string {
   }
 }
 
-function formatDate(value: string | null): string | null {
-  if (!value) return null;
+type Deadline =
+  | { kind: "none" }
+  | { kind: "invalid" }
+  | { kind: "valid"; valueMs: number };
+
+const MAX_TIMER_DELAY_MS = 2 ** 31 - 1;
+
+/** Parses the server deadline without turning malformed input into a payable request. */
+function parseDeadline(value: string | null): Deadline {
+  if (value === null) return { kind: "none" };
+  const valueMs = Date.parse(value);
+  return Number.isFinite(valueMs)
+    ? { kind: "valid", valueMs }
+    : { kind: "invalid" };
+}
+
+function formatDeadline(deadline: Deadline): string | null {
+  if (deadline.kind !== "valid") return null;
   return new Intl.DateTimeFormat("en-US", {
     month: "short",
     day: "numeric",
     hour: "numeric",
     minute: "2-digit",
-  }).format(new Date(value));
+  }).format(new Date(deadline.valueMs));
 }
 
-/** True once a parseable deadline is at or before `nowMs`; requests without a deadline never pass it. */
-function isDeadlinePassed(expiresAt: string | null, nowMs: number): boolean {
-  if (!expiresAt) return false;
-  const deadline = Date.parse(expiresAt);
-  return Number.isFinite(deadline) && deadline <= nowMs;
+function isDeadlinePassed(deadline: Deadline, nowMs: number): boolean {
+  return deadline.kind === "valid" && deadline.valueMs <= nowMs;
 }
 
 function isPayableStatus(status: PaymentRequestStatus): boolean {
@@ -111,9 +124,16 @@ function isPayableStatus(status: PaymentRequestStatus): boolean {
  */
 type PageError =
   | { kind: "request-failed"; cause: unknown }
-  | { kind: "no-checkout-url" };
+  | { kind: "no-checkout-url" }
+  | { kind: "invalid-deadline" };
 
 function errorMessage(error: PageError, t: TFn): string {
+  if (error.kind === "invalid-deadline") {
+    return t("cloud.paymentRequest.invalidExpiry", {
+      defaultValue:
+        "This payment request has an invalid expiry date and cannot be paid.",
+    });
+  }
   if (error.kind === "no-checkout-url") {
     return t("cloud.paymentRequest.noCheckoutUrl", {
       defaultValue: "This payment request has no hosted checkout URL yet.",
@@ -202,18 +222,28 @@ export default function PaymentRequestPage() {
   // cannot keep a stale enabled Pay button across the request's expiry.
   const expiresAt = paymentRequest?.expiresAt ?? null;
   useEffect(() => {
-    if (!expiresAt) return;
-    const deadline = Date.parse(expiresAt);
-    if (!Number.isFinite(deadline)) return;
-    const delay = deadline - Date.now();
-    if (delay <= 0) return;
-    // setTimeout clamps delays above 2^31-1; cap so far-future deadlines
-    // never fire immediately (they are re-armed on any reload anyway).
-    const timer = window.setTimeout(
-      () => setNowMs(Date.now()),
-      Math.min(delay + 1, 2 ** 31 - 1),
-    );
-    return () => window.clearTimeout(timer);
+    const deadline = parseDeadline(expiresAt);
+    if (deadline.kind !== "valid") return;
+
+    let timer: number | undefined;
+    const armTimer = () => {
+      const remainingMs = deadline.valueMs - Date.now();
+      if (remainingMs <= 0) {
+        setNowMs(Date.now());
+        return;
+      }
+      // Browser timers cannot represent delays above 2^31-1 ms. Wake at that
+      // boundary and re-arm until the actual deadline rather than expiring early.
+      timer = window.setTimeout(
+        armTimer,
+        Math.min(remainingMs + 1, MAX_TIMER_DELAY_MS),
+      );
+    };
+
+    armTimer();
+    return () => {
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
   }, [expiresAt]);
 
   const beginCheckout = useCallback(async () => {
@@ -230,9 +260,11 @@ export default function PaymentRequestPage() {
       const freshNow = Date.now();
       setPaymentRequest(fresh);
       setNowMs(freshNow);
+      const freshDeadline = parseDeadline(fresh.expiresAt);
       const payable =
         isPayableStatus(fresh.status) &&
-        !isDeadlinePassed(fresh.expiresAt, freshNow);
+        freshDeadline.kind !== "invalid" &&
+        !isDeadlinePassed(freshDeadline, freshNow);
       if (!payable) {
         setIsPaying(false);
         return;
@@ -299,7 +331,10 @@ export default function PaymentRequestPage() {
   }
 
   const isPaid = paymentRequest.status === "settled";
-  const deadlinePassed = isDeadlinePassed(paymentRequest.expiresAt, nowMs);
+  const deadline = parseDeadline(paymentRequest.expiresAt);
+  const deadlinePassed = isDeadlinePassed(deadline, nowMs);
+  const hasInvalidPayableDeadline =
+    isPayableStatus(paymentRequest.status) && deadline.kind === "invalid";
   const isExpired =
     paymentRequest.status === "expired" ||
     paymentRequest.status === "canceled" ||
@@ -307,11 +342,15 @@ export default function PaymentRequestPage() {
     (isPayableStatus(paymentRequest.status) && deadlinePassed);
   const canPay =
     isPayableStatus(paymentRequest.status) &&
+    !hasInvalidPayableDeadline &&
     !deadlinePassed &&
     Boolean(paymentRequest.hostedUrl);
-  const expiresLabel = formatDate(paymentRequest.expiresAt);
+  const expiresLabel = formatDeadline(deadline);
   const shortId = paymentRequest.id.slice(0, 8);
   const provider = providerLabel(paymentRequest.provider, t);
+  const displayedError: PageError | null = hasInvalidPayableDeadline
+    ? { kind: "invalid-deadline" }
+    : error;
 
   return (
     <div className="theme-cloud min-h-[100dvh] bg-bg px-4 py-8 text-txt sm:px-6 lg:px-8">
@@ -333,26 +372,30 @@ export default function PaymentRequestPage() {
             <div className="mt-3 text-sm text-muted">
               {isPaid
                 ? t("cloud.paymentRequest.paid", { defaultValue: "Paid" })
-                : isExpired
-                  ? paymentRequest.status === "canceled"
-                    ? t("cloud.paymentRequest.cancelled", {
-                        defaultValue: "Cancelled",
-                      })
-                    : paymentRequest.status === "failed"
-                      ? t("cloud.paymentRequest.failed", {
-                          defaultValue: "Failed",
+                : hasInvalidPayableDeadline
+                  ? t("cloud.paymentRequest.invalidExpiryShort", {
+                      defaultValue: "Invalid expiry date",
+                    })
+                  : isExpired
+                    ? paymentRequest.status === "canceled"
+                      ? t("cloud.paymentRequest.cancelled", {
+                          defaultValue: "Cancelled",
                         })
-                      : t("cloud.paymentRequest.expired", {
-                          defaultValue: "Expired",
+                      : paymentRequest.status === "failed"
+                        ? t("cloud.paymentRequest.failed", {
+                            defaultValue: "Failed",
+                          })
+                        : t("cloud.paymentRequest.expired", {
+                            defaultValue: "Expired",
+                          })
+                    : expiresLabel
+                      ? t("cloud.paymentRequest.pendingExpires", {
+                          date: expiresLabel,
+                          defaultValue: "Pending - expires {{date}}",
                         })
-                  : expiresLabel
-                    ? t("cloud.paymentRequest.pendingExpires", {
-                        date: expiresLabel,
-                        defaultValue: "Pending - expires {{date}}",
-                      })
-                    : t("cloud.paymentRequest.pending", {
-                        defaultValue: "Pending",
-                      })}
+                      : t("cloud.paymentRequest.pending", {
+                          defaultValue: "Pending",
+                        })}
             </div>
             {paymentRequest.reason && (
               <p className="mt-3 max-w-md text-sm text-muted-strong">
@@ -361,10 +404,10 @@ export default function PaymentRequestPage() {
             )}
           </div>
 
-          {error && (
+          {displayedError && (
             <div className="mt-7 flex items-center gap-3 border border-destructive/30 bg-destructive-subtle p-3 text-sm text-txt">
               <AlertCircle className="h-5 w-5 shrink-0 text-destructive" />
-              <span>{errorMessage(error, t)}</span>
+              <span>{errorMessage(displayedError, t)}</span>
             </div>
           )}
 

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -6745,6 +6745,8 @@
   "cloud.paymentRequest.cancelled": "Cancelled",
   "cloud.paymentRequest.failed": "Failed",
   "cloud.paymentRequest.expired": "Expired",
+  "cloud.paymentRequest.invalidExpiry": "This payment request has an invalid expiry date and cannot be paid.",
+  "cloud.paymentRequest.invalidExpiryShort": "Invalid expiry date",
   "cloud.paymentRequest.pendingExpires": "Pending - expires {{date}}",
   "cloud.paymentRequest.pending": "Pending",
   "cloud.paymentRequest.alreadyPaid": "Already paid",


### PR DESCRIPTION
# Relates to

Stacked repair for #19820 at exact source head `a1734607130cb7d54f7520c64c0498ae5edb216d`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Checkout revalidation is aborted and generation-invalidated on unmount or route change, so a late response cannot `window.location.assign`.
- [x] `expiresAt: null` is not payable: Pay is disabled and checkout will not navigate.
- [x] Payment authority requires `deadline.kind === "valid"` and `valueMs > now`.
- [x] Focused regressions cover null-deadline render, null-deadline checkout, pending-checkout unmount, and route-change completion.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no repository contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Repair is stacked on the live #19820 head, not a develop rewrite of the contributor series.
- [ ] Hosted checks must report independently for this exact repair head.
- [ ] Visual evidence rows on the source PR remain author-side; this stack is source/test only.

# Risks

Fail-closed for missing expiry: a delivered request with `expiresAt: null` can no longer be paid from this page. That matches the documented Pay contract.

# Background

## What does this PR do?

#19820 already generation-keys the initial load and rejects malformed dates, but checkout fetch had no AbortSignal and cleanup did not invalidate that generation. A user who left the page after clicking Pay could still be redirected. `parseDeadline(null)` also returned `none`, which left Pay enabled.

This follow-up shares lifecycle invalidation between load and checkout, requires a valid future deadline for payment authority, and adds the four production-path cases the current-head review reproduced.

## What kind of change is this?

Correctness / fail-closed checkout safety.

# Testing

Protected worktree. Official UI jsdom setup cannot load `node:` under this host's Vite/jsdom pairing; the focused suite ran with `NODE_ENV=development` so React 19 exports `act`:

```text
$ NODE_ENV=development node ./node_modules/vitest/vitest.mjs run --config ./vitest.config.ts \
    src/cloud/public-pages/pages/payment/payment-request-page.test.tsx
 Test Files  1 passed (1)
      Tests  15 passed (15)

null->none sabotage:
 Test Files  1 failed (1)
      Tests  2 failed | 13 passed (15)
 FAIL fails closed and disables Pay when expiresAt is null
 FAIL blocks checkout navigation when revalidation returns a null deadline

drop unmount generation bump:
 Test Files  1 failed (1)
      Tests  1 failed | 14 passed (15)
 FAIL does not navigate after Pay is clicked and the page unmounts

production restored:
 Test Files  1 passed (1)
      Tests  15 passed (15)
Biome 2 files clean
git diff --check clean
```

# Evidence Gate

<!-- evidence-head:7a88187af91279a8e5a267066a194d0577582050 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - source/test checkout-lifecycle repair; no new visual surface. Source PR still owns the provider screenshot matrix.
<!-- evidence-row:after-screenshots -->
- [x] N/A - source/test checkout-lifecycle repair; no new visual surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - source/test checkout-lifecycle repair; no new visual surface.
<!-- evidence-row:backend-logs -->
- [x] Protected focused runtime transcript:

```text
$ NODE_ENV=development node ./node_modules/vitest/vitest.mjs run
 Test Files  1 passed (1)
      Tests  15 passed (15)
 null sabotage: 2 failed | 13 passed
 unmount sabotage: 1 failed | 14 passed
 restored: 15 passed (15)
Biome clean
git diff --check clean
```

<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser capture in this stacked source repair.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no user-visible domain artifact files; proof is the focused payment-page suite.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Hermes Agent
Contribution skill revision: N/A - contribute-to-eliza skill was not available in this session
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Hermes Agent","skill_revision":"N/A - contribute-to-eliza skill was not available in this session"} -->
