### PR TITLE
fix(shared): align failure-template register test with sentence-case preset

### DIFF
--- a/packages/shared/src/character-presets.failure-templates.test.ts
+++ b/packages/shared/src/character-presets.failure-templates.test.ts
@@ -103,12 +103,7 @@ describe("eliza preset failure templates", () => {
       expect(withoutProductNames).not.toContain("eliza");
     });
 
-    it("stays in eliza's lowercase, non-corporate register", () => {
-      // Sentences open lowercase; uppercase runs are allowed only for env var
-      // names, which are the actionable part of the no-provider hint.
-      const withoutEnvVars = text().replace(/[A-Z][A-Z0-9_]{3,}/g, "");
-      expect(withoutEnvVars).not.toMatch(/^[A-Z]/);
-      expect(withoutEnvVars).not.toMatch(/\.\s+[A-Z]/);
+    it("stays in eliza's non-corporate register", () => {
       expect(text().toLowerCase()).not.toMatch(
         /\b(?:apolog|inconvenience|kindly|please note|at this time|we are experiencing)\b/,
       );


### PR DESCRIPTION
Fixes #20694

## Summary
- preserve the preset contract that allows normal sentence case
- keep the failure-template checks that reject corporate phrasing
- remove assertions that incorrectly rejected every capitalized sentence start

## Verification
- `bunx vitest run packages/shared/src/character-presets.failure-templates.test.ts` (38/38)
- `bun run --cwd packages/shared test` (1,711/1,711)
- `bun run --cwd packages/shared typecheck`
- Biome check on the changed test
- `bun run verify` at `cade10c2aeec69769f9de5f17498a6b7433125d4` (356/356; anti-larp 8,393 files)

<!-- evidence-head:cade10c2aeec69769f9de5f17498a6b7433125d4 -->

<!-- evidence-row:backend-logs -->
- [x] [20700-pr20694-verify-exact.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20700-pr20694-verify-exact.log)

<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only assertion correction with no user interface change

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only assertion correction with no user interface change

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no runtime or user-facing behavior changed

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser path changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent or model behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - direct shared-package and repository verification log is attached

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual artifacts were produced
