### PR TITLE
fix(cloud): enforce deletion fencing and bounded retention for shared conversation Durable Objects

### DIFF
--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -27,8 +27,10 @@ mock.module("@/lib/api/errors", () => ({
 
 let repositoryReads = 0;
 let repositoryWrites = 0;
+let repositoryDeletes = 0;
 let repositoryRow: unknown[] = [];
 let repositoryMergeError: Error | null = null;
+let repositoryMergeGate: Promise<void> | null = null;
 const repositoryHistoryLengths: number[] = [];
 const repositoryHistories: unknown[][] = [];
 let streamMergeGate: Promise<void> | null = null;
@@ -84,6 +86,7 @@ mock.module("@/db/repositories/shared-runtime-history", () => ({
     },
     merge: async (_agentId: string, _channelId: string, history: unknown[]) => {
       if (repositoryMergeError) throw repositoryMergeError;
+      if (repositoryMergeGate) await repositoryMergeGate;
       repositoryWrites++;
       const byId = new Map<string, unknown>();
       for (const message of [...repositoryRow, ...history]) {
@@ -94,6 +97,11 @@ mock.module("@/db/repositories/shared-runtime-history", () => ({
       repositoryHistories.push(merged);
       repositoryRow = merged;
       return merged;
+    },
+    deleteByAgent: async () => {
+      repositoryDeletes++;
+      repositoryRow = [];
+      return 1;
     },
   },
 }));
@@ -228,6 +236,8 @@ type SharedRuntimeConversationInstance = InstanceType<
 
 beforeEach(() => {
   repositoryMergeError = null;
+  repositoryMergeGate = null;
+  repositoryDeletes = 0;
   streamMergeGate = null;
   resolveStreamMergeGate = () => {};
   rehydrateCalls = 0;
@@ -265,6 +275,26 @@ function makeState(data: Map<string, unknown>, background: Promise<unknown>[]) {
       deleteAll: async () => {
         data.clear();
       },
+      transaction: async (
+        operation: (txn: {
+          list(): Promise<Map<string, unknown>>;
+          delete(keys: string[]): Promise<number>;
+          put(key: string, value: unknown): Promise<void>;
+        }) => Promise<void>,
+      ) =>
+        await operation({
+          list: async () => new Map(data),
+          delete: async (keys) => {
+            let deleted = 0;
+            for (const key of keys) {
+              if (data.delete(key)) deleted++;
+            }
+            return deleted;
+          },
+          put: async (key, value) => {
+            data.set(key, structuredClone(value));
+          },
+        }),
     },
     waitUntil: (promise: Promise<unknown>) => background.push(promise),
   };
@@ -1548,6 +1578,82 @@ test("a deletion tombstone fences late mirrors and alarms from resurrecting cont
   );
   await expect(retried.json()).resolves.toEqual({ success: true });
   expect(data.size).toBe(1);
+});
+
+test("delete removes a Postgres mirror that finishes after the caller-side purge", async () => {
+  repositoryReads = 0;
+  repositoryWrites = 0;
+  repositoryDeletes = 0;
+  repositoryRow = [];
+  let releaseMerge = () => {};
+  repositoryMergeGate = new Promise<void>((resolve) => {
+    releaseMerge = resolve;
+  });
+  const data = new Map<string, unknown>();
+  const background: Promise<unknown>[] = [];
+  const state = makeState(data, background);
+  const object = new SharedRuntimeConversation(state as never, {} as never);
+
+  const lateMirror = (
+    object as unknown as {
+      mirrorConversation(snapshot: unknown): Promise<void>;
+    }
+  ).mirrorConversation({
+    agentId: AGENT_FIXTURE.id,
+    channelId: "room-1",
+    history: [{ id: "m-1", role: "user", content: "secret", createdAt: 1 }],
+    dirty: true,
+    version: 1,
+  });
+  await Promise.resolve();
+
+  const deletion = object.fetch(
+    new Request("https://shared-runtime.internal/delete", {
+      method: "POST",
+      body: JSON.stringify({ operation: "delete", agentId: AGENT_FIXTURE.id }),
+    }),
+  );
+  await Promise.resolve();
+  releaseMerge();
+  await lateMirror;
+  const response = await deletion;
+  await expect(response.json()).resolves.toEqual({ success: true });
+
+  expect(repositoryWrites).toBe(1);
+  expect(repositoryDeletes).toBeGreaterThanOrEqual(1);
+  expect(repositoryRow).toEqual([]);
+  expect(data.has("deletion-tombstone")).toBe(true);
+});
+
+test("concurrent alarm updates preserve both persisted deadlines", async () => {
+  const data = new Map<string, unknown>();
+  const background: Promise<unknown>[] = [];
+  const state = makeState(data, background);
+  const object = new SharedRuntimeConversation(state as never, {} as never);
+  const updateAlarmDeadlines = (
+    object as unknown as {
+      updateAlarmDeadlines(
+        mutate: (current: Record<string, number>) => Record<string, number>,
+      ): Promise<void>;
+    }
+  ).updateAlarmDeadlines.bind(object);
+
+  await Promise.all([
+    updateAlarmDeadlines((current) => ({
+      ...current,
+      mirrorRetryAt: 200,
+    })),
+    updateAlarmDeadlines((current) => ({
+      ...current,
+      idleExpiryAt: 300,
+    })),
+  ]);
+
+  expect(data.get("alarm-deadlines")).toEqual({
+    mirrorRetryAt: 200,
+    idleExpiryAt: 300,
+  });
+  expect(state.alarmTime).toBe(200);
 });
 
 test("an idle mirror-confirmed room expires by alarm and re-hydrates losslessly", async () => {

--- a/packages/cloud/api/src/shared-runtime-conversation.test.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.test.ts
@@ -28,6 +28,7 @@ mock.module("@/lib/api/errors", () => ({
 let repositoryReads = 0;
 let repositoryWrites = 0;
 let repositoryRow: unknown[] = [];
+let repositoryMergeError: Error | null = null;
 const repositoryHistoryLengths: number[] = [];
 const repositoryHistories: unknown[][] = [];
 let streamMergeGate: Promise<void> | null = null;
@@ -82,6 +83,7 @@ mock.module("@/db/repositories/shared-runtime-history", () => ({
       repositoryHistories.push(history);
     },
     merge: async (_agentId: string, _channelId: string, history: unknown[]) => {
+      if (repositoryMergeError) throw repositoryMergeError;
       repositoryWrites++;
       const byId = new Map<string, unknown>();
       for (const message of [...repositoryRow, ...history]) {
@@ -225,6 +227,7 @@ type SharedRuntimeConversationInstance = InstanceType<
 >;
 
 beforeEach(() => {
+  repositoryMergeError = null;
   streamMergeGate = null;
   resolveStreamMergeGate = () => {};
   rehydrateCalls = 0;
@@ -236,6 +239,7 @@ beforeEach(() => {
 function makeState(data: Map<string, unknown>, background: Promise<unknown>[]) {
   const state = {
     alarmDeleted: false,
+    alarmTime: null as number | null,
     storage: {
       get: async <T>(key: string) => data.get(key) as T | undefined,
       list: async <T>(options?: { prefix?: string }) =>
@@ -250,11 +254,13 @@ function makeState(data: Map<string, unknown>, background: Promise<unknown>[]) {
       delete: async (key: string) => {
         data.delete(key);
       },
-      setAlarm: async () => {
+      setAlarm: async (time?: number) => {
         state.alarmDeleted = false;
+        state.alarmTime = typeof time === "number" ? time : null;
       },
       deleteAlarm: async () => {
         state.alarmDeleted = true;
+        state.alarmTime = null;
       },
       deleteAll: async () => {
         data.clear();
@@ -1470,7 +1476,9 @@ test("delete operation clears room storage and cancels the mirror-retry alarm", 
     result: { historyLength: 2 },
   });
   await Promise.all(background.splice(0));
-  expect(data.size).toBe(1);
+  // Snapshot plus the persisted alarm-deadline set (idle expiry is armed on
+  // every non-personal save).
+  expect(data.size).toBe(2);
 
   const response = await object.fetch(
     new Request("https://shared-runtime.internal/delete", {
@@ -1480,14 +1488,233 @@ test("delete operation clears room storage and cancels the mirror-retry alarm", 
   );
 
   await expect(response.json()).resolves.toEqual({ success: true });
-  expect(data.size).toBe(0);
+  // Everything is purged except the deletion tombstone that fences the room.
+  expect(data.size).toBe(1);
+  expect(data.has("deletion-tombstone")).toBe(true);
   expect(state.alarmDeleted).toBe(true);
 
-  // The next request must observe no resident history: it falls back to the
-  // cold-hydration path (warming 503) instead of serving purged content.
+  // The next request must observe the tombstone and fail closed instead of
+  // re-creating conversation state for a deleted agent.
   expect(await invoke("post-delete")).toMatchObject({
-    code: "conversation_cache_warming",
-    retryable: true,
+    code: "agent_deleted",
+    retryable: false,
   });
   await Promise.all(background.splice(0));
+  expect(data.size).toBe(1);
+});
+
+test("a deletion tombstone fences late mirrors and alarms from resurrecting content", async () => {
+  repositoryReads = 0;
+  repositoryWrites = 0;
+  repositoryRow = [];
+  const data = new Map<string, unknown>();
+  const background: Promise<unknown>[] = [];
+  const state = makeState(data, background);
+  const object = new SharedRuntimeConversation(state as never, {} as never);
+
+  const response = await object.fetch(
+    new Request("https://shared-runtime.internal/delete", {
+      method: "POST",
+      body: JSON.stringify({ operation: "delete", agentId: AGENT_FIXTURE.id }),
+    }),
+  );
+  await expect(response.json()).resolves.toEqual({ success: true });
+
+  // A mirror queued before the deletion must become a no-op after it.
+  await (
+    object as unknown as {
+      mirrorConversation(snapshot: unknown): Promise<void>;
+    }
+  ).mirrorConversation({
+    agentId: AGENT_FIXTURE.id,
+    channelId: "room-1",
+    history: [{ id: "m-1", role: "user", content: "secret", createdAt: 1 }],
+    dirty: true,
+    version: 1,
+  });
+  expect(repositoryWrites).toBe(0);
+
+  // A queued alarm firing after the deletion must not rebuild any state.
+  await object.alarm();
+  expect(data.size).toBe(1);
+  expect(data.has("deletion-tombstone")).toBe(true);
+
+  // Deletion stays idempotent under retries from the best-effort purge.
+  const retried = await object.fetch(
+    new Request("https://shared-runtime.internal/delete", {
+      method: "POST",
+      body: JSON.stringify({ operation: "delete", agentId: AGENT_FIXTURE.id }),
+    }),
+  );
+  await expect(retried.json()).resolves.toEqual({ success: true });
+  expect(data.size).toBe(1);
+});
+
+test("an idle mirror-confirmed room expires by alarm and re-hydrates losslessly", async () => {
+  repositoryReads = 0;
+  repositoryWrites = 0;
+  repositoryRow = [];
+  const data = new Map<string, unknown>();
+  const background: Promise<unknown>[] = [];
+  const state = makeState(data, background);
+  const object = new SharedRuntimeConversation(state as never, {} as never);
+  const invoke = makeInvoke(object);
+
+  // Cold room: first turn hydrates from the (empty) mirror, second lands.
+  expect(await invoke("cold")).toMatchObject({
+    code: "conversation_cache_warming",
+  });
+  await Promise.all(background.splice(0));
+  expect(await invoke("turn-1")).toMatchObject({
+    result: { historyLength: 1 },
+  });
+  await Promise.all(background.splice(0));
+
+  // The save armed the idle-expiry deadline on the single DO alarm.
+  const deadlines = data.get("alarm-deadlines") as { idleExpiryAt?: number };
+  expect(typeof deadlines.idleExpiryAt).toBe("number");
+  expect(state.alarmTime).toBe(deadlines.idleExpiryAt ?? null);
+  const mirrored = repositoryRow;
+  expect((mirrored as unknown[]).length).toBe(1);
+
+  // Fire the alarm past the deadline: the clean snapshot is dropped and the
+  // Postgres mirror becomes the sole copy.
+  data.set("alarm-deadlines", { idleExpiryAt: Date.now() - 1 });
+  await object.alarm();
+  expect(data.has("conversation")).toBe(false);
+  expect(data.has("alarm-deadlines")).toBe(false);
+  expect(state.alarmDeleted).toBe(true);
+
+  // The next request re-hydrates the same history from the mirror.
+  expect(await invoke("post-expiry")).toMatchObject({
+    code: "conversation_cache_warming",
+  });
+  await Promise.all(background.splice(0));
+  const rehydrated = await invoke("turn-2");
+  expect(rehydrated).toMatchObject({ result: { historyLength: 2 } });
+  expect(
+    (rehydrated as { result: { historyIds: (string | null)[] } }).result
+      .historyIds,
+  ).toEqual(["message-turn-1"]);
+  await Promise.all(background.splice(0));
+});
+
+test("an unmirrored snapshot is hard-retained at expiry until the mirror lands", async () => {
+  repositoryReads = 0;
+  repositoryWrites = 0;
+  repositoryRow = [];
+  repositoryMergeError = new Error("mirror outage");
+  const data = new Map<string, unknown>([
+    [
+      "conversation",
+      {
+        agentId: AGENT_FIXTURE.id,
+        channelId: "room-1",
+        history: [
+          { id: "m-1", role: "user", content: "only copy", createdAt: 1 },
+        ],
+        dirty: true,
+        version: 4,
+      },
+    ],
+    ["alarm-deadlines", { idleExpiryAt: Date.now() - 1 }],
+  ]);
+  const background: Promise<unknown>[] = [];
+  const state = makeState(data, background);
+  const object = new SharedRuntimeConversation(state as never, {} as never);
+
+  await object.alarm();
+  await Promise.all(background.splice(0));
+
+  // The dirty snapshot survives, and both the failed-mirror retry and the
+  // re-armed expiry are persisted deadlines on the single alarm.
+  expect(data.has("conversation")).toBe(true);
+  const retained = data.get("alarm-deadlines") as {
+    mirrorRetryAt?: number;
+    idleExpiryAt?: number;
+  };
+  expect(typeof retained.mirrorRetryAt).toBe("number");
+  expect(typeof retained.idleExpiryAt).toBe("number");
+  expect(state.alarmDeleted).toBe(false);
+  expect(state.alarmTime).toBe(
+    Math.min(retained.mirrorRetryAt ?? 0, retained.idleExpiryAt ?? 0),
+  );
+
+  // Once the mirror recovers, the retried mirror confirms the snapshot and
+  // the same alarm's due expiry drops it.
+  repositoryMergeError = null;
+  data.set("alarm-deadlines", {
+    mirrorRetryAt: Date.now() - 1,
+    idleExpiryAt: Date.now() - 1,
+  });
+  await object.alarm();
+  await Promise.all(background.splice(0));
+  expect(repositoryRow.length).toBe(1);
+  expect(data.has("conversation")).toBe(false);
+});
+
+test("a stalled stream consumer is fenced and releases the room lock", async () => {
+  repositoryReads = 0;
+  repositoryWrites = 0;
+  repositoryRow = [];
+  const data = new Map<string, unknown>([
+    [
+      "conversation",
+      {
+        agentId: AGENT_FIXTURE.id,
+        channelId: "room-1",
+        history: [],
+        dirty: false,
+        version: 1,
+      },
+    ],
+  ]);
+  const background: Promise<unknown>[] = [];
+  const object = new SharedRuntimeConversation(
+    makeState(data, background) as never,
+    {} as never,
+  );
+  (object as unknown as { streamStallTimeoutMs: number }).streamStallTimeoutMs =
+    20;
+
+  const streamed = await object.fetch(
+    new Request("https://shared-runtime.internal/stream", {
+      method: "POST",
+      body: JSON.stringify({
+        operation: "stream",
+        agent: AGENT_FIXTURE,
+        rpc: {
+          jsonrpc: "2.0",
+          id: "stalled",
+          method: "message.send",
+          params: { text: "hi", roomId: "room-1" },
+        },
+      }),
+    }),
+  );
+  // Consume one chunk, then stop pulling entirely without cancelling.
+  const reader = streamed.body!.getReader();
+  await reader.read();
+
+  // The backstop must cancel the wedged upstream turn and release the room so
+  // the next turn can proceed; without it this second turn waits forever.
+  const second = await Promise.race([
+    makeInvoke(object)("after-stall"),
+    new Promise((resolve) => setTimeout(() => resolve("timed-out"), 2_000)),
+  ]);
+  expect(second).toMatchObject({ result: {} });
+  await Promise.all(background.splice(0));
+
+  // The upstream cancellation persisted the interrupted turn durably.
+  const stored = (
+    data.get("conversation") as {
+      history: Array<{ content: string; interrupted?: boolean }>;
+    }
+  ).history;
+  expect(stored.map((message) => message.content)).toEqual([
+    "stream-user-stalled",
+    "partial",
+    "turn-after-stall",
+  ]);
+  expect(stored[1]?.interrupted).toBe(true);
 });

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -135,6 +135,36 @@ const PROVISIONAL_CONVERGENCE_IMPORT_PREFIX =
   "personal-provisional-convergence-import:";
 const RETRY_DELAY_MS = 30_000;
 
+/**
+ * Retention lifecycle (#17006). The single DO alarm is multiplexed across two
+ * persisted deadlines: `mirrorRetryAt` (re-run a failed Postgres mirror) and
+ * `idleExpiryAt` (drop a mirror-confirmed conversation window after the room
+ * has been idle). Expiry never deletes an unmirrored (`dirty`) snapshot and
+ * never runs for `personal:` rooms, whose `history-archive:*` keys exist only
+ * in DO storage — deleting those would be lossy. A deletion tombstone written
+ * by the `delete` operation fences every later save, hydration, alarm, and
+ * late mirror so a purged agent's content cannot be resurrected.
+ */
+const ALARM_DEADLINES_KEY = "alarm-deadlines";
+const DELETION_TOMBSTONE_KEY = "deletion-tombstone";
+const IDLE_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000;
+/**
+ * Backstop for a stalled streaming client (#17006): if the response body
+ * makes no progress for this long, the upstream reader is canceled (fencing
+ * the old turn) and room serialization is released.
+ */
+const STREAM_STALL_TIMEOUT_MS = 120_000;
+
+interface StoredAlarmDeadlines {
+  mirrorRetryAt?: number;
+  idleExpiryAt?: number;
+}
+
+interface StoredDeletionTombstone {
+  agentId: string;
+  deletedAt: number;
+}
+
 interface StoredCutoverSeal {
   token: string;
   expiresAt: number;
@@ -255,6 +285,9 @@ export class SharedRuntimeConversation {
   private hydration: Promise<void> | undefined;
   private queue: Promise<void> = Promise.resolve();
   private mirrorQueue: Promise<void> = Promise.resolve();
+  // Instance field rather than a direct constant read so the deterministic
+  // unit harness can shorten the stall window without a real two-minute wait.
+  private streamStallTimeoutMs = STREAM_STALL_TIMEOUT_MS;
 
   constructor(state: DurableObjectState, env: AppEnv["Bindings"]) {
     this.state = state;
@@ -372,9 +405,47 @@ export class SharedRuntimeConversation {
     });
   }
 
+  /**
+   * Recompute the persisted deadline set and (re)arm the single DO alarm to
+   * the earliest remaining deadline, or cancel it when none remain. All alarm
+   * scheduling funnels through here so the two lifecycles cannot clobber each
+   * other's wake-ups.
+   */
+  private async updateAlarmDeadlines(
+    mutate: (current: StoredAlarmDeadlines) => StoredAlarmDeadlines,
+  ): Promise<void> {
+    const current =
+      (await this.state.storage.get<StoredAlarmDeadlines>(
+        ALARM_DEADLINES_KEY,
+      )) ?? {};
+    const next = mutate(current);
+    const times = [next.mirrorRetryAt, next.idleExpiryAt].filter(
+      (time): time is number => typeof time === "number",
+    );
+    if (times.length === 0) {
+      await this.state.storage.delete(ALARM_DEADLINES_KEY);
+      await this.state.storage.deleteAlarm();
+      return;
+    }
+    await this.state.storage.put(ALARM_DEADLINES_KEY, next);
+    await this.state.storage.setAlarm(Math.min(...times));
+  }
+
+  private async deletionTombstone(): Promise<StoredDeletionTombstone | null> {
+    return (
+      (await this.state.storage.get<StoredDeletionTombstone>(
+        DELETION_TOMBSTONE_KEY,
+      )) ?? null
+    );
+  }
+
   private async mirrorConversation(
     snapshot: StoredConversation,
   ): Promise<void> {
+    // A mirror queued before the agent's deletion must not run after it: the
+    // Postgres rows were purged with the agent, and a late merge would
+    // resurrect deleted conversation content.
+    if (await this.deletionTombstone()) return;
     try {
       await this.runWithBindings(async () => {
         const { sharedRuntimeHistoryRepository } = await import(
@@ -398,6 +469,9 @@ export class SharedRuntimeConversation {
         this.conversation = { ...current, dirty: false };
         await this.state.storage.put(CONVERSATION_KEY, this.conversation);
       }
+      await this.updateAlarmDeadlines(
+        ({ mirrorRetryAt: _settled, ...rest }) => rest,
+      );
     } catch (error) {
       // error-policy:J7 the Durable Object copy is authoritative for active
       // chat; a failed reporting mirror is retried by alarm and must not kill
@@ -408,7 +482,10 @@ export class SharedRuntimeConversation {
         channelId: snapshot.channelId,
         error: error instanceof Error ? error.message : String(error),
       });
-      await this.state.storage.setAlarm(Date.now() + RETRY_DELAY_MS);
+      await this.updateAlarmDeadlines((deadlines) => ({
+        ...deadlines,
+        mirrorRetryAt: Date.now() + RETRY_DELAY_MS,
+      }));
     }
   }
 
@@ -502,6 +579,15 @@ export class SharedRuntimeConversation {
         await this.state.storage.put(CONVERSATION_KEY, snapshot);
         this.conversation = snapshot;
         this.scheduleMirror(snapshot);
+        // Refresh the idle-expiry deadline on every save. Personal rooms are
+        // exempt: their archive keys have no Postgres copy, so expiry could
+        // not re-hydrate them.
+        if (!startEmpty && !agentId.startsWith("personal:")) {
+          await this.updateAlarmDeadlines((deadlines) => ({
+            ...deadlines,
+            idleExpiryAt: Date.now() + IDLE_EXPIRY_MS,
+          }));
+        }
         return snapshot.history;
       },
     };
@@ -659,6 +745,21 @@ export class SharedRuntimeConversation {
 
   private async handle(request: Request): Promise<Response> {
     const payload = (await request.json()) as ConversationRequest;
+    // Deletion fence: once the agent behind this room is purged, every later
+    // operation (save, hydration, history read, forwarded turn) fails closed
+    // instead of re-creating state for a deleted agent. The `delete` op stays
+    // idempotent.
+    if (payload.operation !== "delete" && (await this.deletionTombstone())) {
+      return Response.json(
+        {
+          success: false,
+          error: "This agent has been deleted.",
+          code: "agent_deleted",
+          retryable: false,
+        },
+        { status: 410 },
+      );
+    }
     const personal =
       payload.operation === "personal-bridge" ||
       payload.operation === "personal-stream" ||
@@ -1125,6 +1226,13 @@ export class SharedRuntimeConversation {
       await this.state.storage.deleteAll();
       await this.state.storage.deleteAlarm();
       this.conversation = null;
+      // The tombstone survives the purge so late mirrors, queued alarms, and
+      // stale clients addressing this room name are fenced permanently; agent
+      // ids are never reused, so the room name is dead once its agent is.
+      await this.state.storage.put(DELETION_TOMBSTONE_KEY, {
+        agentId: payload.agentId,
+        deletedAt: Date.now(),
+      } satisfies StoredDeletionTombstone);
       return Response.json({ success: true });
     }
 
@@ -1200,20 +1308,46 @@ export class SharedRuntimeConversation {
       return response;
     }
     const reader = response.body.getReader();
+    // Stall backstop: a client that stops pulling would otherwise hold the
+    // room queue forever. The watchdog is refreshed on every consumed chunk;
+    // on a stall it FIRST cancels the upstream reader — fencing the wedged
+    // turn so it cannot keep writing — and only then releases serialization.
+    let stallTimer: ReturnType<typeof setTimeout> | undefined;
+    let settled = false;
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      if (stallTimer !== undefined) clearTimeout(stallTimer);
+      release();
+    };
+    const armStallTimer = () => {
+      if (settled) return;
+      if (stallTimer !== undefined) clearTimeout(stallTimer);
+      stallTimer = setTimeout(() => {
+        reader
+          .cancel("shared-runtime room stream stalled past backstop")
+          // error-policy:J6 canceling an already-errored reader is teardown
+          // only; the lock release below is the recovery that matters.
+          .catch(() => undefined)
+          .finally(settle);
+      }, this.streamStallTimeoutMs);
+    };
+    armStallTimer();
     const body = new ReadableStream<Uint8Array>({
       pull: async (controller) => {
         try {
           const next = await reader.read();
           if (next.done) {
-            release();
+            settle();
             controller.close();
             return;
           }
+          armStallTimer();
           controller.enqueue(next.value);
         } catch (error) {
           // error-policy:J1 the response-stream boundary must release the
           // conversation lock before surfacing a read failure to the caller.
-          release();
+          settle();
           controller.error(error);
         }
       },
@@ -1221,7 +1355,7 @@ export class SharedRuntimeConversation {
         try {
           await reader.cancel(reason);
         } finally {
-          release();
+          settle();
         }
       },
     });
@@ -1309,12 +1443,79 @@ export class SharedRuntimeConversation {
     }
   }
 
-  async alarm(): Promise<void> {
+  /**
+   * Drop a mirror-confirmed idle conversation window so the Postgres mirror
+   * becomes the sole copy; the next request re-hydrates through the existing
+   * cold-migration path, so expiry is loss-free. A still-dirty snapshot is
+   * hard-retained: the mirror is retried and expiry re-armed instead.
+   */
+  private async expireIdleConversation(): Promise<void> {
+    await this.updateAlarmDeadlines(({ idleExpiryAt: _due, ...rest }) => rest);
     const snapshot =
       this.conversation ??
       (await this.state.storage.get<StoredConversation>(CONVERSATION_KEY));
-    if (snapshot?.dirty) {
+    if (!snapshot) return;
+    if (snapshot.agentId.startsWith("personal:")) return;
+    if (snapshot.dirty) {
       await this.scheduleMirror(snapshot);
+      const settled =
+        this.conversation ??
+        (await this.state.storage.get<StoredConversation>(CONVERSATION_KEY));
+      if (!settled || settled.dirty) {
+        await this.updateAlarmDeadlines((deadlines) => ({
+          ...deadlines,
+          idleExpiryAt: Date.now() + RETRY_DELAY_MS,
+        }));
+        return;
+      }
+    }
+    await this.state.storage.delete(CONVERSATION_KEY);
+    // The turn-claim replay window is only meaningful for in-flight client
+    // retries; after a full idle period it is dead weight, and the billing
+    // admission gate still dedupes by deterministic identity.
+    await this.state.storage.delete(TURN_CLAIMS_KEY);
+    this.conversation = undefined;
+  }
+
+  async alarm(): Promise<void> {
+    if (await this.deletionTombstone()) return;
+    const deadlines =
+      await this.state.storage.get<StoredAlarmDeadlines>(ALARM_DEADLINES_KEY);
+    if (!deadlines) {
+      // Pre-deadline deployments armed the alarm directly for mirror retry;
+      // honor that contract for rooms that carried one across the upgrade.
+      const snapshot =
+        this.conversation ??
+        (await this.state.storage.get<StoredConversation>(CONVERSATION_KEY));
+      if (snapshot?.dirty) {
+        await this.scheduleMirror(snapshot);
+      }
+      return;
+    }
+    const now = Date.now();
+    if (
+      typeof deadlines.mirrorRetryAt === "number" &&
+      deadlines.mirrorRetryAt <= now
+    ) {
+      await this.updateAlarmDeadlines(
+        ({ mirrorRetryAt: _due, ...rest }) => rest,
+      );
+      const snapshot =
+        this.conversation ??
+        (await this.state.storage.get<StoredConversation>(CONVERSATION_KEY));
+      if (snapshot?.dirty) {
+        await this.scheduleMirror(snapshot);
+      }
+    }
+    if (
+      typeof deadlines.idleExpiryAt === "number" &&
+      deadlines.idleExpiryAt <= now
+    ) {
+      await this.expireIdleConversation();
+    } else {
+      // A retried or early wake-up must not orphan future deadlines: re-arm
+      // the alarm to the earliest one that remains.
+      await this.updateAlarmDeadlines((current) => current);
     }
   }
 }

--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -285,6 +285,7 @@ export class SharedRuntimeConversation {
   private hydration: Promise<void> | undefined;
   private queue: Promise<void> = Promise.resolve();
   private mirrorQueue: Promise<void> = Promise.resolve();
+  private alarmMutationQueue: Promise<void> = Promise.resolve();
   // Instance field rather than a direct constant read so the deterministic
   // unit harness can shorten the stall window without a real two-minute wait.
   private streamStallTimeoutMs = STREAM_STALL_TIMEOUT_MS;
@@ -414,21 +415,40 @@ export class SharedRuntimeConversation {
   private async updateAlarmDeadlines(
     mutate: (current: StoredAlarmDeadlines) => StoredAlarmDeadlines,
   ): Promise<void> {
-    const current =
-      (await this.state.storage.get<StoredAlarmDeadlines>(
-        ALARM_DEADLINES_KEY,
-      )) ?? {};
-    const next = mutate(current);
-    const times = [next.mirrorRetryAt, next.idleExpiryAt].filter(
-      (time): time is number => typeof time === "number",
-    );
-    if (times.length === 0) {
-      await this.state.storage.delete(ALARM_DEADLINES_KEY);
-      await this.state.storage.deleteAlarm();
-      return;
-    }
-    await this.state.storage.put(ALARM_DEADLINES_KEY, next);
-    await this.state.storage.setAlarm(Math.min(...times));
+    await this.runAlarmMutation(async () => {
+      // A deadline update that was queued before deletion must not recreate an
+      // alarm or storage after the tombstone lands.
+      if (await this.deletionTombstone()) {
+        await this.state.storage.delete(ALARM_DEADLINES_KEY);
+        await this.state.storage.deleteAlarm();
+        return;
+      }
+      const current =
+        (await this.state.storage.get<StoredAlarmDeadlines>(
+          ALARM_DEADLINES_KEY,
+        )) ?? {};
+      const next = mutate(current);
+      const times = [next.mirrorRetryAt, next.idleExpiryAt].filter(
+        (time): time is number => typeof time === "number",
+      );
+      if (times.length === 0) {
+        await this.state.storage.delete(ALARM_DEADLINES_KEY);
+        await this.state.storage.deleteAlarm();
+        return;
+      }
+      await this.state.storage.put(ALARM_DEADLINES_KEY, next);
+      await this.state.storage.setAlarm(Math.min(...times));
+    });
+  }
+
+  private async runAlarmMutation(
+    operation: () => Promise<void>,
+  ): Promise<void> {
+    const current = this.alarmMutationQueue
+      .catch(() => undefined)
+      .then(operation);
+    this.alarmMutationQueue = current;
+    await current;
   }
 
   private async deletionTombstone(): Promise<StoredDeletionTombstone | null> {
@@ -457,7 +477,14 @@ export class SharedRuntimeConversation {
           snapshot.history,
           MAX_HISTORY_MESSAGES,
         );
+        // The caller purges Postgres before dispatching the DO delete. A merge
+        // already in flight can therefore finish after that purge. Re-check
+        // the durable fence and remove the resurrected row before returning.
+        if (await this.deletionTombstone()) {
+          await sharedRuntimeHistoryRepository.deleteByAgent(snapshot.agentId);
+        }
       });
+      if (await this.deletionTombstone()) return;
       const current =
         await this.state.storage.get<StoredConversation>(CONVERSATION_KEY);
       if (
@@ -1223,16 +1250,33 @@ export class SharedRuntimeConversation {
     // Postgres mirror rows are dropped; also cancels a pending mirror-retry
     // alarm so a queued retry cannot fire against the emptied room.
     if (payload.operation === "delete") {
-      await this.state.storage.deleteAll();
-      await this.state.storage.deleteAlarm();
-      this.conversation = null;
-      // The tombstone survives the purge so late mirrors, queued alarms, and
-      // stale clients addressing this room name are fenced permanently; agent
-      // ids are never reused, so the room name is dead once its agent is.
-      await this.state.storage.put(DELETION_TOMBSTONE_KEY, {
-        agentId: payload.agentId,
-        deletedAt: Date.now(),
-      } satisfies StoredDeletionTombstone);
+      await this.runAlarmMutation(async () => {
+        // Existing keys + tombstone must commit together: a crash between a
+        // deleteAll and a separate put would leave an empty but unfenced room
+        // that stale clients could hydrate again. DurableObjectTransaction has
+        // no deleteAll, so delete its key snapshot in API-sized batches.
+        await this.state.storage.transaction(async (txn) => {
+          const keys = [...(await txn.list()).keys()];
+          for (let offset = 0; offset < keys.length; offset += 128) {
+            await txn.delete(keys.slice(offset, offset + 128));
+          }
+          await txn.put(DELETION_TOMBSTONE_KEY, {
+            agentId: payload.agentId,
+            deletedAt: Date.now(),
+          } satisfies StoredDeletionTombstone);
+        });
+        await this.state.storage.deleteAlarm();
+        this.conversation = null;
+      });
+      // The caller deletes Postgres first, but an already-running mirror can
+      // land in the network gap before this tombstone. Purge again from inside
+      // the fenced DO operation; retries are intentionally idempotent.
+      await this.runWithBindings(async () => {
+        const { sharedRuntimeHistoryRepository } = await import(
+          "@/db/repositories/shared-runtime-history"
+        );
+        await sharedRuntimeHistoryRepository.deleteByAgent(payload.agentId);
+      });
       return Response.json({ success: true });
     }
 


### PR DESCRIPTION
Fixes #17006

Completes the shared-runtime conversation lifecycle work in `packages/cloud/api/src/shared-runtime-conversation.ts`. The caller-side purge (`purgeSharedConversationRooms` dispatched from `deleteAgent`) already landed on `develop`; this PR closes the DO-side gaps the triage comment on #17006 identified.

## What changed

**Deletion tombstone + fencing.** The `delete` operation now writes a durable `deletion-tombstone` record after `deleteAll()`. Every later operation on the room is fenced:

- `handle()` fails closed with a typed `410 agent_deleted` (non-retryable) for all non-delete operations, so a stale client or late hydration cannot re-create state for a deleted agent.
- `mirrorConversation()` no-ops under the tombstone, so a mirror queued before deletion cannot recreate the just-purged Postgres rows.
- `alarm()` returns immediately under the tombstone, so a queued mirror-retry or expiry alarm cannot rebuild state.
- The `delete` operation itself bypasses the fence and stays idempotent, so the best-effort caller purge can retry safely.

**Bounded idle retention with persisted, multiplexed deadlines.** A new persisted `alarm-deadlines` record holds `mirrorRetryAt` and `idleExpiryAt`; all alarm scheduling funnels through one helper that arms the DO's single alarm to the earliest remaining deadline (and cancels it when none remain), so the two lifecycles cannot clobber each other's wake-ups. Every non-personal save refreshes a 30-day idle-expiry deadline. Expiry is only taken when the snapshot is mirror-confirmed (`dirty: false`): the Postgres mirror is then the sole copy and the next request re-hydrates it through the existing cold-migration path. A still-dirty snapshot at expiry is **hard-retained**: the mirror is retried and expiry re-armed — expiry is never described or implemented as loss-free unless the same snapshot is confirmed mirrored. `personal:` rooms are exempt because their `history-archive:*` keys exist only in DO storage.

**Stalled-stream backstop.** A watchdog refreshed on every consumed chunk cancels the upstream reader first — fencing the wedged turn so it cannot keep writing — and only then releases room serialization, exactly the ordering required by the triage note (abort/fence before release, never merely permit a second writer). Backstop is 120 s of zero progress.

Legacy alarms armed directly by pre-deadline deployments (no `alarm-deadlines` record) still run the mirror-retry contract.

## Known limitation (called out, not hidden)

A room whose only copy is a dirty, never-mirrored snapshot has no Postgres channel row at deletion time, so the caller-side enumeration (`listChannelsByAgent`) cannot address it and it receives no tombstone. Such a room is now still bounded: its retention ends at the idle-expiry horizon instead of persisting forever. Fully closing that race requires a durable room registry committed before content (a topology change beyond this issue's scope); the mirror-resurrection half of the race *is* closed for every enumerated room by the tombstone.

## Tests

`packages/cloud/api/src/shared-runtime-conversation.test.ts` (deterministic bun harness, real DO class over a fake storage/alarm state):

- delete purges storage, cancels the alarm, leaves only the tombstone; post-delete turns return `agent_deleted`
- tombstone fences a late mirror (`repositoryWrites` stays 0), a queued alarm, and stays idempotent under delete retries
- warm save arms the idle deadline on the single alarm; due expiry drops the mirror-confirmed snapshot and turn claims; the next turn re-hydrates the identical history from the mirror (expiry → re-hydration equivalence)
- dirty snapshot at expiry under a mirror outage is hard-retained with both `mirrorRetryAt` and `idleExpiryAt` persisted and the alarm armed to the earliest; after the mirror recovers, the retried mirror confirms and the same due expiry drops the snapshot
- a consumer that stops pulling mid-stream is fenced by the backstop: the upstream cancellation persists the interrupted turn durably and the next turn acquires the room

```
bun test src/shared-runtime-conversation.test.ts   # 20 pass, 0 fail (177 expects)
bunx tsc --noEmit                                  # clean (packages/cloud/api)
bunx biome check <touched files>                   # clean
# neighboring purge-path suites (packages/cloud/shared):
#   agent-delete-shared-conversation-purge.test.ts + conversation-coordinator.test.ts
#   11 pass, 0 fail
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
