### PR TITLE
fix(pa): keep-clause titles are exclusions in the single-target delete resolver too

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -1109,7 +1109,16 @@ async function resolveDefinitionForMutation(
   const normalizedOwnerText = normalizeTitle(ownerText);
   const explicitlyNamed = defs.filter((entry) => {
     const title = normalizeTitle(entry.definition.title);
-    return title.length > 0 && normalizedOwnerText.includes(title);
+    if (title.length === 0) return false;
+    const index = normalizedOwnerText.indexOf(title);
+    if (index < 0) return false;
+    // A title named inside a keep-style clause ("keep buy sandpaper",
+    // "don't delete X") is an exclusion, not a target — without this, the
+    // keep clause itself made the kept item an "explicitly named" candidate
+    // and forced a bogus disambiguation ask (or worse, on non-destructive
+    // ops, a wrong-target resolution).
+    const prefix = normalizedOwnerText.slice(Math.max(0, index - 32), index);
+    return !ENUMERATED_DELETE_KEEP_CUE_RE.test(prefix);
   });
   if (explicitlyNamed.length === 1) {
     return {


### PR DESCRIPTION
## What

Follow-up to the enumerated multi-target delete (upstreamed earlier tonight): the single-target resolver's `explicitlyNamed` containment scan treated a title inside a keep-style clause as an explicitly named candidate. Live regression probe: `"delete these todos: regression alpha. keep buy sandpaper."` — with only one deletable target, the multi-target path correctly stands down, but the single path then matched **"buy sandpaper" from the keep clause itself** and forced a bogus disambiguation ask listing the kept item as a delete candidate.

The same `ENUMERATED_DELETE_KEEP_CUE_RE` guard now filters the single-target containment scan: a title preceded by "keep / except / leave / but not / don't delete" is an exclusion, never a target.

## Evidence

- Live before: the probe above → "I found similarly named items … delete which one? - buy sandpaper — no due date - regression alpha …"
- Live after: same probe → "deleted regression alpha." and the todos list shows only "buy sandpaper".
- `life-reminder-datetime` suite 131/131; pa typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:70e11514ca969d5d125bcb5a0de7d408eeee9c70 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - chat-behavior change, before/after transcripts in PR body

<!-- evidence-row:after-screenshots -->
- [ ] N/A - chat-behavior change, before/after transcripts in PR body

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - single resolver guard; live transcripts serve as walkthrough

<!-- evidence-row:backend-logs -->
- [ ] N/A - no server errors involved; resolver-level behavior with live transcripts in body

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [x] [18309#discussioncomment-18038735](https://github.com/elizaOS/eliza/discussions/18309#discussioncomment-18038735)

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - store state verified via live list read (only the kept todo remains), transcript in body

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces
