### PR TITLE
fix(plugin-x): require OAuth state in callback redirects

### DIFF
--- a/plugins/plugin-x/src/client/auth-providers/interactive.ts
+++ b/plugins/plugin-x/src/client/auth-providers/interactive.ts
@@ -15,6 +15,15 @@ export interface OAuthCallbackResult {
   state?: string;
 }
 
+export function assertOAuthState(
+  actualState: string | null | undefined,
+  expectedState: string,
+): void {
+  if (actualState !== expectedState) {
+    throw new Error("OAuth state mismatch");
+  }
+}
+
 function canPrompt(): boolean {
   return !!process.stdin && !!process.stdout && process.stdin.isTTY === true;
 }
@@ -109,10 +118,12 @@ export async function waitForLoopbackCallback(
           return;
         }
 
-        if (state && state !== expectedState) {
+        try {
+          assertOAuthState(state, expectedState);
+        } catch (error) {
           res.writeHead(400, { "content-type": "text/plain" });
           res.end("State mismatch");
-          finish(new Error("OAuth state mismatch"));
+          finish(error instanceof Error ? error : new Error(String(error)));
           return;
         }
 

--- a/plugins/plugin-x/src/client/auth-providers/oauth2-pkce.test.ts
+++ b/plugins/plugin-x/src/client/auth-providers/oauth2-pkce.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Regression coverage for the OAuth 2.0 PKCE callback boundary: the pasted
+ * redirect must include the generated anti-CSRF state before token exchange.
+ * Deterministic provider test; interactive I/O and token HTTP are mocked.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { OAuth2PKCEAuthProvider } from "./oauth2-pkce";
+import type { TokenStore } from "./token-store";
+
+vi.mock("./interactive", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./interactive")>()),
+  waitForLoopbackCallback: vi.fn(async () => {
+    throw new Error("loopback unavailable");
+  }),
+  promptForRedirectedUrl: vi.fn(
+    async () => "http://127.0.0.1/callback?code=auth-code",
+  ),
+}));
+
+function createRuntime(): IAgentRuntime {
+  return {
+    agentId: "00000000-0000-0000-0000-000000000001",
+    getSetting: vi.fn(
+      (key: string) =>
+        ({
+          TWITTER_CLIENT_ID: "client-id",
+          TWITTER_REDIRECT_URI: "http://127.0.0.1/callback",
+        })[key],
+    ),
+  } as unknown as IAgentRuntime;
+}
+
+function createStore(): TokenStore {
+  return {
+    load: vi.fn(async () => null),
+    save: vi.fn(async () => undefined),
+    clear: vi.fn(async () => undefined),
+  };
+}
+
+describe("OAuth2PKCEAuthProvider", () => {
+  it("rejects a pasted redirect that omits state before exchanging the code", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const provider = new OAuth2PKCEAuthProvider(
+      createRuntime(),
+      undefined,
+      createStore(),
+      fetchImpl,
+    );
+
+    await expect(provider.getAccessToken()).rejects.toThrow(
+      "OAuth state mismatch",
+    );
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-x/src/client/auth-providers/oauth2-pkce.ts
+++ b/plugins/plugin-x/src/client/auth-providers/oauth2-pkce.ts
@@ -12,7 +12,11 @@ import { logger } from "@elizaos/core";
 import type { TwitterClientState } from "../../types";
 import { getSetting } from "../../utils/settings";
 import { DEFAULT_X_ACCOUNT_ID, resolveRequestedXAccountId } from "../accounts";
-import { promptForRedirectedUrl, waitForLoopbackCallback } from "./interactive";
+import {
+  assertOAuthState,
+  promptForRedirectedUrl,
+  waitForLoopbackCallback,
+} from "./interactive";
 import { createCodeChallenge, createCodeVerifier, createState } from "./pkce";
 import type { StoredOAuth2Tokens, TokenStore } from "./token-store";
 import { chooseDefaultTokenStore } from "./token-store";
@@ -244,9 +248,7 @@ export class OAuth2PKCEAuthProvider implements TwitterAuthProvider {
       const parsedCode = parsed.searchParams.get("code");
       const parsedState = parsed.searchParams.get("state");
       if (!parsedCode) throw new Error("Pasted URL did not include ?code=");
-      if (parsedState && parsedState !== state) {
-        throw new Error("OAuth state mismatch");
-      }
+      assertOAuthState(parsedState, state);
       code = parsedCode;
     }
 


### PR DESCRIPTION
# Relates to

Closes #20507.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] this PR targets `develop` and is branched directly off the current `origin/develop` tip.
- [x] focused package tests and lint pass on the exact head, see Testing below.
- [x] a reviewer can confirm the fix directly against the deterministic unit test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (fix, tests, via AgentRouter proxy), `anthropic/claude-sonnet-5` (independent re-verification)
<!-- attribution-row:client -->
- Agent tooling: `codex` (via AgentRouter proxy), `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] branched directly off the current `origin/develop` tip

# Risks

low change surface, meaningful security property: the fix only tightens an existing check from a truthy short-circuit to strict equality. Every redirect that previously passed with a *present, matching* `state` still passes identically; only a redirect that omits `state` (never a legitimate provider response — X's OAuth2 authorization server always echoes back the `state` a client sent) is newly rejected.

# Background

## What does this PR do?

`OAuth2PKCEAuthProvider` generates a PKCE `state` value for its OAuth 2.0 authorization-code flow, but both callback paths (the loopback HTTP server and the pasted-redirect-URL fallback) validated it with a truthy short-circuit: `if (state && state !== expectedState)`. A redirect containing a usable `?code=...` but omitting `state` entirely skipped the mismatch check and proceeded straight to token exchange instead of failing closed — defeating the CSRF protection the `state` parameter exists to provide.

confirmed directly before touching the source: a redirect with `code` but no `state`, run against the real `OAuth2PKCEAuthProvider` fallback path with mocked interactive I/O, reached the mocked token-exchange `fetch` call instead of being rejected first.

traced reachability honestly before writing this up: this is the live interactive OAuth setup flow, not a dormant path. `ClientBase` (`plugins/plugin-x/src/base.ts:571`) calls `createTwitterAuthProvider`, which returns `OAuth2PKCEAuthProvider` when `TWITTER_AUTH_MODE=oauth` (`factory.ts:31-40`); `TwitterAuth.getAccessToken()` (`auth.ts:118`) runs `interactiveLogin()`, which tries `waitForLoopbackCallback()` first and falls back to `promptForRedirectedUrl()` — both callback paths accepted a state-less redirect before this fix. Any operator running plugin-x with `TWITTER_AUTH_MODE=oauth` is on the affected path.

fix: one strict `assertOAuthState(actualState, expectedState)` helper in `interactive.ts` requiring exact equality (so `null`/`undefined`/missing all correctly throw), shared by both `waitForLoopbackCallback` and `OAuth2PKCEAuthProvider`'s pasted-URL fallback instead of each having its own ad hoc truthy-guarded comparison.

## What kind of change is this?

bug fix, non-breaking for legitimate traffic (every redirect that previously passed with a present, matching `state` still passes identically; only a state-less redirect — never a legitimate provider response — is newly rejected). Security-relevant: closes a CSRF-protection bypass in an interactive, operator-initiated OAuth setup flow.

# Documentation changes needed?

no.

# Testing

## Where should a reviewer start?

`plugins/plugin-x/src/client/auth-providers/oauth2-pkce.test.ts` (new file), the `rejects a pasted redirect that omits state before exchanging the code` case, then the shared `assertOAuthState` helper in `interactive.ts` and its two call sites.

## Detailed testing steps

```text
$ bun run --cwd plugins/plugin-x vitest run src/client/auth-providers/oauth2-pkce.test.ts
Test Files  1 passed (1)
     Tests  1 passed (1)

$ bun run --cwd plugins/plugin-x lint:check
Checked 85 files in 89ms. No fixes applied.

$ bun run --cwd plugins/plugin-x typecheck
(clean, exit 0)

$ bun run --cwd plugins/plugin-x test
Test Files  28 passed | 1 skipped (29)
Tests       198 passed | 13 skipped (211)

$ bun run --cwd plugins/plugin-x build
ESM Build success, DTS Build success
```

mutation-resistance verified independently: reverted just the source fix (`git stash push` on both touched source files, kept the new test), reran — the test failed with `Cannot read properties of undefined (reading 'json')` instead of the expected `OAuth state mismatch`, proving the missing-state redirect reached the mocked token-exchange fetch. restored the fix, 1/1 green again.

# Evidence Gate

<!-- evidence-head:3b36f4bca0a6fa7ad1e447f65c13922fdf3a76a3 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes an internal auth-callback validation path, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - this changes an internal auth-callback validation path, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive product UI flow (the flow itself is a CLI/terminal OAuth setup prompt, exercised deterministically by the new test).
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic unit test, the real transcript is included under domain artifacts.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code or network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real mutation-resistance run, captured directly:
  ```text
  red (source fix reverted, test kept):
  $ bun run --cwd plugins/plugin-x vitest run src/client/auth-providers/oauth2-pkce.test.ts
  Expected: "OAuth state mismatch"
  Received: "Cannot read properties of undefined (reading 'json')"
  Tests  1 failed (1)

  green (fix restored):
  $ bun run --cwd plugins/plugin-x vitest run src/client/auth-providers/oauth2-pkce.test.ts
  Tests  1 passed (1)
  ```
  also independently confirmed the full reachability chain (`base.ts:571` → `factory.ts:31-40` → `auth.ts:118` → `interactiveLogin()` → both callback paths) directly in source before writing the reachability claim.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface or visual text changed.

## Known gaps / failures

none in the touched surface. Full package gates (lint, typecheck, test, build) all pass clean on the exact head, independently rerun.

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the focused suite, full package lint/typecheck/test/build, and did my own revert-and-confirm-red mutation check myself, independently confirmed the full reachability chain in source, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Contribution skill revision: N/A - direct interactive session, contribute-to-eliza skill not used
Compute receipt: N/A - Slop run-receipt install currently blocked by an unrelated site-deploy-lag issue (deployed skill archive predates recent develop changes)
Attribution status: self-reported
