### PR TITLE
fix(cloud): reject malformed gateway-relay timeoutMs

### DIFF
--- a/packages/cloud/api/v1/eliza/gateway-relay/sessions/[sessionId]/next/route.test.ts
+++ b/packages/cloud/api/v1/eliza/gateway-relay/sessions/[sessionId]/next/route.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Fail-closed timeoutMs contract for the gateway-relay long-poll.
+ *
+ * GET .../sessions/:sessionId/next must reject prefix-coercible garbage
+ * (parseInt("1e4", 10) === 1) before pollNextRequest. Missing or empty
+ * timeoutMs stays at the documented 25s cap.
+ */
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { Hono } from "hono";
+
+const authenticatedUser = {
+  id: "user-1",
+  organization_id: "org-1",
+};
+
+const ownedSession = {
+  id: "session-1",
+  organizationId: "org-1",
+  userId: "user-1",
+  runtimeAgentId: "runtime-1",
+  agentName: "relay",
+  platform: "local-runtime" as const,
+  createdAt: "2026-08-16T00:00:00.000Z",
+  lastSeenAt: "2026-08-16T00:00:00.000Z",
+};
+
+const getSession = mock(async (_sessionId: string) => ownedSession);
+const pollNextRequest = mock(
+  async (_sessionId: string, _timeoutMs: number) => null,
+);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: mock(async () => authenticatedUser),
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (_c: unknown, error: unknown) => {
+    throw error;
+  },
+}));
+mock.module("@/lib/services/agent-gateway-relay", () => ({
+  agentGatewayRelayService: {
+    getSession,
+    pollNextRequest,
+  },
+}));
+
+const { default: nextRoute, parseTimeoutMs } = await import("./route");
+const app = new Hono().route("/:sessionId/next", nextRoute);
+
+function getNext(query = "") {
+  return app.request(`/session-1/next${query}`);
+}
+
+describe("parseTimeoutMs", () => {
+  it.each([
+    [undefined, 25_000],
+    ["", 25_000],
+    ["1", 1],
+    ["5000", 5000],
+    ["25000", 25_000],
+  ] as const)("accepts %s", (raw, expected) => {
+    expect(parseTimeoutMs(raw)).toEqual({ ok: true, value: expected });
+  });
+
+  it.each([
+    ["scientific notation", "1e4"],
+    ["trailing junk", "12px"],
+    ["leading zero", "007"],
+    ["signed", "-1"],
+    ["zero", "0"],
+    ["prefix junk", "25000abc"],
+  ] as const)("rejects %s %s", (_label, raw) => {
+    const result = parseTimeoutMs(raw);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain("timeoutMs");
+    expect(result.error).toContain(raw);
+  });
+});
+
+const invalidTimeoutMs = [
+  ["scientific notation", "1e4"],
+  ["trailing junk", "12px"],
+  ["leading zero", "007"],
+  ["signed", "-1"],
+  ["zero", "0"],
+  ["prefix junk", "25000abc"],
+  ["signed plus", "+1"],
+  ["fractional", "1.5"],
+  ["hex", "0x10"],
+  ["whitespace only", "   "],
+  ["leading whitespace", " 5000"],
+  ["trailing whitespace", "5000 "],
+  ["over the 25s cap", "25001"],
+] as const;
+
+describe("GET /api/v1/eliza/gateway-relay/sessions/:sessionId/next timeoutMs", () => {
+  beforeEach(() => {
+    getSession.mockClear();
+    getSession.mockResolvedValue(ownedSession);
+    pollNextRequest.mockClear();
+    pollNextRequest.mockResolvedValue(null);
+  });
+
+  it("omitted timeoutMs uses the 25s cap and polls", async () => {
+    const response = await getNext();
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      success: boolean;
+      data: { request: null };
+    };
+    expect(body).toEqual({
+      success: true,
+      data: { request: null },
+    });
+    expect(pollNextRequest).toHaveBeenCalledTimes(1);
+    expect(pollNextRequest).toHaveBeenCalledWith("session-1", 25_000);
+  });
+
+  it("empty timeoutMs uses the 25s cap and polls", async () => {
+    const response = await getNext("?timeoutMs=");
+    expect(response.status).toBe(200);
+    expect(pollNextRequest).toHaveBeenCalledWith("session-1", 25_000);
+  });
+
+  it.each([
+    ["1", 1],
+    ["5000", 5000],
+    ["25000", 25_000],
+  ] as const)("canonical timeoutMs=%s polls with %s", async (raw, expected) => {
+    const response = await getNext(`?timeoutMs=${raw}`);
+    expect(response.status).toBe(200);
+    expect(pollNextRequest).toHaveBeenCalledTimes(1);
+    expect(pollNextRequest).toHaveBeenCalledWith("session-1", expected);
+  });
+
+  it.each(invalidTimeoutMs)(
+    "returns 400 and does not poll for %s timeoutMs=%s",
+    async (_label, raw) => {
+      const response = await getNext(`?timeoutMs=${encodeURIComponent(raw)}`);
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { success: false; error: string };
+      expect(body.success).toBe(false);
+      expect(body.error).toContain("timeoutMs");
+      expect(body.error).toContain(raw);
+      expect(pollNextRequest).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/eliza/gateway-relay/sessions/[sessionId]/next/route.ts
+++ b/packages/cloud/api/v1/eliza/gateway-relay/sessions/[sessionId]/next/route.ts
@@ -14,12 +14,51 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
-function parseTimeoutMs(raw: string | undefined): number {
-  const parsed = raw ? Number.parseInt(raw, 10) : 25_000;
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    return 25_000;
+const DEFAULT_TIMEOUT_MS = 25_000;
+const MIN_TIMEOUT_MS = 1;
+const MAX_TIMEOUT_MS = 25_000;
+
+export type TimeoutMsParseResult =
+  | { ok: true; value: number }
+  | { ok: false; error: string };
+
+/**
+ * Canonical long-poll wait at the HTTP boundary.
+ * Missing or empty defaults to the 25s platform cap. Any other token must be
+ * a complete ASCII decimal integer in [1, 25000] — no sign, zero, fraction,
+ * hex, scientific notation, leading zeros, whitespace, junk, or values above
+ * the cap. Prefix-legal garbage must not coerce (parseInt("1e4", 10) is 1
+ * and would return empty immediately instead of waiting 10s).
+ */
+export function parseTimeoutMs(raw: string | undefined): TimeoutMsParseResult {
+  if (raw === undefined || raw === "") {
+    return { ok: true, value: DEFAULT_TIMEOUT_MS };
   }
-  return Math.min(parsed, 25_000);
+
+  if (!/^(?:0|[1-9]\d*)$/.test(raw)) {
+    return {
+      ok: false,
+      error: `Invalid timeoutMs ${JSON.stringify(
+        raw,
+      )}: expected a canonical decimal integer`,
+    };
+  }
+
+  const parsed = Number(raw);
+  if (
+    !Number.isSafeInteger(parsed) ||
+    parsed < MIN_TIMEOUT_MS ||
+    parsed > MAX_TIMEOUT_MS
+  ) {
+    return {
+      ok: false,
+      error: `Invalid timeoutMs ${JSON.stringify(
+        raw,
+      )}: expected an integer between 1 and 25000`,
+    };
+  }
+
+  return { ok: true, value: parsed };
 }
 
 app.get("/", async (c) => {
@@ -39,9 +78,14 @@ app.get("/", async (c) => {
       return c.json({ success: false, error: "Forbidden" }, 403);
     }
 
+    const timeout = parseTimeoutMs(c.req.query("timeoutMs"));
+    if (!timeout.ok) {
+      return c.json({ success: false, error: timeout.error }, 400);
+    }
+
     const requestEnvelope = await agentGatewayRelayService.pollNextRequest(
       sessionId,
-      parseTimeoutMs(c.req.query("timeoutMs")),
+      timeout.value,
     );
 
     return c.json({


### PR DESCRIPTION
Closes #20395.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun run verify` passed after sync at the exact published head.
- [x] A reviewer can confirm the change from the focused route test and service-call assertions below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- AI provider/model: xAI / grok-4.6; OpenAI / gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: `Grok Build TUI`, `Claude Code CLI Proxy`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `764695f33d`; zero conflicts.
- [x] `bun run verify` passed post-sync at `a88d6bb9a6d8774427266dc2940cdd7751c2447d`.

# Risks

Low and bounded to one long-poll query boundary. Clients sending canonical integers `1..25000` are unchanged. Missing or empty values still receive the 25-second default. Malformed values that were previously coerced or silently defaulted now receive HTTP 400. No storage, billing, authorization, or sibling route changes.

# Background

## What does this PR do?

Replace prefix-coercing `Number.parseInt` handling at `GET /api/v1/eliza/gateway-relay/sessions/:sessionId/next` with a canonical decimal parser:

- missing or empty `timeoutMs` defaults to `25000`;
- canonical integers `1..25000` pass through unchanged;
- scientific notation, suffix/prefix junk, signs, zero, fractions, hex, leading zeros, whitespace, and values above `25000` return HTTP 400 before `pollNextRequest`.

The colocated Hono route test covers both the parser result and the service-call/no-call boundary. Independent review tightened the initial patch so whitespace-only input is rejected rather than treated as an omitted value.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

## Why are we doing this? Any context or related work?

`Number.parseInt("1e4", 10) === 1`, so a client asking for a 10-second long-poll could instead wait 1 ms and receive an empty envelope. The same prefix coercion accepted values such as `12px` and `25000abc`.

# Documentation changes needed?

No. This restores the route's existing bounded-timeout contract.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/eliza/gateway-relay/sessions/[sessionId]/next/route.test.ts`

## Detailed testing steps

```bash
bun test 'packages/cloud/api/v1/eliza/gateway-relay/sessions/[sessionId]/next/route.test.ts'
bun run --cwd packages/cloud/api typecheck
bun run --cwd packages/cloud/api lint:check
bun run verify
```

Observed at the exact published head:

- focused route suite: **29 passed, 0 failed, 103 assertions**;
- cloud API TypeScript check and Wrangler production worker dry-run: passed;
- cloud API Biome check: **1,097 files checked, no fixes**;
- repository `bun run verify`: passed;
- `git diff --check origin/develop...HEAD`: clean.

The tests-first baseline against unmodified production produced **12 failures and 5 passes** for the malformed-input cases.

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:a88d6bb9a6d8774427266dc2940cdd7751c2447d -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only query validation; no rendered UI surface changed
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only query validation; no rendered UI surface changed
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive or visual user flow changed
<!-- evidence-row:backend-logs -->
- [x] Focused Hono route suite: 29 passed / 0 failed / 103 assertions; malformed values return 400 and never call `pollNextRequest`
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or agent behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] Cloud API TypeScript check plus Wrangler production worker dry-run passed at the exact head
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or visual text changed

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

The colocated route test drives the real Hono parser and asserts the downstream relay service call. Invalid values return 400 with zero `pollNextRequest` calls; valid values pass the exact canonical integer.

## Screenshots (before / after) + video walkthrough

N/A - backend-only GET query validation; no visual surface.

## Known gaps / failures

None. Focused tests, owning-package typecheck/bundle/lint, and the repository verification gate all passed at the exact published head.

<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Grok Build TUI","skill_revision":"N/A - no contribution skill used"} -->
