### PR TITLE
fix(core): terse verbosity truncation preserves structure and only cuts at real sentence terminators

### DIFF
--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-verbosity.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-verbosity.test.ts
@@ -68,3 +68,31 @@ describe("approximateTokenCount", () => {
 		expect(approximateTokenCount("one")).toBe(2); // ceil(1*1.3)
 	});
 });
+
+describe("terse truncation preserves structure and real sentence boundaries", () => {
+	test("does not treat a dot inside a filename as a sentence end (live 86-char cut)", () => {
+		const text = [
+			"- layout.tsx was changed and you wanted it reverted",
+			"- ran `git checkout -- app/layout.tsx` in /home/milady/projects/agent-home — exit 0, revert done",
+			'- earlier i tried to build an app called "layout-restorer" (wrong move) and it failed verification twice',
+			"- you stopped that and clarified you just wanted the file git-reverted, not an app built",
+		].join("\n");
+		const result = enforceVerbosity(text, "terse");
+		expect(result.truncated).toBe(true);
+		// The old lastIndexOf(".") cut delivered exactly this broken prefix.
+		expect(result.text).not.toBe(
+			"- layout.tsx was changed and you wanted it reverted - ran `git checkout -- app/layout.",
+		);
+		expect(result.text.endsWith("app/layout.")).toBe(false);
+		// Newlines survive: the truncated block keeps its bullet structure.
+		expect(result.text).toContain("\n");
+	});
+
+	test("still truncates at a genuine sentence boundary", () => {
+		const sentence = "This is a real sentence that ends cleanly.";
+		const filler = Array.from({ length: 60 }, (_, i) => `word${i}`).join(" ");
+		const result = enforceVerbosity(`${sentence} ${filler}`, "terse");
+		expect(result.truncated).toBe(true);
+		expect(result.text).toBe(sentence);
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/personality/verbosity-enforcer.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/verbosity-enforcer.ts
@@ -33,24 +33,37 @@ export interface VerbosityEnforcementResult {
 }
 
 function truncateAtSentenceBoundary(text: string, maxWords: number): string {
-	const words = text.trim().split(/\s+/);
-	if (words.length <= maxWords) return text;
-	const truncated = words.slice(0, maxWords).join(" ");
-
-	// Find the last sentence-ending punctuation in the truncated block.
-	const sentenceEnd = truncated.search(/[.!?][^.!?]*$/);
-	if (sentenceEnd > 0) {
-		// Keep up to (and including) the punctuation.
-		const lastTerminator = truncated.lastIndexOf(".");
-		const lastBang = truncated.lastIndexOf("!");
-		const lastQ = truncated.lastIndexOf("?");
-		const cut = Math.max(lastTerminator, lastBang, lastQ);
-		if (cut > 0) {
-			return truncated.slice(0, cut + 1);
+	// Cut the ORIGINAL text at the character offset of the word cap instead of
+	// rebuilding from split words: `split(/\s+/).join(" ")` flattened newlines,
+	// so a four-bullet reply shipped as one run-on line (observed live on the
+	// Discord group surface with a terse personality slot).
+	const trimmed = text.trim();
+	let wordCount = 0;
+	let cutOffset = trimmed.length;
+	for (const match of trimmed.matchAll(/\S+/g)) {
+		wordCount += 1;
+		if (wordCount > maxWords) {
+			cutOffset = match.index;
+			break;
 		}
 	}
+	if (cutOffset >= trimmed.length) return text;
+	const block = trimmed.slice(0, cutOffset);
+
+	// A sentence terminator is [.!?] followed by whitespace or end-of-block. A
+	// bare lastIndexOf(".") treated the dot inside "app/layout.tsx" as a
+	// sentence end and cut the reply mid-filename (observed live: an 86-char
+	// delivery ending "app/layout."). Filenames, versions, and inline code
+	// never terminate at a dot glued to the next character.
+	let lastTerminator = -1;
+	for (const match of block.matchAll(/[.!?](?=\s|$)/g)) {
+		lastTerminator = match.index;
+	}
+	if (lastTerminator > 0) {
+		return block.slice(0, lastTerminator + 1);
+	}
 	// No clean boundary — hard cut with ellipsis.
-	return `${truncated.trimEnd()}…`;
+	return `${block.trimEnd()}…`;
 }
 
 /**


### PR DESCRIPTION
## What

The terse-verbosity enforcement (`enforceVerbosity` → `truncateAtSentenceBoundary`) mangled long replies two ways:

1. **Structure destroyed** — it rebuilt the truncation block from `split(/\s+/).join(" ")`, so every newline collapsed to a space. A four-bullet reply shipped as one run-on line.
2. **False sentence boundaries** — the "sentence end" was a bare `lastIndexOf(".")`, so the dot inside `app/layout.tsx` counted as a terminator and the reply was cut mid-filename.

Observed live (Discord group surface, terse personality slot): a four-bullet recap composed as 342 chars with newlines was delivered as exactly `"- layout.tsx was changed and you wanted it reverted - ran `git checkout -- app/layout."` — 86 flat chars ending inside a filename. Deterministic across three probes; connector exonerated by taps (the callback already received the mangled text); the transform reproduces the exact bytes: flatten + cut at the last bare dot.

Fix: cut the ORIGINAL text at the word-cap character offset (newlines survive), and only treat `[.!?]` followed by whitespace/end-of-block as a sentence terminator; otherwise hard-cut at the word boundary with an honest `…`.

## Evidence

- Before: echo probe of the recap text → 86-char flat mid-filename delivery (three deterministic reproductions, message ids in the test channel).
- After: same probe → 291 chars, all 3 newlines and bullet structure preserved, honest `…` at a word boundary; the terse cap itself still enforced.
- Suite: personality-verbosity 9/9 including two new tests (the live 86-char shape must not reproduce; genuine sentence boundaries still honored). Core typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:6359de425433abe0c8dd543b394ee01a0c395e2b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - chat-behavior change; deterministic before/after byte evidence in PR body

<!-- evidence-row:after-screenshots -->
- [ ] N/A - chat-behavior change; deterministic before/after byte evidence in PR body

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - live Discord transcripts serve as walkthrough

<!-- evidence-row:backend-logs -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - pure text-transform fix; unit tests pin both live shapes

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces
