### PR TITLE
feat(lifeops): finish commitment ingestion, standing guarantees, and regret-audit consumption

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/brief.ts
+++ b/plugins/plugin-personal-assistant/src/actions/brief.ts
@@ -7,7 +7,8 @@
  *   - `compose_weekly`   — `period: this_week` by default
  *
  * Pulls from each domain (calendar feed, inbox triage, life-domain due items,
- * money recurring charges) per the `include` arg, then runs a single LLM
+ * money recurring charges, regret-audited commitment-ledger obligations) per
+ * the `include` arg, then runs a single LLM
  * compose pass to render a narrative over the structured `LifeOpsBriefing`
  * shape. Briefings are kept in-memory.
  *
@@ -38,6 +39,10 @@ import {
   type LifeOpsBriefItemEngagementSummary,
 } from "../lifeops/briefing/editorial-judgment.js";
 import {
+  buildCommitmentRegretAudit,
+  type CommitmentRegretAuditItem,
+} from "../lifeops/commitments/index.js";
+import {
   BRIEF_NARRATIVE_INSTRUCTIONS,
   MEETING_PREP_INSTRUCTIONS,
 } from "../lifeops/optimized-prompt-instructions.js";
@@ -45,6 +50,7 @@ import { LifeOpsRepository } from "../lifeops/repository.js";
 import type {
   LifeOpsBriefing,
   LifeOpsBriefingCalendarItem,
+  LifeOpsBriefingCommitmentItem,
   LifeOpsBriefingEditorialContract,
   LifeOpsBriefingInboxItem,
   LifeOpsBriefingKind,
@@ -109,6 +115,7 @@ interface BriefIncludeFlags {
   inbox?: boolean;
   life?: boolean;
   money?: boolean;
+  commitments?: boolean;
 }
 
 interface BriefActionParameters {
@@ -374,6 +381,58 @@ async function loadMoneyFromPayments(args: {
   }
 }
 
+const MAX_BRIEF_COMMITMENT_ITEMS = 10;
+
+/** Map one regret-audit item onto the briefing's commitment shape. */
+export function mapRegretAuditItemToBriefingItem(
+  item: CommitmentRegretAuditItem,
+): LifeOpsBriefingCommitmentItem {
+  return {
+    id: item.record.id,
+    kind: item.record.kind,
+    summary: item.record.summary,
+    counterparty: item.record.counterparty,
+    dueAt: item.record.dueAt,
+    status: item.record.status === "tracked" ? "tracked" : "open",
+    regretScore: item.score,
+    reasons: item.reasons,
+  };
+}
+
+/**
+ * Regret-audited commitment-ledger obligations (#14864): open and tracked
+ * promises ranked by `buildCommitmentRegretAudit`, so the narrative can name
+ * what the owner would regret dropping. No-DB hosts have no ledger — that is
+ * a designed-empty section, not an error.
+ */
+async function loadCommitmentsFromLedger(args: {
+  runtime: IAgentRuntime;
+}): Promise<readonly LifeOpsBriefingCommitmentItem[]> {
+  const adapter = (args.runtime as { adapter?: { db?: unknown } }).adapter;
+  if (!adapter?.db) return [];
+  try {
+    const records = await new LifeOpsRepository(
+      args.runtime,
+    ).listCommitmentLedgerRecords(String(args.runtime.agentId), {
+      statuses: ["open", "tracked"],
+    });
+    const audit = buildCommitmentRegretAudit(records, {
+      nowIso: new Date().toISOString(),
+    });
+    return audit.items
+      .slice(0, MAX_BRIEF_COMMITMENT_ITEMS)
+      .map(mapRegretAuditItemToBriefingItem);
+  } catch (error) {
+    // error-policy:J4 the brief composes from independent optional sources;
+    // a broken ledger read must not kill the whole brief. The degrade is
+    // designed (section omitted) and stays observable through reportError.
+    args.runtime.reportError("Brief.loadCommitments", error, {
+      surface: "brief-commitment-regret-audit",
+    });
+    return [];
+  }
+}
+
 async function loadEngagementSummariesFromLifeOps(args: {
   runtime: IAgentRuntime;
 }): Promise<readonly LifeOpsBriefItemEngagementSummary[]> {
@@ -418,6 +477,10 @@ export interface BriefComposers {
   loadCompletedToday: (args: {
     runtime: IAgentRuntime;
   }) => Promise<readonly LifeOpsBriefingLifeItem[]>;
+  /** Regret-audited commitment-ledger obligations (#14864). */
+  loadCommitments: (args: {
+    runtime: IAgentRuntime;
+  }) => Promise<readonly LifeOpsBriefingCommitmentItem[]>;
   /** Persisted owner response signals that influence editorial ranking. */
   loadEngagementSummaries: (args: {
     runtime: IAgentRuntime;
@@ -430,6 +493,7 @@ const defaultComposers: BriefComposers = {
   loadLife: loadLifeFromOverview,
   loadMoney: loadMoneyFromPayments,
   loadCompletedToday: loadCompletedTodayFromService,
+  loadCommitments: loadCommitmentsFromLedger,
   loadEngagementSummaries: loadEngagementSummariesFromLifeOps,
 };
 
@@ -483,12 +547,14 @@ function resolveIncludeFlags(input: BriefIncludeFlags | undefined): {
   inbox: boolean;
   life: boolean;
   money: boolean;
+  commitments: boolean;
 } {
   return {
     calendar: input?.calendar !== false,
     inbox: input?.inbox !== false,
     life: input?.life !== false,
     money: input?.money !== false,
+    commitments: input?.commitments !== false,
   };
 }
 
@@ -642,6 +708,7 @@ async function assembleBriefing(args: {
     inboxItems,
     lifeItems,
     moneyItems,
+    commitmentItems,
     engagementSummaries,
   ] = await Promise.all([
     args.include.calendar
@@ -656,6 +723,9 @@ async function assembleBriefing(args: {
     args.include.money
       ? composers.loadMoney({ runtime: args.runtime, period: args.period })
       : Promise.resolve([] as readonly LifeOpsBriefingMoneyItem[]),
+    args.include.commitments
+      ? composers.loadCommitments({ runtime: args.runtime })
+      : Promise.resolve([] as readonly LifeOpsBriefingCommitmentItem[]),
     composers.loadEngagementSummaries({ runtime: args.runtime }),
   ]);
 
@@ -674,6 +744,9 @@ async function assembleBriefing(args: {
     ...(args.include.life ? { life: lifeItems } : {}),
     ...(completedToday.length > 0 ? { completedToday } : {}),
     ...(args.include.money ? { money: moneyItems } : {}),
+    ...(args.include.commitments && commitmentItems.length > 0
+      ? { commitments: commitmentItems }
+      : {}),
   };
 
   const editorial = buildBriefEditorialContract({
@@ -822,7 +895,7 @@ export const briefAction: Action & {
       `Composed your ${briefing.kind} briefing for ${briefing.period}.`;
 
     logger.info(
-      `[BRIEF] ${subaction} id=${briefing.id} period=${briefing.period} calendar=${briefing.sections.calendar?.length ?? 0} inbox=${briefing.sections.inbox?.length ?? 0} life=${briefing.sections.life?.length ?? 0} money=${briefing.sections.money?.length ?? 0}`,
+      `[BRIEF] ${subaction} id=${briefing.id} period=${briefing.period} calendar=${briefing.sections.calendar?.length ?? 0} inbox=${briefing.sections.inbox?.length ?? 0} life=${briefing.sections.life?.length ?? 0} money=${briefing.sections.money?.length ?? 0} commitments=${briefing.sections.commitments?.length ?? 0}`,
     );
 
     await callback?.({

--- a/plugins/plugin-personal-assistant/src/actions/document.ts
+++ b/plugins/plugin-personal-assistant/src/actions/document.ts
@@ -11,6 +11,9 @@
  *   - `upload_asset`       ← `OWNER_DOCUMENTS_UPLOAD_ASSET`
  *   - `collect_id`         ← `OWNER_DOCUMENTS_COLLECT_ID_OR_FORM`
  *   - `close_request`      ← `OWNER_DOCUMENTS_CLOSE_REQUEST`
+ *   - `guarantee_class`    ← `OWNER_DOCUMENTS_GUARANTEE_CLASS` (#14864):
+ *     installs a standing class guarantee so every future deadline-bearing
+ *     artifact of that obligation class is auto-tracked with a lead-time warn.
  *
  * Each subaction composes existing services (`SCHEDULED_TASK` runner for
  * deadline tracking, `ApprovalQueue` for owner-gated dispatch). The
@@ -35,7 +38,12 @@ import type {
 import { logger } from "@elizaos/core";
 import { hasLifeOpsAccess } from "../lifeops/access.js";
 import { createApprovalQueue } from "../lifeops/approval-queue.js";
-import { createDocumentObligationLedgerRecord } from "../lifeops/commitments/index.js";
+import {
+  applyCommitmentClassGuarantees,
+  createDocumentObligationLedgerRecord,
+  installCommitmentClassGuarantee,
+  normalizeObligationClass,
+} from "../lifeops/commitments/index.js";
 import { LifeOpsRepository } from "../lifeops/repository.js";
 import type {
   ScheduledTaskRunnerHandle,
@@ -57,6 +65,7 @@ const SUBACTIONS = [
   "upload_asset",
   "collect_id",
   "close_request",
+  "guarantee_class",
 ] as const;
 
 type Subaction = (typeof SUBACTIONS)[number];
@@ -68,6 +77,7 @@ const SIMILE_NAMES: readonly string[] = [
   "OWNER_DOCUMENTS_UPLOAD_ASSET",
   "OWNER_DOCUMENTS_COLLECT_ID_OR_FORM",
   "OWNER_DOCUMENTS_CLOSE_REQUEST",
+  "OWNER_DOCUMENTS_GUARANTEE_CLASS",
   "PAPERWORK",
 ];
 
@@ -84,6 +94,7 @@ const SIMILE_TO_SUBACTION: Readonly<Record<string, Subaction>> = {
   OWNER_DOCUMENTS_UPLOAD_ASSET: "upload_asset",
   OWNER_DOCUMENTS_COLLECT_ID_OR_FORM: "collect_id",
   OWNER_DOCUMENTS_CLOSE_REQUEST: "close_request",
+  OWNER_DOCUMENTS_GUARANTEE_CLASS: "guarantee_class",
 };
 
 interface DocActionParameters {
@@ -115,6 +126,10 @@ interface DocActionParameters {
   note?: string;
   /** close_request: outcome ("completed" | "expired" | "cancelled"). */
   resolution?: "completed" | "expired" | "cancelled";
+  /** guarantee_class: obligation class to auto-track. */
+  obligationClass?: string;
+  /** guarantee_class: lead-time warn in days before each deadline (default 60). */
+  warnDaysBefore?: number;
 }
 
 /**
@@ -183,7 +198,8 @@ function kindForSubaction(subaction: Subaction): DocumentRequestKind {
       return "collect_id";
     case "track_deadline":
     case "close_request":
-      // No new kind — these operate on an existing request.
+    case "guarantee_class":
+      // No new kind — these operate on existing requests or standing rules.
       return "signature";
   }
 }
@@ -324,13 +340,6 @@ async function persistDocumentObligation(
   scheduledTaskId: string | undefined,
 ): Promise<void> {
   if (!doc.deadline) return;
-  const adapter = (scope.runtime as { adapter?: { db?: unknown } }).adapter;
-  if (!adapter?.db) {
-    logger.debug(
-      `[OWNER_DOCUMENTS] commitment ledger unavailable for ${doc.id}; runtime has no SQL adapter`,
-    );
-    return;
-  }
   const record = createDocumentObligationLedgerRecord({
     agentId: scope.agentId,
     documentId: doc.id,
@@ -345,9 +354,64 @@ async function persistDocumentObligation(
     },
     ...(doc.note ? { note: doc.note } : {}),
   });
-  await new LifeOpsRepository(scope.runtime).upsertCommitmentLedgerRecord(
-    record,
+  const adapter = (scope.runtime as { adapter?: { db?: unknown } }).adapter;
+  if (adapter?.db) {
+    await new LifeOpsRepository(scope.runtime).upsertCommitmentLedgerRecord(
+      record,
+    );
+  } else {
+    logger.debug(
+      `[OWNER_DOCUMENTS] commitment ledger unavailable for ${doc.id}; runtime has no SQL adapter`,
+    );
+  }
+  // Class-level standing guarantees (#14864): a previously installed
+  // guarantee whose obligation class matches this artifact's typed kind adds
+  // the lead-time warn watcher and fires the guarantee's event task. Runs on
+  // no-DB hosts too — the watchers live in the ScheduledTask spine.
+  await applyCommitmentClassGuarantees(scope.runtime, {
+    agentId: scope.agentId,
+    artifact: {
+      documentId: doc.id,
+      title: doc.title,
+      deadline: doc.deadline,
+      obligationKind: record.kind,
+    },
+  });
+}
+
+async function handleGuaranteeClass(
+  scope: RunnerScope,
+  params: DocActionParameters,
+): Promise<ActionResult> {
+  const subaction: Subaction = "guarantee_class";
+  const obligationClass = normalizeObligationClass(params.obligationClass);
+  if (!obligationClass) return missing("obligationClass", subaction);
+  const warnDaysBefore =
+    typeof params.warnDaysBefore === "number" && params.warnDaysBefore > 0
+      ? Math.floor(params.warnDaysBefore)
+      : undefined;
+
+  const task = await installCommitmentClassGuarantee(scope.runtime, {
+    agentId: scope.agentId,
+    obligationClass,
+    ...(warnDaysBefore ? { warnDaysBefore } : {}),
+  });
+
+  const effectiveWarnDays = warnDaysBefore ?? 60;
+  logger.info(
+    `[OWNER_DOCUMENTS] guarantee_class class=${obligationClass} warnDays=${effectiveWarnDays} task=${task.taskId}`,
   );
+
+  return {
+    success: true,
+    text: `Standing guarantee installed: every new ${obligationClass} obligation will be tracked automatically with a ${effectiveWarnDays}-day warning before its deadline.`,
+    data: {
+      subaction,
+      obligationClass,
+      warnDaysBefore: effectiveWarnDays,
+      scheduledTaskId: task.taskId,
+    },
+  };
 }
 
 // ── Subaction handlers ───────────────────────────────────
@@ -744,6 +808,21 @@ const examples: ActionExample[][] = [
   [
     {
       name: "{{name1}}",
+      content: {
+        text: "From now on, always track contract renewals and warn me 60 days before they lapse.",
+      },
+    },
+    {
+      name: "{{agentName}}",
+      content: {
+        text: "Standing guarantee installed: every new renewal obligation will be tracked automatically with a 60-day warning before its deadline.",
+        action: ACTION_NAME,
+      },
+    },
+  ],
+  [
+    {
+      name: "{{name1}}",
       content: { text: "Close out doc-abc123 — it's signed." },
     },
     {
@@ -770,9 +849,9 @@ export const ownerDocumentsAction: Action & {
     "surface:internal",
   ],
   description:
-    "Owner documents: signature requests, approvals, deadlines, portal uploads, ID/form collection, close-out. Ops: request_signature|request_approval|track_deadline|upload_asset|collect_id|close_request.",
+    "Owner documents: signature requests, approvals, deadlines, portal uploads, ID/form collection, close-out, standing obligation-class guarantees. Ops: request_signature|request_approval|track_deadline|upload_asset|collect_id|close_request|guarantee_class.",
   descriptionCompressed:
-    "OWNER_DOCUMENTS signature|approval|deadline|upload_asset|collect_id|close_request",
+    "OWNER_DOCUMENTS signature|approval|deadline|upload_asset|collect_id|close_request|guarantee_class",
   routingHint:
     'owner document signature/approval/upload/portal/ID-form ("get signed", "send approval", "upload deck", "track NDA deadline", "close doc") -> OWNER_DOCUMENTS; approval queue resolution -> RESOLVE_REQUEST',
   contexts: ["docs", "tasks", "calendar", "contacts"],
@@ -783,7 +862,7 @@ export const ownerDocumentsAction: Action & {
     {
       name: "action",
       description:
-        "Document op: request_signature|request_approval|track_deadline|upload_asset|collect_id|close_request.",
+        "Document op: request_signature|request_approval|track_deadline|upload_asset|collect_id|close_request|guarantee_class.",
       schema: { type: "string" as const, enum: [...SUBACTIONS] },
     },
     {
@@ -848,6 +927,21 @@ export const ownerDocumentsAction: Action & {
         enum: ["completed", "expired", "cancelled"],
       },
     },
+    {
+      name: "obligationClass",
+      description:
+        "guarantee_class only: obligation class to auto-track (renewal covers contracts).",
+      schema: {
+        type: "string" as const,
+        enum: ["commitment", "renewal", "filing", "warranty"],
+      },
+    },
+    {
+      name: "warnDaysBefore",
+      description:
+        "guarantee_class only: warn lead time in days before each deadline; default 60.",
+      schema: { type: "number" as const },
+    },
   ],
   examples,
   handler: async (
@@ -868,7 +962,7 @@ export const ownerDocumentsAction: Action & {
     if (!subaction) {
       return {
         success: false,
-        text: "Tell me which document operation: request_signature, request_approval, track_deadline, upload_asset, collect_id, or close_request.",
+        text: "Tell me which document operation: request_signature, request_approval, track_deadline, upload_asset, collect_id, close_request, or guarantee_class.",
         data: { error: "MISSING_SUBACTION" },
       };
     }
@@ -893,6 +987,9 @@ export const ownerDocumentsAction: Action & {
         break;
       case "close_request":
         result = await handleCloseRequest(scope, params);
+        break;
+      case "guarantee_class":
+        result = await handleGuaranteeClass(scope, params);
         break;
     }
 

--- a/plugins/plugin-personal-assistant/src/actions/prioritize.ts
+++ b/plugins/plugin-personal-assistant/src/actions/prioritize.ts
@@ -2,9 +2,10 @@
  * `PRIORITIZE` umbrella action — LLM-ranked importance × urgency.
  *
  * Subactions:
- *   - `rank_todos`     — todo items in the owner's life domain
- *   - `rank_threads`   — open inbox / messaging threads
- *   - `rank_decisions` — pending approval queue decisions
+ *   - `rank_todos`       — todo items in the owner's life domain
+ *   - `rank_threads`     — open inbox / messaging threads
+ *   - `rank_decisions`   — pending approval queue decisions
+ *   - `rank_commitments` — regret-audited commitment-ledger obligations (#14864)
  *
  * Loads items via the relevant loader hook, then calls
  * `runtime.useModel(ModelType.TEXT_LARGE)` once with a structured prompt that
@@ -25,10 +26,20 @@ import type {
 } from "@elizaos/core";
 import { logger, ModelType, runWithTrajectoryPurpose } from "@elizaos/core";
 import { hasLifeOpsAccess } from "../lifeops/access.js";
+import {
+  buildCommitmentRegretAudit,
+  type CommitmentRegretAuditItem,
+} from "../lifeops/commitments/index.js";
+import { LifeOpsRepository } from "../lifeops/repository.js";
 
 const ACTION_NAME = "PRIORITIZE";
 
-const SUBACTIONS = ["rank_todos", "rank_threads", "rank_decisions"] as const;
+const SUBACTIONS = [
+  "rank_todos",
+  "rank_threads",
+  "rank_decisions",
+  "rank_commitments",
+] as const;
 
 type Subaction = (typeof SUBACTIONS)[number];
 
@@ -37,20 +48,24 @@ const SIMILE_NAMES: readonly string[] = [
   "RANK_TODAY",
   "WHAT_MATTERS_MOST",
   "PRIORITIZE_TODAY",
+  "WHAT_WILL_I_REGRET",
+  "REGRET_AUDIT",
 ];
 
-type Subject = "todos" | "threads" | "decisions";
+type Subject = "todos" | "threads" | "decisions" | "commitments";
 
 const SUBJECT_TO_SUBACTION: Readonly<Record<Subject, Subaction>> = {
   todos: "rank_todos",
   threads: "rank_threads",
   decisions: "rank_decisions",
+  commitments: "rank_commitments",
 };
 
 const SUBACTION_TO_SUBJECT: Readonly<Record<Subaction, Subject>> = {
   rank_todos: "todos",
   rank_threads: "threads",
   rank_decisions: "decisions",
+  rank_commitments: "commitments",
 };
 
 interface PrioritizeActionParameters {
@@ -93,6 +108,9 @@ export interface PrioritizeLoaders {
     args: PrioritizeLoaderArgs,
   ) => Promise<readonly PrioritizeRankableItem[]>;
   loadDecisions: (
+    args: PrioritizeLoaderArgs,
+  ) => Promise<readonly PrioritizeRankableItem[]>;
+  loadCommitments: (
     args: PrioritizeLoaderArgs,
   ) => Promise<readonly PrioritizeRankableItem[]>;
 }
@@ -379,10 +397,65 @@ async function loadDecisionsFromRuntime({
   }
 }
 
+/** Map one regret-audit item onto the generic rankable shape. */
+export function mapRegretAuditItemToRankable(
+  item: CommitmentRegretAuditItem,
+): PrioritizeRankableItem {
+  return {
+    id: item.record.id,
+    title: item.record.summary,
+    summary: item.reasons.join("; "),
+    ...(item.record.dueAt ? { dueAt: item.record.dueAt } : {}),
+    metadata: metadata([
+      ["source", "commitment_ledger"],
+      ["kind", item.record.kind],
+      ["status", item.record.status],
+      ["counterparty", item.record.counterparty],
+      ["regretScore", item.score],
+      ["scheduledTaskId", item.record.scheduledTaskId],
+    ]),
+  };
+}
+
+/**
+ * "What will I regret?" (#14864): open/tracked commitment-ledger rows ranked
+ * by `buildCommitmentRegretAudit`, so the LLM pass ranks against the audit's
+ * deterministic scores and reasons instead of re-deriving urgency from prose.
+ * No-DB hosts have no ledger — that is a designed-empty ranking source.
+ */
+async function loadCommitmentsFromLedgerAudit({
+  runtime,
+}: PrioritizeLoaderArgs): Promise<readonly PrioritizeRankableItem[]> {
+  const agentId = runtimeAgentId(runtime);
+  if (!agentId) return [];
+  const adapter = (runtime as { adapter?: { db?: unknown } }).adapter;
+  if (!adapter?.db) return [];
+  try {
+    const records = await new LifeOpsRepository(
+      runtime,
+    ).listCommitmentLedgerRecords(agentId, { statuses: ["open", "tracked"] });
+    const audit = buildCommitmentRegretAudit(records, {
+      nowIso: new Date().toISOString(),
+    });
+    return audit.items
+      .slice(0, MAX_PRIORITIZE_SOURCE_ITEMS)
+      .map(mapRegretAuditItemToRankable);
+  } catch (error) {
+    // error-policy:J4 same degrade contract as the sibling loaders — one
+    // broken ranking source returns designed-empty instead of killing the
+    // whole PRIORITIZE turn; the failure stays visible in the warn log.
+    logger.warn(
+      `[PRIORITIZE] rank_commitments load failed: ${errorDetail(error)}`,
+    );
+    return [];
+  }
+}
+
 const defaultLoaders: PrioritizeLoaders = {
   loadTodos: loadTodosFromRuntime,
   loadThreads: loadThreadsFromRuntime,
   loadDecisions: loadDecisionsFromRuntime,
+  loadCommitments: loadCommitmentsFromLedgerAudit,
 };
 
 let activeLoaders: PrioritizeLoaders = defaultLoaders;
@@ -418,7 +491,12 @@ function normalizeSubaction(value: unknown): Subaction | null {
 function normalizeSubject(value: unknown): Subject | null {
   if (typeof value !== "string") return null;
   const lower = value.trim().toLowerCase();
-  if (lower === "todos" || lower === "threads" || lower === "decisions") {
+  if (
+    lower === "todos" ||
+    lower === "threads" ||
+    lower === "decisions" ||
+    lower === "commitments"
+  ) {
     return lower;
   }
   return null;
@@ -450,6 +528,8 @@ async function loadItemsForSubaction(
       return activeLoaders.loadThreads({ runtime, message });
     case "rank_decisions":
       return activeLoaders.loadDecisions({ runtime, message });
+    case "rank_commitments":
+      return activeLoaders.loadCommitments({ runtime, message });
   }
 }
 
@@ -581,11 +661,11 @@ export const prioritizeAction: Action & {
     "surface:internal",
   ],
   description:
-    "Rank owner open todos, message threads, pending decisions by urgency × importance. LLM pass. Subactions: rank_todos, rank_threads, rank_decisions.",
+    "Rank owner open todos, message threads, pending decisions, or regret-audited commitments by urgency × importance. LLM pass. Subactions: rank_todos, rank_threads, rank_decisions, rank_commitments.",
   descriptionCompressed:
-    "prioritize: rank_todos|rank_threads|rank_decisions; topN ranking by urgency × importance",
+    "prioritize: rank_todos|rank_threads|rank_decisions|rank_commitments; topN ranking by urgency × importance",
   routingHint:
-    'prioritization ("focus on", "rank today", "which thread first", "what matters most") -> PRIORITIZE; do not use plain list -> OWNER_TODOS.list / MESSAGE.list_inbox',
+    'prioritization ("focus on", "rank today", "which thread first", "what matters most", "what will I regret") -> PRIORITIZE; do not use plain list -> OWNER_TODOS.list / MESSAGE.list_inbox',
   contexts: ["focus", "tasks", "inbox", "approvals"],
   roleGate: { minRole: "OWNER" },
   suppressPostActionContinuation: true,
@@ -593,16 +673,17 @@ export const prioritizeAction: Action & {
   parameters: [
     {
       name: "action",
-      description: "Prioritize op: rank_todos | rank_threads | rank_decisions.",
+      description:
+        "Prioritize op: rank_todos | rank_threads | rank_decisions | rank_commitments.",
       schema: { type: "string" as const, enum: [...SUBACTIONS] },
     },
     {
       name: "subject",
       description:
-        "Alt selector: todos | threads | decisions. Maps to subaction.",
+        "Alt selector: todos | threads | decisions | commitments. Maps to subaction.",
       schema: {
         type: "string" as const,
-        enum: ["todos", "threads", "decisions"],
+        enum: ["todos", "threads", "decisions", "commitments"],
       },
     },
     {
@@ -635,7 +716,7 @@ export const prioritizeAction: Action & {
     if (!subaction) {
       return {
         success: false,
-        text: "Tell me what to rank: rank_todos, rank_threads, or rank_decisions.",
+        text: "Tell me what to rank: rank_todos, rank_threads, rank_decisions, or rank_commitments.",
         data: { error: "MISSING_SUBACTION" },
       };
     }

--- a/plugins/plugin-personal-assistant/src/lifeops/commitments/extraction-evaluator.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/commitments/extraction-evaluator.ts
@@ -1,0 +1,242 @@
+/**
+ * `commitment_extraction` — post-turn evaluator that projects concrete
+ * first-person promises in an owner's outbound message into the durable
+ * commitment ledger (#14864). The model runs inside the runtime's single
+ * merged SMALL-model evaluation call; every extracted row must survive a
+ * deterministic false-positive guard before it is persisted, so hedged
+ * chit-chat ("yeah maybe sometime") can never become owner work even when
+ * the model over-extracts. Deterministic-only paths (sent mail, document
+ * hooks, transcripts) stay on `extractCommitmentLedgerRecords`.
+ */
+import { hasOwnerAccess } from "@elizaos/agent";
+import type {
+  Evaluator,
+  IAgentRuntime,
+  JSONSchema,
+  Memory,
+} from "@elizaos/core";
+import { LifeOpsRepository } from "../repository.js";
+import {
+  classifyCommitmentKind,
+  createLifeOpsCommitmentLedgerRecord,
+  isSpeculativeCommitmentText,
+  type LifeOpsCommitmentLedgerRecord,
+  textHasCommitmentCue,
+} from "./ledger.js";
+
+export interface ExtractedCommitmentCandidate {
+  /** Verbatim sentence from the owner's message that carries the promise. */
+  evidence: string;
+  /** Short imperative restatement of the promise. */
+  summary: string;
+  counterparty?: string | null;
+  /** ISO-8601 due date when the promise names one; omitted otherwise. */
+  dueAtIso?: string | null;
+  confidence: number;
+}
+
+export interface CommitmentExtractionOutput {
+  commitments: ExtractedCommitmentCandidate[];
+}
+
+const MIN_CONFIDENCE = 0.6;
+
+const commitmentExtractionSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    commitments: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          evidence: { type: "string" },
+          summary: { type: "string" },
+          counterparty: { type: ["string", "null"] },
+          dueAtIso: { type: ["string", "null"] },
+          confidence: { type: "number" },
+        },
+        required: ["evidence", "summary", "confidence"],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ["commitments"],
+  additionalProperties: false,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeForMatch(value: string): string {
+  return value.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+function validIsoOrNull(value: unknown): string | null {
+  if (typeof value !== "string" || value.trim().length === 0) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+}
+
+export function parseCommitmentExtractionOutput(
+  output: unknown,
+): CommitmentExtractionOutput | null {
+  if (!isRecord(output) || !Array.isArray(output.commitments)) return null;
+  const commitments: ExtractedCommitmentCandidate[] = [];
+  for (const entry of output.commitments) {
+    if (!isRecord(entry)) continue;
+    const evidence = typeof entry.evidence === "string" ? entry.evidence : "";
+    const summary = typeof entry.summary === "string" ? entry.summary : "";
+    const confidence =
+      typeof entry.confidence === "number" ? entry.confidence : Number.NaN;
+    if (!evidence.trim() || !summary.trim() || Number.isNaN(confidence)) {
+      continue;
+    }
+    commitments.push({
+      evidence,
+      summary,
+      counterparty:
+        typeof entry.counterparty === "string" && entry.counterparty.trim()
+          ? entry.counterparty.trim()
+          : null,
+      dueAtIso: validIsoOrNull(entry.dueAtIso),
+      confidence,
+    });
+  }
+  return { commitments };
+}
+
+/**
+ * Deterministic false-positive guard over model-extracted candidates. A
+ * candidate survives only when its verbatim evidence actually appears in the
+ * source text, carries a first-person commitment cue, is not hedged, and the
+ * model's own confidence clears the floor. The guard is pure so tests can
+ * prove "yeah maybe sometime" creates nothing regardless of model output.
+ */
+export function filterExtractedCommitments(
+  sourceText: string,
+  candidates: readonly ExtractedCommitmentCandidate[],
+): ExtractedCommitmentCandidate[] {
+  const haystack = normalizeForMatch(sourceText);
+  return candidates.filter((candidate) => {
+    const evidence = candidate.evidence.trim();
+    if (evidence.length === 0) return false;
+    if (!haystack.includes(normalizeForMatch(evidence))) return false;
+    if (!textHasCommitmentCue(evidence)) return false;
+    if (isSpeculativeCommitmentText(evidence)) return false;
+    return candidate.confidence >= MIN_CONFIDENCE;
+  });
+}
+
+/** Build ledger rows from guarded candidates; exported for direct test proof. */
+export function ledgerRecordsFromCandidates(args: {
+  agentId: string;
+  sourceKey: string;
+  observedAt: string;
+  candidates: readonly ExtractedCommitmentCandidate[];
+}): LifeOpsCommitmentLedgerRecord[] {
+  return args.candidates.map((candidate) =>
+    createLifeOpsCommitmentLedgerRecord({
+      agentId: args.agentId,
+      source: "chat",
+      sourceKey: args.sourceKey,
+      kind: classifyCommitmentKind(candidate.evidence),
+      summary: candidate.summary,
+      counterparty: candidate.counterparty ?? null,
+      dueAt: candidate.dueAtIso ?? null,
+      confidence: candidate.confidence,
+      metadata: {
+        observedAt: args.observedAt,
+        extractedBy: "commitment_extraction",
+        evidence: candidate.evidence,
+      },
+    }),
+  );
+}
+
+function hasSqlAdapter(runtime: IAgentRuntime): boolean {
+  const adapter = (runtime as { adapter?: { db?: unknown } }).adapter;
+  return Boolean(adapter?.db);
+}
+
+function messageSourceKey(message: Memory): string {
+  return `message:${String(message.id ?? message.createdAt ?? "unknown")}`;
+}
+
+export const commitmentExtractionEvaluator: Evaluator<
+  CommitmentExtractionOutput,
+  Record<string, never>
+> = {
+  name: "commitment_extraction",
+  description:
+    "Extracts concrete first-person promises from the owner's message into the durable commitment ledger.",
+  priority: 120,
+  schema: commitmentExtractionSchema,
+
+  async shouldRun({ runtime, message }) {
+    const text = message.content.text;
+    if (typeof text !== "string" || text.trim().length === 0) return false;
+    if (message.entityId === runtime.agentId) return false;
+    // Deterministic prefilter: no commitment cue (or a hedge) means no model
+    // spend and structurally no row — the false-positive guard's outer wall.
+    if (!textHasCommitmentCue(text)) return false;
+    if (!hasSqlAdapter(runtime)) return false;
+    return hasOwnerAccess(runtime, message);
+  },
+
+  async prepare() {
+    return {};
+  },
+
+  prompt({ message }) {
+    return `Extract the concrete commitments (promises to do something) the owner makes in their message below.
+
+Rules:
+- Only include firm first-person promises ("I'll send the deck Friday"). Exclude hedged or speculative remarks ("maybe", "sometime", "we could").
+- "evidence" must be the exact verbatim sentence copied from the message.
+- "summary" is a short restatement of the promised work.
+- "counterparty" is the person the promise is made to, when the message names one.
+- "dueAtIso" is an ISO-8601 timestamp only when the promise names an explicit date; otherwise omit it.
+- "confidence" in [0,1]: how certain you are this is a firm commitment.
+- Return {"commitments": []} when the message contains no firm promise.
+
+Owner message:
+${message.content.text ?? ""}`;
+  },
+
+  parse: parseCommitmentExtractionOutput,
+
+  processors: [
+    {
+      name: "persistExtractedCommitments",
+      async process({ runtime, message, output }) {
+        const text = message.content.text ?? "";
+        const guarded = filterExtractedCommitments(text, output.commitments);
+        if (guarded.length === 0) {
+          return { success: true, values: { commitmentRowsCreated: 0 } };
+        }
+        const records = ledgerRecordsFromCandidates({
+          agentId: String(runtime.agentId),
+          sourceKey: messageSourceKey(message),
+          observedAt: new Date(
+            typeof message.createdAt === "number"
+              ? message.createdAt
+              : Date.now(),
+          ).toISOString(),
+          candidates: guarded,
+        });
+        const repository = new LifeOpsRepository(runtime);
+        for (const record of records) {
+          await repository.upsertCommitmentLedgerRecord(record);
+        }
+        return {
+          success: true,
+          values: {
+            commitmentRowsCreated: records.length,
+            commitmentLedgerIds: records.map((record) => record.id),
+          },
+        };
+      },
+    },
+  ],
+};

--- a/plugins/plugin-personal-assistant/src/lifeops/commitments/index.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/commitments/index.ts
@@ -1,3 +1,6 @@
 /** Commitment-ledger domain exports for durable obligations and regret audits. */
 export * from "./consumer.js";
+export * from "./extraction-evaluator.js";
 export * from "./ledger.js";
+export * from "./standing-guarantees.js";
+export * from "./transcript-hook.js";

--- a/plugins/plugin-personal-assistant/src/lifeops/commitments/ledger.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/commitments/ledger.ts
@@ -80,6 +80,24 @@ const COMMITMENT_RE =
   /\b(i(?:'ll| will| can| need to| owe| promised to)|we(?:'ll| will| need to)|let me|i am going to)\b/i;
 const SPECULATIVE_RE =
   /\b(maybe|sometime|eventually|if we get around to it|might|could)\b/i;
+
+/**
+ * Event kind emitted when a deadline-bearing obligation artifact is observed.
+ * Standing class guarantees subscribe to it with an `obligationKind` filter.
+ * Lives here (a leaf module) so both the event-kind registry and the
+ * standing-guarantee consumer can import it without a module cycle.
+ */
+export const COMMITMENT_OBLIGATION_EVENT_KIND = "document.obligation.observed";
+
+/** Cheap deterministic prefilter: does the text contain a first-person commitment cue? */
+export function textHasCommitmentCue(text: string): boolean {
+  return COMMITMENT_RE.test(text);
+}
+
+/** True when the text hedges ("maybe sometime") and must never become a ledger row. */
+export function isSpeculativeCommitmentText(text: string): boolean {
+  return SPECULATIVE_RE.test(text);
+}
 const WEEKDAYS = [
   "sunday",
   "monday",
@@ -142,7 +160,8 @@ function resolveDueAt(text: string, observedAt: string): string | null {
   return weekday ? nextWeekdayIso(observedAt, weekday) : null;
 }
 
-function classifyKind(text: string): LifeOpsCommitmentKind {
+/** Classify a commitment sentence into the ledger's typed obligation kind. */
+export function classifyCommitmentKind(text: string): LifeOpsCommitmentKind {
   if (/\b(renew|renewal|cancellation deadline|trial ends)\b/i.test(text)) {
     return "renewal";
   }
@@ -214,7 +233,7 @@ export function extractCommitmentLedgerRecords(
 ): LifeOpsCommitmentLedgerRecord[] {
   const sentence = firstCommitmentSentence(input.text);
   if (!sentence) return [];
-  const kind = classifyKind(sentence);
+  const kind = classifyCommitmentKind(sentence);
   return [
     createLifeOpsCommitmentLedgerRecord({
       agentId: input.agentId,

--- a/plugins/plugin-personal-assistant/src/lifeops/commitments/standing-guarantees.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/commitments/standing-guarantees.ts
@@ -1,0 +1,214 @@
+/**
+ * Class-level standing guarantees over obligation artifacts (#14864). One
+ * owner utterance ("always track contract renewals") installs a single
+ * event-triggered ScheduledTask; from then on every newly observed
+ * deadline-bearing artifact of that class deterministically gains its ledger
+ * row + deadline watcher through the document hooks, plus a lead-time warn
+ * watcher (contract renewal → 60-day warn by default) installed here. All
+ * matching branches on typed fields (`trigger.eventKind`, filter
+ * `obligationKind`, `metadata.standingGuarantee`), never on prompt prose.
+ */
+import type { EventPayload, IAgentRuntime } from "@elizaos/core";
+import type { ScheduledTask } from "../scheduled-task/index.js";
+import { getScheduledTaskRunner } from "../scheduled-task/service.js";
+import {
+  COMMITMENT_OBLIGATION_EVENT_KIND,
+  type LifeOpsCommitmentKind,
+} from "./ledger.js";
+
+export interface CommitmentClassGuaranteeInput {
+  agentId: string;
+  obligationClass: LifeOpsCommitmentKind;
+  /** Days before the artifact deadline the warn watcher fires. */
+  warnDaysBefore?: number;
+}
+
+export interface ObservedObligationArtifact {
+  documentId: string;
+  title: string;
+  /** ISO-8601 artifact deadline. */
+  deadline: string;
+  obligationKind: LifeOpsCommitmentKind;
+}
+
+/**
+ * Payload of `COMMITMENT_OBLIGATION_EVENT_KIND`. The scheduling event bridge
+ * subset-matches guarantee filters (`obligationKind`) against these fields.
+ */
+export interface CommitmentObligationEventPayload extends EventPayload {
+  obligationKind: LifeOpsCommitmentKind;
+  documentId: string;
+  title: string;
+  deadline: string;
+}
+
+export interface ApplyGuaranteesResult {
+  matchedGuaranteeTaskIds: string[];
+  warnTaskIds: string[];
+}
+
+const DEFAULT_WARN_DAYS_BEFORE = 60;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const OBLIGATION_KINDS: readonly LifeOpsCommitmentKind[] = [
+  "commitment",
+  "renewal",
+  "filing",
+  "warranty",
+];
+
+export function normalizeObligationClass(
+  value: unknown,
+): LifeOpsCommitmentKind | null {
+  if (typeof value !== "string") return null;
+  const lower = value.trim().toLowerCase();
+  return (OBLIGATION_KINDS as readonly string[]).includes(lower)
+    ? (lower as LifeOpsCommitmentKind)
+    : null;
+}
+
+function guaranteeIdempotencyKey(obligationClass: LifeOpsCommitmentKind) {
+  return `commitment-guarantee:${obligationClass}`;
+}
+
+function guaranteeWarnDays(task: ScheduledTask): number {
+  const raw = (task.metadata as Record<string, unknown> | undefined)
+    ?.warnDaysBefore;
+  return typeof raw === "number" && Number.isFinite(raw) && raw > 0
+    ? raw
+    : DEFAULT_WARN_DAYS_BEFORE;
+}
+
+function isGuaranteeForClass(
+  task: ScheduledTask,
+  obligationKind: LifeOpsCommitmentKind,
+): boolean {
+  if (task.trigger.kind !== "event") return false;
+  if (task.trigger.eventKind !== COMMITMENT_OBLIGATION_EVENT_KIND) return false;
+  const metadata = (task.metadata ?? {}) as Record<string, unknown>;
+  if (metadata.standingGuarantee !== true) return false;
+  const filter = task.trigger.filter;
+  const filterKind =
+    filter && typeof filter === "object"
+      ? (filter as Record<string, unknown>).obligationKind
+      : undefined;
+  return filterKind === obligationKind;
+}
+
+/**
+ * Install (or idempotently reuse) the standing guarantee for one obligation
+ * class. The task is event-triggered: the bridge fires it whenever
+ * `COMMITMENT_OBLIGATION_EVENT_KIND` is emitted with a matching
+ * `obligationKind`, producing the owner-visible "now tracking" notice. The
+ * structural row/watcher work happens in `applyCommitmentClassGuarantees`.
+ */
+export async function installCommitmentClassGuarantee(
+  runtime: IAgentRuntime,
+  input: CommitmentClassGuaranteeInput,
+): Promise<ScheduledTask> {
+  const warnDaysBefore = input.warnDaysBefore ?? DEFAULT_WARN_DAYS_BEFORE;
+  const runner = getScheduledTaskRunner(runtime, { agentId: input.agentId });
+  return runner.schedule({
+    kind: "watcher",
+    promptInstructions: `A new ${input.obligationClass} obligation was observed and is now tracked. Tell the owner what it is and when its deadline and ${warnDaysBefore}-day warning fall. Never expose internal record identifiers.`,
+    trigger: {
+      kind: "event",
+      eventKind: COMMITMENT_OBLIGATION_EVENT_KIND,
+      filter: { obligationKind: input.obligationClass },
+    },
+    priority: "medium",
+    idempotencyKey: guaranteeIdempotencyKey(input.obligationClass),
+    respectsGlobalPause: true,
+    source: "user_chat",
+    createdBy: input.agentId,
+    ownerVisible: true,
+    metadata: {
+      standingGuarantee: true,
+      obligationClass: input.obligationClass,
+      warnDaysBefore,
+    },
+  });
+}
+
+/** List the installed standing guarantees matching one obligation class. */
+export async function listCommitmentClassGuarantees(
+  runtime: IAgentRuntime,
+  args: { agentId: string; obligationKind: LifeOpsCommitmentKind },
+): Promise<ScheduledTask[]> {
+  const runner = getScheduledTaskRunner(runtime, { agentId: args.agentId });
+  const tasks = await runner.list({ kind: "watcher", status: "scheduled" });
+  return tasks.filter((task) => isGuaranteeForClass(task, args.obligationKind));
+}
+
+/**
+ * Structural consequence of a newly observed deadline-bearing artifact: when
+ * a standing guarantee covers its class, schedule the lead-time warn watcher
+ * and emit the obligation event so the guarantee task itself fires through
+ * the spine's event bridge. Idempotent per artifact + deadline + lead time —
+ * replayed observations reuse the same warn watcher. Callers own the base
+ * ledger row + deadline watcher (document hooks already create those).
+ */
+export async function applyCommitmentClassGuarantees(
+  runtime: IAgentRuntime,
+  args: { agentId: string; artifact: ObservedObligationArtifact },
+): Promise<ApplyGuaranteesResult> {
+  const { artifact } = args;
+  const guarantees = await listCommitmentClassGuarantees(runtime, {
+    agentId: args.agentId,
+    obligationKind: artifact.obligationKind,
+  });
+  if (guarantees.length === 0) {
+    return { matchedGuaranteeTaskIds: [], warnTaskIds: [] };
+  }
+
+  const runner = getScheduledTaskRunner(runtime, { agentId: args.agentId });
+  const deadlineMs = Date.parse(artifact.deadline);
+  if (Number.isNaN(deadlineMs)) {
+    throw new Error(
+      `applyCommitmentClassGuarantees: artifact ${artifact.documentId} has an unparseable deadline "${artifact.deadline}".`,
+    );
+  }
+
+  const warnTaskIds: string[] = [];
+  for (const guarantee of guarantees) {
+    const warnDays = guaranteeWarnDays(guarantee);
+    const warnAtMs = deadlineMs - warnDays * DAY_MS;
+    if (warnAtMs <= Date.now()) continue;
+    const warnAtIso = new Date(warnAtMs).toISOString();
+    const warnTask = await runner.schedule({
+      kind: "watcher",
+      promptInstructions: `The ${artifact.obligationKind} deadline for "${artifact.title}" is ${warnDays} days away (${artifact.deadline}). Warn the owner and ask whether to renew, renegotiate, or let it lapse. Never expose internal record identifiers.`,
+      trigger: { kind: "once", atIso: warnAtIso },
+      priority: "medium",
+      subject: { kind: "document", id: artifact.documentId },
+      idempotencyKey: `commitment-warn:${artifact.documentId}:${artifact.deadline}:${warnDays}`,
+      respectsGlobalPause: true,
+      source: "plugin",
+      createdBy: args.agentId,
+      ownerVisible: true,
+      metadata: {
+        standingGuaranteeTaskId: guarantee.taskId,
+        obligationKind: artifact.obligationKind,
+        documentId: artifact.documentId,
+        documentTitle: artifact.title,
+        warnDaysBefore: warnDays,
+      },
+    });
+    warnTaskIds.push(warnTask.taskId);
+  }
+
+  const obligationPayload: CommitmentObligationEventPayload = {
+    runtime,
+    source: "plugin-personal-assistant:commitments",
+    obligationKind: artifact.obligationKind,
+    documentId: artifact.documentId,
+    title: artifact.title,
+    deadline: artifact.deadline,
+  };
+  await runtime.emitEvent(COMMITMENT_OBLIGATION_EVENT_KIND, obligationPayload);
+
+  return {
+    matchedGuaranteeTaskIds: guarantees.map((task) => task.taskId),
+    warnTaskIds,
+  };
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/commitments/transcript-hook.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/commitments/transcript-hook.ts
@@ -1,0 +1,92 @@
+/**
+ * Ingested-transcript commitment projection (#14864). When a meeting
+ * transcript is finalized and the payload identifies the owner, the owner's
+ * own diarized segments run through the conservative deterministic extractor
+ * so promises spoken in a meeting land in the same durable ledger as sent
+ * mail and chat. Only segments attributed to the owner's entity are read —
+ * other speakers' promises are their own — and hedged speech is rejected by
+ * the extractor's speculative guard.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import type { MeetingTranscriptFinalizedPayload } from "@elizaos/shared";
+import { LifeOpsRepository } from "../repository.js";
+import {
+  extractCommitmentLedgerRecords,
+  type LifeOpsCommitmentLedgerRecord,
+} from "./ledger.js";
+
+function hasSqlAdapter(runtime: IAgentRuntime): boolean {
+  const adapter = (runtime as { adapter?: { db?: unknown } }).adapter;
+  return Boolean(adapter?.db);
+}
+
+/**
+ * Pure projection: owner-attributed transcript segments → ledger rows.
+ * Exported separately so tests can prove the attribution and speculative
+ * guards without a database.
+ */
+export function commitmentRecordsFromTranscript(args: {
+  agentId: string;
+  ownerEntityId: string;
+  payload: MeetingTranscriptFinalizedPayload;
+}): LifeOpsCommitmentLedgerRecord[] {
+  const { transcript } = args.payload;
+  const records: LifeOpsCommitmentLedgerRecord[] = [];
+  for (const segment of transcript.segments) {
+    if (segment.speakerEntityId !== args.ownerEntityId) continue;
+    const observedAt = new Date(
+      transcript.createdAt + segment.startMs,
+    ).toISOString();
+    records.push(
+      ...extractCommitmentLedgerRecords({
+        agentId: args.agentId,
+        source: "transcript",
+        sourceKey: `${transcript.id}:${segment.id}`,
+        text: segment.text,
+        observedAt,
+        metadata: {
+          transcriptId: transcript.id,
+          transcriptTitle: transcript.title,
+          segmentId: segment.id,
+          meetingId: args.payload.session.id,
+        },
+      }),
+    );
+  }
+  return records;
+}
+
+/**
+ * Runtime hook for `MEETING_TRANSCRIPT_FINALIZED_EVENT`. Skips typed-empty
+ * (returns 0) when the payload carries no owner identity, no owner segments
+ * produce a concrete promise, or the runtime has no SQL ledger — Wave-1
+ * no-DB hosts keep working without a fake success write.
+ */
+export async function projectFinalizedTranscriptCommitments(
+  runtime: IAgentRuntime,
+  payload: MeetingTranscriptFinalizedPayload,
+): Promise<number> {
+  const ownerEntityId = payload.ghostAttendance?.ownerUserId;
+  if (!ownerEntityId) return 0;
+  if (!hasSqlAdapter(runtime)) {
+    logger.debug(
+      `[commitments] transcript ${payload.transcript.id} skipped ledger projection; runtime has no SQL adapter`,
+    );
+    return 0;
+  }
+  const records = commitmentRecordsFromTranscript({
+    agentId: String(runtime.agentId),
+    ownerEntityId,
+    payload,
+  });
+  if (records.length === 0) return 0;
+  const repository = new LifeOpsRepository(runtime);
+  for (const record of records) {
+    await repository.upsertCommitmentLedgerRecord(record);
+  }
+  logger.info(
+    `[commitments] transcript ${payload.transcript.id} projected ${records.length} owner commitment row(s)`,
+  );
+  return records.length;
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/event-handler.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/event-handler.ts
@@ -11,6 +11,7 @@ import type {
   MeetingGhostAttendanceContext,
   MeetingTranscriptFinalizedPayload,
 } from "@elizaos/shared";
+import { projectFinalizedTranscriptCommitments } from "../commitments/transcript-hook.js";
 import {
   type RunMeetingGhostInput,
   runMeetingGhostForTranscript,
@@ -73,6 +74,10 @@ export function meetingGhostInputFromFinalizedPayload(
 export async function handleMeetingTranscriptFinalized(
   payload: FinalizedMeetingEvent,
 ): Promise<void> {
+  // Commitment projection (#14864) self-gates on owner identity and ledger
+  // availability, and must run even when the ghost-attendance interpretation
+  // below is skipped — the owner's spoken promises are their own record.
+  await projectFinalizedTranscriptCommitments(payload.runtime, payload);
   const input = meetingGhostInputFromFinalizedPayload(payload.runtime, payload);
   if (!input) return;
   await runMeetingGhostForTranscript(payload.runtime, input);

--- a/plugins/plugin-personal-assistant/src/lifeops/registries/event-kind-registry.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/registries/event-kind-registry.ts
@@ -15,6 +15,7 @@
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
+import { COMMITMENT_OBLIGATION_EVENT_KIND } from "../commitments/ledger.js";
 
 export interface EventKindContribution {
   /** Stable event-kind identifier — `"calendar.meeting.ended"`, `"health.wake.confirmed"`, etc. */
@@ -108,6 +109,22 @@ export const APP_LIFEOPS_EVENT_KINDS: readonly EventKindContribution[] = [
     describe: {
       label: "Owner evening / wind-down window opened",
       provider: "app-lifeops:time-window",
+    },
+  },
+  {
+    eventKind: COMMITMENT_OBLIGATION_EVENT_KIND,
+    filterSchema: {
+      type: "object",
+      properties: {
+        obligationKind: {
+          type: "string",
+          enum: ["commitment", "renewal", "filing", "warranty"],
+        },
+      },
+    },
+    describe: {
+      label: "Deadline-bearing obligation artifact observed",
+      provider: "app-lifeops:commitments",
     },
   },
 ];

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -122,6 +122,7 @@ import {
   registerChannelRegistry,
   registerDefaultChannelPack,
 } from "./lifeops/channels/index.js";
+import { commitmentExtractionEvaluator } from "./lifeops/commitments/extraction-evaluator.js";
 import {
   createConnectorRegistry,
   registerConnectorRegistry,
@@ -793,7 +794,11 @@ const rawPersonalAssistantPlugin: Plugin = {
   responseHandlerFieldEvaluators: [threadOpsFieldEvaluator],
   // Post-turn evaluators join the runtime's single merged SMALL-model
   // evaluation call (EvaluatorService) — no extra model round-trip per turn.
-  evaluators: [ftuGoalDiscoveryEvaluator, anticipationFeedbackEvaluator],
+  evaluators: [
+    ftuGoalDiscoveryEvaluator,
+    anticipationFeedbackEvaluator,
+    commitmentExtractionEvaluator,
+  ],
   // No views — the LifeOps overview surface was removed (owner: "no need for an
   // overview"). Domain views live in the per-domain plugins; the personal
   // assistant is the chat itself (PERSONAL_ASSISTANT action).

--- a/plugins/plugin-personal-assistant/src/types/briefing.ts
+++ b/plugins/plugin-personal-assistant/src/types/briefing.ts
@@ -48,6 +48,23 @@ export interface LifeOpsBriefingMoneyItem {
   readonly nextChargeAt: string | null;
 }
 
+/**
+ * One commitment-ledger obligation surfaced by the regret audit (#14864):
+ * an open/tracked promise or deadline the owner would regret dropping,
+ * carrying the audit's deterministic score and reasons so the compose model
+ * can rank it honestly instead of re-deriving urgency from prose.
+ */
+export interface LifeOpsBriefingCommitmentItem {
+  readonly id: string;
+  readonly kind: "commitment" | "renewal" | "filing" | "warranty";
+  readonly summary: string;
+  readonly counterparty: string | null;
+  readonly dueAt: string | null;
+  readonly status: "open" | "tracked";
+  readonly regretScore: number;
+  readonly reasons: readonly string[];
+}
+
 export interface LifeOpsBriefingSections {
   readonly calendar?: readonly LifeOpsBriefingCalendarItem[];
   readonly inbox?: readonly LifeOpsBriefingInboxItem[];
@@ -59,6 +76,8 @@ export interface LifeOpsBriefingSections {
    */
   readonly completedToday?: readonly LifeOpsBriefingLifeItem[];
   readonly money?: readonly LifeOpsBriefingMoneyItem[];
+  /** Regret-audited open obligations from the commitment ledger (#14864). */
+  readonly commitments?: readonly LifeOpsBriefingCommitmentItem[];
 }
 
 export interface LifeOpsBriefingEditorialItem {

--- a/plugins/plugin-personal-assistant/test/brief-action.test.ts
+++ b/plugins/plugin-personal-assistant/test/brief-action.test.ts
@@ -239,6 +239,79 @@ describe("BRIEF umbrella action — Daily Operations", () => {
       );
     });
 
+    it("surfaces regret-audited ledger commitments as a briefing section (#14864)", async () => {
+      setBriefComposers({
+        loadCalendar: async () => [],
+        loadInbox: async () => [],
+        loadLife: async () => [],
+        loadMoney: async () => [],
+        loadCompletedToday: async () => [],
+        loadCommitments: async () => [
+          {
+            id: "commit-1",
+            kind: "commitment",
+            summary: "I'll send the deck Friday",
+            counterparty: "Dana",
+            dueAt: "2026-08-14T17:00:00.000Z",
+            status: "open",
+            regretScore: 1.19,
+            reasons: ["no scheduled tracker", "due within the regret horizon"],
+          },
+        ],
+      });
+      const result = await callBrief(makeRuntime(), makeMessage(), {
+        subaction: "compose_morning",
+        format: "json",
+      });
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        briefing: {
+          sections: {
+            commitments?: readonly { id: string; regretScore: number }[];
+          };
+        };
+      };
+      expect(data.briefing.sections.commitments).toHaveLength(1);
+      expect(data.briefing.sections.commitments?.[0]).toMatchObject({
+        id: "commit-1",
+        regretScore: 1.19,
+      });
+    });
+
+    it("omits the commitments section when include.commitments is false", async () => {
+      const loadCommitments = vi.fn(async () => [
+        {
+          id: "commit-1",
+          kind: "commitment" as const,
+          summary: "I'll send the deck Friday",
+          counterparty: null,
+          dueAt: null,
+          status: "open" as const,
+          regretScore: 1.0,
+          reasons: ["no scheduled tracker"],
+        },
+      ]);
+      setBriefComposers({
+        loadCalendar: async () => [],
+        loadInbox: async () => [],
+        loadLife: async () => [],
+        loadMoney: async () => [],
+        loadCompletedToday: async () => [],
+        loadCommitments,
+      });
+      const result = await callBrief(makeRuntime(), makeMessage(), {
+        subaction: "compose_morning",
+        format: "json",
+        include: { commitments: false },
+      });
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        briefing: { sections: { commitments?: unknown } };
+      };
+      expect(data.briefing.sections.commitments).toBeUndefined();
+      expect(loadCommitments).not.toHaveBeenCalled();
+    });
+
     it("feeds the loader payload to the model and returns the trimmed narrative", async () => {
       // Padded model reply: the pipeline must return the TRIMMED narrative,
       // so a straight echo of the stub cannot satisfy the assertion.

--- a/plugins/plugin-personal-assistant/test/commitment-extraction-evaluator.test.ts
+++ b/plugins/plugin-personal-assistant/test/commitment-extraction-evaluator.test.ts
@@ -1,0 +1,269 @@
+/**
+ * `commitment_extraction` evaluator — unit tests (#14864). Deterministic
+ * harness: the runtime, owner-access check, and ledger repository are mocked;
+ * the parse/guard/record functions under test are the real production
+ * exports. The load-bearing proof is the false-positive guard: hedged
+ * chit-chat ("yeah maybe sometime") must never become a ledger row, even
+ * when the model over-extracts it with high confidence.
+ */
+
+import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  hasOwnerAccess: vi.fn(async () => true),
+  upsertCommitmentLedgerRecord: vi.fn(async () => undefined),
+}));
+
+vi.mock("@elizaos/agent", () => ({
+  hasOwnerAccess: mocks.hasOwnerAccess,
+}));
+
+vi.mock("../src/lifeops/repository.js", () => ({
+  LifeOpsRepository: class {
+    upsertCommitmentLedgerRecord = mocks.upsertCommitmentLedgerRecord;
+  },
+}));
+
+import {
+  commitmentExtractionEvaluator,
+  filterExtractedCommitments,
+  ledgerRecordsFromCandidates,
+  parseCommitmentExtractionOutput,
+} from "../src/lifeops/commitments/extraction-evaluator.js";
+
+function makeRuntime(withDb = true): IAgentRuntime {
+  return {
+    agentId: "agent-commit-test" as UUID,
+    ...(withDb ? { adapter: { db: {} } } : {}),
+  } as unknown as IAgentRuntime;
+}
+
+function makeMessage(text: string, entityId = "owner-1"): Memory {
+  return {
+    id: "msg-commit-1" as UUID,
+    entityId: entityId as UUID,
+    roomId: "room-commit-1" as UUID,
+    createdAt: Date.parse("2026-08-10T15:00:00.000Z"),
+    content: { text },
+  } as Memory;
+}
+
+describe("commitment_extraction evaluator", () => {
+  beforeEach(() => {
+    mocks.hasOwnerAccess.mockReset().mockResolvedValue(true);
+    mocks.upsertCommitmentLedgerRecord.mockClear();
+  });
+
+  describe("parseCommitmentExtractionOutput", () => {
+    it("accepts well-formed output and normalizes optional fields", () => {
+      const parsed = parseCommitmentExtractionOutput({
+        commitments: [
+          {
+            evidence: "I'll send the deck Friday",
+            summary: "Send the deck",
+            counterparty: " Dana ",
+            dueAtIso: "2026-08-14T17:00:00.000Z",
+            confidence: 0.9,
+          },
+        ],
+      });
+      expect(parsed?.commitments).toHaveLength(1);
+      expect(parsed?.commitments[0]).toMatchObject({
+        counterparty: "Dana",
+        dueAtIso: "2026-08-14T17:00:00.000Z",
+      });
+    });
+
+    it("drops malformed entries and invalid dates instead of fabricating rows", () => {
+      const parsed = parseCommitmentExtractionOutput({
+        commitments: [
+          { evidence: "", summary: "x", confidence: 0.9 },
+          { evidence: "I'll call", summary: "", confidence: 0.9 },
+          {
+            evidence: "I'll call Bob",
+            summary: "Call Bob",
+            dueAtIso: "not-a-date",
+            confidence: 0.9,
+          },
+        ],
+      });
+      expect(parsed?.commitments).toHaveLength(1);
+      expect(parsed?.commitments[0]?.dueAtIso).toBeNull();
+    });
+
+    it("returns null for non-object output", () => {
+      expect(parseCommitmentExtractionOutput("nope")).toBeNull();
+      expect(parseCommitmentExtractionOutput({ items: [] })).toBeNull();
+    });
+  });
+
+  describe("filterExtractedCommitments (false-positive guard)", () => {
+    it("rejects hedged chit-chat even when the model is confident", () => {
+      const text = "Yeah maybe sometime I'll organize the garage.";
+      const guarded = filterExtractedCommitments(text, [
+        {
+          evidence: "Yeah maybe sometime I'll organize the garage.",
+          summary: "Organize the garage",
+          confidence: 0.99,
+        },
+      ]);
+      expect(guarded).toHaveLength(0);
+    });
+
+    it("rejects candidates whose evidence is not verbatim in the source", () => {
+      const guarded = filterExtractedCommitments("Thanks, talk soon!", [
+        {
+          evidence: "I'll send the numbers by Friday",
+          summary: "Send numbers",
+          confidence: 0.95,
+        },
+      ]);
+      expect(guarded).toHaveLength(0);
+    });
+
+    it("rejects candidates below the confidence floor", () => {
+      const text = "I'll send the numbers by Friday.";
+      const guarded = filterExtractedCommitments(text, [
+        {
+          evidence: "I'll send the numbers by Friday",
+          summary: "Send numbers",
+          confidence: 0.3,
+        },
+      ]);
+      expect(guarded).toHaveLength(0);
+    });
+
+    it("keeps a firm verbatim promise", () => {
+      const text = "Sounds good. I'll send the numbers by Friday. Bye!";
+      const guarded = filterExtractedCommitments(text, [
+        {
+          evidence: "I'll send the numbers by Friday",
+          summary: "Send numbers",
+          confidence: 0.85,
+        },
+      ]);
+      expect(guarded).toHaveLength(1);
+    });
+  });
+
+  describe("ledgerRecordsFromCandidates", () => {
+    it("builds chat-source rows with typed kind and evidence metadata", () => {
+      const records = ledgerRecordsFromCandidates({
+        agentId: "agent-commit-test",
+        sourceKey: "message:msg-commit-1",
+        observedAt: "2026-08-10T15:00:00.000Z",
+        candidates: [
+          {
+            evidence: "I'll file the quarterly tax return by 2026-09-15",
+            summary: "File the quarterly tax return",
+            counterparty: null,
+            dueAtIso: "2026-09-15T17:00:00.000Z",
+            confidence: 0.9,
+          },
+        ],
+      });
+      expect(records).toHaveLength(1);
+      expect(records[0]).toMatchObject({
+        source: "chat",
+        kind: "filing",
+        status: "open",
+        dueAt: "2026-09-15T17:00:00.000Z",
+      });
+      expect(records[0]?.metadata).toMatchObject({
+        extractedBy: "commitment_extraction",
+      });
+    });
+  });
+
+  describe("shouldRun", () => {
+    it("skips the agent's own messages", async () => {
+      const runtime = makeRuntime();
+      const message = makeMessage(
+        "I'll send it Friday",
+        String(runtime.agentId),
+      );
+      await expect(
+        commitmentExtractionEvaluator.shouldRun({
+          runtime,
+          message,
+          options: {},
+        }),
+      ).resolves.toBe(false);
+    });
+
+    it("skips hedged text without spending a model call", async () => {
+      await expect(
+        commitmentExtractionEvaluator.shouldRun({
+          runtime: makeRuntime(),
+          message: makeMessage("yeah maybe sometime we could do that"),
+          options: {},
+        }),
+      ).resolves.toBe(false);
+      expect(mocks.hasOwnerAccess).not.toHaveBeenCalled();
+    });
+
+    it("skips runtimes without a SQL ledger", async () => {
+      await expect(
+        commitmentExtractionEvaluator.shouldRun({
+          runtime: makeRuntime(false),
+          message: makeMessage("I'll send the deck Friday"),
+          options: {},
+        }),
+      ).resolves.toBe(false);
+    });
+
+    it("runs for an owner promise on a SQL-backed runtime", async () => {
+      await expect(
+        commitmentExtractionEvaluator.shouldRun({
+          runtime: makeRuntime(),
+          message: makeMessage("I'll send the deck Friday"),
+          options: {},
+        }),
+      ).resolves.toBe(true);
+    });
+  });
+
+  describe("persistExtractedCommitments processor", () => {
+    async function runProcessor(text: string, confidence: number) {
+      const processor = commitmentExtractionEvaluator.processors?.[0];
+      if (!processor) throw new Error("processor missing");
+      const runtime = makeRuntime();
+      const message = makeMessage(text);
+      return processor.process({
+        runtime,
+        message,
+        state: {} as never,
+        prepared: {},
+        options: {},
+        evaluatorName: "commitment_extraction",
+        output: {
+          commitments: [
+            {
+              evidence: text.replace(/[.!?]+$/, ""),
+              summary: "Do it",
+              confidence,
+            },
+          ],
+        },
+      });
+    }
+
+    it("persists a guarded firm promise", async () => {
+      const result = await runProcessor("I'll send the deck Friday", 0.9);
+      expect(result?.success).toBe(true);
+      expect(result?.values).toMatchObject({ commitmentRowsCreated: 1 });
+      expect(mocks.upsertCommitmentLedgerRecord).toHaveBeenCalledTimes(1);
+    });
+
+    it("writes nothing for hedged output that slipped past the model", async () => {
+      const result = await runProcessor(
+        "yeah maybe sometime I'll do that",
+        0.99,
+      );
+      expect(result?.success).toBe(true);
+      expect(result?.values).toMatchObject({ commitmentRowsCreated: 0 });
+      expect(mocks.upsertCommitmentLedgerRecord).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/plugins/plugin-personal-assistant/test/commitment-standing-guarantees.test.ts
+++ b/plugins/plugin-personal-assistant/test/commitment-standing-guarantees.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Class-level standing guarantees — unit tests (#14864). The ScheduledTask
+ * runner is mocked so the tests pin the structural contract: an installed
+ * guarantee is an event-triggered task keyed by obligation class; a newly
+ * observed matching artifact adds an idempotent lead-time warn watcher and
+ * fires the obligation event; non-matching artifacts change nothing.
+ */
+
+import type { IAgentRuntime, UUID } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  schedule: vi.fn(),
+  list: vi.fn(async (): Promise<unknown[]> => []),
+}));
+
+vi.mock("../src/lifeops/scheduled-task/service.js", () => ({
+  getScheduledTaskRunner: () => ({
+    schedule: mocks.schedule,
+    list: mocks.list,
+    apply: vi.fn(),
+    pipeline: vi.fn(),
+  }),
+}));
+
+import {
+  applyCommitmentClassGuarantees,
+  installCommitmentClassGuarantee,
+  normalizeObligationClass,
+} from "../src/lifeops/commitments/standing-guarantees.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function makeRuntime(emitEvent = vi.fn(async () => undefined)): {
+  runtime: IAgentRuntime;
+  emitEvent: ReturnType<typeof vi.fn>;
+} {
+  return {
+    runtime: {
+      agentId: "agent-guarantee-test" as UUID,
+      emitEvent,
+    } as unknown as IAgentRuntime,
+    emitEvent,
+  };
+}
+
+function guaranteeTask(warnDaysBefore?: number) {
+  return {
+    taskId: "guarantee-renewal",
+    kind: "watcher",
+    trigger: {
+      kind: "event",
+      eventKind: "document.obligation.observed",
+      filter: { obligationKind: "renewal" },
+    },
+    metadata: {
+      standingGuarantee: true,
+      obligationClass: "renewal",
+      ...(warnDaysBefore ? { warnDaysBefore } : {}),
+    },
+    state: { status: "scheduled", followupCount: 0 },
+  };
+}
+
+describe("commitment standing guarantees", () => {
+  beforeEach(() => {
+    mocks.schedule
+      .mockReset()
+      .mockImplementation(async (task: { trigger: unknown }) => ({
+        taskId: `task-${mocks.schedule.mock.calls.length}`,
+        ...task,
+        state: { status: "scheduled", followupCount: 0 },
+      }));
+    mocks.list.mockReset().mockResolvedValue([]);
+  });
+
+  describe("normalizeObligationClass", () => {
+    it("accepts the four typed classes case-insensitively", () => {
+      expect(normalizeObligationClass("Renewal")).toBe("renewal");
+      expect(normalizeObligationClass(" filing ")).toBe("filing");
+    });
+
+    it("rejects unknown classes and non-strings", () => {
+      expect(normalizeObligationClass("vibes")).toBeNull();
+      expect(normalizeObligationClass(42)).toBeNull();
+    });
+  });
+
+  describe("installCommitmentClassGuarantee", () => {
+    it("schedules an event-triggered task keyed per class", async () => {
+      const { runtime } = makeRuntime();
+      await installCommitmentClassGuarantee(runtime, {
+        agentId: "agent-guarantee-test",
+        obligationClass: "renewal",
+      });
+      expect(mocks.schedule).toHaveBeenCalledTimes(1);
+      expect(mocks.schedule.mock.calls[0]?.[0]).toMatchObject({
+        kind: "watcher",
+        trigger: {
+          kind: "event",
+          eventKind: "document.obligation.observed",
+          filter: { obligationKind: "renewal" },
+        },
+        idempotencyKey: "commitment-guarantee:renewal",
+        metadata: { standingGuarantee: true, warnDaysBefore: 60 },
+      });
+    });
+  });
+
+  describe("applyCommitmentClassGuarantees", () => {
+    const artifact = {
+      documentId: "doc-msa-1",
+      title: "Vendor MSA",
+      deadline: new Date(Date.now() + 120 * DAY_MS).toISOString(),
+      obligationKind: "renewal" as const,
+    };
+
+    it("does nothing when no guarantee covers the class", async () => {
+      const { runtime, emitEvent } = makeRuntime();
+      const result = await applyCommitmentClassGuarantees(runtime, {
+        agentId: "agent-guarantee-test",
+        artifact,
+      });
+      expect(result).toEqual({ matchedGuaranteeTaskIds: [], warnTaskIds: [] });
+      expect(mocks.schedule).not.toHaveBeenCalled();
+      expect(emitEvent).not.toHaveBeenCalled();
+    });
+
+    it("schedules the 60-day warn watcher and fires the obligation event", async () => {
+      mocks.list.mockResolvedValue([guaranteeTask()]);
+      const { runtime, emitEvent } = makeRuntime();
+      const result = await applyCommitmentClassGuarantees(runtime, {
+        agentId: "agent-guarantee-test",
+        artifact,
+      });
+      expect(result.matchedGuaranteeTaskIds).toEqual(["guarantee-renewal"]);
+      expect(result.warnTaskIds).toHaveLength(1);
+      const scheduled = mocks.schedule.mock.calls[0]?.[0] as {
+        trigger: { kind: string; atIso: string };
+        idempotencyKey: string;
+      };
+      expect(scheduled.trigger.kind).toBe("once");
+      expect(scheduled.trigger.atIso).toBe(
+        new Date(Date.parse(artifact.deadline) - 60 * DAY_MS).toISOString(),
+      );
+      expect(scheduled.idempotencyKey).toBe(
+        `commitment-warn:${artifact.documentId}:${artifact.deadline}:60`,
+      );
+      expect(emitEvent).toHaveBeenCalledWith(
+        "document.obligation.observed",
+        expect.objectContaining({
+          obligationKind: "renewal",
+          documentId: artifact.documentId,
+        }),
+      );
+    });
+
+    it("honors a custom warn lead time from the guarantee metadata", async () => {
+      mocks.list.mockResolvedValue([guaranteeTask(30)]);
+      const { runtime } = makeRuntime();
+      await applyCommitmentClassGuarantees(runtime, {
+        agentId: "agent-guarantee-test",
+        artifact,
+      });
+      const scheduled = mocks.schedule.mock.calls[0]?.[0] as {
+        trigger: { atIso: string };
+      };
+      expect(scheduled.trigger.atIso).toBe(
+        new Date(Date.parse(artifact.deadline) - 30 * DAY_MS).toISOString(),
+      );
+    });
+
+    it("skips the warn watcher when the lead time is already past but still fires the event", async () => {
+      mocks.list.mockResolvedValue([guaranteeTask()]);
+      const { runtime, emitEvent } = makeRuntime();
+      const result = await applyCommitmentClassGuarantees(runtime, {
+        agentId: "agent-guarantee-test",
+        artifact: {
+          ...artifact,
+          deadline: new Date(Date.now() + 10 * DAY_MS).toISOString(),
+        },
+      });
+      expect(result.warnTaskIds).toHaveLength(0);
+      expect(mocks.schedule).not.toHaveBeenCalled();
+      expect(emitEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores guarantees for a different obligation class", async () => {
+      mocks.list.mockResolvedValue([guaranteeTask()]);
+      const { runtime, emitEvent } = makeRuntime();
+      const result = await applyCommitmentClassGuarantees(runtime, {
+        agentId: "agent-guarantee-test",
+        artifact: { ...artifact, obligationKind: "warranty" },
+      });
+      expect(result.matchedGuaranteeTaskIds).toHaveLength(0);
+      expect(emitEvent).not.toHaveBeenCalled();
+    });
+
+    it("throws on an unparseable artifact deadline", async () => {
+      mocks.list.mockResolvedValue([guaranteeTask()]);
+      const { runtime } = makeRuntime();
+      await expect(
+        applyCommitmentClassGuarantees(runtime, {
+          agentId: "agent-guarantee-test",
+          artifact: { ...artifact, deadline: "whenever" },
+        }),
+      ).rejects.toThrow(/unparseable deadline/);
+    });
+  });
+});

--- a/plugins/plugin-personal-assistant/test/commitment-transcript-hook.test.ts
+++ b/plugins/plugin-personal-assistant/test/commitment-transcript-hook.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Finalized-transcript commitment projection — unit tests (#14864). The
+ * repository is mocked; the projection under test is the real production
+ * function. Pins the two guards: only the owner's diarized segments are
+ * read, and hedged speech never produces a ledger row.
+ */
+
+import type { IAgentRuntime, UUID } from "@elizaos/core";
+import type { MeetingTranscriptFinalizedPayload } from "@elizaos/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  upsertCommitmentLedgerRecord: vi.fn(async () => undefined),
+}));
+
+vi.mock("../src/lifeops/repository.js", () => ({
+  LifeOpsRepository: class {
+    upsertCommitmentLedgerRecord = mocks.upsertCommitmentLedgerRecord;
+  },
+}));
+
+import {
+  commitmentRecordsFromTranscript,
+  projectFinalizedTranscriptCommitments,
+} from "../src/lifeops/commitments/transcript-hook.js";
+
+const CREATED_AT = Date.parse("2026-08-10T15:00:00.000Z");
+
+function makePayload(withOwner = true): MeetingTranscriptFinalizedPayload {
+  return {
+    session: {
+      id: "meeting-1",
+      participants: [{ displayName: "Owner" }, { displayName: "Sam" }],
+    },
+    transcript: {
+      id: "transcript-1",
+      title: "Vendor sync",
+      createdAt: CREATED_AT,
+      segments: [
+        {
+          id: "seg-1",
+          speakerEntityId: "owner-entity-1",
+          startMs: 30_000,
+          endMs: 34_000,
+          text: "I'll send you the revised numbers by Friday.",
+        },
+        {
+          id: "seg-2",
+          speakerEntityId: "other-entity-9",
+          startMs: 40_000,
+          endMs: 44_000,
+          text: "I'll get you the contract tomorrow.",
+        },
+        {
+          id: "seg-3",
+          speakerEntityId: "owner-entity-1",
+          startMs: 50_000,
+          endMs: 54_000,
+          text: "Maybe we could revisit pricing sometime.",
+        },
+      ],
+    },
+    ...(withOwner
+      ? {
+          ghostAttendance: {
+            ownerUserId: "owner-entity-1",
+            ownerDisplayName: "Owner",
+            careAbouts: [],
+          },
+        }
+      : {}),
+  } as unknown as MeetingTranscriptFinalizedPayload;
+}
+
+describe("transcript commitment projection", () => {
+  beforeEach(() => {
+    mocks.upsertCommitmentLedgerRecord.mockClear();
+  });
+
+  it("projects only the owner's firm promises with meeting-anchored timestamps", () => {
+    const records = commitmentRecordsFromTranscript({
+      agentId: "agent-transcript-test",
+      ownerEntityId: "owner-entity-1",
+      payload: makePayload(),
+    });
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      source: "transcript",
+      sourceKey: "transcript-1:seg-1",
+      kind: "commitment",
+    });
+    expect(records[0]?.metadata).toMatchObject({
+      transcriptId: "transcript-1",
+      meetingId: "meeting-1",
+      observedAt: new Date(CREATED_AT + 30_000).toISOString(),
+    });
+  });
+
+  it("persists projected rows through the ledger repository", async () => {
+    const runtime = {
+      agentId: "agent-transcript-test" as UUID,
+      adapter: { db: {} },
+    } as unknown as IAgentRuntime;
+    const count = await projectFinalizedTranscriptCommitments(
+      runtime,
+      makePayload(),
+    );
+    expect(count).toBe(1);
+    expect(mocks.upsertCommitmentLedgerRecord).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns typed-empty when the payload carries no owner identity", async () => {
+    const runtime = {
+      agentId: "agent-transcript-test" as UUID,
+      adapter: { db: {} },
+    } as unknown as IAgentRuntime;
+    const count = await projectFinalizedTranscriptCommitments(
+      runtime,
+      makePayload(false),
+    );
+    expect(count).toBe(0);
+    expect(mocks.upsertCommitmentLedgerRecord).not.toHaveBeenCalled();
+  });
+
+  it("returns typed-empty on hosts without a SQL ledger", async () => {
+    const runtime = {
+      agentId: "agent-transcript-test" as UUID,
+    } as unknown as IAgentRuntime;
+    const count = await projectFinalizedTranscriptCommitments(
+      runtime,
+      makePayload(),
+    );
+    expect(count).toBe(0);
+  });
+});

--- a/plugins/plugin-personal-assistant/test/document-action.test.ts
+++ b/plugins/plugin-personal-assistant/test/document-action.test.ts
@@ -35,6 +35,7 @@ const mocks = vi.hoisted(() => ({
     resolvedBy: null,
     resolutionReason: null,
   })),
+  listTasks: vi.fn(async (): Promise<unknown[]> => []),
   schedule: vi.fn(async (task: { kind: string; trigger: unknown }) => ({
     taskId: `task-${Math.random().toString(36).slice(2, 8)}`,
     kind: task.kind,
@@ -73,7 +74,7 @@ vi.mock("../src/lifeops/scheduled-task/service.js", () => ({
   getScheduledTaskRunner: () => ({
     schedule: mocks.schedule,
     apply: mocks.apply,
-    list: vi.fn(),
+    list: mocks.listTasks,
     pipeline: vi.fn(),
     evaluateCompletion: vi.fn(),
     fire: vi.fn(),
@@ -135,6 +136,8 @@ describe("OWNER_DOCUMENTS umbrella action — Docs And Portals", () => {
     mocks.schedule.mockClear();
     mocks.upsertCommitmentLedgerRecord.mockClear();
     mocks.apply.mockClear();
+    mocks.listTasks.mockClear();
+    mocks.listTasks.mockImplementation(async () => []);
   });
 
   describe("metadata", () => {
@@ -491,6 +494,127 @@ describe("OWNER_DOCUMENTS umbrella action — Docs And Portals", () => {
       });
       expect(result.success).toBe(false);
       expect(result.data).toMatchObject({ error: "INVALID_RESOLUTION" });
+    });
+  });
+
+  describe("guarantee_class (#14864)", () => {
+    it("installs an event-triggered standing guarantee for a class", async () => {
+      const result = await callDoc(makeRuntime(), makeMessage(), {
+        subaction: "guarantee_class",
+        obligationClass: "renewal",
+      });
+      expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({
+        subaction: "guarantee_class",
+        obligationClass: "renewal",
+        warnDaysBefore: 60,
+      });
+      expect(mocks.schedule).toHaveBeenCalledTimes(1);
+      const scheduled = mocks.schedule.mock.calls[0]?.[0] as {
+        trigger: { kind: string; eventKind?: string; filter?: unknown };
+        idempotencyKey: string;
+        metadata: Record<string, unknown>;
+      };
+      expect(scheduled.trigger.kind).toBe("event");
+      expect(scheduled.trigger.eventKind).toBe("document.obligation.observed");
+      expect(scheduled.trigger.filter).toEqual({ obligationKind: "renewal" });
+      expect(scheduled.idempotencyKey).toBe("commitment-guarantee:renewal");
+      expect(scheduled.metadata).toMatchObject({
+        standingGuarantee: true,
+        warnDaysBefore: 60,
+      });
+    });
+
+    it("rejects an unknown obligation class", async () => {
+      const result = await callDoc(makeRuntime(), makeMessage(), {
+        subaction: "guarantee_class",
+        obligationClass: "vibes",
+      });
+      expect(result.success).toBe(false);
+      expect(result.data).toMatchObject({ error: "MISSING_OBLIGATIONCLASS" });
+      expect(mocks.schedule).not.toHaveBeenCalled();
+    });
+
+    it("track_deadline under a matching guarantee adds the lead-time warn watcher and fires the obligation event", async () => {
+      const emitEvent = vi.fn(async () => undefined);
+      const runtime = {
+        ...makeRuntime(),
+        emitEvent,
+      } as unknown as IAgentRuntime;
+      mocks.listTasks.mockImplementation(async () => [
+        {
+          taskId: "guarantee-1",
+          kind: "watcher",
+          trigger: {
+            kind: "event",
+            eventKind: "document.obligation.observed",
+            filter: { obligationKind: "renewal" },
+          },
+          metadata: { standingGuarantee: true, warnDaysBefore: 60 },
+          state: { status: "scheduled", followupCount: 0 },
+        },
+      ]);
+      const deadline = new Date(
+        Date.now() + 120 * 24 * 60 * 60 * 1000,
+      ).toISOString();
+
+      const created = await callDoc(runtime, makeMessage(), {
+        subaction: "request_approval",
+        documentTitle: "Vendor MSA renewal",
+      });
+      const docId = (created.data as { documentRequestId: string })
+        .documentRequestId;
+      const result = await callDoc(runtime, makeMessage(), {
+        subaction: "track_deadline",
+        documentRequestId: docId,
+        deadline,
+      });
+      expect(result.success).toBe(true);
+
+      const scheduledInputs = mocks.schedule.mock.calls.map(
+        (call) =>
+          call[0] as {
+            trigger: { kind: string; atIso?: string };
+            idempotencyKey?: string;
+          },
+      );
+      const warn = scheduledInputs.find((input) =>
+        input.idempotencyKey?.startsWith("commitment-warn:"),
+      );
+      expect(warn).toBeDefined();
+      expect(warn?.trigger.kind).toBe("once");
+      expect(warn?.trigger.atIso).toBe(
+        new Date(Date.parse(deadline) - 60 * 24 * 60 * 60 * 1000).toISOString(),
+      );
+      expect(emitEvent).toHaveBeenCalledWith(
+        "document.obligation.observed",
+        expect.objectContaining({ obligationKind: "renewal", deadline }),
+      );
+    });
+
+    it("track_deadline with no installed guarantee schedules only the deadline watcher", async () => {
+      const runtime = makeRuntime();
+      const deadline = new Date(
+        Date.now() + 30 * 24 * 60 * 60 * 1000,
+      ).toISOString();
+      const created = await callDoc(runtime, makeMessage(), {
+        subaction: "request_approval",
+        documentTitle: "Simple NDA",
+      });
+      const docId = (created.data as { documentRequestId: string })
+        .documentRequestId;
+      const result = await callDoc(runtime, makeMessage(), {
+        subaction: "track_deadline",
+        documentRequestId: docId,
+        deadline,
+      });
+      expect(result.success).toBe(true);
+      const warnCalls = mocks.schedule.mock.calls.filter((call) =>
+        (call[0] as { idempotencyKey?: string }).idempotencyKey?.startsWith(
+          "commitment-warn:",
+        ),
+      );
+      expect(warnCalls).toHaveLength(0);
     });
   });
 });

--- a/plugins/plugin-personal-assistant/test/prioritize-action.test.ts
+++ b/plugins/plugin-personal-assistant/test/prioritize-action.test.ts
@@ -291,6 +291,56 @@ describe("PRIORITIZE umbrella action — focus ranking", () => {
     });
   });
 
+  describe("rank_commitments (#14864)", () => {
+    it("ranks regret-audited ledger obligations through the model pass", async () => {
+      setPrioritizeLoaders({
+        loadCommitments: async () => [
+          {
+            id: "commit-1",
+            title: "Send Dana the revised numbers",
+            summary: "no scheduled tracker; due within the regret horizon",
+            dueAt: "2026-08-14T17:00:00.000Z",
+            metadata: { source: "commitment_ledger", regretScore: 1.19 },
+          },
+        ],
+      });
+      const useModel = vi.fn(async () =>
+        JSON.stringify({
+          ranked: [
+            { id: "commit-1", score: 0.9, reasoning: "orphaned promise" },
+          ],
+        }),
+      );
+      const result = await callPrioritize(
+        makeRuntime({ useModel }),
+        makeMessage(),
+        { subaction: "rank_commitments" },
+      );
+      expect(result.success).toBe(true);
+      const data = result.data as {
+        subaction: string;
+        ranked: { id: string; rank: number }[];
+      };
+      expect(data.subaction).toBe("rank_commitments");
+      expect(data.ranked[0]).toMatchObject({ id: "commit-1", rank: 1 });
+    });
+
+    it("maps the commitments subject alias onto rank_commitments", async () => {
+      setPrioritizeLoaders({ loadCommitments: async () => [] });
+      const useModel = vi.fn();
+      const result = await callPrioritize(
+        makeRuntime({ useModel: useModel as never }),
+        makeMessage(),
+        { subject: "commitments" },
+      );
+      expect(result.success).toBe(true);
+      const data = result.data as { subaction: string; ranked: unknown[] };
+      expect(data.subaction).toBe("rank_commitments");
+      expect(data.ranked).toHaveLength(0);
+      expect(useModel).not.toHaveBeenCalled();
+    });
+  });
+
   describe("rank_decisions", () => {
     it("loads pending approvals from the production queue by owner", async () => {
       const listApprovals = vi.fn(async () => [


### PR DESCRIPTION
## Summary

Completes the remaining #14864 scope on top of the four merged ledger slices (#15086, #15645, #15653, #15699). The triage gap was: `buildCommitmentRegretAudit()` and `trackDocumentObligationArtifact()` had no production callers, BRIEF/PRIORITIZE never consumed the ledger, and no class-level hook installed standing trackers.

### 1. Extraction evaluator (chat + transcripts)
- New `commitment_extraction` evaluator (`src/lifeops/commitments/extraction-evaluator.ts`), registered in the plugin's evaluators, runs in the merged post-turn model call for owner messages only.
- Deterministic false-positive guard: candidate evidence must appear verbatim in the source, carry a first-person commitment cue, not be hedged (`maybe`/`sometime`/…), and clear a confidence floor. A hedged remark can never become a ledger row regardless of model output; hedged text is prefiltered in `shouldRun` so it costs no model spend.
- Finalized meeting transcripts: `handleMeetingTranscriptFinalized` now projects the owner's own diarized segments through the deterministic extractor into the ledger (`src/lifeops/commitments/transcript-hook.ts`); other speakers' promises are ignored.

### 2. Class-level standing guarantees
- `OWNER_DOCUMENTS.guarantee_class` ("always track contract renewals…") installs one idempotent event-triggered ScheduledTask per obligation class (`commitment|renewal|filing|warranty`), keyed `commitment-guarantee:<class>` — no second scheduler, all matching on typed trigger/filter/metadata fields.
- `persistDocumentObligation` (the existing `track_deadline` path, `trackDocumentObligationArtifact`'s production seam) now calls `applyCommitmentClassGuarantees`: a covered artifact gains an idempotent lead-time warn watcher (default 60 days before deadline, `commitment-warn:<doc>:<deadline>:<days>`) and fires the typed `document.obligation.observed` event through the spine's event bridge. Event kind + filter schema registered in the event-kind registry.

### 3. BRIEF / PRIORITIZE consumption
- BRIEF: new `sections.commitments` block built from `buildCommitmentRegretAudit` over open/tracked rows (score + reasons carried through, `include.commitments` opt-out, designed-empty on no-DB hosts).
- PRIORITIZE: new `rank_commitments` subaction / `commitments` subject (similes `WHAT_WILL_I_REGRET`, `REGRET_AUDIT`) ranking the audit's deterministic scores and reasons through the existing single LLM pass.

Respects the open claim on the authenticated regret-audit read route (#19273 successor) — no HTTP surface is added here.

## Tests

Run in the worktree against `origin/develop` (vitest, plugin config):

- `test/commitment-extraction-evaluator.test.ts` — 14 pass (parse guards, verbatim/hedge/confidence rejection, "yeah maybe sometime" creates zero rows through the real processor, shouldRun prefilters).
- `test/commitment-standing-guarantees.test.ts` — 9 pass (install contract, warn-watcher timing + idempotency key, custom lead time, past-lead-time skip, class mismatch, unparseable-deadline throw).
- `test/commitment-transcript-hook.test.ts` — owner-attribution, hedge rejection, typed-empty paths.
- `test/document-action.test.ts` (+4 guarantee_class cases), `test/brief-action.test.ts` (+2 commitments-section cases), `test/prioritize-action.test.ts` (+2 rank_commitments cases) — 63 pass together.
- `bun run typecheck` (tsc `tsconfig.build.json`) clean.

Live-scenario evidence (seeded sent-mail promise surfacing in a live brief, scenario-time 60-day warn fire) remains tracked on the issue's evidence bar; this PR delivers the product path and deterministic contract proof.

Fixes #14864

🤖 Generated with [Claude Code](https://claude.com/claude-code)