### PR TITLE
fix(desktop): generate homepage release-data before the direct vite renderer build

### DIFF
--- a/packages/app-core/scripts/desktop-build.mjs
+++ b/packages/app-core/scripts/desktop-build.mjs
@@ -1371,6 +1371,17 @@ function stageDesktopBuild() {
     "Ensuring Electrobun workspace dependencies are installed",
   );
 
+  // The renderer is built by invoking the vite binary directly, which bypasses
+  // the app package's `prebuild` hook. Since the Cloud/eliza.app consolidation
+  // the app's public web entry imports the homepage's generated
+  // `src/generated/release-data.ts`, so the generator must run first or vite
+  // fails with UNLOADABLE_DEPENDENCY (#16212). The generator is offline-safe:
+  // it writes a fallback file when the GitHub releases API is unreachable.
+  runBun([path.join(SCRIPT_DIR, "write-homepage-release-data.mjs")], {
+    cwd: ROOT,
+    label: "Generating homepage release data for the renderer build",
+  });
+
   // Capture the moment the renderer build starts so we can prove afterward that
   // a FRESH bundle was produced — not a stale dist silently reused (issue #9309).
   const rendererBuildStartedAt = Date.now() - 1000;


### PR DESCRIPTION
## Summary

Unblocks the packaged desktop App Live lane tracked by #16212 (does not close it — the issue's acceptance is a fully green scheduled `desktop packaged (build + boot + renderer)` job).

Per the 2026-08-14 triage on #16212, the lane no longer reaches the five original boundary contracts: it fails earlier and deterministically at the renderer build with

```
[UNLOADABLE_DEPENDENCY] Could not load ../homepage/src/generated/release-data
  at ../homepage/src/pages/marketing.tsx:14:29
```

Root cause: `packages/app-core/scripts/desktop-build.mjs` invokes the vite binary directly (`runBunPackageBinary("vite", ["build"])`), which bypasses packages/app's `prebuild` npm hook — the step that runs `packages/app-core/scripts/write-homepage-release-data.mjs`. Since the Cloud/eliza.app consolidation (`0468c1850a3`) the app's public web entry mounts `MarketingHomePage`, which imports the homepage's generated `src/generated/release-data.ts`, so every packaged desktop build on a clean checkout dies at import analysis.

Fix: run the generator immediately before the renderer vite build in `stageDesktopBuild()`. The generator is offline-safe — on GitHub API failure it writes a fallback file (or keeps an existing one) instead of failing the build.

## Verification (clean worktree at `origin/develop@05c5f9759b5`)

- Reproduced the exact CI failure: with `packages/homepage/src/generated/` absent, `VITE_APP_VARIANT=base ELIZA_BUILD_VARIANT=base bunx vite build` in packages/app fails with the identical `[UNLOADABLE_DEPENDENCY] Could not load ../homepage/src/generated/release-data` at `marketing.tsx:14`.
- With the fix's generator step (`bun packages/app-core/scripts/write-homepage-release-data.mjs` → `homepage release data: stable=no published release, canary=v2.0.3-beta.7, osArtifacts=10`), the same build goes green: `✓ built in 1m 12s`, renderer manifest written (`eliza-renderer-build.json buildId=9133797a8fc5`, 1045 assets).
- `biome check` on the touched file — clean.

The remaining #16212 acceptance (green scheduled packaged job with artifact digest) needs a post-merge run of `app-live-e2e.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
