### PR TITLE
fix(cloud): isolate Telegram edge cutover binding

### DIFF
--- a/.github/workflows/activate-personal-shared-telegram-edge.yml
+++ b/.github/workflows/activate-personal-shared-telegram-edge.yml
@@ -137,7 +137,7 @@ jobs:
 
           disable_edge() {
             node "$GITHUB_WORKSPACE/packages/cloud/scripts/ensure-worker-secret-absent.mjs" \
-              PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED --env staging >/dev/null
+              PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED --env staging >/dev/null
           }
 
           # A secret mutation can reach Cloudflare even when the CLI response is
@@ -158,7 +158,7 @@ jobs:
             activation_cli_confirmed=false
             for attempt in 1 2 3; do
               if printf '%s' 'true' | bunx wrangler@4.100.0 secret put \
-                PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED --env staging; then
+                PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED --env staging; then
                 activation_cli_confirmed=true
                 break
               fi

--- a/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
+++ b/packages/cloud/api/__tests__/personal-telegram-edge.test.ts
@@ -317,7 +317,7 @@ describe("Personal Shared Telegram edge", () => {
     const response = await app.fetch(
       suffixedRequest,
       {
-        PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED: "true",
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED: "true",
         ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "webhook-secret",
         ELIZA_APP_WEBHOOK_GATEWAY_URL: "https://gateway.example.test",
         ELIZA_APP_WEBHOOK_PROJECT: "eliza-app",
@@ -388,7 +388,7 @@ describe("Personal Shared Telegram edge", () => {
     const response = await app.fetch(
       request,
       {
-        PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED: "false",
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED: "false",
         ELIZA_APP_WEBHOOK_GATEWAY_SECRET: "gateway-secret",
         ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "webhook-secret",
         ELIZA_APP_TELEGRAM_BOT_TOKEN: "123:test-token",

--- a/packages/cloud/api/eliza-app/webhook/telegram/route.ts
+++ b/packages/cloud/api/eliza-app/webhook/telegram/route.ts
@@ -20,7 +20,7 @@ const handle = async (c: Parameters<typeof handlePersonalTelegramEdge>[0]) => {
       : c.json({ success: false, error: "Unauthorized" }, 401);
   }
   return c.req.method === "POST" &&
-    c.env.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED === "true" &&
+    c.env.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED === "true" &&
     suffix === ""
     ? handlePersonalTelegramEdge(c)
     : forwardToWebhookGateway(c, "telegram");

--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -846,7 +846,7 @@ describe("cloud-api worker entrypoint", () => {
       }),
       {
         ENVIRONMENT: "staging",
-        PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED: "true",
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED: "true",
         ELIZA_APP_TELEGRAM_BOT_TOKEN: "never-return-this-bot-token",
         ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: "never-return-this-webhook-secret",
       } as never,
@@ -1012,6 +1012,7 @@ describe("cloud-api worker entrypoint", () => {
       vars?: {
         PERSONAL_DELIVERY_PROJECTION_READ_ENABLED?: string;
         PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
         ELIZA_INFERENCE_TIMING?: string;
       };
       env?: {
@@ -1019,6 +1020,7 @@ describe("cloud-api worker entrypoint", () => {
           vars?: {
             PERSONAL_DELIVERY_PROJECTION_READ_ENABLED?: string;
             PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
+            PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
             ELIZA_INFERENCE_TIMING?: string;
           };
         };
@@ -1026,6 +1028,7 @@ describe("cloud-api worker entrypoint", () => {
           vars?: {
             PERSONAL_DELIVERY_PROJECTION_READ_ENABLED?: string;
             PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
+            PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
             ELIZA_INFERENCE_TIMING?: string;
           };
         };
@@ -1048,6 +1051,16 @@ describe("cloud-api worker entrypoint", () => {
     expect(
       config.env?.production?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED,
     ).toBe("false");
+    expect(
+      config.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED,
+    ).toBeUndefined();
+    expect(
+      config.env?.staging?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED,
+    ).toBeUndefined();
+    expect(
+      config.env?.production?.vars
+        ?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED,
+    ).toBeUndefined();
     expect(config.vars?.ELIZA_INFERENCE_TIMING).toBeUndefined();
     expect(config.env?.staging?.vars?.ELIZA_INFERENCE_TIMING).toBe("info");
     expect(

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -429,7 +429,7 @@ async function dispatchInference(
 
 function healthResponse(env: AppEnv["Bindings"]): Response {
   const personalSharedTelegramEdgeEnabled =
-    env.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED === "true";
+    env.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED === "true";
   const stagingSessionVersion =
     env.STAGING_SESSION_EXCHANGE_VERSION?.trim() || null;
   const stagingSessionSigningSecret =

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -188,11 +188,10 @@ new_sqlite_classes = ["PersonalTelegramDelivery"]
 NODE_ENV = "production"
 SHARED_ELIZA_AGENT_RUNTIME = "false"
 PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "false"
-# PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED is deliberately ABSENT here (and in
-# env.staging.vars): the protected cutover owns it as a per-environment secret,
-# and any [vars] spelling of the name collides with `wrangler secret put`
-# (CF error 10053 — run 31970252094 failed on exactly this top-level entry).
-# Absence is fail-closed: the Worker treats a missing binding as edge-off.
+# This legacy plaintext gate remains explicitly off for the default Worker.
+# The runtime ignores it; protected activation uses the fresh, secret-only
+# PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED binding instead.
+PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED = "false"
 NEXT_PUBLIC_APP_URL = "https://cloud.eliza.app"
 NEXT_PUBLIC_API_URL = "https://api.eliza.app"
 ELIZA_CLOUD_URL = "https://api.eliza.app"
@@ -464,9 +463,9 @@ SHARED_ELIZA_AGENT_RUNTIME = "true"
 # Staging exercises the strongly invalidated sender projection while default
 # and production stay on canonical resolution until the live latency matrix passes.
 PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "true"
-# The protected staging cutover owns PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED as
-# a secret binding. Named-environment vars do not inherit, so leaving only the
-# staging binding absent avoids a name collision while absence remains off.
+# PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED may remain as a legacy plaintext
+# binding under keep_vars. The runtime ignores it and the protected cutover
+# owns the fresh, absent PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED secret.
 # Emit per-turn inference spans at info for the staging latency matrix without
 # changing production log volume or recording prompt content.
 ELIZA_INFERENCE_TIMING = "info"

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -419,7 +419,7 @@ export interface Bindings {
   GATEWAY_WEBHOOK_URL?: string;
   ELIZA_APP_WEBHOOK_PROJECT?: string;
   /** Moves only the official Personal Shared Telegram transport to the Worker edge. */
-  PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
+  PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
   ELIZA_APP_TELEGRAM_BOT_TOKEN?: string;
   ELIZA_APP_TELEGRAM_WEBHOOK_SECRET?: string;
   // Dedicated shared secret stamped onto forwarded webhook calls so the internal

--- a/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
@@ -98,7 +98,10 @@ describe("Personal Shared Telegram edge deploy", () => {
     const apply = step("Apply and verify served edge state");
     expect(apply.run).toContain("wrangler@4.100.0 secret put");
     expect(apply.run).toContain(
-      "PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED --env staging",
+      "PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED --env staging",
+    );
+    expect(apply.run).not.toContain(
+      " PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED --env staging",
     );
     expect(apply.run).toContain("ensure-worker-secret-absent.mjs");
     expect(apply.run).toContain("trap rollback_on_unproven_exit EXIT");
@@ -117,9 +120,11 @@ describe("Personal Shared Telegram edge deploy", () => {
         "utf8",
       ),
     ) as {
+      keep_vars?: boolean;
       vars?: Record<string, string>;
       env?: Record<string, { vars?: Record<string, string> }>;
     };
+    expect(config.keep_vars).toBe(true);
     expect(config.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED).toBe("false");
     expect(
       config.env?.staging?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED,
@@ -127,5 +132,15 @@ describe("Personal Shared Telegram edge deploy", () => {
     expect(
       config.env?.production?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED,
     ).toBe("false");
+    expect(
+      config.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED,
+    ).toBeUndefined();
+    expect(
+      config.env?.staging?.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED,
+    ).toBeUndefined();
+    expect(
+      config.env?.production?.vars
+        ?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED,
+    ).toBeUndefined();
   });
 });

--- a/packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts
@@ -51,12 +51,9 @@ const PUBLISHED_WORKER_SECRETS: Array<{ name: string; envs: string[] }> = [
   // cloud-cf-release.yml publish_secret / publish_toggle_secret chain
   { name: "CARTESIA_API_KEY", envs: ["staging", "production"] },
   { name: "STAGING_SESSION_EXCHANGE_ENABLED", envs: ["staging"] },
-  // activate-personal-shared-telegram-edge.yml (staging-only protected cutover).
-  // "default" is guarded too: the classic `wrangler secret put --env staging`
-  // path materializes bindings from the LOCAL config where a top-level [vars]
-  // spelling of the name still collides (CF 10053 — activation run 31970252094
-  // failed on the top-level entry after env.staging.vars was already clean).
-  { name: "PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED", envs: ["default", "staging"] },
+  // activate-personal-shared-telegram-edge.yml uses a fresh secret-only name;
+  // the legacy plaintext gate can remain off without blocking activation.
+  { name: "PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED", envs: ["staging"] },
 ];
 
 describe("Worker secret/var collision lint (CF error 10053 class)", () => {
@@ -112,16 +109,13 @@ describe("Worker secret/var collision lint (CF error 10053 class)", () => {
     expect([...unmapped].sort()).toEqual([]);
   });
 
-  test("prophylactic: the production edge flip requires removing the production var first", () => {
-    // The staging incident repeats verbatim on the production cutover unless
-    // [env.production.vars] drops PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED before
-    // any workflow publishes it as a production secret. This assertion is the
-    // tripwire: whoever extends the activation workflow to production must
-    // delete the var in the same change (this test's mapping gains
-    // "production" then, and the collision test above enforces the removal).
+  test("prophylactic: the fresh cutover binding is absent from production vars", () => {
+    // A future protected production cutover can safely reuse the fresh secret
+    // name only while no production plaintext binding reserves that name.
     expect(
-      vars.get("production")?.has("PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED") ??
-        false,
-    ).toBe(true);
+      vars
+        .get("production")
+        ?.has("PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED") ?? false,
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Post-merge repair for #20657 and the unresolved Cloudflare 10053 cutover blocker.

The protected activation workflow and runtime now use the fresh secret-only `PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED` binding. The legacy plaintext `PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED` remains explicitly false and is ignored, so top-level `keep_vars=true` cannot preserve a same-name plaintext/secret collision.

## Root cause

Omitting the old variable from staging config did not delete the already-deployed plaintext binding because Wrangler preserves omitted variables under `keep_vars=true`. A same-name `secret put` therefore still collides with that preserved binding.

## Validation

- workflow/collision contract: 8/8
- Personal Telegram edge runtime: 8/8
- targeted health-beacon gate: pass
- cloud-api typecheck: pass
- production Wrangler dry-run bundle: pass
- cloud-shared typecheck: pass
- build:core: 59 package tasks pass
- Biome exact changed files: pass
- diff check: pass

One unrelated cold-start telemetry test timed out once at its 5-second bound during a broad index run; all changed-path assertions passed and the targeted rerun passed.

## Operational boundary

No deploy, secret mutation, environment approval, or cutover was performed. Keep this draft until exact-head hosted checks pass and the protected staging workflow proves the fresh secret binding and canary path.

<!-- evidence-head:4f9b24975c17d793eb4e01d56d0128633b8bb27c -->
