### PR TITLE
fix(ios): preserve remote Mac runtime ownership

### DIFF
--- a/packages/app-core/platforms/ios/App/App/AgentWatchdog.swift
+++ b/packages/app-core/platforms/ios/App/App/AgentWatchdog.swift
@@ -34,11 +34,11 @@ import Capacitor
 ///   so a busy model is never mistaken for a crash, the same way Android's
 ///   `ProbeResult.BUSY` never counts a strike).
 /// * **Mode gate** → reads the renderer's own source of truth
-///   (`localStorage["eliza:mobile-runtime-mode"]`). `cloud` is pure remote and
-///   keeps the watchdog dormant. `local`, `cloud-hybrid`, and `tunnel-to-mobile`
-///   all own a phone-side agent and therefore arm the watchdog when the runtime
-///   plugin is present. An unset mode with the plugin present (fresh install
-///   autostart) arms it as well.
+///   (`localStorage["eliza:mobile-runtime-mode"]`). `cloud` and `remote-mac` are
+///   pure remote modes and keep the watchdog dormant. `local`, `cloud-hybrid`,
+///   and `tunnel-to-mobile` all own a phone-side agent and therefore arm the
+///   watchdog when the runtime plugin is present. An unset mode with the plugin
+///   present (fresh install autostart) arms it as well.
 /// * **"Restart" entrypoint** → re-initializing the in-process runtime via the
 ///   renderer's existing `ElizaBunRuntime.start(...)` path. The watchdog does not
 ///   invent a second restart mechanism and never fabricates a start config it
