### PR TITLE
fix(core): restore boot-time PATH/HOME/SHELL into sanitized spawn envs

### DIFF
--- a/packages/core/src/security/spawn-env-policy.test.ts
+++ b/packages/core/src/security/spawn-env-policy.test.ts
@@ -109,6 +109,20 @@ describe("isBlockedSpawnEnvKey (loader/interpreter hijack keys)", () => {
 	});
 });
 
+/** sanitizeSpawnEnv always restores the boot-time PATH/HOME/SHELL. */
+function withBootBaseline(
+	expected: Record<string, string>,
+): Record<string, string> {
+	const out = { ...expected };
+	for (const key of ["PATH", "HOME", "SHELL"] as const) {
+		const value = process.env[key];
+		if (typeof value === "string" && value.length > 0) {
+			out[key] = value;
+		}
+	}
+	return out;
+}
+
 describe("sanitizeSpawnEnv", () => {
 	it("drops all injection-primitive keys but keeps benign keys", () => {
 		const out = sanitizeSpawnEnv({
@@ -127,12 +141,14 @@ describe("sanitizeSpawnEnv", () => {
 			NODE_ENV: "production",
 			GIT_AUTHOR_NAME: "test",
 		});
-		expect(out).toEqual({
-			MY_APP_SETTING: "ok",
-			LANG: "en_US.UTF-8",
-			NODE_ENV: "production",
-			GIT_AUTHOR_NAME: "test",
-		});
+		expect(out).toEqual(
+			withBootBaseline({
+				MY_APP_SETTING: "ok",
+				LANG: "en_US.UTF-8",
+				NODE_ENV: "production",
+				GIT_AUTHOR_NAME: "test",
+			}),
+		);
 	});
 
 	it("drops equivalent JVM and Git injection primitives added in review", () => {
@@ -145,7 +161,7 @@ describe("sanitizeSpawnEnv", () => {
 			GIT_CONFIG_VALUE_0: "/tmp/evil-cmd",
 			SAFE_KEY: "ok",
 		});
-		expect(out).toEqual({ SAFE_KEY: "ok" });
+		expect(out).toEqual(withBootBaseline({ SAFE_KEY: "ok" }));
 	});
 
 	it("drops git config-file and spawned-helper primitives, keeps benign git keys", () => {
@@ -162,11 +178,34 @@ describe("sanitizeSpawnEnv", () => {
 			PYTHON_VERSION: "3.13",
 			SAFE_KEY: "ok",
 		});
-		expect(out).toEqual({
-			GIT_AUTHOR_NAME: "test",
-			GIT_CONFIGURATION: "not-a-primitive",
-			PYTHON_VERSION: "3.13",
-			SAFE_KEY: "ok",
-		});
+		expect(out).toEqual(
+			withBootBaseline({
+				GIT_AUTHOR_NAME: "test",
+				GIT_CONFIGURATION: "not-a-primitive",
+				PYTHON_VERSION: "3.13",
+				SAFE_KEY: "ok",
+			}),
+		);
+	});
+});
+
+describe("boot-baseline exec env restore", () => {
+	it("discards a poisoned request-time PATH but restores the boot-time value", () => {
+		const out = sanitizeSpawnEnv({ PATH: "/evil/bin", FOO: "bar" });
+		expect(out.PATH).toBe(process.env.PATH);
+		expect(out.PATH).not.toBe("/evil/bin");
+		expect(out.FOO).toBe("bar");
+	});
+
+	it("children always get PATH/HOME even when the input env omits them", () => {
+		const out = sanitizeSpawnEnv({ ONLY: "this" });
+		expect(out.PATH).toBe(process.env.PATH);
+		expect(out.HOME).toBe(process.env.HOME);
+	});
+
+	it("other blocked keys stay stripped with no restore", () => {
+		const out = sanitizeSpawnEnv({ LD_PRELOAD: "/evil.so", NODE_OPTIONS: "-r evil" });
+		expect(out.LD_PRELOAD).toBeUndefined();
+		expect(out.NODE_OPTIONS).toBeUndefined();
 	});
 });

--- a/packages/core/src/security/spawn-env-policy.ts
+++ b/packages/core/src/security/spawn-env-policy.ts
@@ -167,6 +167,33 @@ export function isBlockedSpawnEnvKey(key: string): boolean {
 	return BLOCKED_SPAWN_ENV_PREFIXES.some((prefix) => upper.startsWith(prefix));
 }
 
+/**
+ * Exec-critical baseline captured at module load, BEFORE any runtime config
+ * write can poison process.env (the config→env→spawn hijack this policy
+ * exists to close). PATH/HOME/SHELL are stripped from the merged spawn env
+ * like every other blocked key — a request-time value is never trusted — but
+ * a child spawned with NO PATH falls back to the shell's compiled-in default
+ * (`/usr/local/sbin:…:/bin`), so anything installed under `~/.bun/bin` or
+ * `~/.local/bin` exits 127 and HOME-dependent tooling breaks (observed live:
+ * a coding sub-agent's SHELL `ls -la` returned command_failed while FILE
+ * tools worked). Restoring the boot-time values keeps children runnable while
+ * keeping the hijack window closed: influencing this snapshot requires
+ * controlling the environment before boot, at which point the attacker
+ * already owns the process.
+ */
+const BOOT_BASELINE_EXEC_ENV: Readonly<Record<string, string>> = (() => {
+	const out: Record<string, string> = {};
+	if (typeof process !== "undefined" && process.env) {
+		for (const key of ["PATH", "HOME", "SHELL"] as const) {
+			const value = process.env[key];
+			if (typeof value === "string" && value.length > 0) {
+				out[key] = value;
+			}
+		}
+	}
+	return Object.freeze(out);
+})();
+
 export function sanitizeSpawnEnv(
 	env: Record<string, string | undefined>,
 ): Record<string, string | undefined> {
@@ -175,6 +202,9 @@ export function sanitizeSpawnEnv(
 		if (isBlockedSpawnEnvKey(key)) {
 			continue;
 		}
+		out[key] = value;
+	}
+	for (const [key, value] of Object.entries(BOOT_BASELINE_EXEC_ENV)) {
 		out[key] = value;
 	}
 	return out;


### PR DESCRIPTION
## What

`sanitizeSpawnEnv` (core `security/spawn-env-policy.ts`) strips PATH/HOME/SHELL from every child spawn env as part of the config→env→spawn hijack denylist. A child spawned with NO PATH falls back to the shell's compiled-in default (`/usr/local/sbin:…:/bin`), so any binary under `~/.bun/bin` / `~/.local/bin` exits 127 and HOME-dependent tooling breaks. Observed live twice: TERMINAL_SHELL exit-127s (earlier arc), and today a coding sub-agent's SHELL `ls -la` returning `command_failed` while FILE tools worked (fresh receipt from the orchestration probes on the live box).

Fix: capture a `BOOT_BASELINE_EXEC_ENV` snapshot of PATH/HOME/SHELL at module load — before any runtime config write can poison `process.env` — and restore those values into every sanitized spawn env. Request-time values for those keys are still discarded (a poisoned `PATH=/evil/bin` never reaches a child); the restored values are the boot-time ones, which an attacker can only influence by controlling the environment before boot, at which point they already own the process. All other denylist behavior is unchanged, and every spawn consumer (agent shell-execution-router, sandbox-engine, coding-tools processQueue/run-shell) inherits the fix through the shared helper.

## Evidence

- Diagnostic tell reproduced live: failing children reported the exact compiled-in default PATH, i.e. the spawn env carried no PATH at all.
- spawn-env-policy suite 58/58, including new pins: poisoned request-time PATH is discarded but the boot-time value is restored; PATH/HOME present even when the input env omits them; LD_PRELOAD/NODE_OPTIONS and the rest of the denylist stay stripped with no restore.
- Core typecheck + node build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:42f05cf0ee410c2d0c4877cad5d4362568ef93bf -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - spawn-env behavior; live receipts + test pins in PR body

<!-- evidence-row:after-screenshots -->
- [ ] N/A - spawn-env behavior; live receipts + test pins in PR body

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - unit-pinned env policy change

<!-- evidence-row:backend-logs -->
- [x] [18309](https://github.com/elizaOS/eliza/discussions/18309)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-path change

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - child-process env verified by suite 58/58

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces
