### PR TITLE
fix(core): check for TEXT_EMBEDDING_BATCH when starting EmbeddingGenerationService

### DIFF
--- a/packages/core/src/services/embedding.test.ts
+++ b/packages/core/src/services/embedding.test.ts
@@ -92,6 +92,43 @@ describe("EmbeddingGenerationService drain config", () => {
 		await service.stop();
 	});
 
+	test("initializes successfully when only TEXT_EMBEDDING_BATCH is registered", async () => {
+		const models: Record<string, unknown> = {
+			[ModelType.TEXT_EMBEDDING_BATCH]: async () => [[0.1]],
+		};
+		const runtime = {
+			...makeRuntime({ batch: false }),
+			getModel: (type: string) => models[type],
+		} as unknown as IAgentRuntime;
+
+		const service = (await EmbeddingGenerationService.start(
+			runtime,
+		)) as EmbeddingGenerationService;
+
+		// biome-ignore lint/suspicious/noExplicitAny: inspect private isDisabled state
+		expect((service as any).isDisabled).toBe(false);
+		// biome-ignore lint/suspicious/noExplicitAny: inspect private queue state
+		expect((service as any).batchQueue).toBeTruthy();
+
+		await service.stop();
+	});
+
+	test("disables itself when neither TEXT_EMBEDDING nor TEXT_EMBEDDING_BATCH is registered", async () => {
+		const runtime = {
+			...makeRuntime({ batch: false }),
+			getModel: () => undefined,
+		} as unknown as IAgentRuntime;
+
+		const service = (await EmbeddingGenerationService.start(
+			runtime,
+		)) as EmbeddingGenerationService;
+
+		// biome-ignore lint/suspicious/noExplicitAny: inspect private isDisabled state
+		expect((service as any).isDisabled).toBe(true);
+		// biome-ignore lint/suspicious/noExplicitAny: inspect private queue state
+		expect((service as any).batchQueue).toBeNull();
+	});
+
 	test("without a batch handler: tight 100ms per-item drain, no processBatch", async () => {
 		const runtime = makeRuntime({ batch: false });
 		const service = (await EmbeddingGenerationService.start(

--- a/packages/core/src/services/embedding.ts
+++ b/packages/core/src/services/embedding.ts
@@ -5,7 +5,7 @@
  * task scheduler, embedding each memory's text and writing the vector back via
  * `updateMemory`. When a TEXT_EMBEDDING_BATCH model is registered it collapses a
  * per-turn embed burst into one round-trip, falling back per-item on any batch
- * failure; when no TEXT_EMBEDDING model exists it starts disabled so text-only
+ * failure; when neither TEXT_EMBEDDING nor TEXT_EMBEDDING_BATCH exists it starts disabled so text-only
  * deployments still run.
  */
 import type { EmbeddingGenerationPayload } from "../types/events";

--- a/packages/core/src/services/embedding.ts
+++ b/packages/core/src/services/embedding.ts
@@ -48,14 +48,17 @@ export class EmbeddingGenerationService extends Service {
 			"Starting embedding generation service",
 		);
 
-		const embeddingModel = runtime.getModel(ModelType.TEXT_EMBEDDING);
-		if (!embeddingModel) {
+		const hasEmbeddingModel = Boolean(
+			runtime.getModel(ModelType.TEXT_EMBEDDING) ||
+				runtime.getModel(ModelType.TEXT_EMBEDDING_BATCH),
+		);
+		if (!hasEmbeddingModel) {
 			runtime.logger.warn(
 				{
 					src: "plugin:basic-capabilities:service:embedding",
 					agentId: runtime.agentId,
 				},
-				"No TEXT_EMBEDDING model registered - service will not be initialized",
+				"No TEXT_EMBEDDING or TEXT_EMBEDDING_BATCH model registered - service will not be initialized",
 			);
 			const noOpService = new EmbeddingGenerationService(runtime);
 			noOpService.isDisabled = true;


### PR DESCRIPTION
# Relates to

Fixes #20378.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity CLI`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. Checks for either `ModelType.TEXT_EMBEDDING` or `ModelType.TEXT_EMBEDDING_BATCH` in `EmbeddingGenerationService.start` before disabling the service.

# Background

## What does this PR do?

In `packages/core/src/services/embedding.ts`, `EmbeddingGenerationService.start(runtime)` previously checked only `runtime.getModel(ModelType.TEXT_EMBEDDING)`.
If an inference provider registered a batch embedding model (`ModelType.TEXT_EMBEDDING_BATCH`), `start()` logged a warning and disabled the service, even though `initialize()` supports batch embedding through `BatchQueue.processBatch`.

This fix:
1. Updates `EmbeddingGenerationService.start` to check whether either `ModelType.TEXT_EMBEDDING` or `ModelType.TEXT_EMBEDDING_BATCH` is registered before deciding to disable the service.
2. Adds unit tests in `packages/core/src/services/embedding.test.ts` covering batch-only model registration and unconfigured model fallback.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/core/src/services/embedding.ts` and unit tests in `packages/core/src/services/embedding.test.ts`.

## Detailed testing steps

Run `bun run --cwd packages/core test src/services/embedding.test.ts`.

# Evidence Gate

<!-- evidence-head:293c52c12bde977408d2b47733f2d205bb07d5f7 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached: `N/A - non-UI service change`
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached: `N/A - non-UI service change`
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough is attached: `N/A - non-UI service change`
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path: `N/A - verified via unit test suite in packages/core/src/services/embedding.test.ts`
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response: `N/A - non-UI core package`
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached: `N/A - pure background embedding generation service orchestration`
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached: `N/A - unit test assertions cover all outputs`
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached: `N/A - no UI components changed`

# Evidence Details

## Known gaps / failures

None.

AI provider/model: google / gemini-3.7-flash
Client / agent tooling: Antigravity CLI
Contribution skill revision: elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity-contributor]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity CLI","skill_revision":"elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza"} -->
