### PR TITLE
feat(cloud): wire P3 semantic recall through the shared turn (flags off)

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.recall-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.recall-context.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Pins the P3 recall-context contract on the shared turn: a caller-provided
+ * `recallContext` is appended to the system prompt the model receives, and an
+ * absent one leaves the prompt untouched. The `ai` SDK and language-model
+ * router are stubbed; the capture is the real `system` argument.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+let capturedSystem: string | undefined;
+
+mock.module("../../providers/language-model", () => ({
+  getInteractiveCerebrasLanguageModel: () => ({ modelId: "stub" }),
+  hasLanguageModelProviderConfigured: () => true,
+}));
+
+mock.module("ai", () => ({
+  generateText: async (options: { system?: string }) => {
+    capturedSystem = options.system;
+    return { text: "reply", usage: { totalTokens: 2 } };
+  },
+  streamText: () => {
+    throw new Error("stream path not under test");
+  },
+}));
+
+const { runSharedAgentTurn } = await import("./run-shared-agent-turn");
+
+const character = { name: "Recall Probe", system: "Base persona." };
+
+describe("shared turn recall context", () => {
+  test("appends the recall block to the system prompt", async () => {
+    capturedSystem = undefined;
+    const block = "Recalled from earlier in this conversation:\n- [user] pick blue";
+    await runSharedAgentTurn({
+      character,
+      history: [],
+      message: "which color did I pick?",
+      recallContext: block,
+    });
+    expect(capturedSystem).toBeDefined();
+    expect(capturedSystem?.endsWith(block)).toBe(true);
+    expect(capturedSystem?.startsWith("Base persona.")).toBe(true);
+  });
+
+  test("leaves the system prompt untouched without recall", async () => {
+    capturedSystem = undefined;
+    await runSharedAgentTurn({
+      character,
+      history: [],
+      message: "hello",
+    });
+    expect(capturedSystem).toBeDefined();
+    expect(capturedSystem).not.toContain("Recalled from earlier");
+  });
+});

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -90,6 +90,13 @@ export interface RunSharedAgentTurnInput {
    */
   memory?: SharedMemoryStore;
   /**
+   * Pre-rendered semantic-recall block (P3, `buildSharedRecallContext`) the
+   * caller computed from the tenant memory store when the recall flag is on
+   * and the recent window missed. Appended verbatim to the system prompt on
+   * every engine path; absent means recall contributed nothing this turn.
+   */
+  recallContext?: string;
+  /**
    * Transition-only selector for the genuine Workerd AgentRuntime path. The
    * direct model path remains the control until the runtime path has passed
    * live model and connector proof.
@@ -239,6 +246,7 @@ export function resolveSharedAgentTurnModel(preferred?: string): string | null {
 function buildSystemPrompt(
   character: SharedAgentCharacter,
   capabilities: { reminders: boolean; todos: boolean },
+  recallContext?: string,
 ): string {
   const parts: string[] = [];
   const system = replaceNameTokens(character.system ?? "", character.name).trim();
@@ -265,6 +273,7 @@ function buildSystemPrompt(
       "- Never claim that you performed, scheduled, sent, booked, bought, saved, opened, or changed anything unless a registered action returned a successful result for that exact effect.\n" +
       "- When an ambiguous follow-up asks you to execute a prior external action, state that the action needs Dedicated and offer the useful planning or drafting help you can provide here.",
   );
+  if (recallContext?.trim()) parts.push(recallContext.trim());
   return parts.join("\n\n") || `You are ${character.name}, a helpful assistant.`;
 }
 
@@ -432,10 +441,14 @@ export async function runSharedAgentTurn(
       ...input,
       character: {
         ...input.character,
-        system: buildSystemPrompt(input.character, {
-          reminders: remindersEnabled,
-          todos: todosEnabled,
-        }),
+        system: buildSystemPrompt(
+          input.character,
+          {
+            reminders: remindersEnabled,
+            todos: todosEnabled,
+          },
+          input.recallContext,
+        ),
       },
       agentKey: input.execution.agentKey,
       model: modelId,
@@ -448,10 +461,14 @@ export async function runSharedAgentTurn(
   let turn: RunSharedAgentTurnResult;
   try {
     const model = getInteractiveCerebrasLanguageModel(modelId);
-    const system = buildSystemPrompt(input.character, {
-      reminders: remindersEnabled,
-      todos: todosEnabled,
-    });
+    const system = buildSystemPrompt(
+      input.character,
+      {
+        reminders: remindersEnabled,
+        todos: todosEnabled,
+      },
+      input.recallContext,
+    );
     const messages = [
       ...input.history.map((m) => ({ role: m.role, content: modelHistoryContent(m) })),
       { role: input.messageRole ?? ("user" as const), content: message },
@@ -561,10 +578,14 @@ export async function runSharedAgentTurnStream(
         ...input,
         character: {
           ...input.character,
-          system: buildSystemPrompt(input.character, {
-            reminders: remindersEnabled,
-            todos: todosEnabled,
-          }),
+          system: buildSystemPrompt(
+            input.character,
+            {
+              reminders: remindersEnabled,
+              todos: todosEnabled,
+            },
+            input.recallContext,
+          ),
         },
         agentKey: input.execution.agentKey,
         model: modelId,
@@ -575,10 +596,14 @@ export async function runSharedAgentTurnStream(
 
   try {
     const model = getInteractiveCerebrasLanguageModel(modelId);
-    const system = buildSystemPrompt(input.character, {
-      reminders: remindersEnabled,
-      todos: todosEnabled,
-    });
+    const system = buildSystemPrompt(
+      input.character,
+      {
+        reminders: remindersEnabled,
+        todos: todosEnabled,
+      },
+      input.recallContext,
+    );
     const messages = [
       ...input.history.map((m) => ({ role: m.role, content: modelHistoryContent(m) })),
       { role: input.messageRole ?? ("user" as const), content: message },

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-memory-store.ts
@@ -11,9 +11,13 @@
 
 import { stringToUuid, validateUuid } from "@elizaos/core/edge";
 import {
+  type SharedAgentMemoriesReader,
   type SharedAgentMemoriesWriter,
+  type SharedAgentMemorySearchHit,
+  sharedAgentMemoriesReader,
   sharedAgentMemoriesWriter,
 } from "../../../db/repositories/shared-agent-memories";
+import { logger } from "../../utils/logger";
 import {
   type SharedTodoStorageScope,
   sharedRuntimeConversationRoomId,
@@ -54,11 +58,45 @@ function memoryRowId(transportId: string): string {
   return validateUuid(transportId) ?? stringToUuid(transportId);
 }
 
+/**
+ * Write-side embedder config: batch-embeds a turn pair's texts in ONE sidecar
+ * call so recall's `isNotNull(embedding)` window actually fills. Injected by
+ * the caller only while recall is enabled; absent means rows land without
+ * vectors (tables-only mode stays free of sidecar traffic).
+ */
+export interface SharedMemoryEmbedConfig {
+  embedTexts: (texts: string[]) => Promise<number[][]>;
+  model: string;
+}
+
 export class SharedMemoryStore {
   constructor(
     private readonly scope: SharedMemoryStoreScope,
     private readonly writer: SharedAgentMemoriesWriter = sharedAgentMemoriesWriter,
+    private readonly reader: SharedAgentMemoriesReader = sharedAgentMemoriesReader,
+    private readonly embed?: SharedMemoryEmbedConfig,
   ) {}
+
+  /**
+   * Tenant-scoped vector search over this store's transcript rows (P3 recall's
+   * store leg). Scope pinning mirrors recordTurnPair exactly — the same
+   * organization/user/agent triple — so recall can never read across tenants.
+   */
+  async searchByEmbedding(
+    embedding: number[],
+    limit: number,
+  ): Promise<SharedAgentMemorySearchHit[]> {
+    const agentId = this.scope.storage?.agentId ?? stringToUuid(this.scope.agentKey);
+    return this.reader.searchByEmbedding(
+      {
+        organizationId: this.scope.organizationId,
+        userId: this.scope.userId,
+        agentId,
+      },
+      embedding,
+      limit,
+    );
+  }
 
   /**
    * Durably record one landed user/assistant pair. Writes are sequential so a
@@ -76,6 +114,29 @@ export class SharedMemoryStore {
       agentId,
     };
     const landedAt = Date.now();
+    // One batched sidecar round-trip for both texts; an embedding failure
+    // degrades to vector-less rows (recall coverage shrinks) but never loses
+    // the memory write itself.
+    let vectors: number[][] | undefined;
+    if (this.embed) {
+      try {
+        vectors = await this.embed.embedTexts(
+          [pair.userMessage, pair.assistantReply.trim() || pair.userMessage].map((text) => text),
+        );
+      } catch (error) {
+        // error-policy:J4 embedding is an enhancement on the durable write;
+        // its loss is visible (rows without vectors never match recall).
+        logger.warn(
+          `[SharedMemoryStore] turn-pair embedding failed; writing rows without vectors: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    }
+    const embeddingFields = (index: number) =>
+      vectors?.[index] && this.embed
+        ? { embedding: vectors[index], embeddingModel: this.embed.model }
+        : {};
     await this.writer.insertMemory({
       ...(pair.messageIds ? { id: memoryRowId(pair.messageIds.user) } : {}),
       scope,
@@ -89,6 +150,7 @@ export class SharedMemoryStore {
         channelType: "DM",
         ...(pair.messageRole === "system" ? { role: "system" } : {}),
       },
+      ...embeddingFields(0),
       createdAt: new Date(landedAt),
     });
     const assistantReply = pair.assistantReply.trim();
@@ -111,6 +173,7 @@ export class SharedMemoryStore {
     if (pair.messageIds) {
       await this.writer.mergeMessageMemory({
         ...assistant,
+        ...embeddingFields(1),
         id: memoryRowId(pair.messageIds.assistant),
         interrupted: pair.interrupted === true,
       });
@@ -118,6 +181,7 @@ export class SharedMemoryStore {
     }
     await this.writer.insertMemory({
       ...assistant,
+      ...embeddingFields(1),
       content: {
         ...assistant.content,
         ...(pair.interrupted ? { interrupted: true } : {}),
@@ -127,6 +191,11 @@ export class SharedMemoryStore {
 }
 
 /** Store for one turn's tenant scope, or null while the flag is off. */
-export function createSharedMemoryStore(scope: SharedMemoryStoreScope): SharedMemoryStore | null {
-  return sharedMemoryTablesEnabled() ? new SharedMemoryStore(scope) : null;
+export function createSharedMemoryStore(
+  scope: SharedMemoryStoreScope,
+  embed?: SharedMemoryEmbedConfig,
+): SharedMemoryStore | null {
+  return sharedMemoryTablesEnabled()
+    ? new SharedMemoryStore(scope, sharedAgentMemoriesWriter, sharedAgentMemoriesReader, embed)
+    : null;
 }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-recall.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-recall.ts
@@ -92,6 +92,60 @@ function readSidecarEmbedding(payload: unknown): number[] | undefined {
  * `POST <baseUrl>/v1/embeddings` endpoint. Single attempt, 5s abort, typed
  * failures; never returns a partial or fabricated vector.
  */
+/**
+ * Batch variant of {@link embedTextViaSidecar}: one sidecar call for several
+ * texts, vectors returned in input order. Used by the write path so a turn
+ * pair costs a single embedding round-trip. Same 5s abort and typed failures;
+ * a count mismatch is an invalid response, never a partial result.
+ */
+export async function embedTextsViaSidecar(
+  baseUrl: string,
+  apiKey: string | undefined,
+  texts: string[],
+): Promise<number[][]> {
+  const cleaned = texts.map((text) => text.trim());
+  if (cleaned.length === 0 || cleaned.some((text) => !text)) {
+    throw new ElizaError("Embedding sidecar rejected blank input text", {
+      code: "SHARED_RECALL_EMBEDDING_EMPTY_TEXT",
+      severity: "fatal",
+    });
+  }
+  const url = `${baseUrl.replace(/\/+$/, "")}/v1/embeddings`;
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+      },
+      body: JSON.stringify({ input: cleaned, model: SHARED_RECALL_EMBEDDING_MODEL }),
+      signal: AbortSignal.timeout(SHARED_RECALL_EMBED_TIMEOUT_MS),
+    });
+  } catch (error) {
+    throw new ElizaError("Embedding sidecar was unreachable", {
+      code: "SHARED_RECALL_EMBEDDING_UNREACHABLE",
+      cause: error instanceof Error ? error : undefined,
+    });
+  }
+  if (!response.ok) {
+    throw new ElizaError(`Embedding sidecar returned HTTP ${response.status}`, {
+      code: "SHARED_RECALL_EMBEDDING_HTTP_ERROR",
+      context: { status: response.status },
+    });
+  }
+  const payload = (await response.json()) as { data?: Array<{ embedding?: unknown }> };
+  const data = Array.isArray(payload?.data) ? payload.data : [];
+  const vectors = data.map((entry) => readSidecarEmbedding({ data: [entry] }));
+  if (vectors.length !== cleaned.length || vectors.some((vector) => vector === undefined)) {
+    throw new ElizaError("Embedding sidecar returned an invalid batch response", {
+      code: "SHARED_RECALL_EMBEDDING_INVALID_RESPONSE",
+      context: { expected: cleaned.length, received: vectors.length },
+    });
+  }
+  return vectors as number[][];
+}
+
 export async function embedTextViaSidecar(
   baseUrl: string,
   apiKey: string | undefined,

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-runtime-chat.ts
@@ -57,7 +57,14 @@ import {
 } from "./run-shared-agent-turn";
 import { projectSharedAgentCharacter } from "./shared-agent-character";
 import { capabilityWallActionResult } from "./shared-capability-wall";
-import { createSharedMemoryStore } from "./shared-memory-store";
+import { createSharedMemoryStore, type SharedMemoryStore } from "./shared-memory-store";
+import {
+  buildSharedRecallContext,
+  embedTextsViaSidecar,
+  embedTextViaSidecar,
+  SHARED_RECALL_DEFAULT_TOP_K,
+  SHARED_RECALL_EMBEDDING_MODEL,
+} from "./shared-recall";
 import type { SharedRuntimeAgent } from "./shared-runtime-agent";
 import { SharedRuntimeCacheWarmingError, SharedTurnConflictError } from "./shared-runtime-errors";
 import { MAX_HISTORY_MESSAGES } from "./shared-runtime-history-policy";
@@ -232,15 +239,87 @@ function sharedElizaRuntimeExecution(
  * projected identities.
  */
 function sharedTurnMemoryStore(agent: SharedRuntimeAgent) {
-  return createSharedMemoryStore({
-    organizationId: agent.organization_id,
-    userId: agent.user_id,
-    agentKey: agent.id,
-    storage: sharedTodoStorageScope({
-      sourceAgentId: agent.id,
-      ownerId: agent.user_id,
-    }),
-  });
+  const embedBase = process.env.LOCAL_EMBEDDINGS_BASE_URL;
+  const embed =
+    sharedRecallEnabled() && embedBase
+      ? {
+          embedTexts: (texts: string[]) =>
+            embedTextsViaSidecar(embedBase, process.env.LOCAL_EMBEDDINGS_API_KEY, texts),
+          model: SHARED_RECALL_EMBEDDING_MODEL,
+        }
+      : undefined;
+  return createSharedMemoryStore(
+    {
+      organizationId: agent.organization_id,
+      userId: agent.user_id,
+      agentKey: agent.id,
+      storage: sharedTodoStorageScope({
+        sourceAgentId: agent.id,
+        ownerId: agent.user_id,
+      }),
+    },
+    embed,
+  );
+}
+
+/**
+ * P3 rollout gate: semantic recall exists only while this is exactly "true"
+ * AND the sidecar base URL is configured. Off (the default) leaves every turn
+ * byte-identical to the pre-recall path.
+ */
+function sharedRecallEnabled(): boolean {
+  return (
+    process.env.SHARED_RECALL_ENABLED === "true" && Boolean(process.env.LOCAL_EMBEDDINGS_BASE_URL)
+  );
+}
+
+/**
+ * Compose the recall block for one turn, or undefined when recall contributes
+ * nothing. Recall is an enhancement: a typed embed/search failure is warned
+ * and the turn proceeds without it rather than failing a healthy reply.
+ * `hadKeywordHit` is pinned false for the rollout phase — the lexical-salience
+ * signal is not yet surfaced from the history store, so flag-on turns pay one
+ * sidecar embed each; the short-circuit lands when that signal is plumbed.
+ */
+async function sharedTurnRecallContext(
+  store: SharedMemoryStore | null,
+  queryText: string,
+  history: SharedTurnMessage[],
+): Promise<string | undefined> {
+  if (!store || !sharedRecallEnabled()) return undefined;
+  const embedBase = process.env.LOCAL_EMBEDDINGS_BASE_URL;
+  if (!embedBase) return undefined;
+  try {
+    const block = await buildSharedRecallContext({
+      flagEnabled: true,
+      hadKeywordHit: false,
+      queryText,
+      history,
+      embed: (text) => embedTextViaSidecar(embedBase, process.env.LOCAL_EMBEDDINGS_API_KEY, text),
+      storeSearch: async (vector) => {
+        const hits = await store.searchByEmbedding(vector, SHARED_RECALL_DEFAULT_TOP_K);
+        return hits.map((hit) => ({
+          id: hit.id,
+          role: hit.entity_id === hit.agent_id ? ("assistant" as const) : ("user" as const),
+          content:
+            typeof (hit.content as { text?: unknown })?.text === "string"
+              ? (hit.content as { text: string }).text
+              : "",
+          createdAt: hit.created_at ? new Date(hit.created_at).getTime() : undefined,
+        }));
+      },
+    });
+    return block ?? undefined;
+  } catch (error) {
+    // error-policy:J4 recall loss degrades to a recall-free turn; the warn is
+    // the visible signal and the reply itself stays healthy.
+    logger.warn(
+      `[shared-runtime-chat] semantic recall unavailable this turn: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return undefined;
+  }
 }
 
 function stableUuid(raw: string): string {
@@ -860,12 +939,14 @@ export class SharedRuntimeChatService {
 
     const messageIds = turnMessageIds(agent.id, roomId, claimKey);
     const memoryStore = sharedTurnMemoryStore(agent);
+    const recallContext = await sharedTurnRecallContext(memoryStore, text, history);
     let turn: RunSharedAgentTurnResult;
     try {
       turn = await runSharedAgentTurn({
         character,
         history,
         message: text,
+        ...(recallContext ? { recallContext } : {}),
         ...(options.trustedUserUtterance ? { capabilityText: options.trustedUserUtterance } : {}),
         messageRole,
         messageIds,
@@ -1043,6 +1124,7 @@ export class SharedRuntimeChatService {
       options.abortSignal?.removeEventListener("abort", abortFromRequest);
     let turn: Awaited<ReturnType<typeof runSharedAgentTurnStream>>;
     const streamMemoryStore = sharedTurnMemoryStore(agent);
+    const streamRecallContext = await sharedTurnRecallContext(streamMemoryStore, text, history);
     const providerSetupStartedAt = performance.now();
     try {
       turn = await runSharedAgentTurnStream({
@@ -1050,6 +1132,7 @@ export class SharedRuntimeChatService {
         character,
         history,
         message: text,
+        ...(streamRecallContext ? { recallContext: streamRecallContext } : {}),
         ...(options.trustedUserUtterance ? { capabilityText: options.trustedUserUtterance } : {}),
         messageRole,
         messageIds,


### PR DESCRIPTION
## Summary
Restarts the Shared/Dedicated parity program (wave 2): the P3 recall module (#20628) and P2 memory store (#20630) were merged as parts but never connected — `buildSharedRecallContext` had zero production callers, and the vector search could never match because `recordTurnPair` wrote rows without embeddings while `searchByEmbedding` filters `isNotNull(embedding)`. This PR completes the loop, all behind flags that stay OFF:

- **`RunSharedAgentTurnInput.recallContext`** — new optional input appended to the system prompt on every engine path (direct, eliza-runtime, and both stream variants).
- **Write-side embeddings** — `SharedMemoryStore` accepts an optional embed config; `recordTurnPair` batch-embeds the user/assistant pair in ONE sidecar call (`embedTextsViaSidecar`, new batch variant with the same 5s abort + typed failures + count-mismatch rejection). Embedding failure degrades to vector-less rows with a warn — the durable memory write is never lost (error-policy:J4).
- **Store search leg** — `SharedMemoryStore.searchByEmbedding` delegates to the tenant-pinned reader with the exact same organization/user/agent triple as the write path, so recall can never read across tenants.
- **Chat wiring** — `sharedTurnRecallContext` in shared-runtime-chat composes the block for both the non-stream and stream turn paths: gate = `SHARED_RECALL_ENABLED === "true"` AND `LOCAL_EMBEDDINGS_BASE_URL` set; recall failures warn and the turn proceeds recall-free. `hadKeywordHit` is pinned false for the rollout phase (the lexical-salience signal isn't surfaced from the history store yet; documented in-code as the follow-up).

**Rollout contract:** with `SHARED_RECALL_ENABLED` unset (everywhere today), every turn is byte-identical to before — no sidecar traffic, no prompt change, no new writes. Staging enablement is a separate config step after this merges, followed by the live prove-out (rows with vectors landing, keyword-miss → sidecar embed → recalled block in prompt, billing ledger showing selfhosted) and then P2.5 transfer-fidelity.

## Evidence
- 66/66 across the five touched suites (shared-recall, shared-memory-store, memory-commit, shared-runtime-chat, + new recall-context contract test pinning: block appended to system prompt / absent leaves prompt untouched — asserted on the REAL `system` argument the model receives).
- Package typecheck clean (uncached). Biome clean.
- Sidecar prerequisites all live and merged: auth (401-locked), publication (#20713), immutable pin (#20718), staging base URL var serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)