### PR TITLE
fix(agent): require terminal research results

### DIFF
--- a/packages/agent/src/services/research-task-executor.test.ts
+++ b/packages/agent/src/services/research-task-executor.test.ts
@@ -2,7 +2,11 @@
  * Exercises the research task boundary with a deterministic runtime stub. The
  * suite proves that only the real RESEARCH slot can produce successful research.
  */
-import { type IAgentRuntime, ModelType } from "@elizaos/core";
+import {
+  type IAgentRuntime,
+  ModelType,
+  type ResearchResult,
+} from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { ResearchTaskExecutor } from "./research-task-executor.ts";
 
@@ -16,10 +20,23 @@ function runtimeWith(useModel: unknown): IAgentRuntime {
   return { useModel } as IAgentRuntime;
 }
 
+function researchResult(
+  overrides: Partial<ResearchResult> = {},
+): ResearchResult {
+  return {
+    id: "research-response-1",
+    text: "Cited research report",
+    annotations: [],
+    outputItems: [],
+    status: "completed",
+    ...overrides,
+  };
+}
+
 describe("ResearchTaskExecutor", () => {
   it("returns the real RESEARCH provider report", async () => {
-    const useModel = vi.fn(
-      async (_modelType: string, _params: unknown) => "Cited research report",
+    const useModel = vi.fn(async (_modelType: string, _params: unknown) =>
+      researchResult(),
     );
 
     const result = await new ResearchTaskExecutor().execute(
@@ -34,7 +51,10 @@ describe("ResearchTaskExecutor", () => {
     expect(useModel).toHaveBeenCalledTimes(1);
     expect(useModel).toHaveBeenCalledWith(
       ModelType.RESEARCH,
-      expect.objectContaining({ input: spec.description }),
+      expect.objectContaining({
+        input: spec.description,
+        background: false,
+      }),
     );
   });
 
@@ -58,9 +78,50 @@ describe("ResearchTaskExecutor", () => {
     expect(useModel.mock.calls[0]?.[0]).toBe(ModelType.RESEARCH);
   });
 
-  it("rejects an empty provider response as an explicit failure", async () => {
-    const useModel = vi.fn(
-      async (_modelType: string, _params: unknown) => "   ",
+  it("rejects a terminal provider failure", async () => {
+    const useModel = vi.fn(async (_modelType: string, _params: unknown) =>
+      researchResult({ status: "failed", text: "" }),
+    );
+
+    const result = await new ResearchTaskExecutor().execute(
+      spec,
+      runtimeWith(useModel),
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      errorCode: "RESEARCH_FAILED_RESULT",
+      error: "The research provider reported a terminal failure",
+    });
+    expect(useModel).toHaveBeenCalledTimes(1);
+    expect(useModel.mock.calls[0]?.[0]).toBe(ModelType.RESEARCH);
+  });
+
+  it.each(["queued", "in_progress"] as const)(
+    "rejects a %s acknowledgement even when it carries partial text",
+    async (status) => {
+      const useModel = vi.fn(async (_modelType: string, _params: unknown) =>
+        researchResult({ status, text: "Partial non-terminal report" }),
+      );
+
+      const result = await new ResearchTaskExecutor().execute(
+        spec,
+        runtimeWith(useModel),
+      );
+
+      expect(result).toMatchObject({
+        success: false,
+        errorCode: "RESEARCH_NON_TERMINAL_RESULT",
+        error: `The research provider returned a non-terminal ${status} result`,
+      });
+      expect(useModel).toHaveBeenCalledTimes(1);
+      expect(useModel.mock.calls[0]?.[0]).toBe(ModelType.RESEARCH);
+    },
+  );
+
+  it("rejects an empty completed response as an explicit failure", async () => {
+    const useModel = vi.fn(async (_modelType: string, _params: unknown) =>
+      researchResult({ text: "   " }),
     );
 
     const result = await new ResearchTaskExecutor().execute(

--- a/packages/agent/src/services/research-task-executor.ts
+++ b/packages/agent/src/services/research-task-executor.ts
@@ -7,6 +7,7 @@ import {
   type IAgentRuntime,
   isElizaError,
   ModelType,
+  type ResearchResult,
 } from "@elizaos/core";
 import type { TaskExecutor, TaskResult, TaskSpec } from "./task-executor.ts";
 
@@ -27,24 +28,14 @@ export class ResearchTaskExecutor implements TaskExecutor {
   async execute(spec: TaskSpec, runtime: IAgentRuntime): Promise<TaskResult> {
     const startTime = Date.now();
     try {
-      let researchResult:
-        | {
-            text?: string;
-            annotations?: Array<{ url?: string; title?: string }>;
-          }
-        | string;
+      let researchResult: ResearchResult;
       try {
         researchResult = (await runtime.useModel(ModelType.RESEARCH, {
           input: spec.description,
           tools: [{ type: "web_search_preview" }],
-          background: true,
+          background: false,
           reasoningSummary: "auto",
-        })) as
-          | {
-              text?: string;
-              annotations?: Array<{ url?: string; title?: string }>;
-            }
-          | string;
+        })) as ResearchResult;
       } catch (cause) {
         // error-policy:J2 provider errors gain a stable research-task code and
         // preserve their cause before the executor boundary translates them.
@@ -60,10 +51,33 @@ export class ResearchTaskExecutor implements TaskExecutor {
         );
       }
 
-      const output =
-        typeof researchResult === "string"
-          ? researchResult
-          : (researchResult.text ?? "");
+      if (researchResult.status === "failed") {
+        throw new ElizaError(
+          "The research provider reported a terminal failure",
+          {
+            code: "RESEARCH_FAILED_RESULT",
+            context: { taskId: spec.id, responseId: researchResult.id },
+          },
+        );
+      }
+      if (
+        researchResult.status === "queued" ||
+        researchResult.status === "in_progress"
+      ) {
+        throw new ElizaError(
+          `The research provider returned a non-terminal ${researchResult.status} result`,
+          {
+            code: "RESEARCH_NON_TERMINAL_RESULT",
+            context: {
+              taskId: spec.id,
+              responseId: researchResult.id,
+              status: researchResult.status,
+            },
+          },
+        );
+      }
+
+      const output = researchResult.text;
       if (output.trim().length === 0) {
         throw new ElizaError("The research provider returned no report", {
           code: "RESEARCH_EMPTY_RESULT",


### PR DESCRIPTION
# Relates to

Closes #19178.

# Summary

- Makes the agent research executor request a synchronous terminal `ModelType.RESEARCH` result (`background: false`).
- Accepts only completed, non-empty provider output as a finished research task.
- Fails fast with typed errors for provider rejection, terminal provider failure, queued/in-progress acknowledgements (even when they contain partial text), and empty completion.
- Preserves the explicit Cloud research retirement: there is no `TEXT_LARGE` fallback and no fabricated research report.

# Root cause

After Cloud research was retired, the executor still sent `background: true` and immediately treated the provider response text as a completed report. A queued or in-progress acknowledgement could therefore be persisted as successful research. The executor now requires the terminal contract it actually consumes.

# Verification

- Exact head: `d8f347ac9a96184711cde9571a924e8f821ea739`
- Rebased base: `5212eedbf59164712dffd80d9a222f0675446ad5`
- Research executor contract: 6/6 pass.
- Retired Cloud research compatibility: 3/3 pass.
- `bun run --cwd packages/agent typecheck`: pass.
- `bun run --cwd packages/agent build`: pass; 193 package imports rewritten/verified.
- Exact two-file Biome check: pass.
- Exact-head root `bun run verify`: 351/351 uncached tasks plus every repository audit.
- Anti-larp: 8,268 test files scanned; 0 focused tests and 0 orphaned skips.
- `git diff --check`: pass.

<details>
<summary>Focused behavioral receipt</summary>

```text
(pass) returns the real RESEARCH provider report
(pass) exposes provider rejection and never falls back to TEXT_LARGE
(pass) rejects a terminal provider failure
(pass) rejects a queued acknowledgement even when it carries partial text
(pass) rejects an in_progress acknowledgement even when it carries partial text
(pass) rejects an empty completed response as an explicit failure
6 pass, 0 fail, 17 expect() calls
```

</details>

# Risk

Low and deliberately fail-fast. Providers that return background acknowledgements to this synchronous executor now surface a typed error instead of a false success. Providers that return terminal `completed` output retain the existing success path.

# Evidence gate

<!-- evidence-head:d8f347ac9a96184711cde9571a924e8f821ea739 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changes
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changes
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible UI journey changes
<!-- evidence-row:backend-logs -->
- [ ] N/A - this is an in-process executor contract; the exact provider-shaped behavioral receipt is inline above
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend or network surface changes
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no live research-provider credential or paid-call authorization was available; the provider/prompt/model implementation is unchanged and deterministic terminal/non-terminal provider receipts cover the translation contract
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - this executor returns text to its caller and creates no DB row, memory, scheduled task, generated file, or other persisted domain artifact; the inline receipt proves all result states
<!-- evidence-row:ocr-review -->
- [ ] N/A - no pixels or visual text changed

# Known gaps / failures

- No real-LLM trajectory was produced because this session had neither a research-provider credential nor authorization for a paid external call. This PR changes only how the executor translates an already-typed provider result; it does not change provider selection, prompts, or model implementation.
- An initial compatibility command used the obsolete pre-rebase path `plugins/plugin-elizacloud/src/__tests__/research-retirement.test.ts` and matched no file. The current canonical path `plugins/plugin-elizacloud/__tests__/unit/research-retirement.test.ts` was then run and passed 3/3.

# Documentation

No documentation change is needed; this enforces the existing typed `ResearchResult` and explicit Cloud-retirement contract.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex/19178-terminal-research]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
