### PR TITLE
fix(shared): host execution baseline is invisible across bundled/external module instances

### DIFF
--- a/packages/shared/src/host-execution-env.bridge.fixture.ts
+++ b/packages/shared/src/host-execution-env.bridge.fixture.ts
@@ -1,0 +1,9 @@
+/**
+ * Fresh-process harness for the cross-instance env mirror: reads the baseline
+ * WITHOUT ever calling capture, as an externalized second module instance
+ * (e.g. plugin-coding-tools inside a bundled ACP child) would.
+ */
+
+import { getHostExecutionBaseline } from "./host-execution-env.ts";
+
+process.stdout.write(JSON.stringify(getHostExecutionBaseline()));

--- a/packages/shared/src/host-execution-env.test.ts
+++ b/packages/shared/src/host-execution-env.test.ts
@@ -89,3 +89,46 @@ describe("host execution boot baseline", () => {
     }
   });
 });
+
+describe("host execution baseline env mirror", () => {
+  it("capture publishes the authority for uncaptured module instances", () => {
+    const fixture = fileURLToPath(
+      new URL("./host-execution-env.bridge.fixture.ts", import.meta.url),
+    );
+    const stdout = execFileSync(process.execPath, [fixture], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ELIZA_HOST_EXECUTION_BASELINE_PATH: "/usr/bin:/bin",
+      },
+    });
+    expect(JSON.parse(stdout)).toEqual({ path: "/usr/bin:/bin" });
+  });
+
+  it("rejects an invalid mirrored value instead of trusting it", () => {
+    const fixture = fileURLToPath(
+      new URL("./host-execution-env.bridge.fixture.ts", import.meta.url),
+    );
+    const stdout = execFileSync(process.execPath, [fixture], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ELIZA_HOST_EXECUTION_BASELINE_PATH: "relative/entry:/bin",
+      },
+    });
+    expect(JSON.parse(stdout)).toEqual({});
+  });
+
+  it("stays empty when no capture ran and no mirror is set", () => {
+    const fixture = fileURLToPath(
+      new URL("./host-execution-env.bridge.fixture.ts", import.meta.url),
+    );
+    const env = { ...process.env };
+    delete env.ELIZA_HOST_EXECUTION_BASELINE_PATH;
+    const stdout = execFileSync(process.execPath, [fixture], {
+      encoding: "utf8",
+      env,
+    });
+    expect(JSON.parse(stdout)).toEqual({});
+  });
+});

--- a/packages/shared/src/host-execution-env.ts
+++ b/packages/shared/src/host-execution-env.ts
@@ -54,15 +54,36 @@ export function createHostExecutionBaseline(
   });
 }
 
+/**
+ * Process-global mirror of the captured PATH authority. Module state alone is
+ * NOT process-global under bundling: an entrypoint that bundles this module
+ * captures into ITS copy, while an externalized package (plugin-coding-tools
+ * in the eliza-code ACP child) resolves a second instance from node_modules
+ * whose `capturedBaseline` stays empty — live 2026-08-17, every sub-agent
+ * SHELL died "No boot-authorized shell" with a fully valid child PATH. The
+ * env mirror bridges instances; it is validated on every read and grants no
+ * new authority (whoever sets a child's env already controls its PATH).
+ */
+const BASELINE_ENV_MIRROR = "ELIZA_HOST_EXECUTION_BASELINE_PATH";
+
 /** Capture once. Later calls cannot replace the boot authority. */
 export function captureHostExecutionBaseline(): HostExecutionBaseline {
   if (capturedBaseline) return capturedBaseline;
   capturedBaseline = createHostExecutionBaseline(process.env);
+  if (capturedBaseline.path) {
+    process.env[BASELINE_ENV_MIRROR] = capturedBaseline.path;
+  }
   return capturedBaseline;
 }
 
 export function getHostExecutionBaseline(): HostExecutionBaseline {
-  return capturedBaseline ?? Object.freeze({});
+  if (capturedBaseline) return capturedBaseline;
+  const mirrored = validateHostExecutionPath(process.env[BASELINE_ENV_MIRROR]);
+  if (mirrored) {
+    capturedBaseline = Object.freeze({ path: mirrored });
+    return capturedBaseline;
+  }
+  return Object.freeze({});
 }
 
 /**


### PR DESCRIPTION
## Summary
Live follow-up to #20737: the ACP child capture fix ran but SHELL still died — the eliza-code `dist/acp.js` bundle INLINES `@elizaos/shared/host-execution-env` (capture writes the bundled copy's module state) while `@elizaos/plugin-coding-tools` is externalized and resolves a SECOND instance from node_modules whose `capturedBaseline` stays empty. Diagnosed live 2026-08-17: child PATH fully valid (all-absolute entries), bundle contains 5 inlined `capturedBaseline` copies + 1 external plugin-coding-tools import, and every sub-agent SHELL — builtins included — still exited -1 "No boot-authorized shell".

Fix: `captureHostExecutionBaseline` mirrors the captured PATH into `process.env.ELIZA_HOST_EXECUTION_BASELINE_PATH`; `getHostExecutionBaseline` on an uncaptured instance falls back to the mirror, re-validated through `validateHostExecutionPath` and then frozen as that instance's capture. `process.env` is process-global — immune to module duplication and bundling.

Security: no new authority. Whoever sets a child's env already controls its PATH outright; the mirror is validated on every read and the capture-once contract holds per instance.

## Evidence
- 3 new subprocess-fixture tests (uncaptured instance reads the mirror; invalid mirror rejected; empty when neither capture nor mirror) — suite 9/9.
- Write-side proof: fresh process, capture → mirror set and equals PATH.
- Live reproduction receipts (bundle analysis, child env dump, failing diagnostic session) in HQ #18309.

Completes the #20737 arc; the live box carries this + rebuild for the closing probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)