### PR TITLE
fix(cloud): handle shared-runtime agent start

### DIFF
--- a/packages/cloud/api/__tests__/shared-agent-shell-startup-probes.test.ts
+++ b/packages/cloud/api/__tests__/shared-agent-shell-startup-probes.test.ts
@@ -105,6 +105,20 @@ describe("shared-agent shell startup probes", () => {
     await expect(response.json()).resolves.toEqual({ ok: true, settings: {} });
   });
 
+  test("POST /api/agent/start returns the canonical shared-runtime status", async () => {
+    const response = await request("agent/start", "POST");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      status: {
+        state: "running",
+        agentName: "Eliza",
+        canRespond: true,
+      },
+    });
+  });
+
   test("POST /api/apps/overlay-presence acks with no resolved app", async () => {
     const response = await request("apps/overlay-presence", "POST");
 
@@ -185,6 +199,7 @@ describe("shared-agent shell startup probes", () => {
       ["GET", "custom-actions"],
       ["GET", "agent/events"],
       ["GET", "stream/settings"],
+      ["POST", "agent/start"],
       ["POST", "apps/overlay-presence"],
       ["POST", "views/chat/navigate"],
       ["POST", "lifeops/activity-signals"],
@@ -237,6 +252,7 @@ describe("shared-agent shell startup probes", () => {
       ["GET", "custom-actions"],
       ["GET", "agent/events"],
       ["GET", "stream/settings"],
+      ["POST", "agent/start"],
       ["POST", "apps/overlay-presence"],
       ["POST", "views/chat/navigate"],
       ["POST", "lifeops/activity-signals"],

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
@@ -22,6 +22,7 @@ import {
 } from "@/lib/services/shared-runtime/resolve-shared-agent";
 import {
   sharedRestAgentEvents,
+  sharedRestAgentStart,
   sharedRestAuthMe,
   sharedRestCharacter,
   sharedRestCommands,
@@ -246,6 +247,12 @@ app.post("/", async (c) => {
   const path = shellPath(c);
   if (isWorkflowApiPath(path)) {
     return workflowUnavailable(c, r.agentId, r.agent.execution_tier);
+  }
+  // POST .../api/agent/start — the client's startup handshake.
+  // A shared agent runs in-Worker with no agent server to boot, so the "start"
+  // is a no-op that returns the running status the client expects.
+  if (path === "agent/start") {
+    return json(c, sharedRestAgentStart(r.agentName));
   }
   // Onboarding "submit" — a shared agent has no config to persist, so accept it
   // as a harmless no-op instead of 404'ing onboarding.

--- a/packages/cloud/shared/src/lib/services/payment-requests.ts
+++ b/packages/cloud/shared/src/lib/services/payment-requests.ts
@@ -124,7 +124,7 @@ interface PaymentRequestsServiceDeps {
   adapters: PaymentProviderAdapter[];
 }
 
-function validateCreateInput(input: CreatePaymentRequestInput): void {
+export function validateCreateInput(input: CreatePaymentRequestInput): void {
   if (!input.organizationId) {
     throw new Error("organizationId is required");
   }
@@ -147,7 +147,7 @@ function validateCreateInput(input: CreatePaymentRequestInput): void {
     input.expiresInMs !== undefined &&
     (!Number.isFinite(input.expiresInMs) || input.expiresInMs <= 0)
   ) {
-    throw new Error("expiresInMs must be a finite positive number");
+    throw new Error("expiresInMs must be a finite positive integer");
   }
 }
 

--- a/packages/cloud/shared/src/lib/services/payment-requests.ts
+++ b/packages/cloud/shared/src/lib/services/payment-requests.ts
@@ -124,7 +124,7 @@ interface PaymentRequestsServiceDeps {
   adapters: PaymentProviderAdapter[];
 }
 
-export function validateCreateInput(input: CreatePaymentRequestInput): void {
+function validateCreateInput(input: CreatePaymentRequestInput): void {
   if (!input.organizationId) {
     throw new Error("organizationId is required");
   }
@@ -147,7 +147,7 @@ export function validateCreateInput(input: CreatePaymentRequestInput): void {
     input.expiresInMs !== undefined &&
     (!Number.isFinite(input.expiresInMs) || input.expiresInMs <= 0)
   ) {
-    throw new Error("expiresInMs must be a finite positive integer");
+    throw new Error("expiresInMs must be a finite positive number");
   }
 }
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
@@ -156,14 +156,9 @@ describe("shared-rest-adapter — startup shell surface", () => {
       status: {
         state: "running",
         agentName: "Nova",
-        model: undefined,
-        uptime: 0,
-        startedAt: expect.any(Number),
+        canRespond: true,
       },
     });
-    // startedAt should be recent
-    expect(result.status.startedAt).toBeLessThanOrEqual(Date.now());
-    expect(result.status.startedAt).toBeGreaterThan(Date.now() - 1000);
   });
 
   test("agent/start falls back to Eliza when name is empty", () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
@@ -36,6 +36,7 @@ mock.module("./shared-runtime-chat", () => ({
 
 // Imported after the mock so the adapter binds to our stubbed service.
 const {
+  sharedRestAgentStart,
   sharedRestAuthMe,
   sharedRestCharacter,
   sharedRestConfig,
@@ -146,6 +147,28 @@ describe("shared-rest-adapter — startup shell surface", () => {
   test("first-run is always complete + cloud-provisioned (no onboarding)", () => {
     expect(sharedRestFirstRunStatus()).toEqual({ complete: true, cloudProvisioned: true });
     expect(sharedRestFirstRun()).toEqual({ complete: true, ok: true });
+  });
+
+  test("agent/start returns running status for shared agent", () => {
+    const result = sharedRestAgentStart("Nova");
+    expect(result).toEqual({
+      ok: true,
+      status: {
+        state: "running",
+        agentName: "Nova",
+        model: undefined,
+        uptime: 0,
+        startedAt: expect.any(Number),
+      },
+    });
+    // startedAt should be recent
+    expect(result.status.startedAt).toBeLessThanOrEqual(Date.now());
+    expect(result.status.startedAt).toBeGreaterThan(Date.now() - 1000);
+  });
+
+  test("agent/start falls back to Eliza when name is empty", () => {
+    const result = sharedRestAgentStart("");
+    expect(result.status.agentName).toBe("Eliza");
   });
 
   test("config declares no websocket + no streaming (client uses non-stream REST)", () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -334,23 +334,11 @@ export function sharedRestAgentEvents(): { events: [] } {
  */
 export function sharedRestAgentStart(agentName: string): {
   ok: true;
-  status: {
-    state: "running";
-    agentName: string;
-    model: string | undefined;
-    uptime: 0;
-    startedAt: number;
-  };
+  status: ReturnType<typeof sharedRestStatus>;
 } {
   return {
     ok: true,
-    status: {
-      state: "running",
-      agentName: agentName || "Eliza",
-      model: undefined,
-      uptime: 0,
-      startedAt: Date.now(),
-    },
+    status: sharedRestStatus(agentName),
   };
 }
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -316,8 +316,7 @@ export function sharedRestCustomActions(): { actions: [] } {
   return { actions: [] };
 }
 
-/**
- * GET .../api/agent/events — the agent event log the shell's activity surfaces
+/** GET .../api/agent/events — the agent event log the shell's activity surfaces
  * poll (ui/src/api/client-agent.ts). A Tier-0 agent runs stateless per-request
  * in a Worker and keeps no event ring buffer, so there is nothing to report.
  * Mirrors the iOS local-agent kernel's synthesis of this same probe
@@ -325,6 +324,34 @@ export function sharedRestCustomActions(): { actions: [] } {
  */
 export function sharedRestAgentEvents(): { events: [] } {
   return { events: [] };
+}
+
+/**
+ * POST .../api/agent/start — the client's startup handshake.
+ * A shared agent runs in-Worker with no agent server to boot, so the "start"
+ * is a no-op that returns the running status the client expects. This unblocks
+ * the desktop cloud-only consumer lane which otherwise hot-loops on 404.
+ */
+export function sharedRestAgentStart(agentName: string): {
+  ok: true;
+  status: {
+    state: "running";
+    agentName: string;
+    model: string | undefined;
+    uptime: 0;
+    startedAt: number;
+  };
+} {
+  return {
+    ok: true,
+    status: {
+      state: "running",
+      agentName: agentName || "Eliza",
+      model: undefined,
+      uptime: 0,
+      startedAt: Date.now(),
+    },
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #20473. The desktop cloud-only consumer lane called `POST /api/agent/start`, but the shared-runtime proxy returned 404 because that compatibility route was absent.

Shared agents already run inside the Worker, so start is a no-op that returns the canonical `sharedRestStatus` result. This avoids fabricated timestamps, uptime, or model state and keeps start/status envelopes consistent.

The landing repair also removes an unrelated payment-validator edit from the contributor branch and adds mounted-route coverage proving authentication resolves before the compatibility response.

## Changes

- Route `POST /api/agent/start` through the shared-runtime adapter.
- Reuse `sharedRestStatus(agentName)` for the response.
- Cover the adapter fallback and the mounted Hono route, including CORS and unauthorized callers.

## Verification

Exact repaired head: `fb9f68728a3c6ed2b8329f0504804e3849cf72fe`.

- 42/42 focused adapter and mounted-route tests passed (104 assertions).
- Cloud shared typecheck passed.
- Cloud API typecheck and production Worker dry-run passed.
- Biome passed on all four changed files.
- `bun run verify` passed: 356/356 Turbo tasks; anti-larp scanned 8,386 test files with zero focused or orphaned skips.

## Evidence

<!-- evidence-head:fb9f68728a3c6ed2b8329f0504804e3849cf72fe -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend compatibility route; no rendered surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend compatibility route; no rendered surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend interaction changed.
<!-- evidence-row:backend-logs -->
- [x] [20618-pr20618-verify-exact-final.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20618-pr20618-verify-exact-final.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic REST compatibility behavior; no model call changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - mounted route response is fully exercised in the backend test log.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
yes - z.ai/glm-5.2; maintainer landing repair openai/gpt-5.6-sol
<!-- attribution-row:models -->
z.ai/glm-5.2; openai/gpt-5.6-sol
<!-- attribution-row:client -->
Hermes Agent; Codex
<!-- attribution-row:skill-revision -->
N/A - direct contribution
<!-- attribution-row:status -->
self-reported

<!-- eliza-computer-attribution:v1 lane=fix -->
