### PR TITLE
fix(lifeops): enforce owner identity and revision predicates at the definition persistence boundary

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts
@@ -77,8 +77,19 @@ vi.mock("../lifeops/service.js", () => {
     }
   }
   class LifeOpsService {
+    private readonly ownerEntityIdValue: string;
+
     constructor(_runtime: IAgentRuntime, options?: { ownerEntityId?: string }) {
       serviceState.ownerEntityIds.push(options?.ownerEntityId);
+      this.ownerEntityIdValue = options?.ownerEntityId ?? "owner-test";
+    }
+
+    agentId() {
+      return "agent-test";
+    }
+
+    ownerEntityId() {
+      return this.ownerEntityIdValue;
     }
 
     repository = {
@@ -189,15 +200,27 @@ vi.mock("../lifeops/service.js", () => {
       };
     }
     async listDefinitions() {
+      // The caller-subject filter in life.ts requires each definition to be
+      // bound to the resolving owner; stamp the default subject unless a test
+      // deliberately supplies a foreign one.
       return [
         {
           definition: {
             id: "def-1",
             title: "workout",
             domain: "user_lifeops",
+            subjectType: "owner",
+            subjectId: this.ownerEntityIdValue,
           },
         },
-        ...serviceState.extraDefinitions,
+        ...serviceState.extraDefinitions.map((entry) => ({
+          ...entry,
+          definition: {
+            subjectType: "owner",
+            subjectId: this.ownerEntityIdValue,
+            ...(entry.definition as Record<string, unknown>),
+          },
+        })),
       ];
     }
     async listGoals() {
@@ -1557,12 +1580,16 @@ describe("runLifeConnectedQuery capability boundaries", () => {
 describe("resolveDefinitionFromIntent", () => {
   it("resolves a uniquely named definition from natural-language intent", async () => {
     const service = {
+      agentId: () => "agent-test",
+      ownerEntityId: () => "owner-test",
       listDefinitions: vi.fn(async () => [
         {
           definition: {
             id: "def-1",
             title: "workout",
             domain: "user_lifeops",
+            subjectType: "owner",
+            subjectId: "owner-test",
           },
         },
       ]),

--- a/plugins/plugin-personal-assistant/src/actions/life.delete-name-guard.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.delete-name-guard.test.ts
@@ -35,6 +35,14 @@ vi.mock("../lifeops/service.js", () => {
     }
   }
   class LifeOpsService {
+    agentId() {
+      return "00000000-0000-0000-0000-000000000003";
+    }
+
+    ownerEntityId() {
+      return "00000000-0000-0000-0000-000000000002";
+    }
+
     repository = {
       listAuditEvents: async (
         _agentId: string,

--- a/plugins/plugin-personal-assistant/src/actions/life.review-definitions.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.review-definitions.test.ts
@@ -35,6 +35,14 @@ vi.mock("../lifeops/service.js", () => {
   }
 
   class LifeOpsService {
+    agentId() {
+      return "00000000-0000-0000-0000-000000000003";
+    }
+
+    ownerEntityId() {
+      return "00000000-0000-0000-0000-000000000002";
+    }
+
     async listDefinitions() {
       return serviceState.definitions;
     }

--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -923,6 +923,28 @@ type DefinitionResult = {
   ambiguousCandidates: string[];
 };
 
+/**
+ * Definitions eligible for chat-side fuzzy/title resolution are only those
+ * bound to this runtime's own identities: agent-subject rows must belong to
+ * the agent and owner-subject rows to the configured owner entity. Rows
+ * recorded for any other subject under the same agent are invisible here, so
+ * planner text can only nominate — and mutations can only target — the
+ * caller's own definitions (#17398).
+ */
+async function listCallerDefinitions(
+  service: LifeOpsService,
+  domain?: LifeOpsDomain,
+): Promise<LifeOpsDefinitionRecord[]> {
+  const agentId = service.agentId();
+  const ownerEntityId = service.ownerEntityId();
+  return (await service.listDefinitions()).filter((entry) => {
+    if (domain && entry.definition.domain !== domain) return false;
+    const expectedSubjectId =
+      entry.definition.subjectType === "agent" ? agentId : ownerEntityId;
+    return entry.definition.subjectId === expectedSubjectId;
+  });
+}
+
 function resolveDefinitionInRecords(
   defs: LifeOpsDefinitionRecord[],
   target: string | undefined,
@@ -1006,9 +1028,7 @@ async function resolveDefinition(
   destructive = false,
 ): Promise<DefinitionResult> {
   if (!target) return { match: null, ambiguousCandidates: [] };
-  const defs = (await service.listDefinitions()).filter((e) =>
-    domain ? e.definition.domain === domain : true,
-  );
+  const defs = await listCallerDefinitions(service, domain);
   return resolveDefinitionInRecords(defs, target, destructive);
 }
 
@@ -1103,9 +1123,7 @@ async function resolveDefinitionForMutation(
   domain?: LifeOpsDomain,
   destructive = false,
 ): Promise<DefinitionResult> {
-  const defs = (await service.listDefinitions()).filter((entry) =>
-    domain ? entry.definition.domain === domain : true,
-  );
+  const defs = await listCallerDefinitions(service, domain);
   const normalizedOwnerText = normalizeTitle(ownerText);
   const explicitlyNamed = defs.filter((entry) => {
     const title = normalizeTitle(entry.definition.title);
@@ -1180,9 +1198,7 @@ export async function resolveDefinitionFromIntent(
   if (direct.match || direct.ambiguousCandidates.length > 0) {
     return direct.match;
   }
-  const defs = (await service.listDefinitions()).filter((entry) =>
-    domain ? entry.definition.domain === domain : true,
-  );
+  const defs = await listCallerDefinitions(service, domain);
   const intentTokens = new Set(tokenizeTitle(intent));
   let best: LifeOpsDefinitionRecord | null = null;
   let bestScore = 0;
@@ -4882,7 +4898,7 @@ async function runLifeOperationHandlerInner(
       // identical "Book report…" definition). An ACTIVE definition with the
       // same normalized title and structurally identical cadence IS the same
       // item — report it as already saved instead of stacking a twin.
-      const duplicateOf = (await service.listDefinitions()).find(
+      const duplicateOf = (await listCallerDefinitions(service)).find(
         (record) =>
           record.definition.status === "active" &&
           normalizeLifeInputText(record.definition.title).toLowerCase() ===
@@ -5957,7 +5973,7 @@ async function runLifeOperationHandlerInner(
         };
       }
       const reviewDomain = domain ?? "user_lifeops";
-      const active = (await service.listDefinitions()).filter(
+      const active = (await listCallerDefinitions(service)).filter(
         (record) =>
           record.definition.status === "active" &&
           record.definition.domain === reviewDomain &&

--- a/plugins/plugin-personal-assistant/src/lifeops/definition-owner-scope.pglite.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/definition-owner-scope.pglite.integration.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Real-PGlite coverage for owner-identity scoping and optimistic concurrency
+ * at the LifeOps definition persistence boundary (#17398): two owner subjects
+ * under one agent must never list, update, or delete each other's definitions,
+ * and stale mutations must surface as a typed LIFEOPS_DEFINITION_CONFLICT.
+ * The harness is a real AgentRuntime with the personal-assistant plugin's
+ * schema migrated into PGlite — no mocked repository.
+ */
+import { ElizaError } from "@elizaos/core";
+import type { LifeOpsTaskDefinition } from "@elizaos/shared";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  createLifeOpsTestRuntime,
+  type RealTestRuntimeResult,
+} from "../../test/helpers/runtime.js";
+import {
+  createLifeOpsTaskDefinition,
+  LifeOpsRepository,
+} from "./repository.js";
+
+const OWNER_A = "11111111-1111-4111-8111-111111111111";
+const OWNER_B = "22222222-2222-4222-8222-222222222222";
+
+function makeDefinition(
+  agentId: string,
+  subjectId: string,
+  title: string,
+): LifeOpsTaskDefinition {
+  return createLifeOpsTaskDefinition({
+    agentId,
+    domain: "user_lifeops",
+    subjectType: "owner",
+    subjectId,
+    visibilityScope: "owner_only",
+    contextPolicy: "explicit_only",
+    kind: "task",
+    title,
+    description: "",
+    originalIntent: title,
+    timezone: "UTC",
+    status: "active",
+    priority: 3,
+    cadence: { kind: "once", dueAt: "2027-01-05T09:00:00.000Z" },
+    windowPolicy: { timezone: "UTC", windows: [] },
+    progressionRule: { kind: "none" },
+    websiteAccess: null,
+    reminderPlanId: null,
+    goalId: null,
+    source: "manual",
+    metadata: {},
+  });
+}
+
+async function expectConflict(promise: Promise<unknown>): Promise<void> {
+  await expect(promise).rejects.toSatisfy(
+    (error: unknown) =>
+      error instanceof ElizaError &&
+      error.code === "LIFEOPS_DEFINITION_CONFLICT",
+  );
+}
+
+describe("LifeOps definition persistence — owner scope and revision predicates", () => {
+  let runtimeResult: RealTestRuntimeResult;
+  let repository: LifeOpsRepository;
+  let agentId: string;
+  let defA: LifeOpsTaskDefinition;
+  let defB: LifeOpsTaskDefinition;
+
+  beforeAll(async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    agentId = runtimeResult.runtime.agentId;
+    repository = new LifeOpsRepository(runtimeResult.runtime);
+    // Duplicate titles on purpose: title text must never disambiguate owners.
+    defA = makeDefinition(agentId, OWNER_A, "water the plants");
+    defB = makeDefinition(agentId, OWNER_B, "water the plants");
+    await repository.createDefinition(defA);
+    await repository.createDefinition(defB);
+  }, 120_000);
+
+  afterAll(async () => {
+    await runtimeResult?.cleanup();
+  });
+
+  it("scoped list returns only the requesting owner's definitions", async () => {
+    const forA = await repository.listDefinitions(agentId, {
+      subjectType: "owner",
+      subjectId: OWNER_A,
+    });
+    expect(forA.map((d) => d.id)).toEqual([defA.id]);
+    const forB = await repository.listDefinitions(agentId, {
+      subjectType: "owner",
+      subjectId: OWNER_B,
+    });
+    expect(forB.map((d) => d.id)).toEqual([defB.id]);
+    const activeForA = await repository.listActiveDefinitions(agentId, {
+      subjectType: "owner",
+      subjectId: OWNER_A,
+    });
+    expect(activeForA.map((d) => d.id)).toEqual([defA.id]);
+  });
+
+  it("scoped get denies cross-owner reads by id", async () => {
+    const crossRead = await repository.getDefinition(agentId, defB.id, {
+      subjectType: "owner",
+      subjectId: OWNER_A,
+    });
+    expect(crossRead).toBeNull();
+    const ownRead = await repository.getDefinition(agentId, defB.id, {
+      subjectType: "owner",
+      subjectId: OWNER_B,
+    });
+    expect(ownRead?.id).toBe(defB.id);
+  });
+
+  it("update cannot land on another owner's row even with the victim's id", async () => {
+    const forged: LifeOpsTaskDefinition = {
+      ...defB,
+      subjectId: OWNER_A,
+      title: "hijacked",
+      updatedAt: new Date().toISOString(),
+    };
+    await expectConflict(repository.updateDefinition(forged));
+    const untouched = await repository.getDefinition(agentId, defB.id);
+    expect(untouched?.title).toBe("water the plants");
+    expect(untouched?.subjectId).toBe(OWNER_B);
+  });
+
+  it("stale expectedUpdatedAt yields a typed conflict and leaves the row intact", async () => {
+    const before = await repository.getDefinition(agentId, defA.id);
+    if (!before) throw new Error("definition A missing");
+    const firstWrite: LifeOpsTaskDefinition = {
+      ...before,
+      title: "water the plants (am)",
+      updatedAt: new Date(Date.now() + 1000).toISOString(),
+    };
+    await repository.updateDefinition(firstWrite, {
+      expectedUpdatedAt: before.updatedAt,
+    });
+    // Second writer computed from the pre-update revision must conflict.
+    const staleWrite: LifeOpsTaskDefinition = {
+      ...before,
+      title: "stale overwrite",
+      updatedAt: new Date(Date.now() + 2000).toISOString(),
+    };
+    await expectConflict(
+      repository.updateDefinition(staleWrite, {
+        expectedUpdatedAt: before.updatedAt,
+      }),
+    );
+    const after = await repository.getDefinition(agentId, defA.id);
+    expect(after?.title).toBe("water the plants (am)");
+  });
+
+  it("delete scoped to another owner conflicts and cascades nothing", async () => {
+    await expectConflict(
+      repository.deleteDefinition(agentId, defB.id, {
+        scope: { subjectType: "owner", subjectId: OWNER_A },
+      }),
+    );
+    expect(await repository.getDefinition(agentId, defB.id)).not.toBeNull();
+  });
+
+  it("delete with a stale revision conflicts; the fresh revision deletes exactly once", async () => {
+    const current = await repository.getDefinition(agentId, defB.id);
+    if (!current) throw new Error("definition B missing");
+    await expectConflict(
+      repository.deleteDefinition(agentId, defB.id, {
+        scope: { subjectType: "owner", subjectId: OWNER_B },
+        expectedUpdatedAt: "2000-01-01T00:00:00.000Z",
+      }),
+    );
+    await repository.deleteDefinition(agentId, defB.id, {
+      scope: { subjectType: "owner", subjectId: OWNER_B },
+      expectedUpdatedAt: current.updatedAt,
+    });
+    expect(await repository.getDefinition(agentId, defB.id)).toBeNull();
+    // A repeated delete (retry after success) must conflict, not fabricate success.
+    await expectConflict(
+      repository.deleteDefinition(agentId, defB.id, {
+        scope: { subjectType: "owner", subjectId: OWNER_B },
+        expectedUpdatedAt: current.updatedAt,
+      }),
+    );
+    // An update raced against the completed delete conflicts the same way.
+    await expectConflict(
+      repository.updateDefinition(
+        { ...current, title: "post-delete write" },
+        { expectedUpdatedAt: current.updatedAt },
+      ),
+    );
+    // Owner A's duplicate-titled definition is untouched by B's delete.
+    const survivors = await repository.listDefinitions(agentId, {
+      subjectType: "owner",
+      subjectId: OWNER_A,
+    });
+    expect(survivors.map((d) => d.id)).toEqual([defA.id]);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/definitions-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/definitions-service.ts
@@ -353,7 +353,12 @@ export class DefinitionsDomain {
       request.reminderPlan,
       "update",
     );
-    await this.ctx.repository.updateDefinition(nextDefinition);
+    // Optimistic concurrency: the first write-back must land on the exact
+    // revision this update was computed from; a concurrent mutation or delete
+    // surfaces as a typed LIFEOPS_DEFINITION_CONFLICT for re-resolution.
+    await this.ctx.repository.updateDefinition(nextDefinition, {
+      expectedUpdatedAt: current.definition.updatedAt,
+    });
     const reminderPlan = await this.deps.syncReminderPlan(
       nextDefinition,
       reminderPlanDraft,
@@ -408,6 +413,16 @@ export class DefinitionsDomain {
     if (!definition) {
       fail(404, "life-ops definition not found");
     }
+    // A definition whose subject is neither this runtime's agent nor its
+    // owner belongs to another identity; report it as absent rather than
+    // disclose or destroy it.
+    const expectedSubjectId =
+      definition.subjectType === "agent"
+        ? this.ctx.agentId()
+        : this.ctx.ownerEntityId();
+    if (definition.subjectId !== expectedSubjectId) {
+      fail(404, "life-ops definition not found");
+    }
     await this.deps.syncNativeAppleReminderForDefinition({
       definition: null,
       previousDefinition: definition,
@@ -415,6 +430,13 @@ export class DefinitionsDomain {
     await this.ctx.repository.deleteDefinition(
       this.ctx.agentId(),
       definitionId,
+      {
+        scope: {
+          subjectType: definition.subjectType,
+          subjectId: definition.subjectId,
+        },
+        expectedUpdatedAt: definition.updatedAt,
+      },
     );
     await this.ctx.recordAudit(
       "definition_deleted",

--- a/plugins/plugin-personal-assistant/src/lifeops/repository.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository.ts
@@ -306,6 +306,24 @@ function isoNow(): string {
   return new Date().toISOString();
 }
 
+/**
+ * Owner-identity scope for definition reads and mutations. When supplied,
+ * every predicate binds `subject_type + subject_id` alongside `agent_id` so
+ * one subject can never read or mutate another subject's definitions under
+ * the same agent.
+ */
+export type LifeOpsDefinitionScope = {
+  subjectType: LifeOpsTaskDefinition["subjectType"];
+  subjectId: string;
+};
+
+function definitionScopePredicate(scope?: LifeOpsDefinitionScope): string {
+  if (!scope) return "";
+  return `
+          AND subject_type = ${sqlQuote(scope.subjectType)}
+          AND subject_id = ${sqlQuote(scope.subjectId)}`;
+}
+
 function parseOwnershipFields(row: Record<string, unknown>) {
   const subjectType =
     toText(row.subject_type, "owner") === "agent" ? "agent" : "owner";
@@ -2952,8 +2970,24 @@ export class LifeOpsRepository {
     );
   }
 
-  async updateDefinition(definition: LifeOpsTaskDefinition): Promise<void> {
-    await executeRawSql(
+  /**
+   * Persist a definition mutation. The predicate binds the row to the
+   * definition's own subject identity so a write can never land on another
+   * subject's record, and an optional `expectedUpdatedAt` turns the write
+   * into an optimistic-concurrency mutation: when the stored revision has
+   * moved (or the row is gone / owned by another subject) exactly zero rows
+   * match and a typed `LIFEOPS_DEFINITION_CONFLICT` error is thrown for the
+   * caller to re-resolve.
+   */
+  async updateDefinition(
+    definition: LifeOpsTaskDefinition,
+    options?: { expectedUpdatedAt?: string },
+  ): Promise<void> {
+    const revisionPredicate = options?.expectedUpdatedAt
+      ? `
+         AND updated_at = ${sqlQuote(options.expectedUpdatedAt)}`
+      : "";
+    const rows = await executeRawSql(
       this.runtime,
       `UPDATE app_lifeops.life_task_definitions
          SET domain = ${sqlQuote(definition.domain)},
@@ -2981,32 +3015,53 @@ export class LifeOpsRepository {
              metadata_json = ${sqlJson(definition.metadata)},
              updated_at = ${sqlQuote(definition.updatedAt)}
        WHERE id = ${sqlQuote(definition.id)}
-         AND agent_id = ${sqlQuote(definition.agentId)}`,
+         AND agent_id = ${sqlQuote(definition.agentId)}
+         AND subject_type = ${sqlQuote(definition.subjectType)}
+         AND subject_id = ${sqlQuote(definition.subjectId)}${revisionPredicate}
+       RETURNING id`,
     );
+    if (rows.length !== 1) {
+      throw new ElizaError(
+        "[LifeOpsRepository] definition update matched no row for this subject and revision",
+        {
+          code: "LIFEOPS_DEFINITION_CONFLICT",
+          context: {
+            definitionId: definition.id,
+            agentId: definition.agentId,
+            subjectType: definition.subjectType,
+            expectedUpdatedAt: options?.expectedUpdatedAt ?? null,
+          },
+        },
+      );
+    }
   }
 
   async getDefinition(
     agentId: string,
     definitionId: string,
+    scope?: LifeOpsDefinitionScope,
   ): Promise<LifeOpsTaskDefinition | null> {
     const rows = await executeRawSql(
       this.runtime,
       `SELECT *
          FROM app_lifeops.life_task_definitions
         WHERE agent_id = ${sqlQuote(agentId)}
-          AND id = ${sqlQuote(definitionId)}
+          AND id = ${sqlQuote(definitionId)}${definitionScopePredicate(scope)}
         LIMIT 1`,
     );
     const row = rows[0];
     return row ? parseTaskDefinition(row) : null;
   }
 
-  async listDefinitions(agentId: string): Promise<LifeOpsTaskDefinition[]> {
+  async listDefinitions(
+    agentId: string,
+    scope?: LifeOpsDefinitionScope,
+  ): Promise<LifeOpsTaskDefinition[]> {
     const rows = await executeRawSql(
       this.runtime,
       `SELECT *
          FROM app_lifeops.life_task_definitions
-        WHERE agent_id = ${sqlQuote(agentId)}
+        WHERE agent_id = ${sqlQuote(agentId)}${definitionScopePredicate(scope)}
         ORDER BY created_at ASC`,
     );
     return rows.map(parseTaskDefinition);
@@ -3014,19 +3069,60 @@ export class LifeOpsRepository {
 
   async listActiveDefinitions(
     agentId: string,
+    scope?: LifeOpsDefinitionScope,
   ): Promise<LifeOpsTaskDefinition[]> {
     const rows = await executeRawSql(
       this.runtime,
       `SELECT *
          FROM app_lifeops.life_task_definitions
         WHERE agent_id = ${sqlQuote(agentId)}
-          AND status = 'active'
+          AND status = 'active'${definitionScopePredicate(scope)}
         ORDER BY created_at ASC`,
     );
     return rows.map(parseTaskDefinition);
   }
 
-  async deleteDefinition(agentId: string, definitionId: string): Promise<void> {
+  /**
+   * Destructive removal of a definition and its dependents. The definition
+   * row is deleted first under the subject-scope and optional revision
+   * predicates; when it does not match exactly one row the whole operation
+   * aborts with a typed `LIFEOPS_DEFINITION_CONFLICT` before any dependent
+   * (reminder plans, goal links, occurrences) is touched, so a stale or
+   * cross-subject delete can never cascade.
+   */
+  async deleteDefinition(
+    agentId: string,
+    definitionId: string,
+    options?: {
+      scope?: LifeOpsDefinitionScope;
+      expectedUpdatedAt?: string;
+    },
+  ): Promise<void> {
+    const revisionPredicate = options?.expectedUpdatedAt
+      ? `
+          AND updated_at = ${sqlQuote(options.expectedUpdatedAt)}`
+      : "";
+    const deleted = await executeRawSql(
+      this.runtime,
+      `DELETE FROM app_lifeops.life_task_definitions
+        WHERE agent_id = ${sqlQuote(agentId)}
+          AND id = ${sqlQuote(definitionId)}${definitionScopePredicate(options?.scope)}${revisionPredicate}
+        RETURNING id`,
+    );
+    if (deleted.length !== 1) {
+      throw new ElizaError(
+        "[LifeOpsRepository] definition delete matched no row for this subject and revision",
+        {
+          code: "LIFEOPS_DEFINITION_CONFLICT",
+          context: {
+            definitionId,
+            agentId,
+            subjectType: options?.scope?.subjectType ?? null,
+            expectedUpdatedAt: options?.expectedUpdatedAt ?? null,
+          },
+        },
+      );
+    }
     await executeRawSql(
       this.runtime,
       `DELETE FROM app_reminders.life_reminder_plans
@@ -3046,12 +3142,6 @@ export class LifeOpsRepository {
       `DELETE FROM app_lifeops.life_task_occurrences
         WHERE agent_id = ${sqlQuote(agentId)}
           AND definition_id = ${sqlQuote(definitionId)}`,
-    );
-    await executeRawSql(
-      this.runtime,
-      `DELETE FROM app_lifeops.life_task_definitions
-        WHERE agent_id = ${sqlQuote(agentId)}
-          AND id = ${sqlQuote(definitionId)}`,
     );
   }
 


### PR DESCRIPTION
## Summary

Fixes #17398 — LifeOps definition delete/update were scoped only by `agent_id + id`, so one subject could read, retarget, or destroy another subject's definitions under the same agent, and no mutation carried a revision predicate.

### Persistence boundary (`plugins/plugin-personal-assistant/src/lifeops/repository.ts`)
- `getDefinition` / `listDefinitions` / `listActiveDefinitions` accept a `LifeOpsDefinitionScope` (`subjectType + subjectId`) that binds `subject_type + subject_id` alongside `agent_id`.
- `updateDefinition` always pins the row to the definition's own subject identity, supports an optional `expectedUpdatedAt` optimistic-concurrency predicate, uses `RETURNING id`, and throws a typed `ElizaError` (`LIFEOPS_DEFINITION_CONFLICT`) unless exactly one row matched.
- `deleteDefinition` deletes the definition row first under subject-scope + revision predicates with `RETURNING id`; zero rows aborts with `LIFEOPS_DEFINITION_CONFLICT` before any dependent (reminder plans, goal links, occurrences) is touched, so a stale or cross-subject delete can never cascade.

### Service layer (`src/lifeops/domains/definitions-service.ts`)
- `updateDefinition` passes `expectedUpdatedAt: current.definition.updatedAt` on the first write-back so a concurrent mutation/delete surfaces as a typed conflict for re-resolution.
- `deleteDefinition` reports a definition owned by a foreign subject as absent (404) and executes the destructive delete bound to the verified subject + revision.

### Chat-side nomination (`src/actions/life.ts`)
- All fuzzy/title/intent resolvers and duplicate/review listings go through `listCallerDefinitions`, which only nominates definitions whose subject is this runtime's own agent or configured owner entity — planner text can only nominate, and mutations only execute from, the caller's own definitions (immutable selected ID).

Deferred per issue scope: durable operation ledger and timezone-policy items.

## Tests
- New real-PGlite coverage `src/lifeops/definition-owner-scope.pglite.integration.test.ts` (two owners under one agent): cross-owner list/get denial, cross-owner update/delete denial, duplicate titles across owners, stale-revision conflict, concurrent update/delete conflict — **6 passed** (`vitest --config vitest.src-integration.config.ts`).
- Affected unit suites: `life.delete-name-guard`, `life.review-definitions`, `life-reminder-datetime`, `definitions-service.unscheduled`, `engine.unscheduled`, `test/repository-domain-crud` — **154 passed**.
- `bun run --cwd plugins/plugin-personal-assistant typecheck` — clean.
- Biome check on all touched files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
