### PR TITLE
test(cloud): green the cloud/shared lane — missing mock export + verified-echo call-count drift

### DIFF
--- a/packages/cloud/shared/src/lib/services/app-inference-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/app-inference-admission.test.ts
@@ -71,6 +71,7 @@ mock.module("./credits", () => ({
     }),
   },
   InsufficientCreditsError: TestInsufficientCreditsError,
+  ReservationNotFoundError: class ReservationNotFoundError extends Error {},
   MIN_RESERVATION: 0.000001,
 }));
 

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts
@@ -30,9 +30,8 @@ mock.module("../../runtime/cloud-bindings", () => ({
 
 mock.module("../eliza-managed-launch", () => ({
   launchManagedElizaAgent,
-  // onboarding-chat.ts also imports this named export; a mock.module factory
-  // must supply every imported name or the module fails to LOAD (SyntaxError:
-  // "Export named ... not found"), killing the whole suite.
+  // The mock must expose every name imported by onboarding-chat so this suite
+  // exercises the error policy instead of failing during module linking.
   readManagedElizaAgentConnection: mock(),
 }));
 

--- a/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/onboarding-chat.error-policy.test.ts
@@ -30,6 +30,10 @@ mock.module("../../runtime/cloud-bindings", () => ({
 
 mock.module("../eliza-managed-launch", () => ({
   launchManagedElizaAgent,
+  // onboarding-chat.ts also imports this named export; a mock.module factory
+  // must supply every imported name or the module fails to LOAD (SyntaxError:
+  // "Export named ... not found"), killing the whole suite.
+  readManagedElizaAgentConnection: mock(),
 }));
 
 mock.module("./provisioning", () => ({

--- a/packages/cloud/shared/src/lib/services/eliza-app/user-service.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-app/user-service.error-policy.test.ts
@@ -63,6 +63,7 @@ mock.module("../api-keys", () => ({ apiKeysService: { create: createApiKey } }))
 mock.module("../credits", () => ({
   creditsService: { addCredits },
   InsufficientCreditsError: class InsufficientCreditsError extends Error {},
+  ReservationNotFoundError: class ReservationNotFoundError extends Error {},
 }));
 mock.module("../signup-code", () => ({ redeemSignupCode: mock() }));
 

--- a/packages/cloud/shared/src/lib/services/managed-eliza-lean-chat-boot.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/managed-eliza-lean-chat-boot.integration.test.ts
@@ -18,9 +18,8 @@
  *   3. EMBEDDING COLUMN = dim384. A FRESH provision (no ELIZAOS_CLOUD_API_KEY in
  *      existingEnv) defaults to local-primary gte-small embeddings, so the env
  *      pins `EMBEDDING_DIMENSION=384` and the 384-d vectors land in the
- *      `dim_384` column (nubs/shaw directive 2026-08-16: self-hosted embeddings
- *      are the platform default; previously provisioned agents keep their
- *      pinned 1536 width). We boot a REAL in-memory PGlite adapter, snap it to
+ *      `dim_384` column. Existing provisioned agents retain their explicitly
+ *      pinned width. We boot a REAL in-memory PGlite adapter, snap it to
  *      the env's dimension, and prove a 384-d memory insert SUCCEEDS — while a
  *      1536-d insert hits the "dimension mismatch" guard (the negative
  *      control). Either drift — a revert to cloud-primary 1536 for fresh
@@ -189,8 +188,8 @@ describe("D10 lean-chat local-state cloud agent boot — end-to-end", () => {
 
       // Negative control: a 1536-d vector against the dim384 column trips the
       // insert-path "dimension mismatch" guard — the memory row persists, the
-      // embedding does NOT. Confirms the dim384 column is the one in effect (a
-      // revert to cloud-primary 1536 for fresh provisions would flip both).
+      // embedding does NOT. Together these assertions prove the dim384 column
+      // is the active fresh-provision contract.
       const mismatchId = await adapter.createMemory(makeMemory(1536) as never, "messages");
       const mismatch = await adapter.getMemoryById(mismatchId);
       expect(mismatch).toBeTruthy();

--- a/packages/cloud/shared/src/lib/services/managed-eliza-lean-chat-boot.integration.test.ts
+++ b/packages/cloud/shared/src/lib/services/managed-eliza-lean-chat-boot.integration.test.ts
@@ -15,12 +15,16 @@
  *   2. PLUGIN SET = lean. `@elizaos/agent`'s `collectPluginNames`, driven by the
  *      env's `ELIZA_PLUGIN_SET=lean-chat` + `ELIZAOS_CLOUD_*`, must EXCLUDE
  *      local-inference / wallet / workflow but INCLUDE elizacloud (#8434).
- *   3. EMBEDDING COLUMN = dim1536. The env pins `EMBEDDING_DIMENSION=1536` so the
- *      cloud embedding model's 1536-d vectors land in the `dim_1536` column. We
- *      boot a REAL in-memory PGlite adapter, snap it to the env's dimension, and
- *      prove a 1536-d memory insert SUCCEEDS — while a 384-d insert hits the
- *      "dimension mismatch" guard (the negative control). A revert to the dim_384
- *      default reproduces the "Failed query: insert into embeddings" incident.
+ *   3. EMBEDDING COLUMN = dim384. A FRESH provision (no ELIZAOS_CLOUD_API_KEY in
+ *      existingEnv) defaults to local-primary gte-small embeddings, so the env
+ *      pins `EMBEDDING_DIMENSION=384` and the 384-d vectors land in the
+ *      `dim_384` column (nubs/shaw directive 2026-08-16: self-hosted embeddings
+ *      are the platform default; previously provisioned agents keep their
+ *      pinned 1536 width). We boot a REAL in-memory PGlite adapter, snap it to
+ *      the env's dimension, and prove a 384-d memory insert SUCCEEDS — while a
+ *      1536-d insert hits the "dimension mismatch" guard (the negative
+ *      control). Either drift — a revert to cloud-primary 1536 for fresh
+ *      provisions, or a column/hint disagreement — flips these assertions.
  *
  * Only `apiKeysService.createForAgent` is mocked (it needs the cloud DB to mint a
  * key, irrelevant to this chain) — exactly as the sibling pure-env test does.
@@ -69,8 +73,11 @@ describe("D10 lean-chat local-state cloud agent boot — end-to-end", () => {
     const env = await buildManagedEnv();
     expect(env.ELIZA_AGENT_LOCAL_STATE).toBe("1");
     expect(env.ELIZA_PLUGIN_SET).toBe("lean-chat");
-    expect(env.EMBEDDING_DIMENSION).toBe("1536");
-    expect(env.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("1536");
+    // Fresh provision (no ELIZAOS_CLOUD_API_KEY in existingEnv) => local-primary
+    // gte-small embeddings, 384-d hints, cloud embeddings off.
+    expect(env.EMBEDDING_DIMENSION).toBe("384");
+    expect(env.ELIZAOS_CLOUD_EMBEDDING_DIMENSIONS).toBe("384");
+    expect(env.ELIZAOS_CLOUD_USE_EMBEDDINGS).toBe("false");
     expect(env.ELIZAOS_CLOUD_ENABLED).toBe("true");
     // The load-bearing absence: the producer must NOT carry DATABASE_URL.
     expect(env.DATABASE_URL).toBeUndefined();
@@ -120,10 +127,10 @@ describe("D10 lean-chat local-state cloud agent boot — end-to-end", () => {
     expect(has("plugin-workflow")).toBe(false);
   }, 30_000);
 
-  test("(3) a 1536-d memory insert lands in the dim1536 column (not 'dimension mismatch')", async () => {
+  test("(3) a 384-d memory insert lands in the dim384 column (not 'dimension mismatch')", async () => {
     const env = await buildManagedEnv();
     const dimension = Number(env.EMBEDDING_DIMENSION);
-    expect(dimension).toBe(1536);
+    expect(dimension).toBe(384);
 
     const { createDatabaseAdapter, DatabaseMigrationService, plugin } = await import(
       "@elizaos/plugin-sql"
@@ -140,7 +147,7 @@ describe("D10 lean-chat local-state cloud agent boot — end-to-end", () => {
       migrations.discoverAndRegisterPluginSchemas([plugin]);
       await migrations.runAllPluginMigrations();
 
-      // Snap the active embedding column to the env's dimension (1536) — the
+      // Snap the active embedding column to the env's dimension (384) — the
       // same call core's ensureEmbeddingDimension makes from EMBEDDING_DIMENSION.
       await adapter.ensureEmbeddingDimension(dimension);
 
@@ -165,26 +172,26 @@ describe("D10 lean-chat local-state cloud agent boot — end-to-end", () => {
         content: { text: `vec-${len}` },
         embedding: Array.from({ length: len }, () => 0.01),
         // unique:false skips the costly uniqueness similarity search (which would
-        // itself throw a vector-width error against the dim1536 column for a
-        // 384-d vector) so the test isolates the insert-path dimension guard.
+        // itself throw a vector-width error against the dim384 column for a
+        // 1536-d vector) so the test isolates the insert-path dimension guard.
         unique: false,
         createdAt: Date.now(),
         metadata: { type: "custom", source: "test" },
       });
 
-      // A 1536-d vector matches the dim1536 column → the embedding insert runs.
-      const okId = await adapter.createMemory(makeMemory(1536) as never, "messages");
+      // A 384-d vector matches the dim384 column → the embedding insert runs.
+      const okId = await adapter.createMemory(makeMemory(384) as never, "messages");
       expect(okId).toBeTruthy();
       // The embedding row actually landed (proves it wasn't silently skipped):
-      // getMemoryById joins on the active `dim_1536` column.
+      // getMemoryById joins on the active `dim_384` column.
       const withEmbedding = await adapter.getMemoryById(okId);
-      expect(withEmbedding?.embedding?.length).toBe(1536);
+      expect(withEmbedding?.embedding?.length).toBe(384);
 
-      // Negative control: a 384-d vector against the dim1536 column trips the
+      // Negative control: a 1536-d vector against the dim384 column trips the
       // insert-path "dimension mismatch" guard — the memory row persists, the
-      // embedding does NOT. Confirms the dim1536 column is the one in effect (a
-      // revert to the dim_384 default would flip both assertions).
-      const mismatchId = await adapter.createMemory(makeMemory(384) as never, "messages");
+      // embedding does NOT. Confirms the dim384 column is the one in effect (a
+      // revert to cloud-primary 1536 for fresh provisions would flip both).
+      const mismatchId = await adapter.createMemory(makeMemory(1536) as never, "messages");
       const mismatch = await adapter.getMemoryById(mismatchId);
       expect(mismatch).toBeTruthy();
       expect(mismatch?.embedding ?? []).toHaveLength(0);

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-delete-enqueue.test.ts
@@ -44,11 +44,18 @@ let capturedCancellationWhere: SQL | undefined;
 let selectRows: unknown[] = [];
 let cancelledReturning: Array<{ id: string }> = [];
 
-// select(...).from(...).where(clause).limit(n) -> selectRows
+// The select double supports both ordered stale-row scans and directly awaited
+// fleet-report queries. Tests retain the first WHERE clause for shape checks.
 const selectLimit = mock(() => selectRows);
+const selectOrderBy = mock(() => ({ limit: selectLimit }));
 const selectWhere = mock((clause: SQL) => {
-  capturedSelectWhere = clause;
-  return { limit: selectLimit };
+  capturedSelectWhere ??= clause;
+  return {
+    limit: selectLimit,
+    orderBy: selectOrderBy,
+    // biome-ignore lint/suspicious/noThenProperty: Drizzle query builders are intentionally thenable.
+    then: (resolve: (rows: unknown[]) => unknown) => resolve(selectRows),
+  };
 });
 const selectFrom = mock(() => ({ where: selectWhere }));
 const select = mock(() => ({ from: selectFrom }));
@@ -275,7 +282,9 @@ describe("enqueueScheduledBackups — only reachable agents", () => {
     const { provisioningJobService } = await import("./provisioning-jobs");
 
     const res = await provisioningJobService.enqueueScheduledBackups();
-    expect(res).toEqual({ scanned: 0, enqueued: 0 });
+    // The result also carries the fleet staleness report; this test only pins
+    // the enqueue counters.
+    expect(res).toMatchObject({ scanned: 0, enqueued: 0 });
 
     expect(capturedSelectWhere).toBeDefined();
     const sql = new PgDialect().sqlToQuery(capturedSelectWhere as SQL);
@@ -292,7 +301,7 @@ describe("enqueueScheduledBackups — only reachable agents", () => {
     } as never);
     try {
       const res = await provisioningJobService.enqueueScheduledBackups();
-      expect(res).toEqual({ scanned: 1, enqueued: 1 });
+      expect(res).toMatchObject({ scanned: 1, enqueued: 1 });
       expect(enqueueSpy).toHaveBeenCalledTimes(1);
       expect(enqueueSpy.mock.calls[0]?.[0]).toMatchObject({
         agentId: "agent",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-reminder-relative-delay.runtime.test.ts
@@ -224,7 +224,11 @@ describe("Shared reminder relative-delay runtime authority", () => {
       expect(result.actionResults?.[0]?.success).toBe(false);
       expect(scheduledInputs).toHaveLength(0);
     } else {
-      expect(modelCall).toBe(3);
+      // Two model calls, not three: the REMINDERS action returns a verified
+      // user-facing confirmation (`verifiedUserFacing: true`), and the planner
+      // loop finishes deterministically by echoing that verbatim text instead
+      // of spending a third model call on the completion evaluator.
+      expect(modelCall).toBe(2);
       expect(result.actionResults?.[0]?.success).toBe(true);
       expect(scheduledInputs).toHaveLength(1);
       expect(scheduledInputs[0]?.trigger).toEqual({ kind: "once", atIso });


### PR DESCRIPTION
## Summary

The `@elizaos/cloud-shared` test lane (`bun run --cwd packages/cloud/shared test`) is red on develop tip. This PR greens it — two independent failures, both introduced by `353574037` (merged with zero CI check-runs):

**1. Batch 23/183 — suite killed by an incomplete `mock.module` factory**

```
# Unhandled error between tests
SyntaxError: Export named 'readManagedElizaAgentConnection' not found in module '.../eliza-managed-launch.ts'.
```

`onboarding-chat.ts` gained an import of `readManagedElizaAgentConnection`, but `onboarding-chat.error-policy.test.ts`'s `mock.module("../eliza-managed-launch")` factory only supplied `launchManagedElizaAgent` — a mock factory must provide every named export its consumer imports or the module fails to load. The sibling `onboarding-chat.test.ts` was updated; only the error-policy file was missed. Fix: add the missing mocked export.

**2. Batch 31/182 — model-call-count drift in the reminder runtime proof**

`shared-reminder-relative-delay.runtime.test.ts` asserted `modelCall === 3` on success paths. The REMINDERS action returns `verifiedUserFacing: true`, and the planner loop now finishes deterministically by echoing the verbatim tool confirmation instead of spending a third model call on the completion evaluator. Instrumented runs show the behavior is fully correct — the reminder persists with the exact expected `atIso` (e.g. `2026-08-16T04:49:56.509Z` for "in 1 minute") and all rejection paths still refuse before persistence — only the call-count assertion drifted. Fix: expect the two-call turn with an explanatory comment.


**3. PGlite batch 159/182 — D10 boot proof pinned the pre-directive 1536-d contract**

`managed-eliza-lean-chat-boot.integration.test.ts` expected fresh provisions to pin `EMBEDDING_DIMENSION=1536`. Fresh provisions now default to local-primary gte-small embeddings (384-d hints, cloud embeddings off) per the 2026-08-16 self-hosted-embeddings directive documented in `managed-eliza-config.ts`; the sibling pure-env test (`managed-eliza-config.test.ts`, 22 pass) was updated with the directive, but the D10 end-to-end proof was missed. Fix: the proof now snaps the real PGlite adapter to `dim_384`, proves a 384-d insert lands, and keeps a 1536-d insert as the dimension-mismatch negative control.


**4. PGlite batch 168/182 — delete-enqueue stub missing the scheduled-backup query's new shape**

`enqueueScheduledBackups` now orders stale rows oldest-first (`.orderBy`), issues a second directly-awaited fleet-report select, and returns the fleet report alongside the enqueue counters. `provisioning-jobs-delete-enqueue.test.ts`'s mocked select chain lacked `orderBy`, its `where()` return wasn't awaitable, and the counter assertions used strict `toEqual`. Fix: the stub mirrors the real chain (keeping the first-captured WHERE for the shape assertions) and the counters use `toMatchObject`.

## Verification (exact head)

```
onboarding-chat.error-policy + onboarding-chat: 86 pass, 0 fail (was: SyntaxError, suite dead)
shared-reminder-relative-delay.runtime: 6 pass, 0 fail (was 3 fail)
managed-eliza-lean-chat-boot.integration: 4 pass, 0 fail (was 2 fail)
managed-eliza-config (sibling env contract): 22 pass, 0 fail
provisioning-jobs-delete-enqueue + scheduled-backup-sentinel: 44 pass, 0 fail (was 2 fail)
biome check: clean
```

Stock develop reproduces all four deterministically: the lane stops at batch 23; each successive fix advances it (23 -> 31 -> pglite 159 -> pglite 168). Full-lane confirmation run with all four fixes in progress; will post the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-head:830641ea2671b08acf83da184b0d21c40ba3b051 -->

<!-- evidence-row:backend-logs -->
- [x] [20853-pr20853-cloud-shared-full-3.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20853-pr20853-cloud-shared-full-3.log)

<!-- evidence-row:domain-artifacts -->
- [x] [20853-pr20853-domain-artifacts.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20853-pr20853-domain-artifacts.log)

<!-- evidence-row:before-screenshots -->
- [ ] N/A: test-only baseline repair; no visual surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A: test-only baseline repair; no visual surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A: no user-facing interaction

<!-- evidence-row:frontend-logs -->
- [ ] N/A: no frontend runtime path

<!-- evidence-row:llm-trajectory -->
- [ ] N/A: deterministic test fixtures only; no live model behavior changed
