### PR TITLE
ci(app-live-e2e): add fail-closed staging Cloud login+provision+chat lane

### DIFF
--- a/.github/workflows/app-live-e2e.yml
+++ b/.github/workflows/app-live-e2e.yml
@@ -26,6 +26,10 @@ on:
         description: "Also run the on-device Android local-chat smoke (boots an emulator + builds/installs the APK + stages a GGUF)."
         type: boolean
         default: false
+      run_cloud_staging:
+        description: "Also run the staging Cloud login+provision+chat lane (requires the staging Environment's ELIZAOS_CLOUD_API_KEY)."
+        type: boolean
+        default: false
 
 concurrency:
   group: app-live-e2e-${{ github.ref }}
@@ -224,11 +228,15 @@ jobs:
   # repository secret is configured; the spec remains safely skippable outside
   # this workflow so keyless PR lanes cannot spend Cloud credits.
   cloud-live:
-    name: cloud login + provision + chat (real Eliza Cloud)
+    name: cloud login + provision + chat (real Eliza Cloud, production)
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 45
     env:
       ELIZA_UI_SMOKE_CLOUD_LIVE: "1"
+      # The spec asserts the resolved API origin matches this environment
+      # before spending any Cloud credit (#18076), so a misconfigured base URL
+      # cannot silently retarget the production lane.
+      ELIZA_UI_SMOKE_CLOUD_EXPECTED_ENV: production
       # Prefer the variable named for the runtime contract, but retain the
       # repository's established ELIZACLOUD_API_KEY as the canonical fallback.
       ELIZAOS_CLOUD_API_KEY: ${{ secrets.ELIZAOS_CLOUD_API_KEY || secrets.ELIZACLOUD_API_KEY }}
