### PR TITLE
fix(agent): preserve valid conversation backfill rows

### DIFF
--- a/packages/agent/src/actions/recent-conversation-texts.test.ts
+++ b/packages/agent/src/actions/recent-conversation-texts.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Covers malformed room-memory rows during recent conversation backfill.
+ * The test uses the exported helper with a minimal runtime double.
+ */
+import { describe, expect, it } from "vitest";
+import { recentConversationTexts } from "./recent-conversation-texts.ts";
+
+describe("recentConversationTexts", () => {
+  it("keeps valid memories when one row has no content", async () => {
+    const result = await recentConversationTexts({
+      runtime: {
+        getMemories: async () => [
+          { content: undefined },
+          { content: { text: "older valid message" } },
+        ],
+      } as never,
+      message: { roomId: "room-1" } as never,
+      state: { values: { recentMessages: "current state message" } } as never,
+      limit: 3,
+    });
+
+    expect(result).toEqual(["older valid message", "current state message"]);
+  });
+});

--- a/packages/agent/src/actions/recent-conversation-texts.ts
+++ b/packages/agent/src/actions/recent-conversation-texts.ts
@@ -97,7 +97,7 @@ export async function recentConversationTexts(args: {
     const memoryTexts = Array.isArray(memories)
       ? memories
           .map((memory) =>
-            typeof memory.content.text === "string"
+            memory.content && typeof memory.content.text === "string"
               ? normalizeConversationLine(memory.content.text)
               : "",
           )


### PR DESCRIPTION
# Relates to

Closes #20454.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] this PR targets `develop` and is branched directly off the current `origin/develop` tip.
- [x] focused package tests and lint pass on the exact head, see Testing below.
- [x] a reviewer can confirm the fix directly against the deterministic unit test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (fix, tests, via AgentRouter proxy), `anthropic/claude-sonnet-5` (independent re-verification)
<!-- attribution-row:client -->
- Agent tooling: `codex` (via AgentRouter proxy), `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] branched directly off the current `origin/develop` tip

# Risks

low. this only adds a defined-check before reading `.text`; every existing row with a defined `content` behaves identically, matching the defensive pattern already used elsewhere in this package.

# Background

## What does this PR do?

`recentConversationTexts` mapped every room-memory row with `memory.content.text` and no check that `memory.content` itself is defined. The `Memory` interface's TS type declares `content: Content` as required, but other production helpers in the same package (`memories.ts`, `knowledge.ts`) already treat `content` as possibly-undefined at runtime — a legitimate defensive precedent for legacy/malformed persisted rows that don't actually satisfy the strict compile-time type.

If a single row had no `content`, the `.map()` callback threw. The whole call sits inside `try { ... } catch { return stateTexts; }`, so the error was swallowed and the function returned *only* state-derived text — silently discarding every other otherwise-valid room-memory row in the same batch, not just the bad one.

traced reachability before writing this up: `packages/agent/src/actions/grounded-action-reply.ts` calls `recentConversationTexts` from `renderGroundedActionReply` with the live runtime — the returned lines feed the small-model prompt used to render user-facing grounded action replies. `packages/agent/src/actions/context-signal.ts` calls the same helper (aliased `collectRecentConversationTexts`) from `hasContextSignal` — the returned room history controls whether keyword-gated actions become available. One content-less persisted row could erase all valid DB backfill for both.

fix: guard `memory.content` before reading its `.text` field. Invalid rows are now filtered individually, while valid rows in the same batch remain available.

## What kind of change is this?

bug fix, non-breaking (every existing row with defined `content` behaves identically).

# Documentation changes needed?

no, the fix matches the defensive-content-handling convention already established elsewhere in this package.

# Testing

## Where should a reviewer start?

`packages/agent/src/actions/recent-conversation-texts.test.ts` (new file), the `keeps valid memories when one row has no content` case, then the `memory.content &&` guard in `recent-conversation-texts.ts`.

## Detailed testing steps

```text
$ ../../node_modules/.bin/vitest run src/actions/recent-conversation-texts.test.ts
Test Files  1 passed (1)
     Tests  1 passed (1)

$ ../../node_modules/.bin/biome check src/actions/recent-conversation-texts.ts src/actions/recent-conversation-texts.test.ts
Checked 2 files in 32ms. No fixes applied.
```

mutation-resistance verified independently: reverted just the source fix, kept the new test, reran — 1/1 failed, expected `["older valid message", "current state message"]` but received only `["current state message"]` — reproducing the exact "one bad row erases the whole batch" symptom. restored the fix, 1/1 green again.

# Evidence Gate

<!-- evidence-head:998eab3388e01cd812f30c44d4d2d73550f39892 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes an internal memory-mapping helper, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - this changes an internal memory-mapping helper, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive product flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic unit test, the real transcript is included under domain artifacts.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code or network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed; this fixes which conversation history reaches the prompt, not model behavior itself.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real mutation-resistance run, captured directly:
  ```text
  red (source fix reverted, test kept):
  $ ../../node_modules/.bin/vitest run src/actions/recent-conversation-texts.test.ts
  - Expected: [ "older valid message", "current state message" ]
  + Received: [ "current state message" ]
  Tests  1 failed (1)

  green (fix restored):
  $ ../../node_modules/.bin/vitest run src/actions/recent-conversation-texts.test.ts
  Tests  1 passed (1)
  ```
  also independently confirmed real defensive precedent elsewhere in the package (`memories.ts` casts `memory.content as Record<string, unknown> | undefined`, `knowledge.ts` uses `memory.content?.text`) before accepting the report's claim about the codebase's own established convention, and independently traced both real callers (`grounded-action-reply.ts`, `context-signal.ts`) before writing up the reachability claim.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface or visual text changed.

## Known gaps / failures

none in the touched surface. the package's `typecheck` script surfaces pre-existing, unrelated errors (missing workspace-package type declarations for `@elizaos/plugin-capacitor-bridge`, `@elizaos/plugin-wallet`, and others, plus one pre-existing `findLast` typing error in `plugin-agent-orchestrator`, from a fresh checkout where workspace packages haven't been built yet) — none reference either changed file. The full package test lane hits a pre-existing, unrelated workspace-resolution failure (`@elizaos/plugin-meetings`) before reaching all 421 isolated batches; the focused touched-file suite is green both standalone and independently reran.

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the focused suite and lint myself, confirmed real defensive precedent for optional `content` handling elsewhere in the package, retraced both real caller paths, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Contribution skill revision: N/A - direct interactive session, contribute-to-eliza skill not used
Compute receipt: N/A - Slop run-receipt install currently blocked by an unrelated site-deploy-lag issue (deployed skill archive predates recent develop changes)
Attribution status: self-reported
