### PR TITLE
fix(shared): preserve enabled primary capability intent

### DIFF
--- a/packages/cloud/api/src/shared-runtime-conversation.ts
+++ b/packages/cloud/api/src/shared-runtime-conversation.ts
@@ -31,24 +31,28 @@ type ConversationRequest =
       agent: CachedAgentSandbox;
       rpc: BridgeRequest;
       trustedMessageRole?: "system";
+      trustedUserUtterance?: string;
     }
   | {
       operation: "personal-bridge";
       agent: SharedRuntimeAgent;
       rpc: BridgeRequest;
       trustedMessageRole?: "system";
+      trustedUserUtterance?: string;
     }
   | {
       operation: "stream";
       agent: CachedAgentSandbox;
       rpc: BridgeRequest;
       trustedMessageRole?: "system";
+      trustedUserUtterance?: string;
     }
   | {
       operation: "personal-stream";
       agent: SharedRuntimeAgent;
       rpc: BridgeRequest;
       trustedMessageRole?: "system";
+      trustedUserUtterance?: string;
     }
   | {
       operation: "prewarm";
@@ -1328,6 +1332,7 @@ export class SharedRuntimeConversation {
           turnClaims,
           funding: personal ? "platform" : "organization-credits",
           trustedMessageRole: payload.trustedMessageRole,
+          trustedUserUtterance: payload.trustedUserUtterance,
           executionEngine,
         });
       }
@@ -1337,6 +1342,7 @@ export class SharedRuntimeConversation {
         turnClaims,
         funding: personal ? "platform" : "organization-credits",
         trustedMessageRole: payload.trustedMessageRole,
+        trustedUserUtterance: payload.trustedUserUtterance,
         executionEngine,
       });
       return Response.json(result);

--- a/packages/cloud/shared/src/lib/services/managed-discord-guild-voice.test.ts
+++ b/packages/cloud/shared/src/lib/services/managed-discord-guild-voice.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Covers managed Discord text and voice turns at their real connector boundary.
+ * External identity, speech, and Durable Object collaborators are deterministic seams.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+const sharedRestMessageSend = mock(async () => ({ text: "Shared reply" }));
+const getByDiscordId = mock(async () => ({ id: "account-1" }));
+const speechToText = mock(async () => "remind me in 1 minute: QA20315-DISCORD-DM-R3 verified");
+const textToSpeech = mock(
+  async () =>
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2, 3]));
+        controller.close();
+      },
+    }),
+);
+
+mock.module("./shared-runtime/shared-rest-adapter", () => ({ sharedRestMessageSend }));
+mock.module("./shared-runtime/personal-shared-agent", () => ({
+  personalSharedAgent: () => ({ id: "personal-agent-1", agent_name: "Eliza" }),
+  personalSharedDiscordGuildRoomId: () => "discord-room-1",
+}));
+mock.module("./eliza-app", () => ({ elizaAppUserService: { getByDiscordId } }));
+mock.module("./managed-discord-guild-voice-policy", () => ({
+  evaluateManagedDiscordGuildVoiceOwner: () => ({
+    allowed: true,
+    userId: "user-1",
+    organizationId: "org-1",
+  }),
+}));
+mock.module("./elevenlabs", () => ({
+  ElevenLabsService: {
+    fromEnv: () => ({ speechToText, textToSpeech }),
+  },
+}));
+
+const { runManagedDiscordGuildTextTurn, runManagedDiscordGuildVoiceTurn } = await import(
+  "./managed-discord-guild-voice"
+);
+
+function canonicalWavBase64(): string {
+  const wav = Buffer.alloc(44);
+  wav.write("RIFF", 0, "ascii");
+  wav.write("WAVE", 8, "ascii");
+  return wav.toString("base64");
+}
+
+describe("managed Discord Shared connector boundary", () => {
+  test("keeps the text privacy wrapper for the model and sends raw capability text separately", async () => {
+    const message = "remind me in 1 minute: QA20315-DISCORD-DM-R3 verified";
+    await runManagedDiscordGuildTextTurn(
+      {
+        discordUserId: "discord-1",
+        discordUsername: "alice",
+        displayName: "Alice",
+        guildId: "guild-1",
+        channelId: "channel-1",
+        messageId: "message-1",
+        message,
+        userId: "user-1",
+        organizationId: "org-1",
+      },
+      { namespace: {} as never, executionCtx: {} as never },
+    );
+
+    expect(sharedRestMessageSend).toHaveBeenCalledTimes(1);
+    const call = sharedRestMessageSend.mock.calls[0];
+    expect(call?.[2]).toContain("[Public Discord guild channel; speaker: Alice.");
+    expect(call?.[2]).toContain(message);
+    expect(call?.[9]).toBe(message);
+  });
+
+  test("keeps the voice privacy wrapper for the model and sends raw transcript separately", async () => {
+    const transcript = "remind me in 1 minute: QA20315-DISCORD-DM-R3 verified";
+    await runManagedDiscordGuildVoiceTurn(
+      {
+        discordUserId: "discord-1",
+        discordUsername: "alice",
+        displayName: "Alice",
+        guildId: "guild-1",
+        channelId: "channel-1",
+        utteranceId: "utterance-1",
+        wavBase64: canonicalWavBase64(),
+      },
+      { namespace: {} as never, executionCtx: {} as never, elevenLabsEnv: {} as never },
+    );
+
+    expect(sharedRestMessageSend).toHaveBeenCalledTimes(2);
+    const call = sharedRestMessageSend.mock.calls[1];
+    expect(call?.[2]).toContain("[Public Discord guild voice; speaker: Alice.");
+    expect(call?.[2]).toContain(transcript);
+    expect(call?.[9]).toBe(transcript);
+    expect(textToSpeech).toHaveBeenCalledWith({
+      text: "Shared reply",
+      outputFormat: "mp3_44100_128",
+    });
+  });
+});

