### PR TITLE
fix(orchestrator,agent): parked-unverifiable tasks re-engage or escalate, and escalation reaches connector-primary owners

### DIFF
--- a/packages/agent/src/services/escalation-channels.test.ts
+++ b/packages/agent/src/services/escalation-channels.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit-tests resolveDeliverableChannels: explicit operator channel order wins
+ * untouched; an unconfigured order extends the client_chat default with
+ * owner-reachable channels from routing hints (most recent owner response
+ * first) and owner-contact entries. Pure function, no runtime.
+ */
+import { describe, expect, test } from "vitest";
+import type { OwnerContactRoutingHint } from "../config/owner-contacts.ts";
+import { resolveDeliverableChannels } from "./escalation.ts";
+
+const hint = (
+  lastResponseAt: string | null,
+): OwnerContactRoutingHint =>
+  ({
+    source: "x",
+    entityId: null,
+    channelId: null,
+    roomId: null,
+    lastResponseAt,
+    lastResponseChannel: null,
+    resolvedFrom: "recency",
+  }) as unknown as OwnerContactRoutingHint;
+
+describe("resolveDeliverableChannels", () => {
+  test("explicit operator order wins untouched", () => {
+    const channels = resolveDeliverableChannels(
+      { channels: ["telegram"] },
+      { discord: {} },
+      { discord: hint("2026-08-16T10:00:00Z") },
+    );
+    expect(channels).toEqual(["telegram"]);
+  });
+
+  test("unconfigured order extends client_chat with hinted channels, most recent first", () => {
+    const channels = resolveDeliverableChannels(
+      {},
+      {},
+      {
+        telegram: hint("2026-08-01T00:00:00Z"),
+        discord: hint("2026-08-16T10:00:00Z"),
+      },
+    );
+    expect(channels[0]).toBe("client_chat");
+    expect(channels.slice(1)).toEqual(["discord", "telegram"]);
+  });
+
+  test("owner-contact channels append after hinted ones without duplicates", () => {
+    const channels = resolveDeliverableChannels(
+      {},
+      { discord: {}, imessage: {} },
+      { discord: hint("2026-08-16T10:00:00Z") },
+    );
+    expect(channels).toEqual(["client_chat", "discord", "imessage"]);
+  });
+
+  test("no hints and no contacts keeps the bare default", () => {
+    expect(resolveDeliverableChannels({}, {}, {})).toEqual(["client_chat"]);
+  });
+});

--- a/packages/agent/src/services/escalation.ts
+++ b/packages/agent/src/services/escalation.ts
@@ -185,6 +185,44 @@ function resolveChannels(config: EscalationConfig): string[] {
     : DEFAULT_CHANNELS;
 }
 
