### PR TITLE
feat(cloud): fresh managed agents default to local 384-d embeddings

### DIFF
--- a/packages/cloud/shared/src/lib/services/managed-eliza-config.test.ts
+++ b/packages/cloud/shared/src/lib/services/managed-eliza-config.test.ts
@@ -250,13 +250,11 @@ describe("managed Eliza environment", () => {
     expect(result.environmentVars.ELIZA_AGENT_LOCAL_STATE).toBe("1");
   });
 
-  test("pins both embedding dimensions to 1536 so the storage column and the cloud probe agree (#8769)", async () => {
-    // Pinning EMBEDDING_DIMENSION + ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS=1536 makes
-    // the cloud TEXT_EMBEDDING handler EMIT 1536-wide vectors. plugin-sql does NOT
-    // read these vars; the storage column is sized at boot by the model-length
-    // probe (runtime.ensureEmbeddingDimension). Both must agree on 1536 or the boot
-    // probe snaps the column to a width the handler's output won't match -
-    // re-introducing "Skipping embedding insert: dimension mismatch" (#8769).
+  test("fresh provisions default to local 384-d embeddings and agree on the width (#8769 discipline)", async () => {
+    // 2026-08-16 platform default: fresh agents run local gte-small (384-d)
+    // instead of paid cloud text-embedding-3-small. Both dimension hints must
+    // still agree with the handler's real output or the boot probe snaps the
+    // storage column to a width the handler won't match (#8769).
     const { prepareManagedElizaBaseEnvironment } = await import("./managed-eliza-config");
 
     const result = await prepareManagedElizaBaseEnvironment({
@@ -265,8 +263,9 @@ describe("managed Eliza environment", () => {
       agentSandboxId: "cloud-agent-1",
     });
 
-    expect(result.environmentVars.EMBEDDING_DIMENSION).toBe("1536");
-    expect(result.environmentVars.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("1536");
+    expect(result.environmentVars.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBe("false");
+    expect(result.environmentVars.EMBEDDING_DIMENSION).toBe("384");
+    expect(result.environmentVars.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("384");
   });
 
   test("honors explicit per-agent embedding-dimension overrides", async () => {
@@ -296,7 +295,7 @@ describe("applyManagedAgentInferenceEnvDefaults (#8434)", () => {
     delete process.env.NEXT_PUBLIC_API_URL;
   });
 
-  test("returns all 5 inference keys with 1536-d embedding defaults on an empty env", async () => {
+  test("empty env (fresh provision) defaults to local-primary 384-d embeddings", async () => {
     const { applyManagedAgentInferenceEnvDefaults } = await import("./managed-eliza-config");
 
     const result = applyManagedAgentInferenceEnvDefaults({});
@@ -306,13 +305,39 @@ describe("applyManagedAgentInferenceEnvDefaults (#8434)", () => {
       "ELIZAOS_CLOUD_EMBEDDING_URL",
       "ELIZAOS_CLOUD_LARGE_MODEL",
       "ELIZAOS_CLOUD_SMALL_MODEL",
+      "ELIZAOS_CLOUD_USE_EMBEDDINGS",
       "EMBEDDING_DIMENSION",
     ]);
-    expect(result.EMBEDDING_DIMENSION).toBe("1536");
-    expect(result.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("1536");
+    expect(result.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBe("false");
+    expect(result.EMBEDDING_DIMENSION).toBe("384");
+    expect(result.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("384");
     expect(result.ELIZAOS_CLOUD_EMBEDDING_URL).toBeTruthy();
     expect(result.ELIZAOS_CLOUD_SMALL_MODEL).toBeTruthy();
     expect(result.ELIZAOS_CLOUD_LARGE_MODEL).toBeTruthy();
+  });
+
+  test("a previously provisioned agent (cloud key present) keeps the 1536-d cloud default — no #9911 heal", async () => {
+    const { applyManagedAgentInferenceEnvDefaults } = await import("./managed-eliza-config");
+
+    const result = applyManagedAgentInferenceEnvDefaults({
+      ELIZAOS_CLOUD_API_KEY: "eliza_existing_agent_key",
+    });
+
+    expect(result.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBeUndefined();
+    expect(result.EMBEDDING_DIMENSION).toBe("1536");
+    expect(result.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("1536");
+  });
+
+  test("a fresh provision can explicitly opt back into cloud embeddings", async () => {
+    const { applyManagedAgentInferenceEnvDefaults } = await import("./managed-eliza-config");
+
+    const result = applyManagedAgentInferenceEnvDefaults({
+      ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS: "0",
+    });
+
+    expect(result.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBeUndefined();
+    expect(result.EMBEDDING_DIMENSION).toBe("1536");
+    expect(result.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("1536");
   });
 
   test("local-primary embedding opt-in yields cloud embeddings and uses 384-dim hints", async () => {

--- a/packages/cloud/shared/src/lib/services/managed-eliza-config.ts
+++ b/packages/cloud/shared/src/lib/services/managed-eliza-config.ts
@@ -206,13 +206,17 @@ export function mergeManagedPublicBaseUrl(
  * provisioned BEFORE these pins landed heals on upgrade (#8434). An explicit
  * per-agent value always wins.
  *
- * Local-primary restore: when a managed lean-chat agent opts in with
- * ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS=1, keep cloud text generation defaults but
- * stop pinning the cloud embedding handler as primary. The local gte-small
- * handler emits 384-d vectors, so the managed defaults also move the embedding
- * dimension hints to 384 for that agent. This is deliberately per-agent and
- * flag-gated: existing 1536-d stores must be re-embedded/backfilled before the
- * flag is enabled or recall can degrade (#9911 class).
+ * Local-primary embeddings: FRESH provisions default to the local gte-small
+ * handler (384-d) instead of the paid cloud text-embedding-3-small path —
+ * nubs/shaw directive 2026-08-16: self-hosted embeddings are the platform
+ * default. Freshness is detected by the absence of ELIZAOS_CLOUD_API_KEY in
+ * existingEnv: a previously provisioned agent always carries its key (and its
+ * pinned dimension hints) in stored env, so upgrades/backfills keep their
+ * original width and a pre-pin legacy 1536-d store is never healed onto 384-d
+ * hints (#9911 recall-degradation class). Explicit controls still win both
+ * ways: ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS=1 opts an existing agent in (only
+ * after re-embedding its store), =0 keeps a fresh agent on the cloud path, and
+ * ELIZAOS_CLOUD_USE_EMBEDDINGS=true always restores cloud embeddings.
  *
  * NOTE on dimensions: EMBEDDING_DIMENSION / ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS
  * set the width of the vectors the plugin-elizacloud TEXT_EMBEDDING handler
@@ -228,8 +232,10 @@ export function mergeManagedPublicBaseUrl(
 export function applyManagedAgentInferenceEnvDefaults(
   existingEnv: Record<string, string>,
 ): Record<string, string> {
+  const explicitLean = existingEnv.ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS;
+  const isFreshProvision = !existingEnv.ELIZAOS_CLOUD_API_KEY?.trim();
   const localPrimaryEmbeddings =
-    existingEnv.ELIZA_LEAN_CHAT_LOCAL_EMBEDDINGS === "1" &&
+    (explicitLean === "1" || (isFreshProvision && explicitLean !== "0")) &&
     existingEnv.ELIZAOS_CLOUD_USE_EMBEDDINGS?.trim().toLowerCase() !== "true";
   const embeddingDimension = localPrimaryEmbeddings ? "384" : "1536";
   return {


### PR DESCRIPTION
## Slop-list item 3 (nubs-directed): stop paying OpenAI for every new dedicated agent's embeddings

The 384-d local lane (**lean-chat gte-small**) already existed as an opt-in — this flips it to the **default for fresh provisions only**. Freshness = no `ELIZAOS_CLOUD_API_KEY` in `existingEnv`; previously provisioned agents always carry their key + pinned dimension hints in stored env, so **upgrade backfills keep their original 1536 width** — the #9911 recall-degradation heal (384 hints over a 1536 store) is impossible by construction, and a regression test pins exactly that case. Explicit opt-outs preserved both directions.

## Evidence
| Check | Result |
|---|---|
| managed-eliza-config suite (22 tests incl. 3 new: fresh→384, existing-key→1536 no-heal, explicit opt-out→1536) | 22/22 ✅ |
| cloud/shared typecheck + Biome | ✅ |

Composes with the P1 sidecar arc (Worker-side embeddings) — this is the DEDICATED-agent half of killing the OpenAI dependency; the Worker half rides the parity workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)