### PR TITLE
fix(core): memory-recall correctness — noun-modified budget heuristic and facts-pool widening on keyword miss

### DIFF
--- a/packages/core/src/features/advanced-capabilities/providers/facts.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.ts
@@ -20,6 +20,7 @@
  * and the responding model decides which surfaced preferences apply.
  */
 import { ElizaError } from "../../../errors.ts";
+import { ModelType } from "../../../types/model.ts";
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import { getRelatedEntityIds } from "../../../identity-clusters.ts";
 import type {
@@ -397,9 +398,67 @@ const factsProvider: Provider = {
 			const entityFacts = entityFactPools.flat();
 
 			const minimizePrivateFacts = shouldMinimizePrivateFactsForTurn(message);
-			const dedupedPool = dedupeById([...roomFacts, ...entityFacts]).filter(
+			let dedupedPool = dedupeById([...roomFacts, ...entityFacts]).filter(
 				(memory) => !minimizePrivateFacts || !isMarkedPrivateFact(memory),
 			);
+			// Bounded-pool blindness guard: both pools are RECENCY-fetched, so a
+			// fact older than the last CANDIDATE_POOL_PER_SEARCH extractions per
+			// scope is invisible to ranking no matter how directly the user asks
+			// for it (observed live: "whats my keyboard budget" fabricated an
+			// answer while the extracted "$150 max" fact sat in the store, pushed
+			// out of the recent pool by heavy room traffic). When keyword scoring
+			// finds NOTHING relevant in the recency pools, widen once with an
+			// embedding search over the same room/entity scopes and merge the
+			// hits — ranking stays local and keyword-based over the widened pool.
+			// Gated to genuine misses so ordinary turns pay no embedding cost;
+			// any failure degrades to the recency pools.
+			const poolHasKeywordHit = scoreFactKeywordRelevance(
+				queryText,
+				dedupedPool,
+			).some((entry) => entry.relevance > 0);
+			if (!poolHasKeywordHit) {
+				try {
+					const embedding = await runtime.useModel(ModelType.TEXT_EMBEDDING, {
+						text: queryText,
+					});
+					if (Array.isArray(embedding) && embedding.length > 0) {
+						const [searchedRoom, ...searchedEntities] = await Promise.all([
+							runtime.searchMemories({
+								embedding,
+								tableName: "facts",
+								roomId: message.roomId,
+								worldId: message.worldId,
+								count: 12,
+								unique: false,
+							}),
+							...relatedEntityIds.map((entityId) =>
+								runtime.searchMemories({
+									embedding,
+									tableName: "facts",
+									entityId,
+									count: 12,
+									unique: false,
+								}),
+							),
+						]);
+						dedupedPool = dedupeById([
+							...dedupedPool,
+							...searchedRoom,
+							...searchedEntities.flat(),
+						]).filter(
+							(memory) =>
+								!minimizePrivateFacts || !isMarkedPrivateFact(memory),
+						);
+					}
+				} catch (error) {
+					// error-policy:J4 the widened pool is an optional recall upgrade;
+					// an unavailable embedding model or search degrades to the
+					// recency pools while staying observable.
+					runtime.reportError?.("FactsProvider.poolWiden", error, {
+						roomId: message.roomId,
+					});
+				}
+			}
 			const { durable: durableCandidates, current: currentCandidates } =
 				partitionByKind(dedupedPool);
 

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -1735,3 +1735,28 @@ describe("resolveExplicitContinuationRequestText", () => {
 		).toBe(null);
 	});
 });
+
+describe("noun-modified budget stays a conversational fact, not a finance read", () => {
+	const finances = { name: "OWNER_FINANCES", similes: [], tags: [] };
+
+	it("'whats my keyboard budget' produces no owner-finance candidate (live group denial)", () => {
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[finances],
+				"whats my keyboard budget",
+			),
+		).toEqual({ names: [], kind: null });
+	});
+
+	it("bare and finance-adjective budgets still route to the finances reader", () => {
+		for (const text of [
+			"what is my budget?",
+			"whats my monthly budget",
+			"show me my spending budget",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateInference([finances], text),
+			).toEqual({ names: ["OWNER_FINANCES"], kind: "owner-reads" });
+		}
+	});
+});

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -883,7 +883,26 @@ function ownerLifeReadDomainsInPossessiveScopes(
 			"finances",
 		);
 		for (const [domain, noun] of OWNER_READ_DOMAIN_NOUNS) {
-			if (noun.test(domainScope)) domains.add(domain);
+			if (!noun.test(domainScope)) continue;
+			// A noun-modified "budget" ("my keyboard budget", "my trip budget")
+			// names a conversational figure the user told the agent, not the
+			// owner finance ledger. Treating it as a finance read injected
+			// OWNER_FINANCES on a group turn, its privacy rejection made the
+			// whole turn a "private surface" denial, and a plain memory
+			// question died (observed live: "whats my keyboard budget" →
+			// denial while the $150 fact sat in room facts). Only an
+			// unmodified budget mention — bare or with a finance-ish adjective
+			// ("monthly", "overall") — counts as the finances domain.
+			if (
+				domain === "finances" &&
+				/\b(?!(?:monthly|weekly|annual|yearly|overall|total|current|entire|whole|full|remaining)\b)[a-z][a-z-]*\s+budget\b/iu.test(
+					domainScope,
+				) &&
+				!/\b(?:finances|spending|expenses)\b/iu.test(domainScope)
+			) {
+				continue;
+			}
+			domains.add(domain);
 		}
 	}
 	return domains;


### PR DESCRIPTION
## What

Two composing fixes for a live memory-recall failure chain: "whats my keyboard budget" (a fact the user stated in the same room hours earlier, extracted as "keyboard budget is $150 max") first died as a "that's a private surface" denial, then — with the denial fixed — fabricated "$200", then "17", because the fact never reached context.

1. **Noun-modified budget stays a conversational fact** (`services/message/direct-action-heuristics.ts`) — the possessive owner-read heuristic treated ANY "my … budget" as the owner-finance-ledger domain, injected OWNER_FINANCES, and its privacy rejection on the group surface converted a plain memory question into the private-surface denial. "my keyboard budget" / "my trip budget" name a conversational figure, not the ledger; only a bare or finance-adjective budget ("my budget", "my monthly budget", "my spending budget") still routes to the finances reader. Covered by tests both ways.
2. **Facts provider widens the recency pool on keyword miss** (`features/advanced-capabilities/providers/facts.ts`) — both candidate pools are RECENCY-fetched (120 per scope), so a fact older than the last ~120 extractions per scope is invisible to ranking no matter how directly the user asks (heavy room traffic churned the budget fact out; stage-1 had zero grounding and fabricated a number). When keyword scoring finds NOTHING relevant in the recency pools, the provider widens once with an embedding search over the same room/entity scopes and merges the hits — ranking stays local and keyword-based, ordinary turns pay no embedding cost, and any failure degrades to the recency pools (reportError-observable).

## Evidence

- Live before/after, same Discord group room: "whats my keyboard budget" → "that's a private surface — ask me in a DM" → (heuristic fix) → "from my records your keyboard budget is 17" with zero budget content in the composed context → (pool widen) → "the last thing on file is \"$150 max\"" — correct recall of a 2.5h-old fact through a room with hundreds of newer facts.
- Fresh-fact control: "my favorite switch type is holy pandas" → immediate recall "holy pandas." both before and after (recency path untouched).
- direct-action-heuristics 84/84 (2 new tests); advanced-capabilities 535/535; core typecheck + node build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:bd22bd0b8a4b0cf1a68fe3ec93a35b6a0b75eb23 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - chat-behavior change; before/after transcripts in PR body

<!-- evidence-row:after-screenshots -->
- [ ] N/A - chat-behavior change; before/after transcripts in PR body

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - live Discord transcripts serve as walkthrough

<!-- evidence-row:backend-logs -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:llm-trajectory -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - facts-store recall proven live; transcripts in body

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces
