### PR TITLE
style: repair develop's lint:check baseline — six biome-unformatted files

### DIFF
--- a/packages/agent/src/services/escalation-channels.test.ts
+++ b/packages/agent/src/services/escalation-channels.test.ts
@@ -8,9 +8,7 @@ import { describe, expect, test } from "vitest";
 import type { OwnerContactRoutingHint } from "../config/owner-contacts.ts";
 import { resolveDeliverableChannels } from "./escalation.ts";
 
-const hint = (
-  lastResponseAt: string | null,
-): OwnerContactRoutingHint =>
+const hint = (lastResponseAt: string | null): OwnerContactRoutingHint =>
   ({
     source: "x",
     entityId: null,

--- a/packages/core/src/features/advanced-capabilities/providers/facts.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.ts
@@ -20,7 +20,6 @@
  * and the responding model decides which surfaced preferences apply.
  */
 import { ElizaError } from "../../../errors.ts";
-import { ModelType } from "../../../types/model.ts";
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import { getRelatedEntityIds } from "../../../identity-clusters.ts";
 import type {
@@ -32,6 +31,7 @@ import type {
 	ProviderResult,
 	State,
 } from "../../../types/index.ts";
+import { ModelType } from "../../../types/model.ts";
 import {
 	buildFactQueryText,
 	scoreFactKeywordRelevance,
@@ -446,8 +446,7 @@ const factsProvider: Provider = {
 							...searchedRoom,
 							...searchedEntities.flat(),
 						]).filter(
-							(memory) =>
-								!minimizePrivateFacts || !isMarkedPrivateFact(memory),
+							(memory) => !minimizePrivateFacts || !isMarkedPrivateFact(memory),
 						);
 					}
 				} catch (error) {

--- a/packages/core/src/runtime/__tests__/message-handler-output.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-output.test.ts
@@ -12,7 +12,10 @@ import {
 	replyEffectStatusFieldEvaluator,
 	replyTextFieldEvaluator,
 } from "../builtin-field-evaluators";
-import { parseMessageHandlerOutput, routeMessageHandlerOutput } from "../message-handler";
+import {
+	parseMessageHandlerOutput,
+	routeMessageHandlerOutput,
+} from "../message-handler";
 import { ResponseHandlerFieldRegistry } from "../response-handler-field-registry";
 
 describe("message handler retrieval hint output", () => {

--- a/packages/core/src/runtime/__tests__/message-handler.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler.test.ts
@@ -510,7 +510,8 @@ describe("explicit media-ask promotion", () => {
 		const parsed = parseMessageHandlerOutput(
 			JSON.stringify({
 				shouldRespond: "RESPOND",
-				replyText: "can't do that here. no video generation tools in this setup.",
+				replyText:
+					"can't do that here. no video generation tools in this setup.",
 				contexts: ["simple"],
 				candidateActionNames: [],
 			}),

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -8632,11 +8632,16 @@ export async function runV5MessageRuntimeStage1(args: {
 			getMessageHandlerCandidateActions(messageHandler) ?? []
 		).some((name) => {
 			const candidateName = String(name);
-			const direct = resolveRuntimeAction(stageOneCandidateLookup, candidateName);
+			const direct = resolveRuntimeAction(
+				stageOneCandidateLookup,
+				candidateName,
+			);
 			const resolvedSet = direct
 				? [direct]
 				: parentAliasesForCandidateAction(candidateName)
-						.map((alias) => resolveRuntimeAction(stageOneCandidateLookup, alias))
+						.map((alias) =>
+							resolveRuntimeAction(stageOneCandidateLookup, alias),
+						)
 						.filter((action): action is Action => action !== undefined);
 			return resolvedSet.some((resolved) =>
 				collectedCandidateNames.has(normalizeActionIdentifier(resolved.name)),
@@ -8652,9 +8657,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		const rejectedReminderish =
 			candidateGateDiagnostics.gateRejectedExplicitCandidates.some((name) => {
 				const normalized = normalizeActionIdentifier(name);
-				return (
-					normalized.includes("REMINDER") || normalized.includes("ALARM")
-				);
+				return normalized.includes("REMINDER") || normalized.includes("ALARM");
 			});
 		const ungatedTriggerSiblingAvailable =
 			rejectedReminderish && collectedCandidateNames.has("TRIGGER");

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -2752,9 +2752,7 @@ function taskMatchesSearch(task: TaskThreadDto, search: string): boolean {
   // reads as "no task exists" against a store that plainly holds it (observed
   // live). Every whitespace token present somewhere in the haystack matches.
   const tokens = needle.split(/\s+/).filter((token) => token.length > 0);
-  return (
-    tokens.length > 1 && tokens.every((token) => haystack.includes(token))
-  );
+  return tokens.length > 1 && tokens.every((token) => haystack.includes(token));
 }
 
 function sessionMatchesHistoryFilters(


### PR DESCRIPTION
Closes the repair half of #20523 (the enforcement-point question stays with the maintainers, as the issue frames it).

## What

Six merged PRs (#20514 #20484 #20460 #20511 #20510 #20509) each landed at least one file the pinned biome rejects under `lint:check`, keeping develop's root `bun run verify` continuously red at the `turbo lint:check` stage — every downstream contributor's required pre-PR verify fails on files they never touched.

This is the format-only repair: the pinned `biome check --write` over exactly the six files the issue lists. No semantic changes.

## Verification

- Reproduced first: all six files rejected by `biome check` on current develop before the repair
- Post-repair: all six clean under the pinned biome
- Touched test suites: message-handler 41/41, escalation-channels 4/4, plus (from review) factsProvider 18/18, orchestrator task-history 10/10, core + orchestrator typechecks pass

## Review trail

RP Codex review (exact head `c0540b840`, high reasoning): **APPROVE on round 1** —
- Every head file byte-matches the pinned Biome 2.5.7 output over its develop version; no identifiers, strings, logic, bindings, or config changed
- Scope exact: six files, no others
- Independent runs: 73 tests + two typechecks, all green
- One wording correction accepted: `facts.ts` also includes Biome's `organizeImports` relocation of an unchanged import — formatter-only, not literally wrap-only
- Non-blocking note: `message-runtime-stage1.test.ts` is 138/139 on the **base** as well (extra `TRIGGER` candidate — pre-existing, unrelated to whitespace)

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent"} -->