### PR TITLE
feat(lifeops): brief engagement loop — delivery-boundary impressions + owner recalibrate/reset verbs

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/brief.ts
+++ b/plugins/plugin-personal-assistant/src/actions/brief.ts
@@ -5,6 +5,8 @@
  *   - `compose_morning`  — `period: today` by default
  *   - `compose_evening`  — `period: today` by default
  *   - `compose_weekly`   — `period: this_week` by default
+ *   - `recalibrate`          — demote repeatedly ignored item classes (reversible)
+ *   - `reset_recalibration`  — restore demoted item classes
  *
  * Pulls from each domain (calendar feed, inbox triage, life-domain due items,
  * money recurring charges) per the `include` arg, then runs a single LLM
@@ -36,6 +38,8 @@ import { hasLifeOpsAccess } from "../lifeops/access.js";
 import {
   buildBriefEditorialContract,
   type LifeOpsBriefItemEngagementSummary,
+  recalibrateBriefItemClasses,
+  selectRecalibrationCandidates,
 } from "../lifeops/briefing/editorial-judgment.js";
 import {
   BRIEF_NARRATIVE_INSTRUCTIONS,
@@ -61,12 +65,18 @@ export {
 
 const ACTION_NAME = "BRIEF";
 
-const SUBACTIONS = [
+const COMPOSE_SUBACTIONS = [
   "compose_morning",
   "compose_evening",
   "compose_weekly",
 ] as const;
 
+const CONTROL_SUBACTIONS = ["recalibrate", "reset_recalibration"] as const;
+
+const SUBACTIONS = [...COMPOSE_SUBACTIONS, ...CONTROL_SUBACTIONS] as const;
+
+type ComposeSubaction = (typeof COMPOSE_SUBACTIONS)[number];
+type ControlSubaction = (typeof CONTROL_SUBACTIONS)[number];
 type Subaction = (typeof SUBACTIONS)[number];
 type BriefOptimizationTask = "morning_brief" | "meeting_prep";
 
@@ -81,6 +91,7 @@ const SIMILE_NAMES: readonly string[] = [
   "MEETING_PREP",
   "PREBRIEF",
   "MEETING_DOSSIER",
+  "RECALIBRATE_BRIEF",
 ];
 
 const SIMILE_TO_SUBACTION: Readonly<Record<string, Subaction>> = {
@@ -88,16 +99,19 @@ const SIMILE_TO_SUBACTION: Readonly<Record<string, Subaction>> = {
   EVENING_BRIEF: "compose_evening",
   WEEKLY_BRIEF: "compose_weekly",
   DAILY_DIGEST: "compose_evening",
+  RECALIBRATE_BRIEF: "recalibrate",
 };
 
-const SUBACTION_TO_KIND: Readonly<Record<Subaction, LifeOpsBriefingKind>> = {
+const SUBACTION_TO_KIND: Readonly<
+  Record<ComposeSubaction, LifeOpsBriefingKind>
+> = {
   compose_morning: "morning",
   compose_evening: "evening",
   compose_weekly: "weekly",
 };
 
 const SUBACTION_TO_DEFAULT_PERIOD: Readonly<
-  Record<Subaction, LifeOpsBriefingPeriod>
+  Record<ComposeSubaction, LifeOpsBriefingPeriod>
 > = {
   compose_morning: "today",
   compose_evening: "today",
@@ -119,6 +133,8 @@ interface BriefActionParameters {
   include?: BriefIncludeFlags;
   format?: "narrative" | "json";
   optimizationTask?: BriefOptimizationTask | string;
+  /** Optional exact item class targeted by recalibrate / reset_recalibration. */
+  itemClass?: string;
 }
 
 const INTERNAL_URL = new URL("http://127.0.0.1/");
@@ -393,6 +409,47 @@ async function loadEngagementSummariesFromLifeOps(args: {
 }
 
 /**
+ * Persist one `rendered` impression per surfaced (non-omitted) editorial item.
+ * Called only after the callback delivery of the composed brief resolved, so a
+ * failed delivery never fabricates visibility. Returns the number of rows
+ * written so callers and tests can assert the ledger reflects the delivery.
+ */
+async function recordRenderedImpressionsInLifeOps(args: {
+  runtime: IAgentRuntime;
+  briefing: LifeOpsBriefing;
+}): Promise<number> {
+  const repository = new LifeOpsRepository(args.runtime);
+  const itemsById = new Map(
+    args.briefing.editorial.items.map((item) => [item.itemId, item]),
+  );
+  let recorded = 0;
+  for (const decision of args.briefing.editorial.decisions) {
+    if (decision.action === "omit") continue;
+    const item = itemsById.get(decision.itemId);
+    if (!item) continue;
+    await repository.recordBriefItemEngagement({
+      agentId: args.runtime.agentId,
+      briefingId: args.briefing.id,
+      itemId: item.itemId,
+      source: item.source,
+      kind: item.kind,
+      sourceId: item.sourceId,
+      itemClass: item.itemClass,
+      eventType: "rendered",
+      eventAt: args.briefing.generatedAt,
+      weight: 0,
+      metadata: {
+        briefingKind: args.briefing.kind,
+        period: args.briefing.period,
+        decision: decision.action,
+      },
+    });
+    recorded += 1;
+  }
+  return recorded;
+}
+
+/**
  * Composer hooks — overridable for tests. Defaults compose from LifeOps'
  * structural services: calendar feed, MESSAGE triage, overview reminders, and
  * recurring payments. Unavailable sources degrade to empty arrays.
@@ -422,6 +479,11 @@ export interface BriefComposers {
   loadEngagementSummaries: (args: {
     runtime: IAgentRuntime;
   }) => Promise<readonly LifeOpsBriefItemEngagementSummary[]>;
+  /** Ledger write for delivered brief items; runs only after callback delivery. */
+  recordRenderedImpressions: (args: {
+    runtime: IAgentRuntime;
+    briefing: LifeOpsBriefing;
+  }) => Promise<number>;
 }
 
 const defaultComposers: BriefComposers = {
@@ -431,6 +493,7 @@ const defaultComposers: BriefComposers = {
   loadMoney: loadMoneyFromPayments,
   loadCompletedToday: loadCompletedTodayFromService,
   loadEngagementSummaries: loadEngagementSummariesFromLifeOps,
+  recordRenderedImpressions: recordRenderedImpressionsInLifeOps,
 };
 
 let activeComposers: BriefComposers = defaultComposers;
@@ -494,7 +557,7 @@ function resolveIncludeFlags(input: BriefIncludeFlags | undefined): {
 
 function resolvePeriod(
   params: BriefActionParameters,
-  subaction: Subaction,
+  subaction: ComposeSubaction,
 ): LifeOpsBriefingPeriod {
   const candidate =
     typeof params.period === "string"
@@ -630,7 +693,7 @@ async function composeNarrative(args: {
 
 async function assembleBriefing(args: {
   runtime: IAgentRuntime;
-  subaction: Subaction;
+  subaction: ComposeSubaction;
   period: LifeOpsBriefingPeriod;
   include: ReturnType<typeof resolveIncludeFlags>;
   format: "narrative" | "json";
@@ -704,6 +767,149 @@ async function assembleBriefing(args: {
   return briefing;
 }
 
+function normalizeItemClassParam(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Owner-facing recalibration verbs over the engagement ledger.
+ *
+ * Both verbs summarize only rows that exist at the command instant
+ * (`untilIso = commandAt`), so a delayed or replayed command can never attach
+ * owner intent to impressions rendered after it was issued. Candidate
+ * filtering happens before any write: a targeted `itemClass` command touches
+ * exactly that class, and an untargeted `recalibrate` demotes only classes
+ * the owner has repeatedly seen and never acted on. Demotion is expressed as
+ * an explicit `demoted` marker row and reversed by a `kept` marker, so every
+ * decision is visible in the ledger and reversible from chat.
+ */
+async function handleRecalibration(args: {
+  runtime: IAgentRuntime;
+  subaction: ControlSubaction;
+  itemClass: string | null;
+}): Promise<{
+  text: string;
+  data: ActionResult["data"];
+}> {
+  const repository = new LifeOpsRepository(args.runtime);
+  const commandAt = new Date().toISOString();
+  const summaries = await repository.summarizeBriefItemEngagements(
+    args.runtime.agentId,
+    { untilIso: commandAt },
+  );
+
+  const writeMarker = async (
+    itemClass: string,
+    eventType: "demoted" | "kept",
+    metadata: Record<string, unknown>,
+  ): Promise<void> => {
+    const rows = await repository.listBriefItemEngagements(
+      args.runtime.agentId,
+      { itemClass, untilIso: commandAt },
+    );
+    const anchor = rows.at(-1);
+    if (!anchor) return;
+    await repository.recordBriefItemEngagement({
+      agentId: args.runtime.agentId,
+      briefingId: anchor.briefingId,
+      itemId: anchor.itemId,
+      source: anchor.source,
+      kind: anchor.kind,
+      sourceId: anchor.sourceId,
+      itemClass,
+      eventType,
+      eventAt: commandAt,
+      weight: eventType === "demoted" ? -1 : 1,
+      metadata,
+    });
+  };
+
+  if (args.subaction === "recalibrate") {
+    if (
+      args.itemClass &&
+      !summaries.some((summary) => summary.itemClass === args.itemClass)
+    ) {
+      return {
+        text: `I have no engagement history for "${args.itemClass}", so there is nothing to recalibrate for it.`,
+        data: {
+          subaction: args.subaction,
+          error: "NO_ENGAGEMENT_HISTORY",
+          itemClass: args.itemClass,
+        },
+      };
+    }
+    const candidates = selectRecalibrationCandidates(
+      summaries,
+      args.itemClass ? { itemClass: args.itemClass } : {},
+    );
+    for (const candidate of candidates) {
+      await writeMarker(candidate.itemClass, "demoted", {
+        verb: "recalibrate",
+        requestedItemClass: args.itemClass,
+        renderedCount: candidate.renderedCount,
+        ignoredCount: candidate.ignoredCount,
+        actedOnCount: candidate.actedOnCount,
+      });
+    }
+    const alreadyDemoted = recalibrateBriefItemClasses(summaries);
+    if (candidates.length === 0) {
+      const suffix =
+        alreadyDemoted.length > 0
+          ? ` Currently demoted: ${alreadyDemoted.join(", ")}.`
+          : "";
+      return {
+        text: `Nothing new to recalibrate — no brief item class has enough unacknowledged history yet.${suffix}`,
+        data: {
+          subaction: args.subaction,
+          demotedItemClasses: [],
+          alreadyDemotedItemClasses: alreadyDemoted,
+        },
+      };
+    }
+    const lines = candidates.map(
+      (candidate) =>
+        `- ${candidate.itemClass} (surfaced ${candidate.renderedCount + candidate.ignoredCount} times, acted on ${candidate.actedOnCount})`,
+    );
+    return {
+      text: [
+        "Recalibrated your brief. Demoting these item classes in upcoming briefs:",
+        ...lines,
+        'This is reversible: say "reset the brief recalibration" (optionally naming the item class) to restore any of them.',
+      ].join("\n"),
+      data: {
+        subaction: args.subaction,
+        demotedItemClasses: candidates.map((c) => c.itemClass),
+        alreadyDemotedItemClasses: alreadyDemoted,
+      },
+    };
+  }
+
+  const demotedNow = recalibrateBriefItemClasses(summaries);
+  const targets = args.itemClass
+    ? demotedNow.filter((itemClass) => itemClass === args.itemClass)
+    : demotedNow;
+  for (const itemClass of targets) {
+    await writeMarker(itemClass, "kept", {
+      verb: "reset_recalibration",
+      requestedItemClass: args.itemClass,
+    });
+  }
+  if (targets.length === 0) {
+    return {
+      text: args.itemClass
+        ? `"${args.itemClass}" is not currently demoted, so there is nothing to restore.`
+        : "No brief item classes are currently demoted, so there is nothing to restore.",
+      data: { subaction: args.subaction, restoredItemClasses: [] },
+    };
+  }
+  return {
+    text: `Restored ${targets.join(", ")} to normal ranking in upcoming briefs.`,
+    data: { subaction: args.subaction, restoredItemClasses: targets },
+  };
+}
+
 const examples: ActionExample[][] = [
   [
     { name: "{{name1}}", content: { text: "Give me my morning brief." } },
@@ -740,9 +946,9 @@ export const briefAction: Action & {
     "surface:internal",
   ],
   description:
-    "Compose owner LifeOpsBriefing: morning/evening/weekly; calendar feed, inbox triage, life due, money recurring charges. Subactions: compose_morning, compose_evening, compose_weekly.",
+    "Compose owner LifeOpsBriefing: morning/evening/weekly; calendar feed, inbox triage, life due, money recurring charges. Subactions: compose_morning, compose_evening, compose_weekly, recalibrate (demote repeatedly ignored brief item classes; reversible), reset_recalibration (restore demoted classes).",
   descriptionCompressed:
-    "BRIEF compose_morning|compose_evening|compose_weekly; LifeOpsBriefing",
+    "BRIEF compose_morning|compose_evening|compose_weekly|recalibrate|reset_recalibration; LifeOpsBriefing",
   routingHint:
     'briefing/digest ("morning brief", "evening summary", "this week", "daily digest") -> BRIEF; one-domain read -> CALENDAR.feed, MESSAGE.triage, etc.',
   contexts: ["briefing", "calendar", "inbox", "tasks", "finance"],
@@ -753,8 +959,14 @@ export const briefAction: Action & {
     {
       name: "action",
       description:
-        "Brief op: compose_morning | compose_evening | compose_weekly.",
+        "Brief op: compose_morning | compose_evening | compose_weekly | recalibrate | reset_recalibration.",
       schema: { type: "string" as const, enum: [...SUBACTIONS] },
+    },
+    {
+      name: "itemClass",
+      description:
+        "recalibrate/reset_recalibration only: exact brief item class to target, e.g. inbox:newsletter-digest. Omit to apply to every qualifying class.",
+      schema: { type: "string" as const },
     },
     {
       name: "period",
@@ -797,8 +1009,29 @@ export const briefAction: Action & {
     if (!subaction) {
       return {
         success: false,
-        text: "Tell me which briefing to compose: compose_morning, compose_evening, or compose_weekly.",
+        text: "Tell me which briefing operation to run: compose_morning, compose_evening, compose_weekly, recalibrate, or reset_recalibration.",
         data: { error: "MISSING_SUBACTION" },
+      };
+    }
+
+    if (subaction === "recalibrate" || subaction === "reset_recalibration") {
+      const outcome = await handleRecalibration({
+        runtime,
+        subaction,
+        itemClass: normalizeItemClassParam(params.itemClass),
+      });
+      await callback?.({
+        text: outcome.text,
+        source: "action",
+        action: ACTION_NAME,
+      });
+      return {
+        success: true,
+        text: outcome.text,
+        userFacingText: outcome.text,
+        verifiedUserFacing: true,
+        turnComplete: true,
+        data: outcome.data,
       };
     }
 
@@ -830,6 +1063,24 @@ export const briefAction: Action & {
       source: "action",
       action: ACTION_NAME,
     });
+
+    // Rendered impressions are truthful only after the delivery call above
+    // resolved: no callback means nothing was shown, and a rejected callback
+    // propagates before this point, so a failed delivery never writes rows.
+    if (callback) {
+      try {
+        await activeComposers.recordRenderedImpressions({ runtime, briefing });
+      } catch (error) {
+        // error-policy:J7 the engagement ledger is a learning signal; failing
+        // to persist it must not retract an already-delivered brief. The
+        // failure stays observable through RECENT_ERRORS instead of a silent
+        // gap in the owner-preference history.
+        runtime.reportError("Brief.recordRenderedImpressions", error, {
+          briefingId: briefing.id,
+          briefingKind: briefing.kind,
+        });
+      }
+    }
 
     return {
       success: true,

--- a/plugins/plugin-personal-assistant/src/lifeops/briefing/editorial-judgment.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/briefing/editorial-judgment.ts
@@ -55,6 +55,10 @@ export interface LifeOpsBriefItemEngagementSummary {
   readonly ignoredCount: number;
   readonly actedOnCount: number;
   readonly lastEventAt: string | null;
+  /** Newest explicit owner `demoted` marker for this class, if any. */
+  readonly lastDemotedAt: string | null;
+  /** Newest explicit owner `kept` marker for this class, if any. */
+  readonly lastKeptAt: string | null;
 }
 
 export interface LifeOpsBriefEditorialDecision {
@@ -233,6 +237,8 @@ export function summarizeBriefEngagementRows(
         ignoredCount: 0,
         actedOnCount: 0,
         lastEventAt: null,
+        lastDemotedAt: null,
+        lastKeptAt: null,
       } satisfies LifeOpsBriefItemEngagementSummary);
     summaries.set(row.itemClass, {
       itemClass: row.itemClass,
@@ -246,10 +252,42 @@ export function summarizeBriefEngagementRows(
         current.lastEventAt && current.lastEventAt > row.eventAt
           ? current.lastEventAt
           : row.eventAt,
+      lastDemotedAt:
+        row.eventType === "demoted" &&
+        (!current.lastDemotedAt || row.eventAt > current.lastDemotedAt)
+          ? row.eventAt
+          : current.lastDemotedAt,
+      lastKeptAt:
+        row.eventType === "kept" &&
+        (!current.lastKeptAt || row.eventAt > current.lastKeptAt)
+          ? row.eventAt
+          : current.lastKeptAt,
     });
   }
   return [...summaries.values()].sort((a, b) =>
     a.itemClass.localeCompare(b.itemClass),
+  );
+}
+
+/**
+ * True when the owner's newest explicit marker for a class is `demoted`
+ * (a `kept` marker at the same or a later instant wins, so a reset always
+ * reverses a demotion recorded in the same second).
+ */
+function isExplicitlyDemoted(
+  summary: LifeOpsBriefItemEngagementSummary,
+): boolean {
+  return Boolean(
+    summary.lastDemotedAt &&
+      (!summary.lastKeptAt || summary.lastDemotedAt > summary.lastKeptAt),
+  );
+}
+
+/** True when the owner's newest explicit marker for a class is `kept`. */
+function isExplicitlyKept(summary: LifeOpsBriefItemEngagementSummary): boolean {
+  return Boolean(
+    summary.lastKeptAt &&
+      (!summary.lastDemotedAt || summary.lastKeptAt >= summary.lastDemotedAt),
   );
 }
 
@@ -259,14 +297,46 @@ export function recalibrateBriefItemClasses(
 ): readonly string[] {
   const ignoredThreshold = options.ignoredThreshold ?? 5;
   return summaries
-    .filter(
-      (summary) =>
+    .filter((summary) => {
+      // Explicit owner markers take precedence over inferred ignore history:
+      // a `demoted` marker demotes regardless of counts, and a newer `kept`
+      // marker restores the class regardless of counts.
+      if (isExplicitlyDemoted(summary)) return true;
+      if (isExplicitlyKept(summary)) return false;
+      return (
         summary.ignoredCount >= ignoredThreshold &&
         summary.actedOnCount === 0 &&
-        summary.ignoredCount >= summary.renderedCount - summary.actedOnCount,
-    )
+        summary.ignoredCount >= summary.renderedCount - summary.actedOnCount
+      );
+    })
     .map((summary) => summary.itemClass)
     .sort();
+}
+
+/**
+ * Classes an owner-initiated `recalibrate` command may demote.
+ *
+ * With an explicit `itemClass` the command is a direct owner decision: the
+ * matching class is selected whenever it has any ledger history and is not
+ * already demoted. Without one, only revealed preference qualifies: classes
+ * the owner has seen at least `surfacedThreshold` times (rendered + ignored)
+ * without ever acting on. Filtering happens here, before any write, so a
+ * targeted command can never touch an unrelated class.
+ */
+export function selectRecalibrationCandidates(
+  summaries: readonly LifeOpsBriefItemEngagementSummary[],
+  options: { itemClass?: string; surfacedThreshold?: number } = {},
+): readonly LifeOpsBriefItemEngagementSummary[] {
+  const surfacedThreshold = options.surfacedThreshold ?? 5;
+  const alreadyDemoted = new Set(recalibrateBriefItemClasses(summaries));
+  return summaries.filter((summary) => {
+    if (alreadyDemoted.has(summary.itemClass)) return false;
+    if (options.itemClass) return summary.itemClass === options.itemClass;
+    return (
+      summary.actedOnCount === 0 &&
+      summary.renderedCount + summary.ignoredCount >= surfacedThreshold
+    );
+  });
 }
 
 export function buildBriefEditorialContract(args: {

--- a/plugins/plugin-personal-assistant/src/lifeops/optimized-prompt-instructions.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/optimized-prompt-instructions.ts
@@ -49,7 +49,14 @@ the schedule-changing or reply-needed items first. Mention each non-empty
 domain once. If a domain is empty, omit it rather than saying "nothing to
 report". Plain everyday words only: no internal ids, no ISO timestamps, no
 schema or field names. No invented facts; only describe items in the data
-below.`;
+below.
+
+Obey the editorial block in the data: open with its "lead" item (the highest
+consequence item), cover the "include" items, give "demote" items at most a
+passing mention, and never resurface an "omit" item. Never describe more
+than editorial.maxItems items in total. When editorial.pushback is set,
+end by naming exactly one meeting to cancel, decline, or shorten and justify
+that cut in plain terms.`;
 
 export const MEETING_PREP_INSTRUCTIONS =
   "Prepare the next working block: scan upcoming calendar events, related threads, docs, blockers, and people context. Surface missing agenda, location, dial-in, prep document, decision owner, and likely follow-up. Keep the owner-facing result compact.";

--- a/plugins/plugin-personal-assistant/test/brief-action.test.ts
+++ b/plugins/plugin-personal-assistant/test/brief-action.test.ts
@@ -90,7 +90,10 @@ async function callBrief(
 describe("BRIEF umbrella action — Daily Operations", () => {
   beforeEach(() => {
     __resetBriefComposersForTests();
-    setBriefComposers({ loadEngagementSummaries: async () => [] });
+    setBriefComposers({
+      loadEngagementSummaries: async () => [],
+      recordRenderedImpressions: async () => 0,
+    });
     mocks.hasOwnerAccess.mockReset().mockResolvedValue(true);
   });
 

--- a/plugins/plugin-personal-assistant/test/brief-editorial-judgment.test.ts
+++ b/plugins/plugin-personal-assistant/test/brief-editorial-judgment.test.ts
@@ -6,7 +6,10 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   buildBriefEditorialContract,
+  recalibrateBriefItemClasses,
+  selectRecalibrationCandidates,
   structureBriefingItems,
+  summarizeBriefEngagementRows,
 } from "../src/lifeops/briefing/editorial-judgment.js";
 import { LifeOpsRepository } from "../src/lifeops/repository.js";
 import type { LifeOpsBriefingSections } from "../src/types/briefing.js";
@@ -89,6 +92,8 @@ describe("brief editorial judgment", () => {
           ignoredCount: 5,
           actedOnCount: 0,
           lastEventAt: "2026-07-05T12:00:00.000Z",
+          lastDemotedAt: null,
+          lastKeptAt: null,
         },
       ],
     });
@@ -102,6 +107,113 @@ describe("brief editorial judgment", () => {
           "inbox:newsletter-digest has repeated ignore history with no acted-on signal",
       }),
     );
+  });
+
+  it("tracks explicit demoted/kept markers and gives them precedence over ignore counts", () => {
+    const rows = [
+      {
+        itemClass: "inbox:newsletter-digest",
+        eventType: "rendered" as const,
+        eventAt: "2026-07-01T12:00:00.000Z",
+      },
+      {
+        itemClass: "inbox:newsletter-digest",
+        eventType: "demoted" as const,
+        eventAt: "2026-07-02T12:00:00.000Z",
+      },
+      {
+        itemClass: "life:habit",
+        eventType: "ignored" as const,
+        eventAt: "2026-07-02T12:00:00.000Z",
+      },
+    ];
+    const summaries = summarizeBriefEngagementRows(rows);
+    const newsletter = summaries.find(
+      (summary) => summary.itemClass === "inbox:newsletter-digest",
+    );
+    expect(newsletter).toMatchObject({
+      lastDemotedAt: "2026-07-02T12:00:00.000Z",
+      lastKeptAt: null,
+    });
+
+    // Explicit demoted marker demotes even though ignoredCount is below the
+    // automatic threshold.
+    expect(recalibrateBriefItemClasses(summaries)).toEqual([
+      "inbox:newsletter-digest",
+    ]);
+
+    // A later kept marker reverses the demotion regardless of counts —
+    // including a same-instant reset, which must win.
+    const reset = summarizeBriefEngagementRows([
+      ...rows,
+      {
+        itemClass: "inbox:newsletter-digest",
+        eventType: "kept" as const,
+        eventAt: "2026-07-02T12:00:00.000Z",
+      },
+    ]);
+    expect(recalibrateBriefItemClasses(reset)).toEqual([]);
+
+    // A kept marker also overrides the automatic ignore rule.
+    const keptDespiteIgnores = summarizeBriefEngagementRows(
+      Array.from({ length: 5 }, (_, index) => ({
+        itemClass: "inbox:newsletter-digest",
+        eventType: "ignored" as const,
+        eventAt: `2026-07-0${index + 1}T12:00:00.000Z`,
+      })).concat([
+        {
+          itemClass: "inbox:newsletter-digest",
+          eventType: "kept" as const,
+          eventAt: "2026-07-06T12:00:00.000Z",
+        },
+      ]),
+    );
+    expect(recalibrateBriefItemClasses(keptDespiteIgnores)).toEqual([]);
+  });
+
+  it("selects recalibration candidates by revealed preference and exact targeted class", () => {
+    const summaries = summarizeBriefEngagementRows([
+      // Rendered five times, never acted on -> untargeted candidate.
+      ...Array.from({ length: 5 }, (_, index) => ({
+        itemClass: "inbox:newsletter-digest",
+        eventType: "rendered" as const,
+        eventAt: `2026-07-0${index + 1}T12:00:00.000Z`,
+      })),
+      // Rendered five times but acted on -> never an untargeted candidate.
+      ...Array.from({ length: 5 }, (_, index) => ({
+        itemClass: "calendar:meeting",
+        eventType: "rendered" as const,
+        eventAt: `2026-07-0${index + 1}T13:00:00.000Z`,
+      })),
+      {
+        itemClass: "calendar:meeting",
+        eventType: "completed" as const,
+        eventAt: "2026-07-05T14:00:00.000Z",
+      },
+      // Barely surfaced -> below the threshold.
+      {
+        itemClass: "life:habit",
+        eventType: "rendered" as const,
+        eventAt: "2026-07-05T15:00:00.000Z",
+      },
+    ]);
+
+    expect(
+      selectRecalibrationCandidates(summaries).map((s) => s.itemClass),
+    ).toEqual(["inbox:newsletter-digest"]);
+
+    // A targeted command selects exactly the named class and nothing else,
+    // even when that class would not qualify automatically.
+    expect(
+      selectRecalibrationCandidates(summaries, {
+        itemClass: "life:habit",
+      }).map((s) => s.itemClass),
+    ).toEqual(["life:habit"]);
+    expect(
+      selectRecalibrationCandidates(summaries, {
+        itemClass: "calendar:meeting",
+      }).map((s) => s.itemClass),
+    ).toEqual(["calendar:meeting"]);
   });
 
   it("persists engagement rows and summarizes recalibration signals", async () => {
@@ -155,6 +267,8 @@ describe("brief editorial judgment", () => {
         ignoredCount: 5,
         actedOnCount: 0,
         lastEventAt: "2026-07-05T12:00:00.000Z",
+        lastDemotedAt: null,
+        lastKeptAt: null,
       },
     ]);
     expect(

--- a/plugins/plugin-personal-assistant/test/brief-recalibrate-action.test.ts
+++ b/plugins/plugin-personal-assistant/test/brief-recalibrate-action.test.ts
@@ -1,0 +1,304 @@
+/**
+ * BRIEF recalibration feedback loop — integration tests against the real
+ * PGLite-backed LifeOps runtime. Covers the delivery-boundary `rendered`
+ * impression write (only after a provided callback resolved), the owner
+ * `recalibrate` / `reset_recalibration` verbs (targeted writes touch exactly
+ * the named class), and the persisted markers driving demotion and
+ * restoration in the next composed brief. Owner access is mocked; the
+ * database, repository, editorial contract, and action handler are real.
+ */
+
+import type {
+  HandlerOptions,
+  IAgentRuntime,
+  Memory,
+  UUID,
+} from "@elizaos/core";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  hasOwnerAccess: vi.fn(async () => true),
+}));
+
+vi.mock("@elizaos/agent", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@elizaos/agent")>()),
+  hasOwnerAccess: mocks.hasOwnerAccess,
+}));
+
+import {
+  __resetBriefComposersForTests,
+  briefAction,
+  setBriefComposers,
+} from "../src/actions/brief.js";
+import { structureBriefingItems } from "../src/lifeops/briefing/editorial-judgment.js";
+import { LifeOpsRepository } from "../src/lifeops/repository.js";
+import { executeRawSql } from "../src/lifeops/sql.js";
+import type {
+  LifeOpsBriefing,
+  LifeOpsBriefingSections,
+} from "../src/types/briefing.js";
+import { createLifeOpsTestRuntime } from "./helpers/runtime.ts";
+
+const sections: LifeOpsBriefingSections = {
+  calendar: [
+    {
+      id: "board-prep",
+      title: "Board prep with investor questions",
+      startAt: "2026-07-06T16:00:00.000Z",
+      endAt: "2026-07-06T17:00:00.000Z",
+    },
+  ],
+  inbox: [
+    {
+      id: "msg-newsletter",
+      channel: "gmail",
+      senderName: "Industry Roundup",
+      snippet: "Weekly newsletter digest and promo updates.",
+      urgency: "low",
+      classification: "newsletter",
+    },
+  ],
+};
+
+const NEWSLETTER_CLASS = "inbox:newsletter-digest";
+const CALENDAR_CLASS = "calendar:high-consequence";
+
+function makeMessage(text = "brief housekeeping"): Memory {
+  return {
+    id: "msg-brief-recal-1" as UUID,
+    entityId: "owner-1" as UUID,
+    roomId: "room-brief-recal-1" as UUID,
+    content: { text },
+  } as Memory;
+}
+
+async function callBrief(
+  runtime: IAgentRuntime,
+  parameters: Record<string, unknown>,
+  callback?: () => Promise<undefined>,
+) {
+  return briefAction.handler(
+    runtime,
+    makeMessage(),
+    undefined,
+    { parameters } as unknown as HandlerOptions,
+    callback,
+  );
+}
+
+function briefingFromResult(result: unknown): LifeOpsBriefing {
+  const briefing = (result as { data?: { briefing?: LifeOpsBriefing } }).data
+    ?.briefing;
+  if (!briefing) throw new Error("action result carried no briefing");
+  return briefing;
+}
+
+describe("BRIEF recalibration feedback loop (real PGLite)", () => {
+  let runtimeResult: Awaited<ReturnType<typeof createLifeOpsTestRuntime>>;
+  let runtime: IAgentRuntime;
+  let repository: LifeOpsRepository;
+
+  beforeAll(async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    runtime = runtimeResult.runtime;
+    await LifeOpsRepository.bootstrapSchema(runtime);
+    repository = new LifeOpsRepository(runtime);
+  }, 120_000);
+
+  afterAll(async () => {
+    await runtimeResult?.cleanup();
+  });
+
+  beforeEach(async () => {
+    mocks.hasOwnerAccess.mockReset().mockResolvedValue(true);
+    __resetBriefComposersForTests();
+    setBriefComposers({
+      loadCalendar: async () => sections.calendar ?? [],
+      loadInbox: async () => sections.inbox ?? [],
+      loadLife: async () => [],
+      loadMoney: async () => [],
+      loadCompletedToday: async () => [],
+    });
+    await executeRawSql(
+      runtime,
+      "DELETE FROM app_lifeops.life_brief_item_engagements",
+    );
+  });
+
+  async function allRows() {
+    return repository.listBriefItemEngagements(runtime.agentId);
+  }
+
+  it("records one rendered impression per surfaced item only after a delivered compose", async () => {
+    const result = await callBrief(
+      runtime,
+      { action: "compose_morning", format: "json" },
+      async () => undefined,
+    );
+    expect(result).toMatchObject({ success: true });
+    const briefing = briefingFromResult(result);
+
+    const rows = await allRows();
+    const surfaced = briefing.editorial.decisions.filter(
+      (decision) => decision.action !== "omit",
+    );
+    expect(rows).toHaveLength(surfaced.length);
+    expect(rows.every((row) => row.eventType === "rendered")).toBe(true);
+    expect(rows.every((row) => row.briefingId === briefing.id)).toBe(true);
+    expect(rows[0]?.metadata).toMatchObject({
+      briefingKind: "morning",
+      period: "today",
+    });
+
+    // No callback -> nothing was shown to the owner -> no impressions.
+    const undelivered = await callBrief(runtime, {
+      action: "compose_morning",
+      format: "json",
+    });
+    expect(undelivered).toMatchObject({ success: true });
+    expect(await allRows()).toHaveLength(surfaced.length);
+  });
+
+  async function seedRendered(itemClass: "newsletter" | "calendar") {
+    const source =
+      itemClass === "newsletter"
+        ? { inbox: sections.inbox ?? [] }
+        : { calendar: sections.calendar ?? [] };
+    const [item] = structureBriefingItems(source);
+    if (!item) throw new Error("fixture produced no structured item");
+    for (let day = 1; day <= 5; day += 1) {
+      await repository.recordBriefItemEngagement({
+        agentId: runtime.agentId,
+        briefingId: `seed-brief-${itemClass}-${day}`,
+        itemId: item.itemId,
+        source: item.source,
+        kind: item.kind,
+        sourceId: item.sourceId,
+        itemClass: item.itemClass,
+        eventType: "rendered",
+        eventAt: `2026-07-0${day}T12:00:00.000Z`,
+        weight: 0,
+        metadata: { briefingKind: "morning", period: "today" },
+      });
+    }
+    return item;
+  }
+
+  it("recalibrate demotes surfaced-never-acted classes visibly and reversibly", async () => {
+    const newsletter = await seedRendered("newsletter");
+    const calendar = await seedRendered("calendar");
+    // The owner acted on the calendar class, so it must never auto-demote.
+    await repository.recordBriefItemEngagement({
+      agentId: runtime.agentId,
+      briefingId: "seed-brief-calendar-5",
+      itemId: calendar.itemId,
+      source: calendar.source,
+      kind: calendar.kind,
+      sourceId: calendar.sourceId,
+      itemClass: calendar.itemClass,
+      eventType: "completed",
+      eventAt: "2026-07-05T18:00:00.000Z",
+      weight: 1,
+      metadata: {},
+    });
+
+    const result = await callBrief(
+      runtime,
+      { action: "recalibrate" },
+      async () => undefined,
+    );
+    expect(result).toMatchObject({
+      success: true,
+      data: { demotedItemClasses: [NEWSLETTER_CLASS] },
+    });
+    expect(String((result as { text?: string }).text)).toContain(
+      NEWSLETTER_CLASS,
+    );
+    expect(String((result as { text?: string }).text)).toContain("reversible");
+
+    const markers = (await allRows()).filter(
+      (row) => row.eventType === "demoted",
+    );
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toMatchObject({
+      itemClass: NEWSLETTER_CLASS,
+      itemId: newsletter.itemId,
+    });
+
+    // The next composed brief demotes the class through the real summary load.
+    const composed = await callBrief(
+      runtime,
+      { action: "compose_morning", format: "json" },
+      async () => undefined,
+    );
+    const briefing = briefingFromResult(composed);
+    expect(briefing.editorial.demotedItemClasses).toContain(NEWSLETTER_CLASS);
+    expect(briefing.editorial.demotedItemClasses).not.toContain(CALENDAR_CLASS);
+
+    // reset_recalibration restores the class and the next brief reflects it.
+    const reset = await callBrief(
+      runtime,
+      { action: "reset_recalibration", itemClass: NEWSLETTER_CLASS },
+      async () => undefined,
+    );
+    expect(reset).toMatchObject({
+      success: true,
+      data: { restoredItemClasses: [NEWSLETTER_CLASS] },
+    });
+    const restored = briefingFromResult(
+      await callBrief(
+        runtime,
+        { action: "compose_morning", format: "json" },
+        async () => undefined,
+      ),
+    );
+    expect(restored.editorial.demotedItemClasses).not.toContain(
+      NEWSLETTER_CLASS,
+    );
+  });
+
+  it("targeted recalibrate writes markers for exactly the named class", async () => {
+    await seedRendered("newsletter");
+    await seedRendered("calendar");
+
+    const result = await callBrief(
+      runtime,
+      { action: "recalibrate", itemClass: CALENDAR_CLASS },
+      async () => undefined,
+    );
+    expect(result).toMatchObject({
+      success: true,
+      data: { demotedItemClasses: [CALENDAR_CLASS] },
+    });
+
+    const markers = (await allRows()).filter(
+      (row) => row.eventType === "demoted",
+    );
+    expect(markers).toHaveLength(1);
+    expect(markers[0]?.itemClass).toBe(CALENDAR_CLASS);
+  });
+
+  it("targeted recalibrate for an unknown class is a visible no-op", async () => {
+    await seedRendered("newsletter");
+    const result = await callBrief(
+      runtime,
+      { action: "recalibrate", itemClass: "life:unknown-class" },
+      async () => undefined,
+    );
+    expect(result).toMatchObject({
+      success: true,
+      data: { error: "NO_ENGAGEMENT_HISTORY" },
+    });
+    expect(
+      (await allRows()).filter((row) => row.eventType === "demoted"),
+    ).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Bounded slice of #14872 (Relates to #14872 — the issue-wide live-model scenario evidence and optimization-reward plumbing remain open; see scope notes below).

This lands the pieces of the brief feedback loop that were still missing on develop after #15095 (ledger schema + editorial contract) and #18584 (summary loading during BRIEF), designed around the delivery-boundary and targeted-write findings that blocked #19252:

1. **Truthful rendered impressions at the delivery boundary** — the BRIEF action persists one `rendered` row per surfaced (non-omitted) editorial item only after the callback delivery of the composed brief resolved (`plugins/plugin-personal-assistant/src/actions/brief.ts`). No callback ⇒ nothing was shown ⇒ no rows; a rejected callback propagates before the write. Rows carry `briefingKind`/`period`/`decision` metadata so evening/weekly results are attributable and never masquerade as morning visibility. Ledger write failure degrades observably via `runtime.reportError` (error-policy J7), never retracting a delivered brief.
2. **Owner-facing `recalibrate` / `reset_recalibration` verbs** — new BRIEF subactions. `recalibrate` summarizes the ledger bounded to rows existing at the command instant (`untilIso = commandAt`, per the temporal-ordering finding on #19252), demotes classes the owner has been shown ≥5 times and never acted on — or exactly one explicitly named class — and reports the decision with counts and the reversal instruction. `reset_recalibration` restores classes. Candidate filtering happens before any write, so a targeted command can never write a marker for an unrelated class (the targeted-recalibration regression from the #19252 review is covered directly).
3. **Explicit, reversible markers with precedence** — summaries now track `lastDemotedAt`/`lastKeptAt`; an explicit `demoted` marker demotes regardless of counts, a newer (or same-instant) `kept` marker restores regardless of counts, and only marker-free classes fall back to the automatic ignore rule. No synthetic `ignored` rows are fabricated (the check-then-insert expiry race from #19252 has no analogue here — every write is owner-command-driven).
4. **Editorial contract in the brief prompt** — `BRIEF_NARRATIVE_INSTRUCTIONS` now instructs the compose model to open with the `lead` item, cap at `editorial.maxItems`, give `demote` items at most a passing mention, never resurface `omit` items, and justify exactly one cut when `pushback` is set.

## Explicitly out of scope (stays open on #14872)

- Scheduled-dispatch attribution: the wake-triggered `morning-brief` pack still delegates to `assembleMorningBrief`/CheckinService without structured items; unifying scheduled and interactive assembly behind one delivery artifact is the larger architecture change the #19252 review described.
- Inferred production reply/open/keep capture and optimization-reward plumbing into the `morning_brief` dataset.
- Credentialed live-model scenario evidence (this shell has no live model credentials; the PGLite coverage below is deterministic and real-database).

## Test results (plugins/plugin-personal-assistant)

- `bun run typecheck` — clean
- `bun run test -- test/brief-recalibrate-action.test.ts` — 4/4 passed (real PGLite runtime: delivery-gated impressions incl. no-callback case, untargeted + targeted recalibrate, unknown-class visible no-op, demote→next-brief→reset→next-brief round trip)
- `bun run test -- test/brief-editorial-judgment.test.ts test/brief-action.test.ts test/brief-optimized-prompt.test.ts` — 3 files / 29 passed (includes new marker-precedence and candidate-selection unit tests)
- `bun run test -- test/lifeops-llm-consumer-robustness.test.ts test/lifeops-optimized-artifact-verify.test.ts test/default-pack-morning-brief.parity.test.ts` — 17 passed / 6 skipped
- Biome check on all touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)