### PR TITLE
fix(app): expose local onboarding in ios-local builds

### DIFF
--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.mjs
@@ -1,8 +1,9 @@
 /**
  * Resolves renderer feature flags and cache policy for mobile build lanes.
- * LP3 debug artifacts always enable the realtime voice client, while every
- * Android cloud-debug build starts from a fresh renderer because the current
- * lane stamp does not encode optional Vite feature flags.
+ * Local iOS artifacts expose the existing runtime chooser so a sideload can
+ * select its bundled agent without Cloud authentication. LP3 debug artifacts
+ * enable the realtime voice client, while lanes with optional flags start from
+ * a fresh renderer because the current stamp does not encode those flags.
  */
 
 const ANDROID_CLOUD_DEBUG = "android-cloud-debug";
@@ -10,6 +11,9 @@ const ANDROID_CLOUD_DEBUG = "android-cloud-debug";
 export function resolveMobileRendererFeatureEnv({ platform, env = {} } = {}) {
   if (typeof platform !== "string" || platform.length === 0) {
     throw new Error("resolveMobileRendererFeatureEnv: platform is required");
+  }
+  if (platform === "ios-local") {
+    return { VITE_ELIZA_ENABLE_RUNTIME_CHOOSER: "1" };
   }
   const isLp3Debug =
     platform === ANDROID_CLOUD_DEBUG &&
@@ -25,5 +29,5 @@ export function mobileRendererRequiresFreshBuild({ platform } = {}) {
   if (typeof platform !== "string" || platform.length === 0) {
     throw new Error("mobileRendererRequiresFreshBuild: platform is required");
   }
-  return platform === ANDROID_CLOUD_DEBUG;
+  return platform === ANDROID_CLOUD_DEBUG || platform === "ios-local";
 }

--- a/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
+++ b/packages/app-core/scripts/lib/mobile-renderer-feature-env.test.mts
@@ -1,6 +1,6 @@
 /**
- * Locks the mobile renderer feature boundary that keeps LP3 realtime voice in
- * the packaged APK and prevents cross-feature reuse of debug renderer output.
+ * Locks the mobile renderer feature boundaries for local iOS onboarding and
+ * LP3 realtime voice while preventing cross-feature renderer reuse.
  */
 import { describe, expect, it } from "vitest";
 import {
@@ -9,6 +9,16 @@ import {
 } from "./mobile-renderer-feature-env.mjs";
 
 describe("resolveMobileRendererFeatureEnv", () => {
+  it("enables the runtime chooser only for the local iOS lane", () => {
+    expect(resolveMobileRendererFeatureEnv({ platform: "ios-local" })).toEqual({
+      VITE_ELIZA_ENABLE_RUNTIME_CHOOSER: "1",
+    });
+
+    for (const platform of ["ios", "ios-overlay", "android"]) {
+      expect(resolveMobileRendererFeatureEnv({ platform })).toEqual({});
+    }
+  });
+
   it("enables the realtime voice client for the LP3 cloud-debug lane", () => {
     expect(
       resolveMobileRendererFeatureEnv({
@@ -47,11 +57,14 @@ describe("resolveMobileRendererFeatureEnv", () => {
 });
 
 describe("mobileRendererRequiresFreshBuild", () => {
-  it("rebuilds cloud-debug renderers because their optional flags are not stamped", () => {
+  it("rebuilds renderers whose optional flags are not stamped", () => {
     expect(
       mobileRendererRequiresFreshBuild({ platform: "android-cloud-debug" }),
     ).toBe(true);
-    for (const platform of ["android", "android-cloud", "ios", "ios-local"]) {
+    expect(mobileRendererRequiresFreshBuild({ platform: "ios-local" })).toBe(
+      true,
+    );
+    for (const platform of ["android", "android-cloud", "ios"]) {
       expect(mobileRendererRequiresFreshBuild({ platform })).toBe(false);
     }
   });

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -1163,7 +1163,7 @@ async function buildWeb(platform) {
     requiresFreshRenderer
   ) {
     console.log(
-      `[mobile-build] Rebuilding renderer for '${platform}': debug feature flags require fresh output.`,
+      `[mobile-build] Rebuilding renderer for '${platform}': lane-specific feature flags require fresh output.`,
     );
   }
   if (process.env.ELIZA_MOBILE_SKIP_WEB_BUILD === "1") {


### PR DESCRIPTION
Closes #20319.

## Review result

The build-policy change is the narrow fix: only `ios-local` receives `VITE_ELIZA_ENABLE_RUNTIME_CHOOSER=1`, and only that lane joins the existing fresh-renderer policy. App Store/cloud iOS and Android behavior remain unchanged.

## Exact-head proof

Candidate `8b974daa693d5990536294dc60f8d75de64b5a05`, rebased on `d53100a07e6f02d3eac18af36f01401f1ca18bd5`.

- focused policy tests: 6/6 PASS
- `packages/app-core` typecheck: PASS
- `packages/app` typecheck: PASS
- exact three-file Biome: PASS
- `git diff --check`: PASS
- `bun run --cwd packages/app build:ios:local:sim`: PASS (`** BUILD SUCCEEDED **`)
- packaged renderer manifest commit: `8b974daa693d5990536294dc60f8d75de64b5a05`
- packaged renderer mode: `runtimeMode=local`, `capacitorTarget=ios`
- packaged Vite environment: `VITE_ELIZA_ENABLE_RUNTIME_CHOOSER=1`
- clean install on booted iOS 26.4 simulator: PASS; fresh first-run visibly offered `Eliza Cloud (managed)`, `On this device`, and `Connect to a remote agent`

The simulator full-Bun slice passed its runtime validation. The build correctly continued only for Simulator while retaining the existing strict rejection of the current full-Bun device/App Store slice; this PR does not widen that boundary.

No Cloud, provider, production, App Store, credential, or deployment state was changed.

## Contribution provenance

- AI provider/model: OpenAI / gpt-5.6-sol
- Client / agent tooling: Codex Desktop
- Attribution status: self-reported

<!-- evidence-head:8b974daa693d5990536294dc60f8d75de64b5a05 -->
