### PR TITLE
fix(cloud): reject malformed docker-container list limits

### DIFF
--- a/packages/cloud/api/v1/admin/docker-containers/route.test.ts
+++ b/packages/cloud/api/v1/admin/docker-containers/route.test.ts
@@ -1,6 +1,7 @@
 /**
  * Proves the super-admin container inventory exposes the authoritative image
- * digest needed to construct an exact canary compare-and-swap request.
+ * digest needed to construct an exact canary compare-and-swap request, and
+ * that untrusted `limit` query values fail closed before any inventory query.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -12,6 +13,7 @@ const requireAdmin = mock(async () => ({
 }));
 const getStewardAgent = mock(async () => null);
 const selectedContainerFields: string[] = [];
+const appliedLimits: number[] = [];
 const SOURCE_DIGEST = `sha256:${"a".repeat(64)}`;
 
 const dbRead = {
@@ -58,7 +60,10 @@ const dbRead = {
       from: () => ({
         where: () => ({
           orderBy: () => ({
-            limit: async () => [projected],
+            limit: async (value: number) => {
+              appliedLimits.push(value);
+              return [projected];
+            },
           }),
         }),
       }),
@@ -83,6 +88,7 @@ describe("super-admin Docker container inventory", () => {
     getStewardAgent.mockClear();
     dbRead.select.mockClear();
     selectedContainerFields.length = 0;
+    appliedLimits.length = 0;
   });
 
   test("returns the persisted image digest used by canary source CAS", async () => {
@@ -105,5 +111,56 @@ describe("super-admin Docker container inventory", () => {
         returned: 1,
       },
     });
+  });
+
+  test.each([
+    ["omitted", "/", 100],
+    ["empty", "/?limit=", 100],
+    ["one", "/?limit=1", 1],
+    ["canonical", "/?limit=25", 25],
+    ["max", "/?limit=500", 500],
+    ["oversize clamp", "/?limit=501", 500],
+  ] as const)(
+    "accepts %s limit and forwards a finite page size",
+    async (_label, path, expected) => {
+      const response = await app.request(path);
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        success: boolean;
+        data: { filters: { limit: number } };
+      };
+      expect(body.success).toBe(true);
+      expect(body.data.filters.limit).toBe(expected);
+      expect(appliedLimits).toEqual([expected]);
+      expect(dbRead.select).toHaveBeenCalled();
+    },
+  );
+
+  test.each([
+    ["1e9", "scientific notation that parseInt truncates to 1"],
+    ["10abc", "trailing junk that parseInt accepts as 10"],
+    ["0x10", "hex that parseInt(…, 10) truncates to 0"],
+    ["0100", "leading zeros"],
+    ["+25", "plus sign"],
+    ["-5", "signed negative"],
+    ["25.0", "decimal that parseInt truncates"],
+    [" 25", "leading whitespace"],
+    ["25 ", "trailing whitespace"],
+    ["0", "zero"],
+    ["Infinity", "Infinity"],
+    ["NaN", "NaN"],
+    [" ", "whitespace only"],
+    ["1_00", "separator"],
+    ["9007199254740992", "above safe integer"],
+  ] as const)("rejects %s (%s) before any inventory query", async (raw) => {
+    const response = await app.request(`/?limit=${encodeURIComponent(raw)}`);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: "Invalid limit",
+      code: "validation_error",
+    });
+    expect(dbRead.select).not.toHaveBeenCalled();
+    expect(appliedLimits).toEqual([]);
   });
 });

--- a/packages/cloud/api/v1/admin/docker-containers/route.ts
+++ b/packages/cloud/api/v1/admin/docker-containers/route.ts
@@ -25,6 +25,27 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 const app = new Hono<AppEnv>();
 
 const STEWARD_ENRICHMENT_CONCURRENCY = 5;
+const DEFAULT_CONTAINER_LIST_LIMIT = 100;
+const MAX_CONTAINER_LIST_LIMIT = 500;
+
+/**
+ * Strict positive-decimal `limit` for the inventory query. Absent/empty keep
+ * the documented default. Prefix-coercible garbage (`1e9`, `10abc`, `-5`)
+ * must not reach Drizzle as NaN or a silently truncated page size.
+ */
+function parseContainerListLimit(raw: string | undefined): number {
+  if (raw === undefined || raw === "") {
+    return DEFAULT_CONTAINER_LIST_LIMIT;
+  }
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw ValidationError("Invalid limit");
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw ValidationError("Invalid limit");
+  }
+  return Math.min(parsed, MAX_CONTAINER_LIST_LIMIT);
+}
 
 async function mapWithConcurrency<T, R>(
   items: T[],
@@ -54,7 +75,7 @@ app.get("/", async (c) => {
 
     const statusFilter = c.req.query("status");
     const nodeFilter = c.req.query("nodeId");
-    const limit = Math.min(parseInt(c.req.query("limit") || "100", 10), 500);
+    const limit = parseContainerListLimit(c.req.query("limit"));
 
     const conditions: SQL[] = [isNotNull(agentSandboxes.node_id)];
 


### PR DESCRIPTION
# Relates to

Fixes #20537

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused route tests, Cloud API typecheck/worker bundle, package lint, and root verification were rerun after sync; the unrelated root lint failure is recorded below.
- [x] A reviewer can confirm the boundary behavior from the focused route proof below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
- AI provider/model: xAI / grok-4.6; OpenAI / gpt-5.6-sol
<!-- attribution-row:models -->
- Model(s) used: xAI / grok-4.6; OpenAI / gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Grok Build CLI; Claude Code via CLIProxyAPI
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@8107a23a8b761e76a81d96262bf11a7469f824d3:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased onto `origin/develop` at `c4016a6c46c0272db2b4f77d083304360c17205e`; zero conflicts.
- [x] Exact candidate head: `4ffad2ad71be7c5192fa60fcf2da0c6f0bb066ea`.
- [x] Focused and package checks pass post-sync; root `bun run verify` reaches an unrelated existing `@elizaos/core` Biome failure documented below.

# Risks

Low. This changes only one super-admin inventory query parser. Omitted/empty input still defaults to 100, canonical positive integers remain valid, and values above 500 retain the existing clamp. The main compatibility risk is a caller that relied on malformed prefix coercion; rejecting that input is the intended fix.

# Background

## What does this PR do?

Replaces prefix-coercing `parseInt` handling for `GET /api/v1/admin/docker-containers?limit=` with a strict positive-decimal parser. Malformed tokens now return `400 validation_error` before any inventory query. Accepted values are canonicalized to a safe integer and clamped to the existing maximum of 500.

The focused route suite adds adversarial tables for omitted/empty/default, legal endpoints, the oversize clamp, scientific notation, trailing junk, hex, leading zeros, signs, fractions, whitespace, zero, non-finite strings, separators, and an integer above JavaScript's safe range.

## What kind of change is this?

Bug fix (non-breaking hardening of an untrusted query boundary).

# Documentation changes needed?

No. The endpoint behavior and existing default/maximum are preserved; malformed values now fail closed.

# Testing

## Where should a reviewer start?

- `packages/cloud/api/v1/admin/docker-containers/route.ts`
- `packages/cloud/api/v1/admin/docker-containers/route.test.ts`

## Detailed testing steps

```bash
bun install --frozen-lockfile
bun test packages/cloud/api/v1/admin/docker-containers/route.test.ts
bun run --cwd packages/cloud/api typecheck
bun run --cwd packages/cloud/api lint:check
bun run verify
```

Expected focused result:

```text
22 pass
0 fail
94 expect() calls
```

# Evidence Gate

<!-- evidence-head:4ffad2ad71be7c5192fa60fcf2da0c6f0bb066ea -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only query parsing; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only query parsing; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no visual or interactive frontend flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no live Cloud deployment was authorized; the real Hono route parser is exercised locally with mocked auth and database collaborators.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network client behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head focused route proof:

```text
bun test packages/cloud/api/v1/admin/docker-containers/route.test.ts
22 pass, 0 fail, 94 expect() calls
Accepted values forward the exact finite page size; malformed values return 400 validation_error before dbRead.select.
```

<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface or visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, prompt, provider, or model behavior changed.

## Backend + frontend logs

Backend live logs: N/A - no deployment or live Cloud mutation was authorized.

Deterministic route-boundary proof at exact head `4ffad2ad71be7c5192fa60fcf2da0c6f0bb066ea`:

```text
bun test packages/cloud/api/v1/admin/docker-containers/route.test.ts
22 pass
0 fail
94 expect() calls
```

The invalid-input table asserts `400`, `code: validation_error`, no `dbRead.select` call, and no forwarded limit. The accepted-input table asserts `200` and the exact finite value passed to Drizzle.

Package and repository checks:

```text
bun run --cwd packages/cloud/api typecheck
# tsc --noEmit: passed
# wrangler production dry-run bundle: passed

bun run --cwd packages/cloud/api lint:check
# 1101 files checked, no fixes

bun run verify
# failed outside this PR in @elizaos/core#lint:check: five pre-existing Biome
# formatting/import-order findings in facts.ts, message-handler tests, and message.ts

git diff --check
# clean
```

## Screenshots (before / after) + video walkthrough

N/A - backend-only query parsing; no visual surface.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice behavior changed.

## Known gaps / failures

The broad isolated Cloud API suite was not rerun after the final rebase; an earlier equivalent candidate reported seven unrelated existing failures outside this two-file diff.

Current exact-head root `bun run verify` fails in `@elizaos/core#lint:check` on five pre-existing Biome formatting/import-order findings in `packages/core/src/features/advanced-capabilities/providers/facts.ts`, `packages/core/src/runtime/__tests__/message-handler-output.test.ts`, `packages/core/src/runtime/__tests__/message-handler.test.ts`, and `packages/core/src/services/message.ts`. This PR touches none of those paths.

The owning focused route suite, Cloud API typecheck plus Wrangler production dry-run, package lint, and exact-head proof all pass.

AI provider/model: xAI / grok-4.6; OpenAI / gpt-5.6-sol
Client / agent tooling: Grok Build CLI; Claude Code via CLIProxyAPI
Contribution skill revision: elizaOS/eliza@8107a23a8b761e76a81d96262bf11a7469f824d3:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [sol-eliza-docker-limit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code via CLIProxyAPI","skill_revision":"elizaOS/eliza@8107a23a8b761e76a81d96262bf11a7469f824d3:packages/skills/skills/contribute-to-eliza"} -->
