### PR TITLE
fix(cloud): 400 malformed invites accept JSON

### DIFF
--- a/packages/cloud/api/invites/accept/route.test.ts
+++ b/packages/cloud/api/invites/accept/route.test.ts
@@ -14,9 +14,15 @@ const requireUserOrApiKey = mock(async () => ({
   id: USER_ID,
   organization_id: ORG_ID,
 }));
-const acceptInvite = mock(async () => {
-  throw new Error("acceptInvite must not run");
-});
+const acceptInvite = mock(
+  async (): Promise<{
+    organization_id: string;
+    invited_role: string;
+    accepted_at: string;
+  }> => {
+    throw new Error("acceptInvite must not run");
+  },
+);
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKey,
@@ -63,7 +69,7 @@ describe("POST /api/invites/accept JSON body", () => {
       const res = await post(raw);
 
       expect(res.status).toBe(400);
-      expect(await res.json()).toEqual({
+      expect((await res.json()) as Record<string, unknown>).toEqual({
         success: false,
         error: "Invalid JSON body",
       });

--- a/packages/cloud/api/invites/accept/route.test.ts
+++ b/packages/cloud/api/invites/accept/route.test.ts
@@ -1,0 +1,106 @@
+/**
+ * POST /api/invites/accept untrusted JSON body contract.
+ *
+ * Hono 4.13 `c.req.json()` is a bare `JSON.parse`. The handler catch maps
+ * SyntaxError through `failureResponse` to HTTP 500 ("An unexpected error
+ * occurred") instead of a caller 400. Membership mutation must not run.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const USER_ID = "00000000-0000-4000-8000-0000000000bb";
+const ORG_ID = "00000000-0000-4000-8000-0000000000aa";
+
+const requireUserOrApiKey = mock(async () => ({
+  id: USER_ID,
+  organization_id: ORG_ID,
+}));
+const acceptInvite = mock(async () => {
+  throw new Error("acceptInvite must not run");
+});
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKey,
+}));
+
+mock.module("@/lib/services/invites", () => ({
+  invitesService: { acceptInvite },
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STRICT: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+}));
+
+const { default: app } = await import("./route");
+
+function post(raw: string) {
+  return app.fetch(
+    new Request("http://test.local/", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer eliza_test_key",
+        "Content-Type": "application/json",
+      },
+      body: raw,
+    }),
+  );
+}
+
+describe("POST /api/invites/accept JSON body", () => {
+  beforeEach(() => {
+    requireUserOrApiKey.mockClear();
+    acceptInvite.mockClear();
+    acceptInvite.mockImplementation(async () => {
+      throw new Error("acceptInvite must not run");
+    });
+  });
+
+  test.each(["", "   ", "{", "not-json"])(
+    "rejects malformed invite body %j with 400",
+    async (raw) => {
+      const res = await post(raw);
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({
+        success: false,
+        error: "Invalid JSON body",
+      });
+      expect(acceptInvite).not.toHaveBeenCalled();
+      expect(requireUserOrApiKey).toHaveBeenCalled();
+    },
+  );
+
+  test("still accepts a canonical object body", async () => {
+    acceptInvite.mockResolvedValue({
+      organization_id: ORG_ID,
+      invited_role: "member",
+      accepted_at: "2026-08-17T00:00:00.000Z",
+    });
+
+    const res = await post(JSON.stringify({ token: "invite-token" }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      success: true,
+      data: {
+        organization_id: ORG_ID,
+        role: "member",
+        accepted_at: "2026-08-17T00:00:00.000Z",
+      },
+    });
+    expect(acceptInvite).toHaveBeenCalledTimes(1);
+    expect(acceptInvite).toHaveBeenCalledWith("invite-token", USER_ID);
+  });
+
+  test("still 400s a parseable object missing token via zod", async () => {
+    const res = await post("{}");
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { success?: boolean; error?: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Validation error");
+    expect(acceptInvite).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/invites/accept/route.ts
+++ b/packages/cloud/api/invites/accept/route.ts
@@ -25,7 +25,15 @@ app.use("*", rateLimit(RateLimitPresets.STRICT));
 app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKey(c);
-    const body = await c.req.json();
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      // error-policy:J3 untrusted request JSON — Hono's c.req.json() is a
+      // bare JSON.parse. SyntaxError must be a caller 400, not the
+      // failureResponse 500 that treats it as an unexpected server fault.
+      return c.json({ success: false, error: "Invalid JSON body" }, 400);
+    }
     const validated = acceptInviteSchema.parse(body);
 
     const acceptedInvite = await invitesService.acceptInvite(


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Cloud fail-closed untrusted-input fix
on `POST /api/invites/accept` JSON. Not a twin of redemption quote, compat
agent-logs tail, first-run, notifications, BlueBubbles, login persist, billing,
or avatar.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. JSON-parse only on `POST /api/invites/accept`. Canonical `{ token }` still
accepts. Empty / unparseable bodies 400 before `invitesService.acceptInvite`.
No redemption quote, compat logs, first-run, notifications, BlueBubbles, login
persist, billing, or avatar change.

# Background

## What does this PR do?

Hono 4.13 `c.req.json()` is a bare `JSON.parse`. The handler catch mapped
`SyntaxError` through `failureResponse` to HTTP **500** ("An unexpected error
occurred") instead of a caller 400. Membership mutation must not run on
garbage.

- `{` / `not-json` / empty / whitespace → **400** `Invalid JSON body`
  before `acceptInvite`
- `{}` still 400 via zod `Validation error`
- `{ "token": "invite-token" }` still 200 and accepts

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A malformed invite-accept body was a server fault. Org-join is a Cloud
membership path; caller garbage must not 500 or reach `acceptInvite`.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/invites/accept/route.test.ts` — malformed bodies 400 with
`acceptInvite` uncalled; canonical token still 200.

## Detailed testing steps

```bash
cd packages/cloud/api && bun test invites/accept/route.test.ts
```

6 passed at head `0f1a1b468b4c52ca73675cc37df9da98ced87c59`.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; JSON parse only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; JSON parse only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; JSON parse only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real handler and assert 400 before `acceptInvite`; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, wallet, or generated-file writes in the 400 path.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal JSON 400s
before `acceptInvite`; canonical `{ token }` still 200.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file invite-accept JSON parse with
a green focused suite (6 tests). Full monorepo verify is unrelated to this
body grammar and was skipped to keep the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:0f1a1b468b4c52ca73675cc37df9da98ced87c59 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
