### PR TITLE
fix(cloud-api): gateway-relay timeoutMs strict positive-integer validation

### DIFF
--- a/packages/cloud/api/__tests__/gateway-relay-next-timeout-validation.test.ts
+++ b/packages/cloud/api/__tests__/gateway-relay-next-timeout-validation.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Exercises the gateway-relay next-session route trust boundary: strict
+ * positive-integer timeoutMs parsing before the long-poll call, so a
+ * client-supplied malformed value can never become a coerced 1ms wait.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const getSession = mock(async () => ({
+  id: "session-1",
+  organizationId: "org-1",
+  userId: "user-1",
+}));
+const pollNextRequest = mock(async () => ({
+  requestId: "req-1",
+  payload: { test: "data" },
+}));
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "user-1",
+  organization_id: "org-1",
+}));
+
+mock.module("@/lib/services/agent-gateway-relay", () => ({
+  agentGatewayRelayService: { getSession, pollNextRequest },
+}));
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (c: any, error: any) =>
+    c.json({ success: false, error: String(error) }, 500),
+}));
+
+const route = (
+  await import("../v1/eliza/gateway-relay/sessions/[sessionId]/next/route")
+).default;
+const app = new Hono().route(
+  "/api/v1/eliza/gateway-relay/sessions/:sessionId/next",
+  route,
+);
+
+function nextRequest(query = "") {
+  return app.request(
+    `/api/v1/eliza/gateway-relay/sessions/session-1/next${query}`,
+  );
+}
+
+describe("GET /api/v1/eliza/gateway-relay/sessions/:sessionId/next timeoutMs parsing", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockClear();
+    getSession.mockClear();
+    pollNextRequest.mockClear();
+    getSession.mockResolvedValue({
+      id: "session-1",
+      organizationId: "org-1",
+      userId: "user-1",
+    });
+    pollNextRequest.mockResolvedValue({
+      requestId: "req-1",
+      payload: { test: "data" },
+    });
+    requireUserOrApiKeyWithOrg.mockResolvedValue({
+      id: "user-1",
+      organization_id: "org-1",
+    });
+  });
+
+  test("defaults to 25000 when timeoutMs is absent", async () => {
+    const response = await nextRequest();
+    expect(response.status).toBe(200);
+    expect(pollNextRequest).toHaveBeenCalledWith("session-1", 25000);
+  });
+
+  test.each([1, 1000, 25000])(
+    "passes a valid positive integer of %i through the cap",
+    async (timeoutMs) => {
+      const response = await nextRequest(`?timeoutMs=${timeoutMs}`);
+      expect(response.status).toBe(200);
+      expect(pollNextRequest).toHaveBeenCalledWith("session-1", timeoutMs);
+    },
+  );
+
+  test("caps a valid positive integer above 25000 at 25000", async () => {
+    const response = await nextRequest("?timeoutMs=50000");
+    expect(response.status).toBe(200);
+    expect(pollNextRequest).toHaveBeenCalledWith("session-1", 25000);
+  });
+
+  test.each([
+    ["empty", ""],
+    ["negative", "-1"],
+    ["zero", "0"],
+    ["malformed prefix", "12px"],
+    ["fractional", "1.5"],
+    ["exponent form", "1e4"],
+    ["malformed suffix", "25000abc"],
+    ["non-finite", "Infinity"],
+    ["unsafe integer", "9007199254740992"],
+  ])(
+    "defaults %s timeoutMs to 25000 without calling service",
+    async (_name, timeoutMs) => {
+      const response = await nextRequest(
+        `?timeoutMs=${encodeURIComponent(timeoutMs)}`,
+      );
+      expect(response.status).toBe(200);
+      expect(pollNextRequest).toHaveBeenCalledWith("session-1", 25000);
+    },
+  );
+});

--- a/packages/cloud/api/v1/eliza/gateway-relay/sessions/[sessionId]/next/route.ts
+++ b/packages/cloud/api/v1/eliza/gateway-relay/sessions/[sessionId]/next/route.ts
@@ -6,6 +6,7 @@
  * client waiting on a closed connection.
  */
 
+import { parsePositiveInteger } from "@elizaos/shared/utils/number-parsing";
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
@@ -13,13 +14,12 @@ import { agentGatewayRelayService } from "@/lib/services/agent-gateway-relay";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
+const MAX_TIMEOUT_MS = 25_000;
 
 function parseTimeoutMs(raw: string | undefined): number {
-  const parsed = raw ? Number.parseInt(raw, 10) : 25_000;
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    return 25_000;
-  }
-  return Math.min(parsed, 25_000);
+  const parsed = parsePositiveInteger(raw, MAX_TIMEOUT_MS);
+  if (parsed === undefined) return MAX_TIMEOUT_MS;
+  return Math.min(parsed, MAX_TIMEOUT_MS);
 }
 
 app.get("/", async (c) => {


### PR DESCRIPTION
## Summary

Fixes #20395 — Reject non-canonical gateway-relay timeoutMs before long-poll.

## Changes

- `packages/cloud/api/v1/eliza/gateway-relay/sessions/[sessionId]/next/route.ts`: Replace raw `Number.parseInt` with `parsePositiveInteger` from `@elizaos/shared/utils/number-parsing`
- `packages/cloud/api/__tests__/gateway-relay-next-timeout-validation.test.ts`: New focused unit test (14 cases)

## Validation behavior

| Input | Before | After |
|-------|--------|-------|
| absent | 25000 | 25000 |
| `1` | 1 | 1 |
| `1000` | 1000 | 1000 |
| `25000` | 25000 | 25000 |
| `50000` | 25000 (cap) | 25000 (cap) |
| `-1` | 25000 (fallback) | 25000 (rejected → fallback) |
| `0` | 25000 (fallback) | 25000 (rejected → fallback) |
| `12px` | 12 (prefix parsed) | 25000 (rejected → fallback) |
| `1.5` | 1 (floor) | 25000 (rejected → fallback) |
| `1e4` | 1 (prefix) | 25000 (rejected → fallback) |
| `007` | 7 | 7 (accepted) |
| `25000abc` | 25000 (prefix) | 25000 (rejected → fallback) |
| `Infinity` | 25000 (fallback) | 25000 (rejected → fallback) |
| ` 1 ` | 1 (whitespace trimmed) | 25000 (rejected → fallback) |
| `9007199254740992` (unsafe) | unsafe int | 25000 (rejected → fallback) |

All malformed/non-positive values now default to `25000` before reaching the long-poll service. Valid positive integers pass through the existing `25000` cap.

## Checks

- `bun test` — 14/14 pass
- `biome check` — clean
- `typecheck` — only pre-existing unrelated error in `staging-session-exchange.test.ts` (missing `jose` module)

## Evidence

node scripts/pr-evidence.mjs rows 20437 \
  --row "backend-logs=N/A - deterministic unit tests; test output shown in PR checks" \
  --row "before-screenshots=N/A - no UI change; pure validation/boundary fix" \
  --row "after-screenshots=N/A - no UI change; pure validation/boundary fix" \
  --row "walkthrough-video=N/A - no UI change; pure validation/boundary fix" \
  --row "frontend-logs=N/A - no UI change; pure validation/boundary fix" \
  --row "llm-trajectory=N/A - deterministic unit tests; no LLM execution" \
  --row "domain-artifacts=N/A - pure validation fix; no domain artifacts"

---

## Contribution provenance
<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `z.ai/glm-5.2`
<!-- attribution-row:client -->
- Agent tooling: `Hermes Agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d0c5b4a64bd5435468cc203fa4b22d50b1c7d107:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

<!-- evidence-head:d0c5b4a64bd5435468cc203fa4b22d50b1c7d107 -->

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic unit tests; test output shown in PR checks

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI change; pure validation/boundary fix

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI change; pure validation/boundary fix

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI change; pure validation/boundary fix

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no UI change; pure validation/boundary fix

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic unit tests; no LLM execution

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure validation fix; no domain artifacts
