### PR TITLE
fix(core): reject arbitrary saturated action winner

### DIFF
--- a/packages/core/src/runtime/__tests__/action-tiering.test.ts
+++ b/packages/core/src/runtime/__tests__/action-tiering.test.ts
@@ -193,6 +193,28 @@ describe("action tiering", () => {
 		);
 	});
 
+	it("keeps a sole absolute retrieval winner with asymmetric lexical evidence", () => {
+		const catalog = buildActionCatalog(actions);
+		const music = catalog.parentByName.get("MUSIC");
+		const email = catalog.parentByName.get("EMAIL");
+		if (!music || !email) {
+			throw new Error("missing parents");
+		}
+
+		const surface = tierActionResults({
+			catalog,
+			results: [
+				resultFor(music, 1, 1, { keyword: 1, bm25: 0.4 }),
+				resultFor(email, 0.5, 2, { exact: 1 }),
+			],
+			narrowToCandidateActions: ["SEND_EMAIL"],
+		});
+
+		expect(surface.exposedActionNames).toEqual(
+			expect.arrayContaining(["MUSIC", "EMAIL", "SEND_EMAIL"]),
+		);
+	});
+
 	it("keeps WEB_FETCH exposed for a real weather retrieval when Stage-1 omits it", () => {
 		const catalog = buildActionCatalog([
 			{
@@ -308,6 +330,49 @@ describe("action tiering", () => {
 		]);
 		expect(surface.exposedActionNames).not.toContain("HOUSEHOLD_OPERATIONS");
 		expect(surface.exposedActionNames).not.toContain("SCHOOL_SOURCES");
+	});
+
+	it("does not collapse an unmatched candidate to an arbitrary saturated winner", () => {
+		const catalog = buildActionCatalog([
+			{
+				name: "ALPHA_OPERATIONS",
+				description: "Handle a generic operation.",
+			},
+			{
+				name: "BETA_OPERATIONS",
+				description: "Handle a generic operation.",
+			},
+			{
+				name: "GAMMA_OPERATIONS",
+				description: "Handle a generic operation.",
+			},
+		]);
+		const alpha = catalog.parentByName.get("ALPHA_OPERATIONS");
+		const beta = catalog.parentByName.get("BETA_OPERATIONS");
+		const gamma = catalog.parentByName.get("GAMMA_OPERATIONS");
+		if (!alpha || !beta || !gamma) {
+			throw new Error("missing saturated-tie fixtures");
+		}
+
+		const surface = tierActionResults({
+			catalog,
+			results: [
+				resultFor(alpha, 1, 1, { keyword: 1, bm25: 1 }),
+				resultFor(beta, 1, 2, { keyword: 1, bm25: 1 }),
+				resultFor(gamma, 1, 3, { keyword: 1, bm25: 1 }),
+			],
+			narrowToCandidateActions: ["MODEL_INVENTED_ACTION"],
+		});
+
+		// Nothing in the catalog resolves the Stage-1 hint, and retrieval has no
+		// evidence that distinguishes the saturated parents. Preserve the normal
+		// tier-A surface instead of selecting whichever tied result was assigned
+		// rank 1 by a stable but semantically meaningless fallback order.
+		expect(surface.tierAParents.map((parent) => parent.name)).toEqual([
+			"ALPHA_OPERATIONS",
+			"BETA_OPERATIONS",
+			"GAMMA_OPERATIONS",
+		]);
 	});
 
 	it("still demotes a merely-good non-candidate match below the override score", () => {

--- a/packages/core/src/runtime/action-tiering.ts
+++ b/packages/core/src/runtime/action-tiering.ts
@@ -28,11 +28,11 @@ export const TIER0_PROTOCOL_ACTIONS = [
 export type Tier0ProtocolAction = (typeof TIER0_PROTOCOL_ACTIONS)[number];
 
 // A near-certain non-candidate match may remain on the planner surface when
-// Stage-1 omits it. The absolute retrieval winner is authoritative even when
-// its lexical stages are asymmetric; otherwise independent keyword and BM25
-// agreement, or a unique keyword-plus-selected-context match, identifies one
-// unambiguous user-text-dominant fallback without reopening a broadly
-// saturated surface.
+// Stage-1 omits it. A sole highest-scoring retrieval winner is authoritative
+// even when its lexical stages are asymmetric; a saturated cohort has no
+// absolute winner. Otherwise independent keyword and BM25 agreement, or a
+// unique keyword-plus-selected-context match, identifies one unambiguous
+// user-text-dominant fallback without reopening a broadly saturated surface.
 const RETRIEVAL_OVERRIDE_SCORE = 0.97;
 const DOMINANT_LEXICAL_STAGE_SCORE = 0.99;
 
@@ -266,12 +266,21 @@ export function tierActionResults(
 		});
 		const unambiguousContextualOverride =
 			contextualOverrides.length === 1 ? contextualOverrides[0] : undefined;
-		const absoluteRankOneOverride = tierAParents.find(
+		const absoluteOverrideCandidates = tierAParents.filter(
 			(parent) =>
-				!matchesCandidate(parent) &&
-				parent.score >= RETRIEVAL_OVERRIDE_SCORE &&
-				parent.result.rank === 1,
+				!matchesCandidate(parent) && parent.score >= RETRIEVAL_OVERRIDE_SCORE,
 		);
+		const highestAbsoluteOverrideScore = Math.max(
+			...absoluteOverrideCandidates.map((parent) => parent.score),
+		);
+		const highestAbsoluteOverrides = absoluteOverrideCandidates.filter(
+			(parent) => parent.score === highestAbsoluteOverrideScore,
+		);
+		const absoluteRankOneOverride =
+			highestAbsoluteOverrides.length === 1 &&
+			highestAbsoluteOverrides[0]?.result.rank === 1
+				? highestAbsoluteOverrides[0]
+				: undefined;
 		const retrievalOverride =
 			absoluteRankOneOverride ??
 			unambiguousLexicalOverride ??


### PR DESCRIPTION
# Relates to

Fixes #20597.

- [x] Exact changed-source gates and exact candidate/base live-runtime proof pass.
- [x] Mechanically rebased onto the current `origin/develop` and reran exact source plus live-runtime proof.
- [x] A reviewer can confirm the behavior from the production AgentRuntime trajectory, structured logs, and handler receipt below without reading the implementation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@299540ffc47e8eac11309369ab23ab65a9714aa1:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact candidate: `299540ffc47e8eac11309369ab23ab65a9714aa1`, tree `ca50e648e9fa4ac4eba589ef905ba15f1baaeb50`.
- [x] Exact live base/control: `91b0ad25a35b9588d0f485a7846a8a0afb3cb143`, tree `23eb6660c720dfce7d74346e9092db43e71160ee`.
- [x] Candidate is one commit ahead and zero behind this exact current base.

# Risks

Low and bounded to planner action-surface narrowing. A near-certain non-candidate retrieval override now requires a unique maximum-score cohort whose only member is rank 1. An indistinguishable saturated cohort no longer treats its secondary sort/rank-one member as semantic authority. Unique lexical/contextual fallbacks and genuine sole-winner recovery remain unchanged. No schema, route, credential, provider, UI, deployment, or production resource changes.

# Background

## What does this PR do?

When Stage 1 supplies a candidate that does not map to the runtime catalog and multiple eligible retrieval parents saturate at the same maximum score, the old implementation kept only whichever tied result received rank 1 from a stable but semantically arbitrary secondary ordering. That removed legitimate planner choices before the planner saw them.

This patch preserves the normal tier-A surface for an indistinguishable maximum-score cohort. It still accepts an absolute non-candidate override when the maximum cohort has exactly one member and that member is rank 1.

This narrow replacement follows the owner disposition on closed mega-PR #20607: its root-correct action-tiering commit is byte-identical to this two-file patch, while unrelated authority boundaries remain outside this PR.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No user-facing documentation change. The invariant is documented at the runtime boundary and covered by regression tests.

# Testing

## Where should a reviewer start?

- `packages/core/src/runtime/__tests__/action-tiering.test.ts`
- [production AgentRuntime candidate/base trajectory](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/runtime-2995-trajectory.json)
- [exact proof receipt](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/runtime-2995-receipt.json)

## Current-head and patch-equivalent gates

Current head 299540ffc47 reran the focused tiering file 24/24, core typecheck, exact Biome/diff, and a fresh real candidate/base AgentRuntime + Cerebras proof. The broader four-file, full build, and root verify gates below ran on the independently approved byte-identical patch before two disjoint base-only rebases; both range-diffs are exact.

1. Focused catalog/retrieval/tiering/surface tests: 4 files, 82/82 PASS, 268 assertions.
2. `packages/core` typecheck: PASS.
3. `packages/core` build: PASS — Node, browser, edge, testing, declarations, packed edge import.
4. Exact two-file Biome: PASS.
5. `git diff --check origin/develop...HEAD`: PASS.
6. Root `bun run verify`: PASS — 356/356 Turbo tasks plus repository audits.
7. Genuine candidate/base live run: PASS.
   - Real `AgentRuntime` + PGlite + production `messageService.handleMessage`.
   - Real Cerebras `gemma-4-31b` for Stage 1, action planner, and evaluation.
   - Identical current user input, production Stage-1 candidate `QUASAR_TELEMETRY_DASHBOARD`, selected `general` context, retrieval query, and ranked results on candidate and base.
   - Two non-candidate results saturate at score 1 with identical BM25/context evidence.
   - Base surface: only `QUASAR_TELEMETRY_MEASUREMENTS_ALPHA`; two omitted.
   - Candidate surface: `ALPHA`, `BETA`, and `ROUTE`; none omitted.
   - Base planner received one proof tool and could call only Alpha.
   - Candidate planner received all three proof tools and its raw plan selected Alpha plus the recovered Beta choice.
   - Real handler execution succeeded and the native trajectory contains its structured receipt and final user response.

# Evidence Gate

<!-- evidence-head:299540ffc47e8eac11309369ab23ab65a9714aa1 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - runtime-only action-surface boundary.
<!-- evidence-row:backend-logs -->
- [x] [candidate/base structured logs](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/runtime-2995-backend-logs.jsonl)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or browser-network change.
<!-- evidence-row:llm-trajectory -->
- [x] [full native candidate/base trajectory](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/runtime-2995-trajectory.json)
<!-- evidence-row:domain-artifacts -->
- [x] [planner surfaces, calls, and handler receipts](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/runtime-2995-domain-artifacts.json)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real production trajectory

This is not a direct model call, synthetic router, synthetic retrieval result, or scenario proxy. The same external harness boots the exact candidate and exact detached base through `createRealTestRuntime`, registers the same three proof actions, and invokes the real DM message loop. The published trajectory retains the production Stage-1 system/input/raw tool call, `toolSearch` query/stages/scores/tier, exact planner tool projection/raw call, tool receipt, evaluator, and final response for both runs.

- Harness: [runtime-2995-live-proof.ts](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/runtime-2995-live-proof.ts)
- Receipt: [runtime-2995-receipt.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/runtime-2995-receipt.json)
- Manual inspection and secret-scan manifest: [runtime-2995-inspection-manifest.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/runtime-2995-inspection-manifest.json)

Integrity hashes:

- trajectory: `dab5a331d9664bdd15381d69139bb5d9ac35ade9b6da0045da8be580dc52f8e4`
- backend logs: `03a64546269b96e84b8f35d2bcde9842612d7a6b7d0a399f3e7c98cbcadbe3e1`
- domain artifacts: `10315277d353547e07984f3090b72fce90ffcb8034f15f15fe0f136d4f63aa9b`
- receipt: `e16e602c4d877976b62108a2cac884dcb0ff1f0994ca4613b391310b443ccccd`
- harness: `06cef0d0f7bfe0a0c21306384fdfa699a5a2b19644a25d0755e5e8f3f64cb744`
- inspection manifest: `18c0ee2b58c80f7cecfc0ee6a6da79237169bc40682dcf9d9a314227c5fb6365`

Manual review covered every production context/input, raw Stage-1 and planner call, tool-search stage, planner surface, tool result, evaluator, final response, and both structured-log streams. Exact resolved-credential scan and generic secret scan PASS; headers captured=false.

## Known gaps / failures

- The current `trajectory:inspect validate` command is not compatible with the current native recorder artifact: it reports `model.prompt must be a string` where current recorder uses `null`, rejects the recorded `toolSearch` stage kind, and expects four stages while the production trace correctly contains the fifth `evaluation` stage. This validator mismatch is disclosed rather than misreported as green. The external inspection harness structurally requires both production queries/results to be byte-equal and verifies every acceptance invariant against the unmodified native JSON.
- Independent exact-head review is attached and the PR is ready but unmerged pending maintainer approval; it does not deploy or mutate staging/production.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@299540ffc47e8eac11309369ab23ab65a9714aa1:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-root/action-tiering]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@299540ffc47e8eac11309369ab23ab65a9714aa1:packages/skills/skills/contribute-to-eliza"} -->
