### PR TITLE
fix(cloud): accept personal agent IDs in Twilio history

### DIFF
--- a/packages/cloud/shared/src/db/migrations/0212_twilio_personal_agent_ids.sql
+++ b/packages/cloud/shared/src/db/migrations/0212_twilio_personal_agent_ids.sql
@@ -1,0 +1,4 @@
+-- Personal Shared agents use canonical `personal:<uuid>` identifiers, while
+-- legacy dedicated agents retain plain UUID identifiers.
+ALTER TABLE "twilio_inbound_calls"
+ALTER COLUMN "agent_id" TYPE text USING "agent_id"::text;

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1478,6 +1478,13 @@
       "when": 1787860800001,
       "tag": "0211_shared_turn_traces",
       "breakpoints": true
+    },
+    {
+      "idx": 211,
+      "version": "7",
+      "when": 1787860800002,
+      "tag": "0212_twilio_personal_agent_ids",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/schemas/twilio-inbound-calls.ts
+++ b/packages/cloud/shared/src/db/schemas/twilio-inbound-calls.ts
@@ -18,7 +18,7 @@ export const twilioInboundCalls = pgTable(
     from_number: text("from_number").notNull(),
     to_number: text("to_number").notNull(),
     call_status: text("call_status").notNull(),
-    agent_id: uuid("agent_id"),
+    agent_id: text("agent_id"),
     raw_payload: jsonb("raw_payload").notNull().default({}),
     raw_payload_storage: text("raw_payload_storage").notNull().default("inline"),
     raw_payload_key: text("raw_payload_key"),

--- a/packages/cloud/shared/src/db/twilio-personal-agent-id-migration.test.ts
+++ b/packages/cloud/shared/src/db/twilio-personal-agent-id-migration.test.ts
@@ -1,0 +1,61 @@
+/** Proves Twilio call history accepts canonical personal Shared agent keys. */
+
+import { readFile } from "node:fs/promises";
+import { PGlite } from "@electric-sql/pglite";
+import { afterEach, describe, expect, it } from "vitest";
+
+describe("0212 Twilio personal Shared agent ids", () => {
+  const databases: PGlite[] = [];
+
+  afterEach(async () => {
+    await Promise.all(databases.splice(0).map((database) => database.close()));
+  });
+
+  it("preserves UUID history and accepts a personal:<uuid> agent key", async () => {
+    const database = new PGlite();
+    databases.push(database);
+    await database.exec(`
+      CREATE TABLE twilio_inbound_calls (
+        id uuid PRIMARY KEY,
+        call_sid text NOT NULL UNIQUE,
+        agent_id uuid
+      );
+      INSERT INTO twilio_inbound_calls (id, call_sid, agent_id)
+      VALUES (
+        '00000000-0000-4000-8000-000000000001',
+        'CA-legacy',
+        '11111111-1111-4111-a111-111111111111'
+      );
+      `);
+    const migration = await readFile(
+      new URL("./migrations/0212_twilio_personal_agent_ids.sql", import.meta.url),
+      "utf8",
+    );
+
+    await database.exec(migration);
+    await database.exec(`
+      INSERT INTO twilio_inbound_calls (id, call_sid, agent_id)
+      VALUES (
+        '00000000-0000-4000-8000-000000000002',
+        'CA-personal',
+        'personal:22222222-2222-5222-a222-222222222222'
+      );
+      `);
+
+    const rows = await database.query(
+      `SELECT call_sid, agent_id
+         FROM twilio_inbound_calls
+        ORDER BY call_sid`,
+    );
+    expect(rows.rows).toEqual([
+      {
+        call_sid: "CA-legacy",
+        agent_id: "11111111-1111-4111-a111-111111111111",
+      },
+      {
+        call_sid: "CA-personal",
+        agent_id: "personal:22222222-2222-5222-a222-222222222222",
+      },
+    ]);
+  }, 30_000);
+});


### PR DESCRIPTION
# Relates to

Fixes #20775.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the schema contract and migration from the evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@7b5e7136c79ce22ef7dd7702c7fe3b4429bd32d8:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `7b5e7136c79ce22ef7dd7702c7fe3b4429bd32d8`; zero conflicts.
- [x] `bun run verify` passes at PR head `d0e05eef1448f54203c022541609acc35c30c37d`.

# Risks

Low. The migration widens one nullable indexed column from PostgreSQL `uuid` to
`text`, preserving every existing UUID value while admitting canonical
`personal:<uuid>` Shared-agent identifiers. The affected index remains valid.

# Background

## What does this PR do?

- Changes `twilio_inbound_calls.agent_id` to text so inbound personal Shared-agent calls can query and persist call history.
- Adds append-only migration `0212_twilio_personal_agent_ids.sql`.
- Adds a PGlite migration regression test proving legacy UUID history is preserved and a `personal:<uuid>` key can be inserted.

## What kind of change is this?

Bug fix (non-breaking database contract widening).

# Documentation changes needed?

No product documentation change is needed; this aligns the existing Twilio
history table with the already-shipped canonical Shared-agent identifier contract.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/db/twilio-personal-agent-id-migration.test.ts`

## Detailed testing steps

1. Run `bun test src/db/twilio-personal-agent-id-migration.test.ts` from `packages/cloud/shared`.
2. Run `bun run db:check-migrations` from `packages/cloud/shared`.
3. Run `bun run typecheck` from `packages/cloud/shared`.
4. Run the Twilio voice suites individually from `packages/cloud/api`.
5. Run root `bun run verify`.

# Evidence Gate

<!-- evidence-head:d0e05eef1448f54203c022541609acc35c30c37d -->

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - database and webhook change has no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - database and webhook change has no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no rendered UI surface; live phone validation follows production migration.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: production Twilio replay reached `POST /api/v1/twilio/voice/inbound` and returned HTTP 500 with PostgreSQL `22P02`: `invalid input syntax for type uuid: "personal:<uuid>"` while querying `twilio_inbound_calls.agent_id`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - Twilio invokes the public Worker webhook directly.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no model, prompt, provider, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: PGlite regression preserves the legacy UUID string and stores `personal:<uuid>`; 1 pass, 0 fail.
<!-- evidence-row:ocr-review -->
- [x] OCR review: N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no model, prompt, provider, or agent behavior changed.

## Backend + frontend logs

Production failure before the fix:

```text
POST /api/v1/twilio/voice/inbound -> 500
PostgreSQL 22P02: invalid input syntax for type uuid: "personal:<uuid>"
query: select id, received_at from twilio_inbound_calls ... agent_id = $5
```

Exact-head validation:

```text
bun test src/db/twilio-personal-agent-id-migration.test.ts
1 pass, 0 fail

bun run db:check-migrations
Everything's fine

Twilio voice suites
30 pass, 0 fail across 10 isolated files

bun run verify
356 successful, 356 total; all repository audits passed
```

Frontend: N/A - no frontend request or state transition exists.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

Pending production migration and deployment. The pre-fix live call fails before
TwiML/media startup; after merge, the same real number will be called and the
Twilio event plus Cloudflare logs will be added as deployment evidence.

## Known gaps / failures

The corrected schema cannot be exercised against production until this migration
is merged and deployed. All local migration, type, route, bundle, and repository
gates pass at the exact PR head.

# Deploy Notes

Run the normal production database migrations before or with the Cloud API Worker
deployment. Then replay the failed Twilio webhook and place a real inbound call.

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@7b5e7136c79ce22ef7dd7702c7fe3b4429bd32d8:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex desktop","skill_revision":"elizaOS/eliza@7b5e7136c79ce22ef7dd7702c7fe3b4429bd32d8:packages/skills/skills/contribute-to-eliza"} -->
