### PR TITLE
fix(core): reject NaN and non-finite budget values in sliceToFitBudget

### DIFF
--- a/packages/core/src/utils/slice-to-fit-budget.test.ts
+++ b/packages/core/src/utils/slice-to-fit-budget.test.ts
@@ -51,9 +51,18 @@ describe("sliceToFitBudget", () => {
 		expect(sliceToFitBudget([], byLength, 100)).toEqual([]);
 	});
 
-	it("returns empty for a zero or negative budget", () => {
+	it("returns empty for a zero, negative, or non-finite budget", () => {
 		expect(sliceToFitBudget(["a"], byLength, 0)).toEqual([]);
 		expect(sliceToFitBudget(["a"], byLength, -10)).toEqual([]);
+		expect(sliceToFitBudget(["a", "b", "c"], byLength, Number.NaN)).toEqual([]);
+		expect(
+			sliceToFitBudget(["a", "b", "c"], byLength, Number.NaN, {
+				fromEnd: true,
+			}),
+		).toEqual([]);
+		expect(
+			sliceToFitBudget(["a", "b"], byLength, Number.NEGATIVE_INFINITY),
+		).toEqual([]);
 	});
 
 	it("treats a zero budget as no room even for a zero-cost item", () => {

--- a/packages/core/src/utils/slice-to-fit-budget.ts
+++ b/packages/core/src/utils/slice-to-fit-budget.ts
@@ -14,8 +14,8 @@ export function sliceToFitBudget<T>(
 	options?: { fromEnd?: boolean },
 ): T[] {
 	if (items.length === 0) return [];
-	// Zero or negative budget means no room - return empty array
-	if (targetChars <= 0) return [];
+	// Zero, negative, or non-finite budget means no room - return empty array
+	if (!Number.isFinite(targetChars) || targetChars <= 0) return [];
 
 	const fromEnd = options?.fromEnd ?? false;
 	let total = 0;


### PR DESCRIPTION
# Relates to

Fixes #20372.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity CLI`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. Adds `!Number.isFinite(targetChars)` check to `sliceToFitBudget` validation guard so non-finite or `NaN` budgets return empty arrays.

# Background

## What does this PR do?

In `packages/core/src/utils/slice-to-fit-budget.ts`, the budget guard previously checked `if (targetChars <= 0) return [];`.
When `targetChars` is `NaN`, `NaN <= 0` evaluates to `false`. Inside the iteration loops, comparisons `total + sizes[count] > NaN` also evaluate to `false`, causing the loop to exhaust the entire item array and return all elements instead of rejecting the invalid budget.

This fix:
1. Updates the guard to `if (!Number.isFinite(targetChars) || targetChars <= 0) return [];`.
2. Adds unit tests in `packages/core/src/utils/slice-to-fit-budget.test.ts` asserting that `NaN`, `Number.NEGATIVE_INFINITY`, and non-finite budgets return `[]`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/core/src/utils/slice-to-fit-budget.ts` and unit tests in `packages/core/src/utils/slice-to-fit-budget.test.ts`.

## Detailed testing steps

Run `bun test packages/core/src/utils/slice-to-fit-budget.test.ts`.

# Evidence Gate

<!-- evidence-head:142900c215bae34f634fe00de4a878a63ee7b976 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached: `N/A - non-UI utility function change`
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached: `N/A - non-UI utility function change`
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough is attached: `N/A - non-UI utility function change`
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path: `N/A - verified via unit test suite in packages/core/src/utils/slice-to-fit-budget.test.ts`
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response: `N/A - non-UI core package`
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached: `N/A - pure in-memory character budgeting helper`
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached: `N/A - unit test assertions cover all outputs`
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached: `N/A - no UI components changed`

# Evidence Details

## Known gaps / failures

None.

AI provider/model: google / gemini-3.7-flash
Client / agent tooling: Antigravity CLI
Contribution skill revision: elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity-contributor]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity CLI","skill_revision":"elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza"} -->
