### PR TITLE
fix(ui): rename billingTab.redirecting i18n key to processing across locales

### DIFF
--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -7770,7 +7770,7 @@
   "cloud.billingTab.amountHint": "Enter the amount you want to add. Min: ${{min}}, Max: ${{max}}",
   "cloud.billingTab.card": "Card",
   "cloud.billingTab.crypto": "Crypto",
-  "cloud.billingTab.redirecting": "Redirecting...",
+  "cloud.billingTab.processing": "Processing…",
   "cloud.billingTab.payWithCrypto": "Pay with Crypto",
   "cloud.billingTab.buyCredits": "Buy credits",
   "cloud.billingTab.willBeAdded": "${{amount}} will be added to your balance",

--- a/packages/ui/src/i18n/locales/es.json
+++ b/packages/ui/src/i18n/locales/es.json
@@ -7145,7 +7145,7 @@
   "cloud.billingTab.amountHint": "Introduce el monto que deseas añadir. Mín: ${{min}}, Máx: ${{max}}",
   "cloud.billingTab.card": "Tarjeta",
   "cloud.billingTab.crypto": "Cripto",
-  "cloud.billingTab.redirecting": "Redirigiendo...",
+  "cloud.billingTab.processing": "Procesando…",
   "cloud.billingTab.payWithCrypto": "Pagar con criptomoneda",
   "cloud.billingTab.buyCredits": "Comprar créditos",
   "cloud.billingTab.willBeAdded": "${{amount}} se añadirán a tu saldo",

--- a/packages/ui/src/i18n/locales/ja.json
+++ b/packages/ui/src/i18n/locales/ja.json
@@ -7134,7 +7134,7 @@
   "cloud.billingTab.amountHint": "追加する金額を入力してください。最小: ${{min}}、最大: ${{max}}",
   "cloud.billingTab.card": "カード",
   "cloud.billingTab.crypto": "暗号資産",
-  "cloud.billingTab.redirecting": "リダイレクト中...",
+  "cloud.billingTab.processing": "処理中…",
   "cloud.billingTab.payWithCrypto": "暗号資産で支払う",
   "cloud.billingTab.buyCredits": "クレジットを購入",
   "cloud.billingTab.willBeAdded": "${{amount}} が残高に追加されます",

--- a/packages/ui/src/i18n/locales/ko.json
+++ b/packages/ui/src/i18n/locales/ko.json
@@ -7134,7 +7134,7 @@
   "cloud.billingTab.amountHint": "추가할 금액을 입력하세요. 최소: ${{min}}, 최대: ${{max}}",
   "cloud.billingTab.card": "카드",
   "cloud.billingTab.crypto": "암호화폐",
-  "cloud.billingTab.redirecting": "이동 중...",
+  "cloud.billingTab.processing": "처리 중…",
   "cloud.billingTab.payWithCrypto": "암호화폐로 결제",
   "cloud.billingTab.buyCredits": "크레딧 구매",
   "cloud.billingTab.willBeAdded": "${{amount}}이 잔액에 추가됩니다",

--- a/packages/ui/src/i18n/locales/pt.json
+++ b/packages/ui/src/i18n/locales/pt.json
@@ -7134,7 +7134,7 @@
   "cloud.billingTab.amountHint": "Insira o valor que deseja adicionar. Mín: ${{min}}, Máx: ${{max}}",
   "cloud.billingTab.card": "Cartão",
   "cloud.billingTab.crypto": "Cripto",
-  "cloud.billingTab.redirecting": "Redirecionando...",
+  "cloud.billingTab.processing": "Processando…",
   "cloud.billingTab.payWithCrypto": "Pagar com cripto",
   "cloud.billingTab.buyCredits": "Comprar créditos",
   "cloud.billingTab.willBeAdded": "${{amount}} será adicionado ao seu saldo",

--- a/packages/ui/src/i18n/locales/tl.json
+++ b/packages/ui/src/i18n/locales/tl.json
@@ -7127,7 +7127,7 @@
   "cloud.billingTab.amountHint": "Ilagay ang halagang gusto mong idagdag. Min: ${{min}}, Max: ${{max}}",
   "cloud.billingTab.card": "Kard",
   "cloud.billingTab.crypto": "Crypto",
-  "cloud.billingTab.redirecting": "Nagre-redirect...",
+  "cloud.billingTab.processing": "Pinoproseso…",
   "cloud.billingTab.payWithCrypto": "Magbayad gamit ang Crypto",
   "cloud.billingTab.buyCredits": "Bumili ng mga credit",
   "cloud.billingTab.willBeAdded": "${{amount}} ang idaragdag sa iyong balanse",

--- a/packages/ui/src/i18n/locales/vi.json
+++ b/packages/ui/src/i18n/locales/vi.json
@@ -7127,7 +7127,7 @@
   "cloud.billingTab.amountHint": "Nhập số tiền muốn thêm. Tối thiểu: ${{min}}, Tối đa: ${{max}}",
   "cloud.billingTab.card": "Thẻ",
   "cloud.billingTab.crypto": "Tiền mã hóa",
-  "cloud.billingTab.redirecting": "Đang chuyển hướng...",
+  "cloud.billingTab.processing": "Đang xử lý…",
   "cloud.billingTab.payWithCrypto": "Thanh toán bằng tiền mã hóa",
   "cloud.billingTab.buyCredits": "Mua tín dụng",
   "cloud.billingTab.willBeAdded": "${{amount}} sẽ được thêm vào số dư",

--- a/packages/ui/src/i18n/locales/zh-CN.json
+++ b/packages/ui/src/i18n/locales/zh-CN.json
@@ -7134,7 +7134,7 @@
   "cloud.billingTab.amountHint": "输入您要添加的金额。最低：${{min}}，最高：${{max}}",
   "cloud.billingTab.card": "银行卡",
   "cloud.billingTab.crypto": "加密货币",
-  "cloud.billingTab.redirecting": "正在跳转…",
+  "cloud.billingTab.processing": "处理中…",
   "cloud.billingTab.payWithCrypto": "使用加密货币付款",
   "cloud.billingTab.buyCredits": "购买额度",
   "cloud.billingTab.willBeAdded": "${{amount}} 将添加到您的余额",


### PR DESCRIPTION
Follow-up to #19802, which switched the buy-credits in-flight label to the new `cloud.billingTab.processing` key but left the locale catalogs on the retired `cloud.billingTab.redirecting` key, turning `bun run check:i18n` red on develop (missing key in en.json + orphaned translations in the other seven locales).

This swaps the key and translation in all eight catalogs. `bun run check:i18n` is green at this head (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)