### PR TITLE
fix(computeruse): reject timer-overflow action timeouts

### DIFF
--- a/plugins/plugin-computeruse/src/__tests__/service.integration.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/service.integration.test.ts
@@ -113,6 +113,7 @@ describe("parseComputerUseActionTimeoutMs", () => {
     expect(parseComputerUseActionTimeoutMs("1")).toBe(1);
     expect(parseComputerUseActionTimeoutMs("5000")).toBe(5000);
     expect(parseComputerUseActionTimeoutMs("10000")).toBe(10000);
+    expect(parseComputerUseActionTimeoutMs("2147483647")).toBe(2_147_483_647);
     expect(parseComputerUseActionTimeoutMs(" 2500 ")).toBe(2500);
   });
 
@@ -126,6 +127,8 @@ describe("parseComputerUseActionTimeoutMs", () => {
       "-1",
       "0x10",
       "1.5",
+      "2147483648",
+      "9007199254740991",
       " ",
       "",
     ]) {

--- a/plugins/plugin-computeruse/src/services/computer-use-service.ts
+++ b/plugins/plugin-computeruse/src/services/computer-use-service.ts
@@ -255,6 +255,9 @@ function renderPlainData(value: unknown, indent = 0): string {
  * the scientific spelling of the documented 10000ms default. Prefix junk
  * (`12px`, `007`, `5000abc`) is the same hole. Those spellings are rejected
  * so loadConfig keeps the default instead of silently shrinking the timeout.
+ * Values above Node's timer ceiling are also rejected: Node clamps an
+ * overflowing delay to 1ms, recreating the same failure with a different
+ * spelling.
  */
 export function parseComputerUseActionTimeoutMs(
   raw: string | undefined,
@@ -264,7 +267,9 @@ export function parseComputerUseActionTimeoutMs(
   if (trimmed === "") return undefined;
   if (!/^[1-9]\d*$/.test(trimmed)) return undefined;
   const parsed = Number(trimmed);
-  if (!Number.isSafeInteger(parsed) || parsed < 1) return undefined;
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > 2_147_483_647) {
+    return undefined;
+  }
   return parsed;
 }
 


### PR DESCRIPTION
## Summary

- bound `COMPUTER_USE_ACTION_TIMEOUT_MS` to Node's maximum supported timer delay
- keep the documented 10000ms default for larger values instead of allowing Node to clamp them to 1ms
- cover the exact `2147483647` boundary and overflow values

This is the maintainer repair found while reviewing #20772 after that PR merged concurrently.

Closes #20793.

## Exact-head verification

Head: `a5f4a1e2e5d6f42618194f9978c6d6ace9dd51a8`

- focused computer-use service suite: 36/36 passed
- package typecheck: passed
- Biome on both changed files: passed
- `git diff --check`: passed
- `bun run verify`: passed; 356/356 Turbo tasks and every repository audit gate passed

## Evidence

Backend-only configuration parsing. Screenshots, walkthrough, frontend logs, OCR, and live-model trajectories are N/A. The focused suite exercises the real service configuration boundary.

<!-- evidence-head:a5f4a1e2e5d6f42618194f9978c6d6ace9dd51a8 -->