### PR TITLE
fix: mount Cloud management before agent query

### DIFF
--- a/packages/ui/src/cloud/app-mode/AppModeEntryRoute.test.tsx
+++ b/packages/ui/src/cloud/app-mode/AppModeEntryRoute.test.tsx
@@ -65,7 +65,7 @@ function agent(
 
 interface StubRoutes {
   /** Response for GET /api/v1/eliza/agents. */
-  agents: () => Response;
+  agents: () => Response | Promise<Response>;
   /** Response for GET <cloud>/api/v1/eliza/personal (rowless personal entry). */
   personal?: () => Response;
 }
@@ -321,6 +321,16 @@ describe("AppModeEntryRoute — chat-floor routing table", () => {
     renderEntry("/cloud/billing");
 
     expect(await screen.findByTestId("agent-app")).toBeTruthy();
+  });
+
+  it("mounts Cloud management while the app-mode agents query is still pending", () => {
+    signIn();
+    stubNetwork({
+      agents: () => new Promise<Response>(() => undefined),
+    });
+    renderEntry("/cloud/billing");
+
+    expect(screen.getByTestId("agent-app")).toBeTruthy();
   });
 });
 

--- a/packages/ui/src/cloud/app-mode/AppModeEntryRoute.tsx
+++ b/packages/ui/src/cloud/app-mode/AppModeEntryRoute.tsx
@@ -121,13 +121,20 @@ export function AppModeEntryRoute({
     return <Navigate to={`/login?returnTo=${returnTo}`} replace />;
   }
 
+  // The Cloud route registry is mounted inside appElement. Do not wait for the
+  // app-mode agents query before mounting it on a management URL: doing so
+  // deadlocks private-route registration and leaves authenticated users on
+  // "Loading your agent" when the query is slow or a stale agent credential
+  // is being repaired. Management surfaces own their loading/error states.
+  if (isCloudManagementPath) {
+    return <>{appElement}</>;
+  }
+
   if (agentsQuery.isError) {
-    // Management routes own their own unavailable/error states and remain
-    // usable for account recovery. Ordinary entry can only boot chat when a
-    // Cloud binding already identifies the runtime; otherwise /join retries
-    // selection instead of starting an unbound agent shell.
-    return isCloudManagementPath ||
-      loadPersistedActiveServer()?.kind === "cloud" ? (
+    // Ordinary entry can only boot chat when a Cloud binding already identifies
+    // the runtime; otherwise /join retries selection instead of starting an
+    // unbound agent shell.
+    return loadPersistedActiveServer()?.kind === "cloud" ? (
       appElement
     ) : (
       <Navigate to="/join" replace />


### PR DESCRIPTION
## Summary

- mount the authenticated app shell immediately for `/cloud` management routes
- break the stale-credential/query deadlock that left Cloud agent management on an infinite loading screen
- retain the existing agent-query gate for normal app-mode entry routes

Fixes #20652

## Verification

- `bun test packages/ui/src/cloud/app-mode/AppModeEntryRoute.test.tsx` (22/22)
- `bun run --cwd packages/app audit:app` (219/219 captures passed; 0 broken, 0 needs-work)
- OCR audit: 216 views; 200 verified; 0 broken
- `bun run verify` (exact head `110111a12e54dcbdccb7ecab904afd6d63faca30`)

## Contribution provenance

- AI provider/model: OpenAI / GPT-5
- Client/tooling: Codex desktop
- Contribution skill revision: `7ccf0ccb51216c55f378c5680d053f2a3f2c4297`
- Attribution: Co-authored with Codex
