### PR TITLE
fix(cloud): scope Steward approval pagination

### DIFF
--- a/packages/cloud/api/__tests__/wallet-proxy-steward-agent-id.test.ts
+++ b/packages/cloud/api/__tests__/wallet-proxy-steward-agent-id.test.ts
@@ -54,7 +54,19 @@ type StewardClientMock = {
     typeof mock<(agentId: string, policies: unknown[]) => Promise<void>>
   >;
   getAgentDashboard: ReturnType<
-    typeof mock<(agentId: string) => Promise<{ recentTransactions: unknown[] }>>
+    typeof mock<
+      (
+        agentId: string,
+      ) => Promise<{ pendingApprovals: number; recentTransactions: unknown[] }>
+    >
+  >;
+  listPendingApprovals: ReturnType<
+    typeof mock<
+      (
+        agentId: string,
+        opts?: { limit?: number; offset?: number },
+      ) => Promise<unknown[]>
+    >
   >;
   listApprovals: ReturnType<
     typeof mock<(opts?: unknown) => Promise<Array<{ agentId?: string }>>>
@@ -83,7 +95,11 @@ const stewardClient: StewardClientMock = {
   })),
   getPolicies: mock(async () => []),
   setPolicies: mock(async () => undefined),
-  getAgentDashboard: mock(async () => ({ recentTransactions: [] })),
+  getAgentDashboard: mock(async () => ({
+    pendingApprovals: 0,
+    recentTransactions: [],
+  })),
+  listPendingApprovals: mock(async () => []),
   listApprovals: mock(async () => []),
   approveTransaction: mock(async () => ({})),
   denyTransaction: mock(async () => ({})),
@@ -145,14 +161,19 @@ afterEach(() => {
   }
 });
 
