### PR TITLE
fix(core): reject arbitrary action winner in saturated retrieval ties

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -5501,6 +5501,7 @@ describe("runV5MessageRuntimeStage1", () => {
 		expect(result.messageHandler.plan.candidateActions).toEqual([
 			"MESSAGE_SEND",
 			"OWNER_REMINDERS",
+			"TRIGGER",
 		]);
 		expect(result.messageHandler.plan.candidateActions).not.toContain(
 			"TRIGGER_CREATE",

--- a/packages/core/src/runtime/__tests__/action-tiering.test.ts
+++ b/packages/core/src/runtime/__tests__/action-tiering.test.ts
@@ -193,6 +193,28 @@ describe("action tiering", () => {
 		);
 	});
 
+	it("keeps a sole absolute retrieval winner with asymmetric lexical evidence", () => {
+		const catalog = buildActionCatalog(actions);
+		const music = catalog.parentByName.get("MUSIC");
+		const email = catalog.parentByName.get("EMAIL");
+		if (!music || !email) {
+			throw new Error("missing parents");
+		}
+
+		const surface = tierActionResults({
+			catalog,
+			results: [
+				resultFor(music, 1, 1, { keyword: 1, bm25: 0.4 }),
+				resultFor(email, 0.5, 2, { exact: 1 }),
+			],
+			narrowToCandidateActions: ["SEND_EMAIL"],
+		});
+
+		expect(surface.exposedActionNames).toEqual(
+			expect.arrayContaining(["MUSIC", "EMAIL", "SEND_EMAIL"]),
+		);
+	});
+
 	it("keeps WEB_FETCH exposed for a real weather retrieval when Stage-1 omits it", () => {
 		const catalog = buildActionCatalog([
 			{
@@ -308,6 +330,49 @@ describe("action tiering", () => {
 		]);
 		expect(surface.exposedActionNames).not.toContain("HOUSEHOLD_OPERATIONS");
 		expect(surface.exposedActionNames).not.toContain("SCHOOL_SOURCES");
+	});
+
+	it("does not collapse an unmatched candidate to an arbitrary saturated winner", () => {
+		const catalog = buildActionCatalog([
+			{
+				name: "ALPHA_OPERATIONS",
+				description: "Handle a generic operation.",
+			},
+			{
+				name: "BETA_OPERATIONS",
+				description: "Handle a generic operation.",
+			},
+			{
+				name: "GAMMA_OPERATIONS",
+				description: "Handle a generic operation.",
+			},
+		]);
+		const alpha = catalog.parentByName.get("ALPHA_OPERATIONS");
+		const beta = catalog.parentByName.get("BETA_OPERATIONS");
+		const gamma = catalog.parentByName.get("GAMMA_OPERATIONS");
+		if (!alpha || !beta || !gamma) {
+			throw new Error("missing saturated-tie fixtures");
+		}
+
+		const surface = tierActionResults({
+			catalog,
+			results: [
+				resultFor(alpha, 1, 1, { keyword: 1, bm25: 1 }),
+				resultFor(beta, 1, 2, { keyword: 1, bm25: 1 }),
+				resultFor(gamma, 1, 3, { keyword: 1, bm25: 1 }),
+			],
+			narrowToCandidateActions: ["MODEL_INVENTED_ACTION"],
+		});
+
+		// Nothing in the catalog resolves the Stage-1 hint, and retrieval has no
+		// evidence that distinguishes the saturated parents. Preserve the normal
+		// tier-A surface instead of selecting whichever tied result was assigned
+		// rank 1 by a stable but semantically meaningless fallback order.
+		expect(surface.tierAParents.map((parent) => parent.name)).toEqual([
+			"ALPHA_OPERATIONS",
+			"BETA_OPERATIONS",
+			"GAMMA_OPERATIONS",
+		]);
 	});
 
 	it("still demotes a merely-good non-candidate match below the override score", () => {

--- a/packages/core/src/runtime/action-tiering.ts
+++ b/packages/core/src/runtime/action-tiering.ts
@@ -28,11 +28,11 @@ export const TIER0_PROTOCOL_ACTIONS = [
 export type Tier0ProtocolAction = (typeof TIER0_PROTOCOL_ACTIONS)[number];
 
 // A near-certain non-candidate match may remain on the planner surface when
-// Stage-1 omits it. The absolute retrieval winner is authoritative even when
-// its lexical stages are asymmetric; otherwise independent keyword and BM25
-// agreement, or a unique keyword-plus-selected-context match, identifies one
-// unambiguous user-text-dominant fallback without reopening a broadly
-// saturated surface.
+// Stage-1 omits it. A sole highest-scoring retrieval winner is authoritative
+// even when its lexical stages are asymmetric; a saturated cohort has no
+// absolute winner. Otherwise independent keyword and BM25 agreement, or a
+// unique keyword-plus-selected-context match, identifies one unambiguous
+// user-text-dominant fallback without reopening a broadly saturated surface.
 const RETRIEVAL_OVERRIDE_SCORE = 0.97;
 const DOMINANT_LEXICAL_STAGE_SCORE = 0.99;
 
@@ -266,12 +266,21 @@ export function tierActionResults(
 		});
 		const unambiguousContextualOverride =
 			contextualOverrides.length === 1 ? contextualOverrides[0] : undefined;
-		const absoluteRankOneOverride = tierAParents.find(
+		const absoluteOverrideCandidates = tierAParents.filter(
 			(parent) =>
-				!matchesCandidate(parent) &&
-				parent.score >= RETRIEVAL_OVERRIDE_SCORE &&
-				parent.result.rank === 1,
+				!matchesCandidate(parent) && parent.score >= RETRIEVAL_OVERRIDE_SCORE,
 		);
+		const highestAbsoluteOverrideScore = Math.max(
+			...absoluteOverrideCandidates.map((parent) => parent.score),
+		);
+		const highestAbsoluteOverrides = absoluteOverrideCandidates.filter(
+			(parent) => parent.score === highestAbsoluteOverrideScore,
+		);
+		const absoluteRankOneOverride =
+			highestAbsoluteOverrides.length === 1 &&
+			highestAbsoluteOverrides[0]?.result.rank === 1
+				? highestAbsoluteOverrides[0]
+				: undefined;
 		const retrievalOverride =
 			absoluteRankOneOverride ??
 			unambiguousLexicalOverride ??


### PR DESCRIPTION
Closes #20597.

<!-- evidence-head: 6e8dae26212355d2dbf305794d069336bf14daf9 -->

## Boundary

This is the action-retrieval slice extracted from the closed integration draft. It changes only deterministic core tiering and its regressions.

When Stage 1 names no registered action and several otherwise eligible parents share the same maximum retrieval score, registration-order rank must not invent a winner. The absolute override now requires exactly one highest-scoring eligible parent at rank 1. Existing unique lexical/contextual overrides and a genuine sole maximum winner remain unchanged.

The Stage-1 compound-reminder regression preserves the normal TRIGGER parent while still proving the narrower TRIGGER_CREATE action is not fabricated.

## Exact-head validation

- Core focused runtime matrix: 205/205 passed.
- Core typecheck passed.
- Biome passed on all three changed files.
- git diff --check passed.

## Required before ready/merge

- Hosted exact-head checks.
- Exact-head live-model trajectory showing the saturated tie keeps a usable planner surface and the sole winner remains selected.
- Independent review.

The earlier controlled live-model artifacts attached to #20606 validate the same stable patch but predate this rebase, so they are not claimed as exact-head evidence here. No deploy or external runtime mutation was performed.
