### PR TITLE
fix(scheduling): keep delivery membership JSON-safe

### DIFF
--- a/packages/core/src/security/trusted-delivery-audience.test.ts
+++ b/packages/core/src/security/trusted-delivery-audience.test.ts
@@ -11,6 +11,7 @@ import {
 	attestDeliveryAudienceFromCanonicalRoom,
 	disclosureGateFailure,
 	evaluateOwnerExclusiveDisclosure,
+	getTrustedDeliveryAudience,
 	OWNER_EXCLUSIVE_DISCLOSURE_GATE,
 	ownerExclusiveSuppressionNote,
 	registerRuntimeManagedInternalActor,
@@ -88,6 +89,17 @@ function message(overrides: Partial<Memory> = {}): Memory {
 }
 
 describe("trusted delivery audience", () => {
+	it("encodes canonical membership without PostgreSQL-forbidden NUL bytes", async () => {
+		const { runtime } = harness();
+		const turn = message();
+		await attestDeliveryAudienceFromCanonicalRoom(runtime, turn);
+		const audience = getTrustedDeliveryAudience(turn);
+
+		expect(audience?.membershipVersion).toBe(JSON.stringify([OWNER, AGENT]));
+		expect(audience?.membershipVersion).not.toContain("\u0000");
+		expect(() => JSON.parse(audience?.membershipVersion ?? "")).not.toThrow();
+	});
+
 	it("cannot be minted by body metadata or a JSON round trip", async () => {
 		const { runtime } = harness();
 		const original = message();

--- a/packages/core/src/security/trusted-delivery-audience.ts
+++ b/packages/core/src/security/trusted-delivery-audience.ts
@@ -272,7 +272,7 @@ function canonicalParticipants(participants: readonly UUID[]): UUID[] {
 }
 
 function membershipVersion(participants: readonly UUID[]): string {
-	return canonicalParticipants(participants).join("\u0000");
+	return JSON.stringify(canonicalParticipants(participants));
 }
 
 function sameParticipants(

--- a/packages/scripts/__tests__/vitest-source-aliases.test.ts
+++ b/packages/scripts/__tests__/vitest-source-aliases.test.ts
@@ -1,12 +1,13 @@
 /**
- * Verifies workspace source aliases target source files without prebuilt dist
- * artifacts, including deterministic package-export fixtures.
+ * Verifies workspace and integration source aliases target source files
+ * without prebuilt dist artifacts, including deterministic export fixtures.
  */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
+import integrationConfig from "../vitest/integration.config.ts";
 import {
   buildWorkspaceSourceAliases,
   workspaceRepoRoot,
@@ -21,15 +22,39 @@ afterEach(() => {
 });
 
 function resolveAlias(
-  aliases: ReturnType<typeof buildWorkspaceSourceAliases>,
+  aliases: Array<{ find: string | RegExp; replacement: string }>,
   specifier: string,
 ): string {
-  const alias = aliases.find(({ find }) => find.test(specifier));
+  const alias = aliases.find(({ find }) =>
+    typeof find === "string"
+      ? specifier === find || specifier.startsWith(`${find}/`)
+      : find.test(specifier),
+  );
   expect(alias, `${specifier} must have a source alias`).toBeDefined();
-  return specifier.replace(alias?.find ?? /$^/, alias?.replacement ?? "");
+  if (!alias) return specifier;
+  return specifier.replace(alias.find, alias.replacement);
 }
 
 describe("workspace source aliases", () => {
+  test("keeps package-aware aliases effective in the integration lane", () => {
+    const aliases = integrationConfig.resolve?.alias;
+    if (!Array.isArray(aliases)) {
+      throw new Error("Integration aliases must be an ordered array");
+    }
+
+    const replacement = resolveAlias(
+      aliases as Array<{ find: string | RegExp; replacement: string }>,
+      "@elizaos/plugin-elizacloud/endpoint-config",
+    );
+
+    expect(replacement).toBe(
+      path.join(
+        workspaceRepoRoot,
+        "plugins/plugin-elizacloud/src/utils/config.ts",
+      ),
+    );
+  });
+
   test("resolve file and directory subpaths to source targets", () => {
     const aliases = buildWorkspaceSourceAliases(workspaceRepoRoot);
     const cases = [

--- a/packages/scripts/vitest/integration.config.ts
+++ b/packages/scripts/vitest/integration.config.ts
@@ -146,12 +146,6 @@ const cloudSdkSource = path.join(
   "src",
   "index.ts",
 );
-const elizaCloudSourceRoot = path.join(
-  elizaWorkspaceRoot,
-  "plugins",
-  "plugin-elizacloud",
-  "src",
-);
 // Include/exclude globs are cwd-relative, but the eliza workspace sits at
 // `eliza/` in the nested eliza layout and at the repo root in a flat eliza
 // checkout (#11047). Derive the prefix instead of hardcoding `eliza/` so the
@@ -203,14 +197,6 @@ const integrationResolveAlias: ModuleAlias[] = [
   {
     find: /^@elizaos\/cloud-sdk$/,
     replacement: cloudSdkSource,
-  },
-  {
-    find: /^@elizaos\/plugin-elizacloud$/,
-    replacement: path.join(elizaCloudSourceRoot, "index.node.ts"),
-  },
-  {
-    find: /^@elizaos\/plugin-elizacloud\/(.+)$/,
-    replacement: `${elizaCloudSourceRoot.split(path.sep).join("/")}/$1`,
   },
   {
     // The generic source alias maps subpaths to sibling `.ts` files; `kms` is

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding-internal-sources.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding-internal-sources.test.ts
@@ -17,10 +17,12 @@ import {
   type Room,
   type UUID,
 } from "@elizaos/core";
+import type { ScheduledTaskDispatchRecord } from "@elizaos/plugin-scheduling";
 import { describe, expect, it, vi } from "vitest";
 import {
   bindScheduledTaskToInboundChat,
   isInternalMessageSource,
+  revalidateScheduledTaskChatDeliveryBinding,
 } from "./delivery-binding";
 
 const INTERNAL_SENTINELS = Object.values(MESSAGE_SOURCES);
@@ -146,6 +148,45 @@ describe("bindScheduledTaskToInboundChat provenance guards", () => {
         agentEntityId: AGENT,
       },
     });
+    expect(binding?.audience.membershipVersion).toBe(
+      JSON.stringify([OWNER, AGENT]),
+    );
+    expect(binding?.audience.membershipVersion).not.toContain("\u0000");
+  });
+
+  it("revalidates legacy NUL-delimited membership from compatible stores", async () => {
+    const runtime = connectorRuntime({ roomSource: "discord" });
+    const message = await attestedMessage(runtime, "discord");
+    const binding = await bindScheduledTaskToInboundChat(runtime, message);
+    expect(binding).not.toBeNull();
+    if (!binding) {
+      throw new Error("Expected an attested chat delivery binding");
+    }
+    const legacyBinding = {
+      ...binding,
+      audience: {
+        ...binding.audience,
+        membershipVersion: [OWNER, AGENT].sort().join("\u0000"),
+      },
+    };
+    const record = {
+      taskId: "legacy-membership",
+      kind: "reminder",
+      firedAtIso: "2026-08-16T00:00:00.000Z",
+      channelKey: "discord",
+      intensity: "normal",
+      promptInstructions: "Deliver the reminder.",
+      ownerVisible: true,
+      output: {
+        destination: "channel",
+        target: `discord:${CHANNEL}`,
+      },
+      metadata: { chatDeliveryBinding: legacyBinding },
+    } as ScheduledTaskDispatchRecord;
+
+    await expect(
+      revalidateScheduledTaskChatDeliveryBinding(runtime, record),
+    ).resolves.toMatchObject({ ok: true });
   });
 
   it.each(INTERNAL_SENTINELS)(

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/delivery-binding.ts
@@ -86,7 +86,21 @@ function canonicalParticipants(values: readonly string[]): string[] {
 }
 
 function membershipVersion(values: readonly string[]): string {
+  return JSON.stringify(canonicalParticipants(values));
+}
+
+function legacyMembershipVersion(values: readonly string[]): string {
   return canonicalParticipants(values).join("\u0000");
+}
+
+function matchesMembershipVersion(
+  values: readonly string[],
+  storedVersion: string,
+): boolean {
+  return (
+    membershipVersion(values) === storedVersion ||
+    legacyMembershipVersion(values) === storedVersion
+  );
 }
 
 /**
@@ -156,7 +170,7 @@ export async function bindScheduledTaskToInboundChat(
       ownerEntityId: audience.canonicalOwnerEntityId,
       agentEntityId: audience.agentEntityId,
       participantEntityIds: [...audience.participantEntityIds],
-      membershipVersion: audience.membershipVersion,
+      membershipVersion: membershipVersion(audience.participantEntityIds),
     },
   };
 }
@@ -238,7 +252,7 @@ export async function revalidateScheduledTaskChatDeliveryBinding(
       binding.audience.agentEntityId !== runtime.agentId ||
       current.length !== expected.length ||
       current.some((value, index) => value !== expected[index]) ||
-      membershipVersion(current) !== binding.audience.membershipVersion ||
+      !matchesMembershipVersion(current, binding.audience.membershipVersion) ||
       current.length !== 2 ||
       !current.includes(binding.audience.ownerEntityId) ||
       !current.includes(binding.audience.agentEntityId)

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/dispatch-context.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/dispatch-context.test.ts
@@ -52,7 +52,7 @@ function makeRecord(): ScheduledTaskDispatchRecord {
           ownerEntityId: OWNER_ID,
           agentEntityId: AGENT_ID,
           participantEntityIds: [AGENT_ID, OWNER_ID],
-          membershipVersion: [AGENT_ID, OWNER_ID].sort().join("\u0000"),
+          membershipVersion: JSON.stringify([AGENT_ID, OWNER_ID].sort()),
         },
       },
     },

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts
@@ -205,7 +205,9 @@ describe("processDueScheduledTasks — production wiring", () => {
             ownerEntityId: ownerId,
             agentEntityId: runtime.agentId,
             participantEntityIds: [ownerId, runtime.agentId].sort(),
-            membershipVersion: [ownerId, runtime.agentId].sort().join("\u0000"),
+            membershipVersion: JSON.stringify(
+              [ownerId, runtime.agentId].sort(),
+            ),
           },
         },
       },

--- a/plugins/plugin-personal-assistant/test/life-smoke.integration.test.ts
+++ b/plugins/plugin-personal-assistant/test/life-smoke.integration.test.ts
@@ -18,6 +18,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentRuntime } from "@elizaos/core";
+import { schedulingPlugin } from "@elizaos/plugin-scheduling";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createRealTestRuntime } from "../../../packages/app-core/test/helpers/real-runtime.ts";
 import { runLifeOperationHandler } from "../src/actions/life.js";
@@ -91,11 +92,14 @@ function send(params: Record<string, unknown>, messageText?: string) {
 // an unconfirmed create here previews instead of persisting immediately.
 function sendFromOwnerChat(
   params: Record<string, unknown>,
+  messageId: string,
   messageText?: string,
 ) {
   return runLifeOperationHandler(
     runtime,
     {
+      id: messageId,
+      roomId: "00000000-0000-0000-0000-000000000010",
       entityId: runtime.agentId,
       content: {
         source: "discord",
@@ -110,7 +114,7 @@ function sendFromOwnerChat(
 beforeAll(async () => {
   setIsolatedLifeSmokeEnv();
   const result = await createRealTestRuntime({
-    plugins: [personalAssistantPlugin],
+    plugins: [schedulingPlugin, personalAssistantPlugin],
   });
   runtime = result.runtime;
   cleanup = result.cleanup;
@@ -176,7 +180,10 @@ describe("LIFE action smoke tests -- BRD acceptance criteria", () => {
     };
 
     // Unconfirmed, from owner chat (not "autonomy") -> a PREVIEW, not a save.
-    const preview = await sendFromOwnerChat(recurring);
+    const preview = await sendFromOwnerChat(
+      recurring,
+      "00000000-0000-0000-0000-000000000011",
+    );
     expect(preview).toMatchObject({ success: false });
     expect((preview as { data?: Record<string, unknown> }).data).toMatchObject({
       deferred: true,
@@ -185,10 +192,14 @@ describe("LIFE action smoke tests -- BRD acceptance criteria", () => {
     });
 
     // Confirming the same recurring create persists a real definition.
-    const saved = await sendFromOwnerChat({
-      ...recurring,
-      details: { ...recurring.details, confirmed: true },
-    });
+    const saved = await sendFromOwnerChat(
+      {
+        ...recurring,
+        details: { ...recurring.details, confirmed: true },
+      },
+      "00000000-0000-0000-0000-000000000012",
+      "Yes, save it.",
+    );
     expect(saved).toMatchObject({ success: true });
     expect((saved as { text: string }).text).toContain("Wind down");
   }, 60_000);


### PR DESCRIPTION
## Summary

- serialize scheduled-delivery audience membership as canonical JSON instead of a NUL-delimited string, so PostgreSQL JSON columns can persist it safely
- accept legacy NUL-delimited membership versions while revalidating existing bindings, then write the JSON-safe form on the next binding update
- restore the package-aware `plugin-elizacloud` source alias in the integration lane and lock its `endpoint-config` resolution with a regression test
- exercise recurring workflow creation through the real scheduling plugin and the explicit owner-confirmation contract in the repository smoke flow

Closes #20299.
Closes #20302.

## Validation

Exact head: `a42ae386124776f307253e34327cf8ee7fb13ba6`

- `bun run verify` — 351/351 tasks passed; repository audit inspected 8,272 test files with zero focused tests or orphaned skips
- personal-assistant source integration — 36 files, 306 tests passed
- `scheduler.integration.test.ts` — 14/14 passed on the exact rebased head
- repository personal-assistant smoke flows — 2 files, 17/17 passed on the exact rebased head
- scheduling package — 28 files, 366 tests passed
- trusted delivery audience — 29/29 passed
- delivery binding and dispatch context — 2 files, 25/25 passed on the exact rebased head
- Vitest source-alias regression — 3/3 passed on the exact rebased head

An initial post-verify focused retry exhausted local temporary disk space while creating Vitest directories. Generated package outputs were cleaned, the one tracked native helper affected by that package-clean command was restored byte-for-byte from the exact commit, and every exact-head focused lane above was rerun green with a clean tree.

## Review evidence

- Desktop screenshots: N/A — no UI or rendered product surface changed
- Mobile screenshots: N/A — no UI or rendered product surface changed
- MP4 walkthrough: N/A — backend persistence and test-harness repair only
- Frontend console/network logs: N/A — no frontend behavior changed
- Live-model trajectory: N/A — scheduling semantics and model prompting are unchanged
- Backend evidence: covered by the real runtime scheduler integration and repository smoke flows listed above

AI Model: OpenAI / gpt-5.6-sol  
Agent Platform: Codex Desktop

<!-- evidence-head:a42ae386124776f307253e34327cf8ee7fb13ba6 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI or rendered product surface changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI or rendered product surface changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend persistence and test-harness repair only

<!-- evidence-row:backend-logs -->
- [ ] N/A - validated by real runtime scheduler integration and repository smoke tests

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend behavior changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - model prompting and agent behavior are unchanged

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no generated artifact surface changed

<!-- evidence-row:ocr-review -->
- [ ] N/A - no UI or screenshot surface changed

Skill Revision: N/A - no contribution skill used

— [codex-workflow]

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->

