### PR TITLE
fix(plugin-reminders): make table migration insert idempotent

### DIFF
--- a/plugins/plugin-reminders/src/services/migration.test.ts
+++ b/plugins/plugin-reminders/src/services/migration.test.ts
@@ -53,8 +53,32 @@ describe("RemindersMigration", () => {
         /INSERT INTO .*app_reminders.*life_escalation_states/s.test(s),
       ),
     ).toBe(true);
+    expect(log.some((s) => s.includes('ON CONFLICT ("id") DO NOTHING'))).toBe(
+      true,
+    );
     // never touches the source
     expect(log.some((s) => /DROP|ALTER .*app_lifeops/.test(s))).toBe(false);
+  });
+
+  it("tolerates a concurrent migration after observing an empty target", async () => {
+    const exec: SqlExecutor = async (sql) => {
+      if (sql.includes("to_regclass")) return [{ present: true }];
+      if (sql.includes("SELECT NOT EXISTS")) return [{ empty: true }];
+      if (
+        sql.includes("INSERT INTO") &&
+        !sql.includes('ON CONFLICT ("id") DO NOTHING')
+      ) {
+        throw new Error("duplicate key value violates unique constraint");
+      }
+      return [];
+    };
+
+    await expect(
+      migrateReminderTable(exec, "life_reminder_plans"),
+    ).resolves.toEqual({
+      table: "life_reminder_plans",
+      outcome: "copied",
+    });
   });
 
   it("creates the target schema and processes every reminder table", async () => {

--- a/plugins/plugin-reminders/src/services/migration.ts
+++ b/plugins/plugin-reminders/src/services/migration.ts
@@ -86,7 +86,8 @@ export async function migrateReminderTable(
        SELECT s.* FROM ${source} AS s
        WHERE NOT EXISTS (
          SELECT 1 FROM ${target} AS t WHERE t.id = s.id
-       )`,
+       )
+       ON CONFLICT (${quoteIdent("id")}) DO NOTHING`,
   );
   return { table, outcome: "copied" };
 }


### PR DESCRIPTION
# Relates to

Closes #20474.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] this PR targets `develop` and is branched directly off the current `origin/develop` tip.
- [x] focused package tests, lint, typecheck, and build pass on the exact head, see Testing below.
- [x] a reviewer can confirm the fix directly against the deterministic concurrency-simulation test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (fix, tests, via AgentRouter proxy), `anthropic/claude-sonnet-5` (independent re-verification)
<!-- attribution-row:client -->
- Agent tooling: `codex` (via AgentRouter proxy), `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] branched directly off the current `origin/develop` tip

# Risks

low. `ON CONFLICT DO NOTHING` is a one-clause addition to an existing `INSERT ... SELECT ... WHERE NOT EXISTS`; a single-runtime migration with no concurrent writer behaves identically (the `NOT EXISTS` predicate already prevented any real conflict in that case).

# Background

## What does this PR do?

`migrateReminderTable` checks whether the target table is empty, then performs an unprotected `INSERT ... SELECT` guarded by a `NOT EXISTS` predicate. That predicate is evaluated against the target's state at check time — it does not close the race between two runtimes starting concurrently. If both observe the target as empty before either insert commits, both attempt to copy the same rows; the second `INSERT` then fails with a duplicate-primary-key violation, and that error propagates up and aborts migration (and therefore startup, since migration runs during plugin registration).

traced reachability before writing this up: `plugins/plugin-reminders/src/plugin.ts` registers `RemindersMigrationService` in the plugin's `services` array. `plugins/plugin-personal-assistant/src/plugin.ts` imports `remindersPlugin` and calls `ensureLifeOpsRemindersPluginRegistered`, which calls `runtime.registerPlugin(remindersPlugin)`, during real runtime startup — a live path, not test-only code. Any deployment starting multiple agent runtime instances concurrently against the same database can hit this race.

fix: the insert now ends with `ON CONFLICT DO NOTHING`, making the operation idempotent under concurrent starts — a losing writer does nothing instead of erroring, preserving the existing non-destructive intent.

## What kind of change is this?

bug fix, non-breaking (a single-runtime migration behaves identically; only the concurrent-start race is closed).

# Documentation changes needed?

no, the fix makes the migration match its own already-documented non-destructive, copy-if-missing intent under concurrency.

# Testing

## Where should a reviewer start?

`plugins/plugin-reminders/src/services/migration.test.ts`, the new `tolerates a concurrent migration after observing an empty target` case, then the `ON CONFLICT DO NOTHING` addition in `migration.ts`.

## Detailed testing steps

```text
$ bun test src/services/migration.test.ts
5 pass
0 fail
8 expect() calls

$ bun run build
tsup and declaration build succeeded

$ bun run typecheck
succeeded

$ bun run lint:check
Checked 10 files in 37ms. No fixes applied.
```

The new test's fake executor simulates a concurrent writer directly: it reports the target as empty, then throws a real `duplicate key value violates unique constraint` error for any `INSERT INTO` statement that does **not** contain `ON CONFLICT DO NOTHING` — exercising the actual fix rather than just asserting the symptom.

mutation-resistance verified independently: reverted just the source fix, kept the new test, reran — 1/5 failed with `Expected promise that resolves / Received promise that rejected`. restored the fix, 5/5 green again.

# Evidence Gate

<!-- evidence-head:a6007fe7a135d87d748e6237bc9dd900a8710501 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes an internal SQL migration statement, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - this changes an internal SQL migration statement, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive product flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic concurrency-simulation test, the real transcript is included under domain artifacts.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code or network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real mutation-resistance run, captured directly:
  ```text
  red (source fix reverted, test kept):
  $ bun test src/services/migration.test.ts
  Expected promise that resolves
  Received promise that rejected: Promise { <rejected> }
  4 pass | 1 fail

  green (fix restored):
  $ bun test src/services/migration.test.ts
  5 pass | 0 fail
  ```
  also independently traced the real `RemindersMigrationService` registration and `ensureLifeOpsRemindersPluginRegistered` caller chain (`plugin-reminders/src/plugin.ts` → `plugin-personal-assistant/src/plugin.ts`) before writing up the reachability claim.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface or visual text changed.

## Known gaps / failures

none. focused test suite (5/5), build, typecheck, and lint all pass clean on the exact head.

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the focused suite, build, typecheck, and lint myself, retraced the real plugin registration/caller chain, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Contribution skill revision: N/A - direct interactive session, contribute-to-eliza skill not used
Compute receipt: N/A - Slop run-receipt install currently blocked by an unrelated site-deploy-lag issue (deployed skill archive predates recent develop changes)
Attribution status: self-reported
