### PR TITLE
fix(workflows): expose approval and event detail

### DIFF
--- a/packages/ui/src/api/client-types-chat.ts
+++ b/packages/ui/src/api/client-types-chat.ts
@@ -859,6 +859,19 @@ export interface WorkflowRunEvent {
   payload: Record<string, unknown>;
 }
 
+export interface WorkflowApproval {
+  runId: string;
+  workflowId: string;
+  nodeId: string;
+  iteration: number;
+  status: "pending" | "approved" | "denied";
+  prompt?: string;
+  requestedAt: string;
+  decidedAt?: string;
+  decidedBy?: string;
+  decision?: unknown;
+}
+
 export interface WorkflowExecution {
   id: string;
   status:
@@ -884,7 +897,10 @@ export interface WorkflowExecution {
   output?: unknown;
   error?: { message: string; stack?: string };
   events?: WorkflowRunEvent[];
+  approvals?: WorkflowApproval[];
+  parentRunId?: string | null;
   nextRunId?: string;
+  idempotencyKey?: string;
 }
 
 export interface WorkflowEvaluationSampleNode {

--- a/packages/ui/src/components/pages/WorkflowEditor.test.tsx
+++ b/packages/ui/src/components/pages/WorkflowEditor.test.tsx
@@ -381,6 +381,17 @@ describe("WorkflowEditor", () => {
         startedAt: now,
         stoppedAt: null,
         input: {},
+        approvals: [
+          {
+            runId: "run-approval",
+            workflowId: "workflow-1",
+            nodeId: "publish",
+            iteration: 2,
+            status: "pending",
+            prompt: "Publish the release?",
+            requestedAt: now,
+          },
+        ],
         events: [
           {
             id: "event-approval",
@@ -398,6 +409,7 @@ describe("WorkflowEditor", () => {
     ]);
     render(<WorkflowEditor initial={workflow()} />);
     fireEvent.click(screen.getByRole("button", { name: "Runs" }));
+    expect(await screen.findByText("Publish the release?")).toBeTruthy();
     fireEvent.click(await screen.findByRole("button", { name: "Approve" }));
     await waitFor(() =>
       expect(api.decideWorkflowApproval).toHaveBeenCalledWith(
@@ -407,5 +419,42 @@ describe("WorkflowEditor", () => {
         true,
       ),
     );
+  });
+
+  it("reveals structured event detail only when requested", async () => {
+    api.getWorkflowExecutions.mockResolvedValue([
+      {
+        id: "run-detail",
+        workflowId: "workflow-1",
+        mode: "manual",
+        status: "finished",
+        finished: true,
+        startedAt: now,
+        stoppedAt: now,
+        input: {},
+        events: [
+          {
+            id: "event-detail",
+            sequence: 1,
+            runId: "run-detail",
+            workflowId: "workflow-1",
+            timestamp: now,
+            type: "NodeFinished",
+            nodeId: "digest",
+            payload: { attempt: 2, result: "ready" },
+          },
+        ],
+      },
+    ]);
+    render(<WorkflowEditor initial={workflow()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Runs" }));
+    const inspect = await screen.findByRole("button", {
+      name: "Inspect NodeFinished event",
+    });
+    expect(screen.queryByText(/"result": "ready"/)).toBeNull();
+    fireEvent.click(inspect);
+    expect(await screen.findByText(/"result": "ready"/)).toBeTruthy();
+    fireEvent.click(inspect);
+    expect(screen.queryByText(/"result": "ready"/)).toBeNull();
   });
 });

--- a/packages/ui/src/components/pages/WorkflowEditor.tsx
+++ b/packages/ui/src/components/pages/WorkflowEditor.tsx
@@ -7,6 +7,7 @@ import {
   ArchiveRestore,
   Braces,
   Check,
+  ChevronRight,
   CircleStop,
   FileInput,
   FileOutput,
@@ -328,6 +329,7 @@ export function WorkflowEditor({
   const [revisions, setRevisions] = useState<WorkflowRevision[]>([]);
   const [cancelArmedId, setCancelArmedId] = useState<string | null>(null);
   const [restoreArmedId, setRestoreArmedId] = useState<string | null>(null);
+  const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
 
   useEffect(() => {
     const next = initial ?? newWorkflow();
@@ -341,6 +343,9 @@ export function WorkflowEditor({
   const dirty = JSON.stringify(workflow) !== savedVersion;
   const selectedRun =
     executions.find((run) => run.id === selectedRunId) ?? executions[0] ?? null;
+  const pendingApproval = selectedRun?.approvals?.find(
+    (approval) => approval.status === "pending",
+  );
 
   const refreshRuns = useCallback(async () => {
     if (!workflow.id) return;
@@ -772,29 +777,58 @@ export function WorkflowEditor({
                     aria-label="Events"
                   />
                   <div className="space-y-0">
-                    {(selectedRun.events ?? []).map((event) => (
-                      <div
-                        key={event.id}
-                        className="grid grid-cols-[22px_70px_minmax(0,1fr)] gap-2 border-l border-border pb-3 text-xs last:pb-0"
-                      >
-                        <div className="-ml-[5px] mt-1 h-2.5 w-2.5 rounded-full border-2 border-card bg-primary" />
-                        <span className="font-mono text-[10px] text-muted-foreground/70">
-                          {new Date(event.timestamp).toLocaleTimeString([], {
-                            hour: "2-digit",
-                            minute: "2-digit",
-                            second: "2-digit",
-                          })}
-                        </span>
-                        <div>
-                          <p className="font-medium">{event.type}</p>
-                          {event.nodeId ? (
-                            <p className="mt-0.5 text-muted-foreground">
-                              {event.nodeId}
-                            </p>
-                          ) : null}
+                    {(selectedRun.events ?? []).map((event) => {
+                      const inspectable = hasObjectValues(event.payload);
+                      const selected = selectedEventId === event.id;
+                      return (
+                        <div
+                          key={event.id}
+                          className="grid grid-cols-[22px_70px_minmax(0,1fr)] gap-2 border-l border-border pb-3 text-xs last:pb-0"
+                        >
+                          <div className="-ml-[5px] mt-1 h-2.5 w-2.5 rounded-full border-2 border-card bg-primary" />
+                          <span className="font-mono text-[10px] text-muted-foreground/70">
+                            {new Date(event.timestamp).toLocaleTimeString([], {
+                              hour: "2-digit",
+                              minute: "2-digit",
+                              second: "2-digit",
+                            })}
+                          </span>
+                          <div className="min-w-0">
+                            <button
+                              type="button"
+                              disabled={!inspectable}
+                              className="flex w-full items-start gap-1 text-left disabled:cursor-default"
+                              aria-label={`Inspect ${event.type} event`}
+                              aria-expanded={inspectable ? selected : undefined}
+                              onClick={() =>
+                                setSelectedEventId(selected ? null : event.id)
+                              }
+                            >
+                              <span className="min-w-0 flex-1">
+                                <span className="block truncate font-medium">
+                                  {event.type}
+                                </span>
+                                {event.nodeId ? (
+                                  <span className="mt-0.5 block truncate text-muted-foreground">
+                                    {event.nodeId}
+                                  </span>
+                                ) : null}
+                              </span>
+                              {inspectable ? (
+                                <ChevronRight
+                                  className={`mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform ${selected ? "rotate-90" : ""}`}
+                                />
+                              ) : null}
+                            </button>
+                            {selected ? (
+                              <pre className="mt-2 max-h-56 overflow-auto rounded-lg bg-muted/40 p-2 text-[10px] leading-4">
+                                {pretty(event.payload)}
+                              </pre>
+                            ) : null}
+                          </div>
                         </div>
-                      </div>
-                    ))}
+                      );
+                    })}
                     {(selectedRun.events ?? []).length === 0 ? (
                       <div className="h-2 w-2 animate-pulse rounded-full bg-primary" />
                     ) : null}
@@ -806,16 +840,26 @@ export function WorkflowEditor({
                       <span className="h-2.5 w-2.5 rounded-full bg-amber-500" />
                       <p className="text-sm font-semibold">Approval required</p>
                     </div>
+                    {pendingApproval?.prompt ? (
+                      <p className="mt-2 text-xs text-muted-foreground">
+                        {pendingApproval.prompt}
+                      </p>
+                    ) : null}
                     <div className="mt-3 flex gap-2">
                       {(() => {
-                        const waiting = [...(selectedRun.events ?? [])]
+                        const fallback = [...(selectedRun.events ?? [])]
                           .reverse()
                           .find(
                             (event) =>
                               event.nodeId &&
                               /approval|waiting/i.test(event.type),
                           );
-                        const nodeId = waiting?.nodeId;
+                        const nodeId =
+                          pendingApproval?.nodeId ?? fallback?.nodeId;
+                        const iteration =
+                          pendingApproval?.iteration ??
+                          fallback?.iteration ??
+                          0;
                         if (!nodeId)
                           return (
                             <span className="text-xs text-muted-foreground">
@@ -833,7 +877,7 @@ export function WorkflowEditor({
                                   .decideWorkflowApproval(
                                     selectedRun.id,
                                     nodeId,
-                                    waiting.iteration ?? 0,
+                                    iteration,
                                     true,
                                   )
                                   .then(refreshRuns)
@@ -851,7 +895,7 @@ export function WorkflowEditor({
                                   .decideWorkflowApproval(
                                     selectedRun.id,
                                     nodeId,
-                                    waiting.iteration ?? 0,
+                                    iteration,
                                     false,
                                   )
                                   .then(refreshRuns)

--- a/plugins/plugin-workflow/__tests__/unit/embedded-workflow-lifecycle.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/embedded-workflow-lifecycle.test.ts
@@ -89,6 +89,7 @@ async function harness() {
       const index = tasks.findIndex((task) => task.id === id);
       if (index >= 0) tasks.splice(index, 1);
     },
+    emitEvent: async () => {},
   } as unknown as IAgentRuntime;
   return {
     service: await EmbeddedWorkflowService.start(runtime),
@@ -230,5 +231,84 @@ describe('embedded native workflow lifecycle', () => {
     await Bun.sleep(0);
 
     expect(resumedVersions).toEqual([workflow.versionId]);
+  }, 15_000);
+
+  test('persists authoritative pending approval details from Smithers events', async () => {
+    const { service, client, runtime } = await harness();
+    const workflow = await service.createWorkflow({
+      ...definition('Approval'),
+      id: 'approval',
+      schedule: undefined,
+    });
+    const execution: WorkflowExecution = {
+      id: 'approval-run',
+      workflowId: workflow.id,
+      workflowVersionId: workflow.versionId,
+      workflowName: workflow.name,
+      mode: 'manual',
+      status: 'waiting-approval',
+      finished: false,
+      startedAt: '2026-08-16T00:00:00.000Z',
+      input: {},
+      events: [],
+      approvals: [],
+    };
+    await client.query(
+      `INSERT INTO workflow.embedded_executions
+       (agent_id, id, workflow_id, status, mode, finished, started_at, execution)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)`,
+      [
+        runtime.agentId,
+        execution.id,
+        execution.workflowId,
+        execution.status,
+        execution.mode,
+        execution.finished,
+        execution.startedAt,
+        JSON.stringify(execution),
+      ]
+    );
+
+    const internals = service as unknown as {
+      recordEvent: (
+        execution: WorkflowExecution,
+        event: {
+          id: string;
+          sequence: number;
+          runId: string;
+          workflowId: string;
+          timestamp: string;
+          type: string;
+          nodeId: string;
+          iteration: number;
+          payload: Record<string, unknown>;
+        }
+      ) => Promise<void>;
+    };
+    await internals.recordEvent(execution, {
+      id: 'approval-run:1',
+      sequence: 1,
+      runId: execution.id,
+      workflowId: workflow.id,
+      timestamp: '2026-08-16T00:00:01.000Z',
+      type: 'ApprovalRequested',
+      nodeId: 'publish',
+      iteration: 2,
+      payload: {
+        request: { title: 'Publish', summary: 'Publish the release?' },
+      },
+    });
+
+    expect((await service.getExecution(execution.id)).approvals).toEqual([
+      {
+        runId: execution.id,
+        workflowId: workflow.id,
+        nodeId: 'publish',
+        iteration: 2,
+        status: 'pending',
+        prompt: 'Publish the release?',
+        requestedAt: '2026-08-16T00:00:01.000Z',
+      },
+    ]);
   }, 15_000);
 });

--- a/plugins/plugin-workflow/src/services/embedded-workflow-service.ts
+++ b/plugins/plugin-workflow/src/services/embedded-workflow-service.ts
@@ -25,6 +25,7 @@ import {
   workflowRevisions,
 } from '../db/schema';
 import type {
+  WorkflowApproval,
   WorkflowDefinition,
   WorkflowDefinitionResponse,
   WorkflowExecution,
@@ -69,6 +70,15 @@ function nowIso(): string {
 
 function cloneJson<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function approvalPrompt(payload: Record<string, unknown>): string | undefined {
+  const request = payload.request;
+  if (!request || typeof request !== 'object') return undefined;
+  const record = request as Record<string, unknown>;
+  const title = typeof record.title === 'string' ? record.title.trim() : '';
+  const summary = typeof record.summary === 'string' ? record.summary.trim() : '';
+  return summary || title || undefined;
 }
 
 function normalizeWorkflow(
@@ -582,6 +592,24 @@ export class EmbeddedWorkflowService extends Service {
 
   private async recordEvent(execution: WorkflowExecution, event: WorkflowRunEvent): Promise<void> {
     execution.events = [...(execution.events ?? []), event];
+    if (event.type === 'ApprovalRequested' && event.nodeId && typeof event.iteration === 'number') {
+      const prompt = approvalPrompt(event.payload);
+      const pending: WorkflowApproval = {
+        runId: execution.id,
+        workflowId: execution.workflowId,
+        nodeId: event.nodeId,
+        iteration: event.iteration,
+        status: 'pending',
+        requestedAt: event.timestamp,
+        ...(prompt ? { prompt } : {}),
+      };
+      execution.approvals = [
+        ...(execution.approvals ?? []).filter(
+          (approval) => approval.nodeId !== event.nodeId || approval.iteration !== event.iteration
+        ),
+        pending,
+      ];
+    }
     await this.saveExecution(execution);
     for (const listener of this.listeners.get(execution.id) ?? []) listener(event);
     await this.runtime.emitEvent(WORKFLOW_RUN_EVENT, { runtime: this.runtime, event } as never);
@@ -610,6 +638,9 @@ export class EmbeddedWorkflowService extends Service {
     options: { note?: string; decidedBy?: string; decision?: unknown } = {}
   ): Promise<WorkflowExecution> {
     const execution = await this.getExecution(runId);
+    const pending = (execution.approvals ?? []).find(
+      (approval) => approval.nodeId === nodeId && approval.iteration === iteration
+    );
     await controlSmithersRun(this.tenantId, execution.workflowId, {
       kind: approved ? 'approve' : 'deny',
       runId,
@@ -628,7 +659,8 @@ export class EmbeddedWorkflowService extends Service {
         nodeId,
         iteration,
         status: approved ? 'approved' : 'denied',
-        requestedAt: decidedAt,
+        requestedAt: pending?.requestedAt ?? decidedAt,
+        ...(pending?.prompt ? { prompt: pending.prompt } : {}),
         decidedAt,
         ...(options.decidedBy ? { decidedBy: options.decidedBy } : {}),
         ...(options.decision !== undefined ? { decision: options.decision } : {}),


### PR DESCRIPTION
Closes #20765

## What changed

- persists Smithers `ApprovalRequested` events as authoritative approval records with exact node, iteration, prompt, and request time
- renders pending approvals from the persisted approval contract instead of reconstructing them from the event stream
- makes each execution event inspectable on demand while keeping raw payloads collapsed by default
- widens the client execution contract for approvals, parent runs, and idempotency keys

## Why

Workflow Studio already exposes visual building, source, runs, widgets, history, triggers, and execution events. The remaining Smithers parity gap was operational: approvals lost their structured request metadata at the client boundary, and the run timeline could not reveal event payloads. This closes that gap without adding a Smithers gateway or a second backend; execution remains owned by the elizaOS runtime and Cloud boundary.

## Verification

- `bun run verify` — 356/356 workspace tasks; repository audits green; anti-larp scanned 8,409 test files
- `bun run --cwd packages/app audit:app` — 219/219 captures; broken=0, needs-work=0, minimalism/hover/density failures=0; OCR broken=0
- Workflow Studio audit — mobile portrait, mobile landscape, desktop landscape, and iPad portrait all `good`; 0 console errors; 0 overflow; minimalism ratchet pass
- `bun run --cwd packages/ui test -- src/components/pages/WorkflowEditor.test.tsx` — 10/10
- `bun run --cwd plugins/plugin-workflow test:unit` — 72/72
- `bun run --cwd packages/app test:e2e:workflow-real` — real local-stack journey passed: create, event trigger, manual run, inspect, persist, reload
- hands-on app pass — created and saved `Workflow inspector manual 20765`, ran it to `finished`, inspected its output and event timeline, expanded the `RunStarted` payload, and observed 0 browser console errors

## Evidence matrix

| Evidence | Result |
| --- | --- |
| Desktop visual | Workflow Studio desktop capture: `good`; no overflow, color, hover, density, or render-state issue |
| Mobile visual | Portrait and landscape captures: `good`; no overflow or render-state issue |
| Interaction | Event rows remain compact; payload appears only after activating the event chevron/row |
| Backend | Real PGlite lifecycle persists the authoritative pending approval and prompt from the Smithers event |
| Frontend logs | 0 console errors in audit and hands-on run |
| Backend logs | Workflow registered and the manual execution reached `finished` with persisted events |
| Live model trajectory | The real manual run produced a Smithers agent output and trace events; this change does not alter prompting/model policy |
| Native/device | N/A — browser-owned Workflow Studio interaction; desktop/mobile viewport coverage is captured by the app audit |

Final rebased head `f7058b8588583a8b47de7acf07b5953e2a3f2e14` passed both owning-package typechecks, Workflow Editor 10/10, and workflow plugin 72/72 immediately before merge. The full repository gate passed 356/356 plus all audits on the preceding patch-identical head; the final rebase contained no overlapping workflow-file change.
