### PR TITLE
fix(core): money-spend questions route to the finances reader instead of misrouting to goals

### DIFF
--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -1760,3 +1760,41 @@ describe("noun-modified budget stays a conversational fact, not a finance read",
 		}
 	});
 });
+
+describe("money-spend questions route to the finances reader (non-possessive)", () => {
+	const finances = { name: "OWNER_FINANCES", similes: [], tags: [] };
+
+	it("'how much did i spend this month' → OWNER_FINANCES (live goals-misroute fix)", () => {
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[finances],
+				"how much did i spend this month",
+			),
+		).toEqual({ names: ["OWNER_FINANCES"], kind: "owner-reads" });
+	});
+
+	it("spend/pay/owe phrasings all route to finances", () => {
+		for (const text of [
+			"how much have i spent",
+			"how much do i owe",
+			"what did i spend on groceries",
+			"what did i pay for the car",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateInference([finances], text),
+			).toEqual({ names: ["OWNER_FINANCES"], kind: "owner-reads" });
+		}
+	});
+
+	it("non-money 'spend' phrasings do not route to finances", () => {
+		for (const text of [
+			"i want to spend time with the kids",
+			"how should i budget my spending please give advice",
+			"how much time did i spend coding",
+		]) {
+			expect(
+				inferDirectCurrentRequestCandidateInference([finances], text).names,
+			).not.toContain("OWNER_FINANCES");
+		}
+	});
+});

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -930,6 +930,23 @@ function detectOwnerLifeReadDomain(
 	) {
 		return null;
 	}
+	// Money-spend questions are finance reads even without a possessive scope:
+	// "how much did i spend this month" / "what did i spend on groceries" /
+	// "how much have i spent" / "how much do i owe" all route to the finances
+	// reader (observed live: "how much did i spend this month" mis-routed to
+	// OWNER_GOALS and returned a life summary). Anchored to money-spend phrasing
+	// — "how much (did/have/do) i (spend|spent|pay|paid|owe)" or "what did i
+	// (spend|pay) on/for" — so "spend time with the kids" never matches.
+	if (
+		/\bhow much (?:did|have|do|does) (?:i|we) (?:spend|spent|pay|paid|owe)\b/iu.test(
+			normalized,
+		) ||
+		/\bwhat (?:did|have) (?:i|we) (?:spend|spent|pay|paid)\b(?:\s+(?:on|for)\b)?/iu.test(
+			normalized,
+		)
+	) {
+		return "finances";
+	}
 	const domains = ownerLifeReadDomainsInPossessiveScopes(normalized);
 	if (domains.size === 0) return null;
 	// Mutation shapes belong to the write detectors above (or the model);


### PR DESCRIPTION
## What

"how much did i spend this month" (and other money-verb phrasings) misrouted: stage-1 classified it as a goals ask, ran OWNER_GOALS_REVIEW, and returned a generic life summary instead of the finances reader (observed live). The owner-life read heuristic only detected finances inside a POSSESSIVE scope ("my finances/budget/spending") — a verb-form spend question ("how much did i spend", "what did i pay for X", "how much do i owe") never matched.

`detectOwnerLifeReadDomain` now recognizes non-possessive money-spend questions and routes them to the finances reader, tightly anchored to money-spend phrasing so non-money uses don't match:
- matches: "how much (did/have/do) i (spend|spent|pay|paid|owe)", "what (did/have) i (spend|spent|pay|paid) [on/for]".
- does NOT match: "spend time with the kids", "how should i budget my spending" (advice), "how much time did i spend coding" (time, not money).

## Evidence

- Before (live): "how much did i spend this month" → OWNER_GOALS candidate → life summary ("calendar has a dentist appointment…").
- After (live): same ask → finances reader "spent $0.00 in the last 30 days. 0 transactions tracked. connect a payment source…" with Add source / Import CSV / View spending suggestions.
- OWNER_FINANCES confirmed functional independently ("my finances", "spending summary" already worked) — this was purely a routing gap.
- direct-action-heuristics suite 87/87 (3 new tests, including the non-money negatives); core typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:b62abf5b032acdc8494f08e03b42adce56e8e44c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - chat-routing change; before/after transcripts in PR body

<!-- evidence-row:after-screenshots -->
- [ ] N/A - chat-routing change; before/after transcripts in PR body

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - live transcripts serve as walkthrough

<!-- evidence-row:backend-logs -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:llm-trajectory -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - finances reader output verified via live probe

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces
