### PR TITLE
fix(agent): reject prefix-coerced notifications limit query

### DIFF
--- a/packages/agent/src/api/notification-routes.test.ts
+++ b/packages/agent/src/api/notification-routes.test.ts
@@ -128,6 +128,67 @@ describe("handleNotificationRoute", () => {
     expect(payload.notifications.map((n) => n.title)).toEqual(["A"]);
   });
 
+  it.each(["1e2", "12px", "007", "0", "0x10", "-1", "abc", "50abc", "Infinity"])(
+    "GET rejects prefix-coerced or non-canonical limit %j before list",
+    async (limit) => {
+      await service.notify({ title: "Keep" });
+      const helpers = makeHelpers();
+      const list = vi.spyOn(service, "list");
+      await handleNotificationRoute(
+        req(`/api/notifications?limit=${limit}`),
+        res,
+        "/api/notifications",
+        "GET",
+        { runtime },
+        helpers,
+      );
+      expect(helpers.error).toHaveBeenCalledWith(
+        res,
+        "limit must be a positive integer",
+        400,
+      );
+      expect(helpers.json).not.toHaveBeenCalled();
+      expect(list).not.toHaveBeenCalled();
+    },
+  );
+
+  it("GET omitted limit still lists the unbounded inbox", async () => {
+    await service.notify({ title: "One" });
+    await service.notify({ title: "Two" });
+    const helpers = makeHelpers();
+    await handleNotificationRoute(
+      req("/api/notifications"),
+      res,
+      "/api/notifications",
+      "GET",
+      { runtime },
+      helpers,
+    );
+    const payload = helpers.json.mock.calls[0][1] as {
+      notifications: unknown[];
+    };
+    expect(payload.notifications).toHaveLength(2);
+  });
+
+  it("GET caps a canonical oversize limit at 500", async () => {
+    const helpers = makeHelpers();
+    const list = vi.spyOn(service, "list");
+    await handleNotificationRoute(
+      req("/api/notifications?limit=501"),
+      res,
+      "/api/notifications",
+      "GET",
+      { runtime },
+      helpers,
+    );
+    expect(helpers.error).not.toHaveBeenCalled();
+    expect(list).toHaveBeenCalledWith({
+      unreadOnly: false,
+      category: undefined,
+      limit: 500,
+    });
+  });
+
   it("POST creates a notification (201) via the service", async () => {
     const helpers = makeHelpers();
     helpers.readJsonBody.mockResolvedValue({

--- a/packages/agent/src/api/notification-routes.test.ts
+++ b/packages/agent/src/api/notification-routes.test.ts
@@ -128,7 +128,17 @@ describe("handleNotificationRoute", () => {
     expect(payload.notifications.map((n) => n.title)).toEqual(["A"]);
   });
 
-  it.each(["1e2", "12px", "007", "0", "0x10", "-1", "abc", "50abc", "Infinity"])(
+  it.each([
+    "1e2",
+    "12px",
+    "007",
+    "0",
+    "0x10",
+    "-1",
+    "abc",
+    "50abc",
+    "Infinity",
+  ])(
     "GET rejects prefix-coerced or non-canonical limit %j before list",
     async (limit) => {
       await service.notify({ title: "Keep" });
@@ -151,6 +161,25 @@ describe("handleNotificationRoute", () => {
       expect(list).not.toHaveBeenCalled();
     },
   );
+
+  it("GET rejects a malformed limit before service availability handling", async () => {
+    const helpers = makeHelpers();
+    await handleNotificationRoute(
+      req("/api/notifications?limit=1e2"),
+      res,
+      "/api/notifications",
+      "GET",
+      { runtime: null },
+      helpers,
+    );
+    expect(helpers.error).toHaveBeenCalledWith(
+      res,
+      "limit must be a positive integer",
+      400,
+    );
+    expect(helpers.json).not.toHaveBeenCalled();
+    expect(setHeader).not.toHaveBeenCalled();
+  });
 
   it("GET omitted limit still lists the unbounded inbox", async () => {
     await service.notify({ title: "One" });

--- a/packages/agent/src/api/notification-routes.ts
+++ b/packages/agent/src/api/notification-routes.ts
@@ -208,10 +208,13 @@ function respondServiceUnavailable(
   return true;
 }
 
-function parseLimit(raw: string | null): number | undefined {
-  if (!raw) return undefined;
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed < 0) return undefined;
+function parseLimit(raw: string | null): number | null | undefined {
+  if (raw === null || raw === "") return undefined;
+  // Strict decimal digits only. Number.parseInt("1e2", 10) === 1 would
+  // silently under-read the notification-center page as 1 row.
+  if (!/^[1-9]\d*$/.test(raw)) return null;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return null;
   return Math.min(parsed, 500);
 }
 
@@ -286,10 +289,15 @@ export async function handleNotificationRoute(
   // ── GET /api/notifications ────────────────────────────────────────
   if (method === "GET" && pathname === "/api/notifications") {
     const url = new URL(req.url ?? pathname, "http://localhost");
+    const limit = parseLimit(url.searchParams.get("limit"));
+    if (limit === null) {
+      helpers.error(res, "limit must be a positive integer", 400);
+      return true;
+    }
     const notifications = service.list({
       unreadOnly: url.searchParams.get("unreadOnly") === "true",
       category: parseCategory(url.searchParams.get("category")),
-      limit: parseLimit(url.searchParams.get("limit")),
+      limit,
     });
     helpers.json(res, {
       notifications,

--- a/packages/agent/src/api/notification-routes.ts
+++ b/packages/agent/src/api/notification-routes.ts
@@ -281,12 +281,7 @@ export async function handleNotificationRoute(
 ): Promise<boolean> {
   if (!pathname.startsWith("/api/notifications")) return false;
 
-  const service = getService(state);
-  if (!service) {
-    return respondServiceUnavailable(res, state, method, pathname, helpers);
-  }
-
-  // ── GET /api/notifications ────────────────────────────────────────
+  let listRequest: { url: URL; limit: number | undefined } | undefined;
   if (method === "GET" && pathname === "/api/notifications") {
     const url = new URL(req.url ?? pathname, "http://localhost");
     const limit = parseLimit(url.searchParams.get("limit"));
@@ -294,6 +289,17 @@ export async function handleNotificationRoute(
       helpers.error(res, "limit must be a positive integer", 400);
       return true;
     }
+    listRequest = { url, limit };
+  }
+
+  const service = getService(state);
+  if (!service) {
+    return respondServiceUnavailable(res, state, method, pathname, helpers);
+  }
+
+  // ── GET /api/notifications ────────────────────────────────────────
+  if (listRequest) {
+    const { url, limit } = listRequest;
     const notifications = service.list({
       unreadOnly: url.searchParams.get("unreadOnly") === "true",
       category: parseCategory(url.searchParams.get("category")),


### PR DESCRIPTION
## Summary

Rejects non-canonical `limit` values on `GET /api/notifications` before service availability handling or `NotificationService.list`. Omitted or empty values remain unbounded; canonical positive integers cap at 500.

Closes #20814.

## Review repair

Independent review found and repaired two blockers from the original head:

- the changed test did not pass the package Biome gate;
- malformed input could still return a service-state-dependent disabled `200` or startup `503` because availability was checked before the query grammar.

The final ordering validates the exact GET route first, then resolves service availability. Other notification routes and service-state responses are unchanged.

## Verification

Exact published head: `178c35ba33503a3499d3335f95477468a5f60e3f`.

- Notification route plus lazy-dispatch suites: 32/32 passed.
- Agent typecheck, build, and read-only Biome: passed.
- `git diff --check`: passed.
- Root `bun run verify`: reached 208/210 Turbo tasks, then stopped only on current-base issue #20824 in `packages/cloud/api/v1/limit-clamp-batch3-hono.test.ts` (TS2532/TS2493 from indexing argument 1 of a zero-argument mock). The failing file is byte-identical to `develop` and is not touched here. #20824 has active isolated repair work, so this PR does not duplicate it.

## Evidence

<!-- evidence-head:178c35ba33503a3499d3335f95477468a5f60e3f -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend query validation; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend query validation; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic HTTP route behavior.
<!-- evidence-row:backend-logs -->
- [x] Focused real-handler transcript:
  <details><summary>Exact-head route proof</summary>

  ```text
  Test Files  2 passed (2)
  Tests       32 passed (32)
  Contract    malformed limit returns 400 before list and before service availability handling; canonical and omitted limits remain accepted
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action, or evaluator path changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, wallet, or generated artifact is written.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered surface changed.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6; openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Cursor; Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported


## Independent exact-head review

The current patch validates the GET list query before service availability and any list call, preserves omitted-limit behavior, caps canonical limits at 500, and is rebased onto current develop. Focused route verification passed 28/28, plus agent typecheck, Biome, and diff review; the final rebase had no overlapping notification-file changes.
