### PR TITLE
fix(shared): reject invalid ASR timing bounds

### DIFF
--- a/packages/shared/src/transcripts.test.ts
+++ b/packages/shared/src/transcripts.test.ts
@@ -429,4 +429,21 @@ describe("validateAsrWordTimings", () => {
     const words: TranscriptWord[] = [{ text: "a", startMs: 0, endMs: 9_999 }];
     expect(validateAsrWordTimings(words).ok).toBe(true);
   });
+
+  it("rejects invalid duration and tolerance instead of disabling checks", () => {
+    const words: TranscriptWord[] = [{ text: "a", startMs: 0, endMs: 1200 }];
+
+    expect(() => validateAsrWordTimings(words, -1)).toThrow(
+      /audioDurationMs must be a non-negative finite number/,
+    );
+    expect(() => validateAsrWordTimings(words, Number.NaN)).toThrow(
+      /audioDurationMs must be a non-negative finite number/,
+    );
+    expect(() => validateAsrWordTimings(words, 1000, -1)).toThrow(
+      /toleranceMs must be a non-negative finite number/,
+    );
+    expect(() =>
+      validateAsrWordTimings(words, 1000, Number.POSITIVE_INFINITY),
+    ).toThrow(/toleranceMs must be a non-negative finite number/);
+  });
 });

--- a/packages/shared/src/transcripts.ts
+++ b/packages/shared/src/transcripts.ts
@@ -631,6 +631,17 @@ export function validateAsrWordTimings(
   audioDurationMs = 0,
   toleranceMs = 1,
 ): WordTimingValidation {
+  if (!Number.isFinite(audioDurationMs) || audioDurationMs < 0) {
+    throw new RangeError(
+      `validateAsrWordTimings: audioDurationMs must be a non-negative finite number, got ${String(audioDurationMs)}`,
+    );
+  }
+  if (!Number.isFinite(toleranceMs) || toleranceMs < 0) {
+    throw new RangeError(
+      `validateAsrWordTimings: toleranceMs must be a non-negative finite number, got ${String(toleranceMs)}`,
+    );
+  }
+
   const violations: WordTimingViolation[] = [];
   let prevEndMs = 0;
   words.forEach((w, index) => {


### PR DESCRIPTION
# Relates to

Closes #20527.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] this PR targets `develop` and is branched directly off the current `origin/develop` tip.
- [x] focused package tests and lint pass on the exact head, see Testing below.
- [x] a reviewer can confirm the fix directly against the deterministic unit test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (fix, tests, via AgentRouter proxy), `anthropic/claude-sonnet-5` (independent re-verification)
<!-- attribution-row:client -->
- Agent tooling: `codex` (via AgentRouter proxy), `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] branched directly off the current `origin/develop` tip

# Risks

very low. the documented `audioDurationMs = 0` sentinel still skips the upper-bound check identically; only negative/non-finite values (never a legitimate duration or the documented sentinel) now throw instead of silently disabling validation.

# Background

## What does this PR do?

`validateAsrWordTimings` documents `audioDurationMs = 0` as the one sentinel that intentionally skips the upper-bound word-span check. The implementation instead gates that check with `audioDurationMs > 0`, which is also `false` for negative numbers and `NaN` — so a negative or `NaN` duration silently disabled the bound too, accepting an out-of-audio word span instead of being rejected as invalid input.

confirmed directly before touching the source:
```text
{
  "negative": { "ok": true, "violations": [] },
  "nan": { "ok": true, "violations": [] }
}
```

traced reachability honestly before writing this up: `validateAsrWordTimings` is wildcard-re-exported from `@elizaos/shared` (`packages/shared/src/index.ts:309`, `export * from "./transcripts.js"`). Real non-test callers include `plugins/plugin-local-inference/native/verify/asr_bench.ts` (computes duration from PCM length/sample rate — malformed PCM/sample-rate input could produce an invalid value here), `plugins/plugin-local-inference/src/services/voice/ffi-bindings.ts`, `packages/shared/src/audio-redaction.ts`, and `plugins/plugin-meetings/src/pipeline/transcriber.ts` (intentionally uses the documented `0` sentinel and is unaffected by this fix).

fix: fail fast with `RangeError` for non-finite or negative `audioDurationMs`/`toleranceMs`, so only the documented `0` sentinel (not any invalid value) disables the upper-bound check.

## What kind of change is this?

bug fix, non-breaking (the documented `0` sentinel and every valid positive duration behave identically; only negative/non-finite values that previously silently disabled validation now throw).

# Documentation changes needed?

no, the fix makes the implementation match its own documented contract.

# Testing

## Where should a reviewer start?

`packages/shared/src/transcripts.test.ts`, the new negative/NaN-duration and negative/Infinity-tolerance cases, then the two guards added at the top of `validateAsrWordTimings` in `transcripts.ts`.

## Detailed testing steps

```text
$ bunx vitest run packages/shared/src/transcripts.test.ts --config packages/shared/vitest.config.ts --coverage.enabled=false
Test Files  1 passed (1)
     Tests  23 passed (23)

$ bunx @biomejs/biome check packages/shared/src/transcripts.ts packages/shared/src/transcripts.test.ts
Checked 2 files in 83ms. No fixes applied.
```

mutation-resistance verified independently: reverted just the source fix (`git stash push -- packages/shared/src/transcripts.ts`, kept the test), reran — 1/23 failed, expected the negative-duration call to throw `/audioDurationMs must be a non-negative finite number/` but it returned `undefined`/no throw, reproducing the silent-bypass behavior described above. restored the fix, 23/23 green again.

# Evidence Gate

<!-- evidence-head:cc66cc01d14975f618e79d704277cac254358b11 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes an internal validation function, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - this changes an internal validation function, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive product flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic unit test, the real transcript is included under domain artifacts.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real mutation-resistance run, captured directly:
  ```text
  red (source fix reverted, test kept):
  $ bunx vitest run packages/shared/src/transcripts.test.ts --config packages/shared/vitest.config.ts --coverage.enabled=false
  + Received: undefined
  Tests  1 failed | 22 passed (23)

  green (fix restored):
  $ bunx vitest run packages/shared/src/transcripts.test.ts --config packages/shared/vitest.config.ts --coverage.enabled=false
  Tests  23 passed (23)
  ```
  also independently confirmed the wildcard export path and all four real non-test callers before writing the reachability claim.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface or visual text changed.

## Known gaps / failures

none in the touched surface. `packages/shared`'s package-wide `typecheck` surfaces one pre-existing, unrelated error (`src/todo-cutover.ts` failing to resolve `@elizaos/core/edge` from a fresh checkout where workspace packages haven't been built yet) — it does not reference either changed file. The package-wide test lane hits pre-existing, unrelated failures (`todo-cutover.test.ts`, character-presets failure-template assertions, steward-session-client assertions); the focused touched-file suite is green both standalone and independently reran.

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the focused suite and lint myself, independently confirmed the wildcard export and all four real callers before accepting the reachability claim, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Contribution skill revision: N/A - direct interactive session, contribute-to-eliza skill not used
Compute receipt: N/A - Slop run-receipt install currently blocked by an unrelated site-deploy-lag issue (deployed skill archive predates recent develop changes)
Attribution status: self-reported
