### PR TITLE
fix: enforce settings secret encryption at production persistence boundaries

### DIFF
--- a/packages/agent/src/services/character-persistence.encryption.test.ts
+++ b/packages/agent/src/services/character-persistence.encryption.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Proves the character-persistence sink encrypts secret settings before they
+ * are embedded in the agent row's `metadata.character` snapshot. The harness is
+ * integration-backed: it drives the real ElizaCharacterPersistenceService with a
+ * temp-dir eliza.json and a captured `updateAgent`, so the assertions exercise
+ * the actual persistence path rather than a re-implementation. Secret values are
+ * synthetic; nothing real is leaked.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type Character,
+  clearSaltCache,
+  decryptedCharacter,
+  type IAgentRuntime,
+  type UUID,
+} from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ElizaCharacterPersistenceService } from "./character-persistence.ts";
+
+const TEST_SALT = "character-persistence-encryption-test-salt";
+const OPENAI_SECRET = "sk-openai-persistence-do-not-leak-abc123";
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+
+describe("ElizaCharacterPersistenceService secret encryption", () => {
+  let tempDir: string;
+  let previousSalt: string | undefined;
+  let previousConfigPath: string | undefined;
+  let previousPersistPath: string | undefined;
+  let previousStateDir: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "char-persist-enc-"));
+    previousSalt = process.env.SECRET_SALT;
+    previousConfigPath = process.env.ELIZA_CONFIG_PATH;
+    previousPersistPath = process.env.ELIZA_PERSIST_CONFIG_PATH;
+    previousStateDir = process.env.ELIZA_STATE_DIR;
+    process.env.SECRET_SALT = TEST_SALT;
+    process.env.ELIZA_CONFIG_PATH = join(tempDir, "eliza.json");
+    process.env.ELIZA_PERSIST_CONFIG_PATH = join(tempDir, "eliza.persist.json");
+    process.env.ELIZA_STATE_DIR = tempDir;
+    clearSaltCache();
+  });
+
+  afterEach(() => {
+    const restore = (key: string, value: string | undefined) => {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    };
+    restore("SECRET_SALT", previousSalt);
+    restore("ELIZA_CONFIG_PATH", previousConfigPath);
+    restore("ELIZA_PERSIST_CONFIG_PATH", previousPersistPath);
+    restore("ELIZA_STATE_DIR", previousStateDir);
+    clearSaltCache();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("encrypts settings.secrets in the persisted metadata without mutating the input", async () => {
+    const character: Character = {
+      name: "Persisted Secret Keeper",
+      bio: ["An agent whose secrets must never land in metadata as plaintext."],
+      settings: {
+        defaultTemperature: 0.3,
+        secrets: { OPENAI_API_KEY: OPENAI_SECRET },
+      },
+    };
+
+    let capturedMetadata: Record<string, unknown> | undefined;
+    const runtime = {
+      agentId: AGENT_ID,
+      character,
+      updateAgent: async (
+        _id: UUID,
+        data: { metadata?: Record<string, unknown> },
+      ) => {
+        capturedMetadata = data.metadata;
+        return true;
+      },
+      createMemory: async () => AGENT_ID,
+    } as unknown as IAgentRuntime;
+
+    const service = new ElizaCharacterPersistenceService(runtime);
+    const result = await service.persistCharacter({ character });
+    expect(result.success).toBe(true);
+
+    const persisted = capturedMetadata?.character as {
+      settings?: {
+        secrets?: Record<string, string>;
+        defaultTemperature?: number;
+      };
+    };
+    const persistedSecret = persisted.settings?.secrets?.OPENAI_API_KEY;
+
+    // No plaintext secret is embedded in the persisted metadata snapshot.
+    expect(JSON.stringify(capturedMetadata)).not.toContain(OPENAI_SECRET);
+    expect(persistedSecret).toMatch(/^v2:/);
+    // Non-secret settings pass through untouched.
+    expect(persisted.settings?.defaultTemperature).toBe(0.3);
+
+    // The persisted ciphertext round-trips back to the original plaintext.
+    const roundTripped = decryptedCharacter(persisted as Character);
+    expect(roundTripped.settings?.secrets?.OPENAI_API_KEY).toBe(OPENAI_SECRET);
+
+    // The caller's character object is never mutated.
+    expect(character.settings?.secrets?.OPENAI_API_KEY).toBe(OPENAI_SECRET);
+  });
+});

