### PR TITLE
fix(agent): 400 illegal Discord avatar percent-encoding

### DIFF
--- a/packages/agent/src/api/avatar-routes.test.ts
+++ b/packages/agent/src/api/avatar-routes.test.ts
@@ -32,7 +32,10 @@ describe("handleAvatarRoutes percent-encoding", () => {
   });
 
   it("400s the same illegal encodings on HEAD", async () => {
-    const { handled, error, res } = await drive("/api/avatar/discord/%", "HEAD");
+    const { handled, error, res } = await drive(
+      "/api/avatar/discord/%",
+      "HEAD",
+    );
     expect(handled).toBe(true);
     expect(error).toHaveBeenCalledWith(res, "Invalid Discord avatar path", 400);
   });

--- a/packages/agent/src/api/avatar-routes.test.ts
+++ b/packages/agent/src/api/avatar-routes.test.ts
@@ -1,0 +1,47 @@
+/**
+ * GET/HEAD /api/avatar/discord/<file> must 400 illegal percent-encoding
+ * instead of throwing URIError from decodeURIComponent. A thrown decode
+ * skips the path-traversal regex and never answers the client.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { handleAvatarRoutes } from "./avatar-routes.ts";
+
+function drive(pathname: string, method: "GET" | "HEAD" = "GET") {
+  const res = {} as never;
+  const error = vi.fn();
+  return handleAvatarRoutes({
+    req: {} as never,
+    res,
+    method,
+    pathname,
+    json: vi.fn(),
+    error,
+  }).then((handled) => ({ handled, error, res }));
+}
+
+describe("handleAvatarRoutes percent-encoding", () => {
+  it.each([
+    ["bare percent", "/api/avatar/discord/%"],
+    ["truncated hex", "/api/avatar/discord/%E0%A4%A"],
+    ["illegal hex", "/api/avatar/discord/%ZZ.png"],
+    ["truncated after slash", "/api/avatar/discord/foo%"],
+  ])("400s %s without throwing", async (_label, pathname) => {
+    const { handled, error, res } = await drive(pathname);
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(res, "Invalid Discord avatar path", 400);
+  });
+
+  it("400s the same illegal encodings on HEAD", async () => {
+    const { handled, error, res } = await drive("/api/avatar/discord/%", "HEAD");
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(res, "Invalid Discord avatar path", 400);
+  });
+
+  it("400s a decoded name that fails the cache filename regex", async () => {
+    const { handled, error, res } = await drive(
+      "/api/avatar/discord/..%2Fsecret.png",
+    );
+    expect(handled).toBe(true);
+    expect(error).toHaveBeenCalledWith(res, "Invalid Discord avatar path", 400);
+  });
+});

--- a/packages/agent/src/api/avatar-routes.ts
+++ b/packages/agent/src/api/avatar-routes.ts
@@ -56,6 +56,8 @@ export async function handleAvatarRoutes(
     try {
       fileName = decodeURIComponent(encodedFileName);
     } catch {
+      // error-policy:J3 untrusted-input sanitizing — invalid percent escapes
+      // are a malformed path, not a server failure.
       error(res, "Invalid Discord avatar path", 400);
       return true;
     }

--- a/packages/agent/src/api/avatar-routes.ts
+++ b/packages/agent/src/api/avatar-routes.ts
@@ -52,7 +52,13 @@ export async function handleAvatarRoutes(
     pathname.startsWith("/api/avatar/discord/")
   ) {
     const encodedFileName = pathname.slice("/api/avatar/discord/".length);
-    const fileName = decodeURIComponent(encodedFileName);
+    let fileName: string;
+    try {
+      fileName = decodeURIComponent(encodedFileName);
+    } catch {
+      error(res, "Invalid Discord avatar path", 400);
+      return true;
+    }
     if (
       !fileName ||
       fileName !== path.basename(fileName) ||


### PR DESCRIPTION
# Relates to

Closes #20802

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Path-decode only on `GET`/`HEAD` `/api/avatar/discord/<file>`. Canonical
cache filenames and already-rejected traversal names (`..%2F…`) stay 400.
Illegal percent-encoding now 400s instead of throwing `URIError`. No storage,
billing, auth, or UI change.

# Background

## What does this PR do?

Catch `decodeURIComponent` `URIError` in `handleAvatarRoutes` and answer
**400** `Invalid Discord avatar path` before the basename / filename-regex /
cache-dir checks.

- `/api/avatar/discord/%` / `%ZZ.png` / truncated hex / `foo%` → **400**
- `..%2Fsecret.png` still 400 after a successful decode
- HEAD uses the same contract

A thrown decode never called `error(res, …)` and looked like a server crash.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The Discord avatar cache is a shipped agent route. Client garbage in the path
must fail closed as 400, same as an illegal decoded name.

Disjoint from inbox limit (#20777), PTY grace (#20779), login persist JSON,
and billing checkout JSON.

# Documentation changes needed?

No. The route already documents invalid paths as 400.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/avatar-routes.test.ts` — illegal encodings plus HEAD
and a decoded traversal name.

## Detailed testing steps

```bash
cd packages/agent && bunx vitest run --config vitest.config.ts src/api/avatar-routes.test.ts --coverage.enabled=false
```

6 passed at head `18eb85c5cbc1b26da118bc962e3393e4c5f33855`.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; path decode only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; path decode only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; path decode only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real `handleAvatarRoutes` and assert `error(res, "Invalid Discord avatar path", 400)`; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, wallet, or generated-file writes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal percent-encoding 400s and does not throw.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file agent path-decode fix with a
green focused suite (6 tests in `avatar-routes.test.ts`). Full monorepo verify
is unrelated to this decode catch and was skipped to keep the proof tied to
the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:18eb85c5cbc1b26da118bc962e3393e4c5f33855 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->


## Independent review repair

The final head rebases onto current develop, adds the required J3 untrusted-input catch classification, and applies repository formatting. Exact-head verification passed: avatar route 6/6, agent typecheck, focused Biome, and diff checks.
