### PR TITLE
fix(cloud): fail closed in app-earnings service money paths (#13415 slice)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/app-earnings-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-earnings-fail-closed.test.ts
@@ -201,6 +201,53 @@ describe("AppEarningsService.updatePayoutThreshold validation", () => {
   );
 });
 
+describe("AppEarningsService.requestWithdrawal idempotent replay", () => {
+  test(
+    "a corrupt persisted withdrawal amount makes the replay throw, not fabricate success",
+    async () => {
+      if (!pgliteReady) return;
+      await seedEarnings("50.000000");
+      // Simulate a corrupted persisted withdrawal row carrying the replay key:
+      // Postgres NUMERIC accepts the literal 'NaN'.
+      await dbWrite.execute(
+        `INSERT INTO app_earnings_transactions (app_id, type, amount, metadata)
+         VALUES ('${APP_ID}', 'withdrawal', 'NaN',
+                 '{"idempotencyKey": "replay-corrupt"}'::jsonb);`,
+      );
+
+      await expect(
+        appEarningsService.requestWithdrawal(APP_ID, 10, "replay-corrupt"),
+      ).rejects.toThrow("withdrawal_amount");
+
+      // The replay wrote nothing: still exactly the seeded corrupt row, and the
+      // balance never moved.
+      expect(await transactionCount()).toBe(1);
+      expect(Number(await withdrawableBalance())).toBeCloseTo(50, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a healthy sequential replay returns the original transaction without a second debit",
+    async () => {
+      if (!pgliteReady) return;
+      await seedEarnings("50.000000");
+
+      const first = await appEarningsService.requestWithdrawal(APP_ID, 10, "replay-healthy");
+      const second = await appEarningsService.requestWithdrawal(APP_ID, 10, "replay-healthy");
+
+      expect(first.success).toBe(true);
+      expect(second.success).toBe(true);
+      expect(second.transactionId).toBe(first.transactionId);
+      expect(second.message).toContain("$10.00");
+      // Exactly one withdrawal row; the balance moved exactly once.
+      expect(await transactionCount()).toBe(1);
+      expect(Number(await withdrawableBalance())).toBeCloseTo(40, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
 describe("AppEarningsService.getEarningsSummary corrupt-row handling", () => {
   test(
     "a corrupt NUMERIC balance throws instead of reporting $NaN",
@@ -230,4 +277,11 @@ describe("AppEarningsService.getEarningsSummary corrupt-row handling", () => {
     },
     PGLITE_TIMEOUT,
   );
+});
+
+// Loud guard: PGlite is in-process (no network), so `pgliteReady` must be true.
+// Without this, a broken import or schema setup would skip every DB case above
+// and the suite would pass vacuously.
+test("PGlite harness initialized (DB cases above are not vacuous)", () => {
+  expect(pgliteReady).toBe(true);
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/app-earnings-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-earnings-fail-closed.test.ts
@@ -1,25 +1,6 @@
 /**
- * AppEarningsService fail-closed money-path contract (#13415 slice).
- *
- * Pins three former fail-open paths at the service boundary:
- *
- *  1. `requestWithdrawal` accepted NaN / non-positive amounts: `amount <
- *     threshold` is false for NaN, so the minimum-payout gate was bypassed and
- *     a 'NaN'::numeric transaction row could poison every SUM aggregate over
- *     the app's history. Non-finite and non-positive amounts must now be
- *     refused before any write.
- *  2. `updatePayoutThreshold` guarded only `threshold < 1`, which NaN and
- *     Infinity both pass (comparison false) — and Postgres NUMERIC accepts the
- *     literals 'NaN'/'Infinity', permanently poisoning the row. Non-finite
- *     thresholds must now throw.
- *  3. `getEarningsSummary` coerced NUMERIC columns with bare `Number(...)`,
- *     reporting a corrupt row as a healthy-looking $NaN account. A corrupt
- *     value must now throw.
- *
- * The harness is real: the actual service + repository SQL runs against
- * in-process PGlite. Only `appsRepository.findById` (the unrelated
- * app-existence + monetization check) is stubbed. The `pgliteReady` guard
- * fails loudly if PGlite never initializes.
+ * Integration-backed fail-closed coverage for app-earnings money paths using
+ * the real service and repository against in-process PGlite.
  */
 
 import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
@@ -74,8 +55,6 @@ beforeAll(async () => {
     ({ appEarningsService } = await import("../app-earnings"));
     ({ appsRepository } = await import("../../../db/repositories/apps"));
 
-    // DDL mirrors app-earnings-withdrawal-idempotency.test.ts, including the
-    // migration-0156 idempotency gate the withdrawal path relies on.
     const ddl = [
       `CREATE TABLE IF NOT EXISTS app_earnings (
         id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -207,8 +186,6 @@ describe("AppEarningsService.requestWithdrawal idempotent replay", () => {
     async () => {
       if (!pgliteReady) return;
       await seedEarnings("50.000000");
-      // Simulate a corrupted persisted withdrawal row carrying the replay key:
-      // Postgres NUMERIC accepts the literal 'NaN'.
       await dbWrite.execute(
         `INSERT INTO app_earnings_transactions (app_id, type, amount, metadata)
          VALUES ('${APP_ID}', 'withdrawal', 'NaN',
@@ -219,8 +196,6 @@ describe("AppEarningsService.requestWithdrawal idempotent replay", () => {
         appEarningsService.requestWithdrawal(APP_ID, 10, "replay-corrupt"),
       ).rejects.toThrow("withdrawal_amount");
 
-      // The replay wrote nothing: still exactly the seeded corrupt row, and the
-      // balance never moved.
       expect(await transactionCount()).toBe(1);
       expect(Number(await withdrawableBalance())).toBeCloseTo(50, 6);
     },
@@ -240,7 +215,6 @@ describe("AppEarningsService.requestWithdrawal idempotent replay", () => {
       expect(second.success).toBe(true);
       expect(second.transactionId).toBe(first.transactionId);
       expect(second.message).toContain("$10.00");
-      // Exactly one withdrawal row; the balance moved exactly once.
       expect(await transactionCount()).toBe(1);
       expect(Number(await withdrawableBalance())).toBeCloseTo(40, 6);
     },
@@ -253,8 +227,6 @@ describe("AppEarningsService.getEarningsSummary corrupt-row handling", () => {
     "a corrupt NUMERIC balance throws instead of reporting $NaN",
     async () => {
       if (!pgliteReady) return;
-      // Postgres NUMERIC accepts the literal 'NaN'; this is exactly the
-      // corruption the summary used to render as a healthy-looking account.
       await seedEarnings("NaN");
 
       await expect(appEarningsService.getEarningsSummary(APP_ID)).rejects.toThrow(
@@ -279,9 +251,6 @@ describe("AppEarningsService.getEarningsSummary corrupt-row handling", () => {
   );
 });
 
-// Loud guard: PGlite is in-process (no network), so `pgliteReady` must be true.
-// Without this, a broken import or schema setup would skip every DB case above
-// and the suite would pass vacuously.
 test("PGlite harness initialized (DB cases above are not vacuous)", () => {
   expect(pgliteReady).toBe(true);
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/app-earnings-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-earnings-fail-closed.test.ts
@@ -1,0 +1,233 @@
+/**
+ * AppEarningsService fail-closed money-path contract (#13415 slice).
+ *
+ * Pins three former fail-open paths at the service boundary:
+ *
+ *  1. `requestWithdrawal` accepted NaN / non-positive amounts: `amount <
+ *     threshold` is false for NaN, so the minimum-payout gate was bypassed and
+ *     a 'NaN'::numeric transaction row could poison every SUM aggregate over
+ *     the app's history. Non-finite and non-positive amounts must now be
+ *     refused before any write.
+ *  2. `updatePayoutThreshold` guarded only `threshold < 1`, which NaN and
+ *     Infinity both pass (comparison false) — and Postgres NUMERIC accepts the
+ *     literals 'NaN'/'Infinity', permanently poisoning the row. Non-finite
+ *     thresholds must now throw.
+ *  3. `getEarningsSummary` coerced NUMERIC columns with bare `Number(...)`,
+ *     reporting a corrupt row as a healthy-looking $NaN account. A corrupt
+ *     value must now throw.
+ *
+ * The harness is real: the actual service + repository SQL runs against
+ * in-process PGlite. Only `appsRepository.findById` (the unrelated
+ * app-existence + monetization check) is stubbed. The `pgliteReady` guard
+ * fails loudly if PGlite never initializes.
+ */
+
+import { afterAll, beforeAll, describe, expect, spyOn, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const APP_ID = "00000000-0000-0000-0000-0000000000b1";
+const PGLITE_TIMEOUT = 60000;
+
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let closeDb: typeof import("../../../db/client").closeDatabaseConnectionsForTests | undefined;
+let appEarningsService: typeof import("../app-earnings").appEarningsService;
+let appsRepository: typeof import("../../../db/repositories/apps").appsRepository;
+let findByIdSpy: { mockRestore: () => void } | undefined;
+let pgliteReady = true;
+
+async function seedEarnings(withdrawable: string, threshold = "1.00"): Promise<void> {
+  await dbWrite.execute(`DELETE FROM app_earnings_transactions;`);
+  await dbWrite.execute(`DELETE FROM app_earnings;`);
+  await dbWrite.execute(
+    `INSERT INTO app_earnings (app_id, withdrawable_balance, total_withdrawn, payout_threshold)
+     VALUES ('${APP_ID}', '${withdrawable}', '0', '${threshold}');`,
+  );
+}
+
+async function withdrawableBalance(): Promise<string> {
+  const r = await dbWrite.execute(
+    `SELECT withdrawable_balance FROM app_earnings WHERE app_id = '${APP_ID}';`,
+  );
+  return (r.rows[0] as { withdrawable_balance: string }).withdrawable_balance;
+}
+
+async function payoutThreshold(): Promise<string> {
+  const r = await dbWrite.execute(
+    `SELECT payout_threshold FROM app_earnings WHERE app_id = '${APP_ID}';`,
+  );
+  return (r.rows[0] as { payout_threshold: string }).payout_threshold;
+}
+
+async function transactionCount(): Promise<number> {
+  const r = await dbWrite.execute(
+    `SELECT count(*)::int AS n FROM app_earnings_transactions WHERE app_id = '${APP_ID}';`,
+  );
+  return (r.rows[0] as { n: number }).n;
+}
+
+beforeAll(async () => {
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
+    ({ appEarningsService } = await import("../app-earnings"));
+    ({ appsRepository } = await import("../../../db/repositories/apps"));
+
+    // DDL mirrors app-earnings-withdrawal-idempotency.test.ts, including the
+    // migration-0156 idempotency gate the withdrawal path relies on.
+    const ddl = [
+      `CREATE TABLE IF NOT EXISTS app_earnings (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        app_id uuid NOT NULL,
+        total_lifetime_earnings numeric(12,6) NOT NULL DEFAULT '0.000000',
+        total_inference_earnings numeric(12,6) NOT NULL DEFAULT '0.000000',
+        total_purchase_earnings numeric(12,6) NOT NULL DEFAULT '0.000000',
+        pending_balance numeric(12,6) NOT NULL DEFAULT '0.000000',
+        withdrawable_balance numeric(12,6) NOT NULL DEFAULT '0.000000',
+        total_withdrawn numeric(12,6) NOT NULL DEFAULT '0.000000',
+        last_withdrawal_at timestamp,
+        payout_threshold numeric(10,2) NOT NULL DEFAULT '25.00',
+        created_at timestamp NOT NULL DEFAULT now(),
+        updated_at timestamp NOT NULL DEFAULT now()
+      )`,
+      `CREATE TABLE IF NOT EXISTS app_earnings_transactions (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        app_id uuid NOT NULL,
+        user_id uuid,
+        type text NOT NULL,
+        amount numeric(10,6) NOT NULL,
+        description text,
+        metadata jsonb NOT NULL DEFAULT '{}',
+        created_at timestamp NOT NULL DEFAULT now()
+      )`,
+      `CREATE UNIQUE INDEX IF NOT EXISTS app_earnings_tx_withdrawal_idempotency_uidx
+        ON app_earnings_transactions (app_id, (metadata ->> 'idempotencyKey'))
+        WHERE type = 'withdrawal' AND (metadata ->> 'idempotencyKey') IS NOT NULL`,
+    ];
+    for (const stmt of ddl) await dbWrite.execute(stmt);
+
+    findByIdSpy = spyOn(appsRepository, "findById").mockResolvedValue({
+      id: APP_ID,
+      monetization_enabled: true,
+    } as never);
+  } catch (error) {
+    pgliteReady = false;
+    console.warn("[app-earnings-fail-closed] PGlite unavailable, skipping DB cases:", error);
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  findByIdSpy?.mockRestore();
+  if (closeDb) await closeDb();
+});
+
+describe("AppEarningsService.requestWithdrawal amount validation", () => {
+  for (const [label, amount] of [
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["negative", -5],
+    ["zero", 0],
+  ] as const) {
+    test(
+      `refuses a ${label} amount before any write`,
+      async () => {
+        if (!pgliteReady) return;
+        await seedEarnings("50.000000");
+
+        const result = await appEarningsService.requestWithdrawal(
+          APP_ID,
+          amount,
+          `fail-closed-${label}`,
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.message).toContain("positive, finite");
+        // Nothing was written: no transaction row, balance untouched.
+        expect(await transactionCount()).toBe(0);
+        expect(Number(await withdrawableBalance())).toBeCloseTo(50, 6);
+      },
+      PGLITE_TIMEOUT,
+    );
+  }
+
+  test(
+    "a valid amount still withdraws (guard is not over-broad)",
+    async () => {
+      if (!pgliteReady) return;
+      await seedEarnings("50.000000");
+
+      const result = await appEarningsService.requestWithdrawal(APP_ID, 10, "fail-closed-valid");
+
+      expect(result.success).toBe(true);
+      expect(await transactionCount()).toBe(1);
+      expect(Number(await withdrawableBalance())).toBeCloseTo(40, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+describe("AppEarningsService.updatePayoutThreshold validation", () => {
+  for (const [label, threshold] of [
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["sub-dollar", 0.5],
+  ] as const) {
+    test(
+      `rejects a ${label} threshold without writing`,
+      async () => {
+        if (!pgliteReady) return;
+        await seedEarnings("50.000000", "25.00");
+
+        await expect(appEarningsService.updatePayoutThreshold(APP_ID, threshold)).rejects.toThrow(
+          "finite amount of at least $1.00",
+        );
+        expect(await payoutThreshold()).toBe("25.00");
+      },
+      PGLITE_TIMEOUT,
+    );
+  }
+
+  test(
+    "a valid threshold still updates",
+    async () => {
+      if (!pgliteReady) return;
+      await seedEarnings("50.000000", "25.00");
+
+      await appEarningsService.updatePayoutThreshold(APP_ID, 10);
+      expect(await payoutThreshold()).toBe("10.00");
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+describe("AppEarningsService.getEarningsSummary corrupt-row handling", () => {
+  test(
+    "a corrupt NUMERIC balance throws instead of reporting $NaN",
+    async () => {
+      if (!pgliteReady) return;
+      // Postgres NUMERIC accepts the literal 'NaN'; this is exactly the
+      // corruption the summary used to render as a healthy-looking account.
+      await seedEarnings("NaN");
+
+      await expect(appEarningsService.getEarningsSummary(APP_ID)).rejects.toThrow(
+        "withdrawable_balance",
+      );
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a healthy row still summarizes",
+    async () => {
+      if (!pgliteReady) return;
+      await seedEarnings("12.500000", "5.00");
+
+      const summary = await appEarningsService.getEarningsSummary(APP_ID);
+      expect(summary).not.toBeNull();
+      expect(summary?.withdrawableBalance).toBeCloseTo(12.5, 6);
+      expect(summary?.payoutThreshold).toBeCloseTo(5, 6);
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/lib/services/app-earnings.ts
+++ b/packages/cloud/shared/src/lib/services/app-earnings.ts
@@ -7,6 +7,7 @@ import {
   appEarningsRepository,
   type NewAppEarningsTransaction,
 } from "../../db/repositories/app-earnings";
+import { parseEarningsNumber } from "../../db/repositories/app-earnings-numeric";
 import { appsRepository } from "../../db/repositories/apps";
 import { isUniqueConstraintError } from "../utils/db-errors";
 import { logger } from "../utils/logger";
@@ -45,14 +46,29 @@ export class AppEarningsService {
       return null;
     }
 
+    // Corrupt NUMERIC must throw, not render as NaN: the summary feeds the
+    // creator's withdrawable balance and payout threshold, and a NaN here
+    // would present a broken row as a healthy-looking $NaN account.
     return {
-      totalLifetimeEarnings: Number(earnings.total_lifetime_earnings),
-      totalInferenceEarnings: Number(earnings.total_inference_earnings),
-      totalPurchaseEarnings: Number(earnings.total_purchase_earnings),
-      pendingBalance: Number(earnings.pending_balance),
-      withdrawableBalance: Number(earnings.withdrawable_balance),
-      totalWithdrawn: Number(earnings.total_withdrawn),
-      payoutThreshold: Number(earnings.payout_threshold),
+      totalLifetimeEarnings: parseEarningsNumber(
+        earnings.total_lifetime_earnings,
+        "total_lifetime_earnings",
+      ),
+      totalInferenceEarnings: parseEarningsNumber(
+        earnings.total_inference_earnings,
+        "total_inference_earnings",
+      ),
+      totalPurchaseEarnings: parseEarningsNumber(
+        earnings.total_purchase_earnings,
+        "total_purchase_earnings",
+      ),
+      pendingBalance: parseEarningsNumber(earnings.pending_balance, "pending_balance"),
+      withdrawableBalance: parseEarningsNumber(
+        earnings.withdrawable_balance,
+        "withdrawable_balance",
+      ),
+      totalWithdrawn: parseEarningsNumber(earnings.total_withdrawn, "total_withdrawn"),
+      payoutThreshold: parseEarningsNumber(earnings.payout_threshold, "payout_threshold"),
     };
   }
 
@@ -167,8 +183,11 @@ export class AppEarningsService {
   }
 
   async updatePayoutThreshold(appId: string, threshold: number): Promise<void> {
-    if (threshold < 1) {
-      throw new Error("Payout threshold must be at least $1.00");
+    // `threshold < 1` alone lets NaN and Infinity through (both comparisons are
+    // false), and Postgres NUMERIC accepts the literal strings 'NaN' and
+    // 'Infinity' — a poisoned row would then fail every later withdrawal parse.
+    if (!Number.isFinite(threshold) || threshold < 1) {
+      throw new Error("Payout threshold must be a finite amount of at least $1.00");
     }
 
     await appEarningsRepository.updatePayoutThreshold(appId, threshold);
@@ -193,6 +212,18 @@ export class AppEarningsService {
     amount: number,
     idempotencyKey?: string,
   ): Promise<{ success: boolean; message: string; transactionId?: string }> {
+    // Refuse non-finite and non-positive amounts before any write. The
+    // repository's minimum-payout gate (`amount < threshold`) is bypassed by
+    // NaN (comparison is false), and a NaN amount would otherwise be recorded
+    // as a 'NaN'::numeric transaction row that poisons every SUM aggregate
+    // over this app's earnings history.
+    if (!Number.isFinite(amount) || amount <= 0) {
+      return {
+        success: false,
+        message: "Withdrawal amount must be a positive, finite number",
+      };
+    }
+
     // Idempotent fast path: return the prior transaction if this key already ran.
     if (idempotencyKey) {
       const existing = await appEarningsRepository.findTransactionByIdempotencyKeyOnPrimary(
@@ -319,7 +350,7 @@ export class AppEarningsService {
     });
     return {
       success: true,
-      message: `$${Math.abs(Number(existing.amount)).toFixed(2)} marked as withdrawn. Check your Earnings page to redeem as elizaOS tokens.`,
+      message: `$${Math.abs(parseEarningsNumber(existing.amount, "withdrawal_amount")).toFixed(2)} marked as withdrawn. Check your Earnings page to redeem as elizaOS tokens.`,
       transactionId: existing.id,
     };
   }

--- a/packages/cloud/shared/src/lib/services/app-earnings.ts
+++ b/packages/cloud/shared/src/lib/services/app-earnings.ts
@@ -2,6 +2,7 @@
  * Service for managing app earnings and revenue tracking.
  */
 
+import { ElizaError } from "@elizaos/core";
 import {
   type AppEarningsTransaction,
   appEarningsRepository,
@@ -46,9 +47,6 @@ export class AppEarningsService {
       return null;
     }
 
-    // Corrupt NUMERIC must throw, not render as NaN: the summary feeds the
-    // creator's withdrawable balance and payout threshold, and a NaN here
-    // would present a broken row as a healthy-looking $NaN account.
     return {
       totalLifetimeEarnings: parseEarningsNumber(
         earnings.total_lifetime_earnings,
@@ -183,11 +181,13 @@ export class AppEarningsService {
   }
 
   async updatePayoutThreshold(appId: string, threshold: number): Promise<void> {
-    // `threshold < 1` alone lets NaN and Infinity through (both comparisons are
-    // false), and Postgres NUMERIC accepts the literal strings 'NaN' and
-    // 'Infinity' — a poisoned row would then fail every later withdrawal parse.
+    // NaN and Infinity bypass a comparison-only guard and PostgreSQL NUMERIC
+    // accepts both, so validate finiteness before writing the threshold.
     if (!Number.isFinite(threshold) || threshold < 1) {
-      throw new Error("Payout threshold must be a finite amount of at least $1.00");
+      throw new ElizaError("Payout threshold must be a finite amount of at least $1.00", {
+        code: "APP_EARNINGS_PAYOUT_THRESHOLD_INVALID",
+        context: { appId, threshold },
+      });
     }
 
     await appEarningsRepository.updatePayoutThreshold(appId, threshold);
@@ -212,11 +212,8 @@ export class AppEarningsService {
     amount: number,
     idempotencyKey?: string,
   ): Promise<{ success: boolean; message: string; transactionId?: string }> {
-    // Refuse non-finite and non-positive amounts before any write. The
-    // repository's minimum-payout gate (`amount < threshold`) is bypassed by
-    // NaN (comparison is false), and a NaN amount would otherwise be recorded
-    // as a 'NaN'::numeric transaction row that poisons every SUM aggregate
-    // over this app's earnings history.
+    // NaN bypasses the repository's comparison guards and would poison the
+    // NUMERIC transaction history, so reject invalid amounts before any write.
     if (!Number.isFinite(amount) || amount <= 0) {
       return {
         success: false,


### PR DESCRIPTION
## Summary

Hardens the remaining `AppEarningsService` money boundaries associated with #13415:

- Rejects non-finite and non-positive withdrawal amounts before any write.
- Rejects non-finite or sub-dollar payout thresholds with a classified `ElizaError`.
- Parses persisted earnings and idempotent-replay amounts through the existing fail-closed NUMERIC boundary instead of returning `NaN` as healthy state.

## Verification

Exact head: `0b4c898117def6acd05da128104332676be73d0a`.

- New real-PGlite fail-closed suite: 14/14 passed.
- Existing withdrawal-idempotency and app-credits regression suites: 26/26 passed.
- Cloud shared typecheck and Biome checks passed.
- `bun run verify`: 356/356 Turbo tasks passed; repository audits passed; anti-larp scanned 8,410 test files with no focused or orphaned skipped tests.

## Evidence

<!-- evidence-head:0b4c898117def6acd05da128104332676be73d0a -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend financial validation; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend financial validation; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic service and database behavior.
<!-- evidence-row:backend-logs -->
- [x] [Focused fail-closed suite](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20757-pr20757-focused-repaired.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model path changed.
<!-- evidence-row:domain-artifacts -->
- [x] [PGlite regression log inspecting balances, rows, and idempotency](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20757-pr20757-regression.log)
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered surface changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: Claude; OpenAI Codex
<!-- attribution-row:client -->
- Agent tooling: Claude Code; Codex
<!-- attribution-row:skill-revision -->
- Skill path: N/A
<!-- attribution-row:status -->
- Provenance status: self-reported
