### PR TITLE
fix(reminders): one-shot migration marker stops phantom row resurrection

### DIFF
--- a/plugins/plugin-reminders/src/services/migration.test.ts
+++ b/plugins/plugin-reminders/src/services/migration.test.ts
@@ -66,7 +66,8 @@ describe("RemindersMigration", () => {
       if (sql.includes("SELECT NOT EXISTS")) return [{ empty: true }];
       if (
         sql.includes("INSERT INTO") &&
-        !sql.includes('ON CONFLICT ("id") DO NOTHING')
+        !sql.includes('ON CONFLICT ("id") DO NOTHING') &&
+        !sql.includes("ON CONFLICT (table_name) DO NOTHING")
       ) {
         throw new Error("duplicate key value violates unique constraint");
       }
@@ -95,5 +96,69 @@ describe("RemindersMigration", () => {
     expect(
       log.some((s) => /CREATE SCHEMA IF NOT EXISTS app_reminders/.test(s)),
     ).toBe(true);
+  });
+});
+
+describe("one-shot migration marker (2026-08-16 phantom routine rows)", () => {
+  it("skips the copy entirely once the marker exists — even with an empty target and a populated source", async () => {
+    const log: string[] = [];
+    const exec = fakeExec(
+      [
+        [/reminders_migration_state[\s\S]*table_name = /, [{ done: true }]],
+        [/to_regclass/, [{ present: true }]],
+        [/SELECT NOT EXISTS \(SELECT 1 FROM/, [{ empty: true }]],
+      ],
+      log,
+    );
+    const r = await migrateReminderTable(exec, "life_reminder_plans");
+    expect(r.outcome).toBe("already-migrated");
+    // The stale-source re-import that resurrected deleted routines must not run.
+    expect(log.some((s) => /INSERT INTO .*life_reminder_plans/s.test(s))).toBe(
+      false,
+    );
+  });
+
+  it("writes the marker on every terminal outcome so restarts never re-copy", async () => {
+    for (const [responses, outcome] of [
+      [[[/to_regclass/, [{ present: false }]]], "source-missing"],
+      [
+        [
+          [/to_regclass/, [{ present: true }]],
+          [/SELECT NOT EXISTS \(SELECT 1 FROM/, [{ empty: false }]],
+        ],
+        "target-non-empty",
+      ],
+      [
+        [
+          [/to_regclass/, [{ present: true }]],
+          [/SELECT NOT EXISTS \(SELECT 1 FROM/, [{ empty: true }]],
+        ],
+        "copied",
+      ],
+    ] as Array<[Array<[RegExp, Array<Record<string, unknown>>]>, string]>) {
+      const log: string[] = [];
+      const exec = fakeExec(responses, log);
+      const r = await migrateReminderTable(exec, "life_reminder_plans");
+      expect(r.outcome).toBe(outcome);
+      expect(
+        log.some((s) =>
+          /INSERT INTO .*reminders_migration_state[\s\S]*ON CONFLICT \(table_name\) DO NOTHING/s.test(
+            s,
+          ),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("migrateReminderTables creates the marker table before any per-table work", async () => {
+    const log: string[] = [];
+    const exec = fakeExec([[/to_regclass/, [{ present: false }]]], log);
+    await migrateReminderTables(exec);
+    const markerCreate = log.findIndex((s) =>
+      /CREATE TABLE IF NOT EXISTS .*reminders_migration_state/s.test(s),
+    );
+    const firstRegclass = log.findIndex((s) => s.includes("to_regclass"));
+    expect(markerCreate).toBeGreaterThanOrEqual(0);
+    expect(markerCreate).toBeLessThan(firstRegclass);
   });
 });

--- a/plugins/plugin-reminders/src/services/migration.ts
+++ b/plugins/plugin-reminders/src/services/migration.ts
@@ -10,13 +10,18 @@
  * once, idempotently, and WITHOUT ever touching the source.
  *
  * Guards (per table, independently):
- *   1. Skip if the source table does not exist (fresh install / already dropped).
- *   2. Skip if the target table is non-empty (migration already ran, or the
- *      plugin owns live data).
- *   3. Otherwise copy every source row that is not already present in the target
+ *   1. Skip if a durable completion marker for the table exists (the copy ran
+ *      once on this database — live 2026-08-16 phantom-rows incident: without
+ *      the marker, "skip if target non-empty" re-imported every stale
+ *      app_lifeops row on the first restart after an owner cleared their
+ *      routines, resurrecting long-deleted reminders).
+ *   2. Skip if the source table does not exist (fresh install / already dropped).
+ *   3. Skip if the target table is non-empty (plugin already owns live data).
+ *   4. Otherwise copy every source row that is not already present in the target
  *      (a doubly-safe NOT EXISTS guard on the primary key).
  *
- * The source table is NEVER dropped or altered.
+ * Every terminal outcome writes the marker, so the copy happens at most once
+ * per database. The source table is NEVER dropped or altered.
  */
 
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
@@ -41,7 +46,11 @@ export type SqlExecutor = (
 
 export interface TableMigrationResult {
   table: MigratedReminderTable;
-  outcome: "copied" | "source-missing" | "target-non-empty";
+  outcome:
+    | "copied"
+    | "source-missing"
+    | "target-non-empty"
+    | "already-migrated";
 }
 
 function quoteIdent(name: string): string {
@@ -68,14 +77,54 @@ async function targetTableIsEmpty(
   return rows[0]?.empty === true || rows[0]?.empty === "true";
 }
 
+const MIGRATION_MARKER_TABLE = "reminders_migration_state";
+
+async function ensureMigrationMarkerTable(exec: SqlExecutor): Promise<void> {
+  await exec(
+    `CREATE TABLE IF NOT EXISTS ${TARGET_SCHEMA}.${quoteIdent(MIGRATION_MARKER_TABLE)} (
+       table_name TEXT PRIMARY KEY,
+       migrated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+     )`,
+  );
+}
+
+async function migrationMarkerExists(
+  exec: SqlExecutor,
+  table: MigratedReminderTable,
+): Promise<boolean> {
+  const rows = await exec(
+    `SELECT EXISTS (
+       SELECT 1 FROM ${TARGET_SCHEMA}.${quoteIdent(MIGRATION_MARKER_TABLE)}
+       WHERE table_name = '${table}'
+     ) AS done`,
+  );
+  return rows[0]?.done === true || rows[0]?.done === "true";
+}
+
+async function writeMigrationMarker(
+  exec: SqlExecutor,
+  table: MigratedReminderTable,
+): Promise<void> {
+  await exec(
+    `INSERT INTO ${TARGET_SCHEMA}.${quoteIdent(MIGRATION_MARKER_TABLE)} (table_name)
+     VALUES ('${table}')
+     ON CONFLICT (table_name) DO NOTHING`,
+  );
+}
+
 export async function migrateReminderTable(
   exec: SqlExecutor,
   table: MigratedReminderTable,
 ): Promise<TableMigrationResult> {
+  if (await migrationMarkerExists(exec, table)) {
+    return { table, outcome: "already-migrated" };
+  }
   if (!(await sourceTableExists(exec, table))) {
+    await writeMigrationMarker(exec, table);
     return { table, outcome: "source-missing" };
   }
   if (!(await targetTableIsEmpty(exec, table))) {
+    await writeMigrationMarker(exec, table);
     return { table, outcome: "target-non-empty" };
   }
 
@@ -89,6 +138,7 @@ export async function migrateReminderTable(
        )
        ON CONFLICT (${quoteIdent("id")}) DO NOTHING`,
   );
+  await writeMigrationMarker(exec, table);
   return { table, outcome: "copied" };
 }
 
@@ -96,6 +146,7 @@ export async function migrateReminderTables(
   exec: SqlExecutor,
 ): Promise<TableMigrationResult[]> {
   await exec(`CREATE SCHEMA IF NOT EXISTS ${TARGET_SCHEMA}`);
+  await ensureMigrationMarkerTable(exec);
   const results: TableMigrationResult[] = [];
   for (const table of MIGRATED_REMINDER_TABLES) {
     results.push(await migrateReminderTable(exec, table));


### PR DESCRIPTION
## Problem — watchtower's "routine-read phantom rows" residual, root-caused

The `app_lifeops → app_reminders` copy migration runs on **every boot**, guarded only by "skip if target non-empty." The moment an owner clears their routines/reminders (target empty again), the next restart **re-imports every stale legacy row** — long-deleted reminders resurrected. The box restarts frequently (resyncs), so this fired live today: routine reads returning phantom rows.

## Fix

A durable `app_reminders.reminders_migration_state` marker table records completion per table. Every terminal outcome (`copied` / `source-missing` / `target-non-empty`) writes the marker; a marked table short-circuits to `already-migrated` before any source read. The copy is now at-most-once per database. Source stays untouched; concurrent-start idempotence (today's #aefb420) preserved.

## Evidence

| Check | Result |
|---|---|
| suite incl. 3 new regression tests (marker short-circuits with empty target + populated source — the exact phantom shape; marker written on all terminal outcomes; marker table created before per-table work) | 8/8 ✅ |
| plugin typecheck + Biome | ✅ |

Live re-prove: after next box resync, clear all routines → restart → read must stay empty (the residual's exact repro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)