### PR TITLE
fix(ui): follow the explicitly selected remote runtime for realtime WS

### DIFF
--- a/packages/ui/src/api/client-base-websocket.test.ts
+++ b/packages/ui/src/api/client-base-websocket.test.ts
@@ -85,13 +85,15 @@ function stubWindowProtocol(protocol: string): void {
 
 // Stub the page origin (protocol + host) the same-origin WS derivation reads
 // when the client has no explicit base — the self-hosted "nginx in front of
-// the agent on a portless HTTPS domain" shape.
+// the agent on a portless HTTPS domain" shape. `origin` is derived so
+// #20342's injected-vs-page origin comparison sees the same value.
 function stubWindowOrigin(protocol: string, host: string): void {
   const jsdomWindow = window;
   const location = new Proxy(jsdomWindow.location, {
     get(target, property) {
       if (property === "protocol") return protocol;
       if (property === "host") return host;
+      if (property === "origin") return `${protocol}//${host}`;
       return Reflect.get(target, property, target);
     },
   });
@@ -565,5 +567,64 @@ describe("ElizaClient websocket connection policy", () => {
     expect(instances).toHaveLength(2);
     expect(instances[0].onmessage).toBeNull();
     expect(instances[1].url).toContain("token=new-token");
+  });
+
+  // --- #20342: injected __ELIZA_WS_BASE__ precedence ------------------
+  // The Vite dev server injects a WS base computed from the page origin so
+  // tunnels can proxy /ws. That injection is ambient: it must not pin
+  // realtime to the dev origin when the user explicitly selected a remote
+  // HTTP(S) agent after boot. A genuinely separate injected WS host stays
+  // authoritative.
+  function stubInjectedWsBase(value: string | undefined): void {
+    if (value === undefined) {
+      delete (window as { __ELIZA_WS_BASE__?: string }).__ELIZA_WS_BASE__;
+    } else {
+      (window as { __ELIZA_WS_BASE__?: string }).__ELIZA_WS_BASE__ = value;
+    }
+  }
+
+  it("derives realtime from an explicitly selected remote base when the injected WS base is just the dev origin", () => {
+    const createdUrls = stubWebSocket();
+    // Page served by Vite at 127.0.0.1:2653; injected WS base mirrors it.
+    stubWindowOrigin("http:", "127.0.0.1:2653");
+    stubInjectedWsBase("ws://127.0.0.1:2653");
+
+    const client = new ElizaClient("", "agent-token");
+    client.setBaseUrl("http://127.0.0.1:31337", { persist: false });
+    client.connectWs();
+
+    expect(createdUrls).toHaveLength(1);
+    expect(createdUrls[0]).toContain("ws://127.0.0.1:31337/ws?");
+    expect(createdUrls[0]).not.toContain("2653");
+    stubInjectedWsBase(undefined);
+  });
+
+  it("keeps a genuinely separate injected WS host authoritative over an explicit HTTP base", () => {
+    const createdUrls = stubWebSocket();
+    // Page at the dev origin, but the injected WS base points at a real
+    // separately-hosted realtime service on a different origin.
+    stubWindowOrigin("http:", "127.0.0.1:2653");
+    stubInjectedWsBase("wss://realtime.example.test:4443");
+
+    const client = new ElizaClient("", "agent-token");
+    client.setBaseUrl("http://127.0.0.1:31337", { persist: false });
+    client.connectWs();
+
+    expect(createdUrls).toHaveLength(1);
+    expect(createdUrls[0]).toContain("wss://realtime.example.test:4443/ws?");
+    stubInjectedWsBase(undefined);
+  });
+
+  it("keeps same-origin behavior unchanged when no explicit base is set", () => {
+    const createdUrls = stubWebSocket();
+    stubWindowOrigin("http:", "127.0.0.1:2653");
+    stubInjectedWsBase("ws://127.0.0.1:2653");
+
+    const client = new ElizaClient("", "agent-token");
+    client.connectWs();
+
+    expect(createdUrls).toHaveLength(1);
+    expect(createdUrls[0]).toContain("ws://127.0.0.1:2653/ws?");
+    stubInjectedWsBase(undefined);
   });
 });

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -1977,6 +1977,9 @@ export class ElizaClient {
               const protocol = new URL(this.baseUrl).protocol;
               return protocol === "http:" || protocol === "https:";
             } catch {
+              // error-policy:J3 malformed base URLs are explicitly ineligible
+              // for WS-base precedence; ambient derivation below still reads
+              // them exactly as before.
               return false;
             }
           })()
@@ -1995,8 +1998,8 @@ export class ElizaClient {
           wsBase = undefined; // fall through to the explicit client base
         }
       } catch {
-        // Invalid injected URL: keep the existing parse-and-throw behavior
-        // below rather than silently reinterpreting it.
+        // error-policy:J3 a malformed injected WS URL is not silently
+        // reinterpreted: the existing parse-and-throw below handles it.
       }
     }
     if (wsBase) {

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -1962,7 +1962,43 @@ export class ElizaClient {
 
     let host: string;
     let wsProtocol: "ws:" | "wss:";
-    const wsBase = getInjectedWsBase();
+    let wsBase = getInjectedWsBase();
+    // #20342: the Vite dev server injects __ELIZA_WS_BASE__ unconditionally in
+    // serve mode (computed from the page origin) so tunnels can proxy /ws.
+    // That injection must be AMBIENT — it cannot override an HTTP(S) agent the
+    // user explicitly selected after boot. Rule: when a user-pinned HTTP(S)
+    // base exists and the injected WS base merely normalizes to the current
+    // page origin, derive realtime from the selected base instead. A genuinely
+    // separate injected WS host (different origin) remains authoritative.
+    const explicitHttpBase =
+      this._userSetBase && this.baseUrl
+        ? (() => {
+            try {
+              const protocol = new URL(this.baseUrl).protocol;
+              return protocol === "http:" || protocol === "https:";
+            } catch {
+              return false;
+            }
+          })()
+        : false;
+    if (wsBase && explicitHttpBase) {
+      try {
+        // Normalize ws/wss origins to their http/https equivalents for the
+        // comparison: same host+port+scheme means "just the dev origin".
+        // URL.origin keeps the ws/wss scheme, so map both spellings.
+        const toHttpOrigin = (value: string): string =>
+          value
+            .replace(/^wss:\/\//i, "https://")
+            .replace(/^ws:\/\//i, "http://");
+        const injectedOrigin = toHttpOrigin(new URL(wsBase).origin);
+        if (injectedOrigin === window.location.origin) {
+          wsBase = undefined; // fall through to the explicit client base
+        }
+      } catch {
+        // Invalid injected URL: keep the existing parse-and-throw behavior
+        // below rather than silently reinterpreting it.
+      }
+    }
     if (wsBase) {
       const parsed = new URL(wsBase);
       host = parsed.host;


### PR DESCRIPTION
Closes #20342

## What

A fresh Vite app session could explicitly connect to a healthy remote runtime, move every HTTP request there, and still have its realtime WebSocket pinned to the Vite page origin — which the dev proxy forwards to the (often dead) worktree reservation port. HTTP followed the selection; realtime did not.

## Root cause (RP investigate, session `EDE61CC2`)

`ElizaClient.connectWs()` gave the injected `__ELIZA_WS_BASE__` **unconditional** precedence over the client base. The Vite server injects that value in serve mode (computed from the page origin) so tunnels can proxy `/ws` — correct for no-base sessions, wrong once the user deliberately selects a remote agent after boot.

## Fix

Precedence rule in `connectWs()` (`packages/ui/src/api/client-base.ts`): when a **user-set HTTP(S)** base exists (`_userSetBase` + `http(s)` protocol) and the injected WS base normalizes (`ws→http`, `wss→https`) to the current **page origin**, the injection is treated as ambient and realtime derives from the selected base. Any other shape keeps the existing behavior:

| Scenario | Result |
|---|---|
| Page/Vite `ws://127.0.0.1:2653`, explicitly selected `http://127.0.0.1:31337` | WS uses `ws://127.0.0.1:31337` (the issue's exact repro) |
| Page origin + genuine `wss://realtime.example` injection | Separate realtime endpoint remains authoritative |
| Explicit base = page origin | Unchanged |
| No explicit base (Vite/tunnel dev) | Unchanged |

Untouched by construction: the Cloud REST-only policy check runs before this code; the mixed-content/Capacitor guards run after; non-HTTP environments never reach it; invalid injected URLs keep the existing parse-and-throw. Both new catch handlers carry `error-policy:J3` annotations per repo policy.

## Tests

`client-base-websocket.test.ts` — the file had **zero** `__ELIZA_WS_BASE__` coverage; now pins all three behavior rows above (issue-repro: page 2653, selected 31337 → `ws://127.0.0.1:31337/ws`). The `stubWindowOrigin` helper now derives `location.origin` alongside protocol/host so the comparison is observable under jsdom.

- WebSocket suite **29/29**, all `client-base*` tests **79/79**, UI typecheck clean

## Review trail

- **RP investigate** (`EDE61CC2`): full precedence map, caller inventory (onboarding/runtime-switch/settings vs ambient Electrobun restore), the minimal fix shape above, and confirmation the PR #19186 hunks in this file are disjoint (HTTP warming classifier region; no connectWs/WebSocket hunks)
- **RP review round 1** (`4DD92D5F`, exact head `3017d7241a`): REQUEST_CHANGES with one Medium — missing `error-policy:J3` annotations on the two new catches; every behavioral area verified clean (origin mapping incl. default-port canonicalization, opaque-origin non-issue, policy ordering, `_userSetBase` semantics, invalid-URL throw preservation, test soundness). **Fixed in `24958b87a`.**
- **RP review round 2** (`55E4CC11`, exact head `24958b87a`): **APPROVE** — annotations present and correctly worded; independent git diff confirms only comments changed; no behavioral/test drift.

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent"} -->