### PR TITLE
fix(cloud): reject malformed relay poll timeouts

### DIFF
--- a/packages/cloud/api/v1/eliza/gateway-relay/sessions/[sessionId]/next/route.test.ts
+++ b/packages/cloud/api/v1/eliza/gateway-relay/sessions/[sessionId]/next/route.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Exercises the gateway-relay long-poll route with deterministic auth and
+ * service boundaries, including rejection before polling for invalid timeouts.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const getSession = mock(async () => ({
+  organizationId: "org-1",
+  userId: "user-1",
+}));
+const pollNextRequest = mock(async () => null);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: mock(async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  })),
+}));
+
+mock.module("@/lib/services/agent-gateway-relay", () => ({
+  agentGatewayRelayService: {
+    getSession,
+    pollNextRequest,
+  },
+}));
+
+const { default: nextRoute } = await import("./route");
+
+const app = new Hono();
+app.route("/api/v1/eliza/gateway-relay/sessions/:sessionId/next", nextRoute);
+
+async function requestWithTimeout(timeoutMs?: string): Promise<Response> {
+  const query = timeoutMs === undefined ? "" : `?timeoutMs=${timeoutMs}`;
+  return app.request(
+    `/api/v1/eliza/gateway-relay/sessions/session-1/next${query}`,
+  );
+}
+
+beforeEach(() => {
+  getSession.mockClear();
+  pollNextRequest.mockClear();
+});
+
+describe("gateway-relay next-request timeout", () => {
+  test.each([
+    "+1",
+    "-1",
+    "0",
+    "1.5",
+    "0x10",
+    "1e3",
+    "01",
+    "%201",
+    "1%20",
+    "10junk",
+    "25001",
+  ])("rejects non-canonical timeout token %s before polling", async (token) => {
+    const response = await requestWithTimeout(token);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ success: false });
+    expect(pollNextRequest).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    [undefined, 25_000],
+    ["", 25_000],
+    ["1", 1],
+    ["24999", 24_999],
+    ["25000", 25_000],
+  ] as const)("maps timeout token %s to %i", async (token, expected) => {
+    const response = await requestWithTimeout(token);
+
+    expect(response.status).toBe(200);
+    expect(pollNextRequest).toHaveBeenCalledTimes(1);
+    expect(pollNextRequest).toHaveBeenCalledWith("session-1", expected);
+  });
+});

--- a/packages/cloud/api/v1/eliza/gateway-relay/sessions/[sessionId]/next/route.ts
+++ b/packages/cloud/api/v1/eliza/gateway-relay/sessions/[sessionId]/next/route.ts
@@ -2,8 +2,8 @@
  * GET /api/v1/eliza/gateway-relay/sessions/:sessionId/next
  *
  * Long-poll for the next bridge request envelope on this relay session.
- * Caps the wait at 25s so platform-level edge timeouts can never strand a
- * client waiting on a closed connection.
+ * Accepts only canonical millisecond values through 25s so platform-level
+ * edge timeouts can never strand a client waiting on a closed connection.
  */
 
 import { Hono } from "hono";
