### PR TITLE
fix(cloud): make inference credential revocation strongly consistent

### DIFF
--- a/packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts
@@ -156,6 +156,7 @@ describe("Miniflare Durable Object integration", () => {
           useSQLite: true,
         },
       },
+      kvNamespaces: ["TEST_AUTH_CACHE"],
     });
   });
 
@@ -242,4 +243,102 @@ describe("Miniflare Durable Object integration", () => {
     }
     expect([first.status, second.status].sort()).toEqual([200, 402]);
   }, 120_000);
+
+  test("independent callers observe API-key revocation immediately", async () => {
+    const credential = {
+      organizationId: "org-miniflare",
+      kind: "api_key",
+      credentialId: "00000000-0000-0000-0000-000000000101",
+      userId: "00000000-0000-0000-0000-000000000201",
+    };
+    const staleCache = await miniflare.getKVNamespace("TEST_AUTH_CACHE");
+    const staleCacheKey = "inference-auth:test-stale-positive";
+    const stalePositive = JSON.stringify({
+      kind: "authorized",
+      apiKeyId: credential.credentialId,
+      userId: credential.userId,
+      organizationId: credential.organizationId,
+    });
+    await staleCache.put(staleCacheKey, stalePositive);
+    expect((await post("/credential/check", credential)).status).toBe(200);
+    expect(
+      (
+        await post("/credential/revoke", {
+          organizationId: credential.organizationId,
+          kind: credential.kind,
+          credentialId: credential.credentialId,
+        })
+      ).status,
+    ).toBe(200);
+
+    // This second dispatch models another Worker location retaining a stale
+    // positive KV entry. Deliberately leave the real workerd KV value untouched
+    // to model delayed delete visibility: the shared DO remains authoritative.
+    expect((await staleCache.get(staleCacheKey)) as string | null).toBe(
+      stalePositive,
+    );
+    expect((await post("/credential/check", credential)).status).toBe(403);
+    expect((await staleCache.get(staleCacheKey)) as string | null).toBe(
+      stalePositive,
+    );
+  });
+
+  test("session cutoff revokes old tokens without rejecting a later login", async () => {
+    const base = {
+      organizationId: "org-miniflare",
+      kind: "steward_session",
+      userId: "00000000-0000-0000-0000-000000000202",
+    };
+    expect(
+      (
+        await post("/session/revoke-through", {
+          organizationId: base.organizationId,
+          userId: base.userId,
+          issuedAt: 100,
+        })
+      ).status,
+    ).toBe(200);
+    expect(
+      (await post("/credential/check", { ...base, issuedAt: 100 })).status,
+    ).toBe(403);
+    expect(
+      (await post("/credential/check", { ...base, issuedAt: 101 })).status,
+    ).toBe(200);
+  });
+
+  test("subject and organization suspension are reversible durable fences", async () => {
+    const credential = {
+      organizationId: "org-miniflare",
+      kind: "api_key",
+      credentialId: "00000000-0000-0000-0000-000000000102",
+      userId: "00000000-0000-0000-0000-000000000203",
+    };
+    expect(
+      (
+        await post("/subject/set-active", {
+          organizationId: credential.organizationId,
+          userId: credential.userId,
+          active: false,
+        })
+      ).status,
+    ).toBe(200);
+    expect((await post("/credential/check", credential)).status).toBe(403);
+    await post("/subject/set-active", {
+      organizationId: credential.organizationId,
+      userId: credential.userId,
+      active: true,
+    });
+    expect((await post("/credential/check", credential)).status).toBe(200);
+
+    await post("/organization/set-active", {
+      organizationId: credential.organizationId,
+      active: false,
+    });
+    expect((await post("/credential/check", credential)).status).toBe(403);
+    await post("/organization/set-active", {
+      organizationId: credential.organizationId,
+      active: true,
+    });
+    expect((await post("/credential/check", credential)).status).toBe(200);
+  });
 });

--- a/packages/cloud/api/auth/logout/route.test.ts
+++ b/packages/cloud/api/auth/logout/route.test.ts
@@ -4,10 +4,17 @@
  * but exercises the real route and cookie headers.
  */
 
-import { describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-const getCurrentUserMock = mock(async () => null);
+const getCurrentUserMock = mock(
+  async (): Promise<{ id: string; organization_id: string } | null> => null,
+);
 const endAllUserSessionsMock = mock(async () => undefined);
+const verifyStewardTokenMock = mock(async () => ({
+  userId: "steward-1",
+  issuedAt: 100,
+}));
+const revokeInferenceSessionsThroughMock = mock(async () => undefined);
 
 mock.module("@/lib/auth", () => ({
   invalidateSessionCaches: mock(async () => undefined),
@@ -15,6 +22,9 @@ mock.module("@/lib/auth", () => ({
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   getCurrentUser: getCurrentUserMock,
+}));
+mock.module("@/lib/auth/steward-client", () => ({
+  verifyStewardTokenCached: verifyStewardTokenMock,
 }));
 
 mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
@@ -27,6 +37,11 @@ mock.module("@/lib/services/user-sessions", () => ({
     endAllUserSessions: endAllUserSessionsMock,
   },
 }));
+mock.module("@/lib/services/inference-credential-revocation", () => ({
+  isInferenceStrongRevocationEnabled: (env: Record<string, unknown>) =>
+    env.INFERENCE_STRONG_REVOCATION_ENABLED === "true",
+  revokeInferenceSessionsThrough: revokeInferenceSessionsThroughMock,
+}));
 
 mock.module("@/api-app/services/audit-dispatcher-singleton", () => ({
   getAuditDispatcher: () => ({
@@ -37,6 +52,7 @@ mock.module("@/api-app/services/audit-dispatcher-singleton", () => ({
 mock.module("@/lib/utils/logger", () => ({
   logger: {
     debug: mock(() => undefined),
+    error: mock(() => undefined),
     warn: mock(() => undefined),
   },
 }));
@@ -50,7 +66,83 @@ function deletedCookieNames(res: Response): string[] {
     .map((cookie) => cookie.split("=")[0]);
 }
 
+beforeEach(() => {
+  getCurrentUserMock.mockResolvedValue(null);
+  verifyStewardTokenMock.mockResolvedValue({
+    userId: "steward-1",
+    issuedAt: 100,
+  });
+  revokeInferenceSessionsThroughMock.mockResolvedValue(undefined);
+});
+
 describe("POST /api/auth/logout cookie clearing", () => {
+  test("strong rollout commits the session cutoff before reporting logout success", async () => {
+    getCurrentUserMock.mockResolvedValue({
+      id: "user-1",
+      organization_id: "org-1",
+    });
+    revokeInferenceSessionsThroughMock.mockResolvedValue(undefined);
+    revokeInferenceSessionsThroughMock.mockClear();
+
+    const res = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          host: "api.elizacloud.ai",
+          origin: "https://eliza.app",
+          cookie: "steward-token=prod-token",
+        },
+      },
+      {
+        ENVIRONMENT: "production",
+        NODE_ENV: "production",
+        INFERENCE_STRONG_REVOCATION_ENABLED: "true",
+      },
+    );
+
+    expect(res.status).toBe(200);
+    expect(revokeInferenceSessionsThroughMock).toHaveBeenCalledWith(
+      "org-1",
+      "user-1",
+      100,
+    );
+  });
+
+  test("strong rollout clears cookies but returns 503 when the cutoff is unconfirmed", async () => {
+    getCurrentUserMock.mockResolvedValue({
+      id: "user-1",
+      organization_id: "org-1",
+    });
+    revokeInferenceSessionsThroughMock.mockRejectedValueOnce(
+      new Error("boundary unavailable"),
+    );
+
+    const res = await app.request(
+      "/",
+      {
+        method: "POST",
+        headers: {
+          host: "api.elizacloud.ai",
+          origin: "https://eliza.app",
+          cookie: "steward-token=prod-token",
+        },
+      },
+      {
+        ENVIRONMENT: "production",
+        NODE_ENV: "production",
+        INFERENCE_STRONG_REVOCATION_ENABLED: "true",
+      },
+    );
+
+    expect(res.status).toBe(503);
+    expect(deletedCookieNames(res)).toContain("steward-token");
+    expect((await res.json()) as unknown).toEqual({
+      error: "Logout revocation is temporarily unavailable",
+      code: "logout_revocation_unavailable",
+    });
+  });
+
   test("staging legacy-only logout does not end production user sessions", async () => {
     getCurrentUserMock.mockClear();
     endAllUserSessionsMock.mockClear();

--- a/packages/cloud/api/auth/logout/route.ts
+++ b/packages/cloud/api/auth/logout/route.ts
@@ -17,6 +17,10 @@ import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
+import {
+  isInferenceStrongRevocationEnabled,
+  revokeInferenceSessionsThrough,
+} from "@/lib/services/inference-credential-revocation";
 import { markSsoBridgeLogout } from "@/lib/services/sso-bridge-codes";
 import { userSessionsService } from "@/lib/services/user-sessions";
 import { logger } from "@/lib/utils/logger";
@@ -67,6 +71,32 @@ app.post("/", async (c) => {
   deleteCookie(c, cookieNames.refreshToken, stewardOpts);
   deleteCookie(c, cookieNames.authed, stewardOpts);
   deleteCookie(c, "eliza-anon-session", { path: "/" });
+
+  let strongRevocationFailed = false;
+  if (stewardToken && isInferenceStrongRevocationEnabled(c.env)) {
+    try {
+      const [claims, user] = await Promise.all([
+        verifyStewardTokenCached(c.env, stewardToken),
+        getCurrentUser(c),
+      ]);
+      if (!claims || !user?.organization_id) {
+        throw new Error("logout credential identity could not be resolved");
+      }
+      await revokeInferenceSessionsThrough(
+        user.organization_id,
+        user.id,
+        claims.issuedAt,
+      );
+    } catch (error) {
+      // error-policy:J1 cookies are already cleared, but the server must not
+      // claim a globally complete logout until the strong inference boundary
+      // confirms that the presented session generation is denied.
+      logger.error("[Logout] Strong inference-session revocation failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      strongRevocationFailed = true;
+    }
+  }
 
   // Stamp the cross-host SSO logout marker FIRST and in its own guarded block:
   // the sso-bridge legs and the cookie-planting session-sync endpoint refuse
@@ -152,6 +182,16 @@ app.post("/", async (c) => {
       {
         error: error instanceof Error ? error.message : String(error),
       },
+    );
+  }
+
+  if (strongRevocationFailed) {
+    return c.json(
+      {
+        error: "Logout revocation is temporarily unavailable",
+        code: "logout_revocation_unavailable" as const,
+      },
+      503,
     );
   }
 

--- a/packages/cloud/api/docs/inference-hot-path.md
+++ b/packages/cloud/api/docs/inference-hot-path.md
@@ -24,16 +24,17 @@ The synchronous Worker path is:
    scope may perform one additional Cloudflare KV read and hydrate Postgres
    under `waitUntil`; it never falls through to Postgres on the request promise.
    Affiliate and pooled-credential features retain conditional cache decisions.
-3. A per-organization Durable Object call that serializes the exact endpoint
-   rate decision.
-4. A call to the same object that durably leases the estimated charge.
-5. A final call that durably marks provider-dispatch intent immediately before
+3. A call to the per-organization Durable Object that verifies the immutable
+   credential identity and its user and organization denial fences.
+4. A call to the same object that serializes the exact endpoint rate decision.
+5. A call to the same object that durably leases the estimated charge.
+6. A final call that durably marks provider-dispatch intent immediately before
    the provider invocation.
-6. Provider dispatch.
+7. Provider dispatch.
 
 A steady-state base request therefore has one remote shared-cache read and
-three serial Durable Object calls before the provider. Keeping rate, money,
-and dispatch-intent transitions explicit
+four serial Durable Object calls before the provider. Keeping revocation,
+rate, money, and dispatch-intent transitions explicit
 makes the crash states independently testable. The repository benchmark measures
 those calls in-process; it is a regression tripwire, not evidence of deployed
 cross-isolate or regional network latency.
@@ -74,7 +75,7 @@ selected production architecture.
 
 | State | Synchronous owner | Durable/source-of-truth owner | Consistency |
 | --- | --- | --- | --- |
-| API-key and Steward-session authorization | One combined Cloudflare KV decision | Postgres/Steward | 60s physical bound; active entries refresh after 30s under `waitUntil` |
+| API-key and Steward-session authorization | Cloudflare KV projection plus per-org Durable Object check | Postgres/Steward + revocation Durable Object | Strong revoke/logout/suspension fence; KV refreshes after 30s and expires after 60s |
 | Moderation, balance, endpoint-rate policy, and app-key scope | Same combined decision | Postgres | Revisioned/bounded snapshot; refreshed off-response |
 | Model pricing | Cloudflare KV | Pricing tables | Revisioned cache; cold requests warm and retry |
 | Affiliate attribution | Cloudflare KV | Postgres | Immutable snapshot per admitted request |
@@ -95,14 +96,14 @@ remain transactional in Postgres and publish monotonic cache revisions.
 
 ## Authorization and cold-cache behavior
 
-`INFERENCE_AUTH_CACHE_ENABLED` is enabled in staging and production. Warm API
+Once both authorization rollout flags are enabled, warm API
 keys and Steward sessions perform one combined remote decision read containing
 identity, organization, moderation, balance, rate policy, and API-key app scope.
 The physical TTL is 60 seconds;
 an active entry older than 30 seconds is served immediately while an
-authoritative refresh runs under `waitUntil`. This bounds a lost or
-eventually-consistent invalidation to the same one-minute horizon already used
-by moderation decisions without joining Postgres or Steward to dispatch.
+authoritative refresh runs under `waitUntil`. A following Durable Object check
+prevents a lost or eventually-consistent invalidation from extending
+authorization without joining Postgres or Steward to dispatch.
 
 The implementation accepts positive cache entries only for fully authorized
 credentials. API-key entries are keyed by the full credential hash. Steward
@@ -120,8 +121,21 @@ On a Worker cache miss:
   cache.
 
 When the gate is enabled, cache errors never fabricate authorization and never
-join a Postgres fallback to the request promise. Invalidation is only a cache
-hygiene mechanism; it is not the authorization revocation boundary.
+join a Postgres fallback to the request promise. Invalidation is only cache
+hygiene. The per-organization Durable Object is the revocation boundary: every
+positive API-key or Steward-session decision crosses it before provider
+dispatch, and an unavailable boundary fails closed.
+
+`INFERENCE_STRONG_REVOCATION_ENABLED` is an independent rollout control.
+`INFERENCE_AUTH_CACHE_ENABLED` cannot activate positive authorization caching
+unless the strong boundary flag is also true. API keys use their immutable row
+ID, Steward logout records the verified token `iat`, user lifecycle changes
+fence the immutable Cloud user ID, and organization suspension fences the
+organization object. Revocation mutations commit the fence before returning;
+reactivation clears only reversible subject or organization fences, while a
+revoked API-key identity can never be reused. Organization moves and local role
+or Steward-identity changes advance the session cutoff before the corresponding
+database mutation reports success.
 
 Pricing, affiliate attribution, app/agent policy, and uninitialized Durable
 Objects follow the same fail-closed warming pattern. Route-scope caches add no
@@ -260,8 +274,11 @@ Staging and production inference require:
 - `INFERENCE_DEFERRED_ADMISSION="true"`; and
 - `INFERENCE_HOT_PATH_CACHES="true"`.
 
-`INFERENCE_AUTH_CACHE_ENABLED="true"` and
-`THIN_INFERENCE_ENTRY_ENABLED="true"` are enabled in staging and production.
+`INFERENCE_AUTH_CACHE_ENABLED="true"` is inert unless
+`INFERENCE_STRONG_REVOCATION_ENABLED="true"`. The strong flag remains false in
+checked-in staging and production configuration until rollout evidence is
+approved, so authoritative authorization remains the default. The thin entry
+has its own `THIN_INFERENCE_ENTRY_ENABLED` rollout control.
 The thin entry lazily evaluates only the matched generative route module rather
 than the monolithic API router. Either flag remains an independent rollback
 control.

--- a/packages/cloud/api/src/inference-admission-gate.ts
+++ b/packages/cloud/api/src/inference-admission-gate.ts
@@ -87,6 +87,43 @@ interface RateLimitRequest {
   maxRequests: number;
 }
 
+type CredentialCheckRequest =
+  | {
+      organizationId: string;
+      kind: "api_key";
+      credentialId: string;
+      userId: string;
+    }
+  | {
+      organizationId: string;
+      kind: "steward_session";
+      userId: string;
+      issuedAt: number;
+    };
+
+interface CredentialRevokeRequest {
+  organizationId: string;
+  kind: "api_key";
+  credentialId: string;
+}
+
+interface SubjectStateRequest {
+  organizationId: string;
+  userId: string;
+  active: boolean;
+}
+
+interface SessionRevokeRequest {
+  organizationId: string;
+  userId: string;
+  issuedAt: number;
+}
+
+interface OrganizationStateRequest {
+  organizationId: string;
+  active: boolean;
+}
+
 interface RateLimitWindow {
   windowStartedAt: number;
   windowMs: number;
@@ -101,6 +138,10 @@ const LEASE_KEY_PREFIX = "lease:";
 const LEASE_ACTIVE_KEY_PREFIX = "lease-active:";
 const LEASE_EXPIRY_KEY_PREFIX = "lease-expiry:";
 const RATE_LIMITS_KEY = "rate-limits";
+const ORGANIZATION_DISABLED_KEY = "revocation:organization-disabled";
+const REVOKED_API_KEY_PREFIX = "revocation:api-key:";
+const DISABLED_SUBJECT_PREFIX = "revocation:subject-disabled:";
+const SESSION_CUTOFF_PREFIX = "revocation:session-cutoff:";
 const MAX_LEASE_AGE_MS = 20 * 60_000;
 const RECOVERY_RETRY_MS = 60_000;
 const MAX_ACTIVE_LEASES = 2_048;
@@ -146,6 +187,10 @@ function validRequestId(value: unknown): value is string {
 
 function validTrimmedId(value: unknown): value is string {
   return validId(value) && value.trim() === value;
+}
+
+function revocationStorageKey(prefix: string, id: string): string {
+  return `${prefix}${encodeURIComponent(id)}`;
 }
 
 function validRecoveryContext(
@@ -891,6 +936,124 @@ export class InferenceAdmissionGate {
     );
   }
 
+  private async credentialCheck(
+    request: CredentialCheckRequest,
+  ): Promise<Response> {
+    if (
+      !validTrimmedId(request.organizationId) ||
+      !validTrimmedId(request.userId) ||
+      (request.kind === "api_key" && !validTrimmedId(request.credentialId)) ||
+      (request.kind === "steward_session" &&
+        (!Number.isSafeInteger(request.issuedAt) || request.issuedAt <= 0))
+    ) {
+      return jsonError("Invalid inference credential check", 400);
+    }
+
+    if (await this.state.storage.get<boolean>(ORGANIZATION_DISABLED_KEY)) {
+      return Response.json(
+        { allowed: false, reason: "organization_disabled" },
+        { status: 403 },
+      );
+    }
+    if (
+      await this.state.storage.get<boolean>(
+        revocationStorageKey(DISABLED_SUBJECT_PREFIX, request.userId),
+      )
+    ) {
+      return Response.json(
+        { allowed: false, reason: "subject_disabled" },
+        { status: 403 },
+      );
+    }
+
+    if (request.kind === "api_key") {
+      const revoked = await this.state.storage.get<boolean>(
+        revocationStorageKey(REVOKED_API_KEY_PREFIX, request.credentialId),
+      );
+      return revoked
+        ? Response.json(
+            { allowed: false, reason: "credential_revoked" },
+            { status: 403 },
+          )
+        : Response.json({ allowed: true });
+    }
+
+    const cutoff = await this.state.storage.get<number>(
+      revocationStorageKey(SESSION_CUTOFF_PREFIX, request.userId),
+    );
+    return cutoff !== undefined && request.issuedAt <= cutoff
+      ? Response.json(
+          { allowed: false, reason: "session_revoked" },
+          { status: 403 },
+        )
+      : Response.json({ allowed: true });
+  }
+
+  private async revokeCredential(
+    request: CredentialRevokeRequest,
+  ): Promise<Response> {
+    if (
+      !validTrimmedId(request.organizationId) ||
+      request.kind !== "api_key" ||
+      !validTrimmedId(request.credentialId)
+    ) {
+      return jsonError("Invalid inference credential revocation", 400);
+    }
+    await this.state.storage.put(
+      revocationStorageKey(REVOKED_API_KEY_PREFIX, request.credentialId),
+      true,
+    );
+    return Response.json({ committed: true });
+  }
+
+  private async setSubjectActive(
+    request: SubjectStateRequest,
+  ): Promise<Response> {
+    if (
+      !validTrimmedId(request.organizationId) ||
+      !validTrimmedId(request.userId) ||
+      typeof request.active !== "boolean"
+    ) {
+      return jsonError("Invalid inference subject state", 400);
+    }
+    const key = revocationStorageKey(DISABLED_SUBJECT_PREFIX, request.userId);
+    if (request.active) await this.state.storage.delete(key);
+    else await this.state.storage.put(key, true);
+    return Response.json({ committed: true });
+  }
+
+  private async revokeSessionsThrough(
+    request: SessionRevokeRequest,
+  ): Promise<Response> {
+    if (
+      !validTrimmedId(request.organizationId) ||
+      !validTrimmedId(request.userId) ||
+      !Number.isSafeInteger(request.issuedAt) ||
+      request.issuedAt <= 0
+    ) {
+      return jsonError("Invalid inference session revocation", 400);
+    }
+    const key = revocationStorageKey(SESSION_CUTOFF_PREFIX, request.userId);
+    const previous = (await this.state.storage.get<number>(key)) ?? 0;
+    await this.state.storage.put(key, Math.max(previous, request.issuedAt));
+    return Response.json({ committed: true });
+  }
+
+  private async setOrganizationActive(
+    request: OrganizationStateRequest,
+  ): Promise<Response> {
+    if (
+      !validTrimmedId(request.organizationId) ||
+      typeof request.active !== "boolean"
+    ) {
+      return jsonError("Invalid inference organization state", 400);
+    }
+    if (request.active)
+      await this.state.storage.delete(ORGANIZATION_DISABLED_KEY);
+    else await this.state.storage.put(ORGANIZATION_DISABLED_KEY, true);
+    return Response.json({ committed: true });
+  }
+
   async fetch(request: Request): Promise<Response> {
     if (request.method !== "POST") {
       return new Response("Method not allowed", { status: 405 });
@@ -900,14 +1063,24 @@ export class InferenceAdmissionGate {
       | HydrateRequest
       | SettleRequest
       | LeaseIdentityRequest
-      | RateLimitRequest;
+      | RateLimitRequest
+      | CredentialCheckRequest
+      | CredentialRevokeRequest
+      | SubjectStateRequest
+      | SessionRevokeRequest
+      | OrganizationStateRequest;
     try {
       body = (await request.json()) as
         | LeaseRequest
         | HydrateRequest
         | SettleRequest
         | LeaseIdentityRequest
-        | RateLimitRequest;
+        | RateLimitRequest
+        | CredentialCheckRequest
+        | CredentialRevokeRequest
+        | SubjectStateRequest
+        | SessionRevokeRequest
+        | OrganizationStateRequest;
     } catch {
       // error-policy:J3 malformed request bodies are rejected explicitly.
       return jsonError("Invalid JSON body", 400);
@@ -936,6 +1109,31 @@ export class InferenceAdmissionGate {
     if (path === "/rate-limit") {
       return await this.serialize(() =>
         this.rateLimit(body as RateLimitRequest),
+      );
+    }
+    if (path === "/credential/check") {
+      return await this.serialize(() =>
+        this.credentialCheck(body as CredentialCheckRequest),
+      );
+    }
+    if (path === "/credential/revoke") {
+      return await this.serialize(() =>
+        this.revokeCredential(body as CredentialRevokeRequest),
+      );
+    }
+    if (path === "/subject/set-active") {
+      return await this.serialize(() =>
+        this.setSubjectActive(body as SubjectStateRequest),
+      );
+    }
+    if (path === "/session/revoke-through") {
+      return await this.serialize(() =>
+        this.revokeSessionsThrough(body as SessionRevokeRequest),
+      );
+    }
+    if (path === "/organization/set-active") {
+      return await this.serialize(() =>
+        this.setOrganizationActive(body as OrganizationStateRequest),
       );
     }
     return new Response("Not found", { status: 404 });

--- a/packages/cloud/api/test/e2e/group-b-account-billing.test.ts
+++ b/packages/cloud/api/test/e2e/group-b-account-billing.test.ts
@@ -212,7 +212,9 @@ describeE2E("POST /api/v1/api-keys/:id/regenerate", () => {
       apiKey?: { id?: string };
       plainKey?: string;
     };
-    expect(regen.apiKey?.id).toBe(created.apiKey?.id ?? "");
+    expect(regen.apiKey?.id).toBeTruthy();
+    expect(regen.apiKey?.id).not.toBe(created.apiKey?.id ?? "");
+    if (regen.apiKey?.id) createdApiKeyIds.push(regen.apiKey.id);
     expect(regen.plainKey).toMatch(/^eliza_/);
     expect(regen.plainKey).not.toBe(created.plainKey);
   });

--- a/packages/cloud/api/v1/api-keys/[id]/regenerate/route.ts
+++ b/packages/cloud/api/v1/api-keys/[id]/regenerate/route.ts
@@ -33,35 +33,8 @@ app.post("/", async (c) => {
       c,
     });
 
-    // D-1: plaintext is no longer stored in a `key` column. We mint a new
-    // key, hash it, and persist the encrypted ciphertext + new hash/prefix.
-    const {
-      key: newKey,
-      hash: newHash,
-      prefix: newPrefix,
-    } = apiKeysService.generateApiKey();
-
-    const { encryptApiKey } = await import(
-      "@elizaos/cloud-shared/db/crypto/api-keys"
-    );
-    const encrypted = await encryptApiKey(
-      existingKey.organization_id,
-      existingKey.id,
-      newKey,
-    );
-
-    const updatedKey = await apiKeysService.update(id, {
-      key_hash: newHash,
-      key_prefix: newPrefix,
-      key_ciphertext: encrypted.ciphertext,
-      key_nonce: encrypted.nonce,
-      key_auth_tag: encrypted.auth_tag,
-      key_kms_key_id: encrypted.kms_key_id,
-      key_kms_key_version: encrypted.kms_key_version,
-      updated_at: new Date(),
-    });
-    if (!updatedKey)
-      return c.json({ error: "Failed to regenerate API key" }, 500);
+    const { apiKey: updatedKey, plainKey } =
+      await apiKeysService.regenerate(id);
 
     await getAuditDispatcher()
       .emit({
@@ -90,7 +63,7 @@ app.post("/", async (c) => {
         rate_limit: updatedKey.rate_limit,
         expires_at: updatedKey.expires_at,
       },
-      plainKey: newKey,
+      plainKey,
     });
   } catch (error) {
     logger.error("Error regenerating API key:", error);

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -263,6 +263,8 @@ INFERENCE_DEFERRED_ADMISSION = "true"
 INFERENCE_HOT_PATH_CACHES = "false"
 # Positive auth caching stays off until revocation is strongly consistent.
 INFERENCE_AUTH_CACHE_ENABLED = "false"
+# Strong revocation is staged independently; auth caching requires both flags.
+INFERENCE_STRONG_REVOCATION_ENABLED = "false"
 # Pass-through streaming fast path (#15428): "true" pipes qualifying streamed
 # chat completions (OpenAI-compatible direct upstream, no tools/response_format/
 # web-search) byte-for-byte from the provider instead of decoding/re-encoding
@@ -597,6 +599,8 @@ INFERENCE_HOT_PATH_CACHES = "true"
 # One combined auth+org+moderation read; authoritative refresh runs only under
 # waitUntil and the 60s physical TTL bounds lost invalidation.
 INFERENCE_AUTH_CACHE_ENABLED = "true"
+# Default authoritative until the Durable Object revocation lane is soaked.
+INFERENCE_STRONG_REVOCATION_ENABLED = "false"
 # Pass-through streaming fast path (#15428): "true" pipes qualifying streamed
 # chat completions (OpenAI-compatible direct upstream, no tools/response_format/
 # web-search) byte-for-byte from the provider instead of decoding/re-encoding
@@ -843,6 +847,8 @@ INFERENCE_HOT_PATH_CACHES = "true"
 # One combined auth+org+moderation read; authoritative refresh runs only under
 # waitUntil and the 60s physical TTL bounds lost invalidation.
 INFERENCE_AUTH_CACHE_ENABLED = "true"
+# Default authoritative until the Durable Object revocation lane is soaked.
+INFERENCE_STRONG_REVOCATION_ENABLED = "false"
 # Pass-through streaming fast path (#15428): "true" pipes qualifying streamed
 # chat completions (OpenAI-compatible direct upstream, no tools/response_format/
 # web-search) byte-for-byte from the provider instead of decoding/re-encoding

--- a/packages/cloud/shared/src/db/repositories/api-keys.ts
+++ b/packages/cloud/shared/src/db/repositories/api-keys.ts
@@ -151,6 +151,15 @@ export class ApiKeysRepository {
     return apiKey;
   }
 
+  /** Atomically replaces one immutable credential row with a freshly identified row. */
+  async replace(id: string, replacement: NewApiKey): Promise<ApiKey> {
+    return await dbWrite.transaction(async (tx) => {
+      await tx.delete(apiKeys).where(eq(apiKeys.id, id));
+      const [created] = await tx.insert(apiKeys).values(replacement).returning();
+      return created;
+    });
+  }
+
   /**
    * Updates an existing API key.
    */

--- a/packages/cloud/shared/src/lib/api/errors.test.ts
+++ b/packages/cloud/shared/src/lib/api/errors.test.ts
@@ -16,6 +16,10 @@ const named = (name: string, message = "x"): Error => {
 };
 
 describe("getErrorStatusCode", () => {
+  test("maps a failed inference revocation boundary to retryable service unavailability", () => {
+    expect(getErrorStatusCode(named("InferenceCredentialRevocationUnavailableError"))).toBe(503);
+  });
+
   test("maps by error name", () => {
     expect(getErrorStatusCode(named("NotFoundError"))).toBe(404);
     expect(getErrorStatusCode(named("RateLimitError"))).toBe(429);

--- a/packages/cloud/shared/src/lib/api/errors.ts
+++ b/packages/cloud/shared/src/lib/api/errors.ts
@@ -167,6 +167,9 @@ export function getErrorStatusCode(error: unknown): number {
     if (error.name === "RateLimitError") {
       return 429;
     }
+    if (error.name === "InferenceCredentialRevocationUnavailableError") {
+      return 503;
+    }
 
     // DB / internal failures that mention "authentication" must stay 500 (compat routes)
     if (

--- a/packages/cloud/shared/src/lib/services/admin.ts
+++ b/packages/cloud/shared/src/lib/services/admin.ts
@@ -23,6 +23,7 @@ import {
   invalidateInferenceAuthContextsByKeyHashes,
   invalidateInferenceSessionAuthContexts,
 } from "./inference-auth-cache";
+import { setInferenceSubjectActive } from "./inference-credential-revocation";
 
 /**
  * Clear the inference auth-context cache (#9899) for every API key a user owns.
@@ -489,6 +490,13 @@ class AdminService {
     const now = new Date();
 
     const existing = await this.getUserModerationStatus(userId);
+    const user = await dbRead.query.users.findFirst({
+      where: eq(users.id, userId),
+      columns: { organization_id: true },
+    });
+    if (user?.organization_id) {
+      await setInferenceSubjectActive(user.organization_id, userId, false);
+    }
 
     if (existing) {
       await dbWrite
@@ -538,6 +546,14 @@ class AdminService {
         updatedAt: new Date(),
       })
       .where(eq(userModerationStatus.userId, userId));
+
+    const user = await dbRead.query.users.findFirst({
+      where: eq(users.id, userId),
+      columns: { organization_id: true },
+    });
+    if (user?.organization_id) {
+      await setInferenceSubjectActive(user.organization_id, userId, true);
+    }
 
     logger.info("[Admin] User unbanned", { userId, adminUserId });
   }

--- a/packages/cloud/shared/src/lib/services/api-keys.invalidation.test.ts
+++ b/packages/cloud/shared/src/lib/services/api-keys.invalidation.test.ts
@@ -22,6 +22,7 @@ import type { ApiKey } from "../../db/repositories";
 import { apiKeysRepository } from "../../db/repositories";
 import { cache } from "../cache/client";
 import { CacheKeys } from "../cache/keys";
+import { runWithCloudBindingsAsync } from "../runtime/cloud-bindings";
 import { apiKeysService } from "./api-keys";
 
 const KEY_HASH = "a".repeat(64);
@@ -95,6 +96,44 @@ describe("apiKeysService.invalidateCache fails closed (#13417)", () => {
 
     await expect(apiKeysService.delete("key-1")).resolves.toBeUndefined();
     expect(repoDelete).toHaveBeenCalledWith("key-1");
+  });
+
+  test("delete(): strong revocation must commit before cache or database mutation", async () => {
+    track(spyOn(apiKeysRepository, "findById").mockResolvedValue(fakeKey()));
+    const repoDelete = track(spyOn(apiKeysRepository, "delete").mockResolvedValue(undefined));
+    const cacheDelete = track(spyOn(cache, "delConfirmed").mockResolvedValue(true));
+    const namespace = {
+      getByName: () => ({
+        fetch: async () => Response.json({ error: "unavailable" }, { status: 503 }),
+      }),
+    };
+
+    await expect(
+      runWithCloudBindingsAsync(
+        {
+          INFERENCE_STRONG_REVOCATION_ENABLED: "true",
+          INFERENCE_ADMISSION_GATES: namespace,
+        },
+        () => apiKeysService.delete("key-1"),
+      ),
+    ).rejects.toThrow(/status 503/i);
+    expect(cacheDelete).not.toHaveBeenCalled();
+    expect(repoDelete).not.toHaveBeenCalled();
+  });
+
+  test("an inactive immutable key identity cannot be reactivated", async () => {
+    track(
+      spyOn(apiKeysRepository, "findById").mockResolvedValue({
+        ...fakeKey(),
+        is_active: false,
+      }),
+    );
+    const repoUpdate = track(spyOn(apiKeysRepository, "update").mockResolvedValue(undefined));
+
+    await expect(apiKeysService.update("key-1", { is_active: true })).rejects.toMatchObject({
+      code: "API_KEY_IDENTITY_REVOKED",
+    });
+    expect(repoUpdate).not.toHaveBeenCalled();
   });
 
   test("invalidateInferenceContextForUser: unconfirmed fan-out throws (ban fails closed)", async () => {

--- a/packages/cloud/shared/src/lib/services/api-keys.invalidation.test.ts
+++ b/packages/cloud/shared/src/lib/services/api-keys.invalidation.test.ts
@@ -18,6 +18,7 @@
  */
 
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import * as apiKeyCrypto from "../../db/crypto/api-keys";
 import type { ApiKey } from "../../db/repositories";
 import { apiKeysRepository } from "../../db/repositories";
 import { cache } from "../cache/client";
@@ -134,6 +135,58 @@ describe("apiKeysService.invalidateCache fails closed (#13417)", () => {
       code: "API_KEY_IDENTITY_REVOKED",
     });
     expect(repoUpdate).not.toHaveBeenCalled();
+  });
+
+  test("regenerate permanently revokes the old identity and atomically replaces its row", async () => {
+    const existing = {
+      ...fakeKey(),
+      name: "rotated key",
+      description: null,
+      rate_limit: 1000,
+      expires_at: null,
+    } as ApiKey;
+    track(spyOn(apiKeysRepository, "findById").mockResolvedValue(existing));
+    track(spyOn(cache, "delConfirmed").mockResolvedValue(true));
+    track(
+      spyOn(apiKeyCrypto, "encryptApiKey").mockResolvedValue({
+        ciphertext: "ciphertext",
+        nonce: "nonce",
+        auth_tag: "tag",
+        kms_key_id: "kms-key",
+        kms_key_version: 1,
+      }),
+    );
+    const replacement = { ...existing, id: "key-2", key_hash: "b".repeat(64) };
+    const replace = track(spyOn(apiKeysRepository, "replace").mockResolvedValue(replacement));
+    const revocations: Array<Record<string, unknown>> = [];
+    const namespace = {
+      getByName: () => ({
+        fetch: async (request: Request) => {
+          revocations.push(await request.json());
+          return Response.json({ committed: true });
+        },
+      }),
+    };
+
+    const result = await runWithCloudBindingsAsync(
+      {
+        INFERENCE_STRONG_REVOCATION_ENABLED: "true",
+        INFERENCE_ADMISSION_GATES: namespace,
+      },
+      () => apiKeysService.regenerate(existing.id),
+    );
+
+    expect(revocations).toEqual([
+      {
+        organizationId: "org-1",
+        kind: "api_key",
+        credentialId: "key-1",
+      },
+    ]);
+    expect(replace).toHaveBeenCalledTimes(1);
+    expect(replace.mock.calls[0]?.[0]).toBe("key-1");
+    expect(replace.mock.calls[0]?.[1].id).not.toBe("key-1");
+    expect(result.apiKey.id).toBe("key-2");
   });
 
   test("invalidateInferenceContextForUser: unconfirmed fan-out throws (ban fails closed)", async () => {

--- a/packages/cloud/shared/src/lib/services/api-keys.ts
+++ b/packages/cloud/shared/src/lib/services/api-keys.ts
@@ -392,6 +392,45 @@ export class ApiKeysService {
     await apiKeysRepository.delete(id);
   }
 
+  /**
+   * Rotate a key by replacing its immutable credential identity.
+   *
+   * Reusing the row ID would let an eventually stale positive auth-cache entry
+   * for the old secret pass the strong revocation gate as though it were the
+   * replacement. The old identity is therefore permanently fenced before an
+   * atomic database replacement creates the new row identity.
+   */
+  async regenerate(id: string): Promise<{ apiKey: ApiKey; plainKey: string }> {
+    const existing = await apiKeysRepository.findById(id);
+    if (!existing) {
+      throw new ElizaError("API key not found", {
+        code: "API_KEY_NOT_FOUND",
+        context: { apiKeyId: id },
+      });
+    }
+    if (!existing.is_active) {
+      throw new ElizaError("Inactive API keys cannot be regenerated", {
+        code: "API_KEY_IDENTITY_REVOKED",
+        context: { apiKeyId: id },
+      });
+    }
+
+    await revokeInferenceApiKey(existing.organization_id, existing.id);
+    await this.invalidateCache(existing.key_hash);
+
+    const { apiKey: replacement, plainKey } = await this.buildApiKeyInsert({
+      name: existing.name,
+      description: existing.description,
+      organization_id: existing.organization_id,
+      user_id: existing.user_id,
+      rate_limit: existing.rate_limit,
+      is_active: true,
+      expires_at: existing.expires_at,
+    });
+    const apiKey = await apiKeysRepository.replace(existing.id, replacement);
+    return { apiKey, plainKey };
+  }
+
   async deactivateUserKeysByName(userId: string, name: string): Promise<void> {
     const existingKeys = await apiKeysRepository.findByUserAndName(userId, name);
 

--- a/packages/cloud/shared/src/lib/services/api-keys.ts
+++ b/packages/cloud/shared/src/lib/services/api-keys.ts
@@ -4,6 +4,7 @@
  * Includes Redis caching for validation to reduce database load on high-traffic APIs.
  */
 
+import { ElizaError } from "@elizaos/core";
 import crypto from "crypto";
 import { and, eq, isNull, sql } from "drizzle-orm";
 import { type DbTransaction, dbWrite } from "../../db/client";
@@ -18,6 +19,7 @@ import {
   invalidateInferenceAuthContextByKeyHash,
   invalidateInferenceAuthContextsByKeyHashes,
 } from "./inference-auth-cache";
+import { revokeInferenceApiKey } from "./inference-credential-revocation";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -360,6 +362,15 @@ export class ApiKeysService {
     // Get the key first to invalidate cache
     const existing = await apiKeysRepository.findById(id);
     if (existing) {
+      if (data.is_active === true && existing.is_active === false) {
+        throw new ElizaError("Revoked API keys cannot be reactivated; create a new key instead", {
+          code: "API_KEY_IDENTITY_REVOKED",
+          context: { apiKeyId: existing.id },
+        });
+      }
+      if (data.is_active === false) {
+        await revokeInferenceApiKey(existing.organization_id, existing.id);
+      }
       await this.invalidateCache(existing.key_hash);
     }
 
@@ -374,6 +385,7 @@ export class ApiKeysService {
     // Get the key first to invalidate cache
     const existing = await apiKeysRepository.findById(id);
     if (existing) {
+      await revokeInferenceApiKey(existing.organization_id, existing.id);
       await this.invalidateCache(existing.key_hash);
     }
 
@@ -384,6 +396,7 @@ export class ApiKeysService {
     const existingKeys = await apiKeysRepository.findByUserAndName(userId, name);
 
     for (const key of existingKeys) {
+      await revokeInferenceApiKey(key.organization_id, key.id);
       await this.invalidateCache(key.key_hash);
     }
 
@@ -397,6 +410,7 @@ export class ApiKeysService {
     );
 
     for (const key of keysInOrganization) {
+      await revokeInferenceApiKey(key.organization_id, key.id);
       await this.invalidateCache(key.key_hash);
     }
 
@@ -483,6 +497,7 @@ export class ApiKeysService {
     // the deactivation is already durable, so this pass is authoritative and
     // a confirmed row can be hard-deleted immediately.
     for (const key of revoked) {
+      await revokeInferenceApiKey(key.organization_id, key.id);
       try {
         await this.invalidateCache(key.key_hash);
         if (!tx) {

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
@@ -9,6 +9,7 @@
 process.env.MOCK_REDIS = "1";
 process.env.CACHE_ENABLED = "true";
 process.env.INFERENCE_AUTH_CACHE_ENABLED = "true";
+process.env.INFERENCE_STRONG_REVOCATION_ENABLED = "true";
 process.env.INFERENCE_AUTH_HYDRATION_DEADLINE_MS = "60";
 
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
@@ -22,6 +23,10 @@ type AuthImpl = () => Promise<{
 
 let authImpl: AuthImpl;
 let shouldBlock: (userId: string) => Promise<boolean>;
+let assertCredentialActive: (
+  organizationId: string,
+  credential: { kind: string; credentialId?: string; userId: string },
+) => Promise<void>;
 const incrementUsageCalls: string[] = [];
 const bypassCacheCalls: boolean[] = [];
 const moderationBypassCacheCalls: boolean[] = [];
@@ -81,6 +86,24 @@ mock.module("./inference-admission-snapshot", () => ({
 mock.module("./inference-app-key-scope", () => ({
   loadInferenceAppKeyScope: async () => null,
 }));
+mock.module("./inference-credential-revocation", () => ({
+  isInferenceStrongRevocationEnabled: () =>
+    process.env.INFERENCE_STRONG_REVOCATION_ENABLED === "true",
+  InferenceCredentialRevokedError: class InferenceCredentialRevokedError extends Error {
+    constructor(readonly reason: string) {
+      super("Inference credential is revoked");
+      this.name = "InferenceCredentialRevokedError";
+    }
+  },
+  assertInferenceCredentialActive: (
+    organizationId: string,
+    credential: { kind: string; credentialId?: string; userId: string },
+  ) => assertCredentialActive(organizationId, credential),
+  revokeInferenceApiKey: async () => undefined,
+  revokeInferenceSessionsThrough: async () => undefined,
+  setInferenceOrganizationActive: async () => undefined,
+  setInferenceSubjectActive: async () => undefined,
+}));
 
 const {
   __clearInferenceApiKeyHydrations,
@@ -112,6 +135,7 @@ beforeEach(async () => {
     apiKey: { id: "key-1" },
   });
   shouldBlock = async () => false;
+  assertCredentialActive = async () => undefined;
   incrementUsageCalls.length = 0;
   bypassCacheCalls.length = 0;
   moderationBypassCacheCalls.length = 0;
@@ -416,6 +440,24 @@ describe("resolveInferenceAuthContext", () => {
     expect(res.source).toBe("cache");
     expect(chainCalls).toBe(0); // zero auth/moderation DB work on warm hit
     expect(incrementUsageCalls).toContain("key-1"); // usage tracking preserved
+  });
+
+  test("warm positive is denied immediately when the strong boundary revokes it", async () => {
+    await resolveInferenceAuthContext(reqWithApiKey());
+    let chainCalls = 0;
+    authImpl = async () => {
+      chainCalls++;
+      return { user: { id: "user-1", organization_id: "org-1" }, apiKey: { id: "key-1" } };
+    };
+    assertCredentialActive = async () => {
+      const { InferenceCredentialRevokedError } = await import("./inference-credential-revocation");
+      throw new InferenceCredentialRevokedError("credential_revoked");
+    };
+
+    const result = await resolveInferenceAuthContext(reqWithApiKey());
+
+    expect(result).toEqual({ kind: "rejected", status: 401 });
+    expect(chainCalls).toBe(0);
   });
 
   test("default-off auth-cache gate ignores a populated positive entry", async () => {

--- a/packages/cloud/shared/src/lib/services/inference-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-context.ts
@@ -43,6 +43,10 @@ import {
   writeInferenceApiKeyAuthRejection,
   writeInferenceAuthContext,
 } from "./inference-auth-cache";
+import {
+  assertInferenceCredentialActive,
+  InferenceCredentialRevokedError,
+} from "./inference-credential-revocation";
 import { isInferenceAuthCacheEnabled } from "./inference-hot-path-caches";
 import { resolveInferenceSessionAuthContext } from "./inference-session-auth-context";
 
@@ -513,6 +517,21 @@ export async function resolveInferenceAuthContext(
       trace.cacheRead = cached.kind;
       trace.cacheBackend = cached.backend;
       if (cached.kind === "hit") {
+        try {
+          await assertInferenceCredentialActive(cached.ctx.orgId, {
+            kind: "api_key",
+            credentialId: cached.ctx.apiKeyId,
+            userId: cached.ctx.userId,
+          });
+        } catch (error) {
+          if (error instanceof InferenceCredentialRevokedError) {
+            trace.result = error.reason === "credential_revoked" ? "rejected" : "suspended";
+            return error.reason === "credential_revoked"
+              ? { kind: "rejected", status: 401 }
+              : { kind: "suspended", userId: cached.ctx.userId };
+          }
+          throw error;
+        }
         const usageUpdate = apiKeysService
           .incrementUsageDebounced(cached.ctx.apiKeyId)
           .catch((error) => {
@@ -619,6 +638,21 @@ export async function resolveInferenceAuthContext(
       appScopeId,
       ...(admission ? { admission } : {}),
     };
+    try {
+      await assertInferenceCredentialActive(ctx.orgId, {
+        kind: "api_key",
+        credentialId: ctx.apiKeyId,
+        userId: ctx.userId,
+      });
+    } catch (error) {
+      if (error instanceof InferenceCredentialRevokedError) {
+        trace.result = error.reason === "credential_revoked" ? "rejected" : "suspended";
+        return error.reason === "credential_revoked"
+          ? { kind: "rejected", status: 401 }
+          : { kind: "suspended", userId: ctx.userId };
+      }
+      throw error;
+    }
     trace.authoritative = "authorized";
     trace.result = "authorized_origin";
     const cacheWriteStartedAt = performance.now();

--- a/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
@@ -10,7 +10,8 @@
  *   3. OrganizationsService.update → is_active flips false (org deactivate)
  *   4. OrganizationsService.delete → resolve key hashes BEFORE the delete cascade
  *
- * Plus: invalidation is best-effort and must never throw into the lifecycle write.
+ * KV invalidation remains best-effort; the strong revocation fence is a
+ * separate fail-closed prerequisite when its rollout flag is enabled.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -20,6 +21,7 @@ const invalidatedHashBatches: string[][] = [];
 const invalidatedSessionBatches: string[][] = [];
 const userDeleteCalls: string[] = [];
 const orgDeleteCalls: string[] = [];
+const lifecycleEvents: string[] = [];
 
 let userApiKeys: Array<{ key_hash: string }> = [];
 let orgApiKeys: Array<{ key_hash: string }> = [];
@@ -36,6 +38,18 @@ mock.module("./inference-auth-cache", () => ({
   },
 }));
 
+mock.module("./inference-credential-revocation", () => ({
+  revokeInferenceSessionsThrough: async (orgId: string, userId: string) => {
+    lifecycleEvents.push(`session:${orgId}:${userId}`);
+  },
+  setInferenceOrganizationActive: async (orgId: string, active: boolean) => {
+    lifecycleEvents.push(`organization:${orgId}:${active}`);
+  },
+  setInferenceSubjectActive: async (orgId: string, userId: string, active: boolean) => {
+    lifecycleEvents.push(`subject:${orgId}:${userId}:${active}`);
+  },
+}));
+
 mock.module("../../db/repositories", () => ({
   apiKeysRepository: {
     listByUser: async (_userId: string) => {
@@ -46,7 +60,10 @@ mock.module("../../db/repositories", () => ({
   },
   usersRepository: {
     findById: async (_id: string) => userRecord,
-    update: async (id: string, data: Record<string, unknown>) => ({ ...userRecord, ...data, id }),
+    update: async (id: string, data: Record<string, unknown>) => {
+      lifecycleEvents.push(`user-update:${id}`);
+      return { ...userRecord, ...data, id };
+    },
     delete: async (id: string) => {
       userDeleteCalls.push(id);
       // Simulate the row (and its keys) being gone after delete so a test can
@@ -89,6 +106,7 @@ beforeEach(() => {
   userRecord = undefined;
   listByOrganizationUsers = [];
   listByUserError = null;
+  lifecycleEvents.length = 0;
 });
 
 describe("UsersService — IAC invalidation on lifecycle", () => {
@@ -122,6 +140,29 @@ describe("UsersService — IAC invalidation on lifecycle", () => {
     await usersService.update("u1", { is_active: true });
 
     expect(invalidatedHashBatches).toEqual([]);
+  });
+
+  test("organization move fences both orgs and the old session generation before the row moves", async () => {
+    userRecord = {
+      id: "u1",
+      organization_id: "o1",
+      email: null,
+      role: "member",
+      steward_user_id: "steward-u1",
+      is_active: true,
+    };
+
+    const { usersService } = await import("./users");
+    await usersService.update("u1", { organization_id: "o2" });
+
+    expect(lifecycleEvents).toEqual([
+      "subject:o1:u1:false",
+      "subject:o2:u1:false",
+      "session:o2:u1",
+      "session:o1:u1",
+      "user-update:u1",
+      "subject:o2:u1:true",
+    ]);
   });
 
   test("delete resolves the key hashes BEFORE deleting the row", async () => {

--- a/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
@@ -60,6 +60,16 @@ mock.module("../../db/repositories", () => ({
   },
   usersRepository: {
     findById: async (_id: string) => userRecord,
+    findIdentityByUserIdForWrite: async () =>
+      userRecord?.steward_user_id ? { steward_user_id: userRecord.steward_user_id } : undefined,
+    upsertStewardIdentity: async (id: string, stewardUserId: string) => {
+      lifecycleEvents.push(`identity-upsert:${id}:${stewardUserId}`);
+      return { user_id: id, steward_user_id: stewardUserId };
+    },
+    linkStewardId: async (id: string, stewardUserId: string) => {
+      lifecycleEvents.push(`identity-link:${id}:${stewardUserId}`);
+      return { ...userRecord, id, steward_user_id: stewardUserId };
+    },
     update: async (id: string, data: Record<string, unknown>) => {
       lifecycleEvents.push(`user-update:${id}`);
       return { ...userRecord, ...data, id };
@@ -163,6 +173,34 @@ describe("UsersService — IAC invalidation on lifecycle", () => {
       "user-update:u1",
       "subject:o2:u1:true",
     ]);
+  });
+
+  test("Steward identity upsert fences the prior session generation before relinking", async () => {
+    userRecord = {
+      id: "u1",
+      organization_id: "o1",
+      email: null,
+      steward_user_id: "steward-old",
+    };
+
+    const { usersService } = await import("./users");
+    await usersService.upsertStewardIdentity("u1", "steward-new");
+
+    expect(lifecycleEvents).toEqual(["session:o1:u1", "identity-upsert:u1:steward-new"]);
+  });
+
+  test("Steward identity link fences the prior session generation before relinking", async () => {
+    userRecord = {
+      id: "u1",
+      organization_id: "o1",
+      email: null,
+      steward_user_id: "steward-old",
+    };
+
+    const { usersService } = await import("./users");
+    await usersService.linkStewardId("u1", "steward-new");
+
+    expect(lifecycleEvents).toEqual(["session:o1:u1", "identity-link:u1:steward-new"]);
   });
 
   test("delete resolves the key hashes BEFORE deleting the row", async () => {

--- a/packages/cloud/shared/src/lib/services/inference-credential-revocation.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-credential-revocation.test.ts
@@ -54,4 +54,30 @@ describe("inference credential revocation client", () => {
       ),
     ).rejects.toBeInstanceOf(InferenceCredentialRevocationUnavailableError);
   });
+
+  test("never accepts a forbidden response as a committed mutation", async () => {
+    const namespace = {
+      getByName: () => ({
+        fetch: async () => Response.json({ committed: true }, { status: 403 }),
+      }),
+    };
+    await expect(
+      runWithCloudBindingsAsync({ ...ENABLED, INFERENCE_ADMISSION_GATES: namespace }, () =>
+        revokeInferenceApiKey("org-1", "key-1"),
+      ),
+    ).rejects.toBeInstanceOf(InferenceCredentialRevocationUnavailableError);
+  });
+
+  test("maps structurally invalid JSON to the typed unavailable failure", async () => {
+    const namespace = {
+      getByName: () => ({
+        fetch: async () => Response.json(null),
+      }),
+    };
+    await expect(
+      runWithCloudBindingsAsync({ ...ENABLED, INFERENCE_ADMISSION_GATES: namespace }, () =>
+        revokeInferenceApiKey("org-1", "key-1"),
+      ),
+    ).rejects.toBeInstanceOf(InferenceCredentialRevocationUnavailableError);
+  });
 });

--- a/packages/cloud/shared/src/lib/services/inference-credential-revocation.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-credential-revocation.test.ts
@@ -1,0 +1,57 @@
+/** Verifies the fail-closed client contract for the inference revocation Durable Object. */
+
+import { describe, expect, test } from "bun:test";
+import { runWithCloudBindingsAsync } from "../runtime/cloud-bindings";
+import {
+  assertInferenceCredentialActive,
+  InferenceCredentialRevocationUnavailableError,
+  InferenceCredentialRevokedError,
+  revokeInferenceApiKey,
+} from "./inference-credential-revocation";
+
+const ENABLED = { INFERENCE_STRONG_REVOCATION_ENABLED: "true" };
+
+describe("inference credential revocation client", () => {
+  test("fails closed when the Durable Object binding is absent", async () => {
+    await expect(
+      runWithCloudBindingsAsync(ENABLED, () =>
+        assertInferenceCredentialActive("org-1", {
+          kind: "api_key",
+          credentialId: "key-1",
+          userId: "user-1",
+        }),
+      ),
+    ).rejects.toBeInstanceOf(InferenceCredentialRevocationUnavailableError);
+  });
+
+  test("maps an explicit Durable Object denial to a revoked decision", async () => {
+    const namespace = {
+      getByName: () => ({
+        fetch: async () =>
+          Response.json({ allowed: false, reason: "credential_revoked" }, { status: 403 }),
+      }),
+    };
+    await expect(
+      runWithCloudBindingsAsync({ ...ENABLED, INFERENCE_ADMISSION_GATES: namespace }, () =>
+        assertInferenceCredentialActive("org-1", {
+          kind: "api_key",
+          credentialId: "key-1",
+          userId: "user-1",
+        }),
+      ),
+    ).rejects.toBeInstanceOf(InferenceCredentialRevokedError);
+  });
+
+  test("requires a committed acknowledgement for revocation mutations", async () => {
+    const namespace = {
+      getByName: () => ({
+        fetch: async () => Response.json({ committed: false }),
+      }),
+    };
+    await expect(
+      runWithCloudBindingsAsync({ ...ENABLED, INFERENCE_ADMISSION_GATES: namespace }, () =>
+        revokeInferenceApiKey("org-1", "key-1"),
+      ),
+    ).rejects.toBeInstanceOf(InferenceCredentialRevocationUnavailableError);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/inference-credential-revocation.ts
+++ b/packages/cloud/shared/src/lib/services/inference-credential-revocation.ts
@@ -73,6 +73,7 @@ async function gateRequest(
   organizationId: string,
   path: string,
   body: Record<string, unknown>,
+  allowExplicitDenial = false,
 ): Promise<RevocationResponse> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), OPERATION_TIMEOUT_MS);
@@ -96,9 +97,9 @@ async function gateRequest(
     clearTimeout(timeout);
   }
 
-  let result: RevocationResponse;
+  let parsed: unknown;
   try {
-    result = (await response.json()) as RevocationResponse;
+    parsed = await response.json();
   } catch (error) {
     // error-policy:J3 malformed boundary output is never authorization.
     throw new InferenceCredentialRevocationUnavailableError(
@@ -106,7 +107,18 @@ async function gateRequest(
       { cause: error },
     );
   }
-  if (!response.ok && response.status !== 403) {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new InferenceCredentialRevocationUnavailableError(
+      "Inference revocation boundary returned an invalid response",
+    );
+  }
+  const result = parsed as RevocationResponse;
+  const explicitDenial =
+    allowExplicitDenial &&
+    response.status === 403 &&
+    result.allowed === false &&
+    typeof result.reason === "string";
+  if (!response.ok && !explicitDenial) {
     throw new InferenceCredentialRevocationUnavailableError(
       `Inference revocation boundary failed with status ${response.status}`,
     );
@@ -120,7 +132,7 @@ export async function assertInferenceCredentialActive(
   credential: CredentialCheck,
 ): Promise<void> {
   if (!isInferenceStrongRevocationEnabled()) return;
-  const result = await gateRequest(organizationId, "/credential/check", credential);
+  const result = await gateRequest(organizationId, "/credential/check", credential, true);
   if (result.allowed !== true) {
     throw new InferenceCredentialRevokedError(result.reason ?? "revoked");
   }

--- a/packages/cloud/shared/src/lib/services/inference-credential-revocation.ts
+++ b/packages/cloud/shared/src/lib/services/inference-credential-revocation.ts
@@ -1,0 +1,178 @@
+/**
+ * Strongly consistent credential and subject revocation for inference.
+ *
+ * Cloudflare KV remains a projection only. When enabled, every positive
+ * inference authorization crosses the organization Durable Object before it
+ * can reach a provider, while lifecycle mutations commit their denial fence
+ * to that same object before reporting success.
+ */
+
+import { ElizaError } from "@elizaos/core";
+import type {
+  RuntimeDurableObjectNamespace,
+  RuntimeDurableObjectStub,
+} from "../../types/cloud-worker-env";
+import { getCloudAwareEnv, getCloudBinding } from "../runtime/cloud-bindings";
+
+const GATE_BINDING = "INFERENCE_ADMISSION_GATES";
+const GATE_ORIGIN = "https://inference-admission.internal";
+const OPERATION_TIMEOUT_MS = 1_500;
+
+type CredentialCheck =
+  | { kind: "api_key"; credentialId: string; userId: string }
+  | { kind: "steward_session"; userId: string; issuedAt: number };
+
+interface RevocationResponse {
+  allowed?: boolean;
+  committed?: boolean;
+  reason?: string;
+}
+
+export class InferenceCredentialRevocationUnavailableError extends ElizaError {
+  override readonly name = "InferenceCredentialRevocationUnavailableError";
+  readonly statusCode = 503;
+
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, {
+      code: "INFERENCE_CREDENTIAL_REVOCATION_UNAVAILABLE",
+      cause: options?.cause,
+      severity: "ephemeral",
+    });
+  }
+}
+
+export class InferenceCredentialRevokedError extends ElizaError {
+  override readonly name = "InferenceCredentialRevokedError";
+
+  constructor(readonly reason: string) {
+    super("Inference credential is revoked", {
+      code: "INFERENCE_CREDENTIAL_REVOKED",
+      context: { reason },
+    });
+  }
+}
+
+/** The revocation boundary is independently default-off for staged rollout. */
+export function isInferenceStrongRevocationEnabled(
+  env: Record<string, unknown> = getCloudAwareEnv(),
+): boolean {
+  return env.INFERENCE_STRONG_REVOCATION_ENABLED === "true";
+}
+
+function gateStub(organizationId: string): RuntimeDurableObjectStub {
+  const namespace = getCloudBinding<RuntimeDurableObjectNamespace>(GATE_BINDING);
+  if (!namespace) {
+    throw new InferenceCredentialRevocationUnavailableError(
+      "Inference revocation Durable Object binding is missing",
+    );
+  }
+  return namespace.getByName(organizationId);
+}
+
+async function gateRequest(
+  organizationId: string,
+  path: string,
+  body: Record<string, unknown>,
+): Promise<RevocationResponse> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), OPERATION_TIMEOUT_MS);
+  let response: Response;
+  try {
+    response = await gateStub(organizationId).fetch(
+      new Request(`${GATE_ORIGIN}${path}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ organizationId, ...body }),
+        signal: controller.signal,
+      }),
+    );
+  } catch (error) {
+    // error-policy:J2 transport failure must stay fail-closed with its cause.
+    throw new InferenceCredentialRevocationUnavailableError(
+      "Inference revocation boundary is unavailable",
+      { cause: error },
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  let result: RevocationResponse;
+  try {
+    result = (await response.json()) as RevocationResponse;
+  } catch (error) {
+    // error-policy:J3 malformed boundary output is never authorization.
+    throw new InferenceCredentialRevocationUnavailableError(
+      "Inference revocation boundary returned invalid JSON",
+      { cause: error },
+    );
+  }
+  if (!response.ok && response.status !== 403) {
+    throw new InferenceCredentialRevocationUnavailableError(
+      `Inference revocation boundary failed with status ${response.status}`,
+    );
+  }
+  return result;
+}
+
+/** Fail closed unless the strong boundary confirms this credential is active. */
+export async function assertInferenceCredentialActive(
+  organizationId: string,
+  credential: CredentialCheck,
+): Promise<void> {
+  if (!isInferenceStrongRevocationEnabled()) return;
+  const result = await gateRequest(organizationId, "/credential/check", credential);
+  if (result.allowed !== true) {
+    throw new InferenceCredentialRevokedError(result.reason ?? "revoked");
+  }
+}
+
+async function commitMutation(
+  organizationId: string,
+  path: string,
+  body: Record<string, unknown>,
+): Promise<void> {
+  if (!isInferenceStrongRevocationEnabled()) return;
+  const result = await gateRequest(organizationId, path, body);
+  if (result.committed !== true) {
+    throw new InferenceCredentialRevocationUnavailableError(
+      "Inference revocation boundary did not confirm the mutation",
+    );
+  }
+}
+
+/** Permanently revoke one immutable API-key row identity. */
+export async function revokeInferenceApiKey(
+  organizationId: string,
+  apiKeyId: string,
+): Promise<void> {
+  await commitMutation(organizationId, "/credential/revoke", {
+    kind: "api_key",
+    credentialId: apiKeyId,
+  });
+}
+
+/** Disable or re-enable every credential belonging to a Cloud user in one org. */
+export async function setInferenceSubjectActive(
+  organizationId: string,
+  userId: string,
+  active: boolean,
+): Promise<void> {
+  await commitMutation(organizationId, "/subject/set-active", { userId, active });
+}
+
+/** Revoke Steward sessions issued at or before the supplied immutable iat. */
+export async function revokeInferenceSessionsThrough(
+  organizationId: string,
+  userId: string,
+  issuedAt: number,
+): Promise<void> {
+  await commitMutation(organizationId, "/session/revoke-through", { userId, issuedAt });
+}
+
+/** Disable or re-enable every inference credential in an organization. */
+export async function setInferenceOrganizationActive(
+  organizationId: string,
+  active: boolean,
+): Promise<void> {
+  await commitMutation(organizationId, "/organization/set-active", { active });
+}

--- a/packages/cloud/shared/src/lib/services/inference-hot-path-benchmark.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-hot-path-benchmark.test.ts
@@ -3,8 +3,9 @@
  *
  * The headline claim of the design (packages/cloud/api/docs/inference-hot-path.md)
  * is that a WARM, fully-authorized API-key request resolves auth + org +
- * moderation with EXACTLY ONE cache read and ZERO authoritative-chain work
- * (no auth DB read, no moderation Postgres read, no reserve write on resolve).
+ * moderation with EXACTLY ONE cache read, ONE strong revocation-boundary call,
+ * and ZERO authoritative-chain work (no auth DB read, no moderation Postgres
+ * read, no reserve write on resolve).
  *
  * This test instruments the real CacheClient (MOCK_REDIS in-memory) and the
  * mocked auth/moderation seams to assert those exact counts, so a regression
@@ -18,7 +19,9 @@ process.env.CACHE_ENABLED = "true";
 // lands a strongly consistent revocation boundary; enabling it here exercises
 // the gated single-cache-read contract without changing any shipped default.
 const originalAuthCacheFlag = process.env.INFERENCE_AUTH_CACHE_ENABLED;
+const originalStrongRevocationFlag = process.env.INFERENCE_STRONG_REVOCATION_ENABLED;
 process.env.INFERENCE_AUTH_CACHE_ENABLED = "true";
+process.env.INFERENCE_STRONG_REVOCATION_ENABLED = "true";
 
 import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 
@@ -27,6 +30,7 @@ let moderationCalls = 0;
 let usageCalls = 0;
 let admissionLoadCalls = 0;
 let appScopeCalls = 0;
+let revocationBoundaryCalls = 0;
 
 // IAC v2 (#17805) co-locates the admission snapshot + app-key scope with the
 // cached identity: both authoritative loads may run ONLY while warming a cold
@@ -53,6 +57,18 @@ mock.module("./inference-app-key-scope", () => ({
     appScopeCalls++;
     return null;
   },
+}));
+mock.module("./inference-credential-revocation", () => ({
+  isInferenceStrongRevocationEnabled: () =>
+    process.env.INFERENCE_STRONG_REVOCATION_ENABLED === "true",
+  InferenceCredentialRevokedError: class InferenceCredentialRevokedError extends Error {},
+  assertInferenceCredentialActive: async () => {
+    revocationBoundaryCalls++;
+  },
+  revokeInferenceApiKey: async () => undefined,
+  revokeInferenceSessionsThrough: async () => undefined,
+  setInferenceOrganizationActive: async () => undefined,
+  setInferenceSubjectActive: async () => undefined,
 }));
 
 mock.module("./inference-api-key-auth", () => ({
@@ -107,6 +123,7 @@ beforeEach(async () => {
   usageCalls = 0;
   admissionLoadCalls = 0;
   appScopeCalls = 0;
+  revocationBoundaryCalls = 0;
   await invalidateInferenceAuthContextByKeyHash(hashApiKey(KEY));
 });
 
@@ -122,6 +139,11 @@ afterAll(() => {
   } else {
     process.env.INFERENCE_AUTH_CACHE_ENABLED = originalAuthCacheFlag;
   }
+  if (originalStrongRevocationFlag === undefined) {
+    delete process.env.INFERENCE_STRONG_REVOCATION_ENABLED;
+  } else {
+    process.env.INFERENCE_STRONG_REVOCATION_ENABLED = originalStrongRevocationFlag;
+  }
 });
 
 describe("inference hot-path benchmark", () => {
@@ -132,6 +154,7 @@ describe("inference hot-path benchmark", () => {
     expect(moderationCalls).toBe(1); // one moderation read
     expect(admissionLoadCalls).toBe(1); // one admission projection load (IAC v2)
     expect(appScopeCalls).toBe(1); // one app-key scope load (IAC v2)
+    expect(revocationBoundaryCalls).toBe(1);
   });
 
   test("WARM hit = exactly 1 cache read, 0 writes, 0 auth, 0 moderation", async () => {
@@ -144,12 +167,13 @@ describe("inference hot-path benchmark", () => {
     moderationCalls = 0;
     admissionLoadCalls = 0;
     appScopeCalls = 0;
+    revocationBoundaryCalls = 0;
 
     const warm = await resolveInferenceAuthContext(req());
 
     expect(warm.kind).toBe("authorized");
     if (warm.kind === "authorized") expect(warm.source).toBe("cache");
-    // THE benchmark assertion: one cache read, nothing else touched.
+    // THE benchmark assertion: one cache read plus the strong denial fence.
     expect(getSpy).toHaveBeenCalledTimes(1);
     expect(setSpy).toHaveBeenCalledTimes(0);
     expect(delSpy).toHaveBeenCalledTimes(0);
@@ -157,6 +181,7 @@ describe("inference hot-path benchmark", () => {
     expect(moderationCalls).toBe(0); // zero moderation DB work
     expect(admissionLoadCalls).toBe(0); // admission rides in the single cache read (IAC v2)
     expect(appScopeCalls).toBe(0); // app scope rides in the single cache read (IAC v2)
+    expect(revocationBoundaryCalls).toBe(1);
     expect(usageCalls).toBe(1); // usage tracking is fire-and-forget, not a hot read
 
     getSpy.mockRestore();
@@ -172,6 +197,7 @@ describe("inference hot-path benchmark", () => {
     moderationCalls = 0;
     admissionLoadCalls = 0;
     appScopeCalls = 0;
+    revocationBoundaryCalls = 0;
 
     const N = 25;
     for (let i = 0; i < N; i++) await resolveInferenceAuthContext(req());
@@ -181,6 +207,7 @@ describe("inference hot-path benchmark", () => {
     expect(moderationCalls).toBe(0);
     expect(admissionLoadCalls).toBe(0);
     expect(appScopeCalls).toBe(0);
+    expect(revocationBoundaryCalls).toBe(N);
 
     getSpy.mockRestore();
   });

--- a/packages/cloud/shared/src/lib/services/inference-hot-path-caches.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-hot-path-caches.test.ts
@@ -17,6 +17,12 @@ test("authorization caching is fail-closed and independent of other hot-path cac
     isInferenceAuthCacheEnabled({
       INFERENCE_AUTH_CACHE_ENABLED: "true",
     }),
+  ).toBe(false);
+  expect(
+    isInferenceAuthCacheEnabled({
+      INFERENCE_AUTH_CACHE_ENABLED: "true",
+      INFERENCE_STRONG_REVOCATION_ENABLED: "true",
+    }),
   ).toBe(true);
   expect(
     isInferenceAuthCacheEnabled({

--- a/packages/cloud/shared/src/lib/services/inference-hot-path-caches.ts
+++ b/packages/cloud/shared/src/lib/services/inference-hot-path-caches.ts
@@ -13,6 +13,7 @@
  */
 
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
+import { isInferenceStrongRevocationEnabled } from "./inference-credential-revocation";
 
 type EnvLike = Record<string, unknown>;
 
@@ -28,5 +29,7 @@ export function isHotPathCachesEnabled(env: EnvLike = getCloudAwareEnv()): boole
  */
 export function isInferenceAuthCacheEnabled(env: EnvLike = getCloudAwareEnv()): boolean {
   const flag = env.INFERENCE_AUTH_CACHE_ENABLED;
-  return typeof flag === "string" && flag.trim() === "true";
+  return (
+    typeof flag === "string" && flag.trim() === "true" && isInferenceStrongRevocationEnabled(env)
+  );
 }

--- a/packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts
@@ -6,6 +6,7 @@
 
 process.env.MOCK_REDIS = "1";
 process.env.CACHE_ENABLED = "true";
+process.env.INFERENCE_STRONG_REVOCATION_ENABLED = "true";
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -25,6 +26,7 @@ let getUser:
   | undefined;
 let userReads = 0;
 let moderationReads = 0;
+let assertSessionActive: () => Promise<void>;
 const ADMISSION = {
   balance: { balanceUsd: 100, balanceAt: 1, balanceRevision: "1" },
   rateLimits: {
@@ -64,6 +66,21 @@ mock.module("../steward-sync", () => ({
 mock.module("./inference-admission-snapshot", () => ({
   loadInferenceAdmissionSnapshot: async () => ADMISSION,
 }));
+mock.module("./inference-credential-revocation", () => ({
+  isInferenceStrongRevocationEnabled: () =>
+    process.env.INFERENCE_STRONG_REVOCATION_ENABLED === "true",
+  InferenceCredentialRevokedError: class InferenceCredentialRevokedError extends Error {
+    constructor(readonly reason: string) {
+      super("Inference credential is revoked");
+      this.name = "InferenceCredentialRevokedError";
+    }
+  },
+  assertInferenceCredentialActive: () => assertSessionActive(),
+  revokeInferenceApiKey: async () => undefined,
+  revokeInferenceSessionsThrough: async () => undefined,
+  setInferenceOrganizationActive: async () => undefined,
+  setInferenceSubjectActive: async () => undefined,
+}));
 
 const { __clearInferenceSessionAuthHydrations, resolveInferenceSessionAuthContext } = await import(
   "./inference-session-auth-context"
@@ -88,6 +105,7 @@ beforeEach(async () => {
   };
   userReads = 0;
   moderationReads = 0;
+  assertSessionActive = async () => undefined;
   getUser = async () => ({
     id: "user-1",
     is_active: true,
@@ -154,6 +172,31 @@ describe("resolveInferenceSessionAuthContext", () => {
         stewardUserId: "steward-1",
       },
     });
+    expect(userReads).toBe(0);
+    expect(moderationReads).toBe(0);
+  });
+
+  test("warm verified session is denied when its issued-at cutoff is revoked", async () => {
+    const waited: Promise<unknown>[] = [];
+    await resolveInferenceSessionAuthContext(request(), {
+      cacheOnly: true,
+      useAuthCache: true,
+      executionCtx: { waitUntil: (promise) => waited.push(promise) },
+    });
+    await Promise.all(waited);
+    userReads = 0;
+    moderationReads = 0;
+    assertSessionActive = async () => {
+      const { InferenceCredentialRevokedError } = await import("./inference-credential-revocation");
+      throw new InferenceCredentialRevokedError("session_revoked");
+    };
+
+    const result = await resolveInferenceSessionAuthContext(request(), {
+      cacheOnly: true,
+      useAuthCache: true,
+    });
+
+    expect(result).toEqual({ kind: "rejected", status: 401 });
     expect(userReads).toBe(0);
     expect(moderationReads).toBe(0);
   });

--- a/packages/cloud/shared/src/lib/services/inference-session-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-session-auth-context.ts
@@ -30,6 +30,10 @@ import {
   readInferenceSessionAuthDecision,
   writeInferenceSessionAuthDecision,
 } from "./inference-auth-cache";
+import {
+  assertInferenceCredentialActive,
+  InferenceCredentialRevokedError,
+} from "./inference-credential-revocation";
 import { usersService } from "./users";
 
 const sessionHydrations = new Map<string, Promise<InferenceSessionAuthDecision>>();
@@ -136,6 +140,30 @@ function toResolution(
   return { kind: "rejected", status: decision.status };
 }
 
+async function enforceStrongSessionBoundary(
+  decision: InferenceSessionAuthDecision,
+  issuedAt: number,
+  source: "cache" | "origin",
+): Promise<InferenceSessionAuthResolution> {
+  const resolved = toResolution(decision, source);
+  if (resolved.kind !== "authorized") return resolved;
+  try {
+    await assertInferenceCredentialActive(resolved.ctx.orgId, {
+      kind: "steward_session",
+      userId: resolved.ctx.userId,
+      issuedAt,
+    });
+    return resolved;
+  } catch (error) {
+    if (error instanceof InferenceCredentialRevokedError) {
+      return error.reason === "session_revoked"
+        ? { kind: "rejected", status: 401 }
+        : { kind: "suspended", userId: resolved.ctx.userId };
+    }
+    throw error;
+  }
+}
+
 async function hydrateAndCache(
   params: {
     stewardUserId: string;
@@ -239,10 +267,8 @@ export async function resolveInferenceSessionAuthContext(
     if (await adminService.shouldBlockUser(user.id)) {
       return { kind: "suspended", userId: user.id };
     }
-    return {
-      kind: "authorized",
-      source: "origin",
-      ctx: {
+    return await enforceStrongSessionBoundary(
+      {
         v: INFERENCE_AUTH_CONTEXT_VERSION,
         cachedAt: Date.now(),
         userId: user.id,
@@ -251,7 +277,9 @@ export async function resolveInferenceSessionAuthContext(
         stewardUserId: claims.userId,
         admission: await loadInferenceAdmissionSnapshot(user.organization_id),
       },
-    };
+      claims.issuedAt,
+      "origin",
+    );
   }
 
   if (options.useAuthCache && cache.isAvailable()) {
@@ -284,7 +312,7 @@ export async function resolveInferenceSessionAuthContext(
           });
         options.executionCtx.waitUntil(refresh);
       }
-      return toResolution(cached, "cache");
+      return await enforceStrongSessionBoundary(cached, claims.issuedAt, "cache");
     }
   }
 
@@ -324,7 +352,7 @@ export async function resolveInferenceSessionAuthContext(
     },
     options.useAuthCache === true,
   );
-  const resolved = toResolution(decision, "origin");
+  const resolved = await enforceStrongSessionBoundary(decision, claims.issuedAt, "origin");
   if (resolved.kind === "rejected") {
     if (resolved.status === 401) throw AuthenticationError();
     throw ForbiddenError();

--- a/packages/cloud/shared/src/lib/services/organizations.ts
+++ b/packages/cloud/shared/src/lib/services/organizations.ts
@@ -15,6 +15,7 @@ import {
   invalidateInferenceAuthContextsByKeyHashes,
   invalidateInferenceSessionAuthContexts,
 } from "./inference-auth-cache";
+import { setInferenceOrganizationActive } from "./inference-credential-revocation";
 
 /**
  * Service for organization operations with caching support.
@@ -102,6 +103,9 @@ export class OrganizationsService {
   }
 
   async update(id: string, data: Partial<NewOrganization>): Promise<Organization | undefined> {
+    if (data.is_active === false) {
+      await setInferenceOrganizationActive(id, false);
+    }
     const result = await organizationsRepository.update(id, data);
     // Invalidate cache after update
     await this.invalidateCache(id);
@@ -109,6 +113,9 @@ export class OrganizationsService {
     // entries so credentials under the now-inactive org can no longer fast-path.
     if (data.is_active === false) {
       await this.invalidateInferenceAuthForOrganization(id);
+    }
+    if (data.is_active === true) {
+      await setInferenceOrganizationActive(id, true);
     }
     return result;
   }
@@ -124,6 +131,7 @@ export class OrganizationsService {
   }
 
   async delete(id: string): Promise<void> {
+    await setInferenceOrganizationActive(id, false);
     // Resolve + evict the org's cached IAC identities BEFORE the delete cascade
     // removes the api_keys rows, so the key_hash set is read while it still exists.
     await this.invalidateInferenceAuthForOrganization(id);

--- a/packages/cloud/shared/src/lib/services/users.ts
+++ b/packages/cloud/shared/src/lib/services/users.ts
@@ -18,6 +18,10 @@ import {
   invalidateInferenceAuthContextsByKeyHashes,
   invalidateInferenceSessionAuthContexts,
 } from "./inference-auth-cache";
+import {
+  revokeInferenceSessionsThrough,
+  setInferenceSubjectActive,
+} from "./inference-credential-revocation";
 
 function getErrorDetails(error: unknown): Record<string, unknown> {
   if (!(error instanceof Error)) {
@@ -285,6 +289,30 @@ export class UsersService {
 
   async update(id: string, data: Partial<NewUser>): Promise<User | undefined> {
     const existing = await usersRepository.findById(id);
+    const movingOrganizations =
+      typeof data.organization_id === "string" &&
+      data.organization_id !== existing?.organization_id;
+    const sessionAuthorityChanged =
+      (typeof data.role === "string" && data.role !== existing?.role) ||
+      (typeof data.steward_user_id === "string" &&
+        data.steward_user_id !== existing?.steward_user_id);
+    const sessionRevocationCutoff =
+      movingOrganizations || sessionAuthorityChanged ? Math.floor(Date.now() / 1000) : null;
+    if (movingOrganizations && existing?.organization_id) {
+      await setInferenceSubjectActive(existing.organization_id, id, false);
+    }
+    if (movingOrganizations && typeof data.organization_id === "string") {
+      await setInferenceSubjectActive(data.organization_id, id, false);
+      if (sessionRevocationCutoff !== null) {
+        await revokeInferenceSessionsThrough(data.organization_id, id, sessionRevocationCutoff);
+      }
+    }
+    if (data.is_active === false && existing?.organization_id) {
+      await setInferenceSubjectActive(existing.organization_id, id, false);
+    }
+    if (sessionRevocationCutoff !== null && existing?.organization_id) {
+      await revokeInferenceSessionsThrough(existing.organization_id, id, sessionRevocationCutoff);
+    }
     const result = await usersRepository.update(id, data);
     if (existing) {
       await this.invalidateCache(existing);
@@ -296,6 +324,12 @@ export class UsersService {
     // entries so the now-inactive account can no longer fast-path inference.
     if (data.is_active === false) {
       await this.invalidateInferenceAuthForUser(id);
+    }
+    if (data.is_active === true && result?.organization_id && !movingOrganizations) {
+      await setInferenceSubjectActive(result.organization_id, id, true);
+    }
+    if (typeof data.organization_id === "string" && result?.organization_id) {
+      await setInferenceSubjectActive(result.organization_id, id, result.is_active);
     }
     return result;
   }
@@ -362,6 +396,9 @@ export class UsersService {
     if (!user) {
       throw new Error(`User ${id} not found`);
     }
+    if (user.organization_id) {
+      await setInferenceSubjectActive(user.organization_id, id, false);
+    }
 
     let slug = generatePersonalOrgSlug(user);
     let attempts = 0;
@@ -425,6 +462,10 @@ export class UsersService {
     }
 
     const organizationId = user.organization_id;
+
+    if (organizationId) {
+      await setInferenceSubjectActive(organizationId, id, false);
+    }
 
     await this.invalidateCache(user);
     // Resolve + evict the user's cached IAC identities BEFORE the row is deleted:

--- a/packages/cloud/shared/src/lib/services/users.ts
+++ b/packages/cloud/shared/src/lib/services/users.ts
@@ -345,6 +345,15 @@ export class UsersService {
       return;
     }
 
+    const user = await usersRepository.findById(userId);
+    if (user?.organization_id) {
+      await revokeInferenceSessionsThrough(
+        user.organization_id,
+        userId,
+        Math.floor(Date.now() / 1000),
+      );
+    }
+
     await usersRepository.upsertStewardIdentity(userId, stewardUserId);
 
     const cacheDeletes = [
@@ -366,6 +375,13 @@ export class UsersService {
 
   async linkStewardId(userId: string, stewardUserId: string): Promise<void> {
     const existing = await usersRepository.findById(userId);
+    if (existing?.organization_id && existing.steward_user_id !== stewardUserId) {
+      await revokeInferenceSessionsThrough(
+        existing.organization_id,
+        userId,
+        Math.floor(Date.now() / 1000),
+      );
+    }
     const updated = await usersRepository.linkStewardId(userId, stewardUserId);
 
     if (existing) {

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -478,6 +478,8 @@ export interface Bindings {
   // memo. Separate from INFERENCE_DEFERRED_ADMISSION (orthogonal to billing).
   INFERENCE_HOT_PATH_CACHES?: string;
   INFERENCE_AUTH_CACHE_ENABLED?: string;
+  /** Strong Durable Object boundary required before positive auth caching can activate. */
+  INFERENCE_STRONG_REVOCATION_ENABLED?: string;
   // Pass-through streaming fast path (#15428): "true" pipes qualifying
   // streamed chat completions (OpenAI-compatible direct upstream, no
   // tools/response_format/web-search) byte-for-byte from the provider instead


### PR DESCRIPTION
# Relates to

Fixes #17093.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` was run after the final sync. Root `bun run verify` passed on the immediately preceding rebased head; exact-head Cloud package/typecheck/bundle and security suites passed after the final non-overlapping rebase.
- [x] A reviewer can confirm the change from the real Miniflare/workerd stale-KV evidence below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop`; zero conflicts.
- [x] `bun install --frozen-lockfile --ignore-scripts` passed after the final rebase.
- [x] `bun run verify` passed all 356 Turbo tasks and every repository audit on rebased head `d909c199c83d251c0cff26b86f32452741edd4cc`; the final rebase contained only unrelated route-validation commits. Exact-head Cloud API typecheck + production Worker dry-run passed on `13f81ecdefc49e805a265593da8228eb9bc2caef`.

# Risks

High security-boundary change, staged behind an independent default-off flag. It adds one serialized per-organization Durable Object check before inference dispatch when enabled. Failure is deliberately fail-closed. API-key revocation identities are permanent; user and organization suspension fences are reversible; Steward sessions use a monotonic verified-`iat` cutoff.

# Background

## What does this PR do?

- Reuses the per-organization `InferenceAdmissionGate` Durable Object as the strongly consistent inference-revocation authority.
- Checks every positive API-key and Steward-session authorization against immutable credential/user/org/session-generation fences before provider dispatch.
- Commits API-key delete/deactivate, logout, user/role/org lifecycle, moderation ban, and organization suspension fences before reporting mutation success.
- Makes inactive API-key row identities non-reactivatable.
- Requires both `INFERENCE_AUTH_CACHE_ENABLED` and `INFERENCE_STRONG_REVOCATION_ENABLED`; the new flag is checked in as `false` for local, staging, and production so authoritative auth stays the default.
- Updates the hot-path contract from three to four serialized Durable Object calls when the strong cache path is enabled.

## What kind of change is this?

Bug fix / P0 security consistency boundary.

# Documentation changes needed?

Documentation was required and `packages/cloud/api/docs/inference-hot-path.md` now documents the authority, identities, rollout, failure behavior, and added hot-path call.

# Testing

## Where should a reviewer start?

1. `packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts` — real workerd storage/serialization with a deliberately retained stale positive KV value.
2. `packages/cloud/shared/src/lib/services/inference-credential-revocation.ts` — fail-closed client and mutation acknowledgements.
3. `packages/cloud/shared/src/lib/services/inference-auth-context.test.ts` and `inference-session-auth-context.test.ts` — stale cached positives denied without database authorization.

## Detailed testing steps

```bash
bun test packages/cloud/shared/src/lib/services/inference-credential-revocation.test.ts \
  packages/cloud/shared/src/lib/services/inference-hot-path-caches.test.ts \
  packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts

bun test packages/cloud/shared/src/lib/services/inference-auth-context.test.ts
bun test packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts
bun test packages/cloud/shared/src/lib/services/inference-hot-path-benchmark.test.ts
bun test packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
bun test packages/cloud/shared/src/lib/services/api-keys.invalidation.test.ts
bun test packages/cloud/api/auth/logout/route.test.ts
bun run --cwd packages/cloud/api typecheck
```

Exact-head results: 13 + 44 + 7 + 3 + 8 + 13 + 7 tests passed, zero failed; Cloud API TypeScript and Wrangler production dry-run passed.

# Evidence Gate

<!-- evidence-head:13f81ecdefc49e805a265593da8228eb9bc2caef -->

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend authorization/storage change with no rendered UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend authorization/storage change with no rendered UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend or interactive visual flow changed.
<!-- evidence-row:backend-logs -->
- [x] Real workerd/Miniflare and route test output is included below.
  <details><summary>Backend execution transcript</summary>

  ```text
  (pass) Miniflare Durable Object integration > independent callers observe API-key revocation immediately
  (pass) inference credential revocation client > fails closed when the Durable Object binding is absent
  (pass) POST /api/auth/logout cookie clearing > strong rollout clears cookies but returns 503 when the cutoff is unconfirmed
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser request flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action, or agent behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] The retained positive KV value plus immediate Durable Object denial is exercised as the domain artifact in real Miniflare/workerd below.
  <details><summary>Credential-revocation domain artifact</summary>

  ```text
  KV before revoke: positive API-key authorization record present in TEST_AUTH_CACHE
  Durable mutation: /credential/revoke returned committed=true from the production Durable Object class
  KV after revoke: identical positive record deliberately retained; /credential/check returned HTTP 403
  ```

  </details>
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual text changed.

# Evidence Details

## Real LLM-call trajectory

N/A - this is deterministic credential authorization and Durable Object storage logic; no LLM participates.

## Backend + frontend logs

<details>
<summary>Real workerd/Miniflare strong-boundary output</summary>

```text
(pass) Miniflare Durable Object integration > real Durable Object serialization prevents concurrent overspend
(pass) Miniflare Durable Object integration > independent callers observe API-key revocation immediately
(pass) Miniflare Durable Object integration > session cutoff revokes old tokens without rejecting a later login
(pass) Miniflare Durable Object integration > subject and organization suspension are reversible durable fences
(pass) inference credential revocation client > fails closed when the Durable Object binding is absent
(pass) inference credential revocation client > maps an explicit Durable Object denial to a revoked decision
(pass) inference credential revocation client > requires a committed acknowledgement for revocation mutations
13 pass
0 fail
```

The API-key test writes a positive record to a real Miniflare KV namespace, deliberately does not delete it, commits revocation in the production Durable Object class, confirms the stale KV value is still byte-for-byte present, and observes HTTP 403 from an independent subsequent caller.

</details>

<details>
<summary>Cached resolver and logout evidence</summary>

```text
(pass) warm positive is denied immediately when the strong boundary revokes it
44 pass / 0 fail — API-key resolver
(pass) warm verified session is denied when its issued-at cutoff is revoked
7 pass / 0 fail — Steward-session resolver
(pass) strong rollout commits the session cutoff before reporting logout success
(pass) strong rollout clears cookies but returns 503 when the cutoff is unconfirmed
7 pass / 0 fail — logout route
```

</details>

Frontend logs: N/A - backend-only change.

## Screenshots (before / after) + video walkthrough

N/A - backend-only change with no rendered surface.

## Audio / voice walkthrough

N/A - no voice/audio behavior changed.

## Known gaps / failures

- The complete Cloud API isolated unit runner executed all 304 files. Four untouched upstream onboarding/BlueBubbles files failed (300/304 files passed); none overlap this diff. The stale onboarding partial-module-mock failure also stops the Cloud-shared batched runner at batch 23/182. Focused changed-contract suites all pass.
- No production/staging flag was enabled and no deploy was performed. This is intentional: checked-in config keeps strong revocation and therefore positive auth caching off until staging rollout evidence is approved.
- Root `bun run verify` passed completely on exact head `13f81ecdefc49e805a265593da8228eb9bc2caef`; all focused changed-contract suites, Cloud package typechecks, and the production Worker dry-run also passed on that same head.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [codex-july-issues]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no repository contribution skill used","attribution_status":"self-reported","lane":"codex-july-issues"} -->