### PR TITLE
feat(cloud): sanctioned state-loss override for persistently failing pre-stop captures

### DIFF
--- a/packages/cloud/api/v1/agents/[agentId]/restart/route.test.ts
+++ b/packages/cloud/api/v1/agents/[agentId]/restart/route.test.ts
@@ -20,10 +20,18 @@ const getAgentForWrite = mock(async () => ({
   organization_id: "agent-org",
   status: "running",
 }));
-const enqueueAgentRestartOnce = mock(async () => ({
-  jobId: "restart-job-1",
-  deduped: false,
-}));
+const enqueueAgentRestartOnce = mock(
+  async (): Promise<{
+    job: {
+      id: string;
+      data: { agentId: string; stateLossAcknowledged?: boolean };
+    };
+    created: boolean;
+  }> => ({
+    job: { id: "restart-job-1", data: { agentId: "cloud-agent-1" } },
+    created: true,
+  }),
+);
 const reactivateSandboxBillingAfterFunding = mock(async () => undefined);
 const checkAgentCreditGate = mock(async () => ({
   allowed: false,
@@ -96,6 +104,10 @@ describe("service agent restart route", () => {
       status: "running",
     });
     enqueueAgentRestartOnce.mockClear();
+    enqueueAgentRestartOnce.mockResolvedValue({
+      job: { id: "restart-job-1", data: { agentId: "cloud-agent-1" } },
+      created: true,
+    });
     reactivateSandboxBillingAfterFunding.mockClear();
     checkAgentCreditGate.mockClear();
     checkAgentCreditGate.mockResolvedValue({
@@ -160,11 +172,145 @@ describe("service agent restart route", () => {
       agentId: "cloud-agent-1",
       organizationId: "agent-org",
       userId: "agent-user",
+      stateLossAcknowledged: false,
     });
     expect(reactivateSandboxBillingAfterFunding).toHaveBeenCalledWith(
       "cloud-agent-1",
       expect.any(Date),
     );
+  });
+
+  test("threads an explicit state-loss waiver into the restart job (#18228)", async () => {
+    checkAgentCreditGate.mockResolvedValueOnce({
+      allowed: true,
+      balance: 5,
+      error: "",
+    });
+    enqueueAgentRestartOnce.mockResolvedValueOnce({
+      job: {
+        id: "restart-job-1",
+        data: { agentId: "cloud-agent-1", stateLossAcknowledged: true },
+      },
+      created: true,
+    });
+
+    const response = await app.fetch(
+      new Request(
+        "https://api.example.test/api/v1/agents/cloud-agent-1/restart",
+        {
+          method: "POST",
+          headers: {
+            "X-Service-Key": "svc",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ stateLossAcknowledged: true }),
+        },
+      ),
+      { WAIFU_SERVICE_KEY: "svc" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(enqueueAgentRestartOnce).toHaveBeenCalledWith({
+      agentId: "cloud-agent-1",
+      organizationId: "agent-org",
+      userId: "agent-user",
+      stateLossAcknowledged: true,
+    });
+  });
+
+  test("treats a non-literal-true waiver value as absent", async () => {
+    checkAgentCreditGate.mockResolvedValueOnce({
+      allowed: true,
+      balance: 5,
+      error: "",
+    });
+
+    const response = await app.fetch(
+      new Request(
+        "https://api.example.test/api/v1/agents/cloud-agent-1/restart",
+        {
+          method: "POST",
+          headers: {
+            "X-Service-Key": "svc",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ stateLossAcknowledged: "true" }),
+        },
+      ),
+      { WAIFU_SERVICE_KEY: "svc" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(enqueueAgentRestartOnce).toHaveBeenCalledWith(
+      expect.objectContaining({ stateLossAcknowledged: false }),
+    );
+  });
+
+  test("refuses to silently drop the waiver when a non-waived restart is already in flight", async () => {
+    checkAgentCreditGate.mockResolvedValueOnce({
+      allowed: true,
+      balance: 5,
+      error: "",
+    });
+    enqueueAgentRestartOnce.mockResolvedValueOnce({
+      job: { id: "restart-job-1", data: { agentId: "cloud-agent-1" } },
+      created: false,
+    });
+
+    const response = await app.fetch(
+      new Request(
+        "https://api.example.test/api/v1/agents/cloud-agent-1/restart",
+        {
+          method: "POST",
+          headers: {
+            "X-Service-Key": "svc",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ stateLossAcknowledged: true }),
+        },
+      ),
+      { WAIFU_SERVICE_KEY: "svc" },
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      jobId: "restart-job-1",
+    });
+    expect(reactivateSandboxBillingAfterFunding).not.toHaveBeenCalled();
+  });
+
+  test("accepts a waived request that dedupes onto an in-flight job already carrying the waiver", async () => {
+    checkAgentCreditGate.mockResolvedValueOnce({
+      allowed: true,
+      balance: 5,
+      error: "",
+    });
+    enqueueAgentRestartOnce.mockResolvedValueOnce({
+      job: {
+        id: "restart-job-1",
+        data: { agentId: "cloud-agent-1", stateLossAcknowledged: true },
+      },
+      created: false,
+    });
+
+    const response = await app.fetch(
+      new Request(
+        "https://api.example.test/api/v1/agents/cloud-agent-1/restart",
+        {
+          method: "POST",
+          headers: {
+            "X-Service-Key": "svc",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ stateLossAcknowledged: true }),
+        },
+      ),
+      { WAIFU_SERVICE_KEY: "svc" },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ success: true });
   });
 
   test("rejects a restart while the agent is still provisioning", async () => {

--- a/packages/cloud/api/v1/agents/[agentId]/restart/route.ts
+++ b/packages/cloud/api/v1/agents/[agentId]/restart/route.ts
@@ -9,6 +9,13 @@
  * Replaces the Worker-side `shutdown()` + `provision()` sequence which
  * silently skipped the stop from CF Workers (no SSH) and could leave
  * the old container running alongside the new one.
+ *
+ * Optional JSON body `{ "stateLossAcknowledged": true }` (#18228) is the
+ * sanctioned operator override for an agent whose pre-stop snapshot capture
+ * or transfer persistently fails: the daemon proceeds to stop without a
+ * capture, explicitly discarding state since the last durable backup. The
+ * waiver is refused (409) rather than silently dropped when a non-waived
+ * restart job is already in flight.
  */
 
 import { Hono } from "hono";
@@ -49,7 +56,29 @@ app.post("/", async (c) => {
       );
     }
 
-    logger.info("[service-api] Restart requested", { agentId });
+    // Optional operator waiver (#18228): `{ "stateLossAcknowledged": true }`
+    // lets the restart proceed when the pre-stop capture persistently fails,
+    // explicitly discarding state since the last durable backup. Anything
+    // other than the literal `true` is treated as absent — the waiver must be
+    // deliberate, never inferred from a malformed body.
+    let stateLossAcknowledged = false;
+    try {
+      const body = (await c.req.json()) as { stateLossAcknowledged?: unknown };
+      stateLossAcknowledged = body?.stateLossAcknowledged === true;
+    } catch {
+      // error-policy:J3 an absent or non-JSON body is the ordinary no-waiver
+      // request, not an error.
+      stateLossAcknowledged = false;
+    }
+
+    if (stateLossAcknowledged) {
+      logger.warn(
+        "[service-api] Restart requested WITH state-loss acknowledgment: pre-stop capture failure will be waived",
+        { agentId },
+      );
+    } else {
+      logger.info("[service-api] Restart requested", { agentId });
+    }
 
     const writableAgent = await elizaSandboxService.getAgentForWrite(
       agentId,
@@ -66,11 +95,35 @@ app.post("/", async (c) => {
       );
     }
 
-    await provisioningJobService.enqueueAgentRestartOnce({
+    const enqueue = await provisioningJobService.enqueueAgentRestartOnce({
       agentId,
       organizationId: agent.organization_id,
       userId: agent.user_id,
+      stateLossAcknowledged,
     });
+
+    const existingJobCarriesWaiver =
+      (enqueue.job.data as { stateLossAcknowledged?: unknown } | null)
+        ?.stateLossAcknowledged === true;
+    if (
+      stateLossAcknowledged &&
+      !enqueue.created &&
+      !existingJobCarriesWaiver
+    ) {
+      // The waiver must never be silently dropped: an already-queued restart
+      // job carries its own (non-waived) data, so tell the operator to retry
+      // once that job settles instead of pretending the forced restart is
+      // queued.
+      return c.json(
+        {
+          success: false,
+          error:
+            "A restart job is already in flight without the state-loss waiver; wait for it to settle and retry.",
+          jobId: enqueue.job.id,
+        },
+        409,
+      );
+    }
 
     await agentBillingRepository.reactivateSandboxBillingAfterFunding(
       agentId,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -1723,6 +1723,159 @@ describe("ElizaSandboxService shutdown fails closed without a current capture (#
   });
 });
 
+describe("ElizaSandboxService shutdown state-loss-acknowledged override (#18228)", () => {
+  function makeProvider(): SandboxProvider {
+    return {
+      create: mock(async () => {
+        throw new Error("must not create");
+      }),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
+      stopForReplacement: mock(async () => {}),
+      checkHealth: mock(async () => true),
+    };
+  }
+
+  test("a transfer-hop 500 refusal carries the hop's body, distinguishable from an agent-side capture failure", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const rec = customSandbox();
+    const provider = makeProvider();
+    const svc = new ElizaSandboxService(provider);
+    const getForWrite = spyOn(
+      svc as unknown as { getAgentForWrite: () => Promise<unknown> },
+      "getAgentForWrite",
+    ).mockResolvedValue(rec);
+    // Proxy-hop failure: the agent captured successfully (its handler never
+    // ran this response), and the intermediate hop answered with its own
+    // error page. The refusal must surface that page so the operator can
+    // tell this apart from "agent cannot snapshot".
+    const fetchApi = spyOn(
+      svc as unknown as { fetchAgentApi: () => Promise<Response> },
+      "fetchAgentApi",
+    ).mockImplementation(
+      async () =>
+        new Response("upstream connect error or disconnect before headers", { status: 500 }),
+    );
+    try {
+      const hopResult = await svc.shutdown(rec.id, rec.organization_id);
+      expect(hopResult.success).toBe(false);
+      expect(hopResult.error).toContain("Snapshot fetch failed: HTTP 500");
+      expect(hopResult.error).toContain("upstream connect error");
+
+      // Agent-side failure: the agent's own handler returned its thrown
+      // message. Same status, different diagnostic body.
+      fetchApi.mockImplementation(
+        async () =>
+          new Response('{"error":"Snapshot failed: pglite dump write error"}', { status: 500 }),
+      );
+      const agentResult = await svc.shutdown(rec.id, rec.organization_id);
+      expect(agentResult.success).toBe(false);
+      expect(agentResult.error).toContain("Snapshot fetch failed: HTTP 500");
+      expect(agentResult.error).toContain("pglite dump write error");
+
+      expect(provider.stopForReplacement).not.toHaveBeenCalled();
+    } finally {
+      getForWrite.mockRestore();
+      fetchApi.mockRestore();
+    }
+  });
+
+  test("stateLossAcknowledged proceeds to stop without a capture and reports the waiver", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const rec = customSandbox();
+    const provider = makeProvider();
+    const svc = new ElizaSandboxService(provider);
+    const getForWrite = spyOn(
+      svc as unknown as { getAgentForWrite: () => Promise<unknown> },
+      "getAgentForWrite",
+    ).mockResolvedValue(rec);
+    const fetchApi = spyOn(
+      svc as unknown as { fetchAgentApi: () => Promise<Response> },
+      "fetchAgentApi",
+    ).mockImplementation(
+      async () =>
+        new Response("upstream connect error or disconnect before headers", { status: 500 }),
+    );
+    const lockLifecycle = spyOn(
+      svc as unknown as { lockLifecycle: () => Promise<void> },
+      "lockLifecycle",
+    ).mockResolvedValue(undefined);
+    const getForMutation = spyOn(
+      svc as unknown as { getAgentForLifecycleMutation: () => Promise<unknown> },
+      "getAgentForLifecycleMutation",
+    ).mockResolvedValue(rec);
+    const activeProvision = spyOn(
+      svc as unknown as { hasActiveProvisionJobTx: () => Promise<boolean> },
+      "hasActiveProvisionJobTx",
+    ).mockResolvedValue(false);
+    const persistSnapshot = spyOn(
+      svc as unknown as { persistSnapshotWithinTransaction: () => Promise<never> },
+      "persistSnapshotWithinTransaction",
+    );
+    const prune = spyOn(agentSandboxesRepository, "pruneBackups").mockResolvedValue(
+      undefined as never,
+    );
+    const writes: unknown[] = [];
+    upgradeTransactionImpl = async (fn) =>
+      fn({
+        execute: async (query) => {
+          writes.push(query);
+          return { rows: [] };
+        },
+      });
+    try {
+      const result = await svc.shutdown(rec.id, rec.organization_id, {
+        stateLossAcknowledged: true,
+      });
+      expect(result).toEqual({ success: true, stateLossAcknowledged: true });
+      // The stop really happened; the capture was skipped, never persisted.
+      expect(provider.stopForReplacement).toHaveBeenCalledWith(rec.sandbox_id);
+      expect(persistSnapshot).not.toHaveBeenCalled();
+      expect(writes).toHaveLength(1);
+    } finally {
+      upgradeTransactionImpl = null;
+      getForWrite.mockRestore();
+      fetchApi.mockRestore();
+      lockLifecycle.mockRestore();
+      getForMutation.mockRestore();
+      activeProvision.mockRestore();
+      persistSnapshot.mockRestore();
+      prune.mockRestore();
+    }
+  });
+
+  test("executeRestart threads the waiver into shutdown", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const rec = customSandbox();
+    const svc = new ElizaSandboxService(makeProvider());
+    const getForWrite = spyOn(
+      svc as unknown as { getAgentForWrite: () => Promise<unknown> },
+      "getAgentForWrite",
+    ).mockResolvedValue(rec);
+    const shutdownSpy = spyOn(svc, "shutdown").mockResolvedValue({
+      success: true,
+      stateLossAcknowledged: true,
+    });
+    const provisionSpy = spyOn(svc, "provision").mockResolvedValue({
+      success: true,
+      bridgeUrl: "https://bridge.example",
+      healthUrl: "https://bridge.example/health",
+    } as never);
+    try {
+      const res = await svc.executeRestart(rec.id, rec.organization_id, {
+        stateLossAcknowledged: true,
+      });
+      expect(res.success).toBe(true);
+      expect(shutdownSpy).toHaveBeenCalledWith(rec.id, rec.organization_id, {
+        stateLossAcknowledged: true,
+      });
+    } finally {
+      getForWrite.mockRestore();
+      shutdownSpy.mockRestore();
+      provisionSpy.mockRestore();
+    }
+  });
+});
+
 describe("ElizaSandboxService sleep refuses an unproven fallback backup (#17180 §3)", () => {
   test("capture failed and the latest stored backup cannot be verified — sleep aborts", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -8036,12 +8036,28 @@ export class ElizaSandboxService {
 
   // Shutdown
 
+  /**
+   * Stops the agent's container and flips the row to `stopped`, capturing a
+   * pre-stop snapshot first. Fail-closed by default: a capture failure leaves
+   * the agent running and returns an explicit refusal. The sole sanctioned
+   * bypass is `options.stateLossAcknowledged` (#18228) — an operator's
+   * explicit acceptance that state since the last durable backup is discarded
+   * — which proceeds to stop without a capture, loudly, and reports
+   * `stateLossAcknowledged: true` in the result. It is never implied.
+   */
   async shutdown(
     agentId: string,
     orgId: string,
-  ): Promise<{ success: boolean; error?: string; retryable?: boolean }> {
+    options?: { readonly stateLossAcknowledged?: boolean },
+  ): Promise<{
+    success: boolean;
+    error?: string;
+    retryable?: boolean;
+    stateLossAcknowledged?: boolean;
+  }> {
     let snapshotAgentId: string | null = null;
     let captureUnsupported = false;
+    let captureWaivedByOperator = false;
     let preShutdownSnapshot: {
       stateData: AgentBackupStateData;
       sizeBytes: number;
@@ -8063,6 +8079,17 @@ export class ElizaSandboxService {
           logger.warn(
             "[agent-sandbox] Shutdown proceeding without capture: image has no snapshot endpoint",
             { agentId },
+          );
+        } else if (options?.stateLossAcknowledged) {
+          // Sanctioned operator override (#18228): a persistent capture or
+          // transfer-hop failure otherwise makes the agent unstoppable through
+          // every safe path. The operator explicitly acknowledged the state
+          // loss, so proceed to stop WITHOUT a capture — never silently: the
+          // waiver is logged here and reported in the result.
+          captureWaivedByOperator = true;
+          logger.error(
+            "[agent-sandbox] Shutdown proceeding WITHOUT pre-stop capture: operator acknowledged state loss",
+            { agentId, captureError: message },
           );
         } else if (message === SNAPSHOT_CAPTURE_TRANSIENT) {
           // TRANSIENT (PGlite closing race): do NOT weaken the fail-closed
@@ -8138,7 +8165,12 @@ export class ElizaSandboxService {
         } as const;
       }
 
-      if (rec.status === "running" && rec.bridge_url && !captureUnsupported) {
+      if (
+        rec.status === "running" &&
+        rec.bridge_url &&
+        !captureUnsupported &&
+        !captureWaivedByOperator
+      ) {
         // The capture must be OF THIS generation. A capture taken against a
         // different bridge_url (the row moved between the unlocked fetch and
         // this locked read) is some other container's state; persisting it
@@ -8189,6 +8221,9 @@ export class ElizaSandboxService {
       `);
 
       snapshotAgentId = rec.id;
+      if (captureWaivedByOperator) {
+        return { success: true, stateLossAcknowledged: true } as const;
+      }
       return { success: true } as const;
     });
 
@@ -8199,7 +8234,10 @@ export class ElizaSandboxService {
           error: error instanceof Error ? error.message : String(error),
         });
       });
-      logger.info("[agent-sandbox] Shutdown complete", { agentId });
+      logger.info("[agent-sandbox] Shutdown complete", {
+        agentId,
+        stateLossAcknowledged: captureWaivedByOperator || undefined,
+      });
     }
 
     return result;
@@ -8678,6 +8716,7 @@ export class ElizaSandboxService {
   async executeRestart(
     agentId: string,
     orgId: string,
+    options?: { readonly stateLossAcknowledged?: boolean },
   ): Promise<{
     success: boolean;
     containerStopped: boolean;
@@ -8706,7 +8745,9 @@ export class ElizaSandboxService {
       await this.prepareLegacyWarmClaimCredentialRecovery(agentId, orgId);
     }
 
-    const shutdownResult = await this.shutdown(agentId, orgId);
+    const shutdownResult = await this.shutdown(agentId, orgId, {
+      stateLossAcknowledged: options?.stateLossAcknowledged,
+    });
     if (!shutdownResult.success) {
       return {
         success: false,

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -201,6 +201,12 @@ export interface AgentRestartJobData {
   agentId: string;
   organizationId: string;
   userId: string;
+  /**
+   * Operator-acknowledged state loss (#18228): the pre-stop capture is waived
+   * when it fails, so the restart can free an agent whose snapshot transfer
+   * persistently fails. Never set by default; requires an explicit request.
+   */
+  stateLossAcknowledged?: boolean;
 }
 
 export interface AgentUpgradeJobData {
@@ -607,12 +613,15 @@ function readAgentWakeJobData(job: Job): AgentWakeJobData {
 }
 
 function isAgentRestartJobData(value: unknown): value is AgentRestartJobData {
+  const stateLossAcknowledged = (value as { stateLossAcknowledged?: unknown })
+    ?.stateLossAcknowledged;
   return (
     typeof value === "object" &&
     value !== null &&
     typeof (value as { agentId?: unknown }).agentId === "string" &&
     typeof (value as { organizationId?: unknown }).organizationId === "string" &&
-    typeof (value as { userId?: unknown }).userId === "string"
+    typeof (value as { userId?: unknown }).userId === "string" &&
+    (stateLossAcknowledged === undefined || typeof stateLossAcknowledged === "boolean")
   );
 }
 
@@ -2000,6 +2009,8 @@ export class ProvisioningJobService {
     organizationId: string;
     userId: string;
     webhookUrl?: string;
+    /** Operator waiver for a persistently failing pre-stop capture (#18228). */
+    stateLossAcknowledged?: boolean;
   }): Promise<EnqueueAgentRestartResult> {
     return this.enqueueLifecycleJob<AgentRestartJobData>({
       jobType: JOB_TYPES.AGENT_RESTART,
@@ -2007,6 +2018,7 @@ export class ProvisioningJobService {
         agentId: params.agentId,
         organizationId: params.organizationId,
         userId: params.userId,
+        ...(params.stateLossAcknowledged ? { stateLossAcknowledged: true } : {}),
       },
       toRecord: agentRestartJobDataToRecord,
       agentId: params.agentId,
@@ -4202,10 +4214,13 @@ export class ProvisioningJobService {
     logger.info("[provisioning-jobs] Executing agent_restart", {
       jobId: job.id,
       agentId: data.agentId,
+      stateLossAcknowledged: data.stateLossAcknowledged || undefined,
     });
 
     await this.assertExecutionMutationLease(job);
-    const result = await elizaSandboxService.executeRestart(data.agentId, data.organizationId);
+    const result = await elizaSandboxService.executeRestart(data.agentId, data.organizationId, {
+      stateLossAcknowledged: data.stateLossAcknowledged,
+    });
 
     if (await this.completeIfAgentGone(job, result, data.agentId)) return;
 


### PR DESCRIPTION
Refs #18228 (leaves the issue open for staging real-path evidence per the triage note)

Completes the two code-side acceptance items that remained after the merged transfer hardening (#19080 agent-side streamed snapshot responses with backpressure, #16639 bounded Worker-side hydration via `readBodyWithinBudget`, and the bounded upstream error-body excerpt already in `fetchSnapshotState`):

## Sanctioned operator override (never a silent bypass)

- `POST /api/v1/agents/:agentId/restart` accepts an optional JSON body `{ "stateLossAcknowledged": true }`. Only the literal `true` is honored; a malformed body or any other value is the ordinary no-waiver request.
- The waiver rides typed `AgentRestartJobData` through `enqueueAgentRestartOnce` → `executeRestart` → `shutdown`. With the waiver, a failed pre-stop capture no longer wedges the agent: the stop proceeds WITHOUT a capture, is logged at error level with the capture failure attached, and the result reports `stateLossAcknowledged: true`.
- If a waived request would dedupe onto an already-queued restart job that does not carry the waiver, the route answers 409 with the in-flight job id rather than pretending the forced restart is queued.
- The default path is untouched: without the waiver, shutdown still fails closed exactly as before.

## Regression: "capture succeeded, transfer hop failed" is distinguishable

New tests in `eliza-sandbox.test.ts` prove the refusal for a proxy-hop 500 carries the hop's error page (`upstream connect error…`) while an agent-side 500 carries the agent handler's thrown message — the combination the issue showed was previously indistinguishable — and that the waived path stops the container while never persisting a capture.

## Tests

- `packages/cloud/shared` `eliza-sandbox.test.ts` — 225 pass / 0 fail
- `packages/cloud` `api/v1/agents/[agentId]/restart/route.test.ts` — 7 pass / 0 fail (waiver threading, non-literal-true rejected, 409 on non-waived in-flight job, waived dedupe accepted; also repairs the stale `{jobId, deduped}` mock to the real `{job, created}` enqueue shape)
- `provisioning-jobs-lanes` + `provisioning-jobs-snapshot-gate` — 9 pass / 0 fail
- `tsc --noEmit` clean in `packages/cloud/shared` and `packages/cloud/api`; Biome clean on changed files

No rendered surface changed; visual evidence N/A. The remaining acceptance row on #18228 (staging lifecycle run capturing a multi-MB snapshot across the real agent → bridge → Worker path) needs staging access and stays on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)