### PR TITLE
fix(cloud): validate training export limits

### DIFF
--- a/packages/cloud/api/training/trajectories/export/route.test.ts
+++ b/packages/cloud/api/training/trajectories/export/route.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Exercises the real training-trajectory export Hono route with mocked auth and service boundaries.
+ * It pins strict GET and POST limit validation before any trajectory export begins.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const exportAsTrainingJSONL = mock(async () => '{"id":"trajectory-1"}\n');
+
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg: async () => ({
+    user: { organization_id: "org-1" },
+    apiKey: null,
+  }),
+}));
+mock.module("@/lib/services/llm-trajectory", () => ({
+  llmTrajectoryService: { exportAsTrainingJSONL },
+}));
+
+const route = (await import("./route")).default;
+const app = new Hono().route("/api/training/trajectories/export", route);
+
+function getExport(query = "") {
+  return app.request(`/api/training/trajectories/export${query}`);
+}
+
+function postExport(body: unknown) {
+  return app.request("/api/training/trajectories/export", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/training/trajectories/export limit validation", () => {
+  beforeEach(() => {
+    exportAsTrainingJSONL.mockClear();
+  });
+
+  test.each([
+    ["", undefined],
+    ["?limit=", undefined],
+    ["?limit=1", 1],
+    ["?limit=37", 37],
+    ["?limit=10000", 10000],
+  ])("accepts GET %s and forwards %s", async (query, expectedLimit) => {
+    const response = await getExport(query);
+
+    expect(response.status).toBe(200);
+    expect(
+      (await response.json()) as { jsonl: string; lineCount: number },
+    ).toEqual({
+      jsonl: '{"id":"trajectory-1"}\n',
+      lineCount: 1,
+    });
+    expect(exportAsTrainingJSONL).toHaveBeenCalledWith("org-1", {
+      model: undefined,
+      purpose: undefined,
+      startDate: undefined,
+      endDate: undefined,
+      limit: expectedLimit,
+    });
+  });
+
+  test.each([
+    ["whitespace", " "],
+    ["malformed", "abc"],
+    ["zero", "0"],
+    ["negative", "-1"],
+    ["partial", "12px"],
+    ["fractional", "1.5"],
+    ["exponent form", "1e2"],
+    ["leading zero", "007"],
+    ["explicit plus", "+1"],
+    ["infinite", "Infinity"],
+    ["above maximum", "10001"],
+    ["unsafe integer", "9007199254740992"],
+  ])("rejects GET %s limit before export", async (_name, limit) => {
+    const response = await getExport(`?limit=${encodeURIComponent(limit)}`);
+
+    expect(response.status).toBe(400);
+    expect((await response.json()) as { error: string }).toEqual({
+      error: "Invalid limit",
+    });
+    expect(exportAsTrainingJSONL).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    [{}, undefined],
+    [{ limit: 1 }, 1],
+    [{ limit: 37 }, 37],
+    [{ limit: 10000 }, 10000],
+  ])("accepts POST body %j and forwards %s", async (body, expectedLimit) => {
+    const response = await postExport(body);
+
+    expect(response.status).toBe(200);
+    expect(exportAsTrainingJSONL).toHaveBeenCalledWith("org-1", {
+      model: undefined,
+      purpose: undefined,
+      startDate: undefined,
+      endDate: undefined,
+      limit: expectedLimit,
+    });
+  });
+
+  test.each([
+    ["null", null],
+    ["string", "37"],
+    ["boolean", true],
+    ["zero", 0],
+    ["negative", -1],
+    ["fractional", 1.5],
+    ["above maximum", 10001],
+    ["array", [37]],
+    ["object", { value: 37 }],
+  ])("rejects POST %s limit before export", async (_name, limit) => {
+    const response = await postExport({ limit });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()) as { error: string }).toEqual({
+      error: "Invalid limit",
+    });
+    expect(exportAsTrainingJSONL).not.toHaveBeenCalled();
+  });
+
+  test("rejects a non-finite POST number before export", async () => {
+    const response = await app.request("/api/training/trajectories/export", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: '{"limit":1e999}',
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()) as { error: string }).toEqual({
+      error: "Invalid limit",
+    });
+    expect(exportAsTrainingJSONL).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/training/trajectories/export/route.test.ts
+++ b/packages/cloud/api/training/trajectories/export/route.test.ts
@@ -32,6 +32,14 @@ function postExport(body: unknown) {
   });
 }
 
