### PR TITLE
fix(plugin-scheduling): 400 malformed percent-encoded task ids

### DIFF
--- a/plugins/plugin-scheduling/src/routes/scheduled-tasks.test.ts
+++ b/plugins/plugin-scheduling/src/routes/scheduled-tasks.test.ts
@@ -404,6 +404,80 @@ describe("scheduled-tasks REST handler", () => {
     expect(payload.task.kind).toBe("checkin");
   });
 
+  it("rejects illegal percent-encoding in task ids with 400 before runner calls", async () => {
+    let listed = 0;
+    let applied = 0;
+    let fired = 0;
+    const runner = makeRunner();
+    const origList = runner.list.bind(runner);
+    const origApply = runner.apply.bind(runner);
+    const origFire = runner.fireWithResult.bind(runner);
+    runner.list = async (filter) => {
+      listed += 1;
+      return origList(filter);
+    };
+    runner.apply = async (id, verb, payload) => {
+      applied += 1;
+      return origApply(id, verb, payload);
+    };
+    runner.fireWithResult = async (id, opts) => {
+      fired += 1;
+      return origFire(id, opts);
+    };
+    const handler = makeScheduledTasksRouteHandler({
+      resolveRunner: async () => runner,
+    });
+    for (const { method, pathname } of [
+      { method: "POST", pathname: "/api/lifeops/scheduled-tasks/%/complete" },
+      { method: "GET", pathname: "/api/lifeops/scheduled-tasks/%2/history" },
+      { method: "POST", pathname: "/api/lifeops/scheduled-tasks/%ZZ/fire" },
+      {
+        method: "GET",
+        pathname: "/api/lifeops/dev/scheduled-tasks/%/log",
+      },
+    ]) {
+      const { ctx, res } = buildCtx({ method, pathname });
+      const handled = await handler(ctx);
+      expect(handled).toBe(true);
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toContain("percent-encoding");
+    }
+    expect(listed).toBe(0);
+    expect(applied).toBe(0);
+    expect(fired).toBe(0);
+  });
+
+  it("still applies a canonically encoded task id", async () => {
+    const runner = makeRunner();
+    const task = await runner.schedule({
+      kind: "reminder",
+      promptInstructions: "encoded-id",
+      trigger: { kind: "manual" },
+      priority: "low",
+      respectsGlobalPause: true,
+      source: "user_chat",
+      createdBy: "x",
+      ownerVisible: true,
+    });
+    const encoded = `%${task.taskId.charCodeAt(0).toString(16)}${task.taskId.slice(1)}`;
+    expect(decodeURIComponent(encoded)).toBe(task.taskId);
+    expect(encoded).not.toBe(task.taskId);
+    const handler = makeScheduledTasksRouteHandler({
+      resolveRunner: async () => runner,
+    });
+    const { ctx, res } = buildCtx({
+      method: "POST",
+      pathname: `/api/lifeops/scheduled-tasks/${encoded}/complete`,
+      body: { reason: "canonical-encoding" },
+    });
+    await handler(ctx);
+    expect(res.statusCode).toBe(200);
+    const all = await runner.list();
+    expect(all.find((t) => t.taskId === task.taskId)?.state.status).toBe(
+      "completed",
+    );
+  });
+
   it("GET /api/lifeops/dev/scheduling/registries returns spine registry health (loopback only)", async () => {
     const runner = makeRunner();
     const handler = makeScheduledTasksRouteHandler({

--- a/plugins/plugin-scheduling/src/routes/scheduled-tasks.ts
+++ b/plugins/plugin-scheduling/src/routes/scheduled-tasks.ts
@@ -71,12 +71,27 @@ interface ScheduledTaskRouteDeps {
 const PATH_PREFIX = "/api/lifeops/scheduled-tasks";
 const DEV_REGISTRIES_PATH = "/api/lifeops/dev/scheduling/registries";
 
+class ScheduledTaskPathEncodingError extends Error {
+  constructor() {
+    super("task id is not valid percent-encoding");
+    this.name = "ScheduledTaskPathEncodingError";
+  }
+}
+
+function decodeTaskId(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    throw new ScheduledTaskPathEncodingError();
+  }
+}
+
 function matchTaskVerb(pathname: string): { id: string; verb: string } | null {
   const m = /^\/api\/lifeops\/scheduled-tasks\/([^/]+)\/([^/]+)\/?$/.exec(
     pathname,
   );
   if (!m) return null;
-  return { id: decodeURIComponent(m[1] ?? ""), verb: m[2] ?? "" };
+  return { id: decodeTaskId(m[1] ?? ""), verb: m[2] ?? "" };
 }
 
 function matchTaskFire(pathname: string): { id: string } | null {
@@ -84,7 +99,7 @@ function matchTaskFire(pathname: string): { id: string } | null {
     pathname,
   );
   if (!m) return null;
-  return { id: decodeURIComponent(m[1] ?? "") };
+  return { id: decodeTaskId(m[1] ?? "") };
 }
 
 /** JSON-safe projection of the runner's typed fire outcome. */
@@ -176,7 +191,7 @@ function matchTaskHistory(pathname: string): { id: string } | null {
     pathname,
   );
   if (!m) return null;
-  return { id: decodeURIComponent(m[1] ?? "") };
+  return { id: decodeTaskId(m[1] ?? "") };
 }
 
 function matchDevLog(pathname: string): { id: string } | null {
@@ -184,7 +199,7 @@ function matchDevLog(pathname: string): { id: string } | null {
     pathname,
   );
   if (!m) return null;
-  return { id: decodeURIComponent(m[1] ?? "") };
+  return { id: decodeTaskId(m[1] ?? "") };
 }
 
 function applyVerbToString(verb: string): string | null {
@@ -205,6 +220,22 @@ export function makeScheduledTasksRouteHandler(
   deps: ScheduledTaskRouteDeps,
 ): (ctx: SchedulingRouteContext) => Promise<boolean> {
   return async (ctx) => {
+    try {
+      return await handleScheduledTasks(ctx, deps);
+    } catch (err) {
+      if (err instanceof ScheduledTaskPathEncodingError) {
+        ctx.error(ctx.res, err.message, 400);
+        return true;
+      }
+      throw err;
+    }
+  };
+}
+
+async function handleScheduledTasks(
+  ctx: SchedulingRouteContext,
+  deps: ScheduledTaskRouteDeps,
+): Promise<boolean> {
     const { method, pathname, json, error, readJsonBody, req, res } = ctx;
 
     // Spine registry introspection — loopback only.
@@ -480,7 +511,6 @@ export function makeScheduledTasksRouteHandler(
     }
 
     return false;
-  };
 }
 
 export const SCHEDULED_TASKS_ROUTE_PATHS = [

--- a/plugins/plugin-scheduling/src/routes/scheduled-tasks.ts
+++ b/plugins/plugin-scheduling/src/routes/scheduled-tasks.ts
@@ -223,6 +223,7 @@ export function makeScheduledTasksRouteHandler(
     try {
       return await handleScheduledTasks(ctx, deps);
     } catch (err) {
+      // error-policy:J1 translate malformed path input at the HTTP boundary.
       if (err instanceof ScheduledTaskPathEncodingError) {
         ctx.error(ctx.res, err.message, 400);
         return true;
@@ -236,281 +237,276 @@ async function handleScheduledTasks(
   ctx: SchedulingRouteContext,
   deps: ScheduledTaskRouteDeps,
 ): Promise<boolean> {
-    const { method, pathname, json, error, readJsonBody, req, res } = ctx;
+  const { method, pathname, json, error, readJsonBody, req, res } = ctx;
 
-    // Spine registry introspection — loopback only.
-    if (method === "GET" && pathname === DEV_REGISTRIES_PATH) {
+  // Spine registry introspection — loopback only.
+  if (method === "GET" && pathname === DEV_REGISTRIES_PATH) {
+    if (!isLoopback(ctx)) {
+      error(res, "dev endpoints are loopback-only", 403);
+      return true;
+    }
+    const runner = await deps.resolveRunner(ctx);
+    if (!runner) return true;
+    json(res, runner.inspectRegistries());
+    return true;
+  }
+
+  {
+    const devLog = matchDevLog(pathname);
+    if (method === "GET" && devLog) {
       if (!isLoopback(ctx)) {
         error(res, "dev endpoints are loopback-only", 403);
         return true;
       }
       const runner = await deps.resolveRunner(ctx);
       if (!runner) return true;
-      json(res, runner.inspectRegistries());
-      return true;
-    }
-
-    {
-      const devLog = matchDevLog(pathname);
-      if (method === "GET" && devLog) {
-        if (!isLoopback(ctx)) {
-          error(res, "dev endpoints are loopback-only", 403);
-          return true;
-        }
-        const runner = await deps.resolveRunner(ctx);
-        if (!runner) return true;
-        const history = await runner.list({});
-        const found = history.find((t) => t.taskId === devLog.id);
-        if (!found) {
-          error(res, `task ${devLog.id} not found`, 404);
-          return true;
-        }
-        json(res, {
-          taskId: devLog.id,
-          state: found.state,
-          historyEndpoint: `${PATH_PREFIX}/${devLog.id}/history`,
-        });
+      const history = await runner.list({});
+      const found = history.find((t) => t.taskId === devLog.id);
+      if (!found) {
+        error(res, `task ${devLog.id} not found`, 404);
         return true;
       }
-    }
-
-    // User-visible history endpoint.
-    {
-      const hist = matchTaskHistory(pathname);
-      if (method === "GET" && hist) {
-        const runner = await deps.resolveRunner(ctx);
-        if (!runner) return true;
-        const tasks = await runner.list({});
-        const found = tasks.find((t) => t.taskId === hist.id);
-        if (!found) {
-          error(res, `task ${hist.id} not found`, 404);
-          return true;
-        }
-        json(res, {
-          taskId: hist.id,
-          status: found.state.status,
-          firedAt: found.state.firedAt,
-          completedAt: found.state.completedAt,
-          acknowledgedAt: found.state.acknowledgedAt,
-          followupCount: found.state.followupCount,
-          lastFollowupAt: found.state.lastFollowupAt,
-          lastDecisionLog: found.state.lastDecisionLog,
-        });
-        return true;
-      }
-    }
-
-    // List.
-    if (method === "GET" && pathname === PATH_PREFIX) {
-      const runner = await deps.resolveRunner(ctx);
-      if (!runner) return true;
-      const url = ctx.url;
-      const filterParse = scheduledTaskFilterSchema.safeParse({
-        kind: url.searchParams.get("kind") ?? undefined,
-        status: url.searchParams.get("status") ?? undefined,
-        source: url.searchParams.get("source") ?? undefined,
-        firedSince: url.searchParams.get("firedSince") ?? undefined,
-        ownerVisibleOnly: url.searchParams.get("ownerVisibleOnly") === "1",
+      json(res, {
+        taskId: devLog.id,
+        state: found.state,
+        historyEndpoint: `${PATH_PREFIX}/${devLog.id}/history`,
       });
-      if (!filterParse.success) {
-        error(
-          res,
-          `invalid filter: ${filterParse.error.issues
-            .map((i) => i.message)
-            .join("; ")}`,
-          400,
-        );
-        return true;
-      }
-      const tasks = await runner.list(filterParse.data);
-      json(res, { tasks });
       return true;
     }
+  }
 
-    // Schedule.
-    if (method === "POST" && pathname === PATH_PREFIX) {
+  // User-visible history endpoint.
+  {
+    const hist = matchTaskHistory(pathname);
+    if (method === "GET" && hist) {
       const runner = await deps.resolveRunner(ctx);
       if (!runner) return true;
-      const body = await readJsonBody<Record<string, unknown>>(req, res);
-      if (body === null) return true;
-      const parsed = scheduledTaskInputSchema.safeParse(body);
-      if (!parsed.success) {
-        error(
-          res,
-          `invalid task: ${parsed.error.issues.map((i) => i.message).join("; ")}`,
-          400,
-        );
+      const tasks = await runner.list({});
+      const found = tasks.find((t) => t.taskId === hist.id);
+      if (!found) {
+        error(res, `task ${hist.id} not found`, 404);
         return true;
       }
-      try {
-        const task = await runner.schedule(
-          parsed.data as Omit<ScheduledTask, "taskId" | "state">,
-        );
-        json(res, { task }, 201);
-      } catch (err) {
-        // error-policy:J1 boundary translation — only malformed task input
-        // degrades to 400; a genuine runner failure rethrows to the outer
-        // server handler as a 5xx rather than being masked here.
-        if (
-          err instanceof ScheduledTaskValidationError ||
-          err instanceof ChannelKeyError
-        ) {
-          error(res, err.message, 400);
-          return true;
-        }
-        throw err;
-      }
+      json(res, {
+        taskId: hist.id,
+        status: found.state.status,
+        firedAt: found.state.firedAt,
+        completedAt: found.state.completedAt,
+        acknowledgedAt: found.state.acknowledgedAt,
+        followupCount: found.state.followupCount,
+        lastFollowupAt: found.state.lastFollowupAt,
+        lastDecisionLog: found.state.lastDecisionLog,
+      });
       return true;
     }
+  }
 
-    // Test probe — the one-click "run a live LifeOps validation" entry point.
-    // Seeds a due-now reminder (or check-in) and fires it in the same call, so a
-    // HITL tester can confirm the real schedule → fire → dispatch path works
-    // end-to-end with their connected model/connectors, without hand-crafting a
-    // ScheduledTaskInput. The seeded row is owner-visible and tagged
-    // `metadata.liveTest` so it is identifiable in the task list.
-    if (method === "POST" && pathname === `${PATH_PREFIX}/test-probe`) {
-      const runner = await deps.resolveRunner(ctx);
-      if (!runner) return true;
-      const contentLength = Number.parseInt(
-        (req.headers["content-length"] as string | undefined) ?? "0",
-        10,
+  // List.
+  if (method === "GET" && pathname === PATH_PREFIX) {
+    const runner = await deps.resolveRunner(ctx);
+    if (!runner) return true;
+    const url = ctx.url;
+    const filterParse = scheduledTaskFilterSchema.safeParse({
+      kind: url.searchParams.get("kind") ?? undefined,
+      status: url.searchParams.get("status") ?? undefined,
+      source: url.searchParams.get("source") ?? undefined,
+      firedSince: url.searchParams.get("firedSince") ?? undefined,
+      ownerVisibleOnly: url.searchParams.get("ownerVisibleOnly") === "1",
+    });
+    if (!filterParse.success) {
+      error(
+        res,
+        `invalid filter: ${filterParse.error.issues
+          .map((i) => i.message)
+          .join("; ")}`,
+        400,
       );
-      let body: Record<string, unknown> = {};
-      if (Number.isFinite(contentLength) && contentLength > 0) {
-        const parsed = await readJsonBody<Record<string, unknown>>(req, res);
-        if (parsed === null) return true;
-        body = parsed;
-      }
-      const probeKind = body.kind === "checkin" ? "checkin" : "reminder";
-      const nowIso = new Date().toISOString();
-      const probeInput = {
-        kind: probeKind,
-        promptInstructions:
-          probeKind === "checkin"
-            ? "LifeOps live test: a check-in probe — confirm the scheduler fires and the check-in dispatches to you."
-            : "LifeOps live test: a reminder probe — confirm the scheduler fires and this reminder dispatches to you.",
-        trigger: { kind: "once", atIso: nowIso },
-        priority: "medium",
-        respectsGlobalPause: false,
-        source: "plugin",
-        createdBy: "lifeops-live-test",
-        ownerVisible: true,
-        metadata: { liveTest: true, seededAtIso: nowIso },
-      };
-      const parsedProbe = scheduledTaskInputSchema.safeParse(probeInput);
-      if (!parsedProbe.success) {
-        error(
-          res,
-          `invalid probe: ${parsedProbe.error.issues.map((i) => i.message).join("; ")}`,
-          400,
-        );
+      return true;
+    }
+    const tasks = await runner.list(filterParse.data);
+    json(res, { tasks });
+    return true;
+  }
+
+  // Schedule.
+  if (method === "POST" && pathname === PATH_PREFIX) {
+    const runner = await deps.resolveRunner(ctx);
+    if (!runner) return true;
+    const body = await readJsonBody<Record<string, unknown>>(req, res);
+    if (body === null) return true;
+    const parsed = scheduledTaskInputSchema.safeParse(body);
+    if (!parsed.success) {
+      error(
+        res,
+        `invalid task: ${parsed.error.issues.map((i) => i.message).join("; ")}`,
+        400,
+      );
+      return true;
+    }
+    try {
+      const task = await runner.schedule(
+        parsed.data as Omit<ScheduledTask, "taskId" | "state">,
+      );
+      json(res, { task }, 201);
+    } catch (err) {
+      // error-policy:J1 boundary translation — only malformed task input
+      // degrades to 400; a genuine runner failure rethrows to the outer
+      // server handler as a 5xx rather than being masked here.
+      if (
+        err instanceof ScheduledTaskValidationError ||
+        err instanceof ChannelKeyError
+      ) {
+        error(res, err.message, 400);
         return true;
       }
+      throw err;
+    }
+    return true;
+  }
+
+  // Test probe — the one-click "run a live LifeOps validation" entry point.
+  // Seeds a due-now reminder (or check-in) and fires it in the same call, so a
+  // HITL tester can confirm the real schedule → fire → dispatch path works
+  // end-to-end with their connected model/connectors, without hand-crafting a
+  // ScheduledTaskInput. The seeded row is owner-visible and tagged
+  // `metadata.liveTest` so it is identifiable in the task list.
+  if (method === "POST" && pathname === `${PATH_PREFIX}/test-probe`) {
+    const runner = await deps.resolveRunner(ctx);
+    if (!runner) return true;
+    const contentLength = Number.parseInt(
+      (req.headers["content-length"] as string | undefined) ?? "0",
+      10,
+    );
+    let body: Record<string, unknown> = {};
+    if (Number.isFinite(contentLength) && contentLength > 0) {
+      const parsed = await readJsonBody<Record<string, unknown>>(req, res);
+      if (parsed === null) return true;
+      body = parsed;
+    }
+    const probeKind = body.kind === "checkin" ? "checkin" : "reminder";
+    const nowIso = new Date().toISOString();
+    const probeInput = {
+      kind: probeKind,
+      promptInstructions:
+        probeKind === "checkin"
+          ? "LifeOps live test: a check-in probe — confirm the scheduler fires and the check-in dispatches to you."
+          : "LifeOps live test: a reminder probe — confirm the scheduler fires and this reminder dispatches to you.",
+      trigger: { kind: "once", atIso: nowIso },
+      priority: "medium",
+      respectsGlobalPause: false,
+      source: "plugin",
+      createdBy: "lifeops-live-test",
+      ownerVisible: true,
+      metadata: { liveTest: true, seededAtIso: nowIso },
+    };
+    const parsedProbe = scheduledTaskInputSchema.safeParse(probeInput);
+    if (!parsedProbe.success) {
+      error(
+        res,
+        `invalid probe: ${parsedProbe.error.issues.map((i) => i.message).join("; ")}`,
+        400,
+      );
+      return true;
+    }
+    try {
+      const task = await runner.schedule(
+        parsedProbe.data as Omit<ScheduledTask, "taskId" | "state">,
+      );
+      const result = await runner.fireWithResult(task.taskId, {
+        allowTerminalRefire: true,
+      });
+      json(res, { task, fire: serializeFireResult(result) }, 201);
+    } catch (err) {
+      // error-policy:J1 boundary translation — malformed input → 400,
+      // not-found → 404, and a genuine schedule/fire failure → 500 instead
+      // of the prior blanket 400 that hid runner failures from the tester.
+      const { status, message } = classifyRunnerError(err);
+      error(res, message, status);
+    }
+    return true;
+  }
+
+  // Fire now — the interactive HITL live-test trigger. Runs the task
+  // immediately regardless of due-ness (the same strict-fire path the
+  // scheduler tick uses via `processDueScheduledTasks → runner.fireWithResult`),
+  // returning the typed outcome (fired / skipped / dispatch_deferred /
+  // dispatch_failed / raced) plus the post-fire task. Placed before the
+  // generic verb block so `fire` is not rejected by the apply-verb allowlist.
+  {
+    const fireMatch = matchTaskFire(pathname);
+    if (method === "POST" && fireMatch) {
+      const runner = await deps.resolveRunner(ctx);
+      if (!runner) return true;
       try {
-        const task = await runner.schedule(
-          parsedProbe.data as Omit<ScheduledTask, "taskId" | "state">,
-        );
-        const result = await runner.fireWithResult(task.taskId, {
+        const result = await runner.fireWithResult(fireMatch.id, {
           allowTerminalRefire: true,
         });
-        json(res, { task, fire: serializeFireResult(result) }, 201);
+        json(res, { fire: serializeFireResult(result) });
       } catch (err) {
-        // error-policy:J1 boundary translation — malformed input → 400,
-        // not-found → 404, and a genuine schedule/fire failure → 500 instead
-        // of the prior blanket 400 that hid runner failures from the tester.
+        // error-policy:J1 boundary translation — distinguish not-found (404)
+        // and runner failure (500) from client input error (400).
         const { status, message } = classifyRunnerError(err);
         error(res, message, status);
       }
       return true;
     }
+  }
 
-    // Fire now — the interactive HITL live-test trigger. Runs the task
-    // immediately regardless of due-ness (the same strict-fire path the
-    // scheduler tick uses via `processDueScheduledTasks → runner.fireWithResult`),
-    // returning the typed outcome (fired / skipped / dispatch_deferred /
-    // dispatch_failed / raced) plus the post-fire task. Placed before the
-    // generic verb block so `fire` is not rejected by the apply-verb allowlist.
-    {
-      const fireMatch = matchTaskFire(pathname);
-      if (method === "POST" && fireMatch) {
+  // Apply verb.
+  {
+    const verbed = matchTaskVerb(pathname);
+    if (method === "POST" && verbed) {
+      const verb = applyVerbToString(verbed.verb);
+      if (!verb) {
+        if (verbed.verb !== "history") {
+          error(res, `unknown verb: ${verbed.verb}`, 400);
+          return true;
+        }
+      } else {
         const runner = await deps.resolveRunner(ctx);
         if (!runner) return true;
+        const contentLength = Number.parseInt(
+          (req.headers["content-length"] as string | undefined) ?? "0",
+          10,
+        );
+        let body: unknown;
+        if (Number.isFinite(contentLength) && contentLength > 0) {
+          const parsed = await readJsonBody<Record<string, unknown>>(req, res);
+          if (parsed === null) return true;
+          body = parsed;
+        }
+        let payload: unknown = body ?? undefined;
+        if (verb === "snooze") {
+          const parsed = scheduledTaskSnoozePayloadSchema.safeParse(body ?? {});
+          if (!parsed.success) {
+            error(
+              res,
+              `invalid snooze payload: ${parsed.error.issues.map((i) => i.message).join("; ")}`,
+              400,
+            );
+            return true;
+          }
+          payload = parsed.data;
+        }
         try {
-          const result = await runner.fireWithResult(fireMatch.id, {
-            allowTerminalRefire: true,
-          });
-          json(res, { fire: serializeFireResult(result) });
+          const updated = await runner.apply(
+            verbed.id,
+            verb as Parameters<ScheduledTaskRunnerHandle["apply"]>[1],
+            payload,
+          );
+          json(res, { task: updated });
         } catch (err) {
-          // error-policy:J1 boundary translation — distinguish not-found (404)
-          // and runner failure (500) from client input error (400).
+          // error-policy:J1 boundary translation — not-found → 404, runner
+          // failure → 500; only malformed input degrades to 400.
           const { status, message } = classifyRunnerError(err);
           error(res, message, status);
         }
         return true;
       }
     }
+  }
 
-    // Apply verb.
-    {
-      const verbed = matchTaskVerb(pathname);
-      if (method === "POST" && verbed) {
-        const verb = applyVerbToString(verbed.verb);
-        if (!verb) {
-          if (verbed.verb !== "history") {
-            error(res, `unknown verb: ${verbed.verb}`, 400);
-            return true;
-          }
-        } else {
-          const runner = await deps.resolveRunner(ctx);
-          if (!runner) return true;
-          const contentLength = Number.parseInt(
-            (req.headers["content-length"] as string | undefined) ?? "0",
-            10,
-          );
-          let body: unknown;
-          if (Number.isFinite(contentLength) && contentLength > 0) {
-            const parsed = await readJsonBody<Record<string, unknown>>(
-              req,
-              res,
-            );
-            if (parsed === null) return true;
-            body = parsed;
-          }
-          let payload: unknown = body ?? undefined;
-          if (verb === "snooze") {
-            const parsed = scheduledTaskSnoozePayloadSchema.safeParse(
-              body ?? {},
-            );
-            if (!parsed.success) {
-              error(
-                res,
-                `invalid snooze payload: ${parsed.error.issues.map((i) => i.message).join("; ")}`,
-                400,
-              );
-              return true;
-            }
-            payload = parsed.data;
-          }
-          try {
-            const updated = await runner.apply(
-              verbed.id,
-              verb as Parameters<ScheduledTaskRunnerHandle["apply"]>[1],
-              payload,
-            );
-            json(res, { task: updated });
-          } catch (err) {
-            // error-policy:J1 boundary translation — not-found → 404, runner
-            // failure → 500; only malformed input degrades to 400.
-            const { status, message } = classifyRunnerError(err);
-            error(res, message, status);
-          }
-          return true;
-        }
-      }
-    }
-
-    return false;
+  return false;
 }
 
 export const SCHEDULED_TASKS_ROUTE_PATHS = [


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on LifeOps scheduled-task path segments.
Not a twin of SIWS chainId, workflow percent-encoding, orchestrator `lines=`,
provisioning-worker env ints, invites-accept, cli-auth, redemption quote,
compat agent-logs, first-run, notifications, BlueBubbles, login persist,
billing, or avatar.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Path-segment decode only in `plugin-scheduling` HTTP router. Canonical
percent-encoding still addresses the same task id. Malformed `%` / `%2` / `%ZZ`
become 400 instead of an uncaught `URIError` 500. Existing JSON body 400 is
unchanged.

# Background

## What does this PR do?

`makeScheduledTasksRouteHandler` called `decodeURIComponent` on task ids for
complete / fire / history / loopback log. Illegal percent-encoding throws
`URIError`, which the host mapped to 500.

- `/api/lifeops/scheduled-tasks/%/complete` / `%2/history` / `%ZZ/fire` → **400**, no runner call
- Canonically encoded first-byte still completes that task

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client or proxy that emits a broken percent-encoded task id should get a
request error, not a 500 that looks like a LifeOps runner outage.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-scheduling/src/routes/scheduled-tasks.test.ts` — illegal
percent-encoding table and the canonical encoded-id complete.

## Detailed testing steps

```bash
cd plugins/plugin-scheduling
bunx vitest run --config ./vitest.config.ts src/routes/scheduled-tasks.test.ts
```

16 passed at the evidence head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; LifeOps scheduled-task HTTP router only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; LifeOps scheduled-task HTTP router only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; LifeOps scheduled-task HTTP router only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused vitest drives the real handler and asserts 400 vs runner-call skip; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - in-memory runner only; invalid tokens never apply/fire/list.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: malformed
percent-encoding returns 400 with zero runner calls; a canonically encoded
task id still completes.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file scheduling router decode with a
green focused suite (16 tests). Full monorepo verify is unrelated to this
percent-encoding boundary and was skipped to keep the proof tied to the
changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:da9049fc1aea923c41fe25e65cbc9b3557007a9b -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
