### PR TITLE
fix(core): outbound sanitizer delivers a raw NUL byte and drops code-block content

### DIFF
--- a/packages/core/src/services/message/outbound-sanitize.test.ts
+++ b/packages/core/src/services/message/outbound-sanitize.test.ts
@@ -389,4 +389,24 @@ describe("model-invented [LINK:] pseudo-markers", () => {
 		);
 		expect(sanitizeOutboundText(once)).toBe(once);
 	});
+
+	it("restores a fenced block that an inline span swallowed", () => {
+		// Phase 2 protects inline spans over text that already holds phase-1
+		// fence sentinels, and the inline content class matches a sentinel — so
+		// unbalanced backticks around a fence nest one sentinel inside another.
+		// Restoring forward no-ops on the buried sentinel and ships it raw.
+		const out = sanitizeOutboundText(
+			"<thinking>plan</thinking>Try `x ```code``` y` now",
+		);
+		expect(out).not.toContain("\u0000");
+		expect(out).toBe("Try `x ```code``` y` now");
+	});
+
+	it("never delivers a NUL byte for unbalanced backticks around a fence", () => {
+		const out = sanitizeOutboundText(
+			"<tool_call>x</tool_call>Set `PATH like ```export PATH=/x``` then run `foo`",
+		);
+		expect(out).not.toContain("\u0000");
+		expect(out).toContain("```export PATH=/x```");
+	});
 });

