### PR TITLE
fix(core): restore group-channel reminders — privacy stand-down, TRIGGER collection validate, anti-parrot promotion

### DIFF
--- a/packages/agent/src/actions/trigger.ts
+++ b/packages/agent/src/actions/trigger.ts
@@ -1160,6 +1160,13 @@ export const triggerAction: Action = {
   ): Promise<boolean> => {
     const params = readParams(options);
     const op = readString(params.action ?? params.subaction ?? params.op);
+    // Collection-time capability check runs with NO params (the planner has
+    // not emitted a call yet) — requiring `op` here silently dropped TRIGGER
+    // from every planner surface (observed live: a group-channel "remind me
+    // in 3 minutes" had no reminder tool because TRIGGER validate-rejected
+    // at collection). Available when uncalled; op validity is enforced when
+    // a concrete call arrives.
+    if (op === undefined && Object.keys(params).length === 0) return true;
     return op !== undefined && isTriggerOp(op);
   },
 

--- a/packages/core/src/runtime/message-handler.ts
+++ b/packages/core/src/runtime/message-handler.ts
@@ -262,9 +262,17 @@ const EXPLICIT_MEDIA_GENERATION_REQUEST_RE =
 	/\b(?:generate|make|draw|create|render|paint|produce|design)\b[^.!?]{0,64}\b(?:image|picture|photo|art(?:work)?|illustration|logo|sticker|wallpaper|drawing|painting|meme|gif|video|animation|clip|music|song|audio|sound(?:\s?effect)?|sfx|voice(?:over)?|speech)s?\b/i;
 
 /** Capability-denial reply shape ("can't do that here — no video tools in
- * this setup", "I don't have an image generator"). */
+ * this setup", "I don't have an image generator", "that's a private
+ * surface"). The private-surface arm exists because the denial text this
+ * runtime itself ships in group channels becomes room history that stage-1
+ * then parrots VERBATIM for asks an ungated sibling could serve (observed
+ * live: "remind me in 3 minutes" denied in one stage with empty contexts). */
 const CAPABILITY_DENIAL_REPLY_RE =
