### PR TITLE
fix(ui): preserve payment CTA accent hover

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.test.tsx
@@ -56,8 +56,14 @@ vi.mock("../../../lib/api-client", () => ({
 }));
 
 vi.mock("../../../../components/ui/button", () => ({
-  Button: ({ children, ...props }: ComponentProps<"button">) => (
-    <button {...props}>{children}</button>
+  Button: ({
+    children,
+    variant,
+    ...props
+  }: ComponentProps<"button"> & { variant?: string }) => (
+    <button data-variant={variant} {...props}>
+      {children}
+    </button>
   ),
 }));
 
@@ -126,6 +132,9 @@ describe("PaymentRequestPage public DTO contract", () => {
       name: /pay with wallet/i,
     });
     expect((button as HTMLButtonElement).disabled).toBe(false);
+    expect(button.getAttribute("data-variant")).toBe("surfaceAccent");
+    expect(button.className).not.toContain("hover:bg-bg-hover");
+    expect(button.className).not.toContain("bg-accent-subtle");
     expect(screen.queryByText(/wallet_native/)).toBeNull();
   });
 

--- a/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.tsx
@@ -424,11 +424,11 @@ export default function PaymentRequestPage() {
 
           <div className="mt-8">
             <Button
-              variant="ghost"
+              variant="surfaceAccent"
               type="button"
               disabled={!canPay || isPaying}
               onClick={beginCheckout}
-              className="flex w-full items-center justify-center gap-3 bg-accent-subtle px-4 py-4 text-txt transition hover:bg-bg-hover disabled:pointer-events-none disabled:opacity-30"
+              className="flex h-auto w-full items-center justify-center gap-3 px-4 py-4 disabled:opacity-30"
             >
               {isPaying ? (
                 <Loader2 className="h-5 w-5 animate-spin" />


### PR DESCRIPTION
## Summary

- use the shared `surfaceAccent` button variant for payment-request CTAs
- remove the page-local gray hover override while preserving CTA sizing and disabled opacity
- add regression coverage for the semantic variant and absence of the conflicting local classes

## Root cause

The payment request page selected the shared button's `ghost` variant, then reconstructed the accent rest state locally with `bg-accent-subtle`. Its local `hover:bg-bg-hover` class replaced that accent with the neutral gray hover token. The shared `surfaceAccent` variant already owns the intended accent-subtle rest and darker-accent hover states.

## Validation

- `bun run --cwd packages/ui test -- src/cloud/public-pages/pages/payment/payment-request-page.test.tsx` — 12/12 passed on rebased head
- `bunx @biomejs/biome check packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.tsx packages/ui/src/cloud/public-pages/pages/payment/payment-request-page.test.tsx` — passed
- `git diff --check origin/develop...HEAD` — passed
- `bun run --cwd packages/app audit:cloud --grep payment-request` — 2/2 desktop/mobile route cases passed with zero console errors, blue-color findings, hover-rule violations, or screenshot-quality findings
- manually inspected desktop and mobile rest/hover captures from the exact-base test-auth renderer; the CTA remains accent-colored at rest and darkens on hover

The first cold desktop audit iteration captured the startup screen even though the non-strict audit marked it `needs-eyeball`. A repeated warm iteration under the same server produced the complete desktop page used for manual inspection; no boot-screen artifact is being presented as visual evidence.

Closes #20337
