### PR TITLE
fix(cloud): bounded inline hydration for voice warming 503s (#20557)

### DIFF
--- a/packages/cloud/api/__tests__/generative-route-warming-await.test.ts
+++ b/packages/cloud/api/__tests__/generative-route-warming-await.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Bounded inline hydration for voice generative routes (#20557): when the
+ * per-user inference auth cache entry has expired (60s TTL) the voice
+ * STT/TTS routes must not surface an immediate retryable 503 — they opt
+ * into one bounded await of the already-coalesced hydration and re-resolve.
+ *
+ * Deterministic harness: the combined inference auth resolver is replaced
+ * with a scriptable sequence, so each test controls exactly which
+ * resolutions the caller observes (warming, authorized, rejected, outage).
+ * Rate limiting is disarmed so assertions target only the auth wait.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ApiError } from "@/lib/api/cloud-worker-errors";
+import type { AppContext } from "@/types/cloud-worker-env";
+
+type ScriptedResolution =
+  | { kind: "authorized"; ctx: Record<string, unknown> }
+  | { kind: "warming"; hydration?: Promise<void> }
+  | { kind: "rejected"; status: 401 | 403 }
+  | { kind: "suspended" };
+
+const resolveCalls: unknown[][] = [];
+let scripted: ScriptedResolution[] = [];
+
+const resolveInferenceAuthContext = mock(async (...args: unknown[]) => {
+  resolveCalls.push(args);
+  const next = scripted.shift();
+  if (!next) throw new Error("no scripted resolution left");
+  return next;
+});
+mock.module("@/lib/services/inference-auth-context", () => ({
+  resolveInferenceAuthContext,
+}));
+
+const enforceOrgRateLimit = mock(
+  async (_orgId: string, _endpoint: string, ..._rest: unknown[]) => null,
+);
+mock.module("@/lib/middleware/rate-limit", () => ({
+  enforceOrgRateLimit,
+  OrgRateLimitCacheNotReadyError: class extends Error {},
+}));
+mock.module("@/lib/services/inference-admission-snapshot", () => ({
+  loadInferenceAdmissionSnapshot: async () => null,
+  inferenceRateLimitConfig: () => ({}),
+}));
+
+const { requireGenerativeRouteCaller } = await import(
+  "@/api-app/lib/generative-route-auth"
+);
+
+const ORG = "00000000-0000-4000-8000-0000000000cc";
+const USER = "00000000-0000-4000-8000-0000000000dd";
+
+function context(): AppContext {
+  const store = new Map<string, unknown>();
+  const waitUntilTasks: Promise<unknown>[] = [];
+  return {
+    req: {
+      raw: new Request("https://api.test/v1/voice/tts", { method: "POST" }),
+    },
+    executionCtx: {
+      waitUntil(promise: Promise<unknown>) {
+        waitUntilTasks.push(promise);
+      },
+      passThroughOnException() {},
+      props: {},
+    },
+    get: (key: string) => store.get(key),
+    set: (key: string, value: unknown) => void store.set(key, value),
+  } as unknown as AppContext;
+}
+
+beforeEach(() => {
+  resolveCalls.length = 0;
+  scripted = [];
+  resolveInferenceAuthContext.mockClear();
+  enforceOrgRateLimit.mockClear();
+});
+
+describe("requireGenerativeRouteCaller awaitWarmingMs (#20557)", () => {
+  test("voice budget converts warming into authorized without a client retry", async () => {
+    const gate = Promise.withResolvers<void>();
+    scripted = [
+      {
+        kind: "warming",
+        // Hydration settles quickly — inside the 1500ms voice budget.
+        hydration: gate.promise,
+      },
+      {
+        kind: "authorized",
+        ctx: { userId: USER, orgId: ORG, apiKeyId: null },
+      },
+    ];
+
+    const callerPromise = requireGenerativeRouteCaller(context(), {
+      compatibility: "raw",
+      rateLimitEndpoint: "strict",
+      awaitWarmingMs: 1500,
+    });
+
+    // Let the microtask queue settle so the first resolve has returned
+    // warming before the hydration resolves.
+    await Promise.resolve();
+    await Promise.resolve();
+    gate.resolve();
+    const caller = await callerPromise;
+
+    expect(caller.authSource).toBe("combined_cache");
+    expect(caller.user.id).toBe(USER);
+    expect(caller.user.organization_id).toBe(ORG);
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(2);
+  });
+
+  test("budget expiry preserves the immediate retryable 503 verbatim", async () => {
+    const never = new Promise<void>(() => {});
+    scripted = [
+      { kind: "warming", hydration: never },
+      { kind: "warming", hydration: never },
+    ];
+
+    const startedAt = Date.now();
+    let apiError: (typeof ApiError)["prototype"] | undefined;
+    try {
+      await requireGenerativeRouteCaller(context(), {
+        compatibility: "raw",
+        rateLimitEndpoint: "strict",
+        awaitWarmingMs: 20,
+      });
+      throw new Error("expected a warming ApiError");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiError);
+      apiError = error as InstanceType<typeof ApiError>;
+    }
+    const elapsed = Date.now() - startedAt;
+    expect(elapsed).toBeGreaterThanOrEqual(18);
+    expect(apiError?.status).toBe(503);
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(2);
+  });
+
+  test("warming without a hydration promise (cache outage) fails fast, no budget burn", async () => {
+    scripted = [{ kind: "warming" }];
+
+    const startedAt = Date.now();
+    await expect(
+      requireGenerativeRouteCaller(context(), {
+        compatibility: "raw",
+        rateLimitEndpoint: "strict",
+        awaitWarmingMs: 1500,
+      }),
+    ).rejects.toThrow("Authorization cache is warming; retry shortly");
+    expect(Date.now() - startedAt).toBeLessThan(1500);
+    // No re-resolve was attempted: the outage branch skips the retry.
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
+    expect(enforceOrgRateLimit).not.toHaveBeenCalled();
+  });
+
+  test("unset budget keeps the legacy fast-fail behavior exactly", async () => {
+    const never = new Promise<void>(() => {});
+    scripted = [{ kind: "warming", hydration: never }];
+
+    await expect(
+      requireGenerativeRouteCaller(context(), {
+        compatibility: "raw",
+        rateLimitEndpoint: "strict",
+      }),
+    ).rejects.toThrow("Authorization cache is warming; retry shortly");
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(1);
+  });
+
+  test("a definitive rejection after the awaited hydration surfaces verbatim", async () => {
+    scripted = [
+      { kind: "warming", hydration: Promise.resolve() },
+      { kind: "rejected", status: 401 },
+    ];
+
+    await expect(
+      requireGenerativeRouteCaller(context(), {
+        compatibility: "raw",
+        rateLimitEndpoint: "strict",
+        awaitWarmingMs: 1500,
+      }),
+    ).rejects.toThrow("Authentication required");
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(2);
+  });
+
+  test("a rejecting hydration degrades to the retryable warming 503, not an opaque error", async () => {
+    // Silence at creation so the rejected promise never crosses an await
+    // boundary handler-less (the race attaches its own catch later).
+    const rejecting = Promise.reject(new Error("cache write failed"));
+    rejecting.catch(() => undefined);
+    scripted = [
+      { kind: "warming", hydration: rejecting },
+      { kind: "warming", hydration: new Promise<void>(() => {}) },
+    ];
+
+    await expect(
+      requireGenerativeRouteCaller(context(), {
+        compatibility: "raw",
+        rateLimitEndpoint: "strict",
+        awaitWarmingMs: 100,
+      }),
+    ).rejects.toThrow("Authorization cache is warming; retry shortly");
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(2);
+  });
+
+  test("warming converted to authorized enforces the org rate limit exactly once", async () => {
+    scripted = [
+      { kind: "warming", hydration: Promise.resolve() },
+      {
+        kind: "authorized",
+        ctx: { userId: USER, orgId: ORG, apiKeyId: null },
+      },
+    ];
+
+    const caller = await requireGenerativeRouteCaller(context(), {
+      compatibility: "raw",
+      rateLimitEndpoint: "strict",
+      awaitWarmingMs: 1500,
+    });
+
+    expect(caller.user.organization_id).toBe(ORG);
+    expect(enforceOrgRateLimit).toHaveBeenCalledTimes(1);
+    expect(enforceOrgRateLimit.mock.calls[0][0]).toBe(ORG);
+    expect(enforceOrgRateLimit.mock.calls[0][1]).toBe("strict");
+  });
+
+  test("hydration settled but the reread still warming keeps the retryable 503", async () => {
+    scripted = [
+      { kind: "warming", hydration: Promise.resolve() },
+      { kind: "warming", hydration: new Promise<void>(() => {}) },
+    ];
+
+    await expect(
+      requireGenerativeRouteCaller(context(), {
+        compatibility: "raw",
+        rateLimitEndpoint: "strict",
+        awaitWarmingMs: 1500,
+      }),
+    ).rejects.toThrow("Authorization cache is warming; retry shortly");
+    expect(resolveInferenceAuthContext).toHaveBeenCalledTimes(2);
+    expect(enforceOrgRateLimit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/src/lib/generative-route-auth.ts
+++ b/packages/cloud/api/src/lib/generative-route-auth.ts
@@ -150,12 +150,22 @@ export async function admitFlatGenerativeOperation(params: {
  * Cache misses fail closed with a retryable response while authoritative
  * hydration runs under the Worker lifetime. Wallet proof remains on the
  * compatibility path because replay-protected signatures cannot be cached.
+ *
+ * `awaitWarmingMs` opts a latency-tolerant caller (voice STT/TTS) into one
+ * bounded inline wait for the coalesced hydration: on a warming resolve the
+ * caller races the hydration against the budget; if the hydration settles in
+ * time the resolver runs exactly once more against the cache entry it just
+ * wrote, so the first utterance after idle no longer degrades to a
+ * client-retried 503. The immediate retryable 503 semantics are preserved
+ * verbatim when the budget expires, the hydration is absent (cache outage),
+ * or the option is unset — every other generative route is unchanged.
  */
 export async function requireGenerativeRouteCaller(
   c: AppContext,
   options: {
     compatibility?: "hono" | "raw";
     rateLimitEndpoint?: EndpointType;
+    awaitWarmingMs?: number;
   } = {},
 ): Promise<GenerativeRouteCaller> {
   const executionCtx = getGenerativeExecutionContext(c);
@@ -183,13 +193,21 @@ export async function requireGenerativeRouteCaller(
   const { resolveInferenceAuthContext } = await import(
     "@/lib/services/inference-auth-context"
   );
-  const resolution = await resolveInferenceAuthContext(c.req.raw, {
-    traceId: c.get("traceId") ?? c.get("requestId"),
-    cacheOnly: Boolean(executionCtx),
-    executionCtx,
-  });
 
-  if (resolution.kind === "authorized") {
+  // Single resolver integration point (a source tripwire pins this file to
+  // exactly one resolver invocation site); the bounded warming retry re-runs
+  // through the same helper.
+  const resolveCallerAuth = () =>
+    resolveInferenceAuthContext(c.req.raw, {
+      traceId: c.get("traceId") ?? c.get("requestId"),
+      cacheOnly: Boolean(executionCtx),
+      executionCtx,
+    });
+
+  function toCallerIfAuthorized(
+    resolution: Awaited<ReturnType<typeof resolveCallerAuth>>,
+  ): Extract<typeof resolution, { kind: "authorized" }> | null {
+    if (resolution.kind !== "authorized") return null;
     const user = {
       id: resolution.ctx.userId,
       organization_id: resolution.ctx.orgId,
@@ -199,47 +217,90 @@ export async function requireGenerativeRouteCaller(
     if (resolution.ctx.apiKeyId) {
       c.set("apiKeyId", resolution.ctx.apiKeyId);
     }
-    if (options.rateLimitEndpoint) {
-      const [{ enforceOrgRateLimit }, { inferenceRateLimitConfig }] =
-        await Promise.all([
-          import("@/lib/middleware/rate-limit"),
-          import("@/lib/services/inference-admission-snapshot"),
-        ]);
-      const limited = await enforceOrgRateLimit(
-        resolution.ctx.orgId,
-        options.rateLimitEndpoint,
-        {
-          // The combined decision carries the rate policy only when the hot
-          // cache is enabled. Development and integration Workers still have
-          // an execution context, but their authoritative origin decision has
-          // no snapshot and must retain the compatibility limiter path.
-          cacheOnly: Boolean(resolution.ctx.admission),
-          executionCtx,
-          config: inferenceRateLimitConfig(
-            resolution.ctx.admission,
-            options.rateLimitEndpoint,
-          ),
-        },
+    return resolution;
+  }
+
+  async function enforceOrgRateLimitFor(
+    resolution: Extract<
+      Awaited<ReturnType<typeof resolveCallerAuth>>,
+      { kind: "authorized" }
+    >,
+  ): Promise<void> {
+    if (!options.rateLimitEndpoint) return;
+    const [{ enforceOrgRateLimit }, { inferenceRateLimitConfig }] =
+      await Promise.all([
+        import("@/lib/middleware/rate-limit"),
+        import("@/lib/services/inference-admission-snapshot"),
+      ]);
+    const limited = await enforceOrgRateLimit(
+      resolution.ctx.orgId,
+      options.rateLimitEndpoint,
+      {
+        // The combined decision carries the rate policy only when the hot
+        // cache is enabled. Development and integration Workers still have
+        // an execution context, but their authoritative origin decision has
+        // no snapshot and must retain the compatibility limiter path.
+        cacheOnly: Boolean(resolution.ctx.admission),
+        executionCtx,
+        config: inferenceRateLimitConfig(
+          resolution.ctx.admission,
+          options.rateLimitEndpoint,
+        ),
+      },
+    );
+    if (limited) {
+      throw new ApiError(
+        limited.status,
+        limited.status === 429 ? "rate_limit_exceeded" : "service_unavailable",
+        limited.status === 429
+          ? "Rate limit exceeded"
+          : "Rate limiter is unavailable",
       );
-      if (limited) {
-        throw new ApiError(
-          limited.status,
-          limited.status === 429
-            ? "rate_limit_exceeded"
-            : "service_unavailable",
-          limited.status === 429
-            ? "Rate limit exceeded"
-            : "Rate limiter is unavailable",
-        );
-      }
     }
+  }
+
+  let resolution = await resolveCallerAuth();
+
+  if (resolution.kind === "warming" && options.awaitWarmingMs !== undefined) {
+    if (resolution.hydration) {
+      // The budget timer must never outlive the race: clear it as soon as
+      // either side settles so a winning hydration does not leave a dangling
+      // timer holding the isolate.
+      let budgetTimer: ReturnType<typeof setTimeout> | undefined;
+      const budget = new Promise<void>((resolve) => {
+        budgetTimer = setTimeout(resolve, options.awaitWarmingMs);
+      });
+      try {
+        await Promise.race([
+          // A rejected hydration is not an auth verdict and must not surface
+          // as an opaque 500: the resolver's single-flight already observed
+          // and logged it (error-policy:J5 — the same rejection is observed
+          // by the resolver's own waitUntil/logging copy). It only means
+          // "stop waiting"; the re-resolve below decides the outcome, which
+          // degrades to the designed retryable 503 when nothing was cached.
+          resolution.hydration.catch(() => undefined),
+          budget,
+        ]);
+      } finally {
+        if (budgetTimer !== undefined) clearTimeout(budgetTimer);
+      }
+      resolution = await resolveCallerAuth();
+    }
+  }
+
+  const authorized = toCallerIfAuthorized(resolution);
+  if (authorized) {
+    await enforceOrgRateLimitFor(authorized);
     return {
-      user,
-      apiKeyId: resolution.ctx.apiKeyId,
+      user: {
+        id: authorized.ctx.userId,
+        organization_id: authorized.ctx.orgId,
+      },
+      apiKeyId: authorized.ctx.apiKeyId,
       authSource: "combined_cache",
-      admissionSnapshot: resolution.ctx.admission,
+      admissionSnapshot: authorized.ctx.admission,
       appScopeId:
-        "appScopeId" in resolution.ctx ? resolution.ctx.appScopeId : null,
+        "appScopeId" in authorized.ctx ? authorized.ctx.appScopeId : null,
     };
   }
 

--- a/packages/cloud/api/v1/voice/stt/route.ts
+++ b/packages/cloud/api/v1/voice/stt/route.ts
@@ -469,6 +469,10 @@ async function __hono_POST(c: AppContext) {
       await requireGenerativeRouteCaller(c, {
         compatibility: "raw",
         rateLimitEndpoint: "strict",
+        // Voice is user-audible: the first utterance after idle waits once,
+        // bounded, for the coalesced per-user auth hydration instead of
+        // failing fast into a client-retried 503 (#20557).
+        awaitWarmingMs: 1500,
       });
     const affiliateCode = request.headers.get("X-Affiliate-Code");
     const billingRequestId = `voice-stt:${crypto.randomUUID()}`;

--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -181,6 +181,10 @@ async function __hono_POST(c: AppContext) {
       await requireGenerativeRouteCaller(c, {
         compatibility: "raw",
         rateLimitEndpoint: "strict",
+        // Voice is user-audible: the first reply after idle waits once,
+        // bounded, for the coalesced per-user auth hydration instead of
+        // failing fast into a client-retried 503 (#20557).
+        awaitWarmingMs: 1500,
       });
     timings.authMs = Date.now() - requestStart;
     const admissionStart = Date.now();

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
@@ -253,7 +253,8 @@ describe("resolveInferenceAuthContext", () => {
       cacheOnly: true,
       executionCtx: { waitUntil: (promise) => waited.push(promise) },
     });
-    expect(result).toEqual({ kind: "warming" });
+    expect(result).toMatchObject({ kind: "warming" });
+    expect(typeof result.hydration === "object").toBe(true);
     expect(waited.length).toBeGreaterThan(0);
     await waited[0];
     await Promise.all(waited);
@@ -293,8 +294,8 @@ describe("resolveInferenceAuthContext", () => {
       }),
     ]);
 
-    expect(first).toEqual({ kind: "warming" });
-    expect(second).toEqual({ kind: "warming" });
+    expect(first).toMatchObject({ kind: "warming" });
+    expect(second).toMatchObject({ kind: "warming" });
     expect(waited).toHaveLength(2);
     expect(waited[0]).toBe(waited[1]);
 
@@ -318,7 +319,7 @@ describe("resolveInferenceAuthContext", () => {
       cacheOnly: true,
       executionCtx: { waitUntil: (promise) => waited.push(promise) },
     });
-    expect(cold).toEqual({ kind: "warming" });
+    expect(cold).toMatchObject({ kind: "warming" });
     await Promise.all(waited);
     expect(chainCalls).toBe(1);
 
@@ -342,7 +343,7 @@ describe("resolveInferenceAuthContext", () => {
       cacheOnly: true,
       executionCtx: { waitUntil: (promise) => waited.push(promise) },
     });
-    expect(cold).toEqual({ kind: "warming" });
+    expect(cold).toMatchObject({ kind: "warming" });
     await Promise.all(waited);
     expect(moderationCalls).toBe(1);
 
@@ -530,7 +531,13 @@ describe("resolveInferenceAuthContext", () => {
         executionCtx: { waitUntil: (promise) => waited.push(promise) },
       });
 
-      expect(result).toEqual({ kind: "warming" });
+      expect(result).toMatchObject({ kind: "warming" });
+      // Cache outage: no hydration was started, so the bounded-awaits
+      // contract must see NO promise (callers fail fast without burning
+      // the budget).
+      if (result.kind === "warming") {
+        expect(result.hydration).toBeUndefined();
+      }
       expect(chainCalls).toBe(0);
       expect(waited).toHaveLength(0);
     } finally {
@@ -751,5 +758,34 @@ describe("hydration escape (#18246 — warming must not loop forever)", () => {
     });
     expect(escaped.kind).toBe("authorized");
     release?.();
+  });
+
+  test("cache-only warming surfaces the coalesced hydration for bounded awaiting (#20557)", async () => {
+    const gate = Promise.withResolvers<void>();
+    let chainCalls = 0;
+    authImpl = async () => {
+      chainCalls++;
+      await gate.promise;
+      return {
+        user: { id: "user-1", organization_id: "org-1" },
+        apiKey: { id: "key-1" },
+      };
+    };
+    const waited: Promise<unknown>[] = [];
+
+    const result = await resolveInferenceAuthContext(reqWithApiKey(), {
+      cacheOnly: true,
+      executionCtx: { waitUntil: (promise) => waited.push(promise) },
+    });
+
+    expect(result.kind).toBe("warming");
+    if (result.kind !== "warming") return;
+    expect(result.hydration).toBeInstanceOf(Promise);
+    expect(waited).toHaveLength(1);
+
+    gate.resolve();
+    await result.hydration;
+    expect(chainCalls).toBe(1);
+    await Promise.all(waited);
   });
 });

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.ts
@@ -241,7 +241,11 @@ export type InferenceAuthResolution =
     }
   | { kind: "suspended"; userId?: string }
   | { kind: "rejected"; status: 401 | 403 }
-  | { kind: "warming" }
+  // `hydration` carries the coalesced background hydration so a
+  // latency-tolerant caller (voice) can await it under a bounded budget
+  // instead of round-tripping a retryable 503 through the client; it is set
+  // only when this resolve actually started (or joined) one.
+  | { kind: "warming"; hydration?: Promise<void> }
   | { kind: "slow_path"; reason: "non_api_key" };
 
 /**
@@ -480,7 +484,16 @@ export async function resolveInferenceAuthContext(
       if (session.kind === "warming") {
         trace.cacheRead = cache.isAvailable() ? "miss" : "unavailable";
         trace.result = "warming";
-        return session;
+        // Normalize the session decision promise to the combined void shape;
+        // the swallowed rejection is still observed by the session module's
+        // own waitUntil copy, and an awaiting caller re-resolves instead.
+        return {
+          kind: "warming",
+          hydration: session.hydration?.then(
+            () => undefined,
+            () => undefined,
+          ),
+        };
       }
       if (session.kind === "suspended") {
         trace.cacheRead = "hit";
@@ -552,6 +565,20 @@ export async function resolveInferenceAuthContext(
       if (cacheAvailable && options.executionCtx) {
         const hydration = getOrCreateApiKeyHydration(req, keyHash, options.traceId);
         options.executionCtx.waitUntil(hydration);
+        // Surface the coalesced hydration so a latency-tolerant caller (voice)
+        // can await it under a bounded budget and re-resolve from the cache
+        // the hydration just wrote, instead of a client-side 503 retry. The
+        // single-flight attempt is written to swallow its own failures, but
+        // normalize here too so the caller-facing contract — a hydration
+        // promise settles, never rejects — does not depend on the internals
+        // of that distant catch chain.
+        return {
+          kind: "warming",
+          hydration: hydration.then(
+            () => undefined,
+            () => undefined,
+          ),
+        };
       }
       return { kind: "warming" };
     }

--- a/packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts
@@ -118,7 +118,7 @@ describe("resolveInferenceSessionAuthContext", () => {
       executionCtx: { waitUntil: (promise) => waited.push(promise) },
     });
 
-    expect(result).toEqual({ kind: "warming" });
+    expect(result).toMatchObject({ kind: "warming" });
     expect(waited).toHaveLength(1);
     expect(userReads).toBe(1);
     expect(moderationReads).toBe(0);
@@ -185,8 +185,8 @@ describe("resolveInferenceSessionAuthContext", () => {
       }),
     ]);
 
-    expect(first).toEqual({ kind: "warming" });
-    expect(second).toEqual({ kind: "warming" });
+    expect(first).toMatchObject({ kind: "warming" });
+    expect(second).toMatchObject({ kind: "warming" });
     expect(userReads).toBe(1);
     expect(firstWaited).toHaveLength(1);
     expect(secondWaited).toHaveLength(1);
@@ -240,5 +240,54 @@ describe("resolveInferenceSessionAuthContext", () => {
     ).resolves.toEqual({ kind: "rejected", status: 401 });
     expect(userReads).toBe(0);
     expect(moderationReads).toBe(0);
+  });
+
+  test("warming resolve surfaces the coalesced hydration for bounded awaiting (#20557)", async () => {
+    const releaseUser = Promise.withResolvers<void>();
+    getUser = async () => {
+      await releaseUser.promise;
+      return {
+        id: "user-1",
+        is_active: true,
+        organization_id: "org-1",
+        organization: { is_active: true },
+      };
+    };
+    const waited: Promise<unknown>[] = [];
+
+    const result = await resolveInferenceSessionAuthContext(request(), {
+      cacheOnly: true,
+      useAuthCache: true,
+      executionCtx: { waitUntil: (promise) => waited.push(promise) },
+    });
+
+    expect(result.kind).toBe("warming");
+    if (result.kind !== "warming") return;
+    expect(result.hydration).toBeInstanceOf(Promise);
+
+    releaseUser.resolve();
+    const decision = await result.hydration;
+    expect("userId" in decision && decision.userId).toBe("user-1");
+    await Promise.all(waited);
+    expect(moderationReads).toBe(1);
+  });
+
+  test("cache outage warming carries no hydration promise (#20557)", async () => {
+    const { cache } = await import("../cache/client");
+    const { spyOn } = await import("bun:test");
+    const spy = spyOn(cache, "isAvailable").mockReturnValue(false);
+    try {
+      const result = await resolveInferenceSessionAuthContext(request(), {
+        cacheOnly: true,
+        useAuthCache: true,
+        executionCtx: { waitUntil: () => undefined },
+      });
+      expect(result.kind).toBe("warming");
+      if (result.kind === "warming") {
+        expect(result.hydration).toBeUndefined();
+      }
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/packages/cloud/shared/src/lib/services/inference-session-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-session-auth-context.ts
@@ -50,7 +50,12 @@ export type InferenceSessionAuthResolution =
     }
   | { kind: "suspended"; userId?: string }
   | { kind: "rejected"; status: 401 | 403 }
-  | { kind: "warming" };
+  // `hydration` exposes the already-coalesced single-flight decision so
+  // latency-tolerant callers (voice) can await it under a bounded budget
+  // instead of round-tripping a retryable 503 through the client. It is
+  // present only when this resolve actually started (or joined) a
+  // hydration; a cache outage leaves it unset.
+  | { kind: "warming"; hydration?: Promise<InferenceSessionAuthDecision> };
 
 function looksLikeJwt(token: string): boolean {
   const parts = token.split(".");
@@ -298,16 +303,24 @@ export async function resolveInferenceSessionAuthContext(
           walletChain: claims.walletChain,
         },
         true,
-      )
-        .then(() => undefined)
-        .catch((error) => {
+      );
+      options.executionCtx.waitUntil(
+        hydration.then(
+          () => undefined,
           // error-policy:J7 authoritative hydration is observed by waitUntil;
           // the current request already returned an explicit warming state.
-          logger.warn("[InferenceSessionAuth] Background hydration failed", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        });
-      options.executionCtx.waitUntil(hydration);
+          (error) => {
+            logger.warn("[InferenceSessionAuth] Background hydration failed", {
+              error: error instanceof Error ? error.message : String(error),
+            });
+          },
+        ),
+      );
+      // The coalesced decision itself rides on the resolution so a
+      // latency-tolerant caller (voice) can await it under a bounded budget
+      // and re-resolve from the freshly written cache entry instead of
+      // round-tripping a retryable 503 through the client.
+      return { kind: "warming", hydration };
     }
     return { kind: "warming" };
   }


### PR DESCRIPTION
## Summary

Fixes #20557.

Voice STT/TTS authorize through the cache-only inference auth gate whose per-user entry expires after 60s, so the first utterance of nearly every voice interaction surfaced a retryable `503 "Authorization cache is warming"` — the first spoken reply degraded to the browser `speechSynthesis` fallback and the first STT utterance was delayed or lost. Agent-level keepwarm (#20476) cannot help: the entry is per-user with a 60s TTL that no agent-scoped cron can keep warm.

This implements the issue's option A: voice routes opt into one bounded await of the already-coalesced hydration. On a warming resolution with a hydration promise present, `requireGenerativeRouteCaller` races the coalesced hydration against a `1500ms` budget, then re-resolves through the same cache-only resolver — authorized on success, the existing retryable 503 on budget expiry, cache outage, or when the option is unset. Chat/completions and every other generative route keep the exact fast-fail semantics (option defaults to unset; only the two voice call sites pass it). No TTL change: revocation latency is unchanged.

- `generative-route-auth.ts`: `awaitWarmingMs` opt-in race + re-resolve; resolver invocation stays pinned to one textual site (source tripwire) via a single `resolveCallerAuth` closure; budget timer cleared in `finally`.
- `inference-auth-context.ts` (API-key path): warming resolution now carries the coalesced single-flight hydration, rejection-normalized so the caller-facing contract ("settles, never rejects") does not depend on the distant catch chain.
- `inference-session-auth-context.ts` (session path): warming resolution carries the coalesced `hydrateAndCache` decision; the module's own `waitUntil` copy still observes and logs failures (error-policy:J7/J5).
- `voice/stt/route.ts`, `voice/tts/route.ts`: `awaitWarmingMs: 1500` at their existing call sites — the only two production opt-ins.
- Rejection safety: a rejected hydration means "stop waiting"; the outcome is decided by the re-resolve, degrading to the designed retryable 503 — never an opaque 500.

## Acceptance criteria coverage (issue #20557)

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Idle >60s voice POST: zero warming 503s under normal cache availability; bounded ≤~1.5s inline latency | Unit-proven (budget converts warming→authorized; budget expiry bounded by elapsed assertion ≥18ms at 20ms budget) |
| 2 | First request of a brand-new session: same | Same mechanism (session-path coalesced hydration surfaced) |
| 3 | Chat/completions fast-fail unchanged unless opted in | Unit-proven (unset-budget control test: single resolve, immediate 503; repo grep: only voice routes pass the option) |
| 4 | Revocation latency unchanged | No TTL change; reviewer-verified no invalidation changes in diff |
| 5 | Client-observable desktop proof (Kokoro, no speechSynthesis fallback) | VERIFIED 2026-08-17 via live Worker A/B (see domain-artifacts row): on the real worker, first post-idle voice TTS after a true 70s idle (>60s per-user auth TTL, real Redis expiry) returns 200 Kokoro WAV in 76ms on the PR head, while develop returns the retryable warming 503 that degrades the desktop client to the browser `speechSynthesis` fallback (`useVoiceChat.ts` server-fail -> browser-speech path). Post-idle STT equivalent proven cold-path. Local workerd (wrangler dev --local) + real providers; deployed-environment smoke remains available to a maintainer with cloud credentials on request |

## Evidence

<!-- evidence-head:ed78cd5dfeff2eabae41e62095d9313a18080e56 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - worker-side auth gate change; no UI surface touched

<!-- evidence-row:after-screenshots -->
- [ ] N/A - worker-side auth gate change; no UI surface touched

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic unit harness; no user-visible UI flow to record

<!-- evidence-row:backend-logs -->
- [x] Backend logs: full local execution transcript at head `ed78cd5dfeff2eabae41e62095d9313a18080e56` (mirror: [20753-20557-backend-transcript.txt](https://github.com/HomunculusLabs/eliza/releases/download/pr-evidence/20753-20557-backend-transcript.txt)).

<details>
<summary>Test + gate transcript (bun 1.3.14, worktree /private/tmp/issue-20557)</summary>

```
$ bun test packages/cloud/api/__tests__/generative-route-warming-await.test.ts
bun test v1.3.14 (0d9b296a)
(pass) requireGenerativeRouteCaller awaitWarmingMs (#20557) > voice budget converts warming into authorized without a client retry [0.82ms]
(pass) requireGenerativeRouteCaller awaitWarmingMs (#20557) > budget expiry preserves the immediate retryable 503 verbatim [21.34ms]
(pass) requireGenerativeRouteCaller awaitWarmingMs (#20557) > warming without a hydration promise (cache outage) fails fast, no budget burn [0.16ms]
(pass) requireGenerativeRouteCaller awaitWarmingMs (#20557) > unset budget keeps the legacy fast-fail behavior exactly [0.09ms]
(pass) requireGenerativeRouteCaller awaitWarmingMs (#20557) > a definitive rejection after the awaited hydration surfaces verbatim [0.07ms]
(pass) requireGenerativeRouteCaller awaitWarmingMs (#20557) > a rejecting hydration degrades to the retryable warming 503, not an opaque error [0.08ms]
(pass) requireGenerativeRouteCaller awaitWarmingMs (#20557) > warming converted to authorized enforces the org rate limit exactly once [0.11ms]
(pass) requireGenerativeRouteCaller awaitWarmingMs (#20557) > hydration settled but the reread still warming keeps the retryable 503 [0.08ms]
```

```
$ bun test packages/cloud/shared/src/lib/services/inference-auth-context.test.ts          -> exit 0
$ bun test packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts -> exit 0
$ bun test packages/cloud/api/__tests__/generative-cache-hotpath.test.ts                 -> exit 0
$ bun test packages/cloud/api/__tests__/agent-a2a-billing.test.ts                        -> exit 0
$ bun test packages/cloud/api/__tests__/agent-mcp-billing.test.ts                        -> exit 0
$ bun run --cwd packages/cloud/shared typecheck                                           -> exit 0
$ bun run --cwd packages/cloud/api typecheck                                              -> exit 0
$ biome check <8 changed files>                                                           -> clean
```

</details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code touched (packages/cloud only)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model or prompt-path changes

<!-- evidence-row:domain-artifacts -->
- [x] Live Worker A/B run (criterion 5, added 2026-08-17): [20753-live-worker-ab-evidence.txt](https://github.com/user-attachments/files/31150620/20753-live-worker-ab-evidence.txt) — real workerd (wrangler dev --local), real SIWE sign-in, real Redis 60s inference-auth TTL, real Kokoro + Whisper providers. Protocol identical on both sides: sign in -> warm TTS -> 70s idle (> TTL) -> first post-idle TTS + STT, no client retry. develop control (c1644b9163): warm 503 warming, post-idle TTS 503 warming, post-idle STT 503 warming. PR head (ed78cd5dfe): warm 200 audio/wav 98ms, post-idle TTS 200 audio/wav 76ms (`auth;dur=69`), post-idle STT 200 with full transcript. Synthesized first-post-idle audio (Kokoro, mp4): [20753-head-postidle-tts-kokoro.mp4](https://github.com/user-attachments/assets/17e30f5e-40a1-4850-8bda-deeb6eac0576); warm-pass audio (mp4): [20753-head-warm-tts-kokoro.mp4](https://github.com/user-attachments/assets/e06709ca-d70e-4ac4-834d-6eb32a38b66d).

<!-- evidence-row:ocr-review -->
- [ ] N/A - no screenshots or documents produced to OCR

## Attribution

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: zai/glm-5.2 (implementation) + gpt-5.6-sol (RepoPrompt CE review agent)
<!-- attribution-row:client -->
- Agent tooling: Hermes Agent
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"zai","model":"glm-5.2 (manual) + gpt-5.6-sol (RepoPrompt CE review agent)","client":"Hermes Agent","skill_revision":"elizaOS/eliza@2ed2435bb38aa88c97ae9e3f0dce9fee22009309:packages/skills/skills/contribute-to-eliza"} -->

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop` (`0037742cf6` at authoring time; head `ed78cd5dfe` is a clean rebase child); zero conflicts.
- [x] Package gates pass post-sync: `packages/cloud/shared` + `packages/cloud/api` typecheck exit 0; all six touched/adjacent test suites exit 0; biome clean on the 8 changed files. (Full `bun run verify` not run in the local lane — the equivalent scoped gates are documented above.)

# Risks

Low. The change adds an opt-in bounded wait scoped to two voice route call sites; the default path (option unset) is byte-for-byte the previous fast-fail logic, pinned by a control test. The riskiest interaction — a rejecting hydration promise escaping the race as an opaque 500 — is guarded twice (resolver-side normalization + route-side catch) and covered by a dedicated test.

# Background

## What does this PR do?

Fixes #20557: voice STT/TTS routes no longer surface an immediate retryable `503 "Authorization cache is warming"` on the first utterance after the 60s per-user auth-cache TTL expires. Voice routes opt into one bounded (1500ms) await of the already-coalesced hydration, then re-resolve: authorized on success, the existing retryable 503 on budget expiry / cache outage / option unset.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/cloud/api/src/lib/generative-route-auth.ts` — the `awaitWarmingMs` branch (the only behavioral change), then the two voice call sites, then `generative-route-warming-await.test.ts` for the 8-case behavior matrix.

## Detailed testing steps

None: automated tests are acceptable. (Deterministic harness scripts the combined resolver; the matrix covers success, budget expiry, outage, legacy fast-fail, definitive rejection, rejecting hydration, rate-limit-exactly-once, and reread-still-warming.)

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or trajectory changes; the auth gate sits before any model invocation.

## Backend + frontend logs

Inline transcript attached in the backend-logs row above (8/8 route-gate suite, 5 supporting suites, both typechecks, biome). Frontend N/A - no frontend code touched (packages/cloud only).

## Screenshots (before / after) + video walkthrough

N/A - worker-side auth gate change; no rendered UI surface.

### Before

### After

### Walkthrough video

N/A - worker-side auth gate change exercised via deterministic unit harness; no user-visible UI flow to record.

## Audio / voice walkthrough

N/A - this changes the *authorization gate in front of* the voice routes, not audio processing itself; a real round-trip requires a deployed cloud Worker stack and a live sign-in session, unavailable locally. The unit harness proves the gate no longer 503s on the first utterance after idle; recommend a maintainer live smoke (Kokoro playback, no speechSynthesis fallback) post-merge or on staging.

## Known gaps / failures

- Live Worker proof for acceptance row 5 is now captured on a local real-worker run (see the domain-artifacts row); a deployed-environment (staging/prod) smoke with maintainer cloud credentials remains available on request.
- Release-asset uploads to `elizaOS/eliza` pr-evidence releases returned HTTP 404 for this contributor token, so the transcript is inline (per CONTRIBUTING guidance) plus a fork-release mirror link.



