### PR TITLE
fix(cloud): isolate shared edge cutover binding

### DIFF
--- a/.github/workflows/activate-personal-shared-telegram-edge.yml
+++ b/.github/workflows/activate-personal-shared-telegram-edge.yml
@@ -137,7 +137,7 @@ jobs:
 
           disable_edge() {
             node "$GITHUB_WORKSPACE/packages/cloud/scripts/ensure-worker-secret-absent.mjs" \
-              PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED --env staging >/dev/null
+              PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED --env staging >/dev/null
           }
 
           # A secret mutation can reach Cloudflare even when the CLI response is
@@ -158,7 +158,7 @@ jobs:
             activation_cli_confirmed=false
             for attempt in 1 2 3; do
               if printf '%s' 'true' | bunx wrangler@4.100.0 secret put \
-                PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED --env staging; then
+                PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED --env staging; then
                 activation_cli_confirmed=true
                 break
               fi

--- a/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
+++ b/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
@@ -317,7 +317,7 @@ describe("Personal Shared Telegram edge", () => {
     const response = await app.fetch(
       suffixedRequest,
       {
-        PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED: "true",
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED: "true",
         ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "webhook-secret",
         ELIZA_APP_WEBHOOK_GATEWAY_URL: "https://gateway.example.test",
         ELIZA_APP_WEBHOOK_PROJECT: "eliza-app",
@@ -388,7 +388,7 @@ describe("Personal Shared Telegram edge", () => {
     const response = await app.fetch(
       request,
       {
-        PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED: "false",
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED: "false",
         ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "gateway-secret",
         ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "webhook-secret",
         ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:test-token",

--- a/packages/cloud/api/eliza-app/webhook/telegram/route.ts
+++ b/packages/cloud/api/eliza-app/webhook/telegram/route.ts
@@ -20,7 +20,7 @@ const handle = async (c: Parameters<typeof handlePersonalTelegramEdge>[0]) => {
       : c.json({ success: false, error: "Unauthorized" }, 401);
   }
   return c.req.method === "POST" &&
-    c.env.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED === "true" &&
+    c.env.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED === "true" &&
     suffix === ""
     ? handlePersonalTelegramEdge(c)
     : forwardToWebhookGateway(c, "telegram");

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -846,7 +846,7 @@ describe("cloud-api worker entrypoint", () => {
       }),
       {
         ENVIRONMENT: "staging",
-        PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED: "true",
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED: "true",
         ELIZA_APP_TELEGRAM_BOT_TOKEN: "never-return-this-bot-token",
         ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "never-return-this-webhook-secret",
       } as never,
@@ -1012,6 +1012,7 @@ describe("cloud-api worker entrypoint", () => {
       vars?: {
         PERSONAL_DELIVERY_PROJECTION_READ_ENABLED?: string;
         PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
         ELIZA_INFERENCE_TIMING?: string;
       };
       env?: {
@@ -1019,6 +1020,7 @@ describe("cloud-api worker entrypoint", () => {
           vars?: {
             PERSONAL_DELIVERY_PROJECTION_READ_ENABLED?: string;
             PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
+            PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
             ELIZA_INFERENCE_TIMING?: string;
           };
         };
@@ -1026,6 +1028,7 @@ describe("cloud-api worker entrypoint", () => {
           vars?: {
             PERSONAL_DELIVERY_PROJECTION_READ_ENABLED?: string;
             PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
+            PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
             ELIZA_INFERENCE_TIMING?: string;
           };
         };
@@ -1048,6 +1051,16 @@ describe("cloud-api worker entrypoint", () => {
     expect(
       config.env?.production?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED,
     ).toBe("false");
+    expect(
+      config.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED,
+    ).toBeUndefined();
+    expect(
+      config.env?.staging?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED,
+    ).toBeUndefined();
+    expect(
+      config.env?.production?.vars
+        ?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED,
+    ).toBeUndefined();
     expect(config.vars?.ELIZA_INFERENCE_TIMING).toBeUndefined();
     expect(config.env?.staging?.vars?.ELIZA_INFERENCE_TIMING).toBe("info");
     expect(

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -429,7 +429,7 @@ async function dispatchInference(
 
 function healthResponse(env: AppEnv["Bindings"]): Response {
   const personalSharedTelegramEdgeEnabled =
-    env.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED === "true";
+    env.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED === "true";
   const stagingSessionVersion =
     env.STAGING_SESSION_EXCHANGE_VERSION?.trim() || null;
   const stagingSessionSigningSecret =

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -460,9 +460,9 @@ SHARED_ELIZA_AGENT_RUNTIME = "true"
 # Staging exercises the strongly invalidated sender projection while default
 # and production stay on canonical resolution until the live latency matrix passes.
 PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "true"
-# The protected staging cutover owns PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED as
-# a secret binding. Named-environment vars do not inherit, so leaving only the
-# staging binding absent avoids a name collision while absence remains off.
+# PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED may remain as a legacy plaintext
+# binding under keep_vars. The runtime ignores it and the protected cutover
+# owns the fresh, absent PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED secret.
 # Emit per-turn inference spans at info for the staging latency matrix without
 # changing production log volume or recording prompt content.
 ELIZA_INFERENCE_TIMING = "info"

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -409,7 +409,7 @@ export interface Bindings {
   GATEWAY_WEBHOOK_URL?: string;
   ELIZA_APP_WEBHOOK_PROJECT?: string;
   /** Moves only the official Personal Shared Telegram transport to the Worker edge. */
-  PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
+  PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
   ELIZA_APP_TELEGRAM_BOT_TOKEN?: string;
   ELIZA_APP_TELEGRAM_WEBHOOK_SECRET?: string;
   // Dedicated shared secret stamped onto forwarded webhook calls so the internal

--- a/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
@@ -98,7 +98,10 @@ describe("Personal Shared Telegram edge deploy", () => {
     const apply = step("Apply and verify served edge state");
     expect(apply.run).toContain("wrangler@4.100.0 secret put");
     expect(apply.run).toContain(
-      "PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED --env staging",
+      "PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED --env staging",
+    );
+    expect(apply.run).not.toContain(
+      " PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED --env staging",
     );
     expect(apply.run).toContain("ensure-worker-secret-absent.mjs");
     expect(apply.run).toContain("trap rollback_on_unproven_exit EXIT");
@@ -117,9 +120,11 @@ describe("Personal Shared Telegram edge deploy", () => {
         "utf8",
       ),
     ) as {
+      keep_vars?: boolean;
       vars?: Record<string, string>;
       env?: Record<string, { vars?: Record<string, string> }>;
     };
+    expect(config.keep_vars).toBe(true);
     expect(config.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED).toBe("false");
     expect(
       config.env?.staging?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED,
@@ -127,5 +132,15 @@ describe("Personal Shared Telegram edge deploy", () => {
     expect(
       config.env?.production?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED,
     ).toBe("false");
+    expect(
+      config.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED,
+    ).toBeUndefined();
+    expect(
+      config.env?.staging?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED,
+    ).toBeUndefined();
+    expect(
+      config.env?.production?.vars
+        ?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED,
+    ).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #20601.

<!-- evidence-head: c0baef2db8d594b91a663223c2941309775e0011 -->

## Problem

#20604 omitted `PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED` from the staging Wrangler vars, but top-level `keep_vars = true` preserves the already-deployed plaintext binding. The protected workflow therefore still cannot create a secret with that same name and still encounters Cloudflare error 10053.

## Repair

- Move the protected staging cutover to the fresh `PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED` binding.
- Read only that fresh binding in the Telegram edge route and health response.
- Leave the legacy plaintext binding inert so an existing `keep_vars` deployment cannot authorize traffic.
- Preserve explicit off values in default and production configuration.
- Update protected put/delete and regression contracts to keep the runtime, workflow, and configuration names aligned.

## Exact-head validation

- 54 focused tests passed, 278 assertions.
- Cloud API typecheck passed.
- Cloud API production Wrangler dry-run passed; no deploy was performed.
- Biome passed on the eight changed paths.
- `git diff --check` passed.

## Required before ready/merge

- Hosted exact-head checks.
- Protected staging enable -> exact served Worker health `enabled=true` -> disable -> health `enabled=false` receipt.
- Confirmation that production remained off and untouched.

No deployment, environment approval, secret mutation, or production action was performed while preparing this repair.
