### PR TITLE
perf(cloud): activate Shared sender projection in staging

### DIFF
--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -968,6 +968,46 @@ describe("cloud-api worker entrypoint", () => {
     );
   });
 
+  test("activates sender projection and inference timing only in staging", async () => {
+    const config = Bun.TOML.parse(
+      await Bun.file(new URL("../wrangler.toml", import.meta.url)).text(),
+    ) as {
+      vars?: {
+        PERSONAL_DELIVERY_PROJECTION_READ_ENABLED?: string;
+        ELIZA_INFERENCE_TIMING?: string;
+      };
+      env?: {
+        staging?: {
+          vars?: {
+            PERSONAL_DELIVERY_PROJECTION_READ_ENABLED?: string;
+            ELIZA_INFERENCE_TIMING?: string;
+          };
+        };
+        production?: {
+          vars?: {
+            PERSONAL_DELIVERY_PROJECTION_READ_ENABLED?: string;
+            ELIZA_INFERENCE_TIMING?: string;
+          };
+        };
+      };
+    };
+
+    expect(config.vars?.PERSONAL_DELIVERY_PROJECTION_READ_ENABLED).toBe(
+      "false",
+    );
+    expect(
+      config.env?.staging?.vars?.PERSONAL_DELIVERY_PROJECTION_READ_ENABLED,
+    ).toBe("true");
+    expect(
+      config.env?.production?.vars?.PERSONAL_DELIVERY_PROJECTION_READ_ENABLED,
+    ).toBe("false");
+    expect(config.vars?.ELIZA_INFERENCE_TIMING).toBeUndefined();
+    expect(config.env?.staging?.vars?.ELIZA_INFERENCE_TIMING).toBe("info");
+    expect(
+      config.env?.production?.vars?.ELIZA_INFERENCE_TIMING,
+    ).toBeUndefined();
+  });
+
   test("binds the global native limiter in every Worker environment and keeps inference routes gate-free", async () => {
     type RateLimitBinding = {
       name?: string;

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -448,9 +448,12 @@ __filename = '"/worker.js"'
 # Protected staging proves the genuine Workerd AgentRuntime before production promotion.
 NODE_ENV = "production"
 SHARED_ELIZA_AGENT_RUNTIME = "true"
-# Two-phase rollout: deploy invalidation writers as the rollback baseline
-# before a later reviewed release enables projection reads.
-PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "false"
+# Staging exercises the strongly invalidated sender projection while default
+# and production stay on canonical resolution until the live latency matrix passes.
+PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "true"
+# Emit per-turn inference spans at info for the staging latency matrix without
+# changing production log volume or recording prompt content.
+ELIZA_INFERENCE_TIMING = "info"
 # Apps (Product 2): wire the real deploy trigger so POST /api/v1/apps/:id/deploy
 # enqueues an APP_DEPLOY job the provisioning-worker daemon runs (instead of the
 # legacy status-only stub). Staging only — the apps data plane (tenant DB +


### PR DESCRIPTION
Part of #20313

## What
- enables strongly invalidated Personal Shared sender-projection reads in staging only
- emits staging inference timing spans at info for the live latency matrix
- keeps default and production projection reads disabled

## Rollback baseline
- protected staging run: `31925611759`
- exact commit: `edc6fcdf67af89e28b23c3d887b5f026c364275a`
- Worker deployment: `fe1967dc-fda0-4061-bacd-3c74af97f85a`
- Worker version: `00c6c9a6-f60e-4f9f-bf7c-4b3379497300` (8525)
- baseline binding present; read gate verified `false`

## Exact gates
- Worker config contract: 40/40, 200 assertions
- sender projection/route: 37/37, 130 assertions
- real PGlite identity-link: 13/13, 53 assertions
- cloud API typecheck: PASS
- production Wrangler dry bundle: PASS; production read gate remains `false`
- Biome + diff-check: PASS

## Live proof after merge
Protected staging deploy followed by >=30 ordinary Telegram messages (cold and warm), account-stage p50/p95, per-attempt gateway timing, Shared/model spans, retries/5xx, memory follow-up, and one separate reminder receipt.