### PR TITLE
perf(cloud): bound gateway auth latency

### DIFF
--- a/packages/cloud/api/internal/_auth.ts
+++ b/packages/cloud/api/internal/_auth.ts
@@ -3,7 +3,7 @@ import type { Context } from "hono";
 import { jsonError } from "@/lib/api/cloud-worker-errors";
 import {
   extractBearerToken,
-  verifyInternalToken,
+  verifyInternalRequestToken,
 } from "@/lib/auth/jwt-internal";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -41,7 +41,7 @@ export async function requireInternalAuth(
   }
 
   try {
-    const verified = await verifyInternalToken(token);
+    const verified = await verifyInternalRequestToken(token);
     return {
       podName: verified.payload.sub,
       service: verified.payload.service,

--- a/packages/cloud/api/internal/auth/refresh/route.ts
+++ b/packages/cloud/api/internal/auth/refresh/route.ts
@@ -11,6 +11,7 @@ import { isJWKSConfigured } from "@/lib/auth/jwks";
 import {
   extractBearerToken,
   internalTokenLifetimeForService,
+  isShortLivedGatewayService,
   signInternalToken,
   verifyInternalToken,
 } from "@/lib/auth/jwt-internal";
@@ -38,6 +39,13 @@ app.post("/*", async (c) => {
       service = verified.payload.service;
     } catch {
       return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    // Gateway credentials are deliberately bounded bearer capabilities. They
+    // must return to the bootstrap-secret exchange so a captured token cannot
+    // extend its own replay window through an unbounded refresh chain.
+    if (isShortLivedGatewayService(service)) {
+      return c.json({ error: "gateway_token_rebootstrap_required" }, 403);
     }
 
     const refreshed = await signInternalToken({

--- a/packages/cloud/api/internal/auth/refresh/route.ts
+++ b/packages/cloud/api/internal/auth/refresh/route.ts
@@ -10,6 +10,7 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { isJWKSConfigured } from "@/lib/auth/jwks";
 import {
   extractBearerToken,
+  internalTokenLifetimeForService,
   signInternalToken,
   verifyInternalToken,
 } from "@/lib/auth/jwt-internal";
@@ -39,7 +40,11 @@ app.post("/*", async (c) => {
       return c.json({ error: "Unauthorized" }, 401);
     }
 
-    const refreshed = await signInternalToken({ subject: sub, service });
+    const refreshed = await signInternalToken({
+      subject: sub,
+      service,
+      expiresIn: internalTokenLifetimeForService(service),
+    });
     return c.json(refreshed);
   } catch (err) {
     logger.error("[internal/auth/refresh]", { error: err });

--- a/packages/cloud/api/internal/auth/token/route.test.ts
+++ b/packages/cloud/api/internal/auth/token/route.test.ts
@@ -1,4 +1,4 @@
-/** Proves gateway token exchange and refresh preserve the bounded lifetime. */
+/** Proves short-lived gateway tokens cannot extend their own replay window. */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { generateKeyPairSync } from "node:crypto";
@@ -65,11 +65,30 @@ describe("bounded gateway JWT lifetime", () => {
     });
   });
 
-  test("refreshes discord gateway tokens without widening their lifetime", async () => {
+  test.each(["webhook-gateway", "discord-gateway"])(
+    "rejects self-refresh for %s tokens",
+    async (service) => {
+      const original = await signInternalToken({
+        subject: `${service}-test`,
+        service,
+        expiresIn: GATEWAY_TOKEN_LIFETIME_SECONDS,
+      });
+      const response = await refreshApp.request("/", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${original.access_token}` },
+      });
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toEqual({
+        error: "gateway_token_rebootstrap_required",
+      });
+    },
+  );
+
+  test("ordinary internal tokens retain authenticated rotation", async () => {
     const original = await signInternalToken({
-      subject: "gateway-discord-test",
-      service: "discord-gateway",
-      expiresIn: GATEWAY_TOKEN_LIFETIME_SECONDS,
+      subject: "ordinary-service-test",
+      service: "ordinary-service",
     });
     const response = await refreshApp.request("/", {
       method: "POST",
@@ -77,9 +96,5 @@ describe("bounded gateway JWT lifetime", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toMatchObject({
-      token_type: "Bearer",
-      expires_in: GATEWAY_TOKEN_LIFETIME_SECONDS,
-    });
   });
 });

--- a/packages/cloud/api/internal/auth/token/route.test.ts
+++ b/packages/cloud/api/internal/auth/token/route.test.ts
@@ -1,0 +1,85 @@
+/** Proves gateway token exchange and refresh preserve the bounded lifetime. */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { generateKeyPairSync } from "node:crypto";
+import {
+  GATEWAY_TOKEN_LIFETIME_SECONDS,
+  signInternalToken,
+} from "@/lib/auth/jwt-internal";
+
+const { publicKey, privateKey } = generateKeyPairSync("ec", {
+  namedCurve: "P-256",
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+const originalEnv = {
+  privateKey: process.env.JWT_SIGNING_PRIVATE_KEY,
+  publicKey: process.env.JWT_SIGNING_PUBLIC_KEY,
+  keyId: process.env.JWT_SIGNING_KEY_ID,
+};
+
+beforeAll(() => {
+  process.env.JWT_SIGNING_PRIVATE_KEY =
+    Buffer.from(privateKey).toString("base64");
+  process.env.JWT_SIGNING_PUBLIC_KEY =
+    Buffer.from(publicKey).toString("base64");
+  process.env.JWT_SIGNING_KEY_ID = "gateway-lifetime-test";
+});
+
+afterAll(() => {
+  if (originalEnv.privateKey === undefined)
+    delete process.env.JWT_SIGNING_PRIVATE_KEY;
+  else process.env.JWT_SIGNING_PRIVATE_KEY = originalEnv.privateKey;
+  if (originalEnv.publicKey === undefined)
+    delete process.env.JWT_SIGNING_PUBLIC_KEY;
+  else process.env.JWT_SIGNING_PUBLIC_KEY = originalEnv.publicKey;
+  if (originalEnv.keyId === undefined) delete process.env.JWT_SIGNING_KEY_ID;
+  else process.env.JWT_SIGNING_KEY_ID = originalEnv.keyId;
+});
+
+const { default: tokenApp } = await import("./route");
+const { default: refreshApp } = await import("../refresh/route");
+
+describe("bounded gateway JWT lifetime", () => {
+  test("issues webhook gateway tokens for exactly one minute", async () => {
+    const response = await tokenApp.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Gateway-Secret": "bootstrap-test-secret",
+        },
+        body: JSON.stringify({
+          pod_name: "gateway-webhook-test",
+          service: "webhook-gateway",
+        }),
+      },
+      { GATEWAY_BOOTSTRAP_SECRET: "bootstrap-test-secret" } as never,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      token_type: "Bearer",
+      expires_in: GATEWAY_TOKEN_LIFETIME_SECONDS,
+    });
+  });
+
+  test("refreshes discord gateway tokens without widening their lifetime", async () => {
+    const original = await signInternalToken({
+      subject: "gateway-discord-test",
+      service: "discord-gateway",
+      expiresIn: GATEWAY_TOKEN_LIFETIME_SECONDS,
+    });
+    const response = await refreshApp.request("/", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${original.access_token}` },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      token_type: "Bearer",
+      expires_in: GATEWAY_TOKEN_LIFETIME_SECONDS,
+    });
+  });
+});

--- a/packages/cloud/api/internal/auth/token/route.ts
+++ b/packages/cloud/api/internal/auth/token/route.ts
@@ -10,7 +10,10 @@ import { createHash, timingSafeEqual } from "node:crypto";
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { isJWKSConfigured } from "@/lib/auth/jwks";
-import { signInternalToken } from "@/lib/auth/jwt-internal";
+import {
+  internalTokenLifetimeForService,
+  signInternalToken,
+} from "@/lib/auth/jwt-internal";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -48,7 +51,11 @@ app.post("/*", async (c) => {
     const service =
       typeof body.service === "string" ? body.service.trim() : undefined;
 
-    const token = await signInternalToken({ subject, service });
+    const token = await signInternalToken({
+      subject,
+      service,
+      expiresIn: internalTokenLifetimeForService(service),
+    });
     return c.json(token);
   } catch (err) {
     logger.error("[internal/auth/token]", { error: err });

--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -287,8 +287,10 @@ interface TokenResponse {
   expires_in: number;
 }
 
-/** Percentage of token lifetime at which to refresh (80% = refresh at 48min for 1hr token) */
+/** Percentage of token lifetime at which to refresh. */
 const TOKEN_REFRESH_PERCENTAGE = 0.8;
+/** Bounded retry cadence keeps a transient bootstrap failure from stranding renewal. */
+const TOKEN_REFRESH_RETRY_MS = 1_000;
 
 interface BotConnection {
   connectionId: string;
@@ -600,16 +602,40 @@ export class GatewayManager {
     }
 
     const refreshInMs = expiresInSeconds * 1000 * TOKEN_REFRESH_PERCENTAGE;
-    this.tokenRefreshTimeout = setTimeout(() => {
+    const timeout = setTimeout(() => {
+      // error-policy:J1 The timer boundary converts renewal failure into a paced retry.
       this.refreshToken().catch((error) => {
         logger.error("Token refresh failed", { error: sanitizeError(error) });
+        if (this.tokenRefreshTimeout === timeout) {
+          this.scheduleTokenRefreshRetry();
+        }
       });
     }, refreshInMs);
+    this.tokenRefreshTimeout = timeout;
 
     logger.debug("Token refresh scheduled", {
       refreshInMs,
       refreshInMinutes: Math.round(refreshInMs / 60000),
     });
+  }
+
+  private scheduleTokenRefreshRetry(): void {
+    if (this.tokenRefreshTimeout) {
+      clearTimeout(this.tokenRefreshTimeout);
+    }
+
+    const timeout = setTimeout(() => {
+      // error-policy:J1 The timer boundary retains the paced retry until recovery.
+      this.refreshToken().catch((error) => {
+        logger.error("Token refresh retry failed", {
+          error: sanitizeError(error),
+        });
+        if (this.tokenRefreshTimeout === timeout) {
+          this.scheduleTokenRefreshRetry();
+        }
+      });
+    }, TOKEN_REFRESH_RETRY_MS);
+    this.tokenRefreshTimeout = timeout;
   }
 
   /**

--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -588,53 +588,7 @@ export class GatewayManager {
    * Refresh the JWT token before it expires.
    */
   private async refreshToken(): Promise<void> {
-    if (!this.accessToken) {
-      // No token to refresh, acquire new one
-      await this.acquireToken();
-      return;
-    }
-
-    logger.info("Refreshing JWT token", { podName: this.config.podName });
-
-    try {
-      const response = await fetchWithTimeout(
-        `${this.config.elizaCloudUrl}/api/internal/auth/refresh`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${this.accessToken}`,
-          },
-        },
-      );
-
-      if (!response.ok) {
-        // Token refresh failed, try to acquire new token
-        logger.warn("Token refresh failed, acquiring new token", {
-          status: response.status,
-        });
-        await this.acquireToken();
-        return;
-      }
-
-      const data = (await response.json()) as TokenResponse;
-      this.accessToken = data.access_token;
-      this.tokenExpiresAt = new Date(Date.now() + data.expires_in * 1000);
-
-      logger.info("JWT token refreshed", {
-        podName: this.config.podName,
-        expiresAt: this.tokenExpiresAt.toISOString(),
-      });
-
-      // Schedule next refresh
-      this.scheduleTokenRefresh(data.expires_in);
-    } catch (error) {
-      logger.error("Error refreshing token, attempting re-acquisition", {
-        error: sanitizeError(error),
-      });
-      // Retry with exponential backoff could be added here
-      await this.acquireToken();
-    }
+    await this.acquireToken();
   }
 
   /**

--- a/packages/cloud/services/gateway-discord/tests/gateway-manager-auth.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/gateway-manager-auth.test.ts
@@ -1,0 +1,64 @@
+/** Verifies Discord gateway renewal returns to the bootstrap-secret exchange. */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { GatewayManager } from "../src/gateway-manager";
+
+interface AuthHarness {
+  refreshToken(): Promise<void>;
+  tokenRefreshTimeout: NodeJS.Timeout | null;
+}
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  mock.restore();
+});
+
+describe("GatewayManager token renewal", () => {
+  test("re-bootstraps with the gateway secret instead of bearer self-refresh", async () => {
+    const requests: Array<{
+      path: string;
+      authorization: string | null;
+      secret: string | null;
+    }> = [];
+    globalThis.fetch = mock(async (input: unknown, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      requests.push({
+        path: new URL(String(input)).pathname,
+        authorization: headers.get("authorization"),
+        secret: headers.get("x-gateway-secret"),
+      });
+      return new Response(
+        JSON.stringify({
+          access_token: "replacement-token",
+          token_type: "Bearer",
+          expires_in: 60,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const manager = new GatewayManager({
+      podName: "test-pod",
+      elizaCloudUrl: "https://api.test",
+      gatewayBootstrapSecret: "bootstrap-secret",
+      project: "test",
+    });
+    const harness = manager as unknown as AuthHarness;
+    try {
+      await harness.refreshToken();
+    } finally {
+      if (harness.tokenRefreshTimeout)
+        clearTimeout(harness.tokenRefreshTimeout);
+    }
+
+    expect(requests).toEqual([
+      {
+        path: "/api/internal/auth/token",
+        authorization: null,
+        secret: "bootstrap-secret",
+      },
+    ]);
+  });
+});

--- a/packages/cloud/services/gateway-discord/tests/gateway-manager-auth.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/gateway-manager-auth.test.ts
@@ -5,6 +5,7 @@ import { GatewayManager } from "../src/gateway-manager";
 
 interface AuthHarness {
   refreshToken(): Promise<void>;
+  scheduleTokenRefresh(expiresInSeconds: number): void;
   tokenRefreshTimeout: NodeJS.Timeout | null;
 }
 
@@ -61,4 +62,47 @@ describe("GatewayManager token renewal", () => {
       },
     ]);
   });
+
+  test("retries scheduled bootstrap renewal after a transient failure", async () => {
+    let bootstraps = 0;
+    globalThis.fetch = mock(async () => {
+      bootstraps += 1;
+      if (bootstraps === 1) {
+        return new Response("temporarily unavailable", { status: 503 });
+      }
+      return new Response(
+        JSON.stringify({
+          access_token: "replacement-token",
+          token_type: "Bearer",
+          expires_in: 60,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const manager = new GatewayManager({
+      podName: "test-pod",
+      elizaCloudUrl: "https://api.test",
+      gatewayBootstrapSecret: "bootstrap-secret",
+      project: "test",
+    });
+    const harness = manager as unknown as AuthHarness;
+    try {
+      harness.scheduleTokenRefresh(0.01);
+      await waitFor(() => bootstraps === 2);
+    } finally {
+      if (harness.tokenRefreshTimeout)
+        clearTimeout(harness.tokenRefreshTimeout);
+    }
+
+    expect(bootstraps).toBe(2);
+  });
 });
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("Timed out waiting for retry");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}

--- a/packages/cloud/services/gateway-webhook/__tests__/auth-rebootstrap-on-401.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/auth-rebootstrap-on-401.test.ts
@@ -239,4 +239,44 @@ describe("reacquireAuthHeader is single-flight", () => {
       true,
     );
   });
+
+  test("scheduled renewal retries bootstrap after a transient failure", async () => {
+    let bootstraps = 0;
+    globalThis.fetch = mock(async () => {
+      bootstraps += 1;
+      if (bootstraps === 2) {
+        return new Response("temporarily unavailable", { status: 503 });
+      }
+      return new Response(
+        JSON.stringify({
+          access_token: `tok-${bootstraps}`,
+          token_type: "Bearer",
+          expires_in: bootstraps === 1 ? 0.01 : 60,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const { initAuth, shutdownAuth } = await import("../src/auth");
+    try {
+      await initAuth({
+        cloudUrl: "https://api.test",
+        bootstrapSecret: "bootstrap",
+        podName: "test-pod",
+      });
+      await waitFor(() => bootstraps === 3);
+    } finally {
+      shutdownAuth();
+    }
+
+    expect(bootstraps).toBe(3);
+  });
 });
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("Timed out waiting for retry");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}

--- a/packages/cloud/services/gateway-webhook/__tests__/auth-rebootstrap-on-401.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/auth-rebootstrap-on-401.test.ts
@@ -207,4 +207,36 @@ describe("reacquireAuthHeader is single-flight", () => {
 
     shutdownAuth();
   });
+
+  test("scheduled renewal re-bootstraps and never calls the bearer refresh route", async () => {
+    const paths: string[] = [];
+    globalThis.fetch = mock(async (input: unknown) => {
+      paths.push(new URL(String(input)).pathname);
+      return new Response(
+        JSON.stringify({
+          access_token: `tok-${paths.length}`,
+          token_type: "Bearer",
+          expires_in: 0.05,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const { initAuth, shutdownAuth } = await import("../src/auth");
+    try {
+      await initAuth({
+        cloudUrl: "https://api.test",
+        bootstrapSecret: "bootstrap",
+        podName: "test-pod",
+      });
+      await new Promise((resolve) => setTimeout(resolve, 70));
+    } finally {
+      shutdownAuth();
+    }
+
+    expect(paths.length).toBeGreaterThanOrEqual(2);
+    expect(paths.every((path) => path === "/api/internal/auth/token")).toBe(
+      true,
+    );
+  });
 });

--- a/packages/cloud/services/gateway-webhook/src/auth.ts
+++ b/packages/cloud/services/gateway-webhook/src/auth.ts
@@ -76,49 +76,7 @@ async function acquireToken(): Promise<void> {
 
 async function refreshToken(): Promise<void> {
   if (!config) throw new Error("Auth not initialized");
-
-  if (!accessToken) {
-    await acquireToken();
-    return;
-  }
-
-  logger.info("Refreshing JWT token", { podName: config.podName });
-
-  try {
-    const response = await fetchWithTimeout(
-      `${config.cloudUrl}/api/internal/auth/refresh`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${accessToken}`,
-        },
-      },
-    );
-
-    if (!response.ok) {
-      logger.warn("Token refresh failed, acquiring new token", {
-        status: response.status,
-      });
-      await acquireToken();
-      return;
-    }
-
-    const data = (await response.json()) as TokenResponse;
-    accessToken = data.access_token;
-
-    logger.info("JWT token refreshed", {
-      podName: config.podName,
-      expiresIn: `${data.expires_in}s`,
-    });
-
-    scheduleRefresh(data.expires_in);
-  } catch (error) {
-    logger.error("Error refreshing token, attempting re-acquisition", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    await acquireToken();
-  }
+  await acquireToken();
 }
 
 function scheduleRefresh(expiresInSeconds: number): void {

--- a/packages/cloud/services/gateway-webhook/src/auth.ts
+++ b/packages/cloud/services/gateway-webhook/src/auth.ts
@@ -3,6 +3,7 @@ import { logger } from "./logger";
 
 const HTTP_TIMEOUT_MS = 10_000;
 const TOKEN_REFRESH_PERCENTAGE = 0.8;
+const TOKEN_REFRESH_RETRY_MS = 1_000;
 
 interface TokenResponse {
   access_token: string;
@@ -83,13 +84,31 @@ function scheduleRefresh(expiresInSeconds: number): void {
   if (refreshTimeout) clearTimeout(refreshTimeout);
 
   const refreshInMs = expiresInSeconds * 1000 * TOKEN_REFRESH_PERCENTAGE;
-  refreshTimeout = setTimeout(() => {
+  const timeout = setTimeout(() => {
+    // error-policy:J1 The timer boundary converts renewal failure into a paced retry.
     refreshToken().catch((error) => {
       logger.error("Token refresh failed", {
         error: error instanceof Error ? error.message : String(error),
       });
+      if (refreshTimeout === timeout) scheduleRefreshRetry();
     });
   }, refreshInMs);
+  refreshTimeout = timeout;
+}
+
+function scheduleRefreshRetry(): void {
+  if (refreshTimeout) clearTimeout(refreshTimeout);
+
+  const timeout = setTimeout(() => {
+    // error-policy:J1 The timer boundary retains the paced retry until recovery.
+    refreshToken().catch((error) => {
+      logger.error("Token refresh retry failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      if (refreshTimeout === timeout) scheduleRefreshRetry();
+    });
+  }, TOKEN_REFRESH_RETRY_MS);
+  refreshTimeout = timeout;
 }
 
 export async function initAuth(authConfig: AuthConfig): Promise<void> {

--- a/packages/cloud/shared/src/lib/auth/jwt-internal.test.ts
+++ b/packages/cloud/shared/src/lib/auth/jwt-internal.test.ts
@@ -31,6 +31,7 @@ const KEYS = makeKeys();
 
 const denylistStore = new Map<string, string>();
 let denylistGetError: Error | null = null;
+let denylistGetCount = 0;
 let workerRuntime = false;
 let lastRedisEnv: Record<string, string | undefined> | undefined;
 
@@ -47,6 +48,7 @@ mock.module("../cache/redis-factory", () => ({
     if (!hasConfiguredRedis(env)) return null;
     return {
       async get(key: string) {
+        denylistGetCount += 1;
         if (denylistGetError) throw denylistGetError;
         return denylistStore.get(key) ?? null;
       },
@@ -66,7 +68,10 @@ mock.module("../cache/redis-factory", () => ({
 
 mock.module("../utils/logger", () => ({
   logger: {
+    debug: mock(() => undefined),
+    error: mock(() => undefined),
     info: mock(() => undefined),
+    warn: mock(() => undefined),
   },
 }));
 
@@ -81,6 +86,7 @@ describe("internal JWT jti revocation denylist (#12879)", () => {
     process.env.MOCK_REDIS = "1";
     denylistStore.clear();
     denylistGetError = null;
+    denylistGetCount = 0;
     workerRuntime = false;
     lastRedisEnv = undefined;
     denylistMod.__resetDenylistClientForTests();
@@ -177,6 +183,61 @@ describe("internal JWT jti revocation denylist (#12879)", () => {
       });
 
       await expect(mod.verifyInternalToken(access_token)).rejects.toThrow(/redis unavailable/i);
+    });
+
+    test("verifies one-minute gateway request tokens without a remote denylist read", async () => {
+      denylistGetError = new Error("remote denylist must stay off this path");
+      const { access_token, expires_in } = await mod.signInternalToken({
+        subject: "gateway-webhook-1",
+        service: "webhook-gateway",
+        expiresIn: mod.internalTokenLifetimeForService("webhook-gateway"),
+      });
+
+      const result = await mod.verifyInternalRequestToken(access_token);
+
+      expect(result.payload.service).toBe("webhook-gateway");
+      expect(expires_in).toBe(mod.GATEWAY_TOKEN_LIFETIME_SECONDS);
+      expect(result.payload.exp - result.payload.iat).toBe(mod.GATEWAY_TOKEN_LIFETIME_SECONDS);
+      expect(denylistGetCount).toBe(0);
+    });
+
+    test("keeps long-lived gateway tokens on the fail-closed denylist", async () => {
+      denylistGetError = new Error("long-lived gateway denylist unavailable");
+      const { access_token } = await mod.signInternalToken({
+        subject: "gateway-webhook-legacy",
+        service: "webhook-gateway",
+        expiresIn: mod.GATEWAY_TOKEN_LIFETIME_SECONDS + 1,
+      });
+
+      await expect(mod.verifyInternalRequestToken(access_token)).rejects.toThrow(
+        /long-lived gateway denylist unavailable/i,
+      );
+      expect(denylistGetCount).toBe(1);
+    });
+
+    test("keeps short-lived non-gateway tokens on the fail-closed denylist", async () => {
+      denylistGetError = new Error("non-gateway denylist unavailable");
+      const { access_token } = await mod.signInternalToken({
+        subject: "internal-job",
+        service: "scheduler",
+        expiresIn: mod.GATEWAY_TOKEN_LIFETIME_SECONDS,
+      });
+
+      await expect(mod.verifyInternalRequestToken(access_token)).rejects.toThrow(
+        /non-gateway denylist unavailable/i,
+      );
+      expect(denylistGetCount).toBe(1);
+    });
+
+    test("preserves ordinary token lifetime selection", () => {
+      expect(mod.internalTokenLifetimeForService("discord-gateway")).toBe(
+        mod.GATEWAY_TOKEN_LIFETIME_SECONDS,
+      );
+      expect(mod.internalTokenLifetimeForService("webhook-gateway")).toBe(
+        mod.GATEWAY_TOKEN_LIFETIME_SECONDS,
+      );
+      expect(mod.internalTokenLifetimeForService("scheduler")).toBe(mod.TOKEN_LIFETIME_SECONDS);
+      expect(mod.internalTokenLifetimeForService(undefined)).toBe(mod.TOKEN_LIFETIME_SECONDS);
     });
   });
 

--- a/packages/cloud/shared/src/lib/auth/jwt-internal.ts
+++ b/packages/cloud/shared/src/lib/auth/jwt-internal.ts
@@ -31,6 +31,10 @@ export const GATEWAY_TOKEN_LIFETIME_SECONDS = 60;
 
 const SHORT_LIVED_GATEWAY_SERVICES = new Set(["webhook-gateway", "discord-gateway"]);
 
+export function isShortLivedGatewayService(service: string | undefined): boolean {
+  return service !== undefined && SHORT_LIVED_GATEWAY_SERVICES.has(service);
+}
+
 /**
  * Issuer claim for internal JWTs.
  */
@@ -90,7 +94,7 @@ export interface SignTokenOptions {
 }
 
 export function internalTokenLifetimeForService(service: string | undefined): number {
-  return service && SHORT_LIVED_GATEWAY_SERVICES.has(service)
+  return isShortLivedGatewayService(service)
     ? GATEWAY_TOKEN_LIFETIME_SECONDS
     : TOKEN_LIFETIME_SECONDS;
 }

--- a/packages/cloud/shared/src/lib/auth/jwt-internal.ts
+++ b/packages/cloud/shared/src/lib/auth/jwt-internal.ts
@@ -23,6 +23,15 @@ export {
 export const TOKEN_LIFETIME_SECONDS = 3600;
 
 /**
+ * Gateway tokens cross the public network on every connector delivery. Their
+ * one-minute lifetime bounds replay tightly enough for local signature
+ * verification while ordinary internal tokens retain per-jti revocation.
+ */
+export const GATEWAY_TOKEN_LIFETIME_SECONDS = 60;
+
+const SHORT_LIVED_GATEWAY_SERVICES = new Set(["webhook-gateway", "discord-gateway"]);
+
+/**
  * Issuer claim for internal JWTs.
  */
 const ISSUER = "eliza-cloud";
@@ -80,6 +89,12 @@ export interface SignTokenOptions {
   expiresIn?: number;
 }
 
+export function internalTokenLifetimeForService(service: string | undefined): number {
+  return service && SHORT_LIVED_GATEWAY_SERVICES.has(service)
+    ? GATEWAY_TOKEN_LIFETIME_SECONDS
+    : TOKEN_LIFETIME_SECONDS;
+}
+
 /**
  * Sign a new JWT for an internal service.
  *
@@ -128,7 +143,7 @@ export async function signInternalToken(options: SignTokenOptions): Promise<{
  * @throws Error if token is invalid, expired, has wrong issuer/audience, is
  *   missing a required claim, has a revoked `jti`, or the denylist check fails.
  */
-export async function verifyInternalToken(token: string): Promise<VerificationResult> {
+async function verifyInternalTokenClaims(token: string): Promise<VerificationResult> {
   const publicKey = await getPublicKey();
 
   const { payload } = await jwtVerify(token, publicKey, {
@@ -145,16 +160,51 @@ export async function verifyInternalToken(token: string): Promise<VerificationRe
     throw new Error("Token missing JWT ID claim");
   }
 
-  // Revocation denylist check — fail closed. A thrown store error propagates so
-  // the token is rejected rather than accepted on an unreachable denylist.
-  if (await isJtiRevoked(payload.jti)) {
-    throw new Error("Token has been revoked");
-  }
-
   return {
     valid: true,
     payload: payload as InternalJWTPayload,
   };
+}
+
+async function requireTokenNotRevoked(payload: InternalJWTPayload): Promise<void> {
+  if (await isJtiRevoked(payload.jti)) {
+    throw new Error("Token has been revoked");
+  }
+}
+
+function isBoundedGatewayToken(payload: InternalJWTPayload): boolean {
+  if (!payload.service || !SHORT_LIVED_GATEWAY_SERVICES.has(payload.service)) {
+    return false;
+  }
+  if (
+    typeof payload.iat !== "number" ||
+    !Number.isInteger(payload.iat) ||
+    typeof payload.exp !== "number" ||
+    !Number.isInteger(payload.exp)
+  ) {
+    return false;
+  }
+  const lifetimeSeconds = payload.exp - payload.iat;
+  return lifetimeSeconds > 0 && lifetimeSeconds <= GATEWAY_TOKEN_LIFETIME_SECONDS;
+}
+
+export async function verifyInternalToken(token: string): Promise<VerificationResult> {
+  const result = await verifyInternalTokenClaims(token);
+  await requireTokenNotRevoked(result.payload);
+  return result;
+}
+
+/**
+ * Verifies tokens presented on internal request routes. Only signed gateway
+ * credentials whose complete lifetime is one minute or less avoid the remote
+ * revocation read; every other token keeps the fail-closed denylist contract.
+ */
+export async function verifyInternalRequestToken(token: string): Promise<VerificationResult> {
+  const result = await verifyInternalTokenClaims(token);
+  if (!isBoundedGatewayToken(result.payload)) {
+    await requireTokenNotRevoked(result.payload);
+  }
+  return result;
 }
 
 /**


### PR DESCRIPTION
Fixes #20290.

## What changed

- issues `webhook-gateway` and `discord-gateway` JWTs with an exact 60-second lifetime
- verifies only those signed, bounded gateway request tokens locally on internal request routes
- retains fail-closed Redis JTI checks for ordinary tokens, non-gateway tokens, and gateway tokens over 60 seconds
- rejects gateway refresh chains and preserves the 60-second bound
- retries transient scheduled bootstrap failures at a paced one-second interval, with timer ownership guards across success and shutdown

## Security and reliability boundary

Per-JTI revocation for these two allowlisted gateway services is expiry-bounded to at most 60 seconds; signing-key rotation remains immediate. A transient bootstrap failure previously stopped renewal permanently, silently stranding ordinary Discord traffic after token expiry. The corrected head retries without allowing an obsolete timer to overwrite a newer token or reschedule after shutdown.

## Exact-head validation

- focused JWT/API/Discord/webhook suites: 28 tests, 62 assertions
- cloud shared, Cloud API, Discord gateway, and webhook gateway typechecks: pass
- production Worker dry bundle: pass (dry run only)
- exact ten-file Biome and `git diff --check`: pass
- no deploy, token rotation, environment approval, or provider send performed

The PR remains draft. Hosted CI plus a protected staging before/after latency canary and forced transient-bootstrap recovery receipt are still required.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@a83393b0907262107c8fb5137c65584e27473e0f
Attribution status: self-reported
— [codex / gateway-auth-fast-path]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@a83393b0907262107c8fb5137c65584e27473e0f"} -->

<!-- evidence-head:6da67b5ec0e03636d5cafa02358b1399da076325 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend authentication path; no UI change

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend authentication path; no UI change

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI/device interaction change

<!-- evidence-row:backend-logs -->
- [ ] Pending protected staging before/after and forced-recovery logs

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model behavior change

<!-- evidence-row:domain-artifacts -->
- [ ] Pending protected staging latency/token-renewal receipt

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered UI



<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@a83393b0907262107c8fb5137c65584e27473e0f:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

