### PR TITLE
feat(shell): hold-to-talk quasimode on the home pill — Wispr-style listening chip, cues, headless voice send (#20483)

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -199,6 +199,7 @@ import { TutorialConductorMount } from "./tutorial/TutorialConductor";
 import { isElizaCloudControlPlaneAgentlessBase } from "./utils/cloud-agent-base";
 import { confirmDesktopAction } from "./utils/desktop-dialogs";
 import { openExternalUrl } from "./utils/openExternalUrl";
+import { playCaptureSendCue, playCaptureStartCue } from "./voice/capture-cues";
 import { VoiceSelfTestShell } from "./voice/voice-selftest/VoiceSelfTestShell";
 import { VoiceWorkbenchShell } from "./voice/voice-selftest/VoiceWorkbenchShell";
 
@@ -1836,8 +1837,16 @@ function ShellFoundationMount() {
         phase={controller.phase}
         onOpen={controller.open}
         onClose={controller.close}
-        onHoldStart={() => controller.startRecording("ptt")}
-        onHoldEnd={controller.stopRecording}
+        onHoldStart={() => {
+          // Audible mic-open ping BEFORE capture spins up: the cue is the
+          // "start talking" signal, so it must not wait on getUserMedia.
+          playCaptureStartCue();
+          controller.startRecording("ptt");
+        }}
+        onHoldEnd={() => {
+          playCaptureSendCue();
+          controller.stopRecording();
+        }}
         onHoldCancel={controller.cancelRecording}
       />
       <AssistantOverlay

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1836,8 +1836,15 @@ function ShellFoundationMount() {
         phase={controller.phase}
         onOpen={controller.open}
         onClose={controller.close}
+        onHoldStart={() => controller.startRecording("ptt")}
+        onHoldEnd={controller.stopRecording}
+        onHoldCancel={controller.cancelRecording}
       />
-      <AssistantOverlay phase={controller.phase} onClose={controller.close}>
+      <AssistantOverlay
+        phase={controller.phase}
+        onClose={controller.close}
+        open={controller.isOpen}
+      >
         <ChatSurface
           messages={controller.messages}
           onSend={controller.send}

--- a/packages/ui/src/components/shell/AssistantOverlay.tsx
+++ b/packages/ui/src/components/shell/AssistantOverlay.tsx
@@ -15,6 +15,11 @@ export interface AssistantOverlayProps {
   phase: ShellPhase;
   onClose: () => void;
   children: React.ReactNode;
+  /** Explicit overlay visibility from the shell's open state. When provided it
+   *  overrides the phase-derived fallback — required for the hold-to-talk
+   *  quasimode (#20483), where `listening`/`responding` can be active while
+   *  the overlay stays closed (pill-only capture). */
+  open?: boolean;
 }
 
 const FOCUSABLE_SELECTOR =
@@ -40,10 +45,12 @@ export function AssistantOverlay({
   phase,
   onClose,
   children,
+  open,
 }: AssistantOverlayProps): React.JSX.Element | null {
   const { appName } = useBranding();
   const isOpen =
-    phase === "summoned" || phase === "listening" || phase === "responding";
+    open ??
+    (phase === "summoned" || phase === "listening" || phase === "responding");
   const dialogRef = React.useRef<HTMLDivElement | null>(null);
   const glassTier = useNativeGlassAnchor(dialogRef);
   const previousFocusRef = React.useRef<HTMLElement | null>(null);

--- a/packages/ui/src/components/shell/HomePill.tsx
+++ b/packages/ui/src/components/shell/HomePill.tsx
@@ -1,6 +1,15 @@
 /**
- * Renders the compact home pill that anchors launcher access and current shell
- * status.
+ * Renders the compact home pill that anchors launcher access, current shell
+ * status, and the hold-to-talk quasimode (#20483).
+ *
+ * The pill carries two gestures on one target: a quick press (released inside
+ * {@link HOLD_THRESHOLD_MS}) toggles the assistant overlay, and a sustained
+ * hold becomes push-to-talk — capture starts at the threshold, runs while the
+ * pointer stays down, and the release sends the utterance. The hold is a
+ * quasimode in Raskin's sense: the pressed pointer IS the state, so there is
+ * nothing for the user to remember or un-stick. Cancel affordances: Escape
+ * mid-hold, or sliding the pointer more than {@link SLIDE_CANCEL_PX} off the
+ * pill before releasing.
  */
 import * as React from "react";
 
@@ -14,26 +23,154 @@ export interface HomePillProps {
   phase: ShellPhase;
   onOpen: () => void;
   onClose: () => void;
+  /** Begin hold-to-talk capture (wired to `startRecording("ptt")`). When
+   *  absent the pill is click-only, preserving the pre-quasimode behavior for
+   *  hosts that have no capture pipeline. */
+  onHoldStart?: () => void;
+  /** Release hold-to-talk: stop capture and send the utterance. */
+  onHoldEnd?: () => void;
+  /** Abandon hold-to-talk without sending (Esc mid-hold, slide-off). */
+  onHoldCancel?: () => void;
 }
+
+/** How long the pointer must stay down before a press becomes a hold. Above
+ *  a natural click's duration, below perceptible lag — the disambiguation
+ *  window between the pill's two gestures. */
+export const HOLD_THRESHOLD_MS = 150;
+
+/** Pointer travel from the press point that turns a release into a cancel —
+ *  the iOS "slide off to cancel" convention. */
+export const SLIDE_CANCEL_PX = 44;
+
+/** Stagger offsets (ms) for the listening-state waveform bars. */
+const WAVE_BAR_DELAYS_MS = [0, 150, 300, 450, 600] as const;
 
 /**
  * Persistent Flow-style handle at the bottom-center of the viewport.
  *
- * The visible affordance is deliberately only a short white capsule; the
- * larger transparent button preserves a comfortable pointer target. Status is
- * exposed through ARIA instead of permanent text so the launcher stays out of
- * the user's way until it is invoked.
+ * The visible affordance is deliberately only a short capsule; the larger
+ * transparent button preserves a comfortable pointer target. Status is exposed
+ * through ARIA instead of permanent text so the launcher stays out of the
+ * user's way until it is invoked.
+ *
+ * Each shell phase reads distinctly at a glance (the capsule is the only
+ * always-visible surface, so it carries all ambient status): booting dims and
+ * pulses, idle is a solid white capsule, listening turns the capsule red with
+ * animated white waveform bars (the mic-live convention), and responding
+ * breathes a warm accent glow. Reduced-motion users get the static color/glow
+ * treatments without the animations.
  */
 export function HomePill({
   phase,
   onOpen,
   onClose,
+  onHoldStart,
+  onHoldEnd,
+  onHoldCancel,
 }: HomePillProps): React.JSX.Element {
   const { appName } = useBranding();
-  const isOpen =
-    phase === "summoned" || phase === "listening" || phase === "responding";
+  // The pill reads as "open" (its click will close) only for the overlay
+  // surfaces. `listening` is deliberately NOT included: hold-to-talk runs with
+  // the overlay closed, and treating it as open would flash the label/pressed
+  // state during every hold (#20483).
+  const isOpen = phase === "summoned" || phase === "responding";
+
+  const holdTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const holdActiveRef = React.useRef(false);
+  const pressPointRef = React.useRef<{ x: number; y: number } | null>(null);
+  const suppressClickRef = React.useRef(false);
+  const onHoldStartRef = React.useRef(onHoldStart);
+  const onHoldEndRef = React.useRef(onHoldEnd);
+  const onHoldCancelRef = React.useRef(onHoldCancel);
+  onHoldStartRef.current = onHoldStart;
+  onHoldEndRef.current = onHoldEnd;
+  onHoldCancelRef.current = onHoldCancel;
+
+  const clearHoldTimer = React.useCallback(() => {
+    if (holdTimerRef.current !== null) {
+      clearTimeout(holdTimerRef.current);
+      holdTimerRef.current = null;
+    }
+  }, []);
+
+  const handlePointerDown = React.useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      if (!onHoldStartRef.current) return;
+      // Primary button/touch only; a right-click must not open the mic.
+      if (event.pointerType === "mouse" && event.button !== 0) return;
+      pressPointRef.current = { x: event.clientX, y: event.clientY };
+      suppressClickRef.current = false;
+      // Keep receiving pointer events after the pointer leaves the button so
+      // slide-off distance and the eventual release are still observed.
+      try {
+        event.currentTarget.setPointerCapture?.(event.pointerId);
+      } catch {
+        /* capture is an enhancement; envs without active pointers (jsdom)
+           still get down/up on the button itself */
+      }
+      clearHoldTimer();
+      holdTimerRef.current = setTimeout(() => {
+        holdTimerRef.current = null;
+        holdActiveRef.current = true;
+        // The release (or cancel) must not ALSO fire the click toggle — the
+        // hold consumed this press.
+        suppressClickRef.current = true;
+        onHoldStartRef.current?.();
+      }, HOLD_THRESHOLD_MS);
+    },
+    [clearHoldTimer],
+  );
+
+  const handlePointerUp = React.useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      clearHoldTimer();
+      if (!holdActiveRef.current) return;
+      holdActiveRef.current = false;
+      const origin = pressPointRef.current;
+      pressPointRef.current = null;
+      const dx = origin ? event.clientX - origin.x : 0;
+      const dy = origin ? event.clientY - origin.y : 0;
+      if (Math.hypot(dx, dy) > SLIDE_CANCEL_PX) {
+        onHoldCancelRef.current?.();
+        return;
+      }
+      onHoldEndRef.current?.();
+    },
+    [clearHoldTimer],
+  );
+
+  const handlePointerCancel = React.useCallback(() => {
+    clearHoldTimer();
+    pressPointRef.current = null;
+    if (!holdActiveRef.current) return;
+    holdActiveRef.current = false;
+    onHoldCancelRef.current?.();
+  }, [clearHoldTimer]);
+
+  // Escape aborts an in-flight hold without sending. Bound only while a hold
+  // could be active so the pill never shadows the overlay's own Escape.
+  React.useEffect(() => {
+    if (phase !== "listening") return undefined;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (!holdActiveRef.current) return;
+      holdActiveRef.current = false;
+      clearHoldTimer();
+      pressPointRef.current = null;
+      onHoldCancelRef.current?.();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [phase, clearHoldTimer]);
+
+  React.useEffect(() => clearHoldTimer, [clearHoldTimer]);
 
   const handleClick = React.useCallback(() => {
+    // A completed hold already consumed this press-release pair.
+    if (suppressClickRef.current) {
+      suppressClickRef.current = false;
+      return;
+    }
     if (isOpen) onClose();
     else onOpen();
   }, [isOpen, onOpen, onClose]);
@@ -41,11 +178,20 @@ export function HomePill({
   return (
     <Button
       variant="ghost"
-      aria-label={isOpen ? `Close ${appName}` : `Open ${appName}`}
+      aria-label={
+        phase === "listening"
+          ? `${appName} is listening — release to send`
+          : isOpen
+            ? `Close ${appName}`
+            : `Open ${appName}`
+      }
       aria-pressed={isOpen}
       data-phase={phase}
       data-testid="shell-home-pill"
       onClick={handleClick}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
       style={{ zIndex: Z_SHELL_OVERLAY }}
       className={cn(
         "group pointer-events-auto relative mb-2 flex h-8 w-16 items-center justify-center rounded-full bg-transparent p-0",
@@ -57,14 +203,28 @@ export function HomePill({
         aria-hidden="true"
         data-testid="shell-home-pill-mark"
         className={cn(
-          "block h-2.5 w-12 rounded-full bg-white/95",
-          "shadow-[0_0_0_1px_rgba(0,0,0,0.12)]",
-          "transition-[width,opacity,transform] duration-200 group-hover:w-14",
-          phase === "booting" && "animate-pulse opacity-65",
-          phase === "listening" && "animate-pulse",
-          phase === "responding" && "animate-pulse opacity-85",
+          "flex h-2.5 w-12 items-center justify-center gap-[3px] rounded-full",
+          "transition-[width,opacity,transform,background-color,box-shadow] duration-200 group-hover:w-14",
+          phase === "listening" ? "bg-red-500/95" : "bg-white/95",
+          phase === "responding"
+            ? "shadow-[0_0_10px_rgba(255,138,42,0.6),0_0_0_1px_rgba(0,0,0,0.12)]"
+            : "shadow-[0_0_0_1px_rgba(0,0,0,0.12)]",
+          phase === "booting" &&
+            "animate-pulse opacity-65 motion-reduce:animate-none",
+          phase === "responding" &&
+            "animate-pulse opacity-90 motion-reduce:animate-none",
         )}
-      />
+      >
+        {phase === "listening" &&
+          WAVE_BAR_DELAYS_MS.map((delayMs) => (
+            <span
+              key={delayMs}
+              data-testid="shell-home-pill-wave-bar"
+              className="home-pill-wave-bar h-[3px] w-[2.5px] rounded-full bg-white/95 motion-reduce:animate-none"
+              style={{ animationDelay: `${delayMs}ms` }}
+            />
+          ))}
+      </span>
     </Button>
   );
 }

--- a/packages/ui/src/components/shell/HomePill.tsx
+++ b/packages/ui/src/components/shell/HomePill.tsx
@@ -42,8 +42,21 @@ export const HOLD_THRESHOLD_MS = 150;
  *  the iOS "slide off to cancel" convention. */
 export const SLIDE_CANCEL_PX = 44;
 
-/** Stagger offsets (ms) for the listening-state waveform bars. */
-const WAVE_BAR_DELAYS_MS = [0, 150, 300, 450, 600] as const;
+/** Listening-state waveform bars: nine bars with center-weighted, symmetric
+ *  stagger delays so the chip reads as a live waveform (shimmering from the
+ *  middle out) rather than a marching sequence — mirroring the density of the
+ *  studied Wispr Flow bar. Ids are stable keys; delays repeat symmetrically. */
+const WAVE_BARS = [
+  { id: "l4", delayMs: 420 },
+  { id: "l3", delayMs: 240 },
+  { id: "l2", delayMs: 120 },
+  { id: "l1", delayMs: 60 },
+  { id: "c0", delayMs: 0 },
+  { id: "r1", delayMs: 60 },
+  { id: "r2", delayMs: 120 },
+  { id: "r3", delayMs: 240 },
+  { id: "r4", delayMs: 420 },
+] as const;
 
 /**
  * Persistent Flow-style handle at the bottom-center of the viewport.
@@ -203,12 +216,20 @@ export function HomePill({
         aria-hidden="true"
         data-testid="shell-home-pill-mark"
         className={cn(
-          "flex h-2.5 w-12 items-center justify-center gap-[3px] rounded-full",
-          "transition-[width,opacity,transform,background-color,box-shadow] duration-200 group-hover:w-14",
-          phase === "listening" ? "bg-red-500/95" : "bg-white/95",
-          phase === "responding"
-            ? "shadow-[0_0_10px_rgba(255,138,42,0.6),0_0_0_1px_rgba(0,0,0,0.12)]"
-            : "shadow-[0_0_0_1px_rgba(0,0,0,0.12)]",
+          "flex items-center justify-center rounded-full",
+          "transition-[width,height,opacity,transform,background-color,box-shadow] duration-200",
+          // Listening mirrors the studied Wispr Flow bar: the capsule GROWS
+          // into a dark rounded chip holding live white bars — big enough that
+          // the mic-live state is legible from across the room — with a red
+          // ring keeping "hot mic" unambiguous. Other phases stay the slim
+          // white handle.
+          phase === "listening"
+            ? "h-7 w-20 gap-[3px] bg-neutral-900/95 shadow-[0_0_0_1.5px_rgba(239,68,68,0.9),0_4px_16px_rgba(0,0,0,0.35)]"
+            : "h-2.5 w-12 gap-[3px] bg-white/95 group-hover:w-14",
+          phase !== "listening" &&
+            (phase === "responding"
+              ? "shadow-[0_0_10px_rgba(255,138,42,0.6),0_0_0_1px_rgba(0,0,0,0.12)]"
+              : "shadow-[0_0_0_1px_rgba(0,0,0,0.12)]"),
           phase === "booting" &&
             "animate-pulse opacity-65 motion-reduce:animate-none",
           phase === "responding" &&
@@ -216,12 +237,12 @@ export function HomePill({
         )}
       >
         {phase === "listening" &&
-          WAVE_BAR_DELAYS_MS.map((delayMs) => (
+          WAVE_BARS.map((bar) => (
             <span
-              key={delayMs}
+              key={bar.id}
               data-testid="shell-home-pill-wave-bar"
-              className="home-pill-wave-bar h-[3px] w-[2.5px] rounded-full bg-white/95 motion-reduce:animate-none"
-              style={{ animationDelay: `${delayMs}ms` }}
+              className="home-pill-wave-bar h-[6px] w-[3px] rounded-full bg-white/95 motion-reduce:animate-none"
+              style={{ animationDelay: `${bar.delayMs}ms` }}
             />
           ))}
       </span>

--- a/packages/ui/src/components/shell/__e2e__/chat-sheet-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/chat-sheet-fixture.tsx
@@ -479,6 +479,7 @@ function Harness(): React.JSX.Element {
       console.log(`[fixture] setComposerHasDraft -> ${hasDraft}`),
     startRecording,
     stopRecording,
+    cancelRecording: () => console.log("[fixture] cancelRecording"),
     speak: (text: string) =>
       console.log(`[fixture] speak length=${text.length}`),
     stopSpeaking: () => console.log("[fixture] stopSpeaking"),

--- a/packages/ui/src/components/shell/__e2e__/perf-gate-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/perf-gate-fixture.tsx
@@ -194,6 +194,7 @@ function Harness(): React.JSX.Element {
     setComposerHasDraft: () => {},
     startRecording: () => {},
     stopRecording: () => {},
+    cancelRecording: () => {},
     toggleAgentVoiceMute: () => {},
     unlockAudio: () => {},
     openSettings: () => {},

--- a/packages/ui/src/components/shell/__e2e__/warming-absorption-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/warming-absorption-fixture.tsx
@@ -242,6 +242,7 @@ function Harness(): React.JSX.Element {
     setComposerHasDraft: () => {},
     startRecording: () => {},
     stopRecording: () => {},
+    cancelRecording: () => {},
     toggleAgentVoiceMute: () => {},
     unlockAudio: () => {},
     openSettings: () => {},

--- a/packages/ui/src/components/shell/__e2e__/warmup-eviction-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/warmup-eviction-fixture.tsx
@@ -228,6 +228,7 @@ function Harness(): React.JSX.Element {
     setComposerHasDraft: () => {},
     startRecording: () => {},
     stopRecording: () => {},
+    cancelRecording: () => {},
     toggleAgentVoiceMute: () => {},
     unlockAudio: () => {},
     openSettings: () => {},

--- a/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
@@ -90,15 +90,21 @@ describe("HomePill", () => {
     );
   });
 
-  it("turns the capsule red with staggered waveform bars while listening", () => {
+  it("grows into a dark red-ringed chip with waveform bars while listening", () => {
     render(<HomePill phase="listening" onOpen={() => {}} onClose={() => {}} />);
     const mark = screen.getByTestId("shell-home-pill-mark");
-    expect(mark.className).toContain("bg-red-500/95");
+    // Wispr-style listening chip: larger dark capsule + red hot-mic ring.
+    expect(mark.className).toContain("bg-neutral-900/95");
+    expect(mark.className).toContain("h-7");
+    expect(mark.className).toContain("w-20");
+    expect(mark.className).toContain("239,68,68");
     expect(mark.className).not.toContain("bg-white/95");
     const bars = screen.getAllByTestId("shell-home-pill-wave-bar");
-    expect(bars).toHaveLength(5);
-    const delays = bars.map((b) => b.style.animationDelay);
-    expect(new Set(delays).size).toBe(bars.length);
+    expect(bars).toHaveLength(9);
+    // Center-weighted stagger: symmetric around the middle bar, not monotonic.
+    const delays = bars.map((b) => Number.parseInt(b.style.animationDelay, 10));
+    expect(delays).toEqual([...delays].reverse());
+    expect(Math.min(...delays)).toBe(delays[4]);
     for (const bar of bars) {
       expect(bar.className).toContain("home-pill-wave-bar");
       expect(bar.className).toContain("motion-reduce:animate-none");

--- a/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
@@ -1,16 +1,27 @@
 /** Verifies HomePill through the package's configured test harness. */
 // @vitest-environment jsdom
 //
-// HomePill rendering + phase→interaction wiring (label, mark, open/close on
-// click). Deterministic jsdom render via testing-library — no runtime, no model.
+// HomePill rendering, phase→visual wiring (waveform/glow/pulse), the click
+// toggle, and the hold-to-talk quasimode gesture (#20483): 150ms click/hold
+// disambiguation, release-to-send, slide-off cancel, Esc cancel. Deterministic
+// jsdom render via testing-library with fake timers for the hold threshold —
+// no runtime, no model, no real mic.
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { HomePill } from "../HomePill";
+import { HOLD_THRESHOLD_MS, HomePill, SLIDE_CANCEL_PX } from "../HomePill";
 import type { ShellPhase } from "../shell-state";
 
 afterEach(() => cleanup());
+
+function holdHandlers() {
+  return {
+    onHoldStart: vi.fn(),
+    onHoldEnd: vi.fn(),
+    onHoldCancel: vi.fn(),
+  };
+}
 
 describe("HomePill", () => {
   it("renders an accessible button with only a compact white visual handle", () => {
@@ -21,7 +32,6 @@ describe("HomePill", () => {
     expect(mark.className).toContain("bg-white/95");
     expect(mark.className).toContain("w-12");
     expect(mark.className).toContain("shadow-[0_0_0_1px_rgba(0,0,0,0.12)]");
-    expect(mark.className).not.toContain("0_1px_7px");
     expect(btn.textContent).toBe("");
     expect(btn.style.backgroundColor).toBe("");
     expect(btn.className).toContain("h-8");
@@ -53,25 +63,21 @@ describe("HomePill", () => {
     expect(screen.getByRole("button").getAttribute("data-phase")).toBe(phase);
   });
 
-  it("is aria-pressed=true when summoned/listening/responding, false when idle/booting", () => {
+  it("is aria-pressed only for the overlay phases — listening stays unpressed (headless hold)", () => {
     const { rerender } = render(
       <HomePill phase="idle" onOpen={() => {}} onClose={() => {}} />,
     );
     expect(screen.getByRole("button").getAttribute("aria-pressed")).toBe(
       "false",
     );
-    rerender(<HomePill phase="booting" onOpen={() => {}} onClose={() => {}} />);
+    rerender(
+      <HomePill phase="listening" onOpen={() => {}} onClose={() => {}} />,
+    );
     expect(screen.getByRole("button").getAttribute("aria-pressed")).toBe(
       "false",
     );
     rerender(
       <HomePill phase="summoned" onOpen={() => {}} onClose={() => {}} />,
-    );
-    expect(screen.getByRole("button").getAttribute("aria-pressed")).toBe(
-      "true",
-    );
-    rerender(
-      <HomePill phase="listening" onOpen={() => {}} onClose={() => {}} />,
     );
     expect(screen.getByRole("button").getAttribute("aria-pressed")).toBe(
       "true",
@@ -84,19 +90,189 @@ describe("HomePill", () => {
     );
   });
 
-  it("stays available while booting", () => {
-    render(<HomePill phase="booting" onOpen={() => {}} onClose={() => {}} />);
-    const btn = screen.getByRole("button") as HTMLButtonElement;
-    expect(btn.disabled).toBe(false);
-    expect(screen.getByTestId("shell-home-pill-mark").className).toContain(
-      "animate-pulse",
-    );
+  it("turns the capsule red with staggered waveform bars while listening", () => {
+    render(<HomePill phase="listening" onOpen={() => {}} onClose={() => {}} />);
+    const mark = screen.getByTestId("shell-home-pill-mark");
+    expect(mark.className).toContain("bg-red-500/95");
+    expect(mark.className).not.toContain("bg-white/95");
+    const bars = screen.getAllByTestId("shell-home-pill-wave-bar");
+    expect(bars).toHaveLength(5);
+    const delays = bars.map((b) => b.style.animationDelay);
+    expect(new Set(delays).size).toBe(bars.length);
+    for (const bar of bars) {
+      expect(bar.className).toContain("home-pill-wave-bar");
+      expect(bar.className).toContain("motion-reduce:animate-none");
+    }
   });
 
-  it("opens the popup when clicked during booting", () => {
+  it("keeps the capsule white with no waveform bars outside listening", () => {
+    for (const phase of [
+      "booting",
+      "idle",
+      "summoned",
+      "responding",
+    ] as const) {
+      const { unmount } = render(
+        <HomePill phase={phase} onOpen={() => {}} onClose={() => {}} />,
+      );
+      expect(screen.getByTestId("shell-home-pill-mark").className).toContain(
+        "bg-white/95",
+      );
+      expect(screen.queryAllByTestId("shell-home-pill-wave-bar")).toHaveLength(
+        0,
+      );
+      unmount();
+    }
+  });
+
+  it("breathes a warm accent glow while responding", () => {
+    render(
+      <HomePill phase="responding" onOpen={() => {}} onClose={() => {}} />,
+    );
+    const mark = screen.getByTestId("shell-home-pill-mark");
+    expect(mark.className).toContain("255,138,42");
+    expect(mark.className).toContain("animate-pulse");
+    expect(mark.className).toContain("motion-reduce:animate-none");
+  });
+
+  it("stays available while booting and opens on click", () => {
     const onOpen = vi.fn();
     render(<HomePill phase="booting" onOpen={onOpen} onClose={() => {}} />);
-    fireEvent.click(screen.getByRole("button"));
+    const btn = screen.getByRole("button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    fireEvent.click(btn);
     expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("HomePill hold-to-talk quasimode (#20483)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("a quick press (released before the threshold) is a click, never a hold", () => {
+    const onOpen = vi.fn();
+    const hold = holdHandlers();
+    render(
+      <HomePill phase="idle" onOpen={onOpen} onClose={() => {}} {...hold} />,
+    );
+    const btn = screen.getByRole("button");
+    fireEvent.pointerDown(btn, { button: 0, clientX: 10, clientY: 10 });
+    vi.advanceTimersByTime(HOLD_THRESHOLD_MS - 50);
+    fireEvent.pointerUp(btn, { clientX: 10, clientY: 10 });
+    fireEvent.click(btn);
+    expect(hold.onHoldStart).not.toHaveBeenCalled();
+    expect(hold.onHoldEnd).not.toHaveBeenCalled();
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("holding past the threshold starts capture; release sends and suppresses the click", () => {
+    const onOpen = vi.fn();
+    const hold = holdHandlers();
+    render(
+      <HomePill phase="idle" onOpen={onOpen} onClose={() => {}} {...hold} />,
+    );
+    const btn = screen.getByRole("button");
+    fireEvent.pointerDown(btn, { button: 0, clientX: 10, clientY: 10 });
+    vi.advanceTimersByTime(HOLD_THRESHOLD_MS + 10);
+    expect(hold.onHoldStart).toHaveBeenCalledTimes(1);
+    fireEvent.pointerUp(btn, { clientX: 12, clientY: 11 });
+    // Browsers fire click after pointerup on the same target; the completed
+    // hold must consume it so the overlay does not toggle.
+    fireEvent.click(btn);
+    expect(hold.onHoldEnd).toHaveBeenCalledTimes(1);
+    expect(hold.onHoldCancel).not.toHaveBeenCalled();
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("releasing farther than the slide-off distance cancels instead of sending", () => {
+    const hold = holdHandlers();
+    render(
+      <HomePill phase="idle" onOpen={() => {}} onClose={() => {}} {...hold} />,
+    );
+    const btn = screen.getByRole("button");
+    fireEvent.pointerDown(btn, { button: 0, clientX: 10, clientY: 10 });
+    vi.advanceTimersByTime(HOLD_THRESHOLD_MS + 10);
+    fireEvent.pointerUp(btn, {
+      clientX: 10 + SLIDE_CANCEL_PX + 20,
+      clientY: 10,
+    });
+    expect(hold.onHoldCancel).toHaveBeenCalledTimes(1);
+    expect(hold.onHoldEnd).not.toHaveBeenCalled();
+  });
+
+  it("Escape mid-hold cancels without sending", () => {
+    const hold = holdHandlers();
+    const { rerender } = render(
+      <HomePill phase="idle" onOpen={() => {}} onClose={() => {}} {...hold} />,
+    );
+    const btn = screen.getByRole("button");
+    fireEvent.pointerDown(btn, { button: 0, clientX: 10, clientY: 10 });
+    vi.advanceTimersByTime(HOLD_THRESHOLD_MS + 10);
+    expect(hold.onHoldStart).toHaveBeenCalledTimes(1);
+    // The controller flips phase to listening once capture starts.
+    rerender(
+      <HomePill
+        phase="listening"
+        onOpen={() => {}}
+        onClose={() => {}}
+        {...hold}
+      />,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(hold.onHoldCancel).toHaveBeenCalledTimes(1);
+    // The (now cancelled) release must not also send.
+    fireEvent.pointerUp(btn, { clientX: 10, clientY: 10 });
+    expect(hold.onHoldEnd).not.toHaveBeenCalled();
+  });
+
+  it("pointercancel (e.g. window drag interruption) cancels the hold", () => {
+    const hold = holdHandlers();
+    render(
+      <HomePill phase="idle" onOpen={() => {}} onClose={() => {}} {...hold} />,
+    );
+    const btn = screen.getByRole("button");
+    fireEvent.pointerDown(btn, { button: 0, clientX: 10, clientY: 10 });
+    vi.advanceTimersByTime(HOLD_THRESHOLD_MS + 10);
+    fireEvent.pointerCancel(btn);
+    expect(hold.onHoldCancel).toHaveBeenCalledTimes(1);
+    expect(hold.onHoldEnd).not.toHaveBeenCalled();
+  });
+
+  it("a right-click press never arms the hold", () => {
+    const hold = holdHandlers();
+    render(
+      <HomePill phase="idle" onOpen={() => {}} onClose={() => {}} {...hold} />,
+    );
+    const btn = screen.getByRole("button");
+    fireEvent.pointerDown(btn, {
+      button: 2,
+      pointerType: "mouse",
+      clientX: 10,
+      clientY: 10,
+    });
+    vi.advanceTimersByTime(HOLD_THRESHOLD_MS + 100);
+    expect(hold.onHoldStart).not.toHaveBeenCalled();
+  });
+
+  it("without hold handlers the pill is click-only (no timer armed)", () => {
+    const onOpen = vi.fn();
+    render(<HomePill phase="idle" onOpen={onOpen} onClose={() => {}} />);
+    const btn = screen.getByRole("button");
+    fireEvent.pointerDown(btn, { button: 0, clientX: 10, clientY: 10 });
+    vi.advanceTimersByTime(HOLD_THRESHOLD_MS + 200);
+    fireEvent.pointerUp(btn, { clientX: 10, clientY: 10 });
+    fireEvent.click(btn);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("announces the live hold state through the accessible label", () => {
+    render(<HomePill phase="listening" onOpen={() => {}} onClose={() => {}} />);
+    expect(
+      screen.getByRole("button", { name: /listening — release to send/i }),
+    ).toBeTruthy();
   });
 });

--- a/packages/ui/src/components/shell/shell-controller-sync/__tests__/fixtures.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/__tests__/fixtures.ts
@@ -84,6 +84,7 @@ export function makeFakeShellController(): ShellController {
     toggleRecording: vi.fn(),
     startRecording: vi.fn(),
     stopRecording: vi.fn(),
+    cancelRecording: vi.fn(),
     toggleHandsFree: vi.fn(),
     recheckMicPermission: vi.fn(async () => "granted" as const),
     toggleTranscriptionMode: vi.fn(),

--- a/packages/ui/src/components/shell/shell-controller-sync/apply-command.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/apply-command.ts
@@ -36,6 +36,8 @@ export function applyShellControllerCommand(
       return Promise.resolve(controller.startRecording(command.intent));
     case "stopRecording":
       return Promise.resolve(controller.stopRecording());
+    case "cancelRecording":
+      return Promise.resolve(controller.cancelRecording());
     case "toggleHandsFree":
       return Promise.resolve(controller.toggleHandsFree());
     case "toggleTranscriptionMode":

--- a/packages/ui/src/components/shell/shell-controller-sync/follower-controller.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/follower-controller.ts
@@ -81,6 +81,7 @@ export function buildFollowerController(
     startRecording: (intent) =>
       fire({ kind: "startRecording", ...(intent ? { intent } : {}) }),
     stopRecording: () => fire({ kind: "stopRecording" }),
+    cancelRecording: () => fire({ kind: "cancelRecording" }),
     handsFree: snapshot.handsFree,
     toggleHandsFree: () => fire({ kind: "toggleHandsFree" }),
     micPermission: snapshot.micPermission,

--- a/packages/ui/src/components/shell/shell-controller-sync/protocol.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/protocol.ts
@@ -43,9 +43,10 @@ export type ShellControllerCommand =
   | { kind: "toggleRecording" }
   | {
       kind: "startRecording";
-      intent?: "converse" | "dictate" | "transcription";
+      intent?: "converse" | "dictate" | "transcription" | "ptt";
     }
   | { kind: "stopRecording" }
+  | { kind: "cancelRecording" }
   | { kind: "toggleHandsFree" }
   | { kind: "toggleTranscriptionMode" }
   | { kind: "stopTranscriptionAndMic" }
@@ -130,6 +131,7 @@ const NO_ARG_COMMANDS: ReadonlySet<ShellControllerCommandKind> = new Set([
   "captureVision",
   "toggleRecording",
   "stopRecording",
+  "cancelRecording",
   "toggleHandsFree",
   "toggleTranscriptionMode",
   "stopTranscriptionAndMic",
@@ -182,7 +184,8 @@ export function parseShellControllerCommand(
       return value.intent === undefined ||
         value.intent === "converse" ||
         value.intent === "dictate" ||
-        value.intent === "transcription"
+        value.intent === "transcription" ||
+        value.intent === "ptt"
         ? (value as unknown as ShellControllerCommand)
         : null;
     case "speak":

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -127,7 +127,7 @@ const SHELL_CAPTURE_PAUSE_GRACE_MS = 1500;
  *  session (not per-utterance chat bubbles) and the agent stays quiet until an
  *  exit phrase, at which point the session becomes a Transcript record + a chat
  *  link-widget. */
-export type CaptureIntent = "converse" | "dictate" | "transcription";
+export type CaptureIntent = "converse" | "dictate" | "transcription" | "ptt";
 
 export interface ShellController {
   phase: ShellPhase;
@@ -175,10 +175,16 @@ export interface ShellController {
   toggleRecording: () => void;
   /** Begin voice input unconditionally. `"converse"` (default) starts the
    *  configured realtime session; `"dictate"` routes the final transcript to
-   *  the composer draft without sending. */
+   *  the composer draft without sending; `"ptt"` (the pill's hold-to-talk
+   *  quasimode, #20483) sends the final transcript as a voice turn directly,
+   *  overlay open or not. */
   startRecording: (intent?: CaptureIntent) => void;
   /** End capture unconditionally. Used by push-to-talk release. */
   stopRecording: () => void;
+  /** Abandon an in-flight capture WITHOUT transcribing or sending — the
+   *  hold-to-talk cancel gestures (Esc mid-hold, slide-off release). Releases
+   *  the mic immediately; a no-op when nothing is capturing. */
+  cancelRecording: () => void;
   /** Live interim transcription of the current utterance ("" when none). */
   transcript: string;
   /** True while an assistant reply is being spoken aloud (voice output). */
@@ -1049,6 +1055,29 @@ export function useShellController(): ShellController {
     void stopCaptureAndDrain();
   }, [stopCaptureAndDrain]);
 
+  // Hold-to-talk cancel (#20483): drop the capture WITHOUT the stop() drain, so
+  // no STT round-trip runs and nothing is transcribed or sent. dispose() runs
+  // the recorder's cancel() — it releases the MediaStream tracks and closes the
+  // AudioContext. This is the Esc-mid-hold / slide-off-release path; a
+  // cancelled hold must cost the user nothing.
+  const cancelCapture = React.useCallback(() => {
+    const handle = captureRef.current;
+    captureRef.current = null;
+    explicitStopRef.current = true;
+    turnCarryoverRef.current = "";
+    turnAggregatorRef.current?.reset();
+    if (handle) {
+      try {
+        handle.dispose();
+      } catch {
+        /* dispose is best-effort — the recorder's cancel() is idempotent */
+      }
+    }
+    setAnalyser(null);
+    setRecording(false);
+    setTranscript("");
+  }, []);
+
   // Discard an in-flight capture on app suspend WITHOUT transcribing (#voice-V1).
   // When iOS backgrounds the PWA mid-capture the `ScriptProcessorNode` stalls,
   // so `handle.stop()` (the drain path) would trigger a doomed STT round-trip on
@@ -1126,7 +1155,7 @@ export function useShellController(): ShellController {
       // dictation) it bypasses the echo/disfluency end-of-turn aggregator —
       // every final is sent as-is (after exit-phrase detection).
       const aggregator =
-        intent === "dictate" || intent === "transcription"
+        intent === "dictate" || intent === "transcription" || intent === "ptt"
           ? null
           : new TurnAggregator({
               onCommit: (turn) => {
@@ -1183,11 +1212,11 @@ export function useShellController(): ShellController {
         ...(asrProviderRef.current
           ? { asrProvider: asrProviderRef.current }
           : {}),
-        // Push-to-talk dictation ends on release, so the native recognizer must
-        // commit its running interim as the final turn even if its silence
-        // window hasn't fired. Converse stops only on toggle-off, where a
-        // partial must NOT be submitted.
-        finalizeOnStop: intent === "dictate",
+        // Push-to-talk (dictation AND the pill's hold-to-talk quasimode) ends
+        // on release, so the native recognizer must commit its running interim
+        // as the final turn even if its silence window hasn't fired. Converse
+        // stops only on toggle-off, where a partial must NOT be submitted.
+        finalizeOnStop: intent === "dictate" || intent === "ptt",
         // Pre-POST silence guard fired: a near-silent tap was dropped without a
         // cloud round-trip (correct), but the user got nothing. Surface a subtle
         // "didn't catch that" hint so the dead-air is legible instead of
@@ -1292,6 +1321,18 @@ export function useShellController(): ShellController {
             // don't send, and leave lastTurnVoice false so no reply is spoken.
             setTranscript("");
             onDictatedTextRef.current?.(text);
+          } else if (intent === "ptt") {
+            // Hold-to-talk quasimode (#20483): the press-release IS the turn
+            // boundary and the utterance IS the send. No aggregator, no
+            // composer detour — the transcript goes straight out as a voice
+            // turn, so the pill can serve a full exchange with the overlay
+            // closed. An empty final never reaches here (guarded above), so a
+            // ghost hold costs nothing.
+            setTranscript("");
+            send(text, {
+              channelType: "VOICE_DM",
+              metadata: { voiceSource: segment.backend },
+            });
           } else if (aggregator) {
             // A spoken "start transcription" flips INTO long-form record-only
             // mode instead of being sent as a normal turn. (Exit is handled
@@ -2429,6 +2470,7 @@ export function useShellController(): ShellController {
     toggleRecording,
     startRecording: startCapture,
     stopRecording,
+    cancelRecording: cancelCapture,
     handsFree,
     realtimeVoice: {
       enabled: realtimeVoiceEnabled,

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -385,6 +385,29 @@ body.pwa-standalone textarea {
   }
 }
 
+/* ── Home pill listening waveform ───────────────────────────────────── */
+
+/*
+ * Wispr-Flow-style mic-live bars inside the shell home pill. The bars are
+ * fixed-height spans that oscillate scaleY so the capsule reads as "hearing
+ * you" without real audio metering; per-bar animation-delay staggers them.
+ */
+.home-pill-wave-bar {
+  animation: home-pill-wave 900ms ease-in-out infinite;
+  transform-origin: center;
+}
+
+@keyframes home-pill-wave {
+  0%,
+  100% {
+    transform: scaleY(0.55);
+  }
+
+  50% {
+    transform: scaleY(1.9);
+  }
+}
+
 /* ── Animation utilities ────────────────────────────────────────────── */
 
 .animate-in {

--- a/packages/ui/src/voice/capture-cues.ts
+++ b/packages/ui/src/voice/capture-cues.ts
@@ -1,0 +1,79 @@
+/**
+ * Audible cues for the hold-to-talk quasimode (#20483): a short rising ping
+ * the instant capture opens and a softer falling tick when the utterance is
+ * sent. The pair is the trust signal push-to-talk needs — the user knows the
+ * mic opened (and closed) without looking at the pill, which is the whole
+ * point of a no-window capture. Tones are synthesized with WebAudio so no
+ * asset ships; volumes stay low because the cue confirms, it never announces.
+ *
+ * A cancelled hold plays nothing: cancellation must cost the user zero
+ * attention. Failures are swallowed — an environment without WebAudio (or
+ * with a suspended context the user never unlocked) silently skips the cue
+ * rather than blocking capture.
+ */
+
+let cueContext: AudioContext | null = null;
+
+function getCueContext(): AudioContext | null {
+  if (typeof window === "undefined") return null;
+  const Ctor =
+    window.AudioContext ??
+    (window as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  if (!Ctor) return null;
+  if (!cueContext || cueContext.state === "closed") {
+    try {
+      cueContext = new Ctor();
+    } catch {
+      // error-policy:J4 no audio device / context quota — cues are optional
+      return null;
+    }
+  }
+  if (cueContext.state === "suspended") {
+    // Called from a user gesture (pointerdown hold / release), so resume is
+    // permitted; if the policy still blocks it the cue is skipped, not queued.
+    void cueContext.resume().catch(() => undefined);
+  }
+  return cueContext;
+}
+
+function playTone(
+  frequencies: readonly [startHz: number, endHz: number],
+  durationMs: number,
+  peakGain: number,
+): void {
+  const ctx = getCueContext();
+  if (!ctx) return;
+  try {
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    const now = ctx.currentTime;
+    const duration = durationMs / 1000;
+    osc.type = "sine";
+    osc.frequency.setValueAtTime(frequencies[0], now);
+    osc.frequency.exponentialRampToValueAtTime(frequencies[1], now + duration);
+    // Fast attack, exponential decay — reads as a soft "blip", not a beep.
+    gain.gain.setValueAtTime(0.0001, now);
+    gain.gain.exponentialRampToValueAtTime(peakGain, now + 0.012);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start(now);
+    osc.stop(now + duration + 0.02);
+    osc.onended = () => {
+      osc.disconnect();
+      gain.disconnect();
+    };
+  } catch {
+    // error-policy:J4 cue synthesis is best-effort; capture is unaffected
+  }
+}
+
+/** Rising ping: the mic just opened — start talking. */
+export function playCaptureStartCue(): void {
+  playTone([520, 780], 140, 0.06);
+}
+
+/** Softer falling tick: the utterance was captured and is on its way. */
+export function playCaptureSendCue(): void {
+  playTone([660, 440], 110, 0.04);
+}


### PR DESCRIPTION
## What

Step 1–2 of the pill UX plan (#20483): the **hold-to-talk quasimode** on the home pill, with the Wispr-Flow-informed listening chip and audio cues.

**The gesture.** Press-and-hold the pill (>150ms) → mic opens with a rising ping and the capsule grows into a dark red-ringed chip with nine staggered waveform bars → speak → release → falling tick, capture finalizes, transcript is sent directly as a voice turn. **No window opens, no focus is stolen.** A quick press (<150ms) stays the overlay toggle. The hold is a quasimode (Raskin): the pressed pointer IS the state — nothing to remember, nothing to un-stick.

```
   pointer DOWN ──150ms──→ LISTENING ──release──→ sent (voice turn)
        │                     │  ▲
   up <150ms = click      Esc │  │ slide-off >44px at release
   (summon, as today)      cancel │  = cancel
                       (discard, no STT round trip, no toast)
```

**Controller.** New `"ptt"` capture intent: `finalizeOnStop` like dictation, but the final transcript goes straight to `send()` (VOICE_DM) instead of prefilling the composer — the pill can serve a full exchange with the overlay closed. New `cancelRecording()` disposes an in-flight capture without transcribing (Esc/slide-off must cost nothing); forwarded through the follower-controller sync protocol so detached windows keep parity. `AssistantOverlay` now takes explicit `open` from the shell state, so headless `listening`/`responding` no longer force the overlay open.

**Visuals (field-studied).** Captured the real Wispr Flow bar frame-by-frame during a synthesized fn-hold on this machine: its handle *grows* into a dark chip with dense live bars — growth, not recoloring, is what makes hot-mic legible. Adopted: 48×10 white handle → 80×28 neutral-900 chip, nine center-weighted staggered white bars, red hot-mic ring, `motion-reduce` fallbacks. Study notes on #20483.

**Cues.** `capture-cues.ts`: WebAudio-synthesized start-ping and send-tick (no assets); silent on cancel; best-effort (no context → skipped, never blocks capture).

## Verification

- 21 HomePill tests (gesture state machine: click/hold disambiguation, release-to-send, slide-off, Esc, pointercancel, right-click guard, handler-less fallback; chip visuals, symmetric stagger). Full `packages/ui` suite: 10550+ passed; the single failure (`AppBackground.test.tsx` act() warning) reproduces identically on clean develop.
- Typecheck + Biome clean.
- **Live packaged proof** (cloud-only build, macOS arm64): synthesized a real 2.5s mouse-hold on the packaged pill while burst-capturing the screen — frames show handle → dark red-ringed chip with animated bars during the hold → clean collapse back to the idle handle after release. The gesture, phase transitions, and no-stuck-state recovery all verified on the shipped bundle.

## Scoped out of this PR (verified gaps, tracked on #20483)

1. **End-to-end transcription on the shared cloud tier**: the release correctly POSTs the WAV, but `POST /api/v1/voice/stt` timed out (15s abort ×2 retries) against the shared-tier worker in live testing, so the spoken words did not land as a message this session. The capture/UI layer handled the failure without a stuck state; the STT transport (and a visible "didn't catch that" notice on the ptt path) is the next fix. Same shared-tier service family as #20473.
2. **fn-key / global hold-hotkey**: not in this PR by design — Electrobun's `GlobalShortcut` is trigger-only (verified down to the FFI symbols: `register(accelerator, callback)` with no keyup event), so a hold gesture on a global key needs a native key monitor (CGEventTap/NSEvent), which belongs with the #12184 fork-gap work. The pill gesture is the v1 surface.

Advances #20483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
