### PR TITLE
fix(core): align production shouldRespond guidance

### DIFF
--- a/packages/core/src/__tests__/message-stage1-prompt-tier.test.ts
+++ b/packages/core/src/__tests__/message-stage1-prompt-tier.test.ts
@@ -7,8 +7,15 @@
  * receives, including the footprint drop on the compact tier.
  */
 import { describe, expect, it, vi } from "vitest";
-import { HANDLE_RESPONSE_TOOL_NAME } from "../actions/to-tool";
-import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "../runtime/builtin-field-evaluators";
+import {
+	HANDLE_RESPONSE_SCHEMA,
+	HANDLE_RESPONSE_TOOL_NAME,
+	SHOULD_RESPOND_SCHEMA_DESCRIPTION,
+} from "../actions/to-tool";
+import {
+	BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS,
+	shouldRespondFieldEvaluator,
+} from "../runtime/builtin-field-evaluators";
 import { ContextRegistry } from "../runtime/context-registry";
 import { ResponseHandlerFieldRegistry } from "../runtime/response-handler-field-registry";
 import { runV5MessageRuntimeStage1 } from "../services/message";
@@ -26,7 +33,9 @@ const DIRECT_MESSAGE_MARKER = "direct/private rules:";
 /** Full vs compressed shouldRespond field docs. */
 const FULL_SHOULD_RESPOND_DOCS = "DM usually RESPOND unless explicit stop.";
 const COMPACT_SHOULD_RESPOND_DOCS =
-	"RESPOND if asked/active conversation; IGNORE if not yours; STOP only explicit stop.";
+	"RESPOND if asked, active in the conversation, or able to usefully add to substantive ambient chatter";
+const SHARED_SHOULD_RESPOND_SCHEMA_DOCS =
+	"ambient chatter with real substance you can usefully add to";
 
 const LONG_CONTEXT_DESCRIPTION =
 	"Helpdesk operations of any kind: any imperative ('open a ticket', " +
@@ -227,6 +236,15 @@ describe("isUnaddressedTextGroupTurn", () => {
 });
 
 describe("Stage-1 prompt tiering", () => {
+	it("keeps the production and compatibility shouldRespond schemas aligned", () => {
+		expect(shouldRespondFieldEvaluator.schema.description).toBe(
+			SHOULD_RESPOND_SCHEMA_DESCRIPTION,
+		);
+		expect(HANDLE_RESPONSE_SCHEMA.properties?.shouldRespond?.description).toBe(
+			SHOULD_RESPOND_SCHEMA_DESCRIPTION,
+		);
+	});
+
 	it("renders the compact triage block for an unaddressed group message", async () => {
 		const { systemContent, outcome } = await renderedSystemPrompt(
 			makeMessage({ channelType: String(ChannelType.GROUP) }),
@@ -242,6 +260,13 @@ describe("Stage-1 prompt tiering", () => {
 		expect(systemContent).not.toContain(LONG_CONTEXT_DESCRIPTION);
 		// Compressed field docs replace the full slices.
 		expect(systemContent).toContain(COMPACT_SHOULD_RESPOND_DOCS);
+		expect(systemContent).toContain(SHARED_SHOULD_RESPOND_SCHEMA_DOCS);
+		expect(systemContent).toContain(
+			"IGNORE content-free reactions, feeds, or others' conversation",
+		);
+		expect(systemContent).not.toContain(
+			"RESPOND if asked/active conversation; IGNORE if not yours",
+		);
 		expect(systemContent).not.toContain(FULL_SHOULD_RESPOND_DOCS);
 		// The envelope still parses and routes: IGNORE ends the turn.
 		expect(outcome.kind).toBe("terminal");

--- a/packages/core/src/actions/to-tool.ts
+++ b/packages/core/src/actions/to-tool.ts
@@ -38,6 +38,10 @@ export const NATIVE_TOOL_NAME_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
  */
 export const HANDLE_RESPONSE_TOOL_NAME = "HANDLE_RESPONSE" as const;
 
+/** Shared should-respond contract for static and registry-composed schemas. */
+export const SHOULD_RESPOND_SCHEMA_DESCRIPTION =
+	'RESPOND=reply/run actions — a question, a request, an active conversation, or ambient chatter with real substance you can usefully add to. IGNORE=silent — pure content-free acknowledgements/reactions ("lol", "ok", "nice", "same", "haha", "brb"), bot/webhook/status feeds, or people clearly talking to each other. STOP=explicit user stop.';
+
 /**
  * Canonical Stage-1 HANDLE_RESPONSE parameters. This mirrors the builtin
  * ResponseHandlerFieldRegistry field order used in production. Plugin callers
@@ -51,8 +55,7 @@ export const HANDLE_RESPONSE_SCHEMA: JSONSchema = {
 		shouldRespond: {
 			type: "string",
 			enum: ["RESPOND", "IGNORE", "STOP"],
-			description:
-				'RESPOND=reply/run actions — a question, a request, or ambient chatter with real substance you can add to (stay chatty). IGNORE=silent — pure acknowledgements/reactions with no content ("lol", "ok", "nice", "same", "haha", "brb"), status/feed noise, or people clearly talking to each other. STOP=explicit user stop.',
+			description: SHOULD_RESPOND_SCHEMA_DESCRIPTION,
 		},
 		contexts: {
 			type: "array",

--- a/packages/core/src/runtime/builtin-field-evaluators.ts
+++ b/packages/core/src/runtime/builtin-field-evaluators.ts
@@ -26,6 +26,7 @@
  * for runtime init to consume.
  */
 
+import { SHOULD_RESPOND_SCHEMA_DESCRIPTION } from "../actions/to-tool";
 import type { JSONSchema } from "../types/model";
 import { stripJsonStructuralJunkReply } from "./json-output";
 import type { ResponseHandlerFieldEvaluator } from "./response-handler-field-evaluator";
@@ -69,15 +70,14 @@ export const shouldRespondFieldEvaluator: ResponseHandlerFieldEvaluator<
 > = {
 	name: "shouldRespond",
 	description:
-		"RESPOND if addressed to you, helpful question, or active conversation. IGNORE if others talking, unaddressed small-talk, not yours. STOP only explicit stop/terminate/no more work. DM usually RESPOND unless explicit stop.",
+		'RESPOND if addressed to you, asked a helpful question, needed to act, active in the conversation, or able to usefully add to substantive ambient chatter. IGNORE pure content-free acknowledgements/reactions ("lol", "ok", "nice", "same", "haha", "brb"), bot/webhook/status feeds, or people clearly talking to each other. STOP only explicit stop/terminate/no more work. DM usually RESPOND unless explicit stop.',
 	descriptionCompressed:
-		"RESPOND if asked/active conversation; IGNORE if not yours; STOP only explicit stop.",
+		"RESPOND if asked, active in the conversation, or able to usefully add to substantive ambient chatter; IGNORE content-free reactions, feeds, or others' conversation; STOP only explicit stop.",
 	priority: 5,
 	schema: {
 		type: "string",
 		enum: ["RESPOND", "IGNORE", "STOP"],
-		description:
-			"RESPOND=reply/run actions. IGNORE=silent. STOP=explicit user stop.",
+		description: SHOULD_RESPOND_SCHEMA_DESCRIPTION,
 	},
 	parse(value) {
 		const normalized =

--- a/packages/core/src/services/message/stage1-prompt-tier.ts
+++ b/packages/core/src/services/message/stage1-prompt-tier.ts
@@ -133,8 +133,8 @@ available_contexts:
 {{availableContexts}}
 
 shouldRespond:
-- RESPOND: the message asks something, needs you to act, continues a thread you are in, OR is ambient chatter with real substance you can add to — you are a chatty presence here, so engage anything with content
-- IGNORE: pure acknowledgements/reactions with no content ("lol", "ok", "nice", "same", "haha", "brb"), bot/webhook/status feeds, or people clearly talking to each other
+- RESPOND: the message asks something, needs you to act, continues a thread you are in, OR is ambient chatter with real substance you can usefully add to — be a chatty presence, not a running commentary
+- IGNORE: pure content-free acknowledgements/reactions ("lol", "ok", "nice", "same", "haha", "brb"), bot/webhook/status feeds, or people clearly talking to each other
 - STOP: user explicitly asked you to disengage
 
 rules when RESPOND:


### PR DESCRIPTION
# Relates to

Follow-up to #20720.

Definition of Done: full standard in CONTRIBUTING.md.

- [x] Targets develop and is based directly on exact origin/develop@8251ec3818cb2994353528c5eed3f22dbc62ba73.
- [x] Production Stage-1 and compatibility schemas now share one shouldRespond contract.
- [x] Focused tests, core typecheck, full core build, Biome, and diff-check pass.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - no repository contribution skill used
<!-- attribution-row:status -->
- Provenance status: self-reported

# Background

#20720 updated the compact prompt and legacy static schema, but production Stage-1 composes the field from ResponseHandlerFieldRegistry. Its full, compressed, and schema descriptions still carried the older ignore-unaddressed-small-talk guidance.

This follow-up single-sources the schema description across the static and production paths, aligns full and compact prompt slices, and narrows the chatty rule to substantive ambient content the agent can usefully add to. Existing addressed-to-other-participant and ambient authority gates remain intact.

# Testing

- Focused Stage-1 prompt/schema tests: 29/29 PASS, 93 assertions.
- packages/core typecheck: PASS.
- Full core Node/browser/edge/testing build, declarations, and import verification: PASS.
- Biome on the four affected files: PASS.
- git diff check: PASS.

# Evidence Gate

<!-- evidence-head:fdbaed24d0e7100e944dbb29a0d03f63385028cb -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI change.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - source repair only; exact live connector logs remain an acceptance follow-up.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - exact-head live-model trajectory remains required before claiming behavioral acceptance.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - prompt/schema repair creates no persistent domain artifact.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Known gaps

The merged regression is repaired at source and fully exercised through the real rendered Stage-1 prompt. Exact-head live-model and raw connector evidence is still required before declaring the broader chatty-response behavior accepted.