### PR TITLE
fix(cloud): pin embeddings sidecar to immutable TEI digest (P2 HOLD disposition)

### DIFF
--- a/packages/cloud/services/embeddings/Dockerfile
+++ b/packages/cloud/services/embeddings/Dockerfile
@@ -15,10 +15,12 @@
 # Pin: TEI publishes CPU/CUDA variants under
 # ghcr.io/huggingface/text-embeddings-inference. CPU is the Railway default
 # (no GPU on the default plan); override TEI_IMAGE at build time for a CUDA
-# variant on a GPU-backed plan. Prefer pinning a concrete tag on deploy —
-# cpu-latest is the documented default, but bump deliberately and verify the
-# ghcr manifest still serves /v1/embeddings and /health before shipping.
-ARG TEI_IMAGE=ghcr.io/huggingface/text-embeddings-inference:cpu-latest
+# variant on a GPU-backed plan. The default is an IMMUTABLE digest (resolved
+# from cpu-latest 2026-08-16, live-verified serving 384-d /v1/embeddings with
+# bearer auth on Railway) so a rebuild can never silently change the
+# /v1/embeddings or 384-dimension contract. To bump: resolve the new digest,
+# verify /health + a 384-d embedding against a staging deploy, then update.
+ARG TEI_IMAGE=ghcr.io/huggingface/text-embeddings-inference@sha256:cb570aabbfa016b86684f576b5bd72d1ee96cc0b7a00b0ad221b298762b32157
 
 FROM ${TEI_IMAGE}
 


### PR DESCRIPTION
## Summary
Dispositions launch-audit's MATERIAL P2 HOLD on #20713: the sidecar Dockerfile defaulted `TEI_IMAGE` to floating `cpu-latest`, so a rebuild could silently change the `/v1/embeddings` or 384-dimension contract the Worker routing depends on.

- `TEI_IMAGE` now defaults to the immutable manifest digest `sha256:cb570aab…` resolved from `cpu-latest` at ghcr (registry `docker-content-digest`, receipt below), which is the same image generation currently live-verified on Railway (`embeddings-staging`: bearer-401 unauth, 200 + 384-d authed).
- Comment documents the deliberate bump procedure (resolve → staging verify → update).
- The build-arg override remains for CUDA variants.

Immediately after this merges I will redeploy `embeddings-staging` from the pinned Dockerfile so the deployed artifact and source pin match by construction, and post the re-verification (401 unauth / 384-d authed) to HQ.

## Evidence
```
docker-content-digest: sha256:cb570aabbfa016b86684f576b5bd72d1ee96cc0b7a00b0ad221b298762b32157
(ghcr.io/v2/huggingface/text-embeddings-inference/manifests/cpu-latest, 2026-08-16)
```
Companion to #20713 (secret/base-URL/collision boundary — a codex lane's pickup of the HQ 18044263 diff). Merge order: either first; both before the recall flags turn on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)