### PR TITLE
fix(skills): improve extractFrontmatter delimiter matching for whitespace and prefix validation

### DIFF
--- a/packages/skills/src/frontmatter.ts
+++ b/packages/skills/src/frontmatter.ts
@@ -63,18 +63,24 @@ function extractFrontmatter(content: string): {
 } {
   const normalized = normalizeNewlines(content);
 
-  if (!normalized.startsWith("---")) {
+  const openMatch = normalized.match(/^---\s*(?:\n|$)/);
+  if (!openMatch) {
     return { yamlString: null, body: normalized };
   }
 
-  const endIndex = normalized.indexOf("\n---", 3);
+  const startOffset = openMatch[0].length;
+  const endIndex = normalized.indexOf("\n---", startOffset - 1);
   if (endIndex === -1) {
     return { yamlString: null, body: normalized };
   }
 
+  const afterClosing = normalized.slice(endIndex + 1);
+  const closeMatch = afterClosing.match(/^---\s*(?:\n|$)/);
+  const closingLength = closeMatch ? closeMatch[0].length : 4;
+
   return {
-    yamlString: normalized.slice(4, endIndex),
-    body: normalized.slice(endIndex + 4).trim(),
+    yamlString: normalized.slice(startOffset, endIndex),
+    body: normalized.slice(endIndex + 1 + closingLength).trim(),
   };
 }
 

--- a/packages/skills/test/frontmatter.test.ts
+++ b/packages/skills/test/frontmatter.test.ts
@@ -44,6 +44,21 @@ Body`;
     assert.strictEqual(result.body, "Body");
   });
 
+  it("handles opening delimiter with trailing whitespace", () => {
+    const content = "---   \nname: test-trailing\ndescription: Test\n--- \nBody";
+    const result = parseFrontmatter<SkillFrontmatter>(content);
+    assert.strictEqual(result.frontmatter.name, "test-trailing");
+    assert.strictEqual(result.frontmatter.description, "Test");
+    assert.strictEqual(result.body, "Body");
+  });
+
+  it("does not treat non-delimiter prefix strings as frontmatter", () => {
+    const content = "---not-a-delimiter\nname: test\n---\nBody";
+    const result = parseFrontmatter(content);
+    assert.deepStrictEqual(result.frontmatter, {});
+    assert.strictEqual(result.body, content);
+  });
+
   it("handles Windows-style line endings (CRLF)", () => {
     const content = "---\r\nname: test\r\n---\r\nBody";
     const result = parseFrontmatter<SkillFrontmatter>(content);


### PR DESCRIPTION
# Relates to

Fixes #20377.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity CLI`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. Aligns opening and closing YAML frontmatter delimiter matching with line-anchored regex in `extractFrontmatter`.

# Background

## What does this PR do?

In `packages/skills/src/frontmatter.ts`, `extractFrontmatter` previously checked `if (!normalized.startsWith("---"))` and hardcoded offset 4 (`normalized.slice(4, endIndex)`).
This caused two issues:
1. Files starting with `---` followed by whitespace on the opening line (e.g. `--- \n`) had that whitespace included at the start of the frontmatter YAML string.
2. Non-delimiter lines starting with `---` (e.g. `---not-a-delimiter\n...`) were incorrectly treated as opening delimiters.

This fix:
1. Matches opening delimiter as `^---\s*(?:\n|$)` and computes the exact YAML slice start offset from the matched opening line length.
2. Dynamically calculates closing delimiter line length with `^---\s*(?:\n|$)`.
3. Adds unit tests in `packages/skills/test/frontmatter.test.ts` covering trailing whitespace on delimiter lines and non-delimiter prefix strings.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/skills/src/frontmatter.ts` and unit tests in `packages/skills/test/frontmatter.test.ts`.

## Detailed testing steps

Run `bun run --cwd packages/skills test`.

# Evidence Gate

<!-- evidence-head:c5275c11737635411f1764781f438067dd2f4be5 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached: `N/A - non-UI markdown parser change`
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached: `N/A - non-UI markdown parser change`
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough is attached: `N/A - non-UI markdown parser change`
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path: `N/A - verified via unit test suite in packages/skills/test/frontmatter.test.ts`
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response: `N/A - non-UI skills package`
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached: `N/A - pure utility frontmatter parser`
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached: `N/A - unit test assertions cover all outputs`
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached: `N/A - no UI components changed`

# Evidence Details

## Known gaps / failures

None.

AI provider/model: google / gemini-3.7-flash
Client / agent tooling: Antigravity CLI
Contribution skill revision: elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity-contributor]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity CLI","skill_revision":"elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza"} -->
