### PR TITLE
fix(agent): make LifeOps an app readiness capability

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,12 @@
   "type": "module",
   "elizaos": {
     "app": {
-      "defaults": {},
+      "defaults": {
+        "personal-assistant": {
+          "enabled": true,
+          "requiredForReady": true
+        }
+      },
       "capabilities": {
         "text-large": "required",
         "messaging": "optional",

--- a/packages/agent/src/runtime/core-plugins.test.ts
+++ b/packages/agent/src/runtime/core-plugins.test.ts
@@ -1,11 +1,10 @@
 /**
  * Guards the default plugin partition in core-plugins.ts: plugin-google-workspace and
  * plugin-personal-assistant (heavy native/cloud deps) stay out of the static
- * core and deferred load sets that every image shape shares. Personal-assistant
- * is default-loaded for full desktop/server boots by the collector gate in
- * plugin-collector.ts (#17023), which excludes the slim shapes; keeping it out
- * of CORE_PLUGINS is what protects those shapes (#8081). Pure assertions over
- * the exported name lists.
+ * core and deferred load sets that every image shape shares. The Eliza host
+ * manifest selects personal-assistant and makes it readiness-critical
+ * (#17023); keeping it out of CORE_PLUGINS protects standalone/slim package
+ * closures (#8081). Pure assertions over the exported name lists.
  */
 import { describe, expect, it } from "vitest";
 
@@ -26,10 +25,10 @@ describe("CORE_PLUGINS", () => {
     // @capacitor/core) that the slim Docker runtime image intentionally does
     // not bundle. Loading them from the shared static sets crashed the boot
     // smoke / boot gate (#8081) with "Cannot find package 'googleapis' /
-    // @capacitor/core". Personal-assistant is instead default-added for full
-    // desktop/server boots by the collector gate (#17023), which skips
-    // mobile, lean-chat, store, and provisioned-cloud shapes; the static
-    // CORE/DEFERRED sets stay clean so those shapes never resolve it.
+    // @capacitor/core". The Eliza app's package manifest selects
+    // personal-assistant only for the host that ships it (#17023); the static
+    // CORE/DEFERRED sets stay clean so standalone and slim shapes never resolve
+    // a package outside their dependency closure.
     expect(CORE_PLUGINS).not.toContain("@elizaos/plugin-google-workspace");
     expect(CORE_PLUGINS).not.toContain("@elizaos/plugin-personal-assistant");
     expect(DEFERRED_CORE_PLUGINS).not.toContain(

--- a/packages/agent/src/runtime/core-plugins.ts
+++ b/packages/agent/src/runtime/core-plugins.ts
@@ -418,7 +418,7 @@ export const OPTIONAL_CORE_PLUGINS: readonly string[] = [
   // plugin-manager, secrets (SECRETS), trust: now built-in core capabilities
   // Enable via character settings: ENABLE_PLUGIN_MANAGER, ENABLE_SECRETS_MANAGER, ENABLE_TRUST
   "@elizaos/plugin-google-workspace", // Google Workspace connector (requires googleapis + explicit OAuth config); only loaded when LifeOps/Google is enabled
-  "@elizaos/plugin-personal-assistant", // LifeOps: personal ops - tasks, goals, calendar, inbox, website blocking. Default-on for full desktop/server boots via the collector gate (#17023); stays out of CORE_PLUGINS so mobile/lean-chat/store/slim-cloud images (#8081) never load it; opt out via plugins.entries or ELIZA_DISABLE_PERSONAL_ASSISTANT
+  "@elizaos/plugin-personal-assistant", // LifeOps: personal ops - tasks, goals, calendar, inbox, website blocking. The Eliza app manifest enables it and requires registration before ready (#17023); standalone agent installs stay opt-in because they do not ship this package.
   "@elizaos/plugin-finances", // Owner finances dashboard (app_finances schema); auto-registered by plugin-personal-assistant, also enablable standalone
   "@elizaos/plugin-pdf", // PDF processing (published bundle broken in alpha.15)
   "@elizaos/plugin-obsidian", // Obsidian vault CLI integration

--- a/packages/agent/src/runtime/plugin-collector-personal-assistant.test.ts
+++ b/packages/agent/src/runtime/plugin-collector-personal-assistant.test.ts
@@ -1,10 +1,9 @@
 /**
- * Covers the default LifeOps owner-chat gate in collectPluginNames() (#17023):
- * a clean full desktop/server boot loads @elizaos/plugin-personal-assistant so
- * OWNER_ROUTINES registers for owner conversations, while explicit operator
- * disablement, the env kill-switch, mobile, lean-chat, store builds, and slim
- * cloud containers keep it out. Deterministic — env-driven over an in-memory
- * ElizaConfig, no live model or runtime boot.
+ * Covers the LifeOps owner-chat gates in collectPluginNames() (#17023). Host
+ * manifests opt into @elizaos/plugin-personal-assistant; a plain standalone
+ * agent does not assume that unshipped dependency. Explicit operator and
+ * constrained-profile gates still win. Deterministic — env-driven over an
+ * in-memory ElizaConfig, no live model or runtime boot.
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -37,16 +36,18 @@ afterEach(() => {
 });
 
 const emptyConfig: ElizaConfig = {} as ElizaConfig;
+const enabledConfig = (): ElizaConfig =>
+  ({
+    plugins: { entries: { "personal-assistant": { enabled: true } } },
+  }) as ElizaConfig;
 
-describe("collectPluginNames personal-assistant default gate (#17023)", () => {
-  it("loads personal-assistant on a clean default full boot", () => {
-    const reasons = new Map<string, string>();
-    const names = collectPluginNames(emptyConfig, reasons);
+describe("collectPluginNames personal-assistant host gate (#17023)", () => {
+  it("keeps personal-assistant out of a plain standalone agent boot", () => {
+    const names = collectPluginNames(emptyConfig);
 
-    expect(names.has(PA)).toBe(true);
+    expect(names.has(PA)).toBe(false);
     // The scheduling primitive the routine runner depends on stays core.
     expect(names.has("@elizaos/plugin-scheduling")).toBe(true);
-    expect(reasons.get(PA)).toContain("#17023");
   });
 
   it("honors explicit operator disablement via plugins.entries", () => {
@@ -67,26 +68,26 @@ describe("collectPluginNames personal-assistant default gate (#17023)", () => {
 
   it("honors the ELIZA_DISABLE_PERSONAL_ASSISTANT env kill-switch", () => {
     process.env.ELIZA_DISABLE_PERSONAL_ASSISTANT = "1";
-    expect(collectPluginNames(emptyConfig).has(PA)).toBe(false);
+    expect(collectPluginNames(enabledConfig()).has(PA)).toBe(false);
   });
 
   it("stays out of the lean-chat set", () => {
     process.env.ELIZA_PLUGIN_SET = "lean-chat";
-    expect(collectPluginNames(emptyConfig).has(PA)).toBe(false);
+    expect(collectPluginNames(enabledConfig()).has(PA)).toBe(false);
   });
 
   it("stays out of mobile boots (no PA loader in the app sandbox)", () => {
     process.env.ELIZA_PLATFORM = "android";
-    expect(collectPluginNames(emptyConfig).has(PA)).toBe(false);
+    expect(collectPluginNames(enabledConfig()).has(PA)).toBe(false);
   });
 
   it("stays out of store builds", () => {
     process.env.ELIZA_BUILD_VARIANT = "store";
-    expect(collectPluginNames(emptyConfig).has(PA)).toBe(false);
+    expect(collectPluginNames(enabledConfig()).has(PA)).toBe(false);
   });
 
   it("stays out of slim provisioned cloud containers (#8081 image constraint)", () => {
     process.env.ELIZA_CLOUD_PROVISIONED = "1";
-    expect(collectPluginNames(emptyConfig).has(PA)).toBe(false);
+    expect(collectPluginNames(enabledConfig()).has(PA)).toBe(false);
   });
 });

--- a/packages/agent/src/runtime/plugin-collector-telegram-standalone.test.ts
+++ b/packages/agent/src/runtime/plugin-collector-telegram-standalone.test.ts
@@ -29,15 +29,12 @@ afterEach(() => {
 });
 
 describe("collectPluginNames standalone Telegram policy", () => {
-  it("keeps standalone Telegram dormant on a default full boot (PA default-on, #17023)", () => {
-    // personal-assistant is default-loaded on full boots and declares
-    // passiveConnectorsByDefault, so the pre-runtime prediction now matches
-    // the runtime gate: passive unless explicitly overridden.
+  it("loads Telegram for a plain standalone agent", () => {
     process.env.ELIZA_TELEGRAM_STANDALONE_BOT = "true";
 
     const names = collectPluginNames({} as ElizaConfig);
-    expect(names).toContain("@elizaos/plugin-personal-assistant");
-    expect(names).not.toContain("@elizaos/plugin-telegram");
+    expect(names).not.toContain("@elizaos/plugin-personal-assistant");
+    expect(names).toContain("@elizaos/plugin-telegram");
   });
 
   it("loads Telegram for a plain agent that opts into the standalone poller with PA disabled", () => {
@@ -55,11 +52,15 @@ describe("collectPluginNames standalone Telegram policy", () => {
     expect(names).toContain("@elizaos/plugin-telegram");
   });
 
-  it("loads Telegram for a default full boot that explicitly opts out of passive mode", () => {
+  it("loads Telegram for a LifeOps app that explicitly opts out of passive mode", () => {
     process.env.ELIZA_TELEGRAM_STANDALONE_BOT = "true";
     process.env.ELIZA_LIFEOPS_PASSIVE_CONNECTORS = "false";
 
-    const names = collectPluginNames({} as ElizaConfig);
+    const names = collectPluginNames({
+      plugins: {
+        entries: { "personal-assistant": { enabled: true } },
+      },
+    } as ElizaConfig);
     expect(names).toContain("@elizaos/plugin-personal-assistant");
     expect(names).toContain("@elizaos/plugin-telegram");
   });

--- a/packages/agent/src/runtime/plugin-collector.ts
+++ b/packages/agent/src/runtime/plugin-collector.ts
@@ -152,7 +152,7 @@ function gitpathologistRequested(config: ElizaConfig): boolean {
 }
 
 /**
- * Env kill-switch for the default LifeOps owner-chat capability (#17023).
+ * Env kill-switch for the host-selected LifeOps owner-chat capability (#17023).
  * Config-level opt-out (`plugins.entries["personal-assistant"].enabled=false`)
  * is honored separately by the explicit-disable sweep in collectPluginNames.
  */
@@ -635,35 +635,9 @@ export function collectPluginNames(
       "gitpathologist (auto-on when .git/ present; gate ELIZA_GITPATHOLOGIST)",
     );
   }
-  // Default LifeOps owner-chat capability (#17023). The default app advertises
-  // tasks/habits/routines, and every routine-creating chat action
-  // (OWNER_ROUTINES and the other owner umbrellas) registers only from
-  // plugin-personal-assistant — always-loaded plugin-scheduling hosts the
-  // single runner and the /api/lifeops REST surface but zero actions. Full
-  // desktop/server boots therefore load personal-assistant by default so an
-  // OWNER conversation can actually create the routines the surface claims.
-  // Excluded shapes keep their existing constraints: mobile has no PA loader
-  // in the app sandbox, lean-chat stays lean (#8434), and store builds plus
-  // slim provisioned cloud containers do not bundle PA's googleapis/
-  // @capacitor/core dependency closure (#8081). Explicit operator opt-out via
-  // plugins.entries["personal-assistant"].enabled=false is honored by the
-  // explicit-disable sweep below; ELIZA_DISABLE_PERSONAL_ASSISTANT is the env
-  // kill-switch. Registration stays in the deferred wave, whose
-  // runtime.reportError boundary makes a resolution/registration failure
-  // visible instead of a silent capability hole.
-  if (
-    !onMobile &&
-    !leanChat &&
-    !storeBuild &&
-    !isCloudContainer &&
-    !personalAssistantDisabledByEnv()
-  ) {
-    pluginsToLoad.add("@elizaos/plugin-personal-assistant");
-    track(
-      "@elizaos/plugin-personal-assistant",
-      "default LifeOps owner-chat capability (#17023; opt out via plugins.entries or ELIZA_DISABLE_PERSONAL_ASSISTANT)",
-    );
-  }
+  // The host app owns default feature selection through `elizaos.app.defaults`
+  // in its package manifest. A standalone @elizaos/agent installation must not
+  // implicitly select a package outside its published dependency closure.
   // Allow list is additive — extra plugins on top of auto-detection,
   // not an exclusive whitelist that blocks everything else.
   if (allowList && allowList.length > 0) {
@@ -894,6 +868,14 @@ export function collectPluginNames(
     if (isPluginExplicitlyDisabled(pluginName)) {
       pluginsToLoad.delete(pluginName);
     }
+  }
+  if (
+    personalAssistantDisabledByEnv() ||
+    leanChat ||
+    storeBuild ||
+    isCloudContainer
+  ) {
+    pluginsToLoad.delete("@elizaos/plugin-personal-assistant");
   }
 
   // Calendar home tiles load on every platform (MOBILE_VIEW_PLUGINS). Calendar

--- a/packages/agent/src/runtime/plugin-resolver.test.ts
+++ b/packages/agent/src/runtime/plugin-resolver.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { logger, type Plugin } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ElizaConfig } from "../config/config.ts";
 import {
   resolvePlugins,
   resolveRuntimePluginImportSpecifier,
@@ -143,6 +144,67 @@ describe("resolvePlugins manifest discovery", () => {
       else process.env.ELIZA_PLATFORM = previousPlatform;
     }
   });
+
+  it("loads a host-manifest readiness plugin in blocking only", async () => {
+    const previousCwd = process.cwd();
+    const workspace = await mkdtemp(path.join(tmpdir(), "eliza-app-ready-"));
+    const dropinsDir = path.join(workspace, "dropins");
+    const pluginRoot = path.join(dropinsDir, "ready-fixture");
+    const pluginName = "@fixture/plugin-ready";
+
+    try {
+      await mkdir(pluginRoot, { recursive: true });
+      await writeFile(
+        path.join(workspace, "package.json"),
+        JSON.stringify({
+          name: "ready-host-fixture",
+          elizaos: {
+            app: {
+              defaults: {
+                [pluginName]: { enabled: true, requiredForReady: true },
+              },
+            },
+          },
+        }),
+        "utf8",
+      );
+      await writeFile(
+        path.join(pluginRoot, "package.json"),
+        JSON.stringify({
+          name: pluginName,
+          version: "0.0.0-test",
+          type: "module",
+          main: "./index.js",
+        }),
+        "utf8",
+      );
+      await writeFile(
+        path.join(pluginRoot, "index.js"),
+        `export default { name: ${JSON.stringify(pluginName)}, description: "ready fixture", services: [] };\n`,
+        "utf8",
+      );
+      process.chdir(workspace);
+      const config: ElizaConfig = {
+        plugins: { allow: [], entries: {}, load: { paths: [dropinsDir] } },
+      } as ElizaConfig;
+
+      const blocking = await resolvePlugins(config, {
+        quiet: true,
+        phase: "blocking",
+      });
+      expect(blocking.map((plugin) => plugin.name)).toContain(pluginName);
+      expect(config.plugins?.entries?.[pluginName]).toEqual({ enabled: true });
+
+      const deferred = await resolvePlugins(config, {
+        quiet: true,
+        phase: "deferred",
+      });
+      expect(deferred.map((plugin) => plugin.name)).not.toContain(pluginName);
+    } finally {
+      process.chdir(previousCwd);
+      await rm(workspace, { recursive: true, force: true });
+    }
+  }, 120_000);
 });
 
 describe("resolvePlugins boot-phase split for model providers (#14038)", () => {

--- a/packages/agent/src/runtime/plugin-resolver.ts
+++ b/packages/agent/src/runtime/plugin-resolver.ts
@@ -17,6 +17,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { ElizaError, logger, type Plugin } from "@elizaos/core";
 import { formatError, isMobilePlatform } from "@elizaos/shared";
 import {
+  type AppManifestBlock,
   applyAppManifestDefaults,
   filterCandidatesByAppManifest,
   readAppManifest,
@@ -2080,11 +2081,10 @@ export async function resolvePlugins(
   //   - prepopulate config.plugins.entries with default { enabled } flags
   //     (user config still wins; defaults only fill keys the user hasn't set)
   const changes: string[] = [];
+  let appManifest: AppManifestBlock | null = null;
   if (!mobilePlatform) {
     try {
-      const appManifest = await readAppManifest(process.cwd()).catch(
-        () => null,
-      );
+      appManifest = await readAppManifest(process.cwd()).catch(() => null);
       const defaultedEntries = applyAppManifestDefaults(config, appManifest);
       if (defaultedEntries.length > 0) {
         logger.info(
@@ -2140,6 +2140,19 @@ export async function resolvePlugins(
   const pluginsToLoad = collectPluginNames(config, loadReasons);
   const corePluginSet = new Set<string>(CORE_PLUGINS);
   const blockingPluginSet = new Set<string>(BLOCKING_CORE_PLUGINS);
+  for (const [pluginId, appDefault] of Object.entries(
+    appManifest?.defaults ?? {},
+  )) {
+    if (appDefault.requiredForReady === true) {
+      blockingPluginSet.add(
+        resolvePluginPackageAlias(
+          pluginId.includes("/")
+            ? pluginId
+            : `@elizaos/${pluginId.startsWith("plugin-") ? pluginId : `plugin-${pluginId}`}`,
+        ),
+      );
+    }
+  }
   const forceIncludePluginNames = new Set(opts?.forceIncludePluginNames ?? []);
 
   // Build a mutable map of install records so we can merge drop-in discoveries

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -258,6 +258,14 @@
   },
   "private": true,
   "elizaos": {
+    "app": {
+      "defaults": {
+        "personal-assistant": {
+          "enabled": true,
+          "requiredForReady": true
+        }
+      }
+    },
     "scripts": {
       "testLanes": [
         "client"

--- a/packages/shared/src/config/__tests__/app-manifest.test.ts
+++ b/packages/shared/src/config/__tests__/app-manifest.test.ts
@@ -146,7 +146,10 @@ describe("applyAppManifestDefaults", () => {
       plugins?: { entries?: Record<string, { enabled?: boolean }> };
     } = {};
     const applied = applyAppManifestDefaults(config, {
-      defaults: { wallet: { enabled: false }, anthropic: { enabled: true } },
+      defaults: {
+        wallet: { enabled: false },
+        anthropic: { enabled: true, requiredForReady: true },
+      },
     });
     expect(applied.sort()).toEqual(["anthropic", "wallet"]);
     expect(config.plugins?.entries?.wallet).toEqual({ enabled: false });

--- a/packages/shared/src/config/app-manifest.ts
+++ b/packages/shared/src/config/app-manifest.ts
@@ -8,7 +8,9 @@
  *     app that doesn't list a plugin won't load it even if that plugin's own
  *     auto-enable would match.
  *   - `defaults` prepopulates `config.plugins.entries` with `{ enabled }` flags
- *     before the manifest evaluator runs, so a user's saved config still wins.
+ *     before the manifest evaluator runs, so a user's saved config still wins;
+ *     a host may also mark a selected plugin `requiredForReady` without writing
+ *     that host-only policy into user configuration.
  *   - `capabilities` is informational — surfaced via the verdict so UIs can
  *     warn when a required capability isn't satisfied by any enabled plugin.
  *
@@ -25,6 +27,11 @@ import type { PluginManifestCandidate } from "./plugin-manifest.js";
 export interface PluginAppDefault {
   /** When false, the plugin is disabled by default unless the user enables it. */
   enabled?: boolean;
+  /**
+   * When true, an enabled plugin belongs to the host's readiness contract and
+   * must register before the runtime reports ready.
+   */
+  requiredForReady?: boolean;
 }
 
 /** Capability requirement level declared by the app. */
@@ -143,7 +150,7 @@ export function applyAppManifestDefaults(
   const applied: string[] = [];
   for (const [id, defaultsForPlugin] of Object.entries(manifest.defaults)) {
     if (entries[id] !== undefined) continue; // user wins
-    entries[id] = { ...defaultsForPlugin };
+    entries[id] = { enabled: defaultsForPlugin.enabled };
     applied.push(id);
   }
   return applied;


### PR DESCRIPTION
Closes #17023

## Summary
- declare requiredForReady as a host-manifest default instead of persisting it as plugin config
- enable personal-assistant readiness for the Eliza app while keeping standalone agents opt-in
- preserve constrained-runtime and environment kill switches
- cover resolver, collector, and manifest behavior with contract tests

## Validation
- exact post-rebase head c75dfcfc2d8aa071536da89ccf901ccac50ba375
- 24 focused agent tests passed
- 15 shared manifest tests passed
- agent/shared typecheck and lint passed
- root bun run verify passed before the final non-overlapping rebase: 356/356 tasks and anti-larp clean
- app visual audit: 219 captures passed; 216 strict findings with 0 broken and 0 needs-work; OCR 216 views, 200 verified, 0 broken