### PR TITLE
fix(cloud): migrate Telegram edge cutover secret

### DIFF
--- a/.github/workflows/activate-personal-shared-telegram-edge.yml
+++ b/.github/workflows/activate-personal-shared-telegram-edge.yml
@@ -137,7 +137,7 @@ jobs:
 
           disable_edge() {
             node "$GITHUB_WORKSPACE/packages/cloud/scripts/ensure-worker-secret-absent.mjs" \
-              PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED --env staging >/dev/null
+              PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED --env staging >/dev/null
           }
 
           # A secret mutation can reach Cloudflare even when the CLI response is
@@ -158,7 +158,7 @@ jobs:
             activation_cli_confirmed=false
             for attempt in 1 2 3; do
               if printf '%s' 'true' | bunx wrangler@4.100.0 secret put \
-                PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED --env staging; then
+                PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED --env staging; then
                 activation_cli_confirmed=true
                 break
               fi

--- a/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
+++ b/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
@@ -317,7 +317,9 @@ describe("Personal Shared Telegram edge", () => {
     const response = await app.fetch(
       suffixedRequest,
       {
-        PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED: "true",
+        ENVIRONMENT: "staging",
+        PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED: "false",
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED: "true",
         ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "webhook-secret",
         ELIZA_APP_WEBHOOK_GATEWAY_URL: "https://gateway.example.test",
         ELIZA_APP_WEBHOOK_PROJECT: "eliza-app",

--- a/packages/cloud/api/eliza-app/webhook/telegram/route.ts
+++ b/packages/cloud/api/eliza-app/webhook/telegram/route.ts
@@ -1,5 +1,6 @@
 // Handles webhook cloud API eliza app webhook telegram route traffic with signature or internal auth checks.
 import { Hono } from "hono";
+import { isPersonalSharedTelegramEdgeEnabled } from "@/api-app/personal-shared-telegram-edge";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { forwardToWebhookGateway, safeWebhookSuffix } from "../_forward";
 import {
@@ -20,7 +21,7 @@ const handle = async (c: Parameters<typeof handlePersonalTelegramEdge>[0]) => {
       : c.json({ success: false, error: "Unauthorized" }, 401);
   }
   return c.req.method === "POST" &&
-    c.env.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED === "true" &&
+    isPersonalSharedTelegramEdgeEnabled(c.env) &&
     suffix === ""
     ? handlePersonalTelegramEdge(c)
     : forwardToWebhookGateway(c, "telegram");

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -846,7 +846,8 @@ describe("cloud-api worker entrypoint", () => {
       }),
       {
         ENVIRONMENT: "staging",
-        PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED: "true",
+        PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED: "false",
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED: "true",
         ELIZA_APP_TELEGRAM_BOT_TOKEN: "never-return-this-bot-token",
         ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "never-return-this-webhook-secret",
       } as never,
@@ -1005,13 +1006,14 @@ describe("cloud-api worker entrypoint", () => {
     );
   });
 
-  test("keeps the Personal Shared edge fail-closed without reserving its secret binding", async () => {
+  test("keeps the legacy edge guard false and reserves the replacement name for the cutover secret", async () => {
     const config = Bun.TOML.parse(
       await Bun.file(new URL("../wrangler.toml", import.meta.url)).text(),
     ) as {
       vars?: {
         PERSONAL_DELIVERY_PROJECTION_READ_ENABLED?: string;
         PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
         ELIZA_INFERENCE_TIMING?: string;
       };
       env?: {
@@ -1019,6 +1021,7 @@ describe("cloud-api worker entrypoint", () => {
           vars?: {
             PERSONAL_DELIVERY_PROJECTION_READ_ENABLED?: string;
             PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
+            PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
             ELIZA_INFERENCE_TIMING?: string;
           };
         };
@@ -1026,6 +1029,7 @@ describe("cloud-api worker entrypoint", () => {
           vars?: {
             PERSONAL_DELIVERY_PROJECTION_READ_ENABLED?: string;
             PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
+            PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
             ELIZA_INFERENCE_TIMING?: string;
           };
         };
@@ -1048,6 +1052,16 @@ describe("cloud-api worker entrypoint", () => {
     expect(
       config.env?.production?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED,
     ).toBe("false");
+    expect(
+      config.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED,
+    ).toBeUndefined();
+    expect(
+      config.env?.staging?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED,
+    ).toBeUndefined();
+    expect(
+      config.env?.production?.vars
+        ?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED,
+    ).toBeUndefined();
     expect(config.vars?.ELIZA_INFERENCE_TIMING).toBeUndefined();
     expect(config.env?.staging?.vars?.ELIZA_INFERENCE_TIMING).toBe("info");
     expect(

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -29,6 +29,7 @@ import { shouldDecorateHttpTelemetryStatus } from "@/lib/observability/http-tele
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { serveBlobHostRequest } from "./blob-host";
+import { isPersonalSharedTelegramEdgeEnabled } from "./personal-shared-telegram-edge";
 import { serveRegistryHostRequest } from "./registry-host";
 import { isThinStewardPublicPath } from "./steward/public-paths";
 
@@ -429,7 +430,7 @@ async function dispatchInference(
 
 function healthResponse(env: AppEnv["Bindings"]): Response {
   const personalSharedTelegramEdgeEnabled =
-    env.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED === "true";
+    isPersonalSharedTelegramEdgeEnabled(env);
   const stagingSessionVersion =
     env.STAGING_SESSION_EXCHANGE_VERSION?.trim() || null;
   const stagingSessionSigningSecret =

--- a/packages/cloud/api/src/personal-shared-telegram-edge.test.ts
+++ b/packages/cloud/api/src/personal-shared-telegram-edge.test.ts
@@ -1,0 +1,39 @@
+/** Pins the dual-binding Telegram edge migration gate to exact-true, fail-closed semantics. */
+
+import { describe, expect, test } from "bun:test";
+import { isPersonalSharedTelegramEdgeEnabled } from "./personal-shared-telegram-edge";
+
+describe("Personal Shared Telegram edge gate", () => {
+  test.each([
+    [{}, false],
+    [{ PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED: "false" }, false],
+    [{ PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED: "true" }, true],
+    [
+      {
+        ENVIRONMENT: "staging",
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED: "true",
+      },
+      true,
+    ],
+    [
+      {
+        ENVIRONMENT: "staging",
+        PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED: "false",
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED: "true",
+      },
+      true,
+    ],
+    [
+      {
+        ENVIRONMENT: "production",
+        PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED: "false",
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED: "true",
+      },
+      false,
+    ],
+    [{ PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED: "1" }, false],
+    [{ PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED: " true " }, false],
+  ])("resolves %o as %s", (env, expected) => {
+    expect(isPersonalSharedTelegramEdgeEnabled(env)).toBe(expected);
+  });
+});

--- a/packages/cloud/api/src/personal-shared-telegram-edge.ts
+++ b/packages/cloud/api/src/personal-shared-telegram-edge.ts
@@ -1,0 +1,21 @@
+/** Resolves the fail-closed Personal Shared Telegram edge rollout gate across its legacy and protected cutover bindings. */
+
+export interface PersonalSharedTelegramEdgeBindings {
+  ENVIRONMENT?: string;
+  PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
+  PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
+}
+
+/**
+ * The replacement binding lets staging escape a stale plaintext name without
+ * weakening the old default/production guard. Only an exact true opts in.
+ */
+export function isPersonalSharedTelegramEdgeEnabled(
+  env: PersonalSharedTelegramEdgeBindings,
+): boolean {
+  return (
+    env.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED === "true" ||
+    (env.ENVIRONMENT === "staging" &&
+      env.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED === "true")
+  );
+}

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -188,11 +188,10 @@ new_sqlite_classes = ["PersonalTelegramDelivery"]
 NODE_ENV = "production"
 SHARED_ELIZA_AGENT_RUNTIME = "false"
 PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "false"
-# PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED is deliberately ABSENT here (and in
-# env.staging.vars): the protected cutover owns it as a per-environment secret,
-# and any [vars] spelling of the name collides with `wrangler secret put`
-# (CF error 10053 — run 31970252094 failed on exactly this top-level entry).
-# Absence is fail-closed: the Worker treats a missing binding as edge-off.
+PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED = "false"
+# PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED is deliberately absent from
+# every [vars] block. The protected staging workflow owns it as a secret, while
+# the legacy explicit-false binding stays as the default/production guard.
 NEXT_PUBLIC_APP_URL = "https://cloud.eliza.app"
 NEXT_PUBLIC_API_URL = "https://api.eliza.app"
 ELIZA_CLOUD_URL = "https://api.eliza.app"
@@ -464,9 +463,9 @@ SHARED_ELIZA_AGENT_RUNTIME = "true"
 # Staging exercises the strongly invalidated sender projection while default
 # and production stay on canonical resolution until the live latency matrix passes.
 PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "true"
-# The protected staging cutover owns PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED as
-# a secret binding. Named-environment vars do not inherit, so leaving only the
-# staging binding absent avoids a name collision while absence remains off.
+# The protected staging cutover owns PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED
+# as a secret binding. It uses a fresh name because keep_vars preserved the old
+# staging plaintext binding; either binding must be exactly true to opt in.
 # Emit per-turn inference spans at info for the staging latency matrix without
 # changing production log volume or recording prompt content.
 ELIZA_INFERENCE_TIMING = "info"

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -420,6 +420,8 @@ export interface Bindings {
   ELIZA_APP_WEBHOOK_PROJECT?: string;
   /** Moves only the official Personal Shared Telegram transport to the Worker edge. */
   PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
+  /** Collision-free secret used by the protected staging edge cutover. */
+  PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
   ELIZA_APP_TELEGRAM_BOT_TOKEN?: string;
   ELIZA_APP_TELEGRAM_WEBHOOK_SECRET?: string;
   // Dedicated shared secret stamped onto forwarded webhook calls so the internal

--- a/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
@@ -98,7 +98,7 @@ describe("Personal Shared Telegram edge deploy", () => {
     const apply = step("Apply and verify served edge state");
     expect(apply.run).toContain("wrangler@4.100.0 secret put");
     expect(apply.run).toContain(
-      "PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED --env staging",
+      "PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED --env staging",
     );
     expect(apply.run).toContain("ensure-worker-secret-absent.mjs");
     expect(apply.run).toContain("trap rollback_on_unproven_exit EXIT");
@@ -110,7 +110,7 @@ describe("Personal Shared Telegram edge deploy", () => {
     expect(apply.run).not.toContain('grep -qi "not found"');
   });
 
-  test("keeps every tracked Worker environment fail-closed without colliding with the activation secret", () => {
+  test("keeps the legacy guard false and reserves the replacement name for the activation secret", () => {
     const config = Bun.TOML.parse(
       readFileSync(
         new URL("packages/cloud/api/wrangler.toml", repoRoot),
@@ -127,5 +127,15 @@ describe("Personal Shared Telegram edge deploy", () => {
     expect(
       config.env?.production?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED,
     ).toBe("false");
+    expect(
+      config.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED,
+    ).toBeUndefined();
+    expect(
+      config.env?.staging?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED,
+    ).toBeUndefined();
+    expect(
+      config.env?.production?.vars
+        ?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED,
+    ).toBeUndefined();
   });
 });

--- a/packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts
@@ -51,12 +51,9 @@ const PUBLISHED_WORKER_SECRETS: Array<{ name: string; envs: string[] }> = [
   // cloud-cf-release.yml publish_secret / publish_toggle_secret chain
   { name: "CARTESIA_API_KEY", envs: ["staging", "production"] },
   { name: "STAGING_SESSION_EXCHANGE_ENABLED", envs: ["staging"] },
-  // activate-personal-shared-telegram-edge.yml (staging-only protected cutover).
-  // "default" is guarded too: the classic `wrangler secret put --env staging`
-  // path materializes bindings from the LOCAL config where a top-level [vars]
-  // spelling of the name still collides (CF 10053 — activation run 31970252094
-  // failed on the top-level entry after env.staging.vars was already clean).
-  { name: "PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED", envs: ["default", "staging"] },
+  // The staging cutover uses a fresh secret name because keep_vars preserved
+  // the legacy plaintext binding on the served Worker (run 31970252094).
+  { name: "PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED", envs: ["staging"] },
 ];
 
 describe("Worker secret/var collision lint (CF error 10053 class)", () => {
@@ -112,16 +109,18 @@ describe("Worker secret/var collision lint (CF error 10053 class)", () => {
     expect([...unmapped].sort()).toEqual([]);
   });
 
-  test("prophylactic: the production edge flip requires removing the production var first", () => {
-    // The staging incident repeats verbatim on the production cutover unless
-    // [env.production.vars] drops PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED before
-    // any workflow publishes it as a production secret. This assertion is the
-    // tripwire: whoever extends the activation workflow to production must
-    // delete the var in the same change (this test's mapping gains
-    // "production" then, and the collision test above enforces the removal).
+  test("keeps production fail-closed while the replacement name stays unreserved", () => {
+    // Production has no activation workflow. Its tracked legacy false remains
+    // explicit, while the replacement is absent so a future protected cutover
+    // can choose its own secret contract without another type collision.
     expect(
       vars.get("production")?.has("PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED") ??
         false,
     ).toBe(true);
+    expect(
+      vars
+        .get("production")
+        ?.has("PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED") ?? false,
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Part of #20658

## Why

Protected staging activation failed with Cloudflare 10053 because keep_vars preserved the served legacy edge flag as a plain_text binding. Wrangler secret put cannot replace a same-name plaintext binding.

## What

- preserves the legacy default and production edge guard as explicit false
- introduces a collision-free staging-only cutover secret name
- resolves the edge through one exact-true helper shared by routing and health
- refuses to honor the replacement binding outside staging
- updates protected activation and rollback to mutate only the replacement name
- pins the secret-versus-var collision contract

## Evidence

- real Hono and workflow/config suites: 66/66, 291 assertions
- Cloud API typecheck and production Wrangler dry bundle: PASS
- Cloud Shared typecheck: PASS
- exact-path Biome, actionlint, diff-check: PASS
- production dry bundle retains PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED=false and contains no replacement binding

## Live acceptance remaining

After independent review and merge: exact-current protected staging deploy, false -> true -> false -> true health proof, replacement binding type verification, Telegram/Discord matrix, and production non-mutation proof.