### PR TITLE
test(core): green the core lane — planner fixture drift (#20744 failures 2-3) + cwd-dependent truthy-limit proof

### DIFF
--- a/packages/core/src/__tests__/message-v5-widget-markers.test.ts
+++ b/packages/core/src/__tests__/message-v5-widget-markers.test.ts
@@ -200,7 +200,7 @@ describe("v5 widget markers — action callback and verified payload channels", 
 					text: "",
 					toolCalls: [{ id: "call-1", name: "APP_PICKER", args: {} }],
 				},
-				evaluatorFinish("On it."),
+				evaluatorFinish("I've listed the app options for you."),
 			],
 		});
 
@@ -242,7 +242,9 @@ describe("v5 widget markers — action callback and verified payload channels", 
 		// dedup identical text per turn, so both channels may deliver safely.
 		expect(result.kind).toBe("planned_reply");
 		if (result.kind === "planned_reply") {
-			expect(result.result.responseContent?.text).toBe("On it.");
+			expect(result.result.responseContent?.text).toBe(
+				"I've listed the app options for you.",
+			);
 		}
 	});
 
@@ -268,7 +270,7 @@ describe("v5 widget markers — action callback and verified payload channels", 
 					text: "",
 					toolCalls: [{ id: "call-1", name: "APP_PICKER", args: {} }],
 				},
-				evaluatorFinish("On it."),
+				evaluatorFinish("I've listed the app options for you."),
 			],
 		});
 
@@ -282,7 +284,7 @@ describe("v5 widget markers — action callback and verified payload channels", 
 		expect(result.kind).toBe("planned_reply");
 		if (result.kind !== "planned_reply") return;
 		// Verified user-facing payloads are priority 1 for the final message:
-		// the verbatim marker block wins over "On it.".
+		// the verbatim marker block wins over the evaluator paraphrase.
 		expect(result.result.responseContent?.text).toBe(CHOICE_BLOCK);
 		const { blocks } = parseInteractionBlocks(
 			String(result.result.responseContent?.text ?? ""),

--- a/packages/core/src/__tests__/planner-happy-path.test.ts
+++ b/packages/core/src/__tests__/planner-happy-path.test.ts
@@ -1781,7 +1781,11 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		// string, and suppression compares against this set — recording only the
 		// sanitized form would deliver a duplicate bubble on every drift turn.
 		const rawPayload = '{"status":"ok","taskId":"abc123"}';
-		const driftedRewrite = "Task created: abc123.<tool_call>notify_owner";
+		// NOTE: the rewrite must not CLAIM a completed side effect ("Task created:")
+		// — the planned-reply egress gate fails such claims closed without a
+		// verified receipt. This test pins wire sanitization + suppression, so it
+		// uses a non-claiming phrasing.
+		const driftedRewrite = "Here's the task id: abc123.<tool_call>notify_owner";
 		const delivered: string[] = [];
 		const deliveredVisibleTexts = new Set<string>();
 		const action = makeMockAction({
@@ -1850,10 +1854,10 @@ describe("v5 happy path — message handler → planner → executor → evaluat
 		});
 
 		// The connector saw ONLY the sanitized wire text.
-		expect(delivered).toEqual(["Task created: abc123."]);
+		expect(delivered).toEqual(["Here's the task id: abc123."]);
 		// Both forms were recorded: raw for suppression, sanitized as sent.
 		expect(deliveredVisibleTexts).toContain(driftedRewrite.toLowerCase());
-		expect(deliveredVisibleTexts).toContain("task created: abc123.");
+		expect(deliveredVisibleTexts).toContain("here's the task id: abc123.");
 		// The planner's raw-drift echo was suppressed against the raw record.
 		expect(result.kind).toBe("planned_reply");
 		if (result.kind === "planned_reply") {

--- a/packages/core/src/truthy-limit.test.ts
+++ b/packages/core/src/truthy-limit.test.ts
@@ -109,16 +109,19 @@ describe("truthy limit batch (ship 14) — CO-1, CO-4", () => {
 	it("ship14 sibling proof: files contain `!= null` guard and not bare truthy", async () => {
 		const fs = await import("node:fs");
 		// Resolve from this test file, not the process cwd: the core lane runs
-		// with cwd=packages/core (`bun run --cwd packages/core test`), where a
-		// repo-root-relative path does not exist.
-		const mem = fs.readFileSync(
-			new URL("./database/inMemoryAdapter.ts", import.meta.url).pathname,
-			"utf8",
+		// with cwd=packages/core (`bun run --cwd packages/core test`). Pass file
+		// URLs directly so Node handles Windows drive letters and percent-decoding
+		// instead of treating URL.pathname as a platform-native path.
+		const memorySourceUrl = new URL(
+			"./database/%69nMemoryAdapter.ts",
+			import.meta.url,
 		);
+		expect(memorySourceUrl.pathname).toContain("%69nMemoryAdapter.ts");
+		const mem = fs.readFileSync(memorySourceUrl, "utf8");
 		expect(mem).toContain("if (params.limit != null)");
 		expect(mem).not.toMatch(/\n\t\tif \(params\.limit\) \{/); // old truthy must be gone
 		const traj = fs.readFileSync(
-			new URL("./runtime/trajectory-recorder.ts", import.meta.url).pathname,
+			new URL("./runtime/trajectory-recorder.ts", import.meta.url),
 			"utf8",
 		);
 		expect(traj).toContain(

--- a/packages/core/src/truthy-limit.test.ts
+++ b/packages/core/src/truthy-limit.test.ts
@@ -108,14 +108,17 @@ describe("truthy limit batch (ship 14) — CO-1, CO-4", () => {
 
 	it("ship14 sibling proof: files contain `!= null` guard and not bare truthy", async () => {
 		const fs = await import("node:fs");
+		// Resolve from this test file, not the process cwd: the core lane runs
+		// with cwd=packages/core (`bun run --cwd packages/core test`), where a
+		// repo-root-relative path does not exist.
 		const mem = fs.readFileSync(
-			"packages/core/src/database/inMemoryAdapter.ts",
+			new URL("./database/inMemoryAdapter.ts", import.meta.url).pathname,
 			"utf8",
 		);
 		expect(mem).toContain("if (params.limit != null)");
 		expect(mem).not.toMatch(/\n\t\tif \(params\.limit\) \{/); // old truthy must be gone
 		const traj = fs.readFileSync(
-			"packages/core/src/runtime/trajectory-recorder.ts",
+			new URL("./runtime/trajectory-recorder.ts", import.meta.url).pathname,
 			"utf8",
 		);
 		expect(traj).toContain(


### PR DESCRIPTION
## Summary

Greens `bun run --cwd packages/core test` on develop tip. Fixes the two unclaimed failures recorded in #20744 (failures 2 & 3) plus a third failure class that surfaced at current tip.

**Diagnosis of failures 2 & 3** (`message-v5-widget-markers.test.ts`, `planner-happy-path.test.ts`): both files were merged in `353574037` with zero CI check-runs and were red from birth — their fixtures predate two deliberate runtime behaviors:

1. `repairFinishWithProgressPromise` (evaluator.ts) downgrades an evaluator FINISH whose `messageToUser` is a bare progress ack to CONTINUE after a successful tool result. The fixtures finished with `"On it."` — which matches `FINISH_BARE_PROGRESS_ACK_RE` — so the loop deliberately kept planning and ran off the fixture queue (the "unexpected useModel" / `direct_reply` failures). Fixtures now finish with completed-work phrasing.
2. The planned-reply egress gate (`evaluatePlannedReplyEgress`) fails closed on completed-side-effect claims without a verified receipt. The #15888 fixture's rewrite `"Task created: abc123."` matches the noun-first claim pattern, so delivery degraded to the honest "couldn't verify" fallback. The fixture now uses a non-claiming phrase (`"Here's the task id: abc123."`); the test's actual subject — sanitized wire text plus raw suppression recording — is unchanged and still asserted.

In both cases the runtime behavior is the intended fail-closed contract (anti-lying repairs), so the tests were updated, not the runtime.

**Third failure** (`truthy-limit.test.ts`): the ship14 sibling-proof reads files via repo-root-relative paths, which ENOENT when the lane runs with cwd=`packages/core` (exactly what `bun run --cwd packages/core test` does). Now resolved via `import.meta.url`.

## Verification (exact head)

```
bun run --cwd packages/core test:  553 files | 6491 passed, 0 failed, 13 skipped
bun run --cwd packages/core typecheck: clean
biome check (touched files): clean
```

Closes the remaining scope of #20744 (failure 1 was fixed by #20746, already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Independent review repair

Reviewer validation found that using `new URL(...).pathname` fixed the package-cwd failure but remained non-portable on Windows drive-letter paths and percent-encoded repository paths. Commit `4b39dd0718b0af6167d3201189958701e3603391` passes file URL objects directly to `readFileSync` and adds an encoded-path assertion proving URL decoding.

Exact-head reviewer verification:

- `truthy-limit.test.ts`: 5/5 passed
- `message-v5-widget-markers.test.ts` + `planner-happy-path.test.ts`: 29/29 passed
- Biome on the three touched test files: clean
- `git diff --check`: clean

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop / multi-agent
Contribution skill revision: elizaOS/eliza@1803d6113531e06d5619755e9186ed2dd61b12a8:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported
— [review-lane-b]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop / multi-agent","skill_revision":"elizaOS/eliza@1803d6113531e06d5619755e9186ed2dd61b12a8:packages/skills/skills/contribute-to-eliza"} -->