### PR TITLE
fix(core): bind continuation resolution to the requester and honor content.actions completed markers (stacked on #20227)

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -6824,7 +6824,10 @@ describe("planner prior dialogue and continuation resolution (#17024)", () => {
 		const state = recentState([
 			{
 				id: "00000000-0000-0000-0000-00000000ee01" as UUID,
-				entityId: "00000000-0000-0000-0000-00000000ee11" as UUID,
+				// The requester: matches the makeMessage sender so continuation
+				// resolution, which is bound to the current requester's entity,
+				// treats this as the speaker's own prior request.
+				entityId: "00000000-0000-0000-0000-000000000002" as UUID,
 				agentId,
 				roomId,
 				createdAt: 1,
@@ -6889,7 +6892,10 @@ describe("planner prior dialogue and continuation resolution (#17024)", () => {
 		const state = recentState([
 			{
 				id: "00000000-0000-0000-0000-00000000ee01" as UUID,
-				entityId: "00000000-0000-0000-0000-00000000ee11" as UUID,
+				// The requester: matches the makeMessage sender so continuation
+				// resolution, which is bound to the current requester's entity,
+				// treats this as the speaker's own prior request.
+				entityId: "00000000-0000-0000-0000-000000000002" as UUID,
 				agentId,
 				roomId,
 				createdAt: 1,
@@ -6917,6 +6923,125 @@ describe("planner prior dialogue and continuation resolution (#17024)", () => {
 		});
 
 		expect(result.kind).toBe("direct_reply");
+		expect(useModelCalls(runtime)).toHaveLength(1);
+	});
+
+	it("does not resolve a continuation to another participant's request (#20227 review)", async () => {
+		const shellHandler = vi.fn(async () => ({ success: true, text: "" }));
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: "Sure — what would you like me to do?",
+			}),
+		]);
+		runtime.actions = [
+			{
+				name: "SHELL",
+				similes: [],
+				description: "Run a local shell command.",
+				parameters: [],
+				examples: [],
+				validate: async () => true,
+				handler: shellHandler,
+			},
+		] as never;
+		const agentId = runtime.agentId;
+		// A different participant owns the pending shell request; the current
+		// "go ahead" turn comes from the makeMessage sender (…0002), who has
+		// asked for nothing.
+		const state = recentState([
+			{
+				id: "00000000-0000-0000-0000-00000000ff01" as UUID,
+				entityId: "00000000-0000-0000-0000-00000000ff11" as UUID,
+				agentId,
+				roomId,
+				createdAt: 1,
+				content: {
+					text: "show me disk usage on this server",
+					source: "test",
+				},
+			},
+			{
+				id: "00000000-0000-0000-0000-00000000ff02" as UUID,
+				entityId: agentId,
+				agentId,
+				roomId,
+				createdAt: 2,
+				content: { text: "On it.", source: "test" },
+			},
+		]);
+		runtime.composeState = vi.fn(async () => state);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "go ahead" }),
+			state,
+			responseId: "00000000-0000-0000-0000-0000000000c4" as UUID,
+		});
+
+		// The other participant's request must not be promoted on this
+		// speaker's behalf: no planner turn, no shell run.
+		expect(result.kind).toBe("direct_reply");
+		expect(shellHandler).not.toHaveBeenCalled();
+		expect(useModelCalls(runtime)).toHaveLength(1);
+	});
+
+	it("does not replay a completed action recorded only in content.actions (#20227 review)", async () => {
+		const shellHandler = vi.fn(async () => ({ success: true, text: "" }));
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: "Glad to hear it!",
+			}),
+		]);
+		runtime.actions = [
+			{
+				name: "SHELL",
+				similes: [],
+				description: "Run a local shell command.",
+				parameters: [],
+				examples: [],
+				validate: async () => true,
+				handler: shellHandler,
+			},
+		] as never;
+		const agentId = runtime.agentId;
+		// The agent already ran the tool; the short result carries the tool
+		// marker only in content.actions (no actionCallbackHistory).
+		const state = recentState([
+			{
+				id: "00000000-0000-0000-0000-00000000fa01" as UUID,
+				entityId: "00000000-0000-0000-0000-000000000002" as UUID,
+				agentId,
+				roomId,
+				createdAt: 1,
+				content: {
+					text: "show me disk usage on this server",
+					source: "test",
+				},
+			},
+			{
+				id: "00000000-0000-0000-0000-00000000fa02" as UUID,
+				entityId: agentId,
+				agentId,
+				roomId,
+				createdAt: 2,
+				content: { text: "Done.", source: "test", actions: ["SHELL"] },
+			},
+		]);
+		runtime.composeState = vi.fn(async () => state);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "that is good" }),
+			state,
+			responseId: "00000000-0000-0000-0000-0000000000c5" as UUID,
+		});
+
+		// Praise after a delivered result stays a simple reply — the finished
+		// request is not re-promoted and the tool does not run again.
+		expect(result.kind).toBe("direct_reply");
+		expect(shellHandler).not.toHaveBeenCalled();
 		expect(useModelCalls(runtime)).toHaveLength(1);
 	});
 });

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -4778,7 +4778,16 @@ describe("runV5MessageRuntimeStage1", () => {
 									agentId: "00000000-0000-0000-0000-000000000003" as UUID,
 									roomId: "00000000-0000-0000-0000-000000000004" as UUID,
 									createdAt: 2,
-									content: { text: staleAssistantAnswer },
+									// Tool-derived answers carry their producing action in
+									// content.actions (runtime persists) or
+									// actionCallbackHistory (route persists); the planner
+									// window excludes them by that structural marker, not by
+									// role (#17024), so ordinary assistant questions/previews
+									// stay visible for continuation resolution.
+									content: {
+										text: staleAssistantAnswer,
+										actions: ["CHECK_RUNTIME"],
+									},
 								},
 								currentMessage,
 							],
