### PR TITLE
fix(browser-gates): deterministic quota locale + browser-safe apps-loading contract (#20690)

### DIFF
--- a/packages/shared/src/contracts/apps-loading-routes.test.ts
+++ b/packages/shared/src/contracts/apps-loading-routes.test.ts
@@ -17,10 +17,13 @@ describe("PostLoadFromDirectoryRequestSchema", () => {
     expect(parsed.directory).toBe("/tmp/apps");
   });
 
-  it("rejects a relative path", () => {
-    expect(() =>
-      PostLoadFromDirectoryRequestSchema.parse({ directory: "apps" }),
-    ).toThrow(/absolute path/);
+  it("accepts a relative path (absolute-path enforcement moved to the server route)", () => {
+    // The browser-safe schema no longer checks absoluteness; the
+    // app-manager route enforces it with the host's native node:path.
+    const parsed = PostLoadFromDirectoryRequestSchema.parse({
+      directory: "apps",
+    });
+    expect(parsed.directory).toBe("apps");
   });
 
   it("rejects an empty string", () => {

--- a/packages/shared/src/contracts/apps-loading-routes.ts
+++ b/packages/shared/src/contracts/apps-loading-routes.ts
@@ -6,9 +6,11 @@
  * Second migration in the typed-routes initiative — the App Permissions
  * routes were the pilot in `./app-permissions-routes.ts`. The pattern
  * (schema in shared, safeParse on server, infer types on client) is
- * the same here; the only new wrinkle is `.refine()` for the
- * absolute-path check that previously lived as a hand-rolled `if
- * (!path.isAbsolute(directory))` guard in the route handler.
+ * the same here. This barrel is browser-safe, so it carries only the
+ * required/strict shape checks; the absolute-path check is enforced at
+ * the server route boundary using the host's native path module
+ * (`path.isAbsolute`), which preserves host-native POSIX/Windows
+ * semantics without dragging a Node-only import into shared code.
  *
  * Routes covered:
  *   POST /api/apps/load-from-directory
@@ -22,23 +24,17 @@
  *     500:     filesystem failure during scan
  */
 
-import nodePath from "node:path";
 import z from "zod";
 
 /**
- * `path.isAbsolute` is platform-aware (POSIX vs Windows). Using it
- * inside `.refine()` keeps the schema honest on whichever runtime
- * the agent is on; declaring "must start with /" would silently miss
- * on Windows.
+ * Absoluteness is deliberately not validated here: `path.isAbsolute`
+ * is a Node-only, platform-aware primitive, and this barrel must stay
+ * browser-safe. The server route enforces the absolute-path contract
+ * with the host's native path implementation (`path.isAbsolute`).
  */
 export const PostLoadFromDirectoryRequestSchema = z
   .object({
-    directory: z
-      .string()
-      .min(1, "directory is required")
-      .refine((value) => nodePath.isAbsolute(value), {
-        message: "directory must be an absolute path",
-      }),
+    directory: z.string().min(1, "directory is required"),
   })
   .strict();
 

--- a/packages/ui/src/components/accounts/ConsumerKeyPanel.test.tsx
+++ b/packages/ui/src/components/accounts/ConsumerKeyPanel.test.tsx
@@ -32,7 +32,17 @@ vi.mock("../../state/app-store", () => ({
     selector: (state: {
       t: (key: string, vars?: Record<string, unknown>) => string;
     }) => unknown,
-  ) => selector({ t: (key, vars) => String(vars?.defaultValue ?? key) }),
+  ) =>
+    selector({
+      t: (key, vars) => {
+        const template = String(vars?.defaultValue ?? key);
+        return template.replace(/\{\{(\w+)\}\}/g, (_match, name: string) =>
+          name in (vars ?? {})
+            ? String((vars as Record<string, unknown>)[name])
+            : _match,
+        );
+      },
+    }),
 }));
 
 let mockRole = "OWNER";
@@ -135,6 +145,19 @@ describe("list states", () => {
     expect(screen.getByText("Enabled")).toBeTruthy();
     expect(screen.getByText("Disabled")).toBeTruthy();
     expect(screen.getByText("No quota")).toBeTruthy();
+  });
+
+  it("formats the daily token quota with deterministic en-US separators", async () => {
+    // Regression guard: the quota must render with a fixed locale so CI
+    // runners with a non-en locale cannot flip the thousands separator.
+    const api = makeApi({
+      listConsumerKeys: vi
+        .fn()
+        .mockResolvedValue([key({ dailyTokenQuota: 1_000_000 })]),
+    });
+    render(<ConsumerKeyPanelBody api={api} />);
+    await waitFor(() => expect(screen.getByText("proxy-a")).toBeTruthy());
+    expect(screen.getByText("1,000,000 tokens/day")).toBeTruthy();
   });
 });
 

--- a/packages/ui/src/components/accounts/ConsumerKeyPanel.tsx
+++ b/packages/ui/src/components/accounts/ConsumerKeyPanel.tsx
@@ -384,7 +384,7 @@ export function ConsumerKeyPanelBody({
                         })
                       : t("consumerKeys.quotaPerDay", {
                           defaultValue: "{{quota}} tokens/day",
-                          quota: entry.dailyTokenQuota.toLocaleString(),
+                          quota: entry.dailyTokenQuota.toLocaleString("en-US"),
                         })}
                   </span>
                 </div>

--- a/plugins/plugin-app-manager/src/api/apps-routes.test.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.test.ts
@@ -278,6 +278,38 @@ describe("handleAppsRoutes", () => {
     },
   );
 
+  it("rejects a relative directory on load-from-directory before touching the registry", async () => {
+    const result = await callRoute({
+      method: "POST",
+      pathname: "/api/apps/load-from-directory",
+      body: { directory: "apps/relative" },
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.res.status).toBe(400);
+    expect(result.res.body).toEqual({
+      error: "directory must be an absolute path",
+    });
+  });
+
+  it("accepts an absolute directory and advances past the absolute-path guard", async () => {
+    // With runtime null there is no AppRegistryService, so an absolute
+    // path clears the native path.isAbsolute guard and reaches the
+    // registry lookup, which fails closed with 503 (not the 400 guard).
+    const absolute = path.join(os.tmpdir(), "app-manager-load-abs");
+    const result = await callRoute({
+      method: "POST",
+      pathname: "/api/apps/load-from-directory",
+      body: { directory: absolute },
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.res.status).toBe(503);
+    expect(result.res.body).toEqual({
+      error: "AppRegistryService is not registered on the runtime",
+    });
+  });
+
   it("reuses the app hero registry lookup across adjacent image requests", async () => {
     const packageDir = await mkdtemp(
       path.join(os.tmpdir(), "app-manager-hero-"),

--- a/plugins/plugin-app-manager/src/api/apps-routes.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.ts
@@ -1560,8 +1560,11 @@ export async function handleAppsRoutes(
   if (method === "POST" && pathname === "/api/apps/load-from-directory") {
     // Body validation goes through PostLoadFromDirectoryRequestSchema
     // (zod, see @elizaos/shared/contracts/apps-loading-routes.ts).
-    // The schema handles the required check, the absolute-path check,
-    // and rejects extra unknown fields via .strict().
+    // The schema handles the required/non-empty check and rejects extra
+    // unknown fields via .strict(). Absoluteness is enforced here at the
+    // route boundary with the host's native node:path.isAbsolute so the
+    // shared contract stays browser-safe and POSIX/Windows semantics are
+    // host-native.
     const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
     if (rawBody === null) return true;
     const parsed = PostLoadFromDirectoryRequestSchema.safeParse(rawBody);
@@ -1572,6 +1575,10 @@ export async function handleAppsRoutes(
       return true;
     }
     const directory = parsed.data.directory;
+    if (!path.isAbsolute(directory)) {
+      error(res, "directory must be an absolute path", 400);
+      return true;
+    }
 
     const runtimeWithServices = runtime as {
       getService?: (type: string) => {


### PR DESCRIPTION
# Relates to

Closes #20690

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and focused package gates were run after sync; the one
      unrelated blocker (full `bun run verify` needs a complete workspace build
      chain not reproducible on this Raspberry Pi host) is recorded under
      **Known gaps / failures** with the exact reason.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below (determinism gate flips fail->pass; focused tests).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@556402f3ac28248ac82d43a660ae8c7ce7c87e5e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] Full `bun run verify` post-sync - see **Known gaps / failures** (host build
      chain limit); the owning packages' focused test + typecheck + lint gates
      and the UI determinism gate all pass.

# Risks

Low. The change removes a `node:path` import from a browser-safe contract and
moves the absolute-path check to the server route boundary (behavior-preserving:
the same 400 with the same message is still returned), and pins one UI number
format to an explicit `en-US` locale. No public type, route shape, or response
body changed. The `PostLoadFromDirectoryRequestSchema` request/response types
are unchanged.

# Background

## What does this PR do?

Restores two deterministic "browser gates" that regressed on current `develop`:

1. **Locale-stable consumer quota rendering.** `ConsumerKeyPanel` rendered the
   daily-token quota with a locale-defaulted `toLocaleString()`, so the thousands
   separator depended on the CI runner's locale. It now uses the repo convention
   `toLocaleString("en-US")` (matching `chart.tsx`, `StatusBar.tsx`,
   `calendar.tsx`). The `audit:ui-determinism` gate flagged the bare call and now
   passes.

2. **Browser-safe apps-loading contract.** `packages/shared/src/contracts/apps-loading-routes.ts`
   imported `node:path` and used `path.isAbsolute` inside a Zod `.refine()`. A
   Node-only import must not live in the browser-safe `@elizaos/shared` barrel.
   The `.refine()` is removed; the schema keeps only the browser-safe
   required/strict checks. The absolute-path contract is now enforced at the
   `@elizaos/plugin-app-manager` route boundary using the host's native
   `path.isAbsolute`, preserving host-native POSIX/Windows semantics.

**Before / after (quota):** `entry.dailyTokenQuota.toLocaleString()` ->
`entry.dailyTokenQuota.toLocaleString("en-US")`.

**Before / after (contract):** `import nodePath from "node:path"` +
`.refine(nodePath.isAbsolute, ...)` removed from shared; the app-manager route
adds `if (!path.isAbsolute(directory)) { error(res, "directory must be an
absolute path", 400); return true; }` after the schema `safeParse`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The doc comments
in the two touched source files were updated to describe the new boundary.

# Testing

## Where should a reviewer start?

- `packages/shared/src/contracts/apps-loading-routes.test.ts` - the schema now
  accepts a relative path (absoluteness moved to the route).
- `plugins/plugin-app-manager/src/api/apps-routes.test.ts` - the route returns
  400 for a relative directory and advances past the guard for an absolute one.
- `packages/ui/src/components/accounts/ConsumerKeyPanel.test.tsx` - a
  1,000,000 quota renders as `1,000,000 tokens/day` deterministically.

## Detailed testing steps

Automated tests plus the determinism gate. Commands and output below.

```
$ bun run --cwd packages/shared test -- apps-loading-routes
 Test Files  1 passed (1)
      Tests  12 passed (12)

$ bun run --cwd plugins/plugin-app-manager test -- apps-routes
 Test Files  1 passed (1)
      Tests  13 passed (13)

$ bun run --cwd packages/ui test -- ConsumerKeyPanel
 Test Files  1 passed (1)
      Tests  14 passed (14)
```

Typecheck + lint (each touched package):

```
$ bun run --cwd packages/shared typecheck        # clean
$ bun run --cwd packages/ui typecheck            # clean (tsc --noEmit)
$ bun run --cwd plugins/plugin-app-manager typecheck  # clean (tsc --noEmit)

$ bun run --cwd packages/shared lint             # Checked 396 files. No fixes applied.
$ bun run --cwd packages/ui lint                 # Checked 3027 files. Fixed 1 file (format-only, my test).
$ bun run --cwd plugins/plugin-app-manager lint  # Checked 17 files. No fixes applied.
```

`node:` import removed from the shared contract:

```
$ grep -n "node:" packages/shared/src/contracts/apps-loading-routes.ts
(no output)
```

# Evidence Gate

<!-- evidence-head:3c33fc411326ea2947e9e11365a4c7f2e4e42b50 -->

> Artifact hosting note: this PR comes from a fork. Headless fork contributors
> cannot upload to the upstream `elizaOS/eliza` `pr-evidence` release (push
> access required) nor mint `github.com/user-attachments/...` URLs (web-UI only,
> per #17600). The real artifacts below are therefore hosted on the fork's
> release and render inline here for human review; the automated evidence gate
> may still flag the host. Every artifact is a genuine capture of the changed
> component/route/gate — see the before/after separator flip under a `de-DE`
> locale.

<!-- evidence-row:before-screenshots -->
- [x] Before (bare `toLocaleString()`, browser locale `de-DE`) — quota renders `1.000.000 tokens/day` (locale-dependent, the bug): ![before-screenshots](https://github.com/agent-cortex/eliza/releases/download/pr-evidence-20690/before-desktop.jpg) mobile: https://github.com/agent-cortex/eliza/releases/download/pr-evidence-20690/before-mobile.jpg
<!-- evidence-row:after-screenshots -->
- [x] After (`toLocaleString("en-US")`, browser locale `de-DE`) — quota renders `1,000,000 tokens/day` (locale-stable): ![after-screenshots](https://github.com/agent-cortex/eliza/releases/download/pr-evidence-20690/after-desktop.jpg) mobile: https://github.com/agent-cortex/eliza/releases/download/pr-evidence-20690/after-mobile.jpg
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/agent-cortex/eliza/releases/download/pr-evidence-20690/ConsumerKeyPanel-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [x] app-manager route boundary test (relative -> 400, absolute -> past guard): [backend-logs.txt](https://github.com/agent-cortex/eliza/releases/download/pr-evidence-20690/backend-logs.txt)
<!-- evidence-row:frontend-logs -->
- [x] ConsumerKeyPanel render test + headless Chromium token readout: [frontend-logs.txt](https://github.com/agent-cortex/eliza/releases/download/pr-evidence-20690/frontend-logs.txt)
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent, action, provider, prompt, or model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] audit:ui-determinism gate before/after (fail->pass): [domain-artifacts.txt](https://github.com/agent-cortex/eliza/releases/download/pr-evidence-20690/domain-artifacts.txt)
<!-- evidence-row:ocr-review -->
- [x] tesseract OCR text readout of the rendered panel (before `1.000.000` vs after `1,000,000`): [ocr-readout.txt](https://github.com/agent-cortex/eliza/releases/download/pr-evidence-20690/ocr-readout.txt)

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change in this PR.`

## Backend + frontend logs

**Backend - app-manager route boundary (`plugins/plugin-app-manager/src/api/apps-routes.test.ts`):**

<details><summary>route test output (logs)</summary>

```
$ bun run --cwd plugins/plugin-app-manager test -- apps-routes --reporter=verbose
 ✓ handleAppsRoutes > rejects a relative directory on load-from-directory before touching the registry 2ms
 ✓ handleAppsRoutes > accepts an absolute directory and advances past the absolute-path guard 1ms
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

Full file: https://github.com/agent-cortex/eliza/releases/download/pr-evidence-20690/backend-logs.txt
</details>

**Frontend - component render (`packages/ui/src/components/accounts/ConsumerKeyPanel.test.tsx`):**

<details><summary>component test + headless render (logs)</summary>

```
$ bun run --cwd packages/ui test -- ConsumerKeyPanel --reporter=verbose
 ✓ list states > formats the daily token quota with deterministic en-US separators 25ms
 Test Files  1 passed (1)
      Tests  14 passed (14)

# Real ConsumerKeyPanelBody rendered in headless Chromium (locale=de-DE):
[before/bare toLocaleString] tokens: 1.000.000 tokens/day, 2.500.000 tokens/day
[after /toLocaleString(en-US)] tokens: 1,000,000 tokens/day, 2,500,000 tokens/day
```

Full file: https://github.com/agent-cortex/eliza/releases/download/pr-evidence-20690/frontend-logs.txt
</details>

## Screenshots (before / after) + video walkthrough

Real captures of the actual `ConsumerKeyPanelBody` component rendered in headless
Chromium with the browser locale forced to `de-DE`, so the locale-dependent bug
is visible:

### Before (bare `toLocaleString()`)

![before](https://github.com/agent-cortex/eliza/releases/download/pr-evidence-20690/before-desktop.jpg)

Shows `1.000.000 tokens/day` / `2.500.000 tokens/day` (German separators).

### After (`toLocaleString("en-US")` — this PR)

![after](https://github.com/agent-cortex/eliza/releases/download/pr-evidence-20690/after-desktop.jpg)

Shows `1,000,000 tokens/day` / `2,500,000 tokens/day` (locale-stable), even under
`de-DE`. Mobile: https://github.com/agent-cortex/eliza/releases/download/pr-evidence-20690/before-mobile.jpg and https://github.com/agent-cortex/eliza/releases/download/pr-evidence-20690/after-mobile.jpg

### Walkthrough video

https://github.com/agent-cortex/eliza/releases/download/pr-evidence-20690/ConsumerKeyPanel-walkthrough.mp4

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change.`

## Domain artifacts - audit:ui-determinism gate (before -> after)

This is the gate the issue's acceptance criteria calls out. It parses the UI AST
and fails on render-time locale-defaulted `toLocale*` calls.

**Before (bare `toLocaleString()` - reproduces the regression):**

```
$ bun run audit:ui-determinism
FAIL audit-ui-determinism - 1 NEW render-time nondeterminism occurrence(s):
  packages/ui/src/components/accounts/ConsumerKeyPanel.tsx
      L387 toLocaleString() [no locale]
error: script "audit:ui-determinism" exited with code 1
```

**After (this PR - `toLocaleString("en-US")`):**

```
$ bun run audit:ui-determinism
audit-ui-determinism: render-time=36 deferred=285 module=209 (baseline 29 files)
OK audit-ui-determinism PASSED (no new render-time nondeterminism)
```

Full file: https://github.com/agent-cortex/eliza/releases/download/pr-evidence-20690/domain-artifacts.txt

## Known gaps / failures

- **Full `bun run verify`:** not run to completion on this Raspberry Pi host - it
  drives a full-workspace Turbo build/typecheck/lint/audit chain that is not
  reproducible end-to-end here within resource limits. Mitigation: every touched
  package's `test`, `typecheck`, and `lint` gates pass individually (output
  above), the `audit:ui-determinism` gate passes, and `@elizaos/core` +
  `@elizaos/cloud-routing` + `@elizaos/logger` were built so the shared typecheck
  resolves cross-package types cleanly. Not a blocker for this scoped change.
- **Evidence hosting:** artifacts are hosted on the fork release
  (`agent-cortex/eliza` tag `pr-evidence-20690`) rather than the upstream
  `pr-evidence` release, because a headless fork contributor has neither push
  access to the upstream release nor the ability to mint web-only
  `github.com/user-attachments` URLs (#17600). They render inline above for human
  review; the automated evidence gate may report the host as untrusted for that
  reason alone. Every artifact is a real capture (before/after separator flip,
  route test, determinism gate, tesseract OCR).
- **Out of scope (intentional):** the row timestamp (`ConsumerKeyPanel.tsx:55`,
  `new Date(ts).toLocaleString()`) is still locale-formatted (visible as
  `14.11.2023` in the de-DE captures). The `audit:ui-determinism` gate classifies
  it as a module/util helper (not render-eager) and does not flag it, and issue
  #20690 scopes the fix to the quota. It is deliberately left untouched to keep
  the diff minimal.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@556402f3ac28248ac82d43a660ae8c7ce7c87e5e:packages/skills/skills/contribute-to-eliza"} -->
