### PR TITLE
fix(cloud): retry transient OpenRouter routing 400

### DIFF
--- a/packages/cloud/shared/src/lib/providers/language-model-interactive-cerebras-failover.test.ts
+++ b/packages/cloud/shared/src/lib/providers/language-model-interactive-cerebras-failover.test.ts
@@ -58,6 +58,12 @@ function serverError(): Response {
   return new Response(JSON.stringify({ error: { message: "upstream 5xx" } }), { status: 503 });
 }
 
+function noModelsProvided(): Response {
+  return new Response(JSON.stringify({ error: { message: "No models provided", code: 400 } }), {
+    status: 400,
+  });
+}
+
 // A minimal OpenAI-compatible SSE completion stream (one content delta + done),
 // so the streaming failover path yields real text chunks like production does.
 function streamedCompletion(model: string, content: string): Response {
@@ -180,6 +186,47 @@ describe("getInteractiveCerebrasLanguageModel 5xx instant failover", () => {
     expect(out).toBe("streamed-from-openrouter");
     expect(hosts).toEqual(["cerebras", "openrouter"]);
     expect(models).toEqual(["gemma-4-31b", "google/gemma-4-31b-it"]);
+  });
+
+  test("retries OpenRouter's transient no-models 400 once during streamed failover", async () => {
+    let openRouterAttempts = 0;
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      const host = hostOf(url);
+      hosts.push(host);
+      if (host === "cerebras") return serverError();
+      openRouterAttempts++;
+      return openRouterAttempts === 1
+        ? noModelsProvided()
+        : streamedCompletion("google/gemma-4-31b-it", "recovered-stream");
+    }) as typeof fetch;
+
+    const { textStream } = streamText({
+      model: getInteractiveCerebrasLanguageModel("gemma-4-31b"),
+      prompt: "hi",
+      maxRetries: 0,
+    });
+    let out = "";
+    for await (const chunk of textStream) out += chunk;
+
+    expect(out).toBe("recovered-stream");
+    expect(hosts).toEqual(["cerebras", "openrouter", "openrouter"]);
+  });
+
+  test("bounds repeated OpenRouter no-models failures at one identical retry", async () => {
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      const host = hostOf(url);
+      hosts.push(host);
+      return host === "cerebras" ? serverError() : noModelsProvided();
+    }) as typeof fetch;
+
+    await expect(
+      generateText({
+        model: getInteractiveCerebrasLanguageModel("gemma-4-31b"),
+        prompt: "hi",
+        maxRetries: 0,
+      }),
+    ).rejects.toBeDefined();
+    expect(hosts).toEqual(["cerebras", "openrouter", "openrouter"]);
   });
 
   test("a non-retryable 400 surfaces via cerebras only (no failover)", async () => {

--- a/packages/cloud/shared/src/lib/providers/language-model-openrouter-fallback.test.ts
+++ b/packages/cloud/shared/src/lib/providers/language-model-openrouter-fallback.test.ts
@@ -53,6 +53,12 @@ function badGateway(): Response {
   return new Response(JSON.stringify({ error: { message: "Bad Gateway" } }), { status: 503 });
 }
 
+function noModelsProvided(): Response {
+  return new Response(JSON.stringify({ error: { message: "No models provided", code: 400 } }), {
+    status: 400,
+  });
+}
+
 afterEach(() => {
   globalThis.fetch = ORIGINAL_FETCH;
 });
@@ -96,5 +102,43 @@ describe("getLanguageModel native → OpenRouter fallback (AI SDK path)", () => 
     ).rejects.toBeDefined();
     // OpenRouter is never reached: a 400 is a real request error, not an outage.
     expect(hosts).toEqual(["openai"]);
+  });
+
+  test("retries OpenRouter's transient no-models 400 once after native failover", async () => {
+    let openRouterAttempts = 0;
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      const host = hostOf(url);
+      hosts.push(host);
+      if (host === "openai") return badGateway();
+      openRouterAttempts++;
+      return openRouterAttempts === 1
+        ? noModelsProvided()
+        : completion("openai/gpt-4", "recovered");
+    }) as typeof fetch;
+
+    const result = await generateText({
+      model: getLanguageModel("openai/gpt-4"),
+      prompt: "hi",
+      maxRetries: 0,
+    });
+
+    expect(result.text).toBe("recovered");
+    expect(hosts).toEqual(["openai", "openrouter", "openrouter"]);
+  });
+
+  test("does not retry an unrelated OpenRouter validation 400", async () => {
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      const host = hostOf(url);
+      hosts.push(host);
+      if (host === "openai") return badGateway();
+      return new Response(JSON.stringify({ error: { message: "model is invalid" } }), {
+        status: 400,
+      });
+    }) as typeof fetch;
+
+    await expect(
+      generateText({ model: getLanguageModel("openai/gpt-4"), prompt: "hi", maxRetries: 0 }),
+    ).rejects.toBeDefined();
+    expect(hosts).toEqual(["openai", "openrouter"]);
   });
 });

