### PR TITLE
release: promote develop to main (voice and provider fixes)

### DIFF
--- a/packages/agent/src/api/approval-routes.test.ts
+++ b/packages/agent/src/api/approval-routes.test.ts
@@ -3,8 +3,9 @@
  * `approvalTaskToPendingAction` projection: pending user actions are merged
  * newest-first and de-duplicated across the approval queue, the ApprovalService
  * task rows, and the pending-prompts service, and missing services yield empty
- * arrays. Runs against a mock runtime and a real ApprovalService backed by an
- * in-memory task store — no live model or HTTP.
+ * arrays. The untrusted `limit` query is fail-closed. Runs against a mock
+ * runtime and a real ApprovalService backed by an in-memory task store — no
+ * live model or HTTP.
  */
 import type http from "node:http";
 import type { PendingUserAction, Task, UUID } from "@elizaos/core";
@@ -367,6 +368,73 @@ describe("handleApprovalRoute", () => {
       approvals: [],
       pending: [],
       pendingUserActions: [],
+    });
+  });
+
+  it.each([
+    "1e3",
+    "50abc",
+    "0x10",
+    "50.5",
+    "abc",
+    "-1",
+    "1_000",
+    "+5",
+    " 5",
+    "5 ",
+    "0",
+    "Infinity",
+    "NaN",
+    "01",
+  ])("rejects malformed limit %j with 400", async (raw) => {
+    const { runtime, queueList } = runtimeWithApprovals({});
+    const helpers = makeHelpers();
+
+    const handled = await handleApprovalRoute(
+      req(`/api/approvals?limit=${encodeURIComponent(raw)}`),
+      res,
+      "/api/approvals",
+      "GET",
+      { runtime },
+      helpers,
+    );
+
+    expect(handled).toBe(true);
+    expect(helpers.error).toHaveBeenCalledWith(
+      res,
+      "limit must be a positive integer",
+      400,
+    );
+    expect(helpers.json).not.toHaveBeenCalled();
+    expect(queueList).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [undefined, 50],
+    ["5", 5],
+    ["500", 500],
+    ["501", 500],
+  ] as const)("accepts limit %j as %s", async (raw, expected) => {
+    const { runtime, queueList } = runtimeWithApprovals({});
+    const helpers = makeHelpers();
+    const url =
+      raw === undefined ? "/api/approvals" : `/api/approvals?limit=${raw}`;
+
+    await handleApprovalRoute(
+      req(url),
+      res,
+      "/api/approvals",
+      "GET",
+      { runtime },
+      helpers,
+    );
+
+    expect(helpers.error).not.toHaveBeenCalled();
+    expect(queueList).toHaveBeenCalledWith({
+      subjectUserId: null,
+      state: "pending",
+      action: null,
+      limit: expected,
     });
   });
 });

--- a/packages/agent/src/api/approval-routes.ts
+++ b/packages/agent/src/api/approval-routes.ts
@@ -115,10 +115,13 @@ function isApprovalTaskService(
   );
 }
 
-function parseLimit(raw: string | null): number {
-  if (!raw) return 50;
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) return 50;
+function parseLimit(raw: string | null): number | null {
+  if (raw === null || raw === "") return 50;
+  // Strict decimal digits only. Number.parseInt("1e3", 10) === 1 would
+  // silently under-read a client page size as 1.
+  if (!/^[1-9]\d*$/.test(raw)) return null;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return null;
   return Math.min(parsed, 500);
 }
 
@@ -319,11 +322,16 @@ export async function handleApprovalRoute(
   }
 
   const url = new URL(req.url ?? pathname, "http://localhost");
+  const limit = parseLimit(url.searchParams.get("limit"));
+  if (limit === null) {
+    helpers.error(res, "limit must be a positive integer", 400);
+    return true;
+  }
   const filter: ApprovalListFilter = {
     subjectUserId: null,
     state: parseState(url.searchParams.get("state")),
     action: null,
-    limit: parseLimit(url.searchParams.get("limit")),
+    limit,
   };
 
   const queue = getAgentApprovalQueue(state);

--- a/packages/cloud/api/__tests__/generate-music-provider-health.test.ts
+++ b/packages/cloud/api/__tests__/generate-music-provider-health.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Regression coverage for the generate-music provider health gate (#18436).
+ *
+ * A hanging fal upstream used to hold every music request toward the 300s
+ * ceiling. The route now feeds provider outcomes into a per provider+model
+ * breaker and, while it is open, fails fast with a structured 503 BEFORE
+ * content safety, pricing, or the credit hold — so no billable work is
+ * admitted toward a known-degraded upstream. The breaker module is real;
+ * auth, rate limiting, pricing, credits, and the audio provider are mocked.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as workersHonoAuthActual from "@/lib/auth/workers-hono-auth";
+import * as rateLimitActual from "@/lib/middleware/rate-limit-hono-cloudflare";
+import * as audioRegistryActual from "@/lib/providers/audio/registry";
+import * as aiPricingActual from "@/lib/services/ai-pricing";
+import * as contentSafetyActual from "@/lib/services/content-safety";
+import * as creditsActual from "@/lib/services/credits";
+import * as generationsActual from "@/lib/services/generations";
+import { resetGenerativeProviderHealthForTests } from "@/lib/services/generative-provider-health";
+
+const ORG = "00000000-0000-4000-8000-000000001842";
+const USER = "00000000-0000-4000-8000-000000001843";
+const MINIMAX = "fal-ai/minimax-music/v2.6";
+
+const requireUserOrApiKeyWithOrg = mock();
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  ...workersHonoAuthActual,
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  ...rateLimitActual,
+  RateLimitPresets: { STRICT: { limit: 1, windowSeconds: 1 } },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/services/content-safety", () => ({
+  ...contentSafetyActual,
+  contentSafetyService: {
+    ...contentSafetyActual.contentSafetyService,
+    assertSafeForPublicUse: async () => undefined,
+  },
+}));
+
+const calculateMusicGenerationCostFromCatalog = mock();
+mock.module("@/lib/services/ai-pricing", () => ({
+  ...aiPricingActual,
+  calculateMusicGenerationCostFromCatalog,
+}));
+
+const reserve = mock();
+mock.module("@/lib/services/credits", () => ({
+  ...creditsActual,
+  creditsService: { ...creditsActual.creditsService, reserve },
+}));
+
+const generationsCreate = mock();
+mock.module("@/lib/services/generations", () => ({
+  ...generationsActual,
+  generationsService: {
+    ...generationsActual.generationsService,
+    create: generationsCreate,
+  },
+}));
+
+const getAudioProvider = mock();
+const generateAudio = mock();
+mock.module("@/lib/providers/audio/registry", () => ({
+  ...audioRegistryActual,
+  getAudioProvider,
+}));
+
+const musicRoute = (await import("../v1/generate-music/route")).default;
+
+afterAll(() => {
+  mock.module("@/lib/auth/workers-hono-auth", () => workersHonoAuthActual);
+  mock.module(
+    "@/lib/middleware/rate-limit-hono-cloudflare",
+    () => rateLimitActual,
+  );
+  mock.module("@/lib/services/content-safety", () => contentSafetyActual);
+  mock.module("@/lib/services/ai-pricing", () => aiPricingActual);
+  mock.module("@/lib/services/credits", () => creditsActual);
+  mock.module("@/lib/services/generations", () => generationsActual);
+  mock.module("@/lib/providers/audio/registry", () => audioRegistryActual);
+});
+
+type AppCtx = { set: (k: string, v: unknown) => void };
+
+const COST = {
+  totalCost: 0.18,
+  baseTotalCost: 0.15,
+  platformMarkup: 0.03,
+  matchedEntry: {
+    billingSource: "fal",
+    provider: "fal",
+    model: MINIMAX,
+    productFamily: "music",
+    chargeType: "generation",
+    unit: "request",
+    unitPrice: 0.15,
+    dimensions: {},
+    sourceKind: "fal_model_page",
+    sourceUrl: "https://fal.ai/models/fal-ai/minimax-music/v2.6/api",
+  },
+};
+
+function makeReservation() {
+  const state = { reconcileCalls: 0, lastActual: Number.NaN };
+  return {
+    state,
+    reservation: {
+      reservedAmount: COST.totalCost,
+      reconcile: async (actualCost: number) => {
+        state.reconcileCalls++;
+        state.lastActual = actualCost;
+        return undefined;
+      },
+    },
+  };
+}
+
+function post(body: Record<string, unknown>) {
+  return musicRoute.request(
+    "/",
+    {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer eliza_test_key",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+    { FAL_KEY: "fal-test-key" },
+  );
+}
+
+beforeEach(() => {
+  resetGenerativeProviderHealthForTests();
+  requireUserOrApiKeyWithOrg.mockReset();
+  calculateMusicGenerationCostFromCatalog.mockReset();
+  reserve.mockReset();
+  generationsCreate.mockReset();
+  getAudioProvider.mockReset();
+  generateAudio.mockReset();
+
+  requireUserOrApiKeyWithOrg.mockImplementation(async (c: AppCtx) => {
+    c.set("apiKeyId", "key-1");
+    return {
+      id: USER,
+      organization_id: ORG,
+      organization: { id: ORG, name: "Org", is_active: true },
+      is_active: true,
+    };
+  });
+  calculateMusicGenerationCostFromCatalog.mockResolvedValue(COST);
+  getAudioProvider.mockImplementation((billingSource: string) => ({
+    billingSource,
+    generate: generateAudio,
+  }));
+});
+
+async function failUpstreamOnce(message: string) {
+  const { reservation } = makeReservation();
+  reserve.mockResolvedValueOnce(reservation);
+  generateAudio.mockRejectedValueOnce(new Error(message));
+  const res = await post({ model: MINIMAX, prompt: "night drive synthwave" });
+  expect(res.status).toBeGreaterThanOrEqual(500);
+  return res;
+}
+
+describe("generate-music provider health gate", () => {
+  test("three upstream timeouts open the gate; the next request fails fast before any credit hold", async () => {
+    for (let i = 0; i < 3; i++) {
+      await failUpstreamOnce(
+        "fal queue job timed out after 300000ms (request r1)",
+      );
+    }
+    expect(generateAudio).toHaveBeenCalledTimes(3);
+    const reservesBefore = reserve.mock.calls.length;
+
+    const res = await post({ model: MINIMAX, prompt: "lofi rain" });
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toMatch(/^\d+$/);
+    const body = (await res.json()) as {
+      success: boolean;
+      error: string;
+      code: string;
+      details?: Record<string, unknown>;
+    };
+    expect(body.success).toBe(false);
+    expect(body.code).toBe("service_unavailable");
+    expect(body.error).toContain("backed up");
+    expect(body.details?.provider).toBe("fal");
+    expect(body.details?.model).toBe(MINIMAX);
+    expect(body.details?.lastFailureKind).toBe("timeout");
+    expect(typeof body.details?.retryAfterSeconds).toBe("number");
+
+    // Fail-fast happened before admission and before the provider call.
+    expect(reserve.mock.calls.length).toBe(reservesBefore);
+    expect(generateAudio).toHaveBeenCalledTimes(3);
+  });
+
+  test("upstream 5xx failures also open the gate", async () => {
+    for (let i = 0; i < 3; i++) {
+      await failUpstreamOnce("fal queue submit failed (503)");
+    }
+    const res = await post({ model: MINIMAX, prompt: "lofi rain" });
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe("service_unavailable");
+    expect(generateAudio).toHaveBeenCalledTimes(3);
+  });
+
+  test("config errors (bad key 401) keep failing per request without tripping the gate", async () => {
+    for (let i = 0; i < 3; i++) {
+      await failUpstreamOnce("fal queue submit failed (401): invalid key");
+    }
+    const { reservation } = makeReservation();
+    reserve.mockResolvedValueOnce(reservation);
+    generateAudio.mockRejectedValueOnce(
+      new Error("fal queue submit failed (401): invalid key"),
+    );
+    const res = await post({ model: MINIMAX, prompt: "lofi rain" });
+    // Still reaches the provider — misconfiguration is not an outage.
+    expect(generateAudio).toHaveBeenCalledTimes(4);
+    expect(res.status).not.toBe(503);
+  });
+
+  test("a success closes the gate and later requests flow normally", async () => {
+    await failUpstreamOnce("fal queue job timed out after 300000ms (r1)");
+    await failUpstreamOnce("fal queue job timed out after 300000ms (r2)");
+
+    const { reservation } = makeReservation();
+    reserve.mockResolvedValueOnce(reservation);
+    generationsCreate.mockResolvedValue({ id: "gen-music" });
+    generateAudio.mockResolvedValueOnce({
+      source: "hosted",
+      url: "https://v3b.fal.media/files/music-output.mp3",
+      fileName: "music-output.mp3",
+      fileSize: 1234,
+      contentType: "audio/mpeg",
+      requestId: "req-music",
+      status: "completed",
+      raw: { audio: { url: "https://v3b.fal.media/files/music-output.mp3" } },
+    });
+    const ok = await post({ model: MINIMAX, prompt: "sunrise piano" });
+    expect(ok.status).toBe(200);
+
+    // Two fresh strikes after the success must not open the gate (streak reset).
+    await failUpstreamOnce("fal queue job timed out after 300000ms (r3)");
+    await failUpstreamOnce("fal queue job timed out after 300000ms (r4)");
+    const { reservation: r2 } = makeReservation();
+    reserve.mockResolvedValueOnce(r2);
+    generateAudio.mockResolvedValueOnce({
+      source: "hosted",
+      url: "https://v3b.fal.media/files/music-output-2.mp3",
+      contentType: "audio/mpeg",
+      requestId: "req-music-2",
+      status: "completed",
+      raw: { audio: { url: "https://v3b.fal.media/files/music-2.mp3" } },
+    });
+    const stillOpen = await post({ model: MINIMAX, prompt: "sunset piano" });
+    expect(stillOpen.status).toBe(200);
+  });
+
+  test("failed requests that trip the breaker still refund their hold", async () => {
+    const { state, reservation } = makeReservation();
+    reserve.mockResolvedValueOnce(reservation);
+    generateAudio.mockRejectedValueOnce(
+      new Error("fal queue job timed out after 300000ms (request r9)"),
+    );
+    const res = await post({ model: MINIMAX, prompt: "storm ambience" });
+    expect(res.status).toBeGreaterThanOrEqual(500);
+    expect(state.reconcileCalls).toBe(1);
+    expect(state.lastActual).toBe(0);
+  });
+});

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -606,7 +606,7 @@ describe("cloud-api worker entrypoint", () => {
     }
   });
 
