### PR TITLE
fix(ui): preserve payment CTA accent on hover

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.tsx
@@ -424,11 +424,11 @@ export default function PaymentRequestPage() {
 
           <div className="mt-8">
             <Button
-              variant="ghost"
+              variant="surfaceAccent"
               type="button"
               disabled={!canPay || isPaying}
               onClick={beginCheckout}
-              className="flex w-full items-center justify-center gap-3 bg-accent-subtle px-4 py-4 text-txt transition hover:bg-bg-hover disabled:pointer-events-none disabled:opacity-30"
+              className="flex w-full items-center justify-center gap-3 px-4 py-4 transition disabled:pointer-events-none disabled:opacity-30"
             >
               {isPaying ? (
                 <Loader2 className="h-5 w-5 animate-spin" />


### PR DESCRIPTION
# Relates to

Closes #20337.

- [x] Targets `develop` and is rebased onto exact `origin/develop@1deaf496e1ea9d645dfcfdeaad489dd834d258e4` with zero conflicts.
- [x] Required frozen install and exact-head `bun run verify` passed.
- [x] The visual behavior is reviewable from desktop/mobile rest and hover captures, video, detector output, and logs below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop@1deaf496e1ea9d645dfcfdeaad489dd834d258e4`; zero conflicts.
- [x] Published exact head: `5787e67415ba9ef6225879503bf729a86fc231ca`.
- [x] Exact-head root verify passed: 351/351 tasks, every repository audit, anti-larp 8,289 files with zero focused tests or orphaned skips.

# Risks

Low. The semantic change replaces a page-local `ghost`/gray-hover combination with the existing shared `surfaceAccent` button variant. Payment eligibility, expiry, checkout dispatch, layout, and disabled behavior are unchanged.

# Background

## What does this PR do?

Keeps the public payment-request CTA in the orange accent family when hovered. The old combination declared an orange resting background locally but inherited `ghost`'s gray/white hover background. The shared variant supplies the intended darker-orange hover state without another local override.

## What kind of change is this?

Bug fix (non-breaking UI state correction).

# Documentation changes needed?

No. This restores the documented shared visual contract and introduces no public API or workflow change.

# Testing

## Where should a reviewer start?

Open `/payment/payreq-smoke-1` in the audit harness and hover **Pay with Stripe** at desktop and mobile widths. The CTA stays orange and becomes slightly darker; no payment behavior changes.

## Detailed testing steps

- Frozen `bun install`: pass on Bun 1.3.14; artifact bundle current.
- Payment request behavioral suite: 12/12 pass.
- UI typecheck: pass.
- Exact production renderer build: pass; chunk-safety and viewport audits pass.
- Exact browser audit on the affected surface: desktop + mobile 2/2; broken=0 and needs-work=0. Four current-head captures were manually inspected.
- Prior semantic-head full app audit: 219/219 with broken=0 and needs-work=0. The rebase changed only the base; the one-file feature diff is unchanged.
- Exact-head root `bun run verify`: 351/351, all audits pass, anti-larp 8,289.

# Evidence Gate

<!-- evidence-head:5787e67415ba9ef6225879503bf729a86fc231ca -->

<!-- evidence-row:before-screenshots -->
- [x] Before hover captures: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20337-before-desktop-hover.png), [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20337-before-mobile-hover.png). The detector recorded the old orange-to-gray/white hover declaration as `needs-work`.
<!-- evidence-row:after-screenshots -->
- [x] Current exact-head captures: [desktop rest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20337-2e98cf2-desktop-rest.png), [desktop hover](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20337-2e98cf2-desktop-hover.png), [mobile rest](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20337-2e98cf2-mobile-rest.png), [mobile hover](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20337-2e98cf2-mobile-hover.png).
<!-- evidence-row:walkthrough-video -->
- [x] [Desktop/mobile browser walkthrough (MP4)](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20337-desktop-mobile-walkthrough.mp4). The semantic feature commit is unchanged by the final base-only rebase; current-head screenshots above independently cover every affected rest/hover viewport.
<!-- evidence-row:backend-logs -->
- [ ] N/A - CSS variant selection only; payment API and checkout dispatch are unchanged and protected by the 12/12 behavioral suite.
<!-- evidence-row:frontend-logs -->
- [x] [Browser and repository validation log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20337-validation.txt), supplemented by the current exact-head validation counts above.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, provider, model, action, or planner behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistence, payment record, wallet, or other domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] [OCR review report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20337-ocr-review.txt) records 216 views / 200 verified / broken=0; current-head affected-surface captures were manually reviewed after the final rebase.

# Known gaps / failures

None in the delivered scope. The walkthrough and full-app audit were recorded on the unchanged semantic feature commit before the final base-only rebase; current exact-head production build, focused browser captures, behavior tests, typecheck, and root verify were all rerun after that rebase.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-20337-payment-hover]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->

