### PR TITLE
fix(database): intersect explicit entity query filters

### DIFF
--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -574,7 +574,11 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 
 		let entityIds: UUID[] = [];
 		if (matchedComponentsByEntity.size > 0) {
-			entityIds = Array.from(matchedComponentsByEntity.keys()).map(asUuid);
+			entityIds = _params.entityIds?.length
+				? _params.entityIds.filter((entityId) =>
+						matchedComponentsByEntity.has(String(entityId)),
+					)
+				: Array.from(matchedComponentsByEntity.keys()).map(asUuid);
 		} else if (!hasComponentQuery && _params.limit !== undefined) {
 			for (const entity of this.entities.values()) {
 				if (!entity.id) continue;
@@ -593,6 +597,14 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			return [];
 		}
 
+		entityIds = entityIds.filter((entityId) => {
+			const entity = this.entities.get(String(entityId));
+			return (
+				entity !== undefined &&
+				(!_params.agentId || entity.agentId === _params.agentId)
+			);
+		});
+
 		const offset = _params.offset ?? 0;
 		const limit = _params.limit ?? entityIds.length;
 		entityIds = entityIds.slice(offset, offset + limit);
@@ -601,18 +613,13 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		for (const entityId of entityIds) {
 			const entity = this.entities.get(String(entityId));
 			if (!entity) continue;
-			if (
-				_params.agentId &&
-				entity.agentId &&
-				entity.agentId !== _params.agentId
-			) {
-				continue;
-			}
-
 			const matchedComponents =
 				matchedComponentsByEntity.get(String(entityId)) ?? [];
 			const components = _params.includeAllComponents
-				? this.getStoredComponentsForEntity(entity.id)
+				? this.getStoredComponentsForEntity(entity.id).filter(
+						(component) =>
+							!_params.agentId || component.agentId === _params.agentId,
+					)
 				: matchedComponents;
 			entities.push(this.attachComponents(entity, components));
 		}

--- a/packages/core/src/database/inMemoryQueryEntities.test.ts
+++ b/packages/core/src/database/inMemoryQueryEntities.test.ts
@@ -20,7 +20,10 @@ function entity(id: UUID, scopedAgentId = agentId): Entity {
 	};
 }
 
