### PR TITLE
fix(core): stop fabricated bracket-marker leaks and route document reads to the real DOCUMENT action

### DIFF
--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -280,6 +280,33 @@ describe("action catalogue and retrieval", () => {
 		}
 	});
 
+	it("routes invented document candidate names to the DOCUMENT parent", () => {
+		const catalog = buildActionCatalog([
+			{
+				name: "DOCUMENT",
+				description: "List, search, and read stored documents.",
+				similes: ["search documents", "read document", "list documents"],
+			},
+			...actions,
+		]);
+		for (const candidateAction of [
+			"DOCUMENT_SEARCH",
+			"SEARCH_DOCUMENT",
+			"READ_DOCUMENTS",
+			"GET_DOCUMENTS",
+		]) {
+			const response = retrieveActions({
+				catalog,
+				messageText: "what documents do i have",
+				candidateActions: [candidateAction],
+			});
+			expect(response.results[0]).toMatchObject({
+				name: "DOCUMENT",
+				matchedBy: expect.arrayContaining(["exact"]),
+			});
+		}
+	});
+
 	it("drops a simile claimed by multiple parents instead of first-writer-wins (#16561)", () => {
 		// The live collision this locks: LIST_FILES was a simile on BOTH the
 		// coding-tools FILE action and the stored-media FILES action; catalog

--- a/packages/core/src/runtime/__tests__/evaluator.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator.test.ts
@@ -1318,15 +1318,14 @@ describe("fabricated marker invocations are rejected, real widgets pass", () => 
 	});
 
 	it("a fabricated [DOCUMENT_SEARCH] marker coerces to CONTINUE and does not ship (live leak)", async () => {
-		const result = await runEvaluator(
-			paramsWithTool(
-				finishWith(
-					'checking documents context. [DOCUMENT_SEARCH] {"limit":20} [/DOCUMENT_SEARCH]',
-				),
-			),
-		);
-		expect(result.decision).toBe("CONTINUE");
-		expect(result.messageToUser ?? "").not.toContain("[DOCUMENT_SEARCH]");
+		for (const answer of [
+			'checking documents context. [DOCUMENT_SEARCH] {"limit":20} [/DOCUMENT_SEARCH]',
+			'checking documents context. [ DOCUMENT_SEARCH ] {"limit":20,} [ / DOCUMENT_SEARCH ]',
+		]) {
+			const result = await runEvaluator(paramsWithTool(finishWith(answer)));
+			expect(result.decision).toBe("CONTINUE");
+			expect(result.messageToUser ?? "").not.toContain("DOCUMENT_SEARCH");
+		}
 	});
 
 	it("a real [CHECKLIST] widget block is NOT treated as an invocation", async () => {
@@ -1338,5 +1337,16 @@ describe("fabricated marker invocations are rejected, real widgets pass", () => 
 			),
 		);
 		expect(result.decision).toBe("FINISH");
+	});
+
+	it("literal bracket-tag documentation stays FINISH", async () => {
+		for (const answer of [
+			"Wrap the value in [SECTION]content[/SECTION].",
+			'Example:\n```text\n[DOCUMENT_SEARCH] {"limit":20} [/DOCUMENT_SEARCH]\n```',
+		]) {
+			const result = await runEvaluator(paramsWithTool(finishWith(answer)));
+			expect(result.decision).toBe("FINISH");
+			expect(result.messageToUser).toBe(answer);
+		}
 	});
 });

--- a/packages/core/src/runtime/__tests__/evaluator.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator.test.ts
@@ -1280,3 +1280,63 @@ describe("FINISH with a progress-promise message coerces to CONTINUE", () => {
 		expect(result.decision).toBe("FINISH");
 	});
 });
