### PR TITLE
fix(pa): list-verbiage review targets drop the filter instead of empty-matching real rows

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/life.review-definitions.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.review-definitions.test.ts
@@ -339,6 +339,19 @@ describe("LifeOps definition review isolation", () => {
     expect(missing.text).not.toContain("Call dentist");
   });
 
+  it("drops a list-verbiage target instead of empty-matching (live: planner stamped title 'list all')", async () => {
+    const result = await review({
+      ownerSurface: "OWNER_TODOS",
+      target: "list all",
+    });
+    expect(result.success).toBe(true);
+    expect(definitionTitles(result)).toEqual([
+      "File taxes",
+      "Project Alpha plan",
+      "Project Alpha review",
+    ]);
+  });
+
   it("grounds an empty tracked-work claim only from an observed empty review", async () => {
     serviceState.definitions = [];
 
@@ -384,3 +397,4 @@ describe("LifeOps definition review isolation", () => {
     });
   });
 });
+

--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -5980,7 +5980,18 @@ async function runLifeOperationHandlerInner(
           definitionReviewSurface(record) === surface,
       );
       let selected = active;
-      if (targetName) {
+      // A list-shaped review sometimes arrives with the planner's own list
+      // verbiage stamped into the target ("list all my todos" → title
+      // "list all"); treating that junk as a hard filter empty-matched and
+      // answered "couldn't find an item matching \"list all\"" against a
+      // store with real rows (observed live). List verbiage is never an item
+      // name — drop the filter and list normally.
+      const isListVerbiageTarget =
+        typeof targetName === "string" &&
+        /^(?:list|show|view|all|everything|(?:list|show|view)\s+all|all\s+of\s+them|(?:all\s+)?my\s+\w+|todos?|goals?|reminders?|routines?|alarms?|habits?)$/iu.test(
+          targetName.trim(),
+        );
+      if (targetName && !isListVerbiageTarget) {
         const resolved = resolveDefinitionInRecords(active, targetName);
         if (resolved.ambiguousCandidates.length > 0) {
           const fallback = `Multiple ${definitionReviewSurfaceLabel(surface)} match "${targetName}": ${resolved.ambiguousCandidates.join(", ")}. Which one did you mean?`;
@@ -5996,6 +6007,9 @@ async function runLifeOperationHandlerInner(
           };
         }
         if (!resolved.match) {
+          // A genuine miss stays a pure not-found: disclosing other items
+          // here is a deliberate no-leak contract (see
+          // life.review-definitions.test.ts isolation coverage).
           const fallback = `I couldn't find an active ${definitionReviewSurfaceLabel(surface)} item matching "${targetName}".`;
           return {
             success: false,


### PR DESCRIPTION
## What

A list-shaped owner review sometimes arrives with the planner's own list verbiage stamped into the target parameter ("list all my todos" → `title: "list all"`). The review op treated that junk as a hard item filter, empty-matched, and answered `I couldn't find an active todos item matching "list all"` against a store holding real rows (observed live on the canon battery). List verbiage is never an item name — the review now drops such targets (list/show/all/everything/"my <noun>"/domain plurals) and lists normally. A genuine typo'd lookup keeps the pure honest not-found, preserving the existing no-leak isolation contract (its test still passes untouched).

## Evidence

- Before: "list all my todos" → `I couldn't find an active todos item matching "list all".` (store held 2 todos).
- After, live: "list all my todos" → "2 todos: buy sandpaper, swap the canon filter".
- `life.review-definitions` suite 10/10 including the new live-shape test; the ambiguous/missing isolation contract unchanged; pa typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:46734d23c600a55f255645e7818d13c5074d626b -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - chat-behavior change; before/after transcripts in PR body

<!-- evidence-row:after-screenshots -->
- [ ] N/A - chat-behavior change; before/after transcripts in PR body

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - live transcripts serve as walkthrough

<!-- evidence-row:backend-logs -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:llm-trajectory -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - todo rows verified via live read-backs

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces
