### PR TITLE
fix(orchestrator): nested sub-agent replies die on a connector send to a synthetic task room

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -461,6 +461,44 @@ describe("SubAgentRouter", () => {
     );
   });
 
+  it("delivers nested sub-agent planner replies internally, never via a connector send", async () => {
+    // A nested swarm child's origin is the parent's synthetic task room with
+    // source `sub_agent` — no connector owns it, so the previous connector
+    // send could only fail ("no conversation available to deliver message",
+    // live 2026-08-17) and the reply was dropped.
+    session = makeSession({
+      metadata: {
+        label: "nested-child",
+        roomId: ROOM,
+        worldId: WORLD,
+        userId: USER,
+        messageId: PARENT_MSG,
+        source: "sub_agent",
+        subAgent: true,
+      },
+    });
+    acp = makeAcpService(session);
+    const { runtime, handleMessage, createMemory, sendMessageToTarget } =
+      makeRuntime({ acp: acp.service });
+    handleMessage.mockImplementation(async (_runtime, _memory, callback) => {
+      await callback?.({ text: "nested result" });
+      return {};
+    });
+    await SubAgentRouter.start(runtime);
+
+    acp.emit(SESSION_ID, "task_complete", {
+      response: "nested result",
+    });
+    await new Promise((r) => setImmediate(r));
+
+    expect(sendMessageToTarget).not.toHaveBeenCalled();
+    expect(createMemory).toHaveBeenCalledTimes(1);
+    const persisted = createMemory.mock.calls[0]?.[0];
+    expect(persisted?.roomId).toBe(ROOM);
+    expect(persisted?.content?.text).toBe("nested result");
+    expect(persisted?.content?.inReplyTo).toBe(PARENT_MSG);
+  });
+
   it("keeps the internal workdir out of the task_complete planner header", async () => {
     session = makeSession({
       metadata: {

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -1910,6 +1910,46 @@ export class SubAgentRouter extends Service {
     if (!sendToTarget) return undefined;
     const source = origin.source;
     if (!source) return undefined;
+    // A nested swarm child's origin is the parent's TASK ROOM with source
+    // `sub_agent` — a synthetic room no connector owns, so a connector send
+    // can only fail ("no conversation available to deliver message", live
+    // 2026-08-17) and the planner's reply to the child's completion was
+    // dropped. Deliver it internally instead: persist the reply into the task
+    // room, where the parent session already reads its swarm traffic.
+    if (source === MESSAGE_SOURCE_SUB_AGENT) {
+      return async (response: Content): Promise<Memory[]> => {
+        const text =
+          typeof response.text === "string" ? response.text.trim() : "";
+        if (!text) return [];
+        const memory: Memory = {
+          id: randomUUID() as UUID,
+          entityId: this.runtime.agentId,
+          agentId: this.runtime.agentId,
+          roomId: origin.roomId as UUID,
+          content: {
+            text,
+            source: ACPX_ROUTER_SOURCE,
+            ...(origin.parentMessageId
+              ? { inReplyTo: origin.parentMessageId }
+              : {}),
+          },
+          createdAt: Date.now(),
+        };
+        try {
+          await this.runtime.createMemory(memory, "messages");
+          return [memory];
+        } catch (err) {
+          // error-policy:J1 internal reply-delivery boundary: warns and
+          // returns an honest empty delivery, mirroring the connector leg.
+          this.log("warn", "nested sub-agent reply persistence failed", {
+            sessionId,
+            roomId: origin.roomId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          return [];
+        }
+      };
+    }
     return async (response: Content): Promise<Memory[]> => {
       const text =
         typeof response.text === "string" ? response.text.trim() : "";


### PR DESCRIPTION
## Summary
Live find during owner testing (2026-08-17 01:00Z): a nested swarm child ("fix app-clarifier deployment", source=`sub_agent`) completed, and the parent planner's reply to that completion was DROPPED — `[ACPX:SUB-AGENT-ROUTER] sub-agent reply delivery failed … error=sub_agent send failed: no conversation available to deliver message`.

Mechanism: `buildReplyCallback` always delivers via `sendMessageToTarget({source, roomId})`. For a nested child, `source` is `sub_agent` and `roomId` is the parent's synthetic task room — no connector owns that room, so the send can only fail, and the catch honestly returns "0 delivered": by construction, every nested-child planner reply was lost.

Fix: when `origin.source === MESSAGE_SOURCE_SUB_AGENT`, deliver internally — persist the reply as a memory in the task room (`inReplyTo` the child's completion post), where the parent session already reads its swarm traffic via the task-room forward. Connector origins are unchanged. Persistence failure warns and returns an honest empty delivery (error-policy:J1), mirroring the connector leg.

## Evidence
- New contract test: nested origin → `sendMessageToTarget` NEVER called, reply persisted into the task room with correct `inReplyTo`; existing connector-threading test unchanged.
- Suite: sub-agent-router 100/100 (99 existing + 1 new). Plugin typecheck clean.
- Live receipts: bot.log delivery-failure line + session 5db2972d metadata (source=sub_agent, roomId==targetRoomId) in HQ #18309 ledger.

Same silent-loss family as #20734/#20750 — this closes the nested-swarm leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)