### PR TITLE
fix(agent): reject malformed GET /api/approvals limit query

### DIFF
--- a/packages/agent/src/api/approval-routes.test.ts
+++ b/packages/agent/src/api/approval-routes.test.ts
@@ -3,8 +3,9 @@
  * `approvalTaskToPendingAction` projection: pending user actions are merged
  * newest-first and de-duplicated across the approval queue, the ApprovalService
  * task rows, and the pending-prompts service, and missing services yield empty
- * arrays. Runs against a mock runtime and a real ApprovalService backed by an
- * in-memory task store — no live model or HTTP.
+ * arrays. The untrusted `limit` query is fail-closed. Runs against a mock
+ * runtime and a real ApprovalService backed by an in-memory task store — no
+ * live model or HTTP.
  */
 import type http from "node:http";
 import type { PendingUserAction, Task, UUID } from "@elizaos/core";
@@ -367,6 +368,73 @@ describe("handleApprovalRoute", () => {
       approvals: [],
       pending: [],
       pendingUserActions: [],
+    });
+  });
+
+  it.each([
+    "1e3",
+    "50abc",
+    "0x10",
+    "50.5",
+    "abc",
+    "-1",
+    "1_000",
+    "+5",
+    " 5",
+    "5 ",
+    "0",
+    "Infinity",
+    "NaN",
+    "01",
+  ])("rejects malformed limit %j with 400", async (raw) => {
+    const { runtime, queueList } = runtimeWithApprovals({});
+    const helpers = makeHelpers();
+
+    const handled = await handleApprovalRoute(
+      req(`/api/approvals?limit=${encodeURIComponent(raw)}`),
+      res,
+      "/api/approvals",
+      "GET",
+      { runtime },
+      helpers,
+    );
+
+    expect(handled).toBe(true);
+    expect(helpers.error).toHaveBeenCalledWith(
+      res,
+      "limit must be a positive integer",
+      400,
+    );
+    expect(helpers.json).not.toHaveBeenCalled();
+    expect(queueList).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [undefined, 50],
+    ["5", 5],
+    ["500", 500],
+    ["501", 500],
+  ] as const)("accepts limit %j as %s", async (raw, expected) => {
+    const { runtime, queueList } = runtimeWithApprovals({});
+    const helpers = makeHelpers();
+    const url =
+      raw === undefined ? "/api/approvals" : `/api/approvals?limit=${raw}`;
+
+    await handleApprovalRoute(
+      req(url),
+      res,
+      "/api/approvals",
+      "GET",
+      { runtime },
+      helpers,
+    );
+
+    expect(helpers.error).not.toHaveBeenCalled();
+    expect(queueList).toHaveBeenCalledWith({
+      subjectUserId: null,
+      state: "pending",
+      action: null,
+      limit: expected,
     });
   });
 });

--- a/packages/agent/src/api/approval-routes.ts
+++ b/packages/agent/src/api/approval-routes.ts
@@ -115,10 +115,13 @@ function isApprovalTaskService(
   );
 }
 
-function parseLimit(raw: string | null): number {
-  if (!raw) return 50;
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) return 50;
+function parseLimit(raw: string | null): number | null {
+  if (raw === null || raw === "") return 50;
+  // Strict decimal digits only. Number.parseInt("1e3", 10) === 1 would
+  // silently under-read a client page size as 1.
+  if (!/^[1-9]\d*$/.test(raw)) return null;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return null;
   return Math.min(parsed, 500);
 }
 
@@ -319,11 +322,16 @@ export async function handleApprovalRoute(
   }
 
   const url = new URL(req.url ?? pathname, "http://localhost");
+  const limit = parseLimit(url.searchParams.get("limit"));
+  if (limit === null) {
+    helpers.error(res, "limit must be a positive integer", 400);
+    return true;
+  }
   const filter: ApprovalListFilter = {
     subjectUserId: null,
     state: parseState(url.searchParams.get("state")),
     action: null,
-    limit: parseLimit(url.searchParams.get("limit")),
+    limit,
   };
 
   const queue = getAgentApprovalQueue(state);


### PR DESCRIPTION
Fixes #20535.

# Relates to

`GET /api/approvals?limit=` accepted malformed query spellings through `Number.parseInt`, producing plausible successful responses from invalid input.

Definition of Done: full standard in CONTRIBUTING.md.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
- [x] Focused tests, package typecheck, and affected-file Biome checks were rerun after synchronization
- [x] A reviewer can confirm the fail-closed behavior from the table-driven handler tests

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
- AI provider/model: xAI / grok-4.6; OpenAI / gpt-5.6-sol
<!-- attribution-row:models -->
- Model(s) used: `xAI / grok-4.6; OpenAI / gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Grok Build CLI; Claude Code via CLIProxyAPI`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - operator-bounded parser repair; no measured public skill run`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

Rebased onto `origin/develop` at `c4016a6c46c0272db2b4f77d083304360c17205e` immediately before final proof. Exact candidate head: `fbdd4ff4572acab5a63f3d3436307c76577cc1ba`.

# Risks

Low and fail-closed. Only a present malformed `limit` changes behavior, from a successful coerced/default list response to HTTP 400. Omitted or empty `limit` still defaults to 50, valid positive decimal values still list, values above 500 still clamp to 500, and `state` filtering is unchanged.

# Background

## What does this PR do?

`GET /api/approvals` used `Number.parseInt` on an untrusted query value. Inputs such as `1e3`, `50abc`, `50.5`, `+5`, and `1_000` were partially parsed, while `abc`, `NaN`, `Infinity`, `0`, and `-1` silently became the healthy default 50.

The route now requires a strict positive decimal integer whenever `limit` is present and returns HTTP 400 before calling the approval queue for malformed values.

## What kind of change is this?

Bug fix: untrusted query-parser hardening.

# Documentation changes needed?

No. The route and its handler tests define this narrow API boundary.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/approval-routes.test.ts`, especially the table-driven malformed and valid `limit` cases.

## Detailed testing steps

```bash
bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/api/approval-routes.test.ts --coverage.enabled=false
bun run --cwd packages/agent typecheck
bunx @biomejs/biome check packages/agent/src/api/approval-routes.ts packages/agent/src/api/approval-routes.test.ts
```

Results at exact head `fbdd4ff4572acab5a63f3d3436307c76577cc1ba`:

- focused handler suite: **27 passed**;
- package typecheck: **passed**;
- affected-file Biome: **passed**;
- `git diff --check`: clean;
- clean worktree with one authored commit;
- live ownership refresh: neither target path is touched by another open PR.

# Evidence Gate

<!-- evidence-head:a9843a7aff03ae007c3119c42b217b2ffcdc0bc4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI/layout change; handler-only query parser
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI/layout change; handler-only query parser
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend-testable visual flow; API query validation only
<!-- evidence-row:backend-logs -->
- [x] [20546-pr20546-verify.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20546-pr20546-verify.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path changed
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model path changed
<!-- evidence-row:domain-artifacts -->
- [x] [20546-pr20546-validation-a9843a7a.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20546-pr20546-validation-a9843a7a.md)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface

# Evidence Details

## Real LLM-call trajectory

N/A - no model path.

## Backend + frontend logs

N/A - the focused Vitest suite exercises the real `handleApprovalRoute` boundary with the existing runtime harness.

# Known gaps / failures

None in the affected scope. The full monorepo suite was not run for this two-file route-parser change; the package-level typecheck and focused route suite passed on the exact rebased head.

<!-- elizaos-contribution-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code via CLIProxyAPI","attribution":"self-reported"} -->

