### PR TITLE
fix(cloud): decouple shared reminder delivery from gateway auth

### DIFF
--- a/packages/cloud/services/gateway-webhook/__tests__/internal-delivery.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/internal-delivery.test.ts
@@ -85,11 +85,7 @@ function request(overrides: Record<string, unknown> = {}) {
 }
 
 function dependencies(redis: GatewayRedis) {
-  return {
-    redis,
-    cloudBaseUrl: "https://api-staging.eliza.app",
-    getAuthHeader: () => ({ Authorization: "Bearer internal" }),
-  };
+  return { redis };
 }
 
 describe("internal proactive delivery", () => {
@@ -135,7 +131,7 @@ describe("internal proactive delivery", () => {
     });
   });
 
-  test("delivers once and replays the completed idempotency key", async () => {
+  test("delivers without Cloud API auth and replays the completed idempotency key", async () => {
     process.env.ELIZA_APP_TELEGRAM_BOT_TOKEN = "telegram-test-token";
     const redis = new MemoryRedis();
     const telegramBodies: Array<Record<string, unknown>> = [];

--- a/packages/cloud/services/gateway-webhook/__tests__/webhook-config-miss-cache.test.ts
+++ b/packages/cloud/services/gateway-webhook/__tests__/webhook-config-miss-cache.test.ts
@@ -91,13 +91,17 @@ describe("per-agent webhook config cache", () => {
 
   test("caches a resolved config for the full TTL and returns it", async () => {
     const redis = new MemoryRedis();
-    globalThis.fetch = mock(
-      async () =>
-        new Response(JSON.stringify({ verifyToken: "vt", appSecret: "as" }), {
+    globalThis.fetch = mock(async (input, init) => {
+      const request = new Request(input, init);
+      expect(request.headers.get("authorization")).toBe("Bearer gateway-jwt");
+      return new Response(
+        JSON.stringify({ verifyToken: "vt", appSecret: "as" }),
+        {
           status: 200,
           headers: { "content-type": "application/json" },
-        }),
-    ) as typeof fetch;
+        },
+      );
+    }) as typeof fetch;
 
     expect(await resolve(redis)).toEqual({
       verifyToken: "vt",

--- a/packages/cloud/services/gateway-webhook/src/index.ts
+++ b/packages/cloud/services/gateway-webhook/src/index.ts
@@ -79,8 +79,6 @@ app.post("/internal/deliver", async (c) => {
   }
   return deliverInternalMessage(c.req.raw, {
     redis,
-    cloudBaseUrl: ELIZA_CLOUD_URL,
-    getAuthHeader,
   });
 });
 

--- a/packages/cloud/services/gateway-webhook/src/internal-delivery.ts
+++ b/packages/cloud/services/gateway-webhook/src/internal-delivery.ts
@@ -5,12 +5,10 @@ import { TelegramApiResponseError, telegramAdapter } from "./adapters/telegram";
 import type { ChatEvent } from "./adapters/types";
 import { logger } from "./logger";
 import type { GatewayRedis } from "./redis";
-import { resolveWebhookConfig } from "./webhook-config";
+import { resolveSharedWebhookConfig } from "./webhook-config";
 
 interface InternalDeliveryDependencies {
   redis: GatewayRedis;
-  cloudBaseUrl: string;
-  getAuthHeader(): Record<string, string>;
 }
 
 type InternalWebhookDelivery =
@@ -211,32 +209,10 @@ export async function deliverInternalMessage(
 
   let connectorAttempted = false;
   try {
-    const config = await resolveWebhookConfig(
-      dependencies.redis,
-      dependencies.cloudBaseUrl,
-      dependencies.getAuthHeader(),
+    const config = resolveSharedWebhookConfig(
       delivery.platform,
       delivery.project,
     );
-    if (!config) {
-      let claimReleased = true;
-      try {
-        await dependencies.redis.del(dedupeKey);
-      } catch {
-        // error-policy:J6 the bounded pre-egress claim expires without provider side effects.
-        claimReleased = false;
-      }
-      return Response.json(
-        {
-          success: false,
-          error: "connector unavailable",
-          retryable: true,
-          acceptance: "not_accepted",
-          claimReleased,
-        },
-        { status: 503, headers: { "Retry-After": claimReleased ? "1" : "60" } },
-      );
-    }
     const event: ChatEvent = {
       platform: delivery.platform,
       messageId: delivery.idempotencyKey,

--- a/packages/cloud/services/gateway-webhook/src/webhook-config.ts
+++ b/packages/cloud/services/gateway-webhook/src/webhook-config.ts
@@ -16,7 +16,8 @@ const CONFIG_MISS_CACHE_TTL_SECONDS = 15;
 
 type CachedWebhookConfig = WebhookConfig | { notFound: true };
 
-function buildSharedWebhookConfig(
+/** Resolves a project connector from the gateway's protected local configuration. */
+export function resolveSharedWebhookConfig(
   platform: Platform,
   project: string,
 ): WebhookConfig {
@@ -61,7 +62,7 @@ export async function resolveWebhookConfig(
   reauth: () => Promise<Record<string, string>> = reacquireAuthHeader,
 ): Promise<WebhookConfig | null> {
   if (!agentId) {
-    return buildSharedWebhookConfig(platform, project);
+    return resolveSharedWebhookConfig(platform, project);
   }
 
   const cacheKey = `webhook-config:${platform}:agent:${agentId}`;


### PR DESCRIPTION
Part of #20796

## What changed

- Shared proactive Telegram/Blooio delivery resolves the protected project connector configuration directly from the gateway local configuration boundary.
- `/internal/deliver` no longer acquires or evaluates a Cloud API bearer token.
- Per-agent webhook configuration remains authenticated; its regression asserts the exact bearer header.
- Exact-once Redis claim, Telegram indeterminate tombstone, provider receipt, and replay behavior are unchanged.

## Why

Real staging Telegram reminder `st_mswkv616_kuldwleo` was committed successfully and became due, but gateway delivery failed with `No access token available - call initAuth first` while scheduled JWT refresh was retrying. Shared-project config has no `agentId` and is local; eager `getAuthHeader()` evaluation made that independent delivery fail on an unrelated auth outage. This is separate from #20781/#20787, which changes only the Railway startup health window.

## Verification

- focused auth/config/internal-delivery: 25/25, 88 assertions
- full gateway: 166/166, 460 assertions
- gateway typecheck: PASS
- gateway production bundle: 196 modules, 1.10 MB, PASS
- gateway Biome: 45 files, PASS
- root `bun run verify`: 356/356 Turbo tasks plus terminal audits, PASS
- post-rebase range-diff: 1/1 exact `=`
- `git diff --check`: PASS
- worktree clean

## Evidence ledger

- Real failing DB/domain/gateway receipts are recorded in #20796.
- UI screenshots/video: N/A — backend connector delivery boundary only.
- Live AFTER Telegram reminder/due/provider/domain receipt: pending protected exact-current staging deploy after review/merge; issue remains open until that proof.
- Production: untouched.

## Exact source

- base/current at publication: `df9996e0310931f63387077c0adc4a6d6af07d78`
- head: `635992aacd38ee73ff513afa176abc39b2b5b1f5`
- tree: `762de63d82f810a0d081421a412cb04e2e5d2ae0`

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@df9996e0310931f63387077c0adc4a6d6af07d78:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-root/shared-latency]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex Desktop","skill_revision":"elizaOS/eliza@df9996e0310931f63387077c0adc4a6d6af07d78:packages/skills/skills/contribute-to-eliza"} -->

## Independent exact-head review

Rebased onto current develop. The old shared-delivery call already resolved protected local connector config, but eagerly evaluated getAuthHeader before entering the agent-less branch; removing that unused JWT dependency fixes the failure without weakening /internal/deliver internal-secret authentication or per-agent bearer auth. Exact-head gateway suite passed 166/166 (460 assertions), plus typecheck, build, focused Biome, and diff check. No protected deployment or provider mutation was performed.
