### PR TITLE
fix(cloud): type analytics pagination mock

### DIFF
--- a/packages/cloud/api/v1/limit-clamp-batch3-hono.test.ts
+++ b/packages/cloud/api/v1/limit-clamp-batch3-hono.test.ts
@@ -9,6 +9,7 @@
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Hono } from "hono";
+import type { AppsService } from "@/lib/services/apps";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 mock.module("@/lib/api/cloud-worker-errors", () => ({
@@ -35,7 +36,15 @@ const ENV = { NODE_ENV: "test" } as unknown as AppEnv["Bindings"];
 const getById = mock(async (id: string) =>
   id === APP_ID ? { id: APP_ID, organization_id: ORG_A } : null,
 );
-const getRecentRequests = mock(async () => ({ requests: [], total: 0 }));
+type RecentRequestOptions = NonNullable<
+  Parameters<AppsService["getRecentRequests"]>[1]
+>;
+const getRecentRequests = mock(
+  async (_appId: string, _options: RecentRequestOptions) => ({
+    requests: [],
+    total: 0,
+  }),
+);
 const getTopVisitors = mock(async () => []);
 const getRequestsOverTime = mock(async () => []);
 const getRequestStats = mock(async () => ({}));


### PR DESCRIPTION
Closes #20824

## Summary

- type the analytics service mock with the real `AppsService.getRecentRequests` option contract
- preserve direct assertions on the route's limit/offset call arguments
- remove the zero-argument mock tuple that broke repository typecheck

## Verification

- `bun test packages/cloud/api/v1/limit-clamp-batch3-hono.test.ts` — 22 passed
- `bunx tsc --noEmit -p packages/cloud/api/tsconfig.json` — passed
- `bun run --cwd packages/cloud/api typecheck` — passed, including the production Worker dry-run
- `bun run --cwd packages/cloud/api lint:check` — 1,115 files passed
- `bun run verify` — cleared the cloud failure and reached 354/356 tasks; then exposed the independent clean-worktree homepage release-data ordering race tracked in #20828

## Sync with develop

- Rebases cleanly on `a0c6aeab5bb8c3c8ed11e92282a4fbccfa4e5a40`.

## Risk

Low. Test typing only; route runtime code is unchanged. The type is derived from the service contract so future signature changes remain visible to the test.

## Evidence Gate

- Before screenshots: N/A - no UI change.
- After screenshots: N/A - no UI change.
- Walkthrough video: N/A - no UI flow change.
- Backend logs: N/A - test-harness typing only.
- Frontend logs: N/A - no frontend runtime change.
- LLM trajectory: N/A - no agent/model behavior change.
- Domain artifacts: N/A - the 22 passing request/argument assertions are the applicable artifact.
- OCR review: N/A - no rendered surface changed.

## Contribution provenance

- AI assistance: `yes`
- Model(s) used: `OpenAI/gpt-5`
- Agent tooling: `Codex desktop`
- Skill path: `N/A - no contribution skill used`
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@6c50755826ac5b1e4947d3e46ba262f2c53f8347:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-workflows]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex desktop","skill_revision":"elizaOS/eliza@6c50755826ac5b1e4947d3e46ba262f2c53f8347:packages/skills/skills/contribute-to-eliza"} -->
