### PR TITLE
fix(core): kill the group-surface fabrication class — privacy short-circuit + claim vocabulary

### DIFF
--- a/packages/core/src/services/message.side-effect-claim.test.ts
+++ b/packages/core/src/services/message.side-effect-claim.test.ts
@@ -962,6 +962,8 @@ describe("tasks context recap/status routing vocabulary", () => {
 
 describe("subjectless past-participle openers (Discord group-surface fabrication shape)", () => {
 	it.each([
+		'todo added: "polish the dc7 lens"',
+		"reminder set: 9am tomorrow.",
 		"Added todo: sand the dc5 shelf (no deadline, general task)",
 		"saved a note: the charger is in the kitchen drawer",
 		"Deleted the water the ficus reminder.",
@@ -973,6 +975,7 @@ describe("subjectless past-participle openers (Discord group-surface fabrication
 	it.each([
 		"Set a reminder on your phone so you don't forget the appointment",
 		"Added anything to your calendar lately?",
+		"the todo added by you last week covers it",
 	])("passes %p through (advice / mid-sentence / question)", (reply) => {
 		expect(replyClaimsCompletedSideEffect(reply)).toBe(false);
 	});

--- a/packages/core/src/services/message.side-effect-claim.test.ts
+++ b/packages/core/src/services/message.side-effect-claim.test.ts
@@ -959,3 +959,21 @@ describe("tasks context recap/status routing vocabulary", () => {
 		expect(tasksLine).toMatch(/what did I get done today/i);
 	});
 });
+
+describe("subjectless past-participle openers (Discord group-surface fabrication shape)", () => {
+	it.each([
+		"Added todo: sand the dc5 shelf (no deadline, general task)",
+		"saved a note: the charger is in the kitchen drawer",
+		"Deleted the water the ficus reminder.",
+		"Scheduled task for friday. anything else?",
+	])("flags %p as a completed side-effect claim", (reply) => {
+		expect(replyClaimsCompletedSideEffect(reply)).toBe(true);
+	});
+
+	it.each([
+		"Set a reminder on your phone so you don't forget the appointment",
+		"Added anything to your calendar lately?",
+	])("passes %p through (advice / mid-sentence / question)", (reply) => {
+		expect(replyClaimsCompletedSideEffect(reply)).toBe(false);
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2671,6 +2671,12 @@ async function collectV5PlannerCandidateActions(args: {
 	selectedContexts?: readonly AgentContext[];
 	candidateActions?: readonly string[];
 	userRoles?: readonly RoleGateRole[];
+	/** Out-param: normalized names of EXPLICIT stage-1 candidates whose
+	 * resolved action was rejected by the action gate (role/context/privacy).
+	 * Lets the planner entry distinguish "capability exists but is gated on
+	 * this surface" from ordinary no-match, and answer honestly instead of
+	 * planning against an unrelated retrieval surface. */
+	diagnostics?: { gateRejectedExplicitCandidates: string[] };
 }): Promise<Action[]> {
 	// The candidate surface starts from every runtime action and applies only the
 	// same execution gates the planner executor will enforce — it deliberately does
@@ -2718,6 +2724,7 @@ async function collectV5PlannerCandidateActions(args: {
 		});
 		if (gateFailure !== undefined) {
 			if (explicitCandidateName) {
+				args.diagnostics?.gateRejectedExplicitCandidates.push(action.name);
 				args.runtime.logger.warn(
 					{
 						src: "service:message",
@@ -8020,6 +8027,9 @@ export async function runV5MessageRuntimeStage1(args: {
 		// NOTIFY and the turn ended answerless). Preserve the pre-patch reply so
 		// the planner loop's answer rescue and the answerless-final fallback can
 		// still deliver it.
+		const candidateGateDiagnostics = {
+			gateRejectedExplicitCandidates: [] as string[],
+		};
 		const prePatchStageOneReply =
 			typeof messageHandler.plan.reply === "string" &&
 			messageHandler.plan.reply.trim().length > 0
@@ -8364,7 +8374,47 @@ export async function runV5MessageRuntimeStage1(args: {
 					selectedContexts,
 					candidateActions: getMessageHandlerCandidateActions(messageHandler),
 					userRoles: [senderRole],
+					diagnostics: candidateGateDiagnostics,
 				});
+		// Surface-privacy short-circuit: stage-1 named a capability that EXISTS
+		// but is gated on this surface (role/privacy — e.g. owner-life actions in
+		// a public channel), and no named candidate survived into the collected
+		// set. Planning anyway hands the model an unrelated retrieval surface and
+		// it improvises around the missing capability — observed live on the
+		// Discord group channel: a "todos" ask got a WEB_SEARCH surface and
+		// shipped a fabricated "todo added" with zero writes, and a todos READ
+		// answered a false empty from the orchestrator task store. Answer with an
+		// honest surface denial instead. The phrasing confirms nothing about the
+		// data — only that the surface is private to another channel.
+		if (candidateGateDiagnostics.gateRejectedExplicitCandidates.length > 0) {
+			const collectedNames = new Set(
+				plannerCandidateActions.map((action) =>
+					normalizeActionIdentifier(action.name),
+				),
+			);
+			const candidateLookup = buildRuntimeActionLookup(args.runtime);
+			const anyNamedCandidateSurvived = (
+				getMessageHandlerCandidateActions(messageHandler) ?? []
+			).some((name) => {
+				const resolved = resolveRuntimeAction(candidateLookup, String(name));
+				return (
+					resolved !== undefined &&
+					collectedNames.has(normalizeActionIdentifier(resolved.name))
+				);
+			});
+			if (!anyNamedCandidateSurvived) {
+				return {
+					kind: "direct_reply",
+					messageHandler,
+					result: createV5ReplyStrategyResult({
+						...args,
+						text: "that's a private surface — ask me in a DM and I'll handle it there.",
+						thought: messageHandler.thought,
+						agentVoiced: false,
+					}),
+				};
+			}
+		}
 		const localizedExamplesProvider = getLocalizedExamplesProvider(
 			args.runtime,
 		);

--- a/packages/core/src/services/message/side-effect-claims.ts
+++ b/packages/core/src/services/message/side-effect-claims.ts
@@ -89,6 +89,14 @@ function sideEffectClaimSentenceIsQuestion(
 const SUBJECTLESS_PAST_SIDE_EFFECT_CLAIM_PATTERN =
 	/(?:^|[.!?]\s+)(?:added|created|saved|scheduled|booked|logged|deleted|removed|renamed|cancell?ed|arranged)\b/gi;
 
+// Noun-first passive headline claims — "todo added: polish the lens",
+// "note saved.", "reminder set: 9am" (live variant that evaded the verb-first
+// shape above: the model leads with the record noun). Requires the terminal
+// claim punctuation/colon so descriptive prose ("the todo added by you last
+// week…") passes through.
+const NOUN_FIRST_SIDE_EFFECT_CLAIM_PATTERN =
+	/(?:^|[.!?]\s+)(?:todos?|to[- ]dos?|notes?|reminders?|alarms?|tasks?|events?|appointments?|goals?|habits?)\s+(?:added|created|saved|scheduled|booked|logged|deleted|removed|renamed|cancell?ed|set|updated)\s*(?::|[.!…]|$)/gi;
+
 export function replyClaimsCompletedSideEffect(reply: string): boolean {
 	const text = reply.trim();
 	if (!text) return false;
@@ -97,6 +105,10 @@ export function replyClaimsCompletedSideEffect(reply: string): boolean {
 	for (const match of text.matchAll(
 		SUBJECTLESS_PAST_SIDE_EFFECT_CLAIM_PATTERN,
 	)) {
+		if (sideEffectClaimSentenceIsQuestion(text, match.index)) continue;
+		return true;
+	}
+	for (const match of text.matchAll(NOUN_FIRST_SIDE_EFFECT_CLAIM_PATTERN)) {
 		if (sideEffectClaimSentenceIsQuestion(text, match.index)) continue;
 		return true;
 	}

--- a/packages/core/src/services/message/side-effect-claims.ts
+++ b/packages/core/src/services/message/side-effect-claims.ts
@@ -49,7 +49,7 @@ const NON_ASSERTIVE_SIDE_EFFECT_LEAD_PATTERN =
 // some thoughts". Vocabulary mirrors the scheduled-item nouns the LifeOps
 // surfaces own.
 const SIDE_EFFECT_SUBJECT_NOUN_PATTERN =
-	/\b(?:remind(?:er)?s?|alarms?|schedul(?:e|ed|ing)|scheduled\s+(?:task|item)s?|tasks?|appointments?|calendar|routines?|habits?|goals?|todos?|to[- ]dos?|check[- ]?ins?|follow[- ]?ups?|set[- ]?up|setup|onboard(?:ing)?|first[- ]?run|settings|defaults|configur(?:ation|ed))\b/i;
+	/\b(?:remind(?:er)?s?|alarms?|schedul(?:e|ed|ing)|scheduled\s+(?:task|item)s?|tasks?|appointments?|calendar|routines?|habits?|goals?|todos?|to[- ]dos?|notes?|check[- ]?ins?|follow[- ]?ups?|set[- ]?up|setup|onboard(?:ing)?|first[- ]?run|settings|defaults|configur(?:ation|ed))\b/i;
 
 // True when the sentence containing the match (scanning forward from the
 // match) terminates in "?" — the shape of a consent-seeking offer or a
@@ -77,11 +77,29 @@ function sideEffectClaimSentenceIsQuestion(
  * set…") are NOT claims and must return false — rewriting them to "On it."
  * turns a question the user asked into an action they did not consent to.
  */
+// Subjectless past-participle openers — "Added todo: sand the shelf",
+// "saved a note: the charger is in the drawer", "Deleted the reminder." The
+// live fabrication shape the I-subject patterns miss: the model reports
+// finished work headline-style with no pronoun (observed on the Discord
+// group surface: "Added todo: sand the dc5 shelf (no deadline, general
+// task)" shipped with ZERO tool calls). Anchored to a sentence start so
+// ordinary mid-sentence past tense ("the note I added yesterday") passes;
+// bare "set" is deliberately absent — "Set a reminder on your phone…" is a
+// common advisory imperative, not a report.
+const SUBJECTLESS_PAST_SIDE_EFFECT_CLAIM_PATTERN =
+	/(?:^|[.!?]\s+)(?:added|created|saved|scheduled|booked|logged|deleted|removed|renamed|cancell?ed|arranged)\b/gi;
+
 export function replyClaimsCompletedSideEffect(reply: string): boolean {
 	const text = reply.trim();
 	if (!text) return false;
 	if (!SIDE_EFFECT_SUBJECT_NOUN_PATTERN.test(text)) return false;
 	if (STATE_SIDE_EFFECT_CLAIM_PATTERN.test(text)) return true;
+	for (const match of text.matchAll(
+		SUBJECTLESS_PAST_SIDE_EFFECT_CLAIM_PATTERN,
+	)) {
+		if (sideEffectClaimSentenceIsQuestion(text, match.index)) continue;
+		return true;
+	}
 	for (const match of text.matchAll(PERFECTIVE_SIDE_EFFECT_CLAIM_PATTERN)) {
 		if (
 			!NON_ASSERTIVE_SIDE_EFFECT_LEAD_PATTERN.test(text.slice(0, match.index))


### PR DESCRIPTION
## What — box-carry upstream of watchtower's Discord-hardening pair (authorship preserved)

Battery dc5+dc5b (30 raw-API-verified Discord probes) traced all 4 reds to ONE root: owner-life candidates (OWNER_TODOS) are correctly disclosure-gated OUT of public channels, but the turn then planned against junk retrieval surfaces and FABRICATED outcomes ("Added todo: X" with zero writes, three phrasings; false "0 active todos" from the wrong store).

Two-layer structural kill:
1. **Surface-privacy short-circuit**: `collectV5PlannerCandidateActions` now reports gate-rejected explicit candidates; when a named capability exists but is gated on this surface and no candidate survived, the turn ships an honest privacy-safe denial ("that's a private surface — ask me in a DM") instead of planning against junk. Saves the whole planner round. Owner/DM path verified unaffected on box (create persisted, listed, deleted).
2. **Claim-vocabulary defense-in-depth**: subjectless past-participle openers ("Added todo: …"), noun-first passives ("todo added: …"), and the notes surface join the effect-claim vocabulary — note-write fabrications were invisible to it before.

## Evidence

| Check | Result |
|---|---|
| `message.side-effect-claim` suite (incl. the new shapes) | 52/52 ✅ |
| stage-1 runtime suite (planner-candidate seam) | see CI note below — run locally green |
| Biome | ✅ |
| Live proof | 3-layer fix live-proven on box by watchtower (battery dc5b receipt at HQ 02:42): group todos ask → honest privacy denial in 1s; DM path unaffected |

Same carry flow as #20316/#20246–#20250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)