### PR TITLE
fix(wallet): promote viem declaration compatibility

### DIFF
--- a/plugins/plugin-wallet/src/sdk/wallet-core.ts
+++ b/plugins/plugin-wallet/src/sdk/wallet-core.ts
@@ -9,9 +9,11 @@ import {
   type Address,
   type Chain,
   createPublicClient,
+  type GetContractReturnType,
   getContract,
   type Hash,
   http,
+  type PublicClient,
   type WalletClient,
   zeroAddress,
 } from "viem";
@@ -39,12 +41,24 @@ export function requireWalletAccount(client: WalletClient) {
 /** Native ETH token address (zero address) */
 export const NATIVE_TOKEN: Address = zeroAddress;
 
+/** Portable public shape returned by {@link createWallet}. */
+export interface AgentWallet {
+  address: Address;
+  contract: GetContractReturnType<
+    typeof AgentAccountV2Abi,
+    { public: PublicClient; wallet: WalletClient }
+  >;
+  publicClient: PublicClient;
+  walletClient: WalletClient;
+  chain: Chain;
+}
+
 /**
  * Create a wallet client connected to an existing AgentAccountV2.
  */
 export function createWallet(
   config: AgentWalletConfig & { walletClient: WalletClient },
-) {
+): AgentWallet {
   const chain = CHAINS[config.chain];
   if (!chain) throw new Error(`Unsupported chain: ${config.chain}`);
 
@@ -67,8 +81,6 @@ export function createWallet(
     chain,
   };
 }
-
-export type AgentWallet = ReturnType<typeof createWallet>;
 
 /**
  * Set a spend policy for a token. Only callable by the NFT owner.


### PR DESCRIPTION
# Relates to

- Security remediation PR #20801
- Supersedes the closed duplicate follow-up PR #20823
- Private advisory GHSA-38ww-x42w-xqr6
- Source fix already merged to `develop` as `08b71e80793`.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This is a narrow promotion PR targeting `main`; the source fix is already on `develop`, and the branch is based on the latest `origin/main` with zero conflicts.
- [x] The pinned Bun 1.3.14 install is present and focused validation plus `build:core` pass. The unrelated root `verify` blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code from the before/after compiler result and command evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] The exact source change is already merged to `develop` as `08b71e80793`; this promotion cherry-picks it onto current `main` with zero conflicts.
- [x] Focused validation and the canonical `build:core` pass. The unrelated root `verify` blocker is documented in **Known gaps / failures**.

# Risks

Low. This only replaces an inferred exported return type with an explicit interface composed from public viem types. Runtime behavior and emitted JavaScript are unchanged. The affected surface is wallet SDK TypeScript declarations.

# Background

## What does this PR do?

Promotes the wallet declaration compatibility fix already merged to `develop`. The dependency security upgrade in #20801 moved viem to 2.55.17; on `main`, declaration generation then failed with TS2883 because `createWallet` inferred a type containing viem-internal token action modules. This change gives `createWallet` a stable public `AgentWallet` return type.

Before: `bun run build:core` stopped in `@elizaos/plugin-wallet` with TS2883.

After: `bun run build:core` completes all 59 tasks, including wallet Node/browser bundles, declarations, UI types, and views.

## What kind of change is this?

Bug fix (non-breaking declaration compatibility fix).

# Documentation changes needed?

No. The public runtime behavior is unchanged and the interface is self-describing.

# Testing

## Where should a reviewer start?

Run the canonical core build on this PR head and confirm `@elizaos/plugin-wallet` declaration generation succeeds.

## Detailed testing steps

Using pinned Bun 1.3.14:

```text
bun run build:core
# 59 successful, 59 total

bun run --cwd plugins/plugin-wallet typecheck
# passed

bun run --cwd plugins/plugin-wallet lint:check
# checked 284 files, passed

bun run --cwd plugins/plugin-wallet test
# 48 files passed, 1 skipped; 294 tests passed, 1 skipped

bun audit --audit-level=critical
# exit 0

git diff --check
# passed
```

# Evidence Gate

<!-- evidence-head:a9a80801ed1d940a81a456847b6af02f96264232 -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - declaration-only TypeScript change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - declaration-only TypeScript change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user flow or visual behavior changes.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime behavior changes; compiler/build output is the real affected path.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime behavior changes.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, action, provider, prompt, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no wallet transaction or on-chain behavior changes; only generated declaration portability is affected.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface changes.

# Evidence Details

## Real LLM-call trajectory

N/A - no model path changes.

## Backend + frontend logs

N/A - no runtime paths changed. The affected declaration build and focused test results are recorded above.

## Screenshots (before / after) + video walkthrough

N/A - no UI change.

## Audio / voice walkthrough

N/A - no audio or voice change.

## Known gaps / failures

`bun run verify` was attempted during the source-fix validation on current `develop` and reached an unrelated pre-existing TypeScript failure in `packages/cloud/api/v1/limit-clamp-batch3-hono.test.ts` (TS2532/TS2493). This one-file promotion was instead validated on clean `main` with the canonical `build:core`, wallet build/typecheck/lint/full test suite, critical dependency audit, and `git diff --check`; all pass.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported
— [security-agent]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no contribution skill used"} -->
