### PR TITLE
perf(cloud): bound social gateway auth latency

### DIFF
--- a/packages/cloud/api/internal/_auth.ts
+++ b/packages/cloud/api/internal/_auth.ts
@@ -3,7 +3,7 @@ import type { Context } from "hono";
 import { jsonError } from "@/lib/api/cloud-worker-errors";
 import {
   extractBearerToken,
-  verifyInternalToken,
+  verifyInternalRequestToken,
 } from "@/lib/auth/jwt-internal";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -41,7 +41,7 @@ export async function requireInternalAuth(
   }
 
   try {
-    const verified = await verifyInternalToken(token);
+    const verified = await verifyInternalRequestToken(token);
     return {
       podName: verified.payload.sub,
       service: verified.payload.service,

--- a/packages/cloud/api/internal/auth/refresh/route.ts
+++ b/packages/cloud/api/internal/auth/refresh/route.ts
@@ -11,6 +11,7 @@ import { isJWKSConfigured } from "@/lib/auth/jwks";
 import {
   extractBearerToken,
   internalTokenLifetimeForService,
+  isShortLivedGatewayService,
   signInternalToken,
   verifyInternalToken,
 } from "@/lib/auth/jwt-internal";
@@ -38,6 +39,13 @@ app.post("/*", async (c) => {
       service = verified.payload.service;
     } catch {
       return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    // Gateway credentials are deliberately bounded bearer capabilities. They
+    // must return to the bootstrap-secret exchange so a captured token cannot
+    // extend its own replay window through an unbounded refresh chain.
+    if (isShortLivedGatewayService(service)) {
+      return c.json({ error: "gateway_token_rebootstrap_required" }, 403);
     }
 
     const refreshed = await signInternalToken({

--- a/packages/cloud/api/internal/auth/refresh/route.ts
+++ b/packages/cloud/api/internal/auth/refresh/route.ts
@@ -10,6 +10,7 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { isJWKSConfigured } from "@/lib/auth/jwks";
 import {
   extractBearerToken,
+  internalTokenLifetimeForService,
   signInternalToken,
   verifyInternalToken,
 } from "@/lib/auth/jwt-internal";
@@ -39,7 +40,11 @@ app.post("/*", async (c) => {
       return c.json({ error: "Unauthorized" }, 401);
     }
 
-    const refreshed = await signInternalToken({ subject: sub, service });
+    const refreshed = await signInternalToken({
+      subject: sub,
+      service,
+      expiresIn: internalTokenLifetimeForService(service),
+    });
     return c.json(refreshed);
   } catch (err) {
     logger.error("[internal/auth/refresh]", { error: err });

--- a/packages/cloud/api/internal/auth/token/route.test.ts
+++ b/packages/cloud/api/internal/auth/token/route.test.ts
@@ -1,4 +1,4 @@
-/** Proves gateway token exchange and refresh preserve the bounded lifetime. */
+/** Proves short-lived gateway tokens cannot extend their own replay window. */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { generateKeyPairSync } from "node:crypto";
@@ -65,11 +65,30 @@ describe("bounded gateway JWT lifetime", () => {
     });
   });
 
-  test("refreshes discord gateway tokens without widening their lifetime", async () => {
+  test.each(["webhook-gateway", "discord-gateway"])(
+    "rejects self-refresh for %s tokens",
+    async (service) => {
+      const original = await signInternalToken({
+        subject: `${service}-test`,
+        service,
+        expiresIn: GATEWAY_TOKEN_LIFETIME_SECONDS,
+      });
+      const response = await refreshApp.request("/", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${original.access_token}` },
+      });
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toEqual({
+        error: "gateway_token_rebootstrap_required",
+      });
+    },
+  );
+
+  test("ordinary internal tokens retain authenticated rotation", async () => {
     const original = await signInternalToken({
-      subject: "gateway-discord-test",
-      service: "discord-gateway",
-      expiresIn: GATEWAY_TOKEN_LIFETIME_SECONDS,
+      subject: "ordinary-service-test",
+      service: "ordinary-service",
     });
     const response = await refreshApp.request("/", {
       method: "POST",
@@ -77,9 +96,5 @@ describe("bounded gateway JWT lifetime", () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toMatchObject({
-      token_type: "Bearer",
-      expires_in: GATEWAY_TOKEN_LIFETIME_SECONDS,
-    });
   });
 });

--- a/packages/cloud/api/internal/auth/token/route.test.ts
+++ b/packages/cloud/api/internal/auth/token/route.test.ts
@@ -1,0 +1,85 @@
+/** Proves gateway token exchange and refresh preserve the bounded lifetime. */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { generateKeyPairSync } from "node:crypto";
+import {
+  GATEWAY_TOKEN_LIFETIME_SECONDS,
+  signInternalToken,
+} from "@/lib/auth/jwt-internal";
+
+const { publicKey, privateKey } = generateKeyPairSync("ec", {
+  namedCurve: "P-256",
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs8", format: "pem" },
+});
+const originalEnv = {
+  privateKey: process.env.JWT_SIGNING_PRIVATE_KEY,
+  publicKey: process.env.JWT_SIGNING_PUBLIC_KEY,
+  keyId: process.env.JWT_SIGNING_KEY_ID,
+};
+
+beforeAll(() => {
+  process.env.JWT_SIGNING_PRIVATE_KEY =
+    Buffer.from(privateKey).toString("base64");
+  process.env.JWT_SIGNING_PUBLIC_KEY =
+    Buffer.from(publicKey).toString("base64");
+  process.env.JWT_SIGNING_KEY_ID = "gateway-lifetime-test";
+});
+
+afterAll(() => {
+  if (originalEnv.privateKey === undefined)
+    delete process.env.JWT_SIGNING_PRIVATE_KEY;
+  else process.env.JWT_SIGNING_PRIVATE_KEY = originalEnv.privateKey;
+  if (originalEnv.publicKey === undefined)
+    delete process.env.JWT_SIGNING_PUBLIC_KEY;
+  else process.env.JWT_SIGNING_PUBLIC_KEY = originalEnv.publicKey;
+  if (originalEnv.keyId === undefined) delete process.env.JWT_SIGNING_KEY_ID;
+  else process.env.JWT_SIGNING_KEY_ID = originalEnv.keyId;
+});
+
+const { default: tokenApp } = await import("./route");
+const { default: refreshApp } = await import("../refresh/route");
+
+describe("bounded gateway JWT lifetime", () => {
+  test("issues webhook gateway tokens for exactly one minute", async () => {
+    const response = await tokenApp.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Gateway-Secret": "bootstrap-test-secret",
+        },
+        body: JSON.stringify({
+          pod_name: "gateway-webhook-test",
+          service: "webhook-gateway",
+        }),
+      },
+      { GATEWAY_BOOTSTRAP_SECRET: "bootstrap-test-secret" } as never,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      token_type: "Bearer",
+      expires_in: GATEWAY_TOKEN_LIFETIME_SECONDS,
+    });
+  });
+
+  test("refreshes discord gateway tokens without widening their lifetime", async () => {
+    const original = await signInternalToken({
+      subject: "gateway-discord-test",
+      service: "discord-gateway",
+      expiresIn: GATEWAY_TOKEN_LIFETIME_SECONDS,
+    });
+    const response = await refreshApp.request("/", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${original.access_token}` },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      token_type: "Bearer",
+      expires_in: GATEWAY_TOKEN_LIFETIME_SECONDS,
+    });
+  });
+});

--- a/packages/cloud/api/internal/auth/token/route.ts
+++ b/packages/cloud/api/internal/auth/token/route.ts
@@ -10,7 +10,10 @@ import { createHash, timingSafeEqual } from "node:crypto";
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { isJWKSConfigured } from "@/lib/auth/jwks";
-import { signInternalToken } from "@/lib/auth/jwt-internal";
+import {
+  internalTokenLifetimeForService,
+  signInternalToken,
+} from "@/lib/auth/jwt-internal";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -48,7 +51,11 @@ app.post("/*", async (c) => {
     const service =
       typeof body.service === "string" ? body.service.trim() : undefined;
 
-    const token = await signInternalToken({ subject, service });
+    const token = await signInternalToken({
+      subject,
+      service,
+      expiresIn: internalTokenLifetimeForService(service),
+    });
     return c.json(token);
   } catch (err) {
     logger.error("[internal/auth/token]", { error: err });

--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -289,8 +289,8 @@ interface TokenResponse {
 
 /** Percentage of token lifetime at which to refresh. */
 const TOKEN_REFRESH_PERCENTAGE = 0.8;
-/** Bounded retry cadence keeps a transient bootstrap failure from stranding renewal. */
-const TOKEN_REFRESH_RETRY_MS = 1_000;
+const TOKEN_REFRESH_RETRY_MIN_MS = 1_000;
+const TOKEN_REFRESH_RETRY_MAX_MS = 30_000;
 
 interface BotConnection {
   connectionId: string;
@@ -386,6 +386,9 @@ export class GatewayManager {
   private heartbeatInterval: NodeJS.Timeout | null = null;
   private failoverInterval: NodeJS.Timeout | null = null;
   private tokenRefreshTimeout: NodeJS.Timeout | null = null;
+  private tokenRefreshRetryAttempt = 0;
+  /** Invalidates auth work that outlives shutdown. */
+  private authLifecycleGeneration = 0;
   private voiceHandler: VoiceMessageHandler;
   private readonly routingAdapters: GatewayManagerRoutingAdapters;
   private consecutivePollFailures: number = 0;
@@ -551,6 +554,7 @@ export class GatewayManager {
    * This must be called before any API operations.
    */
   private async acquireToken(): Promise<void> {
+    const lifecycleGeneration = this.authLifecycleGeneration;
     logger.info("Acquiring JWT token", { podName: this.config.podName });
 
     const response = await fetchWithTimeout(
@@ -574,6 +578,9 @@ export class GatewayManager {
     }
 
     const data = (await response.json()) as TokenResponse;
+    if (lifecycleGeneration !== this.authLifecycleGeneration) {
+      throw new Error("Auth lifecycle changed during token acquisition");
+    }
     this.accessToken = data.access_token;
     this.tokenExpiresAt = new Date(Date.now() + data.expires_in * 1000);
 
@@ -602,6 +609,7 @@ export class GatewayManager {
     }
 
     const refreshInMs = expiresInSeconds * 1000 * TOKEN_REFRESH_PERCENTAGE;
+    this.tokenRefreshRetryAttempt = 0;
     const timeout = setTimeout(() => {
       // error-policy:J1 The timer boundary converts renewal failure into a paced retry.
       this.refreshToken().catch((error) => {
@@ -624,7 +632,19 @@ export class GatewayManager {
       clearTimeout(this.tokenRefreshTimeout);
     }
 
+    const retryInMs = Math.min(
+      TOKEN_REFRESH_RETRY_MIN_MS * 2 ** this.tokenRefreshRetryAttempt,
+      TOKEN_REFRESH_RETRY_MAX_MS,
+    );
+    this.tokenRefreshRetryAttempt = Math.min(
+      this.tokenRefreshRetryAttempt + 1,
+      5,
+    );
+    const lifecycleGeneration = this.authLifecycleGeneration;
     const timeout = setTimeout(() => {
+      if (lifecycleGeneration !== this.authLifecycleGeneration) {
+        return;
+      }
       // error-policy:J1 The timer boundary retains the paced retry until recovery.
       this.refreshToken().catch((error) => {
         logger.error("Token refresh retry failed", {
@@ -634,8 +654,13 @@ export class GatewayManager {
           this.scheduleTokenRefreshRetry();
         }
       });
-    }, TOKEN_REFRESH_RETRY_MS);
+    }, retryInMs);
     this.tokenRefreshTimeout = timeout;
+
+    logger.debug("Token refresh retry scheduled", {
+      retryInMs,
+      retryAttempt: this.tokenRefreshRetryAttempt,
+    });
   }
 
   /**
@@ -710,10 +735,15 @@ export class GatewayManager {
   async shutdown(): Promise<void> {
     logger.info("Shutting down gateway manager");
 
+    this.authLifecycleGeneration += 1;
+
     if (this.pollInterval) clearInterval(this.pollInterval);
     if (this.heartbeatInterval) clearInterval(this.heartbeatInterval);
     if (this.failoverInterval) clearInterval(this.failoverInterval);
-    if (this.tokenRefreshTimeout) clearTimeout(this.tokenRefreshTimeout);
+    if (this.tokenRefreshTimeout) {
+      clearTimeout(this.tokenRefreshTimeout);
+      this.tokenRefreshTimeout = null;
+    }
     if (this.elizaAppLeaderInterval) clearInterval(this.elizaAppLeaderInterval);
     if (this.greetingPollInterval) clearInterval(this.greetingPollInterval);
     if (this.dmPollInterval) clearInterval(this.dmPollInterval);

--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -287,8 +287,10 @@ interface TokenResponse {
   expires_in: number;
 }
 
-/** Percentage of token lifetime at which to refresh (80% = refresh at 48min for 1hr token) */
+/** Percentage of token lifetime at which to refresh. */
 const TOKEN_REFRESH_PERCENTAGE = 0.8;
+/** Bounded retry cadence keeps a transient bootstrap failure from stranding renewal. */
+const TOKEN_REFRESH_RETRY_MS = 1_000;
 
 interface BotConnection {
   connectionId: string;
@@ -600,16 +602,40 @@ export class GatewayManager {
     }
 
     const refreshInMs = expiresInSeconds * 1000 * TOKEN_REFRESH_PERCENTAGE;
-    this.tokenRefreshTimeout = setTimeout(() => {
+    const timeout = setTimeout(() => {
+      // error-policy:J1 The timer boundary converts renewal failure into a paced retry.
       this.refreshToken().catch((error) => {
         logger.error("Token refresh failed", { error: sanitizeError(error) });
+        if (this.tokenRefreshTimeout === timeout) {
+          this.scheduleTokenRefreshRetry();
+        }
       });
     }, refreshInMs);
+    this.tokenRefreshTimeout = timeout;
 
     logger.debug("Token refresh scheduled", {
       refreshInMs,
       refreshInMinutes: Math.round(refreshInMs / 60000),
     });
+  }
+
+  private scheduleTokenRefreshRetry(): void {
+    if (this.tokenRefreshTimeout) {
+      clearTimeout(this.tokenRefreshTimeout);
+    }
+
+    const timeout = setTimeout(() => {
+      // error-policy:J1 The timer boundary retains the paced retry until recovery.
+      this.refreshToken().catch((error) => {
+        logger.error("Token refresh retry failed", {
+          error: sanitizeError(error),
+        });
+        if (this.tokenRefreshTimeout === timeout) {
+          this.scheduleTokenRefreshRetry();
+        }
+      });
+    }, TOKEN_REFRESH_RETRY_MS);
+    this.tokenRefreshTimeout = timeout;
   }
 
   /**

--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -588,53 +588,7 @@ export class GatewayManager {
    * Refresh the JWT token before it expires.
    */
   private async refreshToken(): Promise<void> {
-    if (!this.accessToken) {
-      // No token to refresh, acquire new one
-      await this.acquireToken();
-      return;
-    }
-
-    logger.info("Refreshing JWT token", { podName: this.config.podName });
-
-    try {
-      const response = await fetchWithTimeout(
-        `${this.config.elizaCloudUrl}/api/internal/auth/refresh`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${this.accessToken}`,
-          },
-        },
-      );
-
-      if (!response.ok) {
-        // Token refresh failed, try to acquire new token
-        logger.warn("Token refresh failed, acquiring new token", {
-          status: response.status,
-        });
-        await this.acquireToken();
-        return;
-      }
-
-      const data = (await response.json()) as TokenResponse;
-      this.accessToken = data.access_token;
-      this.tokenExpiresAt = new Date(Date.now() + data.expires_in * 1000);
-
-      logger.info("JWT token refreshed", {
-        podName: this.config.podName,
-        expiresAt: this.tokenExpiresAt.toISOString(),
-      });
-
-      // Schedule next refresh
-      this.scheduleTokenRefresh(data.expires_in);
-    } catch (error) {
-      logger.error("Error refreshing token, attempting re-acquisition", {
-        error: sanitizeError(error),
-      });
-      // Retry with exponential backoff could be added here
-      await this.acquireToken();
-    }
+    await this.acquireToken();
   }
 
   /**

--- a/packages/cloud/services/gateway-discord/tests/gateway-manager-auth.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/gateway-manager-auth.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { GatewayManager } from "../src/gateway-manager";
 
 interface AuthHarness {
+  accessToken: string | null;
   refreshToken(): Promise<void>;
   scheduleTokenRefresh(expiresInSeconds: number): void;
   tokenRefreshTimeout: NodeJS.Timeout | null;
@@ -96,6 +97,49 @@ describe("GatewayManager token renewal", () => {
     }
 
     expect(bootstraps).toBe(2);
+  });
+
+  test("does not install a token or timer when bootstrap outlives shutdown", async () => {
+    let resolveBootstrap: ((response: Response) => void) | undefined;
+    globalThis.fetch = mock(async (input: unknown) => {
+      const path = new URL(String(input)).pathname;
+      if (path.endsWith("/auth/token")) {
+        return await new Promise<Response>((resolve) => {
+          resolveBootstrap = resolve;
+        });
+      }
+      if (path.endsWith("/discord/gateway/shutdown")) {
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`Unexpected request: ${path}`);
+    }) as typeof fetch;
+
+    const manager = new GatewayManager({
+      podName: "test-pod",
+      elizaCloudUrl: "https://api.test",
+      gatewayBootstrapSecret: "bootstrap-secret",
+      project: "test",
+    });
+    const harness = manager as unknown as AuthHarness;
+    harness.accessToken = "existing-token";
+
+    const renewal = harness.refreshToken();
+    await waitFor(() => resolveBootstrap !== undefined);
+    await manager.shutdown();
+    resolveBootstrap?.(
+      new Response(
+        JSON.stringify({
+          access_token: "late-token",
+          token_type: "Bearer",
+          expires_in: 60,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    await expect(renewal).rejects.toThrow("Auth lifecycle changed");
+    expect(harness.accessToken).toBe("existing-token");
+    expect(harness.tokenRefreshTimeout).toBeNull();
   });
 });
 

--- a/packages/cloud/services/gateway-discord/tests/gateway-manager-auth.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/gateway-manager-auth.test.ts
@@ -1,0 +1,64 @@
+/** Verifies Discord gateway renewal returns to the bootstrap-secret exchange. */
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { GatewayManager } from "../src/gateway-manager";
+
+interface AuthHarness {
+  refreshToken(): Promise<void>;
+  tokenRefreshTimeout: NodeJS.Timeout | null;
+}
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  mock.restore();
+});
+
+describe("GatewayManager token renewal", () => {
+  test("re-bootstraps with the gateway secret instead of bearer self-refresh", async () => {
+    const requests: Array<{
+      path: string;
+      authorization: string | null;
+      secret: string | null;
+    }> = [];
+    globalThis.fetch = mock(async (input: unknown, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      requests.push({
+        path: new URL(String(input)).pathname,
+        authorization: headers.get("authorization"),
+        secret: headers.get("x-gateway-secret"),
+      });
+      return new Response(
+        JSON.stringify({
+          access_token: "replacement-token",
+          token_type: "Bearer",
+          expires_in: 60,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const manager = new GatewayManager({
+      podName: "test-pod",
+      elizaCloudUrl: "https://api.test",
+      gatewayBootstrapSecret: "bootstrap-secret",
+      project: "test",
+    });
+    const harness = manager as unknown as AuthHarness;
+    try {
+      await harness.refreshToken();
+    } finally {
+      if (harness.tokenRefreshTimeout)
+        clearTimeout(harness.tokenRefreshTimeout);
+    }
+
+    expect(requests).toEqual([
+      {
+        path: "/api/internal/auth/token",
+        authorization: null,
+        secret: "bootstrap-secret",
+      },
+    ]);
+  });
+});

--- a/packages/cloud/services/gateway-discord/tests/gateway-manager-auth.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/gateway-manager-auth.test.ts
@@ -5,6 +5,7 @@ import { GatewayManager } from "../src/gateway-manager";
 
 interface AuthHarness {
   refreshToken(): Promise<void>;
+  scheduleTokenRefresh(expiresInSeconds: number): void;
   tokenRefreshTimeout: NodeJS.Timeout | null;
 }
 
@@ -61,4 +62,47 @@ describe("GatewayManager token renewal", () => {
       },
     ]);
   });
+
+  test("retries scheduled bootstrap renewal after a transient failure", async () => {
+    let bootstraps = 0;
+    globalThis.fetch = mock(async () => {
+      bootstraps += 1;
+      if (bootstraps === 1) {
+        return new Response("temporarily unavailable", { status: 503 });
+      }
+      return new Response(
+        JSON.stringify({
+          access_token: "replacement-token",
+          token_type: "Bearer",
+          expires_in: 60,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const manager = new GatewayManager({
+      podName: "test-pod",
+      elizaCloudUrl: "https://api.test",
+      gatewayBootstrapSecret: "bootstrap-secret",
+      project: "test",
+    });
+    const harness = manager as unknown as AuthHarness;
+    try {
+      harness.scheduleTokenRefresh(0.01);
+      await waitFor(() => bootstraps === 2);
+    } finally {
+      if (harness.tokenRefreshTimeout)
+        clearTimeout(harness.tokenRefreshTimeout);
+    }
+
+    expect(bootstraps).toBe(2);
+  });
 });
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("Timed out waiting for retry");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}

--- a/packages/cloud/services/gateway-webhook/__tests__/auth-rebootstrap-on-401.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/auth-rebootstrap-on-401.test.ts
@@ -239,4 +239,44 @@ describe("reacquireAuthHeader is single-flight", () => {
       true,
     );
   });
+
+  test("scheduled renewal retries bootstrap after a transient failure", async () => {
+    let bootstraps = 0;
+    globalThis.fetch = mock(async () => {
+      bootstraps += 1;
+      if (bootstraps === 2) {
+        return new Response("temporarily unavailable", { status: 503 });
+      }
+      return new Response(
+        JSON.stringify({
+          access_token: `tok-${bootstraps}`,
+          token_type: "Bearer",
+          expires_in: bootstraps === 1 ? 0.01 : 60,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const { initAuth, shutdownAuth } = await import("../src/auth");
+    try {
+      await initAuth({
+        cloudUrl: "https://api.test",
+        bootstrapSecret: "bootstrap",
+        podName: "test-pod",
+      });
+      await waitFor(() => bootstraps === 3);
+    } finally {
+      shutdownAuth();
+    }
+
+    expect(bootstraps).toBe(3);
+  });
 });
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("Timed out waiting for retry");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}

--- a/packages/cloud/services/gateway-webhook/__tests__/auth-rebootstrap-on-401.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/auth-rebootstrap-on-401.test.ts
@@ -271,6 +271,42 @@ describe("reacquireAuthHeader is single-flight", () => {
 
     expect(bootstraps).toBe(3);
   });
+
+  test("shutdown fences an in-flight bootstrap from restoring auth state", async () => {
+    let resolveBootstrap: ((response: Response) => void) | undefined;
+    globalThis.fetch = mock(
+      async () =>
+        await new Promise<Response>((resolve) => {
+          resolveBootstrap = resolve;
+        }),
+    ) as typeof fetch;
+
+    const { getAuthHeader, initAuth, shutdownAuth } = await import(
+      "../src/auth"
+    );
+    const initialization = initAuth({
+      cloudUrl: "https://api.test",
+      bootstrapSecret: "bootstrap",
+      podName: "test-pod",
+    });
+    await waitFor(() => resolveBootstrap !== undefined);
+    shutdownAuth();
+    resolveBootstrap?.(
+      new Response(
+        JSON.stringify({
+          access_token: "late-token",
+          token_type: "Bearer",
+          expires_in: 60,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    await expect(initialization).rejects.toThrow("Auth lifecycle changed");
+    expect(() => getAuthHeader()).toThrow("No access token available");
+    await new Promise((resolve) => setTimeout(resolve, 70));
+    expect(() => getAuthHeader()).toThrow("No access token available");
+  });
 });
 
 async function waitFor(predicate: () => boolean): Promise<void> {

--- a/packages/cloud/services/gateway-webhook/__tests__/auth-rebootstrap-on-401.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/auth-rebootstrap-on-401.test.ts
@@ -207,4 +207,36 @@ describe("reacquireAuthHeader is single-flight", () => {
 
     shutdownAuth();
   });
+
+  test("scheduled renewal re-bootstraps and never calls the bearer refresh route", async () => {
+    const paths: string[] = [];
+    globalThis.fetch = mock(async (input: unknown) => {
+      paths.push(new URL(String(input)).pathname);
+      return new Response(
+        JSON.stringify({
+          access_token: `tok-${paths.length}`,
+          token_type: "Bearer",
+          expires_in: 0.05,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const { initAuth, shutdownAuth } = await import("../src/auth");
+    try {
+      await initAuth({
+        cloudUrl: "https://api.test",
+        bootstrapSecret: "bootstrap",
+        podName: "test-pod",
+      });
+      await new Promise((resolve) => setTimeout(resolve, 70));
+    } finally {
+      shutdownAuth();
+    }
+
+    expect(paths.length).toBeGreaterThanOrEqual(2);
+    expect(paths.every((path) => path === "/api/internal/auth/token")).toBe(
+      true,
+    );
+  });
 });

--- a/packages/cloud/services/gateway-webhook/src/auth.ts
+++ b/packages/cloud/services/gateway-webhook/src/auth.ts
@@ -76,49 +76,7 @@ async function acquireToken(): Promise<void> {
 
 async function refreshToken(): Promise<void> {
   if (!config) throw new Error("Auth not initialized");
-
-  if (!accessToken) {
-    await acquireToken();
-    return;
-  }
-
-  logger.info("Refreshing JWT token", { podName: config.podName });
-
-  try {
-    const response = await fetchWithTimeout(
-      `${config.cloudUrl}/api/internal/auth/refresh`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${accessToken}`,
-        },
-      },
-    );
-
-    if (!response.ok) {
-      logger.warn("Token refresh failed, acquiring new token", {
-        status: response.status,
-      });
-      await acquireToken();
-      return;
-    }
-
-    const data = (await response.json()) as TokenResponse;
-    accessToken = data.access_token;
-
-    logger.info("JWT token refreshed", {
-      podName: config.podName,
-      expiresIn: `${data.expires_in}s`,
-    });
-
-    scheduleRefresh(data.expires_in);
-  } catch (error) {
-    logger.error("Error refreshing token, attempting re-acquisition", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    await acquireToken();
-  }
+  await acquireToken();
 }
 
 function scheduleRefresh(expiresInSeconds: number): void {

--- a/packages/cloud/services/gateway-webhook/src/auth.ts
+++ b/packages/cloud/services/gateway-webhook/src/auth.ts
@@ -3,6 +3,7 @@ import { logger } from "./logger";
 
 const HTTP_TIMEOUT_MS = 10_000;
 const TOKEN_REFRESH_PERCENTAGE = 0.8;
+const TOKEN_REFRESH_RETRY_MS = 1_000;
 
 interface TokenResponse {
   access_token: string;
@@ -83,13 +84,31 @@ function scheduleRefresh(expiresInSeconds: number): void {
   if (refreshTimeout) clearTimeout(refreshTimeout);
 
   const refreshInMs = expiresInSeconds * 1000 * TOKEN_REFRESH_PERCENTAGE;
-  refreshTimeout = setTimeout(() => {
+  const timeout = setTimeout(() => {
+    // error-policy:J1 The timer boundary converts renewal failure into a paced retry.
     refreshToken().catch((error) => {
       logger.error("Token refresh failed", {
         error: error instanceof Error ? error.message : String(error),
       });
+      if (refreshTimeout === timeout) scheduleRefreshRetry();
     });
   }, refreshInMs);
+  refreshTimeout = timeout;
+}
+
+function scheduleRefreshRetry(): void {
+  if (refreshTimeout) clearTimeout(refreshTimeout);
+
+  const timeout = setTimeout(() => {
+    // error-policy:J1 The timer boundary retains the paced retry until recovery.
+    refreshToken().catch((error) => {
+      logger.error("Token refresh retry failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      if (refreshTimeout === timeout) scheduleRefreshRetry();
+    });
+  }, TOKEN_REFRESH_RETRY_MS);
+  refreshTimeout = timeout;
 }
 
 export async function initAuth(authConfig: AuthConfig): Promise<void> {

--- a/packages/cloud/services/gateway-webhook/src/auth.ts
+++ b/packages/cloud/services/gateway-webhook/src/auth.ts
@@ -3,7 +3,8 @@ import { logger } from "./logger";
 
 const HTTP_TIMEOUT_MS = 10_000;
 const TOKEN_REFRESH_PERCENTAGE = 0.8;
-const TOKEN_REFRESH_RETRY_MS = 1_000;
+const TOKEN_REFRESH_RETRY_MIN_MS = 1_000;
+const TOKEN_REFRESH_RETRY_MAX_MS = 30_000;
 
 interface TokenResponse {
   access_token: string;
@@ -20,6 +21,8 @@ interface AuthConfig {
 let accessToken: string | null = null;
 let refreshTimeout: ReturnType<typeof setTimeout> | null = null;
 let config: AuthConfig | null = null;
+let refreshRetryAttempt = 0;
+let authLifecycleGeneration = 0;
 
 async function fetchWithTimeout(
   url: string,
@@ -41,19 +44,21 @@ async function fetchWithTimeout(
 
 async function acquireToken(): Promise<void> {
   if (!config) throw new Error("Auth not initialized");
+  const lifecycleGeneration = authLifecycleGeneration;
+  const activeConfig = config;
 
-  logger.info("Acquiring JWT token", { podName: config.podName });
+  logger.info("Acquiring JWT token", { podName: activeConfig.podName });
 
   const response = await fetchWithTimeout(
-    `${config.cloudUrl}/api/internal/auth/token`,
+    `${activeConfig.cloudUrl}/api/internal/auth/token`,
     {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-Gateway-Secret": config.bootstrapSecret,
+        "X-Gateway-Secret": activeConfig.bootstrapSecret,
       },
       body: JSON.stringify({
-        pod_name: config.podName,
+        pod_name: activeConfig.podName,
         service: "webhook-gateway",
       }),
     },
@@ -65,10 +70,13 @@ async function acquireToken(): Promise<void> {
   }
 
   const data = (await response.json()) as TokenResponse;
+  if (lifecycleGeneration !== authLifecycleGeneration) {
+    throw new Error("Auth lifecycle changed during token acquisition");
+  }
   accessToken = data.access_token;
 
   logger.info("JWT token acquired", {
-    podName: config.podName,
+    podName: activeConfig.podName,
     expiresIn: `${data.expires_in}s`,
   });
 
@@ -84,6 +92,7 @@ function scheduleRefresh(expiresInSeconds: number): void {
   if (refreshTimeout) clearTimeout(refreshTimeout);
 
   const refreshInMs = expiresInSeconds * 1000 * TOKEN_REFRESH_PERCENTAGE;
+  refreshRetryAttempt = 0;
   const timeout = setTimeout(() => {
     // error-policy:J1 The timer boundary converts renewal failure into a paced retry.
     refreshToken().catch((error) => {
@@ -99,7 +108,14 @@ function scheduleRefresh(expiresInSeconds: number): void {
 function scheduleRefreshRetry(): void {
   if (refreshTimeout) clearTimeout(refreshTimeout);
 
+  const retryInMs = Math.min(
+    TOKEN_REFRESH_RETRY_MIN_MS * 2 ** refreshRetryAttempt,
+    TOKEN_REFRESH_RETRY_MAX_MS,
+  );
+  refreshRetryAttempt = Math.min(refreshRetryAttempt + 1, 5);
+  const lifecycleGeneration = authLifecycleGeneration;
   const timeout = setTimeout(() => {
+    if (lifecycleGeneration !== authLifecycleGeneration) return;
     // error-policy:J1 The timer boundary retains the paced retry until recovery.
     refreshToken().catch((error) => {
       logger.error("Token refresh retry failed", {
@@ -107,16 +123,23 @@ function scheduleRefreshRetry(): void {
       });
       if (refreshTimeout === timeout) scheduleRefreshRetry();
     });
-  }, TOKEN_REFRESH_RETRY_MS);
+  }, retryInMs);
   refreshTimeout = timeout;
+
+  logger.debug("Token refresh retry scheduled", {
+    retryInMs,
+    retryAttempt: refreshRetryAttempt,
+  });
 }
 
 export async function initAuth(authConfig: AuthConfig): Promise<void> {
+  authLifecycleGeneration += 1;
   config = authConfig;
   await acquireToken();
 }
 
-let reacquireInFlight: Promise<void> | null = null;
+let reacquireInFlight: { generation: number; promise: Promise<void> } | null =
+  null;
 
 /**
  * Re-bootstraps the JWT and returns a fresh header. Single-flight: a Worker
@@ -128,10 +151,19 @@ let reacquireInFlight: Promise<void> | null = null;
 export async function reacquireAuthHeader(): Promise<{
   Authorization: string;
 }> {
-  reacquireInFlight ??= acquireToken().finally(() => {
-    reacquireInFlight = null;
-  });
-  await reacquireInFlight;
+  const generation = authLifecycleGeneration;
+  if (!reacquireInFlight || reacquireInFlight.generation !== generation) {
+    const promise = acquireToken().finally(() => {
+      if (reacquireInFlight?.promise === promise) {
+        reacquireInFlight = null;
+      }
+    });
+    reacquireInFlight = { generation, promise };
+  }
+  await reacquireInFlight.promise;
+  if (generation !== authLifecycleGeneration) {
+    throw new Error("Auth lifecycle changed during token acquisition");
+  }
   return getAuthHeader();
 }
 
@@ -143,10 +175,12 @@ export function getAuthHeader(): { Authorization: string } {
 }
 
 export function shutdownAuth(): void {
+  authLifecycleGeneration += 1;
   if (refreshTimeout) {
     clearTimeout(refreshTimeout);
     refreshTimeout = null;
   }
   accessToken = null;
   config = null;
+  refreshRetryAttempt = 0;
 }

--- a/packages/cloud/shared/src/lib/auth/jwt-internal.test.ts
+++ b/packages/cloud/shared/src/lib/auth/jwt-internal.test.ts
@@ -31,6 +31,7 @@ const KEYS = makeKeys();
 
 const denylistStore = new Map<string, string>();
 let denylistGetError: Error | null = null;
+let denylistGetCount = 0;
 let workerRuntime = false;
 let lastRedisEnv: Record<string, string | undefined> | undefined;
 
@@ -47,6 +48,7 @@ mock.module("../cache/redis-factory", () => ({
     if (!hasConfiguredRedis(env)) return null;
     return {
       async get(key: string) {
+        denylistGetCount += 1;
         if (denylistGetError) throw denylistGetError;
         return denylistStore.get(key) ?? null;
       },
@@ -66,7 +68,10 @@ mock.module("../cache/redis-factory", () => ({
 
 mock.module("../utils/logger", () => ({
   logger: {
+    debug: mock(() => undefined),
+    error: mock(() => undefined),
     info: mock(() => undefined),
+    warn: mock(() => undefined),
   },
 }));
 
@@ -81,6 +86,7 @@ describe("internal JWT jti revocation denylist (#12879)", () => {
     process.env.MOCK_REDIS = "1";
     denylistStore.clear();
     denylistGetError = null;
+    denylistGetCount = 0;
     workerRuntime = false;
     lastRedisEnv = undefined;
     denylistMod.__resetDenylistClientForTests();
@@ -177,6 +183,61 @@ describe("internal JWT jti revocation denylist (#12879)", () => {
       });
 
       await expect(mod.verifyInternalToken(access_token)).rejects.toThrow(/redis unavailable/i);
+    });
+
+    test("verifies one-minute gateway request tokens without a remote denylist read", async () => {
+      denylistGetError = new Error("remote denylist must stay off this path");
+      const { access_token, expires_in } = await mod.signInternalToken({
+        subject: "gateway-webhook-1",
+        service: "webhook-gateway",
+        expiresIn: mod.internalTokenLifetimeForService("webhook-gateway"),
+      });
+
+      const result = await mod.verifyInternalRequestToken(access_token);
+
+      expect(result.payload.service).toBe("webhook-gateway");
+      expect(expires_in).toBe(mod.GATEWAY_TOKEN_LIFETIME_SECONDS);
+      expect(result.payload.exp - result.payload.iat).toBe(mod.GATEWAY_TOKEN_LIFETIME_SECONDS);
+      expect(denylistGetCount).toBe(0);
+    });
+
+    test("keeps long-lived gateway tokens on the fail-closed denylist", async () => {
+      denylistGetError = new Error("long-lived gateway denylist unavailable");
+      const { access_token } = await mod.signInternalToken({
+        subject: "gateway-webhook-legacy",
+        service: "webhook-gateway",
+        expiresIn: mod.GATEWAY_TOKEN_LIFETIME_SECONDS + 1,
+      });
+
+      await expect(mod.verifyInternalRequestToken(access_token)).rejects.toThrow(
+        /long-lived gateway denylist unavailable/i,
+      );
+      expect(denylistGetCount).toBe(1);
+    });
+
+    test("keeps short-lived non-gateway tokens on the fail-closed denylist", async () => {
+      denylistGetError = new Error("non-gateway denylist unavailable");
+      const { access_token } = await mod.signInternalToken({
+        subject: "internal-job",
+        service: "scheduler",
+        expiresIn: mod.GATEWAY_TOKEN_LIFETIME_SECONDS,
+      });
+
+      await expect(mod.verifyInternalRequestToken(access_token)).rejects.toThrow(
+        /non-gateway denylist unavailable/i,
+      );
+      expect(denylistGetCount).toBe(1);
+    });
+
+    test("preserves ordinary token lifetime selection", () => {
+      expect(mod.internalTokenLifetimeForService("discord-gateway")).toBe(
+        mod.GATEWAY_TOKEN_LIFETIME_SECONDS,
+      );
+      expect(mod.internalTokenLifetimeForService("webhook-gateway")).toBe(
+        mod.GATEWAY_TOKEN_LIFETIME_SECONDS,
+      );
+      expect(mod.internalTokenLifetimeForService("scheduler")).toBe(mod.TOKEN_LIFETIME_SECONDS);
+      expect(mod.internalTokenLifetimeForService(undefined)).toBe(mod.TOKEN_LIFETIME_SECONDS);
     });
   });
 

--- a/packages/cloud/shared/src/lib/auth/jwt-internal.ts
+++ b/packages/cloud/shared/src/lib/auth/jwt-internal.ts
@@ -31,6 +31,10 @@ export const GATEWAY_TOKEN_LIFETIME_SECONDS = 60;
 
 const SHORT_LIVED_GATEWAY_SERVICES = new Set(["webhook-gateway", "discord-gateway"]);
 
+export function isShortLivedGatewayService(service: string | undefined): boolean {
+  return service !== undefined && SHORT_LIVED_GATEWAY_SERVICES.has(service);
+}
+
 /**
  * Issuer claim for internal JWTs.
  */
@@ -90,7 +94,7 @@ export interface SignTokenOptions {
 }
 
 export function internalTokenLifetimeForService(service: string | undefined): number {
-  return service && SHORT_LIVED_GATEWAY_SERVICES.has(service)
+  return isShortLivedGatewayService(service)
     ? GATEWAY_TOKEN_LIFETIME_SECONDS
     : TOKEN_LIFETIME_SECONDS;
 }

--- a/packages/cloud/shared/src/lib/auth/jwt-internal.ts
+++ b/packages/cloud/shared/src/lib/auth/jwt-internal.ts
@@ -23,6 +23,15 @@ export {
 export const TOKEN_LIFETIME_SECONDS = 3600;
 
 /**
+ * Gateway tokens cross the public network on every connector delivery. Their
+ * one-minute lifetime bounds replay tightly enough for local signature
+ * verification while ordinary internal tokens retain per-jti revocation.
+ */
+export const GATEWAY_TOKEN_LIFETIME_SECONDS = 60;
+
+const SHORT_LIVED_GATEWAY_SERVICES = new Set(["webhook-gateway", "discord-gateway"]);
+
+/**
  * Issuer claim for internal JWTs.
  */
 const ISSUER = "eliza-cloud";
@@ -80,6 +89,12 @@ export interface SignTokenOptions {
   expiresIn?: number;
 }
 
+export function internalTokenLifetimeForService(service: string | undefined): number {
+  return service && SHORT_LIVED_GATEWAY_SERVICES.has(service)
+    ? GATEWAY_TOKEN_LIFETIME_SECONDS
+    : TOKEN_LIFETIME_SECONDS;
+}
+
 /**
  * Sign a new JWT for an internal service.
  *
@@ -128,7 +143,7 @@ export async function signInternalToken(options: SignTokenOptions): Promise<{
  * @throws Error if token is invalid, expired, has wrong issuer/audience, is
  *   missing a required claim, has a revoked `jti`, or the denylist check fails.
  */
-export async function verifyInternalToken(token: string): Promise<VerificationResult> {
+async function verifyInternalTokenClaims(token: string): Promise<VerificationResult> {
   const publicKey = await getPublicKey();
 
   const { payload } = await jwtVerify(token, publicKey, {
@@ -145,16 +160,51 @@ export async function verifyInternalToken(token: string): Promise<VerificationRe
     throw new Error("Token missing JWT ID claim");
   }
 
-  // Revocation denylist check — fail closed. A thrown store error propagates so
-  // the token is rejected rather than accepted on an unreachable denylist.
-  if (await isJtiRevoked(payload.jti)) {
-    throw new Error("Token has been revoked");
-  }
-
   return {
     valid: true,
     payload: payload as InternalJWTPayload,
   };
+}
+
+async function requireTokenNotRevoked(payload: InternalJWTPayload): Promise<void> {
+  if (await isJtiRevoked(payload.jti)) {
+    throw new Error("Token has been revoked");
+  }
+}
+
+function isBoundedGatewayToken(payload: InternalJWTPayload): boolean {
+  if (!payload.service || !SHORT_LIVED_GATEWAY_SERVICES.has(payload.service)) {
+    return false;
+  }
+  if (
+    typeof payload.iat !== "number" ||
+    !Number.isInteger(payload.iat) ||
+    typeof payload.exp !== "number" ||
+    !Number.isInteger(payload.exp)
+  ) {
+    return false;
+  }
+  const lifetimeSeconds = payload.exp - payload.iat;
+  return lifetimeSeconds > 0 && lifetimeSeconds <= GATEWAY_TOKEN_LIFETIME_SECONDS;
+}
+
+export async function verifyInternalToken(token: string): Promise<VerificationResult> {
+  const result = await verifyInternalTokenClaims(token);
+  await requireTokenNotRevoked(result.payload);
+  return result;
+}
+
+/**
+ * Verifies tokens presented on internal request routes. Only signed gateway
+ * credentials whose complete lifetime is one minute or less avoid the remote
+ * revocation read; every other token keeps the fail-closed denylist contract.
+ */
+export async function verifyInternalRequestToken(token: string): Promise<VerificationResult> {
+  const result = await verifyInternalTokenClaims(token);
+  if (!isBoundedGatewayToken(result.payload)) {
+    await requireTokenNotRevoked(result.payload);
+  }
+  return result;
 }
 
 /**


### PR DESCRIPTION
## Summary

- issue 60-second access tokens only to the two managed social gateways
- verify those bounded tokens locally and skip the remote denylist round trip
- remove refresh-token chains from gateways and rebootstrap on expiry
- retry renewal with lifecycle fencing instead of letting auth stalls consume the response budget

Closes #20290.

## Security boundary

Ordinary internal tokens retain fail-closed remote verification. The fast path requires a valid signature, exact 60-second lifetime, and an allowlisted gateway service. Maximum revocation delay is therefore 60 seconds; signing-key rotation remains immediate.

## Validation

- focused auth tests: 19 passed, 0 failed
- gateway-discord: 110 tests passed; typecheck, build, lint passed
- gateway-webhook: 164 tests passed; typecheck, build, lint passed
- cloud-shared typecheck passed
- cloud-api typecheck and production Wrangler dry-run passed
- changed-file Biome and git diff --check passed
- root verify is blocked on origin/develop by an unrelated pre-existing formatter error in plugins/plugin-personal-assistant/src/actions/life.review-definitions.test.ts:401

## Evidence

- local contract and package evidence above
- protected staging latency canary pending merge
- UI screenshots/video: N/A, backend transport/auth change
- live-model trajectory: N/A, no model behavior changed

Model: openai / gpt-5.6-sol
Client: Codex Desktop
Skill revision: 8ded298e8068