### PR TITLE
security(pii): register production PII_SCRUB route and wire the context/pseudonym stage

### DIFF
--- a/packages/core/src/services/pii-scrub-context-stage.test.ts
+++ b/packages/core/src/services/pii-scrub-context-stage.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Exercises the production context-retrieval / pseudonym-consistency stage of
+ * {@link PiiScrubService} (#15973) through the service's real request entry and
+ * drain path: requests that arrive WITHOUT a pre-assembled context pack get
+ * one assembled from the REAL encrypted corpus pseudonym map
+ * (`EncryptedCachePseudonymMapStore` over the runtime cache) and the real
+ * `assembleContextPack` stage, the grown map is persisted encrypted BEFORE the
+ * done-marker, and a service restarted over the same cache reuses the same
+ * surrogate for the same entity. The model handler is a scripted judge; every
+ * other collaborator (seam, map, store, markers) is the production code.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+import { PII_PSEUDONYM_MAP_CACHE_KEY } from "../security/pii-pseudonym-map-store.js";
+import type {
+	PiiScrubParams,
+	PiiScrubResult,
+	PiiScrubVerdict,
+} from "../types/model.js";
+import { ModelType } from "../types/model.js";
+import type { IAgentRuntime } from "../types/runtime.js";
+import { PiiScrubService } from "./pii-scrub.js";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000001";
+const RULESET = "2026.08";
+
+interface MockRuntime extends IAgentRuntime {
+	__cache: Map<string, unknown>;
+	__events: { type: string; payload: Record<string, unknown> }[];
+	__reported: { scope: string; error: unknown }[];
+	__scrubCalls: PiiScrubParams[];
+}
+
+/**
+ * Mock runtime with a REAL durable cache map (the encrypted map store and the
+ * done-markers write through it), a scripted PII_SCRUB judge that answers
+ * every required span using the supplied pseudonym assignments, and a fake
+ * knowledge-graph service resolving "Alice Johnson" to one stable entity.
+ */
+function makeRuntime(
+	options: { cache?: Map<string, unknown> } = {},
+): MockRuntime {
+	const cache = options.cache ?? new Map<string, unknown>();
+	const events: { type: string; payload: Record<string, unknown> }[] = [];
+	const reported: { scope: string; error: unknown }[] = [];
+	const scrubCalls: PiiScrubParams[] = [];
+	const noop = () => {};
+
+	const scrubHandler = async (
+		params: PiiScrubParams,
+	): Promise<PiiScrubResult> => {
+		scrubCalls.push(params);
+		const byCluster = new Map(
+			(params.pseudonymAssignments ?? []).map((a) => [a.entityClusterId, a]),
+		);
+		const verdicts: PiiScrubVerdict[] = params.candidateSpans.map((span) => {
+			const assignment = [...byCluster.values()][0];
+			return {
+				span,
+				kind: "pii" as const,
+				replacement: assignment?.surrogate ?? "Redacted Person",
+				...(assignment ? { entityClusterId: assignment.entityClusterId } : {}),
+			};
+		});
+		return {
+			verdicts,
+			modelId: "scripted-judge",
+			rulesetVersion: params.rulesetVersion,
+		};
+	};
+
+	const kgService = {
+		getEntityStore: () => ({
+			resolve: async (query: { name?: string }) =>
+				query.name?.includes("Alice Johnson")
+					? [
+							{
+								entity: {
+									entityId: "e1",
+									type: "person",
+									preferredName: "Alice Johnson",
+									identities: [],
+								},
+								confidence: 0.9,
+								evidence: ["exact-name"],
+							},
+						]
+					: [],
+		}),
+	};
+
+	const runtime = {
+		agentId: AGENT_ID,
+		logger: { info: noop, warn: noop, debug: noop, error: noop },
+		getModel: (type: string) =>
+			type === ModelType.PII_SCRUB ? scrubHandler : undefined,
+		useModel: async (type: string, params: unknown) => {
+			if (type !== ModelType.PII_SCRUB) {
+				throw new Error(`No handler for ${type}`);
+			}
+			return scrubHandler(params as PiiScrubParams);
+		},
+		getService: (name: string) =>
+			name === "eliza_knowledge_graph" ? kgService : null,
+		getCache: async <T>(key: string): Promise<T | undefined> =>
+			cache.has(key) ? (cache.get(key) as T) : undefined,
+		setCache: async <T>(key: string, value: T): Promise<boolean> => {
+			cache.set(key, value);
+			return true;
+		},
+		deleteCache: async (key: string): Promise<boolean> => cache.delete(key),
+		reportError: (scope: string, error: unknown) => {
+			reported.push({ scope, error });
+		},
+		emitEvent: async (type: string, payload: Record<string, unknown>) => {
+			events.push({ type, payload });
+		},
+		registerEvent: vi.fn(),
+		registerTaskWorker: vi.fn(),
+		getTasksByName: async () => [],
+		getTask: async () => null,
+		updateTask: async () => {},
+		createTask: vi.fn(async () => AGENT_ID),
+		deleteTask: vi.fn(async () => {}),
+		log: async () => {},
+	} as unknown as MockRuntime;
+
+	Object.defineProperties(runtime, {
+		__cache: { get: () => cache },
+		__events: { get: () => events },
+		__reported: { get: () => reported },
+		__scrubCalls: { get: () => scrubCalls },
+	});
+	return runtime;
+}
+
+async function drain(service: PiiScrubService): Promise<void> {
+	// biome-ignore lint/suspicious/noExplicitAny: reach the private queue to drive a drain deterministically
+	await (service as any).batchQueue.drain();
+}
+
+async function enqueue(
+	service: PiiScrubService,
+	payload: Record<string, unknown>,
+): Promise<void> {
+	// biome-ignore lint/suspicious/noExplicitAny: exercise the request entry the PII_SCRUB_REQUESTED event invokes
+	await (service as any).handleScrubRequest(payload);
+}
+
+describe("PiiScrubService context stage (#15973)", () => {
+	test("assembles context + assignments and persists the encrypted map before the marker", async () => {
+		const runtime = makeRuntime();
+		const service = (await PiiScrubService.start(runtime)) as PiiScrubService;
+		const content = "Meeting notes: Alice Johnson approved the audit.";
+
+		await enqueue(service, {
+			content,
+			rulesetVersion: RULESET,
+			candidateSpans: ["Alice Johnson"],
+		});
+		await drain(service);
+
+		// The model call carried the assembled stage outputs, not raw defaults.
+		expect(runtime.__scrubCalls).toHaveLength(1);
+		const call = runtime.__scrubCalls[0];
+		expect(call.contextPack).toContain("Resolved entity candidates");
+		expect(call.contextPack).toContain("entity:e1");
+		expect(call.pseudonymAssignments).toHaveLength(1);
+		const assignment = call.pseudonymAssignments?.[0];
+		expect(assignment?.entityClusterId).toBe("entity:e1");
+		expect(assignment?.kind).toBe("person");
+		expect(assignment?.surrogate).toBeTruthy();
+		expect(assignment?.surrogate).not.toContain("Alice");
+
+		// The map was persisted as v2 ciphertext — never plaintext, never the
+		// alias — and the done-marker exists (persist happens before the marker).
+		const stored = runtime.__cache.get(PII_PSEUDONYM_MAP_CACHE_KEY);
+		expect(typeof stored).toBe("string");
+		expect((stored as string).startsWith("v2:")).toBe(true);
+		expect(stored as string).not.toContain("Alice");
+		expect(await service.getMarker(content, RULESET)).toBeDefined();
+		await service.stop();
+	});
+
+	test("a restarted service over the same cache reuses the SAME surrogate for the same entity", async () => {
+		const cache = new Map<string, unknown>();
+		const first = makeRuntime({ cache });
+		const service1 = (await PiiScrubService.start(first)) as PiiScrubService;
+		await enqueue(service1, {
+			content: "Alice Johnson attended the standup.",
+			rulesetVersion: RULESET,
+			candidateSpans: ["Alice Johnson"],
+		});
+		await drain(service1);
+		await service1.stop();
+		const surrogate1 =
+			first.__scrubCalls[0]?.pseudonymAssignments?.[0]?.surrogate;
+		expect(surrogate1).toBeTruthy();
+
+		// "Restart": a fresh service + fresh runtime instance over the SAME
+		// durable cache — only the encrypted artifact carries the assignment.
+		const second = makeRuntime({ cache });
+		const service2 = (await PiiScrubService.start(second)) as PiiScrubService;
+		await enqueue(service2, {
+			content: "Alice Johnson sent the follow-up memo.",
+			rulesetVersion: RULESET,
+			candidateSpans: ["Alice Johnson"],
+		});
+		await drain(service2);
+		await service2.stop();
+
+		const surrogate2 =
+			second.__scrubCalls[0]?.pseudonymAssignments?.[0]?.surrogate;
+		expect(surrogate2).toBe(surrogate1);
+	});
+
+	test("pre-assembled requests bypass the stage untouched (no second assembly, no map write)", async () => {
+		const runtime = makeRuntime();
+		const service = (await PiiScrubService.start(runtime)) as PiiScrubService;
+		const content = "Notes from Alice Johnson.";
+
+		await enqueue(service, {
+			content,
+			rulesetVersion: RULESET,
+			candidateSpans: ["Alice Johnson"],
+			contextPack: "prebuilt pack",
+			pseudonymAssignments: [
+				{
+					entityClusterId: "entity:pre",
+					surrogate: "Pre Built",
+					kind: "person",
+				},
+			],
+		});
+		await drain(service);
+
+		const call = runtime.__scrubCalls[0];
+		expect(call.contextPack).toBe("prebuilt pack");
+		expect(call.pseudonymAssignments?.[0]?.entityClusterId).toBe("entity:pre");
+		// The stage never ran: nothing loaded or persisted the map artifact.
+		expect(runtime.__cache.has(PII_PSEUDONYM_MAP_CACHE_KEY)).toBe(false);
+		await service.stop();
+	});
+
+	test("a tampered map artifact fails closed: no model call, no marker, FAILED after retries", async () => {
+		const runtime = makeRuntime();
+		runtime.__cache.set(PII_PSEUDONYM_MAP_CACHE_KEY, "v2:zz:zz:zz");
+		const service = (await PiiScrubService.start(runtime)) as PiiScrubService;
+		const content = "Escalate Alice Johnson's ticket.";
+
+		await enqueue(service, {
+			content,
+			rulesetVersion: RULESET,
+			candidateSpans: ["Alice Johnson"],
+		});
+		for (let i = 0; i < 6; i++) {
+			await drain(service);
+		}
+
+		expect(runtime.__scrubCalls).toHaveLength(0);
+		expect(await service.getMarker(content, RULESET)).toBeUndefined();
+		expect(runtime.__events.some((e) => e.type === "PII_SCRUB_FAILED")).toBe(
+			true,
+		);
+		expect(runtime.__reported.some((r) => r.scope === "pii-scrub")).toBe(true);
+		await service.stop();
+	});
+});

--- a/packages/core/src/services/pii-scrub.ts
+++ b/packages/core/src/services/pii-scrub.ts
@@ -15,7 +15,13 @@
  *      (idempotency: a re-scrub of unchanged content is a no-op - zero model
  *      calls, zero duplicate writes). This is what makes crash-and-rerun safe
  *      with zero cursor state.
- *   2. Escalates through the merged seam
+ *   2. When the request did not pre-assemble context, runs the
+ *      context-retrieval / pseudonym-consistency stage (#15973): loads the
+ *      encrypted corpus pseudonym map, assembles the context pack + per-chunk
+ *      assignment slice (`../security/pii-context-pack.ts`), and — after a
+ *      successful scrub — persists the grown map BEFORE the done-marker so
+ *      pseudonyms stay consistent across restarts.
+ *   3. Escalates through the merged seam
  *      (`scrubWithEscalation`, #14980/#14809): tier-0 deterministic detectors
  *      run first (free, no model call); only residue candidates hit the
  *      `PII_SCRUB` model with `priority: "background"` so the scrub never
@@ -23,7 +29,7 @@
  *      residue throws, which routes the item through `onExhausted` / retry and
  *      the done-marker is NOT written (the item stays quarantined, never
  *      silently passed as clean).
- *   3. Writes the done-marker ONLY after a successful scrub, then emits
+ *   4. Writes the done-marker ONLY after a successful scrub, then emits
  *      `PII_SCRUB_COMPLETED` for progress/observability. Failures emit
  *      `PII_SCRUB_FAILED` and are surfaced via `runtime.reportError`
  *      (RECENT_ERRORS provider + owner escalation).
@@ -38,6 +44,19 @@
  * the model seam itself (already merged).
  */
 
+import {
+	assembleContextPack,
+	entityResolverFromStore,
+	type PiiContextPack,
+	type PiiContextSources,
+	type PiiEntityResolverStore,
+	sourcesFromRuntime,
+} from "../security/pii-context-pack.js";
+import { CorpusPseudonymMap } from "../security/pii-pseudonym-map.js";
+import {
+	EncryptedCachePseudonymMapStore,
+	type PseudonymMapStore,
+} from "../security/pii-pseudonym-map-store.js";
 import {
 	getScrubMarker,
 	isScrubDone,
@@ -224,13 +243,39 @@ export class PiiScrubService extends Service {
 
 		let escalated: boolean;
 		let modelId: string;
+		let stage: { store: PseudonymMapStore; map: CorpusPseudonymMap } | null =
+			null;
 		try {
+			// Context-retrieval / pseudonym-consistency stage (#15973): when the
+			// requester did not pre-assemble a context pack, assemble one here
+			// from the persisted (encrypted) corpus pseudonym map and the
+			// runtime's retrieval surfaces, so the model verdicts are
+			// context-aware and one person keeps ONE pseudonym corpus-wide. A
+			// corrupt/tampered map artifact throws (fail-closed) and routes the
+			// item through retry/quarantine.
+			let contextPack = item.contextPack;
+			let pseudonymAssignments = item.pseudonymAssignments;
+			let candidateSpans = item.candidateSpans;
+			if (
+				contextPack === undefined &&
+				pseudonymAssignments === undefined &&
+				candidateSpans.length > 0
+			) {
+				const assembled = await this.assembleContextStage(item);
+				stage = { store: assembled.store, map: assembled.map };
+				contextPack = assembled.pack.contextPack;
+				pseudonymAssignments = assembled.pack.assignments;
+				if (assembled.pack.candidateSpans.length > 0) {
+					candidateSpans = assembled.pack.candidateSpans;
+				}
+			}
+
 			const result = await scrubWithEscalation(this.runtime, {
 				text: item.content,
-				candidateSpans: item.candidateSpans,
+				candidateSpans,
 				rulesetVersion: item.rulesetVersion,
-				contextPack: item.contextPack,
-				pseudonymAssignments: item.pseudonymAssignments,
+				contextPack,
+				pseudonymAssignments,
 				priority: item.inferencePriority,
 			});
 			escalated = result.escalated;
@@ -255,6 +300,14 @@ export class PiiScrubService extends Service {
 			throw error;
 		}
 
+		// Persist the (possibly grown) pseudonym map BEFORE the done-marker: a
+		// save failure throws and the item retries, so a marked-done item always
+		// has its cluster assignments durably in the encrypted artifact. Nothing
+		// is persisted on the failure path, so a retry re-mints consistently.
+		if (stage && stage.map.size > 0) {
+			await stage.store.save(stage.map.toSnapshot());
+		}
+
 		// Success: write the content-addressed done-marker so a re-scrub of this
 		// exact content under this ruleset no-ops, and a crash-restart resumes
 		// past it with zero duplicate work.
@@ -274,6 +327,69 @@ export class PiiScrubService extends Service {
 			modelId,
 			source: "piiScrubService",
 		});
+	}
+
+	/**
+	 * Assemble the context pack + pseudonym-assignment slice for one item from
+	 * the persisted encrypted corpus map and the runtime's retrieval surfaces
+	 * (documents / memories / entity resolution when a knowledge-graph service
+	 * is registered). Failures propagate — a tampered or wrong-key map artifact
+	 * must quarantine the item, never degrade to a context-free scrub that
+	 * would mint inconsistent pseudonyms.
+	 */
+	private async assembleContextStage(item: PiiScrubQueueItem): Promise<{
+		store: PseudonymMapStore;
+		map: CorpusPseudonymMap;
+		pack: PiiContextPack;
+	}> {
+		const store = new EncryptedCachePseudonymMapStore(this.runtime);
+		const snapshot = await store.load();
+		const map = snapshot
+			? CorpusPseudonymMap.fromSnapshot(snapshot)
+			: new CorpusPseudonymMap();
+		const resolveEntity = this.entityResolverFromRuntime();
+		// A runtime without service lookup (minimal harnesses) has no retrieval
+		// surfaces; the pack is then assembled from the map alone — sources are
+		// structurally absent, recorded in `sourcesQueried`, never fabricated.
+		const sources: PiiContextSources =
+			typeof (this.runtime as { getService?: unknown }).getService ===
+			"function"
+				? sourcesFromRuntime(
+						this.runtime,
+						resolveEntity ? { resolveEntity } : {},
+					)
+				: {};
+		const pack = await assembleContextPack(sources, {
+			chunk: item.content,
+			candidates: item.candidateSpans.map((surfaceForm) => ({
+				surfaceForm,
+				kind: "unknown",
+			})),
+			map,
+			rulesetVersion: item.rulesetVersion,
+		});
+		return { store, map, pack };
+	}
+
+	/**
+	 * Structural probe for the agent-side knowledge-graph service (core cannot
+	 * import `@elizaos/agent`). An absent service means entity resolution is
+	 * structurally unavailable, which `assembleContextPack` records in
+	 * `sourcesQueried` — a configuration fact, not a silent degrade.
+	 */
+	private entityResolverFromRuntime(): PiiContextSources["resolveEntity"] {
+		const withServices = this.runtime as {
+			getService?: (name: string) => unknown;
+		};
+		if (typeof withServices.getService !== "function") return undefined;
+		const kg = withServices.getService("eliza_knowledge_graph") as
+			| (Service & {
+					getEntityStore?: () => PiiEntityResolverStore;
+			  })
+			| null;
+		const getStore = kg?.getEntityStore;
+		if (!kg || typeof getStore !== "function") return undefined;
+		return entityResolverFromStore(getStore.call(kg));
 	}
 
 	/** Emit FAILED + report the error after retries are exhausted. */

--- a/plugins/plugin-local-inference/AGENTS.md
+++ b/plugins/plugin-local-inference/AGENTS.md
@@ -20,7 +20,7 @@ The plugin owns the `VoiceProfileStore` (speaker centroids); a merge-engine plug
 - **handles** `VOICE_ENTITY_BOUND` (`handleVoiceEntityBound`, registered in `provider.ts`) — persists the merge-engine's `entityId` onto every profile in the imprint cluster via `VoiceProfileStore.bindEntity` (the runtime caller that issue #8234 was missing).
 
 ### Model handlers (registered by `createLocalInferenceModelHandlers()`)
-`TEXT_SMALL`, `TEXT_LARGE`, `TEXT_EMBEDDING`, `IMAGE`, `IMAGE_DESCRIPTION`, `TEXT_TO_SPEECH`, `TRANSCRIPTION`
+`TEXT_SMALL`, `TEXT_LARGE`, `TEXT_EMBEDDING`, `IMAGE`, `IMAGE_DESCRIPTION`, `TEXT_TO_SPEECH`, `TRANSCRIPTION`, `PII_SCRUB`
 
 `TEXT_EMBEDDING` is **not** registered on the static plugin object — it is wired at boot by `ensureLocalInferenceHandler()` in the runtime subpath to avoid claiming the embedding slot before a backend is active.
 
@@ -67,6 +67,7 @@ src/
 
   pii/
     llm-recognizer.ts             LLM-backed PII named-entity recognizer (person/org/location) — prompt build, JSON parse, verbatim relocation, chunking
+    scrub-handler.ts              PII_SCRUB judgment prompt builder + fail-closed completion parser (production scrub escalation, #15973)
     service.ts                    LocalPiiRecognizerService — injects the recognizer behind core's PII_ENTITY_RECOGNIZER_SERVICE seam
 
   actions/

--- a/plugins/plugin-local-inference/CLAUDE.md
+++ b/plugins/plugin-local-inference/CLAUDE.md
@@ -20,7 +20,7 @@ The plugin owns the `VoiceProfileStore` (speaker centroids); a merge-engine plug
 - **handles** `VOICE_ENTITY_BOUND` (`handleVoiceEntityBound`, registered in `provider.ts`) — persists the merge-engine's `entityId` onto every profile in the imprint cluster via `VoiceProfileStore.bindEntity` (the runtime caller that issue #8234 was missing).
 
 ### Model handlers (registered by `createLocalInferenceModelHandlers()`)
-`TEXT_SMALL`, `TEXT_LARGE`, `TEXT_EMBEDDING`, `IMAGE`, `IMAGE_DESCRIPTION`, `TEXT_TO_SPEECH`, `TRANSCRIPTION`
+`TEXT_SMALL`, `TEXT_LARGE`, `TEXT_EMBEDDING`, `IMAGE`, `IMAGE_DESCRIPTION`, `TEXT_TO_SPEECH`, `TRANSCRIPTION`, `PII_SCRUB`
 
 `TEXT_EMBEDDING` is **not** registered on the static plugin object — it is wired at boot by `ensureLocalInferenceHandler()` in the runtime subpath to avoid claiming the embedding slot before a backend is active.
 
@@ -67,6 +67,7 @@ src/
 
   pii/
     llm-recognizer.ts             LLM-backed PII named-entity recognizer (person/org/location) — prompt build, JSON parse, verbatim relocation, chunking
+    scrub-handler.ts              PII_SCRUB judgment prompt builder + fail-closed completion parser (production scrub escalation, #15973)
     service.ts                    LocalPiiRecognizerService — injects the recognizer behind core's PII_ENTITY_RECOGNIZER_SERVICE seam
 
   actions/

--- a/plugins/plugin-local-inference/src/pii/scrub-handler.test.ts
+++ b/plugins/plugin-local-inference/src/pii/scrub-handler.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Deterministic unit tests for the production PII_SCRUB handler lane — the
+ * prompt builder and fail-closed completion parser, plus the registered
+ * handler exercised through the plugin's model map with a scripted backend
+ * service standing in for the resident llama.cpp runtime (no model download).
+ */
+
+import { ModelType, type PiiScrubParams } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { createLocalInferenceModelHandlers } from "../provider.js";
+import { buildPiiScrubPrompt, parseScrubCompletion } from "./scrub-handler.js";
+
+const PARAMS: PiiScrubParams = {
+	text: "Meeting notes: Alice Johnson met Acme Corp about the Q3 audit.",
+	candidateSpans: ["Alice Johnson", "Acme Corp"],
+	contextPack: "Resolved entity candidates:\n- entity:e1 (person)",
+	pseudonymAssignments: [
+		{ entityClusterId: "entity:e1", surrogate: "Nora Vane", kind: "person" },
+	],
+	rulesetVersion: "2026.08",
+};
+
+describe("buildPiiScrubPrompt", () => {
+	it("carries the text, candidates, context pack, and assignment surrogates", () => {
+		const prompt = buildPiiScrubPrompt(PARAMS);
+		expect(prompt).toContain("Alice Johnson");
+		expect(prompt).toContain('"Acme Corp"');
+		expect(prompt).toContain("Resolved entity candidates");
+		expect(prompt).toContain("entity:e1");
+		expect(prompt).toContain('"Nora Vane"');
+		expect(prompt).toContain(PARAMS.text);
+	});
+
+	it("omits the context and assignment sections when absent", () => {
+		const prompt = buildPiiScrubPrompt({
+			...PARAMS,
+			contextPack: undefined,
+			pseudonymAssignments: undefined,
+		});
+		expect(prompt).not.toContain("Context:");
+		expect(prompt).not.toContain("Pseudonym assignments");
+	});
+});
+
+describe("parseScrubCompletion (fail-closed)", () => {
+	it("parses one verdict per candidate and keeps safe verdicts replacement-free", () => {
+		const verdicts = parseScrubCompletion(
+			`[{"span":"Alice Johnson","verdict":"pii","replacement":"Nora Vane","cluster":"entity:e1"},
+			  {"span":"Acme Corp","verdict":"safe"}]`,
+			PARAMS,
+		);
+		expect(verdicts).toHaveLength(2);
+		const pii = verdicts.find((v) => v.span === "Alice Johnson");
+		expect(pii?.kind).toBe("pii");
+		expect(pii?.replacement).toBe("Nora Vane");
+		expect(pii?.entityClusterId).toBe("entity:e1");
+		const safe = verdicts.find((v) => v.span === "Acme Corp");
+		expect(safe?.kind).toBe("safe");
+		expect(safe?.replacement).toBeUndefined();
+	});
+
+	it("forces the assignment surrogate over a divergent model replacement (consistency is structural)", () => {
+		const verdicts = parseScrubCompletion(
+			`[{"span":"Alice Johnson","verdict":"pii","replacement":"SOMEONE ELSE","cluster":"entity:e1"},
+			  {"span":"Acme Corp","verdict":"safe"}]`,
+			PARAMS,
+		);
+		const pii = verdicts.find((v) => v.span === "Alice Johnson");
+		expect(pii?.replacement).toBe("Nora Vane");
+	});
+
+	it("drops hallucinated spans not present in the source text but still requires candidate coverage", () => {
+		const verdicts = parseScrubCompletion(
+			`[{"span":"Alice Johnson","verdict":"pii","replacement":"Nora Vane"},
+			  {"span":"Ghost Name","verdict":"pii","replacement":"Whoever"},
+			  {"span":"Acme Corp","verdict":"safe"}]`,
+			PARAMS,
+		);
+		expect(verdicts.map((v) => v.span).sort()).toEqual([
+			"Acme Corp",
+			"Alice Johnson",
+		]);
+	});
+
+	it("throws when a candidate span receives no verdict (never silently clean)", () => {
+		expect(() =>
+			parseScrubCompletion(
+				'[{"span":"Alice Johnson","verdict":"pii","replacement":"Nora Vane"}]',
+				PARAMS,
+			),
+		).toThrow(/omitted a verdict/);
+	});
+
+	it("throws on a pii verdict lacking a usable replacement", () => {
+		expect(() =>
+			parseScrubCompletion(
+				`[{"span":"Alice Johnson","verdict":"pii"},
+				  {"span":"Acme Corp","verdict":"safe"}]`,
+				PARAMS,
+			),
+		).toThrow(/lacks a usable replacement/);
+	});
+
+	it("throws on a replacement equal to the original value (non-redaction)", () => {
+		expect(() =>
+			parseScrubCompletion(
+				`[{"span":"Alice Johnson","verdict":"pii","replacement":"Alice Johnson"},
+				  {"span":"Acme Corp","verdict":"safe"}]`,
+				{ ...PARAMS, pseudonymAssignments: [] },
+			),
+		).toThrow(/lacks a usable replacement/);
+	});
+
+	it("throws on unknown verdict kinds and non-JSON output", () => {
+		expect(() =>
+			parseScrubCompletion(
+				'[{"span":"Alice Johnson","verdict":"maybe"}]',
+				PARAMS,
+			),
+		).toThrow(/unknown kind/);
+		expect(() => parseScrubCompletion("no json here", PARAMS)).toThrow(
+			/no JSON array/,
+		);
+	});
+});
+
+describe("registered PII_SCRUB model handler (production model map)", () => {
+	function runtimeWithBackend(completion: string) {
+		const prompts: string[] = [];
+		return {
+			prompts,
+			runtime: {
+				agentId: "00000000-0000-0000-0000-000000000001",
+				getService: (name: string) =>
+					name === "localInference"
+						? {
+								generate: async (args: { prompt: string }) => {
+									prompts.push(args.prompt);
+									return completion;
+								},
+							}
+						: null,
+				getSetting: () => undefined,
+			} as never,
+		};
+	}
+
+	it("is present in the plugin model map and produces a structurally valid result", async () => {
+		const handlers = createLocalInferenceModelHandlers();
+		const handler = handlers[ModelType.PII_SCRUB];
+		expect(typeof handler).toBe("function");
+		const { runtime, prompts } = runtimeWithBackend(
+			`[{"span":"Alice Johnson","verdict":"pii","replacement":"Nora Vane","cluster":"entity:e1"},
+			  {"span":"Acme Corp","verdict":"safe"}]`,
+		);
+		const result = await (
+			handler as (r: unknown, p: PiiScrubParams) => Promise<unknown>
+		)(runtime, PARAMS);
+		expect(prompts).toHaveLength(1);
+		expect(result).toMatchObject({
+			rulesetVersion: "2026.08",
+			modelId: expect.stringContaining("eliza-local-inference"),
+		});
+		const verdicts = (result as { verdicts: { span: string }[] }).verdicts;
+		expect(verdicts).toHaveLength(2);
+	});
+
+	it("fails closed when no local backend is active", async () => {
+		const handlers = createLocalInferenceModelHandlers();
+		const handler = handlers[ModelType.PII_SCRUB] as (
+			r: unknown,
+			p: PiiScrubParams,
+		) => Promise<unknown>;
+		await expect(
+			handler({ getService: () => null } as never, PARAMS),
+		).rejects.toThrow(/local inference backend/i);
+	});
+});

--- a/plugins/plugin-local-inference/src/pii/scrub-handler.ts
+++ b/plugins/plugin-local-inference/src/pii/scrub-handler.ts
@@ -1,0 +1,171 @@
+/**
+ * Production `PII_SCRUB` prompt builder and completion parser for the
+ * local-inference lane. The core scrub seam
+ * (`packages/core/src/security/pii-scrub-seam.ts`) escalates residue
+ * candidates its deterministic tier-0 detectors cannot decide; this module
+ * turns that escalation into a constrained JSON-judgment prompt against the
+ * resident Eliza-1 backend and parses the completion into the seam's
+ * fail-closed `PiiScrubResult` shape.
+ *
+ * Contract highlights (enforced here, re-verified by the seam's
+ * `assertValidScrubResult`):
+ * - Every escalated candidate span MUST receive a verdict; a completion that
+ *   drops a candidate throws (absence is never interpreted as clean).
+ * - `pii` verdicts must carry a replacement. When the caller supplied a
+ *   pseudonym assignment for the verdict's cluster, that assignment's
+ *   surrogate is used VERBATIM regardless of what the model emitted, so
+ *   corpus-wide pseudonym consistency is structural, not model-trusted.
+ * - Unparseable output throws — the scrub rails retry/quarantine the item.
+ *
+ * The prompt carries the retrieval context pack and the per-chunk
+ * cluster→surrogate slice, never the whole corpus map.
+ */
+
+import type {
+	PiiPseudonymAssignment,
+	PiiScrubParams,
+	PiiScrubVerdict,
+} from "@elizaos/core";
+
+/** Build the constrained judgment prompt for one escalation call. */
+export function buildPiiScrubPrompt(params: PiiScrubParams): string {
+	const sections: string[] = [
+		"You are a privacy scrubber. Judge each candidate span found in the text between <text> tags: is it personally identifying information (PII) that must be replaced, or safe to keep?",
+		`Rules:
+- Output ONLY a JSON array, no prose: [{"span":"...","verdict":"pii","replacement":"...","cluster":"..."}]
+- Include EXACTLY one object per candidate span listed below, "span" copied VERBATIM.
+- "verdict" must be exactly "pii" or "safe".
+- For "pii" verdicts, provide a realistic surrogate "replacement" of the same kind (fake name for a name, fake company for a company). Never reuse the original value.
+- For "safe" verdicts, omit "replacement".
+- When the pseudonym assignments below list a surrogate for an entity, use exactly that surrogate as the replacement and set "cluster" to its cluster id.`,
+	];
+	if (params.contextPack && params.contextPack.trim().length > 0) {
+		sections.push(`Context:\n${params.contextPack.trim()}`);
+	}
+	const assignments = params.pseudonymAssignments ?? [];
+	if (assignments.length > 0) {
+		const lines = assignments.map(
+			(a) =>
+				`- cluster ${a.entityClusterId} (${a.kind}): use surrogate ${JSON.stringify(a.surrogate)}`,
+		);
+		sections.push(
+			`Pseudonym assignments (reuse EXACTLY):\n${lines.join("\n")}`,
+		);
+	}
+	sections.push(
+		`Candidate spans:\n${params.candidateSpans
+			.map((span) => `- ${JSON.stringify(span)}`)
+			.join("\n")}`,
+	);
+	sections.push(`<text>\n${params.text}\n</text>\n\nJSON array:`);
+	return sections.join("\n\n");
+}
+
+/** Raw item shape the model is asked to emit. */
+interface ReportedVerdict {
+	span?: unknown;
+	verdict?: unknown;
+	replacement?: unknown;
+	cluster?: unknown;
+}
+
+/**
+ * Parse the completion into one verdict per candidate span. Throws on
+ * unparseable output, unknown verdict kinds, missing candidates, or a `pii`
+ * verdict with no usable replacement — the fail-closed doctrine: the rails
+ * retry/quarantine, they never treat garbage as clean. Hallucinated verdicts
+ * for spans not present in the source text are dropped; the coverage check
+ * below still requires every real candidate to be judged.
+ */
+export function parseScrubCompletion(
+	completion: string,
+	params: PiiScrubParams,
+): PiiScrubVerdict[] {
+	const start = completion.indexOf("[");
+	const end = completion.lastIndexOf("]");
+	if (start === -1 || end === -1 || end < start) {
+		throw new Error(
+			`[local-inference] PII_SCRUB output contains no JSON array: ${JSON.stringify(completion.slice(0, 200))}`,
+		);
+	}
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(completion.slice(start, end + 1));
+	} catch (cause) {
+		// error-policy:J2 wrap the parse failure with the model-output context;
+		// the seam quarantines the item on throw.
+		throw new Error(
+			`[local-inference] PII_SCRUB output is not valid JSON: ${JSON.stringify(completion.slice(start, start + 200))}`,
+			{ cause },
+		);
+	}
+	if (!Array.isArray(parsed)) {
+		throw new Error("[local-inference] PII_SCRUB output parsed to a non-array");
+	}
+
+	const byCluster = new Map<string, PiiPseudonymAssignment>();
+	for (const assignment of params.pseudonymAssignments ?? []) {
+		byCluster.set(assignment.entityClusterId, assignment);
+	}
+
+	const bySpan = new Map<string, PiiScrubVerdict>();
+	for (const item of parsed as readonly ReportedVerdict[]) {
+		if (item === null || typeof item !== "object") continue;
+		const span = typeof item.span === "string" ? item.span : "";
+		if (span.length === 0 || !params.text.includes(span)) continue;
+		const kindRaw =
+			typeof item.verdict === "string" ? item.verdict.trim().toLowerCase() : "";
+		if (kindRaw !== "pii" && kindRaw !== "safe") {
+			throw new Error(
+				`[local-inference] PII_SCRUB verdict for ${JSON.stringify(span)} has unknown kind ${JSON.stringify(item.verdict)}`,
+			);
+		}
+		if (kindRaw === "safe") {
+			bySpan.set(span, { span, kind: "safe" });
+			continue;
+		}
+		const clusterId =
+			typeof item.cluster === "string" && item.cluster.trim().length > 0
+				? item.cluster.trim()
+				: undefined;
+		// Consistency is structural: an assigned cluster's surrogate wins over
+		// whatever the model emitted, so one person gets ONE pseudonym
+		// corpus-wide.
+		const assignment = clusterId ? byCluster.get(clusterId) : undefined;
+		const replacement =
+			assignment?.surrogate ??
+			(typeof item.replacement === "string" &&
+			item.replacement.trim().length > 0
+				? item.replacement.trim()
+				: undefined);
+		if (!replacement || replacement === span) {
+			throw new Error(
+				`[local-inference] PII_SCRUB pii verdict for ${JSON.stringify(span)} lacks a usable replacement`,
+			);
+		}
+		bySpan.set(span, {
+			span,
+			kind: "pii",
+			replacement,
+			...(assignment ? { entityClusterId: assignment.entityClusterId } : {}),
+		});
+	}
+
+	// Every escalated candidate must be judged. The seam re-checks coverage,
+	// but throwing here keeps the failure attributed to the handler's model
+	// output.
+	for (const candidate of params.candidateSpans) {
+		const needle = candidate.trim();
+		if (needle.length === 0) continue;
+		const covered = [...bySpan.keys()].some(
+			(s) => s === needle || s.includes(needle),
+		);
+		if (!covered) {
+			throw new Error(
+				`[local-inference] PII_SCRUB output omitted a verdict for candidate ${JSON.stringify(candidate)}`,
+			);
+		}
+	}
+
+	return [...bySpan.values()];
+}

--- a/plugins/plugin-local-inference/src/provider.ts
+++ b/plugins/plugin-local-inference/src/provider.ts
@@ -28,6 +28,8 @@ import {
 	inferenceRamClassFromEnv,
 	logger,
 	ModelType,
+	type PiiScrubParams,
+	type PiiScrubResult,
 	type Plugin,
 	resolveBackgroundInferenceBudget,
 	type TextEmbeddingParams,
@@ -47,6 +49,10 @@ import {
 	startTranscriptionAction,
 	stopTranscriptionAction,
 } from "./actions/transcription-control.js";
+import {
+	buildPiiScrubPrompt,
+	parseScrubCompletion,
+} from "./pii/scrub-handler.js";
 import { LocalPiiRecognizerService } from "./pii/service.js";
 import { transcriptsRoutes } from "./routes/transcripts-routes.js";
 import { voiceProfilePluginRoutes } from "./routes/voice-profile-plugin-routes.js";
@@ -621,6 +627,58 @@ function createTextHandler(modelType: string) {
 	};
 }
 
+/**
+ * Production `PII_SCRUB` handler (#15973): runs the scrub-seam escalation as a
+ * constrained JSON-judgment prompt on the resident local backend, so PII never
+ * leaves the device. Defaults to `background` priority — the corpus scrub is
+ * deferred autonomous work and must never queue ahead of an interactive turn.
+ * The prompt is NOT budget-clamped: truncating the text under judgment would
+ * corrupt the verdicts, so a scrub that cannot run whole fails (and the rails
+ * retry) rather than judging a fragment.
+ */
+function createPiiScrubHandler() {
+	return async (
+		runtime: IAgentRuntime,
+		params: PiiScrubParams,
+	): Promise<PiiScrubResult> => {
+		const service = requireService(runtime, ModelType.PII_SCRUB);
+		const generate = service.generate;
+		if (typeof generate !== "function") {
+			throw unavailable(
+				ModelType.PII_SCRUB,
+				"capability_unavailable",
+				"[local-inference] Active local backend does not implement text generation for PII_SCRUB",
+			);
+		}
+		const prompt = buildPiiScrubPrompt(params);
+		const priority = params.priority ?? "background";
+		const completion = await getInferencePriorityGate().runExclusive(
+			{
+				priority,
+				label: `PII_SCRUB local-service (${prompt.length} chars)`,
+				...(params.signal ? { signal: params.signal } : {}),
+			},
+			() =>
+				generate.call(service, {
+					prompt,
+					maxTokens: 1024,
+					temperature: 0,
+				}),
+		);
+		const verdicts = parseScrubCompletion(completion, params);
+		const tier = runtime.getSetting("LOCAL_INFERENCE_ACTIVE_TIER");
+		const modelId =
+			typeof tier === "string" && tier.trim().length > 0
+				? `${LOCAL_INFERENCE_PROVIDER_ID}:${tier.trim()}`
+				: LOCAL_INFERENCE_PROVIDER_ID;
+		return {
+			verdicts,
+			modelId,
+			rulesetVersion: params.rulesetVersion,
+		};
+	};
+}
+
 function createEmbeddingHandler() {
 	return async (
 		runtime: IAgentRuntime,
@@ -1139,6 +1197,7 @@ export function createLocalInferenceModelHandlers(): NonNullable<
 		[ModelType.IMAGE_DESCRIPTION]: createImageDescriptionHandler(),
 		[ModelType.TEXT_TO_SPEECH]: createTextToSpeechHandler(),
 		[ModelType.TRANSCRIPTION]: createTranscriptionHandler(),
+		[ModelType.PII_SCRUB]: createPiiScrubHandler(),
 	};
 }
 


### PR DESCRIPTION
Fixes #15973

## Problem

The context-aware PII pseudonym stage merged in #15841 was unreachable in production. On develop:
- no production package registers a `ModelType.PII_SCRUB` handler (every registration lives under tests), so `scrubWithEscalation` fail-closes on any residue in a live run;
- nothing in the shipped scrub workflow calls `assembleContextPack()` or loads the encrypted corpus pseudonym map, so even with a handler the verdicts would be context-free and pseudonyms inconsistent across items and restarts.

## Change

**Production `PII_SCRUB` model route** (`plugins/plugin-local-inference`):
- `src/pii/scrub-handler.ts` — constrained JSON-judgment prompt builder + fail-closed completion parser. Every escalated candidate must receive a verdict (a dropped candidate throws, never "clean"); a `pii` verdict must carry a usable replacement; a supplied cluster assignment's surrogate is used verbatim regardless of what the model emitted, so corpus-wide pseudonym consistency is structural, not model-trusted.
- `src/provider.ts` — `createPiiScrubHandler()` registered in `createLocalInferenceModelHandlers()` (and therefore on the static plugin object), running on the resident local backend through the inference priority gate at `background` priority. The prompt is deliberately not budget-clamped: judging a truncated fragment would corrupt verdicts, so an over-budget scrub fails and the rails retry.

**Stage wiring in the single existing scrub workflow** (`packages/core/src/services/pii-scrub.ts`, no second scheduler/mechanism):
- Requests arriving without a pre-assembled pack now run the #15841 stage inside the existing drain: load the encrypted corpus map (`EncryptedCachePseudonymMapStore`), assemble the context pack + per-chunk assignment slice (`assembleContextPack`, entity resolution via the knowledge-graph service when registered), and hand both to the seam.
- After a successful scrub the grown map is persisted **before** the done-marker, so a marked-done item always has its assignments durably in the encrypted artifact; nothing persists on the failure path.
- A tampered/wrong-key map artifact throws (fail-closed) and routes through the existing retry/quarantine path — never a context-free scrub that would mint inconsistent pseudonyms.
- Pre-assembled requests (`buildScrubRequestDraft` producers) pass through untouched.

## Tests (all passing locally)

`packages/core` — `bunx vitest run src/services/pii-scrub.test.ts src/services/pii-scrub-context-stage.test.ts` → **13 passed**
- new suite drives the service's real request entry + drain with the REAL encrypted store/map/seam (only the model judge is scripted):
  - stage assembly: model call carries the assembled `contextPack` + `pseudonymAssignments`; map persisted as `v2:` ciphertext (never plaintext, never the alias); marker written after the map save
  - **restart persistence**: a fresh service over the same durable cache reuses the SAME surrogate for the same entity in different content
  - pre-assembled passthrough: stage skipped, no map artifact touched
  - tampered artifact: zero model calls, no done-marker, `PII_SCRUB_FAILED` + `reportError` after retries
- the pre-existing rails suite still passes unchanged (tier-0 short-circuit, idempotency, crash/retry fail-closed).

`plugins/plugin-local-inference` — `bunx vitest run src/pii/scrub-handler.test.ts` → **11 passed** (prompt content, parser fail-closed contracts, assignment-surrogate override, handler exercised through the production model map, backend-absent fail-closed).

Typecheck: `packages/core` tsc clean; `plugins/plugin-local-inference` tsc clean. Biome clean on all touched files.

Per the issue's narrowed scope, the exhaustive adversarial-corpus acceptance list is follow-up evidence; this PR makes the stage reachable by a normal scrub run with a live local model and proves map application + persistence across restart through the production entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)