### PR TITLE
fix(code): SHELL dead in eliza-code ACP sub-agents — child never captures the host execution baseline

### DIFF
--- a/packages/examples/code/src/acp.ts
+++ b/packages/examples/code/src/acp.ts
@@ -24,6 +24,13 @@
  * @module example-code/acp
  */
 
+// FIRST import: captures this process's executable-search authority before any
+// runtime/plugin module body can mutate process.env. Without it the sub-agent's
+// baseline stays empty, plugin-coding-tools resolves ZERO authority
+// directories, and every SHELL command (builtins included) dies with exit -1
+// "No boot-authorized shell was detected" — the exact live failure observed in
+// spawned eliza-code sessions on 2026-08-16 while FILE tools kept working.
+import "./host-baseline.js";
 import { randomUUID } from "node:crypto";
 import { AgentSideConnection, ndJsonStream } from "@agentclientprotocol/sdk";
 import type { AgentRuntime } from "@elizaos/core";

--- a/packages/examples/code/src/host-baseline.test.ts
+++ b/packages/examples/code/src/host-baseline.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Pins the ACP child's executable-search authority contract: importing the
+ * entry's first module captures a real PATH baseline, and acp.ts keeps
+ * host-baseline as its FIRST import so no runtime module body can beat it.
+ * Deterministic; no live runtime.
+ */
+import { readFileSync } from "node:fs";
+import { getHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
+import { describe, expect, it } from "vitest";
+
+describe("acp host execution baseline", () => {
+  it("captures a non-empty PATH baseline via the side-effect module", async () => {
+    await import("./host-baseline.js");
+    const baseline = getHostExecutionBaseline();
+    expect(baseline.path).toBeDefined();
+    expect(baseline.path).toContain("/");
+  });
+
+  it("keeps host-baseline as the FIRST import of the acp entry", () => {
+    const source = readFileSync(new URL("./acp.ts", import.meta.url), "utf8");
+    const firstImport = source.match(/^import .*$/m)?.[0] ?? "";
+    expect(firstImport).toBe('import "./host-baseline.js";');
+  });
+});

--- a/packages/examples/code/src/host-baseline.ts
+++ b/packages/examples/code/src/host-baseline.ts
@@ -1,0 +1,11 @@
+/**
+ * Captures the executable-search authority for the ACP child process before
+ * any other module body runs. Imported FIRST by the acp entrypoint: ESM
+ * evaluates module bodies in import order, so a plain top-of-file call in the
+ * entry would run only AFTER every imported runtime/plugin module — too late
+ * if one of them mutates process.env. Each ACP child is its own Node process;
+ * the host's boot capture (packages/agent bin.ts) does not transfer.
+ */
+import { captureHostExecutionBaseline } from "@elizaos/shared/host-execution-env";
+
+captureHostExecutionBaseline();


### PR DESCRIPTION
## Summary
Live-fire root cause from tonight's coding-orchestration test (HQ #18309): every SHELL command in a spawned eliza-code sub-agent exits **-1 instantly — including shell builtins like `echo $PATH`** — while FILE tools work. The discriminator probe proved it's not env-PATH content: `resolveHostExecutable` authorizes candidates only against `getHostExecutionBaseline().path`, and `captureHostExecutionBaseline()` is called by the HOST boot (`packages/agent/src/bin.ts`) but **never by the eliza-code ACP entry** — each ACP child is its own Node process, so its baseline is `{}`, authority directories are empty, and even absolute `/bin/bash` is unauthorized → `resolveHostShell` reports "No boot-authorized shell was detected" → `run-shell` returns exit -1 before any spawn. #20221 fixed the host; this is the uncovered child consumer.

- New `src/host-baseline.ts`: side-effect module calling `captureHostExecutionBaseline()`.
- `src/acp.ts` imports it FIRST — a plain top-level call would run only after every hoisted import's module body, which is exactly the window the capture must beat.

## Evidence
- Live trajectory (sub-agent session f6954532, 2026-08-16 23:15): `echo $PATH`, `which ls`, `ls -la` all `[CodingTools] command_failed: exit -1` with `cwd` valid; agent completed its build via FILE tools only. Builtins failing at -1 (not 127) pins spawn-refusal, not PATH content.
- Code path: `plugins/plugin-coding-tools/src/lib/run-shell.ts` (`!shell.available` → exitCode -1) ← `terminal-capabilities.ts resolveHostShell` ← `@elizaos/shared/host-execution-env` (`getHostExecutionBaseline()` returns `{}` when never captured).
- `src/host-baseline.test.ts` → 2 pass: baseline captured non-empty via the module; acp.ts's FIRST import is pinned (source contract, mirrors the workflow-pin test style).
- Package typecheck clean (uncached), Biome clean.
- Full live proof (SHELL green inside a spawned sub-agent) requires the live box's next resync + dist rebuild — will be run as orchestration probe #4 and receipted in HQ; flagging honestly rather than claiming it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)