### PR TITLE
fix(cloud): recheck canonical source at mutation boundaries

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -80,11 +80,19 @@ jobs:
       - name: Run migrations
         env:
           DATABASE_URL: ${{ env.MIGRATION_DATABASE_URL }}
+          CANONICAL_REF: ${{ inputs.target_environment == 'production' && 'refs/heads/main' || 'refs/heads/develop' }}
+          FORCE: ${{ inputs.force }}
         run: |
+          set -euo pipefail
           # The migrate entry imports @elizaos/core, whose i18n barrel pulls in the
           # gitignored generated keyword data. Source-mode (eliza-source) migrate
           # never builds core, so generate the file first (mirrors core's prebuild).
           node packages/shared/scripts/generate-keywords.mjs
+          source_args=(--run-sha "$GITHUB_SHA" --canonical-ref "$CANONICAL_REF")
+          if [ "$FORCE" = "true" ]; then
+            source_args+=(--force)
+          fi
+          node packages/cloud/scripts/canonical-deploy-source-guard.mjs "${source_args[@]}"
           bun run db:cloud:migrate
 
   # ---------------------------------------------------------------------------
@@ -393,8 +401,15 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CANONICAL_REF: ${{ steps.env.outputs.deploy_environment == 'production' && 'refs/heads/main' || 'refs/heads/develop' }}
+          FORCE: ${{ inputs.force }}
         run: |
           set -euo pipefail
+          source_args=(--run-sha "$GITHUB_SHA" --canonical-ref "$CANONICAL_REF")
+          if [ "$FORCE" = "true" ]; then
+            source_args+=(--force)
+          fi
+          node "$CHECKOUT_DIR/packages/cloud/scripts/canonical-deploy-source-guard.mjs" "${source_args[@]}"
           if ! result=$(node "$CHECKOUT_DIR/packages/cloud/scripts/ensure-worker-secret-absent.mjs" \
             STAGING_SESSION_EXCHANGE_ENABLED --env staging); then
             echo "::error::Could not confirm staging session exchange is off before cutover"
@@ -849,9 +864,18 @@ jobs:
           FISH_AUDIO_SAMPLE_RATE: "16000"
           FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS: ${{ vars.FISH_AUDIO_FIRST_AUDIO_TIMEOUT_MS || '1500' }}
           WORKER_SECRETS_FILE: ${{ steps.worker-secrets.outputs.secrets_file }}
+          CANONICAL_REF: ${{ steps.env.outputs.deploy_environment == 'production' && 'refs/heads/main' || 'refs/heads/develop' }}
+          FORCE: ${{ inputs.force }}
         run: |
           set -euo pipefail
           legacy_onboarding_secret_removed=false
