### PR TITLE
fix(shared): reject invalid Upstash pipeline responses

### DIFF
--- a/packages/shared/src/sandbox-registry.test.ts
+++ b/packages/shared/src/sandbox-registry.test.ts
@@ -26,11 +26,13 @@ interface Recorded {
 const recorded: Recorded[] = [];
 const store = new Map<string, string>();
 let failNextFetch = false;
+let nextPipelineResponse: unknown = null;
 
 function installFetch(): void {
   recorded.length = 0;
   store.clear();
   failNextFetch = false;
+  nextPipelineResponse = null;
   global.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
     if (failNextFetch) {
       failNextFetch = false;
@@ -41,6 +43,12 @@ function installFetch(): void {
     recorded.push({ url, body });
 
     if (url.endsWith("/pipeline")) {
+      if (nextPipelineResponse !== null) {
+        return {
+          ok: true,
+          json: async () => nextPipelineResponse,
+        } as unknown as Response;
+      }
       for (const cmd of body as string[][]) {
         if (cmd[0] === "SET") store.set(cmd[1], cmd[2]);
       }
@@ -104,6 +112,15 @@ describe("SandboxRegistry (Upstash REST transport)", () => {
       "EX",
       "90",
     ]);
+  });
+
+  it("rejects a top-level Upstash pipeline error response", async () => {
+    nextPipelineResponse = { error: "pipeline unavailable" };
+    const reg = new SandboxRegistry(baseConfig);
+
+    await expect(reg.register()).rejects.toThrow(
+      "Upstash pipeline returned an invalid response",
+    );
   });
 
   it("unregister() deletes keys only when they still point at this sandbox", async () => {

--- a/packages/shared/src/sandbox-registry.ts
+++ b/packages/shared/src/sandbox-registry.ts
@@ -181,10 +181,21 @@ export class SandboxRegistry {
         `Upstash pipeline failed: ${res.status} ${await res.text()}`,
       );
     }
-    const json = (await res.json()) as Array<{ error?: string }>;
-    if (Array.isArray(json)) {
-      for (const entry of json) {
-        if (entry?.error) throw new Error(`Upstash error: ${entry.error}`);
+    const json: unknown = await res.json();
+    if (!Array.isArray(json) || json.length !== commands.length) {
+      throw new Error("Upstash pipeline returned an invalid response");
+    }
+    for (const entry of json) {
+      if (typeof entry !== "object" || entry === null) {
+        throw new Error("Upstash pipeline returned an invalid response");
+      }
+      const result = Reflect.get(entry, "result");
+      const error = Reflect.get(entry, "error");
+      if (typeof error === "string" && error.length > 0) {
+        throw new Error(`Upstash error: ${error}`);
+      }
+      if (result !== "OK") {
+        throw new Error("Upstash pipeline returned an invalid response");
       }
     }
   }


### PR DESCRIPTION
# Relates to

Closes #20538.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] this PR targets `develop` and is branched directly off the current `origin/develop` tip.
- [x] focused package tests and lint pass on the exact head, see Testing below.
- [x] a reviewer can confirm the fix directly against the deterministic unit test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (fix, tests, via AgentRouter proxy), `anthropic/claude-sonnet-5` (independent re-verification)
<!-- attribution-row:client -->
- Agent tooling: `codex` (via AgentRouter proxy), `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] branched directly off the current `origin/develop` tip

# Risks

low. verified `pipeline()`'s sole caller (`writeKeys()`) only ever sends two `SET` commands, so requiring `result === "OK"` on every reply is exactly correct for the method's actual current usage, not an overly-broad new constraint. Every genuinely successful pipeline response (array of `{ result: "OK" }` per command) behaves identically; only malformed/error responses that previously slipped through as silent success are newly rejected.

# Background

## What does this PR do?

`SandboxRegistry.pipeline()` (the REST/Upstash transport) accepted any HTTP 200 response whose JSON body was not an array. A top-level Upstash error such as `{ "error": "pipeline unavailable" }` made `register()` resolve and log successful registration even though neither routing key (`server:<name>:url`, `agent:<id>:server`) was actually written. The existing check only inspected per-entry errors inside an `if (Array.isArray(json))` branch — the non-array case fell through as silent success.

traced reachability honestly before writing this up: this is live server-startup code, not test-only. `packages/app-core/src/runtime/startup/server-only-host.ts` and `packages/agent/src/runtime/eliza.ts` both call `buildSandboxRegistryFromEnv()` and await `sandboxRegistry.register()` at startup; a rejection is meant to log/report degraded inbound routing, but the false-success path suppressed that entirely. `buildSandboxRegistryFromEnv()` selects this REST path for configured `http(s)://` Upstash URLs, so the response is real external input, not a hardcoded-safe value — an HTTP 200 top-level/malformed pipeline response could leave both gateway routing keys absent while startup reported success, and each heartbeat retry would repeat the same false-success behavior for the same response shape.

fix: the REST pipeline boundary now fails closed unless the decoded response is an array with exactly one reply per submitted command, every reply is a non-null object, no reply carries a non-empty string `error`, and every reply's `result` is exactly `"OK"`.

## What kind of change is this?

bug fix, non-breaking (every genuinely successful pipeline response behaves identically; only malformed/error responses previously mistaken for success are newly rejected).

# Documentation changes needed?

no.

# Testing

## Where should a reviewer start?

`packages/shared/src/sandbox-registry.test.ts`, the `rejects a top-level Upstash pipeline error response` case, then the response-validation rewrite in `pipeline()` in `sandbox-registry.ts`.

## Detailed testing steps

```text
$ bun run --cwd packages/shared test -- src/sandbox-registry.test.ts -t 'Upstash REST transport'
Test Files  1 passed (1)
     Tests  6 passed | 10 skipped (16)

$ bunx vitest run packages/shared/src/sandbox-registry.test.ts --config packages/shared/vitest.config.ts --coverage.enabled=false
Test Files  1 passed (1)
     Tests  16 passed (16)

$ bunx @biomejs/biome check packages/shared/src/sandbox-registry.ts packages/shared/src/sandbox-registry.test.ts
Checked 2 files in 35ms. No fixes applied.

$ bun run --cwd packages/shared typecheck
(clean, exit 0)

$ bun run --cwd packages/shared build
(clean, exit 0)
```

mutation-resistance verified independently: reverted just the source fix (`git stash push -- packages/shared/src/sandbox-registry.ts`, kept the test), reran the full file — 1/16 failed, expected the top-level Upstash error object to make `register()` reject but the promise resolved instead, reproducing the exact false-success bug described above. restored the fix, 16/16 green again.

# Evidence Gate

<!-- evidence-head:f4dadfc2dde3e27c91e6f686ac445b9050eac6b7 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes an internal REST-transport response validator, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - this changes an internal REST-transport response validator, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - server-startup registration logic, no interactive product UI flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic unit test, the real transcript is included under domain artifacts.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code or network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real mutation-resistance run, captured directly:
  ```text
  red (source fix reverted, test kept):
  $ bunx vitest run packages/shared/src/sandbox-registry.test.ts --config packages/shared/vitest.config.ts --coverage.enabled=false
  + Received: undefined
  Tests  1 failed | 15 passed (16)

  green (fix restored):
  $ bunx vitest run packages/shared/src/sandbox-registry.test.ts --config packages/shared/vitest.config.ts --coverage.enabled=false
  Tests  16 passed (16)
  ```
  also independently confirmed `pipeline()`'s sole caller (`writeKeys()`) only ever sends `SET` commands, before accepting the "require result === OK on every reply" risk framing, and confirmed both real server-startup reachability call sites directly in source.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface or visual text changed.

## Known gaps / failures

none in the touched surface. Lint, typecheck, and build all pass clean on the exact head, independently rerun.

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the focused suite, lint, typecheck, and build myself, independently confirmed `pipeline()`'s sole caller only sends SET commands before accepting the risk framing, verified both real startup call sites, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Contribution skill revision: N/A - direct interactive session, contribute-to-eliza skill not used
Compute receipt: N/A - Slop run-receipt install currently blocked by an unrelated site-deploy-lag issue (deployed skill archive predates recent develop changes)
Attribution status: self-reported
