### PR TITLE
fix(wallet): make createWallet declaration portable

### DIFF
--- a/plugins/plugin-wallet/src/sdk/wallet-core.ts
+++ b/plugins/plugin-wallet/src/sdk/wallet-core.ts
@@ -9,9 +9,11 @@ import {
   type Address,
   type Chain,
   createPublicClient,
+  type GetContractReturnType,
   getContract,
   type Hash,
   http,
+  type PublicClient,
   type WalletClient,
   zeroAddress,
 } from "viem";
@@ -39,12 +41,24 @@ export function requireWalletAccount(client: WalletClient) {
 /** Native ETH token address (zero address) */
 export const NATIVE_TOKEN: Address = zeroAddress;
 
+/** Portable public shape returned by {@link createWallet}. */
+export interface AgentWallet {
+  address: Address;
+  contract: GetContractReturnType<
+    typeof AgentAccountV2Abi,
+    { public: PublicClient; wallet: WalletClient }
+  >;
+  publicClient: PublicClient;
+  walletClient: WalletClient;
+  chain: Chain;
+}
+
 /**
  * Create a wallet client connected to an existing AgentAccountV2.
  */
 export function createWallet(
   config: AgentWalletConfig & { walletClient: WalletClient },
-) {
+): AgentWallet {
   const chain = CHAINS[config.chain];
   if (!chain) throw new Error(`Unsupported chain: ${config.chain}`);
 
@@ -67,8 +81,6 @@ export function createWallet(
     chain,
   };
 }
-
-export type AgentWallet = ReturnType<typeof createWallet>;
 
 /**
  * Set a spend policy for a token. Only callable by the NFT owner.


### PR DESCRIPTION
Closes #20812

## Summary
- publish an explicit `AgentWallet` interface
- retain ABI-derived contract read/write typing through viem public types
- prevent declaration output from naming viem internal modules

## Verification
- `bun run build:core` — 59/59 packages passed
- `bun run --cwd plugins/plugin-wallet typecheck`
- `bun run --cwd plugins/plugin-wallet lint:check`
- `bun run --cwd plugins/plugin-wallet build`
- `bun run --cwd plugins/plugin-wallet test` — 48 files passed, 1 skipped; 294 tests passed, 1 skipped
- `bun run verify` reached 208/210 tasks; blocked by pre-existing `packages/cloud/api/v1/limit-clamp-batch3-hono.test.ts` tuple errors, unrelated to this one-file wallet change

## Provenance

| Field | Value |
| --- | --- |
| Model | OpenAI / gpt-5 |
| Client | Codex desktop |
| Target | develop |

---
Agent-authored via Codex desktop.