### PR TITLE
fix(ci): require staging certification before Cloud production

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -141,6 +141,17 @@ through `cloud-release-dependency-trigger-workflow.test.ts`; otherwise a
 source-form package can change an artifact without creating a release
 candidate.
 
+Production Cloud admission is also tree-bound to staging. After every
+successful automatic `develop` Cloud release, `cloud-cf-deploy.yml` uploads a
+14-day immutable certification whose JSON names the repository, workflow,
+source SHA, root Git tree, run/attempt, environment, and deterministic artifact
+name. A production dispatch checks out the exact requested `main` SHA and must
+resolve that tree's non-expired artifact from a completed successful
+`push`/`develop` run before the protected `production` approval job is even
+reachable. The artifact id, GitHub digest, owning run, payload, current workflow
+bytes, and expiry are all checked. Different merge commits are accepted only
+when their root trees are byte-identical; `force` never bypasses this gate.
+
 Cloudflare application deploys require Workers and Pages write access. The
 Terraform domain workflow additionally requires zone-scoped DNS write and
 `SSL and Certificates Write` access because it manages advanced wildcard

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -202,10 +202,162 @@ jobs:
             echo "Superseded staging release: run=$GITHUB_RUN_ID latest=$latest_eligible_run_id" >> "$GITHUB_STEP_SUMMARY"
           fi
 
