### PR TITLE
feat(lifeops): Discord loopback OAuth one-click for the HITL credential dashboard

### DIFF
--- a/scripts/lifeops/connector-paths.mjs
+++ b/scripts/lifeops/connector-paths.mjs
@@ -70,6 +70,7 @@ export function resolveDeepLink(pathEntry, env = process.env) {
 const ONE_CLICK_TYPES = [
   "gh-token",
   "github-device",
+  "discord-oauth",
   "deep-link",
   "shell",
   "siwe",
@@ -399,9 +400,15 @@ export const CONNECTOR_PATHS = [
     kind: "user-oauth",
     label: "Discord user OAuth app",
     requiredAll: ["DISCORD_CLIENT_ID", "DISCORD_CLIENT_SECRET"],
+    optional: ["DISCORD_USER_OAUTH_TOKEN"],
     probeId: null,
     probeEndpoint:
       "POST https://discord.com/api/oauth2/token then GET /users/@me",
+    oneClick: {
+      type: "discord-oauth",
+      detail:
+        "Open Discord's authorization page over the dashboard's loopback redirect and save the identify-scoped user token without exposing it to the browser",
+    },
     availability: {
       type: "env-all",
       names: ["DISCORD_CLIENT_ID", "DISCORD_CLIENT_SECRET"],

--- a/scripts/lifeops/connector-paths.test.mjs
+++ b/scripts/lifeops/connector-paths.test.mjs
@@ -691,6 +691,21 @@ test("github device login is a designed owner-setup state until a client id exis
   assert.equal(configured.available, true);
 });
 
+test("discord user OAuth is a one-click loopback flow gated on owner setup", () => {
+  const path = byId("discord.user-oauth");
+  assert.equal(path.oneClick.type, "discord-oauth");
+  assert.ok(path.optional.includes("DISCORD_USER_OAUTH_TOKEN"));
+  const missing = checkAvailability(path.availability, fakeCtx());
+  assert.equal(missing.available, false);
+  const configured = checkAvailability(
+    path.availability,
+    fakeCtx({
+      env: { DISCORD_CLIENT_ID: "app-id", DISCORD_CLIENT_SECRET: "app-secret" },
+    }),
+  );
+  assert.equal(configured.available, true);
+});
+
 // --- evaluation output safety ---------------------------------------------------------
 
 test("evaluateConnectorPaths emits env names and reasons, never env values", () => {

--- a/scripts/lifeops/discord-oauth-login.mjs
+++ b/scripts/lifeops/discord-oauth-login.mjs
@@ -1,0 +1,234 @@
+/**
+ * Discord user-OAuth authorization-code flow state for the LifeOps credential
+ * dashboard (#14792). This is deliberately an HITL identity/probe path — the
+ * runtime connector's canonical product flow remains bot installation plus
+ * `/eliza-pair` — so the flow acquires a short-lived `identify`-scoped user
+ * token over the dashboard's own loopback redirect and nothing more.
+ *
+ * The browser receives only the authorize URL and an opaque local flow id;
+ * the CSRF state, client secret, and access token stay in server memory.
+ * The callback exchange runs server-side, the token is handed to the caller
+ * exactly once for persistence, and the completed flow retains only a masked
+ * tail plus the Discord username. Network access is injectable so protocol
+ * behavior is covered without contacting Discord in deterministic tests.
+ */
+import { randomBytes, timingSafeEqual } from "node:crypto";
+
+const AUTHORIZE_URL = "https://discord.com/oauth2/authorize";
+const TOKEN_URL = "https://discord.com/api/oauth2/token";
+const IDENTITY_URL = "https://discord.com/api/v10/users/@me";
+const DEFAULT_SCOPE = "identify";
+const FLOW_TTL_MS = 10 * 60 * 1_000;
+const pendingFlows = new Map();
+
+function stateMatches(candidate, expected) {
+  if (typeof candidate !== "string" || candidate.length === 0) return false;
+  const a = Buffer.from(candidate);
+  const b = Buffer.from(expected);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+function sweepExpired(nowMs) {
+  for (const [flowId, flow] of pendingFlows) {
+    if (nowMs >= flow.expiresAtMs) pendingFlows.delete(flowId);
+  }
+}
+
+function findFlowByState(state) {
+  for (const [flowId, flow] of pendingFlows) {
+    if (flow.status === "pending" && stateMatches(state, flow.state)) {
+      return { flowId, flow };
+    }
+  }
+  return null;
+}
+
+async function jsonResponse(response, label) {
+  let payload;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    // error-policy:J2 provider bodies are untrusted; unparseable JSON becomes a typed protocol error with cause.
+    throw new Error(`${label} returned invalid JSON`, { cause: error });
+  }
+  if (!response.ok) {
+    const providerError =
+      typeof payload?.error === "string" ? ` (${payload.error})` : "";
+    throw new Error(`${label} failed: HTTP ${response.status}${providerError}`);
+  }
+  return payload;
+}
+
+/**
+ * Registers a pending flow and builds the Discord authorize URL. Throws when
+ * the OAuth app registration is absent — the dashboard renders that as the
+ * designed needs-owner-setup state, never as a broken flow.
+ */
+export function startDiscordOAuthLogin({
+  clientId,
+  redirectUri,
+  target,
+  now = Date.now,
+  randomBytesFn = randomBytes,
+}) {
+  if (typeof clientId !== "string" || clientId.trim().length === 0) {
+    throw new Error(
+      "Discord user OAuth needs owner setup: DISCORD_CLIENT_ID is absent",
+    );
+  }
+  if (typeof redirectUri !== "string" || !redirectUri.startsWith("http")) {
+    throw new Error("Discord user OAuth requires a loopback redirect URI");
+  }
+  if (target !== "home" && target !== "repo") {
+    throw new Error('Discord user OAuth target must be "home" or "repo"');
+  }
+  const nowMs = now();
+  sweepExpired(nowMs);
+  const flowId = randomBytesFn(24).toString("base64url");
+  const state = randomBytesFn(24).toString("base64url");
+  pendingFlows.set(flowId, {
+    status: "pending",
+    clientId: clientId.trim(),
+    redirectUri,
+    state,
+    target,
+    expiresAtMs: nowMs + FLOW_TTL_MS,
+  });
+  const authorizeUrl = `${AUTHORIZE_URL}?${new URLSearchParams({
+    client_id: clientId.trim(),
+    response_type: "code",
+    redirect_uri: redirectUri,
+    scope: DEFAULT_SCOPE,
+    state,
+    prompt: "consent",
+  }).toString()}`;
+  return { flowId, authorizeUrl, redirectUri };
+}
+
+/**
+ * Handles the loopback callback leg: matches the CSRF state to a pending
+ * flow, exchanges the code server-side, and fetches the Discord identity.
+ * Returns `{ outcome: "complete", token, ... }` exactly once — the caller
+ * persists the token and reports back via {@link markDiscordFlowSaved} so the
+ * poll surface only ever sees masked data. A denial or protocol failure is a
+ * typed outcome on the flow, never a thrown-away error.
+ */
+export async function completeDiscordOAuthCallback({
+  state,
+  code,
+  providerError,
+  clientSecret,
+  fetchFn = fetch,
+  now = Date.now,
+}) {
+  sweepExpired(now());
+  const match = findFlowByState(state);
+  if (!match) {
+    return { outcome: "unknown-state" };
+  }
+  const { flow } = match;
+  if (typeof providerError === "string" && providerError.length > 0) {
+    flow.status = providerError === "access_denied" ? "denied" : "error";
+    flow.detail =
+      providerError === "access_denied"
+        ? "authorization was denied on Discord"
+        : `Discord returned error: ${providerError}`;
+    return { outcome: flow.status, detail: flow.detail };
+  }
+  if (typeof code !== "string" || code.length === 0) {
+    flow.status = "error";
+    flow.detail = "Discord callback carried no authorization code";
+    return { outcome: "error", detail: flow.detail };
+  }
+  if (typeof clientSecret !== "string" || clientSecret.trim().length === 0) {
+    flow.status = "error";
+    flow.detail = "DISCORD_CLIENT_SECRET is absent; cannot exchange the code";
+    return { outcome: "error", detail: flow.detail };
+  }
+  let token;
+  let identity;
+  try {
+    const tokenPayload = await jsonResponse(
+      await fetchFn(TOKEN_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          client_id: flow.clientId,
+          client_secret: clientSecret.trim(),
+          grant_type: "authorization_code",
+          code,
+          redirect_uri: flow.redirectUri,
+        }).toString(),
+      }),
+      "Discord token exchange",
+    );
+    if (
+      typeof tokenPayload.access_token !== "string" ||
+      tokenPayload.access_token.length === 0
+    ) {
+      throw new Error("Discord token exchange returned no access_token");
+    }
+    token = tokenPayload.access_token;
+    const identityPayload = await jsonResponse(
+      await fetchFn(IDENTITY_URL, {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      "Discord identity request",
+    );
+    identity =
+      typeof identityPayload.username === "string"
+        ? identityPayload.username
+        : "unknown";
+  } catch (error) {
+    // error-policy:J3 provider exchange failures become a typed flow outcome the poll surface renders; no fake-valid token exists.
+    flow.status = "error";
+    flow.detail = error instanceof Error ? error.message : String(error);
+    return { outcome: "error", detail: flow.detail };
+  }
+  flow.status = "exchanged";
+  flow.username = identity;
+  return {
+    outcome: "complete",
+    token,
+    username: identity,
+    target: flow.target,
+    flowId: match.flowId,
+  };
+}
+
+/** Records the post-persist masked result so polls never see the token. */
+export function markDiscordFlowSaved(flowId, { masked, key, target }) {
+  const flow = pendingFlows.get(flowId);
+  if (!flow) return;
+  flow.status = "complete";
+  flow.masked = masked;
+  flow.key = key;
+  flow.target = target;
+}
+
+/** Poll surface for the dashboard page; completed flows are single-read. */
+export function pollDiscordOAuthLogin({ flowId, now = Date.now }) {
+  sweepExpired(now());
+  const flow = pendingFlows.get(flowId);
+  if (!flow) {
+    return { status: "expired", detail: "flow is unknown or expired" };
+  }
+  if (flow.status === "pending" || flow.status === "exchanged") {
+    return { status: "pending", retryAfterSeconds: 2 };
+  }
+  pendingFlows.delete(flowId);
+  if (flow.status === "complete") {
+    return {
+      status: "complete",
+      key: flow.key,
+      masked: flow.masked,
+      target: flow.target,
+      username: flow.username,
+    };
+  }
+  return { status: flow.status, detail: flow.detail };
+}
+
+export function clearDiscordOAuthLoginsForTest() {
+  pendingFlows.clear();
+}

--- a/scripts/lifeops/discord-oauth-login.test.mjs
+++ b/scripts/lifeops/discord-oauth-login.test.mjs
@@ -1,0 +1,181 @@
+/** Discord loopback OAuth protocol tests use injected responses and no network. */
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  clearDiscordOAuthLoginsForTest,
+  completeDiscordOAuthCallback,
+  markDiscordFlowSaved,
+  pollDiscordOAuthLogin,
+  startDiscordOAuthLogin,
+} from "./discord-oauth-login.mjs";
+
+function response(payload, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+test.afterEach(() => clearDiscordOAuthLoginsForTest());
+
+const REDIRECT = "http://127.0.0.1:43117/oauth/discord/callback";
+
+function start(overrides = {}) {
+  return startDiscordOAuthLogin({
+    clientId: "client-123",
+    redirectUri: REDIRECT,
+    target: "home",
+    ...overrides,
+  });
+}
+
+function extractState(authorizeUrl) {
+  return new URL(authorizeUrl).searchParams.get("state");
+}
+
+test("start requires owner setup and a loopback redirect", () => {
+  assert.throws(() => start({ clientId: "" }), /needs owner setup/);
+  assert.throws(() => start({ redirectUri: "not-a-url" }), /redirect URI/);
+  assert.throws(() => start({ target: "elsewhere" }), /target must be/);
+});
+
+test("start builds an identify-scoped authorize URL with CSRF state", () => {
+  const flow = start();
+  const url = new URL(flow.authorizeUrl);
+  assert.equal(
+    url.origin + url.pathname,
+    "https://discord.com/oauth2/authorize",
+  );
+  assert.equal(url.searchParams.get("client_id"), "client-123");
+  assert.equal(url.searchParams.get("response_type"), "code");
+  assert.equal(url.searchParams.get("redirect_uri"), REDIRECT);
+  assert.equal(url.searchParams.get("scope"), "identify");
+  assert.ok((url.searchParams.get("state") ?? "").length >= 24);
+  assert.equal(flow.redirectUri, REDIRECT);
+});
+
+test("callback exchanges the code server-side and hands the token over once", async () => {
+  const flow = start();
+  const calls = [];
+  const result = await completeDiscordOAuthCallback({
+    state: extractState(flow.authorizeUrl),
+    code: "auth-code-1",
+    clientSecret: "secret-1",
+    fetchFn: async (url, init) => {
+      calls.push({ url, init });
+      if (url === "https://discord.com/api/oauth2/token") {
+        const body = new URLSearchParams(init.body);
+        assert.equal(body.get("grant_type"), "authorization_code");
+        assert.equal(body.get("code"), "auth-code-1");
+        assert.equal(body.get("client_secret"), "secret-1");
+        assert.equal(body.get("redirect_uri"), REDIRECT);
+        return response({ access_token: "user-token-xyz" });
+      }
+      assert.equal(url, "https://discord.com/api/v10/users/@me");
+      assert.equal(init.headers.Authorization, "Bearer user-token-xyz");
+      return response({ username: "shaw" });
+    },
+  });
+  assert.equal(result.outcome, "complete");
+  assert.equal(result.token, "user-token-xyz");
+  assert.equal(result.username, "shaw");
+  assert.equal(result.target, "home");
+  assert.equal(calls.length, 2);
+
+  // Until the caller reports the persisted result, polls stay pending and
+  // never expose the token.
+  const pending = pollDiscordOAuthLogin({ flowId: result.flowId });
+  assert.equal(pending.status, "pending");
+  assert.equal(JSON.stringify(pending).includes("user-token-xyz"), false);
+
+  markDiscordFlowSaved(result.flowId, {
+    masked: "…-wxyz",
+    key: "DISCORD_USER_OAUTH_TOKEN",
+    target: "home",
+  });
+  const complete = pollDiscordOAuthLogin({ flowId: result.flowId });
+  assert.equal(complete.status, "complete");
+  assert.equal(complete.masked, "…-wxyz");
+  assert.equal(complete.username, "shaw");
+  assert.equal(JSON.stringify(complete).includes("user-token-xyz"), false);
+  // Completed flows are single-read.
+  assert.equal(
+    pollDiscordOAuthLogin({ flowId: result.flowId }).status,
+    "expired",
+  );
+});
+
+test("a denial on Discord becomes a typed denied outcome", async () => {
+  const flow = start();
+  const result = await completeDiscordOAuthCallback({
+    state: extractState(flow.authorizeUrl),
+    code: "",
+    providerError: "access_denied",
+    clientSecret: "secret-1",
+    fetchFn: async () => {
+      throw new Error("network must not be touched on denial");
+    },
+  });
+  assert.equal(result.outcome, "denied");
+  const polled = pollDiscordOAuthLogin({ flowId: flow.flowId });
+  assert.equal(polled.status, "denied");
+  assert.match(polled.detail, /denied on Discord/);
+});
+
+test("an unknown or replayed state is rejected without touching the network", async () => {
+  start();
+  const result = await completeDiscordOAuthCallback({
+    state: "forged-state-value",
+    code: "auth-code",
+    clientSecret: "secret-1",
+    fetchFn: async () => {
+      throw new Error("network must not be touched for unknown state");
+    },
+  });
+  assert.equal(result.outcome, "unknown-state");
+});
+
+test("a failed exchange becomes a typed error outcome the poll reports", async () => {
+  const flow = start();
+  const result = await completeDiscordOAuthCallback({
+    state: extractState(flow.authorizeUrl),
+    code: "bad-code",
+    clientSecret: "secret-1",
+    fetchFn: async () => response({ error: "invalid_grant" }, 400),
+  });
+  assert.equal(result.outcome, "error");
+  assert.match(result.detail, /invalid_grant|HTTP 400/);
+  const polled = pollDiscordOAuthLogin({ flowId: flow.flowId });
+  assert.equal(polled.status, "error");
+  assert.match(polled.detail, /invalid_grant|HTTP 400/);
+});
+
+test("a missing client secret fails closed before any exchange", async () => {
+  const flow = start();
+  const result = await completeDiscordOAuthCallback({
+    state: extractState(flow.authorizeUrl),
+    code: "auth-code",
+    clientSecret: "",
+    fetchFn: async () => {
+      throw new Error("network must not be touched without a secret");
+    },
+  });
+  assert.equal(result.outcome, "error");
+  assert.match(result.detail, /DISCORD_CLIENT_SECRET/);
+});
+
+test("flows expire after their TTL", () => {
+  let nowMs = 1_000;
+  const flow = startDiscordOAuthLogin({
+    clientId: "client-123",
+    redirectUri: REDIRECT,
+    target: "repo",
+    now: () => nowMs,
+  });
+  nowMs += 10 * 60 * 1_000 + 1;
+  const polled = pollDiscordOAuthLogin({
+    flowId: flow.flowId,
+    now: () => nowMs,
+  });
+  assert.equal(polled.status, "expired");
+});

--- a/scripts/lifeops/hitl-credential-dashboard.mjs
+++ b/scripts/lifeops/hitl-credential-dashboard.mjs
@@ -23,7 +23,8 @@
  *
  * Secrets never leave the machine and are never echoed: responses carry
  * last-4 masks only, probe details are redacted upstream, and one-click
- * acquisitions (gh CLI token, headless SIWE cloud login, signal-cli link)
+ * acquisitions (gh CLI token, GitHub device flow, Discord loopback OAuth,
+ * headless SIWE cloud login, signal-cli link)
  * run server-side and save without rendering the credential. Zero
  * dependencies: node:http on 127.0.0.1, first free port from 43117, with
  * same-origin JSON POSTs bound to a per-process session token so another local
@@ -60,6 +61,12 @@ import {
   redactSecrets,
   registerRedactionEnv,
 } from "./credential-probes.mjs";
+import {
+  completeDiscordOAuthCallback,
+  markDiscordFlowSaved,
+  pollDiscordOAuthLogin,
+  startDiscordOAuthLogin,
+} from "./discord-oauth-login.mjs";
 import { HOME_ENV_PATH, loadLayeredEnv, writeSecret } from "./env-layers.mjs";
 import {
   pollGitHubDeviceLogin,
@@ -579,6 +586,78 @@ async function handleGitHubDevicePoll(body) {
   };
 }
 
+const DISCORD_CALLBACK_PATH = "/oauth/discord/callback";
+
+function handleDiscordOAuthStart(body) {
+  const target = parseTarget(body);
+  const layered = loadLayeredEnv();
+  const clientId = layered.values.DISCORD_CLIENT_ID;
+  const clientSecret = layered.values.DISCORD_CLIENT_SECRET;
+  if (
+    typeof clientId !== "string" ||
+    clientId.trim().length === 0 ||
+    typeof clientSecret !== "string" ||
+    clientSecret.trim().length === 0
+  ) {
+    throw new HttpError(
+      409,
+      "Discord user OAuth needs owner setup: DISCORD_CLIENT_ID/DISCORD_CLIENT_SECRET are absent (register a Discord app with this dashboard's loopback redirect URI)",
+    );
+  }
+  return startDiscordOAuthLogin({
+    clientId,
+    redirectUri: `${dashboardOrigin}${DISCORD_CALLBACK_PATH}`,
+    target,
+  });
+}
+
+// The callback leg arrives as a top-level browser navigation from Discord, so
+// it cannot carry the session token; the flow's single-use CSRF state is the
+// authenticator, and the response never contains the token — persistence
+// happens server-side and the dashboard tab polls for the masked result.
+async function handleDiscordOAuthCallback(url, res) {
+  const layered = loadLayeredEnv();
+  const result = await completeDiscordOAuthCallback({
+    state: url.searchParams.get("state") ?? "",
+    code: url.searchParams.get("code") ?? "",
+    providerError: url.searchParams.get("error") ?? "",
+    clientSecret: layered.values.DISCORD_CLIENT_SECRET,
+  });
+  let title = "Discord login failed";
+  let note = result.detail ?? "";
+  if (result.outcome === "complete") {
+    const saved = persistEnvVar(
+      "DISCORD_USER_OAUTH_TOKEN",
+      result.token,
+      result.target,
+    );
+    markDiscordFlowSaved(result.flowId, saved);
+    title = "Discord login complete";
+    note = `Signed in as ${result.username}. Return to the dashboard tab — this page holds no credential.`;
+  } else if (result.outcome === "unknown-state") {
+    note =
+      "This sign-in link is unknown or expired. Restart it from the dashboard.";
+  } else if (result.outcome === "denied") {
+    title = "Discord login denied";
+  }
+  res.writeHead(result.outcome === "complete" ? 200 : 400, {
+    "Content-Type": "text/html; charset=utf-8",
+    "Cache-Control": "no-store",
+  });
+  res.end(
+    `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>${title}</title>` +
+      `<style>body{margin:0;background:#101014;color:#e8e6e3;font:15px/1.5 system-ui,sans-serif;display:grid;place-items:center;min-height:100vh}main{max-width:26rem;padding:1rem;text-align:center}h1{font-size:1.1rem}</style>` +
+      `</head><body><main><h1>${title}</h1><p>${note}</p><p>You can close this tab.</p></main></body></html>`,
+  );
+}
+
+function handleDiscordOAuthPoll(body) {
+  if (typeof body?.flowId !== "string" || body.flowId.length === 0) {
+    throw new HttpError(400, "flowId is required");
+  }
+  return pollDiscordOAuthLogin({ flowId: body.flowId });
+}
+
 async function handleSiweLogin(body) {
   const target = parseTarget(body);
   const layered = loadLayeredEnv();
@@ -778,6 +857,24 @@ async function handle(req, res) {
     url.pathname === "/api/oneclick/github-device/poll"
   ) {
     sendJson(res, 200, await handleGitHubDevicePoll(await readJsonBody(req)));
+    return;
+  }
+  if (
+    req.method === "POST" &&
+    url.pathname === "/api/oneclick/discord-oauth/start"
+  ) {
+    sendJson(res, 200, handleDiscordOAuthStart(await readJsonBody(req)));
+    return;
+  }
+  if (
+    req.method === "POST" &&
+    url.pathname === "/api/oneclick/discord-oauth/poll"
+  ) {
+    sendJson(res, 200, handleDiscordOAuthPoll(await readJsonBody(req)));
+    return;
+  }
+  if (req.method === "GET" && url.pathname === DISCORD_CALLBACK_PATH) {
+    await handleDiscordOAuthCallback(url, res);
     return;
   }
   if (req.method === "POST" && url.pathname === "/api/oneclick/siwe") {
@@ -1052,6 +1149,30 @@ const PAGE_HTML = `<!doctype html>
         }));
       });
       controls.push(device);
+    }
+    if (oc && oc.type === 'discord-oauth') {
+      var discord = el('button', null, 'Login with Discord');
+      discord.title = oc.detail;
+      function pollDiscord(flowId) {
+        return wait(2).then(function () {
+          return api('POST', '/api/oneclick/discord-oauth/poll', { flowId: flowId });
+        }).then(function (payload) {
+          if (payload.status === 'pending') return pollDiscord(flowId);
+          if (payload.status === 'complete') {
+            toast('Discord login complete (' + payload.username + '): saved ' + payload.key + ' = ' + payload.masked + ' → ' + payload.target, false);
+            return payload;
+          }
+          toast('Discord login ' + payload.status + (payload.detail ? ' — ' + payload.detail : ''), true);
+          return payload;
+        });
+      }
+      discord.addEventListener('click', function () {
+        busyRun(discord, 'waiting for Discord…', api('POST', '/api/oneclick/discord-oauth/start', { target: saveTarget() }).then(function (payload) {
+          window.open(payload.authorizeUrl, '_blank', 'noopener,noreferrer');
+          return pollDiscord(payload.flowId);
+        }));
+      });
+      controls.push(discord);
     }
     if (oc && oc.type === 'siwe') {
       var siwe = el('button', null, 'Login with Eliza Cloud');

--- a/scripts/lifeops/hitl-credential-dashboard.test.mjs
+++ b/scripts/lifeops/hitl-credential-dashboard.test.mjs
@@ -140,3 +140,58 @@ test("credential dashboard rejects cross-site writes and requires its page sessi
     rmSync(home, { recursive: true, force: true });
   }
 });
+
+test("discord loopback OAuth surfaces fail closed without registration or a known state", async () => {
+  const home = tempDir("hitl-dashboard-home-");
+  const child = spawn(
+    "node",
+    ["scripts/lifeops/hitl-credential-dashboard.mjs"],
+    {
+      cwd: ROOT,
+      env: {
+        ...process.env,
+        HOME: home,
+        XDG_CONFIG_HOME: join(home, ".config"),
+        XDG_CACHE_HOME: join(home, ".cache"),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  const envPath = join(home, ".eliza", ".env");
+  try {
+    const baseUrl = await waitForDashboard(child);
+    const sameOrigin = new URL(baseUrl).origin;
+    const pageHtml = await (await fetch(baseUrl)).text();
+    const tokenMatch = /var SESSION_TOKEN = "([^"]+)";/.exec(pageHtml);
+    assert.ok(tokenMatch);
+
+    // No Discord OAuth app registered in the isolated HOME: the start
+    // endpoint is the designed needs-owner-setup state, not a broken flow.
+    const start = await fetch(`${baseUrl}api/oneclick/discord-oauth/start`, {
+      method: "POST",
+      headers: {
+        Origin: sameOrigin,
+        "Content-Type": "application/json",
+        "X-HITL-Session": tokenMatch[1],
+      },
+      body: JSON.stringify({ target: "home" }),
+    });
+    assert.equal(start.status, 409);
+    const startPayload = await start.json();
+    assert.match(startPayload.error, /needs owner setup/);
+
+    // A forged callback state is rejected without any credential write and
+    // without echoing anything sensitive.
+    const callback = await fetch(
+      `${baseUrl}oauth/discord/callback?state=forged&code=x`,
+    );
+    assert.equal(callback.status, 400);
+    const callbackHtml = await callback.text();
+    assert.match(callbackHtml, /unknown or expired/);
+    assert.equal(existsSync(envPath), false);
+  } finally {
+    child.kill("SIGTERM");
+    await new Promise((resolvePromise) => child.once("exit", resolvePromise));
+    rmSync(home, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Part of #14792 (does **not** close it — Google deep-link completion and owner-held registration/live proof remain).

## What changed

- **New `scripts/lifeops/discord-oauth-login.mjs`** — authorization-code flow state, mirroring the merged GitHub device-flow module: `startDiscordOAuthLogin` registers a pending flow and builds an `identify`-scoped authorize URL with a random CSRF state; `completeDiscordOAuthCallback` matches the state (timing-safe), exchanges the code server-side, fetches `/users/@me`, and hands the token to the caller exactly once; `pollDiscordOAuthLogin` is the masked, single-read poll surface. Denial, unknown/replayed state, failed exchange, missing secret, and TTL expiry are all typed outcomes. Injectable `fetch`/clock for deterministic tests.
- **`hitl-credential-dashboard.mjs`** — three new surfaces: `POST /api/oneclick/discord-oauth/start` (session-token protected; 409 designed needs-owner-setup when `DISCORD_CLIENT_ID`/`DISCORD_CLIENT_SECRET` are absent), `GET /oauth/discord/callback` (top-level navigation from Discord; authenticated by the flow's single-use CSRF state; persists `DISCORD_USER_OAUTH_TOKEN` via the shared env-layers writer — atomic tmp+rename, mode 600, masked to last 4 — and returns a credential-free HTML page), and `POST /api/oneclick/discord-oauth/poll`. Page JS adds a 'Login with Discord' one-click that opens the authorize tab and polls for the masked result.
- **`connector-paths.mjs`** — `discord.user-oauth` gains the `DISCORD_USER_OAUTH_TOKEN` optional slot (making it writable through the registry allowlist) and a `discord-oauth` one-click; the maintainer constraint is kept explicit: this is an HITL identity/probe path, the runtime connector's product flow remains bot + `/eliza-pair`.

Zero new dependencies (`node:http`/`node:crypto`/`node:fs` only). The token never appears in any browser response, log line, or poll payload — deterministic tests assert its absence by string search.

## Not in this PR (remains on #14792)

- Google deep-link completion — blocked on the durable bare-agent/Cloud credential writer per the #18027 exact-head review (connect → container restart → credential still readable).
- Owner-held: Discord app registration with the loopback redirect URI, and live click-to-green recordings.

## Tests

- `bun run test:lifeops-hitl` — **85/85 pass** (8 new protocol tests in `discord-oauth-login.test.mjs`: state/CSRF, single-read token handover, denial, forged state without network, failed exchange, missing secret fail-closed, TTL expiry; 1 new registry test; 1 new booted-dashboard integration test proving the 409 owner-setup state and that a forged callback state writes nothing).
- Biome clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)