### PR TITLE
fix(auth): distinguish access-token from refresh-token expiry

### DIFF
--- a/packages/auth/src/token-expiry.test.ts
+++ b/packages/auth/src/token-expiry.test.ts
@@ -11,6 +11,12 @@ describe("access-token expiry classification", () => {
     "token expired",
     "token has expired",
     "expired_token",
+    "token_expired",
+    "TOKEN_EXPIRED",
+    "error=token_expired",
+    "error: token_expired",
+    "OAuth error token_expired",
+    '{"error":"token_expired"}',
     "OAuth token has expired",
     "access token is expired",
     "JWT expired",
@@ -20,13 +26,20 @@ describe("access-token expiry classification", () => {
     expect(classifyAuthFailureReason(text)).toBe("token_expired");
   });
 
-  it.each(["401 unauthorized", "invalid token", "credentials revoked"])(
-    "does not infer expiry from a generic authorization failure: %s",
-    (text) => {
-      expect(isTokenExpiryText(text)).toBe(false);
-      expect(classifyAuthFailureReason(text)).toBe("needs_reauth");
-    },
-  );
+  it.each([
+    "401 unauthorized",
+    "invalid token",
+    "credentials revoked",
+    "refresh token expired",
+    "refresh token has expired",
+    "refresh token is expired",
+    "The refresh token expired",
+    "refresh_token_expired",
+    "error=refresh_token_expired",
+  ])("requires reauthentication for non-access-token failures: %s", (text) => {
+    expect(isTokenExpiryText(text)).toBe(false);
+    expect(classifyAuthFailureReason(text)).toBe("needs_reauth");
+  });
 
   it("preserves missing provider detail as an unknown reason", () => {
     expect(isTokenExpiryText(undefined)).toBe(false);

--- a/packages/auth/src/token-expiry.ts
+++ b/packages/auth/src/token-expiry.ts
@@ -12,12 +12,18 @@ export type CodingAuthFailureReason =
   | "rate_limited"
   | "unknown";
 
+const REFRESH_TOKEN_EXPIRED_PATTERN =
+  /\brefresh[_ ]token[_ ](?:(?:has|is)[_ ])?expired\b/i;
 const TOKEN_EXPIRED_PATTERN =
-  /\b(?:token (?:has )?expired|expired[_ ]?token|oauth token (?:has )?expired|access token (?:has )?expired|token is expired|jwt expired|session expired)\b/i;
+  /\b(?:token[_ ](?:has[_ ])?expired|expired[_ ]?token|oauth token (?:has )?expired|access token (?:has )?expired|token is expired|jwt expired|session expired)\b/i;
 
 /** Returns true only for explicit access-token expiry language. */
 export function isTokenExpiryText(text: string | null | undefined): boolean {
-  return !!text && TOKEN_EXPIRED_PATTERN.test(text);
+  return (
+    !!text &&
+    !REFRESH_TOKEN_EXPIRED_PATTERN.test(text) &&
+    TOKEN_EXPIRED_PATTERN.test(text)
+  );
 }
 
 /** Refines an auth-shaped provider error without widening the auth classifier. */


### PR DESCRIPTION
# Relates to

Fixes #20565

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is based on the latest `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile`, package gates, focused consumer tests, and exact-head proof were run after sync.
- [ ] Root `bun run verify` exits in unrelated existing Biome findings across five unaffected paths; exact paths and output are recorded below.
- [x] A reviewer can confirm both recovery decisions from the deterministic classifier proof below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Claude Code via CLIProxyAPI
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@ec14fcf439db4c410fd173d1a5095f96076a9607:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Based on `origin/develop` at `1bbb3b6b18cf344846da0a570e328c33ddca7270`; zero conflicts.
- [x] Read-only ownership scan covered all 59 live open PRs; neither target path overlaps an open PR. The sole PR with more than 100 changed files was checked through its complete files endpoint.

# Risks

Low. The patch changes only the shared text classifier's distinction between access-token expiry and expired refresh grants. Existing access-expiry, generic authorization, missing-detail, and rate-limit behavior is preserved. The compatibility risk is limited to a caller that incorrectly relied on treating an expired refresh token as a reusable access-token expiry; requiring reauthentication is the intended recovery.

# Background

## What does this PR do?

Recognizes `token_expired` machine-code forms as explicit access-token expiry while excluding `refresh token expired` and `refresh_token_expired` forms from that class. Expired refresh grants therefore resolve to `needs_reauth` instead of the recoverable `token_expired` reason.

The focused suite adds adversarial tables for uppercase, query-style, colon-delimited, prose, and JSON-shaped access-expiry text, plus spaced and underscored refresh-grant failures.

## What kind of change is this?

Bug fix (backend auth-failure classification without credential handling).

# Documentation changes needed?

No. This restores the public classifier's documented access-token-only boundary and does not change package exports or provider setup.

# Testing

## Where should a reviewer start?

- `packages/auth/src/token-expiry.ts`
- `packages/auth/src/token-expiry.test.ts`

## Detailed testing steps

```bash
bun install --frozen-lockfile
bun run --cwd packages/shared build
bun run --cwd packages/cloud/routing build
bun run --cwd packages/core build
bun run --cwd packages/vault build
bun run --cwd packages/auth test src/token-expiry.test.ts
bun run --cwd packages/auth test
bun run --cwd packages/auth typecheck
bun run --cwd packages/auth lint:check
bun run --cwd packages/auth format:check
bun run --cwd packages/auth build
bun run --cwd packages/app-core test src/services/claude-token-refresh.test.ts
bun run --cwd plugins/plugin-agent-orchestrator test __tests__/unit/coding-account-selection.test.ts __tests__/unit/account-failure-propagation.test.ts
git diff --check
```

# Evidence Gate

<!-- evidence-head:7d1666d5d5d534fb4bdb87df5b3e3dd6c35b046a -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only text classification; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only text classification; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual or interactive frontend flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no live authentication, provider request, or credential mutation was authorized or needed; the exported pure classifier is exercised directly.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or network client behavior changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head deterministic classifier and downstream consumer proof:

```text
Tests-first baseline before the production change:
10 failed, 11 passed
- token_expired variants were missed
- refresh-token expiry variants were misclassified as access expiry

Final base 1bbb3b6b18cf344846da0a570e328c33ddca7270; exact head 7d1666d5d5d534fb4bdb87df5b3e3dd6c35b046a:
- toolchain: Bun 1.3.14; Node 24.15.0
- bun install --frozen-lockfile: passed (3,822 installs checked; no changes)
- prerequisite shared, cloud/routing, core, and vault builds: passed
- focused token-expiry suite: 23 passed
- complete @elizaos/auth suite: 162 passed
- app-core token-refresh consumer suite: 23 passed
- orchestrator classifier consumer suites: 36 passed
- @elizaos/auth typecheck: passed
- @elizaos/auth lint:check: passed (24 files)
- @elizaos/auth format:check: passed (24 files)
- @elizaos/auth build: passed
- root bun run verify: failed only in unrelated existing Biome findings listed below
- git diff --check: clean
- final tree: clean, exactly one commit ahead of origin/develop
```

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, prompt, provider, or model behavior changed.

## Backend + frontend logs

No live authentication flow or credential material was accessed. The deterministic boundary proof uses only literal error strings and the exported classifier.

The red-first matrix demonstrated the two opposite failures. The final 23-case focused suite proves `token_expired` forms become access expiry while refresh-grant failures require reauthentication. The complete auth and downstream consumer suites pass at the exact candidate head.

## Known gaps / failures

Root `bun run verify` was rerun on `7d1666d5d5d534fb4bdb87df5b3e3dd6c35b046a` with Bun 1.3.14 and Node 24.15.0. It reached the workspace typecheck/lint phase and exited in unrelated existing Biome findings:

- `packages/core/src/features/advanced-capabilities/providers/facts.ts` — import organization and formatting;
- `packages/core/src/runtime/__tests__/message-handler-output.test.ts` — formatting;
- `packages/core/src/runtime/__tests__/message-handler.test.ts` — formatting;
- `packages/core/src/services/message.ts` — formatting;
- `plugins/plugin-agent-orchestrator/src/actions/tasks.ts` — formatting.

`git diff --exit-code origin/develop --` is clean for all five paths. The i18n check also printed the repository's existing missing-translation inventory but continued successfully to later gates. The changed auth package's complete tests, typecheck, lint, format, build, focused downstream consumers, and diff check all pass at the exact candidate head.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Claude Code via CLIProxyAPI
Contribution skill revision: elizaOS/eliza@ec14fcf439db4c410fd173d1a5095f96076a9607:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [sol-eliza-auth-expiry]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code via CLIProxyAPI","skill_revision":"elizaOS/eliza@ec14fcf439db4c410fd173d1a5095f96076a9607:packages/skills/skills/contribute-to-eliza"} -->
