### PR TITLE
fix(core): distinguish disclosure gate rejections

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -372,6 +372,114 @@ describe("runV5MessageRuntimeStage1", () => {
 		}
 	});
 
+	it("short-circuits an explicit owner-private candidate denied by disclosure", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "The user requested an owner-private read.",
+				contexts: ["general"],
+				candidateActionNames: ["OWNER_TODOS"],
+				extra: { requiresTool: true },
+			}),
+		]);
+		runtime.actions = [
+			{
+				...makeMemorySearchAction(),
+				name: "OWNER_TODOS",
+				disclosureGate: { require: "owner_exclusive" },
+			},
+		];
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ channelType: ChannelType.GROUP }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000006" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		if (result.kind === "direct_reply") {
+			expect(result.result.responseContent?.text).toMatch(/private/i);
+		}
+		expect(useModelCalls(runtime)).toHaveLength(1);
+	});
+
+	it("keeps a role-rejected explicit candidate on the planner path", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "The user requested a restricted action.",
+				contexts: ["general"],
+				candidateActionNames: ["ADMIN_TASK"],
+				extra: { requiresTool: true },
+			}),
+			JSON.stringify({
+				thought: "Explain the actual limitation.",
+				toolCalls: [],
+				messageToUser: "This action requires an administrator role.",
+			}),
+		]);
+		runtime.actions = [
+			{
+				...makeMemorySearchAction("OWNER"),
+				name: "ADMIN_TASK",
+				contexts: ["general"],
+			},
+		];
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ channelType: ChannelType.DM }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000007" as UUID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"This action requires an administrator role.",
+			);
+		}
+		expect(useModelCalls(runtime)).toHaveLength(2);
+	});
+
+	it("keeps a context-rejected explicit candidate on the planner path", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "The user requested an action outside this context.",
+				contexts: ["general"],
+				candidateActionNames: ["CONTEXT_TASK"],
+				extra: { requiresTool: true },
+			}),
+			JSON.stringify({
+				thought: "Explain the context limitation.",
+				toolCalls: [],
+				messageToUser: "This action is unavailable in the current context.",
+			}),
+		]);
+		runtime.actions = [
+			{
+				...makeMemorySearchAction(),
+				name: "CONTEXT_TASK",
+				contexts: ["general"],
+				contextGate: { noneOf: ["general"] },
+			},
+		];
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ channelType: ChannelType.GROUP }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000008" as UUID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"This action is unavailable in the current context.",
+			);
+		}
+		expect(useModelCalls(runtime)).toHaveLength(2);
+	});
+
 	it("blocks a Stage-1 action envelope before the direct-reply route", async () => {
 		const actionEnvelope =
 			'{"action":"BROWSER","parameters":{"url":"https://example.com"},"status":"retry","toolCallId":"call-1"}';

--- a/packages/core/src/runtime/action-gate.test.ts
+++ b/packages/core/src/runtime/action-gate.test.ts
@@ -9,6 +9,7 @@ import type { Memory } from "../types/memory";
 import {
 	type ActionGateContext,
 	actionGateFailure,
+	actionGateRejection,
 	canActionRun,
 	type GateableAction,
 } from "./action-gate";
@@ -62,6 +63,9 @@ describe("canActionRun — roleGate", () => {
 	it("denies a USER an OWNER-gated action, allows an OWNER", () => {
 		const owned = action({ name: "SECRETS", roleGate: { minRole: "OWNER" } });
 		expect(canActionRun(owned, ctx({ userRoles: ["USER"] }))).toBe(false);
+		expect(actionGateRejection(owned, ctx({ userRoles: ["USER"] }))?.kind).toBe(
+			"role",
+		);
 		expect(canActionRun(owned, ctx({ userRoles: ["OWNER"] }))).toBe(true);
 	});
 
@@ -90,6 +94,9 @@ describe("canActionRun — private-action gate", () => {
 	it("returns a descriptive failure reason", () => {
 		expect(actionGateFailure(priv, ctx({ message: userTurn }))).toMatch(
 			/private/i,
+		);
+		expect(actionGateRejection(priv, ctx({ message: userTurn }))?.kind).toBe(
+			"private",
 		);
 	});
 });
@@ -129,6 +136,9 @@ describe("canActionRun — ACTION_ROLE_POLICY replaces the declared gate", () =>
 		expect(actionGateFailure(secrets, ctx({ userRoles: ["OWNER"] }))).toContain(
 			"missing_attestation",
 		);
+		expect(
+			actionGateRejection(secrets, ctx({ userRoles: ["OWNER"] }))?.kind,
+		).toBe("disclosure");
 	});
 });
 
@@ -171,6 +181,9 @@ describe("canActionRun — contextGate", () => {
 			contextGate: { contexts: ["coding" as AgentContext] },
 		});
 		expect(canActionRun(coding, ctx({ activeContexts: [] }))).toBe(false);
+		expect(actionGateRejection(coding, ctx({ activeContexts: [] }))?.kind).toBe(
+			"context",
+		);
 		expect(
 			canActionRun(coding, ctx({ activeContexts: ["coding" as AgentContext] })),
 		).toBe(true);

--- a/packages/core/src/runtime/action-gate.ts
+++ b/packages/core/src/runtime/action-gate.ts
@@ -48,6 +48,17 @@ export interface ActionGateContext {
 	skipPrivateGate?: boolean;
 }
 
+export type ActionGateRejectionKind =
+	| "private"
+	| "disclosure"
+	| "role"
+	| "context";
+
+export interface ActionGateRejection {
+	kind: ActionGateRejectionKind;
+	reason: string;
+}
+
 /**
  * The single role/context/policy gate deciding whether `action` may run for
  * `ctx` (#12087 Item 9). Composes, in order:
@@ -65,15 +76,18 @@ export interface ActionGateContext {
  * child filtering, the tool-call executor, and the shortcut gate — routes
  * through this one function so their outcomes cannot drift apart.
  */
-export function actionGateFailure(
+export function actionGateRejection(
 	action: GateableAction,
 	ctx: ActionGateContext,
-): string | undefined {
+): ActionGateRejection | undefined {
 	if (
 		!ctx.skipPrivateGate &&
 		!privateActionAllowedOnTurn(action, ctx.message)
 	) {
-		return `Action ${action.name} is private and can only run in the agent's autonomous loop`;
+		return {
+			kind: "private",
+			reason: `Action ${action.name} is private and can only run in the agent's autonomous loop`,
+		};
 	}
 
 	const disclosureFailure = disclosureGateFailure(
@@ -81,31 +95,56 @@ export function actionGateFailure(
 		ctx.message,
 	);
 	if (disclosureFailure) {
-		return `Action ${action.name} is not allowed: ${disclosureFailure}`;
+		return {
+			kind: "disclosure",
+			reason: `Action ${action.name} is not allowed: ${disclosureFailure}`,
+		};
 	}
 
 	const policyRole = resolveActionRolePolicyRole(action);
 	if (policyRole) {
 		return satisfiesRoleGate(ctx.userRoles, { minRole: policyRole })
 			? undefined
-			: `Action ${action.name} is not allowed for the current role`;
+			: {
+					kind: "role",
+					reason: `Action ${action.name} is not allowed for the current role`,
+				};
 	}
 
-	const contextGate = action.contextGate ?? {
-		contexts: action.contexts,
-		roleGate: action.roleGate,
-	};
+	const contextRoleGate = action.contextGate?.roleGate ?? action.roleGate;
+	if (!satisfiesRoleGate(ctx.userRoles, contextRoleGate)) {
+		return {
+			kind: "role",
+			reason: `Action ${action.name} is not allowed for the current role`,
+		};
+	}
+
+	const contextGate = action.contextGate ?? { contexts: action.contexts };
 	if (!satisfiesContextGate(ctx.activeContexts, contextGate, ctx.userRoles)) {
-		return `Action ${action.name} is not allowed in the current context`;
+		return {
+			kind: "context",
+			reason: `Action ${action.name} is not allowed in the current context`,
+		};
 	}
 
 	if (
 		!satisfiesRoleGate(ctx.userRoles, action.roleGate as RoleGate | undefined)
 	) {
-		return `Action ${action.name} is not allowed for the current role`;
+		return {
+			kind: "role",
+			reason: `Action ${action.name} is not allowed for the current role`,
+		};
 	}
 
 	return undefined;
+}
+
+/** Human-readable compatibility form of {@link actionGateRejection}. */
+export function actionGateFailure(
+	action: GateableAction,
+	ctx: ActionGateContext,
+): string | undefined {
+	return actionGateRejection(action, ctx)?.reason;
 }
 
 /** Boolean form of {@link actionGateFailure}. */

--- a/packages/core/src/services/__tests__/privacy-denial-reply.test.ts
+++ b/packages/core/src/services/__tests__/privacy-denial-reply.test.ts
@@ -2,8 +2,8 @@
  * Unit-tests privacyDenialReplyForReasons: the owner-private decline must be
  * accurate to WHY access was denied — an owner on a shared surface gets the
  * "ask me in a DM" routing hint, a non-owner gets a permission-truthful
- * decline with NO DM advice (a DM would be denied too), and role/context
- * gating states access is missing. Pure function, no runtime.
+ * decline with NO DM advice (a DM would be denied too). Pure function, no
+ * runtime.
  */
 import { describe, expect, test } from "vitest";
 import { privacyDenialReplyForReasons } from "../message";
@@ -27,22 +27,14 @@ describe("privacyDenialReplyForReasons", () => {
 		expect(reply).not.toMatch(/\bdm\b/i);
 	});
 
-	test("owner-on-surface takes precedence when both reasons appear", () => {
+	test("owner mismatch takes precedence across multiple disclosure failures", () => {
 		const reply = privacyDenialReplyForReasons([
 			R("Owner-private disclosure denied: participant_mismatch"),
-			"Action TERMINAL_SHELL is not allowed for the current role",
+			R("Owner-private disclosure denied: owner_mismatch"),
 		]);
-		expect(reply).toMatch(/dm/i);
-	});
-
-	test("role/context gating states missing access, not a surface", () => {
-		const reply = privacyDenialReplyForReasons([
-			"Action TERMINAL_SHELL is not allowed for the current role",
-		]);
-		expect(reply).toMatch(/don't have access|limited to the owner/i);
+		expect(reply).toMatch(/owner's private info|only available to them/i);
 		expect(reply).not.toMatch(/\bdm\b/i);
 	});
-
 	test("empty reasons still yields a non-empty honest decline", () => {
 		expect(privacyDenialReplyForReasons([]).length).toBeGreaterThan(0);
 	});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -67,7 +67,11 @@ import {
 	buildActionCatalog,
 	type LocalizedActionExampleResolver,
 } from "../runtime/action-catalog";
-import { actionGateFailure, canActionRun } from "../runtime/action-gate";
+import {
+	actionGateFailure,
+	actionGateRejection,
+	canActionRun,
+} from "../runtime/action-gate";
 import {
 	parentAliasesForCandidateAction,
 	retrieveActions,
@@ -2751,19 +2755,20 @@ async function collectV5PlannerCandidateActions(args: {
 	selectedContexts?: readonly AgentContext[];
 	candidateActions?: readonly string[];
 	userRoles?: readonly RoleGateRole[];
-	/** Out-param: normalized names of EXPLICIT stage-1 candidates whose
-	 * resolved action was rejected by the action gate (role/context/privacy).
+	/** Out-param: normalized names and reasons for EXPLICIT stage-1 candidates
+	 * rejected by the owner-exclusive disclosure gate.
 	 * Lets the planner entry distinguish "capability exists but is gated on
 	 * this surface" from ordinary no-match, and answer honestly instead of
 	 * planning against an unrelated retrieval surface. */
 	diagnostics?: {
-		gateRejectedExplicitCandidates: string[];
-		/** The gate-failure reason per rejected explicit candidate, so the
+		disclosureRejectedExplicitCandidates: string[];
+		/** The disclosure reason per rejected explicit candidate, so the
 		 * privacy short-circuit can answer accurately: a non-owner
 		 * (`owner_mismatch`) needs a permission-truthful decline, while an owner
 		 * on a group surface (`participant_mismatch`) needs the "ask me in a DM"
-		 * routing hint. Same index order as `gateRejectedExplicitCandidates`. */
-		gateRejectedReasons: string[];
+		 * routing hint. Same index order as
+		 * `disclosureRejectedExplicitCandidates`. */
+		disclosureRejectedReasons: string[];
 	};
 }): Promise<Action[]> {
 	// The candidate surface starts from every runtime action and applies only the
@@ -2805,22 +2810,28 @@ async function collectV5PlannerCandidateActions(args: {
 		// Explicit Stage-1 hints need a diagnostic when their resolved action is
 		// rejected. The all-action pass stays quiet because ordinary gate misses
 		// are expected while building a narrowed surface.
-		const gateFailure = actionGateFailure(action, {
+		const gateRejection = actionGateRejection(action, {
 			message: args.message,
 			activeContexts,
 			userRoles: args.userRoles,
 		});
-		if (gateFailure !== undefined) {
+		if (gateRejection !== undefined) {
 			if (explicitCandidateName) {
-				args.diagnostics?.gateRejectedExplicitCandidates.push(action.name);
-				args.diagnostics?.gateRejectedReasons.push(gateFailure);
+				if (gateRejection.kind === "disclosure") {
+					args.diagnostics?.disclosureRejectedExplicitCandidates.push(
+						action.name,
+					);
+					args.diagnostics?.disclosureRejectedReasons.push(
+						gateRejection.reason,
+					);
+				}
 				args.runtime.logger.warn(
 					{
 						src: "service:message",
 						action: action.name,
 						candidate: explicitCandidateName,
 						gate: "action-gate",
-						reason: gateFailure,
+						reason: gateRejection.reason,
 					},
 					"Explicit stage-1 candidate rejected at the action gate",
 				);
@@ -3044,13 +3055,12 @@ function getMessageHandlerCandidateActions(
  * ("ask me in a DM") is correct ONLY when the asker is the owner on a shared
  * surface — for a genuine non-owner it is misleading advice, since a DM would
  * be denied too. Reasons come from `actionGateFailure` and end in the disclosure
- * decision reason (`participant_mismatch`, `owner_mismatch`, …) or a role/context
- * phrase.
+ * decision reason (`participant_mismatch`, `owner_mismatch`, …).
  *
  *  - owner on a group/shared surface (`participant_mismatch` /
  *    `destination_not_private`) → the DM routing hint is accurate.
- *  - not the owner (`owner_mismatch`) or role/context-gated → a permission-
- *    truthful decline with NO DM hint, because access, not surface, is missing.
+ *  - not the owner (`owner_mismatch`) → a permission-truthful decline with NO
+ *    DM hint, because access, not surface, is missing.
  */
 export function privacyDenialReplyForReasons(
 	reasons: readonly string[],
@@ -3059,18 +3069,15 @@ export function privacyDenialReplyForReasons(
 	const ownerOnWrongSurface =
 		/participant_mismatch|destination_not_private/.test(joined);
 	const notTheOwner = /owner_mismatch/.test(joined);
-	// Owner-on-a-group takes precedence: when the same turn rejected one
-	// candidate for the surface and another for role, the actionable fix for the
-	// legitimate owner is still to move to a private surface.
+	// Owner-on-a-group takes precedence when multiple disclosure-gated candidates
+	// fail for different audience reasons.
 	if (ownerOnWrongSurface && !notTheOwner) {
 		return "that's private, so i can't pull it up in a shared channel — ask me in a DM and i'll handle it there.";
 	}
 	if (notTheOwner) {
 		return "that's the owner's private info, so i can't share it — it's only available to them.";
 	}
-	// Role/context-gated (or an unlabeled reason): access is missing, not the
-	// surface. State that plainly without implying a DM would help.
-	return "you don't have access to that here — it's limited to the owner.";
+	return "i can't share that private information in this conversation.";
 }
 
 function messageHandlerStageOneReplyContexts(
@@ -8298,8 +8305,8 @@ export async function runV5MessageRuntimeStage1(args: {
 		// the planner loop's answer rescue and the answerless-final fallback can
 		// still deliver it.
 		const candidateGateDiagnostics = {
-			gateRejectedExplicitCandidates: [] as string[],
-			gateRejectedReasons: [] as string[],
+			disclosureRejectedExplicitCandidates: [] as string[],
+			disclosureRejectedReasons: [] as string[],
 		};
 		const prePatchStageOneReply =
 			typeof messageHandler.plan.reply === "string" &&
@@ -8649,15 +8656,17 @@ export async function runV5MessageRuntimeStage1(args: {
 					diagnostics: candidateGateDiagnostics,
 				});
 		// Surface-privacy short-circuit: stage-1 named a capability that EXISTS
-		// but is gated on this surface (role/privacy — e.g. owner-life actions in
-		// a public channel), and no named candidate survived into the collected
-		// set. Planning anyway hands the model an unrelated retrieval surface and
+		// but its owner-exclusive disclosure gate rejected this destination, and
+		// no named candidate survived into the collected set. Planning anyway
+		// hands the model an unrelated retrieval surface and
 		// it improvises around the missing capability — observed live on the
 		// Discord group channel: a "todos" ask got a WEB_SEARCH surface and
 		// shipped a fabricated "todo added" with zero writes, and a todos READ
 		// answered a false empty from the orchestrator task store. Answer with an
 		// honest surface denial instead. The phrasing confirms nothing about the
-		// data — only that the surface is private to another channel.
+		// data — only that the disclosure boundary rejected this requester or
+		// destination. Role, context, and autonomy denials keep the ordinary
+		// planner path because they do not prove a privacy denial.
 		const collectedCandidateNames = new Set(
 			plannerCandidateActions.map((action) =>
 				normalizeActionIdentifier(action.name),
@@ -8700,14 +8709,19 @@ export async function runV5MessageRuntimeStage1(args: {
 		// When the rejected candidates are reminder/alarm-shaped and TRIGGER
 		// survived collection, let the turn plan — the trigger path serves it.
 		const rejectedReminderish =
-			candidateGateDiagnostics.gateRejectedExplicitCandidates.some((name) => {
-				const normalized = normalizeActionIdentifier(name);
-				return normalized.includes("REMINDER") || normalized.includes("ALARM");
-			});
+			candidateGateDiagnostics.disclosureRejectedExplicitCandidates.some(
+				(name) => {
+					const normalized = normalizeActionIdentifier(name);
+					return (
+						normalized.includes("REMINDER") || normalized.includes("ALARM")
+					);
+				},
+			);
 		const ungatedTriggerSiblingAvailable =
 			rejectedReminderish && collectedCandidateNames.has("TRIGGER");
 		if (
-			candidateGateDiagnostics.gateRejectedExplicitCandidates.length > 0 &&
+			candidateGateDiagnostics.disclosureRejectedExplicitCandidates.length >
+				0 &&
 			!anyNamedStageOneCandidateSurvived &&
 			!ungatedTriggerSiblingAvailable
 		) {
@@ -8717,7 +8731,7 @@ export async function runV5MessageRuntimeStage1(args: {
 				result: createV5ReplyStrategyResult({
 					...args,
 					text: privacyDenialReplyForReasons(
-						candidateGateDiagnostics.gateRejectedReasons,
+						candidateGateDiagnostics.disclosureRejectedReasons,
 					),
 					thought: messageHandler.thought,
 					agentVoiced: false,


### PR DESCRIPTION
## Summary

Follow-up to merged #20650. The privacy shortcut now activates only for a canonical disclosure-gate rejection. Explicit role, context, and private-action rejections remain on the normal planner/recovery path instead of being mislabeled as owner-private access failures.

The unified action gate now returns a structured rejection category while retaining the existing human-readable compatibility API.

## Root cause

#20650 collected every explicit action-gate failure into the privacy diagnostic. That made unrelated role/context denials bypass planning and produce false owner/private guidance.

## Validation

- action gate + privacy reply: 16/16
- integrated Stage-1 disclosure/role/context regressions: 3/3
- packages/core typecheck: pass
- Biome exact 5 files: pass
- diff check: pass

The broader Stage-1 file has one pre-existing failure on the merged #20650 parent: the reminder reconciliation assertion expects two candidates but also receives the TRIGGER alias. The focused changed paths above are green and this PR does not change that alias behavior.

## Evidence

<!-- evidence-head:677dd7d85fa89a13fce2fab27a2ab5390a548948 -->
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend-only action-gate correction with no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend-only action-gate correction with no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no rendered or interactive UI path changed`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no server or deployment was run; the in-process gate is covered by the deterministic integration tests above`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend code or browser path changed`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no prompt, model, or provider behavior changed; this correction classifies deterministic post-Stage-1 gate results`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no persistence or external domain system changed`.
