### PR TITLE
fix(cloud): reject malformed admin numeric flags

### DIFF
--- a/packages/cloud/scripts/admin/onboard-docker-node.test.ts
+++ b/packages/cloud/scripts/admin/onboard-docker-node.test.ts
@@ -142,6 +142,99 @@ describe("parseArgs", () => {
     ).toThrow("ssh-port");
   });
 
+  it("rejects parseInt-coercible --ssh-port tokens instead of selecting another port", () => {
+    // Number.parseInt("1e4", 10) === 1, still inside 1..65535; dry-run then
+    // printed `root@127.0.0.1:1`. Trailing junk and leading zeros are the
+    // same class: the operator must get the port they typed, or an error.
+    for (const value of [
+      "1e4",
+      "1E4",
+      "8abc",
+      "010",
+      "22.0",
+      "0x10",
+      "65536",
+    ]) {
+      expect(() =>
+        parseArgs(
+          ["--host", "127.0.0.1", "--node-id", "n", "--ssh-port", value],
+          emptyEnv,
+        ),
+      ).toThrow(/ssh-port/);
+    }
+    expect(
+      parseArgs(
+        ["--host", "127.0.0.1", "--node-id", "n", "--ssh-port", "2222"],
+        emptyEnv,
+      ).sshPort,
+    ).toBe(2222);
+    expect(
+      parseArgs(
+        ["--host", "127.0.0.1", "--node-id", "n", "--ssh-port", "1"],
+        emptyEnv,
+      ).sshPort,
+    ).toBe(1);
+    expect(
+      parseArgs(
+        ["--host", "127.0.0.1", "--node-id", "n", "--ssh-port", "65535"],
+        emptyEnv,
+      ).sshPort,
+    ).toBe(65535);
+  });
+
+  it("rejects parseInt-coercible --capacity tokens instead of shrinking the slot count", () => {
+    // Number.parseInt("1e2", 10) === 1, so `--capacity 1e2` used to print
+    // `capacity=1` while `--capacity 100` correctly rejected as out of range.
+    for (const value of [
+      "1e2",
+      "1E2",
+      "8abc",
+      "010",
+      "4.5",
+      "0x10",
+      "0",
+      "65",
+    ]) {
+      expect(() =>
+        parseArgs(
+          ["--host", "127.0.0.1", "--node-id", "n", "--capacity", value],
+          emptyEnv,
+        ),
+      ).toThrow(/capacity/);
+    }
+    expect(
+      parseArgs(
+        ["--host", "127.0.0.1", "--node-id", "n", "--capacity", "1"],
+        emptyEnv,
+      ).capacity,
+    ).toBe(1);
+    expect(
+      parseArgs(
+        ["--host", "127.0.0.1", "--node-id", "n", "--capacity", "64"],
+        emptyEnv,
+      ).capacity,
+    ).toBe(64);
+  });
+
+  it("applies the same canonical integer gate to the env fallbacks", () => {
+    expect(() =>
+      parseArgs(["--host", "h", "--node-id", "n"], {
+        ONBOARD_NODE_SSH_PORT: "1e4",
+      } as NodeJS.ProcessEnv),
+    ).toThrow(/ssh-port/);
+    expect(() =>
+      parseArgs(["--host", "h", "--node-id", "n"], {
+        ONBOARD_NODE_CAPACITY: "1e2",
+      } as NodeJS.ProcessEnv),
+    ).toThrow(/capacity/);
+    expect(
+      parseArgs(["--host", "h", "--node-id", "n"], {
+        ONBOARD_NODE_SSH_PORT: "2200",
+        ONBOARD_NODE_CAPACITY: "16",
+      } as NodeJS.ProcessEnv),
+    ).toMatchObject({ sshPort: 2200, capacity: 16 });
+  });
+
   it("throws when a flag is missing its value", () => {
     expect(() => parseArgs(["--host", "--node-id", "n"], emptyEnv)).toThrow(
       "requires a value",

--- a/packages/cloud/scripts/admin/onboard-docker-node.ts
+++ b/packages/cloud/scripts/admin/onboard-docker-node.ts
@@ -42,6 +42,10 @@
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  parseCanonicalInt,
+  parseTcpPort,
+} from "../../../scripts/lib/cli-numbers.mjs";
 
 // The cloud-shared modules are imported lazily inside main() (see loadDeps) so
 // importing this file for its pure helpers — e.g. from the unit test — does not
@@ -184,7 +188,12 @@ export function capacityForOnboardUpsert(
   return existing?.capacity ?? flagCapacity;
 }
 
-/** Parse argv + env into a validated config. Throws on missing required fields. */
+/**
+ * Parse argv + env into a validated config. Throws on missing required
+ * fields or a non-canonical ssh-port / capacity token (scientific notation,
+ * hex, leading zeros, trailing junk) so Number.parseInt cannot silently
+ * retarget the host or shrink the slot count.
+ */
 export function parseArgs(argv: string[], env: NodeJS.ProcessEnv): OnboardArgs {
   const flags = new Map<string, string>();
   let dryRun = false;
@@ -215,22 +224,18 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv): OnboardArgs {
     flags.get("key") ??
     env.ONBOARD_NODE_SSH_KEY ??
     path.join(os.homedir(), ".ssh", "id_ed25519");
-  const sshPort = Number.parseInt(
+  // parseInt("1e4")===1 is still a legal TCP port; require the same
+  // canonical decimal the rest of the repo uses for CLI ports/limits.
+  const sshPort = parseTcpPort(
     flags.get("ssh-port") ?? env.ONBOARD_NODE_SSH_PORT ?? "22",
-    10,
-  );
+    "--ssh-port",
+  ) as number;
   const sshUser = flags.get("ssh-user") ?? env.ONBOARD_NODE_SSH_USER ?? "root";
   const capacityRaw = flags.get("capacity") ?? env.ONBOARD_NODE_CAPACITY ?? "8";
-  const capacity = Number.parseInt(capacityRaw, 10);
-
-  if (!Number.isInteger(sshPort) || sshPort < 1 || sshPort > 65535) {
-    throw new Error(
-      `Invalid ssh-port: ${flags.get("ssh-port") ?? env.ONBOARD_NODE_SSH_PORT}`,
-    );
-  }
-  if (!Number.isInteger(capacity) || capacity < 1 || capacity > 64) {
-    throw new Error(`Invalid capacity (must be 1..64): ${capacityRaw}`);
-  }
+  const capacity = parseCanonicalInt(capacityRaw, "--capacity", {
+    min: 1,
+    max: 64,
+  }) as number;
 
   return { host, nodeId, keyPath, sshPort, sshUser, capacity, dryRun };
 }

--- a/packages/cloud/scripts/admin/prune-node-disk.test.ts
+++ b/packages/cloud/scripts/admin/prune-node-disk.test.ts
@@ -49,9 +49,44 @@ describe("parsePruneArgs", () => {
     expect(args.sshUser).toBe("ops");
   });
 
-  it("rejects an invalid ssh-port", () => {
+  it("accepts canonical ssh-port boundaries", () => {
+    expect(
+      parsePruneArgs(["--host", "h", "--ssh-port", "1"], EMPTY).sshPort,
+    ).toBe(1);
+    expect(
+      parsePruneArgs(["--host", "h", "--ssh-port", "65535"], EMPTY).sshPort,
+    ).toBe(65535);
+  });
+
+  it("rejects non-canonical and out-of-range ssh-port flags", () => {
+    for (const value of [
+      "1e4",
+      "1E4",
+      "8abc",
+      "022",
+      "22.0",
+      "0x10",
+      "0",
+      "65536",
+    ]) {
+      expect(() =>
+        parsePruneArgs(["--host", "h", "--ssh-port", value], EMPTY),
+      ).toThrow(/ssh-port/);
+    }
+  });
+
+  it("applies the canonical ssh-port gate to env fallbacks", () => {
     expect(() =>
-      parsePruneArgs(["--host", "h", "--ssh-port", "99999"], EMPTY),
-    ).toThrow("Invalid ssh-port");
+      parsePruneArgs([], {
+        PRUNE_NODE_HOST: "h",
+        PRUNE_NODE_SSH_PORT: "1e4",
+      } as NodeJS.ProcessEnv),
+    ).toThrow(/ssh-port/);
+    expect(
+      parsePruneArgs([], {
+        PRUNE_NODE_HOST: "h",
+        PRUNE_NODE_SSH_PORT: "2200",
+      } as NodeJS.ProcessEnv).sshPort,
+    ).toBe(2200);
   });
 });

--- a/packages/cloud/scripts/admin/prune-node-disk.ts
+++ b/packages/cloud/scripts/admin/prune-node-disk.ts
@@ -45,6 +45,7 @@
 
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import { parseTcpPort } from "../../../scripts/lib/cli-numbers.mjs";
 
 async function loadDeps() {
   const [{ dockerNodesRepository }, { DockerSSHClient }, diskMgr] =
@@ -108,13 +109,10 @@ export function parsePruneArgs(
     throw new Error("Provide only ONE of --node-id or --host, not both");
   }
 
-  const sshPort = Number.parseInt(
+  const sshPort = parseTcpPort(
     flags.get("ssh-port") ?? env.PRUNE_NODE_SSH_PORT ?? "22",
-    10,
-  );
-  if (!Number.isInteger(sshPort) || sshPort < 1 || sshPort > 65535) {
-    throw new Error(`Invalid ssh-port: ${flags.get("ssh-port")}`);
-  }
+    "--ssh-port",
+  ) as number;
   const sshUser = flags.get("ssh-user") ?? env.PRUNE_NODE_SSH_USER ?? "root";
 
   return {


### PR DESCRIPTION
# Relates to

Closes #20309.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto current `origin/develop` at `4af7a52143ededb5548d3cc6e9c8d863cc5eff46` with zero conflicts.
- [x] `bun install --frozen-lockfile` and root `bun run verify` were run after final synchronization.
- [x] A reviewer can reproduce the permissive-prefix failure and verify the complete Cloud admin numeric class from the focused suites and exact-head proof below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- AI provider/model: openai / gpt-5.6-sol; identifier openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Client / agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Contribution skill revision: `elizaOS/eliza@4af7a52143ededb5548d3cc6e9c8d863cc5eff46:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Attribution status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `4af7a52143ededb5548d3cc6e9c8d863cc5eff46`; zero conflicts.
- [x] Root `bun run verify` passes at exact PR head `26639a616d97876a5fb79b04b11d8a109cbcd796`.

# Risks

Low. The change is confined to parsing three Cloud administrative numeric inputs. Canonical values, defaults, ranges, flag-over-environment precedence, DTOs, SSH configuration, and database write shapes are unchanged. The intentional compatibility break is limited to malformed values that were previously accepted after silent reinterpretation.

# Background

## What does this PR do?

Replaces permissive numeric-prefix parsing across the complete Cloud admin numeric class:

- onboarding SSH port now uses shared `parseTcpPort`;
- disk-pruning SSH port now uses shared `parseTcpPort`;
- onboarding capacity now uses shared `parseCanonicalInt` bounded to `1..64`.

Previously, `Number.parseInt` silently converted inputs such as `1e4` or `1e2` to `1`. An operator could therefore target SSH port 1 or persist capacity 1 instead of receiving a configuration error.

The shared canonical parser requires the complete raw value to round-trip as canonical decimal digits and a safe integer. It rejects scientific and hexadecimal notation, fractions, leading zeros, surrounding whitespace, trailing junk, unsafe values, and out-of-range values.

## What kind of change is this?

Bug fix (non-breaking for valid configuration; strict rejection of malformed configuration).

# Documentation changes needed?

No. This enforces the intended integer contracts while preserving every valid value, default, range, and precedence rule.

# Testing

## Where should a reviewer start?

- `packages/cloud/scripts/admin/onboard-docker-node.ts`: canonical SSH-port and capacity parsing.
- `packages/cloud/scripts/admin/prune-node-disk.ts`: the sole sibling Cloud admin SSH-port path.
- Their adjacent test files: malformed flag/environment tables, boundaries, defaults, and precedence.
- `packages/scripts/lib/cli-numbers.mjs`: existing shared parser contract used by both paths.

## Detailed testing steps

Run with repository-pinned Bun 1.3.14 and Node 24.15.0:

```bash
bun install --frozen-lockfile
bun test packages/scripts/__tests__/cli-numbers.test.mjs packages/cloud/scripts/admin/onboard-docker-node.test.ts packages/cloud/scripts/admin/prune-node-disk.test.ts
./node_modules/.bin/biome check packages/cloud/scripts/admin/onboard-docker-node.ts packages/cloud/scripts/admin/onboard-docker-node.test.ts packages/cloud/scripts/admin/prune-node-disk.ts packages/cloud/scripts/admin/prune-node-disk.test.ts
git diff --check origin/develop...HEAD
bun run verify:cloud
bun run verify
```

Observed final results at `26639a616d97876a5fb79b04b11d8a109cbcd796`:

- Shared numeric parser plus both changed admin suites: 3 files; 32 tests passed; 97 assertions.
- Changed-file Biome: 4 files checked; no fixes or errors.
- Diff check: passed.
- Official Cloud verification: 80/80 tasks passed.
- Root verification: 351/351 tasks passed; 8,270 test files scanned with 0 focused and 0 orphaned skips.
- Factory proof recorder: exact-head `bun run verify` exit 0.

The expanded `packages/cloud/scripts/admin` directory was also measured at this head: 519 passed, 17 skipped, and 3 unrelated failures across 539 tests in 31 files. All three failures are in `daemons/provisioning-worker.test.ts`, whose fixtures are rejected by the existing memory-KMS durability guard before reaching their expected paths. Neither changed test file failed. The run also emits the existing macOS BSD `sed: illegal option -- -` warning.

# Evidence Gate

<!-- evidence-head:26639a616d97876a5fb79b04b11d8a109cbcd796 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: N/A - headless administrative CLI parsing has no rendered surface.
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots: N/A - headless administrative CLI parsing has no rendered surface.
<!-- evidence-row:walkthrough-video -->
- [ ] Video walkthrough: N/A - deterministic parser and command-argument tests exercise the complete changed path.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - no service process is required; the real argument parsers are invoked directly.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no frontend or network path changes.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: deterministic malformed-input regressions plus exact-head Cloud and repository verification transcripts.

<details>
<summary>Final verification transcript</summary>

```text
focused numeric parser/admin suites: 32 passed, 0 failed, 97 assertions
changed-file biome: Checked 4 files. No fixes applied.
git diff --check origin/develop...HEAD: passed
verify:cloud: 80 successful / 80 total tasks
root verify: 351 successful / 351 total tasks
root verify: [anti-larp] scanned 8270 test files — 0 focused, 0 orphaned skip(s)
proof-run: recorded PROOF for 26639a616 — bun run verify (exit 0)
complete admin directory: 519 pass, 17 skip, 3 fail across 539 tests; failures isolated to provisioning-worker.test.ts
```

</details>

<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review: N/A - no rendered visual surface or text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - the change is deterministic administrative input parsing with no model call or agent trajectory.

## Backend + frontend logs

N/A - focused tests invoke the production argument parsers directly. No backend process, frontend, or network request is required.

## Screenshots (before / after) + video walkthrough

N/A - no UI or rendered output changes.

## Known gaps / failures

The complete admin-directory run has three unrelated current-tree failures in `daemons/provisioning-worker.test.ts` because its explicit environment fixtures reach the existing memory-KMS durability guard before their expected paths. The changed 32-test parser/admin surface, changed-file Biome, diff check, official Cloud gate, and exact-head root verification are green.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/eliza@4af7a52143ededb5548d3cc6e9c8d863cc5eff46:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [sol-cloud-admin-canonical-numbers]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"claude-code","skill_revision":"elizaOS/eliza@4af7a52143ededb5548d3cc6e9c8d863cc5eff46:packages/skills/skills/contribute-to-eliza"} -->
