### PR TITLE
fix(core): restore privacy denial formatting

### DIFF
--- a/packages/core/src/services/__tests__/privacy-denial-reply.test.ts
+++ b/packages/core/src/services/__tests__/privacy-denial-reply.test.ts
@@ -11,39 +11,39 @@ import { privacyDenialReplyForReasons } from "../message";
 const R = (reason: string) => `Action OWNER_TODOS is not allowed: ${reason}`;
 
 describe("privacyDenialReplyForReasons", () => {
-  test("owner on a shared surface gets the DM routing hint", () => {
-    const reply = privacyDenialReplyForReasons([
-      R("Owner-private disclosure denied: participant_mismatch"),
-    ]);
-    expect(reply).toMatch(/dm/i);
-    expect(reply).not.toMatch(/owner's private info/i);
-  });
+	test("owner on a shared surface gets the DM routing hint", () => {
+		const reply = privacyDenialReplyForReasons([
+			R("Owner-private disclosure denied: participant_mismatch"),
+		]);
+		expect(reply).toMatch(/dm/i);
+		expect(reply).not.toMatch(/owner's private info/i);
+	});
 
-  test("non-owner gets a permission decline with NO DM advice", () => {
-    const reply = privacyDenialReplyForReasons([
-      R("Owner-private disclosure denied: owner_mismatch"),
-    ]);
-    expect(reply).toMatch(/owner's private info|only available to them/i);
-    expect(reply).not.toMatch(/\bdm\b/i);
-  });
+	test("non-owner gets a permission decline with NO DM advice", () => {
+		const reply = privacyDenialReplyForReasons([
+			R("Owner-private disclosure denied: owner_mismatch"),
+		]);
+		expect(reply).toMatch(/owner's private info|only available to them/i);
+		expect(reply).not.toMatch(/\bdm\b/i);
+	});
 
-  test("owner-on-surface takes precedence when both reasons appear", () => {
-    const reply = privacyDenialReplyForReasons([
-      R("Owner-private disclosure denied: participant_mismatch"),
-      "Action TERMINAL_SHELL is not allowed for the current role",
-    ]);
-    expect(reply).toMatch(/dm/i);
-  });
+	test("owner-on-surface takes precedence when both reasons appear", () => {
+		const reply = privacyDenialReplyForReasons([
+			R("Owner-private disclosure denied: participant_mismatch"),
+			"Action TERMINAL_SHELL is not allowed for the current role",
+		]);
+		expect(reply).toMatch(/dm/i);
+	});
 
-  test("role/context gating states missing access, not a surface", () => {
-    const reply = privacyDenialReplyForReasons([
-      "Action TERMINAL_SHELL is not allowed for the current role",
-    ]);
-    expect(reply).toMatch(/don't have access|limited to the owner/i);
-    expect(reply).not.toMatch(/\bdm\b/i);
-  });
+	test("role/context gating states missing access, not a surface", () => {
+		const reply = privacyDenialReplyForReasons([
+			"Action TERMINAL_SHELL is not allowed for the current role",
+		]);
+		expect(reply).toMatch(/don't have access|limited to the owner/i);
+		expect(reply).not.toMatch(/\bdm\b/i);
+	});
 
-  test("empty reasons still yields a non-empty honest decline", () => {
-    expect(privacyDenialReplyForReasons([]).length).toBeGreaterThan(0);
-  });
+	test("empty reasons still yields a non-empty honest decline", () => {
+		expect(privacyDenialReplyForReasons([]).length).toBeGreaterThan(0);
+	});
 });

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3052,7 +3052,9 @@ function getMessageHandlerCandidateActions(
  *  - not the owner (`owner_mismatch`) or role/context-gated → a permission-
  *    truthful decline with NO DM hint, because access, not surface, is missing.
  */
-export function privacyDenialReplyForReasons(reasons: readonly string[]): string {
+export function privacyDenialReplyForReasons(
+	reasons: readonly string[],
+): string {
 	const joined = reasons.join(" | ").toLowerCase();
 	const ownerOnWrongSurface =
 		/participant_mismatch|destination_not_private/.test(joined);


### PR DESCRIPTION
## Summary

- restore repository-pinned Biome formatting in the privacy-denial helper and its focused tests
- preserve the behavior merged in #20650 without production token changes
- unblock the canonical `bun run verify` gate on `develop`

Closes #20659

## Verification

- `bunx @biomejs/biome check src/services/message.ts src/services/__tests__/privacy-denial-reply.test.ts` (from `packages/core`) — passed
- `bun test src/services/__tests__/privacy-denial-reply.test.ts` — 5 passed
- `bun run typecheck` (from `packages/core`) — passed
- exact-base root `bun run verify` reproduced the two formatting errors; the diff is formatter-only

## Evidence

- Screenshots / mobile screenshots / video: N/A — formatter-only Core change with no UI surface
- Backend logs: N/A — no runtime behavior changes
- Frontend console/network logs: N/A — no frontend change
- Live-model trajectory: N/A — no agent behavior change
- Domain artifact: focused Core test output above; 5/5 passed

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [qa-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"N/A - no contribution skill used"} -->
