### PR TITLE
fix(cloud): restore limit clamp test typecheck

### DIFF
--- a/packages/cloud/api/v1/limit-clamp-batch3-hono.test.ts
+++ b/packages/cloud/api/v1/limit-clamp-batch3-hono.test.ts
@@ -35,7 +35,19 @@ const ENV = { NODE_ENV: "test" } as unknown as AppEnv["Bindings"];
 const getById = mock(async (id: string) =>
   id === APP_ID ? { id: APP_ID, organization_id: ORG_A } : null,
 );
-const getRecentRequests = mock(async () => ({ requests: [], total: 0 }));
+const getRecentRequests = mock(
+  async (
+    _appId: string,
+    _options?: {
+      limit?: number;
+      offset?: number;
+      requestType?: string;
+      source?: string;
+      startDate?: Date;
+      endDate?: Date;
+    },
+  ) => ({ requests: [], total: 0 }),
+);
 const getTopVisitors = mock(async () => []);
 const getRequestsOverTime = mock(async () => []);
 const getRequestStats = mock(async () => ({}));
@@ -173,8 +185,10 @@ describe("apps analytics requests — strict limit (50, max 100) + offset (0)", 
       ENV,
     );
     expect(res.status).toBe(200);
-    expect(getRecentRequests.mock.calls[0][1].limit).toBe(50);
-    expect(getRecentRequests.mock.calls[0][1].offset).toBe(10);
+    expect(getRecentRequests).toHaveBeenCalledWith(
+      APP_ID,
+      expect.objectContaining({ limit: 50, offset: 10 }),
+    );
   });
   test("missing → 50,0", async () => {
     const res = await buildAnalyticsApp().request(
@@ -183,8 +197,10 @@ describe("apps analytics requests — strict limit (50, max 100) + offset (0)", 
       ENV,
     );
     expect(res.status).toBe(200);
-    expect(getRecentRequests.mock.calls[0][1].limit).toBe(50);
-    expect(getRecentRequests.mock.calls[0][1].offset).toBe(0);
+    expect(getRecentRequests).toHaveBeenCalledWith(
+      APP_ID,
+      expect.objectContaining({ limit: 50, offset: 0 }),
+    );
   });
   test('"5junk" limit → 50', async () => {
     const res = await buildAnalyticsApp().request(
@@ -193,7 +209,10 @@ describe("apps analytics requests — strict limit (50, max 100) + offset (0)", 
       ENV,
     );
     expect(res.status).toBe(200);
-    expect(getRecentRequests.mock.calls[0][1].limit).toBe(50);
+    expect(getRecentRequests).toHaveBeenCalledWith(
+      APP_ID,
+      expect.objectContaining({ limit: 50 }),
+    );
   });
   test('"1e4" limit → 50', async () => {
     const res = await buildAnalyticsApp().request(
@@ -202,7 +221,10 @@ describe("apps analytics requests — strict limit (50, max 100) + offset (0)", 
       ENV,
     );
     expect(res.status).toBe(200);
-    expect(getRecentRequests.mock.calls[0][1].limit).toBe(50);
+    expect(getRecentRequests).toHaveBeenCalledWith(
+      APP_ID,
+      expect.objectContaining({ limit: 50 }),
+    );
   });
   test('"5.5" limit → 50', async () => {
     const res = await buildAnalyticsApp().request(
@@ -211,7 +233,10 @@ describe("apps analytics requests — strict limit (50, max 100) + offset (0)", 
       ENV,
     );
     expect(res.status).toBe(200);
-    expect(getRecentRequests.mock.calls[0][1].limit).toBe(50);
+    expect(getRecentRequests).toHaveBeenCalledWith(
+      APP_ID,
+      expect.objectContaining({ limit: 50 }),
+    );
   });
   test('"0" limit → 50', async () => {
     const res = await buildAnalyticsApp().request(
@@ -220,7 +245,10 @@ describe("apps analytics requests — strict limit (50, max 100) + offset (0)", 
       ENV,
     );
     expect(res.status).toBe(200);
-    expect(getRecentRequests.mock.calls[0][1].limit).toBe(50);
+    expect(getRecentRequests).toHaveBeenCalledWith(
+      APP_ID,
+      expect.objectContaining({ limit: 50 }),
+    );
   });
   test("999 → 100 (clamped)", async () => {
     const res = await buildAnalyticsApp().request(
@@ -229,7 +257,10 @@ describe("apps analytics requests — strict limit (50, max 100) + offset (0)", 
       ENV,
     );
     expect(res.status).toBe(200);
-    expect(getRecentRequests.mock.calls[0][1].limit).toBe(100);
+    expect(getRecentRequests).toHaveBeenCalledWith(
+      APP_ID,
+      expect.objectContaining({ limit: 100 }),
+    );
   });
   test('"5junk" offset → 0', async () => {
     const res = await buildAnalyticsApp().request(
@@ -238,7 +269,10 @@ describe("apps analytics requests — strict limit (50, max 100) + offset (0)", 
       ENV,
     );
     expect(res.status).toBe(200);
-    expect(getRecentRequests.mock.calls[0][1].offset).toBe(0);
+    expect(getRecentRequests).toHaveBeenCalledWith(
+      APP_ID,
+      expect.objectContaining({ offset: 0 }),
+    );
   });
   test('"1e4" offset → 0', async () => {
     const res = await buildAnalyticsApp().request(
@@ -247,7 +281,10 @@ describe("apps analytics requests — strict limit (50, max 100) + offset (0)", 
       ENV,
     );
     expect(res.status).toBe(200);
-    expect(getRecentRequests.mock.calls[0][1].offset).toBe(0);
+    expect(getRecentRequests).toHaveBeenCalledWith(
+      APP_ID,
+      expect.objectContaining({ offset: 0 }),
+    );
   });
   test("valid offset 20 → 20", async () => {
     const res = await buildAnalyticsApp().request(
@@ -256,6 +293,9 @@ describe("apps analytics requests — strict limit (50, max 100) + offset (0)", 
       ENV,
     );
     expect(res.status).toBe(200);
-    expect(getRecentRequests.mock.calls[0][1].offset).toBe(20);
+    expect(getRecentRequests).toHaveBeenCalledWith(
+      APP_ID,
+      expect.objectContaining({ offset: 20 }),
+    );
   });
 });


### PR DESCRIPTION
Closes #20824

## What changed

The Cloud limit-clamp HTTP tests now give the `getRecentRequests` mock its real two-argument contract and assert calls with `toHaveBeenCalledWith` plus `objectContaining`. This preserves the route behavior checks without unsafe indexing into a tuple TypeScript inferred as zero-length.

## Exact-head verification

Head: `917c3356a5179273db59f6a74912ad895bfd1e5a`

- `bun test packages/cloud/api/v1/limit-clamp-batch3-hono.test.ts`: 22 passed
- Cloud API typecheck and Worker dry-run bundle: passed
- `bun run verify`: 356/356 tasks passed
- Anti-larp scan: 8,421 test files; 0 focused and 0 orphaned skips

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - test-only TypeScript repair; no rendered UI.
<!-- evidence-row:after-screenshots -->
- [x] N/A - test-only TypeScript repair; no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interaction changed.
<!-- evidence-row:backend-logs -->
- [x] [20831-prereq20824-focused-exact.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20831-prereq20824-focused-exact.log)
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database or generated artifact changed.
<!-- evidence-row:ocr-review -->
- [x] N/A - no visual surface changed.

## Risk

Low. Production code is unchanged; the repair only aligns a deterministic test mock with the service signature already invoked by the route.

## Contribution provenance

- AI assistance: yes
- Model: OpenAI GPT-5.4
- Agent tooling: Codex desktop
- Provenance status: self-reported

<!-- evidence-head:917c3356a5179273db59f6a74912ad895bfd1e5a -->

