### PR TITLE
fix(elizacloud): surface server-attached provider details on terminal media failures

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/cloud-media-generation.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-media-generation.test.ts
@@ -230,3 +230,43 @@ describe("media generation cold-cache warming retry", () => {
     expect(postApiV1GenerateMusic).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("terminal cloud failure diagnosability (2026-08-16 opaque video outage)", () => {
+  it("surfaces the server-attached provider details in the thrown message", async () => {
+    const apiError = Object.assign(new Error("Video provider request failed"), {
+      errorBody: {
+        success: false,
+        error: "Video provider request failed",
+        code: "internal_error",
+        details: {
+          provider: "fal",
+          model: "veo-3",
+          upstreamStatus: 403,
+          upstreamCode: "auth_error",
+          upstreamMessage: "API key not authorized for this model",
+        },
+      },
+    });
+    const postApiV1GenerateVideo = vi.fn().mockRejectedValue(apiError);
+    setCloudMediaClientFactoryForTesting(() => ({
+      routes: { postApiV1GenerateVideo, postApiV1GenerateMusic: vi.fn() },
+    }));
+
+    await expect(handleVideoGeneration(runtime(), { prompt: "x" })).rejects.toThrow(
+      "Video provider request failed (provider=fal model=veo-3 upstream=403/auth_error API key not authorized for this model)"
+    );
+  });
+
+  it("passes a detail-less error through unchanged", async () => {
+    const postApiV1GenerateVideo = vi
+      .fn()
+      .mockRejectedValue(new Error("Video provider request failed"));
+    setCloudMediaClientFactoryForTesting(() => ({
+      routes: { postApiV1GenerateVideo, postApiV1GenerateMusic: vi.fn() },
+    }));
+
+    await expect(handleVideoGeneration(runtime(), { prompt: "x" })).rejects.toThrow(
+      /^Video provider request failed$/
+    );
+  });
+});

--- a/plugins/plugin-elizacloud/src/models/media.ts
+++ b/plugins/plugin-elizacloud/src/models/media.ts
@@ -34,6 +34,10 @@ export function setCloudMediaClientFactoryForTesting(
     ((runtime) => createElizaCloudClient(runtime) as CloudMediaClient);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
@@ -113,9 +117,42 @@ async function retryMediaWarming<T>(
         await new Promise((r) => setTimeout(r, 1500));
         continue;
       }
-      throw err;
+      throw withCloudFailureDetails(err);
     }
   }
+}
+
+/**
+ * Recompose a terminal cloud media failure so its message carries the
+ * server-attached diagnosis. The cloud's media routes put the actionable
+ * context (provider, model, upstream status/code, redacted upstream message)
+ * in the error body's `details` while the thrown message stays generic — live
+ * matrix sweep 2026-08-16: four video turns failed as bare "Video provider
+ * request failed" with the failing provider unknowable from any trajectory.
+ * The details are server-side redacted and bounded, so surfacing them is
+ * safe; a non-CloudApiError shape passes through untouched.
+ */
+function withCloudFailureDetails(err: unknown): unknown {
+  if (!(err instanceof Error)) return err;
+  const body = (err as { errorBody?: unknown }).errorBody;
+  if (!isRecord(body)) return err;
+  const details = body.details;
+  if (!isRecord(details)) return err;
+  const parts: string[] = [];
+  const provider = stringValue(details.provider);
+  const model = stringValue(details.model);
+  if (provider) parts.push(`provider=${provider}`);
+  if (model) parts.push(`model=${model}`);
+  const status = numberValue(details.upstreamStatus);
+  const code = stringValue(details.upstreamCode);
+  if (status !== undefined || code) {
+    parts.push(`upstream=${status ?? "?"}${code ? `/${code}` : ""}`);
+  }
+  const upstreamMessage = stringValue(details.upstreamMessage);
+  if (upstreamMessage) parts.push(upstreamMessage);
+  if (parts.length === 0) return err;
+  err.message = `${err.message} (${parts.join(" ")})`;
+  return err;
 }
 
 export async function handleVideoGeneration(


### PR DESCRIPTION
## Problem — found in tonight's standing trajectory sweep

Four fresh live video turns failed as bare **"Video provider request failed"** (e.g. tj-715c4a14e25df2). The cloud's `generate-video` route attaches a redacted diagnosis — `details.{provider, model, upstreamStatus, upstreamCode, upstreamMessage}` — to the 503, and `CloudApiError` preserves the whole body on `errorBody`… but the media handler surfaces only `error.message`, so the failing provider is unknowable from any trajectory, log, or user reply. Tonight's outage is literally undiagnosable from the bot side.

## Fix

`retryMediaWarming`'s terminal rethrow recomposes the message with the server-attached details when present: `Video provider request failed (provider=fal model=veo-3 upstream=403/auth_error …)`. Details are already server-side redacted (`redactProviderErrorMessage`) and bounded, so surfacing them is safe. Non-CloudApiError shapes pass through untouched. Single chokepoint covers video, image, and music.

## Evidence

| Check | Result |
|---|---|
| `cloud-media-generation.test.ts` (2 new: details-composed message incl. exact live-outage shape; detail-less passthrough) | 10/10 ✅ |
| plugin typecheck | ✅ |
| Biome | ✅ |

Next live video failure self-identifies its provider — which also answers what tonight's actual video outage is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)