### PR TITLE
config(cloud): production edge-flip prep — drop the colliding var, update the lint

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -730,7 +730,10 @@ __filename = '"/worker.js"'
 NODE_ENV = "production"
 SHARED_ELIZA_AGENT_RUNTIME = "true"
 PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "false"
-PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED = "false"
+# PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED is deliberately ABSENT here: the
+# protected cutover workflow owns it as a secret binding (absence = off), and a
+# var with this name collides with the secret publish (CF 10053 — the exact
+# staging incident on 2026-08-16). The secret/var lint enforces this.
 THIN_INFERENCE_ENTRY_ENABLED = "true"
 # Apps deploy (Product 2): arms the Worker-side deploy trigger (configureAppsDeployTrigger,
 # bootstrap-app.ts) so POST /api/v1/apps/:id/deploy enqueues a real APP_DEPLOY job instead of

--- a/packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts
@@ -108,16 +108,14 @@ describe("Worker secret/var collision lint (CF error 10053 class)", () => {
     expect([...unmapped].sort()).toEqual([]);
   });
 
-  test("prophylactic: the production edge flip requires removing the production var first", () => {
-    // The staging incident repeats verbatim on the production cutover unless
-    // [env.production.vars] drops PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED before
-    // any workflow publishes it as a production secret. This assertion is the
-    // tripwire: whoever extends the activation workflow to production must
-    // delete the var in the same change (this test's mapping gains
-    // "production" then, and the collision test above enforces the removal).
+  test("the production edge-flip var stays deleted (CF 10053 prevention)", () => {
+    // Production cutover prep (2026-08-16): the var was removed so the
+    // protected activation workflow can own the name as a production secret
+    // binding (absence = off). Re-adding it recreates the staging 10053
+    // incident verbatim on the production flip.
     expect(
       vars.get("production")?.has("PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED") ??
         false,
-    ).toBe(true);
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Pre-clears the production cutover: removes the `PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED` var from `[env.production.vars]` (the activation workflow owns the name as a secret; absence = off — behavior unchanged) and flips the #20623 lint tripwire to enforce the deletion permanently. Lint 4/4. With this merged + promoted to main, the production flip after staging numbers is a single dispatch. **HOLD-MERGE until the edge-flip alignment completes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)