### PR TITLE
fix(core): format keyless web search budget test

### DIFF
--- a/packages/core/src/search/keyless-web-search.test.ts
+++ b/packages/core/src/search/keyless-web-search.test.ts
@@ -75,7 +75,12 @@ describe("searchKeylessWeb", () => {
 	});
 
 	it("rejects invalid result budgets instead of silently returning an uncapped result", async () => {
-		for (const maxResultChars of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+		for (const maxResultChars of [
+			-1,
+			1.5,
+			Number.NaN,
+			Number.POSITIVE_INFINITY,
+		]) {
 			await expect(
 				searchKeylessWeb("invalid budget", {
 					fetchImpl: async () => mcp("long result"),


### PR DESCRIPTION
Fixes #20707

## Summary
- apply the repository formatter to the invalid-budget test matrix
- preserve the test logic and production behavior unchanged
- restore the Core lint and root verification gates on `develop`

## Verification
- `bun run --cwd packages/core lint:check` (1,273 files)
- `TURBO_FORCE=1 bun run verify` at `a368a6789576c2a4386e9e5f52a7e50944905f17` (356/356; anti-larp 8,394 files)

<!-- evidence-head:a368a6789576c2a4386e9e5f52a7e50944905f17 -->

<!-- evidence-row:backend-logs -->
- [x] [20711-pr20707-verify-exact.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20711-pr20707-verify-exact.log)

<!-- evidence-row:before-screenshots -->
- [ ] N/A - formatter-only test change with no user interface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - formatter-only test change with no user interface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no runtime or user-facing behavior changed

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model or agent behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - exact-head repository verification log is attached

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual artifact exists
