### PR TITLE
fix(cloud): publish authenticated staging embeddings

### DIFF
--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -534,6 +534,10 @@ jobs:
           # activation is a separate protected, live-proven rollout.
           ELIZA_APP_TELEGRAM_BOT_TOKEN: ${{ secrets.ELIZA_APP_TELEGRAM_BOT_TOKEN }}
           ELIZA_APP_TELEGRAM_WEBHOOK_SECRET: ${{ secrets.ELIZA_APP_TELEGRAM_WEBHOOK_SECRET }}
+          # Bearer key for the self-hosted TEI embeddings sidecar (#20627); the
+          # Worker's local-embeddings routing sends it when LOCAL_EMBEDDINGS_BASE_URL
+          # is configured. The sidecar rejects unauthenticated calls (401).
+          LOCAL_EMBEDDINGS_API_KEY: ${{ secrets.LOCAL_EMBEDDINGS_API_KEY }}
           GATEWAY_INTERNAL_SECRET: ${{ secrets.GATEWAY_INTERNAL_SECRET }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -673,6 +677,12 @@ jobs:
                    ! is_truthy "$ELIZA_TTS_FISH_ENABLED" || \
                    ! is_truthy "$FISH_AUDIO_DATA_GOVERNANCE_APPROVED"; then
                   echo "::notice::$name is gated by realtime voice, Fish enablement, and data-governance approval; skipping"
+                  return 0
+                fi
+                ;;
+              LOCAL_EMBEDDINGS_API_KEY)
+                if [ "$DEPLOY_ENVIRONMENT" != "staging" ]; then
+                  echo "::notice::$name is staging-only; skipping"
                   return 0
                 fi
                 ;;
@@ -818,7 +828,8 @@ jobs:
             GATEWAY_INTERNAL_SECRET \
             ELIZA_APP_WEBHOOK_GATEWAY_SECRET \
             ELIZA_APP_TELEGRAM_BOT_TOKEN \
-            ELIZA_APP_TELEGRAM_WEBHOOK_SECRET
+            ELIZA_APP_TELEGRAM_WEBHOOK_SECRET \
+            LOCAL_EMBEDDINGS_API_KEY
           do
             queue_secret "$name"
           done

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -537,7 +537,7 @@ jobs:
           # Bearer key for the self-hosted TEI embeddings sidecar (#20627); the
           # Worker's local-embeddings routing sends it when LOCAL_EMBEDDINGS_BASE_URL
           # is configured. The sidecar rejects unauthenticated calls (401).
-          LOCAL_EMBEDDINGS_API_KEY: ${{ secrets.LOCAL_EMBEDDINGS_API_KEY }}
+          LOCAL_EMBEDDINGS_API_KEY: ${{ steps.env.outputs.deploy_environment == 'staging' && secrets.LOCAL_EMBEDDINGS_API_KEY || '' }}
           GATEWAY_INTERNAL_SECRET: ${{ secrets.GATEWAY_INTERNAL_SECRET }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/cloud-cf-release.yml
+++ b/.github/workflows/cloud-cf-release.yml
@@ -730,6 +730,30 @@ jobs:
             ' "${worker_secret_names[@]}"
           }
 
+          verify_staging_embeddings_secret_candidate() {
+            if [ "$DEPLOY_ENVIRONMENT" != "staging" ]; then
+              return 0
+            fi
+            local secret_inventory
+            secret_inventory="$(bunx wrangler@4.100.0 secret list ${{ steps.env.outputs.wrangler_args }} --format json)"
+            printf '%s' "$secret_inventory" | node -e '
+              const fs = require("node:fs");
+              const parsed = JSON.parse(fs.readFileSync(0, "utf8"));
+              const entries = Array.isArray(parsed)
+                ? parsed
+                : Array.isArray(parsed?.result)
+                  ? parsed.result
+                  : [];
+              const available = new Set(entries.map((entry) => entry?.name).filter(Boolean));
+              for (const name of process.argv.slice(1)) available.add(name);
+              if (!available.has("LOCAL_EMBEDDINGS_API_KEY")) {
+                console.error("::error::Staging local embeddings cannot be deployed without an existing or configured LOCAL_EMBEDDINGS_API_KEY Worker binding.");
+                process.exit(1);
+              }
+              console.log("Verified staging local embeddings bearer binding name; its value was not read.");
+            ' "${worker_secret_names[@]}"
+          }
+
           # Like queue_secret, but for values that act as ROUTING TOGGLES
           # (code branches on presence, e.g. `env.WHISPER_STT_URL`). An unset
           # source must DELETE any previously published secret. A plain
@@ -854,6 +878,11 @@ jobs:
           # active Worker: every required voice name must either already exist
           # or be queued for the atomic version below.
           verify_production_voice_secret_candidates || exit 1
+          # The staging base URL routes live traffic to an authenticated TEI
+          # sidecar, so its bearer binding must exist or be committed in the
+          # same Worker version. A missing value may never deploy as a healthy
+          # but permanently unauthorized embeddings path.
+          verify_staging_embeddings_secret_candidate || exit 1
 
           # Wrangler deploy accepts this JSON additively: named values are
           # committed in the same Worker version as the exact source, while
@@ -991,6 +1020,9 @@ jobs:
               "STEWARD_TENANT_API_KEY",
               "GATEWAY_INTERNAL_SECRET",
             ];
+            if (process.env.DEPLOY_ENVIRONMENT === "staging") {
+              required.push("LOCAL_EMBEDDINGS_API_KEY");
+            }
             if (
               process.env.DEPLOY_ENVIRONMENT === "production" &&
               process.env.VOICE_REALTIME_WS_ENABLED === "true"

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -469,6 +469,11 @@ PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "true"
 # Emit per-turn inference spans at info for the staging latency matrix without
 # changing production log volume or recording prompt content.
 ELIZA_INFERENCE_TIMING = "info"
+# Self-hosted TEI embeddings sidecar (packages/cloud/services/embeddings,
+# bge-small-en-v1.5, 384 dims). The sidecar requires a bearer credential —
+# LOCAL_EMBEDDINGS_API_KEY is published as a Worker secret by cloud-cf-release
+# and must never appear in a [vars] block.
+LOCAL_EMBEDDINGS_BASE_URL = "https://embeddings-staging-staging.up.railway.app"
 # Apps (Product 2): wire the real deploy trigger so POST /api/v1/apps/:id/deploy
 # enqueues an APP_DEPLOY job the provisioning-worker daemon runs (instead of the
 # legacy status-only stub). Staging only — the apps data plane (tenant DB +

--- a/packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts
@@ -147,14 +147,23 @@ describe("Worker secret/var collision lint (CF error 10053 class)", () => {
     expect(
       config.env?.production?.vars?.LOCAL_EMBEDDINGS_BASE_URL,
     ).toBeUndefined();
-    expect(vars.get("staging")?.has("LOCAL_EMBEDDINGS_API_KEY") ?? false).toBe(
-      false,
-    );
+    for (const [environment, names] of vars) {
+      expect(
+        names.has("LOCAL_EMBEDDINGS_API_KEY"),
+        `${environment} must not publish LOCAL_EMBEDDINGS_API_KEY as plaintext`,
+      ).toBe(false);
+    }
     expect(releaseWorkflowSource).toContain(
       "LOCAL_EMBEDDINGS_API_KEY: $" + "{{ secrets.LOCAL_EMBEDDINGS_API_KEY }}",
     );
     expect(releaseWorkflowSource).toContain(
       'LOCAL_EMBEDDINGS_API_KEY)\n                if [ "$DEPLOY_ENVIRONMENT" != "staging" ]; then',
+    );
+    expect(releaseWorkflowSource).toContain(
+      'if (!available.has("LOCAL_EMBEDDINGS_API_KEY"))',
+    );
+    expect(releaseWorkflowSource).toContain(
+      'required.push("LOCAL_EMBEDDINGS_API_KEY")',
     );
   });
 });

