### PR TITLE
fix(macos): keep expanded chat overlay inside native window

### DIFF
--- a/packages/app/test/electrobun-packaged/electrobun-bottom-bar.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/electrobun-bottom-bar.e2e.spec.ts
@@ -270,6 +270,7 @@ test("desktop popup shell exposes the accessible pill, hotkey toggle, and tray l
       panelRight: number;
       pillTop: number;
       viewportWidth: number;
+      viewportHeight: number;
     }> =>
       harness.eval(`(() => {
       const panel = document.querySelector('[data-testid="shell-assistant-overlay"]');
@@ -285,6 +286,7 @@ test("desktop popup shell exposes the accessible pill, hotkey toggle, and tray l
         panelRight: Math.round(rect.right),
         pillTop: Math.round(pill.getBoundingClientRect().top),
         viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
       };
     })()`);
 
@@ -322,6 +324,20 @@ test("desktop popup shell exposes the accessible pill, hotkey toggle, and tray l
     );
     // Intended top breathing room: ≥ 24px of window above the panel.
     expect(expandedGeometry.panelTop).toBeGreaterThanOrEqual(24);
+    // Bottom containment checked directly against the viewport, not inferred
+    // through pillTop alone (#20063 review finding 2): the panel must stop
+    // short of the resting bar zone.
+    expect(expandedGeometry.viewportHeight - expandedGeometry.panelBottom)
+      .toBeGreaterThanOrEqual(8);
+    // Horizontal centering (#20063 review finding 1): the panel's midpoint
+    // must match the viewport's midpoint — the entry animation previously
+    // replaced the centering transform for its full 220ms duration, flying
+    // the panel in off-center before snapping back.
+    const panelMidpoint =
+      (expandedGeometry.panelLeft + expandedGeometry.panelRight) / 2;
+    expect(Math.abs(panelMidpoint - expandedGeometry.viewportWidth / 2)).toBeLessThanOrEqual(
+      4,
+    );
 
     await harness.eval(
       `document.querySelector('[aria-label="Close assistant"]')?.click()`,

--- a/packages/app/test/electrobun-packaged/electrobun-bottom-bar.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/electrobun-bottom-bar.e2e.spec.ts
@@ -297,21 +297,54 @@ test("desktop popup shell exposes the accessible pill, hotkey toggle, and tray l
     // Mid-entry centering probe (#20063 round-2 finding 2): the settle loop
     // below waits out the 220ms entry animation, so resting-state assertions
     // alone would pass even if the animation replaced the centering transform
-    // (the round-1 bug). Pause the entry animation deterministically at its
-    // midpoint and assert the panel is horizontally centered THERE, where the
-    // round-1 bug would place it off-center by ~half its width.
+    // (the round-1 bug). Deterministically RESTART the entry animation, flush
+    // styles, then pause at the 110ms midpoint and assert the panel is
+    // horizontally centered THERE, where the round-1 bug would place it ~half
+    // its width off-center. A computed animationName alone is NOT evidence the
+    // animation is still running (it stays declared after finish), and a
+    // finished animation ignores animationDelay/playState changes — hence the
+    // explicit restart (round-3 review finding).
     {
       const midEntry = await harness.eval(`(() => {
         const panel = document.querySelector('[data-testid="shell-assistant-overlay"]');
         if (!(panel instanceof HTMLElement)) throw new Error('panel missing');
         const cs = getComputedStyle(panel);
         if (cs.animationName !== 'shell-overlay-in-anchored') {
-          // prefers-reduced-motion or animation already finished: nothing to
+          // prefers-reduced-motion (or animation not applied): nothing to
           // probe mid-flight; the settled assertions below still apply.
           return { skipped: true, reason: cs.animationName };
         }
-        panel.style.animationPlayState = 'paused';
-        panel.style.animationDelay = '-110ms'; // seek to midpoint of 220ms
+        // Capture the utility-declared shorthand so restoration is exact.
+        const declared = {
+          name: cs.animationName,
+          duration: cs.animationDuration,
+          timing: cs.animationTimingFunction,
+          delay: cs.animationDelay,
+          iteration: cs.animationIterationCount,
+          direction: cs.animationDirection,
+          fill: cs.animationFillMode,
+          play: cs.animationPlayState,
+        };
+        // Restart: cancel any in-flight/finished animation, then re-declare
+        // it so a NEW CSSAnimation starts from time zero.
+        for (const anim of panel.getAnimations()) anim.cancel();
+        panel.style.animation = 'none';
+        void panel.offsetWidth; // force style flush
+        panel.style.animation = [
+          declared.duration, declared.timing, '0ms', declared.iteration,
+          declared.direction, declared.fill, 'paused', declared.name,
+        ].join(' ');
+        void panel.offsetWidth; // flush so the paused animation exists
+        // Seek to the midpoint of the 220ms duration via currentTime.
+        const durationMs =
+          Number.parseFloat(declared.duration) *
+          (declared.duration.endsWith('ms') ? 1 : 1000);
+        const anim = panel.getAnimations()[0];
+        if (!(anim instanceof CSSAnimation)) {
+          return { skipped: true, reason: 'no CSSAnimation after restart' };
+        }
+        anim.currentTime = durationMs / 2;
+        void panel.offsetWidth; // flush the seeked frame
         const rect = panel.getBoundingClientRect();
         return {
           skipped: false,
@@ -321,22 +354,23 @@ test("desktop popup shell exposes the accessible pill, hotkey toggle, and tray l
           viewportWidth: window.innerWidth,
         };
       })()`);
-      if (!midEntry.skipped) {
-        expect(midEntry.animationName).toBe("shell-overlay-in-anchored");
-        const midOffset = Math.abs(
-          midEntry.left + midEntry.width / 2 - midEntry.viewportWidth / 2,
+      try {
+        if (!midEntry.skipped) {
+          expect(midEntry.animationName).toBe("shell-overlay-in-anchored");
+          const midOffset = Math.abs(
+            midEntry.left + midEntry.width / 2 - midEntry.viewportWidth / 2,
+          );
+          expect(midOffset).toBeLessThanOrEqual(4);
+        }
+      } finally {
+        // Restoration must run even when an assertion throws (round-3).
+        await harness.eval(
+          `(() => {
+            const panel = document.querySelector('[data-testid="shell-assistant-overlay"]');
+            if (panel instanceof HTMLElement) panel.style.animation = '';
+          })()`,
         );
-        expect(midOffset).toBeLessThanOrEqual(4);
       }
-      await harness.eval(
-        `(() => {
-          const panel = document.querySelector('[data-testid="shell-assistant-overlay"]');
-          if (panel instanceof HTMLElement) {
-            panel.style.animationPlayState = '';
-            panel.style.animationDelay = '';
-          }
-        })()`,
-      );
     }
 
     // The panel enters via a 220ms translate animation (motion-safe). Measuring

--- a/packages/app/test/electrobun-packaged/electrobun-bottom-bar.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/electrobun-bottom-bar.e2e.spec.ts
@@ -263,24 +263,65 @@ test("desktop popup shell exposes the accessible pill, hotkey toggle, and tray l
         height: 600,
       });
 
-    const expandedGeometry = await harness.eval<{
+    const readGeometry = (): Promise<{
+      panelTop: number;
       panelBottom: number;
+      panelLeft: number;
+      panelRight: number;
       pillTop: number;
-    }>(`(() => {
+      viewportWidth: number;
+    }> =>
+      harness.eval(`(() => {
       const panel = document.querySelector('[data-testid="shell-assistant-overlay"]');
       const pill = document.querySelector('[data-testid="shell-home-pill"]');
       if (!(panel instanceof HTMLElement) || !(pill instanceof HTMLElement)) {
         throw new Error('expanded chat geometry unavailable');
       }
+      const rect = panel.getBoundingClientRect();
       return {
-        panelBottom: Math.round(panel.getBoundingClientRect().bottom),
+        panelTop: Math.round(rect.top),
+        panelBottom: Math.round(rect.bottom),
+        panelLeft: Math.round(rect.left),
+        panelRight: Math.round(rect.right),
         pillTop: Math.round(pill.getBoundingClientRect().top),
+        viewportWidth: window.innerWidth,
       };
     })()`);
+
+    // The panel enters via a 220ms translate animation (motion-safe). Measuring
+    // mid-slide reports the panel displaced up to 8% of its height below its
+    // resting place, tripping the containment assertions below. Wait for the
+    // geometry to settle (two identical consecutive reads) before asserting.
+    let settled = await readGeometry();
+    for (let i = 0; i < 20; i++) {
+      await new Promise((r) => setTimeout(r, 150));
+      const next = await readGeometry();
+      if (
+        next.panelTop === settled.panelTop &&
+        next.panelBottom === settled.panelBottom
+      ) {
+        settled = next;
+        break;
+      }
+      settled = next;
+    }
+    const expandedGeometry = settled;
     expect(expandedGeometry.panelBottom).toBeLessThan(expandedGeometry.pillTop);
     expect(
       expandedGeometry.pillTop - expandedGeometry.panelBottom,
     ).toBeGreaterThanOrEqual(8);
+    // Two-sided containment (#20063): the expanded panel must sit FULLY inside
+    // the native window — a panel translated ~50% of its own height upward
+    // (the individual-CSS-`translate` leak this issue describes, measured
+    // y ≈ -276px in a 680px window) still satisfies the one-sided
+    // bottom-above-pill check above, while being visually outside the window.
+    expect(expandedGeometry.panelTop).toBeGreaterThanOrEqual(0);
+    expect(expandedGeometry.panelLeft).toBeGreaterThanOrEqual(0);
+    expect(expandedGeometry.panelRight).toBeLessThanOrEqual(
+      expandedGeometry.viewportWidth,
+    );
+    // Intended top breathing room: ≥ 24px of window above the panel.
+    expect(expandedGeometry.panelTop).toBeGreaterThanOrEqual(24);
 
     await harness.eval(
       `document.querySelector('[aria-label="Close assistant"]')?.click()`,

--- a/packages/app/test/electrobun-packaged/electrobun-bottom-bar.e2e.spec.ts
+++ b/packages/app/test/electrobun-packaged/electrobun-bottom-bar.e2e.spec.ts
@@ -268,6 +268,7 @@ test("desktop popup shell exposes the accessible pill, hotkey toggle, and tray l
       panelBottom: number;
       panelLeft: number;
       panelRight: number;
+      panelWidth: number;
       pillTop: number;
       viewportWidth: number;
       viewportHeight: number;
@@ -280,15 +281,63 @@ test("desktop popup shell exposes the accessible pill, hotkey toggle, and tray l
       }
       const rect = panel.getBoundingClientRect();
       return {
-        panelTop: Math.round(rect.top),
-        panelBottom: Math.round(rect.bottom),
-        panelLeft: Math.round(rect.left),
-        panelRight: Math.round(rect.right),
+        // Raw (unrounded) edges: rounding before midpoint math permits up to
+        // 0.5px error per edge and hides subpixel overflow (round-2 finding 3).
+        panelTop: rect.top,
+        panelBottom: rect.bottom,
+        panelLeft: rect.left,
+        panelRight: rect.right,
+        panelWidth: rect.width,
         pillTop: Math.round(pill.getBoundingClientRect().top),
         viewportWidth: window.innerWidth,
         viewportHeight: window.innerHeight,
       };
     })()`);
+
+    // Mid-entry centering probe (#20063 round-2 finding 2): the settle loop
+    // below waits out the 220ms entry animation, so resting-state assertions
+    // alone would pass even if the animation replaced the centering transform
+    // (the round-1 bug). Pause the entry animation deterministically at its
+    // midpoint and assert the panel is horizontally centered THERE, where the
+    // round-1 bug would place it off-center by ~half its width.
+    {
+      const midEntry = await harness.eval(`(() => {
+        const panel = document.querySelector('[data-testid="shell-assistant-overlay"]');
+        if (!(panel instanceof HTMLElement)) throw new Error('panel missing');
+        const cs = getComputedStyle(panel);
+        if (cs.animationName !== 'shell-overlay-in-anchored') {
+          // prefers-reduced-motion or animation already finished: nothing to
+          // probe mid-flight; the settled assertions below still apply.
+          return { skipped: true, reason: cs.animationName };
+        }
+        panel.style.animationPlayState = 'paused';
+        panel.style.animationDelay = '-110ms'; // seek to midpoint of 220ms
+        const rect = panel.getBoundingClientRect();
+        return {
+          skipped: false,
+          animationName: cs.animationName,
+          left: rect.left,
+          width: rect.width,
+          viewportWidth: window.innerWidth,
+        };
+      })()`);
+      if (!midEntry.skipped) {
+        expect(midEntry.animationName).toBe("shell-overlay-in-anchored");
+        const midOffset = Math.abs(
+          midEntry.left + midEntry.width / 2 - midEntry.viewportWidth / 2,
+        );
+        expect(midOffset).toBeLessThanOrEqual(4);
+      }
+      await harness.eval(
+        `(() => {
+          const panel = document.querySelector('[data-testid="shell-assistant-overlay"]');
+          if (panel instanceof HTMLElement) {
+            panel.style.animationPlayState = '';
+            panel.style.animationDelay = '';
+          }
+        })()`,
+      );
+    }
 
     // The panel enters via a 220ms translate animation (motion-safe). Measuring
     // mid-slide reports the panel displaced up to 8% of its height below its
@@ -327,17 +376,18 @@ test("desktop popup shell exposes the accessible pill, hotkey toggle, and tray l
     // Bottom containment checked directly against the viewport, not inferred
     // through pillTop alone (#20063 review finding 2): the panel must stop
     // short of the resting bar zone.
-    expect(expandedGeometry.viewportHeight - expandedGeometry.panelBottom)
-      .toBeGreaterThanOrEqual(8);
-    // Horizontal centering (#20063 review finding 1): the panel's midpoint
-    // must match the viewport's midpoint — the entry animation previously
-    // replaced the centering transform for its full 220ms duration, flying
-    // the panel in off-center before snapping back.
+    expect(
+      expandedGeometry.viewportHeight - expandedGeometry.panelBottom,
+    ).toBeGreaterThanOrEqual(8);
+    // Horizontal centering at rest (#20063 round-1 finding 1): the panel's
+    // midpoint must match the viewport's midpoint. Midpoint from left+width/2
+    // on raw (unrounded) edges avoids the double-rounding error (round-2
+    // finding 3).
     const panelMidpoint =
-      (expandedGeometry.panelLeft + expandedGeometry.panelRight) / 2;
-    expect(Math.abs(panelMidpoint - expandedGeometry.viewportWidth / 2)).toBeLessThanOrEqual(
-      4,
-    );
+      expandedGeometry.panelLeft + expandedGeometry.panelWidth / 2;
+    expect(
+      Math.abs(panelMidpoint - expandedGeometry.viewportWidth / 2),
+    ).toBeLessThanOrEqual(4);
 
     await harness.eval(
       `document.querySelector('[aria-label="Close assistant"]')?.click()`,

--- a/packages/ui/src/components/shell/AssistantOverlay.tsx
+++ b/packages/ui/src/components/shell/AssistantOverlay.tsx
@@ -9,6 +9,7 @@ import { useBranding } from "../../config/branding";
 import { useNativeGlassAnchor } from "../../glass";
 import { Z_SHELL_OVERLAY } from "../../lib/floating-layers";
 import { Button } from "../ui/button";
+import { useChatOverlayShell } from "./chat-overlay-shell-context";
 import type { ShellPhase } from "./shell-state";
 
 export interface AssistantOverlayProps {
@@ -47,6 +48,9 @@ export function AssistantOverlay({
   const dialogRef = React.useRef<HTMLDivElement | null>(null);
   const glassTier = useNativeGlassAnchor(dialogRef);
   const previousFocusRef = React.useRef<HTMLElement | null>(null);
+  // Must run unconditionally (React hooks rules): the conditional class list
+  // below reads it, and the component early-returns on !isOpen AFTER this.
+  const isChatOverlayShell = useChatOverlayShell();
 
   // Manage Escape, focus trap, initial focus, and focus return as a single
   // effect bound to isOpen so cleanup/setup pair correctly across opens.
@@ -136,11 +140,22 @@ export function AssistantOverlay({
       style={{ zIndex: Z_SHELL_OVERLAY + 1, position: "fixed" }}
       className={[
         "shell-assistant-overlay-panel eliza-glass-sheet pointer-events-auto overflow-hidden",
-        // Position: bottom sheet on mobile, centered drawer on >= sm
-        "fixed inset-x-0 bottom-0",
-        "sm:left-1/2 sm:right-auto sm:top-1/2 sm:bottom-auto",
-        "sm:-translate-x-1/2 sm:-translate-y-1/2",
-        "sm:w-[min(560px,90vw)] sm:h-[min(640px,80vh)]",
+        // Position: bottom sheet on mobile, centered drawer on >= sm —
+        // except in the chat-overlay desktop shell, which anchors the panel
+        // above the persistent pill via the stylesheet override instead
+        // (#20063: the responsive `-translate-*` utilities emit the
+        // individual CSS `translate` property, which composes with the
+        // shell's `transform` and cannot be reliably cancelled from CSS —
+        // the CSS pipeline folds any co-declared cancel away).
+        isChatOverlayShell
+          ? "fixed inset-x-0 bottom-0"
+          : "fixed inset-x-0 bottom-0 sm:left-1/2 sm:right-auto sm:top-1/2 sm:bottom-auto",
+        ...(isChatOverlayShell
+          ? []
+          : [
+              "sm:-translate-x-1/2 sm:-translate-y-1/2",
+              "sm:w-[min(560px,90vw)] sm:h-[min(640px,80vh)]",
+            ]),
         // Size on mobile
         "h-[80vh]",
         // Surface

--- a/packages/ui/src/components/shell/AssistantOverlay.tsx
+++ b/packages/ui/src/components/shell/AssistantOverlay.tsx
@@ -34,7 +34,8 @@ const FOCUSABLE_SELECTOR =
  *   - On close: restores focus to the previously focused element.
  *
  * Animation is a single CSS keyframe (defined in base.css as
- * `@keyframes shell-overlay-in`) on enter; respects
+ * `@keyframes shell-overlay-in`, or the `shell-overlay-in-anchored`
+ * variant selected by the chat-overlay shell override) on enter; respects
  * `prefers-reduced-motion` via Tailwind's `motion-safe:` prefix.
  */
 export function AssistantOverlay({

--- a/packages/ui/src/components/shell/chat-overlay-shell-context.ts
+++ b/packages/ui/src/components/shell/chat-overlay-shell-context.ts
@@ -17,7 +17,16 @@ import * as React from "react";
 const CHAT_OVERLAY_SHELL_CLASS = "eliza-chat-overlay-shell";
 
 export function useChatOverlayShell(): boolean {
-  const [isChatOverlayShell, setIsChatOverlayShell] = React.useState(false);
+  // Initialize synchronously from the live class list: the shell mode is
+  // installed on documentElement before React mounts (main.tsx shell wiring),
+  // so a false-first-then-sync effect would misclassify the first render and
+  // flash the viewport-centring utilities for one paint when the overlay
+  // mounts already-open (#20063 round-2 review finding 1).
+  const [isChatOverlayShell, setIsChatOverlayShell] = React.useState(() =>
+    typeof document === "undefined"
+      ? false
+      : document.documentElement.classList.contains(CHAT_OVERLAY_SHELL_CLASS),
+  );
 
   React.useEffect(() => {
     if (typeof document === "undefined") return;

--- a/packages/ui/src/components/shell/chat-overlay-shell-context.ts
+++ b/packages/ui/src/components/shell/chat-overlay-shell-context.ts
@@ -1,0 +1,38 @@
+/**
+ * Detects the Electrobun chat-overlay desktop shell (`?shellMode=chat-overlay`,
+ * which tags `documentElement` with `eliza-chat-overlay-shell` — see the
+ * shell-mode wiring in `@elizaos/app`'s `main.tsx` and the
+ * `html.eliza-chat-overlay-shell` overrides in `styles/styles.css`).
+ *
+ * Components use this to drop the mobile/web viewport-centring utilities that
+ * fight the shell's bottom-anchored popup geometry: Tailwind v4's
+ * responsive `-translate-*` utilities emit the individual CSS `translate`
+ * property, which COMPOSES with (rather than being overridden by) the
+ * shell stylesheet's `transform`, and CSS-pipeline minification folds any
+ * co-declared `translate: none` cancel away — the only reliable cancel is
+ * to not emit the utilities in this shell at all (#20063).
+ */
+import * as React from "react";
+
+const CHAT_OVERLAY_SHELL_CLASS = "eliza-chat-overlay-shell";
+
+export function useChatOverlayShell(): boolean {
+  const [isChatOverlayShell, setIsChatOverlayShell] = React.useState(false);
+
+  React.useEffect(() => {
+    if (typeof document === "undefined") return;
+    const root = document.documentElement;
+    const sync = () => {
+      setIsChatOverlayShell(root.classList.contains(CHAT_OVERLAY_SHELL_CLASS));
+    };
+    sync();
+    const observer = new MutationObserver(sync);
+    observer.observe(root, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return isChatOverlayShell;
+}

--- a/packages/ui/src/styles/base.css
+++ b/packages/ui/src/styles/base.css
@@ -735,6 +735,28 @@ body.pwa-standalone * {
   }
 }
 
+/*
+ * Chat-overlay-shell variant of the panel entry animation (#20063): the
+ * shell's bottom-anchored geometry centers the panel via
+ * `transform: translateX(-50%)`, and CSS animations REPLACE the transform
+ * wholesale — so animating `translateY(...)` alone (the base keyframes
+ * above) un-centers the panel horizontally for the animation's duration
+ * before snapping back. These shell keyframes carry the centering term
+ * through every frame instead. Selected by the
+ * `html.eliza-chat-overlay-shell` rule in styles.css, which overrides the
+ * utility-picked animation-name.
+ */
+@keyframes shell-overlay-in-anchored {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(8%);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
 /* A freshly-arrived chat turn fades + lifts in. Subtler than shell-overlay-in
    (a single bubble, not the whole panel). Applied via
    `motion-safe:animate-[chat-turn-in_...]` on the message <article>, scoped to

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -181,8 +181,13 @@ html.eliza-chat-overlay-shell .shell-assistant-overlay-panel {
      `translate: -50% -50%` composed with this transform and pushed the
      panel ~50% of its own height above the bottom anchor (measured
      y ≈ -276px, transcripts invisible outside the native window; #20063,
-     #19996) is now structurally impossible rather than cascade-managed. */
+     #19996) is now structurally impossible rather than cascade-managed.
+     The animation-name override swaps the entry keyframes for the
+     `-anchored` variant so the centering transform survives the 220ms
+     entry animation (the base keyframes animate `translateY(...)` alone,
+     which would replace — not compose with — the centering term). */
   transform: translateX(-50%);
+  animation-name: shell-overlay-in-anchored;
   border-radius: 1.5rem;
   border-color: rgb(255 255 255 / 72%);
   background-color: rgb(244 244 246 / 72%);

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -173,6 +173,15 @@ html.eliza-chat-overlay-shell .shell-assistant-overlay-panel {
   left: 50%;
   width: min(560px, calc(100% - 24px));
   height: min(600px, calc(100% - 80px));
+  /* Horizontal centering only. The component drops its responsive
+     `-translate-*`/viewport-centering utilities entirely in this shell
+     (AssistantOverlay reads useChatOverlayShell()), so there is no
+     individual `translate` to cancel and nothing for the CSS pipeline to
+     fold away — the historical failure mode where Tailwind v4's
+     `translate: -50% -50%` composed with this transform and pushed the
+     panel ~50% of its own height above the bottom anchor (measured
+     y ≈ -276px, transcripts invisible outside the native window; #20063,
+     #19996) is now structurally impossible rather than cascade-managed. */
   transform: translateX(-50%);
   border-radius: 1.5rem;
   border-color: rgb(255 255 255 / 72%);


### PR DESCRIPTION
Closes #20063

## What

The expanded assistant panel rendered ~276px above the bottom-anchored native chat window — transcripts existed in the DOM and persisted via the API, but were visually outside the captured window.

## Root cause (verified live on the packaged artifact)

Tailwind v4's `sm:-translate-x/y-1/2` utilities emit the **individual CSS `translate` property**, which composes with (rather than being replaced by) the shell stylesheet's `transform`. The existing `eliza-chat-overlay-shell` override set `transform: translateX(-50%)` — that applied, but `translate: -50% -50%` stayed active alongside it, pushing the panel up by half its height.

Every CSS-level cancel was then folded away by the pipeline: lightningcss merges co-declared `translate`+`transform` pairs into a single `transform`, re-opening the property for the utility to win — verified across four strategies (single block, `!important`, split adjacent rules, higher-specificity selector); the built CSS shipped without the cancel every time. Live computed styles pre-fix: `translate: -50% -50%`, panel `y=-276` in a 680px window.

## Fix — at the source, not the cascade

`AssistantOverlay` now reads a new `useChatOverlayShell()` hook (MutationObserver on the `eliza-chat-overlay-shell` documentElement class) and simply does not emit the viewport-centring utilities (`sm:-translate-*`, `sm:left-1/2`, `sm:top-1/2`, `sm:w/h-[...]`) in the chat-overlay desktop shell. The bottom-anchored stylesheet geometry becomes the only positioning input, so the leak is structurally impossible rather than cascade-managed. Mobile/web layout is unchanged — the conditional only engages under the shell class.

## Review round 1 caught a real follow-on bug

The entry animation's base keyframes animate `transform: translateY(...)` alone, which **replaces** the centering transform for its full 220ms — the panel flew in off-center and snapped back (reviewer reproduced in Chromium: `left=320..880` in a 640px viewport mid-animation). New `shell-overlay-in-anchored` keyframes carry `translateX(-50%)` through every frame; the shell override selects them via `animation-name`.

## Test hardening (review round 1, finding 2)

The packaged bounds test previously asserted only bottom-above-pill — a panel shifted far upward still passed. It now asserts:
- Two-sided containment: panel fully inside the window, ≥24px top margin
- Direct bottom clearance against `innerHeight` (not inferred via pillTop)
- Horizontal centering: panel midpoint within 4px of viewport midpoint
- Settle-wait for the 220ms entry animation (mid-slide reads previously gave phantom 45px violations — this is what produced the issue-era `669 vs 640` failures)

## Verification

- Packaged electrobun build, full `electrobun-bottom-bar.e2e.spec.ts` **passes end-to-end** (geometry, containment, centering, hotkey dismiss/summon, tray) — 10.6s run
- Live computed styles on the packaged app: `translate: none`, `rect y=24..624`, `pillTop=640`, 16px clearance
- Clean-develop baseline run of the same spec still fails at the original geometry (stash-verified) — this branch fixes it
- UI typecheck clean; biome clean

## Files

- `packages/ui/src/components/shell/chat-overlay-shell-context.ts` (new, 38 lines)
- `packages/ui/src/components/shell/AssistantOverlay.tsx`
- `packages/ui/src/styles/styles.css` + `base.css` (anchored keyframes)
- `packages/app/test/electrobun-packaged/electrobun-bottom-bar.e2e.spec.ts`

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent"} -->