### PR TITLE
fix(github): expose capped unread totals as lower bounds

### DIFF
--- a/plugins/plugin-github/src/actions/notification-triage.test.ts
+++ b/plugins/plugin-github/src/actions/notification-triage.test.ts
@@ -5,7 +5,10 @@
 import { logger } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import type { GitHubOctokitClient } from "../types.js";
-import { fetchAllUnreadNotifications } from "./notification-triage.js";
+import {
+  fetchAllUnreadNotifications,
+  formatTriageSummary,
+} from "./notification-triage.js";
 
 describe("fetchAllUnreadNotifications", () => {
   it("collects later pages before reporting and ranking unread notifications", async () => {
@@ -25,10 +28,11 @@ describe("fetchAllUnreadNotifications", () => {
       listNotificationsForAuthenticatedUser,
     } as GitHubOctokitClient["activity"];
 
-    const notifications = await fetchAllUnreadNotifications(activity);
+    const result = await fetchAllUnreadNotifications(activity);
 
-    expect(notifications).toHaveLength(70);
-    expect(notifications.at(-1)?.id).toBe("69");
+    expect(result.notifications).toHaveLength(70);
+    expect(result.notifications.at(-1)?.id).toBe("69");
+    expect(result.totalUnreadIsLowerBound).toBe(false);
     expect(listNotificationsForAuthenticatedUser).toHaveBeenNthCalledWith(1, {
       all: false,
       per_page: 50,
@@ -54,9 +58,10 @@ describe("fetchAllUnreadNotifications", () => {
       listNotificationsForAuthenticatedUser,
     } as GitHubOctokitClient["activity"];
 
-    const notifications = await fetchAllUnreadNotifications(activity);
+    const result = await fetchAllUnreadNotifications(activity);
 
-    expect(notifications).toEqual(fullPage);
+    expect(result.notifications).toEqual(fullPage);
+    expect(result.totalUnreadIsLowerBound).toBe(false);
     expect(listNotificationsForAuthenticatedUser).toHaveBeenCalledTimes(2);
   });
 
@@ -82,10 +87,11 @@ describe("fetchAllUnreadNotifications", () => {
       listNotificationsForAuthenticatedUser,
     } as GitHubOctokitClient["activity"];
 
-    const notifications = await fetchAllUnreadNotifications(activity);
+    const result = await fetchAllUnreadNotifications(activity);
 
-    expect(notifications).toHaveLength(60);
-    expect(new Set(notifications.map((n) => n.id)).size).toBe(60);
+    expect(result.notifications).toHaveLength(60);
+    expect(new Set(result.notifications.map((n) => n.id)).size).toBe(60);
+    expect(result.totalUnreadIsLowerBound).toBe(false);
   });
 
   it("stops after the page cap instead of looping on an always-full inbox", async () => {
@@ -104,14 +110,29 @@ describe("fetchAllUnreadNotifications", () => {
       listNotificationsForAuthenticatedUser,
     } as GitHubOctokitClient["activity"];
 
-    const notifications = await fetchAllUnreadNotifications(activity);
+    const result = await fetchAllUnreadNotifications(activity);
 
     expect(listNotificationsForAuthenticatedUser).toHaveBeenCalledTimes(20);
-    expect(notifications).toHaveLength(1000);
+    expect(result.notifications).toHaveLength(1000);
+    expect(result.totalUnreadIsLowerBound).toBe(true);
     expect(warning).toHaveBeenCalledWith(
       { pages: 20, collected: 1000 },
       "[GitHub:GITHUB_NOTIFICATION_TRIAGE] unread notifications truncated at page cap",
     );
     warning.mockRestore();
+  });
+});
+
+describe("formatTriageSummary", () => {
+  it("keeps the established summary for a complete traversal", () => {
+    expect(formatTriageSummary(7, 7, false)).toBe(
+      "Triaged 7 unread notification(s)",
+    );
+  });
+
+  it("makes a capped total visibly partial", () => {
+    expect(formatTriageSummary(25, 1000, true)).toBe(
+      "Triaged 25 of at least 1000 unread notification(s)",
+    );
   });
 });

--- a/plugins/plugin-github/src/actions/notification-triage.ts
+++ b/plugins/plugin-github/src/actions/notification-triage.ts
@@ -68,10 +68,15 @@ export interface TriagedNotification {
   score: number;
 }
 
-/** Fetch every unread notification page so ranking and totals are complete. */
+interface UnreadNotificationFetchResult {
+  notifications: GitHubNotificationSummary[];
+  totalUnreadIsLowerBound: boolean;
+}
+
+/** Fetch bounded unread pages and report when the collected total is partial. */
 export async function fetchAllUnreadNotifications(
   activity: GitHubOctokitClient["activity"],
-): Promise<GitHubNotificationSummary[]> {
+): Promise<UnreadNotificationFetchResult> {
   const notifications: GitHubNotificationSummary[] = [];
   const seenIds = new Set<string>();
   for (let page = 1; page <= NOTIFICATION_MAX_PAGES; page += 1) {
@@ -87,13 +92,15 @@ export async function fetchAllUnreadNotifications(
       seenIds.add(notification.id);
       notifications.push(notification);
     }
-    if (response.data.length < NOTIFICATION_PAGE_SIZE) return notifications;
+    if (response.data.length < NOTIFICATION_PAGE_SIZE) {
+      return { notifications, totalUnreadIsLowerBound: false };
+    }
   }
   logger.warn(
     { pages: NOTIFICATION_MAX_PAGES, collected: notifications.length },
     "[GitHub:GITHUB_NOTIFICATION_TRIAGE] unread notifications truncated at page cap",
   );
-  return notifications;
+  return { notifications, totalUnreadIsLowerBound: true };
 }
 
 function scoreNotification(params: {
@@ -115,7 +122,17 @@ function scoreNotification(params: {
   return base + subject + freshness;
 }
 
-export { scoreNotification };
+function formatTriageSummary(
+  triagedCount: number,
+  totalUnread: number,
+  totalUnreadIsLowerBound: boolean,
+): string {
+  return totalUnreadIsLowerBound
+    ? `Triaged ${triagedCount} of at least ${totalUnread} unread notification(s)`
+    : `Triaged ${triagedCount} unread notification(s)`;
+}
+
+export { formatTriageSummary, scoreNotification };
 
 export const notificationTriageAction: Action = {
   name: GitHubActions.GITHUB_NOTIFICATION_TRIAGE,
@@ -162,6 +179,7 @@ export const notificationTriageAction: Action = {
       notifications: TriagedNotification[];
       notificationLimit: number;
       totalUnread: number;
+      totalUnreadIsLowerBound: boolean;
     }>
   > => {
     const selection = resolveAccountSelection(options, "user");
@@ -172,9 +190,8 @@ export const notificationTriageAction: Action = {
     }
 
     try {
-      const notifications = await fetchAllUnreadNotifications(
-        resolved.client.activity,
-      );
+      const { notifications, totalUnreadIsLowerBound } =
+        await fetchAllUnreadNotifications(resolved.client.activity);
       const nowMs = Date.now();
       const triaged: TriagedNotification[] = notifications.map((n) => {
         const repoPushedAt = n.repository?.pushed_at ?? null;
@@ -205,7 +222,11 @@ export const notificationTriageAction: Action = {
       triaged.sort((a, b) => b.score - a.score);
       const boundedTriaged = triaged.slice(0, NOTIFICATION_TRIAGE_LIMIT);
       await callback?.({
-        text: `Triaged ${boundedTriaged.length} unread notification(s)`,
+        text: formatTriageSummary(
+          boundedTriaged.length,
+          triaged.length,
+          totalUnreadIsLowerBound,
+        ),
       });
       return {
         success: true,
@@ -213,6 +234,7 @@ export const notificationTriageAction: Action = {
           notifications: boundedTriaged,
           notificationLimit: NOTIFICATION_TRIAGE_LIMIT,
           totalUnread: triaged.length,
+          totalUnreadIsLowerBound,
         },
       };
     } catch (err) {


### PR DESCRIPTION
# Relates to

Closes #20692

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] Targets `develop`; exact published head was rebased onto `origin/develop@6891bda8cd069988c0bfc3c77eb6e123237e5b6d` with zero conflicts before validation.
- [x] A reviewer can verify both complete and capped traversal behavior from focused deterministic evidence below.
- [x] Package build/typecheck/Biome and root `bun run verify` pass on the exact published head.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5-codex`
<!-- attribution-row:client -->
- Agent tooling: `codex-desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@6891bda8cd069988c0bfc3c77eb6e123237e5b6d:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# What changed

The bounded unread-notification traversal introduced by #20668 correctly stops at 100 pages, but its action response still exposed `totalUnread: 1000` as an exact total when the cap was reached. That value is only a lower bound.

This PR keeps the bounded/deduplicated traversal and adds an explicit `totalUnreadIsLowerBound` signal:

- short final page: `totalUnreadIsLowerBound: false`;
- page cap reached: `totalUnreadIsLowerBound: true`;
- capped callback text now says `Triaged 25 of at least 1000 unread notification(s)` instead of claiming exactly 1000.

No error is converted to success, no cap is removed, and the DTO change is additive.

# Risks

Low. The production change is limited to the GitHub notification-triage action and adds a truthful status bit plus user-visible wording. Existing complete traversals retain their established summary.

# Evidence Gate

<!-- evidence-head:a2e7738b1f11a7a7830d2e24db07aa080b2362af -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend GitHub action with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend GitHub action with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no frontend or native user flow changed
<!-- evidence-row:backend-logs -->
- [x] [20716-pr20716-focused-raw.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20716-pr20716-focused-raw.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend console or browser network path changed
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt planner provider or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [x] [20716-domain-artifact-20692.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20716-domain-artifact-20692.log)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual text changed

# Exact-head validation

Exact published head: `a2e7738b1f11a7a7830d2e24db07aa080b2362af`

```text
bun test ./plugins/plugin-github/src/actions/notification-triage.test.ts
6 pass, 0 fail, 17 assertions

bun run --cwd plugins/plugin-github typecheck
PASS

bun run --cwd plugins/plugin-github build
PASS (ESM + declarations)

bunx biome check plugins/plugin-github/src/actions/notification-triage.ts plugins/plugin-github/src/actions/notification-triage.test.ts
Checked 2 files. No fixes applied.

bun run verify
Tasks: 356 successful, 356 total
Cached: 30 cached, 356 total
All repository audits passed.
anti-larp: 8,397 test files; 0 focused; 0 orphaned skips.
```

The same patch was also run uncached before the final non-overlapping merge wave: 356/356, 0 cached, all audits, 8,393 files clean. The final rebased head above is the authoritative published evidence.

## Mutation proof

I temporarily restored the misleading behavior by forcing the capped result to report `totalUnreadIsLowerBound: false` and by removing `at least` from the capped callback. The focused suite failed exactly the two truthful-output assertions:

```text
4 pass, 2 fail
- expected capped lower-bound flag true, received false
- expected `Triaged 25 of at least 1000 unread notification(s)`, received exact-total wording
```

After restoring the implementation, the same file passed 6/6.

## Reviewer commands

```bash
bun test ./plugins/plugin-github/src/actions/notification-triage.test.ts
bun run --cwd plugins/plugin-github typecheck
bun run --cwd plugins/plugin-github build
bunx biome check plugins/plugin-github/src/actions/notification-triage.ts plugins/plugin-github/src/actions/notification-triage.test.ts
bun run verify
```

## Known gaps

None in the delivered scope. Screenshots, video, OCR, frontend logs, live LLM calls, and persistent domain artifacts are genuinely inapplicable to this backend-only deterministic action contract.

AI provider/model: OpenAI / GPT-5 Codex
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@6891bda8cd069988c0bfc3c77eb6e123237e5b6d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-root]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5-codex","client":"codex-desktop","skill_revision":"elizaOS/eliza@6891bda8cd069988c0bfc3c77eb6e123237e5b6d:packages/skills/skills/contribute-to-eliza"} -->







