### PR TITLE
fix(cloud): harden bounded gateway auth renewal

### DIFF
--- a/packages/cloud/api/internal/auth/token/route.test.ts
+++ b/packages/cloud/api/internal/auth/token/route.test.ts
@@ -65,6 +65,29 @@ describe("bounded gateway JWT lifetime", () => {
     });
   });
 
+  test("rejects caller-selected non-gateway service claims", async () => {
+    const response = await tokenApp.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Gateway-Secret": "bootstrap-test-secret",
+        },
+        body: JSON.stringify({
+          pod_name: "gateway-webhook-test",
+          service: "scheduler",
+        }),
+      },
+      { GATEWAY_BOOTSTRAP_SECRET: "bootstrap-test-secret" } as never,
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "unsupported_gateway_service",
+    });
+  });
+
   test.each(["webhook-gateway", "discord-gateway"])(
     "rejects self-refresh for %s tokens",
     async (service) => {

--- a/packages/cloud/api/internal/auth/token/route.ts
+++ b/packages/cloud/api/internal/auth/token/route.ts
@@ -12,6 +12,7 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { isJWKSConfigured } from "@/lib/auth/jwks";
 import {
   internalTokenLifetimeForService,
+  isShortLivedGatewayService,
   signInternalToken,
 } from "@/lib/auth/jwt-internal";
 import { logger } from "@/lib/utils/logger";
@@ -50,6 +51,9 @@ app.post("/*", async (c) => {
     }
     const service =
       typeof body.service === "string" ? body.service.trim() : undefined;
+    if (!isShortLivedGatewayService(service)) {
+      return c.json({ error: "unsupported_gateway_service" }, 400);
+    }
 
     const token = await signInternalToken({
       subject,

--- a/packages/cloud/services/_common/AGENTS.md
+++ b/packages/cloud/services/_common/AGENTS.md
@@ -25,6 +25,8 @@ structured logging, and Kubernetes ServiceAccount helpers. Private
   tests only.
 - `src/identity-link-code.ts` (`./identity-link-code`) — canonical connector
   LINK-code recognition and user-facing confirmation results.
+- `src/gateway-auth.ts` (`./gateway-auth`) — strict short-lived gateway token
+  response validation plus shared refresh and jittered retry timing.
 - `src/response-attempts.ts` (`./response-attempts`) — bounded observable HTTP
   retry behavior shared across transport runtimes.
 - `src/telegram-connector.ts` (`./telegram-connector`) — Web-standard Telegram

--- a/packages/cloud/services/_common/CLAUDE.md
+++ b/packages/cloud/services/_common/CLAUDE.md
@@ -25,6 +25,8 @@ structured logging, and Kubernetes ServiceAccount helpers. Private
   tests only.
 - `src/identity-link-code.ts` (`./identity-link-code`) — canonical connector
   LINK-code recognition and user-facing confirmation results.
+- `src/gateway-auth.ts` (`./gateway-auth`) — strict short-lived gateway token
+  response validation plus shared refresh and jittered retry timing.
 - `src/response-attempts.ts` (`./response-attempts`) — bounded observable HTTP
   retry behavior shared across transport runtimes.
 - `src/telegram-connector.ts` (`./telegram-connector`) — Web-standard Telegram

--- a/packages/cloud/services/_common/package.json
+++ b/packages/cloud/services/_common/package.json
@@ -11,6 +11,7 @@
     "./logger": "./src/logger.ts",
     "./k8s-service-account": "./src/k8s-service-account.ts",
     "./identity-link-code": "./src/identity-link-code.ts",
+    "./gateway-auth": "./src/gateway-auth.ts",
     "./response-attempts": "./src/response-attempts.ts",
     "./telegram-connector": "./src/telegram-connector.ts",
     "./telegram-delivery": "./src/telegram-delivery.ts"

--- a/packages/cloud/services/_common/src/gateway-auth.ts
+++ b/packages/cloud/services/_common/src/gateway-auth.ts
@@ -1,0 +1,61 @@
+/** Defines the shared short-lived gateway token response and renewal timing contract. */
+
+export interface GatewayTokenResponse {
+  access_token: string;
+  token_type: "Bearer";
+  expires_in: number;
+}
+
+export const GATEWAY_TOKEN_MAX_LIFETIME_SECONDS = 60;
+export const GATEWAY_TOKEN_REQUEST_TIMEOUT_MS = 5_000;
+
+const TOKEN_REFRESH_FRACTION = 0.5;
+const TOKEN_REFRESH_RETRY_MIN_MS = 1_000;
+const TOKEN_REFRESH_RETRY_MAX_MS = 8_000;
+
+/** Rejects malformed token responses before they can corrupt gateway auth state. */
+export function parseGatewayTokenResponse(
+  value: unknown,
+): GatewayTokenResponse {
+  if (!value || typeof value !== "object") {
+    throw new Error("Invalid gateway token response");
+  }
+
+  const candidate = value as Record<string, unknown>;
+  if (
+    typeof candidate.access_token !== "string" ||
+    candidate.access_token.trim().length === 0 ||
+    candidate.access_token !== candidate.access_token.trim() ||
+    candidate.token_type !== "Bearer" ||
+    typeof candidate.expires_in !== "number" ||
+    !Number.isFinite(candidate.expires_in) ||
+    candidate.expires_in <= 0 ||
+    candidate.expires_in > GATEWAY_TOKEN_MAX_LIFETIME_SECONDS
+  ) {
+    throw new Error("Invalid gateway token response");
+  }
+
+  return {
+    access_token: candidate.access_token,
+    token_type: candidate.token_type,
+    expires_in: candidate.expires_in,
+  };
+}
+
+/** Refreshes halfway through the lease, leaving room for bounded retries. */
+export function gatewayTokenRefreshDelayMs(expiresInSeconds: number): number {
+  return expiresInSeconds * 1_000 * TOKEN_REFRESH_FRACTION;
+}
+
+/** Applies equal jitter so gateway replicas do not retry in lockstep. */
+export function gatewayTokenRetryDelayMs(
+  attempt: number,
+  random: () => number = Math.random,
+): number {
+  const exponentialDelay = Math.min(
+    TOKEN_REFRESH_RETRY_MIN_MS * 2 ** Math.max(0, attempt),
+    TOKEN_REFRESH_RETRY_MAX_MS,
+  );
+  const jitter = Math.min(1, Math.max(0, random()));
+  return Math.floor(exponentialDelay / 2 + (exponentialDelay / 2) * jitter);
+}

--- a/packages/cloud/services/_common/src/index.ts
+++ b/packages/cloud/services/_common/src/index.ts
@@ -1,6 +1,14 @@
 // Shares index service primitives across cloud worker sidecars.
 
 export {
+  GATEWAY_TOKEN_MAX_LIFETIME_SECONDS,
+  GATEWAY_TOKEN_REQUEST_TIMEOUT_MS,
+  type GatewayTokenResponse,
+  gatewayTokenRefreshDelayMs,
+  gatewayTokenRetryDelayMs,
+  parseGatewayTokenResponse,
+} from "./gateway-auth";
+export {
   extractIdentityLinkCode,
   identityLinkReply,
 } from "./identity-link-code";

--- a/packages/cloud/services/_common/tests/gateway-auth.test.ts
+++ b/packages/cloud/services/_common/tests/gateway-auth.test.ts
@@ -1,0 +1,51 @@
+/** Verifies gateway token response validation and bounded, jittered renewal timing. */
+
+import { describe, expect, test } from "bun:test";
+import {
+  gatewayTokenRefreshDelayMs,
+  gatewayTokenRetryDelayMs,
+  parseGatewayTokenResponse,
+} from "../src/gateway-auth";
+
+describe("gateway auth contract", () => {
+  test("accepts the bounded bearer response", () => {
+    expect(
+      parseGatewayTokenResponse({
+        access_token: "signed-token",
+        token_type: "Bearer",
+        expires_in: 60,
+      }),
+    ).toEqual({
+      access_token: "signed-token",
+      token_type: "Bearer",
+      expires_in: 60,
+    });
+  });
+
+  test.each([
+    null,
+    {},
+    { access_token: "", token_type: "Bearer", expires_in: 60 },
+    { access_token: " token ", token_type: "Bearer", expires_in: 60 },
+    { access_token: "token", token_type: "NotBearer", expires_in: 60 },
+    { access_token: "token", token_type: "Bearer", expires_in: 0 },
+    { access_token: "token", token_type: "Bearer", expires_in: -1 },
+    { access_token: "token", token_type: "Bearer", expires_in: 61 },
+    { access_token: "token", token_type: "Bearer", expires_in: Number.NaN },
+  ])("rejects malformed response %#", (value) => {
+    expect(() => parseGatewayTokenResponse(value)).toThrow(
+      "Invalid gateway token response",
+    );
+  });
+
+  test("refreshes halfway through a lease", () => {
+    expect(gatewayTokenRefreshDelayMs(60)).toBe(30_000);
+  });
+
+  test("caps exponential retries and applies equal jitter", () => {
+    expect(gatewayTokenRetryDelayMs(0, () => 0)).toBe(500);
+    expect(gatewayTokenRetryDelayMs(0, () => 1)).toBe(1_000);
+    expect(gatewayTokenRetryDelayMs(20, () => 0)).toBe(4_000);
+    expect(gatewayTokenRetryDelayMs(20, () => 1)).toBe(8_000);
+  });
+});

--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -1,4 +1,10 @@
 /** Coordinates multi-tenant Discord gateway connections and event routing. */
+import {
+  GATEWAY_TOKEN_REQUEST_TIMEOUT_MS,
+  gatewayTokenRefreshDelayMs,
+  gatewayTokenRetryDelayMs,
+  parseGatewayTokenResponse,
+} from "@elizaos/cloud-services-common/gateway-auth";
 import { Redis } from "@upstash/redis";
 import {
   type Attachment,
@@ -280,18 +286,6 @@ interface GatewayConfig {
   project: string;
 }
 
-/** JWT token response from token endpoint */
-interface TokenResponse {
-  access_token: string;
-  token_type: "Bearer";
-  expires_in: number;
-}
-
-/** Percentage of token lifetime at which to refresh. */
-const TOKEN_REFRESH_PERCENTAGE = 0.8;
-const TOKEN_REFRESH_RETRY_MIN_MS = 1_000;
-const TOKEN_REFRESH_RETRY_MAX_MS = 30_000;
-
 interface BotConnection {
   connectionId: string;
   organizationId: string;
@@ -555,6 +549,7 @@ export class GatewayManager {
    */
   private async acquireToken(): Promise<void> {
     const lifecycleGeneration = this.authLifecycleGeneration;
+    const acquisitionStartedAt = Date.now();
     logger.info("Acquiring JWT token", { podName: this.config.podName });
 
     const response = await fetchWithTimeout(
@@ -569,6 +564,7 @@ export class GatewayManager {
           pod_name: this.config.podName,
           service: "discord-gateway",
         }),
+        timeout: GATEWAY_TOKEN_REQUEST_TIMEOUT_MS,
       },
     );
 
@@ -577,19 +573,20 @@ export class GatewayManager {
       throw new Error(`Failed to acquire token: ${response.status} - ${error}`);
     }
 
-    const data = (await response.json()) as TokenResponse;
+    const data = parseGatewayTokenResponse(await response.json());
     if (lifecycleGeneration !== this.authLifecycleGeneration) {
       throw new Error("Auth lifecycle changed during token acquisition");
     }
     this.accessToken = data.access_token;
-    this.tokenExpiresAt = new Date(Date.now() + data.expires_in * 1000);
+    this.tokenExpiresAt = new Date(
+      acquisitionStartedAt + data.expires_in * 1_000,
+    );
 
     logger.info("JWT token acquired", {
       podName: this.config.podName,
       expiresAt: this.tokenExpiresAt.toISOString(),
     });
 
-    // Schedule token refresh at 80% of lifetime
     this.scheduleTokenRefresh(data.expires_in);
   }
 
@@ -601,14 +598,14 @@ export class GatewayManager {
   }
 
   /**
-   * Schedule token refresh at 80% of token lifetime.
+   * Schedule token refresh halfway through the token lifetime.
    */
   private scheduleTokenRefresh(expiresInSeconds: number): void {
     if (this.tokenRefreshTimeout) {
       clearTimeout(this.tokenRefreshTimeout);
     }
 
-    const refreshInMs = expiresInSeconds * 1000 * TOKEN_REFRESH_PERCENTAGE;
+    const refreshInMs = gatewayTokenRefreshDelayMs(expiresInSeconds);
     this.tokenRefreshRetryAttempt = 0;
     const timeout = setTimeout(() => {
       // error-policy:J1 The timer boundary converts renewal failure into a paced retry.
@@ -632,13 +629,10 @@ export class GatewayManager {
       clearTimeout(this.tokenRefreshTimeout);
     }
 
-    const retryInMs = Math.min(
-      TOKEN_REFRESH_RETRY_MIN_MS * 2 ** this.tokenRefreshRetryAttempt,
-      TOKEN_REFRESH_RETRY_MAX_MS,
-    );
+    const retryInMs = gatewayTokenRetryDelayMs(this.tokenRefreshRetryAttempt);
     this.tokenRefreshRetryAttempt = Math.min(
       this.tokenRefreshRetryAttempt + 1,
-      5,
+      4,
     );
     const lifecycleGeneration = this.authLifecycleGeneration;
     const timeout = setTimeout(() => {
@@ -668,7 +662,11 @@ export class GatewayManager {
    * Throws if no token is available.
    */
   private getAuthHeader(): { Authorization: string } {
-    if (!this.accessToken) {
+    if (
+      !this.accessToken ||
+      !this.tokenExpiresAt ||
+      Date.now() >= this.tokenExpiresAt.getTime()
+    ) {
       throw new Error("No access token available - call acquireToken first");
     }
     return { Authorization: `Bearer ${this.accessToken}` };

--- a/packages/cloud/services/gateway-discord/tests/gateway-manager-auth.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/gateway-manager-auth.test.ts
@@ -5,8 +5,10 @@ import { GatewayManager } from "../src/gateway-manager";
 
 interface AuthHarness {
   accessToken: string | null;
+  getAuthHeader(): { Authorization: string };
   refreshToken(): Promise<void>;
   scheduleTokenRefresh(expiresInSeconds: number): void;
+  tokenExpiresAt: Date | null;
   tokenRefreshTimeout: NodeJS.Timeout | null;
 }
 
@@ -122,6 +124,7 @@ describe("GatewayManager token renewal", () => {
     });
     const harness = manager as unknown as AuthHarness;
     harness.accessToken = "existing-token";
+    harness.tokenExpiresAt = new Date(Date.now() + 60_000);
 
     const renewal = harness.refreshToken();
     await waitFor(() => resolveBootstrap !== undefined);
@@ -140,6 +143,37 @@ describe("GatewayManager token renewal", () => {
     await expect(renewal).rejects.toThrow("Auth lifecycle changed");
     expect(harness.accessToken).toBe("existing-token");
     expect(harness.tokenRefreshTimeout).toBeNull();
+  });
+
+  test("rejects malformed and locally expired credentials", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: "invalid-token",
+            token_type: "NotBearer",
+            expires_in: -1,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    ) as typeof fetch;
+
+    const manager = new GatewayManager({
+      podName: "test-pod",
+      elizaCloudUrl: "https://api.test",
+      gatewayBootstrapSecret: "bootstrap-secret",
+      project: "test",
+    });
+    const harness = manager as unknown as AuthHarness;
+
+    await expect(harness.refreshToken()).rejects.toThrow(
+      "Invalid gateway token response",
+    );
+    expect(harness.accessToken).toBeNull();
+
+    harness.accessToken = "expired-token";
+    harness.tokenExpiresAt = new Date(Date.now() - 1);
+    expect(() => harness.getAuthHeader()).toThrow("No access token available");
   });
 });
 

--- a/packages/cloud/services/gateway-discord/tests/gateway-manager-dm-policy.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/gateway-manager-dm-policy.test.ts
@@ -37,6 +37,7 @@ interface GatewayManagerHarness {
   connections: Map<string, HarnessConnection>;
   redis: object | null;
   accessToken: string | null;
+  tokenExpiresAt: Date | null;
   handleMessage(connectionId: string, message: Message): Promise<void>;
   pollForBots(): Promise<void>;
   voiceHandler: {
@@ -120,6 +121,7 @@ function createBoundary(topology: Topology) {
   const harness = manager as unknown as GatewayManagerHarness;
   harness.redis = {};
   harness.accessToken = "test-token";
+  harness.tokenExpiresAt = new Date(Date.now() + 60_000);
 
   return {
     harness,

--- a/packages/cloud/services/gateway-webhook/__tests__/auth-rebootstrap-on-401.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/auth-rebootstrap-on-401.test.ts
@@ -175,7 +175,7 @@ describe("reacquireAuthHeader is single-flight", () => {
           JSON.stringify({
             access_token: `tok-${bootstraps}`,
             token_type: "Bearer",
-            expires_in: 3600,
+            expires_in: 60,
           }),
           { status: 200, headers: { "content-type": "application/json" } },
         );
@@ -238,6 +238,33 @@ describe("reacquireAuthHeader is single-flight", () => {
     expect(paths.every((path) => path === "/api/internal/auth/token")).toBe(
       true,
     );
+  });
+
+  test("rejects a malformed bootstrap response without installing it", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: "invalid-token",
+            token_type: "NotBearer",
+            expires_in: -1,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    ) as typeof fetch;
+
+    const { getAuthHeader, initAuth, shutdownAuth } = await import(
+      "../src/auth"
+    );
+    await expect(
+      initAuth({
+        cloudUrl: "https://api.test",
+        bootstrapSecret: "bootstrap",
+        podName: "test-pod",
+      }),
+    ).rejects.toThrow("Invalid gateway token response");
+    expect(() => getAuthHeader()).toThrow("No access token available");
+    shutdownAuth();
   });
 
   test("scheduled renewal retries bootstrap after a transient failure", async () => {

--- a/packages/cloud/services/gateway-webhook/src/auth.ts
+++ b/packages/cloud/services/gateway-webhook/src/auth.ts
@@ -1,16 +1,13 @@
 /** Handles webhook gateway authentication for authenticated connector fan-in. */
+import {
+  GATEWAY_TOKEN_REQUEST_TIMEOUT_MS,
+  gatewayTokenRefreshDelayMs,
+  gatewayTokenRetryDelayMs,
+  parseGatewayTokenResponse,
+} from "@elizaos/cloud-services-common/gateway-auth";
 import { logger } from "./logger";
 
 const HTTP_TIMEOUT_MS = 10_000;
-const TOKEN_REFRESH_PERCENTAGE = 0.8;
-const TOKEN_REFRESH_RETRY_MIN_MS = 1_000;
-const TOKEN_REFRESH_RETRY_MAX_MS = 30_000;
-
-interface TokenResponse {
-  access_token: string;
-  token_type: "Bearer";
-  expires_in: number;
-}
 
 interface AuthConfig {
   cloudUrl: string;
@@ -19,6 +16,7 @@ interface AuthConfig {
 }
 
 let accessToken: string | null = null;
+let accessTokenExpiresAt = 0;
 let refreshTimeout: ReturnType<typeof setTimeout> | null = null;
 let config: AuthConfig | null = null;
 let refreshRetryAttempt = 0;
@@ -46,6 +44,7 @@ async function acquireToken(): Promise<void> {
   if (!config) throw new Error("Auth not initialized");
   const lifecycleGeneration = authLifecycleGeneration;
   const activeConfig = config;
+  const acquisitionStartedAt = Date.now();
 
   logger.info("Acquiring JWT token", { podName: activeConfig.podName });
 
@@ -61,6 +60,7 @@ async function acquireToken(): Promise<void> {
         pod_name: activeConfig.podName,
         service: "webhook-gateway",
       }),
+      timeout: GATEWAY_TOKEN_REQUEST_TIMEOUT_MS,
     },
   );
 
@@ -69,11 +69,12 @@ async function acquireToken(): Promise<void> {
     throw new Error(`Failed to acquire token: ${response.status} - ${error}`);
   }
 
-  const data = (await response.json()) as TokenResponse;
+  const data = parseGatewayTokenResponse(await response.json());
   if (lifecycleGeneration !== authLifecycleGeneration) {
     throw new Error("Auth lifecycle changed during token acquisition");
   }
   accessToken = data.access_token;
+  accessTokenExpiresAt = acquisitionStartedAt + data.expires_in * 1_000;
 
   logger.info("JWT token acquired", {
     podName: activeConfig.podName,
@@ -91,7 +92,7 @@ async function refreshToken(): Promise<void> {
 function scheduleRefresh(expiresInSeconds: number): void {
   if (refreshTimeout) clearTimeout(refreshTimeout);
 
-  const refreshInMs = expiresInSeconds * 1000 * TOKEN_REFRESH_PERCENTAGE;
+  const refreshInMs = gatewayTokenRefreshDelayMs(expiresInSeconds);
   refreshRetryAttempt = 0;
   const timeout = setTimeout(() => {
     // error-policy:J1 The timer boundary converts renewal failure into a paced retry.
@@ -108,11 +109,8 @@ function scheduleRefresh(expiresInSeconds: number): void {
 function scheduleRefreshRetry(): void {
   if (refreshTimeout) clearTimeout(refreshTimeout);
 
-  const retryInMs = Math.min(
-    TOKEN_REFRESH_RETRY_MIN_MS * 2 ** refreshRetryAttempt,
-    TOKEN_REFRESH_RETRY_MAX_MS,
-  );
-  refreshRetryAttempt = Math.min(refreshRetryAttempt + 1, 5);
+  const retryInMs = gatewayTokenRetryDelayMs(refreshRetryAttempt);
+  refreshRetryAttempt = Math.min(refreshRetryAttempt + 1, 4);
   const lifecycleGeneration = authLifecycleGeneration;
   const timeout = setTimeout(() => {
     if (lifecycleGeneration !== authLifecycleGeneration) return;
@@ -134,6 +132,12 @@ function scheduleRefreshRetry(): void {
 
 export async function initAuth(authConfig: AuthConfig): Promise<void> {
   authLifecycleGeneration += 1;
+  if (refreshTimeout) {
+    clearTimeout(refreshTimeout);
+    refreshTimeout = null;
+  }
+  accessToken = null;
+  accessTokenExpiresAt = 0;
   config = authConfig;
   await acquireToken();
 }
@@ -168,7 +172,7 @@ export async function reacquireAuthHeader(): Promise<{
 }
 
 export function getAuthHeader(): { Authorization: string } {
-  if (!accessToken) {
+  if (!accessToken || Date.now() >= accessTokenExpiresAt) {
     throw new Error("No access token available - call initAuth first");
   }
   return { Authorization: `Bearer ${accessToken}` };
@@ -181,6 +185,7 @@ export function shutdownAuth(): void {
     refreshTimeout = null;
   }
   accessToken = null;
+  accessTokenExpiresAt = 0;
   config = null;
   refreshRetryAttempt = 0;
 }


### PR DESCRIPTION
# Relates to

- Reopens and advances #20290 after #20560 merged before its follow-up hardening commit.
- Related: #20560, #20344, #20275.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused package tests, typechecks, lint, guide parity, and the production Worker dry bundle pass at the exact head below.
- [x] A reviewer can confirm the contract from the tests and validation listed below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c890b8b95ccd07d58b86b72f9c98f4a4dee22e60:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@c890b8b95ccd07d58b86b72f9c98f4a4dee22e60`; zero conflicts.
- [x] Root `bun run verify` was run after rebase; it reaches workspace lint and fails only on the unrelated base UI formatter defect recorded below.

# Risks

Medium. This changes internal gateway credential lifecycle and token issuance. Failure modes are bounded to explicit auth failure; malformed or expired credentials are never installed or returned.

# Background

## What does this PR do?

It keeps #20560's correct architecture—short-lived allowlisted gateway JWTs avoid a remote Redis denylist check on every message—but repairs the unsafe and duplicated edges left in its merged head:

- rejects caller-selected or missing non-gateway `service` claims at mint time;
- parses the bootstrap response through one shared strict contract;
- caps gateway leases at 60 seconds and refuses locally expired credentials;
- reduces bootstrap timeout from 10s to 5s;
- refreshes halfway through the lease, leaving retry budget before expiry;
- uses capped equal-jitter retries rather than synchronized fixed exponential chains;
- preserves single-flight and lifecycle-generation fencing across webhook and Discord clients.

This intentionally does not reintroduce a negative denylist cache. Cross-isolate revoke/read races make that unsafe. It also does not provision separate bootstrap secrets; that is a protected deployment-secret migration, not a per-message-path fix.

## What kind of change is this?

Bug fix and latency/resilience improvement; no public API change.

# Documentation changes needed?

The internal common-service package guide and exports are updated for the shared gateway-auth contract. No user-facing documentation change is needed.

# Testing

## Where should a reviewer start?

- `packages/cloud/services/_common/src/gateway-auth.ts`
- `packages/cloud/api/internal/auth/token/route.ts`
- `packages/cloud/services/gateway-webhook/src/auth.ts`
- `packages/cloud/services/gateway-discord/src/gateway-manager.ts`

## Detailed testing steps

- `bun run --cwd packages/cloud/services/_common test` — 23 pass.
- isolated webhook auth suite — 9 pass.
- isolated Discord auth suite — 4 pass.
- token route suite — 5 pass.
- common, webhook, Discord, and Cloud API typechecks pass.
- common, webhook, and Discord lint pass.
- `bun run check:agents-claude`, changed-file Biome, and `git diff --check` pass.
- Cloud API production Wrangler dry bundle passes.

# Evidence Gate

<!-- evidence-head:e886a1f43384fc129fd086486197a8807ae83049 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only internal authentication change; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only internal authentication change; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only internal authentication change; no rendered UI.
<!-- evidence-row:backend-logs -->
- [ ] N/A - protected staging auth latency and revocation canary is pending merge and deployment authority
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact is created.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - authentication transport only.

## Backend + frontend logs

The exact-head automated suites above provide deterministic boundary evidence. Protected staging latency/revocation canaries remain required before issue closure and are not claimed here.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Known gaps / failures

- Protected staging canary and deployment are pending; this PR does not claim deployed or live behavior.
- The combined webhook + Discord fake-timer invocation can interfere across suites; each owning suite passes in isolation, which matches their package test lanes.
- Root `bun run verify` fails in unchanged `packages/ui/src/components/accounts/ConsumerKeyPanel.test.tsx:121`; Biome wants an existing mock chain reformatted. The file has no diff from `origin/develop`. The same base-only failure reproduces on both follow-up branches.

— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@c890b8b95ccd07d58b86b72f9c98f4a4dee22e60:packages/skills/skills/contribute-to-eliza"} -->

