### PR TITLE
perf(cloud): expose social turn timing

### DIFF
--- a/packages/cloud/services/gateway-discord/src/dm-polling.ts
+++ b/packages/cloud/services/gateway-discord/src/dm-polling.ts
@@ -20,6 +20,9 @@ export interface DiscordDmPollReport {
   removed: number;
 }
 
+const DEFAULT_CHANNEL_CONCURRENCY = 4;
+const MAX_CHANNEL_CONCURRENCY = 16;
+
 function compareSnowflakes(left: string, right: string): number {
   const a = BigInt(left);
   const b = BigInt(right);
@@ -41,6 +44,8 @@ export async function pollTrackedDiscordDms<
   removeTracked: (state: TrackedDiscordDm) => Promise<void>;
   isTerminalChannelError: (error: unknown) => boolean;
   onError?: (state: TrackedDiscordDm, error: unknown) => void;
+  /** Bounds parallel Discord REST reads while preserving order within a DM. */
+  channelConcurrency?: number;
 }): Promise<DiscordDmPollReport> {
   const report: DiscordDmPollReport = {
     channels: 0,
@@ -52,7 +57,17 @@ export async function pollTrackedDiscordDms<
 
   const tracked = await options.listTracked();
   report.channels = tracked.length;
-  for (const state of tracked) {
+  const requestedConcurrency =
+    options.channelConcurrency ?? DEFAULT_CHANNEL_CONCURRENCY;
+  const finiteConcurrency = Number.isFinite(requestedConcurrency)
+    ? Math.floor(requestedConcurrency)
+    : DEFAULT_CHANNEL_CONCURRENCY;
+  const concurrency = Math.max(
+    1,
+    Math.min(MAX_CHANNEL_CONCURRENCY, finiteConcurrency),
+  );
+  let nextIndex = 0;
+  const pollChannel = async (state: TrackedDiscordDm): Promise<void> => {
     let messages: T[];
     try {
       messages = await options.fetchAfter(state);
@@ -63,7 +78,7 @@ export async function pollTrackedDiscordDms<
       } else {
         options.onError?.(state, error);
       }
-      continue;
+      return;
     }
 
     messages.sort((left, right) => compareSnowflakes(left.id, right.id));
@@ -81,6 +96,17 @@ export async function pollTrackedDiscordDms<
       await options.updateCursor(state, message.id);
       state.lastMessageId = message.id;
     }
-  }
+  };
+  const worker = async (): Promise<void> => {
+    while (nextIndex < tracked.length) {
+      const state = tracked[nextIndex++];
+      if (state) await pollChannel(state);
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, tracked.length) }, () =>
+      worker(),
+    ),
+  );
   return report;
 }

--- a/packages/cloud/services/gateway-discord/tests/dm-polling.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/dm-polling.test.ts
@@ -80,4 +80,50 @@ describe("pollTrackedDiscordDms", () => {
     expect(onError).not.toHaveBeenCalled();
     expect(report.removed).toBe(1);
   });
+
+  it("polls channels concurrently without reordering messages inside a channel", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const routed: string[] = [];
+    const report = await pollTrackedDiscordDms({
+      listTracked: async () =>
+        ["1", "2", "3", "4"].map((suffix) => ({
+          channelId: `channel-${suffix}`,
+          userId: `user-${suffix}`,
+          lastMessageId: "100",
+        })),
+      fetchAfter: async (state) => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        active -= 1;
+        return [
+          {
+            id: `${state.channelId.slice(-1)}02`,
+            author: { bot: false },
+            content: "second",
+          },
+          {
+            id: `${state.channelId.slice(-1)}01`,
+            author: { bot: false },
+            content: "first",
+          },
+        ];
+      },
+      claimMessage: async () => true,
+      routeMessage: async (message) => routed.push(message.id),
+      updateCursor: async () => {},
+      removeTracked: async () => {},
+      isTerminalChannelError: () => false,
+      channelConcurrency: 2,
+    });
+
+    expect(maxActive).toBe(2);
+    for (const suffix of ["1", "2", "3", "4"]) {
+      expect(routed.indexOf(`${suffix}01`)).toBeLessThan(
+        routed.indexOf(`${suffix}02`),
+      );
+    }
+    expect(report).toMatchObject({ channels: 4, messages: 8, routed: 8 });
+  });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.test.ts
@@ -79,6 +79,24 @@ describe("handleCanonicalScopedAgentStream", () => {
     });
   });
 
