### PR TITLE
fix(app): accept cron value-steps (N/step) in browser cron-parser shim

### DIFF
--- a/packages/app/src/shims/cron-parser.test.ts
+++ b/packages/app/src/shims/cron-parser.test.ts
@@ -3,8 +3,10 @@
  * exercises the real shim module (not a mock) and asserts it accepts the same
  * list/range/step syntax the shipped Triggers form relies on while still
  * rejecting out-of-range, inverted, and garbage fields. The accepted set mirrors
- * the real `cron-parser@5.x` verdict for the five-field expressions the Triggers
- * UI validation path feeds through this shim.
+ * the server scheduler's `parseCronExpression` verdict (in
+ * `packages/core/src/services/triggerScheduling.ts`) for the five-field
+ * expressions the Triggers UI validation path feeds through this shim, so the
+ * form neither blocks a schedule the backend runs nor saves one it never runs.
  */
 import { describe, expect, it } from "vitest";
 
@@ -20,6 +22,13 @@ describe("cron-parser shim field grammar", () => {
     "0 9 * * *",
     "0-59 * * * *",
     "*/60 * * * *",
+    // Value-steps (`N/step`): from N to the field max every step. The server
+    // scheduler accepts these; the shim used to reject them, disabling the
+    // Triggers submit button for the common "every 15 minutes from :00" form.
+    "0/15 * * * *",
+    "5/15 * * * *",
+    "9/2 9-17 * * *",
+    "0 0 * * 7",
   ];
 
   it.each(validExpressions)("accepts valid recurring schedule %s", (expr) => {
@@ -36,6 +45,13 @@ describe("cron-parser shim field grammar", () => {
     ["0, * * * *", "trailing empty list element"],
     ["0 9 * *", "only four fields"],
     ["8 25 * * *", "hour out of range"],
+    ["5/0 * * * *", "zero value-step"],
+    ["60/5 * * * *", "value-step base out of range"],
+    ["5/2/3 * * * *", "double step separator"],
+    // Named tokens are rejected on purpose: the server scheduler
+    // (`parseCronExpression`) rejects them too, so accepting them here would
+    // save a trigger the backend never runs.
+    ["0 0 * * MON", "named day-of-week token"],
   ];
 
   it.each(invalidExpressions)("rejects %s (%s)", (expr) => {

--- a/packages/app/src/shims/cron-parser.ts
+++ b/packages/app/src/shims/cron-parser.ts
@@ -2,9 +2,14 @@
  * Browser shim for the `cron-parser` package, mirroring the
  * `CronExpressionParser.parse(expr).next().toDate()` surface the app consumes.
  * `parse` validates a 5-field expression against the same per-field grammar the
- * real cron-parser accepts — `*`, step values (every-N), comma lists (`0,30`),
- * ranges (`9-17`), and range-steps (`0-11` every 2) — while still rejecting
- * malformed or out-of-range fields. The returned iterator is minimal: each
+ * server scheduler (`parseCronExpression` in
+ * `packages/core/src/services/triggerScheduling.ts`) accepts — `*`, star-steps
+ * (`*` every N), comma lists (`0,30`), ranges (`9-17`), range-steps (`0-11`
+ * every 2), and value-steps (`0/15`, `5/15`: from N to the field max every
+ * step) — while still rejecting malformed or out-of-range fields. Named tokens
+ * (`MON`, `JAN`) are deliberately rejected because the server scheduler rejects
+ * them too; accepting them here would let the form save a trigger the backend
+ * never runs. The returned iterator is minimal: each
  * `next()` advances the cursor by one minute from `currentDate` rather than
  * resolving the true next matching instant — enough to satisfy validation and
  * the API shape in the bundle without the full scheduler engine.
@@ -20,7 +25,8 @@ type ParseOptions = {
 };
 
 // Validate one comma-list element of a cron field: `*`, `*/N`, a range `A-B`, a
-// range-step `A-B/N`, or a bare integer, matching cron-parser's field grammar.
+// range-step `A-B/N`, a value-step `N/S`, or a bare integer, matching the
+// server scheduler's field grammar (`parseCronPart` in triggerScheduling.ts).
 function validateFieldElement(
   element: string,
   min: number,
@@ -29,27 +35,35 @@ function validateFieldElement(
 ): void {
   if (element === "*") return;
 
-  const step = element.match(/^\*\/(\d+)$/);
-  if (step) {
-    // A star-step fires from `min` every N; cron-parser only rejects a zero
-    // step, even when N exceeds the range (a step of 60 fires once at `min`).
-    if (Number(step[1]) > 0) return;
+  // A trailing `/step` may qualify any base term (`*/S`, `N/S`, `A-B/S`). Like
+  // the server scheduler, only a non-integer or non-positive step is rejected;
+  // a step that overshoots the range simply fires once at the base value.
+  const slashParts = element.split("/");
+  if (slashParts.length > 2) {
     throw new Error(`Invalid cron field: ${field}`);
   }
+  if (slashParts.length === 2) {
+    const stepToken = slashParts[1];
+    if (!/^\d+$/.test(stepToken) || Number(stepToken) <= 0) {
+      throw new Error(`Invalid cron field: ${field}`);
+    }
+  }
 
-  const range = element.match(/^(\d+)-(\d+)(?:\/(\d+))?$/);
+  const base = slashParts[0];
+  if (base === "*") return;
+
+  const range = base.match(/^(\d+)-(\d+)$/);
   if (range) {
     const lo = Number(range[1]);
     const hi = Number(range[2]);
-    const rangeStep = range[3] === undefined ? 1 : Number(range[3]);
-    if (lo < min || hi > max || lo > hi || rangeStep <= 0) {
+    if (lo < min || hi > max || lo > hi) {
       throw new Error(`Invalid cron field: ${field}`);
     }
     return;
   }
 
-  if (/^\d+$/.test(element)) {
-    const parsed = Number(element);
+  if (/^\d+$/.test(base)) {
+    const parsed = Number(base);
     if (parsed >= min && parsed <= max) return;
   }
 


### PR DESCRIPTION
# Relates to

Closes #20835

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker. — see **Known gaps / failures** (offline env: `bun install` cannot resolve registry deps; focused checks run instead).
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@01f2f7ad09f86c24dbc619a668b395c5a1d4f109:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync — not runnable in this offline worktree (no `node_modules`; registry install blocked). Focused checks documented below.

# Risks

Low. One small pure validation function in a single browser shim
(`packages/app/src/shims/cron-parser.ts`) plus its unit test. No runtime type,
API, or rendered-surface change. The change only *widens* what the client
accepts to match what the server scheduler already accepts, and keeps every
malformed/out-of-range/named-token input rejected.

# Background

## What does this PR do?

The app bundle aliases the real `cron-parser` package to a small browser shim
(`packages/app/src/shims/cron-parser.ts`, wired in `vite.config.ts`). The
Triggers form (`@elizaos/ui`) validates user cron input through this shim via
`validateCronExpression()`; on `cronInvalid` it **disables** the Create/Save
button (`TriggerForm.tsx`).

The shim rejected **value-steps** — `N/step` terms such as `0/15`, `5/15`,
`9/2` ("from N to the field max, every step") — even though the authoritative
server scheduler `parseCronExpression`
(`packages/core/src/services/triggerScheduling.ts`) accepts them. So a user who
typed the very common "every 15 minutes from :00" expression `0/15 * * * *`
could not save the trigger, even though the backend would run it. This is a
client/server contract regression: the client falsely rejected input the
documented backend contract accepts.

This PR rewrites `validateFieldElement` to peel a trailing `/step` off any base
term (`*`, a range, or a single value) and validate the step and base
independently — matching the server grammar (`parseCronPart`). Named tokens
(`MON`, `JAN`) stay **rejected on purpose**: the server scheduler rejects them
too (its `parseInteger` is digits-only), so accepting them here would save a
trigger the backend never runs — a worse, silent failure.

### Scope note (honest re-scope)

The originally-filed defect also listed ranges (`1-5`), lists (`1,15`), and
range-steps (`0-30/5`). Those were already fixed on `develop` by #20361 before
this work started; re-shipping them would be a no-op. The remaining genuine
discrepancy between the shim and the server scheduler was the `N/step`
value-step form, which this PR fixes. The scout's "REAL ACCEPT: 0 0 * * MON"
line compared against the raw `cron-parser` dependency, not the actual server
scheduler, which rejects `MON`; the shim is therefore aligned to the server, not
widened past it.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

No project-doc change required. The shim's file header and the test header were
updated in-place to describe the value-step grammar and the deliberate
named-token rejection.

# Testing

## Where should a reviewer start?

`packages/app/src/shims/cron-parser.test.ts` — a table test asserting the shim
accepts the value-step forms the server accepts and still rejects malformed,
out-of-range, and named-token fields.

## Detailed testing steps

1. Reproduce the old behavior: with the pre-fix source, `0/15 * * * *`,
   `5/15 * * * *`, and `9/2 9-17 * * *` throw `Invalid cron field` in the shim.
2. Apply the fix: the shim accepts them; all pre-existing accepts/rejects are
   unchanged; named tokens (`MON`) still throw.
3. Confirm alignment: the same expressions parse (non-null) in
   `packages/core/src/services/triggerScheduling.ts` `parseCronExpression`,
   while `MON`/out-of-range still parse to `null` there too.

# Evidence Gate

<!-- evidence-head:44e3282f42b08ad6a96e559761ccf03707843564 -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - non-rendered change.` The diff touches only `cron-parser.ts` (a pure validation function) and its `.test.ts`; no rendered `.tsx/.css/.svg` surface changed. The submit-button enablement is a downstream consequence proven by the validation-contract test and the shim/server parity probe below.
<!-- evidence-row:after-screenshots -->
- [x] `N/A - non-rendered change.` Same reason as above.
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - non-rendered change; app UI capture unavailable offline.` `bun install` cannot complete in this worktree (registry-blocked deps), so `bun run --cwd packages/app audit:app` / e2e recording cannot run. The behavior is proven by the red→green unit contract and the parity probe.
<!-- evidence-row:backend-logs -->
- [x] `N/A - no server path changed.` The fix is a client-side validation shim. The server scheduler (`parseCronExpression`) is unchanged; the probe below shows it already accepts these expressions.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - non-rendered change; app UI capture unavailable offline` (see walkthrough row). Contract proven at the module boundary instead.
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model change.`
<!-- evidence-row:domain-artifacts -->
- [x] Parity probe output (shim vs. server scheduler) attached under **Backend + frontend logs**, plus red→green unit output — the domain artifacts for this validation contract.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface changed.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model change.`

## Backend + frontend logs

**Shim vs. server-scheduler parity probe** (`bun`, repo-pinned runtime), showing
the shim now matches `parseCronExpression` on every case:

```
0/15 * * * *       shim=ACCEPT  server=ACCEPT
5/15 * * * *       shim=ACCEPT  server=ACCEPT
9/2 9-17 * * *     shim=ACCEPT  server=ACCEPT
0 0 * * 7          shim=ACCEPT  server=ACCEPT
0 9 * * 1-5        shim=ACCEPT  server=ACCEPT
0 0 1,15 * *       shim=ACCEPT  server=ACCEPT
0 0 * * MON        shim=REJECT  server=REJECT   (named token: both reject)
0 0 32 * *         shim=REJECT  server=REJECT
60 * * * *         shim=REJECT  server=REJECT
```

Before the fix, the first three rows were `shim=REJECT(Invalid cron field)`
while `server=ACCEPT` — the exact contract mismatch this PR closes.

<details><summary>Red → green unit output (mirror of the committed vitest suite via the bun runner, since vitest's node workers need a full install unavailable offline)</summary>

```
=== RED BEFORE (pre-fix source, new tests present) ===
(fail) accepts 0/15 * * * *
(fail) accepts 5/15 * * * *
(fail) accepts 9/2 9-17 * * *
 22 pass
 3 fail

=== GREEN AFTER (fix applied) ===
 25 pass
 0 fail
 25 expect() calls
```

The committed test lives at `packages/app/src/shims/cron-parser.test.ts` and runs
under the package's normal `vitest` lane (`bun run --cwd packages/app test`); the
bun-runner mirror above reproduces the identical assertions in this offline
environment.
</details>

## Screenshots (before / after) + video walkthrough

`N/A - non-rendered change` (see Evidence Gate rows). No `.tsx/.css/.svg` diff.

## Audio / voice walkthrough

`N/A - no voice/audio change.`

## Known gaps / failures

- `bun install` / `bun run verify` could not run: this offline worktree has no
  `node_modules` and the registry install fails to resolve several deps
  (`viem`, `smthrs`, `kubernetes-fluent-client`). Not a blocker — the change is a
  single pure function; it was verified with: (1) the bun-runtime parity probe
  vs. the server scheduler, (2) a red→green unit mirror of the committed vitest
  suite, (3) repo-pinned Biome 2.5.7 `check` (clean) on both changed files, and
  (4) isolated strict `tsc --noEmit` on the shim (clean). The full package
  `vitest` lane (`bun run --cwd packages/app test`) and `bun run verify` should
  be run by CI where the install succeeds.
- Package `typecheck` fails only on missing type-lib files (`bun-types`,
  `vite/client`) — an artifact of the absent install, not of this diff.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@01f2f7ad09f86c24dbc619a668b395c5a1d4f109:packages/skills/skills/contribute-to-eliza"} -->
