### PR TITLE
fix(shared): recognize full IPv4 loopback range

### DIFF
--- a/packages/shared/src/loopback-trust.test.ts
+++ b/packages/shared/src/loopback-trust.test.ts
@@ -65,10 +65,14 @@ function clearTrustEnv() {
 describe("isLoopbackRemoteAddress", () => {
   it.each([
     "127.0.0.1",
+    "127.0.0.2",
+    "127.255.255.254",
     "::1",
     "0:0:0:0:0:0:0:1",
     "::ffff:127.0.0.1",
+    "::ffff:127.0.0.2",
     "::ffff:0:127.0.0.1",
+    "::ffff:0:127.0.0.2",
   ])("accepts loopback peer %s", (addr) => {
     expect(isLoopbackRemoteAddress(addr)).toBe(true);
   });

--- a/packages/shared/src/loopback-trust.ts
+++ b/packages/shared/src/loopback-trust.ts
@@ -216,12 +216,13 @@ export function isLoopbackRemoteAddress(
 ): boolean {
   if (!remoteAddress) return false;
   const normalized = remoteAddress.trim().toLowerCase();
+  if (isIP(normalized) === 0) return false;
   return (
-    normalized === "127.0.0.1" ||
+    normalized.startsWith("127.") ||
     normalized === "::1" ||
     normalized === "0:0:0:0:0:0:0:1" ||
-    normalized === "::ffff:127.0.0.1" ||
-    normalized === "::ffff:0:127.0.0.1"
+    normalized.startsWith("::ffff:127.") ||
+    normalized.startsWith("::ffff:0:127.")
   );
 }
 


### PR DESCRIPTION
# Relates to

Closes #20544.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] this PR targets `develop` and is branched directly off the current `origin/develop` tip.
- [x] focused package tests and lint pass on the exact head, see Testing below.
- [x] a reviewer can confirm the fix directly against the deterministic unit test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (fix, tests, via AgentRouter proxy), `anthropic/claude-sonnet-5` (independent re-verification)
<!-- attribution-row:client -->
- Agent tooling: `codex` (via AgentRouter proxy), `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] branched directly off the current `origin/develop` tip

# Risks

low, and in the safe direction: this widens acceptance from a single address to the full legitimate `127.0.0.0/8` loopback block, gated by a strict `net.isIP` syntax check first — independently fuzz-checked a set of adversarial inputs (`"127.evil.com"`, `"1270.0.0.1"`, `"126.0.0.1"`, `"::ffff:10.0.0.1"`) and confirmed none of them slip through; only genuine loopback addresses are newly accepted, nothing outside `127.0.0.0/8` or `::1`.

# Background

## What does this PR do?

`isLoopbackRemoteAddress` recognized only `127.0.0.1` (and its IPv4-mapped IPv6 forms) as loopback. IPv4 defines the entire `127.0.0.0/8` block as loopback, and the sibling host classifier in the same file already accepts that full block. A genuine same-machine request whose TCP peer address is anything other than exactly `127.0.0.1` (e.g. `127.0.0.2`) was rejected before the local-trust policy even evaluated the Host/Origin/proxy/environment gates — a correctness gap in the safe (over-restrictive) direction rather than a security hole.

confirmed directly before touching the source: `isLoopbackRemoteAddress("127.0.0.2")` and `isLoopbackRemoteAddress("127.255.255.254")` both returned `false`.

traced reachability honestly before writing this up: this is live-reachable, not test-only. `isTrustedLocalRequest` in the same module calls `isLoopbackRemoteAddress(req.socket?.remoteAddress)` as its first gate. `packages/agent/src/api/server-helpers-auth.ts` uses it (via `isTrustedLocalRequest`) for agent-server local authorization across auth/update/server routes; `packages/app-core/src/api/compat-route-shared.ts` re-exports `isLoopbackRemoteAddress` directly and several app-core routes import it for loopback-only route admission. The input is Node's real `req.socket.remoteAddress`, not hardcoded to `127.0.0.1`.

fix: validate the normalized peer address with Node's `net.isIP` first (rejecting malformed input outright), then accept any syntactically-valid IPv4 address beginning with `127.` plus the corresponding IPv4-mapped IPv6 forms. The `isIP` gate is what makes the widened `startsWith` prefix checks safe — a string can only pass `startsWith("127.")` after already being confirmed a syntactically valid IP address, so no prefix trickery (`"127.evil.com"`) can sneak through.

## What kind of change is this?

bug fix, non-breaking and strictly widening in the safe direction (every previously-accepted address, `127.0.0.1`, still passes identically; the fix only accepts additional genuinely-loopback addresses that were incorrectly rejected before).

# Documentation changes needed?

no.

# Testing

## Where should a reviewer start?

`packages/shared/src/loopback-trust.test.ts`, the parametrized `accepts loopback peer %s` cases for `127.0.0.2`, `127.255.255.254`, `::ffff:127.0.0.2`, `::ffff:0:127.0.0.2`, then the rewritten `isLoopbackRemoteAddress` body in `loopback-trust.ts`.

## Detailed testing steps

```text
$ bunx vitest run packages/shared/src/loopback-trust.test.ts --config packages/shared/vitest.config.ts --coverage.enabled=false
Test Files  1 passed (1)
     Tests  72 passed (72)

$ bunx @biomejs/biome check packages/shared/src/loopback-trust.ts packages/shared/src/loopback-trust.test.ts
Checked 2 files in 32ms. No fixes applied.
```

mutation-resistance verified independently: reverted just the source fix (`git stash push -- packages/shared/src/loopback-trust.ts`, kept the test), reran — 4/72 failed, all four new loopback-range cases expected `true` and got `false`, reproducing the exact over-restriction described above. restored the fix, 72/72 green again.

# Evidence Gate

<!-- evidence-head:e14a74e5144cf1d23fdbdad1040bcf0583f4c3fc -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes an internal address-classification predicate, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - this changes an internal address-classification predicate, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive product flow.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - deterministic unit test, the real transcript is included under domain artifacts.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: real mutation-resistance run, captured directly:
  ```text
  red (source fix reverted, test kept):
  $ bunx vitest run packages/shared/src/loopback-trust.test.ts --config packages/shared/vitest.config.ts --coverage.enabled=false
  Expected: true, Received: false (127.0.0.2, 127.255.255.254, ::ffff:127.0.0.2, ::ffff:0:127.0.0.2)
  Tests  4 failed | 68 passed (72)

  green (fix restored):
  $ bunx vitest run packages/shared/src/loopback-trust.test.ts --config packages/shared/vitest.config.ts --coverage.enabled=false
  Tests  72 passed (72)
  ```
  also independently sanity-checked the fixed function against adversarial inputs beyond the committed test suite: `"127.evil.com"` → false, `"1270.0.0.1"` → false, `"126.0.0.1"` → false, `"::ffff:10.0.0.1"` → false, `"10.0.0.1"` → false — confirming the widened prefix checks stay bounded to genuine `127.0.0.0/8` addresses and don't accidentally accept anything outside it. Also independently traced the full reachability chain (`isTrustedLocalRequest` → `server-helpers-auth.ts`, `compat-route-shared.ts` re-export) directly in source.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface or visual text changed.

## Known gaps / failures

none in the touched surface. Lint is clean on both touched files, independently rerun. The package-wide test lane hits pre-existing, unrelated failures (`character-presets.failure-templates.test.ts`, `todo-cutover.test.ts` collection, `steward-session-client/index.test.ts`); the focused touched-file suite is green both standalone and independently reran.

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the focused suite and lint myself, independently fuzz-checked adversarial inputs beyond the committed test suite to confirm the widened check stays correctly bounded, independently traced the full reachability chain, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Contribution skill revision: N/A - direct interactive session, contribute-to-eliza skill not used
Compute receipt: N/A - Slop run-receipt install currently blocked by an unrelated site-deploy-lag issue (deployed skill archive predates recent develop changes)
Attribution status: self-reported
