### PR TITLE
fix(ci): normalize staging certification digest

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -451,11 +451,11 @@ jobs:
             echo "::error::Certification upload did not return an artifact id"
             exit 1
           }
-          [[ "$ARTIFACT_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+          [[ "$ARTIFACT_DIGEST" =~ ^[0-9a-f]{64}$ ]] || {
             echo "::error::Certification upload did not return a SHA-256 digest"
             exit 1
           }
-          echo "Certified staging tree ${TREE_SHA} with artifact ${ARTIFACT_ID} (${ARTIFACT_DIGEST}) after all release and routing checks passed." >> "$GITHUB_STEP_SUMMARY"
+          echo "Certified staging tree ${TREE_SHA} with artifact ${ARTIFACT_ID} (sha256:${ARTIFACT_DIGEST}) after all release and routing checks passed." >> "$GITHUB_STEP_SUMMARY"
 
   resolve-pages-preview-config:
     name: Resolve Pages preview configuration

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -59,6 +59,7 @@ function step(workflow: Workflow, jobId: string, name: string): WorkflowStep {
 // `cloud-cf-release.yml` it calls, so the mutation contracts are read there.
 const cloudSource = read(".github/workflows/cloud-cf-release.yml");
 const cloud = parse(".github/workflows/cloud-cf-release.yml");
+const cloudDeploy = parse(".github/workflows/cloud-cf-deploy.yml");
 const cloudApiWranglerSource = read("packages/cloud/api/wrangler.toml");
 const infraSource = read(".github/workflows/infra.yml");
 const infra = parse(".github/workflows/infra.yml");
@@ -96,6 +97,24 @@ const requiredAuthWorkerSecretNames = [
 ] as const;
 
 describe("canonical cloud deployment environment contract", () => {
+  test("records the staging certificate with the upload action digest shape", () => {
+    const record = step(
+      cloudDeploy,
+      "certify-staging-release",
+      "Record certification identity",
+    );
+
+    expect(record.env?.ARTIFACT_DIGEST).toContain(
+      "steps.upload.outputs.artifact-digest",
+    );
+    expect(record.run).toContain('[[ "$ARTIFACT_DIGEST" =~ ^[0-9a-f]{64}$ ]]');
+    const digestVariable = "$" + "{ARTIFACT_DIGEST}";
+    expect(record.run).toContain(`(sha256:${digestVariable})`);
+    expect(record.run).not.toContain(
+      '[[ "$ARTIFACT_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]',
+    );
+  });
+
   test("runs genuine Shared Eliza in staging and production", () => {
     const staging = cloudApiWranglerSource.slice(
       cloudApiWranglerSource.indexOf("[env.staging.vars]"),


### PR DESCRIPTION
Closes #20788.

## What changed

- validates `actions/upload-artifact`'s `artifact-digest` output as the raw 64-character lowercase hexadecimal value it actually emits
- adds the canonical `sha256:` prefix only when recording the certification identity
- adds a focused workflow contract that pins both the action output and normalized summary
- leaves production artifact API digest verification unchanged

## Ground truth

Cloud CF Deploy run 31984658433 successfully deployed and routed staging Worker source `83215632b3c8925f38db7cf1f2ad3cd453919d70`. Its final certification job 95260188880 then received artifact ID `9273692739` and raw digest `b7346b527d07deda8650f2c07e189cf3fd6f4da9b16f552e5a4fb0354fc488a6`, but rejected it because the workflow required a `sha256:` prefix.

## Verification

- canonical cloud deployment contract: 19/19, 292 assertions
- actionlint: PASS with only the inherited unsupported `concurrency.queue` diagnostic ignored; candidate adds no actionlint finding
- focused Biome: PASS with one pre-existing `noTemplateCurlyInString` warning at unchanged line 432
- diff-check: PASS
- exact worktree clean

## Evidence matrix

| Evidence | Result |
| --- | --- |
| Backend log | Exact failed job 95260188880 manually inspected |
| Domain artifact | Uploaded artifact 9273692739 with exact raw SHA-256 digest |
| Model trajectory | N/A - CI metadata normalization only |
| Frontend pixels/video | N/A - no frontend change |
| Live AFTER | Pending reviewed merge and protected staging certification rerun |

No staging, secret, provider, channel, or production mutation was performed.

## Independent exact-head review

Rebased onto current develop. GitHub actions/upload-artifact documents artifact-digest as a raw 64-character SHA-256 hex value; the REST artifact digest remains separately prefixed and is unchanged. Exact-head contract: 20/20, 294 assertions; focused Biome has only the inherited unchanged line-444 warning; diff check passed. actionlint reports only the pre-existing concurrency.queue extension. No protected environment action was taken.
