### PR TITLE
fix(core): task-status asks with parroted task-state denials promote to planning with TASKS seeded

### DIFF
--- a/packages/core/src/runtime/__tests__/message-handler-output.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-output.test.ts
@@ -12,7 +12,7 @@ import {
 	replyEffectStatusFieldEvaluator,
 	replyTextFieldEvaluator,
 } from "../builtin-field-evaluators";
-import { parseMessageHandlerOutput } from "../message-handler";
+import { parseMessageHandlerOutput, routeMessageHandlerOutput } from "../message-handler";
 import { ResponseHandlerFieldRegistry } from "../response-handler-field-registry";
 
 describe("message handler retrieval hint output", () => {
@@ -197,5 +197,52 @@ describe("message handler retrieval hint output", () => {
 			Object.keys(HANDLE_RESPONSE_SCHEMA.properties ?? {}),
 		);
 		expect(composedSchema.required).toEqual(HANDLE_RESPONSE_SCHEMA.required);
+	});
+});
+
+describe("task-status claim on the simple path promotes to planning", () => {
+	const makeOutput = (reply: string) =>
+		({
+			processMessage: "RESPOND",
+			thought: "",
+			plan: {
+				contexts: ["simple"],
+				reply,
+				simple: true,
+				requiresTool: false,
+			},
+		}) as never;
+
+	it("parroted 'no task exists' denial for a status ask routes to tasks planning with TASKS seeded", () => {
+		const output = makeOutput(
+			'no task exists for "nubs website". the app idea got stopped before anything shipped. nothing running now.',
+		);
+		const route = routeMessageHandlerOutput(output, {
+			messageText:
+				"whats the real status of the nubs website build task right now",
+		});
+		expect(route.type).toBe("planning_needed");
+		if (route.type === "planning_needed") {
+			expect(route.contexts).toEqual(["tasks"]);
+			expect(route.output.plan.candidateActions).toContain("TASKS");
+		}
+	});
+
+	it("a genuine simple answer to a status ask stays final", () => {
+		const output = makeOutput(
+			"the site shipped this morning — it lives at https://example.org/apps/nubs/",
+		);
+		const route = routeMessageHandlerOutput(output, {
+			messageText: "is the website build task done?",
+		});
+		expect(route.type).toBe("final_reply");
+	});
+
+	it("a task-state claim without a status ask stays final", () => {
+		const output = makeOutput("nothing running now, all quiet.");
+		const route = routeMessageHandlerOutput(output, {
+			messageText: "hows your day going",
+		});
+		expect(route.type).toBe("final_reply");
 	});
 });

--- a/packages/core/src/runtime/message-handler.ts
+++ b/packages/core/src/runtime/message-handler.ts
@@ -274,6 +274,20 @@ const CAPABILITY_DENIAL_REPLY_RE =
 const EXPLICIT_REMINDER_REQUEST_RE =
 	/\bremind me\b|\bset (?:a |an )?(?:reminder|alarm)\b/i;
 
+/** Explicit delegated-task status ask ("is the build task done?", "status of
+ * the website task", "did the build finish?") — answerable only from the
+ * durable task store, never from chat impressions. */
+const EXPLICIT_TASK_STATUS_REQUEST_RE =
+	/\b(?:status|progress)\s+(?:of|on)\b[^.!?]{0,60}\b(?:task|build|job|agent)\b|\b(?:task|build|job)\b[^.!?]{0,40}\b(?:done|finished|complete[d]?|status|still (?:running|going))\b|\b(?:is|did)\b[^.!?]{0,40}\b(?:task|build)\b[^.!?]{0,30}\b(?:finish(?:ed)?|done|complete[d]?)\b/i;
+
+/** Task-state claim/denial reply shape ("no task exists", "got stopped before
+ * shipping", "nothing running now"). Stage-1 asserting store state it never
+ * read is the history-poisoning shape again: the runtime's own denials become
+ * room history the next turn parrots verbatim (observed live ×3 on one room —
+ * "no task exists for …" repeated while the store held the task `validating`). */
+const TASK_STATE_CLAIM_REPLY_RE =
+	/\bno (?:such )?task\b|\btask (?:doesn'?t|does not) exist\b|\b(?:got|was|been) (?:stopped|aborted|cancelled)\b|\bnothing (?:is )?running\b|\bstill (?:running|working)\b|\bnot (?:finished|done|complete)\b/i;
+
 export function routeMessageHandlerOutput(
 	output: V5MessageHandlerOutput,
 	options?: {
@@ -330,6 +344,9 @@ export function routeMessageHandlerOutput(
 	const isExplicitReminderAsk = EXPLICIT_REMINDER_REQUEST_RE.test(
 		messageTextForRouting,
 	);
+	const isExplicitTaskStatusAsk = EXPLICIT_TASK_STATUS_REQUEST_RE.test(
+		messageTextForRouting,
+	);
 	const seedCandidate = (name: string): void => {
 		if (
 			(output.plan.candidateActions ?? []).some(
@@ -353,6 +370,9 @@ export function routeMessageHandlerOutput(
 			seedCandidate("OWNER_REMINDERS");
 			seedCandidate("TRIGGER");
 		}
+		// Task-status asks anchor the durable-store read so the planner answers
+		// from TASKS_HISTORY rows, not from room history.
+		if (isExplicitTaskStatusAsk) seedCandidate("TASKS");
 	};
 	const candidateActions = output.plan.candidateActions ?? [];
 	const hasCandidateActions = candidateActions.length > 0;
@@ -422,6 +442,20 @@ export function routeMessageHandlerOutput(
 				type: "planning_needed",
 				output,
 				contexts: isExplicitMediaAsk ? ["media"] : ["tasks"],
+			};
+		}
+		// A task-state claim on the simple path for an explicit task-status ask
+		// is the same poisoning shape with the task store as the ground truth:
+		// stage-1 asserts "no task exists"/"got stopped" from its own prior
+		// denials in room history without ever reading the store. Promote so
+		// the planner consults TASKS — a real absence then ships from the
+		// store's answer instead of from memory.
+		if (isExplicitTaskStatusAsk && TASK_STATE_CLAIM_REPLY_RE.test(reply)) {
+			seedMediaCandidate();
+			return {
+				type: "planning_needed",
+				output,
+				contexts: ["tasks"],
 			};
 		}
 		// A progress-shaped reply on the pure-simple path is a self-contradiction:


### PR DESCRIPTION
## What

Extends the anti-parrot promotion family (#20470) to delegated-task status asks. The runtime's own "no task exists for …" denials become room history that stage-1 then parrots verbatim on the simple path — observed live ×3 in one room while the durable store plainly held the task `validating`. An explicit task-status ask ("whats the real status of the X build task") whose simple reply asserts task state ("no task exists", "got stopped", "nothing running now") now promotes to planning against the `tasks` context with `TASKS` seeded — the store's answer ships instead of memory's.

Both gates must fire (ask-shape AND state-claim reply), so ordinary simple answers — including a genuine grounded status answer — stay final, covered by tests.

## Evidence

- Live before/after (same poisoned room): "is the nubs website build task done or not?" → simple-path parrot "no task exists … nothing running now" → post-fix the turn plans, calls TASKS_HISTORY, and answers with the exact store record (title, status=validating, taskId, created).
- message-handler-output suite 12/12 including three new tests (parroted denial promotes with TASKS seeded; genuine answer stays final; state-claim without a status ask stays final). Core typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:0654d54d3155fa7593141a26997a0615836b7eb7 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - chat/orchestration behavior; before/after transcripts + task-store records in PR body

<!-- evidence-row:after-screenshots -->
- [ ] N/A - chat/orchestration behavior; before/after transcripts + task-store records in PR body

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - live Discord transcripts + task event timeline serve as walkthrough

<!-- evidence-row:backend-logs -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:llm-trajectory -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - task-store rows and event timeline cited in body

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces
