### PR TITLE
fix(cloud): fence Shared memory after cancellation

### DIFF
--- a/packages/cloud/shared/src/db/repositories/shared-agent-memories.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/shared-agent-memories.integration.test.ts
@@ -1,7 +1,7 @@
 /**
  * Drives the shared_agent_memories repository against real in-process PGlite
  * (schema pushed from the Drizzle definition, pgvector extension loaded) so
- * tenant isolation, replay idempotency, recency ordering, and genuine cosine
+ * tenant isolation, replay convergence, recency ordering, and genuine cosine
  * ranking are proven on real rows rather than mocked chains.
  */
 
@@ -149,6 +149,70 @@ describe("SharedAgentMemoriesWriter.insertMemory (real PGlite)", () => {
         content: { text: "orphan" },
       }),
     ).rejects.toThrow();
+  });
+});
+
+describe("SharedAgentMemoriesWriter.mergeMessageMemory (real PGlite)", () => {
+  const id = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+  const message = (text: string, interrupted: boolean) => ({
+    id,
+    scope: scopeA,
+    entityId: AGENT_A,
+    roomId: ROOM_A,
+    type: "messages",
+    content: { text, source: "shared-runtime", channelType: "DM" },
+    interrupted,
+  });
+
+  test("upgrades an interrupted prefix to the complete retry atomically", async () => {
+    const first = await sharedAgentMemoriesWriter.mergeMessageMemory(message("partial", true));
+    expect(first).toEqual({ id, inserted: true });
+
+    const retry = await sharedAgentMemoriesWriter.mergeMessageMemory(
+      message("complete response", false),
+    );
+    expect(retry).toEqual({ id, inserted: false });
+
+    const [row] = await sharedAgentMemoriesReader.listRecentByRoom(scopeA, ROOM_A, 10);
+    expect(row?.content).toEqual({
+      text: "complete response",
+      source: "shared-runtime",
+      channelType: "DM",
+    });
+  });
+
+  test("keeps the longest interrupted prefix and never downgrades complete", async () => {
+    await sharedAgentMemoriesWriter.mergeMessageMemory(message("part", true));
+    await sharedAgentMemoriesWriter.mergeMessageMemory(message("partial response", true));
+    await sharedAgentMemoriesWriter.mergeMessageMemory(message("tiny", true));
+
+    let [row] = await sharedAgentMemoriesReader.listRecentByRoom(scopeA, ROOM_A, 10);
+    expect(row?.content).toEqual({
+      text: "partial response",
+      source: "shared-runtime",
+      channelType: "DM",
+      interrupted: true,
+    });
+
+    await sharedAgentMemoriesWriter.mergeMessageMemory(message("complete response", false));
+    await sharedAgentMemoriesWriter.mergeMessageMemory(message("late interrupted text", true));
+    [row] = await sharedAgentMemoriesReader.listRecentByRoom(scopeA, ROOM_A, 10);
+    expect(row?.content).toEqual({
+      text: "complete response",
+      source: "shared-runtime",
+      channelType: "DM",
+    });
+  });
+
+  test("rejects a colliding id outside the tenant on the merge path", async () => {
+    await sharedAgentMemoriesWriter.mergeMessageMemory(message("tenant A", true));
+    await expect(
+      sharedAgentMemoriesWriter.mergeMessageMemory({
+        ...message("tenant B", false),
+        scope: scopeB,
+        roomId: ROOM_B,
+      }),
+    ).rejects.toThrow("conflicts outside its tenant");
   });
 });
 

--- a/packages/cloud/shared/src/db/repositories/shared-agent-memories.ts
+++ b/packages/cloud/shared/src/db/repositories/shared-agent-memories.ts
@@ -1,7 +1,7 @@
 /**
  * Tenant-scoped CQRS access to `shared_agent_memories`, the durable core-shape
  * memory rows written by container-free Shared runtimes. The writer owns
- * idempotent inserts; the reader owns room-recency listing and embedding
+ * idempotent inserts and monotonic message convergence; the reader owns room-recency listing and embedding
  * search. Every SQL predicate pins `organization_id` AND `user_id` — a row is
  * never reachable through this module from outside its owning tenant.
  *
@@ -52,6 +52,14 @@ export interface InsertSharedAgentMemoryResult {
   id: string;
   /** False when the same id already existed inside this tenant (a replay). */
   inserted: boolean;
+}
+
+export interface MergeSharedAgentMessageMemoryInput
+  extends Omit<InsertSharedAgentMemoryInput, "id"> {
+  /** Stable transport id shared by interrupted attempts and their retry. */
+  id: string;
+  /** Whether this row contains only the client-visible interrupted prefix. */
+  interrupted: boolean;
 }
 
 export type SharedAgentMemorySearchHit = SharedAgentMemoryRow & { distance: number };
@@ -145,6 +153,84 @@ export class SharedAgentMemoriesWriter {
         context: { organizationId: scope.organizationId },
       });
     }
+    const [existing] = await dbRead
+      .select({ id: sharedAgentMemories.id })
+      .from(sharedAgentMemories)
+      .where(and(...tenantPins(scope), eq(sharedAgentMemories.id, input.id)))
+      .limit(1);
+    if (!existing) {
+      throw new ElizaError("Shared agent memory id conflicts outside its tenant", {
+        code: SHARED_AGENT_MEMORY_ID_CONFLICT,
+        context: { organizationId: scope.organizationId, memoryId: input.id },
+      });
+    }
+    return { id: existing.id, inserted: false };
+  }
+
+  /**
+   * Atomically converges one stable assistant message across cancellation and
+   * retry. A complete reply outranks any interrupted prefix; between prefixes,
+   * only the longer visible text wins. Once complete, a row is immutable.
+   */
+  async mergeMessageMemory(
+    input: MergeSharedAgentMessageMemoryInput,
+  ): Promise<InsertSharedAgentMemoryResult> {
+    const scope = requiredScope(input.scope);
+    if (typeof input.type !== "string" || input.type.trim().length === 0) {
+      throw new ElizaError("Shared agent memory type is required", {
+        code: SHARED_AGENT_MEMORY_INVALID_INPUT,
+        context: { field: "type" },
+      });
+    }
+    const text = input.content.text;
+    if (typeof text !== "string" || text.trim().length === 0) {
+      throw new ElizaError("Shared agent message memory text is required", {
+        code: SHARED_AGENT_MEMORY_INVALID_INPUT,
+        context: { field: "content.text" },
+      });
+    }
+    if (input.embedding != null) assertEmbedding(input.embedding);
+    const content = { ...input.content };
+    delete content.interrupted;
+    if (input.interrupted) content.interrupted = true;
+
+    const [merged] = await dbWrite
+      .insert(sharedAgentMemories)
+      .values({
+        id: input.id,
+        organization_id: scope.organizationId,
+        user_id: scope.userId,
+        agent_id: scope.agentId,
+        entity_id: input.entityId ?? null,
+        room_id: input.roomId ?? null,
+        world_id: input.worldId ?? null,
+        type: input.type,
+        content: jsonbParam(content),
+        embedding: input.embedding ?? null,
+        embedding_model: input.embeddingModel ?? null,
+        ...(input.createdAt ? { created_at: input.createdAt } : {}),
+      })
+      .onConflictDoUpdate({
+        target: [sharedAgentMemories.id],
+        set: { content: jsonbParam(content) },
+        setWhere: sql`
+          ${sharedAgentMemories.organization_id} = ${scope.organizationId}
+          AND ${sharedAgentMemories.user_id} = ${scope.userId}
+          AND ${sharedAgentMemories.agent_id} = ${scope.agentId}
+          AND COALESCE(${sharedAgentMemories.content}->>'interrupted' = 'true', false)
+          AND (
+            ${input.interrupted} = false
+            OR length(COALESCE(${sql.raw("excluded.content")}->>'text', ''))
+              > length(COALESCE(${sharedAgentMemories.content}->>'text', ''))
+          )
+        `,
+      })
+      .returning({
+        id: sharedAgentMemories.id,
+        inserted: sql<boolean>`xmax = 0`,
+      });
+    if (merged) return merged;
+
     const [existing] = await dbRead
       .select({ id: sharedAgentMemories.id })
       .from(sharedAgentMemories)

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.memory-commit.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.memory-commit.test.ts
@@ -1,10 +1,12 @@
 /**
  * Pins the P2 edge-memory commit point in runSharedAgentTurn(Stream): a landed
  * user/assistant pair is durably recorded through the attached SharedMemoryStore
- * exactly once, after the reply lands and before a streamed finish frame is
- * observable; failed provider turns never write; store failures surface as
- * storage faults, not provider outcomes. The language-model router and `ai`
- * SDK are stubbed deterministically; the memory store is a scripted double.
+ * exactly once after a non-streamed reply lands. Streaming ownership stays at
+ * the transport finalization boundary, which alone knows whether the consumer
+ * accepted a complete reply or cancelled on an interrupted prefix. Failed
+ * provider turns never write; store failures surface as storage faults, not
+ * provider outcomes. The language-model router and `ai` SDK are stubbed
+ * deterministically; the memory store is a scripted double.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { SharedMemoryStore, SharedMemoryTurnPair } from "./shared-memory-store";
@@ -142,35 +144,20 @@ describe("runSharedAgentTurn memory commit", () => {
   });
 });
 
-describe("runSharedAgentTurnStream memory commit", () => {
-  test("commits the pair when the finish part lands, after all text deltas", async () => {
-    const memory = scriptedMemory();
+describe("runSharedAgentTurnStream memory boundary", () => {
+  test("leaves streaming memory commits to the consumer-aware transport boundary", async () => {
     const turn = await runSharedAgentTurnStream({
       character,
       history: [],
       message: "stream me",
       messageIds,
-      memory: memory.store,
     });
     if (!turn.parts) throw new Error("stream turn returned no parts");
-    const seen: Array<{ type: string; committed: number }> = [];
+    const seen: string[] = [];
     for await (const part of turn.parts) {
-      seen.push({ type: part.type, committed: memory.pairs.length });
+      seen.push(part.type);
     }
-    // No commit while deltas stream; by the time finish is observable the
-    // pair is durable (committed strictly before the finish part is yielded).
-    expect(seen).toEqual([
-      { type: "text-delta", committed: 0 },
-      { type: "text-delta", committed: 0 },
-      { type: "finish", committed: 1 },
-    ]);
-    expect(memory.pairs).toEqual([
-      {
-        userMessage: "stream me",
-        assistantReply: "landed reply",
-        messageIds,
-      },
-    ]);
+    expect(seen).toEqual(["text-delta", "text-delta", "finish"]);
   });
 
   test("without a memory store the stream shape is unchanged and nothing writes", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -103,6 +103,9 @@ export interface RunSharedAgentTurnInput {
   };
 }
 
+/** Streaming persistence belongs to the consumer-aware transport finalizer. */
+export type RunSharedAgentTurnStreamInput = Omit<RunSharedAgentTurnInput, "memory">;
+
 export interface RunSharedAgentTurnResult {
   reply: string;
   /** history + the new user message + the assistant reply (persist this). */
@@ -312,29 +315,6 @@ async function commitSharedTurnMemory(
   });
 }
 
-/**
- * Streaming variant of the memory commit: the pair lands at the terminal
- * `finish` part, so the write is awaited after every text delta has already
- * streamed and BEFORE the finish frame becomes observable — a consumer that
- * sees `finish` can rely on the pair being durable, mirroring the claim-store
- * ordering in shared-runtime-chat.
- */
-function withSharedMemoryCommit(
-  result: RunSharedAgentTurnStreamResult,
-  input: RunSharedAgentTurnInput,
-): RunSharedAgentTurnStreamResult {
-  const memory = input.memory;
-  const inner = result.parts;
-  if (!memory || !inner) return result;
-  const parts = (async function* (): AsyncIterable<SharedAgentTurnStreamPart> {
-    for await (const part of inner) {
-      if (part.type === "finish") await commitSharedTurnMemory(input, part.text);
-      yield part;
-    }
-  })();
-  return { ...result, parts };
-}
-
 function modelHistoryContent(message: SharedTurnMessage): string {
   if (message.role === "assistant" && message.interrupted) {
     return `[interrupted assistant partial]\n${message.content}`;
@@ -491,7 +471,7 @@ export async function runSharedAgentTurn(
  * stream into the shared-runtime turn shape.
  */
 export async function runSharedAgentTurnStream(
-  input: RunSharedAgentTurnInput,
+  input: RunSharedAgentTurnStreamInput,
 ): Promise<RunSharedAgentTurnStreamResult> {
   const message = input.message.trim();
 
@@ -557,21 +537,18 @@ export async function runSharedAgentTurnStream(
 
   if (input.execution?.engine === "eliza-runtime") {
     const { runSharedElizaRuntimeTurnStream } = await import("./shared-eliza-runtime");
-    return withSharedMemoryCommit(
-      await runSharedElizaRuntimeTurnStream({
-        ...input,
-        character: {
-          ...input.character,
-          system: buildSystemPrompt(input.character, {
-            reminders: remindersEnabled,
-            todos: todosEnabled,
-          }),
-        },
-        agentKey: input.execution.agentKey,
-        model: modelId,
-      }),
-      input,
-    );
+    return await runSharedElizaRuntimeTurnStream({
+      ...input,
+      character: {
+        ...input.character,
+        system: buildSystemPrompt(input.character, {
+          reminders: remindersEnabled,
+          todos: todosEnabled,
+        }),
+      },
+      agentKey: input.execution.agentKey,
+      model: modelId,
+    });
   }
 
   try {
@@ -668,15 +645,12 @@ export async function runSharedAgentTurnStream(
       }
     })();
 
-    return withSharedMemoryCommit(
-      {
-        model: modelId,
-        degraded: false,
-        parts,
-        cancel,
-      },
-      input,
-    );
+    return {
+      model: modelId,
+      degraded: false,
+      parts,
+      cancel,
+    };
   } catch (error) {
     // error-policy:J2 context-adding rethrow. Preserve the setup/provider cause
     // so the caller refunds only a provably unaccepted invocation.

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.test.ts
@@ -138,6 +138,38 @@ describe("SharedMemoryStore.recordTurnPair", () => {
     expect(assistantRow?.content?.role).toBeUndefined();
   });
 
+  test("mirrors interrupted history and omits an unseen empty assistant row", async () => {
+    const interrupted = scriptedWriter();
+    const store = new SharedMemoryStore(
+      { organizationId: ORG, userId: USER, agentKey: AGENT_KEY },
+      interrupted.writer,
+    );
+    await store.recordTurnPair({
+      userMessage: "tell me slowly",
+      assistantReply: "partial answer",
+      interrupted: true,
+    });
+    expect(interrupted.inserts[1]?.content).toEqual({
+      text: "partial answer",
+      source: "shared-runtime",
+      channelType: "DM",
+      interrupted: true,
+    });
+
+    const empty = scriptedWriter();
+    const emptyStore = new SharedMemoryStore(
+      { organizationId: ORG, userId: USER, agentKey: AGENT_KEY },
+      empty.writer,
+    );
+    await emptyStore.recordTurnPair({
+      userMessage: "cancelled before output",
+      assistantReply: "   ",
+      interrupted: true,
+    });
+    expect(empty.inserts).toHaveLength(1);
+    expect(empty.inserts[0]?.content.text).toBe("cancelled before output");
+  });
+
   test("omits row ids without transport ids and propagates storage failures", async () => {
     const unkeyed = scriptedWriter();
     const store = new SharedMemoryStore(

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { stringToUuid } from "@elizaos/core/edge";
 import type {
   InsertSharedAgentMemoryInput,
+  MergeSharedAgentMessageMemoryInput,
   SharedAgentMemoriesWriter,
 } from "../../../db/repositories/shared-agent-memories";
 import {
@@ -31,13 +32,24 @@ function scriptedWriter(behavior?: { failOn?: number }): {
   inserts: InsertSharedAgentMemoryInput[];
 } {
   const inserts: InsertSharedAgentMemoryInput[] = [];
+  const write = async (input: InsertSharedAgentMemoryInput) => {
+    inserts.push(input);
+    if (behavior?.failOn === inserts.length) {
+      throw new Error("scripted storage failure");
+    }
+    return { id: input.id ?? "generated-id", inserted: true };
+  };
   const writer = {
-    async insertMemory(input: InsertSharedAgentMemoryInput) {
-      inserts.push(input);
-      if (behavior?.failOn === inserts.length) {
-        throw new Error("scripted storage failure");
-      }
-      return { id: input.id ?? "generated-id", inserted: true };
+    insertMemory: write,
+    async mergeMessageMemory(input: MergeSharedAgentMessageMemoryInput) {
+      const { interrupted, ...memory } = input;
+      return await write({
+        ...memory,
+        content: {
+          ...memory.content,
+          ...(interrupted ? { interrupted: true } : {}),
+        },
+      });
     },
   } as SharedAgentMemoriesWriter;
   return { writer, inserts };

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.ts
@@ -93,8 +93,7 @@ export class SharedMemoryStore {
     });
     const assistantReply = pair.assistantReply.trim();
     if (!assistantReply) return;
-    await this.writer.insertMemory({
-      ...(pair.messageIds ? { id: memoryRowId(pair.messageIds.assistant) } : {}),
+    const assistant = {
       scope,
       // The assistant speaks as the agent itself, mirroring the runtime's
       // projection where assistant memories carry the agent's entity id.
@@ -106,9 +105,23 @@ export class SharedMemoryStore {
         text: assistantReply,
         source: "shared-runtime",
         channelType: "DM",
-        ...(pair.interrupted ? { interrupted: true } : {}),
       },
       createdAt: new Date(landedAt + 1),
+    };
+    if (pair.messageIds) {
+      await this.writer.mergeMessageMemory({
+        ...assistant,
+        id: memoryRowId(pair.messageIds.assistant),
+        interrupted: pair.interrupted === true,
+      });
+      return;
+    }
+    await this.writer.insertMemory({
+      ...assistant,
+      content: {
+        ...assistant.content,
+        ...(pair.interrupted ? { interrupted: true } : {}),
+      },
     });
   }
 }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.ts
@@ -45,6 +45,8 @@ export interface SharedMemoryTurnPair {
   /** Transport-stable ids; reused as row ids so a claim replay cannot double-write. */
   messageIds?: { user: string; assistant: string };
   messageRole?: "system" | "user";
+  /** Mirrors the canonical history marker for a client-cancelled partial reply. */
+  interrupted?: boolean;
 }
 
 /** Row id from a transport message id: pass through uuids, hash anything else. */
@@ -89,6 +91,8 @@ export class SharedMemoryStore {
       },
       createdAt: new Date(landedAt),
     });
+    const assistantReply = pair.assistantReply.trim();
+    if (!assistantReply) return;
     await this.writer.insertMemory({
       ...(pair.messageIds ? { id: memoryRowId(pair.messageIds.assistant) } : {}),
       scope,
@@ -99,9 +103,10 @@ export class SharedMemoryStore {
       worldId,
       type: SHARED_MEMORY_TYPE,
       content: {
-        text: pair.assistantReply,
+        text: assistantReply,
         source: "shared-runtime",
         channelType: "DM",
+        ...(pair.interrupted ? { interrupted: true } : {}),
       },
       createdAt: new Date(landedAt + 1),
     });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -222,6 +222,24 @@ mock.module("./shared-todos", () => ({
   sharedTodoStorageScope,
 }));
 
+type TestMemoryPair = {
+  userMessage: string;
+  assistantReply: string;
+  messageIds?: { user: string; assistant: string };
+  messageRole?: "system" | "user";
+  interrupted?: boolean;
+};
+const memoryPairs: TestMemoryPair[] = [];
+const recordTurnPair = mock(async (pair: TestMemoryPair) => {
+  memoryPairs.push(pair);
+});
+const createSharedMemoryStore = mock(() =>
+  process.env.SHARED_MEMORY_TABLES_ENABLED === "true" ? { recordTurnPair } : null,
+);
+mock.module("./shared-memory-store", () => ({
+  createSharedMemoryStore,
+}));
+
 class TestInferenceAdmissionDispatchMarkError extends Error {}
 
 mock.module("../inference-admission-gate", () => ({
@@ -385,6 +403,10 @@ beforeEach(() => {
   streamAbortSignal = undefined;
   createSharedTodoStore.mockClear();
   sharedTodoStorageScope.mockClear();
+  delete process.env.SHARED_MEMORY_TABLES_ENABLED;
+  memoryPairs.length = 0;
+  recordTurnPair.mockClear();
+  createSharedMemoryStore.mockClear();
   turn = {
     degraded: false,
     reply: "hello back",
@@ -762,6 +784,7 @@ describe("SharedRuntimeChatService", () => {
   });
 
   test("streams chunks, persists the completed turn, and bills off path", async () => {
+    process.env.SHARED_MEMORY_TABLES_ENABLED = "true";
     const service = new SharedRuntimeChatService();
     const h = harness();
     const response = await service.stream(agent, rpc, h);
@@ -769,6 +792,13 @@ describe("SharedRuntimeChatService", () => {
     expect(body).toContain("event: chunk");
     expect(body).toContain("event: done");
     expect(h.history()).toHaveLength(3);
+    expect(memoryPairs).toEqual([
+      expect.objectContaining({
+        userMessage: "hello",
+        assistantReply: "hello back",
+        interrupted: false,
+      }),
+    ]);
     await Promise.all(h.background);
     expect(settleCalls).toEqual([0.004]);
   });
@@ -872,6 +902,7 @@ describe("SharedRuntimeChatService", () => {
   });
 
   test("stream cancellation persists interrupted history without waiting for provider teardown", async () => {
+    process.env.SHARED_MEMORY_TABLES_ENABLED = "true";
     const service = new SharedRuntimeChatService();
     const h = harness();
     let releaseProviderStream = () => {};
@@ -932,6 +963,13 @@ describe("SharedRuntimeChatService", () => {
     expect(streamAbortSignal?.reason).toBe("barge-in");
     expect(providerCancelReason).toBe("barge-in");
     expect(settleUnknownCalls).toBe(1);
+    expect(memoryPairs).toEqual([
+      expect.objectContaining({
+        userMessage: "hello",
+        assistantReply: "partial ",
+        interrupted: true,
+      }),
+    ]);
 
     // Provider teardown remains observed under waitUntil, but it is no longer
     // part of the room-lock release condition. Let both mocked provider tasks
@@ -947,6 +985,12 @@ describe("SharedRuntimeChatService", () => {
       content: "partial",
       interrupted: true,
     });
+    expect(memoryPairs).toEqual([
+      expect.objectContaining({
+        assistantReply: "partial ",
+        interrupted: true,
+      }),
+    ]);
     expect(settleUnknownCalls).toBe(1);
   });
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -901,10 +901,16 @@ describe("SharedRuntimeChatService", () => {
     expect(settleUnknownCalls).toBe(1);
   });
 
-  test("stream cancellation persists interrupted history without waiting for provider teardown", async () => {
+  test("a keyed cancellation and retry converge history and memory on one stable assistant id", async () => {
     process.env.SHARED_MEMORY_TABLES_ENABLED = "true";
     const service = new SharedRuntimeChatService();
     const h = harness();
+    const { store: turnClaims } = memoryTurnClaims();
+    const keyedCancellationRpc = {
+      ...rpc,
+      id: "cancel-retry-key",
+      params: { ...rpc.params, clientMessageId: "cancel-retry-key" },
+    };
     let releaseProviderStream = () => {};
     const providerStreamGate = new Promise<void>((resolve) => {
       releaseProviderStream = resolve;
@@ -932,7 +938,7 @@ describe("SharedRuntimeChatService", () => {
       })(),
     };
 
-    const response = await service.stream(agent, rpc, h);
+    const response = await service.stream(agent, keyedCancellationRpc, { ...h, turnClaims });
     const reader = response.body!.getReader();
     const first = await reader.read();
     expect(new TextDecoder().decode(first.value)).toContain("partial");
@@ -963,11 +969,16 @@ describe("SharedRuntimeChatService", () => {
     expect(streamAbortSignal?.reason).toBe("barge-in");
     expect(providerCancelReason).toBe("barge-in");
     expect(settleUnknownCalls).toBe(1);
+    const interruptedIds = memoryPairs[0]?.messageIds;
     expect(memoryPairs).toEqual([
       expect.objectContaining({
         userMessage: "hello",
         assistantReply: "partial ",
         interrupted: true,
+        messageIds: expect.objectContaining({
+          user: expect.any(String),
+          assistant: expect.any(String),
+        }),
       }),
     ]);
 
@@ -992,6 +1003,35 @@ describe("SharedRuntimeChatService", () => {
       }),
     ]);
     expect(settleUnknownCalls).toBe(1);
+
+    streamTurn = {
+      degraded: false,
+      parts: (async function* () {
+        yield { type: "text-delta", text: "complete " };
+        yield {
+          type: "finish",
+          text: "complete response",
+          usage: { inputTokens: 1, outputTokens: 2 },
+        };
+      })(),
+    };
+    const retry = await service.stream(agent, keyedCancellationRpc, { ...h, turnClaims });
+    expect(await retry.text()).toContain("complete response");
+    await Promise.all(h.background);
+
+    expect(memoryPairs).toHaveLength(2);
+    expect(memoryPairs[1]).toMatchObject({
+      userMessage: "hello",
+      assistantReply: "complete response",
+      messageIds: interruptedIds,
+    });
+    expect(memoryPairs[1]).not.toHaveProperty("interrupted", true);
+    expect(h.history().at(-1)).toMatchObject({
+      id: interruptedIds?.assistant,
+      role: "assistant",
+      content: "complete response",
+    });
+    expect(h.history().at(-1)).not.toHaveProperty("interrupted", true);
   });
 
   test("stream cancellation observes provider teardown failures off the room-lock path", async () => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -1049,7 +1049,6 @@ export class SharedRuntimeChatService {
         messageIds,
         ...(claimKey ? { originClientMessageId: claimKey } : {}),
         onProviderDispatch: billing?.markProviderDispatched,
-        ...(streamMemoryStore ? { memory: streamMemoryStore } : {}),
         ...(options.executionEngine === "eliza-runtime"
           ? {
               execution: sharedElizaRuntimeExecution(agent, params, options.funding),
@@ -1153,6 +1152,15 @@ export class SharedRuntimeChatService {
           makeTurnMessages(reply, interrupted),
           options.historyStore,
         );
+        if (streamMemoryStore && !isDeterministicFreeTurn(turn)) {
+          await streamMemoryStore.recordTurnPair({
+            userMessage: text.trim(),
+            assistantReply: reply,
+            messageIds,
+            messageRole,
+            interrupted,
+          });
+        }
         await afterWrite?.();
         finalized = true;
       })().catch((error) => {


### PR DESCRIPTION
Closes #20632

## Problem

The Shared streaming wrapper wrote the full provider reply to shared_agent_memories as soon as the inner stream emitted finish. A client cancellation is observed only at the outer transport boundary, so a provider that ignores abort could persist unseen late text while canonical history retained only the visible interrupted prefix.

## Fix

- Make SharedRuntimeChatService the sole streaming persistence boundary.
- Persist the exact finalized reply that canonical history accepts.
- Mark stored partial assistant content as interrupted.
- Omit an unseen empty assistant row while retaining the user row.
- Keep deterministic free turns out of the memory table.

SHARED_MEMORY_TABLES_ENABLED remains absent/off in Wrangler and protected workflows. This PR does not activate memory, embeddings, trajectories, channel traffic, or production.

## Exact evidence

Head: 0932baf1c2169995bfd72b4ac232bbe0ccf64b27
Base: ce9d387b2c42dc1d3113f2992ed7155b8168db2d

- 42/42 focused tests, 214 assertions, including a consumer cancellation with a provider that ignores abort and emits a late full reply
- packages/cloud/shared typecheck: PASS
- packages/cloud/api typecheck plus production Wrangler dry bundle: PASS
- Biome on all six changed files: PASS
- git diff --check: PASS

## Reviewer-visible acceptance

The cancellation regression asserts that only the visible interrupted prefix is stored once; the late full response is never written. Empty interrupted output creates no fabricated assistant memory.

## Evidence matrix

- Backend structured behavior: covered by exact focused test output above
- Real model trajectory: N/A - this storage fence is below model selection and the Shared trajectory integration is not wired yet
- UI screenshots/video: N/A - no UI change
- Domain artifact: in-memory repository captures exact rows and interruption metadata; live table activation intentionally remains off until this fence lands
- Production: untouched