### PR TITLE
fix(core): media generation end-to-end — single-message delivery, video seams, routing, provider hygiene, opt-in default

### DIFF
--- a/packages/core/src/features/advanced-capabilities/actions/generateMedia.test.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/generateMedia.test.ts
@@ -25,6 +25,11 @@ function runtimeWithMediaService(
 				? { canGenerateMedia: vi.fn(() => canGenerateMedia), generateMedia }
 				: undefined,
 		getModel: vi.fn(() => undefined),
+		// Video is opt-in in production (bills per clip); tests exercising the
+		// video paths run with the operator opt-in granted.
+		getSetting: vi.fn((key: string) =>
+			key === "ELIZA_VIDEO_GENERATION_ENABLED" ? "true" : undefined,
+		),
 	} as never;
 }
 

--- a/packages/core/src/features/advanced-capabilities/actions/generateMedia.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/generateMedia.ts
@@ -265,6 +265,41 @@ function titleFor(
 	return `${prefix}_${timestamp}.${extensionFor(url, request.mediaType)}`;
 }
 
+// error-policy:J1 Media generation is an action boundary and returns an
+// explicit unsuccessful result.
+function mediaGenerationFailure(
+	runtime: IAgentRuntime,
+	request: MediaGenerationRequest,
+	error: unknown,
+): ActionResult {
+	const errorMessage = error instanceof Error ? error.message : String(error);
+	logger.error(
+		{
+			src: "plugin:advanced-capabilities:action:generate_media",
+			agentId: runtime.agentId,
+			mediaType: request.mediaType,
+			error: errorMessage,
+		},
+		"Media generation failed",
+	);
+	return {
+		text: `Media generation failed: ${errorMessage}`,
+		values: {
+			success: false,
+			error: "MEDIA_GENERATION_FAILED",
+			mediaType: request.mediaType,
+			prompt: request.prompt,
+		},
+		data: {
+			actionName: "GENERATE_MEDIA",
+			mediaType: request.mediaType,
+			prompt: request.prompt,
+			error: errorMessage,
+		},
+		success: false,
+	};
+}
+
 function hasImageGenerationModel(runtime: IAgentRuntime): boolean {
 	return typeof runtime.getModel(ModelType.IMAGE) === "function";
 }
@@ -282,13 +317,15 @@ async function fallbackGenerateVideo(
 	runtime: IAgentRuntime,
 	request: MediaGenerationRequest,
 ): Promise<MediaGenerationResponse> {
+	// Duration and aspect ratio are deliberately NOT forwarded: providers
+	// hard-reject out-of-range or mistyped values (fal veo3 422s on
+	// durationSeconds outside its fixed clip length AND on "16:9" arriving in
+	// its resolution field — both observed live), and a default-shaped video
+	// beats a failed request for the whole ask. The bare prompt (+ optional
+	// reference image) is the proven-working request shape.
 	const videoResponse = (await runtime.useModel(ModelType.VIDEO, {
 		prompt: request.prompt,
 		...(request.imageUrl ? { imageUrl: request.imageUrl } : {}),
-		...(typeof request.duration === "number"
-			? { durationSeconds: request.duration }
-			: {}),
-		...(request.aspectRatio ? { aspectRatio: request.aspectRatio } : {}),
 	})) as { url?: string; videoUrl?: string } | string | undefined;
 	const videoUrl =
 		typeof videoResponse === "string"
@@ -449,36 +486,44 @@ export const generateMediaAction = {
 				"GENERATE_MEDIA handler invoking media service",
 			);
 			result = await generateWithService(runtime, request);
-		} catch (error) {
-			// error-policy:J1 Media generation is an action boundary and returns
-			// an explicit unsuccessful result.
-			const errorMessage =
-				error instanceof Error ? error.message : String(error);
-			logger.error(
-				{
-					src: "plugin:advanced-capabilities:action:generate_media",
-					agentId: runtime.agentId,
-					mediaType: request.mediaType,
-					error: errorMessage,
-				},
-				"Media generation failed",
-			);
-			return {
-				text: `Media generation failed: ${errorMessage}`,
-				values: {
-					success: false,
-					error: "MEDIA_GENERATION_FAILED",
-					mediaType: request.mediaType,
-					prompt: request.prompt,
-				},
-				data: {
-					actionName: "GENERATE_MEDIA",
-					mediaType: request.mediaType,
-					prompt: request.prompt,
-					error: errorMessage,
-				},
-				success: false,
-			};
+		} catch (firstError) {
+			// Provider param constraints (fal veo3 422s on durationSeconds and on
+			// aspect-ratio-as-resolution — observed live) fail the WHOLE ask over
+			// planner-supplied extras the user never insisted on. Retry once with
+			// the bare proven shape (prompt + optional reference image) before
+			// giving up: a default-shaped result beats a failed request. The
+			// rejected attempt is not billed.
+			const hadShapingExtras =
+				request.duration !== undefined ||
+				request.aspectRatio !== undefined ||
+				request.size !== undefined ||
+				request.seed !== undefined;
+			if (hadShapingExtras) {
+				logger.warn(
+					{
+						src: "plugin:advanced-capabilities:action:generate_media",
+						agentId: runtime.agentId,
+						mediaType: request.mediaType,
+						error:
+							firstError instanceof Error
+								? firstError.message
+								: String(firstError),
+					},
+					"Media generation failed with shaping extras; retrying with the bare prompt shape",
+				);
+				try {
+					result = await generateWithService(runtime, {
+						mediaType: request.mediaType,
+						prompt: request.prompt,
+						audioKind: request.audioKind,
+						imageUrl: request.imageUrl,
+					});
+				} catch (retryError) {
+					return mediaGenerationFailure(runtime, request, retryError);
+				}
+			} else {
+				return mediaGenerationFailure(runtime, request, firstError);
+			}
 		}
 
 		const url = resultUrl(result);

