### PR TITLE
fix(voice): stop the robotic first-reply voice on cloud-only builds (#20483)

### DIFF
--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -35,6 +35,7 @@ import {
   type TalkModeStateEvent,
   type TalkModeTranscriptEvent,
 } from "../bridge/native-plugins";
+import { useBranding } from "../config/branding";
 import { APP_PAUSE_EVENT } from "../events";
 import { resolveApiUrl } from "../utils";
 import { getElizaApiToken } from "../utils/eliza-globals";
@@ -392,12 +393,19 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
     }
   });
 
+  // Cloud-only branding makes Eliza Cloud the only possible voice backend, so
+  // the resolver must not leave the provider unset while the async
+  // cloud-status poll (options.cloudConnected) is still warming — that window
+  // is what routed the first replies of a session to the robotic browser
+  // speechSynthesis voice on cloud-only consumer builds.
+  const { cloudOnly: brandingCloudOnly } = useBranding();
   const effectiveVoiceConfig = useMemo(
     () =>
       resolveEffectiveVoiceConfig(options.voiceConfig, {
         cloudConnected: options.cloudConnected,
+        cloudOnly: brandingCloudOnly === true,
       }),
-    [options.cloudConnected, options.voiceConfig],
+    [options.cloudConnected, options.voiceConfig, brandingCloudOnly],
   );
 
   const assistantTtsQuality = useMemo((): "enhanced" | "standard" => {

--- a/packages/ui/src/voice/voice-chat-types.cloud-only-default.test.ts
+++ b/packages/ui/src/voice/voice-chat-types.cloud-only-default.test.ts
@@ -1,0 +1,73 @@
+/** Verifies resolveEffectiveVoiceConfig — cloud-only provider default through the package's configured test harness. */
+import { describe, expect, it } from "vitest";
+import type { VoiceConfig } from "../api/client-types-config";
+import { resolveEffectiveVoiceConfig } from "./voice-chat-types";
+
+/**
+ * Regression coverage for the cloud-only robot-voice window (#20483 follow-up).
+ *
+ * On a cloud-only consumer build the ONLY possible voice backend is Eliza
+ * Cloud, but the resolver's `eliza-cloud` default was gated on
+ * `cloudConnected` — an async status poll whose first success can trail the
+ * first assistant replies by several turns (the worker's auth cache warms with
+ * 503s on a cold session). During that window the provider resolved to
+ * undefined, processQueue fell through to browser speechSynthesis, and the
+ * user heard the robotic OS voice — sneaking past the #12253 fail-closed rule,
+ * which only guards failures AFTER a provider is chosen.
+ *
+ * The fix: `cloudOnly: true` (from branding) makes the resolver default both
+ * TTS and ASR to `eliza-cloud` immediately, without waiting for the poll.
+ * Explicit stored providers are still respected, and non-cloud-only builds
+ * keep the poll-gated behavior unchanged.
+ */
+describe("resolveEffectiveVoiceConfig — cloud-only provider default", () => {
+  it("defaults TTS + ASR to eliza-cloud on cloudOnly builds even before the status poll (the fix)", () => {
+    const config: VoiceConfig = {}; // fresh install: no provider, no asr
+
+    const resolved = resolveEffectiveVoiceConfig(config, {
+      cloudConnected: false, // poll still warming — the robot-voice window
+      cloudOnly: true,
+    });
+
+    expect(resolved).not.toBeNull();
+    expect(resolved?.provider).toBe("eliza-cloud");
+    expect(resolved?.asr?.provider).toBe("eliza-cloud");
+  });
+
+  it("upgrades a stored robot-voice provider on cloudOnly builds", () => {
+    const config: VoiceConfig = { provider: "robot-voice" };
+
+    const resolved = resolveEffectiveVoiceConfig(config, {
+      cloudConnected: false,
+      cloudOnly: true,
+    });
+
+    expect(resolved?.provider).toBe("eliza-cloud");
+  });
+
+  it("still respects an explicit stored provider on cloudOnly builds", () => {
+    const config: VoiceConfig = {
+      provider: "elevenlabs",
+      elevenlabs: { voiceId: "abc" },
+    };
+
+    const resolved = resolveEffectiveVoiceConfig(config, {
+      cloudConnected: false,
+      cloudOnly: true,
+    });
+
+    expect(resolved?.provider).toBe("elevenlabs");
+  });
+
+  it("keeps the poll-gated behavior unchanged when cloudOnly is not set", () => {
+    const config: VoiceConfig = {};
+
+    const resolved = resolveEffectiveVoiceConfig(config, {
+      cloudConnected: false,
+    });
+
+    // No provider resolvable — downstream defaults (pickDefaultVoiceProvider)
+    // still own the non-cloud-only case.
+    expect(resolved).toBeNull();
+  });
+});

--- a/packages/ui/src/voice/voice-chat-types.ts
+++ b/packages/ui/src/voice/voice-chat-types.ts
@@ -491,7 +491,13 @@ export function resolveEffectiveVoiceConfig(
       })
     | null
     | undefined,
-  options?: { cloudConnected?: boolean },
+  options?: {
+    cloudConnected?: boolean;
+    /** Cloud-only distribution (branding.cloudOnly): Eliza Cloud is the only
+     *  possible voice backend, so default to it without waiting on the async
+     *  cloud-status poll. */
+    cloudOnly?: boolean;
+  },
 ):
   | (VoiceConfig & {
       provider?: VoiceConfig["provider"] | "openai";
@@ -503,6 +509,19 @@ export function resolveEffectiveVoiceConfig(
     })
   | null {
   const cloudConnected = options?.cloudConnected === true;
+  // Cloud-only distribution (branding.cloudOnly): Eliza Cloud is the ONLY
+  // voice this build can ever use, so the provider must not wait on the async
+  // cloud-status poll that feeds `cloudConnected`. Without this, the first
+  // replies after a cold boot resolved NO provider (the status poll and the
+  // worker's auth cache were still warming), fell through processQueue's
+  // terminal default, and played in the browser's robotic speechSynthesis
+  // voice — sneaking past the #12253 fail-closed rule, which only guards
+  // failures AFTER a provider is chosen. Defaulting to `eliza-cloud` up front
+  // routes those first turns through speakElizaCloud, whose own retry +
+  // fail-closed handling produces either the real voice or a visible error —
+  // never a silent voice swap.
+  const cloudIsOnlyVoice = options?.cloudOnly === true;
+  const preferCloudVoice = cloudConnected || cloudIsOnlyVoice;
   const base = cloneVoiceConfig(config) ?? {};
   const rawProvider = base.provider as
     | VoiceConfig["provider"]
@@ -512,14 +531,15 @@ export function resolveEffectiveVoiceConfig(
   let provider: VoiceConfig["provider"] | undefined =
     (hasLegacyOpenAiProvider ? undefined : rawProvider) ??
     (base.elevenlabs ? "elevenlabs" : base.edge ? "edge" : undefined) ??
-    (cloudConnected ? "eliza-cloud" : undefined);
+    (preferCloudVoice ? "eliza-cloud" : undefined);
 
   if (
-    cloudConnected &&
+    preferCloudVoice &&
     (hasLegacyOpenAiProvider || provider === "robot-voice")
   ) {
     ttsDebug("voiceConfig:upgrade_provider_for_cloud", {
       fromProvider: hasLegacyOpenAiProvider ? "openai" : provider,
+      viaCloudOnlyBranding: cloudIsOnlyVoice && !cloudConnected,
     });
     provider = "eliza-cloud";
   }
@@ -541,7 +561,7 @@ export function resolveEffectiveVoiceConfig(
   // local/desktop defaults keep resolving through `pickDefaultVoiceProvider`.
   const resolvedAsr: VoiceConfig["asr"] | undefined = base.asr?.provider
     ? base.asr
-    : cloudConnected
+    : preferCloudVoice
       ? { ...(base.asr ?? {}), provider: "eliza-cloud" }
       : base.asr;
 


### PR DESCRIPTION
## Why

User-reported on the cloud-only consumer build (#20483 line of work): *"on first few attempts instead of cloud voice it uses local robotic system voice."* The first spoken replies after a cold boot played in the browser's robotic `speechSynthesis` voice, then later replies switched to the proper Eliza Cloud (Kokoro) voice.

## Root cause

The voice engine picks its backend from `voiceConfig.provider`, and `resolveEffectiveVoiceConfig` only defaults an unset provider to `eliza-cloud` when `cloudConnected` is true:

```
provider = rawProvider ?? … ?? (cloudConnected ? "eliza-cloud" : undefined)
```

But `cloudConnected` isn't the sign-in state — it's `elizaCloudConnected && elizaCloudVoiceProxyAvailable`, fed by an **async status poll** (`pollCloudCredits` → `getCloudStatus()` → a live `GET /api/v1/user` round trip). On a cold session that poll's first success trails the first assistant replies (the worker's auth cache warms with 503s — the same warmup family as #20515's STT fix). Timeline:

```
boot → signed in, chat works → [status poll still warming]
           │
  first replies arrive HERE          later replies arrive HERE
           │                                   │
  provider = undefined                provider = "eliza-cloud"
           │                                   │
  processQueue falls through          speakElizaCloud → Kokoro ✓
  to terminal speakBrowser →
  OS speechSynthesis = 🤖
```

The existing **#12253 fail-closed rule** ("never silently swap the configured cloud voice for the robot voice") never fires here because it only guards failures *after* a provider is chosen — the unresolved-provider window walks right past it.

## Fix

`resolveEffectiveVoiceConfig` gains a `cloudOnly` option, wired from `branding.cloudOnly` inside `useVoiceChat` (one seam, covers every call site). On a cloud-only build, Eliza Cloud is the *only possible* voice backend, so there is nothing to wait for: both TTS and ASR default to `eliza-cloud` immediately. First replies now route through `speakElizaCloud`, whose own retry + fail-closed handling produces the real voice or a visible error — never a silent voice swap.

- Explicit stored providers (e.g. ElevenLabs) are still respected.
- A stored legacy `robot-voice` provider is upgraded on cloud-only builds.
- Non-cloud-only builds keep the poll-gated behavior byte-for-byte (pinned by the new test's null case).

## Verification

- New `voice-chat-types.cloud-only-default.test.ts` (4 cases: the fix, robot-voice upgrade, explicit-provider respect, non-cloud-only unchanged) + existing ASR-default suite: 10/10.
- Wider `packages/ui` hooks/voice/shell suites: **1950 passed**. Typecheck + Biome clean.
- Packaged cloud-only build (macOS arm64) rebuilt with the fix and boots cleanly. Full first-reply listening validation is by ear — the mechanism change is pinned by the unit tests; the reporter can confirm the robotic voice is gone on their next fresh session.

Advances #20483; sibling of the #20515 STT-warming fix (same cold-session warmup family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
