### PR TITLE
fix(shared): preserve enabled primary capability intent

### DIFF
--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -31,24 +31,28 @@ type ConversationRequest =
       agent: CachedAgentSandbox;
       rpc: BridgeRequest;
       trustedMessageRole?: "system";
+      trustedUserUtterance?: string;
     }
   | {
       operation: "personal-bridge";
       agent: SharedRuntimeAgent;
       rpc: BridgeRequest;
       trustedMessageRole?: "system";
+      trustedUserUtterance?: string;
     }
   | {
       operation: "stream";
       agent: CachedAgentSandbox;
       rpc: BridgeRequest;
       trustedMessageRole?: "system";
+      trustedUserUtterance?: string;
     }
   | {
       operation: "personal-stream";
       agent: SharedRuntimeAgent;
       rpc: BridgeRequest;
       trustedMessageRole?: "system";
+      trustedUserUtterance?: string;
     }
   | {
       operation: "prewarm";
@@ -1176,6 +1180,7 @@ export class SharedRuntimeConversation {
           turnClaims,
           funding: personal ? "platform" : "organization-credits",
           trustedMessageRole: payload.trustedMessageRole,
+          trustedUserUtterance: payload.trustedUserUtterance,
           executionEngine,
         });
       }
@@ -1185,6 +1190,7 @@ export class SharedRuntimeConversation {
         turnClaims,
         funding: personal ? "platform" : "organization-credits",
         trustedMessageRole: payload.trustedMessageRole,
+        trustedUserUtterance: payload.trustedUserUtterance,
         executionEngine,
       });
       return Response.json(result);

--- a/packages/cloud/shared/src/lib/services/managed-discord-guild-voice.ts
+++ b/packages/cloud/shared/src/lib/services/managed-discord-guild-voice.ts
@@ -83,6 +83,8 @@ export async function runManagedDiscordGuildTextTurn(
     context.namespace,
     `discord-guild:${input.messageId}`,
     "platform",
+    undefined,
+    input.message,
   );
   return {
     replyText: reply.text.trim(),
@@ -189,6 +191,8 @@ export async function runManagedDiscordGuildVoiceTurn(
     context.namespace,
     input.utteranceId,
     "platform",
+    undefined,
+    transcript,
   );
   const replyText = reply.text.trim();
   if (!replyText) throw new Error("Shared Eliza returned no guild voice reply");

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
@@ -150,6 +150,7 @@ describe("shared conversation coordinator", () => {
       executionCtx,
       agentKind: "personal",
       trustedMessageRole: "system",
+      trustedUserUtterance: "email Bob now",
     });
     await coordinateSharedLifecycleEvent(
       agent.id,
@@ -164,6 +165,7 @@ describe("shared conversation coordinator", () => {
         agent,
         rpc,
         trustedMessageRole: "system",
+        trustedUserUtterance: "email Bob now",
       },
       {
         operation: "lifecycle",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -23,6 +23,8 @@ export interface SharedConversationCoordinatorOptions {
   agentKind?: "sandbox" | "personal";
   /** Authenticated server-only role override; never accepted from RPC params. */
   trustedMessageRole?: "system";
+  /** Authenticated raw utterance when RPC text also contains server-composed context. */
+  trustedUserUtterance?: string;
 }
 
 export interface SharedConversationHistoryCoordinatorOptions {
@@ -220,6 +222,9 @@ export async function coordinateSharedBridge(
         agent,
         rpc,
         ...(options.trustedMessageRole ? { trustedMessageRole: options.trustedMessageRole } : {}),
+        ...(options.trustedUserUtterance
+          ? { trustedUserUtterance: options.trustedUserUtterance }
+          : {}),
       }),
     });
   await requireCoordinatorResponse(response, "conversation");
@@ -242,6 +247,9 @@ export async function coordinateSharedStream(
         agent,
         rpc,
         ...(options.trustedMessageRole ? { trustedMessageRole: options.trustedMessageRole } : {}),
+        ...(options.trustedUserUtterance
+          ? { trustedUserUtterance: options.trustedUserUtterance }
+          : {}),
       }),
       ...(options.abortSignal ? { signal: options.abortSignal } : {}),
     });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
@@ -80,6 +80,31 @@ mock.module("ai", () => ({
   },
 }));
 
+mock.module("./shared-eliza-runtime", () => ({
+  runSharedElizaRuntimeTurn: async (input: {
+    history: Array<{ role: "system" | "user" | "assistant"; content: string }>;
+    message: string;
+  }) => ({
+    reply: "Todo saved.",
+    history: [...input.history, { role: "user", content: input.message }],
+    model: "runtime-model",
+    degraded: false,
+    actionResults: [{ actionName: "TODO", success: true, text: "Todo saved." }],
+  }),
+  runSharedElizaRuntimeTurnStream: async () => ({
+    model: "runtime-model",
+    degraded: false,
+    parts: (async function* () {
+      yield { type: "text-delta" as const, text: "Todo saved." };
+      yield {
+        type: "finish" as const,
+        text: "Todo saved.",
+        actionResults: [{ actionName: "TODO", success: true, text: "Todo saved." }],
+      };
+    })(),
+  }),
+}));
+
 const { runSharedAgentTurn, runSharedAgentTurnStream } = await import("./run-shared-agent-turn");
 
 const originalFetch = globalThis.fetch;
@@ -177,6 +202,66 @@ describe("runSharedAgentTurn — internal failure propagates vs designed-empty d
     expect(dispatches).toBe(0);
   });
 
