### PR TITLE
feat(registry): list elizaos-plugin-livetennis as a third-party plugin

### DIFF
--- a/packages/registry/entries/third-party/elizaos-plugin-livetennis.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-livetennis.json
@@ -1,0 +1,8 @@
+{
+  "package": "elizaos-plugin-livetennis",
+  "repository": "github:livetennisapi/elizaos-plugin-livetennis",
+  "kind": "plugin",
+  "description": "Live tennis scores, upcoming fixtures, and player search for elizaOS agents via the Live Tennis API — ATP, WTA, Challenger, ITF and juniors. FREE-tier endpoints only, with honest per-action tier errors.",
+  "homepage": "https://livetennisapi.com",
+  "tags": ["tennis", "sports", "live-scores", "fixtures", "rankings"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -1374,6 +1374,51 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "elizaos-plugin-livetennis": {
+      "git": {
+        "repo": "livetennisapi/elizaos-plugin-livetennis",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "elizaos-plugin-livetennis",
+        "v0": null,
+        "v1": null,
+        "v2": null
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Live tennis scores, upcoming fixtures, and player search for elizaOS agents via the Live Tennis API — ATP, WTA, Challenger, ITF and juniors. FREE-tier endpoints only, with honest per-action tier errors.",
+      "homepage": "https://livetennisapi.com",
+      "topics": [
+        "tennis",
+        "sports",
+        "live-scores",
+        "fixtures",
+        "rankings"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "elizaos-plugin-neynar-search": {
       "git": {
         "repo": "xavier-arosemena/elizaos-plugin-neynar-search",


### PR DESCRIPTION
## What

Adds `entries/third-party/elizaos-plugin-livetennis.json` and the regenerated `generated-registry.json`, listing [livetennisapi/elizaos-plugin-livetennis](https://github.com/livetennisapi/elizaos-plugin-livetennis) as a community plugin.

**Disclosure: I maintain the Live Tennis API** (the data vendor behind the plugin). This is the vendor's own plugin, per the affiliation-disclosure expectation.

## Why this route

This follows the maintainer guidance on #20477, which closed the in-tree proposal and pointed at exactly this path: *"out-of-tree package + community registry entry"*, using *"an available `elizaos-plugin-*` name"*, with *"honest per-action tier errors and vendor disclosure"*, so the entry *"can then be reviewed for schema, installability, security, metadata, and provenance without importing the implementation into this monorepo."*

## The plugin

- Actions: `GET_LIVE_TENNIS_MATCHES` (score, server, derived break-point flag — receiver AD, or receiver 40 vs server below 40, never during a tiebreak), `GET_TENNIS_FIXTURES`, `SEARCH_TENNIS_PLAYERS` (current official ranking).
- Provider: `LIVE_TENNIS_MATCH_CONTEXT` (compact live-scoreboard state context; renders nothing without a key and never breaks state composition).
- FREE-tier endpoints only; `403 upgrade_required` responses surface as honest per-action tier messages (history/H2H/archive name BASIC, model win probability names ULTRA). Field names verbatim from [docs.livetennisapi.com/openapi.yaml](https://docs.livetennisapi.com/openapi.yaml).
- Key via runtime setting / env `LIVETENNIS_API_KEY`; declared in `agentConfig.pluginParameters`. A FREE key is self-serve, no card.
- MIT, ESM, `@elizaos/core` as a peer dependency (`^2.0.3-beta.7`), tsup build, 29 vitest tests with HTTP fully mocked, credential-free CI (green), tagged [v0.1.0](https://github.com/livetennisapi/elizaos-plugin-livetennis/releases/tag/v0.1.0).

## npm status (honest)

The package is **not yet published to npm** (publish pending on our side), so the entry deliberately **omits `version`** rather than claiming a published one — the generated wire entry carries `npm.v2: null` with the `git` install path. Installation is verified working today in a clean project via `npm install github:livetennisapi/elizaos-plugin-livetennis` (a `prepare` script builds `dist/` on install; the plugin loads and registers its actions/provider). Happy to follow up with the `version` bump once the npm publish lands, or to hold this PR until then if a published npm version is a hard requirement for listing.

## Verification

- `bun run --cwd packages/registry validate` — 46 third-party entries validated.
- `bun run --cwd packages/registry generate` — regenerated output committed; diff is the one new entry only.

Refs #20477.
