### PR TITLE
feat(shell): pill voice follow-ups — instant release, STT warmup retry, global PTT hotkey, full state language (#20483)

### DIFF
--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -98,6 +98,7 @@ import {
   dispatchAppEvent,
   dispatchConnectRequest,
   MOBILE_RUNTIME_MODE_CHANGED_EVENT,
+  PUSH_TO_TALK_TOGGLE_EVENT,
   SHARE_TARGET_EVENT,
   TRAY_ACTION_EVENT,
 } from "@elizaos/ui/events";
@@ -2432,6 +2433,28 @@ async function initializeDesktopShell(): Promise<void> {
     }
   }
 
+  // Global push-to-talk toggle (#20483). Electrobun's GlobalShortcut is
+  // trigger-only (no key-up), so the OS-wide voice hotkey is press-to-start /
+  // press-again-to-send rather than a held quasimode — the pill's own
+  // press-and-hold remains the true hold gesture. Best-effort: a rejected
+  // accelerator (another app owns it) logs and moves on; voice stays reachable
+  // via the pill.
+  const pushToTalkRegistration = await invokeDesktopBridgeRequest<{
+    success: boolean;
+  }>({
+    rpcMethod: "desktopRegisterShortcut",
+    ipcChannel: "desktop:registerShortcut",
+    params: {
+      id: "push-to-talk",
+      accelerator: "CommandOrControl+Shift+Space",
+    },
+  });
+  if (pushToTalkRegistration?.success !== true) {
+    console.warn(
+      "[desktop-shell] Operating system rejected the push-to-talk shortcut; the pill hold gesture remains available",
+    );
+  }
+
   // Toggle semantics (#12184): a focused + visible overlay is dismissed
   // (focus returns to the previously active app via the macOS orderOut path);
   // otherwise summon + focus it. Blur does NOT hide the pill — it is a resting
@@ -2478,6 +2501,8 @@ async function initializeDesktopShell(): Promise<void> {
         dispatchAppEvent(COMMAND_PALETTE_EVENT);
       } else if (id === "chat-overlay") {
         void summonChatOverlay();
+      } else if (id === "push-to-talk") {
+        dispatchAppEvent(PUSH_TO_TALK_TOGGLE_EVENT);
       }
     },
   });

--- a/packages/shared/src/events/index.ts
+++ b/packages/shared/src/events/index.ts
@@ -10,6 +10,11 @@ import type { UiLanguage } from "../i18n/language.js";
 
 // ── App lifecycle ────────────────────────────────────────────────────────
 export const COMMAND_PALETTE_EVENT = "eliza:command-palette" as const;
+/** Global push-to-talk hotkey toggle (#20483): first press starts pill
+ *  listening, second press stops and sends. Trigger-only OS shortcuts cannot
+ *  report key-up, so the hotkey path is press-to-start/press-to-send rather
+ *  than hold-to-talk. */
+export const PUSH_TO_TALK_TOGGLE_EVENT = "eliza:push-to-talk-toggle" as const;
 export const EMOTE_PICKER_EVENT = "eliza:emote-picker" as const;
 export const STOP_EMOTE_EVENT = "eliza:stop-emote" as const;
 
@@ -293,6 +298,7 @@ export interface ChatAvatarVoiceEventDetail {
 
 export type ElizaDocumentEventName =
   | typeof COMMAND_PALETTE_EVENT
+  | typeof PUSH_TO_TALK_TOGGLE_EVENT
   | typeof EMOTE_PICKER_EVENT
   | typeof STOP_EMOTE_EVENT
   | typeof AGENT_READY_EVENT

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -135,6 +135,7 @@ import {
   type FocusConnectorEventDetail,
   listenForConnectRequests,
   NAVIGATE_VIEW_EVENT,
+  PUSH_TO_TALK_TOGGLE_EVENT,
 } from "./events";
 import { adoptRemoteAgentFirstRun } from "./first-run/adopt-remote-first-run";
 import { persistMobileRuntimeModeForServerTarget } from "./first-run/mobile-runtime-mode";
@@ -1810,6 +1811,31 @@ function ShellFoundationMount() {
     });
     return () => controller.setDictationSink(null);
   }, [controller, setChatInput, chatInputRef]);
