### PR TITLE
fix(cloud): isolate Personal Shared rate-limit warming

### DIFF
--- a/packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts
@@ -151,8 +151,8 @@ describe("Miniflare Durable Object integration", () => {
       modules: true,
       script: await output.text(),
       durableObjects: {
-        TEST_ADMISSION_GATE: {
-          className: "InferenceAdmissionGate",
+        INFERENCE_ADMISSION_GATES: {
+          className: "TestInferenceAdmissionGate",
           useSQLite: true,
         },
       },
@@ -167,12 +167,14 @@ describe("Miniflare Durable Object integration", () => {
   async function post(
     path: string,
     body: Record<string, unknown>,
+    gateName = "org-miniflare",
   ): Promise<{ readonly status: number; text(): Promise<string> }> {
     const response = await miniflare.dispatchFetch(`https://gate.test${path}`, {
       method: "POST",
       headers: {
         "content-type": "application/json",
         "x-test-organization-id": "org-miniflare",
+        "x-test-gate-name": gateName,
       },
       body: JSON.stringify(body),
     });
@@ -341,4 +343,45 @@ describe("Miniflare Durable Object integration", () => {
     });
     expect((await post("/credential/check", credential)).status).toBe(200);
   });
+
+  test("a separate rate-limit identity answers while the legacy ledger input gate is blocked", async () => {
+    const policy = {
+      endpointType: "completions",
+      windowMs: 60_000,
+      maxRequests: 2,
+    };
+    expect((await post("/test-block-ledger", {})).status).toBe(202);
+
+    const blockedLegacy = post("/rate-limit", policy);
+    const legacyAnsweredEarly = await Promise.race([
+      blockedLegacy.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 300)),
+    ]);
+    expect(legacyAnsweredEarly).toBe(false);
+
+    const isolated = await Promise.race([
+      post("/rate-limit", policy, "rate-limit:v2:org-miniflare"),
+      new Promise<never>((_, reject) => {
+        setTimeout(
+          () => reject(new Error("isolated rate limit waited behind ledger")),
+          500,
+        );
+      }),
+    ]);
+    expect(isolated.status).toBe(200);
+    expect((await blockedLegacy).status).toBe(200);
+  }, 120_000);
+
+  test("the cutover coordinator chooses the next exact fixed-window boundary", async () => {
+    const response = await post(
+      "/rate-limit-v2-cutover",
+      { windowMs: 60_000 },
+      "rate-limit:v2:cutover",
+    );
+    expect(response.status).toBe(200);
+    const body = JSON.parse(await response.text()) as { cutoverAt: number };
+    expect(body.cutoverAt % 60_000).toBe(0);
+    expect(body.cutoverAt).toBeGreaterThan(Date.now());
+    expect(body.cutoverAt - Date.now()).toBeLessThanOrEqual(60_000);
+  }, 120_000);
 });

--- a/packages/cloud/api/__tests__/inference-admission-gate.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.test.ts
@@ -14,6 +14,7 @@ import {
   InferenceAdmissionLeaseRejectedError,
   markInferenceAdmissionLeaseDispatched,
   settleInferenceAdmissionLease,
+  warmInferenceRateLimitGate,
 } from "@/lib/services/inference-admission-gate";
 import * as admissionRecovery from "@/lib/services/inference-admission-recovery";
 import { InferenceAdmissionGate } from "../src/inference-admission-gate";
@@ -157,11 +158,14 @@ function storedLeaseKey(requestId: string): string {
   return `lease:${encodeURIComponent(requestId)}`;
 }
 
-function createGate(storage = new TestStorage()): InferenceAdmissionGate {
+function createGate(
+  storage = new TestStorage(),
+  env: Record<string, unknown> = {},
+): InferenceAdmissionGate {
   const state = {
     storage,
   } as unknown as DurableObjectState;
-  return new InferenceAdmissionGate(state, {} as never);
+  return new InferenceAdmissionGate(state, env as never);
 }
 
 function post(
@@ -172,7 +176,10 @@ function post(
     | "/dispatch"
     | "/release"
     | "/settle"
-    | "/rate-limit",
+    | "/rate-limit"
+    | "/rate-limit-v2-cutover"
+    | "/rate-limit-warm"
+    | "/rate-limit-handoff",
   body: Record<string, unknown>,
 ): Promise<Response> {
   const payload =
@@ -228,6 +235,42 @@ function gateBindings(gate: InferenceAdmissionGate) {
           gate.fetch(new Request(request, init)),
       }),
     },
+  };
+}
+
+function createRateLimitGateNetwork(organizationId = "org-a") {
+  const legacyStorage = new TestStorage();
+  const rateStorage = new TestStorage();
+  const cutoverStorage = new TestStorage();
+  const gates = new Map<string, InferenceAdmissionGate>();
+  const requestedNames: string[] = [];
+  const namespace = {
+    getByName: (name: string) => {
+      requestedNames.push(name);
+      return {
+        fetch: (request: RequestInfo | URL, init?: RequestInit) => {
+          const gate = gates.get(name);
+          if (!gate) throw new Error(`Unexpected gate identity: ${name}`);
+          return gate.fetch(new Request(request, init));
+        },
+      };
+    },
+  };
+  const env = { INFERENCE_ADMISSION_GATES: namespace };
+  const legacyGate = createGate(legacyStorage, env);
+  const rateGate = createGate(rateStorage, env);
+  const cutoverGate = createGate(cutoverStorage, env);
+  gates.set(organizationId, legacyGate);
+  gates.set(`rate-limit:v2:${organizationId}`, rateGate);
+  gates.set("rate-limit:v2:cutover", cutoverGate);
+  return {
+    bindings: { INFERENCE_ADMISSION_GATES: namespace },
+    legacyGate,
+    legacyStorage,
+    rateGate,
+    rateStorage,
+    cutoverStorage,
+    requestedNames,
   };
 }
 
@@ -302,9 +345,25 @@ describe("InferenceAdmissionGate", () => {
     }
   });
 
+  test("rejects a cutover window whose next boundary exceeds safe integer precision", async () => {
+    const clock = spyOn(Date, "now").mockReturnValue(Number.MAX_SAFE_INTEGER);
+    try {
+      const gate = createGate(new TestStorage());
+      expect(
+        (
+          await post(gate, "/rate-limit-v2-cutover", {
+            windowMs: Number.MAX_SAFE_INTEGER,
+          })
+        ).status,
+      ).toBe(400);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
   test("rate-limit client returns denials without balance hydration", async () => {
-    const gate = createGate();
-    await runWithCloudBindingsAsync(gateBindings(gate), async () => {
+    const network = createRateLimitGateNetwork();
+    await runWithCloudBindingsAsync(network.bindings, async () => {
       expect(
         await consumeInferenceRateLimit({
           organizationId: "org-a",
@@ -330,6 +389,67 @@ describe("InferenceAdmissionGate", () => {
         maxRequests: 1,
       }),
     ).rejects.toBeInstanceOf(InferenceAdmissionGateUnavailableError);
+  });
+
+  test("rate-limit prewarm loads its isolated window without consuming a request", async () => {
+    const network = createRateLimitGateNetwork();
+    await runWithCloudBindingsAsync(network.bindings, async () => {
+      await warmInferenceRateLimitGate("org-a");
+      await warmInferenceRateLimitGate("org-a");
+      expect(network.legacyStorage.read("ledger")).toBeUndefined();
+      expect(network.rateStorage.read("ledger")).toBeUndefined();
+      expect(network.rateStorage.read("rate-limits")).toBeUndefined();
+      expect(network.requestedNames).toContain("rate-limit:v2:org-a");
+      expect(
+        network.requestedNames.filter((name) => name === "rate-limit:v2:org-a"),
+      ).toHaveLength(1);
+      expect(
+        await consumeInferenceRateLimit({
+          organizationId: "org-a",
+          endpointType: "completions",
+          windowMs: 60_000,
+          maxRequests: 1,
+        }),
+      ).toMatchObject({ allowed: true, remaining: 0 });
+    });
+  });
+
+  test("cuts over only after the entire legacy fixed window has expired", async () => {
+    const network = createRateLimitGateNetwork();
+    const clock = spyOn(Date, "now").mockReturnValue(61_234);
+    const body = {
+      endpointType: "completions" as const,
+      windowMs: 61_000,
+      maxRequests: 1,
+    };
+    try {
+      await runWithCloudBindingsAsync(network.bindings, async () => {
+        expect(
+          await consumeInferenceRateLimit({
+            organizationId: "org-a",
+            ...body,
+          }),
+        ).toMatchObject({ allowed: true, remaining: 0 });
+        expect(
+          await consumeInferenceRateLimit({
+            organizationId: "org-a",
+            ...body,
+          }),
+        ).toMatchObject({ allowed: false, remaining: 0 });
+
+        clock.mockReturnValue(122_000);
+        expect(
+          await consumeInferenceRateLimit({
+            organizationId: "org-a",
+            ...body,
+          }),
+        ).toMatchObject({ allowed: true, remaining: 0 });
+      });
+      expect(network.legacyStorage.read("rate-limits")).toBeDefined();
+      expect(network.rateStorage.read("rate-limits")).toBeDefined();
+    } finally {
+      clock.mockRestore();
+    }
   });
 
   test("policy changes preserve the current endpoint count", async () => {

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.test.ts
@@ -241,7 +241,7 @@ describe("personal Shared messaging deliveries", () => {
     });
     expect(findActivePersonalDedicatedTarget).not.toHaveBeenCalled();
     expect(response.headers.get("server-timing")).toMatch(
-      /^account;dur=\d+\.\d;desc="single-query-repeat", shared;dur=\d+\.\d$/,
+      /^account;dur=\d+\.\d;desc="single-query-repeat", prewarm;dur=\d+\.\d, shared;dur=\d+\.\d$/,
     );
     expect(body.data.identity.id).toMatch(/^personal:/);
     expect(sharedRestMessageSend).toHaveBeenCalledWith(
@@ -291,6 +291,7 @@ describe("personal Shared messaging deliveries", () => {
         user_id: "00000000-0000-4000-8000-000000000002",
       }),
       namespace,
+      { warmConversation: true },
     );
     expect(order).toEqual(["prewarm", "turn"]);
     expect(runtimeWaitUntil).toHaveBeenCalledTimes(1);
@@ -299,12 +300,21 @@ describe("personal Shared messaging deliveries", () => {
     );
   });
 
-  test("keeps established personal turns on the direct warm path", async () => {
+  test("prewarms established personal turns before inference admission", async () => {
     const response = await request(valid);
 
     expect(response.status).toBe(200);
-    expect(prewarmPersonalSharedAgentTurnCaches).not.toHaveBeenCalled();
-    expect(runtimeWaitUntil).not.toHaveBeenCalled();
+    expect(prewarmPersonalSharedAgentTurnCaches).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organization_id: "00000000-0000-4000-8000-000000000001",
+      }),
+      namespace,
+      { warmConversation: false },
+    );
+    expect(runtimeWaitUntil).toHaveBeenCalledTimes(1);
+    expect(response.headers.get("server-timing")).toMatch(
+      /^account;dur=\d+\.\d;desc="[^"]+", prewarm;dur=\d+\.\d, shared;dur=\d+\.\d$/,
+    );
   });
 
   test("correlates a Shared failure without logging its sensitive message", async () => {

--- a/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
+++ b/packages/cloud/api/internal/eliza-app/personal-shared/messages/route.ts
@@ -267,11 +267,11 @@ app.post("/", async (c) => {
     const accountStartedAt = performance.now();
     let account: { userId: string; organizationId: string };
     let accountResolution = "phone-query";
-    let isNewPersonalAccount = false;
     let dedicated:
       | Pick<AgentSandbox, "id" | "status" | "bridge_url" | "agent_config">
       | null
       | undefined;
+    let isNewPersonalAccount = false;
     if (parsed.data.platform === "telegram") {
       const delivery = await resolvePersonalDeliveryProjection(
         c.env,
@@ -326,17 +326,18 @@ app.post("/", async (c) => {
       userId: account.userId,
       organizationId: account.organizationId,
     });
-    const personalPrewarm = isNewPersonalAccount
-      ? (() => {
+    const personalPrewarm = dedicated
+      ? null
+      : (() => {
           const startedAt = performance.now();
           const timing = prewarmPersonalSharedAgentTurnCaches(
             agent,
             worker.namespace,
+            { warmConversation: isNewPersonalAccount },
           ).then(() => performance.now() - startedAt);
           worker.executionCtx.waitUntil(timing);
           return timing;
-        })()
-      : null;
+        })();
     let deliveryMessage = parsed.data.message;
     if (
       parsed.data.platform === "telegram" &&
@@ -596,7 +597,10 @@ app.post("/", async (c) => {
       });
     }
     stage = "shared_runtime";
-    const prewarmMs = personalPrewarm ? await personalPrewarm : undefined;
+    if (!personalPrewarm) {
+      throw new Error("Shared turn reached inference with a Dedicated target");
+    }
+    const prewarmMs = await personalPrewarm;
     const sharedStartedAt = performance.now();
     const trustedDelivery =
       parsed.data.platform === "telegram"
@@ -630,9 +634,9 @@ app.post("/", async (c) => {
     );
     c.header(
       "Server-Timing",
-      `${accountTiming}, ${
-        prewarmMs === undefined ? "" : `prewarm;dur=${prewarmMs.toFixed(1)}, `
-      }shared;dur=${(performance.now() - sharedStartedAt).toFixed(1)}`,
+      `${accountTiming}, prewarm;dur=${prewarmMs.toFixed(1)}, shared;dur=${(
+        performance.now() - sharedStartedAt
+      ).toFixed(1)}`,
     );
 
     return c.json({

--- a/packages/cloud/api/src/inference-admission-gate.ts
+++ b/packages/cloud/api/src/inference-admission-gate.ts
@@ -1,11 +1,10 @@
 /**
- * Per-organization serialized admission controls for inference requests.
+ * Serialized admission controls for inference requests.
  *
- * The object never queries Postgres or Redis. It durably enforces exact
- * fixed-window endpoint limits and bounds concurrent provider dispatches to the
- * latest cached balance. Capacity can only increase from a cache snapshot
- * observed after the last accounting event, so stale KV values cannot
- * resurrect already-consumed spend.
+ * Billing leases retain one object identity per organization. Fixed-window
+ * limits use distinct rate-only identities after a globally coordinated window
+ * boundary, so their storage input gates cannot inherit ledger stalls without
+ * resetting an active quota window. The object never queries Postgres or Redis.
  */
 
 import { runWithDbCacheAsync } from "@/db/client";
@@ -124,6 +123,10 @@ interface OrganizationStateRequest {
   active: boolean;
 }
 
+interface RateLimitCutoverRequest {
+  windowMs: number;
+}
+
 interface RateLimitWindow {
   windowStartedAt: number;
   windowMs: number;
@@ -142,6 +145,7 @@ const ORGANIZATION_DISABLED_KEY = "revocation:organization-disabled";
 const REVOKED_API_KEY_PREFIX = "revocation:api-key:";
 const DISABLED_SUBJECT_PREFIX = "revocation:subject-disabled:";
 const SESSION_CUTOFF_PREFIX = "revocation:session-cutoff:";
+const RATE_LIMIT_CUTOVERS_KEY = "rate-limit-v2-cutovers";
 const MAX_LEASE_AGE_MS = 20 * 60_000;
 const RECOVERY_RETRY_MS = 60_000;
 const MAX_ACTIVE_LEASES = 2_048;
@@ -438,6 +442,9 @@ export class InferenceAdmissionGate {
   private ledger: GateLedger | undefined;
   private rateLimitWindows: RateLimitWindows | undefined;
   private operationQueue: Promise<void> = Promise.resolve();
+  // This queue orders calls within a rate-only identity. Cross-lane isolation
+  // comes from the distinct Durable Object identity selected by the caller.
+  private rateLimitOperationQueue: Promise<void> = Promise.resolve();
 
   constructor(state: DurableObjectState, env: AppEnv["Bindings"]) {
     this.state = state;
@@ -594,10 +601,59 @@ export class InferenceAdmissionGate {
     this.rateLimitWindows = snapshot;
   }
 
+  private async rateLimitCutover(
+    request: RateLimitCutoverRequest,
+  ): Promise<Response> {
+    if (!Number.isSafeInteger(request.windowMs) || request.windowMs <= 0) {
+      return jsonError("Invalid inference rate-limit cutover window", 400);
+    }
+    const key = String(request.windowMs);
+    const cutovers =
+      (await this.state.storage.get<Record<string, number>>(
+        RATE_LIMIT_CUTOVERS_KEY,
+      )) ?? {};
+    const existing = cutovers[key];
+    if (existing !== undefined) {
+      if (
+        !Number.isSafeInteger(existing) ||
+        existing <= 0 ||
+        existing % request.windowMs !== 0
+      ) {
+        throw new Error("Inference rate-limit cutover is corrupt");
+      }
+      return Response.json({ cutoverAt: existing });
+    }
+    const now = Date.now();
+    const cutoverAt =
+      (Math.floor(now / request.windowMs) + 1) * request.windowMs;
+    if (!Number.isSafeInteger(cutoverAt)) {
+      return jsonError("Invalid inference rate-limit cutover window", 400);
+    }
+    await this.state.storage.put(RATE_LIMIT_CUTOVERS_KEY, {
+      ...cutovers,
+      [key]: cutoverAt,
+    });
+    return Response.json({ cutoverAt });
+  }
+
   private async serialize<T>(operation: () => Promise<T>): Promise<T> {
     const previous = this.operationQueue;
     let release: () => void = () => undefined;
     this.operationQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  private async serializeRateLimit<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.rateLimitOperationQueue;
+    let release: () => void = () => undefined;
+    this.rateLimitOperationQueue = new Promise<void>((resolve) => {
       release = resolve;
     });
     await previous;
@@ -1054,6 +1110,11 @@ export class InferenceAdmissionGate {
     return Response.json({ committed: true });
   }
 
+  private async warmRateLimit(): Promise<Response> {
+    await this.loadRateLimitWindows();
+    return Response.json({ warmed: true });
+  }
+
   async fetch(request: Request): Promise<Response> {
     if (request.method !== "POST") {
       return new Response("Method not allowed", { status: 405 });
@@ -1068,7 +1129,8 @@ export class InferenceAdmissionGate {
       | CredentialRevokeRequest
       | SubjectStateRequest
       | SessionRevokeRequest
-      | OrganizationStateRequest;
+      | OrganizationStateRequest
+      | RateLimitCutoverRequest;
     try {
       body = (await request.json()) as
         | LeaseRequest
@@ -1080,7 +1142,8 @@ export class InferenceAdmissionGate {
         | CredentialRevokeRequest
         | SubjectStateRequest
         | SessionRevokeRequest
-        | OrganizationStateRequest;
+        | OrganizationStateRequest
+        | RateLimitCutoverRequest;
     } catch {
       // error-policy:J3 malformed request bodies are rejected explicitly.
       return jsonError("Invalid JSON body", 400);
@@ -1107,8 +1170,16 @@ export class InferenceAdmissionGate {
       );
     }
     if (path === "/rate-limit") {
-      return await this.serialize(() =>
+      return await this.serializeRateLimit(() =>
         this.rateLimit(body as RateLimitRequest),
+      );
+    }
+    if (path === "/rate-limit-warm") {
+      return await this.serializeRateLimit(() => this.warmRateLimit());
+    }
+    if (path === "/rate-limit-v2-cutover") {
+      return await this.serializeRateLimit(() =>
+        this.rateLimitCutover(body as RateLimitCutoverRequest),
       );
     }
     if (path === "/credential/check") {

--- a/packages/cloud/api/test/fixtures/inference-admission-gate-worker.ts
+++ b/packages/cloud/api/test/fixtures/inference-admission-gate-worker.ts
@@ -5,18 +5,44 @@
 
 import { InferenceAdmissionGate } from "../../src/inference-admission-gate";
 
-export { InferenceAdmissionGate };
+export class TestInferenceAdmissionGate extends InferenceAdmissionGate {
+  private readonly testState: DurableObjectState;
+
+  constructor(state: DurableObjectState, env: Record<string, unknown>) {
+    super(state, env as never);
+    this.testState = state;
+  }
+
+  override async fetch(request: Request): Promise<Response> {
+    if (new URL(request.url).pathname !== "/test-block-ledger") {
+      return await super.fetch(request);
+    }
+    let entered: () => void = () => undefined;
+    const started = new Promise<void>((resolve) => {
+      entered = resolve;
+    });
+    const blocked = this.testState.storage.transaction(async (transaction) => {
+      await transaction.put("test-ledger-block", Date.now());
+      entered();
+      await new Promise<void>((resolve) => setTimeout(resolve, 2_000));
+    });
+    this.testState.waitUntil(blocked);
+    await started;
+    return new Response(null, { status: 202 });
+  }
+}
 
 export default {
   async fetch(
     request: Request,
-    env: { TEST_ADMISSION_GATE: DurableObjectNamespace },
+    env: { INFERENCE_ADMISSION_GATES: DurableObjectNamespace },
   ) {
     const organizationId = request.headers.get("x-test-organization-id");
     if (!organizationId)
       return new Response("missing organization", { status: 400 });
-    return await env.TEST_ADMISSION_GATE.get(
-      env.TEST_ADMISSION_GATE.idFromName(organizationId),
+    const gateName = request.headers.get("x-test-gate-name") ?? organizationId;
+    return await env.INFERENCE_ADMISSION_GATES.get(
+      env.INFERENCE_ADMISSION_GATES.idFromName(gateName),
     ).fetch(request);
   },
 };

--- a/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
+++ b/packages/cloud/shared/src/lib/services/inference-admission-gate.ts
@@ -2,10 +2,10 @@
  * Serialized organization admission controls for Worker inference.
  *
  * Cloudflare KV is eventually consistent and cannot safely decrement a cached
- * counter or balance under concurrency. A per-organization Durable Object
- * therefore enforces endpoint limits and leases estimated spend before provider
- * dispatch. Postgres accounting starts only after provider work or from an
- * expired-lease alarm.
+ * counter or balance under concurrency. Billing leases retain one Durable
+ * Object per organization, while endpoint limits move to rate-only identities
+ * at the next complete fixed-window boundary. This preserves quota without
+ * letting slow ledger storage block the rate-limit input gate.
  */
 
 import { sql } from "drizzle-orm";
@@ -23,10 +23,14 @@ import type { EndpointType } from "./org-rate-limits";
 
 const GATE_BINDING = "INFERENCE_ADMISSION_GATES";
 const GATE_ORIGIN = "https://inference-admission.internal";
+const RATE_LIMIT_GATE_PREFIX = "rate-limit:v2:";
+const RATE_LIMIT_CUTOVER_GATE = "rate-limit:v2:cutover";
 const HYDRATION_GATE_TIMEOUT_MS = 5_000;
 const GATE_OPERATION_TIMEOUT_MS = 1_500;
 const DISPATCH_GATE_TIMEOUT_MS = 1_500;
 const DISPATCH_GATE_MAX_ATTEMPTS = 3;
+const RATE_LIMIT_WARM_TTL_MS = 5 * 60_000;
+const RATE_LIMIT_WARM_MAX_ENTRIES = 4_096;
 
 interface LeaseResponse {
   admitted: boolean;
@@ -48,6 +52,14 @@ interface ReleaseResponse {
 
 interface HydrateResponse {
   hydrated: boolean;
+}
+
+interface RateLimitWarmResponse {
+  warmed: boolean;
+}
+
+interface RateLimitCutoverResponse {
+  cutoverAt: number;
 }
 
 export interface InferenceRateLimitDecision {
@@ -132,6 +144,26 @@ function gateStub(organizationId: string): RuntimeDurableObjectStub {
     );
   }
   return namespace.getByName(organizationId);
+}
+
+function rateLimitGateStub(organizationId: string): RuntimeDurableObjectStub {
+  const namespace = getCloudBinding<RuntimeDurableObjectNamespace>(GATE_BINDING);
+  if (!namespace) {
+    throw new InferenceAdmissionGateUnavailableError(
+      "Inference admission Durable Object binding is missing",
+    );
+  }
+  return namespace.getByName(`${RATE_LIMIT_GATE_PREFIX}${organizationId}`);
+}
+
+function rateLimitCutoverStub(): RuntimeDurableObjectStub {
+  const namespace = getCloudBinding<RuntimeDurableObjectNamespace>(GATE_BINDING);
+  if (!namespace) {
+    throw new InferenceAdmissionGateUnavailableError(
+      "Inference admission Durable Object binding is missing",
+    );
+  }
+  return namespace.getByName(RATE_LIMIT_CUTOVER_GATE);
 }
 
 async function gateFetch(
@@ -253,6 +285,55 @@ async function parseHydrateResponse(response: Response): Promise<HydrateResponse
   }
 }
 
+async function parseRateLimitWarmResponse(response: Response): Promise<RateLimitWarmResponse> {
+  try {
+    const value = await response.json();
+    if (
+      typeof value !== "object" ||
+      value === null ||
+      (value as Record<string, unknown>).warmed !== true
+    ) {
+      throw new TypeError("response does not match the rate-limit warm schema");
+    }
+    return value as RateLimitWarmResponse;
+  } catch (error) {
+    // error-policy:J3 malformed responses never become successful prewarm.
+    throw new InferenceAdmissionGateUnavailableError(
+      `Inference admission gate returned invalid rate-limit warm JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error },
+    );
+  }
+}
+
+async function parseRateLimitCutoverResponse(
+  response: Response,
+  windowMs: number,
+): Promise<RateLimitCutoverResponse> {
+  try {
+    const value = await response.json();
+    const cutoverAt =
+      value && typeof value === "object" ? (value as Record<string, unknown>).cutoverAt : undefined;
+    if (
+      !Number.isSafeInteger(cutoverAt) ||
+      (cutoverAt as number) <= 0 ||
+      (cutoverAt as number) % windowMs !== 0
+    ) {
+      throw new TypeError("response does not match the rate-limit cutover schema");
+    }
+    return { cutoverAt: cutoverAt as number };
+  } catch (error) {
+    // error-policy:J3 malformed cutover state never selects a second quota lane.
+    throw new InferenceAdmissionGateUnavailableError(
+      `Inference admission gate returned invalid rate-limit cutover JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+      { cause: error },
+    );
+  }
+}
+
 async function parseRateLimitResponse(response: Response): Promise<InferenceRateLimitDecision> {
   try {
     const value = await response.json();
@@ -350,6 +431,85 @@ export async function warmInferenceAdmissionGate(organizationId: string): Promis
   await hydrateInferenceAdmissionGate(organizationId, gateStub(organizationId));
 }
 
+const rateLimitCutovers = new Map<number, Promise<number>>();
+const rateLimitWarms = new Map<string, { expiresAt: number; promise: Promise<void> }>();
+
+function rateLimitCutoverAt(windowMs: number): Promise<number> {
+  const existing = rateLimitCutovers.get(windowMs);
+  if (existing) return existing;
+  const cutover = gateFetch(
+    RATE_LIMIT_CUTOVER_GATE,
+    "/rate-limit-v2-cutover",
+    { windowMs },
+    rateLimitCutoverStub(),
+    AbortSignal.timeout(GATE_OPERATION_TIMEOUT_MS),
+  )
+    .then(async (response) => {
+      if (!response.ok) {
+        throw new InferenceAdmissionGateUnavailableError(
+          `Inference rate-limit cutover failed with status ${response.status}`,
+        );
+      }
+      return (await parseRateLimitCutoverResponse(response, windowMs)).cutoverAt;
+    })
+    .catch((error) => {
+      rateLimitCutovers.delete(windowMs);
+      throw error;
+    });
+  rateLimitCutovers.set(windowMs, cutover);
+  return cutover;
+}
+
+async function activeRateLimitGate(
+  organizationId: string,
+  windowMs: number,
+): Promise<RuntimeDurableObjectStub> {
+  const cutoverAt = await rateLimitCutoverAt(windowMs);
+  return Date.now() >= cutoverAt ? rateLimitGateStub(organizationId) : gateStub(organizationId);
+}
+
+/** Warm only the strongly ordered rate-limit window, without reading the balance database. */
+export async function warmInferenceRateLimitGate(
+  organizationId: string,
+  windowMs = 60_000,
+): Promise<void> {
+  const key = `${windowMs}:${organizationId}`;
+  const now = Date.now();
+  const existing = rateLimitWarms.get(key);
+  if (existing && existing.expiresAt > now) {
+    await existing.promise;
+    return;
+  }
+  if (rateLimitWarms.size >= RATE_LIMIT_WARM_MAX_ENTRIES) {
+    const oldest = rateLimitWarms.keys().next().value;
+    if (oldest !== undefined) rateLimitWarms.delete(oldest);
+  }
+  const warm = (async () => {
+    await rateLimitCutoverAt(windowMs);
+    const response = await gateFetch(
+      organizationId,
+      "/rate-limit-warm",
+      {},
+      rateLimitGateStub(organizationId),
+      AbortSignal.timeout(HYDRATION_GATE_TIMEOUT_MS),
+    );
+    if (!response.ok) {
+      throw new InferenceAdmissionGateUnavailableError(
+        `Inference admission gate rate-limit warm failed with status ${response.status}`,
+      );
+    }
+    await parseRateLimitWarmResponse(response);
+  })().catch((error) => {
+    rateLimitWarms.delete(key);
+    throw error;
+  });
+  rateLimitWarms.set(key, {
+    expiresAt: now + RATE_LIMIT_WARM_TTL_MS,
+    promise: warm,
+  });
+  await warm;
+}
+
 function scheduleGateHydration(
   organizationId: string,
   stub: RuntimeDurableObjectStub,
@@ -397,7 +557,7 @@ export async function consumeInferenceRateLimit(params: {
       windowMs: params.windowMs,
       maxRequests: params.maxRequests,
     },
-    undefined,
+    await activeRateLimitGate(params.organizationId, params.windowMs),
     AbortSignal.timeout(GATE_OPERATION_TIMEOUT_MS),
   );
   if (response.status !== 200 && response.status !== 429) {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.test.ts
@@ -25,6 +25,9 @@ const warmInferenceAdmissionSnapshot = mock(async () => {
 const warmInferenceAdmissionGate = mock(async () => {
   calls.push("admission-gate");
 });
+const warmInferenceRateLimitGate = mock(async () => {
+  calls.push("rate-limit-gate");
+});
 const coordinateSharedHistory = mock(async () => [] as unknown[]);
 const coordinateSharedConversationPrewarm = mock(async () => undefined);
 const seedSharedAgentScopeCache = mock(async () => {
@@ -39,7 +42,10 @@ mock.module("../../pricing", () => ({
 }));
 mock.module("../characters/characters", () => ({ charactersService: { getById } }));
 mock.module("../inference-admission-snapshot", () => ({ warmInferenceAdmissionSnapshot }));
-mock.module("../inference-admission-gate", () => ({ warmInferenceAdmissionGate }));
+mock.module("../inference-admission-gate", () => ({
+  warmInferenceAdmissionGate,
+  warmInferenceRateLimitGate,
+}));
 mock.module("./conversation-coordinator", () => ({
   coordinateSharedConversationPrewarm,
   coordinateSharedHistory,
@@ -82,6 +88,10 @@ beforeEach(() => {
   warmInferenceAdmissionGate.mockClear();
   warmInferenceAdmissionGate.mockImplementation(async () => {
     calls.push("admission-gate");
+  });
+  warmInferenceRateLimitGate.mockClear();
+  warmInferenceRateLimitGate.mockImplementation(async () => {
+    calls.push("rate-limit-gate");
   });
   coordinateSharedHistory.mockClear();
   coordinateSharedHistory.mockImplementation(async () => []);
@@ -201,7 +211,7 @@ describe("prewarmSharedAgentTurnCaches model pricing", () => {
 });
 
 describe("prewarmPersonalSharedAgentTurnCaches", () => {
-  test("warms a new personal room and admission gate concurrently", async () => {
+  test("warms a personal room and rate-limit state without balance hydration", async () => {
     const namespace = { getByName: mock() } as never;
     const personalAgent = {
       id: "personal:user-1:org-1",
@@ -210,7 +220,8 @@ describe("prewarmPersonalSharedAgentTurnCaches", () => {
 
     await prewarmPersonalSharedAgentTurnCaches(personalAgent, namespace);
 
-    expect(warmInferenceAdmissionGate).toHaveBeenCalledWith("org-1");
+    expect(warmInferenceRateLimitGate).toHaveBeenCalledWith("org-1");
+    expect(warmInferenceAdmissionGate).not.toHaveBeenCalled();
     expect(coordinateSharedConversationPrewarm).toHaveBeenCalledWith(
       personalAgent.id,
       personalAgent.id,
@@ -220,7 +231,7 @@ describe("prewarmPersonalSharedAgentTurnCaches", () => {
 
   test("keeps a failed personal prewarm observable and lets the typed retry path remain", async () => {
     const error = new Error("admission gate unavailable");
-    warmInferenceAdmissionGate.mockRejectedValue(error);
+    warmInferenceRateLimitGate.mockRejectedValue(error);
 
     await expect(
       prewarmPersonalSharedAgentTurnCaches(
@@ -234,7 +245,7 @@ describe("prewarmPersonalSharedAgentTurnCaches", () => {
       expect.objectContaining({
         agentId: "personal:user-1:org-1",
         organizationId: "org-1",
-        leg: "admission-gate",
+        leg: "rate-limit-gate",
         error: error.message,
       }),
     );

--- a/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/prewarm-shared-agent.ts
@@ -30,7 +30,10 @@ import type { AgentSandbox } from "../../../db/repositories/agent-sandboxes";
 import type { AppEnv, RuntimeDurableObjectNamespace } from "../../../types/cloud-worker-env";
 import { calculateCost, getProviderFromModel, normalizeModelName } from "../../pricing";
 import { logger } from "../../utils/logger";
-import { warmInferenceAdmissionGate } from "../inference-admission-gate";
+import {
+  warmInferenceAdmissionGate,
+  warmInferenceRateLimitGate,
+} from "../inference-admission-gate";
 import { warmInferenceAdmissionSnapshot } from "../inference-admission-snapshot";
 import {
   coordinateSharedConversationPrewarm,
@@ -168,26 +171,30 @@ export async function prewarmSharedAgentTurnCaches(
 }
 
 /**
- * Warm the two authorities a newly auto-registered personal agent needs.
- * The messaging route starts these concurrent legs as soon as it resolves the
- * account, overlaps them with other preparation, and joins them before Shared
- * dispatch.
+ * Warm the authorities a Personal Shared turn needs. Platform-funded turns use
+ * only the rate-limit window, so this deliberately avoids balance-ledger
+ * hydration. Established accounts can skip the conversation leg while still
+ * keeping inference admission off the first model request.
  */
 export async function prewarmPersonalSharedAgentTurnCaches(
   agent: Pick<SharedRuntimeAgent, "id" | "organization_id">,
   namespace: RuntimeDurableObjectNamespace,
+  options: { warmConversation?: boolean } = {},
 ): Promise<void> {
-  await settlePrewarmLegs(agent, [
+  const legs: PrewarmLeg[] = [
     {
-      leg: "admission-gate",
-      run: warmInferenceAdmissionGate(agent.organization_id),
+      leg: "rate-limit-gate",
+      run: warmInferenceRateLimitGate(agent.organization_id),
     },
-    {
+  ];
+  if (options.warmConversation !== false) {
+    legs.push({
       leg: "conversation-object",
       run: coordinateSharedConversationPrewarm(agent.id, agent.id, {
         namespace,
         startEmpty: true,
       }),
-    },
-  ]);
+    });
+  }
+  await settlePrewarmLegs(agent, legs);
 }


### PR DESCRIPTION
Part of #20271

## Ground truth

A real Eliza Dev Discord turn on staging hit Personal Shared, stalled for 8.023 seconds in inference admission, returned 503, and retried the entire turn. The Worker emitted `[RateLimit] Inference admission gate unavailable` and `The operation was aborted due to timeout`. This occurred before model dispatch; embeddings were not involved.

The first candidate at `b6e3040d` was rejected correctly: separate JavaScript queues inside one Durable Object cannot bypass Workerd input gates while that object has an outstanding storage operation. It also warmed only newly created Personal Shared accounts, so it could not repair the reproduced established-account turn.

## Change

- keep billing leases on the existing per-organization Durable Object identity
- move fixed-window limits to distinct `rate-limit:v2:<organization>` Durable Object identities
- coordinate the transition globally at the next exact fixed-window boundary, so the active legacy window fully expires before v2 can accept traffic; the first v2 request never calls or waits for the legacy ledger object
- warm the v2 rate-only object without consuming quota or reading the balance database
- deduplicate successful warm requests for five minutes in a bounded 4,096-entry module cache; failed warms are evicted so retry remains observable
- prewarm the rate-only lane for both new and established Personal Shared accounts; retain conversation prewarm only for a genuinely new account
- preserve full balance hydration for billed Shared callers and fail closed on malformed, unavailable, or unsafe cutover/rate responses

## Proof

Exact head `50b199888bec5e6f455b81418db643f265e95a9d`, tree `9c3e86061530e9f611b98c29d559e0ba387aac8b`, base/current `88531115dde449cb600e283ad17ed4faa783a84e`.

- 34/34 direct admission tests, 194 assertions
- 10/10 real Miniflare/Workerd tests, 39 assertions
- 26/26 Personal Shared route tests, 115 assertions
- 9/9 prewarm tests, 20 assertions
- real Workerd control proves a legacy rate request remains blocked behind a two-second ledger storage transaction while the FIRST cold v2 request completes
- boundary regression proves legacy denials remain authoritative until the complete fixed window expires, then v2 starts the next window exactly once
- repeated-warm regression proves the same organization resolves/wakes the v2 object once inside the bounded warm TTL
- Cloud Shared typecheck passes
- Cloud API typecheck and production Worker dry bundle pass
- Biome 9/9 and diff-check pass
- no embeddings, models, prompts, providers, credentials, gateway, staging, or production resource changed

Live staging restamp and sequential Telegram/Discord proof remain required after independent review and legitimate merge. Production is untouched.
