### PR TITLE
fix(cloud): seal auto-top-up behind durable cutover controls

### DIFF
--- a/packages/cloud/api/__tests__/analytics-dashboard-empty-org-guard.test.ts
+++ b/packages/cloud/api/__tests__/analytics-dashboard-empty-org-guard.test.ts
@@ -95,6 +95,8 @@ beforeAll(async () => {
         slug text NOT NULL UNIQUE,
         credit_balance numeric(12,6) NOT NULL DEFAULT '0',
         balance_revision bigint NOT NULL DEFAULT 0,
+        balance_decrease_revision bigint NOT NULL DEFAULT 0,
+        auto_top_up_covered_balance_decrease_revision bigint,
         settings jsonb DEFAULT '{}',
         stripe_customer_id text,
         billing_email text,

--- a/packages/cloud/api/__tests__/auto-top-up-cutover-routes.test.ts
+++ b/packages/cloud/api/__tests__/auto-top-up-cutover-routes.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Verifies the auto-top-up cutover routes with mocked auth, limiter, logging,
+ * and service boundaries. The harness is deterministic and never opens a
+ * database connection or loads Stripe.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+import {
+  AuthenticationError,
+  ForbiddenError,
+} from "@/lib/api/cloud-worker-errors";
+import type { Bindings } from "@/types/cloud-worker-env";
+
+const ORGANIZATION_ID = "00000000-0000-4000-8000-000000000207";
+const MANUAL_PATH = "/api/auto-top-up/trigger";
+const CRON_PATH = "/api/cron/auto-top-up";
+const CRON_SECRET = "auto-top-up-cutover-test-secret";
+const PAUSED_AT = new Date("2026-08-17T12:00:00.000Z");
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  organization_id: ORGANIZATION_ID,
+}));
+const requireCronSecret = mock(
+  (context: {
+    env: { CRON_SECRET?: string };
+    req: { header(name: string): string | undefined };
+  }) => {
+    const expected = context.env.CRON_SECRET;
+    if (!expected) throw ForbiddenError("Cron secret not configured");
+    const provided =
+      context.req.header("authorization")?.replace(/^Bearer\s+/i, "") ||
+      context.req.header("x-cron-secret") ||
+      "";
+    if (provided !== expected) throw AuthenticationError("Invalid cron secret");
+  },
+);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+  requireCronSecret,
+}));
+
+const STRICT_RATE_LIMIT = { windowMs: 60_000, maxRequests: 10 } as const;
+const rateLimitConfigs: Array<Record<string, unknown>> = [];
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STRICT: STRICT_RATE_LIMIT },
+  rateLimit: (config: Record<string, unknown>) => {
+    rateLimitConfigs.push(config);
+    return async (_context: unknown, next: () => Promise<void>) => next();
+  },
+}));
+
+const executeAutoTopUpForOrganization = mock(
+  async (_organizationId: string) => ({
+    organizationId: ORGANIZATION_ID,
+    success: false as const,
+    status: "cutover_paused" as const,
+    error:
+      "Auto top-up charging is paused while the durable processor is rolled out",
+  }),
+);
+const checkAndExecuteAutoTopUps = mock(async () => ({
+  timestamp: PAUSED_AT,
+  cutoverPaused: true as const,
+  controlMode: "paused" as const,
+  organizationsChecked: 0 as const,
+  organizationsProcessed: 0 as const,
+  successful: 0 as const,
+  failed: 0 as const,
+  results: [] as [],
+}));
+
+mock.module("@/lib/services/auto-top-up", () => ({
+  autoTopUpService: {
+    executeAutoTopUpForOrganization,
+    checkAndExecuteAutoTopUps,
+  },
+}));
+
+const logInfo = mock(() => undefined);
+const logError = mock(() => undefined);
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: mock(() => undefined),
+    info: logInfo,
+    warn: mock(() => undefined),
+    error: logError,
+  },
+}));
+
+const manualRoute = (await import("../auto-top-up/trigger/route")).default;
+const cronRoute = (await import("../cron/auto-top-up/route")).default;
+
+function makeApp(path: string, route: typeof manualRoute): Hono {
+  const app = new Hono();
+  app.route(path, route);
+  return app;
+}
+
+const manualApp = makeApp(MANUAL_PATH, manualRoute);
+const cronApp = makeApp(CRON_PATH, cronRoute);
+
+function cronEnv(secret: string | null = CRON_SECRET): Bindings {
+  return (secret === null ? {} : { CRON_SECRET: secret }) as Bindings;
+}
+
+function authorizedCronRequest(method: "GET" | "POST"): Request {
+  return new Request(`http://internal${CRON_PATH}`, {
+    method,
+    headers: { authorization: `Bearer ${CRON_SECRET}` },
+  });
+}
+
+beforeEach(() => {
+  requireUserOrApiKeyWithOrg.mockClear();
+  requireUserOrApiKeyWithOrg.mockImplementation(async () => ({
+    organization_id: ORGANIZATION_ID,
+  }));
+  executeAutoTopUpForOrganization.mockClear();
+  executeAutoTopUpForOrganization.mockImplementation(async () => ({
+    organizationId: ORGANIZATION_ID,
+    success: false as const,
+    status: "cutover_paused" as const,
+    error:
+      "Auto top-up charging is paused while the durable processor is rolled out",
+  }));
+  checkAndExecuteAutoTopUps.mockClear();
+  checkAndExecuteAutoTopUps.mockImplementation(async () => ({
+    timestamp: PAUSED_AT,
+    cutoverPaused: true as const,
+    controlMode: "paused" as const,
+    organizationsChecked: 0 as const,
+    organizationsProcessed: 0 as const,
+    successful: 0 as const,
+    failed: 0 as const,
+    results: [] as [],
+  }));
+  logInfo.mockClear();
+  logError.mockClear();
+});
+
+describe("manual auto-top-up cutover route", () => {
+  test("uses STRICT fail-closed limiting and returns an explicit 503 paused state", async () => {
+    expect(rateLimitConfigs).toHaveLength(1);
+    expect(rateLimitConfigs[0]).toMatchObject({
+      ...STRICT_RATE_LIMIT,
+      failClosed: true,
+    });
+
+    const response = await manualApp.fetch(
+      new Request(`http://internal${MANUAL_PATH}`, { method: "POST" }),
+      {} as Bindings,
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("60");
+    expect(await response.json()).toMatchObject({
+      success: false,
+      status: "cutover_paused",
+      code: "service_unavailable",
+    });
+    expect(executeAutoTopUpForOrganization).toHaveBeenCalledTimes(1);
+    expect(executeAutoTopUpForOrganization).toHaveBeenCalledWith(
+      ORGANIZATION_ID,
+    );
+  });
+
+  test("requires organization authentication before calling the service", async () => {
+    requireUserOrApiKeyWithOrg.mockImplementationOnce(async () => {
+      throw AuthenticationError();
+    });
+
+    const response = await manualApp.fetch(
+      new Request(`http://internal${MANUAL_PATH}`, { method: "POST" }),
+      {} as Bindings,
+    );
+
+    expect(response.status).toBe(401);
+    expect(executeAutoTopUpForOrganization).not.toHaveBeenCalled();
+  });
+
+  test("fails closed when the control-backed service is unavailable", async () => {
+    executeAutoTopUpForOrganization.mockImplementationOnce(async () => {
+      throw new Error("control row unavailable");
+    });
+
+    const response = await manualApp.fetch(
+      new Request(`http://internal${MANUAL_PATH}`, { method: "POST" }),
+      {} as Bindings,
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(response.status).toBe(500);
+    expect(body).toMatchObject({ success: false, code: "internal_error" });
+    expect(body).not.toHaveProperty("status", "cutover_paused");
+  });
+});
+
+describe("scheduled auto-top-up cutover route", () => {
+  test.each(["GET", "POST"] as const)(
+    "accepts authenticated %s and reports paused zero work",
+    async (method) => {
+      const response = await cronApp.fetch(
+        authorizedCronRequest(method),
+        cronEnv(),
+      );
+      const body = (await response.json()) as {
+        success: boolean;
+        status: string;
+        cutoverPaused: boolean;
+        stats: Record<string, unknown>;
+      };
+
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({
+        success: true,
+        status: "cutover_paused",
+        cutoverPaused: true,
+        stats: {
+          timestamp: PAUSED_AT.toISOString(),
+          organizationsChecked: 0,
+          organizationsProcessed: 0,
+          successful: 0,
+          failed: 0,
+          details: [],
+        },
+      });
+    },
+  );
+
+  test("requires a valid configured cron secret", async () => {
+    const missingHeader = await cronApp.fetch(
+      new Request(`http://internal${CRON_PATH}`, { method: "POST" }),
+      cronEnv(),
+    );
+    const wrongHeader = await cronApp.fetch(
+      new Request(`http://internal${CRON_PATH}`, {
+        method: "POST",
+        headers: { authorization: "Bearer wrong-secret" },
+      }),
+      cronEnv(),
+    );
+    const missingConfig = await cronApp.fetch(
+      authorizedCronRequest("POST"),
+      cronEnv(null),
+    );
+
+    expect(missingHeader.status).toBe(401);
+    expect(wrongHeader.status).toBe(401);
+    expect(missingConfig.status).toBe(403);
+    expect(checkAndExecuteAutoTopUps).not.toHaveBeenCalled();
+  });
+
+  test("does not fabricate paused zero work when control lookup fails", async () => {
+    checkAndExecuteAutoTopUps.mockImplementationOnce(async () => {
+      throw new Error("control row unavailable");
+    });
+
+    const response = await cronApp.fetch(
+      authorizedCronRequest("POST"),
+      cronEnv(),
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(response.status).toBe(500);
+    expect(body).toMatchObject({ success: false, code: "internal_error" });
+    expect(body).not.toHaveProperty("stats");
+  });
+});

--- a/packages/cloud/api/__tests__/organizations-remove-member-detach.test.ts
+++ b/packages/cloud/api/__tests__/organizations-remove-member-detach.test.ts
@@ -88,6 +88,8 @@ beforeAll(async () => {
         slug text NOT NULL UNIQUE,
         credit_balance numeric(12,6) NOT NULL DEFAULT '0',
         balance_revision bigint NOT NULL DEFAULT 0,
+        balance_decrease_revision bigint NOT NULL DEFAULT 0,
+        auto_top_up_covered_balance_decrease_revision bigint,
         settings jsonb DEFAULT '{}',
         stripe_customer_id text,
         billing_email text,

--- a/packages/cloud/api/auto-top-up/trigger/route.ts
+++ b/packages/cloud/api/auto-top-up/trigger/route.ts
@@ -1,11 +1,10 @@
 /**
- * POST /api/auto-top-up/trigger
- * Manually triggers an auto top-up check for the authenticated user's
- * organization. Useful for testing without waiting for cron.
+ * Translates an authenticated organization's manual auto-top-up request
+ * through the sealed cutover bridge. This boundary never reads or recomputes
+ * money values and rejects requests when the shared limiter is unavailable.
  */
 
 import { Hono } from "hono";
-import { organizationsRepository } from "@/db/repositories";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
@@ -18,57 +17,39 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
-app.use("*", rateLimit(RateLimitPresets.STRICT));
+app.use(
+  "*",
+  rateLimit({
+    ...RateLimitPresets.STRICT,
+    failClosed: true,
+  }),
+);
 
 app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
-    const org = await organizationsRepository.findById(user.organization_id);
-    if (!org) return c.json({ error: "Organization not found" }, 404);
+    const result = await autoTopUpService.executeAutoTopUpForOrganization(
+      user.organization_id,
+    );
 
-    if (!org.auto_top_up_enabled) {
-      return c.json(
-        {
-          error: "Auto top-up is not enabled",
-          message: "Please enable auto top-up first",
-        },
-        400,
-      );
-    }
-
-    const currentBalance = Number(org.credit_balance || 0);
-    const threshold = Number(org.auto_top_up_threshold || 0);
-
-    if (currentBalance >= threshold) {
-      return c.json({
-        success: false,
-        message: `Balance ($${currentBalance.toFixed(2)}) is above threshold ($${threshold.toFixed(2)}). Auto top-up not needed.`,
-        currentBalance,
-        threshold,
-      });
-    }
-
-    const result = await autoTopUpService.executeAutoTopUp(org);
-
-    if (result.success) {
-      return c.json({
-        success: true,
-        message: `Auto top-up successful! Added $${result.amount?.toFixed(2)}`,
-        amount: result.amount,
-        previousBalance: currentBalance,
-        newBalance: result.newBalance,
-      });
-    }
     return c.json(
       {
         success: false,
-        error: result.error || "Auto top-up failed",
-        message: "Please check your payment method and try again",
+        status: result.status,
+        code: "service_unavailable" as const,
+        error: result.error,
+        message:
+          "Auto top-up charging is temporarily paused during the durable cutover.",
       },
-      400,
+      503,
+      { "Retry-After": "60" },
     );
   } catch (error) {
-    logger.error("Error triggering auto top-up:", error);
+    // error-policy:J1 boundary translation — auth and cutover-control failures
+    // remain explicit transport errors and can never fall through to charging.
+    logger.error("[AutoTopUp] Manual cutover request failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
     return failureResponse(c, error);
   }
 });

--- a/packages/cloud/api/cron/auto-top-up/route.ts
+++ b/packages/cloud/api/cron/auto-top-up/route.ts
@@ -1,10 +1,10 @@
 /**
- * GET /api/cron/auto-top-up
- * Periodic cron that processes auto top-up for orgs whose balance is below
- * threshold. Protected by CRON_SECRET.
+ * Exposes the secret-protected scheduled auto-top-up cutover check. Both the
+ * Worker scheduler's POST and an operator's GET return the authoritative
+ * paused state with zero work while this bridge release is deployed.
  */
 
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireCronSecret } from "@/lib/auth/workers-hono-auth";
 import { autoTopUpService } from "@/lib/services/auto-top-up";
@@ -13,51 +13,49 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
-app.get("/", async (c) => {
+async function handleAutoTopUpCutover(c: Context<AppEnv>) {
   const startTime = Date.now();
   try {
     requireCronSecret(c);
 
-    logger.info("auto-top-up-cron", "Starting auto top-up check");
-
     const result = await autoTopUpService.checkAndExecuteAutoTopUps();
-    const duration = Date.now() - startTime;
+    const durationMs = Date.now() - startTime;
 
-    logger.info("auto-top-up-cron", "Auto top-up check completed", {
-      duration: `${duration}ms`,
+    logger.info("[AutoTopUp] Scheduled cutover check remained sealed", {
+      durationMs,
+      controlMode: result.controlMode,
       checked: result.organizationsChecked,
       processed: result.organizationsProcessed,
-      successful: result.successful,
-      failed: result.failed,
     });
 
     return c.json({
       success: true,
-      message: "Auto top-up check completed successfully",
+      status: "cutover_paused" as const,
+      message: "Auto top-up charging is paused during the durable cutover.",
+      cutoverPaused: result.cutoverPaused,
+      controlMode: result.controlMode,
       stats: {
         timestamp: result.timestamp.toISOString(),
-        duration: `${duration}ms`,
+        durationMs,
         organizationsChecked: result.organizationsChecked,
         organizationsProcessed: result.organizationsProcessed,
         successful: result.successful,
         failed: result.failed,
-        details: result.results.map((r) => ({
-          organizationId: r.organizationId,
-          success: r.success,
-          amount: r.amount,
-          newBalance: r.newBalance,
-          error: r.error,
-        })),
+        details: result.results,
       },
     });
   } catch (error) {
-    const duration = Date.now() - startTime;
-    logger.error("auto-top-up-cron", "Auto top-up check failed", {
-      error: error instanceof Error ? error.message : "Unknown error",
-      duration: `${duration}ms`,
+    // error-policy:J1 boundary translation — a missing secret or unavailable
+    // control authority is returned as failure, never fabricated zero work.
+    logger.error("[AutoTopUp] Scheduled cutover check failed", {
+      error: error instanceof Error ? error.message : String(error),
+      durationMs: Date.now() - startTime,
     });
     return failureResponse(c, error);
   }
-});
+}
+
+app.get("/", handleAutoTopUpCutover);
+app.post("/", handleAutoTopUpCutover);
 
 export default app;

--- a/packages/cloud/api/v1/billing/settings/route.test.ts
+++ b/packages/cloud/api/v1/billing/settings/route.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Exercises billing-settings corruption responses and method-specific rate
+ * limits without loading Stripe, Redis, or a database.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const ORGANIZATION_ID = "00000000-0000-4000-8000-000000000207";
+const STANDARD_RATE_LIMIT = { windowMs: 60_000, maxRequests: 100 } as const;
+const rateLimitConfigs: Array<Record<string, unknown>> = [];
+
+class AutoTopUpSettingsValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AutoTopUpSettingsValidationError";
+  }
+}
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "user-20717",
+  organization_id: ORGANIZATION_ID,
+}));
+const getSettings = mock(async () => ({
+  enabled: false,
+  amount: null,
+  threshold: null,
+  hasPaymentMethod: true,
+}));
+const updateSettings = mock(async () => undefined);
+const findOrganizationById = mock(async () => ({
+  id: ORGANIZATION_ID,
+  pay_as_you_go_from_earnings: false,
+}));
+const updateOrganization = mock(async () => undefined);
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/db/repositories", () => ({
+  organizationsRepository: {
+    findById: findOrganizationById,
+    update: updateOrganization,
+  },
+}));
+
+mock.module("@/lib/services/auto-top-up", () => ({
+  AUTO_TOP_UP_LIMITS: {
+    MIN_AMOUNT: 1,
+    MAX_AMOUNT: 1000,
+    MIN_THRESHOLD: 0,
+    MAX_THRESHOLD: 1000,
+  },
+  AutoTopUpSettingsValidationError,
+  autoTopUpService: { getSettings, updateSettings },
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: STANDARD_RATE_LIMIT },
+  rateLimit: (config: Record<string, unknown>) => {
+    rateLimitConfigs.push(config);
+    return async (_context: unknown, next: () => Promise<void>) => next();
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: mock(() => undefined),
+    error: mock(() => undefined),
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+  },
+}));
+
+const { default: app } = await import("./route");
+
+beforeEach(() => {
+  requireUserOrApiKeyWithOrg.mockClear();
+  getSettings.mockClear();
+  getSettings.mockResolvedValue({
+    enabled: false,
+    amount: null,
+    threshold: null,
+    hasPaymentMethod: true,
+  });
+  updateSettings.mockClear();
+  updateSettings.mockResolvedValue(undefined);
+  findOrganizationById.mockClear();
+  findOrganizationById.mockResolvedValue({
+    id: ORGANIZATION_ID,
+    pay_as_you_go_from_earnings: false,
+  });
+  updateOrganization.mockClear();
+});
+
+describe("billing settings cutover safety", () => {
+  test("keeps GET standard and makes PUT standard fail-closed", () => {
+    expect(rateLimitConfigs).toEqual([
+      STANDARD_RATE_LIMIT,
+      { ...STANDARD_RATE_LIMIT, failClosed: true },
+    ]);
+  });
+
+  test("returns honest null values for disabled corrupt settings", async () => {
+    const response = await app.fetch(new Request("http://internal/"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      settings: {
+        autoTopUp: {
+          enabled: false,
+          amount: null,
+          threshold: null,
+        },
+      },
+    });
+  });
+
+  test("persists a fail-closed disable and returns null corrupt values", async () => {
+    const response = await app.fetch(
+      new Request("http://internal/", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ autoTopUp: { enabled: false } }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(updateSettings).toHaveBeenCalledWith(ORGANIZATION_ID, {
+      enabled: false,
+      amount: undefined,
+      threshold: undefined,
+    });
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      settings: {
+        autoTopUp: {
+          enabled: false,
+          amount: null,
+          threshold: null,
+        },
+      },
+    });
+  });
+
+  test("returns a sanitized 400 when corrupt values are enabled implicitly", async () => {
+    updateSettings.mockRejectedValueOnce(
+      new AutoTopUpSettingsValidationError("private corrupt value: NaN"),
+    );
+
+    const response = await app.fetch(
+      new Request("http://internal/", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ autoTopUp: { enabled: true } }),
+      }),
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({
+      success: false,
+      error:
+        "Valid auto top-up values are required to replace corrupt settings.",
+      code: "validation_error",
+    });
+    expect(JSON.stringify(body)).not.toContain("NaN");
+  });
+
+  test("returns the same sanitized 400 for a partial update with hidden corruption", async () => {
+    updateSettings.mockRejectedValueOnce(
+      new AutoTopUpSettingsValidationError(
+        "private corrupt threshold: not-a-number",
+      ),
+    );
+
+    const response = await app.fetch(
+      new Request("http://internal/", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ autoTopUp: { amount: 25 } }),
+      }),
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({
+      success: false,
+      error:
+        "Valid auto top-up values are required to replace corrupt settings.",
+      code: "validation_error",
+    });
+    expect(JSON.stringify(body)).not.toContain("not-a-number");
+  });
+});

