### PR TITLE
feat(corpus): X archive collector with validated resumable shards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,6 +352,10 @@ tasks/
 !packages/training/data/
 !packages/training/data/final-eliza1-smoke/
 !packages/training/data/final-eliza1-smoke/**
+# corpus-tools synthetic X-archive fixture uses the official archive's
+# data/ layout; re-include it beneath the **/data/ rule.
+!packages/corpus-tools/fixtures/x-archive/data/
+!packages/corpus-tools/fixtures/x-archive/data/**
 **/.roo/
 **/.roomodes/
 **/.taskmaster/

--- a/bun.lock
+++ b/bun.lock
@@ -820,6 +820,19 @@
         "vitest": "^4.0.0",
       },
     },
+    "packages/corpus-tools": {
+      "name": "@elizaos/corpus-tools",
+      "version": "0.0.0",
+      "dependencies": {
+        "@elizaos/core": "workspace:*",
+        "fflate": "^0.8.3",
+        "zod": "^4.4.3",
+      },
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "@typescript/native": "npm:typescript@^7.0.2",
+      },
+    },
     "packages/docs": {
       "name": "@elizaos/docs",
       "version": "2.0.0-beta.2",
@@ -3928,6 +3941,8 @@
     "@elizaos/container-control-plane": ["@elizaos/container-control-plane@workspace:packages/cloud/services/container-control-plane"],
 
     "@elizaos/core": ["@elizaos/core@workspace:packages/core"],
+
+    "@elizaos/corpus-tools": ["@elizaos/corpus-tools@workspace:packages/corpus-tools"],
 
     "@elizaos/docs": ["@elizaos/docs@workspace:packages/docs"],
 

--- a/packages/corpus-tools/AGENTS.md
+++ b/packages/corpus-tools/AGENTS.md
@@ -1,0 +1,23 @@
+# @elizaos/corpus-tools
+
+Private workspace package for the personal-corpus program (#14747/#14748). It
+owns the canonical corpus JSONL schema, synthetic fixtures, validators, and
+source-archive collectors consumed by later PII and LifeOps mock-loader work.
+
+## Rules
+
+- Raw, owner, or intermediate corpus data never enters git. Use the ignored
+  `data/` tree; commit only synthetic fixtures under `fixtures/`.
+- `src/schema.ts` is the boundary contract for collectors and scrub stages.
+  Widen additively and update validators/tests with every schema change.
+- Collectors are compatibility adapters, not schema owners. Keep
+  platform-specific compromises (for example the X archive's same-shard
+  reply-reference rule, or likes being counted but never fabricated into
+  message rows) documented at the collector boundary.
+- Validator failures are data errors; return structured diagnostics from the
+  library and let only process boundaries translate them to exit codes.
+- Collector output must be idempotent and resumable: re-running against the
+  same input reuses byte-identical shards and rewrites only missing or changed
+  ones.
+
+Repo-wide rules and evidence standards are in the root `CLAUDE.md`.

--- a/packages/corpus-tools/CLAUDE.md
+++ b/packages/corpus-tools/CLAUDE.md
@@ -1,0 +1,23 @@
+# @elizaos/corpus-tools
+
+Private workspace package for the personal-corpus program (#14747/#14748). It
+owns the canonical corpus JSONL schema, synthetic fixtures, validators, and
+source-archive collectors consumed by later PII and LifeOps mock-loader work.
+
+## Rules
+
+- Raw, owner, or intermediate corpus data never enters git. Use the ignored
+  `data/` tree; commit only synthetic fixtures under `fixtures/`.
+- `src/schema.ts` is the boundary contract for collectors and scrub stages.
+  Widen additively and update validators/tests with every schema change.
+- Collectors are compatibility adapters, not schema owners. Keep
+  platform-specific compromises (for example the X archive's same-shard
+  reply-reference rule, or likes being counted but never fabricated into
+  message rows) documented at the collector boundary.
+- Validator failures are data errors; return structured diagnostics from the
+  library and let only process boundaries translate them to exit codes.
+- Collector output must be idempotent and resumable: re-running against the
+  same input reuses byte-identical shards and rewrites only missing or changed
+  ones.
+
+Repo-wide rules and evidence standards are in the root `CLAUDE.md`.

--- a/packages/corpus-tools/README.md
+++ b/packages/corpus-tools/README.md
@@ -1,0 +1,38 @@
+# @elizaos/corpus-tools
+
+Private personal-corpus interchange schema, validators, and archive collectors
+for #14747. The package normalizes source exports into `CorpusMessage` JSONL
+shards and validates manifest integrity.
+
+Raw and intermediate owner data belongs under `packages/corpus-tools/data/`,
+which is ignored by the repo-wide `**/data/` rule. Only synthetic fixtures
+under `fixtures/` are committed.
+
+## X archive collector
+
+`collectXArchive` (`src/collectors/x-archive.ts`) parses the official X data
+archive — either the downloaded ZIP or an extracted directory — and writes
+validated monthly shards plus `manifest.json` and `x-archive-summary.json`:
+
+```ts
+import { collectXArchive } from "@elizaos/corpus-tools";
+
+const result = await collectXArchive({
+  archivePath: "data/raw/x/archive.zip",
+  ownerAccountId: "<numeric X account id>",
+  ownerDisplay: "Owner Name",
+  outDir: "data",
+});
+```
+
+Tweets map to direction `out` with the thread id resolved to the reply-chain
+root; DMs map per conversation with direction derived from the sender versus
+the owner id; rows before the corpus cutoff (`2024-07-05`) are dropped. Likes
+carry no timestamps in the archive, so they are counted in the summary and
+never emitted as message rows. Re-running is idempotent: unchanged shards are
+reused, missing shards are rewritten.
+
+```bash
+bun run --cwd packages/corpus-tools test
+bun run --cwd packages/corpus-tools typecheck
+```

--- a/packages/corpus-tools/fixtures/x-archive/data/direct-messages.js
+++ b/packages/corpus-tools/fixtures/x-archive/data/direct-messages.js
@@ -1,0 +1,52 @@
+window.YTD.direct_messages.part0 = [
+  {
+    "dmConversation": {
+      "conversationId": "7777-8888",
+      "messages": [
+        {
+          "messageCreate": {
+            "id": "5001",
+            "senderId": "8888",
+            "recipientId": "7777",
+            "text": "synthetic inbound dm",
+            "createdAt": "2024-08-20T15:00:00.000Z"
+          }
+        },
+        {
+          "messageCreate": {
+            "id": "5002",
+            "senderId": "7777",
+            "recipientId": "8888",
+            "text": "synthetic outbound dm reply",
+            "createdAt": "2024-08-20T15:05:00.000Z"
+          }
+        },
+        {
+          "messageCreate": {
+            "id": "4000",
+            "senderId": "8888",
+            "recipientId": "7777",
+            "text": "synthetic pre-cutoff dm that must be dropped",
+            "createdAt": "2024-01-15T10:00:00.000Z"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "dmConversation": {
+      "conversationId": "7777-9999",
+      "messages": [
+        {
+          "messageCreate": {
+            "id": "5003",
+            "senderId": "7777",
+            "recipientId": "9999",
+            "text": "synthetic dm opening a second conversation",
+            "createdAt": "2024-09-05T08:00:00.000Z"
+          }
+        }
+      ]
+    }
+  }
+]

--- a/packages/corpus-tools/fixtures/x-archive/data/like.js
+++ b/packages/corpus-tools/fixtures/x-archive/data/like.js
@@ -1,0 +1,4 @@
+window.YTD.like.part0 = [
+  { "like": { "tweetId": "3001", "fullText": "synthetic liked tweet one" } },
+  { "like": { "tweetId": "3002", "fullText": "synthetic liked tweet two" } }
+]

--- a/packages/corpus-tools/fixtures/x-archive/data/tweets-part1.js
+++ b/packages/corpus-tools/fixtures/x-archive/data/tweets-part1.js
@@ -1,0 +1,20 @@
+window.YTD.tweets.part1 = [
+  {
+    "tweet": {
+      "id_str": "1003",
+      "created_at": "Sun Sep 01 10:00:00 +0000 2024",
+      "full_text": "synthetic later reply that crosses into a new month",
+      "in_reply_to_status_id_str": "1002",
+      "in_reply_to_user_id_str": "7777"
+    }
+  },
+  {
+    "tweet": {
+      "id_str": "1004",
+      "created_at": "Mon Sep 02 11:00:00 +0000 2024",
+      "full_text": "synthetic reply to a tweet outside the archive",
+      "in_reply_to_status_id_str": "999",
+      "in_reply_to_user_id_str": "4242"
+    }
+  }
+]

--- a/packages/corpus-tools/fixtures/x-archive/data/tweets.js
+++ b/packages/corpus-tools/fixtures/x-archive/data/tweets.js
@@ -1,0 +1,26 @@
+window.YTD.tweets.part0 = [
+  {
+    "tweet": {
+      "id_str": "1001",
+      "created_at": "Sat Aug 10 12:00:00 +0000 2024",
+      "full_text": "synthetic root tweet about corpus tooling",
+      "entities": { "hashtags": [] }
+    }
+  },
+  {
+    "tweet": {
+      "id_str": "1002",
+      "created_at": "Sun Aug 11 09:30:00 +0000 2024",
+      "full_text": "synthetic reply continuing the thread",
+      "in_reply_to_status_id_str": "1001",
+      "in_reply_to_user_id_str": "7777"
+    }
+  },
+  {
+    "tweet": {
+      "id_str": "900",
+      "created_at": "Sat Jun 01 08:00:00 +0000 2024",
+      "full_text": "synthetic pre-cutoff tweet that must be dropped"
+    }
+  }
+]

--- a/packages/corpus-tools/package.json
+++ b/packages/corpus-tools/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@elizaos/corpus-tools",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Private personal-corpus interchange schema, validators, and archive collectors for the LifeOps corpus program.",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "node ../scripts/run-vitest.mjs run --config ./vitest.config.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "lint": "node ../scripts/run-biome-typescript.mjs src check",
+    "lint:check": "node ../scripts/run-biome-typescript.mjs src check",
+    "lint:fix": "node ../scripts/run-biome-typescript.mjs src check --write",
+    "format": "node ../scripts/run-biome-typescript.mjs src format",
+    "format:fix": "node ../scripts/run-biome-typescript.mjs src format --write"
+  },
+  "dependencies": {
+    "@elizaos/core": "workspace:*",
+    "fflate": "^0.8.3",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@typescript/native": "npm:typescript@^7.0.2",
+    "@types/node": "^24.0.0"
+  },
+  "elizaos": {
+    "scripts": {
+      "testLanes": [
+        "server"
+      ]
+    }
+  }
+}

--- a/packages/corpus-tools/src/collectors/x-archive.test.ts
+++ b/packages/corpus-tools/src/collectors/x-archive.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Deterministic unit coverage for the X archive collector against the
+ * committed synthetic mini-archive fixture. The harness is real (filesystem
+ * shards, real fflate ZIP bytes) with no network or mocked collaborators.
+ */
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { zipSync } from "fflate";
+import { afterEach, describe, expect, it } from "vitest";
+import { validateCorpusTarget } from "../validator.ts";
+import { collectXArchive } from "./x-archive.ts";
+
+const FIXTURE_DIR = path.join(import.meta.dirname, "../../fixtures/x-archive");
+const OWNER = "7777";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "x-archive-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function zipFixture(): Promise<string> {
+  const dataDir = path.join(FIXTURE_DIR, "data");
+  const entries: Record<string, Uint8Array> = {};
+  for (const name of await fs.readdir(dataDir)) {
+    entries[`data/${name}`] = new Uint8Array(
+      await fs.readFile(path.join(dataDir, name)),
+    );
+  }
+  const zipPath = path.join(await makeTempDir(), "archive.zip");
+  await fs.writeFile(zipPath, zipSync(entries));
+  return zipPath;
+}
+
+describe("collectXArchive", () => {
+  it("parses tweets, DMs, and likes from an extracted archive with cutoff filtering", async () => {
+    const outDir = await makeTempDir();
+    const result = await collectXArchive({
+      archivePath: FIXTURE_DIR,
+      ownerAccountId: OWNER,
+      ownerDisplay: "Synthetic Owner",
+      outDir,
+    });
+
+    expect(result.summary.tweetCount).toBe(4);
+    expect(result.summary.dmMessageCount).toBe(3);
+    expect(result.summary.dmConversationCount).toBe(2);
+    expect(result.summary.likeCount).toBe(2);
+    expect(result.summary.skippedBeforeCutoff).toBe(2);
+    expect(result.issues).toEqual([]);
+    expect(result.manifest.totals.messages).toBe(7);
+  });
+
+  it("maps tweet direction, thread roots, and same-shard reply references", async () => {
+    const outDir = await makeTempDir();
+    await collectXArchive({
+      archivePath: FIXTURE_DIR,
+      ownerAccountId: OWNER,
+      outDir,
+    });
+
+    const august = (
+      await fs.readFile(path.join(outDir, "x", OWNER, "2024-08.jsonl"), "utf8")
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    const root = august.find((m) => m.id === "x:tweet:1001");
+    const reply = august.find((m) => m.id === "x:tweet:1002");
+    expect(root.direction).toBe("out");
+    expect(root.threadId).toBe("x:thread:1001");
+    expect(root.replyToId).toBeUndefined();
+    expect(reply.threadId).toBe("x:thread:1001");
+    expect(reply.replyToId).toBe("x:tweet:1001");
+
+    const september = (
+      await fs.readFile(path.join(outDir, "x", OWNER, "2024-09.jsonl"), "utf8")
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    // Cross-shard parent: thread root still resolves, replyToId omitted.
+    const laterReply = september.find((m) => m.id === "x:tweet:1003");
+    expect(laterReply.threadId).toBe("x:thread:1001");
+    expect(laterReply.replyToId).toBeUndefined();
+    // Parent outside the archive: thread falls back to the referenced id.
+    const orphanReply = september.find((m) => m.id === "x:tweet:1004");
+    expect(orphanReply.threadId).toBe("x:thread:999");
+    expect(orphanReply.replyToId).toBeUndefined();
+  });
+
+  it("derives DM direction from senderId versus the owner id", async () => {
+    const outDir = await makeTempDir();
+    await collectXArchive({
+      archivePath: FIXTURE_DIR,
+      ownerAccountId: OWNER,
+      outDir,
+    });
+    const august = (
+      await fs.readFile(path.join(outDir, "x", OWNER, "2024-08.jsonl"), "utf8")
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    const inbound = august.find((m) => m.id === "x:dm:5001");
+    const outbound = august.find((m) => m.id === "x:dm:5002");
+    expect(inbound.direction).toBe("in");
+    expect(inbound.senderId).toBe("8888");
+    expect(inbound.threadId).toBe("x:dm-conversation:7777-8888");
+    expect(outbound.direction).toBe("out");
+    expect(outbound.senderId).toBe(OWNER);
+  });
+
+  it("produces shards and a manifest that pass corpus validation", async () => {
+    const outDir = await makeTempDir();
+    const result = await collectXArchive({
+      archivePath: FIXTURE_DIR,
+      ownerAccountId: OWNER,
+      outDir,
+    });
+    expect(result.shardPaths).toHaveLength(2);
+    const validation = await validateCorpusTarget(outDir);
+    expect(validation.issues).toEqual([]);
+    expect(validation.ok).toBe(true);
+    const summary = JSON.parse(
+      await fs.readFile(path.join(outDir, "x-archive-summary.json"), "utf8"),
+    );
+    expect(summary.tweetCount).toBe(4);
+    expect(summary.dmConversationCount).toBe(2);
+  });
+
+  it("reads the same corpus from the official ZIP form", async () => {
+    const zipPath = await zipFixture();
+    const dirOut = await makeTempDir();
+    const zipOut = await makeTempDir();
+    const fromDir = await collectXArchive({
+      archivePath: FIXTURE_DIR,
+      ownerAccountId: OWNER,
+      outDir: dirOut,
+    });
+    const fromZip = await collectXArchive({
+      archivePath: zipPath,
+      ownerAccountId: OWNER,
+      outDir: zipOut,
+    });
+    expect(fromZip.summary).toEqual(fromDir.summary);
+    expect(fromZip.manifest.shards.map((s) => s.sha256)).toEqual(
+      fromDir.manifest.shards.map((s) => s.sha256),
+    );
+  });
+
+  it("is resumable: reruns reuse matching shards and restore missing ones", async () => {
+    const outDir = await makeTempDir();
+    const first = await collectXArchive({
+      archivePath: FIXTURE_DIR,
+      ownerAccountId: OWNER,
+      outDir,
+    });
+    expect(first.summary.shardsWritten).toBe(2);
+    expect(first.summary.shardsReused).toBe(0);
+
+    const rerun = await collectXArchive({
+      archivePath: FIXTURE_DIR,
+      ownerAccountId: OWNER,
+      outDir,
+    });
+    expect(rerun.summary.shardsWritten).toBe(0);
+    expect(rerun.summary.shardsReused).toBe(2);
+
+    await fs.rm(path.join(outDir, "x", OWNER, "2024-09.jsonl"));
+    const repaired = await collectXArchive({
+      archivePath: FIXTURE_DIR,
+      ownerAccountId: OWNER,
+      outDir,
+    });
+    expect(repaired.summary.shardsWritten).toBe(1);
+    expect(repaired.summary.shardsReused).toBe(1);
+    const validation = await validateCorpusTarget(outDir);
+    expect(validation.ok).toBe(true);
+  });
+
+  it("fails closed on a missing tweets file and malformed inputs", async () => {
+    const emptyArchive = await makeTempDir();
+    await fs.mkdir(path.join(emptyArchive, "data"), { recursive: true });
+    const outDir = await makeTempDir();
+    await expect(
+      collectXArchive({
+        archivePath: emptyArchive,
+        ownerAccountId: OWNER,
+        outDir,
+      }),
+    ).rejects.toMatchObject({ code: "X_ARCHIVE_MISSING_FILE" });
+
+    const badPrefix = await makeTempDir();
+    await fs.mkdir(path.join(badPrefix, "data"), { recursive: true });
+    await fs.writeFile(
+      path.join(badPrefix, "data", "tweets.js"),
+      '[{"tweet":{}}]',
+      "utf8",
+    );
+    await expect(
+      collectXArchive({
+        archivePath: badPrefix,
+        ownerAccountId: OWNER,
+        outDir,
+      }),
+    ).rejects.toMatchObject({ code: "X_ARCHIVE_BAD_PREFIX" });
+
+    const badJson = await makeTempDir();
+    await fs.mkdir(path.join(badJson, "data"), { recursive: true });
+    await fs.writeFile(
+      path.join(badJson, "data", "tweets.js"),
+      "window.YTD.tweets.part0 = [{ nope",
+      "utf8",
+    );
+    await expect(
+      collectXArchive({ archivePath: badJson, ownerAccountId: OWNER, outDir }),
+    ).rejects.toMatchObject({ code: "X_ARCHIVE_BAD_JSON" });
+  });
+});

--- a/packages/corpus-tools/src/collectors/x-archive.ts
+++ b/packages/corpus-tools/src/collectors/x-archive.ts
@@ -1,0 +1,464 @@
+/**
+ * Official X data-archive collector: parses `data/tweets*.js`,
+ * `data/direct-messages*.js`, and `data/like*.js` out of the archive ZIP (or an
+ * already-extracted directory), strips the `window.YTD.<name>.partN =` script
+ * prefix, filters rows before the corpus cutoff, and writes validated,
+ * idempotently resumable monthly `CorpusMessage` JSONL shards plus the canonical
+ * corpus manifest and an x-archive summary with tweet/DM-conversation counts.
+ *
+ * Tweets map to direction "out" with the thread id resolved to the reply-chain
+ * root within the archive; DMs map per conversation with direction derived from
+ * senderId versus the owner id. Likes carry no timestamps in the archive, so
+ * they are counted in the summary but never fabricated into message rows.
+ * Raw archives belong under the gitignored `data/` tree; only synthetic
+ * fixtures are committed.
+ */
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { ElizaError } from "@elizaos/core";
+import { unzipSync } from "fflate";
+import {
+  CORPUS_CUTOFF_MS,
+  type CorpusManifest,
+  type CorpusMessage,
+  corpusMessageSchema,
+} from "../schema.ts";
+import {
+  buildCorpusManifest,
+  type CorpusValidationIssue,
+} from "../validator.ts";
+
+export interface XArchiveCollectorOptions {
+  /** Path to the official archive ZIP or an extracted archive directory. */
+  archivePath: string;
+  /** The numeric X account id of the archive owner (accountId + tweet sender). */
+  ownerAccountId: string;
+  /** Display name recorded for owner-authored rows; defaults to the owner id. */
+  ownerDisplay?: string;
+  /** Root the `x/<owner>/<yyyy-mm>.jsonl` shard tree is written under. */
+  outDir: string;
+  /** Inclusive minimum timestamp; defaults to the corpus cutoff. */
+  cutoffMs?: number;
+}
+
+export interface XArchiveSummary {
+  tweetCount: number;
+  dmMessageCount: number;
+  dmConversationCount: number;
+  likeCount: number;
+  skippedBeforeCutoff: number;
+  skippedInvalid: number;
+  shardsWritten: number;
+  shardsReused: number;
+}
+
+export interface XArchiveCollectResult {
+  summary: XArchiveSummary;
+  manifest: CorpusManifest;
+  issues: CorpusValidationIssue[];
+  shardPaths: string[];
+}
+
+interface ArchiveFileSource {
+  /** Archive-relative candidate lookup by prefix, e.g. `data/tweets`. */
+  readPart: (baseName: string) => Promise<{ name: string; text: string }[]>;
+}
+
+const YTD_PREFIX = /^\s*window\.YTD\.[\w-]+\.part\d+\s*=\s*/;
+
+function stripYtdPrefix(fileName: string, raw: string): string {
+  if (!YTD_PREFIX.test(raw)) {
+    throw new ElizaError(
+      `X archive file ${fileName} lacks the window.YTD prefix`,
+      {
+        code: "X_ARCHIVE_BAD_PREFIX",
+        context: { fileName },
+      },
+    );
+  }
+  return raw.replace(YTD_PREFIX, "");
+}
+
+function parseYtdJson(fileName: string, raw: string): unknown[] {
+  const body = stripYtdPrefix(fileName, raw);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch (error) {
+    // error-policy:J2 wrap untrusted archive JSON failure with file context.
+    throw new ElizaError(`X archive file ${fileName} is not valid JSON`, {
+      code: "X_ARCHIVE_BAD_JSON",
+      context: { fileName },
+      cause: error,
+    });
+  }
+  if (!Array.isArray(parsed)) {
+    throw new ElizaError(`X archive file ${fileName} is not a JSON array`, {
+      code: "X_ARCHIVE_BAD_JSON",
+      context: { fileName },
+    });
+  }
+  return parsed;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+}
+
+async function openArchive(archivePath: string): Promise<ArchiveFileSource> {
+  const stat = await fs.stat(archivePath);
+  if (stat.isDirectory()) {
+    const dataDir = path.join(archivePath, "data");
+    return {
+      async readPart(baseName) {
+        const entries = await fs.readdir(dataDir);
+        const wanted = entries
+          .filter((name) => matchesPart(name, baseName))
+          .sort();
+        const out: { name: string; text: string }[] = [];
+        for (const name of wanted) {
+          out.push({
+            name: `data/${name}`,
+            text: await fs.readFile(path.join(dataDir, name), "utf8"),
+          });
+        }
+        return out;
+      },
+    };
+  }
+  const bytes = await fs.readFile(archivePath);
+  let files: Record<string, Uint8Array>;
+  try {
+    files = unzipSync(new Uint8Array(bytes), {
+      filter: (file) =>
+        file.name.startsWith("data/") && file.name.endsWith(".js"),
+    });
+  } catch (error) {
+    // error-policy:J2 wrap fflate's untyped failure with the archive path.
+    throw new ElizaError(`failed to read X archive ZIP ${archivePath}`, {
+      code: "X_ARCHIVE_BAD_ZIP",
+      context: { archivePath },
+      cause: error,
+    });
+  }
+  const decoder = new TextDecoder();
+  return {
+    async readPart(baseName) {
+      return Object.keys(files)
+        .filter((name) => matchesPart(path.posix.basename(name), baseName))
+        .sort()
+        .map((name) => ({ name, text: decoder.decode(files[name]) }));
+    },
+  };
+}
+
+/** Matches `tweets.js`, `tweets-part1.js`, ... for baseName `tweets`. */
+function matchesPart(fileName: string, baseName: string): boolean {
+  return new RegExp(`^${baseName}(-part\\d+)?\\.js$`).test(fileName);
+}
+
+interface RawTweet {
+  id: string;
+  ts: number;
+  text: string;
+  replyToStatusId?: string;
+  replyToUserId?: string;
+}
+
+function extractTweets(rows: unknown[], fileName: string): RawTweet[] {
+  const tweets: RawTweet[] = [];
+  for (const row of rows) {
+    if (!isRecord(row) || !isRecord(row.tweet)) continue;
+    const tweet = row.tweet;
+    const id = readString(tweet.id_str) ?? readString(tweet.id);
+    const createdAt = readString(tweet.created_at);
+    const text = readString(tweet.full_text) ?? readString(tweet.text);
+    if (!id || !createdAt || !text) continue;
+    const ts = Date.parse(createdAt);
+    if (Number.isNaN(ts)) {
+      throw new ElizaError(`unparseable tweet created_at in ${fileName}`, {
+        code: "X_ARCHIVE_BAD_TIMESTAMP",
+        context: { fileName, id, createdAt },
+      });
+    }
+    tweets.push({
+      id,
+      ts,
+      text,
+      replyToStatusId: readString(tweet.in_reply_to_status_id_str),
+      replyToUserId: readString(tweet.in_reply_to_user_id_str),
+    });
+  }
+  return tweets;
+}
+
+/**
+ * Resolves each tweet's thread id to the root of its reply chain, following
+ * parents that exist in the archive and falling back to the referenced parent
+ * id when the chain leaves the archive (partial conversation).
+ */
+function resolveThreadId(tweet: RawTweet, byId: Map<string, RawTweet>): string {
+  let current = tweet;
+  const seen = new Set<string>([current.id]);
+  while (current.replyToStatusId) {
+    const parent = byId.get(current.replyToStatusId);
+    if (!parent || seen.has(parent.id)) return current.replyToStatusId;
+    seen.add(parent.id);
+    current = parent;
+  }
+  return current.id;
+}
+
+interface CollectContext {
+  options: Required<
+    Pick<XArchiveCollectorOptions, "ownerAccountId" | "cutoffMs">
+  > & {
+    ownerDisplay: string;
+  };
+  summary: XArchiveSummary;
+  /** Conversation ids seen across all direct-message parts. */
+  dmConversationIds: Set<string>;
+}
+
+function mapTweets(tweets: RawTweet[], ctx: CollectContext): CorpusMessage[] {
+  const byId = new Map(tweets.map((tweet) => [tweet.id, tweet]));
+  const surviving = new Set(
+    tweets.filter((tweet) => tweet.ts >= ctx.options.cutoffMs).map((t) => t.id),
+  );
+  const messages: CorpusMessage[] = [];
+  for (const tweet of tweets) {
+    if (tweet.ts < ctx.options.cutoffMs) {
+      ctx.summary.skippedBeforeCutoff += 1;
+      continue;
+    }
+    // replyToId is only recorded when the parent lands in the same monthly
+    // shard: the shard validator resolves reply references per shard, and a
+    // cross-shard reference would make an otherwise-valid shard fail closed.
+    const parent = tweet.replyToStatusId
+      ? byId.get(tweet.replyToStatusId)
+      : undefined;
+    const parentInCorpus =
+      parent !== undefined &&
+      surviving.has(parent.id) &&
+      monthOf(parent.ts) === monthOf(tweet.ts);
+    messages.push(
+      corpusMessageSchema.parse({
+        id: `x:tweet:${tweet.id}`,
+        platform: "x",
+        accountId: ctx.options.ownerAccountId,
+        threadId: `x:thread:${resolveThreadId(tweet, byId)}`,
+        ts: tweet.ts,
+        direction: "out",
+        senderId: ctx.options.ownerAccountId,
+        senderDisplay: ctx.options.ownerDisplay,
+        recipients: tweet.replyToUserId ? [{ id: tweet.replyToUserId }] : [],
+        text: tweet.text,
+        labels: ["x:tweet"],
+        attachments: [],
+        ...(parentInCorpus
+          ? { replyToId: `x:tweet:${tweet.replyToStatusId}` }
+          : {}),
+        scrubState: "raw",
+      }),
+    );
+    ctx.summary.tweetCount += 1;
+  }
+  return messages;
+}
+
+function mapDms(
+  rows: unknown[],
+  fileName: string,
+  ctx: CollectContext,
+): CorpusMessage[] {
+  const messages: CorpusMessage[] = [];
+  for (const row of rows) {
+    if (!isRecord(row) || !isRecord(row.dmConversation)) continue;
+    const conversation = row.dmConversation;
+    const conversationId = readString(conversation.conversationId);
+    if (!conversationId || !Array.isArray(conversation.messages)) continue;
+    let counted = false;
+    for (const entry of conversation.messages) {
+      if (!isRecord(entry) || !isRecord(entry.messageCreate)) continue;
+      const dm = entry.messageCreate;
+      const id = readString(dm.id);
+      const senderId = readString(dm.senderId);
+      const recipientId = readString(dm.recipientId);
+      const text = readString(dm.text);
+      const createdAt = readString(dm.createdAt);
+      if (!id || !senderId || !text || !createdAt) {
+        ctx.summary.skippedInvalid += 1;
+        continue;
+      }
+      const ts = Date.parse(createdAt);
+      if (Number.isNaN(ts)) {
+        throw new ElizaError(`unparseable DM createdAt in ${fileName}`, {
+          code: "X_ARCHIVE_BAD_TIMESTAMP",
+          context: { fileName, id, createdAt },
+        });
+      }
+      if (ts < ctx.options.cutoffMs) {
+        ctx.summary.skippedBeforeCutoff += 1;
+        continue;
+      }
+      const outbound = senderId === ctx.options.ownerAccountId;
+      messages.push(
+        corpusMessageSchema.parse({
+          id: `x:dm:${id}`,
+          platform: "x",
+          accountId: ctx.options.ownerAccountId,
+          threadId: `x:dm-conversation:${conversationId}`,
+          ts,
+          direction: outbound ? "out" : "in",
+          senderId,
+          senderDisplay: outbound ? ctx.options.ownerDisplay : senderId,
+          recipients: recipientId ? [{ id: recipientId }] : [],
+          text,
+          labels: ["x:dm"],
+          attachments: [],
+          scrubState: "raw",
+        }),
+      );
+      ctx.summary.dmMessageCount += 1;
+      counted = true;
+    }
+    if (counted) ctx.dmConversationIds.add(conversationId);
+  }
+  ctx.summary.dmConversationCount = ctx.dmConversationIds.size;
+  return messages;
+}
+
+function countLikes(rows: unknown[]): number {
+  return rows.filter((row) => isRecord(row) && isRecord(row.like)).length;
+}
+
+function monthOf(ts: number): string {
+  return new Date(ts).toISOString().slice(0, 7);
+}
+
+function sha256Hex(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+/**
+ * Writes monthly shards under `<outDir>/x/<owner>/`. A shard whose bytes
+ * already match on disk is left untouched, which makes interrupted runs
+ * resumable by simply re-running the collector.
+ */
+async function writeShards(
+  messages: CorpusMessage[],
+  outDir: string,
+  ownerAccountId: string,
+  summary: XArchiveSummary,
+): Promise<string[]> {
+  const byMonth = new Map<string, CorpusMessage[]>();
+  for (const message of messages) {
+    const month = monthOf(message.ts);
+    const bucket = byMonth.get(month) ?? [];
+    bucket.push(message);
+    byMonth.set(month, bucket);
+  }
+  const shardDir = path.join(outDir, "x", ownerAccountId);
+  await fs.mkdir(shardDir, { recursive: true });
+  const written: string[] = [];
+  for (const [month, bucket] of [...byMonth.entries()].sort()) {
+    bucket.sort((a, b) => a.ts - b.ts || a.id.localeCompare(b.id));
+    const body = `${bucket.map((message) => JSON.stringify(message)).join("\n")}\n`;
+    const shardPath = path.join(shardDir, `${month}.jsonl`);
+    let existing: string | undefined;
+    try {
+      existing = await fs.readFile(shardPath, "utf8");
+    } catch {
+      // error-policy:J3 a missing shard is the expected fresh-run state.
+      existing = undefined;
+    }
+    if (existing !== undefined && sha256Hex(existing) === sha256Hex(body)) {
+      summary.shardsReused += 1;
+    } else {
+      const tmpPath = `${shardPath}.tmp`;
+      await fs.writeFile(tmpPath, body, "utf8");
+      await fs.rename(tmpPath, shardPath);
+      summary.shardsWritten += 1;
+    }
+    written.push(shardPath);
+  }
+  return written;
+}
+
+/**
+ * Collects the official X archive at `archivePath` into validated monthly
+ * `CorpusMessage` shards plus `manifest.json` and `x-archive-summary.json`
+ * under `outDir`. Throws `ElizaError` on malformed archive input; validation
+ * findings on the written corpus are returned as `issues`.
+ */
+export async function collectXArchive(
+  options: XArchiveCollectorOptions,
+): Promise<XArchiveCollectResult> {
+  const source = await openArchive(options.archivePath);
+  const ctx: CollectContext = {
+    options: {
+      ownerAccountId: options.ownerAccountId,
+      ownerDisplay: options.ownerDisplay ?? options.ownerAccountId,
+      cutoffMs: options.cutoffMs ?? CORPUS_CUTOFF_MS,
+    },
+    summary: {
+      tweetCount: 0,
+      dmMessageCount: 0,
+      dmConversationCount: 0,
+      likeCount: 0,
+      skippedBeforeCutoff: 0,
+      skippedInvalid: 0,
+      shardsWritten: 0,
+      shardsReused: 0,
+    },
+    dmConversationIds: new Set<string>(),
+  };
+
+  const tweetParts = await source.readPart("tweets");
+  if (tweetParts.length === 0) {
+    throw new ElizaError("X archive has no data/tweets.js", {
+      code: "X_ARCHIVE_MISSING_FILE",
+      context: { archivePath: options.archivePath, file: "data/tweets.js" },
+    });
+  }
+  const tweets = tweetParts.flatMap((part) =>
+    extractTweets(parseYtdJson(part.name, part.text), part.name),
+  );
+  const messages = mapTweets(tweets, ctx);
+
+  for (const part of await source.readPart("direct-messages")) {
+    messages.push(
+      ...mapDms(parseYtdJson(part.name, part.text), part.name, ctx),
+    );
+  }
+  for (const part of await source.readPart("like")) {
+    ctx.summary.likeCount += countLikes(parseYtdJson(part.name, part.text));
+  }
+
+  const shardPaths = await writeShards(
+    messages,
+    options.outDir,
+    ctx.options.ownerAccountId,
+    ctx.summary,
+  );
+
+  const { manifest, issues } = await buildCorpusManifest(options.outDir);
+  await fs.writeFile(
+    path.join(options.outDir, "manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(options.outDir, "x-archive-summary.json"),
+    `${JSON.stringify(ctx.summary, null, 2)}\n`,
+    "utf8",
+  );
+  return { summary: ctx.summary, manifest, issues, shardPaths };
+}

--- a/packages/corpus-tools/src/index.ts
+++ b/packages/corpus-tools/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Public entry for corpus schema consumers, validators, and archive
+ * collectors.
+ */
+export * from "./collectors/x-archive.ts";
+export * from "./schema.ts";
+export * from "./validator.ts";

--- a/packages/corpus-tools/src/schema.ts
+++ b/packages/corpus-tools/src/schema.ts
@@ -1,0 +1,152 @@
+/**
+ * Canonical personal-corpus interchange contract for collectors, scrub stages,
+ * and mock loaders. The schema is intentionally collector-neutral: source
+ * platforms keep their native provenance in `platform`/`accountId`, while
+ * downstream tests consume validated messages, contacts, threads, and shard
+ * manifests without learning Gmail, Telegram, Discord, iMessage, Signal, or X
+ * export formats.
+ */
+import { z } from "zod";
+
+export const CORPUS_CUTOFF_ISO = "2024-07-05";
+export const CORPUS_ANCHOR_ISO = "2026-07-05T00:00:00.000Z";
+export const CORPUS_CUTOFF_MS = Date.parse(
+  `${CORPUS_CUTOFF_ISO}T00:00:00.000Z`,
+);
+export const CORPUS_ANCHOR_MS = Date.parse(CORPUS_ANCHOR_ISO);
+
+export const corpusPlatforms = [
+  "gmail",
+  "telegram",
+  "discord",
+  "imessage",
+  "signal",
+  "x",
+] as const;
+
+export const scrubStates = [
+  "raw",
+  "mined",
+  "swapped",
+  "rewritten",
+  "verified",
+] as const;
+
+export const directions = ["in", "out"] as const;
+
+const nonEmptyString = z.string().trim().min(1);
+const optionalNonEmptyString = z.string().trim().min(1).optional();
+
+export const corpusRecipientSchema = z.object({
+  id: nonEmptyString,
+  display: optionalNonEmptyString,
+  address: optionalNonEmptyString,
+});
+
+export const corpusAttachmentSchema = z.object({
+  filename: nonEmptyString,
+  mimeType: nonEmptyString,
+  sha256: z.string().regex(/^[a-f0-9]{64}$/),
+  bytes: z.number().int().nonnegative().optional(),
+  dataBase64: z.string().optional(),
+});
+
+export const corpusMessageSchema = z.object({
+  id: nonEmptyString,
+  platform: z.enum(corpusPlatforms),
+  accountId: nonEmptyString,
+  threadId: nonEmptyString,
+  ts: z.number().int().min(CORPUS_CUTOFF_MS),
+  direction: z.enum(directions),
+  senderId: nonEmptyString,
+  senderDisplay: nonEmptyString,
+  recipients: z.array(corpusRecipientSchema),
+  subject: optionalNonEmptyString,
+  text: nonEmptyString,
+  snippet: optionalNonEmptyString,
+  labels: z.array(nonEmptyString).default([]),
+  attachments: z.array(corpusAttachmentSchema).default([]),
+  replyToId: optionalNonEmptyString,
+  scrubState: z.enum(scrubStates),
+});
+
+export const corpusContactSchema = z.object({
+  id: nonEmptyString,
+  display: nonEmptyString,
+  handles: z
+    .array(
+      z.object({
+        platform: z.enum(corpusPlatforms),
+        accountId: nonEmptyString,
+        handle: nonEmptyString,
+      }),
+    )
+    .default([]),
+  emails: z.array(z.string().email()).default([]),
+  phones: z.array(nonEmptyString).default([]),
+  source: z.enum(["collector", "gazetteer", "manual"]).default("collector"),
+});
+
+export const corpusThreadSchema = z.object({
+  id: nonEmptyString,
+  platform: z.enum(corpusPlatforms),
+  accountId: nonEmptyString,
+  title: optionalNonEmptyString,
+  participantIds: z.array(nonEmptyString),
+  messageIds: z.array(nonEmptyString),
+  startedTs: z.number().int().min(CORPUS_CUTOFF_MS),
+  latestTs: z.number().int().min(CORPUS_CUTOFF_MS),
+});
+
+export const corpusShardManifestEntrySchema = z.object({
+  path: nonEmptyString,
+  platform: z.enum(corpusPlatforms),
+  accountId: nonEmptyString,
+  month: z.string().regex(/^\d{4}-\d{2}$/),
+  count: z.number().int().nonnegative(),
+  firstTs: z.number().int().min(CORPUS_CUTOFF_MS),
+  lastTs: z.number().int().min(CORPUS_CUTOFF_MS),
+  sha256: z.string().regex(/^[a-f0-9]{64}$/),
+});
+
+export const corpusManifestSchema = z.object({
+  schemaVersion: z.literal(1),
+  generatedAt: nonEmptyString,
+  cutoffIso: z.literal(CORPUS_CUTOFF_ISO),
+  shards: z.array(corpusShardManifestEntrySchema),
+  totals: z.object({
+    messages: z.number().int().nonnegative(),
+    contacts: z.number().int().nonnegative().default(0),
+    threads: z.number().int().nonnegative().default(0),
+  }),
+});
+
+export type CorpusPlatform = (typeof corpusPlatforms)[number];
+export type ScrubState = (typeof scrubStates)[number];
+export type CorpusDirection = (typeof directions)[number];
+export type CorpusRecipient = z.infer<typeof corpusRecipientSchema>;
+export type CorpusAttachment = z.infer<typeof corpusAttachmentSchema>;
+export type CorpusMessage = z.infer<typeof corpusMessageSchema>;
+export type CorpusContact = z.infer<typeof corpusContactSchema>;
+export type CorpusThread = z.infer<typeof corpusThreadSchema>;
+export type CorpusShardManifestEntry = z.infer<
+  typeof corpusShardManifestEntrySchema
+>;
+export type CorpusManifest = z.infer<typeof corpusManifestSchema>;
+
+export const scrubStateRank: Readonly<Record<ScrubState, number>> = {
+  raw: 0,
+  mined: 1,
+  swapped: 2,
+  rewritten: 3,
+  verified: 4,
+};
+
+export function assertScrubStateTransition(
+  from: ScrubState,
+  to: ScrubState,
+): void {
+  if (scrubStateRank[to] < scrubStateRank[from]) {
+    throw new Error(`scrubState regressed from ${from} to ${to}`);
+  }
+}

--- a/packages/corpus-tools/src/validator.ts
+++ b/packages/corpus-tools/src/validator.ts
@@ -1,0 +1,329 @@
+/**
+ * JSONL shard and manifest validation for corpus imports. The validator is
+ * deliberately pure at the row level and filesystem-bound only at the shard
+ * boundary so tests can exercise schema logic without fixtures while the CLI
+ * verifies real files, hashes, and path-derived platform/account/month layout.
+ */
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import {
+  CORPUS_ANCHOR_MS,
+  CORPUS_CUTOFF_ISO,
+  type CorpusManifest,
+  type CorpusMessage,
+  type CorpusPlatform,
+  type CorpusShardManifestEntry,
+  corpusManifestSchema,
+  corpusMessageSchema,
+  corpusPlatforms,
+} from "./schema.ts";
+
+export interface CorpusValidationIssue {
+  path?: string;
+  line?: number;
+  code:
+    | "schema-invalid"
+    | "cutoff-window"
+    | "duplicate-id"
+    | "reply-missing"
+    | "thread-mismatch"
+    | "path-mismatch"
+    | "manifest-invalid"
+    | "manifest-mismatch"
+    | "empty-shard";
+  message: string;
+}
+
+export interface CorpusValidationResult {
+  ok: boolean;
+  messages: CorpusMessage[];
+  issues: CorpusValidationIssue[];
+}
+
+export interface ShardReadResult {
+  path: string;
+  messages: CorpusMessage[];
+  sha256: string;
+  issues: CorpusValidationIssue[];
+}
+
+export interface CorpusValidationOptions {
+  maxTs?: number;
+  rootDir?: string;
+}
+
+function sha256(bytes: string): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function isCorpusPlatform(value: string | undefined): value is CorpusPlatform {
+  return corpusPlatforms.some((platform) => platform === value);
+}
+
+function parseShardPath(filePath: string, rootDir?: string) {
+  const relative = rootDir
+    ? path.relative(rootDir, filePath)
+    : path.relative(process.cwd(), filePath);
+  const parts = relative.split(path.sep);
+  const filename = parts.at(-1);
+  if (!filename) {
+    return { relative: relative.split(path.sep).join("/") };
+  }
+  const accountId = parts.at(-2);
+  const maybePlatform = parts.at(-3);
+  const platform = isCorpusPlatform(maybePlatform) ? maybePlatform : undefined;
+  const month = filename.replace(/\.jsonl$/, "");
+  return {
+    relative: relative.split(path.sep).join("/"),
+    platform,
+    accountId,
+    month,
+  };
+}
+
+function validateMessages(
+  messages: CorpusMessage[],
+  options: CorpusValidationOptions = {},
+): CorpusValidationIssue[] {
+  const issues: CorpusValidationIssue[] = [];
+  const ids = new Set<string>();
+  const maxTs = options.maxTs ?? CORPUS_ANCHOR_MS;
+
+  for (const message of messages) {
+    if (ids.has(message.id)) {
+      issues.push({
+        code: "duplicate-id",
+        message: `duplicate message id ${message.id}`,
+      });
+    }
+    ids.add(message.id);
+    if (message.ts > maxTs) {
+      issues.push({
+        code: "cutoff-window",
+        message: `message ${message.id} is after corpus anchor`,
+      });
+    }
+  }
+
+  for (const message of messages) {
+    if (message.replyToId && !ids.has(message.replyToId)) {
+      issues.push({
+        code: "reply-missing",
+        message: `message ${message.id} replies to missing ${message.replyToId}`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+export function validateCorpusMessages(
+  input: unknown[],
+  options: CorpusValidationOptions = {},
+): CorpusValidationResult {
+  const messages: CorpusMessage[] = [];
+  const issues: CorpusValidationIssue[] = [];
+
+  input.forEach((row, index) => {
+    const parsed = corpusMessageSchema.safeParse(row);
+    if (parsed.success) {
+      messages.push(parsed.data);
+    } else {
+      issues.push({
+        line: index + 1,
+        code: "schema-invalid",
+        message: parsed.error.issues
+          .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+          .join("; "),
+      });
+    }
+  });
+
+  issues.push(...validateMessages(messages, options));
+  return { ok: issues.length === 0, messages, issues };
+}
+
+export async function readCorpusShard(
+  filePath: string,
+  options: CorpusValidationOptions = {},
+): Promise<ShardReadResult> {
+  const raw = await fs.readFile(filePath, "utf8");
+  const rows: unknown[] = [];
+  const issues: CorpusValidationIssue[] = [];
+  const lines = raw.split(/\r?\n/).filter((line) => line.trim().length > 0);
+
+  if (lines.length === 0) {
+    issues.push({
+      path: filePath,
+      code: "empty-shard",
+      message: "shard contains no JSONL rows",
+    });
+  }
+
+  lines.forEach((line, index) => {
+    try {
+      rows.push(JSON.parse(line));
+    } catch (error) {
+      // error-policy:J3 JSONL rows are untrusted corpus input; report invalid row.
+      issues.push({
+        path: filePath,
+        line: index + 1,
+        code: "schema-invalid",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+
+  const result = validateCorpusMessages(rows, options);
+  const pathInfo = parseShardPath(filePath, options.rootDir);
+  for (const message of result.messages) {
+    if (
+      message.platform !== pathInfo.platform ||
+      message.accountId !== pathInfo.accountId ||
+      new Date(message.ts).toISOString().slice(0, 7) !== pathInfo.month
+    ) {
+      result.issues.push({
+        path: filePath,
+        code: "path-mismatch",
+        message: `message ${message.id} does not match shard path ${pathInfo.relative}`,
+      });
+    }
+  }
+
+  return {
+    path: filePath,
+    messages: result.messages,
+    sha256: sha256(raw),
+    issues: [...issues, ...result.issues],
+  };
+}
+
+export async function findCorpusShardFiles(
+  targetPath: string,
+): Promise<string[]> {
+  const stat = await fs.stat(targetPath);
+  if (stat.isFile()) return [targetPath];
+
+  const found: string[] = [];
+  async function walk(dir: string): Promise<void> {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(entryPath);
+      } else if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+        found.push(entryPath);
+      }
+    }
+  }
+  await walk(targetPath);
+  return found.sort();
+}
+
+export async function buildCorpusManifest(
+  targetPath: string,
+  generatedAt = new Date().toISOString(),
+): Promise<{ manifest: CorpusManifest; issues: CorpusValidationIssue[] }> {
+  const rootDir = (await fs.stat(targetPath)).isDirectory()
+    ? targetPath
+    : path.dirname(targetPath);
+  const shardFiles = await findCorpusShardFiles(targetPath);
+  const entries: CorpusShardManifestEntry[] = [];
+  const issues: CorpusValidationIssue[] = [];
+
+  for (const file of shardFiles) {
+    const shard = await readCorpusShard(file, { rootDir });
+    issues.push(...shard.issues);
+    const pathInfo = parseShardPath(file, rootDir);
+    if (!pathInfo.platform || !pathInfo.accountId || !pathInfo.month) {
+      issues.push({
+        path: file,
+        code: "path-mismatch",
+        message: `shard path must be <platform>/<account>/<yyyy-mm>.jsonl`,
+      });
+      continue;
+    }
+    if (shard.messages.length === 0) continue;
+    const sortedTs = shard.messages
+      .map((message) => message.ts)
+      .sort((a, b) => a - b);
+    entries.push({
+      path: pathInfo.relative,
+      platform: pathInfo.platform,
+      accountId: pathInfo.accountId,
+      month: pathInfo.month,
+      count: shard.messages.length,
+      firstTs: sortedTs[0],
+      lastTs: sortedTs[sortedTs.length - 1],
+      sha256: shard.sha256,
+    });
+  }
+
+  const manifest = corpusManifestSchema.parse({
+    schemaVersion: 1,
+    generatedAt,
+    cutoffIso: CORPUS_CUTOFF_ISO,
+    shards: entries,
+    totals: {
+      messages: entries.reduce((sum, entry) => sum + entry.count, 0),
+      contacts: 0,
+      threads: 0,
+    },
+  });
+  return { manifest, issues };
+}
+
+export async function validateCorpusTarget(targetPath: string): Promise<{
+  ok: boolean;
+  manifest: CorpusManifest;
+  issues: CorpusValidationIssue[];
+}> {
+  const { manifest, issues } = await buildCorpusManifest(targetPath);
+  const parsed = corpusManifestSchema.safeParse(manifest);
+  if (!parsed.success) {
+    issues.push({
+      code: "manifest-invalid",
+      message: parsed.error.issues
+        .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+        .join("; "),
+    });
+  }
+  const stat = await fs.stat(targetPath);
+  if (stat.isDirectory()) {
+    const entries = await fs.readdir(targetPath);
+    if (entries.includes("manifest.json")) {
+      const manifestPath = path.join(targetPath, "manifest.json");
+      const expected = corpusManifestSchema.safeParse(
+        JSON.parse(await fs.readFile(manifestPath, "utf8")),
+      );
+      if (!expected.success) {
+        issues.push({
+          path: manifestPath,
+          code: "manifest-invalid",
+          message: expected.error.issues
+            .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+            .join("; "),
+        });
+      } else if (
+        JSON.stringify({
+          cutoffIso: expected.data.cutoffIso,
+          shards: expected.data.shards,
+          totals: expected.data.totals,
+        }) !==
+        JSON.stringify({
+          cutoffIso: manifest.cutoffIso,
+          shards: manifest.shards,
+          totals: manifest.totals,
+        })
+      ) {
+        issues.push({
+          path: manifestPath,
+          code: "manifest-mismatch",
+          message: "manifest.json does not match shard contents",
+        });
+      }
+    }
+  }
+  return { ok: issues.length === 0, manifest, issues };
+}

--- a/packages/corpus-tools/tsconfig.json
+++ b/packages/corpus-tools/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node"],
+    "typeRoots": [
+      "../../node_modules/@types",
+      "../../node_modules/.bun/node_modules/@types"
+    ]
+  },
+  "include": ["src"]
+}

--- a/packages/corpus-tools/vitest.config.ts
+++ b/packages/corpus-tools/vitest.config.ts
@@ -1,0 +1,17 @@
+/**
+ * Vitest config for @elizaos/corpus-tools: deterministic unit coverage over
+ * synthetic JSONL fixtures, schema validation, and mock-shape mappers.
+ */
+import { defineConfig, mergeConfig } from "vitest/config";
+import rootConfig from "../../vitest.config.ts";
+
+export default mergeConfig(
+  rootConfig,
+  defineConfig({
+    test: {
+      environment: "node",
+      include: ["src/**/*.test.ts"],
+      exclude: ["**/node_modules/**"],
+    },
+  }),
+);


### PR DESCRIPTION
Fixes #14763

## What

Creates `packages/corpus-tools` (the collectors directory was absent on develop; the closed Signal PR #16036 left no reusable infra) with:

- **`src/schema.ts`** — the private corpus interchange `CorpusMessage` schema (zod-validated) and the `2024-07-05` corpus cutoff constant.
- **`src/validator.ts`** — shard/corpus validation and `buildCorpusManifest` producing the canonical `manifest.json`.
- **`src/collectors/x-archive.ts`** — the official X data-archive collector:
  - Reads the archive **ZIP** (fflate, filtered to `data/*.js` during unzip) or an already-extracted directory.
  - Handles all `window.YTD.<name>.partN` files (`tweets.js`, `tweets-part1.js`, …) and strips the script prefix before JSON parsing, failing closed with typed `ElizaError` codes (`X_ARCHIVE_BAD_PREFIX` / `BAD_JSON` / `BAD_TIMESTAMP` / `BAD_ZIP` / `MISSING_FILE`).
  - Drops rows with `created_at < 2024-07-05` (configurable cutoff).
  - Tweets → `CorpusMessage` direction `out`, `threadId` resolved to the reply-chain root within the archive (cycle-safe, falls back to the referenced parent when the chain leaves the archive).
  - DMs → per-conversation messages, direction derived from `senderId` vs owner account id.
  - Likes are **counted in the summary only** — never fabricated into message rows (per triage guidance).
  - Writes deterministic monthly JSONL shards idempotently (byte-identical shards reused → interrupted runs are resumable), plus `manifest.json` and `x-archive-summary.json` with tweet/DM-conversation counts.

Raw archives stay under the gitignored `data/` tree; only the synthetic fixture is committed (`.gitignore` re-includes `fixtures/x-archive/data/`).

## Out of scope (per issue)

API top-up via plugin-x, media bytes, and the owner's real archive pull (needs-human, 24–48 h X latency).

## Tests

Committed synthetic mini-archive fixture (multi-part tweets, two DM conversations, likes). 7 vitest cases: full directory collection + manifest counts, ZIP-input parity, cutoff filtering, DM direction mapping, resume/shard-reuse, reply-chain threadIds, and malformed-archive failure paths (missing file, bad prefix, bad JSON).

```
bun run --cwd packages/corpus-tools test        # 7 passed
bun run --cwd packages/corpus-tools typecheck   # clean
bun run --cwd packages/corpus-tools lint:check  # clean (pinned Biome via run-biome-typescript.mjs)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)