### PR TITLE
fix(ui): keep agent backup state authoritative

### DIFF
--- a/packages/ui/src/cloud/instances/components/eliza-agent-backups-panel.test.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agent-backups-panel.test.tsx
@@ -1,0 +1,481 @@
+/**
+ * Verifies backup-list and restore UI state against deterministic mocked Cloud
+ * transport responses, including request races and abort ownership.
+ */
+// @vitest-environment jsdom
+
+import {
+  act,
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaAgentBackupsPanel } from "./eliza-agent-backups-panel";
+
+const apiMock = vi.hoisted(() => vi.fn());
+const toastMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+  success: vi.fn(),
+}));
+
+vi.mock("../../lib/api-client", () => ({ api: apiMock }));
+vi.mock("sonner", () => ({ toast: toastMocks }));
+
+const BACKUP = {
+  id: "11111111-1111-4111-8111-111111111111",
+  snapshotType: "manual",
+  sizeBytes: 2048,
+  createdAt: "2026-08-11T12:00:00.000Z",
+  backupKind: "full",
+  parentBackupId: null,
+};
+
+const OLD_BACKUP = {
+  ...BACKUP,
+  id: "22222222-2222-4222-8222-222222222222",
+  snapshotType: "pre-move",
+  sizeBytes: null,
+  createdAt: "2026-08-10T12:00:00.000Z",
+};
+
+function listResponse(data: unknown[] = [BACKUP]) {
+  return { success: true, data };
+}
+
+function restoreResponse(backup = BACKUP) {
+  return {
+    success: true,
+    data: {
+      restoredFromBackupId: backup.id,
+      snapshotType: backup.snapshotType,
+      createdAt: backup.createdAt,
+    },
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+function renderPanel(
+  props: Partial<{
+    agentId: string;
+    agentName: string;
+    status: string;
+  }> = {},
+) {
+  return render(
+    <ElizaAgentBackupsPanel
+      agentId={props.agentId ?? "agent-1"}
+      agentName={props.agentName ?? "Primary agent"}
+      status={props.status ?? "running"}
+    />,
+  );
+}
+
+describe("ElizaAgentBackupsPanel", () => {
+  const originalLocationDescriptor = Object.getOwnPropertyDescriptor(
+    window,
+    "location",
+  );
+  let reloadSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    apiMock.mockReset();
+    toastMocks.error.mockReset();
+    toastMocks.success.mockReset();
+    reloadSpy = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, reload: reloadSpy },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    if (originalLocationDescriptor) {
+      Object.defineProperty(window, "location", originalLocationDescriptor);
+    }
+  });
+
+  it("keeps loading distinct until the backup request settles", async () => {
+    const request = deferred<ReturnType<typeof listResponse>>();
+    apiMock.mockReturnValue(request.promise);
+
+    renderPanel();
+
+    expect(screen.getByRole("status").textContent).toContain("Loading backups");
+    expect(screen.queryByText("No backups yet")).toBeNull();
+
+    await act(async () => {
+      request.resolve(listResponse([]));
+      await request.promise;
+    });
+
+    expect(await screen.findByText("No backups yet")).toBeTruthy();
+  });
+
+  it("renders the designed empty state without treating it as an error", async () => {
+    apiMock.mockResolvedValue(listResponse([]));
+
+    renderPanel();
+
+    expect(await screen.findByText("No backups yet")).toBeTruthy();
+    expect(screen.queryByText("Failed to load backups")).toBeNull();
+  });
+
+  it("renders request failures with a retry instead of an empty list", async () => {
+    apiMock.mockRejectedValue(new Error("Backup service unavailable"));
+
+    renderPanel();
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Failed to load backups");
+    expect(alert.textContent).toContain("Backup service unavailable");
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    expect(screen.queryByText("No backups yet")).toBeNull();
+  });
+
+  it("uses the authenticated Cloud transport and surfaces a rejected session", async () => {
+    apiMock.mockRejectedValue(
+      Object.assign(new Error("Session expired"), { status: 401 }),
+    );
+
+    renderPanel({ agentId: "agent-session" });
+
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Session expired",
+    );
+    expect(apiMock).toHaveBeenCalledWith(
+      "/api/v1/eliza/agents/agent-session/backups",
+      expect.objectContaining({ cache: "no-store", signal: expect.anything() }),
+    );
+  });
+
+  it.each([
+    ["missing data", { success: true }],
+    ["false success", { success: false, data: [] }],
+    ["missing id", listResponse([{ ...BACKUP, id: undefined }])],
+    [
+      "unknown snapshot type",
+      listResponse([{ ...BACKUP, snapshotType: "before-party" }]),
+    ],
+    ["negative size", listResponse([{ ...BACKUP, sizeBytes: -1 }])],
+    ["invalid timestamp", listResponse([{ ...BACKUP, createdAt: "soon" }])],
+  ])("renders malformed success (%s) as an error", async (_name, payload) => {
+    apiMock.mockResolvedValue(payload);
+
+    renderPanel();
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(screen.queryByText("No backups yet")).toBeNull();
+  });
+
+  it("accepts every backend snapshot category", async () => {
+    apiMock.mockResolvedValue(
+      listResponse([
+        {
+          ...BACKUP,
+          id: "55555555-5555-4555-8555-555555555555",
+          snapshotType: "auto",
+        },
+        BACKUP,
+        {
+          ...BACKUP,
+          id: "66666666-6666-4666-8666-666666666666",
+          snapshotType: "pre-shutdown",
+        },
+        {
+          ...BACKUP,
+          id: "77777777-7777-4777-8777-777777777777",
+          snapshotType: "pre-delete",
+        },
+        OLD_BACKUP,
+        {
+          ...BACKUP,
+          id: "33333333-3333-4333-8333-333333333333",
+          snapshotType: "pre-upgrade",
+        },
+      ]),
+    );
+
+    renderPanel();
+
+    expect(await screen.findByText("Auto")).toBeTruthy();
+    expect(screen.getByText("Manual")).toBeTruthy();
+    expect(screen.getByText("Pre-shutdown")).toBeTruthy();
+    expect(screen.getByText("Pre-delete")).toBeTruthy();
+    expect(await screen.findByText("Pre-move")).toBeTruthy();
+    expect(screen.getByText("Pre-upgrade")).toBeTruthy();
+  });
+
+  it("aborts the previous agent request and ignores its late response", async () => {
+    const oldRequest = deferred<ReturnType<typeof listResponse>>();
+    let oldSignal: AbortSignal | undefined;
+    apiMock.mockImplementation(
+      (path: string, init?: { signal?: AbortSignal }) => {
+        if (path.includes("agent-old")) {
+          oldSignal = init?.signal;
+          return oldRequest.promise;
+        }
+        return Promise.resolve(
+          listResponse([
+            {
+              ...BACKUP,
+              id: "44444444-4444-4444-8444-444444444444",
+            },
+          ]),
+        );
+      },
+    );
+
+    const view = renderPanel({ agentId: "agent-old" });
+    view.rerender(
+      <ElizaAgentBackupsPanel
+        agentId="agent-new"
+        agentName="New agent"
+        status="running"
+      />,
+    );
+
+    expect(await screen.findByText("Backup ID: 44444444")).toBeTruthy();
+    expect(oldSignal?.aborted).toBe(true);
+
+    await act(async () => {
+      oldRequest.resolve(listResponse([OLD_BACKUP]));
+      await oldRequest.promise;
+    });
+
+    expect(screen.queryByText("Backup ID: 22222222")).toBeNull();
+    expect(screen.getByText("Backup ID: 44444444")).toBeTruthy();
+  });
+
+  it("hides the previous agent's backups before the replacement request settles", async () => {
+    const nextRequest = deferred<ReturnType<typeof listResponse>>();
+    apiMock.mockImplementation((path: string) =>
+      path.includes("agent-new")
+        ? nextRequest.promise
+        : Promise.resolve(listResponse()),
+    );
+
+    const view = renderPanel({ agentId: "agent-old" });
+    expect(await screen.findByText("Backup ID: 11111111")).toBeTruthy();
+
+    view.rerender(
+      <ElizaAgentBackupsPanel
+        agentId="agent-new"
+        agentName="New agent"
+        status="running"
+      />,
+    );
+
+    expect(screen.queryByText("Backup ID: 11111111")).toBeNull();
+    expect(screen.getByRole("status").textContent).toContain("Loading backups");
+
+    await act(async () => {
+      nextRequest.resolve(listResponse([]));
+      await nextRequest.promise;
+    });
+    expect(await screen.findByText("No backups yet")).toBeTruthy();
+  });
+
+  it("aborts an in-flight list request when the panel unmounts", () => {
+    let signal: AbortSignal | undefined;
+    apiMock.mockImplementation(
+      (_path: string, init?: { signal?: AbortSignal }) => {
+        signal = init?.signal;
+        return new Promise(() => undefined);
+      },
+    );
+
+    const view = renderPanel();
+    view.unmount();
+
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it("requires explicit confirmation and cancel performs no restore", async () => {
+    const user = userEvent.setup();
+    apiMock.mockResolvedValue(listResponse());
+    renderPanel();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Restore latest" }),
+    );
+
+    const dialog = await screen.findByRole("alertdialog");
+    expect(within(dialog).getByText("Restore this backup?")).toBeTruthy();
+    expect(apiMock).toHaveBeenCalledTimes(1);
+
+    await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(apiMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides historical restore actions when an agent is stopped", async () => {
+    apiMock.mockResolvedValue(listResponse([OLD_BACKUP, BACKUP]));
+
+    renderPanel({ status: "sleeping" });
+
+    expect(
+      await screen.findByText("Historical restores require a running agent."),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Restore this backup" }),
+    ).toBeNull();
+    expect(screen.getByRole("button", { name: "Restore latest" })).toBeTruthy();
+  });
+
+  it("keeps restore failures visible inside the confirmation dialog", async () => {
+    const user = userEvent.setup();
+    apiMock.mockImplementation((path: string) => {
+      if (path.endsWith("/restore")) {
+        return Promise.reject(new Error("Restore bridge unavailable"));
+      }
+      return Promise.resolve(listResponse());
+    });
+    renderPanel();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Restore latest" }),
+    );
+    const dialog = await screen.findByRole("alertdialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: "Restore backup" }),
+    );
+
+    expect((await within(dialog).findByRole("alert")).textContent).toContain(
+      "Restore bridge unavailable",
+    );
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+    expect(toastMocks.error).toHaveBeenCalledWith("Restore bridge unavailable");
+  });
+
+  it("rejects a malformed restore success and does not refresh the list", async () => {
+    const user = userEvent.setup();
+    apiMock.mockImplementation((path: string) =>
+      Promise.resolve(
+        path.endsWith("/restore")
+          ? { success: true, data: {} }
+          : listResponse(),
+      ),
+    );
+    renderPanel();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Restore latest" }),
+    );
+    const dialog = await screen.findByRole("alertdialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: "Restore backup" }),
+    );
+
+    expect((await within(dialog).findByRole("alert")).textContent).toContain(
+      "Restore response contained an invalid backup result",
+    );
+    expect(apiMock).toHaveBeenCalledTimes(2);
+    expect(toastMocks.success).not.toHaveBeenCalled();
+  });
+
+  it("shows restore progress, refreshes after success, and never reloads the page", async () => {
+    const user = userEvent.setup();
+    const restoreRequest = deferred<ReturnType<typeof restoreResponse>>();
+    apiMock.mockImplementation((path: string) =>
+      path.endsWith("/restore")
+        ? restoreRequest.promise
+        : Promise.resolve(listResponse()),
+    );
+    renderPanel();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Restore latest" }),
+    );
+    const dialog = await screen.findByRole("alertdialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: "Restore backup" }),
+    );
+
+    expect(
+      within(dialog)
+        .getByRole("button", { name: "Restoring…" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(apiMock).toHaveBeenLastCalledWith(
+      "/api/v1/eliza/agents/agent-1/restore",
+      expect.objectContaining({
+        method: "POST",
+        json: { backupId: BACKUP.id },
+        signal: expect.anything(),
+      }),
+    );
+
+    await act(async () => {
+      restoreRequest.resolve(restoreResponse());
+      await restoreRequest.promise;
+    });
+
+    expect(
+      await screen.findByText("Backup restored successfully."),
+    ).toBeTruthy();
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    await waitFor(() => expect(apiMock).toHaveBeenCalledTimes(3));
+    expect(toastMocks.success).toHaveBeenCalledWith(
+      "Backup restored successfully.",
+    );
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
+  it("aborts a restore when the agent changes and suppresses stale success", async () => {
+    const user = userEvent.setup();
+    const restoreRequest = deferred<ReturnType<typeof restoreResponse>>();
+    let restoreSignal: AbortSignal | undefined;
+    apiMock.mockImplementation(
+      (path: string, init?: { signal?: AbortSignal }) => {
+        if (path.endsWith("/restore")) {
+          restoreSignal = init?.signal;
+          return restoreRequest.promise;
+        }
+        if (path.includes("agent-new"))
+          return Promise.resolve(listResponse([]));
+        return Promise.resolve(listResponse());
+      },
+    );
+    const view = renderPanel({ agentId: "agent-old" });
+
+    await user.click(
+      await screen.findByRole("button", { name: "Restore latest" }),
+    );
+    await user.click(
+      within(await screen.findByRole("alertdialog")).getByRole("button", {
+        name: "Restore backup",
+      }),
+    );
+    view.rerender(
+      <ElizaAgentBackupsPanel
+        agentId="agent-new"
+        agentName="New agent"
+        status="running"
+      />,
+    );
+
+    expect(await screen.findByText("No backups yet")).toBeTruthy();
+    expect(restoreSignal?.aborted).toBe(true);
+    await act(async () => {
+      restoreRequest.resolve(restoreResponse());
+      await restoreRequest.promise;
+    });
+
+    expect(screen.queryByText("Backup restored successfully.")).toBeNull();
+    expect(toastMocks.success).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/cloud/instances/components/eliza-agent-backups-panel.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agent-backups-panel.tsx
@@ -1,11 +1,23 @@
 "use client";
 
 /**
- * Backups panel for a cloud agent instance: lists snapshots with sizes/ages and
- * restore actions.
+ * Lists authoritative backup metadata for one cloud agent and confirms restore
+ * requests without allowing superseded agent responses to update the panel.
  */
 import { formatByteSize } from "@elizaos/shared/utils/format";
-import { Badge, BrandButton, BrandCard, Skeleton } from "@elizaos/ui/cloud-ui";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Badge,
+  BrandButton,
+  BrandCard,
+  Skeleton,
+} from "@elizaos/ui/cloud-ui";
 import { formatDistanceToNowStrict } from "date-fns";
 import {
   AlertTriangle,
@@ -15,8 +27,9 @@ import {
   RefreshCw,
   RotateCcw,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { api } from "../../lib/api-client";
 
 interface ElizaAgentBackupsPanelProps {
   agentId: string;
@@ -24,30 +37,142 @@ interface ElizaAgentBackupsPanelProps {
   status: string;
 }
 
+const SNAPSHOT_TYPES = [
+  "auto",
+  "manual",
+  "pre-shutdown",
+  "pre-delete",
+  "pre-upgrade",
+  "pre-move",
+] as const;
+
+type SnapshotType = (typeof SNAPSHOT_TYPES)[number];
+
 interface BackupRecord {
   id: string;
-  snapshotType: "auto" | "manual" | "pre-shutdown";
+  snapshotType: SnapshotType;
   sizeBytes: number | null;
   createdAt: string;
 }
 
-interface BackupsApiResponse {
-  success?: boolean;
-  error?: string;
-  data?: BackupRecord[];
+interface RestoreOutcome {
+  kind: "success" | "error";
+  message: string;
 }
 
-const SNAPSHOT_TYPE_LABELS: Record<BackupRecord["snapshotType"], string> = {
-  auto: "Auto",
-  manual: "Manual",
-  "pre-shutdown": "Pre-shutdown",
+const SNAPSHOT_TYPE_PRESENTATION: Record<
+  SnapshotType,
+  { label: string; className: string }
+> = {
+  auto: {
+    label: "Auto",
+    className: "border-border bg-bg-muted text-muted-strong",
+  },
+  manual: {
+    label: "Manual",
+    className: "border-accent/40 bg-accent-subtle text-accent",
+  },
+  "pre-shutdown": {
+    label: "Pre-shutdown",
+    className: "border-border-strong bg-surface text-txt-strong",
+  },
+  "pre-delete": {
+    label: "Pre-delete",
+    className:
+      "border-status-warning/40 bg-status-warning-bg text-status-warning",
+  },
+  "pre-upgrade": {
+    label: "Pre-upgrade",
+    className:
+      "border-status-warning/40 bg-status-warning-bg text-status-warning",
+  },
+  "pre-move": {
+    label: "Pre-move",
+    className: "border-border-strong bg-surface text-muted-strong",
+  },
 };
 
-const SNAPSHOT_TYPE_STYLES: Record<BackupRecord["snapshotType"], string> = {
-  auto: "border-border bg-bg-muted text-muted-strong",
-  manual: "border-accent/40 bg-accent-subtle text-accent",
-  "pre-shutdown": "border-border-strong bg-surface text-txt-strong",
-};
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSnapshotType(value: unknown): value is SnapshotType {
+  return SNAPSHOT_TYPES.some((snapshotType) => snapshotType === value);
+}
+
+function isValidCreatedAt(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.includes("T") &&
+    Number.isFinite(Date.parse(value))
+  );
+}
+
+function parseBackupRecord(value: unknown): BackupRecord {
+  if (
+    !isRecord(value) ||
+    typeof value.id !== "string" ||
+    value.id.trim().length === 0 ||
+    !isSnapshotType(value.snapshotType) ||
+    !(
+      value.sizeBytes === null ||
+      (typeof value.sizeBytes === "number" &&
+        Number.isSafeInteger(value.sizeBytes) &&
+        value.sizeBytes >= 0)
+    ) ||
+    !isValidCreatedAt(value.createdAt)
+  ) {
+    throw new Error("Backup response contained an invalid backup record");
+  }
+
+  return {
+    id: value.id,
+    snapshotType: value.snapshotType,
+    sizeBytes: value.sizeBytes,
+    createdAt: value.createdAt,
+  };
+}
+
+function parseBackupsResponse(payload: unknown): BackupRecord[] {
+  if (
+    !isRecord(payload) ||
+    payload.success !== true ||
+    !Array.isArray(payload.data)
+  ) {
+    throw new Error("Backup response did not include a successful data list");
+  }
+  return payload.data.map(parseBackupRecord);
+}
+
+function parseRestoreResponse(
+  payload: unknown,
+  expectedBackupId: string,
+): void {
+  if (
+    !isRecord(payload) ||
+    payload.success !== true ||
+    !isRecord(payload.data)
+  ) {
+    throw new Error("Restore response did not include a successful result");
+  }
+
+  const { restoredFromBackupId, snapshotType, createdAt } = payload.data;
+  if (
+    restoredFromBackupId !== expectedBackupId ||
+    !isSnapshotType(snapshotType) ||
+    !isValidCreatedAt(createdAt)
+  ) {
+    throw new Error("Restore response contained an invalid backup result");
+  }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
 function formatTimestamp(value: string): {
   absolute: string;
@@ -66,117 +191,178 @@ export function ElizaAgentBackupsPanel({
   status,
 }: ElizaAgentBackupsPanelProps) {
   const [backups, setBackups] = useState<BackupRecord[]>([]);
+  const [listAgentId, setListAgentId] = useState(agentId);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [restoreTarget, setRestoreTarget] = useState<BackupRecord | null>(null);
   const [activeRestoreTarget, setActiveRestoreTarget] = useState<string | null>(
     null,
   );
+  const [restoreOutcome, setRestoreOutcome] = useState<RestoreOutcome | null>(
+    null,
+  );
+  const listGenerationRef = useRef(0);
+  const listAbortRef = useRef<AbortController | null>(null);
+  const restoreGenerationRef = useRef(0);
+  const restoreAbortRef = useRef<AbortController | null>(null);
 
   const isRunning = status === "running";
   const isBusy = status === "provisioning";
 
   const fetchBackups = useCallback(async () => {
+    const generation = ++listGenerationRef.current;
+    listAbortRef.current?.abort();
+    const controller = new AbortController();
+    listAbortRef.current = controller;
     setLoading(true);
     setError(null);
 
     try {
-      const response = await fetch(`/api/v1/eliza/agents/${agentId}/backups`, {
-        cache: "no-store",
-      });
-      const payload: BackupsApiResponse = await response
-        .json()
-        .catch(() => ({}));
-
-      if (!response.ok || !payload.success) {
-        throw new Error(payload.error ?? `HTTP ${response.status}`);
+      const payload = await api<unknown>(
+        `/api/v1/eliza/agents/${agentId}/backups`,
+        { cache: "no-store", signal: controller.signal },
+      );
+      const nextBackups = parseBackupsResponse(payload);
+      if (
+        controller.signal.aborted ||
+        generation !== listGenerationRef.current
+      ) {
+        return;
       }
 
-      setBackups(Array.isArray(payload.data) ? payload.data : []);
-    } catch (fetchError) {
-      setError(
-        fetchError instanceof Error ? fetchError.message : String(fetchError),
+      setBackups(nextBackups);
+      setListAgentId(agentId);
+      setRestoreTarget((target) =>
+        target
+          ? (nextBackups.find((backup) => backup.id === target.id) ?? null)
+          : null,
       );
+    } catch (fetchError) {
+      // error-policy:J4 only the active agent request reaches the visible
+      // panel error; aborted and superseded requests remain invisible.
+      if (
+        controller.signal.aborted ||
+        generation !== listGenerationRef.current ||
+        isAbortError(fetchError)
+      ) {
+        return;
+      }
+      setError(errorMessage(fetchError));
+      setListAgentId(agentId);
     } finally {
-      setLoading(false);
+      if (generation === listGenerationRef.current) setLoading(false);
     }
   }, [agentId]);
 
   useEffect(() => {
-    fetchBackups();
+    setBackups([]);
+    setError(null);
+    setLoading(true);
+    setRestoreTarget(null);
+    setActiveRestoreTarget(null);
+    setRestoreOutcome(null);
+    void fetchBackups();
+
+    return () => {
+      listGenerationRef.current += 1;
+      restoreGenerationRef.current += 1;
+      listAbortRef.current?.abort();
+      restoreAbortRef.current?.abort();
+    };
   }, [fetchBackups]);
 
+  const visibleBackups = listAgentId === agentId ? backups : [];
   const latestBackup = useMemo(
     () =>
-      backups.reduce<BackupRecord | null>((latest, backup) => {
+      visibleBackups.reduce<BackupRecord | null>((latest, backup) => {
         if (!latest) return backup;
-        return new Date(backup.createdAt) > new Date(latest.createdAt)
+        return Date.parse(backup.createdAt) > Date.parse(latest.createdAt)
           ? backup
           : latest;
       }, null),
-    [backups],
+    [visibleBackups],
   );
   const manualCount = useMemo(
-    () => backups.filter((backup) => backup.snapshotType === "manual").length,
-    [backups],
+    () =>
+      visibleBackups.filter((backup) => backup.snapshotType === "manual")
+        .length,
+    [visibleBackups],
   );
   const preShutdownCount = useMemo(
     () =>
-      backups.filter((backup) => backup.snapshotType === "pre-shutdown").length,
-    [backups],
+      visibleBackups.filter((backup) => backup.snapshotType === "pre-shutdown")
+        .length,
+    [visibleBackups],
   );
 
-  const restoreBackup = useCallback(
-    async (backupId?: string) => {
-      if (!latestBackup) {
-        toast.error("No backups available to restore");
+  const restoreBackup = useCallback(async () => {
+    if (!restoreTarget || isBusy) return;
+    if (!isRunning && restoreTarget.id !== latestBackup?.id) {
+      setRestoreOutcome({
+        kind: "error",
+        message: "Stopped agents can only restore the latest backup",
+      });
+      return;
+    }
+
+    const generation = ++restoreGenerationRef.current;
+    restoreAbortRef.current?.abort();
+    const controller = new AbortController();
+    restoreAbortRef.current = controller;
+    setActiveRestoreTarget(restoreTarget.id);
+    setRestoreOutcome(null);
+
+    try {
+      const payload = await api<unknown>(
+        `/api/v1/eliza/agents/${agentId}/restore`,
+        {
+          method: "POST",
+          json: { backupId: restoreTarget.id },
+          signal: controller.signal,
+        },
+      );
+      parseRestoreResponse(payload, restoreTarget.id);
+      if (
+        controller.signal.aborted ||
+        generation !== restoreGenerationRef.current
+      ) {
         return;
       }
 
-      if (!isRunning && backupId && backupId !== latestBackup.id) {
-        toast.error("Stopped agents can only restore the latest backup");
+      const message = "Backup restored successfully.";
+      setRestoreOutcome({ kind: "success", message });
+      setRestoreTarget(null);
+      toast.success(message);
+      void fetchBackups();
+    } catch (restoreError) {
+      // error-policy:J4 restore failure stays inside its confirmation boundary;
+      // an agent switch or unmount aborts it without leaking stale feedback.
+      if (
+        controller.signal.aborted ||
+        generation !== restoreGenerationRef.current ||
+        isAbortError(restoreError)
+      ) {
         return;
       }
-
-      const targetBackupId = backupId ?? latestBackup.id;
-      setActiveRestoreTarget(targetBackupId);
-
-      try {
-        const response = await fetch(
-          `/api/v1/eliza/agents/${agentId}/restore`,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(backupId ? { backupId } : {}),
-          },
-        );
-        const payload = await response.json().catch(() => ({}));
-
-        if (!response.ok || !(payload as { success?: boolean }).success) {
-          throw new Error(
-            (payload as { error?: string }).error ?? `HTTP ${response.status}`,
-          );
-        }
-
-        toast.success(
-          isRunning
-            ? "Backup restored"
-            : "Latest backup restored. The agent was restarted with that state.",
-        );
-
-        await fetchBackups();
-        window.location.reload();
-      } catch (restoreError) {
-        toast.error(
-          restoreError instanceof Error
-            ? restoreError.message
-            : String(restoreError),
-        );
-      } finally {
+      const message = errorMessage(restoreError);
+      setRestoreOutcome({ kind: "error", message });
+      toast.error(message);
+    } finally {
+      if (generation === restoreGenerationRef.current) {
         setActiveRestoreTarget(null);
       }
-    },
-    [agentId, fetchBackups, isRunning, latestBackup],
-  );
+    }
+  }, [agentId, fetchBackups, isBusy, isRunning, latestBackup, restoreTarget]);
+
+  const restoreDisallowed =
+    !restoreTarget ||
+    isBusy ||
+    (!isRunning && restoreTarget.id !== latestBackup?.id);
+
+  function requestRestore(backup: BackupRecord) {
+    setRestoreOutcome(null);
+    setRestoreTarget(backup);
+  }
 
   return (
     <BrandCard className="relative" cornerSize="sm">
@@ -184,7 +370,10 @@ export function ElizaAgentBackupsPanel({
         <div className="flex flex-col gap-4 border-b border-border pb-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
             <div className="mb-1 flex flex-wrap items-center gap-2">
-              <span className="inline-block h-2 w-2 rounded-full bg-accent" />
+              <span
+                aria-hidden="true"
+                className="inline-block h-2 w-2 rounded-full bg-accent"
+              />
               <h2 className="font-mono text-xl font-normal text-txt-strong">
                 Backups &amp; History
               </h2>
@@ -200,8 +389,14 @@ export function ElizaAgentBackupsPanel({
           </div>
 
           <div className="flex flex-wrap items-center gap-2">
-            <BrandButton variant="outline" size="sm" onClick={fetchBackups}>
+            <BrandButton
+              variant="outline"
+              size="sm"
+              onClick={() => void fetchBackups()}
+              disabled={loading}
+            >
               <RefreshCw
+                aria-hidden="true"
                 className={`h-4 w-4 ${loading ? "animate-spin" : ""}`}
               />
               Refresh
@@ -209,22 +404,38 @@ export function ElizaAgentBackupsPanel({
             <BrandButton
               variant="outline"
               size="sm"
-              onClick={() => restoreBackup()}
-              disabled={!latestBackup || !!activeRestoreTarget || isBusy}
+              onClick={() => {
+                if (latestBackup) requestRestore(latestBackup);
+              }}
+              disabled={
+                loading || !latestBackup || !!activeRestoreTarget || isBusy
+              }
             >
               {activeRestoreTarget === latestBackup?.id ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
+                <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
               ) : (
-                <RotateCcw className="h-4 w-4" />
+                <RotateCcw aria-hidden="true" className="h-4 w-4" />
               )}
               Restore latest
             </BrandButton>
           </div>
         </div>
 
-        {!isRunning && latestBackup && (
+        {restoreOutcome?.kind === "success" ? (
+          <div
+            className="border border-status-success/30 bg-status-success-bg p-4 text-sm text-status-success"
+            role="status"
+          >
+            {restoreOutcome.message}
+          </div>
+        ) : null}
+
+        {!isRunning && latestBackup ? (
           <div className="flex items-start gap-3 border border-status-warning/30 bg-status-warning-bg p-4">
-            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-status-warning" />
+            <AlertTriangle
+              aria-hidden="true"
+              className="mt-0.5 h-4 w-4 shrink-0 text-status-warning"
+            />
             <div className="space-y-1">
               <p className="text-sm text-status-warning">
                 This agent is not currently running.
@@ -236,20 +447,24 @@ export function ElizaAgentBackupsPanel({
               </p>
             </div>
           </div>
-        )}
+        ) : null}
 
-        {isBusy && (
+        {isBusy ? (
           <div className="flex items-start gap-3 border border-border-strong bg-bg-muted p-4">
-            <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin text-muted-strong" />
+            <Loader2
+              aria-hidden="true"
+              className="mt-0.5 h-4 w-4 shrink-0 animate-spin text-muted-strong"
+            />
             <p className="text-sm text-txt-strong">
               Provisioning is in progress. Wait for the agent to finish starting
               before restoring.
             </p>
           </div>
-        )}
+        ) : null}
 
-        {loading ? (
-          <div className="space-y-4">
+        {loading || listAgentId !== agentId ? (
+          <div className="space-y-4" role="status" aria-live="polite">
+            <span className="sr-only">Loading backups</span>
             <div className="grid gap-4 md:grid-cols-3">
               <Skeleton className="h-24 rounded-sm" />
               <Skeleton className="h-24 rounded-sm" />
@@ -259,25 +474,31 @@ export function ElizaAgentBackupsPanel({
             <Skeleton className="h-16 rounded-sm" />
           </div>
         ) : error ? (
-          <div className="py-8 text-center">
-            <History className="mx-auto mb-3 h-8 w-8 text-muted" />
+          <div className="py-8 text-center" role="alert">
+            <History
+              aria-hidden="true"
+              className="mx-auto mb-3 h-8 w-8 text-muted"
+            />
             <p className="mb-1 text-sm text-destructive">
               Failed to load backups
             </p>
-            <p className="text-xs text-muted">{error}</p>
+            <p className="break-words text-xs text-muted">{error}</p>
             <BrandButton
               variant="outline"
               size="sm"
-              onClick={fetchBackups}
+              onClick={() => void fetchBackups()}
               className="mt-4"
             >
-              <RefreshCw className="mr-2 h-4 w-4" />
+              <RefreshCw aria-hidden="true" className="mr-2 h-4 w-4" />
               Retry
             </BrandButton>
           </div>
-        ) : backups.length === 0 ? (
+        ) : visibleBackups.length === 0 ? (
           <div className="py-10 text-center">
-            <DatabaseBackup className="mx-auto mb-3 h-8 w-8 text-muted" />
+            <DatabaseBackup
+              aria-hidden="true"
+              className="mx-auto mb-3 h-8 w-8 text-muted"
+            />
             <p className="text-sm text-muted-strong">No backups yet</p>
             <p className="mt-1 text-xs text-muted">
               Run the agent and save a snapshot to create the first restore
@@ -289,7 +510,7 @@ export function ElizaAgentBackupsPanel({
             <div className="grid gap-4 md:grid-cols-3">
               <div className="border border-border bg-bg-muted p-4 text-center">
                 <p className="font-mono text-2xl font-medium text-txt-strong">
-                  {backups.length}
+                  {visibleBackups.length}
                 </p>
                 <p className="mt-1 font-mono text-xs uppercase tracking-wider text-muted-strong">
                   Total backups
@@ -314,10 +535,12 @@ export function ElizaAgentBackupsPanel({
             </div>
 
             <div className="space-y-3">
-              {backups.map((backup) => {
+              {visibleBackups.map((backup) => {
                 const timestamp = formatTimestamp(backup.createdAt);
                 const isLatest = backup.id === latestBackup?.id;
                 const isRestoring = activeRestoreTarget === backup.id;
+                const presentation =
+                  SNAPSHOT_TYPE_PRESENTATION[backup.snapshotType];
 
                 return (
                   <div
@@ -327,21 +550,19 @@ export function ElizaAgentBackupsPanel({
                     <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
                       <div className="min-w-0 space-y-2">
                         <div className="flex flex-wrap items-center gap-2">
-                          {isLatest && (
+                          {isLatest ? (
                             <Badge
                               variant="outline"
                               className="border-status-success/40 bg-status-success-bg text-status-success"
                             >
                               Latest
                             </Badge>
-                          )}
+                          ) : null}
                           <Badge
                             variant="outline"
-                            className={
-                              SNAPSHOT_TYPE_STYLES[backup.snapshotType]
-                            }
+                            className={presentation.className}
                           >
-                            {SNAPSHOT_TYPE_LABELS[backup.snapshotType]}
+                            {presentation.label}
                           </Badge>
                         </div>
 
@@ -371,13 +592,19 @@ export function ElizaAgentBackupsPanel({
                           <BrandButton
                             variant="outline"
                             size="sm"
-                            onClick={() => restoreBackup(backup.id)}
-                            disabled={!!activeRestoreTarget}
+                            onClick={() => requestRestore(backup)}
+                            disabled={loading || !!activeRestoreTarget}
                           >
                             {isRestoring ? (
-                              <Loader2 className="h-4 w-4 animate-spin" />
+                              <Loader2
+                                aria-hidden="true"
+                                className="h-4 w-4 animate-spin"
+                              />
                             ) : (
-                              <RotateCcw className="h-4 w-4" />
+                              <RotateCcw
+                                aria-hidden="true"
+                                className="h-4 w-4"
+                              />
                             )}
                             Restore this backup
                           </BrandButton>
@@ -400,6 +627,64 @@ export function ElizaAgentBackupsPanel({
           </>
         )}
       </div>
+
+      <AlertDialog
+        open={restoreTarget !== null && listAgentId === agentId}
+        onOpenChange={(open) => {
+          if (!open && !activeRestoreTarget) {
+            setRestoreTarget(null);
+            setRestoreOutcome(null);
+          }
+        }}
+      >
+        <AlertDialogContent className="border-border bg-card">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-txt-strong">
+              Restore this backup?
+            </AlertDialogTitle>
+            <AlertDialogDescription className="text-muted">
+              This replaces the current state for {agentName || "this agent"}
+              {restoreTarget ? (
+                <span className="mt-2 block font-mono text-xs text-muted-strong">
+                  {SNAPSHOT_TYPE_PRESENTATION[restoreTarget.snapshotType].label}{" "}
+                  backup from{" "}
+                  {formatTimestamp(restoreTarget.createdAt).absolute}
+                </span>
+              ) : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          {restoreOutcome?.kind === "error" ? (
+            <div
+              className="border border-destructive/20 bg-destructive-subtle p-3 text-sm text-destructive"
+              role="alert"
+            >
+              {restoreOutcome.message}
+            </div>
+          ) : null}
+
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              className="border-border bg-transparent text-txt hover:bg-surface"
+              disabled={!!activeRestoreTarget}
+            >
+              Cancel
+            </AlertDialogCancel>
+            <BrandButton
+              type="button"
+              onClick={() => void restoreBackup()}
+              disabled={restoreDisallowed || !!activeRestoreTarget}
+            >
+              {activeRestoreTarget ? (
+                <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
+              ) : (
+                <RotateCcw aria-hidden="true" className="h-4 w-4" />
+              )}
+              {activeRestoreTarget ? "Restoring…" : "Restore backup"}
+            </BrandButton>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </BrandCard>
   );
 }


### PR DESCRIPTION
## Outcome

The signed-in backup panel now treats the backend list/restore responses as authoritative state.

- supports all six backend `AgentBackupSnapshotType` values
- fail-closes malformed list and restore envelopes
- keeps loading, designed-empty, error, and busy states distinct
- generation- and agent-fences stale list/restore completions
- confirms restore, validates success, then refreshes the authoritative list

No backend route, Shared runtime, scheduler, gateway, deployment, or provider behavior changes.

## Exact revision

<!-- evidence-head:694aa287e6ac716142a3234e98005c028e58b47e -->

- head: `694aa287e6ac716142a3234e98005c028e58b47e`
- base: `ade51f1fb767d8a92d0272f25428bb132aec5b64`
- scope: panel plus its co-located test

## Verification

- exact patch replay: focused Vitest 20/20 passed
- `packages/ui` typecheck passed
- exact Biome and diff-check passed
- latest-base integrated affected UI suite: 269/269 passed

## Evidence status

The previously attached artifact set is **not exact-current evidence**: its frontend log identifies renderer build `4c11af0331e0`, not this PR head, and it uses a localhost fixture without backend logs. It remains useful diagnostic material only.

Required before ready/merge:

- hosted exact-head checks
- rebuild/install this exact revision
- recapture signed-in desktop/mobile screenshots and walkthrough
- attach matching frontend/network logs and backend logs for the exercised restore path

The component aborts and fences stale UI state, but native Electrobun `apiFetch` does not currently forward `AbortSignal`; this PR therefore claims UI/result fencing, not native transport cancellation. This PR remains draft.

AI assistance: OpenAI / gpt-5.6-sol via Codex Desktop. Attribution is self-reported; no signed contribution receipt is claimed.
