### PR TITLE
fix(orchestrator): task-status truth chain — duplicate-spawn guard, in-flight grounding, filter disclosure, token-AND search

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/actions/duplicate-spawn-guard.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/duplicate-spawn-guard.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit-tests the cross-request duplicate-spawn guard's pure pieces: the goal
+ * similarity metric on the live observed duplicate pair, threshold behavior on
+ * unrelated goals, and the explicit force-phrase escape. Pure functions, no
+ * runtime.
+ */
+import { describe, expect, test } from "vitest";
+import { DUPLICATE_SPAWN_FORCE_RE, goalSimilarity } from "./tasks.js";
+
+describe("goalSimilarity", () => {
+  test("live duplicate pair scores above the guard threshold", () => {
+    const existing =
+      "Build a single-page personal website for nubs — a guy who collects mechanical keyboards. dark theme, clean, a lil personality";
+    const duplicate =
+      "Nubs mechanical keyboard site Build a single-page personal website for nubs who collects mechanical keyboards";
+    expect(goalSimilarity(duplicate, existing)).toBeGreaterThanOrEqual(0.6);
+  });
+
+  test("unrelated goals stay below threshold", () => {
+    expect(
+      goalSimilarity(
+        "fix the failing unit tests in the billing package",
+        "Build a single-page personal website for nubs mechanical keyboards",
+      ),
+    ).toBeLessThan(0.6);
+  });
+
+  test("empty text never matches", () => {
+    expect(goalSimilarity("", "anything at all here")).toBe(0);
+  });
+});
+
+describe("DUPLICATE_SPAWN_FORCE_RE", () => {
+  test("explicit repeat phrasing escapes the guard", () => {
+    for (const text of [
+      "run it again",
+      "build another one",
+      "start a fresh task",
+      "retry the build",
+      "redo it from scratch",
+    ]) {
+      expect(DUPLICATE_SPAWN_FORCE_RE.test(text)).toBe(true);
+    }
+  });
+
+  test("status-shaped asks do not escape", () => {
+    for (const text of [
+      "so is my site done?? where can i see it",
+      "whats the status of the build",
+      "did it finish",
+    ]) {
+      expect(DUPLICATE_SPAWN_FORCE_RE.test(text)).toBe(false);
+    }
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -2745,7 +2745,16 @@ function taskMatchesSearch(task: TaskThreadDto, search: string): boolean {
     .filter((part): part is string => typeof part === "string")
     .join(" ")
     .toLowerCase();
-  return haystack.includes(needle);
+  if (haystack.includes(needle)) return true;
+  // Token-AND fallback: planner-composed searches are noun phrases in the
+  // planner's word order ("nubs website"), while the stored title carries the
+  // user's ("personal website for nubs") — a whole-phrase substring miss then
+  // reads as "no task exists" against a store that plainly holds it (observed
+  // live). Every whitespace token present somewhere in the haystack matches.
+  const tokens = needle.split(/\s+/).filter((token) => token.length > 0);
+  return (
+    tokens.length > 1 && tokens.every((token) => haystack.includes(token))
+  );
 }
 
 function sessionMatchesHistoryFilters(

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -3068,9 +3068,28 @@ async function runHistory(
         responseText = `I found ${count} orchestrator task${count === 1 ? "" : "s"}${filterSuffix}.`;
       } else if (tasks.length === 0) {
         inFlight = await findInFlightWork(runtime, taskCandidates);
+        // Search-matched tasks the status/window filter excluded. A
+        // planner-guessed status list ("active, done, failed") silently hides
+        // a `validating` task, and the bare "found nothing" then reads as "no
+        // task exists" against a store that plainly holds it (observed live).
+        // Disclose what the filters hid instead of implying absence.
+        const excludedByFilters = taskCandidates
+          .filter((task) => !sessionTask || task.id === sessionTask.id)
+          .filter(
+            (task) =>
+              !taskMatchesHistoryFilters(task, statuses, windowFilters, search),
+          )
+          .slice(0, 3);
         responseText = inFlight
           ? `Nothing has finished yet — I'm still working on ${inFlight.name}.`
-          : `I did not find any orchestrator task threads${filterSuffix}.`;
+          : excludedByFilters.length > 0
+            ? [
+                `No task threads matched${filterSuffix}, but related tasks exist outside those filters:`,
+                ...excludedByFilters.map(
+                  (task) => `- "${task.title}" — status=${task.status}`,
+                ),
+              ].join("\n")
+            : `I did not find any orchestrator task threads${filterSuffix}.`;
       } else if (metric === "detail") {
         const task = tasks[0];
         responseText = [

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -965,6 +965,30 @@ async function runCreateLegacy(
   const taskService = runtime.getService?.(
     OrchestratorTaskService.serviceType,
   ) as OrchestratorTaskService | null | undefined;
+  {
+    // Same skip as the spawn path: router-driven synthetic inbounds restate
+    // in-flight goals by design; only fresh user-originated creates screen.
+    const duplicate =
+      content.source !== MESSAGE_SOURCE_SUB_AGENT &&
+      extraMetadata.subAgent !== true
+        ? await findNearDuplicateInFlightWork({
+            runtime,
+            taskService,
+            candidateText: `${taskTitle} ${taskGoal}`,
+            userText: typeof content.text === "string" ? content.text : "",
+          })
+        : undefined;
+    if (duplicate) {
+      const replyText = duplicateSpawnReply(duplicate);
+      await callbackText(callback, replyText);
+      return {
+        success: true,
+        text: replyText,
+        continueChain: false,
+        data: { actionName: "TASKS", duplicateSpawnGuard: true },
+      };
+    }
+  }
   const useSmithers = shouldUseSmithersTaskRunner();
   let threadId: string | null = null;
   try {
@@ -1868,6 +1892,36 @@ async function runSpawnAgent(
       message,
       content,
     );
+    // Router-driven re-spawns (failed-verification respawn loops) and nested
+    // swarm children joining an explicit task room legitimately restate the
+    // in-flight goal — the guard only screens fresh user-originated spawns.
+    const userOriginatedSpawn =
+      content.source !== MESSAGE_SOURCE_SUB_AGENT &&
+      extraMetadata.subAgent !== true &&
+      !pickRoutingString(params, content, extraMetadata, "taskRoomId")?.trim();
+    {
+      const spawnTaskService = runtime.getService?.(
+        OrchestratorTaskService.serviceType,
+      ) as OrchestratorTaskService | null | undefined;
+      const duplicate = userOriginatedSpawn
+        ? await findNearDuplicateInFlightWork({
+            runtime,
+            taskService: spawnTaskService,
+            candidateText: `${label} ${task}`,
+            userText: typeof content.text === "string" ? content.text : "",
+          })
+        : undefined;
+      if (duplicate) {
+        const replyText = duplicateSpawnReply(duplicate);
+        await callbackText(callback, replyText);
+        return {
+          success: true,
+          text: replyText,
+          continueChain: false,
+          data: { actionName: "TASKS", duplicateSpawnGuard: true },
+        };
+      }
+    }
     // Nested/child sub-agents JOIN the parent's task room when an explicit
     // taskRoomId is supplied (swarm collaboration on the same task); only a
     // brand-new task with no explicit room mints its own distinct room. The
@@ -2745,6 +2799,128 @@ function sessionMatchesTaskStatus(
     return status === "error" || status === "errored";
   if (taskStatus === "interrupted") return status === "cancelled";
   return status === taskStatus;
+}
+
+/**
+ * Explicit user phrasing that overrides the near-duplicate spawn guard — the
+ * user is deliberately asking for a repeat/fresh attempt, not accidentally
+ * re-describing in-flight work.
+ */
+export const DUPLICATE_SPAWN_FORCE_RE =
+  /\b(?:again|another|fresh|new one|restart|retry|redo|re-?run|one more|from scratch)\b/i;
+
+/** Task statuses that mean the work is still in flight (or parked awaiting a
+ * verdict/human) — a near-identical new spawn against one of these is a
+ * duplicate, not a new request. */
+const IN_FLIGHT_TASK_STATUSES: ReadonlySet<string> = new Set([
+  "open",
+  "active",
+  "validating",
+  "waiting_on_user",
+  "blocked",
+]);
+
+function goalTokenSet(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((token) => token.length > 2),
+  );
+}
+
+/** Overlap over the smaller token set — the composed duplicate goal is often a
+ * compressed restatement of the original, so containment beats Jaccard here. */
+export function goalSimilarity(a: string, b: string): number {
+  const tokensA = goalTokenSet(a);
+  const tokensB = goalTokenSet(b);
+  if (tokensA.size === 0 || tokensB.size === 0) return 0;
+  let overlap = 0;
+  for (const token of tokensA) {
+    if (tokensB.has(token)) overlap += 1;
+  }
+  return overlap / Math.min(tokensA.size, tokensB.size);
+}
+
+const DUPLICATE_SPAWN_SIMILARITY_THRESHOLD = 0.6;
+
+/**
+ * Cross-request near-duplicate guard for create/spawn. The per-origin spawn cap
+ * only anchors ONE user request; a status-shaped follow-up ("so is my site
+ * done?? where can i see it") arrives as a NEW message, the planner re-composes
+ * a near-identical goal, and a duplicate agent spawns against work that is
+ * already in flight or parked validating (observed live: "Nubs mechanical
+ * keyboard site" re-spawned while the original build task sat `validating`,
+ * then zombied). When a non-terminal task or session with a near-identical
+ * goal exists, report it instead of spawning; explicit "again/fresh/retry"
+ * phrasing bypasses the guard.
+ */
+async function findNearDuplicateInFlightWork(args: {
+  runtime: IAgentRuntime;
+  taskService: OrchestratorTaskService | null | undefined;
+  candidateText: string;
+  userText: string;
+}): Promise<{ name: string; status: string } | undefined> {
+  const { runtime, taskService, candidateText, userText } = args;
+  if (!candidateText.trim()) return undefined;
+  if (DUPLICATE_SPAWN_FORCE_RE.test(userText)) return undefined;
+  try {
+    if (taskService && typeof taskService.listTasks === "function") {
+      const tasks = await taskService.listTasks({});
+      for (const task of tasks) {
+        if (!IN_FLIGHT_TASK_STATUSES.has(task.status)) continue;
+        const existingText = `${task.title} ${task.originalRequest ?? ""}`;
+        if (
+          goalSimilarity(candidateText, existingText) >=
+          DUPLICATE_SPAWN_SIMILARITY_THRESHOLD
+        ) {
+          return { name: `"${task.title}"`, status: task.status };
+        }
+      }
+    }
+    const service = getAcpService(runtime);
+    if (service) {
+      for (const session of await listSessionsWithin(service)) {
+        if (TERMINAL_SESSION_STATUSES.has(session.status.toLowerCase())) {
+          continue;
+        }
+        const label =
+          typeof session.metadata?.label === "string"
+            ? session.metadata.label
+            : session.name;
+        const initialTask =
+          typeof session.metadata?.initialTask === "string"
+            ? session.metadata.initialTask
+            : "";
+        const existingText = `${label ?? ""} ${initialTask}`;
+        if (
+          goalSimilarity(candidateText, existingText) >=
+          DUPLICATE_SPAWN_SIMILARITY_THRESHOLD
+        ) {
+          return {
+            name: label ? `"${label}"` : "a coding session",
+            status: session.status.toLowerCase(),
+          };
+        }
+      }
+    }
+  } catch {
+    // error-policy:J4 the guard is best-effort protection; an inspection
+    // failure must not block a legitimate spawn.
+    return undefined;
+  }
+  return undefined;
+}
+
+function duplicateSpawnReply(duplicate: {
+  name: string;
+  status: string;
+}): string {
+  const statusLine =
+    duplicate.status === "validating"
+      ? "it finished its work and is awaiting completion verification"
+      : `its status is ${duplicate.status}`;
+  return `That work is already underway: ${duplicate.name} — ${statusLine}. I won't start a duplicate; ask me for its status any time, or say "run it again" if you want a fresh attempt.`;
 }
 
 /**

--- a/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
@@ -129,25 +129,16 @@ const PROVIDER_NAME = "ACTIVE_SUB_AGENTS";
 export const activeSubAgentsProvider: Provider = {
   name: PROVIDER_NAME,
   description:
-    "Active ACPX sub-agent sessions the main agent can reply to via SEND_TO_AGENT or terminate via STOP_AGENT.",
-  dynamic: true,
+    "Active ACPX sub-agent sessions the main agent can reply to via SEND_TO_AGENT or terminate via STOP_AGENT, plus non-terminal durable tasks.",
+  // Ambient, not dynamic: a dynamic provider only composes when a turn
+  // explicitly requests it, so status-shaped asks ("is my build done?")
+  // never saw this state and answered from chat impressions (observed live:
+  // a `validating` task described as "stopped before shipping" while its
+  // deliverable was live). The section is empty-text when nothing is in
+  // flight and cache-stable otherwise, so ambient inclusion costs nothing
+  // on idle turns.
+  dynamic: false,
   position: 0,
-  relevanceKeywords: [
-    "sub-agent",
-    "sub agent",
-    "subagent",
-    "task agent",
-    "coding agent",
-    "acpx",
-    // Status-shaped asks about delegated work ("is my build/site/task done?")
-    // must pull the in-flight task rows, or the turn answers from chat vibes.
-    "task",
-    "build",
-    "built",
-    "website",
-    "finished",
-    "done yet",
-  ],
   get: async (runtime: IAgentRuntime, _message: Memory, _state: State) => {
     const waves = readWaveStatuses(runtime);
     const inFlightTaskLines = await readInFlightTaskLines(runtime);

--- a/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
@@ -139,12 +139,21 @@ export const activeSubAgentsProvider: Provider = {
     "task agent",
     "coding agent",
     "acpx",
+    // Status-shaped asks about delegated work ("is my build/site/task done?")
+    // must pull the in-flight task rows, or the turn answers from chat vibes.
+    "task",
+    "build",
+    "built",
+    "website",
+    "finished",
+    "done yet",
   ],
   get: async (runtime: IAgentRuntime, _message: Memory, _state: State) => {
     const waves = readWaveStatuses(runtime);
+    const inFlightTaskLines = await readInFlightTaskLines(runtime);
     const service = getAcpService(runtime);
     if (!service || typeof service.listSessions !== "function") {
-      return emptyResult(null, null, waves);
+      return emptyResult(null, null, waves, inFlightTaskLines);
     }
     let all: SessionInfo[] | undefined;
     try {
@@ -174,7 +183,8 @@ export const activeSubAgentsProvider: Provider = {
     const routed = (Array.isArray(all) ? all : [])
       .filter(hasOrigin)
       .filter((s) => !TERMINAL_SESSION_STATUSES.has(s.status));
-    if (routed.length === 0) return emptyResult(capacity, admission, waves);
+    if (routed.length === 0)
+      return emptyResult(capacity, admission, waves, inFlightTaskLines);
 
     routed.sort((a, b) => a.id.localeCompare(b.id));
 
@@ -224,6 +234,7 @@ export const activeSubAgentsProvider: Provider = {
         ),
       );
     }
+    lines.push(...inFlightTaskLines);
     const text = lines.join("\n");
 
     return {
@@ -273,6 +284,69 @@ function capacityData(
 interface AdmissionSnapshot {
   queueDepth: number;
   queuedTaskIds: string[];
+}
+
+/** Structural task rows the provider needs from the orchestrator task service
+ * for the in-flight section. Read by serviceType like the admission snapshot. */
+interface InFlightTaskService {
+  listTasks?(filter: Record<string, unknown>): Promise<
+    Array<{
+      id: string;
+      title: string;
+      status: string;
+      activeSessionCount: number;
+    }>
+  >;
+}
+
+/** Task statuses that are CURRENT state even with no live session attached:
+ * the work exists and has not reached a terminal verdict. Excluding these made
+ * "is my build done?" turns answer from chat vibes (observed live: a task
+ * parked `validating` was described as "stopped before shipping" while its
+ * deliverable was live), because nothing in stage-1's context carried the
+ * store's ground truth. */
+const IN_FLIGHT_TASK_STATUSES: ReadonlySet<string> = new Set([
+  "open",
+  "active",
+  "validating",
+  "waiting_on_user",
+  "blocked",
+]);
+
+/** Non-terminal tasks as compact structural lines (title — status — id).
+ * No timestamps, so the provider segment stays cache-stable turn over turn. */
+async function readInFlightTaskLines(
+  runtime: IAgentRuntime,
+): Promise<string[]> {
+  const orchestrator = runtime.getService<Service & InFlightTaskService>(
+    ORCHESTRATOR_TASK_SERVICE_TYPE,
+  );
+  if (!orchestrator || typeof orchestrator.listTasks !== "function") {
+    return [];
+  }
+  try {
+    const tasks = await orchestrator.listTasks({});
+    const inFlight = tasks
+      .filter((task) => IN_FLIGHT_TASK_STATUSES.has(task.status))
+      .sort((a, b) => a.id.localeCompare(b.id));
+    if (inFlight.length === 0) return [];
+    return [
+      "## In-flight tasks (durable store — ground truth for task status)",
+      "A `validating` task finished its work and awaits completion verification; it is NOT failed and NOT still running. Answer task-status questions from these rows, or call TASKS_HISTORY for detail — never from chat impressions.",
+      ...inFlight.map(
+        (task) =>
+          `- "${task.title}" — status=${task.status} taskId=${task.id}${
+            task.activeSessionCount > 0
+              ? ` (sessions running: ${task.activeSessionCount})`
+              : ""
+          }`,
+      ),
+    ];
+  } catch {
+    // error-policy:J4 the in-flight section is supplementary grounding; an
+    // unavailable store degrades to no section, never a fabricated one.
+    return [];
+  }
 }
 
 async function readCapacity(service: {
@@ -347,13 +421,17 @@ function emptyResult(
   capacity: AcpCapacity | null = null,
   admission: AdmissionSnapshot | null = null,
   waves: WaveStatusSnapshot[] = [],
+  inFlightTaskLines: string[] = [],
 ) {
   const lines = [
     formatCapacityLine(capacity, admission),
     ...formatWaveLines(waves),
   ].filter(Boolean);
-  const text =
-    lines.length > 0 ? `## Active sub-agent sessions\n${lines.join("\n")}` : "";
+  const sections = [
+    lines.length > 0 ? `## Active sub-agent sessions\n${lines.join("\n")}` : "",
+    inFlightTaskLines.join("\n"),
+  ].filter(Boolean);
+  const text = sections.join("\n");
   return {
     text,
     values: { activeSubAgents: text },

--- a/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/active-sub-agents.ts
@@ -138,6 +138,10 @@ export const activeSubAgentsProvider: Provider = {
   // flight and cache-stable otherwise, so ambient inclusion costs nothing
   // on idle turns.
   dynamic: false,
+  // Explicit contexts beat the catalog's ["code","automation"] pin: task-status
+  // turns route through "general"/"tasks" (and promoted simple turns), so the
+  // narrow pin excluded this state from exactly the turns that ask about it.
+  contexts: ["general", "tasks", "code", "automation"],
   position: 0,
   get: async (runtime: IAgentRuntime, _message: Memory, _state: State) => {
     const waves = readWaveStatuses(runtime);

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -381,7 +381,21 @@ function matchesFilter(
   if (projectId && task.projectId !== projectId) return false;
   if (filter.search) {
     const needle = filter.search.trim().toLowerCase();
-    if (needle && !searchText.includes(needle)) return false;
+    if (needle && !searchText.includes(needle)) {
+      // Token-AND fallback, mirroring the action-layer taskMatchesSearch: a
+      // planner-composed search is a noun phrase in the planner's word order
+      // ("nubs website") while the stored text carries the user's ("personal
+      // website for nubs"). A whole-phrase miss here silently pre-filters the
+      // task out before ANY downstream matcher runs, so history answers "no
+      // task exists" against a store that holds it (observed live).
+      const tokens = needle.split(/\s+/).filter((token) => token.length > 0);
+      if (
+        tokens.length < 2 ||
+        !tokens.every((token) => searchText.includes(token))
+      ) {
+        return false;
+      }
+    }
   }
   return true;
 }
@@ -1082,8 +1096,19 @@ export class RuntimeDbTaskStore {
       params.push(projectId);
     }
     if (filter.search?.trim()) {
-      clauses.push("search_text LIKE ?");
-      params.push(`%${filter.search.trim().toLowerCase()}%`);
+      // Token-AND, matching the in-memory backend: a whole-phrase `%needle%`
+      // misses planner-composed word orders ("nubs website" vs "website for
+      // nubs") and silently answers "no task exists" against a store that
+      // holds it. Each whitespace token gets its own LIKE clause, ANDed.
+      const tokens = filter.search
+        .trim()
+        .toLowerCase()
+        .split(/\s+/)
+        .filter((token) => token.length > 0);
+      for (const token of tokens) {
+        clauses.push("search_text LIKE ?");
+        params.push(`%${token}%`);
+      }
     }
     const where = clauses.length ? `WHERE ${clauses.join(" AND ")}` : "";
     const limit =


### PR DESCRIPTION
## What

Makes "is my build done? where can I see it" answer from the durable task store instead of chat impressions or a duplicate spawn. Live failure chain (Discord group channel, a website-build task parked `validating`): the status ask spawned a **duplicate sub-agent** that zombied; after guarding that, the turn answered from room history ("stopped before shipping" — false, the deliverable was live); after routing to TASKS_HISTORY, the search and status filters each hid the existing task ("no task exists" ×3, which then poisoned room history further).

Five composing fixes in plugin-agent-orchestrator:

1. **Cross-request duplicate-spawn guard** (`actions/tasks.ts`) — the per-origin spawn cap only anchors ONE user request; a status-shaped follow-up arrives as a new message and the planner re-composes a near-identical goal. When a non-terminal task/session with a near-identical goal exists (token-overlap ≥0.6 over the smaller set), create/spawn report it honestly instead of spawning; explicit "again/fresh/retry" phrasing bypasses; router-driven re-spawns and swarm children are exempt.
2. **In-flight tasks in the sub-agent provider** (`providers/active-sub-agents.ts`) — non-terminal durable tasks (open/active/validating/waiting_on_user/blocked) render as compact structural rows with an explicit "`validating` = finished, awaiting verification — NOT failed" note.
3. **Provider actually reaches the turns that need it** — it was `dynamic: true` (only composes when explicitly requested — never) and catalog-pinned to `["code","automation"]` (status turns route `general`/`tasks`). Now ambient with explicit contexts; empty-text on idle so ambient inclusion costs nothing.
4. **History discloses filter-hidden tasks** (`actions/tasks.ts`) — a planner-guessed status list ("active, done, failed") silently excluded the `validating` task and the bare "found nothing" read as "no task exists". The empty branch now lists search-matched tasks outside the requested filters.
5. **Token-AND search at every layer** (`actions/tasks.ts` + both store backends in `orchestrator-task-store.ts`) — whole-phrase matching missed planner word order ("nubs website" vs "personal website for nubs"); the store-level `LIKE %phrase%` pre-filtered the task out before any downstream matcher ran. Each whitespace token now matches independently, ANDed.

## Evidence

Live before/after on the test deployment (same room, history poisoned with 3 prior denials):
- Before: "so is my site done?? where can i see it" → duplicate spawn (zombied, no task record) / "that work thread got aborted … didn't complete" / "no task exists for \"nubs website\"" ×3.
- After: "give me the exact status of the nubs website build task from your task records" → exact record: title, `status: validating`, taskId, created timestamp, plus the correct "finished its work and is waiting for verification" explanation.
- Unit: duplicate-guard similarity/force-escape suite 5/5 (live pair pinned); orchestrator unit lane 1959 passed (2 pre-existing env failures reproduce on clean tree); plugin typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:0599cb16967f4a732e92f1a4a5f45e3f92cace7a -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - chat/orchestration behavior; before/after transcripts + task-store records in PR body

<!-- evidence-row:after-screenshots -->
- [ ] N/A - chat/orchestration behavior; before/after transcripts + task-store records in PR body

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - live Discord transcripts + task event timeline serve as walkthrough

<!-- evidence-row:backend-logs -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - task-store rows and event timeline cited in body

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces
