### PR TITLE
fix(ui): follow explicit runtime for realtime socket

### DIFF
--- a/packages/ui/src/api/client-base-websocket.test.ts
+++ b/packages/ui/src/api/client-base-websocket.test.ts
@@ -108,6 +108,8 @@ function stubWindowOrigin(protocol: string, host: string): void {
 
 describe("ElizaClient websocket connection policy", () => {
   afterEach(() => {
+    Reflect.deleteProperty(window, "__ELIZA_WS_BASE__");
+    Reflect.deleteProperty(window, "__ELIZAOS_WS_BASE__");
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     __resetNetworkStatusForTests();
@@ -156,6 +158,50 @@ describe("ElizaClient websocket connection policy", () => {
     expect(createdUrls).toHaveLength(1);
     expect(createdUrls[0]).toContain("wss://agent.example.test/ws?");
     expect(createdUrls[0]).toContain("token=agent-token");
+  });
+
+  it("follows an explicit remote runtime instead of a stale same-origin Vite websocket base", () => {
+    const createdUrls = stubWebSocket();
+    stubWindowOrigin("http:", "127.0.0.1:2653");
+    Object.assign(window, {
+      __ELIZA_WS_BASE__: "ws://127.0.0.1:2653",
+      __ELIZAOS_WS_BASE__: "ws://127.0.0.1:2653",
+    });
+
+    const client = new ElizaClient("http://127.0.0.1:31337", "agent-token");
+    client.connectWs();
+
+    expect(createdUrls).toHaveLength(1);
+    expect(createdUrls[0]).toContain("ws://127.0.0.1:31337/ws?");
+    expect(createdUrls[0]).not.toContain("127.0.0.1:2653");
+  });
+
+  it("preserves a genuine separate-host websocket override for an explicit runtime", () => {
+    const createdUrls = stubWebSocket();
+    stubWindowOrigin("https:", "app.example.test");
+    Object.assign(window, {
+      __ELIZA_WS_BASE__: "wss://realtime.example.test",
+    });
+
+    const client = new ElizaClient("https://agent.example.test", "agent-token");
+    client.connectWs();
+
+    expect(createdUrls).toHaveLength(1);
+    expect(createdUrls[0]).toContain("wss://realtime.example.test/ws?");
+  });
+
+  it("retains the same-origin Vite websocket proxy when no runtime base is selected", () => {
+    const createdUrls = stubWebSocket();
+    stubWindowOrigin("http:", "127.0.0.1:2653");
+    Object.assign(window, {
+      __ELIZA_WS_BASE__: "ws://127.0.0.1:2653",
+    });
+
+    const client = new ElizaClient("", "agent-token");
+    client.connectWs();
+
+    expect(createdUrls).toHaveLength(1);
+    expect(createdUrls[0]).toContain("ws://127.0.0.1:2653/ws?");
   });
 
   it("opens a same-origin websocket from a portless HTTPS host in a plain browser", () => {

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -553,7 +553,7 @@ function isDedicatedCloudAgentBase(value: string | null | undefined): boolean {
   }
 }
 
-function getInjectedWsBase(): string | undefined {
+function getInjectedWsBase(explicitBaseUrl: string): string | undefined {
   if (typeof window === "undefined") return undefined;
   const values = [
     (window as { __ELIZA_WS_BASE__?: unknown }).__ELIZA_WS_BASE__,
@@ -562,7 +562,30 @@ function getInjectedWsBase(): string | undefined {
   for (const value of values) {
     if (typeof value !== "string") continue;
     const trimmed = value.trim();
-    if (trimmed) return trimmed;
+    if (!trimmed) continue;
+    if (explicitBaseUrl) {
+      try {
+        const injected = new URL(trimmed);
+        const selected = new URL(explicitBaseUrl);
+        // The Vite dev server injects its own page origin so a no-base client
+        // can reach `/ws` through the dev proxy. Once the user explicitly
+        // selects a different runtime, that same-origin value is stale: HTTP
+        // already follows the selected server while realtime would remain on
+        // the old proxy. A genuinely separate injected WS host is still an
+        // intentional transport override and keeps precedence.
+        if (
+          injected.host === window.location.host &&
+          selected.host !== window.location.host
+        ) {
+          continue;
+        }
+      } catch {
+        // Preserve the existing boundary behavior: connectWs owns URL parsing
+        // and surfaces a malformed configured override rather than silently
+        // replacing it with a plausible endpoint.
+      }
+    }
+    return trimmed;
   }
   return undefined;
 }
@@ -1849,7 +1872,7 @@ export class ElizaClient {
 
     let host: string;
     let wsProtocol: "ws:" | "wss:";
-    const wsBase = getInjectedWsBase();
+    const wsBase = getInjectedWsBase(this.baseUrl);
     if (wsBase) {
       const parsed = new URL(wsBase);
       host = parsed.host;


### PR DESCRIPTION
# Relates to

Fixes #20342.

- [x] Targets `develop` and is rebased onto `origin/develop@a6d9773f4fa2da341e09e8175fb084169d5092a1` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` passed after sync.
- [x] A reviewer can confirm the transport behavior from focused tests and the live Mac-runtime/Cerebras proof below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@a6d9773f4fa2da341e09e8175fb084169d5092a1:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop@a6d9773f4fa2da341e09e8175fb084169d5092a1`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. This is limited to WebSocket base selection. An explicit runtime base now outranks only a same-origin injected development WS base. A genuine separate-host injected realtime endpoint remains authoritative, and the no-base Vite proxy path is unchanged.

# Background

## What does this PR do?

When a renderer connects to an explicitly selected runtime such as a Mac on the LAN, HTTP already follows that explicit base. Realtime could remain pinned to the renderer's injected same-origin Vite WebSocket endpoint, causing chat sends to fail despite healthy HTTP status.

This makes the explicit runtime authoritative when the injected WS host is merely the renderer's own host. It preserves separately hosted realtime endpoints and ordinary Vite proxying.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No documentation change is required.

# Testing

## Where should a reviewer start?

- `packages/ui/src/api/client-base.ts`
- `packages/ui/src/api/client-base-websocket.test.ts`

## Detailed testing steps

1. Run `bun run --cwd packages/ui test -- src/api/client-base-websocket.test.ts` (29/29 pass).
2. Run `bun run --cwd packages/ui typecheck`.
3. Run exact Biome on the two changed files and `git diff --check HEAD^..HEAD`.
4. With UI on `127.0.0.1:2653` and a healthy explicit Mac runtime on `127.0.0.1:31337`, send `Reply with exactly: MAC WS FINAL READY 8391`.
5. Observe exact response `MAC WS FINAL READY 8391`, with runtime mode `local` and active chat provider `cerebras`.

# Evidence Gate

<!-- evidence-head:1f9551fd98c2a84076e7ab926746ebdedbf41ed9 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - transport-only TypeScript change with no rendered visual delta.
<!-- evidence-row:after-screenshots -->
- [ ] Exact-head live-chat screenshot captured locally; inline upload pending before ready-for-review.
<!-- evidence-row:walkthrough-video -->
- [ ] Exact-head transport walkthrough pending before ready-for-review.
<!-- evidence-row:backend-logs -->
- [x] Live runtime health/model state and exact Cerebras round-trip are recorded below.
<!-- evidence-row:frontend-logs -->
- [x] Fresh renderer console had zero warnings/errors after the exact reply.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action, or agent behavior changed; real Cerebras round-trip included as transport proof.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - transport selection creates no domain artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real runtime + Cerebras proof

Exact head: `1f9551fd98c2a84076e7ab926746ebdedbf41ed9`

- `GET /api/health`: `ready=true`, `canRespond=true`, 25 plugins loaded, 0 failed.
- `GET /api/runtime/mode`: `local`.
- `GET /api/models/config`: active chat provider `cerebras`.
- Prompt: `Reply with exactly: MAC WS FINAL READY 8391`
- Response: `MAC WS FINAL READY 8391`
- Fresh renderer warning/error log after proof: `[]`.

## Automated gates

- Focused UI WebSocket tests: 29/29 pass.
- UI typecheck: pass.
- Exact two-file Biome: pass.
- `git diff --check HEAD^..HEAD`: pass.
- Root `bun run verify`: pass.
- Worktree status: clean.

## Screenshots

### Before

N/A - no rendered visual delta.

### After

Pending inline upload from exact-head capture before ready-for-review.

### Walkthrough video

Pending before ready-for-review.

## Known gaps / failures

This remains a draft until exact-head screenshot/video evidence is uploaded and an independent exact-head review is requested. No code/test/typecheck/lint/verify failure remains.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@a6d9773f4fa2da341e09e8175fb084169d5092a1:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported

— [codex / mac-local-runtime-status]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@a6d9773f4fa2da341e09e8175fb084169d5092a1:packages/skills/skills/contribute-to-eliza"} -->