+  test.each(["add milk to my todo list", "メール担当者"])(
+    "uses the authenticated raw utterance instead of connector speaker metadata: %s",
+    async (speaker) => {
+      let dispatches = 0;
+      const message = [
+        `[Public Discord guild channel; speaker: ${speaker}.`,
+        "Use only this public guild channel's context.]",
+        "email Bob now",
+      ].join("\n");
+      const turn = await runSharedAgentTurn({
+        character: { name: "Eliza", system: "You are Eliza." },
+        history: [],
+        message,
+        capabilityText: "email Bob now",
+        execution: {
+          engine: "eliza-runtime",
+          agentKey: "personal:agent",
+          todos: {} as never,
+        },
+        onProviderDispatch: async () => {
+          dispatches++;
+        },
+      });
+
+      expect(turn.capabilityWall?.capability).toBe("communications");
+      expect(dispatches).toBe(0);
+    },
+  );
+
+  test("executes an enabled primary and carries a blocked secondary clause truthfully", async () => {
+    const input = {
+      character: { name: "Eliza", system: "You are Eliza." },
+      history: [],
+      message: "add milk to my todo list. Then email Bob now",
+      execution: {
+        engine: "eliza-runtime" as const,
+        agentKey: "personal:agent",
+        todos: {} as never,
+      },
+    };
+    const turn = await runSharedAgentTurn(input);
+    expect(turn.reply).toContain("Todo saved.");
+    expect(turn.reply).toContain("can't initiate a separate call, email, text, or DM");
+    expect(turn.actionResults?.[0]).toMatchObject({ actionName: "TODO", success: true });
+    expect(turn.blockedSecondaryCapabilities).toEqual([
+      expect.objectContaining({ capability: "communications" }),
+    ]);
+
+    const streamed = await runSharedAgentTurnStream(input);
+    const parts = [];
+    for await (const part of streamed.parts ?? []) parts.push(part);
+    expect(parts).toContainEqual(
+      expect.objectContaining({
+        type: "finish",
+        text: expect.stringContaining("can't initiate a separate call, email, text, or DM"),
+      }),
+    );
+    expect(streamed.blockedSecondaryCapabilities?.[0]?.capability).toBe("communications");
+  });
+
   test("tells the model the same capability truth for ambiguous follow-ups", async () => {
     let system = "";
     generateTextImpl = async (options) => {
@@ -198,7 +283,7 @@ describe("runSharedAgentTurn — internal failure propagates vs designed-empty d
     });
 
     expect(system).toContain("Shared runtime boundaries");
-    expect(system).toContain("no external tools");
+    expect(system).toContain("no connected accounts");
     expect(system).toContain("Never claim that you performed");
     expect(system).toContain("needs Dedicated");
   });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -29,7 +29,11 @@ import {
   getInteractiveCerebrasLanguageModel,
   hasLanguageModelProviderConfigured,
 } from "../../providers/language-model";
