### PR TITLE
fix(cloud): remove personal Shared cold first-contact retry

### DIFF
--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -9,11 +9,12 @@ let activeTarget: {
   status: "running" | "sleeping" | "stopped";
   bridge_url?: string;
 } | null = null;
+let personalDeliveryIsNew = false;
 const resolvePersonalDelivery = mock(async () => ({
   userId: "00000000-0000-4000-8000-000000000002",
   organizationId: "00000000-0000-4000-8000-000000000001",
   dedicatedTarget: activeTarget,
-  isNew: false,
+  isNew: personalDeliveryIsNew,
   resolution: "single-query-repeat" as const,
 }));
 const findOrCreateByPhone = mock(async () => ({
@@ -22,6 +23,7 @@ const findOrCreateByPhone = mock(async () => ({
   isNew: true,
 }));
 const sharedRestMessageSend = mock(async () => ({ text: "hello from Eliza" }));
+const prewarmPersonalSharedAgentTurnCaches = mock(async () => undefined);
 const runOnboardingChat = mock(async (_input: OnboardingChatInput) => ({
   loginUrl:
     "https://cloud-staging.eliza.app/get-started?onboardingSession=claim-token",
@@ -116,6 +118,9 @@ mock.module("@/lib/services/eliza-app", () => ({
 mock.module("@/lib/services/shared-runtime/shared-rest-adapter", () => ({
   sharedRestMessageSend,
 }));
+mock.module("@/lib/services/shared-runtime/prewarm-shared-agent", () => ({
+  prewarmPersonalSharedAgentTurnCaches,
+}));
 mock.module("@/lib/services/eliza-app/onboarding-chat", () => ({
   runOnboardingChat,
 }));
@@ -199,9 +204,11 @@ describe("personal Shared messaging deliveries", () => {
   beforeEach(() => {
     findOrCreateByPhone.mockClear();
     activeTarget = null;
+    personalDeliveryIsNew = false;
     resolvePersonalDelivery.mockClear();
     findActivePersonalDedicatedTarget.mockClear();
     sharedRestMessageSend.mockClear();
+    prewarmPersonalSharedAgentTurnCaches.mockClear();
     runOnboardingChat.mockClear();
     bridge.mockClear();
     importCanonicalConversation.mockClear();
@@ -257,6 +264,45 @@ describe("personal Shared messaging deliveries", () => {
     );
   });
 
+  test("warms a newly auto-registered personal account before its first turn", async () => {
+    personalDeliveryIsNew = true;
+    const order: string[] = [];
+    prewarmPersonalSharedAgentTurnCaches.mockImplementationOnce(async () => {
+      order.push("prewarm");
+    });
+    sharedRestMessageSend.mockImplementationOnce(async () => {
+      order.push("turn");
+      return { text: "hello from Eliza" };
+    });
+
+    const response = await request({
+      ...valid,
+      telegramUserId: "99008152237",
+      chatId: "99008152237",
+      messageId: "QA815-LAT8-COLD",
+    });
+
+    expect(response.status).toBe(200);
+    expect(prewarmPersonalSharedAgentTurnCaches).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organization_id: "00000000-0000-4000-8000-000000000001",
+        user_id: "00000000-0000-4000-8000-000000000002",
+      }),
+      namespace,
+    );
+    expect(order).toEqual(["prewarm", "turn"]);
+    expect(response.headers.get("server-timing")).toMatch(
+      /^account;dur=\d+\.\d;desc="[^"]+", prewarm;dur=\d+\.\d, shared;dur=\d+\.\d$/,
+    );
+  });
+
+  test("keeps established personal turns on the direct warm path", async () => {
+    const response = await request(valid);
+
+    expect(response.status).toBe(200);
+    expect(prewarmPersonalSharedAgentTurnCaches).not.toHaveBeenCalled();
+  });
+
   test("correlates a Shared failure without logging its sensitive message", async () => {
     const errorLog = mock(() => undefined);
     const originalError = logger.error;
@@ -292,6 +338,35 @@ describe("personal Shared messaging deliveries", () => {
     } finally {
       logger.error = originalError;
     }
+  });
+
+  test("preserves cache warming as a retryable 503 at the internal boundary", async () => {
+    const { SharedRuntimeCacheWarmingError } = await import(
+      "@/lib/services/shared-runtime/shared-runtime-errors"
+    );
+    const warming = new SharedRuntimeCacheWarmingError(
+      "private cold-gate detail",
+    );
+    sharedRestMessageSend.mockImplementationOnce(async () => {
+      throw warming;
+    });
+
+    const response = await request(valid);
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("retry-after")).toBe("1");
+    expect(response.headers.get("x-eliza-failure-stage")).toBe(
+      "shared_runtime",
+    );
+    expect(response.headers.get("x-eliza-failure-name")).toBe(
+      "SharedRuntimeCacheWarmingError",
+    );
+    await expect(response.json()).resolves.toEqual({
+      success: false,
+      error: "Shared Eliza is warming. Retry this turn shortly.",
+      code: "service_unavailable",
+      retryable: true,
+    });
   });
 
   test("redacts an unrecognized error name from headers and logs", async () => {

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -14,8 +14,10 @@ import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { preparePersonalDedicatedDelivery } from "@/lib/services/personal-dedicated-delivery";
 import { coordinateSharedHistory } from "@/lib/services/shared-runtime/conversation-coordinator";
 import { personalSharedAgent } from "@/lib/services/shared-runtime/personal-shared-agent";
+import { prewarmPersonalSharedAgentTurnCaches } from "@/lib/services/shared-runtime/prewarm-shared-agent";
 import { resolveSharedRuntimeWorkerRequestContext } from "@/lib/services/shared-runtime/resolve-shared-agent";
 import { sharedRestMessageSend } from "@/lib/services/shared-runtime/shared-rest-adapter";
+import { SharedRuntimeCacheWarmingError } from "@/lib/services/shared-runtime/shared-runtime-errors";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { requireInternalAuth } from "../../../_auth";
@@ -265,6 +267,7 @@ app.post("/", async (c) => {
     const accountStartedAt = performance.now();
     let account: { userId: string; organizationId: string };
     let accountResolution = "phone-query";
+    let isNewPersonalAccount = false;
     let dedicated:
       | Pick<AgentSandbox, "id" | "status" | "bridge_url" | "agent_config">
       | null
@@ -286,6 +289,7 @@ app.post("/", async (c) => {
       };
       accountResolution = delivery.resolution;
       dedicated = delivery.dedicatedTarget;
+      isNewPersonalAccount = delivery.isNew;
     } else if (parsed.data.platform === "discord") {
       const delivery = await resolvePersonalDeliveryProjection(
         c.env,
@@ -304,6 +308,7 @@ app.post("/", async (c) => {
       };
       accountResolution = delivery.resolution;
       dedicated = delivery.dedicatedTarget;
+      isNewPersonalAccount = delivery.isNew;
     } else {
       const phoneAccount = await elizaAppUserService.findOrCreateByPhone(
         parsed.data.phoneNumber,
@@ -312,6 +317,7 @@ app.post("/", async (c) => {
         userId: phoneAccount.user.id,
         organizationId: phoneAccount.organization.id,
       };
+      isNewPersonalAccount = phoneAccount.isNew;
     }
     const accountMs = performance.now() - accountStartedAt;
     const accountTiming = `account;dur=${accountMs.toFixed(1)};desc="${accountResolution}"`;
@@ -579,6 +585,12 @@ app.post("/", async (c) => {
       });
     }
     stage = "shared_runtime";
+    let prewarmMs: number | undefined;
+    if (isNewPersonalAccount) {
+      const prewarmStartedAt = performance.now();
+      await prewarmPersonalSharedAgentTurnCaches(agent, worker.namespace);
+      prewarmMs = performance.now() - prewarmStartedAt;
+    }
     const sharedStartedAt = performance.now();
     const trustedDelivery =
       parsed.data.platform === "telegram"
@@ -612,9 +624,9 @@ app.post("/", async (c) => {
     );
     c.header(
       "Server-Timing",
-      `${accountTiming}, shared;dur=${(
-        performance.now() - sharedStartedAt
-      ).toFixed(1)}`,
+      `${accountTiming}, ${
+        prewarmMs === undefined ? "" : `prewarm;dur=${prewarmMs.toFixed(1)}, `
+      }shared;dur=${(performance.now() - sharedStartedAt).toFixed(1)}`,
     );
 
     return c.json({
@@ -642,6 +654,18 @@ app.post("/", async (c) => {
     // provider/SQL payloads in its logs.
     c.header(FAILURE_STAGE_HEADER, stage);
     c.header(FAILURE_NAME_HEADER, errorName);
+    if (error instanceof SharedRuntimeCacheWarmingError) {
+      return c.json(
+        {
+          success: false,
+          error: "Shared Eliza is warming. Retry this turn shortly.",
+          code: "service_unavailable",
+          retryable: true,
+        },
+        503,
+        { "Retry-After": "1" },
+      );
+    }
     return failureResponse(c, error);
   }
 });

--- a/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
@@ -25,6 +25,7 @@ const GATE_BINDING = "INFERENCE_ADMISSION_GATES";
 const GATE_ORIGIN = "https://inference-admission.internal";
 const HYDRATION_GATE_TIMEOUT_MS = 5_000;
 const GATE_OPERATION_TIMEOUT_MS = 1_500;
+const RATE_LIMIT_GATE_TIMEOUT_MS = 5_000;
 const DISPATCH_GATE_TIMEOUT_MS = 1_500;
 const DISPATCH_GATE_MAX_ATTEMPTS = 3;
 
@@ -398,7 +399,10 @@ export async function consumeInferenceRateLimit(params: {
       maxRequests: params.maxRequests,
     },
     undefined,
-    AbortSignal.timeout(GATE_OPERATION_TIMEOUT_MS),
+    // A brand-new organization addresses a brand-new Durable Object. Preserve
+    // the tighter money-mutation deadline above, but allow the lightweight
+    // rate-limit authority to survive genuine Worker/DO cold initialization.
+    AbortSignal.timeout(RATE_LIMIT_GATE_TIMEOUT_MS),
   );
   if (response.status !== 200 && response.status !== 429) {
     throw new InferenceAdmissionGateUnavailableError(

--- a/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.test.ts
@@ -22,7 +22,11 @@ const getById = mock(async (_id: string): Promise<UserCharacter | undefined> => 
 const warmInferenceAdmissionSnapshot = mock(async () => {
   calls.push("admission");
 });
+const warmInferenceAdmissionGate = mock(async () => {
+  calls.push("admission-gate");
+});
 const coordinateSharedHistory = mock(async () => [] as unknown[]);
+const coordinateSharedConversationPrewarm = mock(async () => undefined);
 const seedSharedAgentScopeCache = mock(async () => {
   calls.push("authorization-scope");
 });
@@ -35,7 +39,9 @@ mock.module("../../pricing", () => ({
 }));
 mock.module("../characters/characters", () => ({ charactersService: { getById } }));
 mock.module("../inference-admission-snapshot", () => ({ warmInferenceAdmissionSnapshot }));
+mock.module("../inference-admission-gate", () => ({ warmInferenceAdmissionGate }));
 mock.module("./conversation-coordinator", () => ({
+  coordinateSharedConversationPrewarm,
   coordinateSharedHistory,
 }));
 mock.module("./resolve-shared-agent", () => ({
@@ -48,7 +54,9 @@ mock.module("./run-shared-agent-turn", () => ({
   resolveSharedAgentTurnModel: (preferred?: string) => preferred?.trim() || null,
 }));
 
-const { prewarmSharedAgentTurnCaches } = await import("./prewarm-shared-agent");
+const { prewarmPersonalSharedAgentTurnCaches, prewarmSharedAgentTurnCaches } = await import(
+  "./prewarm-shared-agent"
+);
 
 afterAll(() => {
   mock.module("../../utils/logger", () => realLogger);
@@ -71,8 +79,14 @@ beforeEach(() => {
   getById.mockClear();
   getById.mockImplementation(async () => undefined);
   warmInferenceAdmissionSnapshot.mockClear();
+  warmInferenceAdmissionGate.mockClear();
+  warmInferenceAdmissionGate.mockImplementation(async () => {
+    calls.push("admission-gate");
+  });
   coordinateSharedHistory.mockClear();
   coordinateSharedHistory.mockImplementation(async () => []);
+  coordinateSharedConversationPrewarm.mockClear();
+  coordinateSharedConversationPrewarm.mockImplementation(async () => undefined);
   seedSharedAgentScopeCache.mockClear();
   seedSharedAgentScopeCache.mockImplementation(async () => {
     calls.push("authorization-scope");
@@ -81,6 +95,13 @@ beforeEach(() => {
 });
 
 describe("prewarmSharedAgentTurnCaches model pricing", () => {
+  test("warms the serialized admission gate beside the policy snapshot", async () => {
+    await prewarmSharedAgentTurnCaches(agent({}));
+
+    expect(warmInferenceAdmissionGate).toHaveBeenCalledWith("org-1");
+    expect(warmInferenceAdmissionSnapshot).toHaveBeenCalledWith("org-1");
+  });
+
   test("warms the nested agent_config.character.model pricing pair", async () => {
     await prewarmSharedAgentTurnCaches(
       agent({
@@ -173,6 +194,47 @@ describe("prewarmSharedAgentTurnCaches model pricing", () => {
         agentId: "agent-1",
         organizationId: "org-1",
         leg: "conversation-object",
+        error: error.message,
+      }),
+    );
+  });
+});
+
+describe("prewarmPersonalSharedAgentTurnCaches", () => {
+  test("warms a new personal room and admission gate concurrently", async () => {
+    const namespace = { getByName: mock() } as never;
+    const personalAgent = {
+      id: "personal:user-1:org-1",
+      organization_id: "org-1",
+    };
+
+    await prewarmPersonalSharedAgentTurnCaches(personalAgent, namespace);
+
+    expect(warmInferenceAdmissionGate).toHaveBeenCalledWith("org-1");
+    expect(coordinateSharedConversationPrewarm).toHaveBeenCalledWith(
+      personalAgent.id,
+      personalAgent.id,
+      { namespace, startEmpty: true },
+    );
+  });
+
+  test("keeps a failed personal prewarm observable and lets the typed retry path remain", async () => {
+    const error = new Error("admission gate unavailable");
+    warmInferenceAdmissionGate.mockRejectedValue(error);
+
+    await expect(
+      prewarmPersonalSharedAgentTurnCaches(
+        { id: "personal:user-1:org-1", organization_id: "org-1" },
+        {} as never,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(loggerWarn).toHaveBeenCalledWith(
+      "[shared-runtime prewarm] leg failed; first turn falls back to warming 503s",
+      expect.objectContaining({
+        agentId: "personal:user-1:org-1",
+        organizationId: "org-1",
+        leg: "admission-gate",
         error: error.message,
       }),
     );

--- a/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts
@@ -30,11 +30,16 @@ import type { AgentSandbox } from "../../../db/repositories/agent-sandboxes";
 import type { AppEnv, RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-env";
 import { calculateCost, getProviderFromModel, normalizeModelName } from "../../pricing";
 import { logger } from "../../utils/logger";
+import { warmInferenceAdmissionGate } from "../inference-admission-gate";
 import { warmInferenceAdmissionSnapshot } from "../inference-admission-snapshot";
-import { coordinateSharedHistory } from "./conversation-coordinator";
+import {
+  coordinateSharedConversationPrewarm,
+  coordinateSharedHistory,
+} from "./conversation-coordinator";
 import { seedSharedAgentScopeCache } from "./resolve-shared-agent";
 import { resolveSharedAgentTurnModel } from "./run-shared-agent-turn";
 import { projectSharedAgentCharacter } from "./shared-agent-character";
+import type { SharedRuntimeAgent } from "./shared-runtime-agent";
 
 export interface PrewarmSharedAgentOptions {
   /**
@@ -58,6 +63,28 @@ export interface PrewarmSharedAgentOptions {
   stewardUserId?: string;
 }
 
+interface PrewarmLeg {
+  leg: string;
+  run: Promise<unknown>;
+}
+
+async function settlePrewarmLegs(
+  agent: Pick<SharedRuntimeAgent, "id" | "organization_id">,
+  legs: PrewarmLeg[],
+): Promise<void> {
+  const results = await Promise.allSettled(legs.map(({ run }) => run));
+  results.forEach((result, index) => {
+    if (result.status === "rejected") {
+      logger.warn("[shared-runtime prewarm] leg failed; first turn falls back to warming 503s", {
+        agentId: agent.id,
+        organizationId: agent.organization_id,
+        leg: legs[index].leg,
+        error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+      });
+    }
+  });
+}
+
 /**
  * Hydrate every cache the cache-only shared first turn consults. Resolves when
  * all legs have settled; never rejects (failed legs are logged and the turn
@@ -67,7 +94,15 @@ export async function prewarmSharedAgentTurnCaches(
   agent: AgentSandbox,
   options: PrewarmSharedAgentOptions = {},
 ): Promise<void> {
-  const legs: Array<{ leg: string; run: Promise<unknown> }> = [];
+  const legs: PrewarmLeg[] = [];
+
+  // The admission snapshot carries policy, while the gate is the independent
+  // serialized authority that enforces it. Warming both avoids exchanging a
+  // cache miss for a cold Durable Object timeout on the first turn.
+  legs.push({
+    leg: "admission-gate",
+    run: warmInferenceAdmissionGate(agent.organization_id),
+  });
 
   // 1. Combined admission snapshot: org balance + rate-limit tier. The
   //    projection behind "Billing authorization is warming", "Inference
@@ -129,15 +164,29 @@ export async function prewarmSharedAgentTurnCaches(
     });
   }
 
-  const results = await Promise.allSettled(legs.map(({ run }) => run));
-  results.forEach((result, index) => {
-    if (result.status === "rejected") {
-      logger.warn("[shared-runtime prewarm] leg failed; first turn falls back to warming 503s", {
-        agentId: agent.id,
-        organizationId: agent.organization_id,
-        leg: legs[index].leg,
-        error: result.reason instanceof Error ? result.reason.message : String(result.reason),
-      });
-    }
-  });
+  await settlePrewarmLegs(agent, legs);
+}
+
+/**
+ * Warm the two authorities a newly auto-registered personal agent needs.
+ * Unlike dashboard agent creation, first contact already carries the user's
+ * message, so the route awaits these concurrent legs before dispatching it.
+ */
+export async function prewarmPersonalSharedAgentTurnCaches(
+  agent: Pick<SharedRuntimeAgent, "id" | "organization_id">,
+  namespace: RuntimeDurableObjectNamespace,
+): Promise<void> {
+  await settlePrewarmLegs(agent, [
+    {
+      leg: "admission-gate",
+      run: warmInferenceAdmissionGate(agent.organization_id),
+    },
+    {
+      leg: "conversation-object",
+      run: coordinateSharedConversationPrewarm(agent.id, agent.id, {
+        namespace,
+        startEmpty: true,
+      }),
+    },
+  ]);
 }


### PR DESCRIPTION
## Summary

- prewarm a newly created personal Shared account before its first model turn
- warm the personal room and inference admission caches concurrently
- preserve sender-projection account timing and expose prewarm duration through Server-Timing
- keep established accounts on the existing direct path

Closes #20271.
Supersedes closed #20273 with a current-develop rebase.

## Validation

- personal Shared route: 25 passed, 0 failed
- prewarm cache suite: 9 passed, 0 failed
- cloud-shared typecheck passed
- changed-file Biome and git diff --check passed
- cloud-api full typecheck is environment-blocked in this borrowed-dependency worktree by unchanged plugin-sql/plugin-todos resolution; the exact API typecheck and production Wrangler dry-run passed in the primary validation worktree at the same develop base
- clean-install CI remains authoritative for the package-wide lane

## Evidence

- protected staging cold-account canary pending merge
- UI screenshots/video: N/A, backend cold-start path
- live-model trajectory: pending staging canary

Model: openai / gpt-5.6-sol
Client: Codex Desktop
Skill revision: 8ded298e8068