--- a/packages/core/src/features/advanced-capabilities/actions/generateMedia.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/generateMedia.ts
@@ -30,6 +30,7 @@ import type {
 } from "../../../types/index.ts";
 import { ContentType, ModelType, ServiceType } from "../../../types/index.ts";
 import { hasActionContext } from "../../../utils/action-validation.ts";
+import { resolveSetting } from "../../../utils/resolve-setting.ts";
 
 const spec: ActionDoc = getActionSpec("GENERATE_MEDIA") ?? {
 	name: "GENERATE_MEDIA",
@@ -469,6 +470,40 @@ export const generateMediaAction = {
 				text: "Media prompt is required",
 				values: { success: false, error: "MISSING_PROMPT" },
 				data: { actionName: "GENERATE_MEDIA", error: "Missing prompt" },
+				success: false,
+			};
+		}
+
+		// Video generation is OPT-IN: every clip bills real provider money
+		// (fal veo3 ≈ $3–4/video via Eliza Cloud) and role policy can expose
+		// GENERATE_MEDIA in public rooms, so an operator must enable it
+		// deliberately with ELIZA_VIDEO_GENERATION_ENABLED. Disabled ⇒ an
+		// honest grounded decline — never a silent denial the model invents.
+		const videoOptIn = (
+			resolveSetting(runtime, "ELIZA_VIDEO_GENERATION_ENABLED") ?? ""
+		)
+			.trim()
+			.toLowerCase();
+		if (
+			request.mediaType === "video" &&
+			!["1", "true", "yes", "on"].includes(videoOptIn)
+		) {
+			const disabledText =
+				"video generation is switched off on this deployment (it bills per clip). the operator can enable it with ELIZA_VIDEO_GENERATION_ENABLED.";
+			return {
+				text: disabledText,
+				userFacingText: disabledText,
+				verifiedUserFacing: true,
+				values: {
+					success: false,
+					error: "VIDEO_GENERATION_DISABLED",
+					mediaType: request.mediaType,
+				},
+				data: {
+					actionName: "GENERATE_MEDIA",
+					mediaType: request.mediaType,
+					disabled: true,
+				},
 				success: false,
 			};
 		}

