### PR TITLE
feat(cloud): bound worker-restart interruptions with the database-owned counter

### DIFF
--- a/packages/cloud/scripts/admin/managed-dedicated-canary-diagnostic.test.ts
+++ b/packages/cloud/scripts/admin/managed-dedicated-canary-diagnostic.test.ts
@@ -89,6 +89,7 @@ function failedDeleteInput(): Record<string, unknown> {
         },
         attempts: 3,
         maxAttempts: 3,
+        executionInterruptions: 0,
         resultStorage: "inline",
         errorStorage: "inline",
         scheduledFor: "2026-07-26T23:10:30.000Z",
@@ -157,7 +158,7 @@ describe("managed dedicated canary diagnostic", () => {
     );
 
     expect(evidence).toEqual({
-      schemaVersion: 3,
+      schemaVersion: 4,
       targetCount: 1,
       sandbox: {
         status: "deletion_failed",
@@ -171,6 +172,7 @@ describe("managed dedicated canary diagnostic", () => {
           status: "failed",
           attempts: 3,
           maxAttempts: 3,
+          executionInterruptions: 0,
           containerStopped: false,
           rowDeleted: false,
           errorCode: "sandbox_stop_failed",
@@ -304,7 +306,7 @@ describe("managed dedicated canary diagnostic", () => {
       );
 
       expect(evidence).toMatchObject({
-        schemaVersion: 3,
+        schemaVersion: 4,
         sandbox: {
           errorCode: "none",
         },
@@ -759,7 +761,7 @@ describe("managed dedicated canary diagnostic", () => {
     const evidence = JSON.parse(canonical);
 
     expect(evidence).toMatchObject({
-      schemaVersion: 3,
+      schemaVersion: 4,
       sandbox: {
         status: "deletion_failed",
         errorCode: "unclassified",
@@ -852,10 +854,13 @@ describe("managed dedicated canary diagnostic", () => {
   test("correlates a retained failure behind a strict terminal recovery without an active job", () => {
     const cause = "opaque retained source failure";
     const input = boundedHistoryInput([
-      "Job interrupted by worker restart 3 times - max attempts reached",
+      "Job interrupted by worker restart 3 times - interruption bound reached",
       cause,
     ]);
     const agent = input.agent as Record<string, unknown>;
+    (
+      (input.jobs as Record<string, unknown>[])[0] as Record<string, unknown>
+    ).executionInterruptions = 3;
     agent.errorMessage = `Deletion permanently failed after 3 attempts: ${cause}`;
     agent.errorCount = 2;
 
@@ -885,16 +890,22 @@ describe("managed dedicated canary diagnostic", () => {
   test.each([
     ["Job timed out 3 times - max attempts reached", "timeout"],
     [
-      "Job interrupted by worker restart 3 times - max attempts reached",
+      "Job interrupted by worker restart 3 times - interruption bound reached",
       "worker_restart_interrupted",
     ],
   ])(
     "accepts a recovery-generated terminal job as wrapper source",
     (cause, code) => {
-      const evidence = sanitizeManagedDedicatedCanaryDiagnostic(
-        correlatedPermanentDeleteInput(cause),
-        SUFFIX,
-      );
+      const input = correlatedPermanentDeleteInput(cause);
+      if (code === "worker_restart_interrupted") {
+        (
+          (input.jobs as Record<string, unknown>[])[0] as Record<
+            string,
+            unknown
+          >
+        ).executionInterruptions = 3;
+      }
+      const evidence = sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX);
       expect(evidence.sandbox.errorCode).toBe(code as never);
       expect(evidence.jobs[0]).toMatchObject({
         status: "failed",
@@ -908,7 +919,7 @@ describe("managed dedicated canary diagnostic", () => {
   // stay a plain raw-equality check.
   test.each([
     "Job timed out 2 times - max attempts reached",
-    "Job interrupted by worker restart 4 times - max attempts reached",
+    "Job interrupted by worker restart 4 times - interruption bound reached",
   ])(
     "rejects a terminal wrapper source whose attempt count disagrees",
     (cause) => {
@@ -1330,13 +1341,14 @@ describe("managed dedicated canary diagnostic", () => {
     const agent = input.agent as Record<string, unknown>;
     const [job] = input.jobs as Record<string, unknown>[];
     const error =
-      "Job interrupted by worker restart 3 times - max attempts reached";
+      "Job interrupted by worker restart 6 times - interruption bound reached";
     agent.status = "deletion_pending";
     agent.errorMessage = null;
     agent.errorCount = 0;
     job.error = error;
     job.result = null;
     job.completedAt = null;
+    job.executionInterruptions = 6;
 
     const canonical = canonicalizeManagedDedicatedCanaryDiagnostic(
       JSON.stringify(input),
@@ -1352,13 +1364,14 @@ describe("managed dedicated canary diagnostic", () => {
       status: "failed",
       attempts: 3,
       maxAttempts: 3,
+      executionInterruptions: 6,
       errorCode: "worker_restart_interrupted",
       resultErrorCode: "none",
       containerStopped: null,
       rowDeleted: null,
     });
     expect(canonical).not.toContain("worker restart");
-    expect(canonical).not.toContain("max attempts");
+    expect(canonical).not.toContain("interruption bound");
   });
 
   test("classifies a terminal timeout without publishing raw text", () => {
@@ -1396,9 +1409,12 @@ describe("managed dedicated canary diagnostic", () => {
   });
 
   test.each([
-    "Job interrupted by worker restart 0 times - max attempts reached",
-    "Job interrupted by worker restart 1000 times - max attempts reached",
-    "Job interrupted by worker restart 3 times - max attempts reached trailing",
+    "Job interrupted by worker restart 0 times - interruption bound reached",
+    "Job interrupted by worker restart 1000 times - interruption bound reached",
+    "Job interrupted by worker restart 3 times - interruption bound reached trailing",
+    // Diagnosis is forward-only (#17473): the retired attempts-based spelling
+    // fails closed instead of classifying.
+    "Job interrupted by worker restart 3 times - max attempts reached",
   ])("rejects a noncanonical worker-restart message", (error) => {
     const input = failedDeleteInput();
     const agent = input.agent as Record<string, unknown>;
@@ -1413,7 +1429,9 @@ describe("managed dedicated canary diagnostic", () => {
 
   test.each([
     [
-      "Job interrupted by worker restart 1 times - max attempts reached",
+      // Restart terminals pin to executionInterruptions (0 in this fixture),
+      // never to the attempt budget.
+      "Job interrupted by worker restart 1 times - interruption bound reached",
       3,
       3,
       "failed",
@@ -1487,7 +1505,8 @@ describe("managed dedicated canary diagnostic", () => {
     agent.errorMessage = null;
     agent.errorCount = 0;
     job.error =
-      "Job interrupted by worker restart 3 times - max attempts reached";
+      "Job interrupted by worker restart 3 times - interruption bound reached";
+    job.executionInterruptions = 3;
     job.result = result;
     job.completedAt = null;
 
@@ -1499,7 +1518,7 @@ describe("managed dedicated canary diagnostic", () => {
   test.each([
     [
       "worker_restart_recovered",
-      "Job interrupted by worker restart - recovered for retry (attempt 1/3)",
+      "Job interrupted by worker restart - recovered for retry (interruption 1/5)",
     ],
     ["timeout_recovered", "Job timed out - recovered for retry (attempt 1/3)"],
   ])(
@@ -1516,6 +1535,7 @@ describe("managed dedicated canary diagnostic", () => {
         job.error = message;
         job.attempts = 1;
         job.maxAttempts = 3;
+        job.executionInterruptions = 1;
         job.startedAt = "2026-07-26T23:10:31.000Z";
         job.completedAt = null;
         job.result = null;
@@ -1547,8 +1567,9 @@ describe("managed dedicated canary diagnostic", () => {
     agent.errorCount = 0;
     job.status = "pending";
     job.error =
-      "Job interrupted by worker restart - recovered for retry (attempt 1/3)";
+      "Job interrupted by worker restart - recovered for retry (interruption 1/5)";
     job.attempts = 1;
+    job.executionInterruptions = 1;
     job.completedAt = null;
 
     expect(
@@ -1565,29 +1586,22 @@ describe("managed dedicated canary diagnostic", () => {
 
   test.each([
     [
-      "mismatched attempt",
-      "Job interrupted by worker restart - recovered for retry (attempt 2/3)",
+      "mismatched interruption",
+      "Job interrupted by worker restart - recovered for retry (interruption 2/5)",
       1,
       3,
       "recovery counters disagree",
     ],
     [
-      "mismatched maximum",
-      "Job interrupted by worker restart - recovered for retry (attempt 1/4)",
-      1,
-      3,
-      "recovery counters disagree",
-    ],
-    [
-      "maxed retry",
-      "Job interrupted by worker restart - recovered for retry (attempt 3/3)",
+      "interruption above its bound",
+      "Job interrupted by worker restart - recovered for retry (interruption 3/2)",
       3,
       3,
       "recovery counters disagree",
     ],
     [
       "failed status",
-      "Job interrupted by worker restart - recovered for retry (attempt 1/3)",
+      "Job interrupted by worker restart - recovered for retry (interruption 1/5)",
       1,
       3,
       "recovery status is invalid",
@@ -1626,6 +1640,7 @@ describe("managed dedicated canary diagnostic", () => {
       job.result = null;
       job.attempts = attempts;
       job.maxAttempts = maxAttempts;
+      job.executionInterruptions = attempts;
       if (_name !== "failed status" && _name !== "timeout failed status") {
         job.status = "pending";
       }
@@ -1635,6 +1650,33 @@ describe("managed dedicated canary diagnostic", () => {
       ).toThrow(expectedError);
     },
   );
+
+  test("accepts a restart recovery breadcrumb at the interruption bound", () => {
+    // Unlike the attempt budget, recovery at N === bound is legal: the sweep
+    // only terminates the job once the counter would exceed the bound.
+    const input = failedDeleteInput();
+    const agent = input.agent as Record<string, unknown>;
+    const [job] = input.jobs as Record<string, unknown>[];
+    agent.status = "deletion_pending";
+    agent.errorMessage = null;
+    agent.errorCount = 0;
+    job.status = "pending";
+    job.error =
+      "Job interrupted by worker restart - recovered for retry (interruption 5/5)";
+    job.result = null;
+    job.attempts = 1;
+    job.executionInterruptions = 5;
+    job.completedAt = null;
+
+    expect(
+      sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX).jobs[0],
+    ).toMatchObject({
+      status: "pending",
+      executionInterruptions: 5,
+      recoveryCode: "worker_restart_recovered",
+      errorCode: "none",
+    });
+  });
 
   test.each([
     [
@@ -1674,7 +1716,8 @@ describe("managed dedicated canary diagnostic", () => {
     agent.errorCount = 0;
     job.status = status;
     job.error =
-      "Job interrupted by worker restart - recovered for retry (attempt 1/3)";
+      "Job interrupted by worker restart - recovered for retry (interruption 1/5)";
+    job.executionInterruptions = 1;
     job.result =
       status === "completed"
         ? {
@@ -1693,9 +1736,12 @@ describe("managed dedicated canary diagnostic", () => {
   });
 
   test.each([
-    "Job interrupted by worker restart - recovered for retry (attempt 0/3)",
-    "Job interrupted by worker restart - recovered for retry (attempt 1/1000)",
-    "Job interrupted by worker restart - recovered for retry (attempt 1/3) trailing",
+    "Job interrupted by worker restart - recovered for retry (interruption 0/5)",
+    "Job interrupted by worker restart - recovered for retry (interruption 1/1000)",
+    "Job interrupted by worker restart - recovered for retry (interruption 1/5) trailing",
+    // Forward-only diagnosis (#17473): the retired attempts-based restart
+    // recovery spelling fails closed.
+    "Job interrupted by worker restart - recovered for retry (attempt 1/3)",
     "Job timed out - recovered for retry (attempt 0/3)",
     "Job timed out - recovered for retry (attempt 1/1000)",
     "Job timed out - recovered for retry (attempt 1/3) trailing",
@@ -1839,7 +1885,8 @@ describe("managed dedicated canary diagnostic", () => {
     agent.errorCount = 0;
     job.status = "pending";
     job.error =
-      "Job interrupted by worker restart - recovered for retry (attempt 1/3)";
+      "Job interrupted by worker restart - recovered for retry (interruption 1/5)";
+    job.executionInterruptions = 1;
     job.result = result;
     job.attempts = 1;
     job.completedAt = null;
@@ -1868,7 +1915,8 @@ describe("managed dedicated canary diagnostic", () => {
       agent.errorCount = 0;
       job.status = "pending";
       job.error =
-        "Job interrupted by worker restart - recovered for retry (attempt 1/3)";
+        "Job interrupted by worker restart - recovered for retry (interruption 1/5)";
+      job.executionInterruptions = 1;
       job.result = {
         containerStopped: false,
         rowDeleted: false,
@@ -2016,5 +2064,4 @@ describe("managed dedicated canary diagnostic", () => {
       sanitizeManagedDedicatedCanaryDiagnostic(input, SUFFIX),
     ).toThrow("newest-first");
   });
-
 });

--- a/packages/cloud/scripts/admin/managed-dedicated-canary-diagnostic.ts
+++ b/packages/cloud/scripts/admin/managed-dedicated-canary-diagnostic.ts
@@ -24,8 +24,12 @@ const TIMEOUT_ERROR_PATTERN = /(?:timed out|timeout)/i;
 const PERMANENT_DELETE_PREFIX = "Deletion permanently failed";
 const PERMANENT_DELETE_PATTERN =
   /^Deletion permanently failed after ([1-9][0-9]{0,2}) attempts: ([\s\S]+)$/;
+// Worker restarts spend a database-owned interruption budget, never the job's
+// attempts (#17473), so the restart family carries the interruption count.
+// Diagnosis is forward-only: rows written under the retired attempts-based
+// spelling fail closed as malformed recovery provenance.
 const WORKER_RESTART_TERMINAL_PATTERN =
-  /^Job interrupted by worker restart ([1-9][0-9]{0,2}) times - max attempts reached$/;
+  /^Job interrupted by worker restart ([1-9][0-9]{0,2}) times - interruption bound reached$/;
 const TIMEOUT_TERMINAL_PATTERN =
   /^Job timed out ([1-9][0-9]{0,2}) times - max attempts reached$/;
 
@@ -66,12 +70,15 @@ type RecoveryCode = "none" | "worker_restart_recovered" | "timeout_recovered";
 
 interface RecoveryClassification {
   code: Exclude<RecoveryCode, "none">;
+  /** Attempts for the timeout family; interruptions for the restart family. */
   attempt: number;
+  /** Attempt budget for the timeout family; interruption bound for restarts. */
   maxAttempts: number;
 }
 
 interface TerminalFailureClassification {
   code: Extract<ErrorCode, "timeout" | "worker_restart_interrupted">;
+  /** Attempts for the timeout family; interruptions for the restart family. */
   attempts: number;
 }
 
@@ -111,7 +118,7 @@ const RECOVERY_PARTIAL_RESULT_ERRORS = new Map<string, ErrorCode>([
 ]);
 
 export interface ManagedDedicatedCanaryDiagnostic {
-  schemaVersion: 3;
+  schemaVersion: 4;
   targetCount: 1;
   sandbox: {
     status: string;
@@ -124,6 +131,7 @@ export interface ManagedDedicatedCanaryDiagnostic {
     status: string;
     attempts: number;
     maxAttempts: number;
+    executionInterruptions: number;
     containerStopped: boolean | null;
     rowDeleted: boolean | null;
     errorCode: ErrorCode;
@@ -438,14 +446,30 @@ function classifySandboxError(
   // validation already pins a terminal message's own attempt count to the
   // job's attempts and maxAttempts, which the equalities below pin to the
   // envelope's.
-  const sourceIndex = jobs.findIndex(
-    ({ diagnostic, rawError }) =>
-      typeof rawError === "string" &&
-      rawError === envelope.cause &&
-      diagnostic.status === "failed" &&
+  // An interruption-terminal cause pins the wrapped count to the job's
+  // interruption counter instead of attempts, because the restart family
+  // never spends the attempt budget (#17473); the envelope's own count is
+  // still the writer's attempt budget.
+  const causeTerminal = classifyTerminalFailure(envelope.cause);
+  const sourceIndex = jobs.findIndex(({ diagnostic, rawError }) => {
+    if (
+      typeof rawError !== "string" ||
+      rawError !== envelope.cause ||
+      diagnostic.status !== "failed"
+    ) {
+      return false;
+    }
+    if (causeTerminal?.code === "worker_restart_interrupted") {
+      return (
+        envelope.attempts === diagnostic.maxAttempts &&
+        causeTerminal.attempts === diagnostic.executionInterruptions
+      );
+    }
+    return (
       diagnostic.attempts === envelope.attempts &&
-      diagnostic.maxAttempts === envelope.attempts,
-  );
+      diagnostic.maxAttempts === envelope.attempts
+    );
+  });
   if (sourceIndex === -1) {
     throw new Error(
       `${label} does not correlate with bounded failed-job history`,
@@ -529,7 +553,7 @@ function classifyRecovery(
     {
       code: "worker_restart_recovered",
       pattern:
-        /^Job interrupted by worker restart - recovered for retry \(attempt ([1-9][0-9]{0,2})\/([1-9][0-9]{0,2})\)$/,
+        /^Job interrupted by worker restart - recovered for retry \(interruption ([1-9][0-9]{0,2})\/([1-9][0-9]{0,2})\)$/,
     },
     {
       code: "timeout_recovered",
@@ -634,6 +658,7 @@ export function sanitizeManagedDedicatedCanaryDiagnostic(
         "result",
         "attempts",
         "maxAttempts",
+        "executionInterruptions",
         "resultStorage",
         "errorStorage",
         "scheduledFor",
@@ -718,22 +743,36 @@ export function sanitizeManagedDedicatedCanaryDiagnostic(
       1,
       100,
     );
+    const executionInterruptions = integer(
+      job.executionInterruptions,
+      `jobs[${index}].executionInterruptions`,
+      0,
+      100,
+    );
     if (attempts > maxAttempts) {
       throw new Error(`jobs[${index}] attempts exceed maxAttempts`);
     }
+    // The timeout family pins to the attempt budget; the restart family pins
+    // to the interruption counter, whose recovery deliberately freezes
+    // attempts (#17473).
     if (
       terminalFailure &&
       (job.status !== "failed" ||
-        terminalFailure.attempts !== attempts ||
-        terminalFailure.attempts !== maxAttempts)
+        (terminalFailure.code === "timeout"
+          ? terminalFailure.attempts !== attempts ||
+            terminalFailure.attempts !== maxAttempts
+          : terminalFailure.attempts !== executionInterruptions))
     ) {
       throw new Error(`jobs[${index}] terminal counters disagree`);
     }
     if (
       recovery &&
-      (recovery.attempt !== attempts ||
-        recovery.maxAttempts !== maxAttempts ||
-        attempts >= maxAttempts)
+      (recovery.code === "timeout_recovered"
+        ? recovery.attempt !== attempts ||
+          recovery.maxAttempts !== maxAttempts ||
+          attempts >= maxAttempts
+        : recovery.attempt !== executionInterruptions ||
+          recovery.attempt > recovery.maxAttempts)
     ) {
       throw new Error(`jobs[${index}] recovery counters disagree`);
     }
@@ -799,9 +838,13 @@ export function sanitizeManagedDedicatedCanaryDiagnostic(
     ) {
       throw new Error(`jobs[${index}] has an invalid completed result`);
     }
+    // An interruption-terminal job may legitimately have spent zero attempts:
+    // restarts kill it before an execution ever fails.
     if (
       job.status === "failed" &&
-      (attempts === 0 || jobErrorCode === "none")
+      ((attempts === 0 &&
+        terminalFailure?.code !== "worker_restart_interrupted") ||
+        jobErrorCode === "none")
     ) {
       throw new Error(`jobs[${index}] has an invalid failed result`);
     }
@@ -819,6 +862,7 @@ export function sanitizeManagedDedicatedCanaryDiagnostic(
       status: job.status,
       attempts,
       maxAttempts,
+      executionInterruptions,
       containerStopped,
       rowDeleted,
       errorCode: jobErrorCode,
@@ -857,7 +901,7 @@ export function sanitizeManagedDedicatedCanaryDiagnostic(
   }
 
   return {
-    schemaVersion: 3,
+    schemaVersion: 4,
     targetCount: 1,
     sandbox: {
       status: agent.status,

--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-completed-at.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-completed-at.test.ts
@@ -77,6 +77,7 @@ beforeAll(async () => {
 				error_key text,
 				attempts integer NOT NULL DEFAULT 0,
 				max_attempts integer NOT NULL DEFAULT 3,
+				execution_interruptions integer NOT NULL DEFAULT 0,
 				organization_id uuid NOT NULL,
 				user_id uuid,
 				api_key_id uuid,

--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
@@ -70,6 +70,7 @@ async function seedJob(params: {
   id: string;
   maxAttempts: number;
   attempts?: number;
+  executionInterruptions?: number;
   type?: string;
   data?: Record<string, unknown>;
   dataStorage?: string;
@@ -93,6 +94,7 @@ async function seedJob(params: {
     result_storage: params.resultStorage ?? "inline",
     attempts: params.attempts ?? 0,
     max_attempts: params.maxAttempts,
+    execution_interruptions: params.executionInterruptions ?? 0,
     organization_id: params.organizationId ?? ORG_ID,
     user_id: params.userId ?? ACTOR_ID,
     agent_id: params.agentId ?? AGENT_ID,
@@ -196,6 +198,7 @@ beforeAll(async () => {
 				error_key text,
 				attempts integer NOT NULL DEFAULT 0,
 				max_attempts integer NOT NULL DEFAULT 3,
+				execution_interruptions integer NOT NULL DEFAULT 0,
 				organization_id uuid NOT NULL,
 				user_id uuid,
 				api_key_id uuid,
@@ -500,6 +503,7 @@ describe("jobsRepository.recoverStaleJobs", () => {
         id: jobs.id,
         status: jobs.status,
         attempts: jobs.attempts,
+        execution_interruptions: jobs.execution_interruptions,
         error: jobs.error,
       })
       .from(jobs)
@@ -509,13 +513,91 @@ describe("jobsRepository.recoverStaleJobs", () => {
     const current = rows.find((row) => row.id === currentJobId);
     expect(interrupted).toMatchObject({
       status: "pending",
-      attempts: 1,
-      error: "Job interrupted by worker restart - recovered for retry (attempt 1/3)",
+      attempts: 0,
+      execution_interruptions: 1,
+      error: "Job interrupted by worker restart - recovered for retry (interruption 1/5)",
     });
     expect(current).toMatchObject({
       status: "in_progress",
       attempts: 0,
+      execution_interruptions: 0,
       error: null,
+    });
+  });
+
+  test("interruption bound is enforced from the database column for inline and R2-offloaded payloads", async () => {
+    expect(pgliteReady).toBe(true);
+    const inlineJobId = "00000000-0000-4000-8000-000000190855";
+    const offloadedJobId = "00000000-0000-4000-8000-000000190856";
+    const dataKey = "jobs/data/offloaded-interruption.json";
+    setRuntimeR2Bucket(
+      memoryBucket(new Map([[dataKey, JSON.stringify({ payload: "x".repeat(64) })]])),
+    );
+    try {
+      await seedJob({ id: inlineJobId, maxAttempts: 3, executionInterruptions: 5 });
+      await seedJob({
+        id: offloadedJobId,
+        maxAttempts: 3,
+        executionInterruptions: 5,
+        data: {},
+        dataStorage: "r2",
+        dataKey,
+      });
+
+      const recovered = await repo.recoverInProgressJobsStartedBefore({
+        type: "agent_message",
+        startedBefore: new Date(),
+      });
+
+      expect(recovered).toMatchObject({ retried: 0, permanentlyFailed: 2, failures: [] });
+      const rows = await dbWrite.select().from(jobs).orderBy(jobs.id);
+      expect(rows).toHaveLength(2);
+      for (const row of rows) {
+        expect(row).toMatchObject({
+          status: "failed",
+          attempts: 0,
+          execution_interruptions: 6,
+          error: "Job interrupted by worker restart 6 times - interruption bound reached",
+        });
+      }
+      expect(rows.find((row) => row.id === offloadedJobId)).toMatchObject({
+        data_storage: "r2",
+        data_key: dataKey,
+      });
+    } finally {
+      setRuntimeR2Bucket(null);
+    }
+  });
+
+  test("concurrent recoveries of one interruption snapshot increment the counter exactly once", async () => {
+    expect(pgliteReady).toBe(true);
+    const jobId = "00000000-0000-4000-8000-000000190857";
+    await seedJob({ id: jobId, maxAttempts: 3 });
+
+    // Both sweeps read the same in_progress snapshot before either CAS runs;
+    // the interruption-count equality in the recovery CAS must make exactly
+    // one writer win, because the restart arm no longer moves `attempts`.
+    const [first, second] = await Promise.all([
+      repo.recoverInProgressJobsStartedBefore({
+        type: "agent_message",
+        startedBefore: new Date(),
+      }),
+      repo.recoverInProgressJobsStartedBefore({
+        type: "agent_message",
+        startedBefore: new Date(),
+      }),
+    ]);
+
+    expect(first.failures).toHaveLength(0);
+    expect(second.failures).toHaveLength(0);
+    expect(first.retried + second.retried).toBe(1);
+    expect(first.unchanged + second.unchanged).toBe(1);
+    const [row] = await dbWrite.select().from(jobs).where(eq(jobs.id, jobId));
+    expect(row).toMatchObject({
+      status: "pending",
+      attempts: 0,
+      execution_interruptions: 1,
+      error: "Job interrupted by worker restart - recovered for retry (interruption 1/5)",
     });
   });
 
@@ -535,6 +617,7 @@ describe("jobsRepository.recoverStaleJobs", () => {
       id: preCutoverJobId,
       type: "agent_admin_canary_image",
       maxAttempts: 1,
+      executionInterruptions: 5,
     });
 
     const recovered = await repo.recoverInProgressJobsStartedBefore({
@@ -547,14 +630,16 @@ describe("jobsRepository.recoverStaleJobs", () => {
     expect(rows.find((row) => row.id === committedJobId)).toMatchObject({
       status: "pending",
       attempts: 0,
+      execution_interruptions: 0,
       result: audit,
       error: expect.stringContaining("without consuming a terminal attempt"),
     });
     expect(rows.find((row) => row.id === preCutoverJobId)).toMatchObject({
       status: "failed",
-      attempts: 1,
+      attempts: 0,
+      execution_interruptions: 6,
       result: null,
-      error: expect.stringContaining("max attempts reached"),
+      error: expect.stringContaining("interruption bound reached"),
     });
   });
 
@@ -1097,7 +1182,12 @@ describe("jobsRepository.recoverStaleJobs", () => {
       expect(pgliteReady).toBe(true);
       const failing = "00000000-0000-4000-8000-000000180906";
       const retrying = "00000000-0000-4000-8000-000000180907";
-      await seedJob({ id: failing, maxAttempts: 1, type: "agent_delete" });
+      await seedJob({
+        id: failing,
+        maxAttempts: 1,
+        type: "agent_delete",
+        executionInterruptions: 5,
+      });
       await seedJob({ id: retrying, maxAttempts: 3, type: "agent_delete" });
 
       const recovered = await repo.recoverInProgressJobsStartedBefore({
@@ -1118,8 +1208,19 @@ describe("jobsRepository.recoverStaleJobs", () => {
     async () => {
       const poisoned = "00000000-0000-4000-8000-000000180910";
       const later = "00000000-0000-4000-8000-000000180911";
-      await seedJob({ id: poisoned, maxAttempts: 1, type: jobTypes.AGENT_DELETE, data: {} });
-      await seedJob({ id: later, maxAttempts: 1, type: jobTypes.AGENT_LOGS });
+      await seedJob({
+        id: poisoned,
+        maxAttempts: 1,
+        type: jobTypes.AGENT_DELETE,
+        data: {},
+        executionInterruptions: 5,
+      });
+      await seedJob({
+        id: later,
+        maxAttempts: 1,
+        type: jobTypes.AGENT_LOGS,
+        executionInterruptions: 5,
+      });
       const service = new ProvisioningJobServiceCtor();
 
       let thrown: unknown;
@@ -1142,8 +1243,13 @@ describe("jobsRepository.recoverStaleJobs", () => {
       expect(await repo.findByIdForWrite(poisoned)).toMatchObject({
         status: "in_progress",
         attempts: 0,
+        execution_interruptions: 5,
       });
-      expect(await repo.findByIdForWrite(later)).toMatchObject({ status: "failed", attempts: 1 });
+      expect(await repo.findByIdForWrite(later)).toMatchObject({
+        status: "failed",
+        attempts: 0,
+        execution_interruptions: 6,
+      });
     },
     PGLITE_TIMEOUT,
   );
@@ -1198,6 +1304,7 @@ describe("jobsRepository.recoverStaleJobs", () => {
         maxAttempts: 1,
         type: jobTypes.APP_DEPLOY,
         data: { appId },
+        executionInterruptions: 5,
       });
       const service = new ProvisioningJobServiceCtor();
 
@@ -1289,6 +1396,7 @@ describe("jobsRepository.recoverStaleJobs", () => {
         maxAttempts: 1,
         type: jobTypes.APP_DEPLOY,
         data: { appId },
+        executionInterruptions: 5,
       });
 
       const staleApp = { id: appId, slug, api_key_id: apiKeyId, deployment_status: "building" };

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -254,6 +254,7 @@ function retryPayloadFence(job: Job) {
     AND ${jobs.character_id} IS NOT DISTINCT FROM ${job.character_id}
     AND ${jobs.attempts} = ${job.attempts}
     AND ${jobs.max_attempts} = ${job.max_attempts}
+    AND ${jobs.execution_interruptions} = ${job.execution_interruptions}
     AND ${jobs.execution_generation} IS NOT DISTINCT FROM ${job.execution_generation}
     AND ${msWindowTimestampMatch(jobs.execution_quiesced_at, job.execution_quiesced_at)}
     AND ${msWindowTimestampMatch(jobs.started_at, job.started_at)}
@@ -295,6 +296,7 @@ function sameRetrySnapshot(left: Job, right: Job): boolean {
     left.character_id === right.character_id &&
     left.attempts === right.attempts &&
     left.max_attempts === right.max_attempts &&
+    left.execution_interruptions === right.execution_interruptions &&
     left.execution_generation === right.execution_generation &&
     sameTimestamp(left.execution_quiesced_at, right.execution_quiesced_at) &&
     sameTimestamp(left.started_at, right.started_at) &&
@@ -310,6 +312,25 @@ function sameRetrySnapshot(left: Job, right: Job): boolean {
     left.error_key === right.error_key &&
     sameError
   );
+}
+
+/**
+ * Worker-restart recoveries a job may absorb before the sweep fails it as a
+ * poison pill. Interruptions are counted in `jobs.execution_interruptions`,
+ * never in the job's attempt budget: a restart is infrastructure churn, not a
+ * failed execution. The bound exists so a job that never survives a deploy
+ * cycle (agent_snapshot was the motivating lane) cannot recover forever.
+ */
+export const MAX_JOB_INTERRUPTIONS = 5;
+
+/** Terminal error written when a job exceeds {@link MAX_JOB_INTERRUPTIONS}. */
+export function jobInterruptionBoundError(interruptions: number): string {
+  return `Job interrupted by worker restart ${interruptions} times - interruption bound reached`;
+}
+
+/** Recovery provenance written when a restart-interrupted job is re-queued. */
+export function jobInterruptionRecoveredError(interruptions: number): string {
+  return `Job interrupted by worker restart - recovered for retry (interruption ${interruptions}/${MAX_JOB_INTERRUPTIONS})`;
 }
 
 export class StaleJobExecutionError extends Error {
@@ -1055,12 +1076,16 @@ export class JobsRepository {
    * Recovers pre-start claims only after their renewable owner lease and
    * takeover grace have expired. Process start time scopes the scan but is not
    * ownership evidence: overlapping workers may both be live during rollout.
+   *
+   * Restart interruptions never spend the job's attempt budget: each recovery
+   * increments `execution_interruptions` atomically with the status flip, and
+   * a job that exceeds {@link MAX_JOB_INTERRUPTIONS} is failed terminally. A
+   * committed canary cutover keeps its dedicated resume path unchanged.
    */
   async recoverInProgressJobsStartedBefore(filters: {
     type: string;
     organizationId?: string;
     startedBefore: Date;
-    maxAttempts?: number;
     /** Settles dependent rows for jobs this sweep flips to `failed`. */
     buildFailureWriteback?: RecoveryFailureWritebackBuilder;
   }): Promise<JobRecoverySweepResult> {
@@ -1095,17 +1120,19 @@ export class JobsRepository {
 
     for (const job of interruptedJobs) {
       const resumeCommittedCanary = hasRecoverableAdminCanaryCutover(job);
-      const preservesAttempt = resumeCommittedCanary || isDurableRetryJob(job.type);
-      const newAttempts = preservesAttempt ? job.attempts : (job.attempts || 0) + 1;
-      const maxAttempts = job.max_attempts ?? filters.maxAttempts ?? 3;
-      const isFailed = !preservesAttempt && newAttempts >= maxAttempts;
+      // A worker restart is not a failed execution: every non-canary job keeps
+      // its attempt budget and spends the database-owned interruption budget
+      // instead, so restart churn cannot exhaust retries but a job that never
+      // survives a deploy cycle still terminates.
+      const newInterruptions = resumeCommittedCanary
+        ? job.execution_interruptions
+        : job.execution_interruptions + 1;
+      const isFailed = !resumeCommittedCanary && newInterruptions > MAX_JOB_INTERRUPTIONS;
       const error = resumeCommittedCanary
         ? "Admin canary cutover cleanup interrupted by worker restart - recovered without consuming a terminal attempt"
-        : isDurableRetryJob(job.type)
-          ? "Durable job interrupted by worker restart - recovered without consuming an attempt"
-          : isFailed
-            ? `Job interrupted by worker restart ${newAttempts} times - max attempts reached`
-            : `Job interrupted by worker restart - recovered for retry (attempt ${newAttempts}/${maxAttempts})`;
+        : isFailed
+          ? jobInterruptionBoundError(newInterruptions)
+          : jobInterruptionRecoveredError(newInterruptions);
       const recoveryFence = resumeCommittedCanary ? adminCanaryRecoveryFence(job) : sql`TRUE`;
       const [attempt] = await Promise.allSettled([
         (async () => {
@@ -1116,7 +1143,8 @@ export class JobsRepository {
             job,
             startedBefore: filters.startedBefore,
             isFailed,
-            newAttempts,
+            newAttempts: job.attempts,
+            newInterruptions,
             error,
             recoveryFence,
             onFailedInTx,
@@ -1165,6 +1193,13 @@ export class JobsRepository {
     startedBefore: Date;
     isFailed: boolean;
     newAttempts: number;
+    /**
+     * New interruption count for the restart sweep; omitted by the timeout
+     * sweep, which leaves the counter untouched. When the restart arm freezes
+     * `attempts`, the interruption equality below is the CAS token that makes
+     * a concurrent recovery of the same snapshot lose.
+     */
+    newInterruptions?: number;
     error: string;
     recoveryFence: SQL;
     /**
@@ -1196,6 +1231,7 @@ export class JobsRepository {
             eq(jobs.id, params.job.id),
             eq(jobs.status, "in_progress"),
             eq(jobs.attempts, params.job.attempts),
+            eq(jobs.execution_interruptions, params.job.execution_interruptions),
             sql`${jobs.execution_generation} IS NOT DISTINCT FROM ${params.job.execution_generation}`,
             msWindowTimestampMatch(jobs.execution_quiesced_at, params.job.execution_quiesced_at),
             lt(jobs.started_at, params.startedBefore),
@@ -1226,6 +1262,7 @@ export class JobsRepository {
           status: params.isFailed ? "failed" : "pending",
           ...payload,
           attempts: params.newAttempts,
+          execution_interruptions: params.newInterruptions ?? params.job.execution_interruptions,
           completed_at: params.isFailed ? new Date() : null,
           execution_quiesced_at: new Date(),
           updated_at: new Date(),
@@ -1235,6 +1272,7 @@ export class JobsRepository {
             eq(jobs.id, params.job.id),
             eq(jobs.status, "in_progress"),
             eq(jobs.attempts, params.job.attempts),
+            eq(jobs.execution_interruptions, params.job.execution_interruptions),
             sql`${jobs.execution_generation} IS NOT DISTINCT FROM ${params.job.execution_generation}`,
             msWindowTimestampMatch(jobs.execution_quiesced_at, params.job.execution_quiesced_at),
             lt(jobs.started_at, params.startedBefore),

--- a/packages/cloud/shared/src/db/schemas/jobs.ts
+++ b/packages/cloud/shared/src/db/schemas/jobs.ts
@@ -31,6 +31,10 @@ export const jobs = pgTable(
     error_key: text("error_key"),
     attempts: integer("attempts").notNull().default(0),
     max_attempts: integer("max_attempts").notNull().default(3),
+    // Worker-restart interruptions recovered without spending an attempt.
+    // Column shipped ahead of this entry in 0185/0194 (#17476) so readers only
+    // deploy against databases that already have it.
+    execution_interruptions: integer("execution_interruptions").notNull().default(0),
     organization_id: uuid("organization_id")
       .notNull()
       .references(() => organizations.id, { onDelete: "cascade" }),

--- a/packages/cloud/shared/src/lib/services/__tests__/container-retirement.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-retirement.integration.test.ts
@@ -51,6 +51,7 @@ beforeAll(async () => {
         error_key text,
         attempts integer NOT NULL DEFAULT 0,
         max_attempts integer NOT NULL DEFAULT 3,
+        execution_interruptions integer NOT NULL DEFAULT 0,
         organization_id uuid NOT NULL,
         user_id uuid,
         api_key_id uuid,

--- a/packages/cloud/shared/src/lib/services/admin-agent-image-rollout.pglite.test.ts
+++ b/packages/cloud/shared/src/lib/services/admin-agent-image-rollout.pglite.test.ts
@@ -3031,7 +3031,12 @@ describe("admin agent image rollout on primary PGlite", () => {
 
     await dbWrite
       .update(jobs)
-      .set({ started_at: new Date("2026-07-22T00:00:00.000Z") })
+      .set({
+        started_at: new Date("2026-07-22T00:00:00.000Z"),
+        // An uncommitted canary at the interruption bound must fail closed
+        // rather than recover forever (#17473).
+        execution_interruptions: 5,
+      })
       .where(eq(jobs.id, persisted.id));
     await expireExecutionLease(persisted.id);
     expect(
@@ -3040,14 +3045,14 @@ describe("admin agent image rollout on primary PGlite", () => {
           type: JOB_TYPES.AGENT_ADMIN_CANARY_IMAGE,
           organizationId: seeded.targets[0]!.organizationId,
           startedBefore: new Date("2026-07-23T00:00:00.000Z"),
-          maxAttempts: 2,
         })
       ).retried,
     ).toBe(0);
     expect(await jobsRepository.findByIdForWrite(persisted.id)).toMatchObject({
       status: "failed",
-      attempts: 1,
-      error: expect.stringContaining("max attempts reached"),
+      attempts: 0,
+      execution_interruptions: 6,
+      error: expect.stringContaining("interruption bound reached"),
     });
   });
 
@@ -3731,8 +3736,11 @@ describe("admin agent image rollout on primary PGlite", () => {
     ).toBe(1);
     expect(await jobsRepository.findByIdForWrite(enqueued.job.id)).toMatchObject({
       status: "pending",
-      attempts: 1,
-      error: expect.stringContaining("recovered for retry"),
+      // Restart recovery spends the interruption budget, never an attempt
+      // (#17473).
+      attempts: 0,
+      execution_interruptions: 1,
+      error: expect.stringContaining("recovered for retry (interruption 1/5)"),
     });
     expect(
       await jobsRepository.claimPendingJobsWithinSharedRunningLimit({

--- a/packages/cloud/shared/src/lib/services/pii-scrub-jobs.test.ts
+++ b/packages/cloud/shared/src/lib/services/pii-scrub-jobs.test.ts
@@ -127,6 +127,7 @@ beforeAll(async () => {
         error_key text,
         attempts integer NOT NULL DEFAULT 0,
         max_attempts integer NOT NULL DEFAULT 3,
+        execution_interruptions integer NOT NULL DEFAULT 0,
         organization_id uuid NOT NULL,
         user_id uuid,
         api_key_id uuid,


### PR DESCRIPTION
Fixes #17473

This is PR 2 of the two-PR plan settled on the issue. PR 1 (#17476, migration `0185_job_execution_interruptions` plus the `0194` catalog guard and the `preflight-job-execution-interruptions` gate) is merged and deployed, so the reader can now land.

## What changed

- **Drizzle schema entry** for `jobs.execution_interruptions` (`integer NOT NULL DEFAULT 0`), deliberately shipped only now that every deployment has the column (the schema entry alone breaks every typed `SELECT` against an unmigrated database — the verified 42703 race from the issue).
- **Restart recovery sweep** (`recoverInProgressJobsStartedBefore`): a worker restart no longer spends the job's attempt budget. Each recovery increments `execution_interruptions` atomically with the status flip under the existing recovery fence; `attempts` is frozen on the interruption arm. A job whose counter would exceed `MAX_JOB_INTERRUPTIONS = 5` is failed terminally with `Job interrupted by worker restart N times - interruption bound reached`.
- **CAS relocation**: because `attempts` is now non-discriminant on the interruption arm, `execution_interruptions` equality joins both CAS sites (the `FOR UPDATE` select and the `UPDATE … WHERE`) and the retry-payload fence, so a concurrent recovery of the same snapshot loses instead of double-incrementing.
- **Committed-canary special case** is retained unchanged under its exact `adminCanaryRecoveryFence` and stays deliberately unbounded.
- **Canary diagnostic** updated in the same PR (as the issue requires): `schemaVersion` 4, the restart terminal/recovery grammars carry the interruption count, ingest gains `executionInterruptions`, and the restart family pins terminal/recovery counts to the interruption counter instead of the attempt budget. Diagnosis is forward-only: the retired attempts-based restart spellings fail closed as malformed recovery provenance.
- The timeout sweep and ordinary `attempts` accounting are untouched.

## Acceptance criteria from the issue

- [x] dedicated non-negative interruption counter (database column, storage-mode independent)
- [x] incremented and failed atomically with the status transition
- [x] ordinary `attempts` preserved (frozen on the interruption arm; timeout arm unchanged)
- [x] inline and R2-offloaded payloads covered identically — regression test reads the bound from the column with `data_storage = 'r2'`
- [x] concurrent recovery proven unable to double-increment or revive an exhausted row (PGlite test racing two sweeps over one snapshot)
- [x] committed-canary special case retained under its existing exact fence

## Tests (all run in this worktree, Bun 1.3.14)

- `packages/cloud/shared` `src/db/repositories/__tests__/jobs-recovery.test.ts` — 25 pass / 0 fail (includes the new inline-vs-R2 bound test and the concurrent single-increment test)
- `packages/cloud` `scripts/admin/managed-dedicated-canary-diagnostic.test.ts` — 209 pass / 0 fail
- `packages/cloud` `scripts/admin/managed-dedicated-canary.test.ts` + `managed-dedicated-canary-workflow.test.ts` — 45 pass / 0 fail
- `packages/cloud/shared` `admin-agent-image-rollout.pglite.test.ts` — 48 pass / 0 fail (uncommitted canary at the bound now fails closed with the interruption spelling)
- `packages/cloud/shared` `jobs-completed-at`, `pii-scrub-jobs`, `container-retirement.integration`, `provisioning-jobs-snapshot-gate`, `provisioning-jobs-lanes` — 44 pass / 0 fail
- `tsc --noEmit` in `packages/cloud/shared` — clean
- Biome check on all changed files — clean

Evidence is deterministic PGlite/unit output; no rendered surface changed, so visual evidence is N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)