### PR TITLE
docs: fix stale voice-bench paths, a nonexistent plugin-relationships script, and a 404 link

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -5,7 +5,7 @@ Standalone elizaOS agent and HTTP backend. Plugin routes can be registered on `A
 ## Documentation
 
 - **Paid HTTP routes (webhooks, plugins):** see the docs site section on [webhooks and routes](https://docs.elizaos.ai/plugins/webhooks-and-routes).
-- **x402 micropayments on plugin routes:** see [x402 paid plugin routes](https://docs.elizaos.ai/plugins/x402-paid-routes) for protocol alignment and env vars.
+- **x402 micropayments on plugin routes:** configured through the runtime's `x402` config block and the `X402_API_KEY` environment variable (see `packages/agent/src/runtime/eliza.ts`).
 
 ## Local development
 

--- a/plugins/plugin-local-inference/native/voice-bench/README.md
+++ b/plugins/plugin-local-inference/native/voice-bench/README.md
@@ -39,16 +39,16 @@ voicebench/run.sh --profile=elevenlabs \
 ### Running on GPU (single-GPU tier)
 
 For Linux + NVIDIA hosts, the harness ships per-GPU autotune profiles
-under `packages/inference/configs/gpu/` (3090, 4090, 5090, H200). The
+under `plugins/plugin-local-inference/native/configs/gpu/` (3090, 4090, 5090, H200). The
 inference engine for this tier is **llama.cpp / llama-server** — not
 vLLM or SGLang.
 
 Detect the host card and print the resolved autotune plan:
 
 ```bash
-bun run --cwd packages/inference/voice-bench bench gpu
+bun run --cwd plugins/plugin-local-inference/native/voice-bench bench gpu
 # Or narrowed to a specific bundle:
-bun run --cwd packages/inference/voice-bench bench gpu --bundle eliza-1-9b
+bun run --cwd plugins/plugin-local-inference/native/voice-bench bench gpu --bundle eliza-1-9b
 ```
 
 The subcommand calls `nvidia-smi --query-gpu=name,memory.total` and
@@ -62,20 +62,20 @@ ctx_size) tuples we benchmark. Each row maps to one autotune config.
 Per-GPU expected metrics live in the config JSON files and are flagged
 `"_provenance": "extrapolated"` until a real run replaces them. The
 override mechanism + per-GPU known limits are documented in
-[`packages/inference/configs/gpu/SPECS.md`](../configs/gpu/SPECS.md) and
+[`plugins/plugin-local-inference/native/configs/gpu/SPECS.md`](../configs/gpu/SPECS.md) and
 [`docs/inference/gpu-tier.md`](../../../docs/inference/gpu-tier.md).
 
 Unit tests:
 
 ```bash
-bun run --cwd packages/inference/voice-bench test
-bun run --cwd packages/inference/voice-bench typecheck
+bun run --cwd plugins/plugin-local-inference/native/voice-bench test
+bun run --cwd plugins/plugin-local-inference/native/voice-bench typecheck
 ```
 
 Regenerate fixture WAVs into `fixtures/`:
 
 ```bash
-bun run --cwd packages/inference/voice-bench generate-fixtures
+bun run --cwd plugins/plugin-local-inference/native/voice-bench generate-fixtures
 ```
 
 The `fixtures/` directory is gitignored — the harness uses in-memory
@@ -123,9 +123,9 @@ When a real optimization legitimately improves a metric, record a new
 baseline:
 
 ```bash
-bun run --cwd packages/inference/voice-bench bench \
+bun run --cwd plugins/plugin-local-inference/native/voice-bench bench \
   --bundle eliza-1-2b --backend metal --runs 5 \
-  --output packages/inference/voice-bench/baselines/M4Max-metal.json
+  --output plugins/plugin-local-inference/native/voice-bench/baselines/M4Max-metal.json
 ```
 
 Commit the JSON. Future PRs compare against it.

--- a/plugins/plugin-relationships/README.md
+++ b/plugins/plugin-relationships/README.md
@@ -74,7 +74,6 @@ src/
 
 ```bash
 bun run --cwd plugins/plugin-relationships build       # bun build → dist/ + tsc types
-bun run --cwd plugins/plugin-relationships dev         # hot-rebuild via build.ts
 bun run --cwd plugins/plugin-relationships test        # vitest run
 bun run --cwd plugins/plugin-relationships typecheck   # tsgo --noEmit
 bun run --cwd plugins/plugin-relationships check       # typecheck + test


### PR DESCRIPTION
# Relates to

No existing issue — found by executing the documented commands and checking the links. Each defect below fails for anyone who follows it.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Low.** Documentation only — three files, no source or test changes. Each edit replaces an instruction that currently errors with one verified to resolve.

# Background

## What does this PR do?

Fixes three documented instructions that fail when followed.

**1. `plugins/plugin-local-inference/native/voice-bench/README.md` — every command targets a directory that does not exist.**

