### PR TITLE
fix(agent): reject prefix-coerced PTY disconnect grace

### DIFF
--- a/packages/agent/src/api/pty-ws-bridge.test.ts
+++ b/packages/agent/src/api/pty-ws-bridge.test.ts
@@ -242,4 +242,13 @@ describe("resolvePtyDisconnectGraceMs", () => {
     expect(resolvePtyDisconnectGraceMs("0")).toBe(0);
     expect(resolvePtyDisconnectGraceMs("15000")).toBe(15_000);
   });
+
+  it.each(["1e4", "12px", "007", "0x10", "1.5", "15000abc"] as const)(
+    "keeps the documented default for prefix-coerced %j (does not apply parseInt)",
+    (raw) => {
+      expect(resolvePtyDisconnectGraceMs(raw)).toBe(
+        DEFAULT_PTY_DISCONNECT_GRACE_MS,
+      );
+    },
+  );
 });

--- a/packages/agent/src/api/pty-ws-bridge.test.ts
+++ b/packages/agent/src/api/pty-ws-bridge.test.ts
@@ -13,6 +13,7 @@ import {
   attachPtySessionWsBridge,
   cancelPendingPtySessionStop,
   DEFAULT_PTY_DISCONNECT_GRACE_MS,
+  MAX_PTY_DISCONNECT_GRACE_MS,
   type PtyWsFrame,
   resolvePtyDisconnectGraceMs,
   schedulePtySessionStopAfterGrace,
@@ -241,7 +242,19 @@ describe("resolvePtyDisconnectGraceMs", () => {
   it("honors explicit values, including 0 (legacy stop-on-close)", () => {
     expect(resolvePtyDisconnectGraceMs("0")).toBe(0);
     expect(resolvePtyDisconnectGraceMs("15000")).toBe(15_000);
+    expect(resolvePtyDisconnectGraceMs("2147483647")).toBe(
+      MAX_PTY_DISCONNECT_GRACE_MS,
+    );
   });
+
+  it.each(["2147483648", "9007199254740991"] as const)(
+    "keeps the documented default for timer-overflow %j (Node would schedule ~1ms)",
+    (raw) => {
+      expect(resolvePtyDisconnectGraceMs(raw)).toBe(
+        DEFAULT_PTY_DISCONNECT_GRACE_MS,
+      );
+    },
+  );
 
   it.each(["1e4", "12px", "007", "0x10", "1.5", "15000abc"] as const)(
     "keeps the documented default for prefix-coerced %j (does not apply parseInt)",

--- a/packages/agent/src/api/pty-ws-bridge.ts
+++ b/packages/agent/src/api/pty-ws-bridge.ts
@@ -30,6 +30,9 @@ export const MAX_PTY_INPUT_MESSAGE_LENGTH = 4096;
 /** Grace window before a disconnected client's PTY sessions are stopped. */
 export const DEFAULT_PTY_DISCONNECT_GRACE_MS = 30_000;
 
+/** Node timer ceiling. Larger values schedule at ~1ms and reap immediately. */
+export const MAX_PTY_DISCONNECT_GRACE_MS = 2_147_483_647;
+
 /**
  * Parses `ELIZA_PTY_WS_DISCONNECT_GRACE_MS`-style overrides. Empty/absent or
  * unparseable/negative values fall back to the default; `0` is honored as
@@ -38,7 +41,9 @@ export const DEFAULT_PTY_DISCONNECT_GRACE_MS = 30_000;
  * Only a canonical non-negative decimal integer is accepted. Prefix-coercing
  * spellings (`1e4`, `12px`, `007`) must not become a 1–12ms reap window —
  * `Number.parseInt("1e4", 10) === 1` would kill the dashboard terminal on the
- * first phone-lock blip the grace was added to survive.
+ * first phone-lock blip the grace was added to survive. Values above the Node
+ * timer ceiling (`2_147_483_647`) also keep the default: `setTimeout` would
+ * otherwise schedule them at approximately 1ms.
  */
 export function resolvePtyDisconnectGraceMs(raw: string | undefined): number {
   if (raw === undefined || raw.trim() === "") {
@@ -52,7 +57,11 @@ export function resolvePtyDisconnectGraceMs(raw: string | undefined): number {
     return DEFAULT_PTY_DISCONNECT_GRACE_MS;
   }
   const parsed = Number(trimmed);
-  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+  if (
+    !Number.isSafeInteger(parsed) ||
+    parsed < 1 ||
+    parsed > MAX_PTY_DISCONNECT_GRACE_MS
+  ) {
     return DEFAULT_PTY_DISCONNECT_GRACE_MS;
   }
   return parsed;

--- a/packages/agent/src/api/pty-ws-bridge.ts
+++ b/packages/agent/src/api/pty-ws-bridge.ts
@@ -34,16 +34,9 @@ export const DEFAULT_PTY_DISCONNECT_GRACE_MS = 30_000;
 export const MAX_PTY_DISCONNECT_GRACE_MS = 2_147_483_647;
 
 /**
- * Parses `ELIZA_PTY_WS_DISCONNECT_GRACE_MS`-style overrides. Empty/absent or
- * unparseable/negative values fall back to the default; `0` is honored as
- * "no grace" (legacy stop-on-close behavior).
- *
- * Only a canonical non-negative decimal integer is accepted. Prefix-coercing
- * spellings (`1e4`, `12px`, `007`) must not become a 1–12ms reap window —
- * `Number.parseInt("1e4", 10) === 1` would kill the dashboard terminal on the
- * first phone-lock blip the grace was added to survive. Values above the Node
- * timer ceiling (`2_147_483_647`) also keep the default: `setTimeout` would
- * otherwise schedule them at approximately 1ms.
+ * Parses a canonical non-negative decimal disconnect-grace override. Invalid
+ * values and values above Node's timer ceiling retain the documented default;
+ * `0` explicitly requests stop-on-close behavior.
  */
 export function resolvePtyDisconnectGraceMs(raw: string | undefined): number {
   if (raw === undefined || raw.trim() === "") {

--- a/packages/agent/src/api/pty-ws-bridge.ts
+++ b/packages/agent/src/api/pty-ws-bridge.ts
@@ -34,13 +34,25 @@ export const DEFAULT_PTY_DISCONNECT_GRACE_MS = 30_000;
  * Parses `ELIZA_PTY_WS_DISCONNECT_GRACE_MS`-style overrides. Empty/absent or
  * unparseable/negative values fall back to the default; `0` is honored as
  * "no grace" (legacy stop-on-close behavior).
+ *
+ * Only a canonical non-negative decimal integer is accepted. Prefix-coercing
+ * spellings (`1e4`, `12px`, `007`) must not become a 1–12ms reap window —
+ * `Number.parseInt("1e4", 10) === 1` would kill the dashboard terminal on the
+ * first phone-lock blip the grace was added to survive.
  */
 export function resolvePtyDisconnectGraceMs(raw: string | undefined): number {
   if (raw === undefined || raw.trim() === "") {
     return DEFAULT_PTY_DISCONNECT_GRACE_MS;
   }
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed < 0) {
+  const trimmed = raw.trim();
+  if (trimmed === "0") {
+    return 0;
+  }
+  if (!/^[1-9]\d*$/.test(trimmed)) {
+    return DEFAULT_PTY_DISCONNECT_GRACE_MS;
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
     return DEFAULT_PTY_DISCONNECT_GRACE_MS;
   }
   return parsed;


### PR DESCRIPTION
## Summary

Rejects prefix-coerced and timer-overflow values for the optional PTY WebSocket disconnect grace. Canonical non-negative decimal values remain supported, including explicit `0`; invalid values retain the documented 30-second default.

Closes #20778.

## Verification

Exact head: `57b1d7452fefeab3131faff4cf6d72a897a35c66`.

- PTY WebSocket bridge suite: 21/21 passed, including canonical, prefix-coerced, and Node timer-ceiling cases.
- Agent typecheck and Biome checks passed.
- `bun run verify`: 356/356 Turbo tasks passed; repository audits passed; anti-larp scanned 8,409 test files with no focused or orphaned skipped tests.

## Evidence

<!-- evidence-head:57b1d7452fefeab3131faff4cf6d72a897a35c66 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend configuration parsing; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend configuration parsing; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic parser behavior.
<!-- evidence-row:backend-logs -->
- [x] [20779-pr20779-focused.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20779-pr20779-focused.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model path changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered surface changed.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6; OpenAI Codex
<!-- attribution-row:client -->
- Agent tooling: Cursor; Codex
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

