### PR TITLE
fix(cloud): reject non-canonical redemption quote pointsAmount

### DIFF
--- a/packages/cloud/api/v1/redemptions/quote/route.test.ts
+++ b/packages/cloud/api/v1/redemptions/quote/route.test.ts
@@ -1,0 +1,219 @@
+/**
+ * GET /api/v1/redemptions/quote pointsAmount contract at the HTTP boundary.
+ *
+ * The harness is deterministic: auth, rate-limit, payout status, TWAP, and
+ * token-availability collaborators are stubbed so a 400 can be proven
+ * write-free. Prefix-coercible garbage must not reach those services.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const USER_ID = "00000000-0000-4000-8000-000000142390";
+const ORG_ID = "00000000-0000-4000-8000-000000142391";
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: USER_ID,
+  organization_id: ORG_ID,
+}));
+const isNetworkAvailable = mock(async () => ({
+  available: true,
+  message: "",
+}));
+const getStatus = mock(async () => ({ networks: [] }));
+const getRedemptionQuote = mock(
+  async (_network: string, pointsAmount: number) => ({
+    success: true,
+    quote: {
+      usdValue: pointsAmount / 100,
+      twapPrice: 0.01,
+      spotPrice: 0.01,
+      sampleCount: 10,
+      volatility: 0.01,
+      requiresDelay: false,
+      delayUntil: undefined,
+      expiresAt: new Date("2026-01-01T00:00:00.000Z"),
+    },
+    warnings: [],
+  }),
+);
+const checkTokenAvailability = mock(async () => ({
+  available: true,
+  balance: 1_000,
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => next(),
+}));
+
+mock.module("@/lib/services/payout-status", () => ({
+  payoutStatusService: {
+    isNetworkAvailable,
+    getStatus,
+  },
+}));
+
+mock.module("@/lib/services/twap-price-oracle", () => ({
+  twapPriceOracle: { getRedemptionQuote },
+}));
+
+mock.module("@/lib/services/eliza-token-price", () => ({
+  ELIZA_TOKEN_ADDRESSES: {
+    ethereum: "0xethereum",
+    base: "0xbase",
+    bnb: "0xbnb",
+    solana: "solana",
+  },
+}));
+
+mock.module("@/lib/services/token-redemption-secure", () => ({
+  secureTokenRedemptionService: { checkTokenAvailability },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+  },
+}));
+
+const { default: app, parseRedemptionQuotePointsAmount } = await import(
+  "./route"
+);
+
+function quoteRequest(query: string) {
+  return app.request(`/${query}`, { method: "GET" });
+}
+
+beforeEach(() => {
+  requireUserOrApiKeyWithOrg.mockClear();
+  isNetworkAvailable.mockClear();
+  getStatus.mockClear();
+  getRedemptionQuote.mockClear();
+  checkTokenAvailability.mockClear();
+});
+
+function expectNoQuoteSideEffects() {
+  expect(requireUserOrApiKeyWithOrg).not.toHaveBeenCalled();
+  expect(isNetworkAvailable).not.toHaveBeenCalled();
+  expect(getRedemptionQuote).not.toHaveBeenCalled();
+  expect(checkTokenAvailability).not.toHaveBeenCalled();
+}
+
+describe("parseRedemptionQuotePointsAmount", () => {
+  test.each([
+    [undefined, 100],
+    ["", 100],
+    ["1", 1],
+    ["100", 100],
+    ["100000", 100_000],
+    ["9007199254740991", Number.MAX_SAFE_INTEGER],
+  ] as const)("accepts %s", (raw, expected) => {
+    expect(parseRedemptionQuotePointsAmount(raw)).toEqual({
+      ok: true,
+      pointsAmount: expected,
+    });
+  });
+
+  test.each([
+    ["1e4", "scientific notation"],
+    ["100abc", "trailing junk"],
+    ["0x10", "hex"],
+    ["0100", "leading zeros"],
+    ["+100", "plus sign"],
+    ["-1", "signed"],
+    ["100.0", "decimal"],
+    [" 100", "leading whitespace"],
+    ["100 ", "trailing whitespace"],
+    ["1_000", "separator"],
+    ["0", "zero"],
+    ["Infinity", "Infinity"],
+    ["NaN", "NaN"],
+    [" ", "whitespace only"],
+    ["9007199254740992", "above safe integer"],
+  ] as const)("rejects %s (%s)", (raw) => {
+    expect(parseRedemptionQuotePointsAmount(raw)).toEqual({ ok: false });
+  });
+});
+
+describe("GET /api/v1/redemptions/quote — pointsAmount contract", () => {
+  test("absent pointsAmount defaults to 100 before any quote service", async () => {
+    const res = await quoteRequest("?network=base");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      quote: { pointsAmount: number };
+    };
+    expect(body.success).toBe(true);
+    expect(body.quote.pointsAmount).toBe(100);
+    expect(getRedemptionQuote).toHaveBeenCalledTimes(1);
+    expect(getRedemptionQuote).toHaveBeenCalledWith("base", 100, USER_ID);
+  });
+
+  test("empty pointsAmount defaults to 100", async () => {
+    const res = await quoteRequest("?network=base&pointsAmount=");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      quote: { pointsAmount: number };
+    };
+    expect(body.quote.pointsAmount).toBe(100);
+    expect(getRedemptionQuote).toHaveBeenCalledWith("base", 100, USER_ID);
+  });
+
+  test.each([
+    ["1", 1],
+    ["100", 100],
+    ["2500", 2500],
+  ] as const)(
+    "canonical pointsAmount %s is forwarded unchanged",
+    async (raw, expected) => {
+      const res = await quoteRequest(`?network=base&pointsAmount=${raw}`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        quote: { pointsAmount: number };
+      };
+      expect(body.quote.pointsAmount).toBe(expected);
+      expect(getRedemptionQuote).toHaveBeenCalledWith(
+        "base",
+        expected,
+        USER_ID,
+      );
+      expect(isNetworkAvailable).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test.each([
+    ["1e4", "scientific notation that parseInt truncates to 1"],
+    ["100abc", "trailing junk that parseInt accepts as 100"],
+    ["0x10", "hex"],
+    ["0100", "leading zeros"],
+    ["+100", "plus sign"],
+    ["-1", "signed"],
+    ["100.0", "decimal that parseInt truncates"],
+    [" 100", "leading whitespace"],
+    ["100 ", "trailing whitespace"],
+    ["1_000", "numeric separator"],
+    ["0", "zero"],
+    ["Infinity", "Infinity"],
+    ["NaN", "NaN"],
+    ["9007199254740992", "unsafe integer"],
+  ] as const)(
+    "returns 400 and calls no quote services for %s (%s)",
+    async (raw) => {
+      const res = await quoteRequest(
+        `?network=base&pointsAmount=${encodeURIComponent(raw)}`,
+      );
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({
+        success: false,
+        error: "Invalid pointsAmount",
+      });
+      expectNoQuoteSideEffects();
+    },
+  );
+});

--- a/packages/cloud/api/v1/redemptions/quote/route.ts
+++ b/packages/cloud/api/v1/redemptions/quote/route.ts
@@ -1,7 +1,12 @@
 /**
  * Token Redemption Price Quote API
  *
- * GET /api/v1/redemptions/quote - Get current elizaOS price and calculate redemption.
+ * GET /api/v1/redemptions/quote returns the current elizaOS price and a
+ * preview conversion. `pointsAmount` is untrusted query input: absent or empty
+ * keeps the documented default of 100, and any present token must be a
+ * complete ASCII decimal safe integer ≥ 1. Prefix-legal garbage must not
+ * coerce (`parseInt("1e4")` is 1) before payout-status, TWAP, or
+ * token-availability I/O.
  */
 
 import { Hono } from "hono";
