### PR TITLE
fix(cloud): make Personal Shared edge flag toggleable

### DIFF
--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -1005,7 +1005,7 @@ describe("cloud-api worker entrypoint", () => {
     );
   });
 
-  test("keeps the Personal Shared edge fail-closed pending a post-migration canary", async () => {
+  test("keeps the Personal Shared edge fail-closed without reserving its secret binding", async () => {
     const config = Bun.TOML.parse(
       await Bun.file(new URL("../wrangler.toml", import.meta.url)).text(),
     ) as {
@@ -1044,7 +1044,7 @@ describe("cloud-api worker entrypoint", () => {
     expect(config.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED).toBe("false");
     expect(
       config.env?.staging?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED,
-    ).toBe("false");
+    ).toBeUndefined();
     expect(
       config.env?.production?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED,
     ).toBe("false");

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -460,10 +460,9 @@ SHARED_ELIZA_AGENT_RUNTIME = "true"
 # Staging exercises the strongly invalidated sender projection while default
 # and production stay on canonical resolution until the live latency matrix passes.
 PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "true"
-# Keep the edge connector fail-closed across the first deployment that creates
-# its Durable Object class. Activation requires a later protected deployment
-# after the post-migration version and live Telegram prerequisites are proven.
-PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED = "false"
+# The protected staging cutover owns PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED as
+# a secret binding. Named-environment vars do not inherit, so leaving only the
+# staging binding absent avoids a name collision while absence remains off.
 # Emit per-turn inference spans at info for the staging latency matrix without
 # changing production log volume or recording prompt content.
 ELIZA_INFERENCE_TIMING = "info"

--- a/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
@@ -110,7 +110,7 @@ describe("Personal Shared Telegram edge deploy", () => {
     expect(apply.run).not.toContain('grep -qi "not found"');
   });
 
-  test("keeps every tracked Worker environment fail-closed", () => {
+  test("keeps every tracked Worker environment fail-closed without colliding with the activation secret", () => {
     const config = Bun.TOML.parse(
       readFileSync(
         new URL("packages/cloud/api/wrangler.toml", repoRoot),
@@ -123,7 +123,7 @@ describe("Personal Shared Telegram edge deploy", () => {
     expect(config.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED).toBe("false");
     expect(
       config.env?.staging?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED,
-    ).toBe("false");
+    ).toBeUndefined();
     expect(
       config.env?.production?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED,
     ).toBe("false");


### PR DESCRIPTION
Closes #20601

## What changed

- Removes `PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED=false` only from `env.staging.vars`.
- Keeps the default and production bindings explicitly `false`.
- Preserves fail-closed staging runtime behavior because only the exact string `true` enables the edge.
- Leaves the staging binding name available for the protected activation workflow to own as a secret.
- Updates config and workflow contract tests to prevent this collision from returning.

Cloudflare documents `vars` as non-inheritable, so the top-level false does not reserve the named staging environment binding.

## Live ground truth

Protected activation run `31964655125`, job `95207850774`, validated exact Worker source `ffd044a3a5c91af7d3b174f5572626a5c1cef198` and exact same-source gateway, then failed all three activation attempts with Cloudflare code `10053`:

`Binding name PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED already in use.`

The workflow rollback proved the edge remained off. Production was untouched.

## Exact local proof

Head: `3ced70bd9c4be6cff637c7b431f13904baa3b435`
Base: `9e09e31ea70e981231e8a72365ae2404e20ff234`

- Workflow contract: 4/4, 31 assertions
- Worker config contract: 1/1, 9 assertions
- Cloud API typecheck: PASS
- Production Worker dry bundle: PASS with explicit false binding
- Staging Worker dry bundle: PASS with activation binding absent
- Biome: 2/2 paths
- Diff check: PASS
- UI evidence: N/A, deployment configuration only

## Protected rollout plan

After legitimate review and merge: deploy exact current develop to staging, deploy the same source to gateway-webhook, prove edge enable, prove rollback to off, re-enable, then execute the real Telegram plus Eliza Dev Discord cold/warm, history, memory, WEB_SEARCH, reminder, and duplicate exact-once matrix with logs and domain receipts. Production remains untouched.