### PR TITLE
feat(desktop): first-class cloud-only consumer build lane

### DIFF
--- a/packages/app-core/platforms/electrobun/.generated/brand-config.json
+++ b/packages/app-core/platforms/electrobun/.generated/brand-config.json
@@ -1,9 +1,10 @@
 {
 	"appName": "Eliza",
 	"appId": "ai.elizaos.app",
-	"namespace": "eliza",
+	"namespace": "elizaos",
 	"urlScheme": "elizaos",
 	"configDirName": "Eliza",
 	"appDescription": "Open framework for autonomous agents",
-	"buildVariant": "direct"
+	"buildVariant": "direct",
+	"cloudOnly": true
 }

--- a/packages/app-core/platforms/electrobun/electrobun.config.ts
+++ b/packages/app-core/platforms/electrobun/electrobun.config.ts
@@ -54,6 +54,11 @@ export function shouldEmbedRuntimeBundle(
       return false;
     }
   }
+  // Cloud-only consumer builds never run a local agent, so shipping the
+  // multi-GB runtime tree would be pure download weight.
+  if (isTruthyEnv(env.ELIZA_DESKTOP_CLOUD_ONLY)) {
+    return false;
+  }
   return !isTruthyEnv(env.ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT);
 }
 
@@ -466,13 +471,15 @@ function resolveBrandConfigCopySource({
   const explicitConfigPath = trimEnv("ELIZA_BRAND_CONFIG_PATH");
   const namespace = trimEnv("ELIZA_NAMESPACE");
   const appDescription = trimEnv("ELIZA_APP_DESCRIPTION");
+  const cloudOnly = isTruthyEnv(process.env.ELIZA_DESKTOP_CLOUD_ONLY);
   const hasBrandOverride = Boolean(
     explicitConfigPath ||
       trimEnv("ELIZA_APP_NAME") ||
       trimEnv("ELIZA_APP_ID") ||
       trimEnv("ELIZA_URL_SCHEME") ||
       namespace ||
-      appDescription,
+      appDescription ||
+      cloudOnly,
   );
 
   if (!hasBrandOverride) {
@@ -496,6 +503,7 @@ function resolveBrandConfigCopySource({
     urlScheme,
     buildVariant:
       process.env.ELIZA_BUILD_VARIANT === "store" ? "store" : "direct",
+    ...(cloudOnly ? { cloudOnly: true } : {}),
     namespace: namespace || fileConfig.namespace || "elizaos",
     configDirName,
     ...(appDescription

--- a/packages/app-core/platforms/electrobun/src/api-base.test.ts
+++ b/packages/app-core/platforms/electrobun/src/api-base.test.ts
@@ -116,6 +116,32 @@ describe("resolveDesktopRuntimeModeWithDeployment — three topologies", () => {
     expect(resolution.externalApi.base).toBe("http://127.0.0.1:9999");
     expect(resolution.externalApi.source).toBe("ELIZA_DESKTOP_API_BASE");
   });
+
+  it("consumer bundle: skip-embedded env + a connected cloud deployment resolves external, not disabled", () => {
+    const resolution = resolveDesktopRuntimeModeWithDeployment(
+      { ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT: "1" },
+      cloudDeployment,
+    );
+    expect(resolution.mode).toBe("external");
+    expect(resolution.externalApi.base).toBe(CLOUD_AGENT_URL);
+  });
+
+  it("consumer bundle: skip-embedded env with no cloud deployment stays disabled (nothing to point at)", () => {
+    const resolution = resolveDesktopRuntimeModeWithDeployment(
+      { ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT: "1" },
+      null,
+    );
+    expect(resolution.mode).toBe("disabled");
+    expect(resolution.externalApi.base).toBeNull();
+  });
+
+  it("consumer bundle: skip-embedded env with an unresolvable cloud deployment stays disabled", () => {
+    const resolution = resolveDesktopRuntimeModeWithDeployment(
+      { ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT: "1" },
+      { runtime: "cloud", remoteApiBase: null },
+    );
+    expect(resolution.mode).toBe("disabled");
+  });
 });
 
 describe("resolveCloudHostedAgentApiBase — precedence + validation", () => {

--- a/packages/app-core/platforms/electrobun/src/api-base.ts
+++ b/packages/app-core/platforms/electrobun/src/api-base.ts
@@ -149,13 +149,17 @@ export function resolveCloudHostedAgentApiBase(
  * Topology-aware runtime-mode resolution. Layers the persisted deployment
  * target on top of the pure env resolver ({@link resolveDesktopRuntimeMode}):
  *
- * - If env already forces `external`/`disabled`, that wins (unchanged).
+ * - If env forces `external` (an explicit API base), that wins (unchanged).
  * - Else, if the persisted deployment is a cloud-hosted (`runtime: "cloud"`) or
  *   external (`runtime: "remote"`) agent AND a renderer-ready agent API base is
  *   resolvable (env override or the persisted `remoteApiBase`), resolve to
  *   `external` with that base so the embedded agent is skipped and the renderer
- *   points at the cloud/external agent (topology 3).
- * - Otherwise fall through to the env result (`local`).
+ *   points at the cloud/external agent (topology 3). This deliberately
+ *   outranks an env `disabled` (`ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT=1`): a
+ *   runtime-less consumer/store bundle boots with the skip flag baked in, and
+ *   once the user has connected a cloud agent the renderer must be pointed at
+ *   it rather than at a dead loopback port.
+ * - Otherwise fall through to the env result (`local`/`disabled`).
  *
  * Topology 1 (local agent → cloud inference; persisted runtime is `"local"`,
  * branded cloud via {@link resolveDesktopRuntimeModeSignal}) and topology 2
@@ -166,7 +170,7 @@ export function resolveDesktopRuntimeModeWithDeployment(
   deployment: PersistedDeployment | null,
 ): DesktopRuntimeModeResolution {
   const envResolution = resolveDesktopRuntimeMode(env);
-  if (envResolution.mode !== "local") {
+  if (envResolution.mode === "external") {
     return envResolution;
   }
 

--- a/packages/app-core/platforms/electrobun/src/brand-config.test.ts
+++ b/packages/app-core/platforms/electrobun/src/brand-config.test.ts
@@ -23,6 +23,21 @@ describe("desktop brand config", () => {
     resetBrandConfigForTests();
   });
 
+  it("reads cloudOnly from a packaged brand file and defaults it off", () => {
+    expect(getBrandConfig().cloudOnly).toBe(false);
+
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "brand-config-"));
+    const file = path.join(dir, "brand-config.json");
+    fs.writeFileSync(
+      file,
+      `${JSON.stringify({ appName: "Eliza", cloudOnly: true })}\n`,
+    );
+    process.env.ELIZA_BRAND_CONFIG_PATH = file;
+    resetBrandConfigForTests();
+
+    expect(getBrandConfig().cloudOnly).toBe(true);
+  });
+
   it("does not let the shared eliza namespace default override a packaged brand file", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "brand-config-"));
     const file = path.join(dir, "brand-config.json");

--- a/packages/app-core/platforms/electrobun/src/brand-config.ts
+++ b/packages/app-core/platforms/electrobun/src/brand-config.ts
@@ -25,6 +25,13 @@ export interface DesktopBrandConfig {
   releaseUrl: string;
   /** Distribution build variant. Store builds must not self-update. */
   buildVariant: "direct" | "store";
+  /**
+   * Cloud-only consumer distribution: the bundle ships without the embedded
+   * agent runtime and the shell runs against Eliza Cloud. Baked in at package
+   * time (`ELIZA_DESKTOP_CLOUD_ONLY=1`); the main process hydrates the
+   * corresponding runtime env flags from this at boot.
+   */
+  cloudOnly: boolean;
   /** Config export file name. */
   configExportFileName: string;
   /** User-facing description. */
@@ -67,6 +74,16 @@ function env(key: string): string {
   return (process.env[key] ?? "").trim();
 }
 
+function isTruthyFlag(value: string): boolean {
+  const normalized = value.toLowerCase();
+  return (
+    normalized === "1" ||
+    normalized === "true" ||
+    normalized === "yes" ||
+    normalized === "on"
+  );
+}
+
 function envFallback(...keys: string[]): string {
   for (const key of keys) {
     const val = env(key);
@@ -106,6 +123,7 @@ const DEFAULT_CONFIG: DesktopBrandConfig = {
   urlScheme: "elizaos",
   releaseUrl: "",
   buildVariant: "direct",
+  cloudOnly: false,
   configExportFileName: "eliza-config.json",
   appDescription: "AI agents for the desktop",
   namespace: "eliza",
@@ -171,6 +189,9 @@ function resolveBrandConfig(): DesktopBrandConfig {
       fileConfig.buildVariant === "store"
         ? "store"
         : "direct",
+    cloudOnly:
+      isTruthyFlag(envFallback("ELIZA_DESKTOP_CLOUD_ONLY")) ||
+      fileConfig.cloudOnly === true,
     configExportFileName:
       fileConfig.configExportFileName ??
       `${appName.toLowerCase().replace(/\s+/g, "-")}-config.json`,

--- a/packages/app-core/platforms/electrobun/src/cloud-only-boot.test.ts
+++ b/packages/app-core/platforms/electrobun/src/cloud-only-boot.test.ts
@@ -1,0 +1,43 @@
+/** Exercises cloud-only env hydration with deterministic app-core test fixtures. */
+import { describe, expect, it } from "vitest";
+import { hydrateCloudOnlyEnv } from "./cloud-only-boot";
+
+describe("hydrateCloudOnlyEnv", () => {
+  it("raises both cloud-only env flags for a cloud-only brand", () => {
+    const env: Record<string, string | undefined> = {};
+    const result = hydrateCloudOnlyEnv(true, env);
+    expect(env.ELIZA_DESKTOP_CLOUD_ONLY).toBe("1");
+    expect(env.ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT).toBe("1");
+    expect(result.applied.sort()).toEqual([
+      "ELIZA_DESKTOP_CLOUD_ONLY",
+      "ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT",
+    ]);
+  });
+
+  it("is a no-op for a non-cloud-only brand", () => {
+    const env: Record<string, string | undefined> = {};
+    const result = hydrateCloudOnlyEnv(false, env);
+    expect(env).toEqual({});
+    expect(result.applied).toEqual([]);
+  });
+
+  it("never overwrites explicit operator env — even a falsy opt-out", () => {
+    const env: Record<string, string | undefined> = {
+      ELIZA_DESKTOP_CLOUD_ONLY: "0",
+      ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT: "0",
+    };
+    const result = hydrateCloudOnlyEnv(true, env);
+    expect(env.ELIZA_DESKTOP_CLOUD_ONLY).toBe("0");
+    expect(env.ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT).toBe("0");
+    expect(result.applied).toEqual([]);
+  });
+
+  it("fills only the missing flag when one is already set", () => {
+    const env: Record<string, string | undefined> = {
+      ELIZA_DESKTOP_CLOUD_ONLY: "1",
+    };
+    const result = hydrateCloudOnlyEnv(true, env);
+    expect(result.applied).toEqual(["ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT"]);
+    expect(env.ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT).toBe("1");
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/cloud-only-boot.ts
+++ b/packages/app-core/platforms/electrobun/src/cloud-only-boot.ts
@@ -1,0 +1,45 @@
+/**
+ * Promotes a packaged cloud-only brand flag into the runtime env contract.
+ *
+ * Cloud-only consumer bundles are produced with `ELIZA_DESKTOP_CLOUD_ONLY=1`,
+ * which bakes `cloudOnly: true` into the shipped `brand-config.json` and drops
+ * the embedded runtime tree from the package. The packaged app launches with a
+ * clean env, so at boot the flag must be re-raised as the env vars every
+ * existing decision point already reads: `ELIZA_DESKTOP_CLOUD_ONLY` (the
+ * cloud-only renderer branding signal in `resolveDesktopRuntimeModeSignal`)
+ * and `ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT` (the runtime-mode resolver's
+ * `disabled` state — there is no runtime dist in the bundle to spawn). Env
+ * values an operator set explicitly always win; this only fills gaps.
+ */
+
+export interface CloudOnlyEnvHydration {
+  /** Env keys this call actually set (empty when nothing changed). */
+  applied: string[];
+}
+
+/**
+ * Raise the cloud-only env flags from the packaged brand config. Idempotent
+ * and non-destructive: keys already present in the env (even set to an
+ * explicit falsy opt-out) are left untouched.
+ */
+export function hydrateCloudOnlyEnv(
+  brandCloudOnly: boolean,
+  env: Record<string, string | undefined> = process.env as Record<
+    string,
+    string | undefined
+  >,
+): CloudOnlyEnvHydration {
+  if (!brandCloudOnly) {
+    return { applied: [] };
+  }
+  const applied: string[] = [];
+  if (env.ELIZA_DESKTOP_CLOUD_ONLY === undefined) {
+    env.ELIZA_DESKTOP_CLOUD_ONLY = "1";
+    applied.push("ELIZA_DESKTOP_CLOUD_ONLY");
+  }
+  if (env.ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT === undefined) {
+    env.ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT = "1";
+    applied.push("ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT");
+  }
+  return { applied };
+}

--- a/packages/app-core/platforms/electrobun/src/cloud-only-token-hygiene.test.ts
+++ b/packages/app-core/platforms/electrobun/src/cloud-only-token-hygiene.test.ts
@@ -1,0 +1,53 @@
+/** Exercises cloud-only local-API-token hygiene with deterministic app-core test fixtures. */
+/*
+ * Pins the token invariants behind `injectApiBase`'s "disabled" branch in
+ * src/index.ts (a non-exported composition-root function; the load-bearing
+ * comment lives there): when the desktop runs the runtime-less cloud-only
+ * consumer bundle (ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT=1), that branch must
+ * NEVER call configureDesktopLocalApiAuth(). Minting a local API token there
+ * pushes it to the renderer, whose getCloudAuthToken falls back to it as a
+ * fake Cloud credential and silently skips interactive sign-in. These tests
+ * prove the seam that makes the fix hold: the disabled mode resolves from the
+ * env flag alone, a token-free env resolves to NO token, and the only thing
+ * that mints ELIZA_API_TOKEN is an explicit ensureDesktopApiToken call.
+ */
+import { resolveApiToken } from "@elizaos/shared";
+import { describe, expect, it } from "vitest";
+import { resolveDesktopRuntimeMode } from "./api-base";
+import { ensureDesktopApiToken } from "./native/agent";
+
+describe("cloud-only token hygiene", () => {
+  it("resolves the skip-embedded-agent flag to the disabled runtime mode", () => {
+    const resolution = resolveDesktopRuntimeMode({
+      ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT: "1",
+    });
+    expect(resolution.mode).toBe("disabled");
+  });
+
+  it("resolves NO api token from a disabled-mode env without ELIZA_API_TOKEN", () => {
+    // This is exactly what injectApiBase's disabled branch publishes to the
+    // renderer: resolveApiToken(env) with nothing minted — so the renderer's
+    // cloud resolver has no fake local credential to fall back to.
+    expect(
+      resolveApiToken({ ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT: "1" }),
+    ).toBeNull();
+    expect(resolveApiToken({})).toBeNull();
+  });
+
+  it("mints a token only via an explicit ensureDesktopApiToken call", () => {
+    const env: NodeJS.ProcessEnv = {};
+    expect(resolveApiToken(env)).toBeNull();
+
+    const minted = ensureDesktopApiToken(env);
+
+    expect(minted).not.toBe("");
+    expect(env.ELIZA_API_TOKEN).toBe(minted);
+    expect(resolveApiToken(env)).toBe(minted);
+  });
+
+  it("never overwrites an operator-provided token when minting", () => {
+    const env: NodeJS.ProcessEnv = { ELIZA_API_TOKEN: "operator-token" };
+    expect(ensureDesktopApiToken(env)).toBe("operator-token");
+    expect(env.ELIZA_API_TOKEN).toBe("operator-token");
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts
@@ -123,11 +123,13 @@ describe("desktop bottom-bar config", () => {
         mode: "bottom-bar",
         titleBarStyle: "hidden",
         transparent: false,
+        nativeShadow: false,
       });
       expect(resolveDesktopShellWindowPresentation({}, [], "darwin")).toEqual({
         mode: "bottom-bar",
         titleBarStyle: "hidden",
         transparent: true,
+        nativeShadow: false,
       });
     });
 
@@ -142,6 +144,7 @@ describe("desktop bottom-bar config", () => {
         mode: "default",
         titleBarStyle: "default",
         transparent: false,
+        nativeShadow: true,
       });
       expect(
         resolveDesktopShellWindowPresentation(
@@ -153,6 +156,7 @@ describe("desktop bottom-bar config", () => {
         mode: "default",
         titleBarStyle: "hiddenInset",
         transparent: false,
+        nativeShadow: true,
       });
     });
 
@@ -170,6 +174,7 @@ describe("desktop bottom-bar config", () => {
         mode: "kiosk",
         titleBarStyle: "hidden",
         transparent: false,
+        nativeShadow: false,
       });
     });
   });

--- a/packages/app-core/platforms/electrobun/src/electrobun-config.test.ts
+++ b/packages/app-core/platforms/electrobun/src/electrobun-config.test.ts
@@ -46,6 +46,22 @@ describe("Electrobun Store packaging", () => {
     expect(Object.values(copy)).not.toContain("remotes");
   });
 
+  it("omits the embedded runtime tree for cloud-only consumer builds", () => {
+    const copy = resolveElectrobunCopyMap({
+      buildVariant: "direct",
+      runtimeDistDir: "eliza-dist",
+      embedRuntime: shouldEmbedRuntimeBundle({
+        ELIZA_DESKTOP_CLOUD_ONLY: "1",
+      }),
+    });
+
+    expect(Object.values(copy)).not.toContain("eliza-dist");
+    expect(Object.values(copy)).not.toContain("eliza-dist/package.json");
+    expect(
+      Object.values(copy).some((target) => target.startsWith("eliza-dist/")),
+    ).toBe(false);
+  });
+
   it("keeps the embedded runtime tree when external API env is invalid", () => {
     const copy = resolveElectrobunCopyMap({
       buildVariant: "direct",

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -41,6 +41,7 @@ import {
 } from "./brand-env-reads";
 import { startBrowserWorkspaceBridgeServer } from "./browser-workspace-bridge-server";
 import { readNavigationEventUrl } from "./cloud-auth-window";
+import { hydrateCloudOnlyEnv } from "./cloud-only-boot";
 import {
   appendChatOverlayShellModeParam,
   computeBottomBarFrame,
@@ -2492,6 +2493,16 @@ async function main(): Promise<void> {
   recordStartupPhase("env_loaded", {
     pid: process.pid,
   });
+  // Cloud-only consumer bundles bake `cloudOnly` into brand-config.json and
+  // ship no embedded runtime; promote that to the runtime env contract before
+  // the first runtime-mode resolution. Runs after env-file loading so an
+  // operator's explicit env always wins.
+  const cloudOnlyHydration = hydrateCloudOnlyEnv(BRAND.cloudOnly);
+  if (cloudOnlyHydration.applied.length > 0) {
+    console.log(
+      `[Env] cloud-only brand flag raised: ${cloudOnlyHydration.applied.join(", ")}`,
+    );
+  }
   // Start the static renderer server in parallel with the rest of pre-window
   // work — first paint needs the renderer URL, so kicking it off now overlaps
   // the server bind/port-scan with crash-prompt checks, WebGPU init, and bridge

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -1826,6 +1826,24 @@ function injectApiBase(win: BrowserWindow): void {
     return;
   }
 
+  if (runtimeResolution.mode === "disabled") {
+    // Runtime-less consumer bundle: there is no embedded agent, so minting a
+    // local API token here would be worse than useless — the renderer's cloud
+    // resolver (getCloudAuthToken) falls back to the client REST token, so a
+    // fabricated local token masquerades as a Cloud credential, silently
+    // skips interactive sign-in, and 401s the join flow. Publish the (dead)
+    // loopback base with NO token so the sign-in flow runs for real.
+    apiBaseOwner.notifyChange(
+      win,
+      resolveInitialApiBase(
+        process.env as Record<string, string | undefined>,
+      ) ?? `http://127.0.0.1:${resolveDesktopApiPort(process.env)}`,
+      resolveApiToken(process.env) ?? "",
+    );
+    setAgentReady(true);
+    return;
+  }
+
   const agent = getAgentManager();
   const port = agent.getPort() ?? resolveDesktopApiPort(process.env);
   const apiToken = configureDesktopLocalApiAuth();

--- a/packages/app-core/scripts/desktop-build.mjs
+++ b/packages/app-core/scripts/desktop-build.mjs
@@ -226,6 +226,19 @@ const buildVariant = resolveBuildVariant(
   getArgValue(args, "build-variant") ?? process.env.ELIZA_BUILD_VARIANT,
 );
 const buildEnv = getArgValue(args, "env") ?? process.env.BUILD_ENV ?? "";
+// Cloud-only consumer lane: package without the embedded agent runtime and
+// bake the cloud-only brand flag into the bundle. The flag is exported into
+// this process's env so every downstream consumer — the renderer build, the
+// Electrobun packaging step (shouldEmbedRuntimeBundle + brand-config), and
+// nested tool spawns that inherit process.env — sees one consistent signal.
+const cloudOnlyBuild =
+  getBooleanArg(args, "cloud-only") ||
+  ["1", "true", "yes", "on"].includes(
+    (process.env.ELIZA_DESKTOP_CLOUD_ONLY ?? "").trim().toLowerCase(),
+  );
+if (cloudOnlyBuild) {
+  process.env.ELIZA_DESKTOP_CLOUD_ONLY = "1";
+}
 const stageMacosReleaseApp = getBooleanArg(args, "stage-macos-release-app");
 // The macOS native-effects dylib build shells to `xcrun clang++` (Xcode CLT).
 // "Explicitly requested" decides whether missing native tooling is a hard
@@ -937,6 +950,12 @@ function desktopRendererBuildEnv() {
     VITE_APP_VARIANT: variant,
     ELIZA_BUILD_VARIANT: buildVariant,
   };
+  if (cloudOnlyBuild) {
+    // Cloud-only renderer builds resolve cloud-only branding at module-eval
+    // time via this Vite env (the packaged static-server inject also sets the
+    // window global, but Vite-served index.html never runs that inject).
+    env.VITE_ELIZA_DESKTOP_RUNTIME_MODE = "cloud";
+  }
   if (env.ELIZA_SKIP_LOCAL_UPSTREAMS !== "1") {
     env.ELIZA_FORCE_LOCAL_UPSTREAMS = "1";
   }
@@ -1020,6 +1039,15 @@ function assertRuntimeCopyDiskHeadroom() {
 }
 
 function copyRuntimeNodeModulesWithRetry() {
+  if (cloudOnlyBuild) {
+    // Cloud-only bundles ship no embedded runtime (shouldEmbedRuntimeBundle
+    // drops eliza-dist from the copy map), so staging the multi-GB
+    // node_modules tree would be wasted work and disk.
+    console.log(
+      "[desktop-build] Skipping runtime node_modules bundle (cloud-only build)",
+    );
+    return;
+  }
   assertRuntimeCopyDiskHeadroom();
 
   const maxAttempts = 2;
@@ -1348,7 +1376,10 @@ function stageDesktopBuild() {
   // Build + bundle the fused local-inference native lib so the packaged app
   // serves local AI out of the box. Gated (see stageDesktopFusedLib) so plain
   // dev builds stay fast; auto-built best-effort on CI release builds.
-  stageDesktopFusedLib();
+  // Cloud-only bundles run no local inference, so the lib is dead weight.
+  if (!cloudOnlyBuild) {
+    stageDesktopFusedLib();
+  }
 
   runBun([WRITE_BUILD_INFO_SCRIPT], {
     cwd: ROOT,
@@ -1757,6 +1788,11 @@ Options:
                                    "store" wires macOS App Sandbox entitlements
                                    and forces Cloud hosting at runtime; "direct"
                                    keeps current unsandboxed behavior.
+  --cloud-only                     Consumer cloud-only lane: skip the embedded
+                                   agent runtime + fused local-inference lib and
+                                   bake cloudOnly into brand-config.json so the
+                                   packaged shell runs against Eliza Cloud.
+                                   (env: ELIZA_DESKTOP_CLOUD_ONLY=1)
   --env <channel>                  Electrobun build env (e.g. canary, stable)
   --stage-macos-release-app        Stage a direct macOS .app + DMG from the Electrobun build output
   --exclude-optional-pack <name>   Exclude a manifest-classified optional capability pack during staging


### PR DESCRIPTION
## Why

A consumer install should sign in with Eliza Cloud and go — no local agent, no multi-GB embedded runtime, no nerd setup. The three seams for this already existed (runtime embed skip, topology-aware runtime-mode resolver, cloud-only branding) but no shipped desktop configuration wired them together; they were exercised only by the Mac App Store lane.

## What

**Build lane** — `desktop-build.mjs --cloud-only` (or `ELIZA_DESKTOP_CLOUD_ONLY=1`):
- skips staging the runtime `node_modules` tree and the fused local-inference lib
- passes `VITE_ELIZA_DESKTOP_RUNTIME_MODE=cloud` to the renderer build
- bakes `cloudOnly: true` into the packaged `brand-config.json`
- `shouldEmbedRuntimeBundle()` drops `eliza-dist` (~1.8 GB uncompressed) from the copy map; the packaged dev `.app` shrinks to ~129 MB

**Boot** — new `cloud-only-boot.ts` promotes the packaged `cloudOnly` brand flag into the runtime env contract (`ELIZA_DESKTOP_CLOUD_ONLY` + `ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT`) at `main()` start; explicit operator env always wins.

**Resolver** — `resolveDesktopRuntimeModeWithDeployment` now lets a *connected* cloud deployment (persisted `deploymentTarget.runtime: "cloud"` with a resolvable base) outrank env `disabled`, so a runtime-less bundle is repointed at the user's cloud agent on next boot instead of a dead loopback port. With no cloud deployment, `disabled` still holds.

**Token hygiene fix (found by live first-boot testing)** — in disabled mode, `injectApiBase()` minted a random local `ELIZA_API_TOKEN` and pushed it to the renderer; `getCloudAuthToken()` fell back to it as a fake Cloud credential, silently skipped interactive sign-in, and dead-ended the join flow on a 401. The disabled branch now publishes no minted token, so sign-in runs for real.

## Verification

- 528/528 electrobun tests pass (includes 14 new: resolver precedence, env hydration, brand-config `cloudOnly`, copy-map exclusion, token hygiene). Typecheck + Biome clean.
- **Real packaged first-boot, driven end to end via UI automation** on macOS arm64:
  - bundle ships with `cloudOnly: true` and **no** `eliza-dist`
  - boot log: `cloud-only brand flag raised: ELIZA_DESKTOP_CLOUD_ONLY, ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT` → `desktopRuntimeMode=disabled` → no embedded agent spawned
  - injected boot config carries **no** `apiToken` (regression fixed; before the fix the flow false-positived past sign-in)
  - pill → overlay → "Sign in to Eliza Cloud" → real browser round trip to `eliza.app/auth/cli-login` → session transferred back → onboarding completed into chat

## Known follow-up (pre-existing, not introduced here)

After sign-in, agent traffic proxied through `api.eliza.app/api/v1/eliza/agents/personal:<id>/api/...` returns 404 for the personal shared Eliza on this account, so first chat doesn't stream a reply yet. This reproduces identically outside this branch (the same proxy path is used by the store lane) and is a Cloud-side routing issue to triage separately; filing it against the cloud proxy rather than blocking this lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)