### PR TITLE
feat(shell): gate the cloud-only home pill behind Cloud sign-in (#20483)

### DIFF
--- a/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.test.ts
@@ -1,12 +1,15 @@
 /** Exercises desktop bottom bar config behavior with deterministic app-core test fixtures. */
 import { describe, expect, it } from "vitest";
 import {
+  AUTH_GATE_BOTTOM_BAR_HEIGHT,
+  AUTH_GATE_BOTTOM_BAR_WIDTH,
   appendChatOverlayShellModeParam,
   computeBottomBarFrame,
   DEFAULT_BOTTOM_BAR_HEIGHT,
   DEFAULT_BOTTOM_BAR_WIDTH,
   EXPANDED_BOTTOM_BAR_HEIGHT,
   EXPANDED_BOTTOM_BAR_WIDTH,
+  resolveBottomBarFrameSize,
   resolveDesktopShellWindowPresentation,
   shouldReanchorBottomBar,
   shouldStartBottomBar,
@@ -102,6 +105,25 @@ describe("desktop bottom-bar config", () => {
         { height: 1 },
       );
       expect(frame.height).toBe(48);
+    });
+
+    it("resolves rest, sign-in chip, and expanded sizes", () => {
+      expect(resolveBottomBarFrameSize({ expanded: false })).toEqual({
+        width: DEFAULT_BOTTOM_BAR_WIDTH,
+        height: DEFAULT_BOTTOM_BAR_HEIGHT,
+      });
+      expect(
+        resolveBottomBarFrameSize({ expanded: false, chip: true }),
+      ).toEqual({
+        width: AUTH_GATE_BOTTOM_BAR_WIDTH,
+        height: AUTH_GATE_BOTTOM_BAR_HEIGHT,
+      });
+      expect(resolveBottomBarFrameSize({ expanded: true, chip: true })).toEqual(
+        {
+          width: EXPANDED_BOTTOM_BAR_WIDTH,
+          height: EXPANDED_BOTTOM_BAR_HEIGHT,
+        },
+      );
     });
 
     it("constrains the expanded chat hit area instead of spanning the display", () => {

--- a/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-bottom-bar-config.ts
@@ -115,9 +115,42 @@ export function resolveDesktopShellWindowPresentation(
 export const DEFAULT_BOTTOM_BAR_WIDTH = 96;
 export const DEFAULT_BOTTOM_BAR_HEIGHT = 56;
 
+/** Intermediate hit area around the cloud-only "Sign in to Eliza" chip. */
+export const AUTH_GATE_BOTTOM_BAR_WIDTH = 240;
+export const AUTH_GATE_BOTTOM_BAR_HEIGHT = DEFAULT_BOTTOM_BAR_HEIGHT;
+
 /** Expanded native hit area around the 560×640 glass panel and bottom pill. */
 export const EXPANDED_BOTTOM_BAR_WIDTH = 600;
 export const EXPANDED_BOTTOM_BAR_HEIGHT = 820;
+
+export interface BottomBarSizeOptions {
+  expanded: boolean;
+  /** Labeled needs-auth chip. Ignored while the overlay is expanded. */
+  chip?: boolean;
+}
+
+/** Resolve the native bottom-bar size for rest, sign-in chip, or overlay. */
+export function resolveBottomBarFrameSize(options: BottomBarSizeOptions): {
+  width: number;
+  height: number;
+} {
+  if (options.expanded) {
+    return {
+      width: EXPANDED_BOTTOM_BAR_WIDTH,
+      height: EXPANDED_BOTTOM_BAR_HEIGHT,
+    };
+  }
+  if (options.chip) {
+    return {
+      width: AUTH_GATE_BOTTOM_BAR_WIDTH,
+      height: AUTH_GATE_BOTTOM_BAR_HEIGHT,
+    };
+  }
+  return {
+    width: DEFAULT_BOTTOM_BAR_WIDTH,
+    height: DEFAULT_BOTTOM_BAR_HEIGHT,
+  };
+}
 
 /**
  * Compute a bottom-centered window frame that is no larger than the visible

--- a/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop-window.test.ts
@@ -408,6 +408,9 @@ describe("DesktopManager main window controls", () => {
 
     await manager.setBottomBarExpanded({ expanded: false });
     expect(window.setFrame).toHaveBeenLastCalledWith(502, 694, 96, 56);
+
+    await manager.setBottomBarExpanded({ expanded: false, chip: true });
+    expect(window.setFrame).toHaveBeenLastCalledWith(430, 694, 240, 56);
     await manager.dispose();
   });
 

--- a/packages/app-core/platforms/electrobun/src/native/desktop.ts
+++ b/packages/app-core/platforms/electrobun/src/native/desktop.ts
@@ -46,8 +46,7 @@ import { getBrandConfig } from "../brand-config";
 import type { DatabaseSnapshot } from "../database";
 import {
   computeBottomBarFrame,
-  EXPANDED_BOTTOM_BAR_HEIGHT,
-  EXPANDED_BOTTOM_BAR_WIDTH,
+  resolveBottomBarFrameSize,
   type ScreenWorkArea,
   shouldReanchorBottomBar,
 } from "../desktop-bottom-bar-config";
@@ -377,6 +376,7 @@ export class DesktopManager {
   private bottomBarReanchorEnabled = false;
   private bottomBarWorkArea: ScreenWorkArea | null = null;
   private bottomBarPoller: ReturnType<typeof setInterval> | null = null;
+  private bottomBarSize = resolveBottomBarFrameSize({ expanded: false });
 
   // Callback to open the settings window (set by index.ts)
   private openSettingsCallback: ((tabHint?: string) => void) | null = null;
@@ -1538,15 +1538,16 @@ X-GNOME-Autostart-enabled=true
   }
 
   /** Expand/collapse the managed chat window without losing its bottom anchor. */
-  async setBottomBarExpanded(options: { expanded: boolean }): Promise<void> {
+  async setBottomBarExpanded(options: {
+    expanded: boolean;
+    chip?: boolean;
+  }): Promise<void> {
     if (!this.bottomBarReanchorEnabled) return;
     const win = this.mainWindow;
     const workArea = this.readPrimaryWorkArea();
     if (!win || !workArea) return;
-    const frame = computeBottomBarFrame(workArea, {
-      width: options.expanded ? EXPANDED_BOTTOM_BAR_WIDTH : undefined,
-      height: options.expanded ? EXPANDED_BOTTOM_BAR_HEIGHT : undefined,
-    });
+    this.bottomBarSize = resolveBottomBarFrameSize(options);
+    const frame = computeBottomBarFrame(workArea, this.bottomBarSize);
     win.setFrame(frame.x, frame.y, frame.width, frame.height);
     this.bottomBarWorkArea = workArea;
   }
@@ -1580,7 +1581,7 @@ X-GNOME-Autostart-enabled=true
     ) {
       return;
     }
-    const frame = computeBottomBarFrame(nextWorkArea);
+    const frame = computeBottomBarFrame(nextWorkArea, this.bottomBarSize);
     win.setFrame(frame.x, frame.y, frame.width, frame.height);
     this.bottomBarWorkArea = nextWorkArea;
   }

--- a/packages/app-core/platforms/electrobun/src/rpc-schema.ts
+++ b/packages/app-core/platforms/electrobun/src/rpc-schema.ts
@@ -1454,7 +1454,7 @@ export type ElizaDesktopRPCSchema = {
       desktopGetWindowBounds: { params: undefined; response: WindowBounds };
       desktopSetWindowBounds: { params: WindowBounds; response: undefined };
       desktopSetBottomBarExpanded: {
-        params: { expanded: boolean };
+        params: { expanded: boolean; chip?: boolean };
         response: undefined;
       };
       desktopMinimizeWindow: { params: undefined; response: undefined };

--- a/packages/app-core/platforms/electrobun/src/shell-sync-relay.ts
+++ b/packages/app-core/platforms/electrobun/src/shell-sync-relay.ts
@@ -293,9 +293,11 @@ export function isShellControllerSnapshot(value: unknown): boolean {
   const model = value.modelStatus;
   return (
     (phase === "booting" ||
+      phase === "needs-auth" ||
       phase === "idle" ||
       phase === "summoned" ||
       phase === "listening" ||
+      phase === "processing" ||
       phase === "responding") &&
     typeof value.responding === "boolean" &&
     (value.turnStatus === null || isRecord(value.turnStatus)) &&

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1802,6 +1802,7 @@ function ShellFoundationMount() {
   const controller = useShellControllerContext();
   const hasController = controller !== null;
   const shellIsOpen = controller?.isOpen ?? false;
+  const shellNeedsAuth = controller?.phase === "needs-auth";
   const { setChatInput } = useChatComposer();
   const chatInputRef = useChatInputRef();
   // Push-to-talk dictation on the ChatSurface mic drops its transcript into
@@ -1830,6 +1831,10 @@ function ShellFoundationMount() {
     const onToggle = () => {
       const shell = controllerRef.current;
       if (!shell) return;
+      if (shell.authGate.gated) {
+        shell.requestSignIn();
+        return;
+      }
       if (shell.recording) {
         playCaptureSendCue();
         shell.stopRecording();
@@ -1859,6 +1864,10 @@ function ShellFoundationMount() {
       if (!detail || typeof detail.held !== "boolean") return;
       if (detail.held) {
         if (fnHoldActiveRef.current || shell.recording) return;
+        if (shell.authGate.gated) {
+          shell.requestSignIn();
+          return;
+        }
         fnHoldActiveRef.current = true;
         playCaptureStartCue();
         shell.startRecording("ptt");
@@ -1886,7 +1895,7 @@ function ShellFoundationMount() {
       await invokeDesktopBridgeRequestWithTimeout<undefined>({
         rpcMethod: "desktopSetBottomBarExpanded",
         ipcChannel: "desktop:setBottomBarExpanded",
-        params: { expanded: shellIsOpen },
+        params: { expanded: shellIsOpen, chip: shellNeedsAuth },
         timeoutMs: 1_000,
       });
     })();
@@ -1894,7 +1903,7 @@ function ShellFoundationMount() {
     return () => {
       cancelled = true;
     };
-  }, [hasController, shellIsOpen]);
+  }, [hasController, shellIsOpen, shellNeedsAuth]);
   if (!controller) return null;
 
   return (
@@ -1902,15 +1911,21 @@ function ShellFoundationMount() {
       <HomePill
         phase={controller.phase}
         speaking={controller.speaking}
+        signingIn={controller.signingIn}
         onOpen={controller.open}
         onClose={controller.close}
         onHoldStart={() => {
+          if (controller.authGate.gated) {
+            controller.requestSignIn();
+            return;
+          }
           // Audible mic-open ping BEFORE capture spins up: the cue is the
           // "start talking" signal, so it must not wait on getUserMedia.
           playCaptureStartCue();
           controller.startRecording("ptt");
         }}
         onHoldEnd={() => {
+          if (controller.authGate.gated) return;
           playCaptureSendCue();
           controller.stopRecording();
         }}

--- a/packages/ui/src/components/shell/HomePill.stories.tsx
+++ b/packages/ui/src/components/shell/HomePill.stories.tsx
@@ -32,6 +32,10 @@ export const Idle: Story = {
 };
 
 export const Booting: Story = { args: { phase: "booting" } };
+export const NeedsAuth: Story = { args: { phase: "needs-auth" } };
+export const NeedsAuthSigningIn: Story = {
+  args: { phase: "needs-auth", signingIn: true },
+};
 export const Summoned: Story = { args: { phase: "summoned" } };
 export const Listening: Story = { args: { phase: "listening" } };
 export const Processing: Story = { args: { phase: "processing" } };

--- a/packages/ui/src/components/shell/HomePill.tsx
+++ b/packages/ui/src/components/shell/HomePill.tsx
@@ -10,6 +10,9 @@
  * nothing for the user to remember or un-stick. Cancel affordances: Escape
  * mid-hold, or sliding the pointer more than {@link SLIDE_CANCEL_PX} off the
  * pill before releasing.
+ *
+ * On a cloud-only build the `needs-auth` phase replaces both gestures with a
+ * labeled chip that launches Cloud sign-in. Hold is not armed there.
  */
 import * as React from "react";
 
@@ -34,6 +37,9 @@ export interface HomePillProps {
   /** True while the assistant reply is being spoken aloud. Sharpens the
    *  responding glow so "speaking" and "thinking" read differently. */
   speaking?: boolean;
+  /** True while Cloud sign-in is in flight from this pill. Pulses the
+   *  `needs-auth` chip so the wait is visible. */
+  signingIn?: boolean;
 }
 
 /** How long the pointer must stay down before a press becomes a hold. Above
@@ -80,6 +86,7 @@ const PROCESS_DOTS = [
  * Each shell phase reads distinctly at a glance (the capsule is the only
  * always-visible surface, so it carries all ambient status):
  *   booting     — dim pulsing handle ("waking up").
+ *   needs-auth  — dark labeled chip ("Sign in to {appName}").
  *   idle        — solid white handle ("here, ready").
  *   listening   — dark chip, live waveform bars ("mic is hot").
  *   processing  — dark chip, pulsing dots — mic closed,
@@ -97,8 +104,10 @@ export function HomePill({
   onHoldEnd,
   onHoldCancel,
   speaking = false,
+  signingIn = false,
 }: HomePillProps): React.JSX.Element {
   const { appName } = useBranding();
+  const needsAuth = phase === "needs-auth";
   // The pill reads as "open" (its click will close) only for the overlay
   // surfaces. `listening` is deliberately NOT included: hold-to-talk runs with
   // the overlay closed, and treating it as open would flash the label/pressed
@@ -125,6 +134,7 @@ export function HomePill({
 
   const handlePointerDown = React.useCallback(
     (event: React.PointerEvent<HTMLButtonElement>) => {
+      if (needsAuth) return;
       if (!onHoldStartRef.current) return;
       // Primary button/touch only; a right-click must not open the mic.
       if (event.pointerType === "mouse" && event.button !== 0) return;
@@ -148,7 +158,7 @@ export function HomePill({
         onHoldStartRef.current?.();
       }, HOLD_THRESHOLD_MS);
     },
-    [clearHoldTimer],
+    [clearHoldTimer, needsAuth],
   );
 
   const handlePointerUp = React.useCallback(
@@ -205,9 +215,12 @@ export function HomePill({
     else onOpen();
   }, [isOpen, onOpen, onClose]);
 
-  const chipExpanded = phase === "listening" || phase === "processing";
-  const label =
-    phase === "listening"
+  const signInLabel = `Sign in to ${appName}`;
+  const chipExpanded =
+    phase === "listening" || phase === "processing" || needsAuth;
+  const label = needsAuth
+    ? signInLabel
+    : phase === "listening"
       ? `${appName} is listening — release to send`
       : phase === "processing"
         ? `${appName} is transcribing your words`
@@ -231,7 +244,8 @@ export function HomePill({
       onPointerCancel={handlePointerCancel}
       style={{ zIndex: Z_SHELL_OVERLAY }}
       className={cn(
-        "group pointer-events-auto relative mb-2 flex h-8 w-16 items-center justify-center rounded-full bg-transparent p-0",
+        "group pointer-events-auto relative mb-2 flex h-8 items-center justify-center rounded-full bg-transparent p-0",
+        needsAuth ? "w-[13rem]" : "w-16",
         "transition-transform duration-200 hover:bg-transparent active:scale-95",
         "focus-visible:bg-transparent focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent",
       )}
@@ -242,15 +256,14 @@ export function HomePill({
         className={cn(
           "flex items-center justify-center rounded-full",
           "transition-[width,height,opacity,transform,background-color,box-shadow] duration-200",
-          // Listening/processing mirror the studied Wispr Flow bar: the capsule
-          // GROWS into a dark rounded chip — legible from across the room.
-          // Listening carries live bars; processing keeps the dark chip
-          // (continuity: "still your utterance") but swaps the bars for
-          // pulsing dots — the mic is CLOSED. Other phases stay the slim
-          // white handle.
-          chipExpanded
-            ? "h-7 w-20 gap-[3px] bg-neutral-900/95"
-            : "h-2.5 w-12 gap-[3px] bg-white/95 group-hover:w-14",
+          // Listening/processing/needs-auth grow the capsule into a dark chip.
+          // Listening carries live bars; processing swaps them for dots;
+          // needs-auth fills the chip with the sign-in label.
+          needsAuth
+            ? "h-7 min-w-[11.5rem] px-3 bg-neutral-900/95"
+            : chipExpanded
+              ? "h-7 w-20 gap-[3px] bg-neutral-900/95"
+              : "h-2.5 w-12 gap-[3px] bg-white/95 group-hover:w-14",
           chipExpanded && "shadow-[0_4px_16px_rgba(0,0,0,0.35)]",
           !chipExpanded &&
             (phase === "responding"
@@ -260,13 +273,21 @@ export function HomePill({
                   "shadow-[0_0_14px_rgba(255,138,42,0.85),0_0_0_1px_rgba(255,138,42,0.5)]"
                 : "shadow-[0_0_10px_rgba(255,138,42,0.6),0_0_0_1px_rgba(0,0,0,0.12)]"
               : "shadow-[0_0_0_1px_rgba(0,0,0,0.12)]"),
-          phase === "booting" &&
+          (phase === "booting" || (needsAuth && signingIn)) &&
             "animate-pulse opacity-65 motion-reduce:animate-none",
           phase === "responding" &&
             !speaking &&
             "animate-pulse opacity-90 motion-reduce:animate-none",
         )}
       >
+        {needsAuth && (
+          <span
+            data-testid="shell-home-pill-sign-in"
+            className="whitespace-nowrap text-[11px] font-medium tracking-tight text-white/95"
+          >
+            {signInLabel}
+          </span>
+        )}
         {phase === "listening" &&
           WAVE_BARS.map((bar) => (
             <span

--- a/packages/ui/src/components/shell/__e2e__/chat-sheet-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/chat-sheet-fixture.tsx
@@ -404,6 +404,9 @@ function Harness(): React.JSX.Element {
 
   const controller: ShellController = {
     phase,
+    authGate: { gated: false, phase: "clear" },
+    requestSignIn: () => {},
+    signingIn: false,
     // Raw in-flight predicate — mirrors the real controller's `chatSending ||
     // speaking`. In the fixture, "responding" phase stands in for chatSending and
     // `?speaking` for the spoken reply, so the trailing control + voice-gating

--- a/packages/ui/src/components/shell/__e2e__/perf-gate-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/perf-gate-fixture.tsx
@@ -152,6 +152,9 @@ function Harness(): React.JSX.Element {
 
   const controller: ShellController = {
     phase: "summoned",
+    authGate: { gated: false, phase: "clear" },
+    requestSignIn: () => {},
+    signingIn: false,
     messages,
     canSend: true,
     responding,

--- a/packages/ui/src/components/shell/__e2e__/warming-absorption-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/warming-absorption-fixture.tsx
@@ -202,6 +202,9 @@ function Harness(): React.JSX.Element {
 
   const controller: ShellController = {
     phase: "summoned",
+    authGate: { gated: false, phase: "clear" },
+    requestSignIn: () => {},
+    signingIn: false,
     responding: chatSending,
     turnStatus: turnStatus ?? (chatSending ? { kind: "thinking" as const } : null),
     messages,

--- a/packages/ui/src/components/shell/__e2e__/warmup-eviction-fixture.tsx
+++ b/packages/ui/src/components/shell/__e2e__/warmup-eviction-fixture.tsx
@@ -188,6 +188,9 @@ function Harness(): React.JSX.Element {
 
   const controller: ShellController = {
     phase: "summoned",
+    authGate: { gated: false, phase: "clear" },
+    requestSignIn: () => {},
+    signingIn: false,
     responding: chatSending,
     turnStatus: chatSending ? { kind: "thinking" as const } : null,
     messages,

--- a/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
@@ -54,6 +54,7 @@ describe("HomePill", () => {
 
   it.each<ShellPhase>([
     "booting",
+    "needs-auth",
     "idle",
     "summoned",
     "listening",
@@ -178,6 +179,44 @@ describe("HomePill", () => {
     expect(mark.className).not.toContain("animate-pulse");
   });
 
+  it("grows into a labeled sign-in chip while needs-auth and does not arm hold", () => {
+    const onOpen = vi.fn();
+    const hold = holdHandlers();
+    render(
+      <HomePill
+        phase="needs-auth"
+        onOpen={onOpen}
+        onClose={() => {}}
+        {...hold}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /sign in to eliza/i });
+    expect(btn.getAttribute("data-phase")).toBe("needs-auth");
+    expect(screen.getByTestId("shell-home-pill-sign-in").textContent).toBe(
+      "Sign in to Eliza",
+    );
+    const mark = screen.getByTestId("shell-home-pill-mark");
+    expect(mark.className).toContain("bg-neutral-900/95");
+    expect(mark.className).toContain("min-w-[11.5rem]");
+    expect(screen.queryAllByTestId("shell-home-pill-wave-bar")).toHaveLength(0);
+    fireEvent.click(btn);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("pulses the sign-in chip while Cloud login is in flight", () => {
+    render(
+      <HomePill
+        phase="needs-auth"
+        signingIn
+        onOpen={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("shell-home-pill-mark").className).toContain(
+      "animate-pulse",
+    );
+  });
+
   it("stays available while booting and opens on click", () => {
     const onOpen = vi.fn();
     render(<HomePill phase="booting" onOpen={onOpen} onClose={() => {}} />);
@@ -283,6 +322,27 @@ describe("HomePill hold-to-talk quasimode (#20483)", () => {
     fireEvent.pointerCancel(btn);
     expect(hold.onHoldCancel).toHaveBeenCalledTimes(1);
     expect(hold.onHoldEnd).not.toHaveBeenCalled();
+  });
+
+  it("needs-auth never arms the hold, even when hold handlers are provided", () => {
+    const onOpen = vi.fn();
+    const hold = holdHandlers();
+    render(
+      <HomePill
+        phase="needs-auth"
+        onOpen={onOpen}
+        onClose={() => {}}
+        {...hold}
+      />,
+    );
+    const btn = screen.getByRole("button");
+    fireEvent.pointerDown(btn, { button: 0, clientX: 10, clientY: 10 });
+    vi.advanceTimersByTime(HOLD_THRESHOLD_MS + 200);
+    fireEvent.pointerUp(btn, { clientX: 10, clientY: 10 });
+    fireEvent.click(btn);
+    expect(hold.onHoldStart).not.toHaveBeenCalled();
+    expect(hold.onHoldEnd).not.toHaveBeenCalled();
+    expect(onOpen).toHaveBeenCalledTimes(1);
   });
 
   it("a right-click press never arms the hold", () => {

--- a/packages/ui/src/components/shell/__tests__/shell-auth-gate.test.ts
+++ b/packages/ui/src/components/shell/__tests__/shell-auth-gate.test.ts
@@ -1,0 +1,118 @@
+/** Verifies the cloud-only pill auth-gate matrix through the package harness. */
+// Pure deriveShellAuthGate + deriveShellPhase decisions. No React, no network.
+
+import { describe, expect, it } from "vitest";
+import type { AuthStatusState } from "../../../hooks/useAuthStatus";
+import {
+  deriveShellAuthGate,
+  deriveShellPhase,
+  type ShellAuthGatePhase,
+} from "../shell-auth-gate";
+import type { ShellPhase } from "../shell-state";
+
+const AUTH_PHASES: AuthStatusState["phase"][] = [
+  "loading",
+  "authenticated",
+  "unauthenticated",
+  "server_unavailable",
+];
+
+describe("deriveShellAuthGate", () => {
+  it("never gates a non-cloud-only build, including a local owner-key session", () => {
+    for (const authPhase of AUTH_PHASES) {
+      expect(deriveShellAuthGate({ cloudOnly: false, authPhase })).toEqual({
+        gated: false,
+        phase: "clear",
+      });
+    }
+  });
+
+  it("treats cloud-only authenticated as clear", () => {
+    expect(
+      deriveShellAuthGate({ cloudOnly: true, authPhase: "authenticated" }),
+    ).toEqual({ gated: false, phase: "clear" });
+  });
+
+  it("treats cloud-only unauthenticated as needs-auth", () => {
+    expect(
+      deriveShellAuthGate({ cloudOnly: true, authPhase: "unauthenticated" }),
+    ).toEqual({ gated: true, phase: "needs-auth" });
+  });
+
+  it("keeps loading and server_unavailable on checking so the chip cannot flash", () => {
+    expect(
+      deriveShellAuthGate({ cloudOnly: true, authPhase: "loading" }),
+    ).toEqual({ gated: true, phase: "checking" });
+    expect(
+      deriveShellAuthGate({
+        cloudOnly: true,
+        authPhase: "server_unavailable",
+      }),
+    ).toEqual({ gated: true, phase: "checking" });
+  });
+});
+
+describe("deriveShellPhase", () => {
+  const idleInputs = {
+    ready: true,
+    recording: false,
+    realtimeVoiceListening: false,
+    sttPending: false,
+    responding: false,
+    isOpen: false,
+    authGate: "clear" as ShellAuthGatePhase,
+  };
+
+  it("keeps checking on booting even when the agent proxy is up", () => {
+    expect(
+      deriveShellPhase({ ...idleInputs, ready: true, authGate: "checking" }),
+    ).toBe("booting");
+  });
+
+  it("surfaces needs-auth even before the agent proxy is up", () => {
+    expect(
+      deriveShellPhase({
+        ...idleInputs,
+        ready: false,
+        authGate: "needs-auth",
+      }),
+    ).toBe("needs-auth");
+  });
+
+  it("surfaces needs-auth above listening and summon once the proxy is up", () => {
+    expect(
+      deriveShellPhase({
+        ...idleInputs,
+        authGate: "needs-auth",
+        recording: true,
+        isOpen: true,
+      }),
+    ).toBe("needs-auth");
+  });
+
+  it("keeps an already-open overlay summoned while the probe is still checking", () => {
+    expect(
+      deriveShellPhase({
+        ...idleInputs,
+        ready: false,
+        isOpen: true,
+        authGate: "checking",
+      }),
+    ).toBe("summoned");
+  });
+
+  it("preserves the existing waterfall when the gate is clear", () => {
+    const cases: Array<[Partial<typeof idleInputs>, ShellPhase]> = [
+      [{ ready: false }, "booting"],
+      [{ recording: true }, "listening"],
+      [{ realtimeVoiceListening: true }, "listening"],
+      [{ sttPending: true }, "processing"],
+      [{ responding: true }, "responding"],
+      [{ isOpen: true }, "summoned"],
+      [{}, "idle"],
+    ];
+    for (const [override, expected] of cases) {
+      expect(deriveShellPhase({ ...idleInputs, ...override })).toBe(expected);
+    }
+  });
+});

--- a/packages/ui/src/components/shell/__tests__/useShellAuthGate.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellAuthGate.test.tsx
@@ -1,0 +1,51 @@
+/** Verifies useShellAuthGate against the shared auth snapshot. */
+// @vitest-environment jsdom
+//
+// Thin React binding over deriveShellAuthGate. Real hook; branding and the
+// auth snapshot are injected through their public test/context seams.
+
+import { cleanup, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { BrandingConfig } from "../../../config/branding-base";
+import { DEFAULT_BRANDING } from "../../../config/branding-base";
+import { BrandingContext } from "../../../config/branding-react.hooks";
+import {
+  __resetAuthStatusForTests,
+  __setAuthStatusForTests,
+} from "../../../hooks/useAuthStatus";
+import { useShellAuthGate } from "../useShellAuthGate";
+
+function wrapperFor(cloudOnly: boolean) {
+  const branding: BrandingConfig = { ...DEFAULT_BRANDING, cloudOnly };
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <BrandingContext.Provider value={branding}>
+        {children}
+      </BrandingContext.Provider>
+    );
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  __resetAuthStatusForTests();
+});
+
+describe("useShellAuthGate", () => {
+  it("stays clear on a local-runtime build even when the snapshot is unauthenticated", () => {
+    __setAuthStatusForTests({ phase: "unauthenticated" });
+    const { result } = renderHook(() => useShellAuthGate(), {
+      wrapper: wrapperFor(false),
+    });
+    expect(result.current).toEqual({ gated: false, phase: "clear" });
+  });
+
+  it("gates a cloud-only unauthenticated snapshot as needs-auth", () => {
+    __setAuthStatusForTests({ phase: "unauthenticated" });
+    const { result } = renderHook(() => useShellAuthGate(), {
+      wrapper: wrapperFor(true),
+    });
+    expect(result.current).toEqual({ gated: true, phase: "needs-auth" });
+  });
+});

--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -2516,4 +2516,101 @@ describe("useShellController cloud-only auth gate", () => {
 
     expect(login).not.toHaveBeenCalled();
   });
+
+  it("sign-out is terminal for hands-free: no auto re-listen after re-login", async () => {
+    vi.useFakeTimers();
+    try {
+      installFakeCapture();
+      micPermissionMock.state = "unknown";
+      const { result, rerender } = renderHook(() => useShellController());
+
+      // Engage the batch hands-free loop while signed in.
+      await act(async () => {
+        result.current.toggleHandsFree();
+      });
+      expect(result.current.handsFree).toBe(true);
+      expect(createVoiceCaptureMock).toHaveBeenCalledTimes(1);
+
+      // Session expires mid-conversation: the gate must tear down hands-free
+      // (state + persisted mode), not just the in-flight capture.
+      authGateMock.value = { gated: true, phase: "needs-auth" };
+      act(() => rerender());
+      expect(result.current.handsFree).toBe(false);
+      expect(result.current.recording).toBe(false);
+      expect(
+        window.localStorage.getItem("eliza:voice:continuous-chat-mode"),
+      ).not.toBe("always-on");
+
+      // Re-login clears the gate. The re-listen loop and the boot auto-engage
+      // must both stay quiet — reopening the mic requires a fresh gesture.
+      createVoiceCaptureMock.mockClear();
+      authGateMock.value = { gated: false, phase: "clear" };
+      act(() => rerender());
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+        await Promise.resolve();
+      });
+      expect(createVoiceCaptureMock).not.toHaveBeenCalled();
+      expect(result.current.handsFree).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("always-on boot restore aborts when the gate closes during the permission probe", async () => {
+    vi.useFakeTimers();
+    try {
+      installFakeCapture();
+      micPermissionMock.state = "unknown";
+      // A persisted always-on session from a previous signed-in run.
+      window.localStorage.setItem(
+        "eliza:voice:continuous-chat-mode",
+        "always-on",
+      );
+
+      // Mount signed-in: the boot restore arms and awaits the async
+      // permission probe.
+      const { result, rerender } = renderHook(() => useShellController());
+
+      // The probe races a sign-out: the gate closes before it resolves.
+      authGateMock.value = { gated: true, phase: "needs-auth" };
+      act(() => rerender());
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // The continuation must not light hands-free, summon the overlay, or
+      // open a capture against the closed gate.
+      expect(result.current.handsFree).toBe(false);
+      expect(result.current.isOpen).toBe(false);
+      expect(createVoiceCaptureMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("always-on boot restore never arms while signed out", async () => {
+    vi.useFakeTimers();
+    try {
+      installFakeCapture();
+      micPermissionMock.state = "unknown";
+      window.localStorage.setItem(
+        "eliza:voice:continuous-chat-mode",
+        "always-on",
+      );
+      authGateMock.value = { gated: true, phase: "needs-auth" };
+
+      const { result } = renderHook(() => useShellController());
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(result.current.handsFree).toBe(false);
+      expect(createVoiceCaptureMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -112,6 +112,7 @@ const appMock = vi.hoisted(() => ({
     uiLanguage: "en",
     elizaCloudConnected: false,
     elizaCloudVoiceProxyAvailable: false,
+    handleInteractiveCloudLogin: vi.fn(async () => {}),
   },
   // Live server-reported turn status (#8813), read via useChatTurnStatus().
   serverTurnStatus: null as { kind: string } | null,
@@ -303,8 +304,24 @@ vi.mock("../../../voice/useWakeListenWindow", () => ({
   },
 }));
 
+const authGateMock = vi.hoisted(() => ({
+  value: {
+    gated: false,
+    phase: "clear" as "checking" | "needs-auth" | "clear",
+  },
+}));
+
+vi.mock("../useShellAuthGate", () => ({
+  useShellAuthGate: () => authGateMock.value,
+}));
+
+vi.mock("../../../state/cloud-login-launch", () => ({
+  claimCloudLoginWindow: vi.fn(() => null),
+}));
+
 afterEach(() => {
   cleanup();
+  authGateMock.value = { gated: false, phase: "clear" };
   appMock.value.startupCoordinator.phase = "ready";
   appMock.value.activeConversationId = null;
   appMock.value.conversationMessages = [];
@@ -2459,5 +2476,44 @@ describe("useShellController — mounted Cartesia Talk ownership", () => {
     } finally {
       window.removeEventListener(NAVIGATE_VIEW_EVENT, onNavigate);
     }
+  });
+});
+
+describe("useShellController cloud-only auth gate", () => {
+  it("stays booting while the auth probe is checking, even when the proxy is ready", () => {
+    authGateMock.value = { gated: true, phase: "checking" };
+    const { result } = renderHook(() => useShellController());
+    expect(result.current.phase).toBe("booting");
+    expect(result.current.authGate.gated).toBe(true);
+  });
+
+  it("surfaces needs-auth and routes open + startRecording to sign-in", () => {
+    authGateMock.value = { gated: true, phase: "needs-auth" };
+    const login = appMock.value.handleInteractiveCloudLogin;
+    login.mockClear();
+    const { result } = renderHook(() => useShellController());
+    expect(result.current.phase).toBe("needs-auth");
+
+    act(() => {
+      result.current.open();
+      result.current.startRecording("ptt");
+    });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(createVoiceCaptureMock).not.toHaveBeenCalled();
+    expect(login).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not launch sign-in from a checking probe", () => {
+    authGateMock.value = { gated: true, phase: "checking" };
+    const login = appMock.value.handleInteractiveCloudLogin;
+    login.mockClear();
+    const { result } = renderHook(() => useShellController());
+
+    act(() => {
+      result.current.requestSignIn();
+    });
+
+    expect(login).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/shell/shell-auth-gate.ts
+++ b/packages/ui/src/components/shell/shell-auth-gate.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure auth-gate decision for the desktop home pill on cloud-only builds.
+ *
+ * Local-runtime products inject an owner API key before React mounts, so a raw
+ * `authenticated` probe is not "signed in to Cloud". The gate therefore applies
+ * only when branding `cloudOnly` is true; every other build leaves the pill
+ * machine unchanged.
+ */
+
+import type { AuthStatusState } from "../../hooks/useAuthStatus";
+import type { ShellPhase } from "./shell-state";
+
+/** Discriminated rest-state of the cloud-only pill auth gate. */
+export type ShellAuthGatePhase = "checking" | "needs-auth" | "clear";
+
+export interface ShellAuthGate {
+  /** True while capture, overlay summon, and hotkeys must not run. */
+  gated: boolean;
+  phase: ShellAuthGatePhase;
+}
+
+export interface DeriveShellAuthGateInput {
+  cloudOnly: boolean;
+  authPhase: AuthStatusState["phase"];
+}
+
+export interface DeriveShellPhaseInput {
+  ready: boolean;
+  recording: boolean;
+  realtimeVoiceListening: boolean;
+  sttPending: boolean;
+  responding: boolean;
+  isOpen: boolean;
+  authGate: ShellAuthGatePhase;
+}
+
+/**
+ * Compose branding + the shared auth snapshot into the pill gate.
+ *
+ * `loading` and `server_unavailable` stay on `checking` so a slow probe never
+ * flashes the sign-in chip. The native-owner-key trap is the `cloudOnly`
+ * guard: without it a local desktop owner token would look like Cloud.
+ */
+export function deriveShellAuthGate(
+  input: DeriveShellAuthGateInput,
+): ShellAuthGate {
+  if (!input.cloudOnly) {
+    return { gated: false, phase: "clear" };
+  }
+  if (input.authPhase === "authenticated") {
+    return { gated: false, phase: "clear" };
+  }
+  if (input.authPhase === "unauthenticated") {
+    return { gated: true, phase: "needs-auth" };
+  }
+  return { gated: true, phase: "checking" };
+}
+
+/**
+ * Derive the pill phase. `needs-auth` sits above the live waterfall so a
+ * signed-out cloud-only pill cannot grow into the waveform chip. `checking`
+ * only holds the closed launcher on `booting` — an already-open overlay stays
+ * summoned, matching the pre-gate rule that `booting` is the closed rest
+ * state.
+ */
+export function deriveShellPhase(input: DeriveShellPhaseInput): ShellPhase {
+  if (input.authGate === "needs-auth") {
+    return "needs-auth";
+  }
+  if (
+    input.authGate === "checking" &&
+    !input.isOpen &&
+    !input.recording &&
+    !input.realtimeVoiceListening &&
+    !input.sttPending &&
+    !input.responding
+  ) {
+    return "booting";
+  }
+  if (input.recording || input.realtimeVoiceListening) {
+    return "listening";
+  }
+  if (input.sttPending) {
+    return "processing";
+  }
+  if (input.responding) {
+    return "responding";
+  }
+  if (input.isOpen) {
+    return "summoned";
+  }
+  return input.ready ? "idle" : "booting";
+}

--- a/packages/ui/src/components/shell/shell-controller-sync/__tests__/fixtures.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/__tests__/fixtures.ts
@@ -53,6 +53,9 @@ export function baseSnapshot(
 export function makeFakeShellController(): ShellController {
   return {
     phase: "idle",
+    authGate: { gated: false, phase: "clear" },
+    requestSignIn: vi.fn(),
+    signingIn: false,
     responding: false,
     turnStatus: null,
     messages: [],

--- a/packages/ui/src/components/shell/shell-controller-sync/follower-controller.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/follower-controller.ts
@@ -55,6 +55,12 @@ export function buildFollowerController(
 
   return {
     phase: snapshot.phase,
+    authGate:
+      snapshot.phase === "needs-auth"
+        ? { gated: true, phase: "needs-auth" }
+        : { gated: false, phase: "clear" },
+    requestSignIn: () => fire({ kind: "open" }),
+    signingIn: false,
     bootProgressSignal: snapshot.bootProgressSignal,
     responding: snapshot.responding,
     turnStatus: snapshot.turnStatus,

--- a/packages/ui/src/components/shell/shell-controller-sync/snapshot.ts
+++ b/packages/ui/src/components/shell/shell-controller-sync/snapshot.ts
@@ -14,7 +14,11 @@
 import type { ChatTurnStatus } from "../../../api/client-types-chat";
 import type { HomeModelStatus } from "../../../services/local-inference/home-model-status";
 import type { MicrophonePermissionState } from "../../../voice/local-asr-capture";
-import type { ShellMessage, ShellPhase } from "../shell-state";
+import {
+  isShellPhase,
+  type ShellMessage,
+  type ShellPhase,
+} from "../shell-state";
 import type { ShellController } from "../useShellController";
 
 /** The subset of {@link import("../conversation-nav").ConversationNav} that is
@@ -67,14 +71,7 @@ export function parseShellControllerSnapshot(
   const model = value.modelStatus;
   const messages = value.messages;
   if (
-    !(
-      phase === "booting" ||
-      phase === "idle" ||
-      phase === "summoned" ||
-      phase === "listening" ||
-      phase === "processing" ||
-      phase === "responding"
-    ) ||
+    !isShellPhase(phase) ||
     typeof value.responding !== "boolean" ||
     (value.turnStatus !== null && !isRecord(value.turnStatus)) ||
     !Array.isArray(messages) ||

--- a/packages/ui/src/components/shell/shell-state.test.ts
+++ b/packages/ui/src/components/shell/shell-state.test.ts
@@ -105,9 +105,11 @@ describe("selectVisibleShellMessages (#9141 gap 4 windowing)", () => {
   it("is exhaustive over ShellPhase for the empty-assistant exception", () => {
     const phases: ShellPhase[] = [
       "booting",
+      "needs-auth",
       "idle",
       "summoned",
       "listening",
+      "processing",
       "responding",
     ];
     const thread = [msg("u1", "user", "hi"), msg("a1", "assistant", "")];
@@ -126,9 +128,11 @@ describe("selectVisibleShellMessages (#9141 gap 4 windowing)", () => {
     };
     const phases: ShellPhase[] = [
       "booting",
+      "needs-auth",
       "idle",
       "summoned",
       "listening",
+      "processing",
       "responding",
     ];
     for (const phase of phases) {

--- a/packages/ui/src/components/shell/shell-state.ts
+++ b/packages/ui/src/components/shell/shell-state.ts
@@ -14,6 +14,9 @@ import type {
  * ChatSurface). Drives the pill's visual treatment.
  *
  *   booting    — startup not ready and popup closed; pill dim, no halo.
+ *                Also the cloud-only auth-probe rest (`checking`) so a slow
+ *                `/api/auth/me` never flashes the sign-in chip.
+ *   needs-auth — cloud-only, proxy up, no Cloud session; labeled sign-in chip.
  *   idle       — ready, no overlay; pill solid.
  *   summoned   — overlay open, no active mic/response; faint halo.
  *   listening  — push-to-talk capture in flight; dark chip + live bars.
@@ -24,13 +27,24 @@ import type {
  *   responding — agent stream in flight; ambient glow (the pill further
  *                differentiates speaking via its `speaking` prop).
  */
-export type ShellPhase =
-  | "booting"
-  | "idle"
-  | "summoned"
-  | "listening"
-  | "processing"
-  | "responding";
+export const SHELL_PHASES = [
+  "booting",
+  "needs-auth",
+  "idle",
+  "summoned",
+  "listening",
+  "processing",
+  "responding",
+] as const;
+
+export type ShellPhase = (typeof SHELL_PHASES)[number];
+
+export function isShellPhase(value: unknown): value is ShellPhase {
+  return (
+    typeof value === "string" &&
+    (SHELL_PHASES as readonly string[]).includes(value)
+  );
+}
 
 export interface ShellMessage {
   id: string;

--- a/packages/ui/src/components/shell/useShellAuthGate.ts
+++ b/packages/ui/src/components/shell/useShellAuthGate.ts
@@ -1,0 +1,23 @@
+/**
+ * React binding for {@link deriveShellAuthGate}: branding `cloudOnly` plus the
+ * shared auth snapshot, with no extra network traffic.
+ *
+ * Subscribe-only (`observeOnly`) so the pill can read the app-level
+ * `/api/auth/me` probe. The first-run conductor still owns the first sign-in
+ * card; this hook is the resting / recovery gate after that card is closed.
+ */
+
+import { useBranding } from "../../config/branding";
+import { useAuthStatus } from "../../hooks/useAuthStatus";
+import { deriveShellAuthGate, type ShellAuthGate } from "./shell-auth-gate";
+
+export function useShellAuthGate(): ShellAuthGate {
+  const { cloudOnly } = useBranding();
+  const { state } = useAuthStatus({ observeOnly: true });
+  return deriveShellAuthGate({
+    cloudOnly: cloudOnly === true,
+    authPhase: state.phase,
+  });
+}
+
+export type { ShellAuthGate, ShellAuthGatePhase } from "./shell-auth-gate";

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -479,6 +479,10 @@ export function useShellController(): ShellController {
     handleInteractiveCloudLogin,
   } = useAppSelectorShallow(selectShellController);
   const authGate = useShellAuthGate();
+  // Ref mirror for async continuations (permission probes, timers) that must
+  // read the gate as it is at fire time, not as it was when they were armed.
+  const authGateRef = React.useRef(authGate);
+  authGateRef.current = authGate;
   const [signingIn, setSigningIn] = React.useState(false);
   const signInInFlightRef = React.useRef(false);
   const requestSignIn = React.useCallback(() => {
@@ -1664,6 +1668,9 @@ export function useShellController(): ShellController {
     // hands-free state while startCapture correctly refuses Cloud ASR.
     if (realtimeVoiceEnabled) return;
     if (autoEngagedHandsFreeRef.current) return;
+    // Cloud-only signed out: leave the ref unset so a later sign-in retries
+    // this restore; auto-engage must not light hands-free against the gate.
+    if (authGate.gated) return;
     // Defer while a reply is mid-flight (voice is gated while responding); the
     // ref stays unset so this retries the instant `chatSending` clears.
     if (!ready || recording || captureRef.current || handsFree || chatSending)
@@ -1688,7 +1695,10 @@ export function useShellController(): ShellController {
       }
       // The probe is async: re-check the gating state so a capture that opened
       // via another path (or a hands-free toggle) during the await isn't
-      // double-opened / overridden.
+      // double-opened / overridden. The auth gate is re-read through the ref —
+      // sign-out during the await must not light hands-free or summon the
+      // overlay against a startCapture that will refuse.
+      if (authGateRef.current.gated) return;
       if (captureRef.current || handsFreeRef.current) return;
       setHandsFree(true);
       setIsOpen(true);
@@ -1702,6 +1712,7 @@ export function useShellController(): ShellController {
     startCapture,
     recheckMicPermission,
     realtimeVoiceEnabled,
+    authGate.gated,
   ]);
 
   // Populate the mic-permission state once on mount so a shell surface can
@@ -2565,11 +2576,25 @@ export function useShellController(): ShellController {
     if (visionCapturing && responding) setVisionCapturing(false);
   }, [visionCapturing, responding]);
 
+  // The auth boundary is terminal for the whole voice loop, not just the
+  // in-flight capture: hands-free and transcription state must fall too, or the
+  // re-listen loop / transcript-resume path silently reopens the mic the moment
+  // a later sign-in clears the gate — without a fresh voice gesture.
   React.useEffect(() => {
     if (!authGate.gated) return;
     if (captureRef.current) cancelCapture();
     if (isOpen) setIsOpen(false);
     stopRealtimeVoiceRef.current();
+    if (handsFreeRef.current) {
+      saveContinuousChatMode(priorContinuousModeRef.current);
+      setHandsFree(false);
+      handsFreeRef.current = false;
+    }
+    resumeHandsFreeAfterTranscriptRef.current = false;
+    if (transcriptionModeRef.current) {
+      setTranscriptionMode(false);
+      transcriptionModeRef.current = false;
+    }
   }, [authGate.gated, cancelCapture, isOpen]);
 
   const startRecording = React.useCallback(

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -1,7 +1,7 @@
 /**
  * The single stateful engine behind the shell's chat + voice surface, exposed as
  * the `ShellController` returned by `useShellController`. It drives the shell
- * phase (booting → summoned → listening → responding), the rendered message
+ * phase (booting → needs-auth → idle → summoned → listening → responding), the rendered message
  * list, send + vision-capture, and the whole voice stack: mic capture (via the
  * voice-capture factory), wake-word listening, end-of-turn aggregation,
  * hands-free conversation looping, transcription-mode long-form recording, and
@@ -50,6 +50,7 @@ import {
 } from "../../state";
 import { dispatchConversationResync } from "../../state/AppContext.hooks";
 import { useAppSelectorShallow } from "../../state/app-store";
+import { claimCloudLoginWindow } from "../../state/cloud-login-launch";
 import type { AppContextValue } from "../../state/internal";
 import {
   loadContinuousChatMode,
@@ -95,7 +96,10 @@ import {
   type ConversationNavDirection,
   resolveAdjacentConversationId,
 } from "./conversation-nav";
+import type { ShellAuthGate } from "./shell-auth-gate";
+import { deriveShellPhase } from "./shell-auth-gate";
 import type { ShellMessage, ShellPhase } from "./shell-state";
+import { useShellAuthGate } from "./useShellAuthGate";
 import { useShellVoiceOutput } from "./useShellVoiceOutput";
 
 export type {
@@ -131,6 +135,12 @@ export type CaptureIntent = "converse" | "dictate" | "transcription" | "ptt";
 
 export interface ShellController {
   phase: ShellPhase;
+  /** Cloud-only auth gate. Local-runtime builds stay `{ gated: false }`. */
+  authGate: ShellAuthGate;
+  /** Launch Cloud sign-in. No-op unless `authGate.phase === "needs-auth"`. */
+  requestSignIn: () => void;
+  /** True while a pill-initiated Cloud sign-in is in flight. */
+  signingIn: boolean;
   /** Raw "a reply is in flight" predicate — text streaming OR being spoken aloud.
    *  Unlike `phase === "responding"`, stays true after the mic opens (which flips
    *  phase to "listening"), so the composer reads one honest busy signal: send
@@ -443,6 +453,7 @@ const selectShellController = (s: AppContextValue) => ({
   setActionNotice: s.setActionNotice,
   chatAgentVoiceMuted: s.chatAgentVoiceMuted,
   setState: s.setState,
+  handleInteractiveCloudLogin: s.handleInteractiveCloudLogin,
 });
 
 export function useShellController(): ShellController {
@@ -465,7 +476,34 @@ export function useShellController(): ShellController {
     setActionNotice,
     chatAgentVoiceMuted,
     setState,
+    handleInteractiveCloudLogin,
   } = useAppSelectorShallow(selectShellController);
+  const authGate = useShellAuthGate();
+  const [signingIn, setSigningIn] = React.useState(false);
+  const signInInFlightRef = React.useRef(false);
+  const requestSignIn = React.useCallback(() => {
+    if (authGate.phase !== "needs-auth") return;
+    if (signInInFlightRef.current) return;
+    signInInFlightRef.current = true;
+    setSigningIn(true);
+    // Keep the popup on the click/key gesture. Effects must not call this.
+    claimCloudLoginWindow();
+    void handleInteractiveCloudLogin()
+      .catch((error: unknown) => {
+        // error-policy:J4 sign-in failed; stay on the needs-auth chip
+        setActionNotice(
+          error instanceof Error
+            ? error.message
+            : "Could not start Cloud login.",
+          "error",
+          5000,
+        );
+      })
+      .finally(() => {
+        signInInFlightRef.current = false;
+        setSigningIn(false);
+      });
+  }, [authGate.phase, handleInteractiveCloudLogin, setActionNotice]);
   // The wake phrase for transcript-mode inline replies follows the character
   // name (issue #9880); falls back to the running agent name, then "eliza".
   const wakeCharacterName =
@@ -1165,6 +1203,10 @@ export function useShellController(): ShellController {
 
   const startCapture = React.useCallback(
     (intent?: CaptureIntent) => {
+      // Cloud-only, signed out: refuse capture. User-initiated paths call
+      // requestSignIn themselves; auto-engage must not pop a login from an
+      // effect (that would lose the gesture and fall into same-tab).
+      if (authGate.gated) return;
       // Cartesia realtime owns conversational Talk end to end. Every legacy
       // boot/re-listen/wake path converges here, so this guard is the hard
       // boundary that prevents an effect from silently reopening batch Cloud
@@ -1475,6 +1517,7 @@ export function useShellController(): ShellController {
         });
     },
     [
+      authGate.gated,
       realtimeVoiceEnabled,
       send,
       stopCapture,
@@ -1586,6 +1629,10 @@ export function useShellController(): ShellController {
   );
 
   const toggleRecording = React.useCallback(() => {
+    if (authGate.gated) {
+      requestSignIn();
+      return;
+    }
     if (realtimeVoiceEnabled) {
       if (realtimeVoiceWantedRef.current) stopRealtimeVoiceRef.current();
       else startRealtimeVoiceRef.current();
@@ -1593,7 +1640,14 @@ export function useShellController(): ShellController {
     }
     if (recording) stopCapture();
     else startCapture();
-  }, [realtimeVoiceEnabled, recording, startCapture, stopCapture]);
+  }, [
+    authGate.gated,
+    realtimeVoiceEnabled,
+    recording,
+    requestSignIn,
+    startCapture,
+    stopCapture,
+  ]);
 
   React.useEffect(() => () => stopCapture(), [stopCapture]);
 
@@ -1666,8 +1720,12 @@ export function useShellController(): ShellController {
   }, []);
 
   const open = React.useCallback(() => {
+    if (authGate.gated) {
+      requestSignIn();
+      return;
+    }
     setIsOpen(true);
-  }, []);
+  }, [authGate.gated, requestSignIn]);
   const close = React.useCallback(() => {
     setIsOpen(false);
     setHandsFree(false);
@@ -1765,19 +1823,17 @@ export function useShellController(): ShellController {
   // Opening the popup is independent of runtime readiness. The composer can
   // already queue/send while the server warms, so keeping an opened shell in
   // `booting` would make AssistantOverlay discard it even though `isOpen` is
-  // true. Reserve `booting` for the closed launcher state.
-  const phase: ShellPhase =
-    recording || realtimeVoiceListening
-      ? "listening"
-      : sttPending
-        ? "processing"
-        : responding
-          ? "responding"
-          : isOpen
-            ? "summoned"
-            : ready
-              ? "idle"
-              : "booting";
+  // true. Reserve `booting` for the closed launcher state and for the
+  // cloud-only auth probe (`checking`).
+  const phase: ShellPhase = deriveShellPhase({
+    ready,
+    recording,
+    realtimeVoiceListening,
+    sttPending,
+    responding,
+    isOpen,
+    authGate: authGate.phase,
+  });
 
   // Boot-progress token for the slow-boot escalation (#14040 sub-defect 3). It
   // advances whenever the readiness poll observes fresh progress while still
@@ -1875,6 +1931,7 @@ export function useShellController(): ShellController {
   }, [stopCapture, voiceOutput.stopSpeaking]);
 
   const startRealtimeVoice = React.useCallback(async () => {
+    if (authGate.gated) return;
     if (!realtimeVoiceEnabled) return;
     if (
       realtimeVoiceWantedRef.current ||
@@ -1934,6 +1991,7 @@ export function useShellController(): ShellController {
     }
     setActionNotice(message, "error", 6000);
   }, [
+    authGate.gated,
     ensureActiveConversationForVoice,
     realtimeVoiceEnabled,
     setActionNotice,
@@ -2005,6 +2063,10 @@ export function useShellController(): ShellController {
   // tap is the gesture) and opens the mic in "converse" mode; disabling stops
   // both the mic and any in-flight reply.
   const toggleHandsFree = React.useCallback(() => {
+    if (authGate.gated) {
+      requestSignIn();
+      return;
+    }
     if (realtimeVoiceEnabled) {
       if (
         realtimeVoiceWantedRef.current ||
@@ -2062,6 +2124,8 @@ export function useShellController(): ShellController {
       });
     }
   }, [
+    authGate.gated,
+    requestSignIn,
     responding,
     startCapture,
     stopCapture,
@@ -2501,8 +2565,29 @@ export function useShellController(): ShellController {
     if (visionCapturing && responding) setVisionCapturing(false);
   }, [visionCapturing, responding]);
 
+  React.useEffect(() => {
+    if (!authGate.gated) return;
+    if (captureRef.current) cancelCapture();
+    if (isOpen) setIsOpen(false);
+    stopRealtimeVoiceRef.current();
+  }, [authGate.gated, cancelCapture, isOpen]);
+
+  const startRecording = React.useCallback(
+    (intent?: CaptureIntent) => {
+      if (authGate.gated) {
+        requestSignIn();
+        return;
+      }
+      startCapture(intent);
+    },
+    [authGate.gated, requestSignIn, startCapture],
+  );
+
   return {
     phase,
+    authGate,
+    requestSignIn,
+    signingIn,
     bootProgressSignal,
     responding,
     turnStatus,
@@ -2519,7 +2604,7 @@ export function useShellController(): ShellController {
     captureVision,
     visionCapturing,
     toggleRecording,
-    startRecording: startCapture,
+    startRecording,
     stopRecording,
     cancelRecording: cancelCapture,
     handsFree,

--- a/packages/ui/src/state/cloud-login-callsite-contract.test.ts
+++ b/packages/ui/src/state/cloud-login-callsite-contract.test.ts
@@ -35,6 +35,7 @@ const SANCTIONED_INTERACTIVE_SITES = new Set([
   "src/components/settings/CloudOverviewSection.tsx",
   "src/components/settings/ProviderSwitcher.tsx",
   "src/cloud/connectors/CloudConnectorsUpsell.tsx",
+  "src/components/shell/useShellController.ts",
 ]);
 
 const EXCLUDE_DIRS = new Set([

--- a/packages/ui/stories/src/stories/shell-foundation.tsx
+++ b/packages/ui/stories/src/stories/shell-foundation.tsx
@@ -13,9 +13,11 @@ import type { StoryDefinition } from "../Story.tsx";
 
 const phases: readonly ShellPhase[] = [
   "booting",
+  "needs-auth",
   "idle",
   "summoned",
   "listening",
+  "processing",
   "responding",
 ];
 


### PR DESCRIPTION
## Summary

On cloud-only desktop builds the home pill now rests in a **`needs-auth`** phase while there is no Cloud session: a labeled **"Sign in to Eliza"** chip that launches the interactive Cloud login instead of opening the overlay or the mic. Previously the pill was fully interactive (open overlay, hold-to-talk, fn-hold PTT, hands-free, realtime voice) even when signed out, which made no sense — every path just 401'd.

Follow-up to the fn-hold PTT work in #20483.

## State machine

`needs-auth` sits **above** the live waterfall so a signed-out pill can never grow into the waveform chip:

```
needs-auth > listening > processing > responding > summoned > idle/booting
```

- Gate derivation is pure (`shell-auth-gate.ts`): `cloudOnly` branding + the shared `/api/auth/me` snapshot (subscribe-only — no extra network traffic).
- `loading` / `server_unavailable` hold the closed launcher on `booting` so a slow probe never flashes the sign-in chip.
- The `cloudOnly` guard is the native-owner-key trap: a local desktop owner token must not look like a Cloud session, so non-cloud-only builds are byte-identical (gate always `{ gated: false }`).

## Gated paths (controller)

- `startCapture` / `startRecording` / `toggleRecording` / `toggleHandsFree` / `startRealtimeVoice` refuse while gated; user-initiated ones call `requestSignIn()` instead.
- `open()` launches sign-in instead of summoning the overlay.
- Sign-out mid-session cancels in-flight capture, closes the overlay, and stops realtime voice.
- `requestSignIn` claims the login popup **synchronously on the user gesture** (`claimCloudLoginWindow`) so the popup is never blocked into same-tab (#17064 contract; callsite added to the sanctioned list in `cloud-login-callsite-contract.test.ts`).
- Desktop shell fn-hold PTT + global toggle hotkeys route to `requestSignIn` while gated.

## Native window (electrobun)

- The transparent bottom-bar window gains an intermediate **240×56 chip frame** (`resolveBottomBarFrameSize`) between the 96×56 rest pill and the 600×820 expanded overlay, and now remembers its size across work-area re-anchors.
- `desktopSetBottomBarExpanded` RPC gains an optional `chip` flag.
- Follower/snapshot sync accepts `needs-auth` (and the previously missing `processing`) as shell phases.

## Verification

- **Unit:** 33 new tests (`shell-auth-gate.test.ts`, `useShellAuthGate.test.tsx`) + updated `HomePill` / `useShellController` / sync suites. Full `packages/ui` lane: **10,647 passed**. Electrobun lane: **538 passed**.
- **Gates:** typecheck + lint clean across all 356 workspace tasks; every `bun run verify` step passes except the pre-existing `ensure-plugin-test-conventions` failure (orphaned llama.cpp submodule webui tests) which also fails on clean `develop` — unrelated.
- **Visual:** `bun run --cwd packages/app audit:app` — 219/219 passed, 0 broken / 0 needs-work. Storybook gains `NeedsAuth` / `NeedsAuthSigningIn` stories (covered by the story gate).
- **Live desktop (macOS, real Electrobun app, signed out via cleared WebKit store, `ELIZA_DESKTOP_CLOUD_ONLY=1`):**
  - `/api/auth/me` → real 401 from `api.eliza.app`; native window resized to **240×56** and the accessibility tree reads `toggle button "Sign in to Eliza"` (was `"Open Eliza"`).
  - Clicking the chip launched the Cloud sign-in flow; after the session was adopted the gate cleared, the window returned to **96×56**, and the pill read `"Open Eliza"` and opened the overlay normally.
  - Signed-in cloud-only boot (existing session) never flashes the chip: probe resolves `authenticated` and the pill rests idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)