+function postRawExport(body: string) {
+  return app.request("/api/training/trajectories/export", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body,
+  });
+}
+
 describe("/api/training/trajectories/export limit validation", () => {
   beforeEach(() => {
     exportAsTrainingJSONL.mockClear();
@@ -124,15 +132,28 @@ describe("/api/training/trajectories/export limit validation", () => {
   });
 
   test("rejects a non-finite POST number before export", async () => {
-    const response = await app.request("/api/training/trajectories/export", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: '{"limit":1e999}',
-    });
+    const response = await postRawExport('{"limit":1e999}');
 
     expect(response.status).toBe(400);
     expect((await response.json()) as { error: string }).toEqual({
       error: "Invalid limit",
+    });
+    expect(exportAsTrainingJSONL).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ["null", "null"],
+    ["array", "[]"],
+    ["string", '"payload"'],
+    ["number", "37"],
+    ["boolean", "true"],
+    ["malformed JSON", "{"],
+  ])("rejects a %s POST body before export", async (_name, body) => {
+    const response = await postRawExport(body);
+
+    expect(response.status).toBe(400);
+    expect((await response.json()) as { error: string }).toEqual({
+      error: "Invalid request body",
     });
     expect(exportAsTrainingJSONL).not.toHaveBeenCalled();
   });

--- a/packages/cloud/api/training/trajectories/export/route.ts
+++ b/packages/cloud/api/training/trajectories/export/route.ts
@@ -1,4 +1,7 @@
-// Handles cloud API training trajectories export route traffic with route-local auth expectations.
+/**
+ * Serves authenticated training-trajectory exports for one organization.
+ * Query and JSON-body limits are validated before the export service can read rows.
+ */
 import { Hono } from "hono";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import {
@@ -6,6 +9,38 @@ import {
   type TrajectoryExportOptions,
 } from "@/lib/services/llm-trajectory";
 import type { AppEnv } from "@/types/cloud-worker-env";
+
+const MAX_EXPORT_LIMIT = 10_000;
+
+type ExportLimitResult =
+  | { ok: true; value: number | undefined }
+  | { ok: false };
+
+function isValidExportLimit(value: number): boolean {
+  return Number.isSafeInteger(value) && value >= 1 && value <= MAX_EXPORT_LIMIT;
+}
+
+function parseQueryLimit(value: string | null): ExportLimitResult {
+  if (value === null || value === "") return { ok: true, value: undefined };
+  if (!/^[1-9]\d*$/.test(value)) return { ok: false };
+
+  const parsed = Number(value);
+  return isValidExportLimit(parsed)
+    ? { ok: true, value: parsed }
+    : { ok: false };
+}
+
+function parseBodyLimit(input: Record<string, unknown>): ExportLimitResult {
+  if (!("limit" in input)) return { ok: true, value: undefined };
+  const value = input.limit;
+  return typeof value === "number" && isValidExportLimit(value)
+    ? { ok: true, value }
+    : { ok: false };
+}
+
+function invalidLimitResponse() {
+  return Response.json({ error: "Invalid limit" }, { status: 400 });
+}
 
 function parseDate(value: string | null): Date | undefined {
   if (!value) return undefined;
@@ -15,6 +50,7 @@ function parseDate(value: string | null): Date | undefined {
 
 function resolveExportOptions(
   input: Record<string, unknown>,
+  limit: number | undefined,
 ): TrajectoryExportOptions {
   return {
     model: typeof input.model === "string" ? input.model : undefined,
@@ -25,7 +61,7 @@ function resolveExportOptions(
         : undefined,
     endDate:
       typeof input.endDate === "string" ? parseDate(input.endDate) : undefined,
-    limit: typeof input.limit === "number" ? input.limit : undefined,
+    limit,
   };
 }
 
@@ -42,21 +78,25 @@ async function __hono_GET(request: Request) {
   try {
     const { user } = await requireAuthOrApiKeyWithOrg(request);
     const { searchParams } = new URL(request.url);
-    const options = resolveExportOptions({
-      model: searchParams.get("model"),
-      purpose: searchParams.get("purpose"),
-      startDate: searchParams.get("startDate"),
-      endDate: searchParams.get("endDate"),
-      limit: searchParams.get("limit")
-        ? Number(searchParams.get("limit"))
-        : undefined,
-    });
+    const parsedLimit = parseQueryLimit(searchParams.get("limit"));
+    if (!parsedLimit.ok) return invalidLimitResponse();
+
+    const options = resolveExportOptions(
+      {
+        model: searchParams.get("model"),
+        purpose: searchParams.get("purpose"),
+        startDate: searchParams.get("startDate"),
+        endDate: searchParams.get("endDate"),
+      },
+      parsedLimit.value,
+    );
     const jsonl = await llmTrajectoryService.exportAsTrainingJSONL(
       user.organization_id,
       options,
     );
     return buildJsonlResponse(jsonl);
   } catch (error) {
+    // error-policy:J1 route boundary translates failures into structured HTTP errors.
     return Response.json(
       {
         error:
@@ -72,17 +112,18 @@ async function __hono_GET(request: Request) {
 async function __hono_POST(request: Request) {
   try {
     const { user } = await requireAuthOrApiKeyWithOrg(request);
-    const body = ((await request.json().catch(() => ({}))) ?? {}) as Record<
-      string,
-      unknown
-    >;
-    const options = resolveExportOptions(body);
+    const body = ((await request.json()) ?? {}) as Record<string, unknown>;
+    const parsedLimit = parseBodyLimit(body);
+    if (!parsedLimit.ok) return invalidLimitResponse();
+
+    const options = resolveExportOptions(body, parsedLimit.value);
     const jsonl = await llmTrajectoryService.exportAsTrainingJSONL(
       user.organization_id,
       options,
     );
     return buildJsonlResponse(jsonl);
   } catch (error) {
+    // error-policy:J1 route boundary translates failures into structured HTTP errors.
     return Response.json(
       {
         error:

--- a/packages/cloud/api/training/trajectories/export/route.ts
+++ b/packages/cloud/api/training/trajectories/export/route.ts
@@ -16,6 +16,10 @@ type ExportLimitResult =
   | { ok: true; value: number | undefined }
   | { ok: false };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 function isValidExportLimit(value: number): boolean {
   return Number.isSafeInteger(value) && value >= 1 && value <= MAX_EXPORT_LIMIT;
 }
@@ -40,6 +44,10 @@ function parseBodyLimit(input: Record<string, unknown>): ExportLimitResult {
 
 function invalidLimitResponse() {
   return Response.json({ error: "Invalid limit" }, { status: 400 });
+}
+
+function invalidRequestBodyResponse() {
+  return Response.json({ error: "Invalid request body" }, { status: 400 });
 }
 
 function parseDate(value: string | null): Date | undefined {
@@ -112,7 +120,15 @@ async function __hono_GET(request: Request) {
 async function __hono_POST(request: Request) {
   try {
     const { user } = await requireAuthOrApiKeyWithOrg(request);
-    const body = ((await request.json()) ?? {}) as Record<string, unknown>;
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      // error-policy:J3 malformed JSON is an explicit invalid request, never a default export.
+      return invalidRequestBodyResponse();
+    }
+    if (!isRecord(body)) return invalidRequestBodyResponse();
+
     const parsedLimit = parseBodyLimit(body);
     if (!parsedLimit.ok) return invalidLimitResponse();
 


### PR DESCRIPTION
# Relates to

Fixes #20681

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased conflict-free onto the latest fetched `origin/develop`.
- [x] The mounted real-Hono GET/POST regression, Cloud API build/typecheck, package lint, and exact-head proof passed with Bun 1.3.14 and Node 24.15.0.
- [ ] Root `bun run verify` was not run; the bounded package evidence and exact reason are recorded below.
- [x] A reviewer can reproduce the prior invalid-limit pass-through and verify HTTP 400 rejection before any trajectory export.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6; openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Grok Build; Claude Code via CLIProxyAPI
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@e17b59f05a25b52a71628fdb295d32a64ec25aea:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased conflict-free onto `origin/develop@7bed7e0c57de67c84f226912d8acf9e9cb0624e4`.
- [x] Final candidate head is `e8a3f2b484ffc3bf4595b7878f597bbaf28f7e74`.
- [x] A complete final read-only scan covered **32 open PRs / 179 changed-file rows** with zero overlap on either target path.
- [x] A separate scan covered **171 open issues** and matching claim comments; only linked issue #20681 claims the training-trajectory export `limit` or `exportAsTrainingJSONL` scope.
- [x] The generated route map is untouched; this changes an already-mounted GET/POST route.

# Risks

Low. The change validates one optional export limit after authentication and before the export service call. Omitted or explicitly empty GET limits and omitted POST limits preserve the existing 10,000-row default. Canonical GET integers and JSON integer values from 1 through 10,000 retain their current behavior.

# Background

## What does this PR do?

Validates the authenticated training-trajectory export limit at both HTTP entry points before `exportAsTrainingJSONL()` can issue a query.

GET now accepts only canonical base-10 integers from 1 through 10,000. POST accepts only JSON integers in the same range. Every other present value returns HTTP 400 with `{ "error": "Invalid limit" }` before the trajectory export service runs.

Before this change, GET applied `Number()` to untrusted text and then accepted every JavaScript number, including `NaN`, negatives, fractions, infinities, and arbitrarily large values. Drizzle's PostgreSQL dialect omits `LIMIT` for `NaN` and negative numbers. POST forwarded invalid numeric limits and silently converted present non-number limits into the 10,000-row default export.

## What kind of change is this?

Bug fix (untrusted HTTP query/body validation).

# Documentation changes needed?

No. This enforces the route's existing 10,000-row service boundary and does not change valid export filters or the JSONL success response.

# Testing

## Where should a reviewer start?

- `packages/cloud/api/training/trajectories/export/route.ts`
- `packages/cloud/api/training/trajectories/export/route.test.ts`

## Detailed testing steps

Pinned toolchain: Bun `1.3.14`, Node `24.15.0`.

```bash
bun test ./packages/cloud/api/training/trajectories/export/route.test.ts
bun run --cwd packages/cloud/api build
bun run --cwd packages/cloud/api lint:check
git diff --check origin/develop...HEAD
```

# Evidence Gate

<!-- evidence-head:e8a3f2b484ffc3bf4595b7878f597bbaf28f7e74 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend API query/body validation; no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend API query/body validation; no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no visual or interactive frontend flow changed.
<!-- evidence-row:backend-logs -->
- [x] Mounted real-route and package verification output is included inline.

<details>
<summary>Exact-head verification transcript</summary>

```text
Tests-first baseline before the production repair:
9 passed / 22 failed / 45 assertions
Every invalid GET and POST case returned HTTP 200 and reached the export service.

Final base: 7bed7e0c57de67c84f226912d8acf9e9cb0624e4
Exact head: e8a3f2b484ffc3bf4595b7878f597bbaf28f7e74
Focused mounted-route suite: 37 passed / 0 failed / 107 assertions
Cloud API tsc6 build: passed
Cloud API Biome lint: 1,113 files checked / no fixes
Focused Biome check: passed
git diff --check origin/develop...HEAD: clean
Exact-head proof: recorded green for e8a3f2b48 with Bun 1.3.14
```
</details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend client code or browser state changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database, memory, scheduled-task, wallet, on-chain, audio, or generated-file artifact changed.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, prompt, provider, or model behavior changed.

## Backend + frontend logs

The test mounts the actual training-trajectory export route in Hono and mocks only authentication and the trajectory export service boundary. It verifies omitted, empty, and valid 1/37/10,000 GET values; omitted and valid JSON POST values; and adversarial malformed, whitespace, zero, negative, partial, fractional, exponent, leading-zero, plus-prefixed, non-finite, unsafe, wrong-type, and above-maximum inputs. Every invalid value must return `{ "error": "Invalid limit" }` with HTTP 400 before the export service is called.

Frontend logs are not applicable because no frontend client behavior changed.

## Screenshots (before / after) + video walkthrough

N/A - backend-only query/body validation with no rendered UI surface.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio path changed.

## Known gaps / failures

- Root `bun run verify` was not run. The changed Cloud API route was instead exercised through the mounted real-route suite, package compiler, full package Biome lane, focused formatter check, and exact-head proof.
- Dependencies were installed in the worktree with `bun install --frozen-lockfile --ignore-scripts`; the final rebase did not change `bun.lock`. Required ignored keyword modules were generated before the compiler lane.
- No live production request or database query was sent because that would require operational credentials; the real mounted Hono transport path and the local Drizzle SQL-generation condition were inspected.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Claude Code via CLIProxyAPI
Contribution skill revision: elizaOS/eliza@e17b59f05a25b52a71628fdb295d32a64ec25aea:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [sol-training-export-limit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code via CLIProxyAPI","skill_revision":"elizaOS/eliza@e17b59f05a25b52a71628fdb295d32a64ec25aea:packages/skills/skills/contribute-to-eliza"} -->