### PR TITLE
fix(app): accept cron ranges/lists/steps in browser cron-parser shim

### DIFF
--- a/packages/app/src/shims/cron-parser.test.ts
+++ b/packages/app/src/shims/cron-parser.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Unit tests for the browser `cron-parser` shim's field grammar. The suite
+ * exercises the real shim module (not a mock) and asserts it accepts the same
+ * list/range/step syntax the shipped Triggers form relies on while still
+ * rejecting out-of-range, inverted, and garbage fields. The accepted set mirrors
+ * the real `cron-parser@5.x` verdict for the five-field expressions the Triggers
+ * UI validation path feeds through this shim.
+ */
+import { describe, expect, it } from "vitest";
+
+import { CronExpressionParser } from "./cron-parser";
+
+describe("cron-parser shim field grammar", () => {
+  const validExpressions = [
+    "0,30 * * * *",
+    "0 9 * * 1-5",
+    "0 0-11/2 * * *",
+    "15,45 8-17 * * 1-5",
+    "*/5 * * * *",
+    "0 9 * * *",
+    "0-59 * * * *",
+    "*/60 * * * *",
+  ];
+
+  it.each(validExpressions)("accepts valid recurring schedule %s", (expr) => {
+    expect(() => CronExpressionParser.parse(expr)).not.toThrow();
+  });
+
+  const invalidExpressions: Array<[string, string]> = [
+    ["60 * * * *", "minute out of range"],
+    ["0,30,60 * * * *", "list element out of range"],
+    ["5-2 * * * *", "inverted range"],
+    ["*/0 * * * *", "zero step"],
+    ["0-11/0 * * * *", "zero range-step"],
+    ["abc * * * *", "non-numeric garbage"],
+    ["0, * * * *", "trailing empty list element"],
+    ["0 9 * *", "only four fields"],
+    ["8 25 * * *", "hour out of range"],
+  ];
+
+  it.each(invalidExpressions)("rejects %s (%s)", (expr) => {
+    expect(() => CronExpressionParser.parse(expr)).toThrow();
+  });
+
+  it("keeps the iterator surface the Triggers preview consumes", () => {
+    const from = new Date("2024-01-01T00:00:00.000Z");
+    const schedule = CronExpressionParser.parse("0 9 * * 1-5", {
+      currentDate: from,
+    });
+    const next = schedule.next().toDate();
+    expect(next).toBeInstanceOf(Date);
+    expect(next.getTime()).toBeGreaterThan(from.getTime());
+  });
+});

--- a/packages/app/src/shims/cron-parser.ts
+++ b/packages/app/src/shims/cron-parser.ts
@@ -1,28 +1,66 @@
 /**
  * Browser shim for the `cron-parser` package, mirroring the
  * `CronExpressionParser.parse(expr).next().toDate()` surface the app consumes.
- * `parse` validates a 5-field expression (rejecting malformed fields or
- * out-of-range values), but the returned iterator is intentionally minimal: each
+ * `parse` validates a 5-field expression against the same per-field grammar the
+ * real cron-parser accepts — `*`, step values (every-N), comma lists (`0,30`),
+ * ranges (`9-17`), and range-steps (`0-11` every 2) — while still rejecting
+ * malformed or out-of-range fields. The returned iterator is minimal: each
  * `next()` advances the cursor by one minute from `currentDate` rather than
  * resolving the true next matching instant — enough to satisfy validation and
  * the API shape in the bundle without the full scheduler engine.
+ *
+ * This is the parser the shipped Triggers form validates against: it is aliased
+ * over the npm `cron-parser` for the whole app bundle in `vite.config.ts`, and
+ * `packages/ui/.../trigger-form-utils.ts` calls its `parse` through
+ * `validateCronExpression`/`nextRunsForCron`. Rejecting valid list/range/step
+ * syntax here blocks users from creating recurring triggers the backend accepts.
  */
 type ParseOptions = {
   currentDate?: Date | string | number;
 };
 