--- a/packages/cloud/shared/src/lib/providers/language-model.ts
+++ b/packages/cloud/shared/src/lib/providers/language-model.ts
@@ -381,6 +381,47 @@ function isRetryableAiSdkError(error: unknown): boolean {
   return status !== null && RETRYABLE_UPSTREAM_STATUSES.has(status);
 }
 
+function aiSdkErrorSearchText(error: unknown): string {
+  const unwrapped = RetryError.isInstance(error) ? error.lastError : error;
+  if (!APICallError.isInstance(unwrapped)) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  return [
+    unwrapped.message,
+    unwrapped.responseBody,
+    unwrapped.data === undefined ? undefined : JSON.stringify(unwrapped.data),
+  ]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ");
+}
+
+/** OpenRouter occasionally rejects a valid serialized model with this exact routing error. */
+function isTransientOpenRouterNoModelsError(error: unknown): boolean {
+  return (
+    aiSdkErrorStatus(error) === 400 && /\bno models provided\b/i.test(aiSdkErrorSearchText(error))
+  );
+}
+
+async function invokeOpenRouterFallback<T>(
+  model: string,
+  operation: "generate" | "stream",
+  invoke: () => PromiseLike<T>,
+): Promise<T> {
+  try {
+    return await invoke();
+  } catch (error) {
+    // error-policy:J1 OpenRouter's exact transient routing rejection is
+    // translated at the provider boundary into one immediate identical retry.
+    if (!isTransientOpenRouterNoModelsError(error)) throw error;
+    logger.warn(
+      "[OpenRouter] Transient no-models %s rejection for %s; retrying once (no backoff)",
+      operation,
+      model,
+    );
+    return await invoke();
+  }
+}
+
 /**
  * Wraps a native primary language model so that, on a retryable upstream error
  * (402/429/5xx), the request fails over to OpenRouter (BYOK) for the same model.
@@ -412,7 +453,9 @@ function withOpenRouterFallback(
           model,
           aiSdkErrorStatus(error),
         );
-        return await fallbackModel.doGenerate(params);
+        return await invokeOpenRouterFallback(model, "generate", () =>
+          fallbackModel.doGenerate(params),
+        );
       }
     },
     wrapStream: async ({ doStream, params }) => {
@@ -427,7 +470,9 @@ function withOpenRouterFallback(
           model,
           aiSdkErrorStatus(error),
         );
-        return await fallbackModel.doStream(params);
+        return await invokeOpenRouterFallback(model, "stream", () =>
+          fallbackModel.doStream(params),
+        );
       }
     },
   };
@@ -528,7 +573,9 @@ function withCerebrasInteractiveFailover(
           model,
           aiSdkErrorStatus(error),
         );
-        return await fallbackModel.doGenerate(params);
+        return await invokeOpenRouterFallback(model, "generate", () =>
+          fallbackModel.doGenerate(params),
+        );
       }
     },
     wrapStream: async ({ doStream, params }) => {
@@ -541,7 +588,9 @@ function withCerebrasInteractiveFailover(
           model,
           aiSdkErrorStatus(error),
         );
-        return await fallbackModel.doStream(params);
+        return await invokeOpenRouterFallback(model, "stream", () =>
+          fallbackModel.doStream(params),
+        );
       }
     },
   };


### PR DESCRIPTION
# Relates to

- Relates to #20331

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] A scoped pinned install and the relevant verification gates were run after sync; full-gate environmental blockers are recorded below.
- [x] A reviewer can confirm the bounded retry contract from the exact-head tests below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `0ad14403d952ff5d8d945d80146aec14c3267ce4`; zero conflicts.
- [x] Exact full-gate environmental blockers are documented below.

# Risks

Low. The retry is limited to OpenRouter HTTP 400 responses containing the exact known transient routing signature `No models provided`, executes once without backoff, and does not retry unrelated 400s or repeated failures. Both generate and stream fallback paths are covered.

# Background

## What does this PR do?

The shared Workerd runtime uses Cerebras for interactive turns and immediately falls back to OpenRouter on a transient native-provider failure. OpenRouter can intermittently return `400 No models provided` for a valid serialized request; because shared turns set `maxRetries: 0`, that one routing blip currently terminates phone voice and text turns.

This adds one immediate identical retry at the shared OpenRouter fallback boundary for that exact signature. It covers streamed voice and ordinary generated text while retaining fail-fast behavior for genuine validation errors.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No. This is internal provider error recovery with no public contract change.

# Testing

## Where should a reviewer start?

- `packages/cloud/shared/src/lib/providers/language-model.ts`
- `packages/cloud/shared/src/lib/providers/language-model-interactive-cerebras-failover.test.ts`
- `packages/cloud/shared/src/lib/providers/language-model-openrouter-fallback.test.ts`

## Detailed testing steps

```bash
bun test packages/cloud/shared/src/lib/providers/language-model-interactive-cerebras-failover.test.ts packages/cloud/shared/src/lib/providers/language-model-openrouter-fallback.test.ts
bun run --cwd packages/cloud/shared typecheck
```

Observed at the exact head: 12 provider tests pass, including streamed recovery, generated-text recovery, unrelated-400 rejection, and the one-retry bound. The cloud-shared typecheck passes. The broader voice-focused run also passed all 23 Twilio target, signing, TwiML, codec, bootstrap, greeting-continuity, and prewarm tests when isolated.

# Evidence Gate

<!-- evidence-head:297deae482fb2e8aabfeb8546d937adecb1818ab -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - production deploy occurs only after merge; deterministic provider-boundary tests exercise the exact wire error and retry sequence.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - local checkout has no OpenRouter/Cerebras credentials; tests use real AI SDK provider adapters with deterministic HTTP responses and assert exact provider attempt order.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact changes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - provider credentials are not present locally. Post-merge release verification will exercise production health/canaries and a real phone/text turn before the release is considered complete.

## Backend + frontend logs

N/A pre-deploy. The new structured warning identifies the exact bounded OpenRouter retry without logging request content or credentials.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

Pending post-deploy production call verification; the code path is shared by phone voice streaming and text generation.

## Known gaps / failures

- `bun run verify` passed repository preflight audits and reached workspace checks, then stopped because the scoped install did not include `node-swiftlint` for an unrelated native gateway package.
- `bun run verify:cloud` completed the relevant formatting and generated builds through 12/13 tasks, then the local disk filled during the core package `npm pack` verification step. The core runtime bundles and declarations had already built successfully; `packages/cloud/shared` typecheck and the exact focused tests pass.
- No Twilio console evidence is attached because the in-app Twilio session is currently signed out. Production call proof will be collected after deployment.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@0ad14403d952ff5d8d945d80146aec14c3267ce4:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-fix-shared-provider]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@0ad14403d952ff5d8d945d80146aec14c3267ce4:packages/skills/skills/contribute-to-eliza"} -->