### PR TITLE
fix(core): prevent overlapping shared task-scheduler ticks

### DIFF
--- a/packages/core/src/services/task-scheduler.test.ts
+++ b/packages/core/src/services/task-scheduler.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit coverage for the shared task-scheduler tick loop under fake timers:
- * error resilience when getTasks rejects, dirty-agent re-arm/quiet semantics,
- * and not re-arming an agent that unregisters mid-tick.
+ * non-overlapping slow ticks, error resilience when getTasks rejects,
+ * dirty-agent re-arm/quiet semantics, and unregister-during-tick behavior.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { logger } from "../logger";
@@ -75,6 +75,36 @@ describe("task-scheduler", () => {
 		await runOneTick();
 		expect(getTasksCalls).toBe(2);
 		expect(errorSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not start another shared tick while a slow tick is active", async () => {
+		let releaseFirstQuery: ((tasks: Task[]) => void) | undefined;
+		const firstQuery = new Promise<Task[]>((resolve) => {
+			releaseFirstQuery = resolve;
+		});
+		const getTasks = vi
+			.fn<() => Promise<Task[]>>()
+			.mockReturnValueOnce(firstQuery)
+			.mockResolvedValue([]);
+
+		startTaskScheduler({ getTasks } as unknown as IDatabaseAdapter);
+		registerTaskSchedulerRuntime(makeRuntime(), {
+			runTick: vi.fn(async () => undefined),
+		});
+
+		await runOneTick();
+		expect(getTasks).toHaveBeenCalledTimes(1);
+
+		// A second interval fires before the first query settles. It must not
+		// snapshot or dispatch the same dirty-agent batch concurrently.
+		await runOneTick();
+		expect(getTasks).toHaveBeenCalledTimes(1);
+
+		releaseFirstQuery?.([]);
+		await vi.advanceTimersByTimeAsync(0);
+		markTaskSchedulerDirty(AGENT_ID);
+		await runOneTick();
+		expect(getTasks).toHaveBeenCalledTimes(2);
 	});
 
 	it("re-arms a still-registered agent after a transient getTasks rejection (no re-register)", async () => {

--- a/packages/core/src/services/task-scheduler.ts
+++ b/packages/core/src/services/task-scheduler.ts
@@ -27,6 +27,7 @@ const registry = new Map<
 const dirtyAgents = new Set<string>();
 let timer: ReturnType<typeof setInterval> | null = null;
 let adapter: IDatabaseAdapter | null = null;
+let activeTick: Promise<void> | null = null;
 
 const TICK_INTERVAL_MS = 1000;
 
@@ -124,9 +125,15 @@ export function startTaskScheduler(adapterInstance: IDatabaseAdapter): void {
 	adapter = adapterInstance;
 	if (timer) return;
 	timer = setInterval(() => {
+		if (activeTick) return;
 		// error-policy:J1 The process timer is the outer scheduler boundary; per-agent
 		// failures are reported inside tick, while adapter-level failure is logged here.
-		tick().catch((err) => logger.error({ err }, "[TaskScheduler] tick failed"));
+		const tickPromise = tick()
+			.catch((err) => logger.error({ err }, "[TaskScheduler] tick failed"))
+			.finally(() => {
+				if (activeTick === tickPromise) activeTick = null;
+			});
+		activeTick = tickPromise;
 	}, TICK_INTERVAL_MS) as ReturnType<typeof setInterval>;
 }
 


### PR DESCRIPTION
# Relates to

Closes #20396.

- [x] Targets `develop` and is rebased onto current `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile` and `bun run verify` passed after sync.
- [x] The slow-tick concurrency regression is covered by a deterministic committed test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`, `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`, `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@764695f33de8aae99308464b3903f392292e2bd1:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

Original implementation: byt61. Maintainer review, concurrency test, clean rebase, and exact-head validation: lalalune.

# Sync with develop

- [x] Cleanly rebased onto `origin/develop@46c0081d875c395f60e774c8e6bb611a0d6ad7a2`.
- [x] Exact head `02df336cafa4bcb502973b028658b05d8483d045` passes focused core checks and `bun run verify`.

# Risks

Low. The process-wide scheduler now enforces the same single-active-tick invariant as `TaskService`. If a database query or dispatch exceeds the one-second interval, the next interval is skipped; scheduling resumes after settlement. This trades accidental concurrent load and duplicate dispatch risk for bounded serialization.

# Background

## What does this PR do?

- Tracks the shared scheduler's active tick and refuses to start an overlapping tick.
- Clears the guard in `finally`, including after adapter errors, so later intervals recover.
- Adds a deterministic fake-timer test that holds the first database query open, fires another interval, proves no second query starts, releases the first query, and proves scheduling resumes.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No. This restores the existing serialized scheduling invariant without changing a public API.

# Testing

## Where should a reviewer start?

- `packages/core/src/services/task-scheduler.ts`: active-tick guard and settlement cleanup.
- `packages/core/src/services/task-scheduler.test.ts`: committed slow-query overlap regression.

## Detailed testing steps

```text
bun install --frozen-lockfile
bunx vitest run packages/core/src/services/task-scheduler.test.ts
bun run --cwd packages/core typecheck
bun run --cwd packages/core lint:check
bun run verify
```

Exact-head results:

- Scheduler suite: 8 passed, 0 failed.
- Core typecheck: passed.
- Core Biome check: 1,261 files clean.
- Root verify: 351/351 tasks, all build/typecheck/workflow/script/test-lane/view-inventory audits green, anti-larp clean across 8,289 test files.

# Evidence Gate

<!-- evidence-head:02df336cafa4bcb502973b028658b05d8483d045 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive UI flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - the scheduler race is exercised directly at its process-timer boundary by the committed deterministic test.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or request path changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent schema or artifact changed; call cardinality and recovery are asserted directly.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface changed.

# Evidence Details

```text
Test Files  1 passed (1)
Tests       8 passed (8)

Tasks:     351 successful, 351 total
[audit-build-typecheck] consistent
[audit-turbo-build-deps] no phantom edges or cycles
[workflow-trigger-policy] verified 48 workflows
[anti-larp] scanned 8289 test files; clean
```

## Known gaps / failures

None.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used for the maintainer repair
Attribution status: self-reported
— [qa-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used for the maintainer repair"} -->
