### PR TITLE
fix(cloud): bill gpt-4o usage on generate-prompts instead of serving free inference

### DIFF
--- a/packages/cloud/api/v1/generate-prompts/route.ts
+++ b/packages/cloud/api/v1/generate-prompts/route.ts
@@ -11,6 +11,7 @@ import { streamText } from "ai";
 import { Hono } from "hono";
 import { requireGenerativeRouteCaller } from "@/api-app/lib/generative-route-auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { billUsage } from "@/lib/services/ai-billing";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -18,7 +19,9 @@ const app = new Hono<AppEnv>();
 
 app.post("/", async (c) => {
   try {
-    await requireGenerativeRouteCaller(c, { rateLimitEndpoint: "strict" });
+    const caller = await requireGenerativeRouteCaller(c, {
+      rateLimitEndpoint: "strict",
+    });
 
     const body = ((await c.req.json().catch(() => ({}))) ?? {}) as {
       seed?: string | number;
@@ -76,6 +79,36 @@ Random seed: ${promptSeed}`,
       maxOutputTokens: 500,
       topP: 0.95,
     });
+
+    // Bill actual gpt-4o token usage once the stream settles. This route
+    // previously served inference UNBILLED (audit finding: the platform paid
+    // OpenAI for every call); `result.usage` resolves after the stream
+    // finishes, and waitUntil settles the charge without delaying the
+    // streamed response.
+    c.executionCtx.waitUntil(
+      (async () => {
+        try {
+          const usage = await result.usage;
+          await billUsage(
+            {
+              organizationId: caller.user.organization_id,
+              userId: caller.user.id,
+              apiKeyId: caller.apiKeyId,
+              model: "gpt-4o",
+              provider: "openai",
+              description: "generate-prompts agent-concept suggestions",
+            },
+            usage,
+          );
+        } catch (error) {
+          // error-policy:J7 billing settlement runs post-response; a failure
+          // must be loud in logs (revenue) but cannot affect the stream.
+          logger.error("[generate-prompts] usage billing failed", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      })(),
+    );
 
     return result.toTextStreamResponse();
   } catch (error) {


### PR DESCRIPTION
## What

Billing-audit finding: `POST /api/v1/generate-prompts` (the dashboard's agent-concept suggester) called `openai("gpt-4o")` via `streamText` with **zero billing** — authenticated and strictly rate-limited, but every call was free inference the platform paid OpenAI for (≈$0.005/call at the 500-token cap).

The route now settles actual token usage through `billUsage` (which applies the standard 20% platform markup via `calculateCost`) once the stream finishes: `result.usage` resolves post-stream and `c.executionCtx.waitUntil` keeps the Worker alive to settle the charge without delaying the streamed response. A billing failure logs loud (`error-policy:J7`) but never breaks the stream.

## Evidence

- Audit sweep across every v1 endpoint that consumes provider resources: chat/completions (+`responses` via delegation), chat, messages, embeddings, generate-image/video/music/sfx, voice tts/stt/clone, agents a2a/mcp, containers — all bill with the credits gate and markup; this route was the one leak. Full matrix: elizaOS/eliza#18309 comment 18038630.
- Markup verified live on a generation receipt (base 3.20 → total 3.84, platformMarkup 0.64).
- `tsc --noEmit` clean in `packages/cloud/api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:e455f2b5901a60d79a9d5ff2e748b487018e23fd -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - Worker billing change, no UI

<!-- evidence-row:after-screenshots -->
- [ ] N/A - Worker billing change, no UI

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend billing settlement; audit matrix linked

<!-- evidence-row:backend-logs -->
- [x] [18309#discussioncomment-18038630](https://github.com/elizaOS/eliza/discussions/18309#discussioncomment-18038630)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent behavior change; route-level billing only

<!-- evidence-row:domain-artifacts -->
- [x] [18309#discussioncomment-18038630](https://github.com/elizaOS/eliza/discussions/18309#discussioncomment-18038630)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces
