### PR TITLE
fix(core): contact-lookup candidate inventions resolve to CONTACT/ENTITY instead of collapsing to PAGE_DELEGATE

### DIFF
--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -327,6 +327,25 @@ const CANDIDATE_ACTION_PARENT_ALIASES: Record<string, readonly string[]> = {
 	SEARCH_ONLINE: ["WEB_SEARCH"],
 	INTERNET_SEARCH: ["WEB_SEARCH"],
 	GOOGLE_SEARCH: ["WEB_SEARCH"],
+	// Contact/person lookups: stage-1 invents CONTACTS_LOOKUP / WHO_IS / etc for
+	// "who is X in my rolodex", which resolves to nothing — the candidate narrow
+	// then collapsed the surface to PAGE_DELEGATE (saturated-tie rank-1) and the
+	// planner invented a non-existent "CONTACTS_LOOKUP" page capability, failing
+	// the read even though CONTACT (score 1.0) and ENTITY (0.99) were retrieved
+	// (observed live). Hint both the CONTACT CRUD umbrella and the ENTITY graph.
+	CONTACTS_LOOKUP: ["CONTACT", "ENTITY"],
+	CONTACT_LOOKUP: ["CONTACT", "ENTITY"],
+	LOOKUP_CONTACT: ["CONTACT", "ENTITY"],
+	FIND_CONTACT: ["CONTACT", "ENTITY"],
+	FIND_PERSON: ["CONTACT", "ENTITY"],
+	CONTACT_INFO: ["CONTACT", "ENTITY"],
+	WHO_IS: ["CONTACT", "ENTITY"],
+	GET_CONTACT: ["CONTACT", "ENTITY"],
+	SHOW_CONTACT: ["CONTACT", "ENTITY"],
+	CONTACTS: ["CONTACT", "ENTITY"],
+	ROLODEX: ["CONTACT", "ENTITY"],
+	ADD_CONTACT: ["CONTACT", "ENTITY"],
+	CREATE_CONTACT: ["CONTACT", "ENTITY"],
 	FIND_MESSAGES: ["MESSAGE"],
 	FIND_MESSAGE: ["MESSAGE"],
 	ARRANGE_VIEWS: ["VIEWS"],


### PR DESCRIPTION
## What

"who is marco polo in my rolodex" (and other contact lookups) failed with an invented page capability instead of reading the contact. Stage-1 emits the invented candidate `CONTACTS_LOOKUP`, which resolves to no runtime action; the candidate narrow then collapses the planner surface to `PAGE_DELEGATE` (the rank-1 parent of a saturated retrieval tie) and the planner invents a non-existent `CONTACTS_LOOKUP` page capability — "the contacts lookup isn't available right now" — even though CONTACT (retrieval score 1.0) and ENTITY (0.99) were right there in the results (observed live, trajectory tier-A = `[PAGE_DELEGATE]`).

Adds the contact-lookup candidate-alias family (CONTACTS_LOOKUP / WHO_IS / FIND_CONTACT / ROLODEX / ADD_CONTACT / … → CONTACT + ENTITY) — the same F21 pattern already used for OWNER_*/web/document inventions — so an invented contact name resolves to the real CONTACT CRUD umbrella and the ENTITY graph, keeping them on the planner surface.

## Evidence

- Before: "who is marco polo in my rolodex" → PAGE_DELEGATE with capability `CONTACTS_LOOKUP` → "CONTACTS_LOOKUP is not available on the owner page" → the read fell back to a vague facts recall.
- After (live): same ask → real ENTITY reader — "marco polo. 51 facts … last interaction 2026-08-16. no linked platforms."
- action-retrieval + action-tiering suites 65/65; core typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:b38617901021edc31f135cf2d01194059d4ac8a2 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - chat-routing change; before/after transcripts + trajectory in PR body

<!-- evidence-row:after-screenshots -->
- [ ] N/A - chat-routing change; before/after transcripts + trajectory in PR body

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - live transcripts serve as walkthrough

<!-- evidence-row:backend-logs -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:llm-trajectory -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - contact read output verified via live probe

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces
