### PR TITLE
fix(shared): make reminder creation receipts durable

### DIFF
--- a/packages/cloud/api/__tests__/shared-eliza-runtime.miniflare.test.ts
+++ b/packages/cloud/api/__tests__/shared-eliza-runtime.miniflare.test.ts
@@ -626,6 +626,16 @@ describe("Shared Eliza runtime in Workerd", () => {
       degraded: false,
     });
     expect(payload.result.actionResults).toHaveLength(1);
+    expect(payload.result.actionResults?.[0]).toMatchObject({
+      verifiedUserFacing: true,
+      effectReceipts: [
+        {
+          outcome: "applied",
+          operation: "shared.reminder.create",
+          idempotency: { replayed: false },
+        },
+      ],
+    });
     expect(payload.scheduledTasks).toHaveLength(1);
     expect(payload.scheduledTasks[0]).toMatchObject({
       kind: "reminder",
@@ -638,7 +648,7 @@ describe("Shared Eliza runtime in Workerd", () => {
         },
       },
     });
-    expect(modelRequests.length - requestsBefore).toBe(4);
+    expect(modelRequests.length - requestsBefore).toBe(3);
   }, 120_000);
 
   test.skipIf(process.env.SHARED_ELIZA_LIVE_WEB_SEARCH !== "1")(

--- a/packages/cloud/api/test/fixtures/shared-eliza-runtime-worker.ts
+++ b/packages/cloud/api/test/fixtures/shared-eliza-runtime-worker.ts
@@ -157,15 +157,30 @@ function createTodoProbeStore(records: Todo[]): TodoStore {
 function createReminderProbeRunner(
   records: ScheduledTask[],
 ): ScheduledTaskRunner {
+  const scheduleWithResult = async (input: ScheduledTaskInput) => {
+    const task: ScheduledTask = {
+      taskId: `92000000-0000-4000-8000-${String(records.length + 1).padStart(12, "0")}`,
+      ...input,
+      state: { status: "scheduled", followupCount: 0 },
+    };
+    records.push(task);
+    return {
+      task,
+      commit: {
+        logId: `93000000-0000-4000-8000-${String(records.length).padStart(12, "0")}`,
+        taskId: task.taskId,
+        agentId: "workerd-reminder-probe",
+        occurredAtIso: "2026-08-15T00:00:00.000Z",
+        transition: "scheduled" as const,
+        rolledUp: false,
+      },
+      replayed: false,
+    };
+  };
   return {
+    scheduleWithResult,
     async schedule(input: ScheduledTaskInput) {
-      const task: ScheduledTask = {
-        taskId: `92000000-0000-4000-8000-${String(records.length + 1).padStart(12, "0")}`,
-        ...input,
-        state: { status: "scheduled", followupCount: 0 },
-      };
-      records.push(task);
-      return task;
+      return (await scheduleWithResult(input)).task;
     },
     async list() {
       return records;

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -133,13 +133,28 @@ const todoStore: TodoStore = {
   },
 };
 const reminderRunner = {
-  async schedule(input: Record<string, unknown>) {
+  async scheduleWithResult(input: Record<string, unknown>) {
     scheduledInputs.push(input);
-    return {
+    const task = {
       taskId: "shared-reminder-1",
       ...input,
-      state: { status: "scheduled", followupCount: 0 },
+      state: { status: "scheduled" as const, followupCount: 0 },
     };
+    return {
+      task,
+      commit: {
+        logId: "shared-reminder-log-1",
+        taskId: task.taskId,
+        agentId: "personal:a26524f1-c4f1-493b-a97e-8be161284a10",
+        occurredAtIso: "2026-08-15T00:00:00.000Z",
+        transition: "scheduled" as const,
+        rolledUp: false,
+      },
+      replayed: false,
+    };
+  },
+  async schedule(input: Record<string, unknown>) {
+    return (await this.scheduleWithResult(input)).task;
   },
   async list() {
     return [];
@@ -748,7 +763,21 @@ describe("Shared Eliza Workerd runtime", () => {
         },
       },
     });
-    expect(modelRequests).toHaveLength(4);
+    expect(modelRequests).toHaveLength(3);
+    expect(result.actionResults?.[0]).toMatchObject({
+      verifiedUserFacing: true,
+      effectReceipts: [
+        {
+          receiptId: "shared-reminder:create:shared-reminder-log-1",
+          outcome: "applied",
+          operation: "shared.reminder.create",
+          idempotency: {
+            key: "shared-reminder:7d734b8f-1ac5-456a-8bf3-9cd61dd546ef:create",
+            replayed: false,
+          },
+        },
+      ],
+    });
     expect(
       (modelRequests[1].tools as Array<{ function?: { name?: string } }>).some(
         (tool) => tool.function?.name === "REMINDERS",

--- a/plugins/plugin-scheduling/src/edge.ts
+++ b/plugins/plugin-scheduling/src/edge.ts
@@ -123,6 +123,7 @@ export type {
   ScheduledTaskRef,
   ScheduledTaskResolvedContext,
   ScheduledTaskRunner,
+  ScheduledTaskScheduleResult,
   ScheduledTaskShouldFire,
   ScheduledTaskSource,
   ScheduledTaskState,

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
@@ -180,13 +180,18 @@ describe("ScheduledTaskRunner — schedule + idempotency", () => {
 
   it("dedupes by idempotencyKey", async () => {
     const h = makeHarness();
-    const a = await h.runner.schedule(baseInput({ idempotencyKey: "uniq-1" }));
-    const b = await h.runner.schedule(
+    const a = await h.runner.scheduleWithResult(
+      baseInput({ idempotencyKey: "uniq-1" }),
+    );
+    const b = await h.runner.scheduleWithResult(
       baseInput({ idempotencyKey: "uniq-1", priority: "high" }),
     );
-    expect(b.taskId).toBe(a.taskId);
+    expect(a.replayed).toBe(false);
+    expect(b.replayed).toBe(true);
+    expect(b.task.taskId).toBe(a.task.taskId);
+    expect(b.commit).toEqual(a.commit);
     // The second call must not have updated priority.
-    expect(b.priority).toBe("medium");
+    expect(b.task.priority).toBe("medium");
   });
 
   it("imports an exact cutover task once and rejects mismatched retries", async () => {

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -52,6 +52,7 @@ import {
   type ScheduledTaskFilter,
   type ScheduledTaskRef,
   type ScheduledTaskRunner,
+  type ScheduledTaskScheduleResult,
   type ScheduledTaskState,
   type ScheduledTaskVerb,
   type SubjectStoreView,
@@ -796,11 +797,31 @@ export function createScheduledTaskRunner(
   async function schedule(
     input: Omit<ScheduledTask, "taskId" | "state">,
   ): Promise<ScheduledTask> {
+    return (await scheduleWithResult(input)).task;
+  }
+
+  async function scheduleWithResult(
+    input: Omit<ScheduledTask, "taskId" | "state">,
+  ): Promise<ScheduledTaskScheduleResult> {
     if (input.idempotencyKey) {
       const existing = await deps.store.findByIdempotencyKey(
         input.idempotencyKey,
       );
-      if (existing) return existing;
+      if (existing) {
+        const commit = (
+          await deps.logStore.list({
+            agentId: deps.agentId,
+            taskId: existing.taskId,
+            excludeRollups: true,
+          })
+        ).find((entry) => entry.transition === "scheduled");
+        if (!commit) {
+          throw new Error(
+            `Scheduled task ${existing.taskId} has no durable creation receipt`,
+          );
+        }
+        return { task: existing, commit, replayed: true };
+      }
     }
 
     const validationIssues = validateScheduledTaskInput(input, deps);
@@ -836,7 +857,7 @@ export function createScheduledTaskRunner(
       state: initialState,
     };
     await persist(task);
-    await logger.log(task.taskId, "scheduled", {
+    const commit = await logger.log(task.taskId, "scheduled", {
       detail: {
         kind: task.kind,
         priority: task.priority,
@@ -853,7 +874,7 @@ export function createScheduledTaskRunner(
           "validation: pipeline.onSkip overrides completionCheck.followupAfterMinutes",
       });
     }
-    return task;
+    return { task, commit, replayed: false };
   }
 
   async function importTask(
@@ -1988,6 +2009,7 @@ export function createScheduledTaskRunner(
   }
 
   return {
+    scheduleWithResult,
     schedule,
     importTask,
     activateImportedTask,

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -50,6 +50,7 @@ import {
   type OwnerFactsView,
   type ScheduledTask,
   type ScheduledTaskFilter,
+  type ScheduledTaskLogEntry,
   type ScheduledTaskRef,
   type ScheduledTaskRunner,
   type ScheduledTaskScheduleResult,
@@ -344,6 +345,43 @@ function defaultTaskIdGenerator(): string {
   return `st_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
 }
 
+const CREATION_RECEIPT_METADATA_KEY = "schedulingCreationReceipt";
+
+interface SchedulingCreationReceiptAnchor {
+  logId: string;
+  occurredAtIso: string;
+}
+
+function readCreationReceiptAnchor(
+  task: ScheduledTask,
+): SchedulingCreationReceiptAnchor | null {
+  const value = task.metadata?.[CREATION_RECEIPT_METADATA_KEY];
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.logId === "string" &&
+    candidate.logId.length > 0 &&
+    typeof candidate.occurredAtIso === "string" &&
+    !Number.isNaN(Date.parse(candidate.occurredAtIso))
+    ? { logId: candidate.logId, occurredAtIso: candidate.occurredAtIso }
+    : null;
+}
+
+async function creationReceiptLogId(
+  agentId: string,
+  taskId: string,
+): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(`${agentId}\0${taskId}`),
+  );
+  const hex = Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+  return `stl_create_${hex}`;
+}
+
 function isTerminal(status: ScheduledTask["state"]["status"]): boolean {
   return (
     status === "completed" ||
@@ -597,8 +635,8 @@ export interface ScheduledTaskRunnerExtras {
     },
   ): Promise<ScheduledTask>;
   /**
-   * Run the nightly rollup pass on the state-log. Default retention is 90
-   * days.
+   * Run the nightly rollup pass on non-creation state-log rows. Default
+   * retention is 90 days; stable `scheduled` creation receipts remain raw.
    */
   rolloverStateLog(opts?: { retentionDays?: number }): Promise<{
     rolledUp: number;
@@ -800,6 +838,68 @@ export function createScheduledTaskRunner(
     return (await scheduleWithResult(input)).task;
   }
 
+  async function creationCommit(
+    task: ScheduledTask,
+  ): Promise<ScheduledTaskLogEntry> {
+    const anchor = readCreationReceiptAnchor(task);
+    const entries = await deps.logStore.list({
+      agentId: deps.agentId,
+      taskId: task.taskId,
+      excludeRollups: true,
+    });
+    const existing = anchor
+      ? entries.find(
+          (entry) =>
+            entry.logId === anchor.logId && entry.transition === "scheduled",
+        )
+      : entries.find((entry) => entry.transition === "scheduled");
+    if (existing) return existing;
+    if (!anchor) {
+      throw new Error(
+        `Scheduled task ${task.taskId} has no durable creation receipt`,
+      );
+    }
+
+    const commit: ScheduledTaskLogEntry = {
+      logId: anchor.logId,
+      taskId: task.taskId,
+      agentId: deps.agentId,
+      occurredAtIso: anchor.occurredAtIso,
+      transition: "scheduled",
+      rolledUp: false,
+      detail: {
+        kind: task.kind,
+        priority: task.priority,
+        triggerKind: task.trigger.kind,
+      },
+    };
+    try {
+      await deps.logStore.append(commit);
+      return commit;
+    } catch (error) {
+      // error-policy:J1 The durable-store boundary resolves a concurrent
+      // append by reading the stable receipt identity back before surfacing it.
+      const raced = (
+        await deps.logStore.list({
+          agentId: deps.agentId,
+          taskId: task.taskId,
+          excludeRollups: true,
+        })
+      ).find(
+        (entry) =>
+          entry.logId === anchor.logId && entry.transition === "scheduled",
+      );
+      if (raced) return raced;
+      throw error;
+    }
+  }
+
+  async function replaySchedule(
+    task: ScheduledTask,
+  ): Promise<ScheduledTaskScheduleResult> {
+    return { task, commit: await creationCommit(task), replayed: true };
+  }
+
   async function scheduleWithResult(
     input: Omit<ScheduledTask, "taskId" | "state">,
   ): Promise<ScheduledTaskScheduleResult> {
@@ -807,21 +907,7 @@ export function createScheduledTaskRunner(
       const existing = await deps.store.findByIdempotencyKey(
         input.idempotencyKey,
       );
-      if (existing) {
-        const commit = (
-          await deps.logStore.list({
-            agentId: deps.agentId,
-            taskId: existing.taskId,
-            excludeRollups: true,
-          })
-        ).find((entry) => entry.transition === "scheduled");
-        if (!commit) {
-          throw new Error(
-            `Scheduled task ${existing.taskId} has no durable creation receipt`,
-          );
-        }
-        return { task: existing, commit, replayed: true };
-      }
+      if (existing) return replaySchedule(existing);
     }
 
     const validationIssues = validateScheduledTaskInput(input, deps);
@@ -851,19 +937,32 @@ export function createScheduledTaskRunner(
       status: "scheduled",
       followupCount: 0,
     };
+    const taskId = newTaskId();
+    const creationReceipt: SchedulingCreationReceiptAnchor = {
+      logId: await creationReceiptLogId(deps.agentId, taskId),
+      occurredAtIso: now().toISOString(),
+    };
     const task: ScheduledTask = {
-      taskId: newTaskId(),
+      taskId,
       ...withApprovalDefaults,
+      metadata: {
+        ...(withApprovalDefaults.metadata ?? {}),
+        [CREATION_RECEIPT_METADATA_KEY]: creationReceipt,
+      },
       state: initialState,
     };
-    await persist(task);
-    const commit = await logger.log(task.taskId, "scheduled", {
-      detail: {
-        kind: task.kind,
-        priority: task.priority,
-        triggerKind: task.trigger.kind,
-      },
-    });
+    try {
+      await persist(task);
+    } catch (error) {
+      // error-policy:J1 A same-key insert race is translated to the already
+      // committed task; unrelated persistence failures still fail closed.
+      const existing = input.idempotencyKey
+        ? await deps.store.findByIdempotencyKey(input.idempotencyKey)
+        : null;
+      if (existing) return replaySchedule(existing);
+      throw error;
+    }
+    const commit = await creationCommit(task);
     if (
       task.completionCheck?.followupAfterMinutes &&
       task.pipeline?.onSkip &&

--- a/plugins/plugin-scheduling/src/scheduled-task/sql-persistence.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/sql-persistence.test.ts
@@ -13,12 +13,16 @@ import {
   migrateSchedulingTables,
   SchedulingMigrationService,
 } from "./migration.js";
-import type { ScheduledTaskDispatcher } from "./runner.js";
+import type {
+  ScheduledTaskDispatcher,
+  ScheduledTaskRunnerHandle,
+} from "./runner.js";
 import {
   getScheduledTaskRunner,
   registerScheduledTaskRunnerDeps,
   ScheduledTaskRunnerService,
 } from "./runner-service.js";
+import type { ScheduledTaskLogStore } from "./state-log.js";
 import {
   createSchedulingSqlScheduledTaskLogStore,
   createSchedulingSqlScheduledTaskStore,
@@ -82,6 +86,49 @@ async function startService(
   return service;
 }
 
+async function startSqlRunner(
+  harness: RuntimeHarness,
+  logStore: ScheduledTaskLogStore = createSchedulingSqlScheduledTaskLogStore({
+    runtime: harness.runtime,
+    agentId: harness.runtime.agentId,
+  }),
+): Promise<{
+  runner: ScheduledTaskRunnerHandle;
+  logStore: ScheduledTaskLogStore;
+}> {
+  registerScheduledTaskRunnerDeps(harness.runtime, (runtime, agentId) => ({
+    store: createSchedulingSqlScheduledTaskStore({ runtime, agentId }),
+    logStore,
+    dispatcher: { async dispatch() {} },
+    ownerFacts: () => ({ timezone: "UTC" }),
+    globalPause: { current: async () => ({ active: false }) },
+    activity: { hasSignalSince: () => false },
+    subjectStore: { wasUpdatedSince: () => false },
+  }));
+  await startService(harness);
+  return {
+    runner: getScheduledTaskRunner(harness.runtime, {
+      agentId: harness.runtime.agentId,
+      now: () => new Date("2026-08-16T03:00:00.000Z"),
+    }),
+    logStore,
+  };
+}
+
+function receiptReminderInput(idempotencyKey: string) {
+  return {
+    kind: "reminder" as const,
+    promptInstructions: "Stretch",
+    trigger: { kind: "once" as const, atIso: "2026-08-16T03:05:00.000Z" },
+    priority: "medium" as const,
+    idempotencyKey,
+    respectsGlobalPause: true,
+    source: "user_chat" as const,
+    createdBy: "test",
+    ownerVisible: true,
+  };
+}
+
 const SQL_PERSISTENCE_TEST_TIMEOUT_MS = 15_000;
 
 describe("scheduling SQL persistence", () => {
@@ -96,6 +143,112 @@ describe("scheduling SQL persistence", () => {
     const service = await SchedulingMigrationService.start(runtime);
     await expect(service.stop()).resolves.toBeUndefined();
   });
+
+  it(
+    "reconciles a stable creation receipt after the task commit outlives a log failure",
+    async () => {
+      const harness = await createRuntimeHarness();
+      harnesses.push(harness);
+      const durableLogStore = createSchedulingSqlScheduledTaskLogStore({
+        runtime: harness.runtime,
+        agentId: harness.runtime.agentId,
+      });
+      let failNextAppend = true;
+      const flakyLogStore: ScheduledTaskLogStore = {
+        ...durableLogStore,
+        async append(entry) {
+          if (failNextAppend) {
+            failNextAppend = false;
+            throw new Error("injected log append failure");
+          }
+          await durableLogStore.append(entry);
+        },
+      };
+      const { runner } = await startSqlRunner(harness, flakyLogStore);
+      const input = receiptReminderInput("receipt-after-log-failure");
+
+      await expect(runner.scheduleWithResult(input)).rejects.toThrow(
+        "injected log append failure",
+      );
+      const replay = await runner.scheduleWithResult(input);
+
+      expect(replay.replayed).toBe(true);
+      expect(replay.commit.logId).toMatch(/^stl_create_[a-f0-9]{64}$/);
+      expect(replay.task.metadata?.schedulingCreationReceipt).toMatchObject({
+        logId: replay.commit.logId,
+      });
+      const counts = await harness.pg.query<{ tasks: number; logs: number }>(`
+        SELECT
+          (SELECT COUNT(*)::int FROM app_scheduling.life_scheduled_tasks
+            WHERE agent_id = 'agent-sql-persist') AS tasks,
+          (SELECT COUNT(*)::int FROM app_scheduling.life_scheduled_task_log
+            WHERE agent_id = 'agent-sql-persist' AND transition = 'scheduled') AS logs
+      `);
+      expect(counts.rows[0]).toEqual({ tasks: 1, logs: 1 });
+    },
+    SQL_PERSISTENCE_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "converges concurrent same-key creates on one task and one receipt",
+    async () => {
+      const harness = await createRuntimeHarness();
+      harnesses.push(harness);
+      const { runner } = await startSqlRunner(harness);
+      const input = receiptReminderInput("concurrent-receipt");
+
+      const results = await Promise.all([
+        runner.scheduleWithResult(input),
+        runner.scheduleWithResult(input),
+      ]);
+
+      expect(new Set(results.map((result) => result.task.taskId)).size).toBe(1);
+      expect(new Set(results.map((result) => result.commit.logId)).size).toBe(
+        1,
+      );
+      expect(results.map((result) => result.replayed).sort()).toEqual([
+        false,
+        true,
+      ]);
+      const counts = await harness.pg.query<{ tasks: number; logs: number }>(`
+        SELECT
+          (SELECT COUNT(*)::int FROM app_scheduling.life_scheduled_tasks
+            WHERE agent_id = 'agent-sql-persist') AS tasks,
+          (SELECT COUNT(*)::int FROM app_scheduling.life_scheduled_task_log
+            WHERE agent_id = 'agent-sql-persist' AND transition = 'scheduled') AS logs
+      `);
+      expect(counts.rows[0]).toEqual({ tasks: 1, logs: 1 });
+    },
+    SQL_PERSISTENCE_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "retains the original receipt identity beyond the log rollup window",
+    async () => {
+      const harness = await createRuntimeHarness();
+      harnesses.push(harness);
+      const { runner, logStore } = await startSqlRunner(harness);
+      const input = receiptReminderInput("receipt-after-rollup");
+      const created = await runner.scheduleWithResult(input);
+
+      const rollup = await logStore.rollupOlderThan({
+        agentId: harness.runtime.agentId,
+        olderThanIso: "2026-08-17T00:00:00.000Z",
+      });
+      const replay = await runner.scheduleWithResult(input);
+
+      expect(rollup).toEqual({ rolledUp: 0, deletedRaw: 0 });
+      expect(replay.replayed).toBe(true);
+      expect(replay.commit.logId).toBe(created.commit.logId);
+      const raw = await logStore.list({
+        agentId: harness.runtime.agentId,
+        taskId: created.task.taskId,
+        excludeRollups: true,
+      });
+      expect(raw.map((entry) => entry.logId)).toEqual([created.commit.logId]);
+    },
+    SQL_PERSISTENCE_TEST_TIMEOUT_MS,
+  );
 
   it(
     "copies legacy app_lifeops scheduled-task rows non-destructively",

--- a/plugins/plugin-scheduling/src/scheduled-task/state-log.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/state-log.test.ts
@@ -187,6 +187,28 @@ describe("createInMemoryScheduledTaskLogStore — rollupOlderThan", () => {
     ).toEqual({ rolledUp: 0, deletedRaw: 0 });
   });
 
+  it("retains scheduled creation receipts beyond the rollup window", async () => {
+    const store = createInMemoryScheduledTaskLogStore();
+    await store.append(
+      entry({
+        logId: "creation-receipt",
+        taskId: "t1",
+        occurredAtIso: "2026-01-01T00:00:00.000Z",
+        transition: "scheduled",
+      }),
+    );
+
+    expect(
+      await store.rollupOlderThan({
+        agentId: AGENT,
+        olderThanIso: "2026-02-01T00:00:00.000Z",
+      }),
+    ).toEqual({ rolledUp: 0, deletedRaw: 0 });
+    await expect(
+      store.list({ agentId: AGENT, taskId: "t1", excludeRollups: true }),
+    ).resolves.toMatchObject([{ logId: "creation-receipt" }]);
+  });
+
   it("does not re-roll already-rolled-up rows", async () => {
     const store = createInMemoryScheduledTaskLogStore();
     await store.append(

--- a/plugins/plugin-scheduling/src/scheduled-task/state-log.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/state-log.ts
@@ -3,9 +3,10 @@
  *
  * The runner writes one row per state transition. The user-visible
  * `GET /api/lifeops/scheduled-tasks/:id/history` endpoint reads from
- * this log. Default 90-day retention with a nightly rollup pass that
- * folds expired entries into a daily-summary row per task per
- * transition kind.
+ * this log. Default 90-day retention with a nightly rollup pass that folds
+ * expired entries into a daily-summary row per task per transition kind.
+ * The one `scheduled` creation receipt stays raw for the task's lifetime so
+ * idempotent request replay retains the same durable proof identity.
  */
 
 import type {
@@ -60,6 +61,7 @@ export function createInMemoryScheduledTaskLogStore(): ScheduledTaskLogStore {
         (r) =>
           r.agentId === agentId &&
           !r.rolledUp &&
+          r.transition !== "scheduled" &&
           r.occurredAtIso < olderThanIso,
       );
       if (expired.length === 0) {

--- a/plugins/plugin-scheduling/src/scheduled-task/store.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/store.ts
@@ -479,6 +479,7 @@ export function createSchedulingSqlScheduledTaskLogStore(
            FROM ${LOG_TABLE}
           WHERE agent_id = ${sqlQuote(agentId)}
             AND rolled_up = FALSE
+            AND transition <> 'scheduled'
             AND occurred_at < ${sqlQuote(args.olderThanIso)}`,
       );
       if (rows.length === 0) return { rolledUp: 0, deletedRaw: 0 };
@@ -513,6 +514,7 @@ export function createSchedulingSqlScheduledTaskLogStore(
         `DELETE FROM ${LOG_TABLE}
           WHERE agent_id = ${sqlQuote(agentId)}
             AND rolled_up = FALSE
+            AND transition <> 'scheduled'
             AND occurred_at < ${sqlQuote(args.olderThanIso)}`,
       );
       let counter = 0;

--- a/plugins/plugin-scheduling/src/scheduled-task/types.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/types.ts
@@ -341,7 +341,17 @@ export interface ScheduledTaskFilter {
   ownerVisibleOnly?: boolean;
 }
 
+/** Durable outcome for one scheduling request, including replay authority. */
+export interface ScheduledTaskScheduleResult {
+  task: ScheduledTask;
+  commit: ScheduledTaskLogEntry;
+  replayed: boolean;
+}
+
 export interface ScheduledTaskRunner {
+  scheduleWithResult(
+    task: Omit<ScheduledTask, "taskId" | "state">,
+  ): Promise<ScheduledTaskScheduleResult>;
   schedule(
     task: Omit<ScheduledTask, "taskId" | "state">,
   ): Promise<ScheduledTask>;

--- a/plugins/plugin-scheduling/src/shared-reminders.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.test.ts
@@ -25,13 +25,23 @@ function scheduledTask(input: ScheduledTaskInput): ScheduledTask {
 
 function harness(): {
   options: SharedRemindersEdgePluginOptions;
-  schedule: ReturnType<typeof vi.fn>;
+  scheduleWithResult: ReturnType<typeof vi.fn>;
 } {
-  const schedule = vi.fn(async (input: ScheduledTaskInput) =>
-    scheduledTask(input),
-  );
+  const scheduleWithResult = vi.fn(async (input: ScheduledTaskInput) => ({
+    task: scheduledTask(input),
+    commit: {
+      logId: "scheduled-log-1",
+      taskId: "reminder-1",
+      agentId: "personal:user-1",
+      occurredAtIso: NOW,
+      transition: "scheduled" as const,
+      rolledUp: false,
+    },
+    replayed: false,
+  }));
   const runner: ScheduledTaskRunner = {
-    schedule,
+    scheduleWithResult,
+    schedule: vi.fn(async (input: ScheduledTaskInput) => scheduledTask(input)),
     list: vi.fn(async () => []),
     apply: vi.fn(async () => {
       throw new Error("not used");
@@ -39,7 +49,7 @@ function harness(): {
     pipeline: vi.fn(async () => []),
   };
   return {
-    schedule,
+    scheduleWithResult,
     options: {
       runner,
       agentId: "personal:user-1",
@@ -91,7 +101,7 @@ describe("Shared reminders edge plugin", () => {
   });
 
   it("creates one canonical task and pins delivery to the trusted current DM", async () => {
-    const { options, schedule } = harness();
+    const { options, scheduleWithResult } = harness();
     const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
     const result = await action?.handler(
       {} as IAgentRuntime,
@@ -109,8 +119,8 @@ describe("Shared reminders edge plugin", () => {
     );
 
     expect(result?.success).toBe(true);
-    expect(schedule).toHaveBeenCalledTimes(1);
-    expect(schedule.mock.calls[0]?.[0]).toMatchObject({
+    expect(scheduleWithResult).toHaveBeenCalledTimes(1);
+    expect(scheduleWithResult.mock.calls[0]?.[0]).toMatchObject({
       kind: "reminder",
       trigger: { kind: "once", atIso: "2026-08-14T20:02:00.000Z" },
       output: {
@@ -127,10 +137,35 @@ describe("Shared reminders edge plugin", () => {
       },
       executionProfile: "notify-only",
     });
+    expect(result).toMatchObject({
+      verifiedUserFacing: true,
+      userFacingEffectReceiptIds: ["shared-reminder:create:scheduled-log-1"],
+      effectReceipts: [
+        {
+          receiptId: "shared-reminder:create:scheduled-log-1",
+          outcome: "applied",
+          operation: "shared.reminder.create",
+          resource: {
+            kind: "shared.reminder",
+            id: "reminder-1",
+            version: "scheduled-log-1",
+          },
+          idempotency: {
+            key: "shared-reminder:message-1:create",
+            replayed: false,
+          },
+          commit: {
+            kind: "durable",
+            id: "scheduled-log-1",
+            committedAt: NOW,
+          },
+        },
+      ],
+    });
   });
 
   it("rejects a create without structural timing instead of guessing", async () => {
-    const { options, schedule } = harness();
+    const { options, scheduleWithResult } = harness();
     const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
     const result = await action?.handler(
       {} as IAgentRuntime,
@@ -140,11 +175,11 @@ describe("Shared reminders edge plugin", () => {
     );
 
     expect(result).toMatchObject({ success: false });
-    expect(schedule).not.toHaveBeenCalled();
+    expect(scheduleWithResult).not.toHaveBeenCalled();
   });
 
   it("rejects reminder text above the connector-safe limit", async () => {
-    const { options, schedule } = harness();
+    const { options, scheduleWithResult } = harness();
     const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
     const result = await action?.handler(
       {} as IAgentRuntime,
@@ -160,6 +195,52 @@ describe("Shared reminders edge plugin", () => {
     );
 
     expect(result).toMatchObject({ success: false });
-    expect(schedule).not.toHaveBeenCalled();
+    expect(scheduleWithResult).not.toHaveBeenCalled();
+  });
+
+  it("returns the original durable receipt identity as a replayed no-op", async () => {
+    const { options, scheduleWithResult } = harness();
+    scheduleWithResult.mockImplementationOnce(
+      async (input: ScheduledTaskInput) => ({
+        task: scheduledTask(input),
+        commit: {
+          logId: "scheduled-log-1",
+          taskId: "reminder-1",
+          agentId: "personal:user-1",
+          occurredAtIso: NOW,
+          transition: "scheduled" as const,
+          rolledUp: false,
+        },
+        replayed: true,
+      }),
+    );
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "message-1" } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "create",
+          reminderText: "Stretch",
+          inMinutes: 2,
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      verifiedUserFacing: true,
+      effectReceipts: [
+        {
+          receiptId: "shared-reminder:create:scheduled-log-1",
+          outcome: "noop",
+          idempotency: {
+            key: "shared-reminder:message-1:create",
+            replayed: true,
+          },
+        },
+      ],
+    });
   });
 });

--- a/plugins/plugin-scheduling/src/shared-reminders.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.test.ts
@@ -119,6 +119,8 @@ describe("Shared reminders edge plugin", () => {
     );
 
     expect(result?.success).toBe(true);
+    expect(action?.tags).not.toContain("effect:idempotent");
+    expect(action?.tags).not.toContain("effect:receipt-required");
     expect(scheduleWithResult).toHaveBeenCalledTimes(1);
     expect(scheduleWithResult.mock.calls[0]?.[0]).toMatchObject({
       kind: "reminder",

--- a/plugins/plugin-scheduling/src/shared-reminders.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.ts
@@ -7,6 +7,7 @@
 import type {
   Action,
   ActionResult,
+  EffectReceipt,
   HandlerCallback,
   Memory,
   Plugin,
@@ -178,6 +179,54 @@ function taskSummary(task: ScheduledTask): string {
   return `${task.taskId}: ${task.output?.fallback?.body ?? task.promptInstructions} — ${when} [${task.state.status}]`;
 }
 
+function creationReceipt(args: {
+  task: ScheduledTask;
+  commit: { logId: string; occurredAtIso: string };
+  replayed: boolean;
+}): EffectReceipt {
+  const base = {
+    receiptId: `shared-reminder:create:${args.commit.logId}`,
+    operation: "shared.reminder.create",
+    resource: {
+      kind: "shared.reminder",
+      id: args.task.taskId,
+      version: args.commit.logId,
+    },
+    artifacts: [
+      {
+        kind: "shared.reminder.log",
+        id: args.commit.logId,
+        version: "scheduled",
+      },
+    ],
+    idempotency: {
+      key: args.task.idempotencyKey ?? null,
+      replayed: args.replayed,
+    },
+    observedAt: args.commit.occurredAtIso,
+  } as const;
+  return args.replayed
+    ? {
+        ...base,
+        outcome: "noop",
+        idempotency: {
+          key: args.task.idempotencyKey ?? null,
+          replayed: true,
+        },
+        reason:
+          "The persisted reminder already satisfies this idempotent request.",
+      }
+    : {
+        ...base,
+        outcome: "applied",
+        commit: {
+          kind: "durable",
+          id: args.commit.logId,
+          committedAt: args.commit.occurredAtIso,
+        },
+      };
+}
+
 export function createSharedRemindersEdgeAction(
   options: SharedRemindersEdgePluginOptions,
 ): Action {
@@ -198,7 +247,13 @@ export function createSharedRemindersEdgeAction(
       "SNOOZE_REMINDER",
       "DISMISS_REMINDER",
     ],
-    tags: ["resource:scheduled-item", "capability:read", "capability:write"],
+    tags: [
+      "resource:scheduled-item",
+      "capability:read",
+      "capability:write",
+      "effect:idempotent",
+      "effect:receipt-required",
+    ],
     contexts: ["reminders", "general"],
     roleGate: { minRole: "GUEST" },
     description:
@@ -302,7 +357,7 @@ export function createSharedRemindersEdgeAction(
             callback,
           );
         }
-        const task = await options.runner.schedule({
+        const scheduled = await options.runner.scheduleWithResult({
           kind: "reminder",
           promptInstructions: body,
           trigger,
@@ -324,12 +379,24 @@ export function createSharedRemindersEdgeAction(
           metadata: { delivery },
           executionProfile: "notify-only",
         });
-        const text = `Reminder set for ${taskSummary(task)}`;
+        const text = scheduled.replayed
+          ? `Reminder already set for ${taskSummary(scheduled.task)}`
+          : `Reminder set for ${taskSummary(scheduled.task)}`;
+        const receipt = creationReceipt(scheduled);
         await callback?.({ text });
         return {
           success: true,
           text,
-          data: { actionName: "REMINDERS", operation, task },
+          data: {
+            actionName: "REMINDERS",
+            operation,
+            task: scheduled.task,
+            replayed: scheduled.replayed,
+          },
+          verifiedUserFacing: true,
+          userFacingText: text,
+          effectReceipts: [receipt],
+          userFacingEffectReceiptIds: [receipt.receiptId],
         };
       }
 

--- a/plugins/plugin-scheduling/src/shared-reminders.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.ts
@@ -247,13 +247,7 @@ export function createSharedRemindersEdgeAction(
       "SNOOZE_REMINDER",
       "DISMISS_REMINDER",
     ],
-    tags: [
-      "resource:scheduled-item",
-      "capability:read",
-      "capability:write",
-      "effect:idempotent",
-      "effect:receipt-required",
-    ],
+    tags: ["resource:scheduled-item", "capability:read", "capability:write"],
     contexts: ["reminders", "general"],
     roleGate: { minRole: "GUEST" },
     description:


### PR DESCRIPTION
Fixes #20312.

## What changed

- returns a canonical scheduling result with a durable creation receipt and replay status
- stores a server-owned `schedulingCreationReceipt` anchor in the authoritative task row in the same task write
- deterministically derives a tenant-safe creation-log identity, then idempotently reconciles the canonical `scheduled` log
- retries safely after post-task log failure and concurrent same-key creation
- keeps raw creation logs out of 90-day rollup so replay identity remains durable
- limits strict action-level receipt/idempotency semantics to create results; snooze/complete/dismiss are not globally mislabeled retry-safe

## Recovery contract

Task persistence and log persistence are separate storage calls, so the task row is the durable authority. A log append failure fails closed on the first call; retry reconstructs the anchored receipt, ensures exactly one canonical log, and returns a replayed no-op. Same-key races converge on one task and one receipt. Existing pre-anchor tasks remain compatible through their existing scheduled log.

## Exact-head validation

- shared reminder + state-log + runner + real PGlite receipt suites: 94/94, 264 assertions
- broader scheduling suite before the final disjoint rebase: 371/371
- core effect/egress: 64/64
- genuine Shared AgentRuntime: 7/7
- Workerd Shared runtime: 3 pass, 1 opt-in live-search skip
- plugin-scheduling typecheck: pass
- Cloud shared/API typechecks and production Worker dry bundle: pass before the byte-equivalent rebase
- exact seven-file Biome and `git diff --check`: pass
- no deploy, provider send, environment approval, or secret mutation performed

The earlier live Cerebras/PGlite evidence is authentic but was captured on the pre-repair source head. This PR is draft until exact-head live evidence is restamped and hosted checks finish.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@599771c174a007f4b989838f66874e6061d59127
Attribution status: self-reported
— [codex-root/shared-reminders]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@599771c174a007f4b989838f66874e6061d59127"} -->

<!-- evidence-head:e0a93af3abb28ecddb46e72509d47f0276a09f16 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend and runtime behavior; no UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend and runtime behavior; no UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered interaction surface changed

<!-- evidence-row:backend-logs -->
- [x] [20315-exact-head-backend-logs.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20315-exact-head-backend-logs.json)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed

<!-- evidence-row:llm-trajectory -->
- [x] [20315-exact-head-live-cerebras-trajectory.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20315-exact-head-live-cerebras-trajectory.json)

<!-- evidence-row:domain-artifacts -->
- [x] [20315-exact-head-domain-artifacts.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20315-exact-head-domain-artifacts.json)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed



<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@599771c174a007f4b989838f66874e6061d59127:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported




