### PR TITLE
fix(agent): reject prefix-coerced inbox limit query

### DIFF
--- a/packages/agent/src/api/inbox-limit-query.test.ts
+++ b/packages/agent/src/api/inbox-limit-query.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Regression coverage for the untrusted `limit` query on
+ * `GET /api/inbox/messages`. The handler must reject non-canonical integers
+ * before it reads inbox state, while preserving the default and hard cap.
+ */
+import type http from "node:http";
+import type { AgentRuntime, RouteHelpers, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { handleInboxRoute } from "./inbox-routes";
+
+// Messages route lazily imports the connector plugin for avatar caching.
+// This suite only exercises the untrusted `limit` query.
+vi.mock("@elizaos/plugin-discord", () => ({
+  cacheDiscordAvatarUrl: async (avatarUrl: string | undefined) => avatarUrl,
+}));
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const ROOM_ID = "11111111-1111-1111-1111-111111111111" as UUID;
+const res = {} as http.ServerResponse;
+
+function makeHelpers() {
+  const json = vi.fn();
+  const error = vi.fn();
+  const readJsonBody = vi.fn();
+  return {
+    helpers: { json, error, readJsonBody } as RouteHelpers,
+    json,
+    error,
+  };
+}
+
+function makeRuntime() {
+  const getRoom = vi.fn(async () => ({
+    id: ROOM_ID,
+    name: "Inbox",
+    source: "discord",
+  }));
+  const getMemories = vi.fn(async () => []);
+  const runtime = {
+    agentId: AGENT_ID,
+    getRoom,
+    getMemories,
+    getService: () => null,
+  } as unknown as AgentRuntime;
+  return { runtime, getRoom, getMemories };
+}
+
+async function requestInboxLimit(raw?: string) {
+  const { runtime, getRoom, getMemories } = makeRuntime();
+  const { helpers, json, error } = makeHelpers();
+  const query = raw === undefined ? "" : `&limit=${encodeURIComponent(raw)}`;
+  const url = `/api/inbox/messages?roomId=${ROOM_ID}&sources=discord${query}`;
+  const handled = await handleInboxRoute(
+    { url } as http.IncomingMessage,
+    res,
+    "/api/inbox/messages",
+    "GET",
+    { runtime },
+    helpers,
+  );
+  return { handled, getRoom, getMemories, json, error };
+}
+
+describe("GET /api/inbox/messages limit query", () => {
+  it.each([
+    "1e3",
+    "50abc",
+    "0x10",
+    "50.5",
+    "abc",
+    "-1",
+    "1_000",
+    "+5",
+    " 5",
+    "5 ",
+    "0",
+    "Infinity",
+    "NaN",
+    "01",
+    "9007199254740992",
+  ])("rejects malformed limit %j before reading inbox state", async (raw) => {
+    const result = await requestInboxLimit(raw);
+
+    expect(result.handled).toBe(true);
+    expect(result.error).toHaveBeenCalledWith(
+      res,
+      "limit must be a positive integer",
+      400,
+    );
+    expect(result.json).not.toHaveBeenCalled();
+    expect(result.getRoom).not.toHaveBeenCalled();
+    expect(result.getMemories).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [undefined, 100],
+    ["", 100],
+    ["25", 25],
+    ["500", 500],
+    ["501", 500],
+  ] as const)("accepts limit %j as %s", async (raw, expected) => {
+    const result = await requestInboxLimit(raw);
+
+    expect(result.handled).toBe(true);
+    expect(result.error).not.toHaveBeenCalled();
+    expect(result.getRoom).toHaveBeenCalledWith(ROOM_ID);
+    expect(result.getMemories).toHaveBeenCalledWith({
+      tableName: "messages",
+      roomId: ROOM_ID,
+      limit: expected * 3,
+      unique: false,
+    });
+    expect(result.json).toHaveBeenCalledWith(res, { messages: [], count: 0 });
+  });
+});

--- a/packages/agent/src/api/inbox-limit-query.test.ts
+++ b/packages/agent/src/api/inbox-limit-query.test.ts
@@ -61,6 +61,21 @@ async function requestInboxLimit(raw?: string) {
   return { handled, getRoom, getMemories, json, error };
 }
 
+async function requestInboxLimitNoRuntime(raw?: string) {
+  const { helpers, json, error } = makeHelpers();
+  const query = raw === undefined ? "" : `&limit=${encodeURIComponent(raw)}`;
+  const url = `/api/inbox/messages?roomId=${ROOM_ID}&sources=discord${query}`;
+  const handled = await handleInboxRoute(
+    { url } as http.IncomingMessage,
+    res,
+    "/api/inbox/messages",
+    "GET",
+    { runtime: null },
+    helpers,
+  );
+  return { handled, json, error };
+}
+
 describe("GET /api/inbox/messages limit query", () => {
   it.each([
     "1e3",
@@ -112,4 +127,30 @@ describe("GET /api/inbox/messages limit query", () => {
     });
     expect(result.json).toHaveBeenCalledWith(res, { messages: [], count: 0 });
   });
+
+  it.each(["1e3", "50abc", "0x10", "0", "01"])(
+    "rejects malformed limit %j with 400 when runtime is unavailable",
+    async (raw) => {
+      const result = await requestInboxLimitNoRuntime(raw);
+
+      expect(result.handled).toBe(true);
+      expect(result.error).toHaveBeenCalledWith(
+        res,
+        "limit must be a positive integer",
+        400,
+      );
+      expect(result.json).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([undefined, "", "25"] as const)(
+    "keeps the empty inbox response for limit %j when runtime is unavailable",
+    async (raw) => {
+      const result = await requestInboxLimitNoRuntime(raw);
+
+      expect(result.handled).toBe(true);
+      expect(result.error).not.toHaveBeenCalled();
+      expect(result.json).toHaveBeenCalledWith(res, { messages: [], count: 0 });
+    },
+  );
 });

--- a/packages/agent/src/api/inbox-routes.ts
+++ b/packages/agent/src/api/inbox-routes.ts
@@ -242,13 +242,14 @@ type ReactionAggregateState = {
 };
 
 /**
- * Parse and clamp the `limit` query parameter. Defaults to 100, capped
- * at 500. Non-numeric input is treated as the default.
+ * Parse and clamp the `limit` query parameter. Defaults to 100 and caps
+ * canonical positive decimal integers at 500.
  */
-function parseLimit(raw: string | null): number {
-  if (!raw) return 100;
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) return 100;
+function parseLimit(raw: string | null): number | null {
+  if (raw === null || raw === "") return 100;
+  if (!/^[1-9]\d*$/.test(raw)) return null;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed)) return null;
   return Math.min(parsed, 500);
 }
 
@@ -2583,6 +2584,10 @@ export async function handleInboxRoute(
 
     const url = new URL(req.url ?? pathname, "http://localhost");
     const limit = parseLimit(url.searchParams.get("limit"));
+    if (limit === null) {
+      helpers.error(res, "limit must be a positive integer", 400);
+      return true;
+    }
     const explicitFilter = parseSourceFilter(url.searchParams.get("sources"));
     const sourceFilter = explicitFilter ?? DEFAULT_INBOX_SOURCES;
     // Optional roomId scope. When the messages view has a

--- a/packages/agent/src/api/inbox-routes.ts
+++ b/packages/agent/src/api/inbox-routes.ts
@@ -2576,12 +2576,6 @@ export async function handleInboxRoute(
 
   // ── GET /api/inbox/messages ───────────────────────────────────────
   if (method === "GET" && pathname === "/api/inbox/messages") {
-    const runtime = state.runtime;
-    if (!runtime) {
-      helpers.json(res, { messages: [], count: 0 });
-      return true;
-    }
-
     const url = new URL(req.url ?? pathname, "http://localhost");
     const limit = parseLimit(url.searchParams.get("limit"));
     if (limit === null) {
@@ -2601,6 +2595,12 @@ export async function handleInboxRoute(
     const roomId = roomIdParam.length > 0 ? (roomIdParam as UUID) : null;
     const roomSourceParam = url.searchParams.get("roomSource")?.trim() ?? "";
     const roomSourceHint = roomSourceParam.length > 0 ? roomSourceParam : null;
+
+    const runtime = state.runtime;
+    if (!runtime) {
+      helpers.json(res, { messages: [], count: 0 });
+      return true;
+    }
 
     try {
       const messages = await loadInboxMessages(


### PR DESCRIPTION
## Summary

Rejects malformed `limit` query values on `GET /api/inbox/messages` before the route reads inbox state. Omitted or empty values retain the default of 100; canonical positive integers remain capped at 500. Validation also runs while the agent runtime is unavailable so malformed requests do not receive a fabricated empty-success response.

Closes #20776.

## Verification

Exact head: `b5c86693736c57d758830bc4a83fc9ca64e8c191`.

- Real inbox route suite: 28/28 passed, covering malformed, default, capped, and runtime-unavailable cases.
- Agent typecheck and Biome checks passed.
- `bun run verify`: 356/356 Turbo tasks passed; repository audits passed; anti-larp scanned 8,413 test files with no focused or orphaned skipped tests.

## Evidence

<!-- evidence-head:b5c86693736c57d758830bc4a83fc9ca64e8c191 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend query validation; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend query validation; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic HTTP route behavior.
<!-- evidence-row:backend-logs -->
- [x] [20777-pr20777-focused.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20777-pr20777-focused.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model path changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered surface changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6; OpenAI Codex
<!-- attribution-row:client -->
- Agent tooling: Cursor; Codex
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