+/**
+ * Channels the escalation can actually deliver on. An explicit operator order
+ * always wins. With no configured order the static default is `client_chat`
+ * alone — which ghosts a connector-primary owner: the dashboard send throws
+ * "no conversation available", every retry re-hits the same channel, and the
+ * owner never hears (observed live: a stalled-task escalation retried
+ * client_chat 3× while the owner sat in Discord). Extend the unconfigured
+ * default with every channel that resolves an owner contact or routing hint,
+ * most recent owner response first, so delivery can fall through to a
+ * connector that actually reaches the owner.
+ */
+export function resolveDeliverableChannels(
+  config: EscalationConfig,
+  ownerContacts: OwnerContactsConfig,
+  routingHints: Record<string, OwnerContactRoutingHint>,
+): string[] {
+  const configured = resolveChannels(config);
+  if (Array.isArray(config.channels) && config.channels.length > 0) {
+    return configured;
+  }
+  const known = new Set(configured);
+  const hinted = Object.entries(routingHints)
+    .filter(([channel, hint]) => !known.has(channel) && hint != null)
+    .sort(
+      (a, b) =>
+        (Date.parse(b[1]?.lastResponseAt ?? "") || 0) -
+        (Date.parse(a[1]?.lastResponseAt ?? "") || 0),
+    )
+    .map(([channel]) => channel);
+  for (const channel of hinted) {
+    known.add(channel);
+  }
+  const contactChannels = Object.keys(ownerContacts).filter(
+    (channel) => !known.has(channel),
+  );
+  return [...configured, ...hinted, ...contactChannels];
+}
+
 function resolveWaitMs(config: EscalationConfig): number {
   const mins =
     typeof config.waitMinutes === "number" && config.waitMinutes > 0
@@ -374,11 +412,15 @@ export class EscalationService {
     }
 
     const config = loadEscalationConfig();
-    const channels = resolveChannels(config);
     const ownerContacts = loadOwnerContacts();
     const routingHints = await loadOwnerContactRoutingHints(
       runtime,
       ownerContacts,
+    );
+    const channels = resolveDeliverableChannels(
+      config,
+      ownerContacts,
+      routingHints,
     );
     const ownerEntityId = await resolveOwnerEntityId(runtime);
     const waitMs = resolveWaitMs(config);
@@ -400,18 +442,23 @@ export class EscalationService {
 
     activeEscalations.set(escalationId, state);
 
-    const firstChannel = channels[0];
-    if (firstChannel) {
+    // Initial delivery falls through failed channels immediately: a channel
+    // whose send throws (dashboard with no conversation, missing handler) is
+    // not a delivery, and waiting a full retry interval to try the next one
+    // just delays the owner hearing about an already-urgent condition.
+    for (const [index, channel] of channels.entries()) {
       const sent = await sendToChannel(
         runtime,
-        firstChannel,
+        channel,
         text,
         ownerContacts,
         routingHints,
         ownerEntityId,
       );
       if (sent) {
-        state.channelsSent.push(firstChannel);
+        state.channelsSent.push(channel);
+        state.currentStep = index;
+        break;
       }
     }
 
@@ -437,11 +484,15 @@ export class EscalationService {
     if (!state || state.resolved) return;
 
     const config = loadEscalationConfig();
-    const channels = resolveChannels(config);
     const ownerContacts = loadOwnerContacts();
     const routingHints = await loadOwnerContactRoutingHints(
       runtime,
       ownerContacts,
+    );
+    const channels = resolveDeliverableChannels(
+      config,
+      ownerContacts,
+      routingHints,
     );
     const ownerEntityId = await resolveOwnerEntityId(runtime);
     const maxRetries = resolveMaxRetries(config);

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -4011,22 +4011,33 @@ export class OrchestratorTaskService extends Service {
       );
       if (independent) {
         if (independent.inconclusive) {
-          // A verifier crash/empty verdict is never a pass — keep validating.
-          await this.store.addEvent({
-            id: randomUUID(),
+          // A verifier crash/empty verdict is never a pass — but a silent
+          // return here parked the task in `validating` forever with no
+          // re-prompt, no escalation, and no signal to the task creator
+          // (observed live: a website-build task whose final task_complete hit
+          // "no usable CompletionEnvelope" and then sat `validating` for
+          // hours while the user asked "is it done?"). Route it through the
+          // shared re-engage/escalate path like every other non-pass verdict:
+          // under the attempts cap the worker is re-prompted to re-report
+          // with the structured envelope (making the next verify decidable);
+          // at the cap the task parks on waiting_on_user instead of ghosting.
+          await this.reEngageOrEscalate({
             taskId,
             sessionId,
+            correction: [
+              "Independent verification of your completion was inconclusive:",
+              `- ${independent.summary}`,
+              "Re-report your completion when the work is truly done. End your final message with the fenced ```json CompletionEnvelope exactly matching the required schema, and include concrete evidence (commands run, their real output, and where the deliverable lives).",
+            ].join("\n"),
             eventType: "independent_verify_inconclusive",
+            verifier: INDEPENDENT_ACP_VERIFIER_NAME,
             summary: independent.summary,
-            data: {
-              verifier: INDEPENDENT_ACP_VERIFIER_NAME,
-              unmet: independent.unmet,
-              failedCommands: independent.failedCommands,
-            },
-            timestamp: Date.now(),
-            createdAt: nowIso(),
+            missing: [
+              ...independent.unmet,
+              ...independent.failedCommands.map((c) => `command failed: ${c}`),
+            ],
+            attempt: attempts,
           });
-          this.emitChange(taskId);
           return;
         }
         if (!independent.passed) {


### PR DESCRIPTION
## What

A task whose completion cannot be auto-verified must reach the owner — today it can park silently forever. Two composing fixes:

1. **Inconclusive independent verify re-engages or escalates** (`plugin-agent-orchestrator/services/orchestrator-task-service.ts`) — the `independent.inconclusive` branch was the ONLY non-pass verdict that returned silently: no re-prompt, no escalation, no signal. Observed live: a website-build task whose final task_complete hit "no usable CompletionEnvelope" sat `validating` for hours while the user asked "is it done?" (the deliverable was live the whole time). It now routes through the shared `reEngageOrEscalate` path like every other verdict: under the attempts cap the worker is re-prompted to re-report with the structured envelope; at the cap the task parks on `waiting_on_user` instead of ghosting.
2. **Owner escalation falls through to channels that reach the owner** (`packages/agent/services/escalation.ts`) — with no configured escalation order the static default is `client_chat` alone; for a connector-primary owner the dashboard send throws "no conversation available", every retry re-hits the same channel, and the owner never hears (observed live: a stalled-task escalation retried client_chat 3× and gave up while the owner sat in Discord). The unconfigured default now extends with every channel that resolves an owner contact or routing hint (most recent owner response first), and initial delivery falls through failed channels immediately instead of waiting a full retry interval. An explicit operator order still wins untouched.

## Evidence

- Live: task 3e5916db timeline shows `independent_verify_inconclusive` as the final event with the task parked `validating` 1.5h+, and `[escalation] Failed to send to channel "client_chat" … no conversation available` ×2 with no fallthrough, in the same window.
- Unit: `resolveDeliverableChannels` suite 4/4 (explicit order wins; hinted channels most-recent-first; contact append; bare default preserved); orchestrator lane 1959 passed; both packages typecheck clean (one pre-existing unrelated cloud/shared resolution error on the box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:f50856691cdfb082aca55b063b9784ed3ef7b749 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - chat/orchestration behavior; before/after transcripts + task-store records in PR body

<!-- evidence-row:after-screenshots -->
- [ ] N/A - chat/orchestration behavior; before/after transcripts + task-store records in PR body

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - live Discord transcripts + task event timeline serve as walkthrough

<!-- evidence-row:backend-logs -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - task-store rows and event timeline cited in body

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces
