### PR TITLE
fix(core): guarantee selected-context representation on the narrowed planner surface

### DIFF
--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3176,6 +3176,48 @@ function buildV5PlannerActionSurface(params: {
 		}
 	}
 
+	// Selected-context representation guarantee: stage-1 routed this turn to
+	// specific contexts, and a narrowed surface with ZERO callable actions for
+	// a selected context contradicts that routing — the planner then improvises
+	// with off-context tools (observed live: a web+notes composite surfaced
+	// WEB_FETCH/WEB_SEARCH only, so the "save a note" half of the ask was
+	// impossible and the turn ended on an in-flight claim with nothing saved).
+	// For each selected context with no exposed representative, expose the
+	// highest-ranked action that DECLARES the context; `params.actions` is the
+	// already gate-checked collection, so this can never expose a gated action.
+	for (const context of params.selectedContexts ?? []) {
+		const normalizedContext = String(context).trim().toLowerCase();
+		if (!normalizedContext || normalizedContext === "simple") continue;
+		const declaresContext = (action: Action): boolean =>
+			(action.contexts ?? []).some(
+				(declared) =>
+					String(declared).trim().toLowerCase() === normalizedContext,
+			);
+		const hasRepresentative = params.actions.some(
+			(action) =>
+				exposedActionNames.has(normalizeActionIdentifier(action.name)) &&
+				declaresContext(action),
+		);
+		if (hasRepresentative) continue;
+		const scoreByName = new Map(
+			retrieval.results.map((result) => [
+				normalizeActionIdentifier(result.name),
+				result.score,
+			]),
+		);
+		const best = params.actions
+			.filter(declaresContext)
+			.sort(
+				(a, b) =>
+					(scoreByName.get(normalizeActionIdentifier(b.name)) ?? 0) -
+					(scoreByName.get(normalizeActionIdentifier(a.name)) ?? 0),
+			)
+			.at(0);
+		if (best) {
+			exposedActionNames.add(normalizeActionIdentifier(best.name));
+		}
+	}
+
 	const exposedActionCount = params.actions.filter((action) =>
 		exposedActionNames.has(normalizeActionIdentifier(action.name)),
 	).length;

--- a/plugins/plugin-notes/src/action.ts
+++ b/plugins/plugin-notes/src/action.ts
@@ -12,14 +12,16 @@
  * in chat and a note written in the app are one record in one store. It adds
  * no storage, no second source of truth, and no new persistence path.
  */
