### PR TITLE
fix(cloud): 400 malformed billing checkout/quote JSON

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/cloud-billing-json-body.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-billing-json-body.test.ts
@@ -46,13 +46,10 @@ function makeReq(raw: string, url: string): http.IncomingMessage {
 
 async function post(pathname: string, raw: string) {
   const cap = makeResponse();
-  const handled = await handleCloudBillingRoute(
-    makeReq(raw, pathname),
-    cap.res,
-    pathname,
-    "POST",
-    { config: {}, runtime: null },
-  );
+  const handled = await handleCloudBillingRoute(makeReq(raw, pathname), cap.res, pathname, "POST", {
+    config: {},
+    runtime: null,
+  });
   return { handled, cap };
 }
 
@@ -73,10 +70,7 @@ describe("billing checkout/quote JSON body", () => {
   });
 
   it("still 401s canonical checkout JSON when disconnected", async () => {
-    const { handled, cap } = await post(
-      "/api/cloud/billing/checkout",
-      '{"amountUsd":10}',
-    );
+    const { handled, cap } = await post("/api/cloud/billing/checkout", '{"amountUsd":10}');
     expect(handled).toBe(true);
     expect(cap.statusCode).toBe(401);
   });

--- a/plugins/plugin-elizacloud/__tests__/cloud-billing-json-body.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-billing-json-body.test.ts
@@ -1,0 +1,83 @@
+/**
+ * POST /api/cloud/billing/checkout and /crypto/quote must 400 malformed JSON
+ * before auth, DNS, or upstream money calls. Stock parseJsonBody used bare
+ * JSON.parse, so `{` threw out of the handler.
+ */
+import type http from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { handleCloudBillingRoute } from "../src/host-routes";
+
+function makeResponse() {
+  let statusCode = 200;
+  let raw = "";
+  const res = {
+    headersSent: false,
+    setHeader: vi.fn(),
+    end: (chunk?: string) => {
+      if (typeof chunk === "string") raw = chunk;
+      (res as { headersSent: boolean }).headersSent = true;
+    },
+    get statusCode() {
+      return statusCode;
+    },
+    set statusCode(value: number) {
+      statusCode = value;
+    },
+  } as unknown as http.ServerResponse;
+  return {
+    res,
+    get statusCode() {
+      return statusCode;
+    },
+    get body(): unknown {
+      return raw ? JSON.parse(raw) : undefined;
+    },
+  };
+}
+
+function makeReq(raw: string, url: string): http.IncomingMessage {
+  return {
+    url,
+    method: "POST",
+    body: raw,
+    readableEnded: true,
+  } as http.IncomingMessage & { body: string };
+}
+
+async function post(pathname: string, raw: string) {
+  const cap = makeResponse();
+  const handled = await handleCloudBillingRoute(
+    makeReq(raw, pathname),
+    cap.res,
+    pathname,
+    "POST",
+    { config: {}, runtime: null },
+  );
+  return { handled, cap };
+}
+
+describe("billing checkout/quote JSON body", () => {
+  it.each([
+    ["/api/cloud/billing/checkout", "{"],
+    ["/api/cloud/billing/checkout", "[]"],
+    ["/api/cloud/billing/checkout", '"x"'],
+    ["/api/cloud/billing/checkout", "null"],
+    ["/api/cloud/billing/crypto/quote", "{"],
+    ["/api/cloud/billing/crypto/quote", "[]"],
+    ["/api/cloud/billing/crypto/quote", "1"],
+  ])("%s 400s %s before auth", async (pathname, raw) => {
+    const { handled, cap } = await post(pathname, raw);
+    expect(handled).toBe(true);
+    expect(cap.statusCode).toBe(400);
+    expect(cap.body).toMatchObject({ error: "Invalid JSON body" });
+  });
+
+  it("still 401s canonical checkout JSON when disconnected", async () => {
+    const { handled, cap } = await post(
+      "/api/cloud/billing/checkout",
+      '{"amountUsd":10}',
+    );
+    expect(handled).toBe(true);
+    expect(cap.statusCode).toBe(401);
+  });
+});

--- a/plugins/plugin-elizacloud/src/routes/cloud-billing-routes.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-billing-routes.ts
@@ -399,10 +399,18 @@ function mapCryptoQuoteResponse(
   };
 }
 
