### PR TITLE
fix(app): expose local runtime chooser in iOS dev builds

### DIFF
--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
@@ -30,5 +30,5 @@ export function mobileRendererRequiresFreshBuild({ platform } = {}) {
   if (typeof platform !== "string" || platform.length === 0) {
     throw new Error("mobileRendererRequiresFreshBuild: platform is required");
   }
-  return platform === ANDROID_CLOUD_DEBUG;
+  return platform === ANDROID_CLOUD_DEBUG || platform === "ios-local";
 }

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
@@ -1,8 +1,10 @@
 /**
  * Resolves renderer feature flags and cache policy for mobile build lanes.
- * LP3 debug artifacts always enable the realtime voice client, while every
- * Android cloud-debug build starts from a fresh renderer because the current
- * lane stamp does not encode optional Vite feature flags.
+ * Local iOS artifacts expose the existing runtime chooser so a sideload can
+ * select its bundled agent without Cloud authentication. LP3 debug artifacts
+ * enable the realtime voice client, while every Android cloud-debug build
+ * starts from a fresh renderer because the current lane stamp does not encode
+ * optional Vite feature flags.
  */
 
 const ANDROID_CLOUD_DEBUG = "android-cloud-debug";
@@ -10,6 +12,9 @@ const ANDROID_CLOUD_DEBUG = "android-cloud-debug";
 export function resolveMobileRendererFeatureEnv({ platform, env = {} } = {}) {
   if (typeof platform !== "string" || platform.length === 0) {
     throw new Error("resolveMobileRendererFeatureEnv: platform is required");
+  }
+  if (platform === "ios-local") {
+    return { VITE_ELIZA_ENABLE_RUNTIME_CHOOSER: "1" };
   }
   const isLp3Debug =
     platform === ANDROID_CLOUD_DEBUG &&

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
@@ -57,11 +57,14 @@ describe("resolveMobileRendererFeatureEnv", () => {
 });
 
 describe("mobileRendererRequiresFreshBuild", () => {
-  it("rebuilds cloud-debug renderers because their optional flags are not stamped", () => {
+  it("rebuilds renderers for lanes whose optional flags are not stamped", () => {
     expect(
       mobileRendererRequiresFreshBuild({ platform: "android-cloud-debug" }),
     ).toBe(true);
-    for (const platform of ["android", "android-cloud", "ios", "ios-local"]) {
+    expect(mobileRendererRequiresFreshBuild({ platform: "ios-local" })).toBe(
+      true,
+    );
+    for (const platform of ["android", "android-cloud", "ios"]) {
       expect(mobileRendererRequiresFreshBuild({ platform })).toBe(false);
     }
   });

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
@@ -9,6 +9,16 @@ import {
 } from "./mobile-renderer-feature-env.mjs";
 
 describe("resolveMobileRendererFeatureEnv", () => {
+  it("enables the runtime chooser only for the local iOS lane", () => {
+    expect(resolveMobileRendererFeatureEnv({ platform: "ios-local" })).toEqual({
+      VITE_ELIZA_ENABLE_RUNTIME_CHOOSER: "1",
+    });
+
+    for (const platform of ["ios", "ios-overlay", "android"]) {
+      expect(resolveMobileRendererFeatureEnv({ platform })).toEqual({});
+    }
+  });
+
   it("enables the realtime voice client for the LP3 cloud-debug lane", () => {
     expect(
       resolveMobileRendererFeatureEnv({

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -1163,7 +1163,7 @@ async function buildWeb(platform) {
     requiresFreshRenderer
   ) {
     console.log(
-      `[mobile-build] Rebuilding renderer for '${platform}': debug feature flags require fresh output.`,
+      `[mobile-build] Rebuilding renderer for '${platform}': lane-specific feature flags require fresh output.`,
     );
   }
   if (process.env.ELIZA_MOBILE_SKIP_WEB_BUILD === "1") {


### PR DESCRIPTION
Closes #20319

## Summary

- enable the existing runtime chooser only for the `ios-local` renderer lane
- keep Cloud, overlay, Android, and LP3 behavior unchanged
- pin the positive and negative lane contract in focused tests

## Root cause

The native iOS local build correctly stamped `runtimeMode=local`, but its renderer never received `VITE_ELIZA_ENABLE_RUNTIME_CHOOSER=1`. The production-default gate therefore hid the local-runtime path and left a fresh local build showing only Cloud sign-in.

## User impact

A fresh local iOS development/sideload build can enter the bundled/local agent flow without authenticating to Eliza Cloud. This is explicitly scoped to `ios-local`; production Cloud artifacts remain fail-closed.

## Verification

- final exact-head mobile build/cache contracts: **51/51 passed** (96 assertions)
- `packages/app-core` typecheck: **passed**
- `packages/app` typecheck: **passed**
- exact two-file Biome: **passed**
- `git diff --check`: **passed**
- original implementation root `bun run verify`: **351/351 passed**; final two-commit replay additionally passed the focused 51-test contract, Biome, and diff-check
- iOS simulator local build: `** BUILD SUCCEEDED **`; renderer manifest build ID `1061d60b90d959bae84f7e7d49c80347a7826ba0ce0ff027e0a648f086459488`, `runtimeMode=local`
- fresh simulator install on `Eliza-Cloud-Fresh-20260815-1559` reached the local-runtime path after native permission handling instead of Cloud sign-in
- live Mac runtime proof: local agent health `ready=true`, `canRespond=true`, Cerebras active; exact HTTP probe returned `200` and `MAC CEREBRAS READY`

## Evidence notes

- Native screenshot was manually reviewed locally at `/tmp/eliza-ios-mac-runtime-permissions-dismissed.png`; upload to the issue/PR remains pending because the current CLI flow cannot attach local binary artifacts.
- `packages/app audit:app` classified 216 views: **199 good**, **13 needs-eyeball**, **4 broken**, then failed its strict aggregate gate on the pre-existing `plugin-cloud-gui` readability debt. This patch changes no rendered component or Cloud GUI source.
- Frontend network/console logs: N/A - the change is a build-lane feature stamp, not a browser transport or rendered component change.
- Walkthrough MP4: pending for the corrected exact head; keep this PR draft until the current simulator/device walkthrough is attached.

## Deliberately separate follow-ups

- remote-Mac mode can retain a stale local-inference error and disabled composer after the Mac endpoint is reachable
- the existing onboarding liveness harness can accept transient `Thinking` text as a successful model reply
- automatic Mac discovery/pairing should be a separate Bonjour + `NWBrowser` feature with explicit trust, authenticated pairing, and manual-host fallback
- the full-Bun simulator artifact is a development target and is not claimed as App Store/device-safe

## Contribution provenance

- AI provider/model: openai / gpt-5.6-sol
- Client / agent tooling: Codex Desktop
- Contribution skill revision: elizaOS/eliza@852b65969dd124db7c98002acbcfd4f7f15af2cf:packages/skills/skills/contribute-to-eliza
- Attribution status: self-reported

— [codex / ios-local-runtime-chooser]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@852b65969dd124db7c98002acbcfd4f7f15af2cf:packages/skills/skills/contribute-to-eliza"} -->


## Corrected exact-head handoff

- Base: `935b4ebb2f8d96fc51c4e14dfe4374774b1c9d8f`
- Head: `852b65969dd124db7c98002acbcfd4f7f15af2cf`
- The follow-up forces an `ios-local` renderer rebuild whenever the lane injects the runtime chooser flag; the original behavior and correction replay byte-equivalently onto current develop.
- Final focused validation: 51/51 tests, 96 assertions; exact three-file Biome and diff-check pass.
- No deploy, device install, environment approval, or external mutation was performed during this repair.

<!-- evidence-head:852b65969dd124db7c98002acbcfd4f7f15af2cf -->

<!-- evidence-row:before-screenshots -->
- [ ] Pending current signed simulator/device baseline capture

<!-- evidence-row:after-screenshots -->
- [ ] Pending current exact-head runtime chooser capture

<!-- evidence-row:walkthrough-video -->
- [ ] Pending current simulator/device walkthrough MP4

<!-- evidence-row:backend-logs -->
- [ ] Pending exact-head local runtime host logs

<!-- evidence-row:frontend-logs -->
- [ ] Pending exact-head native/frontend console logs

<!-- evidence-row:llm-trajectory -->
- [x] N/A — the correction changes build-cache invalidation, not model behavior

<!-- evidence-row:domain-artifacts -->
- [x] N/A — no domain persistence contract changes

<!-- evidence-row:ocr-review -->
- [ ] Pending OCR review of exact-head after-capture

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@935b4ebb2f8d96fc51c4e14dfe4374774b1c9d8f:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported
