### PR TITLE
fix(core): evaluator FINISH with a progress-promise message coerces to CONTINUE

### DIFF
--- a/packages/core/src/runtime/__tests__/evaluator.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator.test.ts
@@ -1202,3 +1202,81 @@ describe("malformed envelope recovery (#18240 class — the 2026-08-10 leak)", (
 		).not.toBe("malformed_envelope_text");
 	});
 });
+
+describe("FINISH with a progress-promise message coerces to CONTINUE", () => {
+	const makeParams = (evaluatorJson: string) => ({
+		runtime: { useModel: vi.fn(async () => evaluatorJson) },
+		context: {
+			id: "ctx",
+			staticPrefix: {
+				characterPrompt: { content: "agent_name: Eliza", stable: true },
+			},
+			events: [
+				{
+					id: "msg",
+					type: "message" as const,
+					message: {
+						role: "user" as const,
+						content: { text: "find the best keyboard" },
+					},
+				},
+			],
+		},
+		trajectory: {
+			context: { id: "ctx" },
+			steps: [
+				{
+					toolCall: { name: "WEB_SEARCH", args: { query: "best keyboard" } },
+					result: { success: true, text: '{"results":[{"url":"x"}]}' },
+				},
+			],
+			archivedSteps: [],
+			plannedQueue: [],
+			evaluatorOutputs: [],
+		},
+		effects: { copyToClipboard: vi.fn(), messageToUser: vi.fn() },
+	});
+
+	it("bare final ack after a successful tool continues the loop (live: 'checking.')", async () => {
+		const result = await runEvaluator(
+			makeParams(
+				'{"success": true, "decision": "FINISH", "thought": "found a list.", "messageToUser": "checking."}',
+			),
+		);
+		expect(result.decision).toBe("CONTINUE");
+		expect(result.messageToUser).toBeUndefined();
+	});
+
+	it("promise-tailed message continues the loop (live: link + 'checking this list for the top pick')", async () => {
+		const result = await runEvaluator(
+			makeParams(
+				'{"success": true, "decision": "FINISH", "thought": "found it.", "messageToUser": "<https://example.com/best-keyboards>\\n\\nchecking this list for the top pick under $150."}',
+			),
+		);
+		expect(result.decision).toBe("CONTINUE");
+		expect(result.messageToUser).toBeUndefined();
+	});
+
+	it("substantive answer that merely opens with a gerund stays FINISH", async () => {
+		const answer =
+			"Checking accounts are bank accounts designed for everyday spending; for your $150 budget the Keychron V5 is the pick.";
+		const result = await runEvaluator(
+			makeParams(
+				`{"success": true, "decision": "FINISH", "thought": "answered.", "messageToUser": ${JSON.stringify(answer)}}`,
+			),
+		);
+		expect(result.decision).toBe("FINISH");
+		expect(result.messageToUser).toContain("Keychron V5");
+	});
+
+	it("real deliverable ending in a plain sentence stays FINISH", async () => {
+		const answer =
+			"top pick: Keychron V5 ($95) — hot-swappable, gasket mount, well under your $150 budget.";
+		const result = await runEvaluator(
+			makeParams(
+				`{"success": true, "decision": "FINISH", "thought": "done.", "messageToUser": ${JSON.stringify(answer)}}`,
+			),
+		);
+		expect(result.decision).toBe("FINISH");
+	});
+});

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -604,19 +604,22 @@ export async function runEvaluator(
 		});
 	}
 	const output = sanitizeOutputMessage(
-		repairFinishedToolTurnWithoutUserMessage(
-			repairMissingEvaluatorMessage(
-				repairMissingEvaluatorSuccess(
-					rejectEvaluatorInvocationMessage(
-						recoverEvaluatorTextOutput(
-							parseEvaluatorOutput(raw),
-							raw,
-							params.trajectory,
+		repairFinishWithProgressPromise(
+			repairFinishedToolTurnWithoutUserMessage(
+				repairMissingEvaluatorMessage(
+					repairMissingEvaluatorSuccess(
+						rejectEvaluatorInvocationMessage(
+							recoverEvaluatorTextOutput(
+								parseEvaluatorOutput(raw),
+								raw,
+								params.trajectory,
+							),
 						),
+						params.trajectory,
 					),
+					params.context,
 					params.trajectory,
 				),
-				params.context,
 				params.trajectory,
 			),
 			params.trajectory,
@@ -1116,6 +1119,50 @@ function repairFinishedToolTurnWithoutUserMessage(
 		decision: "CONTINUE",
 		thought:
 			"Evaluator finished without a user-facing message; replanning from recorded tool results.",
+	};
+}
+
+/**
+ * A FINISH whose user message promises ongoing work is self-contradictory:
+ * the evaluator ends the turn while telling the user the work continues, so
+ * the promised delivery never happens (observed live twice on web-search
+ * turns: a bare final "checking.", and "<link> … checking this list for the
+ * top pick under $150." posted as the turn's last message with no pick ever
+ * delivered). Coerce to CONTINUE and drop the promise text — the planner gets
+ * the iteration the message promised, bounded by the loop's existing caps.
+ *
+ * Matching is deliberately narrow to keep substantive answers final: either
+ * the whole message is a short bare ack ("checking.", "on it", "one moment"),
+ * or the LAST sentence opens with a progress verb aimed at a referent
+ * ("checking this list …", "looking into that now"). Informative statements
+ * that merely open with a gerund ("Checking accounts are bank accounts …")
+ * fail the determiner test and stay final.
+ */
+const FINISH_BARE_PROGRESS_ACK_RE =
+	/^(?:checking|fetching|gathering|reading|scanning|looking (?:up|into)|working on it|on it|one (?:moment|sec(?:ond)?)|give me a (?:sec(?:ond)?|moment)|let me (?!know\b)[a-z]+)[.…!\s]*$/i;
+const FINISH_PROGRESS_PROMISE_TAIL_RE =
+	/(?:^|[.!?…]\s+|\n\s*)(?:checking|reading|opening|fetching|scanning|pulling(?: up)?|going through|digging into|looking (?:up|into)|working on)\s+(?:this|that|these|those|it\b|the\b)[^.!?\n]{0,80}[.!?…]?\s*$/i;
+
+function repairFinishWithProgressPromise(
+	output: EvaluatorOutput,
+	trajectory: PlannerTrajectory,
+): EvaluatorOutput {
+	if (output.decision !== "FINISH") return output;
+	const message = (output.messageToUser ?? "").trim();
+	if (!message) return output;
+	if (!hasSuccessfulToolResult(trajectory)) return output;
+	const bareAck =
+		message.length <= 64 && FINISH_BARE_PROGRESS_ACK_RE.test(message);
+	if (!bareAck && !FINISH_PROGRESS_PROMISE_TAIL_RE.test(message)) {
+		return output;
+	}
+	return {
+		...output,
+		success: false,
+		decision: "CONTINUE",
+		messageToUser: undefined,
+		thought:
+			"Evaluator finished while promising ongoing work; continuing so the promised result is actually delivered.",
 	};
 }
 


### PR DESCRIPTION
## What

A FINISH whose user message promises ongoing work is self-contradictory: the evaluator ends the turn while telling the user the work continues, so the promised delivery never happens. Adds `repairFinishWithProgressPromise` to the evaluator repair chain — when decision=FINISH, a successful tool step exists, and `messageToUser` is either a short bare ack ("checking.") or ends in a progress-promise sentence ("checking this list for the top pick …"), coerce to CONTINUE and drop the promise text. The planner gets the iteration the message promised, bounded by the loop's existing caps.

Matching is deliberately narrow: the tail test requires a progress verb aimed at a referent (`checking this/that/the …`), so informative answers that merely open with a gerund ("Checking accounts are bank accounts …") stay final — covered by unit test.

## Evidence

Two live receipts on the test deployment (web-search turns, success path — the existing forced-synthesis guard only covers turns ending on a FAILED step):

- "whats the latest merged PR … search for it" → WEB_SEARCH succeeded (search_id in trajectory tj-f0946541adf60e), final delivered text was just "checking." — the answer never arrived; the agent later confirmed "no. i said 'checking' and never sent the answer."
- "search the web for the best mechanical keyboard …" → search succeeded, bot posted "<link> … checking this list for the top pick under $150." as the turn's last message; no pick ever delivered.
- Post-fix, same ask: a concrete delivered pick ("Razer BlackWidow V3 … around $99. best overall under your budget.").
- Evaluator suites 60/60 including 4 new tests (both live shapes coerce, two substantive-answer shapes stay FINISH); core typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:561a6611c1bbc188151b24762b72734453aef728 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - chat-behavior change; before/after transcripts with timestamps in PR body

<!-- evidence-row:after-screenshots -->
- [ ] N/A - chat-behavior change; before/after transcripts with timestamps in PR body

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - live Discord/api transcripts serve as walkthrough

<!-- evidence-row:backend-logs -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - planner-surface/evaluator behavior; trajectories cited in body

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces
