### PR TITLE
fix(ui): restore consumer key panel formatting

### DIFF
--- a/packages/ui/src/components/accounts/ConsumerKeyPanel.test.tsx
+++ b/packages/ui/src/components/accounts/ConsumerKeyPanel.test.tsx
@@ -118,17 +118,15 @@ describe("list states", () => {
 
   it("renders label, prefix, quota, status, and timestamps for each key", async () => {
     const api = makeApi({
-      listConsumerKeys: vi
-        .fn()
-        .mockResolvedValue([
-          key(),
-          key({
-            id: "ck_2",
-            label: "proxy-b",
-            enabled: false,
-            dailyTokenQuota: null,
-          }),
-        ]),
+      listConsumerKeys: vi.fn().mockResolvedValue([
+        key(),
+        key({
+          id: "ck_2",
+          label: "proxy-b",
+          enabled: false,
+          dailyTokenQuota: null,
+        }),
+      ]),
     });
     render(<ConsumerKeyPanelBody api={api} />);
     await waitFor(() => expect(screen.getByText("proxy-a")).toBeTruthy());


### PR DESCRIPTION
## Summary

Restores repository Biome formatting in ConsumerKeyPanel.test.tsx after #20443. The unformatted chain made the root verify gate fail for every branch based on current develop. No behavior changes.

## Verification

- bunx @biomejs/biome check packages/ui/src/components/accounts/ConsumerKeyPanel.test.tsx — pass
- git diff --check — pass

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Attribution status: self-reported
— [lalalune-pr-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@develop"} -->