### PR TITLE
fix(plugin-workflow): 400 malformed percent-encoded path segments

### DIFF
--- a/plugins/plugin-workflow/__tests__/unit/workflow-routes.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow-routes.test.ts
@@ -55,6 +55,14 @@ describe('native workflow routes', () => {
                 calls.push('getExecutionDetail');
                 return {};
               },
+              decideApproval: async () => {
+                calls.push('decideApproval');
+                return {};
+              },
+              signalExecution: async () => {
+                calls.push('signalExecution');
+                return {};
+              },
               getWorkflowExecutions: async () => {
                 calls.push('getWorkflowExecutions');
                 return [];
@@ -67,19 +75,44 @@ describe('native workflow routes', () => {
           : null,
     } as unknown as AgentRuntime;
 
-    for (const pathname of [
-      '/api/workflow/workflows/%',
-      '/api/workflow/executions/%',
-      '/api/workflow/workflows/%2',
-      '/api/workflow/executions/%ZZ',
+    for (const { method, pathname, body: requestBody } of [
+      { method: 'GET', pathname: '/api/workflow/workflows/%' },
+      { method: 'GET', pathname: '/api/workflow/executions/%' },
+      { method: 'GET', pathname: '/api/workflow/workflows/%2' },
+      { method: 'GET', pathname: '/api/workflow/executions/%ZZ' },
+      {
+        method: 'POST',
+        pathname: '/api/workflow/executions/run%/approvals/node/1',
+        body: { approved: true },
+      },
+      {
+        method: 'POST',
+        pathname: '/api/workflow/executions/run/approvals/node%/1',
+        body: { approved: true },
+      },
+      {
+        method: 'POST',
+        pathname: '/api/workflow/executions/run%/signals/resume',
+        body: {},
+      },
+      {
+        method: 'POST',
+        pathname: '/api/workflow/executions/run/signals/resume%',
+        body: {},
+      },
+      {
+        method: 'POST',
+        pathname: '/api/workflow/workflows/workflow/revisions/revision%/restore',
+        body: {},
+      },
     ]) {
       calls.length = 0;
       let status: number | undefined;
       let body: unknown;
       await handleWorkflowRoutes({
-        req: {} as http.IncomingMessage,
+        req: { body: requestBody } as http.IncomingMessage,
         res: {} as http.ServerResponse,
-        method: 'GET',
+        method,
         pathname,
         runtime,
         principalId: 'owner',

--- a/plugins/plugin-workflow/__tests__/unit/workflow-routes.test.ts
+++ b/plugins/plugin-workflow/__tests__/unit/workflow-routes.test.ts
@@ -39,4 +39,97 @@ describe('native workflow routes', () => {
       engine: 'smthrs',
     });
   });
+
+  test('rejects illegal percent-encoding in workflow and execution ids before service calls', async () => {
+    const calls: string[] = [];
+    const runtime = {
+      agentId: '00000000-0000-4000-8000-000000000001',
+      getService: (type: string) =>
+        type === WORKFLOW_SERVICE_TYPE || type === EMBEDDED_WORKFLOW_SERVICE_TYPE
+          ? {
+              getWorkflow: async () => {
+                calls.push('getWorkflow');
+                return {};
+              },
+              getExecutionDetail: async () => {
+                calls.push('getExecutionDetail');
+                return {};
+              },
+              getWorkflowExecutions: async () => {
+                calls.push('getWorkflowExecutions');
+                return [];
+              },
+              restoreWorkflowRevision: async () => {
+                calls.push('restoreWorkflowRevision');
+                return {};
+              },
+            }
+          : null,
+    } as unknown as AgentRuntime;
+
+    for (const pathname of [
+      '/api/workflow/workflows/%',
+      '/api/workflow/executions/%',
+      '/api/workflow/workflows/%2',
+      '/api/workflow/executions/%ZZ',
+    ]) {
+      calls.length = 0;
+      let status: number | undefined;
+      let body: unknown;
+      await handleWorkflowRoutes({
+        req: {} as http.IncomingMessage,
+        res: {} as http.ServerResponse,
+        method: 'GET',
+        pathname,
+        runtime,
+        principalId: 'owner',
+        json: (_res, payload, code) => {
+          body = payload;
+          status = code;
+        },
+      });
+      expect(status).toBe(400);
+      expect(body).toEqual({
+        error: 'Path segment is not valid percent-encoding',
+      });
+      expect(calls).toEqual([]);
+    }
+  });
+
+  test('still loads a canonically encoded workflow id', async () => {
+    const seen: string[] = [];
+    const runtime = {
+      agentId: '00000000-0000-4000-8000-000000000001',
+      getService: (type: string) =>
+        type === WORKFLOW_SERVICE_TYPE
+          ? {
+              getWorkflow: async (id: string) => {
+                seen.push(id);
+                return { id };
+              },
+            }
+          : type === EMBEDDED_WORKFLOW_SERVICE_TYPE
+            ? {}
+            : null,
+    } as unknown as AgentRuntime;
+
+    let status: number | undefined;
+    let body: unknown;
+    await handleWorkflowRoutes({
+      req: {} as http.IncomingMessage,
+      res: {} as http.ServerResponse,
+      method: 'GET',
+      pathname: '/api/workflow/workflows/wf%2Dprod',
+      runtime,
+      principalId: 'owner',
+      json: (_res, payload, code) => {
+        body = payload;
+        status = code;
+      },
+    });
+
+    expect(status).toBeUndefined();
+    expect(seen).toEqual(['wf-prod']);
+    expect(body).toEqual({ id: 'wf-prod' });
+  });
 });

--- a/plugins/plugin-workflow/src/routes/workflow-routes.ts
+++ b/plugins/plugin-workflow/src/routes/workflow-routes.ts
@@ -62,6 +62,14 @@ function pathFor(pathname: string): string {
   return pathname.replace(/^\/api\/workflow/, '') || '/';
 }
 
+function decodePathSegment(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    throw new WorkflowApiError('Path segment is not valid percent-encoding', 400);
+  }
+}
+
 async function readBody(
   req: http.IncomingMessage,
   limit = 2_000_000
@@ -100,7 +108,7 @@ function workflowFrom(body: Record<string, unknown>): WorkflowDefinition {
 
 function idMatch(path: string): { id: string; suffix: string } | null {
   const match = /^\/workflows\/([^/]+)(.*)$/.exec(path);
-  return match ? { id: decodeURIComponent(match[1]), suffix: match[2] || '' } : null;
+  return match ? { id: decodePathSegment(match[1]), suffix: match[2] || '' } : null;
 }
 
 async function streamEvents(
@@ -168,7 +176,7 @@ export async function handleWorkflowRoutes(ctx: WorkflowRouteContext): Promise<v
     }
     const executionMatch = /^\/executions\/([^/]+)(?:\/(events|cancel))?$/.exec(path);
     if (executionMatch) {
-      const runId = decodeURIComponent(executionMatch[1]);
+      const runId = decodePathSegment(executionMatch[1]);
       const operation = executionMatch[2];
       if (ctx.method === 'GET' && operation === 'events') return streamEvents(ctx, runId, owner);
       if (ctx.method === 'POST' && operation === 'cancel') {
@@ -190,8 +198,8 @@ export async function handleWorkflowRoutes(ctx: WorkflowRouteContext): Promise<v
         ctx.res,
         {
           execution: await service.decideApproval(
-            decodeURIComponent(approvalMatch[1]),
-            decodeURIComponent(approvalMatch[2]),
+            decodePathSegment(approvalMatch[1]),
+            decodePathSegment(approvalMatch[2]),
             Number(approvalMatch[3]),
             body.approved,
             {
@@ -212,8 +220,8 @@ export async function handleWorkflowRoutes(ctx: WorkflowRouteContext): Promise<v
         ctx.res,
         {
           execution: await service.signalExecution(
-            decodeURIComponent(signalMatch[1]),
-            decodeURIComponent(signalMatch[2]),
+            decodePathSegment(signalMatch[1]),
+            decodePathSegment(signalMatch[2]),
             body.payload,
             owner
           ),
@@ -275,7 +283,7 @@ export async function handleWorkflowRoutes(ctx: WorkflowRouteContext): Promise<v
     if (ctx.method === 'POST' && restore) {
       ctx.json(
         ctx.res,
-        await service.restoreWorkflowRevision(match.id, decodeURIComponent(restore[1]), owner)
+        await service.restoreWorkflowRevision(match.id, decodePathSegment(restore[1]), owner)
       );
       return;
     }

--- a/plugins/plugin-workflow/src/routes/workflow-routes.ts
+++ b/plugins/plugin-workflow/src/routes/workflow-routes.ts
@@ -66,6 +66,7 @@ function decodePathSegment(raw: string): string {
   try {
     return decodeURIComponent(raw);
   } catch {
+    // error-policy:J3 malformed path segments become an explicit 400 response.
     throw new WorkflowApiError('Path segment is not valid percent-encoding', 400);
   }
 }


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on native workflow path segments.
Not a twin of orchestrator `lines=`, provisioning-worker env ints,
invites-accept, cli-auth, redemption quote, compat agent-logs, first-run,
notifications, BlueBubbles, login persist, billing, or avatar. Does not edit
avatar routes or plugin-wechat.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only in `plugin-workflow` HTTP router. Canonical
`wf%2Dprod` still loads as `wf-prod`. Malformed `%` / `%2` / `%ZZ` become 400
instead of an uncaught `URIError` 500. Existing JSON body 400 is unchanged.

# Background

## What does this PR do?

`handleWorkflowRoutes` called `decodeURIComponent` on workflow, execution,
approval, signal, and restore path segments. Illegal percent-encoding throws
`URIError`, which the router mapped to 500.

- `/api/workflow/workflows/%` / `executions/%` / `%2` / `%ZZ` → **400**, no service call
- `/api/workflow/workflows/wf%2Dprod` → still loads `wf-prod`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded workflow id should get a
request error, not a 500 that looks like a Smithers outage.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-workflow/__tests__/unit/workflow-routes.test.ts` — illegal
percent-encoding table and the canonical `wf%2Dprod` load.

## Detailed testing steps

```bash
bun test --config=/tmp/eliza-bunfig-nocov.toml plugins/plugin-workflow/__tests__/unit/workflow-routes.test.ts
```

3 passed at head `f7837e0f3d3d214e412eba9aa8ba4ed2bff12e84`. Coverage is
disabled in that bunfig because the default repo `coverage = true` walks
`@elizaos/core` dist and the coverage writer can `WriteFailed` after a green
suite.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; native workflow HTTP router only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; native workflow HTTP router only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; native workflow HTTP router only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused bun tests drive handleWorkflowRoutes and assert 400 vs service-call skip; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, wallet, or generated-file writes in the decode path.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: malformed
percent-encoding returns 400 with zero service calls; `wf%2Dprod` still loads.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file workflow router decode with a
green focused suite (3 tests). Full monorepo verify is unrelated to this
percent-encoding boundary and was skipped to keep the proof tied to the
changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:f7837e0f3d3d214e412eba9aa8ba4ed2bff12e84 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