+          source_args=(--run-sha "$GITHUB_SHA" --canonical-ref "$CANONICAL_REF")
+          if [ "$FORCE" = "true" ]; then
+            source_args+=(--force)
+          fi
+          recheck_canonical_source() {
+            node "$CHECKOUT_DIR/packages/cloud/scripts/canonical-deploy-source-guard.mjs" "${source_args[@]}"
+          }
           restore_legacy_onboarding_secrets() {
             if [ "$legacy_onboarding_secret_removed" != "true" ]; then
               return
@@ -867,6 +891,7 @@ jobs:
           delete_legacy_onboarding_secret() {
             local name="$1"
             local result
+            recheck_canonical_source
             if ! result=$(node "$CHECKOUT_DIR/packages/cloud/scripts/ensure-worker-secret-absent.mjs" \
               --versions "$name" --env staging); then
               echo "::error::Could not retire legacy staging secret binding $name."
@@ -901,6 +926,7 @@ jobs:
             delete_legacy_onboarding_secret ELIZA_ONBOARDING_LOGIN_APP_URL
             delete_legacy_onboarding_secret ELIZA_APP_ONBOARDING_LOGIN_APP_URL
           fi
+          recheck_canonical_source
           bunx wrangler deploy "${args[@]}"
           trap - ERR
 
@@ -1690,8 +1716,18 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          EVENT_NAME: ${{ github.event_name }}
+          CANONICAL_REF: ${{ inputs.target_environment == 'production' && 'refs/heads/main' || 'refs/heads/develop' }}
+          FORCE: ${{ inputs.force }}
         run: |
           set -euo pipefail
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            source_args=(--run-sha "$GITHUB_SHA" --canonical-ref "$CANONICAL_REF")
+            if [ "$FORCE" = "true" ]; then
+              source_args+=(--force)
+            fi
+            node packages/cloud/scripts/canonical-deploy-source-guard.mjs "${source_args[@]}"
+          fi
           if output=$(bunx wrangler@4.100.0 pages project create eliza-app --production-branch=main 2>&1); then
             printf '%s\n' "$output"
             exit 0
@@ -1729,11 +1765,27 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PAGES_BRANCH: ${{ steps.pages.outputs.branch }}
           PAGES_PROJECT: eliza-app
+          EVENT_NAME: ${{ github.event_name }}
+          CANONICAL_REF: ${{ inputs.target_environment == 'production' && 'refs/heads/main' || 'refs/heads/develop' }}
+          FORCE: ${{ inputs.force }}
         # Do NOT pass a positional `dist` argument: wrangler.toml already sets
         # `pages_build_output_dir = "./dist"`, and passing both makes wrangler
         # ignore wrangler.toml — which silently drops the `functions/` upload.
         run: |
+          set -euo pipefail
+          source_args=(--run-sha "$GITHUB_SHA" --canonical-ref "$CANONICAL_REF")
+          if [ "$FORCE" = "true" ]; then
+            source_args+=(--force)
+          fi
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            recheck_canonical_source() {
+              node "$CHECKOUT_DIR/packages/cloud/scripts/canonical-deploy-source-guard.mjs" "${source_args[@]}"
+            }
+          else
+            recheck_canonical_source() { :; }
+          fi
           for attempt in 1 2 3; do
+            recheck_canonical_source
             if bunx wrangler@4.100.0 pages deploy --project-name="$PAGES_PROJECT" --branch="$PAGES_BRANCH"; then
               exit 0
             fi

--- a/packages/cloud/scripts/__tests__/canonical-deploy-source-guard.test.ts
+++ b/packages/cloud/scripts/__tests__/canonical-deploy-source-guard.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Exercises canonical Cloud release ownership in pure and real-git harnesses.
+ */
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  execFileSync,
+  spawnSync,
+} from "../../../scripts/lib/spawn-sync-captured.mjs";
+import {
+  decideCanonicalDeploySource,
+  parseCanonicalRemoteHead,
+} from "../canonical-deploy-source-guard.mjs";
+
+const RUN = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const HEAD = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const SCRIPT = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../canonical-deploy-source-guard.mjs",
+);
+
+describe("canonical deploy source decision", () => {
+  it("accepts only the exact canonical head", () => {
+    expect(
+      decideCanonicalDeploySource({
+        runSha: RUN,
+        canonicalRef: "refs/heads/develop",
+        canonicalHead: RUN,
+      }),
+    ).toMatchObject({ allowed: true, reason: "current_source" });
+    expect(
+      decideCanonicalDeploySource({
+        runSha: RUN,
+        canonicalRef: "refs/heads/develop",
+        canonicalHead: HEAD,
+      }),
+    ).toMatchObject({ allowed: false, reason: "superseded_source" });
+  });
+
+  it("fails closed for malformed or unresolved identity", () => {
+    expect(
+      decideCanonicalDeploySource({
+        runSha: "short",
+        canonicalRef: "refs/heads/develop",
+        canonicalHead: HEAD,
+      }).reason,
+    ).toBe("invalid_run_sha");
+    expect(
+      decideCanonicalDeploySource({
+        runSha: RUN,
+        canonicalRef: "refs/heads/feature",
+        canonicalHead: HEAD,
+      }).reason,
+    ).toBe("invalid_canonical_ref");
+    expect(
+      decideCanonicalDeploySource({
+        runSha: RUN,
+        canonicalRef: "refs/heads/main",
+        canonicalHead: null,
+      }).reason,
+    ).toBe("canonical_head_unresolved");
+  });
+
+  it("allows an explicit forced rollback without a resolved head", () => {
+    expect(
+      decideCanonicalDeploySource({
+        runSha: RUN,
+        canonicalRef: "refs/heads/main",
+        canonicalHead: null,
+        force: true,
+      }),
+    ).toMatchObject({ allowed: true, reason: "forced" });
+  });
+});
+
+describe("canonical remote head parsing", () => {
+  it("requires one exact ref and a full commit", () => {
+    expect(
+      parseCanonicalRemoteHead(
+        `${RUN}\trefs/heads/develop\n`,
+        "refs/heads/develop",
+      ),
+    ).toBe(RUN);
+    expect(
+      parseCanonicalRemoteHead(
+        `${RUN}\trefs/heads/main\n`,
+        "refs/heads/develop",
+      ),
+    ).toBeNull();
+    expect(
+      parseCanonicalRemoteHead(
+        `${RUN}\trefs/heads/develop\n${HEAD}\trefs/heads/develop\n`,
+        "refs/heads/develop",
+      ),
+    ).toBeNull();
+    expect(
+      parseCanonicalRemoteHead(
+        "not-a-sha\trefs/heads/develop\n",
+        "refs/heads/develop",
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("canonical deploy source CLI", () => {
+  it("accepts current, rejects superseded and unresolved, and permits forced rollback", () => {
+    const root = mkdtempSync(join(tmpdir(), "canonical-deploy-source-"));
+    const origin = join(root, "origin");
+    const clone = join(root, "clone");
+    try {
+      execFileSync("git", ["init", "--initial-branch=develop", origin], {
+        stdio: "ignore",
+      });
+      execFileSync("git", ["config", "user.email", "test@example.com"], {
+        cwd: origin,
+      });
+      execFileSync("git", ["config", "user.name", "Source Guard Test"], {
+        cwd: origin,
+      });
+      writeFileSync(join(origin, "state.txt"), "one\n");
+      execFileSync("git", ["add", "state.txt"], { cwd: origin });
+      execFileSync("git", ["commit", "-m", "one"], {
+        cwd: origin,
+        stdio: "ignore",
+      });
+      const first = execFileSync("git", ["rev-parse", "HEAD"], { cwd: origin })
+        .toString()
+        .trim();
+      execFileSync("git", ["clone", origin, clone], { stdio: "ignore" });
+
+      const current = spawnSync(
+        process.execPath,
+        [SCRIPT, "--run-sha", first, "--canonical-ref", "refs/heads/develop"],
+        { cwd: clone, encoding: "utf8" },
+      );
+      expect(current.status).toBe(0);
+      expect(current.stdout).toContain("current_source");
+
+      writeFileSync(join(origin, "state.txt"), "two\n");
+      execFileSync("git", ["add", "state.txt"], { cwd: origin });
+      execFileSync("git", ["commit", "-m", "two"], {
+        cwd: origin,
+        stdio: "ignore",
+      });
+      const superseded = spawnSync(
+        process.execPath,
+        [SCRIPT, "--run-sha", first, "--canonical-ref", "refs/heads/develop"],
+        { cwd: clone, encoding: "utf8" },
+      );
+      expect(superseded.status).toBe(1);
+      expect(superseded.stdout).toContain("superseded_source");
+
+      const unresolved = spawnSync(
+        process.execPath,
+        [SCRIPT, "--run-sha", first, "--canonical-ref", "refs/heads/main"],
+        { cwd: clone, encoding: "utf8" },
+      );
+      expect(unresolved.status).toBe(1);
+      expect(unresolved.stderr).toContain("could not be verified");
+
+      const forced = spawnSync(
+        process.execPath,
+        [
+          SCRIPT,
+          "--run-sha",
+          first,
+          "--canonical-ref",
+          "refs/heads/main",
+          "--force",
+        ],
+        { cwd: root, encoding: "utf8" },
+      );
+      expect(forced.status).toBe(0);
+      expect(forced.stdout).toContain("forced");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cloud/scripts/canonical-deploy-source-guard.mjs
+++ b/packages/cloud/scripts/canonical-deploy-source-guard.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * Fails closed when a canonical Cloud release no longer owns its branch head.
+ *
+ * Admission can precede a protected-environment wait or a long serialized
+ * release queue. This guard therefore resolves the authoritative remote ref at
+ * each provider mutation boundary instead of trusting the earlier admission.
+ * Explicit forced dispatches remain the only supported stale-SHA rollback path.
+ */
+import { execFileSync } from "../../scripts/lib/spawn-sync-captured.mjs";
+
+const COMMIT_SHA_PATTERN = /^[a-f0-9]{40}$/;
+const CANONICAL_REFS = new Set(["refs/heads/develop", "refs/heads/main"]);
+
+function normalizeSha(value) {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return COMMIT_SHA_PATTERN.test(normalized) ? normalized : null;
+}
+
+/**
+ * Parses the exact one-line response expected from `git ls-remote`.
+ * @param {string} output
+ * @param {string} canonicalRef
+ * @returns {string|null}
+ */
+export function parseCanonicalRemoteHead(output, canonicalRef) {
+  if (typeof output !== "string" || !CANONICAL_REFS.has(canonicalRef)) {
+    return null;
+  }
+  const records = output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.split(/\s+/));
+  if (records.length !== 1) return null;
+  const [sha, ref, ...extra] = records[0];
+  if (extra.length > 0 || ref !== canonicalRef) return null;
+  return normalizeSha(sha);
+}
+
+/**
+ * Makes the strict source-ownership decision without performing I/O.
+ * @param {object} input
+ * @param {string|null|undefined} input.runSha
+ * @param {string|null|undefined} input.canonicalRef
+ * @param {string|null|undefined} input.canonicalHead
+ * @param {boolean} [input.force]
+ */
+export function decideCanonicalDeploySource({
+  runSha,
+  canonicalRef,
+  canonicalHead,
+  force = false,
+}) {
+  const normalizedRun = normalizeSha(runSha);
+  const normalizedHead = normalizeSha(canonicalHead);
+  const normalizedRef =
+    typeof canonicalRef === "string" ? canonicalRef.trim() : "";
+
+  if (!normalizedRun) {
+    return { allowed: false, reason: "invalid_run_sha" };
+  }
+  if (!CANONICAL_REFS.has(normalizedRef)) {
+    return { allowed: false, reason: "invalid_canonical_ref" };
+  }
+  if (force) {
+    return {
+      allowed: true,
+      reason: "forced",
+      runSha: normalizedRun,
+      canonicalRef: normalizedRef,
+      canonicalHead: normalizedHead,
+    };
+  }
+  if (!normalizedHead) {
+    return {
+      allowed: false,
+      reason: "canonical_head_unresolved",
+      runSha: normalizedRun,
+      canonicalRef: normalizedRef,
+    };
+  }
+  if (normalizedRun !== normalizedHead) {
+    return {
+      allowed: false,
+      reason: "superseded_source",
+      runSha: normalizedRun,
+      canonicalRef: normalizedRef,
+      canonicalHead: normalizedHead,
+    };
+  }
+  return {
+    allowed: true,
+    reason: "current_source",
+    runSha: normalizedRun,
+    canonicalRef: normalizedRef,
+    canonicalHead: normalizedHead,
+  };
+}
+
+function parseArgs(argv) {
+  const parsed = { runSha: null, canonicalRef: null, force: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--force") {
+      parsed.force = true;
+    } else if (argument === "--run-sha") {
+      parsed.runSha = argv[index + 1] ?? null;
+      index += 1;
+    } else if (argument === "--canonical-ref") {
+      parsed.canonicalRef = argv[index + 1] ?? null;
+      index += 1;
+    } else if (argument.startsWith("--run-sha=")) {
+      parsed.runSha = argument.slice("--run-sha=".length);
+    } else if (argument.startsWith("--canonical-ref=")) {
+      parsed.canonicalRef = argument.slice("--canonical-ref=".length);
+    } else {
+      throw new Error(`Unsupported argument: ${argument}`);
+    }
+  }
+  return parsed;
+}
+
+function resolveCanonicalHead(canonicalRef) {
+  const output = execFileSync(
+    "git",
+    ["ls-remote", "--exit-code", "origin", canonicalRef],
+    {
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 60000,
+    },
+  ).toString();
+  const head = parseCanonicalRemoteHead(output, canonicalRef);
+  if (!head) {
+    throw new Error(`Remote returned no exact commit for ${canonicalRef}`);
+  }
+  return head;
+}
+
+function reportDecision(decision) {
+  const prefix = decision.allowed
+    ? "Canonical source accepted"
+    : "::error::Canonical source rejected";
+  console.log(`${prefix}: ${decision.reason}`);
+  if (decision.runSha) console.log(`runSha=${decision.runSha}`);
+  if (decision.canonicalRef)
+    console.log(`canonicalRef=${decision.canonicalRef}`);
+  if (decision.canonicalHead)
+    console.log(`canonicalHead=${decision.canonicalHead}`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const preliminary = decideCanonicalDeploySource({
+    ...args,
+    canonicalHead: null,
+  });
+  if (
+    preliminary.reason === "invalid_run_sha" ||
+    preliminary.reason === "invalid_canonical_ref"
+  ) {
+    reportDecision(preliminary);
+    process.exitCode = 1;
+    return;
+  }
+  if (args.force) {
+    reportDecision(preliminary);
+    return;
+  }
+
+  const canonicalHead = resolveCanonicalHead(args.canonicalRef);
+  const decision = decideCanonicalDeploySource({ ...args, canonicalHead });
+  reportDecision(decision);
+  if (!decision.allowed) process.exitCode = 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    // error-policy:J1 the CLI boundary translates remote resolution failures
+    // into a visible, fail-closed workflow result before provider mutation.
+    console.error(
+      `::error::Canonical source could not be verified: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exitCode = 1;
+  });
+}
+
+export { parseArgs, resolveCanonicalHead };

--- a/packages/scripts/__tests__/cloud-cf-canonical-source-guard-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-canonical-source-guard-workflow.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Pins fail-closed canonical-head checks to every Cloud provider mutation.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse } from "yaml";
+
+const workflowPath = join(
+  import.meta.dir,
+  "../../../.github/workflows/cloud-cf-release.yml",
+);
+const workflow = parse(readFileSync(workflowPath, "utf8"));
+
+function steps(jobName: string): Array<{ name?: string; run?: string }> {
+  return workflow.jobs[jobName].steps;
+}
+
+function step(jobName: string, name: string) {
+  const found = steps(jobName).find((candidate) => candidate.name === name);
+  if (!found) throw new Error(`Missing ${jobName} step: ${name}`);
+  return found;
+}
+
+describe("Cloud CF canonical source mutation guards", () => {
+  it("rechecks inside migrations and Worker secret mutation/deploy", () => {
+    const migration = step("migrate-db", "Run migrations");
+    const secretMutation = step(
+      "deploy-api",
+      "Disable staging session exchange before cutover",
+    );
+    const workerDeploy = step("deploy-api", "Deploy to Cloudflare Workers");
+    for (const guarded of [migration, secretMutation, workerDeploy]) {
+      expect(guarded.run).toContain("canonical-deploy-source-guard.mjs");
+      expect(guarded.run).toContain('--run-sha "$GITHUB_SHA"');
+      expect(guarded.run).toContain('--canonical-ref "$CANONICAL_REF"');
+      expect(guarded.run).toContain('if [ "$FORCE" = "true" ]');
+    }
+
+    expect(migration.run?.indexOf("generate-keywords.mjs")).toBeLessThan(
+      migration.run?.indexOf("canonical-deploy-source-guard.mjs") ?? -1,
+    );
+    expect(
+      migration.run?.indexOf("canonical-deploy-source-guard.mjs"),
+    ).toBeLessThan(migration.run?.indexOf("bun run db:cloud:migrate") ?? -1);
+
+    expect(
+      secretMutation.run?.indexOf("canonical-deploy-source-guard.mjs"),
+    ).toBeLessThan(
+      secretMutation.run?.indexOf("ensure-worker-secret-absent.mjs") ?? -1,
+    );
+    const deleteFunction = workerDeploy.run?.slice(
+      workerDeploy.run.indexOf("delete_legacy_onboarding_secret()"),
+      workerDeploy.run.indexOf(
+        String.raw`if [ -z "\${WORKER_SECRETS_FILE:-}" ]`,
+      ),
+    );
+    expect(deleteFunction?.indexOf("recheck_canonical_source")).toBeGreaterThan(
+      -1,
+    );
+    expect(deleteFunction?.indexOf("recheck_canonical_source")).toBeLessThan(
+      deleteFunction?.indexOf("ensure-worker-secret-absent.mjs") ?? -1,
+    );
+    expect(
+      workerDeploy.run?.lastIndexOf("recheck_canonical_source"),
+    ).toBeGreaterThan(-1);
+    expect(
+      workerDeploy.run?.lastIndexOf("recheck_canonical_source"),
+    ).toBeLessThan(workerDeploy.run?.indexOf("bunx wrangler deploy") ?? -1);
+  });
+
+  it("rechecks inside Pages project and deployment mutations", () => {
+    const project = step("deploy-app", "Ensure eliza-app Pages project exists");
+    const deploy = step("deploy-app", "Deploy to Cloudflare Pages");
+    for (const guarded of [project, deploy]) {
+      expect(guarded.run).toContain("canonical-deploy-source-guard.mjs");
+      expect(guarded.run).toContain('--run-sha "$GITHUB_SHA"');
+      expect(guarded.run).toContain('--canonical-ref "$CANONICAL_REF"');
+    }
+
+    expect(
+      project.run?.indexOf("canonical-deploy-source-guard.mjs"),
+    ).toBeLessThan(project.run?.indexOf("pages project create") ?? -1);
+    expect(
+      deploy.run?.indexOf("canonical-deploy-source-guard.mjs"),
+    ).toBeLessThan(deploy.run?.indexOf("pages deploy") ?? -1);
+    const deployLoop = deploy.run?.slice(
+      deploy.run.indexOf("for attempt in 1 2 3; do"),
+    );
+    expect(deployLoop?.indexOf("recheck_canonical_source")).toBeGreaterThan(-1);
+    expect(deployLoop?.indexOf("recheck_canonical_source")).toBeLessThan(
+      deployLoop?.indexOf("pages deploy") ?? -1,
+    );
+  });
+});


### PR DESCRIPTION
# Relates to

Closes #20308.

- [x] This PR targets `develop` and is rebased onto exact `origin/develop@599771c174a007f4b989838f66874e6061d59127` with zero conflicts.
- [x] `bun install --frozen-lockfile` and exact-head `bun run verify` pass.
- [x] Executable guard and workflow-contract evidence lets a reviewer confirm the behavior without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@392e8a665efedc557f50040e6c02d428d709a811:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop@599771c174a007f4b989838f66874e6061d59127`; zero conflicts.
- [x] Exact-head uncached `TURBO_FORCE=1 bun run verify` passes 351/351 with all repository audits green.

# Risks

Medium, limited to protected Cloud release admission immediately before provider mutations.

- A temporary inability to resolve the canonical Git ref now fails the release closed instead of allowing an ambiguous deploy.
- Explicit `force=true` remains the audited rollback escape hatch and still validates the environment/ref/SHA shape.
- The guard emits only branch names, commit SHAs, and the decision reason; no credential or provider value is printed.
- Rollback is a one-commit revert.

# Background

## What does this PR do?

The Cloud CF release previously decided freshness during admission, then could sit queued while the canonical branch advanced. A stale admitted release could consequently mutate Worker secrets or deploy Worker/Pages artifacts.

This change adds a fail-closed canonical-source guard and invokes it at each provider mutation boundary:

- immediately before database migration;
- immediately before staging-session secret removal;
- immediately before every legacy Worker secret deletion and again before Worker deployment;
- immediately before Pages project creation; and
- immediately before every Pages deployment attempt, including retries.

Staging must still equal `refs/heads/develop`; production must still equal `refs/heads/main`. A valid explicit forced rollback bypasses only the remote-head equality check.

## What kind of change is this?

Bug fix (non-breaking release-safety correction).

# Documentation changes needed?

No user-facing documentation change is required. The workflow and executable contract tests are the operational specification.

# Testing

## Where should a reviewer start?

- `packages/cloud/scripts/canonical-deploy-source-guard.mjs`
- `packages/cloud/scripts/__tests__/canonical-deploy-source-guard.test.ts`
- `packages/scripts/__tests__/cloud-cf-canonical-source-guard-workflow.test.ts`
- `.github/workflows/cloud-cf-release.yml`

## Detailed testing steps

- `bun install --frozen-lockfile`: pass, 3,823 installs checked across 4,121 packages, no changes.
- Focused executable and workflow-contract matrix: 33/33 tests, 138 expectations.
- Exact-head `bun run verify:cloud`: 80/80.
- Pinned `actionlint` on `.github/workflows/cloud-cf-release.yml`: pass.
- Biome on the three changed JS/TS files: pass.
- `git diff --check`: pass.
- Exact-head uncached `TURBO_FORCE=1 bun run verify`: 351/351, zero cache hits; all follow-on repository audits and anti-larp checks pass.

# Evidence Gate

<!-- evidence-head:313ec2d7dcada8a3a204e5d7c2343a1570294790 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - workflow and command-line release guard only; no rendered UI surface changed
<!-- evidence-row:after-screenshots -->
- [ ] N/A - workflow and command-line release guard only; no rendered UI surface changed
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or visual user flow changed
<!-- evidence-row:backend-logs -->
- [x] [20322-pr20322-exact.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20322-pr20322-exact.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or agent behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] [20322-pr20322-focused-exact.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20322-pr20322-focused-exact.log)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or visual text changed

# Evidence Details

## Backend + domain evidence

The exact-head log exercises current, superseded, unresolved, malformed, and forced rollback decisions using temporary local Git remotes, then statically proves every guarded workflow mutation boundary. It also records the exact cloud aggregate result. No provider was mutated and no secret value was read or emitted.

## Known gaps / failures

- No live provider mutation was performed by this PR. That is intentional: the patch controls protected production/staging mutations, and its safe evidence is an executable temporary-Git integration plus workflow-ordering contract. The first live use remains subject to protected environment approval and exact-head postdeploy validation.
- Screenshots, video, frontend logs, and OCR are not applicable because the diff has no rendered UI path.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@392e8a665efedc557f50040e6c02d428d709a811:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@392e8a665efedc557f50040e6c02d428d709a811:packages/skills/skills/contribute-to-eliza"} -->


