### PR TITLE
fix(core): compare generated pairing code case-insensitively against existing codes

### DIFF
--- a/packages/core/src/services/pairing.test.ts
+++ b/packages/core/src/services/pairing.test.ts
@@ -272,4 +272,46 @@ describe("PairingService bounded reads", () => {
 			normalizePairingPageOptions({ offset: Number.MAX_SAFE_INTEGER + 1 }),
 		).toThrow(RangeError);
 	});
+
+	it("avoids pairing code collisions case-insensitively", async () => {
+		const existingRequest: PairingRequest = {
+			id: uuid(1),
+			channel: "discord",
+			senderId: "sender-1",
+			code: "ABCDEFGH",
+			createdAt: new Date(),
+			lastSeenAt: new Date(),
+			agentId: MOCK_AGENT_ID,
+		};
+		const getPairingRequests = vi.fn<IAgentRuntime["getPairingRequests"]>(
+			async () => [
+				{
+					channel: "discord",
+					agentId: MOCK_AGENT_ID,
+					requests: [existingRequest],
+				},
+			],
+		);
+		const runtime = runtimeWith({
+			getPairingRequests,
+			getPairingAllowlists: vi.fn(async () => []),
+		});
+		const service = new PairingService(runtime);
+		const generateCodeSpy = vi
+			.spyOn(
+				service as unknown as { generateCode: () => string },
+				"generateCode",
+			)
+			.mockReturnValueOnce("abcdefgh")
+			.mockReturnValueOnce("UNIQUE99");
+
+		const code = await (
+			service as unknown as {
+				generateUniqueCode: (c: "discord") => Promise<string>;
+			}
+		).generateUniqueCode("discord");
+
+		expect(code).toBe("UNIQUE99");
+		expect(generateCodeSpy).toHaveBeenCalledTimes(2);
+	});
 });

--- a/packages/core/src/services/pairing.ts
+++ b/packages/core/src/services/pairing.ts
@@ -99,7 +99,7 @@ export class PairingService extends Service {
 
 		for (let attempt = 0; attempt < 500; attempt++) {
 			const code = this.generateCode();
-			if (!existingCodes.has(code)) {
+			if (!existingCodes.has(code.toUpperCase())) {
 				return code;
 			}
 		}


### PR DESCRIPTION
# Relates to

Fixes #20376.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity CLI`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. Normalizes `code.toUpperCase()` when checking for existing pending pairing codes in `generateUniqueCode`.

# Background

## What does this PR do?

In `packages/core/src/services/pairing.ts`, `generateUniqueCode` prevents duplicate pairing codes on a channel by storing existing pending request codes in uppercase in `existingCodes = new Set(existingRequests.map((r) => r.code.toUpperCase()))`.
However, the collision check tested `if (!existingCodes.has(code))` with the un-normalized generated code. If the code generator produced lowercase or mixed-case characters, the case-insensitive collision check was bypassed.

This fix:
1. Updates the check to `if (!existingCodes.has(code.toUpperCase())) return code;`.
2. Adds a unit test in `packages/core/src/services/pairing.test.ts` verifying case-insensitive collision avoidance.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/core/src/services/pairing.ts` and unit tests in `packages/core/src/services/pairing.test.ts`.

## Detailed testing steps

Run `bun run --cwd packages/core test src/services/pairing.test.ts`.

# Evidence Gate

<!-- evidence-head:91b3891b545928e9d20cdabcfb53649343f734eb -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached: `N/A - non-UI service change`
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached: `N/A - non-UI service change`
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough is attached: `N/A - non-UI service change`
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path: `N/A - verified via unit test suite in packages/core/src/services/pairing.test.ts`
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response: `N/A - non-UI core package`
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached: `N/A - pure deterministic DM pairing authorization service`
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached: `N/A - unit test assertions cover all outputs`
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached: `N/A - no UI components changed`

# Evidence Details

## Known gaps / failures

None.

AI provider/model: google / gemini-3.7-flash
Client / agent tooling: Antigravity CLI
Contribution skill revision: elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity-contributor]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity CLI","skill_revision":"elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza"} -->
