### PR TITLE
fix(cloud): bind provider checkout expiry to payment-request deadline

### DIFF
--- a/packages/cloud/shared/src/lib/services/payment-adapters/checkout-lifetime.test.ts
+++ b/packages/cloud/shared/src/lib/services/payment-adapters/checkout-lifetime.test.ts
@@ -1,0 +1,90 @@
+// Deterministic unit coverage for deadline-to-provider checkout lifetime
+// clamping (Stripe expires_at seconds, OxaPay whole-minute lifetime).
+import { describe, expect, test } from "bun:test";
+import {
+  clampCheckoutLifetimeMs,
+  OXAPAY_INVOICE_MAX_LIFETIME_MS,
+  OXAPAY_INVOICE_MIN_LIFETIME_MS,
+  oxapayInvoiceLifetimeSeconds,
+  STRIPE_CHECKOUT_MAX_LIFETIME_MS,
+  STRIPE_CHECKOUT_MIN_LIFETIME_MS,
+  stripeCheckoutExpiresAtSeconds,
+} from "./checkout-lifetime";
+
+const NOW = new Date("2026-08-15T12:00:00.000Z");
+const HOUR_MS = 3_600_000;
+
+function deadlineIn(ms: number): Date {
+  return new Date(NOW.getTime() + ms);
+}
+
+describe("clampCheckoutLifetimeMs", () => {
+  const bounds = { minMs: 10_000, maxMs: 100_000 };
+
+  test("passes through an in-window deadline", () => {
+    expect(clampCheckoutLifetimeMs(deadlineIn(50_000), NOW, bounds)).toBe(50_000);
+  });
+
+  test("clamps a too-near deadline up to the provider floor", () => {
+    expect(clampCheckoutLifetimeMs(deadlineIn(1_000), NOW, bounds)).toBe(10_000);
+  });
+
+  test("clamps an already-passed deadline up to the provider floor", () => {
+    expect(clampCheckoutLifetimeMs(deadlineIn(-5_000), NOW, bounds)).toBe(10_000);
+  });
+
+  test("clamps a far deadline down to the provider ceiling", () => {
+    expect(clampCheckoutLifetimeMs(deadlineIn(1_000_000), NOW, bounds)).toBe(100_000);
+  });
+
+  test("throws on an invalid deadline instead of minting an unbounded session", () => {
+    expect(() => clampCheckoutLifetimeMs(new Date(Number.NaN), NOW, bounds)).toThrow(
+      /not a valid date/,
+    );
+  });
+});
+
+describe("stripeCheckoutExpiresAtSeconds", () => {
+  test("binds an in-window deadline exactly", () => {
+    const deadline = deadlineIn(2 * HOUR_MS);
+    expect(stripeCheckoutExpiresAtSeconds(deadline, NOW)).toBe(
+      Math.floor(deadline.getTime() / 1000),
+    );
+  });
+
+  test("clamps a 5-minute deadline up to Stripe's 30-minute floor", () => {
+    expect(stripeCheckoutExpiresAtSeconds(deadlineIn(5 * 60_000), NOW)).toBe(
+      Math.floor((NOW.getTime() + STRIPE_CHECKOUT_MIN_LIFETIME_MS) / 1000),
+    );
+  });
+
+  test("clamps a 7-day deadline down to Stripe's 24-hour ceiling", () => {
+    expect(stripeCheckoutExpiresAtSeconds(deadlineIn(7 * 24 * HOUR_MS), NOW)).toBe(
+      Math.floor((NOW.getTime() + STRIPE_CHECKOUT_MAX_LIFETIME_MS) / 1000),
+    );
+  });
+});
+
+describe("oxapayInvoiceLifetimeSeconds", () => {
+  test("binds an in-window deadline, rounded up to a whole minute", () => {
+    expect(oxapayInvoiceLifetimeSeconds(deadlineIn(HOUR_MS + 30_000), NOW)).toBe(61 * 60);
+  });
+
+  test("clamps a 2-minute deadline up to OxaPay's 15-minute floor", () => {
+    expect(oxapayInvoiceLifetimeSeconds(deadlineIn(2 * 60_000), NOW)).toBe(
+      OXAPAY_INVOICE_MIN_LIFETIME_MS / 1000,
+    );
+  });
+
+  test("clamps a 7-day deadline down to OxaPay's 2-day ceiling", () => {
+    expect(oxapayInvoiceLifetimeSeconds(deadlineIn(7 * 24 * HOUR_MS), NOW)).toBe(
+      OXAPAY_INVOICE_MAX_LIFETIME_MS / 1000,
+    );
+  });
+
+  test("ceiling boundary is not pushed past the maximum by minute rounding", () => {
+    expect(oxapayInvoiceLifetimeSeconds(deadlineIn(OXAPAY_INVOICE_MAX_LIFETIME_MS - 1), NOW)).toBe(
+      OXAPAY_INVOICE_MAX_LIFETIME_MS / 1000,
+    );
+  });
+});

--- a/packages/cloud/shared/src/lib/services/payment-adapters/checkout-lifetime.ts
+++ b/packages/cloud/shared/src/lib/services/payment-adapters/checkout-lifetime.ts
@@ -1,0 +1,65 @@
+/**
+ * Binds a payment request's deadline to a provider checkout-session lifetime.
+ *
+ * Providers accept a session lifetime only inside their own bounds (Stripe
+ * Checkout: 30 minutes to 24 hours; OxaPay invoices: 15 minutes to 2 days), so
+ * the request's `expiresAt` is clamped into the supported window rather than
+ * passed through raw. When the deadline is nearer than the provider minimum the
+ * session may outlive the request; the atomic unexpired settle transition in
+ * `payment-requests.ts` remains the settlement authority for that window.
+ * Consumed by the Stripe and OxaPay adapters in this directory.
+ */
+
+const MINUTE_MS = 60_000;
+
+export const STRIPE_CHECKOUT_MIN_LIFETIME_MS = 30 * MINUTE_MS;
+export const STRIPE_CHECKOUT_MAX_LIFETIME_MS = 24 * 60 * MINUTE_MS;
+export const OXAPAY_INVOICE_MIN_LIFETIME_MS = 15 * MINUTE_MS;
+export const OXAPAY_INVOICE_MAX_LIFETIME_MS = 2880 * MINUTE_MS;
+
+/**
+ * Clamps the duration from `now` to the request deadline into the provider's
+ * supported lifetime window, in milliseconds. Throws on an invalid deadline so
+ * intent creation fails loudly instead of minting an unbounded session.
+ */
+export function clampCheckoutLifetimeMs(
+  expiresAt: Date,
+  now: Date,
+  bounds: { minMs: number; maxMs: number },
+): number {
+  const deadlineMs = expiresAt.getTime();
+  if (!Number.isFinite(deadlineMs)) {
+    throw new Error("Payment request expiresAt is not a valid date; cannot bind checkout expiry");
+  }
+  const remainingMs = deadlineMs - now.getTime();
+  return Math.min(bounds.maxMs, Math.max(bounds.minMs, remainingMs));
+}
+
+/**
+ * Stripe Checkout `expires_at` epoch seconds bound to the request deadline,
+ * clamped into Stripe's 30-minute–24-hour session window.
+ */
+export function stripeCheckoutExpiresAtSeconds(expiresAt: Date, now: Date): number {
+  const lifetimeMs = clampCheckoutLifetimeMs(expiresAt, now, {
+    minMs: STRIPE_CHECKOUT_MIN_LIFETIME_MS,
+    maxMs: STRIPE_CHECKOUT_MAX_LIFETIME_MS,
+  });
+  return Math.floor((now.getTime() + lifetimeMs) / 1000);
+}
+
+/**
+ * OxaPay invoice lifetime in seconds bound to the request deadline. OxaPay
+ * takes whole minutes, so the remaining time is rounded up to the next minute
+ * before clamping into the 15-minute–2-day invoice window.
+ */
+export function oxapayInvoiceLifetimeSeconds(expiresAt: Date, now: Date): number {
+  const remainingMs = clampCheckoutLifetimeMs(expiresAt, now, {
+    minMs: OXAPAY_INVOICE_MIN_LIFETIME_MS,
+    maxMs: OXAPAY_INVOICE_MAX_LIFETIME_MS,
+  });
+  const wholeMinutes = Math.min(
+    OXAPAY_INVOICE_MAX_LIFETIME_MS / MINUTE_MS,
+    Math.ceil(remainingMs / MINUTE_MS),
+  );
+  return wholeMinutes * 60;
+}

--- a/packages/cloud/shared/src/lib/services/payment-adapters/oxapay.ts
+++ b/packages/cloud/shared/src/lib/services/payment-adapters/oxapay.ts
@@ -16,6 +16,7 @@ import { logger } from "../../utils/logger";
 import { isOxaPayConfigured, oxaPayService } from "../oxapay";
 import { type PaymentProviderAdapter, type PaymentRequestRow } from "../payment-requests";
 import { IgnoredWebhookEvent } from "../payment-webhook-errors";
+import { oxapayInvoiceLifetimeSeconds } from "./checkout-lifetime";
 
 function readMetaString(request: PaymentRequestRow, key: string): string | undefined {
   const meta = (request.metadata ?? {}) as Record<string, unknown>;
@@ -83,6 +84,9 @@ export function createOxaPayPaymentAdapter(): PaymentProviderAdapter {
       }
 
       const returnUrl = request.successUrl ?? readMetaString(request, "success_url");
+      // Bind the invoice lifetime to the request deadline so the hosted pay
+      // link cannot outlive the request by more than OxaPay's floor.
+      const lifetimeSeconds = oxapayInvoiceLifetimeSeconds(request.expiresAt, new Date());
       const invoice = await oxaPayService.createInvoice({
         amount: amountUsd,
         currency: (request.currency || "usd").toUpperCase(),
@@ -91,6 +95,7 @@ export function createOxaPayPaymentAdapter(): PaymentProviderAdapter {
         description: request.reason ?? readMetaString(request, "product_description"),
         callbackUrl,
         returnUrl,
+        lifetime: lifetimeSeconds,
       });
 
       logger.info("[OxaPayPaymentAdapter] Created invoice", {

--- a/packages/cloud/shared/src/lib/services/payment-adapters/stripe.ts
+++ b/packages/cloud/shared/src/lib/services/payment-adapters/stripe.ts
@@ -17,6 +17,7 @@ import { logger } from "../../utils/logger";
 import { paymentMethodsService } from "../payment-methods";
 import { type PaymentProviderAdapter, type PaymentRequestRow } from "../payment-requests";
 import { IgnoredWebhookEvent } from "../payment-webhook-errors";
+import { stripeCheckoutExpiresAtSeconds } from "./checkout-lifetime";
 
 interface RequestMetadata {
   successUrl?: string;
@@ -94,6 +95,10 @@ export function createStripePaymentAdapter(): PaymentProviderAdapter {
 
       const productName = meta.productName ?? request.reason ?? "Payment";
 
+      // Bind the Checkout session lifetime to the request deadline so the
+      // hosted page cannot outlive the request by more than Stripe's floor.
+      const sessionExpiresAtSeconds = stripeCheckoutExpiresAtSeconds(request.expiresAt, new Date());
+
       const session = await stripe.checkout.sessions.create({
         mode: "payment",
         payment_method_types: ["card"],
@@ -117,6 +122,7 @@ export function createStripePaymentAdapter(): PaymentProviderAdapter {
         ...(!customerId && meta.customerEmail ? { customer_email: meta.customerEmail } : {}),
         metadata: sharedMetadata,
         payment_intent_data: { metadata: sharedMetadata },
+        expires_at: sessionExpiresAtSeconds,
       });
 
       const paymentIntent = session.payment_intent;
@@ -135,6 +141,7 @@ export function createStripePaymentAdapter(): PaymentProviderAdapter {
           stripe_session_id: session.id,
           stripe_payment_intent_id: paymentIntentId,
           stripe_checkout_url: session.url,
+          stripe_session_expires_at: new Date(sessionExpiresAtSeconds * 1000).toISOString(),
         },
       };
     },


### PR DESCRIPTION
## What

Remaining sub-item of #18814 (the client-side navigation/eligibility work landed in #19820, the atomic settle/expire transitional core in #19227): provider checkout sessions were still created with provider-default lifetimes regardless of the payment request's `expiresAt`, so a hosted Stripe/OxaPay checkout page could stay payable long after the request deadline.

- **New `checkout-lifetime.ts`** (`packages/cloud/shared/src/lib/services/payment-adapters/`): pure deadline→lifetime binding, clamped into each provider's supported window — Stripe Checkout `expires_at` (30 min–24 h), OxaPay invoice `lifetime` (15 min–2 d, whole minutes). Invalid `expiresAt` throws so intent creation fails loudly instead of minting an unbounded session.
- **Stripe adapter**: passes `expires_at` bound to the request deadline and persists `stripe_session_expires_at` on the provider intent.
- **OxaPay adapter**: passes `lifetime` bound to the request deadline (previously the service default of 30 minutes was always used, which could also *under*-live a longer request).

## Tests

Run in the worktree on `origin/develop` (8d9f76fb9f0):

- `bun test src/lib/services/payment-adapters/` (packages/cloud/shared) — **20 pass / 0 fail** (12 new deterministic clamp/binding tests + existing OxaPay webhook suite).
- `bun test src/lib/services/payment-requests.test.ts` — **11 pass / 0 fail** (settlement CAS/replay/expiry suite unaffected).
- `bun run --cwd packages/cloud/shared typecheck` — exit 0.
- Biome check on touched files — clean.

## Residual risk

When a request deadline is nearer than a provider's minimum session lifetime (Stripe 30 min, OxaPay 15 min), the provider session can outlive the request by up to that floor. The atomic allowed-status-and-unexpired settle transition from #19227 refuses settlement in that window, so no expired request can settle; reconciliation/refund policy for a payment completed inside that provider-floor window remains with the #19227 author's follow-up as noted on #18814.

Fixes #18814

🤖 Generated with [Claude Code](https://claude.com/claude-code)