-  test("keeps legacy UUID agents proxied while redirecting public service hosts", () => {
+  test("redirects legacy UUID agents and public service hosts", () => {
     const response = redirectFrontendHost(
       new URL(
         "https://e06bb509-6c52-4c33-a9f7-66addc43e8c8.elizacloud.ai/chat?room=1",
@@ -614,7 +614,20 @@ describe("cloud-api worker entrypoint", () => {
       { ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app" },
     );
 
-    expect(response).toBeNull();
+    expect(response?.status).toBe(308);
+    expect(response?.headers.get("location")).toBe(
+      "https://e06bb509-6c52-4c33-a9f7-66addc43e8c8.cloud.eliza.app/chat?room=1",
+    );
+    const stagingResponse = redirectFrontendHost(
+      new URL(
+        "https://e06bb509-6c52-4c33-a9f7-66addc43e8c8.staging.elizacloud.ai/api/health?probe=1",
+      ),
+      { ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud-staging.eliza.app" },
+    );
+    expect(stagingResponse?.status).toBe(308);
+    expect(stagingResponse?.headers.get("location")).toBe(
+      "https://e06bb509-6c52-4c33-a9f7-66addc43e8c8.cloud-staging.eliza.app/api/health?probe=1",
+    );
     const serviceCases = [
       [
         "https://blob.elizacloud.ai/object.bin",
@@ -698,7 +711,7 @@ describe("cloud-api worker entrypoint", () => {
     }
   });
 
-  test("extracts canonical and legacy UUID hosts for the dedicated-agent proxy", () => {
+  test("extracts only canonical UUID hosts for the dedicated-agent proxy", () => {
     const env = { ELIZA_CLOUD_AGENT_BASE_DOMAIN: "cloud.eliza.app" };
     const agentId = "e06bb509-6c52-4c33-a9f7-66addc43e8c8";
 
@@ -713,7 +726,7 @@ describe("cloud-api worker entrypoint", () => {
         new URL(`https://${agentId}.elizacloud.ai/api/health`),
         env,
       ),
-    ).toBe(agentId);
+    ).toBeNull();
     expect(
       getGeneratedAgentId(new URL("https://blob.elizacloud.ai/object"), env),
     ).toBeNull();

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -519,17 +519,7 @@ export function getGeneratedAgentId(
     const subdomain = hostname.slice(0, -suffix.length);
     if (AGENT_ID_RE.test(subdomain)) return subdomain;
   }
-
-  // Keep legacy UUID agent hosts on the authenticated dedicated-agent proxy
-  // until the canonical nested-wildcard DNS and certificate cutover is live.
-  // Redirecting these bridge requests first strips them from the only working
-  // host and makes fail-closed snapshots/restarts time out (#19047).
-  const classified = hostname ? classifyElizaHostname(hostname) : null;
-  return classified?.role === "legacy-dedicated-agent" &&
-    classified.agentId &&
-    AGENT_ID_RE.test(classified.agentId)
-    ? classified.agentId
-    : null;
+  return null;
 }
 
 export function redirectFrontendHost(
@@ -578,10 +568,7 @@ export function redirectFrontendHost(
     classified.agentId &&
     AGENT_ID_RE.test(classified.agentId)
   ) {
-    // UUID agent hosts remain on the legacy hostname until the canonical
-    // nested-wildcard DNS/certificate cutover is complete. The worker proxies
-    // them below through the same authenticated dedicated-agent path.
-    return null;
+    canonicalHostname = classified.canonicalHostname;
   } else {
     canonicalHostname = canonicalElizaServiceHostname(hostname);
     if (!canonicalHostname && hostname === "os.elizacloud.ai") {

--- a/packages/cloud/api/v1/agents/[agentId]/restart/route.test.ts
+++ b/packages/cloud/api/v1/agents/[agentId]/restart/route.test.ts
@@ -20,10 +20,18 @@ const getAgentForWrite = mock(async () => ({
   organization_id: "agent-org",
   status: "running",
 }));
-const enqueueAgentRestartOnce = mock(async () => ({
-  jobId: "restart-job-1",
-  deduped: false,
-}));
+const enqueueAgentRestartOnce = mock(
+  async (): Promise<{
+    job: {
+      id: string;
+      data: { agentId: string; stateLossAcknowledged?: boolean };
+    };
+    created: boolean;
+  }> => ({
+    job: { id: "restart-job-1", data: { agentId: "cloud-agent-1" } },
+    created: true,
+  }),
+);
 const reactivateSandboxBillingAfterFunding = mock(async () => undefined);
 const checkAgentCreditGate = mock(async () => ({
   allowed: false,
@@ -96,6 +104,10 @@ describe("service agent restart route", () => {
       status: "running",
     });
     enqueueAgentRestartOnce.mockClear();
+    enqueueAgentRestartOnce.mockResolvedValue({
+      job: { id: "restart-job-1", data: { agentId: "cloud-agent-1" } },
+      created: true,
+    });
     reactivateSandboxBillingAfterFunding.mockClear();
     checkAgentCreditGate.mockClear();
     checkAgentCreditGate.mockResolvedValue({
@@ -160,11 +172,145 @@ describe("service agent restart route", () => {
       agentId: "cloud-agent-1",
       organizationId: "agent-org",
       userId: "agent-user",
+      stateLossAcknowledged: false,
     });
     expect(reactivateSandboxBillingAfterFunding).toHaveBeenCalledWith(
       "cloud-agent-1",
       expect.any(Date),
     );
+  });
+
+  test("threads an explicit state-loss waiver into the restart job (#18228)", async () => {
+    checkAgentCreditGate.mockResolvedValueOnce({
+      allowed: true,
+      balance: 5,
+      error: "",
+    });
+    enqueueAgentRestartOnce.mockResolvedValueOnce({
+      job: {
+        id: "restart-job-1",
+        data: { agentId: "cloud-agent-1", stateLossAcknowledged: true },
+      },
+      created: true,
+    });
+
+    const response = await app.fetch(
+      new Request(
+        "https://api.example.test/api/v1/agents/cloud-agent-1/restart",
+        {
+          method: "POST",
+          headers: {
+            "X-Service-Key": "svc",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ stateLossAcknowledged: true }),
+        },
+      ),
+      { WAIFU_SERVICE_KEY: "svc" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(enqueueAgentRestartOnce).toHaveBeenCalledWith({
+      agentId: "cloud-agent-1",
+      organizationId: "agent-org",
+      userId: "agent-user",
+      stateLossAcknowledged: true,
+    });
+  });
+
+  test("treats a non-literal-true waiver value as absent", async () => {
+    checkAgentCreditGate.mockResolvedValueOnce({
+      allowed: true,
+      balance: 5,
+      error: "",
+    });
+
+    const response = await app.fetch(
+      new Request(
+        "https://api.example.test/api/v1/agents/cloud-agent-1/restart",
+        {
+          method: "POST",
+          headers: {
+            "X-Service-Key": "svc",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ stateLossAcknowledged: "true" }),
+        },
+      ),
+      { WAIFU_SERVICE_KEY: "svc" },
+    );
+
+    expect(response.status).toBe(200);
+    expect(enqueueAgentRestartOnce).toHaveBeenCalledWith(
+      expect.objectContaining({ stateLossAcknowledged: false }),
+    );
+  });
+
+  test("refuses to silently drop the waiver when a non-waived restart is already in flight", async () => {
+    checkAgentCreditGate.mockResolvedValueOnce({
+      allowed: true,
+      balance: 5,
+      error: "",
+    });
+    enqueueAgentRestartOnce.mockResolvedValueOnce({
+      job: { id: "restart-job-1", data: { agentId: "cloud-agent-1" } },
+      created: false,
+    });
+
+    const response = await app.fetch(
+      new Request(
+        "https://api.example.test/api/v1/agents/cloud-agent-1/restart",
+        {
+          method: "POST",
+          headers: {
+            "X-Service-Key": "svc",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ stateLossAcknowledged: true }),
+        },
+      ),
+      { WAIFU_SERVICE_KEY: "svc" },
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      jobId: "restart-job-1",
+    });
+    expect(reactivateSandboxBillingAfterFunding).not.toHaveBeenCalled();
+  });
+
+  test("accepts a waived request that dedupes onto an in-flight job already carrying the waiver", async () => {
+    checkAgentCreditGate.mockResolvedValueOnce({
+      allowed: true,
+      balance: 5,
+      error: "",
+    });
+    enqueueAgentRestartOnce.mockResolvedValueOnce({
+      job: {
+        id: "restart-job-1",
+        data: { agentId: "cloud-agent-1", stateLossAcknowledged: true },
+      },
+      created: false,
+    });
+
+    const response = await app.fetch(
+      new Request(
+        "https://api.example.test/api/v1/agents/cloud-agent-1/restart",
+        {
+          method: "POST",
+          headers: {
+            "X-Service-Key": "svc",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ stateLossAcknowledged: true }),
+        },
+      ),
+      { WAIFU_SERVICE_KEY: "svc" },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ success: true });
   });
 
   test("rejects a restart while the agent is still provisioning", async () => {

--- a/packages/cloud/api/v1/agents/[agentId]/restart/route.ts
+++ b/packages/cloud/api/v1/agents/[agentId]/restart/route.ts
@@ -9,6 +9,13 @@
  * Replaces the Worker-side `shutdown()` + `provision()` sequence which
  * silently skipped the stop from CF Workers (no SSH) and could leave
  * the old container running alongside the new one.
+ *
+ * Optional JSON body `{ "stateLossAcknowledged": true }` (#18228) is the
+ * sanctioned operator override for an agent whose pre-stop snapshot capture
+ * or transfer persistently fails: the daemon proceeds to stop without a
+ * capture, explicitly discarding state since the last durable backup. The
+ * waiver is refused (409) rather than silently dropped when a non-waived
+ * restart job is already in flight.
  */
 
 import { Hono } from "hono";
@@ -49,7 +56,29 @@ app.post("/", async (c) => {
       );
     }
 
-    logger.info("[service-api] Restart requested", { agentId });
+    // Optional operator waiver (#18228): `{ "stateLossAcknowledged": true }`
+    // lets the restart proceed when the pre-stop capture persistently fails,
+    // explicitly discarding state since the last durable backup. Anything
+    // other than the literal `true` is treated as absent — the waiver must be
+    // deliberate, never inferred from a malformed body.
+    let stateLossAcknowledged = false;
+    try {
+      const body = (await c.req.json()) as { stateLossAcknowledged?: unknown };
+      stateLossAcknowledged = body?.stateLossAcknowledged === true;
+    } catch {
+      // error-policy:J3 an absent or non-JSON body is the ordinary no-waiver
+      // request, not an error.
+      stateLossAcknowledged = false;
+    }
+
+    if (stateLossAcknowledged) {
+      logger.warn(
+        "[service-api] Restart requested WITH state-loss acknowledgment: pre-stop capture failure will be waived",
+        { agentId },
+      );
+    } else {
+      logger.info("[service-api] Restart requested", { agentId });
+    }
 
     const writableAgent = await elizaSandboxService.getAgentForWrite(
       agentId,
@@ -66,11 +95,35 @@ app.post("/", async (c) => {
       );
     }
 
-    await provisioningJobService.enqueueAgentRestartOnce({
+    const enqueue = await provisioningJobService.enqueueAgentRestartOnce({
       agentId,
       organizationId: agent.organization_id,
       userId: agent.user_id,
+      stateLossAcknowledged,
     });
+
+    const existingJobCarriesWaiver =
+      (enqueue.job.data as { stateLossAcknowledged?: unknown } | null)
+        ?.stateLossAcknowledged === true;
+    if (
+      stateLossAcknowledged &&
+      !enqueue.created &&
+      !existingJobCarriesWaiver
+    ) {
+      // The waiver must never be silently dropped: an already-queued restart
+      // job carries its own (non-waived) data, so tell the operator to retry
+      // once that job settles instead of pretending the forced restart is
+      // queued.
+      return c.json(
+        {
+          success: false,
+          error:
+            "A restart job is already in flight without the state-loss waiver; wait for it to settle and retry.",
+          jobId: enqueue.job.id,
+        },
+        409,
+      );
+    }
 
     await agentBillingRepository.reactivateSandboxBillingAfterFunding(
       agentId,

--- a/packages/cloud/api/v1/generate-music/route.ts
+++ b/packages/cloud/api/v1/generate-music/route.ts
@@ -20,6 +20,12 @@ import {
 import { contentSafetyService } from "@/lib/services/content-safety";
 import { InsufficientCreditsError } from "@/lib/services/credits";
 import { generationsService } from "@/lib/services/generations";
+import {
+  checkGenerativeProviderHealth,
+  classifyGenerativeFailure,
+  recordGenerativeFailure,
+  recordGenerativeSuccess,
+} from "@/lib/services/generative-provider-health";
 import { putPublicObject } from "@/lib/storage/r2-public-object";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv, Bindings } from "@/types/cloud-worker-env";
@@ -194,6 +200,30 @@ app.post("/", async (c) => {
       );
     }
 
+    // Fail fast while the upstream is known-degraded (#18436): repeated
+    // timeouts/5xx open a per provider+model breaker, and while it is open we
+    // refuse before content safety, pricing, or the credit hold — no billable
+    // work is admitted toward an upstream that is currently hanging.
+    const providerHealthKey = `music:${provider}:${request.model}`;
+    const providerHealth = checkGenerativeProviderHealth(providerHealthKey);
+    if (providerHealth.degraded) {
+      c.header("Retry-After", String(providerHealth.retryAfterSeconds));
+      return jsonError(
+        c,
+        503,
+        "Music generation is backed up right now; the upstream provider is not responding. Try again shortly.",
+        "service_unavailable",
+        {
+          provider,
+          model: request.model,
+          retryAfterSeconds: providerHealth.retryAfterSeconds,
+          ...(providerHealth.lastFailureKind
+            ? { lastFailureKind: providerHealth.lastFailureKind }
+            : {}),
+        },
+      );
+    }
+
     const durationSeconds =
       definition.durationControl === "supported"
         ? (request.durationSeconds ??
@@ -264,8 +294,9 @@ app.post("/", async (c) => {
     }
 
     await admission.markProviderDispatched?.();
-    const generated = await getAudioProvider(definition.billingSource).generate(
-      {
+    let generated: GeneratedAudio;
+    try {
+      generated = await getAudioProvider(definition.billingSource).generate({
         kind: "music",
         model: request.model,
         prompt: request.prompt,
@@ -292,8 +323,17 @@ app.post("/", async (c) => {
           SUNO_API_KEY: envString(c.env, "SUNO_API_KEY"),
           SUNO_BASE_URL: envString(c.env, "SUNO_BASE_URL"),
         },
-      },
-    );
+      });
+    } catch (error) {
+      // error-policy:J2 breaker accounting for the health gate above, then the
+      // unchanged error proceeds to the route boundary (refund + failureResponse).
+      recordGenerativeFailure(
+        providerHealthKey,
+        classifyGenerativeFailure(error),
+      );
+      throw error;
+    }
+    recordGenerativeSuccess(providerHealthKey);
 
     const music = await storeGeneratedAudio(
       c.env,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -1723,6 +1723,159 @@ describe("ElizaSandboxService shutdown fails closed without a current capture (#
   });
 });
 
+describe("ElizaSandboxService shutdown state-loss-acknowledged override (#18228)", () => {
+  function makeProvider(): SandboxProvider {
+    return {
+      create: mock(async () => {
+        throw new Error("must not create");
+      }),
+      stopForDeletion: mock(async () => ({ kind: "not-running-proven" as const })),
+      stopForReplacement: mock(async () => {}),
+      checkHealth: mock(async () => true),
+    };
+  }
+
+  test("a transfer-hop 500 refusal carries the hop's body, distinguishable from an agent-side capture failure", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const rec = customSandbox();
+    const provider = makeProvider();
+    const svc = new ElizaSandboxService(provider);
+    const getForWrite = spyOn(
+      svc as unknown as { getAgentForWrite: () => Promise<unknown> },
+      "getAgentForWrite",
+    ).mockResolvedValue(rec);
+    // Proxy-hop failure: the agent captured successfully (its handler never
+    // ran this response), and the intermediate hop answered with its own
+    // error page. The refusal must surface that page so the operator can
+    // tell this apart from "agent cannot snapshot".
+    const fetchApi = spyOn(
+      svc as unknown as { fetchAgentApi: () => Promise<Response> },
+      "fetchAgentApi",
+    ).mockImplementation(
+      async () =>
+        new Response("upstream connect error or disconnect before headers", { status: 500 }),
+    );
+    try {
+      const hopResult = await svc.shutdown(rec.id, rec.organization_id);
+      expect(hopResult.success).toBe(false);
+      expect(hopResult.error).toContain("Snapshot fetch failed: HTTP 500");
+      expect(hopResult.error).toContain("upstream connect error");
+
+      // Agent-side failure: the agent's own handler returned its thrown
+      // message. Same status, different diagnostic body.
+      fetchApi.mockImplementation(
+        async () =>
+          new Response('{"error":"Snapshot failed: pglite dump write error"}', { status: 500 }),
+      );
+      const agentResult = await svc.shutdown(rec.id, rec.organization_id);
+      expect(agentResult.success).toBe(false);
+      expect(agentResult.error).toContain("Snapshot fetch failed: HTTP 500");
+      expect(agentResult.error).toContain("pglite dump write error");
+
+      expect(provider.stopForReplacement).not.toHaveBeenCalled();
+    } finally {
+      getForWrite.mockRestore();
+      fetchApi.mockRestore();
+    }
+  });
+
+  test("stateLossAcknowledged proceeds to stop without a capture and reports the waiver", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const rec = customSandbox();
+    const provider = makeProvider();
+    const svc = new ElizaSandboxService(provider);
+    const getForWrite = spyOn(
+      svc as unknown as { getAgentForWrite: () => Promise<unknown> },
+      "getAgentForWrite",
+    ).mockResolvedValue(rec);
+    const fetchApi = spyOn(
+      svc as unknown as { fetchAgentApi: () => Promise<Response> },
+      "fetchAgentApi",
+    ).mockImplementation(
+      async () =>
+        new Response("upstream connect error or disconnect before headers", { status: 500 }),
+    );
+    const lockLifecycle = spyOn(
+      svc as unknown as { lockLifecycle: () => Promise<void> },
+      "lockLifecycle",
+    ).mockResolvedValue(undefined);
+    const getForMutation = spyOn(
+      svc as unknown as { getAgentForLifecycleMutation: () => Promise<unknown> },
+      "getAgentForLifecycleMutation",
+    ).mockResolvedValue(rec);
+    const activeProvision = spyOn(
+      svc as unknown as { hasActiveProvisionJobTx: () => Promise<boolean> },
+      "hasActiveProvisionJobTx",
+    ).mockResolvedValue(false);
+    const persistSnapshot = spyOn(
+      svc as unknown as { persistSnapshotWithinTransaction: () => Promise<never> },
+      "persistSnapshotWithinTransaction",
+    );
+    const prune = spyOn(agentSandboxesRepository, "pruneBackups").mockResolvedValue(
+      undefined as never,
+    );
+    const writes: unknown[] = [];
+    upgradeTransactionImpl = async (fn) =>
+      fn({
+        execute: async (query) => {
+          writes.push(query);
+          return { rows: [] };
+        },
+      });
+    try {
+      const result = await svc.shutdown(rec.id, rec.organization_id, {
+        stateLossAcknowledged: true,
+      });
+      expect(result).toEqual({ success: true, stateLossAcknowledged: true });
+      // The stop really happened; the capture was skipped, never persisted.
+      expect(provider.stopForReplacement).toHaveBeenCalledWith(rec.sandbox_id);
+      expect(persistSnapshot).not.toHaveBeenCalled();
+      expect(writes).toHaveLength(1);
+    } finally {
+      upgradeTransactionImpl = null;
+      getForWrite.mockRestore();
+      fetchApi.mockRestore();
+      lockLifecycle.mockRestore();
+      getForMutation.mockRestore();
+      activeProvision.mockRestore();
+      persistSnapshot.mockRestore();
+      prune.mockRestore();
+    }
+  });
+
+  test("executeRestart threads the waiver into shutdown", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const rec = customSandbox();
+    const svc = new ElizaSandboxService(makeProvider());
+    const getForWrite = spyOn(
+      svc as unknown as { getAgentForWrite: () => Promise<unknown> },
+      "getAgentForWrite",
+    ).mockResolvedValue(rec);
+    const shutdownSpy = spyOn(svc, "shutdown").mockResolvedValue({
+      success: true,
+      stateLossAcknowledged: true,
+    });
+    const provisionSpy = spyOn(svc, "provision").mockResolvedValue({
+      success: true,
+      bridgeUrl: "https://bridge.example",
+      healthUrl: "https://bridge.example/health",
+    } as never);
+    try {
+      const res = await svc.executeRestart(rec.id, rec.organization_id, {
+        stateLossAcknowledged: true,
+      });
+      expect(res.success).toBe(true);
+      expect(shutdownSpy).toHaveBeenCalledWith(rec.id, rec.organization_id, {
+        stateLossAcknowledged: true,
+      });
+    } finally {
+      getForWrite.mockRestore();
+      shutdownSpy.mockRestore();
+      provisionSpy.mockRestore();
+    }
+  });
+});
+
 describe("ElizaSandboxService sleep refuses an unproven fallback backup (#17180 §3)", () => {
   test("capture failed and the latest stored backup cannot be verified — sleep aborts", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -8036,12 +8036,28 @@ export class ElizaSandboxService {
 
   // Shutdown
 
+  /**
+   * Stops the agent's container and flips the row to `stopped`, capturing a
+   * pre-stop snapshot first. Fail-closed by default: a capture failure leaves
+   * the agent running and returns an explicit refusal. The sole sanctioned
+   * bypass is `options.stateLossAcknowledged` (#18228) — an operator's
+   * explicit acceptance that state since the last durable backup is discarded
+   * — which proceeds to stop without a capture, loudly, and reports
+   * `stateLossAcknowledged: true` in the result. It is never implied.
+   */
   async shutdown(
     agentId: string,
     orgId: string,
-  ): Promise<{ success: boolean; error?: string; retryable?: boolean }> {
+    options?: { readonly stateLossAcknowledged?: boolean },
+  ): Promise<{
+    success: boolean;
+    error?: string;
+    retryable?: boolean;
+    stateLossAcknowledged?: boolean;
+  }> {
     let snapshotAgentId: string | null = null;
     let captureUnsupported = false;
+    let captureWaivedByOperator = false;
     let preShutdownSnapshot: {
       stateData: AgentBackupStateData;
       sizeBytes: number;
@@ -8063,6 +8079,17 @@ export class ElizaSandboxService {
           logger.warn(
             "[agent-sandbox] Shutdown proceeding without capture: image has no snapshot endpoint",
             { agentId },
+          );
+        } else if (options?.stateLossAcknowledged) {
+          // Sanctioned operator override (#18228): a persistent capture or
+          // transfer-hop failure otherwise makes the agent unstoppable through
+          // every safe path. The operator explicitly acknowledged the state
+          // loss, so proceed to stop WITHOUT a capture — never silently: the
+          // waiver is logged here and reported in the result.
+          captureWaivedByOperator = true;
+          logger.error(
+            "[agent-sandbox] Shutdown proceeding WITHOUT pre-stop capture: operator acknowledged state loss",
+            { agentId, captureError: message },
           );
         } else if (message === SNAPSHOT_CAPTURE_TRANSIENT) {
           // TRANSIENT (PGlite closing race): do NOT weaken the fail-closed
@@ -8138,7 +8165,12 @@ export class ElizaSandboxService {
         } as const;
       }
 
-      if (rec.status === "running" && rec.bridge_url && !captureUnsupported) {
+      if (
+        rec.status === "running" &&
+        rec.bridge_url &&
+        !captureUnsupported &&
+        !captureWaivedByOperator
+      ) {
         // The capture must be OF THIS generation. A capture taken against a
         // different bridge_url (the row moved between the unlocked fetch and
         // this locked read) is some other container's state; persisting it
@@ -8189,6 +8221,9 @@ export class ElizaSandboxService {
       `);
 
       snapshotAgentId = rec.id;
+      if (captureWaivedByOperator) {
+        return { success: true, stateLossAcknowledged: true } as const;
+      }
       return { success: true } as const;
     });
 
@@ -8199,7 +8234,10 @@ export class ElizaSandboxService {
           error: error instanceof Error ? error.message : String(error),
         });
       });
-      logger.info("[agent-sandbox] Shutdown complete", { agentId });
+      logger.info("[agent-sandbox] Shutdown complete", {
+        agentId,
+        stateLossAcknowledged: captureWaivedByOperator || undefined,
+      });
     }
 
     return result;
@@ -8678,6 +8716,7 @@ export class ElizaSandboxService {
   async executeRestart(
     agentId: string,
     orgId: string,
+    options?: { readonly stateLossAcknowledged?: boolean },
   ): Promise<{
     success: boolean;
     containerStopped: boolean;
@@ -8706,7 +8745,9 @@ export class ElizaSandboxService {
       await this.prepareLegacyWarmClaimCredentialRecovery(agentId, orgId);
     }
 
-    const shutdownResult = await this.shutdown(agentId, orgId);
+    const shutdownResult = await this.shutdown(agentId, orgId, {
+      stateLossAcknowledged: options?.stateLossAcknowledged,
+    });
     if (!shutdownResult.success) {
       return {
         success: false,

--- a/packages/cloud/shared/src/lib/services/generative-provider-health.test.ts
+++ b/packages/cloud/shared/src/lib/services/generative-provider-health.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for the generative provider health breaker: real module, no
+ * mocks, deterministic clocks passed explicitly. Covers threshold opening,
+ * failure classification, config-error immunity, cooldown expiry (half-open),
+ * immediate reopen on a post-cooldown failure, and success closing the gate.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  checkGenerativeProviderHealth,
+  classifyGenerativeFailure,
+  recordGenerativeFailure,
+  recordGenerativeSuccess,
+  resetGenerativeProviderHealthForTests,
+} from "./generative-provider-health";
+
+const KEY = "music:fal:fal-ai/minimax-music/v2.6";
+const T0 = 1_700_000_000_000;
+
+beforeEach(() => {
+  resetGenerativeProviderHealthForTests();
+});
+
+describe("classifyGenerativeFailure", () => {
+  test("timeouts, 5xx, 4xx, and config errors classify distinctly", () => {
+    expect(
+      classifyGenerativeFailure(new Error("fal queue job timed out after 300000ms (request r1)")),
+    ).toBe("timeout");
+    expect(classifyGenerativeFailure(new Error("fal queue submit failed (503)"))).toBe(
+      "upstream_error",
+    );
+    expect(classifyGenerativeFailure(new Error("fal queue submit failed (401): bad key"))).toBe(
+      "config_error",
+    );
+    expect(
+      classifyGenerativeFailure(new Error("fal is not configured: missing FAL_KEY / FAL_API_KEY")),
+    ).toBe("config_error");
+    expect(classifyGenerativeFailure(new Error("socket hang up"))).toBe("upstream_error");
+  });
+});
+
+describe("breaker lifecycle", () => {
+  test("opens only at the consecutive-failure threshold", () => {
+    expect(recordGenerativeFailure(KEY, "timeout", T0).degraded).toBe(false);
+    expect(recordGenerativeFailure(KEY, "timeout", T0).degraded).toBe(false);
+    const opened = recordGenerativeFailure(KEY, "timeout", T0);
+    expect(opened.degraded).toBe(true);
+    expect(opened.retryAfterSeconds).toBeGreaterThan(0);
+    expect(opened.lastFailureKind).toBe("timeout");
+    expect(checkGenerativeProviderHealth(KEY, T0).degraded).toBe(true);
+  });
+
+  test("config errors never advance or reset the breaker", () => {
+    recordGenerativeFailure(KEY, "timeout", T0);
+    recordGenerativeFailure(KEY, "timeout", T0);
+    // A bad-key 401 between timeouts must not trip the gate...
+    expect(recordGenerativeFailure(KEY, "config_error", T0).degraded).toBe(false);
+    // ...and must not have consumed the third strike either.
+    expect(checkGenerativeProviderHealth(KEY, T0).degraded).toBe(false);
+    expect(recordGenerativeFailure(KEY, "upstream_error", T0).degraded).toBe(true);
+  });
+
+  test("cooldown expiry half-opens; one more failure reopens immediately", () => {
+    for (let i = 0; i < 3; i++) recordGenerativeFailure(KEY, "timeout", T0);
+    const later = T0 + 121_000;
+    expect(checkGenerativeProviderHealth(KEY, later).degraded).toBe(false);
+    // Half-open: a single further eligible failure reopens without needing
+    // three fresh strikes.
+    expect(recordGenerativeFailure(KEY, "upstream_error", later).degraded).toBe(true);
+  });
+
+  test("success fully closes the gate and resets the strike count", () => {
+    for (let i = 0; i < 3; i++) recordGenerativeFailure(KEY, "timeout", T0);
+    recordGenerativeSuccess(KEY);
+    expect(checkGenerativeProviderHealth(KEY, T0).degraded).toBe(false);
+    expect(recordGenerativeFailure(KEY, "timeout", T0).degraded).toBe(false);
+    expect(recordGenerativeFailure(KEY, "timeout", T0).degraded).toBe(false);
+  });
+
+  test("keys are independent per provider+model", () => {
+    for (let i = 0; i < 3; i++) recordGenerativeFailure(KEY, "timeout", T0);
+    expect(checkGenerativeProviderHealth("music:elevenlabs/music_v1", T0).degraded).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/generative-provider-health.ts
+++ b/packages/cloud/shared/src/lib/services/generative-provider-health.ts
@@ -1,0 +1,107 @@
+/**
+ * In-memory circuit breaker for long-running generative media providers
+ * (music/audio upstreams such as fal and ElevenLabs). Consecutive breaker
+ * eligible failures (upstream timeouts and 5xx) open a per provider+model gate
+ * so routes can return an honest "backed up" 503 immediately instead of
+ * holding a synchronous HTTP connection toward a multi-minute ceiling against
+ * an upstream that is already known to be hanging (#18436).
+ *
+ * Config/contract failures (4xx, missing keys, unusable payloads) never trip
+ * the breaker: a bad key must surface as a config error on every request, not
+ * masquerade as a provider outage. State is per Worker isolate — the same
+ * accepted tradeoff as the solana-rpc proxy breaker — so a cold isolate always
+ * fails open and re-probes the upstream. After the cooldown the gate half
+ * opens: traffic flows again, one further eligible failure reopens it, and one
+ * success fully closes it.
+ */
+
+const FAILURE_THRESHOLD = 3;
+const OPEN_MS = 120_000;
+
+export type GenerativeFailureKind = "timeout" | "upstream_error" | "config_error";
+
+interface BreakerEntry {
+  consecutiveFailures: number;
+  openUntil: number;
+  lastFailureKind?: GenerativeFailureKind;
+}
+
+const breakers = new Map<string, BreakerEntry>();
+
+function entryFor(key: string): BreakerEntry {
+  let entry = breakers.get(key);
+  if (!entry) {
+    entry = { consecutiveFailures: 0, openUntil: 0 };
+    breakers.set(key, entry);
+  }
+  return entry;
+}
+
+/**
+ * Classifies an upstream generation failure for breaker accounting from the
+ * plain Error messages the fal-queue/audio providers throw. Timeouts and 5xx
+ * count toward opening the gate; 4xx and configuration failures do not.
+ */
+export function classifyGenerativeFailure(error: unknown): GenerativeFailureKind {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/timed out|timeout/i.test(message)) return "timeout";
+  if (/not configured|missing .*key/i.test(message)) return "config_error";
+  const status = /\((\d{3})\)/.exec(message)?.[1];
+  if (status && status.startsWith("4")) return "config_error";
+  return "upstream_error";
+}
+
+export interface GenerativeProviderHealth {
+  degraded: boolean;
+  retryAfterSeconds: number;
+  lastFailureKind?: GenerativeFailureKind;
+}
+
+/** Returns the gate state for a provider+model key without mutating it. */
+export function checkGenerativeProviderHealth(
+  key: string,
+  now: number = Date.now(),
+): GenerativeProviderHealth {
+  const entry = breakers.get(key);
+  if (!entry || entry.openUntil <= now) {
+    return { degraded: false, retryAfterSeconds: 0 };
+  }
+  return {
+    degraded: true,
+    retryAfterSeconds: Math.max(1, Math.ceil((entry.openUntil - now) / 1000)),
+    lastFailureKind: entry.lastFailureKind,
+  };
+}
+
+/** Records a successful generation, fully closing the gate for the key. */
+export function recordGenerativeSuccess(key: string): void {
+  breakers.delete(key);
+}
+
+/**
+ * Records a failed generation. Timeouts and upstream errors advance the
+ * breaker (and reopen a half-open gate immediately); config errors leave the
+ * breaker untouched so misconfiguration keeps failing loudly per request.
+ * Returns the resulting gate state.
+ */
+export function recordGenerativeFailure(
+  key: string,
+  kind: GenerativeFailureKind,
+  now: number = Date.now(),
+): GenerativeProviderHealth {
+  if (kind === "config_error") {
+    return checkGenerativeProviderHealth(key, now);
+  }
+  const entry = entryFor(key);
+  entry.consecutiveFailures += 1;
+  entry.lastFailureKind = kind;
+  if (entry.consecutiveFailures >= FAILURE_THRESHOLD) {
+    entry.openUntil = now + OPEN_MS;
+  }
+  return checkGenerativeProviderHealth(key, now);
+}
+
+/** Test-only: clears all breaker state so cases stay order-independent. */
+export function resetGenerativeProviderHealthForTests(): void {
+  breakers.clear();
+}

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -201,6 +201,12 @@ export interface AgentRestartJobData {
   agentId: string;
   organizationId: string;
   userId: string;
+  /**
+   * Operator-acknowledged state loss (#18228): the pre-stop capture is waived
+   * when it fails, so the restart can free an agent whose snapshot transfer
+   * persistently fails. Never set by default; requires an explicit request.
+   */
+  stateLossAcknowledged?: boolean;
 }
 
 export interface AgentUpgradeJobData {
@@ -607,12 +613,15 @@ function readAgentWakeJobData(job: Job): AgentWakeJobData {
 }
 
 function isAgentRestartJobData(value: unknown): value is AgentRestartJobData {
+  const stateLossAcknowledged = (value as { stateLossAcknowledged?: unknown })
+    ?.stateLossAcknowledged;
   return (
     typeof value === "object" &&
     value !== null &&
     typeof (value as { agentId?: unknown }).agentId === "string" &&
     typeof (value as { organizationId?: unknown }).organizationId === "string" &&
-    typeof (value as { userId?: unknown }).userId === "string"
+    typeof (value as { userId?: unknown }).userId === "string" &&
+    (stateLossAcknowledged === undefined || typeof stateLossAcknowledged === "boolean")
   );
 }
 
@@ -2000,6 +2009,8 @@ export class ProvisioningJobService {
     organizationId: string;
     userId: string;
     webhookUrl?: string;
+    /** Operator waiver for a persistently failing pre-stop capture (#18228). */
+    stateLossAcknowledged?: boolean;
   }): Promise<EnqueueAgentRestartResult> {
     return this.enqueueLifecycleJob<AgentRestartJobData>({
       jobType: JOB_TYPES.AGENT_RESTART,
@@ -2007,6 +2018,7 @@ export class ProvisioningJobService {
         agentId: params.agentId,
         organizationId: params.organizationId,
         userId: params.userId,
+        ...(params.stateLossAcknowledged ? { stateLossAcknowledged: true } : {}),
       },
       toRecord: agentRestartJobDataToRecord,
       agentId: params.agentId,
@@ -4202,10 +4214,13 @@ export class ProvisioningJobService {
     logger.info("[provisioning-jobs] Executing agent_restart", {
       jobId: job.id,
       agentId: data.agentId,
+      stateLossAcknowledged: data.stateLossAcknowledged || undefined,
     });
 
     await this.assertExecutionMutationLease(job);
-    const result = await elizaSandboxService.executeRestart(data.agentId, data.organizationId);
+    const result = await elizaSandboxService.executeRestart(data.agentId, data.organizationId, {
+      stateLossAcknowledged: data.stateLossAcknowledged,
+    });
 
     if (await this.completeIfAgentGone(job, result, data.agentId)) return;
 

--- a/packages/shared/src/error-classification.ts
+++ b/packages/shared/src/error-classification.ts
@@ -28,8 +28,11 @@ export function shouldIgnoreUnhandledRejection(reason: unknown): boolean {
   const pending: unknown[] = [reason];
   while (pending.length > 0) {
     const current = pending.pop();
-    if (!current || typeof current !== "object" || seen.has(current)) continue;
-    seen.add(current);
+    const isObject = current !== null && typeof current === "object";
+    if (isObject) {
+      if (seen.has(current)) continue;
+      seen.add(current);
+    }
 
     const formatted = formatUncaughtError(current);
     const isProviderError =
@@ -39,10 +42,14 @@ export function shouldIgnoreUnhandledRejection(reason: unknown): boolean {
     if (isProviderError) {
       if (hasInsufficientCreditsSignal(formatted)) return true;
 
-      const statusCode = (current as { statusCode?: number }).statusCode;
+      const statusCode = isObject
+        ? (current as { statusCode?: number }).statusCode
+        : undefined;
       if (statusCode === 402) return true;
 
-      const responseBody = (current as { responseBody?: unknown }).responseBody;
+      const responseBody = isObject
+        ? (current as { responseBody?: unknown }).responseBody
+        : undefined;
       if (
         typeof responseBody === "string" &&
         hasInsufficientCreditsSignal(responseBody)
@@ -50,6 +57,8 @@ export function shouldIgnoreUnhandledRejection(reason: unknown): boolean {
         return true;
       }
     }
+
+    if (!isObject) continue;
 
     const errors = (current as { errors?: unknown }).errors;
     if (Array.isArray(errors)) {

--- a/packages/shared/src/meetings.test.ts
+++ b/packages/shared/src/meetings.test.ts
@@ -34,6 +34,15 @@ describe("parseMeetingUrl", () => {
     expect(parsed?.nativeMeetingId).toBe("19:meeting_abc@thread.v2/0");
   });
 
+  it("rejects a Teams short link whose numeric id is only a path prefix", () => {
+    expect(
+      parseMeetingUrl("https://teams.microsoft.com/meet/123456789?p=abc"),
+    ).toMatchObject({ platform: "teams", nativeMeetingId: "123456789" });
+    expect(
+      parseMeetingUrl("https://teams.microsoft.com/meet/123not-a-meeting"),
+    ).toBeNull();
+  });
+
   it("returns null (never throws URIError) on a malformed percent-escape Teams id", () => {
     // A lone trailing `%` is an invalid escape: decodeURIComponent throws
     // URIError, which used to crash the Transcripts view on every keystroke,

--- a/packages/shared/src/meetings.ts
+++ b/packages/shared/src/meetings.ts
@@ -220,8 +220,9 @@ function safeDecodeUriComponent(value: string): string | null {
 const MEET_URL_RE =
   /^https?:\/\/meet\.google\.com\/([a-z]{3}-?[a-z]{4}-?[a-z]{3})(?:\?.*)?$/i;
 const TEAMS_URL_RE =
-  /^https?:\/\/(?:[\w-]+\.)?teams\.(?:microsoft|live)\.com\/(?:v2\/)?(?:l\/)?meet(?:up-join)?\/([^?\s]+)/i;
-const TEAMS_SHORT_RE = /^https?:\/\/teams\.microsoft\.com\/meet\/(\d+)/i;
+  /^https?:\/\/(?:[\w-]+\.)?teams\.(?:microsoft|live)\.com\/(?:v2\/)?(?:l\/)?meetup-join\/([^?\s]+)/i;
+const TEAMS_SHORT_RE =
+  /^https?:\/\/teams\.(?:microsoft|live)\.com\/meet\/(\d+)(?:[/?#]|$)/i;
 const ZOOM_URL_RE =
   /^https?:\/\/(?:[\w-]+\.)?zoom\.us\/(?:j|w|wc)\/(?:join\/)?(\d{9,12})(?:[/?]|$)/i;
 const ZOOM_APP_RE = /^https?:\/\/app\.zoom\.us\/wc\/(\d{9,12})\/join/i;

--- a/packages/shared/src/process-guards.test.ts
+++ b/packages/shared/src/process-guards.test.ts
@@ -156,4 +156,15 @@ describe("shouldIgnoreUnhandledRejection", () => {
       ),
     ).toBe(false);
   });
+
+  it("preserves provider credit classification for string rejection reasons", () => {
+    const creditReason = "AI_APICallError: payment required";
+
+    expect(shouldIgnoreUnhandledRejection(creditReason)).toBe(true);
+    expect(
+      shouldIgnoreUnhandledRejection(
+        new AggregateError([creditReason], "All provider attempts failed"),
+      ),
+    ).toBe(true);
+  });
 });

--- a/packages/shared/src/todo-cutover.test.ts
+++ b/packages/shared/src/todo-cutover.test.ts
@@ -276,6 +276,16 @@ describe("Shared Todo cutover contract", () => {
       { committedAt: "not-a-time" },
       "TODO_CUTOVER_INVALID_TIMESTAMP",
     ],
+    [
+      "non-ISO commit timestamp",
+      { committedAt: "August 14, 2026 10:00:00" },
+      "TODO_CUTOVER_INVALID_TIMESTAMP",
+    ],
+    [
+      "impossible ISO calendar date",
+      { committedAt: "2026-02-30T10:00:00Z" },
+      "TODO_CUTOVER_INVALID_TIMESTAMP",
+    ],
   ])("rejects invalid mutation %s", async (_label, overrides, code) => {
     await expect(
       createSharedTodoCutoverSnapshot({

--- a/packages/shared/src/todo-cutover.ts
+++ b/packages/shared/src/todo-cutover.ts
@@ -19,6 +19,8 @@ const MAX_IDEMPOTENCY_KEY_LENGTH = 1_024;
 const MAX_CONTENT_LENGTH = 16_384;
 const MAX_ACTIVE_FORM_LENGTH = 4_096;
 const MAX_METADATA_DEPTH = 32;
+const ISO_TIMESTAMP_PATTERN =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
 
 export const SHARED_TODO_STATUSES = [
   "pending",
@@ -137,10 +139,31 @@ function nullableUuid(value: unknown, field: string): string | null {
   return requiredUuid(value, field);
 }
 
+function hasValidIsoCalendarFields(raw: string): boolean {
+  const match = ISO_TIMESTAMP_PATTERN.exec(raw);
+  if (!match) return false;
+
+  const [year, month, day, hour, minute, second] = match.slice(1).map(Number);
+  const calendar = new Date(0);
+  calendar.setUTCFullYear(year, month - 1, day);
+  calendar.setUTCHours(hour, minute, second, 0);
+  return (
+    calendar.getUTCFullYear() === year &&
+    calendar.getUTCMonth() === month - 1 &&
+    calendar.getUTCDate() === day &&
+    calendar.getUTCHours() === hour &&
+    calendar.getUTCMinutes() === minute &&
+    calendar.getUTCSeconds() === second
+  );
+}
+
 function canonicalTimestamp(value: unknown, field: string): string {
   const raw = requiredString(value, field, 64);
   const timestamp = new Date(raw);
-  if (!Number.isFinite(timestamp.getTime())) {
+  if (
+    !hasValidIsoCalendarFields(raw) ||
+    !Number.isFinite(timestamp.getTime())
+  ) {
     return invalid(
       "TODO_CUTOVER_INVALID_TIMESTAMP",
       `${field} must be an ISO timestamp`,

--- a/packages/shared/src/utils/format.test.ts
+++ b/packages/shared/src/utils/format.test.ts
@@ -110,11 +110,35 @@ describe("formatDurationMs", () => {
 });
 
 describe("formatUsd", () => {
-  it("renders grouped USD, accepts numeric strings, falls back on junk", () => {
+  it("renders grouped USD and accepts complete decimal strings", () => {
     expect(formatUsd(1234.56)).toBe("$1,234.56");
-    expect(formatUsd("1234.5")).toBe("$1,234.50");
+    expect(formatUsd(" 1234.5 ")).toBe("$1,234.50");
+    expect(formatUsd("+12.")).toBe("$12.00");
+    expect(formatUsd("-.5")).toBe("-$0.50");
+    expect(formatUsd("1.25e2")).toBe("$125.00");
+    expect(formatUsd("1e-2")).toBe("$0.01");
+  });
+
+  it.each([
+    ["missing", null],
+    ["undefined", undefined],
+    ["empty", ""],
+    ["whitespace", "   "],
+    ["plain junk", "abc"],
+    ["currency suffix", "12.50USD"],
+    ["junk after exponent", "1e2junk"],
+    ["hexadecimal", "0x10"],
+    ["binary", "0b10"],
+    ["octal", "0o10"],
+    ["incomplete exponent", "1e"],
+    ["double sign", "--1"],
+    ["non-finite number", Number.POSITIVE_INFINITY],
+  ])("falls back for %s input", (_label, value) => {
+    expect(formatUsd(value)).toBe("—");
+  });
+
+  it("uses a custom fallback for invalid input", () => {
     expect(formatUsd(null)).toBe("—");
-    expect(formatUsd("abc")).toBe("—");
     expect(formatUsd(undefined, { fallback: "n/a" })).toBe("n/a");
   });
 });

--- a/packages/shared/src/utils/format.ts
+++ b/packages/shared/src/utils/format.ts
@@ -162,10 +162,14 @@ type UsdFormatOptions = {
   fallback?: string;
 };
 
+const DECIMAL_NUMBER_PATTERN =
+  /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/;
+
 /**
  * Format a numeric amount as a USD currency string (`$1,234.56`).
  *
- * Accepts numbers or numeric strings; non-numeric input yields `fallback`.
+ * Accepts numbers or complete decimal strings (optionally using exponent
+ * notation); non-numeric input yields `fallback`.
  * Uses the en-US `Intl.NumberFormat` currency style (grouped, 2 fraction
  * digits) — the canonical money display for dashboard views.
  */
@@ -174,7 +178,15 @@ export function formatUsd(
   options: UsdFormatOptions = {},
 ): string {
   const { fallback = "—" } = options;
-  const amount = typeof value === "string" ? Number.parseFloat(value) : value;
+  let amount: number | null | undefined;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    amount = DECIMAL_NUMBER_PATTERN.test(trimmed)
+      ? Number(trimmed)
+      : Number.NaN;
+  } else {
+    amount = value;
+  }
   if (amount == null || !Number.isFinite(amount)) return fallback;
   return new Intl.NumberFormat("en-US", {
     style: "currency",

--- a/plugins/plugin-calendar/src/components/calendar/meeting-url.test.ts
+++ b/plugins/plugin-calendar/src/components/calendar/meeting-url.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Deterministic coverage for the browser-bundled meeting URL parser, which is
+ * intentionally mirrored from @elizaos/shared because view bundles externalize
+ * that package at runtime.
+ */
+import { describe, expect, it } from "vitest";
+import { parseMeetingUrl } from "./meeting-url";
+
+describe("calendar view meeting URL parser", () => {
+  it("accepts numeric Teams short links on Microsoft and Live hosts", () => {
+    expect(
+      parseMeetingUrl("https://teams.microsoft.com/meet/123456789?p=abc"),
+    ).toMatchObject({ platform: "teams", nativeMeetingId: "123456789" });
+    expect(
+      parseMeetingUrl("https://teams.live.com/meet/987654321"),
+    ).toMatchObject({ platform: "teams", nativeMeetingId: "987654321" });
+  });
+
+  it("rejects nonnumeric Teams short-link suffixes instead of truncating them", () => {
+    expect(
+      parseMeetingUrl("https://teams.microsoft.com/meet/123not-a-meeting"),
+    ).toBeNull();
+    expect(
+      parseMeetingUrl("https://teams.live.com/meet/not-a-meeting"),
+    ).toBeNull();
+  });
+});

--- a/plugins/plugin-calendar/src/components/calendar/meeting-url.ts
+++ b/plugins/plugin-calendar/src/components/calendar/meeting-url.ts
@@ -33,8 +33,9 @@ function safeDecodeUriComponent(value: string): string | null {
 const MEET_URL_RE =
   /^https?:\/\/meet\.google\.com\/([a-z]{3}-?[a-z]{4}-?[a-z]{3})(?:\?.*)?$/i;
 const TEAMS_URL_RE =
-  /^https?:\/\/(?:[\w-]+\.)?teams\.(?:microsoft|live)\.com\/(?:v2\/)?(?:l\/)?meet(?:up-join)?\/([^?\s]+)/i;
-const TEAMS_SHORT_RE = /^https?:\/\/teams\.microsoft\.com\/meet\/(\d+)/i;
+  /^https?:\/\/(?:[\w-]+\.)?teams\.(?:microsoft|live)\.com\/(?:v2\/)?(?:l\/)?meetup-join\/([^?\s]+)/i;
+const TEAMS_SHORT_RE =
+  /^https?:\/\/teams\.(?:microsoft|live)\.com\/meet\/(\d+)(?:[/?#]|$)/i;
 const ZOOM_URL_RE =
   /^https?:\/\/(?:[\w-]+\.)?zoom\.us\/(?:j|w|wc)\/(?:join\/)?(\d{9,12})(?:[/?]|$)/i;
 const ZOOM_APP_RE = /^https?:\/\/app\.zoom\.us\/wc\/(\d{9,12})\/join/i;

--- a/plugins/plugin-personal-assistant/src/actions/life.review-definitions.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.review-definitions.test.ts
@@ -397,4 +397,3 @@ describe("LifeOps definition review isolation", () => {
     });
   });
 });
-


### PR DESCRIPTION
Promotes the complete current develop tree to main, including the production-verified shared-agent voice stack and the follow-up provider rejection classifier fix (#20568). Main is now an ancestor of develop via the tree-identical sync PR #20570.