--- a/packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts
@@ -17,6 +17,10 @@ const wranglerSource = readFileSync(
   new URL("packages/cloud/api/wrangler.toml", repoRoot),
   "utf8",
 );
+const releaseWorkflowSource = readFileSync(
+  new URL(".github/workflows/cloud-cf-release.yml", repoRoot),
+  "utf8",
+);
 
 /** Parse var names per environment from wrangler.toml ("default" = top-level [vars]). */
 function parseWranglerVars(source: string): Map<string, Set<string>> {
@@ -54,6 +58,9 @@ const PUBLISHED_WORKER_SECRETS: Array<{ name: string; envs: string[] }> = [
   // The staging cutover uses a fresh secret name because keep_vars preserved
   // the legacy plaintext binding on the served Worker (run 31970252094).
   { name: "PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED", envs: ["staging"] },
+  // Self-hosted TEI sidecar bearer key, published by cloud-cf-release; must
+  // never appear as a [vars] entry anywhere.
+  { name: "LOCAL_EMBEDDINGS_API_KEY", envs: ["staging"] },
 ];
 
 describe("Worker secret/var collision lint (CF error 10053 class)", () => {
@@ -122,5 +129,32 @@ describe("Worker secret/var collision lint (CF error 10053 class)", () => {
         .get("production")
         ?.has("PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED") ?? false,
     ).toBe(false);
+  });
+
+  test("configures authenticated local embeddings only in staging", () => {
+    const config = Bun.TOML.parse(wranglerSource) as {
+      vars?: { LOCAL_EMBEDDINGS_BASE_URL?: string };
+      env?: {
+        staging?: { vars?: { LOCAL_EMBEDDINGS_BASE_URL?: string } };
+        production?: { vars?: { LOCAL_EMBEDDINGS_BASE_URL?: string } };
+      };
+    };
+
+    expect(config.vars?.LOCAL_EMBEDDINGS_BASE_URL).toBeUndefined();
+    expect(config.env?.staging?.vars?.LOCAL_EMBEDDINGS_BASE_URL).toBe(
+      "https://embeddings-staging-staging.up.railway.app",
+    );
+    expect(
+      config.env?.production?.vars?.LOCAL_EMBEDDINGS_BASE_URL,
+    ).toBeUndefined();
+    expect(vars.get("staging")?.has("LOCAL_EMBEDDINGS_API_KEY") ?? false).toBe(
+      false,
+    );
+    expect(releaseWorkflowSource).toContain(
+      "LOCAL_EMBEDDINGS_API_KEY: $" + "{{ secrets.LOCAL_EMBEDDINGS_API_KEY }}",
+    );
+    expect(releaseWorkflowSource).toContain(
+      'LOCAL_EMBEDDINGS_API_KEY)\n                if [ "$DEPLOY_ENVIRONMENT" != "staging" ]; then',
+    );
   });
 });