-  authorize-production:
-    name: Authorize production environment
+  validate-staging-certification:
+    name: Validate staging certification for production tree
     needs: validate-deploy-source
     if: ${{ always() && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && github.event_name != 'pull_request' && ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      tree_sha: ${{ steps.identity.outputs.tree_sha }}
+      artifact_id: ${{ steps.resolve.outputs.artifact_id }}
+      artifact_digest: ${{ steps.resolve.outputs.artifact_digest }}
+      staging_run_id: ${{ steps.resolve.outputs.staging_run_id }}
+    steps:
+      - name: Checkout exact production candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Bind production candidate to its Git tree
+        id: identity
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          [ "$actual_sha" = "$EXPECTED_SHA" ] || {
+            echo "::error::Production certification checkout resolved ${actual_sha}, expected ${EXPECTED_SHA}"
+            exit 1
+          }
+          [ -z "$(git status --porcelain)" ] || {
+            echo "::error::Production certification checkout is not clean"
+            exit 1
+          }
+          tree_sha="$(git rev-parse 'HEAD^{tree}')"
+          artifact_name="cloud-staging-certification-v1-${tree_sha}"
+          echo "tree_sha=$tree_sha" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve immutable successful staging artifact
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_NAME: ${{ steps.identity.outputs.artifact_name }}
+        run: |
+          set -euo pipefail
+          candidates_file="${RUNNER_TEMP}/staging-certification-candidates.json"
+          artifact_file="${RUNNER_TEMP}/staging-certification-artifact.json"
+          run_file="${RUNNER_TEMP}/staging-certification-run.json"
+
+          gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=${ARTIFACT_NAME}&per_page=100" \
+            > "$candidates_file"
+
+          selected=""
+          while IFS= read -r candidate; do
+            [ -n "$candidate" ] || continue
+            artifact_id="$(jq -r '.id' <<<"$candidate")"
+            run_id="$(jq -r '.workflow_run.id // empty' <<<"$candidate")"
+            [ -n "$artifact_id" ] && [ -n "$run_id" ] || continue
+
+            if ! gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" > "$run_file"; then
+              continue
+            fi
+            if ! jq -e \
+              --arg repo "$GITHUB_REPOSITORY" \
+              '.status == "completed"
+                and .conclusion == "success"
+                and .event == "push"
+                and .head_branch == "develop"
+                and .path == ".github/workflows/cloud-cf-deploy.yml"
+                and .repository.full_name == $repo' \
+              "$run_file" >/dev/null; then
+              continue
+            fi
+
+            selected="$candidate"
+            break
+          done < <(
+            jq -c \
+              --arg name "$ARTIFACT_NAME" \
+              '[.artifacts[]
+                | select(.name == $name)
+                | select(.expired == false)
+                | select((.digest // "") | test("^sha256:[0-9a-f]{64}$"))]
+               | sort_by(.created_at)
+               | reverse[]' \
+              "$candidates_file"
+          )
+
+          [ -n "$selected" ] || {
+            echo "::error::No unexpired successful develop Cloud certification exists for production tree ${ARTIFACT_NAME#cloud-staging-certification-v1-}"
+            exit 1
+          }
+
+          printf '%s\n' "$selected" > "$artifact_file"
+          artifact_id="$(jq -r '.id' "$artifact_file")"
+          artifact_digest="$(jq -r '.digest' "$artifact_file")"
+          staging_run_id="$(jq -r '.workflow_run.id' "$artifact_file")"
+          echo "artifact_id=$artifact_id" >> "$GITHUB_OUTPUT"
+          echo "artifact_digest=$artifact_digest" >> "$GITHUB_OUTPUT"
+          echo "staging_run_id=$staging_run_id" >> "$GITHUB_OUTPUT"
+
+      - name: Download selected certification artifact by id
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          artifact-ids: ${{ steps.resolve.outputs.artifact_id }}
+          path: ${{ runner.temp }}/staging-certification
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.resolve.outputs.staging_run_id }}
+          digest-mismatch: error
+
+      - name: Verify certification payload and GitHub ownership
+        env:
+          EXPECTED_TREE_SHA: ${{ steps.identity.outputs.tree_sha }}
+          EXPECTED_REPOSITORY: ${{ github.repository }}
+          ARTIFACT_ID: ${{ steps.resolve.outputs.artifact_id }}
+          ARTIFACT_DIGEST: ${{ steps.resolve.outputs.artifact_digest }}
+          STAGING_RUN_ID: ${{ steps.resolve.outputs.staging_run_id }}
+        run: |
+          set -euo pipefail
+          certification_dir="${RUNNER_TEMP}/staging-certification"
+          mapfile -t files < <(find "$certification_dir" -type f -print)
+          [ "${#files[@]}" -eq 1 ] \
+            && [ "$(basename "${files[0]}")" = "staging-cloud-certification.json" ] || {
+              echo "::error::Certification artifact must contain exactly staging-cloud-certification.json"
+              exit 1
+            }
+
+          result="$(
+            node packages/cloud/scripts/staging-release-certification.mjs verify \
+              --cert "${files[0]}" \
+              --run-json "${RUNNER_TEMP}/staging-certification-run.json" \
+              --artifact-json "${RUNNER_TEMP}/staging-certification-artifact.json" \
+              --expected-repository "$EXPECTED_REPOSITORY" \
+              --expected-tree-sha "$EXPECTED_TREE_SHA" \
+              --workflow-file .github/workflows/cloud-cf-deploy.yml
+          )"
+          jq -e \
+            --arg artifact_id "$ARTIFACT_ID" \
+            --arg artifact_digest "$ARTIFACT_DIGEST" \
+            --arg staging_run_id "$STAGING_RUN_ID" \
+            '.artifactId == $artifact_id
+              and .artifactDigest == $artifact_digest
+              and .runId == $staging_run_id' \
+            <<<"$result" >/dev/null
+          echo "Staging certification admitted tree ${EXPECTED_TREE_SHA} from run ${STAGING_RUN_ID}, artifact ${ARTIFACT_ID} (${ARTIFACT_DIGEST})." >> "$GITHUB_STEP_SUMMARY"
+
+  authorize-production:
+    name: Authorize production environment
+    needs: [validate-deploy-source, validate-staging-certification]
+    if: ${{ always() && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && needs.validate-staging-certification.result == 'success' && github.event_name != 'pull_request' && ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') }}
     runs-on: ubuntu-latest
     timeout-minutes: 2
     # Approval only. This job must not share a mutation concurrency group, or
@@ -217,8 +369,8 @@ jobs:
 
   release:
     name: Mutate and verify Cloud CF release
-    needs: [validate-deploy-source, admit-staging, authorize-production]
-    if: ${{ always() && github.event_name != 'pull_request' && (((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && needs.authorize-production.result == 'success' || !((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && needs.admit-staging.outputs.should_deploy == 'true') }}
+    needs: [validate-deploy-source, admit-staging, validate-staging-certification, authorize-production]
+    if: ${{ always() && github.event_name != 'pull_request' && (((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && (needs.validate-deploy-source.result == 'success' || needs.validate-deploy-source.result == 'skipped') && needs.validate-staging-certification.result == 'success' && needs.authorize-production.result == 'success' || !((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && needs.admit-staging.outputs.should_deploy == 'true') }}
     # One critical section for migrate + API + Pages + routing proof.
     # `queue: max` is GitHub's production-deploy contract: up to 100 approved
     # releases wait instead of the default one-pending eviction. FIFO is by
@@ -233,6 +385,77 @@ jobs:
     with:
       target_environment: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
       force: ${{ github.event_name == 'workflow_dispatch' && inputs.force == true }}
+
+  certify-staging-release:
+    name: Certify successful staging Cloud tree
+    needs: release
+    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/develop' && needs.release.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout exact released staging source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Create tree-bound staging certificate
+        id: identity
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          [ "$actual_sha" = "$EXPECTED_SHA" ] || {
+            echo "::error::Staging certification checkout resolved ${actual_sha}, expected ${EXPECTED_SHA}"
+            exit 1
+          }
+          [ -z "$(git status --porcelain)" ] || {
+            echo "::error::Staging certification checkout is not clean"
+            exit 1
+          }
+          tree_sha="$(git rev-parse 'HEAD^{tree}')"
+          artifact_name="cloud-staging-certification-v1-${tree_sha}"
+          node packages/cloud/scripts/staging-release-certification.mjs create \
+            --out staging-cloud-certification.json \
+            --repository "$GITHUB_REPOSITORY" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --source-sha "$GITHUB_SHA" \
+            --tree-sha "$tree_sha" \
+            --artifact-name "$artifact_name" \
+            --workflow-file .github/workflows/cloud-cf-deploy.yml
+          echo "tree_sha=$tree_sha" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
+
+      - name: Upload immutable staging certification
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ${{ steps.identity.outputs.artifact_name }}
+          path: staging-cloud-certification.json
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Record certification identity
+        env:
+          TREE_SHA: ${{ steps.identity.outputs.tree_sha }}
+          ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
+          ARTIFACT_DIGEST: ${{ steps.upload.outputs.artifact-digest }}
+        run: |
+          set -euo pipefail
+          [[ "$ARTIFACT_ID" =~ ^[1-9][0-9]*$ ]] || {
+            echo "::error::Certification upload did not return an artifact id"
+            exit 1
+          }
+          [[ "$ARTIFACT_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+            echo "::error::Certification upload did not return a SHA-256 digest"
+            exit 1
+          }
+          echo "Certified staging tree ${TREE_SHA} with artifact ${ARTIFACT_ID} (${ARTIFACT_DIGEST}) after all release and routing checks passed." >> "$GITHUB_STEP_SUMMARY"
 
   resolve-pages-preview-config:
     name: Resolve Pages preview configuration

--- a/packages/cloud/scripts/staging-release-certification.mjs
+++ b/packages/cloud/scripts/staging-release-certification.mjs
@@ -1,0 +1,336 @@
+/**
+ * Creates and verifies GitHub-bound staging release certifications.
+ *
+ * The certificate binds a successful develop release to its Git tree rather
+ * than its commit SHA so a byte-identical main promotion can be admitted. The
+ * verifier also requires the immutable GitHub artifact and originating run
+ * metadata; the JSON payload alone is never an authority.
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const CERTIFICATION_SCHEMA =
+  "eliza.cloud.staging-release-certification/v1";
+export const CERTIFICATION_WORKFLOW = ".github/workflows/cloud-cf-deploy.yml";
+export const CERTIFICATION_ENVIRONMENT = "staging";
+export const CERTIFICATION_EVENT = "push";
+export const CERTIFICATION_REF = "refs/heads/develop";
+export const CERTIFICATION_ARTIFACT_PREFIX = "cloud-staging-certification-v1-";
+export const CERTIFICATION_FILENAME = "staging-cloud-certification.json";
+export const CERTIFICATION_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+
+const SHA40 = /^[0-9a-f]{40}$/;
+const SHA256 = /^[0-9a-f]{64}$/;
+const ARTIFACT_DIGEST = /^sha256:[0-9a-f]{64}$/;
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const CLOCK_SKEW_MS = 5 * 60 * 1000;
+
+function fail(message) {
+  throw new Error(`Staging release certification rejected: ${message}`);
+}
+
+function requireRecord(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${label} must be an object`);
+  }
+  return value;
+}
+
+function requireString(value, label, pattern) {
+  if (typeof value !== "string" || value.length === 0) {
+    fail(`${label} must be a non-empty string`);
+  }
+  if (pattern && !pattern.test(value)) {
+    fail(`${label} has an invalid format`);
+  }
+  return value;
+}
+
+function requirePositiveIntegerString(value, label) {
+  const normalized = String(value ?? "");
+  if (!/^[1-9][0-9]*$/.test(normalized)) {
+    fail(`${label} must be a positive integer`);
+  }
+  return normalized;
+}
+
+function parseTimestamp(value, label) {
+  requireString(value, label);
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) {
+    fail(`${label} must be an ISO timestamp`);
+  }
+  return timestamp;
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+export function sha256File(path) {
+  return sha256(readFileSync(path));
+}
+
+export function artifactNameForTree(treeSha) {
+  requireString(treeSha, "tree SHA", SHA40);
+  return `${CERTIFICATION_ARTIFACT_PREFIX}${treeSha}`;
+}
+
+export function createStagingReleaseCertification({
+  repository,
+  runId,
+  runAttempt,
+  sourceSha,
+  treeSha,
+  workflowSha256,
+  artifactName = artifactNameForTree(treeSha),
+  issuedAt = new Date().toISOString(),
+  expiresAt,
+}) {
+  requireString(repository, "repository", REPOSITORY);
+  requirePositiveIntegerString(runId, "run id");
+  requirePositiveIntegerString(runAttempt, "run attempt");
+  requireString(sourceSha, "source SHA", SHA40);
+  requireString(treeSha, "tree SHA", SHA40);
+  requireString(workflowSha256, "workflow SHA-256", SHA256);
+  if (artifactName !== artifactNameForTree(treeSha)) {
+    fail("artifact name does not bind the certified tree");
+  }
+  const issued = parseTimestamp(issuedAt, "issued_at");
+  const resolvedExpiresAt =
+    expiresAt ?? new Date(issued + CERTIFICATION_TTL_MS).toISOString();
+  const expires = parseTimestamp(resolvedExpiresAt, "expires_at");
+  if (expires <= issued || expires - issued > CERTIFICATION_TTL_MS) {
+    fail("certificate lifetime must be positive and at most 14 days");
+  }
+
+  return {
+    schema: CERTIFICATION_SCHEMA,
+    repository,
+    workflow: CERTIFICATION_WORKFLOW,
+    workflow_sha256: workflowSha256,
+    environment: CERTIFICATION_ENVIRONMENT,
+    event: CERTIFICATION_EVENT,
+    ref: CERTIFICATION_REF,
+    run_id: String(runId),
+    run_attempt: String(runAttempt),
+    source_sha: sourceSha,
+    tree_sha: treeSha,
+    artifact: {
+      name: artifactName,
+      filename: CERTIFICATION_FILENAME,
+    },
+    issued_at: new Date(issued).toISOString(),
+    expires_at: new Date(expires).toISOString(),
+  };
+}
+
+export function verifyStagingReleaseCertification({
+  certification,
+  run,
+  artifact,
+  expectedRepository,
+  expectedTreeSha,
+  expectedWorkflowSha256,
+  now = new Date().toISOString(),
+}) {
+  const cert = requireRecord(certification, "certificate");
+  const runMetadata = requireRecord(run, "originating run metadata");
+  const artifactMetadata = requireRecord(artifact, "artifact metadata");
+
+  requireString(expectedRepository, "expected repository", REPOSITORY);
+  requireString(expectedTreeSha, "expected tree SHA", SHA40);
+  requireString(expectedWorkflowSha256, "expected workflow SHA-256", SHA256);
+
+  if (cert.schema !== CERTIFICATION_SCHEMA) fail("schema is unsupported");
+  if (cert.repository !== expectedRepository) fail("repository does not match");
+  if (cert.workflow !== CERTIFICATION_WORKFLOW) fail("workflow does not match");
+  if (cert.workflow_sha256 !== expectedWorkflowSha256) {
+    fail("workflow bytes do not match the promoted tree");
+  }
+  if (cert.environment !== CERTIFICATION_ENVIRONMENT) {
+    fail("environment is not staging");
+  }
+  if (cert.event !== CERTIFICATION_EVENT || cert.ref !== CERTIFICATION_REF) {
+    fail("certificate is not from a develop push");
+  }
+  requireString(cert.source_sha, "certificate source SHA", SHA40);
+  requireString(cert.tree_sha, "certificate tree SHA", SHA40);
+  if (cert.tree_sha !== expectedTreeSha)
+    fail("Git tree does not match production");
+
+  const expectedArtifactName = artifactNameForTree(expectedTreeSha);
+  const certArtifact = requireRecord(cert.artifact, "certificate artifact");
+  if (
+    certArtifact.name !== expectedArtifactName ||
+    certArtifact.filename !== CERTIFICATION_FILENAME
+  ) {
+    fail("certificate artifact identity does not match");
+  }
+
+  const issued = parseTimestamp(cert.issued_at, "issued_at");
+  const expires = parseTimestamp(cert.expires_at, "expires_at");
+  const current = parseTimestamp(now, "verification time");
+  if (issued > current + CLOCK_SKEW_MS) fail("certificate is future-dated");
+  if (expires <= issued || expires - issued > CERTIFICATION_TTL_MS) {
+    fail("certificate lifetime exceeds policy");
+  }
+  if (current >= expires) fail("certificate has expired");
+
+  const runId = requirePositiveIntegerString(cert.run_id, "certificate run id");
+  const runAttempt = requirePositiveIntegerString(
+    cert.run_attempt,
+    "certificate run attempt",
+  );
+  if (String(runMetadata.id) !== runId)
+    fail("originating run id does not match");
+  if (String(runMetadata.run_attempt) !== runAttempt) {
+    fail("originating run attempt does not match");
+  }
+  if (
+    runMetadata.status !== "completed" ||
+    runMetadata.conclusion !== "success"
+  ) {
+    fail("originating run did not complete successfully");
+  }
+  if (
+    runMetadata.event !== CERTIFICATION_EVENT ||
+    runMetadata.head_branch !== "develop" ||
+    runMetadata.path !== CERTIFICATION_WORKFLOW
+  ) {
+    fail("originating run is not the canonical develop Cloud workflow");
+  }
+  const runRepository = requireRecord(
+    runMetadata.repository,
+    "originating run repository",
+  );
+  if (runRepository.full_name !== expectedRepository) {
+    fail("originating run repository does not match");
+  }
+  if (runMetadata.head_sha !== cert.source_sha) {
+    fail("originating run source SHA does not match");
+  }
+
+  const artifactId = requirePositiveIntegerString(
+    artifactMetadata.id,
+    "artifact id",
+  );
+  if (
+    artifactMetadata.name !== expectedArtifactName ||
+    artifactMetadata.expired !== false
+  ) {
+    fail("artifact name or expiry state does not match");
+  }
+  requireString(artifactMetadata.digest, "artifact digest", ARTIFACT_DIGEST);
+  const workflowRun = requireRecord(
+    artifactMetadata.workflow_run,
+    "artifact workflow_run",
+  );
+  if (String(workflowRun.id) !== runId) {
+    fail("artifact is not owned by the certified run");
+  }
+  if (workflowRun.head_sha && workflowRun.head_sha !== cert.source_sha) {
+    fail("artifact source SHA does not match");
+  }
+
+  return {
+    treeSha: cert.tree_sha,
+    stagingSourceSha: cert.source_sha,
+    runId,
+    runAttempt,
+    artifactId,
+    artifactDigest: artifactMetadata.digest,
+    expiresAt: cert.expires_at,
+  };
+}
+
+function parseArguments(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith("--")) fail(`unexpected argument ${token}`);
+    const equal = token.indexOf("=");
+    if (equal > 2) {
+      values[token.slice(2, equal)] = token.slice(equal + 1);
+      continue;
+    }
+    const key = token.slice(2);
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) fail(`missing value for --${key}`);
+    values[key] = value;
+    index += 1;
+  }
+  return values;
+}
+
+function readJson(path, label) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    // error-policy:J1 CLI input failures become one structured process error.
+    fail(`${label} is not valid JSON (${error.message})`);
+  }
+}
+
+function runCli(argv) {
+  const [command, ...rest] = argv;
+  const args = parseArguments(rest);
+  if (command === "create") {
+    const workflowFile = requireString(args["workflow-file"], "workflow file");
+    const certification = createStagingReleaseCertification({
+      repository: args.repository,
+      runId: args["run-id"],
+      runAttempt: args["run-attempt"],
+      sourceSha: args["source-sha"],
+      treeSha: args["tree-sha"],
+      workflowSha256: sha256File(workflowFile),
+      artifactName: args["artifact-name"],
+      issuedAt: args["issued-at"] ?? new Date().toISOString(),
+    });
+    const output = requireString(args.out, "output path");
+    writeFileSync(output, `${JSON.stringify(certification, null, 2)}\n`, {
+      flag: "wx",
+      mode: 0o600,
+    });
+    console.log(
+      JSON.stringify({
+        schema: certification.schema,
+        tree_sha: certification.tree_sha,
+        artifact_name: certification.artifact.name,
+        expires_at: certification.expires_at,
+      }),
+    );
+    return;
+  }
+
+  if (command === "verify") {
+    const workflowFile = requireString(args["workflow-file"], "workflow file");
+    const result = verifyStagingReleaseCertification({
+      certification: readJson(args.cert, "certificate"),
+      run: readJson(args["run-json"], "run metadata"),
+      artifact: readJson(args["artifact-json"], "artifact metadata"),
+      expectedRepository: args["expected-repository"],
+      expectedTreeSha: args["expected-tree-sha"],
+      expectedWorkflowSha256: sha256File(workflowFile),
+      now: args.now ?? new Date().toISOString(),
+    });
+    console.log(JSON.stringify(result));
+    return;
+  }
+
+  fail("command must be create or verify");
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  try {
+    runCli(process.argv.slice(2));
+  } catch (error) {
+    // error-policy:J1 The process boundary owns the stable nonzero CLI result.
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/packages/cloud/scripts/staging-release-certification.test.mjs
+++ b/packages/cloud/scripts/staging-release-certification.test.mjs
@@ -1,0 +1,339 @@
+/**
+ * Exercises tree-bound staging release certification and the production gate.
+ *
+ * The pure fixtures cover malformed and adversarial metadata; the CLI test
+ * executes real JSON files, and the workflow assertions pin the protected job
+ * graph plus the exact artifact actions.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+
+import {
+  artifactNameForTree,
+  CERTIFICATION_ARTIFACT_PREFIX,
+  CERTIFICATION_FILENAME,
+  CERTIFICATION_SCHEMA,
+  CERTIFICATION_WORKFLOW,
+  createStagingReleaseCertification,
+  verifyStagingReleaseCertification,
+} from "./staging-release-certification.mjs";
+
+const repoRoot = resolve(import.meta.dirname, "../../..");
+const workflowPath = resolve(repoRoot, CERTIFICATION_WORKFLOW);
+const workflow = readFileSync(workflowPath, "utf8").replaceAll("\r\n", "\n");
+const sourceSha = "a".repeat(40);
+const treeSha = "b".repeat(40);
+const workflowSha256 = "c".repeat(64);
+const artifactName = artifactNameForTree(treeSha);
+const issuedAt = "2026-08-16T12:00:00.000Z";
+const now = "2026-08-17T12:00:00.000Z";
+
+function fixture() {
+  const certification = createStagingReleaseCertification({
+    repository: "elizaOS/eliza",
+    runId: "12345",
+    runAttempt: "2",
+    sourceSha,
+    treeSha,
+    workflowSha256,
+    artifactName,
+    issuedAt,
+  });
+  return {
+    certification,
+    run: {
+      id: 12345,
+      run_attempt: 2,
+      status: "completed",
+      conclusion: "success",
+      event: "push",
+      head_branch: "develop",
+      head_sha: sourceSha,
+      path: CERTIFICATION_WORKFLOW,
+      repository: { full_name: "elizaOS/eliza" },
+    },
+    artifact: {
+      id: 67890,
+      name: artifactName,
+      expired: false,
+      digest: `sha256:${"d".repeat(64)}`,
+      workflow_run: {
+        id: 12345,
+        head_sha: sourceSha,
+      },
+    },
+    expectedRepository: "elizaOS/eliza",
+    expectedTreeSha: treeSha,
+    expectedWorkflowSha256: workflowSha256,
+    now,
+  };
+}
+
+function jobBlock(source, jobId) {
+  const start = source.search(new RegExp(`^  ${jobId}:\\n`, "m"));
+  if (start < 0) throw new Error(`missing job ${jobId}`);
+  const fromJob = source.slice(start);
+  const header = `  ${jobId}:\n`;
+  const next = fromJob.slice(header.length).search(/^ {2}[A-Za-z0-9_-]+:/m);
+  return next < 0 ? fromJob : fromJob.slice(0, header.length + next);
+}
+
+describe("staging release certification payload", () => {
+  test("accepts a different production commit when the root tree is identical", () => {
+    const input = fixture();
+    expect(verifyStagingReleaseCertification(input)).toEqual({
+      treeSha,
+      stagingSourceSha: sourceSha,
+      runId: "12345",
+      runAttempt: "2",
+      artifactId: "67890",
+      artifactDigest: `sha256:${"d".repeat(64)}`,
+      expiresAt: "2026-08-30T12:00:00.000Z",
+    });
+  });
+
+  test("creates the canonical schema and deterministic artifact identity", () => {
+    const { certification } = fixture();
+    expect(certification).toMatchObject({
+      schema: CERTIFICATION_SCHEMA,
+      repository: "elizaOS/eliza",
+      workflow: CERTIFICATION_WORKFLOW,
+      environment: "staging",
+      event: "push",
+      ref: "refs/heads/develop",
+      source_sha: sourceSha,
+      tree_sha: treeSha,
+      artifact: {
+        name: `${CERTIFICATION_ARTIFACT_PREFIX}${treeSha}`,
+        filename: CERTIFICATION_FILENAME,
+      },
+    });
+  });
+
+  test.each([
+    ["wrong tree", (input) => (input.expectedTreeSha = "e".repeat(40))],
+    [
+      "wrong repository",
+      (input) => (input.expectedRepository = "attacker/fork"),
+    ],
+    [
+      "wrong workflow bytes",
+      (input) => (input.expectedWorkflowSha256 = "e".repeat(64)),
+    ],
+    [
+      "wrong environment",
+      (input) => (input.certification.environment = "production"),
+    ],
+    [
+      "wrong event",
+      (input) => (input.certification.event = "workflow_dispatch"),
+    ],
+    ["wrong ref", (input) => (input.certification.ref = "refs/heads/main")],
+    ["expired", (input) => (input.now = "2026-08-30T12:00:00.000Z")],
+    [
+      "future dated",
+      (input) => (input.certification.issued_at = "2026-08-18T12:00:00.000Z"),
+    ],
+  ])("rejects %s certificate metadata", (_label, mutate) => {
+    const input = fixture();
+    mutate(input);
+    expect(() => verifyStagingReleaseCertification(input)).toThrow(
+      /Staging release certification rejected/,
+    );
+  });
+
+  test.each([
+    ["failed", (run) => (run.conclusion = "failure")],
+    ["incomplete", (run) => (run.status = "in_progress")],
+    ["manual", (run) => (run.event = "workflow_dispatch")],
+    ["main", (run) => (run.head_branch = "main")],
+    ["wrong workflow", (run) => (run.path = ".github/workflows/ci.yml")],
+    ["wrong repository", (run) => (run.repository.full_name = "attacker/fork")],
+    ["wrong source", (run) => (run.head_sha = "f".repeat(40))],
+    ["wrong attempt", (run) => (run.run_attempt = 3)],
+  ])("rejects an originating run that is %s", (_label, mutate) => {
+    const input = fixture();
+    mutate(input.run);
+    expect(() => verifyStagingReleaseCertification(input)).toThrow(
+      /Staging release certification rejected/,
+    );
+  });
+
+  test.each([
+    ["expired", (artifact) => (artifact.expired = true)],
+    ["renamed", (artifact) => (artifact.name = "other")],
+    ["digestless", (artifact) => (artifact.digest = "")],
+    ["wrong owner", (artifact) => (artifact.workflow_run.id = 99999)],
+    [
+      "wrong source",
+      (artifact) => (artifact.workflow_run.head_sha = "f".repeat(40)),
+    ],
+  ])("rejects an artifact that is %s", (_label, mutate) => {
+    const input = fixture();
+    mutate(input.artifact);
+    expect(() => verifyStagingReleaseCertification(input)).toThrow(
+      /Staging release certification rejected/,
+    );
+  });
+
+  test("rejects malformed and overlong certificate lifetimes", () => {
+    const input = fixture();
+    input.certification.expires_at = "2026-09-30T12:00:00.000Z";
+    expect(() => verifyStagingReleaseCertification(input)).toThrow(
+      /lifetime exceeds policy/,
+    );
+    expect(() =>
+      createStagingReleaseCertification({
+        repository: "elizaOS/eliza",
+        runId: "1",
+        runAttempt: "1",
+        sourceSha,
+        treeSha,
+        workflowSha256,
+        issuedAt: "not-a-date",
+      }),
+    ).toThrow(/ISO timestamp/);
+  });
+});
+
+describe("staging release certification CLI", () => {
+  test("creates and verifies real JSON files", () => {
+    const directory = mkdtempSync(resolve(tmpdir(), "eliza-staging-cert-"));
+    try {
+      const localWorkflow = resolve(directory, "cloud-cf-deploy.yml");
+      const certFile = resolve(directory, CERTIFICATION_FILENAME);
+      const runFile = resolve(directory, "run.json");
+      const artifactFile = resolve(directory, "artifact.json");
+      writeFileSync(localWorkflow, "name: test-workflow\n");
+      const createResult = spawnSync(
+        process.execPath,
+        [
+          resolve(import.meta.dirname, "staging-release-certification.mjs"),
+          "create",
+          "--out",
+          certFile,
+          "--repository",
+          "elizaOS/eliza",
+          "--run-id",
+          "12345",
+          "--run-attempt",
+          "2",
+          "--source-sha",
+          sourceSha,
+          "--tree-sha",
+          treeSha,
+          "--artifact-name",
+          artifactName,
+          "--workflow-file",
+          localWorkflow,
+          "--issued-at",
+          issuedAt,
+        ],
+        { encoding: "utf8" },
+      );
+      expect(createResult.status).toBe(0);
+
+      const input = fixture();
+      writeFileSync(runFile, JSON.stringify(input.run));
+      writeFileSync(artifactFile, JSON.stringify(input.artifact));
+      const verifyResult = spawnSync(
+        process.execPath,
+        [
+          resolve(import.meta.dirname, "staging-release-certification.mjs"),
+          "verify",
+          "--cert",
+          certFile,
+          "--run-json",
+          runFile,
+          "--artifact-json",
+          artifactFile,
+          "--expected-repository",
+          "elizaOS/eliza",
+          "--expected-tree-sha",
+          treeSha,
+          "--workflow-file",
+          localWorkflow,
+          "--now",
+          now,
+        ],
+        { encoding: "utf8" },
+      );
+      expect(verifyResult.status).toBe(0);
+      expect(JSON.parse(verifyResult.stdout)).toMatchObject({
+        treeSha,
+        runId: "12345",
+        artifactId: "67890",
+      });
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("Cloud CF workflow staging certification gate", () => {
+  test("emits a certificate only after a successful develop push release", () => {
+    const block = jobBlock(workflow, "certify-staging-release");
+    expect(block).toContain("needs: release");
+    expect(block).toContain("github.event_name == 'push'");
+    expect(block).toContain("github.ref == 'refs/heads/develop'");
+    expect(block).toContain("needs.release.result == 'success'");
+    expect(block).toContain("git rev-parse 'HEAD^{tree}'");
+    expect(block).toContain("staging-release-certification.mjs create");
+    expect(block).toContain(
+      "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+    );
+    expect(block).toContain("retention-days: 14");
+    expect(block).toContain("steps.upload.outputs.artifact-id");
+    expect(block).toContain("steps.upload.outputs.artifact-digest");
+  });
+
+  test("validates the exact production tree before environment approval", () => {
+    const validate = jobBlock(workflow, "validate-staging-certification");
+    const authorize = jobBlock(workflow, "authorize-production");
+    const release = jobBlock(workflow, "release");
+    expect(validate).not.toContain("environment: production");
+    expect(validate).toContain("ref: $" + "{{ github.sha }}");
+    expect(validate).toContain("persist-credentials: false");
+    expect(validate).toContain("git rev-parse 'HEAD^{tree}'");
+    expect(validate).toContain('event == "push"');
+    expect(validate).toContain('head_branch == "develop"');
+    expect(validate).toContain(
+      'path == ".github/workflows/cloud-cf-deploy.yml"',
+    );
+    expect(validate).toContain(
+      "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
+    );
+    expect(validate).toContain("artifact-ids:");
+    expect(validate).toContain("github-token: $" + "{{ github.token }}");
+    expect(validate).toContain(
+      "run-id: $" + "{{ steps.resolve.outputs.staging_run_id }}",
+    );
+    expect(validate).toContain("digest-mismatch: error");
+    expect(validate).toContain("staging-release-certification.mjs verify");
+    expect(validate).not.toContain("inputs.force");
+    expect(authorize).toContain("validate-staging-certification");
+    expect(authorize).toContain(
+      "needs.validate-staging-certification.result == 'success'",
+    );
+    expect(release).toContain("validate-staging-certification");
+    expect(release).toContain(
+      "needs.validate-staging-certification.result == 'success'",
+    );
+  });
+
+  test("fails closed on absent, expired, digestless, or noncanonical artifacts", () => {
+    const block = jobBlock(workflow, "validate-staging-certification");
+    expect(block).toContain(
+      "No unexpired successful develop Cloud certification",
+    );
+    expect(block).toContain("select(.expired == false)");
+    expect(block).toContain('test("^sha256:[0-9a-f]{64}$")');
+    expect(block).toContain('.conclusion == "success"');
+    expect(block).toContain(".repository.full_name == $repo");
+    expect(block).toContain("--artifact-json");
+  });
+});


### PR DESCRIPTION
# Relates to

Fixes #20584.

- [x] Targets `develop` and is rebased onto exact `origin/develop@9b62def2e89ac24d1e643e8549c3c990507c3d67` with zero conflicts.
- [x] Full `bun install`, Cloud verification, and uncached root verification passed after sync.
- [x] The executable workflow contract and evidence below let a reviewer verify the fail-closed boundary without inferring it from prose.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@9b62def2e89ac24d1e643e8549c3c990507c3d67:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact parent is current `origin/develop@9b62def2e89ac24d1e643e8549c3c990507c3d67`; zero conflicts.
- [x] `TURBO_FORCE=1 bun run verify` passed at exact head `9ee4142026017f7362819067f8e4d71b4d3e63f0`: 356/356 tasks, 0 cached, all repository audits green, anti-larp 8,394 files clean.

# Risks

Medium operational risk, fail-closed. Production Cloud releases will stop before the protected production environment and before provider mutation unless the exact candidate Git tree has an unexpired successful staging certification. This is intentionally stricter than the current workflow. Staging releases are unchanged except for a post-success, read-only checkout and immutable artifact upload. Certification expires after 14 days and cannot be bypassed by `force`.

# Background

## What does this PR do?

Successful `push`/`develop` Cloud releases now emit a 14-day immutable certificate only after the reusable release and all of its migration, Worker, Pages, routing, and postdeploy checks succeed. The certificate binds repository, workflow bytes, run id/attempt, staging commit, exact root Git tree, event/ref/environment, artifact name, and validity window.

Production preflight checks out the exact requested `main` SHA, computes `HEAD^{tree}`, resolves the newest unexpired artifact with the deterministic tree-bound name, verifies the originating GitHub run and immutable artifact metadata, downloads by exact artifact id with digest checking, and validates the payload. Only then can the protected `production` approval job or reusable mutation workflow become reachable.

Different `develop` and `main` commit SHAs are accepted only when their complete Git trees are byte-identical. Missing, expired, renamed, digestless, malformed, fork-owned, failed-run, wrong-event/branch/workflow/environment/tree, or changed-workflow evidence is rejected. `force` has no path around the gate.

## What kind of change is this?

Bug fix and release-safety hardening.

# Documentation changes needed?

Updated the Cloud workflow inventory with certificate issuance, production validation, TTL, tree identity, and fail-closed behavior.

# Testing

## Where should a reviewer start?

- `packages/cloud/scripts/staging-release-certification.mjs`
- `packages/cloud/scripts/staging-release-certification.test.mjs`
- `.github/workflows/cloud-cf-deploy.yml`

## Detailed testing steps

- `bun test packages/cloud/scripts/staging-release-certification.test.mjs packages/cloud/scripts/production-deploy-admission-lock.test.mjs` — 44/44 tests, 240 expectations.
- Tests accept equal trees with different commit SHAs and reject malformed/expired/wrong-tree/wrong-repository/wrong-workflow/wrong-environment/wrong-event/wrong-ref/failed/incomplete/manual/main/wrong-run/wrong-attempt/renamed/digestless/wrong-owner artifacts.
- Real CLI test creates and verifies files through the production entrypoint.
- Workflow tests pin upload/download action SHAs, cross-run artifact inputs, exact digest mismatch failure, job dependencies, absence of `force`, and the pre-approval boundary.
- `actionlint` passes with only the repository's existing unsupported `queue: max` parser diagnostic ignored; that same diagnostic exists on the unchanged base workflow.
- `bun run verify:cloud` — 81/81 tasks, 0 cached.
- `TURBO_FORCE=1 bun run verify` — 356/356 tasks, 0 cached; all follow-on audits pass.

# Evidence Gate

<!-- evidence-head:9ee4142026017f7362819067f8e4d71b4d3e63f0 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - protected release workflow and deterministic CLI only; no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime is changed; the live negative and positive release runs are intentionally post-merge acceptance evidence.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code, browser request, or rendered state changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, model, provider, or action behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [20701-staging-certification-evidence-9ee4142.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20701-staging-certification-evidence-9ee4142.log)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Known gaps / failures

- No production or provider mutation was performed while preparing this PR. After merge, acceptance requires one negative production dispatch proving the gate fails before production approval/mutation, then an exact-tree successful staging release that emits a certificate, followed by the separately approved positive production release.
- Raw actionlint does not understand the repository's pre-existing `concurrency.queue: max` extension. The exact workflow passes actionlint when only that unchanged parser diagnostic is ignored.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@9b62def2e89ac24d1e643e8549c3c990507c3d67:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@9b62def2e89ac24d1e643e8549c3c990507c3d67:packages/skills/skills/contribute-to-eliza"} -->

