### PR TITLE
chore: add Slop project authority proof

### DIFF
--- a/.github/slop-project.json
+++ b/.github/slop-project.json
@@ -1,0 +1,17 @@
+{
+  "kind": "slop-project-authority",
+  "policyRevision": "2026-08-16.1",
+  "projectId": "eliza",
+  "proposal": "https://github.com/elizaOS/slopdotcash/issues/115",
+  "repository": {
+    "fullName": "elizaOS/eliza",
+    "id": "826170402",
+    "integrationBranch": "develop"
+  },
+  "schemaVersion": "1",
+  "steward": {
+    "actorId": "186240462",
+    "login": "elizaOS",
+    "nodeId": "O_kgDOCxnNzg"
+  }
+}


### PR DESCRIPTION
Adds the machine-readable `.github/slop-project.json` authority proof binding this repository to its Slop project record, per https://github.com/elizaOS/slopdotcash/issues/115. This file asserts only GitHub-verifiable facts (repository identity, integration branch, steward GitHub identity, policy revision) — it makes no copyright, ownership, or legal claim of any kind. Merging it lets the Slop registry mark the project's repository authority as verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)