### PR TITLE
chore: bind Slop authority proof to policy revision 2026-08-16.3

### DIFF
--- a/.github/slop-project.json
+++ b/.github/slop-project.json
@@ -1,6 +1,6 @@
 {
   "kind": "slop-project-authority",
-  "policyRevision": "2026-08-16.1",
+  "policyRevision": "2026-08-16.3",
   "projectId": "eliza",
   "proposal": "https://github.com/elizaOS/slopdotcash/issues/115",
   "repository": {


### PR DESCRIPTION
Follow-up to #20695: bind the repository authority proof to the current Slop project policy revision 2026-08-16.3.

Verified against the live Slop develop manifest and GitHub APIs at exact head b8f5be366b17437c3b14c57c30396d7138173693:
- project id eliza and integration branch develop
- repository id 826170402 and full name elizaOS/eliza
- steward GitHub organization elizaOS, actor id 186240462, node id O_kgDOCxnNzg
- Slop project status paused, payment mode disabled, committed amount 0, and no funding addresses
- no copyright, ownership, wallet, payout, operator, or legal-capacity claim is added

No deployment or Slop ingestion was performed.