-	/\b(?:can'?t|cannot|unable to|no|don'?t have|lack)\b[^.!?]{0,80}\b(?:tool|generat|capabilit|action|model|service|setup|environment)/i;
+	/\b(?:can'?t|cannot|unable to|no|don'?t have|lack)\b[^.!?]{0,80}\b(?:tool|generat|capabilit|action|model|service|setup|environment)|private surface/i;
+
+/** Explicit reminder/alarm request shape — as unambiguous as an ask gets. */
+const EXPLICIT_REMINDER_REQUEST_RE =
+	/\bremind me\b|\bset (?:a |an )?(?:reminder|alarm)\b/i;
 
 export function routeMessageHandlerOutput(
 	output: V5MessageHandlerOutput,
@@ -319,19 +327,32 @@ export function routeMessageHandlerOutput(
 	// Seeding is applied ONLY on routes that enter the planner: a simple-path
 	// clarify ("a picture of what exactly?") must stay a final reply, so the
 	// seed never by itself converts a simple turn into planning.
-	const seedMediaCandidate = (): void => {
-		if (!isExplicitMediaAsk) return;
+	const isExplicitReminderAsk = EXPLICIT_REMINDER_REQUEST_RE.test(
+		messageTextForRouting,
+	);
+	const seedCandidate = (name: string): void => {
 		if (
 			(output.plan.candidateActions ?? []).some(
-				(name) => String(name).trim().toUpperCase() === "GENERATE_MEDIA",
+				(existing) => String(existing).trim().toUpperCase() === name,
 			)
 		) {
 			return;
 		}
 		output.plan.candidateActions = [
 			...(output.plan.candidateActions ?? []),
-			"GENERATE_MEDIA",
+			name,
 		];
+	};
+	const seedMediaCandidate = (): void => {
+		if (isExplicitMediaAsk) seedCandidate("GENERATE_MEDIA");
+		// Both reminder siblings ride together: the owner surface serves
+		// DM/api rooms, the ungated TRIGGER serves group channels — the
+		// gate-rejection stand-down downstream picks whichever this surface
+		// allows.
+		if (isExplicitReminderAsk) {
+			seedCandidate("OWNER_REMINDERS");
+			seedCandidate("TRIGGER");
+		}
 	};
 	const candidateActions = output.plan.candidateActions ?? [];
 	const hasCandidateActions = candidateActions.length > 0;
@@ -374,7 +395,11 @@ export function routeMessageHandlerOutput(
 		return {
 			type: "planning_needed",
 			output,
-			contexts: isExplicitMediaAsk ? ["media"] : ["general"],
+			contexts: isExplicitMediaAsk
+				? ["media"]
+				: isExplicitReminderAsk
+					? ["tasks"]
+					: ["general"],
 		};
 	}
 
@@ -388,12 +413,15 @@ export function routeMessageHandlerOutput(
 		// if the capability is real the planner exercises it; if it is
 		// genuinely absent the planner surface proves it and the honest denial
 		// ships from ground truth instead of from memory.
-		if (isExplicitMediaAsk && CAPABILITY_DENIAL_REPLY_RE.test(reply)) {
+		if (
+			(isExplicitMediaAsk || isExplicitReminderAsk) &&
+			CAPABILITY_DENIAL_REPLY_RE.test(reply)
+		) {
 			seedMediaCandidate();
 			return {
 				type: "planning_needed",
 				output,
-				contexts: ["media"],
+				contexts: isExplicitMediaAsk ? ["media"] : ["tasks"],
 			};
 		}
 		// A progress-shaped reply on the pure-simple path is a self-contradiction:

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -8631,9 +8631,26 @@ export async function runV5MessageRuntimeStage1(args: {
 				collectedCandidateNames.has(normalizeActionIdentifier(resolved.name))
 			);
 		});
+		// The privacy denial is only terminal when NO ungated sibling can serve
+		// the ask. Reminders have one: the agent-level TRIGGER action claims
+		// "remind me …" and legitimately works in group channels (observed live:
+		// in-channel triggers created and fired there for months; the denial
+		// regressed that the moment OWNER_REMINDERS got named as the candidate).
+		// When the rejected candidates are reminder/alarm-shaped and TRIGGER
+		// survived collection, let the turn plan — the trigger path serves it.
+		const rejectedReminderish =
+			candidateGateDiagnostics.gateRejectedExplicitCandidates.some((name) => {
+				const normalized = normalizeActionIdentifier(name);
+				return (
+					normalized.includes("REMINDER") || normalized.includes("ALARM")
+				);
+			});
+		const ungatedTriggerSiblingAvailable =
+			rejectedReminderish && collectedCandidateNames.has("TRIGGER");
 		if (
 			candidateGateDiagnostics.gateRejectedExplicitCandidates.length > 0 &&
-			!anyNamedStageOneCandidateSurvived
+			!anyNamedStageOneCandidateSurvived &&
+			!ungatedTriggerSiblingAvailable
 		) {
 			return {
 				kind: "direct_reply",


### PR DESCRIPTION
## What

Three stacked fixes that restore group-channel reminders end-to-end. Live regression: after the surface-privacy short-circuit (#20327) landed, "remind me to X in 3 minutes" in a group channel started getting the "private surface — ask me in a DM" denial — even though the ungated agent-level TRIGGER action claims exactly that ask and had served in-channel reminders (created, fired, and delivered) for months.

1. **Privacy stand-down** (`services/message.ts`) — the denial is only terminal when NO ungated sibling can serve the ask. When the gate-rejected candidates are reminder/alarm-shaped and TRIGGER survived collection, the turn plans and the trigger path serves it. Todos/notes (no ungated sibling) keep the denial.
2. **TRIGGER validate contract** (`agent/src/actions/trigger.ts`) — validate() required an `op` param, but the candidate-collection capability check runs with NO params (the planner hasn't emitted a call yet), so TRIGGER silently self-excluded from **every** planner surface (the validate-silent-drop class). Available when uncalled; op validity enforced when a concrete call arrives.
3. **Anti-parrot promotion** (`runtime/message-handler.ts`) — the denial text this runtime ships becomes room history that stage-1 then parrots verbatim (observed: one-stage simple-path turns with empty contexts repeating the denial). Explicit reminder asks (`remind me…` / `set an alarm…`) with denial-shaped simple-path replies now promote to planning with BOTH sibling candidates seeded (OWNER_REMINDERS + TRIGGER) — the stand-down then picks whichever the surface allows: owner surface in DMs, trigger in groups.

## Evidence

Live on the test deployment, group channel, raw Discord API verified:
- Before: `remind me to ring the canon bell in 3 minutes` → "that's a private surface — ask me in a DM…" (single-stage parroted denial; trajectory shows empty contexts, no planner).
- After: `remind me to tap the canon drum in 3 minutes` → 09:03:02 "Reminder set: 'tap the canon drum' — in 3 minutes." → **09:06:02 "tap the canon drum" fired and delivered at exactly +3:00.**
- Privacy denial intact for todos: `whats on my todo list` in the same channel → denial in 2s (correct — owner-private, no ungated sibling).
- Suites: message-handler 29/29, trigger 77/77, core typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:9bfd99ed184c6ad21bd40d0e70e1d9b5cf805e6f -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - chat-behavior change; before/after transcripts with timestamps in PR body

<!-- evidence-row:after-screenshots -->
- [ ] N/A - chat-behavior change; before/after transcripts with timestamps in PR body

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - live Discord/api transcripts serve as walkthrough

<!-- evidence-row:backend-logs -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - stores verified via live read-backs, transcripts in body

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces
