### PR TITLE
test(cloud): preserve voice Core mock surface

### DIFF
--- a/packages/cloud/api/v1/voice/session/__tests__/mint-consent-route.test.ts
+++ b/packages/cloud/api/v1/voice/session/__tests__/mint-consent-route.test.ts
@@ -6,12 +6,14 @@
 
 import { beforeAll, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+import * as workerCoreStub from "../../../../src/stubs/elizaos-core";
 
 const fakeLogger = {
   logger: { error: mock(), info: mock(), warn: mock(), debug: mock() },
 };
 mock.module("@/lib/utils/logger", () => fakeLogger);
 mock.module("@elizaos/core", () => ({
+  ...workerCoreStub,
   isSensitiveKeyName: () => false,
   redactLogArgs: (a: unknown) => a,
 }));

--- a/packages/cloud/api/v1/voice/session/voice-session-routes-and-auth.test.ts
+++ b/packages/cloud/api/v1/voice/session/voice-session-routes-and-auth.test.ts
@@ -19,6 +19,7 @@ import * as realVoiceUsageMeter from "@/lib/services/voice-usage-meter";
 import * as realJwt from "@/lib/voice-session/jwt";
 import * as realSessionRegistry from "@/lib/voice-session/session-registry";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import * as workerCoreStub from "../../../src/stubs/elizaos-core";
 
 const realCloudWorkerErrorsExports = { ...realCloudWorkerErrors };
 const realJwtExports = { ...realJwt };
@@ -53,6 +54,7 @@ const apiRoot = new URL("../../../src", import.meta.url).href;
 // `getCurrentUser`; stub `@elizaos/core` so that graph never has to resolve in
 // the DB-free unit lane (matches the sibling mint-consent route test).
 mock.module("@elizaos/core", () => ({
+  ...workerCoreStub,
   isSensitiveKeyName: () => false,
   redactLogArgs: (a: unknown) => a,
 }));


### PR DESCRIPTION
# Relates to

Fixes #20629

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Rebased onto `develop@fcfd43f3699b` before final validation.
- [x] Both complete voice-session files, Cloud API build/typecheck, Biome, and diff checks pass.
- [x] Exact-head uncached root `bun run verify` passes 356/356 plus every audit.
- [x] Tests-first module-load failure and repaired 19/19 result are recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Exact candidate head: `2d797de8b529ed94d89edfb303a9032fa6bafaf5` on `develop@fcfd43f3699bb856fc04f3fd4d89f5020df5f9d1`.
- [x] `origin/develop` advanced during the uncached root run to `68d6ae9f482d`; the eight intervening commits touch analytics export, app/UI, and Core action tiering, not either changed voice test or the canonical Worker Core stub.
- [x] No production source is changed.

# Risks

Low and test-only. The tests already replace `@elizaos/core` to keep a DB-free Worker boundary. They now start from the repository's canonical Cloud Worker Core shim and retain their two explicit overrides, so transitive Worker-safe exports remain available without loading the Node runtime graph or hand-maintaining another partial Core surface.

# Background

## What does this PR do?

Spreads `packages/cloud/api/src/stubs/elizaos-core.ts` into the two process-global Core mocks used by the voice session HTTP tests. Cloud Shared telemetry now imports `ElizaError`; the former two-export mocks removed it and caused module loading to fail before test collection. The broader stub also preserves other legitimate Worker-safe imports such as `readRequestBody` and prevents the same class of drift from recurring.

## What kind of change is this?

Test-contract repair. No production runtime, API, schema, or deployment behavior changes.

# Documentation changes needed?

No. This restores the existing test boundary to the canonical repository shim.

# Testing

## Where should a reviewer start?

- `packages/cloud/api/v1/voice/session/__tests__/mint-consent-route.test.ts`
- `packages/cloud/api/v1/voice/session/voice-session-routes-and-auth.test.ts`
- `packages/cloud/api/src/stubs/elizaos-core.ts` (existing canonical shim; unchanged)

## Detailed testing steps

Pinned Bun `1.3.14`, Node `24.15.0`.

```bash
bun test packages/cloud/api/v1/voice/session/__tests__/mint-consent-route.test.ts packages/cloud/api/v1/voice/session/voice-session-routes-and-auth.test.ts
bun run --cwd packages/cloud/api build
bunx biome check packages/cloud/api/v1/voice/session/__tests__/mint-consent-route.test.ts packages/cloud/api/v1/voice/session/voice-session-routes-and-auth.test.ts
git diff --check origin/develop...HEAD
TURBO_FORCE=true bun run verify
```

# Evidence Gate

<!-- evidence-head:2d797de8b529ed94d89edfb303a9032fa6bafaf5 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only backend contract; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only backend contract; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive frontend flow changed.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no deployed backend behavior changed; deterministic red/green test transcript is inline below.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser behavior changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, model, agent, or LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted domain artifact is produced by this test-contract repair.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or text changed.

# Evidence Details

```text
Tests-first baseline on develop:
- mint-consent-route.test.ts: 0 pass / 1 module-load error
- voice-session-routes-and-auth.test.ts: 0 pass / 1 module-load error
- SyntaxError: Export named 'ElizaError' not found in packages/core/src/index.node.ts

Exact repaired head 2d797de8:
- combined complete voice-session files: 19 pass / 0 fail / 71 assertions
- natural process exit: 0
- Cloud API build/typecheck: pass
- changed-file Biome: pass
- git diff --check: clean
- uncached root verify: 356/356, 0 cached, every audit
- anti-larp: 8,384 files, 0 focused, 0 orphaned skips
```

The initial direct test attempt in a clean worktree also proved the documented Core generated-keyword/build prerequisite; after the normal Core build boundary, the old mocks deterministically failed on their missing export. No generated files are part of this PR.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Attribution status: self-reported
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop"} -->