@@ -292,6 +300,112 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: app-live-e2e-cloud
+          path: |
+            packages/app/playwright-report/
+            packages/app/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # STAGING counterpart of cloud-live (#18076): the same real login +
+  # provisioning + chat path, pinned to the staging control plane. Kept a
+  # separate job so staging and production report as distinct results and
+  # artifacts. It is fail-closed by construction:
+  #   - the job-level ELIZAOS_CLOUD_BASE_URL pins the staging API origin and
+  #     the spec's origin contract (ELIZA_UI_SMOKE_CLOUD_EXPECTED_ENV=staging)
+  #     hard-fails on any resolution that is not that origin — it can never
+  #     fall back to production;
+  #   - the credential comes ONLY from the protected `staging` Environment's
+  #     ELIZAOS_CLOUD_API_KEY (a production key does not authenticate against
+  #     staging, and no repository-secret fallback is allowed here);
+  #   - a missing credential fails the job loudly before any setup/build work.
+  # Scheduled runs stay opt-in via ELIZA_CLOUD_STAGING_LIVE_READY until an
+  # owner has minted the staging-scoped key, so an unprovisioned nightly is a
+  # visible skip, not a misleading red or a green-by-skip.
+  # NOTE: this lane drives the renderer bundle built from the checked-out
+  # revision against the staging API; it does not exercise the deployed
+  # staging Pages artifact (recorded in the spec annotations + step summary).
+  cloud-live-staging:
+    name: cloud login + provision + chat (real Eliza Cloud, staging)
+    if: ${{ (github.event_name == 'schedule' && vars.ELIZA_CLOUD_STAGING_LIVE_READY == '1') || (github.event_name == 'workflow_dispatch' && inputs.run_cloud_staging) }}
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    environment: staging
+    timeout-minutes: 45
+    env:
+      ELIZA_UI_SMOKE_CLOUD_LIVE: "1"
+      ELIZA_UI_SMOKE_CLOUD_EXPECTED_ENV: staging
+      ELIZAOS_CLOUD_BASE_URL: https://api-staging.eliza.app
+      ELIZAOS_CLOUD_API_KEY: ${{ secrets.ELIZAOS_CLOUD_API_KEY }}
+      PGLITE_WASM_MODE: node
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          submodules: false
+
+      - name: Require staging-scoped Cloud credential and origin
+        shell: bash
+        run: |
+          set -euo pipefail
+          staging_key_without_whitespace="${ELIZAOS_CLOUD_API_KEY:-}"
+          staging_key_without_whitespace="${staging_key_without_whitespace//[[:space:]]/}"
+          if [[ -z "$staging_key_without_whitespace" ]]; then
+            echo "::error::The staging Cloud lane requires the staging Environment's ELIZAOS_CLOUD_API_KEY; refusing to run (and never falling back to the production key)."
+            exit 1
+          fi
+          unset staging_key_without_whitespace
+          if [[ "${ELIZAOS_CLOUD_BASE_URL:-}" != "https://api-staging.eliza.app" ]]; then
+            echo "::error::The staging Cloud lane must pin ELIZAOS_CLOUD_BASE_URL=https://api-staging.eliza.app; got '${ELIZAOS_CLOUD_BASE_URL:-}'."
+            exit 1
+          fi
+
+      - name: Free disk space for browser smoke
+        run: |
+          set -euxo pipefail
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android || true
+          docker system prune -af || true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --frozen-lockfile
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Install Playwright Chromium
+        run: .github/scripts/install-playwright-browsers.sh chromium
+
+      - name: Generate shared i18n assets
+        run: bun run --cwd packages/shared build:i18n
+
+      - name: Build @elizaos/core + @elizaos/shared browser bundles
+        run: bunx turbo run build --filter=@elizaos/core --filter=@elizaos/shared
+
+      - name: Build app renderer bundle
+        run: bun run --cwd packages/app build:web
+
+      - name: Run real STAGING cloud login + provision + chat
+        run: bun run --cwd packages/app test:e2e test/ui-smoke/cloud-live.spec.ts --project=chromium
+
+      - name: Record what this lane drove
+        if: ${{ always() }}
+        run: |
+          {
+            echo "## Staging Cloud live lane"
+            echo "- API origin: https://api-staging.eliza.app (asserted in-spec before auth/provision/chat)"
+            echo "- Renderer: locally built bundle from \`${GITHUB_SHA}\` driven through the live stack — NOT the deployed staging Pages artifact"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload cloud-live staging artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: app-live-e2e-cloud-staging
           path: |
             packages/app/playwright-report/
             packages/app/test-results/
@@ -433,7 +547,14 @@ jobs:
   # manual workflow_dispatch runs stay quiet to avoid noise.
   notify-on-failure:
     name: notify on red nightly
-    needs: [app-live-chat, walkthrough-live, cloud-live, desktop-packaged]
+    needs:
+      [
+        app-live-chat,
+        walkthrough-live,
+        cloud-live,
+        cloud-live-staging,
+        desktop-packaged,
+      ]
     if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE != 'true' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     permissions:
@@ -446,6 +567,7 @@ jobs:
           R_CHAT: ${{ needs.app-live-chat.result }}
           R_WALK: ${{ needs.walkthrough-live.result }}
           R_CLOUD: ${{ needs.cloud-live.result }}
+          R_CLOUD_STAGING: ${{ needs.cloud-live-staging.result }}
           R_DESKTOP: ${{ needs.desktop-packaged.result }}
         with:
           github-token: ${{ github.token }}
@@ -457,7 +579,8 @@ jobs:
               "",
               `- app live chat: \`${process.env.R_CHAT}\``,
               `- full walkthrough: \`${process.env.R_WALK}\``,
-              `- cloud login+provision+chat: \`${process.env.R_CLOUD}\``,
+              `- cloud login+provision+chat (production): \`${process.env.R_CLOUD}\``,
+              `- cloud login+provision+chat (staging): \`${process.env.R_CLOUD_STAGING}\``,
               `- desktop packaged (build+boot+renderer): \`${process.env.R_DESKTOP}\``,
               "",
               `Run log + failure artifacts: ${process.env.RUN_URL}`,

--- a/packages/app/test/cloud-live-origin.test.ts
+++ b/packages/app/test/cloud-live-origin.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Deterministic unit coverage for the Cloud-live API-origin contract (#18076).
+ * Real resolver from @elizaos/shared; process.env override saved/restored so
+ * the internal ELIZAOS_CLOUD_BASE_URL read stays consistent with injected env.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveCloudLiveOriginContract } from "./cloud-live-origin";
+
+const STAGING_API = "https://api-staging.eliza.app";
+const PRODUCTION_API = "https://api.eliza.app";
+
+const SAVED = {
+  base: process.env.ELIZAOS_CLOUD_BASE_URL,
+  dev: process.env.ELIZA_DEV_SOURCE,
+};
+
+function setBaseUrl(value: string | undefined): void {
+  if (value === undefined) delete process.env.ELIZAOS_CLOUD_BASE_URL;
+  else process.env.ELIZAOS_CLOUD_BASE_URL = value;
+}
+
+describe("resolveCloudLiveOriginContract (#18076)", () => {
+  beforeEach(() => {
+    setBaseUrl(undefined);
+    // The dev flag flips the unconfigured default to staging; these contracts
+    // assert the CI shape, where it is unset.
+    delete process.env.ELIZA_DEV_SOURCE;
+  });
+
+  afterEach(() => {
+    setBaseUrl(SAVED.base);
+    if (SAVED.dev === undefined) delete process.env.ELIZA_DEV_SOURCE;
+    else process.env.ELIZA_DEV_SOURCE = SAVED.dev;
+  });
+
+  it("resolves the production origin by default and passes when unpinned", () => {
+    const contract = resolveCloudLiveOriginContract({});
+    expect(contract.origin).toBe(PRODUCTION_API);
+    expect(contract.environment).toBe("production");
+    expect(contract.expected).toBeNull();
+    expect(contract.ok).toBe(true);
+  });
+
+  it("accepts an explicitly pinned staging origin", () => {
+    setBaseUrl(STAGING_API);
+    const contract = resolveCloudLiveOriginContract({
+      ELIZAOS_CLOUD_BASE_URL: STAGING_API,
+      ELIZA_UI_SMOKE_CLOUD_EXPECTED_ENV: "staging",
+    });
+    expect(contract.origin).toBe(STAGING_API);
+    expect(contract.environment).toBe("staging");
+    expect(contract.ok).toBe(true);
+  });
+
+  it("fails closed when staging is expected but no base URL was pinned", () => {
+    const contract = resolveCloudLiveOriginContract({
+      ELIZA_UI_SMOKE_CLOUD_EXPECTED_ENV: "staging",
+    });
+    expect(contract.ok).toBe(false);
+    expect(contract.reason).toContain("refusing the production default");
+  });
+
+  it("fails closed when staging is expected but production is resolved", () => {
+    setBaseUrl(PRODUCTION_API);
+    const contract = resolveCloudLiveOriginContract({
+      ELIZAOS_CLOUD_BASE_URL: PRODUCTION_API,
+      ELIZA_UI_SMOKE_CLOUD_EXPECTED_ENV: "staging",
+    });
+    expect(contract.ok).toBe(false);
+    expect(contract.environment).toBe("production");
+    expect(contract.reason).toContain("expected the staging Cloud API");
+  });
+
+  it("asserts production when the production lane pins its expectation", () => {
+    const contract = resolveCloudLiveOriginContract({
+      ELIZA_UI_SMOKE_CLOUD_EXPECTED_ENV: "production",
+    });
+    expect(contract.ok).toBe(true);
+    expect(contract.environment).toBe("production");
+  });
+
+  it("rejects an unknown expected-environment value instead of guessing", () => {
+    const contract = resolveCloudLiveOriginContract({
+      ELIZA_UI_SMOKE_CLOUD_EXPECTED_ENV: "prod",
+    });
+    expect(contract.ok).toBe(false);
+    expect(contract.reason).toContain('must be "staging" or "production"');
+  });
+
+  it("fails closed when production is expected but staging is resolved", () => {
+    setBaseUrl(STAGING_API);
+    const contract = resolveCloudLiveOriginContract({
+      ELIZAOS_CLOUD_BASE_URL: STAGING_API,
+      ELIZA_UI_SMOKE_CLOUD_EXPECTED_ENV: "production",
+    });
+    expect(contract.ok).toBe(false);
+    expect(contract.environment).toBe("staging");
+  });
+});

--- a/packages/app/test/cloud-live-origin.ts
+++ b/packages/app/test/cloud-live-origin.ts
@@ -1,0 +1,118 @@
+/**
+ * API-origin contract for the opt-in real Cloud Playwright lane (#18076).
+ *
+ * The live stack proxies /api/cloud/* to whatever `resolveCloudApiBaseUrl`
+ * yields from the inherited environment, so a lane that intends to exercise
+ * staging can silently drive production if `ELIZAOS_CLOUD_BASE_URL` is
+ * missing. This module resolves the exact origin the spawned runtime will
+ * target and, when the workflow pins `ELIZA_UI_SMOKE_CLOUD_EXPECTED_ENV`,
+ * refuses a mismatched or defaulted origin instead of falling back. Consumed
+ * by cloud-live.spec.ts before any auth/provision/chat step runs.
+ */
+
+import {
+  ELIZA_DOMAIN_CONTRACTS,
+  type ElizaCloudEnvironment,
+  resolveCloudApiBaseUrl,
+} from "@elizaos/shared/elizacloud";
+
+export type CloudLiveOriginContract = {
+  /** Resolved `<origin>/api/v1` base the runtime's Cloud proxy will call. */
+  apiBase: string;
+  /** Origin component of {@link apiBase}. */
+  origin: string;
+  /** Canonical environment of the resolved origin, or "custom". */
+  environment: ElizaCloudEnvironment | "custom";
+  /** Environment the lane declared it must target, if any. */
+  expected: ElizaCloudEnvironment | null;
+  /** True when the resolution satisfies the declared expectation. */
+  ok: boolean;
+  /** Populated when `ok` is false: why the lane must not proceed. */
+  reason?: string;
+};
+
+function classifyOrigin(origin: string): ElizaCloudEnvironment | "custom" {
+  for (const environment of ["production", "staging"] as const) {
+    if (
+      origin ===
+      new URL(ELIZA_DOMAIN_CONTRACTS[environment].cloudApiOrigin).origin
+    ) {
+      return environment;
+    }
+  }
+  return "custom";
+}
+
+export function resolveCloudLiveOriginContract(
+  env: NodeJS.ProcessEnv = process.env,
+): CloudLiveOriginContract {
+  const expectedRaw =
+    env.ELIZA_UI_SMOKE_CLOUD_EXPECTED_ENV?.trim().toLowerCase();
+  const expected: ElizaCloudEnvironment | null =
+    expectedRaw === "staging" || expectedRaw === "production"
+      ? expectedRaw
+      : null;
+
+  // resolveCloudApiBaseUrl consults the ELIZAOS_CLOUD_BASE_URL env override
+  // internally; passing the same value keeps injected-env unit coverage and
+  // the real process resolution identical.
+  const apiBase = resolveCloudApiBaseUrl(env.ELIZAOS_CLOUD_BASE_URL);
+
+  let origin: string;
+  try {
+    origin = new URL(apiBase).origin;
+  } catch {
+    // error-policy:J3 a malformed resolved base is reported as an explicit
+    // failed contract, never as a healthy-looking default origin.
+    return {
+      apiBase,
+      origin: "",
+      environment: "custom",
+      expected,
+      ok: false,
+      reason: `resolved Cloud API base is not a valid URL: ${apiBase}`,
+    };
+  }
+
+  const environment = classifyOrigin(origin);
+
+  if (expectedRaw && !expected) {
+    return {
+      apiBase,
+      origin,
+      environment,
+      expected: null,
+      ok: false,
+      reason: `ELIZA_UI_SMOKE_CLOUD_EXPECTED_ENV must be "staging" or "production", got "${expectedRaw}"`,
+    };
+  }
+
+  if (!expected) {
+    return { apiBase, origin, environment, expected, ok: true };
+  }
+
+  if (expected === "staging" && !env.ELIZAOS_CLOUD_BASE_URL?.trim()) {
+    return {
+      apiBase,
+      origin,
+      environment,
+      expected,
+      ok: false,
+      reason:
+        "staging lane requires an explicit ELIZAOS_CLOUD_BASE_URL; refusing the production default",
+    };
+  }
+
+  if (environment !== expected) {
+    return {
+      apiBase,
+      origin,
+      environment,
+      expected,
+      ok: false,
+      reason: `lane expected the ${expected} Cloud API but resolved ${origin} (${environment})`,
+    };
+  }
+
+  return { apiBase, origin, environment, expected, ok: true };
+}

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -19,6 +19,7 @@
 
 import { expect, type Locator, type Page, test } from "@playwright/test";
 import { seedCloudLiveBrowserAuth } from "../cloud-live-browser-auth";
+import { resolveCloudLiveOriginContract } from "../cloud-live-origin";
 import { assertOnboardingLiveness } from "../liveness-contract";
 import { openAppPath, seedAppStorage } from "./helpers";
 
@@ -86,6 +87,28 @@ test.describe("real cloud login + provisioning + chat", () => {
   test("provisions a real cloud agent from onboarding and chats with it", async ({
     page,
   }) => {
+    // #18076: prove which Cloud deployment this lane targets BEFORE any
+    // auth/provision/chat traffic. When the workflow pins an expected
+    // environment (staging/production), a defaulted or mismatched origin is a
+    // hard failure — never a silent fall-through to production.
+    const originContract = resolveCloudLiveOriginContract(process.env);
+    test.info().annotations.push(
+      { type: "cloud-api-origin", description: originContract.origin },
+      { type: "cloud-environment", description: originContract.environment },
+      {
+        // This lane always drives the renderer bundle built from the checked-out
+        // revision through the live stack; it does NOT drive a deployed Pages
+        // artifact. Recorded so run artifacts state what was exercised.
+        type: "renderer-source",
+        description: "locally built renderer bundle (not a deployed artifact)",
+      },
+    );
+    expect(
+      originContract.ok,
+      originContract.reason ??
+        `resolved Cloud API origin: ${originContract.origin}`,
+    ).toBe(true);
+
     expect(
       await seedCloudLiveBrowserAuth(page),
       "Cloud-live mode must hand its validated workflow bearer to the browser",

--- a/packages/scripts/__tests__/app-live-e2e-workflow.test.ts
+++ b/packages/scripts/__tests__/app-live-e2e-workflow.test.ts
@@ -26,6 +26,8 @@ interface WorkflowStep {
 
 interface WorkflowJob {
   env?: Record<string, string>;
+  environment?: string;
+  if?: string;
   steps?: WorkflowStep[];
 }
 
@@ -117,6 +119,112 @@ describe("App Live E2E real Cloud job (#14357, #16194)", () => {
 
     expect(spec).toContain("await seedCloudLiveBrowserAuth(page)");
     expect(spec).toContain('test.use({ trace: "off" });');
+  });
+});
+
+describe("App Live E2E staging Cloud job (#18076)", () => {
+  const stagingJob = workflow.jobs?.["cloud-live-staging"];
+
+  function stagingStep(name: string): WorkflowStep {
+    const step = stagingJob?.steps?.find(
+      (candidate) => candidate.name === name,
+    );
+    if (!step) {
+      throw new Error(`Missing cloud-live-staging workflow step: ${name}`);
+    }
+    return step;
+  }
+
+  test("pins the staging origin, expectation, and Environment-scoped credential", () => {
+    expect(stagingJob?.environment).toBe("staging");
+    expect(stagingJob?.env?.ELIZAOS_CLOUD_BASE_URL).toBe(
+      "https://api-staging.eliza.app",
+    );
+    expect(stagingJob?.env?.ELIZA_UI_SMOKE_CLOUD_EXPECTED_ENV).toBe("staging");
+    // The staging credential must come only from the staging Environment —
+    // a production repository-secret fallback would silently retarget prod.
+    expect(stagingJob?.env?.ELIZAOS_CLOUD_API_KEY).toBe(
+      "$" + "{{ secrets.ELIZAOS_CLOUD_API_KEY }}",
+    );
+    expect(stagingJob?.env?.ELIZAOS_CLOUD_API_KEY).not.toContain("||");
+  });
+
+  test("stays opt-in on schedule until the staging key is provisioned", () => {
+    expect(stagingJob?.if).toContain("ELIZA_CLOUD_STAGING_LIVE_READY");
+    expect(stagingJob?.if).toContain("inputs.run_cloud_staging");
+  });
+
+  test("fails closed before setup on a missing credential or a wrong origin", () => {
+    const steps = stagingJob?.steps ?? [];
+    const guardIndex = steps.findIndex(
+      (step) =>
+        step.name === "Require staging-scoped Cloud credential and origin",
+    );
+    const firstExpensiveStepIndex = steps.findIndex(
+      (step) => step.name === "Free disk space for browser smoke",
+    );
+    const testIndex = steps.findIndex(
+      (step) => step.name === "Run real STAGING cloud login + provision + chat",
+    );
+
+    expect(guardIndex).toBeGreaterThanOrEqual(0);
+    expect(firstExpensiveStepIndex).toBeGreaterThan(guardIndex);
+    expect(testIndex).toBeGreaterThan(guardIndex);
+
+    const run = stagingStep(
+      "Require staging-scoped Cloud credential and origin",
+    ).run;
+    expect(run).toBeDefined();
+
+    const stagingEnv = {
+      ...process.env,
+      ELIZAOS_CLOUD_BASE_URL: "https://api-staging.eliza.app",
+    };
+
+    const missingKey = spawnSync("bash", ["-c", run ?? ""], {
+      encoding: "utf8",
+      env: { ...stagingEnv, ELIZAOS_CLOUD_API_KEY: "" },
+    });
+    expect(missingKey.status).toBe(1);
+    expect(missingKey.stdout).toContain(
+      "never falling back to the production key",
+    );
+
+    const wrongOrigin = spawnSync("bash", ["-c", run ?? ""], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ELIZAOS_CLOUD_API_KEY: "staging-contract-key",
+        ELIZAOS_CLOUD_BASE_URL: "https://api.eliza.app",
+      },
+    });
+    expect(wrongOrigin.status).toBe(1);
+    expect(wrongOrigin.stdout).toContain("must pin ELIZAOS_CLOUD_BASE_URL");
+
+    const configured = spawnSync("bash", ["-c", run ?? ""], {
+      encoding: "utf8",
+      env: { ...stagingEnv, ELIZAOS_CLOUD_API_KEY: "staging-contract-key" },
+    });
+    expect(configured.status).toBe(0);
+  });
+
+  test("asserts the resolved API origin inside the spec before onboarding", () => {
+    const spec = read("packages/app/test/ui-smoke/cloud-live.spec.ts");
+    expect(spec).toContain("resolveCloudLiveOriginContract(process.env)");
+    expect(spec).toContain("cloud-api-origin");
+    expect(spec).toContain("renderer-source");
+  });
+
+  test("keeps production and staging as separate jobs and artifacts", () => {
+    expect(cloudJob?.env?.ELIZA_UI_SMOKE_CLOUD_EXPECTED_ENV).toBe("production");
+    const prodUpload = cloudJob?.steps?.find((step) =>
+      step.uses?.startsWith("actions/upload-artifact"),
+    );
+    const stagingUpload = stagingJob?.steps?.find((step) =>
+      step.uses?.startsWith("actions/upload-artifact"),
+    );
+    expect(prodUpload?.with?.name).toBe("app-live-e2e-cloud");
+    expect(stagingUpload?.with?.name).toBe("app-live-e2e-cloud-staging");
   });
 });
 


### PR DESCRIPTION
Fixes #18076

## Problem
`.github/workflows/app-live-e2e.yml` had no `ELIZAOS_CLOUD_BASE_URL`/origin selection or assertion anywhere, so the green Cloud job only ever exercised **production** while the staging first-run path stayed unproved — and nothing prevented a lane that intended staging from silently driving prod.

## Change
- **New `cloud-live-staging` job** (separate job → separate result + `app-live-e2e-cloud-staging` artifact), pinned to the canonical staging API origin `https://api-staging.eliza.app` (the issue's `api-staging.elizacloud.ai` is the legacy alias; `@elizaos/shared` `ELIZA_DOMAIN_CONTRACTS` normalizes both to the same staging environment).
  - Credential comes **only** from the protected `staging` Environment's `ELIZAOS_CLOUD_API_KEY` — no `|| secrets.ELIZACLOUD_API_KEY` production fallback (a prod key does not authenticate against staging anyway; a fallback would silently retarget prod).
  - **Fail-closed**: a first guard step hard-fails with `::error` before any setup/build work when the credential is blank/whitespace or the pinned origin is missing/wrong — it can never fall back to production.
  - Scheduled runs stay opt-in via repo var `ELIZA_CLOUD_STAGING_LIVE_READY` until an owner mints the staging-scoped key (tracked in the issue); `workflow_dispatch` exposes a `run_cloud_staging` input. An unprovisioned nightly is a visible skip, never a green-by-skip.
- **In-spec origin assertion**: `cloud-live.spec.ts` now resolves the exact Cloud API origin the spawned live stack will target (new `packages/app/test/cloud-live-origin.ts`, using the real `resolveCloudApiBaseUrl` from `@elizaos/shared/elizacloud`) and hard-fails on a mismatched or defaulted origin **before** any auth/provision/chat traffic. When `ELIZA_UI_SMOKE_CLOUD_EXPECTED_ENV=staging`, a missing `ELIZAOS_CLOUD_BASE_URL` is itself a failure ("refusing the production default").
- **Driven-surface labeling**: the spec annotations + a step summary record the resolved API origin, environment, and that the lane drives the locally built renderer bundle from the checked-out SHA — explicitly **not** the deployed staging Pages artifact.
- The existing production job now pins `ELIZA_UI_SMOKE_CLOUD_EXPECTED_ENV=production` so both lanes assert their target; the red-nightly notifier reports staging and production as separate rows.

## Owner action required (recorded in #18076)
Mint a staging-scoped `ELIZAOS_CLOUD_API_KEY` in the `staging` Environment, then set `ELIZA_CLOUD_STAGING_LIVE_READY=1` to arm the scheduled lane.

## Tests (run locally on this head, rebased on current develop)
- `bun test packages/scripts/__tests__/app-live-e2e-workflow.test.ts` — **11 pass / 0 fail (44 assertions)**, including new contract tests that execute the staging guard script for missing-key (exit 1, "never falling back to the production key"), wrong-origin (exit 1), and configured (exit 0) paths, pin the Environment-scoped credential with no `||` fallback, and assert separate artifact names.
- `bunx vitest run test/cloud-live-origin.test.ts` (packages/app) — **7 pass / 0 fail**: production default, pinned staging accept, staging-expected-but-defaulted fail-closed, staging-expected-but-prod-resolved fail, production pin, unknown expectation rejected, prod-expected-but-staging-resolved fail.
- `actionlint .github/workflows/app-live-e2e.yml` — clean.
- `packages/app` full typecheck currently fails only on pre-existing unbuilt-generated-module errors in untouched packages (`homepage` generated release-data, `@elizaos/app-core/desktop-shell` dist); the touched files typecheck clean and compile under the real vitest/playwright configs.

Live staging evidence (an actual green staging run) is intentionally not claimed here: it requires the owner-minted staging secret, after which the armed lane produces it as CI artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)