### PR TITLE
fix(github): bound and dedup unread-notification pagination

### DIFF
--- a/plugins/plugin-github/src/actions/notification-triage.test.ts
+++ b/plugins/plugin-github/src/actions/notification-triage.test.ts
@@ -2,6 +2,7 @@
  * Deterministic coverage for unread-notification pagination before priority
  * ranking, using a structural GitHub activity client with multiple pages.
  */
+import { logger } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import type { GitHubOctokitClient } from "../types.js";
 import { fetchAllUnreadNotifications } from "./notification-triage.js";
@@ -88,6 +89,7 @@ describe("fetchAllUnreadNotifications", () => {
   });
 
   it("stops after the page cap instead of looping on an always-full inbox", async () => {
+    const warning = vi.spyOn(logger, "warn").mockImplementation(() => {});
     const page = (start: number) =>
       Array.from({ length: 50 }, (_, index) => ({
         id: String(start + index),
@@ -106,5 +108,10 @@ describe("fetchAllUnreadNotifications", () => {
 
     expect(listNotificationsForAuthenticatedUser).toHaveBeenCalledTimes(20);
     expect(notifications).toHaveLength(1000);
+    expect(warning).toHaveBeenCalledWith(
+      { pages: 20, collected: 1000 },
+      "[GitHub:GITHUB_NOTIFICATION_TRIAGE] unread notifications truncated at page cap",
+    );
+    warning.mockRestore();
   });
 });

--- a/plugins/plugin-github/src/actions/notification-triage.test.ts
+++ b/plugins/plugin-github/src/actions/notification-triage.test.ts
@@ -58,4 +58,53 @@ describe("fetchAllUnreadNotifications", () => {
     expect(notifications).toEqual(fullPage);
     expect(listNotificationsForAuthenticatedUser).toHaveBeenCalledTimes(2);
   });
+
+  it("drops re-served rows instead of double-counting them", async () => {
+    const firstPage = Array.from({ length: 50 }, (_, index) => ({
+      id: String(index),
+      updated_at: "2026-08-16T00:00:00Z",
+    }));
+    // A shifted window (inbox mutated mid-traversal) re-serves ids 40-49
+    // from the first page alongside 10 genuinely new rows.
+    const shiftedSecondPage = [
+      ...firstPage.slice(40),
+      ...Array.from({ length: 10 }, (_, index) => ({
+        id: String(index + 50),
+        updated_at: "2026-08-16T00:00:00Z",
+      })),
+    ];
+    const listNotificationsForAuthenticatedUser = vi
+      .fn()
+      .mockResolvedValueOnce({ data: firstPage })
+      .mockResolvedValueOnce({ data: shiftedSecondPage });
+    const activity = {
+      listNotificationsForAuthenticatedUser,
+    } as GitHubOctokitClient["activity"];
+
+    const notifications = await fetchAllUnreadNotifications(activity);
+
+    expect(notifications).toHaveLength(60);
+    expect(new Set(notifications.map((n) => n.id)).size).toBe(60);
+  });
+
+  it("stops after the page cap instead of looping on an always-full inbox", async () => {
+    const page = (start: number) =>
+      Array.from({ length: 50 }, (_, index) => ({
+        id: String(start + index),
+        updated_at: "2026-08-16T00:00:00Z",
+      }));
+    const listNotificationsForAuthenticatedUser = vi
+      .fn()
+      .mockImplementation(async ({ page: pageNumber }: { page: number }) => ({
+        data: page((pageNumber - 1) * 50),
+      }));
+    const activity = {
+      listNotificationsForAuthenticatedUser,
+    } as GitHubOctokitClient["activity"];
+
+    const notifications = await fetchAllUnreadNotifications(activity);
+
+    expect(listNotificationsForAuthenticatedUser).toHaveBeenCalledTimes(20);
+    expect(notifications).toHaveLength(1000);
+  });
 });

--- a/plugins/plugin-github/src/actions/notification-triage.ts
+++ b/plugins/plugin-github/src/actions/notification-triage.ts
@@ -1,10 +1,6 @@
 /**
- * @module notification-triage
- * @description Fetches unread GitHub notifications and returns them sorted
- * by a composite priority score derived from `reason`, subject type, and
- * the notifying repo's `pushed_at` freshness.
- *
- * Read-only — no confirmation gate.
+ * Fetches unread GitHub notifications and ranks them by reason, subject type,
+ * and repository freshness. The action is read-only and needs no confirmation.
  */
 
 import type {

--- a/plugins/plugin-github/src/actions/notification-triage.ts
+++ b/plugins/plugin-github/src/actions/notification-triage.ts
@@ -56,6 +56,10 @@ const SUBJECT_TYPE_SCORES: Record<string, number> = {
 
 const NOTIFICATION_TRIAGE_LIMIT = 25;
 const NOTIFICATION_PAGE_SIZE = 50;
+// Bounds the unread-notification traversal against an inbox that never
+// returns a short page (misbehaving server, or a genuinely huge backlog):
+// 20 pages * 50/page is 1000 notifications, generous for a triage pass.
+const NOTIFICATION_MAX_PAGES = 20;
 
 export interface TriagedNotification {
   id: string;
@@ -73,15 +77,27 @@ export async function fetchAllUnreadNotifications(
   activity: GitHubOctokitClient["activity"],
 ): Promise<GitHubNotificationSummary[]> {
   const notifications: GitHubNotificationSummary[] = [];
-  for (let page = 1; ; page += 1) {
+  const seenIds = new Set<string>();
+  for (let page = 1; page <= NOTIFICATION_MAX_PAGES; page += 1) {
     const response = await activity.listNotificationsForAuthenticatedUser({
       all: false,
       per_page: NOTIFICATION_PAGE_SIZE,
       page,
     });
-    notifications.push(...response.data);
+    // Offset pagination over a mutating inbox can re-serve a row a shifted
+    // page already returned; dedup so totals and rankings aren't inflated.
+    for (const notification of response.data) {
+      if (seenIds.has(notification.id)) continue;
+      seenIds.add(notification.id);
+      notifications.push(notification);
+    }
     if (response.data.length < NOTIFICATION_PAGE_SIZE) return notifications;
   }
+  logger.warn(
+    { pages: NOTIFICATION_MAX_PAGES, collected: notifications.length },
+    "[GitHub:GITHUB_NOTIFICATION_TRIAGE] unread notifications truncated at page cap",
+  );
+  return notifications;
 }
 
 function scoreNotification(params: {


### PR DESCRIPTION
## Summary

Follow-up hardening for unread GitHub notification pagination.

- Bounds traversal at 20 pages / 1,000 rows so a full-page-only server cannot loop forever.
- Deduplicates notification IDs across shifted offset pages so totals and rankings stay accurate.
- Emits a structured warning when the page cap truncates the inbox.
- Keeps the action read-only and preserves normal short-page behavior.

## Landing review

The maintainer landing repair updates the touched source header to the repository prose contract and extends the production-helper regression to assert the structured truncation warning, not only the call count.

## Verification

Exact reviewed head: 644254c8420aadc62316735ccca7f24a28f0308f.

- plugin-github suite: 123/123 tests across 8 files.
- plugin-github typecheck: passed.
- Biome on both changed files: passed.
- Root bun run verify: 356/356 Turbo tasks; anti-larp scanned 8,393 test files with zero focused or orphaned skips.

## Evidence

<!-- evidence-head:644254c8420aadc62316735ccca7f24a28f0308f -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend pagination logic; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend pagination logic; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive frontend flow changed.
<!-- evidence-row:backend-logs -->
- [x] [20668-pr20668-verify.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20668-pr20668-verify.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic read-only pagination; no model invocation changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - production-helper tests cover deduplication, bounded calls, collected rows, and warning output.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-sonnet-5; openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Claude Code; Codex
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@556402f3ac28248ac82d43a660ae8c7ce7c87e5e:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: anthropic/claude-sonnet-5; openai/gpt-5.6-sol
Client / agent tooling: Claude Code; Codex
Attribution status: self-reported
