### PR TITLE
fix(core): owner-private declines state the real reason — permission vs surface, no misleading DM advice for non-owners

### DIFF
--- a/packages/core/src/actions/to-tool.ts
+++ b/packages/core/src/actions/to-tool.ts
@@ -68,7 +68,7 @@ export const HANDLE_RESPONSE_SCHEMA: JSONSchema = {
 		replyText: {
 			type: "string",
 			description:
-				'User-facing reply. Simple=whole answer. Planning=brief ack ("On it.", "Working on it.").',
+				'User-facing reply. Simple=whole answer. Planning=brief ack ("On it.", "Working on it."). When declining a capability you lack, say plainly that you can\'t do it; do NOT invent a reason you are unsure of (e.g. "no shell access in this channel", "not connected") — an invented surface/setup cause misleads when the real reason is permission or availability.',
 		},
 		replyEffectStatus: {
 			type: "string",

--- a/packages/core/src/runtime/message-handler.ts
+++ b/packages/core/src/runtime/message-handler.ts
@@ -263,12 +263,15 @@ const EXPLICIT_MEDIA_GENERATION_REQUEST_RE =
 
 /** Capability-denial reply shape ("can't do that here — no video tools in
  * this setup", "I don't have an image generator", "that's a private
- * surface"). The private-surface arm exists because the denial text this
- * runtime itself ships in group channels becomes room history that stage-1
- * then parrots VERBATIM for asks an ungated sibling could serve (observed
- * live: "remind me in 3 minutes" denied in one stage with empty contexts). */
+ * surface / private info / limited to the owner"). The privacy arm exists
+ * because the denial text this runtime itself ships in group channels becomes
+ * room history that stage-1 then parrots VERBATIM for asks an ungated sibling
+ * could serve (observed live: "remind me in 3 minutes" denied in one stage
+ * with empty contexts). Kept in sync with `privacyDenialReplyForReasons`
+ * (services/message.ts) — every owner-private decline it can ship must match
+ * one arm here. */
 const CAPABILITY_DENIAL_REPLY_RE =
-	/\b(?:can'?t|cannot|unable to|no|don'?t have|lack)\b[^.!?]{0,80}\b(?:tool|generat|capabilit|action|model|service|setup|environment)|private surface/i;
+	/\b(?:can'?t|cannot|unable to|no|don'?t have|lack)\b[^.!?]{0,80}\b(?:tool|generat|capabilit|action|model|service|setup|environment)|private surface|owner'?s private info|(?:limited|only available) to (?:the owner|them)|don'?t have access to that/i;
 
 /** Explicit reminder/alarm request shape — as unambiguous as an ask gets. */
 const EXPLICIT_REMINDER_REQUEST_RE =

--- a/packages/core/src/services/__tests__/privacy-denial-reply.test.ts
+++ b/packages/core/src/services/__tests__/privacy-denial-reply.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Unit-tests privacyDenialReplyForReasons: the owner-private decline must be
+ * accurate to WHY access was denied — an owner on a shared surface gets the
+ * "ask me in a DM" routing hint, a non-owner gets a permission-truthful
+ * decline with NO DM advice (a DM would be denied too), and role/context
+ * gating states access is missing. Pure function, no runtime.
+ */
+import { describe, expect, test } from "vitest";
+import { privacyDenialReplyForReasons } from "../message";
+
+const R = (reason: string) => `Action OWNER_TODOS is not allowed: ${reason}`;
+
+describe("privacyDenialReplyForReasons", () => {
+  test("owner on a shared surface gets the DM routing hint", () => {
+    const reply = privacyDenialReplyForReasons([
+      R("Owner-private disclosure denied: participant_mismatch"),
+    ]);
+    expect(reply).toMatch(/dm/i);
+    expect(reply).not.toMatch(/owner's private info/i);
+  });
+
+  test("non-owner gets a permission decline with NO DM advice", () => {
+    const reply = privacyDenialReplyForReasons([
+      R("Owner-private disclosure denied: owner_mismatch"),
+    ]);
+    expect(reply).toMatch(/owner's private info|only available to them/i);
+    expect(reply).not.toMatch(/\bdm\b/i);
+  });
+
+  test("owner-on-surface takes precedence when both reasons appear", () => {
+    const reply = privacyDenialReplyForReasons([
+      R("Owner-private disclosure denied: participant_mismatch"),
+      "Action TERMINAL_SHELL is not allowed for the current role",
+    ]);
+    expect(reply).toMatch(/dm/i);
+  });
+
+  test("role/context gating states missing access, not a surface", () => {
+    const reply = privacyDenialReplyForReasons([
+      "Action TERMINAL_SHELL is not allowed for the current role",
+    ]);
+    expect(reply).toMatch(/don't have access|limited to the owner/i);
+    expect(reply).not.toMatch(/\bdm\b/i);
+  });
+
+  test("empty reasons still yields a non-empty honest decline", () => {
+    expect(privacyDenialReplyForReasons([]).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2756,7 +2756,15 @@ async function collectV5PlannerCandidateActions(args: {
 	 * Lets the planner entry distinguish "capability exists but is gated on
 	 * this surface" from ordinary no-match, and answer honestly instead of
 	 * planning against an unrelated retrieval surface. */
-	diagnostics?: { gateRejectedExplicitCandidates: string[] };
+	diagnostics?: {
+		gateRejectedExplicitCandidates: string[];
+		/** The gate-failure reason per rejected explicit candidate, so the
+		 * privacy short-circuit can answer accurately: a non-owner
+		 * (`owner_mismatch`) needs a permission-truthful decline, while an owner
+		 * on a group surface (`participant_mismatch`) needs the "ask me in a DM"
+		 * routing hint. Same index order as `gateRejectedExplicitCandidates`. */
+		gateRejectedReasons: string[];
+	};
 }): Promise<Action[]> {
 	// The candidate surface starts from every runtime action and applies only the
 	// same execution gates the planner executor will enforce — it deliberately does
@@ -2805,6 +2813,7 @@ async function collectV5PlannerCandidateActions(args: {
 		if (gateFailure !== undefined) {
 			if (explicitCandidateName) {
 				args.diagnostics?.gateRejectedExplicitCandidates.push(action.name);
+				args.diagnostics?.gateRejectedReasons.push(gateFailure);
 				args.runtime.logger.warn(
 					{
 						src: "service:message",
@@ -3029,6 +3038,39 @@ function getMessageHandlerCandidateActions(
 // so an absent optional field normalizes to the empty shape those pure
 // predicates already treat as "nothing there" — normalized here once instead of
 // at every call site.
+/**
+ * Choose the honest decline for a gated owner-private ask, driven by the actual
+ * gate-failure reason instead of a single hardcoded line. The old fixed reply
+ * ("ask me in a DM") is correct ONLY when the asker is the owner on a shared
+ * surface — for a genuine non-owner it is misleading advice, since a DM would
+ * be denied too. Reasons come from `actionGateFailure` and end in the disclosure
+ * decision reason (`participant_mismatch`, `owner_mismatch`, …) or a role/context
+ * phrase.
+ *
+ *  - owner on a group/shared surface (`participant_mismatch` /
+ *    `destination_not_private`) → the DM routing hint is accurate.
+ *  - not the owner (`owner_mismatch`) or role/context-gated → a permission-
+ *    truthful decline with NO DM hint, because access, not surface, is missing.
+ */
+export function privacyDenialReplyForReasons(reasons: readonly string[]): string {
+	const joined = reasons.join(" | ").toLowerCase();
+	const ownerOnWrongSurface =
+		/participant_mismatch|destination_not_private/.test(joined);
+	const notTheOwner = /owner_mismatch/.test(joined);
+	// Owner-on-a-group takes precedence: when the same turn rejected one
+	// candidate for the surface and another for role, the actionable fix for the
+	// legitimate owner is still to move to a private surface.
+	if (ownerOnWrongSurface && !notTheOwner) {
+		return "that's private, so i can't pull it up in a shared channel — ask me in a DM and i'll handle it there.";
+	}
+	if (notTheOwner) {
+		return "that's the owner's private info, so i can't share it — it's only available to them.";
+	}
+	// Role/context-gated (or an unlabeled reason): access is missing, not the
+	// surface. State that plainly without implying a DM would help.
+	return "you don't have access to that here — it's limited to the owner.";
+}
+
 function messageHandlerStageOneReplyContexts(
 	messageHandler: MessageHandlerResult,
 ): { stageOneContexts: readonly string[]; stageOneReplyText: string } {
@@ -8255,6 +8297,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		// still deliver it.
 		const candidateGateDiagnostics = {
 			gateRejectedExplicitCandidates: [] as string[],
+			gateRejectedReasons: [] as string[],
 		};
 		const prePatchStageOneReply =
 			typeof messageHandler.plan.reply === "string" &&
@@ -8671,7 +8714,9 @@ export async function runV5MessageRuntimeStage1(args: {
 				messageHandler,
 				result: createV5ReplyStrategyResult({
 					...args,
-					text: "that's a private surface — ask me in a DM and I'll handle it there.",
+					text: privacyDenialReplyForReasons(
+						candidateGateDiagnostics.gateRejectedReasons,
+					),
 					thought: messageHandler.thought,
 					agentVoiced: false,
 				}),


### PR DESCRIPTION
## What

Owner-private declines now state the REAL reason instead of a single hardcoded line that was accurate only for the owner. The privacy short-circuit shipped "that's a private surface — ask me in a DM and I'll handle it there." to everyone — but for a genuine non-owner that is misleading advice: a DM would be denied too, since they're not the owner. Surfaced by the role-gate test matrix.

`privacyDenialReplyForReasons` (services/message.ts) now branches on the actual gate-failure reason (threaded through as `gateRejectedReasons` alongside the existing rejected-candidate names):

- **owner on a shared surface** (`participant_mismatch` / `destination_not_private`) → "that's private, so i can't pull it up in a shared channel — ask me in a DM…" (the DM hint is accurate: the owner just needs a private surface).
- **not the owner** (`owner_mismatch`) → "that's the owner's private info, so i can't share it — it's only available to them." (permission-truthful, no misleading DM advice).
- **role/context-gated** → "you don't have access to that here — it's limited to the owner." (access is missing, not the surface).

Two supporting changes:
- `CAPABILITY_DENIAL_REPLY_RE` (message-handler.ts) extended so parroted forms of the NEW decline texts are still recognized by the anti-parrot promotion (kept in sync with the reply builder).
- `replyText` stage-1 field description (to-tool.ts): guidance not to invent an unsure decline reason ("no shell access in this channel", "not connected") when the real cause is permission/availability — the model was fabricating a surface cause on capability declines.

## Evidence

Live on the box, genuine identity split (owner via loopback, non-owner via the service_gateway token path):
- Non-owner "whats on my todo list" → "that's the owner's private info, so i can't share it — it's only available to them." (was: "ask me in a DM").
- Non-owner "run whoami in the terminal" → "you don't have access to that here — it's limited to the owner." (was: fabricated "no shell access in this channel").
- Owner in the group channel "whats on my todo list" → "that's private, so i can't pull it up in a shared channel — ask me in a DM…" (DM hint correct for the owner).
- Owner shell "run echo hello-canon" → "hello-canon" (unchanged).
- Suites: new privacy-denial-reply 5/5; message-handler + output 46/46; core typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:227d779c9873c59a0990e17e18048019a9474f14 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - chat-behavior change; before/after transcripts in PR body

<!-- evidence-row:after-screenshots -->
- [ ] N/A - chat-behavior change; before/after transcripts in PR body

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - live transcripts serve as walkthrough

<!-- evidence-row:backend-logs -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:llm-trajectory -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - decline strings verified via live owner/non-owner probes

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces
