### PR TITLE
fix(app-core): 400 malformed first-run JSON

### DIFF
--- a/packages/app-core/src/api/first-run-routes.json-body.test.ts
+++ b/packages/app-core/src/api/first-run-routes.json-body.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Untrusted JSON body contract for app-core `POST /api/first-run`.
+ *
+ * The handler is the onboarding submit path. Syntax errors and non-object
+ * bodies are client garbage and must be HTTP 400, not a fabricated
+ * `{ ok: true }`. Valid objects keep today's persist-then-200 behavior.
+ * Deterministic handler tests against the real `handleFirstRunRoute`.
+ */
+import type http from "node:http";
+import { Readable } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CompatRuntimeState } from "./compat-route-shared";
+
+const saveElizaConfig = vi.fn();
+
+vi.mock("@elizaos/core", () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("@elizaos/agent", () => ({
+  applyCanonicalFirstRunConfig: vi.fn(),
+  loadElizaConfig: vi.fn(() => ({})),
+  saveElizaConfig,
+}));
+
+vi.mock("@elizaos/shared", () => ({
+  getCloudSecret: () => undefined,
+  migrateLegacyRuntimeConfig: vi.fn(),
+  normalizeDeploymentTargetConfig: () => undefined,
+  normalizeFirstRunProviderId: () => null,
+  normalizeLinkedAccountFlagsConfig: () => undefined,
+  normalizeServiceRoutingConfig: () => undefined,
+}));
+
+vi.mock("./auth.ts", () => ({
+  ensureRouteAuthorized: vi.fn(async () => true),
+}));
+
+vi.mock("./auth", () => ({
+  ensureRouteAuthorized: vi.fn(async () => true),
+}));
+
+vi.mock("./compat-route-shared", () => ({
+  hasCompatPersistedFirstRunState: () => false,
+}));
+
+vi.mock("./deferred-runtime-boot", () => ({
+  isRuntimeBootDeferred: () => false,
+  triggerDeferredRuntimeBoot: vi.fn(),
+}));
+
+vi.mock("./server-first-run-helpers", () => ({
+  deriveFirstRunReplayBody: (body: Record<string, unknown>) => ({
+    replayBody: body,
+  }),
+  extractAndPersistFirstRunApiKey: vi.fn(),
+  hasDeprecatedFirstRunRequestFields: () => false,
+  persistFirstRunDefaults: vi.fn(),
+}));
+
+function requestWithRawBody(
+  raw: string,
+  pathname = "/api/first-run",
+): http.IncomingMessage {
+  const stream = Readable.from(
+    raw.length === 0 ? [] : [Buffer.from(raw, "utf8")],
+  );
+  return Object.assign(stream, {
+    headers: { "content-type": "application/json" },
+    method: "POST",
+    url: pathname,
+  }) as unknown as http.IncomingMessage;
+}
+
+function responseSink(): http.ServerResponse & {
+  jsonBody: () => unknown;
+} {
+  let body = "";
+  const sink = {
+    headersSent: false,
+    statusCode: 200,
+    setHeader: () => sink,
+    end: (chunk?: unknown) => {
+      body = typeof chunk === "string" ? chunk : String(chunk ?? "");
+      sink.headersSent = true;
+      return {} as http.ServerResponse;
+    },
+    jsonBody: () => (body ? JSON.parse(body) : undefined),
+  };
+  return sink as http.ServerResponse & { jsonBody: () => unknown };
+}
+
+function emptyState(): CompatRuntimeState {
+  return {
+    current: null,
+    pendingAgentName: null,
+    pendingRestartReasons: [],
+  };
+}
+
+async function postFirstRun(raw: string) {
+  const { handleFirstRunRoute } = await import("./first-run-routes");
+  const res = responseSink();
+  const handled = await handleFirstRunRoute(
+    requestWithRawBody(raw),
+    res,
+    emptyState(),
+  );
+  return { handled, res };
+}
+
+describe("POST /api/first-run JSON body", () => {
+  beforeEach(() => {
+    saveElizaConfig.mockReset();
+  });
+
+  it.each(["", "   ", "{", "not-json", "[]", "null", '"foo"', "42", "true"])(
+    "rejects malformed first-run body %j with 400",
+    async (raw) => {
+      const { handled, res } = await postFirstRun(raw);
+
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(400);
+      expect(res.jsonBody()).toEqual({ error: "Invalid JSON body" });
+      expect(saveElizaConfig).not.toHaveBeenCalled();
+    },
+  );
+
+  it("still persists a canonical object body", async () => {
+    const { handled, res } = await postFirstRun('{"name":"Eliza"}');
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(res.jsonBody()).toEqual({ ok: true });
+    expect(saveElizaConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores non-first-run paths", async () => {
+    const { handleFirstRunRoute } = await import("./first-run-routes");
+    const res = responseSink();
+    const handled = await handleFirstRunRoute(
+      requestWithRawBody("{}", "/api/other"),
+      res,
+      emptyState(),
+    );
+    expect(handled).toBe(false);
+    expect(saveElizaConfig).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-core/src/api/first-run-routes.json-body.test.ts
+++ b/packages/app-core/src/api/first-run-routes.json-body.test.ts
@@ -12,6 +12,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CompatRuntimeState } from "./compat-route-shared";
 
 const saveElizaConfig = vi.fn();
+const extractAndPersistFirstRunApiKey = vi.fn();
 
 vi.mock("@elizaos/core", () => ({
   logger: {
@@ -58,7 +59,7 @@ vi.mock("./server-first-run-helpers", () => ({
   deriveFirstRunReplayBody: (body: Record<string, unknown>) => ({
     replayBody: body,
   }),
-  extractAndPersistFirstRunApiKey: vi.fn(),
+  extractAndPersistFirstRunApiKey,
   hasDeprecatedFirstRunRequestFields: () => false,
   persistFirstRunDefaults: vi.fn(),
 }));
@@ -73,6 +74,7 @@ function requestWithRawBody(
   return Object.assign(stream, {
     headers: { "content-type": "application/json" },
     method: "POST",
+    socket: { localPort: undefined },
     url: pathname,
   }) as unknown as http.IncomingMessage;
 }
@@ -92,7 +94,7 @@ function responseSink(): http.ServerResponse & {
     },
     jsonBody: () => (body ? JSON.parse(body) : undefined),
   };
-  return sink as http.ServerResponse & { jsonBody: () => unknown };
+  return sink as unknown as http.ServerResponse & { jsonBody: () => unknown };
 }
 
 function emptyState(): CompatRuntimeState {
@@ -117,6 +119,7 @@ async function postFirstRun(raw: string) {
 describe("POST /api/first-run JSON body", () => {
   beforeEach(() => {
     saveElizaConfig.mockReset();
+    extractAndPersistFirstRunApiKey.mockReset();
   });
 
   it.each(["", "   ", "{", "not-json", "[]", "null", '"foo"', "42", "true"])(
@@ -138,6 +141,35 @@ describe("POST /api/first-run JSON body", () => {
     expect(res.statusCode).toBe(200);
     expect(res.jsonBody()).toEqual({ ok: true });
     expect(saveElizaConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 500 when the config commit fails", async () => {
+    saveElizaConfig.mockImplementationOnce(() => {
+      throw new Error("disk unavailable");
+    });
+
+    const { handled, res } = await postFirstRun('{"name":"Eliza"}');
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(500);
+    expect(res.jsonBody()).toEqual({
+      error: "Failed to persist first-run state",
+    });
+  });
+
+  it("returns 500 when a pre-commit helper fails", async () => {
+    extractAndPersistFirstRunApiKey.mockRejectedValueOnce(
+      new Error("sealed secret unavailable"),
+    );
+
+    const { handled, res } = await postFirstRun('{"name":"Eliza"}');
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(500);
+    expect(res.jsonBody()).toEqual({
+      error: "Failed to complete first-run setup",
+    });
+    expect(saveElizaConfig).not.toHaveBeenCalled();
   });
 
   it("ignores non-first-run paths", async () => {

--- a/packages/app-core/src/api/first-run-routes.ts
+++ b/packages/app-core/src/api/first-run-routes.ts
@@ -305,17 +305,24 @@ export async function handleFirstRunRoute(
       saveElizaConfig(config);
       await syncFirstRunConfigState(req, config as Record<string, unknown>);
     } catch (err) {
-      logger.warn(
+      // error-policy:J1 a failed config commit is a server failure, never a
+      // successful onboarding acknowledgement.
+      logger.error(
         `[api] Failed to persist first-run state: ${err instanceof Error ? err.message : String(err)}`,
       );
+      sendJsonResponse(res, 500, {
+        error: "Failed to persist first-run state",
+      });
+      return true;
     }
   } catch (err) {
-    // error-policy:J4 onboarding helpers failed after a valid JSON object;
-    // config-save errors are already warned above. Keep the historical 200
-    // ack for a parseable body so the client can poll /api/first-run/status.
-    logger.warn(
+    // error-policy:J1 valid JSON does not imply a successful commit; translate
+    // helper failures at the HTTP boundary without exposing internal details.
+    logger.error(
       `[api] First-run helper failed after valid JSON: ${err instanceof Error ? err.message : String(err)}`,
     );
+    sendJsonResponse(res, 500, { error: "Failed to complete first-run setup" });
+    return true;
   }
 
   sendJsonResponse(res, 200, { ok: true });

--- a/packages/app-core/src/api/first-run-routes.ts
+++ b/packages/app-core/src/api/first-run-routes.ts
@@ -12,6 +12,9 @@
  * completion state is on disk, the handler fires the single-flight runtime
  * boot; cloud/remote targets deliberately leave the process runtime-less.
  *
+ * Untrusted request JSON is parsed before any persist: syntax errors and
+ * non-object bodies return 400 and never report `{ ok: true }`.
+ *
  * A defensive delayed resave (`scheduleCloudApiKeyResave`) re-writes
  * `cloud.apiKey` if a concurrent config write clobbers it — a best-effort
  * workaround for an unreproduced upstream race, logged at warn on failure.
@@ -209,16 +212,26 @@ export async function handleFirstRunRoute(
     });
     return true;
   }
-  const rawBody = Buffer.concat(chunks);
+  const rawBody = Buffer.concat(chunks).toString("utf8").trim();
+  let parsed: unknown;
+  try {
+    parsed = rawBody === "" ? undefined : JSON.parse(rawBody);
+  } catch {
+    // error-policy:J3 untrusted-input sanitizing — malformed first-run JSON is
+    // an explicit 400, never a fabricated onboarding success.
+    sendJsonResponse(res, 400, { error: "Invalid JSON body" });
+    return true;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    sendJsonResponse(res, 400, { error: "Invalid JSON body" });
+    return true;
+  }
+  const body = parsed as Record<string, unknown>;
 
   let capturedCloudApiKey: string | undefined;
   let committedRuntimeTarget: DeploymentTargetRuntime | undefined;
 
   try {
-    const body = JSON.parse(rawBody.toString("utf8")) as Record<
-      string,
-      unknown
-    >;
     if (hasDeprecatedFirstRunRequestFields(body)) {
       sendJsonResponse(res, 400, {
         error:
@@ -296,8 +309,13 @@ export async function handleFirstRunRoute(
         `[api] Failed to persist first-run state: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
-  } catch {
-    // JSON parse failed — let upstream handle the error
+  } catch (err) {
+    // error-policy:J4 onboarding helpers failed after a valid JSON object;
+    // config-save errors are already warned above. Keep the historical 200
+    // ack for a parseable body so the client can poll /api/first-run/status.
+    logger.warn(
+      `[api] First-run helper failed after valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 
   sendJsonResponse(res, 200, { ok: true });


### PR DESCRIPTION
# Relates to

Closes #20813

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. JSON-parse only on app-core `POST /api/first-run`. Canonical
`{"name":"Eliza"}` still persists and 200s. Empty / non-object / unparseable
bodies 400 before `saveElizaConfig`. No login persist, billing, avatar, inbox,
or notifications change.

# Background

## What does this PR do?

`handleFirstRunRoute` no longer swallows `JSON.parse` failures as a fabricated
**200 `{ ok: true }`**. Syntax errors and non-object JSON return **400**
`Invalid JSON body` before persist or deferred runtime boot.

- `{` / `[]` / `null` / `"foo"` / empty → **400** Invalid JSON body
- `{"name":"Eliza"}` → **200** `{ ok: true }` and persist (unchanged)
- deprecated-field payloads still 400 (unchanged)

Stock treated parse failure as success. The agent twin already fail-closes.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Onboarding submit must not tell the client first-run committed when the body
never parsed. Disjoint from login persist JSON, billing checkout/quote JSON,
and Discord avatar percent-encoding.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/app-core/src/api/first-run-routes.json-body.test.ts` — reject table
plus canonical persist 200.

## Detailed testing steps

```bash
cd packages/app-core && bunx vitest run --config vitest.config.ts src/api/first-run-routes.json-body.test.ts --coverage.enabled=false
```

11 passed at head `828fd64c60e203a47d272d575e1c80059fa83ed9`.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; JSON parse only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; JSON parse only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; JSON parse only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real `handleFirstRunRoute` and assert 400 before persist; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, wallet, or generated-file writes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal JSON 400s
before persist; canonical object still 200.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file first-run JSON parse with a
green focused suite (11 tests). Full monorepo verify is unrelated to this body
grammar and was skipped to keep the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:828fd64c60e203a47d272d575e1c80059fa83ed9 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->


## Independent review repair

The original patch still returned 200 when valid JSON reached a failing persistence/helper path, which remained fabricated onboarding success. The final head returns sanitized 500 responses for those failures, adds both regressions, fixes the test response type, and rebases onto current develop. Exact-head verification passed: first-run route 13/13, app-core typecheck, focused Biome, and diff checks.
