### PR TITLE
fix(desktop): remove duplicate home pill shadow

### DIFF
--- a/packages/app-core/platforms/electrobun/native/macos/window-effects.mm
+++ b/packages/app-core/platforms/electrobun/native/macos/window-effects.mm
@@ -2305,7 +2305,7 @@ extern "C" bool enableWindowVibrancy(void *windowPtr) {
 	return success;
 }
 
-extern "C" bool ensureWindowShadow(void *windowPtr) {
+extern "C" bool setWindowShadowEnabled(void *windowPtr, bool enabled) {
 	if (windowPtr == nullptr) {
 		return false;
 	}
@@ -2317,7 +2317,7 @@ extern "C" bool ensureWindowShadow(void *windowPtr) {
 			return;
 		}
 
-		[window setHasShadow:YES];
+		[window setHasShadow:enabled ? YES : NO];
 		[window invalidateShadow];
 		success = YES;
 	});

--- a/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts
@@ -76,6 +76,7 @@ export interface DesktopShellWindowPresentation {
   mode: DesktopShellWindowMode;
   titleBarStyle: DesktopShellTitleBarStyle;
   transparent: boolean;
+  nativeShadow: boolean;
 }
 
 /**
@@ -86,6 +87,9 @@ export interface DesktopShellWindowPresentation {
  * over dark web content reads as a full-window frosted sheet (the pill is the
  * only surface that should show the desktop through it). Win/Linux transparency
  * support varies, so the pill also stays opaque there for now (fork gap G4).
+ * The transparent macOS pill disables the native window shadow because its
+ * visible handle already paints a neutral separator; stacking both creates a
+ * heavy halo on light desktops.
  */
 export function resolveDesktopShellWindowPresentation(
   env: Record<string, string | undefined> = process.env,
@@ -103,6 +107,7 @@ export function resolveDesktopShellWindowPresentation(
           ? "hiddenInset"
           : "default",
     transparent: bottomBar && platform === "darwin",
+    nativeShadow: !kiosk && !bottomBar,
   };
 }
 

--- a/packages/app-core/platforms/electrobun/src/desktop-experience-contract.test.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-experience-contract.test.ts
@@ -51,6 +51,7 @@ describe("desktop experience contract — chat-first launch", () => {
     expect(presentation.mode).toBe("bottom-bar");
     expect(presentation.titleBarStyle).toBe("hidden");
     expect(presentation.transparent).toBe(true);
+    expect(presentation.nativeShadow).toBe(false);
   });
 
   it("keeps the full dashboard window opaque on macOS — transparency is the pill only (#12184)", () => {
@@ -63,6 +64,7 @@ describe("desktop experience contract — chat-first launch", () => {
     );
     expect(presentation.mode).toBe("default");
     expect(presentation.transparent).toBe(false);
+    expect(presentation.nativeShadow).toBe(true);
   });
 
   it("resolves kiosk presentation when requested", () => {

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -95,9 +95,9 @@ import { getDesktopManager } from "./native/desktop";
 import { disposeNativeModules, initializeNativeModules } from "./native/index";
 import {
   disableBackForwardNavigationGestures,
-  ensureShadow,
   setNativeDragRegion,
   setTrafficLightsPosition,
+  setWindowShadow,
 } from "./native/mac-window-effects";
 import { getPermissionManager } from "./native/permissions";
 import { checkWebGpuSupport } from "./native/webgpu-browser-support";
@@ -448,7 +448,10 @@ const MAC_NATIVE_DRAG_REGION_HEIGHT = 38;
  * the desktop. Only the chromeless pill and the tray popover are transparent,
  * and each paints its own surface — the dashboard is a normal opaque window.
  */
-function applyMacOSWindowEffects(win: BrowserWindow): void {
+function applyMacOSWindowEffects(
+  win: BrowserWindow,
+  nativeShadow: boolean,
+): void {
   if (process.platform !== "darwin") return;
 
   const ptr = (win as { ptr?: unknown }).ptr;
@@ -457,10 +460,13 @@ function applyMacOSWindowEffects(win: BrowserWindow): void {
     return;
   }
 
-  const shadowEnabled = ensureShadow(ptr as Parameters<typeof ensureShadow>[0]);
+  const shadowConfigured = setWindowShadow(
+    ptr as Parameters<typeof setWindowShadow>[0],
+    nativeShadow,
+  );
   updateCurrentMainWindowEffectsState({
     vibrancyEnabled: false,
-    shadowEnabled,
+    shadowEnabled: shadowConfigured ? nativeShadow : null,
   });
 
   const alignButtons = () =>
@@ -1224,8 +1230,9 @@ async function createMainWindow(rpc: ElizaDesktopRpc): Promise<BrowserWindow> {
     return win;
   }
 
-  // Bottom-bar shell: pin always-on-top and apply the macOS chrome (shadow,
-  // drag region — no vibrancy, so the pill is the only painted surface). The bar
+  // Bottom-bar shell: pin always-on-top and apply the macOS chrome (with its
+  // native shadow disabled, plus the drag region; no vibrancy, so the pill is
+  // the only painted surface). The bar
   // has fixed, display-derived geometry, so skip bounds persistence + the
   // first-launch maximize entirely.
   if (bottomBar) {
@@ -1254,14 +1261,14 @@ async function createMainWindow(rpc: ElizaDesktopRpc): Promise<BrowserWindow> {
         );
       }
     }
-    applyMacOSWindowEffects(win);
+    applyMacOSWindowEffects(win, presentation.nativeShadow);
     // Keep the bar pinned to the primary display's bottom edge across display
     // plug/unplug + resolution changes (recompute on showWindow() + 5s poll).
     getDesktopManager().enableBottomBarReanchor();
     return win;
   }
 
-  applyMacOSWindowEffects(win);
+  applyMacOSWindowEffects(win, presentation.nativeShadow);
   win.on("resize", () => scheduleStateSave(statePath, win));
   win.on("move", () => scheduleStateSave(statePath, win));
 

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -16,7 +16,7 @@ vi.mock("@elizaos/core", async (importOriginal) => {
 vi.mock("./mac-window-effects", () => ({
   createSecurityScopedBookmark: vi.fn(() => null),
   enableVibrancy: vi.fn(() => false),
-  ensureShadow: vi.fn(() => false),
+  setWindowShadow: vi.fn(() => false),
   isAppActive: vi.fn(() => false),
   isKeyWindow: vi.fn(() => false),
   makeKeyAndOrderFront: vi.fn(),

--- a/packages/app-core/platforms/electrobun/src/native/mac-window-effects.ts
+++ b/packages/app-core/platforms/electrobun/src/native/mac-window-effects.ts
@@ -16,7 +16,7 @@ import { resolveNativeLibraryCandidate } from "../../../../src/platform/native-l
  */
 type MacEffectsSymbols = {
   enableWindowVibrancy(ptr: Pointer): boolean;
-  ensureWindowShadow(ptr: Pointer): boolean;
+  setWindowShadowEnabled(ptr: Pointer, enabled: boolean): boolean;
   setWindowTrafficLightsPosition(ptr: Pointer, x: number, y: number): boolean;
   setNativeWindowDragRegion(ptr: Pointer, x: number, height: number): boolean;
   disableWindowBackForwardNavigationGestures(ptr: Pointer): boolean;
@@ -70,7 +70,10 @@ function loadLib(): MacEffectsLib {
     // FFIType descriptors at the TypeScript level.
     return dlopen(dylibPath, {
       enableWindowVibrancy: { args: [FFIType.ptr], returns: FFIType.bool },
-      ensureWindowShadow: { args: [FFIType.ptr], returns: FFIType.bool },
+      setWindowShadowEnabled: {
+        args: [FFIType.ptr, FFIType.bool],
+        returns: FFIType.bool,
+      },
       setWindowTrafficLightsPosition: {
         args: [FFIType.ptr, FFIType.f64, FFIType.f64],
         returns: FFIType.bool,
@@ -152,8 +155,8 @@ export function enableVibrancy(ptr: Pointer): boolean {
   return getLib()?.symbols.enableWindowVibrancy(ptr) ?? false;
 }
 
-export function ensureShadow(ptr: Pointer): boolean {
-  return getLib()?.symbols.ensureWindowShadow(ptr) ?? false;
+export function setWindowShadow(ptr: Pointer, enabled: boolean): boolean {
+  return getLib()?.symbols.setWindowShadowEnabled(ptr, enabled) ?? false;
 }
 
 export function setTrafficLightsPosition(

--- a/packages/ui/src/components/shell/HomePill.tsx
+++ b/packages/ui/src/components/shell/HomePill.tsx
@@ -57,8 +57,8 @@ export function HomePill({
         aria-hidden="true"
         data-testid="shell-home-pill-mark"
         className={cn(
-          "block h-2.5 w-12 rounded-full border border-white/90 bg-white/95",
-          "shadow-[0_1px_7px_rgba(0,0,0,0.32),inset_0_1px_0_rgba(255,255,255,0.95)]",
+          "block h-2.5 w-12 rounded-full bg-white/95",
+          "shadow-[0_0_0_1px_rgba(0,0,0,0.12)]",
           "transition-[width,opacity,transform] duration-200 group-hover:w-14",
           phase === "booting" && "animate-pulse opacity-65",
           phase === "listening" && "animate-pulse",

--- a/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
@@ -20,6 +20,8 @@ describe("HomePill", () => {
     const mark = screen.getByTestId("shell-home-pill-mark");
     expect(mark.className).toContain("bg-white/95");
     expect(mark.className).toContain("w-12");
+    expect(mark.className).toContain("shadow-[0_0_0_1px_rgba(0,0,0,0.12)]");
+    expect(mark.className).not.toContain("0_1px_7px");
     expect(btn.textContent).toBe("");
     expect(btn.style.backgroundColor).toBe("");
     expect(btn.className).toContain("h-8");


### PR DESCRIPTION
# Relates to

Fixes the duplicate outline around the macOS desktop home pill.

- [x] Targets `develop` and is rebased onto current `origin/develop`.
- [x] `bun install` completed after sync.
- [x] Focused UI/native tests, typechecks, lint, desktop build, signature verification, and app visual audit completed.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [ ] Full `bun run verify` is blocked by the existing repository-wide orphaned plugin test audit. Focused checks pass.

# Risks

Low. The change only disables the native NSWindow shadow for the transparent bottom-bar window and replaces the pill blur with a 1px separator. Normal desktop windows retain their native shadow.

# Background

## What does this PR do?

- Disables the native macOS window shadow for the transparent bottom-bar shell.
- Replaces the visible pill's blurred CSS shadow with a crisp 1px neutral edge.
- Adds UI and desktop presentation contract coverage.

## What kind of change is this?

Bug fix.

# Documentation changes needed?

No documentation change is required.

# Testing

- HomePill tests: 11 passed.
- Desktop experience contract tests: 11 passed.
- UI and Electrobun typechecks passed before the final rebase.
- UI and Electrobun lint passed.
- macOS native effects dylib built successfully.
- Desktop app built, installed, and passed strict code-signature verification.
- App audit captured 219/219 views with 0 broken and 0 needs-work verdicts.

# Evidence Gate

<!-- evidence-head:80d199bec4c698ae4658e5eec1a9e8c4ff4bc6f4 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshot is available from the reported issue context; not uploaded to GitHub in this PR.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshot was reviewed locally; not uploaded to GitHub in this PR.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - static resting-state visual correction with no interaction flow change.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend path changed.
<!-- evidence-row:frontend-logs -->
- [x] Browser fixture completed with no page or console errors.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, model, prompt, provider, or action behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Signed macOS application bundle built and installed successfully.
<!-- evidence-row:ocr-review -->
- [x] App audit OCR reviewed 216 views with 0 broken verdicts.

## Known gaps / failures

`bun run verify` stops at `ensure-plugin-test-conventions:check` because existing vendored tests under plugin-agent-orchestrator and plugin-local-inference are reported as orphaned. The changed UI/native packages pass their focused checks.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [codex-desktop]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no contribution skill used"} -->
