### PR TITLE
fix(app): write generated homepage release data atomically

### DIFF
--- a/packages/app-core/scripts/write-homepage-release-data.mjs
+++ b/packages/app-core/scripts/write-homepage-release-data.mjs
@@ -5,9 +5,9 @@
  * image manifest entries, and install-script URLs for the download surface.
  */
 
-import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { buildRawGitHubAssetBase } from "./lib/asset-cdn.mjs";
@@ -817,21 +817,12 @@ async function fetchReleases(url = RELEASES_URL) {
 
 async function writePayload(payload) {
   await mkdir(path.dirname(OUTPUT_PATH), { recursive: true });
-  await writeFile(OUTPUT_PATH, toModule(payload));
-  // Best-effort biome format; biome.json may exclude `src/generated/`, in which
-  // case biome exits non-zero. The generated file is JSON.stringify output and
-  // doesn't need formatting to be correct, so failures here are not fatal.
-  const relOutput = path.relative(REPO_ROOT, OUTPUT_PATH);
-  const biomeArgs = ["@biomejs/biome", "format", "--write", relOutput];
-  const bunx = process.platform === "win32" ? "bunx.cmd" : "bunx";
+  const temporaryPath = `${OUTPUT_PATH}.${process.pid}.${randomUUID()}.tmp`;
   try {
-    execFileSync(bunx, biomeArgs, {
-      stdio: "ignore",
-      cwd: REPO_ROOT,
-      shell: false,
-    });
-  } catch {
-    // Ignore — the file is still valid TypeScript without biome's pass.
+    await writeFile(temporaryPath, toModule(payload));
+    await rename(temporaryPath, OUTPUT_PATH);
+  } finally {
+    await rm(temporaryPath, { force: true });
   }
 }
 


### PR DESCRIPTION
Follow-up to #20834 and #20828.

The app and homepage typecheck tasks now both invoke the release-data generator. The merged fix removed the missing-file ordering race, but both generators could still truncate and rewrite the same ignored TypeScript module in place while the other task compiled it.

This writes the fully serialized module to a unique same-directory temporary file and atomically renames it into place. The previous best-effort Biome subprocess was removed because the generated JSON-stringified module is already deterministic and the generated directory is excluded from formatting.

Verification at exact head `594141f2683849ad500d11089cad3bde923a02af`:
- two concurrent cold-file generator processes completed successfully
- `bun run --cwd packages/app typecheck` passed
- `bun run --cwd packages/homepage typecheck` passed
- release-selection tests: 20/20
- `bun run verify`: 356/356 tasks; anti-larp 8,426 files, 0 focused, 0 orphaned skips

No rendered UI behavior changed; screenshots/video are N/A. No generated artifact is committed.

AI assistance: OpenAI/gpt-5 via Codex desktop. Provenance self-reported.