-import { resolveSharedCapabilityWall, type SharedCapabilityWall } from "./shared-capability-wall";
+import {
+  resolveSharedCapabilityIntent,
+  type SharedCapabilityResolution,
+  type SharedCapabilityWall,
+} from "./shared-capability-wall";
 import { resolveSharedNavIntent, type SharedNavIntent } from "./shared-nav-intent";
 
 export interface SharedTurnMessage {
@@ -63,6 +67,8 @@ export interface RunSharedAgentTurnInput {
   history: SharedTurnMessage[];
   /** The incoming user message or event text. */
   message: string;
+  /** Authenticated raw utterance used for intent checks when `message` includes server context. */
+  capabilityText?: string;
   /** Trusted lifecycle callers may add a system event instead of impersonating the user. */
   messageRole?: "system" | "user";
   /** Stable ids assigned by the transport for the persisted user/assistant pair. */
@@ -118,6 +124,8 @@ export interface RunSharedAgentTurnResult {
   navIntent?: SharedNavIntent;
   /** Typed refusal for a tool or device action Shared cannot execute. */
   capabilityWall?: SharedCapabilityWall;
+  /** Unsupported clauses that follow an enabled primary reminder or Todo. */
+  blockedSecondaryCapabilities?: SharedCapabilityWall[];
 }
 
 export type SharedAgentTurnStreamPart =
@@ -149,6 +157,8 @@ export interface RunSharedAgentTurnStreamResult {
   navIntent?: SharedNavIntent;
   /** Typed refusal for a tool or device action Shared cannot execute. */
   capabilityWall?: SharedCapabilityWall;
+  /** Unsupported clauses that follow an enabled primary reminder or Todo. */
+  blockedSecondaryCapabilities?: SharedCapabilityWall[];
 }
 
 /**
@@ -283,6 +293,65 @@ function modelHistoryContent(message: SharedTurnMessage): string {
   return message.content;
 }
 
+function capabilityResolution(
+  input: RunSharedAgentTurnInput,
+  capabilities: { reminders: boolean; todos: boolean },
+): SharedCapabilityResolution | null {
+  return resolveSharedCapabilityIntent(input.capabilityText ?? input.message, capabilities);
+}
+
+function appendBlockedCapabilityReplies(reply: string, blocked: SharedCapabilityWall[]): string {
+  const additions = blocked.map((wall) => wall.reply).filter((text) => !reply.includes(text));
+  return additions.length ? `${reply.trim()}\n\n${additions.join("\n\n")}` : reply;
+}
+
+function blockedCapabilityReplySuffix(reply: string, blocked: SharedCapabilityWall[]): string {
+  const additions = blocked.map((wall) => wall.reply).filter((text) => !reply.includes(text));
+  return additions.length ? `\n\n${additions.join("\n\n")}` : "";
+}
+
+function withBlockedSecondaryCapabilities(
+  result: RunSharedAgentTurnResult,
+  input: RunSharedAgentTurnInput,
+  blocked: SharedCapabilityWall[],
+): RunSharedAgentTurnResult {
+  if (!blocked.length) return result;
+  const reply = appendBlockedCapabilityReplies(result.reply, blocked);
+  return {
+    ...result,
+    reply,
+    history: appendSharedTurn(
+      input.history,
+      input.message.trim(),
+      reply,
+      input.messageIds,
+      input.messageRole,
+    ),
+    blockedSecondaryCapabilities: blocked,
+  };
+}
+
+function withBlockedSecondaryStream(
+  result: RunSharedAgentTurnStreamResult,
+  blocked: SharedCapabilityWall[],
+): RunSharedAgentTurnStreamResult {
+  if (!blocked.length || !result.parts) return result;
+  const source = result.parts;
+  const parts = (async function* (): AsyncIterable<SharedAgentTurnStreamPart> {
+    for await (const part of source) {
+      if (part.type === "text-delta") {
+        yield part;
+        continue;
+      }
+      const suffix = blockedCapabilityReplySuffix(part.text, blocked);
+      const text = `${part.text.trim()}${suffix}`;
+      if (suffix) yield { type: "text-delta", text: suffix };
+      yield { ...part, text };
+    }
+  })();
+  return { ...result, parts, blockedSecondaryCapabilities: blocked };
+}
+
 /**
  * Run one shared (container-free) turn for a simple agent. Returns a degraded
  * result only when NO shared model is configured (a designed-unavailable state);
@@ -297,11 +366,15 @@ export async function runSharedAgentTurn(
 
   const remindersEnabled = Boolean(input.execution?.reminders);
   const todosEnabled = Boolean(input.execution?.todos);
-  const requestedCapability = resolveSharedCapabilityWall(message);
-  const capabilityWall = resolveSharedCapabilityWall(message, {
+  const capabilities = {
     reminders: remindersEnabled,
     todos: todosEnabled,
-  });
+  };
+  const requestedCapability = resolveSharedCapabilityIntent(input.capabilityText ?? message);
+  const resolution = capabilityResolution(input, capabilities);
+  const capabilityWall = resolution?.kind === "blocked-primary" ? resolution.blocked : undefined;
+  const blockedSecondary =
+    resolution?.kind === "enabled-primary" ? resolution.blockedSecondary : [];
   if (capabilityWall) {
     return {
       reply: capabilityWall.reply,
@@ -326,9 +399,11 @@ export async function runSharedAgentTurn(
   // durable action is registered, persistence must win over an app-navigation
   // handoff or the turn would claim success without writing anything.
   const navIntent =
-    todosEnabled && requestedCapability?.capability === "todos"
+    todosEnabled &&
+    requestedCapability?.kind === "blocked-primary" &&
+    requestedCapability.blocked.capability === "todos"
       ? null
-      : resolveSharedNavIntent(message);
+      : resolveSharedNavIntent(input.capabilityText ?? message);
   if (navIntent) {
     return {
       reply: navIntent.reply,
@@ -359,7 +434,7 @@ export async function runSharedAgentTurn(
 
   if (input.execution?.engine === "eliza-runtime") {
     const { runSharedElizaRuntimeTurn } = await import("./shared-eliza-runtime");
-    return await runSharedElizaRuntimeTurn({
+    const result = await runSharedElizaRuntimeTurn({
       ...input,
       character: {
         ...input.character,
@@ -371,6 +446,7 @@ export async function runSharedAgentTurn(
       agentKey: input.execution.agentKey,
       model: modelId,
     });
+    return withBlockedSecondaryCapabilities(result, input, blockedSecondary);
   }
 
   try {
@@ -395,13 +471,23 @@ export async function runSharedAgentTurn(
       ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
     });
     const reply = text.trim() || "…";
-    return {
-      reply,
-      history: appendSharedTurn(input.history, message, reply, input.messageIds, input.messageRole),
-      model: modelId,
-      degraded: false,
-      usage,
-    };
+    return withBlockedSecondaryCapabilities(
+      {
+        reply,
+        history: appendSharedTurn(
+          input.history,
+          message,
+          reply,
+          input.messageIds,
+          input.messageRole,
+        ),
+        model: modelId,
+        degraded: false,
+        usage,
+      },
+      input,
+      blockedSecondary,
+    );
   } catch (error) {
     // error-policy:J2 context-adding rethrow. An inference/provider failure is an
     // INTERNAL failure, not a designed-empty result: swallowing it into a
@@ -430,12 +516,15 @@ export async function runSharedAgentTurnStream(
 
   const remindersEnabled = Boolean(input.execution?.reminders);
   const todosEnabled = Boolean(input.execution?.todos);
-  const requestedCapability = resolveSharedCapabilityWall(message);
-
-  const capabilityWall = resolveSharedCapabilityWall(message, {
+  const capabilities = {
     reminders: remindersEnabled,
     todos: todosEnabled,
-  });
+  };
+  const requestedCapability = resolveSharedCapabilityIntent(input.capabilityText ?? message);
+  const resolution = capabilityResolution(input, capabilities);
+  const capabilityWall = resolution?.kind === "blocked-primary" ? resolution.blocked : undefined;
+  const blockedSecondary =
+    resolution?.kind === "enabled-primary" ? resolution.blockedSecondary : [];
   if (capabilityWall) {
     const reply = capabilityWall.reply;
     const parts = (async function* (): AsyncIterable<SharedAgentTurnStreamPart> {
@@ -457,9 +546,11 @@ export async function runSharedAgentTurnStream(
   // identical to a normal turn; the caller reads `navIntent` to attach a VIEWS
   // navigation handoff to the `done` frame (#F5-ACTIONS).
   const navIntent =
-    todosEnabled && requestedCapability?.capability === "todos"
+    todosEnabled &&
+    requestedCapability?.kind === "blocked-primary" &&
+    requestedCapability.blocked.capability === "todos"
       ? null
-      : resolveSharedNavIntent(message);
+      : resolveSharedNavIntent(input.capabilityText ?? message);
   if (navIntent) {
     const reply = navIntent.reply;
     const parts = (async function* (): AsyncIterable<SharedAgentTurnStreamPart> {
@@ -490,7 +581,7 @@ export async function runSharedAgentTurnStream(
 
   if (input.execution?.engine === "eliza-runtime") {
     const { runSharedElizaRuntimeTurnStream } = await import("./shared-eliza-runtime");
-    return await runSharedElizaRuntimeTurnStream({
+    const result = await runSharedElizaRuntimeTurnStream({
       ...input,
       character: {
         ...input.character,
@@ -502,6 +593,7 @@ export async function runSharedAgentTurnStream(
       agentKey: input.execution.agentKey,
       model: modelId,
     });
+    return withBlockedSecondaryStream(result, blockedSecondary);
   }
 
   try {
@@ -598,12 +690,15 @@ export async function runSharedAgentTurnStream(
       }
     })();
 
-    return {
-      model: modelId,
-      degraded: false,
-      parts,
-      cancel,
-    };
+    return withBlockedSecondaryStream(
+      {
+        model: modelId,
+        degraded: false,
+        parts,
+        cancel,
+      },
+      blockedSecondary,
+    );
   } catch (error) {
     // error-policy:J2 context-adding rethrow. Preserve the setup/provider cause
     // so the caller refunds only a provably unaccepted invocation.

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
@@ -56,7 +56,9 @@ describe("Shared capability wall", () => {
   test.each([
     "remind me in 1 minute: QA20315-DISCORD-DM-R3 verified",
     "remind me in two minutes to text Alice",
+    "remind me to email Bob",
     "remind me tomorrow to email Bob the itinerary",
+    "remind me to email Bob and call Alice",
   ])("keeps nested communication words inside an enabled reminder: %s", (message) => {
     expect(resolveSharedCapabilityIntent(message, { reminders: true })).toEqual({
       kind: "enabled-primary",
@@ -68,8 +70,11 @@ describe("Shared capability wall", () => {
 
   test.each([
     ["remind me tomorrow, then email Bob now", "communications"],
+    ["remind me tomorrow and email Bob now", "communications"],
+    ["remind me to email Bob, then email Alice now", "communications"],
     ["remind me tomorrow; delete the file in my workspace", "filesystem"],
     ["add milk to my todo list. Then buy groceries", "purchases"],
+    ["add milk to my todo list and email Bob now", "communications"],
   ])(
     "preserves enabled primary intent and reports a blocked later clause: %s",
     (message, blocked) => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
@@ -1,7 +1,10 @@
 /** Exercises the truthful Shared-to-Dedicated boundary against product copy. */
 
 import { describe, expect, test } from "bun:test";
-import { resolveSharedCapabilityWall } from "./shared-capability-wall";
+import {
+  resolveSharedCapabilityIntent,
+  resolveSharedCapabilityWall,
+} from "./shared-capability-wall";
 
 describe("Shared capability wall", () => {
   test.each([
@@ -50,6 +53,45 @@ describe("Shared capability wall", () => {
     expect(resolveSharedCapabilityWall("remind me in two minutes")?.capability).toBe("reminders");
   });
 
+  test.each([
+    "remind me in 1 minute: QA20315-DISCORD-DM-R3 verified",
+    "remind me in two minutes to text Alice",
+    "remind me tomorrow to email Bob the itinerary",
+  ])("keeps nested communication words inside an enabled reminder: %s", (message) => {
+    expect(resolveSharedCapabilityIntent(message, { reminders: true })).toEqual({
+      kind: "enabled-primary",
+      primary: expect.objectContaining({ capability: "reminders" }),
+      blockedSecondary: [],
+    });
+    expect(resolveSharedCapabilityWall(message, { reminders: true })).toBeNull();
+  });
+
+  test.each([
+    ["remind me tomorrow, then email Bob now", "communications"],
+    ["remind me tomorrow; delete the file in my workspace", "filesystem"],
+    ["add milk to my todo list. Then buy groceries", "purchases"],
+  ])(
+    "preserves enabled primary intent and reports a blocked later clause: %s",
+    (message, blocked) => {
+      expect(resolveSharedCapabilityIntent(message, { reminders: true, todos: true })).toEqual({
+        kind: "enabled-primary",
+        primary: expect.any(Object),
+        blockedSecondary: [expect.objectContaining({ capability: blocked })],
+      });
+    },
+  );
+
+  test("keeps first-command authority when an unsupported command precedes a reminder", () => {
+    expect(
+      resolveSharedCapabilityIntent("email Bob now and remind me tomorrow", {
+        reminders: true,
+      }),
+    ).toEqual({
+      kind: "blocked-primary",
+      blocked: expect.objectContaining({ capability: "communications" }),
+    });
+  });
+
   test("does not falsely claim voice and messaging require Dedicated", () => {
     const wall = resolveSharedCapabilityWall("call Mom");
     expect(wall?.reply).toContain("connected voice and messaging channels");
@@ -75,5 +117,13 @@ describe("Shared capability wall", () => {
       }),
     ).toBeNull();
     expect(resolveSharedCapabilityWall("add milk to my todo list")?.capability).toBe("todos");
+  });
+
+  test("keeps nested communication words inside an enabled Todo", () => {
+    expect(resolveSharedCapabilityIntent("add call Mom to my todo list", { todos: true })).toEqual({
+      kind: "enabled-primary",
+      primary: expect.objectContaining({ capability: "todos" }),
+      blockedSecondary: [],
+    });
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
@@ -14,11 +14,13 @@ describe("Shared capability wall", () => {
     ["show my checklist", "todos"],
     ["complete the laundry todo", "todos"],
     ["show my calendar events", "calendar"],
+    ["list my meetings", "calendar"],
     ["book me dinner for four", "bookings"],
     ["book a flight to san francisco", "bookings"],
     ["email Bob the itinerary", "communications"],
     ["call Mom", "communications"],
     ["text Alice that I'm late", "communications"],
+    ["message Bob the update", "communications"],
     ["order dinner for me", "purchases"],
     ["save this as a note", "notes"],
     ["connect my Gmail", "cloud-apps"],
@@ -40,6 +42,9 @@ describe("Shared capability wall", () => {
     "What restaurant should I choose?",
     "Write a TypeScript function",
     "Let's discuss my meeting tomorrow",
+    "Remember this code word for my next message: apricot-816.",
+    "List two ways to make a meeting shorter.",
+    "Make this message shorter.",
   ])("keeps discussion and research in Shared: %s", (message) => {
     expect(resolveSharedCapabilityWall(message)).toBeNull();
   });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
@@ -59,6 +59,7 @@ describe("Shared capability wall", () => {
     "remind me to email Bob",
     "remind me tomorrow to email Bob the itinerary",
     "remind me to email Bob and call Alice",
+    "remind me to email Bob and then call Alice",
   ])("keeps nested communication words inside an enabled reminder: %s", (message) => {
     expect(resolveSharedCapabilityIntent(message, { reminders: true })).toEqual({
       kind: "enabled-primary",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
@@ -20,6 +20,14 @@ export interface SharedCapabilityWall {
   reply: string;
 }
 
+export type SharedCapabilityResolution =
+  | { kind: "blocked-primary"; blocked: SharedCapabilityWall }
+  | {
+      kind: "enabled-primary";
+      primary: SharedCapabilityWall;
+      blockedSecondary: SharedCapabilityWall[];
+    };
+
 const NON_EXECUTION_CONTEXT =
   /^(?:please\s+)?(?:(?:can|could|would)\s+you\s+)?(?:do\s+not|don't|dont|never|explain|describe|define|translate|teach\s+me|tell\s+me\s+how|show\s+me\s+how|how\s+(?:do|would|can|to)|what\s+(?:is|are|would|happens?)|why\s+(?:do|would|can|is|are)|if\s+(?:i|we|you)|before\s+you)\b/i;
 
@@ -123,15 +131,75 @@ export function resolveSharedCapabilityWall(
   message: string | undefined,
   capabilities: { reminders?: boolean; todos?: boolean } = {},
 ): SharedCapabilityWall | null {
+  const resolution = resolveSharedCapabilityIntent(message, capabilities);
+  if (!resolution) return null;
+  return resolution.kind === "blocked-primary"
+    ? resolution.blocked
+    : (resolution.blockedSecondary[0] ?? null);
+}
+
+type CapabilityMatch = {
+  rule: (typeof RULES)[number];
+  priority: number;
+  index: number;
+  end: number;
+};
+
+function isEnabled(
+  match: CapabilityMatch,
+  capabilities: { reminders?: boolean; todos?: boolean },
+): boolean {
+  return (
+    (match.rule.capability === "reminders" && capabilities.reminders === true) ||
+    (match.rule.capability === "todos" && capabilities.todos === true)
+  );
+}
+
+function wallFor(match: CapabilityMatch): SharedCapabilityWall {
+  const { capability, label, reply } = match.rule;
+  return { capability, label, reply };
+}
+
+function beginsSeparateClause(text: string, primary: CapabilityMatch, candidate: CapabilityMatch) {
+  if (candidate.index < primary.end) return false;
+  const between = text.slice(primary.end, candidate.index);
+  return /(?:[.!?;]\s*|,\s*|\b(?:and\s+)?then\b[\s\S]*)$/i.test(between);
+}
+
+/**
+ * Resolve the first executable intent without losing explicit later clauses.
+ * Enabled reminder/Todo payloads may contain capability words, while a later
+ * sentence or sequenced clause remains a typed blocked request.
+ */
+export function resolveSharedCapabilityIntent(
+  message: string | undefined,
+  capabilities: { reminders?: boolean; todos?: boolean } = {},
+): SharedCapabilityResolution | null {
   const text = (message ?? "").trim();
   if (!text || NON_EXECUTION_CONTEXT.test(text)) return null;
-  const match = RULES.find(
-    (rule) =>
-      !(rule.capability === "reminders" && capabilities.reminders) &&
-      !(rule.capability === "todos" && capabilities.todos) &&
-      rule.pattern.test(text),
-  );
-  return match ? { capability: match.capability, label: match.label, reply: match.reply } : null;
+  const matches = RULES.flatMap((rule, priority) => {
+    const match = rule.pattern.exec(text);
+    return match
+      ? [{ rule, priority, index: match.index, end: match.index + match[0].length }]
+      : [];
+  }).sort((left, right) => left.index - right.index || left.priority - right.priority);
+  const primary = matches[0];
+  if (!primary) return null;
+  if (!isEnabled(primary, capabilities)) {
+    return { kind: "blocked-primary", blocked: wallFor(primary) };
+  }
+  const blockedSecondary = matches
+    .slice(1)
+    .filter(
+      (candidate) =>
+        !isEnabled(candidate, capabilities) && beginsSeparateClause(text, primary, candidate),
+    )
+    .map(wallFor);
+  return {
+    kind: "enabled-primary",
+    primary: wallFor(primary),
+    blockedSecondary,
+  };
 }
 
 export function capabilityWallActionResult(wall: SharedCapabilityWall) {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
@@ -163,7 +163,13 @@ function wallFor(match: CapabilityMatch): SharedCapabilityWall {
 function beginsSeparateClause(text: string, primary: CapabilityMatch, candidate: CapabilityMatch) {
   if (candidate.index < primary.end) return false;
   const between = text.slice(primary.end, candidate.index);
-  return /(?:[.!?;]\s*|,\s*|\b(?:and\s+)?then\b[\s\S]*)$/i.test(between);
+  if (/(?:[.!?;]\s*|,\s*|\b(?:and\s+)?then\b[\s\S]*)$/i.test(between)) return true;
+  if (!/\band\s*$/i.test(between)) return false;
+
+  // An infinitive after "remind me" is reminder content, even when that
+  // content coordinates several actions. A completed trigger followed by
+  // "and" starts a new command instead.
+  return primary.rule.capability !== "reminders" || !/\bto\b/i.test(between);
 }
 
 /**
@@ -178,23 +184,34 @@ export function resolveSharedCapabilityIntent(
   const text = (message ?? "").trim();
   if (!text || NON_EXECUTION_CONTEXT.test(text)) return null;
   const matches = RULES.flatMap((rule, priority) => {
-    const match = rule.pattern.exec(text);
-    return match
-      ? [{ rule, priority, index: match.index, end: match.index + match[0].length }]
-      : [];
+    const pattern = new RegExp(
+      rule.pattern.source,
+      rule.pattern.flags.includes("g") ? rule.pattern.flags : `${rule.pattern.flags}g`,
+    );
+    return Array.from(text.matchAll(pattern), (match) => ({
+      rule,
+      priority,
+      index: match.index,
+      end: match.index + match[0].length,
+    }));
   }).sort((left, right) => left.index - right.index || left.priority - right.priority);
   const primary = matches[0];
   if (!primary) return null;
   if (!isEnabled(primary, capabilities)) {
     return { kind: "blocked-primary", blocked: wallFor(primary) };
   }
-  const blockedSecondary = matches
+  const blockedMatches = matches
     .slice(1)
     .filter(
       (candidate) =>
         !isEnabled(candidate, capabilities) && beginsSeparateClause(text, primary, candidate),
-    )
-    .map(wallFor);
+    );
+  const blockedCapabilities = new Set<SharedDedicatedCapability>();
+  const blockedSecondary = blockedMatches.flatMap((match) => {
+    if (blockedCapabilities.has(match.rule.capability)) return [];
+    blockedCapabilities.add(match.rule.capability);
+    return [wallFor(match)];
+  });
   return {
     kind: "enabled-primary",
     primary: wallFor(primary),

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
@@ -163,13 +163,17 @@ function wallFor(match: CapabilityMatch): SharedCapabilityWall {
 function beginsSeparateClause(text: string, primary: CapabilityMatch, candidate: CapabilityMatch) {
   if (candidate.index < primary.end) return false;
   const between = text.slice(primary.end, candidate.index);
-  if (/(?:[.!?;]\s*|,\s*|\b(?:and\s+)?then\b[\s\S]*)$/i.test(between)) return true;
+  const isReminderPayload = primary.rule.capability === "reminders" && /\bto\b/i.test(between);
+  if (/[.!?;,]\s*$/i.test(between)) return true;
+  if (/\b(?:and\s+)?then\b[\s\S]*$/i.test(between)) {
+    return !isReminderPayload || /[.!?;,]\s*(?:and\s+)?then\b[\s\S]*$/i.test(between);
+  }
   if (!/\band\s*$/i.test(between)) return false;
 
   // An infinitive after "remind me" is reminder content, even when that
   // content coordinates several actions. A completed trigger followed by
   // "and" starts a new command instead.
-  return primary.rule.capability !== "reminders" || !/\bto\b/i.test(between);
+  return !isReminderPayload;
 }
 
 /**

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
@@ -51,7 +51,7 @@ const RULES: ReadonlyArray<SharedCapabilityWall & { pattern: RegExp }> = [
     capability: "calendar",
     label: "Calendar",
     pattern:
-      /\b(?:add|create|book|schedule|cancel|delete|move|reschedule|check|show|list|open)\b[\s\S]{0,36}\b(?:calendar|events?|appointments?|meetings?)\b/i,
+      /\b(?:(?:add|create|book|schedule|cancel|delete|move|reschedule)\b[\s\S]{0,36}\b(?:calendar|events?|appointments?|meetings?)|(?:check|show|list|open)\b\s+(?:me\s+)?(?:(?:my|our|the|upcoming|next|today(?:'s)?|tomorrow(?:'s)?)\s+){0,2}(?:calendar|events?|appointments?|meetings?))\b/i,
     reply:
       "Calendar actions need Dedicated. I can help plan the event here, but Shared can't read or change your calendar.",
   },
@@ -67,7 +67,7 @@ const RULES: ReadonlyArray<SharedCapabilityWall & { pattern: RegExp }> = [
     capability: "communications",
     label: "Calls and messages",
     pattern:
-      /\b(?:(?:can|could|would|will)\s+you\s+)?(?:(?:email|call|text|message|dm)\b(?!\s+(?:this|the|a|an)\s+(?:\w+\s+){0,2}(?:function|method|api|endpoint|class|variable|command)\b)|send\b[\s\S]{0,32}\b(?:email|text|message|dm)\b)/i,
+      /(?:(?<=^|[.!?;,]\s*|\b(?:and\s+)?then\s+|\band\s+|\bto\s+|\bplease\s+|\b(?:can|could|would|will)\s+you\s+)(?:email|call|text|message|dm)\s+(?!(?:this|the|a|an)\s+(?:\w+\s+){0,2}(?:function|method|api|endpoint|class|variable|command)\b)|\bsend\b[\s\S]{0,32}\b(?:email|text|message|dm)\b)/i,
     reply:
       "I can talk with you and reply through Eliza's connected voice and messaging channels. I can't initiate a separate call, email, text, or DM to another person from this session.",
   },

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
@@ -324,12 +324,15 @@ describe("shared-rest-adapter — messages", () => {
       NAMESPACE,
       "telegram:update-1",
       "platform",
+      undefined,
+      "hello",
     );
 
     expect(coordinateSharedBridge.mock.calls[0][2]).toEqual({
       executionCtx: EXECUTION_CTX,
       namespace: NAMESPACE,
       agentKind: "personal",
+      trustedUserUtterance: "hello",
     });
   });
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -525,6 +525,7 @@ export async function sharedRestMessageSend(
   clientMessageId?: string,
   funding: "organization-credits" | "platform" = "organization-credits",
   trustedDelivery?: SharedReminderDelivery,
+  trustedUserUtterance?: string,
 ): Promise<{ text: string; agentName: string }> {
   const rpc: BridgeRequest = {
     jsonrpc: "2.0",
@@ -545,6 +546,7 @@ export async function sharedRestMessageSend(
     executionCtx,
     namespace,
     ...(funding === "platform" ? { agentKind: "personal" as const } : {}),
+    ...(trustedUserUtterance ? { trustedUserUtterance } : {}),
   });
   if (response.error) {
     // A credit-reserve rejection is a permanent add-credits condition, not a

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -563,6 +563,36 @@ describe("SharedRuntimeChatService", () => {
     });
   });
 
+  test("streams successful primary effects together with blocked secondary capability results", async () => {
+    const blockedCommunication = {
+      capability: "communications",
+      label: "Calls and messages",
+      reply: "I can't initiate a separate email.",
+    };
+    streamTurn = {
+      degraded: false,
+      blockedSecondaryCapabilities: [blockedCommunication],
+      parts: (async function* () {
+        yield { type: "text-delta", text: "Created: [ ] Buy milk" };
+        yield {
+          type: "finish",
+          text: "Created: [ ] Buy milk\n\nI can't initiate a separate email.",
+          actionResults: [expectedTodoActionResult],
+        };
+      })(),
+    };
+    const response = await new SharedRuntimeChatService().stream(agent, rpc, {
+      ...harness(),
+      funding: "platform",
+      executionEngine: "eliza-runtime",
+    });
+
+    const body = await response.text();
+    expect(body).toContain(JSON.stringify(expectedTodoActionResult));
+    expect(body).toContain('"actionName":"DEDICATED_CAPABILITY_REQUIRED"');
+    expect(body).toContain('"capability":"communications"');
+  });
+
   test("enables reminders only for platform-funded turns with trusted private delivery", async () => {
     const service = new SharedRuntimeChatService();
     const trustedRpc = {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -85,12 +85,18 @@ export interface SharedRuntimeHistoryStore {
 }
 
 function turnActionResults(
-  turn: Pick<RunSharedAgentTurnResult, "actionResults" | "navIntent" | "capabilityWall">,
+  turn: Pick<
+    RunSharedAgentTurnResult,
+    "actionResults" | "navIntent" | "capabilityWall" | "blockedSecondaryCapabilities"
+  >,
 ): unknown[] | undefined {
-  if (turn.actionResults?.length) return turn.actionResults;
-  if (turn.capabilityWall) return [capabilityWallActionResult(turn.capabilityWall)];
-  if (turn.navIntent) return [navIntentActionResult(turn.navIntent)];
-  return undefined;
+  const results: unknown[] = [...(turn.actionResults ?? [])];
+  if (turn.capabilityWall) results.push(capabilityWallActionResult(turn.capabilityWall));
+  if (turn.navIntent) results.push(navIntentActionResult(turn.navIntent));
+  for (const wall of turn.blockedSecondaryCapabilities ?? []) {
+    results.push(capabilityWallActionResult(wall));
+  }
+  return results.length ? results : undefined;
 }
 
 function isDeterministicFreeTurn(
@@ -147,6 +153,8 @@ export interface SharedRuntimeChatOptions {
   funding?: "organization-credits" | "platform";
   /** Server-authenticated lifecycle prompt; never derived from bridge params. */
   trustedMessageRole?: "system";
+  /** Server-authenticated raw utterance when the model message includes connector context. */
+  trustedUserUtterance?: string;
   /** Local/transition gate for proving the genuine Workerd AgentRuntime path. */
   executionEngine?: "direct-model" | "eliza-runtime";
 }
@@ -823,6 +831,7 @@ export class SharedRuntimeChatService {
         character,
         history,
         message: text,
+        ...(options.trustedUserUtterance ? { capabilityText: options.trustedUserUtterance } : {}),
         messageRole,
         messageIds,
         ...(claimKey ? { originClientMessageId: claimKey } : {}),
@@ -993,6 +1002,7 @@ export class SharedRuntimeChatService {
         character,
         history,
         message: text,
+        ...(options.trustedUserUtterance ? { capabilityText: options.trustedUserUtterance } : {}),
         messageRole,
         messageIds,
         ...(claimKey ? { originClientMessageId: claimKey } : {}),
@@ -1148,9 +1158,10 @@ export class SharedRuntimeChatService {
               );
               continue;
             }
-            const actionResults = part.actionResults?.length
-              ? part.actionResults
-              : turnActionResults(turn);
+            const actionResults = turnActionResults({
+              ...turn,
+              ...(part.actionResults?.length ? { actionResults: part.actionResults } : {}),
+            });
             await finalizeMessages(finalReply, false, async () => {
               // Durable claim completion before the done frame: a lost/dropped
               // terminal frame replays this result on retry instead of


### PR DESCRIPTION
Closes #20330

## Summary
- select the earliest explicit capability command as the primary intent
- once REMINDERS or TODOS is genuinely enabled, keep nested payload words such as `DM`, `text`, `email`, or `call` inside that action instead of letting a later wall hijack it
- preserve fail-closed communication blocking when the communication command is actually first

## Ground truth
Live Discord Shared request:

`remind me in 1 minute: QA20315-DISCORD-DM-R3 verified`

returned the calls/messages refusal and wrote no reminder because `DM` in the payload matched the communications rule after the enabled reminder rule was skipped.

## Verification
- focused split suite: 124/124, 339 assertions
- `packages/cloud/shared` typecheck: PASS
- Biome exact 12 files: PASS
- `git diff --check`: PASS
- `audit:error-policy-ratchet`: N/A — script is absent on this exact base

## Evidence
- Unit regression includes the exact live Discord wording plus reminder-to-text/email, Todo-with-call, and communication-first controls.
- Real staging re-proof is pending before this draft is marked ready.

## Evidence checklist
- Live model trajectory: pending staging re-proof
- Backend logs: pending staging re-proof
- Domain artifact: pending scheduled task/delivery re-proof
- Frontend/mobile screenshots: N/A — connector behavior only
- Video: N/A — connector behavior only
- Audio: N/A

Production untouched.

## Corrected root design

The resolver now receives the authenticated raw connector utterance separately from the server-composed privacy wrapper. Model/history inputs still retain the wrapper, but user-controlled speaker metadata can no longer nominate capabilities. The typed result distinguishes a blocked primary intent from an enabled primary intent with blocked secondary clauses; enabled Reminders/Todos proceed while unsupported secondary requests are refused deterministically instead of disappearing.

- Base: `aec075c3e30690645ff076ec604bd5b6aa76df3b`
- Head: `1f484d19aac8734c527921cc5632898abb598cdd`
- Final focused validation: 124/124 tests, 339 assertions across capability, coordinator, REST, turn, chat, and SSE contracts
- Genuine Shared AgentRuntime: 7/7 PASS (REMINDERS, TODOS, grounded web search)
- Shared reminder cron: 13/13 PASS (Discord + Blooio routing and fail-closed receipts)
- Genuine Workerd/Miniflare: 3 PASS, 1 opt-in live-search skip (trusted Discord DM reminder included)
- Cloud Shared and Cloud API typechecks: pass
- Production Worker dry bundle: pass
- Exact 12-file Biome and diff-check: pass
- No deploy, provider send, environment approval, or external mutation was performed

This PR remains draft pending exact-head staging/model/task evidence and hosted checks.

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza"} -->

<!-- evidence-head:1f484d19aac8734c527921cc5632898abb598cdd -->

<!-- evidence-row:before-screenshots -->
- [x] N/A — connector-only backend behavior

<!-- evidence-row:after-screenshots -->
- [x] N/A — connector-only backend behavior

<!-- evidence-row:walkthrough-video -->
- [x] N/A — no visual surface changed

<!-- evidence-row:backend-logs -->
- [ ] Pending exact-head staging compound-intent logs

<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend change

<!-- evidence-row:llm-trajectory -->
- [ ] Pending exact-head live-model compound-intent trajectory

<!-- evidence-row:domain-artifacts -->
- [ ] Pending exact-head reminder/task and secondary-refusal artifacts

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill revision: elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

