### PR TITLE
fix(infra): relinquish R2 blob DNS ownership

### DIFF
--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/README.md
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/README.md
@@ -26,9 +26,11 @@ documentation.
 `www.eliza.app` is attached to the same project so the Pages middleware can
 issue its canonical redirect. Legacy names are intentionally **not** Pages
 custom domains. Their proxied DNS exists only to enter the `elizacloud.ai`
-Worker routes, which return deterministic 308 redirects. The exact inventory
-includes the retired `docs.elizacloud.ai` host, legacy browser names, and the
-legacy API/blob/plugin/x402 names.
+Worker routes, which return deterministic 308 redirects. The exact Terraform
+inventory includes the retired `docs.elizacloud.ai` host, legacy browser names,
+and the legacy API/plugin/relay/x402 names. Cloudflare R2 owns
+`blob.elizacloud.ai` and `blob-staging.elizacloud.ai`; this root must not modify
+or delete those provider-generated custom-domain records.
 
 ## Wildcard TLS
 
@@ -118,6 +120,14 @@ Omit a key only when the corresponding DNS record genuinely does not exist.
 The examples under `tfvars/` enumerate the exact resource keys. An omitted live
 record will make Cloudflare reject the create; it must not be worked around by
 deleting DNS before state adoption.
+
+The legacy blob custom domains are the deliberate exception to the Pages DNS
+inventory. R2 generates those records and rejects DNS API edits. Before the
+first plan with this ownership boundary, dispatch the protected Infrastructure
+workflow once per environment with `operation=state-rm` and the exact address
+`cloudflare_dns_record.pages["legacy_blob"]`. That removes only Terraform state;
+operators must leave both live records in R2 and omit `pages/legacy_blob` from
+new import inventories.
 
 Canonical Pages bindings use deterministic configuration-driven imports of the
 form `<account-id>/eliza-app/<domain>`. The cutover therefore attaches the

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/main.tf
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/main.tf
@@ -62,11 +62,6 @@ locals {
       cname_target = "eliza-app.pages.dev"
       zone_id      = var.elizacloud_ai_zone_id
     }
-    legacy_blob = {
-      domain       = "blob.elizacloud.ai"
-      cname_target = "eliza-app.pages.dev"
-      zone_id      = var.elizacloud_ai_zone_id
-    }
     legacy_plugins = {
       domain       = "plugins.elizacloud.ai"
       cname_target = "eliza-app.pages.dev"
@@ -95,11 +90,6 @@ locals {
     }
     legacy_api = {
       domain       = "api-staging.elizacloud.ai"
-      cname_target = "develop.eliza-app.pages.dev"
-      zone_id      = var.elizacloud_ai_zone_id
-    }
-    legacy_blob = {
-      domain       = "blob-staging.elizacloud.ai"
       cname_target = "develop.eliza-app.pages.dev"
       zone_id      = var.elizacloud_ai_zone_id
     }

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/tfvars/production.tfvars.example
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/tfvars/production.tfvars.example
@@ -13,7 +13,6 @@ dns_record_import_ids = {
   "pages/legacy_www"       = "<record-id-for-www.elizacloud.ai>"
   "pages/legacy_docs"      = "<record-id-for-docs.elizacloud.ai>"
   "pages/legacy_api"       = "<record-id-for-api.elizacloud.ai>"
-  "pages/legacy_blob"      = "<record-id-for-blob.elizacloud.ai>"
   "pages/legacy_plugins"   = "<record-id-for-plugins.elizacloud.ai>"
   "pages/legacy_relay"     = "<record-id-for-relay.elizacloud.ai>"
   "pages/legacy_x402"      = "<record-id-for-x402.elizacloud.ai>"

--- a/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/tfvars/staging.tfvars.example
+++ b/packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/tfvars/staging.tfvars.example
@@ -10,7 +10,6 @@ dns_record_import_ids = {
   "pages/console"                                                     = "<record-id-for-staging.elizacloud.ai>"
   "pages/app"                                                         = "<record-id-for-app-staging.elizacloud.ai>"
   "pages/legacy_api"                                                  = "<record-id-for-api-staging.elizacloud.ai>"
-  "pages/legacy_blob"                                                 = "<record-id-for-blob-staging.elizacloud.ai>"
   "pages/legacy_plugins"                                              = "<record-id-for-plugins.staging.elizacloud.ai>"
   "pages/legacy_relay"                                                = "<record-id-for-relay-staging.elizacloud.ai>"
   "pages/legacy_x402"                                                 = "<record-id-for-x402-staging.elizacloud.ai>"

--- a/packages/cloud/infra/tests/terraform-static.test.ts
+++ b/packages/cloud/infra/tests/terraform-static.test.ts
@@ -400,7 +400,6 @@ describe("Cloudflare Pages domain durability", () => {
       "www.elizacloud.ai",
       "docs.elizacloud.ai",
       "api.elizacloud.ai",
-      "blob.elizacloud.ai",
       "plugins.elizacloud.ai",
       "relay.elizacloud.ai",
       "x402.elizacloud.ai",
@@ -423,6 +422,19 @@ describe("Cloudflare Pages domain durability", () => {
     expect(variables).toContain('variable "legacy_redirect_wildcard_origins"');
     expect(variables).toContain('variable "legacy_redirect_certificate_packs"');
     expect(outputs).toContain('output "redirect_dns"');
+  });
+
+  test("relinquishes R2-owned legacy blob DNS without destroying live records", () => {
+    expect(main).not.toContain("legacy_blob = {");
+    expect(stagingExample).not.toContain('"pages/legacy_blob"');
+    expect(productionExample).not.toContain('"pages/legacy_blob"');
+    expect(readme).toContain("Cloudflare R2 owns");
+    expect(readme).toContain("`blob.elizacloud.ai`");
+    expect(readme).toContain("`blob-staging.elizacloud.ai`");
+    expect(readme).toContain("operators must leave both live records in R2");
+    expect(readme).toContain("`operation=state-rm`");
+    expect(readme).toContain('`cloudflare_dns_record.pages["legacy_blob"]`');
+    expect(workflow).toContain('terraform state rm "$STATE_ADDRESS"');
   });
 
   test("keeps real writes manual and verifies certificate plus routing after apply", () => {


### PR DESCRIPTION
# Relates to

Fixes #20715.

- [x] Targets `develop`; exact head parent is `98f22c64cfb8b0e7deea15184e2b0c45a9a9a920` and the current base `8251ec3818cb2994353528c5eed3f22dbc62ba73` is path-disjoint with a clean merge tree.
- [x] Full `bun install` completed without lockfile drift.
- [x] Exact focused and repository gates are recorded below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@c188bc2ccc06e857f9626a2f75f07d42ab0865f3:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Exact head parent is `98f22c64cfb8b0e7deea15184e2b0c45a9a9a920`; current `origin/develop@8251ec3818cb2994353528c5eed3f22dbc62ba73` advances only the embeddings image and core chat-response prompt, has zero touched-path intersection, and `git merge-tree --write-tree` succeeds as tree `97494cca4ebbb1412b8fd3118a188d2de684db30`.
- [x] Full uncached `TURBO_FORCE=1 bun run verify` passed 356/356 with every follow-on audit green before the final disjoint base-only rebase; the post-rebase infra suite and both Terraform formatters pass at exact head.

# Risks

Medium operational risk, fail-closed. The code intentionally stops Terraform from owning two provider-generated R2 DNS records. State must be removed with the existing protected workflow before any plan on the new configuration; removing state does not delete either live DNS record. The current pre-fix plan is intentionally not applicable because it would try to rewrite the R2-owned staging record.

# Background

## What does this PR do?

Cloudflare R2 generates and owns `blob.elizacloud.ai` and `blob-staging.elizacloud.ai`. Terraform currently imports those records into `cloudflare_dns_record.pages`, then attempts to replace their R2 target with the Pages project target. Cloudflare rejects that edit, leaving every full pages-domains apply red.

This patch removes `legacy_blob` from both environment inventories, removes the obsolete import-id examples, documents the exact protected `state-rm` choreography, and pins the non-management/no-destroy contract in the real static infrastructure suite. It does not delete, edit, or recreate either live R2 record.

## What kind of change is this?

Bug fix and infrastructure ownership correction.

# Documentation changes needed?

The pages-domains runbook now documents R2 ownership and the exact protected state-removal address.

# Testing

## Where should a reviewer start?

- `packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/main.tf`
- `packages/cloud/infra/cloud/terraform/cloudflare/pages-domains/README.md`
- `packages/cloud/infra/tests/terraform-static.test.ts`

## Detailed testing steps

- `bun run --cwd packages/cloud/infra test` — 57/57, 469 expectations.
- `bun test packages/cloud/infra/tests/terraform-static.test.ts` — 21/21, 194 expectations.
- OpenTofu and Terraform recursive format checks pass.
- `TURBO_FORCE=1 bun run verify` — 356/356 uncached, all repository audits green.
- Protected diagnostic plan `31976233337` proved `1 import, 0 add, 1 change, 0 destroy`; the only change is the exact R2-owned record this patch relinquishes. That artifact was not applied.

# Evidence Gate

<!-- evidence-head:fab5c6c35b51d37204b2f1a8df2b40ce0b63adf4 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI surface changes.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - protected Terraform ownership and state workflow only; no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no application backend runtime changes; exact provider-operation evidence is captured as a domain artifact.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser request/state changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, action, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [Exact source, diagnostic plan, and public DNS evidence](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20725-r2-dns-ownership-evidence-fab5c6c.log).
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Known gaps / failures

- No provider mutation is performed by this PR. After merge, acceptance is: protected staging state removal for the exact address, removal of the obsolete protected import key, a fresh reviewed plan with no unexpected action, exact encrypted apply, and an idempotent post-plan. Production state removal follows only after this tree is promoted to `main`.
- The full root gate was run at patch-equivalent head `8e3b0f6b844631ac818b9b7105568ab285bfd4ff`; the final rebase added only the disjoint app-manager path-validation merge. Subsequent current-base advances are also disjoint. Exact-head focused infra/format/diff gates pass, and hosted checks provide the final current-base integration proof.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@c188bc2ccc06e857f9626a2bcf227f4cafb2b5:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [cloud-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex Desktop","skill_revision":"elizaOS/eliza@c188bc2ccc06e857f9626a2bcf227f4cafb2b5:packages/skills/skills/contribute-to-eliza"} -->
