### PR TITLE
fix(shared): bound rate limiter sweep timers

### DIFF
--- a/packages/shared/src/utils/rate-limiter.test.ts
+++ b/packages/shared/src/utils/rate-limiter.test.ts
@@ -36,6 +36,20 @@ describe("createRateLimiter", () => {
     expect(() =>
       createRateLimiter({ windowMs: 1000, sweepIntervalMs: Number.NaN }),
     ).toThrow(RangeError);
+    expect(() =>
+      createRateLimiter({ windowMs: 1000, sweepIntervalMs: 2_147_483_648 }),
+    ).toThrow(RangeError);
+  });
+
+  it("caps the derived sweep interval at the maximum timer delay", () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+    limiter = createRateLimiter({ windowMs: 2_147_483_647 });
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(
+      expect.any(Function),
+      2_147_483_647,
+    );
   });
 
   it("allows initial action and blocks subsequent actions within windowMs", () => {

--- a/packages/shared/src/utils/rate-limiter.ts
+++ b/packages/shared/src/utils/rate-limiter.ts
@@ -32,6 +32,8 @@ export interface RateLimiter {
   dispose(): void;
 }
 
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
 export function createRateLimiter(opts: RateLimiterOptions): RateLimiter {
   const { windowMs } = opts;
   if (
@@ -45,12 +47,17 @@ export function createRateLimiter(opts: RateLimiterOptions): RateLimiter {
     opts.sweepIntervalMs !== undefined &&
     (typeof opts.sweepIntervalMs !== "number" ||
       !Number.isFinite(opts.sweepIntervalMs) ||
-      opts.sweepIntervalMs <= 0)
+      opts.sweepIntervalMs <= 0 ||
+      opts.sweepIntervalMs > MAX_TIMER_DELAY_MS)
   ) {
-    throw new RangeError("sweepIntervalMs must be a positive finite number");
+    throw new RangeError(
+      `sweepIntervalMs must be between 1 and ${MAX_TIMER_DELAY_MS}`,
+    );
   }
 
-  const sweepIntervalMs = opts.sweepIntervalMs ?? Math.ceil(windowMs * 1.5);
+  const sweepIntervalMs =
+    opts.sweepIntervalMs ??
+    Math.min(Math.ceil(windowMs * 1.5), MAX_TIMER_DELAY_MS);
   const map = new Map<string, number>(); // key → lastActionAt
 
   let sweepTimer: ReturnType<typeof setInterval> | null = setInterval(() => {


### PR DESCRIPTION
# Relates to

Closes #20541.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] this PR targets `develop` and is branched directly off the current `origin/develop` tip.
- [x] focused package tests and lint pass on the exact head, see Testing below.
- [x] a reviewer can confirm the fix directly against the deterministic unit test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (fix, tests, via AgentRouter proxy), `anthropic/claude-sonnet-5` (independent re-verification)
<!-- attribution-row:client -->
- Agent tooling: `codex` (via AgentRouter proxy), `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] branched directly off the current `origin/develop` tip

# Risks

very low. every `sweepIntervalMs`/`windowMs` value already within the 32-bit timer range produces an identical sweep interval; only values that previously silently overflowed into a Node hot-loop (1ms re-fire) are newly rejected or clamped.

# Background

## What does this PR do?

`createRateLimiter` accepted an explicit `sweepIntervalMs` above JavaScript's `setInterval` delay ceiling of 2,147,483,647 ms, and its derived default (`Math.ceil(windowMs * 1.5)`) could exceed that ceiling too for a large `windowMs`. Node.js does not treat an oversized `setInterval` delay as a long wait — it emits a `TimeoutOverflowWarning` and silently resets the delay to 1ms, turning a rare background cleanup sweep into a hot loop.

confirmed directly before touching the source: `setInterval(() => {}, 2147483648)` on the pinned Node runtime produces `TimeoutOverflowWarning: 2147483648 does not fit into a 32-bit signed integer. Timeout duration was set to 1.`

traced reachability honestly before writing this up: `createRateLimiter` is exported publicly from `@elizaos/shared` (`packages/shared/src/index.ts:335`) and re-exported by `packages/ui/src/utils/rate-limiter.ts`. A repository-wide search found no current non-test call to this specific shared implementation — the similarly-named function in `packages/core/src/features/documents/document-processor.ts` is a completely separate, locally-defined implementation (confirmed directly: it has its own `function createRateLimiter(...)` at line 1273 rather than importing the shared one). This is a genuine defect in a publicly-exported contract with an explicit numeric parameter, not a currently-exploited live path — reported honestly as such rather than overstating severity.

fix: reject explicit `sweepIntervalMs` values outside `[1, 2147483647]`, and cap the derived default at the same ceiling. `windowMs` itself is untouched since elapsed-time rate limiting doesn't use it directly as a timer delay.

## What kind of change is this?

bug fix, non-breaking (every value already within the valid timer range behaves identically; only previously-overflowing values are newly rejected/clamped).

# Documentation changes needed?

no.

# Testing

## Where should a reviewer start?

`packages/shared/src/utils/rate-limiter.test.ts`, the `validates windowMs and sweepIntervalMs options` and `caps the derived sweep interval at the maximum timer delay` cases, then the bounds added to `createRateLimiter` in `rate-limiter.ts`.

## Detailed testing steps

```text
$ bunx vitest run packages/shared/src/utils/rate-limiter.test.ts --config packages/shared/vitest.config.ts --coverage.enabled=false
Test Files  1 passed (1)
     Tests  9 passed (9)

$ bunx @biomejs/biome check packages/shared/src/utils/rate-limiter.ts packages/shared/src/utils/rate-limiter.test.ts
Checked 2 files in 30ms. No fixes applied.
```

mutation-resistance verified independently: reverted just the source fix (`git stash push -- packages/shared/src/utils/rate-limiter.ts`, kept the test), reran — 2/9 failed: an explicit oversized `sweepIntervalMs` was silently accepted instead of throwing, and the derived default for `windowMs: 2_147_483_647` called `setInterval` with `3221225471` (past the 32-bit ceiling) instead of the clamped `2147483647`. restored the fix, 9/9 green again.

# Evidence Gate

<!-- evidence-head:6c8514240538c7680dadd40f03a18cc9edcf7b71 -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes an internal timer-bounds validator, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - this changes an internal timer-bounds validator, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive product flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic unit test, the real transcript is included under domain artifacts.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend network flow changed; no confirmed live caller of this specific shared function (see reachability note above).
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real mutation-resistance run, captured directly:
  ```text
  red (source fix reverted, test kept):
  $ bunx vitest run packages/shared/src/utils/rate-limiter.test.ts --config packages/shared/vitest.config.ts --coverage.enabled=false
  Expected: [Any<Function>, 2147483647]
  Received: [Function anonymous, 3221225471]
  Tests  2 failed | 7 passed (9)

  green (fix restored):
  $ bunx vitest run packages/shared/src/utils/rate-limiter.test.ts --config packages/shared/vitest.config.ts --coverage.enabled=false
  Tests  9 passed (9)
  ```
  also independently confirmed the reachability claim: no genuine caller of the shared `createRateLimiter` exists in-repo (the similarly-named `document-processor.ts` function is a separate local implementation), verified directly in source before accepting that framing.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface or visual text changed.

## Known gaps / failures

none in the touched surface. Lint is clean on both touched files, independently rerun. The package-wide test lane hits pre-existing, unrelated failures (`character-presets.failure-templates.test.ts`, `steward-session-client/index.test.ts`, `todo-cutover.test.ts` collection); the focused touched-file suite is green both standalone and independently reran.

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the focused suite and lint myself, independently confirmed the reachability claim by checking `document-processor.ts` is a separate implementation, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Contribution skill revision: N/A - direct interactive session, contribute-to-eliza skill not used
Compute receipt: N/A - Slop run-receipt install currently blocked by an unrelated site-deploy-lag issue (deployed skill archive predates recent develop changes)
Attribution status: self-reported
