### PR TITLE
fix(plugin-slack): chunks exceed the 4000-char cap when a break character lands on the boundary

### DIFF
--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -21,6 +21,7 @@ import {
   formatSlackUserMention,
   markdownToSlackMrkdwn,
   parseSlackMessagePermalink,
+  splitSlackText,
   stripSlackFormatting,
   truncateText,
 } from "./formatting.ts";
@@ -152,6 +153,20 @@ describe("chunkSlackText", () => {
       expect((c.match(/```/g) || []).length % 2).toBe(0);
     }
   });
+});
+
+describe("splitSlackText", () => {
+  it.each(["\n", " "])(
+    "keeps the service send path within the cap at an exact %j boundary",
+    (boundary) => {
+      const text = `${"a".repeat(4000)}${boundary}${"b".repeat(100)}`;
+      const chunks = splitSlackText(text, 4000);
+
+      expect(chunks.map((chunk) => chunk.length)).toEqual([4000, 101]);
+      expect(chunks.every((chunk) => chunk.length <= 4000)).toBe(true);
+      expect(chunks.join("")).toBe(text);
+    },
+  );
 });
 
 describe("truncateText", () => {

--- a/plugins/plugin-slack/src/formatting.test.ts
+++ b/plugins/plugin-slack/src/formatting.test.ts
@@ -108,6 +108,29 @@ describe("stripSlackFormatting", () => {
 });
 
 describe("chunkSlackText", () => {
+  it("respects the limit when the break character lands exactly on the fence budget", () => {
+    // lastIndexOf is inclusive of its fromIndex, so a newline sitting exactly
+    // on hardLimit (maxChars - 4) used to push breakPoint one past it and
+    // spend the reserved "\n```" budget, emitting maxChars + 1.
+    const text = `\`\`\`\n${"a".repeat(3992)}\n${"b".repeat(500)}`;
+    const chunks = chunkSlackText(text, 4000);
+    expect(chunks.every((c) => c.length <= 4000)).toBe(true);
+  });
+
+  it("respects a small limit at the same boundary", () => {
+    const text = `\`\`\`\n${"a".repeat(92)}\n${"b".repeat(120)}`;
+    const chunks = chunkSlackText(text, 100);
+    expect(chunks.every((c) => c.length <= 100)).toBe(true);
+  });
+
+  it("holds the limit across a sweep of break positions", () => {
+    for (let pad = 3980; pad <= 3999; pad++) {
+      const text = `\`\`\`\n${"a".repeat(pad)}\n${"b".repeat(200)}`;
+      const chunks = chunkSlackText(text, 4000);
+      expect(chunks.every((c) => c.length <= 4000)).toBe(true);
+    }
+  });
+
   it("never emits a chunk over the limit, even when closing a split code block", () => {
     const text = `\`\`\`\n${"x".repeat(4200)}\n\`\`\``;
     const chunks = chunkSlackText(text, 4000);

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -195,6 +195,47 @@ export interface ChunkSlackTextOpts {
 const DEFAULT_MAX_CHARS = 4000;
 
 /**
+ * Splits plain Slack message text at newline/space boundaries without ever
+ * emitting more than `maxChars`. Unlike `chunkSlackText`, this does not add
+ * code-fence balancing characters.
+ */
+export function splitSlackText(
+  text: string,
+  maxChars: number = DEFAULT_MAX_CHARS,
+): string[] {
+  if (text.length <= maxChars) {
+    return [text];
+  }
+
+  const messages: string[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    if (remaining.length <= maxChars) {
+      messages.push(remaining);
+      break;
+    }
+
+    let splitIndex = maxChars;
+    const lastNewline = remaining.lastIndexOf("\n", maxChars);
+    if (lastNewline > maxChars / 2) {
+      splitIndex = lastNewline + 1;
+    } else {
+      const lastSpace = remaining.lastIndexOf(" ", maxChars);
+      if (lastSpace > maxChars / 2) {
+        splitIndex = lastSpace + 1;
+      }
+    }
+
+    splitIndex = Math.min(splitIndex, maxChars);
+    messages.push(remaining.slice(0, splitIndex));
+    remaining = remaining.slice(splitIndex);
+  }
+
+  return messages;
+}
+
+/**
  * Chunks Slack text while preserving code blocks
  */
 export function chunkSlackText(

--- a/plugins/plugin-slack/src/formatting.ts
+++ b/plugins/plugin-slack/src/formatting.ts
@@ -236,6 +236,11 @@ export function chunkSlackText(
       }
     }
 
+    // lastIndexOf is inclusive of its fromIndex, so a newline or space sitting
+    // exactly on hardLimit yields breakPoint = hardLimit + 1 and the reserved
+    // fence budget is spent, pushing the emitted chunk to maxChars + 1.
+    breakPoint = Math.min(breakPoint, hardLimit);
+
     let chunk = remaining.slice(0, breakPoint);
 
     // Check if this chunk ends inside a code block — count fences in the

--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -4054,6 +4054,10 @@ export class SlackService extends Service implements ISlackService {
         }
       }
 
+      // lastIndexOf is inclusive, so a break character exactly at
+      // MAX_SLACK_MESSAGE_LENGTH would make splitIndex one past the cap.
+      splitIndex = Math.min(splitIndex, MAX_SLACK_MESSAGE_LENGTH);
+
       messages.push(remaining.slice(0, splitIndex));
       remaining = remaining.slice(splitIndex);
     }

--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -404,7 +404,7 @@ import {
   type ResolvedSlackAccount,
   resolveDefaultSlackAccountId,
 } from "./accounts";
-import { markdownToSlackMrkdwn } from "./formatting";
+import { markdownToSlackMrkdwn, splitSlackText } from "./formatting";
 import {
   extractSlackEventWorkspace,
   SlackAccountPolicyResolver,
@@ -4028,41 +4028,7 @@ export class SlackService extends Service implements ISlackService {
   }
 
   private splitMessage(text: string): string[] {
-    if (text.length <= MAX_SLACK_MESSAGE_LENGTH) {
-      return [text];
-    }
-
-    const messages: string[] = [];
-    let remaining = text;
-
-    while (remaining.length > 0) {
-      if (remaining.length <= MAX_SLACK_MESSAGE_LENGTH) {
-        messages.push(remaining);
-        break;
-      }
-
-      // Find a good split point (prefer newlines, then spaces)
-      let splitIndex = MAX_SLACK_MESSAGE_LENGTH;
-
-      const lastNewline = remaining.lastIndexOf("\n", MAX_SLACK_MESSAGE_LENGTH);
-      if (lastNewline > MAX_SLACK_MESSAGE_LENGTH / 2) {
-        splitIndex = lastNewline + 1;
-      } else {
-        const lastSpace = remaining.lastIndexOf(" ", MAX_SLACK_MESSAGE_LENGTH);
-        if (lastSpace > MAX_SLACK_MESSAGE_LENGTH / 2) {
-          splitIndex = lastSpace + 1;
-        }
-      }
-
-      // lastIndexOf is inclusive, so a break character exactly at
-      // MAX_SLACK_MESSAGE_LENGTH would make splitIndex one past the cap.
-      splitIndex = Math.min(splitIndex, MAX_SLACK_MESSAGE_LENGTH);
-
-      messages.push(remaining.slice(0, splitIndex));
-      remaining = remaining.slice(splitIndex);
-    }
-
-    return messages;
+    return splitSlackText(text, MAX_SLACK_MESSAGE_LENGTH);
   }
 
   async addAllowedChannel(


### PR DESCRIPTION
# Relates to

Self-found while auditing hard-cap constants against the code that enforces them.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (verified: `git rev-list --count HEAD..origin/develop` = 0).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Low.** Two `Math.min(..., limit)` clamps. They can only ever make an emitted chunk shorter,
and only in the case that currently exceeds the cap — every input that was already within the
limit takes an identical path. All 58 pre-existing formatting tests pass untouched.

# Background

## What does this PR do?

`String.prototype.lastIndexOf(searchString, fromIndex)` is **inclusive of `fromIndex`**, so a
break character sitting exactly on the limit returns that index, and `index + 1` is one past it.

**1. `formatting.ts` — `chunkSlackText`.** The code reserves four characters for the closing
fence, with the intent stated in its own comment:

```ts
// Reserve room for the closing "\n```" fence so a chunk that splits inside
// a code block never exceeds maxChars.
const hardLimit = Math.max(maxChars - 4, 1);
let breakPoint = hardLimit;

const newlineIndex = remaining.lastIndexOf("\n", hardLimit);
if (newlineIndex > maxChars * 0.5) {
  breakPoint = newlineIndex + 1;      // <- can become hardLimit + 1
}
```

A newline (or space) exactly at `hardLimit` makes `breakPoint = maxChars - 3`. The chunk is then
`maxChars - 3` characters, and appending `"\n```"` yields **`maxChars + 1`** — the reserved
budget is exactly consumed by the off-by-one.

**2. `service.ts` — `splitMessage`.** The same mistake on the actual send path, without the
fence involved at all:

```ts
const lastNewline = remaining.lastIndexOf("\n", MAX_SLACK_MESSAGE_LENGTH);
if (lastNewline > MAX_SLACK_MESSAGE_LENGTH / 2) {
  splitIndex = lastNewline + 1;       // <- MAX + 1 when the newline is at MAX
}
messages.push(remaining.slice(0, splitIndex));
```

Both are clamped to their limit.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

`MAX_SLACK_MESSAGE_LENGTH = 4000` exists to keep outgoing messages inside Slack's limit, and
`chunkSlackText` is the helper the plugin exports for that purpose. Emitting 4001 characters
defeats the one job of both. It is content-dependent — it needs a newline or space to land on
exactly the boundary — which is why it survives normal use and normal tests.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`plugins/plugin-slack/src/formatting.test.ts` — the three new cases in the `chunkSlackText`
block. Check out this branch, revert only `plugins/plugin-slack/src/formatting.ts`, and run the
file: all three fail.

## Detailed testing steps

```bash
bun install --ignore-scripts
bunx vitest run plugins/plugin-slack/src/formatting.test.ts      # 63 passed

git checkout origin/develop -- plugins/plugin-slack/src/formatting.ts   # revert ONLY the fix
bunx vitest run plugins/plugin-slack/src/formatting.test.ts      # 3 failed | 58 passed
```

Observed against the unfixed source:

```
chunkSlackText("```\n" + "a".repeat(3992) + "\n" + "b".repeat(500), 4000)
  -> chunk lengths [ 4001, 504 ]      cap 4000

chunkSlackText("```\n" + "a".repeat(92) + "\n" + "b".repeat(120), 100)
  -> chunk lengths [ 101, 100, 32 ]   cap 100
```

The repaired head extracts the production send-path algorithm as `splitSlackText`, makes
`SlackService.splitMessage` delegate to it, and tests exact-boundary newlines and spaces through
that shared implementation:

```
splitMessage("a".repeat(4000) + "\n" + "b".repeat(100))
  -> lengths [ 4001, 100 ]            cap 4000
```

The third new test sweeps break positions 3980..3999 so the boundary cannot silently return.

The existing chunk test could not catch this: it uses `"x".repeat(4200)` with no newline or
space anywhere in the window, so `breakPoint` always stayed at `hardLimit` and the `+ 1` branch
was never taken.

# Evidence Gate

<!-- evidence-head:5c1a3f2d27e9a979d8419fbd57565f83507d6aed -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; pure string chunking in a plugin package.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; pure string chunking in a plugin package.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - the observable behaviour is an emitted chunk's length, shown as test output above.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the changed functions perform no I/O and emit no log lines; the vitest transcript exercises the real exported function.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involvement.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt or model behaviour changes; this is message chunking.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - produces no DB rows, memories, tasks, files or on-chain output.`
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - see the llm-trajectory row above.`

## Backend + frontend logs

`N/A - pure functions, no I/O.` Behavioural evidence is the before/after transcript above.

## Screenshots (before / after) + video walkthrough

`N/A - no UI change.`

# Known gaps / failures

- I did not attach a live Slack API rejection for the 4001-character message, because that needs
  workspace credentials I do not have. The over-limit output is demonstrated directly instead,
  which is the input such a call would carry.
- No implementation or evidence gap remains at the repaired exact head. A live Slack rejection
  was not required because the changed boundary is the deterministic string passed to Slack;
  the real service now delegates to the directly tested helper.

Exact-head verification:

```
bun run --cwd plugins/plugin-slack test        # 7 files, 128 tests passed
bun run --cwd plugins/plugin-slack typecheck   # passed
bun run --cwd plugins/plugin-slack lint:check  # passed
bun run --cwd plugins/plugin-slack build       # passed
bun run verify                                 # 351/351 tasks passed
```

AI provider/model: Anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A - contribution skill not used; repository template and CONTRIBUTING.md read directly from the checkout
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"N/A - contribution skill not used"} -->
