### PR TITLE
release: promote overlapped shared-agent prewarm and gateway auth hardening

### DIFF
--- a/packages/cloud/api/admin/redemptions/route.ts
+++ b/packages/cloud/api/admin/redemptions/route.ts
@@ -17,6 +17,7 @@ import {
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { secureTokenRedemptionService } from "@/lib/services/token-redemption-secure";
+import { parseClampedLimit } from "@/lib/utils/clamp-limit";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -37,7 +38,7 @@ app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
     const networkFilter = c.req.query("network") || "all";
     const searchQuery = c.req.query("search")?.trim().toLowerCase() || "";
     const limitParam = c.req.query("limit");
-    const limit = limitParam ? Math.min(parseInt(limitParam, 10), 100) : 50;
+    const limit = parseClampedLimit(limitParam, 50);
 
     const allowedStatuses: TokenRedemptionStatus[] = [
       "pending",

--- a/packages/cloud/api/internal/auth/token/route.test.ts
+++ b/packages/cloud/api/internal/auth/token/route.test.ts
@@ -65,6 +65,29 @@ describe("bounded gateway JWT lifetime", () => {
     });
   });
 
+  test("rejects caller-selected non-gateway service claims", async () => {
+    const response = await tokenApp.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Gateway-Secret": "bootstrap-test-secret",
+        },
+        body: JSON.stringify({
+          pod_name: "gateway-webhook-test",
+          service: "scheduler",
+        }),
+      },
+      { GATEWAY_BOOTSTRAP_SECRET: "bootstrap-test-secret" } as never,
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "unsupported_gateway_service",
+    });
+  });
+
   test.each(["webhook-gateway", "discord-gateway"])(
     "rejects self-refresh for %s tokens",
     async (service) => {

--- a/packages/cloud/api/internal/auth/token/route.ts
+++ b/packages/cloud/api/internal/auth/token/route.ts
@@ -12,6 +12,7 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { isJWKSConfigured } from "@/lib/auth/jwks";
 import {
   internalTokenLifetimeForService,
+  isShortLivedGatewayService,
   signInternalToken,
 } from "@/lib/auth/jwt-internal";
 import { logger } from "@/lib/utils/logger";
@@ -50,6 +51,9 @@ app.post("/*", async (c) => {
     }
     const service =
       typeof body.service === "string" ? body.service.trim() : undefined;
+    if (!isShortLivedGatewayService(service)) {
+      return c.json({ error: "unsupported_gateway_service" }, 400);
+    }
 
     const token = await signInternalToken({
       subject,

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -107,7 +107,8 @@ const coordinateSharedHistory = mock(async () => [
 const namespace = {
   getByName: mock(() => ({ fetch: mock(async () => new Response()) })),
 };
-const runtimeExecutionCtx = { waitUntil() {} };
+const runtimeWaitUntil = mock((_promise: Promise<unknown>) => undefined);
+const runtimeExecutionCtx = { waitUntil: runtimeWaitUntil };
 
 mock.module("@/lib/services/eliza-app", () => ({
   elizaAppUserService: {
@@ -209,6 +210,7 @@ describe("personal Shared messaging deliveries", () => {
     findActivePersonalDedicatedTarget.mockClear();
     sharedRestMessageSend.mockClear();
     prewarmPersonalSharedAgentTurnCaches.mockClear();
+    runtimeWaitUntil.mockClear();
     runOnboardingChat.mockClear();
     bridge.mockClear();
     importCanonicalConversation.mockClear();
@@ -291,6 +293,7 @@ describe("personal Shared messaging deliveries", () => {
       namespace,
     );
     expect(order).toEqual(["prewarm", "turn"]);
+    expect(runtimeWaitUntil).toHaveBeenCalledTimes(1);
     expect(response.headers.get("server-timing")).toMatch(
       /^account;dur=\d+\.\d;desc="[^"]+", prewarm;dur=\d+\.\d, shared;dur=\d+\.\d$/,
     );
@@ -301,6 +304,7 @@ describe("personal Shared messaging deliveries", () => {
 
     expect(response.status).toBe(200);
     expect(prewarmPersonalSharedAgentTurnCaches).not.toHaveBeenCalled();
+    expect(runtimeWaitUntil).not.toHaveBeenCalled();
   });
 
   test("correlates a Shared failure without logging its sensitive message", async () => {
@@ -439,6 +443,43 @@ describe("personal Shared messaging deliveries", () => {
       await expect(response.json()).resolves.toMatchObject({
         data: { reply: "hello from Eliza" },
       });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("overlaps new-account prewarm with Telegram voice transcription", async () => {
+    personalDeliveryIsNew = true;
+    const order: string[] = [];
+    prewarmPersonalSharedAgentTurnCaches.mockImplementationOnce(async () => {
+      order.push("prewarm");
+    });
+    sharedRestMessageSend.mockImplementationOnce(async () => {
+      order.push("turn");
+      return { text: "hello from Eliza" };
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () => {
+      order.push("transcription");
+      return Response.json({ text: "remember the red bicycle" });
+    }) as unknown as typeof fetch;
+    const bytes = Buffer.from("OggSvoice-note");
+
+    try {
+      const response = await request({
+        ...valid,
+        message: undefined,
+        voiceNote: {
+          bytesBase64: bytes.toString("base64"),
+          mimeType: "audio/ogg",
+          filename: "telegram-42.ogg",
+          sizeBytes: bytes.length,
+          durationSeconds: 4,
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(order).toEqual(["prewarm", "transcription", "turn"]);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -326,6 +326,17 @@ app.post("/", async (c) => {
       userId: account.userId,
       organizationId: account.organizationId,
     });
+    const personalPrewarm = isNewPersonalAccount
+      ? (() => {
+          const startedAt = performance.now();
+          const timing = prewarmPersonalSharedAgentTurnCaches(
+            agent,
+            worker.namespace,
+          ).then(() => performance.now() - startedAt);
+          worker.executionCtx.waitUntil(timing);
+          return timing;
+        })()
+      : null;
     let deliveryMessage = parsed.data.message;
     if (
       parsed.data.platform === "telegram" &&
@@ -585,12 +596,7 @@ app.post("/", async (c) => {
       });
     }
     stage = "shared_runtime";
-    let prewarmMs: number | undefined;
-    if (isNewPersonalAccount) {
-      const prewarmStartedAt = performance.now();
-      await prewarmPersonalSharedAgentTurnCaches(agent, worker.namespace);
-      prewarmMs = performance.now() - prewarmStartedAt;
-    }
+    const prewarmMs = personalPrewarm ? await personalPrewarm : undefined;
     const sharedStartedAt = performance.now();
     const trustedDelivery =
       parsed.data.platform === "telegram"

--- a/packages/cloud/api/v1/apps/[id]/charges/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/charges/route.ts
@@ -16,6 +16,7 @@ import {
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import { appChargeRequestsService } from "@/lib/services/app-charge-requests";
+import { parseClampedLimit } from "@/lib/utils/clamp-limit";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -104,11 +105,11 @@ app.get("/", async (c) => {
     }
 
     const limitParam = c.req.query("limit");
-    const limit = limitParam ? Number.parseInt(limitParam, 10) : 50;
+    const limit = parseClampedLimit(limitParam, 50);
     const charges = await appChargeRequestsService.listForApp(
       appId,
       user.organization_id,
-      Number.isFinite(limit) ? limit : 50,
+      limit,
     );
 
     return c.json({ success: true, charges });

--- a/packages/cloud/api/v1/redemptions/route.ts
+++ b/packages/cloud/api/v1/redemptions/route.ts
@@ -19,6 +19,7 @@ import {
   REDEMPTION_ORIGIN_VERIFICATION_ERROR,
   secureTokenRedemptionService,
 } from "@/lib/services/token-redemption-secure";
+import { parseClampedLimit } from "@/lib/utils/clamp-limit";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -239,7 +240,7 @@ app.get("/", rateLimit(RateLimitPresets.STRICT), async (c) => {
     const user = await requireUserOrApiKeyWithOrg(c);
 
     const limitParam = c.req.query("limit");
-    const limit = limitParam ? Math.min(parseInt(limitParam, 10), 100) : 20;
+    const limit = parseClampedLimit(limitParam, 20);
 
     const redemptions = await secureTokenRedemptionService.listUserRedemptions(
       user.id,

--- a/packages/cloud/services/_common/AGENTS.md
+++ b/packages/cloud/services/_common/AGENTS.md
@@ -25,6 +25,8 @@ structured logging, and Kubernetes ServiceAccount helpers. Private
   tests only.
 - `src/identity-link-code.ts` (`./identity-link-code`) — canonical connector
   LINK-code recognition and user-facing confirmation results.
+- `src/gateway-auth.ts` (`./gateway-auth`) — strict short-lived gateway token
+  response validation plus shared refresh and jittered retry timing.
 - `src/response-attempts.ts` (`./response-attempts`) — bounded observable HTTP
   retry behavior shared across transport runtimes.
 - `src/telegram-connector.ts` (`./telegram-connector`) — Web-standard Telegram

--- a/packages/cloud/services/_common/CLAUDE.md
+++ b/packages/cloud/services/_common/CLAUDE.md
@@ -25,6 +25,8 @@ structured logging, and Kubernetes ServiceAccount helpers. Private
   tests only.
 - `src/identity-link-code.ts` (`./identity-link-code`) — canonical connector
   LINK-code recognition and user-facing confirmation results.
+- `src/gateway-auth.ts` (`./gateway-auth`) — strict short-lived gateway token
+  response validation plus shared refresh and jittered retry timing.
 - `src/response-attempts.ts` (`./response-attempts`) — bounded observable HTTP
   retry behavior shared across transport runtimes.
 - `src/telegram-connector.ts` (`./telegram-connector`) — Web-standard Telegram

--- a/packages/cloud/services/_common/package.json
+++ b/packages/cloud/services/_common/package.json
@@ -11,6 +11,7 @@
     "./logger": "./src/logger.ts",
     "./k8s-service-account": "./src/k8s-service-account.ts",
     "./identity-link-code": "./src/identity-link-code.ts",
+    "./gateway-auth": "./src/gateway-auth.ts",
     "./response-attempts": "./src/response-attempts.ts",
     "./telegram-connector": "./src/telegram-connector.ts",
     "./telegram-delivery": "./src/telegram-delivery.ts"

--- a/packages/cloud/services/_common/src/gateway-auth.ts
+++ b/packages/cloud/services/_common/src/gateway-auth.ts
@@ -1,0 +1,61 @@
+/** Defines the shared short-lived gateway token response and renewal timing contract. */
+
+export interface GatewayTokenResponse {
+  access_token: string;
+  token_type: "Bearer";
+  expires_in: number;
+}
+
+export const GATEWAY_TOKEN_MAX_LIFETIME_SECONDS = 60;
+export const GATEWAY_TOKEN_REQUEST_TIMEOUT_MS = 5_000;
+
+const TOKEN_REFRESH_FRACTION = 0.5;
+const TOKEN_REFRESH_RETRY_MIN_MS = 1_000;
+const TOKEN_REFRESH_RETRY_MAX_MS = 8_000;
+
+/** Rejects malformed token responses before they can corrupt gateway auth state. */
+export function parseGatewayTokenResponse(
+  value: unknown,
+): GatewayTokenResponse {
+  if (!value || typeof value !== "object") {
+    throw new Error("Invalid gateway token response");
+  }
+
+  const candidate = value as Record<string, unknown>;
+  if (
+    typeof candidate.access_token !== "string" ||
+    candidate.access_token.trim().length === 0 ||
+    candidate.access_token !== candidate.access_token.trim() ||
+    candidate.token_type !== "Bearer" ||
+    typeof candidate.expires_in !== "number" ||
+    !Number.isFinite(candidate.expires_in) ||
+    candidate.expires_in <= 0 ||
+    candidate.expires_in > GATEWAY_TOKEN_MAX_LIFETIME_SECONDS
+  ) {
+    throw new Error("Invalid gateway token response");
+  }
+
+  return {
+    access_token: candidate.access_token,
+    token_type: candidate.token_type,
+    expires_in: candidate.expires_in,
+  };
+}
+
+/** Refreshes halfway through the lease, leaving room for bounded retries. */
+export function gatewayTokenRefreshDelayMs(expiresInSeconds: number): number {
+  return expiresInSeconds * 1_000 * TOKEN_REFRESH_FRACTION;
+}
+
+/** Applies equal jitter so gateway replicas do not retry in lockstep. */
+export function gatewayTokenRetryDelayMs(
+  attempt: number,
+  random: () => number = Math.random,
+): number {
+  const exponentialDelay = Math.min(
+    TOKEN_REFRESH_RETRY_MIN_MS * 2 ** Math.max(0, attempt),
+    TOKEN_REFRESH_RETRY_MAX_MS,
+  );
+  const jitter = Math.min(1, Math.max(0, random()));
+  return Math.floor(exponentialDelay / 2 + (exponentialDelay / 2) * jitter);
+}

--- a/packages/cloud/services/_common/src/index.ts
+++ b/packages/cloud/services/_common/src/index.ts
@@ -1,6 +1,14 @@
 // Shares index service primitives across cloud worker sidecars.
 
 export {
+  GATEWAY_TOKEN_MAX_LIFETIME_SECONDS,
+  GATEWAY_TOKEN_REQUEST_TIMEOUT_MS,
+  type GatewayTokenResponse,
+  gatewayTokenRefreshDelayMs,
+  gatewayTokenRetryDelayMs,
+  parseGatewayTokenResponse,
+} from "./gateway-auth";
+export {
   extractIdentityLinkCode,
   identityLinkReply,
 } from "./identity-link-code";

--- a/packages/cloud/services/_common/tests/gateway-auth.test.ts
+++ b/packages/cloud/services/_common/tests/gateway-auth.test.ts
@@ -1,0 +1,51 @@
+/** Verifies gateway token response validation and bounded, jittered renewal timing. */
+
+import { describe, expect, test } from "bun:test";
+import {
+  gatewayTokenRefreshDelayMs,
+  gatewayTokenRetryDelayMs,
+  parseGatewayTokenResponse,
+} from "../src/gateway-auth";
+
+describe("gateway auth contract", () => {
+  test("accepts the bounded bearer response", () => {
+    expect(
+      parseGatewayTokenResponse({
+        access_token: "signed-token",
+        token_type: "Bearer",
+        expires_in: 60,
+      }),
+    ).toEqual({
+      access_token: "signed-token",
+      token_type: "Bearer",
+      expires_in: 60,
+    });
+  });
+
+  test.each([
+    null,
+    {},
+    { access_token: "", token_type: "Bearer", expires_in: 60 },
+    { access_token: " token ", token_type: "Bearer", expires_in: 60 },
+    { access_token: "token", token_type: "NotBearer", expires_in: 60 },
+    { access_token: "token", token_type: "Bearer", expires_in: 0 },
+    { access_token: "token", token_type: "Bearer", expires_in: -1 },
+    { access_token: "token", token_type: "Bearer", expires_in: 61 },
+    { access_token: "token", token_type: "Bearer", expires_in: Number.NaN },
+  ])("rejects malformed response %#", (value) => {
+    expect(() => parseGatewayTokenResponse(value)).toThrow(
+      "Invalid gateway token response",
+    );
+  });
+
+  test("refreshes halfway through a lease", () => {
+    expect(gatewayTokenRefreshDelayMs(60)).toBe(30_000);
+  });
+
+  test("caps exponential retries and applies equal jitter", () => {
+    expect(gatewayTokenRetryDelayMs(0, () => 0)).toBe(500);
+    expect(gatewayTokenRetryDelayMs(0, () => 1)).toBe(1_000);
+    expect(gatewayTokenRetryDelayMs(20, () => 0)).toBe(4_000);
+    expect(gatewayTokenRetryDelayMs(20, () => 1)).toBe(8_000);
+  });
+});

--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -1,4 +1,10 @@
 /** Coordinates multi-tenant Discord gateway connections and event routing. */
+import {
+  GATEWAY_TOKEN_REQUEST_TIMEOUT_MS,
+  gatewayTokenRefreshDelayMs,
+  gatewayTokenRetryDelayMs,
+  parseGatewayTokenResponse,
+} from "@elizaos/cloud-services-common/gateway-auth";
 import { Redis } from "@upstash/redis";
 import {
   type Attachment,
@@ -280,18 +286,6 @@ interface GatewayConfig {
   project: string;
 }
 
-/** JWT token response from token endpoint */
-interface TokenResponse {
-  access_token: string;
-  token_type: "Bearer";
-  expires_in: number;
-}
-
-/** Percentage of token lifetime at which to refresh. */
-const TOKEN_REFRESH_PERCENTAGE = 0.8;
-const TOKEN_REFRESH_RETRY_MIN_MS = 1_000;
-const TOKEN_REFRESH_RETRY_MAX_MS = 30_000;
-
 interface BotConnection {
   connectionId: string;
   organizationId: string;
@@ -555,6 +549,7 @@ export class GatewayManager {
    */
   private async acquireToken(): Promise<void> {
     const lifecycleGeneration = this.authLifecycleGeneration;
+    const acquisitionStartedAt = Date.now();
     logger.info("Acquiring JWT token", { podName: this.config.podName });
 
     const response = await fetchWithTimeout(
@@ -569,6 +564,7 @@ export class GatewayManager {
           pod_name: this.config.podName,
           service: "discord-gateway",
         }),
+        timeout: GATEWAY_TOKEN_REQUEST_TIMEOUT_MS,
       },
     );
 
@@ -577,19 +573,20 @@ export class GatewayManager {
       throw new Error(`Failed to acquire token: ${response.status} - ${error}`);
     }
 
-    const data = (await response.json()) as TokenResponse;
+    const data = parseGatewayTokenResponse(await response.json());
     if (lifecycleGeneration !== this.authLifecycleGeneration) {
       throw new Error("Auth lifecycle changed during token acquisition");
     }
     this.accessToken = data.access_token;
-    this.tokenExpiresAt = new Date(Date.now() + data.expires_in * 1000);
+    this.tokenExpiresAt = new Date(
+      acquisitionStartedAt + data.expires_in * 1_000,
+    );
 
     logger.info("JWT token acquired", {
       podName: this.config.podName,
       expiresAt: this.tokenExpiresAt.toISOString(),
     });
 
-    // Schedule token refresh at 80% of lifetime
     this.scheduleTokenRefresh(data.expires_in);
   }
 
@@ -601,14 +598,14 @@ export class GatewayManager {
   }
 
   /**
-   * Schedule token refresh at 80% of token lifetime.
+   * Schedule token refresh halfway through the token lifetime.
    */
   private scheduleTokenRefresh(expiresInSeconds: number): void {
     if (this.tokenRefreshTimeout) {
       clearTimeout(this.tokenRefreshTimeout);
     }
 
-    const refreshInMs = expiresInSeconds * 1000 * TOKEN_REFRESH_PERCENTAGE;
+    const refreshInMs = gatewayTokenRefreshDelayMs(expiresInSeconds);
     this.tokenRefreshRetryAttempt = 0;
     const timeout = setTimeout(() => {
       // error-policy:J1 The timer boundary converts renewal failure into a paced retry.
@@ -632,13 +629,10 @@ export class GatewayManager {
       clearTimeout(this.tokenRefreshTimeout);
     }
 
-    const retryInMs = Math.min(
-      TOKEN_REFRESH_RETRY_MIN_MS * 2 ** this.tokenRefreshRetryAttempt,
-      TOKEN_REFRESH_RETRY_MAX_MS,
-    );
+    const retryInMs = gatewayTokenRetryDelayMs(this.tokenRefreshRetryAttempt);
     this.tokenRefreshRetryAttempt = Math.min(
       this.tokenRefreshRetryAttempt + 1,
-      5,
+      4,
     );
     const lifecycleGeneration = this.authLifecycleGeneration;
     const timeout = setTimeout(() => {
@@ -668,7 +662,11 @@ export class GatewayManager {
    * Throws if no token is available.
    */
   private getAuthHeader(): { Authorization: string } {
-    if (!this.accessToken) {
+    if (
+      !this.accessToken ||
+      !this.tokenExpiresAt ||
+      Date.now() >= this.tokenExpiresAt.getTime()
+    ) {
       throw new Error("No access token available - call acquireToken first");
     }
     return { Authorization: `Bearer ${this.accessToken}` };

--- a/packages/cloud/services/gateway-discord/tests/gateway-manager-auth.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/gateway-manager-auth.test.ts
@@ -5,8 +5,10 @@ import { GatewayManager } from "../src/gateway-manager";
 
 interface AuthHarness {
   accessToken: string | null;
+  getAuthHeader(): { Authorization: string };
   refreshToken(): Promise<void>;
   scheduleTokenRefresh(expiresInSeconds: number): void;
+  tokenExpiresAt: Date | null;
   tokenRefreshTimeout: NodeJS.Timeout | null;
 }
 
@@ -122,6 +124,7 @@ describe("GatewayManager token renewal", () => {
     });
     const harness = manager as unknown as AuthHarness;
     harness.accessToken = "existing-token";
+    harness.tokenExpiresAt = new Date(Date.now() + 60_000);
 
     const renewal = harness.refreshToken();
     await waitFor(() => resolveBootstrap !== undefined);
@@ -140,6 +143,37 @@ describe("GatewayManager token renewal", () => {
     await expect(renewal).rejects.toThrow("Auth lifecycle changed");
     expect(harness.accessToken).toBe("existing-token");
     expect(harness.tokenRefreshTimeout).toBeNull();
+  });
+
+  test("rejects malformed and locally expired credentials", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: "invalid-token",
+            token_type: "NotBearer",
+            expires_in: -1,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    ) as typeof fetch;
+
+    const manager = new GatewayManager({
+      podName: "test-pod",
+      elizaCloudUrl: "https://api.test",
+      gatewayBootstrapSecret: "bootstrap-secret",
+      project: "test",
+    });
+    const harness = manager as unknown as AuthHarness;
+
+    await expect(harness.refreshToken()).rejects.toThrow(
+      "Invalid gateway token response",
+    );
+    expect(harness.accessToken).toBeNull();
+
+    harness.accessToken = "expired-token";
+    harness.tokenExpiresAt = new Date(Date.now() - 1);
+    expect(() => harness.getAuthHeader()).toThrow("No access token available");
   });
 });
 

--- a/packages/cloud/services/gateway-discord/tests/gateway-manager-dm-policy.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/gateway-manager-dm-policy.test.ts
@@ -37,6 +37,7 @@ interface GatewayManagerHarness {
   connections: Map<string, HarnessConnection>;
   redis: object | null;
   accessToken: string | null;
+  tokenExpiresAt: Date | null;
   handleMessage(connectionId: string, message: Message): Promise<void>;
   pollForBots(): Promise<void>;
   voiceHandler: {
@@ -120,6 +121,7 @@ function createBoundary(topology: Topology) {
   const harness = manager as unknown as GatewayManagerHarness;
   harness.redis = {};
   harness.accessToken = "test-token";
+  harness.tokenExpiresAt = new Date(Date.now() + 60_000);
 
   return {
     harness,

--- a/packages/cloud/services/gateway-webhook/__tests__/auth-rebootstrap-on-401.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/auth-rebootstrap-on-401.test.ts
@@ -175,7 +175,7 @@ describe("reacquireAuthHeader is single-flight", () => {
           JSON.stringify({
             access_token: `tok-${bootstraps}`,
             token_type: "Bearer",
-            expires_in: 3600,
+            expires_in: 60,
           }),
           { status: 200, headers: { "content-type": "application/json" } },
         );
@@ -238,6 +238,33 @@ describe("reacquireAuthHeader is single-flight", () => {
     expect(paths.every((path) => path === "/api/internal/auth/token")).toBe(
       true,
     );
+  });
+
+  test("rejects a malformed bootstrap response without installing it", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: "invalid-token",
+            token_type: "NotBearer",
+            expires_in: -1,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    ) as typeof fetch;
+
+    const { getAuthHeader, initAuth, shutdownAuth } = await import(
+      "../src/auth"
+    );
+    await expect(
+      initAuth({
+        cloudUrl: "https://api.test",
+        bootstrapSecret: "bootstrap",
+        podName: "test-pod",
+      }),
+    ).rejects.toThrow("Invalid gateway token response");
+    expect(() => getAuthHeader()).toThrow("No access token available");
+    shutdownAuth();
   });
 
   test("scheduled renewal retries bootstrap after a transient failure", async () => {

--- a/packages/cloud/services/gateway-webhook/src/auth.ts
+++ b/packages/cloud/services/gateway-webhook/src/auth.ts
@@ -1,16 +1,13 @@
 /** Handles webhook gateway authentication for authenticated connector fan-in. */
+import {
+  GATEWAY_TOKEN_REQUEST_TIMEOUT_MS,
+  gatewayTokenRefreshDelayMs,
+  gatewayTokenRetryDelayMs,
+  parseGatewayTokenResponse,
+} from "@elizaos/cloud-services-common/gateway-auth";
 import { logger } from "./logger";
 
 const HTTP_TIMEOUT_MS = 10_000;
-const TOKEN_REFRESH_PERCENTAGE = 0.8;
-const TOKEN_REFRESH_RETRY_MIN_MS = 1_000;
-const TOKEN_REFRESH_RETRY_MAX_MS = 30_000;
-
-interface TokenResponse {
-  access_token: string;
-  token_type: "Bearer";
-  expires_in: number;
-}
 
 interface AuthConfig {
   cloudUrl: string;
@@ -19,6 +16,7 @@ interface AuthConfig {
 }
 
 let accessToken: string | null = null;
+let accessTokenExpiresAt = 0;
 let refreshTimeout: ReturnType<typeof setTimeout> | null = null;
 let config: AuthConfig | null = null;
 let refreshRetryAttempt = 0;
@@ -46,6 +44,7 @@ async function acquireToken(): Promise<void> {
   if (!config) throw new Error("Auth not initialized");
   const lifecycleGeneration = authLifecycleGeneration;
   const activeConfig = config;
+  const acquisitionStartedAt = Date.now();
 
   logger.info("Acquiring JWT token", { podName: activeConfig.podName });
 
@@ -61,6 +60,7 @@ async function acquireToken(): Promise<void> {
         pod_name: activeConfig.podName,
         service: "webhook-gateway",
       }),
+      timeout: GATEWAY_TOKEN_REQUEST_TIMEOUT_MS,
     },
   );
 
@@ -69,11 +69,12 @@ async function acquireToken(): Promise<void> {
     throw new Error(`Failed to acquire token: ${response.status} - ${error}`);
   }
 
-  const data = (await response.json()) as TokenResponse;
+  const data = parseGatewayTokenResponse(await response.json());
   if (lifecycleGeneration !== authLifecycleGeneration) {
     throw new Error("Auth lifecycle changed during token acquisition");
   }
   accessToken = data.access_token;
+  accessTokenExpiresAt = acquisitionStartedAt + data.expires_in * 1_000;
 
   logger.info("JWT token acquired", {
     podName: activeConfig.podName,
@@ -91,7 +92,7 @@ async function refreshToken(): Promise<void> {
 function scheduleRefresh(expiresInSeconds: number): void {
   if (refreshTimeout) clearTimeout(refreshTimeout);
 
-  const refreshInMs = expiresInSeconds * 1000 * TOKEN_REFRESH_PERCENTAGE;
+  const refreshInMs = gatewayTokenRefreshDelayMs(expiresInSeconds);
   refreshRetryAttempt = 0;
   const timeout = setTimeout(() => {
     // error-policy:J1 The timer boundary converts renewal failure into a paced retry.
@@ -108,11 +109,8 @@ function scheduleRefresh(expiresInSeconds: number): void {
 function scheduleRefreshRetry(): void {
   if (refreshTimeout) clearTimeout(refreshTimeout);
 
-  const retryInMs = Math.min(
-    TOKEN_REFRESH_RETRY_MIN_MS * 2 ** refreshRetryAttempt,
-    TOKEN_REFRESH_RETRY_MAX_MS,
-  );
-  refreshRetryAttempt = Math.min(refreshRetryAttempt + 1, 5);
+  const retryInMs = gatewayTokenRetryDelayMs(refreshRetryAttempt);
+  refreshRetryAttempt = Math.min(refreshRetryAttempt + 1, 4);
   const lifecycleGeneration = authLifecycleGeneration;
   const timeout = setTimeout(() => {
     if (lifecycleGeneration !== authLifecycleGeneration) return;
@@ -134,6 +132,12 @@ function scheduleRefreshRetry(): void {
 
 export async function initAuth(authConfig: AuthConfig): Promise<void> {
   authLifecycleGeneration += 1;
+  if (refreshTimeout) {
+    clearTimeout(refreshTimeout);
+    refreshTimeout = null;
+  }
+  accessToken = null;
+  accessTokenExpiresAt = 0;
   config = authConfig;
   await acquireToken();
 }
@@ -168,7 +172,7 @@ export async function reacquireAuthHeader(): Promise<{
 }
 
 export function getAuthHeader(): { Authorization: string } {
-  if (!accessToken) {
+  if (!accessToken || Date.now() >= accessTokenExpiresAt) {
     throw new Error("No access token available - call initAuth first");
   }
   return { Authorization: `Bearer ${accessToken}` };
@@ -181,6 +185,7 @@ export function shutdownAuth(): void {
     refreshTimeout = null;
   }
   accessToken = null;
+  accessTokenExpiresAt = 0;
   config = null;
   refreshRetryAttempt = 0;
 }

--- a/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
@@ -25,7 +25,6 @@ const GATE_BINDING = "INFERENCE_ADMISSION_GATES";
 const GATE_ORIGIN = "https://inference-admission.internal";
 const HYDRATION_GATE_TIMEOUT_MS = 5_000;
 const GATE_OPERATION_TIMEOUT_MS = 1_500;
-const RATE_LIMIT_GATE_TIMEOUT_MS = 5_000;
 const DISPATCH_GATE_TIMEOUT_MS = 1_500;
 const DISPATCH_GATE_MAX_ATTEMPTS = 3;
 
@@ -399,10 +398,7 @@ export async function consumeInferenceRateLimit(params: {
       maxRequests: params.maxRequests,
     },
     undefined,
-    // A brand-new organization addresses a brand-new Durable Object. Preserve
-    // the tighter money-mutation deadline above, but allow the lightweight
-    // rate-limit authority to survive genuine Worker/DO cold initialization.
-    AbortSignal.timeout(RATE_LIMIT_GATE_TIMEOUT_MS),
+    AbortSignal.timeout(GATE_OPERATION_TIMEOUT_MS),
   );
   if (response.status !== 200 && response.status !== 429) {
     throw new InferenceAdmissionGateUnavailableError(

--- a/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts
@@ -169,8 +169,9 @@ export async function prewarmSharedAgentTurnCaches(
 
 /**
  * Warm the two authorities a newly auto-registered personal agent needs.
- * Unlike dashboard agent creation, first contact already carries the user's
- * message, so the route awaits these concurrent legs before dispatching it.
+ * The messaging route starts these concurrent legs as soon as it resolves the
+ * account, overlaps them with other preparation, and joins them before Shared
+ * dispatch.
  */
 export async function prewarmPersonalSharedAgentTurnCaches(
   agent: Pick<SharedRuntimeAgent, "id" | "organization_id">,

--- a/packages/cloud/shared/src/lib/utils/clamp-limit.test.ts
+++ b/packages/cloud/shared/src/lib/utils/clamp-limit.test.ts
@@ -1,0 +1,39 @@
+/** Deterministic tests for the shared bounded list-limit query contract. */
+
+import { describe, expect, test } from "bun:test";
+import { parseClampedLimit } from "./clamp-limit";
+
+describe("parseClampedLimit", () => {
+  test("absent → fallback", () => {
+    expect(parseClampedLimit(null, 20)).toBe(20);
+    expect(parseClampedLimit(undefined, 50)).toBe(50);
+    expect(parseClampedLimit("", 20)).toBe(20);
+  });
+
+  test.each([5, 20, 50, 100])("valid %i unchanged", (limit) => {
+    expect(parseClampedLimit(String(limit), 20)).toBe(limit);
+    expect(parseClampedLimit(String(limit), 50)).toBe(limit);
+  });
+
+  test.each(["abc", "-5", "0", "-1", "+5", "5.5", "5junk", " 5"])(
+    "malformed %s → fallback",
+    (limit) => {
+      expect(parseClampedLimit(limit, 20)).toBe(20);
+      expect(parseClampedLimit(limit, 50)).toBe(50);
+    },
+  );
+
+  test.each([
+    ["101", 100],
+    ["999999", 100],
+    ["200", 100],
+  ])("above max %s → 100", (limit, expected) => {
+    expect(parseClampedLimit(limit, 20)).toBe(expected);
+    expect(parseClampedLimit(limit, 50)).toBe(expected);
+  });
+
+  test("custom max respected", () => {
+    expect(parseClampedLimit("600", 20, 500)).toBe(500);
+    expect(parseClampedLimit("400", 20, 500)).toBe(400);
+  });
+});

--- a/packages/cloud/shared/src/lib/utils/clamp-limit.ts
+++ b/packages/cloud/shared/src/lib/utils/clamp-limit.ts
@@ -1,0 +1,11 @@
+/** Parses list-endpoint limit query parameters with a bounded fallback contract. */
+export function parseClampedLimit(
+  param: string | null | undefined,
+  fallback: number,
+  max = 100,
+): number {
+  if (!param) return fallback;
+  if (!/^\d+$/.test(param)) return fallback;
+  const parsed = Number(param);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? Math.min(parsed, max) : fallback;
+}

--- a/packages/shared/src/local-inference/index.ts
+++ b/packages/shared/src/local-inference/index.ts
@@ -94,12 +94,12 @@ export type {
 export type {
   RoutingPolicy,
   RoutingPreferences,
-} from "./routing-preferences.js";
+} from "./routing-policy.js";
 export {
   DEFAULT_ROUTING_POLICY,
   isRoutingPolicy,
   ROUTING_POLICIES,
-} from "./routing-preferences.js";
+} from "./routing-policy.js";
 export {
   classifyCatalogModelRuntimeClass,
   classifyInstalledModelRuntimeClass,

--- a/packages/shared/src/local-inference/routing-policy.ts
+++ b/packages/shared/src/local-inference/routing-policy.ts
@@ -1,0 +1,42 @@
+/**
+ * Browser-safe routing policy contracts shared by UI and runtime consumers.
+ */
+
+import type { AgentModelSlot } from "./types.js";
+
+export type RoutingPolicy =
+  | "manual"
+  | "auto"
+  | "local-only"
+  | "cloud-only"
+  | "cheapest"
+  | "fastest"
+  | "prefer-local"
+  | "round-robin";
+
+export const ROUTING_POLICIES: readonly RoutingPolicy[] = [
+  "manual",
+  "auto",
+  "local-only",
+  "cloud-only",
+  "cheapest",
+  "fastest",
+  "prefer-local",
+  "round-robin",
+] as const;
+
+export function isRoutingPolicy(value: unknown): value is RoutingPolicy {
+  return (
+    typeof value === "string" &&
+    (ROUTING_POLICIES as readonly string[]).includes(value)
+  );
+}
+
+export const DEFAULT_ROUTING_POLICY: RoutingPolicy = "prefer-local";
+
+export interface RoutingPreferences {
+  /** Explicit provider override per agent slot. */
+  preferredProvider: Partial<Record<AgentModelSlot, string>>;
+  /** Per-slot dispatch policy; absent slots use prefer-local. */
+  policy: Partial<Record<AgentModelSlot, RoutingPolicy>>;
+}

--- a/packages/shared/src/local-inference/routing-preferences.ts
+++ b/packages/shared/src/local-inference/routing-preferences.ts
@@ -14,64 +14,23 @@ import { hostname } from "node:os";
 import path from "node:path";
 import { localInferenceRoot } from "./paths.js";
 import {
+  isRoutingPolicy,
+  type RoutingPolicy,
+  type RoutingPreferences,
+} from "./routing-policy.js";
+import {
   AGENT_MODEL_SLOTS,
   type AgentModelSlot,
   TEXT_GENERATION_SLOTS,
 } from "./types.js";
 
-export type RoutingPolicy =
-  | "manual"
-  | "auto"
-  | "local-only"
-  | "cloud-only"
-  | "cheapest"
-  | "fastest"
-  | "prefer-local"
-  | "round-robin";
-
-/**
- * The full set of selectable policies, in display order. Kept as a runtime
- * value (not just a type) so route-layer validation and the settings UI share
- * one source of truth for "which policies are accepted".
- *
- * `local-only` / `cloud-only` are the canonical per-slot replacements for the
- * global `ELIZA_LOCAL_ONLY` env hack: `local-only` is a hard guarantee (never
- * falls through to cloud), `cloud-only` never dispatches on-device.
- */
-export const ROUTING_POLICIES: readonly RoutingPolicy[] = [
-  "manual",
-  "auto",
-  "local-only",
-  "cloud-only",
-  "cheapest",
-  "fastest",
-  "prefer-local",
-  "round-robin",
-] as const;
-
-export function isRoutingPolicy(value: unknown): value is RoutingPolicy {
-  return (
-    typeof value === "string" &&
-    (ROUTING_POLICIES as readonly string[]).includes(value)
-  );
-}
-
-export const DEFAULT_ROUTING_POLICY: RoutingPolicy = "prefer-local";
-
-export interface RoutingPreferences {
-  /**
-   * Explicit provider override per agent slot. Empty record = no overrides,
-   * runtime picks the highest-priority registered handler.
-   */
-  preferredProvider: Partial<Record<AgentModelSlot, string>>;
-  /**
-   * Per-slot policy. "manual" honours `preferredProvider` verbatim;
-   * everything else lets the router-handler compute a winner from the
-   * policy rule set. Absent = "prefer-local" so local models and
-   * subscriptions are tried before direct paid APIs and managed cloud.
-   */
-  policy: Partial<Record<AgentModelSlot, RoutingPolicy>>;
-}
+export {
+  DEFAULT_ROUTING_POLICY,
+  isRoutingPolicy,
+  ROUTING_POLICIES,
+  type RoutingPolicy,
+  type RoutingPreferences,
+} from "./routing-policy.js";
 
 interface RoutingFile {
   version: 1;

--- a/packages/ui/src/cloud/instances/components/eliza-agent-backups-panel.test.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agent-backups-panel.test.tsx
@@ -1,0 +1,481 @@
+/**
+ * Verifies backup-list and restore UI state against deterministic mocked Cloud
+ * transport responses, including request races and abort ownership.
+ */
+// @vitest-environment jsdom
+
+import {
+  act,
+  cleanup,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ElizaAgentBackupsPanel } from "./eliza-agent-backups-panel";
+
+const apiMock = vi.hoisted(() => vi.fn());
+const toastMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+  success: vi.fn(),
+}));
+
+vi.mock("../../lib/api-client", () => ({ api: apiMock }));
+vi.mock("sonner", () => ({ toast: toastMocks }));
+
+const BACKUP = {
+  id: "11111111-1111-4111-8111-111111111111",
+  snapshotType: "manual",
+  sizeBytes: 2048,
+  createdAt: "2026-08-11T12:00:00.000Z",
+  backupKind: "full",
+  parentBackupId: null,
+};
+
+const OLD_BACKUP = {
+  ...BACKUP,
+  id: "22222222-2222-4222-8222-222222222222",
+  snapshotType: "pre-move",
+  sizeBytes: null,
+  createdAt: "2026-08-10T12:00:00.000Z",
+};
+
+function listResponse(data: unknown[] = [BACKUP]) {
+  return { success: true, data };
+}
+
+function restoreResponse(backup = BACKUP) {
+  return {
+    success: true,
+    data: {
+      restoredFromBackupId: backup.id,
+      snapshotType: backup.snapshotType,
+      createdAt: backup.createdAt,
+    },
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}
+
+function renderPanel(
+  props: Partial<{
+    agentId: string;
+    agentName: string;
+    status: string;
+  }> = {},
+) {
+  return render(
+    <ElizaAgentBackupsPanel
+      agentId={props.agentId ?? "agent-1"}
+      agentName={props.agentName ?? "Primary agent"}
+      status={props.status ?? "running"}
+    />,
+  );
+}
+
+describe("ElizaAgentBackupsPanel", () => {
+  const originalLocationDescriptor = Object.getOwnPropertyDescriptor(
+    window,
+    "location",
+  );
+  let reloadSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    apiMock.mockReset();
+    toastMocks.error.mockReset();
+    toastMocks.success.mockReset();
+    reloadSpy = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, reload: reloadSpy },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    if (originalLocationDescriptor) {
+      Object.defineProperty(window, "location", originalLocationDescriptor);
+    }
+  });
+
+  it("keeps loading distinct until the backup request settles", async () => {
+    const request = deferred<ReturnType<typeof listResponse>>();
+    apiMock.mockReturnValue(request.promise);
+
+    renderPanel();
+
+    expect(screen.getByRole("status").textContent).toContain("Loading backups");
+    expect(screen.queryByText("No backups yet")).toBeNull();
+
+    await act(async () => {
+      request.resolve(listResponse([]));
+      await request.promise;
+    });
+
+    expect(await screen.findByText("No backups yet")).toBeTruthy();
+  });
+
+  it("renders the designed empty state without treating it as an error", async () => {
+    apiMock.mockResolvedValue(listResponse([]));
+
+    renderPanel();
+
+    expect(await screen.findByText("No backups yet")).toBeTruthy();
+    expect(screen.queryByText("Failed to load backups")).toBeNull();
+  });
+
+  it("renders request failures with a retry instead of an empty list", async () => {
+    apiMock.mockRejectedValue(new Error("Backup service unavailable"));
+
+    renderPanel();
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain("Failed to load backups");
+    expect(alert.textContent).toContain("Backup service unavailable");
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    expect(screen.queryByText("No backups yet")).toBeNull();
+  });
+
+  it("uses the authenticated Cloud transport and surfaces a rejected session", async () => {
+    apiMock.mockRejectedValue(
+      Object.assign(new Error("Session expired"), { status: 401 }),
+    );
+
+    renderPanel({ agentId: "agent-session" });
+
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Session expired",
+    );
+    expect(apiMock).toHaveBeenCalledWith(
+      "/api/v1/eliza/agents/agent-session/backups",
+      expect.objectContaining({ cache: "no-store", signal: expect.anything() }),
+    );
+  });
+
+  it.each([
+    ["missing data", { success: true }],
+    ["false success", { success: false, data: [] }],
+    ["missing id", listResponse([{ ...BACKUP, id: undefined }])],
+    [
+      "unknown snapshot type",
+      listResponse([{ ...BACKUP, snapshotType: "before-party" }]),
+    ],
+    ["negative size", listResponse([{ ...BACKUP, sizeBytes: -1 }])],
+    ["invalid timestamp", listResponse([{ ...BACKUP, createdAt: "soon" }])],
+  ])("renders malformed success (%s) as an error", async (_name, payload) => {
+    apiMock.mockResolvedValue(payload);
+
+    renderPanel();
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(screen.queryByText("No backups yet")).toBeNull();
+  });
+
+  it("accepts every backend snapshot category", async () => {
+    apiMock.mockResolvedValue(
+      listResponse([
+        {
+          ...BACKUP,
+          id: "55555555-5555-4555-8555-555555555555",
+          snapshotType: "auto",
+        },
+        BACKUP,
+        {
+          ...BACKUP,
+          id: "66666666-6666-4666-8666-666666666666",
+          snapshotType: "pre-shutdown",
+        },
+        {
+          ...BACKUP,
+          id: "77777777-7777-4777-8777-777777777777",
+          snapshotType: "pre-delete",
+        },
+        OLD_BACKUP,
+        {
+          ...BACKUP,
+          id: "33333333-3333-4333-8333-333333333333",
+          snapshotType: "pre-upgrade",
+        },
+      ]),
+    );
+
+    renderPanel();
+
+    expect(await screen.findByText("Auto")).toBeTruthy();
+    expect(screen.getByText("Manual")).toBeTruthy();
+    expect(screen.getByText("Pre-shutdown")).toBeTruthy();
+    expect(screen.getByText("Pre-delete")).toBeTruthy();
+    expect(await screen.findByText("Pre-move")).toBeTruthy();
+    expect(screen.getByText("Pre-upgrade")).toBeTruthy();
+  });
+
+  it("aborts the previous agent request and ignores its late response", async () => {
+    const oldRequest = deferred<ReturnType<typeof listResponse>>();
+    let oldSignal: AbortSignal | undefined;
+    apiMock.mockImplementation(
+      (path: string, init?: { signal?: AbortSignal }) => {
+        if (path.includes("agent-old")) {
+          oldSignal = init?.signal;
+          return oldRequest.promise;
+        }
+        return Promise.resolve(
+          listResponse([
+            {
+              ...BACKUP,
+              id: "44444444-4444-4444-8444-444444444444",
+            },
+          ]),
+        );
+      },
+    );
+
+    const view = renderPanel({ agentId: "agent-old" });
+    view.rerender(
+      <ElizaAgentBackupsPanel
+        agentId="agent-new"
+        agentName="New agent"
+        status="running"
+      />,
+    );
+
+    expect(await screen.findByText("Backup ID: 44444444")).toBeTruthy();
+    expect(oldSignal?.aborted).toBe(true);
+
+    await act(async () => {
+      oldRequest.resolve(listResponse([OLD_BACKUP]));
+      await oldRequest.promise;
+    });
+
+    expect(screen.queryByText("Backup ID: 22222222")).toBeNull();
+    expect(screen.getByText("Backup ID: 44444444")).toBeTruthy();
+  });
+
+  it("hides the previous agent's backups before the replacement request settles", async () => {
+    const nextRequest = deferred<ReturnType<typeof listResponse>>();
+    apiMock.mockImplementation((path: string) =>
+      path.includes("agent-new")
+        ? nextRequest.promise
+        : Promise.resolve(listResponse()),
+    );
+
+    const view = renderPanel({ agentId: "agent-old" });
+    expect(await screen.findByText("Backup ID: 11111111")).toBeTruthy();
+
+    view.rerender(
+      <ElizaAgentBackupsPanel
+        agentId="agent-new"
+        agentName="New agent"
+        status="running"
+      />,
+    );
+
+    expect(screen.queryByText("Backup ID: 11111111")).toBeNull();
+    expect(screen.getByRole("status").textContent).toContain("Loading backups");
+
+    await act(async () => {
+      nextRequest.resolve(listResponse([]));
+      await nextRequest.promise;
+    });
+    expect(await screen.findByText("No backups yet")).toBeTruthy();
+  });
+
+  it("aborts an in-flight list request when the panel unmounts", () => {
+    let signal: AbortSignal | undefined;
+    apiMock.mockImplementation(
+      (_path: string, init?: { signal?: AbortSignal }) => {
+        signal = init?.signal;
+        return new Promise(() => undefined);
+      },
+    );
+
+    const view = renderPanel();
+    view.unmount();
+
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it("requires explicit confirmation and cancel performs no restore", async () => {
+    const user = userEvent.setup();
+    apiMock.mockResolvedValue(listResponse());
+    renderPanel();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Restore latest" }),
+    );
+
+    const dialog = await screen.findByRole("alertdialog");
+    expect(within(dialog).getByText("Restore this backup?")).toBeTruthy();
+    expect(apiMock).toHaveBeenCalledTimes(1);
+
+    await user.click(within(dialog).getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    expect(apiMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides historical restore actions when an agent is stopped", async () => {
+    apiMock.mockResolvedValue(listResponse([OLD_BACKUP, BACKUP]));
+
+    renderPanel({ status: "sleeping" });
+
+    expect(
+      await screen.findByText("Historical restores require a running agent."),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Restore this backup" }),
+    ).toBeNull();
+    expect(screen.getByRole("button", { name: "Restore latest" })).toBeTruthy();
+  });
+
+  it("keeps restore failures visible inside the confirmation dialog", async () => {
+    const user = userEvent.setup();
+    apiMock.mockImplementation((path: string) => {
+      if (path.endsWith("/restore")) {
+        return Promise.reject(new Error("Restore bridge unavailable"));
+      }
+      return Promise.resolve(listResponse());
+    });
+    renderPanel();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Restore latest" }),
+    );
+    const dialog = await screen.findByRole("alertdialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: "Restore backup" }),
+    );
+
+    expect((await within(dialog).findByRole("alert")).textContent).toContain(
+      "Restore bridge unavailable",
+    );
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+    expect(toastMocks.error).toHaveBeenCalledWith("Restore bridge unavailable");
+  });
+
+  it("rejects a malformed restore success and does not refresh the list", async () => {
+    const user = userEvent.setup();
+    apiMock.mockImplementation((path: string) =>
+      Promise.resolve(
+        path.endsWith("/restore")
+          ? { success: true, data: {} }
+          : listResponse(),
+      ),
+    );
+    renderPanel();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Restore latest" }),
+    );
+    const dialog = await screen.findByRole("alertdialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: "Restore backup" }),
+    );
+
+    expect((await within(dialog).findByRole("alert")).textContent).toContain(
+      "Restore response contained an invalid backup result",
+    );
+    expect(apiMock).toHaveBeenCalledTimes(2);
+    expect(toastMocks.success).not.toHaveBeenCalled();
+  });
+
+  it("shows restore progress, refreshes after success, and never reloads the page", async () => {
+    const user = userEvent.setup();
+    const restoreRequest = deferred<ReturnType<typeof restoreResponse>>();
+    apiMock.mockImplementation((path: string) =>
+      path.endsWith("/restore")
+        ? restoreRequest.promise
+        : Promise.resolve(listResponse()),
+    );
+    renderPanel();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Restore latest" }),
+    );
+    const dialog = await screen.findByRole("alertdialog");
+    await user.click(
+      within(dialog).getByRole("button", { name: "Restore backup" }),
+    );
+
+    expect(
+      within(dialog)
+        .getByRole("button", { name: "Restoring…" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(apiMock).toHaveBeenLastCalledWith(
+      "/api/v1/eliza/agents/agent-1/restore",
+      expect.objectContaining({
+        method: "POST",
+        json: { backupId: BACKUP.id },
+        signal: expect.anything(),
+      }),
+    );
+
+    await act(async () => {
+      restoreRequest.resolve(restoreResponse());
+      await restoreRequest.promise;
+    });
+
+    expect(
+      await screen.findByText("Backup restored successfully."),
+    ).toBeTruthy();
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+    await waitFor(() => expect(apiMock).toHaveBeenCalledTimes(3));
+    expect(toastMocks.success).toHaveBeenCalledWith(
+      "Backup restored successfully.",
+    );
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
+  it("aborts a restore when the agent changes and suppresses stale success", async () => {
+    const user = userEvent.setup();
+    const restoreRequest = deferred<ReturnType<typeof restoreResponse>>();
+    let restoreSignal: AbortSignal | undefined;
+    apiMock.mockImplementation(
+      (path: string, init?: { signal?: AbortSignal }) => {
+        if (path.endsWith("/restore")) {
+          restoreSignal = init?.signal;
+          return restoreRequest.promise;
+        }
+        if (path.includes("agent-new"))
+          return Promise.resolve(listResponse([]));
+        return Promise.resolve(listResponse());
+      },
+    );
+    const view = renderPanel({ agentId: "agent-old" });
+
+    await user.click(
+      await screen.findByRole("button", { name: "Restore latest" }),
+    );
+    await user.click(
+      within(await screen.findByRole("alertdialog")).getByRole("button", {
+        name: "Restore backup",
+      }),
+    );
+    view.rerender(
+      <ElizaAgentBackupsPanel
+        agentId="agent-new"
+        agentName="New agent"
+        status="running"
+      />,
+    );
+
+    expect(await screen.findByText("No backups yet")).toBeTruthy();
+    expect(restoreSignal?.aborted).toBe(true);
+    await act(async () => {
+      restoreRequest.resolve(restoreResponse());
+      await restoreRequest.promise;
+    });
+
+    expect(screen.queryByText("Backup restored successfully.")).toBeNull();
+    expect(toastMocks.success).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/cloud/instances/components/eliza-agent-backups-panel.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agent-backups-panel.tsx
@@ -1,11 +1,23 @@
 "use client";
 
 /**
- * Backups panel for a cloud agent instance: lists snapshots with sizes/ages and
- * restore actions.
+ * Lists authoritative backup metadata for one cloud agent and confirms restore
+ * requests without allowing superseded agent responses to update the panel.
  */
 import { formatByteSize } from "@elizaos/shared/utils/format";
-import { Badge, BrandButton, BrandCard, Skeleton } from "@elizaos/ui/cloud-ui";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Badge,
+  BrandButton,
+  BrandCard,
+  Skeleton,
+} from "@elizaos/ui/cloud-ui";
 import { formatDistanceToNowStrict } from "date-fns";
 import {
   AlertTriangle,
@@ -15,8 +27,9 @@ import {
   RefreshCw,
   RotateCcw,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { api } from "../../lib/api-client";
 
 interface ElizaAgentBackupsPanelProps {
   agentId: string;
@@ -24,30 +37,142 @@ interface ElizaAgentBackupsPanelProps {
   status: string;
 }
 
+const SNAPSHOT_TYPES = [
+  "auto",
+  "manual",
+  "pre-shutdown",
+  "pre-delete",
+  "pre-upgrade",
+  "pre-move",
+] as const;
+
+type SnapshotType = (typeof SNAPSHOT_TYPES)[number];
+
 interface BackupRecord {
   id: string;
-  snapshotType: "auto" | "manual" | "pre-shutdown";
+  snapshotType: SnapshotType;
   sizeBytes: number | null;
   createdAt: string;
 }
 
-interface BackupsApiResponse {
-  success?: boolean;
-  error?: string;
-  data?: BackupRecord[];
+interface RestoreOutcome {
+  kind: "success" | "error";
+  message: string;
 }
 
-const SNAPSHOT_TYPE_LABELS: Record<BackupRecord["snapshotType"], string> = {
-  auto: "Auto",
-  manual: "Manual",
-  "pre-shutdown": "Pre-shutdown",
+const SNAPSHOT_TYPE_PRESENTATION: Record<
+  SnapshotType,
+  { label: string; className: string }
+> = {
+  auto: {
+    label: "Auto",
+    className: "border-border bg-bg-muted text-muted-strong",
+  },
+  manual: {
+    label: "Manual",
+    className: "border-accent/40 bg-accent-subtle text-accent",
+  },
+  "pre-shutdown": {
+    label: "Pre-shutdown",
+    className: "border-border-strong bg-surface text-txt-strong",
+  },
+  "pre-delete": {
+    label: "Pre-delete",
+    className:
+      "border-status-warning/40 bg-status-warning-bg text-status-warning",
+  },
+  "pre-upgrade": {
+    label: "Pre-upgrade",
+    className:
+      "border-status-warning/40 bg-status-warning-bg text-status-warning",
+  },
+  "pre-move": {
+    label: "Pre-move",
+    className: "border-border-strong bg-surface text-muted-strong",
+  },
 };
 
-const SNAPSHOT_TYPE_STYLES: Record<BackupRecord["snapshotType"], string> = {
-  auto: "border-border bg-bg-muted text-muted-strong",
-  manual: "border-accent/40 bg-accent-subtle text-accent",
-  "pre-shutdown": "border-border-strong bg-surface text-txt-strong",
-};
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSnapshotType(value: unknown): value is SnapshotType {
+  return SNAPSHOT_TYPES.some((snapshotType) => snapshotType === value);
+}
+
+function isValidCreatedAt(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.includes("T") &&
+    Number.isFinite(Date.parse(value))
+  );
+}
+
+function parseBackupRecord(value: unknown): BackupRecord {
+  if (
+    !isRecord(value) ||
+    typeof value.id !== "string" ||
+    value.id.trim().length === 0 ||
+    !isSnapshotType(value.snapshotType) ||
+    !(
+      value.sizeBytes === null ||
+      (typeof value.sizeBytes === "number" &&
+        Number.isSafeInteger(value.sizeBytes) &&
+        value.sizeBytes >= 0)
+    ) ||
+    !isValidCreatedAt(value.createdAt)
+  ) {
+    throw new Error("Backup response contained an invalid backup record");
+  }
+
+  return {
+    id: value.id,
+    snapshotType: value.snapshotType,
+    sizeBytes: value.sizeBytes,
+    createdAt: value.createdAt,
+  };
+}
+
+function parseBackupsResponse(payload: unknown): BackupRecord[] {
+  if (
+    !isRecord(payload) ||
+    payload.success !== true ||
+    !Array.isArray(payload.data)
+  ) {
+    throw new Error("Backup response did not include a successful data list");
+  }
+  return payload.data.map(parseBackupRecord);
+}
+
+function parseRestoreResponse(
+  payload: unknown,
+  expectedBackupId: string,
+): void {
+  if (
+    !isRecord(payload) ||
+    payload.success !== true ||
+    !isRecord(payload.data)
+  ) {
+    throw new Error("Restore response did not include a successful result");
+  }
+
+  const { restoredFromBackupId, snapshotType, createdAt } = payload.data;
+  if (
+    restoredFromBackupId !== expectedBackupId ||
+    !isSnapshotType(snapshotType) ||
+    !isValidCreatedAt(createdAt)
+  ) {
+    throw new Error("Restore response contained an invalid backup result");
+  }
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
 function formatTimestamp(value: string): {
   absolute: string;
@@ -66,117 +191,178 @@ export function ElizaAgentBackupsPanel({
   status,
 }: ElizaAgentBackupsPanelProps) {
   const [backups, setBackups] = useState<BackupRecord[]>([]);
+  const [listAgentId, setListAgentId] = useState(agentId);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [restoreTarget, setRestoreTarget] = useState<BackupRecord | null>(null);
   const [activeRestoreTarget, setActiveRestoreTarget] = useState<string | null>(
     null,
   );
+  const [restoreOutcome, setRestoreOutcome] = useState<RestoreOutcome | null>(
+    null,
+  );
+  const listGenerationRef = useRef(0);
+  const listAbortRef = useRef<AbortController | null>(null);
+  const restoreGenerationRef = useRef(0);
+  const restoreAbortRef = useRef<AbortController | null>(null);
 
   const isRunning = status === "running";
   const isBusy = status === "provisioning";
 
   const fetchBackups = useCallback(async () => {
+    const generation = ++listGenerationRef.current;
+    listAbortRef.current?.abort();
+    const controller = new AbortController();
+    listAbortRef.current = controller;
     setLoading(true);
     setError(null);
 
     try {
-      const response = await fetch(`/api/v1/eliza/agents/${agentId}/backups`, {
-        cache: "no-store",
-      });
-      const payload: BackupsApiResponse = await response
-        .json()
-        .catch(() => ({}));
-
-      if (!response.ok || !payload.success) {
-        throw new Error(payload.error ?? `HTTP ${response.status}`);
+      const payload = await api<unknown>(
+        `/api/v1/eliza/agents/${agentId}/backups`,
+        { cache: "no-store", signal: controller.signal },
+      );
+      const nextBackups = parseBackupsResponse(payload);
+      if (
+        controller.signal.aborted ||
+        generation !== listGenerationRef.current
+      ) {
+        return;
       }
 
-      setBackups(Array.isArray(payload.data) ? payload.data : []);
-    } catch (fetchError) {
-      setError(
-        fetchError instanceof Error ? fetchError.message : String(fetchError),
+      setBackups(nextBackups);
+      setListAgentId(agentId);
+      setRestoreTarget((target) =>
+        target
+          ? (nextBackups.find((backup) => backup.id === target.id) ?? null)
+          : null,
       );
+    } catch (fetchError) {
+      // error-policy:J4 only the active agent request reaches the visible
+      // panel error; aborted and superseded requests remain invisible.
+      if (
+        controller.signal.aborted ||
+        generation !== listGenerationRef.current ||
+        isAbortError(fetchError)
+      ) {
+        return;
+      }
+      setError(errorMessage(fetchError));
+      setListAgentId(agentId);
     } finally {
-      setLoading(false);
+      if (generation === listGenerationRef.current) setLoading(false);
     }
   }, [agentId]);
 
   useEffect(() => {
-    fetchBackups();
+    setBackups([]);
+    setError(null);
+    setLoading(true);
+    setRestoreTarget(null);
+    setActiveRestoreTarget(null);
+    setRestoreOutcome(null);
+    void fetchBackups();
+
+    return () => {
+      listGenerationRef.current += 1;
+      restoreGenerationRef.current += 1;
+      listAbortRef.current?.abort();
+      restoreAbortRef.current?.abort();
+    };
   }, [fetchBackups]);
 
+  const visibleBackups = listAgentId === agentId ? backups : [];
   const latestBackup = useMemo(
     () =>
-      backups.reduce<BackupRecord | null>((latest, backup) => {
+      visibleBackups.reduce<BackupRecord | null>((latest, backup) => {
         if (!latest) return backup;
-        return new Date(backup.createdAt) > new Date(latest.createdAt)
+        return Date.parse(backup.createdAt) > Date.parse(latest.createdAt)
           ? backup
           : latest;
       }, null),
-    [backups],
+    [visibleBackups],
   );
   const manualCount = useMemo(
-    () => backups.filter((backup) => backup.snapshotType === "manual").length,
-    [backups],
+    () =>
+      visibleBackups.filter((backup) => backup.snapshotType === "manual")
+        .length,
+    [visibleBackups],
   );
   const preShutdownCount = useMemo(
     () =>
-      backups.filter((backup) => backup.snapshotType === "pre-shutdown").length,
-    [backups],
+      visibleBackups.filter((backup) => backup.snapshotType === "pre-shutdown")
+        .length,
+    [visibleBackups],
   );
 
-  const restoreBackup = useCallback(
-    async (backupId?: string) => {
-      if (!latestBackup) {
-        toast.error("No backups available to restore");
+  const restoreBackup = useCallback(async () => {
+    if (!restoreTarget || isBusy) return;
+    if (!isRunning && restoreTarget.id !== latestBackup?.id) {
+      setRestoreOutcome({
+        kind: "error",
+        message: "Stopped agents can only restore the latest backup",
+      });
+      return;
+    }
+
+    const generation = ++restoreGenerationRef.current;
+    restoreAbortRef.current?.abort();
+    const controller = new AbortController();
+    restoreAbortRef.current = controller;
+    setActiveRestoreTarget(restoreTarget.id);
+    setRestoreOutcome(null);
+
+    try {
+      const payload = await api<unknown>(
+        `/api/v1/eliza/agents/${agentId}/restore`,
+        {
+          method: "POST",
+          json: { backupId: restoreTarget.id },
+          signal: controller.signal,
+        },
+      );
+      parseRestoreResponse(payload, restoreTarget.id);
+      if (
+        controller.signal.aborted ||
+        generation !== restoreGenerationRef.current
+      ) {
         return;
       }
 
-      if (!isRunning && backupId && backupId !== latestBackup.id) {
-        toast.error("Stopped agents can only restore the latest backup");
+      const message = "Backup restored successfully.";
+      setRestoreOutcome({ kind: "success", message });
+      setRestoreTarget(null);
+      toast.success(message);
+      void fetchBackups();
+    } catch (restoreError) {
+      // error-policy:J4 restore failure stays inside its confirmation boundary;
+      // an agent switch or unmount aborts it without leaking stale feedback.
+      if (
+        controller.signal.aborted ||
+        generation !== restoreGenerationRef.current ||
+        isAbortError(restoreError)
+      ) {
         return;
       }
-
-      const targetBackupId = backupId ?? latestBackup.id;
-      setActiveRestoreTarget(targetBackupId);
-
-      try {
-        const response = await fetch(
-          `/api/v1/eliza/agents/${agentId}/restore`,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(backupId ? { backupId } : {}),
-          },
-        );
-        const payload = await response.json().catch(() => ({}));
-
-        if (!response.ok || !(payload as { success?: boolean }).success) {
-          throw new Error(
-            (payload as { error?: string }).error ?? `HTTP ${response.status}`,
-          );
-        }
-
-        toast.success(
-          isRunning
-            ? "Backup restored"
-            : "Latest backup restored. The agent was restarted with that state.",
-        );
-
-        await fetchBackups();
-        window.location.reload();
-      } catch (restoreError) {
-        toast.error(
-          restoreError instanceof Error
-            ? restoreError.message
-            : String(restoreError),
-        );
-      } finally {
+      const message = errorMessage(restoreError);
+      setRestoreOutcome({ kind: "error", message });
+      toast.error(message);
+    } finally {
+      if (generation === restoreGenerationRef.current) {
         setActiveRestoreTarget(null);
       }
-    },
-    [agentId, fetchBackups, isRunning, latestBackup],
-  );
+    }
+  }, [agentId, fetchBackups, isBusy, isRunning, latestBackup, restoreTarget]);
+
+  const restoreDisallowed =
+    !restoreTarget ||
+    isBusy ||
+    (!isRunning && restoreTarget.id !== latestBackup?.id);
+
+  function requestRestore(backup: BackupRecord) {
+    setRestoreOutcome(null);
+    setRestoreTarget(backup);
+  }
 
   return (
     <BrandCard className="relative" cornerSize="sm">
@@ -184,7 +370,10 @@ export function ElizaAgentBackupsPanel({
         <div className="flex flex-col gap-4 border-b border-border pb-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
             <div className="mb-1 flex flex-wrap items-center gap-2">
-              <span className="inline-block h-2 w-2 rounded-full bg-accent" />
+              <span
+                aria-hidden="true"
+                className="inline-block h-2 w-2 rounded-full bg-accent"
+              />
               <h2 className="font-mono text-xl font-normal text-txt-strong">
                 Backups &amp; History
               </h2>
@@ -200,8 +389,14 @@ export function ElizaAgentBackupsPanel({
           </div>
 
           <div className="flex flex-wrap items-center gap-2">
-            <BrandButton variant="outline" size="sm" onClick={fetchBackups}>
+            <BrandButton
+              variant="outline"
+              size="sm"
+              onClick={() => void fetchBackups()}
+              disabled={loading}
+            >
               <RefreshCw
+                aria-hidden="true"
                 className={`h-4 w-4 ${loading ? "animate-spin" : ""}`}
               />
               Refresh
@@ -209,22 +404,38 @@ export function ElizaAgentBackupsPanel({
             <BrandButton
               variant="outline"
               size="sm"
-              onClick={() => restoreBackup()}
-              disabled={!latestBackup || !!activeRestoreTarget || isBusy}
+              onClick={() => {
+                if (latestBackup) requestRestore(latestBackup);
+              }}
+              disabled={
+                loading || !latestBackup || !!activeRestoreTarget || isBusy
+              }
             >
               {activeRestoreTarget === latestBackup?.id ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
+                <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
               ) : (
-                <RotateCcw className="h-4 w-4" />
+                <RotateCcw aria-hidden="true" className="h-4 w-4" />
               )}
               Restore latest
             </BrandButton>
           </div>
         </div>
 
-        {!isRunning && latestBackup && (
+        {restoreOutcome?.kind === "success" ? (
+          <div
+            className="border border-status-success/30 bg-status-success-bg p-4 text-sm text-status-success"
+            role="status"
+          >
+            {restoreOutcome.message}
+          </div>
+        ) : null}
+
+        {!isRunning && latestBackup ? (
           <div className="flex items-start gap-3 border border-status-warning/30 bg-status-warning-bg p-4">
-            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-status-warning" />
+            <AlertTriangle
+              aria-hidden="true"
+              className="mt-0.5 h-4 w-4 shrink-0 text-status-warning"
+            />
             <div className="space-y-1">
               <p className="text-sm text-status-warning">
                 This agent is not currently running.
@@ -236,20 +447,24 @@ export function ElizaAgentBackupsPanel({
               </p>
             </div>
           </div>
-        )}
+        ) : null}
 
-        {isBusy && (
+        {isBusy ? (
           <div className="flex items-start gap-3 border border-border-strong bg-bg-muted p-4">
-            <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin text-muted-strong" />
+            <Loader2
+              aria-hidden="true"
+              className="mt-0.5 h-4 w-4 shrink-0 animate-spin text-muted-strong"
+            />
             <p className="text-sm text-txt-strong">
               Provisioning is in progress. Wait for the agent to finish starting
               before restoring.
             </p>
           </div>
-        )}
+        ) : null}
 
-        {loading ? (
-          <div className="space-y-4">
+        {loading || listAgentId !== agentId ? (
+          <div className="space-y-4" role="status" aria-live="polite">
+            <span className="sr-only">Loading backups</span>
             <div className="grid gap-4 md:grid-cols-3">
               <Skeleton className="h-24 rounded-sm" />
               <Skeleton className="h-24 rounded-sm" />
@@ -259,25 +474,31 @@ export function ElizaAgentBackupsPanel({
             <Skeleton className="h-16 rounded-sm" />
           </div>
         ) : error ? (
-          <div className="py-8 text-center">
-            <History className="mx-auto mb-3 h-8 w-8 text-muted" />
+          <div className="py-8 text-center" role="alert">
+            <History
+              aria-hidden="true"
+              className="mx-auto mb-3 h-8 w-8 text-muted"
+            />
             <p className="mb-1 text-sm text-destructive">
               Failed to load backups
             </p>
-            <p className="text-xs text-muted">{error}</p>
+            <p className="break-words text-xs text-muted">{error}</p>
             <BrandButton
               variant="outline"
               size="sm"
-              onClick={fetchBackups}
+              onClick={() => void fetchBackups()}
               className="mt-4"
             >
-              <RefreshCw className="mr-2 h-4 w-4" />
+              <RefreshCw aria-hidden="true" className="mr-2 h-4 w-4" />
               Retry
             </BrandButton>
           </div>
-        ) : backups.length === 0 ? (
+        ) : visibleBackups.length === 0 ? (
           <div className="py-10 text-center">
-            <DatabaseBackup className="mx-auto mb-3 h-8 w-8 text-muted" />
+            <DatabaseBackup
+              aria-hidden="true"
+              className="mx-auto mb-3 h-8 w-8 text-muted"
+            />
             <p className="text-sm text-muted-strong">No backups yet</p>
             <p className="mt-1 text-xs text-muted">
               Run the agent and save a snapshot to create the first restore
@@ -289,7 +510,7 @@ export function ElizaAgentBackupsPanel({
             <div className="grid gap-4 md:grid-cols-3">
               <div className="border border-border bg-bg-muted p-4 text-center">
                 <p className="font-mono text-2xl font-medium text-txt-strong">
-                  {backups.length}
+                  {visibleBackups.length}
                 </p>
                 <p className="mt-1 font-mono text-xs uppercase tracking-wider text-muted-strong">
                   Total backups
@@ -314,10 +535,12 @@ export function ElizaAgentBackupsPanel({
             </div>
 
             <div className="space-y-3">
-              {backups.map((backup) => {
+              {visibleBackups.map((backup) => {
                 const timestamp = formatTimestamp(backup.createdAt);
                 const isLatest = backup.id === latestBackup?.id;
                 const isRestoring = activeRestoreTarget === backup.id;
+                const presentation =
+                  SNAPSHOT_TYPE_PRESENTATION[backup.snapshotType];
 
                 return (
                   <div
@@ -327,21 +550,19 @@ export function ElizaAgentBackupsPanel({
                     <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
                       <div className="min-w-0 space-y-2">
                         <div className="flex flex-wrap items-center gap-2">
-                          {isLatest && (
+                          {isLatest ? (
                             <Badge
                               variant="outline"
                               className="border-status-success/40 bg-status-success-bg text-status-success"
                             >
                               Latest
                             </Badge>
-                          )}
+                          ) : null}
                           <Badge
                             variant="outline"
-                            className={
-                              SNAPSHOT_TYPE_STYLES[backup.snapshotType]
-                            }
+                            className={presentation.className}
                           >
-                            {SNAPSHOT_TYPE_LABELS[backup.snapshotType]}
+                            {presentation.label}
                           </Badge>
                         </div>
 
@@ -371,13 +592,19 @@ export function ElizaAgentBackupsPanel({
                           <BrandButton
                             variant="outline"
                             size="sm"
-                            onClick={() => restoreBackup(backup.id)}
-                            disabled={!!activeRestoreTarget}
+                            onClick={() => requestRestore(backup)}
+                            disabled={loading || !!activeRestoreTarget}
                           >
                             {isRestoring ? (
-                              <Loader2 className="h-4 w-4 animate-spin" />
+                              <Loader2
+                                aria-hidden="true"
+                                className="h-4 w-4 animate-spin"
+                              />
                             ) : (
-                              <RotateCcw className="h-4 w-4" />
+                              <RotateCcw
+                                aria-hidden="true"
+                                className="h-4 w-4"
+                              />
                             )}
                             Restore this backup
                           </BrandButton>
@@ -400,6 +627,64 @@ export function ElizaAgentBackupsPanel({
           </>
         )}
       </div>
+
+      <AlertDialog
+        open={restoreTarget !== null && listAgentId === agentId}
+        onOpenChange={(open) => {
+          if (!open && !activeRestoreTarget) {
+            setRestoreTarget(null);
+            setRestoreOutcome(null);
+          }
+        }}
+      >
+        <AlertDialogContent className="border-border bg-card">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-txt-strong">
+              Restore this backup?
+            </AlertDialogTitle>
+            <AlertDialogDescription className="text-muted">
+              This replaces the current state for {agentName || "this agent"}
+              {restoreTarget ? (
+                <span className="mt-2 block font-mono text-xs text-muted-strong">
+                  {SNAPSHOT_TYPE_PRESENTATION[restoreTarget.snapshotType].label}{" "}
+                  backup from{" "}
+                  {formatTimestamp(restoreTarget.createdAt).absolute}
+                </span>
+              ) : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          {restoreOutcome?.kind === "error" ? (
+            <div
+              className="border border-destructive/20 bg-destructive-subtle p-3 text-sm text-destructive"
+              role="alert"
+            >
+              {restoreOutcome.message}
+            </div>
+          ) : null}
+
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              className="border-border bg-transparent text-txt hover:bg-surface"
+              disabled={!!activeRestoreTarget}
+            >
+              Cancel
+            </AlertDialogCancel>
+            <BrandButton
+              type="button"
+              onClick={() => void restoreBackup()}
+              disabled={restoreDisallowed || !!activeRestoreTarget}
+            >
+              {activeRestoreTarget ? (
+                <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
+              ) : (
+                <RotateCcw aria-hidden="true" className="h-4 w-4" />
+              )}
+              {activeRestoreTarget ? "Restoring…" : "Restore backup"}
+            </BrandButton>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </BrandCard>
   );
 }

--- a/packages/ui/src/services/local-inference/routing-preferences.ts
+++ b/packages/ui/src/services/local-inference/routing-preferences.ts
@@ -1,13 +1,9 @@
 /**
- * Re-exports the inference routing-policy preferences (local vs cloud provider
- * selection) from the local-inference shared surface.
+ * Re-exports the browser-safe inference routing preference types used by the
+ * UI API client. Persistence remains server-owned because the shared runtime
+ * module imports Node filesystem, crypto, path, and host APIs.
  */
-export {
-  DEFAULT_ROUTING_POLICY,
-  type RoutingPolicy,
-  type RoutingPreferences,
-  readRoutingPreferences,
-  setPolicy,
-  setPreferredProvider,
-  writeRoutingPreferences,
-} from "@elizaos/shared/local-inference/routing-preferences";
+export type {
+  RoutingPolicy,
+  RoutingPreferences,
+} from "@elizaos/shared/local-inference";


### PR DESCRIPTION
Promotes current `develop` to `main` after the final synchronization release.

Voice/text-adjacent changes:
- #20592 starts personal Shared prewarm immediately and overlaps it with transcription and route preparation, while awaiting it only for Shared
- #20591 hardens bounded gateway token renewal and refresh timing

Also includes the already-merged supporting fixes currently in `develop`. The previous exact production SHA `0c54af1bed3adb1eb59ccb1bb9fcf0610b72bcdb` is healthy; this release advances it with the latest latency/resilience work.