### PR TITLE
fix(cloud): preserve onboarding handoff provenance

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
@@ -1038,6 +1038,20 @@ describe("runOnboardingChat", () => {
       expect((rememberRequest.body as { text: string }).text).toContain(
         "User's preferred name: Sam",
       );
+      const copiedTranscript = (rememberRequest.body as { text: string }).text;
+      expect(copiedTranscript).toContain("Source platform: blooio");
+      expect(copiedTranscript).toContain("Platform display name: not provided");
+      expect(copiedTranscript).toContain("Verified identity link status: linked");
+      expect(copiedTranscript).toContain(
+        "Original onboarding session: platform:blooio:+14155550123",
+      );
+      expect(copiedTranscript).toContain(
+        `First message timestamp: ${result.session.history[0]?.createdAt}`,
+      );
+      expect(copiedTranscript).toContain(
+        `Last message timestamp: ${result.session.history[0]?.createdAt}`,
+      );
+      expect(copiedTranscript).not.toContain(continuationToken(result));
 
       readManagedElizaAgentConnection.mockClear();
       const continued = await runOnboardingChat({

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts
@@ -1043,14 +1043,13 @@ describe("runOnboardingChat", () => {
       expect(copiedTranscript).toContain("Platform display name: not provided");
       expect(copiedTranscript).toContain("Verified identity link status: linked");
       expect(copiedTranscript).toContain(
-        "Original onboarding session: platform:blooio:+14155550123",
-      );
-      expect(copiedTranscript).toContain(
         `First message timestamp: ${result.session.history[0]?.createdAt}`,
       );
       expect(copiedTranscript).toContain(
         `Last message timestamp: ${result.session.history[0]?.createdAt}`,
       );
+      expect(copiedTranscript).not.toContain(result.session.id);
+      expect(copiedTranscript).not.toContain("+14155550123");
       expect(copiedTranscript).not.toContain(continuationToken(result));
 
       readManagedElizaAgentConnection.mockClear();

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -1224,7 +1224,6 @@ function transcriptText(session: OnboardingSession): string {
     `Source platform: ${session.platform ?? "web"}`,
     `Platform display name: ${session.platformDisplayName ?? "not provided"}`,
     `Verified identity link status: ${identityLinkStatus}`,
-    `Original onboarding session: ${session.id}`,
     `First message timestamp: ${firstMessageAt}`,
     `Last message timestamp: ${lastMessageAt}`,
     "",

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.ts
@@ -1205,6 +1205,15 @@ function generateOnboardingReply(args: {
 }
 
 function transcriptText(session: OnboardingSession): string {
+  const firstMessageAt = session.history[0]?.createdAt ?? session.createdAt;
+  const lastMessageAt = session.history.at(-1)?.createdAt ?? session.updatedAt;
+  const identityLinkStatus = !session.platform
+    ? "none"
+    : session.platformIdentityTrusted !== true
+      ? "pending"
+      : session.userId && session.organizationId
+        ? "linked"
+        : "verified";
   const lines = session.history.map((message) => {
     const speaker = message.role === "user" ? "User" : "Eliza onboarding";
     return `${speaker}: ${message.content}`;
@@ -1212,6 +1221,12 @@ function transcriptText(session: OnboardingSession): string {
   return [
     "Onboarding conversation transcript copied from Eliza Cloud.",
     session.name ? `User's preferred name: ${session.name}` : null,
+    `Source platform: ${session.platform ?? "web"}`,
+    `Platform display name: ${session.platformDisplayName ?? "not provided"}`,
+    `Verified identity link status: ${identityLinkStatus}`,
+    `Original onboarding session: ${session.id}`,
+    `First message timestamp: ${firstMessageAt}`,
+    `Last message timestamp: ${lastMessageAt}`,
     "",
     ...lines,
   ]


### PR DESCRIPTION
## Summary

- preserve source platform, platform display name, verified identity-link status, and transcript time range when onboarding history is copied into managed-agent memory
- keep private deterministic onboarding session IDs out of model-facing memory because platform session IDs can embed raw user identifiers such as phone numbers
- keep continuation tokens out of agent memory

This is a scoped handoff-provenance improvement related to #17344. The umbrella issue is already closed; this PR does not reopen it or claim new live connector work.

## Review repair

The draft originally copied `session.id` into model-facing memory. Platform session IDs use the public/guessable `platform:<platform>:<platformUserId>` form, so that widened exposure of raw identifiers. The repaired implementation omits that ID and adds regression assertions excluding the session ID, raw phone number, and continuation token.

## Exact-head verification

Head: `e3c3225501630704fb8bedea322edb840bb323b6`

- `bun test packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.test.ts`: 83 passed, 0 failed, 397 assertions
- `bun run --cwd packages/cloud/shared typecheck`: passed
- Biome check on both changed files: passed
- `git diff --check`: passed
- `bun run verify`: passed; 356/356 Turbo tasks and all repository audit gates

## Evidence matrix

| Evidence | Result |
| --- | --- |
| Screenshots / mobile / walkthrough | N/A — backend-only deterministic serialization; no rendered or interactive surface changed |
| Frontend logs | N/A — no frontend path changed |
| Backend/domain artifact | Focused test inspects the exact `createMemory` payload, including provenance and sensitive-token exclusions |
| Live-model trajectory | N/A — no model behavior changed; the storage boundary is deterministic |

Relates #17344

<!-- evidence-head:e3c3225501630704fb8bedea322edb840bb323b6 -->

AI provider/model: OpenAI / gpt-5.6-sol  
Client / agent tooling: Codex desktop  
Contribution skill revision: N/A - no repository contribution skill used  
Attribution status: self-reported  
— [codex-july-issues]

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no repository contribution skill used","attribution_status":"self-reported","lane":"codex-july-issues"} -->