### PR TITLE
fix(plugin-imessage): reject prefix-coerced messages limit query

### DIFF
--- a/plugins/plugin-imessage/src/data-routes-limit.test.ts
+++ b/plugins/plugin-imessage/src/data-routes-limit.test.ts
@@ -15,7 +15,7 @@ vi.mock("@elizaos/core", () => ({
 import { imessageDataRoutes } from "./data-routes.ts";
 
 const messagesRoute = imessageDataRoutes.find(
-  (route) => route.type === "GET" && route.path === "/api/imessage/messages",
+  (route) => route.type === "GET" && route.path === "/api/imessage/messages"
 );
 
 if (!messagesRoute?.handler) {
@@ -77,11 +77,7 @@ async function getMessages(url: string, queries: MessageQuery[]): Promise<Captur
       };
     },
   } as unknown as IAgentRuntime;
-  await messagesRoute.handler?.(
-    { url, method: "GET" } as RouteRequest,
-    mockRes(captured),
-    runtime,
-  );
+  await messagesRoute.handler?.({ url, method: "GET" } as RouteRequest, mockRes(captured), runtime);
   return captured;
 }
 
@@ -107,13 +103,13 @@ describe("GET /api/imessage/messages limit query", () => {
     expect(queries).toEqual([{ chatId: undefined, limit: 500 }]);
   });
 
-  it.each(["1e2", "12px", "007", "0", "abc", "-1", "50abc"])(
+  it.each(["1e2", "12px", "007", "0", "abc", "-1", "50abc", " 10", "10 ", " "])(
     "rejects prefix-coerced limit=%s with 400 before the service",
     async (limit) => {
       const queries: MessageQuery[] = [];
       const captured = await getMessages(
         `/api/imessage/messages?limit=${encodeURIComponent(limit)}`,
-        queries,
+        queries
       );
       expect(captured.status).toBe(400);
       expect(captured.body).toEqual({
@@ -123,6 +119,6 @@ describe("GET /api/imessage/messages limit query", () => {
         },
       });
       expect(queries).toEqual([]);
-    },
+    }
   );
 });

--- a/plugins/plugin-imessage/src/data-routes-limit.test.ts
+++ b/plugins/plugin-imessage/src/data-routes-limit.test.ts
@@ -1,0 +1,128 @@
+/**
+ * GET /api/imessage/messages?limit= must reject prefix-coerced tokens before
+ * the iMessage service is called. Number.parseInt("1e2", 10) === 1 used to
+ * silently return one row.
+ */
+import type { IAgentRuntime, RouteRequest, RouteResponse } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", () => ({
+  buildSetupError: (code: string, message: string) => ({
+    error: { code, message },
+  }),
+}));
+
+import { imessageDataRoutes } from "./data-routes.ts";
+
+const messagesRoute = imessageDataRoutes.find(
+  (route) => route.type === "GET" && route.path === "/api/imessage/messages",
+);
+
+if (!messagesRoute?.handler) {
+  throw new Error("GET /api/imessage/messages handler missing");
+}
+
+interface MessageQuery {
+  chatId?: string;
+  limit?: number;
+}
+
+interface Captured {
+  status?: number;
+  body?: unknown;
+}
+
+function mockRes(captured: Captured): RouteResponse {
+  const res = {
+    status(code: number) {
+      captured.status = code;
+      return res;
+    },
+    json(data: unknown) {
+      captured.body = data;
+      return res;
+    },
+    send(data: unknown) {
+      captured.body = data;
+      return res;
+    },
+    end() {
+      return res;
+    },
+  };
+  return res;
+}
+
+async function getMessages(url: string, queries: MessageQuery[]): Promise<Captured> {
+  const captured: Captured = {};
+  const runtime = {
+    getService: (key: string) => {
+      if (key !== "imessage") return null;
+      return {
+        isConnected: () => true,
+        getMessages: async (opts?: { chatId?: string; limit?: number }) => {
+          queries.push({ chatId: opts?.chatId, limit: opts?.limit });
+          return [{ id: "1", text: "hi" }];
+        },
+        getRecentMessages: async (limit?: number) => {
+          queries.push({ limit });
+          return [{ id: "1", text: "hi" }];
+        },
+        sendMessage: async () => ({ success: true }),
+        getChats: async () => [],
+        listAllContacts: async () => [],
+        addContact: async () => "person-1",
+        updateContact: async () => true,
+        deleteContact: async () => true,
+      };
+    },
+  } as unknown as IAgentRuntime;
+  await messagesRoute.handler?.(
+    { url, method: "GET" } as RouteRequest,
+    mockRes(captured),
+    runtime,
+  );
+  return captured;
+}
+
+describe("GET /api/imessage/messages limit query", () => {
+  it("canonical limit=10 reaches getMessages", async () => {
+    const queries: MessageQuery[] = [];
+    const captured = await getMessages("/api/imessage/messages?limit=10", queries);
+    expect(captured.status).toBe(200);
+    expect(queries).toEqual([{ chatId: undefined, limit: 10 }]);
+  });
+
+  it("omitted limit still defaults to 50", async () => {
+    const queries: MessageQuery[] = [];
+    const captured = await getMessages("/api/imessage/messages", queries);
+    expect(captured.status).toBe(200);
+    expect(queries).toEqual([{ chatId: undefined, limit: 50 }]);
+  });
+
+  it("caps a canonical oversize limit at 500", async () => {
+    const queries: MessageQuery[] = [];
+    const captured = await getMessages("/api/imessage/messages?limit=501", queries);
+    expect(captured.status).toBe(200);
+    expect(queries).toEqual([{ chatId: undefined, limit: 500 }]);
+  });
+
+  it.each(["1e2", "12px", "007", "0", "abc", "-1", "50abc"])(
+    "rejects prefix-coerced limit=%s with 400 before the service",
+    async (limit) => {
+      const queries: MessageQuery[] = [];
+      const captured = await getMessages(
+        `/api/imessage/messages?limit=${encodeURIComponent(limit)}`,
+        queries,
+      );
+      expect(captured.status).toBe(400);
+      expect(captured.body).toEqual({
+        error: {
+          code: "bad_request",
+          message: "limit must be a positive integer",
+        },
+      });
+      expect(queries).toEqual([]);
+    },
+  );
+});

