### PR TITLE
fix(core): allow shouldAckReaction in group-mentions mode when requireMention is false

### DIFF
--- a/packages/core/src/utils/channel-utils.test.ts
+++ b/packages/core/src/utils/channel-utils.test.ts
@@ -133,6 +133,14 @@ describe("shouldAckReaction", () => {
 			shouldAckReaction({
 				...base,
 				scope: "group-mentions",
+				requireMention: false,
+				effectiveWasMentioned: true,
+			}),
+		).toBe(true);
+		expect(
+			shouldAckReaction({
+				...base,
+				scope: "group-mentions",
 				effectiveWasMentioned: false,
 			}),
 		).toBe(false);

--- a/packages/core/src/utils/channel-utils.ts
+++ b/packages/core/src/utils/channel-utils.ts
@@ -249,9 +249,6 @@ export function shouldAckReaction(params: AckReactionGateParams): boolean {
 		if (!params.isMentionableGroup) {
 			return false;
 		}
-		if (!params.requireMention) {
-			return false;
-		}
 		if (!params.canDetectMention) {
 			return false;
 		}


### PR DESCRIPTION
# Relates to

Fixes #20375.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity CLI`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. Removes extraneous `!params.requireMention` check in `shouldAckReaction` under `"group-mentions"` scope.

# Background

## What does this PR do?

In `packages/core/src/utils/channel-utils.ts`, `shouldAckReaction` evaluates whether to send an acknowledgment reaction for a message in a channel or group.
When `scope === "group-mentions"`, the function previously checked `if (!params.requireMention) return false;`.
If a group is configured to respond to messages without requiring an explicit mention (`requireMention: false`), but the user *does* explicitly mention the agent (`effectiveWasMentioned: true`), `shouldAckReaction` returned `false`.
Under `"group-mentions"`, acknowledgment reactions should fire whenever the message mentions the agent in a mentionable group, regardless of whether mentions are mandatorily required for normal message replies.

This fix:
1. Removes the `!params.requireMention` condition from the `group-mentions` branch in `shouldAckReaction`.
2. Updates `packages/core/src/utils/channel-utils.test.ts` to assert that acknowledgment reactions trigger in `group-mentions` mode when `requireMention: false` and `effectiveWasMentioned: true`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/core/src/utils/channel-utils.ts` and unit tests in `packages/core/src/utils/channel-utils.test.ts`.

## Detailed testing steps

Run `bun test packages/core/src/utils/channel-utils.test.ts`.

# Evidence Gate

<!-- evidence-head:1d515fbdf2423936b1509e0faf42abbbbcee1ae8 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached: `N/A - non-UI messaging utility change`
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached: `N/A - non-UI messaging utility change`
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough is attached: `N/A - non-UI messaging utility change`
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path: `N/A - verified via unit test suite in packages/core/src/utils/channel-utils.test.ts`
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response: `N/A - non-UI core package`
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached: `N/A - pure channel decision gating utility`
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached: `N/A - unit test assertions cover all outputs`
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached: `N/A - no UI components changed`

# Evidence Details

## Known gaps / failures

None.

AI provider/model: google / gemini-3.7-flash
Client / agent tooling: Antigravity CLI
Contribution skill revision: elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity-contributor]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity CLI","skill_revision":"elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza"} -->
