### PR TITLE
fix(cloud): fail closed on meeting-billing and reserve() money inputs (#13415 slice)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/credits-deduct-guard.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-deduct-guard.test.ts
@@ -488,16 +488,14 @@ describe("reconcile() — settle reserved vs actual", () => {
   );
 });
 
-describe("reserveAndDeductCredits — non-finite amount guard (#13415)", () => {
+describe("reserveAndDeductCredits non-finite amount guard", () => {
   beforeEach(async () => {
     if (!pgliteReady) return;
     await seedOrg("10.000000");
   });
 
-  // `amount <= 0` alone is false for NaN, so before the finite guard a NaN
-  // amount reached `String(amount)::numeric` in the balance/ledger CTE. These
-  // run the REAL authoritative mutation (not the reserve() wrapper) and prove
-  // the DB is untouched on rejection.
+  // These calls exercise the authoritative mutation rather than the reserve
+  // wrapper and prove the database is untouched on rejection.
   for (const [label, amount] of [
     ["NaN", Number.NaN],
     ["Infinity", Number.POSITIVE_INFINITY],
@@ -514,7 +512,10 @@ describe("reserveAndDeductCredits — non-finite amount guard (#13415)", () => {
             description: `non-finite guard (${label})`,
             metadata: { user_id: USER_ID },
           }),
-        ).rejects.toThrow("positive, finite");
+        ).rejects.toMatchObject({
+          code: "INVALID_CREDIT_AMOUNT",
+          context: { amount, operation: "reserve_and_deduct", permitsZero: false },
+        });
 
         // The deductCredits delegate funnels through the same guard.
         await expect(
@@ -524,7 +525,10 @@ describe("reserveAndDeductCredits — non-finite amount guard (#13415)", () => {
             description: `non-finite guard via deductCredits (${label})`,
             metadata: { user_id: USER_ID },
           }),
-        ).rejects.toThrow("positive, finite");
+        ).rejects.toMatchObject({
+          code: "INVALID_CREDIT_AMOUNT",
+          context: { amount, operation: "reserve_and_deduct", permitsZero: false },
+        });
 
         expect(await readBalance()).toBeCloseTo(10, 6);
         expect(await listDebits()).toHaveLength(0);

--- a/packages/cloud/shared/src/lib/services/__tests__/credits-deduct-guard.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-deduct-guard.test.ts
@@ -488,6 +488,52 @@ describe("reconcile() — settle reserved vs actual", () => {
   );
 });
 
+describe("reserveAndDeductCredits — non-finite amount guard (#13415)", () => {
+  beforeEach(async () => {
+    if (!pgliteReady) return;
+    await seedOrg("10.000000");
+  });
+
+  // `amount <= 0` alone is false for NaN, so before the finite guard a NaN
+  // amount reached `String(amount)::numeric` in the balance/ledger CTE. These
+  // run the REAL authoritative mutation (not the reserve() wrapper) and prove
+  // the DB is untouched on rejection.
+  for (const [label, amount] of [
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+  ] as const) {
+    test(
+      `rejects a ${label} amount with no balance movement and no ledger row`,
+      async () => {
+        if (!pgliteReady) return;
+
+        await expect(
+          creditsService.reserveAndDeductCredits({
+            organizationId: ORG_ID,
+            amount,
+            description: `non-finite guard (${label})`,
+            metadata: { user_id: USER_ID },
+          }),
+        ).rejects.toThrow("positive, finite");
+
+        // The deductCredits delegate funnels through the same guard.
+        await expect(
+          creditsService.deductCredits({
+            organizationId: ORG_ID,
+            amount,
+            description: `non-finite guard via deductCredits (${label})`,
+            metadata: { user_id: USER_ID },
+          }),
+        ).rejects.toThrow("positive, finite");
+
+        expect(await readBalance()).toBeCloseTo(10, 6);
+        expect(await listDebits()).toHaveLength(0);
+      },
+      PGLITE_TIMEOUT,
+    );
+  }
+});
+
 // Loud guard: PGlite is in-process (no network), so `pgliteReady` must be true.
 // If pushSchema/PGlite ever fails to init, the DB-dependent tests above
 // early-return; this turns that silent no-op into a hard CI failure so a

--- a/packages/cloud/shared/src/lib/services/__tests__/meeting-billing-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/meeting-billing-fail-closed.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Meeting billing fail-closed input contract (#13415 slice).
+ *
+ * Deterministic unit coverage (no DB needed — every case fails before any
+ * ledger write) for three former fail-open paths:
+ *
+ *  1. `MeetingCreditBillingSession` accepted a NaN `maxDurationMs`, which
+ *     disables the spend cap (`nextConsumedMs > NaN` is false), and NaN or
+ *     negative rate/window options that flow into reservation amounts. The
+ *     constructor must now reject non-finite / non-positive money inputs.
+ *  2. `resolveMeetingUsdPerMinute` silently fell back to the default rate when
+ *     ELIZA_MEETINGS_TRANSCRIPTION_USD_PER_MINUTE was present but invalid, so
+ *     a typo'd price billed every meeting at the wrong rate. Present-but-
+ *     invalid must now throw; unset/blank still uses the default.
+ *  3. `creditsService.reserve()` guarded amounts with `< 0` only, which NaN
+ *     passes — a NaN amount would be written as a 'NaN'::numeric debit row.
+ *     Non-finite amounts must now be refused. (Validation throws before any
+ *     DB access, so this asserts the guard directly.)
+ */
+
+import { describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+import { creditsService } from "../credits";
+import { createMeetingCreditBillingSession, resolveMeetingUsdPerMinute } from "../meeting-billing";
+
+const BASE_OPTIONS = {
+  organizationId: "00000000-0000-0000-0000-000000001627",
+  sessionId: "meeting-session-1",
+  maxDurationMs: 3_600_000,
+};
+
+describe("MeetingCreditBillingSession constructor validation", () => {
+  test("rejects NaN maxDurationMs (would disable the spend cap)", () => {
+    expect(() =>
+      createMeetingCreditBillingSession({ ...BASE_OPTIONS, maxDurationMs: Number.NaN }),
+    ).toThrow("positive, finite maxDurationMs");
+  });
+
+  test("rejects zero and negative maxDurationMs", () => {
+    for (const maxDurationMs of [0, -1]) {
+      expect(() => createMeetingCreditBillingSession({ ...BASE_OPTIONS, maxDurationMs })).toThrow(
+        "positive, finite maxDurationMs",
+      );
+    }
+  });
+
+  test("rejects non-finite and non-positive rate/window options", () => {
+    for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, 0, -0.01]) {
+      expect(() =>
+        createMeetingCreditBillingSession({ ...BASE_OPTIONS, usdPerMinute: bad }),
+      ).toThrow("usdPerMinute");
+      expect(() =>
+        createMeetingCreditBillingSession({ ...BASE_OPTIONS, initialWindowMs: bad }),
+      ).toThrow("initialWindowMs");
+      expect(() =>
+        createMeetingCreditBillingSession({ ...BASE_OPTIONS, chunkWindowMs: bad }),
+      ).toThrow("chunkWindowMs");
+    }
+  });
+
+  test("accepts valid options (guard is not over-broad)", () => {
+    const session = createMeetingCreditBillingSession({
+      ...BASE_OPTIONS,
+      usdPerMinute: 0.006,
+      initialWindowMs: 60_000,
+      chunkWindowMs: 60_000,
+    });
+    expect(session.state.status).toBe("reserved");
+    expect(session.state.capMs).toBe(BASE_OPTIONS.maxDurationMs);
+  });
+});
+
+describe("resolveMeetingUsdPerMinute env parsing", () => {
+  test("unset or blank uses the default", () => {
+    expect(resolveMeetingUsdPerMinute({})).toBeCloseTo(0.006, 9);
+    expect(
+      resolveMeetingUsdPerMinute({ ELIZA_MEETINGS_TRANSCRIPTION_USD_PER_MINUTE: "  " }),
+    ).toBeCloseTo(0.006, 9);
+  });
+
+  test("a valid override is used", () => {
+    expect(
+      resolveMeetingUsdPerMinute({ ELIZA_MEETINGS_TRANSCRIPTION_USD_PER_MINUTE: "0.01" }),
+    ).toBeCloseTo(0.01, 9);
+  });
+
+  test("present-but-invalid values throw instead of billing at the default rate", () => {
+    for (const bad of ["0..01", "abc", "-1", "0", "NaN", "Infinity"]) {
+      expect(() =>
+        resolveMeetingUsdPerMinute({ ELIZA_MEETINGS_TRANSCRIPTION_USD_PER_MINUTE: bad }),
+      ).toThrow("ELIZA_MEETINGS_TRANSCRIPTION_USD_PER_MINUTE");
+    }
+  });
+});
+
+describe("creditsService.reserve amount validation", () => {
+  test("refuses NaN and Infinity amounts before any DB access", async () => {
+    for (const amount of [Number.NaN, Number.POSITIVE_INFINITY]) {
+      await expect(
+        creditsService.reserve({
+          organizationId: BASE_OPTIONS.organizationId,
+          amount,
+          description: "meeting billing guard test",
+        }),
+      ).rejects.toThrow("finite, non-negative");
+    }
+  });
+
+  test("still refuses negative amounts", async () => {
+    await expect(
+      creditsService.reserve({
+        organizationId: BASE_OPTIONS.organizationId,
+        amount: -1,
+        description: "meeting billing guard test",
+      }),
+    ).rejects.toThrow("finite, non-negative");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/meeting-billing-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/meeting-billing-fail-closed.test.ts
@@ -24,6 +24,7 @@ process.env.DATABASE_URL = "pglite://memory";
 process.env.TEST_DATABASE_URL = "pglite://memory";
 process.env.NODE_ENV ||= "test";
 
+import { ElizaError } from "@elizaos/core";
 import { creditsService } from "../credits";
 import { createMeetingCreditBillingSession, resolveMeetingUsdPerMinute } from "../meeting-billing";
 
@@ -33,32 +34,51 @@ const BASE_OPTIONS = {
   maxDurationMs: 3_600_000,
 };
 
+function expectInvalidOption(fn: () => unknown, option: string): void {
+  let caught: unknown;
+  try {
+    fn();
+  } catch (error) {
+    caught = error;
+  }
+  expect(caught).toBeInstanceOf(ElizaError);
+  const err = caught as ElizaError;
+  expect(err.code).toBe("INVALID_MEETING_BILLING_OPTION");
+  expect(err.context?.option).toBe(option);
+  expect(err.context?.sessionId).toBe(BASE_OPTIONS.sessionId);
+}
+
 describe("MeetingCreditBillingSession constructor validation", () => {
   test("rejects NaN maxDurationMs (would disable the spend cap)", () => {
-    expect(() =>
-      createMeetingCreditBillingSession({ ...BASE_OPTIONS, maxDurationMs: Number.NaN }),
-    ).toThrow("positive, finite maxDurationMs");
+    expectInvalidOption(
+      () => createMeetingCreditBillingSession({ ...BASE_OPTIONS, maxDurationMs: Number.NaN }),
+      "maxDurationMs",
+    );
   });
 
   test("rejects zero and negative maxDurationMs", () => {
     for (const maxDurationMs of [0, -1]) {
-      expect(() => createMeetingCreditBillingSession({ ...BASE_OPTIONS, maxDurationMs })).toThrow(
-        "positive, finite maxDurationMs",
+      expectInvalidOption(
+        () => createMeetingCreditBillingSession({ ...BASE_OPTIONS, maxDurationMs }),
+        "maxDurationMs",
       );
     }
   });
 
   test("rejects non-finite and non-positive rate/window options", () => {
     for (const bad of [Number.NaN, Number.POSITIVE_INFINITY, 0, -0.01]) {
-      expect(() =>
-        createMeetingCreditBillingSession({ ...BASE_OPTIONS, usdPerMinute: bad }),
-      ).toThrow("usdPerMinute");
-      expect(() =>
-        createMeetingCreditBillingSession({ ...BASE_OPTIONS, initialWindowMs: bad }),
-      ).toThrow("initialWindowMs");
-      expect(() =>
-        createMeetingCreditBillingSession({ ...BASE_OPTIONS, chunkWindowMs: bad }),
-      ).toThrow("chunkWindowMs");
+      expectInvalidOption(
+        () => createMeetingCreditBillingSession({ ...BASE_OPTIONS, usdPerMinute: bad }),
+        "usdPerMinute",
+      );
+      expectInvalidOption(
+        () => createMeetingCreditBillingSession({ ...BASE_OPTIONS, initialWindowMs: bad }),
+        "initialWindowMs",
+      );
+      expectInvalidOption(
+        () => createMeetingCreditBillingSession({ ...BASE_OPTIONS, chunkWindowMs: bad }),
+        "chunkWindowMs",
+      );
     }
   });
 
@@ -90,9 +110,16 @@ describe("resolveMeetingUsdPerMinute env parsing", () => {
 
   test("present-but-invalid values throw instead of billing at the default rate", () => {
     for (const bad of ["0..01", "abc", "-1", "0", "NaN", "Infinity"]) {
-      expect(() =>
-        resolveMeetingUsdPerMinute({ ELIZA_MEETINGS_TRANSCRIPTION_USD_PER_MINUTE: bad }),
-      ).toThrow("ELIZA_MEETINGS_TRANSCRIPTION_USD_PER_MINUTE");
+      let caught: unknown;
+      try {
+        resolveMeetingUsdPerMinute({ ELIZA_MEETINGS_TRANSCRIPTION_USD_PER_MINUTE: bad });
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(ElizaError);
+      const err = caught as ElizaError;
+      expect(err.code).toBe("INVALID_MEETING_USD_PER_MINUTE");
+      expect(err.context?.configured).toBe(bad);
     }
   });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/meeting-billing-fail-closed.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/meeting-billing-fail-closed.test.ts
@@ -1,8 +1,7 @@
 /**
- * Meeting billing fail-closed input contract (#13415 slice).
+ * Exercises fail-closed input validation for cloud meeting billing.
  *
- * Deterministic unit coverage (no DB needed — every case fails before any
- * ledger write) for three former fail-open paths:
+ * Deterministic unit coverage verifies three security-sensitive boundaries:
  *
  *  1. `MeetingCreditBillingSession` accepted a NaN `maxDurationMs`, which
  *     disables the spend cap (`nextConsumedMs > NaN` is false), and NaN or
@@ -12,10 +11,8 @@
  *     ELIZA_MEETINGS_TRANSCRIPTION_USD_PER_MINUTE was present but invalid, so
  *     a typo'd price billed every meeting at the wrong rate. Present-but-
  *     invalid must now throw; unset/blank still uses the default.
- *  3. `creditsService.reserve()` guarded amounts with `< 0` only, which NaN
- *     passes — a NaN amount would be written as a 'NaN'::numeric debit row.
- *     Non-finite amounts must now be refused. (Validation throws before any
- *     DB access, so this asserts the guard directly.)
+ *  3. `creditsService.reserve()` refuses non-finite amounts before database
+ *     access. The authoritative mutation has separate real-PGlite coverage.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -133,7 +130,10 @@ describe("creditsService.reserve amount validation", () => {
           amount,
           description: "meeting billing guard test",
         }),
-      ).rejects.toThrow("finite, non-negative");
+      ).rejects.toMatchObject({
+        code: "INVALID_CREDIT_AMOUNT",
+        context: { amount, operation: "reserve", permitsZero: true },
+      });
     }
   });
 
@@ -144,6 +144,9 @@ describe("creditsService.reserve amount validation", () => {
         amount: -1,
         description: "meeting billing guard test",
       }),
-    ).rejects.toThrow("finite, non-negative");
+    ).rejects.toMatchObject({
+      code: "INVALID_CREDIT_AMOUNT",
+      context: { amount: -1, operation: "reserve", permitsZero: true },
+    });
   });
 });

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -102,6 +102,25 @@ export class ReservationNotFoundError extends ElizaError {
   }
 }
 
+/** Refuses malformed amounts before they can reach a credit-ledger mutation. */
+export class InvalidCreditAmountError extends ElizaError {
+  override readonly name = "InvalidCreditAmountError";
+
+  constructor(amount: number, operation: "reserve" | "reserve_and_deduct") {
+    const permitsZero = operation === "reserve";
+    super(
+      permitsZero
+        ? "Credit reservation amount must be a finite, non-negative number"
+        : "Credit deduction amount must be a positive, finite number",
+      {
+        code: "INVALID_CREDIT_AMOUNT",
+        context: { amount, operation, permitsZero },
+        severity: "fatal",
+      },
+    );
+  }
+}
+
 export class InsufficientCreditsError extends Error {
   constructor(
     public readonly required: number,
@@ -681,7 +700,7 @@ export class CreditsService {
     // so the finite check lives at this lowest shared boundary (the reserve()
     // wrapper keeps its own guard as defense-in-depth).
     if (!Number.isFinite(amount) || amount <= 0) {
-      throw new Error("Amount must be a positive, finite number");
+      throw new InvalidCreditAmountError(amount, "reserve_and_deduct");
     }
 
     const committedKeyedDeduction = async (): Promise<{
@@ -2436,7 +2455,7 @@ export class CreditsService {
     // `< 0` alone lets NaN through (the comparison is false), and a NaN
     // reservation amount would be written as a 'NaN'::numeric debit row.
     if (params.amount !== undefined && (!Number.isFinite(params.amount) || params.amount < 0)) {
-      throw new Error("reserve() amount must be a finite, non-negative number");
+      throw new InvalidCreditAmountError(params.amount, "reserve");
     }
     if (
       params.estimatedCostMultiplier !== undefined &&

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -675,8 +675,13 @@ export class CreditsService {
       stripePaymentIntentId,
     } = params;
 
-    if (amount <= 0) {
-      throw new Error("Amount must be positive");
+    // Authoritative money-write guard: `<= 0` alone lets NaN through (the
+    // comparison is false), after which `String(amount)::numeric` would reach
+    // the balance/ledger CTE as 'NaN'. Every debit path funnels through here,
+    // so the finite check lives at this lowest shared boundary (the reserve()
+    // wrapper keeps its own guard as defense-in-depth).
+    if (!Number.isFinite(amount) || amount <= 0) {
+      throw new Error("Amount must be a positive, finite number");
     }
 
     const committedKeyedDeduction = async (): Promise<{

--- a/packages/cloud/shared/src/lib/services/credits.ts
+++ b/packages/cloud/shared/src/lib/services/credits.ts
@@ -2428,8 +2428,10 @@ export class CreditsService {
     if (!description) {
       throw new Error("reserve() requires description");
     }
-    if (params.amount !== undefined && params.amount < 0) {
-      throw new Error("reserve() amount must be non-negative");
+    // `< 0` alone lets NaN through (the comparison is false), and a NaN
+    // reservation amount would be written as a 'NaN'::numeric debit row.
+    if (params.amount !== undefined && (!Number.isFinite(params.amount) || params.amount < 0)) {
+      throw new Error("reserve() amount must be a finite, non-negative number");
     }
     if (
       params.estimatedCostMultiplier !== undefined &&

--- a/packages/cloud/shared/src/lib/services/meeting-billing.ts
+++ b/packages/cloud/shared/src/lib/services/meeting-billing.ts
@@ -119,10 +119,7 @@ export class MeetingCreditBillingSession {
       ["initialWindowMs", options.initialWindowMs, false],
       ["chunkWindowMs", options.chunkWindowMs, false],
     ] as const) {
-      if (
-        (required || value !== undefined) &&
-        (!Number.isFinite(value) || (value as number) <= 0)
-      ) {
+      if (value === undefined ? required : !Number.isFinite(value) || value <= 0) {
         throw new ElizaError(
           `MeetingCreditBillingSession ${option} must be a positive, finite number`,
           {

--- a/packages/cloud/shared/src/lib/services/meeting-billing.ts
+++ b/packages/cloud/shared/src/lib/services/meeting-billing.ts
@@ -8,6 +8,7 @@
  * plugin does not import server-only database services.
  */
 
+import { ElizaError } from "@elizaos/core";
 import type { MeetingBillingState, MeetingEndReason } from "@elizaos/shared";
 import { type CreditReservation, creditsService, InsufficientCreditsError } from "./credits";
 
@@ -59,8 +60,13 @@ export function resolveMeetingUsdPerMinute(env: Record<string, string | undefine
   // meeting is charged the wrong amount.
   const parsed = readPositiveNumber(raw);
   if (parsed === null) {
-    throw new Error(
-      `ELIZA_MEETINGS_TRANSCRIPTION_USD_PER_MINUTE must be a positive finite number, got: ${raw}`,
+    throw new ElizaError(
+      "ELIZA_MEETINGS_TRANSCRIPTION_USD_PER_MINUTE must be a positive, finite number",
+      {
+        code: "INVALID_MEETING_USD_PER_MINUTE",
+        context: { configured: raw },
+        severity: "fatal",
+      },
     );
   }
   return parsed;
@@ -107,16 +113,24 @@ export class MeetingCreditBillingSession {
     // disables the spend cap (`nextConsumedMs > NaN` is false) and a NaN or
     // negative rate/window flows into reservation amounts, so a malformed
     // option must fail here rather than at settlement time.
-    if (!Number.isFinite(options.maxDurationMs) || options.maxDurationMs <= 0) {
-      throw new Error("MeetingCreditBillingSession requires a positive, finite maxDurationMs");
-    }
-    for (const [name, value] of [
-      ["usdPerMinute", options.usdPerMinute],
-      ["initialWindowMs", options.initialWindowMs],
-      ["chunkWindowMs", options.chunkWindowMs],
+    for (const [option, value, required] of [
+      ["maxDurationMs", options.maxDurationMs, true],
+      ["usdPerMinute", options.usdPerMinute, false],
+      ["initialWindowMs", options.initialWindowMs, false],
+      ["chunkWindowMs", options.chunkWindowMs, false],
     ] as const) {
-      if (value !== undefined && (!Number.isFinite(value) || value <= 0)) {
-        throw new Error(`MeetingCreditBillingSession ${name} must be a positive, finite number`);
+      if (
+        (required || value !== undefined) &&
+        (!Number.isFinite(value) || (value as number) <= 0)
+      ) {
+        throw new ElizaError(
+          `MeetingCreditBillingSession ${option} must be a positive, finite number`,
+          {
+            code: "INVALID_MEETING_BILLING_OPTION",
+            context: { option, value, sessionId: options.sessionId },
+            severity: "fatal",
+          },
+        );
       }
     }
     this.organizationId = options.organizationId;

--- a/packages/cloud/shared/src/lib/services/meeting-billing.ts
+++ b/packages/cloud/shared/src/lib/services/meeting-billing.ts
@@ -50,9 +50,20 @@ function readPositiveNumber(value: unknown): number | null {
 }
 
 export function resolveMeetingUsdPerMinute(env: Record<string, string | undefined> = process.env) {
-  return (
-    readPositiveNumber(env.ELIZA_MEETINGS_TRANSCRIPTION_USD_PER_MINUTE) ?? DEFAULT_USD_PER_MINUTE
-  );
+  const raw = env.ELIZA_MEETINGS_TRANSCRIPTION_USD_PER_MINUTE;
+  if (raw === undefined || raw.trim() === "") {
+    return DEFAULT_USD_PER_MINUTE;
+  }
+  // A present-but-invalid override must throw, not silently bill at the
+  // default rate — a typo'd price would otherwise go unnoticed while every
+  // meeting is charged the wrong amount.
+  const parsed = readPositiveNumber(raw);
+  if (parsed === null) {
+    throw new Error(
+      `ELIZA_MEETINGS_TRANSCRIPTION_USD_PER_MINUTE must be a positive finite number, got: ${raw}`,
+    );
+  }
+  return parsed;
 }
 
 function dollarsForMs(ms: number, usdPerMinute: number): number {
@@ -92,6 +103,22 @@ export class MeetingCreditBillingSession {
   private reconcilePromise: Promise<MeetingBillingState> | null = null;
 
   constructor(options: MeetingCreditBillingSessionOptions) {
+    // Money inputs must be finite and positive up front. A NaN maxDurationMs
+    // disables the spend cap (`nextConsumedMs > NaN` is false) and a NaN or
+    // negative rate/window flows into reservation amounts, so a malformed
+    // option must fail here rather than at settlement time.
+    if (!Number.isFinite(options.maxDurationMs) || options.maxDurationMs <= 0) {
+      throw new Error("MeetingCreditBillingSession requires a positive, finite maxDurationMs");
+    }
+    for (const [name, value] of [
+      ["usdPerMinute", options.usdPerMinute],
+      ["initialWindowMs", options.initialWindowMs],
+      ["chunkWindowMs", options.chunkWindowMs],
+    ] as const) {
+      if (value !== undefined && (!Number.isFinite(value) || value <= 0)) {
+        throw new Error(`MeetingCreditBillingSession ${name} must be a positive, finite number`);
+      }
+    }
     this.organizationId = options.organizationId;
     this.userId = options.userId;
     this.sessionId = options.sessionId;


### PR DESCRIPTION
## Summary

A #13415 slice covering the meeting transcription billing session and the credit reservation entry point it feeds:

- **`MeetingCreditBillingSession` constructor validation**: a NaN `maxDurationMs` disabled the spend cap entirely (`nextConsumedMs > NaN` is false), and NaN/negative `usdPerMinute`/`initialWindowMs`/`chunkWindowMs` flowed straight into reservation amounts. Non-finite / non-positive money inputs are now rejected at construction, before any ledger write.
- **`resolveMeetingUsdPerMinute`**: a present-but-invalid `ELIZA_MEETINGS_TRANSCRIPTION_USD_PER_MINUTE` silently fell back to the default rate, so a typo'd price billed every meeting at the wrong amount without any signal. It now throws on invalid values; unset/blank still uses the default (matching the `CREDIT_COST_BUFFER` precedent).
- **`creditsService.reserve()` amount guard**: the existing `amount < 0` check lets NaN through (the comparison is false), so a NaN amount would be written as a `'NaN'::numeric` debit row. The guard now refuses non-finite amounts, protecting every reserve() caller.

## Tests

- New `meeting-billing-fail-closed.test.ts` (9 tests): constructor rejection of NaN/Infinity/zero/negative money inputs with valid-input controls, env parsing (default / valid override / invalid throws), and reserve() refusing NaN/Infinity/negative amounts.
- Existing `meeting-billing`, `credits-reconcile`, `credits-cost-buffer`, `app-credit-hold-concurrency`, `credits-deduct-guard`, and `credit-balance-fail-closed` suites all green (79 tests); biome and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:f943c5461e6b3bd39393d8c8d95de3f33fa4929b -->

<!-- evidence-row:backend-logs -->
- [x] [20761-pr20761-focused-exact.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20761-pr20761-focused-exact.log)

<!-- evidence-row:domain-artifacts -->
- [x] [20761-pr20761-verify.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20761-pr20761-verify.log)

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only meeting billing and credit-ledger validation

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only meeting billing and credit-ledger validation

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - exercised by deterministic service and real PGlite ledger tests

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend files or browser behavior changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - deterministic billing service change with no model behavior
