### PR TITLE
fix(ui): remove payment-request render clock read

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.tsx
@@ -155,7 +155,7 @@ export default function PaymentRequestPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<PageError | null>(null);
   const [isPaying, setIsPaying] = useState(false);
-  const [nowMs, setNowMs] = useState(() => Date.now());
+  const [nowMs, setNowMs] = useState<number | null>(null);
   // Monotonic key: only the latest load (or a checkout revalidation started
   // under it) may commit state, so stale responses cannot cross routes.
   const loadGenerationRef = useRef(0);
@@ -341,7 +341,9 @@ export default function PaymentRequestPage() {
 
   const isPaid = paymentRequest.status === "settled";
   const deadline = parseDeadline(paymentRequest.expiresAt);
-  const deadlinePassed = isDeadlinePassed(deadline, nowMs);
+  // Loading the request and capturing its comparison timestamp happen at the
+  // same effect boundary. Fail closed if they ever become temporarily split.
+  const deadlinePassed = nowMs === null || isDeadlinePassed(deadline, nowMs);
   const hasInvalidPayableDeadline =
     isPayableStatus(paymentRequest.status) && deadline.kind === "invalid";
   const isExpired =


### PR DESCRIPTION
## Summary

- remove the public payment-request page's render-time clock read
- keep the page fail-closed until its load effect captures the timestamp used for expiry eligibility
- preserve deadline timers and checkout-time server revalidation

Closes #20320.

## Validation

Exact head: `513df3b21b428236a6cb0208ac47d8985b3ea316`

- payment-request component contract — 12/12 passed on the exact head
- `bun run audit:ui-determinism` — passed on the exact head; render-time occurrences reduced from 37 to 36 without changing the baseline
- `bun run --cwd packages/ui typecheck` — passed
- `bun run verify` — 351/351 tasks and the 8,273-file anti-larp audit passed on the immediately preceding rebased head; the only intervening base change is the unrelated Cloud deploy mutation-boundary repair (#20322)
- `bun run --cwd packages/app audit:app` — 219/219 browser captures passed; broken=0, needs-work=0, minimalism failures=0, hover failures=0, density failures=0
- packaged OCR — 216 views, 200 verified, broken=0, regressions=0

The state change has no visible steady-state delta: loading remains loading, and loaded payment requests use the same effect-captured timestamp they already used after fetch. It removes a nondeterministic render clock read and makes the impossible split state fail closed.

AI Model: OpenAI / gpt-5.6-sol  
Agent Platform: Codex Desktop

<!-- evidence-head:513df3b21b428236a6cb0208ac47d8985b3ea316 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20325-before-payment-request.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20325-after-payment-request.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20325-payment-request-walkthrough.webm

<!-- evidence-row:backend-logs -->
- [ ] N/A - frontend-only clock-state repair; API DTO contract is unchanged

<!-- evidence-row:frontend-logs -->
- [x] [20325-payment-request-frontend-report.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20325-payment-request-frontend-report.json)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model or agent behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no generated domain artifact changed

<!-- evidence-row:ocr-review -->
- [x] [20325-payment-request-ocr.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20325-payment-request-ocr.json)

Skill Revision: N/A - no contribution skill used

— [codex-workflow]

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->

