### PR TITLE
fix(proxy): add upstream timeout with credit refund for birdeye handler

### DIFF
--- a/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.timeout.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.timeout.test.ts
@@ -1,6 +1,6 @@
 /**
- * Timeout and transport refund proof for Birdeye proxy (#20749 P1 fix).
- * Pins that deadline covers fetch+body, and all post-debit transport failures refund exactly once.
+ * Covers Birdeye proxy deadlines and credit refunds with deterministic upstream mocks.
+ * The harness exercises failures during both fetch and response-body consumption.
  */
 import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { Context } from "hono";
@@ -17,7 +17,7 @@ const ORG_ID = "00000000-0000-4000-8000-0000000000bb";
 const COST = 0.0003;
 
 const deductCredits = mock<(args: unknown) => Promise<{ success: boolean }>>();
-const refundCredits = mock<(args: unknown) => Promise<{ success: boolean }>>();
+const refundCredits = mock<(args: unknown) => Promise<unknown>>();
 const getServiceMethodCost = mock<(service: string, method: string) => Promise<number>>();
 const requireUserOrApiKeyWithOrg = mock<(c: unknown) => Promise<{ organization_id: string }>>();
 
@@ -40,7 +40,7 @@ const originalFetch = globalThis.fetch;
 function makeContext(path: string): Context<AppEnv> {
   const url = `https://api.elizacloud.ai/proxy/${path}`;
   return {
-    env: { BIRDEYE_API_KEY: "key" } as any,
+    env: { BIRDEYE_API_KEY: "key" } as unknown as AppEnv["Bindings"],
     req: {
       param: (key: string) => (key === "*" ? path : undefined),
       url,
@@ -83,17 +83,21 @@ describe("birdeye proxy — timeout covers fetch+body and transport refunds", ()
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("timeout");
     expect(refundCredits).toHaveBeenCalledTimes(1);
-    const args = refundCredits.mock.calls[0][0] as any;
+    const args = refundCredits.mock.calls[0]?.[0] as {
+      organizationId: string;
+      amount: number;
+    };
     expect(args.organizationId).toBe(ORG_ID);
     expect(args.amount).toBe(COST);
   });
 
   test("AbortError during body read (stalled body) refunds once and returns 504", async () => {
-    globalThis.fetch = mock(async () =>
-      new Response("{}", {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      })
+    globalThis.fetch = mock(
+      async () =>
+        new Response("{}", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
     ) as unknown as typeof fetch;
     // Make text() throw AbortError to simulate stalled body aborted by timeout
     const originalText = Response.prototype.text;
@@ -101,7 +105,7 @@ describe("birdeye proxy — timeout covers fetch+body and transport refunds", ()
       const err = new Error("This operation was aborted");
       err.name = "AbortError";
       throw err;
-    }) as any;
+    }) as unknown as typeof Response.prototype.text;
     try {
       const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
       expect(res.status).toBe(504);
@@ -122,7 +126,8 @@ describe("birdeye proxy — timeout covers fetch+body and transport refunds", ()
 
   test("upstream 5xx refunds once and forwards status", async () => {
     globalThis.fetch = mock(
-      async () => new Response("upstream down", { status: 502, headers: { "Content-Type": "text/plain" } }),
+      async () =>
+        new Response("upstream down", { status: 502, headers: { "Content-Type": "text/plain" } }),
     ) as unknown as typeof fetch;
     const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
     expect(res.status).toBe(502);
@@ -131,14 +136,19 @@ describe("birdeye proxy — timeout covers fetch+body and transport refunds", ()
 
   test("success 200 and 4xx do not refund", async () => {
     globalThis.fetch = mock(
-      async () => new Response('{"ok":1}', { status: 200, headers: { "Content-Type": "application/json" } }),
+      async () =>
+        new Response('{"ok":1}', { status: 200, headers: { "Content-Type": "application/json" } }),
     ) as unknown as typeof fetch;
     let res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
     expect(res.status).toBe(200);
     expect(refundCredits).not.toHaveBeenCalled();
     refundCredits.mockReset();
     globalThis.fetch = mock(
-      async () => new Response('{"error":"bad"}', { status: 400, headers: { "Content-Type": "application/json" } }),
+      async () =>
+        new Response('{"error":"bad"}', {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
     ) as unknown as typeof fetch;
     res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
     expect(res.status).toBe(400);

--- a/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.timeout.test.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.timeout.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Timeout and transport refund proof for Birdeye proxy (#20749 P1 fix).
+ * Pins that deadline covers fetch+body, and all post-debit transport failures refund exactly once.
+ */
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Context } from "hono";
+import type { AppEnv } from "../../../types/cloud-worker-env";
+import * as authActual from "../../auth/workers-hono-auth";
+import * as creditsActual from "../credits";
+import * as pricingActual from "./pricing";
+
+const realCredits = { ...creditsActual };
+const realPricing = { ...pricingActual };
+const realAuth = { ...authActual };
+
+const ORG_ID = "00000000-0000-4000-8000-0000000000bb";
+const COST = 0.0003;
+
+const deductCredits = mock<(args: unknown) => Promise<{ success: boolean }>>();
+const refundCredits = mock<(args: unknown) => Promise<{ success: boolean }>>();
+const getServiceMethodCost = mock<(service: string, method: string) => Promise<number>>();
+const requireUserOrApiKeyWithOrg = mock<(c: unknown) => Promise<{ organization_id: string }>>();
+
+mock.module("../credits", () => ({
+  ...realCredits,
+  creditsService: { ...realCredits.creditsService, deductCredits, refundCredits },
+}));
+
+mock.module("./pricing", () => ({ ...realPricing, getServiceMethodCost }));
+
+mock.module("../../auth/workers-hono-auth", () => ({
+  ...realAuth,
+  requireUserOrApiKeyWithOrg,
+}));
+
+const { handleBirdeyeMarketDataProxyGet } = await import("./birdeye-handler");
+
+const originalFetch = globalThis.fetch;
+
+function makeContext(path: string): Context<AppEnv> {
+  const url = `https://api.elizacloud.ai/proxy/${path}`;
+  return {
+    env: { BIRDEYE_API_KEY: "key" } as any,
+    req: {
+      param: (key: string) => (key === "*" ? path : undefined),
+      url,
+      header: (_name: string) => undefined,
+    },
+    json: (body: unknown, status?: number) => Response.json(body, { status: status ?? 200 }),
+  } as unknown as Context<AppEnv>;
+}
+
+beforeEach(() => {
+  deductCredits.mockReset();
+  refundCredits.mockReset();
+  getServiceMethodCost.mockReset();
+  requireUserOrApiKeyWithOrg.mockReset();
+  deductCredits.mockResolvedValue({ success: true });
+  refundCredits.mockResolvedValue({ success: true });
+  getServiceMethodCost.mockResolvedValue(COST);
+  requireUserOrApiKeyWithOrg.mockResolvedValue({ organization_id: ORG_ID });
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterAll(() => {
+  mock.module("../credits", () => realCredits);
+  mock.module("./pricing", () => realPricing);
+  mock.module("../../auth/workers-hono-auth", () => realAuth);
+});
+
+describe("birdeye proxy — timeout covers fetch+body and transport refunds", () => {
+  test("AbortError during fetch refunds once and returns 504", async () => {
+    globalThis.fetch = mock(async () => {
+      const err = new Error("This operation was aborted");
+      err.name = "AbortError";
+      throw err;
+    }) as unknown as typeof fetch;
+    const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
+    expect(res.status).toBe(504);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("timeout");
+    expect(refundCredits).toHaveBeenCalledTimes(1);
+    const args = refundCredits.mock.calls[0][0] as any;
+    expect(args.organizationId).toBe(ORG_ID);
+    expect(args.amount).toBe(COST);
+  });
+
+  test("AbortError during body read (stalled body) refunds once and returns 504", async () => {
+    globalThis.fetch = mock(async () =>
+      new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    ) as unknown as typeof fetch;
+    // Make text() throw AbortError to simulate stalled body aborted by timeout
+    const originalText = Response.prototype.text;
+    Response.prototype.text = mock(async function (this: Response) {
+      const err = new Error("This operation was aborted");
+      err.name = "AbortError";
+      throw err;
+    }) as any;
+    try {
+      const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
+      expect(res.status).toBe(504);
+      expect(refundCredits).toHaveBeenCalledTimes(1);
+    } finally {
+      Response.prototype.text = originalText;
+    }
+  });
+
+  test("non-Abort transport failure refunds once and returns 502", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new TypeError("fetch failed: DNS error");
+    }) as unknown as typeof fetch;
+    const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
+    expect(res.status).toBe(502);
+    expect(refundCredits).toHaveBeenCalledTimes(1);
+  });
+
+  test("upstream 5xx refunds once and forwards status", async () => {
+    globalThis.fetch = mock(
+      async () => new Response("upstream down", { status: 502, headers: { "Content-Type": "text/plain" } }),
+    ) as unknown as typeof fetch;
+    const res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
+    expect(res.status).toBe(502);
+    expect(refundCredits).toHaveBeenCalledTimes(1);
+  });
+
+  test("success 200 and 4xx do not refund", async () => {
+    globalThis.fetch = mock(
+      async () => new Response('{"ok":1}', { status: 200, headers: { "Content-Type": "application/json" } }),
+    ) as unknown as typeof fetch;
+    let res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
+    expect(res.status).toBe(200);
+    expect(refundCredits).not.toHaveBeenCalled();
+    refundCredits.mockReset();
+    globalThis.fetch = mock(
+      async () => new Response('{"error":"bad"}', { status: 400, headers: { "Content-Type": "application/json" } }),
+    ) as unknown as typeof fetch;
+    res = await handleBirdeyeMarketDataProxyGet(makeContext("defi/price"));
+    expect(res.status).toBe(400);
+    expect(refundCredits).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.ts
@@ -100,6 +100,8 @@ export async function handleBirdeyeMarketDataProxyGet(c: Context<AppEnv>): Promi
       });
       body = await upstreamResponse.text();
     } catch (error) {
+      // error-policy:J1 upstream boundary — transport and deadline failures
+      // become explicit 502/504 responses after the prepaid cost is refunded.
       const isAbort = error instanceof Error && error.name === "AbortError";
       await creditsService
         .refundCredits({
@@ -114,6 +116,8 @@ export async function handleBirdeyeMarketDataProxyGet(c: Context<AppEnv>): Promi
           },
         })
         .catch((refundError) => {
+          // error-policy:J4 the upstream request is already a visible failure;
+          // preserve that response while recording the secondary refund fault.
           logger.warn("[BirdeyeProxy] refund after upstream failure failed", {
             method: pricedMethod,
             error: refundError instanceof Error ? refundError.message : String(refundError),
@@ -147,6 +151,8 @@ export async function handleBirdeyeMarketDataProxyGet(c: Context<AppEnv>): Promi
           },
         })
         .catch((refundError) => {
+          // error-policy:J4 the upstream 5xx remains visible to the caller;
+          // preserve it while recording the secondary refund fault.
           logger.warn("[BirdeyeProxy] refund after upstream failure failed", {
             method: pricedMethod,
             status: upstreamResponse.status,

--- a/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.ts
@@ -85,13 +85,44 @@ export async function handleBirdeyeMarketDataProxyGet(c: Context<AppEnv>): Promi
       upstreamUrl.searchParams.set(key, value);
     });
 
-    const upstreamResponse = await fetch(upstreamUrl.toString(), {
-      headers: {
-        Accept: "application/json",
-        "x-chain": c.req.header("x-chain") ?? "solana",
-        "X-API-KEY": birdeyeApiKey,
-      },
-    });
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10_000);
+    let upstreamResponse: Response;
+    try {
+      upstreamResponse = await fetch(upstreamUrl.toString(), {
+        headers: {
+          Accept: "application/json",
+          "x-chain": c.req.header("x-chain") ?? "solana",
+          "X-API-KEY": birdeyeApiKey,
+        },
+        signal: controller.signal,
+      });
+    } catch (error) {
+      clearTimeout(timeoutId);
+      if (error instanceof Error && error.name === "AbortError") {
+        await creditsService
+          .refundCredits({
+            organizationId: organization_id,
+            amount: cost,
+            description: `API proxy refund: market-data — ${pricedMethod} (upstream timeout)`,
+            metadata: {
+              type: "proxy_market-data_refund",
+              service: "market-data",
+              provider: "birdeye",
+              method: pricedMethod,
+            },
+          })
+          .catch((refundError) => {
+            logger.warn("[BirdeyeProxy] refund after upstream timeout failed", {
+              method: pricedMethod,
+              error: refundError instanceof Error ? refundError.message : String(refundError),
+            });
+          });
+        return c.json({ error: "Upstream service timeout" }, 504);
+      }
+      throw error;
+    }
+    clearTimeout(timeoutId);
 
     const body = await upstreamResponse.text();
 

--- a/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.ts
+++ b/packages/cloud/shared/src/lib/services/proxy/birdeye-handler.ts
@@ -88,6 +88,7 @@ export async function handleBirdeyeMarketDataProxyGet(c: Context<AppEnv>): Promi
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 10_000);
     let upstreamResponse: Response;
+    let body: string;
     try {
       upstreamResponse = await fetch(upstreamUrl.toString(), {
         headers: {
@@ -97,34 +98,34 @@ export async function handleBirdeyeMarketDataProxyGet(c: Context<AppEnv>): Promi
         },
         signal: controller.signal,
       });
+      body = await upstreamResponse.text();
     } catch (error) {
-      clearTimeout(timeoutId);
-      if (error instanceof Error && error.name === "AbortError") {
-        await creditsService
-          .refundCredits({
-            organizationId: organization_id,
-            amount: cost,
-            description: `API proxy refund: market-data — ${pricedMethod} (upstream timeout)`,
-            metadata: {
-              type: "proxy_market-data_refund",
-              service: "market-data",
-              provider: "birdeye",
-              method: pricedMethod,
-            },
-          })
-          .catch((refundError) => {
-            logger.warn("[BirdeyeProxy] refund after upstream timeout failed", {
-              method: pricedMethod,
-              error: refundError instanceof Error ? refundError.message : String(refundError),
-            });
+      const isAbort = error instanceof Error && error.name === "AbortError";
+      await creditsService
+        .refundCredits({
+          organizationId: organization_id,
+          amount: cost,
+          description: `API proxy refund: market-data — ${pricedMethod} (${isAbort ? "upstream timeout" : "upstream transport failure"})`,
+          metadata: {
+            type: "proxy_market-data_refund",
+            service: "market-data",
+            provider: "birdeye",
+            method: pricedMethod,
+          },
+        })
+        .catch((refundError) => {
+          logger.warn("[BirdeyeProxy] refund after upstream failure failed", {
+            method: pricedMethod,
+            error: refundError instanceof Error ? refundError.message : String(refundError),
           });
+        });
+      if (isAbort) {
         return c.json({ error: "Upstream service timeout" }, 504);
       }
-      throw error;
+      return c.json({ error: "Upstream service unavailable" }, 502);
+    } finally {
+      clearTimeout(timeoutId);
     }
-    clearTimeout(timeoutId);
-
-    const body = await upstreamResponse.text();
 
     // Mirror the engine's billing policy (resolveBillableCost refunds on >=500):
     // we already debited `cost` upfront, so refund it when the upstream FAILS


### PR DESCRIPTION
## Relates to

Money-path fix for the Birdeye proxy: a stalled upstream could hold a prepaid charge beyond the intended deadline, and transport failures after debit were not refunded.

## What changed

- Apply the existing 10-second deadline to both `fetch` and response-body consumption.
- Refund the prepaid cost exactly once on fetch abort, body-read abort, and other transport failures.
- Return 504 for deadline aborts and 502 for other transport failures.
- Preserve the existing policy: upstream 5xx refunds; upstream 4xx and successful responses remain charged.
- Classify the retained boundary/refund catches under the repository error policy.
- Replace broad test casts and change-history narration with explicit deterministic test contracts.

## Risk

Low and bounded to the Birdeye direct proxy. No schema, dependency, UI, auth, or pricing change. The timeout duration remains 10 seconds; it now covers the complete upstream response rather than headers only.

## Exact-head verification

Head: `bdc38f23d1a1ec37be7dab2c2b015559357b915f`

- Birdeye timeout/refund suite: 5 passed
- Existing Birdeye error-policy suite: 6 passed
- Cloud shared typecheck and focused Biome: passed
- `bun run verify`: 356/356 tasks passed
- Anti-larp: 8,427 test files scanned; 0 focused, 0 orphaned skips

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend transport and billing path; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend transport and billing path; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing visual interaction changed.
<!-- evidence-row:backend-logs -->
- [x] [20749-pr20749-focused-both.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20749-pr20749-focused-both.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] [20749-pr20749-verify.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20749-pr20749-verify.log)
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

## Contribution provenance

- Original AI assistance: yes
- Original model: `anthropic/claude-fable-5`
- Original agent tooling: `claude-code`
- Independent review/repair: OpenAI GPT-5.4 via Codex desktop
- Provenance status: self-reported

<!-- evidence-head:bdc38f23d1a1ec37be7dab2c2b015559357b915f -->

— [eliza-computer]
<!-- eliza-computer-attribution:v1 {"agent":"eliza-computer","model":"anthropic/claude-fable-5","skill_revision":"e772e47772cbec251654900d1461bf757e5192bb","contribution_skill_revision":"e772e47772cbec251654900d1461bf757e5192bb","provenance":"self-reported"} -->