@@ -25,6 +30,30 @@ import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
+
+export const DEFAULT_QUOTE_POINTS_AMOUNT = 100;
+
+/**
+ * Canonical redemption-quote `pointsAmount` at the HTTP boundary.
+ * Missing or empty defaults to 100. Any other token must be a complete
+ * ASCII decimal safe integer ≥ 1 — no sign, zero, fraction, hex, scientific
+ * notation, leading zeros, whitespace, junk, or unsafe integers.
+ */
+export function parseRedemptionQuotePointsAmount(
+  raw: string | undefined,
+): { ok: true; pointsAmount: number } | { ok: false } {
+  if (raw === undefined || raw === "") {
+    return { ok: true, pointsAmount: DEFAULT_QUOTE_POINTS_AMOUNT };
+  }
+  if (!/^\d+$/.test(raw)) {
+    return { ok: false };
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(parsed) || String(parsed) !== raw || parsed < 1) {
+    return { ok: false };
+  }
+  return { ok: true, pointsAmount: parsed };
+}
 
 const validNetworkParams = [
   "ethereum",
@@ -57,10 +86,17 @@ app.use("*", rateLimit(RateLimitPresets.STANDARD));
 
 app.get("/", async (c) => {
   try {
+    const parsedPoints = parseRedemptionQuotePointsAmount(
+      c.req.query("pointsAmount"),
+    );
+    if (!parsedPoints.ok) {
+      return c.json({ success: false, error: "Invalid pointsAmount" }, 400);
+    }
+    const { pointsAmount } = parsedPoints;
+
     const user = await requireUserOrApiKeyWithOrg(c);
 
     const networkParam = c.req.query("network");
-    const pointsParam = c.req.query("pointsAmount");
 
     if (
       !networkParam ||
@@ -76,11 +112,6 @@ app.get("/", async (c) => {
     }
 
     const network = normalizeNetworkParam(networkParam as NetworkParam);
-    const pointsAmount = pointsParam ? parseInt(pointsParam, 10) : 100;
-
-    if (Number.isNaN(pointsAmount) || pointsAmount < 1) {
-      return c.json({ success: false, error: "Invalid pointsAmount" }, 400);
-    }
 
     const networkAvailability =
       await payoutStatusService.isNetworkAvailable(network);


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Cloud fail-closed untrusted-input fix
on `GET /api/v1/redemptions/quote` `pointsAmount`. Not a twin of first-run JSON,
notifications limit, BlueBubbles page, login persist, billing, or avatar.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Query-parse only on `GET /api/v1/redemptions/quote`. Absent or empty
`pointsAmount` still defaults to 100. Canonical decimal amounts still quote.
Prefix-coerced tokens 400 before auth, TWAP, or token-availability I/O. No
compat logs, first-run, notifications, BlueBubbles, login persist, billing, or
avatar change.

# Background

## What does this PR do?

`pointsAmount` no longer uses `parseInt`. Prefix-legal garbage (`1e4`,
`100abc`, `0100`) is not `NaN` and used to silently quote the truncated
integer — a payout preview, not a list length.

- omitted / `""` → 100 (unchanged)
- `pointsAmount=1` / `100` / `2500` → that amount, 200
- `1e4` / `100abc` / `0x10` / `007` / `0` → **400** `Invalid pointsAmount`
  before `requireUserOrApiKeyWithOrg` / `getRedemptionQuote`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A coerced `pointsAmount` quotes the wrong payout. Same untrusted-query class
as other fail-closed Cloud parsers; different file and money path.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/redemptions/quote/route.test.ts` — parser table plus
route 400s that call no quote services.

## Detailed testing steps

```bash
cd packages/cloud/api && bun test v1/redemptions/quote/route.test.ts
```

40 passed at head `2441fe6198391de63840ede65502ba03fddcc55d`.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; query parse only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; query parse only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; query parse only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real quote handler and assert 400 before TWAP/token I/O; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, wallet, or generated-file writes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal
`pointsAmount` 400s before quote I/O; omitted and canonical amounts still 200.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file redemption-quote query parse
with a green focused suite (40 tests). Full monorepo verify is unrelated to
this query grammar and was skipped to keep the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:2441fe6198391de63840ede65502ba03fddcc55d -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->


## Independent exact-head review

The parser accepts only canonical positive safe integers, keeps the documented default, and rejects malformed amounts before authentication and all payout/TWAP/token I/O. Final head is rebased onto current develop. Exact-head verification passed: quote route 40/40 (125 assertions), Cloud API typecheck plus production Worker dry bundle, Biome, and diff check. No external quote, payout, or deployment was performed.
