### PR TITLE
fix(shared): reject malformed Teams short-link meeting URLs

### DIFF
--- a/packages/shared/src/meetings.test.ts
+++ b/packages/shared/src/meetings.test.ts
@@ -34,6 +34,15 @@ describe("parseMeetingUrl", () => {
     expect(parsed?.nativeMeetingId).toBe("19:meeting_abc@thread.v2/0");
   });
 
+  it("rejects a Teams short link whose numeric id is only a path prefix", () => {
+    expect(
+      parseMeetingUrl("https://teams.microsoft.com/meet/123456789?p=abc"),
+    ).toMatchObject({ platform: "teams", nativeMeetingId: "123456789" });
+    expect(
+      parseMeetingUrl("https://teams.microsoft.com/meet/123not-a-meeting"),
+    ).toBeNull();
+  });
+
   it("returns null (never throws URIError) on a malformed percent-escape Teams id", () => {
     // A lone trailing `%` is an invalid escape: decodeURIComponent throws
     // URIError, which used to crash the Transcripts view on every keystroke,

--- a/packages/shared/src/meetings.ts
+++ b/packages/shared/src/meetings.ts
@@ -220,8 +220,9 @@ function safeDecodeUriComponent(value: string): string | null {
 const MEET_URL_RE =
   /^https?:\/\/meet\.google\.com\/([a-z]{3}-?[a-z]{4}-?[a-z]{3})(?:\?.*)?$/i;
 const TEAMS_URL_RE =
-  /^https?:\/\/(?:[\w-]+\.)?teams\.(?:microsoft|live)\.com\/(?:v2\/)?(?:l\/)?meet(?:up-join)?\/([^?\s]+)/i;
-const TEAMS_SHORT_RE = /^https?:\/\/teams\.microsoft\.com\/meet\/(\d+)/i;
+  /^https?:\/\/(?:[\w-]+\.)?teams\.(?:microsoft|live)\.com\/(?:v2\/)?(?:l\/)?meetup-join\/([^?\s]+)/i;
+const TEAMS_SHORT_RE =
+  /^https?:\/\/teams\.(?:microsoft|live)\.com\/meet\/(\d+)(?:[/?#]|$)/i;
 const ZOOM_URL_RE =
   /^https?:\/\/(?:[\w-]+\.)?zoom\.us\/(?:j|w|wc)\/(?:join\/)?(\d{9,12})(?:[/?]|$)/i;
 const ZOOM_APP_RE = /^https?:\/\/app\.zoom\.us\/wc\/(\d{9,12})\/join/i;

--- a/plugins/plugin-calendar/src/components/calendar/meeting-url.test.ts
+++ b/plugins/plugin-calendar/src/components/calendar/meeting-url.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Deterministic coverage for the browser-bundled meeting URL parser, which is
+ * intentionally mirrored from @elizaos/shared because view bundles externalize
+ * that package at runtime.
+ */
+import { describe, expect, it } from "vitest";
+import { parseMeetingUrl } from "./meeting-url";
+
+describe("calendar view meeting URL parser", () => {
+  it("accepts numeric Teams short links on Microsoft and Live hosts", () => {
+    expect(
+      parseMeetingUrl("https://teams.microsoft.com/meet/123456789?p=abc"),
+    ).toMatchObject({ platform: "teams", nativeMeetingId: "123456789" });
+    expect(
+      parseMeetingUrl("https://teams.live.com/meet/987654321"),
+    ).toMatchObject({ platform: "teams", nativeMeetingId: "987654321" });
+  });
+
+  it("rejects nonnumeric Teams short-link suffixes instead of truncating them", () => {
+    expect(
+      parseMeetingUrl("https://teams.microsoft.com/meet/123not-a-meeting"),
+    ).toBeNull();
+    expect(
+      parseMeetingUrl("https://teams.live.com/meet/not-a-meeting"),
+    ).toBeNull();
+  });
+});

--- a/plugins/plugin-calendar/src/components/calendar/meeting-url.ts
+++ b/plugins/plugin-calendar/src/components/calendar/meeting-url.ts
@@ -33,8 +33,9 @@ function safeDecodeUriComponent(value: string): string | null {
 const MEET_URL_RE =
   /^https?:\/\/meet\.google\.com\/([a-z]{3}-?[a-z]{4}-?[a-z]{3})(?:\?.*)?$/i;
 const TEAMS_URL_RE =
-  /^https?:\/\/(?:[\w-]+\.)?teams\.(?:microsoft|live)\.com\/(?:v2\/)?(?:l\/)?meet(?:up-join)?\/([^?\s]+)/i;
-const TEAMS_SHORT_RE = /^https?:\/\/teams\.microsoft\.com\/meet\/(\d+)/i;
+  /^https?:\/\/(?:[\w-]+\.)?teams\.(?:microsoft|live)\.com\/(?:v2\/)?(?:l\/)?meetup-join\/([^?\s]+)/i;
+const TEAMS_SHORT_RE =
+  /^https?:\/\/teams\.(?:microsoft|live)\.com\/meet\/(\d+)(?:[/?#]|$)/i;
 const ZOOM_URL_RE =
   /^https?:\/\/(?:[\w-]+\.)?zoom\.us\/(?:j|w|wc)\/(?:join\/)?(\d{9,12})(?:[/?]|$)/i;
 const ZOOM_APP_RE = /^https?:\/\/app\.zoom\.us\/wc\/(\d{9,12})\/join/i;


### PR DESCRIPTION
# Relates to

Closes #20498.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] this PR targets `develop` and is branched directly off the current `origin/develop` tip.
- [x] focused package tests and lint pass on the exact head, see Testing below.
- [x] a reviewer can confirm the fix directly against the deterministic unit test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (fix, tests, via AgentRouter proxy), `anthropic/claude-sonnet-5` (independent re-verification, plus the mirrored bundle-copy fix)
<!-- attribution-row:client -->
- Agent tooling: `codex` (via AgentRouter proxy), `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] branched directly off the current `origin/develop` tip

# Risks

low. the regex tightening only rejects inputs that were previously mis-parsed as valid meetings with a truncated numeric id — every existing test in the file (6/6 prior cases) still passes unchanged, confirmed independently.

# Background

## What does this PR do?

`parseMeetingUrl`'s `TEAMS_SHORT_RE` matched a purely-numeric *prefix* of the URL's final path segment with no boundary after the digits, so `https://teams.microsoft.com/meet/123not-a-meeting` matched and returned `nativeMeetingId: "123"` — a garbage, non-Teams URL was silently accepted as a valid meeting with a truncated id instead of being rejected.

confirmed directly against the original (unpatched) regex before touching the source:

```text
teamsShort match: 123
```

`TEAMS_URL_RE`'s `meet(?:up-join)?` alternative had the same underlying looseness (it also matched a bare `meet/` prefix, not just the real `meetup-join/` link format), so it's tightened to require the literal `meetup-join` segment.

traced reachability honestly before writing this up: `parseMeetingUrl` (`packages/shared/src/meetings.ts`) is called from real, non-test call sites on real user/event-supplied URLs — `plugins/plugin-meetings/src/service.ts` (join-request handling), `plugins/plugin-meetings/src/routes/meetings-routes.ts` (HTTP route), `plugins/plugin-meetings/src/actions/shared.ts` (agent action parsing a URL out of free text), and `plugins/plugin-calendar/src/meetings/auto-join.ts` / `meeting-join-dispatch.ts` (calendar event conference-link auto-join). This is a live, exploitable-by-malformed-input path, not a dormant contract gap.

While tracing callers I found `plugins/plugin-calendar/src/components/calendar/meeting-url.ts` is a second copy of the exact same function, with its own file header explicitly documenting it as "a browser-only copy of `@elizaos/shared`'s `parseMeetingUrl` ... Keep in sync with `packages/shared/src/meetings.ts`." That copy still had the original buggy regexes, so this PR applies the identical fix there too — otherwise the CalendarView bundle (which cannot import `@elizaos/shared` at runtime, per that file's own comment) would still accept the malformed input this PR is fixing everywhere else.

fix: `TEAMS_SHORT_RE` now requires the digit run be immediately followed by `/`, `?`, `#`, or end-of-string, and also widens to `(?:microsoft|live)\.com` to match `TEAMS_URL_RE`'s existing provider set (was `microsoft`-only, an unrelated pre-existing inconsistency fixed in passing since it's a one-token change on the same line being touched). `TEAMS_URL_RE` now requires the literal `meetup-join` segment instead of treating bare `meet` as an equivalent alternative.

## What kind of change is this?

bug fix, non-breaking (every existing valid Teams URL format in the test suite — full `meetup-join` links and properly-numeric short links — still parses identically; only malformed lookalikes are newly rejected).

# Documentation changes needed?

no.

# Testing

## Where should a reviewer start?

`packages/shared/src/meetings.test.ts`, the new `rejects a Teams short link whose numeric id is only a path prefix` case, then the two-regex change in `packages/shared/src/meetings.ts` (mirrored in `plugins/plugin-calendar/src/components/calendar/meeting-url.ts`).

## Detailed testing steps

```text
$ bun run --cwd packages/shared test -- src/meetings.test.ts
Test Files  1 passed (1)
     Tests  7 passed (7)

$ bunx @biomejs/biome check packages/shared/src/meetings.ts packages/shared/src/meetings.test.ts plugins/plugin-calendar/src/components/calendar/meeting-url.ts
Checked 3 files in 64ms. No fixes applied.

$ bun run --cwd plugins/plugin-calendar typecheck
(clean, exit 0)
```

mutation-resistance verified independently: reverted just the source fix in `packages/shared/src/meetings.ts` (kept the test), reran — 1/7 failed, expected `null` for the malformed short link but received a parsed Teams meeting with `nativeMeetingId: "123"`, reproducing the exact truncation behavior described above. restored the fix, 7/7 green again.

# Evidence Gate

<!-- evidence-head:f16b088e622f853171d4103e3e1c3609428f50f5 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes a URL-parsing regex, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - this changes a URL-parsing regex, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive product flow.
<!-- evidence-row:backend-logs -->
- [x] [20499-pr20499-verify-latest.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20499-pr20499-verify-latest.log)
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [20499-pr20499-validation-f16b088e.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20499-pr20499-validation-f16b088e.md)

  green (fix restored):
  $ bun run --cwd packages/shared test -- src/meetings.test.ts
  Tests  7 passed (7)
  ```
  also independently reproduced the pre-fix bug directly against the original regex in isolation:
  ```text
  $ node -e '
  const TEAMS_SHORT_RE = /^https?:\/\/teams\.microsoft\.com\/meet\/(\d+)/i;
  console.log(TEAMS_SHORT_RE.exec("https://teams.microsoft.com/meet/123not-a-meeting")[1]);
  '
  123
  ```
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface or visual text changed.

## Known gaps / failures

none in the touched surface. `packages/shared`'s package-wide `typecheck` script surfaces one pre-existing, unrelated error (`src/todo-cutover.ts` failing to resolve `@elizaos/core/edge` from a fresh checkout where workspace packages haven't been built yet) — it does not reference either changed file. `plugins/plugin-calendar`'s own `typecheck` script is clean.

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the focused suite and lint myself, independently reproduced the pre-fix bug against the original regex before trusting the report, discovered and fixed the second "keep in sync" copy of this function in plugin-calendar that the original session didn't touch, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR — the original codex session's network connection dropped before it could write a report, run lint, or commit, so all of this was done independently from the raw diff)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Contribution skill revision: N/A - direct interactive session, contribute-to-eliza skill not used
Compute receipt: N/A - Slop run-receipt install currently blocked by an unrelated site-deploy-lag issue (deployed skill archive predates recent develop changes)
Attribution status: self-reported

