### PR TITLE
feat(desktop): fn-hold push-to-talk — hold the Globe key anywhere to talk, Wispr-style (#20483)

### DIFF
--- a/packages/app-core/platforms/electrobun/native/macos/window-effects.mm
+++ b/packages/app-core/platforms/electrobun/native/macos/window-effects.mm
@@ -2643,3 +2643,229 @@ extern "C" bool disableWindowBackForwardNavigationGestures(void *windowPtr) {
 
 	return success;
 }
+
+// ============================================================================
+// Fn-key hold monitor (push-to-talk quasimode, #20483)
+// ============================================================================
+
+/*
+ * Listen-only CGEventTap on flagsChanged that reports fn (Globe) key DOWN and
+ * UP transitions, giving the renderer the held quasimode that trigger-only
+ * GlobalShortcut cannot express. The tap runs on a dedicated thread with its
+ * own CFRunLoop; transitions land in a small lock-free ring buffer drained by
+ * the Bun host over FFI (elizaFnMonitorPoll), matching the poll-based
+ * delivery the dylib already uses for notification choices.
+ *
+ * macOS silently disables a tap whose callback stalls
+ * (kCGEventTapDisabledByTimeout) and secure-input can starve it; the callback
+ * re-enables in place and elizaFnMonitorIsHealthy exposes tap liveness so the
+ * host can watchdog-restart. Requires Accessibility trust (listen-only taps
+ * accept either Accessibility or Input Monitoring; the app already requests
+ * the former). fn+key chords are ignored by design: a chord means the user
+ * wanted the other key, so only a bare fn press/release drives the mic.
+ */
+
+static const int kElizaFnEventQueueCapacity = 64;
+
+// Ring buffer: single producer (tap thread) / single consumer (FFI poll).
+// Values: 1 = fn down, 2 = fn up.
+static std::atomic<int> elizaFnEventQueue[kElizaFnEventQueueCapacity];
+static std::atomic<unsigned> elizaFnEventHead{0};
+static std::atomic<unsigned> elizaFnEventTail{0};
+
+static std::atomic<bool> elizaFnMonitorRunning{false};
+static std::atomic<bool> elizaFnKeyIsDown{false};
+static std::atomic<bool> elizaFnSawOtherKeyDuringHold{false};
+static CFMachPortRef elizaFnEventTap = nullptr;
+static CFRunLoopRef elizaFnTapRunLoop = nullptr;
+static NSThread *elizaFnTapThread = nil;
+
+static void elizaFnEventPush(int value) {
+	unsigned head = elizaFnEventHead.load(std::memory_order_relaxed);
+	unsigned tail = elizaFnEventTail.load(std::memory_order_acquire);
+	if (head - tail >= (unsigned)kElizaFnEventQueueCapacity) {
+		return; // Drop on overflow — consumer resyncs from key state.
+	}
+	elizaFnEventQueue[head % kElizaFnEventQueueCapacity].store(
+		value, std::memory_order_relaxed);
+	elizaFnEventHead.store(head + 1, std::memory_order_release);
+}
+
+static CGEventRef elizaFnTapCallback(CGEventTapProxy proxy, CGEventType type,
+									 CGEventRef event, void *refcon) {
+	(void)proxy;
+	(void)refcon;
+
+	if (type == kCGEventTapDisabledByTimeout ||
+		type == kCGEventTapDisabledByUserInput) {
+		if (elizaFnEventTap != nullptr) {
+			CGEventTapEnable(elizaFnEventTap, true);
+		}
+		return event;
+	}
+
+	if (type == kCGEventFlagsChanged) {
+		int64_t keycode =
+			CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode);
+		// kVK_Function == 63. Other modifiers also arrive as flagsChanged;
+		// they must not disturb an in-flight fn hold.
+		if (keycode == 63) {
+			bool down =
+				(CGEventGetFlags(event) & kCGEventFlagMaskSecondaryFn) != 0;
+			bool wasDown = elizaFnKeyIsDown.exchange(down);
+			if (down && !wasDown) {
+				elizaFnSawOtherKeyDuringHold.store(false);
+				elizaFnEventPush(1);
+			} else if (!down && wasDown) {
+				elizaFnEventPush(2);
+			}
+		}
+		return event;
+	}
+
+	// A real key pressed while fn is held: the user typed an fn-chord
+	// (fn+arrow, fn+F5...). Flag it so the host can treat the hold as a
+	// chord, not dictation.
+	if (type == kCGEventKeyDown && elizaFnKeyIsDown.load()) {
+		elizaFnSawOtherKeyDuringHold.store(true);
+	}
+
+	return event;
+}
+
+/**
+ * Start the fn monitor. Returns:
+ *   0 = started (or already running)
+ *   1 = permission missing (tap creation refused)
+ *   2 = unexpected failure
+ * Safe to call repeatedly; the tap thread is created once per start/stop
+ * cycle.
+ */
+extern "C" int elizaFnMonitorStart(void) {
+	if (elizaFnMonitorRunning.load()) {
+		return 0;
+	}
+
+	__block int result = 2;
+	dispatch_semaphore_t ready = dispatch_semaphore_create(0);
+
+	NSThread *thread = [[NSThread alloc] initWithBlock:^{
+		CGEventMask mask = CGEventMaskBit(kCGEventFlagsChanged) |
+						   CGEventMaskBit(kCGEventKeyDown);
+		CFMachPortRef tap = CGEventTapCreate(
+			kCGSessionEventTap, kCGHeadInsertEventTap,
+			kCGEventTapOptionListenOnly, mask, elizaFnTapCallback, nullptr);
+		if (tap == nullptr) {
+			// Refused tap == missing Accessibility/Input Monitoring trust.
+			result = 1;
+			dispatch_semaphore_signal(ready);
+			return;
+		}
+
+		CFRunLoopSourceRef source =
+			CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0);
+		if (source == nullptr) {
+			CFRelease(tap);
+			result = 2;
+			dispatch_semaphore_signal(ready);
+			return;
+		}
+
+		elizaFnEventTap = tap;
+		elizaFnTapRunLoop = CFRunLoopGetCurrent();
+		CFRunLoopAddSource(elizaFnTapRunLoop, source, kCFRunLoopCommonModes);
+		CGEventTapEnable(tap, true);
+		elizaFnMonitorRunning.store(true);
+		result = 0;
+		dispatch_semaphore_signal(ready);
+
+		CFRunLoopRun();
+
+		// Stop path: elizaFnMonitorStop() calls CFRunLoopStop.
+		CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source,
+							  kCFRunLoopCommonModes);
+		CFRelease(source);
+		CGEventTapEnable(tap, false);
+		CFRelease(tap);
+		elizaFnEventTap = nullptr;
+		elizaFnTapRunLoop = nullptr;
+		elizaFnMonitorRunning.store(false);
+	}];
+	[thread setName:@"eliza-fn-monitor"];
+	elizaFnTapThread = thread;
+	[thread start];
+
+	dispatch_semaphore_wait(
+		ready, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
+	return result;
+}
+
+/** Stop the fn monitor and release the tap. Idempotent. */
+extern "C" void elizaFnMonitorStop(void) {
+	if (!elizaFnMonitorRunning.load()) {
+		return;
+	}
+	CFRunLoopRef runLoop = elizaFnTapRunLoop;
+	if (runLoop != nullptr) {
+		CFRunLoopStop(runLoop);
+	}
+	elizaFnTapThread = nil;
+	elizaFnKeyIsDown.store(false);
+	// Drain the queue so a later start begins clean.
+	elizaFnEventTail.store(elizaFnEventHead.load());
+}
+
+/**
+ * Drain one queued fn transition.
+ * Returns 0 = none pending, 1 = fn down, 2 = fn up,
+ * 3 = fn up after a chord (another key was pressed during the hold — the
+ * host should cancel rather than send).
+ */
+extern "C" int elizaFnMonitorPoll(void) {
+	unsigned tail = elizaFnEventTail.load(std::memory_order_relaxed);
+	unsigned head = elizaFnEventHead.load(std::memory_order_acquire);
+	if (tail == head) {
+		return 0;
+	}
+	int value = elizaFnEventQueue[tail % kElizaFnEventQueueCapacity].load(
+		std::memory_order_relaxed);
+	elizaFnEventTail.store(tail + 1, std::memory_order_release);
+	if (value == 2 && elizaFnSawOtherKeyDuringHold.load()) {
+		elizaFnSawOtherKeyDuringHold.store(false);
+		return 3;
+	}
+	return value;
+}
+
+/** True while the monitor is running AND macOS reports the tap enabled. A
+ *  false return with the monitor started means the tap was disabled (secure
+ *  input, timeout storm) and a stop/start cycle is needed. */
+extern "C" bool elizaFnMonitorIsHealthy(void) {
+	if (!elizaFnMonitorRunning.load()) {
+		return false;
+	}
+	CFMachPortRef tap = elizaFnEventTap;
+	return tap != nullptr && CGEventTapIsEnabled(tap);
+}
+
+/** Current physical fn state — lets the host resync after queue overflow. */
+extern "C" bool elizaFnMonitorIsFnDown(void) {
+	return elizaFnKeyIsDown.load();
+}
+
+/**
+ * The macOS "Press 🌐 key to..." system action fires on a bare fn TAP and a
+ * listen-only tap cannot swallow it; if it is set to dictation/emoji the two
+ * behaviors collide. Returns com.apple.HIToolbox AppleFnUsageType:
+ * 0 = do nothing, 1 = change input source, 2 = emoji, 3 = dictation,
+ * -1 = unreadable (treated by callers as the OS default, 2).
+ */
+extern "C" int elizaFnSystemUsageType(void) {
+	NSUserDefaults *defaults = [[NSUserDefaults alloc]
+		initWithSuiteName:@"com.apple.HIToolbox"];
+	id value = [defaults objectForKey:@"AppleFnUsageType"];
+	if (value == nil || ![value respondsToSelector:@selector(intValue)]) {
+		return -1;
+	}
+	return [value intValue];
+}

--- a/packages/app-core/platforms/electrobun/src/native/desktop-fn-hold.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-fn-hold.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Covers the DesktopManager fn-hold push-to-talk bridge (#20483): start
+ * results, drain/dedupe of native fn transitions into desktopFnHoldChanged
+ * pushes, chord-cancel semantics, overflow resync against physical key state,
+ * the tap-health watchdog restart, and teardown. The native CGEventTap layer
+ * is mocked; the timers and manager wiring under test are real.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  FnMonitorEvent,
+  FnMonitorStartResult,
+} from "./mac-window-effects";
+
+const fnMock = vi.hoisted(() => ({
+  startResult: "started" as FnMonitorStartResult,
+  queue: [] as FnMonitorEvent[],
+  healthy: true,
+  fnDown: false,
+  usageType: 0,
+  startCalls: 0,
+  stopCalls: 0,
+}));
+
+vi.mock("./mac-window-effects", () => ({
+  createSecurityScopedBookmark: vi.fn(() => null),
+  enableVibrancy: vi.fn(() => false),
+  setWindowShadow: vi.fn(() => false),
+  isAppActive: vi.fn(() => false),
+  isKeyWindow: vi.fn(() => false),
+  makeKeyAndOrderFront: vi.fn(),
+  orderOut: vi.fn(),
+  setNativeDragRegion: vi.fn(),
+  setTrafficLightsPosition: vi.fn(),
+  startAccessingSecurityScopedBookmark: vi.fn(() => false),
+  stopAccessingSecurityScopedBookmarks: vi.fn(),
+  startFnMonitor: vi.fn(() => {
+    fnMock.startCalls += 1;
+    return fnMock.startResult;
+  }),
+  stopFnMonitor: vi.fn(() => {
+    fnMock.stopCalls += 1;
+  }),
+  pollFnMonitor: vi.fn(() => fnMock.queue.shift() ?? null),
+  isFnMonitorHealthy: vi.fn(() => fnMock.healthy),
+  isFnKeyDown: vi.fn(() => fnMock.fnDown),
+  getFnSystemUsageType: vi.fn(() => fnMock.usageType),
+}));
+
+vi.mock("electrobun/bun", () => ({
+  default: {},
+  BrowserView: vi.fn(),
+  BuildConfig: { get: () => ({}) },
+  ContextMenu: { on: vi.fn() },
+  GlobalShortcut: {
+    register: vi.fn(() => true),
+    unregister: vi.fn(),
+    unregisterAll: vi.fn(),
+    isRegistered: vi.fn(() => false),
+  },
+  Screen: {
+    getPrimaryDisplay: vi.fn(() => ({
+      workArea: { x: 0, y: 0, width: 1440, height: 900 },
+      bounds: { x: 0, y: 0, width: 1440, height: 900 },
+      scaleFactor: 2,
+    })),
+  },
+  Session: {},
+  Tray: vi.fn(),
+  Updater: {},
+  Utils: {
+    quit: vi.fn(),
+    openExternal: vi.fn(),
+    showNotification: vi.fn(),
+    paths: {},
+  },
+}));
+
+import { DesktopManager } from "./desktop";
+
+const darwinOnly = process.platform === "darwin" ? describe : describe.skip;
+
+function createManager() {
+  const pushes: Array<{ message: string; payload: unknown }> = [];
+  const manager = new DesktopManager();
+  manager.setSendToWebview((message, payload) => {
+    pushes.push({ message, payload });
+  });
+  const fnPushes = () =>
+    pushes.filter((entry) => entry.message === "desktopFnHoldChanged");
+  return { manager, fnPushes };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  fnMock.startResult = "started";
+  fnMock.queue = [];
+  fnMock.healthy = true;
+  fnMock.fnDown = false;
+  fnMock.usageType = 0;
+  fnMock.startCalls = 0;
+  fnMock.stopCalls = 0;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+darwinOnly("DesktopManager fn-hold push-to-talk bridge", () => {
+  it("reports start status and the system fn usage setting", async () => {
+    const { manager } = createManager();
+    fnMock.usageType = 3;
+    await expect(manager.startFnHoldMonitor()).resolves.toEqual({
+      status: "started",
+      fnSystemUsageType: 3,
+    });
+    await manager.stopFnHoldMonitor();
+  });
+
+  it("surfaces permission-missing without starting the poller", async () => {
+    const { manager, fnPushes } = createManager();
+    fnMock.startResult = "permission-missing";
+    const result = await manager.startFnHoldMonitor();
+    expect(result.status).toBe("permission-missing");
+    fnMock.queue = ["down"];
+    vi.advanceTimersByTime(200);
+    expect(fnPushes()).toHaveLength(0);
+    await manager.stopFnHoldMonitor();
+  });
+
+  it("forwards a hold as held:true then a plain release as a send", async () => {
+    const { manager, fnPushes } = createManager();
+    await manager.startFnHoldMonitor();
+
+    fnMock.queue = ["down"];
+    fnMock.fnDown = true;
+    vi.advanceTimersByTime(20);
+    expect(fnPushes()).toEqual([
+      {
+        message: "desktopFnHoldChanged",
+        payload: { held: true, cancelled: false },
+      },
+    ]);
+
+    fnMock.queue = ["up"];
+    fnMock.fnDown = false;
+    vi.advanceTimersByTime(20);
+    expect(fnPushes()[1]).toEqual({
+      message: "desktopFnHoldChanged",
+      payload: { held: false, cancelled: false },
+    });
+    await manager.stopFnHoldMonitor();
+  });
+
+  it("marks a chorded release as cancelled", async () => {
+    const { manager, fnPushes } = createManager();
+    await manager.startFnHoldMonitor();
+
+    fnMock.queue = ["down"];
+    fnMock.fnDown = true;
+    vi.advanceTimersByTime(20);
+    fnMock.queue = ["up-chord"];
+    fnMock.fnDown = false;
+    vi.advanceTimersByTime(20);
+
+    expect(fnPushes()[1]).toEqual({
+      message: "desktopFnHoldChanged",
+      payload: { held: false, cancelled: true },
+    });
+    await manager.stopFnHoldMonitor();
+  });
+
+  it("dedupes repeated downs and ignores unpaired releases", async () => {
+    const { manager, fnPushes } = createManager();
+    await manager.startFnHoldMonitor();
+
+    fnMock.queue = ["up", "down", "down"];
+    fnMock.fnDown = true;
+    vi.advanceTimersByTime(20);
+    expect(fnPushes()).toHaveLength(1);
+    expect(fnPushes()[0]?.payload).toEqual({ held: true, cancelled: false });
+    await manager.stopFnHoldMonitor();
+  });
+
+  it("resyncs a stale held state from the physical key on queue overflow", async () => {
+    const { manager, fnPushes } = createManager();
+    await manager.startFnHoldMonitor();
+
+    fnMock.queue = ["down"];
+    fnMock.fnDown = true;
+    vi.advanceTimersByTime(20);
+    // The "up" transition was dropped (ring overflow): queue empty but the
+    // physical key is no longer down.
+    fnMock.fnDown = false;
+    vi.advanceTimersByTime(20);
+
+    expect(fnPushes()[1]).toEqual({
+      message: "desktopFnHoldChanged",
+      payload: { held: false, cancelled: true },
+    });
+    await manager.stopFnHoldMonitor();
+  });
+
+  it("watchdog restarts the tap when macOS disables it", async () => {
+    const { manager } = createManager();
+    await manager.startFnHoldMonitor();
+    expect(fnMock.startCalls).toBe(1);
+
+    fnMock.healthy = false;
+    vi.advanceTimersByTime(5_100);
+    expect(fnMock.stopCalls).toBeGreaterThanOrEqual(1);
+    expect(fnMock.startCalls).toBeGreaterThanOrEqual(2);
+    await manager.stopFnHoldMonitor();
+  });
+
+  it("stop mid-hold pushes a cancelled release and stops the native tap", async () => {
+    const { manager, fnPushes } = createManager();
+    await manager.startFnHoldMonitor();
+
+    fnMock.queue = ["down"];
+    fnMock.fnDown = true;
+    vi.advanceTimersByTime(20);
+    await manager.stopFnHoldMonitor();
+
+    expect(fnPushes()[1]).toEqual({
+      message: "desktopFnHoldChanged",
+      payload: { held: false, cancelled: true },
+    });
+    expect(fnMock.stopCalls).toBeGreaterThanOrEqual(1);
+
+    // Poller is gone: further native events produce no pushes.
+    fnMock.queue = ["down"];
+    vi.advanceTimersByTime(100);
+    expect(fnPushes()).toHaveLength(2);
+  });
+});
+
+describe("DesktopManager fn-hold on non-mac platforms", () => {
+  it("reports unavailable without touching the native layer", async () => {
+    if (process.platform === "darwin") {
+      // Covered by the darwin suite; the guard under test is the
+      // process.platform branch, which cannot be exercised from darwin.
+      return;
+    }
+    const { manager } = createManager();
+    await expect(manager.startFnHoldMonitor()).resolves.toEqual({
+      status: "unavailable",
+      fnSystemUsageType: 0,
+    });
+    expect(fnMock.startCalls).toBe(0);
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -25,6 +25,12 @@ vi.mock("./mac-window-effects", () => ({
   setTrafficLightsPosition: vi.fn(),
   startAccessingSecurityScopedBookmark: vi.fn(() => false),
   stopAccessingSecurityScopedBookmarks: vi.fn(),
+  startFnMonitor: vi.fn(() => "unavailable" as const),
+  stopFnMonitor: vi.fn(),
+  pollFnMonitor: vi.fn(() => null),
+  isFnMonitorHealthy: vi.fn(() => false),
+  isFnKeyDown: vi.fn(() => false),
+  getFnSystemUsageType: vi.fn(() => 0),
 }));
 
 const electrobunMock = vi.hoisted(() => {

--- a/packages/app-core/platforms/electrobun/src/native/desktop.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop.ts
@@ -94,12 +94,19 @@ import {
 } from "./agent";
 import {
   createSecurityScopedBookmark,
+  type FnMonitorStartResult,
+  getFnSystemUsageType,
   isAppActive,
+  isFnKeyDown,
+  isFnMonitorHealthy,
   isKeyWindow,
   makeKeyAndOrderFront,
   orderOut,
+  pollFnMonitor,
   startAccessingSecurityScopedBookmark,
+  startFnMonitor,
   stopAccessingSecurityScopedBookmarks,
+  stopFnMonitor,
 } from "./mac-window-effects";
 import {
   linuxSysfsOnBattery,
@@ -350,6 +357,12 @@ export class DesktopManager {
   // toggles closed instead, so a click on the icon never double-fires.
   private trayPopoverBlurHideTimer: ReturnType<typeof setTimeout> | null = null;
   private shortcuts: Map<string, ShortcutOptions> = new Map();
+  // Fn-hold push-to-talk (#20483): drain poller for the native CGEventTap fn
+  // monitor plus a slow watchdog — macOS silently disables a tap on callback
+  // timeout or secure-input, so health is re-checked and the tap restarted.
+  private fnHoldPoller: ReturnType<typeof setInterval> | null = null;
+  private fnHoldWatchdog: ReturnType<typeof setInterval> | null = null;
+  private fnHoldDownReported = false;
   private notificationCounter = 0;
   private notificationDiagnostics: NotificationDiagnosticsEntry[] = [];
   private sendToWebview: SendToWebview | null = null;
@@ -977,6 +990,80 @@ export class DesktopManager {
       accelerator: shortcut.accelerator,
     });
     return true;
+  }
+
+  // MARK: - Fn-hold push-to-talk (#20483)
+
+  /**
+   * Start the native fn (Globe) key monitor and forward hold transitions to
+   * the renderer as `desktopFnHoldChanged` pushes. macOS-only; the listen-only
+   * CGEventTap needs Accessibility (or Input Monitoring) trust, so the result
+   * distinguishes `permission-missing` from hard failure and reports the
+   * system "Press 🌐 key to..." action so the renderer can warn when a bare
+   * fn tap will also trigger emoji/dictation.
+   */
+  async startFnHoldMonitor(): Promise<{
+    status: FnMonitorStartResult;
+    fnSystemUsageType: number;
+  }> {
+    if (process.platform !== "darwin") {
+      return { status: "unavailable", fnSystemUsageType: 0 };
+    }
+    const status = startFnMonitor();
+    if (status === "started" && !this.fnHoldPoller) {
+      // 16ms drain keeps down→chip latency within one frame; the FFI call is
+      // a lock-free ring-buffer read, so the idle cost is negligible.
+      this.fnHoldPoller = setInterval(() => this.drainFnHoldEvents(), 16);
+      this.fnHoldWatchdog = setInterval(() => {
+        if (!isFnMonitorHealthy()) {
+          stopFnMonitor();
+          startFnMonitor();
+        }
+      }, 5_000);
+    }
+    return { status, fnSystemUsageType: getFnSystemUsageType() };
+  }
+
+  async stopFnHoldMonitor(): Promise<void> {
+    if (this.fnHoldPoller) {
+      clearInterval(this.fnHoldPoller);
+      this.fnHoldPoller = null;
+    }
+    if (this.fnHoldWatchdog) {
+      clearInterval(this.fnHoldWatchdog);
+      this.fnHoldWatchdog = null;
+    }
+    if (this.fnHoldDownReported) {
+      this.fnHoldDownReported = false;
+      this.send("desktopFnHoldChanged", { held: false, cancelled: true });
+    }
+    stopFnMonitor();
+  }
+
+  private drainFnHoldEvents(): void {
+    for (;;) {
+      const event = pollFnMonitor();
+      if (event === null) break;
+      if (event === "down" && !this.fnHoldDownReported) {
+        this.fnHoldDownReported = true;
+        this.send("desktopFnHoldChanged", { held: true, cancelled: false });
+      } else if (
+        (event === "up" || event === "up-chord") &&
+        this.fnHoldDownReported
+      ) {
+        this.fnHoldDownReported = false;
+        this.send("desktopFnHoldChanged", {
+          held: false,
+          cancelled: event === "up-chord",
+        });
+      }
+    }
+    // Overflow resync: if the queue dropped transitions, trust the physical
+    // key state so a stuck "held" chip cannot outlive the actual hold.
+    if (this.fnHoldDownReported && !isFnKeyDown()) {
+      this.fnHoldDownReported = false;
+      this.send("desktopFnHoldChanged", { held: false, cancelled: true });
+    }
   }
 
   // MARK: - Auto Launch
@@ -2841,6 +2928,7 @@ X-GNOME-Autostart-enabled=true
     this.releaseNotesView?.remove();
     this.releaseNotesView = null;
     this.releaseNotesWindow = null;
+    await this.stopFnHoldMonitor();
     await this.unregisterAllShortcuts();
     await this.destroyTray();
     this.trayMenuItems.clear();

--- a/packages/app-core/platforms/electrobun/src/native/mac-window-effects.ts
+++ b/packages/app-core/platforms/electrobun/src/native/mac-window-effects.ts
@@ -33,6 +33,12 @@ type MacEffectsSymbols = {
   elizaOnboardingNotificationDismiss(): void;
   checkNotificationPermission(): number;
   requestNotificationPermission(): number;
+  elizaFnMonitorStart(): number;
+  elizaFnMonitorStop(): void;
+  elizaFnMonitorPoll(): number;
+  elizaFnMonitorIsHealthy(): boolean;
+  elizaFnMonitorIsFnDown(): boolean;
+  elizaFnSystemUsageType(): number;
 };
 
 type LoadedMacEffectsLib = { symbols: MacEffectsSymbols; close(): void };
@@ -117,6 +123,12 @@ function loadLib(): MacEffectsLib {
       },
       checkNotificationPermission: { args: [], returns: FFIType.i32 },
       requestNotificationPermission: { args: [], returns: FFIType.i32 },
+      elizaFnMonitorStart: { args: [], returns: FFIType.i32 },
+      elizaFnMonitorStop: { args: [], returns: FFIType.void },
+      elizaFnMonitorPoll: { args: [], returns: FFIType.i32 },
+      elizaFnMonitorIsHealthy: { args: [], returns: FFIType.bool },
+      elizaFnMonitorIsFnDown: { args: [], returns: FFIType.bool },
+      elizaFnSystemUsageType: { args: [], returns: FFIType.i32 },
     }) as MacEffectsLib;
   } catch (err) {
     console.warn("[MacEffects] Failed to load dylib:", err);
@@ -282,4 +294,75 @@ export function checkNotificationPermission(): number | null {
 export function requestNotificationPermission(): number | null {
   const lib = getLib();
   return lib ? lib.symbols.requestNotificationPermission() : null;
+}
+
+// ── Fn-key hold monitor (push-to-talk quasimode, #20483) ──────────────────
+
+/** Outcome of starting the fn monitor. `permission-missing` means macOS
+ *  refused the listen-only event tap — Accessibility (or Input Monitoring)
+ *  trust has not been granted to this app bundle. */
+export type FnMonitorStartResult =
+  | "started"
+  | "permission-missing"
+  | "failed"
+  | "unavailable";
+
+/** One drained fn-key transition. `up-chord` is a release where another key
+ *  was pressed mid-hold (fn+arrow etc.) — treat as cancel, not send. */
+export type FnMonitorEvent = "down" | "up" | "up-chord";
+
+export function startFnMonitor(): FnMonitorStartResult {
+  const lib = getLib();
+  if (!lib) return "unavailable";
+  switch (lib.symbols.elizaFnMonitorStart()) {
+    case 0:
+      return "started";
+    case 1:
+      return "permission-missing";
+    default:
+      return "failed";
+  }
+}
+
+export function stopFnMonitor(): void {
+  getLib()?.symbols.elizaFnMonitorStop();
+}
+
+/** Drain one queued fn transition; null when the queue is empty. */
+export function pollFnMonitor(): FnMonitorEvent | null {
+  const lib = getLib();
+  if (!lib) return null;
+  switch (lib.symbols.elizaFnMonitorPoll()) {
+    case 1:
+      return "down";
+    case 2:
+      return "up";
+    case 3:
+      return "up-chord";
+    default:
+      return null;
+  }
+}
+
+/** False while started means the tap was disabled out from under us (secure
+ *  input, tap timeout) and the monitor needs a stop/start cycle. */
+export function isFnMonitorHealthy(): boolean {
+  return getLib()?.symbols.elizaFnMonitorIsHealthy() ?? false;
+}
+
+/** Physical fn key state right now — resync anchor after queue overflow. */
+export function isFnKeyDown(): boolean {
+  return getLib()?.symbols.elizaFnMonitorIsFnDown() ?? false;
+}
+
+/** The system "Press 🌐 key to..." action (com.apple.HIToolbox
+ *  AppleFnUsageType): 0 none, 1 input source, 2 emoji, 3 dictation. macOS
+ *  defaults to 2 when the key was never configured; a bare fn tap fires it
+ *  and a listen-only tap cannot swallow it, so callers surface a "set it to
+ *  Do Nothing" hint when this is not 0. */
+export function getFnSystemUsageType(): number {
+  const lib = getLib();
+  if (!lib) return -1;
+  const value = lib.symbols.elizaFnSystemUsageType();
+  return value === -1 ? 2 : value;
 }

--- a/packages/app-core/platforms/electrobun/src/rpc-handlers.ts
+++ b/packages/app-core/platforms/electrobun/src/rpc-handlers.ts
@@ -758,6 +758,8 @@ export function buildBunRpcHandlers({
     desktopIsShortcutRegistered: async (
       params: Parameters<typeof desktop.isShortcutRegistered>[0],
     ) => desktop.isShortcutRegistered(params),
+    desktopStartFnHoldMonitor: async () => desktop.startFnHoldMonitor(),
+    desktopStopFnHoldMonitor: async () => desktop.stopFnHoldMonitor(),
 
     // ---- Desktop: Auto Launch ----
     desktopSetAutoLaunch: async (

--- a/packages/app-core/platforms/electrobun/src/rpc-schema.ts
+++ b/packages/app-core/platforms/electrobun/src/rpc-schema.ts
@@ -1425,6 +1425,19 @@ export type ElizaDesktopRPCSchema = {
         params: { accelerator: string };
         response: { registered: boolean };
       };
+      /** Fn-hold push-to-talk (#20483), macOS direct builds only.
+       *  `permission-missing` means Accessibility/Input Monitoring trust is
+       *  absent; `fnSystemUsageType` mirrors the "Press 🌐 key to..." system
+       *  setting (0 none / 1 input source / 2 emoji / 3 dictation) so the
+       *  renderer can advise setting it to Do Nothing. */
+      desktopStartFnHoldMonitor: {
+        params: undefined;
+        response: {
+          status: "started" | "permission-missing" | "failed" | "unavailable";
+          fnSystemUsageType: number;
+        };
+      };
+      desktopStopFnHoldMonitor: { params: undefined; response: undefined };
 
       // ---- Desktop: Auto Launch ----
       desktopSetAutoLaunch: {
@@ -2253,6 +2266,10 @@ export type ElizaDesktopRPCSchema = {
 
       // Desktop: Shortcut events
       desktopShortcutPressed: { id: string; accelerator: string };
+      /** Fn (Globe) key hold transition (#20483). `cancelled` is true when a
+       *  release must NOT send: the user typed an fn-chord during the hold,
+       *  or the monitor stopped/resynced mid-hold. */
+      desktopFnHoldChanged: { held: boolean; cancelled: boolean };
 
       // Desktop: Window events
       desktopWindowFocus: undefined;
@@ -2420,6 +2437,8 @@ export const CHANNEL_TO_RPC_METHOD: Record<string, string> = {
   "desktop:unregisterShortcut": "desktopUnregisterShortcut",
   "desktop:unregisterAllShortcuts": "desktopUnregisterAllShortcuts",
   "desktop:isShortcutRegistered": "desktopIsShortcutRegistered",
+  "desktop:startFnHoldMonitor": "desktopStartFnHoldMonitor",
+  "desktop:stopFnHoldMonitor": "desktopStopFnHoldMonitor",
 
   // Desktop: Auto Launch
   "desktop:setAutoLaunch": "desktopSetAutoLaunch",
@@ -2714,6 +2733,7 @@ export const PUSH_CHANNEL_TO_RPC_MESSAGE: Record<string, string> = {
   "desktop:trayMenuClick": "desktopTrayMenuClick",
   "desktop:trayClick": "desktopTrayClick",
   "desktop:shortcutPressed": "desktopShortcutPressed",
+  "desktop:fnHoldChanged": "desktopFnHoldChanged",
   "desktop:windowFocus": "desktopWindowFocus",
   "desktop:windowBlur": "desktopWindowBlur",
   "desktop:windowMaximize": "desktopWindowMaximize",

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -98,7 +98,9 @@ import {
   dispatchAppEvent,
   dispatchConnectRequest,
   MOBILE_RUNTIME_MODE_CHANGED_EVENT,
+  PUSH_TO_TALK_HOLD_EVENT,
   PUSH_TO_TALK_TOGGLE_EVENT,
+  type PushToTalkHoldDetail,
   SHARE_TARGET_EVENT,
   TRAY_ACTION_EVENT,
 } from "@elizaos/ui/events";
@@ -2452,6 +2454,42 @@ async function initializeDesktopShell(): Promise<void> {
   if (pushToTalkRegistration?.success !== true) {
     console.warn(
       "[desktop-shell] Operating system rejected the push-to-talk shortcut; the pill hold gesture remains available",
+    );
+  }
+
+  // Fn-hold push-to-talk quasimode (#20483, Wispr parity): the native fn key
+  // monitor delivers true down/up, so holding fn anywhere drives the same
+  // capture as holding the pill. Best-effort: `permission-missing` (no
+  // Accessibility trust yet) and `unavailable` (non-mac, sandboxed store
+  // build) degrade silently to the toggle hotkey above.
+  subscribeDesktopBridgeEvent({
+    rpcMessage: "desktopFnHoldChanged",
+    ipcChannel: "desktop:fnHoldChanged",
+    listener: (payload: unknown) => {
+      const detail = payload as PushToTalkHoldDetail | null | undefined;
+      if (!detail || typeof detail.held !== "boolean") return;
+      dispatchAppEvent(PUSH_TO_TALK_HOLD_EVENT, {
+        held: detail.held,
+        cancelled: detail.cancelled === true,
+      } satisfies PushToTalkHoldDetail);
+    },
+  });
+  const fnHoldStart = await invokeDesktopBridgeRequest<{
+    status: "started" | "permission-missing" | "failed" | "unavailable";
+    fnSystemUsageType: number;
+  }>({
+    rpcMethod: "desktopStartFnHoldMonitor",
+    ipcChannel: "desktop:startFnHoldMonitor",
+  });
+  if (fnHoldStart?.status === "started") {
+    if (fnHoldStart.fnSystemUsageType !== 0) {
+      console.warn(
+        "[desktop-shell] fn-hold push-to-talk is active but the macOS 'Press 🌐 key to' action is also enabled — a quick fn tap will trigger the system action; set it to 'Do Nothing' in System Settings → Keyboard",
+      );
+    }
+  } else if (fnHoldStart?.status === "permission-missing") {
+    console.warn(
+      "[desktop-shell] fn-hold push-to-talk needs Accessibility permission (System Settings → Privacy & Security → Accessibility); falling back to the toggle hotkey",
     );
   }
 

--- a/packages/shared/src/events/index.ts
+++ b/packages/shared/src/events/index.ts
@@ -15,6 +15,19 @@ export const COMMAND_PALETTE_EVENT = "eliza:command-palette" as const;
  *  report key-up, so the hotkey path is press-to-start/press-to-send rather
  *  than hold-to-talk. */
 export const PUSH_TO_TALK_TOGGLE_EVENT = "eliza:push-to-talk-toggle" as const;
+/** Global fn-hold push-to-talk quasimode (#20483): the native fn (Globe) key
+ *  monitor reports true hold semantics — down starts pill listening, up sends,
+ *  and a cancelled release (fn-chord, monitor loss) aborts without sending.
+ *  Complements {@link PUSH_TO_TALK_TOGGLE_EVENT}, which stays the toggle
+ *  fallback for non-mac and store builds. */
+export const PUSH_TO_TALK_HOLD_EVENT = "eliza:push-to-talk-hold" as const;
+
+/** Detail payload for {@link PUSH_TO_TALK_HOLD_EVENT}. */
+export interface PushToTalkHoldDetail {
+  held: boolean;
+  /** True on a release that must abort instead of send. */
+  cancelled: boolean;
+}
 export const EMOTE_PICKER_EVENT = "eliza:emote-picker" as const;
 export const STOP_EMOTE_EVENT = "eliza:stop-emote" as const;
 
@@ -299,6 +312,7 @@ export interface ChatAvatarVoiceEventDetail {
 export type ElizaDocumentEventName =
   | typeof COMMAND_PALETTE_EVENT
   | typeof PUSH_TO_TALK_TOGGLE_EVENT
+  | typeof PUSH_TO_TALK_HOLD_EVENT
   | typeof EMOTE_PICKER_EVENT
   | typeof STOP_EMOTE_EVENT
   | typeof AGENT_READY_EVENT

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1817,7 +1817,7 @@ function ShellFoundationMount() {
   // Global push-to-talk hotkey (#20483): the OS shortcut is trigger-only (no
   // key-up event reaches the renderer), so the hotkey drives the SAME ptt
   // capture as the pill's hold, in toggle form — first press opens the mic
-  // (ping + red chip on the pill), second press stops and sends (tick). No
+  // (ping + listening chip on the pill), second press stops and sends (tick). No
   // window is summoned and no focus is taken; the pill alone shows the state.
   const controllerRef = useRef(controller);
   controllerRef.current = controller;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -135,7 +135,9 @@ import {
   type FocusConnectorEventDetail,
   listenForConnectRequests,
   NAVIGATE_VIEW_EVENT,
+  PUSH_TO_TALK_HOLD_EVENT,
   PUSH_TO_TALK_TOGGLE_EVENT,
+  type PushToTalkHoldDetail,
 } from "./events";
 import { adoptRemoteAgentFirstRun } from "./first-run/adopt-remote-first-run";
 import { persistMobileRuntimeModeForServerTarget } from "./first-run/mobile-runtime-mode";
@@ -1835,6 +1837,40 @@ function ShellFoundationMount() {
     document.addEventListener(PUSH_TO_TALK_TOGGLE_EVENT, onToggle);
     return () =>
       document.removeEventListener(PUSH_TO_TALK_TOGGLE_EVENT, onToggle);
+  }, []);
+
+  // Fn-hold quasimode (#20483): the native fn monitor delivers true down/up,
+  // so this is the same contract as the pill's own press-and-hold — down
+  // opens the mic, up sends, a cancelled release (fn-chord, monitor loss)
+  // aborts silently. Tracks its own held flag so an unpaired release (e.g.
+  // fn was already down at subscribe time) cannot stop a capture the toggle
+  // hotkey or pill started.
+  const fnHoldActiveRef = useRef(false);
+  useEffect(() => {
+    if (typeof document === "undefined") return undefined;
+    const onHold = (event: Event) => {
+      const shell = controllerRef.current;
+      if (!shell) return;
+      const detail = (event as CustomEvent<PushToTalkHoldDetail>).detail;
+      if (!detail || typeof detail.held !== "boolean") return;
+      if (detail.held) {
+        if (fnHoldActiveRef.current || shell.recording) return;
+        fnHoldActiveRef.current = true;
+        playCaptureStartCue();
+        shell.startRecording("ptt");
+        return;
+      }
+      if (!fnHoldActiveRef.current) return;
+      fnHoldActiveRef.current = false;
+      if (detail.cancelled) {
+        shell.cancelRecording();
+        return;
+      }
+      playCaptureSendCue();
+      shell.stopRecording();
+    };
+    document.addEventListener(PUSH_TO_TALK_HOLD_EVENT, onHold);
+    return () => document.removeEventListener(PUSH_TO_TALK_HOLD_EVENT, onHold);
   }, []);
 
   useEffect(() => {

--- a/packages/ui/src/components/shell/HomePill.tsx
+++ b/packages/ui/src/components/shell/HomePill.tsx
@@ -81,8 +81,8 @@ const PROCESS_DOTS = [
  * always-visible surface, so it carries all ambient status):
  *   booting     — dim pulsing handle ("waking up").
  *   idle        — solid white handle ("here, ready").
- *   listening   — dark chip, red hot-mic ring, live waveform bars.
- *   processing  — dark chip, pulsing dots, no red ring — mic closed,
+ *   listening   — dark chip, live waveform bars ("mic is hot").
+ *   processing  — dark chip, pulsing dots — mic closed,
  *                 transcription in flight ("heard you, working on it").
  *   responding  — warm accent glow; `speaking` sharpens it while the reply
  *                 is audibly playing (thinking vs speaking read differently).
@@ -244,16 +244,14 @@ export function HomePill({
           "transition-[width,height,opacity,transform,background-color,box-shadow] duration-200",
           // Listening/processing mirror the studied Wispr Flow bar: the capsule
           // GROWS into a dark rounded chip — legible from across the room.
-          // Listening carries live bars + a red hot-mic ring; processing keeps
-          // the dark chip (continuity: "still your utterance") but swaps the
-          // bars for pulsing dots and drops the red ring — the mic is CLOSED.
-          // Other phases stay the slim white handle.
+          // Listening carries live bars; processing keeps the dark chip
+          // (continuity: "still your utterance") but swaps the bars for
+          // pulsing dots — the mic is CLOSED. Other phases stay the slim
+          // white handle.
           chipExpanded
             ? "h-7 w-20 gap-[3px] bg-neutral-900/95"
             : "h-2.5 w-12 gap-[3px] bg-white/95 group-hover:w-14",
-          phase === "listening" &&
-            "shadow-[0_0_0_1.5px_rgba(239,68,68,0.9),0_4px_16px_rgba(0,0,0,0.35)]",
-          phase === "processing" && "shadow-[0_4px_16px_rgba(0,0,0,0.35)]",
+          chipExpanded && "shadow-[0_4px_16px_rgba(0,0,0,0.35)]",
           !chipExpanded &&
             (phase === "responding"
               ? speaking

--- a/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
@@ -91,14 +91,15 @@ describe("HomePill", () => {
     );
   });
 
-  it("grows into a dark red-ringed chip with waveform bars while listening", () => {
+  it("grows into a dark chip with waveform bars while listening", () => {
     render(<HomePill phase="listening" onOpen={() => {}} onClose={() => {}} />);
     const mark = screen.getByTestId("shell-home-pill-mark");
-    // Wispr-style listening chip: larger dark capsule + red hot-mic ring.
+    // Wispr-style listening chip: larger dark capsule, no colored ring — the
+    // live bars alone carry the "mic is hot" signal.
     expect(mark.className).toContain("bg-neutral-900/95");
     expect(mark.className).toContain("h-7");
     expect(mark.className).toContain("w-20");
-    expect(mark.className).toContain("239,68,68");
+    expect(mark.className).not.toContain("239,68,68");
     expect(mark.className).not.toContain("bg-white/95");
     const bars = screen.getAllByTestId("shell-home-pill-wave-bar");
     expect(bars).toHaveLength(9);
@@ -132,7 +133,7 @@ describe("HomePill", () => {
     }
   });
 
-  it("keeps the dark chip with pulsing dots (no red ring) while processing", () => {
+  it("keeps the dark chip with pulsing dots while processing", () => {
     render(
       <HomePill phase="processing" onOpen={() => {}} onClose={() => {}} />,
     );

--- a/packages/ui/src/components/shell/shell-state.ts
+++ b/packages/ui/src/components/shell/shell-state.ts
@@ -16,7 +16,7 @@ import type {
  *   booting    — startup not ready and popup closed; pill dim, no halo.
  *   idle       — ready, no overlay; pill solid.
  *   summoned   — overlay open, no active mic/response; faint halo.
- *   listening  — push-to-talk capture in flight; red chip + live bars.
+ *   listening  — push-to-talk capture in flight; dark chip + live bars.
  *   processing — the mic is closed but the utterance is still being
  *                transcribed (STT drain after a hold-to-talk release); dark
  *                chip with pulsing dots — "I heard you, working on it"

--- a/packages/ui/src/events/index.ts
+++ b/packages/ui/src/events/index.ts
@@ -46,7 +46,9 @@ export {
   type NavigateViewType,
   NETWORK_STATUS_CHANGE_EVENT,
   type NetworkStatusChangeDetail,
+  PUSH_TO_TALK_HOLD_EVENT,
   PUSH_TO_TALK_TOGGLE_EVENT,
+  type PushToTalkHoldDetail,
   // Sidebar sync
   SELF_STATUS_SYNC_EVENT,
   SHARE_TARGET_EVENT,


### PR DESCRIPTION
## Summary

Wispr Flow parity for the global voice gesture (#20483): **hold the fn (Globe) key from any app to talk to Eliza** — down opens the mic (audible ping + the pill grows into the listening chip), release sends, and a chorded release (fn+arrow etc.) cancels without sending. No window opens and no focus is stolen; the pill alone shows the state.

Until now the OS-wide hotkey was a *toggle* (Cmd/Ctrl+Shift+Space) because Electrobun's `GlobalShortcut` is trigger-only — no key-up ever reaches the app, and fn isn't a registrable accelerator at all. This PR adds the missing native seam.

Also included by product decision: the red hot-mic ring on the listening chip is removed — the dark chip + live waveform bars alone carry "mic is hot"; the red outline read as an error border.

## How Wispr does it (research)

Dissected the installed Wispr Flow app (Electron, v1.6.529): it ships a separate signed Swift helper (`swift-helper-app-dist/…`, `LSUIElement`) spawned over a pipe-fd JSON IPC; the helper links `CGEventTapCreate/Enable`, watches `flagsChanged` for fn down/up, and runs a `TapWatchdog` that re-enables the tap when macOS disables it.

We don't need a helper app or an Electrobun fork: the repo already has a signed in-process native seam — the `bun:ffi` dylib (`window-effects.mm`). The fn monitor lives there, with the same watchdog semantics Wispr ships.

## Implementation

- **`native/macos/window-effects.mm`** — listen-only `CGEventTap` on `flagsChanged` (keycode 63 / `kCGEventFlagMaskSecondaryFn`) on a dedicated CFRunLoop thread; transitions land in a lock-free SPSC ring buffer; the tap self-re-enables on `kCGEventTapDisabledBy*`; exposes start/stop/poll/health/keystate plus an `AppleFnUsageType` reader (the system "Press 🌐 key to…" action collides with a bare fn tap and a listen-only tap can't swallow it, so the renderer warns when it isn't "Do Nothing").
- **`src/native/desktop.ts`** — 16 ms drain poller + 5 s health watchdog that stop/starts the tap; dedupe + overflow resync against the physical key state (a stuck "held" chip can't outlive the actual hold); teardown pushes a cancelled release; wired into `dispose()`.
- **RPC** — `desktopStartFnHoldMonitor` / `desktopStopFnHoldMonitor` requests and the `desktopFnHoldChanged {held, cancelled}` push.
- **Renderer** — new `PUSH_TO_TALK_HOLD_EVENT` drives the *same* pill hold path as press-and-hold (`startRecording("ptt")` / `stopRecording()` / `cancelRecording()` + capture cues). `permission-missing` (no Accessibility trust yet) and non-mac/sandboxed builds degrade silently to the existing toggle hotkey.

## Evidence

- **Live native proof:** synthesized fn hold (CGEvent `flagsChanged`, keycode 63, 1.2 s) against the built dylib — monitor reports `down` at 1105 ms and `up` at 2291 ms, matching the hold window; `healthy: true`.
- **Live packaged proof:** built, signed, and launched the packaged `Eliza-dev.app` from a fully wiped state (WebKit storage/session tokens/preferences deleted); holding fn grows the pill into the dark listening chip with live waveform bars and releases back to the handle. User-confirmed working in the fresh cloud-only consumer build.
- **Unit tests:** new `desktop-fn-hold.test.ts` (9 tests) covers start-status + usage-type reporting, permission-missing (no poller), hold→send, chord-cancel, dedupe/unpaired-release, overflow resync, watchdog restart, and teardown-mid-hold. Electrobun suite 74 files / 537 tests green; `HomePill` suite updated for the ring removal (24 green); shell suite 1059 green; typecheck green in all four touched packages.
- Pre-existing failures on develop (character-presets templates, todo-cutover ENOTDIR, llama.cpp orphaned-test conventions, two app script tests) reproduce on a clean develop checkout and are unrelated.

## Notes for reviewers

- The listen-only tap needs **Accessibility** (or Input Monitoring) trust; the start result distinguishes `permission-missing` so the renderer never mistakes a denied tap for a hard failure. Surfacing a first-class permission prompt card in onboarding is deliberate follow-up scope.
- Store (MAS) builds are sandboxed — event taps can't work there; those builds keep the toggle hotkey (the RPC reports `unavailable`).
- fn+key chords are deliberately ignored: `kCGEventKeyDown` during a hold marks the release `cancelled`, so typing fn+arrow never sends a phantom voice message.

Closes nothing on its own; tracked under #20483 (gap: "global hold-hotkey push-to-talk", previously blocked on the #12184 fork family — this lands it without fork changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
