### PR TITLE
fix(ci): build core before real scenario harnesses

### DIFF
--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Ensure generated shared i18n data
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
+      - name: Build core exports for real API harness
+        run: bun run --cwd packages/core build
+
       - name: Scenario runner unit coverage
         run: bun run --cwd packages/scenario-runner test -- src/executor.test.ts src/runtime-factory.test.ts src/scenario-pr-workflow.test.ts src/__tests__/deterministic-action-coverage.test.ts
 
@@ -708,6 +711,9 @@ jobs:
 
       - name: Ensure generated shared i18n data
         run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
+
+      - name: Build core exports for real API harness
+        run: bun run --cwd packages/core build
 
       - name: Install Playwright browsers (Chromium)
         run: .github/scripts/install-playwright-browsers.sh chromium

--- a/packages/app/e2e/accounts-ui/run-accounts-ui-e2e.mjs
+++ b/packages/app/e2e/accounts-ui/run-accounts-ui-e2e.mjs
@@ -135,12 +135,13 @@ const stubElizaCore = {
     }));
   },
 };
-// Swap ONLY the app-state barrel for the translator stub. The api barrel — the
-// network layer under test — stays real.
-const stubStateBarrel = {
-  name: "stub-state-barrel",
+// Swap only the app-state selectors for the translator stub. Account surfaces
+// import selectors from both the state barrel and its app-store module; the API
+// barrel — the network layer under test — stays real.
+const stubAppState = {
+  name: "stub-app-state",
   setup(b) {
-    b.onResolve({ filter: /^(\.\.\/)+state$/ }, () => ({
+    b.onResolve({ filter: /^(\.\.\/)+state(?:\/app-store)?$/ }, () => ({
       path: join(here, "accounts-fixture-state-stub.ts"),
     }));
   },
@@ -155,7 +156,7 @@ async function bundleFixture() {
     jsx: "automatic",
     loader: { ".tsx": "tsx", ".ts": "ts" },
     define: { "process.env.NODE_ENV": '"production"' },
-    plugins: [stubStateBarrel, stubElizaCore, stubNodeBuiltins],
+    plugins: [stubAppState, stubElizaCore, stubNodeBuiltins],
     write: false,
     absWorkingDir: repoRoot,
     logLevel: "silent",

--- a/packages/scripts/__tests__/scenario-pr-core-build-workflow.test.ts
+++ b/packages/scripts/__tests__/scenario-pr-core-build-workflow.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Ensures real Scenario E2E API harnesses build the core package exports they
+ * resolve before starting local chat or accounts servers.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+interface WorkflowStep {
+  name?: string;
+  run?: string;
+}
+
+interface WorkflowJob {
+  steps?: WorkflowStep[];
+}
+
+interface Workflow {
+  jobs?: Record<string, WorkflowJob>;
+}
+
+const workflow = Bun.YAML.parse(
+  readFileSync(
+    new URL("../../../.github/workflows/scenario-pr.yml", import.meta.url),
+    "utf8",
+  ),
+) as Workflow;
+
+function expectCoreBuildBefore(jobName: string, harnessStepName: string): void {
+  const steps = workflow.jobs?.[jobName]?.steps ?? [];
+  const buildIndexes = steps.flatMap((step, index) =>
+    step.name === "Build core exports for real API harness" ? [index] : [],
+  );
+  const harnessIndex = steps.findIndex((step) => step.name === harnessStepName);
+
+  expect(buildIndexes).toHaveLength(1);
+  expect(steps[buildIndexes[0]]?.run).toBe("bun run --cwd packages/core build");
+  expect(harnessIndex).toBeGreaterThan(buildIndexes[0]);
+}
+
+describe("Scenario E2E real API build ordering (#20363)", () => {
+  test("builds core exports before the real local chat pipeline", () => {
+    expectCoreBuildBefore(
+      "scenario-unit-coverage",
+      "Real local chat pipeline (no model key, no llama)",
+    );
+  });
+
+  test("builds core exports before the real accounts UI API server", () => {
+    expectCoreBuildBefore(
+      "app-accounts-ui",
+      "Accounts UI browser e2e — real AccountList + real accounts routes + real AccountPool",
+    );
+  });
+});


### PR DESCRIPTION
# Relates to

Closes #20363.

- [x] Targets `develop` and is rebased onto current `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` passed after sync.
- [x] The real local-chat and accounts browser harnesses pass end to end.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@94c75f7cf5e9ee854b9e67045e7ec1b8eb27ff96`; zero conflicts.
- [x] `bun run verify` passes post-sync: 351/351 tasks plus every repository audit.

# Risks

Low. The workflow adds the narrow core build required by two existing real API harnesses. The accounts fixture change only restores its browser-only app selector stub after production consumers moved from the state barrel to `state/app-store`; the real accounts UI, client, API, pool, and credential disk store remain under test.

# Background

## What does this PR do?

- Builds `@elizaos/core` before both Scenario E2E jobs start their real API harnesses, restoring `@elizaos/core/client-public` and edge export resolution on clean Linux runners.
- Extends the accounts browser fixture's app-state resolver to cover both supported selector import paths. Without this, the fixture rendered a blank page before making `/api/accounts` requests.
- Adds a YAML contract test that pins one core build step before each real harness.

## What kind of change is this?

Bug fix and CI reliability improvement.

# Documentation changes needed?

No. This repairs existing CI and test contracts without changing a documented product API.

# Testing

## Where should a reviewer start?

Review `.github/workflows/scenario-pr.yml`, then run the ordering contract and either real harness from a checkout without prebuilt core exports.

## Detailed testing steps

```text
bun install --frozen-lockfile
bun test packages/scripts/__tests__/scenario-pr-core-build-workflow.test.ts
bun run --cwd packages/core build
bun run --cwd packages/app-core test:local-chat
PATH=/Users/shawwalters/.nvm/versions/node/v24.15.0/bin:$PATH bun run --cwd packages/app test:e2e:accounts-ui
bun run verify
```

Exact-head results:

- Workflow ordering contract: 2 passed, 0 failed.
- Core build: node, browser, edge, testing, declarations, and packed edge import verification passed.
- Real local chat: API booted, conversation created, deterministic reply returned, and two real messages persisted.
- Real accounts browser lifecycle: 15 screenshots; empty, invalid input, create, disk persistence, reorder, strategy, health, mobile, disable, delete, and final disk-empty assertions all passed; zero page errors.
- Root verification: 351/351 tasks; build/typecheck, workflow policy, script inventory, test-lane, view inventory, and anti-larp audits passed.

# Evidence Gate

<!-- evidence-head:6baa371eef207a8ba9fa00048a10d3c9a5e2d57c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no production UI surface changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no production UI surface changed; the repaired test generated and reviewed 15 fixture screenshots.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no production interaction changed; the accounts harness records its complete browser run.
<!-- evidence-row:backend-logs -->
- [x] [20369-backend-server.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20369-backend-server.log)
<!-- evidence-row:frontend-logs -->
- [x] [20369-frontend-network.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20369-frontend-network.log)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no durable product-domain data is changed by this CI/test repair; scratch credentials are asserted written and deleted by the harness.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered production visual surface changed.

# Evidence Details

## Backend + frontend logs

```text
[local-chat] PASS conversation created
[local-chat] PASS reply via real pipeline: "Hello from the deterministic model provider."
[local-chat] PASS history persisted 2 real messages
[local-chat] ALL ASSERTIONS PASSED

[accounts-e2e-api] GET /api/accounts -> 200
[accounts-e2e-api] POST /api/accounts/anthropic-api -> 201
PASS credential record written to the on-disk store
PASS priority swap persisted through PATCH /api/accounts
PASS strategy PATCH persisted via saveConfig
PASS pool state matches the rendered badges
PASS deleted account's on-disk credential was removed
PASS pool is empty on disk too
PASS zero page errors across the whole flow
ALL ASSERTIONS PASSED — 15 screenshots
```

## Known gaps / failures

None. The exact-head hosted Scenario E2E run is the final merge gate.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [qa-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->

