### PR TITLE
fix(pa): ground lifeops reply rendering in this reply's records

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -1627,6 +1627,13 @@ async function renderLifeActionReply(args: {
       "Never surface raw ISO timestamps unless the user used raw ISO timestamps.",
       "If this is a preview, make clear it is not saved yet and the user can confirm or change it naturally.",
       "If this is reply-only, do not pretend you saved or changed anything.",
+      // Live receipts behind the two rules below: a review turn reported
+      // "1/12 books done" for a goal that was never saved (the number came
+      // from chat history, not records), and a compound ask got a false
+      // "don't know your favorite color" from this renderer even though the
+      // assistant's own context knew it (the fact lives outside lifeops).
+      "Ground every factual claim — counts, progress numbers, item names, schedules, states — in the structured context provided for THIS reply. Never carry numbers or outcomes in from the conversation that the records here do not show; if the records show nothing, say the records show nothing.",
+      "Answer only about the user's tracked items (todos, reminders, goals, routines, habits, alarms). If the user's message also asked about something outside these records — a personal fact, general knowledge, another tool — leave that part unaddressed rather than answering or denying it; the assistant covers it separately.",
     ],
   });
   return rendered.trim().length > 0 ? rendered : naturalFallback;


### PR DESCRIPTION
## What

Two grounding rules for the model-voiced lifeops reply renderer (`renderLifeActionReply` → `renderGroundedActionReply` additionalRules), each behind a live fabrication receipt from a thin-surface battery:

1. **Records-only claims** — a review turn reported "1/12 books done." for a goal that was *never saved* (the create's clarify was never answered): the number came from conversation history, not records. Every factual claim — counts, progress, names, schedules, states — must now ground in the structured context provided for THIS reply; when the records show nothing, the reply says the records show nothing.
2. **No out-of-domain answers** — a compound ask ("whats my favorite color, and how many todos do i have?") got a false "don't know your favorite color" from this renderer even though stage-1's own context knew the fact (it lives outside lifeops). The renderer now answers only about tracked items and leaves out-of-domain parts unaddressed rather than answering or denying them.

## Evidence

Live before/after on the test deployment (api, owner):
- Before: "hows my reading goal going?" → "1/12 books done." (goal nonexistent — trajectory shows OWNER_GOALS_UPDATE had honestly failed "could not find that goal" one turn earlier, then OWNER_GOALS_REVIEW fabricated the progress).
- After: same ask → "no reading goal in the records. only 'learn spanish', and it needs attention."
- Before: compound ask → "don't know your favorite color. you have one todo: buy sandpaper."
- After: same ask → "one todo: buy sandpaper." (no false denial; the out-of-domain half is left to the assistant).
- `life-reminder-datetime` 131/131; pa typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:faa59f74596eaf94ea8b89c025875c2d7976e1f6 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - chat-behavior change; before/after transcripts with timestamps in PR body

<!-- evidence-row:after-screenshots -->
- [ ] N/A - chat-behavior change; before/after transcripts with timestamps in PR body

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - live Discord/api transcripts serve as walkthrough

<!-- evidence-row:backend-logs -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - stores verified via live read-backs, transcripts in body

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces
