### PR TITLE
config(cloud): enable Shared memory tables + semantic recall on staging (wave-2 prove-out)

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -474,6 +474,11 @@ ELIZA_INFERENCE_TIMING = "info"
 # LOCAL_EMBEDDINGS_API_KEY is published as a Worker secret by cloud-cf-release
 # and must never appear in a [vars] block.
 LOCAL_EMBEDDINGS_BASE_URL = "https://embeddings-staging-staging.up.railway.app"
+# Parity wave 2 (staging-only prove-out): durable tenant memory rows for every
+# Shared turn, plus flag-gated semantic recall over them via the sidecar.
+# Reversible: delete both lines to return to byte-identical pre-parity turns.
+SHARED_MEMORY_TABLES_ENABLED = "true"
+SHARED_RECALL_ENABLED = "true"
 # Apps (Product 2): wire the real deploy trigger so POST /api/v1/apps/:id/deploy
 # enqueues an APP_DEPLOY job the provisioning-worker daemon runs (instead of the
 # legacy status-only stub). Staging only — the apps data plane (tenant DB +

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-recall.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-recall.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { isElizaError } from "@elizaos/core/edge";
 import {
   buildSharedRecallContext,
+  embedTextsViaSidecar,
   embedTextViaSidecar,
   SHARED_RECALL_DEFAULT_MAX_CHARS,
   SHARED_RECALL_DEFAULT_TOP_K,
@@ -172,6 +173,43 @@ describe("embedTextViaSidecar — typed failure surface", () => {
     expect(error.context?.reason).toBe("wrong-dimensions");
     expect(error.context?.expected).toBe(SHARED_RECALL_EMBEDDING_DIMENSIONS);
     expect(error.context?.actual).toBe(3);
+  });
+});
+
+describe("embedTextsViaSidecar — batch validation", () => {
+  test("rejects a wrong-dimensional vector before it can reach vector(384) storage", async () => {
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          data: [
+            { embedding: vectorOf(SHARED_RECALL_EMBEDDING_DIMENSIONS) },
+            { embedding: vectorOf(3) },
+          ],
+        }),
+        { status: 200 },
+      )) as unknown as typeof fetch;
+
+    const error = await expectElizaError(
+      embedTextsViaSidecar("https://sidecar.internal", undefined, ["user", "assistant"]),
+      "SHARED_RECALL_EMBEDDING_INVALID_RESPONSE",
+    );
+    expect(error.context).toMatchObject({
+      reason: "wrong-dimensions",
+      index: 1,
+      expected: SHARED_RECALL_EMBEDDING_DIMENSIONS,
+      actual: 3,
+    });
+  });
+
+  test("classifies a non-JSON success body as an invalid batch response", async () => {
+    globalThis.fetch = (async () =>
+      new Response("upstream proxy", { status: 200 })) as unknown as typeof fetch;
+
+    const error = await expectElizaError(
+      embedTextsViaSidecar("https://sidecar.internal", undefined, ["user", "assistant"]),
+      "SHARED_RECALL_EMBEDDING_INVALID_RESPONSE",
+    );
+    expect(error.context?.reason).toBe("non-json-body");
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-recall.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-recall.ts
@@ -6,12 +6,11 @@
  * Embeddings come from a sidecar exposing the OpenAI `/v1/embeddings` shape
  * with `bge-small-en-v1.5` (384 dimensions).
  *
- * Not wired into the live turn yet — the turn integration lands with the P2
- * tenant-store merge. `buildSharedRecallContext` is pure orchestration over
- * injected `embed`/`storeSearch` collaborators and owns no degrade policy:
- * failures propagate typed so the turn boundary decides whether recall loss is
- * survivable. `embedTextViaSidecar` is fail-fast with a single bounded attempt
- * (5s abort, no retries); the caller owns retry/backoff policy.
+ * `buildSharedRecallContext` is pure orchestration over injected
+ * `embed`/`storeSearch` collaborators and owns no degrade policy: failures
+ * propagate typed so the live turn boundary decides whether recall loss is
+ * survivable. Sidecar calls are fail-fast with a single bounded attempt (5s
+ * abort, no retries); the caller owns retry/backoff policy.
  */
 
 import { ElizaError } from "@elizaos/core/edge";
@@ -134,13 +133,41 @@ export async function embedTextsViaSidecar(
       context: { status: response.status },
     });
   }
-  const payload = (await response.json()) as { data?: Array<{ embedding?: unknown }> };
+  let payload: { data?: Array<{ embedding?: unknown }> };
+  try {
+    payload = (await response.json()) as { data?: Array<{ embedding?: unknown }> };
+  } catch (cause) {
+    // error-policy:J3 a non-JSON 2xx body becomes an explicit invalid-response
+    // failure so the memory store can degrade to vector-less rows.
+    throw new ElizaError("Embedding sidecar returned a non-JSON batch body", {
+      code: "SHARED_RECALL_EMBEDDING_INVALID_RESPONSE",
+      cause,
+      context: { reason: "non-json-body" },
+      severity: "ephemeral",
+    });
+  }
   const data = Array.isArray(payload?.data) ? payload.data : [];
   const vectors = data.map((entry) => readSidecarEmbedding({ data: [entry] }));
-  if (vectors.length !== cleaned.length || vectors.some((vector) => vector === undefined)) {
+  const wrongDimensionIndex = vectors.findIndex(
+    (vector) => vector !== undefined && vector.length !== SHARED_RECALL_EMBEDDING_DIMENSIONS,
+  );
+  if (
+    vectors.length !== cleaned.length ||
+    vectors.some((vector) => vector === undefined) ||
+    wrongDimensionIndex !== -1
+  ) {
     throw new ElizaError("Embedding sidecar returned an invalid batch response", {
       code: "SHARED_RECALL_EMBEDDING_INVALID_RESPONSE",
-      context: { expected: cleaned.length, received: vectors.length },
+      context:
+        wrongDimensionIndex === -1
+          ? { reason: "invalid-vector-count", expected: cleaned.length, received: vectors.length }
+          : {
+              reason: "wrong-dimensions",
+              index: wrongDimensionIndex,
+              expected: SHARED_RECALL_EMBEDDING_DIMENSIONS,
+              actual: vectors[wrongDimensionIndex]?.length,
+            },
+      severity: "ephemeral",
     });
   }
   return vectors as number[][];

--- a/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
+++ b/packages/scripts/__tests__/cloud-deploy-environment-contract.test.ts
@@ -128,6 +128,24 @@ describe("canonical cloud deployment environment contract", () => {
     expect(production).toContain('SHARED_ELIZA_AGENT_RUNTIME = "true"');
   });
 
+  test("enables Shared semantic memory only in the staging prove-out", () => {
+    const staging = cloudApiWranglerSource.slice(
+      cloudApiWranglerSource.indexOf("[env.staging.vars]"),
+      cloudApiWranglerSource.indexOf("[env.production.vars]"),
+    );
+    const production = cloudApiWranglerSource.slice(
+      cloudApiWranglerSource.indexOf("[env.production.vars]"),
+    );
+
+    for (const flag of [
+      "SHARED_MEMORY_TABLES_ENABLED",
+      "SHARED_RECALL_ENABLED",
+    ]) {
+      expect(staging).toContain(`${flag} = "true"`);
+      expect(production).not.toContain(flag);
+    }
+  });
+
   test("keeps Shared Discord reminder delivery bound across Worker deploys", () => {
     const staging = cloudApiWranglerSource.slice(
       cloudApiWranglerSource.indexOf("[env.staging.vars]"),


### PR DESCRIPTION
## Summary
Staging-only flag flip for the parity wave-2 prove-out, now that #20841 wired the full recall loop:
- `SHARED_MEMORY_TABLES_ENABLED = "true"` — every Shared turn durably mirrors its user/assistant pair into tenant-scoped `shared_agent_memories`, now WITH 384-d vectors (one batched sidecar call per pair).
- `SHARED_RECALL_ENABLED = "true"` — beyond-window semantic recall joins the system prompt on keyword-miss turns.

Default and production `[vars]` untouched — everywhere else stays byte-identical. Reversible by deleting two lines. Neither name is a published Worker secret (collision lint 4/4 green).

## Post-deploy prove-out plan (receipts to HQ #18309)
1. Real edge-path staging turns → verify vectored rows land with correct org/user/agent tenancy.
2. A beyond-window reference question → verify the sidecar embed fires (selfhosted billing entries) and the recalled block reaches the prompt (Server-Timing/trace + reply content).
3. Then P2.5: transfer-fidelity proof against Dedicated.

Deploy carrying this will be announced to shared-latency before gate approval (their serving pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)