@@ -490,15 +490,15 @@ final class AgentWatchdog {
 
     /// Reads the renderer's runtime mode (its own `localStorage` source of truth)
     /// and the live `ElizaBunRuntime` plugin status. `local` is false for
-    /// pure cloud mode (or a missing plugin) so the watchdog no-ops there;
-    /// `ready` reflects the in-process engine being up.
+    /// pure cloud or remote-Mac mode (or a missing plugin) so the watchdog
+    /// no-ops there; `ready` reflects the in-process engine being up.
     private static let probeScript = """
     var mode = null;
     try { mode = window.localStorage.getItem('eliza:mobile-runtime-mode'); } catch (e) {}
     var cap = window.Capacitor;
     var rt = (cap && cap.Plugins) ? cap.Plugins.ElizaBunRuntime : null;
     var present = !!(rt && typeof rt.getStatus === 'function');
-    var isPureRemote = (mode === 'cloud');
+    var isPureRemote = (mode === 'cloud' || mode === 'remote-mac');
     var local = present && !isPureRemote;
     var ready = false;
     var engine = null;

--- a/packages/app-core/src/api/ios-local-agent-transport.test.ts
+++ b/packages/app-core/src/api/ios-local-agent-transport.test.ts
@@ -453,6 +453,53 @@ describe("iOS local agent transport bridge", () => {
     },
   );
 
+  it.each(["remote-mac"])(
+    "lets the explicit %s selection override a strict local-runtime build",
+    async (mode) => {
+      vi.stubEnv("VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK", "1");
+      vi.stubEnv("VITE_ELIZA_IOS_FULL_BUN_STRICT", "1");
+      capacitorState.pluginAvailable = true;
+      const start = vi.fn(async () => ({ ok: true }));
+      const getStatus = vi.fn(async () => ({ ready: true, engine: "bun" }));
+      const call = vi.fn();
+      vi.doMock("@elizaos/capacitor-bun-runtime", () => ({
+        ElizaBunRuntime: { start, getStatus, call },
+      }));
+      const originalFetch = vi.fn(async () =>
+        Response.json({ source: "mac-runtime" }),
+      );
+      vi.stubGlobal("fetch", originalFetch);
+      vi.stubGlobal("localStorage", {
+        getItem: (key: string) =>
+          key === "eliza:mobile-runtime-mode" ? mode : null,
+      });
+
+      const {
+        handleIosLocalAgentNativeRequest,
+        installIosLocalAgentFetchBridge,
+      } = await import("./ios-local-agent-transport");
+      installIosLocalAgentFetchBridge();
+
+      const url = "http://127.0.0.1:31337/api/notifications?limit=100";
+      const response = await fetch(url);
+
+      await expect(response.json()).resolves.toEqual({
+        source: "mac-runtime",
+      });
+      expect(originalFetch).toHaveBeenCalledWith(url, undefined);
+      await expect(
+        handleIosLocalAgentNativeRequest({
+          method: "GET",
+          path: "/api/notifications?limit=100",
+        }),
+      ).rejects.toThrow("remote-agent modes cannot use local-agent IPC");
+      expect(start).not.toHaveBeenCalled();
+      expect(getStatus).not.toHaveBeenCalled();
+      expect(call).not.toHaveBeenCalled();
+      expect(kernelMock.startIosLocalAgentKernel).not.toHaveBeenCalled();
+    },
+  );
+
   it("retains port 31337 as the on-device agent in local mode", async () => {
     vi.stubGlobal("localStorage", {
       getItem: (key: string) =>

--- a/packages/app-core/src/api/ios-local-agent-transport.test.ts
+++ b/packages/app-core/src/api/ios-local-agent-transport.test.ts
@@ -423,6 +423,69 @@ describe("iOS local agent transport bridge", () => {
     });
   });
 
+  it.each(["remote-mac", "cloud", "tunnel-to-mobile"])(
+    "keeps port 31337 on the real network transport in %s mode",
+    async (mode) => {
+      vi.stubEnv("VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK", "1");
+      const originalFetch = vi.fn(async () =>
+        Response.json({ source: "mac-runtime" }),
+      );
+      vi.stubGlobal("fetch", originalFetch);
+      vi.stubGlobal("localStorage", {
+        getItem: (key: string) =>
+          key === "eliza:mobile-runtime-mode" ? mode : null,
+      });
+
+      const { installIosLocalAgentFetchBridge, isIosInProcessLocalAgentUrl } =
+        await import("./ios-local-agent-transport");
+      const macRuntimeUrl = "http://127.0.0.1:31337/api/health";
+
+      expect(isIosInProcessLocalAgentUrl(macRuntimeUrl)).toBe(false);
+      installIosLocalAgentFetchBridge();
+      const response = await fetch(macRuntimeUrl);
+
+      await expect(response.json()).resolves.toEqual({
+        source: "mac-runtime",
+      });
+      expect(originalFetch).toHaveBeenCalledOnce();
+      expect(originalFetch).toHaveBeenCalledWith(macRuntimeUrl, undefined);
+      expect(kernelMock.handleIosLocalAgentRequest).not.toHaveBeenCalled();
+    },
+  );
+
+  it("retains port 31337 as the on-device agent in local mode", async () => {
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) =>
+        key === "eliza:mobile-runtime-mode" ? "local" : null,
+    });
+
+    const { isIosInProcessLocalAgentUrl } = await import(
+      "./ios-local-agent-transport"
+    );
+
+    expect(
+      isIosInProcessLocalAgentUrl("http://127.0.0.1:31337/api/health"),
+    ).toBe(true);
+  });
+
+  it.each(["local", "cloud-hybrid"])(
+    "retains native IPC as the on-device agent in %s mode",
+    async (mode) => {
+      vi.stubGlobal("localStorage", {
+        getItem: (key: string) =>
+          key === "eliza:mobile-runtime-mode" ? mode : null,
+      });
+
+      const { isIosInProcessLocalAgentUrl } = await import(
+        "./ios-local-agent-transport"
+      );
+
+      expect(
+        isIosInProcessLocalAgentUrl("eliza-local-agent://ipc/api/health"),
+      ).toBe(true);
+    },
+  );
+
   it("routes iOS IPC local-agent URLs through the same in-process transport", async () => {
     const { iosInProcessAgentTransportForUrl } = await import(
       "./ios-local-agent-transport"

--- a/packages/app-core/src/api/ios-local-agent-transport.test.ts
+++ b/packages/app-core/src/api/ios-local-agent-transport.test.ts
@@ -423,7 +423,7 @@ describe("iOS local agent transport bridge", () => {
     });
   });
 
-  it.each(["remote-mac", "cloud", "tunnel-to-mobile"])(
+  it.each(["remote-mac", "cloud"])(
     "keeps port 31337 on the real network transport in %s mode",
     async (mode) => {
       vi.stubEnv("VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK", "1");
@@ -453,52 +453,49 @@ describe("iOS local agent transport bridge", () => {
     },
   );
 
-  it.each(["remote-mac"])(
-    "lets the explicit %s selection override a strict local-runtime build",
-    async (mode) => {
-      vi.stubEnv("VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK", "1");
-      vi.stubEnv("VITE_ELIZA_IOS_FULL_BUN_STRICT", "1");
-      capacitorState.pluginAvailable = true;
-      const start = vi.fn(async () => ({ ok: true }));
-      const getStatus = vi.fn(async () => ({ ready: true, engine: "bun" }));
-      const call = vi.fn();
-      vi.doMock("@elizaos/capacitor-bun-runtime", () => ({
-        ElizaBunRuntime: { start, getStatus, call },
-      }));
-      const originalFetch = vi.fn(async () =>
-        Response.json({ source: "mac-runtime" }),
-      );
-      vi.stubGlobal("fetch", originalFetch);
-      vi.stubGlobal("localStorage", {
-        getItem: (key: string) =>
-          key === "eliza:mobile-runtime-mode" ? mode : null,
-      });
+  it("lets the explicit remote-mac selection override a strict local-runtime build", async () => {
+    vi.stubEnv("VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK", "1");
+    vi.stubEnv("VITE_ELIZA_IOS_FULL_BUN_STRICT", "1");
+    capacitorState.pluginAvailable = true;
+    const start = vi.fn(async () => ({ ok: true }));
+    const getStatus = vi.fn(async () => ({ ready: true, engine: "bun" }));
+    const call = vi.fn();
+    vi.doMock("@elizaos/capacitor-bun-runtime", () => ({
+      ElizaBunRuntime: { start, getStatus, call },
+    }));
+    const originalFetch = vi.fn(async () =>
+      Response.json({ source: "mac-runtime" }),
+    );
+    vi.stubGlobal("fetch", originalFetch);
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) =>
+        key === "eliza:mobile-runtime-mode" ? "remote-mac" : null,
+    });
 
-      const {
-        handleIosLocalAgentNativeRequest,
-        installIosLocalAgentFetchBridge,
-      } = await import("./ios-local-agent-transport");
-      installIosLocalAgentFetchBridge();
+    const {
+      handleIosLocalAgentNativeRequest,
+      installIosLocalAgentFetchBridge,
+    } = await import("./ios-local-agent-transport");
+    installIosLocalAgentFetchBridge();
 
-      const url = "http://127.0.0.1:31337/api/notifications?limit=100";
-      const response = await fetch(url);
+    const url = "http://127.0.0.1:31337/api/notifications?limit=100";
+    const response = await fetch(url);
 
-      await expect(response.json()).resolves.toEqual({
-        source: "mac-runtime",
-      });
-      expect(originalFetch).toHaveBeenCalledWith(url, undefined);
-      await expect(
-        handleIosLocalAgentNativeRequest({
-          method: "GET",
-          path: "/api/notifications?limit=100",
-        }),
-      ).rejects.toThrow("remote-agent modes cannot use local-agent IPC");
-      expect(start).not.toHaveBeenCalled();
-      expect(getStatus).not.toHaveBeenCalled();
-      expect(call).not.toHaveBeenCalled();
-      expect(kernelMock.startIosLocalAgentKernel).not.toHaveBeenCalled();
-    },
-  );
+    await expect(response.json()).resolves.toEqual({
+      source: "mac-runtime",
+    });
+    expect(originalFetch).toHaveBeenCalledWith(url, undefined);
+    await expect(
+      handleIosLocalAgentNativeRequest({
+        method: "GET",
+        path: "/api/notifications?limit=100",
+      }),
+    ).rejects.toThrow("remote-agent modes cannot use local-agent IPC");
+    expect(start).not.toHaveBeenCalled();
+    expect(getStatus).not.toHaveBeenCalled();
+    expect(call).not.toHaveBeenCalled();
+    expect(kernelMock.startIosLocalAgentKernel).not.toHaveBeenCalled();
+  });
 
   it("retains port 31337 as the on-device agent in local mode", async () => {
     vi.stubGlobal("localStorage", {
@@ -515,7 +512,7 @@ describe("iOS local agent transport bridge", () => {
     ).toBe(true);
   });
 
-  it.each(["local", "cloud-hybrid"])(
+  it.each(["local", "cloud-hybrid", "tunnel-to-mobile"])(
     "retains native IPC as the on-device agent in %s mode",
     async (mode) => {
       vi.stubGlobal("localStorage", {

--- a/packages/app-core/src/api/ios-local-agent-transport.ts
+++ b/packages/app-core/src/api/ios-local-agent-transport.ts
@@ -401,12 +401,13 @@ function isIosOnDeviceAgentHttpUrl(value: string): boolean {
 
 /**
  * Whether the selected iOS runtime owns an on-device agent process/runtime.
- * Delegates to the first-run runtime-mode authority so transports cannot drift
- * from restore and active-server policy.
+ * Tunnel mode is the phone-side relay into Bun IPC, even though first-run
+ * treats its connection target as externally configured.
  */
 function iosRuntimeHasOnDeviceAgent(): boolean {
-  return isCommittedOnDeviceMobileRuntimeMode(
-    normalizeMobileRuntimeMode(readRuntimeMode()),
+  const mode = normalizeMobileRuntimeMode(readRuntimeMode());
+  return (
+    mode === "tunnel-to-mobile" || isCommittedOnDeviceMobileRuntimeMode(mode)
   );
 }
 

--- a/packages/app-core/src/api/ios-local-agent-transport.ts
+++ b/packages/app-core/src/api/ios-local-agent-transport.ts
@@ -221,6 +221,7 @@ function readRuntimeMode(): string | null {
 function shouldRequireFullBunRuntime(): boolean {
   const env = viteEnv();
   const runtimeMode = readRuntimeMode();
+  if (isRemoteMacRuntimeMode(runtimeMode)) return false;
   if (runtimeMode === "cloud" || runtimeMode === "cloud-hybrid") return false;
   const fullBunBuiltIn = isFullBunRuntimeBuiltIn();
   return (
@@ -232,6 +233,10 @@ function shouldRequireFullBunRuntime(): boolean {
         (isTruthyBuildFlag(env.PROD) && runtimeMode === "local") ||
         (isNativeIos() && !isDevBuild() && runtimeMode === "local")))
   );
+}
+
+function isRemoteMacRuntimeMode(mode: string | null): boolean {
+  return mode === "remote-mac";
 }
 
 function hasIosFullBunSmokeRequest(): boolean {
@@ -291,7 +296,7 @@ function isNativeIosCloudRuntime(): boolean {
 }
 
 function isPureRemoteRuntimeMode(mode: string | null): boolean {
-  return mode === "cloud";
+  return mode === "cloud" || isRemoteMacRuntimeMode(mode);
 }
 
 function usesStrictIosNetworkPolicy(): boolean {
@@ -407,6 +412,7 @@ function iosRuntimeHasOnDeviceAgent(): boolean {
 
 function canUseIosLocalAgentIpc(): boolean {
   if (!isNativeIos()) return false;
+  if (isRemoteMacRuntimeMode(readRuntimeMode())) return false;
   if (iosRuntimeHasOnDeviceAgent() || shouldRequireFullBunRuntime()) {
     return true;
   }
@@ -949,6 +955,9 @@ export async function handleIosLocalAgentNativeRequest(
   const method = (options.method ?? "GET").trim().toUpperCase();
   if (!/^[A-Z]{1,16}$/.test(method)) {
     throw new Error("Unsupported HTTP method");
+  }
+  if (isRemoteMacRuntimeMode(readRuntimeMode())) {
+    throw new TypeError("iOS remote-agent modes cannot use local-agent IPC");
   }
   if (
     isNativeIosCloudRuntime() &&

--- a/packages/app-core/src/api/ios-local-agent-transport.ts
+++ b/packages/app-core/src/api/ios-local-agent-transport.ts
@@ -44,10 +44,12 @@ import {
 } from "@elizaos/ui/bridge/eliza-window-bridge";
 import { isStoreBuild } from "@elizaos/ui/build-variant";
 import {
+  isCommittedOnDeviceMobileRuntimeMode,
   isMobileLocalAgentUrl as isConfiguredMobileLocalAgentUrl,
   isMobileLocalAgentIpcUrl,
   MOBILE_LOCAL_AGENT_PORT,
   mobileLocalAgentPathFromUrl,
+  normalizeMobileRuntimeMode,
 } from "@elizaos/ui/first-run/mobile-runtime-mode";
 
 let transport: AgentRequestTransport | null = null;
@@ -380,15 +382,26 @@ function isMobileLocalAgentUrl(value: string): boolean {
 }
 
 /**
+ * Classify the legacy loopback HTTP identity only when the selected runtime
+ * actually owns an on-device agent. In `remote-mac`, loopback port 31337 is
+ * the developer's Mac and must stay on the real network transport.
+ */
+function isIosOnDeviceAgentHttpUrl(value: string): boolean {
+  if (!isMobileLocalAgentUrl(value)) return false;
+  const mode = readRuntimeMode();
+  return mode === null
+    ? canUseIosLocalAgentIpc()
+    : iosRuntimeHasOnDeviceAgent();
+}
+
+/**
  * Whether the selected iOS runtime owns an on-device agent process/runtime.
- * `cloud` is the only pure remote mode. `cloud-hybrid` still runs the bundled
- * agent while routing inference through cloud, and `tunnel-to-mobile` exposes
- * the phone-side agent through a relay for a remote client.
+ * Delegates to the first-run runtime-mode authority so transports cannot drift
+ * from restore and active-server policy.
  */
 function iosRuntimeHasOnDeviceAgent(): boolean {
-  const mode = readRuntimeMode();
-  return (
-    mode === "local" || mode === "cloud-hybrid" || mode === "tunnel-to-mobile"
+  return isCommittedOnDeviceMobileRuntimeMode(
+    normalizeMobileRuntimeMode(readRuntimeMode()),
   );
 }
 
@@ -470,7 +483,7 @@ export function isIosInProcessLocalAgentUrl(url: string): boolean {
     // explicitly outside the in-process transport.
     return false;
   }
-  return isNativeIos() && isMobileLocalAgentUrl(url);
+  return isNativeIos() && isIosOnDeviceAgentHttpUrl(url);
 }
 
 export function isIosInProcessLocalAgentBase(
@@ -1025,7 +1038,7 @@ function shouldBridgeFetchUrl(url: URL): boolean {
       "iOS store/cloud builds block cleartext loopback or private-network requests",
     );
   }
-  if (isMobileLocalAgentUrl(url.toString())) return true;
+  if (isIosOnDeviceAgentHttpUrl(url.toString())) return true;
   if (isNativeIosCloudRuntime()) return false;
   if ((url.pathname || "").startsWith("/api/")) {
     return (

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -69,7 +69,7 @@
       function nativeModeUsesOnDeviceAgent() {
         try {
           const mode = window.localStorage.getItem(mobileRuntimeModeStorageKey);
-          if (mode === 'remote-mac' || mode === 'cloud' || mode === 'tunnel-to-mobile') {
+          if (mode === 'remote-mac' || mode === 'cloud') {
             return false;
           }
           return true;

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -42,6 +42,7 @@
       const ipcBase = 'eliza-local-agent://ipc';
       const ipcPathPrefix = `//${ipcHost}`;
       const localAgentPort = '31337';
+      const mobileRuntimeModeStorageKey = 'eliza:mobile-runtime-mode';
 
       // The loopback (127.0.0.1:31337) → native-IPC rewrite below is only
       // correct on a NATIVE Capacitor platform (iOS/Android), where the
@@ -62,6 +63,19 @@
           return p === 'ios' || p === 'android';
         } catch (_) {
           return false;
+        }
+      }
+
+      function nativeModeUsesOnDeviceAgent() {
+        try {
+          const mode = window.localStorage.getItem(mobileRuntimeModeStorageKey);
+          if (mode === 'remote-mac' || mode === 'cloud' || mode === 'tunnel-to-mobile') {
+            return false;
+          }
+          return true;
+        } catch (_) {
+          // error-policy:J4 storage unavailable — preserve native-local compatibility.
+          return true;
         }
       }
 
@@ -87,6 +101,7 @@
           const url = new URL(trimmed, window.location?.href ? window.location.href : 'https://cloud.eliza.app');
           if (
             isNativeCapacitorAgentHost() &&
+            nativeModeUsesOnDeviceAgent() &&
             url.protocol === 'http:' &&
             url.port === localAgentPort &&
             (url.hostname === '127.0.0.1' || url.hostname === 'localhost' || url.hostname === '[::1]' || url.hostname === '::1')

--- a/packages/app/test/index-html-fetch-bridge.test.ts
+++ b/packages/app/test/index-html-fetch-bridge.test.ts
@@ -110,7 +110,7 @@ describe("index.html local-agent fetch bridge", () => {
     });
   });
 
-  it.each(["remote-mac", "cloud", "tunnel-to-mobile"])(
+  it.each(["remote-mac", "cloud"])(
     "lets native %s mode reach loopback HTTP directly",
     async (runtimeMode) => {
       const { agentRequest, originalFetch } = createHarness("ios", runtimeMode);
@@ -123,7 +123,7 @@ describe("index.html local-agent fetch bridge", () => {
     },
   );
 
-  it.each(["local", "cloud-hybrid"])(
+  it.each(["local", "cloud-hybrid", "tunnel-to-mobile"])(
     "keeps native %s mode on Agent.request",
     async (runtimeMode) => {
       const { agentRequest, originalFetch } = createHarness("ios", runtimeMode);

--- a/packages/app/test/index-html-fetch-bridge.test.ts
+++ b/packages/app/test/index-html-fetch-bridge.test.ts
@@ -16,6 +16,8 @@ interface BridgeHarness {
 
 const originalWindowFetch = window.fetch;
 const originalWindowCapacitor = Reflect.get(window, "Capacitor");
+const runtimeModeStorageKey = "eliza:mobile-runtime-mode";
+const originalRuntimeMode = window.localStorage.getItem(runtimeModeStorageKey);
 
 afterEach(() => {
   window.fetch = originalWindowFetch;
@@ -25,6 +27,11 @@ afterEach(() => {
     Reflect.set(window, "Capacitor", originalWindowCapacitor);
   }
   Reflect.deleteProperty(window, "__ELIZA_ANDROID_IPC_FETCH_BRIDGE__");
+  if (originalRuntimeMode === null) {
+    window.localStorage.removeItem(runtimeModeStorageKey);
+  } else {
+    window.localStorage.setItem(runtimeModeStorageKey, originalRuntimeMode);
+  }
 });
 
 function installBridgeScript(): void {
@@ -34,12 +41,15 @@ function installBridgeScript(): void {
     candidate.textContent?.includes("__ELIZA_ANDROID_IPC_FETCH_BRIDGE__"),
   );
   if (!script?.textContent) throw new Error("missing fetch bridge script");
-  // biome-ignore lint/security/noGlobalEval: executes the committed index.html
-  // inline bridge script (trusted build artifact, not user input) to test it.
+  // Executes the committed inline bridge script, never user input.
+  // biome-ignore lint/security/noGlobalEval: the HTML shell is the system under test
   window.eval(script.textContent);
 }
 
-function createHarness(platform: string | (() => string)): BridgeHarness {
+function createHarness(
+  platform: string | (() => string),
+  runtimeMode?: string,
+): BridgeHarness {
   const agentRequest = vi.fn(async () => ({
     status: 201,
     body: "bridged",
@@ -49,6 +59,11 @@ function createHarness(platform: string | (() => string)): BridgeHarness {
     return new this.Response("original", { status: 202 });
   });
   window.fetch = originalFetch as unknown as typeof window.fetch;
+  if (runtimeMode === undefined) {
+    window.localStorage.removeItem(runtimeModeStorageKey);
+  } else {
+    window.localStorage.setItem(runtimeModeStorageKey, runtimeMode);
+  }
   Object.assign(window, {
     Capacitor: {
       getPlatform: typeof platform === "function" ? platform : () => platform,
@@ -94,6 +109,36 @@ describe("index.html local-agent fetch bridge", () => {
       body: null,
     });
   });
+
+  it.each(["remote-mac", "cloud", "tunnel-to-mobile"])(
+    "lets native %s mode reach loopback HTTP directly",
+    async (runtimeMode) => {
+      const { agentRequest, originalFetch } = createHarness("ios", runtimeMode);
+
+      const response = await window.fetch("http://127.0.0.1:31337/api/health");
+
+      expect(await response.text()).toBe("original");
+      expect(originalFetch).toHaveBeenCalledTimes(1);
+      expect(agentRequest).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["local", "cloud-hybrid"])(
+    "keeps native %s mode on Agent.request",
+    async (runtimeMode) => {
+      const { agentRequest, originalFetch } = createHarness("ios", runtimeMode);
+
+      await window.fetch("http://127.0.0.1:31337/api/health");
+
+      expect(originalFetch).not.toHaveBeenCalled();
+      expect(agentRequest).toHaveBeenCalledWith({
+        method: "GET",
+        path: "/api/health",
+        headers: {},
+        body: null,
+      });
+    },
+  );
 
   it("continues to bridge explicit IPC URLs on every platform", async () => {
     const { agentRequest, originalFetch } = createHarness("web");

--- a/packages/ui/src/api/ios-local-agent-transport.test.ts
+++ b/packages/ui/src/api/ios-local-agent-transport.test.ts
@@ -260,6 +260,52 @@ describe("iOS local agent transport (ui copy)", () => {
     },
   );
 
+  it.each(["remote-mac"])(
+    "lets the explicit %s selection override a strict local-runtime build",
+    async (mode) => {
+      vi.stubEnv("VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK", "1");
+      vi.stubEnv("VITE_ELIZA_IOS_FULL_BUN_STRICT", "1");
+      capacitorState.pluginAvailable = true;
+      const start = vi.fn(async () => ({ ok: true }));
+      const getStatus = vi.fn(async () => ({ ready: true, engine: "bun" }));
+      const call = vi.fn();
+      vi.doMock("@elizaos/capacitor-bun-runtime", () => ({
+        ElizaBunRuntime: { start, getStatus, call },
+      }));
+      const originalFetch = vi.fn(async () =>
+        Response.json({ source: "mac-runtime" }),
+      );
+      vi.stubGlobal("fetch", originalFetch);
+      vi.stubGlobal("localStorage", {
+        getItem: (key: string) =>
+          key === "eliza:mobile-runtime-mode" ? mode : null,
+      });
+
+      const {
+        handleIosLocalAgentNativeRequest,
+        installIosLocalAgentFetchBridge,
+      } = await import("./ios-local-agent-transport");
+      installIosLocalAgentFetchBridge();
+
+      const url = "http://127.0.0.1:31337/api/notifications?limit=100";
+      const response = await fetch(url);
+
+      await expect(response.json()).resolves.toEqual({
+        source: "mac-runtime",
+      });
+      expect(originalFetch).toHaveBeenCalledWith(url, undefined);
+      await expect(
+        handleIosLocalAgentNativeRequest({
+          method: "GET",
+          path: "/api/notifications?limit=100",
+        }),
+      ).rejects.toThrow("remote-agent modes cannot use local-agent IPC");
+      expect(start).not.toHaveBeenCalled();
+      expect(getStatus).not.toHaveBeenCalled();
+      expect(call).not.toHaveBeenCalled();
+    },
+  );
+
   it("retains port 31337 as the on-device agent in local mode", async () => {
     vi.stubGlobal("localStorage", {
       getItem: (key: string) =>

--- a/packages/ui/src/api/ios-local-agent-transport.test.ts
+++ b/packages/ui/src/api/ios-local-agent-transport.test.ts
@@ -231,7 +231,7 @@ describe("iOS local agent transport (ui copy)", () => {
     expect(originalFetch).toHaveBeenCalledTimes(1);
   });
 
-  it.each(["remote-mac", "cloud", "tunnel-to-mobile"])(
+  it.each(["remote-mac", "cloud"])(
     "keeps port 31337 on the real network transport in %s mode",
     async (mode) => {
       vi.stubEnv("VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK", "1");
@@ -260,51 +260,48 @@ describe("iOS local agent transport (ui copy)", () => {
     },
   );
 
-  it.each(["remote-mac"])(
-    "lets the explicit %s selection override a strict local-runtime build",
-    async (mode) => {
-      vi.stubEnv("VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK", "1");
-      vi.stubEnv("VITE_ELIZA_IOS_FULL_BUN_STRICT", "1");
-      capacitorState.pluginAvailable = true;
-      const start = vi.fn(async () => ({ ok: true }));
-      const getStatus = vi.fn(async () => ({ ready: true, engine: "bun" }));
-      const call = vi.fn();
-      vi.doMock("@elizaos/capacitor-bun-runtime", () => ({
-        ElizaBunRuntime: { start, getStatus, call },
-      }));
-      const originalFetch = vi.fn(async () =>
-        Response.json({ source: "mac-runtime" }),
-      );
-      vi.stubGlobal("fetch", originalFetch);
-      vi.stubGlobal("localStorage", {
-        getItem: (key: string) =>
-          key === "eliza:mobile-runtime-mode" ? mode : null,
-      });
+  it("lets the explicit remote-mac selection override a strict local-runtime build", async () => {
+    vi.stubEnv("VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK", "1");
+    vi.stubEnv("VITE_ELIZA_IOS_FULL_BUN_STRICT", "1");
+    capacitorState.pluginAvailable = true;
+    const start = vi.fn(async () => ({ ok: true }));
+    const getStatus = vi.fn(async () => ({ ready: true, engine: "bun" }));
+    const call = vi.fn();
+    vi.doMock("@elizaos/capacitor-bun-runtime", () => ({
+      ElizaBunRuntime: { start, getStatus, call },
+    }));
+    const originalFetch = vi.fn(async () =>
+      Response.json({ source: "mac-runtime" }),
+    );
+    vi.stubGlobal("fetch", originalFetch);
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) =>
+        key === "eliza:mobile-runtime-mode" ? "remote-mac" : null,
+    });
 
-      const {
-        handleIosLocalAgentNativeRequest,
-        installIosLocalAgentFetchBridge,
-      } = await import("./ios-local-agent-transport");
-      installIosLocalAgentFetchBridge();
+    const {
+      handleIosLocalAgentNativeRequest,
+      installIosLocalAgentFetchBridge,
+    } = await import("./ios-local-agent-transport");
+    installIosLocalAgentFetchBridge();
 
-      const url = "http://127.0.0.1:31337/api/notifications?limit=100";
-      const response = await fetch(url);
+    const url = "http://127.0.0.1:31337/api/notifications?limit=100";
+    const response = await fetch(url);
 
-      await expect(response.json()).resolves.toEqual({
-        source: "mac-runtime",
-      });
-      expect(originalFetch).toHaveBeenCalledWith(url, undefined);
-      await expect(
-        handleIosLocalAgentNativeRequest({
-          method: "GET",
-          path: "/api/notifications?limit=100",
-        }),
-      ).rejects.toThrow("remote-agent modes cannot use local-agent IPC");
-      expect(start).not.toHaveBeenCalled();
-      expect(getStatus).not.toHaveBeenCalled();
-      expect(call).not.toHaveBeenCalled();
-    },
-  );
+    await expect(response.json()).resolves.toEqual({
+      source: "mac-runtime",
+    });
+    expect(originalFetch).toHaveBeenCalledWith(url, undefined);
+    await expect(
+      handleIosLocalAgentNativeRequest({
+        method: "GET",
+        path: "/api/notifications?limit=100",
+      }),
+    ).rejects.toThrow("remote-agent modes cannot use local-agent IPC");
+    expect(start).not.toHaveBeenCalled();
+    expect(getStatus).not.toHaveBeenCalled();
+    expect(call).not.toHaveBeenCalled();
+  });
 
   it("retains port 31337 as the on-device agent in local mode", async () => {
     vi.stubGlobal("localStorage", {
@@ -321,7 +318,7 @@ describe("iOS local agent transport (ui copy)", () => {
     ).toBe(true);
   });
 
-  it.each(["local", "cloud-hybrid"])(
+  it.each(["local", "cloud-hybrid", "tunnel-to-mobile"])(
     "retains native IPC as the on-device agent in %s mode",
     async (mode) => {
       vi.stubGlobal("localStorage", {

--- a/packages/ui/src/api/ios-local-agent-transport.test.ts
+++ b/packages/ui/src/api/ios-local-agent-transport.test.ts
@@ -230,4 +230,66 @@ describe("iOS local agent transport (ui copy)", () => {
     await expect(response.json()).resolves.toEqual({ ready: true });
     expect(originalFetch).toHaveBeenCalledTimes(1);
   });
+
+  it.each(["remote-mac", "cloud", "tunnel-to-mobile"])(
+    "keeps port 31337 on the real network transport in %s mode",
+    async (mode) => {
+      vi.stubEnv("VITE_ELIZA_IOS_ALLOW_SIMULATOR_LOOPBACK", "1");
+      const originalFetch = vi.fn(async () =>
+        Response.json({ source: "mac-runtime" }),
+      );
+      vi.stubGlobal("fetch", originalFetch);
+      vi.stubGlobal("localStorage", {
+        getItem: (key: string) =>
+          key === "eliza:mobile-runtime-mode" ? mode : null,
+      });
+
+      const { installIosLocalAgentFetchBridge, isIosInProcessLocalAgentUrl } =
+        await import("./ios-local-agent-transport");
+      const macRuntimeUrl = "http://127.0.0.1:31337/api/health";
+
+      expect(isIosInProcessLocalAgentUrl(macRuntimeUrl)).toBe(false);
+      installIosLocalAgentFetchBridge();
+      const response = await fetch(macRuntimeUrl);
+
+      await expect(response.json()).resolves.toEqual({
+        source: "mac-runtime",
+      });
+      expect(originalFetch).toHaveBeenCalledOnce();
+      expect(originalFetch).toHaveBeenCalledWith(macRuntimeUrl, undefined);
+    },
+  );
+
+  it("retains port 31337 as the on-device agent in local mode", async () => {
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) =>
+        key === "eliza:mobile-runtime-mode" ? "local" : null,
+    });
+
+    const { isIosInProcessLocalAgentUrl } = await import(
+      "./ios-local-agent-transport"
+    );
+
+    expect(
+      isIosInProcessLocalAgentUrl("http://127.0.0.1:31337/api/health"),
+    ).toBe(true);
+  });
+
+  it.each(["local", "cloud-hybrid"])(
+    "retains native IPC as the on-device agent in %s mode",
+    async (mode) => {
+      vi.stubGlobal("localStorage", {
+        getItem: (key: string) =>
+          key === "eliza:mobile-runtime-mode" ? mode : null,
+      });
+
+      const { isIosInProcessLocalAgentUrl } = await import(
+        "./ios-local-agent-transport"
+      );
+
+      expect(
+        isIosInProcessLocalAgentUrl("eliza-local-agent://ipc/api/health"),
+      ).toBe(true);
+    },
+  );
 });

--- a/packages/ui/src/api/ios-local-agent-transport.ts
+++ b/packages/ui/src/api/ios-local-agent-transport.ts
@@ -11,9 +11,11 @@ import {
 import { isStoreBuild } from "../build-variant";
 import { getBootConfig } from "../config/boot-config";
 import {
+  isCommittedOnDeviceMobileRuntimeMode,
   isMobileLocalAgentUrl as isConfiguredMobileLocalAgentUrl,
   isMobileLocalAgentIpcUrl,
   mobileLocalAgentPathFromUrl,
+  normalizeMobileRuntimeMode,
 } from "../first-run/mobile-runtime-mode";
 import { reportRendererDiagnostic } from "../utils/renderer-diagnostics";
 import {
@@ -606,14 +608,26 @@ function isMobileLocalAgentUrl(value: string): boolean {
 }
 
 /**
+ * Classify the legacy loopback HTTP identity only when the selected runtime
+ * actually owns an on-device agent. In `remote-mac`, loopback port 31337 is
+ * the developer's Mac and must stay on the real network transport.
+ */
+function isIosOnDeviceAgentHttpUrl(value: string): boolean {
+  if (!isMobileLocalAgentUrl(value)) return false;
+  const mode = readRuntimeMode();
+  return mode === null
+    ? canUseIosLocalAgentIpc()
+    : iosRuntimeHasOnDeviceAgent();
+}
+
+/**
  * Whether the selected runtime runs an on-device agent that serves local-agent
- * IPC. `local`, `cloud-hybrid`, and `tunnel-to-mobile` all run the bundled
- * phone-side agent; only pure `cloud` talks exclusively to a remote agent.
+ * IPC. Delegates to the first-run runtime-mode authority so transports cannot
+ * drift from restore and active-server policy.
  */
 function iosRuntimeHasOnDeviceAgent(): boolean {
-  const mode = readRuntimeMode();
-  return (
-    mode === "local" || mode === "cloud-hybrid" || mode === "tunnel-to-mobile"
+  return isCommittedOnDeviceMobileRuntimeMode(
+    normalizeMobileRuntimeMode(readRuntimeMode()),
   );
 }
 
@@ -695,7 +709,7 @@ export function isIosInProcessLocalAgentUrl(url: string): boolean {
     // network policy rather than treating it as an in-process agent URL.
     return false;
   }
-  return isNativeIos() && isMobileLocalAgentUrl(url);
+  return isNativeIos() && isIosOnDeviceAgentHttpUrl(url);
 }
 
 export function isIosInProcessLocalAgentBase(
@@ -1126,7 +1140,7 @@ function shouldBridgeFetchUrl(url: URL): boolean {
       "iOS store/cloud builds block cleartext loopback or private-network requests",
     );
   }
-  if (isMobileLocalAgentUrl(url.toString())) return true;
+  if (isIosOnDeviceAgentHttpUrl(url.toString())) return true;
   if (isNativeIosCloudRuntime()) return false;
   if ((url.pathname || "").startsWith("/api/")) {
     return (

--- a/packages/ui/src/api/ios-local-agent-transport.ts
+++ b/packages/ui/src/api/ios-local-agent-transport.ts
@@ -630,12 +630,13 @@ function isIosOnDeviceAgentHttpUrl(value: string): boolean {
 
 /**
  * Whether the selected runtime runs an on-device agent that serves local-agent
- * IPC. Delegates to the first-run runtime-mode authority so transports cannot
- * drift from restore and active-server policy.
+ * IPC. Tunnel mode is the phone-side relay into Bun IPC, even though first-run
+ * treats its connection target as externally configured.
  */
 function iosRuntimeHasOnDeviceAgent(): boolean {
-  return isCommittedOnDeviceMobileRuntimeMode(
-    normalizeMobileRuntimeMode(readRuntimeMode()),
+  const mode = normalizeMobileRuntimeMode(readRuntimeMode());
+  return (
+    mode === "tunnel-to-mobile" || isCommittedOnDeviceMobileRuntimeMode(mode)
   );
 }
 

--- a/packages/ui/src/api/ios-local-agent-transport.ts
+++ b/packages/ui/src/api/ios-local-agent-transport.ts
@@ -49,6 +49,8 @@ const IOS_LOCAL_AGENT_IPC_BASE = "eliza-local-agent://ipc";
  */
 const IOS_CLOUD_MODE_LOCAL_IPC_POLICY_MESSAGE =
   "iOS cloud builds cannot use local-agent IPC unless local runtime mode is active";
+const IOS_REMOTE_MODE_LOCAL_IPC_POLICY_MESSAGE =
+  "iOS remote-agent modes cannot use local-agent IPC";
 
 /**
  * Message fragments of TERMINAL (non-retryable) native agent/transport boot
@@ -59,6 +61,7 @@ const IOS_CLOUD_MODE_LOCAL_IPC_POLICY_MESSAGE =
  */
 const TERMINAL_IOS_NATIVE_AGENT_BOOT_ERROR_FRAGMENTS: readonly string[] = [
   IOS_CLOUD_MODE_LOCAL_IPC_POLICY_MESSAGE,
+  IOS_REMOTE_MODE_LOCAL_IPC_POLICY_MESSAGE,
   "iOS store builds must use eliza-local-agent://ipc for local-agent requests",
   "iOS store/cloud builds block cleartext loopback or private-network requests",
   // fullBunStartupError(): the build REQUIRES the embedded Bun engine and it
@@ -447,6 +450,7 @@ function readRuntimeMode(): string | null {
 function shouldRequireFullBunRuntime(): boolean {
   const env = viteEnv();
   const runtimeMode = readRuntimeMode();
+  if (isRemoteMacRuntimeMode(runtimeMode)) return false;
   if (runtimeMode === "cloud" || runtimeMode === "cloud-hybrid") return false;
   const fullBunBuiltIn = isFullBunRuntimeBuiltIn();
   return (
@@ -458,6 +462,10 @@ function shouldRequireFullBunRuntime(): boolean {
         (isTruthyBuildFlag(env.PROD) && runtimeMode === "local") ||
         (isNativeIos() && !isDevBuild() && runtimeMode === "local")))
   );
+}
+
+function isRemoteMacRuntimeMode(mode: string | null): boolean {
+  return mode === "remote-mac";
 }
 
 function hasIosFullBunSmokeRequest(): boolean {
@@ -633,6 +641,7 @@ function iosRuntimeHasOnDeviceAgent(): boolean {
 
 function canUseIosLocalAgentIpc(): boolean {
   if (!isNativeIos()) return false;
+  if (isRemoteMacRuntimeMode(readRuntimeMode())) return false;
   if (iosRuntimeHasOnDeviceAgent() || shouldRequireFullBunRuntime()) {
     return true;
   }
@@ -1057,6 +1066,9 @@ export async function handleIosLocalAgentNativeRequest(
   const method = (options.method ?? "GET").trim().toUpperCase();
   if (!/^[A-Z]{1,16}$/.test(method)) {
     throw new Error("Unsupported HTTP method");
+  }
+  if (isRemoteMacRuntimeMode(readRuntimeMode())) {
+    throw new TypeError(IOS_REMOTE_MODE_LOCAL_IPC_POLICY_MESSAGE);
   }
   if (
     isNativeIosCloudRuntime() &&

--- a/packages/ui/src/components/local-inference/useHomeModelStatus.test.tsx
+++ b/packages/ui/src/components/local-inference/useHomeModelStatus.test.tsx
@@ -7,8 +7,9 @@
  * gate after deferred Cloud registration. Network seams are mocked in jsdom.
  */
 
-import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MOBILE_RUNTIME_MODE_CHANGED_EVENT } from "../../events";
 import type { UseRuntimeModeResult } from "../../hooks/useRuntimeMode";
 
 const runtimeModeMock = vi.hoisted(() => ({
@@ -40,6 +41,15 @@ const eventSourceMock = vi.hoisted(() => ({
 // Auth gate (#11084): the hook must stay dormant until the shared auth
 // snapshot reports an authenticated session. Mutable so tests can flip it.
 const authMock = vi.hoisted(() => ({ authenticated: true }));
+const mobileRuntimeModeMock = vi.hoisted(() => ({
+  value: null as
+    | "remote-mac"
+    | "cloud"
+    | "cloud-hybrid"
+    | "local"
+    | "tunnel-to-mobile"
+    | null,
+}));
 
 vi.mock("../../hooks/useAuthStatus", () => ({
   useIsAuthenticated: () => authMock.authenticated,
@@ -47,6 +57,10 @@ vi.mock("../../hooks/useAuthStatus", () => ({
 
 vi.mock("../../hooks/useRuntimeMode", () => ({
   useRuntimeMode: () => runtimeModeMock.value,
+}));
+
+vi.mock("../../first-run/mobile-runtime-mode", () => ({
+  readPersistedMobileRuntimeMode: () => mobileRuntimeModeMock.value,
 }));
 
 vi.mock("../../api", () => ({
@@ -113,6 +127,7 @@ beforeEach(() => {
   clientMock.getLocalInferenceHub.mockResolvedValue(emptyHub);
   eventSourceMock.openEventSource.mockClear();
   authMock.authenticated = true;
+  mobileRuntimeModeMock.value = null;
   setRuntimeMode("local");
 });
 
@@ -136,6 +151,66 @@ describe("useHomeModelStatus", () => {
       expect(eventSourceMock.openEventSource).not.toHaveBeenCalled();
     },
   );
+
+  it.each(["remote-mac", "tunnel-to-mobile"] as const)(
+    "does not poll phone-local inference for %s placement on a local Mac server",
+    async (mobileRuntimeMode) => {
+      mobileRuntimeModeMock.value = mobileRuntimeMode;
+
+      const { result } = renderHook(() => useHomeModelStatus());
+
+      await waitFor(() => {
+        expect(result.current.kind).toBe("not-required");
+      });
+      expect(clientMock.getModelsConfig).not.toHaveBeenCalled();
+      expect(clientMock.getLocalInferenceHub).not.toHaveBeenCalled();
+      expect(eventSourceMock.openEventSource).not.toHaveBeenCalled();
+    },
+  );
+
+  it("stops phone-local readiness tracking when placement switches to remote Mac", async () => {
+    const { result } = renderHook(() => useHomeModelStatus());
+
+    await waitFor(() => {
+      expect(clientMock.getLocalInferenceHub).toHaveBeenCalledTimes(1);
+    });
+    const stream = eventSourceMock.openEventSource.mock.results[0]?.value;
+
+    act(() => {
+      mobileRuntimeModeMock.value = "remote-mac";
+      document.dispatchEvent(
+        new CustomEvent(MOBILE_RUNTIME_MODE_CHANGED_EVENT, {
+          detail: { mode: "remote-mac" },
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.kind).toBe("not-required");
+    });
+    expect(stream?.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts phone-local readiness tracking when placement switches back to local", async () => {
+    mobileRuntimeModeMock.value = "remote-mac";
+    renderHook(() => useHomeModelStatus());
+
+    expect(clientMock.getLocalInferenceHub).not.toHaveBeenCalled();
+
+    act(() => {
+      mobileRuntimeModeMock.value = "local";
+      document.dispatchEvent(
+        new CustomEvent(MOBILE_RUNTIME_MODE_CHANGED_EVENT, {
+          detail: { mode: "local" },
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(clientMock.getLocalInferenceHub).toHaveBeenCalledTimes(1);
+    });
+    expect(eventSourceMock.openEventSource).toHaveBeenCalledTimes(1);
+  });
 
   it("polls local inference for local runtime mode", async () => {
     renderHook(() => useHomeModelStatus());

--- a/packages/ui/src/components/local-inference/useHomeModelStatus.ts
+++ b/packages/ui/src/components/local-inference/useHomeModelStatus.ts
@@ -53,22 +53,6 @@ function subscribeToMobileRuntimeMode(onStoreChange: () => void): () => void {
   };
 }
 
-function getMobileRuntimeModeSnapshot() {
-  return readPersistedMobileRuntimeMode();
-}
-
-function getServerMobileRuntimeModeSnapshot() {
-  return null;
-}
-
-function useMobileRuntimeMode() {
-  return useSyncExternalStore(
-    subscribeToMobileRuntimeMode,
-    getMobileRuntimeModeSnapshot,
-    getServerMobileRuntimeModeSnapshot,
-  );
-}
-
 function appendTokenParam(url: string): string {
   const token = getElizaApiToken()?.trim();
   if (!token) return url;
@@ -92,7 +76,11 @@ export function useHomeModelStatus(): HomeModelStatus {
   const [status, setStatus] = useState<HomeModelStatus>(NOT_REQUIRED);
   const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const routingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const mobileRuntimeMode = useMobileRuntimeMode();
+  const mobileRuntimeMode = useSyncExternalStore(
+    subscribeToMobileRuntimeMode,
+    readPersistedMobileRuntimeMode,
+    () => null,
+  );
   const runtimeMode = useRuntimeMode();
   // Auth gate (#11084): the shell mounts this hook before the auth probe
   // resolves, so the download SSE stream + hub fetches must stay dormant until

--- a/packages/ui/src/components/local-inference/useHomeModelStatus.ts
+++ b/packages/ui/src/components/local-inference/useHomeModelStatus.ts
@@ -5,11 +5,13 @@
  */
 
 import { normalizeServiceRoutingConfig } from "@elizaos/shared";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 
 import { client } from "../../api";
 import { supportsFullAppShellRoutes } from "../../api/app-shell-capabilities";
 import { isDesktopExternalApiBaseUrl } from "../../api/desktop-external-api-base";
+import { MOBILE_RUNTIME_MODE_CHANGED_EVENT } from "../../events";
+import { readPersistedMobileRuntimeMode } from "../../first-run/mobile-runtime-mode";
 import { useIsAuthenticated } from "../../hooks/useAuthStatus";
 import { useRuntimeMode } from "../../hooks/useRuntimeMode";
 import {
@@ -40,6 +42,33 @@ const ROUTING_STATUS_ERROR: HomeModelStatus = {
 
 const CLOUD_ROUTE_RECHECK_MS = 1_000;
 
+function subscribeToMobileRuntimeMode(onStoreChange: () => void): () => void {
+  if (typeof document === "undefined") return () => {};
+  document.addEventListener(MOBILE_RUNTIME_MODE_CHANGED_EVENT, onStoreChange);
+  return () => {
+    document.removeEventListener(
+      MOBILE_RUNTIME_MODE_CHANGED_EVENT,
+      onStoreChange,
+    );
+  };
+}
+
+function getMobileRuntimeModeSnapshot() {
+  return readPersistedMobileRuntimeMode();
+}
+
+function getServerMobileRuntimeModeSnapshot() {
+  return null;
+}
+
+function useMobileRuntimeMode() {
+  return useSyncExternalStore(
+    subscribeToMobileRuntimeMode,
+    getMobileRuntimeModeSnapshot,
+    getServerMobileRuntimeModeSnapshot,
+  );
+}
+
 function appendTokenParam(url: string): string {
   const token = getElizaApiToken()?.trim();
   if (!token) return url;
@@ -63,6 +92,7 @@ export function useHomeModelStatus(): HomeModelStatus {
   const [status, setStatus] = useState<HomeModelStatus>(NOT_REQUIRED);
   const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const routingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mobileRuntimeMode = useMobileRuntimeMode();
   const runtimeMode = useRuntimeMode();
   // Auth gate (#11084): the shell mounts this hook before the auth probe
   // resolves, so the download SSE stream + hub fetches must stay dormant until
@@ -76,6 +106,8 @@ export function useHomeModelStatus(): HomeModelStatus {
       runtimeMode.state.phase === "loading" ||
       runtimeMode.isCloudMode ||
       runtimeMode.isRemoteMode ||
+      mobileRuntimeMode === "remote-mac" ||
+      mobileRuntimeMode === "tunnel-to-mobile" ||
       !supportsLocalInferenceStatus()
     ) {
       setStatus(NOT_REQUIRED);
@@ -203,6 +235,7 @@ export function useHomeModelStatus(): HomeModelStatus {
     };
   }, [
     authenticated,
+    mobileRuntimeMode,
     runtimeMode.isCloudMode,
     runtimeMode.isRemoteMode,
     runtimeMode.state.phase,

--- a/packages/ui/src/state/persistence-cloud-active-server.test.ts
+++ b/packages/ui/src/state/persistence-cloud-active-server.test.ts
@@ -12,6 +12,7 @@ import { writeStoredStewardToken } from "@elizaos/shared/steward-session-client"
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_DIRECT_CLOUD_API_BASE_URL } from "../api/direct-cloud-endpoints";
 import { DEFAULT_BOOT_CONFIG, setBootConfig } from "../config/boot-config";
+import { MOBILE_RUNTIME_MODE_STORAGE_KEY } from "../first-run/mobile-runtime-mode";
 import { shellLocalStorage } from "../surface-realm-channel";
 import { ELIZA_CLOUD_CONTROL_PLANE_HOSTS } from "../utils/cloud-agent-base";
 import {
@@ -379,6 +380,39 @@ describe("Cloud active server persistence", () => {
       label: "On-device agent",
       apiBase: "eliza-local-agent://ipc",
     });
+  });
+
+  it("restores an explicit remote-mac loopback as a network backend", async () => {
+    const server = {
+      id: "remote:http://127.0.0.1:31337",
+      kind: "remote" as const,
+      label: "Mac agent",
+      apiBase: "http://127.0.0.1:31337",
+    };
+
+    expect(
+      reconcileMobileRestoredActiveServer({
+        platform: "ios",
+        mobileRuntimeMode: "remote-mac",
+        server,
+      }),
+    ).toBeUndefined();
+
+    localStorage.setItem(MOBILE_RUNTIME_MODE_STORAGE_KEY, "remote-mac");
+    const setBaseUrl = vi.fn();
+    const setToken = vi.fn();
+    const startLocalRuntime = vi.fn().mockResolvedValue(undefined);
+
+    await applyRestoredConnection({
+      restoredActiveServer: server,
+      clientRef: { setBaseUrl, setToken },
+      startLocalRuntime,
+    });
+
+    expect(setBaseUrl).toHaveBeenCalledWith("http://127.0.0.1:31337");
+    expect(setToken).toHaveBeenNthCalledWith(1, null);
+    expect(setToken).toHaveBeenNthCalledWith(2, null);
+    expect(startLocalRuntime).not.toHaveBeenCalled();
   });
 
   it("keeps the on-device agent record under cloud-hybrid (#16065 LP3 re-onboarded every cold launch)", () => {

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -36,6 +36,7 @@ import {
   ANDROID_LOCAL_AGENT_SERVER_ID,
   IOS_LOCAL_AGENT_IPC_BASE,
   isCommittedOnDeviceMobileRuntimeMode,
+  isMobileLocalAgentIpcUrl,
   isMobileLocalAgentUrl,
   MOBILE_LOCAL_AGENT_LABEL,
   MOBILE_LOCAL_AGENT_SERVER_ID,
@@ -266,8 +267,21 @@ function isMobileLocalAgentApiBase(value: string | undefined): boolean {
   return isMobileLocalAgentUrl(value);
 }
 
-function isMobileLocalActiveServer(server: PersistedActiveServer): boolean {
-  return server.kind === "local" || isMobileLocalAgentApiBase(server.apiBase);
+function isMobileLocalActiveServer(
+  server: PersistedActiveServer,
+  mobileRuntimeMode = readPersistedMobileRuntimeMode(),
+): boolean {
+  if (server.kind === "local" || isMobileLocalAgentIpcUrl(server.apiBase)) {
+    return true;
+  }
+
+  // The remote-Mac developer target deliberately reuses the desktop agent's
+  // loopback identity inside Simulator. Runtime mode is therefore the owner of
+  // that ambiguous URL: treating it as bundled IPC clears the saved server and
+  // boots the iOS Bun runtime on every cold launch.
+  if (mobileRuntimeMode === "remote-mac") return false;
+
+  return isMobileLocalAgentApiBase(server.apiBase);
 }
 
 function isLoopbackHostname(hostname: string): boolean {
@@ -317,7 +331,7 @@ export function reconcileMobileRestoredActiveServer(args: {
   platform: MobileNativePlatform;
 }): PersistedActiveServer | null | undefined {
   const { server, mobileRuntimeMode, platform } = args;
-  const mobileLocal = isMobileLocalActiveServer(server);
+  const mobileLocal = isMobileLocalActiveServer(server, mobileRuntimeMode);
   // The on-device agent is the chat target for BOTH committed on-device modes
   // — `local` (on-device inference) and `cloud-hybrid` (cloud inference, but
   // the on-device agent still owns chat, plugins, the voice bridge, and device


### PR DESCRIPTION
Closes #20347

## Outcome

Explicit `remote-mac` placement no longer inherits phone-local model readiness, loopback-to-native IPC rewriting, bundled Bun startup, or the native watchdog. The selected Mac runtime at `127.0.0.1:31337` remains a real network backend across initial render and cold restore.

`tunnel-to-mobile` also bypasses the unrelated home local-model readiness UI,
but its runtime ownership is deliberately unchanged: the phone-hosted agent,
full-Bun/IPC path, and watchdog remain active for the native mobile-agent relay.

## Root cause and fix

- Home model status inferred phone-local inference from server deployment alone. It now subscribes to the persisted mobile placement authority and bypasses `remote-mac` and `tunnel-to-mobile`, while real local and cloud-hybrid placement retain readiness tracking.
- The early app fetch shim and both mirrored iOS transport modules treated every loopback `:31337` URL as the in-process phone agent. They now preserve real HTTP for explicit `remote-mac` while retaining native IPC for local, cloud-hybrid, and tunnel modes.
- Cold restore treated the simulator Mac loopback identity as a stale mobile-local record. Runtime mode now disambiguates that URL and preserves the selected Mac target.
- The app-core and Swift watchdog/full-Bun gates now treat `remote-mac` as externally owned and reject direct local-agent IPC requests in that mode.

## Scope

Exactly 11 implementation/test paths across `packages/ui`, `packages/app`, and `packages/app-core`. No reminder semantics, notification store, chat UI, gateway, Worker, staging, production, provider, or credential changes.

## Verification

- Focused app-core/UI/app transport, restore, and model-status tests: 97/97 (app-core 38, UI 50, app bridge 9)
- `packages/app-core` typecheck: PASS
- `packages/ui` typecheck: PASS
- `packages/app` typecheck: PASS
- Affected package builds: PASS on exact head for app-core, UI, and app; app bundle stamped `0c6b802d147e`
- Exact-path Biome: PASS
- `git diff --check`: PASS
- Independent exact-head review: PASS at `0c6b802d147e8bd36c508442990a7338306c89e2` / tree `cd81d7cc5b77b84c423d677c0e4ffff1e5586680` / base `48b63d83a38007f59189b3a88e1d7e9bbdb2c55f`; no P0-P3 and no-swap PASS ([durable review receipt](https://github.com/elizaOS/eliza/pull/20491#issuecomment-5307001377))

## Real device/runtime evidence

- Rebuilt and reinstalled iOS Simulator bundle, explicit `remote-mac`, real Mac runtime on `127.0.0.1:31337`, real Cerebras-backed chat: exact reply `native-chat-ok`.
- Remote-Mac video: [42.667s H.264 walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20491-ios20347-remote-mac-proof-github.mp4) (`sha256:d9304a2f08e2d99f98378ee6ce4d91e21f899c901f532b770cc11591a29a615d`; original capture preserved separately).
- iOS chat frame: [rebuilt/reinstalled real `native-chat-ok` frame](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20491-ed1a-real-chat-overlay.jpeg) (`sha256:ca5cde9d12df15d46743bdf0a812cfac41c12276db7ef69c25bbd7ed93cb1ec7`).
- Strictly signed packaged macOS build reached the same real runtime and returned `macos-native-ok`; [composition-control frame](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20491-ed1a-packaged-real-chat.jpeg) (`sha256:ead3c10b3055f23d0b09ddfb1ffb90b77f9dc1650469c897beb97900043e5819`).
- Source/evidence composition proof: the first four transport commits are byte-equivalent to the proved stack; the two terminal commits restore phone-owned tunnel semantics and remove single-use wrappers. Final branch is based directly on current `develop@48b63d83a38007f59189b3a88e1d7e9bbdb2c55f`.

## Evidence matrix

| Evidence | Receipt |
| --- | --- |
| Before/after mobile screenshot | Attached above |
| Mobile walkthrough video | Attached above |
| Native/runtime logs | `<details>` below |
| Frontend console/network | `<details>` below |
| Real model behavior | Real Cerebras-backed `native-chat-ok` turn above; no mocked model |
| Domain artifact | Conversation/message readback in `<details>` below |
| Desktop screenshot | Attached above |
| Desktop video | N/A - the behavior change is iOS transport ownership; macOS was rebuilt only as a composition control |
| Voice/audio | N/A - no voice behavior changed |
| Staging/deployment | N/A - native local/simulator path only; no Cloud or production code changed |

<details>
<summary>Native/runtime and domain receipts</summary>

Observed runtime sequence, reviewed against the captured pixels and domain readback:

```text
runtime mode: remote-mac
selected backend: http://127.0.0.1:31337
iOS rebuilt/reinstalled turn result: native-chat-ok
packaged macOS composition-control result: macos-native-ok
conversation readback: one active conversation; assistant replies persisted in the native API response
```

No credentials, provider keys, authorization headers, or private environment values are included.

</details>

## Explicit non-claims

- Native notification delivery is a separately reproduced HOLD and is not claimed fixed here.
- Home/chat glass and ChoiceWidget presentation are separately owned by #20462 and are not claimed fixed here.
- Simulator and ports 31337/31338 were released after evidence capture and were not restarted or mutated for publication.

<!-- evidence-head:0c6b802d147e8bd36c508442990a7338306c89e2 -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20491-0EB5AC57-42E1-4BDD-8B9A-A6576CCD1A91.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20491-ed1a-real-chat-overlay.jpeg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20491-ios20347-remote-mac-proof-github.mp4

<!-- evidence-row:backend-logs -->
- [x] [20491-20347-backend-log-v2.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20491-20347-backend-log-v2.txt)

<!-- evidence-row:frontend-logs -->
- [x] [20491-20347-frontend-log-v2.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20491-20347-frontend-log-v2.txt)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - the patch changes native runtime placement and transport, not prompt or model behavior; the real Cerebras-backed exact output is shown in the walkthrough and domain readback

<!-- evidence-row:domain-artifacts -->
- [x] [20491-20347-domain-readback.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20491-20347-domain-readback.txt)

<!-- evidence-row:ocr-review -->
- [x] [20491-20347-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20491-20347-ocr-review.txt)

