### PR TITLE
fix(agent): bare finance verbs no longer hijack replies into the wallet-not-executed dump

### DIFF
--- a/packages/agent/src/api/server-helpers.ts
+++ b/packages/agent/src/api/server-helpers.ts
@@ -831,8 +831,16 @@ export function maybeAugmentChatMessageWithWalletContext(
 // Wallet intent detection & replies
 // ---------------------------------------------------------------------------
 
+// Bare finance verbs (swap/trade/transfer) are NOT wallet evidence on their
+// own: "add a todo: swap the canon filter" is a chore, yet the bare-verb match
+// made isWalletActionRequiredIntent claim the turn, and the api layer then
+// REPLACED a successful OWNER_TODOS_CREATE reply with the wallet-not-executed
+// dump — internal wallet/RPC state leaked into chat and the real confirmation
+// was destroyed (observed live). The verbs count only with a crypto/wallet
+// object nearby, exactly like the existing `send` arm; wallet NOUNS anywhere
+// in the prompt still qualify the turn on their own.
 const WALLET_CHAT_INTENT_RE =
-  /\b(wallet|onchain|on-chain|address|balance|swap|trade|transfer|token|bnb|t?bnb|eth|sol)\b|(?:\bsend\b(?=[\s\S]{0,40}\b(?:token|eth|sol|t?bnb|wallet|crypto|coin)\b))/i;
+  /\b(wallet|onchain|on-chain|address|balance|token|bnb|t?bnb|eth|sol)\b|(?:\b(?:send|swap|trade|transfer)\b(?=[\s\S]{0,40}\b(?:tokens?|eth|sol|t?bnb|wallet|crypto|coins?|usdc|usdt)\b))/i;
 
 export const WALLET_EXECUTION_INTENT_RE =
   /\b(swap|trade|transfer|buy|sell|execute|approve)\b|(?:\bsend\b(?=[\s\S]{0,40}\b(?:token|eth|sol|t?bnb|wallet|crypto|coin)\b))/i;

--- a/packages/agent/src/api/wallet-intent.test.ts
+++ b/packages/agent/src/api/wallet-intent.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Unit-tests the wallet chat-intent gate: bare finance verbs without a crypto
+ * object are not wallet intent (a todo about swapping a filter must never
+ * trigger the wallet-not-executed replacement), while genuine wallet asks
+ * still qualify. Pure regex logic, no runtime.
+ */
+import { describe, expect, test } from "vitest";
+import { isWalletActionRequiredIntent } from "./server-helpers.ts";
+
+describe("isWalletActionRequiredIntent", () => {
+  test("bare finance verbs in non-wallet chores do not qualify (live todo hijack)", () => {
+    for (const text of [
+      "add a todo: swap the canon filter, no deadline needed, just a general todo",
+      "remind me to transfer the laundry to the dryer",
+      "trade you my sandwich for your fries",
+    ]) {
+      expect(isWalletActionRequiredIntent(text)).toBe(false);
+    }
+  });
+
+  test("genuine wallet asks still qualify", () => {
+    for (const text of [
+      "swap 0.1 eth for usdc",
+      "whats my wallet balance",
+      "transfer 5 sol to my other wallet",
+      "send 100 tokens to alice",
+    ]) {
+      expect(isWalletActionRequiredIntent(text)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## What

The api layer's wallet-intent gate (`isWalletActionRequiredIntent` in `packages/agent/src/api/server-helpers.ts`) counted a bare finance verb as wallet evidence: "add a todo: **swap** the canon filter" matched, the turn had (correctly) run no wallet action, and chat-routes then **replaced the successful OWNER_TODOS_CREATE confirmation** with `buildWalletActionNotExecutedReply` — dumping internal wallet/RPC state ("Wallet network: mainnet. Detected wallets: EVM: not generated … RPC ready: no. Blocked reason: …") into chat while the real "got it. swap the canon filter added." was destroyed (observed live; the tool result in the trajectory was clean — only the wire reply was hijacked).

Fix: bare `swap`/`trade`/`transfer` only count as wallet chat intent with a crypto/wallet object within 40 chars — exactly the discipline the existing `send` arm already had. Wallet NOUNS (wallet, balance, eth, sol, token, …) anywhere in the prompt still qualify a turn on their own, so genuine asks ("swap 0.1 eth for usdc", "whats my wallet balance") are unchanged, covered by tests both ways.

## Evidence

- Before: "add a todo: swap the canon filter, no deadline needed" → wallet-not-executed dump as the entire reply (todo silently created underneath).
- After: "add a todo: swap the winter tires, no deadline" → "added swap the winter tires, no deadline."
- New `wallet-intent` unit suite 2/2 (three non-wallet chores must not qualify; four genuine wallet asks must); agent package build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:ac5ff451ac43b030290b8d16a5acdea3e979e2fd -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - chat-behavior change; before/after transcripts in PR body

<!-- evidence-row:after-screenshots -->
- [ ] N/A - chat-behavior change; before/after transcripts in PR body

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - live transcripts serve as walkthrough

<!-- evidence-row:backend-logs -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:llm-trajectory -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - todo rows verified via live read-backs

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces