### PR TITLE
fix(core): normalize custom truthy and falsy option values to lowercase in parseBooleanValue

### DIFF
--- a/packages/core/src/utils/boolean.test.ts
+++ b/packages/core/src/utils/boolean.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for parseBooleanValue and parseBooleanText in packages/core/src/utils/boolean.ts.
+ * Exercises default truthy/falsy vocabularies, custom options with mixed case and whitespace,
+ * boolean pass-throughs, and invalid input fallbacks.
+ */
+import { describe, expect, it } from "vitest";
+import { parseBooleanText, parseBooleanValue } from "./boolean";
+
+describe("parseBooleanValue", () => {
+	it("passes boolean literals through unchanged", () => {
+		expect(parseBooleanValue(true)).toBe(true);
+		expect(parseBooleanValue(false)).toBe(false);
+	});
+
+	it("parses default truthy string representations", () => {
+		for (const val of ["true", "1", "yes", "on", "TRUE", "Yes", "ON "]) {
+			expect(parseBooleanValue(val)).toBe(true);
+		}
+	});
+
+	it("parses default falsy string representations", () => {
+		for (const val of ["false", "0", "no", "off", "FALSE", "No", "OFF\n"]) {
+			expect(parseBooleanValue(val)).toBe(false);
+		}
+	});
+
+	it("returns undefined for unrecognized strings and non-string inputs", () => {
+		expect(parseBooleanValue("maybe")).toBeUndefined();
+		expect(parseBooleanValue("")).toBeUndefined();
+		expect(parseBooleanValue("   ")).toBeUndefined();
+		expect(parseBooleanValue(null)).toBeUndefined();
+		expect(parseBooleanValue(undefined)).toBeUndefined();
+		expect(parseBooleanValue(123)).toBeUndefined();
+		expect(parseBooleanValue({})).toBeUndefined();
+	});
+
+	it("matches custom truthy and falsy options case-insensitively with whitespace trimming", () => {
+		expect(
+			parseBooleanValue("enabled", {
+				truthy: ["Enabled"],
+				falsy: ["Disabled"],
+			}),
+		).toBe(true);
+
+		expect(
+			parseBooleanValue("ENABLED", {
+				truthy: ["enabled"],
+			}),
+		).toBe(true);
+
+		expect(
+			parseBooleanValue("disabled", {
+				truthy: ["Enabled"],
+				falsy: [" Disabled "],
+			}),
+		).toBe(false);
+
+		expect(
+			parseBooleanValue("DISABLED", {
+				falsy: ["disabled"],
+			}),
+		).toBe(false);
+	});
+});
+
+describe("parseBooleanText", () => {
+	it("parses extended text booleans (y/n, enable/disable) with false fallback", () => {
+		expect(parseBooleanText("yes")).toBe(true);
+		expect(parseBooleanText("y")).toBe(true);
+		expect(parseBooleanText("enable")).toBe(true);
+		expect(parseBooleanText("ENABLE")).toBe(true);
+		expect(parseBooleanText("no")).toBe(false);
+		expect(parseBooleanText("n")).toBe(false);
+		expect(parseBooleanText("disable")).toBe(false);
+		expect(parseBooleanText("random_unknown_text")).toBe(false);
+		expect(parseBooleanText(null)).toBe(false);
+		expect(parseBooleanText(undefined)).toBe(false);
+	});
+});

--- a/packages/core/src/utils/boolean.ts
+++ b/packages/core/src/utils/boolean.ts
@@ -57,8 +57,13 @@ export function parseBooleanValue(
 	const truthy = options.truthy ?? DEFAULT_TRUTHY;
 	const falsy = options.falsy ?? DEFAULT_FALSY;
 	const truthySet =
-		truthy === DEFAULT_TRUTHY ? DEFAULT_TRUTHY_SET : new Set(truthy);
-	const falsySet = falsy === DEFAULT_FALSY ? DEFAULT_FALSY_SET : new Set(falsy);
+		truthy === DEFAULT_TRUTHY
+			? DEFAULT_TRUTHY_SET
+			: new Set(truthy.map((v) => v.trim().toLowerCase()));
+	const falsySet =
+		falsy === DEFAULT_FALSY
+			? DEFAULT_FALSY_SET
+			: new Set(falsy.map((v) => v.trim().toLowerCase()));
 	if (truthySet.has(normalized)) {
 		return true;
 	}


### PR DESCRIPTION
# Relates to

Fixes #20371.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity CLI`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. Ensures custom truthy and falsy option array elements in `parseBooleanValue` are mapped to lowercase and trimmed before building the lookup set.

# Background

## What does this PR do?

In `packages/core/src/utils/boolean.ts`, `parseBooleanValue` normalizes the input string via `value.trim().toLowerCase()`.
However, custom `options.truthy` and `options.falsy` arrays were passed directly to `new Set(...)` without lowercase normalization. If callers passed mixed-case or uppercase options like `{ truthy: ["Enabled"] }` or `{ truthy: ["YES"] }`, lookup against the lowercased input string returned `false`, resulting in `undefined`.

This fix:
1. Maps custom `truthy` and `falsy` array elements via `.map((v) => v.trim().toLowerCase())` when building custom Set instances.
2. Preserves constant reference optimization for default vocabulary `DEFAULT_TRUTHY_SET` and `DEFAULT_FALSY_SET`.
3. Adds comprehensive unit tests in `packages/core/src/utils/boolean.test.ts`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/core/src/utils/boolean.ts` and unit tests in `packages/core/src/utils/boolean.test.ts`.

## Detailed testing steps

Run `bun test packages/core/src/utils/boolean.test.ts`.

# Evidence Gate

<!-- evidence-head:1bbf0a02159d8165f311ff4ecc22974d6ffce547 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached: `N/A - non-UI utility parser change`
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached: `N/A - non-UI utility parser change`
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough is attached: `N/A - non-UI utility parser change`
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path: `N/A - verified via unit test suite in packages/core/src/utils/boolean.test.ts`
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response: `N/A - non-UI core package`
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached: `N/A - pure synchronous boolean parsing helper`
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached: `N/A - unit test assertions cover all outputs`
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached: `N/A - no UI components changed`

# Evidence Details

## Known gaps / failures

None.

AI provider/model: google / gemini-3.7-flash
Client / agent tooling: Antigravity CLI
Contribution skill revision: elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity-contributor]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity CLI","skill_revision":"elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza"} -->
