### PR TITLE
fix(agent): keep self-status output within configured caps

### DIFF
--- a/packages/agent/src/actions/runtime.self-status.test.ts
+++ b/packages/agent/src/actions/runtime.self-status.test.ts
@@ -1,8 +1,10 @@
 /**
  * Verifies the RUNTIME action's `self_status` op resolves the self-awareness
- * registry solely from the AWARENESS_REGISTRY runtime service and fails closed
- * when that service is absent or does not expose `getDetail`. Deterministic:
- * drives the handler against a hand-built in-memory runtime stub, no live model.
+ * registry solely from the AWARENESS_REGISTRY runtime service, fails closed when
+ * that service is absent or does not expose `getDetail`, and keeps truncated
+ * brief/full detail within the configured character caps once the truncation
+ * suffix is reserved (issue #20762). Deterministic: drives the handler against a
+ * hand-built in-memory runtime stub, no live model.
  */
 import type {
   ActionResult,
@@ -45,6 +47,27 @@ async function runSelfStatus(runtime: IAgentRuntime): Promise<ActionResult> {
   )) as ActionResult;
 }
 
+async function runSelfStatusDetail(
+  runtime: IAgentRuntime,
+  detailLevel: "brief" | "full",
+): Promise<ActionResult> {
+  return (await runtimeAction.handler(
+    runtime,
+    message,
+    {} as State,
+    { parameters: { action: "self_status", module: "runtime", detailLevel } },
+    (() => Promise.resolve([])) as unknown as HandlerCallback,
+  )) as ActionResult;
+}
+
+const SELF_STATUS_TRUNCATION_SUFFIX = "\n…[self-status truncated]";
+const MAX_SELF_STATUS_BRIEF_CHARS = 1200;
+const MAX_SELF_STATUS_FULL_CHARS = 8000;
+
+function makeOversizedRuntime(payload: string): IAgentRuntime {
+  return makeRuntime({ getDetail: async () => payload });
+}
+
 describe("RUNTIME self_status registry seam", () => {
   it("uses the AWARENESS_REGISTRY service when registered", async () => {
     let seen: { module: string; level: string } | null = null;
@@ -70,6 +93,46 @@ describe("RUNTIME self_status registry seam", () => {
     expect(result.success).toBe(true);
     expect(result.text).toContain("Self-awareness registry is not loaded");
     expect(result.text?.length ?? 0).toBeGreaterThan(60);
+  });
+
+  it("caps a brief self-status result at MAX_SELF_STATUS_BRIEF_CHARS including the suffix", async () => {
+    const result = await runSelfStatusDetail(
+      makeOversizedRuntime("x".repeat(5000)),
+      "brief",
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.text?.length ?? 0).toBeLessThanOrEqual(
+      MAX_SELF_STATUS_BRIEF_CHARS,
+    );
+    expect(result.text?.endsWith(SELF_STATUS_TRUNCATION_SUFFIX)).toBe(true);
+    expect(result.data?.truncated).toBe(true);
+  });
+
+  it("caps a full self-status result at MAX_SELF_STATUS_FULL_CHARS including the suffix", async () => {
+    const result = await runSelfStatusDetail(
+      makeOversizedRuntime("x".repeat(20000)),
+      "full",
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.text?.length ?? 0).toBeLessThanOrEqual(
+      MAX_SELF_STATUS_FULL_CHARS,
+    );
+    expect(result.text?.includes(SELF_STATUS_TRUNCATION_SUFFIX)).toBe(true);
+    expect(result.data?.truncated).toBe(true);
+  });
+
+  it("returns under-cap detail verbatim without the truncation suffix", async () => {
+    const body = "a compact self-status answer";
+    const result = await runSelfStatusDetail(
+      makeOversizedRuntime(body),
+      "brief",
+    );
+
+    expect(result.text).toBe(body);
+    expect(result.text?.includes(SELF_STATUS_TRUNCATION_SUFFIX)).toBe(false);
+    expect(result.data?.truncated).toBe(false);
   });
 
   it("degrades to the snapshot when the service is not a valid registry (no getDetail)", async () => {

--- a/packages/agent/src/actions/runtime.ts
+++ b/packages/agent/src/actions/runtime.ts
@@ -87,6 +87,10 @@ const SHUTDOWN_DELAY_MS = 1_500;
 const MAX_RESTART_REASON_CHARS = 240;
 const MAX_SELF_STATUS_BRIEF_CHARS = 1200;
 const MAX_SELF_STATUS_FULL_CHARS = 8000;
+// Appended when self-status detail is truncated. Its length is reserved out of
+// the cap before slicing so the returned string never exceeds maxChars — the
+// suffix is part of the budget, not added on top of it (issue #20762).
+const SELF_STATUS_TRUNCATION_SUFFIX = "\n…[self-status truncated]";
 
 const RESTART_REQUEST_TERMS = getValidationKeywordTerms(
   "action.restart.request",
@@ -225,10 +229,20 @@ async function selfStatusOp(
     detailLevel === "full"
       ? MAX_SELF_STATUS_FULL_CHARS
       : MAX_SELF_STATUS_BRIEF_CHARS;
-  const text =
-    rawText.length <= maxChars
-      ? rawText
-      : `${rawText.slice(0, maxChars)}\n…[self-status truncated]`;
+  const truncated = rawText.length > maxChars;
+  // Reserve the suffix out of the cap so the final string is <= maxChars. Guard
+  // the slice index against caps smaller than the suffix (never true for the
+  // configured caps, but keeps the bound honest for any future cap).
+  const bodyLimit = Math.max(
+    0,
+    maxChars - SELF_STATUS_TRUNCATION_SUFFIX.length,
+  );
+  const text = truncated
+    ? `${rawText.slice(0, bodyLimit)}${SELF_STATUS_TRUNCATION_SUFFIX}`.slice(
+        0,
+        maxChars,
+      )
+    : rawText;
   return {
     success: true,
     text,
@@ -238,7 +252,7 @@ async function selfStatusOp(
       op: "self_status",
       module,
       detailLevel,
-      truncated: text.length < rawText.length,
+      truncated,
     },
   };
 }


### PR DESCRIPTION
# Relates to

Closes #20762

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` was run after sync. Focused package tests, biome, and an
      isolated typecheck of the touched files pass; the full `bun run verify`
      gate is blocked by pre-existing, unrelated unbuilt-workspace errors
      recorded under **Known gaps / failures**.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below (failing-then-passing reproduction with exact
      1225→1200 / 8025→8000 lengths).

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@fbc3f345caa29dc60302a7555cd8d273d35fa6b9:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync — blocked by pre-existing unrelated
      unbuilt-workspace errors; see **Known gaps / failures**.

# Risks

Low. The change is confined to the truncation branch of the RUNTIME action's
`self_status` op. Under-cap detail is returned byte-for-byte unchanged; only
over-cap output changes, and only to drop the final 25 characters so the string
honours its advertised bound. No public type, export, route, or schema changes.

# Background

## What does this PR do?

Fixes an off-by-suffix bug in the RUNTIME action's `self_status` op
(`packages/agent/src/actions/runtime.ts`). The handler sliced the detail text to
the configured cap and **then** appended the `\n…[self-status truncated]`
suffix (25 chars), so the returned string exceeded the cap by exactly the suffix
length: **1225 chars for the 1200-char brief contract** and **8025 for the
8000-char full contract**.

The fix reserves the suffix length out of the cap before slicing, so the final
string is always `<= maxChars`:

- Introduces `SELF_STATUS_TRUNCATION_SUFFIX` as a single constant (used by the
  slice budget and asserted by the tests).
- Slices the body to `Math.max(0, maxChars - suffix.length)`, guarding against a
  negative index if a future cap were ever smaller than the suffix, and applies
  a final `.slice(0, maxChars)` so the bound holds unconditionally.
- Computes the `data.truncated` flag from whether the raw detail exceeded the
  cap (`rawText.length > maxChars`) rather than comparing final lengths, so the
  flag stays accurate now that the final length equals the cap.

The truncation suffix remains visible in the output.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The caps and
suffix are internal implementation details of the action handler; behaviour
described to users (a truncated self-status ending in the suffix) is unchanged
except that it now honours its stated bound.

# Testing

## Where should a reviewer start?

`packages/agent/src/actions/runtime.self-status.test.ts` — three added cases
drive the real `runtimeAction.handler` with a stub `AWARENESS_REGISTRY` service
whose `getDetail` returns oversized text, at both `detailLevel: "brief"` and
`"full"`, and assert the returned `text.length` is within the cap, the suffix is
still present, and `data.truncated === true`. A fourth assertion confirms
under-cap detail is returned verbatim with `truncated === false`.

## Detailed testing steps

```bash
cd packages/agent
bunx vitest run src/actions/runtime.self-status.test.ts
```

# Evidence Gate

<!-- evidence-head:4f5f7cb3a35c87addc685569ce2da53928098c64 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface; server-side agent action handler only.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface; server-side agent action handler only.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing flow; deterministic unit test covers the contract.`
<!-- evidence-row:backend-logs -->
- [x] Test output shows the real `runtimeAction.handler` path firing for both detail levels (full self-status test file, fix applied):

```
 RUN  v4.1.5 packages/agent

 src/actions/runtime.self-status.test.ts  (6 tests)

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  02:14:13
   Duration  13.28s (transform 10.35s, setup 136ms, import 12.91s)
```
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend request/response involved.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no model call: the handler's truncation branch is pure string
      logic exercised by a deterministic stub registry (per issue guidance,
      no live model).`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact is the returned `ActionResult` string and its length. Failing-then-passing reproduction showing the exact bounds from the issue:

```
=== 1) BEFORE FIX (buggy: slice then append) — new regression tests FAIL with issue's exact lengths ===
     × caps a brief self-status result at MAX_SELF_STATUS_BRIEF_CHARS including the suffix
     × caps a full self-status result at MAX_SELF_STATUS_FULL_CHARS including the suffix
 FAIL > caps a brief self-status result ... AssertionError: expected 1225 to be less than or equal to 1200
 FAIL > caps a full self-status result ... AssertionError: expected 8025 to be less than or equal to 8000
 Test Files  1 failed (1)
      Tests  2 failed | 4 passed (6)

=== 2) AFTER FIX (suffix reserved) — full file passes ===
 Test Files  1 passed (1)
      Tests  6 passed (6)
```
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - the changed path is deterministic string truncation with no model call.`

## Backend + frontend logs

**Failing-then-passing reproduction (the added tests catch the exact bug from the issue).**

With the fix temporarily reverted to the pre-fix logic, the new assertions fail
with the exact over-cap lengths reported in the issue:

```
 × caps a brief self-status result at MAX_SELF_STATUS_BRIEF_CHARS including the suffix
   AssertionError: expected 1225 to be less than or equal to 1200
 × caps a full self-status result at MAX_SELF_STATUS_FULL_CHARS including the suffix
   AssertionError: expected 8025 to be less than or equal to 8000
 Test Files  1 failed (1)
      Tests  2 failed | 4 passed (6)
```

With the fix applied, the full file passes:

```
 RUN  v4.1.5 packages/agent

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Duration  13.59s
```

Biome check on the two changed files:

```
Checked 2 files in 36ms. No fixes applied.
```

## Screenshots (before / after) + video walkthrough

`N/A - server-side agent action handler; no rendered UI.`

## Audio / voice walkthrough

`N/A - no voice/audio surface.`

## Known gaps / failures

- `bun run --cwd packages/agent typecheck` and the root `bun run verify` do not
  pass cleanly on this machine due to **pre-existing, unrelated** errors: unbuilt
  workspace packages and generated modules (`@elizaos/cloud-routing`,
  `@elizaos/plugin-capacitor-bridge/*` type-shims, `@elizaos/plugin-wallet/diagnostic`,
  `src/runtime/optional-plugin-imports.generated.ts` referencing optional plugins
  not built in this worktree) and an `es2023` `lib` target issue in
  `plugins/plugin-agent-orchestrator`. None reference the two files changed in
  this PR — an isolated typecheck confirms `runtime.ts` and its test emit **zero**
  errors. The failures require a full workspace `bun run build` of dependent
  packages, which is an environment/toolchain state independent of this fix.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@fbc3f345caa29dc60302a7555cd8d273d35fa6b9:packages/skills/skills/contribute-to-eliza"} -->
