### PR TITLE
perf(cloud): cache fresh negative denylist results for internal JWT verification

### DIFF
--- a/packages/cloud/shared/src/lib/auth/jwt-internal-denylist.ts
+++ b/packages/cloud/shared/src/lib/auth/jwt-internal-denylist.ts
@@ -142,6 +142,9 @@ export async function revokeInternalToken(jti: string, expSeconds?: number): Pro
   const ttl = computeTtlSeconds(expSeconds);
   // `set key value EX ttl` — value is a marker; presence is what matters.
   await redis.set(denylistKey(jti), "1", { ex: ttl });
+  // Same-isolate revocation takes effect immediately regardless of any warm
+  // negative-cache entry for this jti.
+  negativeCache.delete(jti);
   logger.info("[internal-jwt] revoked jti", { jti, ttl });
 }
 
@@ -155,12 +158,47 @@ export async function revokeInternalToken(jti: string, expSeconds?: number): Pro
  *   fail closed (reject the token) rather than treat an errored check as "not
  *   revoked".
  */
+/**
+ * Short-TTL isolate-local negative cache: `jti → last time the store said
+ * "not revoked"`. Every JWT-authenticated Worker request otherwise pays one
+ * external REST roundtrip here, and that read dominated the real ingress
+ * stage on the shared-agent path (~1.1s real vs ~77ms on the shared-secret
+ * probes that skip it — HQ #18309 latency split). Only NEGATIVE results for
+ * signature-valid tokens are cached: a revoked hit purges the entry and is
+ * never cached, store errors propagate uncached (fail-closed unchanged), and
+ * a same-isolate revoke purges immediately. The security trade is bounded and
+ * explicit: a token revoked from ANOTHER pod/isolate may be accepted by an
+ * isolate holding a warm negative for up to the TTL below.
+ */
+const NEGATIVE_CACHE_TTL_MS = 30_000;
+const NEGATIVE_CACHE_MAX_ENTRIES = 5_000;
+const negativeCache = new Map<string, number>();
+
+function readFreshNegative(jti: string): boolean {
+  const checkedAt = negativeCache.get(jti);
+  if (checkedAt === undefined) return false;
+  if (Date.now() - checkedAt >= NEGATIVE_CACHE_TTL_MS) {
+    negativeCache.delete(jti);
+    return false;
+  }
+  return true;
+}
+
+function rememberNegative(jti: string): void {
+  if (negativeCache.size >= NEGATIVE_CACHE_MAX_ENTRIES) {
+    const oldest = negativeCache.keys().next().value;
+    if (oldest !== undefined) negativeCache.delete(oldest);
+  }
+  negativeCache.set(jti, Date.now());
+}
+
 export async function isJtiRevoked(jti: string): Promise<boolean> {
   if (!jti) {
     // A missing jti can never have been individually revoked; the verifier
     // already rejects tokens without a jti claim upstream.
     return false;
   }
+  if (readFreshNegative(jti)) return false;
   const redis = getRedis();
   if (!redis) {
     // No backend configured: per-jti revocation genuinely unsupported.
@@ -168,9 +206,19 @@ export async function isJtiRevoked(jti: string): Promise<boolean> {
     return false;
   }
   // Intentionally NOT wrapped in try/catch → allow: a store error must
-  // propagate so the verifier fails closed.
+  // propagate so the verifier fails closed (and is never cached).
   const hit = await redis.get(denylistKey(jti));
-  return hit !== null && hit !== undefined;
+  if (hit !== null && hit !== undefined) {
+    negativeCache.delete(jti);
+    return true;
+  }
+  rememberNegative(jti);
+  return false;
+}
+
+/** Test-only: clear the negative revocation cache between cases. */
+export function __resetDenylistNegativeCacheForTests(): void {
+  negativeCache.clear();
 }
 
 /** Test-only: drop the cached client so a fresh env is picked up. */

--- a/packages/cloud/shared/src/lib/auth/jwt-internal.test.ts
+++ b/packages/cloud/shared/src/lib/auth/jwt-internal.test.ts
@@ -256,3 +256,70 @@ describe("internal JWT jti revocation denylist (#12879)", () => {
     });
   });
 });
