### PR TITLE
fix(app): generate homepage data before typecheck

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -12,7 +12,7 @@
     "format": "bunx @biomejs/biome format --write src scripts",
     "format:check": "bunx @biomejs/biome format src scripts",
     "clean": "node ../scripts/rm-path-recursive.mjs dist .turbo",
-    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
+    "typecheck": "node ../app-core/scripts/write-homepage-release-data.mjs && tsc --noEmit -p tsconfig.typecheck.json",
     "test": "bun test scripts && vitest run --config vitest.config.ts",
     "trace:startup": "node scripts/capture-startup-trace.mjs",
     "perf:startup-budget": "node scripts/check-startup-budget.mjs",


### PR DESCRIPTION
Closes #20828

## Summary

Generate the ignored homepage release-data module before the app TypeScript project compiles. This removes the clean-worktree race where app and homepage typechecks run concurrently and app sometimes sees no `@/generated/release-data` module.

## Verification

- Deleted `packages/homepage/src/generated/release-data.ts`, then ran `bun run --cwd packages/app typecheck` — regenerated the fallback/release module and passed.
- Deleted the generated module again, then ran `bun run verify` — 356/356 workspace tasks passed.
- Final anti-larp audit — 8,423 test files scanned; 0 focused and 0 orphaned skips.
- Generated release data remains ignored and is not included in this PR.

## Sync with develop

- Rebased onto `ccb9f03ddeac4700bae90532ce94a98dcb602f7e` before final verification.

## Risk

Low. The app typecheck now performs the same prerequisite generation already used by app predev/prebuild and homepage typecheck. When GitHub is rate-limited, the existing generator writes or retains its deterministic fallback before TypeScript starts.

## Evidence Gate

- Before/after screenshots: N/A - build ordering only; no rendered UI change.
- Walkthrough video: N/A - no user interaction changed.
- Backend/frontend logs: N/A - compile prerequisite only.
- LLM trajectory: N/A - no agent/model behavior change.
- Domain artifact: ignored `release-data.ts` was recreated before successful cold app and root typechecks.
- OCR review: N/A - no rendered surface changed.

## Contribution provenance

- AI assistance: `yes`
- Model(s) used: `OpenAI/gpt-5`
- Agent tooling: `Codex desktop`
- Skill path: `N/A - no contribution skill used`
- Provenance status: `self-reported`

AI provider/model: OpenAI / gpt-5
Client / agent tooling: Codex desktop
Contribution skill revision: elizaOS/eliza@2bd88d916eb8d841f30aa5d763a782777da54298:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [codex-workflows]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex desktop","skill_revision":"elizaOS/eliza@2bd88d916eb8d841f30aa5d763a782777da54298:packages/skills/skills/contribute-to-eliza"} -->
