### PR TITLE
feat(cloud): sampled turn-trace observability for shared agents (parity P5)

### DIFF
--- a/packages/cloud/shared/src/db/migrations/0211_shared_turn_traces.sql
+++ b/packages/cloud/shared/src/db/migrations/0211_shared_turn_traces.sql
@@ -1,0 +1,22 @@
+-- Sampled per-turn observability for Tier-0 shared agent turns (#20615 P5):
+-- compact stage/tool/latency/finish-reason traces written off-path by the
+-- flag-gated recorder. Never stores prompt or response text. Deliberately
+-- decoupled (no FKs) from tenant tables, like shared_runtime_history.
+
+CREATE TABLE IF NOT EXISTS "shared_turn_traces" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL,
+  "user_id" uuid NOT NULL,
+  "agent_id" text NOT NULL,
+  "channel_id" text,
+  "trace_id" text NOT NULL,
+  "started_at" timestamp NOT NULL,
+  "latency_ms" integer NOT NULL,
+  "model" text NOT NULL,
+  "usage" jsonb,
+  "stages" jsonb NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "shared_turn_traces_org_agent_created_idx"
+  ON "shared_turn_traces" ("organization_id", "agent_id", "created_at");

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1471,6 +1471,13 @@
       "when": 1787860800000,
       "tag": "0210_shared_agent_memories",
       "breakpoints": true
+    },
+    {
+      "idx": 210,
+      "version": "7",
+      "when": 1787860800001,
+      "tag": "0211_shared_turn_traces",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/shared-turn-traces.test.ts
+++ b/packages/cloud/shared/src/db/repositories/shared-turn-traces.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Exercises the shared turn traces repository's tenant scoping with scripted
+ * client mocks (no database): the recent-traces read must pin BOTH
+ * organization_id and agent_id in its WHERE clause — agent ids are
+ * caller-supplied text and the table has no FK back to tenant tables, so this
+ * SQL pin is the only cross-tenant read barrier — and the insert must carry
+ * the full org/user/agent scope it was handed.
+ */
+import { afterAll, describe, expect, mock, test } from "bun:test";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+import * as realClient from "../client";
+
+const ORG_ID = "0b6f9dd2-6a2f-4d55-b552-8f4f7bfb9f01";
+const AGENT_ID = "agent-under-test";
+
+// Scripted read chain: capture the WHERE clause and limit handed to the builder.
+let capturedWhere: SQL | undefined;
+let capturedLimit: number | undefined;
+const listRows = [{ id: "row-1" }, { id: "row-2" }];
+const limitFn = mock((n: number) => {
+  capturedLimit = n;
+  return Promise.resolve(listRows);
+});
+const orderByFn = mock(() => ({ limit: limitFn }));
+const whereFn = mock((clause: SQL) => {
+  capturedWhere = clause;
+  return { orderBy: orderByFn };
+});
+const fromFn = mock(() => ({ where: whereFn }));
+const selectFn = mock(() => ({ from: fromFn }));
+const dbReadMock = new Proxy(realClient.dbRead as unknown as Record<PropertyKey, unknown>, {
+  get(target, prop, receiver) {
+    if (prop === "select") return selectFn;
+    return Reflect.get(target, prop, receiver);
+  },
+});
+
+// Scripted write chain: capture the values object handed to insert().values().
+let capturedValues: Record<string, unknown> | undefined;
+const valuesFn = mock((values: Record<string, unknown>) => {
+  capturedValues = values;
+  return Promise.resolve();
+});
+const insertFn = mock(() => ({ values: valuesFn }));
+const dbWriteMock = new Proxy(realClient.dbWrite as unknown as Record<PropertyKey, unknown>, {
+  get(target, prop, receiver) {
+    if (prop === "insert") return insertFn;
+    return Reflect.get(target, prop, receiver);
+  },
+});
+
+mock.module("../client", () => ({
+  ...realClient,
+  dbRead: dbReadMock,
+  dbWrite: dbWriteMock,
+}));
+
+afterAll(() => {
+  mock.module("../client", () => realClient);
+});
+
+describe("SharedTurnTracesRepository.listRecentByAgent", () => {
+  test("pins organization_id AND agent_id in the WHERE clause and caps the limit", async () => {
+    capturedWhere = undefined;
+    capturedLimit = undefined;
+    const { SharedTurnTracesRepository } = await import("./shared-turn-traces");
+
+    const rows = await new SharedTurnTracesRepository().listRecentByAgent(ORG_ID, AGENT_ID, 25);
+
+    expect(rows).toEqual(listRows as never);
+    expect(selectFn).toHaveBeenCalledTimes(1);
+    expect(capturedLimit).toBe(25);
+
+    if (!capturedWhere) throw new Error("WHERE clause was not captured");
+    const sql = new PgDialect().sqlToQuery(capturedWhere);
+    // Both tenant pins must be present: org alone would mix an org's agents up
+    // only by caller honesty; agent alone would leak across organizations.
+    expect(sql.sql).toContain("organization_id");
+    expect(sql.sql).toContain("agent_id");
+    expect(sql.params).toContain(ORG_ID);
+    expect(sql.params).toContain(AGENT_ID);
+  });
+
+  test("clamps a hostile or absurd limit into the bounded page window", async () => {
+    const { SharedTurnTracesRepository } = await import("./shared-turn-traces");
+    const repository = new SharedTurnTracesRepository();
+
+    capturedLimit = undefined;
+    await repository.listRecentByAgent(ORG_ID, AGENT_ID, 1_000_000);
+    expect(capturedLimit).toBe(200);
+
+    capturedLimit = undefined;
+    await repository.listRecentByAgent(ORG_ID, AGENT_ID, -5);
+    expect(capturedLimit).toBe(1);
+
+    capturedLimit = undefined;
+    await repository.listRecentByAgent(ORG_ID, AGENT_ID, Number.NaN);
+    expect(capturedLimit).toBe(1);
+  });
+});
+
+describe("SharedTurnTracesRepository.insertTrace", () => {
+  test("writes the row with its full org/user/agent scope and jsonb payloads", async () => {
+    capturedValues = undefined;
+    const { SharedTurnTracesRepository } = await import("./shared-turn-traces");
+
+    await new SharedTurnTracesRepository().insertTrace({
+      organization_id: ORG_ID,
+      user_id: "4e2ffab7-9f21-4a2c-92b7-33dd25c7f8a2",
+      agent_id: AGENT_ID,
+      channel_id: "shared:agent:room",
+      trace_id: "trace-1",
+      started_at: new Date(1_787_860_800_000),
+      latency_ms: 812,
+      model: "gemma-4-31b",
+      usage: { inputTokens: 12 },
+      stages: { finishReason: "reply", stages: [{ name: "model" }] },
+    });
+
+    expect(insertFn).toHaveBeenCalledTimes(1);
+    if (!capturedValues) throw new Error("insert values were not captured");
+    expect(capturedValues.organization_id).toBe(ORG_ID);
+    expect(capturedValues.user_id).toBe("4e2ffab7-9f21-4a2c-92b7-33dd25c7f8a2");
+    expect(capturedValues.agent_id).toBe(AGENT_ID);
+    expect(capturedValues.trace_id).toBe("trace-1");
+    // jsonb columns are bound through jsonbParam (explicit ::jsonb SQL params).
+    const usageSql = new PgDialect().sqlToQuery(capturedValues.usage as SQL);
+    expect(usageSql.sql).toContain("::jsonb");
+    expect(usageSql.params).toContain(JSON.stringify({ inputTokens: 12 }));
+    const stagesSql = new PgDialect().sqlToQuery(capturedValues.stages as SQL);
+    expect(stagesSql.sql).toContain("::jsonb");
+    expect(stagesSql.params).toContain(
+      JSON.stringify({ finishReason: "reply", stages: [{ name: "model" }] }),
+    );
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/shared-turn-traces.ts
+++ b/packages/cloud/shared/src/db/repositories/shared-turn-traces.ts
@@ -1,0 +1,58 @@
+// Persists sampled shared turn trace records for cloud services through the shared DB boundary.
+import { and, desc, eq } from "drizzle-orm";
+import { dbRead, dbWrite } from "../client";
+import {
+  type NewSharedTurnTraceRow,
+  type SharedTurnTraceRow,
+  sharedTurnTraces,
+} from "../schemas/shared-turn-traces";
+import { jsonbParam } from "../utils/jsonb";
+
+export type { NewSharedTurnTraceRow, SharedTurnTraceRow };
+
+/** Hard cap on a recent-traces page so a diagnostics read can never table-scan. */
+const MAX_LIST_LIMIT = 200;
+
+/**
+ * Storage for the sampled Shared-turn observability traces written by
+ * `shared-turn-trace-recorder.ts`. Inserts carry the full tenant scope
+ * (organization/user/agent are NOT NULL on the table), and every read pins
+ * `organization_id` — the table has no FK back to the tenant tables, so the
+ * repository is the only place scoping is enforced.
+ */
+export class SharedTurnTracesRepository {
+  async insertTrace(trace: NewSharedTurnTraceRow): Promise<void> {
+    await dbWrite.insert(sharedTurnTraces).values({
+      ...trace,
+      ...(trace.usage === undefined || trace.usage === null
+        ? {}
+        : { usage: jsonbParam(trace.usage) }),
+      stages: jsonbParam(trace.stages),
+    });
+  }
+
+  /**
+   * Recent traces for one agent, newest first, pinned to the requesting
+   * organization. The org pin is mandatory: agent ids are caller-supplied
+   * text, so without it a guessed agent id would leak another tenant's traces.
+   */
+  async listRecentByAgent(
+    organizationId: string,
+    agentId: string,
+    limit: number,
+  ): Promise<SharedTurnTraceRow[]> {
+    return await dbRead
+      .select()
+      .from(sharedTurnTraces)
+      .where(
+        and(
+          eq(sharedTurnTraces.organization_id, organizationId),
+          eq(sharedTurnTraces.agent_id, agentId),
+        ),
+      )
+      .orderBy(desc(sharedTurnTraces.created_at))
+      .limit(Math.min(Math.max(Math.trunc(limit) || 1, 1), MAX_LIST_LIMIT));
+  }
+}
+
+export const sharedTurnTracesRepository = new SharedTurnTracesRepository();

--- a/packages/cloud/shared/src/db/schemas/index.ts
+++ b/packages/cloud/shared/src/db/schemas/index.ts
@@ -95,6 +95,7 @@ export * from "./seo";
 export * from "./service-pricing";
 export * from "./shared-agent-memories";
 export * from "./shared-runtime-history";
+export * from "./shared-turn-traces";
 export * from "./sso-bridge";
 export * from "./stripe-connect-accounts";
 export * from "./telegram-chats";

--- a/packages/cloud/shared/src/db/schemas/shared-turn-traces.ts
+++ b/packages/cloud/shared/src/db/schemas/shared-turn-traces.ts
@@ -1,0 +1,74 @@
+// Defines the shared turn traces Drizzle table shape used by cloud repositories and services.
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { index, integer, jsonb, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+
+/** Terminal outcome of a Shared turn as classified by the trace recorder. */
+export type SharedTurnTraceFinishReason = "reply" | "capability-wall" | "nav-intent" | "degraded";
+
+/**
+ * One compact stage in a Shared turn trace: a short machine name, an optional
+ * measured duration, and — for action stages — the registered tool name.
+ * Deliberately carries NO prompt, reply, or argument text.
+ */
+export type SharedTurnTraceStage = {
+  name: string;
+  durationMs?: number;
+  tool?: string;
+};
+
+/** The `stages` jsonb payload: ordered stage list plus the turn's finish reason. */
+export type SharedTurnTraceStages = {
+  finishReason: SharedTurnTraceFinishReason;
+  stages: SharedTurnTraceStage[];
+};
+
+/** Token counts mirrored from `SharedAgentTurnUsage` (numbers only, no text). */
+export type SharedTurnTraceUsage = {
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+};
+
+/**
+ * Sampled per-turn observability for Tier-0 "shared" agent turns, which run
+ * with `enableTrajectories: false` (full trajectory capture costs latency and
+ * money on the interactive hot path). Each row is a COMPACT off-path record —
+ * stage names, durations, tool names, finish reason, token usage — and never
+ * prompt or response text, so the table stays small and privacy-safe.
+ *
+ * Rows are written by the flag-gated, deterministically sampled recorder in
+ * `lib/services/shared-runtime/shared-turn-trace-recorder.ts`. Like
+ * `shared_runtime_history`, the table is deliberately decoupled from the
+ * tenant/billing tables (no FK cascade) so the diagnostics path can never
+ * block or ripple into a tenant-owned write; every read must still pin
+ * `organization_id` in the repository.
+ */
+export const sharedTurnTraces = pgTable(
+  "shared_turn_traces",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organization_id: uuid("organization_id").notNull(),
+    user_id: uuid("user_id").notNull(),
+    agent_id: text("agent_id").notNull(),
+    channel_id: text("channel_id"),
+    trace_id: text("trace_id").notNull(),
+    started_at: timestamp("started_at").notNull(),
+    latency_ms: integer("latency_ms").notNull(),
+    model: text("model").notNull(),
+    usage: jsonb("usage").$type<SharedTurnTraceUsage>(),
+    stages: jsonb("stages").$type<SharedTurnTraceStages>().notNull(),
+    created_at: timestamp("created_at").notNull().defaultNow(),
+  },
+  (table) => ({
+    org_agent_created_idx: index("shared_turn_traces_org_agent_created_idx").on(
+      table.organization_id,
+      table.agent_id,
+      table.created_at,
+    ),
+  }),
+);
+
+export type SharedTurnTraceRow = InferSelectModel<typeof sharedTurnTraces>;
+export type NewSharedTurnTraceRow = InferInsertModel<typeof sharedTurnTraces>;

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-turn-trace-recorder.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-turn-trace-recorder.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Deterministic unit tests for the sampled Shared-turn trace recorder: the
+ * FNV-1a sampling decision (no randomness — same id, same verdict), the
+ * defensive `SHARED_TURN_TRACES_SAMPLE` parse/clamp, the exact-match
+ * `SHARED_TURN_TRACES_ENABLED` gate, the J7 no-throw insert failure path, and
+ * the privacy contract that `buildTurnSummary` never copies prompt/reply text
+ * into the persisted stages. Fully mocked deps (an injected insertTrace and
+ * env map); no database or model is involved.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import type { NewSharedTurnTraceRow } from "../../../db/schemas/shared-turn-traces";
+import type { RunSharedAgentTurnResult } from "./run-shared-agent-turn";
+import {
+  buildTurnSummary,
+  DEFAULT_SHARED_TURN_TRACES_SAMPLE,
+  isSharedTurnTraceSampled,
+  recordSharedTurnTrace,
+  resolveSharedTurnTraceSampleRate,
+  type SharedTurnSummary,
+} from "./shared-turn-trace-recorder";
+
+const ORG_ID = "0b6f9dd2-6a2f-4d55-b552-8f4f7bfb9f01";
+const USER_ID = "4e2ffab7-9f21-4a2c-92b7-33dd25c7f8a2";
+
+function summaryFixture(overrides: Partial<SharedTurnSummary> = {}): SharedTurnSummary {
+  return {
+    organizationId: ORG_ID,
+    userId: USER_ID,
+    agentId: "agent-1",
+    channelId: "shared:agent-1:room",
+    traceId: "trace-1",
+    startedAt: 1_787_860_800_000,
+    latencyMs: 812,
+    model: "gemma-4-31b",
+    usage: { inputTokens: 120, outputTokens: 48, totalTokens: 168 },
+    finishReason: "reply",
+    stages: [{ name: "model" }],
+    ...overrides,
+  };
+}
+
+describe("resolveSharedTurnTraceSampleRate", () => {
+  test("defaults when unset or blank and clamps finite values into [0, 1]", () => {
+    expect(resolveSharedTurnTraceSampleRate(undefined)).toBe(DEFAULT_SHARED_TURN_TRACES_SAMPLE);
+    expect(resolveSharedTurnTraceSampleRate("")).toBe(DEFAULT_SHARED_TURN_TRACES_SAMPLE);
+    expect(resolveSharedTurnTraceSampleRate("   ")).toBe(DEFAULT_SHARED_TURN_TRACES_SAMPLE);
+    expect(resolveSharedTurnTraceSampleRate("0.25")).toBe(0.25);
+    expect(resolveSharedTurnTraceSampleRate("0")).toBe(0);
+    expect(resolveSharedTurnTraceSampleRate("1")).toBe(1);
+    expect(resolveSharedTurnTraceSampleRate("2")).toBe(1);
+    expect(resolveSharedTurnTraceSampleRate("-3")).toBe(0);
+  });
+
+  test("garbage input falls back to the default instead of a fake-valid rate", () => {
+    expect(resolveSharedTurnTraceSampleRate("ten percent")).toBe(DEFAULT_SHARED_TURN_TRACES_SAMPLE);
+    expect(resolveSharedTurnTraceSampleRate("0.1abc")).toBe(DEFAULT_SHARED_TURN_TRACES_SAMPLE);
+    expect(resolveSharedTurnTraceSampleRate("NaN")).toBe(DEFAULT_SHARED_TURN_TRACES_SAMPLE);
+    expect(resolveSharedTurnTraceSampleRate("Infinity")).toBe(DEFAULT_SHARED_TURN_TRACES_SAMPLE);
+  });
+});
+
+describe("isSharedTurnTraceSampled", () => {
+  test("is deterministic: the same trace id always gets the same verdict", () => {
+    for (const traceId of ["trace-a", "trace-b", "5f2c", "", "🌊"]) {
+      const first = isSharedTurnTraceSampled(traceId, 0.1);
+      for (let i = 0; i < 5; i += 1) {
+        expect(isSharedTurnTraceSampled(traceId, 0.1)).toBe(first);
+      }
+    }
+  });
+
+  test("rate 0 keeps nothing and rate 1 keeps everything", () => {
+    for (const traceId of ["a", "b", "c", "trace-42"]) {
+      expect(isSharedTurnTraceSampled(traceId, 0)).toBe(false);
+      expect(isSharedTurnTraceSampled(traceId, 1)).toBe(true);
+    }
+  });
+
+  test("keeps roughly the requested fraction of a deterministic id population", () => {
+    let kept = 0;
+    const total = 2000;
+    for (let i = 0; i < total; i += 1) {
+      if (isSharedTurnTraceSampled(`turn-${i}`, 0.1)) kept += 1;
+    }
+    // FNV-1a spreads uniformly enough that 10% of 2000 ids lands well inside
+    // [5%, 15%]; the exact count is stable because nothing here is random.
+    expect(kept).toBeGreaterThan(total * 0.05);
+    expect(kept).toBeLessThan(total * 0.15);
+  });
+});
+
+describe("recordSharedTurnTrace gating", () => {
+  test('is a no-op unless SHARED_TURN_TRACES_ENABLED is exactly "true"', async () => {
+    for (const enabled of [undefined, "", "1", "TRUE", "True", "yes", "false"]) {
+      const insertTrace = mock(async (_trace: NewSharedTurnTraceRow) => {});
+      const recorded = await recordSharedTurnTrace(
+        {
+          insertTrace,
+          env: { SHARED_TURN_TRACES_ENABLED: enabled, SHARED_TURN_TRACES_SAMPLE: "1" },
+        },
+        summaryFixture(),
+      );
+      expect(recorded).toBe(false);
+      expect(insertTrace).not.toHaveBeenCalled();
+    }
+  });
+
+  test("drops unsampled traces without touching storage", async () => {
+    const insertTrace = mock(async (_trace: NewSharedTurnTraceRow) => {});
+    const recorded = await recordSharedTurnTrace(
+      { insertTrace, env: { SHARED_TURN_TRACES_ENABLED: "true", SHARED_TURN_TRACES_SAMPLE: "0" } },
+      summaryFixture(),
+    );
+    expect(recorded).toBe(false);
+    expect(insertTrace).not.toHaveBeenCalled();
+  });
+
+  test("persists a sampled trace with tenant scope, timing, and compact payloads", async () => {
+    const inserted: NewSharedTurnTraceRow[] = [];
+    const insertTrace = mock(async (trace: NewSharedTurnTraceRow) => {
+      inserted.push(trace);
+    });
+    const recorded = await recordSharedTurnTrace(
+      { insertTrace, env: { SHARED_TURN_TRACES_ENABLED: "true", SHARED_TURN_TRACES_SAMPLE: "1" } },
+      summaryFixture({
+        stages: [{ name: "model" }, { name: "action", tool: "WEB_SEARCH", durationMs: 240 }],
+      }),
+    );
+    expect(recorded).toBe(true);
+    expect(inserted).toHaveLength(1);
+    const row = inserted[0];
+    expect(row.organization_id).toBe(ORG_ID);
+    expect(row.user_id).toBe(USER_ID);
+    expect(row.agent_id).toBe("agent-1");
+    expect(row.channel_id).toBe("shared:agent-1:room");
+    expect(row.trace_id).toBe("trace-1");
+    expect(row.started_at).toEqual(new Date(1_787_860_800_000));
+    expect(row.latency_ms).toBe(812);
+    expect(row.model).toBe("gemma-4-31b");
+    expect(row.usage).toEqual({ inputTokens: 120, outputTokens: 48, totalTokens: 168 });
+    expect(row.stages).toEqual({
+      finishReason: "reply",
+      stages: [{ name: "model" }, { name: "action", tool: "WEB_SEARCH", durationMs: 240 }],
+    });
+  });
+
+  test("a missing channel id persists as an explicit null, and no usage stays absent", async () => {
+    const inserted: NewSharedTurnTraceRow[] = [];
+    const insertTrace = mock(async (trace: NewSharedTurnTraceRow) => {
+      inserted.push(trace);
+    });
+    await recordSharedTurnTrace(
+      { insertTrace, env: { SHARED_TURN_TRACES_ENABLED: "true", SHARED_TURN_TRACES_SAMPLE: "1" } },
+      summaryFixture({ channelId: undefined, usage: undefined }),
+    );
+    expect(inserted[0].channel_id).toBeNull();
+    expect("usage" in inserted[0]).toBe(false);
+  });
+
+  test("a failed insert is swallowed as diagnostics loss, never thrown (J7)", async () => {
+    const insertTrace = mock(async (_trace: NewSharedTurnTraceRow) => {
+      throw new Error("db down");
+    });
+    const recorded = await recordSharedTurnTrace(
+      { insertTrace, env: { SHARED_TURN_TRACES_ENABLED: "true", SHARED_TURN_TRACES_SAMPLE: "1" } },
+      summaryFixture(),
+    );
+    expect(recorded).toBe(false);
+    expect(insertTrace).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("buildTurnSummary compaction", () => {
+  const PROMPT_TEXT = "please book me a flight to Tokyo tomorrow morning";
+  const REPLY_TEXT = "Here is the plan I drafted for your Tokyo trip";
+
+  function turnResult(overrides: Partial<RunSharedAgentTurnResult> = {}): RunSharedAgentTurnResult {
+    return {
+      reply: REPLY_TEXT,
+      history: [
+        { role: "user", content: PROMPT_TEXT },
+        { role: "assistant", content: REPLY_TEXT },
+      ],
+      model: "gemma-4-31b",
+      degraded: false,
+      usage: { inputTokens: 10, outputTokens: 20 },
+      ...overrides,
+    };
+  }
+
+  const identity = {
+    organizationId: ORG_ID,
+    userId: USER_ID,
+    agentId: "agent-1",
+    channelId: "shared:agent-1:room",
+    traceId: "trace-9",
+    startedAt: 1_787_860_800_000,
+    completedAt: 1_787_860_801_250,
+  };
+
+  test("derives model + action stages with tool names and never copies text", () => {
+    const summary = buildTurnSummary({
+      result: turnResult({
+        actionResults: [
+          {
+            success: true,
+            text: `searched the web for "${PROMPT_TEXT}"`,
+            userFacingText: REPLY_TEXT,
+            data: { actionName: "WEB_SEARCH" },
+          },
+          { success: true, data: { actionName: "TODO" } },
+          { success: false },
+        ],
+      }),
+      ...identity,
+    });
+    expect(summary.finishReason).toBe("reply");
+    expect(summary.stages).toEqual([
+      { name: "model" },
+      { name: "action", tool: "WEB_SEARCH" },
+      { name: "action", tool: "TODO" },
+      { name: "action" },
+    ]);
+    expect(summary.latencyMs).toBe(1250);
+    expect(summary.model).toBe("gemma-4-31b");
+    const serialized = JSON.stringify(summary);
+    expect(serialized).not.toContain(PROMPT_TEXT);
+    expect(serialized).not.toContain(REPLY_TEXT);
+    expect(serialized).not.toContain("Tokyo");
+  });
+
+  test("caps the action stage list so a pathological turn stays compact", () => {
+    const summary = buildTurnSummary({
+      result: turnResult({
+        actionResults: Array.from({ length: 40 }, (_, i) => ({
+          success: true,
+          data: { actionName: `ACTION_${i}` },
+        })),
+      }),
+      ...identity,
+    });
+    // 1 model stage + the capped action stages.
+    expect(summary.stages.length).toBe(17);
+  });
+
+  test("classifies capability-wall turns by capability label only", () => {
+    const summary = buildTurnSummary({
+      result: turnResult({
+        model: "capability-wall",
+        capabilityWall: {
+          capability: "reminders",
+          label: "Reminders",
+          reply: "Reminders need Dedicated — but I can draft the reminder text for you.",
+        },
+      }),
+      ...identity,
+    });
+    expect(summary.finishReason).toBe("capability-wall");
+    expect(summary.stages).toEqual([{ name: "capability-wall", tool: "reminders" }]);
+    expect(JSON.stringify(summary)).not.toContain("Dedicated");
+  });
+
+  test("classifies nav-intent turns by view id only", () => {
+    const summary = buildTurnSummary({
+      result: turnResult({
+        model: "nav-intent",
+        navIntent: {
+          viewId: "settings",
+          subview: "voice",
+          label: "Settings",
+          reply: "Opening Settings → Voice for you now.",
+        },
+      }),
+      ...identity,
+    });
+    expect(summary.finishReason).toBe("nav-intent");
+    expect(summary.stages).toEqual([{ name: "nav-intent", tool: "settings" }]);
+    expect(JSON.stringify(summary)).not.toContain("Opening Settings");
+  });
+
+  test("classifies the designed no-model unavailable state as degraded", () => {
+    const summary = buildTurnSummary({
+      result: turnResult({ model: "none", degraded: true, usage: undefined }),
+      ...identity,
+    });
+    expect(summary.finishReason).toBe("degraded");
+    expect(summary.stages).toEqual([{ name: "unavailable" }]);
+    expect(summary.usage).toBeUndefined();
+  });
+
+  test("negative clock skew clamps latency to zero instead of a fake negative", () => {
+    const summary = buildTurnSummary({
+      result: turnResult(),
+      ...identity,
+      completedAt: identity.startedAt - 500,
+    });
+    expect(summary.latencyMs).toBe(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-turn-trace-recorder.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-turn-trace-recorder.ts
@@ -1,0 +1,212 @@
+/**
+ * Sampled, flag-gated, off-path observability for Shared (Tier-0) agent turns.
+ *
+ * Shared turns run with `enableTrajectories: false` because full trajectory
+ * capture costs latency and storage on the interactive hot path. This module
+ * is the deliberate replacement: after a turn completes, the caller builds a
+ * COMPACT summary (stage names, durations, tool names, finish reason, token
+ * usage — never prompt or response text) and hands it to the recorder, which
+ * persists it only when `SHARED_TURN_TRACES_ENABLED === "true"` AND the turn's
+ * `trace_id` falls inside the deterministic sample.
+ *
+ * Sampling hashes the trace id (FNV-1a) instead of drawing randomness so the
+ * same turn always makes the same keep/drop decision — retries and mirrored
+ * writers agree, and tests are reproducible. The recorder never throws: a
+ * failed insert is diagnostics loss, not a turn failure.
+ */
+
+import type {
+  NewSharedTurnTraceRow,
+  SharedTurnTraceFinishReason,
+  SharedTurnTraceStage,
+  SharedTurnTraceUsage,
+} from "../../../db/schemas/shared-turn-traces";
+import { logger } from "../../utils/logger";
+import type { RunSharedAgentTurnResult, SharedAgentTurnUsage } from "./run-shared-agent-turn";
+
+/** Default keep fraction when `SHARED_TURN_TRACES_SAMPLE` is unset or invalid. */
+export const DEFAULT_SHARED_TURN_TRACES_SAMPLE = 0.1;
+
+/** Cap on recorded action stages so a pathological turn cannot bloat the row. */
+const MAX_ACTION_STAGES = 16;
+
+/** Everything the recorder persists about one completed Shared turn. */
+export interface SharedTurnSummary {
+  organizationId: string;
+  userId: string;
+  agentId: string;
+  channelId?: string;
+  /** Stable turn identity; also the deterministic sampling key. */
+  traceId: string;
+  /** Epoch-ms turn start. */
+  startedAt: number;
+  latencyMs: number;
+  model: string;
+  usage?: SharedAgentTurnUsage;
+  finishReason: SharedTurnTraceFinishReason;
+  stages: SharedTurnTraceStage[];
+}
+
+export interface SharedTurnTraceRecorderDeps {
+  /** Scoped insert, normally `sharedTurnTracesRepository.insertTrace`. */
+  insertTrace: (trace: NewSharedTurnTraceRow) => Promise<void>;
+  /** Env override for tests; defaults to `process.env`. */
+  env?: Record<string, string | undefined>;
+}
+
+/**
+ * Parse `SHARED_TURN_TRACES_SAMPLE` defensively: unset/blank/non-finite input
+ * falls back to the default, and any finite value is clamped into [0, 1] so a
+ * typo can never over-sample production.
+ */
+export function resolveSharedTurnTraceSampleRate(raw: string | undefined): number {
+  if (raw === undefined) return DEFAULT_SHARED_TURN_TRACES_SAMPLE;
+  const trimmed = raw.trim();
+  if (trimmed === "") return DEFAULT_SHARED_TURN_TRACES_SAMPLE;
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed)) return DEFAULT_SHARED_TURN_TRACES_SAMPLE;
+  return Math.min(Math.max(parsed, 0), 1);
+}
+
+/** FNV-1a 32-bit hash of the trace id mapped onto the unit interval [0, 1). */
+function traceIdUnitInterval(traceId: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < traceId.length; index += 1) {
+    hash ^= traceId.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0) / 0x1_0000_0000;
+}
+
+/**
+ * Deterministic keep/drop decision for one trace id at the given sample rate.
+ * No randomness: the same id and rate always agree, across processes and time.
+ */
+export function isSharedTurnTraceSampled(traceId: string, sampleRate: number): boolean {
+  if (!(sampleRate > 0)) return false;
+  if (sampleRate >= 1) return true;
+  return traceIdUnitInterval(traceId) < sampleRate;
+}
+
+/** Copy only the numeric token fields so no provider metadata rides into the row. */
+function compactUsage(usage: SharedAgentTurnUsage): SharedTurnTraceUsage | undefined {
+  const compact: SharedTurnTraceUsage = {};
+  for (const key of [
+    "promptTokens",
+    "completionTokens",
+    "totalTokens",
+    "inputTokens",
+    "outputTokens",
+  ] as const) {
+    const value = usage[key];
+    if (typeof value === "number" && Number.isFinite(value)) compact[key] = value;
+  }
+  return Object.keys(compact).length > 0 ? compact : undefined;
+}
+
+/** The result fields the summary derives from; the reply/history text is never read. */
+export type SharedTurnSummaryResult = Pick<
+  RunSharedAgentTurnResult,
+  "model" | "degraded" | "usage" | "actionResults" | "navIntent" | "capabilityWall"
+>;
+
+export interface BuildTurnSummaryInput {
+  result: SharedTurnSummaryResult;
+  organizationId: string;
+  userId: string;
+  agentId: string;
+  channelId?: string;
+  traceId: string;
+  /** Epoch-ms turn start captured by the caller before dispatch. */
+  startedAt: number;
+  /** Epoch-ms turn completion; pass it so latency stays deterministic in tests. */
+  completedAt: number;
+}
+
+/**
+ * Derive the compact stage list from what `runSharedAgentTurn` already
+ * returns. Only structural facts are read — model id, degrade flag, usage
+ * numbers, registered action names (`data.actionName`), capability labels,
+ * and nav view ids. Reply text, history, prompts, and action payload text are
+ * deliberately never copied into the summary.
+ */
+export function buildTurnSummary(input: BuildTurnSummaryInput): SharedTurnSummary {
+  const { result } = input;
+  let finishReason: SharedTurnTraceFinishReason;
+  const stages: SharedTurnTraceStage[] = [];
+  if (result.capabilityWall) {
+    finishReason = "capability-wall";
+    stages.push({ name: "capability-wall", tool: result.capabilityWall.capability });
+  } else if (result.navIntent) {
+    finishReason = "nav-intent";
+    stages.push({ name: "nav-intent", tool: result.navIntent.viewId });
+  } else if (result.degraded) {
+    finishReason = "degraded";
+    stages.push({ name: "unavailable" });
+  } else {
+    finishReason = "reply";
+    stages.push({ name: "model" });
+    for (const actionResult of (result.actionResults ?? []).slice(0, MAX_ACTION_STAGES)) {
+      const actionName = actionResult.data?.actionName;
+      stages.push({
+        name: "action",
+        ...(typeof actionName === "string" && actionName.length > 0 ? { tool: actionName } : {}),
+      });
+    }
+  }
+  return {
+    organizationId: input.organizationId,
+    userId: input.userId,
+    agentId: input.agentId,
+    ...(input.channelId !== undefined ? { channelId: input.channelId } : {}),
+    traceId: input.traceId,
+    startedAt: input.startedAt,
+    latencyMs: Math.max(0, Math.round(input.completedAt - input.startedAt)),
+    model: result.model,
+    ...(result.usage ? { usage: result.usage } : {}),
+    finishReason,
+    stages,
+  };
+}
+
+/**
+ * Persist one sampled turn trace. Returns true only when a row was written.
+ * Gated first on `SHARED_TURN_TRACES_ENABLED === "true"` (exact match — the
+ * feature is opt-in and off by default), then on the deterministic sample.
+ */
+export async function recordSharedTurnTrace(
+  deps: SharedTurnTraceRecorderDeps,
+  summary: SharedTurnSummary,
+): Promise<boolean> {
+  const env = deps.env ?? process.env;
+  if (env.SHARED_TURN_TRACES_ENABLED !== "true") return false;
+  const sampleRate = resolveSharedTurnTraceSampleRate(env.SHARED_TURN_TRACES_SAMPLE);
+  if (!isSharedTurnTraceSampled(summary.traceId, sampleRate)) return false;
+  const compactedUsage = summary.usage ? compactUsage(summary.usage) : undefined;
+  try {
+    await deps.insertTrace({
+      organization_id: summary.organizationId,
+      user_id: summary.userId,
+      agent_id: summary.agentId,
+      channel_id: summary.channelId ?? null,
+      trace_id: summary.traceId,
+      started_at: new Date(summary.startedAt),
+      latency_ms: Math.max(0, Math.round(summary.latencyMs)),
+      model: summary.model,
+      ...(compactedUsage ? { usage: compactedUsage } : {}),
+      stages: { finishReason: summary.finishReason, stages: summary.stages },
+    });
+    return true;
+  } catch (error) {
+    // error-policy:J7 diagnostics must not kill the loop: the user's turn
+    // already completed; losing one sampled trace is warned, never rethrown
+    // into the turn path.
+    logger.warn("[shared-turn-trace-recorder] sampled trace insert failed", {
+      error: error instanceof Error ? error.message : String(error),
+      organizationId: summary.organizationId,
+      agentId: summary.agentId,
+      traceId: summary.traceId,
+    });
+    return false;
+  }
+}


### PR DESCRIPTION
## Parity program P5 (issue #20615) — Shared turns become debuggable

New `shared_turn_traces` table (org/user-scoped, FK-free like shared_runtime_history so diagnostics can never cascade into tenant tables) storing COMPACT per-turn traces: stage names + durations + tool names + finish reason + token counts — **never prompt/response text** (privacy pin in tests). Recorder gated by `SHARED_TURN_TRACES_ENABLED` with deterministic trace-id-hash sampling (`SHARED_TURN_TRACES_SAMPLE`, default 0.1, clamped — no Math.random). Wiring into run-shared-agent-turn lands at P3's review point per the one-money-path-change rule.

**Integration note**: rebased over P2 with the parallel-build migration collision resolved — P5's migration renumbered 0210→0211, journal idx 210 appended after P2's shared_agent_memories; verified: migrations sequence clean, P2+P5 suites green together (28/28).

## Evidence
19/19 agent-run (sampling determinism, flag-off no-op, org-scoping SQL pins, no-prompt-leak compaction) + 28/28 post-rebase combined + typecheck + Biome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)