### PR TITLE
fix(calendar,shared,pa): normalize Zulu timezone spellings and drop title-slugged external ids at the calendar boundary

### DIFF
--- a/packages/shared/src/lifeops-normalize/time-zone.ts
+++ b/packages/shared/src/lifeops-normalize/time-zone.ts
@@ -22,8 +22,23 @@ export function isValidTimeZone(timeZone: string): boolean {
   }
 }
 
+/**
+ * UTC spellings a model routinely emits as a timezone value. A planner that
+ * reads a Zulu-suffixed datetime ("2026-08-19T14:00:00Z") happily stamps
+ * `timeZone: "Z"`; Intl rejects that and, pre-normalization, the whole
+ * calendar create failed at the action boundary with "Invalid time zone
+ * specified: Z" (observed live). Zulu and zero-offset spellings ARE UTC —
+ * mapping them here (rather than falling through to the deployment default)
+ * preserves the instant the model actually meant.
+ */
+const UTC_ALIAS_RE =
+  /^(?:z|zulu|utc|gmt|etc\/utc|etc\/gmt|utc[+-]0{1,2}(?::?00)?|gmt[+-]0{1,2}(?::?00)?|[+-]00:?00)$/i;
+
 export function normalizeTimeZone(timeZone?: string | null): string {
   const candidate = typeof timeZone === "string" ? timeZone.trim() : "";
+  if (UTC_ALIAS_RE.test(candidate)) {
+    return "UTC";
+  }
   if (candidate && isValidTimeZone(candidate)) {
     return candidate;
   }

--- a/plugins/plugin-calendar/src/actions/calendar-handler.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.ts
@@ -1433,6 +1433,7 @@ function dedupeCalendarQueries(queries: Array<string | undefined>): string[] {
 
 function normalizeCalendarDetails(
   details: Record<string, unknown> | undefined,
+  paramsTitleCandidates: Array<string | undefined> = [],
 ): Record<string, unknown> | undefined {
   if (!details) {
     return undefined;
@@ -1474,6 +1475,30 @@ function normalizeCalendarDetails(
     }
     if (normalized[canonical] === undefined) {
       normalized[canonical] = value;
+    }
+  }
+
+  // Planner junk screen for external-id fields: the model routinely slugs the
+  // event TITLE into every id alias it can see (`eventId`/`googleEventId`/
+  // `externalEventId` all = "claim_probe_two" for title "claim probe two").
+  // A present eventId routes the operation to the external-connector lookup,
+  // which then failed the whole turn with "Google Calendar is not connected"
+  // for a locally-stored event (observed live). An id that normalizes to the
+  // same key as the title/query in the SAME args is the title, not an id —
+  // drop it so title resolution owns the lookup.
+  const eventIdValue = normalized.eventId;
+  if (typeof eventIdValue === "string" && eventIdValue.trim()) {
+    const idKey = normalizeLookupKey(eventIdValue);
+    const titleKeys = [
+      normalized.title,
+      normalized.query,
+      normalized.oldTitle,
+      ...paramsTitleCandidates,
+    ]
+      .filter((candidate): candidate is string => typeof candidate === "string")
+      .map((candidate) => normalizeLookupKey(candidate));
+    if (idKey && titleKeys.includes(idKey)) {
+      delete normalized.eventId;
     }
   }
 
@@ -4072,7 +4097,10 @@ const calendarAction: CalendarHandlerAction = {
     const params = rawParams ?? ({} as CalendarActionParams);
     const intent = resolveCalendarIntentInput(params.intent, message);
 
-    const details = normalizeCalendarDetails(params.details);
+    const details = normalizeCalendarDetails(params.details, [
+      params.title,
+      params.query,
+    ]);
     const planningTimeZone = resolveCalendarTimeZone(details);
     const llmPlan = await extractCalendarPlanWithLlm(
       runtime,

--- a/plugins/plugin-personal-assistant/src/actions/calendar.ts
+++ b/plugins/plugin-personal-assistant/src/actions/calendar.ts
@@ -81,6 +81,7 @@ import {
   buildUtcDateFromLocalParts,
   getZonedDateParts,
 } from "../lifeops/time.js";
+import { normalizeTimeZone } from "../lifeops/defaults.js";
 import {
   computeCreateEventTravelBuffer,
   resolveCreateEventTravelIntent,
@@ -1161,6 +1162,42 @@ function messageText(message: Memory): string {
   return typeof message.content.text === "string" ? message.content.text : "";
 }
 
+/**
+ * Normalize model-authored timezone spellings on every calendar route before
+ * forwarding to the concrete handlers. A planner that reads a Zulu-suffixed
+ * datetime routinely stamps `timeZone: "Z"`, and the downstream Intl boundary
+ * then throws "Invalid time zone specified: Z" — which failed an entire
+ * calendar create (observed live). All snake/camel/lower aliases of the
+ * timezone field are rewritten in place, both top-level and inside `details`,
+ * via {@link normalizeTimeZone}; unknown zone names pass through untouched so
+ * genuine mistakes still surface downstream.
+ */
+function normalizeCalendarTimeZoneParams<
+  T extends Record<string, unknown> | undefined,
+>(params: T): T {
+  if (!params || typeof params !== "object") return params;
+  const TZ_KEYS = ["timeZone", "timezone", "time_zone"] as const;
+  const normalized: Record<string, unknown> = { ...params };
+  for (const key of TZ_KEYS) {
+    if (typeof normalized[key] === "string") {
+      normalized[key] = normalizeTimeZone(normalized[key] as string);
+    }
+  }
+  const details = normalized.details;
+  if (details && typeof details === "object" && !Array.isArray(details)) {
+    const nextDetails: Record<string, unknown> = {
+      ...(details as Record<string, unknown>),
+    };
+    for (const key of TZ_KEYS) {
+      if (typeof nextDetails[key] === "string") {
+        nextDetails[key] = normalizeTimeZone(nextDetails[key] as string);
+      }
+    }
+    normalized.details = nextDetails;
+  }
+  return normalized as T;
+}
+
 function extractBulkRescheduleCohortLabel(text: string): string | null {
   const allMatch =
     /\ball\s+([a-z0-9][a-z0-9\s&/+-]{1,40}?)\s+meetings?\b/iu.exec(text) ??
@@ -1366,7 +1403,7 @@ async function route(
   options: HandlerOptions | undefined,
   callback: HandlerCallback | undefined,
 ): Promise<ActionResult> {
-  const params = getParams(options);
+  const params = normalizeCalendarTimeZoneParams(getParams(options));
   const { target, innerSubaction } = translateSubaction(subaction);
   const delegatedCallback: HandlerCallback | undefined = callback
     ? (content, actionName) => callback(content, actionName ?? ACTION_NAME)

--- a/plugins/plugin-personal-assistant/src/lifeops/time-normalize.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/time-normalize.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Unit-tests the canonical timezone normalization as consumed by LifeOps time
+ * primitives: model-authored UTC spellings (the live "Z" failure) map to UTC,
+ * valid IANA names pass through, and getZonedDateParts survives a Zulu
+ * timezone instead of throwing at the Intl boundary.
+ */
+import { describe, expect, test } from "vitest";
+import { normalizeTimeZone } from "./defaults.js";
+import { getZonedDateParts } from "./time.js";
+
+describe("normalizeTimeZone (canonical)", () => {
+  test("UTC spellings normalize to UTC, not the deployment default", () => {
+    for (const alias of ["Z", "z", "zulu", "UTC+0", "GMT+00", "+00:00", "-0000", "Etc/UTC"]) {
+      expect(normalizeTimeZone(alias)).toBe("UTC");
+    }
+  });
+  test("valid IANA zones pass through", () => {
+    expect(normalizeTimeZone("America/New_York")).toBe("America/New_York");
+  });
+  test("getZonedDateParts survives a Zulu timezone (live calendar-create failure shape)", () => {
+    const parts = getZonedDateParts(new Date("2026-08-19T14:00:00Z"), "Z");
+    expect(parts.hour).toBe(14);
+    expect(parts.day).toBe(19);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/time.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/time.ts
@@ -4,6 +4,8 @@
  * date-times use Temporal-compatible disambiguation so repeated and skipped
  * wall times remain deterministic across DST and date-line transitions.
  */
+import { normalizeTimeZone } from "@elizaos/shared";
+
 export interface ZonedDateParts {
   year: number;
   month: number;
@@ -19,7 +21,12 @@ const MINUTE_MS = 60_000;
 const HOUR_MS = 60 * MINUTE_MS;
 const OFFSET_SAMPLE_HOURS = [-48, -36, -24, -12, 0, 12, 24, 36, 48];
 
-function getZonedFormatter(timeZone: string): Intl.DateTimeFormat {
+function getZonedFormatter(rawTimeZone: string): Intl.DateTimeFormat {
+  // The canonical normalizer maps model-authored UTC spellings ("Z", "+00:00")
+  // to UTC and falls back to the deployment default for unknown names —
+  // pre-normalization, a planner-stamped `timeZone: "Z"` threw at this Intl
+  // boundary and failed an entire calendar create (observed live).
+  const timeZone = normalizeTimeZone(rawTimeZone);
   const cacheKey = `parts:${timeZone}`;
   const cached = zonedFormatterCache.get(cacheKey);
   if (cached) return cached;
@@ -37,7 +44,8 @@ function getZonedFormatter(timeZone: string): Intl.DateTimeFormat {
   return formatter;
 }
 
-function getOffsetFormatter(timeZone: string): Intl.DateTimeFormat {
+function getOffsetFormatter(rawTimeZone: string): Intl.DateTimeFormat {
+  const timeZone = normalizeTimeZone(rawTimeZone);
   const cacheKey = `offset:${timeZone}`;
   const cached = offsetFormatterCache.get(cacheKey);
   if (cached) return cached;


### PR DESCRIPTION
## What

Two planner-junk classes at the calendar action boundary, each of which failed a real user operation live:

1. **Zulu timezone spellings** (`shared/lifeops-normalize/time-zone.ts` + PA time/route seams) — a planner that reads a Zulu-suffixed datetime routinely stamps `timeZone: "Z"`; Intl throws `Invalid time zone specified: Z` and the whole calendar create failed ("tried adding the event but the calendar tool failed — looks like a time zone issue"). The canonical `normalizeTimeZone` now maps UTC spellings (`Z`, `zulu`, `UTC+0`, `GMT+00`, `+00:00`, `Etc/UTC`, …) to `UTC` *before* the valid-zone check — preserving the instant the model meant instead of falling to the deployment default — and the PA calendar route + Intl formatter seams normalize through it. Unknown zone names still fall through exactly as before.
2. **Title-slugged external event ids** (`plugin-calendar/actions/calendar-handler.ts`) — the model slugs the event TITLE into every id alias it sees (`eventId`/`googleEventId`/`externalEventId` all `"claim_probe_two"` for "claim probe two"). A present eventId routes the operation to the external-connector lookup, which failed the whole turn with "Google Calendar is not connected" for a **locally-stored** event. An id that normalizes to the same lookup key as the title/query in the same args is the title, not an id — dropped, so title resolution owns the lookup.

## Evidence

Live before/after, api owner surface:
- Create: "add a calendar event tuesday 2pm called morning claim check" → tz failure → post-fix "got it. morning claim check for tuesday 2pm." (trajectory tj-c1b5605c32b809 pins `timeZone: "Z"` in the planner args).
- Delete, exact failing phrasing: "delete the claim probe two event from my local calendar" → "can't reach your calendar — google calendar isn't connected" → post-fix "deleted claim probe two." (trajectory pins the slugged ids).
- Full CRUD chain re-proven clean (create/read/delete incl. a stale battery leftover).
- Suites: plugin-calendar 596 passed; shared lifeops-normalize 19 passed; PA tz tests 3/3 new; typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:8dd15da96ff199f29afeffa5cef7b83d3cc46208 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - chat-behavior change; before/after transcripts + trajectory ids in PR body

<!-- evidence-row:after-screenshots -->
- [ ] N/A - chat-behavior change; before/after transcripts + trajectory ids in PR body

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - live transcripts serve as walkthrough

<!-- evidence-row:backend-logs -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:llm-trajectory -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - calendar rows verified via live read-backs

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces
