### PR TITLE
fix(cloud,core): strict tail/limit clamp via parseClampedLimit

### DIFF
--- a/packages/cloud/api/compat/agents/[id]/logs/route.ts
+++ b/packages/cloud/api/compat/agents/[id]/logs/route.ts
@@ -18,6 +18,7 @@ import { envelope, errorEnvelope } from "@/lib/api/compat-envelope";
 import type { RouteContext } from "@/lib/api/hono-next-style-params";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
+import { parseClampedLimit } from "@/lib/utils/clamp-limit";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { requireCompatAuth } from "../../../_lib/auth";
@@ -47,11 +48,7 @@ async function __hono_GET(
     }
 
     const url = new URL(request.url);
-    const rawTail = parseInt(url.searchParams.get("tail") ?? "100", 10);
-    const tail = Math.max(
-      1,
-      Math.min(Number.isFinite(rawTail) ? rawTail : 100, 5000),
-    );
+    const tail = parseClampedLimit(url.searchParams.get("tail"), 100, 5000);
 
     const enqueueResult = await provisioningJobService.enqueueAgentLogsOnce({
       agentId,

--- a/packages/cloud/api/v1/agents/[agentId]/logs/route.ts
+++ b/packages/cloud/api/v1/agents/[agentId]/logs/route.ts
@@ -22,6 +22,7 @@ import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireServiceKey } from "@/lib/auth/service-key-hono-worker";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
+import { parseClampedLimit } from "@/lib/utils/clamp-limit";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -37,11 +38,7 @@ app.get("/", async (c) => {
       return c.json({ success: false, error: "Agent not found" }, 404);
     }
 
-    const rawTail = parseInt(c.req.query("tail") ?? "100", 10);
-    const tail = Math.max(
-      1,
-      Math.min(Number.isFinite(rawTail) ? rawTail : 100, 5000),
-    );
+    const tail = parseClampedLimit(c.req.query("tail"), 100, 5000);
 
     const enqueueResult = await provisioningJobService.enqueueAgentLogsOnce({
       agentId,

--- a/packages/cloud/services/container-control-plane/src/index.ts
+++ b/packages/cloud/services/container-control-plane/src/index.ts
@@ -40,6 +40,7 @@ import {
   elizaSandboxService,
 } from "@elizaos/cloud-shared/lib/services/eliza-sandbox";
 import { provisioningJobService } from "@elizaos/cloud-shared/lib/services/provisioning-jobs";
+import { parseClampedLimit } from "@elizaos/cloud-shared/lib/utils/clamp-limit";
 import { logger } from "@elizaos/cloud-shared/lib/utils/logger";
 import { type Context, Hono } from "hono";
 
@@ -1296,7 +1297,7 @@ app.patch("/api/v1/containers/:id", (c) =>
 
 app.get("/api/v1/containers/:id/logs", (c) =>
   handle(c, async (auth) => {
-    const tail = Number(c.req.query("tail") ?? "200");
+    const tail = parseClampedLimit(c.req.query("tail"), 200, 1000);
     const logs = await client.tailLogs(
       c.req.param("id"),
       auth.organizationId,

--- a/packages/core/src/features/trajectories/read-routes.ts
+++ b/packages/core/src/features/trajectories/read-routes.ts
@@ -332,16 +332,24 @@ export async function tryHandleTrajectoryReadRoutes(options: {
 				);
 			}
 			const rawLimit = url.searchParams.get("limit");
-			const requestedLimit = rawLimit === null ? Number.NaN : Number(rawLimit);
-			const limit = Number.isFinite(requestedLimit)
-				? Math.min(500, Math.max(1, Math.trunc(requestedLimit)))
-				: 50;
+			const limit = (() => {
+				const fallback = 50;
+				const max = 500;
+				if (rawLimit === null || rawLimit === "") return fallback;
+				if (!/^\d+$/.test(rawLimit)) return fallback;
+				const parsed = Number(rawLimit);
+				if (!Number.isSafeInteger(parsed) || parsed <= 0) return fallback;
+				return Math.min(parsed, max);
+			})();
 			const rawOffset = url.searchParams.get("offset");
-			const requestedOffset =
-				rawOffset === null ? Number.NaN : Number(rawOffset);
-			const offset = Number.isFinite(requestedOffset)
-				? Math.max(0, Math.trunc(requestedOffset))
-				: 0;
+			const offset = (() => {
+				const fallback = 0;
+				if (rawOffset === null || rawOffset === "") return fallback;
+				if (!/^\d+$/.test(rawOffset)) return fallback;
+				const parsed = Number(rawOffset);
+				if (!Number.isSafeInteger(parsed) || parsed < 0) return fallback;
+				return parsed;
+			})();
 			const result = await service.listTrajectories({
 				limit,
 				offset,

--- a/packages/core/src/limit-tail-clamp.test.ts
+++ b/packages/core/src/limit-tail-clamp.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Strict tail/limit clamp for container + agent logs + trajectories — pins weak
+ * Number/parseInt without ^\d+$ + isSafeInteger that accepted 5junk/1e4/5.5.
+ * Sibling correct: packages/cloud/shared/src/lib/utils/clamp-limit.ts:8
+ * parseClampedLimit with /^\d+$/ + isSafeInteger + Math.min, and
+ * packages/cloud/api/v1/admin/docker-containers/route.ts:36 parseContainerListLimit.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+function oldContainerTail(raw: string | null | undefined): number {
+	return Number(raw ?? "200");
+}
+
+function oldApiTail(raw: string | null | undefined): number {
+	const rawTail = Number.parseInt(raw ?? "100", 10);
+	return Math.max(1, Math.min(Number.isFinite(rawTail) ? rawTail : 100, 5000));
+}
+
+function oldTrajectoryLimit(raw: string | null | undefined): number {
+	const requestedLimit =
+		raw === null || raw === undefined ? Number.NaN : Number(raw);
+	return Number.isFinite(requestedLimit)
+		? Math.min(500, Math.max(1, Math.trunc(requestedLimit)))
+		: 50;
+}
+
+function oldTrajectoryOffset(raw: string | null | undefined): number {
+	const requestedOffset =
+		raw === null || raw === undefined ? Number.NaN : Number(raw);
+	return Number.isFinite(requestedOffset)
+		? Math.max(0, Math.trunc(requestedOffset))
+		: 0;
+}
+
+function fixedClampedLimit(
+	param: string | null | undefined,
+	fallback: number,
+	max: number,
+): number {
+	if (!param) return fallback;
+	if (!/^\d+$/.test(param)) return fallback;
+	const parsed = Number(param);
+	return Number.isSafeInteger(parsed) && parsed > 0
+		? Math.min(parsed, max)
+		: fallback;
+}
+
+function fixedClampedOffset(
+	param: string | null | undefined,
+	fallback = 0,
+): number {
+	if (!param) return fallback;
+	if (!/^\d+$/.test(param)) return fallback;
+	const parsed = Number(param);
+	return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+describe("strict tail/limit clamp — 4 routed sites", () => {
+	test("container logs: fallback 200 max 1000 strict (tail)", () => {
+		expect(fixedClampedLimit(null, 200, 1000)).toBe(200);
+		expect(fixedClampedLimit(undefined, 200, 1000)).toBe(200);
+		expect(fixedClampedLimit("", 200, 1000)).toBe(200);
+		expect(fixedClampedLimit("200", 200, 1000)).toBe(200);
+		expect(fixedClampedLimit("500", 200, 1000)).toBe(500);
+		expect(fixedClampedLimit("2000", 200, 1000)).toBe(1000);
+		for (const bad of [
+			"abc",
+			"-5",
+			"0",
+			"5junk",
+			" 5",
+			"5.5",
+			"+5",
+			"1e4",
+			"Infinity",
+		]) {
+			expect(fixedClampedLimit(bad, 200, 1000)).toBe(200);
+		}
+		// old leak: 1e4→10000 not 200, 5.5→5.5 not 200
+		expect(oldContainerTail("1e4")).toBe(10000);
+		expect(fixedClampedLimit("1e4", 200, 1000)).toBe(200);
+		expect(oldContainerTail("5.5")).toBe(5.5);
+		expect(fixedClampedLimit("5.5", 200, 1000)).toBe(200);
+		expect(Number.isNaN(oldContainerTail("5junk"))).toBe(true);
+		expect(fixedClampedLimit("5junk", 200, 1000)).toBe(200);
+	});
+
+	test("agent logs v1 + compat: fallback 100 max 5000 strict (tail)", () => {
+		expect(fixedClampedLimit(null, 100, 5000)).toBe(100);
+		expect(fixedClampedLimit("100", 100, 5000)).toBe(100);
+		expect(fixedClampedLimit("5000", 100, 5000)).toBe(5000);
+		expect(fixedClampedLimit("6000", 100, 5000)).toBe(5000);
+		for (const bad of ["abc", "-10", "0", "5junk", "5.5", "1e4", "Infinity"]) {
+			expect(fixedClampedLimit(bad, 100, 5000)).toBe(100);
+		}
+		// old leak: 5junk→5 not 100, 1e4→1 not 100, 5.5→5 (parseInt truncation) not 100
+		expect(oldApiTail("5junk")).toBe(5);
+		expect(fixedClampedLimit("5junk", 100, 5000)).toBe(100);
+		expect(oldApiTail("1e4")).toBe(1);
+		expect(fixedClampedLimit("1e4", 100, 5000)).toBe(100);
+		expect(oldApiTail("5.5")).toBe(5);
+		expect(fixedClampedLimit("5.5", 100, 5000)).toBe(100);
+	});
+
+	test("trajectories limit/offset: limit 50 max 500, offset 0 strict", () => {
+		expect(fixedClampedLimit(null, 50, 500)).toBe(50);
+		expect(fixedClampedLimit("50", 50, 500)).toBe(50);
+		expect(fixedClampedLimit("500", 50, 500)).toBe(500);
+		expect(fixedClampedLimit("600", 50, 500)).toBe(500);
+		for (const bad of [
+			"abc",
+			"-5",
+			"0",
+			"5junk",
+			" 5",
+			"5.5",
+			"+5",
+			"1e4",
+			"Infinity",
+		]) {
+			expect(fixedClampedLimit(bad, 50, 500)).toBe(50);
+		}
+		for (const bad of [
+			"abc",
+			"-5",
+			"5junk",
+			" 5",
+			"5.5",
+			"+5",
+			"1e4",
+			"Infinity",
+		]) {
+			expect(fixedClampedOffset(bad, 0)).toBe(0);
+		}
+		expect(fixedClampedOffset("0", 0)).toBe(0);
+		expect(fixedClampedOffset("100", 0)).toBe(100);
+		// old leak: 1e4→500 not 50, 5.5→5 not 50, offset 1e4→10000 not 0
+		expect(oldTrajectoryLimit("1e4")).toBe(500);
+		expect(fixedClampedLimit("1e4", 50, 500)).toBe(50);
+		expect(oldTrajectoryLimit("5.5")).toBe(5);
+		expect(fixedClampedLimit("5.5", 50, 500)).toBe(50);
+		expect(oldTrajectoryOffset("1e4")).toBe(10000);
+		expect(fixedClampedOffset("1e4", 0)).toBe(0);
+	});
+
+	test("sibling proof: files use strict regex and no bare weak parse", () => {
+		const ccp = readFileSync(
+			join(
+				process.cwd(),
+				"packages/cloud/services/container-control-plane/src/index.ts",
+			),
+			"utf8",
+		);
+		const apiV1 = readFileSync(
+			join(
+				process.cwd(),
+				"packages/cloud/api/v1/agents/[agentId]/logs/route.ts",
+			),
+			"utf8",
+		);
+		const compat = readFileSync(
+			join(
+				process.cwd(),
+				"packages/cloud/api/compat/agents/[id]/logs/route.ts",
+			),
+			"utf8",
+		);
+		const traj = readFileSync(
+			join(
+				process.cwd(),
+				"packages/core/src/features/trajectories/read-routes.ts",
+			),
+			"utf8",
+		);
+		// strict helper or inline regex present
+		expect(ccp).toContain("parseClampedLimit");
+		expect(apiV1).toContain("parseClampedLimit");
+		expect(compat).toContain("parseClampedLimit");
+		expect(traj).toContain("/^\\d+$/");
+		expect(traj).toContain("isSafeInteger");
+		// no bare weak parse remains in those files for tail/limit
+		expect(apiV1).not.toContain('parseInt(c.req.query("tail")');
+		expect(compat).not.toContain('parseInt(url.searchParams.get("tail")');
+		expect(apiV1).not.toContain("Number.isFinite(rawTail)");
+		expect(traj).not.toContain("Number.isFinite(requestedLimit)");
+		expect(ccp).not.toContain('Number(c.req.query("tail")');
+	});
+});


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Self-found — no linked issue. Remaining weak `Number(\"?tail\")` / `parseInt(\"?tail\")` / `Number(\"?limit\") + isFinite + trunc` without `/^\d+$/` + `isSafeInteger` in 4 tail/limit sites accepts `1e4→10000/500/1` (scientific/exponential), `5junk→5` (parseInt prefix), and `5.5→5.5/5` (float truncation) as valid, bypassing `200/100/50` fallback and `1000/5000/500` max clamp — systematic, 4 files share same root cause, sibling to `clamp-limit.ts:8` `parseClampedLimit` (`/^\d+$/` + `isSafeInteger` + `Math.min`) and `docker-containers/route.ts:36` `parseContainerListLimit` (`/^[1-9]\d*$/` + `isSafeInteger`).

- Packages affected:
  - `packages/cloud/services/container-control-plane/src/index.ts:1299-1300` (`Number(c.req.query("tail") ?? "200")` → `parseClampedLimit(c.req.query("tail"), 200, 1000)` — `1e4 old 10000 vs fixed 200`, `5.5 old 5.5 vs 200`, `5junk old NaN vs 200`) (1 site, fallback 200 max 1000, validates `1..10000` in `hetzner-client/client.ts:769` `isInteger 1..10000`)
  - `packages/cloud/api/v1/agents/[agentId]/logs/route.ts:40-41` (`parseInt(c.req.query("tail") ?? "100",10)` + `Math.max(1, Math.min(isFinite?100:100,5000))` → `parseClampedLimit(c.req.query("tail"), 100, 5000)` — `5junk old 5 vs fixed 100`, `1e4 old 1 vs 100`, `5.5 old 5 vs 100`) (1 site, fallback 100 max 5000)
  - `packages/cloud/api/compat/agents/[id]/logs/route.ts:50-51` same `url.searchParams.get("tail")` → `parseClampedLimit(url.searchParams.get("tail"), 100, 5000)` (1 site)
  - `packages/core/src/features/trajectories/read-routes.ts:334-352` (`Number(rawLimit)` + `isFinite ? Math.min(500, Math.max(1, trunc)) :50` + `Number(rawOffset) + trunc` → inline `if (!/^\d+$/.test) return fallback; isSafeInteger ? Math.min : fallback` — `1e4 old 500 vs fixed 50`, `5.5 old 5 vs 50`, `offset 1e4 old 10000 vs 0`) (1 file, 2 sites: limit 50 max 500, offset 0)
  - `packages/core/src/limit-tail-clamp.test.ts` (4-case matrix: container 1e4/5.5/5junk, api 5junk/1e4/5.5, trajectories 1e4/5.5/offset, payload→effect, sibling proof)
  - Sibling correct `packages/cloud/shared/src/lib/utils/clamp-limit.ts:8` `parseClampedLimit` (`if (!/^\d+$/.test(param)) return fallback; Number.isSafeInteger && >0 ? min(max) : fallback`) and `packages/cloud/shared/src/lib/utils/clamp-limit.ts:14` `parseClampedOffset` (`/ ^\d+$/ + isSafeInteger >=0`) and `packages/cloud/api/v1/admin/docker-containers/route.ts:36` `parseContainerListLimit`
- Base verified at `d53100a07e6f02d3eac18af36f01401f1ca18bd5` (origin/develop HEAD post-#20682 + #20693; bugs present before fix — container used `Number` without regex, logs used `parseInt` without `^\d+$`, trajectories used `Number+isFinite+trunc` without `isSafeInteger`, `1e4→1/500/10000` and `5junk→5` accepted)
- Discovery: grep `Number\(.*tail|parseInt.*tail|requestedLimit|Number\.isFinite.*limit` on latest d53100a07e6f02d3eac18af36f01401f1ca18bd5 after excluding open PR #20678 (8 files) and prior batch control-plane/container and gmail/x maxResults found 4 fresh sites: `container-control-plane/index.ts:1299` + `agents/[agentId]/logs/route.ts:40` + `compat/agents/[id]/logs/route.ts:50` + `trajectories/read-routes.ts:334`; siblings `clamp-limit.ts:8` + `docker-containers:36` prove strict `^\d+$` + `isSafeInteger` is the discipline. Verbatim before vs correct sibling:
  - Before (container 1299): `const tail = Number(c.req.query("tail") ?? "200");` — `1e4→10000` vs fixed `200` → sibling `clamp-limit:8` `/^\d+$/` rejects `1e4`.
  - Before (logs 40): `const rawTail = parseInt(c.req.query("tail") ?? "100", 10); const tail = Math.max(1, Math.min(Number.isFinite(rawTail) ? rawTail : 100, 5000));` — `5junk→5` vs `100` → sibling rejects `5junk`.
  - Before (1e4 logs): same → `1` vs `100` (scientific `1e4` truncated by parseInt to `1`).
  - Before (trajectories 334): `const requestedLimit = rawLimit === null ? Number.NaN : Number(rawLimit); const limit = Number.isFinite(requestedLimit) ? Math.min(500, Math.max(1, Math.trunc(requestedLimit))) : 50;` — `1e4→500` vs `50`, `5.5→5` vs `50`.
  - After: `parseClampedLimit(param, fallback, max)` with `if (!/^\d+$/.test) return fallback; Number.isSafeInteger && >0 ? Math.min : fallback` → non-digit/scientific/float/unsafe → `fallback`, valid digit clamped to max.
  - Repro payload→effect: `container 1e4 old 10000 vs fixed 200; 5.5 old 5.5 vs 200; api 5junk old 5 vs fixed 100; 1e4 old 1 vs 100; traj 1e4 old 500 vs fixed 50` (see backend logs).
- Duplicate check: grep `parseClampedLimit.*tail|Number.*tail.*200|parseInt.*tail` across open PR forks at creation — only this branch patches `container-control-plane/src/index.ts:1299` + `agents/[agentId]/logs/route.ts` + `compat/agents/[id]/logs/route.ts` + `trajectories/read-routes.ts:334` with strict regex (other branches patch `memory`/`jobs` limit via `??`, `gmail/x` maxResults, `control-plane` batch etc, correctly excluded).

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bunx tsc --noEmit` were run after sync — **no type errors** (see Evidence). `bun run verify` has upstream `cloud-api#typecheck` + `plugin-companion#build` flake on `develop` itself, not introduced here.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

The row labels below must **not** reuse the terminal eliza.army footer labels
(`Client / agent tooling`, `Skill revision` / `Contribution skill revision`,
`Attribution status`). Duplicating those strings makes the scoring validator
reject the machine marker (#17855). Keep the `<!-- attribution-row:* -->`
markers; only the human-readable prefixes changed. After filling these rows,
append the standard footer once at the end of the PR body (do not repeat the
visible footer lines here).

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-fable-5`
<!-- attribution-row:client -->
- Agent tooling: `claude-code`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@d53100a07e6f02d3eac18af36f01401f1ca18bd5:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun test` passes post-sync — **4/4** limit-tail-clamp (see below). `bunx tsc --noEmit` clean for `core` + `shared` + `cloud/api`.

Exact candidate: `7d3bc522fa762eb7e2c4f34dc2582f400e60384a` on base `d53100a07e6f02d3eac18af36f01401f1ca18bd5` (`origin/develop`). `git diff --check` is clean.

# Risks

Low (correctness). 4 files, 23 insert 20 delete + 1 test (191 lines): each weak `Number`/`parseInt`/`Number+isFinite+trunc` → `parseClampedLimit` or inline `^\d+$`+`isSafeInteger`. Risk if caller relied on `1e4→10000/500/1` (scientific) or `5junk→5` (parseInt prefix) or `5.5→5.5/5` (float) being accepted — now correctly rejected to `200/100/50` fallback (intended; strict `^\d+$` + `isSafeInteger` is the discipline in `clamp-limit.ts:8` and `docker-containers:36`). Valid digit strings unchanged, large values now correctly clamped to `1000/5000/500`. No schema/migration/new dep, helper is existing `clamp-limit.ts`.

# Background

## What does this PR do?

Fixes remaining 4 weak tail/limit parse sites so non-digit/scientific/float is rejected to fallback instead of being accepted as `10000/500/5`:

- `container-control-plane/index.ts:1299` `Number(c.req.query("tail") ?? "200")` → `parseClampedLimit(...,200,1000)` — `1e4 old 10000 vs fixed 200`
- `cloud/api/v1/agents/[agentId]/logs/route.ts:40` `parseInt(...,10) + Math.max/min` → `parseClampedLimit(...,100,5000)` — `5junk old 5 vs 100`
- `cloud/api/compat/agents/[id]/logs/route.ts:50` same `5000` max
- `core/trajectories/read-routes.ts:334` `Number(rawLimit)+isFinite+trunc` → inline `if (!/^\d+$/.test) return 50; isSafeInteger ? min(500) :50` plus offset `^\d+$`+isSafeInteger — `1e4 old 500 vs 50`
- Adds `limit-tail-clamp.test.ts` 4-case vitest pinning old vs fixed (container 1e4/5.5/5junk, api 5junk/1e4/5.5, trajectories 1e4/5.5/offset, sibling proof).

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/cloud/shared/src/lib/utils/clamp-limit.ts:8` — strict helper `if (!/^\d+$/.test(param)) return fallback; Number.isSafeInteger`
- `packages/cloud/shared/src/lib/utils/clamp-limit.ts:14` — `parseClampedOffset` same contract
- `packages/cloud/api/v1/admin/docker-containers/route.ts:36` — `parseContainerListLimit` strict `^[1-9]\d*$` sibling
- `packages/cloud/services/container-control-plane/src/index.ts:1299` — strict `parseClampedLimit(...,200,1000)`
- `packages/cloud/api/v1/agents/[agentId]/logs/route.ts:40` — same `100,5000`
- `packages/cloud/api/compat/agents/[id]/logs/route.ts:50` — same `100,5000`
- `packages/core/src/features/trajectories/read-routes.ts:334` — inline `^\d+$`+`isSafeInteger` limit 50 max 500 + offset 0
- `packages/core/src/limit-tail-clamp.test.ts` — 4-case matrix + sibling proof

## Detailed testing steps

1. `grep -rn "Number(c.req.query.*tail|parseInt.*tail|requestedLimit" packages/cloud/services/container-control-plane packages/cloud/api/v1/agents packages/cloud/api/compat packages/core/src/features/trajectories --include="*.ts"` → `0` hits for weak pattern (all 4 fixed to `parseClampedLimit` or `^\d+$`).
2. `grep -n "parseClampedLimit" packages/cloud/services/container-control-plane/src/index.ts packages/cloud/api/v1/agents/[agentId]/logs/route.ts packages/cloud/api/compat/agents/[id]/logs/route.ts` → hits strict helper.
3. `grep -n "/^\\d+\$/.test" packages/core/src/features/trajectories/read-routes.ts` → hits inline strict regex.
4. `bun -e '...probe...'` — replica: `container 1e4 old 10000 vs fixed 200; api 5junk old 5 vs fixed 100; 1e4 old 1 vs 100; traj 1e4 old 500 vs fixed 50` (see backend logs).
5. `bun test packages/core/src/limit-tail-clamp.test.ts` → `4 pass, 0 fail` (see logs).
6. `bunx @biomejs/biome check packages/cloud/services/container-control-plane/src/index.ts "packages/cloud/api/v1/agents/[agentId]/logs/route.ts" "packages/cloud/api/compat/agents/[id]/logs/route.ts" packages/core/src/features/trajectories/read-routes.ts packages/core/src/limit-tail-clamp.test.ts` → `Checked 5 files ... No fixes applied.` (after --write).
7. `git diff --check` → clean.
8. `bunx tsc --noEmit --project packages/core/tsconfig.json && bunx tsc --noEmit --project packages/cloud/shared/tsconfig.json && bunx tsc --noEmit --project packages/cloud/api/tsconfig.json` → no errors.

# Evidence

- `bun test` → `4 pass, 0 fail` (see logs).
- `bunx tsc --noEmit` (core + shared + api) → `0 errors` (see logs).
- `git diff --check` → `0` (clean).
- `bunx @biomejs/biome check` → `Checked 5 files ... No fixes applied.` (after write).
- `git diff --stat` → `5 files changed, 214 insertions(+), 20 deletions(-)` (4 source + 1 test).

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:7d3bc522fa762eb7e2c4f34dc2582f400e60384a -->

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: `N/A - backend-only tail/limit clamp in container and logs routes and trajectory service with no UI component or visual surface, limit parsing is invisible to screenshots`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: `N/A - backend-only clamp fix same as before, no file under packages/app or packages/ui with visual extension was changed`.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: `N/A - tail/limit strictness has no visual walkthrough, verified via isolated unit-test matrix and direct replica one-liners rather than video`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: attached inline — `bun test` for limit-tail-clamp matrix (4 pass) and `bun -e` replica probes for 4 vectors.
  <details><summary>backend logs: limit-tail-clamp (4 pass) + probes + verify</summary>

  ```
  bun test packages/core/src/limit-tail-clamp.test.ts
  v1.3.11 /private/tmp/eliza-verify2/packages/core
   ✓ container logs: fallback 200 max 1000 strict (tail) 1ms
   ✓ agent logs v1 + compat: fallback 100 max 5000 strict (tail) 0ms
   ✓ trajectories limit/offset: limit 50 max 500, offset 0 strict 0ms
   ✓ sibling proof: files use strict regex and no bare weak parse 5ms
  4 pass, 0 fail
  77 expect() calls

  bun -e payload→effect probes (old vs fixed):
  container 1e4 old 10000 fixed 200
  container 5.5 old 5.5 fixed 200
  container 5junk old NaN fixed 200
  api 5junk old 5 fixed 100
  api 1e4 old 1 fixed 100
  api 5.5 old 5 fixed 100
  traj 1e4 old 500 fixed 50
  traj 5.5 old 5 fixed 50
  traj abc old 50 fixed 50
  probe payload: 1e4→10000/500/1 vs 200/100/50, 5junk→5 vs 100, 5.5→5.5/5 vs 200/100/50, scientific/float/junk rejected

  Typecheck + lint + diff:
  bunx tsc --noEmit --project packages/core/tsconfig.json → 0 errors
  bunx tsc --noEmit --project packages/cloud/shared/tsconfig.json → 0 errors
  bunx tsc --noEmit --project packages/cloud/api/tsconfig.json → 0 errors
  bunx @biomejs/biome check → Checked 5 files ... No fixes applied. (after write)
  git diff --check → 0 (clean)
  git diff --stat → 5 files changed, 214 insertions(+), 20 deletions(-)
  Sibling correct: clamp-limit.ts:8 parseClampedLimit /^\d+$/ + isSafeInteger and docker-containers:36 parseContainerListLimit and trajectories inline /^\d+$/ + isSafeInteger
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs: `N/A - no frontend change, tail/limit clamp is server-side container/logs/trajectory logic with no browser request or response to capture`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: `N/A - no agent or action or provider or prompt or model change, limit parsing is pure input validation with no LLM trajectory`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: attached inline — `git diff --stat` and `git diff --check` plus the 4-case matrix above serve as domain artifacts for limit clamp; no DB rows or wallet output to attach.
  <details><summary>domain artifacts: git diff --stat and verify</summary>

  ```
  5 files changed, 214 insertions(+), 20 deletions(-)
  packages/cloud/api/compat/agents/[id]/logs/route.ts            |  7 ++----
  packages/cloud/api/v1/agents/[agentId]/logs/route.ts           |  7 ++----
  packages/cloud/services/container-control-plane/src/index.ts   |  3 ++-
  packages/core/src/features/trajectories/read-routes.ts         | 26 ++++++++++++++--------
  1 test: packages/core/src/limit-tail-clamp.test.ts (4 tests, strict regex + isSafeInteger + sibling)
  git diff --check → 0 (clean)
  bunx @biomejs/biome check → Checked 5 files ... No fixes applied. (after write)
  bun test → 4 pass (matrix + sibling + file-content guard)
  bunx tsc --noEmit (core) → 0 errors
  bunx tsc --noEmit (shared) → 0 errors
  bunx tsc --noEmit (api) → 0 errors
  Sibling correct: clamp-limit.ts:8 parseClampedLimit /^\d+$/ + isSafeInteger and docker-containers:36 and trajectories inline
  ```

  </details>
<!-- evidence-row:ocr-review -->
- [x] OCR visual-text review: `N/A - backend-only change has no rendered visual surface, no OCR text to review for tail/limit clamp`.

# Evidence Details

## Real LLM-call trajectory

`N/A - no LLM trajectory, limit clamp strictness is pure input validation with no agent or model change`.

## Backend + frontend logs

Backend: `bun test` `4 pass, 0 fail` (matrix + sibling proof + file-content guard) + `bun -e` probes `container 1e4 old 10000 vs fixed 200, api 5junk old 5 vs fixed 100, 1e4 old 1 vs 100, traj 1e4 old 500 vs fixed 50` pasted inline above under `backend-logs` row. Frontend: `N/A - no frontend change`.

## Screenshots (before / after) + video walkthrough

`N/A - backend-only change, no UI surface` — see evidence-row reasons above. Diff is `packages/cloud/...` + `packages/core/src/limit-tail-clamp.test.ts`; no file under `packages/app|ui|tui|homepage` with visual extension was changed, so `requiresSurfaceArtifactsFromFiles` is false and screenshots/video may be N/A.

## Audio / voice walkthrough

`N/A - no voice/transcript/TTS/STT change`.

---
— [eliza-computer]
<!-- eliza-computer-attribution:v1 {"agent":"eliza-computer","model":"anthropic/claude-fable-5","skill_revision":"d53100a07e6f02d3eac18af36f01401f1ca18bd5","contribution_skill_revision":"d53100a07e6f02d3eac18af36f01401f1ca18bd5","provenance":"self-reported"} -->
