### PR TITLE
perf(cloud): prepare personal delivery projections

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-upgrade-tier.test.ts
@@ -68,6 +68,8 @@ const currentUser = {
   organization: { id: ORG_A, name: "Org A", is_active: true },
   is_active: true,
   role: "owner",
+  telegram_id: null as string | null,
+  discord_id: null as string | null,
 };
 
 // VALUE snapshot at module evaluation + mock installed in beforeAll — never at
@@ -149,9 +151,19 @@ const cutoverCoordinatorFetch = mock(
 const cutoverNamespace = {
   getByName: mock(() => ({ fetch: cutoverCoordinatorFetch })),
 };
+const invalidatedDeliveryProjections: string[] = [];
+const personalDeliveryProjectionNamespace = {
+  getByName: mock((name: string) => ({
+    fetch: mock(async () => {
+      invalidatedDeliveryProjections.push(name);
+      return Response.json({ success: true });
+    }),
+  })),
+};
 const ENV = {
   NODE_ENV: "test",
   SHARED_RUNTIME_CONVERSATIONS: cutoverNamespace,
+  PERSONAL_DELIVERY_PROJECTIONS: personalDeliveryProjectionNamespace,
   ELIZA_CLOUD_AGENT_BASE_DOMAIN: "dedicated-cutover.test",
 } as unknown as AppEnv["Bindings"];
 
@@ -968,6 +980,7 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
       organization_id: ORG_C,
       role: "owner",
       steward_user_id: `steward-${USER_C}`,
+      telegram_id: "919191",
     });
     await dbWrite.insert(agentSandboxes).values({
       id: CUTOVER_TARGET,
@@ -995,6 +1008,7 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
       name: "Cutover Org",
       is_active: true,
     };
+    currentUser.telegram_id = "919191";
     const convergenceToken = `phone-telegram:source:${USER_C}`;
     const { createSharedTodoStore, sharedTodoStorageScope } = await import(
       "@/lib/services/shared-runtime/shared-todos"
@@ -1008,6 +1022,7 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
 
     try {
       cutoverCoordinatorOperations.length = 0;
+      invalidatedDeliveryProjections.length = 0;
       cutoverCoordinatorTokens.length = 0;
       cutoverSealToken = null;
       cutoverSealCommitted = false;
@@ -1370,6 +1385,7 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
         },
       });
       expect(cutoverCoordinatorOperations).toEqual(["cutover-commit"]);
+      expect(invalidatedDeliveryProjections).toContain("telegram:919191");
       expect(markerObservedAtCommit).toMatchObject({
         sourceAgentId: PERSONAL_C,
         cutoverToken: `personal-cutover:${PERSONAL_C}:${CUTOVER_TARGET}`,
@@ -1535,6 +1551,7 @@ describe("POST /api/v1/eliza/agents/:agentId/upgrade-tier", () => {
         name: "Org A",
         is_active: true,
       };
+      currentUser.telegram_id = null;
       cutoverHistory = [
         { id: "u1", role: "user", content: "hello", createdAt: 10 },
         {

--- a/packages/cloud/api/eliza-app/auth/discord/route.ts
+++ b/packages/cloud/api/eliza-app/auth/discord/route.ts
@@ -25,12 +25,16 @@ import {
   elizaAppUserService,
   type ValidatedSession,
 } from "@/lib/services/eliza-app";
+import { invalidatePersonalDeliveryProjection } from "@/lib/services/eliza-app/personal-delivery-projection-contract";
 import { logger } from "@/lib/utils/logger";
 import {
   isValidE164,
   normalizePhoneNumber,
 } from "@/lib/utils/phone-normalization";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type {
+  AppEnv,
+  RuntimeDurableObjectNamespace,
+} from "@/types/cloud-worker-env";
 
 /**
  * Optional E.164 phone number validation (after normalization)
@@ -74,7 +78,10 @@ const discordAuthSchema = z.object({
     .transform((s) => s?.trim() || undefined),
 });
 
-async function handleDiscordAuth(request: Request): Promise<Response> {
+async function handleDiscordAuth(
+  request: Request,
+  personalDeliveryProjections?: RuntimeDurableObjectNamespace,
+): Promise<Response> {
   // Parse and validate request body
   let body: unknown;
   try {
@@ -304,6 +311,12 @@ async function handleDiscordAuth(request: Request): Promise<Response> {
     sessionBased: !!existingSession,
   });
 
+  await invalidatePersonalDeliveryProjection(
+    personalDeliveryProjections,
+    "discord",
+    discordUser.id,
+  );
+
   // Create session (new session includes discord identity)
   const session = await elizaAppSessionService.createSession(
     user.id,
@@ -347,7 +360,10 @@ const honoRouter = new Hono<AppEnv>();
 honoRouter.get("/", async () => __next_GET());
 honoRouter.post("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
   try {
-    return await handleDiscordAuth(c.req.raw);
+    return await handleDiscordAuth(
+      c.req.raw,
+      c.env.PERSONAL_DELIVERY_PROJECTIONS,
+    );
   } catch (error) {
     return failureResponse(c, error);
   }

--- a/packages/cloud/api/eliza-app/auth/telegram/route.ts
+++ b/packages/cloud/api/eliza-app/auth/telegram/route.ts
@@ -32,12 +32,16 @@ import {
   runOnboardingChat,
   type TelegramOnboardingContinuationClaim,
 } from "@/lib/services/eliza-app/onboarding-chat";
+import { invalidatePersonalDeliveryProjection } from "@/lib/services/eliza-app/personal-delivery-projection-contract";
 import { logger } from "@/lib/utils/logger";
 import {
   isValidE164,
   normalizePhoneNumber,
 } from "@/lib/utils/phone-normalization";
-import type { AppEnv } from "@/types/cloud-worker-env";
+import type {
+  AppEnv,
+  RuntimeDurableObjectNamespace,
+} from "@/types/cloud-worker-env";
 
 /**
  * E.164 phone number validation (after normalization)
@@ -191,6 +195,7 @@ function isTelegramContinuationClaim(
 export async function handleTelegramAuth(
   request: Request,
   dependencies: TelegramAuthDependencies = defaultDependencies,
+  personalDeliveryProjections?: RuntimeDurableObjectNamespace,
 ): Promise<Response> {
   // Parse and validate request body
   let body: unknown;
@@ -521,6 +526,12 @@ export async function handleTelegramAuth(
     );
   }
 
+  await invalidatePersonalDeliveryProjection(
+    personalDeliveryProjections,
+    "telegram",
+    String(authData.id),
+  );
+
   logger.info("[ElizaApp TelegramAuth] Authentication successful", {
     userId: user.id,
     telegramId: authData.id,
@@ -619,7 +630,11 @@ const honoRouter = new Hono<AppEnv>();
 honoRouter.get("/", async () => __next_GET());
 honoRouter.post("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
   try {
-    return await handleTelegramAuth(c.req.raw);
+    return await handleTelegramAuth(
+      c.req.raw,
+      defaultDependencies,
+      c.env.PERSONAL_DELIVERY_PROJECTIONS,
+    );
   } catch (error) {
     return failureResponse(c, error);
   }

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -232,7 +232,7 @@ describe("personal Shared messaging deliveries", () => {
     });
     expect(findActivePersonalDedicatedTarget).not.toHaveBeenCalled();
     expect(response.headers.get("server-timing")).toMatch(
-      /^account;dur=\d+\.\d, shared;dur=\d+\.\d$/,
+      /^account;dur=\d+\.\d;desc="single-query-repeat", shared;dur=\d+\.\d$/,
     );
     expect(body.data.identity.id).toMatch(/^personal:/);
     expect(sharedRestMessageSend).toHaveBeenCalledWith(
@@ -557,7 +557,7 @@ describe("personal Shared messaging deliveries", () => {
     expect(sharedRestMessageSend).not.toHaveBeenCalled();
     expect(findActivePersonalDedicatedTarget).not.toHaveBeenCalled();
     expect(response.headers.get("server-timing")).toMatch(
-      /^account;dur=\d+\.\d, dedicated;dur=\d+\.\d$/,
+      /^account;dur=\d+\.\d;desc="single-query-repeat", dedicated;dur=\d+\.\d$/,
     );
     expect(bridge).toHaveBeenCalledWith(
       "00000000-0000-4000-8000-000000000020",

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -2,6 +2,7 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
+import { resolvePersonalDeliveryProjection } from "@/api-app/personal-delivery-projection";
 import type { AgentSandbox } from "@/db/schemas/agent-sandboxes";
 import { failureResponse, jsonError } from "@/lib/api/cloud-worker-errors";
 import { resolveElizaTraceId } from "@/lib/observability/http-telemetry";
@@ -263,34 +264,45 @@ app.post("/", async (c) => {
     stage = "account_resolution";
     const accountStartedAt = performance.now();
     let account: { userId: string; organizationId: string };
+    let accountResolution = "phone-query";
     let dedicated:
       | Pick<AgentSandbox, "id" | "status" | "bridge_url" | "agent_config">
       | null
       | undefined;
     if (parsed.data.platform === "telegram") {
-      const delivery = await elizaAppUserService.resolvePersonalDelivery({
-        platform: "telegram",
-        telegramId: parsed.data.telegramUserId,
-        username: parsed.data.telegramUsername,
-        displayName: parsed.data.displayName,
-      });
+      const delivery = await resolvePersonalDeliveryProjection(
+        c.env,
+        {
+          platform: "telegram",
+          telegramId: parsed.data.telegramUserId,
+          username: parsed.data.telegramUsername,
+          displayName: parsed.data.displayName,
+        },
+        elizaAppUserService,
+      );
       account = {
         userId: delivery.userId,
         organizationId: delivery.organizationId,
       };
+      accountResolution = delivery.resolution;
       dedicated = delivery.dedicatedTarget;
     } else if (parsed.data.platform === "discord") {
-      const delivery = await elizaAppUserService.resolvePersonalDelivery({
-        platform: "discord",
-        discordId: parsed.data.discordUserId,
-        username: parsed.data.discordUsername,
-        globalName: parsed.data.displayName,
-        avatarUrl: parsed.data.avatarUrl,
-      });
+      const delivery = await resolvePersonalDeliveryProjection(
+        c.env,
+        {
+          platform: "discord",
+          discordId: parsed.data.discordUserId,
+          username: parsed.data.discordUsername,
+          globalName: parsed.data.displayName,
+          avatarUrl: parsed.data.avatarUrl,
+        },
+        elizaAppUserService,
+      );
       account = {
         userId: delivery.userId,
         organizationId: delivery.organizationId,
       };
+      accountResolution = delivery.resolution;
       dedicated = delivery.dedicatedTarget;
     } else {
       const phoneAccount = await elizaAppUserService.findOrCreateByPhone(
@@ -302,7 +314,8 @@ app.post("/", async (c) => {
       };
     }
     const accountMs = performance.now() - accountStartedAt;
-    c.header("Server-Timing", `account;dur=${accountMs.toFixed(1)}`);
+    const accountTiming = `account;dur=${accountMs.toFixed(1)};desc="${accountResolution}"`;
+    c.header("Server-Timing", accountTiming);
     const agent = personalSharedAgent({
       userId: account.userId,
       organizationId: account.organizationId,
@@ -545,7 +558,7 @@ app.post("/", async (c) => {
       }
       c.header(
         "Server-Timing",
-        `account;dur=${accountMs.toFixed(1)}, dedicated;dur=${(
+        `${accountTiming}, dedicated;dur=${(
           performance.now() - dedicatedStartedAt
         ).toFixed(1)}`,
       );
@@ -599,7 +612,7 @@ app.post("/", async (c) => {
     );
     c.header(
       "Server-Timing",
-      `account;dur=${accountMs.toFixed(1)}, shared;dur=${(
+      `${accountTiming}, shared;dur=${(
         performance.now() - sharedStartedAt
       ).toFixed(1)}`,
     );

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -35,6 +35,7 @@ import { isThinStewardPublicPath } from "./steward/public-paths";
 export { AnonymousChatGate } from "./anonymous-chat-gate";
 export { InferenceAdmissionGate } from "./inference-admission-gate";
 export { OnboardingSessionCoordinator } from "./onboarding-session-coordinator";
+export { PersonalDeliveryProjection } from "./personal-delivery-projection";
 export { SharedRuntimeConversation } from "./shared-runtime-conversation";
 export { isThinStewardPublicPath } from "./steward/public-paths";
 export { TwitterOAuthRefreshCoordinator } from "./twitter-oauth-refresh-coordinator";

--- a/packages/cloud/api/src/personal-delivery-projection.test.ts
+++ b/packages/cloud/api/src/personal-delivery-projection.test.ts
@@ -244,6 +244,7 @@ describe("resolvePersonalDeliveryProjection", () => {
     const result = await resolvePersonalDeliveryProjection(
       {
         PERSONAL_DELIVERY_PROJECTIONS: { getByName },
+        PERSONAL_DELIVERY_PROJECTION_READ_ENABLED: "true",
       } as unknown as AppEnv["Bindings"],
       TELEGRAM,
       { resolvePersonalDelivery },
@@ -252,6 +253,29 @@ describe("resolvePersonalDeliveryProjection", () => {
     expect(result.resolution).toBe("sender-projection-hit");
     expect(getByName).toHaveBeenCalledWith("telegram:123456");
     expect(resolvePersonalDelivery).not.toHaveBeenCalled();
+  });
+
+  test("keeps reads canonical until invalidation writers are the rollback baseline", async () => {
+    const getByName = mock(() => ({
+      fetch: async () =>
+        Response.json({
+          ...sharedResult(),
+          resolution: "sender-projection-hit",
+        }),
+    }));
+    const resolvePersonalDelivery = mock(async () => sharedResult());
+
+    const result = await resolvePersonalDeliveryProjection(
+      {
+        PERSONAL_DELIVERY_PROJECTIONS: { getByName },
+      } as unknown as AppEnv["Bindings"],
+      TELEGRAM,
+      { resolvePersonalDelivery },
+    );
+
+    expect(result).toEqual(sharedResult());
+    expect(resolvePersonalDelivery).toHaveBeenCalledTimes(1);
+    expect(getByName).not.toHaveBeenCalled();
   });
 
   test("fails closed when a bound projection returns malformed state", async () => {
@@ -265,6 +289,7 @@ describe("resolvePersonalDeliveryProjection", () => {
       resolvePersonalDeliveryProjection(
         {
           PERSONAL_DELIVERY_PROJECTIONS: namespace,
+          PERSONAL_DELIVERY_PROJECTION_READ_ENABLED: "true",
         } as unknown as AppEnv["Bindings"],
         TELEGRAM,
         { resolvePersonalDelivery: async () => sharedResult() },

--- a/packages/cloud/api/src/personal-delivery-projection.test.ts
+++ b/packages/cloud/api/src/personal-delivery-projection.test.ts
@@ -1,0 +1,274 @@
+/** Exercises sender projection persistence, coherence, and Dedicated fail-open avoidance. */
+
+import { describe, expect, mock, test } from "bun:test";
+import type { PersonalDeliveryInput } from "@/lib/services/eliza-app/user-service";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import {
+  PersonalDeliveryProjection,
+  resolvePersonalDeliveryProjection,
+} from "./personal-delivery-projection";
+
+class MemoryStorage {
+  readonly values = new Map<string, unknown>();
+
+  async get<T>(key: string): Promise<T | undefined> {
+    return this.values.get(key) as T | undefined;
+  }
+
+  async put(key: string, value: unknown): Promise<void> {
+    this.values.set(key, structuredClone(value));
+  }
+
+  async delete(key: string): Promise<boolean> {
+    return this.values.delete(key);
+  }
+}
+
+function state(storage = new MemoryStorage()): {
+  durableState: DurableObjectState;
+  storage: MemoryStorage;
+} {
+  return {
+    durableState: { storage } as unknown as DurableObjectState,
+    storage,
+  };
+}
+
+const ENV = {} as AppEnv["Bindings"];
+const TELEGRAM: PersonalDeliveryInput = {
+  platform: "telegram",
+  telegramId: "123456",
+  username: "nubs",
+  displayName: "Nubs",
+};
+
+function request(path: "/resolve" | "/invalidate", body?: unknown): Request {
+  return new Request(`https://personal-delivery-projection${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
+function sharedResult() {
+  return {
+    userId: "user-1",
+    organizationId: "org-1",
+    dedicatedTarget: null,
+    isNew: false,
+    resolution: "single-query-repeat" as const,
+  };
+}
+
+describe("PersonalDeliveryProjection", () => {
+  test("hydrates once and serves repeat Shared turns from durable sender state", async () => {
+    const memory = state();
+    const resolvePersonalDelivery = mock(async () => sharedResult());
+    const object = new PersonalDeliveryProjection(memory.durableState, ENV, {
+      resolvePersonalDelivery,
+    });
+
+    const cold = await object.fetch(request("/resolve", TELEGRAM));
+    const warm = await object.fetch(request("/resolve", TELEGRAM));
+
+    expect(cold.status).toBe(200);
+    expect(await cold.json()).toMatchObject({
+      resolution: "single-query-repeat",
+    });
+    expect((await warm.json()) as Record<string, unknown>).toEqual({
+      userId: "user-1",
+      organizationId: "org-1",
+      dedicatedTarget: null,
+      isNew: false,
+      resolution: "sender-projection-hit",
+    });
+    expect(resolvePersonalDelivery).toHaveBeenCalledTimes(1);
+  });
+
+  test("survives object eviction through Durable Object storage", async () => {
+    const memory = state();
+    const firstResolver = mock(async () => sharedResult());
+    const first = new PersonalDeliveryProjection(memory.durableState, ENV, {
+      resolvePersonalDelivery: firstResolver,
+    });
+    await first.fetch(request("/resolve", TELEGRAM));
+
+    const afterEvictionResolver = mock(async () => sharedResult());
+    const afterEviction = new PersonalDeliveryProjection(
+      memory.durableState,
+      ENV,
+      {
+        resolvePersonalDelivery: afterEvictionResolver,
+      },
+    );
+    const response = await afterEviction.fetch(request("/resolve", TELEGRAM));
+
+    expect(await response.json()).toMatchObject({
+      resolution: "sender-projection-hit",
+    });
+    expect(afterEvictionResolver).not.toHaveBeenCalled();
+  });
+
+  test("rehydrates after the hard safety expiry", async () => {
+    const memory = state();
+    const firstResolver = mock(async () => sharedResult());
+    const first = new PersonalDeliveryProjection(memory.durableState, ENV, {
+      resolvePersonalDelivery: firstResolver,
+    });
+    await first.fetch(request("/resolve", TELEGRAM));
+    const stored = memory.storage.values.get("shared-account") as Record<
+      string,
+      unknown
+    >;
+    memory.storage.values.set("shared-account", { ...stored, expiresAt: 0 });
+
+    const expiredResolver = mock(async () => sharedResult());
+    const afterExpiry = new PersonalDeliveryProjection(
+      memory.durableState,
+      ENV,
+      {
+        resolvePersonalDelivery: expiredResolver,
+      },
+    );
+    const response = await afterExpiry.fetch(request("/resolve", TELEGRAM));
+
+    expect(await response.json()).toMatchObject({
+      resolution: "single-query-repeat",
+    });
+    expect(expiredResolver).toHaveBeenCalledTimes(1);
+  });
+
+  test("refreshes when the trusted transport profile changes", async () => {
+    const memory = state();
+    const resolvePersonalDelivery = mock(async () => sharedResult());
+    const object = new PersonalDeliveryProjection(memory.durableState, ENV, {
+      resolvePersonalDelivery,
+    });
+    await object.fetch(request("/resolve", TELEGRAM));
+    await object.fetch(
+      request("/resolve", { ...TELEGRAM, username: "nubs-renamed" }),
+    );
+
+    expect(resolvePersonalDelivery).toHaveBeenCalledTimes(2);
+  });
+
+  test("never caches a Dedicated target with mutable lifecycle fields", async () => {
+    const memory = state();
+    const resolvePersonalDelivery = mock(async () => ({
+      ...sharedResult(),
+      dedicatedTarget: {
+        id: "dedicated-1",
+        status: "running" as const,
+        bridge_url: "https://agent.example",
+        agent_config: { __agentUpgradedFrom: "personal:user-1:org-1" },
+      },
+    }));
+    const object = new PersonalDeliveryProjection(memory.durableState, ENV, {
+      resolvePersonalDelivery,
+    });
+
+    await object.fetch(request("/resolve", TELEGRAM));
+    await object.fetch(request("/resolve", TELEGRAM));
+
+    expect(resolvePersonalDelivery).toHaveBeenCalledTimes(2);
+    expect(memory.storage.values.size).toBe(0);
+  });
+
+  test("explicit invalidation makes the next turn rehydrate", async () => {
+    const memory = state();
+    const resolvePersonalDelivery = mock(async () => sharedResult());
+    const object = new PersonalDeliveryProjection(memory.durableState, ENV, {
+      resolvePersonalDelivery,
+    });
+    await object.fetch(request("/resolve", TELEGRAM));
+
+    expect((await object.fetch(request("/invalidate"))).status).toBe(200);
+    await object.fetch(request("/resolve", TELEGRAM));
+
+    expect(resolvePersonalDelivery).toHaveBeenCalledTimes(2);
+  });
+
+  test("serializes concurrent cold turns into one database hydration", async () => {
+    const memory = state();
+    const resolvePersonalDelivery = mock(async () => {
+      await Promise.resolve();
+      return sharedResult();
+    });
+    const object = new PersonalDeliveryProjection(memory.durableState, ENV, {
+      resolvePersonalDelivery,
+    });
+
+    const responses = await Promise.all([
+      object.fetch(request("/resolve", TELEGRAM)),
+      object.fetch(request("/resolve", TELEGRAM)),
+    ]);
+
+    expect(responses.map((response) => response.status)).toEqual([200, 200]);
+    expect(resolvePersonalDelivery).toHaveBeenCalledTimes(1);
+  });
+
+  test("rejects malformed sender input before database work", async () => {
+    const memory = state();
+    const resolvePersonalDelivery = mock(async () => sharedResult());
+    const object = new PersonalDeliveryProjection(memory.durableState, ENV, {
+      resolvePersonalDelivery,
+    });
+
+    const response = await object.fetch(
+      request("/resolve", { platform: "telegram" }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(resolvePersonalDelivery).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolvePersonalDeliveryProjection", () => {
+  test("keeps Node and tests on the canonical database resolver when unbound", async () => {
+    const resolvePersonalDelivery = mock(async () => sharedResult());
+    const result = await resolvePersonalDeliveryProjection(ENV, TELEGRAM, {
+      resolvePersonalDelivery,
+    });
+
+    expect(result).toEqual(sharedResult());
+    expect(resolvePersonalDelivery).toHaveBeenCalledTimes(1);
+  });
+
+  test("uses the bound sender object without touching the database fallback", async () => {
+    const fetch = mock(async () =>
+      Response.json({ ...sharedResult(), resolution: "sender-projection-hit" }),
+    );
+    const getByName = mock(() => ({ fetch }));
+    const resolvePersonalDelivery = mock(async () => sharedResult());
+
+    const result = await resolvePersonalDeliveryProjection(
+      {
+        PERSONAL_DELIVERY_PROJECTIONS: { getByName },
+      } as unknown as AppEnv["Bindings"],
+      TELEGRAM,
+      { resolvePersonalDelivery },
+    );
+
+    expect(result.resolution).toBe("sender-projection-hit");
+    expect(getByName).toHaveBeenCalledWith("telegram:123456");
+    expect(resolvePersonalDelivery).not.toHaveBeenCalled();
+  });
+
+  test("fails closed when a bound projection returns malformed state", async () => {
+    const namespace = {
+      getByName: () => ({
+        fetch: async () => Response.json({ success: true }),
+      }),
+    };
+
+    await expect(
+      resolvePersonalDeliveryProjection(
+        {
+          PERSONAL_DELIVERY_PROJECTIONS: namespace,
+        } as unknown as AppEnv["Bindings"],
+        TELEGRAM,
+        { resolvePersonalDelivery: async () => sharedResult() },
+      ),
+    ).rejects.toThrow("Personal delivery projection failed with status 200");
+  });
+});

--- a/packages/cloud/api/src/personal-delivery-projection.ts
+++ b/packages/cloud/api/src/personal-delivery-projection.ts
@@ -133,7 +133,9 @@ export async function resolvePersonalDeliveryProjection(
   fallback: PersonalDeliveryResolver,
 ): Promise<PersonalDeliveryResult> {
   const namespace = env.PERSONAL_DELIVERY_PROJECTIONS;
-  if (!namespace) return fallback.resolvePersonalDelivery(input);
+  if (!namespace || env.PERSONAL_DELIVERY_PROJECTION_READ_ENABLED !== "true") {
+    return fallback.resolvePersonalDelivery(input);
+  }
 
   const response = await namespace
     .getByName(

--- a/packages/cloud/api/src/personal-delivery-projection.ts
+++ b/packages/cloud/api/src/personal-delivery-projection.ts
@@ -1,0 +1,285 @@
+/**
+ * Per-sender account projection for Personal Shared connector turns.
+ *
+ * The Durable Object absorbs repeat Postgres/Hyperdrive bootstrap while the
+ * account still routes to Shared. Dedicated targets are deliberately never
+ * cached: their lifecycle and bridge fields remain authoritative in Postgres.
+ * Identity writers and tier cutover explicitly delete the sender projection;
+ * a one-hour hard expiry is the final safety bound, not the coherence model.
+ */
+
+import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
+import {
+  PERSONAL_DELIVERY_PROJECTION_INVALIDATE_PATH,
+  PERSONAL_DELIVERY_PROJECTION_RESOLVE_PATH,
+  personalDeliveryProjectionObjectName,
+} from "@/lib/services/eliza-app/personal-delivery-projection-contract";
+import type {
+  PersonalDeliveryInput,
+  PersonalDeliveryResult,
+} from "@/lib/services/eliza-app/user-service";
+import { logger } from "@/lib/utils/logger";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+const CACHE_KEY = "shared-account";
+const CACHE_TTL_MS = 60 * 60_000;
+
+interface SharedAccountProjection {
+  profileKey: string;
+  userId: string;
+  organizationId: string;
+  expiresAt: number;
+}
+
+interface PersonalDeliveryResolver {
+  resolvePersonalDelivery(
+    params: PersonalDeliveryInput,
+  ): Promise<PersonalDeliveryResult>;
+}
+
+function boundedText(value: unknown, max = 512): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= max;
+}
+
+function optionalText(value: unknown, max = 512): boolean {
+  return (
+    value === undefined || (typeof value === "string" && value.length <= max)
+  );
+}
+
+export function isPersonalDeliveryInput(
+  value: unknown,
+): value is PersonalDeliveryInput {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  if (candidate.platform === "telegram") {
+    return (
+      boundedText(candidate.telegramId, 20) &&
+      /^\d{1,20}$/.test(candidate.telegramId) &&
+      optionalText(candidate.username) &&
+      optionalText(candidate.firstName) &&
+      optionalText(candidate.displayName)
+    );
+  }
+  if (candidate.platform === "discord") {
+    return (
+      boundedText(candidate.discordId, 32) &&
+      /^\d{1,32}$/.test(candidate.discordId) &&
+      boundedText(candidate.username) &&
+      (candidate.globalName === null || optionalText(candidate.globalName)) &&
+      (candidate.avatarUrl === null || optionalText(candidate.avatarUrl, 2_048))
+    );
+  }
+  return false;
+}
+
+function senderId(input: PersonalDeliveryInput): string {
+  return input.platform === "telegram"
+    ? input.telegramId.trim()
+    : input.discordId.trim();
+}
+
+function profileKey(input: PersonalDeliveryInput): string {
+  return input.platform === "telegram"
+    ? JSON.stringify({
+        platform: input.platform,
+        senderId: senderId(input),
+        username: input.username?.trim() || null,
+        firstName: input.firstName?.trim() || null,
+      })
+    : JSON.stringify({
+        platform: input.platform,
+        senderId: senderId(input),
+        username: input.username.trim(),
+        globalName:
+          input.globalName === undefined
+            ? undefined
+            : input.globalName?.trim() || null,
+        avatarUrl: input.avatarUrl === undefined ? undefined : input.avatarUrl,
+      });
+}
+
+function isPersonalDeliveryResult(
+  value: unknown,
+): value is PersonalDeliveryResult {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  const target = candidate.dedicatedTarget;
+  const validTarget =
+    target === null ||
+    (typeof target === "object" &&
+      boundedText((target as Record<string, unknown>).id) &&
+      boundedText((target as Record<string, unknown>).status) &&
+      ((target as Record<string, unknown>).bridge_url === null ||
+        typeof (target as Record<string, unknown>).bridge_url === "string") &&
+      ((target as Record<string, unknown>).agent_config === null ||
+        (typeof (target as Record<string, unknown>).agent_config === "object" &&
+          !Array.isArray((target as Record<string, unknown>).agent_config))));
+  return (
+    boundedText(candidate.userId) &&
+    boundedText(candidate.organizationId) &&
+    validTarget &&
+    typeof candidate.isNew === "boolean" &&
+    (candidate.resolution === "sender-projection-hit" ||
+      candidate.resolution === "single-query-repeat" ||
+      candidate.resolution === "exact-dedicated-fallback" ||
+      candidate.resolution === "locked-create-or-repair")
+  );
+}
+
+export async function resolvePersonalDeliveryProjection(
+  env: AppEnv["Bindings"],
+  input: PersonalDeliveryInput,
+  fallback: PersonalDeliveryResolver,
+): Promise<PersonalDeliveryResult> {
+  const namespace = env.PERSONAL_DELIVERY_PROJECTIONS;
+  if (!namespace) return fallback.resolvePersonalDelivery(input);
+
+  const response = await namespace
+    .getByName(
+      personalDeliveryProjectionObjectName(input.platform, senderId(input)),
+    )
+    .fetch(
+      `https://personal-delivery-projection${PERSONAL_DELIVERY_PROJECTION_RESOLVE_PATH}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      },
+    );
+  const body: unknown = await response.json();
+  if (!response.ok || !isPersonalDeliveryResult(body)) {
+    throw new Error(
+      `Personal delivery projection failed with status ${response.status}`,
+    );
+  }
+  return body;
+}
+
+export class PersonalDeliveryProjection {
+  private readonly state: DurableObjectState;
+  private readonly env: AppEnv["Bindings"];
+  private readonly resolver: PersonalDeliveryResolver | undefined;
+  private entry: SharedAccountProjection | undefined;
+  private entryLoaded = false;
+  private operationQueue: Promise<void> = Promise.resolve();
+
+  constructor(
+    state: DurableObjectState,
+    env: AppEnv["Bindings"],
+    resolver?: PersonalDeliveryResolver,
+  ) {
+    this.state = state;
+    this.env = env;
+    this.resolver = resolver;
+  }
+
+  private async serialize<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.operationQueue;
+    let release: () => void = () => undefined;
+    this.operationQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  private async loadEntry(): Promise<SharedAccountProjection | undefined> {
+    if (!this.entryLoaded) {
+      this.entry =
+        await this.state.storage.get<SharedAccountProjection>(CACHE_KEY);
+      this.entryLoaded = true;
+    }
+    return this.entry;
+  }
+
+  private async invalidate(): Promise<void> {
+    await this.state.storage.delete(CACHE_KEY);
+    this.entry = undefined;
+    this.entryLoaded = true;
+  }
+
+  private async resolve(
+    input: PersonalDeliveryInput,
+  ): Promise<PersonalDeliveryResult> {
+    const now = Date.now();
+    const expectedProfile = profileKey(input);
+    const cached = await this.loadEntry();
+    if (
+      cached &&
+      cached.expiresAt > now &&
+      cached.profileKey === expectedProfile
+    ) {
+      return {
+        userId: cached.userId,
+        organizationId: cached.organizationId,
+        dedicatedTarget: null,
+        isNew: false,
+        resolution: "sender-projection-hit",
+      };
+    }
+    if (cached) await this.invalidate();
+
+    const resolved = await runWithCloudBindingsAsync(this.env, async () => {
+      const resolver =
+        this.resolver ??
+        (await import("@/lib/services/eliza-app/user-service"))
+          .elizaAppUserService;
+      return resolver.resolvePersonalDelivery(input);
+    });
+    if (resolved.dedicatedTarget === null) {
+      const projection: SharedAccountProjection = {
+        profileKey: expectedProfile,
+        userId: resolved.userId,
+        organizationId: resolved.organizationId,
+        expiresAt: now + CACHE_TTL_MS,
+      };
+      await this.state.storage.put(CACHE_KEY, projection);
+      this.entry = projection;
+      this.entryLoaded = true;
+    } else {
+      await this.invalidate();
+    }
+    return resolved;
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    return this.serialize(async () => {
+      try {
+        const path = new URL(request.url).pathname;
+        if (request.method !== "POST") {
+          return Response.json({ error: "Not found" }, { status: 404 });
+        }
+        if (path === PERSONAL_DELIVERY_PROJECTION_INVALIDATE_PATH) {
+          await this.invalidate();
+          return Response.json({ success: true });
+        }
+        if (path !== PERSONAL_DELIVERY_PROJECTION_RESOLVE_PATH) {
+          return Response.json({ error: "Not found" }, { status: 404 });
+        }
+        const body: unknown = await request.json();
+        if (!isPersonalDeliveryInput(body)) {
+          return Response.json(
+            { error: "Invalid personal delivery input" },
+            { status: 400 },
+          );
+        }
+        return Response.json(await this.resolve(body));
+      } catch (error) {
+        // error-policy:J1 this internal transport boundary fails closed rather
+        // than hiding a projection or database failure behind stale routing.
+        logger.error("[PersonalDeliveryProjection] resolution failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return Response.json(
+          { error: "Personal delivery resolution failed" },
+          { status: 502 },
+        );
+      }
+    });
+  }
+}

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/cutover/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/cutover/route.ts
@@ -20,6 +20,7 @@ import {
   findLiveTierUpgradeTarget,
 } from "@/lib/services/agent-tier-upgrade-target";
 import { readPersonalElizaCutover } from "@/lib/services/eliza-agent-config";
+import { invalidatePersonalDeliveryProjection } from "@/lib/services/eliza-app/personal-delivery-projection-contract";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import {
   coordinateSharedCutoverCommit,
@@ -46,6 +47,24 @@ const bodySchema = z.object({ dedicatedAgentId: z.string().uuid() });
 
 function json(body: unknown, status = 200): Response {
   return applyCorsHeaders(Response.json(body, { status }), CORS_METHODS);
+}
+
+async function invalidateUserDeliveryProjections(
+  env: AppEnv["Bindings"],
+  user: { telegram_id?: string | null; discord_id?: string | null },
+): Promise<void> {
+  await Promise.all([
+    invalidatePersonalDeliveryProjection(
+      env.PERSONAL_DELIVERY_PROJECTIONS,
+      "telegram",
+      user.telegram_id,
+    ),
+    invalidatePersonalDeliveryProjection(
+      env.PERSONAL_DELIVERY_PROJECTIONS,
+      "discord",
+      user.discord_id,
+    ),
+  ]);
 }
 
 function prepareRemindersForDedicated(
@@ -303,6 +322,7 @@ app.post("/", async (c) => {
         activeBase
       ) {
         try {
+          await invalidateUserDeliveryProjections(c.env, user);
           await coordinateSharedCutoverCommit(
             sourceAgentId,
             sourceAgentId,
@@ -552,6 +572,7 @@ app.post("/", async (c) => {
         sharedTodoDigest: todoSnapshot.digest,
       });
       markerCommitted = true;
+      await invalidateUserDeliveryProjections(c.env, user);
       await coordinateSharedCutoverCommit(
         sourceAgentId,
         sourceAgentId,

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -179,6 +179,7 @@ new_sqlite_classes = ["PersonalDeliveryProjection"]
 # Local/default deployments retain the direct-model control unless explicitly opted in.
 NODE_ENV = "production"
 SHARED_ELIZA_AGENT_RUNTIME = "false"
+PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "false"
 NEXT_PUBLIC_APP_URL = "https://cloud.eliza.app"
 NEXT_PUBLIC_API_URL = "https://api.eliza.app"
 ELIZA_CLOUD_URL = "https://api.eliza.app"
@@ -447,6 +448,9 @@ __filename = '"/worker.js"'
 # Protected staging proves the genuine Workerd AgentRuntime before production promotion.
 NODE_ENV = "production"
 SHARED_ELIZA_AGENT_RUNTIME = "true"
+# Two-phase rollout: deploy invalidation writers as the rollback baseline
+# before a later reviewed release enables projection reads.
+PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "false"
 # Apps (Product 2): wire the real deploy trigger so POST /api/v1/apps/:id/deploy
 # enqueues an APP_DEPLOY job the provisioning-worker daemon runs (instead of the
 # legacy status-only stub). Staging only — the apps data plane (tenant DB +
@@ -706,6 +710,7 @@ __filename = '"/worker.js"'
 # Production uses the genuine Shared Workerd runtime for personal voice.
 NODE_ENV = "production"
 SHARED_ELIZA_AGENT_RUNTIME = "true"
+PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "false"
 THIN_INFERENCE_ENTRY_ENABLED = "true"
 # Apps deploy (Product 2): arms the Worker-side deploy trigger (configureAppsDeployTrigger,
 # bootstrap-app.ts) so POST /api/v1/apps/:id/deploy enqueues a real APP_DEPLOY job instead of

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -125,6 +125,10 @@ class_name = "OnboardingSessionCoordinator"
 name = "TWITTER_OAUTH_REFRESH_COORDINATORS"
 class_name = "TwitterOAuthRefreshCoordinator"
 
+[[durable_objects.bindings]]
+name = "PERSONAL_DELIVERY_PROJECTIONS"
+class_name = "PersonalDeliveryProjection"
+
 [[migrations]]
 tag = "shared-runtime-conversations-v1"
 new_sqlite_classes = ["SharedRuntimeConversation"]
@@ -144,6 +148,10 @@ new_sqlite_classes = ["OnboardingSessionCoordinator"]
 [[migrations]]
 tag = "twitter-oauth-refresh-coordinator-v1"
 new_sqlite_classes = ["TwitterOAuthRefreshCoordinator"]
+
+[[migrations]]
+tag = "personal-delivery-projection-v1"
+new_sqlite_classes = ["PersonalDeliveryProjection"]
 
 # General API limits and queues may use Railway Redis via REDIS_URL. Inference
 # routes never connect to it: Cloudflare Rate Limiting bindings protect ingress,
@@ -635,6 +643,10 @@ class_name = "OnboardingSessionCoordinator"
 name = "TWITTER_OAUTH_REFRESH_COORDINATORS"
 class_name = "TwitterOAuthRefreshCoordinator"
 
+[[env.staging.durable_objects.bindings]]
+name = "PERSONAL_DELIVERY_PROJECTIONS"
+class_name = "PersonalDeliveryProjection"
+
 [[env.staging.ratelimits]]
 name = "GLOBAL_RATE_LIMITER"
 namespace_id = "1615311"
@@ -861,6 +873,10 @@ class_name = "OnboardingSessionCoordinator"
 [[env.production.durable_objects.bindings]]
 name = "TWITTER_OAUTH_REFRESH_COORDINATORS"
 class_name = "TwitterOAuthRefreshCoordinator"
+
+[[env.production.durable_objects.bindings]]
+name = "PERSONAL_DELIVERY_PROJECTIONS"
+class_name = "PersonalDeliveryProjection"
 
 [[env.production.ratelimits]]
 name = "GLOBAL_RATE_LIMITER"

--- a/packages/cloud/shared/src/lib/services/eliza-app/identity-link.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/identity-link.integration.test.ts
@@ -4,7 +4,7 @@
  * platform mismatch, cross-account handle-conflict rejection, and the actual
  * canonical + projection binding writes. Real SQL, no rollback-capable mocks.
  */
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
 const CAN_USE_ISOLATED_PGLITE =
@@ -23,7 +23,10 @@ import {
 } from "../../../db/schemas/organizations";
 import { userIdentities } from "../../../db/schemas/user-identities";
 import { users } from "../../../db/schemas/users";
+import type { RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-env";
+import { runWithCloudBindingsAsync } from "../../runtime/cloud-bindings";
 import { confirmIdentityLink, startIdentityLink } from "./identity-link";
+import { PERSONAL_DELIVERY_PROJECTION_BINDING } from "./personal-delivery-projection-contract";
 
 const PGLITE_TIMEOUT = 60_000;
 const ORG_A = "00000000-0000-4000-8000-00000000a001";
@@ -136,6 +139,88 @@ describe("startIdentityLink", () => {
 });
 
 describe("confirmIdentityLink", () => {
+  test("invalidates a cached provisional sender before the next Telegram resolve", async () => {
+    await seedAccount(USER_A, ORG_A, "steward-a");
+    const { code } = await startIdentityLink({
+      userId: USER_A,
+      organizationId: ORG_A,
+      platform: "telegram",
+    });
+
+    let cachedOwner: string | null = USER_B;
+    const fetch = mock(async () => {
+      cachedOwner = null;
+      return Response.json({ success: true });
+    });
+    const getByName = mock(() => ({ fetch }));
+
+    const confirmed = await runWithCloudBindingsAsync(
+      {
+        [PERSONAL_DELIVERY_PROJECTION_BINDING]: {
+          getByName,
+        } as unknown as RuntimeDurableObjectNamespace,
+      },
+      () =>
+        confirmIdentityLink({
+          code,
+          platform: "telegram",
+          platformId: "424242",
+          platformName: "linked_owner",
+        }),
+    );
+
+    expect(confirmed).toMatchObject({ status: "linked", userId: USER_A });
+    expect(getByName).toHaveBeenCalledWith("telegram:424242");
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    const nextOwner =
+      cachedOwner ??
+      (
+        await dbWrite
+          .select({ id: users.id })
+          .from(users)
+          .where(eq(users.telegram_id, "424242"))
+          .limit(1)
+      )[0]?.id;
+    expect(nextOwner).toBe(USER_A);
+  });
+
+  test("a matching LINK replay heals a transient projection invalidation failure", async () => {
+    await seedAccount(USER_A, ORG_A, "steward-a");
+    const { code } = await startIdentityLink({
+      userId: USER_A,
+      organizationId: ORG_A,
+      platform: "discord",
+    });
+
+    let attempts = 0;
+    const fetch = mock(async () => {
+      attempts += 1;
+      return attempts === 1
+        ? Response.json({ error: "unavailable" }, { status: 503 })
+        : Response.json({ success: true });
+    });
+    const bindings = {
+      [PERSONAL_DELIVERY_PROJECTION_BINDING]: {
+        getByName: () => ({ fetch }),
+      } as unknown as RuntimeDurableObjectNamespace,
+    };
+    const confirmation = {
+      code,
+      platform: "discord" as const,
+      platformId: "987654321",
+      platformName: "linked_owner",
+    };
+
+    await expect(
+      runWithCloudBindingsAsync(bindings, () => confirmIdentityLink(confirmation)),
+    ).rejects.toThrow("projection invalidation failed with status 503");
+    expect(
+      await runWithCloudBindingsAsync(bindings, () => confirmIdentityLink(confirmation)),
+    ).toEqual({ status: "already_used" });
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
   test("binds the handle once and reports replay as already_used", async () => {
     await seedAccount(USER_A, ORG_A, "steward-a");
     const { code } = await startIdentityLink({

--- a/packages/cloud/shared/src/lib/services/eliza-app/identity-link.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/identity-link.ts
@@ -24,6 +24,7 @@ import { users } from "../../../db/schemas/users";
 import { isUniqueConstraintError } from "../../utils/db-errors";
 import { logger } from "../../utils/logger";
 import { isValidE164, normalizePhoneNumber } from "../../utils/phone-normalization";
+import { invalidateBoundPersonalDeliveryProjection } from "./personal-delivery-projection-contract";
 
 /** Unambiguous alphabet (no 0/O, 1/I/L) so codes survive being typed by hand. */
 const CODE_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
@@ -166,6 +167,7 @@ export async function confirmIdentityLink(
   }
 
   let result: ConfirmIdentityLinkResult;
+  let replayInvalidation: { platform: "telegram" | "discord"; platformId: string } | undefined;
   try {
     result = await dbWrite.transaction(async (tx) => {
       const [row] = await tx
@@ -175,7 +177,16 @@ export async function confirmIdentityLink(
         .for("update")
         .limit(1);
       if (!row) return { status: "code_not_found" };
-      if (row.status === "linked") return { status: "already_used" };
+      if (row.status === "linked") {
+        if (
+          row.platform === input.platform &&
+          row.platform_id === platformId &&
+          (row.platform === "telegram" || row.platform === "discord")
+        ) {
+          replayInvalidation = { platform: row.platform, platformId };
+        }
+        return { status: "already_used" };
+      }
       if (row.status === "expired" || row.expires_at.getTime() <= Date.now()) {
         return { status: "expired" };
       }
@@ -215,6 +226,17 @@ export async function confirmIdentityLink(
     // handle. The transaction rollback also restores this code to pending.
     if (isUniqueConstraintError(error)) return { status: "handle_conflict" };
     throw error;
+  }
+
+  const projectionInvalidation =
+    result.status === "linked" && (result.platform === "telegram" || result.platform === "discord")
+      ? { platform: result.platform, platformId }
+      : replayInvalidation;
+  if (projectionInvalidation) {
+    await invalidateBoundPersonalDeliveryProjection(
+      projectionInvalidation.platform,
+      projectionInvalidation.platformId,
+    );
   }
 
   if (result.status !== "linked") return result;

--- a/packages/cloud/shared/src/lib/services/eliza-app/personal-delivery-projection-contract.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/personal-delivery-projection-contract.test.ts
@@ -1,0 +1,45 @@
+/** Verifies sender projection addressing and the fail-closed invalidation boundary. */
+
+import { describe, expect, mock, test } from "bun:test";
+import type { RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-env";
+import {
+  invalidatePersonalDeliveryProjection,
+  personalDeliveryProjectionObjectName,
+} from "./personal-delivery-projection-contract";
+
+describe("personal delivery projection contract", () => {
+  test("uses one stable object name per platform sender", () => {
+    expect(personalDeliveryProjectionObjectName("telegram", " 123456 ")).toBe("telegram:123456");
+    expect(personalDeliveryProjectionObjectName("discord", "987654")).toBe("discord:987654");
+  });
+
+  test("sends an explicit invalidation to the bound sender object", async () => {
+    const fetch = mock(async () => Response.json({ success: true }));
+    const getByName = mock(() => ({ fetch }));
+
+    await invalidatePersonalDeliveryProjection(
+      { getByName } as unknown as RuntimeDurableObjectNamespace,
+      "telegram",
+      "123456",
+    );
+
+    expect(getByName).toHaveBeenCalledWith("telegram:123456");
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  test("fails closed when the projection cannot confirm invalidation", async () => {
+    const namespace = {
+      getByName: () => ({
+        fetch: async () => Response.json({ error: "unavailable" }, { status: 503 }),
+      }),
+    };
+
+    await expect(
+      invalidatePersonalDeliveryProjection(
+        namespace as unknown as RuntimeDurableObjectNamespace,
+        "telegram",
+        "123456",
+      ),
+    ).rejects.toThrow("projection invalidation failed with status 503");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/eliza-app/personal-delivery-projection-contract.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/personal-delivery-projection-contract.ts
@@ -1,0 +1,44 @@
+/** Defines the internal Durable Object address and fail-closed invalidation contract. */
+
+import type { RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-env";
+import { getCloudBinding } from "../../runtime/cloud-bindings";
+
+export const PERSONAL_DELIVERY_PROJECTION_BINDING = "PERSONAL_DELIVERY_PROJECTIONS";
+export const PERSONAL_DELIVERY_PROJECTION_RESOLVE_PATH = "/resolve";
+export const PERSONAL_DELIVERY_PROJECTION_INVALIDATE_PATH = "/invalidate";
+
+export function personalDeliveryProjectionObjectName(
+  platform: "telegram" | "discord",
+  platformUserId: string,
+): string {
+  return `${platform}:${platformUserId.trim()}`;
+}
+
+export async function invalidatePersonalDeliveryProjection(
+  namespace: RuntimeDurableObjectNamespace | undefined,
+  platform: "telegram" | "discord",
+  platformUserId: string | null | undefined,
+): Promise<void> {
+  if (!namespace || !platformUserId) return;
+  const response = await namespace
+    .getByName(personalDeliveryProjectionObjectName(platform, platformUserId))
+    .fetch(`https://personal-delivery-projection${PERSONAL_DELIVERY_PROJECTION_INVALIDATE_PATH}`, {
+      method: "POST",
+    });
+  if (!response.ok) {
+    throw new Error(
+      `Personal delivery projection invalidation failed with status ${response.status}`,
+    );
+  }
+}
+
+export async function invalidateBoundPersonalDeliveryProjection(
+  platform: "telegram" | "discord",
+  platformUserId: string | null | undefined,
+): Promise<void> {
+  return invalidatePersonalDeliveryProjection(
+    getCloudBinding<RuntimeDurableObjectNamespace>(PERSONAL_DELIVERY_PROJECTION_BINDING),
+    platform,
+    platformUserId,
+  );
+}

--- a/packages/cloud/shared/src/lib/services/eliza-app/user-service.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/user-service.ts
@@ -30,6 +30,7 @@ import { apiKeysService } from "../api-keys";
 import { readUpgradedFromAgentId } from "../eliza-agent-config";
 import { personalSharedAgentId } from "../shared-runtime/personal-shared-agent";
 import { redeemSignupCode } from "../signup-code";
+import { invalidateBoundPersonalDeliveryProjection } from "./personal-delivery-projection-contract";
 import type { TelegramAuthData } from "./telegram-auth";
 
 export interface FindOrCreateResult {
@@ -43,8 +44,28 @@ export interface PersonalDeliveryResult {
   organizationId: string;
   dedicatedTarget: Pick<AgentSandbox, "id" | "status" | "bridge_url" | "agent_config"> | null;
   isNew: boolean;
-  resolution: "single-query-repeat" | "exact-dedicated-fallback" | "locked-create-or-repair";
+  resolution:
+    | "sender-projection-hit"
+    | "single-query-repeat"
+    | "exact-dedicated-fallback"
+    | "locked-create-or-repair";
 }
+
+export type PersonalDeliveryInput =
+  | {
+      platform: "telegram";
+      telegramId: string;
+      username?: string;
+      firstName?: string;
+      displayName?: string;
+    }
+  | {
+      platform: "discord";
+      discordId: string;
+      username: string;
+      globalName?: string | null;
+      avatarUrl?: string | null;
+    };
 
 function generateSlugFromTelegram(username?: string, telegramId?: string): string {
   const base = username ? username.toLowerCase().replace(/[^a-z0-9]/g, "-") : `tg-${telegramId}`;
@@ -199,23 +220,7 @@ class ElizaAppUserService {
    * in one read-only statement. Missing, stale, or conflicting projections
    * retain one sender-locked convergence transaction as the only repair writer.
    */
-  async resolvePersonalDelivery(
-    params:
-      | {
-          platform: "telegram";
-          telegramId: string;
-          username?: string;
-          firstName?: string;
-          displayName?: string;
-        }
-      | {
-          platform: "discord";
-          discordId: string;
-          username: string;
-          globalName?: string | null;
-          avatarUrl?: string | null;
-        },
-  ): Promise<PersonalDeliveryResult> {
+  async resolvePersonalDelivery(params: PersonalDeliveryInput): Promise<PersonalDeliveryResult> {
     const senderId =
       params.platform === "telegram" ? params.telegramId.trim() : params.discordId.trim();
     const idPattern = params.platform === "telegram" ? /^\d{1,20}$/ : /^\d{1,32}$/;
@@ -1040,6 +1045,8 @@ class ElizaAppUserService {
       phone: `***${normalizedPhone.slice(-2)}`,
     });
 
+    await invalidateBoundPersonalDeliveryProjection("telegram", telegramId);
+
     return { success: true };
   }
 
@@ -1161,6 +1168,8 @@ class ElizaAppUserService {
       username: telegramData.username,
     });
 
+    await invalidateBoundPersonalDeliveryProjection("telegram", telegramId);
+
     return { success: true };
   }
 
@@ -1208,6 +1217,8 @@ class ElizaAppUserService {
       discordId,
       username,
     });
+
+    await invalidateBoundPersonalDeliveryProjection("discord", discordId);
 
     return { success: true };
   }

--- a/packages/cloud/shared/src/lib/steward-sync.ts
+++ b/packages/cloud/shared/src/lib/steward-sync.ts
@@ -26,6 +26,7 @@ import type { RuntimeDurableObjectNamespace } from "../types/cloud-worker-env";
 import { apiKeysService } from "./services/api-keys";
 import { charactersService } from "./services/characters/characters";
 import { discordService } from "./services/discord";
+import { invalidateBoundPersonalDeliveryProjection } from "./services/eliza-app/personal-delivery-projection-contract";
 import { emailService } from "./services/email";
 import { invitesService } from "./services/invites";
 import { organizationsService } from "./services/organizations";
@@ -593,6 +594,10 @@ export async function syncUserFromSteward(params: StewardSyncParams): Promise<St
         organization: promotion.organization,
       };
     }
+  }
+
+  if (claimedTelegramUser?.telegram_id) {
+    await invalidateBoundPersonalDeliveryProjection("telegram", claimedTelegramUser.telegram_id);
   }
 
   // ── 1. Existing user by steward_user_id ──────────────────────────────

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -100,6 +100,8 @@ export interface Bindings {
 
   /** One explicitly invalidated Shared account projection per connector sender. */
   PERSONAL_DELIVERY_PROJECTIONS?: RuntimeDurableObjectNamespace;
+  /** Two-phase rollout gate; readers activate only after invalidation writers are the rollback baseline. */
+  PERSONAL_DELIVERY_PROJECTION_READ_ENABLED?: string;
 
   // ---- Cloudflare machine-local protective rate limits ----
   GLOBAL_RATE_LIMITER?: RuntimeRateLimitBinding;

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -98,6 +98,9 @@ export interface Bindings {
   /** One strongly ordered X credential refresh coordinator per organization and role. */
   TWITTER_OAUTH_REFRESH_COORDINATORS?: RuntimeDurableObjectNamespace;
 
+  /** One explicitly invalidated Shared account projection per connector sender. */
+  PERSONAL_DELIVERY_PROJECTIONS?: RuntimeDurableObjectNamespace;
+
   // ---- Cloudflare machine-local protective rate limits ----
   GLOBAL_RATE_LIMITER?: RuntimeRateLimitBinding;
   CHAT_ROUTE_RATE_LIMITER?: RuntimeRateLimitBinding;


### PR DESCRIPTION
Part of #20313

## What this phase does

This is the rollback-safe foundation for sender-scoped Personal Shared account projections:

- adds one Durable Object per connector sender for Shared user/org resolution
- caches only stable Shared account identifiers; Dedicated lifecycle/config remains canonical
- serializes concurrent cold hydration and persists before serving the in-memory projection
- invalidates on Telegram/Discord identity mutation, Steward convergence, and Shared-to-Dedicated cutover
- adds exact resolution telemetry without logging message or credential content
- deploys the binding and all invalidation writers with PERSONAL_DELIVERY_PROJECTION_READ_ENABLED=false

Reads deliberately remain on the canonical database path in this PR. A later reviewed activation PR may set the gate to the exact string true only after this foundation is the deployed rollback baseline. That prevents a binding-absent rollback from silently missing invalidations and later resurrecting stale Durable Object state.

## Exact evidence

Head: 6106efaf4da19e56da0ad1c2bfe802e6b0077234
Tree: 25fbf9655986eb53852199c36df90474f10355ee
Base: 591119472a6cb554b46d1ddbb23e59ac421d8f63

- 180/180 focused tests, 833 assertions, 0 failures on the reviewed byte-equivalent three-commit stack
- terminal rebase onto disjoint core secret-context develop: exact three-commit range-diff byte-equivalent; identity 13/13 and direct projection/route 37/37 rerun
- identity-link real PGlite integration: 13/13, including cached provisional invalidation and transient failure replay healing
- projection/contract/Personal Shared route: 37/37, 130 assertions
- cloud/shared typecheck: PASS
- cloud/api typecheck: PASS
- production Worker dry bundle: PASS; projection binding present and read gate false
- Biome: 16/16 files PASS
- git diff --check: PASS

The full focused matrix is: projection/route 37, identity-link 13, user/account 45, Steward convergence 45, auth/cutover 40. Bun's repo-wide text coverage renderer produced a terminal WriteFailed on one large suite; the exact assertions passed with LCOV-only reporting. Stateful PGlite suites were run one process per file to avoid cross-suite database/mock contamination.

## Runtime evidence and remaining activation bar

This PR does not claim a live latency win because reads are intentionally disabled and staging is untouched. Activation remains gated on a deployed descendant plus labeled cold and immediate-warm Telegram probes showing account resolution, Shared/model, gateway attempt, and phone-visible timing. Embeddings remain disabled for Personal Shared and are not part of this change.



