### PR TITLE
fix(shared): converge the spoken-text sanitizer twins on each side's safe pass

### DIFF
--- a/packages/agent/src/services/escalation-channels.test.ts
+++ b/packages/agent/src/services/escalation-channels.test.ts
@@ -8,9 +8,7 @@ import { describe, expect, test } from "vitest";
 import type { OwnerContactRoutingHint } from "../config/owner-contacts.ts";
 import { resolveDeliverableChannels } from "./escalation.ts";
 
-const hint = (
-  lastResponseAt: string | null,
-): OwnerContactRoutingHint =>
+const hint = (lastResponseAt: string | null): OwnerContactRoutingHint =>
   ({
     source: "x",
     entityId: null,

--- a/packages/core/src/features/advanced-capabilities/providers/facts.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.ts
@@ -20,7 +20,6 @@
  * and the responding model decides which surfaced preferences apply.
  */
 import { ElizaError } from "../../../errors.ts";
-import { ModelType } from "../../../types/model.ts";
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import { getRelatedEntityIds } from "../../../identity-clusters.ts";
 import type {
@@ -32,6 +31,7 @@ import type {
 	ProviderResult,
 	State,
 } from "../../../types/index.ts";
+import { ModelType } from "../../../types/model.ts";
 import {
 	buildFactQueryText,
 	scoreFactKeywordRelevance,
@@ -446,8 +446,7 @@ const factsProvider: Provider = {
 							...searchedRoom,
 							...searchedEntities.flat(),
 						]).filter(
-							(memory) =>
-								!minimizePrivateFacts || !isMarkedPrivateFact(memory),
+							(memory) => !minimizePrivateFacts || !isMarkedPrivateFact(memory),
 						);
 					}
 				} catch (error) {

--- a/packages/core/src/runtime/__tests__/message-handler-output.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-output.test.ts
@@ -12,7 +12,10 @@ import {
 	replyEffectStatusFieldEvaluator,
 	replyTextFieldEvaluator,
 } from "../builtin-field-evaluators";
-import { parseMessageHandlerOutput, routeMessageHandlerOutput } from "../message-handler";
+import {
+	parseMessageHandlerOutput,
+	routeMessageHandlerOutput,
+} from "../message-handler";
 import { ResponseHandlerFieldRegistry } from "../response-handler-field-registry";
 
 describe("message handler retrieval hint output", () => {

--- a/packages/core/src/runtime/__tests__/message-handler.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler.test.ts
@@ -510,7 +510,8 @@ describe("explicit media-ask promotion", () => {
 		const parsed = parseMessageHandlerOutput(
 			JSON.stringify({
 				shouldRespond: "RESPOND",
-				replyText: "can't do that here. no video generation tools in this setup.",
+				replyText:
+					"can't do that here. no video generation tools in this setup.",
 				contexts: ["simple"],
 				candidateActionNames: [],
 			}),

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -8632,11 +8632,16 @@ export async function runV5MessageRuntimeStage1(args: {
 			getMessageHandlerCandidateActions(messageHandler) ?? []
 		).some((name) => {
 			const candidateName = String(name);
-			const direct = resolveRuntimeAction(stageOneCandidateLookup, candidateName);
+			const direct = resolveRuntimeAction(
+				stageOneCandidateLookup,
+				candidateName,
+			);
 			const resolvedSet = direct
 				? [direct]
 				: parentAliasesForCandidateAction(candidateName)
-						.map((alias) => resolveRuntimeAction(stageOneCandidateLookup, alias))
+						.map((alias) =>
+							resolveRuntimeAction(stageOneCandidateLookup, alias),
+						)
 						.filter((action): action is Action => action !== undefined);
 			return resolvedSet.some((resolved) =>
 				collectedCandidateNames.has(normalizeActionIdentifier(resolved.name)),
@@ -8652,9 +8657,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		const rejectedReminderish =
 			candidateGateDiagnostics.gateRejectedExplicitCandidates.some((name) => {
 				const normalized = normalizeActionIdentifier(name);
-				return (
-					normalized.includes("REMINDER") || normalized.includes("ALARM")
-				);
+				return normalized.includes("REMINDER") || normalized.includes("ALARM");
 			});
 		const ungatedTriggerSiblingAvailable =
 			rejectedReminderish && collectedCandidateNames.has("TRIGGER");

--- a/packages/core/src/spoken-text.test.ts
+++ b/packages/core/src/spoken-text.test.ts
@@ -46,4 +46,13 @@ describe("sanitizeSpeechText", () => {
 			);
 		},
 	);
+
+	// Twin-pin with packages/shared/src/spoken-text.test.ts (#20519): repeated
+	// punctuation collapses BEFORE the spacing rules separate the repeats, so
+	// identical model output speaks identically on both surfaces.
+	it("removes non-speech directions and cleans repeated punctuation", () => {
+		expect(
+			sanitizeSpeechText("*whispers* Wait!!! (pause) Are you sure??"),
+		).toBe("Wait! Are you sure?");
+	});
 });

--- a/packages/core/src/spoken-text.ts
+++ b/packages/core/src/spoken-text.ts
@@ -60,6 +60,10 @@ function sanitizeSpeechPunctuation(input: string): string {
 	text = text.replace(/[‘’]/g, "'");
 	text = text.replace(/[…]/g, "...");
 	text = text.replace(/[–—]/g, ", ");
+	// Collapse repeated punctuation BEFORE the spacing rules separate the
+	// repeats ("Wait!!!" must speak as "Wait!", not "Wait! ! !"). Twin of
+	// packages/shared/src/spoken-text.ts (#20519) — change both together.
+	text = text.replace(/([,.!?，。！？])\1+/g, "$1");
 	text = text.replace(/\s{0,32}([,;:，；：])\s{0,32}/g, "$1 ");
 	text = text.replace(/\s{0,32}([.!?。！？])\s{0,32}/g, "$1 ");
 	text = text.replace(/[^\p{L}\p{N}\s.,!?'"%/$:+，。！？；：-]/gu, " ");

--- a/packages/shared/src/spoken-text.test.ts
+++ b/packages/shared/src/spoken-text.test.ts
@@ -8,7 +8,50 @@ import { describe, expect, it } from "vitest";
 
 import { sanitizeSpeechText } from "./spoken-text";
 
+// Twin-pin: this table is byte-identical to the one in
+// packages/core/src/spoken-text.test.ts. The two sanitizers share one contract
+// ("hidden model markup must never reach spoken output"), so a fix landing on
+// one side only must fail the other side's suite (#20519).
+const hiddenBlockTags = [
+  "think",
+  "analysis",
+  "reasoning",
+  "tool_call",
+  "tool_calls",
+  "tool",
+  "tools",
+] as const;
+
 describe("sanitizeSpeechText", () => {
+  it.each(hiddenBlockTags)(
+    "removes a closed <%s> block and preserves following speech",
+    (tag) => {
+      expect(
+        sanitizeSpeechText(
+          `Visible. <${tag}>private payload</${tag}> Continue.`,
+        ),
+      ).toBe("Visible. Continue.");
+    },
+  );
+
+  it.each(hiddenBlockTags)(
+    "removes an unterminated <%s> block through end of input",
+    (tag) => {
+      expect(sanitizeSpeechText(`Visible. <${tag}>private payload`)).toBe(
+        "Visible.",
+      );
+    },
+  );
+
+  it.each(hiddenBlockTags)(
+    "removes a truncated <%s> opening tag through end of input (#20519)",
+    (tag) => {
+      expect(sanitizeSpeechText(`Visible. <${tag} private payload`)).toBe(
+        "Visible.",
+      );
+    },
+  );
+
   it("removes closed internal thinking and reasoning blocks", () => {
     expect(
       sanitizeSpeechText(

--- a/packages/shared/src/spoken-text.ts
+++ b/packages/shared/src/spoken-text.ts
@@ -14,11 +14,14 @@ function stripUrls(input: string): string {
 function stripThinkingAndMarkup(input: string): string {
   let text = input;
   text = text.replace(
-    /<(think|analysis|reasoning|tool_calls?|tools?)\b[^>]*>[\s\S]*?<\/\1>/gi,
+    /<(think|analysis|reasoning|tool_calls?|tools?)\b[^>]*>[\s\S]*?(?:<\/\1>|$)/gi,
     " ",
   );
+  // A stream can end inside the opening tag itself ("Visible. <think"); the
+  // bare tag word must not be spoken. Twin of packages/core/src/spoken-text.ts
+  // (#20519) — change both together.
   text = text.replace(
-    /<(think|analysis|reasoning|tool_calls?|tools?)\b[^>]*>[\s\S]*$/gi,
+    /<(?:think|analysis|reasoning|tool_calls?|tools?)\b[^>]*$/gi,
     " ",
   );
   text = text.replace(/```[\s\S]*?```/g, " ");

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -2752,9 +2752,7 @@ function taskMatchesSearch(task: TaskThreadDto, search: string): boolean {
   // reads as "no task exists" against a store that plainly holds it (observed
   // live). Every whitespace token present somewhere in the haystack matches.
   const tokens = needle.split(/\s+/).filter((token) => token.length > 0);
-  return (
-    tokens.length > 1 && tokens.every((token) => haystack.includes(token))
-  );
+  return tokens.length > 1 && tokens.every((token) => haystack.includes(token));
 }
 
 function sessionMatchesHistoryFilters(


### PR DESCRIPTION
Closes #20519.

## What breaks today

The spoken-text sanitizer twins share one contract — hidden model markup must never reach spoken output — but drifted after #20440: core's TTS-server path got a truncated-opener pass, so a stream cut mid-opening-tag (`"Visible. <think"`) strips cleanly there while the UI voice path (`packages/shared/src/spoken-text.ts`) speaks the bare tag word ("Visible. think"). Independently, the two collapse repeated punctuation on opposite sides of the spacing rules, so identical model output is spoken differently across surfaces ("Wait!!!" → "Wait!" in shared, "Wait! ! !" in core). Both verified against the issue's table before claiming.

## The fix — converge on each side's safe pass

Rather than declaring one file canon wholesale, each twin adopts the other's superior behavior:

- **shared** takes core's merged closed-or-unterminated alternation and the #20440 truncated-opener pass, closing the spoken-leak (issue acceptance criterion 1);
- **core** takes shared's collapse-before-spacing punctuation ordering, so repeated punctuation speaks once on every surface (criterion 2, resolved in the direction that produces better speech — "Wait!" everywhere, rather than porting core's "Wait! ! !" into shared).

Criterion 3 (cross-pinning): both suites now carry the byte-identical 7-tag × closed/unterminated/truncated-opener table plus the same punctuation case, each annotated as the other's twin — a future single-sided change fails the other side's suite loudly. Full extraction to one shared module is left as the documented follow-up: core cannot depend on @elizaos/shared (dependency direction), so extraction means a new home package and consumer migration — out of scope for a leak fix.

Also folds in the biome format repairs (line wraps only) the pinned `lint:check` gate requires on the current develop base — six files across core/agent/plugin-agent-orchestrator, none touched by the sanitizer change, each discovered by the root verify at this head. A process note on this repeating develop-red pattern is coming as a separate issue.

# Evidence

<!-- evidence-head:e47659309e81d738cac2696b03f360f88b7ef657 -->

<!-- evidence-row:before-screenshots -->
N/A - sanitizer string transformation; no rendered UI surface in the diff.

<!-- evidence-row:after-screenshots -->
N/A - sanitizer string transformation; no rendered UI surface in the diff.

<!-- evidence-row:walkthrough-video -->
N/A - non-UI change; behavior proven by the failing-before/passing-after twin suites below.

<!-- evidence-row:backend-logs -->
Both twin suites at this head:

```
packages/shared: bun run test src/spoken-text.test.ts
      Tests  26 passed (26)   [7 truncated-opener arms new]
packages/core:   bun run test src/spoken-text.test.ts
      Tests  22 passed (22)   [punctuation convergence case new]
Root bun run verify at this exact head: exit 0, ending with
[anti-larp] scanned 8330 test files — 0 focused, 0 orphaned skip(s)
```

<!-- evidence-row:frontend-logs -->
N/A - the UI voice path consumes the same exported function exercised directly by the shared suite; no network/console surface changes.

<!-- evidence-row:llm-trajectory -->
N/A - no model call in scope: sanitizeSpeechText is a pure text transformation between model output and TTS, exercised deterministically by both suites.

<!-- evidence-row:domain-artifacts -->
Failing-before, both directions (fix stashed per side, tests kept):

```
packages/shared without its sanitizer change — exactly the 7 new arms fail:
 × removes a truncated <think> opening tag through end of input (#20519)
 × removes a truncated <analysis> opening tag ... (+ tool_call, tool_calls, tool, tools, reasoning)
      Tests  7 failed | 19 passed (26)
packages/core without its punctuation change:
 × removes non-speech directions and cleans repeated punctuation
      Tests  1 failed | 21 passed (22)
```

<!-- evidence-row:ocr-review -->
N/A - no rendered visual surface in this change.

---
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [kenjohnscreates]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01M05A547HGHGCQZ9RX1S1Y0A2","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-16T12:53:41.233Z","completed_at":"2026-08-16T13:15:05.689Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ02FuP7I_LN-J_iadT_q0j0Rj0Yugo5SJvOjhR_hrfw","device_key_id":"15e4c3effe5c8a2b2c22617596afd1044544026dfb99605709a677bf57050d3b","device_signature":"cYMUCtMRTYUhCjElV-VMNIEwadrKbVOAqqawAmtxa0crL9RIBH0tl6Zv6Phf8jbhiogSn4b3099RwmutokWACw"}} -->
