### PR TITLE
fix(core): restore the deterministic no-web-action decline after progress-ack promotion

### DIFF
--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -8386,34 +8386,77 @@ export async function runV5MessageRuntimeStage1(args: {
 		// answered a false empty from the orchestrator task store. Answer with an
 		// honest surface denial instead. The phrasing confirms nothing about the
 		// data — only that the surface is private to another channel.
-		if (candidateGateDiagnostics.gateRejectedExplicitCandidates.length > 0) {
-			const collectedNames = new Set(
-				plannerCandidateActions.map((action) =>
-					normalizeActionIdentifier(action.name),
-				),
+		const collectedCandidateNames = new Set(
+			plannerCandidateActions.map((action) =>
+				normalizeActionIdentifier(action.name),
+			),
+		);
+		const stageOneCandidateLookup = buildRuntimeActionLookup(args.runtime);
+		const anyNamedStageOneCandidateSurvived = (
+			getMessageHandlerCandidateActions(messageHandler) ?? []
+		).some((name) => {
+			const resolved = resolveRuntimeAction(
+				stageOneCandidateLookup,
+				String(name),
 			);
-			const candidateLookup = buildRuntimeActionLookup(args.runtime);
-			const anyNamedCandidateSurvived = (
-				getMessageHandlerCandidateActions(messageHandler) ?? []
-			).some((name) => {
-				const resolved = resolveRuntimeAction(candidateLookup, String(name));
-				return (
-					resolved !== undefined &&
-					collectedNames.has(normalizeActionIdentifier(resolved.name))
-				);
-			});
-			if (!anyNamedCandidateSurvived) {
-				return {
-					kind: "direct_reply",
-					messageHandler,
-					result: createV5ReplyStrategyResult({
-						...args,
-						text: "that's a private surface — ask me in a DM and I'll handle it there.",
-						thought: messageHandler.thought,
-						agentVoiced: false,
-					}),
-				};
-			}
+			return (
+				resolved !== undefined &&
+				collectedCandidateNames.has(normalizeActionIdentifier(resolved.name))
+			);
+		});
+		if (
+			candidateGateDiagnostics.gateRejectedExplicitCandidates.length > 0 &&
+			!anyNamedStageOneCandidateSurvived
+		) {
+			return {
+				kind: "direct_reply",
+				messageHandler,
+				result: createV5ReplyStrategyResult({
+					...args,
+					text: "that's a private surface — ask me in a DM and I'll handle it there.",
+					thought: messageHandler.thought,
+					agentVoiced: false,
+				}),
+			};
+		}
+		// Live-lookup unavailability short-circuit. The progress-ack promotion
+		// (routeMessageHandlerOutput, #20249) now routes "On it."-shaped turns
+		// into planning, which bypassed the direct-reply egress replacement that
+		// used to convert a live-lookup ask with NO registered web action into
+		// the honest decline. A planner round cannot conjure the missing
+		// capability — its best case is a model-authored decline and its worst
+		// case is a shell fallback — so decline deterministically here, exactly
+		// like the egress-side replacement. Scope: only turns whose planning
+		// round exists purely because of the promotion (stage-1's own plan
+		// selected no non-simple context). When stage-1 genuinely routed to a
+		// context, or a named candidate survived collection, the planner may
+		// hold a registered domain action that serves the ask without web
+		// search — those turns still plan.
+		const stageOneOwnNonSimpleContexts = (
+			messageHandler.plan.contexts ?? []
+		).filter((context) => {
+			const normalized = String(context).trim().toLowerCase();
+			return normalized.length > 0 && normalized !== SIMPLE_CONTEXT_ID;
+		});
+		if (
+			stageOneOwnNonSimpleContexts.length === 0 &&
+			!anyNamedStageOneCandidateSurvived &&
+			shouldReplaceUnavailableLiveLookupAck({
+				message: args.message,
+				actions: args.runtime.actions ?? [],
+				reply: prePatchStageOneReply ?? "",
+			})
+		) {
+			return {
+				kind: "direct_reply",
+				messageHandler,
+				result: createV5ReplyStrategyResult({
+					...args,
+					text: LIVE_LOOKUP_UNAVAILABLE_REPLY,
+					thought: messageHandler.thought,
+					agentVoiced: false,
+				}),
+			};
 		}
 		const localizedExamplesProvider = getLocalizedExamplesProvider(
 			args.runtime,


### PR DESCRIPTION
## Problem — develop-red (3 tests), interaction regression between two merged carries

#20249 (promote progress-shaped simple-path acks to planning) bypassed the direct-reply egress seam where `shouldReplaceUnavailableLiveLookupAck` converted a live-lookup ask with NO registered web action into the honest canned decline. Three stage-1 tests went red on clean develop (verified red at #20260's merge AND its parent — not introduced by any single PR's own suite, pure interaction): promoted turns now took a planner round whose best case is a model-authored decline and worst case is a shell fallback.

## Fix

The planning entry declines deterministically (`LIVE_LOOKUP_UNAVAILABLE_REPLY`) when **all** hold: web-search-shaped ask · no web-lookup action registered · progress-shaped stage-1 reply · no stage-1-named candidate survived collection · **stage-1's own plan selected no non-simple context** (i.e. the planning round exists purely because of the promotion). Genuinely-routed turns ("general" chosen by stage-1 itself) and surviving-candidate turns still plan — a registered domain action can serve the ask without web search. Shares the survived-candidate computation with #20327's surface-privacy short-circuit rather than recomputing.

## Evidence

| Check | Result |
|---|---|
| `message-runtime-stage1` (was 129/132 on develop) | **132/132** ✅ |
| side-effect-claim + stage1-prompt-tier + shortcut-gate | 77/77 ✅ |
| Biome | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)