### PR TITLE
test(app): wait for startup before cloud audit capture

### DIFF
--- a/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
@@ -10,6 +10,7 @@ import {
   evaluateStrictGate,
   readReadableCharsWithNavigationRetry,
 } from "./aesthetic-audit-rules";
+import { openAppPath } from "./helpers";
 import {
   collectBlueColors,
   collectHoverViolations,
@@ -694,7 +695,10 @@ test.describe("cloud-surfaces aesthetic audit (#10725/#11342)", () => {
             });
           });
         }
-        await page.goto(auditCase.path, { waitUntil: "domcontentloaded" });
+        // The static preboot and StartupScreen copy are not route readiness.
+        // Reuse the shared bounded startup contract so a cold "Booting up..."
+        // splash cannot satisfy the readable-character gate and pass green.
+        await openAppPath(page, auditCase.path);
 
         if (auditCase.slug === "get-started-success") {
           await page


### PR DESCRIPTION
# Relates to

Closes #20368.

- [x] Targets `develop` and was rebased by a maintainer onto exact `origin/develop@a689e29bbc8e03a5050940ea2aec26f6f3bf25d8` with zero conflicts.
- [x] Frozen install and focused validation were run after sync. Full app typecheck remains blocked by unrelated unbuilt optional workspace packages, documented below.
- [x] A reviewer can confirm the behavior from the real cold-audit transcript and exact captured route described below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no repository contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop@a689e29bbc8e03a5050940ea2aec26f6f3bf25d8`; zero conflicts.
- [ ] Full `bun run verify` was not rerun for this one-file Playwright harness change; focused real-browser validation passed, while app typecheck is blocked by unrelated unbuilt optional workspace packages as documented below.

# Risks

Low. Production code and rendered UI are unchanged. Cloud aesthetic-audit route cases now use the existing shared bounded startup/readiness helper already used by the UI smoke suite. A genuine startup failure can make the audit fail instead of producing a false green.

# Background

## What does this PR do?

- Reuses `openAppPath()` for cloud aesthetic-audit route navigation.
- Waits for static preboot and `StartupScreen` settlement before applying readable-content gates.
- Replays the requested route after startup, matching established UI smoke-test behavior.

## What kind of change is this?

Test-harness correctness fix with no production behavior change.

## Root cause

The cloud aesthetic audit navigated directly with `page.goto()` and then accepted any body with at least 10 readable characters. On a cold renderer start, the 19-character `Booting up...` splash met that threshold, so the audit could pass and save a startup-only screenshot without validating the requested route.

The existing `openAppPath()` helper already provides the bounded startup-shell wait, first-run interception detection, post-startup navigation replay, and telemetry checks used by the UI smoke suite.

# Documentation changes needed?

No. This corrects internal test navigation and does not change a user workflow or public API.

# Testing

## Where should a reviewer start?

Review the navigation call in `packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts`, then run the focused cold payment-request desktop audit once. The first capture must show the payment page, not `Booting up...`.

## Detailed testing steps

- `bun run --cwd packages/app audit:cloud --grep 'payment-request desktop'` — 1/1 cold single-iteration route case passed.
- Manually inspected `packages/app/aesthetic-audit-output-cloud/desktop/payment-request.png`; the first and only capture shows the complete $5 payment-request page and CTA, not the startup splash.
- `bunx @biomejs/biome check packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts` — passed on rebased head.
- `git diff --check origin/develop...HEAD` — passed on rebased head.
- `packages/app-core` build — passed.

# Evidence Gate

<!-- evidence-head:99d05301dd61ba20da32c83ae87ca65e554b2bf3 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-harness-only change; production rendering is unchanged, and the reported before artifact is the cold `Booting up...` false green described in #20368.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-harness-only change; the real after capture was manually inspected locally and shows the unchanged payment page rather than a new UI state.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no product flow or rendered UI changed; the regression is a deterministic one-shot Playwright capture.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend path changed; this patch only changes Playwright navigation readiness.
<!-- evidence-row:frontend-logs -->
- [x] Focused real-browser transcript:

  ```text
  Running 1 test using 1 worker
  [cloud-aesthetic-audit] 1 findings — broken=0 needs-work=0 needs-eyeball=1 good=0
  ok 1 [audit-cloud] › cloud-surfaces-aesthetic-audit.spec.ts › payment-request desktop (2.5s); 1 passed (3.7m including cold prerequisite builds)
  ```
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistence or domain artifact changed; audit screenshots are ephemeral test output.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered UI source changed; the captured page was manually inspected only to prove route readiness.

# Known gaps / failures

- `bun run --cwd packages/app typecheck` advanced after building `packages/app-core` but remains blocked by unrelated unbuilt optional workspace packages including `@elizaos/auth`, vault, plugin, and cloud SDK packages. No diagnostic points to the changed Playwright harness file.
- Full root `bun run verify` was not rerun for this one-file harness-only patch. The focused real cold browser audit, changed-file Biome, and diff checks pass on the published head.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [codex-cloud-audit-startup]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no repository contribution skill used"} -->
