### PR TITLE
fix(calendar): reuse linear attendee email validation

### DIFF
--- a/plugins/plugin-calendar/src/actions/calendar-attendees.test.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-attendees.test.ts
@@ -1,8 +1,6 @@
 /**
- * Planner-arg attendee sanitization: invented non-email attendees ("lunch with
- * dana" → {email: "dana"}) must be dropped, not forwarded to the calendar
- * service where the strict boundary validator 400s the whole create.
- * Deterministic unit harness over the exported normalizer.
+ * Deterministic coverage for attendee sanitization at the planner-output
+ * boundary, before strict calendar-service validation.
  */
 
 import { describe, expect, it } from "vitest";

--- a/plugins/plugin-calendar/src/actions/calendar-handler.ts
+++ b/plugins/plugin-calendar/src/actions/calendar-handler.ts
@@ -65,6 +65,7 @@ import {
   ELIZA_CALENDAR_GRANT_ID,
   ELIZA_CALENDAR_PROVIDER,
 } from "../internal/eliza-calendar.js";
+import { basicEmailValid } from "../internal/email.js";
 import { CalendarServiceError } from "../internal/errors.js";
 import {
   formatCalendarEventDateTime,
@@ -3613,18 +3614,6 @@ export function formatCalendarSearchResults(
   return lines.join("\n");
 }
 
-/**
- * The planner routinely invents attendees from bare names in the request
- * ("lunch with dana" → {email: "dana"}). The calendar service boundary
- * strict-400s any non-email attendee, which failed the WHOLE create for an
- * event that never needed the invite (live: "add lunch with dana thursday
- * noon" → CALENDAR_SERVICE_400 attendees[0].email). Planner output is
- * untrusted, so this normalizer DROPS non-email attendees instead of
- * forwarding them to die at the service; the service validator keeps its
- * strict contract for direct API callers.
- */
-const CALENDAR_ATTENDEE_EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
-
 export function normalizeCalendarAttendees(
   details: Record<string, unknown> | undefined,
 ): CreateLifeOpsCalendarEventAttendee[] | undefined {
@@ -3636,7 +3625,7 @@ export function normalizeCalendarAttendees(
     attendees.map((attendee) => {
       if (typeof attendee === "string") {
         const email = attendee.trim();
-        return CALENDAR_ATTENDEE_EMAIL_RE.test(email) ? { email } : null;
+        return basicEmailValid(email) ? { email } : null;
       }
       if (
         !attendee ||
@@ -3647,8 +3636,7 @@ export function normalizeCalendarAttendees(
       }
       const record = attendee as Record<string, unknown>;
       const email =
-        typeof record.email === "string" &&
-        CALENDAR_ATTENDEE_EMAIL_RE.test(record.email.trim())
+        typeof record.email === "string" && basicEmailValid(record.email.trim())
           ? record.email.trim()
           : null;
       if (!email) {


### PR DESCRIPTION
## Summary

Follow-up to #20759. The attendee sanitizer correctly drops planner-invented bare names, but its newly introduced regular expression can backtrack quadratically on long untrusted planner values. The calendar plugin already has a linear-time validator with the same accepted email shape, so this reuses that implementation instead of maintaining a second validator.

Closes #20773.

## Changes

- Reuse `basicEmailValid` at the planner attendee boundary.
- Remove the duplicate backtracking regular expression.
- Keep the accepted email shape unchanged.

## Exact-head verification

Head: `d8c9918960f14c7151a104f007389202fdeda66c` rebased onto current `origin/develop`.

- Focused attendee suite: 3/3 passed.
- Calendar typecheck: passed.
- Biome on both changed files: passed.
- `git diff --check`: passed.
- The pre-rebase source-equivalent head also passed the full 601-test calendar suite, package build, and 356-task repository verify; those broader results are retained as supporting but not exact-head evidence.

## Evidence

Backend-only deterministic input validation; screenshots, walkthrough, frontend logs, OCR, and live-model trajectory are N/A. The focused suite exercises the planner-output normalizer directly.

<!-- evidence-head:d8c9918960f14c7151a104f007389202fdeda66c -->

AI assistance: yes  
Model: OpenAI Codex  
Agent tooling: Codex  
Provenance status: self-reported