```
$ ls packages/inference
ls: packages/inference: No such file or directory

$ bun run --cwd packages/inference/voice-bench test
ENOENT: Could not change directory to "packages/inference/voice-bench"
```

The package actually lives at `plugins/plugin-local-inference/native/voice-bench`. All 7 commands (lines 49, 51, 71, 72, 78, 126, 128) and the 2 `configs/gpu/` path labels (lines 42, 65) are corrected. After the fix the directory resolves and the script is found:

```
$ bun run --cwd plugins/plugin-local-inference/native/voice-bench typecheck
$ tsc --noEmit          # runs; only fails on a missing local devDep, no ENOENT
```

The relative markdown link targets (`../configs/gpu/SPECS.md`) already resolved correctly and are unchanged — only the displayed labels and the shell commands were wrong.

**2. `plugins/plugin-relationships/README.md` — documents a script that does not exist.**

```
$ bun run --cwd plugins/plugin-relationships dev
error: Script not found "dev"

$ python3 -c "import json;print(list(json.load(open('plugins/plugin-relationships/package.json'))['scripts']))"
['build', 'build:js', 'build:views', 'build:types', 'clean', 'test',
 'typecheck', 'lint', 'lint:check', 'check', 'format', 'format:check']

$ ls plugins/plugin-relationships/build.ts
ls: plugins/plugin-relationships/build.ts: No such file or directory
```

The line claimed `dev  # hot-rebuild via build.ts`; the package builds with tsup. I removed the line rather than inventing a watch script — if one is wanted it has to be added to `package.json` first. The other five lines in that block are correct and untouched.

**3. `packages/agent/README.md` — a hard 404.**

```
$ curl -s -o /dev/null -w "%{http_code}\n" https://docs.elizaos.ai/plugins/x402-paid-routes
404
$ curl -s -o /dev/null -w "%{http_code}\n" https://docs.elizaos.ai/plugins/webhooks-and-routes
200
```

Not a site outage — the sibling link on the line above resolves. No x402 page exists on the docs site, and no x402 doc source exists under `packages/docs/` either, so there was no correct URL to substitute. Rather than invent one, the bullet now points at the real configuration surface, which I verified exists (`x402` config block and `X402_API_KEY`, `packages/agent/src/runtime/eliza.ts:2579-2584`). If an x402 docs page is planned, swapping this back to a link is a one-line follow-up.

## What kind of change is this?

Documentation

## Why are we doing this? Any context or related work?

All three are copy-paste failures for a new contributor: two produce a hard error in the shell, one sends the reader to a 404. They are independent of each other but identical in kind — documentation referring to things that are not there — which is why they are grouped in one small review rather than three.

# Documentation changes needed?

This PR *is* the documentation change. No further docs work is implied.

# Testing

## Where should a reviewer start?

Run the two shell commands from the "before" blocks above on `develop` (both error), then on this branch (both resolve). The link check is a single `curl`.

## Detailed testing steps

```bash
# on develop — both fail
bun run --cwd packages/inference/voice-bench test          # ENOENT
bun run --cwd plugins/plugin-relationships dev             # Script not found

# on this branch — corrected paths resolve
ls plugins/plugin-local-inference/native/voice-bench       # exists
ls plugins/plugin-local-inference/native/configs/gpu       # exists
grep -c "packages/inference" plugins/plugin-local-inference/native/voice-bench/README.md   # 0

# link
curl -s -o /dev/null -w "%{http_code}\n" https://docs.elizaos.ai/plugins/x402-paid-routes   # 404
```

# Evidence Gate

<!-- evidence-head:696e9de97a171d2637bd02c2914e7a0e2974d7d3 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - documentation only; no UI surface.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - documentation only; no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - the observable behaviour is a shell command succeeding instead of erroring, shown as verbatim terminal output above.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no code path changes; the terminal transcripts above are the end-to-end evidence.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involvement.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt or model behaviour changes; this diff touches three markdown files only.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - produces no DB rows, memories, tasks, files or on-chain output.`
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - markdown-only change.`

## Backend + frontend logs

`N/A - markdown-only change.` The behavioural evidence is the before/after terminal output above.

## Screenshots (before / after) + video walkthrough

`N/A - no UI change.`

# Known gaps / failures

**`bun run verify` blocker (pre-existing on `develop`, not from this PR).** The repository-wide gate currently fails at:

```
@elizaos/gateway-webhook:typecheck: src/billing.test.ts(8,65): error TS2307:
  Cannot find module '@elizaos/cloud-shared/billing'
```

I confirmed this reproduces on a clean checkout of `origin/develop` with **zero** changes applied (`56 successful, 57 total`, same failure), so it is unrelated to this diff. This PR changes only markdown and cannot affect a typecheck target. Flagging it rather than ticking a green I can't stand behind.

AI provider/model: Anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A - contribution skill not used; repository template and CONTRIBUTING.md read directly from the checkout
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"N/A - contribution skill not used"} -->
