### PR TITLE
fix(computeruse): reject prefix-coerced action timeout

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/service.integration.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/service.integration.test.ts
@@ -22,7 +22,10 @@ import {
   startComputerUseRuntime,
   stopComputerUseRuntime,
 } from "../../test/helpers/service-runtime.ts";
-import { ComputerUseService } from "../services/computer-use-service.js";
+import {
+  ComputerUseService,
+  parseComputerUseActionTimeoutMs,
+} from "../services/computer-use-service.js";
 
 type RawActionParams = { action: string };
 
@@ -102,6 +105,54 @@ describe("ComputerUseService configuration", () => {
       actionTimeoutMs: 5000,
     });
     expect(service.getRecentActions()).toEqual([]);
+  });
+});
+
+describe("parseComputerUseActionTimeoutMs", () => {
+  it("accepts canonical positive integers", () => {
+    expect(parseComputerUseActionTimeoutMs("1")).toBe(1);
+    expect(parseComputerUseActionTimeoutMs("5000")).toBe(5000);
+    expect(parseComputerUseActionTimeoutMs("10000")).toBe(10000);
+    expect(parseComputerUseActionTimeoutMs(" 2500 ")).toBe(2500);
+  });
+
+  it("rejects prefix-numeric and non-canonical spellings that parseInt would coerce", () => {
+    for (const raw of [
+      "1e4",
+      "12px",
+      "007",
+      "5000abc",
+      "0",
+      "-1",
+      "0x10",
+      "1.5",
+      " ",
+      "",
+    ]) {
+      expect(parseComputerUseActionTimeoutMs(raw)).toBeUndefined();
+    }
+    expect(parseComputerUseActionTimeoutMs(undefined)).toBeUndefined();
+  });
+});
+
+describe("ComputerUseService configuration rejects prefix-coerced timeouts", () => {
+  let runtime: AgentRuntime;
+  let service: ComputerUseService;
+
+  beforeAll(async () => {
+    ({ runtime, service } = await startComputerUseRuntime({
+      COMPUTER_USE_ACTION_TIMEOUT_MS: "1e4",
+    }));
+  });
+
+  afterAll(async () => {
+    await stopComputerUseRuntime(runtime);
+  });
+
+  it("does not apply parseInt('1e4') === 1 as the per-action timeout", () => {
+    expect(Number.parseInt("1e4", 10)).toBe(1);
+    expect(service.getConfig().actionTimeoutMs).not.toBe(1);
+    expect(service.getConfig().actionTimeoutMs).toBe(10000);
   });
 });
 

--- a/plugins/plugin-computeruse/src/services/computer-use-service.ts
+++ b/plugins/plugin-computeruse/src/services/computer-use-service.ts
@@ -249,6 +249,25 @@ function renderPlainData(value: unknown, indent = 0): string {
   return String(value);
 }
 
+/**
+ * Canonical positive-integer parse for `COMPUTER_USE_ACTION_TIMEOUT_MS`.
+ * `Number.parseInt("1e4", 10) === 1` used to apply a 1ms per-action budget —
+ * the scientific spelling of the documented 10000ms default. Prefix junk
+ * (`12px`, `007`, `5000abc`) is the same hole. Those spellings are rejected
+ * so loadConfig keeps the default instead of silently shrinking the timeout.
+ */
+export function parseComputerUseActionTimeoutMs(
+  raw: string | undefined,
+): number | undefined {
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === "") return undefined;
+  if (!/^[1-9]\d*$/.test(trimmed)) return undefined;
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) return undefined;
+  return parsed;
+}
+
 export class ComputerUseService extends Service {
   static serviceType = "computeruse";
 
@@ -2329,11 +2348,9 @@ export class ComputerUseService extends Service {
     }
 
     const timeout = getSetting("COMPUTER_USE_ACTION_TIMEOUT_MS");
-    if (timeout) {
-      const numericTimeout = Number.parseInt(timeout, 10);
-      if (Number.isFinite(numericTimeout) && numericTimeout > 0) {
-        this.cuConfig.actionTimeoutMs = numericTimeout;
-      }
+    const parsedTimeout = parseComputerUseActionTimeoutMs(timeout);
+    if (parsedTimeout !== undefined) {
+      this.cuConfig.actionTimeoutMs = parsedTimeout;
     }
 
     const approvalMode = getSetting("COMPUTER_USE_APPROVAL_MODE");


### PR DESCRIPTION
# Relates to

Closes #20771

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `xai/grok-4.6`
<!-- attribution-row:client -->
- Agent tooling: `Cursor`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Optional config parse only. Operators already sending canonical positive
integers (`5000`, `10000`) are unchanged. Spellings that `parseInt` used to
coerce (`1e4`, `12px`, `007`) now keep the documented 10000ms default instead
of applying a 1–12ms action budget. No storage, billing, auth, or UI change.

# Background

## What does this PR do?

Reject non-canonical `COMPUTER_USE_ACTION_TIMEOUT_MS` values in
`ComputerUseService.loadConfig`.

- Missing / blank / rejected spelling → documented default `10000`
- Canonical positive integer → that timeout
- `1e4` / `12px` / `007` / `5000abc` / `0` / `-1` / `0x10` / `1.5` → keep `10000`
  (do **not** apply `parseInt`'s prefix integer)

`1e4` is the scientific spelling of the documented default and was becoming a
**1ms** per-action timeout, which aborts desktop actions before the host driver
runs.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Computer-use actions inherit `this.cuConfig.actionTimeoutMs`. A coerced 1ms
budget is not a timeout the operator asked for; it is a silent fail of every
action. Fail closed on the setting, keep the default.

# Documentation changes needed?

The plugin guide already documents the setting as a number with default 10000.
Canonical integer grammar is compatible; no doc edit in this PR.

# Testing

## Where should a reviewer start?

`plugins/plugin-computeruse/src/__tests__/service.integration.test.ts` — the
`parseComputerUseActionTimeoutMs` table and the `1e4` runtime config describe.

## Detailed testing steps

```bash
bun run --cwd plugins/plugin-computeruse test -- src/__tests__/service.integration.test.ts
```

36 passed at head `c7bfc745a25944527f228ac76ada7c8ee87a73cc`, including the
existing canonical `5000` case.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:c7bfc745a25944527f228ac76ada7c8ee87a73cc -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; config parse only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; config parse only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; config parse only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused service tests drive the real `AgentRuntime` registration path and assert `getConfig().actionTimeoutMs`; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, wallet, or generated-file writes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: `1e4` no longer sets
`actionTimeoutMs` to 1; canonical `5000` still applies.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file plugin config parse with a
green focused suite (36 tests in `service.integration.test.ts`). Full monorepo
verify is unrelated to this timeout grammar and was skipped to keep the proof
tied to the changed path.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