+
+describe("denylist negative cache (warm-ingress latency, HQ #18309)", () => {
+  beforeEach(() => {
+    process.env.JWT_SIGNING_PRIVATE_KEY = KEYS.priv;
+    process.env.JWT_SIGNING_PUBLIC_KEY = KEYS.pub;
+    process.env.JWT_SIGNING_KEY_ID = "test";
+    process.env.MOCK_REDIS = "1";
+    denylistStore.clear();
+    denylistGetError = null;
+    workerRuntime = false;
+    denylistMod.__resetDenylistClientForTests();
+    denylistMod.__resetDenylistNegativeCacheForTests();
+    setSystemTime();
+  });
+
+  afterEach(() => {
+    delete process.env.JWT_SIGNING_PRIVATE_KEY;
+    delete process.env.JWT_SIGNING_PUBLIC_KEY;
+    delete process.env.JWT_SIGNING_KEY_ID;
+    delete process.env.MOCK_REDIS;
+    denylistGetError = null;
+    denylistMod.__resetDenylistNegativeCacheForTests();
+    setSystemTime();
+  });
+
+  test("a warm negative skips the store read entirely (verify succeeds with the store down)", async () => {
+    const { access_token } = await mod.signInternalToken({ subject: "pod-warm" });
+    expect((await mod.verifyInternalToken(access_token)).valid).toBe(true);
+
+    // Break the store: an uncached second verify would fail closed here.
+    denylistGetError = new Error("denylist store unreachable");
+    const warm = await mod.verifyInternalToken(access_token);
+    expect(warm.valid).toBe(true);
+  });
+
+  test("the negative expires after its TTL and fail-closed resumes on the next read", async () => {
+    const { access_token } = await mod.signInternalToken({ subject: "pod-ttl" });
+    expect((await mod.verifyInternalToken(access_token)).valid).toBe(true);
+
+    denylistGetError = new Error("denylist store unreachable");
+    setSystemTime(new Date(Date.now() + 31_000));
+    await expect(mod.verifyInternalToken(access_token)).rejects.toThrow(
+      "denylist store unreachable",
+    );
+  });
+
+  test("a same-isolate revoke purges the warm negative immediately", async () => {
+    const { access_token } = await mod.signInternalToken({ subject: "pod-revoke" });
+    const first = await mod.verifyInternalToken(access_token);
+    expect(first.valid).toBe(true);
+
+    await denylistMod.revokeInternalToken(first.payload.jti);
+    await expect(mod.verifyInternalToken(access_token)).rejects.toThrow("Token has been revoked");
+  });
+
+  test("a revoked hit found by the store is never cached as negative", async () => {
+    const { access_token } = await mod.signInternalToken({ subject: "pod-hit" });
+    const first = await mod.verifyInternalToken(access_token);
+    await denylistMod.revokeInternalToken(first.payload.jti);
+    denylistMod.__resetDenylistNegativeCacheForTests();
+
+    await expect(mod.verifyInternalToken(access_token)).rejects.toThrow("Token has been revoked");
+    // Still revoked on the immediate next check — the revoked result did not
+    // plant a fresh negative.
+    await expect(mod.verifyInternalToken(access_token)).rejects.toThrow("Token has been revoked");
+  });
+});


### PR DESCRIPTION
## SECURITY SURFACE — requesting gauss/lalalune review; not self-merging (auth/revocation seam)

## Context — the warm-latency hunt, stage 2 (companion to merged #20338)

The lane's split shows real warm ingress ≈1124ms vs 77ms on synthetic probes. Root cause found: synthetic probes authenticate via the `INTERNAL_SECRET` fast path (zero subrequests), while real gateway JWTs go through `verifyInternalToken` → `isJtiRevoked` → **an uncached external Redis REST roundtrip on every request**.

## Change

30-second isolate-local **negative** cache in `jwt-internal-denylist.ts`:
- Only negative results for **signature-valid** tokens are cached.
- A revoked hit **purges** the entry and is never cached.
- Store errors **propagate uncached** — fail-closed behavior byte-identical.
- A same-isolate `revokeInternalToken` purges immediately.
- Bounded size (5k entries, insertion-order eviction).

**The explicit trade**: a token revoked from another pod/isolate may be accepted by an isolate holding a warm negative for ≤30s. Against 1-hour-lifetime internal service tokens whose blast-radius control is key rotation (which this cache cannot extend — signature verify runs first), a 30s revocation propagation window is the standard denylist-cache posture. If reviewers want it tighter, the TTL is one constant.

## Evidence

| Check | Result |
|---|---|
| `jwt-internal.test.ts` 15/15 — incl. store-DOWN proofs: warm negative verifies with the store unreachable; TTL expiry resumes fail-closed; both revoke paths reject immediately; revoked hits never plant a negative | ✅ |
| cloud/shared typecheck | ✅ |
| Biome | ✅ |

## Predicted effect (with #20338)

Real warm turn: ingress collapses toward the 77ms synthetic floor, account already addressed by #20338's connect reuse — Worker-side warm total approaches the measured 0.611s synthetic best, putting nubs's sub-second warm target within the gateway hop's reach. @codex-root/shared-latency: same measurement ask — post-deploy real-warm stage split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)