### PR TITLE
fix(app-core): reject prefix-coerced database-rows page

### DIFF
--- a/packages/app-core/src/api/database-rows-compat-routes.test.ts
+++ b/packages/app-core/src/api/database-rows-compat-routes.test.ts
@@ -392,3 +392,121 @@ describe("GET /api/database/tables/:name/rows OWNER gate", () => {
     });
   });
 });
+
+describe("GET /api/database/tables/:name/rows limit/offset query", () => {
+  it.each([
+    "1e2",
+    "12px",
+    "007",
+    "-1",
+    "50abc",
+    "0",
+    "0x10",
+    "50.5",
+    "+5",
+    " 5",
+    "5 ",
+    "Infinity",
+    "NaN",
+    "9007199254740992",
+  ])("rejects malformed limit %j before any SQL", async (raw) => {
+    const req = makeReq(
+      {},
+      `/api/database/tables/secrets/rows?schema=public&limit=${encodeURIComponent(raw)}`,
+    );
+    const res = fakeRes();
+    const ensureOwner = vi.fn(async () => true);
+
+    await expect(
+      handleDatabaseRowsCompatRoute(req, res.res, STATE_WITH_DB, {
+        ensureOwner,
+      }),
+    ).resolves.toBe(true);
+
+    expect(res.status()).toBe(400);
+    expect(res.json()).toEqual({ error: "limit must be a positive integer" });
+    expect(mocks.executeRawSql).not.toHaveBeenCalled();
+  });
+
+  it.each(["1e2", "12px", "007", "-1", "0x10", "1.5", "+0", " 0"])(
+    "rejects malformed offset %j before any SQL",
+    async (raw) => {
+      const req = makeReq(
+        {},
+        `/api/database/tables/secrets/rows?schema=public&offset=${encodeURIComponent(raw)}`,
+      );
+      const res = fakeRes();
+      const ensureOwner = vi.fn(async () => true);
+
+      await expect(
+        handleDatabaseRowsCompatRoute(req, res.res, STATE_WITH_DB, {
+          ensureOwner,
+        }),
+      ).resolves.toBe(true);
+
+      expect(res.status()).toBe(400);
+      expect(res.json()).toEqual({
+        error: "offset must be a non-negative integer",
+      });
+      expect(mocks.executeRawSql).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    [undefined, 50, 0],
+    ["", 50, 0],
+    ["25", 25, 0],
+    ["500", 500, 0],
+    ["501", 500, 0],
+  ] as const)("accepts limit %j as %s", async (raw, expectedLimit, expectedOffset) => {
+    stubReadableTable();
+    const query =
+      raw === undefined
+        ? "/api/database/tables/secrets/rows?schema=public"
+        : `/api/database/tables/secrets/rows?schema=public&limit=${encodeURIComponent(raw)}`;
+    const req = makeReq({}, query);
+    const res = fakeRes();
+    const ensureOwner = vi.fn(async () => true);
+
+    await expect(
+      handleDatabaseRowsCompatRoute(req, res.res, STATE_WITH_DB, {
+        ensureOwner,
+      }),
+    ).resolves.toBe(true);
+
+    expect(res.status()).toBe(200);
+    expect(res.json()).toMatchObject({
+      limit: expectedLimit,
+      offset: expectedOffset,
+    });
+    expect(
+      mocks.executeRawSql.mock.calls.some(([, sql]) =>
+        String(sql).includes(`LIMIT ${expectedLimit}`),
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts canonical offset 0 and 10", async () => {
+    stubReadableTable();
+    const req = makeReq(
+      {},
+      "/api/database/tables/secrets/rows?schema=public&limit=25&offset=10",
+    );
+    const res = fakeRes();
+    const ensureOwner = vi.fn(async () => true);
+
+    await expect(
+      handleDatabaseRowsCompatRoute(req, res.res, STATE_WITH_DB, {
+        ensureOwner,
+      }),
+    ).resolves.toBe(true);
+
+    expect(res.status()).toBe(200);
+    expect(res.json()).toMatchObject({ limit: 25, offset: 10 });
+    expect(
+      mocks.executeRawSql.mock.calls.some(([, sql]) =>
+        String(sql).includes("OFFSET 10"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/app-core/src/api/database-rows-compat-routes.test.ts
+++ b/packages/app-core/src/api/database-rows-compat-routes.test.ts
@@ -458,33 +458,36 @@ describe("GET /api/database/tables/:name/rows limit/offset query", () => {
     ["25", 25, 0],
     ["500", 500, 0],
     ["501", 500, 0],
-  ] as const)("accepts limit %j as %s", async (raw, expectedLimit, expectedOffset) => {
-    stubReadableTable();
-    const query =
-      raw === undefined
-        ? "/api/database/tables/secrets/rows?schema=public"
-        : `/api/database/tables/secrets/rows?schema=public&limit=${encodeURIComponent(raw)}`;
-    const req = makeReq({}, query);
-    const res = fakeRes();
-    const ensureOwner = vi.fn(async () => true);
+  ] as const)(
+    "accepts limit %j as %s",
+    async (raw, expectedLimit, expectedOffset) => {
+      stubReadableTable();
+      const query =
+        raw === undefined
+          ? "/api/database/tables/secrets/rows?schema=public"
+          : `/api/database/tables/secrets/rows?schema=public&limit=${encodeURIComponent(raw)}`;
+      const req = makeReq({}, query);
+      const res = fakeRes();
+      const ensureOwner = vi.fn(async () => true);
 
-    await expect(
-      handleDatabaseRowsCompatRoute(req, res.res, STATE_WITH_DB, {
-        ensureOwner,
-      }),
-    ).resolves.toBe(true);
+      await expect(
+        handleDatabaseRowsCompatRoute(req, res.res, STATE_WITH_DB, {
+          ensureOwner,
+        }),
+      ).resolves.toBe(true);
 
-    expect(res.status()).toBe(200);
-    expect(res.json()).toMatchObject({
-      limit: expectedLimit,
-      offset: expectedOffset,
-    });
-    expect(
-      mocks.executeRawSql.mock.calls.some(([, sql]) =>
-        String(sql).includes(`LIMIT ${expectedLimit}`),
-      ),
-    ).toBe(true);
-  });
+      expect(res.status()).toBe(200);
+      expect(res.json()).toMatchObject({
+        limit: expectedLimit,
+        offset: expectedOffset,
+      });
+      expect(
+        mocks.executeRawSql.mock.calls.some(([, sql]) =>
+          String(sql).includes(`LIMIT ${expectedLimit}`),
+        ),
+      ).toBe(true);
+    },
+  );
 
   it("accepts canonical offset 0 and 10", async () => {
     stubReadableTable();

--- a/packages/app-core/src/api/database-rows-compat-routes.ts
+++ b/packages/app-core/src/api/database-rows-compat-routes.ts
@@ -45,6 +45,31 @@ const tableIntrospectionCache = new Map<string, TableIntrospection>();
 const TABLE_INTROSPECTION_TTL_MS = 30_000;
 const TABLE_INTROSPECTION_CACHE_LIMIT = 256;
 
+/**
+ * Parse the untrusted `limit` query. Defaults to 50 and caps canonical
+ * positive decimal integers at 500. Prefix-numeric junk must not become a
+ * different OWNER page size (`1e2` → 1 via parseInt).
+ */
+function parseDatabaseRowsLimit(raw: string | null): number | null {
+  if (raw === null || raw === "") return 50;
+  if (!/^[1-9]\d*$/.test(raw)) return null;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed)) return null;
+  return Math.min(parsed, 500);
+}
+
+/**
+ * Parse the untrusted `offset` query. Defaults to 0. Reject leading zeros,
+ * signs, hex, scientific notation, and other parseInt prefix forms.
+ */
+function parseDatabaseRowsOffset(raw: string | null): number | null {
+  if (raw === null || raw === "") return 0;
+  if (!/^(0|[1-9]\d*)$/.test(raw)) return null;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed)) return null;
+  return parsed;
+}
+
 function rememberTableIntrospection(
   key: string,
   resolvedSchema: string,
@@ -96,6 +121,17 @@ export async function handleDatabaseRowsCompatRoute(
 
   if (!tableName) {
     sendJsonErrorResponse(res, 400, "Invalid table name");
+    return true;
+  }
+
+  const limit = parseDatabaseRowsLimit(requestUrl.searchParams.get("limit"));
+  const offset = parseDatabaseRowsOffset(requestUrl.searchParams.get("offset"));
+  if (limit === null) {
+    sendJsonErrorResponse(res, 400, "limit must be a positive integer");
+    return true;
+  }
+  if (offset === null) {
+    sendJsonErrorResponse(res, 400, "offset must be a non-negative integer");
     return true;
   }
 
@@ -180,19 +216,6 @@ export async function handleDatabaseRowsCompatRoute(
     );
   }
 
-  const parsedLimit = Number.parseInt(
-    requestUrl.searchParams.get("limit") ?? "",
-    10,
-  );
-  const parsedOffset = Number.parseInt(
-    requestUrl.searchParams.get("offset") ?? "",
-    10,
-  );
-  const limit = Math.max(
-    1,
-    Math.min(500, Number.isNaN(parsedLimit) ? 50 : parsedLimit),
-  );
-  const offset = Math.max(0, Number.isNaN(parsedOffset) ? 0 : parsedOffset);
   const sortColumn = sanitizeIdentifier(requestUrl.searchParams.get("sort"));
   const order =
     requestUrl.searchParams.get("order") === "desc" ? "DESC" : "ASC";


### PR DESCRIPTION
# Relates to

Closes #20783

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Query-parse only on the OWNER dashboard table-browser route. Canonical
positive integers and omitted/blank `limit` (default 50, cap 500) / `offset`
(default 0) are unchanged. Prefix-numeric junk now 400s before any SQL.
No storage, billing, or UI change.

# Background

## What does this PR do?

Reject non-canonical `limit` / `offset` query values in
`handleDatabaseRowsCompatRoute` **before** table introspection.

- Missing / blank `limit` → documented default `50`
- Canonical positive integer → that limit, capped at `500`
- Missing / blank `offset` → `0`
- `1e2` / `12px` / `007` / `0` / `-1` / `0x10` → **400** (do **not** apply
  `parseInt`'s prefix)

`1e2` is the scientific spelling of 100 and was becoming a **1-row** OWNER
`SELECT *` page.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

This route is OWNER-gated because raw table reads can expose secrets and
sessions. A coerced 1-row window is not the page the operator asked for.
Fail closed on the query; keep defaults when it is omitted.

Disjoint from computer-use timeout (#20772), inbox messages `limit` (#20777),
PTY disconnect grace (#20779), and the cloud numeric/date/tail series.

# Documentation changes needed?

The file header already documents paginated searchable rows. Canonical integer
grammar is compatible; no doc edit in this PR.

# Testing

## Where should a reviewer start?

`packages/app-core/src/api/database-rows-compat-routes.test.ts` — new
limit/offset tables plus existing OWNER-gate and `DB_COUNT_UNAVAILABLE` cases.

## Detailed testing steps

```bash
cd packages/app-core && bunx vitest run --config vitest.config.ts src/api/database-rows-compat-routes.test.ts --coverage.enabled=false
```

34 passed at head `50eb711c076b20295f4e84346c03b5e5059c5b50`. Red on stock
`parseInt` was 22 failed / 12 passed.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.
<!-- evidence-head:50eb711c076b20295f4e84346c03b5e5059c5b50 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; query parse only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; query parse only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; query parse only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real handler and assert `executeRawSql` is not called on rejected pagination; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB writes; read-only table browser parse.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: `1e2` no longer
applies a 1-row OWNER page; canonical `25` / `offset=10` still apply.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file app-core query parse with a
green focused suite (34 tests in `database-rows-compat-routes.test.ts`). Full
monorepo verify is unrelated to this pagination grammar and was skipped to
keep the proof tied to the changed path.

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->


## Independent exact-head review

The parser rejects noncanonical and unsafe values before SQL, preserves OWNER authorization ordering, caps limit at 500, and accepts canonical offset zero. Final head is rebased onto current develop. Exact-head verification passed: database rows route 34/34, app-core typecheck, focused Biome, and diff checks.