+
+describe("fabricated marker invocations are rejected, real widgets pass", () => {
+	const finishWith = (messageToUser: string) =>
+		`{"success": true, "decision": "FINISH", "thought": "done.", "messageToUser": ${JSON.stringify(messageToUser)}}`;
+	const paramsWithTool = (json: string) => ({
+		runtime: { useModel: vi.fn(async () => json) },
+		context: {
+			id: "ctx",
+			staticPrefix: {
+				characterPrompt: { content: "agent_name: Eliza", stable: true },
+			},
+			events: [
+				{
+					id: "msg",
+					type: "message" as const,
+					message: {
+						role: "user" as const,
+						content: { text: "what documents do i have" },
+					},
+				},
+			],
+		},
+		trajectory: {
+			context: { id: "ctx" },
+			steps: [
+				{
+					toolCall: { name: "DOCUMENTS", args: {} },
+					result: { success: true, text: "{}" },
+				},
+			],
+			archivedSteps: [],
+			plannedQueue: [],
+			evaluatorOutputs: [],
+		},
+		effects: { copyToClipboard: vi.fn(), messageToUser: vi.fn() },
+	});
+
+	it("a fabricated [DOCUMENT_SEARCH] marker coerces to CONTINUE and does not ship (live leak)", async () => {
+		const result = await runEvaluator(
+			paramsWithTool(
+				finishWith(
+					'checking documents context. [DOCUMENT_SEARCH] {"limit":20} [/DOCUMENT_SEARCH]',
+				),
+			),
+		);
+		expect(result.decision).toBe("CONTINUE");
+		expect(result.messageToUser ?? "").not.toContain("[DOCUMENT_SEARCH]");
+	});
+
+	it("a real [CHECKLIST] widget block is NOT treated as an invocation", async () => {
+		const result = await runEvaluator(
+			paramsWithTool(
+				finishWith(
+					'here is your list:\n[CHECKLIST]\n{"title":"x","items":[{"content":"a","status":"pending"}]}\n[/CHECKLIST]',
+				),
+			),
+		);
+		expect(result.decision).toBe("FINISH");
+	});
+});

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -344,6 +344,22 @@ const CANDIDATE_ACTION_PARENT_ALIASES: Record<string, readonly string[]> = {
 	SHOW_CONTACT: ["CONTACT", "ENTITY"],
 	CONTACTS: ["CONTACT", "ENTITY"],
 	ROLODEX: ["CONTACT", "ENTITY"],
+	// Document-read inventions resolve to the DOCUMENT umbrella. Stage-1 (and
+	// the evaluator) routinely invent DOCUMENT_SEARCH / LIST_DOCUMENTS for
+	// "what documents do i have"; without the alias the turn fell through to a
+	// raw DATABASE_QUERY guessing a `documents` table (which failed), observed
+	// live. The DOCUMENT similes are lowercase phrases that never match these
+	// UPPER_SNAKE inventions.
+	DOCUMENT_SEARCH: ["DOCUMENT"],
+	SEARCH_DOCUMENTS: ["DOCUMENT"],
+	SEARCH_DOCUMENT: ["DOCUMENT"],
+	LIST_DOCUMENTS: ["DOCUMENT"],
+	LIST_DOCUMENT: ["DOCUMENT"],
+	READ_DOCUMENT: ["DOCUMENT"],
+	READ_DOCUMENTS: ["DOCUMENT"],
+	DOCUMENTS: ["DOCUMENT"],
+	GET_DOCUMENTS: ["DOCUMENT"],
+	SHOW_DOCUMENTS: ["DOCUMENT"],
 	FIND_MESSAGES: ["MESSAGE"],
 	FIND_MESSAGE: ["MESSAGE"],
 	ARRANGE_VIEWS: ["VIEWS"],

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -1333,9 +1333,47 @@ function trailingFinishEnvelopeMessage(text: string): string | null {
 		: null;
 }
 
+/**
+ * Real emittable widget markers — a paired `[NAME]…[/NAME]` (or single-line
+ * `[NAME…]`) block with one of these names renders to a native component and
+ * must NOT be treated as a fabricated tool invocation. Everything else that
+ * looks like `[SOME_ACTION] {json} [/SOME_ACTION]` is the model inventing a
+ * marker to "call" an action in prose (observed live: a documents ask replied
+ * `checking documents context. [DOCUMENT_SEARCH] {"limit":20} [/DOCUMENT_SEARCH]`
+ * — the raw marker shipped to the user AND no search actually ran). Kept in
+ * lockstep with the widget markers `stripDashboardOnlyMarkers` /
+ * `parseInteractionBlocks` recognize. */
+const KNOWN_WIDGET_MARKER_NAMES = new Set([
+	"CHECKLIST",
+	"WORKFLOW",
+	"FORM",
+	"CONFIG",
+	"BACKGROUND",
+	"FOLLOWUPS",
+	"CHOICE",
+	"TASK",
+]);
+
+/** A fabricated marker invocation: a paired uppercase bracket tag whose name is
+ * not a known widget marker. `[DOCUMENT_SEARCH] … [/DOCUMENT_SEARCH]`, but not
+ * `[CHECKLIST] … [/CHECKLIST]`. */
+function containsFabricatedMarkerInvocation(text: string): boolean {
+	for (const match of text.matchAll(
+		/\[([A-Z][A-Z0-9_]{2,})\][\s\S]*?\[\/\1\]/g,
+	)) {
+		const name = match[1];
+		if (name && !KNOWN_WIDGET_MARKER_NAMES.has(name)) {
+			return true;
+		}
+	}
+	return false;
+}
+
 function containsInvocationDsl(text: string): boolean {
-	return /(?:^|[^A-Za-z0-9_])(?:call|invoke|use|run)\s*:\s*[A-Za-z][A-Za-z0-9_.-]*(?::[A-Za-z][A-Za-z0-9_.-]*)*\s*[({]/im.test(
-		text,
+	return (
+		/(?:^|[^A-Za-z0-9_])(?:call|invoke|use|run)\s*:\s*[A-Za-z][A-Za-z0-9_.-]*(?::[A-Za-z][A-Za-z0-9_.-]*)*\s*[({]/im.test(
+			text,
+		) || containsFabricatedMarkerInvocation(text)
 	);
 }
 

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -1355,14 +1355,24 @@ const KNOWN_WIDGET_MARKER_NAMES = new Set([
 ]);
 
 /** A fabricated marker invocation: a paired uppercase bracket tag whose name is
- * not a known widget marker. `[DOCUMENT_SEARCH] … [/DOCUMENT_SEARCH]`, but not
- * `[CHECKLIST] … [/CHECKLIST]`. */
+ * not a known widget marker and whose body is a JSON-shaped action payload.
+ * Literal bracket-tag examples and fenced code are user-visible content, not
+ * planner control flow. */
 function containsFabricatedMarkerInvocation(text: string): boolean {
-	for (const match of text.matchAll(
-		/\[([A-Z][A-Z0-9_]{2,})\][\s\S]*?\[\/\1\]/g,
+	const prose = text
+		.replace(/```[\s\S]*?```|~~~[\s\S]*?~~~/g, "")
+		.replace(/`[^`\r\n]*`/g, "");
+	for (const match of prose.matchAll(
+		/\[[ \t]*([A-Z][A-Z0-9_]{2,})[ \t]*\]([\s\S]*?)\[[ \t]*\/[ \t]*\1[ \t]*\]/g,
 	)) {
 		const name = match[1];
-		if (name && !KNOWN_WIDGET_MARKER_NAMES.has(name)) {
+		if (!name || KNOWN_WIDGET_MARKER_NAMES.has(name)) continue;
+		const body = match[2]?.trim();
+		if (!body) continue;
+		if (
+			(body.startsWith("{") && body.endsWith("}")) ||
+			(body.startsWith("[") && body.endsWith("]"))
+		) {
 			return true;
 		}
 	}


### PR DESCRIPTION
## Summary

- routes document-read aliases to the canonical DOCUMENT action without inventing a second tool or bypassing its USER/validate/requester-scope gates
- detects unknown bracketed JSON invocation payloads without treating ordinary paired uppercase tags or inline/fenced documentation as tool calls
- preserves the merged contact-routing safety correction

## Root cause and repair

The original guard classified every paired uppercase bracket tag as an invocation. Legitimate `[SECTION]...[/SECTION]` text and fenced marker examples could therefore coerce FINISH to CONTINUE and retry-loop. The repaired guard requires a JSON-shaped unknown invocation outside inline/fenced code, while retaining the malformed/spaced invocation cases from the incident.

## Validation

- evaluator + retrieval + document routing/list: 150/150
- packages/core typecheck: pass
- exact 4-file Biome: pass
- diff check: pass
- core build emitted Node/browser/edge/testing/declaration completion, but the Bun process did not terminate and was interrupted; no clean exit-code claim is made

## Evidence

<!-- evidence-head:3c5518e55a67c240bd3e9a711a46935f7b50f154 -->
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend-only deterministic routing/evaluator change with no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend-only deterministic routing/evaluator change with no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no rendered or interactive UI path changed`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no server or deployment was run; behavior is covered by deterministic evaluator/retrieval tests`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend code or browser path changed`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model, prompt, or provider behavior changed; this validates deterministic post-response protocol text`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no document data, database rows, or external systems were read or mutated`.
