### PR TITLE
chore(ci): retire the --min-tasks/MIN_TEST_TASKS numeric floor from the test runner

### DIFF
--- a/packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
+++ b/packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts
@@ -259,13 +259,26 @@ describe("run-all-tests --require-work vacuous-green guard", () => {
   );
 
   test(
-    "--min-tasks restores the numeric floor the develop-pr plugin gate passes",
+    "the retired --min-tasks flag fails closed at argv parse (#17070)",
     () => {
-      // The consolidation (02d89802f2c) dropped --min-tasks while
-      // develop-pr.yml still passes --min-tasks=<selected count>, so every
-      // plugin-touching PR failed at argv parse (exit 2) before a single test
-      // ran. The flag is a supported surface again: n > 0 implies the
-      // --require-work guards plus a lane-wide >= n collection floor.
+      // The numeric collection floor was a historical-count baseline; it is
+      // removed rather than silently ignored, so a stale caller dies loudly
+      // before any test runs instead of running with a floor it believes is
+      // armed.
+      const result = run(["--no-cloud", "--min-tasks=1", "--plan"]);
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain("unknown argument");
+      expect(result.stderr).toContain("--min-tasks=1");
+    },
+    SPAWN_TIMEOUT_MS,
+  );
+
+  test(
+    "the retired MIN_TEST_TASKS env is inert (#17070)",
+    () => {
+      // The env twin of --min-tasks must not resurrect the numeric floor: a
+      // lane that matches one task succeeds even under an absurd env floor,
+      // and the boolean zero-task guard is unaffected.
       rmSync(PLAN_FLOOR_PACKAGE_DIR, { recursive: true, force: true });
       mkdirSync(PLAN_FLOOR_PACKAGE_DIR, { recursive: true });
       try {
@@ -285,57 +298,21 @@ describe("run-all-tests --require-work vacuous-green guard", () => {
           )}\n`,
         );
 
-        // The develop-pr shape: floor satisfied by the one selected task.
-        const satisfied = run([
-          "--plan=json",
-          "--only=test",
-          "--no-cloud",
-          "--filter=@elizaos/run-all-tests-plan-floor-fixture",
-          "--min-tasks=1",
-        ]);
-        expect(satisfied.status).toBe(0);
-        expect(JSON.parse(satisfied.stdout).summary.taskCount).toBe(1);
-
-        // Below the declared floor: loud exit 3, before plan mode exits.
-        const belowFloor = run([
-          "--plan=json",
-          "--only=test",
-          "--no-cloud",
-          "--filter=@elizaos/run-all-tests-plan-floor-fixture",
-          "--min-tasks=2",
-        ]);
-        expect(belowFloor.status).toBe(3);
-        expect(belowFloor.stderr).toContain("VACUOUS-GREEN GUARD");
-        expect(belowFloor.stderr).toContain("< required 2");
+        const result = run(
+          [
+            "--plan=json",
+            "--only=test",
+            "--no-cloud",
+            "--filter=@elizaos/run-all-tests-plan-floor-fixture",
+            "--require-work",
+          ],
+          { MIN_TEST_TASKS: "999" },
+        );
+        expect(result.status).toBe(0);
+        expect(JSON.parse(result.stdout).summary.taskCount).toBe(1);
       } finally {
         rmSync(PLAN_FLOOR_PACKAGE_DIR, { recursive: true, force: true });
       }
-    },
-    SPAWN_TIMEOUT_MS,
-  );
-
-  test(
-    "--min-tasks > 0 arms the zero-task require-work guard",
-    () => {
-      const result = run([
-        "--no-cloud",
-        `--filter=${NOWHERE_FILTER}`,
-        "--min-tasks=1",
-      ]);
-      expect(result.status).toBe(3);
-      expect(`${result.stdout}${result.stderr}`).toContain(
-        ZERO_TASK_DIAGNOSTIC,
-      );
-    },
-    SPAWN_TIMEOUT_MS,
-  );
-
-  test(
-    "a malformed --min-tasks value fails usage, not the guard",
-    () => {
-      const result = run(["--no-cloud", "--min-tasks=abc", "--plan"]);
-      expect(result.status).toBe(2);
-      expect(result.stderr).toContain("--min-tasks/MIN_TEST_TASKS");
     },
     SPAWN_TIMEOUT_MS,
   );

--- a/packages/scripts/run-all-tests.mjs
+++ b/packages/scripts/run-all-tests.mjs
@@ -181,7 +181,6 @@ let excludeFlags;
 let concurrencyFlag;
 let concurrency;
 let planFlag;
-let minTasksFlag;
 try {
   filterFlag = parseFlagValue("--filter");
   patternFlag = parseFlagValue("--pattern");
@@ -190,30 +189,18 @@ try {
   excludeFlags = parseRepeatedFlagValue("--exclude");
   concurrencyFlag = parseFlagValue("--concurrency");
   planFlag = parseFlagValue("--plan");
-  minTasksFlag = parseFlagValue("--min-tasks");
 } catch (error) {
   // error-policy:J1 CLI parsing failures become a bounded usage error.
   failUsage(error.message);
 }
 
-// `--min-tasks=<n>` / MIN_TEST_TASKS is the numeric ancestor of
-// `--require-work` and remains a supported surface: callers that KNOW how many
-// tasks their filter selected (the develop-pr changed-plugin gate passes its
-// exact selection count) get a floor the boolean cannot express. n > 0 implies
-// every `--require-work` guard plus the lane-wide `>= n` collection floor;
-// n = 0 is off. Dropping the flag broke those callers loudly at argv parse
-// (exit 2 before any test ran), which is the wrong kind of loud.
-const minTasksRaw = minTasksFlag ?? process.env.MIN_TEST_TASKS ?? "0";
-const minTasks =
-  typeof minTasksRaw === "string" && /^\d+$/.test(minTasksRaw)
-    ? Number(minTasksRaw)
-    : Number.NaN;
-if (!Number.isSafeInteger(minTasks)) {
-  failUsage(
-    `--min-tasks/MIN_TEST_TASKS must be a non-negative integer, got "${minTasksRaw}"`,
-  );
-}
-const requireWork = requireWorkFlag || minTasks > 0;
+// `--min-tasks=<n>` / MIN_TEST_TASKS — the numeric ancestor of
+// `--require-work` — is retired (#17070). A numeric collection floor is a
+// historical-count baseline: it fails a lane because a task count changed, not
+// because a source contract broke. The boolean `--require-work` guards remain
+// the vacuous-green protection; a caller still passing the retired flag fails
+// closed at argv parse (unknown argument, exit 2).
+const requireWork = requireWorkFlag;
 
 // A named root lane (`--lane server`) resolves the anchored package filter it
 // used to hardcode as a `TEST_PACKAGE_FILTER` regex in the root package.json:
@@ -252,8 +239,6 @@ if (helpFlag) {
       "  --plan[=text|json]   Print the discovered test plan without running it.",
       "  --require-work       Fail (exit 3) when no runnable task is selected,",
       "                       a shard owns no task, or no reconciled testcase runs.",
-      "  --min-tasks=<n>      --require-work plus a lane-wide floor: fail (exit 3)",
-      "                       when fewer than n tasks are collected. 0 = off.",
       "",
       "Env vars:",
       "  TEST_LANE=pr|post-merge        Lane select (default: pr).",
@@ -262,7 +247,6 @@ if (helpFlag) {
       "  TEST_PACKAGE_FILTER=<regex>     Equivalent to --filter (legacy).",
       "  TEST_SCRIPT_FILTER=<regex>      Filter by script name.",
       "  TEST_START_AT=<substring>       Skip until first matching label.",
-      "  MIN_TEST_TASKS=<n>              Same as --min-tasks (default 0 = off).",
       "",
       "See `.env.test.example` for deterministic PR and live lane env setup.",
       "",
@@ -1376,16 +1360,6 @@ if (requireWork && laneMatchedTaskCount === 0) {
   console.error(
     "[eliza-test] VACUOUS-GREEN GUARD lane matched 0 runnable tasks. " +
       "A filter or source contract collapsed this required lane.",
-  );
-  process.exit(3);
-}
-// Lane-wide, not per-shard: TEST_SHARD intentionally splits a healthy lane
-// into M parts, so a shard owning 1/M of the work is not a collapsed glob.
-if (minTasks > 0 && laneMatchedTaskCount < minTasks) {
-  console.error(
-    `[eliza-test] VACUOUS-GREEN GUARD lane matched ${laneMatchedTaskCount} task(s) < required ${minTasks}` +
-      (shardConfig ? ` (this shard: ${tasks.length})` : "") +
-      ". A filter/shard/glob collapsed this lane below its declared selection.",
   );
   process.exit(3);
 }


### PR DESCRIPTION
Fixes #17070 (maintainer-corrected scope).

## Survey: what remained after #17003

Per the triage verdict, removal of historical floors required #17003's ordinary-test authority to land first — it has (`CI / Required` in `.github/workflows/ci.yml` runs unconditional `test:scripts`/`test:server`/`test:client`/`test:plugins` lanes on develop PRs).

Audit of blocking develop-PR CI on current `develop` for remaining count/inventory/debt baselines:

- **`--min-tasks`/`MIN_TEST_TASKS` in `packages/scripts/run-all-tests.mjs`** — the last live historical-count floor: a lane-wide numeric collection floor (exit 3 when fewer than n tasks are collected). Workflows are already banned from passing it by the contract test, but the machinery remained. **Removed by this PR.**
- `audit:scripts:inventory` / `audit:view-bundle-inventory` (verify chain) — diagnostic report writers; they fail only on discovery errors, never on counts. Kept.
- `audit:scripts` plugin-coupling allowlist — reasoned, staleness-checked source-derived contract (stale entries fail), not a shrink-only baseline. Kept.
- `--require-work` (develop-pr.yml / root test scripts) — boolean vacuous-green guard (zero-task lane / empty shard / zero reconciled testcases); source-derived correctness, not a count floor. Kept unchanged.
- UI story-coverage/headers/colors/boundaries ratchets — not reachable from any blocking PR lane (push-to-develop `quality.yml` and on-demand only). Out of blocking scope.
- `audit:e2e-coverage` keyless gate — runs in `scenario-pr.yml`, which triggers on push/schedule, not `pull_request`; not a blocking PR gate.
- UI console-warning baseline — a grandfathered maximum (fails only on NEW console output, never on shrinkage); correctness guard, kept.

## Changes

- `packages/scripts/run-all-tests.mjs`: `--min-tasks`/`MIN_TEST_TASKS` parsing, the numeric guard block, and its help text removed. `requireWork` is now purely the boolean flag. A stale caller fails closed at argv parse (unknown argument, exit 2) rather than running with a floor it believes is armed.
- `packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts`: the three numeric-floor tests are replaced by retirement contracts — the flag fails usage with the offending argument echoed, and the env twin is proven inert under `--require-work` (fixture lane with `MIN_TEST_TASKS=999` still passes). All `--require-work` fixture-driven behavior coverage is preserved; the existing workflow contract test (bans the retired flag/env in `.github/workflows`) is unchanged and still passes.

## Tests

- `bun test packages/scripts/__tests__/run-all-tests-vacuous-green-guard.test.ts` — 20/20 pass.
- `bun test` on `run-all-tests-plan-source-contract`, `run-all-tests-concurrency-usage`, `run-all-tests-captured-output`, `audit-test-lane-membership` — 31/31 pass.
- Biome clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)