--- a/packages/core/src/features/advanced-capabilities/actions/generateMedia.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/generateMedia.ts
@@ -481,12 +481,18 @@ export const generateMediaAction = {
 							? "sound effect"
 							: "audio";
 		const responseText = `Generated ${label}`;
+		const caption = `here's your ${label}.`;
 		const responseContent = {
 			attachments: [attachment],
 			thought: `Generated ${label} based on: "${request.prompt}"`,
 			actions: ["GENERATE_MEDIA"],
-			// Attachment-only callback: the planner/evaluator composes user-facing text.
-			text: "",
+			// Caption rides WITH the attachment so connectors deliver ONE message
+			// (media + caption). The old attachment-only callback (text: "") plus
+			// a planner-composed follow-up shipped as TWO Discord messages — the
+			// image, then a trailing "your image." (owner-reported UX bug). The
+			// turn is marked terminal below, so this caption is the turn's whole
+			// user-facing text on every surface.
+			text: caption,
 			source: "media-generation",
 		};
 
@@ -508,12 +514,13 @@ export const generateMediaAction = {
 
 		return {
 			text: responseText,
-			userFacingText:
-				request.mediaType === "video"
-					? "Here's your video."
-					: request.mediaType === "image"
-						? "Here's your image."
-						: "Here's your audio.",
+			userFacingText: caption,
+			// The media + caption already delivered as one connector message via
+			// the callback above; a planner finish pass would only add a second,
+			// redundant text message ("your image.") after the attachment. End
+			// the chain in deliberate silence — a follow-up ask re-invokes
+			// normally on its own turn.
+			continueChain: false,
 			values: {
 				success: true,
 				mediaGenerated: true,
@@ -524,6 +531,9 @@ export const generateMediaAction = {
 			},
 			data: {
 				actionName: "GENERATE_MEDIA",
+				// Pairs with continueChain above: blanks the planner finish text so
+				// the delivered media+caption message stays the ONLY message.
+				suppressPlannerReply: true,
 				mediaType: request.mediaType,
 				audioKind: request.audioKind,
 				mediaUrl: url,

--- a/packages/core/src/features/advanced-capabilities/actions/generateMedia.ts
+++ b/packages/core/src/features/advanced-capabilities/actions/generateMedia.ts
@@ -269,6 +269,41 @@ function hasImageGenerationModel(runtime: IAgentRuntime): boolean {
 	return typeof runtime.getModel(ModelType.IMAGE) === "function";
 }
 
+function hasVideoGenerationModel(runtime: IAgentRuntime): boolean {
+	return typeof runtime.getModel(ModelType.VIDEO) === "function";
+}
+
+/** Direct VIDEO-model fallback, mirror of {@link fallbackGenerateImage}: a
+ * runtime with a registered VIDEO handler (e.g. Eliza Cloud's
+ * /generate-video) can serve video asks without the media-generation
+ * service — previously such runtimes falsely denied "no video generator"
+ * (the same self-belief class the image fallback fixed). */
+async function fallbackGenerateVideo(
+	runtime: IAgentRuntime,
+	request: MediaGenerationRequest,
+): Promise<MediaGenerationResponse> {
+	const videoResponse = (await runtime.useModel(ModelType.VIDEO, {
+		prompt: request.prompt,
+		...(request.imageUrl ? { imageUrl: request.imageUrl } : {}),
+		...(typeof request.duration === "number"
+			? { durationSeconds: request.duration }
+			: {}),
+		...(request.aspectRatio ? { aspectRatio: request.aspectRatio } : {}),
+	})) as { url?: string; videoUrl?: string } | string | undefined;
+	const videoUrl =
+		typeof videoResponse === "string"
+			? videoResponse
+			: (videoResponse?.videoUrl ?? videoResponse?.url);
+	if (!videoUrl) {
+		throw new Error("Video generation failed - no valid response received");
+	}
+	return {
+		mediaType: "video",
+		videoUrl,
+		url: videoUrl,
+	};
+}
+
 async function fallbackGenerateImage(
 	runtime: IAgentRuntime,
 	request: MediaGenerationRequest,
@@ -313,6 +348,10 @@ async function generateWithService(
 		return fallbackGenerateImage(runtime, request);
 	}
 
+	if (request.mediaType === "video" && hasVideoGenerationModel(runtime)) {
+		return fallbackGenerateVideo(runtime, request);
+	}
+
 	throw new Error(
 		service
 			? `${request.mediaType} generation is not configured.`
@@ -344,7 +383,8 @@ export const generateMediaAction = {
 		);
 		const canGenerate =
 			(service && (await service.canGenerateMedia(request))) ||
-			(request.mediaType === "image" && hasImageGenerationModel(runtime));
+			(request.mediaType === "image" && hasImageGenerationModel(runtime)) ||
+			(request.mediaType === "video" && hasVideoGenerationModel(runtime));
 		if (!canGenerate) {
 			logger.debug(
 				{

--- a/packages/core/src/runtime/__tests__/message-handler.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler.test.ts
@@ -504,3 +504,81 @@ describe("v5 message handler routing", () => {
 		expect(parsed?.extract).toBeUndefined();
 	});
 });
+
+describe("explicit media-ask promotion", () => {
+	it("promotes a poisoned capability denial on the simple path to media planning", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "can't do that here. no video generation tools in this setup.",
+				contexts: ["simple"],
+				candidateActionNames: [],
+			}),
+		);
+		expect(parsed).not.toBeNull();
+		if (!parsed) return;
+		const route = routeMessageHandlerOutput(parsed, {
+			messageText: "generate a 3 second video of falling leaves",
+		});
+		expect(route.type).toBe("planning_needed");
+		if (route.type === "planning_needed") {
+			expect(route.contexts).toEqual(["media"]);
+			expect(route.output.plan.candidateActions).toContain("GENERATE_MEDIA");
+		}
+	});
+
+	it("seeds GENERATE_MEDIA as a candidate on planned media asks", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "on it",
+				contexts: ["general"],
+				candidateActionNames: ["WORKFLOW"],
+			}),
+		);
+		expect(parsed).not.toBeNull();
+		if (!parsed) return;
+		const route = routeMessageHandlerOutput(parsed, {
+			messageText: "make a short video of ocean waves",
+		});
+		expect(route.type).toBe("planning_needed");
+		expect(route.output.plan.candidateActions).toContain("GENERATE_MEDIA");
+	});
+
+	it("leaves non-media asks and clarifying replies untouched", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "sure — a picture of what exactly?",
+				contexts: ["simple"],
+				candidateActionNames: [],
+			}),
+		);
+		expect(parsed).not.toBeNull();
+		if (!parsed) return;
+		const route = routeMessageHandlerOutput(parsed, {
+			messageText: "generate an image of a fox",
+		});
+		expect(route.type).toBe("final_reply");
+	});
+
+	it("does not seed media candidates for incidental media mentions", () => {
+		const parsed = parseMessageHandlerOutput(
+			JSON.stringify({
+				shouldRespond: "RESPOND",
+				replyText: "here you go",
+				contexts: ["simple"],
+				candidateActionNames: [],
+			}),
+		);
+		expect(parsed).not.toBeNull();
+		if (!parsed) return;
+		const route = routeMessageHandlerOutput(parsed, {
+			messageText: "send me the image you saved yesterday",
+		});
+		expect(route.type).toBe("final_reply");
+		expect(route.output.plan.candidateActions ?? []).not.toContain(
+			"GENERATE_MEDIA",
+		);
+	});
+});

