### PR TITLE
fix(core): shouldRespond stays chatty on substance but ignores pure acknowledgements

### DIFF
--- a/packages/core/src/actions/to-tool.ts
+++ b/packages/core/src/actions/to-tool.ts
@@ -52,7 +52,7 @@ export const HANDLE_RESPONSE_SCHEMA: JSONSchema = {
 			type: "string",
 			enum: ["RESPOND", "IGNORE", "STOP"],
 			description:
-				"RESPOND=reply/run actions. IGNORE=silent. STOP=explicit user stop.",
+				'RESPOND=reply/run actions — a question, a request, or ambient chatter with real substance you can add to (stay chatty). IGNORE=silent — pure acknowledgements/reactions with no content ("lol", "ok", "nice", "same", "haha", "brb"), status/feed noise, or people clearly talking to each other. STOP=explicit user stop.',
 		},
 		contexts: {
 			type: "array",

--- a/packages/core/src/services/message/stage1-prompt-tier.ts
+++ b/packages/core/src/services/message/stage1-prompt-tier.ts
@@ -133,8 +133,8 @@ available_contexts:
 {{availableContexts}}
 
 shouldRespond:
-- RESPOND: the message clearly asks you something, continues a conversation you are actively part of, or needs you to act
-- IGNORE: participants talking to each other, ambient chatter, bot/webhook/status feeds, anything not yours (most unaddressed messages)
+- RESPOND: the message asks something, needs you to act, continues a thread you are in, OR is ambient chatter with real substance you can add to — you are a chatty presence here, so engage anything with content
+- IGNORE: pure acknowledgements/reactions with no content ("lol", "ok", "nice", "same", "haha", "brb"), bot/webhook/status feeds, or people clearly talking to each other
 - STOP: user explicitly asked you to disengage
 
 rules when RESPOND:


### PR DESCRIPTION
## What

The Stage-1 `shouldRespond` guidance was one line ("RESPOND=reply, IGNORE=silent"), so in group channels the agent mirrored pure filler ("lol" → "lol") as readily as it engaged real conversation. This keeps the agent chatty on substance but teaches it to let content-free reactions pass — the "chatty but not noise" calibration.

Both surfaces that carry the decision are updated in lockstep so group behavior is consistent:
- **`actions/to-tool.ts`** — the universal `shouldRespond` field description (full/DM/unknown-channel path).
- **`services/message/stage1-prompt-tier.ts`** — the compact group-triage template (real GROUP/THREAD/FORUM channels). Its previous rule blanket-ignored "ambient chatter (most unaddressed messages)", which was actually *quieter* than the full path — so ambient-with-substance now RESPONDs there too, matching the full path.

New guidance both places: **RESPOND** to a question, a request, or ambient chatter with real substance you can add to (stay chatty); **IGNORE** pure acknowledgements/reactions with no content ("lol", "ok", "nice", "same", "haha", "brb"), status/feed noise, or people clearly talking to each other. The addressing gate (don't butt into others' 1:1s) is unchanged and still armed.

## Evidence

Live before/after in the test group channel (raw Discord API verified):

| Message | Before | After |
|---|---|---|
| "the printmaking studio looks cool" | spoke | **spoke** — "what kind of setup do they have?" |
| "whats a good wine with aged cheddar" | spoke | **spoke** — real answer |
| "lol" | spoke ("lol") | **quiet** |
| "haha nice" | spoke | **quiet** |
| "ok cool" | spoke | **quiet** |
| "hey @dana finished the zine?" | quiet | **quiet** (addressing gate) |

Substance and questions still engage; pure filler now passes; others' 1:1s still protected. message-service suite 188/188; core typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:4af614130656bbdad093148bcb2f19a5386b6ed0 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - chat-behavior change; before/after table in PR body

<!-- evidence-row:after-screenshots -->
- [ ] N/A - chat-behavior change; before/after table in PR body

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - live Discord transcripts serve as walkthrough

<!-- evidence-row:backend-logs -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:llm-trajectory -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - shouldRespond verdicts verified via raw Discord API

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces
