### PR TITLE
fix(app): scope iOS chat overlay chrome

### DIFF
--- a/packages/app/src/main.ios-interactive-entrypoint.test.ts
+++ b/packages/app/src/main.ios-interactive-entrypoint.test.ts
@@ -147,7 +147,7 @@ describe("renderer interactive iOS composition", () => {
     );
     expect(iosBoot.setAccessoryBarVisible).toHaveBeenCalledOnce();
     expect(iosBoot.setAccessoryBarVisible).toHaveBeenCalledWith({
-      isVisible: false,
+      isVisible: true,
     });
 
     expect(main.isIOS).toBe(true);

--- a/packages/app/src/main.ios-interactive-entrypoint.test.ts
+++ b/packages/app/src/main.ios-interactive-entrypoint.test.ts
@@ -17,6 +17,7 @@ const iosBoot = vi.hoisted(() => ({
   createRoot: vi.fn(),
   runEmbedHandshake: vi.fn(async () => undefined),
   registerServiceWorker: vi.fn(),
+  setAccessoryBarVisible: vi.fn(async () => undefined),
   keyboardListeners: new Map<string, (value?: unknown) => void>(),
   lifecycleDependencies: undefined as
     | { handleDeepLink: (url: string) => void }
@@ -60,7 +61,7 @@ vi.mock("@capacitor/keyboard", () => ({
   Keyboard: {
     setResizeMode: vi.fn(async () => undefined),
     setScroll: vi.fn(async () => undefined),
-    setAccessoryBarVisible: vi.fn(async () => undefined),
+    setAccessoryBarVisible: iosBoot.setAccessoryBarVisible,
     addListener: vi.fn((name: string, listener: (value?: unknown) => void) => {
       iosBoot.keyboardListeners.set(name, listener);
       return Promise.resolve({ remove: vi.fn(async () => undefined) });
@@ -144,6 +145,10 @@ describe("renderer interactive iOS composition", () => {
     await vi.waitFor(() =>
       expect(iosBoot.initializeAppLifecycle).toHaveBeenCalledOnce(),
     );
+    expect(iosBoot.setAccessoryBarVisible).toHaveBeenCalledOnce();
+    expect(iosBoot.setAccessoryBarVisible).toHaveBeenCalledWith({
+      isVisible: false,
+    });
 
     expect(main.isIOS).toBe(true);
     expect(main.isNative).toBe(true);

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -1889,7 +1889,10 @@ async function initializeKeyboard(): Promise<void> {
     if (isIOS) {
       await Keyboard.setResizeMode({ mode: KeyboardResize.None });
       await Keyboard.setScroll({ isDisabled: true });
-      await Keyboard.setAccessoryBarVisible({ isVisible: true });
+      // The chat sheet already owns keyboard dismissal through its drag/tap
+      // interactions. Keep WebKit's previous/next/Done accessory out of the
+      // app chrome instead of rendering a second floating toolbar below it.
+      await Keyboard.setAccessoryBarVisible({ isVisible: false });
     }
 
     keyboardListenersRegistered = true;

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -1889,10 +1889,9 @@ async function initializeKeyboard(): Promise<void> {
     if (isIOS) {
       await Keyboard.setResizeMode({ mode: KeyboardResize.None });
       await Keyboard.setScroll({ isDisabled: true });
-      // The chat sheet already owns keyboard dismissal through its drag/tap
-      // interactions. Keep WebKit's previous/next/Done accessory out of the
-      // app chrome instead of rendering a second floating toolbar below it.
-      await Keyboard.setAccessoryBarVisible({ isVisible: false });
+      // Preserve WebKit's navigation/dismissal accessory for every ordinary
+      // form. The chat composer suppresses it only while that field owns focus.
+      await Keyboard.setAccessoryBarVisible({ isVisible: true });
     }
 
     keyboardListenersRegistered = true;

--- a/packages/app/src/mobile-lifecycle.ts
+++ b/packages/app/src/mobile-lifecycle.ts
@@ -100,9 +100,9 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
       if (ctx.isIOS) {
         await Keyboard.setResizeMode({ mode: KeyboardResize.None });
         await Keyboard.setScroll({ isDisabled: true });
-        // The chat sheet owns keyboard dismissal. Hiding WebKit's accessory
-        // prevents a second previous/next/Done toolbar below the composer.
-        await Keyboard.setAccessoryBarVisible({ isVisible: false });
+        // Preserve WebKit's navigation/dismissal accessory for every ordinary
+        // form. The chat composer suppresses it only while that field owns focus.
+        await Keyboard.setAccessoryBarVisible({ isVisible: true });
       }
 
       keyboardListenersRegistered = true;

--- a/packages/app/src/mobile-lifecycle.ts
+++ b/packages/app/src/mobile-lifecycle.ts
@@ -100,7 +100,9 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
       if (ctx.isIOS) {
         await Keyboard.setResizeMode({ mode: KeyboardResize.None });
         await Keyboard.setScroll({ isDisabled: true });
-        await Keyboard.setAccessoryBarVisible({ isVisible: true });
+        // The chat sheet owns keyboard dismissal. Hiding WebKit's accessory
+        // prevents a second previous/next/Done toolbar below the composer.
+        await Keyboard.setAccessoryBarVisible({ isVisible: false });
       }
 
       keyboardListenersRegistered = true;

--- a/packages/app/test/mobile-lifecycle.test.ts
+++ b/packages/app/test/mobile-lifecycle.test.ts
@@ -7,7 +7,7 @@
  * jsdom test can drive deterministically:
  *
  *   - `initializeKeyboard()` — iOS WebView resize/scroll configuration keeps
- *     the native previous/next/Done accessory out of app-owned chat chrome.
+ *     the native previous/next/Done accessory available outside chat.
  *   - `initializeDeepLinks()` + `initializeAppLifecycle()` — early
  *     `appUrlOpen`/cold-launch capture plus `appStateChange` / `backButton`
  *     wiring. Asserts the events the module dispatches
@@ -199,7 +199,7 @@ afterEach(() => {
 });
 
 describe("createMobileLifecycle — keyboard", () => {
-  it("hides the iOS WebView accessory bar below the app-owned composer", async () => {
+  it("preserves the iOS WebView accessory bar for ordinary form fields", async () => {
     const lifecycle = createMobileLifecycle(
       makeContext({ isIOS: true, isAndroid: false }),
     );
@@ -208,7 +208,7 @@ describe("createMobileLifecycle — keyboard", () => {
 
     expect(keyboardMock.setAccessoryBarVisible).toHaveBeenCalledOnce();
     expect(keyboardMock.setAccessoryBarVisible).toHaveBeenCalledWith({
-      isVisible: false,
+      isVisible: true,
     });
   });
 });

--- a/packages/app/test/mobile-lifecycle.test.ts
+++ b/packages/app/test/mobile-lifecycle.test.ts
@@ -3,9 +3,11 @@
 
 /**
  * Coverage for `src/mobile-lifecycle.ts` — the idempotent Capacitor lifecycle
- * wiring (`createMobileLifecycle`). Exercises the two device-free seams a
+ * wiring (`createMobileLifecycle`). Exercises the three device-free seams a
  * jsdom test can drive deterministically:
  *
+ *   - `initializeKeyboard()` — iOS WebView resize/scroll configuration keeps
+ *     the native previous/next/Done accessory out of app-owned chat chrome.
  *   - `initializeDeepLinks()` + `initializeAppLifecycle()` — early
  *     `appUrlOpen`/cold-launch capture plus `appStateChange` / `backButton`
  *     wiring. Asserts the events the module dispatches
@@ -92,17 +94,19 @@ const { appListeners, networkListeners, capacitorAppMock, networkMock } =
     };
   });
 
+const keyboardMock = vi.hoisted(() => ({
+  setResizeMode: vi.fn(async () => undefined),
+  setScroll: vi.fn(async () => undefined),
+  setAccessoryBarVisible: vi.fn(async () => undefined),
+  addListener: vi.fn(async () => ({ remove: async () => undefined })),
+}));
+
 vi.mock("@capacitor/app", () => ({ App: capacitorAppMock }));
 vi.mock("@capacitor/network", () => ({ Network: networkMock }));
 // `mobile-lifecycle.ts` imports these statically; only the app lifecycle and
 // network paths are exercised here, so the keyboard module just needs to load.
 vi.mock("@capacitor/keyboard", () => ({
-  Keyboard: {
-    setResizeMode: vi.fn(async () => undefined),
-    setScroll: vi.fn(async () => undefined),
-    setAccessoryBarVisible: vi.fn(async () => undefined),
-    addListener: vi.fn(async () => ({ remove: async () => undefined })),
-  },
+  Keyboard: keyboardMock,
   KeyboardResize: { None: "none" },
 }));
 
@@ -192,6 +196,21 @@ afterEach(() => {
   historyBackSpy.mockRestore();
   delete (window as { matchMedia?: unknown }).matchMedia;
   delete (navigator as { standalone?: unknown }).standalone;
+});
+
+describe("createMobileLifecycle — keyboard", () => {
+  it("hides the iOS WebView accessory bar below the app-owned composer", async () => {
+    const lifecycle = createMobileLifecycle(
+      makeContext({ isIOS: true, isAndroid: false }),
+    );
+
+    await lifecycle.initializeKeyboard();
+
+    expect(keyboardMock.setAccessoryBarVisible).toHaveBeenCalledOnce();
+    expect(keyboardMock.setAccessoryBarVisible).toHaveBeenCalledWith({
+      isVisible: false,
+    });
+  });
 });
 
 describe("createMobileLifecycle — app lifecycle", () => {

--- a/packages/ui/src/components/shell/ChatOverlay.ios-accessory.test.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.ios-accessory.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Verifies the real chat composer scopes Capacitor's WebView-global iOS
+ * accessory suppression to its own focus lifecycle, including the handoff to
+ * a non-chat field after chat. The native bridge is mocked; the rendered shell
+ * and focus/blur boundary are real jsdom behavior.
+ */
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+const accessoryMock = vi.hoisted(() => ({
+  setHidden: vi.fn(),
+}));
+
+vi.mock("./ios-chat-accessory-bar", () => ({
+  setChatComposerAccessoryBarHidden: accessoryMock.setHidden,
+}));
+
+vi.mock("../../api/client", () => ({
+  client: {
+    fetch: vi.fn().mockRejectedValue(new Error("no api in test")),
+    createTranscript: vi
+      .fn()
+      .mockResolvedValue({ transcript: { id: "t1", title: "Transcript" } }),
+    searchConversationMessages: vi.fn(),
+  },
+}));
+
+import { ChatOverlay } from "./ChatOverlay";
+import type { ShellController } from "./useShellController";
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function makeController(): ShellController {
+  return {
+    phase: "summoned",
+    messages: [
+      { id: "a", role: "assistant", content: "hi", createdAt: 1 },
+      { id: "b", role: "user", content: "hello", createdAt: 2 },
+    ],
+    canSend: true,
+    responding: false,
+    turnStatus: null,
+    recording: false,
+    transcript: "",
+    transcriptionMode: false,
+    modelStatus: { kind: "ready" },
+    send: vi.fn(),
+    stop: vi.fn(),
+    startRecording: vi.fn(),
+    stopRecording: vi.fn(),
+    toggleRecording: vi.fn(),
+    handsFree: false,
+    toggleHandsFree: vi.fn(),
+    toggleTranscriptionMode: vi.fn(),
+    stopTranscriptionAndMic: vi.fn(),
+    setDictationSink: vi.fn(),
+    setTranscriptSessionSink: vi.fn(),
+    setComposerHasDraft: vi.fn(),
+    clearConversation: vi.fn(),
+  } as unknown as ShellController;
+}
+
+describe("ChatOverlay iOS accessory bar", () => {
+  it("restores the global accessory before a non-chat field takes focus", async () => {
+    render(
+      <>
+        <ChatOverlay controller={makeController()} />
+        <input aria-label="Settings field" />
+      </>,
+    );
+
+    const composer = screen.getByLabelText("message");
+    const settingsField = screen.getByLabelText("Settings field");
+
+    act(() => composer.focus());
+    await waitFor(() =>
+      expect(accessoryMock.setHidden).toHaveBeenCalledWith(true),
+    );
+
+    act(() => settingsField.focus());
+    await waitFor(() =>
+      expect(accessoryMock.setHidden).toHaveBeenLastCalledWith(false),
+    );
+    expect(document.activeElement).toBe(settingsField);
+  });
+});

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -155,6 +155,7 @@ import {
   resolveChatPanelHalfDetentHeight,
   resolveChatPanelLayout,
 } from "./chat-panel-layout";
+import { setChatComposerAccessoryBarHidden } from "./ios-chat-accessory-bar";
 import { LIQUID_GLASS_SHEEN, liquidGlassEdgeShadow } from "./liquid-glass";
 import { withPressLatch } from "./press-latch";
 import { SlashCommandMenu, useSlashMenu } from "./SlashCommandMenu";
@@ -1545,6 +1546,14 @@ export function ChatOverlay({
   // empty composer settles it back to compact. Elsewhere focus is tracked via
   // refs (composerFocusedAtPressRef) that must not trigger a re-render.
   const [composerFocused, setComposerFocused] = React.useState(false);
+  React.useEffect(
+    () => () => {
+      // The setting is WebView-global. Always restore it when chat leaves the
+      // tree so a later settings/form field retains Previous/Next/Done.
+      setChatComposerAccessoryBarHidden(false);
+    },
+    [],
+  );
   // Whether the sheet was collapsed when the composer last gained focus — so
   // dismissing the keyboard (tap the handle, tap the scrim, tap outside) returns
   // to the prior resting state (collapsed → input) instead of leaving the sheet
@@ -6492,6 +6501,7 @@ export function ChatOverlay({
                     if (nextDraft.trim().length > 0) expandFromTyping();
                   }}
                   onFocus={() => {
+                    setChatComposerAccessoryBarHidden(true);
                     // Widen out of the short-landscape compact affordance (#14173)
                     // on focus, before the first keystroke.
                     setComposerFocused(true);
@@ -6504,6 +6514,7 @@ export function ChatOverlay({
                     }
                   }}
                   onBlur={() => {
+                    setChatComposerAccessoryBarHidden(false);
                     setComposerFocused(false);
                     // A suppress-expand flag armed for a focus that never landed
                     // (openFromPill arms it BEFORE focusing) must not survive to

--- a/packages/ui/src/components/shell/ChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ChatOverlay.tsx
@@ -5412,6 +5412,10 @@ export function ChatOverlay({
       !restoreDragging &&
       !fullBleed &&
       !firstRunOpen,
+    // The chat sheet is dark chrome even when the device appearance is light.
+    // Match its native UIGlassEffect to the DOM fallback so the material never
+    // becomes a bright slab over the conversation.
+    colorScheme: "dark",
   });
   const nativeInsetSheet = nativeSheetTier === "native";
   // Keep the CSS material identity stable through fullscreen and its restore.
@@ -5865,7 +5869,8 @@ export function ChatOverlay({
               vertical pull now) and no clear/new-chat (the thread never resets).
               It carries NO buttons — Home/search/upload live in the composer
               "+" menu — so the chat stops acting like a second app nav bar. The bar remains only to reserve
-              the safe-area top inset at full-bleed and host the transcribe badge. */}
+              the safe-area top inset at full-bleed and host the quiet serving
+              source or transcribe badge. */}
             {threadPresented ? (
               <motion.div
                 data-testid="chat-sheet-header"
@@ -5904,8 +5909,8 @@ export function ChatOverlay({
                 )}
               >
                 {/* The header carries no nav/search buttons — Home, Search, and
-                    Upload live in the composer "+" menu. This bar exists only to reserve the safe-area
-                    top inset at full-bleed and host the transcription badge. */}
+                    Upload live in the composer "+" menu. This bar reserves the
+                    full-bleed safe area and keeps status labels out of the input. */}
                 {transcriptionComposerActive ? (
                   <div
                     data-testid="chat-transcribing-badge"
@@ -5915,6 +5920,9 @@ export function ChatOverlay({
                       ? "Finishing transcription…"
                       : "Transcribing — say “exit transcription mode” to stop"}
                   </div>
+                ) : null}
+                {!transcriptionComposerActive ? (
+                  <ServingProviderChip className="pointer-events-none ml-auto shrink-0 self-center" />
                 ) : null}
               </motion.div>
             ) : null}
@@ -6365,12 +6373,6 @@ export function ChatOverlay({
                   error={isSlashDraft && slash.error}
                   onPick={pickSlashItem}
                 />
-              ) : null}
-              {/* Who is answering this chat. The overlay is the primary chat
-                  surface, so without it the serving source was only visible in
-                  Settings (#20045 U6). */}
-              {!transcriptionComposerActive ? (
-                <ServingProviderChip className="pointer-events-none order-last shrink-0 self-center pr-1" />
               ) : null}
               {/* The "+" opens shell navigation plus surface-local Search and
                   Upload actions for this in-app conversation, never connector actions on a

--- a/packages/ui/src/components/shell/ios-chat-accessory-bar.test.ts
+++ b/packages/ui/src/components/shell/ios-chat-accessory-bar.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Verifies the iOS chat accessory controller's visibility mapping and ordered
+ * WebView-global writes with a deterministic fake native bridge.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createChatAccessoryBarController } from "./ios-chat-accessory-bar";
+
+describe("iOS chat accessory controller", () => {
+  it("serializes chat hide then non-chat restore in request order", async () => {
+    let releaseHide: (() => void) | undefined;
+    const setAccessoryBarVisible = vi.fn(
+      ({ isVisible }: { isVisible: boolean }) => {
+        if (isVisible) return Promise.resolve();
+        return new Promise<void>((resolve) => {
+          releaseHide = resolve;
+        });
+      },
+    );
+    const reportError = vi.fn();
+    const setHidden = createChatAccessoryBarController({
+      enabled: true,
+      loadKeyboard: async () => ({ setAccessoryBarVisible }),
+      reportError,
+    });
+
+    setHidden(true);
+    setHidden(false);
+    await vi.waitFor(() =>
+      expect(setAccessoryBarVisible).toHaveBeenCalledOnce(),
+    );
+    expect(setAccessoryBarVisible).toHaveBeenLastCalledWith({
+      isVisible: false,
+    });
+
+    releaseHide?.();
+    await vi.waitFor(() =>
+      expect(setAccessoryBarVisible).toHaveBeenLastCalledWith({
+        isVisible: true,
+      }),
+    );
+    expect(reportError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/shell/ios-chat-accessory-bar.ts
+++ b/packages/ui/src/components/shell/ios-chat-accessory-bar.ts
@@ -1,0 +1,56 @@
+/**
+ * Scopes WebView-global iOS keyboard accessory suppression to the chat
+ * composer's focus lifecycle and serializes native bridge writes so a later
+ * restore cannot be overtaken by an earlier hide.
+ */
+
+import { logger } from "@elizaos/logger";
+
+import { isIOS, isNative } from "../../platform/init";
+
+interface KeyboardAccessoryBridge {
+  setAccessoryBarVisible(options: { isVisible: boolean }): Promise<void>;
+}
+
+type KeyboardAccessoryLoader = () => Promise<KeyboardAccessoryBridge>;
+
+export function createChatAccessoryBarController({
+  enabled,
+  loadKeyboard,
+  reportError,
+}: {
+  enabled: boolean;
+  loadKeyboard: KeyboardAccessoryLoader;
+  reportError: (error: unknown) => void;
+}): (hidden: boolean) => void {
+  let update = Promise.resolve();
+
+  return (hidden: boolean): void => {
+    if (!enabled) return;
+    update = update
+      .then(async () => {
+        const Keyboard = await loadKeyboard();
+        await Keyboard.setAccessoryBarVisible({ isVisible: !hidden });
+      })
+      .catch((error) => {
+        // error-policy:J4 the optional native keyboard bridge can be absent or
+        // unavailable; ordinary WebView keyboard behavior remains usable.
+        reportError(error);
+      });
+  };
+}
+
+export const setChatComposerAccessoryBarHidden =
+  createChatAccessoryBarController({
+    enabled: isNative && isIOS,
+    loadKeyboard: async () => {
+      const { Keyboard } = await import("@capacitor/keyboard");
+      return Keyboard;
+    },
+    reportError: (error) => {
+      logger.warn(
+        { error },
+        "[ChatOverlay] iOS keyboard accessory visibility unavailable",
+      );
+    },
+  });

--- a/packages/ui/src/glass/GlassSurface.tsx
+++ b/packages/ui/src/glass/GlassSurface.tsx
@@ -100,6 +100,8 @@ export interface NativeGlassAnchorOptions {
   enabled?: boolean;
   /** UIGlassEffect.isInteractive — mount-time only (see GlassSurfaceProps). */
   interactive?: boolean;
+  /** Appearance forwarded to the native material for this anchored surface. */
+  colorScheme?: "light" | "dark" | "system";
 }
 
 /**
@@ -126,7 +128,11 @@ export interface NativeGlassAnchorOptions {
  */
 export function useNativeGlassAnchor(
   ref: React.RefObject<HTMLElement | null>,
-  { enabled = true, interactive = false }: NativeGlassAnchorOptions = {},
+  {
+    enabled = true,
+    interactive = false,
+    colorScheme = "system",
+  }: NativeGlassAnchorOptions = {},
 ): GlassTier {
   const regionId = useId();
   const [available, setAvailable] = useState(false);
@@ -209,6 +215,7 @@ export function useNativeGlassAnchor(
             rect: rectOf(),
             cornerRadius: radius,
             interactive,
+            colorScheme,
           })
         ).attached;
       } catch {
@@ -244,7 +251,7 @@ export function useNativeGlassAnchor(
       unsubscribe?.();
       teardown();
     };
-  }, [wantNative, enabled, available, interactive, ref, regionId]);
+  }, [wantNative, enabled, available, interactive, colorScheme, ref, regionId]);
 
   return nativeLive && backdropActive ? "native" : cssGlassTier();
 }

--- a/packages/ui/src/glass/glass.test.tsx
+++ b/packages/ui/src/glass/glass.test.tsx
@@ -121,9 +121,15 @@ describe("glass tokens", () => {
   });
 });
 
-function AnchorHarness({ enabled }: { enabled: boolean }) {
+function AnchorHarness({
+  enabled,
+  colorScheme,
+}: {
+  enabled: boolean;
+  colorScheme?: "light" | "dark" | "system";
+}) {
   const ref = useRef<HTMLDivElement>(null);
-  const tier = useNativeGlassAnchor(ref, { enabled });
+  const tier = useNativeGlassAnchor(ref, { enabled, colorScheme });
   return <div ref={ref} data-testid="anchor" data-glass-tier={tier} />;
 }
 
@@ -166,6 +172,25 @@ describe("GlassSurface", () => {
     // The lease was the last holder, so the wallpaper clears (a couple of
     // frames later — the native copy covers the DOM swap-back).
     await waitFor(() => expect(bridge.clearBackdrop).toHaveBeenCalledTimes(1));
+  });
+
+  it("forwards a surface-owned dark appearance to native material", async () => {
+    const bridge = fakeBridge();
+    installCapacitor(bridge);
+    seedWallpaper();
+
+    const { getByTestId, unmount } = render(
+      <AnchorHarness enabled colorScheme="dark" />,
+    );
+
+    await waitFor(() =>
+      expect(getByTestId("anchor").dataset.glassTier).toBe("native"),
+    );
+    expect(bridge.attachGlass).toHaveBeenCalledWith(
+      expect.objectContaining({ colorScheme: "dark" }),
+    );
+    unmount();
+    await waitFor(() => expect(bridge.detachGlass).toHaveBeenCalledOnce());
   });
 
   it("holds the CSS tier while either native acknowledgement is pending", async () => {


### PR DESCRIPTION
Closes #20291.

## What changed

- keeps the iOS WebView accessory bar enabled by default for onboarding, settings, search, payment, and other forms
- hides the accessory bar only while the real chat composer is focused, then restores it on blur, collapse, unmount, and navigation
- serializes native visibility writes so a late hide cannot overtake a newer restore
- forwards the dark color scheme to the chat-only native glass anchor
- moves the serving-provider chip from the compact composer into the open chat-sheet header

## Root cause

The prior head disabled a WebView-global keyboard accessory setting during app bootstrap. That removed Previous/Next/Done from every later iOS form, not only chat. The corrected head scopes suppression to the chat-composer lifecycle and proves a non-chat settings input regains the native accessory bar after leaving chat.

## Exact-head validation

- UI focused tests: 19/19
- app focused tests: 27/27
- app and UI typechecks: pass
- exact eight-file Biome: pass
- `git diff --check`: pass
- no deploy or physical-device mutation performed

The PR remains draft. Hosted checks plus a signed physical-device screenshot/MP4 and native log receipt are still required before merge.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@a83393b0907262107c8fb5137c65584e27473e0f
Attribution status: self-reported
— [codex / ios-chat-overlay-polish]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@a83393b0907262107c8fb5137c65584e27473e0f"} -->

<!-- evidence-head:3a5e86fd73513ff542c2570e971c7c854be4fe4f -->

<!-- evidence-row:before-screenshots -->
- [ ] Pending exact-head physical-device capture

<!-- evidence-row:after-screenshots -->
- [ ] Pending exact-head physical-device capture

<!-- evidence-row:walkthrough-video -->
- [ ] Pending exact-head physical-device walkthrough

<!-- evidence-row:backend-logs -->
- [ ] Pending native bridge log receipt

<!-- evidence-row:frontend-logs -->
- [ ] Pending device console/network receipt

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model behavior changes

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain persistence changes

<!-- evidence-row:ocr-review -->
- [ ] Pending exact-head screenshot OCR review



<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@a83393b0907262107c8fb5137c65584e27473e0f:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

