### PR TITLE
perf(cloud): overlap personal Shared admission prewarm

### DIFF
--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -107,7 +107,8 @@ const coordinateSharedHistory = mock(async () => [
 const namespace = {
   getByName: mock(() => ({ fetch: mock(async () => new Response()) })),
 };
-const runtimeExecutionCtx = { waitUntil() {} };
+const runtimeWaitUntil = mock((_promise: Promise<unknown>) => undefined);
+const runtimeExecutionCtx = { waitUntil: runtimeWaitUntil };
 
 mock.module("@/lib/services/eliza-app", () => ({
   elizaAppUserService: {
@@ -209,6 +210,7 @@ describe("personal Shared messaging deliveries", () => {
     findActivePersonalDedicatedTarget.mockClear();
     sharedRestMessageSend.mockClear();
     prewarmPersonalSharedAgentTurnCaches.mockClear();
+    runtimeWaitUntil.mockClear();
     runOnboardingChat.mockClear();
     bridge.mockClear();
     importCanonicalConversation.mockClear();
@@ -291,6 +293,7 @@ describe("personal Shared messaging deliveries", () => {
       namespace,
     );
     expect(order).toEqual(["prewarm", "turn"]);
+    expect(runtimeWaitUntil).toHaveBeenCalledTimes(1);
     expect(response.headers.get("server-timing")).toMatch(
       /^account;dur=\d+\.\d;desc="[^"]+", prewarm;dur=\d+\.\d, shared;dur=\d+\.\d$/,
     );
@@ -301,6 +304,7 @@ describe("personal Shared messaging deliveries", () => {
 
     expect(response.status).toBe(200);
     expect(prewarmPersonalSharedAgentTurnCaches).not.toHaveBeenCalled();
+    expect(runtimeWaitUntil).not.toHaveBeenCalled();
   });
 
   test("correlates a Shared failure without logging its sensitive message", async () => {
@@ -439,6 +443,43 @@ describe("personal Shared messaging deliveries", () => {
       await expect(response.json()).resolves.toMatchObject({
         data: { reply: "hello from Eliza" },
       });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("overlaps new-account prewarm with Telegram voice transcription", async () => {
+    personalDeliveryIsNew = true;
+    const order: string[] = [];
+    prewarmPersonalSharedAgentTurnCaches.mockImplementationOnce(async () => {
+      order.push("prewarm");
+    });
+    sharedRestMessageSend.mockImplementationOnce(async () => {
+      order.push("turn");
+      return { text: "hello from Eliza" };
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () => {
+      order.push("transcription");
+      return Response.json({ text: "remember the red bicycle" });
+    }) as unknown as typeof fetch;
+    const bytes = Buffer.from("OggSvoice-note");
+
+    try {
+      const response = await request({
+        ...valid,
+        message: undefined,
+        voiceNote: {
+          bytesBase64: bytes.toString("base64"),
+          mimeType: "audio/ogg",
+          filename: "telegram-42.ogg",
+          sizeBytes: bytes.length,
+          durationSeconds: 4,
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(order).toEqual(["prewarm", "transcription", "turn"]);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -326,6 +326,17 @@ app.post("/", async (c) => {
       userId: account.userId,
       organizationId: account.organizationId,
     });
+    const personalPrewarm = isNewPersonalAccount
+      ? (() => {
+          const startedAt = performance.now();
+          const timing = prewarmPersonalSharedAgentTurnCaches(
+            agent,
+            worker.namespace,
+          ).then(() => performance.now() - startedAt);
+          worker.executionCtx.waitUntil(timing);
+          return timing;
+        })()
+      : null;
     let deliveryMessage = parsed.data.message;
     if (
       parsed.data.platform === "telegram" &&
@@ -585,12 +596,7 @@ app.post("/", async (c) => {
       });
     }
     stage = "shared_runtime";
-    let prewarmMs: number | undefined;
-    if (isNewPersonalAccount) {
-      const prewarmStartedAt = performance.now();
-      await prewarmPersonalSharedAgentTurnCaches(agent, worker.namespace);
-      prewarmMs = performance.now() - prewarmStartedAt;
-    }
+    const prewarmMs = personalPrewarm ? await personalPrewarm : undefined;
     const sharedStartedAt = performance.now();
     const trustedDelivery =
       parsed.data.platform === "telegram"

--- a/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
@@ -25,7 +25,6 @@ const GATE_BINDING = "INFERENCE_ADMISSION_GATES";
 const GATE_ORIGIN = "https://inference-admission.internal";
 const HYDRATION_GATE_TIMEOUT_MS = 5_000;
 const GATE_OPERATION_TIMEOUT_MS = 1_500;
-const RATE_LIMIT_GATE_TIMEOUT_MS = 5_000;
 const DISPATCH_GATE_TIMEOUT_MS = 1_500;
 const DISPATCH_GATE_MAX_ATTEMPTS = 3;
 
@@ -399,10 +398,7 @@ export async function consumeInferenceRateLimit(params: {
       maxRequests: params.maxRequests,
     },
     undefined,
-    // A brand-new organization addresses a brand-new Durable Object. Preserve
-    // the tighter money-mutation deadline above, but allow the lightweight
-    // rate-limit authority to survive genuine Worker/DO cold initialization.
-    AbortSignal.timeout(RATE_LIMIT_GATE_TIMEOUT_MS),
+    AbortSignal.timeout(GATE_OPERATION_TIMEOUT_MS),
   );
   if (response.status !== 200 && response.status !== 429) {
     throw new InferenceAdmissionGateUnavailableError(

--- a/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts
@@ -169,8 +169,9 @@ export async function prewarmSharedAgentTurnCaches(
 
 /**
  * Warm the two authorities a newly auto-registered personal agent needs.
- * Unlike dashboard agent creation, first contact already carries the user's
- * message, so the route awaits these concurrent legs before dispatching it.
+ * The messaging route starts these concurrent legs as soon as it resolves the
+ * account, overlaps them with other preparation, and joins them before Shared
+ * dispatch.
  */
 export async function prewarmPersonalSharedAgentTurnCaches(
   agent: Pick<SharedRuntimeAgent, "id" | "organization_id">,


### PR DESCRIPTION
# Relates to

- Reopens and advances #20271 after #20561 merged before its response-path simplification commit.
- Related: #20561, #20273, #20275.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] Focused package tests, typechecks, lint, and the production Worker dry bundle pass at the exact head below.
- [x] A reviewer can confirm the scheduling order from the deterministic route test.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c890b8b95ccd07d58b86b72f9c98f4a4dee22e60:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@7bb45bc1c4063f07d73e7edf5b48e6b0837282f2`; zero conflicts.
- [x] Root `bun run verify` was run after rebase; it reaches workspace lint and fails only on the unrelated base UI formatter defect recorded below.

# Risks

Low to medium. The prewarm operation is unchanged; only its scheduling and the unrelated global request timeout are corrected. Shared dispatch still awaits prewarm before starting the turn.

# Background

## What does this PR do?

It preserves #20561's useful cold-account admission prewarm while removing two avoidable response-path costs:

- restores the ordinary admission request timeout to 1.5s instead of globally raising it to 5s;
- starts personal prewarm immediately after account/runtime construction;
- overlaps it with voice transcription and route preparation;
- awaits it only when the request actually selects Shared;
- registers it with `waitUntil` so non-Shared routing does not orphan the work;
- reports the actual overlapped duration in Server-Timing.

The 5s hydration budget remains explicit inside the prewarm operation, where it belongs. A deterministic route test proves `prewarm` begins before `transcription`, and the Shared turn starts only after prewarm resolves.

## What kind of change is this?

Latency improvement and timeout-scope bug fix; no public API change.

# Documentation changes needed?

No user-facing documentation change is needed. The code responsibility comment is updated.

# Testing

## Where should a reviewer start?

- `packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts`
- `packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts`
- `packages/cloud/shared/src/lib/services/inference-admission-gate.ts`

## Detailed testing steps

- personal Shared route suite — 26 pass.
- shared-agent prewarm suite — 9 pass.
- conversation coordinator suite — 8 pass.
- inference admission gate suite — 31 pass.
- Cloud shared and Cloud API typechecks pass.
- Cloud shared lint passes.
- `bun run check:agents-claude`, changed-file Biome, and `git diff --check` pass.
- Cloud API production Wrangler dry bundle passes.

# Evidence Gate

<!-- evidence-head:b596f315b23bfe19b0f3c186bd96b636273f9c0f -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only request scheduling change; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only request scheduling change; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend-only request scheduling change; no rendered UI.
<!-- evidence-row:backend-logs -->
- [x] N/A - protected staging cold and warm trace canary is pending merge and deployment authority.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request or state change.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact is created by this scheduling change.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - request scheduling only; no model behavior changed.

## Backend + frontend logs

The exact-head automated suites above provide deterministic ordering and admission-gate evidence. Protected staging cold/warm trace canaries remain required before issue closure and are not claimed here.

## Screenshots (before / after) + video walkthrough

N/A - no UI changes.

## Known gaps / failures

- Protected staging cold/warm traces and deployment are pending; this PR does not claim deployed or live behavior.
- Root `bun run verify` fails in unchanged `packages/ui/src/components/accounts/ConsumerKeyPanel.test.tsx:121`; Biome wants an existing mock chain reformatted. The file has no diff from `origin/develop`. The same base-only failure reproduces on both follow-up branches.

— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@c890b8b95ccd07d58b86b72f9c98f4a4dee22e60:packages/skills/skills/contribute-to-eliza"} -->
