### PR TITLE
release: synchronize post-release develop fixes

### DIFF
--- a/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
@@ -233,7 +233,7 @@ function notificationsPayload() {
   };
 }
 
-// A full-capability host (real API base + an Electrobun window id) so the
+// A full-capability host (real API base + an Electrobun bridge) so the
 // onboarding offers — and ENABLES — the Local runtime card. `__electrobunWindowId`
 // makes isElectrobunRuntime()→isDesktopPlatform() true, which is what
 // canSelectLocalRuntime() keys off (without it the Local card is rendered but
@@ -255,6 +255,15 @@ export async function injectFullCapabilityHost(page: Page): Promise<void> {
     win.__ELIZAOS_APP_BOOT_CONFIG__ = { apiBase: origin };
     win.__ELIZAOS_API_BASE__ = origin;
     win.__electrobunWindowId = 1;
+    win.__ELIZA_ELECTROBUN_RPC__ = {
+      request: {
+        desktopGetVersion: async () => ({ runtime: "playwright-smoke" }),
+        desktopRegisterShortcut: async () => ({ success: true }),
+        desktopSetTrayMenu: async () => undefined,
+      },
+      onMessage: () => {},
+      offMessage: () => {},
+    };
     // Production remains cloud-only by default (#13377). These helpers also run
     // against packaged builds where Vite's development default is absent, so
     // opt in explicitly; the production default is covered by
@@ -552,8 +561,7 @@ export const CLOUD_AGENT_ID = "ui-smoke-cloud-agent-1";
 // origins are trusted cloud API bases), keeping the real agent surface live.
 export const PERSONAL_ELIZA_ID =
   "personal:11111111-1111-5111-8111-111111111111";
-export const PERSONAL_ACTIVE_AGENT_ID =
-  "22222222-2222-4222-8222-222222222222";
+export const PERSONAL_ACTIVE_AGENT_ID = "22222222-2222-4222-8222-222222222222";
 export const CLOUD_AGENT_NAME = "Smoke Cloud Agent";
 
 /** Inject the cloud session token before React boots (getCloudAuthToken reads

--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -104,6 +104,100 @@ describe("action catalogue and retrieval", () => {
 		);
 	});
 
+	it("resolves wildcard candidate hints against child action names (#20467)", () => {
+		// normalizeActionName strips "*" before the wildcard branch ran, and the
+		// escape/replace pair searched for a "\*" that was never produced, so
+		// "GMAIL_*" compiled to ^GMAIL$ and matched nothing it was meant to.
+		const [parent, ...virtuals] = promoteSubactionsToActions({
+			name: "GMAIL",
+			description: "Send mail, and create or update drafts.",
+			parameters: [
+				{
+					name: "action",
+					description: "Gmail operation.",
+					required: true,
+					schema: {
+						type: "string",
+						enum: ["send", "create_draft"],
+					},
+				},
+			],
+			validate: async () => true,
+			handler: async () => ({ success: true }),
+		});
+		const catalog = buildActionCatalog([
+			parent,
+			...virtuals,
+			{ name: "CALENDAR", description: "Manage calendar events." },
+		]);
+
+		for (const hint of ["GMAIL_*", "gmail-*", "GMAIL_*_DRAFT", "*_DRAFT"]) {
+			const response = retrieveActions({
+				catalog,
+				candidateActions: [hint],
+			});
+			expect(response.results[0]).toMatchObject({
+				name: "GMAIL",
+				matchedBy: expect.arrayContaining(["regex"]),
+			});
+			expect(
+				response.results.some(
+					(entry) =>
+						entry.name === "CALENDAR" && entry.matchedBy.includes("regex"),
+				),
+			).toBe(false);
+		}
+	});
+
+	it("keeps a separator-less trailing wildcard anchored to its own name (#20467 review)", () => {
+		// "GMAIL_SEND*" means "that action and anything under it": it must match
+		// the exact anchored name (zero wildcard characters) AND its extensions,
+		// and the separator-less "GMAIL*" spelling is the one that may reach a
+		// GMAILSYNC sibling — the user wrote no separator to forbid it.
+		const catalog = buildActionCatalog([
+			{ name: "GMAIL_SEND", description: "Send a mail message." },
+			{ name: "GMAIL_SEND_LATER", description: "Schedule a mail message." },
+			{ name: "GMAILSYNC", description: "Synchronize the mail archive." },
+			{ name: "CALENDAR", description: "Manage calendar events." },
+		]);
+		const creditedBy = (hint: string) =>
+			retrieveActions({ catalog, candidateActions: [hint] })
+				.results.filter((entry) => entry.matchedBy.includes("regex"))
+				.map((entry) => entry.name)
+				.sort();
+
+		expect(creditedBy("GMAIL_SEND*")).toEqual([
+			"GMAIL_SEND",
+			"GMAIL_SEND_LATER",
+		]);
+		expect(creditedBy("GMAIL*")).toEqual([
+			"GMAILSYNC",
+			"GMAIL_SEND",
+			"GMAIL_SEND_LATER",
+		]);
+		expect(creditedBy("*SYNC")).toEqual(["GMAILSYNC"]);
+	});
+
+	it("keeps a wildcard's adjacent underscore from swallowing sibling namespaces (#20467)", () => {
+		// The underscore ahead of the wildcard is load-bearing in the compiled
+		// pattern: "GMAIL_*" must translate to ^GMAIL_.*$, not ^GMAIL.*$ — a
+		// greedy translation would wrongly claim GMAILSYNC and its children.
+		const catalog = buildActionCatalog([
+			{ name: "GMAILSYNC", description: "Synchronize the mail archive." },
+			{ name: "CALENDAR", description: "Manage calendar events." },
+		]);
+		const response = retrieveActions({
+			catalog,
+			candidateActions: ["GMAIL_*"],
+		});
+		expect(
+			response.results.some(
+				(entry) =>
+					entry.name === "GMAILSYNC" && entry.matchedBy.includes("regex"),
+			),
+		).toBe(false);
+	});
+
 	it("groups promoted virtual subactions under their umbrella parent", () => {
 		const [parent, ...virtuals] = promoteSubactionsToActions({
 			name: "PAYMENT",

--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -179,23 +179,40 @@ describe("action catalogue and retrieval", () => {
 	});
 
 	it("keeps a wildcard's adjacent underscore from swallowing sibling namespaces (#20467)", () => {
-		// The underscore ahead of the wildcard is load-bearing in the compiled
-		// pattern: "GMAIL_*" must translate to ^GMAIL_.*$, not ^GMAIL.*$ — a
-		// greedy translation would wrongly claim GMAILSYNC and its children.
+		// A normalized separator ahead of the wildcard is load-bearing in the
+		// compiled pattern: neither "GMAIL_*" nor "GMAIL *" may translate to
+		// ^GMAIL.*$ and wrongly claim GMAILSYNC or its children.
 		const catalog = buildActionCatalog([
+			{ name: "GMAIL_SEND", description: "Send a mail message." },
 			{ name: "GMAILSYNC", description: "Synchronize the mail archive." },
 			{ name: "CALENDAR", description: "Manage calendar events." },
 		]);
-		const response = retrieveActions({
-			catalog,
-			candidateActions: ["GMAIL_*"],
-		});
-		expect(
-			response.results.some(
-				(entry) =>
-					entry.name === "GMAILSYNC" && entry.matchedBy.includes("regex"),
-			),
-		).toBe(false);
+		const creditedBy = (hint: string) =>
+			retrieveActions({ catalog, candidateActions: [hint] })
+				.results.filter((entry) => entry.matchedBy.includes("regex"))
+				.map((entry) => entry.name);
+
+		expect(creditedBy("GMAIL_*")).toEqual(["GMAIL_SEND"]);
+		expect(creditedBy("  GMAIL *  ")).toEqual(["GMAIL_SEND"]);
+	});
+
+	it("preserves a separator-only literal between wildcards (#20467 review)", () => {
+		const catalog = buildActionCatalog([
+			{
+				name: "GMAIL_CREATE_DRAFT",
+				description: "Create a Gmail draft.",
+			},
+			{
+				name: "GMAILCREATEDRAFT",
+				description: "A sibling without normalized separators.",
+			},
+		]);
+		const creditedBy = (hint: string) =>
+			retrieveActions({ catalog, candidateActions: [hint] })
+				.results.filter((entry) => entry.matchedBy.includes("regex"))
+				.map((entry) => entry.name);
+
+		expect(creditedBy("GMAIL* *DRAFT")).toEqual(["GMAIL_CREATE_DRAFT"]);
 	});
 
 	it("groups promoted virtual subactions under their umbrella parent", () => {

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -958,13 +958,14 @@ function buildCandidatePatterns(candidateActions: string[]): Array<{
 		}
 
 		if (candidateAction.includes("*")) {
-			patterns.push({
-				regex: new RegExp(
-					`^${escapeRegex(normalized).replace(/\\\*/g, ".*")}$`,
-				),
-				namespace: normalized.split("_")[0],
-				score: 0.8,
-			});
+			const wildcardRegex = wildcardCandidateRegex(candidateAction);
+			if (wildcardRegex) {
+				patterns.push({
+					regex: wildcardRegex,
+					namespace: normalized.split("_")[0],
+					score: 0.8,
+				});
+			}
 			continue;
 		}
 
@@ -1332,6 +1333,37 @@ function normalizeTextList(
 
 function escapeRegex(value: string): string {
 	return value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+}
+
+/**
+ * Translates a wildcard candidate hint ("GMAIL_*", "GMAIL_SEND*", "*_DRAFT")
+ * into a matcher over catalog-normalized action names. normalizeActionName
+ * strips the "*" itself, so each literal segment between wildcards is
+ * normalized with the real normalizer and only the star-adjacent separators
+ * the hint actually wrote are re-attached afterward: "GMAIL_*" compiles to
+ * ^GMAIL_.*$ (the children, not bare GMAIL or a GMAILSYNC sibling), while the
+ * separator-less "GMAIL_SEND*" compiles to ^GMAIL_SEND.*$ and keeps matching
+ * the exact name the glob is anchored to (#20467).
+ */
+function wildcardCandidateRegex(candidateAction: string): RegExp | null {
+	const rawSegments = String(candidateAction).replace(/\*+/g, "*").split("*");
+	const lastIndex = rawSegments.length - 1;
+	const parts = rawSegments.map((rawSegment, index) => {
+		const trimmed = rawSegment.trim();
+		const normalized = normalizeActionName(rawSegment);
+		if (!normalized) {
+			// A separator-only segment between wildcards ("A*_*B") still
+			// constrains the match; whitespace-only or absent segments do not.
+			return index > 0 && index < lastIndex && trimmed.length > 0 ? "_" : "";
+		}
+		const lead = index > 0 && /^[^A-Za-z0-9]/.test(trimmed) ? "_" : "";
+		const trail = index < lastIndex && /[^A-Za-z0-9]$/.test(trimmed) ? "_" : "";
+		return `${lead}${normalized}${trail}`;
+	});
+	if (parts.every((part) => part === "")) {
+		return null;
+	}
+	return new RegExp(`^${parts.map((part) => escapeRegex(part)).join(".*")}$`);
 }
 
 function clampScore(value: number): number {

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -1346,18 +1346,22 @@ function escapeRegex(value: string): string {
  * the exact name the glob is anchored to (#20467).
  */
 function wildcardCandidateRegex(candidateAction: string): RegExp | null {
-	const rawSegments = String(candidateAction).replace(/\*+/g, "*").split("*");
+	const rawSegments = String(candidateAction)
+		.trim()
+		.replace(/\*+/g, "*")
+		.split("*");
 	const lastIndex = rawSegments.length - 1;
 	const parts = rawSegments.map((rawSegment, index) => {
-		const trimmed = rawSegment.trim();
 		const normalized = normalizeActionName(rawSegment);
 		if (!normalized) {
 			// A separator-only segment between wildcards ("A*_*B") still
-			// constrains the match; whitespace-only or absent segments do not.
-			return index > 0 && index < lastIndex && trimmed.length > 0 ? "_" : "";
+			// constrains the match. Overall whitespace was trimmed before splitting,
+			// so a whitespace-only middle segment is also an intentional separator.
+			return index > 0 && index < lastIndex && rawSegment.length > 0 ? "_" : "";
 		}
-		const lead = index > 0 && /^[^A-Za-z0-9]/.test(trimmed) ? "_" : "";
-		const trail = index < lastIndex && /[^A-Za-z0-9]$/.test(trimmed) ? "_" : "";
+		const lead = index > 0 && /^[^A-Za-z0-9]/.test(rawSegment) ? "_" : "";
+		const trail =
+			index < lastIndex && /[^A-Za-z0-9]$/.test(rawSegment) ? "_" : "";
 		return `${lead}${normalized}${trail}`;
 	});
 	if (parts.every((part) => part === "")) {

--- a/packages/scripts/__tests__/vitest-core-edge-aliases.test.ts
+++ b/packages/scripts/__tests__/vitest-core-edge-aliases.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Verifies package test configs resolve the scheduling runtime's core edge
+ * import to a real source entry before their broad bare-core aliases.
+ */
+
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import codingToolsConfig from "../../../plugins/plugin-coding-tools/vitest.config";
+import defaultConfig from "../vitest/default.config";
+import { repoRoot } from "../vitest/repo-root";
+
+type Alias = { find: string | RegExp; replacement: string };
+
+function resolveAlias(config: unknown, specifier: string): string {
+  const aliases = (config as { resolve?: { alias?: Alias[] } }).resolve?.alias;
+  if (!Array.isArray(aliases)) {
+    throw new TypeError("Vitest aliases must be an ordered array");
+  }
+  const alias = aliases.find(({ find }) =>
+    typeof find === "string"
+      ? specifier === find || specifier.startsWith(`${find}/`)
+      : find.test(specifier),
+  );
+  if (!alias) throw new TypeError(`No alias found for ${specifier}`);
+  return specifier.replace(alias.find, alias.replacement);
+}
+
+describe("@elizaos/core/edge package-test aliases", () => {
+  test.each([
+    ["shared package config", defaultConfig],
+    ["coding-tools config", codingToolsConfig],
+  ])("%s targets the edge source entry", (_label, config) => {
+    expect(resolveAlias(config, "@elizaos/core/edge")).toBe(
+      path.join(repoRoot, "packages/core/src/index.edge.ts"),
+    );
+  });
+
+  test("coding-tools keeps core's cloud-routing re-export on source", () => {
+    expect(resolveAlias(codingToolsConfig, "@elizaos/cloud-routing")).toBe(
+      path.join(repoRoot, "packages/cloud/routing/src/index.ts"),
+    );
+  });
+
+  test("shared package config keeps the agent vault dependency on source", () => {
+    expect(resolveAlias(defaultConfig, "@elizaos/vault")).toBe(
+      path.join(repoRoot, "packages/vault/src/index.ts"),
+    );
+  });
+
+  test("shared package config resolves the agent's app-manager plugin", () => {
+    expect(resolveAlias(defaultConfig, "@elizaos/plugin-app-manager")).toBe(
+      path.join(repoRoot, "plugins/plugin-app-manager/src/index.ts"),
+    );
+  });
+});

--- a/packages/scripts/vitest/default.config.ts
+++ b/packages/scripts/vitest/default.config.ts
@@ -172,6 +172,7 @@ const workspacePluginSourceAliases = getWorkspacePluginAliases(repoRoot, [
   "plugin-agent-skills",
   "plugin-anthropic",
   "plugin-app-control",
+  "plugin-app-manager",
   "plugin-browser",
   "plugin-capacitor-bridge",
   "plugin-coding-tools",
@@ -354,6 +355,10 @@ const vitestResolveAlias: ModuleAlias[] = [
     replacement: path.join(cloudSdkSourceRoot, "index.ts"),
   },
   {
+    find: /^@elizaos\/vault$/,
+    replacement: path.join(elizaWorkspaceRoot, "packages/vault/src/index.ts"),
+  },
+  {
     // App-core tests mock this plugin, but Vitest still has to resolve the specifier.
     find: "@elizaos/capacitor-agent",
     replacement: appCoreModuleFallbackPath,
@@ -404,6 +409,18 @@ const vitestResolveAlias: ModuleAlias[] = [
           replacement: path.join(
             path.dirname(elizaCoreEntry),
             "testing/index.ts",
+          ),
+        },
+        {
+          // Scheduling's source runner imports the edge-safe serializer. Keep
+          // this exports-map subpath ahead of the prefix-matching bare alias so
+          // clean package tests never resolve `index.node.ts/edge` (ENOTDIR).
+          find: /^@elizaos\/core\/edge$/,
+          replacement: path.join(
+            path.dirname(elizaCoreEntry),
+            elizaCoreEntry.endsWith(".ts")
+              ? "index.edge.ts"
+              : "edge/index.edge.js",
           ),
         },
         {

--- a/packages/ui/src/components/accounts/ConsumerKeyPanel.test.tsx
+++ b/packages/ui/src/components/accounts/ConsumerKeyPanel.test.tsx
@@ -118,17 +118,15 @@ describe("list states", () => {
 
   it("renders label, prefix, quota, status, and timestamps for each key", async () => {
     const api = makeApi({
-      listConsumerKeys: vi
-        .fn()
-        .mockResolvedValue([
-          key(),
-          key({
-            id: "ck_2",
-            label: "proxy-b",
-            enabled: false,
-            dailyTokenQuota: null,
-          }),
-        ]),
+      listConsumerKeys: vi.fn().mockResolvedValue([
+        key(),
+        key({
+          id: "ck_2",
+          label: "proxy-b",
+          enabled: false,
+          dailyTokenQuota: null,
+        }),
+      ]),
     });
     render(<ConsumerKeyPanelBody api={api} />);
     await waitFor(() => expect(screen.getByText("proxy-a")).toBeTruthy());

--- a/plugins/plugin-coding-tools/src/lib/terminal-capabilities.test.ts
+++ b/plugins/plugin-coding-tools/src/lib/terminal-capabilities.test.ts
@@ -2,14 +2,47 @@
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { captureHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import {
   detectTerminalSupport,
   missingToolForCommand,
   resolveExecutable,
   resolveHostShell,
 } from "./terminal-capabilities.js";
+
+vi.mock("@elizaos/shared/host-execution-env", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@elizaos/shared/host-execution-env")>();
+  const { accessSync, constants } = await import("node:fs");
+  const pathApi = await import("node:path");
+  return {
+    ...actual,
+    resolveHostExecutable: (nameOrPath: string): string | undefined => {
+      const candidates = pathApi.isAbsolute(nameOrPath)
+        ? [nameOrPath]
+        : (process.env.PATH ?? "")
+            .split(pathApi.delimiter)
+            .filter(Boolean)
+            .map((entry) => pathApi.join(entry, nameOrPath));
+      return candidates.find((candidate) => {
+        try {
+          accessSync(candidate, constants.X_OK);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+    },
+  };
+});
 
 const ENV_KEYS = [
   "ELIZA_PLATFORM",
@@ -31,7 +64,6 @@ beforeAll(() => {
   savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
   tempDir = mkdtempSync(path.join(tmpdir(), "ct-cap-"));
   process.env.PATH = tempDir;
-  captureHostExecutionBaseline();
 });
 
 beforeEach(() => {

--- a/plugins/plugin-coding-tools/src/shell/__tests__/terminal-capabilities.test.ts
+++ b/plugins/plugin-coding-tools/src/shell/__tests__/terminal-capabilities.test.ts
@@ -6,14 +6,47 @@
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { captureHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 import {
   detectTerminalSupport,
   missingTerminalToolForCommand,
   resolveExecutable,
   resolveTerminalShell,
 } from "../utils/terminalCapabilities";
+
+vi.mock("@elizaos/shared/host-execution-env", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@elizaos/shared/host-execution-env")>();
+  const { accessSync, constants } = await import("node:fs");
+  const pathApi = await import("node:path");
+  return {
+    ...actual,
+    resolveHostExecutable: (nameOrPath: string): string | undefined => {
+      const candidates = pathApi.isAbsolute(nameOrPath)
+        ? [nameOrPath]
+        : (process.env.PATH ?? "")
+            .split(pathApi.delimiter)
+            .filter(Boolean)
+            .map((entry) => pathApi.join(entry, nameOrPath));
+      return candidates.find((candidate) => {
+        try {
+          accessSync(candidate, constants.X_OK);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+    },
+  };
+});
 
 const ENV_KEYS = [
   "ELIZA_PLATFORM",
@@ -35,7 +68,6 @@ beforeAll(() => {
   savedEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
   tempDir = mkdtempSync(path.join(tmpdir(), "shell-cap-"));
   process.env.PATH = tempDir;
-  captureHostExecutionBaseline();
 });
 
 beforeEach(() => {

--- a/plugins/plugin-coding-tools/vitest.config.ts
+++ b/plugins/plugin-coding-tools/vitest.config.ts
@@ -10,6 +10,14 @@ export default defineConfig({
   resolve: {
     alias: [
       {
+        find: /^@elizaos\/core\/edge$/,
+        replacement: path.join(repoRoot, "packages/core/src/index.edge.ts"),
+      },
+      {
+        find: /^@elizaos\/cloud-routing$/,
+        replacement: path.join(repoRoot, "packages/cloud/routing/src/index.ts"),
+      },
+      {
         find: /^@elizaos\/core$/,
         replacement: path.join(repoRoot, "packages/core/src/index.node.ts"),
       },
@@ -43,6 +51,11 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    setupFiles: ["./vitest.setup.ts"],
+    // Capability tests intentionally replace process-wide PATH values. Keep
+    // files serial so those fixtures cannot race shell-action execution in a
+    // sibling file inside the same Vitest worker process.
+    fileParallelism: false,
     include: ["__tests__/**/*.test.ts", "src/**/*.test.ts"],
     // *.real.test.ts files run only in the dedicated real/live lane
     // (packages/scripts/vitest/real.config.ts), never in the default suite.

--- a/plugins/plugin-coding-tools/vitest.setup.ts
+++ b/plugins/plugin-coding-tools/vitest.setup.ts
@@ -1,0 +1,5 @@
+/** Captures host executable authority before any test fixture mutates PATH. */
+
+import { captureHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
+
+captureHostExecutionBaseline();

--- a/plugins/plugin-reminders/src/services/migration.test.ts
+++ b/plugins/plugin-reminders/src/services/migration.test.ts
@@ -66,7 +66,8 @@ describe("RemindersMigration", () => {
       if (sql.includes("SELECT NOT EXISTS")) return [{ empty: true }];
       if (
         sql.includes("INSERT INTO") &&
-        !sql.includes('ON CONFLICT ("id") DO NOTHING')
+        !sql.includes('ON CONFLICT ("id") DO NOTHING') &&
+        !sql.includes("ON CONFLICT (table_name) DO NOTHING")
       ) {
         throw new Error("duplicate key value violates unique constraint");
       }
@@ -95,5 +96,69 @@ describe("RemindersMigration", () => {
     expect(
       log.some((s) => /CREATE SCHEMA IF NOT EXISTS app_reminders/.test(s)),
     ).toBe(true);
+  });
+});
+
+describe("one-shot migration marker (2026-08-16 phantom routine rows)", () => {
+  it("skips the copy entirely once the marker exists — even with an empty target and a populated source", async () => {
+    const log: string[] = [];
+    const exec = fakeExec(
+      [
+        [/reminders_migration_state[\s\S]*table_name = /, [{ done: true }]],
+        [/to_regclass/, [{ present: true }]],
+        [/SELECT NOT EXISTS \(SELECT 1 FROM/, [{ empty: true }]],
+      ],
+      log,
+    );
+    const r = await migrateReminderTable(exec, "life_reminder_plans");
+    expect(r.outcome).toBe("already-migrated");
+    // The stale-source re-import that resurrected deleted routines must not run.
+    expect(log.some((s) => /INSERT INTO .*life_reminder_plans/s.test(s))).toBe(
+      false,
+    );
+  });
+
+  it("writes the marker on every terminal outcome so restarts never re-copy", async () => {
+    for (const [responses, outcome] of [
+      [[[/to_regclass/, [{ present: false }]]], "source-missing"],
+      [
+        [
+          [/to_regclass/, [{ present: true }]],
+          [/SELECT NOT EXISTS \(SELECT 1 FROM/, [{ empty: false }]],
+        ],
+        "target-non-empty",
+      ],
+      [
+        [
+          [/to_regclass/, [{ present: true }]],
+          [/SELECT NOT EXISTS \(SELECT 1 FROM/, [{ empty: true }]],
+        ],
+        "copied",
+      ],
+    ] as Array<[Array<[RegExp, Array<Record<string, unknown>>]>, string]>) {
+      const log: string[] = [];
+      const exec = fakeExec(responses, log);
+      const r = await migrateReminderTable(exec, "life_reminder_plans");
+      expect(r.outcome).toBe(outcome);
+      expect(
+        log.some((s) =>
+          /INSERT INTO .*reminders_migration_state[\s\S]*ON CONFLICT \(table_name\) DO NOTHING/s.test(
+            s,
+          ),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("migrateReminderTables creates the marker table before any per-table work", async () => {
+    const log: string[] = [];
+    const exec = fakeExec([[/to_regclass/, [{ present: false }]]], log);
+    await migrateReminderTables(exec);
+    const markerCreate = log.findIndex((s) =>
+      /CREATE TABLE IF NOT EXISTS .*reminders_migration_state/s.test(s),
+    );
+    const firstRegclass = log.findIndex((s) => s.includes("to_regclass"));
+    expect(markerCreate).toBeGreaterThanOrEqual(0);
+    expect(markerCreate).toBeLessThan(firstRegclass);
   });
 });

--- a/plugins/plugin-reminders/src/services/migration.ts
+++ b/plugins/plugin-reminders/src/services/migration.ts
@@ -10,13 +10,18 @@
  * once, idempotently, and WITHOUT ever touching the source.
  *
  * Guards (per table, independently):
- *   1. Skip if the source table does not exist (fresh install / already dropped).
- *   2. Skip if the target table is non-empty (migration already ran, or the
- *      plugin owns live data).
- *   3. Otherwise copy every source row that is not already present in the target
+ *   1. Skip if a durable completion marker for the table exists (the copy ran
+ *      once on this database — live 2026-08-16 phantom-rows incident: without
+ *      the marker, "skip if target non-empty" re-imported every stale
+ *      app_lifeops row on the first restart after an owner cleared their
+ *      routines, resurrecting long-deleted reminders).
+ *   2. Skip if the source table does not exist (fresh install / already dropped).
+ *   3. Skip if the target table is non-empty (plugin already owns live data).
+ *   4. Otherwise copy every source row that is not already present in the target
  *      (a doubly-safe NOT EXISTS guard on the primary key).
  *
- * The source table is NEVER dropped or altered.
+ * Every terminal outcome writes the marker, so the copy happens at most once
+ * per database. The source table is NEVER dropped or altered.
  */
 
 import { type IAgentRuntime, logger, Service } from "@elizaos/core";
@@ -41,7 +46,11 @@ export type SqlExecutor = (
 
 export interface TableMigrationResult {
   table: MigratedReminderTable;
-  outcome: "copied" | "source-missing" | "target-non-empty";
+  outcome:
+    | "copied"
+    | "source-missing"
+    | "target-non-empty"
+    | "already-migrated";
 }
 
 function quoteIdent(name: string): string {
@@ -68,14 +77,54 @@ async function targetTableIsEmpty(
   return rows[0]?.empty === true || rows[0]?.empty === "true";
 }
 
+const MIGRATION_MARKER_TABLE = "reminders_migration_state";
+
+async function ensureMigrationMarkerTable(exec: SqlExecutor): Promise<void> {
+  await exec(
+    `CREATE TABLE IF NOT EXISTS ${TARGET_SCHEMA}.${quoteIdent(MIGRATION_MARKER_TABLE)} (
+       table_name TEXT PRIMARY KEY,
+       migrated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+     )`,
+  );
+}
+
+async function migrationMarkerExists(
+  exec: SqlExecutor,
+  table: MigratedReminderTable,
+): Promise<boolean> {
+  const rows = await exec(
+    `SELECT EXISTS (
+       SELECT 1 FROM ${TARGET_SCHEMA}.${quoteIdent(MIGRATION_MARKER_TABLE)}
+       WHERE table_name = '${table}'
+     ) AS done`,
+  );
+  return rows[0]?.done === true || rows[0]?.done === "true";
+}
+
+async function writeMigrationMarker(
+  exec: SqlExecutor,
+  table: MigratedReminderTable,
+): Promise<void> {
+  await exec(
+    `INSERT INTO ${TARGET_SCHEMA}.${quoteIdent(MIGRATION_MARKER_TABLE)} (table_name)
+     VALUES ('${table}')
+     ON CONFLICT (table_name) DO NOTHING`,
+  );
+}
+
 export async function migrateReminderTable(
   exec: SqlExecutor,
   table: MigratedReminderTable,
 ): Promise<TableMigrationResult> {
+  if (await migrationMarkerExists(exec, table)) {
+    return { table, outcome: "already-migrated" };
+  }
   if (!(await sourceTableExists(exec, table))) {
+    await writeMigrationMarker(exec, table);
     return { table, outcome: "source-missing" };
   }
   if (!(await targetTableIsEmpty(exec, table))) {
+    await writeMigrationMarker(exec, table);
     return { table, outcome: "target-non-empty" };
   }
 
@@ -89,6 +138,7 @@ export async function migrateReminderTable(
        )
        ON CONFLICT (${quoteIdent("id")}) DO NOTHING`,
   );
+  await writeMigrationMarker(exec, table);
   return { table, outcome: "copied" };
 }
 
@@ -96,6 +146,7 @@ export async function migrateReminderTables(
   exec: SqlExecutor,
 ): Promise<TableMigrationResult[]> {
   await exec(`CREATE SCHEMA IF NOT EXISTS ${TARGET_SCHEMA}`);
+  await ensureMigrationMarkerTable(exec);
   const results: TableMigrationResult[] = [];
   for (const table of MIGRATED_REMINDER_TABLES) {
     results.push(await migrateReminderTable(exec, table));


### PR DESCRIPTION
Promotes the remaining current `develop` tree after #20586. The delta is limited to the already-merged core wildcard action-hint normalization repair and consumer-key panel test formatting.

The shared-agent voice/text production release is already live at `3ce2f95f9bda59d2c730894f070d729979a808c8`; this PR keeps `main` synchronized with the complete current `develop` tree as requested.