--- a/packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts
@@ -154,7 +154,8 @@ describe("Worker secret/var collision lint (CF error 10053 class)", () => {
       ).toBe(false);
     }
     expect(releaseWorkflowSource).toContain(
-      "LOCAL_EMBEDDINGS_API_KEY: $" + "{{ secrets.LOCAL_EMBEDDINGS_API_KEY }}",
+      "LOCAL_EMBEDDINGS_API_KEY: $" +
+        "{{ steps.env.outputs.deploy_environment == 'staging' && secrets.LOCAL_EMBEDDINGS_API_KEY || '' }}",
     );
     expect(releaseWorkflowSource).toContain(
       'LOCAL_EMBEDDINGS_API_KEY)\n                if [ "$DEPLOY_ENVIRONMENT" != "staging" ]; then',


### PR DESCRIPTION
# Relates to

Closes #20710.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto exact `origin/develop@e385d7dd357d87c07627921fa33fccff7c1e8bea` with zero conflicts.
- [x] `bun install --frozen-lockfile --ignore-scripts` and scoped verification were run after sync; no source-gate failure remains.
- [x] A reviewer can confirm the publication/config contract from the exact test and dry-bundle receipts below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no repository contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop@e385d7dd357d87c07627921fa33fccff7c1e8bea`; zero conflicts.
- [x] Scoped source gates pass. Root `bun run verify` is not claimed; this three-path workflow/config change ran the package typecheck, real Worker dry bundles, exact tests, Biome, actionlint, and diff-check.

# Risks

Low and staging-bounded. The bearer secret expression is also gated at the job boundary, so production jobs never receive the staging credential. A malformed workflow publication could leave Shared memory recall unable to authenticate to the TEI sidecar. The secret remains value-blind, publication is explicitly staging-only, production has no base URL, and collision lint prevents Cloudflare 10053 secret/plaintext conflicts.

# Background

## What does this PR do?

Companion PR #20718 is merged on this base and immutably pins the TEI sidecar image; its exact linux/amd64 Docker build and independent review are recorded on that PR.

Publishes the existing protected staging `LOCAL_EMBEDDINGS_API_KEY` through the atomic Worker secret queue, configures the staging TEI sidecar URL, and guards the secret namespace. The workflow refuses to publish this key outside staging. Default and production retain no local-embeddings URL.

## What kind of change is this?

Bug fix / protected staging configuration.

# Documentation changes needed?

No public documentation change is needed. The durable configuration rationale is inline beside the Worker binding and workflow publication boundary.

# Testing

## Where should a reviewer start?

1. `.github/workflows/cloud-cf-release.yml` staging-only key gate and queue.
2. `packages/cloud/api/wrangler.toml` staging-only base URL.
3. `packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts` namespace and environment contract.

## Detailed testing steps

- `bun test packages/scripts/__tests__/cloud-cf-secret-var-collision.test.ts packages/scripts/__tests__/cloud-cf-atomic-worker-secrets-workflow.test.ts packages/cloud/shared/src/lib/providers/language-model-local-embeddings.test.ts` — 18/18, 86 assertions.
- `bun run --cwd packages/cloud/api typecheck` — PASS, including production Worker dry bundle.
- `bunx wrangler@4.100.0 deploy --env staging --dry-run ...` — PASS; staging bundle lists `LOCAL_EMBEDDINGS_BASE_URL`; no secret value is read.
- `bunx wrangler@4.100.0 deploy --env production --dry-run ...` — PASS; production bundle has no `LOCAL_EMBEDDINGS_BASE_URL`.
- `actionlint .github/workflows/cloud-cf-release.yml` — PASS.
- exact Biome + `git diff --check` — PASS.

# Evidence Gate

<!-- evidence-head:b4230adcee62d47636df86b45861a247fb312972 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow/config-only change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow/config-only change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - protected Worker publication has no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - source PR does not mutate staging; exact protected release logs will be attached after merge before acceptance.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or request path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt/model/action behavior changes; this only supplies the existing authenticated provider binding.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - source-only workflow configuration produces no persistent domain row; protected staging proof follows merge
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider implementation changes. Runtime authenticated-embedding proof remains a protected post-merge staging acceptance gate.

## Backend + frontend logs

N/A - source review only; no staging mutation in this lane.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no voice behavior change.

## Known gaps / failures

- `bun run audit:error-policy-ratchet` is absent on this base. This diff changes no production TypeScript catch/console boundary.
- The first Cloud API typecheck attempt failed only because generated keyword sources were absent in the fresh worktree. `bun run build:core` completed 59/59, then the exact typecheck and Worker bundle passed.
- Live authenticated 384-dimensional sidecar proof is intentionally post-merge because the protected release workflow must publish the existing staging secret. Production remains untouched.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: e385d7dd357d87c07627921fa33fccff7c1e8bea:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported



