### PR TITLE
fix(corpus-tools): report malformed manifests

### DIFF
--- a/packages/corpus-tools/src/validator.test.ts
+++ b/packages/corpus-tools/src/validator.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Filesystem-backed coverage for corpus target validation. The harness writes
+ * synthetic manifests and shards to temporary directories without mocks.
+ */
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildCorpusManifest, validateCorpusTarget } from "./validator.ts";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "corpus-validator-test-"),
+  );
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe("validateCorpusTarget", () => {
+  it.each([
+    ["truncated object", "{"],
+    ["empty file", ""],
+    ["trailing comma", '{"schemaVersion":1,}'],
+    ["extra tokens", "{} trailing"],
+    ["UTF-8 BOM", `${String.fromCharCode(0xfeff)}{}`],
+  ])(
+    "returns a structured issue for malformed manifest JSON: %s",
+    async (_, raw) => {
+      const targetPath = await makeTempDir();
+      const manifestPath = path.join(targetPath, "manifest.json");
+      await fs.writeFile(manifestPath, raw, "utf8");
+
+      const result = await validateCorpusTarget(targetPath);
+
+      expect(result.ok).toBe(false);
+      expect(result.manifest.totals.messages).toBe(0);
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0]).toMatchObject({
+        path: manifestPath,
+        code: "manifest-invalid",
+      });
+      expect(result.issues[0]?.message).toEqual(expect.any(String));
+      expect(result.issues[0]?.message.length).toBeGreaterThan(0);
+    },
+  );
+
+  it("keeps valid JSON schema failures as structured manifest issues", async () => {
+    const targetPath = await makeTempDir();
+    const manifestPath = path.join(targetPath, "manifest.json");
+    await fs.writeFile(manifestPath, '"not-an-object"', "utf8");
+
+    const result = await validateCorpusTarget(targetPath);
+
+    expect(result.ok).toBe(false);
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        path: manifestPath,
+        code: "manifest-invalid",
+      }),
+    ]);
+  });
+
+  it("accepts a valid manifest matching the rebuilt shard inventory", async () => {
+    const targetPath = await makeTempDir();
+    const { manifest } = await buildCorpusManifest(
+      targetPath,
+      "2026-08-16T00:00:00.000Z",
+    );
+    await fs.writeFile(
+      path.join(targetPath, "manifest.json"),
+      JSON.stringify(manifest),
+      "utf8",
+    );
+
+    const result = await validateCorpusTarget(targetPath);
+
+    expect(result.ok).toBe(true);
+    expect(result.issues).toEqual([]);
+  });
+
+  it("preserves structured JSONL parse issues while rebuilding the manifest", async () => {
+    const targetPath = await makeTempDir();
+    const shardPath = path.join(targetPath, "x", "1234", "2024-08.jsonl");
+    await fs.mkdir(path.dirname(shardPath), { recursive: true });
+    await fs.writeFile(shardPath, "{\n", "utf8");
+
+    const result = await validateCorpusTarget(targetPath);
+
+    expect(result.ok).toBe(false);
+    expect(result.manifest.totals.messages).toBe(0);
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        path: shardPath,
+        line: 1,
+        code: "schema-invalid",
+      }),
+    ]);
+  });
+});

--- a/packages/corpus-tools/src/validator.ts
+++ b/packages/corpus-tools/src/validator.ts
@@ -294,34 +294,46 @@ export async function validateCorpusTarget(targetPath: string): Promise<{
     const entries = await fs.readdir(targetPath);
     if (entries.includes("manifest.json")) {
       const manifestPath = path.join(targetPath, "manifest.json");
-      const expected = corpusManifestSchema.safeParse(
-        JSON.parse(await fs.readFile(manifestPath, "utf8")),
-      );
-      if (!expected.success) {
+      const rawManifest = await fs.readFile(manifestPath, "utf8");
+      let manifestInput: unknown;
+      try {
+        manifestInput = JSON.parse(rawManifest);
+      } catch (error) {
+        // error-policy:J3 manifest bytes are untrusted corpus input; report invalid JSON.
         issues.push({
           path: manifestPath,
           code: "manifest-invalid",
-          message: expected.error.issues
-            .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
-            .join("; "),
+          message: error instanceof Error ? error.message : String(error),
         });
-      } else if (
-        JSON.stringify({
-          cutoffIso: expected.data.cutoffIso,
-          shards: expected.data.shards,
-          totals: expected.data.totals,
-        }) !==
-        JSON.stringify({
-          cutoffIso: manifest.cutoffIso,
-          shards: manifest.shards,
-          totals: manifest.totals,
-        })
-      ) {
-        issues.push({
-          path: manifestPath,
-          code: "manifest-mismatch",
-          message: "manifest.json does not match shard contents",
-        });
+      }
+      if (manifestInput !== undefined) {
+        const expected = corpusManifestSchema.safeParse(manifestInput);
+        if (!expected.success) {
+          issues.push({
+            path: manifestPath,
+            code: "manifest-invalid",
+            message: expected.error.issues
+              .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+              .join("; "),
+          });
+        } else if (
+          JSON.stringify({
+            cutoffIso: expected.data.cutoffIso,
+            shards: expected.data.shards,
+            totals: expected.data.totals,
+          }) !==
+          JSON.stringify({
+            cutoffIso: manifest.cutoffIso,
+            shards: manifest.shards,
+            totals: manifest.totals,
+          })
+        ) {
+          issues.push({
+            path: manifestPath,
+            code: "manifest-mismatch",
+            message: "manifest.json does not match shard contents",
+          });
+        }
       }
     }
   }


### PR DESCRIPTION
# Relates to

Fixes #20576

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest fetched `origin/develop` with zero conflicts.
- [x] `bun install --frozen-lockfile`, focused/package checks, and exact-head proof were run after sync with Bun 1.3.14 and Node 24.15.0.
- [ ] Root `bun run verify` did not complete: it entered the workspace `typecheck lint:check` phase and terminated with exit 144. No candidate-path failure was emitted; exact bounded evidence is recorded below.
- [x] A reviewer can reproduce both the prior rejection and the structured result from the filesystem-backed test table.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Claude Code via CLIProxyAPI
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@62f1861f6e9bed7fbf29b7a6f7ef25127f4b83a9:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased conflict-free onto `origin/develop@62f1861f6e9bed7fbf29b7a6f7ef25127f4b83a9`.
- [x] Final candidate head is `87dcd326fbfc192908fd19880ca707e1570577c9`; `git range-diff` confirms the rebase preserved the authored patch.
- [x] A complete read-only changed-file scan covered all 56 open PRs and found no owner for either target path. PR #20275 was fully paginated across two pages (132 files) and had no overlap.
- [x] Broad open issue/PR searches found no duplicate malformed-`manifest.json` fix.

# Risks

Low. The catch is confined to parsing a present `manifest.json` and translates only malformed JSON into the package's existing `manifest-invalid` diagnostic. Filesystem read failures still reject, valid JSON still passes through the same Zod schema and mismatch comparison, and the rebuilt manifest plus all shard issues remain unchanged.

# Background

## What does this PR do?

Makes `validateCorpusTarget()` fulfill with a structured `manifest-invalid` issue when a corpus directory contains malformed manifest JSON. Previously the unguarded `JSON.parse` rejected the entire validation promise with `SyntaxError`.

The new filesystem-backed suite covers truncated JSON, an empty file, trailing comma, extra tokens, and a UTF-8 BOM. Controls preserve valid-JSON schema failures, matching manifests, and malformed JSONL row diagnostics.

## What kind of change is this?

Bug fix (untrusted corpus-input validation).

# Documentation changes needed?

No. This restores the package guide's existing contract that validator failures are returned as structured diagnostics.

# Testing

## Where should a reviewer start?

- `packages/corpus-tools/src/validator.ts`
- `packages/corpus-tools/src/validator.test.ts`

## Detailed testing steps

Pinned toolchain: Bun `1.3.14`, Node `24.15.0`.

```bash
bun install --frozen-lockfile
bun run --cwd packages/core build
bun run --cwd packages/corpus-tools test src/validator.test.ts
bun run --cwd packages/corpus-tools test
bun run --cwd packages/corpus-tools typecheck
bun run --cwd packages/corpus-tools lint:check
bun run --cwd packages/corpus-tools format
bun run test:server
bun run verify
git diff --check origin/develop...HEAD
```

`@elizaos/corpus-tools` has no package `build` script; building its `@elizaos/core` dependency is the applicable build check.

# Evidence Gate

<!-- evidence-head:87dcd326fbfc192908fd19880ca707e1570577c9 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend filesystem validator; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend filesystem validator; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual or interactive frontend flow changed.
<!-- evidence-row:backend-logs -->
- [x] Deterministic Vitest output below captures the real filesystem boundary result.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or network client behavior changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Exact-head filesystem validation proof:

```text
Tests-first authored baseline before the production change:
- focused validator file: 5 failed, 3 passed
- all five malformed manifest rows rejected with SyntaxError at validator.ts JSON.parse

Final base 62f1861f6e9bed7fbf29b7a6f7ef25127f4b83a9
Exact head 87dcd326fbfc192908fd19880ca707e1570577c9
- authenticated skill installer: verified/no-op at 72e4239ebed8c99d34181d5d1f21fb316cacecd6
- bun install --frozen-lockfile: passed
- @elizaos/core build: passed
- focused validator suite: 8 passed
- complete @elizaos/corpus-tools suite: 15 passed
- @elizaos/corpus-tools typecheck: passed
- @elizaos/corpus-tools lint:check: passed (6 files)
- @elizaos/corpus-tools format: passed (6 files; no fixes)
- server lane's @elizaos/corpus-tools task: 15 passed, observed=true
- git diff --check origin/develop...HEAD: clean
- worktree: clean; branch is one commit ahead of origin/develop
- changed-file ownership: 56 open PRs fully scanned, zero overlap
```

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, prompt, provider, or model behavior changed.

## Backend + frontend logs

The table writes five malformed `manifest.json` byte sequences to real temporary directories and calls the exported validator. Before the production change, every row rejected at the unguarded `JSON.parse`. At the exact candidate head, each call fulfills with one path-qualified `manifest-invalid` issue and the rebuilt zero-message manifest.

The complete package suite also exercises the existing real X archive fixture, shard generation, manifest matching, resumability, and malformed collector inputs.

## Known gaps / failures

- Root `bun run verify` was run after the final rebase with the pinned toolchain. Repository preflight gates advanced into the workspace `typecheck lint:check` Turbo phase, then the process terminated with exit 144. The output emitted existing locale inventory warnings and no failure in `packages/corpus-tools/**`; because the command did not complete, this row remains unchecked rather than being represented as green.
- The full server lane exceeded ten minutes and was bounded after the changed package had already passed its in-lane task (15/15). Unrelated failures had been emitted in untouched packages:
  - `packages/shared`: `src/todo-cutover.test.ts` could not resolve the built `@elizaos/core/edge` path, and five `character-presets.failure-templates.test.ts` casing assertions failed.
  - `packages/app-core`: `src/api/conversation-restore-relaunch.test.ts` could not resolve `@elizaos/core/edge`; `credential-resolver.test.ts` observed a pre-existing host credential variable instead of its test alias (secret value omitted); two wrapped-server route-auth assertions expected 503 and received 500.
- None of those files or packages is changed by this two-file patch. The candidate's focused suite, complete package suite, package typecheck/lint/format, dependency build, in-lane corpus task, and whitespace check are green.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Claude Code via CLIProxyAPI
Contribution skill revision: elizaOS/eliza@62f1861f6e9bed7fbf29b7a6f7ef25127f4b83a9:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [sol-eliza-corpus-manifest]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code via CLIProxyAPI","skill_revision":"elizaOS/eliza@62f1861f6e9bed7fbf29b7a6f7ef25127f4b83a9:packages/skills/skills/contribute-to-eliza"} -->
