### PR TITLE
fix(cloud): eliminate residual login navigation churn

### DIFF
--- a/packages/app/test/ui-smoke/managed-login-stability.spec.ts
+++ b/packages/app/test/ui-smoke/managed-login-stability.spec.ts
@@ -8,6 +8,7 @@
 import { writeFile } from "node:fs/promises";
 import { expect, type Page, test } from "@playwright/test";
 import { installDefaultAppRoutes } from "./helpers";
+import { seedStewardSession } from "./helpers/test-auth";
 
 const PROVIDERS = {
   passkey: false,
@@ -27,6 +28,7 @@ const TEST_AUTH_ENABLED =
   process.env.VITE_PLAYWRIGHT_TEST_AUTH === "true" ||
   process.env.NEXT_PUBLIC_PLAYWRIGHT_TEST_AUTH === "true";
 const PERSONAL_ID = "personal:11111111-1111-5111-8111-111111111111";
+const ONBOARDING_TOKEN = "aaaaaaaa-test-test-test-tokentoken01";
 const SURFACES = [
   { name: "desktop", viewport: { width: 1440, height: 900 } },
   { name: "mobile", viewport: { width: 390, height: 844 } },
@@ -59,6 +61,58 @@ async function installManagedOriginProxy(
   return managed.origin;
 }
 
+async function installAuthenticatedPersonalRoutes(
+  page: Page,
+  managedOrigin: string,
+  personalGate?: Promise<void>,
+): Promise<() => number> {
+  await installDefaultAppRoutes(page);
+  await page.context().addCookies([
+    {
+      name: "eliza-test-auth",
+      value: "1",
+      domain: "cloud.eliza.app",
+      path: "/",
+      sameSite: "Lax",
+    },
+  ]);
+  await seedStewardSession(page, {
+    jwt: true,
+    userId: "22222222-2222-4222-8222-222222222222",
+    email: "managed-handoff@test.local",
+  });
+
+  let personalRequests = 0;
+  await page.route("**/api/v1/eliza/agents", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ success: true, data: [] }),
+    });
+  });
+  await page.route("**/api/v1/eliza/personal", async (route) => {
+    personalRequests += 1;
+    if (personalGate) await personalGate;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        data: {
+          identity: {
+            id: PERSONAL_ID,
+            displayName: "Eliza",
+            runtime: "shared",
+            activeAgentId: "22222222-2222-4222-8222-222222222222",
+            apiBase: managedOrigin,
+          },
+        },
+      }),
+    });
+  });
+  return () => personalRequests;
+}
+
 for (const surface of SURFACES) {
   test(`authenticated login handoff mounts chat in the same document (${surface.name})`, async ({
     page,
@@ -71,23 +125,19 @@ for (const surface of SURFACES) {
     if (!baseURL) throw new Error("Playwright baseURL is required");
     await page.setViewportSize(surface.viewport);
     const managedOrigin = await installManagedOriginProxy(page, baseURL);
-    await installDefaultAppRoutes(page);
     const documentRequests: string[] = [];
     const pageErrors: string[] = [];
     const requestFailures: string[] = [];
     const consoleMessages: Array<{ type: string; text: string }> = [];
-    let personalRequests = 0;
     let releasePersonal: (() => void) | undefined;
     const personalGate = new Promise<void>((resolve) => {
       releasePersonal = resolve;
     });
-    const jwtPart = (value: unknown) =>
-      Buffer.from(JSON.stringify(value)).toString("base64url");
-    const stewardToken = `${jwtPart({ alg: "none", typ: "JWT" })}.${jwtPart({
-      userId: "22222222-2222-4222-8222-222222222222",
-      email: "managed-handoff@test.local",
-      exp: Math.floor(Date.now() / 1000) + 3_600,
-    })}.sig`;
+    const personalRequests = await installAuthenticatedPersonalRoutes(
+      page,
+      managedOrigin,
+      personalGate,
+    );
 
     page.on("request", (request) => {
       if (
@@ -106,46 +156,6 @@ for (const surface of SURFACES) {
     page.on("console", (message) => {
       consoleMessages.push({ type: message.type(), text: message.text() });
     });
-    await page.context().addCookies([
-      {
-        name: "eliza-test-auth",
-        value: "1",
-        domain: "cloud.eliza.app",
-        path: "/",
-        sameSite: "Lax",
-      },
-    ]);
-    await page.addInitScript((token) => {
-      localStorage.setItem("steward_session_token", token);
-    }, stewardToken);
-    await page.route("**/api/v1/eliza/agents", async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ success: true, data: [] }),
-      });
-    });
-    await page.route("**/api/v1/eliza/personal", async (route) => {
-      personalRequests += 1;
-      await personalGate;
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          success: true,
-          data: {
-            identity: {
-              id: PERSONAL_ID,
-              displayName: "Eliza",
-              runtime: "shared",
-              activeAgentId: "22222222-2222-4222-8222-222222222222",
-              apiBase: managedOrigin,
-            },
-          },
-        }),
-      });
-    });
-
     await page.goto(`${managedOrigin}/join`);
     await expect(page.getByText(/Opening your personal Eliza/)).toBeVisible();
     await page.evaluate(() => {
@@ -153,7 +163,7 @@ for (const surface of SURFACES) {
     });
     releasePersonal?.();
 
-    await expect.poll(() => personalRequests).toBeGreaterThanOrEqual(1);
+    await expect.poll(personalRequests).toBe(1);
     await expect(page.locator("html")).toHaveAttribute(
       "data-login-document",
       "survived",
@@ -165,6 +175,7 @@ for (const surface of SURFACES) {
     await page.waitForTimeout(1_000);
 
     expect(documentRequests).toHaveLength(1);
+    expect(personalRequests()).toBe(1);
     expect(new URL(documentRequests[0]).pathname).toBe("/join");
     expect(pageErrors).toEqual([]);
     expect(requestFailures).toEqual([]);
@@ -184,7 +195,7 @@ for (const surface of SURFACES) {
             entryPath: "/join",
             finalUrl: page.url(),
             documentRequests,
-            personalRequests,
+            personalRequests: personalRequests(),
             pageErrors,
             requestFailures,
             consoleMessages,
@@ -289,4 +300,203 @@ for (const surface of SURFACES) {
       }
     });
   }
+}
+
+for (const surface of SURFACES) {
+  test(`email callback reaches chat without replacing the document (${surface.name})`, async ({
+    page,
+    baseURL,
+  }, testInfo) => {
+    test.skip(
+      !TEST_AUTH_ENABLED,
+      "requires VITE_PLAYWRIGHT_TEST_AUTH=true in the renderer build",
+    );
+    if (!baseURL) throw new Error("Playwright baseURL is required");
+    await page.setViewportSize(surface.viewport);
+    const managedOrigin = await installManagedOriginProxy(page, baseURL);
+    const personalRequests = await installAuthenticatedPersonalRoutes(
+      page,
+      managedOrigin,
+    );
+    const documentRequests: string[] = [];
+    const failures: string[] = [];
+    page.on("request", (request) => {
+      if (
+        request.isNavigationRequest() &&
+        request.frame() === page.mainFrame()
+      ) {
+        documentRequests.push(request.url());
+      }
+    });
+    page.on("pageerror", (error) => failures.push(error.message));
+    page.on("requestfailed", (request) => {
+      failures.push(
+        `${request.method()} ${request.url()} ${request.failure()?.errorText ?? "unknown"}`,
+      );
+    });
+
+    await page.goto(`${managedOrigin}/auth/callback/email`);
+    await page.evaluate(() => {
+      document.documentElement.dataset.emailCallbackDocument = "survived";
+    });
+    await expect(
+      page.getByRole("heading", { name: "Signed in" }),
+    ).toBeVisible();
+    await expect(page).toHaveURL(`${managedOrigin}/`, { timeout: 15_000 });
+    await expect(page.getByTestId("home-screen")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    expect(documentRequests).toHaveLength(1);
+    expect(new URL(documentRequests[0]).pathname).toBe("/auth/callback/email");
+    expect(personalRequests()).toBe(1);
+    await expect(page.locator("html")).toHaveAttribute(
+      "data-email-callback-document",
+      "survived",
+    );
+    expect(failures).toEqual([]);
+
+    if (process.env.E2E_RECORD === "1") {
+      await page.screenshot({
+        path: testInfo.outputPath(
+          `${surface.name}-email-callback-same-document.png`,
+        ),
+        fullPage: true,
+      });
+      await writeFile(
+        testInfo.outputPath(`${surface.name}-email-callback-observations.json`),
+        `${JSON.stringify(
+          {
+            head: process.env.GITHUB_SHA ?? "local-exact-head",
+            entryPath: "/auth/callback/email",
+            finalUrl: page.url(),
+            documentRequests,
+            personalRequests: personalRequests(),
+            failures,
+            documentMarker: await page
+              .locator("html")
+              .getAttribute("data-email-callback-document"),
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    }
+  });
+}
+
+for (const surface of SURFACES) {
+  test(`messaging continuation opens chat without replacing the document (${surface.name})`, async ({
+    page,
+    baseURL,
+  }, testInfo) => {
+    test.skip(
+      !TEST_AUTH_ENABLED,
+      "requires VITE_PLAYWRIGHT_TEST_AUTH=true in the renderer build",
+    );
+    if (!baseURL) throw new Error("Playwright baseURL is required");
+    await page.setViewportSize(surface.viewport);
+    const managedOrigin = await installManagedOriginProxy(page, baseURL);
+    const personalRequests = await installAuthenticatedPersonalRoutes(
+      page,
+      managedOrigin,
+    );
+    await page.route("**/api/eliza-app/onboarding/chat**", async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            data: {
+              platform: "discord",
+              platformUserId: "1234567890",
+              platformDisplayName: "managed-login-test",
+              returnUrl: null,
+            },
+          }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, data: { linked: true } }),
+      });
+    });
+    const documentRequests: string[] = [];
+    const failures: string[] = [];
+    page.on("request", (request) => {
+      if (
+        request.isNavigationRequest() &&
+        request.frame() === page.mainFrame()
+      ) {
+        documentRequests.push(request.url());
+      }
+    });
+    page.on("pageerror", (error) => failures.push(error.message));
+    page.on("requestfailed", (request) => {
+      failures.push(
+        `${request.method()} ${request.url()} ${request.failure()?.errorText ?? "unknown"}`,
+      );
+    });
+
+    await page.goto(
+      `${managedOrigin}/get-started?onboardingSession=${ONBOARDING_TOKEN}`,
+    );
+    await page.evaluate(() => {
+      document.documentElement.dataset.messagingContinuationDocument =
+        "survived";
+    });
+    await expect(page.getByText("managed-login-test")).toBeVisible();
+    await page
+      .getByRole("button", { name: "Connect this Discord account" })
+      .click();
+    await expect(
+      page.getByRole("heading", { name: "You're connected" }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Or chat here instead" }).click();
+    await expect(page).toHaveURL(`${managedOrigin}/`, { timeout: 15_000 });
+    await expect(page.getByTestId("home-screen")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    expect(documentRequests).toHaveLength(1);
+    expect(new URL(documentRequests[0]).pathname).toBe("/get-started");
+    expect(personalRequests()).toBe(1);
+    await expect(page.locator("html")).toHaveAttribute(
+      "data-messaging-continuation-document",
+      "survived",
+    );
+    expect(failures).toEqual([]);
+
+    if (process.env.E2E_RECORD === "1") {
+      await page.screenshot({
+        path: testInfo.outputPath(
+          `${surface.name}-messaging-continuation-same-document.png`,
+        ),
+        fullPage: true,
+      });
+      await writeFile(
+        testInfo.outputPath(
+          `${surface.name}-messaging-continuation-observations.json`,
+        ),
+        `${JSON.stringify(
+          {
+            head: process.env.GITHUB_SHA ?? "local-exact-head",
+            entryPath: "/get-started",
+            finalUrl: page.url(),
+            documentRequests,
+            personalRequests: personalRequests(),
+            failures,
+            documentMarker: await page
+              .locator("html")
+              .getAttribute("data-messaging-continuation-document"),
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    }
+  });
 }

--- a/packages/ui/src/cloud/app-mode/AppModeEntryRoute.test.tsx
+++ b/packages/ui/src/cloud/app-mode/AppModeEntryRoute.test.tsx
@@ -12,6 +12,7 @@ import {
 } from "../../state/persistence";
 import { AppModeEntryRoute } from "./AppModeEntryRoute";
 import { type AppModeAgent, appModeNavigation } from "./app-mode";
+import { publishPersonalEntryHandoff } from "./use-personal-entry";
 
 function base64url(value: unknown): string {
   return btoa(JSON.stringify(value))
@@ -34,8 +35,10 @@ function stewardToken(): string {
   ].join(".");
 }
 
-function signIn(): void {
-  localStorage.setItem(STEWARD_TOKEN_KEY, stewardToken());
+function signIn(): string {
+  const token = stewardToken();
+  localStorage.setItem(STEWARD_TOKEN_KEY, token);
+  return token;
 }
 
 function bindCloudAgent(id = "agent-1"): void {
@@ -340,6 +343,48 @@ describe("AppModeEntryRoute — rowless personal entry", () => {
       apiBase: `https://api.eliza.app/api/v1/eliza/agents/${encodeURIComponent(id)}`,
     });
   }
+
+  it("consumes the session-bound /join result without resolving the same personal identity twice", async () => {
+    const authToken = signIn();
+    bindPersonal();
+    publishPersonalEntryHandoff(authToken, {
+      personalElizaId: PERSONAL_ID,
+      agentId: PERSONAL_ID,
+      activeAgentId: "00000000-0000-4000-8000-000000000002",
+      agentName: "Eliza",
+      apiBase: "https://api.eliza.app",
+      runtime: "shared",
+    });
+    stubNetwork({ agents: agentsOk([]), personal: personalOk() });
+    renderEntry();
+
+    expect(await screen.findByTestId("agent-app")).toBeTruthy();
+    expect(
+      fetchLog.filter((line) => line.includes("/api/v1/eliza/personal")),
+    ).toEqual([]);
+    expect(assignedUrls).toEqual([]);
+  });
+
+  it("discards a /join handoff from a different Steward session", async () => {
+    signIn();
+    bindPersonal();
+    publishPersonalEntryHandoff("different-session-token", {
+      personalElizaId: PERSONAL_ID,
+      agentId: PERSONAL_ID,
+      activeAgentId: "00000000-0000-4000-8000-000000000002",
+      agentName: "Eliza",
+      apiBase: "https://api.eliza.app",
+      runtime: "shared",
+    });
+    stubNetwork({ agents: agentsOk([]), personal: personalOk() });
+    renderEntry();
+
+    expect(await screen.findByTestId("agent-app")).toBeTruthy();
+    expect(
+      fetchLog.filter((line) => line.includes("/api/v1/eliza/personal")),
+    ).toHaveLength(1);
+    expect(assignedUrls).toEqual([]);
+  });
 
   it("clean account with a matching personal binding → chat, no /join bounce, no reload (the #19360 loop)", async () => {
     signIn();

--- a/packages/ui/src/cloud/app-mode/use-personal-entry.ts
+++ b/packages/ui/src/cloud/app-mode/use-personal-entry.ts
@@ -25,6 +25,31 @@ import {
 } from "../join/lib/resolve-cloud-connection";
 import { type JoinFlowResult, runJoinFlow } from "../join/lib/run-join-flow";
 
+interface PersonalEntryHandoff {
+  authToken: string;
+  result: JoinFlowResult;
+}
+
+let pendingPersonalEntryHandoff: PersonalEntryHandoff | null = null;
+
+/**
+ * Carry the already-authoritative `/join` result across the public-to-full
+ * renderer swap. The Steward token binds the one-shot receipt to the session
+ * that resolved it, so a later account can never consume stale identity state.
+ */
+export function publishPersonalEntryHandoff(
+  authToken: string,
+  result: JoinFlowResult,
+): void {
+  pendingPersonalEntryHandoff = { authToken, result };
+}
+
+function takePersonalEntryHandoff(authToken: string): JoinFlowResult | null {
+  const pending = pendingPersonalEntryHandoff;
+  pendingPersonalEntryHandoff = null;
+  return pending?.authToken === authToken ? pending.result : null;
+}
+
 /** The persisted-active-server id a resolved personal Eliza binds under. */
 export function personalEntryBindingId(result: JoinFlowResult): string {
   return `cloud:${result.agentId}`;
@@ -47,6 +72,8 @@ export function usePersonalEntry(
           "PersonalEntry: no Steward session token for an authenticated entry.",
         );
       }
+      const handedOff = takePersonalEntryHandoff(authToken);
+      if (handedOff) return handedOff;
       return runJoinFlow({
         client,
         effects: { savePersistedActiveServer, savePersistedFirstRunComplete },

--- a/packages/ui/src/cloud/join/GetStartedPage.test.tsx
+++ b/packages/ui/src/cloud/join/GetStartedPage.test.tsx
@@ -15,8 +15,14 @@ import {
   completePendingOnboardingContinuation,
   peekPendingOnboardingSession,
   previewPendingOnboardingContinuation,
+  storePendingOnboardingSession,
   TELEGRAM_ACCOUNT_CLAIM_PURPOSE,
 } from "./lib/onboarding-continuation";
+
+const pageState = vi.hoisted(() => ({
+  session: { ready: true, authenticated: true },
+  persistenceBlocked: false,
+}));
 
 const TOKEN = "aaaaaaaa-test-test-test-tokentoken01";
 const syncStewardSessionCookie = vi.fn(async () => {
@@ -35,7 +41,7 @@ vi.mock("../public-pages/lib/steward-session", () => ({
 }));
 
 vi.mock("./lib/use-join-session", () => ({
-  useJoinSessionAuth: () => ({ ready: true, authenticated: true }),
+  useJoinSessionAuth: () => pageState.session,
 }));
 
 vi.mock("../shell/CloudI18nProvider", () => ({
@@ -48,6 +54,12 @@ vi.mock("./lib/onboarding-continuation", async (importOriginal) => {
     await importOriginal<typeof import("./lib/onboarding-continuation")>();
   return {
     ...actual,
+    storePendingOnboardingSession: vi.fn(
+      (token: string, purpose?: "link" | "telegram-account-claim") =>
+        pageState.persistenceBlocked
+          ? false
+          : actual.storePendingOnboardingSession(token, purpose),
+    ),
     previewPendingOnboardingContinuation: vi.fn(async () => ({
       platform: "discord" as const,
       platformUserId: "1234567890",
@@ -63,6 +75,9 @@ vi.mock("./lib/onboarding-continuation", async (importOriginal) => {
 const { default: GetStartedPage } = await import("./GetStartedPage");
 
 beforeEach(() => {
+  pageState.session = { ready: true, authenticated: true };
+  pageState.persistenceBlocked = false;
+  vi.mocked(storePendingOnboardingSession).mockClear();
   syncStewardSessionCookie.mockClear();
   vi.mocked(previewPendingOnboardingContinuation).mockReset();
   vi.mocked(previewPendingOnboardingContinuation).mockResolvedValue({
@@ -85,12 +100,14 @@ afterEach(() => {
   window.sessionStorage.clear();
   window.localStorage.clear();
   window.history.replaceState(null, "", "/");
+  delete document.documentElement.dataset.getStartedDocument;
 });
 
 describe("GetStartedPage", () => {
   it("does not restore a URL continuation after a successful redemption rerender", async () => {
     const entry = `/get-started?onboardingSession=${TOKEN}`;
     window.history.replaceState(null, "", entry);
+    document.documentElement.dataset.getStartedDocument = "survived";
 
     render(
       <MemoryRouter initialEntries={[entry]}>
@@ -113,6 +130,44 @@ describe("GetStartedPage", () => {
       expect(window.localStorage.length).toBe(0);
     });
     expect(window.location.search).not.toContain("onboardingSession");
+    fireEvent.click(
+      screen.getByRole("button", { name: "Or chat here instead" }),
+    );
+    expect(await screen.findByText("join")).toBeTruthy();
+    expect(document.documentElement.dataset.getStartedDocument).toBe(
+      "survived",
+    );
+  });
+
+  it("retries blocked Telegram-token persistence without reloading the document", async () => {
+    pageState.session = { ready: true, authenticated: false };
+    pageState.persistenceBlocked = true;
+    const entry = `/get-started?onboardingSession=${TOKEN}&accountClaim=telegram`;
+    window.history.replaceState(null, "", entry);
+    document.documentElement.dataset.getStartedDocument = "survived";
+
+    render(
+      <MemoryRouter initialEntries={[entry]}>
+        <Routes>
+          <Route path="/get-started" element={<GetStartedPage />} />
+          <Route path="/login" element={<div>login without reload</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByText(
+        "Allow browser storage, then try again. Your Telegram account was not changed.",
+      ),
+    ).toBeTruthy();
+    pageState.persistenceBlocked = false;
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(await screen.findByText("login without reload")).toBeTruthy();
+    expect(document.documentElement.dataset.getStartedDocument).toBe(
+      "survived",
+    );
+    expect(storePendingOnboardingSession).toHaveBeenCalledTimes(2);
   });
 
   it("retries a failed preview without silently confirming the identity link", async () => {

--- a/packages/ui/src/cloud/join/GetStartedPage.tsx
+++ b/packages/ui/src/cloud/join/GetStartedPage.tsx
@@ -18,7 +18,7 @@
 import { BRAND_PATHS, LOGO_FILES } from "@elizaos/shared/brand";
 import { readStoredStewardToken } from "@elizaos/shared/steward-session-client";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Navigate, useSearchParams } from "react-router-dom";
+import { Navigate, useNavigate, useSearchParams } from "react-router-dom";
 import { Button } from "../../components/ui/button";
 import { syncStewardSessionCookie } from "../public-pages/lib/steward-session";
 import { useCloudT } from "../shell/CloudI18nProvider";
@@ -57,12 +57,17 @@ function describeContinuationError(err: unknown): string {
 
 export default function GetStartedPage(): React.JSX.Element {
   const t = useCloudT();
+  const navigate = useNavigate();
   const session = useJoinSessionAuth();
   const [searchParams] = useSearchParams();
   const [phase, setPhase] = useState<GetStartedPhase>("checking");
   const [error, setError] = useState<string | null>(null);
   const [platformIdentity, setPlatformIdentity] =
     useState<MessagingContinuationPreview | null>(null);
+  const [
+    telegramClaimPersistenceRecovered,
+    setTelegramClaimPersistenceRecovered,
+  ] = useState(false);
   // StrictMode double-mount guard: the redemption POST must run once.
   const startedRef = useRef(false);
 
@@ -100,8 +105,26 @@ export default function GetStartedPage(): React.JSX.Element {
     session.ready &&
       !session.authenticated &&
       urlContinuation?.purpose === TELEGRAM_ACCOUNT_CLAIM_PURPOSE &&
-      !urlContinuation.persisted,
+      !urlContinuation.persisted &&
+      !telegramClaimPersistenceRecovered,
   );
+
+  const retryTelegramClaimPersistence = useCallback(() => {
+    if (
+      !urlContinuation ||
+      urlContinuation.purpose !== TELEGRAM_ACCOUNT_CLAIM_PURPOSE
+    ) {
+      return;
+    }
+    if (
+      storePendingOnboardingSession(
+        urlContinuation.token,
+        TELEGRAM_ACCOUNT_CLAIM_PURPOSE,
+      )
+    ) {
+      setTelegramClaimPersistenceRecovered(true);
+    }
+  }, [urlContinuation]);
 
   const claimTelegramAccount = useCallback(async (continuation: string) => {
     setPhase("linking");
@@ -259,7 +282,7 @@ export default function GetStartedPage(): React.JSX.Element {
             {platformIdentity?.returnUrl ? (
               <Button
                 asChild
-                className="bg-txt px-6 py-2.5 font-semibold text-bg transition-colors hover:bg-txt/90"
+                className="bg-txt px-6 py-2.5 font-semibold text-bg transition-colors hover:bg-txt/90 hover:!text-bg"
               >
                 <a href={platformIdentity.returnUrl}>
                   Back to {messagingPlatformLabel(platformIdentity.platform)}
@@ -269,8 +292,8 @@ export default function GetStartedPage(): React.JSX.Element {
             <Button
               variant="ghost"
               type="button"
-              onClick={() => window.location.assign("/join")}
-              className="bg-txt px-6 py-2.5 font-semibold text-bg transition-colors hover:bg-txt/90"
+              onClick={() => navigate("/join")}
+              className="bg-txt px-6 py-2.5 font-semibold text-bg transition-colors hover:bg-txt/90 hover:!text-bg"
             >
               {t("cloud.getStarted.openChat", {
                 defaultValue: "Or chat here instead",
@@ -290,7 +313,7 @@ export default function GetStartedPage(): React.JSX.Element {
               type="button"
               onClick={() => {
                 if (telegramClaimPersistenceBlocked) {
-                  window.location.reload();
+                  retryTelegramClaimPersistence();
                   return;
                 }
                 if (telegramClaimToken) {
@@ -302,7 +325,7 @@ export default function GetStartedPage(): React.JSX.Element {
                 if (platformIdentity) void redeem(token);
                 else void preview(token);
               }}
-              className="bg-txt px-6 py-2.5 font-semibold text-bg transition-colors hover:bg-txt/90"
+              className="bg-txt px-6 py-2.5 font-semibold text-bg transition-colors hover:bg-txt/90 hover:!text-bg"
             >
               {t("cloud.getStarted.retry", { defaultValue: "Try again" })}
             </Button>

--- a/packages/ui/src/cloud/join/JoinPage.tsx
+++ b/packages/ui/src/cloud/join/JoinPage.tsx
@@ -23,6 +23,7 @@ import {
   savePersistedFirstRunComplete,
 } from "../../state/persistence";
 import { appModeNavigation } from "../app-mode/app-mode";
+import { publishPersonalEntryHandoff } from "../app-mode/use-personal-entry";
 import { useCloudT } from "../shell/CloudI18nProvider";
 import {
   clearSsoLoggedOut,
@@ -92,11 +93,11 @@ export default function JoinPage(): React.JSX.Element {
           },
         });
         controller.signal.throwIfAborted();
+        publishPersonalEntryHandoff(authToken, result);
         setPhase("ready");
         // The flow has configured the in-memory client and persisted the exact
-        // binding, so chat can mount without replacing the browser document.
-        // `void result` keeps the resolved identity available for telemetry.
-        void result;
+        // binding. Its session-bound handoff receipt lets app-mode consume the
+        // same authoritative result without a duplicate identity request.
       } catch (err) {
         if (controller.signal.aborted) return;
         setError(describeJoinError(err));

--- a/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.test.tsx
@@ -11,8 +11,8 @@
 import { StewardApiError } from "@stwd/sdk";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { ReactNode } from "react";
-import { MemoryRouter } from "react-router-dom";
+import type { ComponentProps, ReactNode } from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const callbackState = vi.hoisted(() => ({
@@ -78,8 +78,10 @@ vi.mock("../../../../cloud-ui/components/auth/authorize-return", () => ({
   clearStoredAppAuthorizeReturnTo: () => {},
 }));
 vi.mock("../../../../cloud-ui/components/brand/brand-button", () => ({
-  BrandButton: ({ children }: { children: ReactNode }) => (
-    <button type="button">{children}</button>
+  BrandButton: ({ children, ...props }: ComponentProps<"button">) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
   ),
 }));
 
@@ -95,6 +97,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  delete document.documentElement.dataset.emailCallbackDocument;
 });
 
 describe("EmailCallbackPage", () => {
@@ -212,6 +215,39 @@ describe("EmailCallbackPage", () => {
         "/get-started",
       ),
     ).toBe("/app-auth/authorize?id=1");
+  });
+
+  it("continues to a same-origin return path without replacing the document", async () => {
+    const user = userEvent.setup();
+    callbackState.pendingReturnTo = "/get-started";
+    callbackState.verifyEmailCallback.mockResolvedValue({
+      token: "verified-token",
+    });
+    document.documentElement.dataset.emailCallbackDocument = "survived";
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          "/auth/callback/email?token=navigation-token&email=navigation%40b.co",
+        ]}
+      >
+        <Routes>
+          <Route path="/auth/callback/email" element={<EmailCallbackPage />} />
+          <Route path="/get-started" element={<div>continued in place</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Continue to app authorization",
+      }),
+    );
+
+    expect(await screen.findByText("continued in place")).toBeTruthy();
+    expect(document.documentElement.dataset.emailCallbackDocument).toBe(
+      "survived",
+    );
   });
 
   it("rejects an incomplete callback and offers a safe keyboard-reachable recovery action", async () => {

--- a/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/email-callback-page.tsx
@@ -7,7 +7,7 @@
 import { AlertTriangle, CheckCircle2, Loader2 } from "lucide-react";
 import type { ReactNode } from "react";
 import { useContext, useEffect, useMemo, useRef, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import {
   clearStoredAppAuthorizeReturnTo,
   readStoredAppAuthorizeReturnTo,
@@ -106,6 +106,7 @@ export default function EmailCallbackPage() {
 
 function EmailCallbackContent() {
   const t = useCloudT();
+  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const auth = useContext(LocalStewardAuthContext);
   const attemptedRef = useRef(false);
@@ -136,7 +137,6 @@ function EmailCallbackContent() {
       return;
     }
 
-    let redirectTimer: ReturnType<typeof setTimeout> | null = null;
     const finishSuccess = () => {
       const destination = resolveEmailCallbackDestination(
         returnTo,
@@ -145,16 +145,11 @@ function EmailCallbackContent() {
       successDestinationRef.current = destination;
       clearStoredAppAuthorizeReturnTo();
       setStatus("success");
-      redirectTimer = setTimeout(() => {
-        window.location.replace(destination);
-      }, 1500);
     };
 
     if (auth.isAuthenticated) {
       finishSuccess();
-      return () => {
-        if (redirectTimer) clearTimeout(redirectTimer);
-      };
+      return;
     }
 
     const token = searchParams.get("token");
@@ -190,11 +185,16 @@ function EmailCallbackContent() {
         setError(describeVerificationError(err, t));
       }
     })();
-
-    return () => {
-      if (redirectTimer) clearTimeout(redirectTimer);
-    };
   }, [auth, returnTo, searchParams, t]);
+
+  useEffect(() => {
+    if (status !== "success") return;
+    const destination = successDestinationRef.current ?? defaultLoginReturnTo();
+    const redirectTimer = setTimeout(() => {
+      navigate(destination, { replace: true });
+    }, 1500);
+    return () => clearTimeout(redirectTimer);
+  }, [navigate, status]);
 
   if (status === "error") {
     return (
@@ -234,9 +234,9 @@ function EmailCallbackContent() {
         <BrandButton
           className="mt-2"
           onClick={() =>
-            window.location.assign(
-              successDestinationRef.current ?? defaultLoginReturnTo(),
-            )
+            navigate(successDestinationRef.current ?? defaultLoginReturnTo(), {
+              replace: true,
+            })
           }
         >
           {t("cloud.emailCallback.continue", {

--- a/packages/ui/src/cloud/shell/StewardProvider.tsx
+++ b/packages/ui/src/cloud/shell/StewardProvider.tsx
@@ -15,7 +15,13 @@ import { lazy, type ReactNode, Suspense, useEffect, useRef } from "react";
 import { useLocation } from "react-router-dom";
 import { reportRendererDiagnostic } from "../../utils/renderer-diagnostics";
 import { CloudRouteErrorBoundary } from "./CloudRouteErrorBoundary";
-import { isPlaceholderValue, readStoredToken } from "./StewardProviderShared";
+import {
+  clearStaleStewardSession,
+  isPlaceholderValue,
+  LocalStewardAuthContext,
+  type LocalStewardAuthValue,
+  readStoredToken,
+} from "./StewardProviderShared";
 import {
   configuredStewardTenantId,
   DEFAULT_STEWARD_TENANT_ID,
@@ -120,6 +126,36 @@ function StewardRuntimeLoading() {
   );
 }
 
+/** Deterministic auth context for renderer-only browser tests. */
+function PlaywrightStewardAuthProvider({
+  children,
+}: {
+  children: ReactNode;
+}): React.JSX.Element {
+  const token = readStoredToken();
+  const value: LocalStewardAuthValue = {
+    isAuthenticated: Boolean(token),
+    isLoading: false,
+    user: token ? { id: "playwright-test-user" } : null,
+    session: null,
+    signOut: clearStaleStewardSession,
+    getToken: () => token,
+    verifyEmailCallback: async () => {
+      if (!token) {
+        throw new Error(
+          "Playwright test auth requires a pre-seeded Steward token.",
+        );
+      }
+      return { token };
+    },
+  };
+  return (
+    <LocalStewardAuthContext.Provider value={value}>
+      {children}
+    </LocalStewardAuthContext.Provider>
+  );
+}
+
 function StewardConfigError() {
   return (
     <main
@@ -193,7 +229,9 @@ export function StewardAuthProvider({ children }: { children: ReactNode }) {
   }, [hasValidUrl, playwrightTestAuthEnabled]);
 
   if (playwrightTestAuthEnabled) {
-    return <>{children}</>;
+    return (
+      <PlaywrightStewardAuthProvider>{children}</PlaywrightStewardAuthProvider>
+    );
   }
 
   const needsStewardRuntime = shouldLoadStewardRuntime(location.pathname);


### PR DESCRIPTION
# Relates to

Closes #20286. This follows the single-document managed-login fix with the adjacent same-origin callback and continuation paths that still caused reloads, duplicate identity work, or avoidable loading transitions.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@548b11dcfe8f72fc325d9d532543e84e266bfaaa:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# What changed

- `/join` publishes its already-authoritative personal identity as a one-shot, exact-Steward-session-bound handoff. App-mode consumes it instead of issuing the same `/api/v1/eliza/personal` request again.
- Email callback success and its Continue action use React Router replacement navigation. Completion timing is owned by a separate status effect, so an auth-context rerender cannot cancel the redirect timer.
- Messaging continuation opens chat with SPA navigation.
- Telegram storage recovery retries token persistence in place and navigates only after persistence succeeds; it no longer reloads the document.
- The compile-time Playwright auth shell now provides the same local Steward context shape as the real provider, allowing the browser lane to exercise callback behavior. Production SDK/runtime behavior is unchanged.
- Touched dark-surface actions retain an explicit readable foreground at rest, hover, and touch-hover.

Cross-origin OAuth/SSO handoffs and service-worker activation navigation are intentionally unchanged.

# Risks

Medium, limited to browser navigation and auth-entry state ownership.

- The handoff is process-local, one-shot, and cleared on every consume attempt. The exact Steward token must match, so another session cannot consume stale identity state.
- If no matching handoff exists, app-mode follows the existing authoritative personal-identity request path.
- Same-origin callback destinations were already sanitized to single-slash paths; React Router now owns those paths without changing their validation.
- Rollback is a single-commit revert.

# Testing

- `bun install --frozen-lockfile`: 3,823 installs checked across 4,121 packages, no changes.
- Focused Vitest: 12 files, 92/92 tests.
- UI typecheck: pass.
- UI full lint: pass with eight existing warning-only cookie-test diagnostics.
- Changed app-test Biome and `git diff --check`: pass.
- Exact Chromium with recording: 10/10 across desktop/mobile authenticated `/join`, signed-out `/`, signed-out `/login?intent=launch`, email callback, and messaging continuation.
- Browser contract: all ten cases use one main-frame document; all six authenticated personal-entry cases use one personal-identity request; zero page, request, flow, or console errors.
- `bun run --cwd packages/app audit:app` on patch-equivalent `9d24785a12c3`: 219/219, broken=0, needs-work=0, hover/minimalism/density failures=0. The final rebase leaves `packages/ui` byte-identical and changes only three unrelated app test specs, not rendered app source.
- Packaged OCR: 216 views, verified=200, broken=0, needs-eyeball=16.
- Exact uncached `TURBO_FORCE=1 bun run verify`: 351/351, zero cache hits; all repository audits and anti-larp checks pass.

# Evidence Gate

<!-- evidence-head:548b11dcfe8f72fc325d9d532543e84e266bfaaa -->

<!-- evidence-row:before-screenshots -->
- [x] ![before](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20160-before-desktop.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20303-desktop-authenticated-same-document.png)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20303-desktop-login-stability-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - no server/backend route changes; browser API boundaries use deterministic fixtures
<!-- evidence-row:frontend-logs -->
- [x] [frontend observations](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20303-.tmp-frontend-observations-548b11d.log)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changes
<!-- evidence-row:domain-artifacts -->
- [x] [navigation contract](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20303-navigation-contract.json)
<!-- evidence-row:ocr-review -->
- [x] [OCR triage](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20303-ocr-triage.json)

# Evidence notes

The before screenshot is the original parent reproduction used by #20160/#20283. The exact candidate evidence records the residual adjacent paths added here. No evidence artifact includes cookies, auth tokens, credentials, or response bodies.

Additional exact-head visual evidence:

- [desktop stable login](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20303-desktop-stable-login.png) and [mobile stable login](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20303-mobile-stable-login.png)
- [mobile authenticated handoff](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20303-mobile-authenticated-same-document.png)
- [desktop email callback](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20303-desktop-email-callback-same-document.png) and [mobile email callback](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20303-mobile-email-callback-same-document.png)
- [desktop messaging continuation](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20303-desktop-messaging-continuation-same-document.png) and [mobile messaging continuation](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20303-mobile-messaging-continuation-same-document.png)
- [mobile walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20303-mobile-login-stability-walkthrough.mp4) and [app-audit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20303-app-audit-report.json)

The final patch is range-diff equivalent to the audited pre-rebase commit. `packages/ui` is byte-identical; the only `packages/app` changes between the audit head and final head are unrelated test specs. Current `origin/develop@4af7a52143ed` changes three payment/i18n files outside this PR's nine paths, and a synthetic merge is conflict-free.

Live production is not claimed as fixed until the protected main promotion and deploy complete. This PR supplies exact local browser proof; a clean-browser authenticated production acceptance pass remains a release requirement.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@548b11dcfe8f72fc325d9d532543e84e266bfaaa:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@548b11dcfe8f72fc325d9d532543e84e266bfaaa:packages/skills/skills/contribute-to-eliza"} -->
