### PR TITLE
test(ci): lint Worker secret/var namespace collisions (CF 10053 class)

### DIFF
--- a/packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Guards the Worker secret/var namespace: Cloudflare rejects `wrangler secret
+ * put NAME` with error 10053 when the served Worker version already defines
+ * NAME as a plain [vars] binding. This collision class caused two live
+ * incidents (CARTESIA_API_KEY at launch; PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED
+ * on the 2026-08-16 staging edge flip). Every workflow-published secret is
+ * enumerated here with the environments it targets; the test fails when
+ * wrangler.toml defines the same name as a var for a targeted environment —
+ * and when a new `secret put` appears in a workflow without a mapping entry.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+
+const repoRoot = new URL("../../../", import.meta.url);
+const wranglerSource = readFileSync(
+  new URL("packages/cloud/api/wrangler.toml", repoRoot),
+  "utf8",
+);
+
+/** Parse var names per environment from wrangler.toml ("default" = top-level [vars]). */
+function parseWranglerVars(source: string): Map<string, Set<string>> {
+  const envs = new Map<string, Set<string>>();
+  let current: string | null = null;
+  for (const rawLine of source.split("\n")) {
+    const line = rawLine.trim();
+    const section = line.match(/^\[(?:env\.([a-z0-9_-]+)\.)?vars\]$/);
+    if (section) {
+      current = section[1] ?? "default";
+      if (!envs.has(current)) envs.set(current, new Set());
+      continue;
+    }
+    if (/^\[/.test(line)) {
+      current = null;
+      continue;
+    }
+    if (current) {
+      const assignment = line.match(/^([A-Z][A-Z0-9_]+)\s*=/);
+      if (assignment) envs.get(current)?.add(assignment[1]);
+    }
+  }
+  return envs;
+}
+
+/**
+ * Workflow-published Worker secrets and the environments whose Worker script
+ * they target. Adding a new `wrangler secret put` to any workflow requires a
+ * row here — the discovery assertion below fails otherwise.
+ */
+const PUBLISHED_WORKER_SECRETS: Array<{ name: string; envs: string[] }> = [
+  // cloud-cf-release.yml publish_secret / publish_toggle_secret chain
+  { name: "CARTESIA_API_KEY", envs: ["staging", "production"] },
+  { name: "STAGING_SESSION_EXCHANGE_ENABLED", envs: ["staging"] },
+  // activate-personal-shared-telegram-edge.yml (staging-only protected cutover)
+  { name: "PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED", envs: ["staging"] },
+];
+
+describe("Worker secret/var collision lint (CF error 10053 class)", () => {
+  const vars = parseWranglerVars(wranglerSource);
+
+  test("wrangler.toml parses at least default and staging var blocks", () => {
+    expect(vars.has("default")).toBe(true);
+    expect(vars.has("staging")).toBe(true);
+    expect((vars.get("default") ?? new Set()).size).toBeGreaterThan(3);
+  });
+
+  test("no workflow-published secret name is defined as a wrangler var in a targeted environment", () => {
+    const collisions: string[] = [];
+    for (const { name, envs } of PUBLISHED_WORKER_SECRETS) {
+      for (const env of envs) {
+        if (vars.get(env)?.has(name)) {
+          collisions.push(`${name} → [env.${env}.vars]`);
+        }
+      }
+    }
+    expect(collisions).toEqual([]);
+  });
+
+  test("every `wrangler secret put` in workflows has a mapping entry", () => {
+    const workflowsDir = new URL(".github/workflows/", repoRoot);
+    const mapped = new Set(PUBLISHED_WORKER_SECRETS.map((s) => s.name));
+    const unmapped = new Set<string>();
+    for (const file of readdirSync(workflowsDir)) {
+      if (!file.endsWith(".yml") && !file.endsWith(".yaml")) continue;
+      const source = readFileSync(new URL(file, workflowsDir), "utf8");
+      for (const match of source.matchAll(
+        /secret\s+put\s+"?\$?\{?\{?\s*([A-Z][A-Z0-9_]+)/g,
+      )) {
+        const token = match[1];
+        // Indirect names (secret put "$SECRET_NAME") resolve through workflow
+        // env vars; capture the literal env-var values on SECRET_NAME-style
+        // assignments instead.
+        if (
+          token === "SECRET_NAME" ||
+          token === "GITHUB" ||
+          token === "INPUT"
+        ) {
+          continue;
+        }
+        if (!mapped.has(token)) unmapped.add(token);
+      }
+      for (const match of source.matchAll(
+        /SECRET_NAME:\s*"?([A-Z][A-Z0-9_]+)"?/g,
+      )) {
+        if (!mapped.has(match[1])) unmapped.add(match[1]);
+      }
+    }
+    expect([...unmapped].sort()).toEqual([]);
+  });
+
+  test("prophylactic: the production edge flip requires removing the production var first", () => {
+    // The staging incident repeats verbatim on the production cutover unless
+    // [env.production.vars] drops PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED before
+    // any workflow publishes it as a production secret. This assertion is the
+    // tripwire: whoever extends the activation workflow to production must
+    // delete the var in the same change (this test's mapping gains
+    // "production" then, and the collision test above enforces the removal).
+    expect(
+      vars.get("production")?.has("PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED") ??
+        false,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Kills the collision class that caused two live incidents

CARTESIA_API_KEY (launch night) and PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED (tonight's staging edge flip, CF 10053, fail-closed rollback) both came from the same footgun: a wrangler `[vars]` name colliding with a workflow-published Worker secret. This env-aware lint: enumerates every workflow-published secret + its target environments (discovery assertion fails on any new `secret put` without a mapping row), fails when wrangler defines the same name as a var for a targeted env, and carries a **prophylactic tripwire**: the production edge flip must drop `PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED` from `[env.production.vars]` in the same change or CI screams before CF does.

4/4 (bun), Biome clean, pure test addition. Runs in the existing packages/scripts lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)