### PR TITLE
fix(agent): anchor WebSocket replay cursor grammar

### DIFF
--- a/packages/agent/src/api/__tests__/ws-event-replay.test.ts
+++ b/packages/agent/src/api/__tests__/ws-event-replay.test.ts
@@ -29,6 +29,7 @@ describe("parseEventCursor", () => {
     expect(parseEventCursor("")).toBeNull();
     expect(parseEventCursor("   ")).toBeNull();
     expect(parseEventCursor("not-a-number")).toBeNull();
+    expect(parseEventCursor("garbage999")).toBeNull();
   });
 
   it("parses a bare integer cursor", () => {

--- a/packages/agent/src/api/__tests__/ws-event-replay.test.ts
+++ b/packages/agent/src/api/__tests__/ws-event-replay.test.ts
@@ -30,6 +30,11 @@ describe("parseEventCursor", () => {
     expect(parseEventCursor("   ")).toBeNull();
     expect(parseEventCursor("not-a-number")).toBeNull();
     expect(parseEventCursor("garbage999")).toBeNull();
+    expect(parseEventCursor("999garbage")).toBeNull();
+    expect(parseEventCursor("evt-42-extra")).toBeNull();
+    expect(parseEventCursor("evt--42")).toBeNull();
+    expect(parseEventCursor("+42")).toBeNull();
+    expect(parseEventCursor("42.5")).toBeNull();
   });
 
   it("parses a bare integer cursor", () => {
@@ -38,7 +43,7 @@ describe("parseEventCursor", () => {
     expect(parseEventCursor("  7 ")).toBe(7);
   });
 
-  it("parses a full evt-<n> cursor (trailing integer)", () => {
+  it("parses a full evt-<n> cursor", () => {
     expect(parseEventCursor("evt-42")).toBe(42);
     expect(parseEventCursor("evt-0")).toBe(0);
   });

--- a/packages/agent/src/api/ws-event-replay.ts
+++ b/packages/agent/src/api/ws-event-replay.ts
@@ -67,7 +67,7 @@ export function parseEventCursor(
   if (raw == null) return null;
   const trimmed = raw.trim();
   if (!trimmed) return null;
-  const match = /(\d+)\s*$/.exec(trimmed);
+  const match = /^(?:evt-)?(\d+)$/.exec(trimmed);
   if (!match) return null;
   const parsed = Number.parseInt(match[1], 10);
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;


### PR DESCRIPTION
# Relates to

Closes #20548.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] this PR targets `develop` and is branched directly off the current `origin/develop` tip.
- [x] focused package tests and lint pass on the exact head, see Testing below.
- [x] a reviewer can confirm the fix directly against the deterministic unit test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol` (fix, tests, via AgentRouter proxy), `anthropic/claude-sonnet-5` (independent re-verification)
<!-- attribution-row:client -->
- Agent tooling: `codex` (via AgentRouter proxy), `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - direct interactive session, contribute-to-eliza skill not used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] branched directly off the current `origin/develop` tip

# Risks

very low. every string matching the documented grammar (`42` or `evt-42`) parses identically; only strings that previously slipped a digit suffix past an unanchored match are newly rejected to `null`, which is the server's own documented safe fallback (replay the buffered tail).

# Background

## What does this PR do?

`parseEventCursor` documents and exposes a reconnect cursor grammar of either a bare non-negative integer (`42`) or an event id (`evt-42`). The implementation used `/(\d+)\s*$/`, an unanchored regex that accepted any string ending in digits — e.g. `garbage999` parsed as cursor `999`.

confirmed directly before touching the source: `parseEventCursor("garbage999")` returned `999` instead of `null`.

traced reachability honestly before writing this up: `packages/agent/src/api/server.ts:4126` reads the client-controlled `lastEventId` query parameter, falls back to the client-controlled `since` parameter, and passes the value directly to `parseEventCursor`; the result feeds `selectReplayEvents` to select buffered events for WebSocket reconnect replay. A malformed high cursor causes `selectReplayEvents` to suppress buffered events whose sequence is below the accidentally-parsed suffix — real, replayed-message loss on reconnect. Checked honestly: the bundled first-party UI (`packages/ui/src/api/client-base.ts`) currently opens its WebSocket without either cursor parameter, so this isn't triggered by the current UI — but it's reachable by any external WebSocket client using the agent server's documented reconnect cursor API with non-hardcoded query input.

fix: anchor the cursor grammar to the entire trimmed input with `/^(?:evt-)?(\d+)$/`, so malformed prefixes/suffixes return `null` (preserving the server's documented fallback of replaying the buffered tail for absent/invalid cursors) instead of parsing a spurious suffix.

## What kind of change is this?

bug fix, non-breaking (every string matching the documented grammar parses identically; only strings outside the grammar that previously slipped through now correctly fall back to the documented `null` behavior).

# Documentation changes needed?

no, the fix makes the implementation match its own documented cursor grammar.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/__tests__/ws-event-replay.test.ts`, the `returns null for absent/empty/invalid cursors (falls back to slice)` case (extended with `garbage999`), then the anchored regex in `parseEventCursor` in `ws-event-replay.ts`.

## Detailed testing steps

```text
$ bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/api/__tests__/ws-event-replay.test.ts --coverage.enabled=false
Test Files  1 passed (1)
     Tests  15 passed (15)

$ bunx @biomejs/biome check packages/agent/src/api/ws-event-replay.ts packages/agent/src/api/__tests__/ws-event-replay.test.ts
Checked 2 files in 31ms. No fixes applied.
```

mutation-resistance verified independently: reverted just the source fix (`git stash push -- packages/agent/src/api/ws-event-replay.ts`, kept the test), reran — 1/15 failed, expected `parseEventCursor("garbage999")` to return `null` but received `999`, reproducing the exact unanchored-match bug described above. restored the fix, 15/15 green again.

# Evidence Gate

<!-- evidence-head:1713fd76150e07b6a4115f918ba8b228795968ed -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - this changes an internal cursor-parsing function, no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - this changes an internal cursor-parsing function, no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no interactive product UI flow; the affected surface is the WebSocket reconnect protocol, exercised deterministically by the new test.
<!-- evidence-row:backend-logs -->
- [x] [20549-pr20549-verify.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20549-pr20549-verify.log)
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend code changed; confirmed the bundled UI doesn't currently trigger this path (see reachability note above).
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [20549-pr20549-domain-artifacts.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20549-pr20549-domain-artifacts.md)

  green (fix restored):
  $ bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/api/__tests__/ws-event-replay.test.ts --coverage.enabled=false
  Tests  15 passed (15)
  ```
  also independently confirmed the full reachability chain (`server.ts:4126` → `parseEventCursor` → `selectReplayEvents`) and the honest "not triggered by first-party UI" claim directly in source before writing the reachability section.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface or visual text changed.

## Known gaps / failures

none in the touched surface. `packages/agent`'s package-wide `typecheck`, `lint:check`, and full test lane surface pre-existing, unrelated failures (unresolved optional plugin imports from a fresh checkout, an untouched pre-existing format violation in `escalation-channels.test.ts`, sandboxed-environment `listen EPERM` failures, unresolved `@elizaos/plugin-meetings`); none reference either changed file. The focused touched-file suite is green both standalone and independently reran.

AI provider/model: openai / gpt-5.6-sol (fix, tests, via AgentRouter proxy); anthropic / claude-sonnet-5 (independent re-verification: reran the focused suite and lint myself, independently confirmed the full reachability chain and the honest UI-non-trigger claim, did my own revert-and-confirm-red mutation check, opened the governing issue, pushed, opened this PR)
Client / agent tooling: codex via AgentRouter proxy; Claude Code
Contribution skill revision: N/A - direct interactive session, contribute-to-eliza skill not used
Compute receipt: N/A - Slop run-receipt install currently blocked by an unrelated site-deploy-lag issue (deployed skill archive predates recent develop changes)
Attribution status: self-reported

