### PR TITLE
fix(cloud): honor limit=0 via ?? for memory and jobs pagination

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs.limit-zero.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs.limit-zero.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Verifies JobsRepository.findByFilters honors limit=0 via real PGlite.
+ * Covers the ||1000 → ??1000 fix: limit 0 must return 0 rows, not 1000.
+ * Uses real in-process PGlite with minimal jobs table, no mocks.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS ||= "1";
+
+const ORG_ID = "00000000-0000-4000-8000-00000000a001";
+const USER_ID = "00000000-0000-4000-8000-00000000a002";
+const PGLITE_TIMEOUT = 60_000;
+
+let dbWrite: typeof import("../../client").dbWrite;
+let closeDb: typeof import("../../client").closeDatabaseConnectionsForTests | undefined;
+let repo: typeof import("../jobs").jobsRepository;
+let ready = true;
+
+beforeAll(async () => {
+  try {
+    const client = await import("../../client");
+    dbWrite = client.dbWrite;
+    closeDb = client.closeDatabaseConnectionsForTests;
+    const mod = await import("../jobs");
+    repo = mod.jobsRepository;
+    // Minimal jobs table sufficient for findByFilters (id, type, status, data, organization_id, created_at)
+    await dbWrite.execute(`
+      CREATE TABLE IF NOT EXISTS jobs (
+        id uuid PRIMARY KEY,
+        type text NOT NULL,
+        status text NOT NULL DEFAULT 'pending',
+        data jsonb NOT NULL,
+        data_storage text NOT NULL DEFAULT 'inline',
+        data_key text,
+        agent_id text,
+        character_id text,
+        result jsonb,
+        result_storage text NOT NULL DEFAULT 'inline',
+        result_key text,
+        error text,
+        error_storage text NOT NULL DEFAULT 'inline',
+        error_key text,
+        attempts integer NOT NULL DEFAULT 0,
+        max_attempts integer NOT NULL DEFAULT 3,
+        execution_interruptions integer NOT NULL DEFAULT 0,
+        organization_id uuid NOT NULL,
+        user_id uuid,
+        api_key_id uuid,
+        generation_id uuid,
+        webhook_url text,
+        webhook_status text,
+        estimated_completion_at timestamp,
+        scheduled_for timestamp NOT NULL DEFAULT NOW(),
+        started_at timestamp,
+        execution_generation uuid,
+        execution_quiesced_at timestamp,
+        completed_at timestamp,
+        created_at timestamp NOT NULL DEFAULT NOW(),
+        updated_at timestamp NOT NULL DEFAULT NOW()
+      )
+    `);
+    await dbWrite.execute(`
+      CREATE TABLE IF NOT EXISTS organizations (id uuid PRIMARY KEY, name text, slug text)
+    `);
+    await dbWrite.execute(`
+      CREATE TABLE IF NOT EXISTS users (id uuid PRIMARY KEY, organization_id uuid, steward_user_id text)
+    `);
+    await dbWrite.execute(`INSERT INTO organizations (id, name, slug) VALUES ('${ORG_ID}', 'test-org', 'test-org') ON CONFLICT DO NOTHING`);
+    await dbWrite.execute(`INSERT INTO users (id, organization_id, steward_user_id) VALUES ('${USER_ID}', '${ORG_ID}', 'steward') ON CONFLICT DO NOTHING`);
+  } catch (e) {
+    ready = false;
+    console.error("[jobs.limit-zero] PGlite setup failed", e);
+  }
+}, PGLITE_TIMEOUT);
+
+beforeEach(async () => {
+  expect(ready).toBe(true);
+  await dbWrite.execute(`DELETE FROM jobs WHERE organization_id = '${ORG_ID}'`);
+});
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("JobsRepository.findByFilters limit=0 (real PGlite)", () => {
+  test("limit=0 returns 0 rows, undefined returns all, positive caps", async () => {
+    // seed 3 jobs
+    for (let i = 0; i < 3; i++) {
+      await dbWrite.execute(`
+        INSERT INTO jobs (id, type, status, data, organization_id, user_id, scheduled_for, created_at, updated_at)
+        VALUES (gen_random_uuid(), 'agent_message', 'pending', '{}'::jsonb, '${ORG_ID}', '${USER_ID}', NOW(), NOW(), NOW())
+      `);
+    }
+    const allUndefined = await repo.findByFilters({ organizationId: ORG_ID });
+    expect(allUndefined.length).toBe(3);
+
+    const withZero = await repo.findByFilters({ organizationId: ORG_ID, limit: 0 });
+    expect(withZero.length).toBe(0);
+
+    const withOne = await repo.findByFilters({ organizationId: ORG_ID, limit: 1 });
+    expect(withOne.length).toBe(1);
+
+    const withTwo = await repo.findByFilters({ organizationId: ORG_ID, limit: 2 });
+    expect(withTwo.length).toBe(2);
+
+    // old ||1000 would have returned 3 for limit 0, not 0
+    expect(withZero.length).not.toBe(allUndefined.length);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs.limit-zero.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs.limit-zero.test.ts
@@ -1,7 +1,6 @@
 /**
- * Verifies JobsRepository.findByFilters honors limit=0 via real PGlite.
- * Covers the ||1000 → ??1000 fix: limit 0 must return 0 rows, not 1000.
- * Uses real in-process PGlite with minimal jobs table, no mocks.
+ * Exercises JobsRepository.findByFilters against real in-process PGlite.
+ * Zero, omitted, and positive limits must retain distinct SQL semantics.
  */
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 
@@ -14,19 +13,16 @@ const USER_ID = "00000000-0000-4000-8000-00000000a002";
 const PGLITE_TIMEOUT = 60_000;
 
 let dbWrite: typeof import("../../client").dbWrite;
-let closeDb: typeof import("../../client").closeDatabaseConnectionsForTests | undefined;
+let closeDb: typeof import("../../client").closeDatabaseConnectionsForTests;
 let repo: typeof import("../jobs").jobsRepository;
-let ready = true;
 
 beforeAll(async () => {
-  try {
-    const client = await import("../../client");
-    dbWrite = client.dbWrite;
-    closeDb = client.closeDatabaseConnectionsForTests;
-    const mod = await import("../jobs");
-    repo = mod.jobsRepository;
-    // Minimal jobs table sufficient for findByFilters (id, type, status, data, organization_id, created_at)
-    await dbWrite.execute(`
+  const client = await import("../../client");
+  dbWrite = client.dbWrite;
+  closeDb = client.closeDatabaseConnectionsForTests;
+  const mod = await import("../jobs");
+  repo = mod.jobsRepository;
+  await dbWrite.execute(`
       CREATE TABLE IF NOT EXISTS jobs (
         id uuid PRIMARY KEY,
         type text NOT NULL,
@@ -60,33 +56,31 @@ beforeAll(async () => {
         created_at timestamp NOT NULL DEFAULT NOW(),
         updated_at timestamp NOT NULL DEFAULT NOW()
       )
-    `);
-    await dbWrite.execute(`
+  `);
+  await dbWrite.execute(`
       CREATE TABLE IF NOT EXISTS organizations (id uuid PRIMARY KEY, name text, slug text)
-    `);
-    await dbWrite.execute(`
+  `);
+  await dbWrite.execute(`
       CREATE TABLE IF NOT EXISTS users (id uuid PRIMARY KEY, organization_id uuid, steward_user_id text)
-    `);
-    await dbWrite.execute(`INSERT INTO organizations (id, name, slug) VALUES ('${ORG_ID}', 'test-org', 'test-org') ON CONFLICT DO NOTHING`);
-    await dbWrite.execute(`INSERT INTO users (id, organization_id, steward_user_id) VALUES ('${USER_ID}', '${ORG_ID}', 'steward') ON CONFLICT DO NOTHING`);
-  } catch (e) {
-    ready = false;
-    console.error("[jobs.limit-zero] PGlite setup failed", e);
-  }
+  `);
+  await dbWrite.execute(
+    `INSERT INTO organizations (id, name, slug) VALUES ('${ORG_ID}', 'test-org', 'test-org') ON CONFLICT DO NOTHING`,
+  );
+  await dbWrite.execute(
+    `INSERT INTO users (id, organization_id, steward_user_id) VALUES ('${USER_ID}', '${ORG_ID}', 'steward') ON CONFLICT DO NOTHING`,
+  );
 }, PGLITE_TIMEOUT);
 
 beforeEach(async () => {
-  expect(ready).toBe(true);
   await dbWrite.execute(`DELETE FROM jobs WHERE organization_id = '${ORG_ID}'`);
 });
 
 afterAll(async () => {
-  if (closeDb) await closeDb();
+  await closeDb();
 });
 
 describe("JobsRepository.findByFilters limit=0 (real PGlite)", () => {
   test("limit=0 returns 0 rows, undefined returns all, positive caps", async () => {
-    // seed 3 jobs
     for (let i = 0; i < 3; i++) {
       await dbWrite.execute(`
         INSERT INTO jobs (id, type, status, data, organization_id, user_id, scheduled_for, created_at, updated_at)
@@ -104,8 +98,6 @@ describe("JobsRepository.findByFilters limit=0 (real PGlite)", () => {
 
     const withTwo = await repo.findByFilters({ organizationId: ORG_ID, limit: 2 });
     expect(withTwo.length).toBe(2);
-
-    // old ||1000 would have returned 3 for limit 0, not 0
     expect(withZero.length).not.toBe(allUndefined.length);
   });
 });

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -615,7 +615,7 @@ export class JobsRepository {
     const query = dbRead.select().from(jobs).$dynamic();
 
     const rows = await (conditions.length > 0 ? query.where(and(...conditions)) : query)
-      .limit(filters.limit || 1000)
+      .limit(filters.limit ?? 1000)
       .orderBy(filters.orderBy === "desc" ? desc(jobs.created_at) : jobs.created_at);
     return await Promise.all(rows.map(hydrateJob));
   }

--- a/packages/cloud/shared/src/lib/api/a2a/skills.pagination-limit.test.ts
+++ b/packages/cloud/shared/src/lib/api/a2a/skills.pagination-limit.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Exercises the exported A2A skill handlers at their untrusted data boundary.
+ * The real handlers must preserve zero, apply defaults and caps, and reject
+ * malformed limits before invoking their service collaborators.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { RetrieveMemoriesInput } from "../../services/memory";
+import type { A2AContext } from "./types";
+
+const usageLimits: number[] = [];
+const memoryInputs: RetrieveMemoriesInput[] = [];
+const listByOrganization = mock(async () =>
+  Array.from({ length: 60 }, (_, index) => ({
+    id: `agent-${index}`,
+    name: `Agent ${index}`,
+    bio: [`Bio ${index}`],
+    avatar_url: null,
+    created_at: new Date(2026, 0, index + 1),
+  })),
+);
+
+mock.module("../../services/usage", () => ({
+  usageService: {
+    listByOrganization: async (_organizationId: string, limit: number) => {
+      usageLimits.push(limit);
+      return [];
+    },
+  },
+}));
+mock.module("../../services/characters/characters", () => ({
+  charactersService: { listByOrganization },
+}));
+mock.module("../../services/memory", () => ({
+  memoryService: {
+    retrieveMemories: async (input: RetrieveMemoriesInput) => {
+      memoryInputs.push(input);
+      return [];
+    },
+  },
+}));
+
+const context = {
+  apiKeyId: null,
+  agentIdentifier: "pagination-test-agent",
+  user: {
+    id: "user-1",
+    organization_id: "org-1",
+    organization: { id: "org-1" },
+  },
+} as A2AContext;
+
+beforeEach(() => {
+  usageLimits.length = 0;
+  memoryInputs.length = 0;
+  listByOrganization.mockClear();
+});
+
+describe("A2A skill limit boundary", () => {
+  test("get_usage preserves zero, defaults omitted, and caps positive limits", async () => {
+    const { executeSkillGetUsage } = await import("./skills");
+
+    await executeSkillGetUsage({ limit: 0 }, context);
+    await executeSkillGetUsage({}, context);
+    await executeSkillGetUsage({ limit: 80 }, context);
+
+    expect(usageLimits).toEqual([0, 10, 50]);
+  });
+
+  test("list_agents preserves zero, defaults omitted, and caps positive limits", async () => {
+    const { executeSkillListAgents } = await import("./skills");
+
+    const zero = await executeSkillListAgents({ limit: 0 }, context);
+    const omitted = await executeSkillListAgents({}, context);
+    const capped = await executeSkillListAgents({ limit: 80 }, context);
+
+    expect(zero.agents).toHaveLength(0);
+    expect(omitted.agents).toHaveLength(20);
+    expect(capped.agents).toHaveLength(50);
+    expect(listByOrganization).toHaveBeenCalledTimes(3);
+  });
+
+  test("retrieve_memories passes zero, default, and capped limits to MemoryService", async () => {
+    const { executeSkillRetrieveMemories } = await import("./skills");
+
+    await executeSkillRetrieveMemories("query-zero", { limit: 0 }, context);
+    await executeSkillRetrieveMemories("query-default", {}, context);
+    await executeSkillRetrieveMemories("query-capped", { limit: 80 }, context);
+
+    expect(memoryInputs.map((input) => input.limit)).toEqual([0, 10, 50]);
+  });
+
+  test.each([-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, "2", null])(
+    "rejects malformed limit %p before invoking any service",
+    async (limit) => {
+      const { executeSkillGetUsage, executeSkillListAgents, executeSkillRetrieveMemories } =
+        await import("./skills");
+
+      await expect(executeSkillGetUsage({ limit }, context)).rejects.toThrow(
+        "limit must be a non-negative safe integer",
+      );
+      await expect(executeSkillListAgents({ limit }, context)).rejects.toThrow(
+        "limit must be a non-negative safe integer",
+      );
+      await expect(executeSkillRetrieveMemories("query", { limit }, context)).rejects.toThrow(
+        "limit must be a non-negative safe integer",
+      );
+
+      expect(usageLimits).toEqual([]);
+      expect(memoryInputs).toEqual([]);
+      expect(listByOrganization).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/shared/src/lib/api/a2a/skills.ts
+++ b/packages/cloud/shared/src/lib/api/a2a/skills.ts
@@ -68,6 +68,15 @@ import type {
 } from "./types";
 
 const MIN_RESPONSE_TOKENS = 4096;
+const MAX_A2A_LIST_LIMIT = 50;
+
+function parseA2AListLimit(value: unknown, fallback: number): number {
+  if (value === undefined) return fallback;
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error("limit must be a non-negative safe integer");
+  }
+  return Math.min(MAX_A2A_LIST_LIMIT, value);
+}
 
 function rejectUnwiredPaidSkill(skillId: "chat_with_agent" | "video_generation"): never {
   throw new Error(
@@ -449,7 +458,7 @@ export async function executeSkillGetUsage(
   dataContent: Record<string, unknown>,
   ctx: A2AContext,
 ): Promise<UsageResult> {
-  const limit = Math.min(50, (dataContent.limit as number) ?? 10);
+  const limit = parseA2AListLimit(dataContent.limit, 10);
   const records = await usageService.listByOrganization(ctx.user.organization_id, limit);
   return {
     usage: records.map((r) => ({
@@ -472,7 +481,7 @@ export async function executeSkillListAgents(
   dataContent: Record<string, unknown>,
   ctx: A2AContext,
 ): Promise<ListAgentsResult> {
-  const limit = (dataContent.limit as number) ?? 20;
+  const limit = parseA2AListLimit(dataContent.limit, 20);
   const chars = await charactersService.listByOrganization(ctx.user.organization_id);
   return {
     agents: chars.slice(0, limit).map((c) => ({
@@ -563,7 +572,7 @@ export async function executeSkillRetrieveMemories(
   const roomId = dataContent.roomId as string | undefined;
   const type = dataContent.type as string[] | undefined;
   const tags = dataContent.tags as string[] | undefined;
-  const limit = Math.min(50, (dataContent.limit as number) ?? 10);
+  const limit = parseA2AListLimit(dataContent.limit, 10);
   const sortBy = (dataContent.sortBy as "relevance" | "recent" | "importance") || "relevance";
 
   const memories = await memoryService.retrieveMemories({

--- a/packages/cloud/shared/src/lib/api/a2a/skills.ts
+++ b/packages/cloud/shared/src/lib/api/a2a/skills.ts
@@ -449,7 +449,7 @@ export async function executeSkillGetUsage(
   dataContent: Record<string, unknown>,
   ctx: A2AContext,
 ): Promise<UsageResult> {
-  const limit = Math.min(50, (dataContent.limit as number) || 10);
+  const limit = Math.min(50, (dataContent.limit as number) ?? 10);
   const records = await usageService.listByOrganization(ctx.user.organization_id, limit);
   return {
     usage: records.map((r) => ({
@@ -472,7 +472,7 @@ export async function executeSkillListAgents(
   dataContent: Record<string, unknown>,
   ctx: A2AContext,
 ): Promise<ListAgentsResult> {
-  const limit = (dataContent.limit as number) || 20;
+  const limit = (dataContent.limit as number) ?? 20;
   const chars = await charactersService.listByOrganization(ctx.user.organization_id);
   return {
     agents: chars.slice(0, limit).map((c) => ({
@@ -563,7 +563,7 @@ export async function executeSkillRetrieveMemories(
   const roomId = dataContent.roomId as string | undefined;
   const type = dataContent.type as string[] | undefined;
   const tags = dataContent.tags as string[] | undefined;
-  const limit = Math.min(50, (dataContent.limit as number) || 10);
+  const limit = Math.min(50, (dataContent.limit as number) ?? 10);
   const sortBy = (dataContent.sortBy as "relevance" | "recent" | "importance") || "relevance";
 
   const memories = await memoryService.retrieveMemories({

--- a/packages/cloud/shared/src/lib/services/__tests__/memory.limit-zero.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/memory.limit-zero.test.ts
@@ -1,72 +1,190 @@
 /**
- * Verifies MemoryService honors limit=0 via real seams (no mocks hiding || vs ??).
- * Covers 3 branches: runtime.searchMemories, room DB limit, all-rooms batched.
- * Captures pagination count to prove ?? preserves 0 while || would coerce to 10.
+ * Exercises all three MemoryService retrieval branches against real PGlite
+ * tables while replacing only the runtime and cache collaborators. The suite
+ * proves zero, omitted, and positive limits reach the production query paths.
  */
-import { describe, expect, test } from "bun:test";
 
-process.env.DATABASE_URL ||= "pglite://memory";
+import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { AgentRuntime, Memory, UUID } from "@elizaos/core";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
-process.env.MOCK_REDIS ||= "1";
+process.env.MOCK_REDIS = "1";
 
-function makeRuntime(capture: (args: any) => void) {
-  return {
-    agentId: "agent-1",
-    getService: () => null,
-    searchMemories: async (params: any) => { capture(params); return []; },
-  } as any;
-}
+const ORGANIZATION_ID = "10000000-0000-4000-8000-000000000001";
+const USER_A_ID = "10000000-0000-4000-8000-000000000002";
+const USER_B_ID = "10000000-0000-4000-8000-000000000003";
+const AGENT_ID = "10000000-0000-4000-8000-000000000004" as UUID;
+const ROOM_A_ID = "10000000-0000-4000-8000-000000000005";
+const ROOM_B_ID = "10000000-0000-4000-8000-000000000006";
 
-describe("MemoryService.retrieveMemories limit=0 (real service seams)", () => {
-  test("passes limit=0 to runtime.searchMemories (branch with roomId)", async () => {
-    const mod = await import("../memory");
-    const MemoryService = (mod as any).MemoryService;
-    let captured: any = null;
-    const runtime = makeRuntime((args) => { captured = args; });
-    const svc = new MemoryService(runtime);
-    // Provide embedding? The service will call runtime.searchMemories when roomId present and embedding available.
-    // RetrieveMemories will try to use embedding; if missing it may go to DB path. We supply searchText so embedding path triggers.
-    // If our runtime mock lacks embedding generation, it may still call searchMemories.
-    captured = null;
-    try {
-      await svc.retrieveMemories({ roomId: "r1", searchText: "hello", limit: 0 } as any);
-    } catch {}
-    // Branch A: if searchMemories was called, limit should be 0 (not 10)
-    if (captured) {
-      expect(captured.limit).toBe(0);
-      expect(captured.limit).not.toBe(10);
-    } else {
-      // Fallback: direct proof that ?? preserves 0
-      const limitZero: number | undefined = 0;
-      expect(limitZero ?? 10).toBe(0);
-      expect((limitZero as any) || 10).toBe(10);
-    }
+type SearchMemoriesInput = Parameters<AgentRuntime["searchMemories"]>[0];
+const searchCalls: SearchMemoriesInput[] = [];
+
+const runtime = {
+  agentId: AGENT_ID,
+  searchMemories: async (input: SearchMemoriesInput): Promise<Memory[]> => {
+    searchCalls.push(input);
+    return [];
+  },
+};
+
+mock.module("../../eliza/runtime-factory", () => ({
+  runtimeFactory: { createRuntimeForUser: async () => runtime },
+}));
+mock.module("../../eliza/user-context", () => ({
+  userContextService: { createSystemContext: () => ({}) },
+}));
+mock.module("../../cache/memory-cache", () => ({
+  memoryCache: {
+    getSearchResults: async () => null,
+    cacheSearchResults: async () => undefined,
+  },
+}));
+
+let closeDatabase: () => Promise<void>;
+
+beforeAll(async () => {
+  const { closeDatabaseConnectionsForTests, dbWrite } = await import("../../../db/client");
+  const { pushSchemaToTestDb } = await import("../../../db/push-schema-for-tests");
+  const { organizations } = await import("../../../db/schemas/organizations");
+  const { users } = await import("../../../db/schemas/users");
+  const { agentTable, entityTable, memoryTable, participantTable, roomTable } = await import(
+    "../../../db/schemas/eliza"
+  );
+
+  closeDatabase = closeDatabaseConnectionsForTests;
+  await pushSchemaToTestDb({
+    agentTable,
+    entityTable,
+    memoryTable,
+    organizations,
+    participantTable,
+    roomTable,
+    users,
   });
 
-  test("passes limit=10 when undefined (default)", async () => {
-    const mod = await import("../memory");
-    const MemoryService = (mod as any).MemoryService;
-    let captured: any = null;
-    const runtime = makeRuntime((args) => { captured = args; });
-    const svc = new MemoryService(runtime);
-    captured = null;
-    try {
-      await svc.retrieveMemories({ roomId: "r1", searchText: "hello" } as any);
-    } catch {}
-    if (captured) {
-      expect(captured.limit).toBe(10);
-    } else {
-      expect((undefined as any) ?? 10).toBe(10);
-    }
+  await dbWrite.insert(organizations).values({
+    id: ORGANIZATION_ID,
+    name: "Memory pagination org",
+    slug: "memory-pagination-org",
+  });
+  await dbWrite.insert(users).values([
+    {
+      id: USER_A_ID,
+      organization_id: ORGANIZATION_ID,
+      steward_user_id: "memory-limit-user-a",
+    },
+    {
+      id: USER_B_ID,
+      organization_id: ORGANIZATION_ID,
+      steward_user_id: "memory-limit-user-b",
+    },
+  ]);
+  await dbWrite.insert(agentTable).values({ id: AGENT_ID, name: "Memory pagination agent" });
+  await dbWrite.insert(entityTable).values([
+    { id: USER_A_ID, agentId: AGENT_ID },
+    { id: USER_B_ID, agentId: AGENT_ID },
+  ]);
+  await dbWrite.insert(roomTable).values([
+    { id: ROOM_A_ID, agentId: AGENT_ID, source: "test", type: "DM" },
+    { id: ROOM_B_ID, agentId: AGENT_ID, source: "test", type: "DM" },
+  ]);
+  await dbWrite.insert(participantTable).values([
+    { entityId: USER_A_ID, roomId: ROOM_A_ID, agentId: AGENT_ID },
+    { entityId: USER_B_ID, roomId: ROOM_B_ID, agentId: AGENT_ID },
+  ]);
+
+  const memoryRows = [
+    { id: "10000000-0000-4000-8000-000000000011", roomId: ROOM_A_ID, entityId: USER_A_ID },
+    { id: "10000000-0000-4000-8000-000000000012", roomId: ROOM_A_ID, entityId: USER_A_ID },
+    { id: "10000000-0000-4000-8000-000000000013", roomId: ROOM_A_ID, entityId: USER_A_ID },
+    { id: "10000000-0000-4000-8000-000000000014", roomId: ROOM_B_ID, entityId: USER_B_ID },
+    { id: "10000000-0000-4000-8000-000000000015", roomId: ROOM_B_ID, entityId: USER_B_ID },
+  ];
+  await dbWrite.insert(memoryTable).values(
+    memoryRows.map((row, index) => ({
+      ...row,
+      agentId: AGENT_ID,
+      type: "messages",
+      content: { text: `memory-${index}` },
+    })),
+  );
+}, 60_000);
+
+beforeEach(() => {
+  searchCalls.length = 0;
+});
+
+afterAll(async () => {
+  await closeDatabase();
+  mock.restore();
+});
+
+describe("MemoryService.retrieveMemories pagination", () => {
+  test("query retrieval passes zero, default, and positive limits to runtime search", async () => {
+    const { memoryService } = await import("../memory");
+
+    await memoryService.retrieveMemories({
+      organizationId: ORGANIZATION_ID,
+      roomId: ROOM_A_ID,
+      query: "needle-zero",
+      limit: 0,
+    });
+    await memoryService.retrieveMemories({
+      organizationId: ORGANIZATION_ID,
+      roomId: ROOM_A_ID,
+      query: "needle-default",
+    });
+    await memoryService.retrieveMemories({
+      organizationId: ORGANIZATION_ID,
+      roomId: ROOM_A_ID,
+      query: "needle-positive",
+      limit: 2,
+    });
+
+    expect(searchCalls.map((call) => call.limit)).toEqual([0, 10, 2]);
   });
 
-  test("direct ?? preserves 0, || would not (all 3 memory limit sites)", () => {
-    const limitZero: number | undefined = 0;
-    const viaNullish = limitZero ?? 10;
-    const viaOr = (limitZero as any) || 10;
-    expect(viaNullish).toBe(0);
-    expect(viaOr).toBe(10);
-    expect(viaNullish).not.toBe(viaOr);
-    // Also verify the 3 fixed lines in memory.ts use ?? (static check)
+  test("single-room SQL retrieval honors zero, default, and positive limits", async () => {
+    const { memoryService } = await import("../memory");
+
+    const zero = await memoryService.retrieveMemories({
+      organizationId: ORGANIZATION_ID,
+      roomId: ROOM_A_ID,
+      limit: 0,
+    });
+    const omitted = await memoryService.retrieveMemories({
+      organizationId: ORGANIZATION_ID,
+      roomId: ROOM_A_ID,
+    });
+    const positive = await memoryService.retrieveMemories({
+      organizationId: ORGANIZATION_ID,
+      roomId: ROOM_A_ID,
+      limit: 2,
+    });
+
+    expect(zero).toHaveLength(0);
+    expect(omitted).toHaveLength(3);
+    expect(positive).toHaveLength(2);
+  });
+
+  test("all-room SQL retrieval honors zero, default, and positive limits", async () => {
+    const { memoryService } = await import("../memory");
+
+    const zero = await memoryService.retrieveMemories({
+      organizationId: ORGANIZATION_ID,
+      limit: 0,
+    });
+    const omitted = await memoryService.retrieveMemories({ organizationId: ORGANIZATION_ID });
+    const positive = await memoryService.retrieveMemories({
+      organizationId: ORGANIZATION_ID,
+      limit: 2,
+    });
+
+    expect(zero).toHaveLength(0);
+    expect(omitted).toHaveLength(5);
+    expect(positive).toHaveLength(2);
   });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/memory.limit-zero.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/memory.limit-zero.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Verifies MemoryService honors limit=0 via real seams (no mocks hiding || vs ??).
+ * Covers 3 branches: runtime.searchMemories, room DB limit, all-rooms batched.
+ * Captures pagination count to prove ?? preserves 0 while || would coerce to 10.
+ */
+import { describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS ||= "1";
+
+function makeRuntime(capture: (args: any) => void) {
+  return {
+    agentId: "agent-1",
+    getService: () => null,
+    searchMemories: async (params: any) => { capture(params); return []; },
+  } as any;
+}
+
+describe("MemoryService.retrieveMemories limit=0 (real service seams)", () => {
+  test("passes limit=0 to runtime.searchMemories (branch with roomId)", async () => {
+    const mod = await import("../memory");
+    const MemoryService = (mod as any).MemoryService;
+    let captured: any = null;
+    const runtime = makeRuntime((args) => { captured = args; });
+    const svc = new MemoryService(runtime);
+    // Provide embedding? The service will call runtime.searchMemories when roomId present and embedding available.
+    // RetrieveMemories will try to use embedding; if missing it may go to DB path. We supply searchText so embedding path triggers.
+    // If our runtime mock lacks embedding generation, it may still call searchMemories.
+    captured = null;
+    try {
+      await svc.retrieveMemories({ roomId: "r1", searchText: "hello", limit: 0 } as any);
+    } catch {}
+    // Branch A: if searchMemories was called, limit should be 0 (not 10)
+    if (captured) {
+      expect(captured.limit).toBe(0);
+      expect(captured.limit).not.toBe(10);
+    } else {
+      // Fallback: direct proof that ?? preserves 0
+      const limitZero: number | undefined = 0;
+      expect(limitZero ?? 10).toBe(0);
+      expect((limitZero as any) || 10).toBe(10);
+    }
+  });
+
+  test("passes limit=10 when undefined (default)", async () => {
+    const mod = await import("../memory");
+    const MemoryService = (mod as any).MemoryService;
+    let captured: any = null;
+    const runtime = makeRuntime((args) => { captured = args; });
+    const svc = new MemoryService(runtime);
+    captured = null;
+    try {
+      await svc.retrieveMemories({ roomId: "r1", searchText: "hello" } as any);
+    } catch {}
+    if (captured) {
+      expect(captured.limit).toBe(10);
+    } else {
+      expect((undefined as any) ?? 10).toBe(10);
+    }
+  });
+
+  test("direct ?? preserves 0, || would not (all 3 memory limit sites)", () => {
+    const limitZero: number | undefined = 0;
+    const viaNullish = limitZero ?? 10;
+    const viaOr = (limitZero as any) || 10;
+    expect(viaNullish).toBe(0);
+    expect(viaOr).toBe(10);
+    expect(viaNullish).not.toBe(viaOr);
+    // Also verify the 3 fixed lines in memory.ts use ?? (static check)
+  });
+});

--- a/packages/cloud/shared/src/lib/services/memory.ts
+++ b/packages/cloud/shared/src/lib/services/memory.ts
@@ -283,7 +283,7 @@ export class MemoryService {
         memories = await runtime.searchMemories({
           embedding,
           tableName: "memories",
-          limit: input.limit || 10,
+          limit: input.limit ?? 10,
           roomId: input.roomId as UUID,
           match_threshold: 0.7,
         });
@@ -297,7 +297,7 @@ export class MemoryService {
             and(eq(memoryTable.roomId, input.roomId), eq(memoryTable.agentId, runtime.agentId)),
           )
           .orderBy(desc(memoryTable.createdAt))
-          .limit(input.limit || 10);
+          .limit(input.limit ?? 10);
 
         memories = results.map(
           (row) =>
@@ -329,7 +329,7 @@ export class MemoryService {
         return [];
       }
 
-      const limit = input.limit || 10;
+      const limit = input.limit ?? 10;
       const roomIdArray = Array.from(allowedRoomIds);
 
       // PERFORMANCE FIX: Use single batched query with IN clause instead of N+1 queries


### PR DESCRIPTION
# Relates to

Self-found pagination correctness bug: numeric `limit=0` was treated as omitted at seven cloud call sites because truthy `||` defaults were used. This PR now preserves zero in `MemoryService`, `JobsRepository`, and the A2A skill handlers. The A2A boundary also validates that limits are non-negative safe integers and caps list operations at 50.

- [x] Targets `develop` and is rebased on `e60120a0e2f26b36a26b42d9558ecc54fe1a43b7`.
- [x] No schema, migration, dependency, UI, model, or prompt change.
- [x] Real PGlite exercises the jobs repository and both SQL memory branches.
- [x] Production exported A2A handlers exercise zero/default/cap and reject malformed input before service invocation.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5, openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `claude-code, Codex desktop / multi-agent`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@e60120a0e2f26b36a26b42d9558ecc54fe1a43b7:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop` with zero conflicts.
- [x] Exact candidate: `197e9420d0fb3578d8bef1868dc304bdb4279a7b`.
- [x] `git diff --check` is clean.

# Risks

Low and bounded. `0` now has conventional empty-page semantics rather than silently becoming 10, 20, or 1000. Omitted values retain their existing defaults. A2A list requests above 50 are capped, and negative, fractional, non-finite, string, and null limits are rejected at the untrusted handler boundary instead of flowing into services or `slice`.

# What changed

- Replaced seven `||` pagination defaults with nullish/default-aware handling.
- Added one shared A2A limit parser for an integer lower bound and 50-item upper bound.
- Replaced the earlier memory test replica/seam assertions with production `MemoryService.retrieveMemories` calls, backed by real PGlite for both SQL branches and the actual runtime search path for query retrieval.
- Kept the jobs proof on the actual repository/PGlite path and removed conditional setup/assertion behavior.
- Added direct tests of the three exported A2A skill handlers.

# Testing

All commands were run from exact head `197e9420d0fb3578d8bef1868dc304bdb4279a7b` with pinned Bun `1.3.14`:

```text
bunx bun@1.3.14 --config=.review-bunfig.toml test --isolate ./packages/cloud/shared/src/lib/services/__tests__/memory.limit-zero.test.ts --timeout 60000
3 pass, 0 fail, 7 assertions

bunx bun@1.3.14 --config=.review-bunfig.toml test --isolate ./packages/cloud/shared/src/lib/api/a2a/skills.pagination-limit.test.ts --timeout 60000
9 pass, 0 fail, 42 assertions

bunx bun@1.3.14 --config=.review-bunfig.toml test --isolate ./packages/cloud/shared/src/db/repositories/__tests__/jobs.limit-zero.test.ts --timeout 60000
1 pass, 0 fail, 5 assertions

bunx bun@1.3.14 run --cwd packages/cloud/shared typecheck
exit 0

bunx @biomejs/biome check <four touched test/handler files>
Checked 4 files. No fixes applied.

git diff --check
exit 0
```

The temporary test config only disabled repository-wide coverage collection for these focused runs; it was not committed.

# Evidence Gate

<!-- evidence-head:197e9420d0fb3578d8bef1868dc304bdb4279a7b -->

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only pagination behavior; no visual surface changed`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only pagination behavior; no visual surface changed`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - no UI workflow; the real repository/service/handler outputs are captured by focused tests`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: focused production-path test transcript.

  <details><summary>Pinned Bun 1.3.14 focused runs</summary>

  ```text
  memory.limit-zero.test.ts: 3 pass, 0 fail, 7 assertions
  skills.pagination-limit.test.ts: 9 pass, 0 fail, 42 assertions
  jobs.limit-zero.test.ts: 1 pass, 0 fail, 5 assertions
  packages/cloud/shared typecheck: exit 0
  Biome: Checked 4 files. No fixes applied.
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend code or browser path changed`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent behavior, model, prompt, or provider path changed`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: actual PGlite and handler result summary.

  <details><summary>Pagination contract results</summary>

  ```text
  JobsRepository real PGlite: omitted=3, limit 0=0, limit 1=1, limit 2=2
  MemoryService single-room real PGlite: limit 0=0, omitted=3, limit 2=2
  MemoryService all-room real PGlite: limit 0=0, omitted=5, limit 2=2
  A2A handlers: zero preserved, omitted defaults applied, values above 50 capped
  A2A handlers: negative/fractional/non-finite/string/null rejected before collaborators
  ```

  </details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - no rendered visual surface`.

---
— [codex-root/pr-20721-repair]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@e60120a0e2f26b36a26b42d9558ecc54fe1a43b7:packages/skills/skills/contribute-to-eliza"} -->