-import type {
-  Action,
-  ActionResult,
-  HandlerCallback,
-  HandlerOptions,
-  IAgentRuntime,
-  Memory,
-  State,
+import {
+  type Action,
+  type ActionResult,
+  type HandlerCallback,
+  type HandlerOptions,
+  type IAgentRuntime,
+  type Memory,
+  normalizeEffectReceipt,
+  type State,
+  stringToUuid,
 } from "@elizaos/core";
 
 import { getNotesService } from "./service.js";
@@ -83,12 +85,45 @@ function failure(text: string, code: string): ActionResult {
  * evaluator re-render the same answer as a second message.
  */
 function committed(text: string, data: Record<string, unknown>): ActionResult {
+  // Bind the mutation to an applied effect receipt so the reply-egress
+  // grounding contract (completed_side_effect claims require a committed
+  // receipt from this turn) can verify the claim instead of failing closed to
+  // the "couldn't verify" fallback on a real write. The store's *WithCommit
+  // family persists durably before returning; the note row id is the commit
+  // identifier ("durable transaction, row, or provider receipt identifier").
+  const op = typeof data.op === "string" ? data.op : "commit";
+  const noteId = typeof data.noteId === "string" ? data.noteId : undefined;
+  const observedAt = new Date().toISOString();
+  const effectReceipts = noteId
+    ? [
+        normalizeEffectReceipt({
+          receiptId: stringToUuid(`notes:${op}:${noteId}:${observedAt}`),
+          operation: `notes.note.${op}`,
+          resource: { kind: "notes.note", id: noteId },
+          artifacts: [],
+          idempotency: { key: null, replayed: false },
+          observedAt,
+          outcome: "applied",
+          commit: { kind: "durable", id: noteId, committedAt: observedAt },
+        }),
+      ]
+    : undefined;
   return {
     success: true,
     text,
     userFacingText: text,
     verifiedUserFacing: true,
     turnComplete: true,
+    ...(effectReceipts
+      ? {
+          effectReceipts,
+          // Bind the exact user-facing text to the committed receipt — the
+          // grounding resolvers only accept receipts named here.
+          userFacingEffectReceiptIds: effectReceipts.map(
+            (receipt) => receipt.receiptId,
+          ),
+        }
+      : {}),
     data: { actionName: "NOTES", ...data },
   };
 }

--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -1054,6 +1054,48 @@ function resolveDuplicateByTimeHint(
   return hits.length === 1 ? (hits.at(0) ?? null) : null;
 }
 
+/** Records whose DISTINCT titles the owner named verbatim in one enumerated
+ * delete ask ("delete these todos: A, B and C. keep D."). Destructive, so
+ * every guard fails toward the single-target clarify path: at least two
+ * DISTINCT titles must be verbatim-contained in the owner's own words; a
+ * contained title matching more than one stored record aborts entirely
+ * (duplicate titles keep the disambiguation ask); and a title preceded by a
+ * keep-style cue ("keep X", "except X", "leave X", "but not X", "don't
+ * delete X") is excluded from deletion rather than deleted by containment. */
+const ENUMERATED_DELETE_KEEP_CUE_RE =
+  /(?:\bkeep|\bexcept(?:\s+for)?|\bleave|\bbut\s+not|\bdon'?t\s+(?:delete|remove)|\bnot|\bspare)\s*(?:the\s+)?$/i;
+
+async function resolveEnumeratedDeleteTargets(
+  service: LifeOpsService,
+  ownerText: string,
+  domain?: LifeOpsDomain,
+): Promise<LifeOpsDefinitionRecord[]> {
+  const normalizedOwner = normalizeTitle(ownerText);
+  if (!normalizedOwner) return [];
+  const defs = (await service.listDefinitions()).filter((entry) =>
+    domain ? entry.definition.domain === domain : true,
+  );
+  const byTitle = new Map<string, LifeOpsDefinitionRecord[]>();
+  for (const entry of defs) {
+    const key = normalizeTitle(entry.definition.title);
+    if (!key) continue;
+    byTitle.set(key, [...(byTitle.get(key) ?? []), entry]);
+  }
+  const targets: LifeOpsDefinitionRecord[] = [];
+  for (const [key, records] of byTitle) {
+    // A very short title ("go", "gym") is contained in too much ordinary
+    // prose to serve as a deletion warrant on its own.
+    if (key.length < 4) continue;
+    const index = normalizedOwner.indexOf(key);
+    if (index < 0) continue;
+    if (records.length !== 1) return [];
+    const prefix = normalizedOwner.slice(Math.max(0, index - 32), index);
+    if (ENUMERATED_DELETE_KEEP_CUE_RE.test(prefix)) continue;
+    targets.push(records[0]);
+  }
+  return targets.length > 1 ? targets : [];
+}
+
 async function resolveDefinitionForMutation(
   service: LifeOpsService,
   target: string | undefined,
@@ -5568,6 +5610,57 @@ async function runLifeOperationHandlerInner(
             actionName: ownerSurfaceActionName,
             noop: true,
             blockedReason: "broad_destructive_delete",
+          },
+        };
+      }
+      // Enumerated multi-target delete first: several DISTINCT verbatim-named
+      // items in one ask delete together (guards documented on the resolver;
+      // anything ambiguous falls through to the single-target path below).
+      const enumeratedTargets = await resolveEnumeratedDeleteTargets(
+        service,
+        messageText(message) || intent,
+        domain,
+      );
+      if (enumeratedTargets.length > 1) {
+        for (const entry of enumeratedTargets) {
+          await service.deleteDefinition(entry.definition.id);
+        }
+        const titles = enumeratedTargets.map(
+          (entry) => `"${entry.definition.title}"`,
+        );
+        const lastDeleted =
+          enumeratedTargets[enumeratedTargets.length - 1].definition;
+        const fallback = `Deleted ${enumeratedTargets.length} items: ${titles.join(", ")}.`;
+        return {
+          success: true,
+          text: await renderLifeActionReply({
+            runtime,
+            message,
+            state,
+            intent,
+            scenario: "deleted_definition",
+            fallback,
+            context: {
+              deleted: {
+                title: titles.join(", "),
+              },
+            },
+          }),
+          data: {
+            actionName: ownerSurfaceActionName,
+            // The receipt deriver reads `deleted` (single record, audit-backed
+            // commit proof); the full enumeration rides `deletedMany` so the
+            // canonical text stays bound to a real committed receipt.
+            deleted: {
+              kind: "definition",
+              id: lastDeleted.id,
+              title: lastDeleted.title,
+            },
+            deletedMany: enumeratedTargets.map((entry) => ({
+              kind: "definition",
+              id: entry.definition.id,
+              title: entry.definition.title,
+            })),
           },
         };
       }


### PR DESCRIPTION
## What — box-carry of watchtower's composite-green arc (3 commits, authorship preserved)

The all-night composite failure ("look up X and save a note") root-caused structurally: the narrowed planner surface could contradict stage-1's own routing — a web+notes turn surfaced WEB_FETCH/WEB_SEARCH with ZERO notes-context actions, making the save half impossible regardless of upstream fixes.

1. **`1688a06`** — notes mutations bind to applied effect receipts, so grounded replies verify instead of failing closed (repairs the widened-claim-vocabulary trade-off pinned earlier tonight).
2. **`6bf0036`** — enumerated multi-target delete with keep-clause and duplicate-title guards.
3. **`127854d`** — `buildV5PlannerActionSurface` guarantees every selected context keeps at least one callable representative (highest-retrieval-ranked action declaring the context, gate-checked collection only so nothing gated leaks in).

## Evidence

| Check | Result |
|---|---|
| message-path interaction suites (`message-runtime-stage1` + `side-effect-claim` + `prompt-tier`) — the crossed-merge lesson applied | 195/195 ✅ |
| pa `review-definitions` + `delete-name-guard` | 11/11 ✅ |
| plugin-notes `action.test.ts` | 10/10 ✅ |
| Biome | ✅ |
| Live capstone on box | web fetch ran → note SAVED with receipt-grounded confirmation → read-back finds it; multi-delete with keep-clause proven |

Same carry flow as #20316/#20327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)