### PR TITLE
fix(orchestrator): completion relay leads with the verified deliverable URLs

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/completion-relay-deliverable.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/completion-relay-deliverable.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Completion-relay deliverable guarantee (2026-08-16 website-build cluster,
+ * leg 1): the relay text handed to the origin room must carry the verified
+ * deliverable URLs even when the sub-agent's narration describes its last
+ * step instead of the deliverable. Pure-function coverage of
+ * verifiedUrlCompletionFallback — deterministic, no runtime.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { verifiedUrlCompletionFallback } from "../../src/services/sub-agent-router.js";
+
+const HEADER = "[sub-agent: builder] relay this result; do not respawn";
+const URL = "https://nubilio.org/apps/nubs/";
+
+describe("verifiedUrlCompletionFallback — deliverable-first relay", () => {
+  it("leads prose narration with the verified URL when the narration omits it (live receipt shape)", () => {
+    const text = `${HEADER}\nUpdated app/layout.tsx metadata and verified the build output on disk.`;
+    const out = verifiedUrlCompletionFallback(text, [URL]);
+    const lines = out.split("\n");
+    expect(lines[0]).toBe(HEADER);
+    expect(lines[1]).toBe(URL);
+    expect(out).toContain("Updated app/layout.tsx");
+  });
+
+  it("leaves narration alone when it already names a user-facing URL", () => {
+    const text = `${HEADER}\nDone — live at ${URL} with the new metadata.`;
+    expect(verifiedUrlCompletionFallback(text, [URL])).toBe(text);
+  });
+
+  it("surfaces the public URL when narration only names the loopback variant", () => {
+    const loopback = "http://127.0.0.1:3000/apps/nubs/";
+    const text = `${HEADER}\nServed and checked at ${loopback}.`;
+    const out = verifiedUrlCompletionFallback(text, [loopback, URL]);
+    expect(out.split("\n")[1]).toBe(URL);
+  });
+
+  it("keeps the URL-only replacement branch intact", () => {
+    const text = `${HEADER}\nhttp://127.0.0.1:3000/apps/nubs/`;
+    const out = verifiedUrlCompletionFallback(text, [
+      "http://127.0.0.1:3000/apps/nubs/",
+      URL,
+    ]);
+    expect(out).toBe(`${HEADER}\n${URL}`);
+  });
+
+  it("keeps the empty-narration branch intact", () => {
+    const out = verifiedUrlCompletionFallback(HEADER, [URL]);
+    expect(out).toBe(`${HEADER}\n${URL}`);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -2677,7 +2677,19 @@ function isUnsupportedAcpMethodError(data: unknown): boolean {
   return !/session\/prompt/i.test(serialized);
 }
 
-function verifiedUrlCompletionFallback(text: string, verifiedUrls: string[]) {
+/**
+ * Guarantee the verified deliverable URLs survive the completion relay. The
+ * sub-agent's own narration routinely describes its LAST STEP instead of the
+ * deliverable ("updated app/layout.tsx metadata … verified on disk") — live
+ * 2026-08-16 website-build receipt: the user asked "tell me where it lives"
+ * and never got the URL even though the router held it in `verifiedUrls`.
+ * Model compliance with the "lead with the URL" spawn-brief line is not
+ * enforceable; this projection is. Exported for unit coverage.
+ */
+export function verifiedUrlCompletionFallback(
+  text: string,
+  verifiedUrls: string[],
+) {
   const userFacingUrls = publicPreferredUrls(verifiedUrls);
   const lines = text.replace(/\r\n/g, "\n").split("\n");
   const retained: string[] = [];
@@ -2711,6 +2723,21 @@ function verifiedUrlCompletionFallback(text: string, verifiedUrls: string[]) {
       meaningfulLines.join("\n") !== userFacingUrls.join("\n")
     ) {
       return [header, ...userFacingUrls].filter(Boolean).join("\n");
+    }
+    // Prose narration that omits every user-facing deliverable URL: lead with
+    // the URLs (right after the planner header) instead of trusting the
+    // model's narration to mention where the result lives. Containment is
+    // checked against the PUBLIC projection — a narration that only names the
+    // loopback variant still gets the public URL surfaced.
+    if (
+      userFacingUrls.length > 0 &&
+      !userFacingUrls.some((url) => meaningful.includes(url))
+    ) {
+      const body = retained
+        .filter((line) => !line.trim().startsWith("[sub-agent:"))
+        .join("\n")
+        .trim();
+      return [header, ...userFacingUrls, body].filter(Boolean).join("\n");
     }
     return text;
   }


### PR DESCRIPTION
## Problem — website-build cluster leg 1 (watchtower's live test, HQ 10:34)

"Build me a small website" succeeded end-to-end (site live at nubilio.org/apps/nubs/ in ~5 min) but the user — who asked *"tell me when it's done and where it lives"* — **never got the URL**. Root cause is deterministic: the sub-agent narrated its final edit instead of the deliverable, and `verifiedUrlCompletionFallback` only surfaces the router-held `verifiedUrls` when the narration is **empty** or **URL-only**. Prose narration returns unchanged; the spawn brief's "lead with the URL" directive depends on model compliance nothing enforces.

## Fix — enforce it in the projection, not the prompt

New branch: prose narration that omits every user-facing URL gets the URLs inserted **directly after the planner header** (deliverable-first — survives downstream paraphrase and the 200-char notification preview), narration preserved below. Containment checks the public projection, so narration naming only the loopback variant still surfaces the public URL. Existing branches unchanged and now pinned. Function exported for unit coverage (same pattern as `annotateUnverifiedUrls`).

## Evidence

| Check | Result |
|---|---|
| new suite: live-receipt shape leads with URL · already-named passthrough · loopback→public · URL-only branch · empty branch | 5/5 ✅ |
| adjacent URL-verify suites | 16/16 ✅ |
| plugin typecheck + Biome | ✅ |

Legs 2–4 of the cluster (status-ask duplicate spawn, coordinator ACP blindness, zombie duplicate) offered to the verify lane per the HQ split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)