### PR TITLE
fix(skills): support flat markdown skill files with filename slug naming

### DIFF
--- a/packages/skills/src/loader.ts
+++ b/packages/skills/src/loader.ts
@@ -38,12 +38,18 @@ const MAX_DESCRIPTION_LENGTH = 1024;
 const CONFIG_DIR_NAME = ".elizaos";
 const DEFAULT_AGENT_DIR = resolveStateDir();
 
-function validateName(name: string, parentDirName: string): string[] {
+function validateName(
+  name: string,
+  expectedName: string,
+  isSkillMd: boolean,
+): string[] {
   const errors: string[] = [];
 
-  if (name !== parentDirName) {
+  if (name !== expectedName) {
     errors.push(
-      `name "${name}" does not match parent directory "${parentDirName}"`,
+      isSkillMd
+        ? `name "${name}" does not match parent directory "${expectedName}"`
+        : `name "${name}" does not match filename slug "${expectedName}"`,
     );
   }
 
@@ -116,17 +122,22 @@ function loadSkillFromFile(
     });
     return { skill: null, diagnostics };
   }
+  const fileName = basename(filePath);
+  const isSkillMd = fileName.toLowerCase() === "skill.md";
   const skillDir = dirname(filePath);
   const parentDirName = basename(skillDir);
+  const expectedName = isSkillMd
+    ? parentDirName
+    : fileName.replace(/\.md$/i, "");
 
   const descErrors = validateDescription(frontmatter.description);
   for (const error of descErrors) {
     diagnostics.push({ type: "warning", message: error, path: filePath });
   }
 
-  const name = frontmatter.name || parentDirName;
+  const name = frontmatter.name || expectedName;
 
-  const nameErrors = validateName(name, parentDirName);
+  const nameErrors = validateName(name, expectedName, isSkillMd);
   for (const error of nameErrors) {
     diagnostics.push({ type: "warning", message: error, path: filePath });
   }

--- a/packages/skills/test/loader.test.ts
+++ b/packages/skills/test/loader.test.ts
@@ -115,7 +115,9 @@ description: Mismatched skill name
       const result = loadSkillsFromDir({ dir: tempDir, source: "test" });
       assert.strictEqual(result.skills.length, 1);
       const diag = result.diagnostics.find((d) =>
-        d.message.includes('name "different-name" does not match filename slug "actual-filename"'),
+        d.message.includes(
+          'name "different-name" does not match filename slug "actual-filename"',
+        ),
       );
       assert.ok(diag);
     } finally {

--- a/packages/skills/test/loader.test.ts
+++ b/packages/skills/test/loader.test.ts
@@ -60,6 +60,7 @@ description: Subdirectory skill description
 
       const result = loadSkillsFromDir({ dir: tempDir, source: "test" });
       assert.strictEqual(result.skills.length, 2);
+      assert.strictEqual(result.diagnostics.length, 0);
 
       const rootSkill = result.skills.find((s) => s.name === "root-skill");
       assert.ok(rootSkill);
@@ -74,6 +75,49 @@ description: Subdirectory skill description
         subSkill.description,
         "Subdirectory skill description",
       );
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("defaults flat markdown skill name to filename slug when name is omitted", () => {
+    const tempDir = createTempDir("skill-loader-flat-slug");
+    try {
+      writeFileSync(
+        join(tempDir, "auto-named-tool.md"),
+        `---
+description: Tool description without explicit name
+---
+# Content`,
+      );
+
+      const result = loadSkillsFromDir({ dir: tempDir, source: "test" });
+      assert.strictEqual(result.skills.length, 1);
+      assert.strictEqual(result.diagnostics.length, 0);
+      assert.strictEqual(result.skills[0]?.name, "auto-named-tool");
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("emits warning diagnostic when flat markdown skill name does not match filename slug", () => {
+    const tempDir = createTempDir("skill-loader-mismatched-slug");
+    try {
+      writeFileSync(
+        join(tempDir, "actual-filename.md"),
+        `---
+name: different-name
+description: Mismatched skill name
+---
+# Content`,
+      );
+
+      const result = loadSkillsFromDir({ dir: tempDir, source: "test" });
+      assert.strictEqual(result.skills.length, 1);
+      const diag = result.diagnostics.find((d) =>
+        d.message.includes('name "different-name" does not match filename slug "actual-filename"'),
+      );
+      assert.ok(diag);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
# Relates to

Fixes #20370.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity CLI`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. Refines skill name defaulting and validation logic in `packages/skills/src/loader.ts` to recognize flat `.md` files alongside `SKILL.md` subdirectories.

# Background

## What does this PR do?

When loading root `.md` files from a skills directory, `loadSkillFromFile` previously resolved `parentDirName = basename(skillDir)` (which evaluates to the root skills folder, e.g. `"skills"`).
This caused two issues for flat markdown files:
1. `validateName(name, parentDirName)` emitted a spurious warning: `name "my-tool" does not match parent directory "skills"`.
2. Missing frontmatter `name` defaulted to `"skills"` instead of the filename slug `"my-tool"`.

This fix:
1. Distinguishes `SKILL.md` subdirectories from flat markdown files.
2. Derives expected name as `parentDirName` for `SKILL.md` and `fileName.replace(/\.md$/i, "")` for flat `.md` files.
3. Updates `validateName` to emit `does not match filename slug` for flat files and `does not match parent directory` for directory skills.
4. Adds tests for flat `.md` files with omitted `name` and mismatched name frontmatter.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/skills/src/loader.ts` and unit tests in `packages/skills/test/loader.test.ts`.

## Detailed testing steps

Run `bun run --cwd packages/skills test`.

# Evidence Gate

<!-- evidence-head:d97046dcd8cd67f738a8f56b46dc7167589b3682 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached: `N/A - non-UI parser change`
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached: `N/A - non-UI parser change`
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough is attached: `N/A - non-UI parser change`
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path: `N/A - verified via unit test suite in packages/skills/test/loader.test.ts`
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response: `N/A - non-UI parser package`
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached: `N/A - pure utility skill discovery/loader parser`
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached: `N/A - unit test assertions cover all outputs`
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached: `N/A - no UI components changed`

# Evidence Details

## Known gaps / failures

None.

AI provider/model: google / gemini-3.7-flash
Client / agent tooling: Antigravity CLI
Contribution skill revision: elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity-contributor]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity CLI","skill_revision":"elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza"} -->