+  test("preserves coordinator phase timings beside route timings", async () => {
+    coordinateSharedStream.mockResolvedValueOnce(
+      new Response("event: done\ndata: {}\n\n", {
+        headers: {
+          "Content-Type": "text/event-stream; charset=utf-8",
+          "Server-Timing":
+            "turn_claim;dur=1.2, turn_hydrate;dur=3.4, turn_admission;dur=5.6, turn_provider_setup;dur=7.8",
+        },
+      }),
+    );
+
+    const res = await handleCanonicalScopedAgentStream(BASE);
+
+    expect(res.headers.get("Server-Timing")).toMatch(
+      /^turn_claim;dur=1\.2, turn_hydrate;dur=3\.4, turn_admission;dur=5\.6, turn_provider_setup;dur=7\.8, parse;dur=\d+(?:\.\d+)?, bridge;dur=\d+(?:\.\d+)?$/,
+    );
+  });
+
   test("does not trust a system role supplied in the ordinary request body", async () => {
     await handleCanonicalScopedAgentStream({
       ...BASE,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/canonical-scoped-stream.ts
@@ -57,10 +57,9 @@ function addStreamTimingHeaders(response: Response, timings: Record<string, numb
   const headers = new Headers(response.headers);
   const entries = Object.entries(timings).filter(([, duration]) => Number.isFinite(duration));
   if (entries.length) {
-    headers.set(
-      "Server-Timing",
-      entries.map(([phase, duration]) => `${phase};dur=${duration}`).join(", "),
-    );
+    const current = entries.map(([phase, duration]) => `${phase};dur=${duration}`).join(", ");
+    const upstream = headers.get("Server-Timing");
+    headers.set("Server-Timing", upstream ? `${upstream}, ${current}` : current);
     for (const [phase, duration] of entries) {
       headers.set(`X-Eliza-Stream-${phase}-Ms`, String(duration));
     }
@@ -227,9 +226,13 @@ export async function handleCanonicalScopedAgentStream(
     );
   }
 
+  const streamHeaders = new Headers(STREAM_HEADERS);
+  const upstreamTiming = upstream.headers.get("Server-Timing");
+  if (upstreamTiming) streamHeaders.set("Server-Timing", upstreamTiming);
+
   return addStreamTimingHeaders(
     applyCorsHeaders(
-      new Response(upstream.body, { headers: STREAM_HEADERS }),
+      new Response(upstream.body, { headers: streamHeaders }),
       CORS_METHODS,
       request.origin,
     ),

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -1213,9 +1213,13 @@ describe("SharedRuntimeChatService", () => {
     const options = { ...h, turnClaims: store };
 
     const first = await service.stream(agent, keyedRpc, options);
+    expect(first.headers.get("Server-Timing")).toMatch(
+      /turn_claim;dur=\d+(?:\.\d+)?, turn_hydrate;dur=\d+(?:\.\d+)?, turn_admission;dur=\d+(?:\.\d+)?, turn_provider_setup;dur=\d+(?:\.\d+)?/,
+    );
     const firstBody = await first.text();
     await Promise.all(h.background);
     const second = await service.stream(agent, keyedRpc, options);
+    expect(second.headers.get("Server-Timing")).toMatch(/^turn_claim;dur=\d+(?:\.\d+)?$/);
     const secondBody = await second.text();
 
     expect(streamTurnCalls).toBe(1);

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -71,6 +71,24 @@ const PROVIDER_CANCELLATION_OBSERVE_MS = 5_000;
 const PERSONAL_SHARED_RATE_LIMIT = { windowMs: 60_000, maxRequests: 60 } as const;
 const linkedCharacterMemoryCache = new InMemoryLRUCache<UserCharacter>(256, 60_000);
 
+function elapsedTurnMs(startedAt: number): number {
+  return Math.round((performance.now() - startedAt) * 10) / 10;
+}
+
+function withTurnTimingHeaders(response: Response, timings: Record<string, number>): Response {
+  const entries = Object.entries(timings).filter(([, duration]) => Number.isFinite(duration));
+  if (entries.length === 0) return response;
+  const headers = new Headers(response.headers);
+  const existing = headers.get("Server-Timing");
+  const current = entries.map(([phase, duration]) => `${phase};dur=${duration}`).join(", ");
+  headers.set("Server-Timing", existing ? `${existing}, ${current}` : current);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
 export type BridgeExecutionContext = {
   waitUntil(promise: Promise<unknown>): void;
 };
@@ -915,6 +933,7 @@ export class SharedRuntimeChatService {
     rpc: BridgeRequest,
     options: SharedRuntimeChatOptions = {},
   ): Promise<Response> {
+    const timings: Record<string, number> = {};
     const params = record(rpc.params) ?? {};
     const text = stringValue(params.text);
     if (!text) return sseError("message.send requires params.text");
@@ -922,28 +941,34 @@ export class SharedRuntimeChatService {
     const messageRole = options.trustedMessageRole ?? "user";
     const claimKey = options.turnClaims ? sharedTurnClientMessageId(params) : undefined;
     if (claimKey && options.turnClaims) {
+      const claimStartedAt = performance.now();
       const replay = await claimSharedTurn(options.turnClaims, claimKey, text);
+      timings.turn_claim = elapsedTurnMs(claimStartedAt);
       if (replay) {
-        return new Response(
-          chatSseFrame("chunk", {
-            messageId: replay.messageId,
-            userMessageId: replay.userMessageId,
-            chunk: replay.text,
-            text: replay.text,
-            fullText: replay.text,
-            timestamp: Date.now(),
-          }) +
-            chatSseFrame("done", {
+        return withTurnTimingHeaders(
+          new Response(
+            chatSseFrame("chunk", {
               messageId: replay.messageId,
               userMessageId: replay.userMessageId,
+              chunk: replay.text,
               text: replay.text,
               fullText: replay.text,
-              ...(replay.actionResults ? { actionResults: replay.actionResults } : {}),
-            }),
-          { headers: { "Content-Type": "text/event-stream; charset=utf-8" } },
+              timestamp: Date.now(),
+            }) +
+              chatSseFrame("done", {
+                messageId: replay.messageId,
+                userMessageId: replay.userMessageId,
+                text: replay.text,
+                fullText: replay.text,
+                ...(replay.actionResults ? { actionResults: replay.actionResults } : {}),
+              }),
+            { headers: { "Content-Type": "text/event-stream; charset=utf-8" } },
+          ),
+          timings,
         );
       }
     }
+    const hydrateStartedAt = performance.now();
     const [character, history] = await Promise.all([
       characterFor(agent, {
         cacheOnly: Boolean(options.historyStore),
@@ -951,7 +976,9 @@ export class SharedRuntimeChatService {
       }),
       loadHistory(agent.id, roomId, options.historyStore, text),
     ]);
+    timings.turn_hydrate = elapsedTurnMs(hydrateStartedAt);
     let billing: BillingTurn | null;
+    const admissionStartedAt = performance.now();
     try {
       billing = await admitTurn(
         agent,
@@ -972,6 +999,7 @@ export class SharedRuntimeChatService {
       }
       throw error;
     }
+    timings.turn_admission = elapsedTurnMs(admissionStartedAt);
     const messageIds = turnMessageIds(agent.id, roomId, claimKey);
     const generationAbort = new AbortController();
     const abortFromRequest = () => {
@@ -987,6 +1015,7 @@ export class SharedRuntimeChatService {
     const detachRequestAbort = () =>
       options.abortSignal?.removeEventListener("abort", abortFromRequest);
     let turn: Awaited<ReturnType<typeof runSharedAgentTurnStream>>;
+    const providerSetupStartedAt = performance.now();
     try {
       turn = await runSharedAgentTurnStream({
         abortSignal: generationAbort.signal,
@@ -1014,29 +1043,33 @@ export class SharedRuntimeChatService {
       );
       throw error;
     }
+    timings.turn_provider_setup = elapsedTurnMs(providerSetupStartedAt);
     if (turn.degraded) {
       detachRequestAbort();
       await billing?.settle(0);
       const reply = turn.reply?.trim() ?? "";
       if (!reply) return sseError("Shared runtime is unavailable");
-      return new Response(
-        chatSseFrame("chunk", {
-          messageId: messageIds.assistant,
-          userMessageId: messageIds.user,
-          chunk: reply,
-          text: reply,
-          fullText: reply,
-          timestamp: Date.now(),
-        }) +
-          chatSseFrame("done", {
+      return withTurnTimingHeaders(
+        new Response(
+          chatSseFrame("chunk", {
             messageId: messageIds.assistant,
             userMessageId: messageIds.user,
+            chunk: reply,
             text: reply,
             fullText: reply,
-          }),
-        {
-          headers: { "Content-Type": "text/event-stream; charset=utf-8" },
-        },
+            timestamp: Date.now(),
+          }) +
+            chatSseFrame("done", {
+              messageId: messageIds.assistant,
+              userMessageId: messageIds.user,
+              text: reply,
+              fullText: reply,
+            }),
+          {
+            headers: { "Content-Type": "text/event-stream; charset=utf-8" },
+          },
+        ),
+        timings,
       );
     }
     if (!turn.parts) {
@@ -1047,7 +1080,7 @@ export class SharedRuntimeChatService {
         options.executionCtx,
         "stream returned without a provider body",
       );
-      return sseError("Shared runtime stream did not start");
+      return withTurnTimingHeaders(sseError("Shared runtime stream did not start"), timings);
     }
 
     const encoder = new TextEncoder();
@@ -1266,12 +1299,15 @@ export class SharedRuntimeChatService {
         );
       },
     });
-    return new Response(stream, {
-      headers: {
-        "Content-Type": "text/event-stream; charset=utf-8",
-        "Cache-Control": "no-cache, no-transform",
-      },
-    });
+    return withTurnTimingHeaders(
+      new Response(stream, {
+        headers: {
+          "Content-Type": "text/event-stream; charset=utf-8",
+          "Cache-Control": "no-cache, no-transform",
+        },
+      }),
+      timings,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

- preserve Shared turn claim, hydrate, admission, and provider-setup durations in Server-Timing
- carry coordinator timings through the canonical scoped stream instead of overwriting them
- make the existing webhook gateway log those phases through its cloudServerTiming field
- poll tracked Discord fallback DM channels with bounded concurrency while retaining strict per-channel ordering and durable message claims

Part of #16079.

## Why

Warm social turns still spend most of their wall time outside model inference. The prior header exposed only account and aggregate Shared time, which could not distinguish Durable Object claim, history/character hydration, inference admission, or provider setup. User-installed Discord DMs also scanned tracked channels serially, so one slow REST read delayed unrelated DMs.

## Safety

- no history, billing, claim, or egress ordering changed
- message order stays sequential inside each Discord channel
- fallback concurrency is capped at four by default and sixteen at the API boundary
- Server-Timing contains only phase names and durations, never message content or credentials

## Validation

- gateway-discord full suite: 109 passed, 0 failed, 335 assertions
- Shared runtime chat: 28 passed, 0 failed, 146 assertions
- canonical scoped stream: 9 passed, 0 failed, 33 assertions
- cloud-shared typecheck passed
- gateway-discord typecheck, lint, and build passed
- changed-file Biome and diff-check passed

## Evidence

- backend contract tests above
- staging live timing matrix pending merge
- UI screenshots/video: N/A, transport telemetry and scheduler change
- live-model trajectory: pending staging canary

Model: openai / gpt-5.6-sol
Client: Codex Desktop
Skill revision: 23765a1da05f