### PR TITLE
fix(orchestrator): persist a durable restart owner for spawn_agent sessions

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
@@ -529,3 +529,89 @@ describe("TASKS:spawn_agent", () => {
     });
   });
 });
+
+describe("TASKS:spawn_agent durable restart owner", () => {
+  const durableRuntime = (
+    svc: unknown,
+    taskService: unknown,
+  ): ReturnType<typeof runtimeWith> => {
+    const runtime = runtimeWith(svc);
+    (runtime.getService as ReturnType<typeof vi.fn>).mockImplementation(
+      (type: string) =>
+        type === "ORCHESTRATOR_TASK_SERVICE" ? taskService : svc,
+    );
+    return runtime;
+  };
+
+  const taskServiceMock = () => ({
+    createTask: vi.fn(async () => ({ id: "durable-task-1" })),
+    attachSession: vi.fn(async () => true),
+  });
+
+  it("persists a durable task and attaches the session for a user-originated spawn", async () => {
+    const svc = serviceMock();
+    const tasks = taskServiceMock();
+    const result = await spawnAgentAction.handler(
+      durableRuntime(svc, tasks),
+      memory({ task: "fix bug", agentType: "codex", workdir: process.cwd() }),
+      state,
+      spawnOptions,
+      callback(),
+    );
+    expect(result?.success).toBe(true);
+    expect(tasks.createTask).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "coding", goal: "fix bug" }),
+    );
+    expect(tasks.attachSession).toHaveBeenCalledWith(
+      "durable-task-1",
+      expect.objectContaining({ sessionId: "abcdef123456" }),
+    );
+    expect(result?.data).toMatchObject({ durableTaskId: "durable-task-1" });
+  });
+
+  it("skips the durable record for routed sub-agent respawns", async () => {
+    const svc = serviceMock();
+    const tasks = taskServiceMock();
+    const result = await spawnAgentAction.handler(
+      durableRuntime(svc, tasks),
+      memory({
+        task: "fix bug",
+        agentType: "codex",
+        workdir: process.cwd(),
+        source: "sub_agent",
+      }),
+      state,
+      spawnOptions,
+      callback(),
+    );
+    expect(result?.success).toBe(true);
+    expect(tasks.createTask).not.toHaveBeenCalled();
+    expect(result?.data).not.toMatchObject({
+      durableTaskId: expect.anything(),
+    });
+  });
+
+  it("degrades loudly but keeps the spawn when persistence fails", async () => {
+    const svc = serviceMock();
+    const tasks = {
+      createTask: vi.fn(async () => {
+        throw new Error("store offline");
+      }),
+      attachSession: vi.fn(),
+    };
+    const runtime = durableRuntime(svc, tasks);
+    const result = await spawnAgentAction.handler(
+      runtime,
+      memory({ task: "fix bug", agentType: "codex", workdir: process.cwd() }),
+      state,
+      spawnOptions,
+      callback(),
+    );
+    expect(result?.success).toBe(true);
+    expect(result?.data).not.toMatchObject({
+      durableTaskId: expect.anything(),
+    });
+    expect(runtime.reportError).toHaveBeenCalled();
+    expect(tasks.attachSession).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -2074,6 +2074,74 @@ async function runSpawnAgent(
       })}`,
     );
 
+    // Durable restart owner for the fire-and-forget spawn path. Without a
+    // task record a runtime restart orphans the live session SILENTLY: the
+    // sub-agent's work may finish on disk, but the "result will arrive as a
+    // follow-up" promise below dies with the process and nothing resumes or
+    // relays (observed live 2026-08-16: the session built its artifact,
+    // a restart killed the relay, and no record existed to recover it).
+    // create-path tasks persist their owner BEFORE the first prompt;
+    // spawn_agent mirrors that contract post-spawn. Only user-originated
+    // top-level spawns mint a record — router respawns and swarm children
+    // are owned by their parent task. Persistence failure degrades (the
+    // session is already running; killing it over bookkeeping would trade
+    // a silent-loss bug for a loud-loss one) but is reported loudly.
+    let durableTaskId: string | null = null;
+    if (userOriginatedSpawn) {
+      const spawnDurableService = runtime.getService?.(
+        OrchestratorTaskService.serviceType,
+      ) as OrchestratorTaskService | null | undefined;
+      if (
+        spawnDurableService &&
+        typeof spawnDurableService.createTask === "function" &&
+        typeof spawnDurableService.attachSession === "function"
+      ) {
+        try {
+          const detail = await spawnDurableService.createTask({
+            title: label,
+            goal: task,
+            kind: "coding",
+            priority: "normal",
+            originalRequest: requestText(message),
+            ...(session.workdir ? { workdir: session.workdir } : {}),
+            ...(message.roomId ? { roomId: message.roomId } : {}),
+            ...(resolvedTaskRoomId ? { taskRoomId: resolvedTaskRoomId } : {}),
+            metadata: {
+              ...(resolvedSpawnSource ? { source: resolvedSpawnSource } : {}),
+              spawnPath: "spawn_agent",
+            },
+          });
+          durableTaskId = detail?.id ?? null;
+          if (durableTaskId) {
+            await spawnDurableService.attachSession(durableTaskId, {
+              sessionId: session.sessionId,
+              agentType: session.agentType,
+              workdir: session.workdir,
+              status: session.status,
+              ...(session.metadata ? { metadata: session.metadata } : {}),
+              label,
+              originalTask: taskWithRouteHints,
+            });
+          }
+        } catch (error) {
+          // error-policy:J7 durable bookkeeping must not kill the already
+          // running session; the gap is surfaced through reportError so the
+          // owner sees the restart-durability exposure instead of silence.
+          durableTaskId = null;
+          runtime.reportError?.(
+            "TASKS:spawn_agent",
+            error instanceof Error ? error : new Error(String(error)),
+            { sessionId: session.sessionId, label },
+          );
+          logger(runtime).error(
+            `[TASKS:spawn_agent] durable task persistence failed for ${session.sessionId}; session runs WITHOUT restart protection: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
+    }
+
     // An empty text here left the planner finish with nothing to relay for an
     // async spawn, and it answered the user's question from thin air instead
     // (observed live: fabricated `bun --version` output). State the pending
