### PR TITLE
fix(agent): cap terminal truncation within maxChars

### DIFF
--- a/packages/agent/src/actions/terminal-truncation.test.ts
+++ b/packages/agent/src/actions/terminal-truncation.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Exercises terminal output bounds through the production formatting helpers.
+ * The deterministic cases cover omission accounting, tiny limits, and Unicode.
+ */
+import { describe, expect, it } from "vitest";
+import { buildOutputPreview, truncateForData } from "./terminal.ts";
+
+function hasLoneSurrogate(text: string): boolean {
+  for (let index = 0; index < text.length; index++) {
+    const code = text.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = text.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) return true;
+      index++;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+describe("terminal output truncation", () => {
+  it("keeps the preview and its truthful omission count within the cap", () => {
+    const content = "x".repeat(4_000);
+    const preview = buildOutputPreview(content, 3_000);
+    const marker = preview.match(
+      /\n\n\[\.\.\. (\d+) chars omitted; use the attachment for full output \.\.\.\]$/,
+    );
+
+    expect(preview.length).toBeLessThanOrEqual(3_000);
+    expect(marker).not.toBeNull();
+    const prefixLength = preview.length - (marker?.[0].length ?? 0);
+    expect(Number(marker?.[1])).toBe(content.length - prefixLength);
+  });
+
+  it("never leaves a lone surrogate at either terminal boundary", () => {
+    const content = "a😀".repeat(6_000);
+
+    for (let max = 14; max <= 80; max++) {
+      expect(hasLoneSurrogate(buildOutputPreview(content, max))).toBe(false);
+      expect(hasLoneSurrogate(truncateForData(content, max))).toBe(false);
+    }
+  });
+
+  it("uses content when a marker cannot fit and honors nonpositive limits", () => {
+    expect(buildOutputPreview("abcdef", 3)).toBe("abc");
+    expect(truncateForData("abcdef", 3)).toBe("abc");
+    expect(buildOutputPreview("   ", 4)).toBe("(emp");
+    expect(buildOutputPreview("abcdef", 0)).toBe("");
+    expect(truncateForData("abcdef", -1)).toBe("");
+  });
+});

--- a/packages/agent/src/actions/terminal.ts
+++ b/packages/agent/src/actions/terminal.ts
@@ -203,11 +203,16 @@ function buildOutputPreview(content: string, maxLength = 3_000): string {
   if (trimmed.length <= maxLength) {
     return formatOutputBlock(trimmed);
   }
-  return `${trimmed.slice(0, maxLength).trimEnd()}\n\n[... ${trimmed.length - maxLength} chars omitted; use the attachment for full output ...]`;
+  const suffix = `\n\n[... ${trimmed.length - maxLength} chars omitted; use the attachment for full output ...]`;
+  if (maxLength <= suffix.length) return suffix.slice(0, maxLength);
+  return `${trimmed.slice(0, maxLength - suffix.length).trimEnd()}${suffix}`;
 }
 
 function truncateForData(text: string, max = MAX_TERMINAL_DATA_CHARS): string {
-  return text.length <= max ? text : `${text.slice(0, max)}\n…[truncated]`;
+  if (text.length <= max) return text;
+  const suffix = "\n…[truncated]";
+  if (max <= suffix.length) return suffix.slice(0, max);
+  return `${text.slice(0, max - suffix.length)}${suffix}`;
 }
 
 async function createCommandOutputAttachment(

--- a/packages/agent/src/actions/terminal.ts
+++ b/packages/agent/src/actions/terminal.ts
@@ -29,6 +29,7 @@ import {
   logger,
   redactSensitiveText,
   stringToUuid,
+  truncateWellFormed,
 } from "@elizaos/core";
 import { readAliasedEnv, resolveServerOnlyPort } from "@elizaos/shared";
 import { normalizeTerminalCommand } from "../utils/terminal-command.ts";
@@ -198,21 +199,38 @@ function buildCommandArtifactContent(result: CapturedTerminalRun): string {
     .join("\n");
 }
 
-function buildOutputPreview(content: string, maxLength = 3_000): string {
+/** @internal Exported for deterministic boundary tests. */
+export function buildOutputPreview(content: string, maxLength = 3_000): string {
+  if (maxLength <= 0) return "";
   const trimmed = content.trimEnd();
   if (trimmed.length <= maxLength) {
-    return formatOutputBlock(trimmed);
+    return truncateWellFormed(formatOutputBlock(trimmed), maxLength);
   }
-  const suffix = `\n\n[... ${trimmed.length - maxLength} chars omitted; use the attachment for full output ...]`;
-  if (maxLength <= suffix.length) return suffix.slice(0, maxLength);
-  return `${trimmed.slice(0, maxLength - suffix.length).trimEnd()}${suffix}`;
+
+  const suffixFor = (omittedChars: number) =>
+    `\n\n[... ${omittedChars} chars omitted; use the attachment for full output ...]`;
+  const retainedBudget = Math.max(
+    0,
+    maxLength - suffixFor(trimmed.length).length,
+  );
+  const prefix = truncateWellFormed(trimmed, retainedBudget).trimEnd();
+  const suffix = suffixFor(trimmed.length - prefix.length);
+
+  return prefix.length + suffix.length <= maxLength
+    ? `${prefix}${suffix}`
+    : truncateWellFormed(trimmed, maxLength);
 }
 
-function truncateForData(text: string, max = MAX_TERMINAL_DATA_CHARS): string {
+/** @internal Exported for deterministic boundary tests. */
+export function truncateForData(
+  text: string,
+  max = MAX_TERMINAL_DATA_CHARS,
+): string {
+  if (max <= 0) return "";
   if (text.length <= max) return text;
   const suffix = "\n…[truncated]";
-  if (max <= suffix.length) return suffix.slice(0, max);
-  return `${text.slice(0, max - suffix.length)}${suffix}`;
+  if (max <= suffix.length) return truncateWellFormed(text, max);
+  return `${truncateWellFormed(text, max - suffix.length)}${suffix}`;
 }
 
 async function createCommandOutputAttachment(


### PR DESCRIPTION
## Summary

Keeps terminal preview and action-data output within their declared character budgets. Both original helpers sliced to the full cap and then appended a marker.

The landing repair corrects four issues in the contributor patch: omission counts now describe the actual retained prefix, truncation never leaves a lone UTF-16 surrogate, tiny limits retain output rather than a fragment of the marker, and nonpositive limits return empty output.

## Changes

- Reserve marker space within the configured cap.
- Derive the displayed omission count from the actual retained prefix.
- Use `truncateWellFormed` at both boundaries.
- Add deterministic production-helper tests for bounds, Unicode, tiny limits, empty placeholders, and nonpositive limits.

## Verification

Exact repaired head: `6952f8aecf51f7d4f9a28511d0a88fa3eae8af63`.

- New truncation suite: 3/3 tests, 142 assertions.
- Existing terminal effect and role-gate suites: 13/13 tests.
- `packages/agent` typecheck passed.
- Biome passed on both changed files.
- `bun run verify` passed: 356/356 Turbo tasks; anti-larp scanned 8,389 test files with zero focused or orphaned skips.

## Evidence

<!-- evidence-head:6952f8aecf51f7d4f9a28511d0a88fa3eae8af63 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend terminal-output formatting; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend terminal-output formatting; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive frontend flow changed.
<!-- evidence-row:backend-logs -->
- [x] [20640-pr20640-verify.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20640-pr20640-verify.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic output-size guard; no model invocation changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - helper outputs and terminal contracts are covered by backend tests.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5; maintainer landing repair openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: claude-code; Codex
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@65e933516af65b94e9d7fbe87bbc4b519c4dc775:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: anthropic/claude-fable-5; openai/gpt-5.6-sol
Client / agent tooling: claude-code; Codex
Attribution status: self-reported