--- a/packages/cloud/shared/src/lib/services/managed-discord-guild-voice.ts
+++ b/packages/cloud/shared/src/lib/services/managed-discord-guild-voice.ts
@@ -83,6 +83,8 @@ export async function runManagedDiscordGuildTextTurn(
     context.namespace,
     `discord-guild:${input.messageId}`,
     "platform",
+    undefined,
+    input.message,
   );
   return {
     replyText: reply.text.trim(),
@@ -189,6 +191,8 @@ export async function runManagedDiscordGuildVoiceTurn(
     context.namespace,
     input.utteranceId,
     "platform",
+    undefined,
+    transcript,
   );
   const replyText = reply.text.trim();
   if (!replyText) throw new Error("Shared Eliza returned no guild voice reply");

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.test.ts
@@ -150,6 +150,7 @@ describe("shared conversation coordinator", () => {
       executionCtx,
       agentKind: "personal",
       trustedMessageRole: "system",
+      trustedUserUtterance: "email Bob now",
     });
     await coordinateSharedLifecycleEvent(
       agent.id,
@@ -164,6 +165,7 @@ describe("shared conversation coordinator", () => {
         agent,
         rpc,
         trustedMessageRole: "system",
+        trustedUserUtterance: "email Bob now",
       },
       {
         operation: "lifecycle",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/conversation-coordinator.ts
@@ -23,6 +23,8 @@ export interface SharedConversationCoordinatorOptions {
   agentKind?: "sandbox" | "personal";
   /** Authenticated server-only role override; never accepted from RPC params. */
   trustedMessageRole?: "system";
+  /** Authenticated raw utterance when RPC text also contains server-composed context. */
+  trustedUserUtterance?: string;
 }
 
 export interface SharedConversationHistoryCoordinatorOptions {
@@ -220,6 +222,9 @@ export async function coordinateSharedBridge(
         agent,
         rpc,
         ...(options.trustedMessageRole ? { trustedMessageRole: options.trustedMessageRole } : {}),
+        ...(options.trustedUserUtterance
+          ? { trustedUserUtterance: options.trustedUserUtterance }
+          : {}),
       }),
     });
   await requireCoordinatorResponse(response, "conversation");
@@ -242,6 +247,9 @@ export async function coordinateSharedStream(
         agent,
         rpc,
         ...(options.trustedMessageRole ? { trustedMessageRole: options.trustedMessageRole } : {}),
+        ...(options.trustedUserUtterance
+          ? { trustedUserUtterance: options.trustedUserUtterance }
+          : {}),
       }),
       ...(options.abortSignal ? { signal: options.abortSignal } : {}),
     });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
@@ -232,10 +232,16 @@ describe("runSharedAgentTurn — internal failure propagates vs designed-empty d
   );
 
   test("executes an enabled primary and carries a blocked secondary clause truthfully", async () => {
+    const recordedReplies: string[] = [];
     const input = {
       character: { name: "Eliza", system: "You are Eliza." },
       history: [],
       message: "add call Mom to my todo list. Then email Bob now",
+      memory: {
+        recordTurnPair: async ({ assistantReply }: { assistantReply: string }) => {
+          recordedReplies.push(assistantReply);
+        },
+      } as never,
       execution: {
         engine: "eliza-runtime" as const,
         agentKey: "personal:agent",
@@ -249,6 +255,7 @@ describe("runSharedAgentTurn — internal failure propagates vs designed-empty d
     expect(turn.blockedSecondaryCapabilities).toEqual([
       expect.objectContaining({ capability: "communications" }),
     ]);
+    expect(recordedReplies).toEqual([turn.reply]);
 
     const streamed = await runSharedAgentTurnStream(input);
     const parts = [];
@@ -260,6 +267,7 @@ describe("runSharedAgentTurn — internal failure propagates vs designed-empty d
       }),
     );
     expect(streamed.blockedSecondaryCapabilities?.[0]?.capability).toBe("communications");
+    expect(recordedReplies).toEqual([turn.reply, parts.at(-1)?.text]);
   });
 
   test("tells the model the same capability truth for ambiguous follow-ups", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
@@ -80,6 +80,31 @@ mock.module("ai", () => ({
   },
 }));
 
+mock.module("./shared-eliza-runtime", () => ({
+  runSharedElizaRuntimeTurn: async (input: {
+    history: Array<{ role: "system" | "user" | "assistant"; content: string }>;
+    message: string;
+  }) => ({
+    reply: "Todo saved.",
+    history: [...input.history, { role: "user", content: input.message }],
+    model: "runtime-model",
+    degraded: false,
+    actionResults: [{ actionName: "TODO", success: true, text: "Todo saved." }],
+  }),
+  runSharedElizaRuntimeTurnStream: async () => ({
+    model: "runtime-model",
+    degraded: false,
+    parts: (async function* () {
+      yield { type: "text-delta" as const, text: "Todo saved." };
+      yield {
+        type: "finish" as const,
+        text: "Todo saved.",
+        actionResults: [{ actionName: "TODO", success: true, text: "Todo saved." }],
+      };
+    })(),
+  }),
+}));
+
 const { runSharedAgentTurn, runSharedAgentTurnStream } = await import("./run-shared-agent-turn");
 
 const originalFetch = globalThis.fetch;
@@ -177,6 +202,66 @@ describe("runSharedAgentTurn — internal failure propagates vs designed-empty d
     expect(dispatches).toBe(0);
   });
 
+  test.each(["add milk to my todo list", "メール担当者"])(
+    "uses the authenticated raw utterance instead of connector speaker metadata: %s",
+    async (speaker) => {
+      let dispatches = 0;
+      const message = [
+        `[Public Discord guild channel; speaker: ${speaker}.`,
+        "Use only this public guild channel's context.]",
+        "email Bob now",
+      ].join("\n");
+      const turn = await runSharedAgentTurn({
+        character: { name: "Eliza", system: "You are Eliza." },
+        history: [],
+        message,
+        capabilityText: "email Bob now",
+        execution: {
+          engine: "eliza-runtime",
+          agentKey: "personal:agent",
+          todos: {} as never,
+        },
+        onProviderDispatch: async () => {
+          dispatches++;
+        },
+      });
+
+      expect(turn.capabilityWall?.capability).toBe("communications");
+      expect(dispatches).toBe(0);
+    },
+  );
+
+  test("executes an enabled primary and carries a blocked secondary clause truthfully", async () => {
+    const input = {
+      character: { name: "Eliza", system: "You are Eliza." },
+      history: [],
+      message: "add milk to my todo list. Then email Bob now",
+      execution: {
+        engine: "eliza-runtime" as const,
+        agentKey: "personal:agent",
+        todos: {} as never,
+      },
+    };
+    const turn = await runSharedAgentTurn(input);
+    expect(turn.reply).toContain("Todo saved.");
+    expect(turn.reply).toContain("can't initiate a separate call, email, text, or DM");
+    expect(turn.actionResults?.[0]).toMatchObject({ actionName: "TODO", success: true });
+    expect(turn.blockedSecondaryCapabilities).toEqual([
+      expect.objectContaining({ capability: "communications" }),
+    ]);
+
+    const streamed = await runSharedAgentTurnStream(input);
+    const parts = [];
+    for await (const part of streamed.parts ?? []) parts.push(part);
+    expect(parts).toContainEqual(
+      expect.objectContaining({
+        type: "finish",
+        text: expect.stringContaining("can't initiate a separate call, email, text, or DM"),
+      }),
+    );
+    expect(streamed.blockedSecondaryCapabilities?.[0]?.capability).toBe("communications");
+  });
+
   test("tells the model the same capability truth for ambiguous follow-ups", async () => {
     let system = "";
     generateTextImpl = async (options) => {
@@ -198,7 +283,7 @@ describe("runSharedAgentTurn — internal failure propagates vs designed-empty d
     });
 
     expect(system).toContain("Shared runtime boundaries");
-    expect(system).toContain("no external tools");
+    expect(system).toContain("no connected accounts");
     expect(system).toContain("Never claim that you performed");
     expect(system).toContain("needs Dedicated");
   });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
@@ -235,7 +235,7 @@ describe("runSharedAgentTurn — internal failure propagates vs designed-empty d
     const input = {
       character: { name: "Eliza", system: "You are Eliza." },
       history: [],
-      message: "add milk to my todo list. Then email Bob now",
+      message: "add call Mom to my todo list. Then email Bob now",
       execution: {
         engine: "eliza-runtime" as const,
         agentKey: "personal:agent",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
@@ -267,7 +267,9 @@ describe("runSharedAgentTurn — internal failure propagates vs designed-empty d
       }),
     );
     expect(streamed.blockedSecondaryCapabilities?.[0]?.capability).toBe("communications");
-    expect(recordedReplies).toEqual([turn.reply, parts.at(-1)?.text]);
+    // Streaming persistence is owned by SharedRuntimeChatService so cancellation
+    // and retries converge on the transport's stable message ids.
+    expect(recordedReplies).toEqual([turn.reply]);
   });
 
   test("tells the model the same capability truth for ambiguous follow-ups", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -29,8 +29,12 @@ import {
   getInteractiveCerebrasLanguageModel,
   hasLanguageModelProviderConfigured,
 } from "../../providers/language-model";
-import { resolveSharedCapabilityWall, type SharedCapabilityWall } from "./shared-capability-wall";
 import type { SharedMemoryStore } from "./shared-memory-store";
+import {
+  resolveSharedCapabilityIntent,
+  type SharedCapabilityResolution,
+  type SharedCapabilityWall,
+} from "./shared-capability-wall";
 import { resolveSharedNavIntent, type SharedNavIntent } from "./shared-nav-intent";
 
 export interface SharedTurnMessage {
@@ -64,6 +68,8 @@ export interface RunSharedAgentTurnInput {
   history: SharedTurnMessage[];
   /** The incoming user message or event text. */
   message: string;
+  /** Authenticated raw utterance used for intent checks when `message` includes server context. */
+  capabilityText?: string;
   /** Trusted lifecycle callers may add a system event instead of impersonating the user. */
   messageRole?: "system" | "user";
   /** Stable ids assigned by the transport for the persisted user/assistant pair. */
@@ -129,6 +135,8 @@ export interface RunSharedAgentTurnResult {
   navIntent?: SharedNavIntent;
   /** Typed refusal for a tool or device action Shared cannot execute. */
   capabilityWall?: SharedCapabilityWall;
+  /** Unsupported clauses that follow an enabled primary reminder or Todo. */
+  blockedSecondaryCapabilities?: SharedCapabilityWall[];
 }
 
 export type SharedAgentTurnStreamPart =
@@ -160,6 +168,8 @@ export interface RunSharedAgentTurnStreamResult {
   navIntent?: SharedNavIntent;
   /** Typed refusal for a tool or device action Shared cannot execute. */
   capabilityWall?: SharedCapabilityWall;
+  /** Unsupported clauses that follow an enabled primary reminder or Todo. */
+  blockedSecondaryCapabilities?: SharedCapabilityWall[];
 }
 
 /**
@@ -322,6 +332,64 @@ function modelHistoryContent(message: SharedTurnMessage): string {
   return message.content;
 }
 
+function capabilityResolution(
+  input: RunSharedAgentTurnInput,
+  capabilities: { reminders: boolean; todos: boolean },
+): SharedCapabilityResolution | null {
+  return resolveSharedCapabilityIntent(input.capabilityText ?? input.message, capabilities);
+}
+
+function appendBlockedCapabilityReplies(reply: string, blocked: SharedCapabilityWall[]): string {
+  const additions = blocked.map((wall) => wall.reply).filter((text) => !reply.includes(text));
+  return additions.length ? `${reply.trim()}\n\n${additions.join("\n\n")}` : reply;
+}
+
+function blockedCapabilityReplySuffix(reply: string, blocked: SharedCapabilityWall[]): string {
+  const additions = blocked.map((wall) => wall.reply).filter((text) => !reply.includes(text));
+  return additions.length ? `\n\n${additions.join("\n\n")}` : "";
+}
+
+function withBlockedSecondaryCapabilities(
+  result: RunSharedAgentTurnResult,
+  input: RunSharedAgentTurnInput,
+  blocked: SharedCapabilityWall[],
+): RunSharedAgentTurnResult {
+  if (!blocked.length) return result;
+  const reply = appendBlockedCapabilityReplies(result.reply, blocked);
+  return {
+    ...result,
+    reply,
+    history: appendSharedTurn(
+      input.history,
+      input.message.trim(),
+      reply,
+      input.messageIds,
+      input.messageRole,
+    ),
+    blockedSecondaryCapabilities: blocked,
+  };
+}
+
+function withBlockedSecondaryStream(
+  result: RunSharedAgentTurnStreamResult,
+  blocked: SharedCapabilityWall[],
+): RunSharedAgentTurnStreamResult {
+  if (!blocked.length || !result.parts) return result;
+  const source = result.parts;
+  const parts = (async function* (): AsyncIterable<SharedAgentTurnStreamPart> {
+    for await (const part of source) {
+      if (part.type === "text-delta") {
+        yield part;
+        continue;
+      }
+      const suffix = blockedCapabilityReplySuffix(part.text, blocked);
+      const text = `${part.text.trim()}${suffix}`;
+      if (suffix) yield { type: "text-delta", text: suffix };
+      yield { ...part, text };
+    }
+  })();
+  return { ...result, parts, blockedSecondaryCapabilities: blocked };
+}
 /**
  * Run one shared (container-free) turn for a simple agent. Returns a degraded
  * result only when NO shared model is configured (a designed-unavailable state);
@@ -336,11 +404,15 @@ export async function runSharedAgentTurn(
 
   const remindersEnabled = Boolean(input.execution?.reminders);
   const todosEnabled = Boolean(input.execution?.todos);
-  const requestedCapability = resolveSharedCapabilityWall(message);
-  const capabilityWall = resolveSharedCapabilityWall(message, {
+  const capabilities = {
     reminders: remindersEnabled,
     todos: todosEnabled,
-  });
+  };
+  const requestedCapability = resolveSharedCapabilityIntent(input.capabilityText ?? message);
+  const resolution = capabilityResolution(input, capabilities);
+  const capabilityWall = resolution?.kind === "blocked-primary" ? resolution.blocked : undefined;
+  const blockedSecondary =
+    resolution?.kind === "enabled-primary" ? resolution.blockedSecondary : [];
   if (capabilityWall) {
     return {
       reply: capabilityWall.reply,
@@ -365,9 +437,11 @@ export async function runSharedAgentTurn(
   // durable action is registered, persistence must win over an app-navigation
   // handoff or the turn would claim success without writing anything.
   const navIntent =
-    todosEnabled && requestedCapability?.capability === "todos"
+    todosEnabled &&
+    requestedCapability?.kind === "blocked-primary" &&
+    requestedCapability.blocked.capability === "todos"
       ? null
-      : resolveSharedNavIntent(message);
+      : resolveSharedNavIntent(input.capabilityText ?? message);
   if (navIntent) {
     return {
       reply: navIntent.reply,
@@ -398,7 +472,7 @@ export async function runSharedAgentTurn(
 
   if (input.execution?.engine === "eliza-runtime") {
     const { runSharedElizaRuntimeTurn } = await import("./shared-eliza-runtime");
-    const turn = await runSharedElizaRuntimeTurn({
+    const result = await runSharedElizaRuntimeTurn({
       ...input,
       character: {
         ...input.character,
@@ -410,6 +484,7 @@ export async function runSharedAgentTurn(
       agentKey: input.execution.agentKey,
       model: modelId,
     });
+    const turn = withBlockedSecondaryCapabilities(result, input, blockedSecondary);
     await commitSharedTurnMemory(input, turn.reply);
     return turn;
   }
@@ -437,13 +512,23 @@ export async function runSharedAgentTurn(
       ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
     });
     const reply = text.trim() || "…";
-    turn = {
-      reply,
-      history: appendSharedTurn(input.history, message, reply, input.messageIds, input.messageRole),
-      model: modelId,
-      degraded: false,
-      usage,
-    };
+    turn = withBlockedSecondaryCapabilities(
+      {
+        reply,
+        history: appendSharedTurn(
+          input.history,
+          message,
+          reply,
+          input.messageIds,
+          input.messageRole,
+        ),
+        model: modelId,
+        degraded: false,
+        usage,
+      },
+      input,
+      blockedSecondary,
+    );
   } catch (error) {
     // error-policy:J2 context-adding rethrow. An inference/provider failure is an
     // INTERNAL failure, not a designed-empty result: swallowing it into a
@@ -477,12 +562,15 @@ export async function runSharedAgentTurnStream(
 
   const remindersEnabled = Boolean(input.execution?.reminders);
   const todosEnabled = Boolean(input.execution?.todos);
-  const requestedCapability = resolveSharedCapabilityWall(message);
-
-  const capabilityWall = resolveSharedCapabilityWall(message, {
+  const capabilities = {
     reminders: remindersEnabled,
     todos: todosEnabled,
-  });
+  };
+  const requestedCapability = resolveSharedCapabilityIntent(input.capabilityText ?? message);
+  const resolution = capabilityResolution(input, capabilities);
+  const capabilityWall = resolution?.kind === "blocked-primary" ? resolution.blocked : undefined;
+  const blockedSecondary =
+    resolution?.kind === "enabled-primary" ? resolution.blockedSecondary : [];
   if (capabilityWall) {
     const reply = capabilityWall.reply;
     const parts = (async function* (): AsyncIterable<SharedAgentTurnStreamPart> {
@@ -504,9 +592,11 @@ export async function runSharedAgentTurnStream(
   // identical to a normal turn; the caller reads `navIntent` to attach a VIEWS
   // navigation handoff to the `done` frame (#F5-ACTIONS).
   const navIntent =
-    todosEnabled && requestedCapability?.capability === "todos"
+    todosEnabled &&
+    requestedCapability?.kind === "blocked-primary" &&
+    requestedCapability.blocked.capability === "todos"
       ? null
-      : resolveSharedNavIntent(message);
+      : resolveSharedNavIntent(input.capabilityText ?? message);
   if (navIntent) {
     const reply = navIntent.reply;
     const parts = (async function* (): AsyncIterable<SharedAgentTurnStreamPart> {
@@ -537,18 +627,21 @@ export async function runSharedAgentTurnStream(
 
   if (input.execution?.engine === "eliza-runtime") {
     const { runSharedElizaRuntimeTurnStream } = await import("./shared-eliza-runtime");
-    return await runSharedElizaRuntimeTurnStream({
-      ...input,
-      character: {
-        ...input.character,
-        system: buildSystemPrompt(input.character, {
-          reminders: remindersEnabled,
-          todos: todosEnabled,
-        }),
-      },
-      agentKey: input.execution.agentKey,
-      model: modelId,
-    });
+    return withBlockedSecondaryStream(
+      await runSharedElizaRuntimeTurnStream({
+        ...input,
+        character: {
+          ...input.character,
+          system: buildSystemPrompt(input.character, {
+            reminders: remindersEnabled,
+            todos: todosEnabled,
+          }),
+        },
+        agentKey: input.execution.agentKey,
+        model: modelId,
+      }),
+      blockedSecondary,
+    );
   }
 
   try {
@@ -645,12 +738,15 @@ export async function runSharedAgentTurnStream(
       }
     })();
 
-    return {
-      model: modelId,
-      degraded: false,
-      parts,
-      cancel,
-    };
+    return withBlockedSecondaryStream(
+      {
+        model: modelId,
+        degraded: false,
+        parts,
+        cancel,
+      },
+      blockedSecondary,
+    );
   } catch (error) {
     // error-policy:J2 context-adding rethrow. Preserve the setup/provider cause
     // so the caller refunds only a provably unaccepted invocation.

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -29,12 +29,12 @@ import {
   getInteractiveCerebrasLanguageModel,
   hasLanguageModelProviderConfigured,
 } from "../../providers/language-model";
-import type { SharedMemoryStore } from "./shared-memory-store";
 import {
   resolveSharedCapabilityIntent,
   type SharedCapabilityResolution,
   type SharedCapabilityWall,
 } from "./shared-capability-wall";
+import type { SharedMemoryStore } from "./shared-memory-store";
 import { resolveSharedNavIntent, type SharedNavIntent } from "./shared-nav-intent";
 
 export interface SharedTurnMessage {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
@@ -71,7 +71,10 @@ describe("Shared capability wall", () => {
     "remind me to email Bob",
     "remind me to email Bob and then call Alice",
     "remind me to email Bob and email Alice tomorrow",
-  ])("keeps coordinated communication inside an enabled reminder payload: %s", (message) => {
+    "remind me in 1 minute: QA20315-DISCORD-DM-R3 verified",
+    "remind me in two minutes to text Alice",
+    "remind me tomorrow to email Bob the itinerary",
+  ])("keeps nested communication inside an enabled reminder payload: %s", (message) => {
     expect(resolveSharedCapabilityIntent(message, { reminders: true })).toEqual({
       kind: "enabled-primary",
       primary: expect.objectContaining({ capability: "reminders" }),
@@ -101,6 +104,32 @@ describe("Shared capability wall", () => {
     ).toBe("communications");
   });
 
+  test.each([
+    ["remind me tomorrow, then email Bob now", "communications"],
+    ["remind me tomorrow; delete the file in my workspace", "filesystem"],
+    ["add milk to my todo list. Then buy groceries", "purchases"],
+  ])(
+    "preserves enabled primary intent and reports a blocked later clause: %s",
+    (message, blocked) => {
+      expect(resolveSharedCapabilityIntent(message, { reminders: true, todos: true })).toEqual({
+        kind: "enabled-primary",
+        primary: expect.any(Object),
+        blockedSecondary: [expect.objectContaining({ capability: blocked })],
+      });
+    },
+  );
+
+  test("keeps first-command authority when an unsupported command precedes a reminder", () => {
+    expect(
+      resolveSharedCapabilityIntent("email Bob now and remind me tomorrow", {
+        reminders: true,
+      }),
+    ).toEqual({
+      kind: "blocked-primary",
+      blocked: expect.objectContaining({ capability: "communications" }),
+    });
+  });
+
   test("does not falsely claim voice and messaging require Dedicated", () => {
     const wall = resolveSharedCapabilityWall("call Mom");
     expect(wall?.reply).toContain("connected voice and messaging channels");
@@ -126,5 +155,13 @@ describe("Shared capability wall", () => {
       }),
     ).toBeNull();
     expect(resolveSharedCapabilityWall("add milk to my todo list")?.capability).toBe("todos");
+  });
+
+  test("keeps nested communication words inside an enabled Todo", () => {
+    expect(resolveSharedCapabilityIntent("add call Mom to my todo list", { todos: true })).toEqual({
+      kind: "enabled-primary",
+      primary: expect.objectContaining({ capability: "todos" }),
+      blockedSecondary: [],
+    });
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
@@ -74,6 +74,7 @@ describe("Shared capability wall", () => {
     "remind me in 1 minute: QA20315-DISCORD-DM-R3 verified",
     "remind me in two minutes to text Alice",
     "remind me tomorrow to email Bob the itinerary",
+    "remind me to email Bob and call Alice",
   ])("keeps nested communication inside an enabled reminder payload: %s", (message) => {
     expect(resolveSharedCapabilityIntent(message, { reminders: true })).toEqual({
       kind: "enabled-primary",
@@ -106,8 +107,11 @@ describe("Shared capability wall", () => {
 
   test.each([
     ["remind me tomorrow, then email Bob now", "communications"],
+    ["remind me tomorrow and email Bob now", "communications"],
+    ["remind me to email Bob, then email Alice now", "communications"],
     ["remind me tomorrow; delete the file in my workspace", "filesystem"],
     ["add milk to my todo list. Then buy groceries", "purchases"],
+    ["add milk to my todo list and email Bob now", "communications"],
   ])(
     "preserves enabled primary intent and reports a blocked later clause: %s",
     (message, blocked) => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
@@ -27,6 +27,7 @@ describe("Shared capability wall", () => {
     ["text Alice that I'm late", "communications"],
     ["send Bob a message", "communications"],
     ["remind me tomorrow and message Bob now", "reminders"],
+    ["message Bob the update", "communications"],
     ["order dinner for me", "purchases"],
     ["save this as a note", "notes"],
     ["connect my Gmail", "cloud-apps"],
@@ -54,6 +55,8 @@ describe("Shared capability wall", () => {
     "List two ways to make a meeting shorter.",
     "List three ways to make a meeting shorter.",
     "Give me two ideas for making a meeting shorter.",
+    "Remember this code word for my next message: apricot-816.",
+    "Make this message shorter.",
   ])("keeps discussion and research in Shared: %s", (message) => {
     expect(resolveSharedCapabilityWall(message)).toBeNull();
   });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
@@ -140,6 +140,19 @@ describe("Shared capability wall", () => {
     },
   );
 
+  test("reports one actionable wall for repeated clauses of the same blocked capability", () => {
+    expect(
+      resolveSharedCapabilityIntent(
+        "add milk to my todo list. Then email Bob now, then email Alice now",
+        { todos: true },
+      ),
+    ).toEqual({
+      kind: "enabled-primary",
+      primary: expect.objectContaining({ capability: "todos" }),
+      blockedSecondary: [expect.objectContaining({ capability: "communications" })],
+    });
+  });
+
   test("keeps first-command authority when an unsupported command precedes a reminder", () => {
     expect(
       resolveSharedCapabilityIntent("email Bob now and remind me tomorrow", {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.test.ts
@@ -119,6 +119,20 @@ describe("Shared capability wall", () => {
     },
   );
 
+  test.each([
+    ["remind me tomorrow to call Mom; then email Bob now", "reminders"],
+    ["add call Mom to my todo list. Then text Alice now", "todos"],
+  ])(
+    "does not let a nested match hide a later clause of the same capability: %s",
+    (message, primary) => {
+      expect(resolveSharedCapabilityIntent(message, { reminders: true, todos: true })).toEqual({
+        kind: "enabled-primary",
+        primary: expect.objectContaining({ capability: primary }),
+        blockedSecondary: [expect.objectContaining({ capability: "communications" })],
+      });
+    },
+  );
+
   test("keeps first-command authority when an unsupported command precedes a reminder", () => {
     expect(
       resolveSharedCapabilityIntent("email Bob now and remind me tomorrow", {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
@@ -167,7 +167,6 @@ function startsInNonExecutionClause(text: string, index: number): boolean {
   const clauseStart = boundary ? boundary.index + boundary[0].length : 0;
   return NON_EXECUTION_CONTEXT.test(text.slice(clauseStart, index));
 }
-
 function matchesForRule(
   rule: (typeof RULES)[number],
   priority: number,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
@@ -191,6 +191,9 @@ function beginsSeparateClause(text: string, primary: CapabilityMatch, candidate:
     return !isReminderPayload || /[.!?;,]\s*(?:and\s+)?then\b[\s\S]*$/i.test(between);
   }
   if (!/\band\s*$/i.test(between)) return false;
+  // An infinitive after "remind me" is reminder content, even when that
+  // content coordinates several actions. A completed trigger followed by
+  // "and" starts a new command instead.
   return !isReminderPayload;
 }
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
@@ -212,13 +212,18 @@ export function resolveSharedCapabilityIntent(
   if (!isEnabled(primary, capabilities)) {
     return { kind: "blocked-primary", blocked: wallFor(primary) };
   }
+  const blockedCapabilities = new Set<SharedDedicatedCapability>();
   const blockedSecondary = matches
     .slice(1)
     .filter(
       (candidate) =>
         !isEnabled(candidate, capabilities) && beginsSeparateClause(text, primary, candidate),
     )
-    .map(wallFor);
+    .flatMap((candidate) => {
+      if (blockedCapabilities.has(candidate.rule.capability)) return [];
+      blockedCapabilities.add(candidate.rule.capability);
+      return [wallFor(candidate)];
+    });
   return {
     kind: "enabled-primary",
     primary: wallFor(primary),

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-capability-wall.ts
@@ -212,18 +212,13 @@ export function resolveSharedCapabilityIntent(
   if (!isEnabled(primary, capabilities)) {
     return { kind: "blocked-primary", blocked: wallFor(primary) };
   }
-  const blockedCapabilities = new Set<SharedDedicatedCapability>();
   const blockedSecondary = matches
     .slice(1)
     .filter(
       (candidate) =>
         !isEnabled(candidate, capabilities) && beginsSeparateClause(text, primary, candidate),
     )
-    .flatMap((match) => {
-      if (blockedCapabilities.has(match.rule.capability)) return [];
-      blockedCapabilities.add(match.rule.capability);
-      return [wallFor(match)];
-    });
+    .map(wallFor);
   return {
     kind: "enabled-primary",
     primary: wallFor(primary),

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
@@ -342,12 +342,15 @@ describe("shared-rest-adapter — messages", () => {
       NAMESPACE,
       "telegram:update-1",
       "platform",
+      undefined,
+      "hello",
     );
 
     expect(coordinateSharedBridge.mock.calls[0][2]).toEqual({
       executionCtx: EXECUTION_CTX,
       namespace: NAMESPACE,
       agentKind: "personal",
+      trustedUserUtterance: "hello",
     });
   });
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -540,6 +540,7 @@ export async function sharedRestMessageSend(
   clientMessageId?: string,
   funding: "organization-credits" | "platform" = "organization-credits",
   trustedDelivery?: SharedReminderDelivery,
+  trustedUserUtterance?: string,
 ): Promise<{ text: string; agentName: string }> {
   const rpc: BridgeRequest = {
     jsonrpc: "2.0",
@@ -560,6 +561,7 @@ export async function sharedRestMessageSend(
     executionCtx,
     namespace,
     ...(funding === "platform" ? { agentKind: "personal" as const } : {}),
+    ...(trustedUserUtterance ? { trustedUserUtterance } : {}),
   });
   if (response.error) {
     // A credit-reserve rejection is a permanent add-credits condition, not a

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -585,6 +585,36 @@ describe("SharedRuntimeChatService", () => {
     });
   });
 
+  test("streams successful primary effects together with blocked secondary capability results", async () => {
+    const blockedCommunication = {
+      capability: "communications",
+      label: "Calls and messages",
+      reply: "I can't initiate a separate email.",
+    };
+    streamTurn = {
+      degraded: false,
+      blockedSecondaryCapabilities: [blockedCommunication],
+      parts: (async function* () {
+        yield { type: "text-delta", text: "Created: [ ] Buy milk" };
+        yield {
+          type: "finish",
+          text: "Created: [ ] Buy milk\n\nI can't initiate a separate email.",
+          actionResults: [expectedTodoActionResult],
+        };
+      })(),
+    };
+    const response = await new SharedRuntimeChatService().stream(agent, rpc, {
+      ...harness(),
+      funding: "platform",
+      executionEngine: "eliza-runtime",
+    });
+
+    const body = await response.text();
+    expect(body).toContain(JSON.stringify(expectedTodoActionResult));
+    expect(body).toContain('"actionName":"DEDICATED_CAPABILITY_REQUIRED"');
+    expect(body).toContain('"capability":"communications"');
+  });
+
   test("enables reminders only for platform-funded turns with trusted private delivery", async () => {
     const service = new SharedRuntimeChatService();
     const trustedRpc = {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -586,6 +586,7 @@ describe("SharedRuntimeChatService", () => {
   });
 
   test("streams successful primary effects together with blocked secondary capability results", async () => {
+    process.env.SHARED_MEMORY_TABLES_ENABLED = "true";
     const blockedCommunication = {
       capability: "communications",
       label: "Calls and messages",
@@ -613,6 +614,12 @@ describe("SharedRuntimeChatService", () => {
     expect(body).toContain(JSON.stringify(expectedTodoActionResult));
     expect(body).toContain('"actionName":"DEDICATED_CAPABILITY_REQUIRED"');
     expect(body).toContain('"capability":"communications"');
+    expect(memoryPairs).toEqual([
+      expect.objectContaining({
+        assistantReply: "Created: [ ] Buy milk\n\nI can't initiate a separate email.",
+        interrupted: false,
+      }),
+    ]);
   });
 
   test("enables reminders only for platform-funded turns with trusted private delivery", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -104,12 +104,18 @@ export interface SharedRuntimeHistoryStore {
 }
 
 function turnActionResults(
-  turn: Pick<RunSharedAgentTurnResult, "actionResults" | "navIntent" | "capabilityWall">,
+  turn: Pick<
+    RunSharedAgentTurnResult,
+    "actionResults" | "navIntent" | "capabilityWall" | "blockedSecondaryCapabilities"
+  >,
 ): unknown[] | undefined {
-  if (turn.actionResults?.length) return turn.actionResults;
-  if (turn.capabilityWall) return [capabilityWallActionResult(turn.capabilityWall)];
-  if (turn.navIntent) return [navIntentActionResult(turn.navIntent)];
-  return undefined;
+  const results: unknown[] = [...(turn.actionResults ?? [])];
+  if (turn.capabilityWall) results.push(capabilityWallActionResult(turn.capabilityWall));
+  if (turn.navIntent) results.push(navIntentActionResult(turn.navIntent));
+  for (const wall of turn.blockedSecondaryCapabilities ?? []) {
+    results.push(capabilityWallActionResult(wall));
+  }
+  return results.length ? results : undefined;
 }
 
 function isDeterministicFreeTurn(
@@ -166,6 +172,8 @@ export interface SharedRuntimeChatOptions {
   funding?: "organization-credits" | "platform";
   /** Server-authenticated lifecycle prompt; never derived from bridge params. */
   trustedMessageRole?: "system";
+  /** Server-authenticated raw utterance when the model message includes connector context. */
+  trustedUserUtterance?: string;
   /** Local/transition gate for proving the genuine Workerd AgentRuntime path. */
   executionEngine?: "direct-model" | "eliza-runtime";
 }
@@ -862,6 +870,7 @@ export class SharedRuntimeChatService {
         character,
         history,
         message: text,
+        ...(options.trustedUserUtterance ? { capabilityText: options.trustedUserUtterance } : {}),
         messageRole,
         messageIds,
         ...(claimKey ? { originClientMessageId: claimKey } : {}),
@@ -1045,6 +1054,7 @@ export class SharedRuntimeChatService {
         character,
         history,
         message: text,
+        ...(options.trustedUserUtterance ? { capabilityText: options.trustedUserUtterance } : {}),
         messageRole,
         messageIds,
         ...(claimKey ? { originClientMessageId: claimKey } : {}),
@@ -1213,9 +1223,10 @@ export class SharedRuntimeChatService {
               );
               continue;
             }
-            const actionResults = part.actionResults?.length
-              ? part.actionResults
-              : turnActionResults(turn);
+            const actionResults = turnActionResults({
+              ...turn,
+              ...(part.actionResults?.length ? { actionResults: part.actionResults } : {}),
+            });
             await finalizeMessages(finalReply, false, async () => {
               // Durable claim completion before the done frame: a lost/dropped
               // terminal frame replays this result on retry instead of


### PR DESCRIPTION
Closes #20330.

## Boundary

This is the Shared capability-intent slice extracted from the closed integration draft. It is limited to authenticated utterance plumbing and deterministic capability handling for Shared turns.

## Repair

- evaluate capability intent from the server-authenticated raw user utterance, not connector speaker/context wrappers
- preserve enabled reminders or Todos as primary operations when action words occur inside their payload
- surface independent unsupported secondary clauses as typed results and truthful reply suffixes in sync and SSE flows
- retain later blocked clauses, deduplicate repeated walls, and keep advice, research, negation, and ordered payload text out of the execution wall
- commit the final truthful reply to durable Shared memory before the streaming finish frame

## Exact-head validation

- head: 7ca98b565fbbd51006e5728bc1cbadb6fa37aaf5
- six affected suites: 152/152 passed, 403 assertions
- Cloud Shared typecheck: pass
- Cloud Shared Biome: pass
- diff check: pass
- root verify on the immediately preceding base: 356/356 plus anti-larp clean; final rebase added only unrelated auth UI, DNS/infra, embeddings, and core response-guidance commits, then the complete affected matrix and package gates were rerun on this exact head

No deployment, provider send, production reminder creation, environment approval, or production action was performed.