### PR TITLE
fix(shared): require strict ISO-8601 in todo cutover timestamps

### DIFF
--- a/packages/shared/src/todo-cutover.test.ts
+++ b/packages/shared/src/todo-cutover.test.ts
@@ -276,6 +276,16 @@ describe("Shared Todo cutover contract", () => {
       { committedAt: "not-a-time" },
       "TODO_CUTOVER_INVALID_TIMESTAMP",
     ],
+    [
+      "non-ISO commit timestamp",
+      { committedAt: "August 14, 2026 10:00:00" },
+      "TODO_CUTOVER_INVALID_TIMESTAMP",
+    ],
+    [
+      "impossible ISO calendar date",
+      { committedAt: "2026-02-30T10:00:00Z" },
+      "TODO_CUTOVER_INVALID_TIMESTAMP",
+    ],
   ])("rejects invalid mutation %s", async (_label, overrides, code) => {
     await expect(
       createSharedTodoCutoverSnapshot({

--- a/packages/shared/src/todo-cutover.ts
+++ b/packages/shared/src/todo-cutover.ts
@@ -19,6 +19,8 @@ const MAX_IDEMPOTENCY_KEY_LENGTH = 1_024;
 const MAX_CONTENT_LENGTH = 16_384;
 const MAX_ACTIVE_FORM_LENGTH = 4_096;
 const MAX_METADATA_DEPTH = 32;
+const ISO_TIMESTAMP_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
 
 export const SHARED_TODO_STATUSES = [
   "pending",
@@ -137,10 +139,31 @@ function nullableUuid(value: unknown, field: string): string | null {
   return requiredUuid(value, field);
 }
 
+function hasValidIsoCalendarFields(raw: string): boolean {
+  const match = ISO_TIMESTAMP_PATTERN.exec(raw);
+  if (!match) return false;
+
+  const [year, month, day, hour, minute, second] = match.slice(1).map(Number);
+  const calendar = new Date(0);
+  calendar.setUTCFullYear(year, month - 1, day);
+  calendar.setUTCHours(hour, minute, second, 0);
+  return (
+    calendar.getUTCFullYear() === year &&
+    calendar.getUTCMonth() === month - 1 &&
+    calendar.getUTCDate() === day &&
+    calendar.getUTCHours() === hour &&
+    calendar.getUTCMinutes() === minute &&
+    calendar.getUTCSeconds() === second
+  );
+}
+
 function canonicalTimestamp(value: unknown, field: string): string {
   const raw = requiredString(value, field, 64);
   const timestamp = new Date(raw);
-  if (!Number.isFinite(timestamp.getTime())) {
+  if (
+    !hasValidIsoCalendarFields(raw) ||
+    !Number.isFinite(timestamp.getTime())
+  ) {
     return invalid(
       "TODO_CUTOVER_INVALID_TIMESTAMP",
       `${field} must be an ISO timestamp`,


### PR DESCRIPTION
# Relates to

Closes #20531.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] this PR targets `develop` and is branched directly off the current `origin/develop` tip.
- [x] focused package tests and lint pass on the exact head, see Testing below.
- [x] a reviewer can confirm the fix directly against the deterministic unit test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (fix, tests, via AgentRouter proxy), `anthropic/claude-sonnet-5` (independent re-verification)
<!-- attribution-row:client -->
- Agent tooling: `codex` (via AgentRouter proxy), `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] branched directly off the current `origin/develop` tip

# Risks

very low. every genuine ISO-8601 timestamp (the format the real cloud producer always emits via `Date.toISOString()`) still passes identically; only non-ISO, Date-parseable strings — never a legitimate value on this contract — are newly rejected.

# Background

## What does this PR do?

`canonicalTimestamp` only checked `Number.isFinite(new Date(raw).getTime())`, despite the field's documented contract requiring an ISO timestamp. JavaScript's `Date` constructor accepts many non-ISO formats, including locale-formatted strings like `"August 14, 2026 10:00:00"` — which is interpreted in the *machine's local timezone*, not UTC. The same payload can therefore produce a different instant depending on which machine parses it — a real correctness hazard for a cutover/sync contract meant to be timezone-agnostic.

confirmed directly before touching the source: `"August 14, 2026 10:00:00"` was accepted and produced `"2026-08-14T09:00:00.000Z"` (timezone-dependent), instead of being rejected as non-ISO.

traced reachability honestly before writing this up: authenticated input reaches this parser through `packages/agent/src/api/conversation-routes.ts` — `rawImport.todoSnapshot` is passed to `parseSharedTodoCutoverSnapshot()`, which calls `createSharedTodoCutoverSnapshot()` and normalizes `createdAt`, `updatedAt`, `completedAt`, and mutation `committedAt` through this function. The normal cloud producer (`packages/cloud/api/v1/eliza/agents/[agentId]/upgrade-tier/cutover/route.ts`) always emits `Date.toISOString()`, but malformed or tampered wire payloads reach this parser directly and were previously accepted with timezone-dependent results.

fix: an explicit ISO-8601 pattern (`YYYY-MM-DDTHH:mm:ss`, optional fractional seconds, mandatory `Z` or numeric offset) checked alongside the existing finite-date guard.

## What kind of change is this?

bug fix, non-breaking (every genuine ISO-8601 timestamp — the only format the real producer ever emits — still passes identically; only non-ISO Date-parseable strings are newly rejected).

# Documentation changes needed?

no, the fix makes the parser match its own documented "ISO timestamp" contract.

# Testing

## Where should a reviewer start?

`packages/shared/src/todo-cutover.test.ts`, the `rejects invalid mutation non-ISO commit timestamp` case, then the `ISO_TIMESTAMP_PATTERN` check added to `canonicalTimestamp` in `todo-cutover.ts`.

## Detailed testing steps

```text
$ cd packages/shared && FORCE_COLOR=0 bun test src/todo-cutover.test.ts
17 pass, 0 fail, 35 expect() calls

$ bunx @biomejs/biome check packages/shared/src/todo-cutover.ts packages/shared/src/todo-cutover.test.ts
Checked 2 files in 53ms. No fixes applied.
```

(note: `bun run --cwd packages/shared test -- todo-cutover.test.ts` fails to *collect* on this checkout due to a pre-existing, unrelated `ENOTDIR` alias/config error resolving `@elizaos/core`'s edge export from a fresh checkout — used the direct `bun test` invocation above instead, which runs the real compiled test file identically.)

mutation-resistance verified independently: reverted just the source fix (`git stash push -- packages/shared/src/todo-cutover.ts`, kept the test), reran — 1/17 failed, expected the non-ISO mutation timestamp to be rejected but the promise resolved instead, reproducing the exact silent-acceptance bug described above. restored the fix, 17/17 green again.

# Evidence Gate

<!-- evidence-head:69bed9da30e28011564b0b0c39d5f164318dbbae -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes an internal timestamp-validation function, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - this changes an internal timestamp-validation function, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive product flow.
<!-- evidence-row:backend-logs -->
- [x] [20532-pr20532-verify.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20532-pr20532-verify.log)
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [20532-pr20532-validation-69bed9da.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20532-pr20532-validation-69bed9da.md)

  green (fix restored):
  17 pass, 0 fail, 35 expect() calls
  ```
  also independently confirmed the real reachability chain (`conversation-routes.ts` → `parseSharedTodoCutoverSnapshot` → `createSharedTodoCutoverSnapshot` → `canonicalTimestamp`) before writing the reachability claim.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface or visual text changed.

## Known gaps / failures

none in the touched surface. `bun run --cwd packages/shared test -- todo-cutover.test.ts` fails to collect due to a pre-existing, unrelated `ENOTDIR` alias-resolution error for `@elizaos/core`'s edge export on a fresh checkout — unrelated to either changed file; the direct `bun test` invocation runs the same compiled test file and passes cleanly.

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the focused suite and lint myself, independently confirmed the real reachability chain, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Contribution skill revision: N/A - direct interactive session, contribute-to-eliza skill not used
Compute receipt: N/A - Slop run-receipt install currently blocked by an unrelated site-deploy-lag issue (deployed skill archive predates recent develop changes)
Attribution status: self-reported