@@ -2110,6 +2178,7 @@ async function runSpawnAgent(
         workdir: session.workdir,
         status: session.status,
         label,
+        ...(durableTaskId ? { durableTaskId } : {}),
         deferredUserReply: deferUserReply,
         suppressActionResultClipboard: true,
       },


### PR DESCRIPTION
## Summary
Live-fire finding from tonight's coding-orchestration test on the production box: a `TASKS:spawn_agent` session has **no durable task record**, so a runtime restart orphans it silently. Observed end-to-end: the eliza-code sub-agent BUILT its artifact within seconds (file on disk, later verified serving), a dev restart landed ~2 min in, the session died, and the "result will arrive as a follow-up" promise was never fulfilled — no resume, no relay, no record. The `create`/Smithers path persists its restart owner before the first prompt and survives the identical restart.

This mirrors that contract onto the fire-and-forget spawn path:

- After a successful `spawnSession`, a **user-originated top-level** spawn persists an `OrchestratorTaskService` task (`kind: "coding"`, origin room, task room, connector source, `spawnPath: "spawn_agent"` marker) and attaches the live session — the same `createTask` → `attachSession` pair `TASKS:create` uses, so startup resume and the task-event relay cover both paths identically.
- Router respawns and swarm children skip the record — their parent task already owns them (guarded by the existing `userOriginatedSpawn` predicate).
- Persistence failure degrades loudly instead of killing the already-running session: `runtime.reportError` + an explicit "runs WITHOUT restart protection" log (error-policy:J7) — trading the silent-loss bug for a reported one, never a fabricated success.
- `durableTaskId` joins the action result data for downstream consumers.

## Evidence
- `__tests__/unit/spawn-agent.test.ts` → **22 pass** (19 existing + 3 new contracts: persist+attach on user-originated spawn; skip for `sub_agent`-sourced respawns; loud degrade keeps the spawn and skips attach on store failure).
- `__tests__/unit/orchestrator-task-service.test.ts` → 104 pass (unchanged).
- Plugin typecheck clean; Biome clean.
- Live reproduction receipts (session 02399a82: artifact written 22:35, restart 22:37, empty output, no record; probe #2 confirmed artifact existed) in HQ #18309.

Related: the peer-session's completion-relay/zombie-leg findings are the same durability family; this closes the spawn-side root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)