### PR TITLE
fix(personal-assistant): restore formatter compliance

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/calendar.ts
+++ b/plugins/plugin-personal-assistant/src/actions/calendar.ts
@@ -67,7 +67,10 @@ import type {
   CalendarSeriesMasterBinding,
 } from "../lifeops/approval-queue.types.js";
 import { buildApprovalChoiceText } from "../lifeops/choice-markers.js";
-import { resolveDefaultTimeZone } from "../lifeops/defaults.js";
+import {
+  normalizeTimeZone,
+  resolveDefaultTimeZone,
+} from "../lifeops/defaults.js";
 import {
   formatCalendarEventDateTime,
   runLifeOpsJsonModel,
@@ -81,7 +84,6 @@ import {
   buildUtcDateFromLocalParts,
   getZonedDateParts,
 } from "../lifeops/time.js";
-import { normalizeTimeZone } from "../lifeops/defaults.js";
 import {
   computeCreateEventTravelBuffer,
   resolveCreateEventTravelIntent,

--- a/plugins/plugin-personal-assistant/src/lifeops/time-normalize.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/time-normalize.test.ts
@@ -10,7 +10,16 @@ import { getZonedDateParts } from "./time.js";
 
 describe("normalizeTimeZone (canonical)", () => {
   test("UTC spellings normalize to UTC, not the deployment default", () => {
-    for (const alias of ["Z", "z", "zulu", "UTC+0", "GMT+00", "+00:00", "-0000", "Etc/UTC"]) {
+    for (const alias of [
+      "Z",
+      "z",
+      "zulu",
+      "UTC+0",
+      "GMT+00",
+      "+00:00",
+      "-0000",
+      "Etc/UTC",
+    ]) {
       expect(normalizeTimeZone(alias)).toBe("UTC");
     }
   });


### PR DESCRIPTION
Restores the root verify gate after the latest develop changes left two personal-assistant files outside the pinned Biome format. This is a mechanical import/line-wrap repair only; changed-file Biome and git diff checks pass.