### PR TITLE
fix(core): canonicalize analyzeRelationship cache key and evaluate TTL from calculation time

### DIFF
--- a/packages/core/src/services/relationships-analytics-cache.test.ts
+++ b/packages/core/src/services/relationships-analytics-cache.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Unit tests for RelationshipsService.analyzeRelationship caching semantics.
+ * Verifies that unordered entity pairs share a canonical cache entry regardless
+ * of argument order, and that TTL expiry is evaluated against computation time.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { UUID } from "../types/primitives";
+import { RelationshipsService } from "./relationships";
+
+const ENTITY_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" as UUID;
+const ENTITY_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" as UUID;
+
+describe("RelationshipsService.analyzeRelationship cache", () => {
+	it("shares canonical cache between reversed entity arguments", async () => {
+		let queryCount = 0;
+		let writeCount = 0;
+
+		const runtime = {
+			agentId: "11111111-1111-4111-8111-111111111111" as UUID,
+			async getRelationships() {
+				queryCount += 1;
+				return [
+					{
+						id: "rel-ab",
+						sourceEntityId: ENTITY_A,
+						targetEntityId: ENTITY_B,
+						strength: 0,
+						lastInteractionAt: new Date(Date.now() - 86400000).toISOString(),
+					},
+				];
+			},
+			async getRoomsForParticipant() {
+				return [];
+			},
+			async getMemoriesByRoomIds() {
+				return [];
+			},
+			async createComponent() {
+				writeCount += 1;
+				return true;
+			},
+		};
+
+		const service = new RelationshipsService(runtime as never);
+
+		// First call: computes and caches
+		const first = await service.analyzeRelationship(ENTITY_A, ENTITY_B);
+		expect(first).not.toBeNull();
+		expect(queryCount).toBe(1);
+		expect(writeCount).toBe(1);
+
+		// Second call with reversed argument order: must hit canonical cache
+		const second = await service.analyzeRelationship(ENTITY_B, ENTITY_A);
+		expect(second).not.toBeNull();
+		expect(second).toEqual(first);
+		expect(queryCount).toBe(1);
+		expect(writeCount).toBe(1);
+	});
+
+	it("serves cached analytics when lastInteractionAt is older than 1 hour", async () => {
+		let queryCount = 0;
+
+		const oldInteractionTime = new Date(
+			Date.now() - 7 * 86400000,
+		).toISOString();
+		const runtime = {
+			agentId: "11111111-1111-4111-8111-111111111111" as UUID,
+			async getRelationships() {
+				queryCount += 1;
+				return [
+					{
+						id: "rel-ab",
+						sourceEntityId: ENTITY_A,
+						targetEntityId: ENTITY_B,
+						strength: 0,
+						lastInteractionAt: oldInteractionTime,
+					},
+				];
+			},
+			async getRoomsForParticipant() {
+				return [];
+			},
+			async getMemoriesByRoomIds() {
+				return [];
+			},
+			async createComponent() {
+				return true;
+			},
+		};
+
+		const service = new RelationshipsService(runtime as never);
+
+		// Compute fresh analytics for relationship with old interaction
+		const first = await service.analyzeRelationship(ENTITY_A, ENTITY_B);
+		expect(first).not.toBeNull();
+		expect(queryCount).toBe(1);
+
+		// Subsequent call within 1 hour must hit cache even though lastInteractionAt is 7 days ago
+		const second = await service.analyzeRelationship(ENTITY_A, ENTITY_B);
+		expect(second).not.toBeNull();
+		expect(queryCount).toBe(1);
+	});
+
+	it("recomputes when the cache entry has exceeded 1 hour TTL", async () => {
+		let queryCount = 0;
+
+		const runtime = {
+			agentId: "11111111-1111-4111-8111-111111111111" as UUID,
+			async getRelationships() {
+				queryCount += 1;
+				return [
+					{
+						id: "rel-ab",
+						sourceEntityId: ENTITY_A,
+						targetEntityId: ENTITY_B,
+						strength: 0,
+					},
+				];
+			},
+			async getRoomsForParticipant() {
+				return [];
+			},
+			async getMemoriesByRoomIds() {
+				return [];
+			},
+			async createComponent() {
+				return true;
+			},
+		};
+
+		const service = new RelationshipsService(runtime as never);
+
+		const now = Date.now();
+		vi.spyOn(Date, "now").mockReturnValue(now);
+
+		await service.analyzeRelationship(ENTITY_A, ENTITY_B);
+		expect(queryCount).toBe(1);
+
+		// Advance time by 30 minutes: still in cache
+		vi.spyOn(Date, "now").mockReturnValue(now + 30 * 60 * 1000);
+		await service.analyzeRelationship(ENTITY_A, ENTITY_B);
+		expect(queryCount).toBe(1);
+
+		// Advance time past 1 hour: expired, recomputes
+		vi.spyOn(Date, "now").mockReturnValue(now + 61 * 60 * 1000);
+		await service.analyzeRelationship(ENTITY_A, ENTITY_B);
+		expect(queryCount).toBe(2);
+
+		vi.restoreAllMocks();
+	});
+});

