### PR TITLE
chore(personal-assistant): format life review regression test

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/life.review-definitions.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.review-definitions.test.ts
@@ -397,4 +397,3 @@ describe("LifeOps definition review isolation", () => {
     });
   });
 });
-


### PR DESCRIPTION
## Summary

- remove one extra trailing blank line from the life review regression test
- restore the formatting gate on current `develop` without changing runtime or test behavior

## Validation

- `bun run --cwd plugins/plugin-personal-assistant lint`
- `bun run verify`
- `git diff --check origin/develop...HEAD`

Exact head: `05969021608f`
Exact base: `8ded298e`

## Generation provenance

- Provider: OpenAI
- Model: gpt-5
- Agent: Codex desktop