### PR TITLE
fix(plugin-bluebubbles): reject prefix-coerced chat/message page

### DIFF
--- a/plugins/plugin-bluebubbles/__tests__/data-routes.test.ts
+++ b/plugins/plugin-bluebubbles/__tests__/data-routes.test.ts
@@ -68,7 +68,7 @@ describe("blueBubblesDataRoutes", () => {
 		expect(client.getMessages).not.toHaveBeenCalled();
 	});
 
-	it("clamps hostile pagination values for chat listing", async () => {
+	it("clamps an oversize canonical chat limit and keeps offset 0", async () => {
 		const client = {
 			listChats: vi.fn(async () => [{ guid: "chat-1" }]),
 		};
@@ -78,7 +78,7 @@ describe("blueBubblesDataRoutes", () => {
 		const res = makeResponse();
 
 		await route("/api/bluebubbles/chats", "GET").handler(
-			{ url: "/api/bluebubbles/chats?limit=999999&offset=-20" } as RouteRequest,
+			{ url: "/api/bluebubbles/chats?limit=999999" } as RouteRequest,
 			res,
 			makeRuntime(service),
 		);
@@ -92,6 +92,107 @@ describe("blueBubblesDataRoutes", () => {
 			offset: 0,
 		});
 	});
+
+	it.each(["1e2", "12px", "007", "0", "0x10", "-1", "abc"])(
+		"rejects prefix-coerced chat limit %j before listChats",
+		async (limit) => {
+			const client = {
+				listChats: vi.fn(async () => [{ guid: "chat-1" }]),
+			};
+			const service = {
+				getClient: vi.fn(() => client),
+			};
+			const res = makeResponse();
+
+			await route("/api/bluebubbles/chats", "GET").handler(
+				{ url: `/api/bluebubbles/chats?limit=${limit}` } as RouteRequest,
+				res,
+				makeRuntime(service),
+			);
+
+			expect(res.status).toHaveBeenCalledWith(400);
+			expect(res.json).toHaveBeenCalledWith({
+				error: {
+					code: "bad_request",
+					message: "limit must be a positive integer",
+				},
+			});
+			expect(client.listChats).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each(["1e2", "12px", "007", "-20", "0x10", "abc"])(
+		"rejects prefix-coerced or negative chat offset %j before listChats",
+		async (offset) => {
+			const client = {
+				listChats: vi.fn(async () => [{ guid: "chat-1" }]),
+			};
+			const service = {
+				getClient: vi.fn(() => client),
+			};
+			const res = makeResponse();
+
+			await route("/api/bluebubbles/chats", "GET").handler(
+				{ url: `/api/bluebubbles/chats?offset=${offset}` } as RouteRequest,
+				res,
+				makeRuntime(service),
+			);
+
+			expect(res.status).toHaveBeenCalledWith(400);
+			expect(res.json).toHaveBeenCalledWith({
+				error: {
+					code: "bad_request",
+					message: "offset must be a non-negative integer",
+				},
+			});
+			expect(client.listChats).not.toHaveBeenCalled();
+		},
+	);
+
+	it("accepts a canonical messages page and default offset", async () => {
+		const client = {
+			getMessages: vi.fn(async () => [{ guid: "m-1" }]),
+		};
+		const service = {
+			getClient: vi.fn(() => client),
+		};
+		const res = makeResponse();
+
+		await route("/api/bluebubbles/messages", "GET").handler(
+			{
+				url: "/api/bluebubbles/messages?chatGuid=chat-1&limit=20",
+			} as RouteRequest,
+			res,
+			makeRuntime(service),
+		);
+
+		expect(client.getMessages).toHaveBeenCalledWith("chat-1", 20, 0);
+		expect(res.status).toHaveBeenCalledWith(200);
+	});
+
+	it.each(["1e2", "12px", "007", "0"])(
+		"rejects prefix-coerced message limit %j before getMessages",
+		async (limit) => {
+			const client = {
+				getMessages: vi.fn(async () => []),
+			};
+			const service = {
+				getClient: vi.fn(() => client),
+			};
+			const res = makeResponse();
+
+			await route("/api/bluebubbles/messages", "GET").handler(
+				{
+					url: `/api/bluebubbles/messages?chatGuid=chat-1&limit=${limit}`,
+				} as RouteRequest,
+				res,
+				makeRuntime(service),
+			);
+
+			expect(res.status).toHaveBeenCalledWith(400);
+			expect(client.getMessages).not.toHaveBeenCalled();
+		},
+	);
 
 	it("rejects webhooks without the configured shared secret", async () => {
 		const service = {

--- a/plugins/plugin-bluebubbles/src/data-routes.ts
+++ b/plugins/plugin-bluebubbles/src/data-routes.ts
@@ -112,19 +112,14 @@ async function handleChats(
 	if (limit === null) {
 		res
 			.status(400)
-			.json(
-				buildSetupError("bad_request", "limit must be a positive integer"),
-			);
+			.json(buildSetupError("bad_request", "limit must be a positive integer"));
 		return;
 	}
 	if (offset === null) {
 		res
 			.status(400)
 			.json(
-				buildSetupError(
-					"bad_request",
-					"offset must be a non-negative integer",
-				),
+				buildSetupError("bad_request", "offset must be a non-negative integer"),
 			);
 		return;
 	}
@@ -191,19 +186,14 @@ async function handleMessages(
 	if (limit === null) {
 		res
 			.status(400)
-			.json(
-				buildSetupError("bad_request", "limit must be a positive integer"),
-			);
+			.json(buildSetupError("bad_request", "limit must be a positive integer"));
 		return;
 	}
 	if (offset === null) {
 		res
 			.status(400)
 			.json(
-				buildSetupError(
-					"bad_request",
-					"offset must be a non-negative integer",
-				),
+				buildSetupError("bad_request", "offset must be a non-negative integer"),
 			);
 		return;
 	}

--- a/plugins/plugin-bluebubbles/src/data-routes.ts
+++ b/plugins/plugin-bluebubbles/src/data-routes.ts
@@ -54,6 +54,28 @@ function resolveService(runtime: IAgentRuntime): BlueBubblesServiceLike | null {
 	return (raw as BlueBubblesServiceLike | null | undefined) ?? null;
 }
 
+function parsePositiveLimit(
+	raw: string | null,
+	fallback: number,
+): number | null {
+	if (raw === null || raw === "") return fallback;
+	// Strict digits only. Number.parseInt("1e2", 10) === 1 would silently
+	// return one iMessage chat/page instead of 100 (or 400).
+	if (!/^[1-9]\d*$/.test(raw)) return null;
+	const parsed = Number(raw);
+	if (!Number.isSafeInteger(parsed) || parsed <= 0) return null;
+	return Math.min(parsed, 500);
+}
+
+function parseOffset(raw: string | null): number | null {
+	if (raw === null || raw === "") return 0;
+	// "0" is a legal offset. "007" is prefix-zero junk and must 400.
+	if (raw !== "0" && !/^[1-9]\d*$/.test(raw)) return null;
+	const parsed = Number(raw);
+	if (!Number.isSafeInteger(parsed) || parsed < 0) return null;
+	return parsed;
+}
+
 // ── GET /api/bluebubbles/chats ─────────────────────────────────────
 async function handleChats(
 	req: RouteRequest,
@@ -85,17 +107,27 @@ async function handleChats(
 		return;
 	}
 	const url = new URL(req.url ?? "/api/bluebubbles/chats", "http://localhost");
-	const limit = Math.min(
-		Math.max(
-			1,
-			Number.parseInt(url.searchParams.get("limit") ?? "100", 10) || 100,
-		),
-		500,
-	);
-	const offset = Math.max(
-		0,
-		Number.parseInt(url.searchParams.get("offset") ?? "0", 10) || 0,
-	);
+	const limit = parsePositiveLimit(url.searchParams.get("limit"), 100);
+	const offset = parseOffset(url.searchParams.get("offset"));
+	if (limit === null) {
+		res
+			.status(400)
+			.json(
+				buildSetupError("bad_request", "limit must be a positive integer"),
+			);
+		return;
+	}
+	if (offset === null) {
+		res
+			.status(400)
+			.json(
+				buildSetupError(
+					"bad_request",
+					"offset must be a non-negative integer",
+				),
+			);
+		return;
+	}
 	try {
 		const chats = await client.listChats(limit, offset);
 		res.status(200).json({ chats, count: chats.length, limit, offset });
@@ -154,17 +186,27 @@ async function handleMessages(
 			);
 		return;
 	}
-	const limit = Math.min(
-		Math.max(
-			1,
-			Number.parseInt(url.searchParams.get("limit") ?? "50", 10) || 50,
-		),
-		500,
-	);
-	const offset = Math.max(
-		0,
-		Number.parseInt(url.searchParams.get("offset") ?? "0", 10) || 0,
-	);
+	const limit = parsePositiveLimit(url.searchParams.get("limit"), 50);
+	const offset = parseOffset(url.searchParams.get("offset"));
+	if (limit === null) {
+		res
+			.status(400)
+			.json(
+				buildSetupError("bad_request", "limit must be a positive integer"),
+			);
+		return;
+	}
+	if (offset === null) {
+		res
+			.status(400)
+			.json(
+				buildSetupError(
+					"bad_request",
+					"offset must be a non-negative integer",
+				),
+			);
+		return;
+	}
 	try {
 		const messages = await client.getMessages(chatGuid, limit, offset);
 		res.status(200).json({


### PR DESCRIPTION
# Relates to

Closes #20815

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. Query-parse only on BlueBubbles `GET /api/bluebubbles/chats` and
`GET /api/bluebubbles/messages`. Documented defaults stay (chats 100, messages
50, offset 0). Canonical oversize `limit` still caps at 500. Prefix-coerced
tokens 400 before the client. No cloud login/billing, avatar, inbox, or
notifications change.

# Background

## What does this PR do?

Chat/message pagination no longer uses `Number.parseInt`. Prefix-legal garbage
(`1e2`, `12px`, `007`) silently listed one iMessage row. Canonical positive
`limit` caps at 500; canonical `offset` including `0` is accepted; anything
else 400s before `listChats` / `getMessages`.

- omitted limit → 100 (chats) / 50 (messages)
- `limit=999999` → cap 500, 200
- `1e2` / `12px` / `007` / `0` → **400** `limit must be a positive integer`
- `offset=-20` / `007` / `1e2` → **400** `offset must be a non-negative integer`

Negative offset is no longer clamped to page 0.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The BlueBubbles connector is the shipped iMessage read path. A coerced page
under-reads chats/messages. Disjoint from the cloud/login/billing/avatar
classes published earlier this turn.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-bluebubbles/__tests__/data-routes.test.ts` — oversize clamp,
reject tables, and a canonical messages page.

## Detailed testing steps

```bash
cd plugins/plugin-bluebubbles && bunx vitest run --config vitest.config.ts __tests__/data-routes.test.ts --coverage.enabled=false
```

22 passed at head `fe3c6d1b0b17a04c73a15433164e5e2176c9c33b`.

# Evidence Gate

Evidence must match the exact commit reviewed. `scripts/pr-evidence.mjs rows`
sets this marker from the live PR head; rerun it after every push.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; query parse only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; query parse only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; query parse only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real handlers and assert 400 before the client; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, wallet, or generated-file writes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: illegal page tokens
400 before the client; oversize canonical limit still 500.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file BlueBubbles pagination parse
with a green focused suite (22 tests). Full monorepo verify is unrelated to
this query grammar and was skipped to keep the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:fe3c6d1b0b17a04c73a15433164e5e2176c9c33b -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->


## Independent exact-head review

Both data routes now reject noncanonical and unsafe page values before BlueBubbles client I/O, retain their documented defaults, accept canonical offset zero, and cap limit at 500. Final head is rebased onto current develop and repository-formatted. Exact-head verification passed: data routes 22/22, plugin typecheck/build, Biome, and diff check.