-function mockContext(body?: unknown) {
+function mockContext(
+  body?: unknown,
+  options: { query?: string; authorization?: string } = {},
+) {
   return {
     req: {
-      url: "http://test.local/api/wallet/addresses",
-      header: (name: string) =>
-        name.toLowerCase() === "content-type" && body
-          ? "application/json"
-          : undefined,
+      url: `http://test.local/api/wallet/addresses${options.query ?? ""}`,
+      header: (name: string) => {
+        const normalized = name.toLowerCase();
+        if (normalized === "content-type" && body) return "application/json";
+        if (normalized === "authorization") return options.authorization;
+        return undefined;
+      },
       text: async () => (body ? JSON.stringify(body) : ""),
     },
   } as never;
@@ -162,6 +183,7 @@ async function callWallet(
   path: string,
   method: "GET" | "POST" | "PUT" = "GET",
   body?: unknown,
+  options: { query?: string; authorization?: string } = {},
 ) {
   requireUserOrApiKeyWithOrg.mockResolvedValue({
     id: "user-1",
@@ -170,7 +192,7 @@ async function callWallet(
   getAgent.mockResolvedValue({ id: "sandbox-agent-1" });
   createStewardClient.mockResolvedValue(stewardClient);
   return routeModule.handleDirectWalletRequest(
-    mockContext(body),
+    mockContext(body, options),
     Promise.resolve({ agentId: "sandbox-agent-1", path: [path] }),
     method,
   );
@@ -267,5 +289,68 @@ describe("wallet proxy steward agent id resolution", () => {
     expect(response.status).toBe(404);
     expect(body).toEqual({ success: false, error: "Agent not found" });
     expect(createStewardClient).not.toHaveBeenCalled();
+  });
+
+  test("pages pending approvals at the scoped Steward boundary and uses its authoritative total", async () => {
+    dbRows.push({ stewardAgentId: "cloud-client-address" });
+    const approvals = [
+      {
+        queueId: "approval-2",
+        status: "pending",
+        transaction: { id: "tx-2" },
+      },
+      {
+        queueId: "approval-3",
+        status: "pending",
+        transaction: { id: "tx-3" },
+      },
+    ];
+    stewardClient.listPendingApprovals.mockResolvedValue(approvals);
+    stewardClient.getAgentDashboard.mockResolvedValue({
+      pendingApprovals: 7,
+      recentTransactions: [],
+    });
+
+    const response = await callWallet(
+      "steward-pending-approvals",
+      "GET",
+      undefined,
+      {
+        query: "?limit=2&offset=1",
+        authorization: "Bearer header.payload.signature",
+      },
+    );
+
+    expect(response.status).toBe(200);
+    const responseBody = await response.json();
+    expect(responseBody).toEqual({
+      approvals,
+      total: 7,
+      offset: 1,
+      limit: 2,
+    });
+    expect(createStewardClient).toHaveBeenCalledWith({
+      organizationId: "org-1",
+      bearerToken: "header.payload.signature",
+    });
+    expect(stewardClient.listPendingApprovals).toHaveBeenCalledWith(
+      "cloud-client-address",
+      { limit: 2, offset: 1 },
+    );
+    expect(stewardClient.getAgentDashboard).toHaveBeenCalledWith(
+      "cloud-client-address",
+    );
+    expect(stewardClient.listApprovals).not.toHaveBeenCalled();
+  });
+
+  test("does not fabricate a Steward session bearer for API-key requests", async () => {
+    dbRows.push({ stewardAgentId: "cloud-client-address" });
+
+    const response = await callWallet("steward-pending-approvals");
+
+    expect(response.status).toBe(200);
+    expect(createStewardClient).toHaveBeenCalledWith({
+      organizationId: "org-1",
+    });
   });
 });

--- a/packages/cloud/api/__tests__/wallet-proxy-steward-agent-id.test.ts
+++ b/packages/cloud/api/__tests__/wallet-proxy-steward-agent-id.test.ts
@@ -1,4 +1,4 @@
-// Exercises cloud API tests wallet proxy steward agent id.test behavior with deterministic Worker route fixtures.
+/** Exercises Steward wallet routing with deterministic Cloud auth, mapping, and upstream fixtures. */
 import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
 // Spread the real module into the partial mock below — `mock.module` is
 // process-global, so dropping the other real exports breaks every later
@@ -351,6 +351,22 @@ describe("wallet proxy steward agent id resolution", () => {
     expect(response.status).toBe(200);
     expect(createStewardClient).toHaveBeenCalledWith({
       organizationId: "org-1",
+    });
+  });
+
+  test("fails closed when Steward returns an invalid pending approval total", async () => {
+    dbRows.push({ stewardAgentId: "cloud-client-address" });
+    stewardClient.getAgentDashboard.mockResolvedValue({
+      pendingApprovals: -1,
+      recentTransactions: [],
+    });
+
+    await expect(
+      callWallet("steward-pending-approvals", "GET", undefined, {
+        authorization: "Bearer header.payload.signature",
+      }),
+    ).rejects.toMatchObject({
+      code: "INVALID_STEWARD_PENDING_APPROVAL_TOTAL",
     });
   });
 });

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.ts
@@ -1,4 +1,5 @@
-// Handles v1 cloud API v1 eliza agents agentid api wallet ...path route traffic with route-local auth expectations.
+/** Proxies an authenticated Cloud agent's supported wallet operations to its mapped Steward wallet. */
+import { ElizaError } from "@elizaos/core";
 import { and, eq } from "drizzle-orm";
 import { type Context, Hono } from "hono";
 import { dbWrite } from "@/db/helpers";
@@ -235,6 +236,16 @@ function isPolicyType(value: unknown): value is PolicyType {
 
 function isJsonObject(value: unknown): value is JsonObject {
   return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function assertPendingApprovalTotal(value: unknown): asserts value is number {
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new ElizaError("Steward returned an invalid pending approval total", {
+      code: "INVALID_STEWARD_PENDING_APPROVAL_TOTAL",
+      context: { value },
+      severity: "fatal",
+    });
+  }
 }
 
 function assertStewardWalletClient(
@@ -498,6 +509,7 @@ export async function handleDirectWalletRequest(
       client.listPendingApprovals(stewardAgentId, { limit, offset }),
       client.getAgentDashboard(stewardAgentId),
     ]);
+    assertPendingApprovalTotal(dashboard.pendingApprovals);
     return json({
       approvals,
       total: dashboard.pendingApprovals,

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.ts
@@ -5,7 +5,10 @@ import { dbWrite } from "@/db/helpers";
 import { agentServerWallets } from "@/db/schemas/agent-server-wallets";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { nextStyleParams } from "@/lib/api/hono-next-style-params";
-import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
+import {
+  readSessionCredential,
+  requireUserOrApiKeyWithOrg,
+} from "@/lib/auth/workers-hono-auth";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import { createStewardClient } from "@/lib/services/steward-client";
@@ -59,6 +62,7 @@ type StewardWalletClient = {
   getPolicies(agentId: string): Promise<StewardPolicyRule[]>;
   setPolicies(agentId: string, policies: StewardPolicyRule[]): Promise<void>;
   getAgentDashboard(agentId: string): Promise<{
+    pendingApprovals: number;
     recentTransactions: Array<{
       id: string;
       status: string;
@@ -67,11 +71,13 @@ type StewardWalletClient = {
       request?: JsonObject;
     }>;
   }>;
-  listApprovals(opts?: {
-    status?: string;
-    limit?: number;
-    offset?: number;
-  }): Promise<Array<{ agentId?: string } & JsonObject>>;
+  listPendingApprovals(
+    agentId: string,
+    opts?: {
+      limit?: number;
+      offset?: number;
+    },
+  ): Promise<unknown[]>;
   approveTransaction(
     txId: string,
     opts?: { comment?: string; approvedBy?: string },
@@ -245,7 +251,7 @@ function assertStewardWalletClient(
     "getPolicies",
     "setPolicies",
     "getAgentDashboard",
-    "listApprovals",
+    "listPendingApprovals",
     "approveTransaction",
     "denyTransaction",
   ] as const;
@@ -346,8 +352,10 @@ export async function handleDirectWalletRequest(
 
   let client: StewardClient;
   try {
+    const bearerToken = readSessionCredential(c);
     const stewardClient = await createStewardClient({
       organizationId: user.organization_id,
+      ...(bearerToken ? { bearerToken } : {}),
     });
     assertStewardWalletClient(stewardClient);
     client = stewardClient;
@@ -486,10 +494,16 @@ export async function handleDirectWalletRequest(
       0,
       Number.MAX_SAFE_INTEGER,
     );
-    const approvals = (
-      await client.listApprovals({ status: "pending", limit, offset })
-    ).filter((entry) => entry.agentId === stewardAgentId);
-    return json({ approvals, total: approvals.length, offset, limit });
+    const [approvals, dashboard] = await Promise.all([
+      client.listPendingApprovals(stewardAgentId, { limit, offset }),
+      client.getAgentDashboard(stewardAgentId),
+    ]);
+    return json({
+      approvals,
+      total: dashboard.pendingApprovals,
+      offset,
+      limit,
+    });
   }
 
   if (method === "POST" && walletPath === "steward-approve-tx") {

--- a/packages/cloud/shared/src/lib/services/steward-client.sdk-pending-approvals.test.ts
+++ b/packages/cloud/shared/src/lib/services/steward-client.sdk-pending-approvals.test.ts
@@ -68,4 +68,25 @@ describe("Steward SDK agent-scoped pending approvals", () => {
       client.listPendingApprovals("agent-1", { limit: 2, offset: 1 }),
     ).rejects.toBeInstanceOf(StewardApiError);
   });
+
+  test("fails closed when the scoped response contains a malformed approval", async () => {
+    globalThis.fetch = mock(async () =>
+      Response.json({
+        ok: true,
+        data: {
+          approvals: [{ queueId: "approval-1", status: "pending" }],
+          limit: 2,
+          offset: 0,
+        },
+      }),
+    ) as unknown as typeof fetch;
+    const client = new StewardClient({
+      baseUrl: "https://steward.example",
+      bearerToken: "verified-session",
+    });
+
+    await expect(
+      client.listPendingApprovals("agent-1", { limit: 2, offset: 0 }),
+    ).rejects.toBeInstanceOf(StewardApiError);
+  });
 });

--- a/packages/cloud/shared/src/lib/services/steward-client.sdk-pending-approvals.test.ts
+++ b/packages/cloud/shared/src/lib/services/steward-client.sdk-pending-approvals.test.ts
@@ -1,0 +1,71 @@
+/** Verifies the patched Steward SDK reaches the real agent-scoped approvals contract with session authority. */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { StewardApiError, StewardClient } from "@stwd/sdk";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("Steward SDK agent-scoped pending approvals", () => {
+  test("encodes the agent page and prefers the verified bearer over the tenant key", async () => {
+    const fetchMock = mock(async () =>
+      Response.json({
+        ok: true,
+        data: {
+          approvals: [
+            {
+              queueId: "approval-2",
+              status: "pending",
+              requestedAt: "2026-08-15T00:00:00.000Z",
+              transaction: { id: "tx-2" },
+            },
+          ],
+          limit: 2,
+          offset: 1,
+        },
+      }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const client = new StewardClient({
+      baseUrl: "https://steward.example",
+      apiKey: "tenant-key",
+      bearerToken: "verified-session",
+      tenantId: "tenant-1",
+    });
+
+    await expect(
+      client.listPendingApprovals("agent / one", { limit: 2, offset: 1 }),
+    ).resolves.toEqual([
+      {
+        queueId: "approval-2",
+        status: "pending",
+        requestedAt: "2026-08-15T00:00:00.000Z",
+        transaction: { id: "tx-2" },
+      },
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("https://steward.example/vault/agent%20%2F%20one/pending?limit=2&offset=1");
+    const headers = new Headers(init.headers);
+    expect(headers.get("Authorization")).toBe("Bearer verified-session");
+    expect(headers.get("X-Steward-Key")).toBeNull();
+    expect(headers.get("X-Steward-Tenant")).toBe("tenant-1");
+  });
+
+  test("fails closed when the scoped response omits the approvals page", async () => {
+    globalThis.fetch = mock(async () =>
+      Response.json({ ok: true, data: { limit: 2, offset: 1 } }),
+    ) as unknown as typeof fetch;
+    const client = new StewardClient({
+      baseUrl: "https://steward.example",
+      bearerToken: "verified-session",
+    });
+
+    await expect(
+      client.listPendingApprovals("agent-1", { limit: 2, offset: 1 }),
+    ).rejects.toBeInstanceOf(StewardApiError);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/steward-client.ts
+++ b/packages/cloud/shared/src/lib/services/steward-client.ts
@@ -34,7 +34,9 @@ let hasWarnedMissingStewardTenantApiKey = false;
 
 let _client: { key: string; value: StewardClient } | null = null;
 
-export interface StewardClientOptions extends ResolveStewardTenantCredentialsOptions {}
+export interface StewardClientOptions extends ResolveStewardTenantCredentialsOptions {
+  bearerToken?: string;
+}
 
 export type StewardPhoneOwnershipErrorCode =
   | "invalid_phone"
@@ -115,6 +117,7 @@ export async function createStewardClient(
   return new StewardClient({
     baseUrl: resolveStewardHostUrl(),
     apiKey: credentials.apiKey,
+    bearerToken: options.bearerToken,
     tenantId: credentials.tenantId,
   });
 }

--- a/patches/@stwd%2Fsdk@0.11.0.patch
+++ b/patches/@stwd%2Fsdk@0.11.0.patch
@@ -61,3 +61,45 @@
          }
          catch (err) {
              throw new StewardApiError(`WebAuthn authentication cancelled or failed: ${err instanceof Error ? err.message : String(err)}`, 0);
+--- a/dist/client.d.ts
++++ b/dist/client.d.ts
+@@ -1421,5 +1421,15 @@
+     revokeTenantRequestSigningKey(tenantId: string, keyId: string): Promise<TenantRequestSigningKey>;
+     /** Get the aggregated dashboard for an agent (balance, spend, policies, recent tx, pending approvals). */
+     getAgentDashboard(agentId: string): Promise<AgentDashboardResponse>;
++    /** List the agent-scoped pending approval page. */
++    listPendingApprovals(agentId: string, opts?: {
++        limit?: number;
++        offset?: number;
++    }): Promise<Array<{
++        queueId: string;
++        status: string;
++        requestedAt: Date;
++        transaction: TxRecord;
++    }>>;
+     /** Get on-chain and realtime spend accounting for an agent. */
+     getAgentSpend(agentId: string): Promise<AgentSpendSummary>;
+--- a/dist/client.js
++++ b/dist/client.js
+@@ -2032,6 +2032,21 @@
+             throw new StewardApiError(response.error, response.status, response.data);
+         return response.data;
+     }
++    /** List the agent-scoped pending approval page. */
++    async listPendingApprovals(agentId, opts = {}) {
++        const params = new URLSearchParams();
++        if (opts.limit !== undefined)
++            params.set("limit", String(opts.limit));
++        if (opts.offset !== undefined)
++            params.set("offset", String(opts.offset));
++        const qs = params.toString();
++        const response = await this.request(`/vault/${encodeURIComponent(agentId)}/pending${qs ? `?${qs}` : ""}`);
++        if (!response.ok)
++            throw new StewardApiError(response.error, response.status, response.data);
++        if (!response.data || !Array.isArray(response.data.approvals))
++            throw new StewardApiError("Steward pending approvals response is invalid", 502, response.data);
++        return response.data.approvals;
++    }
+     /** Get on-chain and realtime spend accounting for an agent. */
+     async getAgentSpend(agentId) {
+         const response = await this.request(`/agents/${encodeURIComponent(agentId)}/spend`);

--- a/patches/@stwd%2Fsdk@0.11.0.patch
+++ b/patches/@stwd%2Fsdk@0.11.0.patch
@@ -81,7 +81,7 @@
      getAgentSpend(agentId: string): Promise<AgentSpendSummary>;
 --- a/dist/client.js
 +++ b/dist/client.js
-@@ -2032,6 +2032,21 @@
+@@ -2032,6 +2032,26 @@
              throw new StewardApiError(response.error, response.status, response.data);
          return response.data;
      }
@@ -96,7 +96,12 @@
 +        const response = await this.request(`/vault/${encodeURIComponent(agentId)}/pending${qs ? `?${qs}` : ""}`);
 +        if (!response.ok)
 +            throw new StewardApiError(response.error, response.status, response.data);
-+        if (!response.data || !Array.isArray(response.data.approvals))
++        if (!response.data || !Array.isArray(response.data.approvals) ||
++            !response.data.approvals.every((approval) => approval && typeof approval === "object" &&
++                typeof approval.queueId === "string" && approval.status === "pending" &&
++                typeof approval.requestedAt === "string" && approval.transaction &&
++                typeof approval.transaction === "object" && !Array.isArray(approval.transaction) &&
++                typeof approval.transaction.id === "string"))
 +            throw new StewardApiError("Steward pending approvals response is invalid", 502, response.data);
 +        return response.data.approvals;
 +    }


### PR DESCRIPTION
# Relates to

Closes #19099.

# Summary

- Replaces tenant-global approval pagination plus post-filtering with Steward's existing agent-scoped `GET /vault/:agentId/pending` contract.
- Reports the authoritative same-agent dashboard `pendingApprovals` count instead of the current page length.
- Forwards only an already-selected session credential to the SDK; API-key requests do not receive a fabricated bearer.
- Extends the pinned `@stwd/sdk@0.11.0` patch with the missing additive `listPendingApprovals` client method and fails closed on malformed page responses.

# Root cause

The Cloud route called tenant-global `listApprovals({ status, limit, offset })`, then filtered the already-sliced page by agent. Other agents could push the requested agent's rows off-page, `offset` operated in the wrong population, and `total` was merely the filtered page length. Steward already implements an owner/admin-authorized agent-scoped page and a dashboard count with the same agent/status predicates; the pinned SDK simply omitted the page method.

# Verification

- Exact head: `e38647af28599c7fd6ec0ba44b96ad56e1f19bb6`
- Rebased base: `38247dbf2316748e538bbe18ed373cc48fd94d95`
- Pinned toolchain: Node 24.15.0 / Bun 1.3.14
- Frozen install: pass; repository patch applied to the published SDK.
- Focused route + SDK contract: 10/10, 34 assertions.
- Cloud Shared typecheck: pass.
- Cloud API typecheck plus production Worker dry-run: pass.
- Changed-file Biome: 4 files clean.
- Exact-head root `bun run verify`: 351/351 uncached tasks plus every audit.
- Anti-larp: 8,271 test files, 0 focused, 0 orphaned skips.
- `git diff --check`: pass.

<details>
<summary>Mutation proof</summary>

```text
Mutation: total = approvals.length
Result: route regression failed, expected authoritative 7 and received page length 2.

Mutation: SDK request /vault/:agentId/pending -> /approvals
Result: SDK regression failed, expected the encoded agent-scoped URL and received the global URL.

Both mutations were discarded. The restored exact tree passed 10/10.
```

</details>

# Risk

Low and read-only. Approval mutation endpoints are untouched. Upstream authorization errors and malformed page responses remain visible failures; the patch does not synthesize an empty page or zero total.

# Evidence gate

<!-- evidence-head:5aaf987edded6e9dbeb8b9c1de5ed76cea2f4620 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend JSON pagination path; no rendered surface changed
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend JSON pagination path; no rendered surface changed
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible UI journey changed
<!-- evidence-row:backend-logs -->
- [x] [20301-pr20301-focused-rebased.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20301-pr20301-focused-rebased.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend or browser network surface changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action-planner, or agent-behavior path is involved
<!-- evidence-row:domain-artifacts -->
- [x] [20301-pr20301-steward-contract-exact-head.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20301-pr20301-steward-contract-exact-head.txt)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no pixels or visual text changed

# Known gaps / failures

- No credentialed live Steward owner/admin request was made because no Steward production/staging credential or external-call authorization was available. The production upstream contract was independently read from Steward's authoritative implementation, while the patched published SDK and Cloud handler were exercised with deterministic protocol-shaped responses.
- An extra command attempted after the authoritative Cloud API typecheck used a nonexistent `build:worker` script. This is not a product failure: the package's real `typecheck` command had already passed and includes the successful production Wrangler dry-run shown above.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex/19099-steward-pagination]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->

