### PR TITLE
fix(cloud): protect Shared Telegram edge cutover

### DIFF
--- a/.github/workflows/activate-personal-shared-telegram-edge.yml
+++ b/.github/workflows/activate-personal-shared-telegram-edge.yml
@@ -1,0 +1,212 @@
+name: Activate Personal Shared Telegram Edge
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_source_sha:
+        description: Exact currently served staging Worker source SHA
+        required: true
+        type: string
+      enabled:
+        description: Enable the edge path; false performs the fail-closed rollback
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: activate-personal-shared-telegram-edge-staging
+  cancel-in-progress: false
+
+jobs:
+  cutover:
+    name: Cut over Personal Shared Telegram edge
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment: staging
+    env:
+      EXPECTED_SOURCE_SHA: ${{ inputs.expected_source_sha }}
+      DESIRED_ENABLED: ${{ inputs.enabled && 'true' || 'false' }}
+      HEALTH_URL: https://api-staging.eliza.app/api/health
+      GATEWAY_URL: https://gateway-webhook-stg-staging.up.railway.app
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: "1.3.14"
+
+      - name: Validate exact served Worker source
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_REF" != "refs/heads/develop" ]; then
+            echo "::error::Staging edge cutover must run from refs/heads/develop"
+            exit 1
+          fi
+          if [[ ! "$EXPECTED_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::expected_source_sha must be an exact lowercase commit SHA"
+            exit 1
+          fi
+          git cat-file -e "$EXPECTED_SOURCE_SHA^{commit}"
+          if ! git merge-base --is-ancestor "$EXPECTED_SOURCE_SHA" "$GITHUB_SHA"; then
+            echo "::error::Expected Worker source is not in canonical develop history"
+            exit 1
+          fi
+
+          health="$(mktemp)"
+          for attempt in 1 2 3 4 5 6; do
+            code="$(curl -sS -o "$health" -w '%{http_code}' -m 20 "$HEALTH_URL" || echo '000')"
+            if [ "$code" = "200" ] && jq -e \
+              --arg sha "$EXPECTED_SOURCE_SHA" \
+              '.status == "ok" and
+               .environment == "staging" and
+               .commit == $sha and
+               (.personalSharedTelegramEdge.enabled | type == "boolean")' \
+              "$health" >/dev/null; then
+              rm -f "$health"
+              echo "Staging Worker serves the exact requested source."
+              exit 0
+            fi
+            [ "$attempt" -lt 6 ] && sleep 10
+          done
+          rm -f "$health"
+          echo "::error::Staging Worker does not serve the exact requested source and edge beacon"
+          exit 1
+
+      - name: Verify exact-source gateway before enable
+        if: inputs.enabled == true
+        run: |
+          set -euo pipefail
+          gateway_run="$(mktemp)"
+          gh api \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/deploy-gateway-webhook.yml/runs?branch=develop&event=workflow_dispatch&per_page=1" \
+            > "$gateway_run"
+          if ! jq -e \
+            --arg sha "$EXPECTED_SOURCE_SHA" \
+            '.workflow_runs | length == 1 and
+             .[0].head_sha == $sha and
+             .[0].status == "completed" and
+             .[0].conclusion == "success"' \
+            "$gateway_run" >/dev/null; then
+            rm -f "$gateway_run"
+            echo "::error::Latest protected staging gateway release is not successful on the exact Worker source"
+            exit 1
+          fi
+          gateway_run_id="$(jq -r '.workflow_runs[0].id' "$gateway_run")"
+          rm -f "$gateway_run"
+
+          health="$(mktemp)"
+          code="$(curl -sS -o "$health" -w '%{http_code}' -m 20 "$GATEWAY_URL/health" || echo '000')"
+          if [ "$code" != "200" ] || ! jq -e '.status == "healthy"' "$health" >/dev/null; then
+            rm -f "$health"
+            echo "::error::Exact-source staging gateway is not healthy"
+            exit 1
+          fi
+          rm -f "$health"
+
+          readiness="$(mktemp)"
+          code="$(curl -sS -o "$readiness" -w '%{http_code}' -m 20 \
+            "$GATEWAY_URL/ready/forwarder-auth/eliza-app" || echo '000')"
+          if [ "$code" != "401" ] || ! jq -e \
+            'type == "object" and
+             keys == ["error", "project", "status"] and
+             .error == "unauthorized" and
+             .project == "eliza-app" and
+             .status == "enforced"' \
+            "$readiness" >/dev/null; then
+            rm -f "$readiness"
+            echo "::error::Exact-source staging gateway forwarder gate is not enforced"
+            exit 1
+          fi
+          rm -f "$readiness"
+          echo "Protected gateway run $gateway_run_id is healthy on the exact Worker source."
+
+      - name: Apply and verify served edge state
+        working-directory: packages/cloud/api
+        run: |
+          set -euo pipefail
+
+          disable_edge() {
+            node "$GITHUB_WORKSPACE/packages/cloud/scripts/ensure-worker-secret-absent.mjs" \
+              PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED --env staging >/dev/null
+          }
+
+          # A secret mutation can reach Cloudflare even when the CLI response is
+          # ambiguous. Until the served health beacon proves the desired state,
+          # every exit owns a rollback to the tracked false configuration.
+          rollback_needed=true
+          rollback_on_unproven_exit() {
+            local status=$?
+            if [ "$rollback_needed" = "true" ] && ! disable_edge; then
+              echo "::error::Unproven Telegram edge cutover exited and rollback could not be confirmed"
+            fi
+            return "$status"
+          }
+          trap rollback_on_unproven_exit EXIT
+          trap 'exit 1' INT TERM
+
+          if [ "$DESIRED_ENABLED" = "true" ]; then
+            activation_cli_confirmed=false
+            for attempt in 1 2 3; do
+              if printf '%s' 'true' | bunx wrangler@4.100.0 secret put \
+                PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED --env staging; then
+                activation_cli_confirmed=true
+                break
+              fi
+              [ "$attempt" -lt 3 ] && sleep 10
+            done
+            if [ "$activation_cli_confirmed" != "true" ]; then
+              echo "::warning::Telegram edge activation CLI result was ambiguous; requiring served-state proof"
+            fi
+          else
+            disable_edge
+          fi
+
+          for attempt in 1 2 3 4 5 6; do
+            health="$(mktemp)"
+            code="$(curl -sS -o "$health" -w '%{http_code}' -m 20 "$HEALTH_URL" || echo '000')"
+            if [ "$code" = "200" ] && jq -e \
+              --arg sha "$EXPECTED_SOURCE_SHA" \
+              --argjson enabled "$DESIRED_ENABLED" \
+              '.status == "ok" and
+               .environment == "staging" and
+               .commit == $sha and
+               .personalSharedTelegramEdge.enabled == $enabled' \
+              "$health" >/dev/null; then
+              rm -f "$health"
+              rollback_needed=false
+              echo "Personal Shared Telegram edge serves the requested state on the exact Worker source."
+              exit 0
+            fi
+            rm -f "$health"
+            [ "$attempt" -lt 6 ] && sleep 10
+          done
+
+          if disable_edge; then
+            rollback_needed=false
+            echo "::warning::Telegram edge proof failed; staging was rolled back off"
+          else
+            echo "::error::Telegram edge proof failed and rollback could not be confirmed"
+          fi
+          echo "::error::Personal Shared Telegram edge served-state proof failed"
+          exit 1
+
+      - name: Write cutover summary
+        run: |
+          {
+            echo "### Personal Shared Telegram edge"
+            echo
+            echo "- Worker source: $EXPECTED_SOURCE_SHA"
+            echo "- Desired enabled state: $DESIRED_ENABLED"
+            echo "- Served-state proof: passed"
+            echo "- Production: untouched"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -822,7 +822,31 @@ describe("cloud-api worker entrypoint", () => {
       status: "ok",
       region: "local-test",
       commit: "feedfacefeedfacefeedfacefeedfacefeedface",
+      personalSharedTelegramEdge: { enabled: false },
     });
+  });
+
+  test("reports only the served Personal Shared Telegram edge gate state", async () => {
+    const response = await cloudApiWorker.fetch(
+      new Request("https://api-staging.eliza.app/api/health", {
+        headers: { host: "api-staging.eliza.app" },
+      }),
+      {
+        ENVIRONMENT: "staging",
+        PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED: "true",
+        ELIZA_APP_TELEGRAM_BOT_TOKEN: "never-return-this-bot-token",
+        ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "never-return-this-webhook-secret",
+      } as never,
+      {} as never,
+    );
+
+    const text = await response.text();
+    expect(JSON.parse(text)).toMatchObject({
+      environment: "staging",
+      personalSharedTelegramEdge: { enabled: true },
+    });
+    expect(text).not.toContain("never-return-this-bot-token");
+    expect(text).not.toContain("never-return-this-webhook-secret");
   });
 
   test("reports only value-free staging session cutover readiness", async () => {

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -428,6 +428,8 @@ async function dispatchInference(
 }
 
 function healthResponse(env: AppEnv["Bindings"]): Response {
+  const personalSharedTelegramEdgeEnabled =
+    env.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED === "true";
   const stagingSessionVersion =
     env.STAGING_SESSION_EXCHANGE_VERSION?.trim() || null;
   const stagingSessionSigningSecret =
@@ -472,6 +474,13 @@ function healthResponse(env: AppEnv["Bindings"]): Response {
       // the beacon the cross-environment routing verifier probes
       // (packages/cloud/scripts/verify-environment-routing.mjs).
       environment: env.ENVIRONMENT ?? null,
+      // The protected Telegram cutover uses a secret binding to override the
+      // tracked false default without changing code. This value-free beacon
+      // lets the release workflow prove the served state and fail closed when
+      // a provider-side mutation has an ambiguous result.
+      personalSharedTelegramEdge: {
+        enabled: personalSharedTelegramEdgeEnabled,
+      },
       // Value-free cutover receipt for the default-off staging QA bridge. The
       // deploy workflow proves exact code first, flips the secret last, then
       // requires this beacon to report the expected version/readiness. No key,

--- a/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Guards the migration-safe Personal Shared Telegram edge cutover: exact
+ * Worker and gateway source proof, protected activation, and rollback.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const repoRoot = new URL("../../../", import.meta.url);
+const source = readFileSync(
+  new URL(
+    ".github/workflows/activate-personal-shared-telegram-edge.yml",
+    repoRoot,
+  ),
+  "utf8",
+);
+
+interface WorkflowStep {
+  name?: string;
+  if?: string;
+  env?: Record<string, string>;
+  run?: string;
+}
+
+interface Workflow {
+  permissions?: Record<string, string>;
+  concurrency?: Record<string, string | boolean>;
+  jobs?: Record<
+    string,
+    {
+      environment?: string;
+      env?: Record<string, string>;
+      steps?: WorkflowStep[];
+    }
+  >;
+}
+
+const workflow = Bun.YAML.parse(source) as Workflow;
+const job = workflow.jobs?.cutover;
+const steps = job?.steps ?? [];
+
+function step(name: string): WorkflowStep {
+  const found = steps.find((candidate) => candidate.name === name);
+  if (!found?.run) throw new Error(`Missing executable workflow step: ${name}`);
+  return found;
+}
+
+function index(name: string): number {
+  return steps.findIndex((candidate) => candidate.name === name);
+}
+
+describe("Personal Shared Telegram edge deploy", () => {
+  test("is staging-only, serialized, and least-privileged", () => {
+    expect(job?.environment).toBe("staging");
+    expect(workflow.permissions).toEqual({ actions: "read", contents: "read" });
+    expect(workflow.concurrency?.group).toBe(
+      "activate-personal-shared-telegram-edge-staging",
+    );
+    expect(workflow.concurrency?.["cancel-in-progress"]).toBe(false);
+    expect(job?.env?.HEALTH_URL).toBe(
+      "https://api-staging.eliza.app/api/health",
+    );
+    expect(job?.env?.GATEWAY_URL).toBe(
+      "https://gateway-webhook-stg-staging.up.railway.app",
+    );
+    expect(source).not.toContain("api.eliza.app/api/health");
+    expect(source).not.toContain("--env production");
+  });
+
+  test("proves exact served Worker and gateway sources before enable", () => {
+    const ordered = [
+      "Validate exact served Worker source",
+      "Verify exact-source gateway before enable",
+      "Apply and verify served edge state",
+      "Write cutover summary",
+    ].map(index);
+    expect(ordered.every((value) => value >= 0)).toBe(true);
+    expect(ordered).toEqual([...ordered].sort((a, b) => a - b));
+
+    const worker = step("Validate exact served Worker source");
+    expect(worker.run).toContain('"refs/heads/develop"');
+    expect(worker.run).toContain("git merge-base --is-ancestor");
+    expect(worker.run).toContain(".commit == $sha");
+    expect(worker.run).toContain("personalSharedTelegramEdge.enabled");
+
+    const gateway = step("Verify exact-source gateway before enable");
+    expect(gateway.if).toContain("inputs.enabled == true");
+    expect(gateway.run).toContain(
+      "actions/workflows/deploy-gateway-webhook.yml/runs",
+    );
+    expect(gateway.run).toContain(".[0].head_sha == $sha");
+    expect(gateway.run).toContain('.[0].conclusion == "success"');
+    expect(gateway.run).toContain("$GATEWAY_URL/health");
+    expect(gateway.run).toContain("ready/forwarder-auth/eliza-app");
+  });
+
+  test("applies the gate last and rolls every unproven exit back off", () => {
+    const apply = step("Apply and verify served edge state");
+    expect(apply.run).toContain("wrangler@4.100.0 secret put");
+    expect(apply.run).toContain(
+      "PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED --env staging",
+    );
+    expect(apply.run).toContain("ensure-worker-secret-absent.mjs");
+    expect(apply.run).toContain("trap rollback_on_unproven_exit EXIT");
+    expect(apply.run).toContain(".commit == $sha");
+    expect(apply.run).toContain(
+      ".personalSharedTelegramEdge.enabled == $enabled",
+    );
+    expect(apply.run).toContain("if disable_edge; then");
+    expect(apply.run).not.toContain('grep -qi "not found"');
+  });
+
+  test("keeps every tracked Worker environment fail-closed", () => {
+    const config = Bun.TOML.parse(
+      readFileSync(
+        new URL("packages/cloud/api/wrangler.toml", repoRoot),
+        "utf8",
+      ),
+    ) as {
+      vars?: Record<string, string>;
+      env?: Record<string, { vars?: Record<string, string> }>;
+    };
+    expect(config.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED).toBe("false");
+    expect(
+      config.env?.staging?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED,
+    ).toBe("false");
+    expect(
+      config.env?.production?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED,
+    ).toBe("false");
+  });
+});


### PR DESCRIPTION
Part of #20314

## Outcome

Adds the missing protected activation/rollback seam for the already-merged Personal Shared Telegram edge path. The Worker remains deployed once from the exact tracked-false source; after the explicit gateway deployment, a small staging-only workflow toggles that already-served version and proves the live state. No migrations, Pages build, or second code deploy is required.

## Safety contract

- Requires an explicit 40-character Worker source SHA that is both in canonical `develop` history and currently served by staging health.
- Enablement requires the newest protected `deploy-gateway-webhook.yml` run to have completed successfully on that exact Worker SHA; live gateway health and enforced forwarder-auth readiness must also pass.
- Uses a secret binding only as a same-version override of the tracked false value.
- The Worker health beacon exposes only `{ enabled: boolean }`, never Telegram credentials.
- An ambiguous mutation, health mismatch, signal, or unexpected exit removes the override so the tracked false value wins.
- The same workflow with `enabled=false` is the exact rollback path.
- Production remains tracked false and has no production URL, environment, or mutation command in this workflow.

## Exact-head proof

Head: `6335bdec8b885a7415df5ea062e0a19d6d4047e1`
Base: `4c94369ed62e23c2d5c5e038f0dd536dfb7c954e`

- Workflow contract matrix: 33/33 tests, 439 assertions
- Real Cloud Worker entrypoint: 42/42 tests, 210 assertions
- Cloud API typecheck: PASS
- Production Wrangler dry bundle: PASS; production edge binding remains `false`
- New activation workflow actionlint: PASS
- Biome exact TypeScript paths: PASS
- `git diff --check`: PASS

## Protected staging sequence after review/merge

1. Deploy exact merged source through the existing protected Worker workflow; retain its post-migration flag-false version as the rollback pin.
2. Dispatch the protected gateway workflow on that same exact `develop` SHA.
3. Dispatch this workflow with that served source SHA and `enabled=true`; it validates Worker, gateway, and health before mutation.
4. Run the real natural Telegram/Discord cold/warm/history/web-search/reminder/duplicate and 30-message matrix with logs and domain receipts.
5. Dispatch this workflow with the same source SHA and `enabled=false` to prove rollback; re-enable only after that proof passes.

No staging, provider, secret, gateway, or production mutation was performed by this PR.
