### PR TITLE
fix(cloud): validate analytics overview time range

### DIFF
--- a/packages/cloud/api/analytics/overview/route.test.ts
+++ b/packages/cloud/api/analytics/overview/route.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Exercises the mounted analytics overview Hono route with mocked auth, rate
+ * limiting, service, and logging boundaries. Unsupported time ranges must be
+ * rejected before the analytics service receives them.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const supportedTimeRanges = new Set(["daily", "weekly", "monthly"]);
+const getOverview = mock(async (_organizationId: string, timeRange: string) => {
+  if (!supportedTimeRanges.has(timeRange)) {
+    throw new TypeError(
+      "Cannot read properties of undefined (reading 'getTime')",
+    );
+  }
+  return {
+    summary: {
+      totalRequests: 10,
+      successRate: 0.8,
+      totalCost: 4,
+      avgCostPerRequest: 0.4,
+      totalTokens: 100,
+    },
+  };
+});
+
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: (c: { json: (body: unknown, status: number) => Response }) =>
+    c.json({ error: "internal_error" }, 500),
+}));
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg: async () => ({
+    id: "user-1",
+    organization_id: "org-1",
+  }),
+}));
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+mock.module("@/lib/services/analytics", () => ({
+  analyticsService: { getOverview },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: () => undefined },
+}));
+
+const route = (await import("./route")).default;
+const app = new Hono().route("/api/analytics/overview", route);
+
+function getAnalyticsOverview(query = "") {
+  return app.request(`/api/analytics/overview${query}`);
+}
+
+describe("GET /api/analytics/overview timeRange validation", () => {
+  beforeEach(() => getOverview.mockClear());
+
+  test.each([
+    ["", "daily"],
+    ["?timeRange=", "daily"],
+    ["?timeRange=daily", "daily"],
+    ["?timeRange=weekly", "weekly"],
+    ["?timeRange=monthly", "monthly"],
+  ])("accepts %s as %s", async (query, expectedTimeRange) => {
+    const response = await getAnalyticsOverview(query);
+
+    expect(response.status).toBe(200);
+    expect(getOverview).toHaveBeenCalledTimes(1);
+    expect(getOverview).toHaveBeenCalledWith("org-1", expectedTimeRange);
+    const body = (await response.json()) as {
+      data: { timeRange: string };
+    };
+    expect(body.data.timeRange).toBe(expectedTimeRange);
+  });
+
+  test.each(["hourly", "week", "bogus", "daily ", "1"])(
+    "rejects unsupported timeRange=%s before analytics lookup",
+    async (value) => {
+      const response = await getAnalyticsOverview(
+        `?timeRange=${encodeURIComponent(value)}`,
+      );
+
+      expect(response.status).toBe(400);
+      const body = (await response.json()) as { error: string };
+      expect(body).toEqual({ error: "Invalid timeRange" });
+      expect(getOverview).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/analytics/overview/route.ts
+++ b/packages/cloud/api/analytics/overview/route.ts
@@ -16,17 +16,24 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
+type TimeRange = "daily" | "weekly" | "monthly";
+
+function isTimeRange(value: string | undefined): value is TimeRange {
+  return value === "daily" || value === "weekly" || value === "monthly";
+}
+
 app.use("*", rateLimit(RateLimitPresets.STANDARD));
 
 app.get("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
-    const timeRange =
-      (c.req.query("timeRange") as
-        | "daily"
-        | "weekly"
-        | "monthly"
-        | undefined) || "daily";
+    const rawTimeRange = c.req.query("timeRange");
+    if (rawTimeRange && !isTimeRange(rawTimeRange)) {
+      return c.json({ error: "Invalid timeRange" }, 400);
+    }
+    const timeRange: TimeRange = isTimeRange(rawTimeRange)
+      ? rawTimeRange
+      : "daily";
 
     const overview = await analyticsService.getOverview(
       user.organization_id,


### PR DESCRIPTION
# Relates to

Fixes #20643

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased conflict-free onto the latest fetched `origin/develop`.
- [x] The mounted real-Hono route regression, Cloud API build/typecheck, package lint, and exact-head proof passed with Bun 1.3.14 and Node 24.15.0.
- [ ] Root `bun run verify` was not run; the bounded package evidence and exact reason are recorded below.
- [x] A reviewer can reproduce both the prior HTTP 500 and the repaired HTTP 400 boundary response from the focused table.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6; openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Grok Build; Claude Code via CLIProxyAPI
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@68d6ae9f482dbfc01165745fa6a950461834e024:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased conflict-free onto `origin/develop@68d6ae9f482dbfc01165745fa6a950461834e024`.
- [x] Final candidate head is `53b1decb53266b04deccfe236cfdbb5e66e2240e`.
- [x] A complete final read-only scan covered **24 open PRs / 140 changed-file rows** with zero overlap on either target path.
- [x] A separate scan covered **181 open issues** and matching claim comments; only linked issue #20643 claims analytics-overview `timeRange` validation.
- [x] The generated route map is untouched; this changes an already-mounted route.

# Risks

Low. The change is confined to validating one optional query value after the existing auth boundary and before the analytics service call. Omitted or explicitly empty values preserve the existing `daily` default, and `daily`, `weekly`, and `monthly` retain their current service and response behavior.

# Background

## What does this PR do?

Validates the untrusted `timeRange` query value against the three supported runtime values before calling `analyticsService.getOverview()`. Any other non-empty value now returns HTTP 400 with `{ "error": "Invalid timeRange" }`.

Before this change, the route cast any query string to the union type. An unsupported value reached `calculateDateRanges()`, whose switch did not assign `startDate`; the later `startDate.getTime()` call threw, and the shared HTTP failure boundary returned 500.

## What kind of change is this?

Bug fix (untrusted HTTP query validation).

# Documentation changes needed?

No. This makes the existing three-value query contract fail deterministically and does not change valid overview behavior or the success response.

# Testing

## Where should a reviewer start?

- `packages/cloud/api/analytics/overview/route.ts`
- `packages/cloud/api/analytics/overview/route.test.ts`

## Detailed testing steps

Pinned toolchain: Bun `1.3.14`, Node `24.15.0`.

```bash
/Users/thescoho/.nvm/versions/node/v24.15.0/bin/node packages/cloud/api/test/run-unit-isolated.mjs analytics/overview
bun run --cwd packages/cloud/api build
bun run --cwd packages/cloud/api lint:check
git diff --check origin/develop...HEAD
```

# Evidence Gate

<!-- evidence-head:53b1decb53266b04deccfe236cfdbb5e66e2240e -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend API query validation; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend API query validation; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual or interactive frontend flow changed.
<!-- evidence-row:backend-logs -->
- [x] Mounted real-route and package verification output is included inline.

<details>
<summary>Exact-head verification transcript</summary>

```text
Tests-first baseline before the production repair:
5 passed / 5 failed / 25 assertions
Every unsupported timeRange value returned HTTP 500.

Final base: 68d6ae9f482dbfc01165745fa6a950461834e024
Exact head: 53b1decb53266b04deccfe236cfdbb5e66e2240e
Focused mounted-route suite: 10 passed / 0 failed / 35 assertions
Cloud API tsc6 build: passed
Cloud API Biome lint: 1,110 files checked / no fixes
Focused Biome check: passed
git diff --check origin/develop...HEAD: clean
Exact-head proof: recorded green for 53b1decb5 with Node 24.15.0
```
</details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend client code or browser state changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, scheduled-task, wallet, on-chain, audio, or generated-file artifact changed.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, prompt, provider, or model behavior changed.

## Backend + frontend logs

The test mounts the actual analytics overview route in Hono and mocks only authentication, rate limiting, analytics-service, shared failure-response, and logging boundaries. It verifies omitted, empty, and every supported value, then asserts that five unsupported values return `{ "error": "Invalid timeRange" }` with HTTP 400 before any analytics lookup.

Frontend logs are not applicable because no frontend client behavior changed.

## Screenshots (before / after) + video walkthrough

N/A - backend-only query validation with no rendered UI surface.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changed.

## Known gaps / failures

- Root `bun run verify` was not run. The changed Cloud API route was instead exercised through the mounted real-route suite, package compiler, full package Biome lane, focused formatter check, and exact-head proof.
- Dependencies were installed in the worktree with `bun install --frozen-lockfile --ignore-scripts`; the final rebase did not change `bun.lock`. Required ignored keyword modules were generated before the compiler lane.
- No live production request was sent because that would require operational credentials; the real mounted Hono transport path is covered locally.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Claude Code via CLIProxyAPI
Contribution skill revision: elizaOS/eliza@68d6ae9f482dbfc01165745fa6a950461834e024:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [sol-analytics-overview-time-range]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code via CLIProxyAPI","skill_revision":"elizaOS/eliza@68d6ae9f482dbfc01165745fa6a950461834e024:packages/skills/skills/contribute-to-eliza"} -->
