### PR TITLE
fix(ui): make Workflow event inspection accessible

### DIFF
--- a/packages/ui/src/components/pages/WorkflowEditor.test.tsx
+++ b/packages/ui/src/components/pages/WorkflowEditor.test.tsx
@@ -410,6 +410,11 @@ describe("WorkflowEditor", () => {
     render(<WorkflowEditor initial={workflow()} />);
     fireEvent.click(screen.getByRole("button", { name: "Runs" }));
     expect(await screen.findByText("Publish the release?")).toBeTruthy();
+    expect(
+      screen.queryByRole("button", {
+        name: "Inspect node.waiting-approval event",
+      }),
+    ).toBeNull();
     fireEvent.click(await screen.findByRole("button", { name: "Approve" }));
     await waitFor(() =>
       expect(api.decideWorkflowApproval).toHaveBeenCalledWith(
@@ -451,6 +456,7 @@ describe("WorkflowEditor", () => {
     const inspect = await screen.findByRole("button", {
       name: "Inspect NodeFinished event",
     });
+    expect(inspect.className).toContain("min-h-11");
     expect(screen.queryByText(/"result": "ready"/)).toBeNull();
     fireEvent.click(inspect);
     expect(await screen.findByText(/"result": "ready"/)).toBeTruthy();

--- a/packages/ui/src/components/pages/WorkflowEditor.tsx
+++ b/packages/ui/src/components/pages/WorkflowEditor.tsx
@@ -794,16 +794,31 @@ export function WorkflowEditor({
                             })}
                           </span>
                           <div className="min-w-0">
-                            <button
-                              type="button"
-                              disabled={!inspectable}
-                              className="flex w-full items-start gap-1 text-left disabled:cursor-default"
-                              aria-label={`Inspect ${event.type} event`}
-                              aria-expanded={inspectable ? selected : undefined}
-                              onClick={() =>
-                                setSelectedEventId(selected ? null : event.id)
-                              }
-                            >
+                            {inspectable ? (
+                              <button
+                                type="button"
+                                className="flex min-h-11 w-full items-start gap-1 text-left"
+                                aria-label={`Inspect ${event.type} event`}
+                                aria-expanded={selected}
+                                onClick={() =>
+                                  setSelectedEventId(selected ? null : event.id)
+                                }
+                              >
+                                <span className="min-w-0 flex-1">
+                                  <span className="block truncate font-medium">
+                                    {event.type}
+                                  </span>
+                                  {event.nodeId ? (
+                                    <span className="mt-0.5 block truncate text-muted-foreground">
+                                      {event.nodeId}
+                                    </span>
+                                  ) : null}
+                                </span>
+                                <ChevronRight
+                                  className={`mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform ${selected ? "rotate-90" : ""}`}
+                                />
+                              </button>
+                            ) : (
                               <span className="min-w-0 flex-1">
                                 <span className="block truncate font-medium">
                                   {event.type}
@@ -814,12 +829,7 @@ export function WorkflowEditor({
                                   </span>
                                 ) : null}
                               </span>
-                              {inspectable ? (
-                                <ChevronRight
-                                  className={`mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform ${selected ? "rotate-90" : ""}`}
-                                />
-                              ) : null}
-                            </button>
+                            )}
                             {selected ? (
                               <pre className="mt-2 max-h-56 overflow-auto rounded-lg bg-muted/40 p-2 text-[10px] leading-4">
                                 {pretty(event.payload)}


### PR DESCRIPTION
Closes #20810

## What changed

- renders payload-free workflow events as static timeline content instead of disabled inspector buttons
- gives inspectable event rows the repository-required 44px minimum activation target
- preserves keyboard-accessible on-demand payload expansion
- adds focused semantic and target-size regression coverage

## Verification

Exact head `f444ceb354d52b4b7a9e52c2cbbc6bcc0304dc6e`:

- `bun run verify` — 356/356 workspace tasks; repository audits green; anti-larp scanned 8,421 test files
- `bun run --cwd packages/ui test -- src/components/pages/WorkflowEditor.test.tsx` — 10/10
- `bun run --cwd packages/ui typecheck` — pass
- `bun run --cwd packages/ui lint` — pass; 8 unrelated existing cookie warnings
- `bun run --cwd packages/app audit:app` — 219/219 captures; broken=0, needs-work=0, minimalism/hover/density failures=0; OCR 216 views, broken=0
- the post-rebase patch ID is byte-equivalent to the fully audited pre-rebase commit

## Evidence matrix

| Evidence | Result |
| --- | --- |
| Desktop visual | Workflow Studio desktop capture green |
| Mobile visual | Workflow Studio portrait and landscape captures green |
| Tablet visual | Workflow Studio iPad portrait capture green |
| Interaction | Payload event toggles remain keyboard-accessible; empty payload events have static semantics |
| Console / overflow | Full app audit reports no broken or needs-work findings |
| Native/device | N/A — browser-owned Workflow Studio interaction |