### PR TITLE
fix(ui): gate Shared Cloud notification hydration

### DIFF
--- a/packages/app/test/ui-smoke/managed-login-stability.spec.ts
+++ b/packages/app/test/ui-smoke/managed-login-stability.spec.ts
@@ -3,6 +3,8 @@
  * The fixture proxies the local renderer behind the canonical app hostname so
  * production hostname gates run unchanged while all application bytes remain
  * exact-head and local; network-bound auth provider discovery is deterministic.
+ * Authenticated Shared/agentless shells also prove unsupported standalone-agent
+ * notification routes stay capability-disabled instead of painting an error.
  */
 
 import { writeFile } from "node:fs/promises";
@@ -129,6 +131,7 @@ for (const surface of SURFACES) {
     const pageErrors: string[] = [];
     const requestFailures: string[] = [];
     const consoleMessages: Array<{ type: string; text: string }> = [];
+    let notificationRequests = 0;
     let releasePersonal: (() => void) | undefined;
     const personalGate = new Promise<void>((resolve) => {
       releasePersonal = resolve;
@@ -140,6 +143,9 @@ for (const surface of SURFACES) {
     );
 
     page.on("request", (request) => {
+      if (new URL(request.url()).pathname.startsWith("/api/notifications")) {
+        notificationRequests += 1;
+      }
       if (
         request.isNavigationRequest() &&
         request.frame() === page.mainFrame()
@@ -177,6 +183,8 @@ for (const surface of SURFACES) {
     expect(documentRequests).toHaveLength(1);
     expect(personalRequests()).toBe(1);
     expect(new URL(documentRequests[0]).pathname).toBe("/join");
+    expect(notificationRequests).toBe(0);
+    await expect(page.getByText("Notifications unavailable")).toHaveCount(0);
     expect(pageErrors).toEqual([]);
     expect(requestFailures).toEqual([]);
 
@@ -196,6 +204,7 @@ for (const surface of SURFACES) {
             finalUrl: page.url(),
             documentRequests,
             personalRequests: personalRequests(),
+            notificationRequests,
             pageErrors,
             requestFailures,
             consoleMessages,

--- a/packages/ui/src/state/notifications/notification-store.test.ts
+++ b/packages/ui/src/state/notifications/notification-store.test.ts
@@ -913,6 +913,8 @@ describe("notification-store — protected hydrate gate (#16242)", () => {
       .mockReset()
       .mockResolvedValue({ notifications: [], unreadCount: 0 });
     onWsEvent.mockReset().mockReturnValue(() => {});
+    getBaseUrl.mockReset().mockReturnValue("");
+    onBaseUrlChange.mockReset().mockReturnValue(() => {});
     invokeDesktopBridgeRequest.mockReset().mockResolvedValue(null);
   });
 
@@ -924,13 +926,14 @@ describe("notification-store — protected hydrate gate (#16242)", () => {
     }
   });
 
-  it("holds GET /api/notifications on the unauthenticated Cloud origin, then hydrates after sign-in", async () => {
+  it("holds the inbox on a bare Cloud authority after sign-in, then hydrates exactly once when a Dedicated agent is selected", async () => {
     setOrigin("https://app.elizacloud.ai/");
     initNotifications();
     // WS subscriptions still wire up; only the protected hydrate is held.
     await Promise.resolve();
     expect(listNotifications).not.toHaveBeenCalled();
     expect(onWsEvent).toHaveBeenCalled();
+    expect(__getStateForTests().hydrationStatus).toBe("disabled");
 
     __setAuthStatusForTests({
       phase: "authenticated",
@@ -943,7 +946,56 @@ describe("notification-store — protected hydrate gate (#16242)", () => {
         role: "OWNER",
       },
     });
+    await Promise.resolve();
+    expect(listNotifications).not.toHaveBeenCalled();
+    expect(__getStateForTests().hydrationStatus).toBe("disabled");
+
+    const baseUrlHandler = onBaseUrlChange.mock.calls[0][0] as () => void;
+    getBaseUrl.mockReturnValue(
+      "https://api.eliza.app/api/v1/eliza/agents/11111111-1111-4111-8111-111111111111",
+    );
+    baseUrlHandler();
+    await Promise.resolve();
+    expect(listNotifications).not.toHaveBeenCalled();
+    expect(__getStateForTests().hydrationStatus).toBe("disabled");
+
+    getBaseUrl.mockReturnValue(
+      "https://11111111-1111-4111-8111-111111111111.cloud.eliza.app",
+    );
+    baseUrlHandler();
     await vi.waitFor(() => expect(listNotifications).toHaveBeenCalledTimes(1));
+    expect(__getStateForTests().hydrationStatus).toBe("ready");
+  });
+
+  it("keeps an authenticated managed Shared agent capability-disabled", async () => {
+    setOrigin("https://cloud-staging.eliza.app/");
+    getBaseUrl.mockReturnValue(
+      "https://api-staging.eliza.app/api/v1/eliza/agents/11111111-1111-4111-8111-111111111111",
+    );
+    __setAuthStatusForTests({
+      phase: "authenticated",
+      identity: { id: "u-1", displayName: "Owner", kind: "owner" },
+      session: { id: "s-1", kind: "browser", expiresAt: null },
+      access: {
+        mode: "session",
+        passwordConfigured: true,
+        ownerConfigured: true,
+        role: "OWNER",
+      },
+    });
+
+    initNotifications();
+    await Promise.resolve();
+
+    expect(listNotifications).not.toHaveBeenCalled();
+    expect(onWsEvent).toHaveBeenCalled();
+    expect(__getStateForTests()).toMatchObject({
+      notifications: [],
+      unreadCount: 0,
+      hydrated: false,
+      hydrationStatus: "disabled",
+      hydrationError: null,
+    });
   });
 
   it("hydrates on mount on a non-Cloud origin regardless of auth (unchanged)", async () => {

--- a/packages/ui/src/state/notifications/notification-store.ts
+++ b/packages/ui/src/state/notifications/notification-store.ts
@@ -40,6 +40,10 @@ import {
   subscribeAuthStatus,
 } from "../../hooks/useAuthStatus";
 import { protectedAgentProbesEnabled } from "../../hooks/useProtectedAgentProbesEnabled";
+import {
+  isElizaCloudControlPlaneAgentlessBase,
+  isManagedCloudSharedAgentBase,
+} from "../../utils/cloud-agent-base";
 
 /**
  * Notification center store.
@@ -114,13 +118,25 @@ let notificationEventUnsub: (() => void) | null = null;
 
 /**
  * Whether the inbox hydrate may hit the protected `GET /api/notifications` now.
- * Same origin-aware gate the React shell hooks use, read without a hook so the
- * store can consult it from its module-scope hydrate path.
+ * Starts with the shell's auth/origin gate, then requires an active authority
+ * that implements the standalone-agent inbox API. Read without a hook so the
+ * module-scope hydrate path can re-evaluate on auth/base changes.
  */
 function notificationProbesEnabled(): boolean {
-  return protectedAgentProbesEnabled(
-    isAuthenticatedNow(),
-    typeof window !== "undefined" ? window.location.origin : null,
+  const origin = typeof window !== "undefined" ? window.location.origin : null;
+  if (!protectedAgentProbesEnabled(isAuthenticatedNow(), origin)) return false;
+
+  // Shared Cloud agents expose the conversation REST adapter, not the full
+  // standalone-agent inbox API. A bare Cloud base has no selected agent at all.
+  // Probing either authority produces a deterministic resource_not_found and a
+  // permanent failure card after every login/refresh. Use the effective base
+  // (the client stores an empty string for same-origin) so later switches to a
+  // Dedicated/local authority re-enable hydration through reconcileAuthority.
+  const configuredBase = client.getBaseUrl().trim();
+  const effectiveBase = configuredBase || origin || "";
+  return (
+    !isElizaCloudControlPlaneAgentlessBase(effectiveBase) &&
+    !isManagedCloudSharedAgentBase(effectiveBase)
   );
 }
 
@@ -670,10 +686,23 @@ async function runHydrationAttempt(generation: number): Promise<void> {
 
 function requestHydration(): Promise<void> {
   if (!notificationProbesEnabled()) {
-    // No session yet on the shared Cloud app — skip the protected fetch (it
-    // would 401 and Chromium logs the console error). initNotifications()'s
-    // persistent auth-status subscription re-triggers this once a session
-    // lands post-sign-in via reconcileAuthority() (#16242).
+    // No session yet on the shared Cloud app, or the selected Cloud authority
+    // has no standalone-agent inbox capability. Keep this distinct from an
+    // in-flight load/error; auth/base subscriptions re-evaluate after sign-in
+    // and on every authority switch.
+    if (
+      state.hydrated ||
+      state.hydrationStatus !== "disabled" ||
+      state.hydrationAttempts !== 0 ||
+      state.hydrationError !== null
+    ) {
+      setState({
+        hydrated: false,
+        hydrationStatus: "disabled",
+        hydrationAttempts: 0,
+        hydrationError: null,
+      });
+    }
     return Promise.resolve();
   }
   if (hydrationInFlight) return hydrationInFlight;


### PR DESCRIPTION
# Relates to

Fixes #20563.

- [x] This PR targets `develop` and was rebased onto `origin/develop` at `384302387914c696ebafb6926eb449eb265eaca1` with zero conflicts. The 13 commits that landed after the frozen verification are path-disjoint from this three-file patch; `git merge-tree --write-tree origin/develop HEAD` succeeds cleanly.
- [x] `bun install` and exact-head `TURBO_FORCE=1 bun run verify` passed after sync.
- [x] The browser evidence below proves the real authenticated Shared Cloud shell behavior without requiring code inspection.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@80e777042152ab3c7961dc60f19fa4edaca5154d:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `384302387914c696ebafb6926eb449eb265eaca1`; zero conflicts.
- [x] Exact-head `bun run verify` passed. Current later develop range is path-disjoint and merge-tree-clean; the reviewed head is intentionally frozen rather than repeatedly invalidating evidence for unrelated merges.

# Risks

Low. The change suppresses notification hydration only when the effective authenticated agent base is the bare Cloud control plane or the managed Shared adapter, where `/api/notifications` is not an available capability. Dedicated Cloud, local, and self-hosted agents retain notification hydration. Authority changes re-evaluate the capability and re-enable hydration, covered by tests.

# Background

## What does this PR do?

The authenticated Shared Cloud shell was probing `/api/notifications?limit=100`, receiving a permanent 404, logging terminal hydration failures, and rendering “Notifications unavailable” after login and refresh. This gates the probe by the effective agent capability, resets the disabled state explicitly, and preserves WebSocket registration plus Dedicated/local behavior.

The recorded browser contract also pins the reload-loop concern: `/join` is the only document request, the final route is `/`, the same document marker survives, the personal resolver runs once, notification requests remain zero, and there are no page errors or failed requests on desktop or mobile.

## What kind of change is this?

Bug fix (non-breaking).

# Documentation changes needed?

No project documentation change is needed; this corrects runtime capability detection and adds regression coverage.

# Testing

## Where should a reviewer start?

Start with `packages/ui/src/state/notifications/notification-store.ts` and the exact-head observation JSON attached below. The observation is the user-facing contract: one document load, same-document survival, zero notification requests, and no unavailable banner.

## Detailed testing steps

- `bun install` — 3,824 installs checked, no changes.
- `bunx vitest run src/state/notifications/notification-store.test.ts` — 63/63 passed.
- `bun run typecheck` in `packages/ui` — passed.
- Biome on all three changed files and `git diff --check` — passed.
- `TURBO_FORCE=1 bun run verify` — 356/356 tasks, 0 cached; every follow-on repository audit passed.
- Exact-head recorded Chromium — desktop/mobile 2/2 passed at `80e777042152ab3c7961dc60f19fa4edaca5154d`.
- Full app audit on patch-equivalent UI head `50448e21b6ffcffc1bd9660eb40afc782ae3154a` — 219/219 captures; 216 findings with broken=0, needs-work=0; OCR 216 views with verified=200, broken=0. Later rebases changed unrelated base files, while exact final-head browser evidence was renewed.

# Evidence Gate

<!-- evidence-head:80e777042152ab3c7961dc60f19fa4edaca5154d -->

<!-- evidence-row:before-screenshots -->
- [x] [Live staging before screenshot after refresh](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20563-before-live-staging.png) shows the permanent unavailable state.
<!-- evidence-row:after-screenshots -->
- [x] Exact-head after screenshots: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20689-after-desktop-80e777.jpg) and [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20689-after-mobile-80e777.jpg).
<!-- evidence-row:walkthrough-video -->
- [x] Exact-head H.264 walkthroughs: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20689-walkthrough-desktop-80e777.mp4) and [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20689-walkthrough-mobile-80e777.mp4).
<!-- evidence-row:backend-logs -->
- [x] N/A - the corrected path intentionally makes no notification backend request; the frontend network artifact proves `notificationRequests: 0` while the Shared personal resolver succeeds once.
<!-- evidence-row:frontend-logs -->
- [x] Exact-head console/network observations: [desktop JSON](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20689-desktop-authenticated-observations.json) and [mobile JSON](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20689-mobile-authenticated-observations.json). Each shows one document request, one personal resolver request, zero notification requests, same-document survival, and zero page/request failures.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, scheduled-task, wallet, audio, or generated domain artifact changes.
<!-- evidence-row:ocr-review -->
- [x] [OCR triage JSON](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20689-ocr-triage-50448e-80e777-provenance.json) and [exact provenance wrapper](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20689-audit-provenance-80e777.txt) are attached.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Backend: N/A by design. Shared Cloud must not call the unavailable notification endpoint.

Frontend: exact-head observation JSON records both viewport console messages, network counts, document requests, final URL, and error arrays.

## Screenshots (before / after) + video walkthrough

### Before

[Live staging after refresh](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20563-before-live-staging.png) shows the unavailable notification state before the fix.

### After

[Desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20689-after-desktop-80e777.jpg) and [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20689-after-mobile-80e777.jpg) exact-head captures are visually clean and contain no unavailable banner.

### Walkthrough video

[Desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20689-walkthrough-desktop-80e777.mp4) and [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20689-walkthrough-mobile-80e777.mp4) are valid H.264/yuv420p MP4s. The [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20689-desktop-authenticated-observations.json) and [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20689-mobile-authenticated-observations.json) frontend observations bind the recordings to the exact reviewed head.

Full visual audit artifacts: [strict report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20689-app-audit-report-50448e-80e777-provenance.json), [OCR triage](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20689-ocr-triage-50448e-80e777-provenance.json), and [provenance/result summary](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20689-audit-provenance-80e777.txt).

## Audio / voice walkthrough

N/A - no voice/audio change.

## Known gaps / failures

- The full app audit was captured on patch-equivalent UI head `50448e21b6ffcffc1bd9660eb40afc782ae3154a`; the final rebased head has exact renewed desktop/mobile browser evidence. The intervening base changes do not touch the notification store or managed-login test.
- A raw `bun test` invocation was discarded because this suite requires the repository Vitest/jsdom harness. The correct Vitest command passed 63/63.
- No deployment occurs in this PR. After merge, staging must be deployed and the authenticated login/refresh/notification behavior rechecked live before promotion.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@80e777042152ab3c7961dc60f19fa4edaca5154d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@80e777042152ab3c7961dc60f19fa4edaca5154d:packages/skills/skills/contribute-to-eliza"} -->
