### PR TITLE
fix(cloud): serialize retirement CONTAINER_DELETE payloads through the canonical codec

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/container-retirement.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-retirement.integration.test.ts
@@ -151,6 +151,28 @@ describe("atomic prior-container retirement", () => {
     expect((await databaseState(RUNNING_ID)).deleteJobIds).toEqual(state.deleteJobIds);
   });
 
+  test("the persisted delete job validates under the canonical codec with the selected row's id (#15821)", async () => {
+    await seedContainer(RUNNING_ID, "running");
+
+    const result = await retireContainerWithDeleteJob(RUNNING_ID, ORG_ID);
+    expect(result.outcome).toBe("retired");
+
+    const { isContainerDeleteJobData } = await import("../container-jobs-data");
+    const jobResult = await dbWrite.execute(
+      `SELECT data FROM jobs
+       WHERE type = 'container_delete' AND data->>'containerId' = '${RUNNING_ID}';`,
+    );
+    expect(jobResult.rows).toHaveLength(1);
+    const data = (jobResult.rows[0] as { data: unknown }).data;
+    // The producer serialized through containerDeleteJobDataToRecord, so the
+    // executor's canonical guard must accept the row without ever reaching the
+    // malformed-job recovery branch, and containerId must be the exact
+    // selected container row id.
+    expect(isContainerDeleteJobData(data)).toBe(true);
+    expect((data as { containerId: string }).containerId).toBe(RUNNING_ID);
+    expect((data as { organizationId: string }).organizationId).toBe(ORG_ID);
+  });
+
   test("a worker terminal transition cannot be overwritten by retry compensation", async () => {
     await seedContainer(TERMINAL_ID, "running");
     await retireContainerWithDeleteJob(TERMINAL_ID, ORG_ID);

--- a/packages/cloud/shared/src/lib/services/container-retirement.ts
+++ b/packages/cloud/shared/src/lib/services/container-retirement.ts
@@ -12,6 +12,7 @@ import { dbWrite } from "../../db/helpers";
 import { containers } from "../../db/schemas/containers";
 import { jobs } from "../../db/schemas/jobs";
 import { logger } from "../utils/logger";
+import { containerDeleteJobDataToRecord } from "./container-jobs-data";
 import { JOB_TYPES } from "./provisioning-job-types";
 
 const LIVE_JOB_STATUSES = ["pending", "in_progress"] as const;
@@ -98,7 +99,14 @@ async function retireLockedContainer(
       id: jobId,
       type: JOB_TYPES.CONTAINER_DELETE,
       organization_id: row.organizationId,
-      data: { containerId: row.id, organizationId: row.organizationId },
+      // Serialize through the canonical CONTAINER_DELETE codec so this
+      // producer can never persist a payload missing containerId (#15821) —
+      // the codec throws before the insert instead of enqueueing a malformed
+      // job for the executor's recovery branch to classify later.
+      data: containerDeleteJobDataToRecord({
+        containerId: row.id,
+        organizationId: row.organizationId,
+      }),
       data_storage: "inline",
     });
   }


### PR DESCRIPTION
Part of #15821 (the codeable producer slice; the staging/production queue inventory, operator requeue of legacy rows, and live concurrent-worker proof remain operator-gated per the issue triage).

## Producer trace (the scoped ask: prove containerId is present before serialization at every enqueue caller)
There are exactly three CONTAINER_DELETE producers on develop:

1. `ContainerJobEnqueuer.enqueueDelete` (`container-job-service.ts:125`) — used by app-delete teardown (`app-container-teardown.ts`). Already serializes through `containerDeleteJobDataToRecord`, whose `readContainerDeleteJobData` guard throws on a missing/blank `containerId` **before** the insert. Covered by `container-jobs-data.test.ts` (round-trip + throw-on-invalid).
2. `retireContainerWithDeleteJob` (`container-retirement.ts`, used by `app-deploy-runner.ts` `retirePriorContainers`) — was the **one producer bypassing the codec**, inserting a raw `data: { containerId: row.id, organizationId }` object inside its transaction.
3. The executor's org-only recovery branch never enqueues; it only consumes.

## Change
- `container-retirement.ts` now serializes its job payload through the same canonical `containerDeleteJobDataToRecord` codec, so no producer can persist a CONTAINER_DELETE payload missing `containerId` — the codec throws before the insert and the atomic transaction rolls back, instead of enqueueing a malformed job for the executor's recovery branch to classify later.
- Regression test at the identified producer: new case in `container-retirement.integration.test.ts` (real PGlite Postgres semantics, no mocks) retires a running row and asserts the **persisted** job row's `data` passes the canonical `isContainerDeleteJobData` guard with the exact selected container row id and org — proving the producer/executor contract round-trips and the malformed-recovery branch is unreachable from this path.

Classification note: malformed-job classification already flows through the canonical guard (`isContainerDeleteJobData` / `readContainerDeleteJobData`) in `executeContainerDelete`, with recoverable org-only jobs recovered via `findDeletingByOrganization` and unrecoverable ones failing through typed `ElizaError` — no ad-hoc regex exists on the payload path, so no change was needed there.

## Tests (packages/cloud/shared, real PGlite DB, no mocks of the system under test)
- `bun test src/lib/services/__tests__/container-retirement.integration.test.ts` — **6 pass / 0 fail** (includes the new codec round-trip regression plus the pre-existing rollback / commit-then-throw / worker-owned invariants).
- `bun test container-jobs-data.test.ts container-job-service.test.ts container-job-executors.test.ts app-deploy-runner-retire.test.ts` — **48 pass / 0 fail**.
- Package typecheck + Biome clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)