--- a/plugins/plugin-imessage/src/data-routes.ts
+++ b/plugins/plugin-imessage/src/data-routes.ts
@@ -149,14 +149,13 @@ const MAX_MESSAGES_LIMIT = 500;
  * silently return one iMessage instead of rejecting the token.
  */
 function parseMessagesLimit(raw: string | null): number | null {
-  if (raw === null || raw.trim() === "") {
+  if (raw === null || raw === "") {
     return DEFAULT_MESSAGES_LIMIT;
   }
-  const trimmed = raw.trim();
-  if (!/^[1-9]\d*$/.test(trimmed)) {
+  if (!/^[1-9]\d*$/.test(raw)) {
     return null;
   }
-  return Math.min(Number.parseInt(trimmed, 10), MAX_MESSAGES_LIMIT);
+  return Math.min(Number.parseInt(raw, 10), MAX_MESSAGES_LIMIT);
 }
 
 // ── GET /api/imessage/messages?limit=N ──────────────────────────────
@@ -173,9 +172,7 @@ async function handleMessages(
   const url = new URL(req.url ?? "/api/imessage/messages", "http://localhost");
   const limit = parseMessagesLimit(url.searchParams.get("limit"));
   if (limit === null) {
-    res
-      .status(400)
-      .json(buildSetupError("bad_request", "limit must be a positive integer"));
+    res.status(400).json(buildSetupError("bad_request", "limit must be a positive integer"));
     return;
   }
   const chatId = url.searchParams.get("chatId")?.trim() || undefined;

--- a/plugins/plugin-imessage/src/data-routes.ts
+++ b/plugins/plugin-imessage/src/data-routes.ts
@@ -141,6 +141,24 @@ function parseContactId(pathname: string): string | null {
   return decodeURIComponent(rest);
 }
 
+const DEFAULT_MESSAGES_LIMIT = 50;
+const MAX_MESSAGES_LIMIT = 500;
+
+/**
+ * Canonical positive page size. `Number.parseInt("1e2", 10) === 1` used to
+ * silently return one iMessage instead of rejecting the token.
+ */
+function parseMessagesLimit(raw: string | null): number | null {
+  if (raw === null || raw.trim() === "") {
+    return DEFAULT_MESSAGES_LIMIT;
+  }
+  const trimmed = raw.trim();
+  if (!/^[1-9]\d*$/.test(trimmed)) {
+    return null;
+  }
+  return Math.min(Number.parseInt(trimmed, 10), MAX_MESSAGES_LIMIT);
+}
+
 // ── GET /api/imessage/messages?limit=N ──────────────────────────────
 async function handleMessages(
   req: RouteRequest,
@@ -153,8 +171,13 @@ async function handleMessages(
     return;
   }
   const url = new URL(req.url ?? "/api/imessage/messages", "http://localhost");
-  const limitParam = url.searchParams.get("limit");
-  const limit = Math.min(Math.max(1, Number.parseInt(limitParam ?? "50", 10) || 50), 500);
+  const limit = parseMessagesLimit(url.searchParams.get("limit"));
+  if (limit === null) {
+    res
+      .status(400)
+      .json(buildSetupError("bad_request", "limit must be a positive integer"));
+    return;
+  }
   const chatId = url.searchParams.get("chatId")?.trim() || undefined;
   try {
     const messages =


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on native iMessage `GET /api/imessage/messages?limit=`.
Not a twin of percent-encoded path/id leftovers (scheduling, app-manager, workflow),
SIWS chainId, orchestrator `lines=`, provisioning-worker env ints, invites-accept,
cli-auth, redemption quote, compat agent-logs, first-run, notifications,
BlueBubbles, login persist, billing, or avatar. Does not edit
`bluebubbles-routes.ts` or the legacy `imessage-routes.ts` dispatcher.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Query `limit` parse only on the live `imessageDataRoutes` GET messages
handler. Omitted/empty still defaults to 50 and caps at 500. Prefix-coerced
tokens (`1e2`, `12px`, `007`) become 400 before `getMessages`.

# Background

## What does this PR do?

`handleMessages` used `Number.parseInt(limitParam ?? "50", 10) || 50`.
`parseInt` stops at the first non-digit, so `1e2` became 1, `12px` became 12,
and `007` became 7 — then the service returned that silently truncated page.

- omitted / empty `limit` → default **50**
- `/^[1-9]\d*$/` → that integer, cap **500**
- `1e2` / `12px` / `007` / `0` / `abc` → **400** `limit must be a positive integer`, no service call

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A client that sends a scientific or unit-suffixed page size should get a
request error, not a silently truncated iMessage page that looks like a
successful read.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`plugins/plugin-imessage/src/data-routes-limit.test.ts` — default, exact,
capped, and prefix-coerced `limit` table against the live GET handler.

## Detailed testing steps

```bash
cd plugins/plugin-imessage
bunx vitest run src/data-routes-limit.test.ts --coverage.enabled=false
```

10 passed at the evidence head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; native iMessage GET /api/imessage/messages query parse only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; native iMessage GET /api/imessage/messages query parse only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; native iMessage GET /api/imessage/messages query parse only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused vitest drives the live GET handler and asserts 400 vs getMessages skip; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - in-memory service stub only; invalid tokens never call getMessages.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused vitest output: prefix-coerced
`limit` returns 400 with zero service calls; omitted/empty still defaults to 50.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file iMessage query-limit parse with a
green focused suite (10 tests). Full monorepo verify is unrelated to this
limit boundary and was skipped to keep the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:cc7458fa9d95002852f1228e79857f678dded942 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->


## Independent review repair

The final head is rebased onto `develop@a83f15c10fd5adc0730937ebe7df2ee9ac8a93dd`. Review found that trimming before validation admitted non-canonical whitespace-padded tokens despite the stated raw `/^[1-9]\d*$/` contract. The final parser defaults only omitted/empty values and rejects leading, trailing, or whitespace-only tokens before the service call. Repository formatting was also applied to both changed files. Exact-head verification: focused 13/13; full iMessage 147/147; typecheck/build/Biome/diff clean; forced root verify 356/356, 0 cached, every audit; anti-larp 8,435 files, 0 focused/orphaned skips.