### PR TITLE
test(ui): complete the #20652 acceptance coverage for the Cloud management bypass

### DIFF
--- a/packages/ui/src/cloud/app-mode/AppModeEntryRoute.test.tsx
+++ b/packages/ui/src/cloud/app-mode/AppModeEntryRoute.test.tsx
@@ -10,6 +10,7 @@ import {
   loadPersistedActiveServer,
   savePersistedActiveServer,
 } from "../../state/persistence";
+import { LocalStewardAuthContext } from "../shell/StewardProviderShared";
 import { AppModeEntryRoute } from "./AppModeEntryRoute";
 import { type AppModeAgent, appModeNavigation } from "./app-mode";
 import { publishPersonalEntryHandoff } from "./use-personal-entry";
@@ -121,30 +122,59 @@ function LoginProbe(): React.JSX.Element {
   return <div data-testid="login-page">{location.search}</div>;
 }
 
-function renderEntry(initialPath = "/"): void {
+function renderEntry(
+  initialPath = "/",
+  options?: { sessionLoading?: boolean },
+): void {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  render(
+  // The management destination lives INSIDE appElement's route registry (the
+  // real shape: AppModeEntryRoute mounts appElement, whose internal router
+  // serves /cloud/*). Registering it as an outer sibling would let React
+  // Router bypass the component entirely — a false guard (#20652 review).
+  const appElement = (
+    <Routes>
+      <Route
+        path="/cloud/agents"
+        element={<div data-testid="instances-page" />}
+      />
+      <Route path="*" element={<div data-testid="agent-app" />} />
+    </Routes>
+  );
+  const entry = (
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={[initialPath]}>
         <Routes>
           <Route path="/login" element={<LoginProbe />} />
-          <Route
-            path="/cloud/agents"
-            element={<div data-testid="instances-page" />}
-          />
           <Route path="/join" element={<div data-testid="join-page" />} />
           <Route
             path="*"
-            element={
-              <AppModeEntryRoute appElement={<div data-testid="agent-app" />} />
-            }
+            element={<AppModeEntryRoute appElement={appElement} />}
           />
         </Routes>
       </MemoryRouter>
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
+  if (options?.sessionLoading) {
+    render(
+      <LocalStewardAuthContext.Provider
+        value={{
+          isAuthenticated: false,
+          isLoading: true,
+          user: null,
+          session: null,
+          signOut: () => undefined,
+          getToken: () => null,
+          verifyEmailCallback: () => Promise.reject(new Error("not stubbed")),
+        }}
+      >
+        {entry}
+      </LocalStewardAuthContext.Provider>,
+    );
+    return;
+  }
+  render(entry);
 }
 
 afterEach(() => {
@@ -351,12 +381,34 @@ describe("AppModeEntryRoute — chat-floor routing table", () => {
     });
     renderEntry("/cloud/agents");
 
-    // The management surface mounts and its internal router serves the
-    // /cloud/agents destination (the harness registers it as instances-page).
-    // The deadlock shape is the persistent loading notice with NOTHING
-    // mounted; both must be absent.
+    // The component was exercised (the query ran), the management surface
+    // mounted, and its internal router serves the /cloud/agents destination.
+    // The deadlock shape — a persistent loading notice with nothing mounted —
+    // must be absent.
     expect(await screen.findByTestId("instances-page")).toBeTruthy();
+    await waitFor(() =>
+      expect(
+        fetchLog.some((line) => line.includes("/api/v1/eliza/agents")),
+      ).toBe(true),
+    );
     expect(screen.queryByText("Loading your agent")).toBeNull();
+  });
+
+  it("holds the session gate before the management bypass: auth still resolving mounts nothing (#20652)", async () => {
+    // Negative control from the acceptance: the bypass fires only AFTER
+    // session resolution. With the auth provider still loading, even a
+    // management path holds the loading notice — the bypass cannot surface
+    // an app before the session is known.
+    signIn();
+    stubNetwork({
+      agents: () => new Promise<Response>(() => undefined),
+    });
+    renderEntry("/cloud/agents", { sessionLoading: true });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.getByText("Loading")).toBeTruthy();
+    expect(screen.queryByTestId("instances-page")).toBeNull();
+    expect(screen.queryByTestId("agent-app")).toBeNull();
   });
 
   it("ordinary entry keeps the existing query-error policy when the agents query rejects with 401", async () => {

--- a/packages/ui/src/cloud/app-mode/AppModeEntryRoute.test.tsx
+++ b/packages/ui/src/cloud/app-mode/AppModeEntryRoute.test.tsx
@@ -332,6 +332,62 @@ describe("AppModeEntryRoute — chat-floor routing table", () => {
 
     expect(screen.getByTestId("agent-app")).toBeTruthy();
   });
+
+  // --- #20652 acceptance completion ------------------------------------
+  // The landed reorder (develop 110111a12e) bypasses the agents gate on
+  // management paths, but the deadlock's exact live shape — a REJECTED
+  // credential, not a slow one — and the negative controls below were
+  // unguarded. These pin them.
+
+  it("keeps /cloud management mounted when the agents query REJECTS with a stale credential (the #20652 deadlock shape)", async () => {
+    // The live incident: a stale dedicated-agent credential made
+    // GET /api/v1/eliza/agents return 401; the gate then waited forever on
+    // "Loading your agent" with the Cloud registry unmounted, locking the
+    // user out of the very page that mints a fresh pairing token.
+    signIn();
+    stubNetwork({
+      agents: () =>
+        jsonResponse(401, { error: "stale dedicated-agent credential" }),
+    });
+    renderEntry("/cloud/agents");
+
+    // The management surface mounts and its internal router serves the
+    // /cloud/agents destination (the harness registers it as instances-page).
+    // The deadlock shape is the persistent loading notice with NOTHING
+    // mounted; both must be absent.
+    expect(await screen.findByTestId("instances-page")).toBeTruthy();
+    expect(screen.queryByText("Loading your agent")).toBeNull();
+  });
+
+  it("ordinary entry keeps the existing query-error policy when the agents query rejects with 401", async () => {
+    // Negative control: the management bypass must not leak into the ordinary
+    // path. A cloud-bound session renders the chat app (existing fallback);
+    // an unbound one routes to /join — either way, NOT the management bypass.
+    signIn();
+    bindCloudAgent();
+    stubNetwork({
+      agents: () =>
+        jsonResponse(401, { error: "stale dedicated-agent credential" }),
+    });
+    renderEntry("/");
+
+    expect(await screen.findByTestId("agent-app")).toBeTruthy();
+    expect(screen.queryByText("Loading your agent")).toBeNull();
+  });
+
+  it("ordinary entry with the agents query unresolved still holds the loading notice (the bypass is management-only)", async () => {
+    signIn();
+    stubNetwork({
+      agents: () => new Promise<Response>(() => undefined),
+    });
+    renderEntry("/");
+
+    // Give the query a beat to settle into pending; the notice must persist
+    // and the app element must NOT mount.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.getByText("Loading your agent")).toBeTruthy();
+    expect(screen.queryByTestId("agent-app")).toBeNull();
+  });
 });
 
 describe("AppModeEntryRoute — rowless personal entry", () => {


### PR DESCRIPTION
Closes #20652 (coverage completion — the core reorder landed as develop `110111a12e`).

## What

The deadlock fix (management paths mount `appElement` without waiting for the agents query) landed with one pending-state regression test. An RP investigation of the landed code identified the acceptance's remaining unguarded cases; this PR pins them. **Test-only diff — no production changes.**

## Tests added (`AppModeEntryRoute.test.tsx`, now 26/26)

1. **The incident's exact shape** — `/cloud/agents` with the agents query *rejecting* (401 stale dedicated-agent credential, not merely slow): the management surface mounts and serves the destination; the loading notice never persists. The harness registers the management destination **inside** `appElement`'s route registry (the real production shape), and the test asserts the agents request actually fired — proving `AppModeEntryRoute` was exercised.
2. **Session gate stays first** — with the auth provider still `isLoading`, even a management path holds the `Loading` notice and mounts nothing; the bypass cannot surface an app before the session resolves.
3. **No leak to ordinary entry** — ordinary `/` on the same 401 keeps the existing query-error policy (cloud-bound fallback renders the chat app).
4. **Bypass is management-only** — ordinary `/` with the query unresolved still holds "Loading your agent" with no app element.

## Review trail

- **RP review round 1** (`c3877c8c`): REQUEST_CHANGES — (1) HIGH: the 401 test's `/cloud/agents` was an outer *sibling* route, so React Router bypassed the component entirely (a false guard); (2) MEDIUM: the session-unresolved case was still uncovered. **Both fixed in `31110aa2`** — harness restructured to the inner-registry shape + fetch-log proof + `sessionLoading` provider control.
- **RP review round 2** (`31110aa2`): **APPROVE** — independently confirmed the guard is real: reverting the production bypass would route the unbound 401 case to `/join` and fail the test; restoring the old sibling harness would fail the fetch-log assertion. 26/26 + typecheck + Biome verified by the reviewer directly.

## Verification

26/26 focused suite, `packages/ui` typecheck clean, Biome clean (all reviewer-run as well as locally).

AI provider/model: zai / glm-5.3
Client / agent tooling: Hermes Agent
Attribution status: self-reported
— [hermes-t3rpz]
<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.3","client":"Hermes Agent"} -->