### PR TITLE
fix(agent): load personal-assistant by default on full app boots

### DIFF
--- a/packages/agent/src/runtime/core-plugins.test.ts
+++ b/packages/agent/src/runtime/core-plugins.test.ts
@@ -1,8 +1,11 @@
 /**
  * Guards the default plugin partition in core-plugins.ts: plugin-google-workspace and
- * plugin-personal-assistant (heavy native/cloud deps) stay out of the default
- * core and deferred load sets and remain opt-in via OPTIONAL_CORE_PLUGINS. Pure
- * assertions over the exported name lists.
+ * plugin-personal-assistant (heavy native/cloud deps) stay out of the static
+ * core and deferred load sets that every image shape shares. Personal-assistant
+ * is default-loaded for full desktop/server boots by the collector gate in
+ * plugin-collector.ts (#17023), which excludes the slim shapes; keeping it out
+ * of CORE_PLUGINS is what protects those shapes (#8081). Pure assertions over
+ * the exported name lists.
  */
 import { describe, expect, it } from "vitest";
 
@@ -18,13 +21,15 @@ describe("CORE_PLUGINS", () => {
     expect(DEFERRED_CORE_PLUGINS).toContain("@elizaos/plugin-documents");
   });
 
-  it("does not load plugin-google-workspace or plugin-personal-assistant by default", () => {
+  it("keeps plugin-google-workspace and plugin-personal-assistant out of the static core sets", () => {
     // These two plugins pull in heavy native/cloud deps (googleapis and
     // @capacitor/core) that the slim Docker runtime image intentionally does
-    // not bundle. Loading them by default crashed the boot smoke / boot gate
-    // (#8081) with "Cannot find package 'googleapis' / @capacitor/core". They
-    // require explicit configuration (Google OAuth, LifeOps enablement), so
-    // they belong in OPTIONAL_CORE_PLUGINS, never the default core load set.
+    // not bundle. Loading them from the shared static sets crashed the boot
+    // smoke / boot gate (#8081) with "Cannot find package 'googleapis' /
+    // @capacitor/core". Personal-assistant is instead default-added for full
+    // desktop/server boots by the collector gate (#17023), which skips
+    // mobile, lean-chat, store, and provisioned-cloud shapes; the static
+    // CORE/DEFERRED sets stay clean so those shapes never resolve it.
     expect(CORE_PLUGINS).not.toContain("@elizaos/plugin-google-workspace");
     expect(CORE_PLUGINS).not.toContain("@elizaos/plugin-personal-assistant");
     expect(DEFERRED_CORE_PLUGINS).not.toContain(

--- a/packages/agent/src/runtime/core-plugins.ts
+++ b/packages/agent/src/runtime/core-plugins.ts
@@ -418,7 +418,7 @@ export const OPTIONAL_CORE_PLUGINS: readonly string[] = [
   // plugin-manager, secrets (SECRETS), trust: now built-in core capabilities
   // Enable via character settings: ENABLE_PLUGIN_MANAGER, ENABLE_SECRETS_MANAGER, ENABLE_TRUST
   "@elizaos/plugin-google-workspace", // Google Workspace connector (requires googleapis + explicit OAuth config); only loaded when LifeOps/Google is enabled
-  "@elizaos/plugin-personal-assistant", // LifeOps: personal ops - tasks, goals, calendar, inbox, website blocking (requires @capacitor/core + plugin-google-workspace); enable explicitly
+  "@elizaos/plugin-personal-assistant", // LifeOps: personal ops - tasks, goals, calendar, inbox, website blocking. Default-on for full desktop/server boots via the collector gate (#17023); stays out of CORE_PLUGINS so mobile/lean-chat/store/slim-cloud images (#8081) never load it; opt out via plugins.entries or ELIZA_DISABLE_PERSONAL_ASSISTANT
   "@elizaos/plugin-finances", // Owner finances dashboard (app_finances schema); auto-registered by plugin-personal-assistant, also enablable standalone
   "@elizaos/plugin-pdf", // PDF processing (published bundle broken in alpha.15)
   "@elizaos/plugin-obsidian", // Obsidian vault CLI integration

--- a/packages/agent/src/runtime/plugin-collector-personal-assistant.test.ts
+++ b/packages/agent/src/runtime/plugin-collector-personal-assistant.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Covers the default LifeOps owner-chat gate in collectPluginNames() (#17023):
+ * a clean full desktop/server boot loads @elizaos/plugin-personal-assistant so
+ * OWNER_ROUTINES registers for owner conversations, while explicit operator
+ * disablement, the env kill-switch, mobile, lean-chat, store builds, and slim
+ * cloud containers keep it out. Deterministic — env-driven over an in-memory
+ * ElizaConfig, no live model or runtime boot.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ElizaConfig } from "../config/config.ts";
+import { collectPluginNames } from "./plugin-collector.ts";
+
+const PA = "@elizaos/plugin-personal-assistant";
+
+const ENV_KEYS = [
+  "ELIZA_PLATFORM",
+  "ELIZA_PLUGIN_SET",
+  "ELIZA_BUILD_VARIANT",
+  "ELIZA_CLOUD_PROVISIONED",
+  "ELIZA_DISABLE_PERSONAL_ASSISTANT",
+] as const;
+
+let savedEnv: Record<string, string | undefined>;
+
+beforeEach(() => {
+  savedEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    const v = savedEnv[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+const emptyConfig: ElizaConfig = {} as ElizaConfig;
+
+describe("collectPluginNames personal-assistant default gate (#17023)", () => {
+  it("loads personal-assistant on a clean default full boot", () => {
+    const reasons = new Map<string, string>();
+    const names = collectPluginNames(emptyConfig, reasons);
+
+    expect(names.has(PA)).toBe(true);
+    // The scheduling primitive the routine runner depends on stays core.
+    expect(names.has("@elizaos/plugin-scheduling")).toBe(true);
+    expect(reasons.get(PA)).toContain("#17023");
+  });
+
+  it("honors explicit operator disablement via plugins.entries", () => {
+    const names = collectPluginNames({
+      plugins: { entries: { "personal-assistant": { enabled: false } } },
+    } as ElizaConfig);
+
+    expect(names.has(PA)).toBe(false);
+  });
+
+  it("keeps a persisted legacy explicit enable working", () => {
+    const names = collectPluginNames({
+      plugins: { entries: { "personal-assistant": { enabled: true } } },
+    } as ElizaConfig);
+
+    expect(names.has(PA)).toBe(true);
+  });
+
+  it("honors the ELIZA_DISABLE_PERSONAL_ASSISTANT env kill-switch", () => {
+    process.env.ELIZA_DISABLE_PERSONAL_ASSISTANT = "1";
+    expect(collectPluginNames(emptyConfig).has(PA)).toBe(false);
+  });
+
+  it("stays out of the lean-chat set", () => {
+    process.env.ELIZA_PLUGIN_SET = "lean-chat";
+    expect(collectPluginNames(emptyConfig).has(PA)).toBe(false);
+  });
+
+  it("stays out of mobile boots (no PA loader in the app sandbox)", () => {
+    process.env.ELIZA_PLATFORM = "android";
+    expect(collectPluginNames(emptyConfig).has(PA)).toBe(false);
+  });
+
+  it("stays out of store builds", () => {
+    process.env.ELIZA_BUILD_VARIANT = "store";
+    expect(collectPluginNames(emptyConfig).has(PA)).toBe(false);
+  });
+
+  it("stays out of slim provisioned cloud containers (#8081 image constraint)", () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    expect(collectPluginNames(emptyConfig).has(PA)).toBe(false);
+  });
+});

--- a/packages/agent/src/runtime/plugin-collector-telegram-standalone.test.ts
+++ b/packages/agent/src/runtime/plugin-collector-telegram-standalone.test.ts
@@ -29,12 +29,39 @@ afterEach(() => {
 });
 
 describe("collectPluginNames standalone Telegram policy", () => {
-  it("loads Telegram for a plain agent that opts into the standalone poller", () => {
+  it("keeps standalone Telegram dormant on a default full boot (PA default-on, #17023)", () => {
+    // personal-assistant is default-loaded on full boots and declares
+    // passiveConnectorsByDefault, so the pre-runtime prediction now matches
+    // the runtime gate: passive unless explicitly overridden.
     process.env.ELIZA_TELEGRAM_STANDALONE_BOT = "true";
 
-    expect(collectPluginNames({} as ElizaConfig)).toContain(
-      "@elizaos/plugin-telegram",
-    );
+    const names = collectPluginNames({} as ElizaConfig);
+    expect(names).toContain("@elizaos/plugin-personal-assistant");
+    expect(names).not.toContain("@elizaos/plugin-telegram");
+  });
+
+  it("loads Telegram for a plain agent that opts into the standalone poller with PA disabled", () => {
+    process.env.ELIZA_TELEGRAM_STANDALONE_BOT = "true";
+    const config = {
+      plugins: {
+        entries: {
+          "personal-assistant": { enabled: false },
+        },
+      },
+    } as ElizaConfig;
+
+    const names = collectPluginNames(config);
+    expect(names).not.toContain("@elizaos/plugin-personal-assistant");
+    expect(names).toContain("@elizaos/plugin-telegram");
+  });
+
+  it("loads Telegram for a default full boot that explicitly opts out of passive mode", () => {
+    process.env.ELIZA_TELEGRAM_STANDALONE_BOT = "true";
+    process.env.ELIZA_LIFEOPS_PASSIVE_CONNECTORS = "false";
+
+    const names = collectPluginNames({} as ElizaConfig);
+    expect(names).toContain("@elizaos/plugin-personal-assistant");
+    expect(names).toContain("@elizaos/plugin-telegram");
   });
 
   it("keeps standalone Telegram dormant when LifeOps is configured", () => {

--- a/packages/agent/src/runtime/plugin-collector.ts
+++ b/packages/agent/src/runtime/plugin-collector.ts
@@ -152,6 +152,17 @@ function gitpathologistRequested(config: ElizaConfig): boolean {
 }
 
 /**
+ * Env kill-switch for the default LifeOps owner-chat capability (#17023).
+ * Config-level opt-out (`plugins.entries["personal-assistant"].enabled=false`)
+ * is honored separately by the explicit-disable sweep in collectPluginNames.
+ */
+function personalAssistantDisabledByEnv(): boolean {
+  const raw =
+    process.env.ELIZA_DISABLE_PERSONAL_ASSISTANT?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes";
+}
+
+/**
  * The opt-in standalone Telegram polling bot (the standalone mode of
  * `@elizaos/plugin-telegram`) runs when `ELIZA_TELEGRAM_STANDALONE_BOT` is
  * truthy and the resolved plugin set is not in LifeOps passive mode. The same
@@ -622,6 +633,35 @@ export function collectPluginNames(
     track(
       "@elizaos/plugin-gitpathologist",
       "gitpathologist (auto-on when .git/ present; gate ELIZA_GITPATHOLOGIST)",
+    );
+  }
+  // Default LifeOps owner-chat capability (#17023). The default app advertises
+  // tasks/habits/routines, and every routine-creating chat action
+  // (OWNER_ROUTINES and the other owner umbrellas) registers only from
+  // plugin-personal-assistant — always-loaded plugin-scheduling hosts the
+  // single runner and the /api/lifeops REST surface but zero actions. Full
+  // desktop/server boots therefore load personal-assistant by default so an
+  // OWNER conversation can actually create the routines the surface claims.
+  // Excluded shapes keep their existing constraints: mobile has no PA loader
+  // in the app sandbox, lean-chat stays lean (#8434), and store builds plus
+  // slim provisioned cloud containers do not bundle PA's googleapis/
+  // @capacitor/core dependency closure (#8081). Explicit operator opt-out via
+  // plugins.entries["personal-assistant"].enabled=false is honored by the
+  // explicit-disable sweep below; ELIZA_DISABLE_PERSONAL_ASSISTANT is the env
+  // kill-switch. Registration stays in the deferred wave, whose
+  // runtime.reportError boundary makes a resolution/registration failure
+  // visible instead of a silent capability hole.
+  if (
+    !onMobile &&
+    !leanChat &&
+    !storeBuild &&
+    !isCloudContainer &&
+    !personalAssistantDisabledByEnv()
+  ) {
+    pluginsToLoad.add("@elizaos/plugin-personal-assistant");
+    track(
+      "@elizaos/plugin-personal-assistant",
+      "default LifeOps owner-chat capability (#17023; opt out via plugins.entries or ELIZA_DISABLE_PERSONAL_ASSISTANT)",
     );
   }
   // Allow list is additive — extra plugins on top of auto-detection,


### PR DESCRIPTION
## What

Fixes #17023 — the default app advertises tasks/habits/routines but booted without any action that can create an owner routine: `OWNER_ROUTINES` (and all owner umbrellas) register only from `@elizaos/plugin-personal-assistant`, which sat in `OPTIONAL_CORE_PLUGINS` behind a strict `plugins.entries[\"personal-assistant\"].enabled === true` opt-in that no first-run path ever set. Always-loaded `plugin-scheduling` hosts the runner and `/api/lifeops` routes but zero actions, so the surface looked alive while the agent claimed saves that never happened.

**Change** (`packages/agent/src/runtime/plugin-collector.ts`): a default gate adds `plugin-personal-assistant` on full desktop/server boots. Excluded shapes keep their constraints: mobile (no PA loader in the app sandbox), lean-chat (#8434), store builds, and slim provisioned cloud containers (#8081 googleapis/@capacitor closure). No second scheduler, no Health-connector requirement.

- **Explicit disablement stays supported**: `plugins.entries[\"personal-assistant\"].enabled=false` is honored by the existing explicit-disable sweep, and `/api/plugins` then reports the entry disabled/inactive from config rather than a fake-loaded state; `ELIZA_DISABLE_PERSONAL_ASSISTANT` is the env kill-switch.
- **Failures are visible**: registration stays in the deferred wave, whose existing `runtime.reportError('eliza.deferredPluginRegistration', ...)` boundary (error-policy #14415) plus typed resolver `FailedPluginDetail` surface startup/migration failures instead of a silent capability hole.
- **Deliberate consequence**: PA declares `passiveConnectorsByDefault`, so the pre-runtime standalone-Telegram prediction now matches the runtime gate on default boots (dormant unless `ELIZA_LIFEOPS_PASSIVE_CONNECTORS=false` or PA disabled). The test encodes all three states.
- `core-plugins.ts` / `core-plugins.test.ts`: the #8081 guard is deliberately rewritten to the new contract — PA stays out of the static CORE/DEFERRED sets (protecting slim images); the collector gate is the default-on path.

## Tests (worktree at develop@afa169e81cb)

- New `plugin-collector-personal-assistant.test.ts`: clean default boot loads PA + reason provenance; explicit `entries` disablement; persisted legacy explicit enable; env kill-switch; lean-chat/mobile/store/cloud-container exclusions — **8 files / 78 tests passed** together with the core-plugins guard and the collector lean-chat/mode-policy/AOSP/channel-map/short-id/telegram-standalone suites.
- Full `src/runtime/` vitest shard: 5 failures in 3 files (`build-character-config*`, `view-capability-audit`) — **verified pre-existing**: identical failures with the change stashed on the same head.
- `bun run --cwd packages/agent typecheck`: 7 pre-existing unresolved-dist/env errors, **byte-identical with and without this change** (diff of error lists is empty); none in touched files.
- Biome check on touched files: clean.

## Residual risk

- Fresh installs now seed PA's default scheduled-task packs and its ~10 sub-plugin registrations in the deferred wave; boot cost lands after `ready:true` and PA stays out of `BLOCKING_CORE_PLUGINS`.
- Connector-passive default on full boots is the documented behavior change above; operators who want active-reply Telegram/Discord with PA loaded set `ELIZA_LIFEOPS_PASSIVE_CONNECTORS=false`.
- The issue's typed chat-level 'capability unavailable' reply and a PA capability descriptor on both /api/plugins tiers remain tracked by siblings #17027/#17028 per the coordination notes on #17022.

🤖 Generated with [Claude Code](https://claude.com/claude-code)