### PR TITLE
perf(cloud): reuse the request-scoped pg connection across a turn's queries

### DIFF
--- a/packages/cloud/shared/src/db/__tests__/client-tls.test.ts
+++ b/packages/cloud/shared/src/db/__tests__/client-tls.test.ts
@@ -116,3 +116,29 @@ describe("applyIdleSessionTimeouts", () => {
     ).resolves.toBeUndefined();
   });
 });
+
+describe("resolveWorkerPoolMaxUses", () => {
+  test("allows intra-request connection reuse when the request-scoped cache is active", async () => {
+    const { resolveWorkerPoolMaxUses, runWithDbCacheAsync } = await import("../client");
+    expect(resolveWorkerPoolMaxUses({ isLocalTcp: false, hasRequestScopedCache: true })).toBe(0);
+    // The real Worker path: bootstrap middleware enters the request scope, so
+    // a pool created during request handling reuses its connection per query.
+    await runWithDbCacheAsync(async () => {
+      const { hasDbCacheContext } = await import("../client");
+      expect(hasDbCacheContext()).toBe(true);
+      expect(
+        resolveWorkerPoolMaxUses({
+          isLocalTcp: false,
+          hasRequestScopedCache: hasDbCacheContext(),
+        }),
+      ).toBe(0);
+    });
+  });
+
+  test("keeps single-use connections when no request scope guards cross-request sharing", async () => {
+    const { resolveWorkerPoolMaxUses, hasDbCacheContext } = await import("../client");
+    expect(hasDbCacheContext()).toBe(false);
+    expect(resolveWorkerPoolMaxUses({ isLocalTcp: false, hasRequestScopedCache: false })).toBe(1);
+    expect(resolveWorkerPoolMaxUses({ isLocalTcp: true, hasRequestScopedCache: false })).toBe(0);
+  });
+});

--- a/packages/cloud/shared/src/db/client.ts
+++ b/packages/cloud/shared/src/db/client.ts
@@ -223,6 +223,18 @@ export async function applyIdleSessionTimeouts(client: {
   }
 }
 
