### PR TITLE
fix(scheduling): make Shared reminder receipts terminal

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -802,8 +802,9 @@ describe("Shared Eliza Workerd runtime", () => {
               content: JSON.stringify({
                 success: true,
                 decision: "FINISH",
-                thought: "The reminder is stored.",
-                messageToUser: "i'll remind you in two minutes",
+                thought: "The completion claim is not verified.",
+                messageToUser:
+                  "I couldn't verify that the requested change was completed, so I won't claim it was. Want me to try again?",
               }),
             },
             finish_reason: "stop",
@@ -840,7 +841,8 @@ describe("Shared Eliza Workerd runtime", () => {
       },
     });
 
-    expect(result.reply).toBe("i'll remind you in two minutes");
+    expect(result.reply).toMatch(/^Reminder set for shared-reminder-1:/);
+    expect(result.reply).not.toContain("couldn't verify");
     expect(scheduledInputs).toHaveLength(1);
     expect(scheduledInputs[0]).toMatchObject({
       kind: "reminder",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -857,7 +857,7 @@ describe("Shared Eliza Workerd runtime", () => {
         },
       },
     });
-    expect(modelRequests).toHaveLength(3);
+    expect(modelRequests).toHaveLength(2);
     expect(result.actionResults?.[0]).toMatchObject({
       verifiedUserFacing: true,
       effectReceipts: [

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -8,6 +8,7 @@
 import {
   AgentRuntime,
   ChannelType,
+  type Content,
   createMessageMemory,
   type GenerateTextParams,
   type IAgentRuntime,
@@ -59,6 +60,14 @@ type NativeTextModelResult = string & {
 
 let edgeStreamingContextReady: Promise<void> | undefined;
 let sharedRuntimeKernelReady: Promise<AgentRuntime> | undefined;
+
+function receiptBackedCallbackReply(delivered: readonly Content[]): string | undefined {
+  const receiptBackedReplies = delivered.flatMap((content) => {
+    const text = content.text?.trim();
+    return content.agentVoiced === true && content.effectReceiptIds?.length && text ? [text] : [];
+  });
+  return receiptBackedReplies.length === 1 ? receiptBackedReplies[0] : undefined;
+}
 
 async function ensureEdgeStreamingContext(): Promise<void> {
   edgeStreamingContextReady ??= import("node:async_hooks").then(({ AsyncLocalStorage }) => {
@@ -462,7 +471,7 @@ async function executeSharedElizaRuntimeTurn(
       );
     }
 
-    const delivered: string[] = [];
+    const delivered: Content[] = [];
     const messageService = runtime.messageService;
     if (!messageService) {
       throw new Error("Eliza Shared runtime initialized without a message service");
@@ -489,7 +498,7 @@ async function executeSharedElizaRuntimeTurn(
         },
       }),
       async (content) => {
-        if (content.text?.trim()) delivered.push(content.text.trim());
+        delivered.push(content);
         return [];
       },
       input.abortSignal || onStreamChunk
@@ -499,10 +508,14 @@ async function executeSharedElizaRuntimeTurn(
           }
         : undefined,
     );
-    const reply = result?.responseContent?.text?.trim() || delivered.at(-1)?.trim() || "";
-    // A verified action may own the response and deliver it through the
-    // callback with `agentVoiced`; core then correctly reports no second model
-    // response. The callback receipt is still an actual user-visible delivery.
+    // A core-bound effect receipt makes the action's canonical callback the
+    // authoritative terminal reply. Other callbacks remain ordinary captured
+    // output and cannot displace model prose returned by MessageService.
+    const reply =
+      receiptBackedCallbackReply(delivered) ??
+      result?.responseContent?.text?.trim() ??
+      delivered.at(-1)?.text?.trim() ??
+      "";
     if ((!result?.didRespond && delivered.length === 0) || !reply) {
       throw new Error("Eliza Shared runtime completed without a user-visible reply");
     }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.ts
@@ -8,7 +8,6 @@
 import {
   AgentRuntime,
   ChannelType,
-  type Content,
   createMessageMemory,
   type GenerateTextParams,
   type IAgentRuntime,
@@ -60,14 +59,6 @@ type NativeTextModelResult = string & {
 
 let edgeStreamingContextReady: Promise<void> | undefined;
 let sharedRuntimeKernelReady: Promise<AgentRuntime> | undefined;
-
-function receiptBackedCallbackReply(delivered: readonly Content[]): string | undefined {
-  const receiptBackedReplies = delivered.flatMap((content) => {
-    const text = content.text?.trim();
-    return content.agentVoiced === true && content.effectReceiptIds?.length && text ? [text] : [];
-  });
-  return receiptBackedReplies.length === 1 ? receiptBackedReplies[0] : undefined;
-}
 
 async function ensureEdgeStreamingContext(): Promise<void> {
   edgeStreamingContextReady ??= import("node:async_hooks").then(({ AsyncLocalStorage }) => {
@@ -471,7 +462,7 @@ async function executeSharedElizaRuntimeTurn(
       );
     }
 
-    const delivered: Content[] = [];
+    const delivered: string[] = [];
     const messageService = runtime.messageService;
     if (!messageService) {
       throw new Error("Eliza Shared runtime initialized without a message service");
@@ -498,7 +489,7 @@ async function executeSharedElizaRuntimeTurn(
         },
       }),
       async (content) => {
-        delivered.push(content);
+        if (content.text?.trim()) delivered.push(content.text.trim());
         return [];
       },
       input.abortSignal || onStreamChunk
@@ -508,14 +499,10 @@ async function executeSharedElizaRuntimeTurn(
           }
         : undefined,
     );
-    // A core-bound effect receipt makes the action's canonical callback the
-    // authoritative terminal reply. Other callbacks remain ordinary captured
-    // output and cannot displace model prose returned by MessageService.
-    const reply =
-      receiptBackedCallbackReply(delivered) ??
-      result?.responseContent?.text?.trim() ??
-      delivered.at(-1)?.text?.trim() ??
-      "";
+    const reply = result?.responseContent?.text?.trim() || delivered.at(-1)?.trim() || "";
+    // A verified action may own the response and deliver it through the
+    // callback with `agentVoiced`; core then correctly reports no second model
+    // response. The callback receipt is still an actual user-visible delivery.
     if ((!result?.didRespond && delivered.length === 0) || !reply) {
       throw new Error("Eliza Shared runtime completed without a user-visible reply");
     }

--- a/plugins/plugin-scheduling/src/shared-reminders.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.test.ts
@@ -141,6 +141,7 @@ describe("Shared reminders edge plugin", () => {
     });
     expect(result).toMatchObject({
       verifiedUserFacing: true,
+      turnComplete: true,
       userFacingEffectReceiptIds: ["shared-reminder:create:scheduled-log-1"],
       effectReceipts: [
         {
@@ -233,6 +234,7 @@ describe("Shared reminders edge plugin", () => {
     expect(result).toMatchObject({
       success: true,
       verifiedUserFacing: true,
+      turnComplete: true,
       effectReceipts: [
         {
           receiptId: "shared-reminder:create:scheduled-log-1",

--- a/plugins/plugin-scheduling/src/shared-reminders.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.ts
@@ -417,6 +417,7 @@ export function createSharedRemindersEdgeAction(
           userFacingText: text,
           effectReceipts: [receipt],
           userFacingEffectReceiptIds: [receipt.receiptId],
+          turnComplete: true,
         };
       }
 


### PR DESCRIPTION
## What changed

- mark a successfully persisted Shared reminder result as `turnComplete: true`
- let the existing core planner gate return the action's verified, receipt-backed acknowledgement without a contradictory second evaluator pass
- preserve normal planner/evaluator behavior for mixed, queued, prior-tool, and explicitly `more_work_pending` turns

## Why

A real staging Telegram reminder durably created its task and applied receipt, but the user was told it could not be verified. The exact trace showed a successful REMINDERS action followed by a second RESPONSE_HANDLER evaluation that replaced the canonical `Reminder set...` acknowledgement with generic failure prose.

The reminder action already returned `verifiedUserFacing`, `userFacingText`, and the applied receipt ID. It was missing the core structural signal that the action-owned result completed this turn. Setting `turnComplete` uses the framework's existing action-terminal gate; there is no reply-string matching, adapter precedence rule, or channel-specific shortcut.

## Evidence

- genuine Shared `AgentRuntime`: 8/8 tests, 44 assertions
- full scheduling suite: 468/468 tests
- core terminal-action gate: 6/6 focused tests, 24 assertions
  - sole terminal action skips the evaluator
  - `more_work_pending` continues
  - sequential multi-operation turns continue
  - queued and prior tools prevent early termination
- scheduling typecheck and build: PASS
- Cloud Shared typecheck: PASS
- Cloud API production Worker dry bundle: PASS
- Biome exact three paths: PASS
- diff-check: PASS

The current `develop` Cloud API typecheck has an unrelated pre-existing failure in `v1/limit-clamp-batch3-hono.test.ts`; this PR has zero overlap with that file. The production Worker dry bundle passes independently.

Live post-deploy Telegram acknowledgement and one-minute delivery proof remain required in the protected staging matrix after review and merge.

Closes #20805


## Independent exact-head review

The updated action-level approach is preferable to callback-precedence logic: it uses the existing core terminal-action gate, whose receipt, verification, sole-action, queue, prior-tool, and more-work constraints prevent forged or premature completion. Exact head passed the genuine Shared runtime and reminder tests (13/13, 59 assertions), full scheduling 468/468, scheduling typecheck/build, Cloud Shared typecheck, focused core terminal-gate tests (23 passed), Biome, and diff check. No protected deployment or provider message was performed.