-function parseJsonBody(body: string | undefined): Record<string, unknown> {
+function parseJsonBody(body: string | undefined): Record<string, unknown> | null {
   if (!body) return {};
-  const parsed = JSON.parse(body);
-  return isRecord(parsed) ? parsed : {};
+  try {
+    const parsed = JSON.parse(body);
+    // Arrays pass `typeof === "object"`; checkout/quote need a real object.
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
 }
 
 async function forwardSummary(
@@ -551,6 +559,20 @@ export async function handleCloudBillingRoute(
 ): Promise<boolean> {
   if (!pathname.startsWith("/api/cloud/billing")) return false;
 
+  if (
+    method === "POST" &&
+    (pathname === "/api/cloud/billing/checkout" ||
+      pathname === "/api/cloud/billing/crypto/quote")
+  ) {
+    const raw = await readBody(req);
+    const parsed = parseJsonBody(raw);
+    if (parsed === null) {
+      sendJsonError(res, "Invalid JSON body", 400);
+      return true;
+    }
+    (req as http.IncomingMessage & { body?: unknown }).body = parsed;
+  }
+
   const apiKey = resolveProxyApiKey(state);
   if (!apiKey) {
     sendJsonError(
@@ -627,6 +649,10 @@ export async function handleCloudBillingRoute(
   if (pathname === "/api/cloud/billing/checkout" && method === "POST") {
     const body = await readBody(req);
     const requestBody = parseJsonBody(body);
+    if (!requestBody) {
+      sendJsonError(res, "Invalid JSON body", 400);
+      return true;
+    }
     const amountUsd = readNumber(requestBody.amountUsd);
 
     if (!amountUsd || amountUsd <= 0) {
@@ -666,6 +692,10 @@ export async function handleCloudBillingRoute(
   if (pathname === "/api/cloud/billing/crypto/quote" && method === "POST") {
     const body = await readBody(req);
     const requestBody = parseJsonBody(body);
+    if (!requestBody) {
+      sendJsonError(res, "Invalid JSON body", 400);
+      return true;
+    }
     const amountUsd = readNumber(requestBody.amountUsd);
 
     if (!amountUsd || amountUsd <= 0) {

--- a/plugins/plugin-elizacloud/src/routes/cloud-billing-routes.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-billing-routes.ts
@@ -409,6 +409,8 @@ function parseJsonBody(body: string | undefined): Record<string, unknown> | null
     }
     return parsed as Record<string, unknown>;
   } catch {
+    // error-policy:J3 untrusted-input sanitizing — malformed JSON is an
+    // explicit invalid body and never reaches authentication or money APIs.
     return null;
   }
 }


### PR DESCRIPTION
# Relates to

Closes #20804

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. JSON-parse only on `POST /api/cloud/billing/checkout` and
`POST /api/cloud/billing/crypto/quote`. Canonical `{"amountUsd":10}` when
disconnected still 401. Empty body still becomes `{}` (stock). No login
persist, avatar, or inbox change.

# Background

## What does this PR do?

`parseJsonBody` no longer uses bare `JSON.parse`. Syntax errors and
non-object JSON (`[]`, primitives, `null`) return `null`. Checkout and
crypto quote reject that with **400** `Invalid JSON body` **before**
`resolveProxyApiKey`, DNS, or upstream credit/crypto calls.

- `{` / `[]` / `"x"` / `null` / `1` → **400** Invalid JSON body
- `{"amountUsd":10}` disconnected → **401** (unchanged)
- valid object, bad `amountUsd` → **400** Invalid top-up amount (unchanged)

Stock threw out of the handler on `{`, and arrays passed `typeof === "object"`
so they could fall through toward auth.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

These routes mint checkout links and crypto quotes. Client garbage must not
throw and must not reach upstream money endpoints.

Disjoint from login persist JSON (`cloud-routes.ts`), inbox limit (#20777),
and avatar percent-encoding.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-elizacloud/__tests__/cloud-billing-json-body.test.ts` —
checkout/quote reject table plus disconnected canonical 401.

## Detailed testing steps

```bash
cd plugins/plugin-elizacloud && bunx vitest run --config vitest.config.ts __tests__/cloud-billing-json-body.test.ts --coverage.enabled=false
```

8 passed at head `fd34de888806871f84442adc6e26fd63b1ce6fbb`.
(Local proof used a vitest alias overlay for `@elizaos/core/client-public`
because core dist is not built in the worktree; the suite file and production
change are the two committed files.)

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; JSON parse only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; JSON parse only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; JSON parse only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real `handleCloudBillingRoute` and assert 400 before auth; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, wallet, or generated-file writes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal JSON 400s
before auth; canonical checkout JSON still 401 when disconnected.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file billing JSON parse with a
green focused suite (8 tests). Full monorepo verify is unrelated to this body
grammar and was skipped to keep the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:fd34de888806871f84442adc6e26fd63b1ce6fbb -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->


## Independent review repair

The final head rebases onto current develop, applies repository formatting, and classifies malformed JSON under the required J3 boundary policy. Exact-head verification passed: billing route 8/8, plugin typecheck, focused Biome, and diff checks.
