### PR TITLE
fix(lifeops): preserve one-off local dates

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts
@@ -7,7 +7,8 @@
  *  2. an unresolvable (or absent) time expression yields NO cadence so the
  *     handler asks "when?" instead of scheduling an immediate fire;
  *  3. rescheduling a one-off actually moves the stored dueAt (and reports
- *     honestly when nothing changed);
+ *     honestly when nothing changed), while a time-only edit preserves the
+ *     stored zoned local date;
  *  4. LLM-extracted snooze minutes/presets and top-level `minutes` params
  *     reach the snooze handler instead of being discarded.
  */
@@ -498,6 +499,47 @@ describe("buildCadenceFromUpdateFields (once reschedule)", () => {
     expect(
       built && built.cadence.kind === "once" ? built.cadence.dueAt : null,
     ).not.toBe(currentCadence.dueAt);
+  });
+
+  it("preserves the stored local date when only the clock time changes", () => {
+    const built = buildCadenceFromUpdateFields({
+      currentCadence: {
+        kind: "once",
+        dueAt: "2026-07-03T15:00:00.000Z",
+      },
+      currentWindowPolicy,
+      timeZone: DENVER,
+      update: { ...emptyUpdate, timeOfDay: "18:00" },
+    });
+
+    // The stored instant is July 3 at 09:00 in Denver. A time-only edit must
+    // remain July 3 instead of rebuilding the reminder from fake "today."
+    expect(built?.cadence).toEqual({
+      kind: "once",
+      dueAt: "2026-07-04T00:00:00.000Z",
+    });
+  });
+
+  it("preserves the stored date across a skipped DST wall time", () => {
+    const built = buildCadenceFromUpdateFields({
+      currentCadence: {
+        kind: "once",
+        dueAt: "2026-03-08T17:00:00.000Z",
+      },
+      currentWindowPolicy: {
+        timezone: "America/Los_Angeles",
+        windows: [],
+      },
+      timeZone: "America/Los_Angeles",
+      update: { ...emptyUpdate, timeOfDay: "02:30" },
+    });
+
+    // Temporal-compatible disambiguation advances the nonexistent 02:30 to
+    // 03:30 while keeping the stored March 8 local date.
+    expect(built?.cadence).toEqual({
+      kind: "once",
+      dueAt: "2026-03-08T10:30:00.000Z",
+    });
   });
 
   it("returns null (no silent no-op) when nothing reschedulable was extracted", () => {

--- a/plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life-reminder-datetime.test.ts
@@ -542,6 +542,29 @@ describe("buildCadenceFromUpdateFields (once reschedule)", () => {
     });
   });
 
+  it("uses the stored timezone for the date when time and timezone change together", () => {
+    const built = buildCadenceFromUpdateFields({
+      currentCadence: {
+        kind: "once",
+        // July 3 at 23:00 in Los Angeles, but already July 4 in Tokyo.
+        dueAt: "2026-07-04T06:00:00.000Z",
+      },
+      currentWindowPolicy: {
+        timezone: "America/Los_Angeles",
+        windows: [],
+      },
+      timeZone: "Asia/Tokyo",
+      update: { ...emptyUpdate, timeOfDay: "09:00" },
+    });
+
+    // Preserve the stored July 3 calendar date, then interpret the requested
+    // wall time in the new timezone.
+    expect(built?.cadence).toEqual({
+      kind: "once",
+      dueAt: "2026-07-03T00:00:00.000Z",
+    });
+  });
+
   it("returns null (no silent no-op) when nothing reschedulable was extracted", () => {
     const built = buildCadenceFromUpdateFields({
       currentCadence,

--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -2869,13 +2869,24 @@ export function buildCadenceFromUpdateFields(args: {
       return dueAt ? { cadence: { kind: "once", dueAt } } : null;
     }
     if (timeOfDayMinute !== null) {
+      if (currentCadence.kind !== "once") {
+        return null;
+      }
+      const currentLocalDate = getZonedDateParts(
+        new Date(currentCadence.dueAt),
+        timeZone,
+      );
       return {
         cadence: {
           kind: "once",
-          dueAt: buildOneOffDueAtFromMinuteOfDay({
-            minuteOfDay: timeOfDayMinute,
-            timeZone,
-          }),
+          dueAt: buildUtcDateFromLocalParts(timeZone, {
+            year: currentLocalDate.year,
+            month: currentLocalDate.month,
+            day: currentLocalDate.day,
+            hour: Math.floor(timeOfDayMinute / 60),
+            minute: timeOfDayMinute % 60,
+            second: 0,
+          }).toISOString(),
         },
       };
     }

--- a/plugins/plugin-personal-assistant/src/actions/life.ts
+++ b/plugins/plugin-personal-assistant/src/actions/life.ts
@@ -2874,7 +2874,7 @@ export function buildCadenceFromUpdateFields(args: {
       }
       const currentLocalDate = getZonedDateParts(
         new Date(currentCadence.dueAt),
-        timeZone,
+        currentWindowPolicy.timezone,
       );
       return {
         cadence: {

--- a/plugins/plugin-personal-assistant/src/lifeops/definition-timezone-invariants.pglite.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/definition-timezone-invariants.pglite.integration.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Real-PGlite integration coverage for the LifeOps definition timezone
+ * invariant at create and update boundaries.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import type { RealTestRuntimeResult } from "../../test/helpers/runtime.ts";
+import { createLifeOpsTestRuntime } from "../../test/helpers/runtime.ts";
+import { LifeOpsService } from "./service.ts";
+
+const MORNING_WINDOW = {
+  name: "morning" as const,
+  label: "Morning",
+  startMinute: 480,
+  endMinute: 720,
+};
+
+describe("LifeOps definition timezone invariants (real PGlite)", () => {
+  let runtimeResult: RealTestRuntimeResult | null = null;
+
+  afterEach(async () => {
+    await runtimeResult?.cleanup();
+    runtimeResult = null;
+  });
+
+  it("rejects a mismatched window-policy timezone before create persistence", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const service = new LifeOpsService(runtimeResult.runtime);
+
+    await expect(
+      service.createDefinition({
+        kind: "task",
+        title: "Call the pharmacy",
+        timezone: "America/Los_Angeles",
+        cadence: { kind: "once", dueAt: "2026-11-04T18:00:00.000Z" },
+        windowPolicy: {
+          timezone: "UTC",
+          windows: [MORNING_WINDOW],
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: "windowPolicy.timezone must match timezone",
+      status: 400,
+    });
+
+    await expect(service.listDefinitions()).resolves.toEqual([]);
+  });
+
+  it("rejects a mismatched update and preserves the persisted definition", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const service = new LifeOpsService(runtimeResult.runtime);
+    const created = await service.createDefinition({
+      kind: "task",
+      title: "Call the pharmacy",
+      timezone: "America/Los_Angeles",
+      cadence: { kind: "once", dueAt: "2026-11-04T18:00:00.000Z" },
+      windowPolicy: {
+        timezone: "America/Los_Angeles",
+        windows: [MORNING_WINDOW],
+      },
+    });
+
+    await expect(
+      service.updateDefinition(created.definition.id, {
+        windowPolicy: {
+          timezone: "UTC",
+          windows: [MORNING_WINDOW],
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: "windowPolicy.timezone must match timezone",
+      status: 400,
+    });
+
+    await expect(service.getDefinition(created.definition.id)).resolves.toEqual(
+      expect.objectContaining({
+        definition: expect.objectContaining({
+          id: created.definition.id,
+          timezone: "America/Los_Angeles",
+          windowPolicy: expect.objectContaining({
+            timezone: "America/Los_Angeles",
+          }),
+        }),
+      }),
+    );
+
+    const moved = await service.updateDefinition(created.definition.id, {
+      timezone: "Asia/Tokyo",
+    });
+    expect(moved.definition).toMatchObject({
+      timezone: "Asia/Tokyo",
+      windowPolicy: { timezone: "Asia/Tokyo" },
+    });
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/definitions-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/definitions-service.ts
@@ -278,8 +278,16 @@ export class DefinitionsDomain {
       "timezone",
       current.definition.timezone,
     );
+    const windowPolicyInput =
+      request.windowPolicy ??
+      (request.timezone === undefined
+        ? current.definition.windowPolicy
+        : {
+            ...current.definition.windowPolicy,
+            timezone: nextTimezone,
+          });
     const nextWindowPolicy = normalizeWindowPolicyInput(
-      request.windowPolicy ?? current.definition.windowPolicy,
+      windowPolicyInput,
       "windowPolicy",
       nextTimezone,
     );

--- a/plugins/plugin-personal-assistant/src/lifeops/service-normalize-connector.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/service-normalize-connector.ts
@@ -891,6 +891,9 @@ export function normalizeWindowPolicyInput(
     `${field}.timezone`,
     timeZone,
   );
+  if (policyTimeZone !== timeZone) {
+    fail(400, `${field}.timezone must match timezone`);
+  }
   const seenNames = new Set<string>();
   const windows = input.windows.map((candidate, index) => {
     const windowInput = requireRecord(candidate, `${field}.windows[${index}]`);


### PR DESCRIPTION
## Summary

- preserve a one-off definition's stored local date when an update changes only its clock time
- when clock time and timezone change together, derive that date in the stored timezone before interpreting the requested wall time in the new timezone
- retain deterministic DST skipped-time handling
- enforce definition/window-policy timezone equality at the LifeOps domain boundary
- migrate the existing window policy when an update changes only the definition timezone

This is a scoped contribution toward #17398. It completes the local-date/timezone invariant slice; it does not claim the remaining ownership, revision, or durable operation-ledger work.

## Review repair

The draft originally derived the preserved date in the requested timezone. For instants near midnight, a simultaneous time/timezone update could therefore move the reminder to the adjacent calendar day. The repaired head derives the date from the stored window-policy timezone and adds a Los Angeles-to-Tokyo regression spanning different local dates.

## Exact-head verification

Head: `1441d307345cf941294e1b3a645f7236b6d13bbc`

- datetime suite under the package Vitest config: 134 passed
- real-PGlite timezone invariant suite: 2 passed
- personal-assistant typecheck: passed
- Biome on all five changed files: passed
- `git diff --check`: passed
- full `bun run verify` on the source-equivalent pre-final-rebase head: 356/356 workspace tasks and all repository audits passed; the final rebase added only unrelated integrated develop commits, then both affected suites/typecheck/lint were rerun on the exact head

## Evidence

Backend-only scheduling and persistence invariants. Screenshots, mobile captures, walkthrough, frontend logs, OCR, and live-model trajectory are N/A. The PGlite suite proves mismatched create/update requests fail before persistence changes and a timezone-only update keeps definition and window policy aligned.

Relates #17398

<!-- evidence-head:1441d307345cf941294e1b3a645f7236b6d13bbc -->

- [datetime test log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20774-17398-rebased-datetime-tests.log)
- [PGlite test log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20774-17398-rebased-pglite-tests.log)