### PR TITLE
fix(cloud): reject non-canonical SIWE nonce chainId

### DIFF
--- a/packages/cloud/api/auth/siwe/nonce/route.ts
+++ b/packages/cloud/api/auth/siwe/nonce/route.ts
@@ -20,13 +20,57 @@ import { logger } from "@/lib/utils/logger";
 import { issueNonce } from "@/lib/utils/siwe-helpers";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
+/**
+ * EIP-4361 `chainId` is a positive decimal integer and defines no narrower
+ * bit-width. Keep the numeric API exact by accepting the full JavaScript safe
+ * integer domain; larger values cannot round-trip through JSON as numbers.
+ */
+export const SIWE_CHAIN_ID_MIN = 1;
+export const SIWE_CHAIN_ID_MAX = Number.MAX_SAFE_INTEGER;
+
+/**
+ * Canonical SIWE chain id at the nonce boundary.
+ * Missing or empty defaults to Ethereum mainnet (1). Any other token must be
+ * a complete ASCII decimal safe integer in [1, Number.MAX_SAFE_INTEGER] — no
+ * sign, zero, fraction, hex, scientific notation, leading zeros, whitespace,
+ * junk, or out-of-range values. Prefix-legal garbage must not coerce (parseInt("1e4")
+ * is 1 and would bind the nonce to the wrong chain).
+ */
+export function parseSiweChainId(
+  raw: string | undefined,
+): { ok: true; chainId: number } | { ok: false } {
+  if (raw === undefined || raw === "") {
+    return { ok: true, chainId: 1 };
+  }
+  if (!/^\d+$/.test(raw)) {
+    return { ok: false };
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (
+    !Number.isSafeInteger(parsed) ||
+    String(parsed) !== raw ||
+    parsed < SIWE_CHAIN_ID_MIN ||
+    parsed > SIWE_CHAIN_ID_MAX
+  ) {
+    return { ok: false };
+  }
+  return { ok: true, chainId: parsed };
+}
+
 const app = new Hono<AppEnv>();
 
 app.use("*", rateLimit(RateLimitPresets.STRICT));
 
 app.get("/", async (c) => {
-  const chainIdRaw = c.req.query("chainId") ?? "1";
-  const chainId = Number.parseInt(chainIdRaw, 10);
+  const parsedChainId = parseSiweChainId(c.req.query("chainId"));
+  if (!parsedChainId.ok) {
+    return c.json(
+      { error: "Invalid SIWE chainId", code: "invalid_chain_id" },
+      400,
+      { "Cache-Control": "no-store" },
+    );
+  }
+  const resolvedChainId = parsedChainId.chainId;
 
   const redis = buildRedisClient(c.env);
   if (!redis) {
@@ -34,7 +78,6 @@ app.get("/", async (c) => {
   }
 
   const uri = getAppUrl(c.env);
-  const resolvedChainId = Number.isNaN(chainId) ? 1 : chainId;
   let nonce: string;
   try {
     nonce = await issueNonce(redis, { uri, chainId: resolvedChainId });

--- a/packages/cloud/api/auth/siwe/nonce/siwe-nonce-chainid.test.ts
+++ b/packages/cloud/api/auth/siwe/nonce/siwe-nonce-chainid.test.ts
@@ -1,0 +1,118 @@
+/**
+ * SIWE nonce chainId contract at the HTTP boundary.
+ *
+ * The real route must reject prefix-coercible garbage before issueNonce /
+ * Redis setex. This file stubs the rate limiter so failures cannot be blamed
+ * on middleware, and records setex so every 400 is proven write-free.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+const setex = mock(async (_key: string, _ttl: number, _value: string) => "OK");
+
+mock.module("@/lib/cache/redis-factory", () => ({
+  buildRedisClient: () => ({ setex }),
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STRICT: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: { warn: mock(() => undefined) },
+}));
+
+const { default: app } = await import("./route");
+
+function getNonce(query = "") {
+  return app.request(
+    `/${query}`,
+    { method: "GET" },
+    {
+      NEXT_PUBLIC_APP_URL: "https://staging.elizacloud.ai",
+    },
+  );
+}
+
+describe("GET /api/auth/siwe/nonce — chainId contract", () => {
+  test.each([
+    ["1", "Ethereum mainnet", 1],
+    ["137", "Polygon", 137],
+    ["8453", "Base", 8453],
+    ["2147483648", "above signed 32-bit", 2_147_483_648],
+    [
+      "9007199254740991",
+      "JavaScript safe-integer max",
+      Number.MAX_SAFE_INTEGER,
+    ],
+  ] as const)(
+    "canonical chainId %s (%s) succeeds and persists the offered binding",
+    async (value, _label, chainId) => {
+      setex.mockClear();
+      const res = await getNonce(`?chainId=${value}`);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Cache-Control")).toBe("no-store");
+      const body = (await res.json()) as { chainId: number; nonce: string };
+      expect(body.chainId).toBe(chainId);
+      expect(body.nonce).toMatch(/^[0-9a-f]{32}$/);
+      expect(setex).toHaveBeenCalledTimes(1);
+      const stored = setex.mock.calls[0]?.[2];
+      expect(JSON.parse(String(stored))).toMatchObject({ chainId });
+    },
+  );
+
+  test("missing chainId defaults to 1 and persists that binding", async () => {
+    setex.mockClear();
+    const res = await getNonce();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { chainId: number };
+    expect(body.chainId).toBe(1);
+    expect(setex).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(setex.mock.calls[0]?.[2]))).toMatchObject({
+      chainId: 1,
+    });
+  });
+
+  test("empty chainId defaults to 1 and persists that binding", async () => {
+    setex.mockClear();
+    const res = await getNonce("?chainId=");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { chainId: number };
+    expect(body.chainId).toBe(1);
+    expect(setex).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(setex.mock.calls[0]?.[2]))).toMatchObject({
+      chainId: 1,
+    });
+  });
+
+  test.each([
+    ["not-a-number", "junk"],
+    ["1e4", "scientific notation"],
+    ["0x10", "hex"],
+    ["137abc", "trailing junk"],
+    ["-1", "signed"],
+    ["+1", "signed plus"],
+    ["0", "zero"],
+    ["080", "leading zero"],
+    ["1.5", "fractional"],
+    [" 1", "leading whitespace"],
+    ["1 ", "trailing whitespace"],
+    ["1 0", "internal whitespace"],
+    ["9007199254740992", "above JavaScript safe-integer max"],
+    ["9007199254740993", "unsafe integer that rounds"],
+  ] as const)(
+    "returns 400 invalid_chain_id and writes no nonce for %s (%s)",
+    async (value) => {
+      setex.mockClear();
+      const res = await getNonce(`?chainId=${encodeURIComponent(value)}`);
+      expect(res.status).toBe(400);
+      expect(res.headers.get("Cache-Control")).toBe("no-store");
+      await expect(res.json()).resolves.toEqual({
+        error: "Invalid SIWE chainId",
+        code: "invalid_chain_id",
+      });
+      expect(setex).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/auth/siwe/nonce/siwe-nonce-redis-outage.test.ts
+++ b/packages/cloud/api/auth/siwe/nonce/siwe-nonce-redis-outage.test.ts
@@ -191,10 +191,73 @@ describe("GET /api/auth/siwe/nonce — Redis failure boundary", () => {
     });
   });
 
-  test("malformed chainId falls back to mainnet (1) instead of erroring", async () => {
-    const res = await getNonce("?chainId=not-a-number");
+  test("canonical Base chainId 8453 binds the issued nonce to 8453", async () => {
+    const res = await getNonce("?chainId=8453");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { chainId: number };
+    expect(body.chainId).toBe(8453);
+    expect(stored.size).toBe(1);
+    const [storedValue] = stored.values();
+    expect(JSON.parse(storedValue)).toMatchObject({
+      uri: "https://staging.elizacloud.ai",
+      chainId: 8453,
+    });
+  });
+
+  test("JavaScript safe-integer max chainId binds that exact integer", async () => {
+    const res = await getNonce("?chainId=9007199254740991");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { chainId: number };
+    expect(body.chainId).toBe(Number.MAX_SAFE_INTEGER);
+    expect(stored.size).toBe(1);
+    const [storedValue] = stored.values();
+    expect(JSON.parse(storedValue)).toMatchObject({
+      chainId: Number.MAX_SAFE_INTEGER,
+    });
+  });
+
+  test("missing chainId defaults to mainnet and binds chain 1", async () => {
+    const res = await getNonce();
     expect(res.status).toBe(200);
     const body = (await res.json()) as { chainId: number };
     expect(body.chainId).toBe(1);
+    expect(stored.size).toBe(1);
+    const [storedValue] = stored.values();
+    expect(JSON.parse(storedValue)).toMatchObject({ chainId: 1 });
+  });
+
+  test("empty chainId defaults to mainnet and binds chain 1", async () => {
+    const res = await getNonce("?chainId=");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { chainId: number };
+    expect(body.chainId).toBe(1);
+    expect(stored.size).toBe(1);
+    const [storedValue] = stored.values();
+    expect(JSON.parse(storedValue)).toMatchObject({ chainId: 1 });
+  });
+
+  test.each([
+    ["not-a-number", "junk"],
+    ["1e4", "scientific notation"],
+    ["0x10", "hex"],
+    ["137abc", "trailing junk"],
+    ["-1", "signed"],
+    ["+1", "signed plus"],
+    ["0", "zero"],
+    ["080", "leading zero"],
+    ["1.5", "fractional"],
+    [" 1", "leading whitespace"],
+    ["1 ", "trailing whitespace"],
+    ["1 0", "internal whitespace"],
+    ["9007199254740992", "above JavaScript safe-integer max"],
+    ["9007199254740993", "unsafe integer that rounds"],
+  ] as const)("rejects %s (%s) with 400 and writes no nonce", async (value) => {
+    const res = await getNonce(`?chainId=${encodeURIComponent(value)}`);
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "Invalid SIWE chainId",
+      code: "invalid_chain_id",
+    });
+    expect(stored.size).toBe(0);
   });
 });


### PR DESCRIPTION
Closes #20326.

## Summary

- Replace prefix-coercing `Number.parseInt` handling at `GET /api/auth/siwe/nonce` with a canonical positive-decimal parser.
- Preserve the missing/empty mainnet default while accepting the full JavaScript safe-integer domain required by the numeric API.
- Return `400 invalid_chain_id` before Redis construction, nonce generation, or persistence for malformed, signed, zero, fractional, hexadecimal, scientific, leading-zero, whitespace, junk, or unsafe inputs.
- Add HTTP-boundary coverage with both a stubbed rate limiter and the real rate-limit middleware, proving every rejected token writes no nonce and every legal token stores the exact chain binding.

## Why

`Number.parseInt` accepted tokens such as `1e4`, `0x10`, and `137abc`, then issued and Redis-bound the one-time nonce to `1`, `0`, or `137`. The later SIWE signature check correctly enforces the stored binding, but the nonce endpoint had already changed the chain the client requested.

EIP-4361 defines `chain-id = 1*DIGIT` and does not impose a signed-32-bit ceiling. The implementation therefore rejects non-canonical tokens while retaining every positive integer that JavaScript can represent exactly.

## Verification

Exact head: `729a6723ec5c051d07270828678a11abbc15fab8`

- `node packages/cloud/api/test/run-unit-isolated.mjs siwe/nonce` — 3/3 files, 43 tests passed at exact head.
- `bun run verify:cloud` — 80/80 tasks passed on the synchronized patch; final exact-head root verification includes the Cloud lint/typecheck lanes.
- `bun run verify` — 351/351 tasks passed at exact head; anti-larp scanned 8,277 test files with 0 focused and 0 orphaned skips.
- Changed-file Biome and `git diff --check` — clean.
- Red proof with the original `Number.parseInt` route restored — all 28 invalid-input assertions failed as intended by receiving `200` instead of `400`; restoring the fix returned the isolated suite to green.

## Evidence

- Logs: command results above; no credentialed integration or production mutation is required for this pure request-validation boundary.
- Domain artifact: deterministic HTTP responses plus the recorded fake-Redis `setex` map prove accepted bindings and write-free 400s.
- UI / screenshots / video: N/A — backend-only GET route; no visual surface changes.
- Live-model trajectory: N/A — no agent or model behavior changes.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Claude Code via CLIProxyAPI
Attribution status: self-reported
<!-- elizaos-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code via CLIProxyAPI","attribution":"self-reported"} -->

<!-- evidence-head:7efe86c95f89faa9bdc146f948962c9a24bacd1a -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only SIWE request validation; no rendered UI surface changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only SIWE request validation; no rendered UI surface changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or visual user flow changed

<!-- evidence-row:backend-logs -->
- [x] [20339-pr20339-exact.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20339-pr20339-exact.log)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or agent behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [20339-pr20339-focused-exact.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20339-pr20339-focused-exact.log)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or visual text changed
