### PR TITLE
fix(auth): recognize separated access expiry codes

### DIFF
--- a/packages/auth/src/token-expiry.test.ts
+++ b/packages/auth/src/token-expiry.test.ts
@@ -18,9 +18,16 @@ describe("access-token expiry classification", () => {
     "OAuth error token_expired",
     '{"error":"token_expired"}',
     "OAuth token has expired",
+    "OAuth token is expired",
+    "oauth_token_expired",
+    "OAUTH_TOKEN_HAS_EXPIRED",
     "access token is expired",
+    "access_token_expired",
+    "ACCESS_TOKEN_HAS_EXPIRED",
     "JWT expired",
+    "jwt_expired",
     "session expired",
+    "session_expired",
   ])("recognizes explicit expiry text: %s", (text) => {
     expect(isTokenExpiryText(text)).toBe(true);
     expect(classifyAuthFailureReason(text)).toBe("token_expired");
@@ -36,6 +43,7 @@ describe("access-token expiry classification", () => {
     "The refresh token expired",
     "refresh_token_expired",
     "error=refresh_token_expired",
+    "access_token_expired; refresh_token_expired",
   ])("requires reauthentication for non-access-token failures: %s", (text) => {
     expect(isTokenExpiryText(text)).toBe(false);
     expect(classifyAuthFailureReason(text)).toBe("needs_reauth");

--- a/packages/auth/src/token-expiry.ts
+++ b/packages/auth/src/token-expiry.ts
@@ -15,7 +15,7 @@ export type CodingAuthFailureReason =
 const REFRESH_TOKEN_EXPIRED_PATTERN =
   /\brefresh[_ ]token[_ ](?:(?:has|is)[_ ])?expired\b/i;
 const TOKEN_EXPIRED_PATTERN =
-  /\b(?:token[_ ](?:has[_ ])?expired|expired[_ ]?token|oauth token (?:has )?expired|access token (?:has )?expired|token is expired|jwt expired|session expired)\b/i;
+  /\b(?:token[_ ](?:(?:has|is)[_ ])?expired|expired[_ ]?token|(?:oauth|access)[_ ]token[_ ](?:(?:has|is)[_ ])?expired|jwt[_ ]expired|session[_ ]expired)\b/i;
 
 /** Returns true only for explicit access-token expiry language. */
 export function isTokenExpiryText(text: string | null | undefined): boolean {


### PR DESCRIPTION
Fixes the additional expiry spellings found while independently reviewing #20566. Relates to #20565.

## What changed

- Recognize provider machine codes such as `access_token_expired`, `oauth_token_expired`, `jwt_expired`, and `session_expired` as explicit access-token expiry.
- Keep refresh-token expiry fail-closed as `needs_reauth`, including mixed messages that mention both access and refresh expiry.
- Preserve all generic auth-failure behavior; a bare 401, invalid token, or revoked credential is still not treated as recoverable access expiry.

## Exact-head validation

- Head: `a5569ccc723608629ad9c4e387c26133e90f903b`
- Base: `develop@68d6ae9f482dbfc01165745fa6a950461834e024`
- Full `@elizaos/auth` suite: 170/170 passed.
- Auth typecheck, lint check, format check, build, and diff check passed.
- No credential, OAuth exchange, refresh mutex, storage, provider, network, or deployment behavior changed.

## Evidence

N/A for screenshots/video/frontend logs: this is a deterministic backend classifier. The table-driven tests exercise the exported public behavior directly without reading or logging credentials.

AI assistance: yes
AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@68d6ae9f482dbfc01165745fa6a950461834e024:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported; no signed contribution receipt claimed
— [codex-root]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@68d6ae9f482dbfc01165745fa6a950461834e024:packages/skills/skills/contribute-to-eliza"} -->
