### PR TITLE
fix(calendar): drop planner-invented non-email attendees instead of failing the whole create

### DIFF
--- a/plugins/plugin-calendar/src/actions/calendar-attendees.test.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-attendees.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Planner-arg attendee sanitization: invented non-email attendees ("lunch with
+ * dana" → {email: "dana"}) must be dropped, not forwarded to the calendar
+ * service where the strict boundary validator 400s the whole create.
+ * Deterministic unit harness over the exported normalizer.
+ */
+
+import { describe, expect, it } from "vitest";
+import { normalizeCalendarAttendees } from "./calendar-handler.ts";
+
+describe("normalizeCalendarAttendees (planner-arg sanitization)", () => {
+  it("drops a planner-invented bare-name attendee instead of failing the create (live regression)", () => {
+    const out = normalizeCalendarAttendees({
+      attendees: [{ email: "dana", displayName: "Dana", optional: false }],
+    });
+    expect(out).toBeUndefined();
+  });
+
+  it("keeps valid-email attendees and drops invalid ones from a mixed list", () => {
+    const out = normalizeCalendarAttendees({
+      attendees: [
+        { email: "dana", displayName: "Dana" },
+        { email: "sam@example.com", displayName: "Sam" },
+        "marco",
+        "polo@example.com",
+      ],
+    });
+    expect(out).toEqual([
+      { email: "sam@example.com", displayName: "Sam" },
+      { email: "polo@example.com" },
+    ]);
+  });
+
+  it("returns undefined when the details carry no attendees", () => {
+    expect(normalizeCalendarAttendees({})).toBeUndefined();
+    expect(normalizeCalendarAttendees(undefined)).toBeUndefined();
+  });
+});

--- a/plugins/plugin-calendar/src/actions/calendar-handler.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.ts
@@ -3613,7 +3613,19 @@ export function formatCalendarSearchResults(
   return lines.join("\n");
 }
 
-function normalizeCalendarAttendees(
+/**
+ * The planner routinely invents attendees from bare names in the request
+ * ("lunch with dana" → {email: "dana"}). The calendar service boundary
+ * strict-400s any non-email attendee, which failed the WHOLE create for an
+ * event that never needed the invite (live: "add lunch with dana thursday
+ * noon" → CALENDAR_SERVICE_400 attendees[0].email). Planner output is
+ * untrusted, so this normalizer DROPS non-email attendees instead of
+ * forwarding them to die at the service; the service validator keeps its
+ * strict contract for direct API callers.
+ */
+const CALENDAR_ATTENDEE_EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+
+export function normalizeCalendarAttendees(
   details: Record<string, unknown> | undefined,
 ): CreateLifeOpsCalendarEventAttendee[] | undefined {
   const attendees = detailArray(details, "attendees");
@@ -3622,10 +3634,9 @@ function normalizeCalendarAttendees(
   }
   const mapped: Array<CreateLifeOpsCalendarEventAttendee | null> =
     attendees.map((attendee) => {
-      if (typeof attendee === "string" && attendee.trim().length > 0) {
-        return {
-          email: attendee.trim(),
-        };
+      if (typeof attendee === "string") {
+        const email = attendee.trim();
+        return CALENDAR_ATTENDEE_EMAIL_RE.test(email) ? { email } : null;
       }
       if (
         !attendee ||
@@ -3636,7 +3647,8 @@ function normalizeCalendarAttendees(
       }
       const record = attendee as Record<string, unknown>;
       const email =
-        typeof record.email === "string" && record.email.trim().length > 0
+        typeof record.email === "string" &&
+        CALENDAR_ATTENDEE_EMAIL_RE.test(record.email.trim())
           ? record.email.trim()
           : null;
       if (!email) {


### PR DESCRIPTION
## What

"add lunch with dana to my calendar thursday at noon" failed the ENTIRE create with `CALENDAR_SERVICE_400: attendees[0].email must be a valid email address` (live trajectory). The planner routinely invents attendees from bare names in the request — it emitted `attendees: [{"email": "dana", "displayName": "Dana"}]` — and the action-side `normalizeCalendarAttendees` (calendar-handler.ts) forwarded any non-empty string as an email straight into the calendar service, whose boundary validator strict-400s.

Fix at the untrusted-planner-output boundary: the action-side normalizer now validates email shape and DROPS non-conforming attendees (bare names, handles) instead of forwarding them — the user's event still gets created; a bogus invented invite never needed to sink it. The service-side validator (`internal/calendar-normalize.ts`) keeps its strict 400 contract for direct API callers — the two normalizers serve different boundaries on purpose (sanitize untrusted model output vs enforce the API contract).

## Evidence

- Before (live): create → `CALENDAR_SERVICE_400 attendees[0].email` → "calendar errored."
- After (live): same ask → "done. lunch with dana is on for thursday at noon." → read-back confirms "aug 20 at noon".
- New deterministic suite `calendar-attendees.test.ts` (3): live-regression pin (bare-name attendee dropped → undefined), mixed list keeps only valid emails, absent attendees unchanged. Plugin typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:59a302456b369ebc15328a315bee5ad68f3632b7 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - chat-behavior change; live before/after transcripts in PR body

<!-- evidence-row:after-screenshots -->
- [ ] N/A - chat-behavior change; live before/after transcripts in PR body

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - live transcripts serve as walkthrough

<!-- evidence-row:backend-logs -->
- [ ] N/A - the live run did not retain structured backend logs; the exact planner input, service error, repaired response, and calendar read-back are preserved below and in the linked Fleet HQ receipt.

<details><summary>Live boundary transcript reported by the author</summary>

```text
Before request: add lunch with dana to my calendar thursday at noon
Before service result: CALENDAR_SERVICE_400 attendees[0].email must be a valid email address
After response: done. lunch with dana is on for thursday at noon.
After calendar read-back: lunch with dana — Aug 20 at noon
Receipt: https://github.com/elizaOS/eliza/discussions/18309#discussioncomment-18045601
```

</details>

<!-- evidence-row:llm-trajectory -->
- [x] Live-model trajectory excerpt and exact Fleet HQ receipt:

<details><summary>Before/after live-model action trajectory</summary>

```text
User: add lunch with dana to my calendar thursday at noon
Planner before repair: attendees=[{"email":"dana","displayName":"Dana"}]
Calendar boundary before repair: CALENDAR_SERVICE_400 attendees[0].email must be a valid email address
Assistant after repair: done. lunch with dana is on for thursday at noon.
Calendar read-back after repair: lunch with dana — Aug 20 at noon
Receipt: https://github.com/elizaOS/eliza/discussions/18309#discussioncomment-18045601
```

</details>

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface

<!-- evidence-row:domain-artifacts -->
- [x] Live calendar read-back artifact:

<details><summary>Created-event read-back</summary>

```text
Create request: add lunch with dana to my calendar thursday at noon
Assistant confirmation: done. lunch with dana is on for thursday at noon.
Calendar read-back: lunch with dana — Aug 20 at noon
Coordination receipt: https://github.com/elizaOS/eliza/discussions/18309#discussioncomment-18045601
```

</details>

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered surfaces

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/model-not-reported` (the PR author identified Claude Code but did not report the exact model id)
<!-- attribution-row:client -->
- Agent tooling: `Claude Code`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill revision was reported`
<!-- attribution-row:status -->
- Provenance status: `self-reported in the original PR body`

