### PR TITLE
fix(cloud): reject impossible analytics dates

### DIFF
--- a/packages/cloud/api/__tests__/apps-analytics-sessions.integration.test.ts
+++ b/packages/cloud/api/__tests__/apps-analytics-sessions.integration.test.ts
@@ -137,11 +137,14 @@ describe("app analytics sessions route (#11349)", () => {
     );
   });
 
-  test("rejects unparseable date bounds before any read", async () => {
+  test("rejects invalid date bounds before any read", async () => {
     const app = buildApp();
     for (const [param, expected] of [
       ["start_date=not-a-date", "Invalid start_date"],
       ["end_date=not-a-date", "Invalid end_date"],
+      ["start_date=2026-02-29", "Invalid start_date"],
+      ["start_date=2026-02-31", "Invalid start_date"],
+      ["end_date=2026-04-31", "Invalid end_date"],
     ]) {
       const res = await app.request(
         `/api/v1/apps/${APP_ID}/analytics/requests?${param}`,
@@ -149,8 +152,8 @@ describe("app analytics sessions route (#11349)", () => {
         ENV,
       );
 
-      // An Invalid Date reaches Drizzle's timestamp serializer and throws, so
-      // without this guard a caller typo answers 500 instead of 400.
+      // Invalid or overflow-normalized dates otherwise reach the service layer,
+      // where malformed ranges can answer 500 or query the wrong calendar days.
       expect(res.status).toBe(400);
       expect((await res.json()) as { success: boolean; error: string }).toEqual(
         {
@@ -182,20 +185,25 @@ describe("app analytics sessions route (#11349)", () => {
 
   test("passes valid supplied bounds unchanged", async () => {
     const app = buildApp();
-    const res = await app.request(
-      `/api/v1/apps/${APP_ID}/analytics/requests?view=sessions&start_date=2026-07-01T12:30:00.000Z&end_date=2026-07-02T15:45:00.000Z`,
-      {},
-      ENV,
-    );
+    for (const [startDate, endDate] of [
+      ["2024-02-29", "2024-03-01"],
+      ["2026-07-01T12:30:00.000Z", "2026-07-02T15:45:00.000Z"],
+    ]) {
+      const res = await app.request(
+        `/api/v1/apps/${APP_ID}/analytics/requests?view=sessions&start_date=${startDate}&end_date=${endDate}`,
+        {},
+        ENV,
+      );
 
-    expect(res.status).toBe(200);
-    expect(getSessionAnalytics).toHaveBeenCalledWith(
-      APP_ID,
-      expect.objectContaining({
-        startDate: new Date("2026-07-01T12:30:00.000Z"),
-        endDate: new Date("2026-07-02T15:45:00.000Z"),
-      }),
-    );
+      expect(res.status).toBe(200);
+      expect(getSessionAnalytics).toHaveBeenLastCalledWith(
+        APP_ID,
+        expect.objectContaining({
+          startDate: new Date(startDate),
+          endDate: new Date(endDate),
+        }),
+      );
+    }
   });
 
   test("denies another org before reading session analytics", async () => {

--- a/packages/cloud/shared/src/lib/api/date-range-params.ts
+++ b/packages/cloud/shared/src/lib/api/date-range-params.ts
@@ -3,16 +3,29 @@ export type DateRangeParams =
   | { success: true; startDate?: Date; endDate?: Date }
   | { success: false; error: string };
 
+const ISO_DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseOptionalDate(raw: string | null): Date | undefined {
+  if (raw === null) return undefined;
+
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) return undefined;
+  if (ISO_DATE_ONLY.test(raw) && date.toISOString().slice(0, 10) !== raw) {
+    return undefined;
+  }
+  return date;
+}
+
 export function parseDateRangeParams(searchParams: URLSearchParams): DateRangeParams {
   const rawStart = searchParams.get("start_date");
   const rawEnd = searchParams.get("end_date");
-  const startDate = rawStart === null ? undefined : new Date(rawStart);
-  const endDate = rawEnd === null ? undefined : new Date(rawEnd);
+  const startDate = parseOptionalDate(rawStart);
+  const endDate = parseOptionalDate(rawEnd);
 
-  if (startDate && Number.isNaN(startDate.getTime())) {
+  if (rawStart !== null && !startDate) {
     return { success: false, error: "Invalid start_date" };
   }
-  if (endDate && Number.isNaN(endDate.getTime())) {
+  if (rawEnd !== null && !endDate) {
     return { success: false, error: "Invalid end_date" };
   }
   if (startDate && endDate && startDate > endDate) {


### PR DESCRIPTION
# Relates to

Closes #20740

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated repository blocker is recorded below.
- [x] A reviewer can confirm the changed request contract from the focused real-Hono route suite and exact-head proof below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Claude Code CLI Proxy`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@7e04c64c73f007610e5da4654803589fdee7c96d:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `7e04c64c73f007610e5da4654803589fdee7c96d`; zero conflicts.
- [x] `bun run verify` was run at exact head `55ec9beceab068b62ec920f79a334addbad9106d`; its unrelated control-plane typecheck blocker is documented in **Known gaps / failures**.

# Risks

Low. The repair is limited to the shared app-analytics date-range boundary. It adds strict calendar-day validation only for canonical `YYYY-MM-DD` strings, while preserving valid leap days, full ISO timestamps, omitted bounds, and the existing reversed-range check. Clients that supplied impossible date-only values now receive HTTP 400 instead of querying normalized calendar days.

# Background

## What does this PR do?

Validates canonical date-only analytics bounds by parsing them and requiring a UTC `YYYY-MM-DD` round-trip. JavaScript normalizes `2026-02-31` to March 3 rather than producing an invalid timestamp; the round-trip closes that gap without replacing the route's broader existing timestamp compatibility.

The focused route suite covers unparseable values, non-leap-year February 29, February 31, April 31, a valid leap day, valid full ISO timestamps, reversed bounds, omitted bounds, and rejection before app or analytics reads.

## What kind of change is this?

Bug fix (non-breaking for valid requests).

# Documentation changes needed?

No. This makes the existing date-range request contract reject impossible calendar dates; it does not add or change a documented endpoint.

# Testing

## Where should a reviewer start?

- `packages/cloud/shared/src/lib/api/date-range-params.ts`
- `packages/cloud/api/__tests__/apps-analytics-sessions.integration.test.ts`

## Detailed testing steps

1. Run `bun test packages/cloud/api/__tests__/apps-analytics-sessions.integration.test.ts`.
2. Confirm impossible date-only bounds return HTTP 400 before `appsService.getById` or `appAnalyticsService.getSessionAnalytics` is called.
3. Confirm `2024-02-29` and full ISO timestamp bounds reach the service unchanged.
4. Run the Cloud shared and Cloud API typechecks.

Verification at exact head `55ec9beceab068b62ec920f79a334addbad9106d`:

- Tests-first baseline: `start_date=2026-02-31` passed parsing, reached the unmocked service branch, and produced HTTP 500 instead of the required pre-read HTTP 400.
- Focused real-Hono route suite: 5 passed, 0 failed, 27 assertions.
- Cloud shared typecheck: passed.
- Cloud API typecheck + Worker dry-run bundle: passed.
- Biome check on both changed files: passed.
- `git diff --check`: clean.
- Exact-head proof recorded for the focused suite.
- Live ownership rescan: 27 open PRs / 193 changed-file rows and 177 open issues, with zero target-file overlaps or matching claims.

# Evidence Gate

<!-- evidence-head:55ec9beceab068b62ec920f79a334addbad9106d -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - service-only request validation has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - service-only request validation has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - there is no visual user flow for this parser boundary.
<!-- evidence-row:backend-logs -->
- [x] Focused real-Hono boundary transcript:
  <details><summary>Test result</summary>

  ```text
  app analytics sessions route (#11349) > rejects invalid date bounds before any read: pass
  app analytics sessions route (#11349) > rejects reversed date bounds before any read: pass
  app analytics sessions route (#11349) > passes valid supplied bounds unchanged: pass
  5 pass, 0 fail, 27 expect() calls
  Ran 5 tests across 1 file in 27.05 seconds.
  ```
  </details>
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or network client changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - invalid requests are rejected before creating DB or service artifacts.
<!-- evidence-row:ocr-review -->
- [ ] N/A - the change has no rendered visual surface to inspect with OCR.

# Evidence Details

## Real LLM-call trajectory

N/A - no model path changed.

## Backend + frontend logs

The focused Hono request suite exercises the real route and parser with mocked auth/data seams. Impossible dates return `{ success: false, error: "Invalid start_date" | "Invalid end_date" }` with status 400, and assertions prove that neither the app read nor analytics service read occurs.

Frontend: N/A - no frontend surface changed.

## Screenshots (before / after) + video walkthrough

N/A - no UI changed.

## Known gaps / failures

`bun run verify:cloud` and root `bun run verify` currently stop on the same unrelated `@elizaos/container-control-plane` typecheck failures already present on the synchronized base:

- `shared-nav-intent.ts`: `SharedNavTarget.viewPath` is missing.
- `shared-todos.ts`: `@elizaos/shared/todo-cutover` cannot be resolved by this consumer.
- `cloud-eliza-persona.ts`: `StylePreset.templates` is missing.

The two touched files are outside that package. Their owning package typechecks, focused route suite, Biome checks, and exact-head proof pass.

AI provider/model: openai / gpt-5.6-sol
Client / agent tooling: Claude Code CLI Proxy
Contribution skill revision: elizaOS/eliza@7e04c64c73f007610e5da4654803589fdee7c96d:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [sol-cloud-date-range-calendar]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Claude Code CLI Proxy","skill_revision":"elizaOS/eliza@7e04c64c73f007610e5da4654803589fdee7c96d:packages/skills/skills/contribute-to-eliza"} -->
