### PR TITLE
fix(cloud): preserve Personal Shared transcript intent and chronology

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
@@ -1,7 +1,10 @@
 /** Exercises the truthful Shared-to-Dedicated boundary against product copy. */
 
 import { describe, expect, test } from "bun:test";
-import { resolveSharedCapabilityWall } from "./shared-capability-wall";
+import {
+  resolveSharedCapabilityIntent,
+  resolveSharedCapabilityWall,
+} from "./shared-capability-wall";
 
 describe("Shared capability wall", () => {
   test.each([
@@ -11,11 +14,19 @@ describe("Shared capability wall", () => {
     ["show my checklist", "todos"],
     ["complete the laundry todo", "todos"],
     ["show my calendar events", "calendar"],
+    ["list my meetings", "calendar"],
+    ["show upcoming meetings", "calendar"],
+    ["check if I have any meetings tomorrow", "calendar"],
+    ["check whether I have a meeting tomorrow", "calendar"],
+    ["show me whether I have meetings tomorrow", "calendar"],
+    ["check if there are any events tomorrow", "calendar"],
     ["book me dinner for four", "bookings"],
     ["book a flight to san francisco", "bookings"],
     ["email Bob the itinerary", "communications"],
     ["call Mom", "communications"],
     ["text Alice that I'm late", "communications"],
+    ["send Bob a message", "communications"],
+    ["remind me tomorrow and message Bob now", "reminders"],
     ["order dinner for me", "purchases"],
     ["save this as a note", "notes"],
     ["connect my Gmail", "cloud-apps"],
@@ -37,6 +48,12 @@ describe("Shared capability wall", () => {
     "What restaurant should I choose?",
     "Write a TypeScript function",
     "Let's discuss my meeting tomorrow",
+    "Summarize our entire conversation and tell me the first message I sent you",
+    "Can you summarize my last five messages?",
+    "Do not remind me to email Bob and call Alice",
+    "List two ways to make a meeting shorter.",
+    "List three ways to make a meeting shorter.",
+    "Give me two ideas for making a meeting shorter.",
   ])("keeps discussion and research in Shared: %s", (message) => {
     expect(resolveSharedCapabilityWall(message)).toBeNull();
   });
@@ -48,6 +65,40 @@ describe("Shared capability wall", () => {
       }),
     ).toBeNull();
     expect(resolveSharedCapabilityWall("remind me in two minutes")?.capability).toBe("reminders");
+  });
+
+  test.each([
+    "remind me to email Bob",
+    "remind me to email Bob and then call Alice",
+    "remind me to email Bob and email Alice tomorrow",
+  ])("keeps coordinated communication inside an enabled reminder payload: %s", (message) => {
+    expect(resolveSharedCapabilityIntent(message, { reminders: true })).toEqual({
+      kind: "enabled-primary",
+      primary: expect.objectContaining({ capability: "reminders" }),
+      blockedSecondary: [],
+    });
+    expect(resolveSharedCapabilityWall(message, { reminders: true })).toBeNull();
+  });
+
+  test("blocks an independent communication after an enabled reminder", () => {
+    expect(
+      resolveSharedCapabilityWall("remind me tomorrow and email Bob now", {
+        reminders: true,
+      })?.capability,
+    ).toBe("communications");
+    expect(
+      resolveSharedCapabilityWall("remind me to email Bob, then email Alice now", {
+        reminders: true,
+      })?.capability,
+    ).toBe("communications");
+  });
+
+  test("keeps a later executable clause after a non-execution prefix", () => {
+    expect(
+      resolveSharedCapabilityWall("Do not remind me tomorrow, email Bob now", {
+        reminders: true,
+      })?.capability,
+    ).toBe("communications");
   });
 
   test("does not falsely claim voice and messaging require Dedicated", () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
@@ -20,6 +20,14 @@ export interface SharedCapabilityWall {
   reply: string;
 }
 
+export type SharedCapabilityResolution =
+  | { kind: "blocked-primary"; blocked: SharedCapabilityWall }
+  | {
+      kind: "enabled-primary";
+      primary: SharedCapabilityWall;
+      blockedSecondary: SharedCapabilityWall[];
+    };
+
 const NON_EXECUTION_CONTEXT =
   /^(?:please\s+)?(?:(?:can|could|would)\s+you\s+)?(?:do\s+not|don't|dont|never|explain|describe|define|translate|teach\s+me|tell\s+me\s+how|show\s+me\s+how|how\s+(?:do|would|can|to)|what\s+(?:is|are|would|happens?)|why\s+(?:do|would|can|is|are)|if\s+(?:i|we|you)|before\s+you)\b/i;
 
@@ -43,7 +51,7 @@ const RULES: ReadonlyArray<SharedCapabilityWall & { pattern: RegExp }> = [
     capability: "calendar",
     label: "Calendar",
     pattern:
-      /\b(?:add|create|book|schedule|cancel|delete|move|reschedule|check|show|list|open)\b[\s\S]{0,36}\b(?:calendar|events?|appointments?|meetings?)\b/i,
+      /\b(?:(?:add|create|book|schedule|cancel|delete|move|reschedule)\b[\s\S]{0,36}\b(?:calendar|events?|appointments?|meetings?)|(?:check|show|list|open)\b\s+(?:me\s+)?(?:(?:my|our|the|upcoming|next|today(?:'s)?|tomorrow(?:'s)?)\s+){0,2}(?:calendar|events?|appointments?|meetings?)|(?:check|show)\b\s+(?:me\s+)?(?:if|whether)\s+(?:(?:i|we)\s+have|there\s+(?:is|are))\s+(?:(?:any|some|an?)\s+)?(?:events?|appointments?|meetings?))\b/i,
     reply:
       "Calendar actions need Dedicated. I can help plan the event here, but Shared can't read or change your calendar.",
   },
@@ -59,7 +67,7 @@ const RULES: ReadonlyArray<SharedCapabilityWall & { pattern: RegExp }> = [
     capability: "communications",
     label: "Calls and messages",
     pattern:
-      /\b(?:(?:can|could|would|will)\s+you\s+)?(?:(?:email|call|text|message|dm)\b(?!\s+(?:this|the|a|an)\s+(?:\w+\s+){0,2}(?:function|method|api|endpoint|class|variable|command)\b)|send\b[\s\S]{0,32}\b(?:email|text|message|dm)\b)/i,
+      /(?:(?<=^|[.!?;,]\s*|\b(?:and\s+)?then\s+|\band\s+|\bto\s+|\bplease\s+|\b(?:can|could|would|will)\s+you\s+)(?:email|call|text|message|dm)\s+(?!(?:this|the|a|an)\s+(?:\w+\s+){0,2}(?:function|method|api|endpoint|class|variable|command)\b)|\bsend\b[\s\S]{0,32}\b(?:email|text|message|dm)\b)/i,
     reply:
       "I can talk with you and reply through Eliza's connected voice and messaging channels. I can't initiate a separate call, email, text, or DM to another person from this session.",
   },
@@ -123,15 +131,102 @@ export function resolveSharedCapabilityWall(
   message: string | undefined,
   capabilities: { reminders?: boolean; todos?: boolean } = {},
 ): SharedCapabilityWall | null {
-  const text = (message ?? "").trim();
-  if (!text || NON_EXECUTION_CONTEXT.test(text)) return null;
-  const match = RULES.find(
-    (rule) =>
-      !(rule.capability === "reminders" && capabilities.reminders) &&
-      !(rule.capability === "todos" && capabilities.todos) &&
-      rule.pattern.test(text),
+  const resolution = resolveSharedCapabilityIntent(message, capabilities);
+  if (!resolution) return null;
+  return resolution.kind === "blocked-primary"
+    ? resolution.blocked
+    : (resolution.blockedSecondary[0] ?? null);
+}
+
+type CapabilityMatch = {
+  rule: (typeof RULES)[number];
+  priority: number;
+  index: number;
+  end: number;
+};
+
+function isEnabled(
+  match: CapabilityMatch,
+  capabilities: { reminders?: boolean; todos?: boolean },
+): boolean {
+  return (
+    (match.rule.capability === "reminders" && capabilities.reminders === true) ||
+    (match.rule.capability === "todos" && capabilities.todos === true)
   );
-  return match ? { capability: match.capability, label: match.label, reply: match.reply } : null;
+}
+
+function wallFor(match: CapabilityMatch): SharedCapabilityWall {
+  const { capability, label, reply } = match.rule;
+  return { capability, label, reply };
+}
+
+function startsInNonExecutionClause(text: string, index: number): boolean {
+  const prefix = text.slice(0, index);
+  const boundaries = Array.from(prefix.matchAll(/[.!?;,\n]+/g));
+  const boundary = boundaries.at(-1);
+  const clauseStart = boundary ? boundary.index + boundary[0].length : 0;
+  return NON_EXECUTION_CONTEXT.test(text.slice(clauseStart, index));
+}
+
+function matchesForRule(
+  rule: (typeof RULES)[number],
+  priority: number,
+  text: string,
+): CapabilityMatch[] {
+  const flags = rule.pattern.global ? rule.pattern.flags : `${rule.pattern.flags}g`;
+  const pattern = new RegExp(rule.pattern.source, flags);
+  return Array.from(text.matchAll(pattern), (match) => ({
+    rule,
+    priority,
+    index: match.index,
+    end: match.index + match[0].length,
+  })).filter((match) => !startsInNonExecutionClause(text, match.index));
+}
+
+function beginsSeparateClause(text: string, primary: CapabilityMatch, candidate: CapabilityMatch) {
+  if (candidate.index < primary.end) return false;
+  const between = text.slice(primary.end, candidate.index);
+  const isReminderPayload = primary.rule.capability === "reminders" && /\bto\b/i.test(between);
+  if (/[.!?;,]\s*$/i.test(between)) return true;
+  if (/\b(?:and\s+)?then\b[\s\S]*$/i.test(between)) {
+    return !isReminderPayload || /[.!?;,]\s*(?:and\s+)?then\b[\s\S]*$/i.test(between);
+  }
+  if (!/\band\s*$/i.test(between)) return false;
+  return !isReminderPayload;
+}
+
+/** Resolve enabled primary intents without hiding unsupported later clauses. */
+export function resolveSharedCapabilityIntent(
+  message: string | undefined,
+  capabilities: { reminders?: boolean; todos?: boolean } = {},
+): SharedCapabilityResolution | null {
+  const text = (message ?? "").trim();
+  if (!text) return null;
+  const matches = RULES.flatMap((rule, priority) => matchesForRule(rule, priority, text)).sort(
+    (left, right) => left.index - right.index || left.priority - right.priority,
+  );
+  const primary = matches[0];
+  if (!primary) return null;
+  if (!isEnabled(primary, capabilities)) {
+    return { kind: "blocked-primary", blocked: wallFor(primary) };
+  }
+  const blockedCapabilities = new Set<SharedDedicatedCapability>();
+  const blockedSecondary = matches
+    .slice(1)
+    .filter(
+      (candidate) =>
+        !isEnabled(candidate, capabilities) && beginsSeparateClause(text, primary, candidate),
+    )
+    .flatMap((match) => {
+      if (blockedCapabilities.has(match.rule.capability)) return [];
+      blockedCapabilities.add(match.rule.capability);
+      return [wallFor(match)];
+    });
+  return {
+    kind: "enabled-primary",
+    primary: wallFor(primary),
+    blockedSecondary,
+  };
 }
 
 export function capabilityWallActionResult(wall: SharedCapabilityWall) {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -458,6 +458,95 @@ describe("Shared Eliza Workerd runtime", () => {
     ).toBe(true);
   });
 
+  test("projects durable history into RECENT_MESSAGES in chronological order", async () => {
+    const requests: Array<Record<string, unknown>> = [];
+    globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+      requests.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+      return Response.json({
+        id: "chatcmpl-shared-history-order",
+        object: "chat.completion",
+        created: 0,
+        model: "gemma-4-31b",
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: "assistant",
+              content: null,
+              tool_calls: [
+                {
+                  id: "shared-history-order-response",
+                  type: "function",
+                  function: {
+                    name: "HANDLE_RESPONSE",
+                    arguments: JSON.stringify({
+                      shouldRespond: "RESPOND",
+                      thought: "The transcript is chronological.",
+                      contexts: ["simple"],
+                      intents: [],
+                      candidateActionNames: [],
+                      replyText: "history received",
+                      replyEffectStatus: "none",
+                      facts: [],
+                      relationships: [],
+                      addressedTo: [],
+                    }),
+                  },
+                },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+        usage: { prompt_tokens: 40, completion_tokens: 10, total_tokens: 50 },
+      });
+    }) as typeof fetch;
+
+    const { runSharedAgentTurn } = await import("./run-shared-agent-turn");
+    await runSharedAgentTurn({
+      character: {
+        name: "Shared Eliza",
+        system: "You are Eliza.",
+        model: "gemma-4-31b",
+      },
+      history: [
+        {
+          id: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+          role: "user",
+          content: "legacy chronology marker one",
+        },
+        {
+          id: "00000000-0000-4000-8000-000000000001",
+          role: "assistant",
+          content: "durable chronology marker two",
+          createdAt: Date.now() - 24 * 60 * 60_000,
+        },
+        {
+          id: "f0000000-0000-4000-8000-000000000003",
+          role: "user",
+          content: "legacy chronology marker three",
+        },
+      ],
+      message: "summarize the previous three messages",
+      execution: {
+        engine: "eliza-runtime",
+        agentKey: "personal:d6b81293-6440-4ec1-ae46-8fed715c1570",
+      },
+    });
+
+    expect(requests).toHaveLength(1);
+    const prompt = JSON.stringify(requests[0].messages);
+    const markers = [
+      "legacy chronology marker one",
+      "durable chronology marker two",
+      "legacy chronology marker three",
+      "summarize the previous three messages",
+    ];
+    const positions = markers.map((marker) => prompt.indexOf(marker));
+    expect(positions.every((position) => position >= 0)).toBe(true);
+    expect(positions).toEqual([...positions].sort((left, right) => left - right));
+  });
+
   test("plans WEB_SEARCH and grounds the final reply in the free search result", async () => {
     const modelRequests: Array<Record<string, unknown>> = [];
     const searchRequests: Array<Record<string, unknown>> = [];

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -251,6 +251,46 @@ function runtimeMemoryId(message: SharedTurnMessage, index: number) {
   );
 }
 
+function projectedHistoryTimestamps(history: SharedTurnMessage[]): number[] {
+  const anchors: Array<{ index: number; timestamp: number }> = [];
+  for (const [index, message] of history.entries()) {
+    const timestamp = message.createdAt;
+    if (
+      typeof timestamp === "number" &&
+      Number.isFinite(timestamp) &&
+      timestamp > 0 &&
+      (anchors.length === 0 || timestamp > anchors[anchors.length - 1].timestamp)
+    ) {
+      anchors.push({ index, timestamp });
+    }
+  }
+  if (anchors.length === 0) {
+    const epoch = Date.now() - 5 * 60_000 - history.length;
+    return history.map((_, index) => epoch + index);
+  }
+
+  const timestamps = new Array<number>(history.length);
+  for (const anchor of anchors) timestamps[anchor.index] = anchor.timestamp;
+  const first = anchors[0];
+  for (let index = 0; index < first.index; index += 1) {
+    timestamps[index] = first.timestamp - (first.index - index);
+  }
+  for (let anchorIndex = 0; anchorIndex < anchors.length - 1; anchorIndex += 1) {
+    const left = anchors[anchorIndex];
+    const right = anchors[anchorIndex + 1];
+    const span = right.index - left.index;
+    for (let index = left.index + 1; index < right.index; index += 1) {
+      timestamps[index] =
+        left.timestamp + ((right.timestamp - left.timestamp) * (index - left.index)) / span;
+    }
+  }
+  const last = anchors.at(-1)!;
+  for (let index = last.index + 1; index < history.length; index += 1) {
+    timestamps[index] = last.timestamp + (index - last.index);
+  }
+  return timestamps;
+}
+
 async function executeSharedElizaRuntimeTurn(
   input: RunSharedAgentTurnInput & { agentKey: string; model: string },
   onStreamChunk?: (chunk: string) => void | Promise<void>,
@@ -391,10 +431,11 @@ async function executeSharedElizaRuntimeTurn(
       type: ChannelType.DM,
     });
     if (input.history.length > 0) {
+      const historyTimestamps = projectedHistoryTimestamps(input.history);
       await adapter.createMemories(
-        input.history.map((message, index) => ({
-          tableName: "messages",
-          memory: createMessageMemory({
+        input.history.map((message, index) => {
+          const createdAt = historyTimestamps[index];
+          const memory = createMessageMemory({
             id: runtimeMemoryId(message, index),
             entityId: message.role === "assistant" ? runtime.agentId : entityId,
             agentId: runtime.agentId,
@@ -404,8 +445,17 @@ async function executeSharedElizaRuntimeTurn(
               source: "shared-runtime",
               channelType: ChannelType.DM,
             },
-          }),
-        })),
+          });
+          memory.createdAt = createdAt;
+          if (!memory.metadata) {
+            throw new Error("Projected Shared message omitted canonical metadata");
+          }
+          memory.metadata.timestamp = createdAt;
+          return {
+            tableName: "messages",
+            memory,
+          };
+        }),
       );
     }
 


### PR DESCRIPTION
Fixes #20452

## What changed
- classify transcript and memory questions as conversation requests while preserving the canonical multi-match capability intent semantics
- preserve enabled reminder payloads containing coordinated communication verbs and still wall independent later commands
- filter non-execution context per clause so a later explicit command is not hidden
- project mixed stamped and unstamped durable history with monotonic timestamps around real anchors
- populate both memory createdAt and canonical metadata timestamp

## Verification
- 49/49 focused genuine AgentRuntime and capability tests, 88 assertions
- adversarial production-path history fixture: unstamped, durable past timestamp, unstamped with reverse-sorting UUIDs
- Cloud Shared typecheck PASS
- Cloud API build PASS
- Biome exact four paths PASS
- git diff --check PASS
- Wrangler production Worker dry bundle PASS, no deploy

## Live evidence
Pre-fix staging returned the communications refusal for the exact transcript-summary question and grounded a recent-history question in stale content. After protected staging deployment, this PR will be restamped with those exact prompts plus ordinary chat and memory recall through live Cerebras.

Production is untouched.