-function component(entityId: UUID): Component {
+function component(
+	entityId: UUID,
+	overrides: Partial<Component> = {},
+): Component {
 	return {
 		id: `${entityId}-component` as UUID,
 		entityId,
@@ -30,7 +33,8 @@ function component(entityId: UUID): Component {
 		sourceEntityId: agentId,
 		type: "form_session:room",
 		createdAt: 1,
-		data: { id: entityId },
+		data: { id: entityId, profile: { active: true }, tags: ["alpha", "beta"] },
+		...overrides,
 	};
 }
 
@@ -88,5 +92,67 @@ describe("InMemoryDatabaseAdapter queryEntities", () => {
 			"form_session:room",
 		]);
 		expect(idsOnly.map((item) => item.id)).toEqual([entityTwo]);
+	});
+
+	it("intersects data, world, agent, and paging filters before attaching components", async () => {
+		const adapter = new InMemoryDatabaseAdapter();
+		await adapter.initialize();
+		const otherWorld = "30000000-0000-0000-0000-000000000002" as UUID;
+		await adapter.createEntities([
+			entity(entityOne),
+			entity(entityTwo),
+			entity(entityThree),
+		]);
+		await adapter.createComponents([
+			component(entityOne),
+			component(entityOne, {
+				id: "40000000-0000-0000-0000-000000000002" as UUID,
+				type: "secondary",
+				worldId: otherWorld,
+				data: { enabled: true },
+			}),
+			component(entityTwo, {
+				id: "40000000-0000-0000-0000-000000000003" as UUID,
+				data: { profile: { active: false }, tags: ["alpha"] },
+			}),
+		]);
+
+		const page = await adapter.queryEntities({
+			entityIds: [entityThree, entityTwo, entityOne],
+			componentType: "form_session:room",
+			limit: 1,
+		});
+		const nestedDataMatch = await adapter.queryEntities({
+			entityIds: [entityOne, entityTwo],
+			componentDataFilter: { profile: { active: true }, tags: ["beta"] },
+		});
+		const otherWorldMatch = await adapter.queryEntities({
+			entityIds: [entityOne, entityTwo],
+			worldId: otherWorld,
+		});
+		const wrongAgent = await adapter.queryEntities({
+			entityIds: [entityOne],
+			agentId: otherAgentId,
+			limit: 1,
+		});
+		const allComponents = await adapter.queryEntities({
+			entityIds: [entityOne],
+			componentType: "form_session:room",
+			includeAllComponents: true,
+		});
+
+		expect(page.map((item) => item.id)).toEqual([entityTwo]);
+		expect(page[0].components?.map((item) => item.type)).toEqual([
+			"form_session:room",
+		]);
+		expect(nestedDataMatch.map((item) => item.id)).toEqual([entityOne]);
+		expect(otherWorldMatch.map((item) => item.id)).toEqual([entityOne]);
+		expect(otherWorldMatch[0].components?.map((item) => item.type)).toEqual([
+			"secondary",
+		]);
+		expect(wrongAgent).toEqual([]);
+		expect(
+			allComponents[0].components?.map((item) => item.type).sort(),
+		).toEqual(["form_session:room", "secondary"]);
 	});
 });

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -104,6 +104,38 @@ interface StoredRelationship {
   createdAt?: string;
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function dataContainsFilter(value: unknown, filter: Record<string, unknown> | undefined): boolean {
+  if (!filter) return true;
+  if (!isPlainObject(value)) return false;
+
+  for (const [key, expected] of Object.entries(filter)) {
+    const actual = value[key];
+    if (isPlainObject(expected)) {
+      if (!dataContainsFilter(actual, expected)) return false;
+      continue;
+    }
+    if (Array.isArray(expected)) {
+      if (!Array.isArray(actual)) return false;
+      for (const expectedItem of expected) {
+        const found = actual.some((actualItem) =>
+          isPlainObject(expectedItem)
+            ? dataContainsFilter(actualItem, expectedItem)
+            : actualItem === expectedItem
+        );
+        if (!found) return false;
+      }
+      continue;
+    }
+    if (actual !== expected) return false;
+  }
+
+  return true;
+}
+
 interface StoredCacheEntry<T = unknown> {
   value: T;
   expiresAt?: number;
@@ -430,36 +462,67 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     includeAllComponents?: boolean;
     entityContext?: UUID;
   }): Promise<Entity[]> {
-    let entityIds: UUID[];
-    if (params.entityIds && params.entityIds.length > 0) {
-      entityIds = params.entityIds;
-    } else {
-      const allComponents = await this.storage.getWhere<Component>(COLLECTIONS.COMPONENTS, (c) => {
-        if (params.componentType && c.type !== params.componentType) return false;
-        if (params.worldId && c.worldId !== params.worldId) return false;
-        if (params.componentDataFilter) {
-          const data = (c as Component & { data?: Record<string, unknown> }).data;
-          if (!data || typeof data !== "object") return false;
-          for (const [k, v] of Object.entries(params.componentDataFilter)) {
-            if (data[k] !== v) return false;
+    const hasComponentQuery =
+      params.componentType !== undefined ||
+      params.componentDataFilter !== undefined ||
+      params.worldId !== undefined;
+    const matchedComponentsByEntity = new Map<UUID, Component[]>();
+
+    if (hasComponentQuery) {
+      const matchedComponents = await this.storage.getWhere<Component>(
+        COLLECTIONS.COMPONENTS,
+        (component) => {
+          if (params.agentId && component.agentId !== params.agentId) return false;
+          if (params.entityIds?.length && !params.entityIds.includes(component.entityId)) {
+            return false;
           }
+          if (params.componentType !== undefined && component.type !== params.componentType) {
+            return false;
+          }
+          if (params.worldId !== undefined && component.worldId !== params.worldId) return false;
+          return dataContainsFilter(component.data, params.componentDataFilter);
         }
-        return true;
-      });
-      entityIds = [...new Set(allComponents.map((c) => c.entityId as UUID))];
+      );
+      for (const component of matchedComponents) {
+        const bucket = matchedComponentsByEntity.get(component.entityId) ?? [];
+        bucket.push(component);
+        matchedComponentsByEntity.set(component.entityId, bucket);
+      }
     }
 
-    const offset = params.offset ?? 0;
-    const limit = params.limit;
-    const sliced =
-      limit !== undefined ? entityIds.slice(offset, offset + limit) : entityIds.slice(offset);
+    let entityIds: UUID[];
+    if (hasComponentQuery) {
+      entityIds = params.entityIds?.length
+        ? params.entityIds.filter((entityId) => matchedComponentsByEntity.has(entityId))
+        : [...matchedComponentsByEntity.keys()];
+    } else if (params.entityIds?.length) {
+      entityIds = [...params.entityIds];
+    } else if (params.limit !== undefined) {
+      const entities = await this.storage.getWhere<Entity>(COLLECTIONS.ENTITIES, (entity) =>
+        params.agentId ? entity.agentId === params.agentId : true
+      );
+      entityIds = entities.flatMap((entity) => (entity.id ? [entity.id] : []));
+    } else {
+      return [];
+    }
 
-    const entities = await this.getEntitiesByIds(sliced);
-    if (params.includeAllComponents) {
-      for (const entity of entities) {
-        if (!entity.id) continue;
-        const components = await this.getComponentsForEntities([entity.id]);
-        (entity as Entity & { components?: Component[] }).components = components;
+    const candidates = (await this.getEntitiesByIds(entityIds)).filter((entity) =>
+      params.agentId ? entity.agentId === params.agentId : true
+    );
+    const offset = params.offset ?? 0;
+    const limit = params.limit ?? candidates.length;
+    const entities = candidates.slice(offset, offset + limit).map((entity) => ({ ...entity }));
+    for (const entity of entities) {
+      if (!entity.id) continue;
+      const components = params.includeAllComponents
+        ? (await this.getComponentsForEntities([entity.id])).filter((component) =>
+            params.agentId ? component.agentId === params.agentId : true
+          )
+        : (matchedComponentsByEntity.get(entity.id) ?? []);
+      if (components.length > 0) {
+        entity.components = components;
+      } else {
+        delete entity.components;
       }
     }
     return entities;

--- a/plugins/plugin-inmemorydb/query-entities.test.ts
+++ b/plugins/plugin-inmemorydb/query-entities.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Exercises `queryEntities` against the real Map-backed adapter, proving that
+ * explicit IDs intersect with component, scope, data, and paging predicates.
+ */
+import type { Component, Entity, UUID } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "./adapter";
+import { MemoryStorage } from "./storage-memory";
+
+const agentId = "00000000-0000-0000-0000-000000000001" as UUID;
+const otherAgentId = "00000000-0000-0000-0000-000000000002" as UUID;
+const entityOne = "10000000-0000-0000-0000-000000000001" as UUID;
+const entityTwo = "10000000-0000-0000-0000-000000000002" as UUID;
+const entityThree = "10000000-0000-0000-0000-000000000003" as UUID;
+const worldOne = "30000000-0000-0000-0000-000000000001" as UUID;
+const worldTwo = "30000000-0000-0000-0000-000000000002" as UUID;
+const roomId = "20000000-0000-0000-0000-000000000001" as UUID;
+
+function entity(id: UUID): Entity {
+  return { id, agentId, names: [`entity-${id}`] };
+}
+
+function component(
+  id: UUID,
+  entityId: UUID,
+  type: string,
+  worldId: UUID,
+  data: Record<string, unknown>
+): Component {
+  return {
+    id,
+    entityId,
+    agentId,
+    roomId,
+    worldId,
+    sourceEntityId: entityOne,
+    type,
+    data,
+    createdAt: 1,
+  };
+}
+
+describe("plugin-inmemorydb queryEntities", () => {
+  let adapter: InMemoryDatabaseAdapter;
+
+  beforeEach(async () => {
+    adapter = new InMemoryDatabaseAdapter(new MemoryStorage(), agentId);
+    await adapter.initialize();
+    await adapter.createEntities([entity(entityOne), entity(entityTwo), entity(entityThree)]);
+    await adapter.createComponents([
+      component("40000000-0000-0000-0000-000000000001" as UUID, entityOne, "profile", worldOne, {
+        profile: { active: true },
+        tags: ["alpha", "beta"],
+      }),
+      component("40000000-0000-0000-0000-000000000002" as UUID, entityOne, "secondary", worldTwo, {
+        enabled: true,
+      }),
+      component("40000000-0000-0000-0000-000000000003" as UUID, entityTwo, "profile", worldOne, {
+        profile: { active: false },
+        tags: ["alpha"],
+      }),
+    ]);
+  });
+
+  afterEach(async () => {
+    await adapter.close();
+  });
+
+  it("intersects every filter before paging and returns the documented components", async () => {
+    const noMatch = await adapter.queryEntities({
+      entityIds: [entityThree],
+      componentType: "profile",
+    });
+    const page = await adapter.queryEntities({
+      entityIds: [entityThree, entityTwo, entityOne],
+      componentType: "profile",
+      limit: 1,
+    });
+    const nestedDataMatch = await adapter.queryEntities({
+      entityIds: [entityOne, entityTwo],
+      componentDataFilter: { profile: { active: true }, tags: ["beta"] },
+    });
+    const worldMatch = await adapter.queryEntities({
+      entityIds: [entityOne, entityTwo],
+      worldId: worldTwo,
+    });
+    const wrongAgent = await adapter.queryEntities({
+      entityIds: [entityOne],
+      agentId: otherAgentId,
+      limit: 1,
+    });
+    const allComponents = await adapter.queryEntities({
+      entityIds: [entityOne],
+      componentType: "profile",
+      includeAllComponents: true,
+    });
+
+    expect(noMatch).toEqual([]);
+    expect(page.map((item) => item.id)).toEqual([entityTwo]);
+    expect(page[0].components?.map((item) => item.type)).toEqual(["profile"]);
+    expect(nestedDataMatch.map((item) => item.id)).toEqual([entityOne]);
+    expect(worldMatch.map((item) => item.id)).toEqual([entityOne]);
+    expect(worldMatch[0].components?.map((item) => item.type)).toEqual(["secondary"]);
+    expect(wrongAgent).toEqual([]);
+    expect(allComponents[0].components?.map((item) => item.type).sort()).toEqual([
+      "profile",
+      "secondary",
+    ]);
+  });
+});

--- a/plugins/plugin-sql/src/__tests__/integration/query-entities.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/query-entities.real.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Runs the entity-query intersection contract against a real isolated PGlite
+ * or PostgreSQL database, including JSONB containment and component hydration.
+ */
+import {
+  ChannelType,
+  type Component,
+  type Entity,
+  type Room,
+  type UUID,
+  type World,
+} from "@elizaos/core";
+import { v4 as uuidv4 } from "uuid";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { PgDatabaseAdapter } from "../../pg/adapter";
+import type { PgliteDatabaseAdapter } from "../../pglite/adapter";
+import { createIsolatedTestDatabase } from "../test-helpers";
+
+describe("queryEntities intersection contract", () => {
+  let adapter: PgliteDatabaseAdapter | PgDatabaseAdapter;
+  let cleanup: () => Promise<void>;
+  let agentId: UUID;
+  const otherAgentId = uuidv4() as UUID;
+  const entityOne = uuidv4() as UUID;
+  const entityTwo = uuidv4() as UUID;
+  const entityThree = uuidv4() as UUID;
+  const worldOne = uuidv4() as UUID;
+  const worldTwo = uuidv4() as UUID;
+  const roomOne = uuidv4() as UUID;
+  const roomTwo = uuidv4() as UUID;
+
+  beforeAll(async () => {
+    const setup = await createIsolatedTestDatabase("query-entities-intersection");
+    adapter = setup.adapter;
+    cleanup = setup.cleanup;
+    agentId = setup.testAgentId;
+
+    await adapter.createWorlds([
+      { id: worldOne, agentId, name: "World one", serverId: worldOne } as World,
+      { id: worldTwo, agentId, name: "World two", serverId: worldTwo } as World,
+    ]);
+    await adapter.createRooms([
+      {
+        id: roomOne,
+        agentId,
+        worldId: worldOne,
+        source: "test",
+        type: ChannelType.GROUP,
+      } as Room,
+      {
+        id: roomTwo,
+        agentId,
+        worldId: worldTwo,
+        source: "test",
+        type: ChannelType.GROUP,
+      } as Room,
+    ]);
+    await adapter.createEntities(
+      [entityOne, entityTwo, entityThree].map(
+        (id): Entity => ({ id, agentId, names: [`entity-${id}`] })
+      )
+    );
+    await adapter.createComponents([
+      {
+        id: uuidv4() as UUID,
+        entityId: entityOne,
+        agentId,
+        roomId: roomOne,
+        worldId: worldOne,
+        sourceEntityId: entityOne,
+        type: "profile",
+        data: { profile: { active: true }, tags: ["alpha", "beta"] },
+        createdAt: Date.now(),
+      } as Component,
+      {
+        id: uuidv4() as UUID,
+        entityId: entityOne,
+        agentId,
+        roomId: roomTwo,
+        worldId: worldTwo,
+        sourceEntityId: entityOne,
+        type: "secondary",
+        data: { enabled: true },
+        createdAt: Date.now(),
+      } as Component,
+      {
+        id: uuidv4() as UUID,
+        entityId: entityTwo,
+        agentId,
+        roomId: roomOne,
+        worldId: worldOne,
+        sourceEntityId: entityOne,
+        type: "profile",
+        data: { profile: { active: false }, tags: ["alpha"] },
+        createdAt: Date.now(),
+      } as Component,
+    ]);
+  });
+
+  afterAll(async () => {
+    await cleanup();
+  });
+
+  it("intersects explicit IDs with component, data, world, agent, and paging filters", async () => {
+    const noMatch = await adapter.queryEntities({
+      entityIds: [entityThree],
+      componentType: "profile",
+    });
+    const page = await adapter.queryEntities({
+      entityIds: [entityThree, entityTwo, entityOne],
+      componentType: "profile",
+      limit: 1,
+    });
+    const nestedDataMatch = await adapter.queryEntities({
+      entityIds: [entityOne, entityTwo],
+      componentDataFilter: { profile: { active: true }, tags: ["beta"] },
+    });
+    const worldMatch = await adapter.queryEntities({
+      entityIds: [entityOne, entityTwo],
+      worldId: worldTwo,
+    });
+    const wrongAgent = await adapter.queryEntities({
+      entityIds: [entityOne],
+      agentId: otherAgentId,
+      limit: 1,
+    });
+    const allComponents = await adapter.queryEntities({
+      entityIds: [entityOne],
+      componentType: "profile",
+      includeAllComponents: true,
+    });
+
+    expect(noMatch).toEqual([]);
+    expect(page.map((item) => item.id)).toEqual([entityTwo]);
+    expect(page[0].components?.map((item) => item.type)).toEqual(["profile"]);
+    expect(nestedDataMatch.map((item) => item.id)).toEqual([entityOne]);
+    expect(worldMatch.map((item) => item.id)).toEqual([entityOne]);
+    expect(worldMatch[0].components?.map((item) => item.type)).toEqual(["secondary"]);
+    expect(wrongAgent).toEqual([]);
+    expect(allComponents[0].components?.map((item) => item.type).sort()).toEqual([
+      "profile",
+      "secondary",
+    ]);
+  });
+});

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -6163,33 +6163,37 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     includeAllComponents?: boolean;
     entityContext?: UUID;
   }): Promise<Entity[]> {
-    // If specific entityIds are provided, delegate to getEntitiesByIds
-    if (params.entityIds?.length) {
-      const entities = await this.getEntitiesByIds(params.entityIds);
-      return entities || [];
-    }
-
     return this.withDatabase(async () => {
       const conditions: SQL[] = [];
+      const hasComponentQuery =
+        params.componentType !== undefined ||
+        params.componentDataFilter !== undefined ||
+        params.worldId !== undefined;
 
       if (params.agentId) {
         conditions.push(eq(entityTable.agentId, params.agentId));
+      }
+      if (params.entityIds?.length) {
+        conditions.push(inArray(entityTable.id, params.entityIds));
       }
 
       // Build a single EXISTS subquery when filtering by componentType,
       // component data, and/or worldId.
       // Both predicates apply to the component table so they share one subquery.
-      if (params.componentType || params.componentDataFilter || params.worldId) {
+      if (hasComponentQuery) {
         const subConditions: SQL[] = [sql`${componentTable.entityId} = ${entityTable.id}`];
-        if (params.componentType) {
+        if (params.agentId) {
+          subConditions.push(sql`${componentTable.agentId} = ${params.agentId}`);
+        }
+        if (params.componentType !== undefined) {
           subConditions.push(sql`${componentTable.type} = ${params.componentType}`);
         }
-        if (params.componentDataFilter) {
+        if (params.componentDataFilter !== undefined) {
           subConditions.push(
             sql`${componentTable.data} @> ${JSON.stringify(params.componentDataFilter)}::jsonb`
           );
         }
-        if (params.worldId) {
+        if (params.worldId !== undefined) {
           subConditions.push(sql`${componentTable.worldId} = ${params.worldId}`);
         }
         const subquery = sql`EXISTS (
@@ -6204,27 +6208,70 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         .from(entityTable)
         .where(conditions.length > 0 ? and(...conditions) : undefined);
 
-      if (params.limit) {
+      if (params.limit !== undefined && !params.entityIds?.length) {
         query = query.limit(params.limit) as typeof query;
       }
-      if (params.offset) {
+      if (params.offset !== undefined && !params.entityIds?.length) {
         query = query.offset(params.offset) as typeof query;
       }
 
       const result = await query;
 
-      const entities: Entity[] = result.map((row) => ({
+      let entities: Entity[] = result.map((row) => ({
         ...row,
         id: row.id as UUID,
         agentId: row.agentId as UUID,
         names: (row.names || []) as string[],
         metadata: (row.metadata || {}) as Metadata,
       }));
+      if (params.entityIds?.length) {
+        const inputOrder = new Map(params.entityIds.map((entityId, index) => [entityId, index]));
+        entities.sort(
+          (left, right) =>
+            (inputOrder.get(left.id as UUID) ?? Number.MAX_SAFE_INTEGER) -
+            (inputOrder.get(right.id as UUID) ?? Number.MAX_SAFE_INTEGER)
+        );
+        const offset = params.offset ?? 0;
+        const limit = params.limit ?? entities.length;
+        entities = entities.slice(offset, offset + limit);
+      }
 
-      // Load components for returned entities when requested
-      if (params.includeAllComponents && entities.length > 0) {
+      // Component-filtered queries return the components that established the
+      // match. Callers may explicitly request every component on those entities.
+      if ((params.includeAllComponents || hasComponentQuery) && entities.length > 0) {
         const entityIds = entities.flatMap((entity) => (entity.id ? [entity.id] : []));
-        const components = await this.getComponentsForEntities(entityIds, params.worldId);
+        const componentConditions: SQL[] = [inArray(componentTable.entityId, entityIds)];
+        if (params.agentId) {
+          componentConditions.push(eq(componentTable.agentId, params.agentId));
+        }
+        if (!params.includeAllComponents) {
+          if (params.componentType !== undefined) {
+            componentConditions.push(eq(componentTable.type, params.componentType));
+          }
+          if (params.componentDataFilter !== undefined) {
+            componentConditions.push(
+              sql`${componentTable.data} @> ${JSON.stringify(params.componentDataFilter)}::jsonb`
+            );
+          }
+          if (params.worldId !== undefined) {
+            componentConditions.push(eq(componentTable.worldId, params.worldId));
+          }
+        }
+        const componentRows = await this.db
+          .select()
+          .from(componentTable)
+          .where(and(...componentConditions));
+        const components: Component[] = componentRows.map((component) => ({
+          ...component,
+          id: component.id as UUID,
+          entityId: component.entityId as UUID,
+          agentId: component.agentId as UUID,
+          roomId: component.roomId as UUID,
+          worldId: (component.worldId ?? "") as UUID,
+          sourceEntityId: (component.sourceEntityId ?? "") as UUID,
+          data: component.data as Metadata,
+          createdAt: component.createdAt.getTime(),
+        }));
         const componentsByEntity = new Map<UUID, Component[]>();
         for (const comp of components) {
           const list = componentsByEntity.get(comp.entityId) ?? [];


### PR DESCRIPTION
# Relates to

Closes #20340.

- [x] Targets `develop` and is rebased onto exact `origin/develop@63456c8706c946fe1d00e4a994409f0ebc1e4ac6` with zero conflicts.
- [x] Frozen install and exact-head `bun run verify` pass.
- [x] Real freshly migrated PGlite evidence lets a reviewer verify the database behavior without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact base: `origin/develop@63456c8706c946fe1d00e4a994409f0ebc1e4ac6`.
- [x] Published exact head: `e83c9c13200163bf3bb59c78be819dd562f32ad5`.
- [x] Exact-head root verify passed uncached: 351/351 tasks, every repository audit, anti-larp 8,288 files with zero focused tests or orphaned skips.

# Risks

Low and bounded to entity-query semantics. The change makes explicit IDs obey the filters already declared by the public query contract. It changes no schema, performs no production migration, and mutates no production data. Regression coverage exercises the core fallback, plugin-inmemorydb, and a real migrated SQL/PGlite path.

# Background

## What does this PR do?

`queryEntities({ entityIds, ...filters })` previously returned requested rows immediately in SQL and plugin-inmemorydb, bypassing component type/data containment, world, agent, offset, limit, and component-hydration semantics.

This PR treats explicit IDs as one query constraint:

- all adapters intersect IDs with component, nested data, world, and agent filters;
- filtering happens before paging while explicit-ID order remains stable;
- default hydration returns only components matching the query;
- `includeAllComponents` returns every component for matched entities while retaining agent scope;
- plugin-inmemorydb deep-matches nested objects/arrays without mutating stored entities during hydration.

No timeout, retry, catch-and-continue, or fabricated fallback is introduced.

## What kind of change is this?

Bug fix (non-breaking correction to existing database-adapter behavior).

# Documentation changes needed?

No; this aligns implementations with the existing `queryEntities` contract.

# Testing

## Where should a reviewer start?

Open the [current exact-head validation transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20340-query-entities-validation-e83c9c1.md). It records the isolated database migration, contract results, frozen install, and uncached root verification.

## Detailed testing steps

```bash
bun run --cwd packages/core test -- src/database/inMemoryQueryEntities.test.ts
bun run --cwd plugins/plugin-inmemorydb test -- query-entities.test.ts
cd plugins/plugin-sql/src
bunx vitest run --config vitest.real.config.ts __tests__/integration/query-entities.real.test.ts
bun install --frozen-lockfile
bun run verify
```

Exact-head results: core 3/3; plugin-inmemorydb 1/1; real freshly migrated PGlite 1/1; root verify uncached 351/351; anti-larp 8,288 files clean.

# Evidence Gate

<!-- evidence-head:e83c9c13200163bf3bb59c78be819dd562f32ad5 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - database-adapter behavior has no rendered user interface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - database-adapter behavior has no rendered user interface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - database-adapter behavior has no visual interaction flow.
<!-- evidence-row:backend-logs -->
- [x] [Current exact-head PGlite and repository validation transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20340-query-entities-validation-e83c9c1.md); the [semantic-head raw transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20340-query-entities-pglite-0ecddf8.md) is retained for comparison.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, request, or state transition changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [Database contract artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20340-query-entities-domain-0ecddf8.json) records the filter, paging, ordering, and hydration assertions; the feature diff is unchanged by the final base-only rebase and the same contract passed on current head.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface or visual text changed.

# Known gaps / failures

None in the delivered scope. The normal SQL unit config deliberately excludes `*.real.test.ts`; the committed `vitest.real.config.ts` was used explicitly and passed against an isolated, fully migrated PGlite database.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-query-entities-intersection]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