@@ -6652,5 +6661,262 @@ describe("runV5MessageRuntimeStage1 — engagement addressing gate", () => {
 		}
 		const scopes = reportErrorCalls(runtime).map((call) => call[0]);
 		expect(scopes).toContain("MessageService.resolveAddressees");
+	});
+});
+
+describe("planner prior dialogue and continuation resolution (#17024)", () => {
+	const roomId = "00000000-0000-0000-0000-000000001111" as UUID;
+
+	function recentState(recentMessages: unknown[]): State {
+		return {
+			values: { availableContexts: "simple, general" },
+			data: {
+				providers: {
+					RECENT_MESSAGES: {
+						text: "# Conversation Messages\nprovider text should not render",
+						data: { recentMessages },
+						providerName: "RECENT_MESSAGES",
+					},
+				},
+			},
+			text: "",
+		};
+	}
+
+	it("renders ordinary own replies in the planner context while excluding tool-derived ones", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["general"],
+				replyText: "On it.",
+				extra: { requiresTool: true },
+			}),
+			JSON.stringify({
+				thought: "No tool needed in this fixture.",
+				toolCalls: [],
+				messageToUser: "Done.",
+			}),
+		]);
+		const agentId = runtime.agentId;
+		const state = recentState([
+			{
+				id: "00000000-0000-0000-0000-00000000dd01" as UUID,
+				entityId: "00000000-0000-0000-0000-00000000dd11" as UUID,
+				agentId,
+				roomId,
+				createdAt: 1,
+				content: { text: "whats the btc price", source: "discord" },
+				metadata: {
+					type: "message",
+					sender: { id: "discord-1gig", name: "1gig" },
+				},
+			},
+			{
+				id: "00000000-0000-0000-0000-00000000dd02" as UUID,
+				entityId: agentId,
+				agentId,
+				roomId,
+				createdAt: 2,
+				content: {
+					text: "Do you want that in USD or EUR?",
+					source: "discord",
+				},
+			},
+			{
+				id: "00000000-0000-0000-0000-00000000dd03" as UUID,
+				entityId: agentId,
+				agentId,
+				roomId,
+				createdAt: 3,
+				content: {
+					text: "BTC is around $63,000 right now.",
+					source: "discord",
+					actions: ["WEB_SEARCH"],
+				},
+			},
+			{
+				id: "00000000-0000-0000-0000-00000000dd04" as UUID,
+				entityId: agentId,
+				agentId,
+				roomId,
+				createdAt: 4,
+				content: {
+					text: "ETH is $3,000 right now.",
+					source: "discord",
+					actionCallbackHistory: ["ETH is $3,000 right now."],
+				},
+			},
+		]);
+		runtime.composeState = vi.fn(async () => state);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "in USD please" }),
+			state,
+			responseId: "00000000-0000-0000-0000-0000000000c1" as UUID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		const calls = useModelCalls(runtime);
+		expect(calls[1]?.[0]).toBe(ModelType.ACTION_PLANNER);
+		const plannerParams = calls[1]?.[1] as {
+			messages?: Array<{ role?: string; content?: string | null }>;
+		};
+		const plannerUserContent = plannerParams.messages?.[1]?.content ?? "";
+		// The ordinary own reply — the question a continuation refers to — is
+		// visible and role-tagged.
+		expect(plannerUserContent).toContain(
+			"prior_message:agent:\nTest Agent: Do you want that in USD or EUR?",
+		);
+		// Tool-derived own answers stay out of the planner window (stale-answer
+		// hazard): both the actions-marked and callback-history-marked rows.
+		expect(plannerUserContent).not.toContain("BTC is around $63,000");
+		expect(plannerUserContent).not.toContain("ETH is $3,000");
+		// The planner boundary instruction now covers own-reply staleness.
+		expect(plannerUserContent).toContain("treat every fact in them as stale");
+	});
+
+	it("resolves an explicit continuation turn to the prior user request for candidate inference", async () => {
+		const shellHandler = vi.fn(async () => ({
+			success: true,
+			text: "Filesystem usage: 42%",
+		}));
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: "Sure.",
+			}),
+			{
+				thought: "Run the pending disk-usage request.",
+				toolCalls: [
+					{
+						id: "shell-disk-usage",
+						name: "SHELL",
+						args: { command: "df -h" },
+					},
+				],
+			},
+			JSON.stringify({
+				success: true,
+				decision: "FINISH",
+				thought: "Shell returned the disk usage.",
+				messageToUser: "Filesystem usage is at 42%.",
+			}),
+		]);
+		runtime.actions = [
+			{
+				name: "SHELL",
+				similes: [],
+				description: "Run a local shell command.",
+				parameters: [
+					{
+						name: "command",
+						description: "Command to run",
+						required: true,
+						schema: { type: "string" },
+					},
+				],
+				examples: [],
+				validate: async () => true,
+				handler: shellHandler,
+			},
+		] as never;
+		const agentId = runtime.agentId;
+		const state = recentState([
+			{
+				id: "00000000-0000-0000-0000-00000000ee01" as UUID,
+				entityId: "00000000-0000-0000-0000-00000000ee11" as UUID,
+				agentId,
+				roomId,
+				createdAt: 1,
+				content: {
+					text: "show me disk usage on this server",
+					source: "test",
+				},
+			},
+			{
+				id: "00000000-0000-0000-0000-00000000ee02" as UUID,
+				entityId: agentId,
+				agentId,
+				roomId,
+				createdAt: 2,
+				content: { text: "On it.", source: "test" },
+			},
+		]);
+		runtime.composeState = vi.fn(async () => state);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "finish my request" }),
+			state,
+			responseId: "00000000-0000-0000-0000-0000000000c2" as UUID,
+		});
+
+		// The contentless continuation turn resolved to the pending shell
+		// request, so the turn routes to the planner with the shell candidate
+		// and the shell action actually runs.
+		expect(result.kind).toBe("planned_reply");
+		expect(shellHandler).toHaveBeenCalledTimes(1);
+		const calls = useModelCalls(runtime);
+		expect(calls[1]?.[0]).toBe(ModelType.ACTION_PLANNER);
+		const plannerParams = JSON.stringify(calls[1]?.[1] ?? {});
+		expect(plannerParams).toContain("SHELL");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"Filesystem usage is at 42%.",
+			);
+		}
+	});
+
+	it("does not promote a non-continuation turn from prior history (topic-switch control)", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: "You're welcome!",
+			}),
+		]);
+		runtime.actions = [
+			{
+				name: "SHELL",
+				similes: [],
+				description: "Run a local shell command.",
+				parameters: [],
+				examples: [],
+				validate: async () => true,
+				handler: vi.fn(async () => ({ success: true, text: "" })),
+			},
+		] as never;
+		const agentId = runtime.agentId;
+		const state = recentState([
+			{
+				id: "00000000-0000-0000-0000-00000000ee01" as UUID,
+				entityId: "00000000-0000-0000-0000-00000000ee11" as UUID,
+				agentId,
+				roomId,
+				createdAt: 1,
+				content: {
+					text: "show me disk usage on this server",
+					source: "test",
+				},
+			},
+			{
+				id: "00000000-0000-0000-0000-00000000ee02" as UUID,
+				entityId: agentId,
+				agentId,
+				roomId,
+				createdAt: 2,
+				content: { text: "On it.", source: "test" },
+			},
+		]);
+		runtime.composeState = vi.fn(async () => state);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ text: "thanks, you are great" }),
+			state,
+			responseId: "00000000-0000-0000-0000-0000000000c3" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		expect(useModelCalls(runtime)).toHaveLength(1);
 	});
 });

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -351,6 +351,7 @@ import {
 	inferLocalShellCommandFromMessageText,
 	inferWebSearchQueryFromMessageText,
 	isShellDirectActionName,
+	isToolDerivedAssistantContent,
 	LEGACY_CODING_DELEGATION_ACTION_NAMES,
 	looksLikeBareLinkShare,
 	looksLikeLocalShellRequest,
@@ -2272,34 +2273,6 @@ function priorDialogueContent(text: string, speaker?: string): string {
  */
 const PLANNER_MAX_OWN_REPLY_TURNS = 4;
 
-/**
- * Structural marker for an assistant memory whose text is a tool-derived
- * answer rather than plain dialogue: it carries merged action-callback
- * history, or its recorded actions include a real tool (anything beyond the
- * reply/none envelope). The planner context excludes these rows so a stale
- * tool-derived answer is never parroted in place of a fresh tool run.
- */
-function isToolDerivedAssistantContent(content: Memory["content"]): boolean {
-	if (!content || typeof content !== "object") return false;
-	const callbackHistory = (content as { actionCallbackHistory?: unknown })
-		.actionCallbackHistory;
-	if (Array.isArray(callbackHistory) && callbackHistory.length > 0) {
-		return true;
-	}
-	const actions = (content as { actions?: unknown }).actions;
-	if (!Array.isArray(actions)) return false;
-	return actions.some((action) => {
-		if (typeof action !== "string") return false;
-		const normalized = normalizeActionIdentifier(action);
-		return (
-			normalized.length > 0 &&
-			normalized !== "REPLY" &&
-			normalized !== "NONE" &&
-			normalized !== "IGNORE"
-		);
-	});
-}
-
 function appendPriorDialogueEvents(
 	events: ContextEvent[],
 	runtime: IAgentRuntime,
@@ -2615,6 +2588,7 @@ function resolveContinuationInferenceMessageText(
 		currentText,
 		recentMessages,
 		runtime.agentId,
+		message.entityId,
 		message.id,
 	);
 }

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -356,6 +356,7 @@ import {
 	looksLikeLocalShellRequest,
 	looksLikeWebSearchRequest,
 	normalizeActionIdentifier,
+	resolveExplicitContinuationRequestText,
 } from "./message/direct-action-heuristics";
 import {
 	buildFailureReplyPrompt,
@@ -2264,12 +2265,57 @@ function priorDialogueContent(text: string, speaker?: string): string {
 	return `${speaker}: ${text}`;
 }
 
+/**
+ * How many of the agent's own prior turns the tool-planner context renders.
+ * Enough to cover the pending question/preview plus a short back-and-forth,
+ * small enough to keep the stale-answer surface and token cost bounded.
+ */
+const PLANNER_MAX_OWN_REPLY_TURNS = 4;
+
+/**
+ * Structural marker for an assistant memory whose text is a tool-derived
+ * answer rather than plain dialogue: it carries merged action-callback
+ * history, or its recorded actions include a real tool (anything beyond the
+ * reply/none envelope). The planner context excludes these rows so a stale
+ * tool-derived answer is never parroted in place of a fresh tool run.
+ */
+function isToolDerivedAssistantContent(content: Memory["content"]): boolean {
+	if (!content || typeof content !== "object") return false;
+	const callbackHistory = (content as { actionCallbackHistory?: unknown })
+		.actionCallbackHistory;
+	if (Array.isArray(callbackHistory) && callbackHistory.length > 0) {
+		return true;
+	}
+	const actions = (content as { actions?: unknown }).actions;
+	if (!Array.isArray(actions)) return false;
+	return actions.some((action) => {
+		if (typeof action !== "string") return false;
+		const normalized = normalizeActionIdentifier(action);
+		return (
+			normalized.length > 0 &&
+			normalized !== "REPLY" &&
+			normalized !== "NONE" &&
+			normalized !== "IGNORE"
+		);
+	});
+}
+
 function appendPriorDialogueEvents(
 	events: ContextEvent[],
 	runtime: IAgentRuntime,
 	state: State,
 	currentMessage: Memory,
-	options?: { includeOwnReplies?: boolean },
+	options?: {
+		includeOwnReplies?: boolean;
+		/**
+		 * Planner mode: keep ordinary own replies (questions, previews, acks —
+		 * what "yes"/"finish it" refers to) while excluding tool-derived own
+		 * answers structurally (stale-answer hazard) and bounding how many own
+		 * turns render.
+		 */
+		excludeToolDerivedOwnReplies?: boolean;
+		maxOwnReplies?: number;
+	},
 ): void {
 	const includeOwnReplies = options?.includeOwnReplies ?? false;
 	const providers = state.data?.providers;
@@ -2297,12 +2343,19 @@ function appendPriorDialogueEvents(
 			// (role-tagged prior_message:agent below): the current_turn_boundary
 			// contract tells the model these blocks are its only chat-recall
 			// source, so dropping its own turns made it confabulate about what it
-			// previously said. The tool planner opts out (includeOwnReplies=false)
-			// because a planner that sees its own stale tool-derived answer
-			// parrots it instead of running the fresh check. The artifact guards
+			// previously said. The tool planner keeps ordinary own dialogue too
+			// (the question/preview a continuation turn refers to) but excludes
+			// tool-derived own answers structurally so it never parrots a stale
+			// tool result instead of running the fresh check. The artifact guards
 			// below still strip non-dialogue agent output for every sender.
-			if (!includeOwnReplies && m.entityId === runtime.agentId) {
-				return false;
+			if (m.entityId === runtime.agentId) {
+				if (!includeOwnReplies) return false;
+				if (
+					options?.excludeToolDerivedOwnReplies === true &&
+					isToolDerivedAssistantContent(m.content)
+				) {
+					return false;
+				}
 			}
 			if (
 				typeof m.content?.source === "string" &&
@@ -2329,6 +2382,20 @@ function appendPriorDialogueEvents(
 			return text.length > 0;
 		})
 		.sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0));
+	// Bound how many of the agent's own turns render (newest win): the planner
+	// needs the immediate question/preview a continuation refers to, not the
+	// agent's whole side of a long conversation.
+	const maxOwnReplies = options?.maxOwnReplies;
+	if (maxOwnReplies !== undefined) {
+		let ownRepliesKept = 0;
+		for (let index = dialogue.length - 1; index >= 0; index--) {
+			if (dialogue[index]?.entityId !== runtime.agentId) continue;
+			ownRepliesKept++;
+			if (ownRepliesKept > maxOwnReplies) {
+				dialogue.splice(index, 1);
+			}
+		}
+	}
 	for (const memory of dialogue) {
 		const text = getUserMessageText(memory);
 		if (!text) continue;
@@ -2503,20 +2570,52 @@ function looksLikePriorDialogueArtifact(text: string): boolean {
 	);
 }
 
-function hasStructuredRecentMessagesProvider(state: State): boolean {
-	const providers = state.data?.providers;
+function getStructuredRecentMessages(
+	state: State | undefined,
+): Memory[] | null {
+	const providers = state?.data?.providers;
 	if (!providers || typeof providers !== "object") {
-		return false;
+		return null;
 	}
 	const recent = (providers as Record<string, unknown>).RECENT_MESSAGES;
 	if (!recent || typeof recent !== "object") {
-		return false;
+		return null;
 	}
 	const data = (recent as { data?: unknown }).data;
-	return Boolean(
-		data &&
-			typeof data === "object" &&
-			Array.isArray((data as { recentMessages?: unknown }).recentMessages),
+	const recentMessages =
+		data && typeof data === "object" && "recentMessages" in data
+			? (data as { recentMessages?: unknown }).recentMessages
+			: undefined;
+	return Array.isArray(recentMessages) ? (recentMessages as Memory[]) : null;
+}
+
+function hasStructuredRecentMessagesProvider(state: State): boolean {
+	return getStructuredRecentMessages(state) !== null;
+}
+
+/**
+ * Resolves an explicit continuation turn ("finish my request", "that is
+ * good") to the nearest prior user request from the composed RECENT_MESSAGES
+ * window so candidate inference reruns against the request the turn refers
+ * to. Returns null for every non-continuation turn (topic switches, fresh
+ * asks, and turns without structured history are untouched); the resolved
+ * text feeds ONLY action-candidate inference — the prompt keeps the user's
+ * literal message.
+ */
+function resolveContinuationInferenceMessageText(
+	runtime: IAgentRuntime,
+	message: Memory,
+	state: State | undefined,
+): string | null {
+	const currentText = getUserMessageText(message);
+	if (!currentText?.trim()) return null;
+	const recentMessages = getStructuredRecentMessages(state);
+	if (!recentMessages) return null;
+	return resolveExplicitContinuationRequestText(
+		currentText,
+		recentMessages,
+		runtime.agentId,
+		message.id,
 	);
 }
 
@@ -3315,10 +3414,18 @@ async function createV5MessageContextObject(args: {
 
 	appendPriorDialogueEvents(events, args.runtime, args.state, args.message, {
 		// The response handler needs the agent's own prior turns for grounded
-		// chat recall ("did you tell me X?"); the tool planner must not see its
-		// own stale tool-derived answers or it answers from them instead of
-		// executing the fresh check the user asked for.
-		includeOwnReplies: !args.includeTools,
+		// chat recall ("did you tell me X?"). The tool planner needs the
+		// ordinary ones too — the question/preview a continuation turn ("finish
+		// it", "that is good") refers to — but role-wide inclusion resurrects
+		// the stale-answer hazard, so the planner's window is bounded and
+		// excludes tool-derived own answers structurally.
+		includeOwnReplies: true,
+		...(args.includeTools
+			? {
+					excludeToolDerivedOwnReplies: true,
+					maxOwnReplies: PLANNER_MAX_OWN_REPLY_TURNS,
+				}
+			: {}),
 	});
 
 	// Contexts are routing taxonomy, not proof that a handler exists. Promise
@@ -3360,7 +3467,7 @@ async function createV5MessageContextObject(args: {
 		source: "message-service",
 		stable: false,
 		content: args.includeTools
-			? "current_turn_boundary: Plan and execute only the final message:user. Prior messages and reply_reference are context for resolving references, never pending commands. Stage 1 already decided this turn needs tools; use current tool results for live data and side effects, and never claim work that no tool result proves."
+			? 'current_turn_boundary: Plan and execute only the final message:user. Prior messages and reply_reference are context for resolving references, never pending commands. The prior_message:agent blocks are your own earlier replies, shown only so you can resolve what a continuation like "finish it", "yes", or "that is good" refers to — treat every fact in them as stale. Stage 1 already decided this turn needs tools; use current tool results for live data and side effects, never answer by repeating a prior reply in place of executing the fresh check, and never claim work that no tool result proves.'
 			: 'current_turn_boundary: The prior_message blocks above are context only. If a reply_reference block follows, it is the platform message that the final message:user is replying to; use it only to resolve references such as this/that/it. Execute and answer only the final message:user below. Do not merge separate prior requests into the current task unless the final message explicitly references them. Exception for visible-context recall: when the final message asks a recall question about what was said in this conversation (who mentioned X, did anyone bring up Y, what did I say about Z, what was the last message, did you yourself say W), you may scan the prior_message blocks above and answer from what is literally visible there. This recall exception covers only what was literally SAID in the visible chat. It does NOT cover the user\'s tracked work: a recap, status, or what-did-I-get-done ask about their todos, tasks, reminders, habits, goals, notes, or day ("recap my day", "what\'s left today", "did I finish everything", "how did I do this week") is a live tasks lookup, not chat recall — route it to the tasks tools and answer from what they return; never report an empty or missing day from the visible window alone.' +
 				// Only the chat-recall context renders the agent's own prior turns;
 				// the tool-planner context deliberately omits them (stale-answer
@@ -4014,7 +4121,7 @@ export const BUILTIN_RESPONSE_HANDLER_EVALUATORS: readonly ResponseHandlerEvalua
 			description:
 				"Promotes simple-path replies to planning when the current user request matches a registered action's metadata.",
 			priority: 20,
-			shouldRun: ({ message, messageHandler, runtime }) => {
+			shouldRun: ({ message, messageHandler, runtime, state }) => {
 				if (messageHandler.processMessage !== "RESPOND") return false;
 				if (messageHandler.plan.requiresTool === true) return false;
 				// A sub-agent completion relay is owned by the sub-agent-completion
@@ -4031,9 +4138,15 @@ export const BUILTIN_RESPONSE_HANDLER_EVALUATORS: readonly ResponseHandlerEvalua
 				if (nonSimpleContexts.length > 0) return false;
 				const text = getUserMessageText(message);
 				if (!text?.trim()) return false;
+				// A continuation turn ("finish it", "that is good") has no
+				// inferable intent of its own — rerun inference on the resolved
+				// nearest prior user request instead.
+				const inferenceText =
+					resolveContinuationInferenceMessageText(runtime, message, state) ??
+					text;
 				const inference = inferDirectCurrentRequestCandidateInference(
 					runtime.actions ?? [],
-					text,
+					inferenceText,
 				);
 				if (inference.names.length === 0) return false;
 				// Same escalation valve as messageHandlerFromFieldResult: this
@@ -4047,11 +4160,14 @@ export const BUILTIN_RESPONSE_HANDLER_EVALUATORS: readonly ResponseHandlerEvalua
 					stageOneCandidateActions: messageHandler.plan.candidateActions ?? [],
 				});
 			},
-			evaluate: ({ message, messageHandler, runtime }) => {
+			evaluate: ({ message, messageHandler, runtime, state }) => {
 				const text = getUserMessageText(message) ?? "";
+				const inferenceText =
+					resolveContinuationInferenceMessageText(runtime, message, state) ??
+					text;
 				const inference = inferDirectCurrentRequestCandidateInference(
 					runtime.actions ?? [],
-					text,
+					inferenceText,
 				);
 				const candidateActions = shouldSuppressInferredCandidateEscalation({
 					inference,
@@ -7691,6 +7807,27 @@ export async function runV5MessageRuntimeStage1(args: {
 			ModelType.RESPONSE_HANDLER,
 		);
 		const rawFieldParsed = extractMessageHandlerRawParsed(rawMessageHandler);
+		// An explicit continuation turn ("finish my request", "that is good")
+		// carries no inferable intent of its own, so candidate inference runs on
+		// the nearest pending prior user request instead. The substitution feeds
+		// only routing heuristics — prompts keep the literal user text.
+		const continuationResolvedMessageText =
+			resolveContinuationInferenceMessageText(
+				args.runtime,
+				args.message,
+				args.state,
+			);
+		const inferenceMessageText =
+			continuationResolvedMessageText ?? getUserMessageText(args.message);
+		if (continuationResolvedMessageText) {
+			args.runtime.logger?.debug?.(
+				{
+					src: "service:message",
+					resolvedRequest: continuationResolvedMessageText.slice(0, 200),
+				},
+				"[message] continuation turn resolved to prior user request for candidate inference",
+			);
+		}
 		let fieldRunResult: ResponseHandlerFieldRunResult | null = null;
 		let messageHandler: MessageHandlerResult | null = null;
 		if (rawFieldParsed) {
@@ -7711,7 +7848,7 @@ export async function runV5MessageRuntimeStage1(args: {
 				fieldRunResult,
 				{
 					actions: args.runtime.actions,
-					messageText: getUserMessageText(args.message),
+					messageText: inferenceMessageText,
 					candidateBackstopRules: getCandidateActionBackstopRules(args.runtime),
 					subAgentCompletionRelay: isSubAgentCompletionArtifact(args.message),
 				},
@@ -7720,7 +7857,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		if (!messageHandler) {
 			messageHandler = parseMessageHandlerModelOutput(rawMessageHandler, {
 				actions: args.runtime.actions,
-				messageText: getUserMessageText(args.message),
+				messageText: inferenceMessageText,
 				subAgentCompletionRelay: isSubAgentCompletionArtifact(args.message),
 			});
 		}
@@ -7762,7 +7899,7 @@ export async function runV5MessageRuntimeStage1(args: {
 			messageHandler = synthesizePlannerFallbackFromStage1Failure({
 				reason: stage1FailureReason,
 				actions: args.runtime.actions,
-				messageText: getUserMessageText(args.message),
+				messageText: inferenceMessageText,
 			});
 			args.runtime.logger?.warn?.(
 				{
@@ -8211,7 +8348,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		// heuristic must not undo that decision.
 		const directPlannerInference = inferDirectCurrentRequestCandidateInference(
 			args.runtime.actions ?? [],
-			getUserMessageText(args.message) ?? "",
+			inferenceMessageText ?? "",
 		);
 		const directPlannerCandidateActions = directPlannerInference.names;
 		if (

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -1451,22 +1451,27 @@ describe("classifyExplicitContinuationTurn", () => {
 
 describe("resolveExplicitContinuationRequestText", () => {
 	const AGENT_ID = "00000000-0000-0000-0000-0000000000aa";
+	const USER_ID = "00000000-0000-0000-0000-0000000000bb";
+	const OTHER_USER_ID = "00000000-0000-0000-0000-0000000000cc";
 	const room = (
 		entries: Array<{
 			id: string;
 			agent?: boolean;
+			entity?: string;
 			text: string;
 			createdAt: number;
 			callbacks?: string[];
+			actions?: string[];
 		}>,
 	) =>
 		entries.map((entry) => ({
 			id: entry.id,
-			entityId: entry.agent ? AGENT_ID : "00000000-0000-0000-0000-0000000000bb",
+			entityId: entry.agent ? AGENT_ID : (entry.entity ?? USER_ID),
 			createdAt: entry.createdAt,
 			content: {
 				text: entry.text,
 				...(entry.callbacks ? { actionCallbackHistory: entry.callbacks } : {}),
+				...(entry.actions ? { actions: entry.actions } : {}),
 			},
 		}));
 
@@ -1484,6 +1489,7 @@ describe("resolveExplicitContinuationRequestText", () => {
 				{ id: "m3", text: "finish my request", createdAt: 3 },
 			]),
 			AGENT_ID,
+			USER_ID,
 			"m3",
 		);
 		expect(resolved).toBe("track a 30 minute run for me");
@@ -1497,6 +1503,7 @@ describe("resolveExplicitContinuationRequestText", () => {
 				{ id: "m2", agent: true, text: "On it.", createdAt: 2 },
 			]),
 			AGENT_ID,
+			USER_ID,
 		);
 		expect(pending).toBe("run ls in my home directory");
 
@@ -1513,6 +1520,7 @@ describe("resolveExplicitContinuationRequestText", () => {
 				},
 			]),
 			AGENT_ID,
+			USER_ID,
 		);
 		expect(delivered).toBe(null);
 	});
@@ -1523,10 +1531,16 @@ describe("resolveExplicitContinuationRequestText", () => {
 				"what's the weather in tokyo?",
 				room([{ id: "m1", text: "track a run", createdAt: 1 }]),
 				AGENT_ID,
+				USER_ID,
 			),
 		).toBe(null);
 		expect(
-			resolveExplicitContinuationRequestText("finish it", [], AGENT_ID),
+			resolveExplicitContinuationRequestText(
+				"finish it",
+				[],
+				AGENT_ID,
+				USER_ID,
+			),
 		).toBe(null);
 	});
 
@@ -1541,8 +1555,111 @@ describe("resolveExplicitContinuationRequestText", () => {
 				{ id: "m5", text: "finish it", createdAt: 5 },
 			]),
 			AGENT_ID,
+			USER_ID,
 			"m5",
 		);
 		expect(resolved).toBe("run df -h on the server");
+	});
+
+	it("never resolves a continuation to another participant's request (#20227 review)", () => {
+		// User A's destructive request is the nearest prior request in the
+		// shared room; User B's contentless "go ahead" must not select it.
+		const sharedRoom = room([
+			{
+				id: "m1",
+				entity: OTHER_USER_ID,
+				text: "delete my deployment",
+				createdAt: 1,
+			},
+			{
+				id: "m2",
+				agent: true,
+				text: "Should I delete the production deployment?",
+				createdAt: 2,
+			},
+			{ id: "m3", text: "go ahead", createdAt: 3 },
+		]);
+		expect(
+			resolveExplicitContinuationRequestText(
+				"go ahead",
+				sharedRoom,
+				AGENT_ID,
+				USER_ID,
+				"m3",
+			),
+		).toBe(null);
+		// The same room resolves for the participant who actually asked.
+		expect(
+			resolveExplicitContinuationRequestText(
+				"go ahead",
+				sharedRoom,
+				AGENT_ID,
+				OTHER_USER_ID,
+				"m3",
+			),
+		).toBe("delete my deployment");
+	});
+
+	it("binds resolution to the requester's own request when both participants have asked", () => {
+		const resolved = resolveExplicitContinuationRequestText(
+			"finish my request",
+			room([
+				{ id: "m1", text: "track a 30 minute run for me", createdAt: 1 },
+				{
+					id: "m2",
+					entity: OTHER_USER_ID,
+					text: "delete my deployment",
+					createdAt: 2,
+				},
+				{ id: "m3", agent: true, text: "Working on it.", createdAt: 3 },
+				{ id: "m4", text: "finish my request", createdAt: 4 },
+			]),
+			AGENT_ID,
+			USER_ID,
+			"m4",
+		);
+		// The other participant's request is nearer, but resolution stays on
+		// the requester's own prior ask.
+		expect(resolved).toBe("track a 30 minute run for me");
+	});
+
+	it("treats a completed action recorded only in content.actions as delivered (#20227 review)", () => {
+		const completed = room([
+			{ id: "m1", text: "delete the stale deployment", createdAt: 1 },
+			{
+				id: "m2",
+				agent: true,
+				text: "Done.",
+				createdAt: 2,
+				actions: ["DELETE_DEPLOYMENT"],
+			},
+		]);
+		expect(
+			resolveExplicitContinuationRequestText(
+				"that is good",
+				completed,
+				AGENT_ID,
+				USER_ID,
+			),
+		).toBe(null);
+		// The reply/none envelope is not a tool marker: a short pending ack
+		// recorded with actions: ["REPLY"] still resolves.
+		expect(
+			resolveExplicitContinuationRequestText(
+				"that is good",
+				room([
+					{ id: "m1", text: "run ls in my home directory", createdAt: 1 },
+					{
+						id: "m2",
+						agent: true,
+						text: "On it.",
+						createdAt: 2,
+						actions: ["REPLY"],
+					},
+				]),
+				AGENT_ID,
+				USER_ID,
+			),
+		).toBe("run ls in my home directory");
 	});
 });

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import type { Action } from "../../types/components";
 import {
+	classifyExplicitContinuationTurn,
 	findAvailableActionName,
 	findCodingDelegationActionName,
 	findShellDirectActionName,
@@ -21,6 +22,7 @@ import {
 	looksLikeBareLinkShare,
 	looksLikeLocalShellRequest,
 	looksLikeWebSearchRequest,
+	resolveExplicitContinuationRequestText,
 } from "./direct-action-heuristics.ts";
 
 /** The exact processed-content shape Discord produces for a shared link with a
@@ -1400,5 +1402,147 @@ describe("batch-1 matrix fixes: budget noun + scheduled-item admin (F3/F5)", () 
 				"draw up a plan for the garage",
 			).kind,
 		).not.toBe("media-generation");
+	});
+});
+describe("classifyExplicitContinuationTurn", () => {
+	it("classifies directive continuations", () => {
+		expect(classifyExplicitContinuationTurn("finish my request")).toBe(
+			"directive",
+		);
+		expect(classifyExplicitContinuationTurn("Finish it.")).toBe("directive");
+		expect(classifyExplicitContinuationTurn("continue")).toBe("directive");
+		expect(classifyExplicitContinuationTurn("ok, go ahead")).toBe("directive");
+		expect(classifyExplicitContinuationTurn("yes please do it")).toBe(
+			"directive",
+		);
+		expect(classifyExplicitContinuationTurn("keep going")).toBe("directive");
+	});
+
+	it("classifies approval continuations", () => {
+		expect(classifyExplicitContinuationTurn("that is good")).toBe("approval");
+		expect(classifyExplicitContinuationTurn("that's good, go ahead")).toBe(
+			"approval",
+		);
+		expect(classifyExplicitContinuationTurn("yes")).toBe("approval");
+		expect(classifyExplicitContinuationTurn("sounds good")).toBe("approval");
+		expect(classifyExplicitContinuationTurn("that works")).toBe("approval");
+	});
+
+	it("rejects ordinary chat, topic switches, and questions", () => {
+		expect(classifyExplicitContinuationTurn("that is a good question")).toBe(
+			null,
+		);
+		expect(
+			classifyExplicitContinuationTurn("how tall is the eiffel tower?"),
+		).toBe(null);
+		expect(
+			classifyExplicitContinuationTurn("finish my sandwich and tell me a joke"),
+		).toBe(null);
+		expect(classifyExplicitContinuationTurn("good morning")).toBe(null);
+		expect(classifyExplicitContinuationTurn("is that good?")).toBe(null);
+		expect(classifyExplicitContinuationTurn("")).toBe(null);
+		expect(
+			classifyExplicitContinuationTurn(
+				"that is good but now let's talk about the weather in tokyo instead",
+			),
+		).toBe(null);
+	});
+});
+
+describe("resolveExplicitContinuationRequestText", () => {
+	const AGENT_ID = "00000000-0000-0000-0000-0000000000aa";
+	const room = (
+		entries: Array<{
+			id: string;
+			agent?: boolean;
+			text: string;
+			createdAt: number;
+			callbacks?: string[];
+		}>,
+	) =>
+		entries.map((entry) => ({
+			id: entry.id,
+			entityId: entry.agent ? AGENT_ID : "00000000-0000-0000-0000-0000000000bb",
+			createdAt: entry.createdAt,
+			content: {
+				text: entry.text,
+				...(entry.callbacks ? { actionCallbackHistory: entry.callbacks } : {}),
+			},
+		}));
+
+	it("resolves a directive continuation to the nearest prior user request", () => {
+		const resolved = resolveExplicitContinuationRequestText(
+			"finish my request",
+			room([
+				{ id: "m1", text: "track a 30 minute run for me", createdAt: 1 },
+				{
+					id: "m2",
+					agent: true,
+					text: "Want me to log it as cardio?",
+					createdAt: 2,
+				},
+				{ id: "m3", text: "finish my request", createdAt: 3 },
+			]),
+			AGENT_ID,
+			"m3",
+		);
+		expect(resolved).toBe("track a 30 minute run for me");
+	});
+
+	it("resolves an approval turn only while the agent's last reply looks pending", () => {
+		const pending = resolveExplicitContinuationRequestText(
+			"that is good",
+			room([
+				{ id: "m1", text: "run ls in my home directory", createdAt: 1 },
+				{ id: "m2", agent: true, text: "On it.", createdAt: 2 },
+			]),
+			AGENT_ID,
+		);
+		expect(pending).toBe("run ls in my home directory");
+
+		const delivered = resolveExplicitContinuationRequestText(
+			"that is good",
+			room([
+				{ id: "m1", text: "run ls in my home directory", createdAt: 1 },
+				{
+					id: "m2",
+					agent: true,
+					text: "Here are your files: a.txt b.txt",
+					createdAt: 2,
+					callbacks: ["Here are your files: a.txt b.txt"],
+				},
+			]),
+			AGENT_ID,
+		);
+		expect(delivered).toBe(null);
+	});
+
+	it("returns null for non-continuation turns and empty history", () => {
+		expect(
+			resolveExplicitContinuationRequestText(
+				"what's the weather in tokyo?",
+				room([{ id: "m1", text: "track a run", createdAt: 1 }]),
+				AGENT_ID,
+			),
+		).toBe(null);
+		expect(
+			resolveExplicitContinuationRequestText("finish it", [], AGENT_ID),
+		).toBe(null);
+	});
+
+	it("skips prior continuation turns instead of chaining them", () => {
+		const resolved = resolveExplicitContinuationRequestText(
+			"finish it",
+			room([
+				{ id: "m1", text: "run df -h on the server", createdAt: 1 },
+				{ id: "m2", agent: true, text: "Should I run it now?", createdAt: 2 },
+				{ id: "m3", text: "go ahead", createdAt: 3 },
+				{ id: "m4", agent: true, text: "Working on it.", createdAt: 4 },
+				{ id: "m5", text: "finish it", createdAt: 5 },
+			]),
+			AGENT_ID,
+			"m5",
+		);
+		expect(resolved).toBe("run df -h on the server");
 	});
 });

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -1686,10 +1686,41 @@ export type ContinuationDialogueEntry = {
 		text?: unknown;
 		type?: unknown;
 		source?: unknown;
+		actions?: unknown;
 		actionCallbackHistory?: unknown;
 		metadata?: unknown;
 	};
 };
+
+/**
+ * Structural marker for message content whose text is a tool-derived answer
+ * rather than plain dialogue: it carries merged action-callback history, or
+ * its recorded actions include a real tool (anything beyond the
+ * reply/none/ignore envelope). Continuation resolution and the planner
+ * context share this predicate so a completed tool result is never mistaken
+ * for a still-pending turn regardless of which field recorded the tool run.
+ */
+export function isToolDerivedAssistantContent(
+	content: ContinuationDialogueEntry["content"],
+): boolean {
+	if (!content || typeof content !== "object") return false;
+	const callbackHistory = content.actionCallbackHistory;
+	if (Array.isArray(callbackHistory) && callbackHistory.length > 0) {
+		return true;
+	}
+	const actions = content.actions;
+	if (!Array.isArray(actions)) return false;
+	return actions.some((action) => {
+		if (typeof action !== "string") return false;
+		const normalized = normalizeActionIdentifier(action);
+		return (
+			normalized.length > 0 &&
+			normalized !== "REPLY" &&
+			normalized !== "NONE" &&
+			normalized !== "IGNORE"
+		);
+	});
+}
 
 const CONTINUATION_LEAD_IN =
 	"(?:ok(?:ay)?|yes|yep|yeah|sure|alright|great|perfect)?[,.!]?\\s*(?:please\\s+)?";
@@ -1754,6 +1785,7 @@ function isContinuationDialogueArtifact(
 	const content = entry.content;
 	if (!content || typeof content !== "object") return true;
 	if (content.type === "action_result") return true;
+	if (isToolDerivedAssistantContent(content)) return true;
 	if (
 		typeof content.source === "string" &&
 		content.source.includes("sub-agent")
@@ -1780,16 +1812,21 @@ const PENDING_ASSISTANT_TURN_MAX_CHARS = 160;
  * on the request the user is actually referring to. Deterministic and
  * conservative: non-continuation turns resolve to nothing (topic switches are
  * untouched), approval turns additionally require the agent's latest visible
- * reply to still look pending (a question or a short ack without tool-result
- * callbacks), and the resolved text is the single nearest prior user request
- * — prior requests are never concatenated together or onto the current turn.
+ * reply to still look pending (a question or a short ack without structural
+ * tool-derived markers), the resolved text is the single nearest prior user
+ * request — prior requests are never concatenated together or onto the
+ * current turn — and candidates are bound to the requester: RECENT_MESSAGES
+ * is room-scoped, so a continuation only ever resolves to a prior request
+ * from the same entity that is speaking now, never another participant's.
  */
 export function resolveExplicitContinuationRequestText(
 	currentText: string,
 	recentMessages: ReadonlyArray<ContinuationDialogueEntry>,
 	agentId: string,
+	requesterEntityId: string,
 	currentMessageId?: string,
 ): string | null {
+	if (!requesterEntityId || requesterEntityId === agentId) return null;
 	const kind = classifyExplicitContinuationTurn(currentText);
 	if (!kind) return null;
 	const ordered = [...recentMessages]
@@ -1808,8 +1845,6 @@ export function resolveExplicitContinuationRequestText(
 		if (!lastAssistant || isContinuationDialogueArtifact(lastAssistant)) {
 			return null;
 		}
-		const callbacks = lastAssistant.content?.actionCallbackHistory;
-		if (Array.isArray(callbacks) && callbacks.length > 0) return null;
 		const lastText = continuationEntryText(lastAssistant);
 		const looksPending =
 			lastText.endsWith("?") ||
@@ -1819,7 +1854,7 @@ export function resolveExplicitContinuationRequestText(
 
 	for (let index = ordered.length - 1; index >= 0; index--) {
 		const entry = ordered[index];
-		if (!entry || entry.entityId === agentId) continue;
+		if (!entry || entry.entityId !== requesterEntityId) continue;
 		if (isContinuationDialogueArtifact(entry)) continue;
 		const text = continuationEntryText(entry);
 		if (text.length === 0) continue;

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -1672,3 +1672,164 @@ export function inferWebSearchQueryFromMessageText(
 
 	return query.length > 0 ? query : messageText.trim();
 }
+
+/**
+ * Minimal structural view of a recent-message memory used by continuation
+ * resolution. Kept local so the heuristics module stays free of the full
+ * Memory type; callers pass provider-shaped rows (state RECENT_MESSAGES data).
+ */
+export type ContinuationDialogueEntry = {
+	id?: string;
+	entityId?: string;
+	createdAt?: number;
+	content?: {
+		text?: unknown;
+		type?: unknown;
+		source?: unknown;
+		actionCallbackHistory?: unknown;
+		metadata?: unknown;
+	};
+};
+
+const CONTINUATION_LEAD_IN =
+	"(?:ok(?:ay)?|yes|yep|yeah|sure|alright|great|perfect)?[,.!]?\\s*(?:please\\s+)?";
+
+// Directive continuations explicitly tell the agent to keep working; they are
+// contentless by construction (no domain nouns survive the anchored match), so
+// substituting the resolved prior request for candidate inference cannot mask
+// a fresh ask.
+const CONTINUATION_DIRECTIVE_RE = new RegExp(
+	`^${CONTINUATION_LEAD_IN}(?:(?:finish|complete|continue|resume)(?:\\s+(?:up|it|that|this|(?:my|the|that|this)\\s+(?:request|task|work|job)|what\\s+you\\s+were\\s+doing|where\\s+you\\s+left\\s+off))?|go\\s+ahead|do\\s+it|proceed|keep\\s+going|carry\\s+on|make\\s+it\\s+so)(?:\\s+(?:please|then|now))?$`,
+	"iu",
+);
+
+// Approval continuations accept a pending question/preview ("that is good",
+// bare "yes"). They only resolve when the agent's latest visible turn still
+// looks pending — an ack or a question — so praise after a delivered result
+// does not re-trigger the finished request.
+const CONTINUATION_APPROVAL_RE = new RegExp(
+	`^${CONTINUATION_LEAD_IN}(?:yes|yep|yeah|(?:that|this|it)(?:'s|\\s+is)?\\s+(?:good|great|perfect|fine|right|correct)|(?:that|this|it)\\s+works|sounds\\s+good|looks\\s+good)(?:\\s*[,.!]?\\s*(?:please\\s+)?(?:go\\s+ahead|do\\s+it|proceed|finish(?:\\s+it)?|continue|thanks?|thank\\s+you))?$`,
+	"iu",
+);
+
+function normalizeContinuationText(text: string): string {
+	return text
+		.trim()
+		.replace(/[.!…]+$/u, "")
+		.replace(/\s+/gu, " ");
+}
+
+export type ExplicitContinuationKind = "directive" | "approval";
+
+/**
+ * Classifies a turn that carries no request of its own and only tells the
+ * agent to proceed with (or approves) earlier work. Anchored whole-message
+ * matches with a short length cap keep ordinary chat ("that is a good
+ * question", topic switches) out.
+ */
+export function classifyExplicitContinuationTurn(
+	text: string,
+): ExplicitContinuationKind | null {
+	const normalized = normalizeContinuationText(text);
+	if (normalized.length === 0 || normalized.length > 60) return null;
+	if (normalized.includes("?")) return null;
+	if (CONTINUATION_DIRECTIVE_RE.test(normalized)) return "directive";
+	if (CONTINUATION_APPROVAL_RE.test(normalized)) return "approval";
+	return null;
+}
+
+export function looksLikeExplicitContinuationTurn(text: string): boolean {
+	return classifyExplicitContinuationTurn(text) !== null;
+}
+
+function continuationEntryText(entry: ContinuationDialogueEntry): string {
+	return typeof entry.content?.text === "string"
+		? entry.content.text.trim()
+		: "";
+}
+
+function isContinuationDialogueArtifact(
+	entry: ContinuationDialogueEntry,
+): boolean {
+	const content = entry.content;
+	if (!content || typeof content !== "object") return true;
+	if (content.type === "action_result") return true;
+	if (
+		typeof content.source === "string" &&
+		content.source.includes("sub-agent")
+	) {
+		return true;
+	}
+	const metadata = content.metadata;
+	if (
+		metadata &&
+		typeof metadata === "object" &&
+		(metadata as { subAgent?: unknown }).subAgent === true
+	) {
+		return true;
+	}
+	return false;
+}
+
+const CONTINUATION_LOOKBACK_ENTRIES = 12;
+const PENDING_ASSISTANT_TURN_MAX_CHARS = 160;
+
+/**
+ * Resolves an explicit continuation turn ("finish my request", "that is
+ * good") to the nearest prior user request so candidate inference can rerun
+ * on the request the user is actually referring to. Deterministic and
+ * conservative: non-continuation turns resolve to nothing (topic switches are
+ * untouched), approval turns additionally require the agent's latest visible
+ * reply to still look pending (a question or a short ack without tool-result
+ * callbacks), and the resolved text is the single nearest prior user request
+ * — prior requests are never concatenated together or onto the current turn.
+ */
+export function resolveExplicitContinuationRequestText(
+	currentText: string,
+	recentMessages: ReadonlyArray<ContinuationDialogueEntry>,
+	agentId: string,
+	currentMessageId?: string,
+): string | null {
+	const kind = classifyExplicitContinuationTurn(currentText);
+	if (!kind) return null;
+	const ordered = [...recentMessages]
+		.filter((entry) => {
+			if (!entry || typeof entry !== "object") return false;
+			if (currentMessageId && entry.id === currentMessageId) return false;
+			return continuationEntryText(entry).length > 0;
+		})
+		.sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0))
+		.slice(-CONTINUATION_LOOKBACK_ENTRIES);
+
+	if (kind === "approval") {
+		const lastAssistant = [...ordered]
+			.reverse()
+			.find((entry) => entry.entityId === agentId);
+		if (!lastAssistant || isContinuationDialogueArtifact(lastAssistant)) {
+			return null;
+		}
+		const callbacks = lastAssistant.content?.actionCallbackHistory;
+		if (Array.isArray(callbacks) && callbacks.length > 0) return null;
+		const lastText = continuationEntryText(lastAssistant);
+		const looksPending =
+			lastText.endsWith("?") ||
+			lastText.length <= PENDING_ASSISTANT_TURN_MAX_CHARS;
+		if (!looksPending) return null;
+	}
+
+	for (let index = ordered.length - 1; index >= 0; index--) {
+		const entry = ordered[index];
+		if (!entry || entry.entityId === agentId) continue;
+		if (isContinuationDialogueArtifact(entry)) continue;
+		const text = continuationEntryText(entry);
+		if (text.length === 0) continue;
+		if (classifyExplicitContinuationTurn(text) !== null) continue;
+		if (
+			normalizeContinuationText(text) === normalizeContinuationText(currentText)
+		) {
+			continue;
+		}
+		return text;
+	}
+	return null;
+}


### PR DESCRIPTION
# Relates to

Stacked repair for https://github.com/elizaOS/eliza/pull/20227 — implements both blocking defects from the 0takuc0mrade `REQUEST_CHANGES` review. This PR targets the contributor branch `fix/17024-planner-continuation-context` (not `develop`) so #20227 can absorb it before merging.

- Original PR: https://github.com/elizaOS/eliza/pull/20227
- Exact repair base (live #20227 head at publish): `88f8235a8f02113ff11bb0dc6bc329b2fa880cfb`
- Repair commit: `b2f79481cdef98234bc1dbf24fb2305ab23256fd`

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR is stacked on the exact live head of #20227 (`88f8235a8`); the base branch tracks `develop` through the original PR, so no separate rebase applies here.
- [ ] `bun install` and `bun run verify` were not run in this isolated repair worktree — recorded in **Known gaps / failures** with the exact blocker; focused package gates (typecheck, Biome, targeted Vitest suites) all pass.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Stacked exactly on `fix/17024-planner-continuation-context` @ `88f8235a8f02113ff11bb0dc6bc329b2fa880cfb`, which is the branch #20227 targets `develop` from; zero conflicts.
- [ ] `bun run verify` not run post-sync in this isolated worktree — exact blocker documented in **Known gaps / failures**.

# Risks

Low. The change tightens two guards on an already-conservative deterministic resolver: continuation resolution now returns `null` in cases where it previously returned another participant's text or a completed request. The failure mode of the fix is a missed continuation (agent asks again) instead of a wrong side-effecting action inference. `isToolDerivedAssistantContent` moved from `message.ts` into `direct-action-heuristics.ts` verbatim, so the planner prior-dialogue exclusion behavior is unchanged (covered by the existing stage-1 test).

# Background

## What does this PR do?

Fixes the two independently breakable defects the #20227 review reproduced at head `88f8235a8`:

1. **Cross-participant continuation resolution.** `resolveExplicitContinuationRequestText` excluded only the agent from the candidate loop, and `RECENT_MESSAGES` is room-scoped, so User B saying `go ahead` could resolve to User A's nearest request (the review's adversarial case returned `"delete my deployment"` instead of `null`). The resolver now takes the current requester's `entityId` (threaded from `message.entityId` at the single production call site) and only ever resolves that entity's own prior request. It also refuses to resolve when the requester is the agent itself.

2. **Completed action replayed as pending.** The approval gate only consulted `actionCallbackHistory`, while the message path already treats `content.actions` (anything beyond the reply/none/ignore envelope) as a structural tool-derived marker. A completed `{ text: "Done.", actions: ["DELETE_DEPLOYMENT"] }` reply fit the 160-char "looks pending" fallback and replayed the finished request (the review's case returned `"delete the stale deployment"` instead of `null`). The shared predicate `isToolDerivedAssistantContent` now lives in `direct-action-heuristics.ts`, is folded into `isContinuationDialogueArtifact` (covering both the approval gate and candidate loop), and `message.ts` imports it instead of keeping a private copy — one predicate, used consistently.

## What kind of change is this?

Bug fixes (non-breaking; `resolveExplicitContinuationRequestText` is module-internal to `@elizaos/core` — not exported from any package entrypoint — so the added required parameter has exactly one production caller, updated in the same commit).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/core/src/services/message/direct-action-heuristics.ts` — the resolver: requester binding, shared `isToolDerivedAssistantContent`, artifact check.
- `packages/core/src/services/message/direct-action-heuristics.test.ts` — three new unit regressions (cross-participant → `null`, requester-bound resolution with both participants asking, completed-`content.actions` → `null` with `actions: ["REPLY"]` control).
- `packages/core/src/__tests__/message-runtime-stage1.test.ts` — two new production-path regressions through `runV5MessageRuntimeStage1` (real stage-1 runtime, mocked model responses): another participant's pending request is not promoted, and a completed `content.actions` result is not replayed — in both, the shell handler is never invoked and the turn stays a simple reply.

## Detailed testing steps

Focused gates (Bun 1.3.14, `--conditions=eliza-source`):

| Gate | Result |
| --- | --- |
| `packages/core` `direct-action-heuristics.test.ts` | **77 pass / 0 fail** (74 at base, +3 regressions) |
| `packages/core` `message-runtime-stage1.test.ts` | **137 pass / 0 fail** (135 at base, +2 regressions) |
| Consumer sweep (10 message-service suites, Vitest lane) | **612 pass / 4 fail** — all 4 are the same two pre-existing `deliver-then-persist` audience-attestation failures, reproduced identically at base `88f8235a8` in the same harness (see Known gaps) |
| `bun run typecheck` (`packages/core`) | pass |
| Biome on the four touched files | clean |
| `git diff --check` | clean |

Mutation-sensitivity (sabotage) proof — each repair was individually reverted, the suites rerun, and the fix restored:

| Sabotage | Unit result | Production-path result |
| --- | --- | --- |
| Drop entity binding (candidate loop back to agent-only exclusion) | exactly 2 fail: `never resolves a continuation to another participant's request`, `binds resolution to the requester's own request…` | exactly 1 fail: `does not resolve a continuation to another participant's request` |
| Ignore `content.actions` marker (artifact check back to callbacks-only) | exactly 1 fail: `treats a completed action recorded only in content.actions as delivered` | exactly 1 fail: `does not replay a completed action recorded only in content.actions` |

After restoring the fix: 77/77 and 137/137 green.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:b2f79481cdef98234bc1dbf24fb2305ab23256fd -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - core runtime heuristic change with no rendered UI surface; nothing under packages/app, packages/ui, or any view layer is touched.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - core runtime heuristic change with no rendered UI surface; nothing under packages/app, packages/ui, or any view layer is touched.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-visible flow; the change is a deterministic pre-model routing guard exercised end to end by the stage-1 runtime suites below.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs: runner output of the focused suites (which drive the real `runV5MessageRuntimeStage1` message loop end to end) attached below.

  <details>
  <summary>Focused suites at repair head b2f79481c (bun test, --conditions=eliza-source)</summary>

  ```
  $ bun test --conditions=eliza-source src/services/message/direct-action-heuristics.test.ts
   77 pass
   0 fail
   239 expect() calls
  Ran 77 tests across 1 file.

  $ bun test --conditions=eliza-source src/__tests__/message-runtime-stage1.test.ts
   137 pass
   0 fail
   669 expect() calls
  Ran 137 tests across 1 file.
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code path exists for this change; no client request/response or UI state is involved.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no prompt, model handler, or model-facing contract changed; the fix is a deterministic guard that runs before any model call, and both defects plus both fixes are proven by deterministic full-runtime stage-1 regressions with recorded model responses (a live single-user session cannot even construct the two-participant shared-room precondition).`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: mutation-sensitivity (sabotage) run outputs attached below; full matrix under **Evidence Details**.

  <details>
  <summary>Sabotage runs — each repair reverted individually, suites rerun, fix restored</summary>

  ```
  # Sabotage 1: entity binding dropped
  (fail) … never resolves a continuation to another participant's request (#20227 review)
  (fail) … binds resolution to the requester's own request when both participants have asked
   75 pass / 2 fail (unit)
  (fail) … does not resolve a continuation to another participant's request (#20227 review)
   136 pass / 1 fail (production stage-1)

  # Sabotage 2: content.actions marker ignored
  (fail) … treats a completed action recorded only in content.actions as delivered (#20227 review)
   76 pass / 1 fail (unit)
  (fail) … does not replay a completed action recorded only in content.actions (#20227 review)
   136 pass / 1 fail (production stage-1)

  # Fix restored: 77/77 and 137/137 green
  ```

  </details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - the change has no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A` — see the `llm-trajectory` row reason above.

## Backend + frontend logs

<details>
<summary>Focused suites at repair head b2f79481c (bun test, --conditions=eliza-source)</summary>

```
$ bun test --conditions=eliza-source src/services/message/direct-action-heuristics.test.ts
 77 pass
 0 fail
 239 expect() calls
Ran 77 tests across 1 file.

$ bun test --conditions=eliza-source src/__tests__/message-runtime-stage1.test.ts
 137 pass
 0 fail
 669 expect() calls
Ran 137 tests across 1 file.
```

</details>

<details>
<summary>Sabotage 1 — entity binding dropped (candidate loop excludes only the agent)</summary>

```
(fail) resolveExplicitContinuationRequestText > never resolves a continuation to another participant's request (#20227 review)
(fail) resolveExplicitContinuationRequestText > binds resolution to the requester's own request when both participants have asked
 75 pass
 2 fail

(fail) planner prior dialogue and continuation resolution (#17024) > does not resolve a continuation to another participant's request (#20227 review)
 136 pass
 1 fail
```

</details>

<details>
<summary>Sabotage 2 — content.actions marker ignored (artifact check reverted to callbacks-only)</summary>

```
(fail) resolveExplicitContinuationRequestText > treats a completed action recorded only in content.actions as delivered (#20227 review)
 76 pass
 1 fail

(fail) planner prior dialogue and continuation resolution (#17024) > does not replay a completed action recorded only in content.actions (#20227 review)
 136 pass
 1 fail
```

</details>

<details>
<summary>Consumer sweep (Vitest lane) and pre-existing-at-base control</summary>

```
$ bun run test <10 message-service suites>   # with repair applied
 Test Files  2 failed | 8 passed (10)
      Tests  4 failed | 612 passed (616)
# all 4 failures are the shared "simple-path deliver-then-persist ordering" pair
# (audience attestation), surfacing via two files that include the shared suite

$ git stash && bun run test src/services/message-planner-rescue-lane.test.ts   # at base 88f8235a8
 FAIL  … > replaces private callback, persistence, event, and returned content when membership changes
 FAIL  … > rewrites every actions-mode response memory after the audience changes
      Tests  2 failed | 208 passed (210)
```

The identical pair fails at the unmodified base in the same harness — pre-existing, unrelated to this repair.

</details>

## Screenshots (before / after) + video walkthrough

`N/A - no UI surface is touched by this change.`

## Audio / voice walkthrough

`N/A - no voice, transcript, TTS, or STT path is touched.`

## Known gaps / failures

- `bun install` and root `bun run verify` were not run: this repair was built in an isolated stacked worktree that shares the control checkout's installed dependencies read-only (installing would mutate the shared tree). In their place: `packages/core` `bun run typecheck` passes, Biome is clean on all four touched files, and the focused + consumer Vitest/bun suites above pass.
- Consumer sweep shows 2 pre-existing failures (`deliver-then-persist` audience attestation), reproduced byte-identically at the unmodified base `88f8235a8` in the same harness; not introduced or affected by this change.
- Sibling PR #19822 was checked for overlap: its head predates the continuation resolver entirely (no `resolveExplicitContinuationRequestText` in its tree), so nothing here duplicates it.