+/**
+ * Worker-runtime `maxUses` policy: 0 (unlimited within the pool's own
+ * lifetime) whenever the pool is request-scoped or local, 1 otherwise. See
+ * the call site comment for the latency consequence this encodes.
+ */
+export function resolveWorkerPoolMaxUses(args: {
+  isLocalTcp: boolean;
+  hasRequestScopedCache: boolean;
+}): number {
+  return args.isLocalTcp || args.hasRequestScopedCache ? 0 : 1;
+}
+
 function createPgPool(url: string, hyperdriveUrl?: string): PgPool {
   const env = getCloudAwareEnv();
   const inWorkerRuntime = isCloudflareWorkerRuntime();
@@ -245,13 +257,25 @@ function createPgPool(url: string, hyperdriveUrl?: string): PgPool {
 
   if (inWorkerRuntime) {
     options.max = parsePositiveInteger(env.LOCAL_PG_POOL_MAX, 1);
-    // Discard connections after a single query — Workers can't reliably
-    // share I/O across requests. EXCEPT against local PGlite: the PGlite
-    // socket bridge is fragile and creating a fresh TCP connection per
-    // query causes "Connection terminated unexpectedly" mid-stream. Local
-    // dev uses long-lived connections instead; the per-request isolation
-    // workers need only matters for shared remote pools.
-    options.maxUses = isLocalTcp ? 0 : 1;
+    // workerd forbids sharing I/O objects ACROSS requests, not reusing them
+    // within one. When the request-scoped db cache is active (dbCacheAls —
+    // bootstrap middleware enters it per fetch invocation), the pool itself
+    // lives and dies inside a single request, so its connection may serve
+    // every query of that request: one connect handshake per turn instead of
+    // one per query. maxUses=1 stays as the safety net only when no
+    // request-scoped cache is active (module-scope fallback, where a pooled
+    // connection COULD leak across requests) — there, discard after a single
+    // query. This mattered live (shared-agent latency, HQ #18309): the
+    // per-query reconnect multiplied the Worker→Hyperdrive connect RTT by the
+    // turn's query count, dominating the account stage on real traffic while
+    // same-colo synthetic probes hid it. EXCEPT against local PGlite: the
+    // PGlite socket bridge is fragile and a fresh TCP connection per query
+    // causes "Connection terminated unexpectedly" mid-stream; local dev uses
+    // long-lived connections either way.
+    options.maxUses = resolveWorkerPoolMaxUses({
+      isLocalTcp,
+      hasRequestScopedCache: hasDbCacheContext(),
+    });
     options.connectionTimeoutMillis = 30_000;
   }
 


### PR DESCRIPTION
## Context — the shared-agent warm-latency hunt (nubs-directed assist to codex-root/shared-latency)

The lane's measured split: real warm Telegram turn **account=3485ms** vs **118ms** on same-colo synthetic probes, with SQL query time / module init / DNS / fresh-TCP-to-CF already falsified. This PR attacks a code-level amplifier that fits that exact signature.

## Finding

`createPgPool` sets `maxUses: 1` on Workers — **every query discards its connection and pays a fresh Worker→Hyperdrive connect handshake**. But workerd's constraint forbids sharing I/O objects *across* requests, not reusing them *within* one — and the pool is already request-scoped (`dbCacheAls`, entered by bootstrap middleware on every fetch). The single-use discard is redundant protection that multiplies the per-connect RTT by the turn's query count. Sparse real traffic (gateway egress colo, non-trivial RTT to the Hyperdrive endpoint) pays it in full; burst synthetic probes on a warm same-colo isolate hide it.

## Change

`maxUses` resolves through an exported policy helper `resolveWorkerPoolMaxUses`: **0 (reuse within the pool's own lifetime)** when the request-scoped cache is active or against local PGlite; **1 preserved** as the safety net for the module-scope fallback, where a pooled connection could genuinely leak across requests. No change to pool caching, TLS, Hyperdrive selection, or Node/daemon behavior (`onConnect` idle-timeout hook already Worker-skipped).

## Evidence

| Check | Result |
|---|---|
| `client-tls.test.ts` incl. new policy pins (real-path ALS scope → reuse; fallback → single-use; PGlite → reuse) | 13/13 ✅ |
| cloud/shared typecheck | ✅ |
| Biome | ✅ |

## Review + measurement ask (@codex-root/shared-latency)

This is your measured surface — requesting your review rather than self-merging, and the proof is one staging canary probe: after deploy, the `account;dur` Server-Timing on a real warm turn should collapse toward the synthetic ~118ms if the per-query reconnect was the amplifier, or move not at all if it wasn't (either way the redundant handshakes are gone). #20323 does not enter `runWithDbCacheAsync`, so this change does not remove its first canonical warm-hit handshake; that composition claim is intentionally withdrawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Audit hold

This PR remains draft. The implementation direction is plausible, but the current pure policy tests do not prove real workerd pool reuse, overlapping request isolation, request abort/query-error recovery, or DB-backed `executionCtx.waitUntil` work. Early pool teardown would race deferred billing/auth/cache tasks, so no speculative teardown patch was added.

Required before merge: a real Miniflare/workerd lifecycle test covering two overlapping fetches, same-request query reuse, foreground plus waitUntil concurrency, error/abort recovery, and next-request success; then a protected staging warm Telegram canary with Hyperdrive connection metrics. No deploy or provider send was performed in this audit.

<!-- evidence-head:89b2575d738605cbe599cda3feb8577f839df4aa -->

<!-- evidence-row:before-screenshots -->
- [x] N/A — backend connection policy only

<!-- evidence-row:after-screenshots -->
- [x] N/A — backend connection policy only

<!-- evidence-row:walkthrough-video -->
- [x] N/A — no user-visible surface

<!-- evidence-row:backend-logs -->
- [ ] Pending real workerd lifecycle and protected staging Hyperdrive logs

<!-- evidence-row:frontend-logs -->
- [x] N/A — no frontend change

<!-- evidence-row:llm-trajectory -->
- [x] N/A — no model behavior change

<!-- evidence-row:domain-artifacts -->
- [ ] Pending connection-count and Server-Timing canary artifact
