### PR TITLE
fix(cloud): validate analytics days query

### DIFF
--- a/packages/cloud/api/v1/apps/[id]/promote/analytics/route.test.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/analytics/route.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Exercises the real promote-analytics Hono route with mocked auth and
+ * service boundaries. It pins a canonical 1–90 days query before campaign
+ * and attribution lookups.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const getById = mock(async () => ({
+  id: "app-1",
+  organization_id: "org-1",
+}));
+const listCampaigns = mock(async () => [
+  {
+    id: "camp-1",
+    name: "Launch",
+    platform: "twitter",
+    status: "active",
+    total_spend: "10.00",
+    total_impressions: 1000,
+    total_clicks: 50,
+    total_conversions: 5,
+  },
+]);
+const getCampaignAttribution = mock(async () => [
+  {
+    campaignId: "camp-1",
+    campaignName: "Launch",
+    platform: "twitter",
+    signups: 5,
+    conversions: 5,
+    cost: 10,
+  },
+]);
+
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg: async () => ({
+    user: { organization_id: "org-1" },
+    apiKey: null,
+  }),
+}));
+mock.module("@/lib/auth/app-key-scope", () => ({
+  isAppKeyOutOfScope: async () => false,
+}));
+mock.module("@/lib/services/apps", () => ({
+  appsService: { getById },
+}));
+mock.module("@/lib/services/advertising", () => ({
+  advertisingService: { listCampaigns },
+}));
+mock.module("@/lib/services/conversion-tracking", () => ({
+  conversionTrackingService: { getCampaignAttribution },
+}));
+
+const route = (await import("./route")).default;
+const app = new Hono().route("/api/v1/apps/:id/promote/analytics", route);
+
+function getAnalytics(query = "") {
+  return app.request(`/api/v1/apps/app-1/promote/analytics${query}`);
+}
+
+function expectWindowDays(
+  body: { dateRange: { start: string; end: string } },
+  days: number,
+  beforeMs: number,
+  afterMs: number,
+) {
+  const start = Date.parse(body.dateRange.start);
+  const end = Date.parse(body.dateRange.end);
+  expect(Number.isNaN(start)).toBe(false);
+  expect(Number.isNaN(end)).toBe(false);
+  expect(end).toBeGreaterThanOrEqual(beforeMs);
+  expect(end).toBeLessThanOrEqual(afterMs);
+  expect(start).toBeGreaterThanOrEqual(beforeMs - days * DAY_MS);
+  expect(start).toBeLessThanOrEqual(afterMs - days * DAY_MS);
+}
+
+describe("GET /api/v1/apps/:id/promote/analytics days validation", () => {
+  beforeEach(() => {
+    getById.mockClear();
+    listCampaigns.mockClear();
+    getCampaignAttribution.mockClear();
+  });
+
+  test("defaults to a 30-day window when days is omitted", async () => {
+    const beforeMs = Date.now();
+    const response = await getAnalytics();
+    const afterMs = Date.now();
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      dateRange: { start: string; end: string };
+    };
+    expectWindowDays(body, 30, beforeMs, afterMs);
+    expect(listCampaigns).toHaveBeenCalledWith("org-1", { appId: "app-1" });
+    expect(getCampaignAttribution).toHaveBeenCalledWith("org-1", {
+      appId: "app-1",
+    });
+  });
+
+  test.each([7, 90])(
+    "accepts a valid base-10 days value of %i",
+    async (days) => {
+      const beforeMs = Date.now();
+      const response = await getAnalytics(`?days=${days}`);
+      const afterMs = Date.now();
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        dateRange: { start: string; end: string };
+      };
+      expectWindowDays(body, days, beforeMs, afterMs);
+      expect(listCampaigns).toHaveBeenCalledTimes(1);
+      expect(getCampaignAttribution).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test.each([
+    ["malformed", "abc"],
+    ["zero", "0"],
+    ["negative", "-5"],
+    ["fractional", "1.5"],
+    ["scientific", "1e9"],
+    ["prefix-tolerant", "30abc"],
+    ["hex", "0x1e"],
+    ["leading-zero", "07"],
+    ["explicit-plus", "+7"],
+    ["surrounding-whitespace", " 7 "],
+    ["empty", ""],
+    ["above maximum", "999999"],
+  ])(
+    "rejects %s days=%s before campaign and attribution lookups",
+    async (_name, days) => {
+      const response = await getAnalytics(`?days=${encodeURIComponent(days)}`);
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body).toEqual({ error: "Invalid days" });
+      expect(listCampaigns).not.toHaveBeenCalled();
+      expect(getCampaignAttribution).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/v1/apps/[id]/promote/analytics/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/analytics/route.ts
@@ -1,4 +1,6 @@
-// Handles v1 cloud API v1 apps id promote analytics route traffic with route-local auth expectations.
+/**
+ * Serves authenticated app-promotion analytics with a bounded reporting window.
+ */
 import { parsePositiveInteger } from "@elizaos/shared/utils/number-parsing";
 import { Hono } from "hono";
 import { nextJsonFromCaughtError } from "@/lib/api/errors";
@@ -105,6 +107,7 @@ async function __hono_GET(
       },
     });
   } catch (error) {
+    // error-policy:J1 Translate route failures through the shared HTTP boundary.
     return nextJsonFromCaughtError(error);
   }
 }

