### PR TITLE
fix(cloud): avoid duplicate voice conversation prewarm

### DIFF
--- a/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
+++ b/packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
@@ -156,16 +156,20 @@ export function createInternalElizaConversationFetchFactory(
         env as unknown as Record<string, unknown>,
         async () => {
           let agent = await readCachedAgent();
+          let conversationPrewarmAttemptedByHydration = false;
           if (!agent) {
             scheduleHydration();
             // Capture before awaiting: the hydration's finally block clears the
             // shared slot. Joining this exact promise lets the first voice turn
             // use the freshly cached scope without cache-miss polling/backoff.
             const pendingHydration = hydrationPromise;
-            if (pendingHydration) await pendingHydration;
+            if (pendingHydration) {
+              await pendingHydration;
+              conversationPrewarmAttemptedByHydration = true;
+            }
             agent = await readCachedAgent();
           }
-          if (!agent) return;
+          if (!agent || conversationPrewarmAttemptedByHydration) return;
           await coordinateSharedConversationPrewarm(
             agent.id,
             claims.conversationId,


### PR DESCRIPTION
# Relates to

Fixes #20612

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`; the candidate was rebased onto fetched `develop@b4ec809ad28e` before final focused/package validation.
- [x] The real internal-fetch regression, Cloud API build/typecheck, changed-file Biome, and diff checks pass.
- [x] An uncached root `bun run verify` passed 356/356 with every audit on the exact patch candidate before a final non-overlapping rebase.
- [x] The failure and repaired operation sequence are deterministic and recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Final published candidate: `9aa3f59fb6a4af90b34305691259a71d7cf4be4c` on `develop@b4ec809ad28e500d57eebd2b0d2afcc8bc961afc`.
- [x] `origin/develop` advanced after validation by two unrelated CI/scenario commits to `979408faf396`; neither touches Cloud API or the repaired source/test paths.
- [x] The repaired source is byte-identical to the root-verified candidate.

# Risks

Low and bounded to explicit voice conversation prewarm. Cold scope hydration already owns the conversation prewarm; this prevents its caller from immediately issuing the same operation again after joining that hydration. A warm cached scope still receives one explicit prewarm. Missing scope and hydration errors remain fail-closed.

# Background

## What does this PR do?

Tracks whether the cold-cache path joined the authoritative voice-scope hydration. Because that hydration already invokes `coordinateSharedConversationPrewarm`, the internal-fetch adapter returns after the joined attempt instead of repeating it. The normal cached-scope path is unchanged.

Before:

```text
expected operations: ["prewarm", "stream"]
actual operations:   ["prewarm", "prewarm", "stream"]
```

After:

```text
operations: ["prewarm", "stream"]
```

## What kind of change is this?

Bug fix (duplicate side effect in the realtime voice cold-cache path).

# Documentation changes needed?

No. This restores the existing single-prewarm contract without changing a public API.

# Testing

## Where should a reviewer start?

- `packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts`
- `packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts`

## Detailed testing steps

Pinned Bun `1.3.14`, Node `24.15.0`.

```bash
bun test packages/cloud/api/__tests__/shared-agent-messages-stream.test.ts
bun test packages/cloud/api/src/shared-runtime-conversation.test.ts
bun run --cwd packages/cloud/api build
bunx biome check packages/cloud/api/v1/voice/session/lib/internal-eliza-conversation-fetch.ts
git diff --check origin/develop...HEAD
bun run verify
```

# Evidence Gate

<!-- evidence-head:9aa3f59fb6a4af90b34305691259a71d7cf4be4c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend voice orchestration only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend voice orchestration only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual frontend flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no deploy or live backend was changed; the deterministic internal-operation transcript is recorded below.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser behavior changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, model output, or LLM decision behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted domain artifact is produced; the ordered voice-operation ledger is asserted in the focused regression below.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or text changed.

# Evidence Details

```text
Tests-first baseline on develop:
- shared-agent-messages-stream.test.ts: 20 pass / 1 fail
- expected ["prewarm", "stream"]
- received ["prewarm", "prewarm", "stream"]

Exact repaired candidate c0e5550 on develop@61d7df5:
- full shared-agent messages/stream file: 21/21
- shared runtime conversation: 16/16
- Cloud API build/typecheck: pass
- uncached root verify: 356/356, 0 cached, every audit
- anti-larp: 8,371 files, 0 focused, 0 orphaned skips

Final rebased head 9aa3f59 on develop@b4ec809:
- focused cold-cache contract: pass
- Cloud API build/typecheck: pass
- changed-file Biome and git diff --check: clean
- target source/test bytes unchanged from the root-verified candidate
```

The direct focused Bun test reports its passing result but retains an unrelated pricing/Postgres warmup handle; it was interrupted only after the result printed. This is not represented as a natural process exit. The authoritative isolated runner exits normally and supplied the original red result; the full file is green after the repair.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop"} -->
