### PR TITLE
fix(cloud): reject prefix-coerced compat agent-logs tail

### DIFF
--- a/packages/cloud/api/compat/agents/[id]/logs/route.test.ts
+++ b/packages/cloud/api/compat/agents/[id]/logs/route.test.ts
@@ -175,9 +175,7 @@ describe("compat agent logs tail contract", () => {
   ] as const)(
     "returns 400 and does not look up or enqueue for tail=%s (%s)",
     async (raw) => {
-      const response = await requestLogs(
-        `?tail=${encodeURIComponent(raw)}`,
-      );
+      const response = await requestLogs(`?tail=${encodeURIComponent(raw)}`);
       expect(response.status).toBe(400);
       await expect(response.json()).resolves.toEqual({
         success: false,

--- a/packages/cloud/api/compat/agents/[id]/logs/route.test.ts
+++ b/packages/cloud/api/compat/agents/[id]/logs/route.test.ts
@@ -1,0 +1,190 @@
+/**
+ * GET /api/compat/agents/:id/logs tail contract at the HTTP boundary.
+ *
+ * Auth, sandbox lookup, and the logs enqueue are stubbed so a 400 can be
+ * proven write-free. Prefix-coercible garbage must not become docker
+ * `logs --tail N`.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { Hono } from "hono";
+
+const requireCompatAuth = mock(async () => ({
+  user: {
+    id: "compat-user-1",
+    organization_id: "compat-org-1",
+  },
+  authMethod: "standard" as const,
+}));
+
+const getAgent = mock(
+  async (): Promise<{
+    id: string;
+    organization_id: string;
+    status: string;
+  } | null> => ({
+    id: "compat-agent-1",
+    organization_id: "compat-org-1",
+    status: "running",
+  }),
+);
+
+const enqueueAgentLogsOnce = mock(async () => ({
+  created: true,
+  job: {
+    id: "compat-logs-job-1",
+    status: "pending",
+  },
+}));
+const triggerImmediate = mock(async () => undefined);
+
+mock.module("../../../_lib/auth", () => ({
+  requireCompatAuth,
+}));
+
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: {
+    getAgent,
+  },
+}));
+
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: {
+    enqueueAgentLogsOnce,
+    triggerImmediate,
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+    debug: mock(() => undefined),
+  },
+}));
+
+const { default: logsRoute, parseCompatLogsTail } = await import("./route");
+
+describe("parseCompatLogsTail", () => {
+  test.each([
+    [null, 100],
+    ["1", 1],
+    ["100", 100],
+    ["5000", 5000],
+  ] as const)("accepts %s", (raw, expected) => {
+    expect(parseCompatLogsTail(raw)).toEqual({ ok: true, tail: expected });
+  });
+
+  test.each([
+    ["", "empty"],
+    ["1e4", "scientific notation that parseInt truncates to 1"],
+    ["12px", "trailing junk"],
+    ["007", "leading zeros"],
+    ["0", "zero"],
+    ["-1", "signed"],
+    ["0x10", "hex"],
+    ["5001", "above max"],
+    ["9007199254740992", "unsafe integer"],
+    ["Infinity", "Infinity"],
+  ] as const)("rejects %s (%s)", (raw) => {
+    expect(parseCompatLogsTail(raw)).toEqual({ ok: false });
+  });
+});
+
+describe("compat agent logs tail contract", () => {
+  const app = new Hono();
+  app.route("/api/compat/agents/:id/logs", logsRoute);
+
+  beforeEach(() => {
+    requireCompatAuth.mockClear();
+    getAgent.mockClear();
+    getAgent.mockResolvedValue({
+      id: "compat-agent-1",
+      organization_id: "compat-org-1",
+      status: "running",
+    });
+    enqueueAgentLogsOnce.mockClear();
+    enqueueAgentLogsOnce.mockResolvedValue({
+      created: true,
+      job: {
+        id: "compat-logs-job-1",
+        status: "pending",
+      },
+    });
+    triggerImmediate.mockClear();
+  });
+
+  async function requestLogs(query = "") {
+    return app.fetch(
+      new Request(
+        `https://api.example.test/api/compat/agents/compat-agent-1/logs${query}`,
+        { method: "GET" },
+      ),
+    );
+  }
+
+  test("omitted tail defaults to 100 and enqueues", async () => {
+    const response = await requestLogs();
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: {
+        jobId: "compat-logs-job-1",
+        tail: 100,
+        agentStatus: "running",
+      },
+    });
+    expect(enqueueAgentLogsOnce).toHaveBeenCalledWith({
+      agentId: "compat-agent-1",
+      organizationId: "compat-org-1",
+      userId: "compat-user-1",
+      tail: 100,
+    });
+  });
+
+  test("canonical tail=10 is forwarded unchanged", async () => {
+    const response = await requestLogs("?tail=10");
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      data: { tail: 10 },
+    });
+    expect(enqueueAgentLogsOnce).toHaveBeenCalledWith(
+      expect.objectContaining({ tail: 10 }),
+    );
+  });
+
+  test("unknown agent 404s after a canonical tail and does not enqueue", async () => {
+    getAgent.mockResolvedValueOnce(null);
+    const response = await requestLogs("?tail=10");
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: "Agent not found",
+    });
+    expect(enqueueAgentLogsOnce).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ["1e4", "scientific notation"],
+    ["12px", "trailing junk"],
+    ["007", "leading zeros"],
+    ["0", "zero"],
+    ["5001", "above max"],
+  ] as const)(
+    "returns 400 and does not look up or enqueue for tail=%s (%s)",
+    async (raw) => {
+      const response = await requestLogs(
+        `?tail=${encodeURIComponent(raw)}`,
+      );
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        success: false,
+        error: "tail must be a whole number between 1 and 5000",
+      });
+      expect(getAgent).not.toHaveBeenCalled();
+      expect(enqueueAgentLogsOnce).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/cloud/api/compat/agents/[id]/logs/route.ts
+++ b/packages/cloud/api/compat/agents/[id]/logs/route.ts
@@ -25,6 +25,31 @@ import { handleCompatCorsOptions, withCompatCors } from "../../../_lib/cors";
 import { handleCompatError } from "../../../_lib/error-handler";
 
 const CORS_METHODS = "GET, OPTIONS";
+const DEFAULT_TAIL = 100;
+const MAX_TAIL = 5000;
+const CANONICAL_POSITIVE_INTEGER = /^[1-9]\d*$/;
+
+/**
+ * Canonical compat `tail` at the HTTP boundary. Same contract as v1
+ * `GET /api/v1/agents/:agentId/logs`: omitted defaults to 100; any other
+ * token must be a complete ASCII decimal integer in [1, 5000]. Prefix-legal
+ * garbage must not coerce (`parseInt("1e4", 10)` is 1) into `docker logs --tail`.
+ */
+export function parseCompatLogsTail(
+  rawTail: string | null,
+): { ok: true; tail: number } | { ok: false } {
+  if (rawTail === null) {
+    return { ok: true, tail: DEFAULT_TAIL };
+  }
+  if (!CANONICAL_POSITIVE_INTEGER.test(rawTail)) {
+    return { ok: false };
+  }
+  const tail = Number(rawTail);
+  if (!Number.isSafeInteger(tail) || tail > MAX_TAIL) {
+    return { ok: false };
+  }
+  return { ok: true, tail };
+}
 
 async function __hono_GET(
   request: Request,
@@ -34,6 +59,21 @@ async function __hono_GET(
   try {
     const { user } = await requireCompatAuth(request);
     const { id: agentId } = await params;
+
+    const url = new URL(request.url);
+    const parsedTail = parseCompatLogsTail(url.searchParams.get("tail"));
+    if (!parsedTail.ok) {
+      // error-policy:J3 reject malformed request input instead of coercing
+      // or clamping it into docker logs --tail.
+      return withCompatCors(
+        Response.json(
+          errorEnvelope(`tail must be a whole number between 1 and ${MAX_TAIL}`),
+          { status: 400 },
+        ),
+        CORS_METHODS,
+      );
+    }
+    const { tail } = parsedTail;
 
     const agent = await elizaSandboxService.getAgent(
       agentId,
@@ -45,13 +85,6 @@ async function __hono_GET(
         CORS_METHODS,
       );
     }
-
-    const url = new URL(request.url);
-    const rawTail = parseInt(url.searchParams.get("tail") ?? "100", 10);
-    const tail = Math.max(
-      1,
-      Math.min(Number.isFinite(rawTail) ? rawTail : 100, 5000),
-    );
 
     const enqueueResult = await provisioningJobService.enqueueAgentLogsOnce({
       agentId,

--- a/packages/cloud/api/compat/agents/[id]/logs/route.ts
+++ b/packages/cloud/api/compat/agents/[id]/logs/route.ts
@@ -67,7 +67,9 @@ async function __hono_GET(
       // or clamping it into docker logs --tail.
       return withCompatCors(
         Response.json(
-          errorEnvelope(`tail must be a whole number between 1 and ${MAX_TAIL}`),
+          errorEnvelope(
+            `tail must be a whole number between 1 and ${MAX_TAIL}`,
+          ),
           { status: 400 },
         ),
         CORS_METHODS,


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Cloud fail-closed untrusted-input fix
on `GET /api/compat/agents/:id/logs` `tail`. Sibling leftover of the already
fail-closed v1 agent-logs parser. Not a twin of first-run JSON, notifications
limit, BlueBubbles page, login persist, billing, or avatar.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Query-parse only on the compat agent-logs route. Omitted `tail` still
defaults to 100. Canonical `tail=10` still enqueues. Prefix-coerced tokens 400
before sandbox lookup or `enqueueAgentLogsOnce`. Does not retouch v1 logs,
redemption quote, first-run, notifications, BlueBubbles, login persist,
billing, or avatar.

# Background

## What does this PR do?

Compat `tail` no longer uses `parseInt` then clamp. Prefix-legal garbage
(`1e4`, `12px`, `007`) used to become `docker logs --tail 1` (or another
truncated page). Same contract as v1 `GET /api/v1/agents/:agentId/logs`.

- omitted → 100, 202 (unchanged)
- `tail=10` / `5000` → that many, 202
- `1e4` / `12px` / `007` / `0` / `5001` → **400**
  `tail must be a whole number between 1 and 5000` before `getAgent` / enqueue

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Thin clients still load logs through the compat path. A coerced `tail` under-
reads daemon `docker logs`. v1 already fail-closes; compat was the leftover.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/compat/agents/[id]/logs/route.test.ts` — parser table plus
route 400s that neither look up the agent nor enqueue.

## Detailed testing steps

```bash
cd packages/cloud/api && bun test "compat/agents/[id]/logs/route.test.ts"
```

22 passed at head `2301da2fb8bac2979dfcf6f92e8070e86286d529`.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; query parse only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; query parse only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; query parse only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real compat handler and assert 400 before sandbox lookup/enqueue; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, wallet, or generated-file writes.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal `tail`
400s before lookup/enqueue; omitted and canonical `tail=10` still 202.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file compat logs query parse with
a green focused suite (22 tests). Full monorepo verify is unrelated to this
query grammar and was skipped to keep the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:2301da2fb8bac2979dfcf6f92e8070e86286d529 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->


## Independent exact-head review

The compat path now matches the v1 log-tail contract: auth remains first, malformed or out-of-range tails stop before agent lookup/enqueue, omission defaults to 100, and 5000 remains accepted. Final head is rebased and repository-formatted. Exact-head verification passed: compat logs 22/22 (43 assertions), Cloud API typecheck plus production Worker dry bundle, Biome, and diff check. No sandbox lookup, log enqueue, or deployment was performed outside the deterministic tests.
