### PR TITLE
fix(core): keep public lookups out of contact routes

### DIFF
--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -1100,6 +1100,85 @@ describe("F21 alias rows: email + terminal candidates bind to real parents", () 
 		]);
 	});
 });
+
+describe("contact lookup candidate aliases", () => {
+	it.each([
+		"CONTACTS_LOOKUP",
+		"CONTACT_LOOKUP",
+		"LOOKUP_CONTACT",
+		"FIND_CONTACT",
+		"CONTACT_INFO",
+		"SHOW_CONTACT",
+		"CONTACTS",
+		"ROLODEX",
+	])("binds the contact-specific %s invention to both readers", (candidate) => {
+		expect(parentAliasesForCandidateAction(candidate)).toEqual([
+			"CONTACT",
+			"ENTITY",
+		]);
+	});
+
+	it("does not claim a generic WHO_IS invention for private contacts", () => {
+		expect(parentAliasesForCandidateAction("WHO_IS")).toEqual([]);
+
+		const catalog = buildActionCatalog([
+			{
+				name: "CONTACT",
+				description: "Read and manage private Rolodex contacts.",
+			},
+			{
+				name: "ENTITY",
+				description: "Read the owner's private entity graph.",
+			},
+			{
+				name: "WEB_SEARCH",
+				description: "Search the public web for people and facts.",
+			},
+		]);
+		const response = retrieveActions({
+			catalog,
+			messageText: "who is Ada Lovelace",
+			candidateActions: ["WHO_IS"],
+		});
+
+		expect(response.query.parentActionHints).toEqual([]);
+		expect(
+			response.results.find((result) => result.name === "CONTACT")?.matchedBy,
+		).not.toContain("exact");
+		expect(
+			response.results.find((result) => result.name === "ENTITY")?.matchedBy,
+		).not.toContain("exact");
+	});
+
+	it.each(["ADD_CONTACT", "CREATE_CONTACT", "GET_CONTACT", "FIND_PERSON"])(
+		"leaves existing CONTACT simile %s authoritative instead of adding ENTITY",
+		(candidate) => {
+			const catalog = buildActionCatalog([
+				{
+					name: "CONTACT",
+					description: "Read and manage private Rolodex contacts.",
+					similes: [candidate],
+				},
+				{
+					name: "ENTITY",
+					description: "Read the owner's private entity graph.",
+				},
+			]);
+			const response = retrieveActions({
+				catalog,
+				messageText: "",
+				candidateActions: [candidate],
+			});
+
+			expect(response.query.parentActionHints).toEqual(["CONTACT"]);
+			expect(response.results[0]).toMatchObject({ name: "CONTACT" });
+			expect(
+				response.results.find((result) => result.name === "ENTITY")?.matchedBy,
+			).not.toContain("exact");
+		},
+	);
+});
+
 describe("F21 aliases survive production retrieval topology filtering", () => {
 	it.each([
 		["EMAIL", "MESSAGE"],

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -327,25 +327,23 @@ const CANDIDATE_ACTION_PARENT_ALIASES: Record<string, readonly string[]> = {
 	SEARCH_ONLINE: ["WEB_SEARCH"],
 	INTERNET_SEARCH: ["WEB_SEARCH"],
 	GOOGLE_SEARCH: ["WEB_SEARCH"],
-	// Contact/person lookups: stage-1 invents CONTACTS_LOOKUP / WHO_IS / etc for
+	// Contact lookups: stage-1 invents CONTACTS_LOOKUP and similar names for
 	// "who is X in my rolodex", which resolves to nothing — the candidate narrow
 	// then collapsed the surface to PAGE_DELEGATE (saturated-tie rank-1) and the
 	// planner invented a non-existent "CONTACTS_LOOKUP" page capability, failing
 	// the read even though CONTACT (score 1.0) and ENTITY (0.99) were retrieved
-	// (observed live). Hint both the CONTACT CRUD umbrella and the ENTITY graph.
+	// (observed live). Hint both the CONTACT CRUD umbrella and the ENTITY graph,
+	// but only for names that unambiguously identify a contact surface. Generic
+	// inventions such as WHO_IS must remain available to public-information
+	// actions, and existing CONTACT similes already cover CRUD names.
 	CONTACTS_LOOKUP: ["CONTACT", "ENTITY"],
 	CONTACT_LOOKUP: ["CONTACT", "ENTITY"],
 	LOOKUP_CONTACT: ["CONTACT", "ENTITY"],
 	FIND_CONTACT: ["CONTACT", "ENTITY"],
-	FIND_PERSON: ["CONTACT", "ENTITY"],
 	CONTACT_INFO: ["CONTACT", "ENTITY"],
-	WHO_IS: ["CONTACT", "ENTITY"],
-	GET_CONTACT: ["CONTACT", "ENTITY"],
 	SHOW_CONTACT: ["CONTACT", "ENTITY"],
 	CONTACTS: ["CONTACT", "ENTITY"],
 	ROLODEX: ["CONTACT", "ENTITY"],
-	ADD_CONTACT: ["CONTACT", "ENTITY"],
-	CREATE_CONTACT: ["CONTACT", "ENTITY"],
 	FIND_MESSAGES: ["MESSAGE"],
 	FIND_MESSAGE: ["MESSAGE"],
 	ARRANGE_VIEWS: ["VIEWS"],


### PR DESCRIPTION
## Summary

Post-merge correction for #20676.

Retains the contact-specific lookup aliases needed by the original incident, while removing broad and redundant aliases that route public or CRUD queries into private CONTACT/ENTITY surfaces. Adds positive contact-lookup coverage and public `who is`/CRUD negatives.

## Root cause

The merged alias table mapped generic `WHO_IS` to CONTACT and ENTITY. For `who is Ada Lovelace`, both private actions scored 1.0 while WEB_SEARCH remained 0, allowing contact routes to displace the public lookup. FIND_PERSON also widened to ENTITY, and CRUD aliases already handled by CONTACT similes were unnecessarily widened to ENTITY.

## Validation

- action retrieval + tiering: 84/84, 250 assertions
- packages/core typecheck: pass
- exact 2-file Biome: pass
- diff check: pass

## Evidence

<!-- evidence-head:3814a577be989ad4b0980ba76afdf2c1fe14ca71 -->
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend-only deterministic routing table with no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend-only deterministic routing table with no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no rendered or interactive UI path changed`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no server or deployment was run; routing is covered by deterministic retrieval/tiering tests`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend code or browser path changed`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model, prompt, or provider behavior changed; this narrows deterministic post-Stage-1 aliases`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no contacts, entities, database rows, or external systems were read or mutated`.
