### PR TITLE
fix(ui): respect app locale in quota formatting

### DIFF
--- a/packages/ui/src/components/accounts/ConsumerKeyPanel.test.tsx
+++ b/packages/ui/src/components/accounts/ConsumerKeyPanel.test.tsx
@@ -31,11 +31,21 @@ vi.mock("../../state/app-store", () => ({
   useAppSelector: (
     selector: (state: {
       t: (key: string, vars?: Record<string, unknown>) => string;
+      uiLanguage: string;
     }) => unknown,
-  ) => selector({ t: (key, vars) => String(vars?.defaultValue ?? key) }),
+  ) =>
+    selector({
+      t: (key, vars) =>
+        String(vars?.defaultValue ?? key).replace(
+          "{{quota}}",
+          String(vars?.quota ?? ""),
+        ),
+      uiLanguage: mockUiLanguage,
+    }),
 }));
 
 let mockRole = "OWNER";
+let mockUiLanguage = "en";
 vi.mock("../../hooks/useRole.tsx", () => ({
   useRole: () => ({ role: mockRole }),
 }));
@@ -44,6 +54,7 @@ const clipboardWrites: string[] = [];
 
 beforeEach(() => {
   mockRole = "OWNER";
+  mockUiLanguage = "en";
   clipboardWrites.length = 0;
   Object.defineProperty(navigator, "clipboard", {
     configurable: true,
@@ -134,7 +145,20 @@ describe("list states", () => {
     expect(screen.getAllByText(/eliza_cp_abcdef1234/)).toHaveLength(2);
     expect(screen.getByText("Enabled")).toBeTruthy();
     expect(screen.getByText("Disabled")).toBeTruthy();
+    expect(screen.getByText("1,000,000 tokens/day")).toBeTruthy();
     expect(screen.getByText("No quota")).toBeTruthy();
+  });
+
+  it("formats quotas with the explicit app language", async () => {
+    mockUiLanguage = "es";
+    render(
+      <ConsumerKeyPanelBody
+        api={makeApi({ listConsumerKeys: vi.fn().mockResolvedValue([key()]) })}
+      />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText("1.000.000 tokens/day")).toBeTruthy(),
+    );
   });
 });
 

--- a/packages/ui/src/components/accounts/ConsumerKeyPanel.tsx
+++ b/packages/ui/src/components/accounts/ConsumerKeyPanel.tsx
@@ -138,6 +138,7 @@ export function ConsumerKeyPanelBody({
   api?: ConsumerKeyPanelApi;
 }) {
   const t = useAppSelector((s) => s.t);
+  const uiLanguage = useAppSelector((s) => s.uiLanguage);
   const [keys, setKeys] = useState<ConsumerKeySummary[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -384,7 +385,8 @@ export function ConsumerKeyPanelBody({
                         })
                       : t("consumerKeys.quotaPerDay", {
                           defaultValue: "{{quota}} tokens/day",
-                          quota: entry.dailyTokenQuota.toLocaleString("en-US"),
+                          quota:
+                            entry.dailyTokenQuota.toLocaleString(uiLanguage),
                         })}
                   </span>
                 </div>


### PR DESCRIPTION
# Relates to

Closes #20703.

- [x] Targets `develop` and is rebased with zero conflicts.
- [x] Formats quota values with the app-selected locale instead of hardcoded `en-US`.
- [x] Covers English and Spanish grouping separators with the production component contract.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto current `origin/develop`; zero conflicts.
- [x] `bun run verify` result is recorded below.

# Risks

Low. The change is presentation-only and limited to the existing quota label. The selected `uiLanguage` is already the app's canonical locale state.

# Background

## What does this PR do?

Uses the selected app language when rendering consumer-key daily quotas. Spanish now displays `1.000.000 tokens/day`; English remains `1,000,000 tokens/day`.

## What kind of change is this?

Bug fix for localized account settings.

# Documentation changes needed?

No. This corrects existing localized UI behavior without changing a public API.

# Testing

## Where should a reviewer start?

`packages/ui/src/components/accounts/ConsumerKeyPanel.tsx`

## Detailed testing steps

```bash
bun run --cwd packages/ui test src/components/accounts/ConsumerKeyPanel.test.tsx
bun run verify
bun run --cwd packages/app audit:app
```

- Focused component result: 14 passed, 0 failed.
- Repository verification: 356/356 workspace tasks plus all root audits passed.
- App visual audit: 219/219 passed; broken 0, needs-work 0, minimalism failures 0, hover failures 0, density failures 0.
- OCR triage: 216 views, 200 verified, broken 0, needs-eyeball 16.

# Evidence Gate

<!-- evidence-head:73dde75773528efbb8661d7810c785dbee2011db -->
<!-- evidence-row:before-screenshots -->
- [x] [Desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20760-20703-before-desktop.jpg), [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20760-20703-before-mobile.jpg) - hardcoded English grouping is visible.
<!-- evidence-row:after-screenshots -->
- [x] [Desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20760-20703-after-desktop.jpg), [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20760-20703-after-mobile.jpg) - Spanish grouping follows the selected app locale.
<!-- evidence-row:walkthrough-video -->
- [x] [Exact-component walkthrough](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20760-20703-walkthrough.mp4)
<!-- evidence-row:backend-logs -->
- [ ] `N/A - no backend or transport behavior changed.`
<!-- evidence-row:frontend-logs -->
- [x] [Full exact-head app audit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20760-report.json)
<!-- evidence-row:llm-trajectory -->
- [ ] `N/A - no agent, prompt, model, provider, or action behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [ ] `N/A - no external domain artifact changed.`
<!-- evidence-row:ocr-review -->
- [x] [Exact-head OCR triage report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20760-ocr-triage.json)

# Evidence Details

- Before: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20760-20703-before-desktop.jpg), [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20760-20703-before-mobile.jpg)
- After: [desktop](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20760-20703-after-desktop.jpg), [mobile](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20760-20703-after-mobile.jpg)
- [Walkthrough MP4](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20760-20703-walkthrough.mp4)
- [Full app audit report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20760-report.json)
- [OCR triage report](https://github.com/elizaOS/eliza/releases/download/pr-evidence-6/20760-ocr-triage.json)

## Known gaps / failures

None in the changed scope. The OCR report's 16 `needs-eyeball` entries are review prompts, not broken surfaces; the strict visual audit has zero broken or needs-work verdicts.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex Desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [qa-agent]

<!-- eliza-army-attribution:{"provider":"OpenAI","model":"gpt-5.6-sol","client":"Codex Desktop","skill":"N/A","status":"self-reported","agent":"qa-agent"} -->
