### PR TITLE
fix(core): preserve mixed action-gate rejection routing

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -480,6 +480,59 @@ describe("runV5MessageRuntimeStage1", () => {
 		expect(useModelCalls(runtime)).toHaveLength(2);
 	});
 
+	it("keeps a MIXED disclosure+role rejection set on the planner path (#20679)", async () => {
+		// A compound request whose Stage-1 candidate set rejects one action on the
+		// owner-exclusive disclosure gate AND another on a role gate must NOT get
+		// the deterministic privacy template: the privacy denial only proves a
+		// disclosure boundary, and the non-disclosure limitation must reach the
+		// planner/recovery path so the turn answers it honestly. Refines #20660,
+		// which short-circuited whenever ANY disclosure rejection existed.
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "The user asked for an owner read and a restricted action.",
+				contexts: ["general"],
+				candidateActionNames: ["OWNER_TODOS", "ADMIN_TASK"],
+				extra: { requiresTool: true },
+			}),
+			JSON.stringify({
+				thought: "Explain the role limitation for the non-private action.",
+				toolCalls: [],
+				messageToUser: "This action requires an administrator role.",
+			}),
+		]);
+		runtime.actions = [
+			{
+				...makeMemorySearchAction(),
+				name: "OWNER_TODOS",
+				disclosureGate: { require: "owner_exclusive" },
+			},
+			{
+				...makeMemorySearchAction("OWNER"),
+				name: "ADMIN_TASK",
+				contexts: ["general"],
+			},
+		];
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ channelType: ChannelType.GROUP }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000009" as UUID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"This action requires an administrator role.",
+			);
+			// The privacy template must NOT have swallowed the compound turn.
+			expect(result.result.responseContent?.text).not.toMatch(
+				/that's private|owner's private info|private information in this conversation/i,
+			);
+		}
+		expect(useModelCalls(runtime)).toHaveLength(2);
+	});
+
 	it("blocks a Stage-1 action envelope before the direct-reply route", async () => {
 		const actionEnvelope =
 			'{"action":"BROWSER","parameters":{"url":"https://example.com"},"status":"retry","toolCallId":"call-1"}';
@@ -5606,9 +5659,14 @@ describe("runV5MessageRuntimeStage1", () => {
 		});
 
 		expect(result.kind).toBe("planned_reply");
+		// The direct-route reconciliation removes the granular TRIGGER_CREATE alias
+		// in favor of the authoritative OWNER_REMINDERS action, while deliberately
+		// retaining the canonical TRIGGER umbrella alias that legitimately serves
+		// in-channel triggers (see #20660's TRIGGER-sibling carve-out).
 		expect(result.messageHandler.plan.candidateActions).toEqual([
 			"MESSAGE_SEND",
 			"OWNER_REMINDERS",
+			"TRIGGER",
 		]);
 		expect(result.messageHandler.plan.candidateActions).not.toContain(
 			"TRIGGER_CREATE",

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2769,6 +2769,13 @@ async function collectV5PlannerCandidateActions(args: {
 		 * routing hint. Same index order as
 		 * `disclosureRejectedExplicitCandidates`. */
 		disclosureRejectedReasons: string[];
+		/** Normalized names of EXPLICIT stage-1 candidates rejected by a
+		 * NON-disclosure gate (role/context/private-action). A privacy denial
+		 * only proves a disclosure boundary; when the same turn also has a
+		 * non-disclosure rejection the request is compound, so the privacy
+		 * short-circuit must stand down and let the planner/recovery path answer
+		 * the non-disclosure limitation honestly (#20679). */
+		nonDisclosureRejectedExplicitCandidates: string[];
 	};
 }): Promise<Action[]> {
 	// The candidate surface starts from every runtime action and applies only the
@@ -2823,6 +2830,10 @@ async function collectV5PlannerCandidateActions(args: {
 					);
 					args.diagnostics?.disclosureRejectedReasons.push(
 						gateRejection.reason,
+					);
+				} else {
+					args.diagnostics?.nonDisclosureRejectedExplicitCandidates.push(
+						action.name,
 					);
 				}
 				args.runtime.logger.warn(
@@ -8307,6 +8318,7 @@ export async function runV5MessageRuntimeStage1(args: {
 		const candidateGateDiagnostics = {
 			disclosureRejectedExplicitCandidates: [] as string[],
 			disclosureRejectedReasons: [] as string[],
+			nonDisclosureRejectedExplicitCandidates: [] as string[],
 		};
 		const prePatchStageOneReply =
 			typeof messageHandler.plan.reply === "string" &&
@@ -8719,9 +8731,20 @@ export async function runV5MessageRuntimeStage1(args: {
 			);
 		const ungatedTriggerSiblingAvailable =
 			rejectedReminderish && collectedCandidateNames.has("TRIGGER");
+		// The privacy denial only proves an owner-exclusive disclosure boundary.
+		// A MIXED rejection set — one candidate denied by disclosure AND another
+		// explicit candidate denied by a role/context/private-action gate — is a
+		// compound request whose non-disclosure limitation the planner/recovery
+		// path must answer honestly. Short-circuit ONLY when the rejection set is
+		// purely disclosure-based; any non-disclosure rejection stands the privacy
+		// template down (#20679, refining #20660).
+		const onlyDisclosureRejections =
+			candidateGateDiagnostics.nonDisclosureRejectedExplicitCandidates
+				.length === 0;
 		if (
 			candidateGateDiagnostics.disclosureRejectedExplicitCandidates.length >
 				0 &&
+			onlyDisclosureRejections &&
 			!anyNamedStageOneCandidateSurvived &&
 			!ungatedTriggerSiblingAvailable
 		) {


### PR DESCRIPTION
# Relates to

Closes #20679. Refines #20660 (`fix(core): distinguish disclosure gate rejections`).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after sync; the substantive `verify` gate (core `typecheck` + `lint:check` across all dependencies, plus `check:i18n` and `audit:focused-tests`) passes. See **Known gaps / failures** for the one repo-wide gate not run to completion on this constrained host.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below (failing-then-passing reproduction of the four routing cases).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e17b59f05a25b52a71628fdb295d32a64ec25aea:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [x] Core `typecheck` + `lint:check` (turbo, 59 tasks incl. all deps) pass post-sync. The full repo-wide `bun run verify` fan-out was not run to completion on this host; see **Known gaps / failures**.

# Risks

Low. The change is a single additional guard on an existing short-circuit in the Stage-1 message runtime. It only *narrows* when the deterministic privacy-reply template fires — it never widens it. Pure-disclosure behavior (the intended #20660 outcome) is unchanged; only compound (mixed) rejection sets are redirected back to the pre-existing planner/recovery path. No public type or export signature changed (an internal out-param diagnostic gained one field).

# Background

## What does this PR do?

PR #20660 added a disclosure-only short-circuit: a pure owner-exclusive **disclosure** rejection returns the deterministic privacy-reply template, while explicit role / context / private-action rejections stay on the normal planner/recovery path.

The bug: when a Stage-1 candidate set contains a **MIXED** rejection — one candidate fails the owner-exclusive disclosure gate **and** another explicit candidate fails a role/context/private-action gate — the disclosure diagnostic is non-empty and no candidate survives, so the runtime incorrectly returned the privacy template instead of retaining the planner/recovery path for the non-disclosure rejection. That mislabels compound requests and contradicts #20660's contract.

The fix, in `packages/core/src/services/message.ts`:

- `collectV5PlannerCandidateActions` now records **non-disclosure** explicit-candidate rejections in a new `nonDisclosureRejectedExplicitCandidates` diagnostic (disclosure rejections are still tracked separately, exactly as #20660 introduced them).
- `runV5MessageRuntimeStage1` short-circuits to the privacy template **only** when the rejection set is *purely* disclosure-based (`onlyDisclosureRejections`). Any non-disclosure rejection stands the template down and the turn keeps the planner/recovery path.

The four routing cases now behave as the issue requires:

| Case | Rejection set | Route |
| --- | --- | --- |
| Pure disclosure | owner-exclusive disclosure only | deterministic privacy reply (unchanged) |
| Pure role | role gate only | planner/recovery |
| Pure context | context gate only | planner/recovery |
| **Mixed** | disclosure **+** role/context/private | **planner/recovery** (was: privacy reply — the bug) |

Separately, the Stage-1 test file carried a stale reminder-reconciliation assertion: the canonical `TRIGGER` umbrella alias is deliberately retained while `TRIGGER_CREATE` is removed, but the assertion still expected only two candidates. Updated to `["MESSAGE_SEND", "OWNER_REMINDERS", "TRIGGER"]`.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation — behavior is corrected to match the already-documented #20660 contract; the routing rationale is captured in in-code comments.

# Testing

## Where should a reviewer start?

`packages/core/src/__tests__/message-runtime-stage1.test.ts` — four routing cases plus the reminder-reconciliation assertion. The core logic change is `packages/core/src/services/message.ts` (`onlyDisclosureRejections` guard + `nonDisclosureRejectedExplicitCandidates` diagnostic).

## Detailed testing steps

```bash
bun test packages/core/src/__tests__/message-runtime-stage1.test.ts \
         packages/core/src/runtime/action-gate.test.ts \
         packages/core/src/services/__tests__/privacy-denial-reply.test.ts
```

Reproduction of the bug (temporarily disabling the new guard makes the MIXED case return `direct_reply`/the privacy template):

```
523 | expect(result.kind).toBe("planned_reply");
error: expect(received).toBe(expected)
Expected: "planned_reply"
Received: "direct_reply"
(fail) runV5MessageRuntimeStage1 > keeps a MIXED disclosure+role rejection set on the planner path (#20679)
```

With the fix in place, all four cases pass:

```
(pass) runV5MessageRuntimeStage1 > short-circuits an explicit owner-private candidate denied by disclosure
(pass) runV5MessageRuntimeStage1 > keeps a role-rejected explicit candidate on the planner path
(pass) runV5MessageRuntimeStage1 > keeps a context-rejected explicit candidate on the planner path
(pass) runV5MessageRuntimeStage1 > keeps a MIXED disclosure+role rejection set on the planner path (#20679)
(pass) runV5MessageRuntimeStage1 > reconciles the owner reminder route without dropping a compound Stage-1 candidate
 143 pass
 0 fail
Ran 143 tests across 1 file.
```

# Evidence Gate

<!-- evidence-head:3b0e463f77db27f0a19cd4cb89b97c6cf97a1dc8 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - core message-runtime routing logic; no UI/rendered surface in this diff.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - core message-runtime routing logic; no UI/rendered surface in this diff.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing UI flow; the behavior is a server-side routing decision exercised by deterministic unit tests.`
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end — the failing-then-passing reproduction of the MIXED case through `runV5MessageRuntimeStage1`:
<details>
<summary>bun test output — reproduction (fix disabled → restored)</summary>

```
--- STEP 1: fix disabled (onlyDisclosureRejections guard removed) → MIXED case wrongly returns the privacy template ---
523 | expect(result.kind).toBe("planned_reply");
error: expect(received).toBe(expected)
Expected: "planned_reply"
Received: "direct_reply"
(fail) runV5MessageRuntimeStage1 > keeps a MIXED disclosure+role rejection set on the planner path (#20679)

--- STEP 2: fix restored → all four routing cases + reminder reconciliation pass ---
(pass) runV5MessageRuntimeStage1 > short-circuits an explicit owner-private candidate denied by disclosure
(pass) runV5MessageRuntimeStage1 > keeps a role-rejected explicit candidate on the planner path
(pass) runV5MessageRuntimeStage1 > keeps a context-rejected explicit candidate on the planner path
(pass) runV5MessageRuntimeStage1 > keeps a MIXED disclosure+role rejection set on the planner path (#20679)
(pass) runV5MessageRuntimeStage1 > reconciles the owner reminder route without dropping a compound Stage-1 candidate
 143 pass
 0 fail
Ran 143 tests across 1 file.
```
</details>
Mirror artifact: https://gist.github.com/agent-cortex/7d797d6ffce92ed4b09f46b34bd8e3bc
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: `N/A - no frontend surface touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - this is a deterministic routing decision (which reply strategy fires for a given gate-rejection set), not a model-behavior/prompt change; it is fully covered by deterministic model stubs in the focused tests.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `N/A - no DB rows, scheduled tasks, files, or on-chain output are produced by this routing fix.`
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - deterministic routing decision covered by model stubs; no live-model behavior change.`

## Backend + frontend logs

Backend: the focused Stage-1 suite drives `runV5MessageRuntimeStage1` through the real gate/short-circuit path. The regression proof (fix disabled → fix restored) is inline under **Testing**. Full focused run across the three touched suites:

<details>
<summary>bun test (three touched suites)</summary>

```
 159 pass
 0 fail
Ran 159 tests across 3 files.
```
</details>

Frontend: `N/A - no frontend surface touched.`

## Screenshots (before / after) + video walkthrough

### Before

`N/A - no UI change.`

### After

`N/A - no UI change.`

### Walkthrough video

`N/A - no UI change.`

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT surface touched.`

## Known gaps / failures

- The full repo-wide `bun run verify` fan-out (turbo `typecheck`+`lint:check` across **every** workspace plus the full audit chain) was not run to completion on this constrained host (a Raspberry Pi); the workspace-wide fan-out exceeds a practical time budget here. The substantive portion was run and passes: core `typecheck` + `lint:check` via turbo with all dependency builds (59 tasks successful), plus `check:i18n` (OK) and `audit:focused-tests` (clean — 0 focused/orphaned). The diff is confined to `@elizaos/core`, which is fully green (typecheck, lint, multi-target build, and the touched test suites). Not a blocker: no other workspace source changed.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@e17b59f05a25b52a71628fdb295d32a64ec25aea:packages/skills/skills/contribute-to-eliza"} -->
