### PR TITLE
test(scenarios): expect the paginated unread-notifications call in the github-routes ledger

### DIFF
--- a/packages/scenario-runner/test/scenarios/deterministic-github-actions-routes.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-github-actions-routes.scenario.ts
@@ -791,6 +791,9 @@ async function finalGithubCheck(): Promise<string | undefined> {
       method: "activity.listNotificationsForAuthenticatedUser",
       args: {
         all: false,
+        // fetchAllUnreadNotifications paginates explicitly (#20534); the fake
+        // returns fewer than per_page rows, so the loop stops after page 1.
+        page: 1,
         per_page: 50,
       },
     },

--- a/packages/scenario-runner/test/scenarios/deterministic-github-actions-routes.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-github-actions-routes.scenario.ts
@@ -6,6 +6,10 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { type IAgentRuntime, ModelType, type Plugin } from "@elizaos/core";
+import {
+  type RuntimeWithScenarioModelFixtures,
+  registerStrictActionRouteFixtures,
+} from "@elizaos/core/testing";
 import type {
   CapturedAction,
   ScenarioContext,
@@ -15,10 +19,6 @@ import { scenario } from "@elizaos/scenario-runner/schema";
 import githubPlugin, {
   GitHubService,
 } from "../../../../plugins/plugin-github/src/index.ts";
-import {
-  type RuntimeWithScenarioModelFixtures,
-  registerStrictActionRouteFixtures,
-} from "@elizaos/core/testing";
 
 const REPO = "octo/repo";
 const ISSUE_TITLE = "Deterministic issue";
@@ -791,8 +791,8 @@ async function finalGithubCheck(): Promise<string | undefined> {
       method: "activity.listNotificationsForAuthenticatedUser",
       args: {
         all: false,
-        // fetchAllUnreadNotifications paginates explicitly (#20534); the fake
-        // returns fewer than per_page rows, so the loop stops after page 1.
+        // The unread helper paginates explicitly; this fake returns fewer than
+        // per_page rows, so the loop stops after the first request.
         page: 1,
         per_page: 50,
       },


### PR DESCRIPTION
Closes #20602.

#20534's `fetchAllUnreadNotifications` paginates the unread listing explicitly — `page` always accompanies `per_page` — and the deterministic `github-actions-routes` scenario asserts its fake-Octokit ledger by exact deep equality against args with no `page` key, so the scenario and the `test:pr:e2e` lane fail deterministically on develop. The issue's revert-control establishes the recorded behavior as the intended one, so the expectation moves to match: `page: 1`, with a comment noting the fake returns fewer rows than `per_page`, so the pagination loop stops after the first call (the multi-page path records no further calls in this scenario).

Also folds in two biome repairs (import merge, array line-wrap — no semantic change) for plugin-personal-assistant files the pinned `lint:check` gate requires on the current develop base — the rolling develop-red class documented in #20523.

# Evidence

<!-- evidence-head:ea20806ffabd89d6d3fa8c8bf106eeafb20cfa21 -->

<!-- evidence-row:before-screenshots -->
N/A - deterministic scenario expectation plus format repairs; no rendered UI surface.

<!-- evidence-row:after-screenshots -->
N/A - deterministic scenario expectation plus format repairs; no rendered UI surface.

<!-- evidence-row:walkthrough-video -->
N/A - non-UI change; behavior proven by the failing-before/passing-after scenario runs below.

<!-- evidence-row:backend-logs -->
- [x] [20610-pr20610-verify.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20610-pr20610-verify.log)

```
$ SCENARIO_USE_DETERMINISTIC_MODEL=1 bun run --cwd packages/scenario-runner test:deterministic:e2e --scenario deterministic-github-actions-routes
| deterministic-github-actions-routes | passed | 10806ms |  |
Totals: 1 passed, 0 failed, 0 skipped of 1
```

Root `bun run verify` at this exact head: exit 0. scenario-runner typecheck clean (after rebuilding the stale local core dist that the freshly-merged spoken-text extraction had outdated — noted for reproducibility, not a change in this PR).

<!-- evidence-row:frontend-logs -->
N/A - no frontend surface; the scenario drives the real runtime against a deterministic model with a recorded fake-Octokit ledger.

<!-- evidence-row:llm-trajectory -->
N/A - the scenario runs the deterministic model provider by design (SCENARIO_USE_DETERMINISTIC_MODEL=1); the lane exists precisely to be model-independent.

<!-- evidence-row:domain-artifacts -->
- [x] [20610-pr20610-domain-artifacts.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20610-pr20610-domain-artifacts.md)

```
$ git stash push -- packages/scenario-runner/test/scenarios/deterministic-github-actions-routes.scenario.ts
$ SCENARIO_USE_DETERMINISTIC_MODEL=1 bun run --cwd packages/scenario-runner test:deterministic:e2e --scenario deterministic-github-actions-routes
| deterministic-github-actions-routes | failed | 11361ms | expected GitHub Octokit ledger=[{"args":{"assignees":["hubot"],"body":"Created by scenario","labels":["scenario"],"owner":"octo","repo":"rep |
Totals: 0 passed, 1 failed, 0 skipped of 1
$ git stash pop   # expectation restored; scenario returns to 1 passed / 0 failed
```

The failure text shows the exact-equality mismatch on the recorded args (`page: 1` present in the ledger, absent from the expectation) — matching the issue's transcript at develop tip.

<!-- evidence-row:ocr-review -->
N/A - no rendered visual surface in this change.

---
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [kenjohnscreates]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01M05XM8G4MBD5DH4Q871ZD1Z0","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-16T18:34:00.069Z","completed_at":"2026-08-16T18:50:41.671Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ02FuP7I_LN-J_iadT_q0j0Rj0Yugo5SJvOjhR_hrfw","device_key_id":"15e4c3effe5c8a2b2c22617596afd1044544026dfb99605709a677bf57050d3b","device_signature":"1GlFnrlXlVUmcUQvDRexZC-EaotVd2kMLtF1kRKoP9QdgKyVOyXeCRsaV4WoZQLkGFfBwIlYyOpBD2hgktiIDw"}} -->