+
+  // Global push-to-talk hotkey (#20483): the OS shortcut is trigger-only (no
+  // key-up event reaches the renderer), so the hotkey drives the SAME ptt
+  // capture as the pill's hold, in toggle form — first press opens the mic
+  // (ping + red chip on the pill), second press stops and sends (tick). No
+  // window is summoned and no focus is taken; the pill alone shows the state.
+  const controllerRef = useRef(controller);
+  controllerRef.current = controller;
+  useEffect(() => {
+    if (typeof document === "undefined") return undefined;
+    const onToggle = () => {
+      const shell = controllerRef.current;
+      if (!shell) return;
+      if (shell.recording) {
+        playCaptureSendCue();
+        shell.stopRecording();
+        return;
+      }
+      playCaptureStartCue();
+      shell.startRecording("ptt");
+    };
+    document.addEventListener(PUSH_TO_TALK_TOGGLE_EVENT, onToggle);
+    return () =>
+      document.removeEventListener(PUSH_TO_TALK_TOGGLE_EVENT, onToggle);
+  }, []);
 
   useEffect(() => {
     if (!hasController) return undefined;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1861,6 +1861,7 @@ function ShellFoundationMount() {
     <>
       <HomePill
         phase={controller.phase}
+        speaking={controller.speaking}
         onOpen={controller.open}
         onClose={controller.close}
         onHoldStart={() => {

--- a/packages/ui/src/components/shell/HomePill.stories.tsx
+++ b/packages/ui/src/components/shell/HomePill.stories.tsx
@@ -34,4 +34,8 @@ export const Idle: Story = {
 export const Booting: Story = { args: { phase: "booting" } };
 export const Summoned: Story = { args: { phase: "summoned" } };
 export const Listening: Story = { args: { phase: "listening" } };
+export const Processing: Story = { args: { phase: "processing" } };
 export const Responding: Story = { args: { phase: "responding" } };
+export const Speaking: Story = {
+  args: { phase: "responding", speaking: true },
+};

--- a/packages/ui/src/components/shell/HomePill.tsx
+++ b/packages/ui/src/components/shell/HomePill.tsx
@@ -31,6 +31,9 @@ export interface HomePillProps {
   onHoldEnd?: () => void;
   /** Abandon hold-to-talk without sending (Esc mid-hold, slide-off). */
   onHoldCancel?: () => void;
+  /** True while the assistant reply is being spoken aloud. Sharpens the
+   *  responding glow so "speaking" and "thinking" read differently. */
+  speaking?: boolean;
 }
 
 /** How long the pointer must stay down before a press becomes a hold. Above
@@ -58,6 +61,14 @@ const WAVE_BARS = [
   { id: "r4", delayMs: 420 },
 ] as const;
 
+/** Processing-state dots: the mic closed but transcription is in flight —
+ *  three dots breathing left-to-right, the universal "working on it". */
+const PROCESS_DOTS = [
+  { id: "d0", delayMs: 0 },
+  { id: "d1", delayMs: 160 },
+  { id: "d2", delayMs: 320 },
+] as const;
+
 /**
  * Persistent Flow-style handle at the bottom-center of the viewport.
  *
@@ -67,11 +78,16 @@ const WAVE_BARS = [
  * user's way until it is invoked.
  *
  * Each shell phase reads distinctly at a glance (the capsule is the only
- * always-visible surface, so it carries all ambient status): booting dims and
- * pulses, idle is a solid white capsule, listening turns the capsule red with
- * animated white waveform bars (the mic-live convention), and responding
- * breathes a warm accent glow. Reduced-motion users get the static color/glow
- * treatments without the animations.
+ * always-visible surface, so it carries all ambient status):
+ *   booting     — dim pulsing handle ("waking up").
+ *   idle        — solid white handle ("here, ready").
+ *   listening   — dark chip, red hot-mic ring, live waveform bars.
+ *   processing  — dark chip, pulsing dots, no red ring — mic closed,
+ *                 transcription in flight ("heard you, working on it").
+ *   responding  — warm accent glow; `speaking` sharpens it while the reply
+ *                 is audibly playing (thinking vs speaking read differently).
+ * Reduced-motion users get the static color/glow treatments without the
+ * animations.
  */
 export function HomePill({
   phase,
@@ -80,6 +96,7 @@ export function HomePill({
   onHoldStart,
   onHoldEnd,
   onHoldCancel,
+  speaking = false,
 }: HomePillProps): React.JSX.Element {
   const { appName } = useBranding();
   // The pill reads as "open" (its click will close) only for the overlay
@@ -188,18 +205,25 @@ export function HomePill({
     else onOpen();
   }, [isOpen, onOpen, onClose]);
 
+  const chipExpanded = phase === "listening" || phase === "processing";
+  const label =
+    phase === "listening"
+      ? `${appName} is listening — release to send`
+      : phase === "processing"
+        ? `${appName} is transcribing your words`
+        : speaking
+          ? `${appName} is speaking`
+          : isOpen
+            ? `Close ${appName}`
+            : `Open ${appName}`;
+
   return (
     <Button
       variant="ghost"
-      aria-label={
-        phase === "listening"
-          ? `${appName} is listening — release to send`
-          : isOpen
-            ? `Close ${appName}`
-            : `Open ${appName}`
-      }
+      aria-label={label}
       aria-pressed={isOpen}
       data-phase={phase}
+      data-speaking={speaking || undefined}
       data-testid="shell-home-pill"
       onClick={handleClick}
       onPointerDown={handlePointerDown}
@@ -218,21 +242,30 @@ export function HomePill({
         className={cn(
           "flex items-center justify-center rounded-full",
           "transition-[width,height,opacity,transform,background-color,box-shadow] duration-200",
-          // Listening mirrors the studied Wispr Flow bar: the capsule GROWS
-          // into a dark rounded chip holding live white bars — big enough that
-          // the mic-live state is legible from across the room — with a red
-          // ring keeping "hot mic" unambiguous. Other phases stay the slim
-          // white handle.
-          phase === "listening"
-            ? "h-7 w-20 gap-[3px] bg-neutral-900/95 shadow-[0_0_0_1.5px_rgba(239,68,68,0.9),0_4px_16px_rgba(0,0,0,0.35)]"
+          // Listening/processing mirror the studied Wispr Flow bar: the capsule
+          // GROWS into a dark rounded chip — legible from across the room.
+          // Listening carries live bars + a red hot-mic ring; processing keeps
+          // the dark chip (continuity: "still your utterance") but swaps the
+          // bars for pulsing dots and drops the red ring — the mic is CLOSED.
+          // Other phases stay the slim white handle.
+          chipExpanded
+            ? "h-7 w-20 gap-[3px] bg-neutral-900/95"
             : "h-2.5 w-12 gap-[3px] bg-white/95 group-hover:w-14",
-          phase !== "listening" &&
+          phase === "listening" &&
+            "shadow-[0_0_0_1.5px_rgba(239,68,68,0.9),0_4px_16px_rgba(0,0,0,0.35)]",
+          phase === "processing" && "shadow-[0_4px_16px_rgba(0,0,0,0.35)]",
+          !chipExpanded &&
             (phase === "responding"
-              ? "shadow-[0_0_10px_rgba(255,138,42,0.6),0_0_0_1px_rgba(0,0,0,0.12)]"
+              ? speaking
+                ? // Speaking: stronger, tighter warm glow than thinking — the
+                  // reply is audibly playing right now.
+                  "shadow-[0_0_14px_rgba(255,138,42,0.85),0_0_0_1px_rgba(255,138,42,0.5)]"
+                : "shadow-[0_0_10px_rgba(255,138,42,0.6),0_0_0_1px_rgba(0,0,0,0.12)]"
               : "shadow-[0_0_0_1px_rgba(0,0,0,0.12)]"),
           phase === "booting" &&
             "animate-pulse opacity-65 motion-reduce:animate-none",
           phase === "responding" &&
+            !speaking &&
             "animate-pulse opacity-90 motion-reduce:animate-none",
         )}
       >
@@ -243,6 +276,15 @@ export function HomePill({
               data-testid="shell-home-pill-wave-bar"
               className="home-pill-wave-bar h-[6px] w-[3px] rounded-full bg-white/95 motion-reduce:animate-none"
               style={{ animationDelay: `${bar.delayMs}ms` }}
+            />
+          ))}
+        {phase === "processing" &&
+          PROCESS_DOTS.map((dot) => (
+            <span
+              key={dot.id}
+              data-testid="shell-home-pill-process-dot"
+              className="home-pill-process-dot h-[5px] w-[5px] rounded-full bg-white/90 motion-reduce:animate-none"
+              style={{ animationDelay: `${dot.delayMs}ms` }}
             />
           ))}
       </span>

--- a/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
@@ -57,6 +57,7 @@ describe("HomePill", () => {
     "idle",
     "summoned",
     "listening",
+    "processing",
     "responding",
   ])("renders a data-phase attribute for phase=%s", (phase) => {
     render(<HomePill phase={phase} onOpen={() => {}} onClose={() => {}} />);
@@ -131,6 +132,25 @@ describe("HomePill", () => {
     }
   });
 
+  it("keeps the dark chip with pulsing dots (no red ring) while processing", () => {
+    render(
+      <HomePill phase="processing" onOpen={() => {}} onClose={() => {}} />,
+    );
+    const mark = screen.getByTestId("shell-home-pill-mark");
+    expect(mark.className).toContain("bg-neutral-900/95");
+    expect(mark.className).not.toContain("239,68,68");
+    const dots = screen.getAllByTestId("shell-home-pill-process-dot");
+    expect(dots).toHaveLength(3);
+    for (const dot of dots) {
+      expect(dot.className).toContain("home-pill-process-dot");
+      expect(dot.className).toContain("motion-reduce:animate-none");
+    }
+    expect(screen.queryAllByTestId("shell-home-pill-wave-bar")).toHaveLength(0);
+    expect(
+      screen.getByRole("button", { name: /transcribing your words/i }),
+    ).toBeTruthy();
+  });
+
   it("breathes a warm accent glow while responding", () => {
     render(
       <HomePill phase="responding" onOpen={() => {}} onClose={() => {}} />,
@@ -139,6 +159,22 @@ describe("HomePill", () => {
     expect(mark.className).toContain("255,138,42");
     expect(mark.className).toContain("animate-pulse");
     expect(mark.className).toContain("motion-reduce:animate-none");
+  });
+
+  it("sharpens the glow and drops the pulse while speaking aloud", () => {
+    render(
+      <HomePill
+        phase="responding"
+        speaking
+        onOpen={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /is speaking/i });
+    expect(btn.getAttribute("data-speaking")).toBe("true");
+    const mark = screen.getByTestId("shell-home-pill-mark");
+    expect(mark.className).toContain("0.85");
+    expect(mark.className).not.toContain("animate-pulse");
   });
 
   it("stays available while booting and opens on click", () => {

--- a/packages/ui/src/components/shell/shell-controller-sync/snapshot.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/snapshot.ts
@@ -72,6 +72,7 @@ export function parseShellControllerSnapshot(
       phase === "idle" ||
       phase === "summoned" ||
       phase === "listening" ||
+      phase === "processing" ||
       phase === "responding"
     ) ||
     typeof value.responding !== "boolean" ||

--- a/packages/ui/src/components/shell/shell-state.ts
+++ b/packages/ui/src/components/shell/shell-state.ts
@@ -16,14 +16,20 @@ import type {
  *   booting    — startup not ready and popup closed; pill dim, no halo.
  *   idle       — ready, no overlay; pill solid.
  *   summoned   — overlay open, no active mic/response; faint halo.
- *   listening  — push-to-talk capture in flight; red pulse.
- *   responding — agent stream in flight; ambient glow.
+ *   listening  — push-to-talk capture in flight; red chip + live bars.
+ *   processing — the mic is closed but the utterance is still being
+ *                transcribed (STT drain after a hold-to-talk release); dark
+ *                chip with pulsing dots — "I heard you, working on it"
+ *                (#20483). Distinct from responding: no agent turn exists yet.
+ *   responding — agent stream in flight; ambient glow (the pill further
+ *                differentiates speaking via its `speaking` prop).
  */
 export type ShellPhase =
   | "booting"
   | "idle"
   | "summoned"
   | "listening"
+  | "processing"
   | "responding";
 
 export interface ShellMessage {

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -773,6 +773,10 @@ export function useShellController(): ShellController {
   const modelStatus = useHomeModelStatus();
   const [isOpen, setIsOpen] = React.useState(false);
   const [recording, setRecording] = React.useState(false);
+  // Post-release STT drain (#20483): the mic is closed but the utterance is
+  // still transcribing. Drives the pill's "processing" phase so the gap
+  // between hold-release and the send/turn never reads as a silent idle.
+  const [sttPending, setSttPending] = React.useState(false);
   const [transcript, setTranscript] = React.useState("");
   const [analyser, setAnalyser] = React.useState<AnalyserNode | null>(null);
   // True when the most recent user turn was voice-originated (VOICE_DM). Gates
@@ -1053,14 +1057,16 @@ export function useShellController(): ShellController {
       // For the cloud backend `handle.stop()` includes the whole STT round trip
       // (seconds), and the pill's hold release must visibly end the hot-mic
       // state the instant the finger lifts — the mic hardware is already done
-      // capturing; only transcription remains. Opt-in only: the mode-handoff
-      // drains (hands-free → transcription) key their replacement-capture
-      // effects off `recording`, so flipping it early there would open the
-      // next recorder before this one finishes draining.
+      // capturing; only transcription remains. That remainder is surfaced as
+      // the `processing` phase via sttPending so the drain never reads as a
+      // silent idle. Opt-in only: the mode-handoff drains (hands-free →
+      // transcription) key their replacement-capture effects off `recording`,
+      // so flipping it early there would open the next recorder mid-drain.
       if (options?.immediateUiReset) {
         setAnalyser(null);
         setRecording(false);
         setTranscript("");
+        if (handle) setSttPending(true);
       }
       if (handle) {
         try {
@@ -1070,6 +1076,7 @@ export function useShellController(): ShellController {
              through onStateChange("error") */
         } finally {
           handle.dispose();
+          if (options?.immediateUiReset) setSttPending(false);
         }
       }
       setAnalyser(null);
@@ -1106,6 +1113,7 @@ export function useShellController(): ShellController {
     }
     setAnalyser(null);
     setRecording(false);
+    setSttPending(false);
     setTranscript("");
   }, []);
 
@@ -1761,13 +1769,15 @@ export function useShellController(): ShellController {
   const phase: ShellPhase =
     recording || realtimeVoiceListening
       ? "listening"
-      : responding
-        ? "responding"
-        : isOpen
-          ? "summoned"
-          : ready
-            ? "idle"
-            : "booting";
+      : sttPending
+        ? "processing"
+        : responding
+          ? "responding"
+          : isOpen
+            ? "summoned"
+            : ready
+              ? "idle"
+              : "booting";
 
   // Boot-progress token for the slow-boot escalation (#14040 sub-defect 3). It
   // advances whenever the readiness poll observes fresh progress while still

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -360,6 +360,17 @@ function describeCaptureFailure(err: unknown): string {
   ) {
     return "No microphone was found. Connect a microphone to use voice.";
   }
+  // Post-capture transcription failure (cloud/local STT): the mic worked and
+  // the utterance was recorded, but the words could not be transcribed — the
+  // honest message is "didn't catch that", not a microphone accusation.
+  if (
+    haystack.includes("cloudstterror") ||
+    haystack.includes("cloud asr") ||
+    haystack.includes("transcri") ||
+    haystack.includes("no microphone audio was captured")
+  ) {
+    return "Didn't catch that — voice transcription failed. Try again.";
+  }
   return "Could not start the microphone. Check your microphone permissions and try again.";
 }
 
@@ -1028,32 +1039,52 @@ export function useShellController(): ShellController {
     [sendChatText],
   );
 
-  const stopCaptureAndDrain = React.useCallback(async () => {
-    const handle = captureRef.current;
-    captureRef.current = null;
-    // Mark this as a user-initiated stop so the clean-auto-stop carryover does
-    // NOT fire — a toggle-off / barge-in / typing-pause must discard a
-    // half-finished utterance rather than carry or commit it.
-    explicitStopRef.current = true;
-    turnCarryoverRef.current = "";
-    turnAggregatorRef.current?.reset();
-    if (handle) {
-      try {
-        await handle.stop();
-      } catch {
-        /* stop is best-effort from UI controls */
-      } finally {
-        handle.dispose();
+  const stopCaptureAndDrain = React.useCallback(
+    async (options?: { immediateUiReset?: boolean }) => {
+      const handle = captureRef.current;
+      captureRef.current = null;
+      // Mark this as a user-initiated stop so the clean-auto-stop carryover does
+      // NOT fire — a toggle-off / barge-in / typing-pause must discard a
+      // half-finished utterance rather than carry or commit it.
+      explicitStopRef.current = true;
+      turnCarryoverRef.current = "";
+      turnAggregatorRef.current?.reset();
+      // Push-to-talk release (#20483): drop the listening UI state IMMEDIATELY.
+      // For the cloud backend `handle.stop()` includes the whole STT round trip
+      // (seconds), and the pill's hold release must visibly end the hot-mic
+      // state the instant the finger lifts — the mic hardware is already done
+      // capturing; only transcription remains. Opt-in only: the mode-handoff
+      // drains (hands-free → transcription) key their replacement-capture
+      // effects off `recording`, so flipping it early there would open the
+      // next recorder before this one finishes draining.
+      if (options?.immediateUiReset) {
+        setAnalyser(null);
+        setRecording(false);
+        setTranscript("");
       }
-    }
-    setAnalyser(null);
-    setRecording(false);
-    setTranscript("");
-  }, []);
+      if (handle) {
+        try {
+          await handle.stop();
+        } catch {
+          /* stop is best-effort from UI controls; transcribe failures surface
+             through onStateChange("error") */
+        } finally {
+          handle.dispose();
+        }
+      }
+      setAnalyser(null);
+      setRecording(false);
+      setTranscript("");
+    },
+    [],
+  );
 
-  const stopCapture = React.useCallback(() => {
-    void stopCaptureAndDrain();
-  }, [stopCaptureAndDrain]);
+  const stopCapture = React.useCallback(
+    (options?: { immediateUiReset?: boolean }) => {
+      void stopCaptureAndDrain(options);
+    },
+    [stopCaptureAndDrain],
+  );
 
   // Hold-to-talk cancel (#20483): drop the capture WITHOUT the stop() drain, so
   // no STT round-trip runs and nothing is transcribed or sent. dispose() runs
@@ -1352,7 +1383,15 @@ export function useShellController(): ShellController {
             setTranscript(committed ? "" : aggregator.pending);
           }
         },
-        onStateChange: (state: VoiceCaptureState) => {
+        onStateChange: (state: VoiceCaptureState, error?: Error) => {
+          // A transcribe failure after a real utterance must be VISIBLE: the
+          // hold-to-talk contract is that a ghost hold costs nothing but a
+          // spoken turn never silently vanishes (#20483). Cloud STT throwing
+          // at stop() lands here as the error state; surface one actionable
+          // notice instead of letting the words evaporate.
+          if (state === "error" && error) {
+            setActionNotice(describeCaptureFailure(error), "error", 6000);
+          }
           if (state === "error" || state === "stopped" || state === "idle") {
             // Capture ended (clean stop, dispose, or error). Drop the handle and
             // analyser so the shell phase returns to idle/summoned and a later
@@ -1904,7 +1943,9 @@ export function useShellController(): ShellController {
       stopRealtimeVoice();
       return;
     }
-    stopCapture();
+    // Push-to-talk release: end the visible hot-mic state the instant the
+    // finger lifts — the STT drain continues in the background (#20483).
+    stopCapture({ immediateUiReset: true });
   }, [stopCapture, stopRealtimeVoice]);
 
   // A LIVE Talk session that dies past the client's reconnect budget (network

--- a/packages/ui/src/events/index.ts
+++ b/packages/ui/src/events/index.ts
@@ -46,6 +46,7 @@ export {
   type NavigateViewType,
   NETWORK_STATUS_CHANGE_EVENT,
   type NetworkStatusChangeDetail,
+  PUSH_TO_TALK_TOGGLE_EVENT,
   // Sidebar sync
   SELF_STATUS_SYNC_EVENT,
   SHARE_TARGET_EVENT,

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -408,6 +408,27 @@ body.pwa-standalone textarea {
   }
 }
 
+/*
+ * Processing-state dots: mic closed, transcription in flight. A soft
+ * opacity/scale breath sweeping left-to-right via per-dot animation-delay.
+ */
+.home-pill-process-dot {
+  animation: home-pill-process 1100ms ease-in-out infinite;
+}
+
+@keyframes home-pill-process {
+  0%,
+  100% {
+    opacity: 0.35;
+    transform: scale(0.8);
+  }
+
+  40% {
+    opacity: 1;
+    transform: scale(1.15);
+  }
+}
+
 /* ── Animation utilities ────────────────────────────────────────────── */
 
 .animate-in {

--- a/packages/ui/src/voice/local-asr-transcribe.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.ts
@@ -82,6 +82,24 @@ export class CloudSttError extends Error {
 const CLOUD_STT_STARTING_RETRY_LIMIT = 30;
 const CLOUD_STT_STARTING_RETRY_DELAY_MS = 1_000;
 
+/**
+ * Whether a Cloud STT failure is a self-healing warmup the client should wait
+ * out with the patient 1s×30 retry loop rather than the single transient
+ * retry. Two server shapes qualify: a dedicated runtime's `feature_starting`
+ * (deferred route registration) and the shared worker's warming 503
+ * (`service_unavailable` — "Authorization cache is warming; retry shortly",
+ * observed clearing within a few seconds). A single retry loses a real
+ * utterance to a warmup that would have succeeded moments later, which
+ * violates the hold-to-talk contract that a spoken turn must not silently
+ * vanish (#20483).
+ */
+function isCloudSttWarmup(err: CloudSttError): boolean {
+  return (
+    err.code === "feature_starting" ||
+    (err.status === 503 && err.code === "service_unavailable")
+  );
+}
+
 function readCloudSttErrorCode(body: string): string | undefined {
   try {
     const parsed = JSON.parse(body) as { code?: unknown; error?: unknown };
@@ -389,7 +407,7 @@ export async function transcribeCloudWav(
           cause: err,
         });
       }
-      if (err.code === "feature_starting") {
+      if (isCloudSttWarmup(err)) {
         if (startingRetries >= CLOUD_STT_STARTING_RETRY_LIMIT) throw err;
         startingRetries++;
         await waitForCloudSttStartup(callerSignal);

--- a/packages/ui/src/voice/voice-capture-factory.ts
+++ b/packages/ui/src/voice/voice-capture-factory.ts
@@ -275,7 +275,13 @@ export function createVoiceCapture(
     const next = await startLocalAsrRecorder({
       ...(localAsrAutoStop ? { autoStop: localAsrAutoStop } : {}),
       onAutoStop: () => {
-        void stop();
+        // stop() both reports a transcribe failure via setState("error", err)
+        // AND rethrows it for awaiting callers. This fire-and-forget auto-stop
+        // has no awaiting caller, so observe the rejection here — otherwise
+        // every failed transcribe on the silence path surfaces as an unhandled
+        // promise rejection on top of the already-delivered error state.
+        // error-policy:J5 the same rejection is delivered via onStateChange.
+        void stop().catch(() => {});
       },
     });
     recorder = next;


### PR DESCRIPTION
## What

Follow-ups to the merged hold-to-talk quasimode (#20502), all live-validated on the packaged cloud-only build with synthesized speech (`say` into the mic) per the validation ask on #20483. Three commits:

### 1. Release is instant; STT warmup is survivable; failures are visible

Live RCA of "it doesn't actually transcribe": the capture and POST were correct — the shared worker's STT route returns a warming 503 (`"Authorization cache is warming"`, code `service_unavailable`) for the first requests of a session, and the client's single transient retry gave up while a warmup that clears in seconds was still settling. Direct probes of the same route with the same WAV confirm it transcribes exactly once warm (`say "purple elephant seventeen"` → `{"transcript":"Purple Elephant 17."}` in 5–8s, 4/4 runs).

- Warming 503 now routes into the patient 1s×30 warmup loop (alongside `feature_starting`) instead of dying after one retry — a spoken turn must not silently vanish.
- **Release visibly stops recording immediately**: `stopCaptureAndDrain` used to reset the listening UI only after `handle.stop()`, which includes the whole cloud STT round trip — the pill stayed red for seconds after the finger lifted. Release now resets instantly (opt-in `immediateUiReset`, used by the ptt release path only; mode-handoff drains keep their ordered reset — pinned by the existing drain-sequencing test).
- Transcribe failures surfaced as **unhandled promise rejections** with no UI: now observed (error-policy J5) and routed to one actionable notice with honest copy ("Didn't catch that — voice transcription failed") instead of a microphone accusation.

### 2. Global push-to-talk hotkey

`Cmd/Ctrl+Shift+Space` drives the same ptt capture as the pill's hold, in **toggle** form: first press opens the mic (ping + red chip), second press stops and sends (tick). Toggle rather than hold because Electrobun's `GlobalShortcut` is trigger-only — no key-up event exists in its FFI — so the held quasimode on a global key stays with the native-monitor follow-up; the pill's press-and-hold remains the true hold gesture. Registration is best-effort (a rejected accelerator logs and moves on). No window summoned, no focus taken.

### 3. Full pill state language

The capsule now reads every stage of the voice loop distinctly:

```
booting     dim pulsing handle          "waking up"
idle        solid white handle          "here, ready"
listening   dark chip, red ring, bars   "mic is HOT"
processing  dark chip, pulsing dots     "heard you, transcribing"   ← NEW
responding  warm breathing glow         "thinking"
speaking    sharper steady glow         "reply playing aloud"       ← NEW
```

- New `ShellPhase` `"processing"`: driven by `sttPending` — set the instant a ptt release closes the mic, cleared when the STT drain settles or the hold cancels. Fills the gap where a multi-second cloud transcription previously read as silent idle. Dark-chip continuity ("still your utterance"), dots instead of bars, no red ring — the mic is closed.
- `speaking` prop on HomePill (from `controller.speaking`): sharpens the responding glow and stops the pulse while TTS is audibly playing, with distinct aria labels.
- Sync snapshot validator accepts the new phase; stories cover the full matrix (`Processing`, `Speaking` added).

## Verification

- `packages/ui`: 1534 shell+voice tests pass post-rebase; full suites for shell (1054), typecheck + Biome clean across ui/shared/app.
- Live packaged validation (macOS arm64, cloud-only build): pill hold → red chip with bars → `say` speaks a phrase → release → chip collapses instantly → warming 503s retried (previously fatal). One session completed the loop end-to-end with the spoken phrase transcribed and sent; server-side STT availability remains variable (503/429 under warmup/rate-limit — cloud-side, #20473 family) which is exactly what the new patient retry + visible-failure handling is for.

Advances #20483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
