### PR TITLE
fix(plugin-openai): retry transient OpenRouter routing 400

### DIFF
--- a/plugins/plugin-openai/__tests__/provider-error-enrichment.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/provider-error-enrichment.shape.test.ts
@@ -106,6 +106,28 @@ describe("isTransientProviderError with response bodies", () => {
     expect(__INTERNAL_isTransientProviderError(error)).toBe(true);
   });
 
+  it("classifies OpenRouter's intermittent no-models routing 400 as transient", () => {
+    const error = apiCallError({
+      statusCode: 400,
+      responseBody: '{"error":{"message":"No models provided","code":400}}',
+    });
+    expect(__INTERNAL_isTransientProviderError(error)).toBe(true);
+  });
+
+  it("keeps other missing-model validation errors non-transient", () => {
+    for (const message of [
+      "required field 'model' is missing",
+      "model is invalid",
+      "unsupported model identifier",
+    ]) {
+      const error = apiCallError({
+        statusCode: 400,
+        responseBody: JSON.stringify({ error: { message } }),
+      });
+      expect(__INTERNAL_isTransientProviderError(error), message).toBe(false);
+    }
+  });
+
   it("keeps a genuine validation 400 non-transient (no retry masking)", () => {
     const error = apiCallError({ statusCode: 400, responseBody: CEREBRAS_FLAT_400 });
     expect(__INTERNAL_isTransientProviderError(error)).toBe(false);

--- a/plugins/plugin-openai/__tests__/stream-start-retry.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/stream-start-retry.shape.test.ts
@@ -287,6 +287,36 @@ describe("live-stream start retry", () => {
     expect(aiMocks.generateText).toHaveBeenCalledTimes(2);
   }, 20_000);
 
+  it("non-streaming: OpenRouter's intermittent no-models 400 retries unchanged", async () => {
+    let call = 0;
+    aiMocks.generateText.mockImplementation(() => {
+      call++;
+      if (call === 1) {
+        return Promise.reject({
+          statusCode: 400,
+          message: "Bad Request",
+          responseBody: '{"error":{"message":"No models provided","code":400}}',
+        });
+      }
+      return Promise.resolve({
+        text: "recovered",
+        toolCalls: [],
+        finishReason: "stop",
+        usage: { inputTokens: 4, outputTokens: 2 },
+        providerMetadata: undefined,
+      });
+    });
+
+    const { handleTextSmall } = await import("../models/text");
+    const result = await handleTextSmall(createRuntime(), { prompt: "hi" } as never);
+
+    expect(result).toBe("recovered");
+    expect(aiMocks.generateText).toHaveBeenCalledTimes(2);
+    expect(aiMocks.generateText.mock.calls[1]?.[0]).toEqual(
+      aiMocks.generateText.mock.calls[0]?.[0]
+    );
+  }, 20_000);
+
   it("non-streaming: a genuine validation 400 does not retry", async () => {
     aiMocks.generateText.mockRejectedValue({
       statusCode: 400,

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -1832,6 +1832,12 @@ function providerErrorSearchText(error: unknown): string {
 const SPURIOUS_TOOL_PAIRING_400_RE =
   /role '?"?tool"?'? must be a response to a prece+ding message with '?"?tool_calls"?'?/;
 
+// OpenRouter can intermittently fail provider routing with this exact 400 even
+// when the serialized request contains a valid model. The identical request
+// succeeds on retry, so keep the exception signature-specific rather than
+// broadening retry behavior for missing/invalid model validation errors.
+const TRANSIENT_OPENROUTER_NO_MODELS_400_RE = /\bno models provided\b/;
+
 function isSpuriousToolPairingRejection(error: unknown): boolean {
   return SPURIOUS_TOOL_PAIRING_400_RE.test(providerErrorSearchText(error));
 }
@@ -1868,7 +1874,7 @@ function isTransientProviderError(error: unknown): boolean {
   // normalization makes structurally impossible, so it can only be a spurious
   // provider-side rejection worth retrying.
   if (status === 400) {
-    if (SPURIOUS_TOOL_PAIRING_400_RE.test(msg)) {
+    if (SPURIOUS_TOOL_PAIRING_400_RE.test(msg) || TRANSIENT_OPENROUTER_NO_MODELS_400_RE.test(msg)) {
       return true;
     }
     if (/invalid|unsupported|must be|required|malformed|not allowed|schema/.test(msg)) {


### PR DESCRIPTION
# Relates to

Closes #20331

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@ee6f83f64b08025320c7dd0ae21dc4d57a927ce0:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@ee6f83f64b08025320c7dd0ae21dc4d57a927ce0`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. The change is limited to the existing bounded provider retry classifier. It matches one exact OpenRouter response signature and preserves terminal handling for other HTTP 400 validation failures. The primary risk is briefly retrying a genuinely terminal provider response that happens to use the same exact phrase; the existing retry bound limits impact.

# Background

## What does this PR do?

Classifies OpenRouter's intermittent HTTP 400 `No models provided` routing response as transient so the existing bounded stream-start retry can recover. It adds focused classifier and integration coverage, including an assertion that the retry receives the same request arguments.

## What kind of change is this?

Bug fix (non-breaking change).

The root cause is that the generic HTTP 400 validation guard ran before this provider-specific transient signature was recognized, so a recoverable routing response escaped the retry path.

# Documentation changes needed?

No documentation change is needed. This restores provider behavior behind the existing retry contract without changing configuration or public APIs.

# Testing

## Where should a reviewer start?

Start with `plugins/plugin-openai/models/text.ts`, then review the focused cases in `provider-error-enrichment.shape.test.ts` and `stream-start-retry.shape.test.ts`.

## Detailed testing steps

At exact head `f1f000409398ee3c679575d4c1d84b28a87c9902`:

1. Run `bun run --cwd plugins/plugin-openai test -- __tests__/provider-error-enrichment.shape.test.ts __tests__/stream-start-retry.shape.test.ts __tests__/tool-result-pairing.test.ts` — 2 files, 34 tests passed.
2. Run `bun run --cwd plugins/plugin-openai typecheck` — passed.
3. Run `bunx biome check` on the three changed files — passed.
4. Inspect the integration regression: the first request rejects with the exact transient 400 signature, the second resolves, and both calls receive equal serialized arguments.

# Evidence Gate

<!-- evidence-head:f1f000409398ee3c679575d4c1d84b28a87c9902 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend provider retry behavior has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend provider retry behavior has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no interactive user flow or visible UI change.
<!-- evidence-row:backend-logs -->
- [x] Redacted local runtime transcript (authorization and private request content were not retained):

  ```text
  endpoint: https://openrouter.ai/api/v1/chat/completions; authorization header redacted
  attempt 1: HTTP 400 with provider signature `No models provided`; serialized request included the configured model
  attempt 2: identical serialized request returned HTTP 200; the bounded retry recovered without changing request arguments
  ```
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] Redacted structured real-provider trajectory (see #20331 for the reproduction description):

  ```json
  {
    "provider": "openrouter",
    "model": "nvidia/nemotron-3.5-lightning:free",
    "input": {
      "summary": "Local Eliza text-generation request; private message content and authorization were redacted.",
      "modelFieldPresent": true
    },
    "output": {
      "attempts": [
        "HTTP 400 with provider signature No models provided",
        "Identical serialized request returned HTTP 200"
      ],
      "result": "Existing bounded retry recovered without changing request arguments."
    }
  }
  ```
<!-- evidence-row:domain-artifacts -->
- [x] N/A - provider retry classification does not create a DB row, memory, task, file, audio, or on-chain artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - the diff has no rendered visual text.

# Evidence Details

## Real LLM-call trajectory

The real local Eliza model path was exercised against OpenRouter. A loopback-only redacting capture confirmed the configured model was serialized in the transiently failing request and that the identical serialized request immediately succeeded. Sensitive headers and private request content were not retained, so no raw trajectory artifact is attached.

## Backend + frontend logs

Backend: redacted runtime output showed HTTP 400 from `https://openrouter.ai/api/v1/chat/completions` with `No models provided`, followed by HTTP 200 for the unchanged serialized request.

Frontend: N/A - no frontend surface changed.

## Screenshots (before / after) + video walkthrough

N/A - backend-only provider retry classification.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT behavior changed.

## Known gaps / failures

- Full plugin validation previously reached 311/312 tests; the sole failure is an unrelated existing Windows drive-path URL assertion in `browser-consumer-bundle.mjs` (`/C:/...`).
- Root `bun run verify` previously passed its initial gates and then stopped on an untouched CRLF formatting finding in `packages/homepage/src/index.css` on Windows. This PR does not modify that file.
- The focused exact-head tests, plugin typecheck, and changed-file Biome check pass after rebasing.

— [codex-contributor]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@ee6f83f64b08025320c7dd0ae21dc4d57a927ce0:packages/skills/skills/contribute-to-eliza"} -->
