### PR TITLE
fix(core,pa): restore the web-search planner surface — calendar context de-claim, SEARCH candidate aliases, alias-aware privacy survivor check

### DIFF
--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -296,6 +296,17 @@ const CANDIDATE_ACTION_PARENT_ALIASES: Record<string, readonly string[]> = {
 	TRIP_SAVINGS_PLAN: ["OWNER_GOALS"],
 	SEARCH_CHATS: ["MESSAGE"],
 	SEARCH_CHAT: ["MESSAGE"],
+	// Bare "SEARCH" is a routine Stage-1 invention for open-web asks ("latest
+	// merged PR on develop, search for it" emitted candidate SEARCH, live
+	// trajectory tj-df4f61ac001a27). It resolved to nothing, the candidate
+	// narrow kept only the arbitrary rank-1 parent of a saturated tie, and the
+	// planner ran CALENDAR_BULK_RESCHEDULE for a web query. Genuinely ambiguous
+	// with message search, so hint both owners and let the planner arbitrate
+	// from the selected contexts (#9950 pattern).
+	SEARCH: ["WEB_SEARCH", "MESSAGE"],
+	SEARCH_ONLINE: ["WEB_SEARCH"],
+	INTERNET_SEARCH: ["WEB_SEARCH"],
+	GOOGLE_SEARCH: ["WEB_SEARCH"],
 	FIND_MESSAGES: ["MESSAGE"],
 	FIND_MESSAGE: ["MESSAGE"],
 	ARRANGE_VIEWS: ["VIEWS"],

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -8619,16 +8619,27 @@ export async function runV5MessageRuntimeStage1(args: {
 			),
 		);
 		const stageOneCandidateLookup = buildRuntimeActionLookup(args.runtime);
+		// Resolve candidates exactly the way collection does — direct name/simile
+		// first, then the shared parent-alias map. Collection admits an aliased
+		// action (Stage-1's invented "SEARCH" → WEB_SEARCH) but a direct-only
+		// check here reads that same candidate as resolving to nothing, counts
+		// the turn as "no survivors", and the privacy denial fires on a turn
+		// whose web capability is sitting in the collected set (observed live:
+		// group "search the web … within my budget" — the possessive-budget
+		// heuristic's OWNER_FINANCES was rightly privacy-rejected, and the
+		// denial swallowed a servable web search).
 		const anyNamedStageOneCandidateSurvived = (
 			getMessageHandlerCandidateActions(messageHandler) ?? []
 		).some((name) => {
-			const resolved = resolveRuntimeAction(
-				stageOneCandidateLookup,
-				String(name),
-			);
-			return (
-				resolved !== undefined &&
-				collectedCandidateNames.has(normalizeActionIdentifier(resolved.name))
+			const candidateName = String(name);
+			const direct = resolveRuntimeAction(stageOneCandidateLookup, candidateName);
+			const resolvedSet = direct
+				? [direct]
+				: parentAliasesForCandidateAction(candidateName)
+						.map((alias) => resolveRuntimeAction(stageOneCandidateLookup, alias))
+						.filter((action): action is Action => action !== undefined);
+			return resolvedSet.some((resolved) =>
+				collectedCandidateNames.has(normalizeActionIdentifier(resolved.name)),
 			);
 		});
 		// The privacy denial is only terminal when NO ungated sibling can serve

--- a/plugins/plugin-personal-assistant/src/actions/calendar.ts
+++ b/plugins/plugin-personal-assistant/src/actions/calendar.ts
@@ -1489,8 +1489,13 @@ export const calendarAction: Action & {
   // "general" included so messageHandler can route direct owner calendar
   // most user-facing event/scheduling requests to "general" rather than
   // "calendar", so retrieval would otherwise filter CALENDAR out before
-  // the planner sees it. See `12-real-root-cause.md`.
-  contexts: ["general", "calendar", "contacts", "tasks", "connectors", "web"],
+  // the planner sees it. See `12-real-root-cause.md`. "web" is deliberately
+  // NOT claimed: on live-web-lookup turns the context-match boost tied every
+  // promoted CALENDAR_* subaction with WEB_SEARCH at score 1.0, and the
+  // registration-order tie-break handed the planner a calendar-only surface
+  // for a web ask (observed live: "latest merged PR, search for it" →
+  // CALENDAR_BULK_RESCHEDULE).
+  contexts: ["general", "calendar", "contacts", "tasks", "connectors"],
   roleGate: { minRole: "OWNER" },
   // CALENDAR is a flat-subaction umbrella: every verb is selected via the
   // `subaction` parameter enum below, and the handler routes via `route()`

--- a/plugins/plugin-personal-assistant/test/native-parameters.test.ts
+++ b/plugins/plugin-personal-assistant/test/native-parameters.test.ts
@@ -215,13 +215,15 @@ describe("LifeOps native options.parameters migration", () => {
   });
 
   it("CALENDAR exposes concrete contexts and is a flat action-valued umbrella (no nested subActions/subPlanner)", () => {
+    // "web" is deliberately absent: claiming it tied every CALENDAR_* subaction
+    // with WEB_SEARCH on live-web turns and starved the planner surface of the
+    // actual web tool (see the contexts comment in actions/calendar.ts).
     expect(calendarAction.contexts).toEqual([
       "general",
       "calendar",
       "contacts",
       "tasks",
       "connectors",
-      "web",
     ]);
     // The legacy 2-layer `subActions` + `subPlanner` dispatch was removed in
     // favor of a flat action enum + `promoteSubactionsToActions` virtuals


### PR DESCRIPTION
## What

Restores the web-search surface end-to-end for live-web asks. Three composing defects, each with a live receipt on the test deployment (canonical develop build):

1. **CALENDAR de-claims the `web` context** (`plugin-personal-assistant/actions/calendar.ts`) — the umbrella claimed `"web"` with no stated justification (the adjacent comment only justifies `"general"`). On live-web turns the retrieval context-match boost (+0.3) then tied every promoted `CALENDAR_*` subaction with WEB_SEARCH at score 1.0, and the saturated-tie ordering handed tier-A to the registration-order winner. Observed live: "whats the latest merged PR on develop? search for it" → planner surface was `[CALENDAR_BULK_RESCHEDULE, REPLY, IGNORE, STOP]` → the planner ran a calendar bulk-reschedule with the user's question stuffed into `intent`, replying "I found 1 those meetings … ready to push into next month" (trajectory tj-df4f61ac001a27).
2. **`SEARCH` joins the candidate parent-alias map** (`core/runtime/action-retrieval.ts`) — Stage-1 routinely invents the bare candidate `SEARCH` for open-web asks; it resolved to no runtime action (F21 class), so the candidate narrow kept only the arbitrary rank-1 parent of the saturated tie. `SEARCH → [WEB_SEARCH, MESSAGE]` (genuinely ambiguous, both hinted per the #9950 pattern), plus `SEARCH_ONLINE` / `INTERNET_SEARCH` / `GOOGLE_SEARCH → WEB_SEARCH`.
3. **Privacy-denial survivor check resolves through the same alias map as collection** (`core/services/message.ts`) — collection admits aliased candidates, but `anyNamedStageOneCandidateSurvived` resolved direct-only. Observed live: group-channel "search the web for the best mechanical keyboard within my budget" — the possessive-budget heuristic injected OWNER_FINANCES (rightly privacy-rejected), the direct-only check read Stage-1's `SEARCH`/`BROWSE` as resolving to nothing, and the surface-privacy denial ("that's a private surface — ask me in a DM") swallowed a fully servable web search.

## Evidence

- Before/after, same ask, api owner surface: calendar-plan reply → tierA `[WEB_FETCH, WEB_SEARCH]`, planner calls `WEB_SEARCH{query:"latest merged PR elizaOS/eliza develop branch"}` and answers with a real PR (`#20469 feat(desktop): …`).
- Before/after, group channel via raw Discord API: privacy denial at 09:47:57 → post-fix same ask searches and answers with an in-budget pick (Razer BlackWidow V3, ~$99 against the remembered $150 budget).
- `action-retrieval` + `action-tiering` suites 65/65; PA lane 2046 passed with the CALENDAR contexts test updated to pin the de-claim; core typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:82522908c29f8fc8b395508fd47d645a938c1997 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - chat-behavior change; before/after transcripts with timestamps in PR body

<!-- evidence-row:after-screenshots -->
- [ ] N/A - chat-behavior change; before/after transcripts with timestamps in PR body

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - live Discord/api transcripts serve as walkthrough

<!-- evidence-row:backend-logs -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - planner-surface/evaluator behavior; trajectories cited in body

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces
