### PR TITLE
fix(transcripts): enforce canonical tenant scope

### DIFF
--- a/plugins/plugin-local-inference/src/routes/transcripts-routes.test.ts
+++ b/plugins/plugin-local-inference/src/routes/transcripts-routes.test.ts
@@ -19,7 +19,7 @@ import {
 	transcriptsRoutes,
 } from "./transcripts-routes";
 
-const WORLD = "00000000-0000-0000-0000-0000000000ww" as UUID;
+const WORLD = "00000000-0000-4000-8000-000000000001" as UUID;
 const ROOM = "11111111-1111-1111-1111-111111111111" as UUID;
 const ENTITY = "22222222-2222-2222-2222-222222222222" as UUID;
 const OTHER_ENTITY = "33333333-3333-3333-3333-333333333333" as UUID;
@@ -57,6 +57,9 @@ function fakeRuntime(storage?: {
 		},
 		getMemories: async () => [...rows.values()],
 		getMemoryById: async (id: UUID) => rows.get(id) ?? null,
+		getRoom: async (id: UUID) => ({ id, worldId: WORLD }),
+		getRoomsForParticipants: async () => [ROOM],
+		reportError: () => undefined,
 		updateMemory: async (m: Partial<Memory> & { id: UUID }) => {
 			const existing = rows.get(m.id);
 			if (!existing) return false;
@@ -305,6 +308,147 @@ describe("transcripts routes", () => {
 			"/api/transcripts/:id",
 		)(ctx({ runtime: runtime as never, params: { id: "x" }, body: {} }));
 		expect(res.status).toBe(400);
+	});
+
+	it("POST derives tenant scope from the canonical room for an authorized participant", async () => {
+		const { rows, runtime } = fakeRuntime();
+		const created = await handlerFor(
+			"POST",
+			"/api/transcripts",
+		)(
+			ctx({
+				runtime: runtime as never,
+				accessContext: access(ENTITY),
+				body: {
+					segments,
+					roomId: ROOM,
+					worldId: WORLD,
+					entityId: ENTITY,
+				},
+			}),
+		);
+
+		expect(created.status).toBe(201);
+		expect([...rows.values()][0]).toMatchObject({
+			worldId: WORLD,
+			roomId: ROOM,
+			entityId: ENTITY,
+		});
+	});
+
+	it("POST rejects mismatched tenant scope and non-participant rooms", async () => {
+		const { runtime } = fakeRuntime();
+		const otherWorld = "00000000-0000-4000-8000-000000000099" as UUID;
+		const mismatch = await handlerFor(
+			"POST",
+			"/api/transcripts",
+		)(
+			ctx({
+				runtime: runtime as never,
+				accessContext: access(ENTITY),
+				body: { segments, roomId: ROOM, worldId: otherWorld },
+			}),
+		);
+		expect(mismatch.status).toBe(403);
+
+		const nonParticipantRuntime = {
+			...(runtime as object),
+			getRoomsForParticipants: async () => [],
+		};
+		const nonParticipant = await handlerFor(
+			"POST",
+			"/api/transcripts",
+		)(
+			ctx({
+				runtime: nonParticipantRuntime as never,
+				accessContext: access(ENTITY),
+				body: { segments, roomId: ROOM },
+			}),
+		);
+		expect(nonParticipant.status).toBe(403);
+	});
+
+	it("POST rejects identity spoofing and reports canonical-room lookup failure", async () => {
+		const { runtime } = fakeRuntime();
+		const spoofed = await handlerFor(
+			"POST",
+			"/api/transcripts",
+		)(
+			ctx({
+				runtime: runtime as never,
+				accessContext: access(ENTITY),
+				body: { segments, entityId: OTHER_ENTITY },
+			}),
+		);
+		expect(spoofed.status).toBe(403);
+
+		const lookupFailure = new Error("database unavailable");
+		const reported: unknown[][] = [];
+		const failingRuntime = {
+			...(runtime as object),
+			getRoom: async () => {
+				throw lookupFailure;
+			},
+			reportError: (...args: unknown[]) => reported.push(args),
+		};
+		const unavailable = await handlerFor(
+			"POST",
+			"/api/transcripts",
+		)(
+			ctx({
+				runtime: failingRuntime as never,
+				body: { segments, roomId: ROOM },
+			}),
+		);
+		expect(unavailable.status).toBe(503);
+		expect(reported).toEqual([
+			["transcripts.create-scope", lookupFailure, { roomId: ROOM }],
+		]);
+	});
+
+	it("PUT preserves the persisted tenant scope and rejects relocation", async () => {
+		const { rows, runtime } = fakeRuntime();
+		const created = await handlerFor(
+			"POST",
+			"/api/transcripts",
+		)(
+			ctx({
+				runtime: runtime as never,
+				body: { segments, roomId: ROOM, worldId: WORLD, entityId: ENTITY },
+			}),
+		);
+		const id = (created.body as { transcript: { id: string } }).transcript.id;
+		const otherRoom = "00000000-0000-4000-8000-000000000098" as UUID;
+
+		const update = await handlerFor(
+			"PUT",
+			"/api/transcripts/:id",
+		)(
+			ctx({
+				runtime: runtime as never,
+				params: { id },
+				body: { title: "relocated", roomId: otherRoom },
+			}),
+		);
+
+		expect(update.status).toBe(403);
+		expect(rows.get(id)).toMatchObject({
+			worldId: WORLD,
+			roomId: ROOM,
+			entityId: ENTITY,
+		});
+
+		const malformed = await handlerFor(
+			"PUT",
+			"/api/transcripts/:id",
+		)(
+			ctx({
+				runtime: runtime as never,
+				params: { id },
+				body: { title: "malformed", worldId: "not-a-uuid" },
+			}),
+		);
+		expect(malformed.status).toBe(400);
 	});
 
 	it("filters GET list and get-by-id for a non-owner requester", async () => {

--- a/plugins/plugin-local-inference/src/routes/transcripts-routes.ts
+++ b/plugins/plugin-local-inference/src/routes/transcripts-routes.ts
@@ -250,6 +250,141 @@ function participantEntityIds(transcript: Transcript): UUID[] {
 	return [...ids];
 }
 
+type TranscriptWriteScope = {
+	worldId: UUID;
+	roomId: UUID;
+	entityId: UUID;
+};
+
+type TranscriptWriteScopeResult =
+	| { ok: true; value: TranscriptWriteScope }
+	| { ok: false; status: number; error: string };
+
+async function resolveTranscriptCreateScope(
+	ctx: RouteHandlerContext,
+	body: CreateTranscriptRequest,
+): Promise<TranscriptWriteScopeResult> {
+	const agentId = ctx.runtime.agentId as UUID;
+	const requestedWorldId = requestUuid(body.worldId);
+	const requestedRoomId = requestUuid(body.roomId);
+	const requestedEntityId = requestUuid(body.entityId);
+	if (body.worldId !== undefined && !requestedWorldId) {
+		return { ok: false, status: 400, error: "worldId must be a UUID" };
+	}
+	if (body.roomId !== undefined && !requestedRoomId) {
+		return { ok: false, status: 400, error: "roomId must be a UUID" };
+	}
+	if (body.entityId !== undefined && !requestedEntityId) {
+		return { ok: false, status: 400, error: "entityId must be a UUID" };
+	}
+
+	const access = ctx.accessContext;
+	const elevated = isAdminRank(access?.role) || access?.isOwner === true;
+	if (
+		access &&
+		requestedEntityId &&
+		requestedEntityId !== access.requesterEntityId &&
+		!elevated
+	) {
+		return {
+			ok: false,
+			status: 403,
+			error: "entityId must match the authenticated requester",
+		};
+	}
+	const entityId = requestedEntityId ?? access?.requesterEntityId ?? agentId;
+
+	if (!requestedRoomId) {
+		if (requestedWorldId) {
+			return {
+				ok: false,
+				status: 400,
+				error: "worldId requires a roomId so tenant scope can be verified",
+			};
+		}
+		return {
+			ok: true,
+			value: { worldId: agentId, roomId: agentId, entityId },
+		};
+	}
+
+	let room: Awaited<ReturnType<typeof ctx.runtime.getRoom>>;
+	try {
+		room = await ctx.runtime.getRoom(requestedRoomId);
+	} catch (cause) {
+		// error-policy:J1 The HTTP boundary reports canonical-room lookup failure as unavailable.
+		ctx.runtime.reportError("transcripts.create-scope", cause, {
+			roomId: requestedRoomId,
+		});
+		return {
+			ok: false,
+			status: 503,
+			error: "Transcript room lookup is unavailable",
+		};
+	}
+	if (!room) {
+		return { ok: false, status: 400, error: "roomId does not exist" };
+	}
+	if (!room.worldId) {
+		ctx.runtime.reportError(
+			"transcripts.create-scope",
+			new Error("Canonical transcript room has no worldId"),
+			{ roomId: requestedRoomId },
+		);
+		return {
+			ok: false,
+			status: 503,
+			error: "Transcript room tenant scope is unavailable",
+		};
+	}
+	const worldId = room.worldId as UUID;
+	if (requestedWorldId && requestedWorldId !== worldId) {
+		return {
+			ok: false,
+			status: 403,
+			error: "worldId does not match the canonical room tenant",
+		};
+	}
+	if (access && !elevated) {
+		if (access.worldId !== worldId) {
+			return {
+				ok: false,
+				status: 403,
+				error: "Requester is not authorized for the room tenant",
+			};
+		}
+		let participantRooms: UUID[];
+		try {
+			participantRooms = await ctx.runtime.getRoomsForParticipants([
+				access.requesterEntityId,
+			]);
+		} catch (cause) {
+			// error-policy:J1 The HTTP boundary reports membership lookup failure as unavailable.
+			ctx.runtime.reportError("transcripts.create-membership", cause, {
+				roomId: requestedRoomId,
+				requesterEntityId: access.requesterEntityId,
+			});
+			return {
+				ok: false,
+				status: 503,
+				error: "Transcript room membership is unavailable",
+			};
+		}
+		if (!participantRooms.includes(requestedRoomId)) {
+			return {
+				ok: false,
+				status: 403,
+				error: "Requester is not a participant in the transcript room",
+			};
+		}
+	}
+
+	return {
+		ok: true,
+		value: { worldId, roomId: requestedRoomId, entityId },
+	};
+}
+
 const updateRoute: Route = {
 	type: "PUT",
 	path: "/api/transcripts/:id",
@@ -280,11 +415,44 @@ const updateRoute: Route = {
 		if (!requesterCanManageRow(ctx, row)) {
 			return { status: 403, body: { error: "manage access required" } };
 		}
-		const agentId = ctx.runtime.agentId as UUID;
+		const editWorldId = requestUuid(body.worldId);
+		const editRoomId = requestUuid(body.roomId);
+		const editEntityId = requestUuid(body.entityId);
+		if (
+			(body.worldId !== undefined && !editWorldId) ||
+			(body.roomId !== undefined && !editRoomId) ||
+			(body.entityId !== undefined && !editEntityId)
+		) {
+			return {
+				status: 400,
+				body: { error: "Transcript scope identifiers must be UUIDs" },
+			};
+		}
+		if (
+			(editWorldId && editWorldId !== row.worldId) ||
+			(editRoomId && editRoomId !== row.roomId) ||
+			(editEntityId && editEntityId !== row.entityId)
+		) {
+			return {
+				status: 403,
+				body: { error: "Transcript scope cannot be changed by an edit" },
+			};
+		}
+		if (!row.worldId) {
+			ctx.runtime.reportError(
+				"transcripts.update-scope",
+				new Error("Persisted transcript row has no worldId"),
+				{ transcriptId: ctx.params.id },
+			);
+			return {
+				status: 503,
+				body: { error: "Persisted transcript tenant scope is unavailable" },
+			};
+		}
 		const updated = await service(ctx).update(ctx.params.id as UUID, {
-			worldId: (body.worldId ?? agentId) as UUID,
-			roomId: (body.roomId ?? agentId) as UUID,
-			entityId: (body.entityId ?? agentId) as UUID,
+			worldId: row.worldId,
+			roomId: row.roomId,
+			entityId: row.entityId,
 			patch: { title: body.title, segments: body.segments },
 		});
 		if (!updated) return { status: 404, body: { error: "not found" } };
@@ -315,7 +483,13 @@ const createRoute: Route = {
 		}
 		// The shell client doesn't carry world/room/entity ids — default them to
 		// the agent context (single-user local) when not supplied.
-		const agentId = ctx.runtime.agentId as UUID;
+		const writeScope = await resolveTranscriptCreateScope(ctx, body);
+		if (!writeScope.ok) {
+			return {
+				status: writeScope.status,
+				body: { error: writeScope.error },
+			};
+		}
 		// Persist the recorded session WAV into the served media store so the
 		// player has audio to scrub. The shell sends base64 (it can't write files).
 		if (body.audioBase64 && !body.audioUrl) {
@@ -330,9 +504,7 @@ const createRoute: Route = {
 			Date.now(),
 		);
 		const saved = await service(ctx).create({
-			worldId: (body.worldId ?? agentId) as UUID,
-			roomId: (body.roomId ?? agentId) as UUID,
-			entityId: (body.entityId ?? agentId) as UUID,
+			...writeScope.value,
 			transcript,
 		});
 		return { status: 201, body: { transcript: saved } };

--- a/plugins/plugin-local-inference/src/services/voice/transcript-service.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-service.ts
@@ -82,7 +82,7 @@ export class TranscriptService {
 		const record = knowledgeDocumentId
 			? { ...transcript, knowledgeDocumentId }
 			: transcript;
-		return this.store.create({ roomId, entityId, transcript: record });
+		return this.store.create({ worldId, roomId, entityId, transcript: record });
 	}
 
 	list(

--- a/plugins/plugin-local-inference/src/services/voice/transcript-store.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-store.ts
@@ -76,6 +76,8 @@ export interface TranscriptStoreRuntime {
 }
 
 export interface CreateTranscriptInput {
+	/** Canonical tenant scope supplied by TranscriptService; legacy direct-store callers may omit it. */
+	worldId?: UUID;
 	roomId: UUID;
 	/** The owner/speaker entity the recording is attributed to. */
 	entityId: UUID;
@@ -493,7 +495,7 @@ export class TranscriptStore {
 
 	/** Persist a transcript record; returns it unchanged. */
 	async create(input: CreateTranscriptInput): Promise<Transcript> {
-		const { roomId, entityId, transcript } = input;
+		const { worldId, roomId, entityId, transcript } = input;
 		const metadata: MemoryMetadata = {
 			type: "custom",
 			source: TRANSCRIPT_METADATA_TYPE,
@@ -507,6 +509,7 @@ export class TranscriptStore {
 		};
 		const memory: Memory = {
 			id: transcript.id as UUID,
+			...(worldId ? { worldId } : {}),
 			entityId,
 			roomId,
 			agentId: this.runtime.agentId,


### PR DESCRIPTION
## Scope

Repairs the remaining tenant-isolation defect from the original branch at the authoritative transcript HTTP boundary. The document-processor and docs-loader changes were removed: after #20670, document upload/action callers resolve canonical scope once, and re-resolving it per fragment would create divergent authority and N+1 lookups.

## Correct fix

- Transcript create validates explicit UUIDs, rejects world-without-room, resolves the canonical room world, verifies non-owner tenant and room participation, prevents entity spoofing, and distinguishes invalid, unauthorized, and unavailable lookups.
- Transcript update preserves the persisted row worldId, roomId, and entityId; malformed scope is 400 and relocation is 403.
- TranscriptService now passes canonical worldId into TranscriptStore, which persists it on the source row so later edits never reconstruct scope from caller input.
- Lookup and membership failures are reported at the HTTP boundary; no catch fabricates agent-local success.

## Validation

Exact head `4975495974d944265b6e3d9221219210108006d3`, rebased on `develop@4bf4e96e3938e9a249b6abb5fe94bc6af6ad1f23`.

- Real transcript route suite: 19/19 passed, including canonical room derivation, valid foreign-world mismatch, nonparticipant denial, identity spoof denial, lookup-error diagnostics, immutable persisted scope, and malformed edit scope.
- Biome: four changed files clean.
- `git diff --check`: clean.
- Package typecheck reached only sparse-checkout missing-workspace aliases (`cloud-routing`, computeruse/mobile, capacitor bridge, native inference); it emitted no changed-file diagnostic. The real Vitest transform/import compiled the changed production graph.

<!-- evidence-head:4975495974d944265b6e3d9221219210108006d3 -->

No frontend, model, prompt, native, or visual surface changed; screenshot, video, OCR, audio, and model-trajectory evidence are N/A. The observable artifact is the production route response and persisted Memory scope asserted by the real route suite.

## Contribution provenance

AI assistance: yes
AI provider/model: Anthropic / claude-fable-5; OpenAI / gpt-5.6-sol
Client / agent tooling: Claude Code; Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@4bf4e96e3938e9a249b6abb5fe94bc6af6ad1f23:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-pr-audit]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@4bf4e96e3938e9a249b6abb5fe94bc6af6ad1f23:packages/skills/skills/contribute-to-eliza"} -->