### PR TITLE
fix(shared): preserve explicit reminder delays

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
@@ -86,7 +86,7 @@ describe("Shared reminder relative-delay runtime authority", () => {
     },
     {
       label: "rejects a cancellation synonym before scheduler persistence",
-      message: "Remind me in 1 minute. Actually, please cancel that.",
+      message: "Remind me in 1 minute. Please, actually cancel that.",
       atIso: undefined,
     },
   ])("$label", async ({ message, atIso }) => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
@@ -86,7 +86,7 @@ describe("Shared reminder relative-delay runtime authority", () => {
     },
     {
       label: "rejects a cancellation synonym before scheduler persistence",
-      message: "Remind me in 1 minute, cancel that.",
+      message: "Remind me in 1 minute — cancel that.",
       atIso: undefined,
     },
   ])("$label", async ({ message, atIso }) => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
@@ -58,7 +58,28 @@ afterEach(() => {
 });
 
 describe("Shared reminder relative-delay runtime authority", () => {
-  test("persists literal one minute even when the planner emits two", async () => {
+  test.each([
+    {
+      label: "persists literal one minute even when the planner emits two",
+      message: "Remind me in 1 minute: stand up and stretch.",
+      atIso: "2026-08-16T04:49:56.509Z",
+    },
+    {
+      label: "persists a compound duration as one exact delay",
+      message: "Remind me to stretch in 1 minute and 30 seconds.",
+      atIso: "2026-08-16T04:50:26.509Z",
+    },
+    {
+      label: "persists the final explicit duration revision",
+      message: "Remind me in 1 minute, actually make that 2 minutes.",
+      atIso: "2026-08-16T04:50:56.509Z",
+    },
+    {
+      label: "rejects a negated command before scheduler persistence",
+      message: "I do not want you to remind me in 1 minute.",
+      atIso: undefined,
+    },
+  ])("$label", async ({ message, atIso }) => {
     let modelCall = 0;
     globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
       JSON.parse(String(init?.body));
@@ -169,7 +190,7 @@ describe("Shared reminder relative-delay runtime authority", () => {
         model: "gemma-4-31b",
       },
       history: [],
-      message: "Remind me in 1 minute: stand up and stretch.",
+      message,
       messageIds: {
         user: "7d734b8f-1ac5-456a-8bf3-9cd61dd546ef",
         assistant: "83de2c02-ec48-48d6-a734-c665b27d23cf",
@@ -188,12 +209,15 @@ describe("Shared reminder relative-delay runtime authority", () => {
       },
     });
 
-    expect(modelCall).toBe(3);
-    expect(result.actionResults?.[0]?.success).toBe(true);
-    expect(scheduledInputs).toHaveLength(1);
-    expect(scheduledInputs[0]?.trigger).toEqual({
-      kind: "once",
-      atIso: "2026-08-16T04:49:56.509Z",
-    });
+    if (atIso === undefined) {
+      expect(modelCall).toBeGreaterThanOrEqual(3);
+      expect(result.actionResults?.[0]?.success).toBe(false);
+      expect(scheduledInputs).toHaveLength(0);
+    } else {
+      expect(modelCall).toBe(3);
+      expect(result.actionResults?.[0]?.success).toBe(true);
+      expect(scheduledInputs).toHaveLength(1);
+      expect(scheduledInputs[0]?.trigger).toEqual({ kind: "once", atIso });
+    }
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
@@ -1,0 +1,199 @@
+/** Drives the genuine Shared AgentRuntime reminder action with a fixed clock and deterministic model boundary. */
+
+import { afterEach, beforeEach, describe, expect, setSystemTime, test } from "bun:test";
+import type { ScheduledTaskRunner } from "@elizaos/plugin-scheduling/edge";
+
+const NOW = "2026-08-16T04:48:56.509Z";
+const scheduledInputs: Array<Record<string, unknown>> = [];
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_CEREBRAS_KEY = process.env.CEREBRAS_API_KEY;
+
+const reminderRunner = {
+  async scheduleWithResult(input: Record<string, unknown>) {
+    scheduledInputs.push(input);
+    const task = {
+      taskId: "shared-reminder-relative-delay-1",
+      ...input,
+      state: { status: "scheduled" as const, followupCount: 0 },
+    };
+    return {
+      task,
+      commit: {
+        logId: "shared-reminder-relative-delay-log-1",
+        taskId: task.taskId,
+        agentId: "personal:a26524f1-c4f1-493b-a97e-8be161284a10",
+        occurredAtIso: NOW,
+        transition: "scheduled" as const,
+        rolledUp: false,
+      },
+      replayed: false,
+    };
+  },
+  async schedule(input: Record<string, unknown>) {
+    return (await this.scheduleWithResult(input)).task;
+  },
+  async list() {
+    return [];
+  },
+  async apply() {
+    throw new Error("Reminder mutation is outside this runtime creation proof");
+  },
+  async pipeline() {
+    return [];
+  },
+} satisfies ScheduledTaskRunner;
+
+beforeEach(() => {
+  scheduledInputs.length = 0;
+  setSystemTime(new Date(NOW));
+  process.env.CEREBRAS_API_KEY = "shared-runtime-relative-delay-test-key";
+  process.env.NODE_ENV = "production";
+});
+
+afterEach(() => {
+  setSystemTime();
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_CEREBRAS_KEY === undefined) delete process.env.CEREBRAS_API_KEY;
+  else process.env.CEREBRAS_API_KEY = ORIGINAL_CEREBRAS_KEY;
+});
+
+describe("Shared reminder relative-delay runtime authority", () => {
+  test("persists literal one minute even when the planner emits two", async () => {
+    let modelCall = 0;
+    globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+      JSON.parse(String(init?.body));
+      modelCall += 1;
+      if (modelCall === 1) {
+        return Response.json({
+          id: "chatcmpl-relative-delay-stage-one",
+          object: "chat.completion",
+          created: 0,
+          model: "gemma-4-31b",
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: "assistant",
+                content: null,
+                tool_calls: [
+                  {
+                    id: "relative-delay-handle-response",
+                    type: "function",
+                    function: {
+                      name: "HANDLE_RESPONSE",
+                      arguments: JSON.stringify({
+                        shouldRespond: "RESPOND",
+                        thought: "The user requested a reminder.",
+                        contexts: ["reminders"],
+                        intents: [],
+                        candidateActionNames: ["REMINDERS"],
+                        requiresTool: true,
+                        replyText: "",
+                        replyEffectStatus: "none",
+                        facts: [],
+                        relationships: [],
+                        addressedTo: [],
+                      }),
+                    },
+                  },
+                ],
+              },
+              finish_reason: "tool_calls",
+            },
+          ],
+          usage: { prompt_tokens: 30, completion_tokens: 12, total_tokens: 42 },
+        });
+      }
+      if (modelCall === 2) {
+        return Response.json({
+          id: "chatcmpl-relative-delay-plan",
+          object: "chat.completion",
+          created: 0,
+          model: "gemma-4-31b",
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: "assistant",
+                content: null,
+                tool_calls: [
+                  {
+                    id: "relative-delay-reminder-action",
+                    type: "function",
+                    function: {
+                      name: "REMINDERS",
+                      arguments: JSON.stringify({
+                        operation: "create",
+                        reminderText: "stand up and stretch",
+                        inMinutes: 2,
+                      }),
+                    },
+                  },
+                ],
+              },
+              finish_reason: "tool_calls",
+            },
+          ],
+          usage: { prompt_tokens: 40, completion_tokens: 10, total_tokens: 50 },
+        });
+      }
+      return Response.json({
+        id: "chatcmpl-relative-delay-finish",
+        object: "chat.completion",
+        created: 0,
+        model: "gemma-4-31b",
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: JSON.stringify({
+                success: true,
+                decision: "FINISH",
+                thought: "The reminder is stored.",
+                messageToUser: "Reminder saved.",
+              }),
+            },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 50, completion_tokens: 14, total_tokens: 64 },
+      });
+    }) as typeof fetch;
+
+    const { runSharedAgentTurn } = await import("./run-shared-agent-turn");
+    const result = await runSharedAgentTurn({
+      character: {
+        name: "Shared Eliza",
+        system: "You are Eliza.",
+        model: "gemma-4-31b",
+      },
+      history: [],
+      message: "Remind me in 1 minute: stand up and stretch.",
+      messageIds: {
+        user: "7d734b8f-1ac5-456a-8bf3-9cd61dd546ef",
+        assistant: "83de2c02-ec48-48d6-a734-c665b27d23cf",
+      },
+      execution: {
+        engine: "eliza-runtime",
+        agentKey: "personal:a26524f1-c4f1-493b-a97e-8be161284a10",
+        reminders: {
+          runner: reminderRunner,
+          delivery: {
+            platform: "telegram",
+            project: "eliza-app",
+            chatId: "123456789",
+          },
+        },
+      },
+    });
+
+    expect(modelCall).toBe(3);
+    expect(result.actionResults?.[0]?.success).toBe(true);
+    expect(scheduledInputs).toHaveLength(1);
+    expect(scheduledInputs[0]?.trigger).toEqual({
+      kind: "once",
+      atIso: "2026-08-16T04:49:56.509Z",
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
@@ -79,6 +79,11 @@ describe("Shared reminder relative-delay runtime authority", () => {
       message: "I do not want you to remind me in 1 minute.",
       atIso: undefined,
     },
+    {
+      label: "rejects a later cancellation before scheduler persistence",
+      message: "Remind me in 1 minute, actually do not remind me.",
+      atIso: undefined,
+    },
   ])("$label", async ({ message, atIso }) => {
     let modelCall = 0;
     globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
@@ -86,7 +86,7 @@ describe("Shared reminder relative-delay runtime authority", () => {
     },
     {
       label: "rejects a cancellation synonym before scheduler persistence",
-      message: "Remind me in 1 minute. However, cancel that, please.",
+      message: "Remind me in 1 minute. Actually, please cancel that.",
       atIso: undefined,
     },
   ])("$label", async ({ message, atIso }) => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
@@ -84,6 +84,11 @@ describe("Shared reminder relative-delay runtime authority", () => {
       message: "Remind me in 1 minute, actually do not remind me.",
       atIso: undefined,
     },
+    {
+      label: "rejects a cancellation synonym before scheduler persistence",
+      message: "Remind me in 1 minute, cancel that.",
+      atIso: undefined,
+    },
   ])("$label", async ({ message, atIso }) => {
     let modelCall = 0;
     globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
@@ -86,7 +86,7 @@ describe("Shared reminder relative-delay runtime authority", () => {
     },
     {
       label: "rejects a cancellation synonym before scheduler persistence",
-      message: "Remind me in 1 minute — cancel that.",
+      message: "Remind me in 1 minute. However, cancel that, please.",
       atIso: undefined,
     },
   ])("$label", async ({ message, atIso }) => {

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
@@ -36,6 +36,7 @@ describe("explicit Shared reminder relative delay", () => {
     ["Remind me in 1 minute: cancel that meeting with Bob.", 60_000],
     ["Remind me in 1 minute: cancel the subscription.", 60_000],
     ["Remind me in 1 minute: never mind the meeting title.", 60_000],
+    ["Remind me in 1 minute: cancel that meeting, please.", 60_000],
   ])("resolves %s", (text, milliseconds) => {
     expect(resolveExplicitSharedReminderDelay(text)).toEqual({
       kind: "resolved",
@@ -92,6 +93,11 @@ describe("explicit Shared reminder relative delay", () => {
     "Remind me in 1 minute — actually cancel that.",
     "Remind me in 1 minute... cancel that.",
     "Remind me in 1 minute… cancel that.",
+    "Remind me in 1 minute, cancel that, please.",
+    "Remind me in 1 minute. Cancel it please.",
+    "Remind me in 1 minute; never mind please.",
+    "Remind me in 1 minute. However, cancel that.",
+    "Remind me in 1 minute, actually, cancel that.",
   ])("fails closed for a negated reminder command: %s", (text) => {
     expect(resolveExplicitSharedReminderDelay(text)).toEqual({
       kind: "invalid",
@@ -228,6 +234,11 @@ describe("explicit Shared reminder relative delay", () => {
     ["a cancel-that cancellation", "Remind me in 1 minute, cancel that."],
     ["an em-dash cancellation", "Remind me in 1 minute — cancel that."],
     ["an ellipsis cancellation", "Remind me in 1 minute… cancel that."],
+    ["a polite cancellation", "Remind me in 1 minute, cancel that, please."],
+    [
+      "a punctuated discourse cancellation",
+      "Remind me in 1 minute. However, cancel that.",
+    ],
   ])("rejects %s before persistence", async (_label, text) => {
     const scheduleWithResult = vi.fn(async (_input: ScheduledTaskInput) => {
       throw new Error("Ambiguous reminder must not be scheduled");

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
@@ -24,6 +24,12 @@ describe("explicit Shared reminder relative delay", () => {
     ["In an hour remind me to leave.", 3_600_000],
     ["Remind me to stretch in 1 minute.", 60_000],
     ["Set a reminder to call mom in two hours.", 7_200_000],
+    ["Remind me in 1 minute and 30 seconds.", 90_000],
+    ["Remind me in 1 hour plus 30 minutes.", 5_400_000],
+    ["Remind me in 1 hour and a half.", 5_400_000],
+    ["Remind me to stretch in 1 minute and 30 seconds.", 90_000],
+    ["Remind me in 1 minute 30 seconds to stretch.", 90_000],
+    ["Remind me in 1 minute, actually make that 2 minutes.", 120_000],
   ])("resolves %s", (text, milliseconds) => {
     expect(resolveExplicitSharedReminderDelay(text)).toEqual({
       kind: "resolved",
@@ -62,11 +68,24 @@ describe("explicit Shared reminder relative delay", () => {
     "Do not remind me in 1 minute.",
     "Don't remind me in 1 minute.",
     "Never remind me in 1 minute.",
+    "I do not want you to remind me in 1 minute.",
+    "I don’t want you to remind me in 1 minute.",
+    "Do not ever remind me in 1 minute.",
+    "I don’t want a reminder in 1 minute.",
+    "I do not need a reminder in 1 minute.",
   ])("fails closed for a negated reminder command: %s", (text) => {
     expect(resolveExplicitSharedReminderDelay(text)).toEqual({
       kind: "invalid",
       reason: "A negated reminder command cannot create a reminder.",
     });
+  });
+
+  it("does not confuse unrelated negative context with command negation", () => {
+    expect(
+      resolveExplicitSharedReminderDelay(
+        "I do not know why, but remind me in 1 minute.",
+      ),
+    ).toEqual({ kind: "resolved", milliseconds: 60_000 });
   });
 
   it("rejects multiple relative reminder directives", () => {
@@ -81,7 +100,6 @@ describe("explicit Shared reminder relative delay", () => {
   });
 
   it.each([
-    "Remind me in 1 minute and 30 seconds to stretch.",
     "Remind me in 1 minute and in 2 hours to stretch.",
     "Remind me in 1 minute or in 2 minutes to stretch.",
   ])(
@@ -93,65 +111,78 @@ describe("explicit Shared reminder relative delay", () => {
     },
   );
 
-  it("uses the authenticated utterance instead of a conflicting planner delay", async () => {
-    const scheduleWithResult = vi.fn(async (input: ScheduledTaskInput) => ({
-      task: {
-        taskId: "reminder-1",
-        ...input,
-        state: { status: "scheduled", followupCount: 0 },
-      } satisfies ScheduledTask,
-      commit: {
-        logId: "scheduled-log-1",
-        taskId: "reminder-1",
-        agentId: "personal:user-1",
-        occurredAtIso: NOW,
-        transition: "scheduled" as const,
-        rolledUp: false,
-      },
-      replayed: false,
-    }));
-    const runner: ScheduledTaskRunner = {
-      scheduleWithResult,
-      schedule: vi.fn(),
-      list: vi.fn(async () => []),
-      apply: vi.fn(),
-      pipeline: vi.fn(async () => []),
-    };
-    const [action] =
-      createSharedRemindersEdgePlugin({
-        runner,
-        agentId: "personal:user-1",
-        delivery: {
-          platform: "telegram",
-          project: "eliza-app",
-          chatId: "123456",
+  it.each([
+    ["Remind me in 1 minute: stretch.", "2026-08-16T04:49:56.509Z"],
+    [
+      "Remind me to stretch in 1 minute and 30 seconds.",
+      "2026-08-16T04:50:26.509Z",
+    ],
+    [
+      "Remind me in 1 minute, actually make that 2 minutes.",
+      "2026-08-16T04:50:56.509Z",
+    ],
+  ])(
+    "uses the authenticated utterance instead of a conflicting planner delay: %s",
+    async (messageText, atIso) => {
+      const scheduleWithResult = vi.fn(async (input: ScheduledTaskInput) => ({
+        task: {
+          taskId: "reminder-1",
+          ...input,
+          state: { status: "scheduled", followupCount: 0 },
+        } satisfies ScheduledTask,
+        commit: {
+          logId: "scheduled-log-1",
+          taskId: "reminder-1",
+          agentId: "personal:user-1",
+          occurredAtIso: NOW,
+          transition: "scheduled" as const,
+          rolledUp: false,
         },
-        now: () => new Date(NOW),
-      }).actions ?? [];
+        replayed: false,
+      }));
+      const runner: ScheduledTaskRunner = {
+        scheduleWithResult,
+        schedule: vi.fn(),
+        list: vi.fn(async () => []),
+        apply: vi.fn(),
+        pipeline: vi.fn(async () => []),
+      };
+      const [action] =
+        createSharedRemindersEdgePlugin({
+          runner,
+          agentId: "personal:user-1",
+          delivery: {
+            platform: "telegram",
+            project: "eliza-app",
+            chatId: "123456",
+          },
+          now: () => new Date(NOW),
+        }).actions ?? [];
 
-    const result = await action?.handler(
-      {} as IAgentRuntime,
-      {
-        id: "message-1",
-        content: { text: "Remind me in 1 minute: stretch." },
-      } as Memory,
-      undefined,
-      {
-        parameters: {
-          operation: "create",
-          reminderText: "Stretch",
-          inMinutes: 2,
+      const result = await action?.handler(
+        {} as IAgentRuntime,
+        {
+          id: "message-1",
+          content: { text: messageText },
+        } as Memory,
+        undefined,
+        {
+          parameters: {
+            operation: "create",
+            reminderText: "Stretch",
+            inMinutes: 2,
+          },
         },
-      },
-    );
+      );
 
-    expect(result?.success).toBe(true);
-    expect(scheduleWithResult).toHaveBeenCalledOnce();
-    expect(scheduleWithResult.mock.calls[0]?.[0].trigger).toEqual({
-      kind: "once",
-      atIso: "2026-08-16T04:49:56.509Z",
-    });
-  });
+      expect(result?.success).toBe(true);
+      expect(scheduleWithResult).toHaveBeenCalledOnce();
+      expect(scheduleWithResult.mock.calls[0]?.[0].trigger).toEqual({
+        kind: "once",
+        atIso,
+      });
+    },
+  );
 
   it.each([
     [
@@ -159,6 +190,12 @@ describe("explicit Shared reminder relative delay", () => {
       "Remind me in 1 minute, then remind me in 2 minutes.",
     ],
     ["a negated command", "Do not remind me in 1 minute."],
+    ["a polite negated command", "I do not want you to remind me in 1 minute."],
+    [
+      "a curly-apostrophe negation",
+      "I don’t want you to remind me in 1 minute.",
+    ],
+    ["an ambiguous compound", "Remind me in 1 minute and in 2 hours."],
   ])("rejects %s before persistence", async (_label, text) => {
     const scheduleWithResult = vi.fn(async (_input: ScheduledTaskInput) => {
       throw new Error("Ambiguous reminder must not be scheduled");

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
@@ -33,6 +33,9 @@ describe("explicit Shared reminder relative delay", () => {
     ["Remind me in 1 minute. Actually make that 2 minutes.", 120_000],
     ["Remind me in 1 minute, but actually make that 2 minutes.", 120_000],
     ["Remind me in 1 minute to say: actually make that 2 minutes.", 60_000],
+    ["Remind me in 1 minute: cancel that meeting with Bob.", 60_000],
+    ["Remind me in 1 minute: cancel the subscription.", 60_000],
+    ["Remind me in 1 minute: never mind the meeting title.", 60_000],
   ])("resolves %s", (text, milliseconds) => {
     expect(resolveExplicitSharedReminderDelay(text)).toEqual({
       kind: "resolved",
@@ -85,6 +88,10 @@ describe("explicit Shared reminder relative delay", () => {
     "Remind me in 1 minute, actually do not remind me.",
     "Remind me in 1 minute, never mind.",
     "Remind me in 1 minute, cancel that.",
+    "Remind me in 1 minute — cancel that.",
+    "Remind me in 1 minute — actually cancel that.",
+    "Remind me in 1 minute... cancel that.",
+    "Remind me in 1 minute… cancel that.",
   ])("fails closed for a negated reminder command: %s", (text) => {
     expect(resolveExplicitSharedReminderDelay(text)).toEqual({
       kind: "invalid",
@@ -219,6 +226,8 @@ describe("explicit Shared reminder relative delay", () => {
     ],
     ["a never-mind cancellation", "Remind me in 1 minute, never mind."],
     ["a cancel-that cancellation", "Remind me in 1 minute, cancel that."],
+    ["an em-dash cancellation", "Remind me in 1 minute — cancel that."],
+    ["an ellipsis cancellation", "Remind me in 1 minute… cancel that."],
   ])("rejects %s before persistence", async (_label, text) => {
     const scheduleWithResult = vi.fn(async (_input: ScheduledTaskInput) => {
       throw new Error("Ambiguous reminder must not be scheduled");

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
@@ -37,6 +37,7 @@ describe("explicit Shared reminder relative delay", () => {
     ["Remind me in 1 minute: cancel the subscription.", 60_000],
     ["Remind me in 1 minute: never mind the meeting title.", 60_000],
     ["Remind me in 1 minute: cancel that meeting, please.", 60_000],
+    ["Remind me in 1 minute: please cancel that meeting.", 60_000],
   ])("resolves %s", (text, milliseconds) => {
     expect(resolveExplicitSharedReminderDelay(text)).toEqual({
       kind: "resolved",
@@ -98,6 +99,10 @@ describe("explicit Shared reminder relative delay", () => {
     "Remind me in 1 minute; never mind please.",
     "Remind me in 1 minute. However, cancel that.",
     "Remind me in 1 minute, actually, cancel that.",
+    "Remind me in 1 minute, please cancel that.",
+    "Remind me in 1 minute. Please, cancel that.",
+    "Remind me in 1 minute; actually please cancel that.",
+    "Remind me in 1 minute — please never mind.",
   ])("fails closed for a negated reminder command: %s", (text) => {
     expect(resolveExplicitSharedReminderDelay(text)).toEqual({
       kind: "invalid",
@@ -238,6 +243,10 @@ describe("explicit Shared reminder relative delay", () => {
     [
       "a punctuated discourse cancellation",
       "Remind me in 1 minute. However, cancel that.",
+    ],
+    [
+      "a leading-polite cancellation",
+      "Remind me in 1 minute. Please, cancel that.",
     ],
   ])("rejects %s before persistence", async (_label, text) => {
     const scheduleWithResult = vi.fn(async (_input: ScheduledTaskInput) => {

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
@@ -30,6 +30,7 @@ describe("explicit Shared reminder relative delay", () => {
     ["Remind me to stretch in 1 minute and 30 seconds.", 90_000],
     ["Remind me in 1 minute 30 seconds to stretch.", 90_000],
     ["Remind me in 1 minute, actually make that 2 minutes.", 120_000],
+    ["Remind me in 1 minute to say: actually make that 2 minutes.", 60_000],
   ])("resolves %s", (text, milliseconds) => {
     expect(resolveExplicitSharedReminderDelay(text)).toEqual({
       kind: "resolved",
@@ -75,6 +76,11 @@ describe("explicit Shared reminder relative delay", () => {
     "I do not need a reminder in 1 minute.",
     "I never asked you to remind me in 1 minute.",
     "Do not, under any circumstances, remind me in 1 minute.",
+    "I don’t mind if you never remind me in 1 minute.",
+    "Don’t forget: never remind me in 1 minute.",
+    "I don’t mind reminders and never remind me in 1 minute.",
+    "Remind me in 1 minute, actually don’t remind me.",
+    "Remind me in 1 minute, actually do not remind me.",
   ])("fails closed for a negated reminder command: %s", (text) => {
     expect(resolveExplicitSharedReminderDelay(text)).toEqual({
       kind: "invalid",
@@ -203,6 +209,10 @@ describe("explicit Shared reminder relative delay", () => {
       "I don’t want you to remind me in 1 minute.",
     ],
     ["an ambiguous compound", "Remind me in 1 minute and in 2 hours."],
+    [
+      "a post-directive cancellation",
+      "Remind me in 1 minute, actually do not remind me.",
+    ],
   ])("rejects %s before persistence", async (_label, text) => {
     const scheduleWithResult = vi.fn(async (_input: ScheduledTaskInput) => {
       throw new Error("Ambiguous reminder must not be scheduled");

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
@@ -30,6 +30,8 @@ describe("explicit Shared reminder relative delay", () => {
     ["Remind me to stretch in 1 minute and 30 seconds.", 90_000],
     ["Remind me in 1 minute 30 seconds to stretch.", 90_000],
     ["Remind me in 1 minute, actually make that 2 minutes.", 120_000],
+    ["Remind me in 1 minute. Actually make that 2 minutes.", 120_000],
+    ["Remind me in 1 minute, but actually make that 2 minutes.", 120_000],
     ["Remind me in 1 minute to say: actually make that 2 minutes.", 60_000],
   ])("resolves %s", (text, milliseconds) => {
     expect(resolveExplicitSharedReminderDelay(text)).toEqual({
@@ -81,6 +83,8 @@ describe("explicit Shared reminder relative delay", () => {
     "I don’t mind reminders and never remind me in 1 minute.",
     "Remind me in 1 minute, actually don’t remind me.",
     "Remind me in 1 minute, actually do not remind me.",
+    "Remind me in 1 minute, never mind.",
+    "Remind me in 1 minute, cancel that.",
   ])("fails closed for a negated reminder command: %s", (text) => {
     expect(resolveExplicitSharedReminderDelay(text)).toEqual({
       kind: "invalid",
@@ -213,6 +217,8 @@ describe("explicit Shared reminder relative delay", () => {
       "a post-directive cancellation",
       "Remind me in 1 minute, actually do not remind me.",
     ],
+    ["a never-mind cancellation", "Remind me in 1 minute, never mind."],
+    ["a cancel-that cancellation", "Remind me in 1 minute, cancel that."],
   ])("rejects %s before persistence", async (_label, text) => {
     const scheduleWithResult = vi.fn(async (_input: ScheduledTaskInput) => {
       throw new Error("Ambiguous reminder must not be scheduled");

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
@@ -73,6 +73,8 @@ describe("explicit Shared reminder relative delay", () => {
     "Do not ever remind me in 1 minute.",
     "I don’t want a reminder in 1 minute.",
     "I do not need a reminder in 1 minute.",
+    "I never asked you to remind me in 1 minute.",
+    "Do not, under any circumstances, remind me in 1 minute.",
   ])("fails closed for a negated reminder command: %s", (text) => {
     expect(resolveExplicitSharedReminderDelay(text)).toEqual({
       kind: "invalid",
@@ -81,11 +83,16 @@ describe("explicit Shared reminder relative delay", () => {
   });
 
   it("does not confuse unrelated negative context with command negation", () => {
-    expect(
-      resolveExplicitSharedReminderDelay(
-        "I do not know why, but remind me in 1 minute.",
-      ),
-    ).toEqual({ kind: "resolved", milliseconds: 60_000 });
+    for (const text of [
+      "I do not know why, but remind me in 1 minute.",
+      "I don’t mind if you remind me in 1 minute.",
+      "Don’t forget to remind me in 1 minute.",
+    ]) {
+      expect(resolveExplicitSharedReminderDelay(text)).toEqual({
+        kind: "resolved",
+        milliseconds: 60_000,
+      });
+    }
   });
 
   it("rejects multiple relative reminder directives", () => {

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
@@ -38,6 +38,7 @@ describe("explicit Shared reminder relative delay", () => {
     ["Remind me in 1 minute: never mind the meeting title.", 60_000],
     ["Remind me in 1 minute: cancel that meeting, please.", 60_000],
     ["Remind me in 1 minute: please cancel that meeting.", 60_000],
+    ["Remind me in 1 minute: please actually cancel that meeting.", 60_000],
   ])("resolves %s", (text, milliseconds) => {
     expect(resolveExplicitSharedReminderDelay(text)).toEqual({
       kind: "resolved",
@@ -103,6 +104,9 @@ describe("explicit Shared reminder relative delay", () => {
     "Remind me in 1 minute. Please, cancel that.",
     "Remind me in 1 minute; actually please cancel that.",
     "Remind me in 1 minute — please never mind.",
+    "Remind me in 1 minute, please actually cancel that.",
+    "Remind me in 1 minute. Please, actually cancel that.",
+    "Remind me in 1 minute; please actually never mind.",
   ])("fails closed for a negated reminder command: %s", (text) => {
     expect(resolveExplicitSharedReminderDelay(text)).toEqual({
       kind: "invalid",
@@ -247,6 +251,10 @@ describe("explicit Shared reminder relative delay", () => {
     [
       "a leading-polite cancellation",
       "Remind me in 1 minute. Please, cancel that.",
+    ],
+    [
+      "a reordered-modifier cancellation",
+      "Remind me in 1 minute. Please, actually cancel that.",
     ],
   ])("rejects %s before persistence", async (_label, text) => {
     const scheduleWithResult = vi.fn(async (_input: ScheduledTaskInput) => {

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.test.ts
@@ -1,0 +1,207 @@
+/** Verifies user-authored relative delays and their action-level authority without a model stub. */
+
+import type { IAgentRuntime, Memory } from "@elizaos/core/edge";
+import { describe, expect, it, vi } from "vitest";
+import type {
+  ScheduledTask,
+  ScheduledTaskInput,
+  ScheduledTaskRunner,
+} from "./scheduled-task/types.js";
+import { resolveExplicitSharedReminderDelay } from "./shared-reminder-relative-delay.js";
+import { createSharedRemindersEdgePlugin } from "./shared-reminders.js";
+
+const NOW = "2026-08-16T04:48:56.509Z";
+
+describe("explicit Shared reminder relative delay", () => {
+  it.each([
+    ["Remind me in 1 minute: stretch.", 60_000],
+    ["Please remind me in 2 minutes to stretch.", 120_000],
+    ["Please remind me in two minutes to stretch.", 120_000],
+    ["Set a reminder in 90 seconds to check the oven.", 90_000],
+    ["Create me a reminder in 2 hours to call mom.", 7_200_000],
+    ["Add a reminder in 1.5 hours to leave.", 5_400_000],
+    ["In one minute, remind me to stand up.", 60_000],
+    ["In an hour remind me to leave.", 3_600_000],
+    ["Remind me to stretch in 1 minute.", 60_000],
+    ["Set a reminder to call mom in two hours.", 7_200_000],
+  ])("resolves %s", (text, milliseconds) => {
+    expect(resolveExplicitSharedReminderDelay(text)).toEqual({
+      kind: "resolved",
+      milliseconds,
+    });
+  });
+
+  it.each([
+    "Remind me in 0 minutes to stretch.",
+    "Remind me in -1 minute to stretch.",
+    "Remind me in 0.0001 seconds to stretch.",
+    "Remind me in banana minutes to stretch.",
+    "Remind me in 1e3 minutes to stretch.",
+    "Remind me in 999999999999999 hours to stretch.",
+  ])("fails closed for invalid delay %s", (text) => {
+    expect(resolveExplicitSharedReminderDelay(text)).toMatchObject({
+      kind: "invalid",
+    });
+  });
+
+  it.each([
+    'Use the example "remind me in 2 minutes" in the documentation.',
+    "For example: remind me in 2 minutes.",
+    "Remind me tomorrow to stretch for five minutes.",
+    "Remind me at 3pm to check in with the team for 30 minutes.",
+  ])(
+    "does not treat quoted, example, or body duration text as timing: %s",
+    (text) => {
+      expect(resolveExplicitSharedReminderDelay(text)).toEqual({
+        kind: "absent",
+      });
+    },
+  );
+
+  it.each([
+    "Do not remind me in 1 minute.",
+    "Don't remind me in 1 minute.",
+    "Never remind me in 1 minute.",
+  ])("fails closed for a negated reminder command: %s", (text) => {
+    expect(resolveExplicitSharedReminderDelay(text)).toEqual({
+      kind: "invalid",
+      reason: "A negated reminder command cannot create a reminder.",
+    });
+  });
+
+  it("rejects multiple relative reminder directives", () => {
+    expect(
+      resolveExplicitSharedReminderDelay(
+        "Remind me in 1 minute to stretch, then remind me in 2 hours to leave.",
+      ),
+    ).toEqual({
+      kind: "invalid",
+      reason: "Use exactly one relative delay for a reminder.",
+    });
+  });
+
+  it.each([
+    "Remind me in 1 minute and 30 seconds to stretch.",
+    "Remind me in 1 minute and in 2 hours to stretch.",
+    "Remind me in 1 minute or in 2 minutes to stretch.",
+  ])(
+    "rejects compound relative delays instead of truncating them: %s",
+    (text) => {
+      expect(resolveExplicitSharedReminderDelay(text)).toMatchObject({
+        kind: "invalid",
+      });
+    },
+  );
+
+  it("uses the authenticated utterance instead of a conflicting planner delay", async () => {
+    const scheduleWithResult = vi.fn(async (input: ScheduledTaskInput) => ({
+      task: {
+        taskId: "reminder-1",
+        ...input,
+        state: { status: "scheduled", followupCount: 0 },
+      } satisfies ScheduledTask,
+      commit: {
+        logId: "scheduled-log-1",
+        taskId: "reminder-1",
+        agentId: "personal:user-1",
+        occurredAtIso: NOW,
+        transition: "scheduled" as const,
+        rolledUp: false,
+      },
+      replayed: false,
+    }));
+    const runner: ScheduledTaskRunner = {
+      scheduleWithResult,
+      schedule: vi.fn(),
+      list: vi.fn(async () => []),
+      apply: vi.fn(),
+      pipeline: vi.fn(async () => []),
+    };
+    const [action] =
+      createSharedRemindersEdgePlugin({
+        runner,
+        agentId: "personal:user-1",
+        delivery: {
+          platform: "telegram",
+          project: "eliza-app",
+          chatId: "123456",
+        },
+        now: () => new Date(NOW),
+      }).actions ?? [];
+
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      {
+        id: "message-1",
+        content: { text: "Remind me in 1 minute: stretch." },
+      } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "create",
+          reminderText: "Stretch",
+          inMinutes: 2,
+        },
+      },
+    );
+
+    expect(result?.success).toBe(true);
+    expect(scheduleWithResult).toHaveBeenCalledOnce();
+    expect(scheduleWithResult.mock.calls[0]?.[0].trigger).toEqual({
+      kind: "once",
+      atIso: "2026-08-16T04:49:56.509Z",
+    });
+  });
+
+  it.each([
+    [
+      "an ambiguous utterance",
+      "Remind me in 1 minute, then remind me in 2 minutes.",
+    ],
+    ["a negated command", "Do not remind me in 1 minute."],
+  ])("rejects %s before persistence", async (_label, text) => {
+    const scheduleWithResult = vi.fn(async (_input: ScheduledTaskInput) => {
+      throw new Error("Ambiguous reminder must not be scheduled");
+    });
+    const runner: ScheduledTaskRunner = {
+      scheduleWithResult,
+      schedule: vi.fn(async () => {
+        throw new Error("Ambiguous reminder must not be scheduled");
+      }),
+      list: vi.fn(async () => []),
+      apply: vi.fn(async () => {
+        throw new Error("Ambiguous reminder must not be mutated");
+      }),
+      pipeline: vi.fn(async () => []),
+    };
+    const [action] =
+      createSharedRemindersEdgePlugin({
+        runner,
+        agentId: "personal:user-1",
+        delivery: {
+          platform: "discord",
+          discordUserId: "123456789012345678",
+        },
+        now: () => new Date(NOW),
+      }).actions ?? [];
+
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      {
+        id: "message-2",
+        content: { text },
+      } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "create",
+          reminderText: "Stretch",
+          inMinutes: 2,
+        },
+      },
+    );
+
+    expect(result).toMatchObject({ success: false });
+    expect(scheduleWithResult).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
@@ -134,7 +134,7 @@ const IMMEDIATE_REVISION_PATTERN = new RegExp(
 );
 
 const LATER_CANCELLATION_PATTERN = new RegExp(
-  String.raw`^\s*${COMMAND_SEPARATOR}?\s*(?:(?:but|however)\s*${COMMAND_SEPARATOR}?\s*)?(?:actually\s*${COMMAND_SEPARATOR}?\s*)?(?:please\s*${COMMAND_SEPARATOR}?\s*)?(?:(?:do\s+not|don['’]?t|dont|never)(?:\s+ever)?\s+(?:please\s+)?(?:remind\s+me|(?:set|create|add)(?:\s+me)?\s+(?:a\s+)?reminder)\b|(?:never\s+mind\b|cancel(?:\s+(?:that(?:\s+reminder)?|it|the\s+reminder))?\b)(?:\s*,?\s+please\b)?(?=\s*(?:[.!?…]+|$)))`,
+  String.raw`^\s*${COMMAND_SEPARATOR}?\s*(?:(?:but|however)\s*${COMMAND_SEPARATOR}?\s*)?(?:(?:actually\s*${COMMAND_SEPARATOR}?\s*please|please\s*${COMMAND_SEPARATOR}?\s*actually|actually|please)\s*${COMMAND_SEPARATOR}?\s*)?(?:(?:do\s+not|don['’]?t|dont|never)(?:\s+ever)?\s+(?:please\s+)?(?:remind\s+me|(?:set|create|add)(?:\s+me)?\s+(?:a\s+)?reminder)\b|(?:never\s+mind\b|cancel(?:\s+(?:that(?:\s+reminder)?|it|the\s+reminder))?\b)(?:\s*,?\s+please\b)?(?=\s*(?:[.!?…]+|$)))`,
   "i",
 );
 

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
@@ -128,12 +128,12 @@ const DURATION_CONTINUATION_PATTERN = new RegExp(
 const HALF_CONTINUATION_PATTERN = /^\s*(?:and|plus)\s+(?:a\s+)?half\b/i;
 
 const IMMEDIATE_REVISION_PATTERN = new RegExp(
-  String.raw`^\s*[,;:\-]?\s*(?:actually|instead)\s+(?:make|set|change)(?:\s+(?:it|that))?\s+(?:(?:for|to|in)\s+)?(${NUMBER_TOKEN})\s*${UNIT_TOKEN}\b`,
+  String.raw`^\s*[,.;:!?\-]?\s*(?:but\s+)?(?:actually|instead)\s+(?:make|set|change)(?:\s+(?:it|that))?\s+(?:(?:for|to|in)\s+)?(${NUMBER_TOKEN})\s*${UNIT_TOKEN}\b`,
   "i",
 );
 
 const LATER_CANCELLATION_PATTERN =
-  /\b(?:actually\s+)?(?:do\s+not|don['’]?t|dont|never)(?:\s+ever)?\s+(?:please\s+)?(?:remind\s+me|(?:set|create|add)(?:\s+me)?\s+(?:a\s+)?reminder)\b/i;
+  /^\s*(?:[,.;:!?-]\s*|(?:but|however)\s+)?(?:actually\s+)?(?:(?:do\s+not|don['’]?t|dont|never)(?:\s+ever)?\s+(?:please\s+)?(?:remind\s+me|(?:set|create|add)(?:\s+me)?\s+(?:a\s+)?reminder)\b|never\s+mind\b|cancel(?:\s+(?:that|it|the\s+reminder))?\b)/i;
 
 function extendDuration(text: string, candidate: DelayCandidate): void {
   let cursor = candidate.end;

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
@@ -18,7 +18,7 @@ const LEADING_DELAY_PATTERN = new RegExp(
 );
 
 const TRAILING_DELAY_PATTERN = new RegExp(
-  String.raw`\b(?:(?:please\s+)?remind\s+me\s+to|(?:set|create|add)(?:\s+me)?\s+(?:a\s+)?reminder\s+(?:to|for))\s+[^.!?\n]{1,200}?\s+in\s+(${NUMBER_TOKEN})\s*${UNIT_TOKEN}(?=\s*(?:[.!?]|$))`,
+  String.raw`\b(?:(?:please\s+)?remind\s+me\s+to|(?:set|create|add)(?:\s+me)?\s+(?:a\s+)?reminder\s+(?:to|for))\s+[^.!?\n]{1,200}?\s+in\s+(${NUMBER_TOKEN})\s*${UNIT_TOKEN}\b`,
   "gi",
 );
 
@@ -26,7 +26,11 @@ const DECIMAL_TOKEN = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/;
 const META_PREFIX =
   /(?:for\s+example|e\.g\.|example|say|write|quote|phrase|wording|text)\s*[:;,-]?\s*$/i;
 const NEGATED_COMMAND_PREFIX =
-  /\b(?:do\s+not|don['’]?t|dont|never)\s+(?:please\s+)?$/i;
+  /\b(?:please\s+)?(?:i\s+)?(?:do\s+not|don['’]?t|dont|never)(?:\s+(?:ever|please|want(?:\s+you)?\s+to))*\s*$/i;
+const NEGATED_REMINDER_DELAY_PATTERN = new RegExp(
+  String.raw`\b(?:do\s+not|don['’]?t|dont|never)\s+(?:(?:ever|please)\s+)*(?:(?:want|need)(?:\s+you\s+to|\s+(?:a|the))?\s+)?(?:remind\s+me|(?:set|create|add)(?:\s+me)?\s+(?:a\s+)?reminder|(?:a\s+)?reminder)\b[^.!?\n]{0,100}?\bin\s+${NUMBER_TOKEN}\s*${UNIT_TOKEN}\b`,
+  "i",
+);
 
 const UNIT_MILLISECONDS = {
   second: 1_000,
@@ -60,9 +64,12 @@ export type ExplicitSharedReminderDelay =
 interface DelayCandidate {
   index: number;
   end: number;
-  rawNumber: string;
-  unit: keyof typeof UNIT_MILLISECONDS;
+  terms: Array<{
+    rawNumber: string;
+    unit: keyof typeof UNIT_MILLISECONDS;
+  }>;
   negated: boolean;
+  invalidComposition: boolean;
 }
 
 function maskQuotedText(text: string): string {
@@ -78,8 +85,87 @@ function candidateIsExample(text: string, index: number): boolean {
 
 function candidateIsNegated(text: string, index: number): boolean {
   return NEGATED_COMMAND_PREFIX.test(
-    text.slice(Math.max(0, index - 40), index),
+    text.slice(Math.max(0, index - 100), index),
   );
+}
+
+const DURATION_CONTINUATION_PATTERN = new RegExp(
+  String.raw`^\s*(?:(and|or|plus|,)\s+)?(in\s+)?(${NUMBER_TOKEN})\s*${UNIT_TOKEN}\b`,
+  "i",
+);
+const HALF_CONTINUATION_PATTERN = /^\s*(?:and|plus)\s+(?:a\s+)?half\b/i;
+
+const REVISION_PATTERN = new RegExp(
+  String.raw`\b(?:actually|instead)\s+(?:make|set|change)(?:\s+(?:it|that))?\s+(?:(?:for|to|in)\s+)?(${NUMBER_TOKEN})\s*${UNIT_TOKEN}\b`,
+  "gi",
+);
+
+function extendDuration(text: string, candidate: DelayCandidate): void {
+  let cursor = candidate.end;
+  while (true) {
+    const half = text.slice(cursor).match(HALF_CONTINUATION_PATTERN);
+    if (half) {
+      const previous = candidate.terms.at(-1);
+      if (!previous) {
+        candidate.invalidComposition = true;
+        break;
+      }
+      candidate.terms.push({ rawNumber: "0.5", unit: previous.unit });
+      candidate.end = cursor + half[0].length;
+      cursor = candidate.end;
+      continue;
+    }
+    const continuation = text
+      .slice(cursor)
+      .match(DURATION_CONTINUATION_PATTERN);
+    const connector = continuation?.[1]?.toLowerCase();
+    const repeatedIn = continuation?.[2];
+    const rawNumber = continuation?.[3];
+    const rawUnit = continuation?.[4]?.toLowerCase();
+    if (
+      !continuation ||
+      !rawNumber ||
+      !(rawUnit && rawUnit in UNIT_MILLISECONDS)
+    ) {
+      break;
+    }
+    candidate.end = cursor + continuation[0].length;
+    if (connector === "or" || repeatedIn) {
+      candidate.invalidComposition = true;
+    } else {
+      candidate.terms.push({
+        rawNumber,
+        unit: rawUnit as keyof typeof UNIT_MILLISECONDS,
+      });
+    }
+    cursor = candidate.end;
+  }
+}
+
+function applyLastRevision(text: string, candidate: DelayCandidate): void {
+  const tail = text.slice(candidate.end, candidate.end + 240);
+  REVISION_PATTERN.lastIndex = 0;
+  let revision: RegExpExecArray | undefined;
+  for (const match of tail.matchAll(REVISION_PATTERN)) revision = match;
+  const rawNumber = revision?.[1];
+  const rawUnit = revision?.[2]?.toLowerCase();
+  if (
+    !revision ||
+    revision.index === undefined ||
+    !rawNumber ||
+    !(rawUnit && rawUnit in UNIT_MILLISECONDS)
+  ) {
+    return;
+  }
+  candidate.terms = [
+    {
+      rawNumber,
+      unit: rawUnit as keyof typeof UNIT_MILLISECONDS,
+    },
+  ];
+  candidate.invalidComposition = false;
+  candidate.end += revision.index + revision[0].length;
+  extendDuration(text, candidate);
 }
 
 function collectCandidates(text: string): DelayCandidate[] {
@@ -104,47 +190,45 @@ function collectCandidates(text: string): DelayCandidate[] {
       candidates.push({
         index: match.index,
         end: match.index + match[0].length,
-        rawNumber,
-        unit: rawUnit as keyof typeof UNIT_MILLISECONDS,
+        terms: [
+          {
+            rawNumber,
+            unit: rawUnit as keyof typeof UNIT_MILLISECONDS,
+          },
+        ],
         negated: candidateIsNegated(text, match.index),
+        invalidComposition: false,
       });
     }
   }
-  const compoundPattern = new RegExp(
-    String.raw`^\s*(?:and|or|,)\s+(?:in\s+)?(${NUMBER_TOKEN})\s*${UNIT_TOKEN}\b`,
-    "i",
-  );
-  for (const candidate of [...candidates]) {
-    const compound = text.slice(candidate.end).match(compoundPattern);
-    const rawNumber = compound?.[1];
-    const rawUnit = compound?.[2]?.toLowerCase();
-    if (compound && rawNumber && rawUnit && rawUnit in UNIT_MILLISECONDS) {
-      candidates.push({
-        index: candidate.end + (compound.index ?? 0),
-        end: candidate.end + (compound.index ?? 0) + compound[0].length,
-        rawNumber,
-        unit: rawUnit as keyof typeof UNIT_MILLISECONDS,
-        negated: candidate.negated,
-      });
-    }
-  }
-  return candidates.sort((left, right) => left.index - right.index);
+  const ordered = candidates.sort((left, right) => left.index - right.index);
+  for (const candidate of ordered) extendDuration(text, candidate);
+  if (ordered.length === 1) applyLastRevision(text, ordered[0]);
+  return ordered;
 }
 
 function parseCandidate(candidate: DelayCandidate): number | undefined {
-  const normalizedNumber = candidate.rawNumber.toLowerCase();
-  const amount =
-    NUMBER_WORDS[normalizedNumber] !== undefined
-      ? NUMBER_WORDS[normalizedNumber]
-      : DECIMAL_TOKEN.test(normalizedNumber)
-        ? Number(normalizedNumber)
-        : Number.NaN;
-  const milliseconds = amount * UNIT_MILLISECONDS[candidate.unit];
-  return Number.isFinite(amount) &&
-    amount > 0 &&
-    Number.isSafeInteger(milliseconds)
-    ? milliseconds
-    : undefined;
+  let total = 0;
+  for (const term of candidate.terms) {
+    const normalizedNumber = term.rawNumber.toLowerCase();
+    const amount =
+      NUMBER_WORDS[normalizedNumber] !== undefined
+        ? NUMBER_WORDS[normalizedNumber]
+        : DECIMAL_TOKEN.test(normalizedNumber)
+          ? Number(normalizedNumber)
+          : Number.NaN;
+    const milliseconds = amount * UNIT_MILLISECONDS[term.unit];
+    if (
+      !Number.isFinite(amount) ||
+      amount <= 0 ||
+      !Number.isSafeInteger(milliseconds) ||
+      !Number.isSafeInteger(total + milliseconds)
+    ) {
+      return undefined;
+    }
+    total += milliseconds;
+  }
+  return total > 0 ? total : undefined;
 }
 
 /**
@@ -155,7 +239,14 @@ export function resolveExplicitSharedReminderDelay(
   text: unknown,
 ): ExplicitSharedReminderDelay {
   if (typeof text !== "string" || !text.trim()) return { kind: "absent" };
-  const candidates = collectCandidates(maskQuotedText(text));
+  const commandText = maskQuotedText(text);
+  if (NEGATED_REMINDER_DELAY_PATTERN.test(commandText)) {
+    return {
+      kind: "invalid",
+      reason: "A negated reminder command cannot create a reminder.",
+    };
+  }
+  const candidates = collectCandidates(commandText);
   if (candidates.length === 0) return { kind: "absent" };
   if (candidates.length !== 1) {
     return {
@@ -167,6 +258,12 @@ export function resolveExplicitSharedReminderDelay(
     return {
       kind: "invalid",
       reason: "A negated reminder command cannot create a reminder.",
+    };
+  }
+  if (candidates[0].invalidComposition) {
+    return {
+      kind: "invalid",
+      reason: "Use one unambiguous relative delay for a reminder.",
     };
   }
 

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
@@ -134,7 +134,7 @@ const IMMEDIATE_REVISION_PATTERN = new RegExp(
 );
 
 const LATER_CANCELLATION_PATTERN = new RegExp(
-  String.raw`^\s*${COMMAND_SEPARATOR}?\s*(?:(?:but|however)\s*${COMMAND_SEPARATOR}?\s*)?(?:actually\s*${COMMAND_SEPARATOR}?\s*)?(?:(?:do\s+not|don['’]?t|dont|never)(?:\s+ever)?\s+(?:please\s+)?(?:remind\s+me|(?:set|create|add)(?:\s+me)?\s+(?:a\s+)?reminder)\b|(?:never\s+mind\b|cancel(?:\s+(?:that(?:\s+reminder)?|it|the\s+reminder))?\b)(?:\s*,?\s+please\b)?(?=\s*(?:[.!?…]+|$)))`,
+  String.raw`^\s*${COMMAND_SEPARATOR}?\s*(?:(?:but|however)\s*${COMMAND_SEPARATOR}?\s*)?(?:actually\s*${COMMAND_SEPARATOR}?\s*)?(?:please\s*${COMMAND_SEPARATOR}?\s*)?(?:(?:do\s+not|don['’]?t|dont|never)(?:\s+ever)?\s+(?:please\s+)?(?:remind\s+me|(?:set|create|add)(?:\s+me)?\s+(?:a\s+)?reminder)\b|(?:never\s+mind\b|cancel(?:\s+(?:that(?:\s+reminder)?|it|the\s+reminder))?\b)(?:\s*,?\s+please\b)?(?=\s*(?:[.!?…]+|$)))`,
   "i",
 );
 

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
@@ -25,9 +25,9 @@ const TRAILING_DELAY_PATTERN = new RegExp(
 const DECIMAL_TOKEN = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/;
 const META_PREFIX =
   /(?:for\s+example|e\.g\.|example|say|write|quote|phrase|wording|text)\s*[:;,-]?\s*$/i;
-const NEGATION_TOKEN = /\b(?:do\s+not|don['’]?t|dont|never)\b/i;
+const NEGATION_TOKEN_PATTERN = /\b(?:do\s+not|don['’]?t|dont|never)\b/gi;
 const POSITIVE_NEGATION_IDIOM =
-  /\b(?:do\s+not|don['’]?t|dont)\s+(?:mind|forget)\b/i;
+  /^(?:do\s+not|don['’]?t|dont)\s+(?:mind|forget)\b/i;
 const CLAUSE_RESET_PATTERN = /[.!?\n;]|\b(?:but|however|though|yet)\b/gi;
 const BARE_REMINDER_DELAY_PATTERN = new RegExp(
   String.raw`\breminder\b[^.!?\n]{0,100}?\bin\s+${NUMBER_TOKEN}\s*${UNIT_TOKEN}\b`,
@@ -96,7 +96,12 @@ function currentClausePrefix(text: string, index: number): string {
 }
 
 function prefixNegatesCommand(prefix: string): boolean {
-  return NEGATION_TOKEN.test(prefix) && !POSITIVE_NEGATION_IDIOM.test(prefix);
+  NEGATION_TOKEN_PATTERN.lastIndex = 0;
+  let negated = false;
+  for (const token of prefix.matchAll(NEGATION_TOKEN_PATTERN)) {
+    negated = !POSITIVE_NEGATION_IDIOM.test(prefix.slice(token.index ?? 0));
+  }
+  return negated;
 }
 
 function candidateIsNegated(text: string, index: number): boolean {
@@ -122,10 +127,13 @@ const DURATION_CONTINUATION_PATTERN = new RegExp(
 );
 const HALF_CONTINUATION_PATTERN = /^\s*(?:and|plus)\s+(?:a\s+)?half\b/i;
 
-const REVISION_PATTERN = new RegExp(
-  String.raw`\b(?:actually|instead)\s+(?:make|set|change)(?:\s+(?:it|that))?\s+(?:(?:for|to|in)\s+)?(${NUMBER_TOKEN})\s*${UNIT_TOKEN}\b`,
-  "gi",
+const IMMEDIATE_REVISION_PATTERN = new RegExp(
+  String.raw`^\s*[,;:\-]?\s*(?:actually|instead)\s+(?:make|set|change)(?:\s+(?:it|that))?\s+(?:(?:for|to|in)\s+)?(${NUMBER_TOKEN})\s*${UNIT_TOKEN}\b`,
+  "i",
 );
+
+const LATER_CANCELLATION_PATTERN =
+  /\b(?:actually\s+)?(?:do\s+not|don['’]?t|dont|never)(?:\s+ever)?\s+(?:please\s+)?(?:remind\s+me|(?:set|create|add)(?:\s+me)?\s+(?:a\s+)?reminder)\b/i;
 
 function extendDuration(text: string, candidate: DelayCandidate): void {
   let cursor = candidate.end;
@@ -169,30 +177,36 @@ function extendDuration(text: string, candidate: DelayCandidate): void {
   }
 }
 
-function applyLastRevision(text: string, candidate: DelayCandidate): void {
-  const tail = text.slice(candidate.end, candidate.end + 240);
-  REVISION_PATTERN.lastIndex = 0;
-  let revision: RegExpExecArray | undefined;
-  for (const match of tail.matchAll(REVISION_PATTERN)) revision = match;
-  const rawNumber = revision?.[1];
-  const rawUnit = revision?.[2]?.toLowerCase();
-  if (
-    !revision ||
-    revision.index === undefined ||
-    !rawNumber ||
-    !(rawUnit && rawUnit in UNIT_MILLISECONDS)
-  ) {
-    return;
+function applyImmediateRevisions(
+  text: string,
+  candidate: DelayCandidate,
+): void {
+  while (true) {
+    const revision = text
+      .slice(candidate.end)
+      .match(IMMEDIATE_REVISION_PATTERN);
+    const rawNumber = revision?.[1];
+    const rawUnit = revision?.[2]?.toLowerCase();
+    if (!revision || !rawNumber || !(rawUnit && rawUnit in UNIT_MILLISECONDS)) {
+      return;
+    }
+    candidate.terms = [
+      {
+        rawNumber,
+        unit: rawUnit as keyof typeof UNIT_MILLISECONDS,
+      },
+    ];
+    candidate.invalidComposition = false;
+    candidate.end += revision[0].length;
+    extendDuration(text, candidate);
   }
-  candidate.terms = [
-    {
-      rawNumber,
-      unit: rawUnit as keyof typeof UNIT_MILLISECONDS,
-    },
-  ];
-  candidate.invalidComposition = false;
-  candidate.end += revision.index + revision[0].length;
-  extendDuration(text, candidate);
+}
+
+function hasLaterCancellation(
+  text: string,
+  candidate: DelayCandidate,
+): boolean {
+  return LATER_CANCELLATION_PATTERN.test(text.slice(candidate.end));
 }
 
 function collectCandidates(text: string): DelayCandidate[] {
@@ -230,7 +244,7 @@ function collectCandidates(text: string): DelayCandidate[] {
   }
   const ordered = candidates.sort((left, right) => left.index - right.index);
   for (const candidate of ordered) extendDuration(text, candidate);
-  if (ordered.length === 1) applyLastRevision(text, ordered[0]);
+  if (ordered.length === 1) applyImmediateRevisions(text, ordered[0]);
   return ordered;
 }
 
@@ -281,7 +295,10 @@ export function resolveExplicitSharedReminderDelay(
       reason: "Use exactly one relative delay for a reminder.",
     };
   }
-  if (candidates[0].negated) {
+  if (
+    candidates[0].negated ||
+    hasLaterCancellation(commandText, candidates[0])
+  ) {
     return {
       kind: "invalid",
       reason: "A negated reminder command cannot create a reminder.",

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
@@ -1,0 +1,181 @@
+/**
+ * Recovers an explicit relative reminder delay from the current user command.
+ * Only command-position delays are authoritative so durations inside reminder
+ * bodies, quoted examples, and model-generated parameters cannot move a timer.
+ */
+
+const NUMBER_TOKEN = String.raw`(?:[+-]?(?:\d+(?:\.\d+)?|\.\d+)|an?|one|[^\s,;:!?]+)`;
+const UNIT_TOKEN = `(seconds?|minutes?|hours?)`;
+
+const COMMAND_DELAY_PATTERN = new RegExp(
+  String.raw`\b(?:(?:please\s+)?remind\s+me|(?:set|create|add)(?:\s+me)?\s+(?:a\s+)?reminder)\s+(?:for\s+)?in\s+(${NUMBER_TOKEN})\s*${UNIT_TOKEN}\b`,
+  "gi",
+);
+
+const LEADING_DELAY_PATTERN = new RegExp(
+  String.raw`(?:^|[.!?]\s+)(?:please\s+)?in\s+(${NUMBER_TOKEN})\s*${UNIT_TOKEN}\s*[,;:\-]?\s*(?:please\s+)?remind\s+me\b`,
+  "gi",
+);
+
+const TRAILING_DELAY_PATTERN = new RegExp(
+  String.raw`\b(?:(?:please\s+)?remind\s+me\s+to|(?:set|create|add)(?:\s+me)?\s+(?:a\s+)?reminder\s+(?:to|for))\s+[^.!?\n]{1,200}?\s+in\s+(${NUMBER_TOKEN})\s*${UNIT_TOKEN}(?=\s*(?:[.!?]|$))`,
+  "gi",
+);
+
+const DECIMAL_TOKEN = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/;
+const META_PREFIX =
+  /(?:for\s+example|e\.g\.|example|say|write|quote|phrase|wording|text)\s*[:;,-]?\s*$/i;
+const NEGATED_COMMAND_PREFIX =
+  /\b(?:do\s+not|don['’]?t|dont|never)\s+(?:please\s+)?$/i;
+
+const UNIT_MILLISECONDS = {
+  second: 1_000,
+  seconds: 1_000,
+  minute: 60_000,
+  minutes: 60_000,
+  hour: 3_600_000,
+  hours: 3_600_000,
+} as const;
+
+const NUMBER_WORDS: Readonly<Record<string, number>> = {
+  a: 1,
+  an: 1,
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+  ten: 10,
+};
+
+export type ExplicitSharedReminderDelay =
+  | { kind: "absent" }
+  | { kind: "resolved"; milliseconds: number }
+  | { kind: "invalid"; reason: string };
+
+interface DelayCandidate {
+  index: number;
+  end: number;
+  rawNumber: string;
+  unit: keyof typeof UNIT_MILLISECONDS;
+  negated: boolean;
+}
+
+function maskQuotedText(text: string): string {
+  return text.replace(
+    /"[^"\n]*"|'[^'\n]*'|`[^`\n]*`|“[^”\n]*”|‘[^’\n]*’/g,
+    (match) => " ".repeat(match.length),
+  );
+}
+
+function candidateIsExample(text: string, index: number): boolean {
+  return META_PREFIX.test(text.slice(Math.max(0, index - 80), index));
+}
+
+function candidateIsNegated(text: string, index: number): boolean {
+  return NEGATED_COMMAND_PREFIX.test(
+    text.slice(Math.max(0, index - 40), index),
+  );
+}
+
+function collectCandidates(text: string): DelayCandidate[] {
+  const candidates: DelayCandidate[] = [];
+  for (const pattern of [
+    COMMAND_DELAY_PATTERN,
+    LEADING_DELAY_PATTERN,
+    TRAILING_DELAY_PATTERN,
+  ]) {
+    pattern.lastIndex = 0;
+    for (const match of text.matchAll(pattern)) {
+      const rawNumber = match[1];
+      const rawUnit = match[2]?.toLowerCase();
+      if (
+        match.index === undefined ||
+        rawNumber === undefined ||
+        !(rawUnit && rawUnit in UNIT_MILLISECONDS) ||
+        candidateIsExample(text, match.index)
+      ) {
+        continue;
+      }
+      candidates.push({
+        index: match.index,
+        end: match.index + match[0].length,
+        rawNumber,
+        unit: rawUnit as keyof typeof UNIT_MILLISECONDS,
+        negated: candidateIsNegated(text, match.index),
+      });
+    }
+  }
+  const compoundPattern = new RegExp(
+    String.raw`^\s*(?:and|or|,)\s+(?:in\s+)?(${NUMBER_TOKEN})\s*${UNIT_TOKEN}\b`,
+    "i",
+  );
+  for (const candidate of [...candidates]) {
+    const compound = text.slice(candidate.end).match(compoundPattern);
+    const rawNumber = compound?.[1];
+    const rawUnit = compound?.[2]?.toLowerCase();
+    if (compound && rawNumber && rawUnit && rawUnit in UNIT_MILLISECONDS) {
+      candidates.push({
+        index: candidate.end + (compound.index ?? 0),
+        end: candidate.end + (compound.index ?? 0) + compound[0].length,
+        rawNumber,
+        unit: rawUnit as keyof typeof UNIT_MILLISECONDS,
+        negated: candidate.negated,
+      });
+    }
+  }
+  return candidates.sort((left, right) => left.index - right.index);
+}
+
+function parseCandidate(candidate: DelayCandidate): number | undefined {
+  const normalizedNumber = candidate.rawNumber.toLowerCase();
+  const amount =
+    NUMBER_WORDS[normalizedNumber] !== undefined
+      ? NUMBER_WORDS[normalizedNumber]
+      : DECIMAL_TOKEN.test(normalizedNumber)
+        ? Number(normalizedNumber)
+        : Number.NaN;
+  const milliseconds = amount * UNIT_MILLISECONDS[candidate.unit];
+  return Number.isFinite(amount) &&
+    amount > 0 &&
+    Number.isSafeInteger(milliseconds)
+    ? milliseconds
+    : undefined;
+}
+
+/**
+ * Returns one exact command-position delay, or an explicit invalid result when
+ * the user supplied multiple or non-positive supported delay expressions.
+ */
+export function resolveExplicitSharedReminderDelay(
+  text: unknown,
+): ExplicitSharedReminderDelay {
+  if (typeof text !== "string" || !text.trim()) return { kind: "absent" };
+  const candidates = collectCandidates(maskQuotedText(text));
+  if (candidates.length === 0) return { kind: "absent" };
+  if (candidates.length !== 1) {
+    return {
+      kind: "invalid",
+      reason: "Use exactly one relative delay for a reminder.",
+    };
+  }
+  if (candidates[0].negated) {
+    return {
+      kind: "invalid",
+      reason: "A negated reminder command cannot create a reminder.",
+    };
+  }
+
+  const milliseconds = parseCandidate(candidates[0]);
+  return milliseconds === undefined
+    ? {
+        kind: "invalid",
+        reason:
+          "The relative reminder delay must be a positive supported duration.",
+      }
+    : { kind: "resolved", milliseconds };
+}

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
@@ -25,11 +25,13 @@ const TRAILING_DELAY_PATTERN = new RegExp(
 const DECIMAL_TOKEN = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/;
 const META_PREFIX =
   /(?:for\s+example|e\.g\.|example|say|write|quote|phrase|wording|text)\s*[:;,-]?\s*$/i;
-const NEGATED_COMMAND_PREFIX =
-  /\b(?:please\s+)?(?:i\s+)?(?:do\s+not|don['’]?t|dont|never)(?:\s+(?:ever|please|want(?:\s+you)?\s+to))*\s*$/i;
-const NEGATED_REMINDER_DELAY_PATTERN = new RegExp(
-  String.raw`\b(?:do\s+not|don['’]?t|dont|never)\s+(?:(?:ever|please)\s+)*(?:(?:want|need)(?:\s+you\s+to|\s+(?:a|the))?\s+)?(?:remind\s+me|(?:set|create|add)(?:\s+me)?\s+(?:a\s+)?reminder|(?:a\s+)?reminder)\b[^.!?\n]{0,100}?\bin\s+${NUMBER_TOKEN}\s*${UNIT_TOKEN}\b`,
-  "i",
+const NEGATION_TOKEN = /\b(?:do\s+not|don['’]?t|dont|never)\b/i;
+const POSITIVE_NEGATION_IDIOM =
+  /\b(?:do\s+not|don['’]?t|dont)\s+(?:mind|forget)\b/i;
+const CLAUSE_RESET_PATTERN = /[.!?\n;]|\b(?:but|however|though|yet)\b/gi;
+const BARE_REMINDER_DELAY_PATTERN = new RegExp(
+  String.raw`\breminder\b[^.!?\n]{0,100}?\bin\s+${NUMBER_TOKEN}\s*${UNIT_TOKEN}\b`,
+  "gi",
 );
 
 const UNIT_MILLISECONDS = {
@@ -83,10 +85,35 @@ function candidateIsExample(text: string, index: number): boolean {
   return META_PREFIX.test(text.slice(Math.max(0, index - 80), index));
 }
 
+function currentClausePrefix(text: string, index: number): string {
+  const prefix = text.slice(Math.max(0, index - 160), index);
+  CLAUSE_RESET_PATTERN.lastIndex = 0;
+  let start = 0;
+  for (const boundary of prefix.matchAll(CLAUSE_RESET_PATTERN)) {
+    start = (boundary.index ?? 0) + boundary[0].length;
+  }
+  return prefix.slice(start);
+}
+
+function prefixNegatesCommand(prefix: string): boolean {
+  return NEGATION_TOKEN.test(prefix) && !POSITIVE_NEGATION_IDIOM.test(prefix);
+}
+
 function candidateIsNegated(text: string, index: number): boolean {
-  return NEGATED_COMMAND_PREFIX.test(
-    text.slice(Math.max(0, index - 100), index),
-  );
+  return prefixNegatesCommand(currentClausePrefix(text, index));
+}
+
+function hasNegatedBareReminderDelay(text: string): boolean {
+  BARE_REMINDER_DELAY_PATTERN.lastIndex = 0;
+  for (const match of text.matchAll(BARE_REMINDER_DELAY_PATTERN)) {
+    if (
+      match.index !== undefined &&
+      prefixNegatesCommand(currentClausePrefix(text, match.index))
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 const DURATION_CONTINUATION_PATTERN = new RegExp(
@@ -240,7 +267,7 @@ export function resolveExplicitSharedReminderDelay(
 ): ExplicitSharedReminderDelay {
   if (typeof text !== "string" || !text.trim()) return { kind: "absent" };
   const commandText = maskQuotedText(text);
-  if (NEGATED_REMINDER_DELAY_PATTERN.test(commandText)) {
+  if (hasNegatedBareReminderDelay(commandText)) {
     return {
       kind: "invalid",
       reason: "A negated reminder command cannot create a reminder.",

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
@@ -126,14 +126,17 @@ const DURATION_CONTINUATION_PATTERN = new RegExp(
   "i",
 );
 const HALF_CONTINUATION_PATTERN = /^\s*(?:and|plus)\s+(?:a\s+)?half\b/i;
+const COMMAND_SEPARATOR = "(?:[,.;:!?—–-]+|…)";
 
 const IMMEDIATE_REVISION_PATTERN = new RegExp(
-  String.raw`^\s*(?:[,.;:!?—–\-]+|…)?\s*(?:but\s+)?(?:actually|instead)\s+(?:make|set|change)(?:\s+(?:it|that))?\s+(?:(?:for|to|in)\s+)?(${NUMBER_TOKEN})\s*${UNIT_TOKEN}\b`,
+  String.raw`^\s*${COMMAND_SEPARATOR}?\s*(?:(?:but|however)\s*${COMMAND_SEPARATOR}?\s*)?(?:actually|instead)\s*${COMMAND_SEPARATOR}?\s*(?:make|set|change)(?:\s+(?:it|that))?\s+(?:(?:for|to|in)\s+)?(${NUMBER_TOKEN})\s*${UNIT_TOKEN}\b`,
   "i",
 );
 
-const LATER_CANCELLATION_PATTERN =
-  /^\s*(?:(?:[,.;:!?—–-]+|…)\s*|(?:but|however)\s+)?(?:actually\s+)?(?:(?:do\s+not|don['’]?t|dont|never)(?:\s+ever)?\s+(?:please\s+)?(?:remind\s+me|(?:set|create|add)(?:\s+me)?\s+(?:a\s+)?reminder)\b|(?:never\s+mind|cancel(?:\s+(?:that(?:\s+reminder)?|it|the\s+reminder))?)(?=\s*(?:[.!?…]+|$)))/i;
+const LATER_CANCELLATION_PATTERN = new RegExp(
+  String.raw`^\s*${COMMAND_SEPARATOR}?\s*(?:(?:but|however)\s*${COMMAND_SEPARATOR}?\s*)?(?:actually\s*${COMMAND_SEPARATOR}?\s*)?(?:(?:do\s+not|don['’]?t|dont|never)(?:\s+ever)?\s+(?:please\s+)?(?:remind\s+me|(?:set|create|add)(?:\s+me)?\s+(?:a\s+)?reminder)\b|(?:never\s+mind\b|cancel(?:\s+(?:that(?:\s+reminder)?|it|the\s+reminder))?\b)(?:\s*,?\s+please\b)?(?=\s*(?:[.!?…]+|$)))`,
+  "i",
+);
 
 function extendDuration(text: string, candidate: DelayCandidate): void {
   let cursor = candidate.end;

--- a/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
+++ b/plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts
@@ -128,12 +128,12 @@ const DURATION_CONTINUATION_PATTERN = new RegExp(
 const HALF_CONTINUATION_PATTERN = /^\s*(?:and|plus)\s+(?:a\s+)?half\b/i;
 
 const IMMEDIATE_REVISION_PATTERN = new RegExp(
-  String.raw`^\s*[,.;:!?\-]?\s*(?:but\s+)?(?:actually|instead)\s+(?:make|set|change)(?:\s+(?:it|that))?\s+(?:(?:for|to|in)\s+)?(${NUMBER_TOKEN})\s*${UNIT_TOKEN}\b`,
+  String.raw`^\s*(?:[,.;:!?—–\-]+|…)?\s*(?:but\s+)?(?:actually|instead)\s+(?:make|set|change)(?:\s+(?:it|that))?\s+(?:(?:for|to|in)\s+)?(${NUMBER_TOKEN})\s*${UNIT_TOKEN}\b`,
   "i",
 );
 
 const LATER_CANCELLATION_PATTERN =
-  /^\s*(?:[,.;:!?-]\s*|(?:but|however)\s+)?(?:actually\s+)?(?:(?:do\s+not|don['’]?t|dont|never)(?:\s+ever)?\s+(?:please\s+)?(?:remind\s+me|(?:set|create|add)(?:\s+me)?\s+(?:a\s+)?reminder)\b|never\s+mind\b|cancel(?:\s+(?:that|it|the\s+reminder))?\b)/i;
+  /^\s*(?:(?:[,.;:!?—–-]+|…)\s*|(?:but|however)\s+)?(?:actually\s+)?(?:(?:do\s+not|don['’]?t|dont|never)(?:\s+ever)?\s+(?:please\s+)?(?:remind\s+me|(?:set|create|add)(?:\s+me)?\s+(?:a\s+)?reminder)\b|(?:never\s+mind|cancel(?:\s+(?:that(?:\s+reminder)?|it|the\s+reminder))?)(?=\s*(?:[.!?…]+|$)))/i;
 
 function extendDuration(text: string, candidate: DelayCandidate): void {
   let cursor = candidate.end;

--- a/plugins/plugin-scheduling/src/shared-reminders.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.ts
@@ -17,10 +17,12 @@ import type {
   ScheduledTaskRunner,
   ScheduledTaskTrigger,
 } from "./scheduled-task/types.js";
+import { resolveExplicitSharedReminderDelay } from "./shared-reminder-relative-delay.js";
 
 /** Dedicated runtimes route imported Shared reminders through Cloud's trusted gateway. */
 export const SHARED_CUTOVER_GATEWAY_CHANNEL = "shared_gateway_dm";
 export const SHARED_REMINDER_MAX_TEXT_LENGTH = 2000;
+const MAX_DATE_TIMESTAMP_MS = 8_640_000_000_000_000;
 
 export const SHARED_REMINDERS_EDGE_COMPATIBILITY = {
   target: "edge",
@@ -145,12 +147,24 @@ async function actionFailure(
 function reminderTrigger(
   input: Record<string, unknown>,
   now: Date,
+  explicitDelayMilliseconds?: number,
 ): ScheduledTaskTrigger | undefined {
+  if (explicitDelayMilliseconds !== undefined) {
+    const at = now.getTime() + explicitDelayMilliseconds;
+    if (Number.isFinite(at) && Math.abs(at) <= MAX_DATE_TIMESTAMP_MS) {
+      return { kind: "once", atIso: new Date(at).toISOString() };
+    }
+    return undefined;
+  }
   const inMinutes = positiveNumber(input, "inMinutes", "minutesFromNow");
   if (inMinutes !== undefined) {
+    const at = now.getTime() + inMinutes * 60_000;
+    if (!Number.isFinite(at) || Math.abs(at) > MAX_DATE_TIMESTAMP_MS) {
+      return undefined;
+    }
     return {
       kind: "once",
-      atIso: new Date(now.getTime() + inMinutes * 60_000).toISOString(),
+      atIso: new Date(at).toISOString(),
     };
   }
   const atIso = textParameter(input, "atIso", "at");
@@ -344,7 +358,19 @@ export function createSharedRemindersEdgeAction(
             callback,
           );
         }
-        const trigger = reminderTrigger(input, now());
+        const explicitDelay = resolveExplicitSharedReminderDelay(
+          message.content?.text,
+        );
+        if (explicitDelay.kind === "invalid") {
+          return await actionFailure(explicitDelay.reason, callback);
+        }
+        const trigger = reminderTrigger(
+          input,
+          now(),
+          explicitDelay.kind === "resolved"
+            ? explicitDelay.milliseconds
+            : undefined,
+        );
         if (!trigger) {
           return await actionFailure(
             "A reminder time is required: inMinutes, atIso, everyMinutes, or cronExpression with timezone.",


### PR DESCRIPTION
Closes #20404.

# Relates to

- [x] Targets `develop` and is mechanically rebased onto `origin/develop@1cc2ee4588af55795fb8f866f27de1d7d549b3ba` with zero conflicts.
- [x] Exact-head package, runtime, type, build, formatting, and diff gates pass.
- [x] Exact-head live Cerebras + genuine Shared AgentRuntime + real PGlite proof is complete and manually inspected.
- [x] Independent terminal review found no P0-P3: [receipt](https://github.com/elizaOS/eliza/pull/20419#issuecomment-5306735988).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`, live evidence `cerebras/gemma-4-31b`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - local installed contribute-to-eliza skill`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact candidate `ed6691971164ef0dff8bedea1d67eab6865afba6`, tree `77b85d4e74f0b2ff8209b4341df89f764c18b629`, base `1cc2ee4588af55795fb8f866f27de1d7d549b3ba`.
- [x] Independent `range-diff` proves all nine patches are byte-equivalent to the reviewed series.
- [x] Remote branch and PR both resolve to the exact candidate head.

# Risks

Medium. This changes timing authority for one-off Shared reminders. The parser must not mistake body text for timing, persist a negated/cancelled request, truncate a compound duration, cross into reminder content while reading revisions, or let planner parameters override an explicit authenticated user delay. The implementation therefore uses bounded command structures, ordered negation/cancellation parsing, exact duration composition, and fails closed before persistence on ambiguity.

# Background

## What does this PR do?

- Reconciles a supported explicit relative delay from the authenticated current user message before constructing the Shared reminder trigger.
- Makes literal `in 1 minute` persist exactly `action-now + 60,000ms` even if the planner emits `inMinutes: 2`.
- Supports compound and compact seconds/minutes/hours, `and a half`, and bounded later revisions.
- Rejects negation, later cancellation, cancellation synonyms, malformed/overflow values, multiple directives, and alternatives before any scheduler write.
- Keeps reminder body phrases such as `cancel that meeting` valid while treating terminal `cancel that` as a no-write cancellation.
- Accepts bounded `actually` / `please` modifiers in either order without crossing into the reminder body.
- Leaves the canonical ScheduledTask runner, delivery contract, and idempotency key unchanged.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No. The public reminder parameters and canonical scheduling architecture are unchanged.

# Testing

## Where should a reviewer start?

1. `plugins/plugin-scheduling/src/shared-reminder-relative-delay.ts`
2. `plugins/plugin-scheduling/src/shared-reminders.ts`
3. `packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts`

## Exact-head gates

- focused parser/action: **89/89 pass**
- full plugin-scheduling: **29 files / 468 tests pass**
- genuine Shared AgentRuntime: **6/6 pass, 21 assertions**
- plugin-scheduling typecheck + JS/views/types build: **pass**
- cloud/shared typecheck: **pass**
- exact four-file Biome + `git diff --check`: **pass**
- independent network-disabled adversarial matrix: **pass**
- independent exact-head review: **APPROVE, no P0-P3**

# Evidence Gate

<!-- evidence-head:ed6691971164ef0dff8bedea1d67eab6865afba6 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI surface changed.
<!-- evidence-row:backend-logs -->
- [x] [Exact-head live backend logs](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20419-ed669197-backend-logs.jsonl) — genuine Shared AgentRuntime and canonical SQL scheduler over file-backed PGlite.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] [Exact-head live Cerebras trajectory](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20419-ed669197-trajectory.json) — three real `gemma-4-31b` exchanges; REMINDERS deliberately emitted `inMinutes: 2`.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact-head SQL domain artifact](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20419-ed669197-domain-artifacts.json) — exactly one ScheduledTask row, one creation log, and one durable applied receipt; stored due is inside the measured literal +60s bracket.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

## Genuine live-model/runtime/database proof

On exact clean `ed669197`, the user said `Remind me in 1 minute: verify literal delay ed669197.` The live model deliberately emitted `inMinutes: 2`. The canonical task persisted at `2026-08-16T09:24:23.120Z`, inside the exact action bracket `09:24:23.113Z..09:24:23.148Z` plus 60 seconds. The database contained exactly one task and one creation log with a durable applied effect receipt.

- [receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20419-ed669197-receipt.json)
- [manual inspection + hashes](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20419-ed669197-inspection-manifest.json)
- [reproducible proof driver](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20419-ed669197-live-proof.ts)

All trajectory inputs/contexts/raw outputs/tool calls, backend events, SQL rows, and effect receipts were manually inspected. Exact credential, generic secret-pattern, and sensitive-field scans passed; request headers were never captured.

## Protected rollout boundary

Source acceptance is complete. Authenticated Telegram and Eliza Dev Discord create -> acknowledgement -> stored due -> delivery -> no-duplicate proof will run only after legitimate maintainer disposition and an explicit protected staging release of this exact source. Production remains untouched and human-gated.

— [codex-root/shared-runtime]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A"} -->
