### PR TITLE
fix(ui): keep routing persistence out of browser bundles

### DIFF
--- a/packages/shared/src/local-inference/index.ts
+++ b/packages/shared/src/local-inference/index.ts
@@ -94,12 +94,12 @@ export type {
 export type {
   RoutingPolicy,
   RoutingPreferences,
-} from "./routing-preferences.js";
+} from "./routing-policy.js";
 export {
   DEFAULT_ROUTING_POLICY,
   isRoutingPolicy,
   ROUTING_POLICIES,
-} from "./routing-preferences.js";
+} from "./routing-policy.js";
 export {
   classifyCatalogModelRuntimeClass,
   classifyInstalledModelRuntimeClass,

--- a/packages/shared/src/local-inference/routing-policy.ts
+++ b/packages/shared/src/local-inference/routing-policy.ts
@@ -1,0 +1,42 @@
+/**
+ * Browser-safe routing policy contracts shared by UI and runtime consumers.
+ */
+
+import type { AgentModelSlot } from "./types.js";
+
+export type RoutingPolicy =
+  | "manual"
+  | "auto"
+  | "local-only"
+  | "cloud-only"
+  | "cheapest"
+  | "fastest"
+  | "prefer-local"
+  | "round-robin";
+
+export const ROUTING_POLICIES: readonly RoutingPolicy[] = [
+  "manual",
+  "auto",
+  "local-only",
+  "cloud-only",
+  "cheapest",
+  "fastest",
+  "prefer-local",
+  "round-robin",
+] as const;
+
+export function isRoutingPolicy(value: unknown): value is RoutingPolicy {
+  return (
+    typeof value === "string" &&
+    (ROUTING_POLICIES as readonly string[]).includes(value)
+  );
+}
+
+export const DEFAULT_ROUTING_POLICY: RoutingPolicy = "prefer-local";
+
+export interface RoutingPreferences {
+  /** Explicit provider override per agent slot. */
+  preferredProvider: Partial<Record<AgentModelSlot, string>>;
+  /** Per-slot dispatch policy; absent slots use prefer-local. */
+  policy: Partial<Record<AgentModelSlot, RoutingPolicy>>;
+}

--- a/packages/shared/src/local-inference/routing-preferences.ts
+++ b/packages/shared/src/local-inference/routing-preferences.ts
@@ -14,64 +14,23 @@ import { hostname } from "node:os";
 import path from "node:path";
 import { localInferenceRoot } from "./paths.js";
 import {
+  isRoutingPolicy,
+  type RoutingPolicy,
+  type RoutingPreferences,
+} from "./routing-policy.js";
+import {
   AGENT_MODEL_SLOTS,
   type AgentModelSlot,
   TEXT_GENERATION_SLOTS,
 } from "./types.js";
 
-export type RoutingPolicy =
-  | "manual"
-  | "auto"
-  | "local-only"
-  | "cloud-only"
-  | "cheapest"
-  | "fastest"
-  | "prefer-local"
-  | "round-robin";
-
-/**
- * The full set of selectable policies, in display order. Kept as a runtime
- * value (not just a type) so route-layer validation and the settings UI share
- * one source of truth for "which policies are accepted".
- *
- * `local-only` / `cloud-only` are the canonical per-slot replacements for the
- * global `ELIZA_LOCAL_ONLY` env hack: `local-only` is a hard guarantee (never
- * falls through to cloud), `cloud-only` never dispatches on-device.
- */
-export const ROUTING_POLICIES: readonly RoutingPolicy[] = [
-  "manual",
-  "auto",
-  "local-only",
-  "cloud-only",
-  "cheapest",
-  "fastest",
-  "prefer-local",
-  "round-robin",
-] as const;
-
-export function isRoutingPolicy(value: unknown): value is RoutingPolicy {
-  return (
-    typeof value === "string" &&
-    (ROUTING_POLICIES as readonly string[]).includes(value)
-  );
-}
-
-export const DEFAULT_ROUTING_POLICY: RoutingPolicy = "prefer-local";
-
-export interface RoutingPreferences {
-  /**
-   * Explicit provider override per agent slot. Empty record = no overrides,
-   * runtime picks the highest-priority registered handler.
-   */
-  preferredProvider: Partial<Record<AgentModelSlot, string>>;
-  /**
-   * Per-slot policy. "manual" honours `preferredProvider` verbatim;
-   * everything else lets the router-handler compute a winner from the
-   * policy rule set. Absent = "prefer-local" so local models and
-   * subscriptions are tried before direct paid APIs and managed cloud.
-   */
-  policy: Partial<Record<AgentModelSlot, RoutingPolicy>>;
-}
+export {
+  DEFAULT_ROUTING_POLICY,
+  isRoutingPolicy,
+  ROUTING_POLICIES,
+  type RoutingPolicy,
+  type RoutingPreferences,
+} from "./routing-policy.js";
 
 interface RoutingFile {
   version: 1;

--- a/packages/ui/src/services/local-inference/routing-preferences.ts
+++ b/packages/ui/src/services/local-inference/routing-preferences.ts
@@ -1,13 +1,9 @@
 /**
- * Re-exports the inference routing-policy preferences (local vs cloud provider
- * selection) from the local-inference shared surface.
+ * Re-exports the browser-safe inference routing preference types used by the
+ * UI API client. Persistence remains server-owned because the shared runtime
+ * module imports Node filesystem, crypto, path, and host APIs.
  */
-export {
-  DEFAULT_ROUTING_POLICY,
-  type RoutingPolicy,
-  type RoutingPreferences,
-  readRoutingPreferences,
-  setPolicy,
-  setPreferredProvider,
-  writeRoutingPreferences,
+export type {
+  RoutingPolicy,
+  RoutingPreferences,
 } from "@elizaos/shared/local-inference/routing-preferences";

--- a/packages/ui/src/services/local-inference/routing-preferences.ts
+++ b/packages/ui/src/services/local-inference/routing-preferences.ts
@@ -6,4 +6,4 @@
 export type {
   RoutingPolicy,
   RoutingPreferences,
-} from "@elizaos/shared/local-inference/routing-preferences";
+} from "@elizaos/shared/local-inference";


### PR DESCRIPTION
## Summary

Splits the routing policy contract from its Node-only persistence implementation and makes the UI seam type-only. The previous local-inference barrel re-exported runtime values from routing-preferences.ts, pulling filesystem, crypto, path, and hostname into browser fixtures and breaking UI e2e bundling on node:os.

Public compatibility is preserved: the existing routing-preferences subpath still re-exports the policy types/constants while server consumers keep the persistence functions. Browser consumers reach the policy contract through the runtime-agnostic local-inference barrel.

## Verification

- bun run --cwd packages/shared typecheck — pass
- bun test packages/shared/src/local-inference/routing-preferences.test.ts — 9 pass
- bun run --cwd packages/ui typecheck — pass
- Biome on all four touched files — pass
- bun run --cwd packages/ui test:credentials-e2e — ALL GREEN; real fixture bundle and 14 desktop/mobile captures complete

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Attribution status: self-reported
— [lalalune-pr-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@develop"} -->