### PR TITLE
fix(cloud): reject whitespace-prefixed worker integers

### DIFF
--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.test.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.test.ts
@@ -750,7 +750,7 @@ describe("readWorkerConfig (canonical env ints)", () => {
   });
 
   it("throws on prefix-coerced WORKER_POLL_INTERVAL tokens (would have been a 1ms-class poll)", () => {
-    for (const token of ["1e4", "12px", "007", "0", "0x10"]) {
+    for (const token of ["1e4", "12px", "007", "0", "0x10", " 1e4", "\t12px"]) {
       expect(() =>
         readWorkerConfig(
           { WORKER_POLL_INTERVAL: token } as NodeJS.ProcessEnv,

--- a/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
+++ b/packages/cloud/scripts/admin/daemons/provisioning-worker.ts
@@ -210,10 +210,10 @@ function parsePositiveInt(
     }
     return parsed;
   }
-  // parseInt("1e4", 10) === 1 would silently set a 1ms poll loop.
-  // Prefix-numeric tokens fail closed. Non-numeric garbage still falls back
-  // so documented "nope"/"soon" knobs keep their default.
-  if (/^[-+0-9]/.test(value)) {
+  // Preserve the old parser's boundary: anything it could prefix-coerce,
+  // including after leading whitespace, must now fail closed. Fully
+  // non-numeric "nope"/"soon" values retain their documented fallback.
+  if (!Number.isNaN(Number.parseInt(value, 10))) {
     throw new Error(
       `${label} must be a canonical positive integer (received ${JSON.stringify(value)})`,
     );


### PR DESCRIPTION
## Summary

Closes #20837.

The provisioning-worker integer parser now rejects whitespace-prefixed values that the legacy `Number.parseInt` could prefix-coerce. Canonical positive integers, the #20833 watchdog maximum, and the documented fully non-numeric fallback remain unchanged.

## Review finding and repair

Post-merge review of #20833 found that its first-character detector missed leading whitespace:

```text
WORKER_POLL_INTERVAL=" 1e4"   -> 30000 fallback
WORKER_POLL_INTERVAL="\t12px" -> 30000 fallback
```

The repaired boundary asks whether the legacy parser could find any numeric prefix. If so, a non-canonical token throws; genuinely non-numeric values such as `nope` / `soon` still use the documented fallback.

## Verification

Exact published head: `5c505d7f106b04c6370dfcf0873df2106273dc8a`, rebased on `develop@03e61db536b3f3ce982dfc3084c955c73f4c5266`.

- Tests-first mutation: 55 pass / 1 fail; whitespace-prefixed numeric junk did not throw.
- Repaired provisioning-worker suite: 56/56, 117 assertions.
- Cloud API typecheck and production Worker dry-run: pass.
- Changed-file Biome: pass (11 pre-existing undeclared-env warnings, 0 errors).
- `git diff --check`: pass.
- Forced root `bun run verify`: 356/356, 0 cached, every repository audit passed.
- Anti-larp: 8,427 test files, 0 focused, 0 orphaned skips.

## Evidence

<!-- evidence-head:5c505d7f106b04c6370dfcf0873df2106273dc8a -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend process-start environment parsing only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend process-start environment parsing only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic configuration parser behavior; no interactive surface.
<!-- evidence-row:backend-logs -->
- [x] Red/green parser transcript:
  <details><summary>Focused proof</summary>

  ```text
  Before production repair: 55 pass, 1 fail
  Received function did not throw for whitespace-prefixed numeric junk

  Exact final head: 56 pass, 0 fail, 117 assertions
  " 1e4" and "\t12px" throw before a worker config can bind
  "nope" still falls back to 30000
  59999 remains accepted; 60000 remains rejected by the watchdog bound
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, action, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no database, memory, wallet, deployment, or generated artifact is written.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - repository guide followed directly
<!-- attribution-row:status -->
- Provenance status: self-reported