--- a/packages/core/src/runtime/message-handler.ts
+++ b/packages/core/src/runtime/message-handler.ts
@@ -253,9 +253,28 @@ function parseExtract(raw: unknown): MessageHandlerExtract | undefined {
 	return result;
 }
 
+/** Explicit media-generation request shape: a generation verb paired with a
+ * media-artifact noun within one clause. Self-contained mirror of
+ * GENERATE_MEDIA's own explicit-request detector — validate() and routing
+ * deliberately own their layers separately (#20174), but they must agree on
+ * what an explicit ask looks like. */
+const EXPLICIT_MEDIA_GENERATION_REQUEST_RE =
+	/\b(?:generate|make|draw|create|render|paint|produce|design)\b[^.!?]{0,64}\b(?:image|picture|photo|art(?:work)?|illustration|logo|sticker|wallpaper|drawing|painting|meme|gif|video|animation|clip|music|song|audio|sound(?:\s?effect)?|sfx|voice(?:over)?|speech)s?\b/i;
+
+/** Capability-denial reply shape ("can't do that here — no video tools in
+ * this setup", "I don't have an image generator"). */
+const CAPABILITY_DENIAL_REPLY_RE =
+	/\b(?:can'?t|cannot|unable to|no|don'?t have|lack)\b[^.!?]{0,80}\b(?:tool|generat|capabilit|action|model|service|setup|environment)/i;
+
 export function routeMessageHandlerOutput(
 	output: V5MessageHandlerOutput,
-	options?: { addressedToOtherParticipant?: boolean },
+	options?: {
+		addressedToOtherParticipant?: boolean;
+		/** The user's own message text; enables request-shape promotions the
+		 * stage-1 output alone cannot justify. Optional for compatibility —
+		 * absent, the request-shape promotions simply do not run. */
+		messageText?: string;
+	},
 ): MessageHandlerRoute {
 	const processMessage = output.processMessage;
 	if (processMessage === "IGNORE") {
@@ -282,6 +301,38 @@ export function routeMessageHandlerOutput(
 
 	const allContexts = [...output.plan.contexts];
 	const requiresTool = output.plan.requiresTool === true;
+	// An explicit "generate a <media>" ask is answerable ONLY by the media
+	// action, yet two live failure shapes bypass it: (a) stage-1 parrots a
+	// stale capability denial from room history and ships it on the simple
+	// path ("no video generation tools in this setup" — false, the model is
+	// registered), and (b) planning routes to an adjacent surface (a workflow
+	// builder) because no candidate anchored the media action. Seeding
+	// GENERATE_MEDIA as a candidate fixes both: the candidate-append pass
+	// forces it onto the planner surface, and stage-1-named-tool enforcement
+	// makes the planner actually CALL it instead of acking. If the action is
+	// genuinely gated for this surface, the gate-rejection short-circuit
+	// still answers honestly — the layers compose.
+	const messageTextForRouting = options?.messageText ?? "";
+	const isExplicitMediaAsk = EXPLICIT_MEDIA_GENERATION_REQUEST_RE.test(
+		messageTextForRouting,
+	);
+	// Seeding is applied ONLY on routes that enter the planner: a simple-path
+	// clarify ("a picture of what exactly?") must stay a final reply, so the
+	// seed never by itself converts a simple turn into planning.
+	const seedMediaCandidate = (): void => {
+		if (!isExplicitMediaAsk) return;
+		if (
+			(output.plan.candidateActions ?? []).some(
+				(name) => String(name).trim().toUpperCase() === "GENERATE_MEDIA",
+			)
+		) {
+			return;
+		}
+		output.plan.candidateActions = [
+			...(output.plan.candidateActions ?? []),
+			"GENERATE_MEDIA",
+		];
+	};
 	const candidateActions = output.plan.candidateActions ?? [];
 	const hasCandidateActions = candidateActions.length > 0;
 
@@ -319,15 +370,32 @@ export function routeMessageHandlerOutput(
 		(requiresTool || candidateActionsRequestPlanning) &&
 		nonSimpleContexts.length === 0;
 	if (promotionRequested) {
+		seedMediaCandidate();
 		return {
 			type: "planning_needed",
 			output,
-			contexts: ["general"],
+			contexts: isExplicitMediaAsk ? ["media"] : ["general"],
 		};
 	}
 
 	if (nonSimpleContexts.length === 0) {
 		const reply = getMessageHandlerReply(output);
+		// A capability denial on the simple path for an explicit media ask is
+		// the history-poisoning shape: stage-1 repeats a stale "no video/image
+		// tools" precedent from room history without consulting the runtime
+		// (observed live: the same room that generated two images denied that
+		// GENERATE_MEDIA exists). Route to planning against the media context —
+		// if the capability is real the planner exercises it; if it is
+		// genuinely absent the planner surface proves it and the honest denial
+		// ships from ground truth instead of from memory.
+		if (isExplicitMediaAsk && CAPABILITY_DENIAL_REPLY_RE.test(reply)) {
+			seedMediaCandidate();
+			return {
+				type: "planning_needed",
+				output,
+				contexts: ["media"],
+			};
+		}
 		// A progress-shaped reply on the pure-simple path is a self-contradiction:
 		// "checking paris weather now" promises tool work, and the simple path
 		// runs no tools — shipping it as the WHOLE turn is the bare-ack class
@@ -358,6 +426,7 @@ export function routeMessageHandlerOutput(
 	}
 
 	// Mixed selection: drop the `simple` marker and plan against the rest.
+	seedMediaCandidate();
 	return {
 		type: "planning_needed",
 		output,

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -8340,6 +8340,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		}
 		const route = routeMessageHandlerOutput(messageHandler, {
 			addressedToOtherParticipant,
+			messageText: getUserMessageText(args.message) ?? "",
 		});
 		if (route.type === "ignored" || route.type === "stopped") {
 			return {


### PR DESCRIPTION
## What

Five stacked fixes that take media generation from "false capability denials + double-message delivery" to green end-to-end, each root-caused from live trajectories on the nubilio test deployment:

1. **Single-message delivery** — `GENERATE_MEDIA` used an attachment-only callback (`text: ""`) and the planner then composed a separate caption, shipping TWO Discord messages (image, then a trailing "your image." — owner-reported UX bug). The caption now rides in the same message as the attachment, and the action ends the chain in deliberate silence (`continueChain: false` + `suppressPlannerReply`).
2. **Video validate/fallback seams** — a runtime with a registered `ModelType.VIDEO` handler (Eliza Cloud registers one via `/api/v1/generate-video`) falsely denied "no video generator" because the #20174 image fallback had no video counterpart. `hasVideoGenerationModel` + `fallbackGenerateVideo` mirror the image path.
3. **Media-ask routing** — two live failure shapes bypassed the action entirely: stage-1 parroted stale capability denials from room history on the simple path (the same room that had generated two images denied `GENERATE_MEDIA` exists), and a fresh room routed a video ask to a workflow builder. Explicit media asks (gen-verb + media-noun, mirroring the action's own detector) now seed `GENERATE_MEDIA` as a candidate on planning routes and promote denial-shaped simple-path replies to media-context planning. Clarifying replies stay final; incidental mentions ("send me the image you saved") never match.
4. **Provider param hygiene** — fal veo3 hard-422s on `durationSeconds` outside its fixed clip length AND on aspect-ratio values arriving in its resolution field (both isolated via direct endpoint probes; the bare prompt returned HTTP 200 + a real MP4). The video fallback no longer forwards shaping extras, and the handler retries once with the bare proven shape when a fully-shaped service request fails — provider-agnostic; rejected attempts are unbilled.
5. **Video is opt-in by default** — every clip bills real provider money (veo3 ≈ $3.84/video via Eliza Cloud) and role policy can expose the action in public rooms, so `ELIZA_VIDEO_GENERATION_ENABLED` gates it per deployment. Disabled ⇒ an honest grounded decline, never a model-invented denial.

## Evidence

- Live Discord proof (raw-API verified): image ask → ONE message, 726KB jpeg + caption; video ask → ONE message, **8.1MB `video/mp4`** + caption, ~90s wall.
- Poisoned-room video ask went from parroted denial → real tool call → honest provider-failure report → (post param fix) delivered video.
- Opt-in gate live: "generate a short video…" on a non-opted deployment → "video generation is switched off on this deployment (it bills per clip)…", zero spend.
- Suites: advanced-capabilities 533/533, message-handler 29/29. Full receipts: elizaOS/eliza#18309 (comments 18038519, 18038630).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:6bb3cea8579a279236625770fda36e630c5fece2 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI change; behavior is Discord message shape, receipts linked

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI change; single-message delivery verified via raw Discord API

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend change; live Discord receipts serve as the walkthrough

<!-- evidence-row:backend-logs -->
- [x] [18309#discussioncomment-18038519](https://github.com/elizaOS/eliza/discussions/18309#discussioncomment-18038519)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface touched

<!-- evidence-row:llm-trajectory -->
- [x] [18309#discussioncomment-18038519](https://github.com/elizaOS/eliza/discussions/18309#discussioncomment-18038519)

<!-- evidence-row:domain-artifacts -->
- [x] [18309#discussioncomment-18038519](https://github.com/elizaOS/eliza/discussions/18309#discussioncomment-18038519)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered text surfaces changed
