### PR TITLE
fix(scripts): serialize every build-lock mutation through a kernel-arbitrated mutex

### DIFF
--- a/packages/scripts/__tests__/with-package-build-lock.test.ts
+++ b/packages/scripts/__tests__/with-package-build-lock.test.ts
@@ -370,6 +370,91 @@ describe("with-package-build-lock", () => {
     expect(existsSync(lockPath)).toBe(false);
   });
 
+  test("keeps a third contender out while a paused takeover holds the mutex (#20265)", async () => {
+    // The review-reproduced interleaving on #19356: stale contender A pauses
+    // immediately before its quarantine rename, live peer B replaces the
+    // stale lock and starts its command, A's resumed rename then moves B's
+    // LIVE lock and empties the canonical path, and a third contender C wins
+    // open(lockPath, "wx") while B is still active. With every canonical-path
+    // mutation holding the kernel-arbitrated mutex, B and C must instead wait
+    // out A's pause, and no two commands may ever overlap.
+    const packageKey = uniquePackageKey("three-party");
+    const lockPath = lockPathFor(packageKey);
+    mkdirSync(path.dirname(lockPath), { recursive: true });
+    writeFileSync(
+      lockPath,
+      `${JSON.stringify({ pid: 2_147_483_647, ownerId: "dead", createdAt: new Date().toISOString() })}\n`,
+    );
+    const evidenceDir = mkdtempSync(path.join(tmpdir(), "eliza-lock-three-"));
+    cleanupPaths.add(evidenceDir);
+    const readyPath = path.join(evidenceDir, "rename-ready");
+    const releasePath = path.join(evidenceDir, "rename-release");
+    const readyAfterPath = path.join(evidenceDir, "rename-ready-after");
+    const releaseAfterPath = path.join(evidenceDir, "rename-release-after");
+    const preloadPath = path.join(evidenceDir, "rename-barrier.mjs");
+    const activePath = path.join(evidenceDir, "active");
+    const overlapPath = path.join(evidenceDir, "overlap");
+    // Two-stage barrier: pause immediately before AND immediately after the
+    // wrapper's actual fs.rename, matching the interleaving reproduced in the
+    // #19356 review. Marker files persist, so later renames pass straight
+    // through both stages.
+    writeFileSync(
+      preloadPath,
+      `import fs from "node:fs/promises";\nconst originalRename=fs.rename.bind(fs);\nconst pause=async(ready,release)=>{await fs.writeFile(ready,"ready");while(true){try{await fs.access(release);break;}catch(error){/* error-policy:J3 a missing release marker remains an explicit blocked state. */if(error?.code!=="ENOENT")throw error;}await new Promise(resolve=>setTimeout(resolve,5));}};\nfs.rename=async(source,destination)=>{if(source===process.env.ELIZA_BUILD_LOCK_TEST_TARGET){await pause(process.env.ELIZA_BUILD_LOCK_TEST_READY,process.env.ELIZA_BUILD_LOCK_TEST_RELEASE);const result=await originalRename(source,destination);await pause(process.env.ELIZA_BUILD_LOCK_TEST_READY_AFTER,process.env.ELIZA_BUILD_LOCK_TEST_RELEASE_AFTER);return result;}return originalRename(source,destination);};\n`,
+    );
+    const childCode = `const fs=require("node:fs");const active=${JSON.stringify(activePath)};const overlap=${JSON.stringify(overlapPath)};if(fs.existsSync(active))fs.writeFileSync(overlap,"overlap");fs.writeFileSync(active,String(process.pid));setTimeout(()=>fs.rmSync(active,{force:true}),800);`;
+
+    const pausedTakeover = spawnWrapper(
+      packageKey,
+      [NODE_BIN, "-e", childCode],
+      "1",
+      {
+        NODE_OPTIONS: `--import=${preloadPath}`,
+        ELIZA_BUILD_LOCK_TEST_TARGET: lockPath,
+        ELIZA_BUILD_LOCK_TEST_READY: readyPath,
+        ELIZA_BUILD_LOCK_TEST_RELEASE: releasePath,
+        ELIZA_BUILD_LOCK_TEST_READY_AFTER: readyAfterPath,
+        ELIZA_BUILD_LOCK_TEST_RELEASE_AFTER: releaseAfterPath,
+      },
+    );
+    const pausedResult = collect(pausedTakeover);
+    await waitForPath(readyPath);
+
+    // A is paused before its rename. Under the mutex protocol B must wait out
+    // the pause; under the broken protocol B completes its own takeover and
+    // is mid-command when A's resumed rename moves B's live lock away.
+    const livePeer = spawnWrapper(packageKey, [NODE_BIN, "-e", childCode], "1");
+    const livePeerResult = collect(livePeer);
+    await Bun.sleep(250);
+    writeFileSync(releasePath, "release");
+    await waitForPath(readyAfterPath);
+
+    // A is now frozen between its rename and its validate/restore step. With
+    // the mutex, C just queues; without it, C wins open(lockPath, "wx") on
+    // the emptied canonical path while B's command is still active, and A's
+    // later restoration hits EEXIST and strands B in quarantine.
+    const thirdContender = spawnWrapper(
+      packageKey,
+      [NODE_BIN, "-e", childCode],
+      "1",
+    );
+    await Bun.sleep(250);
+    writeFileSync(releaseAfterPath, "release");
+
+    const [pausedOutcome, peerOutcome, thirdOutcome] = await Promise.all([
+      pausedResult,
+      livePeerResult,
+      collect(thirdContender),
+    ]);
+
+    expect(pausedOutcome.code).toBe(0);
+    expect(pausedOutcome.stderr).toBe("");
+    expect(peerOutcome.code).toBe(0);
+    expect(thirdOutcome.code).toBe(0);
+    expect(existsSync(overlapPath)).toBe(false);
+    expect(existsSync(lockPath)).toBe(false);
+  }, 20_000);
+
   test("an old owner cleanup preserves a replacement lock", () => {
     const packageKey = uniquePackageKey("replacement");
     const lockPath = lockPathFor(packageKey);

--- a/packages/scripts/with-package-build-lock.mjs
+++ b/packages/scripts/with-package-build-lock.mjs
@@ -3,11 +3,23 @@
  * Serializes builds that write a package's shared output directory. Lock
  * ownership is process-bound, stale takeover is quarantined before deletion,
  * and command failures release only the lock created by this wrapper.
+ *
+ * Every mutation of the canonical lock path — acquisition, stale takeover, and
+ * owner cleanup — happens while holding a per-lock mutex implemented as a
+ * loopback TCP listen. The kernel arbitrates that bind: it cannot be stolen by
+ * another process (there is no file to unlink or rename), it is released
+ * automatically when its holder dies (so a SIGKILLed takeover never leaves a
+ * stale guard to reclaim), and a paused-but-alive holder keeps it (so peers
+ * wait instead of misclassifying a stopped process as dead). This is what
+ * keeps a snapshot-validated takeover bound to the inode it validated: no
+ * contender can replace or acquire the canonical path between revalidation,
+ * the quarantine rename, and any restoration (#20265).
  */
 
 import { execFile, spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
+import net from "node:net";
 import path from "node:path";
 import { promisify } from "node:util";
 import { findWorkspaceRoot } from "./lib/repo-root.mjs";
@@ -15,6 +27,12 @@ import { findWorkspaceRoot } from "./lib/repo-root.mjs";
 const execFileAsync = promisify(execFile);
 const DEFAULT_STALE_AFTER_MS = 1_800_000;
 const WAIT_MAX_MS = 1_000;
+// 24000-32767 sits above the well-known range and below the default ephemeral
+// ranges of both Linux (32768+) and macOS/Windows (49152+), minimizing
+// collisions with transient client sockets.
+const MUTEX_PORT_BASE = 24_000;
+const MUTEX_PORT_SPAN = 8_768;
+const MUTEX_ACQUIRE_TIMEOUT_MS = 60_000;
 
 const [packageDirArg, separator, ...command] = process.argv.slice(2);
 
@@ -72,6 +90,97 @@ function parseStaleAfterMs(raw) {
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function fnv1a(value) {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash;
+}
+
+function parseMutexPort(raw) {
+  if (!/^[1-9]\d*$/u.test(raw)) {
+    throw new TypeError(
+      `ELIZA_PACKAGE_BUILD_LOCK_MUTEX_PORT must be a decimal port between 1024 and 65535; received ${JSON.stringify(raw)}`,
+    );
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < 1024 || value > 65_535) {
+    throw new TypeError(
+      `ELIZA_PACKAGE_BUILD_LOCK_MUTEX_PORT must be a decimal port between 1024 and 65535; received ${JSON.stringify(raw)}`,
+    );
+  }
+  return value;
+}
+
+let resolvedMutexPort = null;
+function resolveMutexPort() {
+  if (resolvedMutexPort === null) {
+    resolvedMutexPort =
+      process.env.ELIZA_PACKAGE_BUILD_LOCK_MUTEX_PORT !== undefined
+        ? parseMutexPort(process.env.ELIZA_PACKAGE_BUILD_LOCK_MUTEX_PORT)
+        : MUTEX_PORT_BASE + (fnv1a(lockPath) % MUTEX_PORT_SPAN);
+  }
+  return resolvedMutexPort;
+}
+
+function listenOnce(server, port) {
+  return new Promise((resolve, reject) => {
+    const onError = (error) => {
+      server.removeListener("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.removeListener("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen({ host: "127.0.0.1", port, exclusive: true });
+  });
+}
+
+/**
+ * Runs `mutate` while holding this lock's kernel-arbitrated mutex. Contention
+ * shows up as EADDRINUSE from a live (possibly paused) peer and is retried
+ * with backoff; anything else — including a persistently occupied port from an
+ * unrelated service — surfaces as an actionable failure rather than a silent
+ * unserialized mutation.
+ */
+async function withLockMutex(mutate) {
+  const mutexPort = resolveMutexPort();
+  const deadline = Date.now() + MUTEX_ACQUIRE_TIMEOUT_MS;
+  let waitMs = 25;
+  while (true) {
+    const server = net.createServer();
+    server.unref();
+    try {
+      await listenOnce(server, mutexPort);
+    } catch (error) {
+      server.close();
+      if (error?.code !== "EADDRINUSE" && error?.code !== "EACCES") {
+        throw error;
+      }
+      if (Date.now() >= deadline) {
+        // error-policy:J2 a saturated mutex port becomes an actionable typed failure.
+        throw new Error(
+          `Could not acquire the build-lock mutex on 127.0.0.1:${mutexPort} within ${MUTEX_ACQUIRE_TIMEOUT_MS}ms; if an unrelated service owns that port, set ELIZA_PACKAGE_BUILD_LOCK_MUTEX_PORT to a free port`,
+          { cause: error },
+        );
+      }
+      await sleep(waitMs);
+      waitMs = Math.min(waitMs * 1.5, WAIT_MAX_MS);
+      continue;
+    }
+    try {
+      return await mutate();
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  }
 }
 
 function parseMetadata(raw) {
@@ -171,23 +280,35 @@ async function restoreChangedLock(quarantinePath, movedSnapshot) {
 }
 
 async function quarantineAndRemove(snapshot, reason) {
-  const quarantinePath = `${lockPath}.${reason}-${process.pid}-${randomUUID()}`;
-  try {
-    await fs.rename(lockPath, quarantinePath);
-  } catch (error) {
-    // error-policy:J3 a peer removal invalidates this stale snapshot explicitly.
-    if (error?.code === "ENOENT") return false;
-    throw error;
-  }
+  return withLockMutex(async () => {
+    // Revalidate under the mutex: if a peer's takeover replaced the snapshot
+    // while this contender was waiting (or paused), the live replacement is
+    // seen HERE, before any mutation, and the takeover aborts without touching
+    // it. Between this check and the rename the canonical path is immutable:
+    // takeover and acquisition both require the mutex this transaction holds,
+    // and cleanup only runs in the live owner of the canonical content, which
+    // this stale snapshot does not have.
+    const current = await readLockSnapshot();
+    if (!sameSnapshot(snapshot, current)) return false;
 
-  const movedSnapshot = await readLockSnapshot(quarantinePath);
-  if (!sameSnapshot(snapshot, movedSnapshot)) {
-    await restoreChangedLock(quarantinePath, movedSnapshot);
-    return false;
-  }
+    const quarantinePath = `${lockPath}.${reason}-${process.pid}-${randomUUID()}`;
+    try {
+      await fs.rename(lockPath, quarantinePath);
+    } catch (error) {
+      // error-policy:J3 a peer removal invalidates this stale snapshot explicitly.
+      if (error?.code === "ENOENT") return false;
+      throw error;
+    }
 
-  await removePath(quarantinePath);
-  return true;
+    const movedSnapshot = await readLockSnapshot(quarantinePath);
+    if (!sameSnapshot(snapshot, movedSnapshot)) {
+      await restoreChangedLock(quarantinePath, movedSnapshot);
+      return false;
+    }
+
+    await removePath(quarantinePath);
+    return true;
+  });
 }
 
 async function removeStaleLock(staleAfterMs) {
@@ -206,24 +327,30 @@ async function removeStaleLock(staleAfterMs) {
 }
 
 async function writeOwnedLock() {
-  const handle = await fs.open(lockPath, "wx", 0o600);
-  try {
-    await handle.writeFile(
-      `${JSON.stringify(
-        {
-          pid: process.pid,
-          ownerId,
-          command,
-          createdAt: new Date().toISOString(),
-        },
-        null,
-        2,
-      )}\n`,
-    );
-    await handle.sync();
-  } finally {
-    await handle.close();
-  }
+  // Acquisition also holds the mutex so a fresh contender cannot slip into
+  // the brief window a mutex-holding takeover leaves the canonical path
+  // absent — that slip is what let a third contender in while a moved live
+  // owner still awaited restoration (#20265).
+  await withLockMutex(async () => {
+    const handle = await fs.open(lockPath, "wx", 0o600);
+    try {
+      await handle.writeFile(
+        `${JSON.stringify(
+          {
+            pid: process.pid,
+            ownerId,
+            command,
+            createdAt: new Date().toISOString(),
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+  });
 }
 
 async function acquireLock(staleAfterMs) {


### PR DESCRIPTION
Closes #20265.

Closes #20265.

## What breaks today

`quarantineAndRemove` validates a snapshot, then `fs.rename(lockPath, quarantinePath)` — but rename moves whatever inode the canonical path holds *at that moment*, not the inode that was validated. The #19356 review reproduced the resulting third-contender interleaving against real wrapper processes: stale contender A pauses before its rename; live peer B replaces the stale lock and starts its command; A's resumed rename moves **B's live lock** and empties the canonical path; contender C wins `open(lockPath, "wx")` while B is still running; A's restoration then hits `EEXIST`, exits 1, and strands B's lock in quarantine. Two builds write the same output directory concurrently.

## Why not another fs-only protocol

This is round 5 on this file, and every prior round narrowed the window instead of closing it, because with a pause-anywhere adversary there is no portable way to bind "rename exactly the inode I validated" atomically:

- any check-then-act sequence on the canonical path can be paused between the check and the act;
- a guard **file** recurses the same bug one level down — removing a "stale" guard can remove a live replacement guard, and guard theft collapses the exclusion, resurrecting the original interleaving;
- a guard file that is never force-removed deadlocks takeover permanently when its holder is SIGKILLed between creation and cleanup.

## The mechanism

Every mutation of the canonical lock path — `wx` acquisition, stale takeover, and owner cleanup — now runs while holding a per-lock mutex implemented as a loopback TCP listen (`127.0.0.1`, port derived from the lock path via FNV-1a into 24000–32767, overridable with `ELIZA_PACKAGE_BUILD_LOCK_MUTEX_PORT`). The kernel arbitrates the bind, which supplies exactly the three properties the file-based schemes lack:

1. **Unstealable** — there is no file to unlink or rename; a second bind gets `EADDRINUSE`.
2. **Death-releasing** — the port frees the instant its holder dies, including SIGKILL mid-takeover. No staleness heuristic exists at all.
3. **Pause-correct** — a stopped-but-alive holder keeps the port, so peers wait, rather than misclassifying a paused process as dead (the misclassification that TTL/heuristic guards are built on).

Takeover revalidates its snapshot **under the mutex** before renaming, so a peer's completed replacement is observed before any mutation and the takeover aborts without touching it. Between that revalidation and the rename the canonical path is immutable: takeover and acquisition both require the mutex this transaction holds, and cleanup only runs inside the live owner of the canonical content — which a stale (dead-pid) snapshot by definition has no live owner to run in. The restoration path is retained for out-of-protocol mutations and can no longer lose an acquisition race mid-restore, because acquisition itself now queues on the mutex — this is the "new contenders excluded for the complete move/validation/restoration transaction" the #19356 review asked for, implemented literally.

Port-range choice: 24000–32767 sits above the well-known range and below the default ephemeral ranges of Linux (32768+) and macOS/Windows (49152+). A persistent collision with an unrelated service surfaces after a bounded wait as an actionable error naming the port and the override variable, never as a silent unserialized mutation.

## The regression test

`keeps a third contender out while a paused takeover holds the mutex (#20265)` re-implements the review's two-stage harness: a `NODE_OPTIONS` preload pauses contender A immediately before **and** immediately after its actual `fs.rename`, a live peer B arrives mid-pause and holds its command active for 800ms, and contender C is spawned while A is frozen between its rename and its validate/restore step. On the previous protocol this deterministically reproduces the review's outcome (overlap marker created while B is active; A exits 1 with the moved owner preserved in quarantine). With the mutex, B and C queue behind A's pause, all three serialize, the overlap marker is never created, and every wrapper exits 0. The suite's nine existing tests — including the single-stage replacement-preservation barrier and the directory-form dead-owner race — pass unchanged.

## Coordination

- yizhengzhou filed #20265 (thank you for the precise interleaving writeup); no competing PR existed at claim time or at this PR's open (rechecked via file-overlap scan).
- The stranded-quarantine litter a SIGKILLed takeover can leave under `.turbo/build-locks/` is pre-existing behavior and unchanged here; quarantine names remain unique so nothing collides.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Evidence

<!-- evidence-head:5a73793381680141ba795c2a5eb0e90581ccc98e -->

<!-- evidence-row:before-screenshots -->
N/A - build-lock wrapper script; no rendered UI surface in the diff.

<!-- evidence-row:after-screenshots -->
N/A - build-lock wrapper script; no rendered UI surface in the diff.

<!-- evidence-row:walkthrough-video -->
N/A - non-UI process-coordination change; behavior is proven by the deterministic multi-process regression in the domain-artifacts row.

<!-- evidence-row:backend-logs -->
Full suite at this head — nine pre-existing tests plus the new three-party regression, all against real wrapper processes:

```
$ bun test packages/scripts/__tests__/with-package-build-lock.test.ts   # at 5a73793381
(pass) rejects malformed stale thresholds before acquiring a lock
(pass) accepts the unset default and complete positive safe integers
(pass) rejects workspace-root and escaping package keys without touching other locks
(pass) keeps a live owner exclusive after the stale-age threshold
(pass) serializes simultaneous takeovers of a directory-style dead-owner lock
(pass) preserves a live replacement installed before atomic stale takeover
(pass) waits for the age bound before reclaiming incomplete metadata
(pass) releases the lock after a command-start failure
(pass) keeps a third contender out while a paused takeover holds the mutex (#20265)
(pass) an old owner cleanup preserves a replacement lock
 10 pass / 0 fail / 109 expect() calls — Ran 10 tests across 1 file. [9.91s]
```

Root `bun run verify`: the Turbo phase passes 351/351 tasks (including this package's suite, typecheck, and lint). The trailing root audit `audit:workflow-triggers` fails on current develop itself — `.github/workflows/ui-story-gate.yml` carries a `pull_request` trigger on the develop base (verified byte-identical on `origin/develop`, which also carries a "wip(ci): workflow consolidation in-progress snapshot" commit) — an unrelated, pre-existing develop-side blocker not touched by this diff:

```
Tasks:    351 successful, 351 total
Error: GitHub workflow triggers must not run for pull requests, and automated branch pushes must target develop only:
ui-story-gate.yml: forbidden pull-request event trigger: pull_request  (identical on origin/develop)
```

<!-- evidence-row:frontend-logs -->
N/A - no frontend surface; the wrapper is a Node CLI used by Turbo build tasks.

<!-- evidence-row:llm-trajectory -->
N/A - no agent/model behavior in scope; pure build-infrastructure concurrency fix.

<!-- evidence-row:domain-artifacts -->
The reviewer-prescribed regression, run both ways at this head. Against the previous protocol (this branch's test with `packages/scripts/with-package-build-lock.mjs` restored to `origin/develop`), the two-stage pause harness deterministically reproduces the #19356 review outcome — contender A exits 1 after moving the live peer's lock:

```
bun test v1.3.14 (d1632b29)

packages/scripts/__tests__/with-package-build-lock.test.ts:
445 |       pausedResult,
446 |       livePeerResult,
447 |       collect(thirdContender),
448 |     ]);
449 | 
450 |     expect(pausedOutcome.code).toBe(0);
                                     ^
error: expect(received).toBe(expected)

Expected: 0
Received: 1

      at <anonymous> (/Users/home/slop-cash/eliza/packages/scripts/__tests__/with-package-build-lock.test.ts:450:32)
(fail) with-package-build-lock > keeps a third contender out while a paused takeover holds the mutex (#20265) [1536.12ms]

 0 pass
 9 filtered out
 1 fail
 1 expect() calls
Ran 1 test across 1 file. [1.83s]
```

With the mutex protocol at this head, the same harness serializes all three wrappers (10-pass suite transcript in the backend-logs row; the three-party test passes in ~1.4s and an 8x repeat of the full suite passed 8/8). The lock file is removed at the end of every serialized run and the overlap marker is never created.

<!-- evidence-row:ocr-review -->
N/A - no rendered visual surface in this change.

---
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [kenjohnscreates]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01M03XHYG0T4MS3RMCA49TJHJQ","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-15T23:54:15.424Z","completed_at":"2026-08-16T02:05:49.736Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ02FuP7I_LN-J_iadT_q0j0Rj0Yugo5SJvOjhR_hrfw","device_key_id":"15e4c3effe5c8a2b2c22617596afd1044544026dfb99605709a677bf57050d3b","device_signature":"B1jLCJghhG69nURnFkjW85WQHADs8yS0H0tynfma-sf__rO5j1zKmvHxbajEQ_8u5Fm96rLZgu0Gkpn7-jB3Ag"}} -->
Attribution status: self-reported
— [kenjohnscreates]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza"} -->

