### PR TITLE
fix(cloud): allow gateway JWT bootstrap through Railway health cutover

### DIFF
--- a/.github/workflows/deploy-gateway-webhook.yml
+++ b/.github/workflows/deploy-gateway-webhook.yml
@@ -371,14 +371,14 @@ jobs:
             .[0].meta.fileServiceManifest.build.dockerfilePath ==
               "packages/cloud/services/gateway-webhook/Dockerfile" and
             .[0].meta.fileServiceManifest.deploy.healthcheckPath == "/health" and
-            .[0].meta.fileServiceManifest.deploy.healthcheckTimeout == 30 and
+            .[0].meta.fileServiceManifest.deploy.healthcheckTimeout == 90 and
             .[0].meta.fileServiceManifest.deploy.restartPolicyType == "ON_FAILURE" and
             .[0].meta.fileServiceManifest.deploy.restartPolicyMaxRetries == 10 and
             .[0].meta.serviceManifest.build.builder == "DOCKERFILE" and
             .[0].meta.serviceManifest.build.dockerfilePath ==
               "packages/cloud/services/gateway-webhook/Dockerfile" and
             .[0].meta.serviceManifest.deploy.healthcheckPath == "/health" and
-            .[0].meta.serviceManifest.deploy.healthcheckTimeout == 30 and
+            .[0].meta.serviceManifest.deploy.healthcheckTimeout == 90 and
             .[0].meta.serviceManifest.deploy.restartPolicyType == "ON_FAILURE" and
             .[0].meta.serviceManifest.deploy.restartPolicyMaxRetries == 10
           ' "$deployment_meta_path" >/dev/null || {

--- a/packages/cloud/services/gateway-webhook/railway.toml
+++ b/packages/cloud/services/gateway-webhook/railway.toml
@@ -30,6 +30,9 @@ dockerfilePath = "packages/cloud/services/gateway-webhook/Dockerfile"
 
 [deploy]
 healthcheckPath = "/health"
-healthcheckTimeout = 30
+# JWT bootstrap is crash-only and may exhaust the bounded restart budget before
+# a replacement can become healthy; the platform health window must encompass
+# that budget without weakening startup authentication.
+healthcheckTimeout = 90
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10

--- a/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
@@ -19,6 +19,10 @@ const workflowPath = new URL(
   repoRoot,
 );
 const source = readFileSync(workflowPath, "utf8");
+const railwayManifest = readFileSync(
+  new URL("packages/cloud/services/gateway-webhook/railway.toml", repoRoot),
+  "utf8",
+);
 const workflowReadme = readFileSync(
   new URL(".github/workflows/README.md", repoRoot),
   "utf8",
@@ -336,6 +340,8 @@ describe("protected gateway-webhook deployment workflow", () => {
     expect(exactSource.run).toContain(
       "cp packages/cloud/services/gateway-webhook/railway.toml railway.toml",
     );
+    expect(railwayManifest).toContain("healthcheckTimeout = 90");
+    expect(railwayManifest).not.toContain("healthcheckTimeout = 30");
     expect(exactSource.run).toContain("cmp --silent");
     expect(exactSource.run).toContain('!= "?? railway.toml"');
     expect(exactSource.run).toContain('--project "$RAILWAY_PROJECT_ID"');
@@ -424,6 +430,18 @@ describe("protected gateway-webhook deployment workflow", () => {
     );
     expect(verify.run).toContain(
       ".meta.fileServiceManifest.deploy.healthcheckPath",
+    );
+    expect(verify.run).toContain(
+      ".meta.fileServiceManifest.deploy.healthcheckTimeout == 90",
+    );
+    expect(verify.run).toContain(
+      ".meta.serviceManifest.deploy.healthcheckTimeout == 90",
+    );
+    expect(verify.run).not.toContain(
+      ".meta.fileServiceManifest.deploy.healthcheckTimeout == 30",
+    );
+    expect(verify.run).not.toContain(
+      ".meta.serviceManifest.deploy.healthcheckTimeout == 30",
     );
     expect(verify.run).toContain("railway service status");
     expect(


### PR DESCRIPTION
Closes #20781.

## What changed

- expands the tracked Railway gateway health window from 30s to 90s so the existing bounded crash-only JWT bootstrap/restart policy can become healthy before cutover
- keeps required startup authentication and routing fail-fast
- makes the protected deployment workflow reject applied manifests that do not prove the exact 90s window
- adds a focused source/workflow contract so the manifest and post-deploy verifier cannot drift

## Ground truth

Protected staging run 31977989060 uploaded exact source 7e04c64c73f007610e5da4654803589fdee7c96d as Railway deployment aac7bb6d-7246-4b03-affe-a1fbfd67843a. Sanitized logs show the gateway began listening about 29s after container start, then Railway marked it failed about 2.5s later under the 30s health window. The old deployment remained active. No auth/provider/runtime source change is required.

## Verification

- focused deployment contract: 6/6, 133 assertions
- full gateway package: 166/166, 459 assertions
- gateway typecheck: PASS
- gateway build: PASS
- actionlint: PASS
- focused Biome: PASS
- diff-check: PASS
- error-policy ratchet: N/A — script is absent on current develop and this patch touches no production TypeScript
- root verify: 242 tasks completed before inherited shared build-lock contention on 127.0.0.1:24448 stopped capacitor-browser-surface; no candidate-file failure, and the final worktree remained clean

## Evidence matrix

| Evidence | Result |
| --- | --- |
| Real failing backend logs | Attached by issue #20781 via run/deployment IDs; manually reviewed |
| Real provider/model trajectory | N/A — deployment-manifest timing repair; no model/action behavior changes |
| Frontend screenshots/video | N/A — no frontend change |
| Domain artifact | Railway deployment aac7bb6d-7246-4b03-affe-a1fbfd67843a failed after the process reached listen; old serving deployment preserved |
| Live AFTER | Pending independent exact-head review and protected staging deploy from merged current develop |

No staging, secret, provider, channel, or production mutation was performed by this branch.

## Independent exact-head review

Rebased onto current develop. Railway documents healthcheckTimeout as the seconds allowed for the path to become healthy; 90 seconds safely covers the observed roughly 29-second authenticated startup while retaining the existing fail-closed health path and prior active deployment. Exact-head verification passed: deployment contract 6/6 (133 assertions), gateway 166/166 (459 assertions), typecheck, build, focused Biome, and diff check. No protected deployment or environment approval was performed.
