### PR TITLE
fix: Biome formatting regression in keyless web search test

### DIFF
--- a/packages/core/src/search/keyless-web-search.test.ts
+++ b/packages/core/src/search/keyless-web-search.test.ts
@@ -75,7 +75,12 @@ describe("searchKeylessWeb", () => {
 	});
 
 	it("rejects invalid result budgets instead of silently returning an uncapped result", async () => {
-		for (const maxResultChars of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+		for (const maxResultChars of [
+			-1,
+			1.5,
+			Number.NaN,
+			Number.POSITIVE_INFINITY,
+		]) {
 			await expect(
 				searchKeylessWeb("invalid budget", {
 					fetchImpl: async () => mcp("long result"),


### PR DESCRIPTION
# Relates to

Closes #20706

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun run verify` gate exercised for the affected package; `bun install` blocker documented below.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d53100a07e6f02d3eac18af36f01401f1ca18bd5:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop` (`49a71d7f97`); zero conflicts.
- [x] Affected-package gate (`@elizaos/core` biome `check ./src`) passes post-sync. Full `bun run verify` blocker documented in **Known gaps / failures**.

# Risks

Low. This is a formatter-only change to a single test file. No runtime code, no
test assertions, no imports, and no test values change. It only expands one
array literal to the multi-line form Biome requires.

# Background

## What does this PR do?

`develop` was failing the `@elizaos/core` lint gate because
`packages/core/src/search/keyless-web-search.test.ts` was not Biome-formatted.
The keyless-search result-budget validation test landed with an array literal
on a single line, but Biome expands it to multi-line form, so
`bunx @biomejs/biome check ./src` (the `@elizaos/core#lint:check` gate) failed
and blocked all rebased PRs at `bun run verify`.

This PR applies only the formatter-required change: expanding
`[-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]` to the multi-line array form.

Diff (the entire change):

```diff
-		for (const maxResultChars of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+		for (const maxResultChars of [
+			-1,
+			1.5,
+			Number.NaN,
+			Number.POSITIVE_INFINITY,
+		]) {
```

## What kind of change is this?

Bug fixes (non-breaking change which fixes a CI/lint-gate regression).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Run the exact gate that was failing on `develop`:

```bash
cd packages/core && bunx @biomejs/biome check ./src
```

## Detailed testing steps

None beyond automated checks. Formatting-only change; the keyless-web-search
test suite still passes unchanged.

# Evidence Gate

<!-- evidence-head:9ca61970f33f01a7d0d2f486ecb38e4e161a07f8 -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - no UI surface; formatter-only change to a .test.ts file.`
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - no UI surface; formatter-only change to a .test.ts file.`
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: `N/A - no user-facing flow; formatter-only change.`
<!-- evidence-row:backend-logs -->
- [x] Failing-then-passing reproduction of the `@elizaos/core` Biome lint gate (mirror: [gist](https://gist.github.com/agent-cortex/a140b57bfc54b7a6687adb46f1df6384)).

<details><summary>@elizaos/core Biome lint gate — logs (before fails, after passes)</summary>

```text
PR #20708  HEAD=9ca61970f33f01a7d0d2f486ecb38e4e161a07f8
Failing-then-passing reproduction of the @elizaos/core Biome lint gate.

########## BEFORE (single-line array, as on origin/develop) — GATE FAILS ##########
=== FAILING gate (pre-fix, single-line array as on origin/develop) ===
$ bunx @biomejs/biome check ./src   # from packages/core
src/search/keyless-web-search.test.ts format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  × Formatter would have printed the following content:
  
     76  76 │   
     77  77 │     it("rejects invalid result budgets instead of silently returning an uncapped result", async () => {
     78     │ - → → for·(const·maxResultChars·of·[-1,·1.5,·Number.NaN,·Number.POSITIVE_INFINITY])·{
         78 │ + → → for·(const·maxResultChars·of·[
         79 │ + → → → -1,
         80 │ + → → → 1.5,
         81 │ + → → → Number.NaN,
         82 │ + → → → Number.POSITIVE_INFINITY,
         83 │ + → → ])·{
     79  84 │         await expect(
     80  85 │           searchKeylessWeb("invalid budget", {
  

Checked 1273 files in 5s. No fixes applied.
Found 1 error.
check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  × Some errors were emitted while running checks.

########## AFTER (this PR) — format check on the file ##########
$ bunx @biomejs/biome format packages/core/src/search/keyless-web-search.test.ts
Checked 1 file in 11ms. No fixes applied.

########## AFTER (this PR) — @elizaos/core lint gate ##########
$ cd packages/core && bunx @biomejs/biome check ./src
Checked 1273 files in 4s. No fixes applied.
```

</details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend/network path touched.`
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model change.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - formatter-only edit to a test file produces no domain artifact (no DB row, generated file, memory, or on-chain output). The behavior-unchanged proof is the backend-logs reproduction above, where all seven searchKeylessWeb tests pass.
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

Failing-then-passing reproduction of the exact gate.

**Before (on `origin/develop`, single-line array) — gate fails:**

```
packages/core/src/search/keyless-web-search.test.ts format
  × Formatter would have printed the following content:
     78     │ - → → for·(const·maxResultChars·of·[-1,·1.5,·Number.NaN,·Number.POSITIVE_INFINITY])·{
         78 │ + → → for·(const·maxResultChars·of·[
         79 │ + → → → -1,
         80 │ + → → → 1.5,
         81 │ + → → → Number.NaN,
         82 │ + → → → Number.POSITIVE_INFINITY,
         83 │ + → → ])·{
Checked 1 file in 12ms. No fixes applied.
Found 1 error.
```

**After (this PR) — Biome format check on the file:**

```
$ bunx @biomejs/biome format packages/core/src/search/keyless-web-search.test.ts
Checked 1 file in 11ms. No fixes applied.
```

**After (this PR) — the `@elizaos/core` lint gate (`bunx @biomejs/biome check ./src`):**

```
$ cd packages/core && bunx @biomejs/biome check ./src
Checked 1273 files in 4s. No fixes applied.
```

## Screenshots (before / after) + video walkthrough

N/A - no UI change (formatter-only edit to a `.test.ts` file).

## Audio / voice walkthrough

N/A - no voice/audio path touched.

## Known gaps / failures

- Behavior unchanged — the keyless-web-search suite passes (7/7):

```
$ cd packages/core && bun test src/search/keyless-web-search.test.ts
(pass) searchKeylessWeb > rejects invalid result budgets instead of silently returning an uncapped result
 7 pass
 0 fail
Ran 7 tests across 1 file.
```

- Full-repo `bun install` / `bun run verify` could not complete on this machine:
  the workspace install is blocked by a global Bun `minimumReleaseAge = 604800`
  policy on a transitive dependency (`smthrs@0.34.0`, published within the last
  7 days), unrelated to this change. The affected-package Biome gate — the exact
  gate that was failing — was run directly via `bunx @biomejs/biome` (which
  resolves independently of the workspace install) and passes, as shown above.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@d53100a07e6f02d3eac18af36f01401f1ca18bd5:packages/skills/skills/contribute-to-eliza"} -->


