### PR TITLE
feat(registry): list @aomi-labs/eliza-plugin-aomi in the third-party registry

### DIFF
--- a/packages/registry/entries/third-party/aomi-labs__eliza-plugin-aomi.json
+++ b/packages/registry/entries/third-party/aomi-labs__eliza-plugin-aomi.json
@@ -1,0 +1,9 @@
+{
+  "package": "@aomi-labs/eliza-plugin-aomi",
+  "repository": "github:aomi-labs/eliza-plugin-aomi",
+  "kind": "plugin",
+  "description": "Delegates open-ended on-chain workflows to Aomi while elizaOS retains wallet custody, subject-bound confirmation, signing, and submission.",
+  "homepage": "https://github.com/aomi-labs/eliza-plugin-aomi",
+  "version": "0.1.0",
+  "tags": ["aomi", "blockchain", "wallet", "evm", "solana", "defi"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -92,6 +92,52 @@
       "registryKind": "plugin",
       "directory": "eliza-plugin-agentradar"
     },
+    "@aomi-labs/eliza-plugin-aomi": {
+      "git": {
+        "repo": "aomi-labs/eliza-plugin-aomi",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@aomi-labs/eliza-plugin-aomi",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Delegates open-ended on-chain workflows to Aomi while elizaOS retains wallet custody, subject-bound confirmation, signing, and submission.",
+      "homepage": "https://github.com/aomi-labs/eliza-plugin-aomi",
+      "topics": [
+        "aomi",
+        "blockchain",
+        "wallet",
+        "evm",
+        "solana",
+        "defi"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "@davyjones0x/plugin-peer-cash": {
       "git": {
         "repo": "ADWilkinson/plugin-peer-cash",


### PR DESCRIPTION
## Summary

Registry-only listing for the Aomi on-chain execution plugin, completing the maintainer-requested path for #17288: the in-repo plugin PR (#17289) was closed per third-party plugin policy, the author published the standalone package, and this PR links it into `packages/registry`.

- Adds `packages/registry/entries/third-party/aomi-labs__eliza-plugin-aomi.json` with metadata matching the plugin repo's committed `registry-entry.json` (https://github.com/aomi-labs/eliza-plugin-aomi/blob/main/registry-entry.json)
- Regenerates `generated-registry.json` via `bun run --cwd packages/registry generate` (45 entries)

Published package verified on npm: `@aomi-labs/eliza-plugin-aomi@0.1.0` (integrity `sha512-lXRzQa+d24...`). The standalone release includes the fixes from the #17289 review (single-flight confirmation, subject binding, decoded Solana consent, fail-closed opaque signing) plus Solana devnet execution evidence, per the author's follow-up on #17289.

Fixes #17288

## Test results

- `bun run --cwd packages/registry validate` — 45 third-party entries validated
- `bun run --cwd packages/registry generate` — regenerated wire registry, diff inspected (new `@aomi-labs/eliza-plugin-aomi` block only)
- `bun run --cwd packages/registry test` — 6 files / 36 tests passed
- `bun run --cwd packages/registry typecheck` — clean
- `bun run --cwd packages/registry lint:check` / `format:check` — clean

Note: `generate:first-party:check` fails on current develop from pre-existing plugin-twitter registry-entry drift unrelated to this change; not included here to keep the diff scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)