-function parseField(value: string, min: number, max: number): number {
-  if (value === "*") return min;
-  const interval = value.match(/^\*\/(\d+)$/);
-  if (interval) {
-    const parsed = Number(interval[1]);
-    if (Number.isInteger(parsed) && parsed > 0) return min;
+// Validate one comma-list element of a cron field: `*`, `*/N`, a range `A-B`, a
+// range-step `A-B/N`, or a bare integer, matching cron-parser's field grammar.
+function validateFieldElement(
+  element: string,
+  min: number,
+  max: number,
+  field: string,
+): void {
+  if (element === "*") return;
+
+  const step = element.match(/^\*\/(\d+)$/);
+  if (step) {
+    // A star-step fires from `min` every N; cron-parser only rejects a zero
+    // step, even when N exceeds the range (a step of 60 fires once at `min`).
+    if (Number(step[1]) > 0) return;
+    throw new Error(`Invalid cron field: ${field}`);
   }
-  const parsed = Number(value);
-  if (Number.isInteger(parsed) && parsed >= min && parsed <= max) {
-    return parsed;
+
+  const range = element.match(/^(\d+)-(\d+)(?:\/(\d+))?$/);
+  if (range) {
+    const lo = Number(range[1]);
+    const hi = Number(range[2]);
+    const rangeStep = range[3] === undefined ? 1 : Number(range[3]);
+    if (lo < min || hi > max || lo > hi || rangeStep <= 0) {
+      throw new Error(`Invalid cron field: ${field}`);
+    }
+    return;
   }
-  throw new Error(`Invalid cron field: ${value}`);
+
+  if (/^\d+$/.test(element)) {
+    const parsed = Number(element);
+    if (parsed >= min && parsed <= max) return;
+  }
+
+  throw new Error(`Invalid cron field: ${field}`);
+}
+
+function parseField(value: string, min: number, max: number): void {
+  const elements = value.split(",");
+  for (const element of elements) {
+    validateFieldElement(element, min, max, value);
+  }
 }
 
 class ParsedCronExpression {


### PR DESCRIPTION
# Relates to

Closes #20355

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; focused package checks (test, typecheck, lint) were run. `bun run verify` is not fully runnable on this contributor machine (unbuilt/ungenerated sibling packages); see **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the before/after reproduction, the parity table, and the unit test + mutation evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync — see **Known gaps / failures** for the unrelated blocker.

# Risks

Low. The change is confined to a single browser shim's field-validation grammar
(`packages/app/src/shims/cron-parser.ts`). It only *widens* the set of accepted
cron fields to match the real `cron-parser@5.7.0` this shim replaces, and keeps
all previously-rejected invalid inputs rejected. The minimal `next()` iterator
surface is unchanged. No public API, DTO, or runtime schema changes.

# Background

## What does this PR do?

`packages/app` aliases the npm `cron-parser` package to the browser shim at
`src/shims/cron-parser.ts` for the whole app bundle (`vite.config.ts`). The
shim's `parseField()` only accepted `*`, `*/N` steps, and a single bare integer.
It rejected comma-lists (`0,30`), ranges (`9-17`, `1-5`), and range-steps
(`0-11/2`) — all standard, valid cron syntax the real `cron-parser@5.7.0` (used
by the backend scheduling stack) accepts.

This shim is the parser the shipped Triggers form validates against:
`packages/ui/src/components/pages/trigger-form-utils.ts` imports
`CronExpressionParser` from `"cron-parser"` and calls `validateCronExpression()`
/ `nextRunsForCron()`; in the web/native app those resolve to this shim via the
Vite alias. As a result a user entering a perfectly valid recurring schedule such
as "weekdays at 9am" (`0 9 * * 1-5`) or "every :00 and :30" (`0,30 * * * *`) got
`Invalid cron field` and was blocked from creating the trigger — even though the
backend would accept and run it.

The fix extends `parseField()` to validate each comma-separated element as one
of `*`, a star-step (`*/N`, N>0), a range (`A-B`, min≤A≤B≤max), a range-step
(`A-B/N`, N>0), or a bare integer in range — rejecting out-of-range, inverted
(`5-2`), zero-step (`*/0`), garbage (`abc`), and empty (`0,`) fields exactly as
before. The intentional 5-field strictness of the shim is preserved.

## What kind of change is this?

Bug fix (non-breaking; fixes a contract regression against the package the shim replaces).

# Documentation changes needed?

The module header in `cron-parser.ts` is updated to document the accepted field
grammar and the Triggers-form validation path. No other docs change.

# Testing

## Where should a reviewer start?

`packages/app/src/shims/cron-parser.ts` (the fix) and
`packages/app/src/shims/cron-parser.test.ts` (the new regression test).

## Detailed testing steps

```bash
bun install --minimum-release-age=0   # (the plain flag if your bunfig has no min-age gate)
bun run --cwd packages/app exec vitest run --config vitest.config.ts src/shims/cron-parser.test.ts
```

Result: **18 passed**.

# Evidence Gate

<!-- evidence-head:cfe88e6d5b88ddfec4eb42e39b1a568f9f30f21e -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-rendered .ts parser shim under packages/app/src/shims; no rendered surface
<!-- evidence-row:after-screenshots -->
- [x] `N/A - non-rendered change.` See above; behavior proven via reproduction probe + unit test + mutation check.
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - non-rendered change.` No pixels change; the before/after CLI reproduction is the flow proof.
<!-- evidence-row:backend-logs -->
- [x] `N/A - client-side validation shim.` This path is browser-bundle validation; it never reaches the server. Parity with the backend's real `cron-parser@5.7.0` is shown in the side-by-side table.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - client-side validation shim with no network or console I/O; the full before/after parser reproduction (driving the same parse() the Triggers form calls) is inline in Evidence Details
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the domain artifact for a parser is its accept/reject verdict, shown inline as the before/after reproduction, the shim-vs-cron-parser@5.7.0 parity table, and the verbose 18-case test + mutation output in Evidence Details
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface in this diff.`

# Evidence Details

## Reproduction: before / after (the shim probe from the issue)

Probe runs `CronExpressionParser.parse(expr)` against the shim for each sample.

**BEFORE (shim on `origin/develop`):**
```
REJECT: 0,30 * * * * -> Invalid cron field: 0,30
REJECT: 0 9 * * 1-5 -> Invalid cron field: 1-5
REJECT: 0 0-11/2 * * * -> Invalid cron field: 0-11/2
ACCEPT: */5 * * * *
REJECT: 15,45 8-17 * * 1-5 -> Invalid cron field: 15,45
ACCEPT: 0 9 * * *
REJECT: 60 * * * * -> Invalid cron field: 60
REJECT: 5-2 * * * * -> Invalid cron field: 5-2
REJECT: */0 * * * * -> Invalid cron field: */0
REJECT: abc * * * * -> Invalid cron field: abc
```

**AFTER (this PR):**
```
ACCEPT: 0,30 * * * *
ACCEPT: 0 9 * * 1-5
ACCEPT: 0 0-11/2 * * *
ACCEPT: */5 * * * *
ACCEPT: 15,45 8-17 * * 1-5
ACCEPT: 0 9 * * *
REJECT: 60 * * * * -> Invalid cron field: 60
REJECT: 5-2 * * * * -> Invalid cron field: 5-2
REJECT: */0 * * * * -> Invalid cron field: */0
REJECT: abc * * * * -> Invalid cron field: abc
```

The four `REJECT` lines from the issue (`0,30`, `1-5`, `0-11/2`, `15,45`) become
`ACCEPT`; every invalid input stays rejected.

## Parity: shim (after) vs `cron-parser@5.7.0` (the real backend parser)

| Expression | shim BEFORE | shim AFTER | real cron-parser@5.7.0 |
| --- | --- | --- | --- |
| `0,30 * * * *` | ❌ REJECT | ✅ ACCEPT | ✅ ACCEPT |
| `0 9 * * 1-5` | ❌ REJECT | ✅ ACCEPT | ✅ ACCEPT |
| `0 0-11/2 * * *` | ❌ REJECT | ✅ ACCEPT | ✅ ACCEPT |
| `15,45 8-17 * * 1-5` | ❌ REJECT | ✅ ACCEPT | ✅ ACCEPT |
| `*/5 * * * *` | ✅ ACCEPT | ✅ ACCEPT | ✅ ACCEPT |
| `0 9 * * *` | ✅ ACCEPT | ✅ ACCEPT | ✅ ACCEPT |
| `60 * * * *` | ❌ REJECT | ❌ REJECT | ❌ REJECT (out of range) |
| `5-2 * * * *` | ❌ REJECT | ❌ REJECT | ❌ REJECT (inverted range) |
| `*/0 * * * *` | ❌ REJECT | ❌ REJECT | ❌ REJECT (zero step) |
| `abc * * * *` | ❌ REJECT | ❌ REJECT | ❌ REJECT (garbage) |

The shim's accept/reject verdict now matches the real parser for every 5-field
sample. (The shim intentionally keeps stricter 5-field-count validation: it
rejects `0 9 * *`, which the real parser would zero-fill — unchanged by this PR.)

## User path trace (why this shim is the one the form uses)

1. `packages/ui/src/components/pages/trigger-form-utils.ts` →
   `import { CronExpressionParser } from "cron-parser"`; `validateCronExpression()`
   and `nextRunsForCron()` call `CronExpressionParser.parse(...)`.
2. `packages/app/vite.config.ts` aliases `cron-parser` → `src/shims/cron-parser.ts`
   for the entire app bundle, so in the shipped web/native app the form's
   `parse()` resolves to this shim.
3. `validateForm()` (same file) surfaces the shim's thrown message to the user as
   `Cron error: Invalid cron field: …`, blocking trigger creation.

## Unit test + mutation check

New file `packages/app/src/shims/cron-parser.test.ts` (18 cases: valid
list/range/step accepts, out-of-range/inverted/zero-step/garbage/empty/4-field
rejects, and the `next().toDate()` iterator surface).

```
$ vitest run --config vitest.config.ts src/shims/cron-parser.test.ts
 Test Files  1 passed (1)
      Tests  18 passed (18)
```

Mutation check — reverting `parseField` to the old star/step/bare-int-only body
turns the accept cases red, proving the tests bind the fix:

```
 ❯ src/shims/cron-parser.test.ts (18 tests | 6 failed)
     × accepts valid recurring schedule 0,30 * * * *
     × accepts valid recurring schedule 0 9 * * 1-5
     × accepts valid recurring schedule 0 0-11/2 * * *
     × accepts valid recurring schedule 15,45 8-17 * * 1-5
     × accepts valid recurring schedule 0-59 * * * *
     × keeps the iterator surface the Triggers preview consumes
      Tests  6 failed | 12 passed (18)
```

## Backend + frontend logs

`N/A - client-side validation shim` (no server path). Frontend equivalent = the
before/after reproduction above, which drives the same `parse()` the form calls.

## Screenshots (before / after) + video walkthrough

`N/A - non-rendered change.` The diff is a `.ts` parser shim, not a rendered
surface; no pixels change. The observable effect is the accept/reject verdict
captured in the reproduction and parity table.

## Audio / voice walkthrough

`N/A - no voice/audio surface.`

## Known gaps / failures

- **`bun run verify` / full workspace typecheck not fully runnable here.** The
  app package typecheck (`tsc -p tsconfig.typecheck.json`) reports **0**
  app-internal errors after building `@elizaos/app-core` + deps; the only
  remaining errors are in *other* packages from ungenerated/unbuilt artifacts on
  this contributor machine (`@elizaos/plugin-todos` not built,
  `homepage` `@/generated/release-data` not generated). None touch the changed
  files. Focused package `test`, `typecheck` (scoped), and Biome `lint --write`
  on the two changed files pass.
- **`bun install` required `--minimum-release-age=0`** to bypass a local (not
  repo) bunfig min-release-age gate on an unrelated recent transitive dep; this
  is environment-only and does not affect the change.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza"} -->


