### PR TITLE
fix(ui): recover hosted login after browser Back

### DIFF
--- a/packages/app/test/ui-smoke/managed-login-stability.spec.ts
+++ b/packages/app/test/ui-smoke/managed-login-stability.spec.ts
@@ -355,6 +355,15 @@ for (const surface of SURFACES) {
       });
     });
 
+    await page.addInitScript(() => {
+      window.addEventListener("pageshow", (event) => {
+        Object.defineProperty(window, "__elizaLoginHistoryRestore", {
+          configurable: true,
+          value: event.persisted,
+        });
+      });
+    });
+
     // Loopback is a browser trustworthy origin, so this reaches the real
     // WebCrypto-backed PKCE boundary. The canonical-host HTTP proxy used by
     // the handoff tests is intentionally not secure and cannot expose subtle.
@@ -381,6 +390,40 @@ for (const surface of SURFACES) {
       consoleMessages.filter((message) => message.type === "error"),
     ).toEqual([]);
 
+    await page.goBack();
+    await expect(google).toBeVisible();
+    await expect(google).toBeEnabled();
+    await expect(
+      page.getByRole("button", { name: "Discord", exact: true }),
+    ).toBeEnabled();
+    await expect(
+      page.getByRole("button", { name: "GitHub", exact: true }),
+    ).toBeEnabled();
+    const restoredFromHistory = await page.evaluate(
+      () =>
+        (
+          window as typeof window & {
+            __elizaLoginHistoryRestore?: boolean;
+          }
+        ).__elizaLoginHistoryRestore,
+    );
+    expect(restoredFromHistory).toEqual(expect.any(Boolean));
+    await page.waitForTimeout(STABILITY_WINDOW_MS);
+    await expect(google).toBeEnabled();
+    const expectedDocumentPaths: Array<
+      string | ReturnType<typeof expect.stringContaining>
+    > = ["/login", expect.stringContaining("/auth/oauth/google/authorize")];
+    if (!restoredFromHistory) expectedDocumentPaths.push("/login");
+    expect(documentRequests.map((url) => new URL(url).pathname)).toEqual(
+      expectedDocumentPaths,
+    );
+    expect(popupCount).toBe(0);
+    expect(authorizeRequests).toBe(1);
+    expect(failures).toEqual([]);
+    expect(
+      consoleMessages.filter((message) => message.type === "error"),
+    ).toEqual([]);
+
     if (process.env.E2E_RECORD === "1") {
       await page.screenshot({
         path: testInfo.outputPath(`${surface.name}-oauth-current-document.png`),
@@ -395,6 +438,7 @@ for (const surface of SURFACES) {
             documentRequests,
             popupCount,
             authorizeRequests,
+            restoredFromHistory,
             failures,
             consoleMessages,
           },

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.oauth-launch.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.oauth-launch.test.tsx
@@ -160,6 +160,41 @@ describe("StewardLoginSection OAuth launch", () => {
     },
   );
 
+  it("releases the OAuth provider lock after a back-forward cache restoration", async () => {
+    renderSection();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Google" }));
+
+    await waitFor(() =>
+      expect(window.location.href).toContain(
+        "/steward/auth/oauth/google/authorize",
+      ),
+    );
+    expect(
+      (screen.getByRole("button", { name: "Google" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+
+    const historyRestore = new Event("pageshow");
+    Object.defineProperty(historyRestore, "persisted", { value: true });
+    fireEvent(window, historyRestore);
+
+    await waitFor(() =>
+      expect(
+        (screen.getByRole("button", { name: "Google" }) as HTMLButtonElement)
+          .disabled,
+      ).toBe(false),
+    );
+    expect(
+      (screen.getByRole("button", { name: "Discord" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+    expect(
+      (screen.getByRole("button", { name: "GitHub" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+  });
+
   it("keeps the form retryable when browser storage cannot save the verifier", async () => {
     oauthState.storeVerifier = false;
     renderSection();

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -514,6 +514,36 @@ export default function StewardLoginSection() {
     providers.passkey !== false && passkeyCapability?.usable === true;
 
   useEffect(() => {
+    const recoverOAuthIntentAfterHistoryRestore = (
+      event: PageTransitionEvent,
+    ) => {
+      if (!event.persisted) return;
+      setLoading((current) => {
+        if (
+          current === "google" ||
+          current === "discord" ||
+          current === "github"
+        ) {
+          return null;
+        }
+        return current;
+      });
+    };
+
+    // OAuth owns the current document, but browser Back may revive this React
+    // tree from the back/forward cache with its pre-navigation loading state.
+    // A fresh load already starts idle; only a persisted history restoration
+    // needs to release the provider lock (#20385).
+    window.addEventListener("pageshow", recoverOAuthIntentAfterHistoryRestore);
+    return () => {
+      window.removeEventListener(
+        "pageshow",
+        recoverOAuthIntentAfterHistoryRestore,
+      );
+    };
+  }, []);
+
+  useEffect(() => {
     if (PLAYWRIGHT_TEST_AUTH_ENABLED) {
       setProvidersLoaded(true);
       return;


### PR DESCRIPTION
# Relates to

Closes #20385.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] The affected UI, browser, type, lint, and visual gates pass on the final source tree.
- [ ] Exact-head hosted repository checks must pass before merge; the local exact root retry was interrupted only by shared-volume ENOSPC.
- [x] A reviewer can confirm the regression and recovery from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop@09ca1a7c2b2e7bccedd6a8e33a4bf279209f8ec6`; zero conflicts.
- [x] The final base-only rebase changed two unrelated files and left `packages/app` and `packages/ui` byte-identical to the validated/captured trees.
- [x] Prior exact uncached root verification passed 351/351 with all audits. A later exact retry reached 134 successful tasks and stopped only when the shared volume returned `ENOSPC` while extracting package tarballs; it reported no product failure before that external stop.

# Risks

Low and isolated to hosted OAuth history restoration. The new listener only handles a persisted `pageshow` event and only clears the three hosted OAuth loading discriminants (`google`, `discord`, `github`). Email, phone, passkey, wallet, callback exchange, and non-persisted page lifecycle state are unchanged. The listener is removed on component cleanup.

# Background

## What does this PR do?

After the current-document OAuth fix reached staging, Google correctly navigated the existing tab with no popup. Browser Back could then restore the login document from the back-forward cache with React's pre-navigation `loading="google"` state still frozen. Every authentication control remained disabled indefinitely even though the user was back on `/login`.

This patch treats a persisted `pageshow` as a browser-history recovery boundary. It clears only a stale hosted-provider launch state, making all login choices usable again without reloading the document, remounting the page, or disturbing active non-OAuth work.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No product documentation change is required; this is an internal browser lifecycle correction.

# Testing

## Where should a reviewer start?

- `packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx`
- `packages/ui/src/cloud/public-pages/pages/login/steward-login-section.oauth-launch.test.tsx`
- `packages/app/test/ui-smoke/managed-login-stability.spec.ts`

## Detailed testing steps

1. Open hosted `/login?returnTo=%2F`.
2. Click Google, Discord, or GitHub and confirm the existing tab navigates; no sibling popup opens.
3. Use browser Back without completing provider sign-in.
4. Confirm every login choice is enabled immediately and stays enabled beyond the previous ten-second stuck window.
5. Confirm no repeated document reload, duplicate authorize request, page/request failure, or error-level console message occurs.

Validated source gates:

- Exact-head login Vitest directory: 14 files, 69 tests pass.
- Exact-head UI typecheck passes after rebuilding its generated workspace prerequisites; changed-file Biome and `git diff --check` pass.
- Chromium desktop/mobile: 2/2 pass. Each records one authorize request, zero popups, zero request failures, and no error-level console messages; all hosted-provider controls remain enabled through the stability window after history return.
- `bun run --cwd packages/app audit:app`: 219/219 captures, broken=0, needs-work=0, strict visual probes clean; packaged OCR 216 views, broken=0, regressions=0.
- Uncached root verification passed 351/351 at the rendered-equivalent predecessor. Exact-head hosted checks are the merge gate because the local exact retry was externally stopped by ENOSPC rather than a test failure.

# Evidence Gate

<!-- evidence-head:3b8ec807ba7dbb2afe8c1ec1375a485512c8edf3 -->

<!-- evidence-row:before-screenshots -->
- [x] Live staging failure after browser Back: [desktop JPG](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20385-before-staging-back-disabled.jpg).
<!-- evidence-row:after-screenshots -->
- [x] Corrected history-return state: [desktop JPG](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20385-after-history-desktop.jpg) and [mobile JPG](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20385-after-history-mobile.jpg).
<!-- evidence-row:walkthrough-video -->
- [x] H.264 walkthroughs: [desktop MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20385-history-desktop.mp4) and [mobile MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20385-history-mobile.mp4).
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend implementation changes; the deterministic authorize endpoint is intercepted before provider egress.
<!-- evidence-row:frontend-logs -->
- [x] Console/network/history records: [live before state](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20385-before-staging-back-disabled.txt), [desktop JSON](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20385-frontend-desktop.json), and [mobile JSON](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20385-frontend-mobile.json).
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, model-provider, or LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head evidence provenance and hashes](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20385-evidence-provenance-3b8ec80.txt).
<!-- evidence-row:ocr-review -->
- [x] [Affected-surface manual/OCR review](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20385-ocr-review-3b8ec80.txt), [app audit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20385-app-audit-report.json), and [packaged OCR triage](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20385-app-audit-ocr.json).

# Evidence Details

## Before

![Live staging login disabled after Back](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20385-before-staging-back-disabled.jpg)

The live capture records all seven authentication controls still disabled after a ten-second observation. The same browser tab was used, no account was selected, and no credential was submitted.

## After

![Desktop history recovery](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20385-after-history-desktop.jpg)

![Mobile history recovery](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20385-after-history-mobile.jpg)

[Desktop H.264 MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20385-history-desktop.mp4) · [Mobile H.264 MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20385-history-mobile.mp4)

## Known gaps / failures

- The local Vite/WebSocket harness is intentionally not bfcache-eligible, so its browser history path performs one fresh document reload and records `restoredFromHistory=false`. The browser contract allows that extra document only for this explicit condition. The live staging before capture supplies the real bfcache reproduction; postdeploy staging acceptance will repeat it against the hosted build.
- Pixel and browser artifacts were captured on `a89c58313d904ecbcc353bdd6e6f02fc586f6160`; the affected production source and browser spec are byte-identical at exact evidence head `3b8ec807ba7dbb2afe8c1ec1375a485512c8edf3`. The linked provenance artifact includes hashes and the base-only rebase disclosure.
- The exact local root retry was stopped by shared-volume ENOSPC, not a product assertion. Merge remains gated on exact-head hosted checks.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