--- a/packages/cloud/api/v1/billing/settings/route.ts
+++ b/packages/cloud/api/v1/billing/settings/route.ts
@@ -20,6 +20,7 @@ import {
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
 import {
   AUTO_TOP_UP_LIMITS,
+  AutoTopUpSettingsValidationError,
   autoTopUpService,
 } from "@/lib/services/auto-top-up";
 import { logger } from "@/lib/utils/logger";
@@ -46,9 +47,7 @@ const UpdateSettingsSchema = z.object({
 
 const app = new Hono<AppEnv>();
 
-app.use("*", rateLimit(RateLimitPresets.STANDARD));
-
-app.get("/", async (c) => {
+app.get("/", rateLimit(RateLimitPresets.STANDARD), async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
 
@@ -81,90 +80,112 @@ app.get("/", async (c) => {
   }
 });
 
-app.put("/", async (c) => {
-  try {
-    const user = await requireUserOrApiKeyWithOrg(c);
+app.put(
+  "/",
+  rateLimit({ ...RateLimitPresets.STANDARD, failClosed: true }),
+  async (c) => {
+    try {
+      const user = await requireUserOrApiKeyWithOrg(c);
 
-    const body = await c.req.json();
-    const validation = UpdateSettingsSchema.safeParse(body);
+      const body = await c.req.json();
+      const validation = UpdateSettingsSchema.safeParse(body);
 
-    if (!validation.success) {
-      return c.json(
-        {
-          success: false,
-          error: "Invalid request data",
-          details: validation.error.format(),
-        },
-        400,
-      );
-    }
-
-    const { autoTopUp, payAsYouGoFromEarnings } = validation.data;
-
-    if (autoTopUp) {
-      try {
-        await autoTopUpService.updateSettings(user.organization_id, {
-          enabled: autoTopUp.enabled,
-          amount: autoTopUp.amount,
-          threshold: autoTopUp.threshold,
-        });
-      } catch (err) {
-        // Allow domain-specific validation messages through (e.g. "Cannot
-        // enable auto-top-up without a payment method") — they don't leak
-        // internals.
-        const message = err instanceof Error ? err.message : "";
-        const isValidationError =
-          message.includes("Cannot enable") ||
-          message.includes("must be") ||
-          message.includes("cannot exceed");
-        if (isValidationError) {
-          return c.json({ success: false, error: message }, 400);
-        }
-        throw err;
+      if (!validation.success) {
+        return c.json(
+          {
+            success: false,
+            error: "Invalid request data",
+            details: validation.error.format(),
+          },
+          400,
+        );
       }
 
-      logger.info("[Billing Settings API] Updated auto-top-up settings", {
-        organizationId: user.organization_id,
-        userId: user.id,
-        settings: autoTopUp,
-      });
-    }
+      const { autoTopUp, payAsYouGoFromEarnings } = validation.data;
 
-    if (payAsYouGoFromEarnings !== undefined) {
-      await organizationsRepository.update(user.organization_id, {
-        pay_as_you_go_from_earnings: payAsYouGoFromEarnings,
-        updated_at: new Date(),
-      });
+      if (autoTopUp) {
+        try {
+          await autoTopUpService.updateSettings(user.organization_id, {
+            enabled: autoTopUp.enabled,
+            amount: autoTopUp.amount,
+            threshold: autoTopUp.threshold,
+          });
+        } catch (err) {
+          if (err instanceof AutoTopUpSettingsValidationError) {
+            return c.json(
+              {
+                success: false,
+                error:
+                  "Valid auto top-up values are required to replace corrupt settings.",
+                code: "validation_error" as const,
+              },
+              400,
+            );
+          }
+          // Allow domain-specific validation messages through (e.g. "Cannot
+          // enable auto-top-up without a payment method") — they don't leak
+          // internals.
+          const message = err instanceof Error ? err.message : "";
+          const isValidationError =
+            message.includes("Cannot enable") ||
+            message.includes("must be") ||
+            message.includes("cannot exceed");
+          if (isValidationError) {
+            return c.json(
+              {
+                success: false,
+                error: message,
+                code: "validation_error" as const,
+              },
+              400,
+            );
+          }
+          throw err;
+        }
 
-      logger.info("[Billing Settings API] Updated pay-as-you-go toggle", {
-        organizationId: user.organization_id,
-        userId: user.id,
-        enabled: payAsYouGoFromEarnings,
-      });
-    }
+        logger.info("[Billing Settings API] Updated auto-top-up settings", {
+          organizationId: user.organization_id,
+          userId: user.id,
+          settings: autoTopUp,
+        });
+      }
 
-    const [updatedSettings, org] = await Promise.all([
-      autoTopUpService.getSettings(user.organization_id),
-      organizationsRepository.findById(user.organization_id),
-    ]);
+      if (payAsYouGoFromEarnings !== undefined) {
+        await organizationsRepository.update(user.organization_id, {
+          pay_as_you_go_from_earnings: payAsYouGoFromEarnings,
+          updated_at: new Date(),
+        });
 
-    return c.json({
-      success: true,
-      message: "Billing settings updated successfully",
-      settings: {
-        autoTopUp: {
-          enabled: updatedSettings.enabled,
-          amount: updatedSettings.amount,
-          threshold: updatedSettings.threshold,
-          hasPaymentMethod: updatedSettings.hasPaymentMethod,
+        logger.info("[Billing Settings API] Updated pay-as-you-go toggle", {
+          organizationId: user.organization_id,
+          userId: user.id,
+          enabled: payAsYouGoFromEarnings,
+        });
+      }
+
+      const [updatedSettings, org] = await Promise.all([
+        autoTopUpService.getSettings(user.organization_id),
+        organizationsRepository.findById(user.organization_id),
+      ]);
+
+      return c.json({
+        success: true,
+        message: "Billing settings updated successfully",
+        settings: {
+          autoTopUp: {
+            enabled: updatedSettings.enabled,
+            amount: updatedSettings.amount,
+            threshold: updatedSettings.threshold,
+            hasPaymentMethod: updatedSettings.hasPaymentMethod,
+          },
+          payAsYouGoFromEarnings: org?.pay_as_you_go_from_earnings ?? true,
         },
-        payAsYouGoFromEarnings: org?.pay_as_you_go_from_earnings ?? true,
-      },
-    });
-  } catch (error) {
-    logger.error("[Billing Settings API] Error updating settings:", error);
-    return failureResponse(c, error);
-  }
-});
+      });
+    } catch (error) {
+      logger.error("[Billing Settings API] Error updating settings:", error);
+      return failureResponse(c, error);
+    }
+  },
+);
 
 export default app;

--- a/packages/cloud/shared/docs/auto-top-up-durable-cutover.md
+++ b/packages/cloud/shared/docs/auto-top-up-durable-cutover.md
@@ -1,0 +1,120 @@
+# Durable auto-top-up cutover
+
+This runbook separates three things that must not be conflated:
+
+- **Previous processor:** the pre-ledger implementation that can call Stripe
+  directly and uses a time-bucket idempotency key.
+- **Sealed bridge:** the transition release. It can reconcile payments that
+  already exist, but it cannot create a new auto-top-up PaymentIntent.
+- **Durable processor:** the follow-up release that records and leases an
+  attempt before contacting Stripe and reuses one stable provider key.
+
+The database control row is the charging authority. It starts in `paused`.
+Deploying code or setting a Worker variable alone must never start charging.
+
+## Invariant
+
+At most one processor generation may be able to create an auto-top-up payment
+for an organization. An invocation of an older Worker can remain in flight
+after a newer version is deployed, so a deploy timestamp or quiet timer is not
+a provider fence.
+
+The organization-level covered-decrease revision is the canonical re-arm
+fence. Existing organizations are conservatively baselined during migration;
+a real `auto_top_up` credit advances the fence in the same database transaction
+as the credit row. Retrying or changing processor versions must not re-arm an
+organization without a later balance decrease.
+
+## Transition release behavior
+
+The sealed bridge intentionally creates a short maintenance window for
+automatic card recharges:
+
+1. the control row is created in `paused` mode;
+2. cron and post-debit checks report paused and do zero charging work;
+3. the authenticated manual trigger returns a distinct maintenance response;
+4. signed webhooks may still reconcile provider payments created before the
+   bridge was deployed;
+5. organization deletion and the last user's departure are blocked while the
+   control row is `paused`, because an older provider payment may not have been
+   inventoried yet;
+6. moving the control row to `durable` does not unseal this bridge binary.
+
+Do not activate `durable` while only the bridge binary is deployed.
+This foundation release does not expose an activation command. The reviewed,
+dry-run-first operator command for inventory, quarantine resolution, and the
+guarded control transition must ship with the durable processor before any
+cutover is attempted. Direct SQL is not a supported activation procedure.
+
+The lifecycle guard is an intentional, operator-visible maintenance impact.
+Migration `0217` enforces it globally: while `auto_top_up_control.mode` is
+`paused`, it blocks organization deletion and last-user departure even when no
+attempt or quarantine row is known, because a pre-cutover PaymentIntent may not
+have been inventoried yet. After activation the guard becomes
+organization-scoped: unresolved payments still block deletion or last-user
+departure, and a terminal organization must have a zero primary credit balance
+before its last user can leave.
+
+API boundaries translate the stable database guard identifiers without
+exposing SQL: a globally paused lifecycle operation returns `503
+service_unavailable` with `Retry-After`, while organization-specific unresolved
+work or a nonzero primary balance returns `409 billing_state_conflict`.
+
+## Production activation (human-gated)
+
+This procedure mutates payment infrastructure and secrets. It requires an
+explicit operator approval and a claimed production lever. A normal merge or
+deploy does not authorize it.
+
+1. Deploy the sealed bridge and migrations, then verify that 100% of Worker
+   traffic uses the reviewed version. Confirm manual and scheduled triggers do
+   no charging work.
+2. Deploy the durable-processor release with its secondary runtime kill switch
+   disabled and the database control still `paused`.
+3. Establish a provider-side fence against older Worker invocations. Use an
+   approved replacement/revocation strategy for the Stripe credential capable
+   of creating these PaymentIntents. Merely omitting a Worker secret is not
+   proof: deploy tooling can preserve existing bindings.
+4. Page through Stripe PaymentIntents using the authoritative list API for the
+   full cutover interval. Do not use eventually-consistent search as the
+   inventory. Reconcile every `auto_top_up` intent created before the provider
+   fence, including intents whose HTTP response was lost.
+5. Drain and inspect the Stripe webhook queue and dead-letter queue. Successful
+   intents must have exactly one matching credit; canceled intents must not have
+   a credit; processing, malformed, or otherwise ambiguous intents remain
+   quarantined with auto-top-up disabled for that organization.
+6. In the primary database, verify the reconciliation watermark, zero
+   unresolved imported payments, valid organization re-arm baselines, and no
+   unresolved durable attempt that could overlap activation.
+7. Transition the database control from `paused` to `durable` with its guarded
+   compare-and-set operation. Only after that transaction succeeds may the
+   exact reviewed durable runtime switch be enabled.
+8. Observe claim, lease, provider-id reuse, credit, terminal-state, and manual
+   review logs before declaring the cutover complete.
+
+Record the exact Worker version, database migration/head, provider-key change,
+Stripe inventory high-water mark, queue/DLQ counts, control-row transition, and
+reviewer approval as deployment evidence. Never put credentials in that record.
+
+## Rollback
+
+1. Move the database control from `durable` to `paused`. This is the
+   linearizable stop for new claims.
+2. Disable the secondary durable runtime switch.
+3. Keep the recovery-capable durable binary deployed while existing attempts
+   converge or enter manual review.
+4. Investigate and reconcile before re-enabling charging.
+
+Do **not** redeploy the previous processor as a rollback. It does not understand
+the durable attempt ledger or organization re-arm fence and can create a new
+provider charge for a balance already covered by a durable attempt.
+
+## Unsafe shortcuts
+
+- waiting a fixed number of minutes instead of fencing the old provider key;
+- assuming an omitted Worker secret was deleted;
+- activating from a Worker variable without the database transition;
+- checking only non-terminal durable attempts while ignoring older provider
+  payments or the webhook DLQ;
+- using Stripe Search instead of a complete paginated inventory;
+- rolling back to the previous direct-charging implementation.

--- a/packages/cloud/shared/src/db/auto-top-up-cutover-migrations.test.ts
+++ b/packages/cloud/shared/src/db/auto-top-up-cutover-migrations.test.ts
@@ -1,0 +1,644 @@
+/**
+ * Applies migrations 0213-0217 to real PGlite and proves the auto-top-up ledger's
+ * tenant foreign keys, blocking uniqueness, nullable terminal schedule, lease
+ * checks, provider identities, lifecycle guards, and migration registration.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { PGlite } from "@electric-sql/pglite";
+
+const ORG_A = "10000000-0000-4000-8000-000000000001";
+const ORG_B = "10000000-0000-4000-8000-000000000002";
+const ORG_C = "10000000-0000-4000-8000-000000000003";
+const ATTEMPT_A = "20000000-0000-4000-8000-000000000001";
+const ATTEMPT_B = "20000000-0000-4000-8000-000000000002";
+const CREDIT_TX = "30000000-0000-4000-8000-000000000001";
+const USER_A = "40000000-0000-4000-8000-000000000001";
+
+async function migrationSql(): Promise<string> {
+  const [organizationFence, organizationBackfill, attempts, control, lifecycleGuards] =
+    await Promise.all([
+      readFile(
+        new URL("./migrations/0213_auto_top_up_organization_fence.sql", import.meta.url),
+        "utf8",
+      ),
+      readFile(
+        new URL("./migrations/0214_backfill_auto_top_up_organization_fence.sql", import.meta.url),
+        "utf8",
+      ),
+      readFile(new URL("./migrations/0215_auto_top_up_attempts.sql", import.meta.url), "utf8"),
+      readFile(
+        new URL("./migrations/0216_auto_top_up_cutover_control.sql", import.meta.url),
+        "utf8",
+      ),
+      readFile(
+        new URL("./migrations/0217_guard_auto_top_up_cutover_lifecycle.sql", import.meta.url),
+        "utf8",
+      ),
+    ]);
+  return `${organizationFence}\n${organizationBackfill}\n${attempts}\n${control}\n${lifecycleGuards}`;
+}
+
+async function createPrerequisites(database: PGlite): Promise<void> {
+  await database.exec(`
+    CREATE TABLE "organizations" (
+      "id" uuid PRIMARY KEY,
+      "credit_balance" numeric(12,6) NOT NULL DEFAULT 0,
+      "auto_top_up_enabled" boolean NOT NULL DEFAULT true
+    );
+    CREATE TABLE "users" (
+      "id" uuid PRIMARY KEY,
+      "organization_id" uuid REFERENCES "organizations"("id") ON DELETE CASCADE
+    );
+    CREATE TABLE "credit_transactions" (
+      "id" uuid PRIMARY KEY,
+      "organization_id" uuid NOT NULL
+        REFERENCES "organizations"("id") ON DELETE CASCADE,
+      "amount" numeric(12,6) NOT NULL DEFAULT 0,
+      "type" text NOT NULL DEFAULT 'credit',
+      "metadata" jsonb NOT NULL DEFAULT '{}'::jsonb,
+      "stripe_payment_intent_id" text
+    );
+    CREATE UNIQUE INDEX "credit_transactions_stripe_payment_intent_idx"
+      ON "credit_transactions" ("stripe_payment_intent_id");
+    INSERT INTO "organizations" ("id", "credit_balance")
+    VALUES ('${ORG_A}', 10), ('${ORG_B}', 10);
+  `);
+}
+
+function validAttempt(id: string, organizationId: string, idempotencyKey: string): string {
+  return `
+    INSERT INTO "auto_top_up_attempts" (
+      "id", "organization_id", "trigger_source", "status",
+      "credit_amount_cents", "charge_amount_cents", "currency",
+      "stripe_customer_id_snapshot", "stripe_payment_method_id_snapshot",
+      "idempotency_key"
+    ) VALUES (
+      '${id}', '${organizationId}', 'cron', 'claimed',
+      1000, 1200, 'usd', 'cus_snapshot', 'pm_snapshot', '${idempotencyKey}'
+    );
+  `;
+}
+
+async function expectDatabaseConstraint(
+  operation: Promise<unknown>,
+  expected: { code: "23503" | "23514"; constraint: string },
+): Promise<void> {
+  let rejection: unknown;
+  try {
+    await operation;
+  } catch (error) {
+    rejection = error;
+  }
+  expect(rejection).toMatchObject(expected);
+}
+
+describe("0213-0217 auto-top-up cutover foundation", () => {
+  const databases: PGlite[] = [];
+
+  afterEach(async () => {
+    await Promise.all(databases.splice(0).map((database) => database.close()));
+  });
+
+  test("is journaled, idempotent, and exposes the intended columns and indexes", async () => {
+    const database = new PGlite();
+    databases.push(database);
+    await createPrerequisites(database);
+    const migration = await migrationSql();
+    await database.exec(migration);
+    await database.exec(migration);
+
+    const journal = JSON.parse(
+      await readFile(new URL("./migrations/meta/_journal.json", import.meta.url), "utf8"),
+    ) as {
+      entries: Array<{
+        idx: number;
+        version: string;
+        when: number;
+        tag: string;
+        breakpoints: boolean;
+      }>;
+    };
+    expect(
+      journal.entries.find((entry) => entry.tag === "0213_auto_top_up_organization_fence"),
+    ).toEqual({
+      idx: 212,
+      version: "7",
+      when: 1787860800003,
+      tag: "0213_auto_top_up_organization_fence",
+      breakpoints: true,
+    });
+    expect(
+      journal.entries.find((entry) => entry.tag === "0214_backfill_auto_top_up_organization_fence"),
+    ).toEqual({
+      idx: 213,
+      version: "7",
+      when: 1787860800004,
+      tag: "0214_backfill_auto_top_up_organization_fence",
+      breakpoints: true,
+    });
+    expect(journal.entries.find((entry) => entry.tag === "0215_auto_top_up_attempts")).toEqual({
+      idx: 214,
+      version: "7",
+      when: 1787860800005,
+      tag: "0215_auto_top_up_attempts",
+      breakpoints: true,
+    });
+    expect(
+      journal.entries.find((entry) => entry.tag === "0216_auto_top_up_cutover_control"),
+    ).toEqual({
+      idx: 215,
+      version: "7",
+      when: 1787860800006,
+      tag: "0216_auto_top_up_cutover_control",
+      breakpoints: true,
+    });
+    expect(
+      journal.entries.find((entry) => entry.tag === "0217_guard_auto_top_up_cutover_lifecycle"),
+    ).toEqual({
+      idx: 216,
+      version: "7",
+      when: 1787860800007,
+      tag: "0217_guard_auto_top_up_cutover_lifecycle",
+      breakpoints: true,
+    });
+
+    const columns = await database.query<{
+      column_name: string;
+      data_type: string;
+      is_nullable: "YES" | "NO";
+    }>(`
+      SELECT column_name, data_type, is_nullable
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'auto_top_up_attempts'
+      ORDER BY column_name
+    `);
+    expect(columns.rows).toHaveLength(29);
+    expect(columns.rows).toContainEqual({
+      column_name: "credit_amount_cents",
+      data_type: "bigint",
+      is_nullable: "NO",
+    });
+    expect(columns.rows).toContainEqual({
+      column_name: "next_attempt_at",
+      data_type: "timestamp with time zone",
+      is_nullable: "YES",
+    });
+    expect(columns.rows).toContainEqual({
+      column_name: "covered_balance_decrease_revision",
+      data_type: "bigint",
+      is_nullable: "YES",
+    });
+
+    const organizationColumns = await database.query<{
+      column_name: string;
+      data_type: string;
+      is_nullable: "YES" | "NO";
+    }>(`
+      SELECT column_name, data_type, is_nullable
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'organizations'
+    `);
+    expect(organizationColumns.rows).toContainEqual({
+      column_name: "balance_decrease_revision",
+      data_type: "bigint",
+      is_nullable: "NO",
+    });
+    expect(organizationColumns.rows).toContainEqual({
+      column_name: "auto_top_up_covered_balance_decrease_revision",
+      data_type: "bigint",
+      is_nullable: "YES",
+    });
+    expect(columns.rows).toContainEqual({
+      column_name: "provider_request_started_at",
+      data_type: "timestamp with time zone",
+      is_nullable: "YES",
+    });
+
+    const indexes = await database.query<{ indexname: string }>(`
+      SELECT indexname FROM pg_indexes
+      WHERE tablename = 'auto_top_up_attempts'
+      ORDER BY indexname
+    `);
+    expect(indexes.rows.map((row) => row.indexname)).toEqual([
+      "auto_top_up_attempts_blocking_org_idx",
+      "auto_top_up_attempts_due_idx",
+      "auto_top_up_attempts_idempotency_key_idx",
+      "auto_top_up_attempts_org_created_idx",
+      "auto_top_up_attempts_payment_intent_idx",
+      "auto_top_up_attempts_pkey",
+    ]);
+  });
+
+  test("advances the durable balance-decrease revision only when balance falls", async () => {
+    const database = new PGlite();
+    databases.push(database);
+    await createPrerequisites(database);
+    await database.exec(await migrationSql());
+
+    const revision = async (): Promise<number> => {
+      const result = await database.query<{ revision: string }>(`
+        SELECT balance_decrease_revision::text AS revision
+        FROM organizations WHERE id = '${ORG_A}'
+      `);
+      return Number(result.rows[0]?.revision);
+    };
+
+    expect(await revision()).toBe(0);
+    await database.exec(`UPDATE organizations SET credit_balance = 11 WHERE id = '${ORG_A}'`);
+    expect(await revision()).toBe(0);
+    await database.exec(`UPDATE organizations SET credit_balance = 11 WHERE id = '${ORG_A}'`);
+    expect(await revision()).toBe(0);
+    await database.exec(`UPDATE organizations SET credit_balance = 9 WHERE id = '${ORG_A}'`);
+    const firstDecrease = await revision();
+    expect(firstDecrease).toBeGreaterThan(0);
+    await database.exec(`UPDATE organizations SET credit_balance = 12 WHERE id = '${ORG_A}'`);
+    expect(await revision()).toBe(firstDecrease);
+    await database.exec(`UPDATE organizations SET credit_balance = 8 WHERE id = '${ORG_A}'`);
+    expect(await revision()).toBeGreaterThan(firstDecrease);
+  });
+
+  test("backfills an existing organization fence but leaves a new organization unfenced", async () => {
+    const database = new PGlite();
+    databases.push(database);
+    await createPrerequisites(database);
+    await database.exec(await migrationSql());
+
+    const existing = await database.query<{
+      revision: string;
+      covered: string | null;
+    }>(`
+      SELECT balance_decrease_revision::text AS revision,
+        auto_top_up_covered_balance_decrease_revision::text AS covered
+      FROM organizations WHERE id = '${ORG_A}'
+    `);
+    expect(existing.rows[0]).toEqual({ revision: "0", covered: "0" });
+
+    await database.exec(`
+      INSERT INTO organizations (id, credit_balance, auto_top_up_enabled)
+      VALUES ('${ORG_C}', 1, true)
+    `);
+    const created = await database.query<{ covered: string | null }>(`
+      SELECT auto_top_up_covered_balance_decrease_revision::text AS covered
+      FROM organizations WHERE id = '${ORG_C}'
+    `);
+    expect(created.rows[0]?.covered).toBeNull();
+
+    await database.exec(`UPDATE organizations SET credit_balance = 9 WHERE id = '${ORG_A}'`);
+    const rearmed = await database.query<{ rearmed: boolean }>(`
+      SELECT balance_decrease_revision <> auto_top_up_covered_balance_decrease_revision AS rearmed
+      FROM organizations WHERE id = '${ORG_A}'
+    `);
+    expect(rearmed.rows[0]?.rearmed).toBe(true);
+  });
+
+  test("fences a real legacy credit insert and a duplicate PI no-op cannot restamp it", async () => {
+    const database = new PGlite();
+    databases.push(database);
+    await createPrerequisites(database);
+    await database.exec(await migrationSql());
+    await database.exec(`UPDATE organizations SET credit_balance = 9 WHERE id = '${ORG_A}'`);
+
+    await database.exec(`
+      INSERT INTO credit_transactions (
+        id, organization_id, amount, type, metadata, stripe_payment_intent_id
+      ) VALUES (
+        '${CREDIT_TX}', '${ORG_A}', 10, 'credit', '{"type":"auto_top_up"}', 'pi_legacy'
+      )
+    `);
+    const firstFence = await database.query<{ covered: string; revision: string }>(`
+      SELECT auto_top_up_covered_balance_decrease_revision::text AS covered,
+        balance_decrease_revision::text AS revision
+      FROM organizations WHERE id = '${ORG_A}'
+    `);
+    expect(firstFence.rows[0]?.covered).toBe(firstFence.rows[0]?.revision);
+
+    await database.exec(`UPDATE organizations SET credit_balance = 8 WHERE id = '${ORG_A}'`);
+    const afterDebit = await database.query<{ covered: string; revision: string }>(`
+      SELECT auto_top_up_covered_balance_decrease_revision::text AS covered,
+        balance_decrease_revision::text AS revision
+      FROM organizations WHERE id = '${ORG_A}'
+    `);
+    expect(afterDebit.rows[0]?.covered).toBe(firstFence.rows[0]?.covered);
+    expect(afterDebit.rows[0]?.revision).not.toBe(firstFence.rows[0]?.revision);
+
+    await database.exec(`
+      INSERT INTO credit_transactions (
+        id, organization_id, amount, type, metadata, stripe_payment_intent_id
+      ) VALUES (
+        gen_random_uuid(), '${ORG_A}', 10, 'credit', '{"type":"auto_top_up"}', 'pi_legacy'
+      ) ON CONFLICT (stripe_payment_intent_id) DO NOTHING
+    `);
+    const afterReplay = await database.query<{ covered: string; revision: string }>(`
+      SELECT auto_top_up_covered_balance_decrease_revision::text AS covered,
+        balance_decrease_revision::text AS revision
+      FROM organizations WHERE id = '${ORG_A}'
+    `);
+    expect(afterReplay.rows[0]).toEqual(afterDebit.rows[0]);
+  });
+
+  test("enforces one blocking attempt per org, including manual review", async () => {
+    const database = new PGlite();
+    databases.push(database);
+    await createPrerequisites(database);
+    await database.exec(await migrationSql());
+    await database.exec(validAttempt(ATTEMPT_A, ORG_A, "key-a"));
+
+    await expect(database.exec(validAttempt(ATTEMPT_B, ORG_A, "key-b"))).rejects.toThrow(
+      /auto_top_up_attempts_blocking_org_idx/i,
+    );
+    await database.exec(`
+      UPDATE "auto_top_up_attempts"
+      SET "status" = 'manual_review', "next_attempt_at" = NULL,
+          "manual_review_at" = now()
+      WHERE "id" = '${ATTEMPT_A}';
+    `);
+    await expect(database.exec(validAttempt(ATTEMPT_B, ORG_A, "key-b"))).rejects.toThrow(
+      /auto_top_up_attempts_blocking_org_idx/i,
+    );
+
+    await database.exec(`
+      UPDATE "auto_top_up_attempts"
+      SET "status" = 'canceled', "canceled_at" = now()
+      WHERE "id" = '${ATTEMPT_A}';
+    `);
+    await database.exec(validAttempt(ATTEMPT_B, ORG_A, "key-b"));
+  });
+
+  test("rejects incoherent leases, provider windows, duplicate PI, and bad amounts", async () => {
+    const database = new PGlite();
+    databases.push(database);
+    await createPrerequisites(database);
+    await database.exec(await migrationSql());
+    await database.exec(validAttempt(ATTEMPT_A, ORG_A, "key-a"));
+    await database.exec(validAttempt(ATTEMPT_B, ORG_B, "key-b"));
+
+    await expect(
+      database.exec(`
+        UPDATE "auto_top_up_attempts"
+        SET "lease_token" = '40000000-0000-4000-8000-000000000001'
+        WHERE "id" = '${ATTEMPT_A}';
+      `),
+    ).rejects.toThrow(/auto_top_up_attempts_lease_pair_check/i);
+    await expect(
+      database.exec(`
+        UPDATE "auto_top_up_attempts"
+        SET "provider_request_started_at" = now()
+        WHERE "id" = '${ATTEMPT_A}';
+      `),
+    ).rejects.toThrow(/auto_top_up_attempts_provider_window_check/i);
+    await expect(
+      database.exec(`
+        UPDATE "auto_top_up_attempts"
+        SET "status" = 'canceled', "next_attempt_at" = NULL,
+            "provider_request_started_at" = now(),
+            "recovery_deadline_at" = now() + interval '1 hour',
+            "canceled_at" = now()
+        WHERE "id" = '${ATTEMPT_A}';
+      `),
+    ).rejects.toThrow(/auto_top_up_attempts_canceled_check/i);
+    await expect(
+      database.exec(`
+        UPDATE "auto_top_up_attempts"
+        SET "status" = 'canceled', "next_attempt_at" = NULL,
+            "stripe_payment_intent_id" = 'pi_ambiguous',
+            "provider_status" = 'processing', "canceled_at" = now()
+        WHERE "id" = '${ATTEMPT_A}';
+      `),
+    ).rejects.toThrow(/auto_top_up_attempts_canceled_check/i);
+    await expect(
+      database.exec(`
+        UPDATE "auto_top_up_attempts"
+        SET "charge_amount_cents" = 999
+        WHERE "id" = '${ATTEMPT_A}';
+      `),
+    ).rejects.toThrow(/auto_top_up_attempts_amount_check/i);
+
+    await database.exec(`
+      UPDATE "auto_top_up_attempts" SET "stripe_payment_intent_id" = 'pi_same'
+      WHERE "id" = '${ATTEMPT_A}';
+    `);
+    await expect(
+      database.exec(`
+        UPDATE "auto_top_up_attempts" SET "stripe_payment_intent_id" = 'pi_same'
+        WHERE "id" = '${ATTEMPT_B}';
+      `),
+    ).rejects.toThrow(/auto_top_up_attempts_payment_intent_idx/i);
+
+    await database.exec(`
+      INSERT INTO "credit_transactions" ("id", "organization_id")
+      VALUES ('${CREDIT_TX}', '${ORG_A}');
+    `);
+    await expect(
+      database.exec(`
+        UPDATE "auto_top_up_attempts"
+        SET "status" = 'credited', "next_attempt_at" = NULL,
+            "credit_transaction_id" = '${CREDIT_TX}',
+            "payment_succeeded_at" = now(), "credited_at" = now()
+        WHERE "id" = '${ATTEMPT_A}';
+      `),
+    ).rejects.toThrow(/auto_top_up_attempts_credited_check/i);
+  });
+
+  test("cascading organization deletion removes attempts and linked credits without FK deadlock", async () => {
+    const database = new PGlite();
+    databases.push(database);
+    await createPrerequisites(database);
+    await database.exec(await migrationSql());
+    await database.exec(`
+      UPDATE auto_top_up_control
+      SET mode = 'durable', legacy_reconciled_through = paused_at;
+      INSERT INTO "users" ("id", "organization_id") VALUES ('${USER_A}', '${ORG_A}');
+      INSERT INTO "credit_transactions" ("id", "organization_id")
+      VALUES ('${CREDIT_TX}', '${ORG_A}');
+      INSERT INTO "auto_top_up_attempts" (
+        "id", "organization_id", "trigger_source", "status",
+        "credit_amount_cents", "charge_amount_cents", "currency",
+        "stripe_customer_id_snapshot", "stripe_payment_method_id_snapshot",
+        "idempotency_key", "stripe_payment_intent_id", "credit_transaction_id",
+        "covered_balance_decrease_revision", "payment_succeeded_at", "credited_at",
+        "next_attempt_at"
+      ) VALUES (
+        '${ATTEMPT_A}', '${ORG_A}', 'cron', 'credited',
+        1000, 1000, 'usd', 'cus_snapshot', 'pm_snapshot', 'key-a', 'pi_a',
+        '${CREDIT_TX}', 0, now(), now(), NULL
+      );
+      DELETE FROM "organizations" WHERE "id" = '${ORG_A}';
+    `);
+
+    const attempts = await database.query<{ count: string }>(
+      `SELECT count(*)::text AS count FROM "auto_top_up_attempts"`,
+    );
+    const credits = await database.query<{ count: string }>(
+      `SELECT count(*)::text AS count FROM "credit_transactions"`,
+    );
+    const users = await database.query<{ count: string }>(
+      `SELECT count(*)::text AS count FROM "users"`,
+    );
+    expect(attempts.rows[0]?.count).toBe("0");
+    expect(credits.rows[0]?.count).toBe("0");
+    expect(users.rows[0]?.count).toBe("0");
+  });
+
+  test("blocks organization deletion until every provider attempt is terminal", async () => {
+    const database = new PGlite();
+    databases.push(database);
+    await createPrerequisites(database);
+    await database.exec(await migrationSql());
+    await database.exec(`
+      UPDATE auto_top_up_control
+      SET mode = 'durable', legacy_reconciled_through = paused_at
+    `);
+    await database.exec(validAttempt(ATTEMPT_A, ORG_A, "delete-guard-active"));
+
+    await expectDatabaseConstraint(
+      database.exec(`DELETE FROM "organizations" WHERE "id" = '${ORG_A}';`),
+      { code: "23503", constraint: "auto_top_up_unresolved_work" },
+    );
+    expect(
+      (
+        await database.query<{ count: string }>(
+          `SELECT count(*)::text AS count FROM "auto_top_up_attempts" WHERE "id" = '${ATTEMPT_A}'`,
+        )
+      ).rows[0]?.count,
+    ).toBe("1");
+
+    await database.exec(`
+      UPDATE "auto_top_up_attempts"
+      SET "status" = 'canceled', "next_attempt_at" = NULL, "canceled_at" = now()
+      WHERE "id" = '${ATTEMPT_A}';
+      DELETE FROM "organizations" WHERE "id" = '${ORG_A}';
+    `);
+    expect(
+      (
+        await database.query<{ count: string }>(
+          `SELECT count(*)::text AS count FROM "auto_top_up_attempts" WHERE "id" = '${ATTEMPT_A}'`,
+        )
+      ).rows[0]?.count,
+    ).toBe("0");
+  });
+
+  test("seals lifecycle before inventory and durable mode keeps tenant guards", async () => {
+    const database = new PGlite();
+    databases.push(database);
+    await createPrerequisites(database);
+    await database.exec(await migrationSql());
+
+    const control = await database.query<{ mode: string; reconciled: Date | null }>(`
+      SELECT mode, legacy_reconciled_through AS reconciled FROM auto_top_up_control
+    `);
+    expect(control.rows).toHaveLength(1);
+    expect(control.rows[0]).toMatchObject({ mode: "paused", reconciled: null });
+
+    await database.exec(`
+      INSERT INTO users (id, organization_id) VALUES ('${USER_A}', '${ORG_A}');
+    `);
+    await expectDatabaseConstraint(
+      database.exec(`DELETE FROM organizations WHERE id = '${ORG_A}'`),
+      { code: "23503", constraint: "auto_top_up_cutover_paused" },
+    );
+    await expectDatabaseConstraint(
+      database.exec(`UPDATE users SET organization_id = '${ORG_B}' WHERE id = '${USER_A}'`),
+      { code: "23503", constraint: "auto_top_up_cutover_paused" },
+    );
+
+    await database.exec(`
+      UPDATE auto_top_up_control
+      SET mode = 'durable', legacy_reconciled_through = paused_at;
+      INSERT INTO auto_top_up_legacy_payment_quarantine (
+        organization_id, stripe_payment_intent_id, provider_status, credit_amount_cents
+      ) VALUES ('${ORG_A}', 'pi_quarantined', 'canceled', 1000);
+    `);
+    await expectDatabaseConstraint(
+      database.exec(`DELETE FROM organizations WHERE id = '${ORG_A}'`),
+      { code: "23503", constraint: "auto_top_up_unresolved_work" },
+    );
+    await expectDatabaseConstraint(
+      database.exec(`UPDATE users SET organization_id = '${ORG_B}' WHERE id = '${USER_A}'`),
+      { code: "23503", constraint: "auto_top_up_unresolved_work" },
+    );
+
+    await expect(
+      database.exec(`
+        UPDATE auto_top_up_legacy_payment_quarantine
+        SET status = 'credited', resolved_at = now()
+        WHERE stripe_payment_intent_id = 'pi_quarantined'
+      `),
+    ).rejects.toThrow(/auto_top_up_legacy_quarantine_resolution_check/i);
+    await database.exec(`
+      UPDATE auto_top_up_legacy_payment_quarantine
+      SET status = 'canceled', resolved_at = now()
+      WHERE stripe_payment_intent_id = 'pi_quarantined';
+      UPDATE organizations SET credit_balance = 0 WHERE id = '${ORG_A}';
+      UPDATE users SET organization_id = '${ORG_B}' WHERE id = '${USER_A}';
+    `);
+    const enabled = await database.query<{ enabled: boolean }>(`
+      SELECT auto_top_up_enabled AS enabled FROM organizations WHERE id = '${ORG_A}'
+    `);
+    expect(enabled.rows[0]?.enabled).toBe(false);
+    await database.exec(`DELETE FROM organizations WHERE id = '${ORG_A}'`);
+    expect(
+      (
+        await database.query<{ count: string }>(`
+          SELECT count(*)::text AS count FROM organizations WHERE id = '${ORG_A}'
+        `)
+      ).rows[0]?.count,
+    ).toBe("0");
+  });
+
+  test("blocks a last-user vacate while unresolved and otherwise disarms future claims", async () => {
+    const database = new PGlite();
+    databases.push(database);
+    await createPrerequisites(database);
+    await database.exec(await migrationSql());
+    await database.exec(`
+      UPDATE auto_top_up_control
+      SET mode = 'durable', legacy_reconciled_through = paused_at;
+      INSERT INTO "users" ("id", "organization_id") VALUES ('${USER_A}', '${ORG_A}');
+      ${validAttempt(ATTEMPT_A, ORG_A, "vacate-guard-active")}
+    `);
+
+    await expectDatabaseConstraint(
+      database.exec(`UPDATE "users" SET "organization_id" = '${ORG_B}' WHERE "id" = '${USER_A}'`),
+      { code: "23503", constraint: "auto_top_up_unresolved_work" },
+    );
+    await expectDatabaseConstraint(database.exec(`DELETE FROM "users" WHERE "id" = '${USER_A}'`), {
+      code: "23503",
+      constraint: "auto_top_up_unresolved_work",
+    });
+    expect(
+      (
+        await database.query<{ organizationId: string }>(`
+          SELECT "organization_id"::text AS "organizationId" FROM "users" WHERE "id" = '${USER_A}'
+        `)
+      ).rows[0]?.organizationId,
+    ).toBe(ORG_A);
+
+    await database.exec(`
+      INSERT INTO "credit_transactions" ("id", "organization_id")
+      VALUES ('${CREDIT_TX}', '${ORG_A}');
+      UPDATE "auto_top_up_attempts"
+      SET "status" = 'credited', "next_attempt_at" = NULL,
+          "stripe_payment_intent_id" = 'pi_vacate_guard',
+          "credit_transaction_id" = '${CREDIT_TX}',
+          "covered_balance_decrease_revision" = 0,
+          "payment_succeeded_at" = now(), "credited_at" = now()
+      WHERE "id" = '${ATTEMPT_A}';
+    `);
+    await expectDatabaseConstraint(
+      database.exec(`UPDATE "users" SET "organization_id" = '${ORG_B}' WHERE "id" = '${USER_A}'`),
+      { code: "23514", constraint: "organization_nonzero_credit_balance" },
+    );
+    await database.exec(`
+      UPDATE "organizations" SET "credit_balance" = 0 WHERE "id" = '${ORG_A}';
+      UPDATE "users" SET "organization_id" = '${ORG_B}' WHERE "id" = '${USER_A}';
+    `);
+    expect(
+      (
+        await database.query<{ enabled: boolean }>(`
+          SELECT "auto_top_up_enabled" AS enabled FROM "organizations" WHERE "id" = '${ORG_A}'
+        `)
+      ).rows[0]?.enabled,
+    ).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/db/migrations/0213_auto_top_up_organization_fence.sql
+++ b/packages/cloud/shared/src/db/migrations/0213_auto_top_up_organization_fence.sql
@@ -1,0 +1,37 @@
+-- Durable organization-level auto-top-up re-arm fence objects. The existing
+-- organization baseline is applied separately by the following migration.
+CREATE SEQUENCE IF NOT EXISTS "organization_balance_decrease_revision_seq" AS bigint;
+ALTER TABLE "organizations"
+  ADD COLUMN IF NOT EXISTS "balance_decrease_revision" bigint DEFAULT 0 NOT NULL;
+ALTER TABLE "organizations"
+  ADD COLUMN IF NOT EXISTS "auto_top_up_covered_balance_decrease_revision" bigint;
+
+CREATE OR REPLACE FUNCTION "advance_organization_balance_decrease_revision"()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW."credit_balance" < OLD."credit_balance" THEN
+    NEW."balance_decrease_revision" := nextval('organization_balance_decrease_revision_seq');
+  ELSE
+    NEW."balance_decrease_revision" := OLD."balance_decrease_revision";
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS "organizations_balance_decrease_revision_trigger" ON "organizations";
+CREATE TRIGGER "organizations_balance_decrease_revision_trigger"
+BEFORE UPDATE OF "credit_balance" ON "organizations" FOR EACH ROW
+EXECUTE FUNCTION "advance_organization_balance_decrease_revision"();
+CREATE OR REPLACE FUNCTION "fence_auto_top_up_credit"()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW."type" = 'credit' AND NEW."metadata"->>'type' = 'auto_top_up' THEN
+    UPDATE "organizations"
+    SET "auto_top_up_covered_balance_decrease_revision" = "balance_decrease_revision"
+    WHERE "id" = NEW."organization_id";
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS "credit_transactions_auto_top_up_fence_trigger" ON "credit_transactions";
+CREATE TRIGGER "credit_transactions_auto_top_up_fence_trigger"
+AFTER INSERT ON "credit_transactions" FOR EACH ROW EXECUTE FUNCTION "fence_auto_top_up_credit"();

--- a/packages/cloud/shared/src/db/migrations/0214_backfill_auto_top_up_organization_fence.sql
+++ b/packages/cloud/shared/src/db/migrations/0214_backfill_auto_top_up_organization_fence.sql
@@ -1,0 +1,5 @@
+-- Conservatively baseline every organization present at backfill time; new
+-- organizations created after this migration retain the column default NULL.
+UPDATE "organizations"
+SET "auto_top_up_covered_balance_decrease_revision" = "balance_decrease_revision"
+WHERE "auto_top_up_covered_balance_decrease_revision" IS NULL;

--- a/packages/cloud/shared/src/db/migrations/0215_auto_top_up_attempts.sql
+++ b/packages/cloud/shared/src/db/migrations/0215_auto_top_up_attempts.sql
@@ -1,0 +1,72 @@
+CREATE TABLE IF NOT EXISTS "auto_top_up_attempts" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+  "trigger_source" text NOT NULL,
+  "status" text DEFAULT 'claimed' NOT NULL,
+  "credit_amount_cents" bigint NOT NULL,
+  "charge_amount_cents" bigint NOT NULL,
+  "currency" text DEFAULT 'usd' NOT NULL,
+  "stripe_customer_id_snapshot" text NOT NULL,
+  "stripe_payment_method_id_snapshot" text NOT NULL,
+  "request_metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+  "idempotency_key" text NOT NULL,
+  "stripe_payment_intent_id" text,
+  "credit_transaction_id" uuid REFERENCES "credit_transactions"("id"),
+  "covered_balance_decrease_revision" bigint,
+  "provider_status" text,
+  "attempt_count" integer DEFAULT 0 NOT NULL,
+  "next_attempt_at" timestamp with time zone DEFAULT now(),
+  "lease_token" uuid,
+  "lease_expires_at" timestamp with time zone,
+  "provider_request_started_at" timestamp with time zone,
+  "recovery_deadline_at" timestamp with time zone,
+  "last_error" text,
+  "result" jsonb,
+  "payment_succeeded_at" timestamp with time zone,
+  "credited_at" timestamp with time zone,
+  "canceled_at" timestamp with time zone,
+  "manual_review_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "auto_top_up_attempts_trigger_source_check"
+    CHECK ("trigger_source" IN ('cron','credit_deduction','manual','recovery')),
+  CONSTRAINT "auto_top_up_attempts_status_check"
+    CHECK ("status" IN ('claimed','payment_pending','payment_succeeded','credited','canceled','manual_review')),
+  CONSTRAINT "auto_top_up_attempts_amount_check"
+    CHECK ("credit_amount_cents" BETWEEN 100 AND 100000
+      AND "charge_amount_cents" BETWEEN "credit_amount_cents" AND 1120000),
+  CONSTRAINT "auto_top_up_attempts_currency_check" CHECK ("currency" ~ '^[a-z]{3}$'),
+  CONSTRAINT "auto_top_up_attempts_attempt_count_check" CHECK ("attempt_count" >= 0),
+  CONSTRAINT "auto_top_up_attempts_lease_pair_check"
+    CHECK (("lease_token" IS NULL) = ("lease_expires_at" IS NULL)),
+  CONSTRAINT "auto_top_up_attempts_provider_window_check"
+    CHECK ((("provider_request_started_at" IS NULL) = ("recovery_deadline_at" IS NULL))
+      AND ("recovery_deadline_at" IS NULL OR "recovery_deadline_at" > "provider_request_started_at")),
+  CONSTRAINT "auto_top_up_attempts_terminal_check"
+    CHECK ("status" NOT IN ('credited','canceled','manual_review')
+      OR ("lease_token" IS NULL AND "next_attempt_at" IS NULL)),
+  CONSTRAINT "auto_top_up_attempts_succeeded_check"
+    CHECK ("status" NOT IN ('payment_succeeded','credited')
+      OR ("stripe_payment_intent_id" IS NOT NULL AND "payment_succeeded_at" IS NOT NULL)),
+  CONSTRAINT "auto_top_up_attempts_canceled_check"
+    CHECK ("status" <> 'canceled' OR ("provider_request_started_at" IS NULL
+        AND "stripe_payment_intent_id" IS NULL)
+      OR ("stripe_payment_intent_id" IS NOT NULL AND "provider_status" = 'canceled')),
+  CONSTRAINT "auto_top_up_attempts_credited_check"
+    CHECK ("status" <> 'credited' OR ("credit_transaction_id" IS NOT NULL
+      AND "covered_balance_decrease_revision" IS NOT NULL AND "credited_at" IS NOT NULL)),
+  CONSTRAINT "auto_top_up_attempts_covered_revision_check"
+    CHECK ("covered_balance_decrease_revision" IS NULL OR "covered_balance_decrease_revision" >= 0)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "auto_top_up_attempts_idempotency_key_idx"
+  ON "auto_top_up_attempts" ("idempotency_key");
+CREATE UNIQUE INDEX IF NOT EXISTS "auto_top_up_attempts_payment_intent_idx"
+  ON "auto_top_up_attempts" ("stripe_payment_intent_id") WHERE "stripe_payment_intent_id" IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS "auto_top_up_attempts_blocking_org_idx"
+  ON "auto_top_up_attempts" ("organization_id")
+  WHERE "status" IN ('claimed','payment_pending','payment_succeeded','manual_review');
+CREATE INDEX IF NOT EXISTS "auto_top_up_attempts_due_idx"
+  ON "auto_top_up_attempts" ("next_attempt_at", "lease_expires_at")
+  WHERE "status" IN ('claimed','payment_pending','payment_succeeded') AND "next_attempt_at" IS NOT NULL;
+CREATE INDEX IF NOT EXISTS "auto_top_up_attempts_org_created_idx"
+  ON "auto_top_up_attempts" ("organization_id", "created_at");

--- a/packages/cloud/shared/src/db/migrations/0216_auto_top_up_cutover_control.sql
+++ b/packages/cloud/shared/src/db/migrations/0216_auto_top_up_cutover_control.sql
@@ -1,0 +1,41 @@
+-- Singleton cutover authority: no executable legacy mode exists.
+CREATE TABLE IF NOT EXISTS "auto_top_up_control" (
+  "singleton" boolean PRIMARY KEY DEFAULT true NOT NULL,
+  "mode" text DEFAULT 'paused' NOT NULL,
+  "paused_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "legacy_reconciled_through" timestamp with time zone,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "auto_top_up_control_singleton_check" CHECK ("singleton" = true),
+  CONSTRAINT "auto_top_up_control_mode_check" CHECK ("mode" IN ('paused','durable')),
+  CONSTRAINT "auto_top_up_control_reconciliation_check"
+    CHECK ("legacy_reconciled_through" IS NULL OR "legacy_reconciled_through" >= "paused_at")
+);
+INSERT INTO "auto_top_up_control" ("singleton", "mode") VALUES (true, 'paused')
+ON CONFLICT ("singleton") DO NOTHING;
+
+-- Reconciliation-only quarantine; this table never initiates Stripe.
+CREATE TABLE IF NOT EXISTS "auto_top_up_legacy_payment_quarantine" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "organization_id" uuid NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+  "stripe_payment_intent_id" text NOT NULL,
+  "provider_status" text NOT NULL,
+  "credit_amount_cents" bigint NOT NULL,
+  "status" text DEFAULT 'unresolved' NOT NULL,
+  "credit_transaction_id" uuid REFERENCES "credit_transactions"("id"),
+  "metadata" jsonb DEFAULT '{}'::jsonb NOT NULL,
+  "discovered_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "resolved_at" timestamp with time zone,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "auto_top_up_legacy_quarantine_status_check"
+    CHECK ("status" IN ('unresolved','credited','canceled','manual_review')),
+  CONSTRAINT "auto_top_up_legacy_quarantine_resolution_check"
+    CHECK (("status" IN ('credited','canceled')) = ("resolved_at" IS NOT NULL)
+      AND (("status" = 'credited') = ("credit_transaction_id" IS NOT NULL))
+      AND ("status" <> 'credited' OR "provider_status" = 'succeeded')
+      AND ("status" <> 'canceled' OR "provider_status" = 'canceled')),
+  CONSTRAINT "auto_top_up_legacy_quarantine_amount_check" CHECK ("credit_amount_cents" BETWEEN 100 AND 100000)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "auto_top_up_legacy_quarantine_pi_idx"
+  ON "auto_top_up_legacy_payment_quarantine" ("stripe_payment_intent_id");
+CREATE INDEX IF NOT EXISTS "auto_top_up_legacy_quarantine_org_status_idx"
+  ON "auto_top_up_legacy_payment_quarantine" ("organization_id", "status");

--- a/packages/cloud/shared/src/db/migrations/0217_guard_auto_top_up_cutover_lifecycle.sql
+++ b/packages/cloud/shared/src/db/migrations/0217_guard_auto_top_up_cutover_lifecycle.sql
@@ -1,0 +1,75 @@
+-- Lifecycle is globally sealed until reconciliation activates durable mode.
+CREATE OR REPLACE FUNCTION "guard_active_auto_top_up_organization_deletion"()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  cutover_mode text;
+BEGIN
+  SELECT "mode" INTO cutover_mode FROM "auto_top_up_control"
+  WHERE "singleton" = true FOR SHARE;
+  IF cutover_mode IS DISTINCT FROM 'durable' THEN
+    RAISE EXCEPTION 'organization deletion blocked while auto-top-up cutover is paused'
+      USING ERRCODE = '23503', CONSTRAINT = 'auto_top_up_cutover_paused';
+  END IF;
+  IF EXISTS (SELECT 1 FROM "auto_top_up_attempts" WHERE "organization_id" = OLD."id"
+      AND "status" IN ('claimed','payment_pending','payment_succeeded','manual_review'))
+    OR EXISTS (SELECT 1 FROM "auto_top_up_legacy_payment_quarantine"
+      WHERE "organization_id" = OLD."id" AND "status" IN ('unresolved','manual_review')) THEN
+    RAISE EXCEPTION 'organization has unresolved auto-top-up work'
+      USING ERRCODE = '23503', CONSTRAINT = 'auto_top_up_unresolved_work';
+  END IF;
+  RETURN OLD;
+END;
+$$;
+DROP TRIGGER IF EXISTS "organizations_active_auto_top_up_delete_guard" ON "organizations";
+CREATE TRIGGER "organizations_active_auto_top_up_delete_guard" BEFORE DELETE ON "organizations"
+FOR EACH ROW EXECUTE FUNCTION "guard_active_auto_top_up_organization_deletion"();
+
+CREATE OR REPLACE FUNCTION "guard_last_user_auto_top_up_vacate"()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  old_organization_id uuid := OLD."organization_id";
+  remaining_users bigint;
+  locked_credit_balance numeric;
+  cutover_mode text;
+BEGIN
+  IF old_organization_id IS NULL OR (TG_OP = 'UPDATE'
+      AND NEW."organization_id" IS NOT DISTINCT FROM old_organization_id) THEN
+    IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+    RETURN NEW;
+  END IF;
+  SELECT "credit_balance" INTO locked_credit_balance FROM "organizations"
+  WHERE "id" = old_organization_id FOR UPDATE;
+  IF NOT FOUND THEN
+    IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+    RETURN NEW;
+  END IF;
+  SELECT count(*) INTO remaining_users FROM "users"
+  WHERE "organization_id" = old_organization_id AND "id" <> OLD."id";
+  IF remaining_users = 0 THEN
+    SELECT "mode" INTO cutover_mode FROM "auto_top_up_control"
+    WHERE "singleton" = true FOR SHARE;
+    IF cutover_mode IS DISTINCT FROM 'durable' THEN
+      RAISE EXCEPTION 'last user cannot leave while auto-top-up cutover is paused'
+        USING ERRCODE = '23503', CONSTRAINT = 'auto_top_up_cutover_paused';
+    END IF;
+    IF EXISTS (SELECT 1 FROM "auto_top_up_attempts" WHERE "organization_id" = old_organization_id
+        AND "status" IN ('claimed','payment_pending','payment_succeeded','manual_review'))
+      OR EXISTS (SELECT 1 FROM "auto_top_up_legacy_payment_quarantine"
+        WHERE "organization_id" = old_organization_id AND "status" IN ('unresolved','manual_review')) THEN
+      RAISE EXCEPTION 'last user cannot leave unresolved auto-top-up work'
+        USING ERRCODE = '23503', CONSTRAINT = 'auto_top_up_unresolved_work';
+    END IF;
+    IF locked_credit_balance IS DISTINCT FROM 0::numeric THEN
+      RAISE EXCEPTION 'last user cannot leave an organization with credits'
+        USING ERRCODE = '23514', CONSTRAINT = 'organization_nonzero_credit_balance';
+    END IF;
+    UPDATE "organizations" SET "auto_top_up_enabled" = false WHERE "id" = old_organization_id;
+  END IF;
+  IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS "users_active_auto_top_up_vacate_guard" ON "users";
+CREATE TRIGGER "users_active_auto_top_up_vacate_guard"
+BEFORE UPDATE OF "organization_id" OR DELETE ON "users"
+FOR EACH ROW EXECUTE FUNCTION "guard_last_user_auto_top_up_vacate"();

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1485,6 +1485,41 @@
       "when": 1787860800002,
       "tag": "0212_twilio_personal_agent_ids",
       "breakpoints": true
+    },
+    {
+      "idx": 212,
+      "version": "7",
+      "when": 1787860800003,
+      "tag": "0213_auto_top_up_organization_fence",
+      "breakpoints": true
+    },
+    {
+      "idx": 213,
+      "version": "7",
+      "when": 1787860800004,
+      "tag": "0214_backfill_auto_top_up_organization_fence",
+      "breakpoints": true
+    },
+    {
+      "idx": 214,
+      "version": "7",
+      "when": 1787860800005,
+      "tag": "0215_auto_top_up_attempts",
+      "breakpoints": true
+    },
+    {
+      "idx": 215,
+      "version": "7",
+      "when": 1787860800006,
+      "tag": "0216_auto_top_up_cutover_control",
+      "breakpoints": true
+    },
+    {
+      "idx": 216,
+      "version": "7",
+      "when": 1787860800007,
+      "tag": "0217_guard_auto_top_up_cutover_lifecycle",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/auto-top-up-attempts.ts
+++ b/packages/cloud/shared/src/db/repositories/auto-top-up-attempts.ts
@@ -1,0 +1,1895 @@
+/**
+ * Owns the transactional auto-top-up attempt ledger: eligibility is rechecked
+ * under the organization row lock, provider work is protected by expiring
+ * lease tokens, and successful charges are atomically applied and linked while
+ * the attempt remains recoverable. A separate fenced terminal transition runs
+ * only after cache invalidation. Monetary inputs and outputs remain exact
+ * integer cents or canonical Postgres decimal strings throughout this module.
+ */
+import { ElizaError } from "@elizaos/core";
+import { and, asc, desc, eq, gt, inArray, isNull, lte, notExists, or, sql } from "drizzle-orm";
+import { dbWrite } from "../client";
+import {
+  type AutoTopUpAttemptRow,
+  type AutoTopUpAttemptStatus,
+  type AutoTopUpControlMode,
+  type AutoTopUpControlRow,
+  type AutoTopUpLegacyPaymentQuarantineRow,
+  type AutoTopUpLegacyQuarantineStatus,
+  type AutoTopUpTriggerSource,
+  autoTopUpAttempts,
+  autoTopUpControl,
+  autoTopUpLegacyPaymentQuarantine,
+} from "../schemas/auto-top-up-attempts";
+import { creditTransactions } from "../schemas/credit-transactions";
+import { organizations } from "../schemas/organizations";
+
+export const AUTO_TOP_UP_ATTEMPT_INVALID_INPUT = "AUTO_TOP_UP_ATTEMPT_INVALID_INPUT";
+export const AUTO_TOP_UP_ATTEMPT_INVARIANT_VIOLATION = "AUTO_TOP_UP_ATTEMPT_INVARIANT_VIOLATION";
+
+const BLOCKING_STATUSES: AutoTopUpAttemptStatus[] = [
+  "claimed",
+  "payment_pending",
+  "payment_succeeded",
+  "manual_review",
+];
+const CLAIMABLE_STATUSES: AutoTopUpAttemptStatus[] = [
+  "claimed",
+  "payment_pending",
+  "payment_succeeded",
+];
+const MIN_AUTO_TOP_UP_CENTS = 100;
+const MAX_AUTO_TOP_UP_CENTS = 100_000;
+const MAX_AUTO_TOP_UP_CHARGE_CENTS = 1_120_000;
+const MAX_DUE_LIMIT = 100;
+const TERMINAL_LEGACY_PROVIDER_STATUSES = new Set(["succeeded", "canceled"]);
+const TRIGGER_SOURCES = new Set<AutoTopUpTriggerSource>([
+  "cron",
+  "credit_deduction",
+  "manual",
+  "recovery",
+]);
+
+export interface AutoTopUpAttempt {
+  id: string;
+  organizationId: string;
+  triggerSource: AutoTopUpTriggerSource;
+  status: AutoTopUpAttemptStatus;
+  creditAmountCents: number;
+  chargeAmountCents: number;
+  currency: string;
+  stripeCustomerId: string;
+  stripePaymentMethodId: string;
+  requestMetadata: Record<string, unknown>;
+  idempotencyKey: string;
+  stripePaymentIntentId: string | null;
+  creditTransactionId: string | null;
+  coveredBalanceDecreaseRevision: number | null;
+  providerStatus: string | null;
+  attemptCount: number;
+  nextAttemptAt: Date | null;
+  leaseToken: string | null;
+  leaseExpiresAt: Date | null;
+  providerRequestStartedAt: Date | null;
+  recoveryDeadlineAt: Date | null;
+  lastError: string | null;
+  result: Record<string, unknown> | null;
+  paymentSucceededAt: Date | null;
+  creditedAt: Date | null;
+  canceledAt: Date | null;
+  manualReviewAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface AutoTopUpControl {
+  mode: AutoTopUpControlMode;
+  pausedAt: Date;
+  legacyReconciledThrough: Date | null;
+}
+
+export type AutoTopUpControlTransitionBlockedReason =
+  | "mode_mismatch"
+  | "legacy_not_reconciled"
+  | "future_reconciliation_watermark"
+  | "blocking_attempts"
+  | "legacy_quarantine"
+  | "enabled_manual_review";
+
+export interface TransitionAutoTopUpControlInput {
+  expectedMode: AutoTopUpControlMode;
+  targetMode: AutoTopUpControlMode;
+  now: Date;
+  legacyReconciledThrough?: Date;
+}
+
+export type TransitionAutoTopUpControlResult =
+  | { outcome: "applied"; control: AutoTopUpControl }
+  | {
+      outcome: "not_applied";
+      reason: AutoTopUpControlTransitionBlockedReason;
+      control: AutoTopUpControl;
+    };
+
+export interface AutoTopUpLegacyPaymentQuarantine {
+  id: string;
+  organizationId: string;
+  stripePaymentIntentId: string;
+  providerStatus: string;
+  creditAmountCents: number;
+  status: AutoTopUpLegacyQuarantineStatus;
+  creditTransactionId: string | null;
+  metadata: Record<string, unknown>;
+  discoveredAt: Date;
+  resolvedAt: Date | null;
+  updatedAt: Date;
+}
+
+export interface QuarantineLegacyPaymentIntentInput {
+  organizationId: string;
+  paymentIntentId: string;
+  providerStatus: string;
+  creditAmountCents: number;
+  metadata: Record<string, unknown>;
+  now: Date;
+}
+
+export interface ResolveLegacyPaymentIntentInput {
+  paymentIntentId: string;
+  resolution: Exclude<AutoTopUpLegacyQuarantineStatus, "unresolved">;
+  metadata: Record<string, unknown>;
+  now: Date;
+}
+
+export interface ClaimEligibleAttemptInput {
+  organizationId: string;
+  triggerSource: AutoTopUpTriggerSource;
+  attemptId: string;
+  idempotencyKey: string;
+  now: Date;
+}
+
+export type AutoTopUpNotEligibleReason =
+  | "cutover_paused"
+  | "legacy_payment_unresolved"
+  | "not_found"
+  | "disabled"
+  | "balance_at_or_above_threshold"
+  | "missing_customer"
+  | "missing_payment_method"
+  | "invalid_balance"
+  | "invalid_threshold"
+  | "invalid_amount"
+  | "balance_not_rearmed";
+
+export type ClaimEligibleAttemptResult =
+  | {
+      outcome: "created" | "reused";
+      attempt: AutoTopUpAttempt;
+    }
+  | {
+      outcome: "not_eligible";
+      organizationId: string;
+      reason: AutoTopUpNotEligibleReason;
+      currentBalanceCents?: number;
+      thresholdCents?: number;
+    };
+
+export interface ClaimDueLeaseInput {
+  attemptId: string;
+  leaseToken: string;
+  now: Date;
+  leaseExpiresAt: Date;
+}
+
+export interface FinalizeAutoTopUpRequestInput {
+  attemptId: string;
+  leaseToken: string;
+  chargeAmountCents: number;
+  requestMetadata: Record<string, unknown>;
+  now: Date;
+}
+
+export interface MarkProviderRequestStartedInput {
+  attemptId: string;
+  leaseToken: string;
+  now: Date;
+  recoveryDeadlineAt: Date;
+}
+
+export interface RecordPaymentIntentInput {
+  attemptId: string;
+  leaseToken: string;
+  paymentIntentId: string;
+  providerStatus: string;
+  result: Record<string, unknown>;
+  now: Date;
+}
+
+export interface RecordAutoTopUpFailureInput {
+  attemptId: string;
+  leaseToken: string;
+  error: string;
+  result?: Record<string, unknown>;
+  nextAttemptAt: Date;
+  now: Date;
+}
+
+export interface MarkAutoTopUpTerminalInput {
+  attemptId: string;
+  leaseToken: string;
+  error: string;
+  result?: Record<string, unknown>;
+  now: Date;
+}
+
+export interface ReopenManualReviewForSucceededPaymentInput {
+  attemptId: string;
+  paymentIntentId: string;
+  result: Record<string, unknown>;
+  now: Date;
+}
+
+export interface ListDueAutoTopUpAttemptsInput {
+  now: Date;
+  limit: number;
+}
+
+export type SettleSucceededAttemptResult =
+  | {
+      outcome: "applied" | "already_applied";
+      attempt: AutoTopUpAttempt;
+      creditTransactionId: string;
+      newBalance: string;
+    }
+  | {
+      outcome: "manual_review";
+      attempt: AutoTopUpAttempt;
+    };
+
+export interface MarkAutoTopUpCreditedInput {
+  attemptId: string;
+  leaseToken: string;
+  now: Date;
+}
+
+function invalidInput(message: string, context: Record<string, unknown>): never {
+  throw new ElizaError(message, {
+    code: AUTO_TOP_UP_ATTEMPT_INVALID_INPUT,
+    context,
+  });
+}
+
+function invariantViolation(message: string, context: Record<string, unknown>): never {
+  throw new ElizaError(message, {
+    code: AUTO_TOP_UP_ATTEMPT_INVARIANT_VIOLATION,
+    context,
+    severity: "fatal",
+  });
+}
+
+function assertDate(value: Date, field: string): void {
+  if (!(value instanceof Date) || !Number.isFinite(value.getTime())) {
+    invalidInput("Auto-top-up attempt date is invalid", { field });
+  }
+}
+
+function requiredString(value: string, field: string): string {
+  if (typeof value !== "string" || value.trim().length === 0 || value !== value.trim()) {
+    invalidInput("Auto-top-up attempt string is missing or non-canonical", { field });
+  }
+  return value;
+}
+
+function jsonObject(value: Record<string, unknown>, field: string): Record<string, unknown> {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null)
+  ) {
+    invalidInput("Auto-top-up attempt JSON value must be a plain object", { field });
+  }
+  try {
+    JSON.stringify(value);
+  } catch (cause) {
+    throw new ElizaError("Auto-top-up attempt JSON value is not serializable", {
+      code: AUTO_TOP_UP_ATTEMPT_INVALID_INPUT,
+      cause,
+      context: { field },
+    });
+  }
+  return value;
+}
+
+function safeIntegerCents(value: number, field: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    invalidInput("Auto-top-up cents must be a positive safe integer", { field });
+  }
+  return value;
+}
+
+function canonicalNonNegativeDecimal(raw: unknown): string | null {
+  const value = typeof raw === "string" ? raw : typeof raw === "number" ? String(raw) : "";
+  return /^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(value) ? value : null;
+}
+
+function canonicalSignedDecimal(raw: unknown): string | null {
+  const value = typeof raw === "string" ? raw : typeof raw === "number" ? String(raw) : "";
+  return /^-?(?:0|[1-9]\d*)(?:\.\d+)?$/.test(value) ? value : null;
+}
+
+function exactCentsFromDecimal(raw: unknown): number | null {
+  const value = canonicalNonNegativeDecimal(raw);
+  if (!value) return null;
+  const [whole, fraction = ""] = value.split(".");
+  if (fraction.slice(2).replaceAll("0", "").length > 0) return null;
+  const cents = BigInt(whole) * 100n + BigInt(`${fraction}00`.slice(0, 2));
+  return cents <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(cents) : null;
+}
+
+function exactSignedCentsFromDecimal(raw: unknown): number | null {
+  const value = canonicalSignedDecimal(raw);
+  if (!value) return null;
+  const negative = value.startsWith("-");
+  const unsigned = negative ? value.slice(1) : value;
+  const cents = exactCentsFromDecimal(unsigned);
+  return cents === null ? null : negative ? -cents : cents;
+}
+
+function toAttempt(row: AutoTopUpAttemptRow): AutoTopUpAttempt {
+  const creditAmountCents = safeIntegerCents(row.credit_amount_cents, "credit_amount_cents");
+  const chargeAmountCents = safeIntegerCents(row.charge_amount_cents, "charge_amount_cents");
+  if (chargeAmountCents < creditAmountCents) {
+    invariantViolation("Auto-top-up charge is smaller than its credit amount", {
+      attemptId: row.id,
+    });
+  }
+  return {
+    id: row.id,
+    organizationId: row.organization_id,
+    triggerSource: row.trigger_source,
+    status: row.status,
+    creditAmountCents,
+    chargeAmountCents,
+    currency: row.currency,
+    stripeCustomerId: row.stripe_customer_id_snapshot,
+    stripePaymentMethodId: row.stripe_payment_method_id_snapshot,
+    requestMetadata: row.request_metadata,
+    idempotencyKey: row.idempotency_key,
+    stripePaymentIntentId: row.stripe_payment_intent_id,
+    creditTransactionId: row.credit_transaction_id,
+    coveredBalanceDecreaseRevision: row.covered_balance_decrease_revision,
+    providerStatus: row.provider_status,
+    attemptCount: row.attempt_count,
+    nextAttemptAt: row.next_attempt_at,
+    leaseToken: row.lease_token,
+    leaseExpiresAt: row.lease_expires_at,
+    providerRequestStartedAt: row.provider_request_started_at,
+    recoveryDeadlineAt: row.recovery_deadline_at,
+    lastError: row.last_error,
+    result: row.result,
+    paymentSucceededAt: row.payment_succeeded_at,
+    creditedAt: row.credited_at,
+    canceledAt: row.canceled_at,
+    manualReviewAt: row.manual_review_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function toControl(row: AutoTopUpControlRow): AutoTopUpControl {
+  return {
+    mode: row.mode,
+    pausedAt: row.paused_at,
+    legacyReconciledThrough: row.legacy_reconciled_through,
+  };
+}
+
+function toLegacyQuarantine(
+  row: AutoTopUpLegacyPaymentQuarantineRow,
+): AutoTopUpLegacyPaymentQuarantine {
+  return {
+    id: row.id,
+    organizationId: row.organization_id,
+    stripePaymentIntentId: row.stripe_payment_intent_id,
+    providerStatus: row.provider_status,
+    creditAmountCents: safeIntegerCents(row.credit_amount_cents, "credit_amount_cents"),
+    status: row.status,
+    creditTransactionId: row.credit_transaction_id,
+    metadata: row.metadata,
+    discoveredAt: row.discovered_at,
+    resolvedAt: row.resolved_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function notEligible(
+  organizationId: string,
+  reason: AutoTopUpNotEligibleReason,
+  amounts?: { currentBalanceCents?: number; thresholdCents?: number },
+): ClaimEligibleAttemptResult {
+  return { outcome: "not_eligible", organizationId, reason, ...amounts };
+}
+
+function assertLeaseWindow(now: Date, leaseExpiresAt: Date): void {
+  assertDate(now, "now");
+  assertDate(leaseExpiresAt, "leaseExpiresAt");
+  if (leaseExpiresAt.getTime() <= now.getTime()) {
+    invalidInput("Auto-top-up lease must expire after its claim time", {
+      field: "leaseExpiresAt",
+    });
+  }
+}
+
+/** Primary-only CQRS repository; recovery reads intentionally never use a lagging replica. */
+export class AutoTopUpAttemptsRepository {
+  /**
+   * Read the singleton cutover authority from the primary. Missing state is a
+   * fatal migration/configuration error; callers must never infer a mode.
+   */
+  async getControl(): Promise<AutoTopUpControl> {
+    const [row] = await dbWrite
+      .select()
+      .from(autoTopUpControl)
+      .where(eq(autoTopUpControl.singleton, true))
+      .limit(1);
+    if (!row) invariantViolation("Auto-top-up control row is missing", {});
+    return toControl(row);
+  }
+
+  /**
+   * Compare-and-set the cutover mode under an exclusive singleton lock.
+   * Activation and claim acquisition use the same first lock, making the
+   * paused/durable boundary linearizable. Pausing never strands recovery:
+   * only new claims consult this control row.
+   */
+  async transitionControl(
+    input: TransitionAutoTopUpControlInput,
+  ): Promise<TransitionAutoTopUpControlResult> {
+    assertDate(input.now, "now");
+    if (input.legacyReconciledThrough) {
+      assertDate(input.legacyReconciledThrough, "legacyReconciledThrough");
+    }
+    if (
+      (input.expectedMode !== "paused" && input.expectedMode !== "durable") ||
+      (input.targetMode !== "paused" && input.targetMode !== "durable") ||
+      input.expectedMode === input.targetMode
+    ) {
+      invalidInput("Auto-top-up control transition is invalid", {
+        expectedMode: input.expectedMode,
+        targetMode: input.targetMode,
+      });
+    }
+
+    return dbWrite.transaction(async (tx) => {
+      const [locked] = await tx
+        .select()
+        .from(autoTopUpControl)
+        .where(eq(autoTopUpControl.singleton, true))
+        .for("update")
+        .limit(1);
+      if (!locked) invariantViolation("Auto-top-up control row is missing", {});
+      const current = toControl(locked);
+      if (locked.mode !== input.expectedMode) {
+        return { outcome: "not_applied", reason: "mode_mismatch", control: current };
+      }
+
+      if (input.targetMode === "paused") {
+        const [paused] = await tx
+          .update(autoTopUpControl)
+          .set({
+            mode: "paused",
+            paused_at: input.now,
+            legacy_reconciled_through: null,
+            updated_at: input.now,
+          })
+          .where(
+            and(
+              eq(autoTopUpControl.singleton, true),
+              eq(autoTopUpControl.mode, input.expectedMode),
+            ),
+          )
+          .returning();
+        if (!paused) invariantViolation("Auto-top-up pause CAS lost its control row", {});
+        return { outcome: "applied", control: toControl(paused) };
+      }
+
+      const reconciledThrough = input.legacyReconciledThrough ?? locked.legacy_reconciled_through;
+      if (reconciledThrough && reconciledThrough.getTime() > input.now.getTime()) {
+        return {
+          outcome: "not_applied",
+          reason: "future_reconciliation_watermark",
+          control: current,
+        };
+      }
+      if (!reconciledThrough || reconciledThrough.getTime() < locked.paused_at.getTime()) {
+        return {
+          outcome: "not_applied",
+          reason: "legacy_not_reconciled",
+          control: current,
+        };
+      }
+
+      const [blockingAttempt] = await tx
+        .select({ id: autoTopUpAttempts.id })
+        .from(autoTopUpAttempts)
+        .where(
+          inArray(autoTopUpAttempts.status, ["claimed", "payment_pending", "payment_succeeded"]),
+        )
+        .limit(1);
+      if (blockingAttempt) {
+        return { outcome: "not_applied", reason: "blocking_attempts", control: current };
+      }
+
+      const [quarantined] = await tx
+        .select({ id: autoTopUpLegacyPaymentQuarantine.id })
+        .from(autoTopUpLegacyPaymentQuarantine)
+        .where(eq(autoTopUpLegacyPaymentQuarantine.status, "unresolved"))
+        .limit(1);
+      if (quarantined) {
+        return { outcome: "not_applied", reason: "legacy_quarantine", control: current };
+      }
+
+      const [enabledLegacyManualReview] = await tx
+        .select({ id: autoTopUpLegacyPaymentQuarantine.id })
+        .from(autoTopUpLegacyPaymentQuarantine)
+        .innerJoin(
+          organizations,
+          eq(organizations.id, autoTopUpLegacyPaymentQuarantine.organization_id),
+        )
+        .where(
+          and(
+            eq(autoTopUpLegacyPaymentQuarantine.status, "manual_review"),
+            eq(organizations.auto_top_up_enabled, true),
+          ),
+        )
+        .limit(1);
+      if (enabledLegacyManualReview) {
+        return { outcome: "not_applied", reason: "legacy_quarantine", control: current };
+      }
+
+      const [enabledManualReview] = await tx
+        .select({ id: autoTopUpAttempts.id })
+        .from(autoTopUpAttempts)
+        .innerJoin(organizations, eq(organizations.id, autoTopUpAttempts.organization_id))
+        .where(
+          and(
+            eq(autoTopUpAttempts.status, "manual_review"),
+            eq(organizations.auto_top_up_enabled, true),
+          ),
+        )
+        .limit(1);
+      if (enabledManualReview) {
+        return { outcome: "not_applied", reason: "enabled_manual_review", control: current };
+      }
+
+      const [durable] = await tx
+        .update(autoTopUpControl)
+        .set({
+          mode: "durable",
+          legacy_reconciled_through: reconciledThrough,
+          updated_at: input.now,
+        })
+        .where(
+          and(eq(autoTopUpControl.singleton, true), eq(autoTopUpControl.mode, input.expectedMode)),
+        )
+        .returning();
+      if (!durable) invariantViolation("Auto-top-up activation CAS lost its control row", {});
+      return { outcome: "applied", control: toControl(durable) };
+    });
+  }
+
+  /**
+   * Import a newly discovered legacy PaymentIntent only while paused. An exact
+   * existing-row replay may still refresh a nonterminal provider status after
+   * durable activation; identity and credit amount remain immutable, and this
+   * method never starts a provider request.
+   */
+  async quarantineLegacyPaymentIntent(
+    input: QuarantineLegacyPaymentIntentInput,
+  ): Promise<AutoTopUpLegacyPaymentQuarantine | null> {
+    requiredString(input.organizationId, "organizationId");
+    requiredString(input.paymentIntentId, "paymentIntentId");
+    requiredString(input.providerStatus, "providerStatus");
+    assertDate(input.now, "now");
+    const metadata = jsonObject(input.metadata, "metadata");
+    const creditAmountCents = safeIntegerCents(input.creditAmountCents, "creditAmountCents");
+    if (creditAmountCents < MIN_AUTO_TOP_UP_CENTS || creditAmountCents > MAX_AUTO_TOP_UP_CENTS) {
+      invalidInput("Legacy PaymentIntent credit amount is outside its bounded range", {
+        creditAmountCents,
+      });
+    }
+
+    return dbWrite.transaction(async (tx) => {
+      // Match lifecycle, claim, and reconciliation: organization -> control ->
+      // quarantine. New inserts also take their FK lock only after this row.
+      const [lockedOrganization] = await tx
+        .select({ id: organizations.id })
+        .from(organizations)
+        .where(eq(organizations.id, input.organizationId))
+        .for("update")
+        .limit(1);
+      if (!lockedOrganization) {
+        invariantViolation("Legacy PaymentIntent organization is missing", {
+          paymentIntentId: input.paymentIntentId,
+          organizationId: input.organizationId,
+        });
+      }
+
+      const [control] = await tx
+        .select({ mode: autoTopUpControl.mode })
+        .from(autoTopUpControl)
+        .where(eq(autoTopUpControl.singleton, true))
+        .for("share")
+        .limit(1);
+      if (!control) invariantViolation("Auto-top-up control row is missing", {});
+      let [existing] = await tx
+        .select()
+        .from(autoTopUpLegacyPaymentQuarantine)
+        .where(eq(autoTopUpLegacyPaymentQuarantine.stripe_payment_intent_id, input.paymentIntentId))
+        .for("update")
+        .limit(1);
+      if (!existing) {
+        if (control.mode !== "paused") return null;
+        const [inserted] = await tx
+          .insert(autoTopUpLegacyPaymentQuarantine)
+          .values({
+            organization_id: input.organizationId,
+            stripe_payment_intent_id: input.paymentIntentId,
+            provider_status: input.providerStatus,
+            credit_amount_cents: creditAmountCents,
+            status: "unresolved",
+            metadata,
+            discovered_at: input.now,
+            updated_at: input.now,
+          })
+          .onConflictDoNothing({
+            target: autoTopUpLegacyPaymentQuarantine.stripe_payment_intent_id,
+          })
+          .returning();
+        if (inserted) return toLegacyQuarantine(inserted);
+        [existing] = await tx
+          .select()
+          .from(autoTopUpLegacyPaymentQuarantine)
+          .where(
+            eq(autoTopUpLegacyPaymentQuarantine.stripe_payment_intent_id, input.paymentIntentId),
+          )
+          .for("update")
+          .limit(1);
+      }
+      if (!existing) {
+        invariantViolation("Legacy PaymentIntent quarantine conflict returned no row", {
+          paymentIntentId: input.paymentIntentId,
+        });
+      }
+      if (existing.organization_id !== input.organizationId) {
+        invariantViolation("Legacy PaymentIntent belongs to another organization", {
+          paymentIntentId: input.paymentIntentId,
+          organizationId: input.organizationId,
+        });
+      }
+      if (existing.credit_amount_cents !== creditAmountCents) {
+        invariantViolation("Legacy PaymentIntent snapshot conflicts with its quarantine", {
+          paymentIntentId: input.paymentIntentId,
+          organizationId: input.organizationId,
+        });
+      }
+      if (existing.provider_status === input.providerStatus) return toLegacyQuarantine(existing);
+      if (
+        existing.status === "credited" ||
+        existing.status === "canceled" ||
+        TERMINAL_LEGACY_PROVIDER_STATUSES.has(existing.provider_status)
+      ) {
+        invariantViolation("Legacy PaymentIntent terminal status cannot be rewritten", {
+          paymentIntentId: input.paymentIntentId,
+          providerStatus: existing.provider_status,
+          requestedProviderStatus: input.providerStatus,
+        });
+      }
+
+      const [refreshed] = await tx
+        .update(autoTopUpLegacyPaymentQuarantine)
+        .set({
+          provider_status: input.providerStatus,
+          metadata,
+          updated_at: input.now,
+        })
+        .where(
+          and(
+            eq(autoTopUpLegacyPaymentQuarantine.id, existing.id),
+            eq(autoTopUpLegacyPaymentQuarantine.provider_status, existing.provider_status),
+            inArray(autoTopUpLegacyPaymentQuarantine.status, ["unresolved", "manual_review"]),
+          ),
+        )
+        .returning();
+      if (!refreshed) {
+        invariantViolation("Legacy PaymentIntent status refresh lost its quarantine fence", {
+          paymentIntentId: input.paymentIntentId,
+        });
+      }
+      return toLegacyQuarantine(refreshed);
+    });
+  }
+
+  async resolveLegacyPaymentIntent(
+    input: ResolveLegacyPaymentIntentInput,
+  ): Promise<AutoTopUpLegacyPaymentQuarantine | null> {
+    requiredString(input.paymentIntentId, "paymentIntentId");
+    assertDate(input.now, "now");
+    const metadata = jsonObject(input.metadata, "metadata");
+    if (!(["credited", "canceled", "manual_review"] as const).includes(input.resolution)) {
+      invalidInput("Legacy PaymentIntent resolution is unsupported", {
+        resolution: input.resolution,
+      });
+    }
+
+    return dbWrite.transaction(async (tx) => {
+      // The first read discovers immutable ownership without taking a row lock.
+      // Every actual lock then follows organization -> quarantine -> credit,
+      // matching imports, claims, lifecycle guards, and webhook credit writers.
+      const [observedEntry] = await tx
+        .select({
+          id: autoTopUpLegacyPaymentQuarantine.id,
+          organizationId: autoTopUpLegacyPaymentQuarantine.organization_id,
+        })
+        .from(autoTopUpLegacyPaymentQuarantine)
+        .where(eq(autoTopUpLegacyPaymentQuarantine.stripe_payment_intent_id, input.paymentIntentId))
+        .limit(1);
+      if (!observedEntry) return null;
+
+      const [lockedOrganization] = await tx
+        .select({ id: organizations.id })
+        .from(organizations)
+        .where(eq(organizations.id, observedEntry.organizationId))
+        .for("update")
+        .limit(1);
+      if (!lockedOrganization) return null;
+
+      const [entry] = await tx
+        .select()
+        .from(autoTopUpLegacyPaymentQuarantine)
+        .where(
+          and(
+            eq(autoTopUpLegacyPaymentQuarantine.id, observedEntry.id),
+            eq(autoTopUpLegacyPaymentQuarantine.organization_id, observedEntry.organizationId),
+            eq(autoTopUpLegacyPaymentQuarantine.stripe_payment_intent_id, input.paymentIntentId),
+          ),
+        )
+        .for("update")
+        .limit(1);
+      if (!entry) return null;
+
+      const [credit] = await tx
+        .select()
+        .from(creditTransactions)
+        .where(eq(creditTransactions.stripe_payment_intent_id, input.paymentIntentId))
+        .for("update")
+        .limit(1);
+      const creditAmountCents = credit ? exactCentsFromDecimal(credit.amount) : null;
+      const creditMatches =
+        credit !== undefined &&
+        credit.organization_id === entry.organization_id &&
+        credit.type === "credit" &&
+        credit.metadata.type === "auto_top_up" &&
+        creditAmountCents === entry.credit_amount_cents;
+
+      if (entry.status === "credited" || entry.status === "canceled") {
+        if (entry.status !== input.resolution) return null;
+        if (entry.status === "credited") {
+          return entry.provider_status === "succeeded" && creditMatches
+            ? toLegacyQuarantine(entry)
+            : null;
+        }
+        return entry.provider_status === "canceled" && !credit ? toLegacyQuarantine(entry) : null;
+      }
+
+      if (input.resolution === "credited") {
+        if (entry.provider_status !== "succeeded" || !creditMatches) {
+          return null;
+        }
+      } else if (input.resolution === "canceled") {
+        if (entry.provider_status !== "canceled" || credit) return null;
+      }
+
+      if (input.resolution === "manual_review") {
+        const disabled = await tx
+          .update(organizations)
+          .set({ auto_top_up_enabled: false, updated_at: input.now })
+          .where(eq(organizations.id, entry.organization_id))
+          .returning({ id: organizations.id });
+        if (disabled.length !== 1) {
+          invariantViolation("Legacy PaymentIntent review could not disable its organization", {
+            paymentIntentId: input.paymentIntentId,
+            organizationId: entry.organization_id,
+          });
+        }
+      }
+      const [resolved] = await tx
+        .update(autoTopUpLegacyPaymentQuarantine)
+        .set({
+          status: input.resolution,
+          credit_transaction_id: input.resolution === "credited" ? credit?.id : null,
+          metadata,
+          resolved_at: input.resolution === "manual_review" ? null : input.now,
+          updated_at: input.now,
+        })
+        .where(eq(autoTopUpLegacyPaymentQuarantine.id, entry.id))
+        .returning();
+      return resolved ? toLegacyQuarantine(resolved) : null;
+    });
+  }
+
+  async findById(attemptId: string): Promise<AutoTopUpAttempt | null> {
+    const [row] = await dbWrite
+      .select()
+      .from(autoTopUpAttempts)
+      .where(eq(autoTopUpAttempts.id, attemptId))
+      .limit(1);
+    return row ? toAttempt(row) : null;
+  }
+
+  async findBlockingByOrganization(organizationId: string): Promise<AutoTopUpAttempt | null> {
+    requiredString(organizationId, "organizationId");
+    const [row] = await dbWrite
+      .select()
+      .from(autoTopUpAttempts)
+      .where(
+        and(
+          eq(autoTopUpAttempts.organization_id, organizationId),
+          inArray(autoTopUpAttempts.status, BLOCKING_STATUSES),
+        ),
+      )
+      .orderBy(desc(autoTopUpAttempts.created_at))
+      .limit(1);
+    return row ? toAttempt(row) : null;
+  }
+
+  /**
+   * Primary-read UX hint for settings flows. This is not the security boundary:
+   * claimEligibleAttempt rechecks the same predicate under the organization lock.
+   */
+  async findBlockingLegacyPaymentByOrganization(
+    organizationId: string,
+  ): Promise<AutoTopUpLegacyPaymentQuarantine | null> {
+    requiredString(organizationId, "organizationId");
+    const [row] = await dbWrite
+      .select()
+      .from(autoTopUpLegacyPaymentQuarantine)
+      .where(
+        and(
+          eq(autoTopUpLegacyPaymentQuarantine.organization_id, organizationId),
+          inArray(autoTopUpLegacyPaymentQuarantine.status, ["unresolved", "manual_review"]),
+        ),
+      )
+      .orderBy(desc(autoTopUpLegacyPaymentQuarantine.discovered_at))
+      .limit(1);
+    return row ? toLegacyQuarantine(row) : null;
+  }
+
+  async findByPaymentIntentId(paymentIntentId: string): Promise<AutoTopUpAttempt | null> {
+    requiredString(paymentIntentId, "paymentIntentId");
+    const [row] = await dbWrite
+      .select()
+      .from(autoTopUpAttempts)
+      .where(eq(autoTopUpAttempts.stripe_payment_intent_id, paymentIntentId))
+      .limit(1);
+    return row ? toAttempt(row) : null;
+  }
+
+  /**
+   * Linearization point for a new top-up. The organization row is locked before
+   * checking an idempotency replay, an existing blocking attempt, or current
+   * billing eligibility. The inserted provider snapshot therefore cannot be
+   * assembled from a stale pre-lock organization read.
+   */
+  async claimEligibleAttempt(
+    input: ClaimEligibleAttemptInput,
+  ): Promise<ClaimEligibleAttemptResult> {
+    requiredString(input.organizationId, "organizationId");
+    requiredString(input.attemptId, "attemptId");
+    requiredString(input.idempotencyKey, "idempotencyKey");
+    assertDate(input.now, "now");
+    if (!TRIGGER_SOURCES.has(input.triggerSource)) {
+      invalidInput("Auto-top-up trigger source is unsupported", { field: "triggerSource" });
+    }
+
+    return dbWrite.transaction(async (tx) => {
+      // Global lock order is organization -> cutover control -> quarantine.
+      // Lifecycle triggers already hold the organization before consulting the
+      // control row; matching that order prevents a queued phase writer from
+      // creating a PostgreSQL fairness deadlock.
+      const [organization] = await tx
+        .select({
+          id: organizations.id,
+          is_active: organizations.is_active,
+          auto_top_up_enabled: organizations.auto_top_up_enabled,
+          credit_balance: organizations.credit_balance,
+          auto_top_up_threshold: organizations.auto_top_up_threshold,
+          auto_top_up_amount: organizations.auto_top_up_amount,
+          stripe_customer_id: organizations.stripe_customer_id,
+          stripe_default_payment_method: organizations.stripe_default_payment_method,
+          balance_decrease_revision: organizations.balance_decrease_revision,
+          covered_balance_decrease_revision:
+            organizations.auto_top_up_covered_balance_decrease_revision,
+          below_threshold: sql<boolean>`${organizations.credit_balance} < ${organizations.auto_top_up_threshold}`,
+        })
+        .from(organizations)
+        .where(eq(organizations.id, input.organizationId))
+        .for("update")
+        .limit(1);
+
+      if (!organization) return notEligible(input.organizationId, "not_found");
+
+      // A pause or activation takes the singleton exclusively. Reading it only
+      // after the tenant lock still linearizes the phase boundary: the claim
+      // waits for any queued writer, then acts on the committed mode.
+      const [control] = await tx
+        .select({ mode: autoTopUpControl.mode })
+        .from(autoTopUpControl)
+        .where(eq(autoTopUpControl.singleton, true))
+        .for("share")
+        .limit(1);
+      if (!control) invariantViolation("Auto-top-up control row is missing", {});
+      if (control.mode !== "durable") {
+        return notEligible(input.organizationId, "cutover_paused");
+      }
+
+      // Authoritative legacy quarantine fence. Settings may have been
+      // re-enabled after global cutover, so force the tenant back to disabled
+      // while the same organization lock is held before considering any
+      // idempotency replay or new provider work. This read deliberately takes
+      // no quarantine row lock; a concurrent stale blocking read is safely
+      // fail-closed.
+      const [blockingLegacyPayment] = await tx
+        .select({ id: autoTopUpLegacyPaymentQuarantine.id })
+        .from(autoTopUpLegacyPaymentQuarantine)
+        .where(
+          and(
+            eq(autoTopUpLegacyPaymentQuarantine.organization_id, input.organizationId),
+            inArray(autoTopUpLegacyPaymentQuarantine.status, ["unresolved", "manual_review"]),
+          ),
+        )
+        .limit(1);
+      if (blockingLegacyPayment) {
+        const disabled = await tx
+          .update(organizations)
+          .set({ auto_top_up_enabled: false, updated_at: input.now })
+          .where(eq(organizations.id, input.organizationId))
+          .returning({ id: organizations.id });
+        if (disabled.length !== 1) {
+          invariantViolation("Legacy PaymentIntent quarantine could not disable its organization", {
+            organizationId: input.organizationId,
+            quarantineId: blockingLegacyPayment.id,
+          });
+        }
+        return notEligible(input.organizationId, "legacy_payment_unresolved");
+      }
+
+      const [idempotent] = await tx
+        .select()
+        .from(autoTopUpAttempts)
+        .where(eq(autoTopUpAttempts.idempotency_key, input.idempotencyKey))
+        .limit(1);
+      if (idempotent) {
+        if (idempotent.organization_id !== input.organizationId) {
+          invariantViolation("Auto-top-up idempotency key belongs to another organization", {
+            organizationId: input.organizationId,
+            attemptId: idempotent.id,
+          });
+        }
+        return { outcome: "reused", attempt: toAttempt(idempotent) };
+      }
+
+      const [blocking] = await tx
+        .select()
+        .from(autoTopUpAttempts)
+        .where(
+          and(
+            eq(autoTopUpAttempts.organization_id, input.organizationId),
+            inArray(autoTopUpAttempts.status, BLOCKING_STATUSES),
+          ),
+        )
+        .limit(1);
+      if (blocking) return { outcome: "reused", attempt: toAttempt(blocking) };
+
+      if (!organization.is_active || organization.auto_top_up_enabled !== true) {
+        return notEligible(input.organizationId, "disabled");
+      }
+
+      const disableInvalidConfiguration = async (
+        reason: Extract<
+          AutoTopUpNotEligibleReason,
+          | "invalid_balance"
+          | "invalid_threshold"
+          | "invalid_amount"
+          | "missing_customer"
+          | "missing_payment_method"
+        >,
+        amounts?: { currentBalanceCents?: number; thresholdCents?: number },
+      ): Promise<ClaimEligibleAttemptResult> => {
+        const disabled = await tx
+          .update(organizations)
+          .set({ auto_top_up_enabled: false, updated_at: input.now })
+          .where(eq(organizations.id, input.organizationId))
+          .returning({ id: organizations.id });
+        if (disabled.length !== 1) {
+          invariantViolation("Invalid auto-top-up configuration could not be disabled", {
+            organizationId: input.organizationId,
+            reason,
+          });
+        }
+        return notEligible(input.organizationId, reason, amounts);
+      };
+
+      const balance = canonicalSignedDecimal(organization.credit_balance);
+      if (!balance) return disableInvalidConfiguration("invalid_balance");
+      const currentBalanceCents = exactSignedCentsFromDecimal(balance) ?? undefined;
+      const thresholdCents = exactCentsFromDecimal(organization.auto_top_up_threshold);
+      if (thresholdCents === null || thresholdCents > MAX_AUTO_TOP_UP_CENTS) {
+        return disableInvalidConfiguration("invalid_threshold", { currentBalanceCents });
+      }
+      if (organization.below_threshold !== true) {
+        return notEligible(input.organizationId, "balance_at_or_above_threshold", {
+          currentBalanceCents,
+          thresholdCents,
+        });
+      }
+      const creditAmountCents = exactCentsFromDecimal(organization.auto_top_up_amount);
+      if (
+        creditAmountCents === null ||
+        creditAmountCents < MIN_AUTO_TOP_UP_CENTS ||
+        creditAmountCents > MAX_AUTO_TOP_UP_CENTS
+      ) {
+        return disableInvalidConfiguration("invalid_amount", {
+          currentBalanceCents,
+          thresholdCents,
+        });
+      }
+      const stripeCustomerId = organization.stripe_customer_id;
+      if (!stripeCustomerId || stripeCustomerId !== stripeCustomerId.trim()) {
+        return disableInvalidConfiguration("missing_customer", {
+          currentBalanceCents,
+          thresholdCents,
+        });
+      }
+      const stripePaymentMethodId = organization.stripe_default_payment_method;
+      if (!stripePaymentMethodId || stripePaymentMethodId !== stripePaymentMethodId.trim()) {
+        return disableInvalidConfiguration("missing_payment_method", {
+          currentBalanceCents,
+          thresholdCents,
+        });
+      }
+
+      if (
+        organization.covered_balance_decrease_revision !== null &&
+        organization.balance_decrease_revision <= organization.covered_balance_decrease_revision
+      ) {
+        return notEligible(input.organizationId, "balance_not_rearmed", {
+          currentBalanceCents,
+          thresholdCents,
+        });
+      }
+
+      const [created] = await tx
+        .insert(autoTopUpAttempts)
+        .values({
+          id: input.attemptId,
+          organization_id: input.organizationId,
+          trigger_source: input.triggerSource,
+          status: "claimed",
+          credit_amount_cents: creditAmountCents,
+          charge_amount_cents: creditAmountCents,
+          currency: "usd",
+          stripe_customer_id_snapshot: stripeCustomerId,
+          stripe_payment_method_id_snapshot: stripePaymentMethodId,
+          request_metadata: {},
+          idempotency_key: input.idempotencyKey,
+          next_attempt_at: input.now,
+          created_at: input.now,
+          updated_at: input.now,
+        })
+        .returning();
+      if (!created) {
+        invariantViolation("Auto-top-up claim insert returned no row", {
+          organizationId: input.organizationId,
+          attemptId: input.attemptId,
+        });
+      }
+      return { outcome: "created", attempt: toAttempt(created) };
+    });
+  }
+
+  async claimDueLease(input: ClaimDueLeaseInput): Promise<AutoTopUpAttempt | null> {
+    requiredString(input.attemptId, "attemptId");
+    requiredString(input.leaseToken, "leaseToken");
+    assertLeaseWindow(input.now, input.leaseExpiresAt);
+    const [claimed] = await dbWrite
+      .update(autoTopUpAttempts)
+      .set({
+        lease_token: input.leaseToken,
+        lease_expires_at: input.leaseExpiresAt,
+        attempt_count: sql`${autoTopUpAttempts.attempt_count} + 1`,
+        updated_at: input.now,
+      })
+      .where(
+        and(
+          eq(autoTopUpAttempts.id, input.attemptId),
+          inArray(autoTopUpAttempts.status, CLAIMABLE_STATUSES),
+          lte(autoTopUpAttempts.next_attempt_at, input.now),
+          or(
+            isNull(autoTopUpAttempts.lease_token),
+            lte(autoTopUpAttempts.lease_expires_at, input.now),
+          ),
+        ),
+      )
+      .returning();
+    if (claimed) return toAttempt(claimed);
+
+    const [replayed] = await dbWrite
+      .select()
+      .from(autoTopUpAttempts)
+      .where(
+        and(
+          eq(autoTopUpAttempts.id, input.attemptId),
+          eq(autoTopUpAttempts.lease_token, input.leaseToken),
+          gt(autoTopUpAttempts.lease_expires_at, input.now),
+          inArray(autoTopUpAttempts.status, CLAIMABLE_STATUSES),
+        ),
+      )
+      .limit(1);
+    return replayed ? toAttempt(replayed) : null;
+  }
+
+  async finalizeRequest(input: FinalizeAutoTopUpRequestInput): Promise<AutoTopUpAttempt | null> {
+    requiredString(input.attemptId, "attemptId");
+    requiredString(input.leaseToken, "leaseToken");
+    assertDate(input.now, "now");
+    const chargeAmountCents = safeIntegerCents(input.chargeAmountCents, "chargeAmountCents");
+    if (chargeAmountCents > MAX_AUTO_TOP_UP_CHARGE_CENTS) {
+      invalidInput("Auto-top-up charge exceeds the configured provider bound", {
+        field: "chargeAmountCents",
+        max: MAX_AUTO_TOP_UP_CHARGE_CENTS,
+      });
+    }
+    const metadata = jsonObject(input.requestMetadata, "requestMetadata");
+    const [updated] = await dbWrite
+      .update(autoTopUpAttempts)
+      .set({
+        status: "payment_pending",
+        charge_amount_cents: chargeAmountCents,
+        request_metadata: metadata,
+        last_error: null,
+        updated_at: input.now,
+      })
+      .where(
+        and(
+          eq(autoTopUpAttempts.id, input.attemptId),
+          eq(autoTopUpAttempts.lease_token, input.leaseToken),
+          gt(autoTopUpAttempts.lease_expires_at, input.now),
+          eq(autoTopUpAttempts.status, "claimed"),
+          isNull(autoTopUpAttempts.provider_request_started_at),
+          lte(autoTopUpAttempts.credit_amount_cents, chargeAmountCents),
+        ),
+      )
+      .returning();
+    if (updated) return toAttempt(updated);
+
+    const [replayed] = await dbWrite
+      .select()
+      .from(autoTopUpAttempts)
+      .where(
+        and(
+          eq(autoTopUpAttempts.id, input.attemptId),
+          eq(autoTopUpAttempts.lease_token, input.leaseToken),
+          gt(autoTopUpAttempts.lease_expires_at, input.now),
+          eq(autoTopUpAttempts.status, "payment_pending"),
+          isNull(autoTopUpAttempts.provider_request_started_at),
+          eq(autoTopUpAttempts.charge_amount_cents, chargeAmountCents),
+          sql`${autoTopUpAttempts.request_metadata} = ${JSON.stringify(metadata)}::jsonb`,
+        ),
+      )
+      .limit(1);
+    return replayed ? toAttempt(replayed) : null;
+  }
+
+  async markProviderRequestStarted(
+    input: MarkProviderRequestStartedInput,
+  ): Promise<AutoTopUpAttempt | null> {
+    requiredString(input.attemptId, "attemptId");
+    requiredString(input.leaseToken, "leaseToken");
+    assertLeaseWindow(input.now, input.recoveryDeadlineAt);
+    const [updated] = await dbWrite
+      .update(autoTopUpAttempts)
+      .set({
+        provider_request_started_at: input.now,
+        recovery_deadline_at: input.recoveryDeadlineAt,
+        next_attempt_at: input.now,
+        updated_at: input.now,
+      })
+      .where(
+        and(
+          eq(autoTopUpAttempts.id, input.attemptId),
+          eq(autoTopUpAttempts.lease_token, input.leaseToken),
+          gt(autoTopUpAttempts.lease_expires_at, input.now),
+          eq(autoTopUpAttempts.status, "payment_pending"),
+          isNull(autoTopUpAttempts.provider_request_started_at),
+        ),
+      )
+      .returning();
+    if (updated) return toAttempt(updated);
+
+    const [replayed] = await dbWrite
+      .select()
+      .from(autoTopUpAttempts)
+      .where(
+        and(
+          eq(autoTopUpAttempts.id, input.attemptId),
+          eq(autoTopUpAttempts.lease_token, input.leaseToken),
+          gt(autoTopUpAttempts.lease_expires_at, input.now),
+          eq(autoTopUpAttempts.status, "payment_pending"),
+          gt(autoTopUpAttempts.recovery_deadline_at, input.now),
+        ),
+      )
+      .limit(1);
+    return replayed ? toAttempt(replayed) : null;
+  }
+
+  async recordPaymentIntent(input: RecordPaymentIntentInput): Promise<AutoTopUpAttempt | null> {
+    requiredString(input.attemptId, "attemptId");
+    requiredString(input.leaseToken, "leaseToken");
+    requiredString(input.paymentIntentId, "paymentIntentId");
+    requiredString(input.providerStatus, "providerStatus");
+    assertDate(input.now, "now");
+    const result = jsonObject(input.result, "result");
+    const succeeded = input.providerStatus === "succeeded";
+    const allowedStatuses: AutoTopUpAttemptStatus[] = succeeded
+      ? ["payment_pending", "payment_succeeded"]
+      : ["payment_pending"];
+    const [updated] = await dbWrite
+      .update(autoTopUpAttempts)
+      .set({
+        status: succeeded ? "payment_succeeded" : "payment_pending",
+        stripe_payment_intent_id: input.paymentIntentId,
+        provider_status: input.providerStatus,
+        result,
+        last_error: null,
+        ...(succeeded ? { payment_succeeded_at: input.now, next_attempt_at: input.now } : {}),
+        updated_at: input.now,
+      })
+      .where(
+        and(
+          eq(autoTopUpAttempts.id, input.attemptId),
+          eq(autoTopUpAttempts.lease_token, input.leaseToken),
+          gt(autoTopUpAttempts.lease_expires_at, input.now),
+          inArray(autoTopUpAttempts.status, allowedStatuses),
+          or(
+            isNull(autoTopUpAttempts.stripe_payment_intent_id),
+            eq(autoTopUpAttempts.stripe_payment_intent_id, input.paymentIntentId),
+          ),
+          sql`${autoTopUpAttempts.provider_request_started_at} IS NOT NULL`,
+        ),
+      )
+      .returning();
+    return updated ? toAttempt(updated) : null;
+  }
+
+  async recordFailure(input: RecordAutoTopUpFailureInput): Promise<AutoTopUpAttempt | null> {
+    requiredString(input.attemptId, "attemptId");
+    requiredString(input.leaseToken, "leaseToken");
+    requiredString(input.error, "error");
+    assertDate(input.now, "now");
+    assertDate(input.nextAttemptAt, "nextAttemptAt");
+    if (input.nextAttemptAt.getTime() <= input.now.getTime()) {
+      invalidInput("Auto-top-up retry must be scheduled in the future", {
+        field: "nextAttemptAt",
+      });
+    }
+    const result = input.result ? jsonObject(input.result, "result") : undefined;
+    const [updated] = await dbWrite
+      .update(autoTopUpAttempts)
+      .set({
+        last_error: input.error,
+        ...(result ? { result } : {}),
+        next_attempt_at: sql`CASE
+          WHEN ${autoTopUpAttempts.stripe_payment_intent_id} IS NULL
+            THEN LEAST(${input.nextAttemptAt}, COALESCE(${autoTopUpAttempts.recovery_deadline_at}, ${input.nextAttemptAt}))
+          ELSE ${input.nextAttemptAt}
+        END`,
+        lease_token: null,
+        lease_expires_at: null,
+        updated_at: input.now,
+      })
+      .where(
+        and(
+          eq(autoTopUpAttempts.id, input.attemptId),
+          eq(autoTopUpAttempts.lease_token, input.leaseToken),
+          gt(autoTopUpAttempts.lease_expires_at, input.now),
+          inArray(autoTopUpAttempts.status, ["claimed", "payment_pending"]),
+        ),
+      )
+      .returning();
+    return updated ? toAttempt(updated) : null;
+  }
+
+  async markCanceled(input: MarkAutoTopUpTerminalInput): Promise<AutoTopUpAttempt | null> {
+    requiredString(input.attemptId, "attemptId");
+    requiredString(input.leaseToken, "leaseToken");
+    requiredString(input.error, "error");
+    assertDate(input.now, "now");
+    const result = input.result ? jsonObject(input.result, "result") : undefined;
+
+    return dbWrite.transaction(async (tx) => {
+      const [attempt] = await tx
+        .select()
+        .from(autoTopUpAttempts)
+        .where(eq(autoTopUpAttempts.id, input.attemptId))
+        .for("update")
+        .limit(1);
+      if (
+        !attempt ||
+        attempt.lease_token !== input.leaseToken ||
+        !attempt.lease_expires_at ||
+        attempt.lease_expires_at.getTime() <= input.now.getTime() ||
+        (attempt.status !== "claimed" && attempt.status !== "payment_pending") ||
+        !(
+          (attempt.provider_request_started_at === null &&
+            attempt.stripe_payment_intent_id === null) ||
+          (attempt.stripe_payment_intent_id !== null && attempt.provider_status === "canceled")
+        )
+      ) {
+        return null;
+      }
+
+      const disabled = await tx
+        .update(organizations)
+        .set({ auto_top_up_enabled: false, updated_at: input.now })
+        .where(eq(organizations.id, attempt.organization_id))
+        .returning({ id: organizations.id });
+      if (disabled.length !== 1) {
+        invariantViolation("Auto-top-up cancellation could not disable its organization", {
+          attemptId: attempt.id,
+          organizationId: attempt.organization_id,
+        });
+      }
+
+      const [canceled] = await tx
+        .update(autoTopUpAttempts)
+        .set({
+          status: "canceled",
+          last_error: input.error,
+          ...(result ? { result } : {}),
+          next_attempt_at: null,
+          lease_token: null,
+          lease_expires_at: null,
+          canceled_at: input.now,
+          updated_at: input.now,
+        })
+        .where(
+          and(
+            eq(autoTopUpAttempts.id, attempt.id),
+            eq(autoTopUpAttempts.status, attempt.status),
+            eq(autoTopUpAttempts.lease_token, input.leaseToken),
+            gt(autoTopUpAttempts.lease_expires_at, input.now),
+            or(
+              and(
+                isNull(autoTopUpAttempts.provider_request_started_at),
+                isNull(autoTopUpAttempts.stripe_payment_intent_id),
+              ),
+              and(
+                sql`${autoTopUpAttempts.stripe_payment_intent_id} IS NOT NULL`,
+                eq(autoTopUpAttempts.provider_status, "canceled"),
+              ),
+            ),
+          ),
+        )
+        .returning();
+      if (!canceled) {
+        invariantViolation("Auto-top-up cancellation lost its lease fence", {
+          attemptId: attempt.id,
+        });
+      }
+      return toAttempt(canceled);
+    });
+  }
+
+  async markManualReview(input: MarkAutoTopUpTerminalInput): Promise<AutoTopUpAttempt | null> {
+    requiredString(input.attemptId, "attemptId");
+    requiredString(input.leaseToken, "leaseToken");
+    requiredString(input.error, "error");
+    assertDate(input.now, "now");
+    const result = input.result ? jsonObject(input.result, "result") : undefined;
+
+    return dbWrite.transaction(async (tx) => {
+      const [attempt] = await tx
+        .select()
+        .from(autoTopUpAttempts)
+        .where(eq(autoTopUpAttempts.id, input.attemptId))
+        .for("update")
+        .limit(1);
+      if (
+        !attempt ||
+        attempt.lease_token !== input.leaseToken ||
+        !attempt.lease_expires_at ||
+        attempt.lease_expires_at.getTime() <= input.now.getTime() ||
+        !CLAIMABLE_STATUSES.includes(attempt.status)
+      ) {
+        return null;
+      }
+
+      const disabled = await tx
+        .update(organizations)
+        .set({ auto_top_up_enabled: false, updated_at: input.now })
+        .where(eq(organizations.id, attempt.organization_id))
+        .returning({ id: organizations.id });
+      if (disabled.length !== 1) {
+        invariantViolation("Auto-top-up manual review could not disable its organization", {
+          attemptId: attempt.id,
+          organizationId: attempt.organization_id,
+        });
+      }
+
+      const [reviewed] = await tx
+        .update(autoTopUpAttempts)
+        .set({
+          status: "manual_review",
+          last_error: input.error,
+          ...(result ? { result } : {}),
+          next_attempt_at: null,
+          lease_token: null,
+          lease_expires_at: null,
+          manual_review_at: input.now,
+          updated_at: input.now,
+        })
+        .where(
+          and(
+            eq(autoTopUpAttempts.id, attempt.id),
+            eq(autoTopUpAttempts.status, attempt.status),
+            eq(autoTopUpAttempts.lease_token, input.leaseToken),
+            gt(autoTopUpAttempts.lease_expires_at, input.now),
+          ),
+        )
+        .returning();
+      if (!reviewed) {
+        invariantViolation("Auto-top-up manual review lost its lease fence", {
+          attemptId: attempt.id,
+        });
+      }
+      return toAttempt(reviewed);
+    });
+  }
+
+  /**
+   * Reopen only a previously provider-started manual review after the service
+   * validates a late signed success. The organization deliberately remains
+   * disabled and the audit timestamp is retained; recovery must claim a fresh
+   * lease before settlement.
+   */
+  async reopenManualReviewForSucceededPayment(
+    input: ReopenManualReviewForSucceededPaymentInput,
+  ): Promise<AutoTopUpAttempt | null> {
+    requiredString(input.attemptId, "attemptId");
+    requiredString(input.paymentIntentId, "paymentIntentId");
+    assertDate(input.now, "now");
+    const result = jsonObject(input.result, "result");
+
+    return dbWrite.transaction(async (tx) => {
+      const [attempt] = await tx
+        .select()
+        .from(autoTopUpAttempts)
+        .where(eq(autoTopUpAttempts.id, input.attemptId))
+        .for("update")
+        .limit(1);
+      if (!attempt) return null;
+      if (
+        (attempt.status === "payment_succeeded" || attempt.status === "credited") &&
+        attempt.stripe_payment_intent_id === input.paymentIntentId
+      ) {
+        return toAttempt(attempt);
+      }
+      if (
+        attempt.status !== "manual_review" ||
+        !attempt.provider_request_started_at ||
+        attempt.credit_transaction_id !== null ||
+        (attempt.stripe_payment_intent_id !== null &&
+          attempt.stripe_payment_intent_id !== input.paymentIntentId)
+      ) {
+        return null;
+      }
+
+      const [reopened] = await tx
+        .update(autoTopUpAttempts)
+        .set({
+          status: "payment_succeeded",
+          stripe_payment_intent_id: input.paymentIntentId,
+          provider_status: "succeeded",
+          result,
+          last_error: null,
+          payment_succeeded_at: input.now,
+          next_attempt_at: input.now,
+          updated_at: input.now,
+        })
+        .where(
+          and(
+            eq(autoTopUpAttempts.id, attempt.id),
+            eq(autoTopUpAttempts.status, "manual_review"),
+            or(
+              isNull(autoTopUpAttempts.stripe_payment_intent_id),
+              eq(autoTopUpAttempts.stripe_payment_intent_id, input.paymentIntentId),
+            ),
+            sql`${autoTopUpAttempts.provider_request_started_at} IS NOT NULL`,
+          ),
+        )
+        .returning();
+      return reopened ? toAttempt(reopened) : null;
+    });
+  }
+
+  async listDue(input: ListDueAutoTopUpAttemptsInput): Promise<AutoTopUpAttempt[]> {
+    assertDate(input.now, "now");
+    if (!Number.isSafeInteger(input.limit) || input.limit < 1 || input.limit > MAX_DUE_LIMIT) {
+      invalidInput("Auto-top-up due limit is outside its bounded range", {
+        field: "limit",
+        max: MAX_DUE_LIMIT,
+      });
+    }
+    const rows = await dbWrite
+      .select()
+      .from(autoTopUpAttempts)
+      .where(
+        and(
+          inArray(autoTopUpAttempts.status, CLAIMABLE_STATUSES),
+          lte(autoTopUpAttempts.next_attempt_at, input.now),
+          or(
+            isNull(autoTopUpAttempts.lease_token),
+            lte(autoTopUpAttempts.lease_expires_at, input.now),
+          ),
+        ),
+      )
+      .orderBy(asc(autoTopUpAttempts.next_attempt_at), asc(autoTopUpAttempts.created_at))
+      .limit(input.limit);
+    return rows.map(toAttempt);
+  }
+
+  async listDueAttempts(input: ListDueAutoTopUpAttemptsInput): Promise<AutoTopUpAttempt[]> {
+    return this.listDue(input);
+  }
+
+  /**
+   * Primary-only bounded discovery hint for the cron. Every returned id still
+   * passes through claimEligibleAttempt, which owns the locked authoritative
+   * eligibility decision and rejects corrupt monetary fields.
+   */
+  async listEligibleOrganizationIds(input: { limit: number }): Promise<string[]> {
+    if (!Number.isSafeInteger(input.limit) || input.limit < 1 || input.limit > MAX_DUE_LIMIT) {
+      invalidInput("Auto-top-up discovery limit is outside its bounded range", {
+        field: "limit",
+        max: MAX_DUE_LIMIT,
+      });
+    }
+    const rows = await dbWrite
+      .select({ organizationId: organizations.id })
+      .from(organizations)
+      .innerJoin(autoTopUpControl, eq(autoTopUpControl.singleton, true))
+      .where(
+        and(
+          eq(autoTopUpControl.mode, "durable"),
+          eq(organizations.is_active, true),
+          eq(organizations.auto_top_up_enabled, true),
+          sql`${organizations.credit_balance} < ${organizations.auto_top_up_threshold}`,
+          notExists(
+            dbWrite
+              .select({ present: sql`1` })
+              .from(autoTopUpAttempts)
+              .where(
+                and(
+                  eq(autoTopUpAttempts.organization_id, organizations.id),
+                  inArray(autoTopUpAttempts.status, BLOCKING_STATUSES),
+                ),
+              ),
+          ),
+          notExists(
+            dbWrite
+              .select({ present: sql`1` })
+              .from(autoTopUpLegacyPaymentQuarantine)
+              .where(
+                and(
+                  eq(autoTopUpLegacyPaymentQuarantine.organization_id, organizations.id),
+                  inArray(autoTopUpLegacyPaymentQuarantine.status, ["unresolved", "manual_review"]),
+                ),
+              ),
+          ),
+          or(
+            isNull(organizations.auto_top_up_covered_balance_decrease_revision),
+            sql`${organizations.auto_top_up_covered_balance_decrease_revision} < ${organizations.balance_decrease_revision}`,
+          ),
+        ),
+      )
+      .orderBy(asc(organizations.id))
+      .limit(input.limit);
+    return rows.map((row) => row.organizationId);
+  }
+
+  /**
+   * Apply or find the exact provider credit and link it to the succeeded
+   * attempt. The status deliberately remains payment_succeeded: only the
+   * service can mark it credited after entitlement caches are invalidated.
+   */
+  async settleSucceededAttempt(input: {
+    attemptId: string;
+    leaseToken: string;
+    now: Date;
+  }): Promise<SettleSucceededAttemptResult | null> {
+    requiredString(input.attemptId, "attemptId");
+    requiredString(input.leaseToken, "leaseToken");
+    assertDate(input.now, "now");
+
+    return dbWrite.transaction(async (tx) => {
+      const [attempt] = await tx
+        .select()
+        .from(autoTopUpAttempts)
+        .where(eq(autoTopUpAttempts.id, input.attemptId))
+        .for("update")
+        .limit(1);
+      if (!attempt) return null;
+
+      // Match the canonical credit writer's lock order: organization before
+      // credit_transactions. The independent attempt lock cannot participate
+      // in a cycle because provider/webhook credit writers never acquire it.
+      const [lockedOrganization] = await tx
+        .select({
+          balance: organizations.credit_balance,
+          balanceDecreaseRevision: organizations.balance_decrease_revision,
+          coveredBalanceDecreaseRevision:
+            organizations.auto_top_up_covered_balance_decrease_revision,
+        })
+        .from(organizations)
+        .where(eq(organizations.id, attempt.organization_id))
+        .for("update")
+        .limit(1);
+      if (!lockedOrganization) {
+        invariantViolation("Auto-top-up settlement organization is missing", {
+          attemptId: attempt.id,
+          organizationId: attempt.organization_id,
+        });
+      }
+
+      if (attempt.status === "credited") {
+        if (!attempt.credit_transaction_id) {
+          invariantViolation("Credited auto-top-up has no credit transaction", {
+            attemptId: attempt.id,
+          });
+        }
+        return {
+          outcome: "already_applied",
+          attempt: toAttempt(attempt),
+          creditTransactionId: attempt.credit_transaction_id,
+          newBalance: String(lockedOrganization.balance),
+        };
+      }
+
+      if (
+        attempt.status !== "payment_succeeded" ||
+        attempt.lease_token !== input.leaseToken ||
+        !attempt.lease_expires_at ||
+        attempt.lease_expires_at.getTime() <= input.now.getTime() ||
+        !attempt.stripe_payment_intent_id
+      ) {
+        return null;
+      }
+
+      const [existingCredit] = await tx
+        .select()
+        .from(creditTransactions)
+        .where(eq(creditTransactions.stripe_payment_intent_id, attempt.stripe_payment_intent_id))
+        .for("update")
+        .limit(1);
+      if (existingCredit) {
+        const existingCents = exactCentsFromDecimal(existingCredit.amount);
+        if (
+          existingCredit.organization_id !== attempt.organization_id ||
+          existingCredit.type !== "credit" ||
+          existingCredit.metadata.type !== "auto_top_up" ||
+          existingCents !== attempt.credit_amount_cents
+        ) {
+          const reviewed = await this.markManualReviewInTransaction(tx, attempt, input.now);
+          return { outcome: "manual_review", attempt: toAttempt(reviewed) };
+        }
+        const coveredRevision =
+          attempt.covered_balance_decrease_revision ??
+          lockedOrganization.coveredBalanceDecreaseRevision;
+        if (coveredRevision === null) {
+          const reviewed = await this.markManualReviewInTransaction(tx, attempt, input.now, {
+            error: "Existing credit timing cannot be reconciled safely",
+            creditTransactionId: existingCredit.id,
+          });
+          return { outcome: "manual_review", attempt: toAttempt(reviewed) };
+        }
+        const linked = await this.linkCreditInTransaction(
+          tx,
+          attempt,
+          existingCredit.id,
+          // A retry after credit application must preserve the revision that
+          // was covered by that credit. Using the live revision here would
+          // swallow a debit that happened after settlement but before the
+          // cache/final-state step recovered.
+          coveredRevision,
+          input.now,
+        );
+        return {
+          outcome: "already_applied",
+          attempt: toAttempt(linked),
+          creditTransactionId: existingCredit.id,
+          newBalance: String(lockedOrganization.balance),
+        };
+      }
+
+      const metadata = {
+        ...attempt.request_metadata,
+        type: "auto_top_up",
+        auto_top_up_attempt_id: attempt.id,
+        auto_top_up_idempotency_key: attempt.idempotency_key,
+        payment_intent_id: attempt.stripe_payment_intent_id,
+      };
+      const [creditTransaction] = await tx
+        .insert(creditTransactions)
+        .values({
+          organization_id: attempt.organization_id,
+          amount: sql`${String(attempt.credit_amount_cents)}::numeric / 100`,
+          type: "credit",
+          description: `Auto top-up - ${attempt.credit_amount_cents} cents`,
+          metadata,
+          stripe_payment_intent_id: attempt.stripe_payment_intent_id,
+          created_at: input.now,
+        })
+        .returning();
+      if (!creditTransaction) {
+        invariantViolation("Auto-top-up credit insert returned no row", {
+          attemptId: attempt.id,
+        });
+      }
+
+      const [organization] = await tx
+        .update(organizations)
+        .set({
+          credit_balance: sql`${organizations.credit_balance} + (${String(attempt.credit_amount_cents)}::numeric / 100)`,
+          settings: sql`COALESCE(${organizations.settings}, '{}'::jsonb) - 'welcomeBonusWithheld'`,
+          updated_at: input.now,
+        })
+        .where(eq(organizations.id, attempt.organization_id))
+        .returning({ balance: organizations.credit_balance });
+      if (!organization) {
+        invariantViolation("Auto-top-up credit balance update returned no organization", {
+          attemptId: attempt.id,
+          organizationId: attempt.organization_id,
+        });
+      }
+
+      const linked = await this.linkCreditInTransaction(
+        tx,
+        attempt,
+        creditTransaction.id,
+        lockedOrganization.balanceDecreaseRevision,
+        input.now,
+      );
+      return {
+        outcome: "applied",
+        attempt: toAttempt(linked),
+        creditTransactionId: creditTransaction.id,
+        newBalance: String(organization.balance),
+      };
+    });
+  }
+
+  /** Terminalize only after the service has awaited all required cache invalidations. */
+  async markCredited(input: MarkAutoTopUpCreditedInput): Promise<AutoTopUpAttempt | null> {
+    requiredString(input.attemptId, "attemptId");
+    requiredString(input.leaseToken, "leaseToken");
+    assertDate(input.now, "now");
+    const [credited] = await dbWrite
+      .update(autoTopUpAttempts)
+      .set({
+        status: "credited",
+        credited_at: input.now,
+        next_attempt_at: null,
+        lease_token: null,
+        lease_expires_at: null,
+        last_error: null,
+        updated_at: input.now,
+      })
+      .where(
+        and(
+          eq(autoTopUpAttempts.id, input.attemptId),
+          eq(autoTopUpAttempts.status, "payment_succeeded"),
+          eq(autoTopUpAttempts.lease_token, input.leaseToken),
+          gt(autoTopUpAttempts.lease_expires_at, input.now),
+          sql`${autoTopUpAttempts.credit_transaction_id} IS NOT NULL`,
+          sql`${autoTopUpAttempts.covered_balance_decrease_revision} IS NOT NULL`,
+        ),
+      )
+      .returning();
+    return credited ? toAttempt(credited) : null;
+  }
+
+  private async markManualReviewInTransaction(
+    tx: Parameters<Parameters<typeof dbWrite.transaction>[0]>[0],
+    attempt: AutoTopUpAttemptRow,
+    now: Date,
+    options: { error?: string; creditTransactionId?: string } = {},
+  ): Promise<AutoTopUpAttemptRow> {
+    const disabled = await tx
+      .update(organizations)
+      .set({ auto_top_up_enabled: false, updated_at: now })
+      .where(eq(organizations.id, attempt.organization_id))
+      .returning({ id: organizations.id });
+    if (disabled.length !== 1) {
+      invariantViolation("Auto-top-up settlement review could not disable its organization", {
+        attemptId: attempt.id,
+        organizationId: attempt.organization_id,
+      });
+    }
+
+    const [reviewed] = await tx
+      .update(autoTopUpAttempts)
+      .set({
+        status: "manual_review",
+        credit_transaction_id: options.creditTransactionId ?? attempt.credit_transaction_id,
+        last_error:
+          options.error ?? "Existing credit transaction does not match the auto-top-up attempt",
+        next_attempt_at: null,
+        lease_token: null,
+        lease_expires_at: null,
+        manual_review_at: now,
+        updated_at: now,
+      })
+      .where(
+        and(
+          eq(autoTopUpAttempts.id, attempt.id),
+          eq(autoTopUpAttempts.status, "payment_succeeded"),
+          eq(autoTopUpAttempts.lease_token, attempt.lease_token as string),
+          gt(autoTopUpAttempts.lease_expires_at, now),
+        ),
+      )
+      .returning();
+    if (!reviewed) {
+      invariantViolation("Auto-top-up manual-review transition lost its fence", {
+        attemptId: attempt.id,
+      });
+    }
+    return reviewed;
+  }
+
+  private async linkCreditInTransaction(
+    tx: Parameters<Parameters<typeof dbWrite.transaction>[0]>[0],
+    attempt: AutoTopUpAttemptRow,
+    creditTransactionId: string,
+    coveredBalanceDecreaseRevision: number,
+    now: Date,
+  ): Promise<AutoTopUpAttemptRow> {
+    const [linked] = await tx
+      .update(autoTopUpAttempts)
+      .set({
+        credit_transaction_id: creditTransactionId,
+        covered_balance_decrease_revision: coveredBalanceDecreaseRevision,
+        next_attempt_at: now,
+        last_error: null,
+        updated_at: now,
+      })
+      .where(
+        and(
+          eq(autoTopUpAttempts.id, attempt.id),
+          eq(autoTopUpAttempts.status, "payment_succeeded"),
+          eq(autoTopUpAttempts.lease_token, attempt.lease_token as string),
+        ),
+      )
+      .returning();
+    if (!linked) {
+      invariantViolation("Auto-top-up credit-link transition lost its fence", {
+        attemptId: attempt.id,
+      });
+    }
+    return linked;
+  }
+}
+
+export const autoTopUpAttemptsRepository = new AutoTopUpAttemptsRepository();

--- a/packages/cloud/shared/src/db/repositories/auto-top-up-cutover.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/auto-top-up-cutover.pglite.test.ts
@@ -1,0 +1,1742 @@
+/**
+ * Exercises the durable auto-top-up repository against real PGlite, including
+ * concurrent claims, immutable provider snapshots, lease takeover, crash
+ * recovery after credit application, exact-cent settlement, and stale-fence
+ * rejection. Stripe itself is not called; its durable request boundary is the
+ * persisted payment-intent identity and result exercised here.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { sql } from "drizzle-orm";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const TIMEOUT = 60_000;
+const BASE_TIME = Date.parse("2026-08-17T12:00:00.000Z");
+const ORG_A = "51000000-0000-4000-8000-000000000001";
+const ORG_B = "51000000-0000-4000-8000-000000000002";
+const ORG_C = "51000000-0000-4000-8000-000000000003";
+const ORG_D = "51000000-0000-4000-8000-000000000004";
+const ORG_E = "51000000-0000-4000-8000-000000000005";
+const ORG_F = "51000000-0000-4000-8000-000000000006";
+const ORG_G = "51000000-0000-4000-8000-000000000007";
+
+let dbWrite: typeof import("../client").dbWrite;
+let closeDatabaseConnectionsForTests:
+  | typeof import("../client").closeDatabaseConnectionsForTests
+  | undefined;
+let getPgliteClientForTests: typeof import("../client").getPgliteClientForTests;
+let repository: import("./auto-top-up-attempts").AutoTopUpAttemptsRepository;
+
+function at(offsetMs: number): Date {
+  return new Date(BASE_TIME + offsetMs);
+}
+
+async function insertOrganization(input: {
+  id: string;
+  balance?: string;
+  threshold?: string | null;
+  amount?: string | null;
+  enabled?: boolean;
+  active?: boolean;
+  customerId?: string | null;
+  paymentMethodId?: string | null;
+}): Promise<void> {
+  await dbWrite.execute(sql`
+    INSERT INTO organizations (
+      id, name, slug, credit_balance, settings, stripe_customer_id,
+      stripe_default_payment_method, auto_top_up_enabled,
+      auto_top_up_threshold, auto_top_up_amount, is_active, updated_at
+    ) VALUES (
+      ${input.id}, ${`Org ${input.id.slice(-1)}`}, ${`org-${input.id.slice(-1)}`},
+      ${input.balance ?? "1.000000"}::numeric, '{}'::jsonb,
+      ${input.customerId === undefined ? `cus_${input.id.slice(-1)}` : input.customerId},
+      ${input.paymentMethodId === undefined ? `pm_${input.id.slice(-1)}` : input.paymentMethodId},
+      ${input.enabled ?? true},
+      ${input.threshold === undefined ? "5.00" : input.threshold}::numeric,
+      ${input.amount === undefined ? "10.00" : input.amount}::numeric,
+      ${input.active ?? true}, ${at(0)}
+    )
+  `);
+}
+
+async function claim(
+  organizationId = ORG_A,
+  now = at(0),
+): Promise<import("./auto-top-up-attempts").AutoTopUpAttempt> {
+  const result = await repository.claimEligibleAttempt({
+    organizationId,
+    triggerSource: "cron",
+    attemptId: randomUUID(),
+    idempotencyKey: `auto-top-up:${organizationId}:${now.getTime()}:${randomUUID()}`,
+    now,
+  });
+  expect(result.outcome).toBe("created");
+  if (result.outcome === "not_eligible") throw new Error("expected a created attempt");
+  return result.attempt;
+}
+
+async function lease(
+  attemptId: string,
+  leaseToken: string,
+  now = at(1_000),
+  leaseExpiresAt = at(61_000),
+): Promise<import("./auto-top-up-attempts").AutoTopUpAttempt> {
+  const attempt = await repository.claimDueLease({ attemptId, leaseToken, now, leaseExpiresAt });
+  expect(attempt).not.toBeNull();
+  return attempt as import("./auto-top-up-attempts").AutoTopUpAttempt;
+}
+
+async function prepareSucceededAttempt(input?: {
+  organizationId?: string;
+  balance?: string;
+  threshold?: string;
+  amount?: string;
+  paymentIntentId?: string;
+}): Promise<{
+  attempt: import("./auto-top-up-attempts").AutoTopUpAttempt;
+  leaseToken: string;
+  paymentIntentId: string;
+}> {
+  const organizationId = input?.organizationId ?? ORG_A;
+  await insertOrganization({
+    id: organizationId,
+    balance: input?.balance,
+    threshold: input?.threshold,
+    amount: input?.amount ?? "10.01",
+  });
+  const claimed = await claim(organizationId);
+  const leaseToken = randomUUID();
+  await lease(claimed.id, leaseToken);
+  const finalized = await repository.finalizeRequest({
+    attemptId: claimed.id,
+    leaseToken,
+    chargeAmountCents: claimed.creditAmountCents + 200,
+    requestMetadata: { organization_id: organizationId, source: "pglite" },
+    now: at(2_000),
+  });
+  expect(finalized?.status).toBe("payment_pending");
+  const started = await repository.markProviderRequestStarted({
+    attemptId: claimed.id,
+    leaseToken,
+    now: at(3_000),
+    recoveryDeadlineAt: at(23 * 60 * 60 * 1_000),
+  });
+  expect(started?.nextAttemptAt).toEqual(at(3_000));
+  const paymentIntentId = input?.paymentIntentId ?? `pi_${claimed.id}`;
+  const succeeded = await repository.recordPaymentIntent({
+    attemptId: claimed.id,
+    leaseToken,
+    paymentIntentId,
+    providerStatus: "succeeded",
+    result: { id: paymentIntentId, status: "succeeded" },
+    now: at(4_000),
+  });
+  expect(succeeded?.status).toBe("payment_succeeded");
+  return { attempt: succeeded!, leaseToken, paymentIntentId };
+}
+
+async function scalar<T>(query: ReturnType<typeof sql>): Promise<T> {
+  const result = await dbWrite.execute(query);
+  const row = result.rows[0];
+  if (!row) throw new Error("expected one scalar row");
+  return row as T;
+}
+
+beforeAll(async () => {
+  ({ closeDatabaseConnectionsForTests, dbWrite, getPgliteClientForTests } = await import(
+    "../client"
+  ));
+  ({ autoTopUpAttemptsRepository: repository } = await import("./auto-top-up-attempts"));
+  await getPgliteClientForTests().exec(`
+    CREATE TABLE organizations (
+      id uuid PRIMARY KEY,
+      name text NOT NULL,
+      slug text NOT NULL UNIQUE,
+      credit_balance numeric(12,6) NOT NULL DEFAULT 0,
+      balance_revision bigint NOT NULL DEFAULT 0,
+      settings jsonb NOT NULL DEFAULT '{}'::jsonb,
+      stripe_customer_id text,
+      stripe_default_payment_method text,
+      auto_top_up_enabled boolean NOT NULL DEFAULT false,
+      auto_top_up_threshold numeric(10,2),
+      auto_top_up_amount numeric(10,2),
+      is_active boolean NOT NULL DEFAULT true,
+      updated_at timestamp NOT NULL DEFAULT now()
+    );
+    CREATE TABLE credit_transactions (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+      user_id uuid,
+      amount numeric(12,6) NOT NULL,
+      type text NOT NULL,
+      description text,
+      metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+      stripe_payment_intent_id text,
+      created_at timestamp NOT NULL DEFAULT now(),
+      settled_at timestamp
+    );
+    CREATE UNIQUE INDEX credit_transactions_stripe_payment_intent_idx
+      ON credit_transactions (stripe_payment_intent_id);
+    CREATE TABLE users (
+      id uuid PRIMARY KEY,
+      organization_id uuid REFERENCES organizations(id) ON DELETE CASCADE
+    );
+  `);
+  const migrations = await Promise.all([
+    readFile(
+      new URL("../migrations/0213_auto_top_up_organization_fence.sql", import.meta.url),
+      "utf8",
+    ),
+    readFile(
+      new URL("../migrations/0214_backfill_auto_top_up_organization_fence.sql", import.meta.url),
+      "utf8",
+    ),
+    readFile(new URL("../migrations/0215_auto_top_up_attempts.sql", import.meta.url), "utf8"),
+    readFile(
+      new URL("../migrations/0216_auto_top_up_cutover_control.sql", import.meta.url),
+      "utf8",
+    ),
+    readFile(
+      new URL("../migrations/0217_guard_auto_top_up_cutover_lifecycle.sql", import.meta.url),
+      "utf8",
+    ),
+  ]);
+  await getPgliteClientForTests().exec(migrations.join("\n"));
+}, TIMEOUT);
+
+beforeEach(async () => {
+  await getPgliteClientForTests().exec(`
+    UPDATE auto_top_up_control
+    SET mode = 'durable', legacy_reconciled_through = paused_at
+    WHERE singleton = true;
+    DELETE FROM auto_top_up_attempts;
+    DELETE FROM auto_top_up_legacy_payment_quarantine;
+    DELETE FROM credit_transactions;
+    DELETE FROM organizations;
+    UPDATE auto_top_up_control
+    SET mode = 'paused', paused_at = '${at(0).toISOString()}',
+        legacy_reconciled_through = NULL, updated_at = '${at(0).toISOString()}'
+    WHERE singleton = true;
+  `);
+  const activated = await repository.transitionControl({
+    expectedMode: "paused",
+    targetMode: "durable",
+    legacyReconciledThrough: at(1),
+    now: at(2),
+  });
+  expect(activated).toMatchObject({ outcome: "applied", control: { mode: "durable" } });
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests?.();
+});
+
+describe("AutoTopUpAttemptsRepository", () => {
+  test("keeps every multi-row reconciliation lock in organization-first order", async () => {
+    const source = await readFile(new URL("./auto-top-up-attempts.ts", import.meta.url), "utf8");
+    const method = (name: string, nextName: string): string => {
+      const start = source.indexOf(`async ${name}`);
+      const end = source.indexOf(`async ${nextName}`, start + 1);
+      expect(start).toBeGreaterThan(-1);
+      expect(end).toBeGreaterThan(start);
+      return source.slice(start, end);
+    };
+
+    const claim = method("claimEligibleAttempt", "claimDueLease");
+    const claimOrganization = claim.indexOf(".from(organizations)");
+    const claimControl = claim.indexOf(".from(autoTopUpControl)");
+    expect(claimOrganization).toBeGreaterThan(-1);
+    expect(claimOrganization).toBeLessThan(claimControl);
+    expect(claim.slice(claimOrganization, claimControl)).toContain('.for("update")');
+    expect(claim.slice(claimControl)).toContain('.for("share")');
+
+    const quarantine = method("quarantineLegacyPaymentIntent", "resolveLegacyPaymentIntent");
+    const importOrganization = quarantine.indexOf(".from(organizations)");
+    const importControl = quarantine.indexOf(".from(autoTopUpControl)");
+    const importQuarantine = quarantine.indexOf(".from(autoTopUpLegacyPaymentQuarantine)");
+    expect(importOrganization).toBeGreaterThan(-1);
+    expect(importOrganization).toBeLessThan(importControl);
+    expect(importControl).toBeLessThan(importQuarantine);
+    expect(quarantine.slice(importOrganization, importControl)).toContain('.for("update")');
+    expect(quarantine.slice(importControl, importQuarantine)).toContain('.for("share")');
+
+    const resolve = method("resolveLegacyPaymentIntent", "findById");
+    const observedQuarantine = resolve.indexOf(".from(autoTopUpLegacyPaymentQuarantine)");
+    const resolveOrganization = resolve.indexOf(".from(organizations)");
+    const lockedQuarantine = resolve.indexOf(
+      ".from(autoTopUpLegacyPaymentQuarantine)",
+      observedQuarantine + 1,
+    );
+    const lockedCredit = resolve.indexOf(".from(creditTransactions)");
+    expect(observedQuarantine).toBeGreaterThan(-1);
+    expect(resolve.slice(observedQuarantine, resolveOrganization)).not.toContain('.for("update")');
+    expect(resolveOrganization).toBeLessThan(lockedQuarantine);
+    expect(lockedQuarantine).toBeLessThan(lockedCredit);
+    expect(resolve.slice(resolveOrganization, lockedQuarantine)).toContain('.for("update")');
+    expect(resolve.slice(lockedQuarantine, lockedCredit)).toContain('.for("update")');
+  });
+
+  test("starts from an explicit control state and paused mode blocks only new claims", async () => {
+    const paused = await repository.transitionControl({
+      expectedMode: "durable",
+      targetMode: "paused",
+      now: at(100),
+    });
+    expect(paused).toEqual({
+      outcome: "applied",
+      control: { mode: "paused", pausedAt: at(100), legacyReconciledThrough: null },
+    });
+    expect(await repository.getControl()).toEqual(paused.control);
+
+    await insertOrganization({ id: ORG_A });
+    const blocked = await repository.claimEligibleAttempt({
+      organizationId: ORG_A,
+      triggerSource: "cron",
+      attemptId: randomUUID(),
+      idempotencyKey: "paused-claim",
+      now: at(101),
+    });
+    expect(blocked).toMatchObject({ outcome: "not_eligible", reason: "cutover_paused" });
+    expect(await repository.listEligibleOrganizationIds({ limit: 100 })).toEqual([]);
+
+    const missingWatermark = await repository.transitionControl({
+      expectedMode: "paused",
+      targetMode: "durable",
+      now: at(102),
+    });
+    expect(missingWatermark).toMatchObject({
+      outcome: "not_applied",
+      reason: "legacy_not_reconciled",
+    });
+    const futureWatermark = await repository.transitionControl({
+      expectedMode: "paused",
+      targetMode: "durable",
+      legacyReconciledThrough: at(104),
+      now: at(103),
+    });
+    expect(futureWatermark).toMatchObject({
+      outcome: "not_applied",
+      reason: "future_reconciliation_watermark",
+    });
+    const activated = await repository.transitionControl({
+      expectedMode: "paused",
+      targetMode: "durable",
+      legacyReconciledThrough: at(100),
+      now: at(105),
+    });
+    expect(activated).toMatchObject({ outcome: "applied", control: { mode: "durable" } });
+    expect((await claim(ORG_A, at(106))).organizationId).toBe(ORG_A);
+  });
+
+  test("linearizes a transition/claim race on the singleton phase lock", async () => {
+    await insertOrganization({ id: ORG_A });
+    await repository.transitionControl({
+      expectedMode: "durable",
+      targetMode: "paused",
+      now: at(100),
+    });
+
+    const [activation, racedClaim] = await Promise.all([
+      repository.transitionControl({
+        expectedMode: "paused",
+        targetMode: "durable",
+        legacyReconciledThrough: at(100),
+        now: at(101),
+      }),
+      repository.claimEligibleAttempt({
+        organizationId: ORG_A,
+        triggerSource: "cron",
+        attemptId: randomUUID(),
+        idempotencyKey: "phase-race",
+        now: at(101),
+      }),
+    ]);
+    expect(activation).toMatchObject({ outcome: "applied", control: { mode: "durable" } });
+    expect(
+      racedClaim.outcome === "created" ||
+        (racedClaim.outcome === "not_eligible" && racedClaim.reason === "cutover_paused"),
+    ).toBe(true);
+
+    if (racedClaim.outcome === "not_eligible") await claim(ORG_A, at(102));
+    const count = await scalar<{ count: string }>(
+      sql`SELECT count(*)::text AS count FROM auto_top_up_attempts WHERE organization_id = ${ORG_A}`,
+    );
+    expect(count.count).toBe("1");
+  });
+
+  test("uses the canonical organization fence for conservative baseline and first claim", async () => {
+    await insertOrganization({ id: ORG_A });
+    await dbWrite.execute(sql`
+      UPDATE organizations
+      SET auto_top_up_covered_balance_decrease_revision = balance_decrease_revision
+      WHERE id = ${ORG_A}
+    `);
+    const baseline = await repository.claimEligibleAttempt({
+      organizationId: ORG_A,
+      triggerSource: "cron",
+      attemptId: randomUUID(),
+      idempotencyKey: "existing-baseline",
+      now: at(100),
+    });
+    expect(baseline).toMatchObject({ outcome: "not_eligible", reason: "balance_not_rearmed" });
+
+    await dbWrite.execute(sql`UPDATE organizations SET credit_balance = 0.50 WHERE id = ${ORG_A}`);
+    expect((await claim(ORG_A, at(101))).organizationId).toBe(ORG_A);
+
+    await insertOrganization({ id: ORG_B });
+    const newOrganizationFence = await scalar<{ covered: string | null }>(sql`
+      SELECT auto_top_up_covered_balance_decrease_revision::text AS covered
+      FROM organizations WHERE id = ${ORG_B}
+    `);
+    expect(newOrganizationFence.covered).toBeNull();
+    expect((await claim(ORG_B, at(102))).organizationId).toBe(ORG_B);
+
+    await insertOrganization({ id: ORG_C });
+    await dbWrite.execute(sql`
+      UPDATE organizations
+      SET auto_top_up_covered_balance_decrease_revision = balance_decrease_revision + 1000
+      WHERE id = ${ORG_C}
+    `);
+    expect(
+      await repository.claimEligibleAttempt({
+        organizationId: ORG_C,
+        triggerSource: "cron",
+        attemptId: randomUUID(),
+        idempotencyKey: "future-corrupt-fence",
+        now: at(103),
+      }),
+    ).toMatchObject({ outcome: "not_eligible", reason: "balance_not_rearmed" });
+    expect(await repository.listEligibleOrganizationIds({ limit: 100 })).toEqual([]);
+  });
+
+  test("quarantines only known legacy PIs and verifies credited/canceled/manual-review resolution", async () => {
+    await insertOrganization({ id: ORG_A });
+    await repository.transitionControl({
+      expectedMode: "durable",
+      targetMode: "paused",
+      now: at(100),
+    });
+    const quarantined = await repository.quarantineLegacyPaymentIntent({
+      organizationId: ORG_A,
+      paymentIntentId: "pi_imported_legacy",
+      providerStatus: "processing",
+      creditAmountCents: 1000,
+      metadata: { source: "stripe_reconciliation" },
+      now: at(101),
+    });
+    expect(quarantined).toMatchObject({ status: "unresolved", creditTransactionId: null });
+    expect(
+      await repository.resolveLegacyPaymentIntent({
+        paymentIntentId: "pi_imported_legacy",
+        resolution: "credited",
+        metadata: { checked: true },
+        now: at(102),
+      }),
+    ).toBeNull();
+    expect(
+      await repository.quarantineLegacyPaymentIntent({
+        organizationId: ORG_A,
+        paymentIntentId: "pi_imported_legacy",
+        providerStatus: "succeeded",
+        creditAmountCents: 1000,
+        metadata: { source: "stripe_reconciliation", refreshed: true },
+        now: at(103),
+      }),
+    ).toMatchObject({ providerStatus: "succeeded", status: "unresolved" });
+    expect(
+      await repository.transitionControl({
+        expectedMode: "paused",
+        targetMode: "durable",
+        legacyReconciledThrough: at(100),
+        now: at(104),
+      }),
+    ).toMatchObject({ outcome: "not_applied", reason: "legacy_quarantine" });
+
+    const inserted = await dbWrite.execute(sql`
+      INSERT INTO credit_transactions (
+        organization_id, amount, type, metadata, stripe_payment_intent_id
+      ) VALUES (
+        ${ORG_A}, 10, 'credit', '{"type":"auto_top_up"}'::jsonb, 'pi_imported_legacy'
+      ) RETURNING id::text AS id
+    `);
+    const creditTransactionId = String(inserted.rows[0]?.id);
+    expect(
+      await repository.resolveLegacyPaymentIntent({
+        paymentIntentId: "pi_imported_legacy",
+        resolution: "canceled",
+        metadata: { checked: true },
+        now: at(105),
+      }),
+    ).toBeNull();
+    expect(
+      await repository.resolveLegacyPaymentIntent({
+        paymentIntentId: "pi_imported_legacy",
+        resolution: "credited",
+        metadata: { checked: true },
+        now: at(106),
+      }),
+    ).toMatchObject({ status: "credited", creditTransactionId });
+    expect(
+      await repository.transitionControl({
+        expectedMode: "paused",
+        targetMode: "durable",
+        legacyReconciledThrough: at(100),
+        now: at(107),
+      }),
+    ).toMatchObject({ outcome: "applied" });
+
+    await repository.transitionControl({
+      expectedMode: "durable",
+      targetMode: "paused",
+      now: at(110),
+    });
+    const review = await repository.quarantineLegacyPaymentIntent({
+      organizationId: ORG_A,
+      paymentIntentId: "pi_imported_review",
+      providerStatus: "unknown",
+      creditAmountCents: 1000,
+      metadata: {},
+      now: at(111),
+    });
+    expect(review).not.toBeNull();
+    expect(
+      await repository.resolveLegacyPaymentIntent({
+        paymentIntentId: "pi_imported_review",
+        resolution: "credited",
+        metadata: {},
+        now: at(111),
+      }),
+    ).toBeNull();
+    expect(
+      await repository.resolveLegacyPaymentIntent({
+        paymentIntentId: "pi_imported_review",
+        resolution: "canceled",
+        metadata: {},
+        now: at(111),
+      }),
+    ).toBeNull();
+    expect(
+      await repository.resolveLegacyPaymentIntent({
+        paymentIntentId: "pi_imported_review",
+        resolution: "manual_review",
+        metadata: { operator: "required" },
+        now: at(112),
+      }),
+    ).toMatchObject({ status: "manual_review", resolvedAt: null });
+    expect(
+      await scalar<{ enabled: boolean }>(
+        sql`SELECT auto_top_up_enabled AS enabled FROM organizations WHERE id = ${ORG_A}`,
+      ),
+    ).toEqual({ enabled: false });
+    expect(
+      await repository.transitionControl({
+        expectedMode: "paused",
+        targetMode: "durable",
+        legacyReconciledThrough: at(110),
+        now: at(113),
+      }),
+    ).toMatchObject({ outcome: "applied" });
+    expect(await repository.findBlockingLegacyPaymentByOrganization(ORG_A)).toMatchObject({
+      stripePaymentIntentId: "pi_imported_review",
+      status: "manual_review",
+    });
+    await dbWrite.execute(sql`
+      UPDATE organizations
+      SET auto_top_up_enabled = true,
+          auto_top_up_covered_balance_decrease_revision = NULL
+      WHERE id = ${ORG_A}
+    `);
+    expect(await repository.listEligibleOrganizationIds({ limit: 100 })).toEqual([]);
+    expect(
+      await repository.claimEligibleAttempt({
+        organizationId: ORG_A,
+        triggerSource: "manual",
+        attemptId: randomUUID(),
+        idempotencyKey: "manual-review-must-still-block",
+        now: at(114),
+      }),
+    ).toMatchObject({ outcome: "not_eligible", reason: "legacy_payment_unresolved" });
+    expect(
+      await scalar<{ enabled: boolean }>(
+        sql`SELECT auto_top_up_enabled AS enabled FROM organizations WHERE id = ${ORG_A}`,
+      ),
+    ).toEqual({ enabled: false });
+    expect(
+      await repository.quarantineLegacyPaymentIntent({
+        organizationId: ORG_A,
+        paymentIntentId: "pi_must_not_import_after_activation",
+        providerStatus: "unknown",
+        creditAmountCents: 1000,
+        metadata: {},
+        now: at(115),
+      }),
+    ).toBeNull();
+  });
+
+  test("unresolved legacy quarantine remains an authoritative claim fence", async () => {
+    await insertOrganization({ id: ORG_A });
+    await repository.transitionControl({
+      expectedMode: "durable",
+      targetMode: "paused",
+      now: at(100),
+    });
+    await repository.quarantineLegacyPaymentIntent({
+      organizationId: ORG_A,
+      paymentIntentId: "pi_still_unresolved",
+      providerStatus: "processing",
+      creditAmountCents: 1000,
+      metadata: { source: "stripe_reconciliation" },
+      now: at(101),
+    });
+    expect(await repository.findBlockingLegacyPaymentByOrganization(ORG_A)).toMatchObject({
+      stripePaymentIntentId: "pi_still_unresolved",
+      status: "unresolved",
+    });
+    expect(
+      await repository.transitionControl({
+        expectedMode: "paused",
+        targetMode: "durable",
+        legacyReconciledThrough: at(100),
+        now: at(102),
+      }),
+    ).toMatchObject({ outcome: "not_applied", reason: "legacy_quarantine" });
+
+    // Defense in depth: even if the singleton were changed outside the checked
+    // CAS, the tenant claim remains the authoritative payment boundary.
+    await dbWrite.execute(sql`
+      UPDATE auto_top_up_control
+      SET mode = 'durable', legacy_reconciled_through = ${at(100)}, updated_at = ${at(103)}
+      WHERE singleton = true
+    `);
+    await dbWrite.execute(sql`
+      UPDATE organizations
+      SET auto_top_up_enabled = true,
+          auto_top_up_covered_balance_decrease_revision = NULL
+      WHERE id = ${ORG_A}
+    `);
+    expect(await repository.listEligibleOrganizationIds({ limit: 100 })).toEqual([]);
+    expect(
+      await repository.claimEligibleAttempt({
+        organizationId: ORG_A,
+        triggerSource: "cron",
+        attemptId: randomUUID(),
+        idempotencyKey: "unresolved-must-still-block",
+        now: at(104),
+      }),
+    ).toMatchObject({ outcome: "not_eligible", reason: "legacy_payment_unresolved" });
+    expect(
+      await scalar<{ enabled: boolean }>(
+        sql`SELECT auto_top_up_enabled AS enabled FROM organizations WHERE id = ${ORG_A}`,
+      ),
+    ).toEqual({ enabled: false });
+    expect(
+      await scalar<{ count: string }>(sql`
+        SELECT count(*)::text AS count FROM auto_top_up_attempts WHERE organization_id = ${ORG_A}
+      `),
+    ).toEqual({ count: "0" });
+  });
+
+  test("refreshes nonterminal legacy provider status without rewriting identity or terminal state", async () => {
+    await insertOrganization({ id: ORG_A });
+    await insertOrganization({ id: ORG_B });
+    await repository.transitionControl({
+      expectedMode: "durable",
+      targetMode: "paused",
+      now: at(100),
+    });
+    await repository.quarantineLegacyPaymentIntent({
+      organizationId: ORG_A,
+      paymentIntentId: "pi_processing_to_canceled",
+      providerStatus: "processing",
+      creditAmountCents: 1000,
+      metadata: { poll: 1 },
+      now: at(101),
+    });
+    await expect(
+      repository.quarantineLegacyPaymentIntent({
+        organizationId: ORG_B,
+        paymentIntentId: "pi_processing_to_canceled",
+        providerStatus: "processing",
+        creditAmountCents: 1000,
+        metadata: {},
+        now: at(102),
+      }),
+    ).rejects.toThrow(/another organization/i);
+    await expect(
+      repository.quarantineLegacyPaymentIntent({
+        organizationId: ORG_A,
+        paymentIntentId: "pi_processing_to_canceled",
+        providerStatus: "processing",
+        creditAmountCents: 1100,
+        metadata: {},
+        now: at(102),
+      }),
+    ).rejects.toThrow(/snapshot conflicts/i);
+
+    expect(
+      await repository.quarantineLegacyPaymentIntent({
+        organizationId: ORG_A,
+        paymentIntentId: "pi_processing_to_canceled",
+        providerStatus: "canceled",
+        creditAmountCents: 1000,
+        metadata: { poll: 2 },
+        now: at(103),
+      }),
+    ).toMatchObject({ providerStatus: "canceled", status: "unresolved" });
+    expect(
+      await repository.resolveLegacyPaymentIntent({
+        paymentIntentId: "pi_processing_to_canceled",
+        resolution: "canceled",
+        metadata: { resolution: "provider_confirmed" },
+        now: at(104),
+      }),
+    ).toMatchObject({ providerStatus: "canceled", status: "canceled" });
+    await expect(
+      repository.quarantineLegacyPaymentIntent({
+        organizationId: ORG_A,
+        paymentIntentId: "pi_processing_to_canceled",
+        providerStatus: "succeeded",
+        creditAmountCents: 1000,
+        metadata: {},
+        now: at(105),
+      }),
+    ).rejects.toThrow(/terminal status cannot be rewritten/i);
+  });
+
+  test("rejects legacy credit adoption with wrong metadata, amount, or canceled provider state", async () => {
+    await insertOrganization({ id: ORG_A });
+    await insertOrganization({ id: ORG_B });
+    await insertOrganization({ id: ORG_C });
+    await repository.transitionControl({
+      expectedMode: "durable",
+      targetMode: "paused",
+      now: at(100),
+    });
+
+    await repository.quarantineLegacyPaymentIntent({
+      organizationId: ORG_A,
+      paymentIntentId: "pi_wrong_credit_metadata",
+      providerStatus: "succeeded",
+      creditAmountCents: 1000,
+      metadata: {},
+      now: at(101),
+    });
+    await dbWrite.execute(sql`
+      INSERT INTO credit_transactions (
+        organization_id, amount, type, metadata, stripe_payment_intent_id
+      ) VALUES (${ORG_A}, 10, 'credit', '{"type":"grant"}'::jsonb, 'pi_wrong_credit_metadata')
+    `);
+    expect(
+      await repository.resolveLegacyPaymentIntent({
+        paymentIntentId: "pi_wrong_credit_metadata",
+        resolution: "credited",
+        metadata: {},
+        now: at(102),
+      }),
+    ).toBeNull();
+
+    await repository.quarantineLegacyPaymentIntent({
+      organizationId: ORG_B,
+      paymentIntentId: "pi_wrong_credit_amount",
+      providerStatus: "succeeded",
+      creditAmountCents: 1000,
+      metadata: {},
+      now: at(103),
+    });
+    await dbWrite.execute(sql`
+      INSERT INTO credit_transactions (
+        organization_id, amount, type, metadata, stripe_payment_intent_id
+      ) VALUES (${ORG_B}, 9.99, 'credit', '{"type":"auto_top_up"}'::jsonb, 'pi_wrong_credit_amount')
+    `);
+    expect(
+      await repository.resolveLegacyPaymentIntent({
+        paymentIntentId: "pi_wrong_credit_amount",
+        resolution: "credited",
+        metadata: {},
+        now: at(104),
+      }),
+    ).toBeNull();
+
+    await repository.quarantineLegacyPaymentIntent({
+      organizationId: ORG_C,
+      paymentIntentId: "pi_canceled_with_credit",
+      providerStatus: "canceled",
+      creditAmountCents: 1000,
+      metadata: {},
+      now: at(105),
+    });
+    await dbWrite.execute(sql`
+      INSERT INTO credit_transactions (
+        organization_id, amount, type, metadata, stripe_payment_intent_id
+      ) VALUES (${ORG_C}, 10, 'credit', '{"type":"auto_top_up"}'::jsonb, 'pi_canceled_with_credit')
+    `);
+    expect(
+      await repository.resolveLegacyPaymentIntent({
+        paymentIntentId: "pi_canceled_with_credit",
+        resolution: "canceled",
+        metadata: {},
+        now: at(106),
+      }),
+    ).toBeNull();
+    expect(
+      await repository.resolveLegacyPaymentIntent({
+        paymentIntentId: "pi_canceled_with_credit",
+        resolution: "credited",
+        metadata: {},
+        now: at(107),
+      }),
+    ).toBeNull();
+  });
+
+  test("refreshes existing manual-review PIs after activation but never imports a new PI", async () => {
+    await insertOrganization({ id: ORG_A });
+    await insertOrganization({ id: ORG_B });
+    await repository.transitionControl({
+      expectedMode: "durable",
+      targetMode: "paused",
+      now: at(100),
+    });
+    for (const [organizationId, paymentIntentId] of [
+      [ORG_A, "pi_durable_refresh_succeeded"],
+      [ORG_B, "pi_durable_refresh_canceled"],
+    ] as const) {
+      await repository.quarantineLegacyPaymentIntent({
+        organizationId,
+        paymentIntentId,
+        providerStatus: "processing",
+        creditAmountCents: 1000,
+        metadata: {},
+        now: at(101),
+      });
+      await repository.resolveLegacyPaymentIntent({
+        paymentIntentId,
+        resolution: "manual_review",
+        metadata: { reason: "awaiting_terminal_provider_status" },
+        now: at(102),
+      });
+    }
+    expect(
+      await repository.transitionControl({
+        expectedMode: "paused",
+        targetMode: "durable",
+        legacyReconciledThrough: at(100),
+        now: at(103),
+      }),
+    ).toMatchObject({ outcome: "applied" });
+    expect(
+      await repository.quarantineLegacyPaymentIntent({
+        organizationId: ORG_A,
+        paymentIntentId: "pi_unknown_after_activation",
+        providerStatus: "processing",
+        creditAmountCents: 1000,
+        metadata: {},
+        now: at(104),
+      }),
+    ).toBeNull();
+
+    expect(
+      await repository.quarantineLegacyPaymentIntent({
+        organizationId: ORG_A,
+        paymentIntentId: "pi_durable_refresh_succeeded",
+        providerStatus: "succeeded",
+        creditAmountCents: 1000,
+        metadata: { poll: "terminal" },
+        now: at(105),
+      }),
+    ).toMatchObject({ status: "manual_review", providerStatus: "succeeded" });
+    await dbWrite.execute(sql`
+      INSERT INTO credit_transactions (
+        organization_id, amount, type, metadata, stripe_payment_intent_id
+      ) VALUES (
+        ${ORG_A}, 10, 'credit', '{"type":"auto_top_up"}'::jsonb,
+        'pi_durable_refresh_succeeded'
+      )
+    `);
+    expect(
+      await repository.resolveLegacyPaymentIntent({
+        paymentIntentId: "pi_durable_refresh_succeeded",
+        resolution: "credited",
+        metadata: { reconciled: true },
+        now: at(106),
+      }),
+    ).toMatchObject({ status: "credited", providerStatus: "succeeded" });
+
+    expect(
+      await repository.quarantineLegacyPaymentIntent({
+        organizationId: ORG_B,
+        paymentIntentId: "pi_durable_refresh_canceled",
+        providerStatus: "canceled",
+        creditAmountCents: 1000,
+        metadata: { poll: "terminal" },
+        now: at(107),
+      }),
+    ).toMatchObject({ status: "manual_review", providerStatus: "canceled" });
+    expect(
+      await repository.resolveLegacyPaymentIntent({
+        paymentIntentId: "pi_durable_refresh_canceled",
+        resolution: "canceled",
+        metadata: { reconciled: true },
+        now: at(108),
+      }),
+    ).toMatchObject({ status: "canceled", providerStatus: "canceled" });
+  });
+
+  test("linearizes concurrent claims and reuses the durable provider snapshot", async () => {
+    await insertOrganization({ id: ORG_A, amount: "10.01" });
+    const firstId = randomUUID();
+    const secondId = randomUUID();
+    const [first, second] = await Promise.all([
+      repository.claimEligibleAttempt({
+        organizationId: ORG_A,
+        triggerSource: "cron",
+        attemptId: firstId,
+        idempotencyKey: "claim-race-first",
+        now: at(0),
+      }),
+      repository.claimEligibleAttempt({
+        organizationId: ORG_A,
+        triggerSource: "credit_deduction",
+        attemptId: secondId,
+        idempotencyKey: "claim-race-second",
+        now: at(0),
+      }),
+    ]);
+
+    expect([first.outcome, second.outcome].sort()).toEqual(["created", "reused"]);
+    if (first.outcome === "not_eligible" || second.outcome === "not_eligible") {
+      throw new Error("concurrent eligible claims must create or reuse");
+    }
+    expect(second.attempt.id).toBe(first.attempt.id);
+    expect(first.attempt.creditAmountCents).toBe(1001);
+    const count = await scalar<{ count: string }>(
+      sql`SELECT count(*)::text AS count FROM auto_top_up_attempts`,
+    );
+    expect(count.count).toBe("1");
+
+    await dbWrite.execute(sql`
+      UPDATE organizations
+      SET auto_top_up_amount = 20, stripe_customer_id = 'cus_changed'
+      WHERE id = ${ORG_A}
+    `);
+    const replay = await repository.claimEligibleAttempt({
+      organizationId: ORG_A,
+      triggerSource: "manual",
+      attemptId: randomUUID(),
+      idempotencyKey: "claim-after-settings-change",
+      now: at(2_000),
+    });
+    expect(replay.outcome).toBe("reused");
+    if (replay.outcome !== "not_eligible") {
+      expect(replay.attempt.creditAmountCents).toBe(1001);
+      expect(replay.attempt.stripeCustomerId).toBe("cus_1");
+    }
+  });
+
+  test("fails closed on out-of-domain amounts and accepts a canonical signed balance", async () => {
+    await insertOrganization({ id: ORG_A, balance: "-1.250000" });
+    await insertOrganization({ id: ORG_B, threshold: "1000.01" });
+    await insertOrganization({ id: ORG_C, amount: "0.99" });
+    await insertOrganization({ id: ORG_D, customerId: null });
+    await insertOrganization({ id: ORG_E, paymentMethodId: " " });
+    await insertOrganization({ id: ORG_F, balance: "NaN" });
+    await insertOrganization({ id: ORG_G, balance: "5.00", threshold: "5.00" });
+
+    const signed = await repository.claimEligibleAttempt({
+      organizationId: ORG_A,
+      triggerSource: "cron",
+      attemptId: randomUUID(),
+      idempotencyKey: "signed-balance",
+      now: at(0),
+    });
+    expect(signed.outcome).toBe("created");
+
+    const badThreshold = await repository.claimEligibleAttempt({
+      organizationId: ORG_B,
+      triggerSource: "cron",
+      attemptId: randomUUID(),
+      idempotencyKey: "bad-threshold",
+      now: at(1_000),
+    });
+    expect(badThreshold).toMatchObject({ outcome: "not_eligible", reason: "invalid_threshold" });
+
+    const subMinimum = await repository.claimEligibleAttempt({
+      organizationId: ORG_C,
+      triggerSource: "cron",
+      attemptId: randomUUID(),
+      idempotencyKey: "sub-minimum",
+      now: at(1_000),
+    });
+    expect(subMinimum).toMatchObject({ outcome: "not_eligible", reason: "invalid_amount" });
+
+    const missingCustomer = await repository.claimEligibleAttempt({
+      organizationId: ORG_D,
+      triggerSource: "cron",
+      attemptId: randomUUID(),
+      idempotencyKey: "missing-customer",
+      now: at(1_000),
+    });
+    expect(missingCustomer).toMatchObject({
+      outcome: "not_eligible",
+      reason: "missing_customer",
+    });
+
+    const missingPaymentMethod = await repository.claimEligibleAttempt({
+      organizationId: ORG_E,
+      triggerSource: "cron",
+      attemptId: randomUUID(),
+      idempotencyKey: "missing-payment-method",
+      now: at(1_000),
+    });
+    expect(missingPaymentMethod).toMatchObject({
+      outcome: "not_eligible",
+      reason: "missing_payment_method",
+    });
+
+    const invalidBalance = await repository.claimEligibleAttempt({
+      organizationId: ORG_F,
+      triggerSource: "cron",
+      attemptId: randomUUID(),
+      idempotencyKey: "invalid-balance",
+      now: at(1_000),
+    });
+    expect(invalidBalance).toMatchObject({ outcome: "not_eligible", reason: "invalid_balance" });
+
+    const atThreshold = await repository.claimEligibleAttempt({
+      organizationId: ORG_G,
+      triggerSource: "cron",
+      attemptId: randomUUID(),
+      idempotencyKey: "at-threshold",
+      now: at(2_000),
+    });
+    expect(atThreshold).toMatchObject({
+      outcome: "not_eligible",
+      reason: "balance_at_or_above_threshold",
+    });
+
+    const enabledRows = await dbWrite.execute(sql`
+      SELECT id, auto_top_up_enabled AS enabled, updated_at
+      FROM organizations
+      WHERE id IN (${ORG_A}, ${ORG_B}, ${ORG_C}, ${ORG_D}, ${ORG_E}, ${ORG_F}, ${ORG_G})
+      ORDER BY id
+    `);
+    expect(enabledRows.rows).toEqual([
+      { id: ORG_A, enabled: true, updated_at: "2026-08-17 12:00:00" },
+      { id: ORG_B, enabled: false, updated_at: "2026-08-17 12:00:01" },
+      { id: ORG_C, enabled: false, updated_at: "2026-08-17 12:00:01" },
+      { id: ORG_D, enabled: false, updated_at: "2026-08-17 12:00:01" },
+      { id: ORG_E, enabled: false, updated_at: "2026-08-17 12:00:01" },
+      { id: ORG_F, enabled: false, updated_at: "2026-08-17 12:00:01" },
+      { id: ORG_G, enabled: true, updated_at: "2026-08-17 12:00:00" },
+    ]);
+  });
+
+  test("keeps finalized charge metadata immutable and makes stamped work due after lease expiry", async () => {
+    await insertOrganization({ id: ORG_A });
+    const attempt = await claim();
+    const leaseToken = randomUUID();
+    await lease(attempt.id, leaseToken);
+    const metadata = { stable: true, nested: { fee_cents: 200 } };
+    const finalized = await repository.finalizeRequest({
+      attemptId: attempt.id,
+      leaseToken,
+      chargeAmountCents: 1200,
+      requestMetadata: metadata,
+      now: at(2_000),
+    });
+    expect(finalized?.chargeAmountCents).toBe(1200);
+    expect(
+      await repository.finalizeRequest({
+        attemptId: attempt.id,
+        leaseToken,
+        chargeAmountCents: 1200,
+        requestMetadata: metadata,
+        now: at(2_500),
+      }),
+    ).not.toBeNull();
+    expect(
+      await repository.finalizeRequest({
+        attemptId: attempt.id,
+        leaseToken,
+        chargeAmountCents: 1300,
+        requestMetadata: metadata,
+        now: at(2_500),
+      }),
+    ).toBeNull();
+
+    const started = await repository.markProviderRequestStarted({
+      attemptId: attempt.id,
+      leaseToken,
+      now: at(3_000),
+      recoveryDeadlineAt: at(23 * 60 * 60 * 1_000),
+    });
+    expect(started?.nextAttemptAt).toEqual(at(3_000));
+    expect(await repository.listDue({ now: at(30_000), limit: 10 })).toEqual([]);
+    expect((await repository.listDue({ now: at(62_000), limit: 10 })).map((row) => row.id)).toEqual(
+      [attempt.id],
+    );
+  });
+
+  test("fences stale terminal leases and disables only with a live cancel or review lease", async () => {
+    await insertOrganization({ id: ORG_A });
+    const attempt = await claim();
+    const staleToken = randomUUID();
+    await lease(attempt.id, staleToken, at(1_000), at(10_000));
+    expect(
+      await repository.markCanceled({
+        attemptId: attempt.id,
+        leaseToken: staleToken,
+        error: "declined",
+        now: at(11_000),
+      }),
+    ).toBeNull();
+    expect(
+      (
+        await scalar<{ auto_top_up_enabled: boolean }>(
+          sql`SELECT auto_top_up_enabled FROM organizations WHERE id = ${ORG_A}`,
+        )
+      ).auto_top_up_enabled,
+    ).toBe(true);
+
+    const liveToken = randomUUID();
+    await lease(attempt.id, liveToken, at(11_000), at(30_000));
+    expect(
+      await repository.finalizeRequest({
+        attemptId: attempt.id,
+        leaseToken: staleToken,
+        chargeAmountCents: 1000,
+        requestMetadata: {},
+        now: at(12_000),
+      }),
+    ).toBeNull();
+    const canceled = await repository.markCanceled({
+      attemptId: attempt.id,
+      leaseToken: liveToken,
+      error: "requires_payment_method",
+      result: { status: "requires_payment_method" },
+      now: at(12_000),
+    });
+    expect(canceled?.status).toBe("canceled");
+    expect(
+      (
+        await scalar<{ auto_top_up_enabled: boolean }>(
+          sql`SELECT auto_top_up_enabled FROM organizations WHERE id = ${ORG_A}`,
+        )
+      ).auto_top_up_enabled,
+    ).toBe(false);
+
+    await insertOrganization({ id: ORG_B });
+    const reviewAttempt = await claim(ORG_B);
+    const staleReviewToken = randomUUID();
+    await lease(reviewAttempt.id, staleReviewToken, at(13_000), at(20_000));
+    expect(
+      await repository.markManualReview({
+        attemptId: reviewAttempt.id,
+        leaseToken: staleReviewToken,
+        error: "ambiguous provider state",
+        now: at(21_000),
+      }),
+    ).toBeNull();
+    expect(
+      (
+        await scalar<{ auto_top_up_enabled: boolean }>(
+          sql`SELECT auto_top_up_enabled FROM organizations WHERE id = ${ORG_B}`,
+        )
+      ).auto_top_up_enabled,
+    ).toBe(true);
+
+    const liveReviewToken = randomUUID();
+    await lease(reviewAttempt.id, liveReviewToken, at(21_000), at(40_000));
+    const reviewed = await repository.markManualReview({
+      attemptId: reviewAttempt.id,
+      leaseToken: liveReviewToken,
+      error: "ambiguous provider state",
+      result: { requires_operator: true },
+      now: at(22_000),
+    });
+    expect(reviewed).toMatchObject({
+      status: "manual_review",
+      nextAttemptAt: null,
+      leaseToken: null,
+    });
+    expect(
+      (
+        await scalar<{ auto_top_up_enabled: boolean }>(
+          sql`SELECT auto_top_up_enabled FROM organizations WHERE id = ${ORG_B}`,
+        )
+      ).auto_top_up_enabled,
+    ).toBe(false);
+  });
+
+  test("refuses to cancel provider-started work without an authoritative canceled PI", async () => {
+    await insertOrganization({ id: ORG_A });
+    const attempt = await claim();
+    const leaseToken = randomUUID();
+    await lease(attempt.id, leaseToken, at(1_000), at(60_000));
+    await repository.finalizeRequest({
+      attemptId: attempt.id,
+      leaseToken,
+      chargeAmountCents: 1000,
+      requestMetadata: {},
+      now: at(2_000),
+    });
+    await repository.markProviderRequestStarted({
+      attemptId: attempt.id,
+      leaseToken,
+      now: at(3_000),
+      recoveryDeadlineAt: at(23 * 60 * 60 * 1_000),
+    });
+
+    expect(
+      await repository.markCanceled({
+        attemptId: attempt.id,
+        leaseToken,
+        error: "ambiguous provider boundary",
+        now: at(4_000),
+      }),
+    ).toBeNull();
+    expect(await repository.findById(attempt.id)).toMatchObject({
+      status: "payment_pending",
+      stripePaymentIntentId: null,
+      providerRequestStartedAt: at(3_000),
+    });
+    expect(
+      await scalar<{ enabled: boolean }>(sql`
+        SELECT auto_top_up_enabled AS enabled FROM organizations WHERE id = ${ORG_A}
+      `),
+    ).toEqual({ enabled: true });
+    expect(
+      await repository.markManualReview({
+        attemptId: attempt.id,
+        leaseToken,
+        error: "ambiguous provider boundary",
+        now: at(5_000),
+      }),
+    ).toMatchObject({ status: "manual_review" });
+  });
+
+  test("reopens a late signed success from manual review but never from canceled", async () => {
+    await insertOrganization({ id: ORG_A });
+    const reviewedAttempt = await claim();
+    const reviewLeaseToken = randomUUID();
+    await lease(reviewedAttempt.id, reviewLeaseToken);
+    await repository.finalizeRequest({
+      attemptId: reviewedAttempt.id,
+      leaseToken: reviewLeaseToken,
+      chargeAmountCents: 1000,
+      requestMetadata: { source: "late-webhook" },
+      now: at(2_000),
+    });
+    await repository.markProviderRequestStarted({
+      attemptId: reviewedAttempt.id,
+      leaseToken: reviewLeaseToken,
+      now: at(3_000),
+      recoveryDeadlineAt: at(23 * 60 * 60 * 1_000),
+    });
+    const reviewed = await repository.markManualReview({
+      attemptId: reviewedAttempt.id,
+      leaseToken: reviewLeaseToken,
+      error: "provider outcome unknown",
+      now: at(4_000),
+    });
+    expect(reviewed).toMatchObject({ status: "manual_review", manualReviewAt: at(4_000) });
+
+    const reopened = await repository.reopenManualReviewForSucceededPayment({
+      attemptId: reviewedAttempt.id,
+      paymentIntentId: "pi_late_signed_success",
+      result: { id: "pi_late_signed_success", status: "succeeded" },
+      now: at(5_000),
+    });
+    expect(reopened).toMatchObject({
+      status: "payment_succeeded",
+      stripePaymentIntentId: "pi_late_signed_success",
+      providerStatus: "succeeded",
+      leaseToken: null,
+      nextAttemptAt: at(5_000),
+      manualReviewAt: at(4_000),
+    });
+    expect((await repository.listDue({ now: at(5_000), limit: 10 })).map((row) => row.id)).toEqual([
+      reviewedAttempt.id,
+    ]);
+    expect(
+      await repository.reopenManualReviewForSucceededPayment({
+        attemptId: reviewedAttempt.id,
+        paymentIntentId: "pi_late_signed_success",
+        result: { duplicate: true },
+        now: at(5_500),
+      }),
+    ).toMatchObject({ status: "payment_succeeded", paymentSucceededAt: at(5_000) });
+
+    const recoveryLeaseToken = randomUUID();
+    await lease(reviewedAttempt.id, recoveryLeaseToken, at(6_000), at(60_000));
+    expect(
+      await repository.settleSucceededAttempt({
+        attemptId: reviewedAttempt.id,
+        leaseToken: recoveryLeaseToken,
+        now: at(7_000),
+      }),
+    ).toMatchObject({ outcome: "applied" });
+    expect(
+      (
+        await scalar<{ auto_top_up_enabled: boolean }>(
+          sql`SELECT auto_top_up_enabled FROM organizations WHERE id = ${ORG_A}`,
+        )
+      ).auto_top_up_enabled,
+    ).toBe(false);
+
+    await insertOrganization({ id: ORG_B });
+    const canceledAttempt = await claim(ORG_B);
+    const cancelLeaseToken = randomUUID();
+    await lease(canceledAttempt.id, cancelLeaseToken);
+    await repository.finalizeRequest({
+      attemptId: canceledAttempt.id,
+      leaseToken: cancelLeaseToken,
+      chargeAmountCents: 1000,
+      requestMetadata: {},
+      now: at(2_000),
+    });
+    await repository.markProviderRequestStarted({
+      attemptId: canceledAttempt.id,
+      leaseToken: cancelLeaseToken,
+      now: at(3_000),
+      recoveryDeadlineAt: at(23 * 60 * 60 * 1_000),
+    });
+    await repository.recordPaymentIntent({
+      attemptId: canceledAttempt.id,
+      leaseToken: cancelLeaseToken,
+      paymentIntentId: "pi_must_stay_canceled",
+      providerStatus: "canceled",
+      result: { status: "canceled" },
+      now: at(3_500),
+    });
+    await repository.markCanceled({
+      attemptId: canceledAttempt.id,
+      leaseToken: cancelLeaseToken,
+      error: "terminal decline",
+      now: at(4_000),
+    });
+    expect(
+      await repository.reopenManualReviewForSucceededPayment({
+        attemptId: canceledAttempt.id,
+        paymentIntentId: "pi_must_stay_canceled",
+        result: { status: "succeeded" },
+        now: at(5_000),
+      }),
+    ).toBeNull();
+    expect(await repository.findById(canceledAttempt.id)).toMatchObject({ status: "canceled" });
+  });
+
+  test("bounds unknown-PI retry by recovery deadline but preserves known-PI retry", async () => {
+    await insertOrganization({ id: ORG_A });
+    const unknown = await claim();
+    const unknownToken = randomUUID();
+    await lease(unknown.id, unknownToken, at(1_000), at(120_000));
+    await repository.finalizeRequest({
+      attemptId: unknown.id,
+      leaseToken: unknownToken,
+      chargeAmountCents: 1000,
+      requestMetadata: {},
+      now: at(2_000),
+    });
+    const deadline = at(30_000);
+    await repository.markProviderRequestStarted({
+      attemptId: unknown.id,
+      leaseToken: unknownToken,
+      now: at(3_000),
+      recoveryDeadlineAt: deadline,
+    });
+    const unknownFailed = await repository.recordFailure({
+      attemptId: unknown.id,
+      leaseToken: unknownToken,
+      error: "response lost",
+      nextAttemptAt: at(40_000),
+      now: at(4_000),
+    });
+    expect(unknownFailed?.nextAttemptAt).toEqual(deadline);
+
+    await insertOrganization({ id: ORG_B });
+    const known = await claim(ORG_B, at(6_000));
+    const knownToken = randomUUID();
+    await lease(known.id, knownToken, at(7_000), at(120_000));
+    await repository.finalizeRequest({
+      attemptId: known.id,
+      leaseToken: knownToken,
+      chargeAmountCents: 1000,
+      requestMetadata: {},
+      now: at(8_000),
+    });
+    await repository.markProviderRequestStarted({
+      attemptId: known.id,
+      leaseToken: knownToken,
+      now: at(9_000),
+      recoveryDeadlineAt: at(30_000),
+    });
+    await repository.recordPaymentIntent({
+      attemptId: known.id,
+      leaseToken: knownToken,
+      paymentIntentId: "pi_processing",
+      providerStatus: "processing",
+      result: { status: "processing" },
+      now: at(10_000),
+    });
+    const knownFailed = await repository.recordFailure({
+      attemptId: known.id,
+      leaseToken: knownToken,
+      error: "still processing",
+      nextAttemptAt: at(40_000),
+      now: at(11_000),
+    });
+    expect(knownFailed?.nextAttemptAt).toEqual(at(40_000));
+  });
+
+  test("recovers a crash after credit application without double-crediting", async () => {
+    const { attempt, leaseToken } = await prepareSucceededAttempt({ amount: "10.01" });
+    await dbWrite.execute(
+      sql`UPDATE organizations SET credit_balance='1.234567' WHERE id=${ORG_A}`,
+    );
+    const applied = await repository.settleSucceededAttempt({
+      attemptId: attempt.id,
+      leaseToken,
+      now: at(5_000),
+    });
+    expect(applied).toMatchObject({ outcome: "applied", newBalance: "11.244567" });
+    expect(applied?.attempt.status).toBe("payment_succeeded");
+    expect(applied?.attempt.creditTransactionId).not.toBeNull();
+
+    // Simulate process death/cache invalidation failure: do not markCredited.
+    const recoveryToken = randomUUID();
+    await lease(attempt.id, recoveryToken, at(62_000), at(122_000));
+    const recovered = await repository.settleSucceededAttempt({
+      attemptId: attempt.id,
+      leaseToken: recoveryToken,
+      now: at(63_000),
+    });
+    expect(recovered).toMatchObject({ outcome: "already_applied", newBalance: "11.244567" });
+    const counts = await scalar<{ count: string; amount: string }>(sql`
+      SELECT count(*)::text AS count, sum(amount)::text AS amount
+      FROM credit_transactions WHERE stripe_payment_intent_id = ${attempt.stripePaymentIntentId}
+    `);
+    expect(counts).toEqual({ count: "1", amount: "10.010000" });
+
+    // The service would await cache invalidation here, then terminalize.
+    const credited = await repository.markCredited({
+      attemptId: attempt.id,
+      leaseToken: recoveryToken,
+      now: at(64_000),
+    });
+    expect(credited).toMatchObject({ status: "credited", nextAttemptAt: null, leaseToken: null });
+    expect(await repository.listDue({ now: at(200_000), limit: 10 })).toEqual([]);
+  });
+
+  test("blocks repeat top-ups until a later balance decrease and ignores refunds", async () => {
+    const { attempt, leaseToken } = await prepareSucceededAttempt({
+      balance: "1.00",
+      threshold: "5.00",
+      amount: "1.00",
+    });
+    const settled = await repository.settleSucceededAttempt({
+      attemptId: attempt.id,
+      leaseToken,
+      now: at(5_000),
+    });
+    expect(settled).toMatchObject({
+      outcome: "applied",
+      newBalance: "2.000000",
+      attempt: { coveredBalanceDecreaseRevision: 0 },
+    });
+    expect(
+      await repository.markCredited({
+        attemptId: attempt.id,
+        leaseToken,
+        now: at(6_000),
+      }),
+    ).toMatchObject({ status: "credited", coveredBalanceDecreaseRevision: 0 });
+
+    const repeated = await repository.claimEligibleAttempt({
+      organizationId: ORG_A,
+      triggerSource: "cron",
+      attemptId: randomUUID(),
+      idempotencyKey: "not-rearmed-after-success",
+      now: at(7_000),
+    });
+    expect(repeated).toMatchObject({ outcome: "not_eligible", reason: "balance_not_rearmed" });
+    expect(await repository.listEligibleOrganizationIds({ limit: 100 })).toEqual([]);
+
+    await dbWrite.execute(
+      sql`UPDATE organizations SET credit_balance = credit_balance + 1 WHERE id = ${ORG_A}`,
+    );
+    const afterRefund = await repository.claimEligibleAttempt({
+      organizationId: ORG_A,
+      triggerSource: "cron",
+      attemptId: randomUUID(),
+      idempotencyKey: "not-rearmed-after-refund",
+      now: at(8_000),
+    });
+    expect(afterRefund).toMatchObject({
+      outcome: "not_eligible",
+      reason: "balance_not_rearmed",
+    });
+    expect(
+      await scalar<{ revision: string }>(sql`
+        SELECT balance_decrease_revision::text AS revision
+        FROM organizations WHERE id = ${ORG_A}
+      `),
+    ).toEqual({ revision: "0" });
+  });
+
+  test("covers every balance decrease observed before settlement", async () => {
+    const { attempt, leaseToken } = await prepareSucceededAttempt({
+      balance: "1.00",
+      threshold: "5.00",
+      amount: "1.00",
+    });
+    await dbWrite.execute(sql`UPDATE organizations SET credit_balance = 0.50 WHERE id = ${ORG_A}`);
+    const revision = await scalar<{ revision: string }>(sql`
+      SELECT balance_decrease_revision::text AS revision
+      FROM organizations WHERE id = ${ORG_A}
+    `);
+    expect(Number(revision.revision)).toBeGreaterThan(0);
+
+    const settled = await repository.settleSucceededAttempt({
+      attemptId: attempt.id,
+      leaseToken,
+      now: at(5_000),
+    });
+    expect(settled?.attempt.coveredBalanceDecreaseRevision).toBe(Number(revision.revision));
+    await repository.markCredited({ attemptId: attempt.id, leaseToken, now: at(6_000) });
+
+    const repeated = await repository.claimEligibleAttempt({
+      organizationId: ORG_A,
+      triggerSource: "cron",
+      attemptId: randomUUID(),
+      idempotencyKey: "pre-settlement-debit-covered",
+      now: at(7_000),
+    });
+    expect(repeated).toMatchObject({ outcome: "not_eligible", reason: "balance_not_rearmed" });
+  });
+
+  test("rearms after a balance decrease that follows settlement", async () => {
+    const { attempt, leaseToken } = await prepareSucceededAttempt({
+      balance: "1.00",
+      threshold: "5.00",
+      amount: "1.00",
+    });
+    const settled = await repository.settleSucceededAttempt({
+      attemptId: attempt.id,
+      leaseToken,
+      now: at(5_000),
+    });
+    expect(settled?.attempt.coveredBalanceDecreaseRevision).toBe(0);
+
+    await dbWrite.execute(sql`UPDATE organizations SET credit_balance = 1.50 WHERE id = ${ORG_A}`);
+    await repository.markCredited({ attemptId: attempt.id, leaseToken, now: at(6_000) });
+    expect(await repository.listEligibleOrganizationIds({ limit: 100 })).toEqual([ORG_A]);
+
+    const rearmed = await repository.claimEligibleAttempt({
+      organizationId: ORG_A,
+      triggerSource: "credit_deduction",
+      attemptId: randomUUID(),
+      idempotencyKey: "post-settlement-debit-rearmed",
+      now: at(7_000),
+    });
+    expect(rearmed.outcome).toBe("created");
+  });
+
+  test("does not cover a debit that lands after credit application during recovery", async () => {
+    const { attempt, leaseToken } = await prepareSucceededAttempt({
+      balance: "1.00",
+      threshold: "5.00",
+      amount: "1.00",
+    });
+    const applied = await repository.settleSucceededAttempt({
+      attemptId: attempt.id,
+      leaseToken,
+      now: at(5_000),
+    });
+    expect(applied?.attempt.coveredBalanceDecreaseRevision).toBe(0);
+
+    // Credit is durable, but the process dies before cache invalidation and
+    // markCredited. A later debit must rearm the next logical top-up.
+    await dbWrite.execute(sql`UPDATE organizations SET credit_balance = 1.50 WHERE id = ${ORG_A}`);
+    const recoveryToken = randomUUID();
+    await lease(attempt.id, recoveryToken, at(62_000), at(122_000));
+    const recovered = await repository.settleSucceededAttempt({
+      attemptId: attempt.id,
+      leaseToken: recoveryToken,
+      now: at(63_000),
+    });
+    expect(recovered).toMatchObject({
+      outcome: "already_applied",
+      attempt: { coveredBalanceDecreaseRevision: 0 },
+    });
+    await repository.markCredited({
+      attemptId: attempt.id,
+      leaseToken: recoveryToken,
+      now: at(64_000),
+    });
+
+    const rearmed = await repository.claimEligibleAttempt({
+      organizationId: ORG_A,
+      triggerSource: "credit_deduction",
+      attemptId: randomUUID(),
+      idempotencyKey: "post-credit-pre-terminal-debit-rearmed",
+      now: at(65_000),
+    });
+    expect(rearmed.outcome).toBe("created");
+  });
+
+  test("moves a mismatched pre-existing provider credit to blocking manual review", async () => {
+    const { attempt, leaseToken, paymentIntentId } = await prepareSucceededAttempt();
+    await dbWrite.execute(sql`
+      INSERT INTO credit_transactions (
+        organization_id, amount, type, metadata, stripe_payment_intent_id
+      ) VALUES (${ORG_A}, '9.99', 'credit', '{}'::jsonb, ${paymentIntentId})
+    `);
+    const settled = await repository.settleSucceededAttempt({
+      attemptId: attempt.id,
+      leaseToken,
+      now: at(5_000),
+    });
+    expect(settled?.outcome).toBe("manual_review");
+    expect(settled?.attempt.status).toBe("manual_review");
+    expect(
+      (
+        await scalar<{ auto_top_up_enabled: boolean }>(
+          sql`SELECT auto_top_up_enabled FROM organizations WHERE id = ${ORG_A}`,
+        )
+      ).auto_top_up_enabled,
+    ).toBe(false);
+    expect(await repository.listDue({ now: at(100_000), limit: 10 })).toEqual([]);
+
+    const claimAgain = await repository.claimEligibleAttempt({
+      organizationId: ORG_A,
+      triggerSource: "cron",
+      attemptId: randomUUID(),
+      idempotencyKey: "blocked-by-review",
+      now: at(6_000),
+    });
+    expect(claimAgain.outcome).toBe("reused");
+    if (claimAgain.outcome !== "not_eligible") {
+      expect(claimAgain.attempt.status).toBe("manual_review");
+    }
+    expect(await repository.listEligibleOrganizationIds({ limit: 100 })).toEqual([]);
+  });
+
+  test("never adopts matching provider credit with non-auto-top-up metadata or a stale fence", async () => {
+    const { attempt, leaseToken, paymentIntentId } = await prepareSucceededAttempt({
+      balance: "1.00",
+      threshold: "5.00",
+      amount: "1.00",
+    });
+    await dbWrite.execute(sql`
+      UPDATE organizations
+      SET auto_top_up_covered_balance_decrease_revision = balance_decrease_revision
+      WHERE id = ${ORG_A}
+    `);
+    await dbWrite.execute(sql`
+      INSERT INTO credit_transactions (
+        organization_id, amount, type, metadata, stripe_payment_intent_id
+      ) VALUES (
+        ${ORG_A}, '1.00', 'credit', '{"type":"grant"}'::jsonb, ${paymentIntentId}
+      )
+    `);
+    await dbWrite.execute(
+      sql`UPDATE organizations SET credit_balance = credit_balance + 1 WHERE id = ${ORG_A}`,
+    );
+    await dbWrite.execute(
+      sql`UPDATE organizations SET credit_balance = credit_balance - 0.25 WHERE id = ${ORG_A}`,
+    );
+    const beforeSettlement = await scalar<{ covered: string; current: string }>(sql`
+      SELECT auto_top_up_covered_balance_decrease_revision::text AS covered,
+        balance_decrease_revision::text AS current
+      FROM organizations WHERE id = ${ORG_A}
+    `);
+    expect(beforeSettlement.covered).not.toBe(beforeSettlement.current);
+
+    expect(
+      await repository.settleSucceededAttempt({
+        attemptId: attempt.id,
+        leaseToken,
+        now: at(5_000),
+      }),
+    ).toMatchObject({
+      outcome: "manual_review",
+      attempt: {
+        status: "manual_review",
+        creditTransactionId: null,
+        coveredBalanceDecreaseRevision: null,
+      },
+    });
+    expect(
+      await scalar<{ enabled: boolean }>(sql`
+        SELECT auto_top_up_enabled AS enabled FROM organizations WHERE id = ${ORG_A}
+      `),
+    ).toEqual({ enabled: false });
+  });
+
+  test("blocks rolling-deploy credit adoption when its covered revision is unknowable", async () => {
+    const { attempt, leaseToken, paymentIntentId } = await prepareSucceededAttempt({
+      balance: "1.00",
+      threshold: "5.00",
+      amount: "1.00",
+    });
+    const inserted = await dbWrite.execute(sql`
+      INSERT INTO credit_transactions (
+        organization_id, amount, type, metadata, stripe_payment_intent_id
+      ) VALUES (
+        ${ORG_A}, '1.00', 'credit',
+        ${JSON.stringify({ type: "auto_top_up", auto_top_up_attempt_id: attempt.id })}::jsonb,
+        ${paymentIntentId}
+      )
+      RETURNING id::text AS id
+    `);
+    const creditTransactionId = String(inserted.rows[0]?.id);
+    // Model a rolling-deploy credit that predates the organization fence
+    // backfill even though its ledger metadata is otherwise authoritative.
+    await dbWrite.execute(sql`
+      UPDATE organizations
+      SET auto_top_up_covered_balance_decrease_revision = NULL
+      WHERE id = ${ORG_A}
+    `);
+    await dbWrite.execute(
+      sql`UPDATE organizations SET credit_balance = credit_balance + 1 WHERE id = ${ORG_A}`,
+    );
+    await dbWrite.execute(
+      sql`UPDATE organizations SET credit_balance = credit_balance - 0.25 WHERE id = ${ORG_A}`,
+    );
+
+    const settled = await repository.settleSucceededAttempt({
+      attemptId: attempt.id,
+      leaseToken,
+      now: at(5_000),
+    });
+
+    expect(settled).toMatchObject({
+      outcome: "manual_review",
+      attempt: {
+        status: "manual_review",
+        creditTransactionId,
+        coveredBalanceDecreaseRevision: null,
+        lastError: "Existing credit timing cannot be reconciled safely",
+      },
+    });
+    expect(
+      await repository.reopenManualReviewForSucceededPayment({
+        attemptId: attempt.id,
+        paymentIntentId,
+        result: { status: "succeeded" },
+        now: at(6_000),
+      }),
+    ).toBeNull();
+    expect(
+      (
+        await scalar<{ auto_top_up_enabled: boolean }>(
+          sql`SELECT auto_top_up_enabled FROM organizations WHERE id = ${ORG_A}`,
+        )
+      ).auto_top_up_enabled,
+    ).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/index.ts
+++ b/packages/cloud/shared/src/db/repositories/index.ts
@@ -66,6 +66,7 @@ export * from "./app-earnings";
 // App Domain
 // ============================================
 export * from "./apps";
+export * from "./auto-top-up-attempts";
 // ============================================
 // Character Domain (User-created definitions)
 // ============================================

--- a/packages/cloud/shared/src/db/schemas/auto-top-up-attempts.ts
+++ b/packages/cloud/shared/src/db/schemas/auto-top-up-attempts.ts
@@ -1,0 +1,234 @@
+/**
+ * Defines the durable auto-top-up attempt ledger used to single-flight provider
+ * requests and fence recovery workers before any customer charge is attempted.
+ */
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+import {
+  bigint,
+  boolean,
+  check,
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { creditTransactions } from "./credit-transactions";
+import { organizations } from "./organizations";
+
+export const AUTO_TOP_UP_TRIGGER_SOURCES = [
+  "cron",
+  "credit_deduction",
+  "manual",
+  "recovery",
+] as const;
+export type AutoTopUpTriggerSource = (typeof AUTO_TOP_UP_TRIGGER_SOURCES)[number];
+
+export const AUTO_TOP_UP_ATTEMPT_STATUSES = [
+  "claimed",
+  "payment_pending",
+  "payment_succeeded",
+  "credited",
+  "canceled",
+  "manual_review",
+] as const;
+export type AutoTopUpAttemptStatus = (typeof AUTO_TOP_UP_ATTEMPT_STATUSES)[number];
+
+export const AUTO_TOP_UP_CONTROL_MODES = ["paused", "durable"] as const;
+export type AutoTopUpControlMode = (typeof AUTO_TOP_UP_CONTROL_MODES)[number];
+
+export const AUTO_TOP_UP_LEGACY_QUARANTINE_STATUSES = [
+  "unresolved",
+  "credited",
+  "canceled",
+  "manual_review",
+] as const;
+export type AutoTopUpLegacyQuarantineStatus =
+  (typeof AUTO_TOP_UP_LEGACY_QUARANTINE_STATUSES)[number];
+
+export const autoTopUpAttempts = pgTable(
+  "auto_top_up_attempts",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organization_id: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    trigger_source: text("trigger_source").$type<AutoTopUpTriggerSource>().notNull(),
+    status: text("status").$type<AutoTopUpAttemptStatus>().notNull().default("claimed"),
+    credit_amount_cents: bigint("credit_amount_cents", { mode: "number" }).notNull(),
+    charge_amount_cents: bigint("charge_amount_cents", { mode: "number" }).notNull(),
+    currency: text("currency").notNull().default("usd"),
+    stripe_customer_id_snapshot: text("stripe_customer_id_snapshot").notNull(),
+    stripe_payment_method_id_snapshot: text("stripe_payment_method_id_snapshot").notNull(),
+    request_metadata: jsonb("request_metadata")
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default({}),
+    idempotency_key: text("idempotency_key").notNull(),
+    stripe_payment_intent_id: text("stripe_payment_intent_id"),
+    credit_transaction_id: uuid("credit_transaction_id").references(() => creditTransactions.id),
+    covered_balance_decrease_revision: bigint("covered_balance_decrease_revision", {
+      mode: "number",
+    }),
+    provider_status: text("provider_status"),
+    attempt_count: integer("attempt_count").notNull().default(0),
+    next_attempt_at: timestamp("next_attempt_at", { withTimezone: true }).defaultNow(),
+    lease_token: uuid("lease_token"),
+    lease_expires_at: timestamp("lease_expires_at", { withTimezone: true }),
+    provider_request_started_at: timestamp("provider_request_started_at", { withTimezone: true }),
+    recovery_deadline_at: timestamp("recovery_deadline_at", { withTimezone: true }),
+    last_error: text("last_error"),
+    result: jsonb("result").$type<Record<string, unknown>>(),
+    payment_succeeded_at: timestamp("payment_succeeded_at", { withTimezone: true }),
+    credited_at: timestamp("credited_at", { withTimezone: true }),
+    canceled_at: timestamp("canceled_at", { withTimezone: true }),
+    manual_review_at: timestamp("manual_review_at", { withTimezone: true }),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    idempotency_key_idx: uniqueIndex("auto_top_up_attempts_idempotency_key_idx").on(
+      table.idempotency_key,
+    ),
+    payment_intent_idx: uniqueIndex("auto_top_up_attempts_payment_intent_idx")
+      .on(table.stripe_payment_intent_id)
+      .where(sql`${table.stripe_payment_intent_id} IS NOT NULL`),
+    blocking_org_idx: uniqueIndex("auto_top_up_attempts_blocking_org_idx")
+      .on(table.organization_id)
+      .where(
+        sql`${table.status} IN ('claimed','payment_pending','payment_succeeded','manual_review')`,
+      ),
+    due_idx: index("auto_top_up_attempts_due_idx")
+      .on(table.next_attempt_at, table.lease_expires_at)
+      .where(
+        sql`${table.status} IN ('claimed','payment_pending','payment_succeeded') AND ${table.next_attempt_at} IS NOT NULL`,
+      ),
+    org_created_idx: index("auto_top_up_attempts_org_created_idx").on(
+      table.organization_id,
+      table.created_at,
+    ),
+    trigger_source_check: check(
+      "auto_top_up_attempts_trigger_source_check",
+      sql`${table.trigger_source} IN ('cron','credit_deduction','manual','recovery')`,
+    ),
+    status_check: check(
+      "auto_top_up_attempts_status_check",
+      sql`${table.status} IN ('claimed','payment_pending','payment_succeeded','credited','canceled','manual_review')`,
+    ),
+    amount_check: check(
+      "auto_top_up_attempts_amount_check",
+      sql`${table.credit_amount_cents} BETWEEN 100 AND 100000 AND ${table.charge_amount_cents} BETWEEN ${table.credit_amount_cents} AND 1120000`,
+    ),
+    currency_check: check(
+      "auto_top_up_attempts_currency_check",
+      sql`${table.currency} ~ '^[a-z]{3}$'`,
+    ),
+    attempt_count_check: check(
+      "auto_top_up_attempts_attempt_count_check",
+      sql`${table.attempt_count} >= 0`,
+    ),
+    lease_pair_check: check(
+      "auto_top_up_attempts_lease_pair_check",
+      sql`(${table.lease_token} IS NULL) = (${table.lease_expires_at} IS NULL)`,
+    ),
+    provider_window_check: check(
+      "auto_top_up_attempts_provider_window_check",
+      sql`((${table.provider_request_started_at} IS NULL) = (${table.recovery_deadline_at} IS NULL)) AND (${table.recovery_deadline_at} IS NULL OR ${table.recovery_deadline_at} > ${table.provider_request_started_at})`,
+    ),
+    terminal_check: check(
+      "auto_top_up_attempts_terminal_check",
+      sql`${table.status} NOT IN ('credited','canceled','manual_review') OR (${table.lease_token} IS NULL AND ${table.next_attempt_at} IS NULL)`,
+    ),
+    succeeded_check: check(
+      "auto_top_up_attempts_succeeded_check",
+      sql`${table.status} NOT IN ('payment_succeeded','credited') OR (${table.stripe_payment_intent_id} IS NOT NULL AND ${table.payment_succeeded_at} IS NOT NULL)`,
+    ),
+    canceled_check: check(
+      "auto_top_up_attempts_canceled_check",
+      sql`${table.status} <> 'canceled' OR (${table.provider_request_started_at} IS NULL AND ${table.stripe_payment_intent_id} IS NULL) OR (${table.stripe_payment_intent_id} IS NOT NULL AND ${table.provider_status} = 'canceled')`,
+    ),
+    credited_check: check(
+      "auto_top_up_attempts_credited_check",
+      sql`${table.status} <> 'credited' OR (${table.credit_transaction_id} IS NOT NULL AND ${table.covered_balance_decrease_revision} IS NOT NULL AND ${table.credited_at} IS NOT NULL)`,
+    ),
+    covered_revision_check: check(
+      "auto_top_up_attempts_covered_revision_check",
+      sql`${table.covered_balance_decrease_revision} IS NULL OR ${table.covered_balance_decrease_revision} >= 0`,
+    ),
+  }),
+);
+
+export type AutoTopUpAttemptRow = InferSelectModel<typeof autoTopUpAttempts>;
+export type NewAutoTopUpAttempt = InferInsertModel<typeof autoTopUpAttempts>;
+
+/** Singleton cutover authority. There is intentionally no executable legacy mode. */
+export const autoTopUpControl = pgTable(
+  "auto_top_up_control",
+  {
+    singleton: boolean("singleton").primaryKey().notNull().default(true),
+    mode: text("mode").$type<AutoTopUpControlMode>().notNull().default("paused"),
+    paused_at: timestamp("paused_at", { withTimezone: true }).notNull().defaultNow(),
+    legacy_reconciled_through: timestamp("legacy_reconciled_through", {
+      withTimezone: true,
+    }),
+    updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    singleton_check: check("auto_top_up_control_singleton_check", sql`${table.singleton} = true`),
+    mode_check: check("auto_top_up_control_mode_check", sql`${table.mode} IN ('paused','durable')`),
+    reconciliation_check: check(
+      "auto_top_up_control_reconciliation_check",
+      sql`${table.legacy_reconciled_through} IS NULL OR ${table.legacy_reconciled_through} >= ${table.paused_at}`,
+    ),
+  }),
+);
+
+/** Reconciliation-only quarantine for PaymentIntents created by removed legacy code. */
+export const autoTopUpLegacyPaymentQuarantine = pgTable(
+  "auto_top_up_legacy_payment_quarantine",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organization_id: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    stripe_payment_intent_id: text("stripe_payment_intent_id").notNull(),
+    provider_status: text("provider_status").notNull(),
+    credit_amount_cents: bigint("credit_amount_cents", { mode: "number" }).notNull(),
+    status: text("status").$type<AutoTopUpLegacyQuarantineStatus>().notNull().default("unresolved"),
+    credit_transaction_id: uuid("credit_transaction_id").references(() => creditTransactions.id),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
+    discovered_at: timestamp("discovered_at", { withTimezone: true }).notNull().defaultNow(),
+    resolved_at: timestamp("resolved_at", { withTimezone: true }),
+    updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    payment_intent_idx: uniqueIndex("auto_top_up_legacy_quarantine_pi_idx").on(
+      table.stripe_payment_intent_id,
+    ),
+    org_status_idx: index("auto_top_up_legacy_quarantine_org_status_idx").on(
+      table.organization_id,
+      table.status,
+    ),
+    status_check: check(
+      "auto_top_up_legacy_quarantine_status_check",
+      sql`${table.status} IN ('unresolved','credited','canceled','manual_review')`,
+    ),
+    resolution_check: check(
+      "auto_top_up_legacy_quarantine_resolution_check",
+      sql`((${table.status} IN ('credited','canceled')) = (${table.resolved_at} IS NOT NULL)) AND ((${table.status} = 'credited') = (${table.credit_transaction_id} IS NOT NULL)) AND (${table.status} <> 'credited' OR ${table.provider_status} = 'succeeded') AND (${table.status} <> 'canceled' OR ${table.provider_status} = 'canceled')`,
+    ),
+    amount_check: check(
+      "auto_top_up_legacy_quarantine_amount_check",
+      sql`${table.credit_amount_cents} BETWEEN 100 AND 100000`,
+    ),
+  }),
+);
+
+export type AutoTopUpControlRow = InferSelectModel<typeof autoTopUpControl>;
+export type AutoTopUpLegacyPaymentQuarantineRow = InferSelectModel<
+  typeof autoTopUpLegacyPaymentQuarantine
+>;

--- a/packages/cloud/shared/src/db/schemas/index.ts
+++ b/packages/cloud/shared/src/db/schemas/index.ts
@@ -40,6 +40,7 @@ export * from "./app-reviews";
 export * from "./app-usage-projections";
 export * from "./apps";
 export * from "./auth-events";
+export * from "./auto-top-up-attempts";
 export * from "./cli-auth-sessions";
 export * from "./cloud-files";
 export * from "./containers";

--- a/packages/cloud/shared/src/db/schemas/organizations.ts
+++ b/packages/cloud/shared/src/db/schemas/organizations.ts
@@ -1,4 +1,6 @@
-// Defines the organizations Drizzle table shape used by cloud repositories and services.
+/**
+ * Defines the organizations Drizzle table shape used by cloud repositories and services.
+ */
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 import { sql } from "drizzle-orm";
 import {
@@ -46,6 +48,16 @@ export const organizations = pgTable(
     // is the per-organization initial revision; only mutations need a globally
     // monotonic sequence value.
     balance_revision: bigint("balance_revision", { mode: "number" }).notNull().default(0),
+    // Durable auto-top-up re-arms only after a balance decrease. Existing
+    // organizations are conservatively fenced during migration; newly created
+    // organizations start without a fence so their first eligible top-up can run.
+    balance_decrease_revision: bigint("balance_decrease_revision", { mode: "number" })
+      .notNull()
+      .default(0),
+    auto_top_up_covered_balance_decrease_revision: bigint(
+      "auto_top_up_covered_balance_decrease_revision",
+      { mode: "number" },
+    ),
 
     // Settings (kept for backward compatibility with container management)
     settings: jsonb("settings").$type<Record<string, unknown>>().default({}),

--- a/packages/cloud/shared/src/lib/api/cloud-worker-errors.test.ts
+++ b/packages/cloud/shared/src/lib/api/cloud-worker-errors.test.ts
@@ -1,20 +1,26 @@
-// Exercises cloud worker errors behavior with deterministic cloud-shared lib fixtures.
+/**
+ * Exercises canonical Worker error responses without external infrastructure.
+ */
 import { describe, expect, it } from "vitest";
 import { failureResponse } from "./cloud-worker-errors";
 
 function fakeContext() {
   return {
-    json(body: unknown, status: number) {
+    json(body: unknown, status: number, headers?: Record<string, string>) {
       return new Response(JSON.stringify(body), {
         status,
-        headers: { "content-type": "application/json" },
+        headers: { "content-type": "application/json", ...headers },
       });
     },
   } as unknown as import("hono").Context;
 }
 
-async function bodyOf(res: Response): Promise<{ error: string; code: string }> {
-  return (await res.json()) as { error: string; code: string };
+async function bodyOf(res: Response): Promise<{
+  success: false;
+  error: string;
+  code: string;
+}> {
+  return (await res.json()) as { success: false; error: string; code: string };
 }
 
 describe("failureResponse infrastructure-error sanitization", () => {
@@ -39,6 +45,58 @@ describe("failureResponse infrastructure-error sanitization", () => {
     expect(res.status).toBe(500);
     const body = await bodyOf(res);
     expect(body.error).toBe("An unexpected error occurred");
+  });
+
+  it("maps a nested cutover pause constraint to a sanitized retryable 503", async () => {
+    const databaseCause = Object.assign(new Error("raw lifecycle trigger detail"), {
+      code: "23503",
+      constraint: "auto_top_up_cutover_paused",
+    });
+    const error = new Error("Failed query: delete from organizations", {
+      cause: databaseCause,
+    });
+
+    const res = failureResponse(fakeContext(), error);
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("30");
+    expect(await bodyOf(res)).toEqual({
+      success: false,
+      error: "Service temporarily unavailable",
+      code: "service_unavailable",
+    });
+  });
+
+  it.each(["auto_top_up_unresolved_work", "organization_nonzero_credit_balance"])(
+    "maps the exact %s constraint to a sanitized lifecycle conflict",
+    async (constraint) => {
+      const error = Object.assign(new Error("private database lifecycle detail"), {
+        code: constraint === "organization_nonzero_credit_balance" ? "23514" : "23503",
+        constraint,
+      });
+
+      const res = failureResponse(fakeContext(), error);
+      expect(res.status).toBe(409);
+      expect(await bodyOf(res)).toEqual({
+        success: false,
+        error: "Organization cannot be removed while billing work or credit remains",
+        code: "billing_state_conflict",
+      });
+    },
+  );
+
+  it("does not classify an unrelated foreign-key violation", async () => {
+    const error = Object.assign(new Error("private foreign-key detail"), {
+      code: "23503",
+      constraint: "users_organization_id_organizations_id_fk",
+    });
+
+    const res = failureResponse(fakeContext(), error);
+    expect(res.status).toBe(500);
+    expect(await bodyOf(res)).toEqual({
+      success: false,
+      error: "An unexpected error occurred",
+      code: "internal_error",
+    });
   });
 
   it("still surfaces genuine 4xx domain messages", async () => {

--- a/packages/cloud/shared/src/lib/api/cloud-worker-errors.ts
+++ b/packages/cloud/shared/src/lib/api/cloud-worker-errors.ts
@@ -23,6 +23,7 @@ export type ApiErrorCode =
   | "agent_quota_exceeded"
   | "agent_image_not_allowed"
   | "agent_image_not_digest_pinned"
+  | "billing_state_conflict"
   | "service_unavailable"
   | "internal_error";
 
@@ -186,6 +187,46 @@ function inferStatusFromLegacyError(error: Error): number {
   return 500;
 }
 
+type AutoTopUpLifecycleGuardConstraint =
+  | "auto_top_up_cutover_paused"
+  | "auto_top_up_unresolved_work"
+  | "organization_nonzero_credit_balance";
+
+const AUTO_TOP_UP_LIFECYCLE_GUARD_CONSTRAINTS = new Set<AutoTopUpLifecycleGuardConstraint>([
+  "auto_top_up_cutover_paused",
+  "auto_top_up_unresolved_work",
+  "organization_nonzero_credit_balance",
+]);
+
+/**
+ * Drizzle wraps postgres.js errors, so the stable Postgres constraint can live
+ * on a nested cause. Only named lifecycle constraints are classified: SQLSTATE
+ * alone is intentionally insufficient because unrelated foreign-key failures
+ * must remain sanitized infrastructure errors.
+ */
+function findAutoTopUpLifecycleGuardConstraint(
+  error: unknown,
+): AutoTopUpLifecycleGuardConstraint | null {
+  const visited = new Set<object>();
+  let current = error;
+
+  while ((typeof current === "object" && current !== null) || typeof current === "function") {
+    if (visited.has(current)) return null;
+    visited.add(current);
+
+    const constraint = (current as { constraint?: unknown }).constraint;
+    if (
+      typeof constraint === "string" &&
+      AUTO_TOP_UP_LIFECYCLE_GUARD_CONSTRAINTS.has(constraint as AutoTopUpLifecycleGuardConstraint)
+    ) {
+      return constraint as AutoTopUpLifecycleGuardConstraint;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+
+  return null;
+}
+
 export function jsonError(
   c: Context,
   status: number,
@@ -228,6 +269,28 @@ export function failureResponse(c: Context, error: unknown): Response {
         code: inferCodeFromStatus(error.status),
       },
       error.status as 400,
+    );
+  }
+  const lifecycleConstraint = findAutoTopUpLifecycleGuardConstraint(error);
+  if (lifecycleConstraint === "auto_top_up_cutover_paused") {
+    return c.json(
+      {
+        success: false,
+        error: "Service temporarily unavailable",
+        code: "service_unavailable" as const,
+      },
+      503,
+      { "Retry-After": "30" },
+    );
+  }
+  if (lifecycleConstraint) {
+    return c.json(
+      {
+        success: false,
+        error: "Organization cannot be removed while billing work or credit remains",
+        code: "billing_state_conflict" as const,
+      },
+      409,
     );
   }
   const status = error instanceof Error ? inferStatusFromLegacyError(error) : 500;

--- a/packages/cloud/shared/src/lib/services/__tests__/auto-top-up.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/auto-top-up.test.ts
@@ -1,72 +1,31 @@
-// Exercises auto top up behavior with deterministic cloud-shared lib fixtures.
+/**
+ * Proves the cutover bridge cannot create charges before the durable processor ships.
+ */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-const selectMock = mock(() => ({
-  from: mock(() => ({
-    where: mock(async () => []),
-  })),
-}));
-
-mock.module("../../../db/client", () => ({
-  dbRead: {
-    select: selectMock,
-  },
-}));
-
-const updateOrganization = mock();
+const getControl = mock();
+const findBlockingByOrganization = mock();
+const findBlockingLegacyPaymentByOrganization = mock();
 const findOrganizationById = mock();
-const listByOrganization = mock();
+const updateOrganization = mock();
 
 mock.module("../../../db/repositories", () => ({
+  autoTopUpAttemptsRepository: {
+    getControl,
+    findBlockingByOrganization,
+    findBlockingLegacyPaymentByOrganization,
+  },
   organizationsRepository: {
-    update: updateOrganization,
     findById: findOrganizationById,
-  },
-  usersRepository: {
-    listByOrganization,
+    update: updateOrganization,
   },
 }));
 
-const createPaymentIntent = mock();
-const retrievePaymentMethod = mock();
-const requireStripe = mock(() => ({
-  paymentIntents: {
-    create: createPaymentIntent,
-  },
-  paymentMethods: {
-    retrieve: retrievePaymentMethod,
-  },
-}));
+const requireStripe = mock(() => {
+  throw new Error("Stripe must not be loaded by the sealed cutover bridge");
+});
 
-mock.module("../../stripe", () => ({
-  requireStripe,
-}));
-
-const addCredits = mock();
-
-mock.module("../credits", () => ({
-  creditsService: {
-    addCredits,
-  },
-}));
-
-const getReferrer = mock();
-
-mock.module("../affiliates", () => ({
-  affiliatesService: {
-    getReferrer,
-  },
-}));
-
-const sendAutoTopUpSuccessEmail = mock();
-const sendAutoTopUpDisabledEmail = mock();
-
-mock.module("../email", () => ({
-  emailService: {
-    sendAutoTopUpSuccessEmail,
-    sendAutoTopUpDisabledEmail,
-  },
-}));
+mock.module("../../stripe", () => ({ requireStripe }));
 
 mock.module("../../utils/logger", () => ({
   logger: {
@@ -77,7 +36,7 @@ mock.module("../../utils/logger", () => ({
   },
 }));
 
-const { AutoTopUpService, parseAutoTopUpNumber, CorruptAutoTopUpNumberError } = await import(
+const { AutoTopUpService, CorruptAutoTopUpNumberError, parseAutoTopUpNumber } = await import(
   "../auto-top-up"
 );
 
@@ -87,201 +46,387 @@ function makeOrganization(overrides: Partial<AutoTopUpOrganization> = {}): AutoT
   return {
     id: "org-1",
     name: "Acme Cloud",
-    credit_balance: "5.00",
-    auto_top_up_threshold: "10.00",
-    auto_top_up_amount: "10.00",
-    stripe_customer_id: "cus_123",
-    stripe_default_payment_method: "pm_123",
-    billing_email: "billing@example.com",
     auto_top_up_enabled: true,
+    auto_top_up_amount: "10.00",
+    auto_top_up_threshold: "5.00",
+    stripe_default_payment_method: "pm_123",
     ...overrides,
   } as AutoTopUpOrganization;
 }
 
 beforeEach(() => {
-  updateOrganization.mockReset();
+  getControl.mockReset();
+  getControl.mockResolvedValue({
+    mode: "paused",
+    pausedAt: new Date("2026-08-17T00:00:00.000Z"),
+    legacyReconciledThrough: null,
+  });
+  findBlockingByOrganization.mockReset();
+  findBlockingByOrganization.mockResolvedValue(null);
+  findBlockingLegacyPaymentByOrganization.mockReset();
+  findBlockingLegacyPaymentByOrganization.mockResolvedValue(null);
   findOrganizationById.mockReset();
-  listByOrganization.mockReset();
   findOrganizationById.mockResolvedValue(makeOrganization());
-  createPaymentIntent.mockReset();
-  retrievePaymentMethod.mockReset();
+  updateOrganization.mockReset();
+  updateOrganization.mockResolvedValue(makeOrganization());
   requireStripe.mockClear();
-  addCredits.mockReset();
-  getReferrer.mockReset();
-  sendAutoTopUpSuccessEmail.mockReset();
-  sendAutoTopUpDisabledEmail.mockReset();
-
-  listByOrganization.mockResolvedValue([{ id: "user-1", email: "billing@example.com" }]);
-  createPaymentIntent.mockResolvedValue({ id: "pi_auto_123", status: "succeeded" });
-  retrievePaymentMethod.mockResolvedValue({ card: { brand: "visa", last4: "4242" } });
-  addCredits.mockResolvedValue({ transaction: { id: "tx-1" }, newBalance: 42.25 });
-  getReferrer.mockResolvedValue(null);
-  sendAutoTopUpSuccessEmail.mockResolvedValue(true);
-  sendAutoTopUpDisabledEmail.mockResolvedValue(true);
 });
 
-describe("AutoTopUpService.executeAutoTopUp", () => {
-  test("persists successful auto top-up credits before returning success", async () => {
+describe("AutoTopUpService sealed cutover bridge", () => {
+  test("rejects a direct organization charge while control is paused", async () => {
     const result = await new AutoTopUpService().executeAutoTopUp(makeOrganization());
-
-    expect(createPaymentIntent).toHaveBeenCalledTimes(1);
-    expect(createPaymentIntent.mock.calls[0][0]).toEqual(
-      expect.objectContaining({
-        amount: 1000,
-        currency: "usd",
-        customer: "cus_123",
-        payment_method: "pm_123",
-        metadata: expect.objectContaining({
-          organization_id: "org-1",
-          credits: "10.00",
-          type: "auto_top_up",
-        }),
-      }),
-    );
-
-    expect(addCredits).toHaveBeenCalledTimes(1);
-    expect(addCredits).toHaveBeenCalledWith({
-      organizationId: "org-1",
-      amount: 10,
-      description: "Auto top-up - $10.00",
-      metadata: expect.objectContaining({
-        organization_id: "org-1",
-        credits: "10.00",
-        type: "auto_top_up",
-        payment_intent_id: "pi_auto_123",
-      }),
-      stripePaymentIntentId: "pi_auto_123",
-    });
 
     expect(result).toEqual({
       organizationId: "org-1",
-      success: true,
-      amount: 10,
-      newBalance: 42.25,
+      success: false,
+      status: "cutover_paused",
+      error: "Auto top-up charging is paused while the durable processor is rolled out",
     });
+    expect(requireStripe).not.toHaveBeenCalled();
+  });
+
+  test("stays sealed even if control is moved to durable before the processor binary ships", async () => {
+    getControl.mockResolvedValue({
+      mode: "durable",
+      pausedAt: new Date("2026-08-17T00:00:00.000Z"),
+      legacyReconciledThrough: new Date("2026-08-17T00:05:00.000Z"),
+    });
+
+    const result = await new AutoTopUpService().executeAutoTopUpForOrganization("org-2");
+
+    expect(result.status).toBe("cutover_paused");
+    expect(result.success).toBe(false);
+    expect(requireStripe).not.toHaveBeenCalled();
+  });
+
+  test("returns an explicit zero-work cron result", async () => {
+    const result = await new AutoTopUpService().checkAndExecuteAutoTopUps();
+
+    expect(result).toEqual({
+      timestamp: expect.any(Date),
+      cutoverPaused: true,
+      controlMode: "paused",
+      organizationsChecked: 0,
+      organizationsProcessed: 0,
+      successful: 0,
+      failed: 0,
+      results: [],
+    });
+    expect(requireStripe).not.toHaveBeenCalled();
+  });
+
+  test("fails closed when the database control authority is unavailable", async () => {
+    getControl.mockRejectedValue(new Error("control unavailable"));
+
+    await expect(new AutoTopUpService().executeAutoTopUpForOrganization("org-1")).rejects.toThrow(
+      "control unavailable",
+    );
+    expect(requireStripe).not.toHaveBeenCalled();
   });
 });
 
-describe("parseAutoTopUpNumber (fail-closed NUMERIC boundary)", () => {
+describe("parseAutoTopUpNumber", () => {
   test("parses finite numeric strings and numbers", () => {
     expect(parseAutoTopUpNumber("auto_top_up_amount", "10.00")).toBe(10);
     expect(parseAutoTopUpNumber("markup_percent", 5)).toBe(5);
     expect(parseAutoTopUpNumber("markup_percent", "0")).toBe(0);
-    expect(parseAutoTopUpNumber("markup_percent", 0)).toBe(0);
   });
 
-  test("throws on the corrupt 'NaN'::numeric read-back that slips past bare Number()", () => {
-    // Regression guard: bare Number("NaN") is NaN and NaN <= 0 / NaN > MAX are
-    // both false, so this exact value used to flow into a Stripe NaN charge.
-    expect(() => parseAutoTopUpNumber("auto_top_up_amount", "NaN")).toThrow(
-      CorruptAutoTopUpNumberError,
-    );
-    expect(Number("NaN")).toBeNaN();
-  });
-
-  test("throws on null/undefined/blank/non-numeric values", () => {
-    expect(() => parseAutoTopUpNumber("auto_top_up_amount", null)).toThrow(
-      CorruptAutoTopUpNumberError,
-    );
-    expect(() => parseAutoTopUpNumber("auto_top_up_amount", undefined)).toThrow(
-      CorruptAutoTopUpNumberError,
-    );
-    expect(() => parseAutoTopUpNumber("auto_top_up_amount", "   ")).toThrow(
-      CorruptAutoTopUpNumberError,
-    );
-    expect(() => parseAutoTopUpNumber("auto_top_up_amount", "abc")).toThrow(
-      CorruptAutoTopUpNumberError,
-    );
-    expect(() => parseAutoTopUpNumber("markup_percent", Number.POSITIVE_INFINITY)).toThrow(
-      CorruptAutoTopUpNumberError,
-    );
-  });
-});
-
-describe("AutoTopUpService.executeAutoTopUp fail-closed money gates", () => {
-  test("corrupt auto_top_up_amount ('NaN') disables + fails instead of charging NaN", async () => {
-    const org = makeOrganization({ auto_top_up_amount: "NaN" });
-
-    const result = await new AutoTopUpService().executeAutoTopUp(org);
-
-    // The corrupt amount must NEVER reach Stripe as Math.round(NaN * 100).
-    expect(createPaymentIntent).not.toHaveBeenCalled();
-    expect(addCredits).not.toHaveBeenCalled();
-    // Same fail-closed path as an out-of-range invalid amount: disable + fail.
-    expect(updateOrganization).toHaveBeenCalledWith(
-      "org-1",
-      expect.objectContaining({ auto_top_up_enabled: false }),
-    );
-    expect(result).toEqual(
-      expect.objectContaining({
-        organizationId: "org-1",
-        success: false,
-        error: "Invalid top-up amount",
-      }),
-    );
-  });
-
-  test("corrupt affiliate markup_percent charges the base amount (no NaN total), no surcharge", async () => {
-    getReferrer.mockResolvedValue({
-      user_id: "affiliate-owner",
-      id: "code-1",
-      markup_percent: "NaN",
-    });
-
-    const result = await new AutoTopUpService().executeAutoTopUp(makeOrganization());
-
-    expect(createPaymentIntent).toHaveBeenCalledTimes(1);
-    const chargedAmount = createPaymentIntent.mock.calls[0][0].amount;
-    // Base $10.00 charged as 1000 cents, NOT Math.round(NaN * 100) = NaN.
-    expect(chargedAmount).toBe(1000);
-    expect(Number.isNaN(chargedAmount)).toBe(false);
-    // Surcharge dropped: no affiliate fee metadata on a corrupt markup.
-    const metadata = createPaymentIntent.mock.calls[0][0].metadata;
-    expect(metadata.affiliate_fee_amount).toBeUndefined();
-    expect(metadata.affiliate_owner_id).toBeUndefined();
-    expect(metadata.total_charged).toBe("10.00");
-    // Customer's top-up still succeeds (best-effort surcharge, fail-safe).
-    expect(addCredits).toHaveBeenCalledTimes(1);
-    expect(result).toEqual(
-      expect.objectContaining({ organizationId: "org-1", success: true, amount: 10 }),
-    );
-  });
-
-  test("valid affiliate markup still applies the surcharge (no behavior change)", async () => {
-    getReferrer.mockResolvedValue({
-      user_id: "affiliate-owner",
-      id: "code-1",
-      markup_percent: "10",
-    });
-
-    await new AutoTopUpService().executeAutoTopUp(makeOrganization());
-
-    expect(createPaymentIntent).toHaveBeenCalledTimes(1);
-    // $10 base + 10% affiliate ($1) + 20% platform ($2) = $13.00 -> 1300 cents.
-    expect(createPaymentIntent.mock.calls[0][0].amount).toBe(1300);
-    const metadata = createPaymentIntent.mock.calls[0][0].metadata;
-    expect(metadata.affiliate_fee_amount).toBe("1.00");
-    expect(metadata.affiliate_owner_id).toBe("affiliate-owner");
-    expect(metadata.total_charged).toBe("13.00");
+  test("rejects missing, blank, non-numeric, and non-finite values", () => {
+    for (const value of [null, undefined, "", "   ", "abc", Number.POSITIVE_INFINITY]) {
+      expect(() => parseAutoTopUpNumber("auto_top_up_amount", value)).toThrow(
+        CorruptAutoTopUpNumberError,
+      );
+    }
   });
 });
 
 describe("AutoTopUpService.validateSettings", () => {
-  const svc = new AutoTopUpService();
-  test("accepts in-range values incl. boundaries", () => {
-    expect(() => svc.validateSettings(1, 0)).not.toThrow();
-    expect(() => svc.validateSettings(1000, 1000)).not.toThrow();
+  const service = new AutoTopUpService();
+
+  test("accepts boundary values", () => {
+    expect(() => service.validateSettings(1, 0)).not.toThrow();
+    expect(() => service.validateSettings(1000, 1000)).not.toThrow();
   });
-  test("rejects amount below $1", () => {
-    expect(() => svc.validateSettings(0.5, 5)).toThrow(/at least \$1/);
+
+  test("rejects invalid and non-finite settings", () => {
+    expect(() => service.validateSettings(0, 5)).toThrow("at least $1");
+    expect(() => service.validateSettings(1001, 5)).toThrow("cannot exceed $1000");
+    expect(() => service.validateSettings(10, -1)).toThrow("threshold must be at least $0");
+    expect(() => service.validateSettings(10, 1001)).toThrow("threshold cannot exceed $1000");
+    expect(() => service.validateSettings(Number.NaN, 5)).toThrow("must be valid numbers");
   });
-  test("rejects amount above $1000", () => {
-    expect(() => svc.validateSettings(1001, 5)).toThrow(/cannot exceed \$1000/);
+});
+
+describe("AutoTopUpService settings compatibility", () => {
+  test("reads the existing billing settings without unsealing charging", async () => {
+    const result = await new AutoTopUpService().getSettings("org-1");
+
+    expect(result).toEqual({
+      enabled: true,
+      amount: 10,
+      threshold: 5,
+      hasPaymentMethod: true,
+    });
+    expect(requireStripe).not.toHaveBeenCalled();
   });
-  test("rejects negative threshold", () => {
-    expect(() => svc.validateSettings(10, -1)).toThrow(/threshold must be at least/);
+
+  test("preserves zero defaults for normally unconfigured settings", async () => {
+    findOrganizationById.mockResolvedValueOnce(
+      makeOrganization({
+        auto_top_up_enabled: false,
+        auto_top_up_amount: null,
+        auto_top_up_threshold: null,
+      }),
+    );
+
+    await expect(new AutoTopUpService().getSettings("org-1")).resolves.toEqual({
+      enabled: false,
+      amount: 0,
+      threshold: 0,
+      hasPaymentMethod: true,
+    });
   });
-  test("rejects threshold above $1000", () => {
-    expect(() => svc.validateSettings(10, 1001)).toThrow(/threshold cannot exceed/);
+
+  test("reports genuinely corrupt disabled settings as null without fabricating values", async () => {
+    findOrganizationById.mockResolvedValueOnce(
+      makeOrganization({
+        auto_top_up_enabled: false,
+        auto_top_up_amount: "NaN",
+        auto_top_up_threshold: "not-a-number",
+      }),
+    );
+
+    await expect(new AutoTopUpService().getSettings("org-1")).resolves.toEqual({
+      enabled: false,
+      amount: null,
+      threshold: null,
+      hasPaymentMethod: true,
+    });
+  });
+
+  test("persists validated decimal settings", async () => {
+    await new AutoTopUpService().updateSettings("org-1", {
+      enabled: true,
+      amount: 25,
+      threshold: 10,
+    });
+
+    expect(updateOrganization).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({
+        auto_top_up_enabled: true,
+        auto_top_up_amount: "25.00",
+        auto_top_up_threshold: "10.00",
+        updated_at: expect.any(Date),
+      }),
+    );
+    expect(requireStripe).not.toHaveBeenCalled();
+  });
+
+  test("rejects enabling without a payment method", async () => {
+    findOrganizationById.mockResolvedValueOnce(
+      makeOrganization({ stripe_default_payment_method: null }),
+    );
+
+    await expect(new AutoTopUpService().updateSettings("org-1", { enabled: true })).rejects.toThrow(
+      "Cannot enable auto top-up without a default payment method",
+    );
+    expect(updateOrganization).not.toHaveBeenCalled();
+  });
+
+  test("rejects re-enabling while an earlier provider payment requires reconciliation", async () => {
+    findBlockingLegacyPaymentByOrganization.mockResolvedValueOnce({
+      id: "legacy-review-1",
+      status: "manual_review",
+    });
+
+    await expect(new AutoTopUpService().updateSettings("org-1", { enabled: true })).rejects.toThrow(
+      "Cannot enable auto top-up while an earlier card payment requires reconciliation",
+    );
+    expect(updateOrganization).not.toHaveBeenCalled();
+  });
+
+  test("rejects re-enabling while a durable attempt requires manual review", async () => {
+    findBlockingByOrganization.mockResolvedValueOnce({
+      id: "durable-review-1",
+      status: "manual_review",
+    });
+
+    await expect(new AutoTopUpService().updateSettings("org-1", { enabled: true })).rejects.toThrow(
+      "Cannot enable auto top-up while an earlier card payment requires reconciliation",
+    );
+    expect(updateOrganization).not.toHaveBeenCalled();
+  });
+
+  test("requires an explicit value for every corrupt setting when enabling", async () => {
+    findOrganizationById.mockResolvedValueOnce(
+      makeOrganization({
+        auto_top_up_enabled: false,
+        auto_top_up_amount: "NaN",
+        auto_top_up_threshold: "not-a-number",
+      }),
+    );
+
+    await expect(
+      new AutoTopUpService().updateSettings("org-1", { enabled: true, amount: 25 }),
+    ).rejects.toThrow("Valid auto top-up values are required to replace corrupt settings");
+    expect(updateOrganization).not.toHaveBeenCalled();
+  });
+
+  test("repairs only a corrupt amount while reusing a valid persisted threshold", async () => {
+    findOrganizationById.mockResolvedValueOnce(
+      makeOrganization({
+        auto_top_up_enabled: false,
+        auto_top_up_amount: "NaN",
+        auto_top_up_threshold: "8.00",
+      }),
+    );
+
+    await new AutoTopUpService().updateSettings("org-1", {
+      enabled: true,
+      amount: 25,
+    });
+
+    expect(updateOrganization).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({
+        auto_top_up_enabled: true,
+        auto_top_up_amount: "25.00",
+      }),
+    );
+    expect(updateOrganization.mock.calls[0]?.[1]).not.toHaveProperty("auto_top_up_threshold");
+  });
+
+  test("repairs only a corrupt threshold while reusing a valid persisted amount", async () => {
+    findOrganizationById.mockResolvedValueOnce(
+      makeOrganization({
+        auto_top_up_enabled: false,
+        auto_top_up_amount: "25.00",
+        auto_top_up_threshold: "not-a-number",
+      }),
+    );
+
+    await new AutoTopUpService().updateSettings("org-1", {
+      enabled: true,
+      threshold: 8,
+    });
+
+    expect(updateOrganization).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({
+        auto_top_up_enabled: true,
+        auto_top_up_threshold: "8.00",
+      }),
+    );
+    expect(updateOrganization.mock.calls[0]?.[1]).not.toHaveProperty("auto_top_up_amount");
+  });
+
+  test("repairs corrupt settings when enabling with explicit valid values", async () => {
+    findOrganizationById.mockResolvedValueOnce(
+      makeOrganization({
+        auto_top_up_enabled: false,
+        auto_top_up_amount: "NaN",
+        auto_top_up_threshold: "not-a-number",
+      }),
+    );
+
+    await new AutoTopUpService().updateSettings("org-1", {
+      enabled: true,
+      amount: 25,
+      threshold: 10,
+    });
+
+    expect(updateOrganization).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({
+        auto_top_up_enabled: true,
+        auto_top_up_amount: "25.00",
+        auto_top_up_threshold: "10.00",
+      }),
+    );
+  });
+
+  test("rejects enabling normally unconfigured settings through safe range validation", async () => {
+    findOrganizationById.mockResolvedValueOnce(
+      makeOrganization({
+        auto_top_up_enabled: false,
+        auto_top_up_amount: null,
+        auto_top_up_threshold: null,
+      }),
+    );
+
+    await expect(new AutoTopUpService().updateSettings("org-1", { enabled: true })).rejects.toThrow(
+      "Auto top-up amount must be at least $1",
+    );
+    expect(updateOrganization).not.toHaveBeenCalled();
+  });
+
+  test("persists the legacy zero threshold when enabling from SQL NULL", async () => {
+    findOrganizationById.mockResolvedValueOnce(
+      makeOrganization({
+        auto_top_up_enabled: false,
+        auto_top_up_amount: "10.00",
+        auto_top_up_threshold: null,
+      }),
+    );
+
+    await new AutoTopUpService().updateSettings("org-1", { enabled: true });
+
+    expect(updateOrganization).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({
+        auto_top_up_enabled: true,
+        auto_top_up_threshold: "0.00",
+      }),
+    );
+  });
+
+  test("uses the legacy zero fallback for a partial update on unconfigured settings", async () => {
+    findOrganizationById.mockResolvedValueOnce(
+      makeOrganization({
+        auto_top_up_enabled: false,
+        auto_top_up_amount: null,
+        auto_top_up_threshold: null,
+      }),
+    );
+
+    await new AutoTopUpService().updateSettings("org-1", { amount: 10 });
+
+    expect(updateOrganization).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({ auto_top_up_amount: "10.00" }),
+    );
+  });
+
+  test("rejects a partial update whose missing counterpart is corrupt", async () => {
+    findOrganizationById.mockResolvedValueOnce(
+      makeOrganization({
+        auto_top_up_enabled: false,
+        auto_top_up_amount: "10.00",
+        auto_top_up_threshold: "not-a-number",
+      }),
+    );
+
+    await expect(new AutoTopUpService().updateSettings("org-1", { amount: 25 })).rejects.toThrow(
+      "Valid auto top-up values are required to replace corrupt settings",
+    );
+    expect(updateOrganization).not.toHaveBeenCalled();
+  });
+
+  test("allows fail-closed disable even when persisted amount fields are corrupt", async () => {
+    findOrganizationById.mockResolvedValueOnce(
+      makeOrganization({
+        auto_top_up_amount: "NaN",
+        auto_top_up_threshold: "not-a-number",
+      }),
+    );
+
+    await new AutoTopUpService().updateSettings("org-1", { enabled: false });
+
+    expect(updateOrganization).toHaveBeenCalledWith(
+      "org-1",
+      expect.objectContaining({ auto_top_up_enabled: false }),
+    );
   });
 });

--- a/packages/cloud/shared/src/lib/services/__tests__/credits-deduct-guard.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-deduct-guard.test.ts
@@ -101,6 +101,8 @@ beforeAll(async () => {
         slug text NOT NULL,
         credit_balance numeric(12,6) NOT NULL DEFAULT '0',
         balance_revision bigint NOT NULL DEFAULT 0,
+        balance_decrease_revision bigint NOT NULL DEFAULT 0,
+        auto_top_up_covered_balance_decrease_revision bigint,
         settings jsonb DEFAULT '{}',
         stripe_customer_id text,
         billing_email text,

--- a/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-reconcile.test.ts
@@ -206,6 +206,8 @@ beforeAll(async () => {
         slug text NOT NULL DEFAULT 'test-org',
         credit_balance numeric(20,6) NOT NULL DEFAULT '0' CHECK (credit_balance >= 0),
         balance_revision bigint NOT NULL DEFAULT 0,
+        balance_decrease_revision bigint NOT NULL DEFAULT 0,
+        auto_top_up_covered_balance_decrease_revision bigint,
         settings jsonb DEFAULT '{}',
         stripe_customer_id text,
         billing_email text,

--- a/packages/cloud/shared/src/lib/services/__tests__/crypto-payments-topup-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/crypto-payments-topup-idempotency.test.ts
@@ -116,6 +116,8 @@ beforeAll(async () => {
         slug text NOT NULL DEFAULT 'test-org',
         credit_balance numeric(12,6) NOT NULL DEFAULT '0',
         balance_revision bigint NOT NULL DEFAULT 0,
+        balance_decrease_revision bigint NOT NULL DEFAULT 0,
+        auto_top_up_covered_balance_decrease_revision bigint,
         settings jsonb DEFAULT '{}',
         stripe_customer_id text,
         billing_email text,

--- a/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-confirm-atomic.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/direct-wallet-confirm-atomic.test.ts
@@ -180,6 +180,8 @@ beforeAll(async () => {
         slug text NOT NULL DEFAULT 'test-org',
         credit_balance numeric(12,6) NOT NULL DEFAULT '0',
         balance_revision bigint NOT NULL DEFAULT 0,
+        balance_decrease_revision bigint NOT NULL DEFAULT 0,
+        auto_top_up_covered_balance_decrease_revision bigint,
         settings jsonb DEFAULT '{}',
         stripe_customer_id text,
         billing_email text,

--- a/packages/cloud/shared/src/lib/services/__tests__/domain-maintenance.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/domain-maintenance.test.ts
@@ -131,7 +131,7 @@ beforeAll(async () => {
       `CREATE TABLE IF NOT EXISTS organizations (
         id uuid PRIMARY KEY, name text NOT NULL, slug text NOT NULL,
         credit_balance numeric(12,6) NOT NULL DEFAULT '0',
-        balance_revision bigint NOT NULL DEFAULT 0, settings jsonb DEFAULT '{}',
+        balance_revision bigint NOT NULL DEFAULT 0, balance_decrease_revision bigint NOT NULL DEFAULT 0, auto_top_up_covered_balance_decrease_revision bigint, settings jsonb DEFAULT '{}',
         stripe_customer_id text, billing_email text, stripe_payment_method_id text,
         stripe_default_payment_method text, auto_top_up_enabled boolean DEFAULT false,
         auto_top_up_threshold numeric(10,2), auto_top_up_amount numeric(10,2),

--- a/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/inference-billing-ledger.test.ts
@@ -146,6 +146,8 @@ beforeAll(async () => {
         slug text NOT NULL,
         credit_balance numeric(12,6) NOT NULL DEFAULT '0' CHECK (credit_balance >= 0),
         balance_revision bigint NOT NULL DEFAULT 0,
+        balance_decrease_revision bigint NOT NULL DEFAULT 0,
+        auto_top_up_covered_balance_decrease_revision bigint,
         settings jsonb DEFAULT '{}',
         stripe_customer_id text,
         billing_email text,

--- a/packages/cloud/shared/src/lib/services/__tests__/meeting-billing.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/meeting-billing.test.ts
@@ -87,6 +87,8 @@ beforeAll(async () => {
       slug text NOT NULL DEFAULT 'test-org',
       credit_balance numeric(20,6) NOT NULL DEFAULT '0' CHECK (credit_balance >= 0),
       balance_revision bigint NOT NULL DEFAULT 0,
+      balance_decrease_revision bigint NOT NULL DEFAULT 0,
+      auto_top_up_covered_balance_decrease_revision bigint,
       settings jsonb DEFAULT '{}',
       stripe_customer_id text,
       billing_email text,

--- a/packages/cloud/shared/src/lib/services/__tests__/tier-upgrade-pglite-schema.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/tier-upgrade-pglite-schema.ts
@@ -14,6 +14,8 @@ export const PROVISIONING_JOB_TEST_TABLES: readonly string[] = [
   "slug" text NOT NULL,
   "credit_balance" numeric(12,6) NOT NULL DEFAULT 0.000000,
   "balance_revision" bigint NOT NULL DEFAULT 0,
+  "balance_decrease_revision" bigint NOT NULL DEFAULT 0,
+  "auto_top_up_covered_balance_decrease_revision" bigint,
   "settings" jsonb DEFAULT '{}'::jsonb,
   "stripe_customer_id" text,
   "billing_email" text,

--- a/packages/cloud/shared/src/lib/services/__tests__/video-generation-reconcile.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/video-generation-reconcile.test.ts
@@ -163,6 +163,8 @@ beforeAll(async () => {
         slug text NOT NULL DEFAULT 'test-org',
         credit_balance numeric(20,6) NOT NULL DEFAULT '0' CHECK (credit_balance >= 0),
         balance_revision bigint NOT NULL DEFAULT 0,
+        balance_decrease_revision bigint NOT NULL DEFAULT 0,
+        auto_top_up_covered_balance_decrease_revision bigint,
         settings jsonb DEFAULT '{}',
         stripe_customer_id text,
         billing_email text,

--- a/packages/cloud/shared/src/lib/services/auto-top-up.ts
+++ b/packages/cloud/shared/src/lib/services/auto-top-up.ts
@@ -1,12 +1,9 @@
-// Coordinates cloud service auto top up behavior behind route handlers.
-import { and, eq, sql } from "drizzle-orm";
-import { dbRead } from "../../db/client";
+/**
+ * Seals legacy auto-top-up charging while the durable processor is rolled out.
+ */
 import type { Organization } from "../../db/repositories";
-import { organizationsRepository, usersRepository } from "../../db/repositories";
-import { organizations } from "../../db/schemas/organizations";
-import { requireStripe } from "../stripe";
+import { autoTopUpAttemptsRepository, organizationsRepository } from "../../db/repositories";
 import { logger } from "../utils/logger";
-import { emailService } from "./email";
 
 export const AUTO_TOP_UP_LIMITS = {
   MIN_AMOUNT: 1,
@@ -17,9 +14,7 @@ export const AUTO_TOP_UP_LIMITS = {
 
 /**
  * Thrown when an auto-top-up money-gate field read from a NUMERIC column
- * cannot be coerced to a finite number. A corrupt persisted value must fail
- * closed (no charge, no fabricated success) rather than flow a `NaN` into the
- * charged Stripe amount or the affiliate/total markup math.
+ * cannot be coerced to a finite number. Persisted corruption must fail closed.
  */
 export class CorruptAutoTopUpNumberError extends Error {
   constructor(
@@ -31,19 +26,14 @@ export class CorruptAutoTopUpNumberError extends Error {
   }
 }
 
-/**
- * Fail-closed boundary for auto-top-up NUMERIC reads. Postgres NUMERIC values
- * arrive as strings at the driver, and `'NaN'::numeric` is a VALID stored value
- * that reads back as the string `"NaN"` — `Number("NaN")` is `NaN`, and every
- * `NaN <= 0` / `NaN > MAX` comparison is `false`, so a bare `Number(...)` read
- * silently slips a corrupt amount PAST the invalid-amount guard and into a
- * Stripe `paymentIntents.create({ amount: Math.round(NaN * 100) })` charge (or
- * a `NaN` total via corrupt affiliate `markup_percent`).
- *
- * Throws {@link CorruptAutoTopUpNumberError} on a missing/blank/non-finite
- * value so the caller aborts before charging. An explicit domain value of `0`
- * is allowed (a legitimately zero markup/threshold is not corruption).
- */
+/** Safe domain error for settings input that must be repaired explicitly. */
+export class AutoTopUpSettingsValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AutoTopUpSettingsValidationError";
+  }
+}
+
 export function parseAutoTopUpNumber(field: string, raw: unknown): number {
   if (raw === null || raw === undefined) {
     throw new CorruptAutoTopUpNumberError(field, raw);
@@ -58,25 +48,52 @@ export function parseAutoTopUpNumber(field: string, raw: unknown): number {
   return value;
 }
 
+function parseAutoTopUpNumberForSettingsRead(field: string, raw: unknown): number | null {
+  // SQL NULL is the established unconfigured state exposed as 0 by this API.
+  // Non-null malformed values are different: surface them honestly as null so
+  // callers cannot mistake corruption for a configured monetary value.
+  if (raw === null || raw === undefined) return 0;
+  try {
+    return parseAutoTopUpNumber(field, raw);
+  } catch (error) {
+    if (error instanceof CorruptAutoTopUpNumberError) return null;
+    throw error;
+  }
+}
+
 export interface AutoTopUpResult {
   organizationId: string;
-  success: boolean;
-  amount?: number;
-  newBalance?: number;
-  error?: string;
+  success: false;
+  status: "cutover_paused";
+  error: string;
 }
 
 export interface AutoTopUpCheckResult {
   timestamp: Date;
-  organizationsChecked: number;
-  organizationsProcessed: number;
-  successful: number;
-  failed: number;
-  results: AutoTopUpResult[];
+  cutoverPaused: true;
+  controlMode: "paused" | "durable";
+  organizationsChecked: 0;
+  organizationsProcessed: 0;
+  successful: 0;
+  failed: 0;
+  results: [];
 }
 
+const CUTOVER_PAUSED_MESSAGE =
+  "Auto top-up charging is paused while the durable processor is rolled out";
+
+/**
+ * This release is deliberately unable to create a Stripe PaymentIntent.
+ *
+ * The database control row is still read so an unavailable authority fails
+ * closed. Even when the row is moved to `durable`, this bridge binary remains
+ * sealed: only the follow-up durable-processor release may start charging.
+ */
 export class AutoTopUpService {
   validateSettings(amount: number, threshold: number): void {
+    if (!Number.isFinite(amount) || !Number.isFinite(threshold)) {
+      throw new Error("Auto top-up settings must be valid numbers");
+    }
     if (amount < AUTO_TOP_UP_LIMITS.MIN_AMOUNT) {
       throw new Error(`Auto top-up amount must be at least $${AUTO_TOP_UP_LIMITS.MIN_AMOUNT}`);
     }
@@ -91,411 +108,67 @@ export class AutoTopUpService {
     if (threshold > AUTO_TOP_UP_LIMITS.MAX_THRESHOLD) {
       throw new Error(`Auto top-up threshold cannot exceed $${AUTO_TOP_UP_LIMITS.MAX_THRESHOLD}`);
     }
-    if (!Number.isFinite(amount) || !Number.isFinite(threshold)) {
-      throw new Error("Auto top-up settings must be valid numbers");
-    }
   }
 
   async checkAndExecuteAutoTopUps(): Promise<AutoTopUpCheckResult> {
-    const startTime = new Date();
-    const results: AutoTopUpResult[] = [];
-
-    logger.info(`[AutoTopUp] Starting auto top-up check at ${startTime.toISOString()}`);
-
-    const orgsNeedingTopUp = await dbRead
-      .select()
-      .from(organizations)
-      .where(
-        and(
-          eq(organizations.auto_top_up_enabled, true),
-          sql`CAST(${organizations.credit_balance} AS NUMERIC) < CAST(${organizations.auto_top_up_threshold} AS NUMERIC)`,
-        ),
-      );
-
-    logger.info(`[AutoTopUp] Found ${orgsNeedingTopUp.length} organizations needing auto top-up`);
-
-    const settledResults = await Promise.allSettled(
-      orgsNeedingTopUp.map((org) => this.executeAutoTopUp(org)),
-    );
-
-    for (const settled of settledResults) {
-      if (settled.status === "fulfilled") {
-        results.push(settled.value);
-      } else {
-        logger.error(`[AutoTopUp] Unexpected error:`, settled.reason);
-        results.push({
-          organizationId: "unknown",
-          success: false,
-          error: settled.reason instanceof Error ? settled.reason.message : String(settled.reason),
-        });
-      }
-    }
-
-    const successful = results.filter((r) => r.success).length;
-    const failed = results.filter((r) => !r.success).length;
-
-    logger.info(
-      `[AutoTopUp] Completed check. Processed: ${results.length}, Successful: ${successful}, Failed: ${failed}`,
-    );
+    const control = await autoTopUpAttemptsRepository.getControl();
+    logger.warn("[AutoTopUp] Charging sweep sealed during durable cutover", {
+      controlMode: control.mode,
+    });
 
     return {
-      timestamp: startTime,
-      organizationsChecked: orgsNeedingTopUp.length,
-      organizationsProcessed: results.length,
-      successful,
-      failed,
-      results,
+      timestamp: new Date(),
+      cutoverPaused: true,
+      controlMode: control.mode,
+      organizationsChecked: 0,
+      organizationsProcessed: 0,
+      successful: 0,
+      failed: 0,
+      results: [],
     };
   }
 
   async executeAutoTopUp(org: Organization): Promise<AutoTopUpResult> {
-    const organizationId = org.id;
-
-    logger.info(`[AutoTopUp] Processing org ${organizationId} (${org.name})`);
-    logger.info(
-      `[AutoTopUp] Current balance: $${org.credit_balance}, Threshold: $${org.auto_top_up_threshold}`,
-    );
-
-    let trackingId = `org:${organizationId}`;
-    try {
-      const users = await usersRepository.listByOrganization(organizationId);
-      const billingUser = org.billing_email
-        ? users.find((u) => u.email === org.billing_email)
-        : null;
-      const userId = billingUser?.id || (users.length > 0 ? users[0].id : null);
-      trackingId = userId || `org:${organizationId}`;
-    } catch (userLookupError) {
-      logger.warn(`[AutoTopUp] Failed to fetch users for payment metadata, using org ID`, {
-        organizationId,
-        error: userLookupError instanceof Error ? userLookupError.message : "Unknown error",
-      });
-    }
-
-    if (!org.stripe_customer_id) {
-      logger.error(`[AutoTopUp] Org ${organizationId} missing Stripe customer`);
-      await this.disableAutoTopUp(organizationId, "Missing Stripe customer");
-      return {
-        organizationId,
-        success: false,
-        error: "Missing Stripe customer",
-      };
-    }
-
-    if (!org.stripe_default_payment_method) {
-      logger.error(`[AutoTopUp] Org ${organizationId} missing default payment method`);
-      await this.disableAutoTopUp(organizationId, "Missing default payment method");
-      return {
-        organizationId,
-        success: false,
-        error: "Missing default payment method",
-      };
-    }
-
-    // Fail-closed read: a corrupt/non-finite persisted auto_top_up_amount (e.g.
-    // 'NaN'::numeric) would coerce to NaN and PASS both `<= 0` and `> MAX`
-    // guards below, then flow into Stripe as amount: Math.round(NaN * 100).
-    // Treat a corrupt amount exactly like an invalid amount: disable + fail,
-    // never charge.
-    let amount: number;
-    try {
-      amount = parseAutoTopUpNumber("auto_top_up_amount", org.auto_top_up_amount ?? 0);
-    } catch (parseError) {
-      logger.error(
-        `[AutoTopUp] Org ${organizationId} has a corrupt top-up amount`,
-        parseError instanceof Error ? { error: parseError.message } : { error: String(parseError) },
-      );
-      await this.disableAutoTopUp(organizationId, "Invalid top-up amount");
-      return {
-        organizationId,
-        success: false,
-        error: "Invalid top-up amount",
-      };
-    }
-    if (amount <= 0 || amount > AUTO_TOP_UP_LIMITS.MAX_AMOUNT) {
-      logger.error(`[AutoTopUp] Org ${organizationId} has invalid top-up amount: ${amount}`);
-      await this.disableAutoTopUp(organizationId, "Invalid top-up amount");
-      return {
-        organizationId,
-        success: false,
-        error: "Invalid top-up amount",
-      };
-    }
-
-    // WHY affiliate lookup here: Affiliate markup is added to what the customer pays
-    // (we don't eat it). So totalAmount = amount + affiliate% + platform%; credits
-    // added = amount. Revenue splits are not run for auto top-up (see Stripe webhook).
-    let affiliateFeeAmount = 0;
-    let platformFeeAmount = 0;
-    let affiliateOwnerId: string | null = null;
-    let affiliateCodeId: string | null = null;
-    let totalAmount: number;
-
-    try {
-      const { affiliatesService } = await import("./affiliates");
-      let checkUserId = trackingId.startsWith("org:") ? null : trackingId;
-
-      if (!checkUserId) {
-        const users = await usersRepository.listByOrganization(organizationId);
-        if (users.length > 0) checkUserId = users[0].id;
-      }
-
-      if (checkUserId) {
-        const referrer = await affiliatesService.getReferrer(checkUserId);
-        if (referrer) {
-          // Fail-closed read: a corrupt markup_percent ('NaN'::numeric) would
-          // make affiliateFeeAmount = amount * (NaN / 100) = NaN, poisoning
-          // totalAmount into Math.round(NaN * 100) = NaN. Never charge NaN.
-          let affiliatePercent: number;
-          try {
-            affiliatePercent = parseAutoTopUpNumber("markup_percent", referrer.markup_percent);
-          } catch (markupError) {
-            // A corrupt affiliate surcharge must NOT deny the customer's top-up
-            // and must NOT fabricate a NaN charge: drop the affiliate
-            // attribution + surcharge and proceed to bill the base amount.
-            logger.error(
-              `[AutoTopUp] Corrupt affiliate markup_percent for org ${organizationId}; charging base amount without surcharge`,
-              markupError instanceof Error
-                ? { error: markupError.message }
-                : { error: String(markupError) },
-            );
-            affiliateOwnerId = null;
-            affiliateCodeId = null;
-            affiliateFeeAmount = 0;
-            platformFeeAmount = 0;
-            affiliatePercent = Number.NaN; // sentinel: skip surcharge below
-          }
-
-          if (Number.isFinite(affiliatePercent)) {
-            affiliateOwnerId = referrer.user_id;
-            affiliateCodeId = referrer.id;
-            const platformPercent = 20.0;
-
-            affiliateFeeAmount = amount * (affiliatePercent / 100);
-            platformFeeAmount = amount * (platformPercent / 100);
-            logger.info("Affiliate metadata applied", referrer);
-          }
-        }
-      }
-    } catch (e) {
-      // Affiliate lookup/markup is a best-effort surcharge; on any failure we
-      // charge the base amount (surcharge fields reset to 0 above) rather than
-      // abort the top-up or bill a fabricated total.
-      logger.error(`[AutoTopUp] Failed to lookup affiliate for org ${organizationId}`, e);
-    }
-
-    totalAmount = amount + affiliateFeeAmount + platformFeeAmount;
-
-    const metadata: Record<string, string> = {
-      organization_id: organizationId,
-      credits: amount.toFixed(2),
-      type: "auto_top_up",
-      base_amount: amount.toFixed(2),
-      total_charged: totalAmount.toFixed(2),
-      platform_fee_amount: platformFeeAmount.toFixed(2),
-      fees_included: "true",
-    };
-
-    if (!trackingId.startsWith("org:")) {
-      metadata.user_id = trackingId;
-    }
-
-    if (affiliateFeeAmount > 0 && affiliateOwnerId && affiliateCodeId) {
-      metadata.affiliate_fee_amount = affiliateFeeAmount.toFixed(2);
-      metadata.affiliate_owner_id = affiliateOwnerId;
-      metadata.affiliate_code_id = affiliateCodeId;
-    }
-
-    logger.info(
-      `[AutoTopUp] Creating PaymentIntent for $${totalAmount.toFixed(
-        2,
-      )} (Base: $${amount.toFixed(2)})`,
-    );
-
-    const IDEMPOTENCY_WINDOW_MS = 5 * 60 * 1000;
-    const idempotencyKey = `auto-topup-${organizationId}-${Math.floor(
-      Date.now() / IDEMPOTENCY_WINDOW_MS,
-    )}`;
-
-    const paymentIntent = await requireStripe().paymentIntents.create(
-      {
-        amount: Math.round(totalAmount * 100),
-        currency: "usd",
-        customer: org.stripe_customer_id,
-        payment_method: org.stripe_default_payment_method,
-        confirm: true,
-        off_session: true,
-        metadata: metadata,
-        description: `Auto top-up - $${totalAmount.toFixed(2)}`,
-      },
-      { idempotencyKey },
-    );
-
-    logger.info(`[AutoTopUp] PaymentIntent ${paymentIntent.id} status: ${paymentIntent.status}`);
-
-    if (paymentIntent.status === "succeeded") {
-      const previousBalance = Number(org.credit_balance);
-      const { creditsService } = await import("./credits");
-      const { newBalance } = await creditsService.addCredits({
-        organizationId,
-        amount,
-        description: `Auto top-up - $${amount.toFixed(2)}`,
-        metadata: {
-          ...metadata,
-          payment_intent_id: paymentIntent.id,
-        },
-        stripePaymentIntentId: paymentIntent.id,
-      });
-
-      logger.info(
-        `[AutoTopUp] ✓ Auto top-up succeeded for org ${organizationId}. Payment: ${paymentIntent.id}`,
-      );
-
-      logger.info(`[AutoTopUp] About to call queueAutoTopUpSuccessEmail for org ${organizationId}`);
-      this.queueAutoTopUpSuccessEmail(org, amount, previousBalance, newBalance, paymentIntent.id);
-
-      return {
-        organizationId,
-        success: true,
-        amount,
-        newBalance,
-      };
-    } else if (
-      paymentIntent.status === "requires_action" ||
-      paymentIntent.status === "requires_payment_method"
-    ) {
-      logger.error(
-        `[AutoTopUp] Payment requires action for org ${organizationId}: ${paymentIntent.status}`,
-      );
-
-      await this.disableAutoTopUp(organizationId, `Payment ${paymentIntent.status}`);
-      return {
-        organizationId,
-        success: false,
-        error: `Payment ${paymentIntent.status}`,
-      };
-    } else {
-      logger.error(
-        `[AutoTopUp] Payment in unexpected state for org ${organizationId}: ${paymentIntent.status}`,
-      );
-
-      return {
-        organizationId,
-        success: false,
-        error: `Payment ${paymentIntent.status}`,
-      };
-    }
+    return this.executeAutoTopUpForOrganization(org.id);
   }
 
-  private async disableAutoTopUp(organizationId: string, reason: string): Promise<void> {
-    logger.info(`[AutoTopUp] Disabling auto top-up for org ${organizationId}: ${reason}`);
-
-    const org = await organizationsRepository.findById(organizationId);
-    if (!org) {
-      logger.error(`[AutoTopUp] Organization ${organizationId} not found`);
-      return;
-    }
-
-    await organizationsRepository.update(organizationId, {
-      auto_top_up_enabled: false,
-      updated_at: new Date(),
+  async executeAutoTopUpForOrganization(organizationId: string): Promise<AutoTopUpResult> {
+    const control = await autoTopUpAttemptsRepository.getControl();
+    logger.warn("[AutoTopUp] Charge request rejected by sealed cutover bridge", {
+      organizationId,
+      controlMode: control.mode,
     });
 
-    void this.queueAutoTopUpDisabledEmail(org, reason);
-  }
-
-  private async queueAutoTopUpSuccessEmail(
-    org: Organization,
-    amount: number,
-    previousBalance: number,
-    newBalance: number,
-    paymentIntentId: string,
-  ): Promise<void> {
-    logger.info(`[AutoTopUp] queueAutoTopUpSuccessEmail START for org ${org.id}`);
-
-    const recipientEmail = await this.getUserEmail(org.id);
-    logger.info(`[AutoTopUp] User email: ${recipientEmail || "NONE"}`);
-
-    if (!recipientEmail) {
-      logger.error(`[AutoTopUp] CRITICAL: No user email for org ${org.id} - EMAIL NOT SENT`);
-      return;
-    }
-
-    let paymentMethodDisplay = "Card on file";
-    if (org.stripe_default_payment_method) {
-      const pm = await requireStripe().paymentMethods.retrieve(org.stripe_default_payment_method);
-      if (pm.card) {
-        paymentMethodDisplay = `${pm.card.brand} ••••${pm.card.last4}`;
-      }
-    }
-
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://cloud.eliza.app";
-    const emailData = {
-      email: recipientEmail,
-      organizationName: org.name,
-      amount,
-      previousBalance,
-      newBalance,
-      paymentMethod: paymentMethodDisplay,
-      invoiceUrl: `${appUrl}/cloud/invoices/${paymentIntentId}`,
-      billingUrl: `${appUrl}/cloud/settings`,
+    return {
+      organizationId,
+      success: false,
+      status: "cutover_paused",
+      error: CUTOVER_PAUSED_MESSAGE,
     };
-
-    logger.info(`[AutoTopUp] Calling emailService.sendAutoTopUpSuccessEmail with:`);
-    logger.info(JSON.stringify(emailData, null, 2));
-
-    const result = await emailService.sendAutoTopUpSuccessEmail(emailData);
-
-    logger.info(`[AutoTopUp] Email service returned: ${result}`);
-    if (result) {
-      logger.info(`[AutoTopUp] ✓ SUCCESS: Auto top-up email sent to ${recipientEmail}`);
-    } else {
-      logger.error(`[AutoTopUp] ✗ FAILED: Email service returned false for ${recipientEmail}`);
-    }
-  }
-
-  private async queueAutoTopUpDisabledEmail(org: Organization, reason: string): Promise<void> {
-    const recipientEmail = await this.getUserEmail(org.id);
-    if (!recipientEmail) {
-      logger.error(`[AutoTopUp] No user email for org ${org.id}`);
-      return;
-    }
-
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://cloud.eliza.app";
-    await emailService.sendAutoTopUpDisabledEmail({
-      email: recipientEmail,
-      organizationName: org.name,
-      reason,
-      currentBalance: Number(org.credit_balance || 0),
-      settingsUrl: `${appUrl}/cloud/settings`,
-    });
-  }
-
-  private async getUserEmail(orgId: string): Promise<string | null> {
-    logger.info(`[AutoTopUp] getUserEmail: Fetching users for org ${orgId}`);
-    const users = await usersRepository.listByOrganization(orgId);
-    logger.info(`[AutoTopUp] getUserEmail: Found ${users.length} users`);
-    const email = users.length > 0 && users[0].email ? users[0].email : null;
-    logger.info(`[AutoTopUp] getUserEmail: Returning ${email || "NULL"}`);
-    return email;
   }
 
   async getSettings(organizationId: string): Promise<{
     enabled: boolean;
-    amount: number;
-    threshold: number;
+    amount: number | null;
+    threshold: number | null;
     hasPaymentMethod: boolean;
   }> {
-    const org = await organizationsRepository.findById(organizationId);
-
-    if (!org) {
+    const organization = await organizationsRepository.findById(organizationId);
+    if (!organization) {
       throw new Error("Organization not found");
     }
 
     return {
-      enabled: org.auto_top_up_enabled || false,
-      amount: Number(org.auto_top_up_amount || 0),
-      threshold: Number(org.auto_top_up_threshold || 0),
-      hasPaymentMethod: !!org.stripe_default_payment_method,
+      enabled: organization.auto_top_up_enabled === true,
+      amount: parseAutoTopUpNumberForSettingsRead(
+        "auto_top_up_amount",
+        organization.auto_top_up_amount,
+      ),
+      threshold: parseAutoTopUpNumberForSettingsRead(
+        "auto_top_up_threshold",
+        organization.auto_top_up_threshold,
+      ),
+      hasPaymentMethod: Boolean(organization.stripe_default_payment_method),
     };
   }
 
@@ -507,48 +180,83 @@ export class AutoTopUpService {
       threshold?: number;
     },
   ): Promise<void> {
-    const org = await organizationsRepository.findById(organizationId);
-
-    if (!org) {
+    const organization = await organizationsRepository.findById(organizationId);
+    if (!organization) {
       throw new Error("Organization not found");
     }
 
+    if (settings.enabled === true && !organization.stripe_default_payment_method) {
+      throw new Error(
+        "Cannot enable auto top-up without a default payment method. Please add a payment method first.",
+      );
+    }
     if (settings.enabled === true) {
-      if (!org.stripe_default_payment_method) {
+      const [blockingAttempt, blockingLegacyPayment] = await Promise.all([
+        autoTopUpAttemptsRepository.findBlockingByOrganization(organizationId),
+        autoTopUpAttemptsRepository.findBlockingLegacyPaymentByOrganization(organizationId),
+      ]);
+      if (blockingAttempt || blockingLegacyPayment) {
         throw new Error(
-          "Cannot enable auto top-up without a default payment method. Please add a payment method first.",
+          "Cannot enable auto top-up while an earlier card payment requires reconciliation.",
         );
       }
-
-      const amount = settings.amount ?? Number(org.auto_top_up_amount || 0);
-      const threshold = settings.threshold ?? Number(org.auto_top_up_threshold || 0);
-
+    }
+    const mustValidateAmounts =
+      settings.enabled === true ||
+      settings.amount !== undefined ||
+      settings.threshold !== undefined;
+    if (mustValidateAmounts) {
+      const persistedAmount = parseAutoTopUpNumberForSettingsRead(
+        "auto_top_up_amount",
+        organization.auto_top_up_amount,
+      );
+      const persistedThreshold = parseAutoTopUpNumberForSettingsRead(
+        "auto_top_up_threshold",
+        organization.auto_top_up_threshold,
+      );
+      if (
+        (persistedAmount === null && settings.amount === undefined) ||
+        (persistedThreshold === null && settings.threshold === undefined)
+      ) {
+        throw new AutoTopUpSettingsValidationError(
+          "Valid auto top-up values are required to replace corrupt settings.",
+        );
+      }
+      const amount = settings.amount ?? persistedAmount;
+      const threshold = settings.threshold ?? persistedThreshold;
+      if (amount === null || threshold === null) {
+        throw new AutoTopUpSettingsValidationError(
+          "Valid auto top-up values are required to replace corrupt settings.",
+        );
+      }
       this.validateSettings(amount, threshold);
     }
 
-    if (settings.amount !== undefined || settings.threshold !== undefined) {
-      const amount = settings.amount ?? Number(org.auto_top_up_amount || 0);
-      const threshold = settings.threshold ?? Number(org.auto_top_up_threshold || 0);
-      this.validateSettings(amount, threshold);
-    }
-
-    const updates: Partial<Organization> = {
-      updated_at: new Date(),
-    };
-
-    if (settings.enabled !== undefined) {
-      updates.auto_top_up_enabled = settings.enabled;
-    }
-    if (settings.amount !== undefined) {
-      updates.auto_top_up_amount = settings.amount.toFixed(2);
-    }
+    const updates: Partial<Organization> = { updated_at: new Date() };
+    if (settings.enabled !== undefined) updates.auto_top_up_enabled = settings.enabled;
+    if (settings.amount !== undefined) updates.auto_top_up_amount = settings.amount.toFixed(2);
     if (settings.threshold !== undefined) {
       updates.auto_top_up_threshold = settings.threshold.toFixed(2);
     }
+    if (
+      settings.enabled === true &&
+      settings.threshold === undefined &&
+      (organization.auto_top_up_threshold === null ||
+        organization.auto_top_up_threshold === undefined)
+    ) {
+      // Settings reads preserve the historical SQL NULL -> 0 contract. Persist
+      // that normalized value when enabling so durable discovery and the locked
+      // claim observe the same threshold instead of treating NULL as invalid.
+      updates.auto_top_up_threshold = "0.00";
+    }
 
     await organizationsRepository.update(organizationId, updates);
-
-    logger.info(`[AutoTopUp] Updated settings for org ${organizationId}:`, updates);
+    logger.info("[AutoTopUp] Updated settings", {
+      organizationId,
+      enabled: settings.enabled,
+      amount: settings.amount,
+      threshold: settings.threshold,
+    });
   }
 }
 


### PR DESCRIPTION
# Relates to

Relates to #20717.

This is PR 1 of 2. It installs the sealed cutover foundation only; the durable processor and activation tooling will follow in a stacked PR.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop@1803d6113531e06d5619755e9186ed2dd61b12a8` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after the final sync; the exact unrelated `plugin-wallet` blocker is recorded below.
- [x] A reviewer can confirm the sealed behavior and database invariants from the exact-head tests and attached domain transcript.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@1803d6113531e06d5619755e9186ed2dd61b12a8:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop@1803d6113531e06d5619755e9186ed2dd61b12a8`; final head `8eb30c08d1290e3530a9a8c2239d051fe7bb0903`, zero conflicts.
- [x] Root verification was run post-sync; its exact unrelated baseline blocker is documented under **Known gaps / failures**.
- Stable patch-id: `2a1a6d4090f4cf1581d5ec69da03c6777c6bbd84`.
- `git range-diff` reports `=` across the final base-only rebases.

# Risks

**Large.** This changes a money-integrity path, adds five append-only database migrations, introduces durable attempt/reconciliation state, and intentionally affects organization lifecycle operations while the cutover control is paused.

The main mitigations are:

- the database control starts in `paused`;
- this binary remains sealed even if the control row is changed to `durable`;
- no Stripe PaymentIntent create or confirm call is reachable from the auto-top-up service;
- database constraints and organization-level fences fail closed;
- unresolved or ambiguous payments block re-enable and lifecycle operations;
- stable database guard identifiers map to sanitized `503` or `409` API responses;
- the runbook forbids direct-SQL activation and requires database-pause-first rollback.

No production/staging deployment, live Stripe call, credential change, migration execution, or billing lever is authorized by this PR.

# Background

## What does this PR do?

- Replaces the previous direct-charging auto-top-up processor with a sealed bridge that performs zero new charging work.
- Makes manual and scheduled triggers return explicit paused behavior while preserving authentication and fail-closed control lookup.
- Keeps billing settings safely readable and mutable without fabricating corrupt persisted money values.
- Adds a durable attempt ledger, lease/recovery fields, stable provider identity, credit-convergence state, and an organization re-arm fence for PR 2.
- Adds a paused-by-default singleton cutover authority and a reconciliation-only quarantine for PaymentIntents created before the provider fence.
- Blocks organization deletion and last-user departure while the cutover is globally paused; after activation, organization-specific unresolved work and nonzero balances remain guarded.
- Maps stable cutover constraints to sanitized API errors without exposing SQL.
- Adds the operator runbook at `packages/cloud/shared/docs/auto-top-up-durable-cutover.md`.

This PR intentionally does **not** ship the processor that crosses the Stripe boundary or an activation command. PR 2 will add durable execution, recovery, webhook convergence, provider-boundary tests, structured lifecycle logs, and a reviewed dry-run-first operator command.

## What kind of change is this?

Bug fix and safety foundation: server/data-domain changes with intentional paused maintenance behavior.

# Documentation changes needed?

Yes. The provider fence, inventory/reconciliation prerequisites, lifecycle impact, unsupported direct-SQL activation, and rollback order are documented in the checked-in runbook.

# Testing

Exact final head `8eb30c08d1290e3530a9a8c2239d051fe7bb0903`:

- focused cloud-shared migration/repository/service suite: **58/58 tests, 350 assertions**;
- cutover route and billing-settings suites: **12/12 tests, 35 assertions**;
- API typecheck and Cloudflare Worker dry-run: green;
- `bun install`, `git diff --check`, clean-worktree check, and independent exact-head review: green;
- independent review verdict: **GO**, no blocker/P1/P2.

Patch-identical candidate evidence (`git range-diff =` through the final base-only rebases):

- compatibility fixture gates: **138 tests**, green;
- lifecycle error mapping: **7 tests, 19 assertions**, green;
- Drizzle migration check, shared typecheck, shared/API lint, tenant-scope audit, and root format audit: green;
- before the newly introduced dependency baseline regression, the same patch completed root verify: **356/356 Turbo tasks**.

Latest-base unrelated failures:

- final `bun run verify`: fails only at `@elizaos/plugin-wallet#build` with `viem` TypeScript `TS2883`; this PR changes neither `plugins/plugin-wallet`, `plugins/plugin-build.ts`, `package.json`, nor `bun.lock`;
- final `bun run verify:cloud`: blocked by that same workspace dependency build;
- full cloud-shared lane: one pre-existing `onboarding-chat.error-policy.test.ts` mock failure, reproduced on its exact parent;
- full cloud-api lane: four pre-existing failing files unrelated to this diff.

## Where should a reviewer start?

1. `packages/cloud/shared/src/lib/services/auto-top-up.ts` — confirm the bridge is sealed and has no provider-create dependency.
2. Migrations `0213`–`0217`, schemas, and `auto-top-up-attempts.ts` — control authority, fences, state constraints, and lock ordering.
3. PGlite migration/repository tests plus API route/error tests.
4. The cutover runbook — provider fence, unsupported direct-SQL activation, maintenance impact, and rollback.

## Detailed testing steps

Using Bun `1.3.14` and Node `24.15.0`:

```bash
mise exec bun@1.3.14 node@24.15.0 -- bun install
mise exec bun@1.3.14 node@24.15.0 -- bun run build:core

cd packages/cloud/shared
mise exec bun@1.3.14 node@24.15.0 -- bun --conditions=eliza-source test --reporter=dot \
  src/db/auto-top-up-cutover-migrations.test.ts \
  src/db/repositories/auto-top-up-cutover.pglite.test.ts \
  src/lib/services/__tests__/auto-top-up.test.ts
mise exec bun@1.3.14 node@24.15.0 -- bun test src/lib/api/cloud-worker-errors.test.ts
cd ../../..

mise exec bun@1.3.14 node@24.15.0 -- bun run --cwd packages/cloud/api test auto-top-up-cutover-routes
mise exec bun@1.3.14 node@24.15.0 -- bun test --cwd packages/cloud/api v1/billing/settings/route.test.ts
mise exec bun@1.3.14 node@24.15.0 -- bun run --cwd packages/cloud/shared db:check-migrations
mise exec bun@1.3.14 node@24.15.0 -- bun run --cwd packages/cloud/shared typecheck
mise exec bun@1.3.14 node@24.15.0 -- bun run --cwd packages/cloud/api typecheck
mise exec bun@1.3.14 node@24.15.0 -- bun run verify:cloud
RUN_TURBO_CONCURRENCY=4 mise exec bun@1.3.14 node@24.15.0 -- bun run verify
```

# Evidence Gate

<!-- evidence-head:8eb30c08d1290e3530a9a8c2239d051fe7bb0903 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - server/data-domain change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - server/data-domain change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no frontend or interactive user flow changes.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no staging, production, or live Stripe execution was authorized; new provider creation is intentionally unreachable.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code, request flow, or rendered state changes.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] [20819-review-evidence-8eb30c0.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20819-review-evidence-8eb30c0.md)
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface or visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changes.

## Backend + frontend logs

N/A - no frontend surface exists, and no staging, production, live Stripe, or credential-bearing backend execution was authorized. Exact-head API, service, migration, and PGlite output is supplied as the domain transcript.

## Domain artifacts

The focused suites apply migrations `0213`–`0217` to real PGlite and inspect constraints, control state, attempt/quarantine rows, organization fences, deterministic transactional interleavings, retry-safe credit convergence, lifecycle guards, and sanitized API behavior.

The linked rebased-head receipt records the final base/head, stable patch identity, focused validation, review findings, and limitations.

## Screenshots (before / after) + video walkthrough

N/A - this PR changes no UI, CSS, SVG, or rendered application surface.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, audio, native, or device behavior changes.

## Known gaps / failures

- Root and Cloud verification are currently blocked by the latest `develop` baseline `plugin-wallet`/`viem` declaration-generation error. The PR diff is empty across the failing plugin and dependency inputs.
- PGlite exercises real PostgreSQL-compatible schema, constraints, and deterministic interleavings, but does not prove real PostgreSQL multi-session lock contention. PR 2 must exercise the provider boundary and recovery cases; multi-session PostgreSQL verification is required before production activation.
- PR 1 intentionally leaves automatic card recharge paused. It does not satisfy the complete durable-processor acceptance criteria by itself and must not be activated alone.
- No live Stripe call, provider-key fence, production inventory, queue/DLQ reconciliation, database transition, runtime switch, deploy, or rollback was performed.

# Deploy Notes

This PR is not authorization to deploy or activate auto-top-up.

The control row starts in `paused`. Even if changed to `durable`, this sealed bridge binary cannot create a new auto-top-up PaymentIntent. This foundation intentionally exposes no activation command, and direct SQL is not supported.

## Database changes

| Migration | Purpose |
| --- | --- |
| `0213_auto_top_up_organization_fence.sql` | Adds monotonic balance-decrease and covered-credit fences. |
| `0214_backfill_auto_top_up_organization_fence.sql` | Conservatively baselines existing organizations. |
| `0215_auto_top_up_attempts.sql` | Adds the constrained durable attempt ledger and indexes. |
| `0216_auto_top_up_cutover_control.sql` | Adds the paused authority and earlier-payment quarantine. |
| `0217_guard_auto_top_up_cutover_lifecycle.sql` | Guards deletion and last-user departure during/after cutover. |

All migrations are append-only and separated by purpose.

## Deployment instructions

Do not activate this PR alone.

After PR 2 is reviewed and merged, production activation still requires the human/provider handoff tracked in #20717: provider credential fencing, confirmation that 100% of Worker traffic runs the reviewed binary, complete paginated PaymentIntent inventory, queue/DLQ reconciliation, guarded database transition from `paused` to `durable`, and only then the secondary runtime switch.

Rollback order is database mode back to `paused` first, runtime switch off second. Keep the recovery-capable durable binary deployed; never redeploy the previous direct-charging processor.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex
Contribution skill revision: elizaOS/eliza@1803d6113531e06d5619755e9186ed2dd61b12a8:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-billing-autotopup-singleflight]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex","skill_revision":"elizaOS/eliza@1803d6113531e06d5619755e9186ed2dd61b12a8:packages/skills/skills/contribute-to-eliza"} -->