--- a/packages/cloud/api/v1/apps/[id]/promote/analytics/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/promote/analytics/route.ts
@@ -1,4 +1,5 @@
 // Handles v1 cloud API v1 apps id promote analytics route traffic with route-local auth expectations.
+import { parsePositiveInteger } from "@elizaos/shared/utils/number-parsing";
 import { Hono } from "hono";
 import { nextJsonFromCaughtError } from "@/lib/api/errors";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
@@ -8,6 +9,8 @@ import { advertisingService } from "@/lib/services/advertising";
 import { appsService } from "@/lib/services/apps";
 import { conversionTrackingService } from "@/lib/services/conversion-tracking";
 import type { AppEnv } from "@/types/cloud-worker-env";
+
+const MAX_ANALYTICS_DAYS = 90;
 
 async function __hono_GET(
   request: Request,
@@ -26,7 +29,19 @@ async function __hono_GET(
     }
 
     const url = new URL(request.url);
-    const days = parseInt(url.searchParams.get("days") || "30", 10);
+    const rawDays = url.searchParams.get("days");
+    let days = 30;
+    if (rawDays !== null) {
+      const parsed = parsePositiveInteger(rawDays);
+      if (
+        parsed === undefined ||
+        rawDays !== String(parsed) ||
+        parsed > MAX_ANALYTICS_DAYS
+      ) {
+        return Response.json({ error: "Invalid days" }, { status: 400 });
+      }
+      days = parsed;
+    }
     const startDate = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
 
     const campaigns = await advertisingService.listCampaigns(


### PR DESCRIPTION
# Relates to

Fixes #20588

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased conflict-free onto the latest fetched `origin/develop`.
- [x] The real Hono route regression, Cloud API build/typecheck, package lint, and exact-head proof passed with Bun 1.3.14 and Node 24.15.0.
- [ ] Root `bun run verify` was not run; the bounded package evidence and known workspace blockers are recorded below.
- [x] A reviewer can reproduce both the prior HTTP 500/wrong-window behavior and the HTTP 400 boundary response from the focused table.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6; openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Grok Build; Claude Code via CLIProxyAPI
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased conflict-free onto `origin/develop@ade51f1fb767d8a92d0272f25428bb132aec5b64`.
- [x] Final candidate head is `edf2e1ebab7a6636c5baa30611cf1a1113935dfc`.
- [x] A complete read-only scan covered **29 open PRs / 332 changed-file rows** and found no owner for either target path.
- [x] The generated route map is untouched; this changes an already-mounted route.

# Risks

Low. The change is confined to one optional query parameter after the existing auth, organization ownership, and API-key scope checks. Valid 1–90 day windows and the omitted 30-day default retain the same response shape and calculations. Invalid input now returns HTTP 400 before campaign or attribution lookups instead of reaching those services or falling into the generic HTTP 500 boundary.

# Background

## What does this PR do?

Requires `days` to be a canonical base-10 integer from 1 through 90. The route reuses the shared positive-integer parser, then requires the raw query text to equal the canonical parsed spelling.

This rejects empty, zero, negative, fractional, scientific, hexadecimal, prefixed/suffixed, whitespace-padded, leading-zero, explicitly signed, and oversized values. Omitted `days` still defaults to 30.

Before this change, `days=abc` created an invalid `Date` and `toISOString()` threw `RangeError`, producing HTTP 500. Prefix-tolerant inputs such as `1e9`, `30abc`, and `0x1e` silently selected unintended windows.

## What kind of change is this?

Bug fix (untrusted HTTP query validation).

# Documentation changes needed?

No. This makes the existing analytics query boundary deterministic and does not change the documented success response.

# Testing

## Where should a reviewer start?

- `packages/cloud/api/v1/apps/[id]/promote/analytics/route.ts`
- `packages/cloud/api/v1/apps/[id]/promote/analytics/route.test.ts`

## Detailed testing steps

Pinned toolchain: Bun `1.3.14`, Node `24.15.0`.

```bash
bun test 'packages/cloud/api/v1/apps/[id]/promote/analytics/route.test.ts'
bun run --cwd packages/cloud/api build
bunx tsc --noEmit -p packages/cloud/api/tsconfig.json
bun run --cwd packages/cloud/api lint:check
git diff --check origin/develop...HEAD
```

# Evidence Gate

<!-- evidence-head:d5ad2bcd9e52c97ff2b1d6a9507be501b739627f -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend API query validation; no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend API query validation; no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual or interactive frontend flow changed.
<!-- evidence-row:backend-logs -->
- [x] [20590-pr20590-verify.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20590-pr20590-verify.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend client behavior changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [20590-pr20590-domain-artifacts.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20590-pr20590-domain-artifacts.md)

```text
Tests-first baseline before the production change:
- 3 passed / 7 failed
- days=abc returned 500
- zero, negative, scientific, hexadecimal, suffixed, and oversized values returned 200 with wrong windows

Final base ade51f1fb767d8a92d0272f25428bb132aec5b64
Exact head edf2e1ebab7a6636c5baa30611cf1a1113935dfc
- focused mounted-route suite: 15 passed / 0 failed
- assertions: 75
- route source coverage: 100% functions / 97.06% lines
- Cloud API tsc6 build: passed
- Cloud API TypeScript 6 typecheck: passed
- Cloud API Biome lint: 1,108 files checked, no fixes
- git diff --check origin/develop...HEAD: clean
- worktree: clean; one authored commit ahead of origin/develop
- changed-file ownership: 29 open PRs fully scanned, zero overlap
```

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or visual text changed.

# Evidence Details

## Backend + frontend logs

The test mounts the actual route in Hono and mocks only authentication and external service boundaries. It verifies the default, valid, and maximum date windows and asserts that every invalid spelling returns `{ "error": "Invalid days" }` with HTTP 400 before campaign or attribution calls.

## Known gaps / failures

- The complete isolated Cloud API unit runner was attempted in this light-install worktree and failed in untouched tests that could not resolve built `@elizaos/core` from `plugins/plugin-sql/src/index.ts`. The focused changed-route suite is exact-head green.
- The package `typecheck` script's Wrangler dry-run also requires built `@elizaos/core/dist/edge` artifacts absent from the light install. Both direct compiler lanes (`tsc6 --noEmit` and `tsc --noEmit`) passed.
- Root `bun run verify` was not run. No candidate-path error was observed in the bounded package checks above.

AI provider/model: xAI / grok-4.6; OpenAI / gpt-5.6-sol
Client / agent tooling: Grok Build; Claude Code via CLIProxyAPI
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code via CLIProxyAPI"} -->

