### PR TITLE
fix(core): reserve suffix length in truncations to respect caps

### DIFF
--- a/plugins/plugin-embeddings/__tests__/events.test.ts
+++ b/plugins/plugin-embeddings/__tests__/events.test.ts
@@ -1,10 +1,9 @@
 /**
- * Regression tests for truncatePrompt via emitModelUsageEvent.
- * Ensures total output <= MAX_PROMPT_LENGTH (200) inclusive of suffix,
- * suffix preservation, and well-formed surrogate handling (non-BMP boundary).
+ * Verifies that embedding usage events keep prompts within their telemetry
+ * budget without producing malformed UTF-16 at the truncation boundary.
  */
 
-import type { IAgentRuntime } from "@elizaos/core";
+import { type IAgentRuntime, ModelType } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import { emitModelUsageEvent } from "../src/utils/events";
 
@@ -29,7 +28,7 @@ describe("emitModelUsageEvent truncation", () => {
   it("keeps at-cap (200) unchanged", () => {
     const { runtime, emit } = createRuntime();
     const prompt = "a".repeat(MAX);
-    emitModelUsageEvent(runtime, "TEXT_EMBEDDING" as never, prompt, {});
+    emitModelUsageEvent(runtime, ModelType.TEXT_EMBEDDING, prompt, {});
     const out = emittedPrompt(emit);
     expect(out).toBe(prompt);
     expect(out.length).toBe(MAX);
@@ -38,19 +37,18 @@ describe("emitModelUsageEvent truncation", () => {
   it("truncates one-over (201) to 200 inclusive of suffix", () => {
     const { runtime, emit } = createRuntime();
     const prompt = "a".repeat(MAX + 1);
-    emitModelUsageEvent(runtime, "TEXT_EMBEDDING" as never, prompt, {});
+    emitModelUsageEvent(runtime, ModelType.TEXT_EMBEDDING, prompt, {});
     const out = emittedPrompt(emit);
     expect(out.length).toBe(MAX);
     expect(out.endsWith(SUFFIX)).toBe(true);
     expect(out).toBe("a".repeat(MAX - SUFFIX.length) + SUFFIX);
-    // Verify strict JSON well-formed
-    expect(() => JSON.stringify({ prompt: out })).not.toThrow();
+    expect(out.isWellFormed()).toBe(true);
   });
 
   it("preserves suffix and respects cap for long prompt", () => {
     const { runtime, emit } = createRuntime();
     const prompt = "b".repeat(500);
-    emitModelUsageEvent(runtime, "TEXT_EMBEDDING" as never, prompt, {});
+    emitModelUsageEvent(runtime, ModelType.TEXT_EMBEDDING, prompt, {});
     const out = emittedPrompt(emit);
     expect(out.length).toBe(MAX);
     expect(out.endsWith(SUFFIX)).toBe(true);
@@ -59,27 +57,24 @@ describe("emitModelUsageEvent truncation", () => {
 
   it("does not split surrogate pair at truncation boundary (non-BMP)", () => {
     const { runtime, emit } = createRuntime();
-    // 198 'a' + two emoji (each 2 code units) = 202 code units, forces cut inside first emoji if naive slice
+    // The first emoji straddles the 199-code-unit content boundary.
     const prompt = `${"a".repeat(198)}😀😀`; // length 202
     expect(prompt.length).toBe(202);
-    emitModelUsageEvent(runtime, "TEXT_EMBEDDING" as never, prompt, {});
+    emitModelUsageEvent(runtime, ModelType.TEXT_EMBEDDING, prompt, {});
     const out = emittedPrompt(emit);
     expect(out.length).toBeLessThanOrEqual(MAX);
     expect(out.endsWith(SUFFIX)).toBe(true);
-    // Must be well-formed: no lone surrogate at end before suffix
-    expect(/[\uD800-\uDBFF]$/.test(out.slice(0, -1))).toBe(false);
-    expect(() => JSON.stringify({ prompt: out })).not.toThrow();
-    // With 198 'a' + emoji, naive 199 slice would end with high surrogate; we expect 198 'a' + suffix = 199
+    expect(out.isWellFormed()).toBe(true);
     expect(out.length).toBe(199);
   });
 
   it("handles single emoji at boundary without breaking", () => {
     const { runtime, emit } = createRuntime();
     const prompt = `${"a".repeat(199)}😀`; // 201
-    emitModelUsageEvent(runtime, "TEXT_EMBEDDING" as never, prompt, {});
+    emitModelUsageEvent(runtime, ModelType.TEXT_EMBEDDING, prompt, {});
     const out = emittedPrompt(emit);
     expect(out.length).toBe(MAX);
     expect(out.endsWith(SUFFIX)).toBe(true);
-    expect(() => JSON.stringify({ prompt: out })).not.toThrow();
+    expect(out.isWellFormed()).toBe(true);
   });
 });

--- a/plugins/plugin-embeddings/__tests__/events.test.ts
+++ b/plugins/plugin-embeddings/__tests__/events.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Regression tests for truncatePrompt via emitModelUsageEvent.
+ * Ensures total output <= MAX_PROMPT_LENGTH (200) inclusive of suffix,
+ * suffix preservation, and well-formed surrogate handling (non-BMP boundary).
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { emitModelUsageEvent } from "../src/utils/events";
+
+const MAX = 200;
+const SUFFIX = "…";
+
+function createRuntime(): { runtime: IAgentRuntime; emit: ReturnType<typeof vi.fn> } {
+  const emit = vi.fn(async () => undefined);
+  const runtime = {
+    emitEvent: emit,
+  } as unknown as IAgentRuntime;
+  return { runtime, emit };
+}
+
+function emittedPrompt(emit: ReturnType<typeof vi.fn>): string {
+  expect(emit).toHaveBeenCalledTimes(1);
+  const [, payload] = emit.mock.calls[0] as [unknown, { prompt: string }];
+  return payload.prompt;
+}
+
+describe("emitModelUsageEvent truncation", () => {
+  it("keeps at-cap (200) unchanged", () => {
+    const { runtime, emit } = createRuntime();
+    const prompt = "a".repeat(MAX);
+    emitModelUsageEvent(runtime, "TEXT_EMBEDDING" as never, prompt, {});
+    const out = emittedPrompt(emit);
+    expect(out).toBe(prompt);
+    expect(out.length).toBe(MAX);
+  });
+
+  it("truncates one-over (201) to 200 inclusive of suffix", () => {
+    const { runtime, emit } = createRuntime();
+    const prompt = "a".repeat(MAX + 1);
+    emitModelUsageEvent(runtime, "TEXT_EMBEDDING" as never, prompt, {});
+    const out = emittedPrompt(emit);
+    expect(out.length).toBe(MAX);
+    expect(out.endsWith(SUFFIX)).toBe(true);
+    expect(out).toBe("a".repeat(MAX - SUFFIX.length) + SUFFIX);
+    // Verify strict JSON well-formed
+    expect(() => JSON.stringify({ prompt: out })).not.toThrow();
+  });
+
+  it("preserves suffix and respects cap for long prompt", () => {
+    const { runtime, emit } = createRuntime();
+    const prompt = "b".repeat(500);
+    emitModelUsageEvent(runtime, "TEXT_EMBEDDING" as never, prompt, {});
+    const out = emittedPrompt(emit);
+    expect(out.length).toBe(MAX);
+    expect(out.endsWith(SUFFIX)).toBe(true);
+    expect(out.slice(0, MAX - SUFFIX.length)).toBe("b".repeat(MAX - SUFFIX.length));
+  });
+
+  it("does not split surrogate pair at truncation boundary (non-BMP)", () => {
+    const { runtime, emit } = createRuntime();
+    // 198 'a' + two emoji (each 2 code units) = 202 code units, forces cut inside first emoji if naive slice
+    const prompt = `${"a".repeat(198)}😀😀`; // length 202
+    expect(prompt.length).toBe(202);
+    emitModelUsageEvent(runtime, "TEXT_EMBEDDING" as never, prompt, {});
+    const out = emittedPrompt(emit);
+    expect(out.length).toBeLessThanOrEqual(MAX);
+    expect(out.endsWith(SUFFIX)).toBe(true);
+    // Must be well-formed: no lone surrogate at end before suffix
+    expect(/[\uD800-\uDBFF]$/.test(out.slice(0, -1))).toBe(false);
+    expect(() => JSON.stringify({ prompt: out })).not.toThrow();
+    // With 198 'a' + emoji, naive 199 slice would end with high surrogate; we expect 198 'a' + suffix = 199
+    expect(out.length).toBe(199);
+  });
+
+  it("handles single emoji at boundary without breaking", () => {
+    const { runtime, emit } = createRuntime();
+    const prompt = `${"a".repeat(199)}😀`; // 201
+    emitModelUsageEvent(runtime, "TEXT_EMBEDDING" as never, prompt, {});
+    const out = emittedPrompt(emit);
+    expect(out.length).toBe(MAX);
+    expect(out.endsWith(SUFFIX)).toBe(true);
+    expect(() => JSON.stringify({ prompt: out })).not.toThrow();
+  });
+});

--- a/plugins/plugin-embeddings/src/utils/events.ts
+++ b/plugins/plugin-embeddings/src/utils/events.ts
@@ -31,7 +31,13 @@ function truncatePrompt(prompt: string): string {
   if (prompt.length <= MAX_PROMPT_LENGTH) {
     return prompt;
   }
-  return `${prompt.slice(0, MAX_PROMPT_LENGTH)}…`;
+  const suffix = "…";
+  let truncated = prompt.slice(0, MAX_PROMPT_LENGTH - suffix.length);
+  // Avoid splitting a surrogate pair at the truncation boundary
+  if (/[\uD800-\uDBFF]$/.test(truncated)) {
+    truncated = truncated.slice(0, -1);
+  }
+  return `${truncated}${suffix}`;
 }
 
 export function emitModelUsageEvent(

--- a/plugins/plugin-embeddings/src/utils/events.ts
+++ b/plugins/plugin-embeddings/src/utils/events.ts
@@ -33,7 +33,7 @@ function truncatePrompt(prompt: string): string {
   }
   const suffix = "…";
   let truncated = prompt.slice(0, MAX_PROMPT_LENGTH - suffix.length);
-  // Avoid splitting a surrogate pair at the truncation boundary
+  // Avoid splitting a surrogate pair at the truncation boundary.
   if (/[\uD800-\uDBFF]$/.test(truncated)) {
     truncated = truncated.slice(0, -1);
   }


### PR DESCRIPTION
# Summary

Narrowed to **single total-output cap** bug: `plugins/plugin-embeddings/src/utils/events.ts:34` `MAX_PROMPT_LENGTH=200` with suffix `…` (1 char). Pattern `slice(0, MAX)+suffix` violated inclusive cap by `suffix.length` (201>200). Fix derives suffix length: `slice(0, MAX - suffix.length)+suffix`, plus surrogate-pair guard for non-BMP boundaries — matching siblings `trajectory-recorder.ts:806` (`MAX - suffix.length`) and `pending-prompts/store.ts:96` (`MAX-1+"…"`).

Other caps noted in first draft (readAttachment 32000 content allowance, entities 2000 metadata, runtime 500 retry context) are content budgets not total-output — split out per P0, no change here.

## Exact candidate / base
- **Candidate**: `e80d965288b94b9d36e4eede549cf4faf2905f09`
- **Base**: `1ed4eb9a7b3c3c0c6b755785000aeae95c0e7a92` (`origin/develop`)
- **Sync**: `fix/truncation-large-suffix` reset to `origin/develop` 1ed4eb9a then cherry-picked fix — HEAD clean, diff 2 files.

## Repro (payload→effect)
```bash
node -e "console.log(('a'.repeat(201).slice(0,200)+'…').length, ('a'.repeat(201).slice(0,199)+'…').length)" # 201 200
node -e "const s='😀',p='a'.repeat(198)+s+s; console.log(p.length, `${p.slice(0,199)}…`.length, /[\uD800-\uDBFF]$/.test(p.slice(0,199)))" # 202 surrogate split vs guarded 199
```

## Fix
```ts
const suffix = "…";
let truncated = prompt.slice(0, MAX_PROMPT_LENGTH - suffix.length);
if (/[\uD800-\uDBFF]$/.test(truncated)) truncated = truncated.slice(0, -1);
return `${truncated}${suffix}`;
```

Sibling proofs: `trajectory-recorder.ts:806` derives `suffix.length`, `store.ts:96` same class.

## Local verify on candidate
- `bun run --cwd plugins/plugin-embeddings typecheck` — 0 errors
- `bun run --cwd plugins/plugin-embeddings test` — 52/52 pass (new 5 regression rows: at-cap, one-over, long, non-BMP pair, single emoji)
- `bunx @biomejs/biome check --write ./plugins/plugin-embeddings/src` — 1 file fixed then clean
- `git diff --check` — clean

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5
<!-- attribution-row:client -->
- Agent tooling: claude-code
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@1ed4eb9a7b3c3c0c6b755785000aeae95c0e7a92:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Evidence Gate

Evidence must match the exact commit reviewed.
<!-- evidence-head:e80d965288b94b9d36e4eede549cf4faf2905f09 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI surface changed, logic-only embedding prompt cap fix with no renderable output to capture
<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI surface changed, logic-only embedding prompt cap fix with no renderable output to capture
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no frontend flow changed, no video walkthrough applicable to server-side truncation logic
<!-- evidence-row:backend-logs -->
- [ ] N/A - backend logs N/A for pure cap derivation fix, unit test output in PR body proves 201→200 and surrogate guard 202→199
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code touched, no console or network logs applicable to this change
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent prompt or model behavior change, only deterministic truncation cap derived from suffix length
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB rows or on-chain artifacts produced, fix verified via node -e and committed unit tests

---
AI provider/model: anthropic/claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/eliza@1ed4eb9a7b3c3c0c6b755785000aeae95c0e7a92:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [eliza-computer]
<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/eliza@1ed4eb9a7b3c3c0c6b755785000aeae95c0e7a92:packages/skills/skills/contribute-to-eliza"} -->
