### PR TITLE
ci: rewire exact-head device-bundle proof behind the ci:device label

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -37,6 +37,12 @@ Representative examples:
   `main`-targeted PRs carrying the `ci:full` label.
 - `ui-e2e-gate.yml` and `ui-fixture-e2e.yml` run the packages/ui Chromium and
   WebKit fixture gates when `packages/ui/src/**` changes.
+- `device-e2e.yml` is the exact-head Android-emulator and iOS-simulator
+  device-bundle producer (#19640). Canonical `ci.yml` calls it only for PRs
+  carrying the `ci:device` label; `workflow_dispatch` is the on-demand route.
+  Both jobs run the bundle-owning runners with `--output` and upload the full
+  bundle (`inline/`, `logs/`, `summary.json`, `junit.xml`) on success and
+  failure, without reading any repository secret.
 
 ## Manual operations
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,6 +477,15 @@ jobs:
           retention-days: 3
           if-no-files-found: warn
 
+  # Exact-head device-bundle proof (#19640, #14336). Opt-in only: a PR carries
+  # the heavy Android-emulator and iOS-simulator bundle producers exactly when
+  # it wears the `ci:device` label at event time. Intentionally absent from
+  # `required` — an unlabeled PR skips this and the merge gate is unaffected.
+  device:
+    name: Device bundles
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:device')
+    uses: ./.github/workflows/device-e2e.yml
+
   secrets:
     # Preserve the stable check context consumed by branch protection and the
     # security advisory gate while canonical CI owns PR dispatch.

--- a/.github/workflows/device-e2e.yml
+++ b/.github/workflows/device-e2e.yml
@@ -1,0 +1,153 @@
+name: Device E2E
+
+# Exact-head Android emulator and iOS simulator device-bundle proof (#19640,
+# #14336). The retired android-device-e2e.yml / mobile-build-smoke.yml producers
+# were deleted by the CI consolidation (926dc8b58a1); this workflow restores a
+# minimal route without the retired sprawl. Each job hands the whole lane to
+# the single bundle-owning runner (android-e2e.mjs / ios-e2e.mjs --output) so
+# build, install, boot, and drive failures all land inside one bundle root
+# (inline/, logs/, summary.json, junit.xml), and the artifact is uploaded on
+# success AND failure. No repository secrets are read anywhere, so fork PRs
+# stay credential-free.
+#
+# Reachability: repository policy forbids direct pull-request triggers
+# (audit:workflow-triggers), so canonical ci.yml calls this workflow behind the
+# `ci:device` label gate — the emulator/simulator legs are heavy and a PR runs
+# them only when explicitly opted in. Labels are read from the run's event
+# payload, so apply `ci:device` before the head push (or re-open) that should
+# carry the proof. workflow_dispatch remains the on-demand route for arbitrary
+# refs.
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+concurrency:
+  group: device-e2e-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CI: "true"
+  BUN_VERSION: "1.3.14" # pinned to the repository packageManager; match .github/ci-bun-version.json (#15071)
+  NODE_VERSION: "24.15.0"
+
+jobs:
+  android-device-bundle:
+    name: Android emulator bundle
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    env:
+      ELIZA_MOBILE_REPO_ROOT: ${{ github.workspace }}
+      ELIZA_WEBVIEW_DEBUG: "1"
+      ELIZA_BUN_RISCV64_OPTIONAL: "1"
+      ELIZA_ANDROID_SKIP_FORK_LLAMA_LIB: "1"
+      # The embedded on-device agent (bun + llama) SIGSEGVs on a stock x86_64
+      # emulator, so this lane proves build + install + WebView attach + route
+      # coverage against the host-run agent; the LOCAL arm64 route stays on
+      # self-hosted device runners.
+      ELIZA_ANDROID_BACKEND: "host"
+      ELIZA_DEVICE_BUNDLE_ROOT: ${{ github.workspace }}/device-e2e-artifacts
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961
+        with:
+          distribution: temurin
+          java-version: "21"
+      - uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699
+
+      - name: Install workspace
+        run: bun install --frozen-lockfile
+
+      # KVM enables a usable emulator on GitHub ubuntu runners.
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules && sudo udevadm trigger --name-match=kvm
+
+      # android-e2e.mjs owns the whole lane inside the emulator session — APK
+      # build (--build), install, WebView route coverage — so every preflight
+      # failure is a recorded bundle step instead of a bundle-less job failure.
+      - name: Android device-bundle run
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d
+        with:
+          api-level: "34"
+          arch: x86_64
+          ram-size: 6144M
+          # avx2/fma passthrough so the (x86) on-device agent doesn't SIGILL.
+          emulator-options: -no-window -no-snapshot -no-boot-anim -gpu swiftshader_indirect -qemu -cpu qemu64,+avx,+avx2,+f16c,+fma
+          script: node packages/app/scripts/android-e2e.mjs --build --skip-local-chat --no-emulator-boot --output "$ELIZA_DEVICE_BUNDLE_ROOT/android"
+
+      - name: Upload Android device bundle
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: android-device-e2e-bundle
+          path: device-e2e-artifacts/android/**
+          if-no-files-found: warn
+          retention-days: 14
+
+  ios-simulator-bundle:
+    name: iOS simulator bundle
+    runs-on: macos-15
+    timeout-minutes: 90
+    env:
+      LANG: en_US.UTF-8
+      # The simulator smoke drives a loopback host agent. Use the direct
+      # developer iOS lane; App Store/cloud builds intentionally reject
+      # cleartext loopback and are covered by release workflows.
+      ELIZA_BUILD_VARIANT: "direct"
+      ELIZA_RELEASE_AUTHORITY: "developer-toolchain"
+      VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK: "1"
+      ELIZA_IOS_FULL_BUN_ENGINE: "0"
+      NODE_OPTIONS: "--max-old-space-size=8192"
+      ELIZA_DEVICE_BUNDLE_ROOT: ${{ github.workspace }}/device-e2e-artifacts
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --frozen-lockfile --ignore-scripts
+          install-native-deps: "false"
+          run-postinstall: "true"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      # vite.config.ts imports dist-only workspace packages; build those
+      # package chains before the runner's internal Vite/Capacitor build.
+      - name: Build Vite config package deps
+        run: bun turbo run build --filter=@elizaos/ui --filter=@elizaos/vault
+
+      # ios-e2e.mjs owns the whole lane — simulator boot, app build, install,
+      # auth deep-link drive — inside one bundle root.
+      - name: iOS device-bundle run
+        run: node packages/app/scripts/ios-e2e.mjs --skip-local-chat --output "$ELIZA_DEVICE_BUNDLE_ROOT/ios"
+
+      - name: Upload iOS simulator bundle
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ios-simulator-e2e-bundle
+          path: device-e2e-artifacts/ios/**
+          if-no-files-found: warn
+          retention-days: 14

--- a/packages/scripts/__tests__/device-e2e-workflow.test.ts
+++ b/packages/scripts/__tests__/device-e2e-workflow.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Contract for the label-gated device-bundle workflow (#19640, #14336).
+ *
+ * The CI consolidation removed every live route to the exact-head Android and
+ * iOS device-bundle proof. device-e2e.yml restores one: this suite pins that
+ * the `ci:device` label actually reaches BOTH bundle-owning runners
+ * (android-e2e.mjs / ios-e2e.mjs) with `--output` inside the uploaded artifact
+ * root, that the uploads run `if: always()` so an induced failure still ships
+ * a bundle, that the bundle producers emit the required inline/, logs/,
+ * summary.json, and junit.xml members, and that the workflow stays
+ * credential-free for fork PRs with pinned toolchains and SHA-pinned actions.
+ * Parses the real workflow YAML; deterministic, no network or devices.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const repoRoot = new URL("../../../", import.meta.url);
+
+function read(path: string): string {
+  return readFileSync(new URL(path, repoRoot), "utf8");
+}
+
+interface WorkflowStep {
+  if?: string;
+  name?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, string>;
+}
+
+interface WorkflowJob {
+  env?: Record<string, string>;
+  if?: string;
+  "runs-on"?: string;
+  steps?: WorkflowStep[];
+  "timeout-minutes"?: number;
+}
+
+interface CallerJob {
+  if?: string;
+  needs?: string[];
+  uses?: string;
+}
+
+interface Workflow {
+  concurrency?: { group?: string; "cancel-in-progress"?: boolean | string };
+  env?: Record<string, string>;
+  jobs?: Record<string, WorkflowJob>;
+  on?: Record<string, unknown>;
+  permissions?: Record<string, string>;
+}
+
+const workflowSource = read(".github/workflows/device-e2e.yml");
+const workflow = Bun.YAML.parse(workflowSource) as Workflow;
+const ci = Bun.YAML.parse(read(".github/workflows/ci.yml")) as {
+  jobs?: Record<string, CallerJob>;
+};
+
+const androidJob = workflow.jobs?.["android-device-bundle"];
+const iosJob = workflow.jobs?.["ios-simulator-bundle"];
+
+function requireJob(job: WorkflowJob | undefined, name: string): WorkflowJob {
+  if (!job) throw new Error(`Missing device-e2e job: ${name}`);
+  return job;
+}
+
+function findStep(
+  job: WorkflowJob,
+  predicate: (step: WorkflowStep) => boolean,
+  label: string,
+): WorkflowStep {
+  const step = job.steps?.find(predicate);
+  if (!step) throw new Error(`Missing device-e2e step: ${label}`);
+  return step;
+}
+
+describe("device-e2e workflow trigger reaches both bundle producers (#19640)", () => {
+  test("canonical ci.yml calls the producer workflow behind the ci:device label gate", () => {
+    const caller = ci.jobs?.device;
+    if (!caller) throw new Error("ci.yml is missing the device caller job");
+    expect(caller.uses).toBe("./.github/workflows/device-e2e.yml");
+    expect(caller.if).toContain(
+      "contains(github.event.pull_request.labels.*.name, 'ci:device')",
+    );
+    expect(caller.if).toContain("github.event_name == 'pull_request'");
+  });
+
+  test("an unlabeled PR's skipped device job cannot fail the merge gate", () => {
+    const required = ci.jobs?.required;
+    if (!required) throw new Error("ci.yml is missing the required job");
+    expect(required.needs).not.toContain("device");
+  });
+
+  test("the producer stays callable and dispatchable but never directly PR/push triggered", () => {
+    expect(workflow.on && "workflow_call" in workflow.on).toBe(true);
+    expect(workflow.on && "workflow_dispatch" in workflow.on).toBe(true);
+    expect(workflow.on && "pull_request" in (workflow.on ?? {})).toBe(false);
+    expect(workflow.on && "push" in (workflow.on ?? {})).toBe(false);
+  });
+
+  test("the Android job invokes the bundle-owning runner with --output inside the artifact root", () => {
+    const job = requireJob(androidJob, "android-device-bundle");
+    const runner = findStep(
+      job,
+      (step) =>
+        step.uses?.startsWith("reactivecircus/android-emulator-runner@") ===
+        true,
+      "Android emulator runner",
+    );
+    const script = runner.with?.script ?? "";
+    expect(script).toContain("packages/app/scripts/android-e2e.mjs");
+    expect(script).toContain(
+      '--output "$ELIZA_DEVICE_BUNDLE_ROOT/android"',
+    );
+    expect(job.env?.ELIZA_DEVICE_BUNDLE_ROOT).toBe(
+      "${{ github.workspace }}/device-e2e-artifacts",
+    );
+  });
+
+  test("the iOS job invokes ios-e2e.mjs with --output inside the artifact root", () => {
+    const job = requireJob(iosJob, "ios-simulator-bundle");
+    expect(job["runs-on"]).toMatch(/^macos-/);
+    const runner = findStep(
+      job,
+      (step) => step.run?.includes("packages/app/scripts/ios-e2e.mjs") === true,
+      "iOS bundle runner",
+    );
+    expect(runner.run).toContain('--output "$ELIZA_DEVICE_BUNDLE_ROOT/ios"');
+    expect(job.env?.ELIZA_DEVICE_BUNDLE_ROOT).toBe(
+      "${{ github.workspace }}/device-e2e-artifacts",
+    );
+  });
+
+  test("both uploads run if: always() and cover the exact --output roots", () => {
+    const android = findStep(
+      requireJob(androidJob, "android-device-bundle"),
+      (step) => step.uses?.startsWith("actions/upload-artifact@") === true,
+      "Android upload",
+    );
+    expect(android.if).toBe("always()");
+    expect(android.with?.path).toContain("device-e2e-artifacts/android/**");
+
+    const ios = findStep(
+      requireJob(iosJob, "ios-simulator-bundle"),
+      (step) => step.uses?.startsWith("actions/upload-artifact@") === true,
+      "iOS upload",
+    );
+    expect(ios.if).toBe("always()");
+    expect(ios.with?.path).toContain("device-e2e-artifacts/ios/**");
+  });
+});
+
+describe("device-e2e bundle producers emit the required bundle members", () => {
+  const bundleLib = read("packages/app/scripts/lib/device-e2e-bundle.mjs");
+
+  test("createDeviceE2eBundle materializes inline/, logs/, and summary.json at the root", () => {
+    expect(bundleLib).toContain('path.join(root, "inline")');
+    expect(bundleLib).toContain('path.join(root, "logs")');
+    expect(bundleLib).toContain('path.join(root, "summary.json")');
+  });
+
+  test("finalize writes junit.xml at the bundle root", () => {
+    expect(bundleLib).toContain('path.join(bundle.root, "junit.xml")');
+  });
+
+  test("both runners create and honor the --output bundle root", () => {
+    for (const runnerPath of [
+      "packages/app/scripts/android-e2e.mjs",
+      "packages/app/scripts/ios-e2e.mjs",
+    ]) {
+      const source = read(runnerPath);
+      expect(source).toContain("createDeviceE2eBundle");
+      expect(source).toContain("finalizeDeviceE2eBundle");
+      expect(source).toMatch(/parseOutputDirArg|flags\.output/);
+    }
+  });
+});
+
+describe("device-e2e workflow hygiene", () => {
+  test("toolchains are pinned to the repository versions", () => {
+    expect(workflow.env?.BUN_VERSION).toBe("1.3.14");
+    expect(workflow.env?.NODE_VERSION).toBe("24.15.0");
+  });
+
+  test("every third-party action is pinned by full commit SHA", () => {
+    const uses = [...workflowSource.matchAll(/uses:\s*([^\s]+)/g)]
+      .map((match) => match[1])
+      .filter((ref) => !ref.startsWith("./"));
+    expect(uses.length).toBeGreaterThan(0);
+    for (const ref of uses) {
+      expect(ref).toMatch(/@[0-9a-f]{40}$/);
+    }
+  });
+
+  test("permissions are read-only and no repository secrets are referenced (fork-safe)", () => {
+    expect(workflow.permissions).toEqual({ contents: "read" });
+    expect(workflowSource).not.toContain("secrets.");
+  });
+
+  test("jobs carry bounded timeouts and the workflow cancels superseded runs", () => {
+    expect(requireJob(androidJob, "android")["timeout-minutes"]).toBe(90);
+    expect(requireJob(iosJob, "ios")["timeout-minutes"]).toBe(90);
+    expect(workflow.concurrency?.["cancel-in-progress"]).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #19640. The CI consolidation (926dc8b58a1) deleted the `android-device-e2e.yml` and `mobile-build-smoke.yml` producers, leaving the `ci:device` label with no listener and #14336's exact-head device-bundle proof with no live GitHub Actions route (PR #19656 explicitly deferred this rewiring back to the issue). This restores one minimal route without the retired workflow sprawl.

### Changes

- **`.github/workflows/device-e2e.yml`** (new): `workflow_call` + `workflow_dispatch` producer with two jobs:
  - **Android emulator bundle** (ubuntu-24.04, KVM, SHA-pinned `reactivecircus/android-emulator-runner`): the emulator script hands the entire lane to the single bundle-owning runner — `node packages/app/scripts/android-e2e.mjs --build --skip-local-chat --no-emulator-boot --output "$ELIZA_DEVICE_BUNDLE_ROOT/android"` — so APK build, install, attach, and route-coverage failures all land as recorded bundle steps inside one root. Host backend (the embedded bun+llama agent SIGSEGVs on stock x86_64 emulators; the LOCAL arm64 route stays on device runners).
  - **iOS simulator bundle** (macos-15): `node packages/app/scripts/ios-e2e.mjs --skip-local-chat --output "$ELIZA_DEVICE_BUNDLE_ROOT/ios"` — simulator boot, app build, install, and auth deep-link drive inside one bundle root.
  - Both upload the full bundle (`inline/`, `logs/`, `summary.json`, `junit.xml`) via `if: always()`, so an induced failure still ships a complete bundle.
- **`.github/workflows/ci.yml`**: new non-required `device` job calls the producer only when a `pull_request` run carries the `ci:device` label at event time. Not in `required`'s `needs`, so unlabeled PRs skip it without affecting the merge gate. (Repository policy — `audit:workflow-triggers` in `bun run verify` — forbids direct `pull_request` triggers; canonical ci.yml is the PR-event entry point, same as every other PR gate.)
- **`packages/scripts/__tests__/device-e2e-workflow.test.ts`** (new): workflow-contract test proving the `ci:device` gate reaches both bundle producers with `--output` inside the exact uploaded artifact roots, the uploads run `if: always()`, the bundle library emits `inline/`/`logs/`/`summary.json`/`junit.xml`, toolchains are pinned (Bun 1.3.14 / Node 24.15.0), every third-party action is pinned by full commit SHA, permissions are `contents: read` only, no `secrets.` reference exists (fork PRs stay credential-free), timeouts are bounded, and concurrency cancels superseded runs.
- **`.github/workflows/README.md`**: documents the new producer.

### Hygiene contract

- Bun `1.3.14` / Node `24.15.0` pinned; all action SHAs reused from existing reviewed pins in this repo.
- `permissions: contents: read`; zero secrets; hosted runners only (no self-hosted exposure to fork PRs).
- `timeout-minutes: 90` per job; `concurrency` with `cancel-in-progress: true`.

### Tests run

- `bun test packages/scripts/__tests__/device-e2e-workflow.test.ts` — 13 pass.
- `actionlint` on `device-e2e.yml` + `ci.yml` — clean.
- `node packages/scripts/workflow-trigger-policy.mjs` — 49 workflows verified (no forbidden PR trigger introduced).
- `node packages/scripts/ci-bun-version-contract.mjs` — passed (54 workflow pins in lockstep).
- `node packages/scripts/hetzner-fleet-routing-contract.mjs` — 64 selectors verified.
- `bun test packages/scripts/__tests__/ci-path-gate.test.mjs ci-i18n-gate.test.ts turbo-cache-key.test.ts` — 17 pass.
- `biome check` on the new test — clean.

### Labeled-run demonstration

This PR wears `ci:device` itself, so its own CI run exercises the label gate on this exact head; the Android/iOS bundle jobs upload their artifacts under `android-device-e2e-bundle` / `ios-simulator-e2e-bundle` regardless of pass/fail (that if-always contract is the acceptance seam). Run/artifact links for #14336 will be on this PR's checks tab once the labeled run completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)