--- a/packages/core/src/services/relationships.ts
+++ b/packages/core/src/services/relationships.ts
@@ -597,7 +597,10 @@ export class RelationshipsService extends Service {
 
 	// In-memory caches for performance
 	private contactInfoCache: Map<UUID, ContactInfo> = new Map();
-	private analyticsCache: Map<string, RelationshipAnalytics> = new Map();
+	private analyticsCache: Map<
+		string,
+		{ analytics: RelationshipAnalytics; cachedAt: number }
+	> = new Map();
 	private categoriesCache: ContactCategory[] = [];
 	private static readonly CONTACT_CACHE_LIMIT = 2000;
 	private static readonly ANALYTICS_CACHE_LIMIT = 2000;
@@ -1022,20 +1025,16 @@ export class RelationshipsService extends Service {
 		sourceEntityId: UUID,
 		targetEntityId: UUID,
 	): Promise<RelationshipAnalytics | null> {
-		const cacheKey = `${sourceEntityId}-${targetEntityId}`;
+		const [firstEntityId, secondEntityId] =
+			sourceEntityId < targetEntityId
+				? [sourceEntityId, targetEntityId]
+				: [targetEntityId, sourceEntityId];
+		const cacheKey = `${firstEntityId}-${secondEntityId}`;
 
-		// Check cache first
-		if (this.analyticsCache.has(cacheKey)) {
-			const cached = this.analyticsCache.get(cacheKey);
-			if (cached) {
-				// Cache for 1 hour
-				if (
-					cached.lastInteractionAt &&
-					Date.now() - new Date(cached.lastInteractionAt).getTime() < 3600000
-				) {
-					return cached;
-				}
-			}
+		// Check cache first (valid for 1 hour from computation)
+		const cached = this.analyticsCache.get(cacheKey);
+		if (cached && Date.now() - cached.cachedAt < 3600000) {
+			return cached.analytics;
 		}
 
 		// Get relationship
@@ -1177,7 +1176,7 @@ export class RelationshipsService extends Service {
 		this.setCacheWithLimit(
 			this.analyticsCache,
 			cacheKey,
-			analytics,
+			{ analytics, cachedAt: Date.now() },
 			RelationshipsService.ANALYTICS_CACHE_LIMIT,
 		);
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Resolves #20357

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity CLI`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop@764695f33de8aae99308464b3903f392292e2bd1`; zero conflicts.
- [x] Exact-head `bun run verify` passes: 351/351 tasks and every repository audit.

# Risks

Low. In-memory analytics cache normalization and TTL calculation fix in `RelationshipsService.analyzeRelationship`. No public type changes, no schema migrations, and no breaking behavioral changes for callers.

# Background

## What does this PR do?

1. **Canonicalizes the cache key in `RelationshipsService.analyzeRelationship`**: Normalizes `(sourceEntityId, targetEntityId)` by sorting UUIDs lexicographically so that symmetric calls `analyzeRelationship(A, B)` and `analyzeRelationship(B, A)` hit the same cache entry instead of re-querying relationships, participant rooms, memories, and creating duplicate `relationship_update` components.
2. **Fixes cache TTL evaluation**: Measures the 1-hour cache expiry against `cachedAt` timestamp recorded at computation time, rather than comparing against `cached.lastInteractionAt` (which caused cache misses for any relationship where the last message was older than 1 hour or non-existent).

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/core/src/services/relationships.ts`: lines 596, 1021-1033, 1172-1178
- `packages/core/src/services/relationships-analytics-cache.test.ts`: comprehensive tests for reversed argument lookup, old interaction timestamps, and 1-hour TTL expiry.

## Detailed testing steps

Run unit tests via vitest:
```bash
bun run --cwd packages/core test src/services/relationships
```
All tests in `relationships-analytics-cache.test.ts`, `relationships-pair-predicate.test.ts`, and `relationships.test.ts` pass.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:3ac16510be74996b743dabcdc93dde4700c8c6e8 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered visual surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered visual surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing flow; Core service internal caching logic
<!-- evidence-row:backend-logs -->
- [ ] N/A - unit test suite in `packages/core/src/services/relationships-analytics-cache.test.ts` directly exercises the cache hit/miss and TTL paths
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend change
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM or prompt changes
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - in-memory relationship analytics caching
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - no LLM change

## Backend + frontend logs

N/A - covered by vitest unit tests in `packages/core/src/services/relationships-analytics-cache.test.ts`.

## Screenshots (before / after) + video walkthrough

N/A - backend runtime core service

## Audio / voice walkthrough

N/A - no audio surface

## Known gaps / failures

None. All checks, typecheck, lint, and unit tests pass.

AI provider/model: google / gemini-3.7-flash
Client / agent tooling: Antigravity CLI
Contribution skill revision: elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity-contributor]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity CLI","skill_revision":"elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza"} -->