--- a/packages/core/src/services/message/outbound-sanitize.ts
+++ b/packages/core/src/services/message/outbound-sanitize.ts
@@ -197,7 +197,13 @@ export function sanitizeOutboundText(text: string): string {
 	// blank-line spacing inside fences.
 	processed = processed.replace(/\n{3,}/g, "\n\n");
 
-	for (let index = 0; index < codeSpans.length; index++) {
+	// Restore in REVERSE order. Phase 2 (inline spans) runs over text that
+	// already holds phase-1 fence sentinels, and the inline content class
+	// matches a sentinel, so a later-indexed span can contain an earlier one.
+	// Forward restoration then no-ops on the buried sentinel and re-injects it
+	// raw. Nesting only ever runs later-contains-earlier, because fences are
+	// extracted from the original text and cannot hold an inline sentinel.
+	for (let index = codeSpans.length - 1; index >= 0; index--) {
 		processed = processed.replace(
 			`${CODE_SENTINEL_PREFIX}${index}${CODE_SENTINEL_PREFIX}`,
 			() => codeSpans[index],


### PR DESCRIPTION
# Relates to

Self-found while auditing invariants that are argued in comments rather than enforced in code.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (verified: `git rev-list --count HEAD..origin/develop` = 0).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

**Low.** One loop direction changes. Restoration is order-independent for every input that
does *not* nest sentinels, so all existing behaviour is untouched — the 38 pre-existing tests in
this file pass unchanged. For inputs that *do* nest, forward order is already broken, so reverse
can only improve them.

# Background

## What does this PR do?

`sanitizeOutboundText` protects code from the machine-syntax strippers in two phases: fenced
blocks are swapped for `\x00CB<i>\x00CB` sentinels first, then inline spans are swapped.

Phase 2 runs over text that **already contains phase-1 sentinels**, and the inline content class
`[^\`\n]+?` matches a sentinel quite happily — it holds no backtick and no newline. So when
backticks surround a collapsed fence on one line, the inline span saved at index *k* literally
contains the string `\x00CB0\x00CB`.

Restoration then walks forward, 0 → n. By the time it tries to replace sentinel 0, that sentinel
is no longer present in the text — it is buried inside `codeSpans[k]`, which is itself still a
sentinel — so the replace is a silent no-op. Sentinel *k* is expanded afterwards and re-injects
the raw, now-unexpandable sentinel 0 into the returned string.

Reversing the loop fixes it, and is provably safe: nesting only ever runs
later-index-contains-earlier-index, because fenced blocks are extracted from the **original**
text and therefore cannot contain an inline sentinel.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

This is the shared delivery-boundary sanitizer. Its own docstring records that it was promoted out
of `plugin-discord` (#15888 / #16047) so "every text connector receives sanitized prose without
carrying its own copy", and it runs on the per-turn visible callback, in the mandatory
`outgoing_before_deliver` phase, and in `sendMessageToTarget` — so this reaches every text
surface at once.

When it triggers, the user is delivered a literal **NUL byte** plus `CB0` where a code block
should be, **and the block's content is destroyed** — the agent's answer is lost, not merely
mangled. A NUL is also not representable in a Postgres `text` column
(`invalid byte sequence for encoding "UTF8": 0x00`), so anything that persists or re-ingests the
delivered string can hard-error.

Worth noting for the record: the module comment at L71-76 argues the sentinel cannot collide
because "NUL cannot be produced by model tokenizers or survive the JSON transport" — an invariant
about **content**. This collision is manufactured by the sanitizer's own two-phase extraction, so
that argument never covered it, and nothing enforced it.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/core/src/services/message/outbound-sanitize.test.ts` — the two new cases. Check out this
branch, revert only `outbound-sanitize.ts`, and run the file: both fail.

## Detailed testing steps

```bash
bun install --ignore-scripts
bunx vitest run packages/core/src/services/message/outbound-sanitize.test.ts   # 40 passed

git checkout origin/develop -- packages/core/src/services/message/outbound-sanitize.ts
bunx vitest run packages/core/src/services/message/outbound-sanitize.test.ts   # 2 failed | 38 passed
```

Observed against the unfixed source, driving the real exported function:

```
IN : "<thinking>plan</thinking>Try `x \`\`\`code\`\`\` y` now"
OUT: "Try `x \u0000CB0\u0000CB y` now"          <- raw NUL delivered, code content gone

IN : "<tool_call>x</tool_call>Set `PATH like \`\`\`export PATH=/x\`\`\` then run `foo`"
OUT: "Set `PATH like \u0000CB0\u0000CB then run `foo`"
```

With the fix, both round-trip exactly:

```
"Try `x \`\`\`code\`\`\` y` now"
"Set `PATH like \`\`\`export PATH=/x\`\`\` then run `foo`"
```

The trigger needs (a) machine syntax or a `[LINK:` marker present so the sanitizer engages at all —
the exact drift this module exists for — and (b) a fenced block sitting between two backticks on
one line, i.e. unbalanced inline backticks around a fence. Models emit unbalanced backticks
routinely; both inputs above are ordinary assistant prose.

# Evidence Gate

<!-- evidence-head:65a83c8f988ab62a75a0c89995b2be97aa75d12d -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; pure string sanitisation in packages/core.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; pure string sanitisation in packages/core.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - the observable behaviour is the returned string, shown verbatim above.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - the function performs no I/O and emits no log lines; the vitest transcript exercises the real exported function end to end.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend involvement.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt or model behaviour changes; this is post-generation text sanitisation.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - produces no DB rows, memories, tasks, files or on-chain output. (The Postgres NUL consequence noted above is a downstream risk of the bug, not an artifact this PR emits.)`
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - see the llm-trajectory row above; the input is model text, but the defect is deterministic given that text and is shown directly.`

## Backend + frontend logs

`N/A - pure function, no I/O.` Behavioural evidence is the before/after transcript above.

## Screenshots (before / after) + video walkthrough

`N/A - no UI change.`

# Known gaps / failures

- I did not attach a live connector delivery showing the NUL reaching Discord/Slack, because that
  needs workspace credentials I do not have. The sanitizer's output is shown directly instead,
  which is exactly the string those connectors would send.

**`bun run verify` blocker (pre-existing on `develop`, not from this PR).**

```
@elizaos/gateway-webhook:typecheck: src/billing.test.ts(8,65): error TS2307:
  Cannot find module '@elizaos/cloud-shared/billing'
```

It is the only `error TS` in the entire run, and it reproduces on a clean checkout of
`origin/develop` with zero changes applied. The package this PR touches is green at the exact head:

```
bunx turbo run typecheck lint:check --filter=@elizaos/core
Tasks:    58 successful, 58 total
```

AI provider/model: Anthropic / claude-fable-5
Client / agent tooling: Claude Code
Contribution skill revision: N/A - contribution skill not used; repository template and CONTRIBUTING.md read directly from the checkout
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"Claude Code","skill_revision":"N/A - contribution skill not used"} -->
