### PR TITLE
fix(skills): use surrogate-safe truncation in buildSkillCommandSpecs

### DIFF
--- a/packages/skills/src/formatter.ts
+++ b/packages/skills/src/formatter.ts
@@ -4,6 +4,7 @@
  * `disableModelInvocation` are omitted from the prompt (invocable only via an
  * explicit command). Consumed by the enabled-skills provider.
  */
+import { toWellFormedUnicode, truncateWellFormed } from "@elizaos/core";
 import type { Skill, SkillCommandSpec, SkillEntry } from "./types.js";
 
 function compactPromptField(str: string): string {
@@ -120,10 +121,11 @@ export function buildSkillCommandSpecs(
     used.add(unique.toLowerCase());
 
     const rawDescription = entry.skill.description?.trim() || rawName;
+    const wellFormedDescription = toWellFormedUnicode(rawDescription);
     const description =
-      rawDescription.length > SKILL_COMMAND_DESCRIPTION_MAX_LENGTH
-        ? `${rawDescription.slice(0, SKILL_COMMAND_DESCRIPTION_MAX_LENGTH - 1)}…`
-        : rawDescription;
+      wellFormedDescription.length > SKILL_COMMAND_DESCRIPTION_MAX_LENGTH
+        ? `${truncateWellFormed(wellFormedDescription, SKILL_COMMAND_DESCRIPTION_MAX_LENGTH - 1)}…`
+        : wellFormedDescription;
 
     const dispatch = (() => {
       const kindRaw = (

--- a/packages/skills/test/formatter.test.ts
+++ b/packages/skills/test/formatter.test.ts
@@ -189,6 +189,44 @@ describe("buildSkillCommandSpecs", () => {
     assert.ok(specs[0].description.length <= 100);
   });
 
+  it("truncates descriptions without splitting UTF-16 surrogate pairs", () => {
+    // 98 ascii characters followed by 🤖 (which is 2 UTF-16 code units, at indices 98 and 99)
+    const descWithSurrogateAtBoundary = `${"a".repeat(98)}🤖extra`;
+    const entries: SkillEntry[] = [
+      {
+        skill: { name: "emoji-desc", description: descWithSurrogateAtBoundary },
+        frontmatter: {},
+        metadata: {},
+        invocation: {},
+      },
+    ];
+    const specs = buildSkillCommandSpecs(entries);
+    assert.strictEqual(specs[0].description, `${"a".repeat(98)}…`);
+  });
+
+  it("replaces pre-existing lone surrogates before building descriptions", () => {
+    const entries: SkillEntry[] = [
+      {
+        skill: { name: "short", description: "before \uD83D after" },
+        frontmatter: {},
+        metadata: {},
+        invocation: {},
+      },
+      {
+        skill: {
+          name: "boundary",
+          description: `${"a".repeat(98)}\uD83Dextra`,
+        },
+        frontmatter: {},
+        metadata: {},
+        invocation: {},
+      },
+    ];
+    const specs = buildSkillCommandSpecs(entries);
+    assert.strictEqual(specs[0].description, "before � after");
+    assert.strictEqual(specs[1].description, `${"a".repeat(98)}�…`);
+  });
+
   it("handles duplicate skill names by adding numeric suffix", () => {
     const entries: SkillEntry[] = [
       {


### PR DESCRIPTION
# Relates to

Fixes #20379.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `google/gemini-3.7-flash`
<!-- attribution-row:client -->
- Agent tooling: `Antigravity CLI`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync.

# Risks

Low. Uses `truncateWellFormed` instead of raw `.slice()` in `buildSkillCommandSpecs` description truncation to avoid splitting UTF-16 surrogate pairs.

# Background

## What does this PR do?

In `packages/skills/src/formatter.ts`, `buildSkillCommandSpecs` truncates skill descriptions exceeding `SKILL_COMMAND_DESCRIPTION_MAX_LENGTH` (100 characters) using `rawDescription.slice(0, SKILL_COMMAND_DESCRIPTION_MAX_LENGTH - 1)`.
If a 2-code-unit UTF-16 surrogate pair (such as an emoji) lands across the 99-character boundary, raw `.slice()` splits the high and low surrogate, producing an invalid lone surrogate character `\uD8xx` that fails strict JSON parsing or wire transmission.

This fix:
1. Imports `truncateWellFormed` from `@elizaos/core`.
2. Truncates skill descriptions via `truncateWellFormed(rawDescription, SKILL_COMMAND_DESCRIPTION_MAX_LENGTH - 1)`.
3. Adds a unit test in `packages/skills/test/formatter.test.ts` verifying surrogate-safe truncation when emojis land on boundary indices.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review `packages/skills/src/formatter.ts` and unit tests in `packages/skills/test/formatter.test.ts`.

## Detailed testing steps

Run `bun run --cwd packages/skills test`.

# Evidence Gate

<!-- evidence-head:7888de3bf416139c7d0a087cf4013e74ca1b4568 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots are attached: `N/A - non-UI formatter change`
<!-- evidence-row:after-screenshots -->
- [ ] After full-page screenshots are attached: `N/A - non-UI formatter change`
<!-- evidence-row:walkthrough-video -->
- [ ] A video walkthrough is attached: `N/A - non-UI formatter change`
<!-- evidence-row:backend-logs -->
- [ ] Backend logs show the real code path: `N/A - verified via unit test suite in packages/skills/test/formatter.test.ts`
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console and network logs show the request/response: `N/A - non-UI skills package`
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory is attached: `N/A - pure utility command spec formatting helper`
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts are attached: `N/A - unit test assertions cover all outputs`
<!-- evidence-row:ocr-review -->
- [ ] OCR visual-text review output is attached: `N/A - no UI components changed`

# Evidence Details

## Known gaps / failures

None.

AI provider/model: google / gemini-3.7-flash
Client / agent tooling: Antigravity CLI
Contribution skill revision: elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [antigravity-contributor]
<!-- eliza-computer-attribution:v1 {"provider":"google","model":"gemini-3.7-flash","client":"Antigravity CLI","skill_revision":"elizaOS/eliza@aec075c3e30690645ff076ec604bd5b6aa76df3b:packages/skills/skills/contribute-to-eliza"} -->
