### PR TITLE
fix(cloud): validate app earnings day range

### DIFF
--- a/packages/cloud/api/__tests__/app-earnings-days-validation.test.ts
+++ b/packages/cloud/api/__tests__/app-earnings-days-validation.test.ts
@@ -94,6 +94,8 @@ describe("GET /api/v1/apps/:id/earnings days validation", () => {
     ["partial", "30abc"],
     ["fractional", "1.5"],
     ["exponent form", "2e3"],
+    ["leading zero", "07"],
+    ["explicit plus", "+7"],
     ["surrounding whitespace", " 7 "],
     ["above maximum", "91"],
     ["unsafe integer", "9007199254740992"],

--- a/packages/cloud/api/__tests__/app-earnings-days-validation.test.ts
+++ b/packages/cloud/api/__tests__/app-earnings-days-validation.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Exercises the real app-earnings Hono route with mocked auth and service boundaries.
+ * It pins strict days validation before any app or earnings lookup.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const getById = mock(async () => ({
+  id: "app-1",
+  organization_id: "org-1",
+  monetization_enabled: true,
+  inference_markup_percentage: "10",
+  purchase_share_percentage: "5",
+  platform_offset_amount: "0",
+  total_creator_earnings: "100",
+  total_platform_revenue: "20",
+}));
+const getEarningsSummary = mock(async () => ({ total: 100 }));
+const getEarningsBreakdown = mock(async () => ({ thisMonth: { total: 20 } }));
+const getTransactionHistory = mock(async () => []);
+const getDailyEarningsChart = mock(async (_appId: string, days: number) => {
+  if (!Number.isSafeInteger(days) || days < 1 || days > 90) {
+    throw new RangeError("Invalid time value");
+  }
+  return [];
+});
+
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg: async () => ({
+    user: { organization_id: "org-1" },
+    apiKey: null,
+  }),
+}));
+mock.module("@/lib/auth/app-key-scope", () => ({
+  isAppKeyOutOfScope: async () => false,
+}));
+mock.module("@/lib/services/apps", () => ({
+  appsService: { getById },
+}));
+mock.module("@/lib/services/app-earnings", () => ({
+  appEarningsService: {
+    getEarningsSummary,
+    getEarningsBreakdown,
+    getTransactionHistory,
+    getDailyEarningsChart,
+  },
+}));
+mock.module("@/lib/utils/logger", () => ({
+  logger: { error: mock() },
+}));
+
+const route = (await import("../v1/apps/[id]/earnings/route")).default;
+const app = new Hono().route("/api/v1/apps/:id/earnings", route);
+
+function getEarnings(query = "") {
+  return app.request(`/api/v1/apps/app-1/earnings${query}`);
+}
+
+const earningsMocks = [
+  getEarningsSummary,
+  getEarningsBreakdown,
+  getTransactionHistory,
+  getDailyEarningsChart,
+];
+
+describe("GET /api/v1/apps/:id/earnings days validation", () => {
+  beforeEach(() => {
+    getById.mockClear();
+    for (const serviceMock of earningsMocks) serviceMock.mockClear();
+  });
+
+  test.each([
+    ["", 30],
+    ["?days=", 30],
+    ["?days=1", 1],
+    ["?days=7", 7],
+    ["?days=30", 30],
+    ["?days=90", 90],
+  ])("accepts %s and forwards %i days", async (query, expectedDays) => {
+    const response = await getEarnings(query);
+
+    expect(response.status).toBe(200);
+    expect(getById).toHaveBeenCalledTimes(1);
+    expect(getDailyEarningsChart).toHaveBeenCalledWith("app-1", expectedDays);
+  });
+
+  test.each([
+    ["malformed", "abc"],
+    ["not-a-number", "NaN"],
+    ["infinite", "Infinity"],
+    ["whitespace", "   "],
+    ["zero", "0"],
+    ["negative", "-1"],
+    ["partial", "30abc"],
+    ["fractional", "1.5"],
+    ["exponent form", "2e3"],
+    ["surrounding whitespace", " 7 "],
+    ["above maximum", "91"],
+    ["unsafe integer", "9007199254740992"],
+  ])("rejects %s days before app lookup", async (_name, days) => {
+    const response = await getEarnings(`?days=${encodeURIComponent(days)}`);
+
+    expect(response.status).toBe(400);
+    const body = (await response.json()) as {
+      success: boolean;
+      error: string;
+    };
+    expect(body).toEqual({ success: false, error: "Invalid days" });
+    expect(getById).not.toHaveBeenCalled();
+    for (const serviceMock of earningsMocks) {
+      expect(serviceMock).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/packages/cloud/api/v1/apps/[id]/earnings/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/earnings/route.ts
@@ -1,4 +1,8 @@
-// Handles v1 cloud API v1 apps id earnings route traffic with route-local auth expectations.
+/**
+ * Serves authenticated app-earnings summaries and chart data.
+ * It validates the requested chart window before any app or earnings lookup.
+ */
+import { parsePositiveInteger } from "@elizaos/shared/utils/number-parsing";
 import { Hono } from "hono";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import { isAppKeyOutOfScope } from "@/lib/auth/app-key-scope";
@@ -6,6 +10,9 @@ import { appEarningsService } from "@/lib/services/app-earnings";
 import { appsService } from "@/lib/services/apps";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
+
+const DEFAULT_DAYS = 30;
+const MAX_DAYS = 90;
 
 /**
  * GET /api/v1/apps/[id]/earnings
@@ -27,10 +34,20 @@ async function __hono_GET(
     const { user, apiKey } = await requireAuthOrApiKeyWithOrg(request);
     const { id } = await params;
 
-    const daysParam = new URL(request.url).searchParams.get("days");
-    const days = daysParam
-      ? Math.min(Math.max(parseInt(daysParam, 10), 1), 90)
-      : 30;
+    const rawDays = new URL(request.url).searchParams.get("days");
+    const parsedDays = parsePositiveInteger(rawDays);
+    if (
+      rawDays &&
+      (rawDays !== rawDays.trim() ||
+        parsedDays === undefined ||
+        parsedDays > MAX_DAYS)
+    ) {
+      return Response.json(
+        { success: false, error: "Invalid days" },
+        { status: 400 },
+      );
+    }
+    const days = parsedDays ?? DEFAULT_DAYS;
 
     const app = await appsService.getById(id);
 
@@ -75,6 +92,7 @@ async function __hono_GET(
       },
     });
   } catch (error) {
+    // error-policy:J1 route boundary translates failures into structured HTTP errors.
     logger.error("Failed to get app earnings:", error);
     return Response.json(
       {

--- a/packages/cloud/api/v1/apps/[id]/earnings/route.ts
+++ b/packages/cloud/api/v1/apps/[id]/earnings/route.ts
@@ -37,9 +37,10 @@ async function __hono_GET(
     const rawDays = new URL(request.url).searchParams.get("days");
     const parsedDays = parsePositiveInteger(rawDays);
     if (
-      rawDays &&
-      (rawDays !== rawDays.trim() ||
-        parsedDays === undefined ||
+      rawDays !== null &&
+      rawDays !== "" &&
+      (parsedDays === undefined ||
+        rawDays !== String(parsedDays) ||
         parsedDays > MAX_DAYS)
     ) {
       return Response.json(


### PR DESCRIPTION
## Summary

Fixes #20667.

Strictly validates the untrusted app-earnings days query before app or earnings-service lookup. Omitted and empty values preserve the 30-day default; canonical integers from 1 through 90 preserve existing behavior. Malformed, non-positive, fractional, non-canonical, unsafe, and out-of-range values return HTTP 400 with a structured Invalid days response.

## Review repairs

- Uses the shared parsePositiveInteger boundary helper.
- Rejects non-canonical representations such as 07, +7, exponent notation, and surrounding whitespace.
- Preserves route-boundary error translation with the required error-policy classification.
- Exercises the mounted real Hono route and asserts rejection occurs before service lookup.

## Verification

Exact reviewed head: cc4679ed2a5b8f29804c9162ae8f348804476e3c.

- Mounted route regression: 20/20 tests, 116 assertions.
- Cloud API typecheck and Worker dry-run: passed.
- Biome and diff checks: passed.
- Root bun run verify: 356/356 Turbo tasks; anti-larp scanned 8,391 files with zero focused or orphaned skips.

## Evidence

<!-- evidence-head:cc4679ed2a5b8f29804c9162ae8f348804476e3c -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend query validation; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend query validation; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive frontend flow changed.
<!-- evidence-row:backend-logs -->
- [x] [20672-pr20672-verify-current.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20672-pr20672-verify-current.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic request validation; no model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - mounted route responses and service-call boundaries are covered by tests.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6; openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Grok Build; Claude Code via CLIProxyAPI; Codex
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@386fc6afc4cef32a7296d0d8864da95f6a65c412:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

AI provider/model: xai/grok-4.6; openai/gpt-5.6-sol
Client / agent tooling: Grok Build; Claude Code via CLIProxyAPI; Codex
Attribution status: self-reported
