### PR TITLE
fix(agent): cap runtime self-status truncation within maxChars

### DIFF
--- a/packages/agent/src/actions/runtime.self-status.test.ts
+++ b/packages/agent/src/actions/runtime.self-status.test.ts
@@ -1,8 +1,8 @@
 /**
  * Verifies the RUNTIME action's `self_status` op resolves the self-awareness
- * registry solely from the AWARENESS_REGISTRY runtime service and fails closed
- * when that service is absent or does not expose `getDetail`. Deterministic:
- * drives the handler against a hand-built in-memory runtime stub, no live model.
+ * registry solely from the AWARENESS_REGISTRY runtime service, bounds returned
+ * detail, and degrades to live status when the registry is unavailable.
+ * Deterministic: drives the handler against an in-memory runtime stub.
  */
 import type {
   ActionResult,
@@ -35,12 +35,21 @@ function makeRuntime(service: AwarenessServiceLike | null): IAgentRuntime {
 
 const message = { content: { text: "" } } as unknown as Memory;
 
-async function runSelfStatus(runtime: IAgentRuntime): Promise<ActionResult> {
+async function runSelfStatus(
+  runtime: IAgentRuntime,
+  detailLevel: "brief" | "full" = "brief",
+): Promise<ActionResult> {
   return (await runtimeAction.handler(
     runtime,
     message,
     {} as State,
-    { parameters: { action: "self_status", module: "runtime" } },
+    {
+      parameters: {
+        action: "self_status",
+        module: "runtime",
+        detailLevel,
+      },
+    },
     (() => Promise.resolve([])) as unknown as HandlerCallback,
   )) as ActionResult;
 }
@@ -60,6 +69,25 @@ describe("RUNTIME self_status registry seam", () => {
     expect(result.text).toBe("runtime module detail from service");
     expect(seen).toEqual({ module: "runtime", level: "brief" });
   });
+
+  it.each([
+    ["brief", 1200],
+    ["full", 8000],
+  ] as const)(
+    "keeps truncated %s detail within its %i-character contract",
+    async (detailLevel, maxChars) => {
+      const service: AwarenessServiceLike = {
+        getDetail: async () => "x".repeat(maxChars + 100),
+      };
+
+      const result = await runSelfStatus(makeRuntime(service), detailLevel);
+
+      expect(result.success).toBe(true);
+      expect(result.text).toHaveLength(maxChars);
+      expect(result.text?.endsWith("\n…[self-status truncated]")).toBe(true);
+      expect(result.data?.truncated).toBe(true);
+    },
+  );
 
   it("degrades to the live status snapshot when no AWARENESS_REGISTRY service is registered", async () => {
     // The registry is optional enrichment; without it the runtime still owns a

--- a/packages/agent/src/actions/runtime.ts
+++ b/packages/agent/src/actions/runtime.ts
@@ -225,10 +225,13 @@ async function selfStatusOp(
     detailLevel === "full"
       ? MAX_SELF_STATUS_FULL_CHARS
       : MAX_SELF_STATUS_BRIEF_CHARS;
+  const suffix = "\n…[self-status truncated]";
   const text =
     rawText.length <= maxChars
       ? rawText
-      : `${rawText.slice(0, maxChars)}\n…[self-status truncated]`;
+      : maxChars <= suffix.length
+        ? suffix.slice(0, maxChars)
+        : `${rawText.slice(0, maxChars - suffix.length)}${suffix}`;
   return {
     success: true,
     text,


### PR DESCRIPTION
## Summary

Keeps runtime `self_status` output within its advertised brief and full character limits. The old implementation sliced to the full limit before appending the truncation marker, so truncated output exceeded the configured cap.

Closes #20762.

## Changes

- Reserve the truncation suffix length before slicing runtime status output.
- Preserve the configured maximum even when the maximum is shorter than the suffix.
- Add action-level regression coverage for both brief (`1200`) and full (`8000`) status modes, including the exact output bound and truncation marker.

## Verification

Exact head: `66e4c949b255b04375d5a1657f8233d66a450ddb`.

- `bunx vitest run src/actions/runtime.self-status.test.ts` — 5 passed.
- `bun run --cwd packages/agent typecheck` — passed.
- `bun run --cwd packages/agent lint` — passed.
- `bun run verify` — 356/356 Turbo tasks passed; repository audits passed; anti-larp scanned 8,405 test files with no focused or orphaned skipped tests.

## Evidence

<!-- evidence-head:66e4c949b255b04375d5a1657f8233d66a450ddb -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend runtime action bound; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend runtime action bound; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic backend behavior with no interactive flow.
<!-- evidence-row:backend-logs -->
- [x] [20748-pr20748-focused.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20748-pr20748-focused.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - deterministic formatting behavior; no model invocation changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: anthropic/claude-fable-5; OpenAI Codex
<!-- attribution-row:client -->
- Agent tooling: claude-code; Codex
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@65e933516af65b94e9d7fbe87bbc4b519c4dc775:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

