### PR TITLE
fix(core): owner verb-noun candidate permutations resolve to their umbrellas instead of collapsing the planner surface

### DIFF
--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -296,6 +296,26 @@ const CANDIDATE_ACTION_PARENT_ALIASES: Record<string, readonly string[]> = {
 	TRIP_SAVINGS_PLAN: ["OWNER_GOALS"],
 	SEARCH_CHATS: ["MESSAGE"],
 	SEARCH_CHAT: ["MESSAGE"],
+	// OWNER_<VERB>_<NOUN> permutations: the registered owner umbrellas are
+	// noun-first (OWNER_TODOS, promoted OWNER_TODOS_DELETE), but Stage-1
+	// routinely inverts to verb-first ("actually delete it" one turn after a
+	// todo create emitted candidate OWNER_DELETE_TODO, live trajectory
+	// tj-85d166dc4710f0 — it resolved to nothing, the candidate narrow
+	// collapsed the surface to VIEWS, and the planner invented an undeclared
+	// "delete-todo" view capability). Same dual-owner hints as the noun-first
+	// entries above.
+	OWNER_ADD_TODO: ["OWNER_TODOS", "TODO"],
+	OWNER_CREATE_TODO: ["OWNER_TODOS", "TODO"],
+	OWNER_DELETE_TODO: ["OWNER_TODOS", "TODO"],
+	OWNER_COMPLETE_TODO: ["OWNER_TODOS", "TODO"],
+	OWNER_DELETE_GOAL: ["OWNER_GOALS"],
+	OWNER_CREATE_GOAL: ["OWNER_GOALS"],
+	OWNER_DELETE_REMINDER: ["OWNER_REMINDERS", "TRIGGER"],
+	OWNER_CREATE_REMINDER: ["OWNER_REMINDERS", "TRIGGER"],
+	OWNER_DELETE_ALARM: ["OWNER_ALARMS", "TRIGGER"],
+	OWNER_CREATE_ALARM: ["OWNER_ALARMS", "TRIGGER"],
+	OWNER_DELETE_ROUTINE: ["OWNER_ROUTINES", "TRIGGER"],
+	OWNER_CREATE_ROUTINE: ["OWNER_ROUTINES", "TRIGGER"],
 	// Bare "SEARCH" is a routine Stage-1 invention for open-web asks ("latest
 	// merged PR on develop, search for it" emitted candidate SEARCH, live
 	// trajectory tj-df4f61ac001a27). It resolved to nothing, the candidate


### PR DESCRIPTION
## What

Stage-1 routinely inverts the registered noun-first owner action names into verb-first inventions: "actually delete it" one turn after a todo create emitted candidate `OWNER_DELETE_TODO` (registered surface: `OWNER_TODOS` / promoted `OWNER_TODOS_DELETE`). The invented name resolved to nothing (F21 class), the candidate narrow collapsed the planner surface to `[VIEWS]` (60 parents omitted), and the planner invented an undeclared `delete-todo` view capability — the turn failed and a later iteration asked "which contact?" while the just-created todo sat untouched (live trajectory tj-85d166dc4710f0).

Adds the OWNER_\<VERB\>_\<NOUN\> permutation family to `CANDIDATE_ACTION_PARENT_ALIASES` with the same dual-owner hints as the existing noun-first entries (todos → OWNER_TODOS+TODO; reminders/alarms/routines → owner umbrella + always-registered TRIGGER; goals → OWNER_GOALS only, matching the deliberate goals fail-closed policy).

## Evidence

- Live before/after under the exact failing turn order (contact-delete clarify → todo create → "actually delete it"): VIEWS flail + "which contact?" → post-fix "deleted oil the canon hinge." with the todo verified gone on read-back.
- action-retrieval + action-tiering suites 65/65; core typecheck + node build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:9b0e1bbd44d134a63bb9d0cb0c33337cb2cf44df -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - chat-behavior change; before/after transcripts + trajectory id in PR body

<!-- evidence-row:after-screenshots -->
- [ ] N/A - chat-behavior change; before/after transcripts + trajectory id in PR body

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - live transcripts serve as walkthrough

<!-- evidence-row:backend-logs -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:llm-trajectory -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - todo rows verified via live read-backs

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces
