### PR TITLE
feat(registry): add plugin-x402-finance@1.0.1 (public source)

### DIFF
--- a/packages/registry/entries/third-party/plugin-x402-finance.json
+++ b/packages/registry/entries/third-party/plugin-x402-finance.json
@@ -1,0 +1,17 @@
+{
+  "package": "plugin-x402-finance",
+  "repository": "github:lokixc84/x402-finance-api",
+  "kind": "plugin",
+  "description": "Base Mainnet token safety + market data via x402 micropayments (USDC). CHECK_TOKEN_SAFETY returns agent_action (block|warn|allow|skip). No API keys.",
+  "homepage": "https://x402-paid-api.x402-finance.workers.dev/llms.txt",
+  "version": "1.0.1",
+  "tags": [
+    "x402",
+    "base",
+    "defi",
+    "security",
+    "token-safety",
+    "micropayments",
+    "usdc"
+  ]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -2175,6 +2175,53 @@
       "kind": "plugin",
       "registryKind": "plugin",
       "directory": null
+    },
+    "plugin-x402-finance": {
+      "git": {
+        "repo": "lokixc84/x402-finance-api",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "plugin-x402-finance",
+        "v0": null,
+        "v1": null,
+        "v2": "1.0.1"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Base Mainnet token safety + market data via x402 micropayments (USDC). CHECK_TOKEN_SAFETY returns agent_action (block|warn|allow|skip). No API keys.",
+      "homepage": "https://x402-paid-api.x402-finance.workers.dev/llms.txt",
+      "topics": [
+        "x402",
+        "base",
+        "defi",
+        "security",
+        "token-safety",
+        "micropayments",
+        "usdc"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
     }
   }
 }


### PR DESCRIPTION
## Resubmission after #20543

### Fixes from maintainer feedback
- Source repo is now **public**: https://github.com/lokixc84/x402-finance-api
- npm `plugin-x402-finance@1.0.1` includes valid `repository` + `homepage`
- Registry JSON has trailing newline
- `bun run --cwd packages/registry validate` + `generate` both pass (46 third-party entries)

### Package
- **npm:** plugin-x402-finance@1.0.1
- **repo:** github:lokixc84/x402-finance-api
- **live API:** https://x402-paid-api.x402-finance.workers.dev/llms.txt