### PR TITLE
fix(test): restore clean workflow test contracts

### DIFF
--- a/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
@@ -233,7 +233,7 @@ function notificationsPayload() {
   };
 }
 
-// A full-capability host (real API base + an Electrobun window id) so the
+// A full-capability host (real API base + an Electrobun bridge) so the
 // onboarding offers — and ENABLES — the Local runtime card. `__electrobunWindowId`
 // makes isElectrobunRuntime()→isDesktopPlatform() true, which is what
 // canSelectLocalRuntime() keys off (without it the Local card is rendered but
@@ -255,6 +255,15 @@ export async function injectFullCapabilityHost(page: Page): Promise<void> {
     win.__ELIZAOS_APP_BOOT_CONFIG__ = { apiBase: origin };
     win.__ELIZAOS_API_BASE__ = origin;
     win.__electrobunWindowId = 1;
+    win.__ELIZA_ELECTROBUN_RPC__ = {
+      request: {
+        desktopGetVersion: async () => ({ runtime: "playwright-smoke" }),
+        desktopRegisterShortcut: async () => ({ success: true }),
+        desktopSetTrayMenu: async () => undefined,
+      },
+      onMessage: () => {},
+      offMessage: () => {},
+    };
     // Production remains cloud-only by default (#13377). These helpers also run
     // against packaged builds where Vite's development default is absent, so
     // opt in explicitly; the production default is covered by
@@ -552,8 +561,7 @@ export const CLOUD_AGENT_ID = "ui-smoke-cloud-agent-1";
 // origins are trusted cloud API bases), keeping the real agent surface live.
 export const PERSONAL_ELIZA_ID =
   "personal:11111111-1111-5111-8111-111111111111";
-export const PERSONAL_ACTIVE_AGENT_ID =
-  "22222222-2222-4222-8222-222222222222";
+export const PERSONAL_ACTIVE_AGENT_ID = "22222222-2222-4222-8222-222222222222";
 export const CLOUD_AGENT_NAME = "Smoke Cloud Agent";
 
 /** Inject the cloud session token before React boots (getCloudAuthToken reads

--- a/packages/scripts/__tests__/vitest-core-edge-aliases.test.ts
+++ b/packages/scripts/__tests__/vitest-core-edge-aliases.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Verifies package test configs resolve the scheduling runtime's core edge
+ * import to a real source entry before their broad bare-core aliases.
+ */
+
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import codingToolsConfig from "../../../plugins/plugin-coding-tools/vitest.config";
+import defaultConfig from "../vitest/default.config";
+import { repoRoot } from "../vitest/repo-root";
+
+type Alias = { find: string | RegExp; replacement: string };
+
+function resolveAlias(config: unknown, specifier: string): string {
+  const aliases = (config as { resolve?: { alias?: Alias[] } }).resolve?.alias;
+  if (!Array.isArray(aliases)) {
+    throw new TypeError("Vitest aliases must be an ordered array");
+  }
+  const alias = aliases.find(({ find }) =>
+    typeof find === "string"
+      ? specifier === find || specifier.startsWith(`${find}/`)
+      : find.test(specifier),
+  );
+  if (!alias) throw new TypeError(`No alias found for ${specifier}`);
+  return specifier.replace(alias.find, alias.replacement);
+}
+
+describe("@elizaos/core/edge package-test aliases", () => {
+  test.each([
+    ["shared package config", defaultConfig],
+    ["coding-tools config", codingToolsConfig],
+  ])("%s targets the edge source entry", (_label, config) => {
+    expect(resolveAlias(config, "@elizaos/core/edge")).toBe(
+      path.join(repoRoot, "packages/core/src/index.edge.ts"),
+    );
+  });
+
+  test("coding-tools keeps core's cloud-routing re-export on source", () => {
+    expect(resolveAlias(codingToolsConfig, "@elizaos/cloud-routing")).toBe(
+      path.join(repoRoot, "packages/cloud/routing/src/index.ts"),
+    );
+  });
+
+  test("shared package config keeps the agent vault dependency on source", () => {
+    expect(resolveAlias(defaultConfig, "@elizaos/vault")).toBe(
+      path.join(repoRoot, "packages/vault/src/index.ts"),
+    );
+  });
+
+  test("shared package config resolves the agent's app-manager plugin", () => {
+    expect(resolveAlias(defaultConfig, "@elizaos/plugin-app-manager")).toBe(
+      path.join(repoRoot, "plugins/plugin-app-manager/src/index.ts"),
+    );
+  });
+});

--- a/packages/scripts/vitest/default.config.ts
+++ b/packages/scripts/vitest/default.config.ts
@@ -172,6 +172,7 @@ const workspacePluginSourceAliases = getWorkspacePluginAliases(repoRoot, [
   "plugin-agent-skills",
   "plugin-anthropic",
   "plugin-app-control",
+  "plugin-app-manager",
   "plugin-browser",
   "plugin-capacitor-bridge",
   "plugin-coding-tools",
@@ -354,6 +355,10 @@ const vitestResolveAlias: ModuleAlias[] = [
     replacement: path.join(cloudSdkSourceRoot, "index.ts"),
   },
   {
+    find: /^@elizaos\/vault$/,
+    replacement: path.join(elizaWorkspaceRoot, "packages/vault/src/index.ts"),
+  },
+  {
     // App-core tests mock this plugin, but Vitest still has to resolve the specifier.
     find: "@elizaos/capacitor-agent",
     replacement: appCoreModuleFallbackPath,
@@ -404,6 +409,18 @@ const vitestResolveAlias: ModuleAlias[] = [
           replacement: path.join(
             path.dirname(elizaCoreEntry),
             "testing/index.ts",
+          ),
+        },
+        {
+          // Scheduling's source runner imports the edge-safe serializer. Keep
+          // this exports-map subpath ahead of the prefix-matching bare alias so
+          // clean package tests never resolve `index.node.ts/edge` (ENOTDIR).
+          find: /^@elizaos\/core\/edge$/,
+          replacement: path.join(
+            path.dirname(elizaCoreEntry),
+            elizaCoreEntry.endsWith(".ts")
+              ? "index.edge.ts"
+              : "edge/index.edge.js",
           ),
         },
         {

--- a/packages/ui/src/components/accounts/ConsumerKeyPanel.test.tsx
+++ b/packages/ui/src/components/accounts/ConsumerKeyPanel.test.tsx
@@ -118,17 +118,15 @@ describe("list states", () => {
 
   it("renders label, prefix, quota, status, and timestamps for each key", async () => {
     const api = makeApi({
-      listConsumerKeys: vi
-        .fn()
-        .mockResolvedValue([
-          key(),
-          key({
-            id: "ck_2",
-            label: "proxy-b",
-            enabled: false,
-            dailyTokenQuota: null,
-          }),
-        ]),
+      listConsumerKeys: vi.fn().mockResolvedValue([
+        key(),
+        key({
+          id: "ck_2",
+          label: "proxy-b",
+          enabled: false,
+          dailyTokenQuota: null,
+        }),
+      ]),
     });
     render(<ConsumerKeyPanelBody api={api} />);
     await waitFor(() => expect(screen.getByText("proxy-a")).toBeTruthy());

--- a/plugins/plugin-coding-tools/src/lib/terminal-capabilities.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/terminal-capabilities.test.ts
@@ -2,14 +2,47 @@
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { captureHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import {
   detectTerminalSupport,
   missingToolForCommand,
   resolveExecutable,
   resolveHostShell,
 } from "./terminal-capabilities.js";
+
+vi.mock("@elizaos/shared/host-execution-env", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@elizaos/shared/host-execution-env")>();
+  const { accessSync, constants } = await import("node:fs");
+  const pathApi = await import("node:path");
+  return {
+    ...actual,
+    resolveHostExecutable: (nameOrPath: string): string | undefined => {
+      const candidates = pathApi.isAbsolute(nameOrPath)
+        ? [nameOrPath]
+        : (process.env.PATH ?? "")
+            .split(pathApi.delimiter)
+            .filter(Boolean)
+            .map((entry) => pathApi.join(entry, nameOrPath));
+      return candidates.find((candidate) => {
+        try {
+          accessSync(candidate, constants.X_OK);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+    },
+  };
+});
 
 const ENV_KEYS = [
   "ELIZA_PLATFORM",
@@ -31,7 +64,6 @@ beforeAll(() => {
   savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
   tempDir = mkdtempSync(path.join(tmpdir(), "ct-cap-"));
   process.env.PATH = tempDir;
-  captureHostExecutionBaseline();
 });
 
 beforeEach(() => {

--- a/plugins/plugin-coding-tools/src/shell/__tests__/terminal-capabilities.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/__tests__/terminal-capabilities.test.ts
@@ -6,14 +6,47 @@
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { captureHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import {
   detectTerminalSupport,
   missingTerminalToolForCommand,
   resolveExecutable,
   resolveTerminalShell,
 } from "../utils/terminalCapabilities";
+
+vi.mock("@elizaos/shared/host-execution-env", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@elizaos/shared/host-execution-env")>();
+  const { accessSync, constants } = await import("node:fs");
+  const pathApi = await import("node:path");
+  return {
+    ...actual,
+    resolveHostExecutable: (nameOrPath: string): string | undefined => {
+      const candidates = pathApi.isAbsolute(nameOrPath)
+        ? [nameOrPath]
+        : (process.env.PATH ?? "")
+            .split(pathApi.delimiter)
+            .filter(Boolean)
+            .map((entry) => pathApi.join(entry, nameOrPath));
+      return candidates.find((candidate) => {
+        try {
+          accessSync(candidate, constants.X_OK);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+    },
+  };
+});
 
 const ENV_KEYS = [
   "ELIZA_PLATFORM",
@@ -35,7 +68,6 @@ beforeAll(() => {
   savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
   tempDir = mkdtempSync(path.join(tmpdir(), "shell-cap-"));
   process.env.PATH = tempDir;
-  captureHostExecutionBaseline();
 });
 
 beforeEach(() => {

--- a/plugins/plugin-coding-tools/vitest.config.ts
+++ b/plugins/plugin-coding-tools/vitest.config.ts
@@ -10,6 +10,14 @@ export default defineConfig({
   resolve: {
     alias: [
       {
+        find: /^@elizaos\/core\/edge$/,
+        replacement: path.join(repoRoot, "packages/core/src/index.edge.ts"),
+      },
+      {
+        find: /^@elizaos\/cloud-routing$/,
+        replacement: path.join(repoRoot, "packages/cloud/routing/src/index.ts"),
+      },
+      {
         find: /^@elizaos\/core$/,
         replacement: path.join(repoRoot, "packages/core/src/index.node.ts"),
       },
@@ -43,6 +51,11 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    setupFiles: ["./vitest.setup.ts"],
+    // Capability tests intentionally replace process-wide PATH values. Keep
+    // files serial so those fixtures cannot race shell-action execution in a
+    // sibling file inside the same Vitest worker process.
+    fileParallelism: false,
     include: ["__tests__/**/*.test.ts", "src/**/*.test.ts"],
     // *.real.test.ts files run only in the dedicated real/live lane
     // (packages/scripts/vitest/real.config.ts), never in the default suite.

--- a/plugins/plugin-coding-tools/vitest.setup.ts
+++ b/plugins/plugin-coding-tools/vitest.setup.ts
@@ -1,0 +1,5 @@
+/** Captures host executable authority before any test fixture mutates PATH. */
+
+import { captureHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
+
+captureHostExecutionBaseline();


### PR DESCRIPTION
Fixes #20405

## Summary

- resolve package-test imports for `@elizaos/core/edge`, vault, app-manager, and cloud routing directly from workspace source
- isolate coding-tools terminal capability tests from process-wide `PATH` mutation and serialize the suite where that shared process contract requires it
- give the full-capability onboarding fixture the minimal Electrobun RPC surface used by the application shell
- lock the source-alias contract with focused regression coverage

## Verification

Exact-head evidence: `c61a594f8147cf683dff31b27683fd358c7b8c07`

- `bun install --frozen-lockfile`
- `bun test packages/scripts/__tests__/vitest-core-edge-aliases.test.ts` — 5 passed
- `bun run --cwd plugins/plugin-inbox test` — 175 passed, 2 intentional skips
- `bun run --cwd plugins/plugin-coding-tools test` — 583 passed
- `bun run --cwd packages/ui test --run src/components/accounts/ConsumerKeyPanel.test.tsx` — 13 passed
- `bun run verify` — 356/356 workspace tasks passed; all repository audits passed

Additional built-app regression evidence immediately before the final clean, no-conflict rebase:

- `bun run --cwd packages/app test:e2e test/ui-smoke/onboarding-to-home.spec.ts --project=chromium` — 6 passed against the production renderer
- `bun run --cwd packages/app audit:app` — 219 captures passed; aesthetic broken=0, needs-work=0; OCR broken=0
- `bun run verify` — 353/353 workspace tasks and all repository audits passed

## Review evidence

- Before/after screenshots: N/A — this patch repairs test/runtime fixtures and resolution contracts; it does not change product pixels.
- Desktop/mobile visual review: the existing Workflow Studio surface passed all audited desktop, tablet, portrait-mobile, and landscape-mobile captures.
- Manual review: Workflow Studio remains sparse and canvas-first. A separate UX follow-up should consolidate the two-row mobile toolbar and disambiguate the competing header/canvas add controls without reintroducing text.

<!-- evidence-head:c61a594f8147cf683dff31b27683fd358c7b8c07 -->
<!-- evidence-row:before-screenshots -->
- N/A - no rendered product pixels changed; this patch only repairs test fixtures and module resolution.
<!-- evidence-row:after-screenshots -->
- N/A - no rendered product pixels changed; the existing app surface was separately audited.
<!-- evidence-row:walkthrough-video -->
- N/A - there is no changed user flow to record; the production-renderer onboarding suite covers all six paths.
<!-- evidence-row:backend-logs -->
- N/A - no backend runtime behavior changed.
<!-- evidence-row:frontend-logs -->
- N/A - no frontend network or state contract changed.
<!-- evidence-row:llm-trajectory -->
- N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- N/A - no persistent domain artifact is created by this test-infrastructure repair.
<!-- evidence-row:ocr-review -->
- N/A - no rendered visual surface changed; the independent app audit reported zero broken OCR views.

## Attribution

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: OpenAI/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: OpenAI / gpt-5.6-sol  
Client / agent tooling: Codex Desktop  
Contribution skill revision: N/A - no contribution skill used  
Attribution status: self-reported  
— [qa-agent]

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
