### PR TITLE
fix(core): coding-mode failure authority erased shipped deliverables (fixes #20738)

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-failure-correlation.test.ts
@@ -736,9 +736,80 @@ describe("planner-loop failed-operation correlation", () => {
 			});
 
 			expect(result.status).toBe("finished");
-			expect(result.finalMessage).toBe(shellFailure);
+			// The failure keeps the lead and the model's contradicting prose is
+			// excluded, but the tool-owned success from project B is reported —
+			// erasing it produced the inverse lie ("never produced a usable
+			// result" while the deliverable shipped, live 2026-08-16).
+			expect(result.finalMessage?.startsWith(shellFailure)).toBe(true);
 			expect(result.finalMessage).not.toContain("Both test runs passed");
+			expect(result.finalMessage).toContain("Project B tests passed.");
 			expect(evaluate).not.toHaveBeenCalled();
+		});
+	});
+
+	it("reports tool-owned recovery evidence after an unresolved coding failure", async () => {
+		await withCodingFullSurface(async () => {
+			const runtime = {
+				useModel: vi
+					.fn()
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "shell-echo",
+								name: "SHELL",
+								arguments: { command: "echo $PATH", cwd: "/workspace" },
+							},
+						],
+					})
+					.mockResolvedValueOnce({
+						text: "",
+						toolCalls: [
+							{
+								id: "file-write",
+								name: "FILE",
+								arguments: {
+									action: "write",
+									file_path: "index.html",
+								},
+							},
+						],
+					})
+					.mockResolvedValueOnce({
+						text: "Done! The page is live.",
+					}),
+			};
+			const shellFailure = "No boot-authorized shell was detected.";
+			const evaluate = vi.fn();
+			const result = await runPlannerLoop({
+				runtime,
+				context: { id: "ctx" },
+				executeToolCall: vi
+					.fn()
+					.mockResolvedValueOnce({
+						success: false,
+						error: "command_failed",
+						text: shellFailure,
+						userFacingText: shellFailure,
+					})
+					.mockResolvedValueOnce({
+						success: true,
+						text: "Wrote index.html (74 lines).",
+						userFacingText: "Wrote index.html (74 lines).",
+					}),
+				evaluate,
+			});
+
+			expect(result.status).toBe("finished");
+			// The live 2026-08-16 inversion: the sub-agent built and deployed its
+			// page after auxiliary shell failures, and the final message claimed
+			// nothing usable was produced. The failure keeps the lead; the
+			// tool-owned write is reported as recovery evidence; untrusted model
+			// prose stays out.
+			expect(result.finalMessage?.startsWith(shellFailure)).toBe(true);
+			expect(result.finalMessage).toContain("Wrote index.html (74 lines).");
+			expect(result.finalMessage).not.toContain("Done! The page is live.");
+			expect(result.finalMessage).not.toBe(shellFailure);
 		});
 	});
 

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -3632,6 +3632,38 @@ function latestUnresolvedFailedNonTerminalToolStep(
  * may stand in for the generic fallback when the failed tool owns no
  * user-safe text of its own (#17948).
  */
+/**
+ * User-safe, tool-owned result text from non-terminal steps that SUCCEEDED
+ * after `failedStep` in trajectory order — the structural evidence that the
+ * turn recovered past the failure and produced real work. Capped to the most
+ * recent entries so a long build does not flood the terminal message (see
+ * terminalMessageWithFailureAuthority).
+ */
+function toolOwnedSuccessEvidenceAfter(
+	trajectory: PlannerTrajectory,
+	failedStep: PlannerStep,
+): string[] {
+	const steps = [...trajectory.archivedSteps, ...trajectory.steps];
+	const failedIndex = steps.indexOf(failedStep);
+	if (failedIndex === -1) return [];
+	const evidence: string[] = [];
+	for (const step of steps.slice(failedIndex + 1)) {
+		if (
+			step.toolCall === undefined ||
+			isTerminalToolCall(step.toolCall) ||
+			step.result?.success !== true
+		) {
+			continue;
+		}
+		const owned = sanitizePlannerMessage(
+			step.result.userFacingText ?? step.result.text,
+		);
+		if (!owned || isUnsafeUserVisibleText(owned)) continue;
+		if (!evidence.includes(owned)) evidence.push(owned);
+	}
+	return evidence.slice(-3);
+}
+
 function terminalMessageWithFailureAuthority(
 	trajectory: PlannerTrajectory,
 	candidate: string | undefined,
@@ -3658,7 +3690,29 @@ function terminalMessageWithFailureAuthority(
 		return pendingInteraction;
 	}
 
-	return groundedFailedToolMessage(unresolvedFailure, failureReport);
+	// Chat mode replaces the candidate on purpose: the exact-fallback final
+	// message is the trigger for ensureFailedTurnFinalMessage, whose model
+	// call rewrites it into an honest mixed report. Coding/full-surface mode
+	// SKIPS that synthesis (its result feeds the orchestrator), so the raw
+	// replacement shipped a lie: the sub-agent built and deployed its page and
+	// the relayed reply claimed it "never produced a usable result" (live
+	// 2026-08-16). Model prose after a failed operation stays untrusted here —
+	// it can affirmatively contradict the failure — but TOOL-OWNED text from
+	// steps that succeeded AFTER the failure cannot launder by construction.
+	// So in coding mode the failure text keeps the lead and the tool-owned
+	// success evidence is appended, giving the orchestrator's summary both
+	// truths instead of only the failure.
+	const failureNote = groundedFailedToolMessage(
+		unresolvedFailure,
+		failureReport,
+	);
+	if (!isCodingFullSurfaceMode()) return failureNote;
+	const successEvidence = toolOwnedSuccessEvidenceAfter(
+		trajectory,
+		unresolvedFailure,
+	);
+	if (successEvidence.length === 0) return failureNote;
+	return `${failureNote}\n\nWork that did complete: ${successEvidence.join(" ")}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes #20738 — the false-failure completion relay nubs hit live: the coding sub-agent built and deployed its page, its model authored "Done! …live at…", and the user was told it "hit a runtime step failure and never produced a usable result."

Mechanism: `terminalMessageWithFailureAuthority` replaces the terminal candidate with the failure text whenever an unresolved failed operation exists. In CHAT mode that exact-fallback replacement deliberately triggers `ensureFailedTurnFinalMessage`'s model-authored honest synthesis — that path was never broken. CODING/full-surface mode **skips** that synthesis (result feeds the orchestrator), so the raw replacement shipped the lie verbatim, and the parent relayed it.

The fix keeps every anti-laundering invariant and adds the missing truth channel, structurally:
- Model prose after a failed operation stays **untrusted** in coding mode (it can affirmatively contradict the failure — the existing adversarial test's "Both test runs passed" case still excludes it).
- **Tool-owned text from steps that SUCCEEDED after the unresolved failure cannot launder by construction** — new `toolOwnedSuccessEvidenceAfter` collects it (sanitized, user-safe-filtered, deduped, capped at 3) and appends it after the authoritative failure note: `"<failure>\n\nWork that did complete: <tool-owned successes>"`.
- No successful steps after the failure → behavior unchanged (failure text only).
- Chat mode → behavior unchanged entirely.

## Evidence
- New regression test mirrors the live incident exactly (SHELL failure → FILE success → model "Done!" prose): failure leads, tool-owned "Wrote index.html" reported, untrusted prose excluded.
- Updated adversarial contract: failure still leads and the model's false claim is still excluded, but project B's tool-owned success is now reported — erasing it was the inverse lie.
- Suites: planner-loop-failure-correlation 16/16, honest-failure + user-facing-text + correlation combined 65/65, **full core runtime sweep 83 files / 1264 tests green**.
- Live receipts (trajectories, sessions, Discord transcript) in HQ #18309 and #20738.

Chain context: #20734 (spawn durability) + #20737 (ACP child SHELL baseline) + this = all three findings from tonight's live orchestration test fixed. Live-box application plan: resync + dist rebuild + probe #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)