### PR TITLE
fix(cloud): converge completed Shared memory retries

### DIFF
--- a/packages/cloud/shared/src/db/repositories/shared-agent-memories.integration.test.ts
+++ b/packages/cloud/shared/src/db/repositories/shared-agent-memories.integration.test.ts
@@ -181,7 +181,7 @@ describe("SharedAgentMemoriesWriter.mergeMessageMemory (real PGlite)", () => {
     });
   });
 
-  test("keeps the longest interrupted prefix and never downgrades complete", async () => {
+  test("keeps the longest interrupted prefix and lets a later complete retry converge", async () => {
     await sharedAgentMemoriesWriter.mergeMessageMemory(message("part", true));
     await sharedAgentMemoriesWriter.mergeMessageMemory(message("partial response", true));
     await sharedAgentMemoriesWriter.mergeMessageMemory(message("tiny", true));
@@ -199,6 +199,14 @@ describe("SharedAgentMemoriesWriter.mergeMessageMemory (real PGlite)", () => {
     [row] = await sharedAgentMemoriesReader.listRecentByRoom(scopeA, ROOM_A, 10);
     expect(row?.content).toEqual({
       text: "complete response",
+      source: "shared-runtime",
+      channelType: "DM",
+    });
+
+    await sharedAgentMemoriesWriter.mergeMessageMemory(message("retry terminal response", false));
+    [row] = await sharedAgentMemoriesReader.listRecentByRoom(scopeA, ROOM_A, 10);
+    expect(row?.content).toEqual({
+      text: "retry terminal response",
       source: "shared-runtime",
       channelType: "DM",
     });

--- a/packages/cloud/shared/src/db/repositories/shared-agent-memories.ts
+++ b/packages/cloud/shared/src/db/repositories/shared-agent-memories.ts
@@ -169,8 +169,9 @@ export class SharedAgentMemoriesWriter {
 
   /**
    * Atomically converges one stable assistant message across cancellation and
-   * retry. A complete reply outranks any interrupted prefix; between prefixes,
-   * only the longer visible text wins. Once complete, a row is immutable.
+   * retry. The latest complete retry is authoritative; between interrupted
+   * prefixes, only the longer visible text wins. Interrupted text can never
+   * downgrade a complete reply.
    */
   async mergeMessageMemory(
     input: MergeSharedAgentMessageMemoryInput,
@@ -217,11 +218,13 @@ export class SharedAgentMemoriesWriter {
           ${sharedAgentMemories.organization_id} = ${scope.organizationId}
           AND ${sharedAgentMemories.user_id} = ${scope.userId}
           AND ${sharedAgentMemories.agent_id} = ${scope.agentId}
-          AND COALESCE(${sharedAgentMemories.content}->>'interrupted' = 'true', false)
           AND (
             ${input.interrupted} = false
-            OR length(COALESCE(${sql.raw("excluded.content")}->>'text', ''))
-              > length(COALESCE(${sharedAgentMemories.content}->>'text', ''))
+            OR (
+              COALESCE(${sharedAgentMemories.content}->>'interrupted' = 'true', false)
+              AND length(COALESCE(${sql.raw("excluded.content")}->>'text', ''))
+                > length(COALESCE(${sharedAgentMemories.content}->>'text', ''))
+            )
           )
         `,
       })

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.test.ts
@@ -1172,8 +1172,9 @@ describe("SharedRuntimeChatService", () => {
 
   type ClaimRecord = { hash: string; result?: Record<string, unknown> };
 
-  function memoryTurnClaims() {
+  function memoryTurnClaims(options: { failCompleteAttempts?: number } = {}) {
     const claims = new Map<string, ClaimRecord>();
+    let remainingCompleteFailures = options.failCompleteAttempts ?? 0;
     return {
       claims,
       store: {
@@ -1190,6 +1191,10 @@ describe("SharedRuntimeChatService", () => {
           return { state: "claimed" as const };
         },
         complete: async (key: string, result: Record<string, unknown>) => {
+          if (remainingCompleteFailures > 0) {
+            remainingCompleteFailures--;
+            throw new Error("claim completion failed");
+          }
           const existing = claims.get(key);
           if (existing) existing.result = result;
         },
@@ -1319,5 +1324,80 @@ describe("SharedRuntimeChatService", () => {
     expect(secondDone.fullText).toBe("hello back");
     expect(secondDone.messageId).toBe(firstDone.messageId);
     expect(secondDone.userMessageId).toBe(firstDone.userMessageId);
+  });
+
+  test("claim completion failure retries to one canonical history, memory, and replay result", async () => {
+    process.env.SHARED_MEMORY_TABLES_ENABLED = "true";
+    const service = new SharedRuntimeChatService();
+    const h = harness();
+    const { store } = memoryTurnClaims({ failCompleteAttempts: 1 });
+    const options = { ...h, turnClaims: store };
+
+    streamTurn = {
+      degraded: false,
+      parts: (async function* () {
+        yield { type: "text-delta", text: "first " };
+        yield {
+          type: "finish",
+          text: "first completed reply",
+          usage: { inputTokens: 1, outputTokens: 2 },
+        };
+      })(),
+    };
+    const first = await service.stream(agent, keyedRpc, options);
+    expect(await first.text()).toContain("Shared runtime stream failed");
+    expect(memoryPairs.length).toBeGreaterThanOrEqual(1);
+    const firstAttemptPairCount = memoryPairs.length;
+    const stableIds = memoryPairs[0]?.messageIds;
+    expect(memoryPairs[0]).toMatchObject({
+      assistantReply: "first completed reply",
+      messageIds: stableIds,
+    });
+    for (const pair of memoryPairs) {
+      expect(pair).toMatchObject({
+        messageIds: stableIds,
+      });
+    }
+    expect(h.history().at(-1)).toMatchObject({
+      id: stableIds?.assistant,
+    });
+
+    streamTurn = {
+      degraded: false,
+      parts: (async function* () {
+        yield { type: "text-delta", text: "retry " };
+        yield {
+          type: "finish",
+          text: "retry terminal reply",
+          usage: { inputTokens: 1, outputTokens: 2 },
+        };
+      })(),
+    };
+    const retry = await service.stream(agent, keyedRpc, options);
+    const retryBody = await retry.text();
+    expect(retryBody).toContain("retry terminal reply");
+    expect(memoryPairs.length).toBeGreaterThan(firstAttemptPairCount);
+    const retryPairs = memoryPairs.slice(firstAttemptPairCount);
+    expect(retryPairs).toContainEqual(
+      expect.objectContaining({
+        assistantReply: "retry terminal reply",
+        messageIds: stableIds,
+      }),
+    );
+    for (const pair of retryPairs) {
+      expect(pair).toMatchObject({
+        messageIds: stableIds,
+      });
+    }
+    expect(h.history().at(-1)).toMatchObject({
+      id: stableIds?.assistant,
+      content: "retry terminal reply",
+    });
+
+    const pairCountAfterRetry = memoryPairs.length;
+    const replay = await service.stream(agent, keyedRpc, options);
+    expect(await replay.text()).toContain("retry terminal reply");
+    expect(streamTurnCalls).toBe(2);
+    expect(memoryPairs).toHaveLength(pairCountAfterRetry);
   });
 });


### PR DESCRIPTION
Part of #20632

Follow-up to merged #20642. A successful provider reply can write history and memory, then fail while completing the durable turn claim. The pending same-key recovery re-executes and may produce a different complete reply. History and terminal replay adopt the retry, so the same stable memory row must converge too.

This narrow repair makes later same-tenant complete replies authoritative while preserving the interruption ordering from #20642:

- latest complete retry replaces prior complete or interrupted text
- longer interrupted prefix replaces only a shorter interrupted prefix
- interrupted text never downgrades a complete row
- all conflict updates remain pinned to organization + user + agent

Exact head: f992d9528de5d8790594e197e7b50a3f109f067d
Base/current at proof: f6d46677d4edb746f99f7cff8d64c35820331b22

Evidence:

- 49/49 focused tests, 250 assertions
- real isolated PGlite complete-A -> complete-B convergence, interrupted ordering, and cross-tenant collision proof
- keyed stream claim-completion failure -> provider retry -> terminal replay test proves stable message IDs and retry-B convergence inputs across history/memory/replay
- Cloud Shared typecheck PASS
- Cloud API typecheck + production Worker dry bundle PASS
- Biome 3/3 and diff-check PASS

SHARED_MEMORY_TABLES_ENABLED remains absent/off. No staging, gateway, channel, provider, secret, or production mutation. UI/video/LLM trajectory are N/A because this is a disabled storage recovery boundary; real DB rows are the domain proof.