### PR TITLE
fix(cloud): gate Discord gateway readiness on startup

### DIFF
--- a/packages/cloud/services/_common/src/gateway-auth.ts
+++ b/packages/cloud/services/_common/src/gateway-auth.ts
@@ -7,7 +7,7 @@ export interface GatewayTokenResponse {
 }
 
 export const GATEWAY_TOKEN_MAX_LIFETIME_SECONDS = 60;
-export const GATEWAY_TOKEN_REQUEST_TIMEOUT_MS = 5_000;
+export const GATEWAY_TOKEN_REQUEST_TIMEOUT_MS = 15_000;
 
 const TOKEN_REFRESH_FRACTION = 0.5;
 const TOKEN_REFRESH_RETRY_MIN_MS = 1_000;

--- a/packages/cloud/services/gateway-discord/railway.toml
+++ b/packages/cloud/services/gateway-discord/railway.toml
@@ -28,7 +28,7 @@ builder = "DOCKERFILE"
 dockerfilePath = "Dockerfile"
 
 [deploy]
-healthcheckPath = "/health"
-healthcheckTimeout = 30
+healthcheckPath = "/ready"
+healthcheckTimeout = 90
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10

--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -2776,6 +2776,17 @@ export class GatewayManager {
     };
   }
 
+  /** Readiness requires one authenticated control-plane poll, not merely a live process. */
+  isReady(health: HealthStatus = this.getHealth()): boolean {
+    return (
+      !health.draining &&
+      health.status === "healthy" &&
+      health.controlPlane.healthy &&
+      health.controlPlane.lastSuccessfulPoll !== null &&
+      (health.totalBots === 0 || health.connectedBots > 0)
+    );
+  }
+
   getMetrics(): string {
     const h = this.getHealth();
     const pod = this.config.podName;

--- a/packages/cloud/services/gateway-discord/src/index.ts
+++ b/packages/cloud/services/gateway-discord/src/index.ts
@@ -117,11 +117,7 @@ app.get("/health", (c) => {
 // Draining pods are explicitly not ready to prevent new bot assignments
 app.get("/ready", (c) => {
   const health = gatewayManager.getHealth();
-  const ready =
-    !health.draining &&
-    health.status === "healthy" &&
-    health.controlPlane.healthy &&
-    (health.totalBots === 0 || health.connectedBots > 0);
+  const ready = gatewayManager.isReady(health);
   return c.json({ ready, ...health }, ready ? 200 : 503);
 });
 

--- a/packages/cloud/services/gateway-discord/tests/startup-readiness-contract.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/startup-readiness-contract.test.ts
@@ -1,0 +1,88 @@
+/** Exercises the real gateway startup boundary that Railway uses for admission. */
+
+import { afterEach, expect, mock, test } from "bun:test";
+import { GATEWAY_TOKEN_REQUEST_TIMEOUT_MS } from "@elizaos/cloud-services-common/gateway-auth";
+import { GatewayManager } from "../src/gateway-manager";
+
+const originalFetch = globalThis.fetch;
+const originalBotEnabled = process.env.ELIZA_APP_DISCORD_BOT_ENABLED;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalBotEnabled === undefined) {
+    delete process.env.ELIZA_APP_DISCORD_BOT_ENABLED;
+  } else {
+    process.env.ELIZA_APP_DISCORD_BOT_ENABLED = originalBotEnabled;
+  }
+  mock.restore();
+});
+
+test("allows bounded cold token acquisition before Railway admits the replica", async () => {
+  expect(GATEWAY_TOKEN_REQUEST_TIMEOUT_MS).toBeGreaterThanOrEqual(15_000);
+
+  const railwayConfig = await Bun.file(
+    new URL("../railway.toml", import.meta.url),
+  ).text();
+  expect(railwayConfig).toContain('healthcheckPath = "/ready"');
+  expect(railwayConfig).toContain("healthcheckTimeout = 90");
+});
+
+test("stays unready through delayed authentication and admits only after the first poll", async () => {
+  process.env.ELIZA_APP_DISCORD_BOT_ENABLED = "false";
+  let resolveToken: ((response: Response) => void) | undefined;
+  globalThis.fetch = mock(async (input: unknown) => {
+    const path = new URL(String(input)).pathname;
+    if (path.endsWith("/auth/token")) {
+      return await new Promise<Response>((resolve) => {
+        resolveToken = resolve;
+      });
+    }
+    if (path.endsWith("/discord/gateway/shutdown")) {
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`Unexpected request: ${path}`);
+  }) as typeof fetch;
+
+  const manager = new GatewayManager(
+    {
+      podName: "readiness-test-pod",
+      elizaCloudUrl: "https://api.test",
+      gatewayBootstrapSecret: "bootstrap-secret",
+      project: "test",
+    },
+    {
+      fetchAssignments: mock(async () =>
+        Response.json({ assignments: [] }),
+      ) as typeof fetch,
+    },
+  );
+
+  expect(manager.isReady()).toBeFalse();
+  const startup = manager.start();
+  await waitFor(() => resolveToken !== undefined);
+  expect(manager.isReady()).toBeFalse();
+
+  resolveToken?.(
+    Response.json({
+      access_token: "ready-token",
+      token_type: "Bearer",
+      expires_in: 60,
+    }),
+  );
+  await startup;
+  try {
+    expect(manager.isReady()).toBeTrue();
+    expect(manager.getHealth().controlPlane.lastSuccessfulPoll).not.toBeNull();
+  } finally {
+    await manager.shutdown();
+  }
+});
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline)
+      throw new Error("Timed out waiting for gateway state");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}


### PR DESCRIPTION
Closes #20850

## What changed
- allow the bounded gateway bootstrap exchange up to 15 seconds
- gate Railway deployment on `/ready`, not liveness-only `/health`
- give readiness 90 seconds for JWT acquisition, leader election, and Discord login

## Reproduction and real staging proof
The exact previous staging image started HTTP, timed out its 5-second JWT request, and restarted even though Railway admitted `/health`. Exact candidate deployment `ded51245-c0b0-4948-a19d-7aa5ce323560` reached JWT acquisition in 5.611s, acquired Eliza App leadership, connected the Discord bot, and completed two later token renewals without 401/403 or restart. Image: `sha256:1f5261fd189938c483fbabb1ad5a28fc9cd652d45fa828f17b8258a8ce5b4223`. Production was untouched.

## Verification
- `13/13` focused gateway auth + readiness contract tests (`18` assertions)
- gateway-discord typecheck PASS
- gateway-discord production build PASS (`745` modules)
- Biome exact changed TypeScript paths PASS
- diff-check PASS

## Evidence matrix
- Backend structured logs: attached above as exact timestamps and deployment/image receipts
- Real connector: PASS, Eliza App bot login and token renewal observed
- UI screenshots/video: N/A — sidecar startup/readiness only
- Model trajectory: N/A — no agent/model behavior changed
- Domain artifact: active Railway deployment and image digest above