--- a/packages/agent/src/services/character-persistence.ts
+++ b/packages/agent/src/services/character-persistence.ts
@@ -6,7 +6,13 @@
  * shape the config/DB payloads; `persistCharacter` applies all three and returns
  * a success/error result rather than throwing.
  */
-import { type IAgentRuntime, logger, Service } from "@elizaos/core";
+import {
+  type Character,
+  encryptedCharacter,
+  type IAgentRuntime,
+  logger,
+  Service,
+} from "@elizaos/core";
 import {
   type ElizaConfig,
   loadElizaConfig,
@@ -193,7 +199,13 @@ export class ElizaCharacterPersistenceService extends Service {
       const nextAgent = syncCharacterIntoConfig(config, runtimeCharacter);
       saveElizaConfig(config);
 
-      const persistedCharacter = buildPersistedCharacterData(runtimeCharacter);
+      // Encrypt secret containers before embedding the character snapshot in the
+      // agent row's metadata. runtime.updateAgent only encrypts top-level
+      // agent.settings/secrets, so this nested snapshot must pass through the
+      // canonical helper itself to avoid persisting plaintext secrets at rest.
+      const persistedCharacter = encryptedCharacter(
+        buildPersistedCharacterData(runtimeCharacter) as Character,
+      ) as unknown as Record<string, unknown>;
       const runtimeMetadata =
         runtimeCharacter.metadata &&
         typeof runtimeCharacter.metadata === "object" &&

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -493,12 +493,14 @@ export function encryptedCharacter(character: Character): Character {
 /**
  * Decrypts sensitive data in a Character object
  * @param {Character} character - The character object with encrypted secrets
- * @param {IAgentRuntime} runtime - The runtime information needed for salt generation
+ * @param {IAgentRuntime} [_runtime] - Unused; retained for call-site compatibility.
+ *   The salt is resolved through getSalt(), so persistence adapters that lack a
+ *   runtime handle can call this at their read boundary.
  * @returns {Character} - A copy of the character with decrypted secrets
  */
 export function decryptedCharacter(
 	character: Character,
-	_runtime: IAgentRuntime,
+	_runtime?: IAgentRuntime,
 ): Character {
 	const decryptedChar: Character = {
 		...character,

--- a/plugins/plugin-sql/src/__tests__/integration/agent-secret-encryption.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/agent-secret-encryption.real.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Real-database proof that the shared SQL adapter is the canonical at-rest
+ * encryption boundary for agent secret settings. Every assertion runs against a
+ * live PGlite (or Postgres) adapter — createAgent/updateAgent encrypt eligible
+ * secret values before write, mapAgentRow decrypts them on read, and the RAW
+ * stored JSON is inspected directly to prove no configured plaintext secret is
+ * persisted. Covers create, update, restart/reload, idempotency, migration on
+ * write of pre-existing plaintext, missing-settings, caller-input non-mutation,
+ * and wrong-salt fail-closed behavior.
+ */
+import { type Agent, clearSaltCache, type UUID } from "@elizaos/core";
+import { eq } from "drizzle-orm";
+import { v4 as uuidv4 } from "uuid";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { PgDatabaseAdapter } from "../../pg/adapter";
+import type { PgliteDatabaseAdapter } from "../../pglite/adapter";
+import { agentTable } from "../../schema";
+import { createIsolatedTestDatabase } from "../test-helpers";
+
+const TEST_SALT = "agent-secret-encryption-test-salt";
+const OPENAI_SECRET = "sk-openai-do-not-leak-abcdef1234567890";
+const ANTHROPIC_SECRET = "sk-anthropic-do-not-leak-0987654321";
+
+const agentDefaults = {
+  templates: {},
+  messageExamples: [],
+  postExamples: [],
+  topics: [],
+  adjectives: [],
+  knowledge: [],
+  plugins: [],
+  style: { all: [], chat: [], post: [] },
+};
+
+function makeAgent(overrides: Partial<Agent>): Agent {
+  return {
+    ...agentDefaults,
+    id: uuidv4() as UUID,
+    name: "Secret Boundary Agent",
+    username: "secret_boundary",
+    bio: ["An agent used to prove settings-secret encryption at rest."],
+    system: "You are a helpful assistant.",
+    settings: {},
+    secrets: {},
+    enabled: true,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  } as Agent;
+}
+
+describe("Agent secret settings encryption at the SQL persistence boundary", () => {
+  let adapter: PgliteDatabaseAdapter | PgDatabaseAdapter;
+  let cleanup: () => Promise<void>;
+  let previousSalt: string | undefined;
+
+  beforeAll(async () => {
+    const setup = await createIsolatedTestDatabase("agent-secret-encryption");
+    adapter = setup.adapter;
+    cleanup = setup.cleanup;
+  });
+
+  afterAll(async () => {
+    if (cleanup) await cleanup();
+  });
+
+  beforeEach(() => {
+    previousSalt = process.env.SECRET_SALT;
+    process.env.SECRET_SALT = TEST_SALT;
+    clearSaltCache();
+  });
+
+  afterEach(() => {
+    if (previousSalt === undefined) delete process.env.SECRET_SALT;
+    else process.env.SECRET_SALT = previousSalt;
+    clearSaltCache();
+  });
+
+  const readRawSettings = async (id: UUID): Promise<Record<string, unknown>> => {
+    const db = adapter.getDatabase() as unknown as {
+      select: () => {
+        from: (table: typeof agentTable) => {
+          where: (cond: unknown) => Promise<Array<{ settings: unknown; secrets: unknown }>>;
+        };
+      };
+    };
+    const rows = await db.select().from(agentTable).where(eq(agentTable.id, id));
+    return (rows[0] ?? {}) as Record<string, unknown>;
+  };
+
+  it("createAgent stores no plaintext secret at rest and getAgent resolves plaintext", async () => {
+    const input = makeAgent({
+      settings: {
+        defaultTemperature: 0.4,
+        secrets: { OPENAI_API_KEY: OPENAI_SECRET, ANTHROPIC_API_KEY: ANTHROPIC_SECRET },
+      },
+    });
+
+    const created = await adapter.createAgent(input);
+    expect(created).toBe(true);
+
+    // RAW stored JSON must not contain any configured plaintext secret value.
+    const raw = await readRawSettings(input.id as UUID);
+    const rawJson = JSON.stringify(raw);
+    expect(rawJson).not.toContain(OPENAI_SECRET);
+    expect(rawJson).not.toContain(ANTHROPIC_SECRET);
+    const rawSettings = raw.settings as {
+      secrets?: Record<string, string>;
+      defaultTemperature?: number;
+    };
+    expect(rawSettings.secrets?.OPENAI_API_KEY).toMatch(/^v2:/);
+    expect(rawSettings.secrets?.ANTHROPIC_API_KEY).toMatch(/^v2:/);
+    // Non-secret settings stay untouched.
+    expect(rawSettings.defaultTemperature).toBe(0.4);
+
+    // Runtime read boundary resolves the original plaintext.
+    const loaded = await adapter.getAgent(input.id as UUID);
+    expect(loaded?.settings?.secrets?.OPENAI_API_KEY).toBe(OPENAI_SECRET);
+    expect(loaded?.settings?.secrets?.ANTHROPIC_API_KEY).toBe(ANTHROPIC_SECRET);
+  });
+
+  it("does not mutate the caller's input object", async () => {
+    const secretsRef = { OPENAI_API_KEY: OPENAI_SECRET };
+    const input = makeAgent({ settings: { secrets: secretsRef } });
+
+    await adapter.createAgent(input);
+
+    // The exact object the caller passed must still hold plaintext.
+    expect(secretsRef.OPENAI_API_KEY).toBe(OPENAI_SECRET);
+    expect(input.settings?.secrets?.OPENAI_API_KEY).toBe(OPENAI_SECRET);
+  });
+
+  it("updateAgent encrypts newly written secrets and getAgent resolves them", async () => {
+    const input = makeAgent({ settings: { secrets: {} } });
+    await adapter.createAgent(input);
+
+    const ok = await adapter.updateAgent(input.id as UUID, {
+      settings: { secrets: { OPENAI_API_KEY: OPENAI_SECRET } },
+    });
+    expect(ok).toBe(true);
+
+    const raw = await readRawSettings(input.id as UUID);
+    expect(JSON.stringify(raw)).not.toContain(OPENAI_SECRET);
+    const rawSettings = raw.settings as { secrets?: Record<string, string> };
+    expect(rawSettings.secrets?.OPENAI_API_KEY).toMatch(/^v2:/);
+
+    const loaded = await adapter.getAgent(input.id as UUID);
+    expect(loaded?.settings?.secrets?.OPENAI_API_KEY).toBe(OPENAI_SECRET);
+  });
+
+  it("is idempotent — an already-encrypted value is not double-encrypted", async () => {
+    const input = makeAgent({ settings: { secrets: { OPENAI_API_KEY: OPENAI_SECRET } } });
+    await adapter.createAgent(input);
+
+    // Grab the stored ciphertext and feed it straight back through updateAgent.
+    const firstRaw = await readRawSettings(input.id as UUID);
+    const cipher = (firstRaw.settings as { secrets: Record<string, string> }).secrets
+      .OPENAI_API_KEY;
+    expect(cipher).toMatch(/^v2:/);
+
+    const ok = await adapter.updateAgent(input.id as UUID, {
+      settings: { secrets: { OPENAI_API_KEY: cipher } },
+    });
+    expect(ok).toBe(true);
+
+    const secondRaw = await readRawSettings(input.id as UUID);
+    const stored = (secondRaw.settings as { secrets: Record<string, string> }).secrets
+      .OPENAI_API_KEY;
+    // Still a single v2 envelope (four colon-delimited parts), not a nested one.
+    expect(stored.split(":")).toHaveLength(4);
+    const loaded = await adapter.getAgent(input.id as UUID);
+    expect(loaded?.settings?.secrets?.OPENAI_API_KEY).toBe(OPENAI_SECRET);
+  });
+
+  it("migrates pre-existing plaintext-at-rest to ciphertext on the next write", async () => {
+    const id = uuidv4() as UUID;
+    // Simulate a legacy row written before encryption existed by inserting
+    // plaintext directly, bypassing the adapter's encrypt-on-write boundary.
+    const db = adapter.getDatabase() as unknown as {
+      insert: (table: typeof agentTable) => {
+        values: (v: Record<string, unknown>) => Promise<unknown>;
+      };
+    };
+    await db.insert(agentTable).values({
+      id,
+      name: "Legacy Plaintext Agent",
+      bio: ["legacy"],
+      settings: { secrets: { OPENAI_API_KEY: OPENAI_SECRET } },
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    // Plaintext read still works (decrypt passes non-ciphertext through).
+    const beforeMigration = await adapter.getAgent(id);
+    expect(beforeMigration?.settings?.secrets?.OPENAI_API_KEY).toBe(OPENAI_SECRET);
+
+    // Any subsequent write encrypts the legacy plaintext.
+    await adapter.updateAgent(id, { settings: { secrets: { OPENAI_API_KEY: OPENAI_SECRET } } });
+    const raw = await readRawSettings(id);
+    expect(JSON.stringify(raw)).not.toContain(OPENAI_SECRET);
+    expect((raw.settings as { secrets: Record<string, string> }).secrets.OPENAI_API_KEY).toMatch(
+      /^v2:/
+    );
+  });
+
+  it("handles agents with no settings/secrets without error", async () => {
+    const input = makeAgent({ settings: {}, secrets: {} });
+    const created = await adapter.createAgent(input);
+    expect(created).toBe(true);
+    const loaded = await adapter.getAgent(input.id as UUID);
+    expect(loaded).not.toBeNull();
+    expect(loaded?.name).toBe("Secret Boundary Agent");
+  });
+
+  it("fails closed on read when the salt is wrong instead of exposing ciphertext", async () => {
+    const input = makeAgent({ settings: { secrets: { OPENAI_API_KEY: OPENAI_SECRET } } });
+    await adapter.createAgent(input);
+
+    // Rotate to the wrong salt: decryption must throw, never return ciphertext
+    // as a usable value.
+    process.env.SECRET_SALT = "a-different-wrong-salt";
+    clearSaltCache();
+    await expect(adapter.getAgent(input.id as UUID)).rejects.toThrow(
+      /Failed to decrypt secret setting/
+    );
+  });
+});

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -15,6 +15,7 @@ import {
   type AgentRunSummaryResult,
   type AppendConnectorAccountAuditEventParams,
   ChannelType,
+  type Character,
   type Component,
   type ConnectorAccountAuditEventRecord,
   type ConnectorAccountCredentialRefRecord,
@@ -35,11 +36,13 @@ import {
   type DocumentListQueryParams,
   type DocumentListQueryResult,
   type DocumentMutationResult,
+  decryptedCharacter,
   documentMutationSnapshotMatches,
   documentRoleHasGlobalVisibility,
   ElizaError,
   type EntitiesForRoomsResult,
   type Entity,
+  encryptedCharacter,
   type GetConnectorAccountCredentialRefParams,
   type GetConnectorAccountParams,
   type IDatabaseAdapter,
@@ -451,7 +454,10 @@ function mapAgentRow(row: AgentRow): Agent {
     createdAt: row.createdAt.getTime(),
     updatedAt: row.updatedAt.getTime(),
   };
-  return agent;
+  // Decrypt secret containers at the single storage read boundary so callers
+  // (runtime merge, APIs) always observe plaintext while values stay encrypted
+  // at rest. Plaintext-at-rest rows pass through untouched (migration-on-write).
+  return decryptedCharacter(agent) as Agent;
 }
 
 import {
@@ -993,9 +999,15 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
           }
         }
 
+        // Encrypt secret containers at the persistence boundary using the
+        // canonical helper. encryptedCharacter returns a copy, so the caller's
+        // agent object is never mutated and already-encrypted values are
+        // idempotently left untouched.
+        const agentToStore = encryptedCharacter(agent) as Agent;
+
         await this.db.transaction(async (tx) => {
           const agentData = {
-            ...agent,
+            ...agentToStore,
             createdAt: new Date(
               typeof agent.createdAt === "bigint"
                 ? Number(agent.createdAt)
@@ -1050,14 +1062,34 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         }
 
         await this.db.transaction(async (tx) => {
-          // Handle settings update if present
+          // Convert numeric timestamps to Date objects for database storage
+          // The Agent interface uses numbers, but the database schema expects Date objects.
+          // Build updateData from a shallow copy so the caller's agent object is
+          // not mutated by the settings merge or the encryption boundary.
+          const updateData: Record<string, unknown> = { ...agent };
+
+          // Handle settings update if present. The merge reads the (encrypted)
+          // row and overlays the incoming values before persistence.
           if (agent.settings) {
-            agent.settings = await this.mergeAgentSettings(tx, agentId, agent.settings);
+            updateData.settings = await this.mergeAgentSettings(tx, agentId, agent.settings);
           }
 
-          // Convert numeric timestamps to Date objects for database storage
-          // The Agent interface uses numbers, but the database schema expects Date objects
-          const updateData: Record<string, unknown> = { ...agent };
+          // Encrypt secret containers at the persistence boundary using the
+          // canonical helper. encryptedCharacter copies before transforming, so
+          // no plaintext secret is written at rest and already-encrypted values
+          // (e.g. keys merged from the existing row) are not double-encrypted.
+          if (updateData.settings !== undefined || updateData.secrets !== undefined) {
+            const encryptedForWrite = encryptedCharacter({
+              name: "",
+              ...(updateData as Partial<Character>),
+            } as Character);
+            if (updateData.settings !== undefined) {
+              updateData.settings = encryptedForWrite.settings;
+            }
+            if (updateData.secrets !== undefined) {
+              updateData.secrets = encryptedForWrite.secrets;
+            }
+          }
 
           if (updateData.createdAt) {
             if (typeof updateData.createdAt === "number") {


### PR DESCRIPTION
# Relates to

Closes #20354

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync. The focused package gates (typecheck, Biome, tests) for every affected package pass; see **Known gaps / failures** for the full `bun run verify` note.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below (raw at-rest ciphertext vs decrypted reload).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@8d932dd1494db6dc4842dd42cd5a4b11e75d6525:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` — see **Known gaps / failures** (ran focused package gates instead; full repo verify not completed on this machine).

# Risks

Low. The change is confined to the persistence boundary of the shared SQL
adapter plus the character-persistence service. Encryption is applied
immediately before write and decryption immediately after read, so in-memory
runtime code continues to observe plaintext exactly as before. The transform is
idempotent and pre-existing plaintext-at-rest passes through reads untouched
(migrating to ciphertext on the next write), so no data-migration step is
required and no existing row is broken. Wrong-salt reads fail closed (typed
error) rather than returning ciphertext as a usable value.

# Background

## What does this PR do?

`encryptedCharacter` / `decryptedCharacter` in `packages/core/src/settings.ts`
knew how to transform `character.settings.secrets`, but **no production
persistence path invoked them** (a repo-wide search found zero non-test
callers). Secret settings were therefore written to storage as plaintext at
rest.

This PR wires the existing canonical helpers into every real character
persistence sink — without duplicating any crypto logic:

- **`plugins/plugin-sql/src/base.ts` (the single storage boundary).**
  `createAgent` and `updateAgent` now run the agent through `encryptedCharacter`
  before write, and `mapAgentRow` decrypts through `decryptedCharacter` on read
  (`getAgent` / `getAgentsByIds`). Every agent write in the framework routes
  through these two methods, so this is the one canonical encrypt-on-write /
  decrypt-on-read boundary. `updateAgent` encrypts the merged result, so values
  merged from the existing (encrypted) row are not double-encrypted and legacy
  plaintext migrates to ciphertext on write.
- **`packages/agent/src/services/character-persistence.ts`.** This service
  embeds a character snapshot in the agent row's `metadata.character`, which the
  adapter's top-level `agent.settings` encryption does not reach. It now runs
  that snapshot through the same `encryptedCharacter` helper before embedding.
- **`packages/core/src/settings.ts`.** `decryptedCharacter`'s `runtime`
  parameter is now optional (it was already unused — the salt comes from
  `getSalt()`), so a read boundary without a runtime handle can decrypt.

Neither path mutates the caller's input object (the helpers spread-copy). The
`agents` table has no top-level `secrets` column; secrets live in
`settings.secrets`, which is exactly what the boundary protects.

## What kind of change is this?

Bug fix (non-breaking change which fixes a security-relevant defect).

# Documentation changes needed?

No. Behavior of the public read/write contract is unchanged (callers still see
plaintext); only the at-rest representation changes.

# Testing

## Where should a reviewer start?

`plugins/plugin-sql/src/__tests__/integration/agent-secret-encryption.real.test.ts`
— a real PGlite (or Postgres, if `POSTGRES_URL` is set) roundtrip that inspects
the **raw** stored JSON directly (bypassing the decrypt boundary) and proves no
configured plaintext secret is present, then reloads through `getAgent` and
proves the original value resolves back to plaintext.

## Detailed testing steps

```bash
# Real PGlite roundtrip (create/update/idempotency/migration/missing-settings/
# non-mutation/wrong-salt), from plugins/plugin-sql/src:
VITEST_LANE=post-merge bunx vitest run \
  __tests__/integration/agent-secret-encryption.real.test.ts

# Character-persistence sink encryption:
bunx vitest run --config packages/agent/vitest.config.ts \
  packages/agent/src/services/character-persistence.encryption.test.ts

# Core helper regression suite:
bunx vitest run --config packages/core/vitest.config.ts \
  packages/core/src/settings.encryption.test.ts
```

# Evidence Gate

<!-- evidence-head:1293f822dc344a1813f4c3ee935ead00a7e54231 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: `N/A - backend persistence-layer change; no rendered UI surface is touched.`
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `N/A - backend persistence-layer change; no rendered UI surface is touched.`
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - backend persistence-layer change; no UI flow to record.`
<!-- evidence-row:backend-logs -->
- [x] Focused test output at the reviewed head `1293f822dc` (real code path firing end to end):
<details><summary>plugin-sql real PGlite roundtrip — 7 passed</summary>
<pre>
 ✓ createAgent stores no plaintext secret at rest and getAgent resolves plaintext
 ✓ does not mutate the caller's input object
 ✓ updateAgent encrypts newly written secrets and getAgent resolves them
 ✓ is idempotent — an already-encrypted value is not double-encrypted
 ✓ migrates pre-existing plaintext-at-rest to ciphertext on the next write
 ✓ handles agents with no settings/secrets without error
 ✓ fails closed on read when the salt is wrong instead of exposing ciphertext
 Test Files  1 passed (1)   Tests  7 passed (7)
 packages/agent character-persistence.encryption.test.ts   Tests 1 passed (1)
 packages/core  settings.encryption.test.ts               Tests 8 passed (8)
 plugin-sql agent.real.test.ts (regression)               Tests 30 passed (30)
 typecheck core=Done! plugin-sql=ok ; biome 5 files no fixes
</pre>
</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: `N/A - no frontend code path involved.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model behavior changes.`
<!-- evidence-row:domain-artifacts -->
- [x] Raw at-rest ciphertext vs decrypted reload from a real PGlite adapter (`SECRET_SALT=evidence-demo-salt`):
<details><summary>no plaintext at rest; original resolves on reload</summary>
<pre>
Configured plaintext secret : sk-live-demo-SUPERSECRET-value-1234567890
RAW stored settings JSON    : {"secrets":{"OPENAI_API_KEY":"v2:8e3d56d674aa5122b5f1b9ad:de70e889eae97d4508548ab67cb71e4bb33ade6c89a16197437ac615ce709c292d543fbdc3de0f57a1:5f35b10127992b4994888d163592422e"},"defaultTemperature":0.4}
Raw JSON contains plaintext?: false
getAgent() resolved secret  : sk-live-demo-SUPERSECRET-value-1234567890
</pre>
</details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model behavior changes.`

## Backend + frontend logs

Focused test output at the exact reviewed head (`1293f822dc`):

<details><summary>plugin-sql real PGlite roundtrip — 7 passed</summary>

```
 ✓ createAgent stores no plaintext secret at rest and getAgent resolves plaintext
 ✓ does not mutate the caller's input object
 ✓ updateAgent encrypts newly written secrets and getAgent resolves them
 ✓ is idempotent — an already-encrypted value is not double-encrypted
 ✓ migrates pre-existing plaintext-at-rest to ciphertext on the next write
 ✓ handles agents with no settings/secrets without error
 ✓ fails closed on read when the salt is wrong instead of exposing ciphertext

 Test Files  1 passed (1)
      Tests  7 passed (7)
```
</details>

<details><summary>character-persistence sink + core helper regression</summary>

```
packages/agent .../character-persistence.encryption.test.ts
 Test Files  1 passed (1)
      Tests  1 passed (1)

packages/core  .../settings.encryption.test.ts
 Test Files  1 passed (1)
      Tests  8 passed (8)
```
</details>

<details><summary>typecheck + Biome lint (affected packages)</summary>

```
$ bun run --cwd packages/core typecheck        -> Done! (no errors)
$ bun run --cwd plugins/plugin-sql typecheck   -> tsc --noEmit (no errors)
$ biome check <5 changed files>                -> Checked 5 files. No fixes applied.
```

Note: `bun run --cwd packages/agent typecheck` reports only pre-existing
`Cannot find module '@elizaos/plugin-*'` errors from unbuilt optional sibling
plugins (capacitor-bridge, wallet, video, vision, notes, todos) and an
unrelated `findLast` lib-target error in `plugin-agent-orchestrator`. None
reference the files changed here.
</details>

Frontend: `N/A - no frontend code path involved.`

## Screenshots (before / after) + video walkthrough

`N/A - backend persistence-layer change; no rendered UI surface is touched.`

### Before
`N/A`
### After
`N/A`
### Walkthrough video
`N/A - no UI flow.`

## Audio / voice walkthrough

`N/A - not a voice/transcript/TTS/STT change.`

## Domain artifact — raw at-rest ciphertext vs decrypted reload

Generated from a real PGlite adapter (`SECRET_SALT=evidence-demo-salt`). The raw
stored `settings` JSON holds only a `v2:` AES-256-GCM envelope; the configured
plaintext is absent at rest yet resolves correctly through the runtime read
boundary:

```
Configured plaintext secret : sk-live-demo-SUPERSECRET-value-1234567890
RAW stored settings JSON    : {"secrets":{"OPENAI_API_KEY":"v2:8e3d56d674aa5122b5f1b9ad:de70e889eae97d4508548ab67cb71e4bb33ade6c89a16197437ac615ce709c292d543fbdc3de0f57a1:5f35b10127992b4994888d163592422e"},"defaultTemperature":0.4}
Raw JSON contains plaintext?: false
getAgent() resolved secret  : sk-live-demo-SUPERSECRET-value-1234567890
```

(The secret above is a synthetic demo value, not a real credential.)

## Known gaps / failures

- **`bun run verify` (full repo gate) was not completed on this machine.** It
  runs parity/dependency/type/lint/audit across the entire monorepo and requires
  every optional plugin to be built; on this constrained worktree it is not
  reliably runnable end to end. Instead I ran the focused gates for each affected
  package: `packages/core` typecheck + `settings.encryption.test.ts`;
  `plugins/plugin-sql` typecheck + the new real PGlite roundtrip **and** the
  existing `agent.real.test.ts` (30 passed, no regressions); the
  `packages/agent` character-persistence test; and Biome on all five changed
  files. All pass at the reviewed head.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@8d932dd1494db6dc4842dd42cd5a4b11e75d6525:packages/skills/skills/contribute-to-eliza"} -->