@@ -14,12 +14,17 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
-function parseTimeoutMs(raw: string | undefined): number {
-  const parsed = raw ? Number.parseInt(raw, 10) : 25_000;
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+function parseTimeoutMs(raw: string | undefined): number | null {
+  if (raw === undefined || raw === "") {
     return 25_000;
   }
-  return Math.min(parsed, 25_000);
+
+  if (!/^[1-9][0-9]*$/.test(raw)) {
+    return null;
+  }
+
+  const parsed = Number(raw);
+  return parsed <= 25_000 ? parsed : null;
 }
 
 app.get("/", async (c) => {
@@ -39,9 +44,20 @@ app.get("/", async (c) => {
       return c.json({ success: false, error: "Forbidden" }, 403);
     }
 
+    const timeoutMs = parseTimeoutMs(c.req.query("timeoutMs"));
+    if (timeoutMs === null) {
+      return c.json(
+        {
+          success: false,
+          error: "timeoutMs must be a canonical integer from 1 to 25000",
+        },
+        400,
+      );
+    }
+
     const requestEnvelope = await agentGatewayRelayService.pollNextRequest(
       sessionId,
-      parseTimeoutMs(c.req.query("timeoutMs")),
+      timeoutMs,
     );
 
     return c.json({


### PR DESCRIPTION
# Relates to

Closes #20395.

- [x] Targets `develop` and is rebased onto exact `origin/develop@09ca1a7c2b2e7bccedd6a8e33a4bf279209f8ec6` with zero conflicts.
- [x] Rejects malformed input before the long-poll service call; no retry, clamp, or fallback hides the error.
- [x] Exact-head focused, Cloud Worker, and uncached repository gates pass.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact base: `origin/develop@09ca1a7c2b2e7bccedd6a8e33a4bf279209f8ec6`.
- [x] Published exact head: `22c8d7a5b035146a18f352046e798a699d555935`.
- [x] Exact-head root verify passed uncached: 351/351 tasks, every repository audit, anti-larp 8,290 files with zero focused tests or orphaned skips.

# Risks

Low and bounded to the gateway-relay `timeoutMs` query boundary. Previously accepted malformed values now receive HTTP 400. Missing and explicitly empty values retain the documented 25-second default, and valid canonical values retain their exact wait. No sibling route, storage, billing, authorization, or production data changes.

# Background

## What does this PR do?

The route used `Number.parseInt`, which silently reinterpreted tokens such as `1e4`, `12px`, `007`, and `1.5`, while zero/negative inputs fell back to 25 seconds and oversized inputs were clamped.

This PR requires the entire non-empty token to be an unsigned ASCII decimal integer in `[1, 25000]`. Invalid values return a visible 400 response before `pollNextRequest`. The colocated route test proves all malformed cases make zero service calls.

No timeout, retry, catch-and-continue, or fabricated fallback is introduced.

## What kind of change is this?

Bug fix (fail-fast correction to an existing HTTP input contract).

# Documentation changes needed?

No; this enforces the issue's documented gateway-relay query contract.

# Testing

## Where should a reviewer start?

Open the [exact-head validation transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20395-relay-timeout-validation-22c8d7a.md). It records the adversarial boundary matrix, production Worker dry-run, uncached root verification, and the transparent local install-space disclosure.

## Detailed testing steps

```bash
bun test 'packages/cloud/api/v1/eliza/gateway-relay/sessions/[sessionId]/next/route.test.ts'
bunx @biomejs/biome check \
  'packages/cloud/api/v1/eliza/gateway-relay/sessions/[sessionId]/next/route.ts' \
  'packages/cloud/api/v1/eliza/gateway-relay/sessions/[sessionId]/next/route.test.ts'
bun run --cwd packages/cloud/api typecheck
TURBO_FORCE=true bun run verify
```

Exact-head results: route 16/16 with 48 assertions; changed-file Biome clean; Cloud TypeScript and production Worker dry-run pass; root verify uncached 351/351; anti-larp 8,290 files clean.

# Evidence Gate

<!-- evidence-head:22c8d7a5b035146a18f352046e798a699d555935 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only query parsing has no rendered user interface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only query parsing has no rendered user interface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - there is no visual interaction flow.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head route, Cloud Worker, and repository validation transcript](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20395-relay-timeout-validation-22c8d7a.md).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, request state, or browser behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - invalid requests are rejected before the relay service and create no persistent artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface or visual text changed.

# Known gaps / failures

The first fresh frozen install attempt failed openly because the shared host volume reached `ENOSPC`. The incomplete generated tree was removed; validation used an already-complete isolated dependency tree with the identical lockfile SHA-1, then rebuilt current-head outputs through the uncached 351/351 root matrix. No dependency or lockfile changed. Hosted CI will perform its own clean install.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-20395-relay-timeout]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
