### PR TITLE
feat(registry): add plugin-x402-finance

### DIFF
--- a/packages/registry/entries/third-party/plugin-x402-finance.json
+++ b/packages/registry/entries/third-party/plugin-x402-finance.json
@@ -1,0 +1,9 @@
+{
+  "package": "plugin-x402-finance",
+  "repository": "github:lokixc84/x402-finance-api",
+  "kind": "plugin",
+  "description": "Base Mainnet token safety + market data via x402 micropayments. CHECK_TOKEN_SAFETY returns agent_action (block|warn|allow|skip). No API keys.",
+  "homepage": "https://x402-paid-api.x402-finance.workers.dev/llms.txt",
+  "version": "1.0.0",
+  "tags": ["x402", "base", "defi", "security", "token-safety", "micropayments"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -2175,6 +2175,52 @@
       "kind": "plugin",
       "registryKind": "plugin",
       "directory": null
+    },
+    "plugin-x402-finance": {
+      "git": {
+        "repo": "lokixc84/x402-finance-api",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "plugin-x402-finance",
+        "v0": null,
+        "v1": null,
+        "v2": "1.0.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Base Mainnet token safety + market data via x402 micropayments. CHECK_TOKEN_SAFETY returns agent_action (block|warn|allow|skip). No API keys.",
+      "homepage": "https://x402-paid-api.x402-finance.workers.dev/llms.txt",
+      "topics": [
+        "x402",
+        "base",
+        "defi",
+        "security",
+        "token-safety",
+        "micropayments"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
     }
   }
 }


### PR DESCRIPTION
Adds third-party registry entry for plugin-x402-finance.

- npm: plugin-x402-finance
- Base token safety via x402 ($0.04 USDC) + market data ($0.002)
- Returns agent_action for autonomous agents (block | warn | allow | skip)
- Docs: https://x402-paid-api.x402-finance.workers.dev/llms.txt
- Smoke-tested live payment + settlement on Base mainnet

Files:
- packages/registry/entries/third-party/plugin-x402-finance.json
- packages/registry/generated-registry.json (regenerated)