### PR TITLE
fix(cloud): drop top-level PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED var (CF 10053 on activation)

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -188,7 +188,11 @@ new_sqlite_classes = ["PersonalTelegramDelivery"]
 NODE_ENV = "production"
 SHARED_ELIZA_AGENT_RUNTIME = "false"
 PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "false"
-PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED = "false"
+# PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED is deliberately ABSENT here (and in
+# env.staging.vars): the protected cutover owns it as a per-environment secret,
+# and any [vars] spelling of the name collides with `wrangler secret put`
+# (CF error 10053 — run 31970252094 failed on exactly this top-level entry).
+# Absence is fail-closed: the Worker treats a missing binding as edge-off.
 NEXT_PUBLIC_APP_URL = "https://cloud.eliza.app"
 NEXT_PUBLIC_API_URL = "https://api.eliza.app"
 ELIZA_CLOUD_URL = "https://api.eliza.app"

--- a/packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts
@@ -51,8 +51,12 @@ const PUBLISHED_WORKER_SECRETS: Array<{ name: string; envs: string[] }> = [
   // cloud-cf-release.yml publish_secret / publish_toggle_secret chain
   { name: "CARTESIA_API_KEY", envs: ["staging", "production"] },
   { name: "STAGING_SESSION_EXCHANGE_ENABLED", envs: ["staging"] },
-  // activate-personal-shared-telegram-edge.yml (staging-only protected cutover)
-  { name: "PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED", envs: ["staging"] },
+  // activate-personal-shared-telegram-edge.yml (staging-only protected cutover).
+  // "default" is guarded too: the classic `wrangler secret put --env staging`
+  // path materializes bindings from the LOCAL config where a top-level [vars]
+  // spelling of the name still collides (CF 10053 — activation run 31970252094
+  // failed on the top-level entry after env.staging.vars was already clean).
+  { name: "PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED", envs: ["default", "staging"] },
 ];
 
 describe("Worker secret/var collision lint (CF error 10053 class)", () => {


### PR DESCRIPTION
## Summary
Edge-flip activation run 31970252094 reached the cutover with a PERFECTLY aligned Worker+gateway pair at `68d6ae9f48` and still failed on `wrangler secret put PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED --env staging` → CF error 10053 "binding name already in use".

Root cause: the **top-level `[vars]` block** still spells the flag (`wrangler.toml` line 191). `env.staging.vars` was cleaned in the attempt-1 fix, but the classic (non-`versions`) `secret put` path the activation workflow uses materializes bindings from the local config where the top-level entry collides. The top-level env is never deployed (`--env staging|production` is always passed), and the Worker fails closed when the binding is absent — so the entry is pure hazard.

- Remove the top-level var; leave a comment stating the invariant with the failing-run receipt.
- Extend the collision lint map to guard `"default"` for this name, so any respelling in either block fails `cloud-cf-secret-var-collision.test.ts` (4/4 green, tripwire for the production cutover unchanged).

## Evidence
- Activation failure log: `Binding name 'PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED' already in use. [code: 10053]` ×3 retries, then the workflow's fail-closed rollback held staging off (health beacon proof in HQ #18309).
- `bun test packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts` → 4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)