### PR TITLE
fix(cloud): require applied Discord gateway poll for readiness

### DIFF
--- a/packages/cloud/services/gateway-discord/src/gateway-manager.ts
+++ b/packages/cloud/services/gateway-discord/src/gateway-manager.ts
@@ -928,10 +928,6 @@ export class GatewayManager {
         return;
       }
 
-      // Success - reset failure counter
-      this.consecutivePollFailures = 0;
-      this.lastSuccessfulPoll = new Date();
-
       const data = (await response.json()) as {
         assignments: Array<{
           connectionId: string;
@@ -1010,6 +1006,12 @@ export class GatewayManager {
       for (const connectionId of toDisconnect) {
         await this.disconnectBot(connectionId);
       }
+
+      // Readiness begins only after the complete assignment response has been
+      // validated and applied. A 2xx response with malformed data must not
+      // admit a cold replica.
+      this.consecutivePollFailures = 0;
+      this.lastSuccessfulPoll = new Date();
     } catch (error) {
       this.consecutivePollFailures++;
       logger.error("Error polling for bots", {
@@ -2748,6 +2750,8 @@ export class GatewayManager {
     const CRITICAL_FAILURE_THRESHOLD = 5;
     const controlPlaneLost =
       this.consecutivePollFailures >= CRITICAL_FAILURE_THRESHOLD;
+    const controlPlaneReady =
+      this.lastSuccessfulPoll !== null && !controlPlaneLost;
 
     // Note: draining pods are still "healthy" for liveness (don't restart)
     // but will fail readiness (don't accept new work)
@@ -2771,7 +2775,7 @@ export class GatewayManager {
       controlPlane: {
         consecutiveFailures: this.consecutivePollFailures,
         lastSuccessfulPoll: this.lastSuccessfulPoll?.toISOString() ?? null,
-        healthy: !controlPlaneLost,
+        healthy: controlPlaneReady,
       },
     };
   }

--- a/packages/cloud/services/gateway-discord/tests/startup-readiness-contract.test.ts
+++ b/packages/cloud/services/gateway-discord/tests/startup-readiness-contract.test.ts
@@ -78,6 +78,47 @@ test("stays unready through delayed authentication and admits only after the fir
   }
 });
 
+test("stays unready when the first 2xx poll payload cannot be applied", async () => {
+  process.env.ELIZA_APP_DISCORD_BOT_ENABLED = "false";
+  globalThis.fetch = mock(async (input: unknown) => {
+    const path = new URL(String(input)).pathname;
+    if (path.endsWith("/auth/token")) {
+      return Response.json({
+        access_token: "ready-token",
+        token_type: "Bearer",
+        expires_in: 60,
+      });
+    }
+    if (path.endsWith("/discord/gateway/shutdown")) {
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`Unexpected request: ${path}`);
+  }) as typeof fetch;
+
+  const manager = new GatewayManager(
+    {
+      podName: "malformed-poll-test-pod",
+      elizaCloudUrl: "https://api.test",
+      gatewayBootstrapSecret: "bootstrap-secret",
+      project: "test",
+    },
+    {
+      fetchAssignments: mock(async () => Response.json({})) as typeof fetch,
+    },
+  );
+
+  await manager.start();
+  try {
+    expect(manager.isReady()).toBeFalse();
+    expect(manager.getHealth().controlPlane).toMatchObject({
+      healthy: false,
+      lastSuccessfulPoll: null,
+    });
+  } finally {
+    await manager.shutdown();
+  }
+});
+
 async function waitFor(predicate: () => boolean): Promise<void> {
   const deadline = Date.now() + 2_000;
   while (!predicate()) {


### PR DESCRIPTION
Closes #20858.

## What changed

- records `lastSuccessfulPoll` only after the assignment payload has been parsed and fully applied
- reports the control plane unhealthy until the first successful poll
- adds a real manager-startup regression proving malformed 2xx assignment data cannot admit a cold replica

## Verification

- `bun run --cwd packages/cloud/services/gateway-discord test` — 116 pass
- gateway-discord typecheck and production build pass
- focused Biome check passes
- `bun run verify` passes at exact head `6a9efd15564dbbe3ff6214b4584cbe032445cc90`

## Evidence applicability

This is a backend readiness-state correction with no user interface, media, or model behavior. Screenshot, video, frontend-log, and LLM-trajectory evidence are therefore not applicable.

<!-- evidence-head:6a9efd15564dbbe3ff6214b4584cbe032445cc90 -->

<!-- evidence-row:backend-logs -->
- [x] [20863-pr20858-gateway-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20863-pr20858-gateway-tests.log)

<!-- evidence-row:domain-artifacts -->
- [x] [20863-pr20863-domain-artifacts.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20863-pr20863-domain-artifacts.log)

<!-- evidence-row:before-screenshots -->
- [ ] N/A: backend-only readiness state correction; no visual surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A: backend-only readiness state correction; no visual surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A: no user-facing interaction or visual flow

<!-- evidence-row:frontend-logs -->
- [ ] N/A: no frontend code or browser path

<!-- evidence-row:llm-trajectory -->
- [ ] N/A: no model behavior or prompt path
