### PR TITLE
fix(cloud): fail generate-music fast while the upstream provider is degraded

### DIFF
--- a/packages/cloud/api/__tests__/generate-music-provider-health.test.ts
+++ b/packages/cloud/api/__tests__/generate-music-provider-health.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Regression coverage for the generate-music provider health gate (#18436).
+ *
+ * A hanging fal upstream used to hold every music request toward the 300s
+ * ceiling. The route now feeds provider outcomes into a per provider+model
+ * breaker and, while it is open, fails fast with a structured 503 BEFORE
+ * content safety, pricing, or the credit hold — so no billable work is
+ * admitted toward a known-degraded upstream. The breaker module is real;
+ * auth, rate limiting, pricing, credits, and the audio provider are mocked.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as workersHonoAuthActual from "@/lib/auth/workers-hono-auth";
+import * as rateLimitActual from "@/lib/middleware/rate-limit-hono-cloudflare";
+import * as audioRegistryActual from "@/lib/providers/audio/registry";
+import * as aiPricingActual from "@/lib/services/ai-pricing";
+import * as contentSafetyActual from "@/lib/services/content-safety";
+import * as creditsActual from "@/lib/services/credits";
+import * as generationsActual from "@/lib/services/generations";
+import { resetGenerativeProviderHealthForTests } from "@/lib/services/generative-provider-health";
+
+const ORG = "00000000-0000-4000-8000-000000001842";
+const USER = "00000000-0000-4000-8000-000000001843";
+const MINIMAX = "fal-ai/minimax-music/v2.6";
+
+const requireUserOrApiKeyWithOrg = mock();
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  ...workersHonoAuthActual,
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  ...rateLimitActual,
+  RateLimitPresets: { STRICT: { limit: 1, windowSeconds: 1 } },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/services/content-safety", () => ({
+  ...contentSafetyActual,
+  contentSafetyService: {
+    ...contentSafetyActual.contentSafetyService,
+    assertSafeForPublicUse: async () => undefined,
+  },
+}));
+
+const calculateMusicGenerationCostFromCatalog = mock();
+mock.module("@/lib/services/ai-pricing", () => ({
+  ...aiPricingActual,
+  calculateMusicGenerationCostFromCatalog,
+}));
+
+const reserve = mock();
+mock.module("@/lib/services/credits", () => ({
+  ...creditsActual,
+  creditsService: { ...creditsActual.creditsService, reserve },
+}));
+
+const generationsCreate = mock();
+mock.module("@/lib/services/generations", () => ({
+  ...generationsActual,
+  generationsService: {
+    ...generationsActual.generationsService,
+    create: generationsCreate,
+  },
+}));
+
+const getAudioProvider = mock();
+const generateAudio = mock();
+mock.module("@/lib/providers/audio/registry", () => ({
+  ...audioRegistryActual,
+  getAudioProvider,
+}));
+
+const musicRoute = (await import("../v1/generate-music/route")).default;
+
+afterAll(() => {
+  mock.module("@/lib/auth/workers-hono-auth", () => workersHonoAuthActual);
+  mock.module(
+    "@/lib/middleware/rate-limit-hono-cloudflare",
+    () => rateLimitActual,
+  );
+  mock.module("@/lib/services/content-safety", () => contentSafetyActual);
+  mock.module("@/lib/services/ai-pricing", () => aiPricingActual);
+  mock.module("@/lib/services/credits", () => creditsActual);
+  mock.module("@/lib/services/generations", () => generationsActual);
+  mock.module("@/lib/providers/audio/registry", () => audioRegistryActual);
+});
+
+type AppCtx = { set: (k: string, v: unknown) => void };
+
+const COST = {
+  totalCost: 0.18,
+  baseTotalCost: 0.15,
+  platformMarkup: 0.03,
+  matchedEntry: {
+    billingSource: "fal",
+    provider: "fal",
+    model: MINIMAX,
+    productFamily: "music",
+    chargeType: "generation",
+    unit: "request",
+    unitPrice: 0.15,
+    dimensions: {},
+    sourceKind: "fal_model_page",
+    sourceUrl: "https://fal.ai/models/fal-ai/minimax-music/v2.6/api",
+  },
+};
+
+function makeReservation() {
+  const state = { reconcileCalls: 0, lastActual: Number.NaN };
+  return {
+    state,
+    reservation: {
+      reservedAmount: COST.totalCost,
+      reconcile: async (actualCost: number) => {
+        state.reconcileCalls++;
+        state.lastActual = actualCost;
+        return undefined;
+      },
+    },
+  };
+}
+
+function post(body: Record<string, unknown>) {
+  return musicRoute.request(
+    "/",
+    {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer eliza_test_key",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+    { FAL_KEY: "fal-test-key" },
+  );
+}
+
+beforeEach(() => {
+  resetGenerativeProviderHealthForTests();
+  requireUserOrApiKeyWithOrg.mockReset();
+  calculateMusicGenerationCostFromCatalog.mockReset();
+  reserve.mockReset();
+  generationsCreate.mockReset();
+  getAudioProvider.mockReset();
+  generateAudio.mockReset();
+
+  requireUserOrApiKeyWithOrg.mockImplementation(async (c: AppCtx) => {
+    c.set("apiKeyId", "key-1");
+    return {
+      id: USER,
+      organization_id: ORG,
+      organization: { id: ORG, name: "Org", is_active: true },
+      is_active: true,
+    };
+  });
+  calculateMusicGenerationCostFromCatalog.mockResolvedValue(COST);
+  getAudioProvider.mockImplementation((billingSource: string) => ({
+    billingSource,
+    generate: generateAudio,
+  }));
+});
+
+async function failUpstreamOnce(message: string) {
+  const { reservation } = makeReservation();
+  reserve.mockResolvedValueOnce(reservation);
+  generateAudio.mockRejectedValueOnce(new Error(message));
+  const res = await post({ model: MINIMAX, prompt: "night drive synthwave" });
+  expect(res.status).toBeGreaterThanOrEqual(500);
+  return res;
+}
+
+describe("generate-music provider health gate", () => {
+  test("three upstream timeouts open the gate; the next request fails fast before any credit hold", async () => {
+    for (let i = 0; i < 3; i++) {
+      await failUpstreamOnce(
+        "fal queue job timed out after 300000ms (request r1)",
+      );
+    }
+    expect(generateAudio).toHaveBeenCalledTimes(3);
+    const reservesBefore = reserve.mock.calls.length;
+
+    const res = await post({ model: MINIMAX, prompt: "lofi rain" });
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toMatch(/^\d+$/);
+    const body = (await res.json()) as {
+      success: boolean;
+      error: string;
+      code: string;
+      details?: Record<string, unknown>;
+    };
+    expect(body.success).toBe(false);
+    expect(body.code).toBe("service_unavailable");
+    expect(body.error).toContain("backed up");
+    expect(body.details?.provider).toBe("fal");
+    expect(body.details?.model).toBe(MINIMAX);
+    expect(body.details?.lastFailureKind).toBe("timeout");
+    expect(typeof body.details?.retryAfterSeconds).toBe("number");
+
+    // Fail-fast happened before admission and before the provider call.
+    expect(reserve.mock.calls.length).toBe(reservesBefore);
+    expect(generateAudio).toHaveBeenCalledTimes(3);
+  });
+
+  test("upstream 5xx failures also open the gate", async () => {
+    for (let i = 0; i < 3; i++) {
+      await failUpstreamOnce("fal queue submit failed (503)");
+    }
+    const res = await post({ model: MINIMAX, prompt: "lofi rain" });
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("service_unavailable");
+    expect(generateAudio).toHaveBeenCalledTimes(3);
+  });
+
+  test("config errors (bad key 401) keep failing per request without tripping the gate", async () => {
+    for (let i = 0; i < 3; i++) {
+      await failUpstreamOnce("fal queue submit failed (401): invalid key");
+    }
+    const { reservation } = makeReservation();
+    reserve.mockResolvedValueOnce(reservation);
+    generateAudio.mockRejectedValueOnce(
+      new Error("fal queue submit failed (401): invalid key"),
+    );
+    const res = await post({ model: MINIMAX, prompt: "lofi rain" });
+    // Still reaches the provider — misconfiguration is not an outage.
+    expect(generateAudio).toHaveBeenCalledTimes(4);
+    expect(res.status).not.toBe(503);
+  });
+
+  test("a success closes the gate and later requests flow normally", async () => {
+    await failUpstreamOnce("fal queue job timed out after 300000ms (r1)");
+    await failUpstreamOnce("fal queue job timed out after 300000ms (r2)");
+
+    const { reservation } = makeReservation();
+    reserve.mockResolvedValueOnce(reservation);
+    generationsCreate.mockResolvedValue({ id: "gen-music" });
+    generateAudio.mockResolvedValueOnce({
+      source: "hosted",
+      url: "https://v3b.fal.media/files/music-output.mp3",
+      fileName: "music-output.mp3",
+      fileSize: 1234,
+      contentType: "audio/mpeg",
+      requestId: "req-music",
+      status: "completed",
+      raw: { audio: { url: "https://v3b.fal.media/files/music-output.mp3" } },
+    });
+    const ok = await post({ model: MINIMAX, prompt: "sunrise piano" });
+    expect(ok.status).toBe(200);
+
+    // Two fresh strikes after the success must not open the gate (streak reset).
+    await failUpstreamOnce("fal queue job timed out after 300000ms (r3)");
+    await failUpstreamOnce("fal queue job timed out after 300000ms (r4)");
+    const { reservation: r2 } = makeReservation();
+    reserve.mockResolvedValueOnce(r2);
+    generateAudio.mockResolvedValueOnce({
+      source: "hosted",
+      url: "https://v3b.fal.media/files/music-output-2.mp3",
+      contentType: "audio/mpeg",
+      requestId: "req-music-2",
+      status: "completed",
+      raw: { audio: { url: "https://v3b.fal.media/files/music-2.mp3" } },
+    });
+    const stillOpen = await post({ model: MINIMAX, prompt: "sunset piano" });
+    expect(stillOpen.status).toBe(200);
+  });
+
+  test("failed requests that trip the breaker still refund their hold", async () => {
+    const { state, reservation } = makeReservation();
+    reserve.mockResolvedValueOnce(reservation);
+    generateAudio.mockRejectedValueOnce(
+      new Error("fal queue job timed out after 300000ms (request r9)"),
+    );
+    const res = await post({ model: MINIMAX, prompt: "storm ambience" });
+    expect(res.status).toBeGreaterThanOrEqual(500);
+    expect(state.reconcileCalls).toBe(1);
+    expect(state.lastActual).toBe(0);
+  });
+});

--- a/packages/cloud/api/v1/generate-music/route.ts
+++ b/packages/cloud/api/v1/generate-music/route.ts
@@ -20,6 +20,12 @@ import {
 import { contentSafetyService } from "@/lib/services/content-safety";
 import { InsufficientCreditsError } from "@/lib/services/credits";
 import { generationsService } from "@/lib/services/generations";
+import {
+  checkGenerativeProviderHealth,
+  classifyGenerativeFailure,
+  recordGenerativeFailure,
+  recordGenerativeSuccess,
+} from "@/lib/services/generative-provider-health";
 import { putPublicObject } from "@/lib/storage/r2-public-object";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv, Bindings } from "@/types/cloud-worker-env";
@@ -194,6 +200,30 @@ app.post("/", async (c) => {
       );
     }
 
+    // Fail fast while the upstream is known-degraded (#18436): repeated
+    // timeouts/5xx open a per provider+model breaker, and while it is open we
+    // refuse before content safety, pricing, or the credit hold — no billable
+    // work is admitted toward an upstream that is currently hanging.
+    const providerHealthKey = `music:${provider}:${request.model}`;
+    const providerHealth = checkGenerativeProviderHealth(providerHealthKey);
+    if (providerHealth.degraded) {
+      c.header("Retry-After", String(providerHealth.retryAfterSeconds));
+      return jsonError(
+        c,
+        503,
+        "Music generation is backed up right now; the upstream provider is not responding. Try again shortly.",
+        "service_unavailable",
+        {
+          provider,
+          model: request.model,
+          retryAfterSeconds: providerHealth.retryAfterSeconds,
+          ...(providerHealth.lastFailureKind
+            ? { lastFailureKind: providerHealth.lastFailureKind }
+            : {}),
+        },
+      );
+    }
+
     const durationSeconds =
       definition.durationControl === "supported"
         ? (request.durationSeconds ??
@@ -264,8 +294,9 @@ app.post("/", async (c) => {
     }
 
     await admission.markProviderDispatched?.();
-    const generated = await getAudioProvider(definition.billingSource).generate(
-      {
+    let generated: GeneratedAudio;
+    try {
+      generated = await getAudioProvider(definition.billingSource).generate({
         kind: "music",
         model: request.model,
         prompt: request.prompt,
@@ -292,8 +323,17 @@ app.post("/", async (c) => {
           SUNO_API_KEY: envString(c.env, "SUNO_API_KEY"),
           SUNO_BASE_URL: envString(c.env, "SUNO_BASE_URL"),
         },
-      },
-    );
+      });
+    } catch (error) {
+      // error-policy:J2 breaker accounting for the health gate above, then the
+      // unchanged error proceeds to the route boundary (refund + failureResponse).
+      recordGenerativeFailure(
+        providerHealthKey,
+        classifyGenerativeFailure(error),
+      );
+      throw error;
+    }
+    recordGenerativeSuccess(providerHealthKey);
 
     const music = await storeGeneratedAudio(
       c.env,

--- a/packages/cloud/shared/src/lib/services/generative-provider-health.test.ts
+++ b/packages/cloud/shared/src/lib/services/generative-provider-health.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for the generative provider health breaker: real module, no
+ * mocks, deterministic clocks passed explicitly. Covers threshold opening,
+ * failure classification, config-error immunity, cooldown expiry (half-open),
+ * immediate reopen on a post-cooldown failure, and success closing the gate.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  checkGenerativeProviderHealth,
+  classifyGenerativeFailure,
+  recordGenerativeFailure,
+  recordGenerativeSuccess,
+  resetGenerativeProviderHealthForTests,
+} from "./generative-provider-health";
+
+const KEY = "music:fal:fal-ai/minimax-music/v2.6";
+const T0 = 1_700_000_000_000;
+
+beforeEach(() => {
+  resetGenerativeProviderHealthForTests();
+});
+
+describe("classifyGenerativeFailure", () => {
+  test("timeouts, 5xx, 4xx, and config errors classify distinctly", () => {
+    expect(
+      classifyGenerativeFailure(new Error("fal queue job timed out after 300000ms (request r1)")),
+    ).toBe("timeout");
+    expect(classifyGenerativeFailure(new Error("fal queue submit failed (503)"))).toBe(
+      "upstream_error",
+    );
+    expect(classifyGenerativeFailure(new Error("fal queue submit failed (401): bad key"))).toBe(
+      "config_error",
+    );
+    expect(
+      classifyGenerativeFailure(new Error("fal is not configured: missing FAL_KEY / FAL_API_KEY")),
+    ).toBe("config_error");
+    expect(classifyGenerativeFailure(new Error("socket hang up"))).toBe("upstream_error");
+  });
+});
+
+describe("breaker lifecycle", () => {
+  test("opens only at the consecutive-failure threshold", () => {
+    expect(recordGenerativeFailure(KEY, "timeout", T0).degraded).toBe(false);
+    expect(recordGenerativeFailure(KEY, "timeout", T0).degraded).toBe(false);
+    const opened = recordGenerativeFailure(KEY, "timeout", T0);
+    expect(opened.degraded).toBe(true);
+    expect(opened.retryAfterSeconds).toBeGreaterThan(0);
+    expect(opened.lastFailureKind).toBe("timeout");
+    expect(checkGenerativeProviderHealth(KEY, T0).degraded).toBe(true);
+  });
+
+  test("config errors never advance or reset the breaker", () => {
+    recordGenerativeFailure(KEY, "timeout", T0);
+    recordGenerativeFailure(KEY, "timeout", T0);
+    // A bad-key 401 between timeouts must not trip the gate...
+    expect(recordGenerativeFailure(KEY, "config_error", T0).degraded).toBe(false);
+    // ...and must not have consumed the third strike either.
+    expect(checkGenerativeProviderHealth(KEY, T0).degraded).toBe(false);
+    expect(recordGenerativeFailure(KEY, "upstream_error", T0).degraded).toBe(true);
+  });
+
+  test("cooldown expiry half-opens; one more failure reopens immediately", () => {
+    for (let i = 0; i < 3; i++) recordGenerativeFailure(KEY, "timeout", T0);
+    const later = T0 + 121_000;
+    expect(checkGenerativeProviderHealth(KEY, later).degraded).toBe(false);
+    // Half-open: a single further eligible failure reopens without needing
+    // three fresh strikes.
+    expect(recordGenerativeFailure(KEY, "upstream_error", later).degraded).toBe(true);
+  });
+
+  test("success fully closes the gate and resets the strike count", () => {
+    for (let i = 0; i < 3; i++) recordGenerativeFailure(KEY, "timeout", T0);
+    recordGenerativeSuccess(KEY);
+    expect(checkGenerativeProviderHealth(KEY, T0).degraded).toBe(false);
+    expect(recordGenerativeFailure(KEY, "timeout", T0).degraded).toBe(false);
+    expect(recordGenerativeFailure(KEY, "timeout", T0).degraded).toBe(false);
+  });
+
+  test("keys are independent per provider+model", () => {
+    for (let i = 0; i < 3; i++) recordGenerativeFailure(KEY, "timeout", T0);
+    expect(checkGenerativeProviderHealth("music:elevenlabs/music_v1", T0).degraded).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/generative-provider-health.ts
+++ b/packages/cloud/shared/src/lib/services/generative-provider-health.ts
@@ -1,0 +1,107 @@
+/**
+ * In-memory circuit breaker for long-running generative media providers
+ * (music/audio upstreams such as fal and ElevenLabs). Consecutive breaker
+ * eligible failures (upstream timeouts and 5xx) open a per provider+model gate
+ * so routes can return an honest "backed up" 503 immediately instead of
+ * holding a synchronous HTTP connection toward a multi-minute ceiling against
+ * an upstream that is already known to be hanging (#18436).
+ *
+ * Config/contract failures (4xx, missing keys, unusable payloads) never trip
+ * the breaker: a bad key must surface as a config error on every request, not
+ * masquerade as a provider outage. State is per Worker isolate — the same
+ * accepted tradeoff as the solana-rpc proxy breaker — so a cold isolate always
+ * fails open and re-probes the upstream. After the cooldown the gate half
+ * opens: traffic flows again, one further eligible failure reopens it, and one
+ * success fully closes it.
+ */
+
+const FAILURE_THRESHOLD = 3;
+const OPEN_MS = 120_000;
+
+export type GenerativeFailureKind = "timeout" | "upstream_error" | "config_error";
+
+interface BreakerEntry {
+  consecutiveFailures: number;
+  openUntil: number;
+  lastFailureKind?: GenerativeFailureKind;
+}
+
+const breakers = new Map<string, BreakerEntry>();
+
+function entryFor(key: string): BreakerEntry {
+  let entry = breakers.get(key);
+  if (!entry) {
+    entry = { consecutiveFailures: 0, openUntil: 0 };
+    breakers.set(key, entry);
+  }
+  return entry;
+}
+
+/**
+ * Classifies an upstream generation failure for breaker accounting from the
+ * plain Error messages the fal-queue/audio providers throw. Timeouts and 5xx
+ * count toward opening the gate; 4xx and configuration failures do not.
+ */
+export function classifyGenerativeFailure(error: unknown): GenerativeFailureKind {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/timed out|timeout/i.test(message)) return "timeout";
+  if (/not configured|missing .*key/i.test(message)) return "config_error";
+  const status = /\((\d{3})\)/.exec(message)?.[1];
+  if (status && status.startsWith("4")) return "config_error";
+  return "upstream_error";
+}
+
+export interface GenerativeProviderHealth {
+  degraded: boolean;
+  retryAfterSeconds: number;
+  lastFailureKind?: GenerativeFailureKind;
+}
+
+/** Returns the gate state for a provider+model key without mutating it. */
+export function checkGenerativeProviderHealth(
+  key: string,
+  now: number = Date.now(),
+): GenerativeProviderHealth {
+  const entry = breakers.get(key);
+  if (!entry || entry.openUntil <= now) {
+    return { degraded: false, retryAfterSeconds: 0 };
+  }
+  return {
+    degraded: true,
+    retryAfterSeconds: Math.max(1, Math.ceil((entry.openUntil - now) / 1000)),
+    lastFailureKind: entry.lastFailureKind,
+  };
+}
+
+/** Records a successful generation, fully closing the gate for the key. */
+export function recordGenerativeSuccess(key: string): void {
+  breakers.delete(key);
+}
+
+/**
+ * Records a failed generation. Timeouts and upstream errors advance the
+ * breaker (and reopen a half-open gate immediately); config errors leave the
+ * breaker untouched so misconfiguration keeps failing loudly per request.
+ * Returns the resulting gate state.
+ */
+export function recordGenerativeFailure(
+  key: string,
+  kind: GenerativeFailureKind,
+  now: number = Date.now(),
+): GenerativeProviderHealth {
+  if (kind === "config_error") {
+    return checkGenerativeProviderHealth(key, now);
+  }
+  const entry = entryFor(key);
+  entry.consecutiveFailures += 1;
+  entry.lastFailureKind = kind;
+  if (entry.consecutiveFailures >= FAILURE_THRESHOLD) {
+    entry.openUntil = now + OPEN_MS;
+  }
+  return checkGenerativeProviderHealth(key, now);
+}
+
+/** Test-only: clears all breaker state so cases stay order-independent. */
+export function resetGenerativeProviderHealthForTests(): void {
+  breakers.clear();
+}


### PR DESCRIPTION
Fixes #18436

## Problem

Live probes (issue thread) showed `POST /v1/generate-music` holding a synchronous HTTP connection 115s+ against a hanging fal upstream — well inside the 300s music timeout — while Discord/app chat surfaces could only time out. Two prior repair attempts (#18681, #18719) were closed unbuildable/incomplete.

## Change

- **`packages/cloud/shared/src/lib/services/generative-provider-health.ts`** (new): in-memory per provider+model circuit breaker. Three consecutive breaker-eligible failures (upstream timeout or 5xx) open a 120s gate; config/contract failures (4xx, missing keys) never count, so a bad `FAL_KEY`/`ELEVENLABS_API_KEY` keeps failing loudly per request instead of masquerading as an outage (per the failure-classification split proposed in the issue thread). After cooldown the gate half-opens: one further eligible failure reopens it, one success fully closes it. State is per Worker isolate (same accepted tradeoff as the solana-rpc proxy breaker), so a cold isolate fails open and re-probes.
- **`packages/cloud/api/v1/generate-music/route.ts`**: while the gate is open, return an immediate structured 503 `"Music generation is backed up right now; the upstream provider is not responding."` with `Retry-After`, **before** content safety, pricing, and the credit hold — no billable work is admitted toward a known-hanging upstream. Provider failures are classified and recorded (`// error-policy:J2` rethrow to the existing route boundary, so refund + failureResponse behavior is unchanged).

The async-job conversion (202 + pending settlement + reconcile cron, mirroring the video path) remains a follow-up; this lands the bounded fail-fast half of the issue scope without holding the billing rail hostage to that larger change.

## Tests

- `packages/cloud/api` — `bun test __tests__/generate-music-provider-health.test.ts`: **5/5** against a mocked fal upstream: three timeouts open the gate and the next request fails fast with no credit hold; 5xx also opens; 401 config errors keep failing per request without tripping; success closes the gate (recovery); the tripping failure still refunds its hold.
- `packages/cloud/shared` — `bun test src/lib/services/generative-provider-health.test.ts`: **6/6** (classification, threshold, half-open reopen/close).
- Existing `__tests__/generate-music-duration-billing.test.ts`: **3/3** still green.
- `tsc --noEmit` clean in both `packages/cloud/api` and `packages/cloud/shared`; Biome clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)