### PR TITLE
feat(companion): opt-in ESP32 companion device bridge

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -118,6 +118,7 @@
         "@elizaos/plugin-cloud-apps": "workspace:*",
         "@elizaos/plugin-coding-tools": "workspace:*",
         "@elizaos/plugin-commands": "workspace:*",
+        "@elizaos/plugin-companion": "workspace:*",
         "@elizaos/plugin-computeruse": "workspace:*",
         "@elizaos/plugin-contacts": "workspace:*",
         "@elizaos/plugin-discord": "workspace:*",
@@ -1556,6 +1557,22 @@
         "@types/bun": "^1.2.22",
         "@types/node": "^24.5.2",
         "@typescript/native": "npm:typescript@^7.0.2",
+        "typescript": "^6.0.3",
+        "vitest": "^4.0.18",
+      },
+    },
+    "plugins/plugin-companion": {
+      "name": "@elizaos/plugin-companion",
+      "version": "2.0.3-beta.7",
+      "dependencies": {
+        "@elizaos/core": "workspace:*",
+        "ws": "^8.21.3",
+      },
+      "devDependencies": {
+        "@types/node": "^25.0.3",
+        "@types/ws": "^8.18.1",
+        "@typescript/native": "npm:typescript@^7.0.2",
+        "tsup": "^8.5.1",
         "typescript": "^6.0.3",
         "vitest": "^4.0.18",
       },
@@ -3994,6 +4011,8 @@
     "@elizaos/plugin-coding-tools": ["@elizaos/plugin-coding-tools@workspace:plugins/plugin-coding-tools"],
 
     "@elizaos/plugin-commands": ["@elizaos/plugin-commands@workspace:plugins/plugin-commands"],
+
+    "@elizaos/plugin-companion": ["@elizaos/plugin-companion@workspace:plugins/plugin-companion"],
 
     "@elizaos/plugin-computeruse": ["@elizaos/plugin-computeruse@workspace:plugins/plugin-computeruse"],
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -340,6 +340,7 @@
     "@elizaos/plugin-cloud-apps": "workspace:*",
     "@elizaos/plugin-calendar": "workspace:*",
     "@elizaos/plugin-coding-tools": "workspace:*",
+    "@elizaos/plugin-companion": "workspace:*",
     "@elizaos/plugin-commands": "workspace:*",
     "@elizaos/plugin-computeruse": "workspace:*",
     "@elizaos/plugin-discord": "workspace:*",

--- a/packages/agent/src/runtime/optional-plugins.ts
+++ b/packages/agent/src/runtime/optional-plugins.ts
@@ -74,6 +74,10 @@ export const OPTIONAL_STATIC_PLUGIN_PACKAGES: readonly string[] = [
 export const UNBUNDLED_OPTIONAL_PLUGINS: readonly string[] = [
   "@elizaos/plugin-gitpathologist",
   "@elizaos/plugin-zerollama",
+  // ESP32 companion device bridge (#18957): opt-in, desktop/node only — the
+  // device is LAN hardware a phone-resident agent never drives, so it stays
+  // out of the mobile bundle.
+  "@elizaos/plugin-companion",
 ];
 
 /**
@@ -164,6 +168,9 @@ export const OPTIONAL_STATIC_PLUGIN_OVERRIDES: Readonly<
   // Ollama is a desktop/server HTTP daemon; never spend a mobile boot timeout
   // trying to import a provider that cannot run on the phone itself.
   "@elizaos/plugin-zerollama": { skipOnMobile: true },
+  // The ESP32 companion bridge is desktop-only opt-in hardware tooling; it is
+  // absent from the mobile bundle, so skip the import up front on android/ios.
+  "@elizaos/plugin-companion": { skipOnMobile: true },
   // Root barrel exports the InboxView React components; the runtime plugin
   // object lives at the ./plugin subpath (src/plugin.ts). Bundling the root
   // would drag react/.tsx into the bun-target mobile agent bundle. (In

--- a/plugins/plugin-companion/AGENTS.md
+++ b/plugins/plugin-companion/AGENTS.md
@@ -1,0 +1,46 @@
+# @elizaos/plugin-companion
+
+Opt-in bridge to a Waveshare ESP32-S3 companion device. The device runs its
+own firmware and acts as the WebSocket **server**
+(`ws://<device>:8080/api/companion/device-bridge?token=<PAIRING_TOKEN>`); this
+plugin is the client.
+
+## Architecture
+
+- `src/protocol.ts` — the single trust boundary for inbound frames.
+  `parseDeviceFrame` yields a typed frame or throws
+  `ElizaError(COMPANION_BAD_FRAME)`; nothing downstream touches raw JSON.
+- `src/service.ts` — `CompanionService` owns the full socket lifecycle:
+  pairing-token connect, `welcome` → `register` handshake gating (no host
+  command before a registered `deviceId`), correlationId-matched commands,
+  ping/pong keepalive with stale-socket disconnect, bounded reconnect, and a
+  generation counter so stale sockets can never resurrect state.
+- `src/actions.ts` — `SET_COMPANION_MOOD`, `GET_COMPANION_STATUS`. Both fail
+  closed (structured failed `ActionResult`) on disconnect or device rejection;
+  the firmware is the authority on valid moods.
+- `src/provider.ts` — `companionDevice` provider surfacing connection, mood,
+  and the last device event (`touch`, `mood_changed`).
+
+## Invariants
+
+- Opt-in only: no `autoEnable`, registered in the agent's
+  `UNBUNDLED_OPTIONAL_PLUGINS` with `skipOnMobile` — never baked into the
+  mobile APK.
+- `COMPANION_WS_URL` and an explicit `COMPANION_PAIRING_TOKEN` are required;
+  the service throws typed errors at start rather than idling half-configured.
+- Protocol garbage from the device (malformed JSON, unknown frames,
+  uncorrelated results) is reported via `runtime.reportError` and never kills
+  the service.
+
+## Validation
+
+```bash
+bun run --cwd plugins/plugin-companion test        # deterministic mock-device suite (real ws server)
+bun run --cwd plugins/plugin-companion typecheck
+bun run --cwd plugins/plugin-companion lint:check
+```
+
+Hardware runs are evidence-only, never a CI gate. Keepalive and command
+timeouts are tunable via `COMPANION_PING_INTERVAL_MS`,
+`COMPANION_PONG_TIMEOUT_MS`, `COMPANION_COMMAND_TIMEOUT_MS`, and
+`COMPANION_RECONNECT_DELAY_MS` (used by the tests; defaults suit hardware).

--- a/plugins/plugin-companion/CLAUDE.md
+++ b/plugins/plugin-companion/CLAUDE.md
@@ -1,0 +1,46 @@
+# @elizaos/plugin-companion
+
+Opt-in bridge to a Waveshare ESP32-S3 companion device. The device runs its
+own firmware and acts as the WebSocket **server**
+(`ws://<device>:8080/api/companion/device-bridge?token=<PAIRING_TOKEN>`); this
+plugin is the client.
+
+## Architecture
+
+- `src/protocol.ts` — the single trust boundary for inbound frames.
+  `parseDeviceFrame` yields a typed frame or throws
+  `ElizaError(COMPANION_BAD_FRAME)`; nothing downstream touches raw JSON.
+- `src/service.ts` — `CompanionService` owns the full socket lifecycle:
+  pairing-token connect, `welcome` → `register` handshake gating (no host
+  command before a registered `deviceId`), correlationId-matched commands,
+  ping/pong keepalive with stale-socket disconnect, bounded reconnect, and a
+  generation counter so stale sockets can never resurrect state.
+- `src/actions.ts` — `SET_COMPANION_MOOD`, `GET_COMPANION_STATUS`. Both fail
+  closed (structured failed `ActionResult`) on disconnect or device rejection;
+  the firmware is the authority on valid moods.
+- `src/provider.ts` — `companionDevice` provider surfacing connection, mood,
+  and the last device event (`touch`, `mood_changed`).
+
+## Invariants
+
+- Opt-in only: no `autoEnable`, registered in the agent's
+  `UNBUNDLED_OPTIONAL_PLUGINS` with `skipOnMobile` — never baked into the
+  mobile APK.
+- `COMPANION_WS_URL` and an explicit `COMPANION_PAIRING_TOKEN` are required;
+  the service throws typed errors at start rather than idling half-configured.
+- Protocol garbage from the device (malformed JSON, unknown frames,
+  uncorrelated results) is reported via `runtime.reportError` and never kills
+  the service.
+
+## Validation
+
+```bash
+bun run --cwd plugins/plugin-companion test        # deterministic mock-device suite (real ws server)
+bun run --cwd plugins/plugin-companion typecheck
+bun run --cwd plugins/plugin-companion lint:check
+```
+
+Hardware runs are evidence-only, never a CI gate. Keepalive and command
+timeouts are tunable via `COMPANION_PING_INTERVAL_MS`,
+`COMPANION_PONG_TIMEOUT_MS`, `COMPANION_COMMAND_TIMEOUT_MS`, and
+`COMPANION_RECONNECT_DELAY_MS` (used by the tests; defaults suit hardware).

--- a/plugins/plugin-companion/README.md
+++ b/plugins/plugin-companion/README.md
@@ -1,0 +1,46 @@
+# @elizaos/plugin-companion
+
+Opt-in plugin that lets an Eliza agent drive a Waveshare ESP32-S3 companion
+device (mood display + touch sensor) over the device's authenticated JSON
+WebSocket protocol. The device is the WebSocket server (SoftAP); the agent is
+the client.
+
+## Configuration
+
+| Setting | Required | Description |
+| --- | --- | --- |
+| `COMPANION_WS_URL` | yes | `ws://<device>:8080/api/companion/device-bridge` |
+| `COMPANION_PAIRING_TOKEN` | yes | Pairing token appended as `?token=` |
+
+Optional timing overrides (milliseconds): `COMPANION_PING_INTERVAL_MS`,
+`COMPANION_PONG_TIMEOUT_MS`, `COMPANION_COMMAND_TIMEOUT_MS`,
+`COMPANION_RECONNECT_DELAY_MS`.
+
+The plugin never auto-enables and is desktop/node only. Add
+`@elizaos/plugin-companion` to a character's plugin list and set both required
+settings; a missing token or URL fails fast at service start.
+
+## Surface
+
+- **`SET_COMPANION_MOOD`** — sends `SET_MOOD` with a `correlationId`, waits
+  for the matching `commandResult`, returns the device-confirmed mood.
+  Invalid moods are typed failures.
+- **`GET_COMPANION_STATUS`** — returns `deviceId`, mood, connection state,
+  firmware, and capabilities; fails closed when disconnected.
+- **`companionDevice` provider** — surfaces the last device event
+  (`touch`, `mood_changed`) and live connection state as context.
+
+## Protocol
+
+Device frames: `welcome`, `register` (`deviceId`, `firmware`,
+`capabilities`), `commandResult`, `event`, `pong`. Host frames: `SET_MOOD`,
+`GET_STATUS`, `ping`. No host command is sent before the `welcome` →
+`register` handshake completes with a non-empty `deviceId`; a missed pong
+marks the socket stale, rejects pending commands, and reconnects.
+
+## Tests
+
+`bun run --cwd plugins/plugin-companion test` runs a deterministic
+mock-device suite against a real in-process `ws` server: handshake ordering,
+bad token, correlation matching, invalid mood, touch events, keepalive
+staleness, malformed JSON, and disconnect fail-closed behavior.

--- a/plugins/plugin-companion/package.json
+++ b/plugins/plugin-companion/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@elizaos/plugin-companion",
+  "version": "2.0.3-beta.7",
+  "type": "module",
+  "description": "Opt-in ESP32 companion device bridge: WebSocket client service, SET_COMPANION_MOOD / GET_COMPANION_STATUS actions, and a companionDevice provider for touch events.",
+  "main": "./dist/index.js",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "eliza-source": {
+        "types": "./src/index.ts",
+        "import": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./*": {
+      "types": "./dist/*.d.ts",
+      "eliza-source": {
+        "types": "./src/*.ts",
+        "import": "./src/*.ts",
+        "default": "./src/*.ts"
+      },
+      "import": "./dist/*.js",
+      "default": "./dist/*.js"
+    }
+  },
+  "dependencies": {
+    "@elizaos/core": "workspace:*",
+    "ws": "^8.21.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "bun run build:js && bun run build:types",
+    "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist",
+    "test": "vitest run --config vitest.config.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",
+    "build:types": "tsc6 --noCheck -p tsconfig.build.json",
+    "lint": "bunx @biomejs/biome check --write --unsafe .",
+    "lint:check": "bunx @biomejs/biome check .",
+    "format": "bunx @biomejs/biome format --write .",
+    "format:check": "bunx @biomejs/biome format ."
+  },
+  "files": [
+    "dist"
+  ],
+  "devDependencies": {
+    "@types/node": "^25.0.3",
+    "@types/ws": "^8.18.1",
+    "@typescript/native": "npm:typescript@^7.0.2",
+    "tsup": "^8.5.1",
+    "typescript": "^6.0.3",
+    "vitest": "^4.0.18"
+  }
+}

--- a/plugins/plugin-companion/src/actions.ts
+++ b/plugins/plugin-companion/src/actions.ts
@@ -1,0 +1,109 @@
+/**
+ * Planner actions for the companion device: SET_COMPANION_MOOD forwards a mood
+ * to the device and waits for the correlated confirmation;
+ * GET_COMPANION_STATUS reads the live device status. Both fail closed with the
+ * service's typed error text when the device is disconnected or rejects the
+ * command — a failure is never rendered as a healthy result. The device
+ * firmware is the authority on valid moods; the action passes the requested
+ * mood through and surfaces the device's rejection verbatim.
+ */
+import {
+  type Action,
+  type ActionResult,
+  ElizaError,
+  type IAgentRuntime,
+} from "@elizaos/core";
+import { CompanionService } from "./service";
+
+function companionService(runtime: IAgentRuntime): CompanionService | null {
+  return runtime.getService<CompanionService>(CompanionService.serviceType);
+}
+
+function failureText(error: unknown): string {
+  if (error instanceof ElizaError) return `${error.code}: ${error.message}`;
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Extracts the requested mood: an explicit `mood` option from the planner
+ * wins; otherwise the last quoted or trailing word of the message text is NOT
+ * guessed — a missing parameter is an explicit failure, not a default mood.
+ */
+function requestedMood(options?: Record<string, unknown>): string | undefined {
+  const mood = options?.mood;
+  return typeof mood === "string" && mood.trim().length > 0
+    ? mood.trim()
+    : undefined;
+}
+
+export const setCompanionMoodAction: Action = {
+  name: "SET_COMPANION_MOOD",
+  description:
+    "Set the companion device's displayed mood. Requires the `mood` parameter; the device confirms or rejects the mood.",
+  descriptionCompressed: "Set the companion device mood.",
+  tags: ["capability:send"],
+  validate: async (runtime) => companionService(runtime) !== null,
+  handler: async (
+    runtime,
+    _message,
+    _state,
+    options,
+  ): Promise<ActionResult> => {
+    const service = companionService(runtime);
+    if (!service) {
+      return {
+        success: false,
+        text: "COMPANION_NOT_CONNECTED: companion service is not running",
+      };
+    }
+    const mood = requestedMood(options as Record<string, unknown> | undefined);
+    if (!mood) {
+      return {
+        success: false,
+        text: "SET_COMPANION_MOOD requires a `mood` parameter (e.g. happy, sleepy).",
+      };
+    }
+    try {
+      const confirmed = await service.setMood(mood);
+      return {
+        success: true,
+        text: `Companion mood set to ${confirmed}.`,
+        userFacingText: `Companion mood set to ${confirmed}.`,
+        data: { mood: confirmed },
+      };
+    } catch (error) {
+      // error-policy:J1 action boundary: typed service failure becomes a
+      // structured failed ActionResult for the planner.
+      return { success: false, text: failureText(error) };
+    }
+  },
+};
+
+export const getCompanionStatusAction: Action = {
+  name: "GET_COMPANION_STATUS",
+  description:
+    "Read the companion device status: deviceId, mood, connection state, firmware, and capabilities. Fails when the device is disconnected.",
+  descriptionCompressed: "Read companion device status.",
+  validate: async (runtime) => companionService(runtime) !== null,
+  handler: async (runtime): Promise<ActionResult> => {
+    const service = companionService(runtime);
+    if (!service) {
+      return {
+        success: false,
+        text: "COMPANION_NOT_CONNECTED: companion service is not running",
+      };
+    }
+    try {
+      const status = await service.getStatus();
+      return {
+        success: true,
+        text: `Companion ${status.deviceId} connected (mood: ${status.mood ?? "unknown"}, firmware: ${status.firmware ?? "unknown"}).`,
+        data: JSON.parse(JSON.stringify(status)),
+      };
+    } catch (error) {
+      // error-policy:J1 action boundary: a disconnected or rejecting device is
+      // a structured failure, never an empty-healthy status.
+      return { success: false, text: failureText(error) };
+    }
+  },
+};

--- a/plugins/plugin-companion/src/companion.test.ts
+++ b/plugins/plugin-companion/src/companion.test.ts
@@ -1,0 +1,448 @@
+/**
+ * Deterministic mock-device suite for the companion plugin. Spins up a real
+ * in-process `ws` WebSocket server that impersonates the ESP32 firmware
+ * (welcome/register handshake, token check, correlated commandResults,
+ * events, pong keepalive) and drives the real CompanionService, actions, and
+ * provider against it. No hardware, no vi.mock, no network egress.
+ */
+import type { AddressInfo } from "node:net";
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { type WebSocket as DeviceSocket, WebSocketServer } from "ws";
+import { getCompanionStatusAction, setCompanionMoodAction } from "./actions";
+import { companionDeviceProvider } from "./provider";
+import { CompanionService } from "./service";
+
+const VALID_MOODS = new Set(["happy", "sleepy", "curious"]);
+
+interface MockDeviceOptions {
+  token?: string;
+  autoWelcome?: boolean;
+  autoRegister?: boolean;
+  registerFrame?: Record<string, unknown>;
+  pong?: boolean;
+  onCommand?: (frame: Record<string, unknown>, socket: DeviceSocket) => boolean;
+}
+
+interface MockDevice {
+  url: string;
+  sockets: DeviceSocket[];
+  received: Record<string, unknown>[];
+  close: () => Promise<void>;
+}
+
+const cleanups: Array<() => Promise<void> | void> = [];
+
+afterEach(async () => {
+  while (cleanups.length > 0) {
+    await cleanups.pop()?.();
+  }
+});
+
+function startMockDevice(options: MockDeviceOptions = {}): Promise<MockDevice> {
+  const token = options.token ?? "secret";
+  const wss = new WebSocketServer({ port: 0 });
+  const sockets: DeviceSocket[] = [];
+  const received: Record<string, unknown>[] = [];
+  wss.on("connection", (socket, request) => {
+    const url = new URL(request.url ?? "/", "http://device.local");
+    if (url.searchParams.get("token") !== token) {
+      socket.close(4001, "bad token");
+      return;
+    }
+    sockets.push(socket);
+    let mood = "idle";
+    socket.on("message", (data) => {
+      const frame = JSON.parse(String(data)) as Record<string, unknown>;
+      received.push(frame);
+      if (options.onCommand?.(frame, socket)) return;
+      if (frame.type === "ping") {
+        if (options.pong !== false) {
+          socket.send(JSON.stringify({ type: "pong", at: frame.at }));
+        }
+        return;
+      }
+      if (frame.type === "SET_MOOD") {
+        const requested = String(frame.mood);
+        if (!VALID_MOODS.has(requested)) {
+          socket.send(
+            JSON.stringify({
+              type: "commandResult",
+              correlationId: frame.correlationId,
+              ok: false,
+              error: `invalid mood: ${requested}`,
+            }),
+          );
+          return;
+        }
+        mood = requested;
+        socket.send(
+          JSON.stringify({
+            type: "commandResult",
+            correlationId: frame.correlationId,
+            ok: true,
+            mood,
+          }),
+        );
+        return;
+      }
+      if (frame.type === "GET_STATUS") {
+        socket.send(
+          JSON.stringify({
+            type: "commandResult",
+            correlationId: frame.correlationId,
+            ok: true,
+            mood,
+            status: { uptimeSeconds: 42 },
+          }),
+        );
+        return;
+      }
+      socket.send(
+        JSON.stringify({
+          type: "commandResult",
+          correlationId: frame.correlationId ?? "unknown",
+          ok: false,
+          error: "unknown-command",
+        }),
+      );
+    });
+    if (options.autoWelcome !== false) {
+      socket.send(
+        JSON.stringify({ type: "welcome", protocol: "eliza-companion/1" }),
+      );
+      if (options.autoRegister !== false) {
+        socket.send(
+          JSON.stringify(
+            options.registerFrame ?? {
+              type: "register",
+              deviceId: "esp32-companion-01",
+              firmware: "companion-fw 1.4.0",
+              capabilities: { platform: "esp32-s3", touch: true },
+            },
+          ),
+        );
+      }
+    }
+  });
+  const close = () =>
+    new Promise<void>((resolve) => {
+      for (const socket of sockets) socket.terminate();
+      wss.close(() => resolve());
+    });
+  cleanups.push(close);
+  return new Promise((resolve) => {
+    wss.on("listening", () => {
+      const { port } = wss.address() as AddressInfo;
+      resolve({
+        url: `ws://127.0.0.1:${port}/api/companion/device-bridge`,
+        sockets,
+        received,
+        close,
+      });
+    });
+  });
+}
+
+interface StubRuntime {
+  runtime: IAgentRuntime;
+  reported: { scope: string; error: unknown }[];
+  services: Map<string, unknown>;
+}
+
+function makeRuntime(settings: Record<string, string>): StubRuntime {
+  const reported: { scope: string; error: unknown }[] = [];
+  const services = new Map<string, unknown>();
+  const runtime = {
+    getSetting: (key: string) => settings[key] ?? null,
+    reportError: (scope: string, error: unknown) => {
+      reported.push({ scope, error });
+    },
+    getService: (type: string) => services.get(type) ?? null,
+  } as unknown as IAgentRuntime;
+  return { runtime, reported, services };
+}
+
+const FAST_TIMING = {
+  COMPANION_PING_INTERVAL_MS: "40",
+  COMPANION_PONG_TIMEOUT_MS: "60",
+  COMPANION_COMMAND_TIMEOUT_MS: "400",
+  COMPANION_RECONNECT_DELAY_MS: "60000",
+};
+
+async function startService(
+  url: string,
+  overrides: Record<string, string> = {},
+): Promise<{ service: CompanionService; stub: StubRuntime }> {
+  const stub = makeRuntime({
+    COMPANION_WS_URL: url,
+    COMPANION_PAIRING_TOKEN: "secret",
+    ...FAST_TIMING,
+    ...overrides,
+  });
+  const service = await CompanionService.start(stub.runtime);
+  stub.services.set(CompanionService.serviceType, service);
+  cleanups.push(() => service.stop());
+  return { service, stub };
+}
+
+async function until(
+  condition: () => boolean,
+  timeoutMs = 3000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!condition()) {
+    if (Date.now() > deadline) throw new Error("until(): condition timed out");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+const NO_MESSAGE = {} as never;
+
+describe("configuration boundary", () => {
+  it("fails fast without a URL or an explicit pairing token", async () => {
+    const noUrl = makeRuntime({ COMPANION_PAIRING_TOKEN: "secret" });
+    await expect(CompanionService.start(noUrl.runtime)).rejects.toMatchObject({
+      code: "COMPANION_URL_MISSING",
+    });
+    const noToken = makeRuntime({ COMPANION_WS_URL: "ws://127.0.0.1:9/x" });
+    await expect(CompanionService.start(noToken.runtime)).rejects.toMatchObject(
+      { code: "COMPANION_TOKEN_MISSING" },
+    );
+  });
+});
+
+describe("handshake (UC4/UC5)", () => {
+  it("completes welcome→register and records the device identity", async () => {
+    const device = await startMockDevice();
+    const { service } = await startService(device.url);
+    await until(() => service.isReady());
+    const snapshot = service.snapshot();
+    expect(snapshot.connected).toBe(true);
+    expect(snapshot.deviceId).toBe("esp32-companion-01");
+    expect(snapshot.firmware).toBe("companion-fw 1.4.0");
+    expect(snapshot.capabilities).toMatchObject({ platform: "esp32-s3" });
+  });
+
+  it("rejects a wrong pairing token and fails commands closed", async () => {
+    const device = await startMockDevice({ token: "other-token" });
+    const { service } = await startService(device.url);
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(service.isReady()).toBe(false);
+    await expect(service.setMood("happy")).rejects.toMatchObject({
+      code: "COMPANION_NOT_CONNECTED",
+    });
+  });
+
+  it("sends no commands before register completes", async () => {
+    const device = await startMockDevice({ autoRegister: false });
+    const { service } = await startService(device.url);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(service.isReady()).toBe(false);
+    await expect(service.setMood("happy")).rejects.toMatchObject({
+      code: "COMPANION_NOT_CONNECTED",
+    });
+    // The device saw no host frames at all — not even a ping.
+    expect(device.received).toHaveLength(0);
+  });
+
+  it("does not treat a register without deviceId as connected", async () => {
+    const device = await startMockDevice({
+      registerFrame: { type: "register", capabilities: {} },
+    });
+    const { service, stub } = await startService(device.url);
+    await until(() => stub.reported.length > 0);
+    expect(service.isReady()).toBe(false);
+    expect(
+      stub.reported.some(
+        (entry) =>
+          entry.error instanceof ElizaError &&
+          entry.error.code === "COMPANION_BAD_FRAME",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("commands (UC1/UC2)", () => {
+  it("SET_MOOD resolves the device-confirmed mood via correlationId", async () => {
+    const device = await startMockDevice();
+    const { service } = await startService(device.url);
+    await until(() => service.isReady());
+    await expect(service.setMood("happy")).resolves.toBe("happy");
+    const sent = device.received.find((frame) => frame.type === "SET_MOOD");
+    expect(sent).toBeDefined();
+    expect(typeof sent?.correlationId).toBe("string");
+  });
+
+  it("ignores an uncorrelated commandResult and still matches the real one", async () => {
+    const device = await startMockDevice({
+      onCommand: (frame, socket) => {
+        if (frame.type !== "SET_MOOD") return false;
+        socket.send(
+          JSON.stringify({
+            type: "commandResult",
+            correlationId: "not-this-command",
+            ok: false,
+            error: "stale",
+          }),
+        );
+        socket.send(
+          JSON.stringify({
+            type: "commandResult",
+            correlationId: frame.correlationId,
+            ok: true,
+            mood: frame.mood,
+          }),
+        );
+        return true;
+      },
+    });
+    const { service, stub } = await startService(device.url);
+    await until(() => service.isReady());
+    await expect(service.setMood("curious")).resolves.toBe("curious");
+    expect(
+      stub.reported.some(
+        (entry) =>
+          entry.error instanceof ElizaError &&
+          entry.error.code === "COMPANION_UNCORRELATED_RESULT",
+      ),
+    ).toBe(true);
+  });
+
+  it("invalid mood is a typed rejection, not a silent idle", async () => {
+    const device = await startMockDevice();
+    const { service, stub } = await startService(device.url);
+    await until(() => service.isReady());
+    await expect(service.setMood("angry")).rejects.toMatchObject({
+      code: "COMPANION_COMMAND_REJECTED",
+    });
+    const result = await setCompanionMoodAction.handler(
+      stub.runtime,
+      NO_MESSAGE,
+      undefined,
+      { mood: "angry" },
+    );
+    expect(result?.success).toBe(false);
+    expect(result?.text).toContain("invalid mood");
+  });
+
+  it("GET_STATUS returns identity + device status and fails closed after disconnect", async () => {
+    const device = await startMockDevice();
+    const { service, stub } = await startService(device.url);
+    await until(() => service.isReady());
+    const status = await service.getStatus();
+    expect(status.deviceId).toBe("esp32-companion-01");
+    expect(status.firmware).toBe("companion-fw 1.4.0");
+    expect(status.status).toMatchObject({ uptimeSeconds: 42 });
+
+    const action = await getCompanionStatusAction.handler(
+      stub.runtime,
+      NO_MESSAGE,
+    );
+    expect(action?.success).toBe(true);
+    expect(action?.text).toContain("esp32-companion-01");
+
+    await device.close();
+    await until(() => !service.isReady());
+    await expect(service.getStatus()).rejects.toMatchObject({
+      code: "COMPANION_NOT_CONNECTED",
+    });
+    const failed = await getCompanionStatusAction.handler(
+      stub.runtime,
+      NO_MESSAGE,
+    );
+    expect(failed?.success).toBe(false);
+    expect(failed?.text).toContain("COMPANION_NOT_CONNECTED");
+  });
+
+  it("SET_COMPANION_MOOD without a mood parameter fails explicitly", async () => {
+    const device = await startMockDevice();
+    const { stub } = await startService(device.url);
+    const result = await setCompanionMoodAction.handler(
+      stub.runtime,
+      NO_MESSAGE,
+    );
+    expect(result?.success).toBe(false);
+    expect(result?.text).toContain("mood");
+  });
+});
+
+describe("touch events (UC3)", () => {
+  it("stores the device touch event and surfaces it through the provider", async () => {
+    const device = await startMockDevice();
+    const { service, stub } = await startService(device.url);
+    await until(() => service.isReady());
+    device.sockets[0]?.send(
+      JSON.stringify({ type: "event", event: "touch", data: { zone: "head" } }),
+    );
+    await until(() => service.snapshot().lastEvent?.event === "touch");
+    const result = await companionDeviceProvider.get(
+      stub.runtime,
+      NO_MESSAGE,
+      NO_MESSAGE,
+    );
+    expect(result.values?.companionLastEvent).toBe("touch");
+    expect(result.text).toContain("lastEvent=touch");
+  });
+
+  it("mood_changed events update the tracked mood", async () => {
+    const device = await startMockDevice();
+    const { service } = await startService(device.url);
+    await until(() => service.isReady());
+    device.sockets[0]?.send(
+      JSON.stringify({ type: "event", event: "mood_changed", mood: "sleepy" }),
+    );
+    await until(() => service.snapshot().mood === "sleepy");
+    expect(service.snapshot().mood).toBe("sleepy");
+  });
+});
+
+describe("keepalive (UC6)", () => {
+  it("a device that answers pings stays connected across intervals", async () => {
+    const device = await startMockDevice();
+    const { service } = await startService(device.url);
+    await until(() => service.isReady());
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    expect(service.isReady()).toBe(true);
+    expect(device.received.some((frame) => frame.type === "ping")).toBe(true);
+  });
+
+  it("a stale socket (no pong) marks disconnected and rejects commands", async () => {
+    const device = await startMockDevice({ pong: false });
+    const { service } = await startService(device.url);
+    await until(() => service.isReady());
+    await until(() => !service.isReady());
+    await expect(service.setMood("happy")).rejects.toMatchObject({
+      code: "COMPANION_NOT_CONNECTED",
+    });
+  });
+});
+
+describe("resilience (UC7)", () => {
+  it("survives malformed JSON and unknown frames; commands still work", async () => {
+    const device = await startMockDevice();
+    const { service, stub } = await startService(device.url);
+    await until(() => service.isReady());
+    device.sockets[0]?.send("{ not json");
+    device.sockets[0]?.send(JSON.stringify({ type: "mystery", x: 1 }));
+    await until(() => stub.reported.length >= 2);
+    expect(service.isReady()).toBe(true);
+    await expect(service.setMood("sleepy")).resolves.toBe("sleepy");
+  });
+
+  it("provider reports disconnected state distinctly", async () => {
+    const device = await startMockDevice();
+    const { service, stub } = await startService(device.url);
+    await until(() => service.isReady());
+    await device.close();
+    await until(() => !service.isReady());
+    const result = await companionDeviceProvider.get(
+      stub.runtime,
+      NO_MESSAGE,
+      NO_MESSAGE,
+    );
+    expect(result.values?.companionConnected).toBe(false);
+    expect(result.text).toContain("disconnected");
+    void service;
+  });
+});

--- a/plugins/plugin-companion/src/index.ts
+++ b/plugins/plugin-companion/src/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Entry point for `@elizaos/plugin-companion` — the opt-in ESP32 companion
+ * device bridge. Assembles the WebSocket client service, the
+ * SET_COMPANION_MOOD / GET_COMPANION_STATUS actions, and the companionDevice
+ * provider. Desktop/node only (registered via UNBUNDLED_OPTIONAL_PLUGINS);
+ * never auto-enables — a character must list the plugin and configure
+ * `COMPANION_WS_URL` plus an explicit `COMPANION_PAIRING_TOKEN`.
+ */
+import type { Plugin } from "@elizaos/core";
+import { getCompanionStatusAction, setCompanionMoodAction } from "./actions";
+import { companionDeviceProvider } from "./provider";
+import { CompanionService } from "./service";
+
+export { getCompanionStatusAction, setCompanionMoodAction } from "./actions";
+export type {
+  CommandResultFrame,
+  CompanionCommand,
+  DeviceFrame,
+  EventFrame,
+  PongFrame,
+  RegisterFrame,
+  WelcomeFrame,
+} from "./protocol";
+export { parseDeviceFrame } from "./protocol";
+export { companionDeviceProvider } from "./provider";
+export {
+  COMPANION_SERVICE_TYPE,
+  type CompanionEvent,
+  type CompanionIdentity,
+  CompanionService,
+  type CompanionSnapshot,
+} from "./service";
+
+export const companionPlugin: Plugin = {
+  name: "companion",
+  description:
+    "Opt-in ESP32 companion device bridge: mood control, status, and touch events over the device's authenticated WebSocket protocol.",
+  services: [CompanionService],
+  actions: [setCompanionMoodAction, getCompanionStatusAction],
+  providers: [companionDeviceProvider],
+};
+
+export default companionPlugin;

--- a/plugins/plugin-companion/src/protocol.ts
+++ b/plugins/plugin-companion/src/protocol.ts
@@ -1,0 +1,143 @@
+/**
+ * Wire contract for the ESP32 companion device bridge: the JSON frames the
+ * device (WebSocket server) sends to the plugin (client) and the host commands
+ * the plugin sends back. Every inbound frame crosses this trust boundary
+ * exactly once — `parseDeviceFrame` either yields a fully typed frame or
+ * throws a typed `ElizaError`; no downstream code touches raw JSON. The
+ * device speaks: `welcome`, `register`, `commandResult`, `event`
+ * (`touch` / `mood_changed`), and `pong`; the host sends `SET_MOOD`,
+ * `GET_STATUS`, and `ping`.
+ */
+import { ElizaError } from "@elizaos/core";
+
+/** First frame the device sends after accepting the socket. */
+export interface WelcomeFrame {
+  type: "welcome";
+  protocol?: string;
+}
+
+/** Device identity frame; a device without a `deviceId` is not connected. */
+export interface RegisterFrame {
+  type: "register";
+  deviceId: string;
+  firmware?: string;
+  capabilities: Record<string, unknown>;
+}
+
+/** Correlated response to a host `SET_MOOD` / `GET_STATUS` command. */
+export interface CommandResultFrame {
+  type: "commandResult";
+  correlationId: string;
+  ok: boolean;
+  error?: string;
+  mood?: string;
+  status?: Record<string, unknown>;
+}
+
+/** Spontaneous device event (touch sensor, mood transition). */
+export interface EventFrame {
+  type: "event";
+  event: string;
+  mood?: string;
+  data?: Record<string, unknown>;
+}
+
+/** Keepalive reply to a host `ping`. */
+export interface PongFrame {
+  type: "pong";
+  at?: number;
+}
+
+export type DeviceFrame =
+  | WelcomeFrame
+  | RegisterFrame
+  | CommandResultFrame
+  | EventFrame
+  | PongFrame;
+
+/** Host command names accepted by the device firmware. */
+export type CompanionCommand = "SET_MOOD" | "GET_STATUS";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function badFrame(reason: string, raw: string): ElizaError {
+  return new ElizaError(`companion device sent an invalid frame: ${reason}`, {
+    code: "COMPANION_BAD_FRAME",
+    context: { reason, raw: raw.slice(0, 256) },
+  });
+}
+
+/**
+ * Parses one raw WebSocket text payload into a typed device frame. Throws
+ * `ElizaError(COMPANION_BAD_FRAME)` on malformed JSON, a missing/unknown
+ * `type`, or a frame whose required fields are absent or mistyped.
+ */
+export function parseDeviceFrame(raw: string): DeviceFrame {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    // error-policy:J2 wrap the untyped JSON.parse failure as a typed frame error.
+    throw new ElizaError("companion device sent malformed JSON", {
+      code: "COMPANION_BAD_FRAME",
+      context: { raw: raw.slice(0, 256) },
+      cause: error,
+    });
+  }
+  if (!isRecord(parsed)) throw badFrame("frame is not an object", raw);
+  const type = nonEmptyString(parsed.type);
+  switch (type) {
+    case "welcome":
+      return { type, protocol: nonEmptyString(parsed.protocol) };
+    case "register": {
+      const deviceId = nonEmptyString(parsed.deviceId);
+      if (!deviceId) throw badFrame("register frame lacks deviceId", raw);
+      return {
+        type,
+        deviceId,
+        firmware: nonEmptyString(parsed.firmware),
+        capabilities: isRecord(parsed.capabilities) ? parsed.capabilities : {},
+      };
+    }
+    case "commandResult": {
+      const correlationId = nonEmptyString(parsed.correlationId);
+      if (!correlationId) {
+        throw badFrame("commandResult lacks correlationId", raw);
+      }
+      if (typeof parsed.ok !== "boolean") {
+        throw badFrame("commandResult lacks boolean ok", raw);
+      }
+      return {
+        type,
+        correlationId,
+        ok: parsed.ok,
+        error: nonEmptyString(parsed.error),
+        mood: nonEmptyString(parsed.mood),
+        status: isRecord(parsed.status) ? parsed.status : undefined,
+      };
+    }
+    case "event": {
+      const event = nonEmptyString(parsed.event);
+      if (!event) throw badFrame("event frame lacks event name", raw);
+      return {
+        type,
+        event,
+        mood: nonEmptyString(parsed.mood),
+        data: isRecord(parsed.data) ? parsed.data : undefined,
+      };
+    }
+    case "pong":
+      return {
+        type,
+        at: typeof parsed.at === "number" ? parsed.at : undefined,
+      };
+    default:
+      throw badFrame(`unknown frame type ${String(parsed.type)}`, raw);
+  }
+}

--- a/plugins/plugin-companion/src/provider.ts
+++ b/plugins/plugin-companion/src/provider.ts
@@ -1,0 +1,43 @@
+/**
+ * Context provider surfacing the companion device's live state — connection,
+ * identity, current mood, and the last spontaneous device event (touch /
+ * mood_changed) — so the agent can react to physical interaction. Read-only:
+ * it snapshots service state and never touches the socket.
+ */
+import type { IAgentRuntime, Provider, ProviderResult } from "@elizaos/core";
+import { CompanionService } from "./service";
+
+export const companionDeviceProvider: Provider = {
+  name: "companionDevice",
+  description:
+    "Live companion-device state: connection, mood, and last touch event.",
+  descriptionCompressed: "Companion device state.",
+  dynamic: true,
+  get: async (runtime: IAgentRuntime): Promise<ProviderResult> => {
+    const service = runtime.getService<CompanionService>(
+      CompanionService.serviceType,
+    );
+    if (!service) {
+      return { text: "Companion device: service not running." };
+    }
+    const snapshot = service.snapshot();
+    if (!snapshot.connected) {
+      return {
+        text: "Companion device: disconnected.",
+        values: { companionConnected: false },
+      };
+    }
+    const lastEvent = snapshot.lastEvent
+      ? `; lastEvent=${snapshot.lastEvent.event} at ${new Date(snapshot.lastEvent.at).toISOString()}`
+      : "";
+    return {
+      text: `Companion device ${snapshot.deviceId} connected (mood: ${snapshot.mood ?? "unknown"})${lastEvent}.`,
+      values: {
+        companionConnected: true,
+        companionDeviceId: snapshot.deviceId ?? "",
+        companionMood: snapshot.mood ?? "",
+        companionLastEvent: snapshot.lastEvent?.event ?? "",
+      },
+    };
+  },
+};

--- a/plugins/plugin-companion/src/service.ts
+++ b/plugins/plugin-companion/src/service.ts
@@ -1,0 +1,398 @@
+/**
+ * WebSocket client service that owns the connection to an ESP32 companion
+ * device (device-as-server, SoftAP). Owns the entire socket lifecycle: connect
+ * with the pairing token, gate on the device's `welcome` → `register`
+ * handshake (no host command leaves before a registered `deviceId`),
+ * correlationId-matched command dispatch, ping/pong keepalive with
+ * stale-socket disconnect, bounded reconnect, and event capture (`touch`,
+ * `mood_changed`) for the `companionDevice` provider.
+ *
+ * A socket "generation" counter guards every async callback: frames or timers
+ * from a superseded socket can never resurrect state on the current one.
+ * Failures on the data path throw typed `ElizaError`s; per-frame protocol
+ * garbage is diagnostic only (reported via `runtime.reportError`) so a
+ * misbehaving device cannot kill the service.
+ */
+import { randomUUID } from "node:crypto";
+import { ElizaError, type IAgentRuntime, logger, Service } from "@elizaos/core";
+import WebSocket from "ws";
+import {
+  type CommandResultFrame,
+  type CompanionCommand,
+  parseDeviceFrame,
+} from "./protocol";
+
+export const COMPANION_SERVICE_TYPE = "COMPANION" as const;
+
+/** Identity the device declared in its `register` frame. */
+export interface CompanionIdentity {
+  deviceId: string;
+  firmware?: string;
+  capabilities: Record<string, unknown>;
+}
+
+/** Last spontaneous device event, surfaced by the companionDevice provider. */
+export interface CompanionEvent {
+  event: string;
+  at: number;
+  mood?: string;
+  data?: Record<string, unknown>;
+}
+
+/** Read-only connection snapshot for the provider and status action. */
+export interface CompanionSnapshot {
+  connected: boolean;
+  deviceId?: string;
+  firmware?: string;
+  capabilities?: Record<string, unknown>;
+  mood?: string;
+  lastEvent?: CompanionEvent;
+}
+
+interface PendingCommand {
+  resolve: (result: CommandResultFrame) => void;
+  reject: (error: ElizaError) => void;
+  timer: NodeJS.Timeout;
+}
+
+interface Timing {
+  pingIntervalMs: number;
+  pongTimeoutMs: number;
+  commandTimeoutMs: number;
+  reconnectDelayMs: number;
+}
+
+function readTimingMs(
+  runtime: IAgentRuntime,
+  key: string,
+  fallback: number,
+): number {
+  const raw = runtime.getSetting(key);
+  const value = typeof raw === "string" ? Number(raw) : raw;
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
+}
+
+export class CompanionService extends Service {
+  static serviceType = COMPANION_SERVICE_TYPE;
+
+  capabilityDescription =
+    "Drives an ESP32 companion device over its authenticated WebSocket bridge: set mood, read status, receive touch events.";
+
+  private url!: URL;
+  private timing!: Timing;
+  private socket: WebSocket | null = null;
+  private generation = 0;
+  private welcomed = false;
+  private identity: CompanionIdentity | null = null;
+  private mood: string | undefined;
+  private lastEvent: CompanionEvent | undefined;
+  private readonly pending = new Map<string, PendingCommand>();
+  private pingTimer: NodeJS.Timeout | null = null;
+  private pongTimer: NodeJS.Timeout | null = null;
+  private reconnectTimer: NodeJS.Timeout | null = null;
+  private stopped = false;
+
+  static async start(runtime: IAgentRuntime): Promise<CompanionService> {
+    const service = new CompanionService(runtime);
+    const rawUrl = runtime.getSetting("COMPANION_WS_URL");
+    if (typeof rawUrl !== "string" || rawUrl.length === 0) {
+      throw new ElizaError(
+        "CompanionService requires COMPANION_WS_URL (ws://<device>:8080/api/companion/device-bridge)",
+        { code: "COMPANION_URL_MISSING" },
+      );
+    }
+    const token = runtime.getSetting("COMPANION_PAIRING_TOKEN");
+    if (typeof token !== "string" || token.length === 0) {
+      throw new ElizaError(
+        "CompanionService requires an explicit COMPANION_PAIRING_TOKEN",
+        { code: "COMPANION_TOKEN_MISSING" },
+      );
+    }
+    let url: URL;
+    try {
+      url = new URL(rawUrl);
+    } catch (error) {
+      // error-policy:J2 wrap the untyped URL failure with the offending setting.
+      throw new ElizaError("COMPANION_WS_URL is not a valid URL", {
+        code: "COMPANION_URL_INVALID",
+        context: { url: rawUrl },
+        cause: error,
+      });
+    }
+    url.searchParams.set("token", token);
+    service.url = url;
+    service.timing = {
+      pingIntervalMs: readTimingMs(
+        runtime,
+        "COMPANION_PING_INTERVAL_MS",
+        15_000,
+      ),
+      pongTimeoutMs: readTimingMs(runtime, "COMPANION_PONG_TIMEOUT_MS", 5_000),
+      commandTimeoutMs: readTimingMs(
+        runtime,
+        "COMPANION_COMMAND_TIMEOUT_MS",
+        10_000,
+      ),
+      reconnectDelayMs: readTimingMs(
+        runtime,
+        "COMPANION_RECONNECT_DELAY_MS",
+        5_000,
+      ),
+    };
+    service.connect();
+    return service;
+  }
+
+  /** True once the welcome→register handshake completed on the live socket. */
+  isReady(): boolean {
+    return (
+      this.socket !== null &&
+      this.socket.readyState === WebSocket.OPEN &&
+      this.welcomed &&
+      this.identity !== null
+    );
+  }
+
+  snapshot(): CompanionSnapshot {
+    return {
+      connected: this.isReady(),
+      deviceId: this.identity?.deviceId,
+      firmware: this.identity?.firmware,
+      capabilities: this.identity?.capabilities,
+      mood: this.mood,
+      lastEvent: this.lastEvent,
+    };
+  }
+
+  /** Sends `SET_MOOD` and resolves to the device-confirmed mood. */
+  async setMood(mood: string): Promise<string> {
+    const result = await this.sendCommand("SET_MOOD", { mood });
+    const confirmed = result.mood ?? mood;
+    this.mood = confirmed;
+    return confirmed;
+  }
+
+  /** Sends `GET_STATUS` and resolves to the identity + device status fields. */
+  async getStatus(): Promise<
+    CompanionSnapshot & { status?: Record<string, unknown> }
+  > {
+    const result = await this.sendCommand("GET_STATUS", {});
+    if (result.mood) this.mood = result.mood;
+    return { ...this.snapshot(), status: result.status };
+  }
+
+  private async sendCommand(
+    command: CompanionCommand,
+    payload: Record<string, unknown>,
+  ): Promise<CommandResultFrame> {
+    if (!this.isReady() || this.socket === null) {
+      throw new ElizaError(
+        `companion device is not connected; cannot send ${command}`,
+        {
+          code: "COMPANION_NOT_CONNECTED",
+          context: { command, connected: false },
+        },
+      );
+    }
+    const correlationId = randomUUID();
+    const socket = this.socket;
+    const result = new Promise<CommandResultFrame>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(correlationId);
+        reject(
+          new ElizaError(`companion device did not answer ${command}`, {
+            code: "COMPANION_COMMAND_TIMEOUT",
+            context: { command, correlationId },
+          }),
+        );
+      }, this.timing.commandTimeoutMs);
+      timer.unref?.();
+      this.pending.set(correlationId, { resolve, reject, timer });
+    });
+    socket.send(JSON.stringify({ type: command, correlationId, ...payload }));
+    const frame = await result;
+    if (!frame.ok) {
+      throw new ElizaError(
+        `companion device rejected ${command}: ${frame.error ?? "unknown error"}`,
+        {
+          code: "COMPANION_COMMAND_REJECTED",
+          context: { command, correlationId, error: frame.error },
+        },
+      );
+    }
+    return frame;
+  }
+
+  private connect(): void {
+    if (this.stopped) return;
+    this.generation += 1;
+    const generation = this.generation;
+    this.welcomed = false;
+    this.identity = null;
+    const socket = new WebSocket(this.url);
+    this.socket = socket;
+
+    socket.on("message", (data) => {
+      if (generation !== this.generation) return;
+      this.handleFrame(String(data));
+    });
+    socket.on("close", (code) => {
+      if (generation !== this.generation) return;
+      this.markDisconnected(`socket closed (${code})`);
+      this.scheduleReconnect();
+    });
+    socket.on("error", (error) => {
+      if (generation !== this.generation) return;
+      // error-policy:J7 socket errors are diagnostics; close handles recovery.
+      this.runtime.reportError("CompanionService", error, {
+        url: this.url.host,
+      });
+    });
+  }
+
+  private handleFrame(raw: string): void {
+    let frame: ReturnType<typeof parseDeviceFrame>;
+    try {
+      frame = parseDeviceFrame(raw);
+    } catch (error) {
+      // error-policy:J3 protocol garbage from the device becomes a reported
+      // diagnostic, never fabricated state and never a service crash.
+      this.runtime.reportError("CompanionService", error, {
+        phase: "parseDeviceFrame",
+      });
+      return;
+    }
+    switch (frame.type) {
+      case "welcome":
+        this.welcomed = true;
+        return;
+      case "register":
+        if (!this.welcomed) {
+          this.runtime.reportError(
+            "CompanionService",
+            new ElizaError("device sent register before welcome", {
+              code: "COMPANION_HANDSHAKE_ORDER",
+            }),
+          );
+          return;
+        }
+        this.identity = {
+          deviceId: frame.deviceId,
+          firmware: frame.firmware,
+          capabilities: frame.capabilities,
+        };
+        logger.info(
+          `CompanionService: registered device ${frame.deviceId} (${frame.firmware ?? "unknown firmware"})`,
+        );
+        this.startKeepalive();
+        return;
+      case "commandResult": {
+        const pending = this.pending.get(frame.correlationId);
+        if (!pending) {
+          this.runtime.reportError(
+            "CompanionService",
+            new ElizaError("uncorrelated commandResult", {
+              code: "COMPANION_UNCORRELATED_RESULT",
+              context: { correlationId: frame.correlationId },
+            }),
+          );
+          return;
+        }
+        this.pending.delete(frame.correlationId);
+        clearTimeout(pending.timer);
+        pending.resolve(frame);
+        return;
+      }
+      case "event":
+        this.lastEvent = {
+          event: frame.event,
+          at: Date.now(),
+          mood: frame.mood,
+          data: frame.data,
+        };
+        if (frame.event === "mood_changed" && frame.mood) {
+          this.mood = frame.mood;
+        }
+        return;
+      case "pong":
+        if (this.pongTimer) {
+          clearTimeout(this.pongTimer);
+          this.pongTimer = null;
+        }
+        return;
+    }
+  }
+
+  private startKeepalive(): void {
+    if (this.pingTimer) clearInterval(this.pingTimer);
+    const generation = this.generation;
+    this.pingTimer = setInterval(() => {
+      if (generation !== this.generation || !this.isReady()) return;
+      if (this.pongTimer) {
+        // The previous ping's pong never arrived — the socket is stale. Do not
+        // re-arm the timeout; a silent device must not stay "connected".
+        return;
+      }
+      this.socket?.send(JSON.stringify({ type: "ping", at: Date.now() }));
+      this.pongTimer = setTimeout(() => {
+        if (generation !== this.generation) return;
+        this.markDisconnected("keepalive pong missed; socket is stale");
+        this.scheduleReconnect();
+      }, this.timing.pongTimeoutMs);
+      this.pongTimer.unref?.();
+    }, this.timing.pingIntervalMs);
+    this.pingTimer.unref?.();
+  }
+
+  private markDisconnected(reason: string): void {
+    logger.warn(`CompanionService: disconnected — ${reason}`);
+    this.generation += 1;
+    this.welcomed = false;
+    this.identity = null;
+    if (this.pingTimer) {
+      clearInterval(this.pingTimer);
+      this.pingTimer = null;
+    }
+    if (this.pongTimer) {
+      clearTimeout(this.pongTimer);
+      this.pongTimer = null;
+    }
+    const socket = this.socket;
+    this.socket = null;
+    socket?.removeAllListeners();
+    // error-policy:J6 best-effort teardown — terminating a still-connecting ws
+    // emits an error event; swallow it so teardown cannot crash the process.
+    socket?.on("error", () => {});
+    socket?.terminate();
+    for (const [correlationId, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      pending.reject(
+        new ElizaError("companion device disconnected mid-command", {
+          code: "COMPANION_NOT_CONNECTED",
+          context: { correlationId, reason },
+        }),
+      );
+    }
+    this.pending.clear();
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped || this.reconnectTimer) return;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, this.timing.reconnectDelayMs);
+    this.reconnectTimer.unref?.();
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.markDisconnected("service stopped");
+  }
+}

--- a/plugins/plugin-companion/tsconfig.build.json
+++ b/plugins/plugin-companion/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.build.shared.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/__tests__/**"]
+}

--- a/plugins/plugin-companion/tsconfig.json
+++ b/plugins/plugin-companion/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "strictNullChecks": true,
+    "noUncheckedIndexedAccess": false,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "types": ["node", "bun", "vitest"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "dist/**",
+    "node_modules/**",
+    "src/**/__tests__/**",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.e2e.test.ts"
+  ]
+}

--- a/plugins/plugin-companion/vitest.config.ts
+++ b/plugins/plugin-companion/vitest.config.ts
@@ -1,0 +1,16 @@
+/**
+ * Vitest configuration for the companion plugin's deterministic mock-device
+ * suite (in-process `ws` server; no hardware, no network egress).
+ */
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    conditions: ["eliza-source"],
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    exclude: ["dist/**", "node_modules/**"],
+  },
+});


### PR DESCRIPTION
Fixes #18957

## What

New `@elizaos/plugin-companion`: a WebSocket **client** Service connecting to the ESP32-S3 companion device's own server at `ws://<device>:8080/api/companion/device-bridge?token=<PAIRING_TOKEN>` (settings `COMPANION_WS_URL`, `COMPANION_PAIRING_TOKEN` — both required, fail-fast typed errors when absent). Opt-in only: no `autoEnable`, registered via `UNBUNDLED_OPTIONAL_PLUGINS` with `skipOnMobile`, never baked into the mobile APK.

### Acceptance criteria mapping

- **UC1** `SET_COMPANION_MOOD` sends `SET_MOOD`, awaits the `commandResult` with matching `correlationId`, returns the device-confirmed mood; device `ok:false` (e.g. mood `angry`) is a typed `COMPANION_COMMAND_REJECTED` failure surfaced as a failed `ActionResult`.
- **UC2** `GET_COMPANION_STATUS` returns `deviceId`, mood, connected, firmware, capabilities; a disconnected device fails closed (`COMPANION_NOT_CONNECTED`), never empty-healthy.
- **UC3** Device `event touch` is stored on the service and surfaced by the `companionDevice` provider (`companionLastEvent=touch`); `mood_changed` updates the tracked mood.
- **UC4** Token appended as `?token=`; a rejected socket never becomes ready and commands fail closed. No host frame (not even ping) leaves before the handshake — verified by asserting the mock device received zero frames.
- **UC5** `welcome` → `register` gating; identity (`deviceId`, `firmware`, `capabilities.platform`) recorded from `register`; a register without `deviceId` is a reported bad frame and NOT connected.
- **UC6** Host `ping` → device `pong` keepalive; a missed pong marks the socket stale, terminates it, rejects pending commands (`COMPANION_NOT_CONNECTED`), and schedules a bounded reconnect. A socket-generation counter prevents stale timers/frames from resurrecting state.
- **UC7** Malformed JSON, unknown frame types, and uncorrelated `commandResult`s are reported via `runtime.reportError` and ignored; the service keeps working (verified: a subsequent `SET_MOOD` succeeds).

`src/protocol.ts` is the single inbound trust boundary — every frame is structurally validated once into a typed union; downstream code never touches raw JSON. Retained catches carry `error-policy:J<N>` classifications.

## Tests

`bun run --cwd plugins/plugin-companion test` — **16/16 passed**: a deterministic mock device built on a real in-process `ws` `WebSocketServer` (no `vi.mock`, no hardware, no egress) covering configuration fail-fast, handshake/identity, bad token, register-without-deviceId, correlation matching incl. an interleaved uncorrelated result, invalid mood (service + action), status + disconnect fail-closed, missing-mood parameter, touch/mood_changed events + provider, keepalive healthy/stale paths, and malformed-frame resilience.

Also green: plugin `typecheck` + `lint:check`; agent registration drift suites `optional-plugins.test.ts` + `core-static-plugin-registrations.test.ts` (19/19) and `core-plugins-profile-metadata.test.ts` (12/12); `ensure-plugin-test-conventions:check`; `check:agents-claude` (153 pairs).

## Evidence caveat

Real ESP32 hardware output and a live-model action trajectory are not included — no companion device is attached to this runner. Mock-device coverage is presented as exactly that; hardware runs remain evidence-only per the issue ("Tests use a mock WebSocket device; hardware is evidence-only, not a CI gate").

🤖 Generated with [Claude Code](https://claude.com/claude-code)