### PR TITLE
fix(wallet): stabilize viem declaration boundary

### DIFF
--- a/plugins/plugin-wallet/src/sdk/wallet-core.ts
+++ b/plugins/plugin-wallet/src/sdk/wallet-core.ts
@@ -9,9 +9,11 @@ import {
   type Address,
   type Chain,
   createPublicClient,
+  type GetContractReturnType,
   getContract,
   type Hash,
   http,
+  type PublicClient,
   type WalletClient,
   zeroAddress,
 } from "viem";
@@ -39,12 +41,24 @@ export function requireWalletAccount(client: WalletClient) {
 /** Native ETH token address (zero address) */
 export const NATIVE_TOKEN: Address = zeroAddress;
 
+/** Stable public SDK boundary for the typed AgentAccountV2 contract client. */
+export interface AgentWallet {
+  address: Address;
+  contract: GetContractReturnType<
+    typeof AgentAccountV2Abi,
+    { public: PublicClient; wallet: WalletClient }
+  >;
+  publicClient: PublicClient;
+  walletClient: WalletClient;
+  chain: Chain;
+}
+
 /**
  * Create a wallet client connected to an existing AgentAccountV2.
  */
 export function createWallet(
   config: AgentWalletConfig & { walletClient: WalletClient },
-) {
+): AgentWallet {
   const chain = CHAINS[config.chain];
   if (!chain) throw new Error(`Unsupported chain: ${config.chain}`);
 
@@ -67,8 +81,6 @@ export function createWallet(
     chain,
   };
 }
-
-export type AgentWallet = ReturnType<typeof createWallet>;
 
 /**
  * Set a spend policy for a token. Only callable by the NFT owner.


### PR DESCRIPTION
# Relates to

Follow-up to [#20801](https://github.com/elizaOS/eliza/pull/20801) and private advisory [GHSA-38ww-x42w-xqr6](https://github.com/elizaOS/eliza/security/advisories/GHSA-38ww-x42w-xqr6).

Definition of Done: full standard in [`CONTRIBUTING.md`](https://github.com/elizaOS/eliza/blob/develop/CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop` at `d6d3acd3247` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync; the exact unrelated root failure is recorded below.
- [x] A reviewer can confirm the fix through the counterfactual package build and generated declaration artifact.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop` at `d6d3acd3247`; zero conflicts.
- [x] Root verification passed all gates through the workspace typecheck/lint fan-out, then stopped on unrelated pre-existing cloud test typing errors documented below.

# Risks

Low. The runtime object and exported `AgentWallet` shape are unchanged. This replaces a recursively inferred public alias with an explicit interface backed by viem's exported `GetContractReturnType`, preventing declaration emit from naming viem-internal token-action types.

# Background

## What does this PR do?

The viem 2.55 security upgrade in #20801 exposed TS2883 errors while generating declarations for `createWallet`. This PR gives `createWallet` an explicit stable public return boundary, preserving the same typed contract, public client, wallet client, chain, and address fields.

## What kind of change is this?

Non-breaking build compatibility fix.

# Documentation changes needed?

No. The public runtime shape and supported API remain unchanged.

# Testing

## Where should a reviewer start?

Run `bun run --cwd plugins/plugin-wallet build`. Before this change, declaration generation fails at `src/sdk/wallet-core.ts:45` with TS2883 references to viem-internal token action types; after this change it emits `dist/sdk/wallet-core.d.ts` successfully using public viem type exports.

## Detailed testing steps

Using pinned Bun 1.3.14 after rebasing:

```text
bun install --frozen-lockfile
bun run --cwd plugins/plugin-wallet build
bun run --cwd plugins/plugin-wallet typecheck
bun run --cwd plugins/plugin-wallet lint:check
bun run --cwd plugins/plugin-wallet test
bun run verify
```

Results:

- Wallet build, including Node/browser bundles, TypeScript declarations, UI declarations, and Vite view bundle: passed.
- Wallet Node and UI typechecks: passed.
- Wallet Biome check: passed across 284 files.
- Wallet tests: 48 files passed, 1 skipped; 294 tests passed, 1 skipped.
- Root verification: package change and wallet lanes passed; stopped only on unrelated `packages/cloud/api/v1/limit-clamp-batch3-hono.test.ts` tuple-access errors already present on the rebased `develop` tip.

# Evidence Gate

<!-- evidence-head:94b2a38650d47ab5813a0cf54f5d303e7f873e21 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no UI flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - this is a TypeScript declaration-generation boundary; the package build output is the direct artifact evidence.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, scheduled-task, wallet transaction, or generated user artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changed.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changed.

## Backend + frontend logs

N/A - the generated `dist/sdk/wallet-core.d.ts` and successful package build are the applicable evidence.

## Screenshots (before / after) + video walkthrough

N/A - no UI files or rendered surfaces changed.

## Audio / voice walkthrough

N/A - no voice or audio path changed.

## Known gaps / failures

`bun run verify` fails in `@elizaos/cloud-api#typecheck` on `packages/cloud/api/v1/limit-clamp-batch3-hono.test.ts` lines 176-259 (`TS2532` and `TS2493` on an empty tuple). That file is unchanged by this PR and exists identically at the rebased `origin/develop` base. The wallet package build, typecheck, lint, and full test suite all pass.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [security-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no contribution skill used"} -->
