### PR TITLE
fix(apps): validate directory paths at host boundary

### DIFF
--- a/packages/shared/src/contracts/apps-loading-routes.test.ts
+++ b/packages/shared/src/contracts/apps-loading-routes.test.ts
@@ -1,7 +1,7 @@
 /**
- * Contract tests for the load-apps-from-directory route Zod schemas: the request (absolute-path
- * requirement) and the success response carrying registered items plus rejected-manifest
- * diagnostics. Parses real fixtures for accept/reject cases.
+ * Contract tests for the load-apps-from-directory route Zod schemas: the structural request and
+ * success response carrying registered items plus rejected-manifest diagnostics. Host-native path
+ * semantics are exercised by the server route tests.
  */
 import { describe, expect, it } from "vitest";
 import {
@@ -17,28 +17,14 @@ describe("PostLoadFromDirectoryRequestSchema", () => {
     expect(parsed.directory).toBe("/tmp/apps");
   });
 
-  it("matches the host platform's rooted-path semantics", () => {
-    if (process.platform === "win32") {
-      expect(
-        PostLoadFromDirectoryRequestSchema.parse({ directory: "C:\\apps" })
-          .directory,
-      ).toBe("C:\\apps");
-      expect(
-        PostLoadFromDirectoryRequestSchema.parse({ directory: "\\apps" })
-          .directory,
-      ).toBe("\\apps");
-      return;
-    }
-
-    expect(() =>
-      PostLoadFromDirectoryRequestSchema.parse({ directory: "C:\\apps" }),
-    ).toThrow(/absolute path/);
-  });
-
-  it("rejects a relative path", () => {
-    expect(() =>
-      PostLoadFromDirectoryRequestSchema.parse({ directory: "apps" }),
-    ).toThrow(/absolute path/);
+  it("leaves host-native path validation to the server boundary", () => {
+    expect(
+      PostLoadFromDirectoryRequestSchema.parse({ directory: "apps" }).directory,
+    ).toBe("apps");
+    expect(
+      PostLoadFromDirectoryRequestSchema.parse({ directory: "C:\\apps" })
+        .directory,
+    ).toBe("C:\\apps");
   });
 
   it("rejects an empty string", () => {

--- a/packages/shared/src/contracts/apps-loading-routes.ts
+++ b/packages/shared/src/contracts/apps-loading-routes.ts
@@ -6,9 +6,8 @@
  * Second migration in the typed-routes initiative — the App Permissions
  * routes were the pilot in `./app-permissions-routes.ts`. The pattern
  * (schema in shared, safeParse on server, infer types on client) is
- * the same here; the only new wrinkle is `.refine()` for the
- * absolute-path check that previously lived as a hand-rolled `if
- * (!path.isAbsolute(directory))` guard in the route handler.
+ * the same here. Host-platform path semantics remain at the server boundary so
+ * this browser-safe contract does not depend on, or emulate, Node's path API.
  *
  * Routes covered:
  *   POST /api/apps/load-from-directory
@@ -24,28 +23,9 @@
 
 import z from "zod";
 
-/**
- * Match `path.isAbsolute` without importing a Node-only module into the shared
- * browser-safe contract barrel. Windows accepts rooted slash/backslash paths
- * and drive-rooted paths; POSIX requires a leading slash.
- */
-function isAbsoluteDirectoryPath(value: string): boolean {
-  const platform =
-    typeof process === "undefined" ? undefined : process.platform;
-  if (platform === "win32") {
-    return /^[\\/]/.test(value) || /^[A-Za-z]:[\\/]/.test(value);
-  }
-  return value.startsWith("/");
-}
-
 export const PostLoadFromDirectoryRequestSchema = z
   .object({
-    directory: z
-      .string()
-      .min(1, "directory is required")
-      .refine(isAbsoluteDirectoryPath, {
-        message: "directory must be an absolute path",
-      }),
+    directory: z.string().min(1, "directory is required"),
   })
   .strict();
 

--- a/plugins/plugin-app-manager/src/api/apps-routes.test.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.test.ts
@@ -149,6 +149,21 @@ function sanitizeExpectedFavorites(values: readonly string[]): string[] {
 }
 
 describe("handleAppsRoutes", () => {
+  it("rejects relative app directories at the host boundary", async () => {
+    const result = await callRoute({
+      method: "POST",
+      pathname: "/api/apps/load-from-directory",
+      body: { directory: "apps" },
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.res.status).toBe(400);
+    expect(result.res.body).toEqual({
+      error:
+        "Invalid request body at directory: directory must be an absolute path",
+    });
+  });
+
   it("rejects malformed favorite updates before writing the store", async () => {
     const store = createFavoriteStore(["@elizaos/plugin-phone"]);
 

--- a/plugins/plugin-app-manager/src/api/apps-routes.ts
+++ b/plugins/plugin-app-manager/src/api/apps-routes.ts
@@ -1560,8 +1560,8 @@ export async function handleAppsRoutes(
   if (method === "POST" && pathname === "/api/apps/load-from-directory") {
     // Body validation goes through PostLoadFromDirectoryRequestSchema
     // (zod, see @elizaos/shared/contracts/apps-loading-routes.ts).
-    // The schema handles the required check, the absolute-path check,
-    // and rejects extra unknown fields via .strict().
+    // The browser-safe schema handles the structural wire contract. The host
+    // owns native path semantics and rejects non-absolute directories here.
     const rawBody = await readJsonBody<Record<string, unknown>>(req, res);
     if (rawBody === null) return true;
     const parsed = PostLoadFromDirectoryRequestSchema.safeParse(rawBody);
@@ -1572,6 +1572,14 @@ export async function handleAppsRoutes(
       return true;
     }
     const directory = parsed.data.directory;
+    if (!path.isAbsolute(directory)) {
+      error(
+        res,
+        "Invalid request body at directory: directory must be an absolute path",
+        400,
+      );
+      return true;
+    }
 
     const runtimeWithServices = runtime as {
       getService?: (type: string) => {


### PR DESCRIPTION
## Summary

- keep the shared app-loading request schema browser-safe and structural
- validate absolute directory paths with Node's host-native path implementation in the app-manager route
- reject relative directories before invoking app loading

Closes #20690

## Validation

- exact-head shared contract suite: 12/12
- exact-head app-manager route suite: 12/12
- shared and app-manager typecheck/lint: pass
- full app audit with this repair: 219/219; broken=0; needs-work=0
- packaged OCR: 216 views; verified=200; broken=0
- root verify passed three times during rebase churn: 356/356 plus anti-larp clean; the final exact-head rebase added only the unrelated plugin-github notification merge, after which both affected suites were rerun and passed

## Scope

No deployment, credential use, environment approval, or external service mutation.

<!-- evidence-head:7392aac04591bf47d0fe1842746164d0b68bc69c -->