### PR TITLE
fix(pa): F33 disconnect confirm gate + F37 duplicate-title disambiguation

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/connector.ts
+++ b/plugins/plugin-personal-assistant/src/actions/connector.ts
@@ -185,6 +185,14 @@ function messageText(message: Memory): string {
   return typeof text === "string" ? text : "";
 }
 
+/** Explicit-confirmation cues for the destructive `disconnect` subaction.
+ * Mirrors the LifeOps confirmation-cue dialect (life.ts) so the assistant
+ * keeps one confirmation vocabulary: a bare "disconnect google" ask carries
+ * no cue and gets a question back; "yes" / "yes, disconnect it" /
+ * "disconnect google, I'm sure" carries one and executes. */
+const CONNECTOR_DISCONNECT_CONFIRM_RE =
+  /\b(?:yes|yep|yeah|confirm|confirmed|go ahead|do it|proceed|i'?m sure)\b/i;
+
 /**
  * Short plugin id for the setup card. Message connectors resolve through the
  * existing source mapping; registry-backed connectors use their kind directly
@@ -1622,6 +1630,29 @@ export const connectorAction: Action & {
           actionName: ACTION_NAME,
           error: "MISSING_ACTION",
           validSubactions: [...VALID_SUBACTIONS],
+        },
+      };
+    }
+    // F33: `disconnect` revokes a live grant — destructive and not instantly
+    // reversible (re-auth may need the owner's device). It previously executed
+    // on the FIRST ask with no gate (live matrix F33). Require an explicit
+    // confirmation cue in the owner's own message: the bare ask gets a
+    // question back; the follow-up ("yes" / "yes, disconnect it") re-invokes
+    // with the cue present and executes.
+    if (
+      subaction === "disconnect" &&
+      !CONNECTOR_DISCONNECT_CONFIRM_RE.test(messageText(message))
+    ) {
+      const connectorLabel = params.connector ?? "that connector";
+      return {
+        success: false,
+        text: `Disconnecting ${connectorLabel} revokes its access grant, and restoring it may require re-authenticating from your device. Confirm and I'll disconnect it.`,
+        data: {
+          actionName: ACTION_NAME,
+          connector: params.connector,
+          subaction,
+          requiresConfirmation: true,
+          awaitingUserInput: true,
         },
       };
     }

--- a/plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts
@@ -848,41 +848,16 @@ describe("runLifeOperationHandler clarification contract", () => {
       return "";
     });
 
-    const preview = await runLifeOperationHandler(
+    // A fresh, fully-explicit undated ask saves in ONE turn (nubs-directed
+    // contract change): the owner already stated the item AND its
+    // undatedness, so a preview would echo back exactly what they just said.
+    const result = await runLifeOperationHandler(
       runtime,
       makeMessage("Add buy milk as a todo with no due date."),
       undefined,
       {
         parameters: {
           action: "create",
-          intent: "Add buy milk as a todo with no due date.",
-          ownerSurface: "OWNER_TODOS",
-        },
-      } as HandlerOptions,
-    );
-
-    expect(preview).toMatchObject({
-      success: false,
-      data: {
-        deferred: true,
-        saved: false,
-        requiresConfirmation: true,
-        lifeDraft: { request: { reminderPlan: null } },
-      },
-    });
-    expect(serviceState.createCalls).toHaveLength(0);
-
-    const result = await runLifeOperationHandler(
-      runtime,
-      {
-        ...makeMessage("Yes, save that todo."),
-        id: "00000000-0000-0000-0000-000000000005",
-      } as Memory,
-      undefined,
-      {
-        parameters: {
-          action: "create",
-          confirmed: true,
           intent: "Add buy milk as a todo with no due date.",
           ownerSurface: "OWNER_TODOS",
         },
@@ -964,11 +939,10 @@ describe("runLifeOperationHandler clarification contract", () => {
         } as HandlerOptions,
       );
 
-      expect(result).toMatchObject({
-        success: false,
-        data: { deferred: true, saved: false, requiresConfirmation: true },
-      });
-      expect(serviceState.createCalls).toHaveLength(0);
+      expect(result.success).toBe(true);
+      expect(serviceState.createCalls).toEqual([
+        expect.objectContaining({ cadence: { kind: "unscheduled" } }),
+      ]);
     },
   );
 
@@ -1014,12 +988,12 @@ describe("runLifeOperationHandler clarification contract", () => {
 
     const preview = await runLifeOperationHandler(
       runtime,
-      makeMessage("Add buy milk with no due date."),
+      makeMessage("Add buy milk with no due date. Preview it first."),
       undefined,
       {
         parameters: {
           action: "create",
-          intent: "Add buy milk with no due date.",
+          intent: "Add buy milk with no due date. Preview it first.",
           ownerSurface: "OWNER_TODOS",
         },
       } as HandlerOptions,
@@ -1107,12 +1081,12 @@ describe("runLifeOperationHandler clarification contract", () => {
 
     const preview = await runLifeOperationHandler(
       runtime,
-      makeMessage("Add buy milk with no due date."),
+      makeMessage("Add buy milk with no due date. Preview it first."),
       undefined,
       {
         parameters: {
           action: "create",
-          intent: "Add buy milk with no due date.",
+          intent: "Add buy milk with no due date. Preview it first.",
           ownerSurface: "OWNER_TODOS",
         },
       } as HandlerOptions,

--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -1038,10 +1038,17 @@ function resolveDuplicateByTimeHint(
     const clockTokens =
       summary.toLowerCase().match(/\d{1,2}(?::\d{2})?\s*(?:am|pm)/g) ?? [];
     return clockTokens.some((token) => {
-      const flexible = token
-        .replace(/\s+/g, "\\s*")
-        .replace(/:/g, "[:. ]?");
-      return new RegExp(`\\b${flexible}\\b`).test(normalizedOwner);
+      const variants = [token];
+      // "10:00 am" and the owner's "10am" are the same clock time — an
+      // on-the-hour summary also matches its bare-hour form.
+      const onTheHour = token.match(/^(\d{1,2}):00\s*(am|pm)$/);
+      if (onTheHour) variants.push(`${onTheHour[1]} ${onTheHour[2]}`);
+      return variants.some((variant) => {
+        const flexible = variant
+          .replace(/\s+/g, "\\s*")
+          .replace(/:/g, "[:. ]?");
+        return new RegExp(`\\b${flexible}\\b`).test(normalizedOwner);
+      });
     });
   });
   return hits.length === 1 ? (hits.at(0) ?? null) : null;

--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -946,7 +946,7 @@ function resolveDefinitionInRecords(
   if (exactMatches.length > 1) {
     return {
       match: null,
-      ambiguousCandidates: exactMatches.map((entry) => entry.definition.title),
+      ambiguousCandidates: exactMatches.map(definitionDisambiguationLabel),
     };
   }
   const substringMatches = defs.filter((entry) =>
@@ -961,9 +961,7 @@ function resolveDefinitionInRecords(
   if (substringMatches.length > 1) {
     return {
       match: null,
-      ambiguousCandidates: substringMatches.map(
-        (entry) => entry.definition.title,
-      ),
+      ambiguousCandidates: substringMatches.map(definitionDisambiguationLabel),
     };
   }
   const targetTokens = new Set(tokenizeTitle(target));
@@ -995,7 +993,7 @@ function resolveDefinitionInRecords(
   if (bestMatches.length >= 1) {
     return {
       match: null,
-      ambiguousCandidates: bestMatches.map((entry) => entry.definition.title),
+      ambiguousCandidates: bestMatches.map(definitionDisambiguationLabel),
     };
   }
   return { match: null, ambiguousCandidates: [] };
@@ -1012,6 +1010,41 @@ async function resolveDefinition(
     domain ? e.definition.domain === domain : true,
   );
   return resolveDefinitionInRecords(defs, target, destructive);
+}
+
+/** "title — cadence" disambiguation label so identical-title duplicates are
+ * tellable-apart in a clarification list (live matrix F37: two "water the
+ * ficus" reminders rendered as two identical lines with no times — an
+ * unanswerable question). */
+function definitionDisambiguationLabel(entry: LifeOpsDefinitionRecord): string {
+  const when = summarizeCadence(entry.definition.cadence)?.trim();
+  return when && when.length > 0
+    ? `${entry.definition.title} — ${when}`
+    : entry.definition.title;
+}
+
+/** Resolve a duplicate-title tie by a clock hint in the owner's own words:
+ * each candidate's cadence summary contributes its clock tokens ("10am",
+ * "5:30 pm"), and the tie resolves only when EXACTLY ONE candidate's tokens
+ * appear in the owner text — zero or multiple hits keep the clarification
+ * ask (destructive ops never act on a guess). */
+function resolveDuplicateByTimeHint(
+  candidates: LifeOpsDefinitionRecord[],
+  ownerText: string,
+): LifeOpsDefinitionRecord | null {
+  const normalizedOwner = ownerText.toLowerCase().replace(/\s+/g, " ");
+  const hits = candidates.filter((entry) => {
+    const summary = summarizeCadence(entry.definition.cadence) ?? "";
+    const clockTokens =
+      summary.toLowerCase().match(/\d{1,2}(?::\d{2})?\s*(?:am|pm)/g) ?? [];
+    return clockTokens.some((token) => {
+      const flexible = token
+        .replace(/\s+/g, "\\s*")
+        .replace(/:/g, "[:. ]?");
+      return new RegExp(`\\b${flexible}\\b`).test(normalizedOwner);
+    });
+  });
+  return hits.length === 1 ? (hits.at(0) ?? null) : null;
 }
 
 async function resolveDefinitionForMutation(
@@ -1036,11 +1069,13 @@ async function resolveDefinitionForMutation(
     };
   }
   if (explicitlyNamed.length > 1) {
+    const byTimeHint = resolveDuplicateByTimeHint(explicitlyNamed, ownerText);
+    if (byTimeHint) {
+      return { match: byTimeHint, ambiguousCandidates: [] };
+    }
     return {
       match: null,
-      ambiguousCandidates: explicitlyNamed.map(
-        (entry) => entry.definition.title,
-      ),
+      ambiguousCandidates: explicitlyNamed.map(definitionDisambiguationLabel),
     };
   }
 
@@ -1068,9 +1103,13 @@ async function resolveDefinitionForMutation(
     };
   }
   if (bestMatches.length >= 1) {
+    const byTimeHint = resolveDuplicateByTimeHint(bestMatches, ownerText);
+    if (byTimeHint) {
+      return { match: byTimeHint, ambiguousCandidates: [] };
+    }
     return {
       match: null,
-      ambiguousCandidates: bestMatches.map((entry) => entry.definition.title),
+      ambiguousCandidates: bestMatches.map(definitionDisambiguationLabel),
     };
   }
   return resolveDefinition(service, target, domain, destructive);
@@ -3074,6 +3113,13 @@ function shouldAdoptPlannerCadence(args: {
   return true;
 }
 
+/** Explicit deferred-consent request: the owner asked to SEE it before it is
+ * written ("preview it first", "do not save until I confirm", "don't save it
+ * yet", "ask me before"). A user-requested preview outranks every
+ * crisp-ask immediate-save exemption below. */
+const LIFE_TEXT_REQUESTS_PREVIEW_RE =
+  /\b(?:preview\b[^.!?]{0,40}\bfirst|(?:do not|don'?t)\s+(?:save|add|create|write)\b[^.!?]{0,40}\b(?:until|unless|before)\b|(?:until|unless|before)\s+i\s+(?:confirm|approve|say so)|(?:don'?t|do not)\s+(?:save|add|create|write)\s+(?:it\s+)?yet\b|ask\s+(?:me\s+)?(?:first|before))/i;
+
 function shouldRequireLifeCreateConfirmation(args: {
   confirmed: boolean;
   messageSource: string | undefined;
@@ -3081,9 +3127,19 @@ function shouldRequireLifeCreateConfirmation(args: {
   cadence?: LifeOpsCadence;
   multiStep?: boolean;
   explicitUndated?: boolean;
+  previewRequested?: boolean;
 }): boolean {
   if (args.messageSource === "autonomy") {
     return false;
+  }
+  // An explicit "preview first / don't save until I confirm" in the owner's
+  // own words defeats BOTH immediate-save exemptions below AND the extracted
+  // `confirmed` flag itself: a future-consent clause means consent has NOT
+  // been given on THIS turn, even when the extractor (mis)reads the sentence
+  // as a confirmation. The follow-up turn's plain "yes, save it" carries no
+  // such clause and confirms normally.
+  if (args.previewRequested === true) {
+    return true;
   }
   // Crisp single dated asks save immediately (#16935); a multi-milestone ask
   // ("reminders for outline, rough draft, and final proofread") collapses into
@@ -4697,7 +4753,14 @@ async function runLifeOperationHandlerInner(
           requestKind: timedRequestKind,
           cadence: definitionDraft.request.cadence,
           multiStep: llmPlan?.multiStep === true,
-          explicitUndated: textStatesExplicitUndatedTodo(currentText),
+          // Creates only: an EDIT that re-states undatedness keeps the
+          // two-phase preview (the #20182 draft-lifecycle contract) — the
+          // skip is for the owner's fresh "add a todo: X, no deadline" ask,
+          // where the preview would echo back exactly what they just said.
+          explicitUndated:
+            !editingDeferredDefinitionDraft &&
+            textStatesExplicitUndatedTodo(currentText),
+          previewRequested: LIFE_TEXT_REQUESTS_PREVIEW_RE.test(currentText),
         })
       ) {
         const draftLeadSteps = (
@@ -5089,6 +5152,9 @@ async function runLifeOperationHandlerInner(
             typeof message.content.source === "string"
               ? message.content.source
               : undefined,
+          previewRequested: LIFE_TEXT_REQUESTS_PREVIEW_RE.test(
+            messageText(message),
+          ),
         })
       ) {
         if (


### PR DESCRIPTION
## What

Box-carry upstream of watchtower's fix-all round-3 pair (authorship preserved from the live checkout; nubs's fix-all order resolved both design questions):

- **F33**: `CONNECTOR` disconnect now passes through a confirm gate — a disconnect ask gets an explicit are-you-sure turn before the account is detached.
- **F37**: identical-title items get cadence-labeled disambiguation plus a duplicate time-hint resolver ("the 9am one" resolves), with a preview-request override so immediate-save exemptions stay honest; follow-up commit makes on-the-hour clock summaries ("9:00") match their bare-hour form ("9am") in the resolver.

## Evidence

| Check | Result |
|---|---|
| `life-reminder-datetime` + deferred-draft + undated-intent + review-definitions | 210/210 ✅ |
| connector payload-fuzz + config-card suites | 29/29 ✅ |
| Biome on touched files | ✅ |
| Live proof | both features proven on box by watchtower (fix-all batch receipt at HQ, 01:41) before carry |

Same flow as #20219/#20220/#20246–#20250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)