### PR TITLE
fix(core): gate owner finance routing

### DIFF
--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -1776,6 +1776,7 @@ describe("money-spend questions route to the finances reader (non-possessive)", 
 	it("spend/pay/owe phrasings all route to finances", () => {
 		for (const text of [
 			"how much have i spent",
+			"how much money did i spend this month",
 			"how much do i owe",
 			"what did i spend on groceries",
 			"what did i pay for the car",
@@ -1791,6 +1792,13 @@ describe("money-spend questions route to the finances reader (non-possessive)", 
 			"i want to spend time with the kids",
 			"how should i budget my spending please give advice",
 			"how much time did i spend coding",
+			"how much did i spend time coding",
+			"what did i spend effort on",
+			"what did i pay attention to",
+			"how much do i owe you an apology",
+			"how much did we spend on the team lunch",
+			"when I say how much did I spend, what does that mean?",
+			"the phrase how much did I spend is a finance question",
 		]) {
 			expect(
 				inferDirectCurrentRequestCandidateInference([finances], text).names,

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -930,22 +930,49 @@ function detectOwnerLifeReadDomain(
 	) {
 		return null;
 	}
+	// Quoted examples and metalinguistic discussion are not requests to open the
+	// owner's finance ledger. This guard must run before the non-possessive money
+	// detector because those examples intentionally contain its whole phrase.
+	if (
+		/\b(?:when|if)\s+(?:i|we)\s+say\b/iu.test(normalized) ||
+		/\b(?:the\s+)?(?:phrase|sentence|wording|utterance|quote|quoted)\b/iu.test(
+			normalized,
+		) ||
+		/["“][^"”]*\b(?:how much|what)\b[^"”]*["”]/u.test(normalized) ||
+		/‘[^’]*\b(?:how much|what)\b[^’]*’/u.test(normalized)
+	) {
+		return BLOCKED_OWNER_LIFE_READ;
+	}
 	// Money-spend questions are finance reads even without a possessive scope:
 	// "how much did i spend this month" / "what did i spend on groceries" /
 	// "how much have i spent" / "how much do i owe" all route to the finances
 	// reader (observed live: "how much did i spend this month" mis-routed to
 	// OWNER_GOALS and returned a life summary). Anchored to money-spend phrasing
-	// — "how much (did/have/do) i (spend|spent|pay|paid|owe)" or "what did i
-	// (spend|pay) on/for" — so "spend time with the kids" never matches.
-	if (
-		/\bhow much (?:did|have|do|does) (?:i|we) (?:spend|spent|pay|paid|owe)\b/iu.test(
+	// to first-person amount/expense questions; common time, attention, and
+	// obligation idioms remain conversational instead of opening private data.
+	const moneyQuestion =
+		/\b(?:how much(?: money)?|what) (?:did|have|do) i (spend|spent|pay|paid|owe)\b/iu.exec(
 			normalized,
-		) ||
-		/\bwhat (?:did|have) (?:i|we) (?:spend|spent|pay|paid)\b(?:\s+(?:on|for)\b)?/iu.test(
-			normalized,
-		)
-	) {
-		return "finances";
+		);
+	if (moneyQuestion) {
+		const verb = moneyQuestion[1]?.toLowerCase();
+		const tail = normalized.slice(
+			(moneyQuestion.index ?? 0) + moneyQuestion[0].length,
+		);
+		const nonFinancialSpend =
+			(verb === "spend" || verb === "spent") &&
+			/^\s+(?:time|effort|energy)\b/iu.test(tail);
+		const nonFinancialPay =
+			(verb === "pay" || verb === "paid") &&
+			/^\s+(?:attention|tribute|homage|respects?|heed)\b/iu.test(tail);
+		const nonFinancialOwe =
+			verb === "owe" &&
+			/^\s+(?:(?:you|him|her|them|someone)\s+)?(?:an?\s+)?(?:apology|explanation|favor)\b/iu.test(
+				tail,
+			);
+		if (!nonFinancialSpend && !nonFinancialPay && !nonFinancialOwe) {
+			return "finances";
+		}
 	}
 	const domains = ownerLifeReadDomainsInPossessiveScopes(normalized);
 	if (domains.size === 0) return null;

--- a/plugins/plugin-finances/src/actions/finances.ts
+++ b/plugins/plugin-finances/src/actions/finances.ts
@@ -12,6 +12,7 @@
 
 import type {
   ActionResult,
+  AgentContext,
   HandlerOptions,
   IAgentRuntime,
   Memory,
@@ -234,7 +235,7 @@ export const MONEY_TAGS: readonly string[] = [
   "cost:expensive",
 ];
 
-export const MONEY_CONTEXTS: readonly string[] = [
+export const MONEY_CONTEXTS = [
   "payments",
   "finance",
   "wallet",
@@ -242,7 +243,7 @@ export const MONEY_CONTEXTS: readonly string[] = [
   "subscriptions",
   "browser",
   "automation",
-];
+] satisfies readonly AgentContext[];
 
 type PaymentsSubaction =
   | "dashboard"

--- a/plugins/plugin-personal-assistant/src/actions/owner-surfaces.ts
+++ b/plugins/plugin-personal-assistant/src/actions/owner-surfaces.ts
@@ -32,7 +32,9 @@ import {
   runLifeOperationHandler,
 } from "./life.js";
 import {
+  MONEY_CONTEXTS,
   MONEY_PARAMETERS,
+  MONEY_TAGS,
   OWNER_FINANCE_SIMILES,
   runMoneyHandler,
 } from "./money.js";
@@ -631,6 +633,13 @@ export const ownerFinancesAction: Action = {
     "Owner finances: sources, imports, spending, recurring charges, subscriptions.",
   descriptionCompressed:
     "owner finances dashboard|sources|csv|transactions|spending|recurring|subscription",
+  routingHint:
+    "owner finance records, spending, payments, and subscriptions -> OWNER_FINANCES; owner-only LifeOps",
+  tags: [...MONEY_TAGS],
+  contexts: [...MONEY_CONTEXTS],
+  roleGate: OWNER_OPERATION_ROLE_GATE,
+  suppressPostActionContinuation:
+    OWNER_OPERATION_SUPPRESS_POST_ACTION_CONTINUATION,
   parameters: [
     {
       name: "action",

--- a/plugins/plugin-personal-assistant/test/owner-user-permission-matrix.test.ts
+++ b/plugins/plugin-personal-assistant/test/owner-user-permission-matrix.test.ts
@@ -21,7 +21,10 @@ import {
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { connectorAction } from "../src/actions/connector.js";
 import { credentialsAction } from "../src/actions/credentials.js";
-import { personalAssistantAction } from "../src/actions/owner-surfaces.js";
+import {
+  ownerFinancesAction,
+  personalAssistantAction,
+} from "../src/actions/owner-surfaces.js";
 import { voiceCallAction } from "../src/actions/voice-call.js";
 import {
   createLifeOpsConnectorGrant,
@@ -37,6 +40,7 @@ import { createLifeOpsTestRuntime } from "./helpers/runtime.js";
 const OWNER_GATED_ACTIONS = [
   connectorAction,
   credentialsAction,
+  ownerFinancesAction,
   personalAssistantAction,
   voiceCallAction,
 ] as const;
@@ -52,6 +56,7 @@ const OWNER_GATED_ACTION_CASES = [
     credentialsAction,
     { action: "fill", url: "https://example.com" },
   ],
+  [ownerFinancesAction.name, ownerFinancesAction, { action: "dashboard" }],
   [
     personalAssistantAction.name,
     personalAssistantAction,


### PR DESCRIPTION
## Summary

Security and routing follow-up to merged #20655.

- adds the canonical OWNER gate, finance contexts/tags, routing metadata, and suppression to the registered OWNER_FINANCES action and promoted virtual actions
- narrows deterministic money-spend routing to singular first-person money questions
- rejects time/effort/attention/tribute, non-money obligations, quoted/meta examples, and ambiguous group language
- includes the finance action in the real AgentRuntime permission matrix

## Root cause

The registered personal-assistant finance umbrella lacked the owner-access guard required by the plugin contract. The new classifier also matched broad pay/spend/owe language, including non-financial and group phrases.

## Validation

- direct-action heuristics: 87/87, 280 assertions
- real AgentRuntime/PGlite OWNER-vs-USER permission matrix: 20/20
- packages/core typecheck: pass
- Biome exact 5 files: pass
- diff check: pass
- plugin-finances/personal-assistant aggregate typechecks were attempted in the isolated worktree; missing prebuilt workspace outputs caused unrelated module-resolution failures, with no diagnostic in the changed files

## Evidence

<!-- evidence-head:1b75ce3f81aa16148f61ae680eef2d9d98c52fbc -->
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend-only authorization and routing change with no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend-only authorization and routing change with no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no rendered or interactive UI path changed`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no server or deployment was run; the changed in-process gate is covered by deterministic and real AgentRuntime tests above`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend code or browser path changed`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no prompt, model, or provider behavior changed; this is a deterministic authorization and lexical-routing boundary`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no production finance data was read or mutated; tenant authorization is proven with an isolated real PGlite matrix`.
