### PR TITLE
feat(agent): add bounded manifest-v3 backup capture

### DIFF
--- a/packages/agent/src/api/backup-v2-stream-response.test.ts
+++ b/packages/agent/src/api/backup-v2-stream-response.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Exercises capture-v2 response backpressure with a deterministic writable and
+ * the complete request/response boundary through a real Node HTTP server. No
+ * storage provider, database, credential, or cloud executor is substituted.
+ */
+
+import { createHash } from "node:crypto";
+import { EventEmitter } from "node:events";
+import http from "node:http";
+import {
+  AGENT_BACKUP_CAPTURE_V2_CONTENT_TYPE,
+  AGENT_BACKUP_CAPTURE_V2_REQUEST_FORMAT,
+  AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+  type AgentBackupCaptureV2Request,
+  parseAgentBackupCaptureV2Frames,
+} from "@elizaos/shared";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ElizaConfig } from "../config/config.ts";
+import {
+  type AgentBackupV2CaptureComponentSource,
+  AgentBackupV2CaptureError,
+} from "../services/agent-backup-v2-capture.ts";
+import {
+  type AgentBackupV2WritableResponse,
+  handleAgentBackupV2SnapshotRequest,
+  writeAgentBackupV2StreamResponse,
+} from "./backup-v2-stream-response.ts";
+
+const ids = {
+  operation: "11111111-1111-4111-8111-111111111111",
+  agent: "22222222-2222-4222-8222-222222222222",
+  activation: "33333333-3333-4333-8333-333333333333",
+};
+const servers: http.Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers
+      .splice(0)
+      .map(
+        (server) =>
+          new Promise<void>((resolve, reject) =>
+            server.close((error) => (error ? reject(error) : resolve())),
+          ),
+      ),
+  );
+});
+
+function request(agentId = ids.agent): AgentBackupCaptureV2Request {
+  return {
+    format: AGENT_BACKUP_CAPTURE_V2_REQUEST_FORMAT,
+    schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+    operationId: ids.operation,
+    agentId,
+    activationGeneration: ids.activation,
+    lifecycleRevision: "91",
+    deadlineEpochMs: Date.now() + 60_000,
+  };
+}
+
+class BackpressureResponse
+  extends EventEmitter
+  implements AgentBackupV2WritableResponse
+{
+  statusCode = 0;
+  headersSent = false;
+  writableEnded = false;
+  readonly headers = new Map<string, string>();
+  readonly writes: Uint8Array[] = [];
+  destroyedWith: Error | undefined;
+  private shouldBackpressure = true;
+
+  setHeader(name: string, value: string): void {
+    this.headers.set(name.toLowerCase(), value);
+  }
+
+  write(chunk: Uint8Array, callback?: (error?: Error | null) => void): boolean {
+    this.headersSent = true;
+    this.writes.push(chunk.slice());
+    setImmediate(() => callback?.());
+    if (this.shouldBackpressure) {
+      this.shouldBackpressure = false;
+      return false;
+    }
+    return true;
+  }
+
+  end(): void {
+    this.writableEnded = true;
+  }
+
+  destroy(error?: Error): void {
+    this.destroyedWith = error;
+    this.emit("close");
+  }
+}
+
+async function nextTurn(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+function source(): AgentBackupV2CaptureComponentSource {
+  return {
+    descriptor: {
+      name: "database",
+      format: "synthetic-v1",
+      compression: "none",
+      contentKind: "opaque",
+      consistency: "transactional",
+    },
+    async *open() {
+      yield { bytes: new TextEncoder().encode("database-state") };
+    },
+  };
+}
+
+async function listen(
+  handler: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ) => Promise<void>,
+): Promise<number> {
+  const server = http.createServer((req, res) => void handler(req, res));
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("No test port");
+  return address.port;
+}
+
+async function* responseChunks(
+  body: ReadableStream<Uint8Array>,
+): AsyncGenerator<Uint8Array> {
+  const reader = body.getReader();
+  try {
+    for (;;) {
+      const next = await reader.read();
+      if (next.done) return;
+      yield next.value;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+describe("writeAgentBackupV2StreamResponse", () => {
+  it("does not pull the next frame until the response drains", async () => {
+    const response = new BackpressureResponse();
+    let pulls = 0;
+    async function* frames(): AsyncGenerator<Uint8Array> {
+      pulls += 1;
+      yield Uint8Array.of(1);
+      pulls += 1;
+      yield Uint8Array.of(2);
+    }
+
+    const writing = writeAgentBackupV2StreamResponse(response, frames());
+    await nextTurn();
+    expect(response.writes).toHaveLength(1);
+    expect(pulls).toBe(1);
+
+    response.emit("drain");
+    await writing;
+    expect(response.writes).toHaveLength(2);
+    expect(pulls).toBe(2);
+    expect(response.writableEnded).toBe(true);
+  });
+
+  it("zeroizes each serialized frame only after the transport flush completes", async () => {
+    const response = new BackpressureResponse();
+    const frame = Uint8Array.of(7, 8, 9);
+    async function* frames(): AsyncGenerator<Uint8Array> {
+      yield frame;
+    }
+
+    const writing = writeAgentBackupV2StreamResponse(response, frames());
+    await nextTurn();
+    expect(frame).toEqual(Uint8Array.of(7, 8, 9));
+    response.emit("drain");
+    await writing;
+
+    expect(response.writes).toEqual([Uint8Array.of(7, 8, 9)]);
+    expect(frame).toEqual(Uint8Array.of(0, 0, 0));
+  });
+
+  it("abandons a backpressured writer immediately on abort", async () => {
+    const response = new BackpressureResponse();
+    const controller = new AbortController();
+    async function* frames(): AsyncGenerator<Uint8Array> {
+      yield Uint8Array.of(1);
+      yield Uint8Array.of(2);
+    }
+
+    const writing = writeAgentBackupV2StreamResponse(response, frames(), {
+      signal: controller.signal,
+    });
+    await nextTurn();
+    controller.abort(new Error("deadline"));
+
+    await expect(writing).rejects.toThrow("deadline");
+    expect(response.writes).toHaveLength(1);
+    expect(response.writableEnded).toBe(false);
+  });
+});
+
+describe("handleAgentBackupV2SnapshotRequest", () => {
+  it("serves a parseable framed capture through a real HTTP connection", async () => {
+    const config: ElizaConfig = {};
+    const port = await listen((req, res) =>
+      handleAgentBackupV2SnapshotRequest(req, res, {
+        runtime: { agentId: ids.agent },
+        config,
+        components: [source()],
+      }),
+    );
+
+    const response = await fetch(`http://127.0.0.1:${port}/api/snapshot/v2`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(request()),
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      AGENT_BACKUP_CAPTURE_V2_CONTENT_TYPE,
+    );
+    expect(response.headers.get("x-eliza-backup-operation-id")).toBe(
+      ids.operation,
+    );
+    if (!response.body) throw new Error("Capture response has no body");
+    const kinds: string[] = [];
+    for await (const frame of parseAgentBackupCaptureV2Frames(
+      responseChunks(response.body),
+      {
+        digest: (bytes) => createHash("sha256").update(bytes).digest(),
+        sha256StreamFactory: () => {
+          const hash = createHash("sha256");
+          return {
+            update: (bytes) => void hash.update(bytes),
+            digestHex: () => hash.digest("hex"),
+          };
+        },
+      },
+    )) {
+      kinds.push(frame.header.kind);
+      if (frame.header.kind === "capture-start") {
+        expect(frame.header.activationGeneration).toBe(ids.activation);
+        expect(frame.header.lifecycleRevision).toBe("91");
+      }
+    }
+    expect(kinds).toEqual([
+      "capture-start",
+      "component-start",
+      "data",
+      "component-end",
+      "capture-end",
+    ]);
+  });
+
+  it("rejects wrong-agent and non-strict requests before binary headers", async () => {
+    const config: ElizaConfig = {};
+    const port = await listen((req, res) =>
+      handleAgentBackupV2SnapshotRequest(req, res, {
+        runtime: { agentId: ids.agent },
+        config,
+        components: [source()],
+      }),
+    );
+    const wrongAgent = await fetch(`http://127.0.0.1:${port}/api/snapshot/v2`, {
+      method: "POST",
+      body: JSON.stringify(request("44444444-4444-4444-8444-444444444444")),
+    });
+    expect(wrongAgent.status).toBe(409);
+    await expect(wrongAgent.json()).resolves.toMatchObject({
+      code: "AGENT_BACKUP_V2_AGENT_MISMATCH",
+    });
+
+    const extraField = await fetch(`http://127.0.0.1:${port}/api/snapshot/v2`, {
+      method: "POST",
+      body: JSON.stringify({ ...request(), provider: "robot" }),
+    });
+    expect(extraField.status).toBe(400);
+    await expect(extraField.json()).resolves.toMatchObject({
+      code: "AGENT_BACKUP_V2_INVALID_REQUEST",
+    });
+  });
+
+  it("returns stable pre-header status and retry policy for bounded PGlite failures", async () => {
+    const failures = [
+      {
+        code: "AGENT_BACKUP_V2_PGLITE_PHYSICAL_BYTES_LIMIT",
+        status: 413,
+        retryAfter: null,
+      },
+      {
+        code: "AGENT_BACKUP_V2_PGLITE_DUMP_BUSY",
+        status: 429,
+        retryAfter: "5",
+      },
+      {
+        code: "AGENT_BACKUP_V2_PGLITE_RSS_BUDGET_EXCEEDED",
+        status: 503,
+        retryAfter: "5",
+      },
+      {
+        code: "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_CHANGED",
+        status: 409,
+        retryAfter: "1",
+      },
+    ] as const;
+    let failureIndex = 0;
+    const preparedSource: AgentBackupV2CaptureComponentSource = {
+      ...source(),
+      async prepare() {
+        const failure = failures[failureIndex++];
+        if (!failure) throw new Error("unexpected capture request");
+        throw new AgentBackupV2CaptureError(
+          "bounded PGlite failure",
+          failure.code,
+          undefined,
+          { severity: "ephemeral" },
+        );
+      },
+    };
+    const port = await listen((req, res) =>
+      handleAgentBackupV2SnapshotRequest(req, res, {
+        runtime: { agentId: ids.agent },
+        config: {},
+        components: [preparedSource],
+      }),
+    );
+
+    for (const failure of failures) {
+      const response = await fetch(`http://127.0.0.1:${port}/api/snapshot/v2`, {
+        method: "POST",
+        body: JSON.stringify(request()),
+      });
+      expect(response.status).toBe(failure.status);
+      expect(response.headers.get("retry-after")).toBe(failure.retryAfter);
+      await expect(response.json()).resolves.toMatchObject({
+        code: failure.code,
+      });
+    }
+  });
+});

--- a/packages/agent/src/api/backup-v2-stream-response.ts
+++ b/packages/agent/src/api/backup-v2-stream-response.ts
@@ -1,0 +1,422 @@
+/**
+ * Owns the authenticated snapshot-v2 HTTP boundary and its backpressure-aware
+ * binary response writer. Request identity is validated before headers commit;
+ * after commit, any source/transport failure terminates the response so a
+ * truncated capture can never be mistaken for a successful terminal frame.
+ */
+
+import type http from "node:http";
+import { logger, readRequestBody } from "@elizaos/core";
+import {
+  AGENT_BACKUP_CAPTURE_V2_CONTENT_TYPE,
+  AGENT_BACKUP_CAPTURE_V2_LIMITS,
+  type AgentBackupCaptureV2Request,
+  parseAgentBackupCaptureV2Request,
+} from "@elizaos/shared";
+import type { ElizaConfig } from "../config/config.ts";
+import {
+  type AgentBackupV2CaptureComponentSource,
+  AgentBackupV2CaptureError,
+  type AgentBackupV2CaptureRuntime,
+  createAgentBackupV2Capture,
+} from "../services/agent-backup-v2-capture.ts";
+
+export interface AgentBackupV2WritableResponse {
+  statusCode: number;
+  readonly headersSent?: boolean;
+  readonly writableEnded?: boolean;
+  setHeader(name: string, value: string): unknown;
+  write(chunk: Uint8Array, callback?: (error?: Error | null) => void): boolean;
+  end(): unknown;
+  destroy(error?: Error): unknown;
+  once(
+    event: "drain" | "close" | "error",
+    listener: (...args: unknown[]) => void,
+  ): unknown;
+  off(
+    event: "drain" | "close" | "error",
+    listener: (...args: unknown[]) => void,
+  ): unknown;
+}
+
+function writeWithCompletion(
+  res: AgentBackupV2WritableResponse,
+  frame: Uint8Array,
+  signal: AbortSignal | undefined,
+): { accepted: boolean; completion: Promise<void> } {
+  let accepted = false;
+  const completion = new Promise<void>((resolve, reject) => {
+    const cleanup = (): void => {
+      res.off("close", onClose);
+      res.off("error", onError);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    const finish = (error?: Error | null): void => {
+      cleanup();
+      if (error) reject(error);
+      else resolve();
+    };
+    const onClose = (): void =>
+      finish(
+        new AgentBackupV2CaptureError(
+          "Agent backup capture client disconnected before a frame was flushed",
+          "AGENT_BACKUP_V2_CLIENT_DISCONNECTED",
+          undefined,
+          { severity: "ephemeral" },
+        ),
+      );
+    const onError = (error: unknown): void =>
+      finish(
+        error instanceof Error ? error : new Error("Capture response failed"),
+      );
+    const onAbort = (): void =>
+      finish(signal ? interruptionError(signal) : new Error("Aborted"));
+    res.once("close", onClose);
+    res.once("error", onError);
+    signal?.addEventListener("abort", onAbort, { once: true });
+    try {
+      accepted = res.write(frame, finish);
+    } catch (error) {
+      finish(
+        error instanceof Error
+          ? error
+          : new Error("Capture response write failed"),
+      );
+    }
+    if (signal?.aborted) onAbort();
+  });
+  return { accepted, completion };
+}
+
+export interface AgentBackupV2SnapshotRouteDependencies {
+  runtime: AgentBackupV2CaptureRuntime;
+  config: ElizaConfig;
+  /** Deterministic source injection for real transport tests only. */
+  components?: readonly AgentBackupV2CaptureComponentSource[];
+  now?: () => number;
+}
+
+const activeCaptureByAgent = new Map<string, string>();
+
+function interruptionError(signal: AbortSignal): Error {
+  if (signal.reason instanceof Error) return signal.reason;
+  return new AgentBackupV2CaptureError(
+    "Agent backup capture response was interrupted",
+    "AGENT_BACKUP_V2_CAPTURE_ABORTED",
+    undefined,
+    { severity: "ephemeral" },
+  );
+}
+
+function assertWritableActive(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw interruptionError(signal);
+}
+
+function waitForDrain(
+  res: AgentBackupV2WritableResponse,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  assertWritableActive(signal);
+  return new Promise((resolve, reject) => {
+    const cleanup = (): void => {
+      res.off("drain", onDrain);
+      res.off("close", onClose);
+      res.off("error", onError);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    const onDrain = (): void => {
+      cleanup();
+      resolve();
+    };
+    const onClose = (): void => {
+      cleanup();
+      reject(
+        new AgentBackupV2CaptureError(
+          "Agent backup capture client disconnected during backpressure",
+          "AGENT_BACKUP_V2_CLIENT_DISCONNECTED",
+          undefined,
+          { severity: "ephemeral" },
+        ),
+      );
+    };
+    const onError = (error: unknown): void => {
+      cleanup();
+      reject(
+        error instanceof Error
+          ? error
+          : new Error("Agent backup capture response failed"),
+      );
+    };
+    const onAbort = (): void => {
+      cleanup();
+      reject(signal ? interruptionError(signal) : new Error("Capture aborted"));
+    };
+    res.once("drain", onDrain);
+    res.once("close", onClose);
+    res.once("error", onError);
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (signal?.aborted) onAbort();
+  });
+}
+
+/** Write one frame at a time and never pull the next frame before `drain`. */
+export async function writeAgentBackupV2StreamResponse(
+  res: AgentBackupV2WritableResponse,
+  frames: AsyncIterable<Uint8Array>,
+  options: Readonly<{ signal?: AbortSignal; operationId?: string }> = {},
+): Promise<void> {
+  res.statusCode = 200;
+  res.setHeader("Content-Type", AGENT_BACKUP_CAPTURE_V2_CONTENT_TYPE);
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("X-Eliza-Backup-Capture-Version", "2");
+  if (options.operationId) {
+    res.setHeader("X-Eliza-Backup-Operation-Id", options.operationId);
+  }
+  for await (const frame of frames) {
+    try {
+      assertWritableActive(options.signal);
+      const write = writeWithCompletion(res, frame, options.signal);
+      if (write.accepted) await write.completion;
+      else
+        await Promise.all([
+          write.completion,
+          waitForDrain(res, options.signal),
+        ]);
+    } finally {
+      frame.fill(0);
+    }
+  }
+  assertWritableActive(options.signal);
+  res.end();
+}
+
+function writeJsonFailure(
+  res: http.ServerResponse,
+  status: number,
+  code: string,
+  message: string,
+): void {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json");
+  res.setHeader("Cache-Control", "no-store");
+  res.end(JSON.stringify({ error: message, code }));
+}
+
+function captureFailureStatus(error: AgentBackupV2CaptureError): number {
+  switch (error.code) {
+    case "AGENT_BACKUP_V2_CAPTURE_DEADLINE_EXCEEDED":
+    case "AGENT_BACKUP_V2_INVALID_DEADLINE":
+      return 408;
+    case "AGENT_BACKUP_V2_AGENT_MISMATCH":
+    case "AGENT_BACKUP_V2_FILE_CHANGED":
+    case "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_CHANGED":
+      return 409;
+    case "AGENT_BACKUP_V2_PGLITE_PHYSICAL_BYTES_LIMIT":
+    case "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_ENTRY_LIMIT":
+    case "AGENT_BACKUP_V2_PGLITE_DUMP_EXCEEDS_PREFLIGHT":
+      return 413;
+    case "AGENT_BACKUP_V2_PGLITE_DUMP_BUSY":
+      return 429;
+    case "AGENT_BACKUP_V2_PGLITE_RSS_BUDGET_EXCEEDED":
+      return 503;
+    case "AGENT_BACKUP_V2_POSTGRES_UNSUPPORTED":
+    case "AGENT_BACKUP_V2_PGLITE_NOT_FILESYSTEM":
+    case "AGENT_BACKUP_V2_PGLITE_MANAGED_DUMP_UNAVAILABLE":
+      return 501;
+    case "AGENT_BACKUP_V2_CAPTURE_ABORTED":
+    case "AGENT_BACKUP_V2_CLIENT_DISCONNECTED":
+      return 499;
+    default:
+      return 500;
+  }
+}
+
+function captureFailureRetryAfter(
+  error: AgentBackupV2CaptureError,
+): string | null {
+  switch (error.code) {
+    case "AGENT_BACKUP_V2_PGLITE_DUMP_BUSY":
+    case "AGENT_BACKUP_V2_PGLITE_RSS_BUDGET_EXCEEDED":
+      return "5";
+    case "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_CHANGED":
+      return "1";
+    default:
+      return null;
+  }
+}
+
+async function readCaptureRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+): Promise<Readonly<AgentBackupCaptureV2Request> | null> {
+  let raw: string | null;
+  try {
+    raw = await readRequestBody(req, {
+      maxBytes: AGENT_BACKUP_CAPTURE_V2_LIMITS.maxRequestBytes,
+      tooLargeMessage: "Capture-v2 request exceeds its 4 KiB limit",
+    });
+  } catch (error) {
+    // error-policy:J1 request read failures are translated at the HTTP boundary.
+    writeJsonFailure(
+      res,
+      400,
+      "AGENT_BACKUP_V2_INVALID_REQUEST",
+      error instanceof Error ? error.message : "Invalid capture-v2 request",
+    );
+    return null;
+  }
+  if (!raw) {
+    writeJsonFailure(
+      res,
+      400,
+      "AGENT_BACKUP_V2_INVALID_REQUEST",
+      "Capture-v2 request body is required",
+    );
+    return null;
+  }
+  try {
+    return parseAgentBackupCaptureV2Request(JSON.parse(raw));
+  } catch (error) {
+    // error-policy:J3 JSON and schema validation reject untrusted input before
+    // any capture source or streaming response is opened.
+    writeJsonFailure(
+      res,
+      400,
+      "AGENT_BACKUP_V2_INVALID_REQUEST",
+      error instanceof Error ? error.message : "Invalid capture-v2 request",
+    );
+    return null;
+  }
+}
+
+/** Handle `POST /api/snapshot/v2` after the server's normal auth gate. */
+export async function handleAgentBackupV2SnapshotRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  dependencies: Readonly<AgentBackupV2SnapshotRouteDependencies>,
+): Promise<void> {
+  const request = await readCaptureRequest(req, res);
+  if (!request) return;
+  const now = dependencies.now ?? Date.now;
+  if (request.agentId !== dependencies.runtime.agentId) {
+    writeJsonFailure(
+      res,
+      409,
+      "AGENT_BACKUP_V2_AGENT_MISMATCH",
+      "Capture request agent does not match the active runtime",
+    );
+    return;
+  }
+  const remainingMs = request.deadlineEpochMs - now();
+  if (
+    remainingMs <= 0 ||
+    remainingMs > AGENT_BACKUP_CAPTURE_V2_LIMITS.maxDeadlineAheadMs
+  ) {
+    writeJsonFailure(
+      res,
+      408,
+      "AGENT_BACKUP_V2_INVALID_DEADLINE",
+      "Capture request deadline is expired or too far in the future",
+    );
+    return;
+  }
+  const activeOperationId = activeCaptureByAgent.get(request.agentId);
+  if (activeOperationId) {
+    res.setHeader("Retry-After", "5");
+    writeJsonFailure(
+      res,
+      429,
+      "AGENT_BACKUP_V2_CAPTURE_BUSY",
+      activeOperationId === request.operationId
+        ? "This capture operation is already active"
+        : "Another capture operation is already active for this agent",
+    );
+    return;
+  }
+
+  activeCaptureByAgent.set(request.agentId, request.operationId);
+  const controller = new AbortController();
+  const deadlineTimer = setTimeout(
+    () =>
+      controller.abort(
+        new AgentBackupV2CaptureError(
+          "Agent backup capture deadline exceeded",
+          "AGENT_BACKUP_V2_CAPTURE_DEADLINE_EXCEEDED",
+          { operationId: request.operationId },
+          { severity: "ephemeral" },
+        ),
+      ),
+    Math.min(remainingMs, 2_147_483_647),
+  );
+  const clientDisconnected = (): void => {
+    if (!res.writableEnded && !controller.signal.aborted) {
+      controller.abort(
+        new AgentBackupV2CaptureError(
+          "Agent backup capture client disconnected",
+          "AGENT_BACKUP_V2_CLIENT_DISCONNECTED",
+          { operationId: request.operationId },
+          { severity: "ephemeral" },
+        ),
+      );
+    }
+  };
+  req.once("aborted", clientDisconnected);
+  res.once("close", clientDisconnected);
+
+  try {
+    const frames = createAgentBackupV2Capture(
+      dependencies.runtime,
+      dependencies.config,
+      request,
+      {
+        signal: controller.signal,
+        components: dependencies.components,
+        now,
+      },
+    );
+    await writeAgentBackupV2StreamResponse(res, frames, {
+      signal: controller.signal,
+      operationId: request.operationId,
+    });
+  } catch (error) {
+    // error-policy:J1 a pre-commit failure receives structured JSON; once any
+    // frame is committed the only truthful response is a truncated transport.
+    const normalized =
+      error instanceof AgentBackupV2CaptureError
+        ? error
+        : new AgentBackupV2CaptureError(
+            "Agent backup capture failed",
+            "AGENT_BACKUP_V2_CAPTURE_FAILED",
+            { operationId: request.operationId },
+            { cause: error, severity: "ephemeral" },
+          );
+    logger.warn(
+      {
+        err: normalized.message,
+        code: normalized.code,
+        operationId: request.operationId,
+      },
+      "[agent-backup-v2] Capture request failed",
+    );
+    if (res.headersSent) {
+      res.destroy(normalized);
+    } else {
+      const retryAfter = captureFailureRetryAfter(normalized);
+      if (retryAfter) res.setHeader("Retry-After", retryAfter);
+      writeJsonFailure(
+        res,
+        captureFailureStatus(normalized),
+        normalized.code,
+        normalized.message,
+      );
+    }
+  } finally {
+    clearTimeout(deadlineTimer);
+    req.off("aborted", clientDisconnected);
+    res.off("close", clientDisconnected);
+    if (activeCaptureByAgent.get(request.agentId) === request.operationId) {
+      activeCaptureByAgent.delete(request.agentId);
+    }
+  }
+}

--- a/packages/agent/src/api/index.ts
+++ b/packages/agent/src/api/index.ts
@@ -39,6 +39,7 @@ export * from "./agent-model.ts";
 export * from "./agent-transfer-routes.ts";
 export * from "./approval-routes.ts";
 export * from "./auth-routes.ts";
+export * from "./backup-v2-stream-response.ts";
 export * from "./bug-report-routes.ts";
 export * from "./character-routes.ts";
 export * from "./compat-utils.ts";

--- a/packages/agent/src/api/restore-route-restart.test.ts
+++ b/packages/agent/src/api/restore-route-restart.test.ts
@@ -3,12 +3,20 @@
  * replacing PGlite files, using a real snapshot, TCP API host, and PGlite dump.
  */
 
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { PGlite } from "@electric-sql/pglite";
 import { AgentRuntime, InMemoryDatabaseAdapter } from "@elizaos/core";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AGENT_BACKUP_V2_PGLITE_CAPTURE_LIMITS } from "../services/agent-backup-v2-capture.ts";
 import { startApiServer } from "./server.ts";
 
 const API_TOKEN = "restore-runtime-restart-token";
@@ -26,12 +34,22 @@ const touchedEnv = [
 const originalEnv = new Map<string, string | undefined>();
 
 class PgliteDumpAdapter extends InMemoryDatabaseAdapter {
-  constructor(private readonly dump: Blob) {
+  constructor(
+    private readonly dataDir: string,
+    private readonly dump: Blob,
+  ) {
     super();
   }
 
-  getRawConnection(): unknown {
-    return { dumpDataDir: async () => this.dump };
+  getPgliteDataDir(): string {
+    return this.dataDir;
+  }
+
+  async dumpPgliteDataDirAfterPreflight<T>(
+    preflight: () => Promise<T>,
+  ): Promise<{ dump: Blob; preflight: T; release: () => void }> {
+    const proof = await preflight();
+    return { dump: this.dump, preflight: proof, release: () => undefined };
   }
 }
 
@@ -49,7 +67,28 @@ function restoreEnvironment(): void {
   originalEnv.clear();
 }
 
-afterEach(restoreEnvironment);
+async function logicalDirectoryBytes(root: string): Promise<number> {
+  let total = 0;
+  const pending = [root];
+  while (pending.length > 0) {
+    const directory = pending.pop();
+    if (!directory) break;
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const absolutePath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(absolutePath);
+      } else {
+        total += (await lstat(absolutePath)).size;
+      }
+    }
+  }
+  return total;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  restoreEnvironment();
+});
 
 describe("POST /api/restore runtime lifecycle", () => {
   it("returns success only after a replacement runtime is active", async () => {
@@ -71,7 +110,7 @@ describe("POST /api/restore runtime lifecycle", () => {
         "utf8",
       );
       process.env.ELIZA_STATE_DIR = stateDir;
-      process.env.PGLITE_DATA_DIR = targetDir;
+      process.env.PGLITE_DATA_DIR = sourceDir;
       process.env.ELIZA_CONFIG_PATH = configPath;
       process.env.ELIZA_PERSIST_CONFIG_PATH = configPath;
       process.env.ELIZA_API_BIND_HOST = "127.0.0.1";
@@ -86,9 +125,19 @@ describe("POST /api/restore runtime lifecycle", () => {
       await source.exec("INSERT INTO restore_probe VALUES ('preserved')");
       const dump = await source.dumpDataDir("gzip");
       await source.close();
+      const sourceLogicalBytes = await logicalDirectoryBytes(sourceDir);
+      expect(sourceLogicalBytes).toBeGreaterThan(32 * 1024 * 1024);
+      expect(sourceLogicalBytes).toBeLessThanOrEqual(
+        AGENT_BACKUP_V2_PGLITE_CAPTURE_LIMITS.maxPhysicalBytes,
+      );
+      // A real initialized PGlite already carries a substantial WASM baseline.
+      // Admission is based on remaining memory for the additional dump copies,
+      // not on requiring the total process RSS to remain artificially low.
+      expect(process.memoryUsage().rss).toBeGreaterThan(110 * 1024 * 1024);
+      vi.spyOn(process, "availableMemory").mockReturnValue(512 * 1024 * 1024);
 
       runtime = new AgentRuntime({ logLevel: "fatal", plugins: [] });
-      runtime.registerDatabaseAdapter(new PgliteDumpAdapter(dump));
+      runtime.registerDatabaseAdapter(new PgliteDumpAdapter(sourceDir, dump));
       await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
 
       let restartCalls = 0;
@@ -126,6 +175,7 @@ describe("POST /api/restore runtime lifecycle", () => {
       );
       expect(snapshotResponse.status).toBe(200);
       const snapshot = await snapshotResponse.json();
+      process.env.PGLITE_DATA_DIR = targetDir;
 
       const failedRestoreResponse = await fetch(
         `http://127.0.0.1:${api.port}/api/restore`,

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -68,6 +68,7 @@ import { parseClampedInteger } from "@elizaos/shared/utils/number-parsing";
 import { type WebSocket, WebSocketServer } from "ws";
 import { installPlugin as installPluginDirect } from "../services/plugin-installer.ts";
 import { writeAgentBackupJsonResponse } from "./backup-json-response.ts";
+import { handleAgentBackupV2SnapshotRequest } from "./backup-v2-stream-response.ts";
 import { handleStandaloneCloudPairRoute } from "./cloud-pair-route.ts";
 import { resolveConnectorHealthIntervalMs } from "./connector-health.ts";
 import { handlePluginDirectoryRoutes } from "./plugin-directory-routes.ts";
@@ -1903,6 +1904,18 @@ async function handleRequest(
       }
       error(res, message, 500);
     }
+    return;
+  }
+
+  if (method === "POST" && pathname === "/api/snapshot/v2") {
+    if (!state.runtime) {
+      error(res, "Runtime not ready", 503);
+      return;
+    }
+    await handleAgentBackupV2SnapshotRequest(req, res, {
+      runtime: state.runtime,
+      config: state.config,
+    });
     return;
   }
 

--- a/packages/agent/src/api/snapshot-route-transient.test.ts
+++ b/packages/agent/src/api/snapshot-route-transient.test.ts
@@ -11,7 +11,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { AgentRuntime, InMemoryDatabaseAdapter } from "@elizaos/core";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT,
   PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT_CODE,
@@ -74,16 +74,30 @@ async function seedState(root: string): Promise<void> {
 }
 
 /**
- * Real in-memory adapter widened with the PGlite raw-connection surface the
- * snapshot capture path reads; `dumpDataDir` behavior is injected per test.
+ * Real in-memory adapter widened with the bounded PGlite export surface the
+ * snapshot capture path reads; materialization behavior is injected per test.
  */
 class PgliteFacadeAdapter extends InMemoryDatabaseAdapter {
-  constructor(private readonly dumpDataDir: () => Promise<unknown>) {
+  constructor(
+    private readonly dataDir: string,
+    private readonly materialize: () => Promise<unknown>,
+  ) {
     super();
   }
 
-  getRawConnection(): unknown {
-    return { dumpDataDir: this.dumpDataDir };
+  getPgliteDataDir(): string {
+    return this.dataDir;
+  }
+
+  async dumpPgliteDataDirAfterPreflight<T>(
+    preflight: () => Promise<T>,
+  ): Promise<{ dump: unknown; preflight: T; release: () => void }> {
+    const proof = await preflight();
+    return {
+      dump: await this.materialize(),
+      preflight: proof,
+      release: () => undefined,
+    };
   }
 }
 
@@ -100,7 +114,9 @@ async function withSnapshotServer(
     runtime = new AgentRuntime({ logLevel: "fatal", plugins: [] });
     // Register before initialize() so the runtime does not fall back to a
     // plain in-memory adapter without the raw-connection facade.
-    runtime.registerDatabaseAdapter(new PgliteFacadeAdapter(dumpDataDir));
+    runtime.registerDatabaseAdapter(
+      new PgliteFacadeAdapter(path.join(root, "state", "pglite"), dumpDataDir),
+    );
     await runtime.initialize({ allowNoDatabase: true, skipMigrations: true });
 
     api = await startApiServer({
@@ -129,7 +145,14 @@ async function postSnapshot(baseUrl: string): Promise<Response> {
   });
 }
 
-afterEach(restoreEnvironment);
+beforeEach(() => {
+  vi.spyOn(process, "availableMemory").mockReturnValue(512 * 1024 * 1024);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  restoreEnvironment();
+});
 
 describe("POST /api/snapshot transient/terminal mapping", () => {
   it("maps a PGlite closing race to 503 with the structured transient code", async () => {

--- a/packages/agent/src/services/agent-backup-v2-capture.test.ts
+++ b/packages/agent/src/services/agent-backup-v2-capture.test.ts
@@ -8,6 +8,8 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+import { createDatabaseAdapter } from "@elizaos/plugin-sql";
 import {
   AGENT_BACKUP_CAPTURE_V2_LIMITS,
   AGENT_BACKUP_CAPTURE_V2_REQUEST_FORMAT,
@@ -356,6 +358,103 @@ describe("streamAgentBackupV2Capture", () => {
       await fs.promises.rm(root, { recursive: true, force: true });
     }
   });
+
+  it("captures and restores a real filesystem-backed PGlite producer", async () => {
+    const root = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "eliza-backup-real-pglite-"),
+    );
+    const stateDir = path.join(root, "state");
+    const pgliteDir = path.join(stateDir, ".pgdata");
+    const restoredDir = path.join(root, "restored");
+    const previousStateDir = process.env.ELIZA_STATE_DIR;
+    const previousPgliteDir = process.env.PGLITE_DATA_DIR;
+    const previousPostgresUrl = process.env.POSTGRES_URL;
+    const previousDatabaseUrl = process.env.DATABASE_URL;
+    const previousDisableExtensions =
+      process.env.ELIZA_PGLITE_DISABLE_EXTENSIONS;
+    const availableMemory = vi
+      .spyOn(process, "availableMemory")
+      .mockReturnValue(512 * MIB);
+    type RealPgliteAdapter = ReturnType<typeof createDatabaseAdapter> & {
+      getRawConnection(): PGlite;
+      getPgliteDataDir(): string | null;
+      dumpPgliteDataDirAfterPreflight<T>(
+        preflight: () => Promise<T>,
+        compression?: "gzip",
+      ): Promise<{ dump: File | Blob; preflight: T; release: () => void }>;
+      close(): Promise<void>;
+    };
+    let adapter: RealPgliteAdapter | undefined;
+    let restored: PGlite | undefined;
+    try {
+      await fs.promises.mkdir(stateDir, { recursive: true });
+      process.env.ELIZA_STATE_DIR = stateDir;
+      process.env.PGLITE_DATA_DIR = pgliteDir;
+      process.env.ELIZA_PGLITE_DISABLE_EXTENSIONS = "1";
+      delete process.env.POSTGRES_URL;
+      delete process.env.DATABASE_URL;
+      adapter = createDatabaseAdapter(
+        { dataDir: pgliteDir },
+        ids.agent,
+      ) as RealPgliteAdapter;
+
+      const source = adapter.getRawConnection();
+      await source.waitReady;
+      await source.exec(
+        "CREATE TABLE capture_e2e (id integer PRIMARY KEY, value text NOT NULL); INSERT INTO capture_e2e VALUES (7, 'real-pglite');",
+      );
+
+      const components = createDefaultAgentBackupV2CaptureSources(
+        {
+          agentId: ids.agent,
+          character: null,
+          adapter,
+          getSetting: () => undefined,
+        },
+        {},
+      );
+      const databaseParts: Uint8Array[] = [];
+      for await (const frame of parseAgentBackupCaptureV2Frames(
+        streamAgentBackupV2Capture({
+          request: request(),
+          agentId: ids.agent,
+          components,
+        }),
+        { digest: nodeDigest, sha256StreamFactory: nodeStreamFactory },
+      )) {
+        if (
+          frame.header.kind === "data" &&
+          frame.header.componentName === "database"
+        ) {
+          databaseParts.push(frame.payload.slice());
+        }
+      }
+      expect(databaseParts.length).toBeGreaterThan(0);
+
+      restored = new PGlite({
+        dataDir: restoredDir,
+        loadDataDir: new Blob([concat(databaseParts)]),
+      });
+      await restored.waitReady;
+      const restoredRows = await restored.query<{ id: number; value: string }>(
+        "SELECT id, value FROM capture_e2e",
+      );
+      expect(restoredRows.rows).toEqual([{ id: 7, value: "real-pglite" }]);
+    } finally {
+      await restored?.close();
+      await adapter?.close();
+      availableMemory.mockRestore();
+      restoreEnvironmentValue("ELIZA_STATE_DIR", previousStateDir);
+      restoreEnvironmentValue("PGLITE_DATA_DIR", previousPgliteDir);
+      restoreEnvironmentValue("POSTGRES_URL", previousPostgresUrl);
+      restoreEnvironmentValue("DATABASE_URL", previousDatabaseUrl);
+      if (previousDisableExtensions === undefined)
+        delete process.env.ELIZA_PGLITE_DISABLE_EXTENSIONS;
+      else
+        process.env.ELIZA_PGLITE_DISABLE_EXTENSIONS = previousDisableExtensions;
+      await fs.promises.rm(root, { recursive: true, force: true });
+    }
+  }, 60_000);
 
   it("fails closed without the fenced managed exporter and never falls back to live files", async () => {
     const root = await fs.promises.mkdtemp(

--- a/packages/agent/src/services/agent-backup-v2-capture.test.ts
+++ b/packages/agent/src/services/agent-backup-v2-capture.test.ts
@@ -1,0 +1,1229 @@
+/**
+ * Exercises the real capture-v2 producer and shared decoder with deterministic
+ * streaming sources. The 10 MiB and 128 MiB cases move every byte through both
+ * boundaries while sampling RSS; the 1 GiB proof is explicitly nightly-gated.
+ */
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  AGENT_BACKUP_CAPTURE_V2_LIMITS,
+  AGENT_BACKUP_CAPTURE_V2_REQUEST_FORMAT,
+  AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+  type AgentBackupCaptureV2Request,
+  type AgentBackupCaptureV2Sha256Digest,
+  type AgentBackupCaptureV2Sha256StreamFactory,
+  type AgentBackupRecordStreamV1Record,
+  parseAgentBackupCaptureV2Frames,
+  parseAgentBackupRecordStreamV1,
+  serializeAgentBackupRecordStreamV1Magic,
+  serializeAgentBackupRecordStreamV1Record,
+} from "@elizaos/shared";
+import { describe, expect, it, vi } from "vitest";
+import {
+  AGENT_BACKUP_V2_PGLITE_CAPTURE_LIMITS,
+  type AgentBackupV2CaptureComponentSource,
+  type AgentBackupV2CaptureSourceChunk,
+  createDefaultAgentBackupV2CaptureSources,
+  streamAgentBackupV2Capture,
+} from "./agent-backup-v2-capture.ts";
+
+const MIB = 1024 * 1024;
+const ids = {
+  operation: "11111111-1111-4111-8111-111111111111",
+  agent: "22222222-2222-4222-8222-222222222222",
+  activation: "33333333-3333-4333-8333-333333333333",
+};
+
+const nodeDigest: AgentBackupCaptureV2Sha256Digest = (bytes) =>
+  createHash("sha256").update(bytes).digest();
+
+const nodeStreamFactory: AgentBackupCaptureV2Sha256StreamFactory = () => {
+  const hash = createHash("sha256");
+  return {
+    update(bytes) {
+      hash.update(bytes);
+    },
+    digestHex() {
+      return hash.digest("hex");
+    },
+  };
+};
+
+function request(deadlineMs = 120_000): AgentBackupCaptureV2Request {
+  return {
+    format: AGENT_BACKUP_CAPTURE_V2_REQUEST_FORMAT,
+    schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+    operationId: ids.operation,
+    agentId: ids.agent,
+    activationGeneration: ids.activation,
+    lifecycleRevision: "73",
+    deadlineEpochMs: Date.now() + deadlineMs,
+  };
+}
+
+function syntheticSource(
+  totalBytes: number,
+  options: { name?: string; byte?: number } = {},
+): AgentBackupV2CaptureComponentSource {
+  const chunk = Buffer.alloc(
+    AGENT_BACKUP_CAPTURE_V2_LIMITS.maxFramePayloadBytes,
+    options.byte ?? 0x5a,
+  );
+  return {
+    descriptor: {
+      name: options.name ?? "database",
+      format: "synthetic-v1",
+      compression: "none",
+      contentKind: "opaque",
+      consistency: "transactional",
+    },
+    async *open(signal) {
+      let remaining = totalBytes;
+      while (remaining > 0) {
+        if (signal.aborted) throw signal.reason;
+        const length = Math.min(remaining, chunk.length);
+        yield { bytes: chunk.subarray(0, length) };
+        remaining -= length;
+      }
+    },
+  };
+}
+
+function concat(parts: readonly Uint8Array[]): Uint8Array {
+  const joined = new Uint8Array(
+    parts.reduce((total, part) => total + part.byteLength, 0),
+  );
+  let offset = 0;
+  for (const part of parts) {
+    joined.set(part, offset);
+    offset += part.byteLength;
+  }
+  return joined;
+}
+
+interface CapturedDefaultDataFrame {
+  componentName: string;
+  entryPath: string | null;
+  bytes: Uint8Array;
+}
+
+function managedPgliteAdapter(
+  dataDir: string,
+  dump: Blob,
+  release: () => void = vi.fn(),
+) {
+  return {
+    dumpPgliteDataDirAfterPreflight: vi.fn(
+      async <T>(preflight: () => Promise<T>) => ({
+        dump,
+        preflight: await preflight(),
+        release,
+      }),
+    ),
+    getPgliteDataDir: vi.fn(() => dataDir),
+  };
+}
+
+function mockCaptureAvailableMemory(bytes = 512 * MIB): void {
+  vi.spyOn(process, "availableMemory").mockReturnValue(bytes);
+}
+
+async function waitForAssertion(
+  assertion: () => void,
+  maxAttempts = 1_000,
+): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+  }
+  throw lastError;
+}
+
+async function captureDefaultDataFrames(
+  databasePayload: BlobPart = "managed-pglite-dump",
+): Promise<readonly CapturedDefaultDataFrame[]> {
+  const pgliteDir = process.env.PGLITE_DATA_DIR;
+  if (!pgliteDir) throw new Error("PGLITE_DATA_DIR is required by this test");
+  const components = createDefaultAgentBackupV2CaptureSources(
+    {
+      agentId: ids.agent,
+      character: null,
+      adapter: managedPgliteAdapter(pgliteDir, new Blob([databasePayload])),
+      getSetting: () => undefined,
+    },
+    {},
+  );
+  const frames: CapturedDefaultDataFrame[] = [];
+  for await (const frame of parseAgentBackupCaptureV2Frames(
+    streamAgentBackupV2Capture({
+      request: request(),
+      agentId: ids.agent,
+      components,
+    }),
+    { digest: nodeDigest, sha256StreamFactory: nodeStreamFactory },
+  )) {
+    if (frame.header.kind !== "data") continue;
+    frames.push({
+      componentName: frame.header.componentName,
+      entryPath: frame.header.entry?.path ?? null,
+      bytes: frame.payload,
+    });
+  }
+  return frames;
+}
+
+function restoreEnvironmentValue(
+  name: "DATABASE_URL" | "ELIZA_STATE_DIR" | "PGLITE_DATA_DIR" | "POSTGRES_URL",
+  previous: string | undefined,
+): void {
+  if (previous === undefined) delete process.env[name];
+  else process.env[name] = previous;
+}
+
+async function consumeSyntheticCapture(totalBytes: number): Promise<{
+  payloadBytes: number;
+  dataFrames: number;
+  peakRssDelta: number;
+  lifecycleRevision: string;
+  activationGeneration: string;
+}> {
+  const baselineRss = process.memoryUsage().rss;
+  let peakRss = baselineRss;
+  let payloadBytes = 0;
+  let dataFrames = 0;
+  let lifecycleRevision = "";
+  let activationGeneration = "";
+  const capture = streamAgentBackupV2Capture({
+    request: request(10 * 60_000),
+    agentId: ids.agent,
+    components: [syntheticSource(totalBytes)],
+  });
+  for await (const frame of parseAgentBackupCaptureV2Frames(capture, {
+    digest: nodeDigest,
+    sha256StreamFactory: nodeStreamFactory,
+  })) {
+    peakRss = Math.max(peakRss, process.memoryUsage().rss);
+    if (frame.header.kind === "capture-start") {
+      lifecycleRevision = frame.header.lifecycleRevision;
+      activationGeneration = frame.header.activationGeneration;
+    }
+    if (frame.header.kind === "data") {
+      payloadBytes += frame.payload.length;
+      dataFrames += 1;
+      expect(frame.payload.length).toBeLessThanOrEqual(
+        AGENT_BACKUP_CAPTURE_V2_LIMITS.maxFramePayloadBytes,
+      );
+    }
+  }
+  return {
+    payloadBytes,
+    dataFrames,
+    peakRssDelta: Math.max(0, peakRss - baselineRss),
+    lifecycleRevision,
+    activationGeneration,
+  };
+}
+
+describe("streamAgentBackupV2Capture", () => {
+  it("streams a real synthetic 10 MiB capture with bounded RSS", async () => {
+    const result = await consumeSyntheticCapture(10 * MIB);
+
+    expect(result.payloadBytes).toBe(10 * MIB);
+    expect(result.dataFrames).toBe(40);
+    expect(result.peakRssDelta).toBeLessThan(64 * MIB);
+    expect(result.lifecycleRevision).toBe("73");
+    expect(result.activationGeneration).toBe(ids.activation);
+  }, 60_000);
+
+  it("streams a real synthetic 128 MiB capture under a fixed RSS ceiling", async () => {
+    const result = await consumeSyntheticCapture(128 * MIB);
+
+    expect(result.payloadBytes).toBe(128 * MIB);
+    expect(result.dataFrames).toBe(512);
+    expect(result.peakRssDelta).toBeLessThan(224 * MIB);
+  }, 120_000);
+
+  it.skipIf(process.env.AGENT_BACKUP_V2_NIGHTLY_1_GIB !== "1")(
+    "streams the nightly 1 GiB capture under a fixed RSS ceiling",
+    async () => {
+      const result = await consumeSyntheticCapture(1024 * MIB);
+
+      expect(result.payloadBytes).toBe(1024 * MIB);
+      expect(result.dataFrames).toBe(4_096);
+      expect(result.peakRssDelta).toBeLessThan(320 * MIB);
+    },
+    10 * 60_000,
+  );
+
+  it("opens and drains components strictly one at a time", async () => {
+    const events: string[] = [];
+    const source = (name: string): AgentBackupV2CaptureComponentSource => ({
+      descriptor: {
+        name,
+        format: "synthetic-v1",
+        compression: "none",
+        contentKind: "opaque",
+        consistency: "transactional",
+      },
+      async *open() {
+        events.push(`${name}:open`);
+        yield { bytes: Uint8Array.of(1) };
+        events.push(`${name}:done`);
+      },
+    });
+    const capture = streamAgentBackupV2Capture({
+      request: request(),
+      agentId: ids.agent,
+      components: [source("character"), source("database")],
+    });
+
+    for await (const _wireFrame of capture) {
+      // Fully consume the producer; events prove no eager second source open.
+    }
+    expect(events).toEqual([
+      "character:open",
+      "character:done",
+      "database:open",
+      "database:done",
+    ]);
+  });
+
+  it("streams the managed PGlite Blob without calling arrayBuffer", async () => {
+    mockCaptureAvailableMemory();
+    const root = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "eliza-backup-managed-pglite-"),
+    );
+    const stateDir = path.join(root, "state");
+    const pgliteDir = path.join(stateDir, ".pgdata");
+    const previousStateDir = process.env.ELIZA_STATE_DIR;
+    const previousPgliteDir = process.env.PGLITE_DATA_DIR;
+    const previousPostgresUrl = process.env.POSTGRES_URL;
+    const previousDatabaseUrl = process.env.DATABASE_URL;
+    await fs.promises.mkdir(pgliteDir, { recursive: true });
+    process.env.ELIZA_STATE_DIR = stateDir;
+    process.env.PGLITE_DATA_DIR = pgliteDir;
+    delete process.env.POSTGRES_URL;
+    delete process.env.DATABASE_URL;
+    const payload = Buffer.alloc(2 * MIB, 0x33);
+    await fs.promises.writeFile(path.join(pgliteDir, "base.dat"), payload);
+    const dump = new Blob([payload]);
+    const arrayBuffer = vi
+      .spyOn(dump, "arrayBuffer")
+      .mockRejectedValue(new Error("arrayBuffer must not be called"));
+    const release = vi.fn();
+    try {
+      const adapter = managedPgliteAdapter(pgliteDir, dump, release);
+      const streamDatabase = async () => {
+        const database = createDefaultAgentBackupV2CaptureSources(
+          {
+            agentId: ids.agent,
+            adapter,
+            getSetting: () => undefined,
+          },
+          {},
+        ).find((candidate) => candidate.descriptor.name === "database");
+        if (!database) throw new Error("database source missing");
+        let streamedBytes = 0;
+        for await (const chunk of database.open(new AbortController().signal)) {
+          streamedBytes += chunk.bytes.length;
+        }
+        return streamedBytes;
+      };
+
+      await expect(streamDatabase()).resolves.toBe(payload.length);
+      await expect(streamDatabase()).resolves.toBe(payload.length);
+      expect(arrayBuffer).not.toHaveBeenCalled();
+      expect(adapter.dumpPgliteDataDirAfterPreflight).toHaveBeenCalledTimes(2);
+      expect(release).toHaveBeenCalledTimes(2);
+    } finally {
+      if (previousStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+      else process.env.ELIZA_STATE_DIR = previousStateDir;
+      if (previousPgliteDir === undefined) delete process.env.PGLITE_DATA_DIR;
+      else process.env.PGLITE_DATA_DIR = previousPgliteDir;
+      if (previousPostgresUrl === undefined) delete process.env.POSTGRES_URL;
+      else process.env.POSTGRES_URL = previousPostgresUrl;
+      if (previousDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+      else process.env.DATABASE_URL = previousDatabaseUrl;
+      await fs.promises.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed without the fenced managed exporter and never falls back to live files", async () => {
+    const root = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "eliza-backup-missing-managed-dump-"),
+    );
+    const stateDir = path.join(root, "state");
+    const pgliteDir = path.join(stateDir, ".pgdata");
+    const previousStateDir = process.env.ELIZA_STATE_DIR;
+    const previousPgliteDir = process.env.PGLITE_DATA_DIR;
+    const previousPostgresUrl = process.env.POSTGRES_URL;
+    const previousDatabaseUrl = process.env.DATABASE_URL;
+    const legacyDump = vi.fn(async () => new Blob(["legacy"]));
+    try {
+      await fs.promises.mkdir(pgliteDir, { recursive: true });
+      await fs.promises.writeFile(
+        path.join(pgliteDir, "PG_VERSION"),
+        "live-file-must-not-be-captured",
+      );
+      process.env.ELIZA_STATE_DIR = stateDir;
+      process.env.PGLITE_DATA_DIR = pgliteDir;
+      delete process.env.POSTGRES_URL;
+      delete process.env.DATABASE_URL;
+
+      expect(() =>
+        createDefaultAgentBackupV2CaptureSources(
+          {
+            agentId: ids.agent,
+            adapter: {
+              dumpPgliteDataDir: legacyDump,
+              getPgliteDataDir: () => pgliteDir,
+            },
+            getSetting: () => undefined,
+          },
+          {},
+        ),
+      ).toThrowError(
+        expect.objectContaining({
+          code: "AGENT_BACKUP_V2_PGLITE_MANAGED_DUMP_UNAVAILABLE",
+        }),
+      );
+      expect(legacyDump).not.toHaveBeenCalled();
+    } finally {
+      restoreEnvironmentValue("ELIZA_STATE_DIR", previousStateDir);
+      restoreEnvironmentValue("PGLITE_DATA_DIR", previousPgliteDir);
+      restoreEnvironmentValue("POSTGRES_URL", previousPostgresUrl);
+      restoreEnvironmentValue("DATABASE_URL", previousDatabaseUrl);
+      await fs.promises.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an over-limit physical PGlite directory before materialization", async () => {
+    const root = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "eliza-backup-over-limit-pglite-"),
+    );
+    const stateDir = path.join(root, "state");
+    const pgliteDir = path.join(stateDir, ".pgdata");
+    const previousStateDir = process.env.ELIZA_STATE_DIR;
+    const previousPgliteDir = process.env.PGLITE_DATA_DIR;
+    const previousPostgresUrl = process.env.POSTGRES_URL;
+    const previousDatabaseUrl = process.env.DATABASE_URL;
+    const materialize = vi.fn(async () => new Blob(["must-not-run"]));
+    try {
+      await fs.promises.mkdir(pgliteDir, { recursive: true });
+      await fs.promises.writeFile(path.join(pgliteDir, "oversized.dat"), "");
+      await fs.promises.truncate(
+        path.join(pgliteDir, "oversized.dat"),
+        AGENT_BACKUP_V2_PGLITE_CAPTURE_LIMITS.maxPhysicalBytes + 1,
+      );
+      process.env.ELIZA_STATE_DIR = stateDir;
+      process.env.PGLITE_DATA_DIR = pgliteDir;
+      delete process.env.POSTGRES_URL;
+      delete process.env.DATABASE_URL;
+
+      const database = createDefaultAgentBackupV2CaptureSources(
+        {
+          agentId: ids.agent,
+          adapter: {
+            dumpPgliteDataDirAfterPreflight: async <T>(
+              preflight: () => Promise<T>,
+            ) => {
+              const preflightResult = await preflight();
+              return {
+                dump: await materialize(),
+                preflight: preflightResult,
+                release: vi.fn(),
+              };
+            },
+            getPgliteDataDir: () => pgliteDir,
+          },
+          getSetting: () => undefined,
+        },
+        {},
+      ).find((source) => source.descriptor.name === "database");
+      if (!database) throw new Error("database capture source missing");
+
+      await expect(
+        database
+          .open(new AbortController().signal)
+          [Symbol.asyncIterator]()
+          .next(),
+      ).rejects.toMatchObject({
+        code: "AGENT_BACKUP_V2_PGLITE_PHYSICAL_BYTES_LIMIT",
+      });
+      expect(materialize).not.toHaveBeenCalled();
+    } finally {
+      restoreEnvironmentValue("ELIZA_STATE_DIR", previousStateDir);
+      restoreEnvironmentValue("PGLITE_DATA_DIR", previousPgliteDir);
+      restoreEnvironmentValue("POSTGRES_URL", previousPostgresUrl);
+      restoreEnvironmentValue("DATABASE_URL", previousDatabaseUrl);
+      await fs.promises.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects when available memory leaves no conservative dump budget", async () => {
+    mockCaptureAvailableMemory(
+      AGENT_BACKUP_V2_PGLITE_CAPTURE_LIMITS.availableMemoryHeadroomBytes,
+    );
+    const root = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "eliza-backup-rss-budget-pglite-"),
+    );
+    const stateDir = path.join(root, "state");
+    const pgliteDir = path.join(stateDir, ".pgdata");
+    const previousStateDir = process.env.ELIZA_STATE_DIR;
+    const previousPgliteDir = process.env.PGLITE_DATA_DIR;
+    const previousPostgresUrl = process.env.POSTGRES_URL;
+    const previousDatabaseUrl = process.env.DATABASE_URL;
+    const materialize = vi.fn(async () => new Blob(["must-not-run"]));
+    try {
+      await fs.promises.mkdir(pgliteDir, { recursive: true });
+      await fs.promises.writeFile(path.join(pgliteDir, "PG_VERSION"), "17");
+      process.env.ELIZA_STATE_DIR = stateDir;
+      process.env.PGLITE_DATA_DIR = pgliteDir;
+      delete process.env.POSTGRES_URL;
+      delete process.env.DATABASE_URL;
+
+      const database = createDefaultAgentBackupV2CaptureSources(
+        {
+          agentId: ids.agent,
+          adapter: {
+            dumpPgliteDataDirAfterPreflight: async <T>(
+              preflight: () => Promise<T>,
+            ) => {
+              const preflightResult = await preflight();
+              return {
+                dump: await materialize(),
+                preflight: preflightResult,
+                release: vi.fn(),
+              };
+            },
+            getPgliteDataDir: () => pgliteDir,
+          },
+          getSetting: () => undefined,
+        },
+        {},
+      ).find((source) => source.descriptor.name === "database");
+      if (!database) throw new Error("database capture source missing");
+
+      await expect(
+        database
+          .open(new AbortController().signal)
+          [Symbol.asyncIterator]()
+          .next(),
+      ).rejects.toMatchObject({
+        code: "AGENT_BACKUP_V2_PGLITE_RSS_BUDGET_EXCEEDED",
+      });
+      expect(materialize).not.toHaveBeenCalled();
+    } finally {
+      restoreEnvironmentValue("ELIZA_STATE_DIR", previousStateDir);
+      restoreEnvironmentValue("PGLITE_DATA_DIR", previousPgliteDir);
+      restoreEnvironmentValue("POSTGRES_URL", previousPostgresUrl);
+      restoreEnvironmentValue("DATABASE_URL", previousDatabaseUrl);
+      await fs.promises.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps an aborted uncancellable dump busy until it settles", async () => {
+    mockCaptureAvailableMemory();
+    const root = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "eliza-backup-late-pglite-dump-"),
+    );
+    const stateDir = path.join(root, "state");
+    const pgliteDir = path.join(stateDir, ".pgdata");
+    const previousStateDir = process.env.ELIZA_STATE_DIR;
+    const previousPgliteDir = process.env.PGLITE_DATA_DIR;
+    const previousPostgresUrl = process.env.POSTGRES_URL;
+    const previousDatabaseUrl = process.env.DATABASE_URL;
+    let releaseDump!: (dump: Blob) => void;
+    const materialize = vi.fn(
+      async () =>
+        await new Promise<Blob>((resolve) => {
+          releaseDump = resolve;
+        }),
+    );
+    const releaseLease = vi.fn();
+    const adapter = {
+      dumpPgliteDataDirAfterPreflight: async <T>(
+        preflight: () => Promise<T>,
+      ) => {
+        const preflightResult = await preflight();
+        return {
+          dump: await materialize(),
+          preflight: preflightResult,
+          release: releaseLease,
+        };
+      },
+      getPgliteDataDir: () => pgliteDir,
+    };
+    try {
+      await fs.promises.mkdir(pgliteDir, { recursive: true });
+      await fs.promises.writeFile(path.join(pgliteDir, "PG_VERSION"), "17");
+      process.env.ELIZA_STATE_DIR = stateDir;
+      process.env.PGLITE_DATA_DIR = pgliteDir;
+      delete process.env.POSTGRES_URL;
+      delete process.env.DATABASE_URL;
+
+      const createDatabaseSource = () => {
+        const source = createDefaultAgentBackupV2CaptureSources(
+          {
+            agentId: ids.agent,
+            adapter,
+            getSetting: () => undefined,
+          },
+          {},
+        ).find((candidate) => candidate.descriptor.name === "database");
+        if (!source) throw new Error("database capture source missing");
+        return source;
+      };
+
+      const firstController = new AbortController();
+      const firstIterator = createDatabaseSource()
+        .open(firstController.signal)
+        [Symbol.asyncIterator]();
+      const firstNext = firstIterator.next();
+      await waitForAssertion(() =>
+        expect(materialize).toHaveBeenCalledTimes(1),
+      );
+      firstController.abort(new Error("client disconnected"));
+
+      await expect(
+        createDatabaseSource()
+          .open(new AbortController().signal)
+          [Symbol.asyncIterator]()
+          .next(),
+      ).rejects.toMatchObject({
+        code: "AGENT_BACKUP_V2_PGLITE_DUMP_BUSY",
+      });
+      expect(materialize).toHaveBeenCalledTimes(1);
+
+      releaseDump(new Blob(["late-dump"]));
+      await expect(firstNext).rejects.toThrow("client disconnected");
+      expect(materialize).toHaveBeenCalledTimes(1);
+      expect(releaseLease).toHaveBeenCalledTimes(1);
+    } finally {
+      restoreEnvironmentValue("ELIZA_STATE_DIR", previousStateDir);
+      restoreEnvironmentValue("PGLITE_DATA_DIR", previousPgliteDir);
+      restoreEnvironmentValue("POSTGRES_URL", previousPostgresUrl);
+      restoreEnvironmentValue("DATABASE_URL", previousDatabaseUrl);
+      await fs.promises.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps an aborted stalled Blob reader busy until source cleanup settles", async () => {
+    mockCaptureAvailableMemory();
+    const root = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "eliza-backup-stalled-pglite-reader-"),
+    );
+    const stateDir = path.join(root, "state");
+    const pgliteDir = path.join(stateDir, ".pgdata");
+    const previousStateDir = process.env.ELIZA_STATE_DIR;
+    const previousPgliteDir = process.env.PGLITE_DATA_DIR;
+    const previousPostgresUrl = process.env.POSTGRES_URL;
+    const previousDatabaseUrl = process.env.DATABASE_URL;
+    let releaseRead!: (result: ReadableStreamReadResult<Uint8Array>) => void;
+    const stalledRead = new Promise<ReadableStreamReadResult<Uint8Array>>(
+      (resolve) => {
+        releaseRead = resolve;
+      },
+    );
+    let readCount = 0;
+    const reader = {
+      cancel: vi.fn(async () => await new Promise<void>(() => undefined)),
+      read: vi.fn(async () => {
+        readCount += 1;
+        if (readCount === 1) {
+          return { done: false as const, value: Uint8Array.of(0x41) };
+        }
+        return await stalledRead;
+      }),
+      releaseLock: vi.fn(),
+    };
+    const stalledDump = {
+      size: 1,
+      stream: () => ({ getReader: () => reader }),
+    };
+    const materialize = vi
+      .fn<() => typeof stalledDump | Blob>()
+      .mockReturnValueOnce(stalledDump)
+      .mockReturnValue(new Blob(["released"]));
+    const releaseLease = vi.fn();
+    const adapter = {
+      dumpPgliteDataDirAfterPreflight: async <T>(
+        preflight: () => Promise<T>,
+      ) => {
+        const preflightResult = await preflight();
+        return {
+          dump: materialize(),
+          preflight: preflightResult,
+          release: releaseLease,
+        };
+      },
+      getPgliteDataDir: () => pgliteDir,
+    };
+    try {
+      await fs.promises.mkdir(pgliteDir, { recursive: true });
+      await fs.promises.writeFile(path.join(pgliteDir, "PG_VERSION"), "17");
+      process.env.ELIZA_STATE_DIR = stateDir;
+      process.env.PGLITE_DATA_DIR = pgliteDir;
+      delete process.env.POSTGRES_URL;
+      delete process.env.DATABASE_URL;
+
+      const createDatabaseSource = () => {
+        const source = createDefaultAgentBackupV2CaptureSources(
+          {
+            agentId: ids.agent,
+            adapter,
+            getSetting: () => undefined,
+          },
+          {},
+        ).find((candidate) => candidate.descriptor.name === "database");
+        if (!source) throw new Error("database capture source missing");
+        return source;
+      };
+      const controller = new AbortController();
+      const capture = streamAgentBackupV2Capture({
+        request: request(),
+        agentId: ids.agent,
+        components: [createDatabaseSource()],
+        signal: controller.signal,
+      })[Symbol.asyncIterator]();
+
+      await capture.next();
+      await capture.next();
+      await capture.next();
+      const stalledFrame = capture.next();
+      await waitForAssertion(() =>
+        expect(reader.read).toHaveBeenCalledTimes(2),
+      );
+      controller.abort(new Error("client disconnected"));
+      await expect(stalledFrame).rejects.toMatchObject({
+        code: "AGENT_BACKUP_V2_CAPTURE_ABORTED",
+      });
+
+      await expect(
+        createDatabaseSource()
+          .open(new AbortController().signal)
+          [Symbol.asyncIterator]()
+          .next(),
+      ).rejects.toMatchObject({
+        code: "AGENT_BACKUP_V2_PGLITE_DUMP_BUSY",
+      });
+      expect(materialize).toHaveBeenCalledTimes(1);
+
+      releaseRead({ done: true, value: undefined });
+      await waitForAssertion(() =>
+        expect(reader.releaseLock).toHaveBeenCalledTimes(1),
+      );
+      expect(releaseLease).toHaveBeenCalledTimes(1);
+
+      const third = createDatabaseSource()
+        .open(new AbortController().signal)
+        [Symbol.asyncIterator]();
+      await expect(third.next()).resolves.toMatchObject({ done: false });
+      await expect(third.return?.()).resolves.toMatchObject({ done: true });
+      expect(materialize).toHaveBeenCalledTimes(2);
+      expect(releaseLease).toHaveBeenCalledTimes(2);
+    } finally {
+      restoreEnvironmentValue("ELIZA_STATE_DIR", previousStateDir);
+      restoreEnvironmentValue("PGLITE_DATA_DIR", previousPgliteDir);
+      restoreEnvironmentValue("POSTGRES_URL", previousPostgresUrl);
+      restoreEnvironmentValue("DATABASE_URL", previousDatabaseUrl);
+      await fs.promises.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("orders real state-file capture exactly as the canonical record codec requires", async () => {
+    const root = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "eliza-backup-path-order-"),
+    );
+    const pglite = path.join(root, "pglite");
+    const previousStateDir = process.env.ELIZA_STATE_DIR;
+    const previousPgliteDir = process.env.PGLITE_DATA_DIR;
+    const previousPostgresUrl = process.env.POSTGRES_URL;
+    const previousDatabaseUrl = process.env.DATABASE_URL;
+    process.env.ELIZA_STATE_DIR = root;
+    process.env.PGLITE_DATA_DIR = pglite;
+    delete process.env.POSTGRES_URL;
+    delete process.env.DATABASE_URL;
+    try {
+      await fs.promises.mkdir(pglite, { recursive: true });
+      await fs.promises.mkdir(path.join(root, "a"), { recursive: true });
+      for (const [relativePath, value] of [
+        ["a-plain", "hyphen"],
+        ["a/nested", "nested"],
+        ["B", "uppercase"],
+        ["file_1", "underscore"],
+        ["file-2", "dash"],
+        ["ä", "non-ascii"],
+        ["z", "last-ascii"],
+      ] as const) {
+        await fs.promises.writeFile(path.join(root, relativePath), value);
+      }
+      const stateFiles = createDefaultAgentBackupV2CaptureSources(
+        {
+          agentId: ids.agent,
+          character: null,
+          adapter: managedPgliteAdapter(pglite, new Blob(["database"])),
+          getSetting: () => undefined,
+        },
+        {},
+      ).find((source) => source.descriptor.name === "state-files");
+      if (!stateFiles) throw new Error("state-files capture source missing");
+
+      const recordParts: Uint8Array[] = [];
+      const capture = parseAgentBackupCaptureV2Frames(
+        streamAgentBackupV2Capture({
+          request: request(),
+          agentId: ids.agent,
+          components: [stateFiles],
+        }),
+        { digest: nodeDigest, sha256StreamFactory: nodeStreamFactory },
+      );
+      for await (const captured of capture) {
+        if (captured.header.kind === "component-start") {
+          recordParts.push(
+            serializeAgentBackupRecordStreamV1Magic(),
+            ...serializeAgentBackupRecordStreamV1Record({
+              kind: "component-start",
+              descriptor: captured.header.component,
+            }),
+          );
+        } else if (captured.header.kind === "data") {
+          recordParts.push(
+            ...serializeAgentBackupRecordStreamV1Record({
+              kind: "data",
+              dataIndex: captured.header.dataIndex,
+              offsetBytes: captured.header.offsetBytes,
+              payloadBytes: captured.header.payloadBytes,
+              entry: captured.header.entry ?? null,
+              payload: captured.payload,
+            }),
+          );
+        } else if (captured.header.kind === "component-end") {
+          recordParts.push(
+            ...serializeAgentBackupRecordStreamV1Record({
+              kind: "component-end",
+              dataFrameCount: captured.header.dataFrameCount,
+              payloadBytes: captured.header.plainBytes,
+              payloadSha256: captured.header.payloadSha256,
+            }),
+          );
+        }
+      }
+
+      const wire = concat(recordParts);
+      const source = (async function* () {
+        for (let offset = 0; offset < wire.byteLength; offset += 17) {
+          yield wire.slice(offset, Math.min(offset + 17, wire.byteLength));
+        }
+      })();
+      const records: AgentBackupRecordStreamV1Record[] = [];
+      for await (const record of parseAgentBackupRecordStreamV1(source, {
+        sha256StreamFactory: nodeStreamFactory,
+      })) {
+        records.push(record);
+      }
+      expect(
+        records
+          .filter((record) => record.kind === "data")
+          .map((record) => record.entry?.path),
+      ).toEqual(["B", "a-plain", "a/nested", "file-2", "file_1", "z", "ä"]);
+    } finally {
+      if (previousStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+      else process.env.ELIZA_STATE_DIR = previousStateDir;
+      if (previousPgliteDir === undefined) delete process.env.PGLITE_DATA_DIR;
+      else process.env.PGLITE_DATA_DIR = previousPgliteDir;
+      if (previousPostgresUrl === undefined) delete process.env.POSTGRES_URL;
+      else process.env.POSTGRES_URL = previousPostgresUrl;
+      if (previousDatabaseUrl === undefined) delete process.env.DATABASE_URL;
+      else process.env.DATABASE_URL = previousDatabaseUrl;
+      await fs.promises.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("captures cloud-style .pgdata bytes only in the database component", async () => {
+    mockCaptureAvailableMemory();
+    const root = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "eliza-backup-pgdata-disjoint-"),
+    );
+    const stateDir = path.join(root, "state");
+    const pgliteDir = path.join(stateDir, ".pgdata");
+    const databaseMarker = "database-only-managed-pgdata";
+    const previousStateDir = process.env.ELIZA_STATE_DIR;
+    const previousPgliteDir = process.env.PGLITE_DATA_DIR;
+    const previousPostgresUrl = process.env.POSTGRES_URL;
+    const previousDatabaseUrl = process.env.DATABASE_URL;
+    try {
+      await fs.promises.mkdir(pgliteDir, { recursive: true });
+      await fs.promises.writeFile(
+        path.join(pgliteDir, "PG_VERSION"),
+        databaseMarker,
+      );
+      await fs.promises.writeFile(path.join(stateDir, "settings.json"), "{}");
+      process.env.ELIZA_STATE_DIR = stateDir;
+      process.env.PGLITE_DATA_DIR = pgliteDir;
+      delete process.env.POSTGRES_URL;
+      delete process.env.DATABASE_URL;
+
+      const frames = await captureDefaultDataFrames(databaseMarker);
+      const markerComponents = frames
+        .filter(
+          (frame) => Buffer.from(frame.bytes).toString() === databaseMarker,
+        )
+        .map((frame) => frame.componentName);
+      const statePaths = frames
+        .filter((frame) => frame.componentName === "state-files")
+        .map((frame) => frame.entryPath);
+
+      expect(markerComponents).toEqual(["database"]);
+      expect(statePaths).toContain("settings.json");
+      expect(statePaths).not.toContain(".pgdata/PG_VERSION");
+    } finally {
+      restoreEnvironmentValue("ELIZA_STATE_DIR", previousStateDir);
+      restoreEnvironmentValue("PGLITE_DATA_DIR", previousPgliteDir);
+      restoreEnvironmentValue("POSTGRES_URL", previousPostgresUrl);
+      restoreEnvironmentValue("DATABASE_URL", previousDatabaseUrl);
+      await fs.promises.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("excludes a custom relative PGlite subtree without pruning sibling state", async () => {
+    mockCaptureAvailableMemory();
+    const root = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "eliza-backup-relative-pgdata-"),
+    );
+    const stateDir = path.join(root, "state");
+    const pgliteDir = path.join(stateDir, "custom", "database");
+    const databaseMarker = "database-only-relative-path";
+    const previousStateDir = process.env.ELIZA_STATE_DIR;
+    const previousPgliteDir = process.env.PGLITE_DATA_DIR;
+    const previousPostgresUrl = process.env.POSTGRES_URL;
+    const previousDatabaseUrl = process.env.DATABASE_URL;
+    try {
+      await fs.promises.mkdir(pgliteDir, { recursive: true });
+      await fs.promises.writeFile(
+        path.join(pgliteDir, "PG_VERSION"),
+        databaseMarker,
+      );
+      await fs.promises.writeFile(
+        path.join(stateDir, "custom", "keep.json"),
+        "{}",
+      );
+      process.env.ELIZA_STATE_DIR = stateDir;
+      process.env.PGLITE_DATA_DIR = path.relative(process.cwd(), pgliteDir);
+      delete process.env.POSTGRES_URL;
+      delete process.env.DATABASE_URL;
+
+      const frames = await captureDefaultDataFrames(databaseMarker);
+      const markerComponents = frames
+        .filter(
+          (frame) => Buffer.from(frame.bytes).toString() === databaseMarker,
+        )
+        .map((frame) => frame.componentName);
+      const statePaths = frames
+        .filter((frame) => frame.componentName === "state-files")
+        .map((frame) => frame.entryPath);
+
+      expect(markerComponents).toEqual(["database"]);
+      expect(statePaths).toContain("custom/keep.json");
+      expect(
+        statePaths.some(
+          (entryPath) =>
+            entryPath === "custom/database" ||
+            entryPath?.startsWith("custom/database/"),
+        ),
+      ).toBe(false);
+    } finally {
+      restoreEnvironmentValue("ELIZA_STATE_DIR", previousStateDir);
+      restoreEnvironmentValue("PGLITE_DATA_DIR", previousPgliteDir);
+      restoreEnvironmentValue("POSTGRES_URL", previousPostgresUrl);
+      restoreEnvironmentValue("DATABASE_URL", previousDatabaseUrl);
+      await fs.promises.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "uses physical directory identity when PGLITE_DATA_DIR is a symlink alias",
+    async () => {
+      mockCaptureAvailableMemory();
+      const root = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), "eliza-backup-symlink-pgdata-"),
+      );
+      const stateDir = path.join(root, "state");
+      const physicalPgliteDir = path.join(stateDir, ".pgdata-physical");
+      const pgliteAlias = path.join(root, "pglite-alias");
+      const databaseMarker = "database-only-symlink-target";
+      const previousStateDir = process.env.ELIZA_STATE_DIR;
+      const previousPgliteDir = process.env.PGLITE_DATA_DIR;
+      const previousPostgresUrl = process.env.POSTGRES_URL;
+      const previousDatabaseUrl = process.env.DATABASE_URL;
+      try {
+        await fs.promises.mkdir(physicalPgliteDir, { recursive: true });
+        await fs.promises.writeFile(
+          path.join(physicalPgliteDir, "PG_VERSION"),
+          databaseMarker,
+        );
+        await fs.promises.symlink(physicalPgliteDir, pgliteAlias, "dir");
+        process.env.ELIZA_STATE_DIR = stateDir;
+        process.env.PGLITE_DATA_DIR = pgliteAlias;
+        delete process.env.POSTGRES_URL;
+        delete process.env.DATABASE_URL;
+
+        const frames = await captureDefaultDataFrames(databaseMarker);
+        const markerComponents = frames
+          .filter(
+            (frame) => Buffer.from(frame.bytes).toString() === databaseMarker,
+          )
+          .map((frame) => frame.componentName);
+        const statePaths = frames
+          .filter((frame) => frame.componentName === "state-files")
+          .map((frame) => frame.entryPath);
+
+        expect(markerComponents).toEqual(["database"]);
+        expect(statePaths).not.toContain(".pgdata-physical/PG_VERSION");
+      } finally {
+        restoreEnvironmentValue("ELIZA_STATE_DIR", previousStateDir);
+        restoreEnvironmentValue("PGLITE_DATA_DIR", previousPgliteDir);
+        restoreEnvironmentValue("POSTGRES_URL", previousPostgresUrl);
+        restoreEnvironmentValue("DATABASE_URL", previousDatabaseUrl);
+        await fs.promises.rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("fails closed when PGlite contains the state directory", async () => {
+    const root = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "eliza-backup-overlap-pgdata-"),
+    );
+    const pgliteDir = path.join(root, "database");
+    const stateDir = path.join(pgliteDir, "state");
+    const previousStateDir = process.env.ELIZA_STATE_DIR;
+    const previousPgliteDir = process.env.PGLITE_DATA_DIR;
+    const previousPostgresUrl = process.env.POSTGRES_URL;
+    const previousDatabaseUrl = process.env.DATABASE_URL;
+    try {
+      await fs.promises.mkdir(stateDir, { recursive: true });
+      process.env.ELIZA_STATE_DIR = stateDir;
+      process.env.PGLITE_DATA_DIR = pgliteDir;
+      delete process.env.POSTGRES_URL;
+      delete process.env.DATABASE_URL;
+
+      expect(() =>
+        createDefaultAgentBackupV2CaptureSources(
+          { agentId: ids.agent, getSetting: () => undefined },
+          {},
+        ),
+      ).toThrowError(
+        expect.objectContaining({
+          code: "AGENT_BACKUP_V2_PGLITE_STATE_OVERLAP",
+        }),
+      );
+
+      process.env.PGLITE_DATA_DIR = stateDir;
+      expect(() =>
+        createDefaultAgentBackupV2CaptureSources(
+          { agentId: ids.agent, getSetting: () => undefined },
+          {},
+        ),
+      ).toThrowError(
+        expect.objectContaining({
+          code: "AGENT_BACKUP_V2_PGLITE_STATE_OVERLAP",
+        }),
+      );
+    } finally {
+      restoreEnvironmentValue("ELIZA_STATE_DIR", previousStateDir);
+      restoreEnvironmentValue("PGLITE_DATA_DIR", previousPgliteDir);
+      restoreEnvironmentValue("POSTGRES_URL", previousPostgresUrl);
+      restoreEnvironmentValue("DATABASE_URL", previousDatabaseUrl);
+      await fs.promises.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "fails closed when a dangling PGlite alias has no physical identity",
+    async () => {
+      const root = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), "eliza-backup-dangling-pgdata-"),
+      );
+      const stateDir = path.join(root, "state");
+      const pgliteAlias = path.join(root, "pglite-alias");
+      const previousStateDir = process.env.ELIZA_STATE_DIR;
+      const previousPgliteDir = process.env.PGLITE_DATA_DIR;
+      const previousPostgresUrl = process.env.POSTGRES_URL;
+      const previousDatabaseUrl = process.env.DATABASE_URL;
+      try {
+        await fs.promises.mkdir(stateDir, { recursive: true });
+        await fs.promises.symlink(
+          path.join(root, "missing-database"),
+          pgliteAlias,
+          "dir",
+        );
+        process.env.ELIZA_STATE_DIR = stateDir;
+        process.env.PGLITE_DATA_DIR = pgliteAlias;
+        delete process.env.POSTGRES_URL;
+        delete process.env.DATABASE_URL;
+
+        expect(() =>
+          createDefaultAgentBackupV2CaptureSources(
+            { agentId: ids.agent, getSetting: () => undefined },
+            {},
+          ),
+        ).toThrowError(
+          expect.objectContaining({
+            code: "AGENT_BACKUP_V2_DIRECTORY_IDENTITY_UNRESOLVED",
+          }),
+        );
+      } finally {
+        restoreEnvironmentValue("ELIZA_STATE_DIR", previousStateDir);
+        restoreEnvironmentValue("PGLITE_DATA_DIR", previousPgliteDir);
+        restoreEnvironmentValue("POSTGRES_URL", previousPostgresUrl);
+        restoreEnvironmentValue("DATABASE_URL", previousDatabaseUrl);
+        await fs.promises.rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("fails closed when a component crashes and emits no terminal success", async () => {
+    const source: AgentBackupV2CaptureComponentSource = {
+      descriptor: {
+        name: "database",
+        format: "synthetic-v1",
+        compression: "none",
+        contentKind: "opaque",
+        consistency: "transactional",
+      },
+      async *open() {
+        yield { bytes: Uint8Array.of(1, 2, 3) };
+        throw new Error("synthetic source crash");
+      },
+    };
+    const capture = streamAgentBackupV2Capture({
+      request: request(),
+      agentId: ids.agent,
+      components: [source],
+    });
+    let emittedFrames = 0;
+    let thrown: unknown;
+    try {
+      for await (const _wireFrame of capture) emittedFrames += 1;
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(emittedFrames).toBe(3);
+    expect(thrown).toMatchObject({
+      code: "AGENT_BACKUP_V2_SOURCE_FAILED",
+      cause: expect.objectContaining({ message: "synthetic source crash" }),
+    });
+  });
+
+  it("propagates abort while a capture is in flight", async () => {
+    const controller = new AbortController();
+    const iterator = streamAgentBackupV2Capture({
+      request: request(),
+      agentId: ids.agent,
+      components: [syntheticSource(2 * MIB)],
+      signal: controller.signal,
+    })[Symbol.asyncIterator]();
+
+    await iterator.next();
+    await iterator.next();
+    await iterator.next();
+    controller.abort(new Error("client disconnected"));
+
+    await expect(iterator.next()).rejects.toMatchObject({
+      code: "AGENT_BACKUP_V2_CAPTURE_ABORTED",
+    });
+  });
+
+  it("interrupts a stuck source at the absolute deadline", async () => {
+    let sourceSignal: AbortSignal | undefined;
+    const never = new Promise<IteratorResult<AgentBackupV2CaptureSourceChunk>>(
+      () => undefined,
+    );
+    const source: AgentBackupV2CaptureComponentSource = {
+      descriptor: {
+        name: "database",
+        format: "synthetic-v1",
+        compression: "none",
+        contentKind: "opaque",
+        consistency: "transactional",
+      },
+      open(signal) {
+        sourceSignal = signal;
+        return {
+          [Symbol.asyncIterator]() {
+            return {
+              next: () => never,
+              return: () => never,
+            };
+          },
+        };
+      },
+    };
+    const iterator = streamAgentBackupV2Capture({
+      request: request(30),
+      agentId: ids.agent,
+      components: [source],
+    })[Symbol.asyncIterator]();
+
+    await iterator.next();
+    await iterator.next();
+    await expect(iterator.next()).rejects.toMatchObject({
+      code: "AGENT_BACKUP_V2_CAPTURE_DEADLINE_EXCEEDED",
+    });
+    expect(sourceSignal?.aborted).toBe(true);
+  });
+
+  it("rejects a source that yields zero progress", async () => {
+    const source: AgentBackupV2CaptureComponentSource = {
+      descriptor: {
+        name: "database",
+        format: "synthetic-v1",
+        compression: "none",
+        contentKind: "opaque",
+        consistency: "transactional",
+      },
+      async *open() {
+        yield { bytes: new Uint8Array(0) };
+      },
+    };
+    const consume = async (): Promise<void> => {
+      for await (const _wireFrame of streamAgentBackupV2Capture({
+        request: request(),
+        agentId: ids.agent,
+        components: [source],
+      })) {
+        // Consume until the producer rejects the invalid source chunk.
+      }
+    };
+
+    await expect(consume()).rejects.toMatchObject({
+      code: "AGENT_BACKUP_V2_ZERO_PROGRESS",
+    });
+  });
+
+  it("rejects a request routed to the wrong runtime agent", async () => {
+    const consume = async (): Promise<void> => {
+      for await (const _wireFrame of streamAgentBackupV2Capture({
+        request: request(),
+        agentId: "44444444-4444-4444-8444-444444444444",
+        components: [syntheticSource(1)],
+      })) {
+        // Capture must fail before its first frame.
+      }
+    };
+
+    await expect(consume()).rejects.toMatchObject({
+      code: "AGENT_BACKUP_V2_AGENT_MISMATCH",
+    });
+  });
+});

--- a/packages/agent/src/services/agent-backup-v2-capture.test.ts
+++ b/packages/agent/src/services/agent-backup-v2-capture.test.ts
@@ -433,7 +433,7 @@ describe("streamAgentBackupV2Capture", () => {
 
       restored = new PGlite({
         dataDir: restoredDir,
-        loadDataDir: new Blob([concat(databaseParts)]),
+        loadDataDir: new Blob([new Uint8Array(concat(databaseParts))]),
       });
       await restored.waitReady;
       const restoredRows = await restored.query<{ id: number; value: string }>(

--- a/packages/agent/src/services/agent-backup-v2-capture.test.ts
+++ b/packages/agent/src/services/agent-backup-v2-capture.test.ts
@@ -454,7 +454,7 @@ describe("streamAgentBackupV2Capture", () => {
         process.env.ELIZA_PGLITE_DISABLE_EXTENSIONS = previousDisableExtensions;
       await fs.promises.rm(root, { recursive: true, force: true });
     }
-  }, 60_000);
+  }, 120_000);
 
   it("fails closed without the fenced managed exporter and never falls back to live files", async () => {
     const root = await fs.promises.mkdtemp(

--- a/packages/agent/src/services/agent-backup-v2-capture.ts
+++ b/packages/agent/src/services/agent-backup-v2-capture.ts
@@ -1,0 +1,1536 @@
+/**
+ * Produces a sequential, provider-neutral capture-v2 stream directly from an
+ * agent runtime and its local state. The service never calls the legacy JSON
+ * snapshot path, never base64-encodes payloads, and retains at most one bounded
+ * data frame while downstream backpressure is applied. PGlite 0.4.x remains a
+ * bounded materializing exception, enforced by the physical/RSS gate below.
+ */
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import { freemem } from "node:os";
+import path from "node:path";
+import { ElizaError, logger } from "@elizaos/core";
+import {
+  AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+  AGENT_BACKUP_CAPTURE_V2_LIMITS,
+  AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+  type AgentBackupCaptureV2ComponentDescriptor,
+  AgentBackupCaptureV2ComponentDescriptorSchema,
+  type AgentBackupCaptureV2FileEntry,
+  type AgentBackupCaptureV2FrameHeader,
+  type AgentBackupCaptureV2Request,
+  compareAgentBackupCaptureV2FilePaths,
+  parseAgentBackupCaptureV2Request,
+  readAgentBackupCaptureV2FrameDigest,
+  serializeAgentBackupCaptureV2Frame,
+} from "@elizaos/shared";
+import type { ElizaConfig } from "../config/config.ts";
+import { resolveStateDir, resolveUserPath } from "../config/paths.ts";
+import { resolveDefaultAgentWorkspaceDir } from "../shared/workspace-resolution.ts";
+
+const MEDIA_DIR_NAME = "media";
+const BACKUPS_DIR_NAME = "backups";
+const MODELS_DIR_NAME = "models";
+const TOOL_CACHE_DIR_NAME = "tool-cache";
+const CACHE_DIR_NAME = "cache";
+const ACTIVATION_DIR_NAME = ".activation";
+const DEFAULT_PGLITE_DIR_NAME = ".elizadb";
+const VAULT_PGLITE_DIR_NAME = ".vault-pglite";
+const VAULT_AUDIT_DIR_NAME = "audit";
+const VAULT_AUDIT_PATH = "audit/vault.jsonl";
+const VAULT_JSON_PATH = "vault.json";
+const MIB = 1024 * 1024;
+const PGLITE_CAPTURE_AVAILABLE_MEMORY_HEADROOM_BYTES = 32 * MIB;
+
+/**
+ * PGlite 0.4.x materializes the file list, tar, gzip chunks, joined gzip bytes,
+ * and Blob before capture can stream the result. The gate reserves eight
+ * archive-sized additional-memory copies (including GC overlap and the
+ * downstream frame) plus 32 MiB of emergency headroom from the memory Node/Bun
+ * reports as still available to this process. This is cgroup-aware in supported
+ * runtimes and does not incorrectly charge the already-resident PGlite WASM
+ * heap a second time. The archive estimate charges 4 KiB per entry plus 1 MiB
+ * fixed tar/gzip overhead.
+ */
+export const AGENT_BACKUP_V2_PGLITE_CAPTURE_LIMITS = Object.freeze({
+  maxPhysicalBytes: 40 * MIB,
+  availableMemoryHeadroomBytes: PGLITE_CAPTURE_AVAILABLE_MEMORY_HEADROOM_BYTES,
+  archiveCopyFactor: 8,
+  archiveEntryOverheadBytes: 4 * 1024,
+  archiveBaseOverheadBytes: MIB,
+});
+
+export interface AgentBackupV2CaptureSourceChunk {
+  bytes: Uint8Array;
+  /** Required for file-set sources; absent for opaque/record streams. */
+  entry?: AgentBackupCaptureV2FileEntry;
+}
+
+/** Minimal runtime surface needed by capture; deliberately excludes providers. */
+export interface AgentBackupV2CaptureRuntime {
+  agentId: string;
+  character?: unknown;
+  adapter?: unknown;
+  getSetting?(key: string): unknown;
+}
+
+export interface AgentBackupV2CaptureComponentSource {
+  descriptor: AgentBackupCaptureV2ComponentDescriptor;
+  /** Optional pre-header preparation for sources that must fail before commit. */
+  prepare?(signal: AbortSignal): Promise<void>;
+  /** Release any prepared source state when the enclosing capture closes. */
+  dispose?(): void;
+  open(signal: AbortSignal): AsyncIterable<AgentBackupV2CaptureSourceChunk>;
+}
+
+export interface StreamAgentBackupV2CaptureOptions {
+  request: AgentBackupCaptureV2Request;
+  agentId: string;
+  components: readonly AgentBackupV2CaptureComponentSource[];
+  signal?: AbortSignal;
+  now?: () => number;
+}
+
+export interface CreateAgentBackupV2CaptureOptions {
+  signal?: AbortSignal;
+  components?: readonly AgentBackupV2CaptureComponentSource[];
+  now?: () => number;
+}
+
+export class AgentBackupV2CaptureError extends ElizaError {
+  override readonly name = "AgentBackupV2CaptureError";
+
+  constructor(
+    message: string,
+    code: string,
+    context?: Record<string, unknown>,
+    options?: { cause?: unknown; severity?: "ephemeral" | "fatal" },
+  ) {
+    super(message, {
+      code,
+      context,
+      cause: options?.cause,
+      severity: options?.severity,
+    });
+  }
+}
+
+function captureError(
+  message: string,
+  code: string,
+  context?: Record<string, unknown>,
+  options?: { cause?: unknown; severity?: "ephemeral" | "fatal" },
+): never {
+  throw new AgentBackupV2CaptureError(message, code, context, options);
+}
+
+function abortReason(signal: AbortSignal | undefined): unknown {
+  return signal?.reason instanceof Error ? signal.reason : undefined;
+}
+
+function sourceAbortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new AgentBackupV2CaptureError(
+        "Agent backup capture was cancelled",
+        "AGENT_BACKUP_V2_CAPTURE_ABORTED",
+        undefined,
+        { severity: "ephemeral" },
+      );
+}
+
+function assertCaptureActive(
+  request: AgentBackupCaptureV2Request,
+  signal: AbortSignal | undefined,
+  now: () => number,
+): void {
+  if (signal?.aborted) {
+    if (signal.reason instanceof AgentBackupV2CaptureError) {
+      throw signal.reason;
+    }
+    captureError(
+      "Agent backup capture was cancelled",
+      "AGENT_BACKUP_V2_CAPTURE_ABORTED",
+      { operationId: request.operationId },
+      { cause: abortReason(signal), severity: "ephemeral" },
+    );
+  }
+  if (now() >= request.deadlineEpochMs) {
+    captureError(
+      "Agent backup capture deadline exceeded",
+      "AGENT_BACKUP_V2_CAPTURE_DEADLINE_EXCEEDED",
+      {
+        operationId: request.operationId,
+        deadlineEpochMs: request.deadlineEpochMs,
+      },
+      { severity: "ephemeral" },
+    );
+  }
+}
+
+async function awaitWithCaptureControl<T>(
+  operation: () => PromiseLike<T>,
+  request: AgentBackupCaptureV2Request,
+  signal: AbortSignal | undefined,
+  now: () => number,
+): Promise<T> {
+  assertCaptureActive(request, signal, now);
+  const value = Promise.resolve(operation());
+  const remainingMs = request.deadlineEpochMs - now();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  let abortListener: (() => void) | undefined;
+  const interrupted = new Promise<never>((_resolve, reject) => {
+    timeout = setTimeout(
+      () =>
+        reject(
+          new AgentBackupV2CaptureError(
+            "Agent backup capture deadline exceeded",
+            "AGENT_BACKUP_V2_CAPTURE_DEADLINE_EXCEEDED",
+            {
+              operationId: request.operationId,
+              deadlineEpochMs: request.deadlineEpochMs,
+            },
+            { severity: "ephemeral" },
+          ),
+        ),
+      Math.min(remainingMs, 2_147_483_647),
+    );
+    if (signal) {
+      abortListener = () =>
+        reject(
+          signal.reason instanceof AgentBackupV2CaptureError
+            ? signal.reason
+            : new AgentBackupV2CaptureError(
+                "Agent backup capture was cancelled",
+                "AGENT_BACKUP_V2_CAPTURE_ABORTED",
+                { operationId: request.operationId },
+                { cause: abortReason(signal), severity: "ephemeral" },
+              ),
+        );
+      signal.addEventListener("abort", abortListener, { once: true });
+    }
+  });
+  try {
+    return await Promise.race([value, interrupted]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+    if (signal && abortListener) {
+      signal.removeEventListener("abort", abortListener);
+    }
+  }
+}
+
+function nodeSha256Digest(bytes: Uint8Array): Uint8Array {
+  return createHash("sha256").update(bytes).digest();
+}
+
+function sha256Hex(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function normalizeRelativePath(input: string): string {
+  const normalized = path.posix.normalize(input.replaceAll(path.sep, "/"));
+  if (
+    !normalized ||
+    normalized === "." ||
+    normalized === ".." ||
+    normalized.startsWith("../") ||
+    path.posix.isAbsolute(normalized)
+  ) {
+    captureError(
+      `Invalid backup path: ${input}`,
+      "AGENT_BACKUP_V2_INVALID_PATH",
+      { path: input },
+      { severity: "fatal" },
+    );
+  }
+  return normalized;
+}
+
+function isWithin(root: string, target: string): boolean {
+  const relative = path.relative(root, target);
+  return (
+    relative === "" ||
+    (!relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
+function resolveCaptureDirectoryIdentity(
+  directory: string,
+  role: "pglite" | "state",
+): string {
+  const resolved = path.resolve(directory);
+  try {
+    const physical = fs.realpathSync.native(resolved);
+    if (!fs.statSync(physical).isDirectory()) {
+      captureError(
+        `Agent backup ${role} path is not a directory`,
+        "AGENT_BACKUP_V2_DIRECTORY_IDENTITY_INVALID",
+        { role, path: resolved },
+        { severity: "fatal" },
+      );
+    }
+    return physical;
+  } catch (error) {
+    if (error instanceof AgentBackupV2CaptureError) throw error;
+    // error-policy:J2 a missing, dangling, or unreadable path has no stable
+    // physical identity, so capture cannot prove component disjointness.
+    throw new AgentBackupV2CaptureError(
+      `Agent backup could not resolve the ${role} directory identity`,
+      "AGENT_BACKUP_V2_DIRECTORY_IDENTITY_UNRESOLVED",
+      { role, path: resolved },
+      { cause: error, severity: "fatal" },
+    );
+  }
+}
+
+function pathsOverlap(left: string, right: string): boolean {
+  return isWithin(left, right) || isWithin(right, left);
+}
+
+function resolveStateFilesPgliteExclusion(
+  stateDir: string,
+  pgliteDir: string,
+): string | null {
+  const physicalStateDir = resolveCaptureDirectoryIdentity(stateDir, "state");
+  const physicalPgliteDir = resolveCaptureDirectoryIdentity(
+    pgliteDir,
+    "pglite",
+  );
+
+  if (isWithin(physicalPgliteDir, physicalStateDir)) {
+    captureError(
+      "PGlite cannot contain or equal the agent state directory during capture",
+      "AGENT_BACKUP_V2_PGLITE_STATE_OVERLAP",
+      { stateDir: physicalStateDir, pgliteDir: physicalPgliteDir },
+      { severity: "fatal" },
+    );
+  }
+  if (!isWithin(physicalStateDir, physicalPgliteDir)) return null;
+
+  const mediaDir = path.join(physicalStateDir, MEDIA_DIR_NAME);
+  const vaultPgliteDir = path.join(physicalStateDir, VAULT_PGLITE_DIR_NAME);
+  const vaultAuditDir = path.join(physicalStateDir, VAULT_AUDIT_DIR_NAME);
+  if (
+    pathsOverlap(mediaDir, physicalPgliteDir) ||
+    pathsOverlap(vaultPgliteDir, physicalPgliteDir) ||
+    physicalPgliteDir === vaultAuditDir
+  ) {
+    captureError(
+      "PGlite overlaps another dedicated backup component",
+      "AGENT_BACKUP_V2_PGLITE_COMPONENT_OVERLAP",
+      { stateDir: physicalStateDir, pgliteDir: physicalPgliteDir },
+      { severity: "fatal" },
+    );
+  }
+
+  return normalizeRelativePath(
+    path.relative(physicalStateDir, physicalPgliteDir),
+  );
+}
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fs.promises.lstat(target);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+export interface PglitePhysicalPreflight {
+  physicalBytes: number;
+  estimatedArchiveBytes: number;
+  entryCount: number;
+  availableMemoryBytes: number;
+  additionalMemoryBudgetBytes: number;
+  requiredAvailableMemoryBytes: number;
+}
+
+/** Remaining memory available to this process, cgroup-aware when supported. */
+export function resolveAgentBackupAvailableMemoryBytes(): number {
+  const processAvailableMemory = process.availableMemory?.();
+  if (
+    typeof processAvailableMemory === "number" &&
+    Number.isSafeInteger(processAvailableMemory) &&
+    processAvailableMemory >= 0
+  ) {
+    return processAvailableMemory;
+  }
+  const hostFreeMemory = freemem();
+  if (Number.isSafeInteger(hostFreeMemory) && hostFreeMemory >= 0) {
+    return hostFreeMemory;
+  }
+  captureError(
+    "Available memory could not be proven before PGlite export",
+    "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_UNPROVEN",
+    undefined,
+    { severity: "fatal" },
+  );
+}
+
+function roundUpTarBlock(bytes: bigint): bigint {
+  const block = 512n;
+  return ((bytes + block - 1n) / block) * block;
+}
+
+function sameDirectoryIdentity(
+  left: fs.BigIntStats,
+  right: fs.BigIntStats,
+): boolean {
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.mtimeNs === right.mtimeNs
+  );
+}
+
+export async function preflightPglitePhysicalDirectory(
+  physicalRoot: string,
+  signal: AbortSignal,
+  agentId: string,
+  options: { archiveCopyFactor?: number } = {},
+): Promise<PglitePhysicalPreflight> {
+  const limits = AGENT_BACKUP_V2_PGLITE_CAPTURE_LIMITS;
+  let physicalBytes = 0n;
+  let estimatedArchiveBytes = BigInt(limits.archiveBaseOverheadBytes);
+  let entryCount = 0;
+  const pendingDirectories = [physicalRoot];
+
+  try {
+    while (pendingDirectories.length > 0) {
+      if (signal.aborted) throw sourceAbortError(signal);
+      const directory = pendingDirectories.pop();
+      if (!directory) break;
+      const before = await fs.promises.lstat(directory, { bigint: true });
+      if (!before.isDirectory() || before.isSymbolicLink()) {
+        captureError(
+          "PGlite physical-size preflight encountered an unsafe directory",
+          "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_UNPROVEN",
+          { agentId },
+          { severity: "fatal" },
+        );
+      }
+
+      const entries = await fs.promises.opendir(directory);
+      for await (const entry of entries) {
+        if (signal.aborted) throw sourceAbortError(signal);
+        entryCount += 1;
+        if (entryCount > AGENT_BACKUP_CAPTURE_V2_LIMITS.maxFiles) {
+          captureError(
+            "PGlite physical-size preflight exceeds the entry-count limit",
+            "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_ENTRY_LIMIT",
+            { agentId, entryCount },
+            { severity: "fatal" },
+          );
+        }
+
+        const absolutePath = path.join(directory, entry.name);
+        if (!isWithin(physicalRoot, absolutePath)) {
+          captureError(
+            "PGlite physical-size preflight escaped its configured root",
+            "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_UNPROVEN",
+            { agentId },
+            { severity: "fatal" },
+          );
+        }
+        const stats = await fs.promises.lstat(absolutePath, { bigint: true });
+        if (stats.isSymbolicLink()) {
+          captureError(
+            "PGlite physical-size preflight refuses symbolic links",
+            "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_UNPROVEN",
+            { agentId },
+            { severity: "fatal" },
+          );
+        }
+
+        estimatedArchiveBytes += BigInt(limits.archiveEntryOverheadBytes);
+        if (stats.isDirectory()) {
+          pendingDirectories.push(absolutePath);
+          continue;
+        }
+        if (!stats.isFile() || stats.size < 0n) {
+          captureError(
+            "PGlite physical-size preflight encountered a non-regular entry",
+            "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_UNPROVEN",
+            { agentId },
+            { severity: "fatal" },
+          );
+        }
+
+        physicalBytes += stats.size;
+        if (physicalBytes > BigInt(limits.maxPhysicalBytes)) {
+          captureError(
+            "PGlite exceeds the bounded materializing-export size limit",
+            "AGENT_BACKUP_V2_PGLITE_PHYSICAL_BYTES_LIMIT",
+            {
+              agentId,
+              maxPhysicalBytes: limits.maxPhysicalBytes,
+              observedPhysicalBytes: physicalBytes.toString(),
+            },
+            { severity: "fatal" },
+          );
+        }
+        estimatedArchiveBytes += roundUpTarBlock(stats.size);
+      }
+
+      const after = await fs.promises.lstat(directory, { bigint: true });
+      if (!sameDirectoryIdentity(before, after)) {
+        captureError(
+          "PGlite changed while its physical size was being proven",
+          "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_CHANGED",
+          { agentId },
+          { severity: "ephemeral" },
+        );
+      }
+    }
+  } catch (error) {
+    if (error instanceof AgentBackupV2CaptureError) throw error;
+    throw new AgentBackupV2CaptureError(
+      "PGlite physical size could not be proven before export",
+      "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_UNPROVEN",
+      { agentId },
+      { cause: error, severity: "fatal" },
+    );
+  }
+
+  const estimatedArchive = Number(estimatedArchiveBytes);
+  const archiveCopyFactor =
+    options.archiveCopyFactor ?? limits.archiveCopyFactor;
+  if (
+    !Number.isSafeInteger(archiveCopyFactor) ||
+    archiveCopyFactor < limits.archiveCopyFactor
+  ) {
+    captureError(
+      "PGlite export requested an invalid archive-copy budget",
+      "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_UNPROVEN",
+      { agentId, archiveCopyFactor },
+      { severity: "fatal" },
+    );
+  }
+  const additionalMemoryBudgetBytes = estimatedArchive * archiveCopyFactor;
+  const requiredAvailableMemoryBytes =
+    additionalMemoryBudgetBytes + limits.availableMemoryHeadroomBytes;
+  const availableMemoryBytes = resolveAgentBackupAvailableMemoryBytes();
+  if (availableMemoryBytes < requiredAvailableMemoryBytes) {
+    captureError(
+      "PGlite export would exceed the available-memory budget",
+      // This deployed wire code remains stable for Cloud failure classification.
+      "AGENT_BACKUP_V2_PGLITE_RSS_BUDGET_EXCEEDED",
+      {
+        agentId,
+        availableMemoryBytes,
+        estimatedArchiveBytes: estimatedArchive,
+        archiveCopyFactor,
+        additionalMemoryBudgetBytes,
+        requiredAvailableMemoryBytes,
+        availableMemoryHeadroomBytes: limits.availableMemoryHeadroomBytes,
+      },
+      { severity: "ephemeral" },
+    );
+  }
+
+  return {
+    physicalBytes: Number(physicalBytes),
+    estimatedArchiveBytes: estimatedArchive,
+    entryCount,
+    availableMemoryBytes,
+    additionalMemoryBudgetBytes,
+    requiredAvailableMemoryBytes,
+  };
+}
+
+async function* splitOpaqueBytes(
+  bytes: Uint8Array,
+): AsyncGenerator<AgentBackupV2CaptureSourceChunk> {
+  for (
+    let offset = 0;
+    offset < bytes.length;
+    offset += AGENT_BACKUP_CAPTURE_V2_LIMITS.maxFramePayloadBytes
+  ) {
+    yield {
+      bytes: bytes.subarray(
+        offset,
+        Math.min(
+          bytes.length,
+          offset + AGENT_BACKUP_CAPTURE_V2_LIMITS.maxFramePayloadBytes,
+        ),
+      ),
+    };
+  }
+}
+
+async function* walkFiles(
+  root: string,
+  include: ((relativePath: string) => boolean) | undefined,
+  signal: AbortSignal,
+): AsyncGenerator<{ absolutePath: string; relativePath: string }> {
+  const resolvedRoot = path.resolve(root);
+  if (!(await pathExists(resolvedRoot))) return;
+
+  async function* visit(
+    directory: string,
+  ): AsyncGenerator<{ absolutePath: string; relativePath: string }> {
+    if (signal.aborted) {
+      captureError(
+        "Agent backup file walk was cancelled",
+        "AGENT_BACKUP_V2_CAPTURE_ABORTED",
+        undefined,
+        { cause: abortReason(signal), severity: "ephemeral" },
+      );
+    }
+    const entries = await fs.promises.readdir(directory, {
+      withFileTypes: true,
+    });
+    entries.sort((left, right) =>
+      compareAgentBackupCaptureV2FilePaths(
+        `${left.name}${left.isDirectory() ? "/" : ""}`,
+        `${right.name}${right.isDirectory() ? "/" : ""}`,
+      ),
+    );
+    for (const entry of entries) {
+      const absolutePath = path.join(directory, entry.name);
+      if (!isWithin(resolvedRoot, absolutePath)) continue;
+      const relativePath = normalizeRelativePath(
+        path.relative(resolvedRoot, absolutePath),
+      );
+      if (include && !include(relativePath)) continue;
+      if (entry.isDirectory()) {
+        yield* visit(absolutePath);
+      } else if (entry.isFile()) {
+        yield { absolutePath, relativePath };
+      }
+    }
+  }
+
+  yield* visit(resolvedRoot);
+}
+
+function fileSetSource(
+  descriptor: AgentBackupCaptureV2ComponentDescriptor,
+  root: string,
+  include?: (relativePath: string) => boolean,
+): AgentBackupV2CaptureComponentSource {
+  return {
+    descriptor,
+    async *open(signal) {
+      let fileCount = 0;
+      for await (const file of walkFiles(root, include, signal)) {
+        fileCount += 1;
+        if (fileCount > AGENT_BACKUP_CAPTURE_V2_LIMITS.maxFiles) {
+          captureError(
+            `Component ${descriptor.name} exceeds the file-count limit`,
+            "AGENT_BACKUP_V2_FILE_LIMIT",
+            { componentName: descriptor.name, fileCount },
+            { severity: "fatal" },
+          );
+        }
+        const before = await fs.promises.stat(file.absolutePath);
+        const commonEntry = {
+          path: file.relativePath,
+          fileSizeBytes: before.size,
+          mode: before.mode & 0o777,
+          mtimeMs: Math.max(0, Math.trunc(before.mtimeMs)),
+        };
+        if (before.size === 0) {
+          yield {
+            bytes: new Uint8Array(0),
+            entry: { ...commonEntry, fileOffsetBytes: 0 },
+          };
+        } else {
+          let fileOffsetBytes = 0;
+          const stream = fs.createReadStream(file.absolutePath, {
+            highWaterMark: AGENT_BACKUP_CAPTURE_V2_LIMITS.maxFramePayloadBytes,
+          });
+          if (signal.aborted) stream.destroy(sourceAbortError(signal));
+          const abort = () => stream.destroy(sourceAbortError(signal));
+          signal.addEventListener("abort", abort, { once: true });
+          try {
+            for await (const chunk of stream) {
+              const bytes = chunk as Buffer;
+              if (bytes.length === 0) {
+                captureError(
+                  `File stream made no progress for ${file.relativePath}`,
+                  "AGENT_BACKUP_V2_ZERO_PROGRESS",
+                  { componentName: descriptor.name, path: file.relativePath },
+                  { severity: "fatal" },
+                );
+              }
+              yield {
+                bytes,
+                entry: { ...commonEntry, fileOffsetBytes },
+              };
+              fileOffsetBytes += bytes.length;
+            }
+          } finally {
+            signal.removeEventListener("abort", abort);
+          }
+          if (fileOffsetBytes !== before.size) {
+            captureError(
+              `File size changed while capturing ${file.relativePath}`,
+              "AGENT_BACKUP_V2_FILE_CHANGED",
+              {
+                componentName: descriptor.name,
+                path: file.relativePath,
+                expectedBytes: before.size,
+                observedBytes: fileOffsetBytes,
+              },
+              { severity: "ephemeral" },
+            );
+          }
+        }
+        const after = await fs.promises.stat(file.absolutePath);
+        if (
+          after.size !== before.size ||
+          after.mtimeMs !== before.mtimeMs ||
+          (after.mode & 0o777) !== (before.mode & 0o777)
+        ) {
+          captureError(
+            `File changed while capturing ${file.relativePath}`,
+            "AGENT_BACKUP_V2_FILE_CHANGED",
+            { componentName: descriptor.name, path: file.relativePath },
+            { severity: "ephemeral" },
+          );
+        }
+      }
+    },
+  };
+}
+
+function jsonSource(
+  descriptor: AgentBackupCaptureV2ComponentDescriptor,
+  value: unknown,
+): AgentBackupV2CaptureComponentSource {
+  return {
+    descriptor,
+    open() {
+      return splitOpaqueBytes(new TextEncoder().encode(JSON.stringify(value)));
+    },
+  };
+}
+
+function isPgliteDump(value: unknown): value is {
+  size: number;
+  stream: () => ReadableStream<Uint8Array>;
+} {
+  const size = (value as { size?: unknown } | null)?.size;
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof size === "number" &&
+    Number.isSafeInteger(size) &&
+    size >= 0 &&
+    typeof (value as { stream?: unknown }).stream === "function"
+  );
+}
+
+const activePgliteDumpByPhysicalDirectory = new Map<string, symbol>();
+
+function pgliteManagedExportErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+function acquirePgliteDumpSlot(
+  physicalPgliteDir: string,
+  agentId: string,
+): () => void {
+  if (activePgliteDumpByPhysicalDirectory.has(physicalPgliteDir)) {
+    captureError(
+      "A previous PGlite export is still active or settling",
+      "AGENT_BACKUP_V2_PGLITE_DUMP_BUSY",
+      { agentId },
+      { severity: "ephemeral" },
+    );
+  }
+  const token = Symbol("pglite-dump");
+  activePgliteDumpByPhysicalDirectory.set(physicalPgliteDir, token);
+  return () => {
+    if (activePgliteDumpByPhysicalDirectory.get(physicalPgliteDir) === token) {
+      activePgliteDumpByPhysicalDirectory.delete(physicalPgliteDir);
+    }
+  };
+}
+
+function pgliteDumpSource(
+  runtime: AgentBackupV2CaptureRuntime,
+  physicalPgliteDir: string,
+): AgentBackupV2CaptureComponentSource {
+  const adapter = runtime.adapter as
+    | {
+        dumpPgliteDataDirAfterPreflight?: (
+          preflight: () => Promise<PglitePhysicalPreflight>,
+          compression?: "gzip",
+        ) => Promise<{
+          dump: unknown;
+          preflight: PglitePhysicalPreflight;
+          release: () => void;
+        }>;
+        getPgliteDataDir?: () => unknown;
+      }
+    | undefined;
+  const managedDump = adapter?.dumpPgliteDataDirAfterPreflight;
+  if (typeof managedDump !== "function") {
+    captureError(
+      "Capture v2 requires the fenced, lifecycle-managed PGlite dump exporter",
+      "AGENT_BACKUP_V2_PGLITE_MANAGED_DUMP_UNAVAILABLE",
+      { agentId: runtime.agentId },
+      { severity: "fatal" },
+    );
+  }
+  if (typeof adapter?.getPgliteDataDir !== "function") {
+    captureError(
+      "The PGlite exporter cannot attest its physical data directory",
+      "AGENT_BACKUP_V2_PGLITE_DIRECTORY_UNATTESTED",
+      { agentId: runtime.agentId },
+      { severity: "fatal" },
+    );
+  }
+  const managedDataDir = adapter.getPgliteDataDir();
+  if (
+    typeof managedDataDir !== "string" ||
+    managedDataDir.length === 0 ||
+    managedDataDir === ":memory:" ||
+    managedDataDir.includes("://")
+  ) {
+    captureError(
+      "The PGlite exporter did not attest a filesystem-backed data directory",
+      "AGENT_BACKUP_V2_PGLITE_DIRECTORY_UNATTESTED",
+      { agentId: runtime.agentId },
+      { severity: "fatal" },
+    );
+  }
+  const managedPhysicalDir = resolveCaptureDirectoryIdentity(
+    resolveUserPath(managedDataDir),
+    "pglite",
+  );
+  if (managedPhysicalDir !== physicalPgliteDir) {
+    captureError(
+      "The PGlite exporter data directory does not match capture configuration",
+      "AGENT_BACKUP_V2_PGLITE_DIRECTORY_MISMATCH",
+      { agentId: runtime.agentId },
+      { severity: "fatal" },
+    );
+  }
+  const runManagedDump = managedDump.bind(adapter);
+
+  let prepared:
+    | { dump: { size: number; stream: () => ReadableStream<Uint8Array> } }
+    | undefined;
+  let preparing: Promise<void> | undefined;
+  let releasePreparedExport: (() => void) | undefined;
+  let opened = false;
+  let disposed = false;
+
+  const prepare = async (signal: AbortSignal): Promise<void> => {
+    if (signal.aborted) throw sourceAbortError(signal);
+    if (disposed) {
+      captureError(
+        "The PGlite capture source is already closed",
+        "AGENT_BACKUP_V2_PGLITE_DUMP_ALREADY_CONSUMED",
+        { agentId: runtime.agentId },
+        { severity: "fatal" },
+      );
+    }
+    if (prepared) return;
+    if (!preparing) {
+      preparing = (async () => {
+        const releaseDumpSlot = acquirePgliteDumpSlot(
+          physicalPgliteDir,
+          runtime.agentId,
+        );
+        let retainDumpSlot = false;
+        let releaseManagedLease: (() => void) | undefined;
+        try {
+          let boundedDump: {
+            dump: unknown;
+            preflight: PglitePhysicalPreflight;
+            release: () => void;
+          };
+          let provenPreflight: PglitePhysicalPreflight | undefined;
+          try {
+            const dumpPromise = Promise.resolve().then(() =>
+              runManagedDump(async () => {
+                const proof = await preflightPglitePhysicalDirectory(
+                  physicalPgliteDir,
+                  signal,
+                  runtime.agentId,
+                );
+                provenPreflight = proof;
+                return proof;
+              }, "gzip"),
+            );
+            // PGlite 0.4.x cannot cancel a materializing dump. Keep its rejection
+            // observed and its directory slot held until this promise settles.
+            void dumpPromise.catch(() => undefined);
+            boundedDump = await dumpPromise;
+          } catch (error) {
+            if (error instanceof AgentBackupV2CaptureError) throw error;
+            if (
+              pgliteManagedExportErrorCode(error) ===
+              "PGLITE_DATA_DIR_EXPORT_BUSY"
+            ) {
+              captureError(
+                "A previous PGlite export is still active or settling",
+                "AGENT_BACKUP_V2_PGLITE_DUMP_BUSY",
+                { agentId: runtime.agentId },
+                { severity: "ephemeral" },
+              );
+            }
+            throw new AgentBackupV2CaptureError(
+              "PGlite could not create a managed data-dir export",
+              "AGENT_BACKUP_V2_PGLITE_DUMP_FAILED",
+              { agentId: runtime.agentId },
+              { cause: error, severity: "ephemeral" },
+            );
+          }
+          if (typeof boundedDump.release !== "function") {
+            captureError(
+              "The managed PGlite exporter did not provide a consumer-lifetime lease",
+              "AGENT_BACKUP_V2_PGLITE_MANAGED_DUMP_UNAVAILABLE",
+              { agentId: runtime.agentId },
+              { severity: "fatal" },
+            );
+          }
+          releaseManagedLease = boundedDump.release;
+          if (signal.aborted) throw sourceAbortError(signal);
+          if (disposed) {
+            captureError(
+              "The PGlite capture source closed while export was settling",
+              "AGENT_BACKUP_V2_CAPTURE_CLOSED",
+              { agentId: runtime.agentId },
+              { severity: "ephemeral" },
+            );
+          }
+          const { dump, preflight } = boundedDump;
+          if (!isPgliteDump(dump)) {
+            captureError(
+              "PGlite dumpDataDir() did not return a streamable Blob/File",
+              "AGENT_BACKUP_V2_PGLITE_DUMP_NOT_STREAMABLE",
+              { agentId: runtime.agentId },
+              { severity: "fatal" },
+            );
+          }
+          if (
+            !provenPreflight ||
+            preflight !== provenPreflight ||
+            !Number.isSafeInteger(preflight.estimatedArchiveBytes) ||
+            preflight.estimatedArchiveBytes < 0
+          ) {
+            captureError(
+              "The managed PGlite exporter skipped its required preflight",
+              "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_UNPROVEN",
+              { agentId: runtime.agentId },
+              { severity: "fatal" },
+            );
+          }
+          if (dump.size > preflight.estimatedArchiveBytes) {
+            captureError(
+              "PGlite export exceeds its preflighted archive bound",
+              "AGENT_BACKUP_V2_PGLITE_DUMP_EXCEEDS_PREFLIGHT",
+              {
+                agentId: runtime.agentId,
+                dumpBytes: dump.size,
+                estimatedArchiveBytes: preflight.estimatedArchiveBytes,
+                physicalBytes: preflight.physicalBytes,
+              },
+              { severity: "fatal" },
+            );
+          }
+          prepared = { dump };
+          releasePreparedExport = () => {
+            const releaseLease = releaseManagedLease;
+            releaseManagedLease = undefined;
+            releaseLease?.();
+            releaseDumpSlot();
+          };
+          retainDumpSlot = true;
+        } finally {
+          if (!retainDumpSlot) {
+            releaseManagedLease?.();
+            releaseDumpSlot();
+          }
+        }
+      })();
+      void preparing.catch(() => undefined);
+    }
+    await preparing;
+    if (signal.aborted) throw sourceAbortError(signal);
+  };
+
+  return {
+    descriptor: {
+      name: "database",
+      format: "pglite-data-dir-tar-gzip-v1",
+      compression: "gzip",
+      contentKind: "opaque",
+      consistency: "transactional",
+    },
+    prepare,
+    dispose() {
+      disposed = true;
+      prepared = undefined;
+      if (!opened) {
+        releasePreparedExport?.();
+        releasePreparedExport = undefined;
+      }
+    },
+    async *open(signal) {
+      await prepare(signal);
+      if (opened) {
+        captureError(
+          "A prepared PGlite export can only be consumed once",
+          "AGENT_BACKUP_V2_PGLITE_DUMP_ALREADY_CONSUMED",
+          { agentId: runtime.agentId },
+          { severity: "fatal" },
+        );
+      }
+      opened = true;
+      const dump = prepared?.dump;
+      if (!dump) {
+        captureError(
+          "The prepared PGlite export is unavailable",
+          "AGENT_BACKUP_V2_PGLITE_DUMP_FAILED",
+          { agentId: runtime.agentId },
+          { severity: "fatal" },
+        );
+      }
+      let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+      let abort: (() => void) | undefined;
+      try {
+        reader = dump.stream().getReader();
+        abort = () => {
+          // error-policy:J6 cancellation is already observed through the capture
+          // signal; a reader cleanup failure is diagnostic and must not be unhandled.
+          void reader?.cancel(abortReason(signal)).catch((error) => {
+            logger.warn(
+              { err: error instanceof Error ? error.message : String(error) },
+              "[agent-backup-v2] PGlite reader cancellation failed",
+            );
+          });
+        };
+        signal.addEventListener("abort", abort, { once: true });
+        if (signal.aborted) abort();
+        for (;;) {
+          const next = await reader.read();
+          if (next.done) break;
+          if (next.value.length === 0) {
+            captureError(
+              "PGlite export made no progress",
+              "AGENT_BACKUP_V2_ZERO_PROGRESS",
+              { componentName: "database" },
+              { severity: "fatal" },
+            );
+          }
+          yield* splitOpaqueBytes(next.value);
+        }
+      } finally {
+        if (abort) signal.removeEventListener("abort", abort);
+        try {
+          reader?.releaseLock();
+        } finally {
+          prepared = undefined;
+          releasePreparedExport?.();
+          releasePreparedExport = undefined;
+        }
+      }
+    },
+  };
+}
+
+function resolvePgliteDir(config: ElizaConfig): string {
+  const configured = process.env.PGLITE_DATA_DIR?.trim();
+  if (configured) return resolveUserPath(configured);
+  const workspace =
+    config.agents?.defaults?.workspace ?? resolveDefaultAgentWorkspaceDir();
+  return path.join(resolveUserPath(workspace), DEFAULT_PGLITE_DIR_NAME);
+}
+
+function hasPostgresUrl(runtime: AgentBackupV2CaptureRuntime): boolean {
+  const runtimeSetting = runtime.getSetting?.("POSTGRES_URL");
+  return (
+    (typeof runtimeSetting === "string" && runtimeSetting.trim().length > 0) ||
+    Boolean(
+      process.env.POSTGRES_URL?.trim() || process.env.DATABASE_URL?.trim(),
+    )
+  );
+}
+
+function baseStateFileInclude(
+  relativePath: string,
+  pgliteRelativePath: string | null,
+): boolean {
+  if (
+    pgliteRelativePath !== null &&
+    (relativePath === pgliteRelativePath ||
+      relativePath.startsWith(`${pgliteRelativePath}/`))
+  ) {
+    return false;
+  }
+  const first = relativePath.split("/")[0];
+  if (
+    first === MEDIA_DIR_NAME ||
+    first === BACKUPS_DIR_NAME ||
+    first === MODELS_DIR_NAME ||
+    first === TOOL_CACHE_DIR_NAME ||
+    first === CACHE_DIR_NAME ||
+    first === ACTIVATION_DIR_NAME ||
+    first === DEFAULT_PGLITE_DIR_NAME ||
+    first === VAULT_PGLITE_DIR_NAME ||
+    relativePath === VAULT_JSON_PATH ||
+    relativePath === VAULT_AUDIT_PATH
+  ) {
+    return false;
+  }
+  return !relativePath.endsWith(".log");
+}
+
+function vaultFileInclude(relativePath: string): boolean {
+  return (
+    relativePath === VAULT_JSON_PATH ||
+    relativePath === VAULT_AUDIT_DIR_NAME ||
+    relativePath === VAULT_AUDIT_PATH ||
+    relativePath === VAULT_PGLITE_DIR_NAME ||
+    relativePath.startsWith(`${VAULT_PGLITE_DIR_NAME}/`)
+  );
+}
+
+/** Build the five required full-capture components without provider provenance. */
+export function createDefaultAgentBackupV2CaptureSources(
+  runtime: AgentBackupV2CaptureRuntime,
+  config: ElizaConfig,
+): readonly AgentBackupV2CaptureComponentSource[] {
+  if (hasPostgresUrl(runtime)) {
+    captureError(
+      "Capture v2 currently requires the sandbox-local PGlite database export",
+      "AGENT_BACKUP_V2_POSTGRES_UNSUPPORTED",
+      { agentId: runtime.agentId },
+      { severity: "fatal" },
+    );
+  }
+  const stateDir = resolveStateDir();
+  const pgliteDir = resolvePgliteDir(config);
+  if (pgliteDir === ":memory:" || pgliteDir.includes("://")) {
+    captureError(
+      "Capture v2 requires a filesystem-backed PGlite database",
+      "AGENT_BACKUP_V2_PGLITE_NOT_FILESYSTEM",
+      { pgliteDir },
+      { severity: "fatal" },
+    );
+  }
+  const pgliteStateFilesExclusion = resolveStateFilesPgliteExclusion(
+    stateDir,
+    pgliteDir,
+  );
+  const physicalPgliteDir = resolveCaptureDirectoryIdentity(
+    pgliteDir,
+    "pglite",
+  );
+  const database = pgliteDumpSource(runtime, physicalPgliteDir);
+
+  return Object.freeze([
+    jsonSource(
+      {
+        name: "character",
+        format: "runtime-character-json-v1",
+        compression: "none",
+        contentKind: "opaque",
+        consistency: "best-effort",
+      },
+      runtime.character ?? null,
+    ),
+    database,
+    fileSetSource(
+      {
+        name: "media",
+        format: "file-set-v1",
+        compression: "none",
+        contentKind: "file-set",
+        consistency: "best-effort",
+      },
+      path.join(stateDir, MEDIA_DIR_NAME),
+    ),
+    fileSetSource(
+      {
+        name: "state-files",
+        format: "file-set-v1",
+        compression: "none",
+        contentKind: "file-set",
+        consistency: "best-effort",
+      },
+      stateDir,
+      (relativePath) =>
+        baseStateFileInclude(relativePath, pgliteStateFilesExclusion),
+    ),
+    fileSetSource(
+      {
+        name: "vault",
+        format: "file-set-v1",
+        compression: "none",
+        contentKind: "file-set",
+        consistency: "best-effort",
+      },
+      stateDir,
+      vaultFileInclude,
+    ),
+  ]);
+}
+
+function assertComponentSources(
+  components: readonly AgentBackupV2CaptureComponentSource[],
+): void {
+  if (
+    components.length === 0 ||
+    components.length > AGENT_BACKUP_CAPTURE_V2_LIMITS.maxComponents
+  ) {
+    captureError(
+      "Capture component count is outside its bound",
+      "AGENT_BACKUP_V2_COMPONENT_COUNT",
+      { componentCount: components.length },
+      { severity: "fatal" },
+    );
+  }
+  let previousName: string | undefined;
+  for (const source of components) {
+    AgentBackupCaptureV2ComponentDescriptorSchema.parse(source.descriptor);
+    if (previousName && source.descriptor.name <= previousName) {
+      captureError(
+        "Capture components must be unique and lexicographically ordered",
+        "AGENT_BACKUP_V2_COMPONENT_ORDER",
+        { previousName, componentName: source.descriptor.name },
+        { severity: "fatal" },
+      );
+    }
+    previousName = source.descriptor.name;
+  }
+}
+
+/** Stream an injected capture source; used by production and large real tests. */
+export async function* streamAgentBackupV2Capture(
+  options: Readonly<StreamAgentBackupV2CaptureOptions>,
+): AsyncGenerator<Uint8Array> {
+  const request = parseAgentBackupCaptureV2Request(options.request);
+  const now = options.now ?? Date.now;
+  if (request.agentId !== options.agentId) {
+    captureError(
+      "Capture request agent does not match the active runtime",
+      "AGENT_BACKUP_V2_AGENT_MISMATCH",
+      { requestedAgentId: request.agentId, activeAgentId: options.agentId },
+      { severity: "fatal" },
+    );
+  }
+  const deadlineAheadMs = request.deadlineEpochMs - now();
+  if (
+    deadlineAheadMs <= 0 ||
+    deadlineAheadMs > AGENT_BACKUP_CAPTURE_V2_LIMITS.maxDeadlineAheadMs
+  ) {
+    captureError(
+      "Capture request deadline is expired or too far in the future",
+      "AGENT_BACKUP_V2_INVALID_DEADLINE",
+      { deadlineEpochMs: request.deadlineEpochMs, deadlineAheadMs },
+      { severity: "fatal" },
+    );
+  }
+  assertComponentSources(options.components);
+
+  const controller = new AbortController();
+  const signal = options.signal
+    ? AbortSignal.any([options.signal, controller.signal])
+    : controller.signal;
+  const deadlineTimer = setTimeout(
+    () =>
+      controller.abort(
+        new AgentBackupV2CaptureError(
+          "Agent backup capture deadline exceeded",
+          "AGENT_BACKUP_V2_CAPTURE_DEADLINE_EXCEEDED",
+          { operationId: request.operationId },
+          { severity: "ephemeral" },
+        ),
+      ),
+    Math.min(deadlineAheadMs, 2_147_483_647),
+  );
+  const frameDigestChain = createHash("sha256");
+  let sequence = 0;
+  let totalDataFrames = 0;
+  let totalPlainBytes = 0;
+  const base = {
+    format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+    schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+  } as const;
+
+  const serialize = async (
+    header: AgentBackupCaptureV2FrameHeader,
+    payload?: Uint8Array,
+    includeInChain = true,
+  ): Promise<Uint8Array> => {
+    assertCaptureActive(request, signal, now);
+    const wire = await serializeAgentBackupCaptureV2Frame(
+      { header, payload },
+      nodeSha256Digest,
+    );
+    if (includeInChain) {
+      frameDigestChain.update(readAgentBackupCaptureV2FrameDigest(wire));
+    }
+    return wire;
+  };
+
+  try {
+    for (const source of options.components) {
+      if (!source.prepare) continue;
+      try {
+        await awaitWithCaptureControl(
+          () => source.prepare?.(signal) ?? Promise.resolve(),
+          request,
+          signal,
+          now,
+        );
+      } catch (error) {
+        if (error instanceof AgentBackupV2CaptureError) throw error;
+        throw new AgentBackupV2CaptureError(
+          `Capture source preparation failed for component ${source.descriptor.name}`,
+          "AGENT_BACKUP_V2_SOURCE_PREPARE_FAILED",
+          {
+            operationId: request.operationId,
+            componentName: source.descriptor.name,
+          },
+          { cause: error, severity: "ephemeral" },
+        );
+      }
+    }
+
+    yield await serialize({
+      ...base,
+      kind: "capture-start",
+      sequence: sequence++,
+      operationId: request.operationId,
+      agentId: request.agentId,
+      activationGeneration: request.activationGeneration,
+      lifecycleRevision: request.lifecycleRevision,
+      createdAt: new Date(now()).toISOString(),
+      componentCount: options.components.length,
+      maxFramePayloadBytes: AGENT_BACKUP_CAPTURE_V2_LIMITS.maxFramePayloadBytes,
+    });
+
+    for (const [componentIndex, source] of options.components.entries()) {
+      yield await serialize({
+        ...base,
+        kind: "component-start",
+        sequence: sequence++,
+        componentIndex,
+        component: source.descriptor,
+      });
+      const payloadHash = createHash("sha256");
+      let componentDataFrames = 0;
+      let componentPlainBytes = 0;
+      const iterator = source.open(signal)[Symbol.asyncIterator]();
+      let sourceCompleted = false;
+      try {
+        for (;;) {
+          const next = await awaitWithCaptureControl(
+            () => iterator.next(),
+            request,
+            signal,
+            now,
+          );
+          if (next.done) {
+            sourceCompleted = true;
+            break;
+          }
+          const { bytes, entry } = next.value;
+          if (!(bytes instanceof Uint8Array)) {
+            captureError(
+              `Component ${source.descriptor.name} yielded non-byte data`,
+              "AGENT_BACKUP_V2_INVALID_SOURCE_CHUNK",
+              { componentName: source.descriptor.name },
+              { severity: "fatal" },
+            );
+          }
+          if (
+            bytes.length > AGENT_BACKUP_CAPTURE_V2_LIMITS.maxFramePayloadBytes
+          ) {
+            captureError(
+              `Component ${source.descriptor.name} exceeded the frame payload bound`,
+              "AGENT_BACKUP_V2_SOURCE_CHUNK_TOO_LARGE",
+              { componentName: source.descriptor.name, bytes: bytes.length },
+              { severity: "fatal" },
+            );
+          }
+          if (
+            bytes.length === 0 &&
+            (entry?.fileSizeBytes !== 0 || entry.fileOffsetBytes !== 0)
+          ) {
+            captureError(
+              `Component ${source.descriptor.name} made no progress`,
+              "AGENT_BACKUP_V2_ZERO_PROGRESS",
+              { componentName: source.descriptor.name },
+              { severity: "fatal" },
+            );
+          }
+          if (
+            totalPlainBytes >
+            AGENT_BACKUP_CAPTURE_V2_LIMITS.maxPlainBytes - bytes.length
+          ) {
+            captureError(
+              "Capture exceeds the plaintext byte limit",
+              "AGENT_BACKUP_V2_PLAIN_BYTES_LIMIT",
+              { observedBytes: totalPlainBytes + bytes.length },
+              { severity: "fatal" },
+            );
+          }
+          if (totalDataFrames >= AGENT_BACKUP_CAPTURE_V2_LIMITS.maxDataFrames) {
+            captureError(
+              "Capture exceeds the data-frame limit",
+              "AGENT_BACKUP_V2_DATA_FRAME_LIMIT",
+              { observedFrames: totalDataFrames + 1 },
+              { severity: "fatal" },
+            );
+          }
+          payloadHash.update(bytes);
+          yield await serialize(
+            {
+              ...base,
+              kind: "data",
+              sequence: sequence++,
+              componentIndex,
+              componentName: source.descriptor.name,
+              dataIndex: componentDataFrames,
+              offsetBytes: componentPlainBytes,
+              payloadBytes: bytes.length,
+              ...(entry ? { entry } : {}),
+            },
+            bytes,
+          );
+          componentDataFrames += 1;
+          componentPlainBytes += bytes.length;
+          totalDataFrames += 1;
+          totalPlainBytes += bytes.length;
+        }
+      } catch (error) {
+        // error-policy:J2 source failures gain stable operation/component
+        // context; typed capture failures already carry that context.
+        if (error instanceof AgentBackupV2CaptureError) throw error;
+        throw new AgentBackupV2CaptureError(
+          `Capture source failed for component ${source.descriptor.name}`,
+          "AGENT_BACKUP_V2_SOURCE_FAILED",
+          {
+            operationId: request.operationId,
+            componentName: source.descriptor.name,
+          },
+          { cause: error, severity: "ephemeral" },
+        );
+      } finally {
+        if (!sourceCompleted && !controller.signal.aborted) {
+          controller.abort(
+            new AgentBackupV2CaptureError(
+              "Agent backup capture source closed before completion",
+              "AGENT_BACKUP_V2_CAPTURE_CLOSED",
+              {
+                operationId: request.operationId,
+                componentName: source.descriptor.name,
+              },
+              { severity: "ephemeral" },
+            ),
+          );
+        }
+        const closing = iterator.return?.();
+        if (closing) {
+          if (signal.aborted) {
+            // error-policy:J6 an interrupted source may never settle `return`;
+            // observe cleanup rejection without pinning the HTTP deadline.
+            void Promise.resolve(closing).catch((error) => {
+              logger.warn(
+                {
+                  err: error instanceof Error ? error.message : String(error),
+                  componentName: source.descriptor.name,
+                },
+                "[agent-backup-v2] Interrupted source cleanup failed",
+              );
+            });
+          } else {
+            await closing;
+          }
+        }
+      }
+      yield await serialize({
+        ...base,
+        kind: "component-end",
+        sequence: sequence++,
+        componentIndex,
+        componentName: source.descriptor.name,
+        dataFrameCount: componentDataFrames,
+        plainBytes: componentPlainBytes,
+        payloadSha256: payloadHash.digest("hex"),
+      });
+    }
+
+    assertCaptureActive(request, signal, now);
+    const frameDigestChainSha256 = frameDigestChain.digest("hex");
+    yield await serialize(
+      {
+        ...base,
+        kind: "capture-end",
+        sequence: sequence++,
+        componentCount: options.components.length,
+        dataFrameCount: totalDataFrames,
+        plainBytes: totalPlainBytes,
+        frameDigestChainSha256,
+      },
+      undefined,
+      false,
+    );
+  } finally {
+    clearTimeout(deadlineTimer);
+    for (const source of options.components) {
+      try {
+        source.dispose?.();
+      } catch (error) {
+        logger.warn(
+          {
+            err: error instanceof Error ? error.message : String(error),
+            componentName: source.descriptor.name,
+          },
+          "[agent-backup-v2] Capture source disposal failed",
+        );
+      }
+    }
+    if (!controller.signal.aborted) {
+      controller.abort(
+        new AgentBackupV2CaptureError(
+          "Agent backup capture iterator closed",
+          "AGENT_BACKUP_V2_CAPTURE_CLOSED",
+          { operationId: request.operationId },
+          { severity: "ephemeral" },
+        ),
+      );
+    }
+  }
+}
+
+/** Create the production capture stream for one authenticated runtime. */
+export function createAgentBackupV2Capture(
+  runtime: AgentBackupV2CaptureRuntime,
+  config: ElizaConfig,
+  request: AgentBackupCaptureV2Request,
+  options: Readonly<CreateAgentBackupV2CaptureOptions> = {},
+): AsyncIterable<Uint8Array> {
+  const components =
+    options.components ??
+    createDefaultAgentBackupV2CaptureSources(runtime, config);
+  assertComponentSources(components);
+  return streamAgentBackupV2Capture({
+    request,
+    agentId: runtime.agentId,
+    components,
+    signal: options.signal,
+    now: options.now,
+  });
+}
+
+/** Utility for callers/tests that need the payload digest of one bounded chunk. */
+export function sha256AgentBackupV2CaptureChunk(bytes: Uint8Array): string {
+  return sha256Hex(bytes);
+}

--- a/packages/agent/src/services/agent-backup.test.ts
+++ b/packages/agent/src/services/agent-backup.test.ts
@@ -8,7 +8,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { AgentRuntime } from "@elizaos/core";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   type AgentBackupStateData,
   AgentSnapshotBudgetExceededError,
@@ -21,6 +21,7 @@ import {
   restoreLocalAgentBackup,
   SnapshotBudget,
 } from "./agent-backup.ts";
+import { AGENT_BACKUP_V2_PGLITE_CAPTURE_LIMITS } from "./agent-backup-v2-capture.ts";
 
 const ORIGINAL_ENV = {
   ELIZA_STATE_DIR: process.env.ELIZA_STATE_DIR,
@@ -51,6 +52,21 @@ function runtimeStub(agentId: string): AgentRuntime {
     },
     getSetting: () => null,
   } as unknown as AgentRuntime;
+}
+
+function boundedPgliteAdapter(
+  dataDir: string,
+  createDump: () => unknown | Promise<unknown>,
+  release: () => void = () => undefined,
+) {
+  return {
+    close: async () => undefined,
+    getPgliteDataDir: () => dataDir,
+    dumpPgliteDataDirAfterPreflight: async <T>(preflight: () => Promise<T>) => {
+      const proof = await preflight();
+      return { dump: await createDump(), preflight: proof, release };
+    },
+  };
 }
 
 async function writeFixtureState(
@@ -136,11 +152,16 @@ async function exists(filePath: string): Promise<boolean> {
   }
 }
 
-describe("agent backup manifest", () => {
-  afterEach(() => {
-    restoreEnv();
-  });
+beforeEach(() => {
+  vi.spyOn(process, "availableMemory").mockReturnValue(512 * 1024 * 1024);
+});
 
+afterEach(() => {
+  vi.restoreAllMocks();
+  restoreEnv();
+});
+
+describe("agent backup manifest", () => {
   test("captures and restores local PGlite, media, vault, character, and state-dir files", async () => {
     const root = await fs.mkdtemp(
       path.join(os.tmpdir(), "eliza-agent-backup-"),
@@ -268,7 +289,7 @@ describe("agent backup manifest", () => {
     );
   });
 
-  test("captures live PGlite through dumpDataDir when the adapter exposes it", async () => {
+  test("captures live PGlite through the bounded leased exporter", async () => {
     const root = await fs.mkdtemp(
       path.join(os.tmpdir(), "eliza-agent-backup-"),
     );
@@ -281,21 +302,16 @@ describe("agent backup manifest", () => {
     await writeFixtureState(root, pgliteDir);
 
     const dumpBytes = Buffer.from("official-pglite-dump-bytes");
-    const rawConnection = {
-      ready: true,
-      async dumpDataDir(this: { ready: boolean }, compression?: "gzip") {
-        expect(this.ready).toBe(true);
-        expect(compression).toBe("gzip");
-        return new Blob([dumpBytes], { type: "application/gzip" });
-      },
-      runExclusive: async <T>(operation: () => Promise<T>) => operation(),
-    };
+    let releases = 0;
     const runtime = {
       ...runtimeStub("44444444-4444-4444-8444-444444444444"),
-      adapter: {
-        close: async () => undefined,
-        getRawConnection: () => rawConnection,
-      },
+      adapter: boundedPgliteAdapter(
+        pgliteDir,
+        () => new Blob([dumpBytes], { type: "application/gzip" }),
+        () => {
+          releases += 1;
+        },
+      ),
     } as unknown as AgentRuntime;
 
     const snapshot = await createAgentSnapshot(runtime, {} as never);
@@ -308,26 +324,27 @@ describe("agent backup manifest", () => {
       dumpBytes,
     );
     expect(snapshot.manifest.components.database.pglite).toBeUndefined();
+    expect(releases).toBe(1);
   });
 
   test("captures through the adapter's lifecycle-serialized PGlite operation", async () => {
     const root = await fs.mkdtemp(
       path.join(os.tmpdir(), "eliza-agent-backup-"),
     );
+    const pgliteDir = path.join(root, "pglite");
     process.env.ELIZA_STATE_DIR = root;
+    process.env.PGLITE_DATA_DIR = pgliteDir;
     delete process.env.POSTGRES_URL;
     delete process.env.DATABASE_URL;
+    await writeFixtureState(root, pgliteDir);
 
     let captures = 0;
     const runtime = {
       ...runtimeStub("55555555-5555-4555-8555-555555555555"),
-      adapter: {
-        close: async () => undefined,
-        dumpPgliteDataDir: async () => {
-          captures += 1;
-          return new Blob(["captured"], { type: "application/gzip" });
-        },
-      },
+      adapter: boundedPgliteAdapter(pgliteDir, async () => {
+        captures += 1;
+        return new Blob(["captured"], { type: "application/gzip" });
+      }),
     } as unknown as AgentRuntime;
 
     const snapshot = await createAgentSnapshot(runtime, {} as never);
@@ -340,19 +357,19 @@ describe("agent backup manifest", () => {
     const root = await fs.mkdtemp(
       path.join(os.tmpdir(), "eliza-agent-backup-"),
     );
+    const pgliteDir = path.join(root, "pglite");
     process.env.ELIZA_STATE_DIR = root;
+    process.env.PGLITE_DATA_DIR = pgliteDir;
     delete process.env.POSTGRES_URL;
     delete process.env.DATABASE_URL;
+    await writeFixtureState(root, pgliteDir);
 
-    const snapshotWithError = (message: string) => {
+    const snapshotWithError = (message: string, code?: string) => {
       const runtime = {
         ...runtimeStub("66666666-6666-4666-8666-666666666666"),
-        adapter: {
-          close: async () => undefined,
-          dumpPgliteDataDir: async () => {
-            throw new Error(message);
-          },
-        },
+        adapter: boundedPgliteAdapter(pgliteDir, async () => {
+          throw Object.assign(new Error(message), code ? { code } : {});
+        }),
       } as unknown as AgentRuntime;
       return createAgentSnapshot(runtime, {} as never);
     };
@@ -360,6 +377,18 @@ describe("agent backup manifest", () => {
     await expect(snapshotWithError("connection is closing")).rejects.toThrow(
       PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT,
     );
+    await expect(
+      snapshotWithError(
+        "rss budget exhausted",
+        "AGENT_BACKUP_V2_PGLITE_RSS_BUDGET_EXCEEDED",
+      ),
+    ).rejects.toThrow(PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT);
+    await expect(
+      snapshotWithError(
+        "directory changed",
+        "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_CHANGED",
+      ),
+    ).rejects.toThrow(PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT);
     await expect(
       snapshotWithError("failed while closing corrupted WAL segment"),
     ).rejects.toThrow("failed while closing corrupted WAL segment");
@@ -428,10 +457,6 @@ describe("agent backup manifest", () => {
 });
 
 describe("source-side snapshot budget (#17172 §1)", () => {
-  afterEach(() => {
-    restoreEnv();
-  });
-
   async function fixtureRoot(): Promise<{ root: string; pgliteDir: string }> {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "eliza-budget-"));
     const pgliteDir = path.join(root, "pglite");
@@ -557,10 +582,11 @@ describe("source-side snapshot budget (#17172 §1)", () => {
   });
 
   test("refuses an oversized PGlite dump from Blob.size, before arrayBuffer()", async () => {
-    await fixtureRoot();
+    const { pgliteDir } = await fixtureRoot();
     let materialized = false;
-    const rawConnection = {
-      async dumpDataDir() {
+    const withDump = {
+      ...runtime(),
+      adapter: boundedPgliteAdapter(pgliteDir, async () => {
         return {
           size: 256 * 1024,
           arrayBuffer: async () => {
@@ -568,15 +594,7 @@ describe("source-side snapshot budget (#17172 §1)", () => {
             return new ArrayBuffer(256 * 1024);
           },
         };
-      },
-      runExclusive: async <T>(operation: () => Promise<T>) => operation(),
-    };
-    const withDump = {
-      ...runtime(),
-      adapter: {
-        close: async () => undefined,
-        getRawConnection: () => rawConnection,
-      },
+      }),
     } as unknown as AgentRuntime;
 
     await expect(
@@ -587,8 +605,70 @@ describe("source-side snapshot budget (#17172 §1)", () => {
     expect(materialized).toBe(false);
   });
 
+  test("rejects a non-finite PGlite Blob size and releases its export lease", async () => {
+    const { pgliteDir } = await fixtureRoot();
+    let materialized = false;
+    let releases = 0;
+    const withDump = {
+      ...runtime(),
+      adapter: boundedPgliteAdapter(
+        pgliteDir,
+        async () => ({
+          size: Number.NaN,
+          arrayBuffer: async () => {
+            materialized = true;
+            return new ArrayBuffer(0);
+          },
+        }),
+        () => {
+          releases += 1;
+        },
+      ),
+    } as unknown as AgentRuntime;
+
+    await expect(createAgentSnapshot(withDump, config)).rejects.toThrow(
+      "did not return a Blob/File",
+    );
+    expect(materialized).toBe(false);
+    expect(releases).toBe(1);
+  });
+
+  test("refuses legacy Blob conversion when remaining memory cannot cover its copies", async () => {
+    const { pgliteDir } = await fixtureRoot();
+    vi.restoreAllMocks();
+    vi.spyOn(process, "availableMemory")
+      .mockReturnValueOnce(512 * 1024 * 1024)
+      .mockReturnValue(
+        AGENT_BACKUP_V2_PGLITE_CAPTURE_LIMITS.availableMemoryHeadroomBytes,
+      );
+    let materialized = false;
+    let releases = 0;
+    const withDump = {
+      ...runtime(),
+      adapter: boundedPgliteAdapter(
+        pgliteDir,
+        async () => ({
+          size: 1,
+          arrayBuffer: async () => {
+            materialized = true;
+            return new ArrayBuffer(1);
+          },
+        }),
+        () => {
+          releases += 1;
+        },
+      ),
+    } as unknown as AgentRuntime;
+
+    await expect(createAgentSnapshot(withDump, config)).rejects.toThrow(
+      PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT,
+    );
+    expect(materialized).toBe(false);
+    expect(releases).toBe(1);
+  });
+
   test("an in-budget PGlite dump is charged, so a sibling cannot spend the same bytes", async () => {
-    const { root } = await fixtureRoot();
+    const { root, pgliteDir } = await fixtureRoot();
     // Dump ~48 KiB + a 48 KiB media file: each fits a 96 KiB (base64) budget
     // alone, both together do not.
     const dumpBytes = Buffer.alloc(48 * 1024, 5);
@@ -596,18 +676,12 @@ describe("source-side snapshot budget (#17172 §1)", () => {
       path.join(root, "media", "big.bin"),
       Buffer.alloc(48 * 1024, 7),
     );
-    const rawConnection = {
-      async dumpDataDir() {
-        return new Blob([dumpBytes], { type: "application/gzip" });
-      },
-      runExclusive: async <T>(operation: () => Promise<T>) => operation(),
-    };
     const withDump = {
       ...runtime(),
-      adapter: {
-        close: async () => undefined,
-        getRawConnection: () => rawConnection,
-      },
+      adapter: boundedPgliteAdapter(
+        pgliteDir,
+        async () => new Blob([dumpBytes], { type: "application/gzip" }),
+      ),
     } as unknown as AgentRuntime;
 
     await expect(
@@ -617,8 +691,8 @@ describe("source-side snapshot budget (#17172 §1)", () => {
 
   test("refuses an oversized file on the pglite-files fallback walk", async () => {
     const { pgliteDir } = await fixtureRoot();
-    // No getRawConnection on the stub adapter, so the capture takes the
-    // fallback file walk — which used to run with no budget at all.
+    // No bounded exporter on the stub adapter, so the capture takes the
+    // legacy fallback file walk — which used to run with no budget at all.
     await fs.writeFile(
       path.join(pgliteDir, "oversized.wal"),
       Buffer.alloc(256 * 1024, 9),

--- a/packages/agent/src/services/agent-backup.ts
+++ b/packages/agent/src/services/agent-backup.ts
@@ -19,6 +19,12 @@ import { createKmsClient, systemKey } from "@elizaos/core/security/kms";
 import { MAX_RESTORABLE_AGENT_BACKUP_BYTES } from "@elizaos/shared/agent-backup-limits";
 import type { ElizaConfig } from "../config/config.ts";
 import { resolveConfigPath, resolveStateDir } from "../config/paths.ts";
+import {
+  AGENT_BACKUP_V2_PGLITE_CAPTURE_LIMITS,
+  type PglitePhysicalPreflight,
+  preflightPglitePhysicalDirectory,
+  resolveAgentBackupAvailableMemoryBytes,
+} from "./agent-backup-v2-capture.ts";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -916,11 +922,14 @@ function isBlobLike(value: unknown): value is {
   arrayBuffer: () => Promise<ArrayBuffer>;
   size: number;
 } {
+  const size = (value as { size?: unknown } | null)?.size;
   return (
     value !== null &&
     typeof value === "object" &&
     typeof (value as { arrayBuffer?: unknown }).arrayBuffer === "function" &&
-    typeof (value as { size?: unknown }).size === "number"
+    typeof size === "number" &&
+    Number.isSafeInteger(size) &&
+    size >= 0
   );
 }
 
@@ -938,6 +947,13 @@ export const PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT =
   "PGlite snapshot temporarily unavailable (connection closing)";
 export const PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT_CODE =
   "PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT";
+
+const PGLITE_BOUNDED_SNAPSHOT_TRANSIENT_CODES = new Set([
+  "PGLITE_DATA_DIR_EXPORT_BUSY",
+  "AGENT_BACKUP_V2_PGLITE_RSS_BUDGET_EXCEEDED",
+  "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_CHANGED",
+]);
+const LEGACY_PGLITE_POST_DUMP_COPY_FACTOR = 4;
 
 /**
  * A PGlite handle that is mid-close throws with these shapes. Kept narrow so a
@@ -958,63 +974,156 @@ function isPgliteClosingError(err: unknown): boolean {
 
 async function capturePgliteDump(
   runtime: IAgentRuntime | AgentRuntime,
+  pgliteDir: string,
+  signal: AbortSignal,
   budget?: SnapshotBudget,
 ): Promise<AgentBackupPgliteDump | null> {
   const adapter = runtime.adapter as
     | {
-        dumpPgliteDataDir?: (compression?: "gzip") => Promise<unknown>;
-        getRawConnection?: () => unknown;
+        dumpPgliteDataDirAfterPreflight?: (
+          preflight: () => Promise<PglitePhysicalPreflight>,
+          compression?: "gzip",
+        ) => Promise<unknown>;
+        getPgliteDataDir?: () => unknown;
       }
     | undefined;
-  const managedDump = adapter?.dumpPgliteDataDir;
-  const raw = adapter?.getRawConnection?.();
-  const rawDump =
-    raw && typeof raw === "object"
-      ? (raw as { dumpDataDir?: (compression?: "gzip") => Promise<unknown> })
-          .dumpDataDir
-      : undefined;
-  if (typeof managedDump !== "function" && typeof rawDump !== "function") {
+  const managedDump = adapter?.dumpPgliteDataDirAfterPreflight;
+  if (typeof managedDump !== "function") {
     return null;
   }
+  if (typeof adapter?.getPgliteDataDir !== "function") {
+    throw new Error(
+      "The bounded PGlite exporter cannot attest its physical data directory",
+    );
+  }
+  const managedDataDir = adapter.getPgliteDataDir();
+  if (
+    typeof managedDataDir !== "string" ||
+    managedDataDir.length === 0 ||
+    managedDataDir === ":memory:" ||
+    managedDataDir.includes("://")
+  ) {
+    throw new Error(
+      "The bounded PGlite exporter is not backed by a physical data directory",
+    );
+  }
 
-  let dump: unknown;
+  const [physicalPgliteDir, physicalManagedDataDir] = await Promise.all([
+    fs.realpath(path.resolve(pgliteDir)),
+    fs.realpath(path.resolve(managedDataDir)),
+  ]);
+  if (physicalPgliteDir !== physicalManagedDataDir) {
+    throw new Error(
+      "The bounded PGlite exporter data directory does not match backup configuration",
+    );
+  }
+
+  let bounded: unknown;
+  let provenPreflight: PglitePhysicalPreflight | undefined;
   try {
-    dump = managedDump
-      ? await managedDump.call(adapter, "gzip")
-      : await rawDump?.call(raw, "gzip");
+    bounded = await managedDump.call(
+      adapter,
+      async () => {
+        const proof = await preflightPglitePhysicalDirectory(
+          physicalPgliteDir,
+          signal,
+          runtime.agentId,
+        );
+        provenPreflight = proof;
+        return proof;
+      },
+      "gzip",
+    );
   } catch (err) {
-    if (isPgliteClosingError(err)) {
+    const code =
+      err && typeof err === "object"
+        ? (err as { code?: unknown }).code
+        : undefined;
+    if (
+      isPgliteClosingError(err) ||
+      (typeof code === "string" &&
+        PGLITE_BOUNDED_SNAPSHOT_TRANSIENT_CODES.has(code))
+    ) {
       throw new Error(PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT);
     } else {
       throw err;
     }
   }
-  if (!isBlobLike(dump)) {
-    throw new Error("PGlite dumpDataDir() did not return a Blob/File");
+  if (!bounded || typeof bounded !== "object") {
+    throw new Error("The bounded PGlite exporter returned an invalid result");
   }
-  // Refuse from Blob.size BEFORE arrayBuffer(): the dump would otherwise be
-  // resident three times over (ArrayBuffer + Buffer + base64) with the budget
-  // none the wiser.
-  const hold = budget?.reserve(dump.size);
-  let committed = false;
+  const { dump, preflight, release } = bounded as {
+    dump?: unknown;
+    preflight?: unknown;
+    release?: unknown;
+  };
+  if (typeof release !== "function") {
+    throw new Error(
+      "The bounded PGlite exporter did not provide a consumer-lifetime lease",
+    );
+  }
+
+  let released = false;
+  const releaseOnce = () => {
+    if (released) return;
+    released = true;
+    release();
+  };
   try {
-    const bytes = Buffer.from(await dump.arrayBuffer());
-    const file = fileEntryFromBytes(PGLITE_DUMP_PATH, bytes);
-    hold?.commit(Buffer.byteLength(JSON.stringify(file), "utf8"));
-    committed = true;
-    return withPgliteDumpHash({
-      kind: "pglite-dump",
-      compression: "gzip",
-      file,
-      sha256: "",
-    });
+    if (preflight !== provenPreflight || !provenPreflight) {
+      throw new Error(
+        "The bounded PGlite exporter skipped its required preflight",
+      );
+    }
+    if (!isBlobLike(dump)) {
+      throw new Error("PGlite dumpDataDir() did not return a Blob/File");
+    }
+    if (dump.size > provenPreflight.estimatedArchiveBytes) {
+      throw new Error("PGlite export exceeds its preflighted archive bound");
+    }
+    // The shared eight-copy preflight bounds PGlite's directory/tar/gzip/Blob
+    // materialization. Legacy JSON then retains up to one ArrayBuffer copy plus
+    // 4/3-size base64 and JSON-string copies: 1 + 4/3 + 4/3 < 4. Re-check the
+    // remaining memory against those four actual compressed-dump copies before
+    // reading the Blob, while the shared export lease is still held.
+    const legacyAdditionalMemoryBudgetBytes =
+      dump.size * LEGACY_PGLITE_POST_DUMP_COPY_FACTOR;
+    const legacyRequiredAvailableMemoryBytes =
+      legacyAdditionalMemoryBudgetBytes +
+      AGENT_BACKUP_V2_PGLITE_CAPTURE_LIMITS.availableMemoryHeadroomBytes;
+    if (
+      resolveAgentBackupAvailableMemoryBytes() <
+      legacyRequiredAvailableMemoryBytes
+    ) {
+      throw new Error(PGLITE_SNAPSHOT_UNAVAILABLE_TRANSIENT);
+    }
+    // Refuse from Blob.size BEFORE arrayBuffer(): the dump would otherwise be
+    // resident three times over (ArrayBuffer + Buffer + base64) with the budget
+    // none the wiser.
+    const hold = budget?.reserve(dump.size);
+    let committed = false;
+    try {
+      const bytes = Buffer.from(await dump.arrayBuffer());
+      const file = fileEntryFromBytes(PGLITE_DUMP_PATH, bytes);
+      hold?.commit(Buffer.byteLength(JSON.stringify(file), "utf8"));
+      committed = true;
+      return withPgliteDumpHash({
+        kind: "pglite-dump",
+        compression: "gzip",
+        file,
+        sha256: "",
+      });
+    } finally {
+      if (!committed) hold?.release();
+    }
   } finally {
-    if (!committed) hold?.release();
+    releaseOnce();
   }
 }
 
 async function captureDatabaseComponent(
   runtime: IAgentRuntime | AgentRuntime,
+  signal: AbortSignal,
   budget?: SnapshotBudget,
 ): Promise<AgentBackupDatabaseComponent> {
   const postgresUrl = hasPostgresUrl(runtime);
@@ -1037,7 +1146,12 @@ async function captureDatabaseComponent(
     return { kind: "none", reason, sha256: sha256Json({ reason }) };
   }
 
-  const pgliteDump = await capturePgliteDump(runtime, budget);
+  const pgliteDump = await capturePgliteDump(
+    runtime,
+    pgliteDir,
+    signal,
+    budget,
+  );
   if (pgliteDump) {
     return {
       kind: "pglite-dump",
@@ -1137,7 +1251,7 @@ export async function createAgentSnapshot(
     }
   };
   const captures = [
-    guarded(captureDatabaseComponent(runtime, budget)),
+    guarded(captureDatabaseComponent(runtime, signal, budget)),
     guarded(
       collectFileSet({
         root: path.join(stateDir, MEDIA_DIR_NAME),

--- a/packages/agent/src/services/index.ts
+++ b/packages/agent/src/services/index.ts
@@ -9,6 +9,7 @@
  */
 
 export * from "./agent-backup.ts";
+export * from "./agent-backup-v2-capture.ts";
 export * from "./agent-export.ts";
 export * from "./app-session-gate.ts";
 export * from "./audio-redaction-service.ts";

--- a/packages/cloud/api/__tests__/bootstrap-callback-node-identity.test.ts
+++ b/packages/cloud/api/__tests__/bootstrap-callback-node-identity.test.ts
@@ -20,6 +20,7 @@ interface StoredNode {
   ssh_user: string;
   capacity: number;
   host_key_fingerprint: string | null;
+  node_incarnation: string | null;
   status: string;
   metadata: Record<string, unknown>;
 }
@@ -32,6 +33,7 @@ const EXISTING: StoredNode = {
   ssh_user: "root",
   capacity: 8,
   host_key_fingerprint: "SHA256:pinned-fingerprint",
+  node_incarnation: "00000000-0000-4000-8000-000000000001",
   status: "healthy",
   metadata: { provider: "operator-provisioned" },
 };
@@ -54,6 +56,22 @@ const mockCreate = mock(async (data: StoredNode) => {
   stored = { ...data, id: "node-row-new" };
   return stored;
 });
+const mockRotateNodeHostKeyFingerprint = mock(
+  async (input: {
+    expectedFingerprint: string | null;
+    observedFingerprint: string | null;
+  }) => {
+    if (!stored || stored.host_key_fingerprint !== input.expectedFingerprint) {
+      throw new Error("stale host-key rotation");
+    }
+    stored = {
+      ...stored,
+      host_key_fingerprint: input.observedFingerprint,
+      node_incarnation: null,
+    };
+    return stored;
+  },
+);
 const mockReconcileProvisionalCapacity = mock(
   async (
     _id: string,
@@ -76,6 +94,7 @@ mock.module("@/db/repositories/docker-nodes", () => ({
     findByNodeId: mockFindByNodeId,
     update: mockUpdate,
     create: mockCreate,
+    rotateNodeHostKeyFingerprint: mockRotateNodeHostKeyFingerprint,
     reconcileProvisionalCapacity: mockReconcileProvisionalCapacity,
   },
 }));
@@ -116,6 +135,7 @@ function useProvisionalAutoscaledNode(requestedCapacity: number | null): void {
     ...EXISTING,
     capacity: 0,
     host_key_fingerprint: null,
+    node_incarnation: null,
     metadata: {
       provider: "hetzner-cloud",
       autoscaled: true,
@@ -134,6 +154,7 @@ describe("bootstrap-callback node-identity guard (#12876)", () => {
     mockUpdate.mockClear();
     mockCreate.mockClear();
     mockFindByNodeId.mockClear();
+    mockRotateNodeHostKeyFingerprint.mockClear();
     mockReconcileProvisionalCapacity.mockClear();
   });
 
@@ -216,8 +237,15 @@ describe("bootstrap-callback node-identity guard (#12876)", () => {
 
     expect(res.status).toBe(200);
     expect(mockUpdate).toHaveBeenCalledTimes(1);
-    expect(lastUpdateArg?.host_key_fingerprint).toBe("SHA256:first-real-pin");
+    expect(mockRotateNodeHostKeyFingerprint).toHaveBeenCalledWith({
+      id: EXISTING.id,
+      nodeId: EXISTING.node_id,
+      expectedFingerprint: null,
+      observedFingerprint: "SHA256:first-real-pin",
+    });
+    expect(lastUpdateArg).not.toHaveProperty("host_key_fingerprint");
     expect(stored?.host_key_fingerprint).toBe("SHA256:first-real-pin");
+    expect(stored?.node_incarnation).toBeNull();
   });
 
   test("allows identity mutation with a matching pinned fingerprint", async () => {

--- a/packages/cloud/api/v1/admin/docker-nodes/[nodeId]/route.ts
+++ b/packages/cloud/api/v1/admin/docker-nodes/[nodeId]/route.ts
@@ -121,6 +121,8 @@ const updateNodeSchema = z
     capacity: z.number().int().min(1).optional(),
     sshPort: z.number().int().min(1).max(65535).optional(),
     sshUser: z.string().min(1).optional(),
+    // Explicit pin rotation/revocation always clears node_incarnation. A later
+    // host-key-verified health probe must re-attest the boot before capture.
     hostKeyFingerprint: z.string().min(1).nullable().optional(),
     metadata: z.record(z.string(), z.unknown()).optional(),
   })
@@ -198,11 +200,21 @@ async function __hono_PATCH(
     if (capacity !== undefined) updateData.capacity = capacity;
     if (sshPort !== undefined) updateData.ssh_port = sshPort;
     if (sshUser !== undefined) updateData.ssh_user = sshUser;
-    if (hostKeyFingerprint !== undefined)
-      updateData.host_key_fingerprint = hostKeyFingerprint;
     if (metadata !== undefined) updateData.metadata = metadata;
 
-    const updated = await dockerNodesRepository.update(existing.id, updateData);
+    const pinRotated =
+      hostKeyFingerprint === undefined
+        ? null
+        : await dockerNodesRepository.rotateNodeHostKeyFingerprint({
+            id: existing.id,
+            nodeId,
+            expectedFingerprint: existing.host_key_fingerprint,
+            observedFingerprint: hostKeyFingerprint,
+          });
+    const updated =
+      Object.keys(updateData).length > 0
+        ? await dockerNodesRepository.update(existing.id, updateData)
+        : pinRotated;
 
     logger.info("[Admin Docker Nodes] Node updated", {
       nodeId,

--- a/packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts
+++ b/packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts
@@ -237,6 +237,15 @@ async function __hono_POST(request: Request) {
           );
         }
 
+        if (!hasPinnedFingerprint) {
+          await dockerNodesRepository.rotateNodeHostKeyFingerprint({
+            id: existing.id,
+            nodeId,
+            expectedFingerprint: null,
+            observedFingerprint: hostKeyFingerprint,
+          });
+        }
+
         const attestedAt = new Date().toISOString();
         const reconciled =
           await dockerNodesRepository.reconcileProvisionalCapacity(
@@ -246,9 +255,6 @@ async function __hono_POST(request: Request) {
               hostname: identityChanged ? hostname : existing.hostname,
               ssh_port: identityChanged ? sshPort : existing.ssh_port,
               ssh_user: identityChanged ? sshUser : existing.ssh_user,
-              host_key_fingerprint: hasPinnedFingerprint
-                ? existing.host_key_fingerprint!
-                : hostKeyFingerprint,
               status: "unknown",
             },
             stampDockerNodeEnvironmentMetadata({
@@ -297,13 +303,18 @@ async function __hono_POST(request: Request) {
       // it was born on, so re-writing it on every liveness re-bootstrap would
       // silently reset a hand-tuned value (e.g. a 252 GB robot at capacity=24
       // back to 8). Capacity is stamped only on the create path below.
+      if (!hasPinnedFingerprint) {
+        await dockerNodesRepository.rotateNodeHostKeyFingerprint({
+          id: existing.id,
+          nodeId,
+          expectedFingerprint: null,
+          observedFingerprint: hostKeyFingerprint,
+        });
+      }
       const updated = await dockerNodesRepository.update(existing.id, {
         hostname: identityChanged ? hostname : existing.hostname,
         ssh_port: identityChanged ? sshPort : existing.ssh_port,
         ssh_user: identityChanged ? sshUser : existing.ssh_user,
-        host_key_fingerprint: hasPinnedFingerprint
-          ? existing.host_key_fingerprint
-          : hostKeyFingerprint,
         status: "unknown",
         metadata: stampDockerNodeEnvironmentMetadata({
           ...((existing.metadata as Record<string, unknown>) ?? {}),

--- a/packages/cloud/scripts/admin/onboard-docker-node.test.ts
+++ b/packages/cloud/scripts/admin/onboard-docker-node.test.ts
@@ -5,11 +5,13 @@
  */
 import { describe, expect, it } from "bun:test";
 import {
+  assertRobotOnboardAuthorityCompatible,
   buildOnboardSshConfig,
   capacityForOnboardUpsert,
   hostKeyFingerprintForOnboardUpsert,
   parseArgs,
   parseDockerPs,
+  requireOnboardHostKeyFingerprint,
   selectZombieAgentContainers,
 } from "./onboard-docker-node";
 
@@ -306,6 +308,65 @@ describe("host-key pinning helpers", () => {
       ),
     ).toBe("first-pin");
     expect(hostKeyFingerprintForOnboardUpsert(null, undefined)).toBeNull();
+  });
+
+  it("requires a persisted or TOFU-captured fingerprint before source attestation", () => {
+    expect(
+      requireOnboardHostKeyFingerprint(
+        { host_key_fingerprint: "pinned", capacity: 8 },
+        undefined,
+      ),
+    ).toBe("pinned");
+    expect(requireOnboardHostKeyFingerprint(null, "captured")).toBe("captured");
+    expect(requireOnboardHostKeyFingerprint(null, "  captured  ")).toBe(
+      "captured",
+    );
+    expect(() => requireOnboardHostKeyFingerprint(null, undefined)).toThrow(
+      /host-key fingerprint/,
+    );
+  });
+});
+
+describe("Robot source authority", () => {
+  it("accepts legacy/Robot targets but never reinterprets a typed Cloud row", () => {
+    expect(() => assertRobotOnboardAuthorityCompatible(null)).not.toThrow();
+    expect(() =>
+      assertRobotOnboardAuthorityCompatible({
+        fleet_kind: null,
+        infrastructure_provider: null,
+        provider_server_id: null,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertRobotOnboardAuthorityCompatible({
+        fleet_kind: "robot",
+        infrastructure_provider: "hetzner",
+        provider_server_id: null,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertRobotOnboardAuthorityCompatible({
+        fleet_kind: "cloud",
+        infrastructure_provider: "hetzner",
+        provider_server_id: "4242",
+      }),
+    ).toThrow(/Cloud node/);
+    for (const ambiguous of [
+      {
+        fleet_kind: null,
+        infrastructure_provider: "hetzner" as const,
+        provider_server_id: null,
+      },
+      {
+        fleet_kind: "robot" as const,
+        infrastructure_provider: null,
+        provider_server_id: null,
+      },
+    ]) {
+      expect(() => assertRobotOnboardAuthorityCompatible(ambiguous)).toThrow(
+        /Cloud node/,
+      );
+    }
   });
 });
 

--- a/packages/cloud/scripts/admin/onboard-docker-node.ts
+++ b/packages/cloud/scripts/admin/onboard-docker-node.ts
@@ -19,8 +19,10 @@
  *      agent naming scheme — never an active sandbox),
  *   5. ensure the local-embedding sidecar is running (same contract the
  *      cloud-init bootstrap installs; see `embedding-sidecar.ts`),
- *   6. upsert the node into `docker_nodes` (update if it already exists),
- *   7. print a clear summary of what changed vs. was already in place.
+ *   6. pre-pull the agent image,
+ *   7. attest the exact Linux boot UUID over host-key-verified SSH,
+ *   8. upsert the node into `docker_nodes` (update if it already exists),
+ *   9. print a clear summary of what changed vs. was already in place.
  *
  * No secrets are hard-coded: the registry token (if any) comes from the
  * control-plane env via `containersEnv`; the DB target from `DATABASE_URL`.
@@ -53,12 +55,16 @@ import {
 async function loadDeps() {
   const [
     { dockerNodesRepository, stampDockerNodeEnvironmentMetadata },
+    { parseLinuxBootId },
     { ensureRegistryAccess },
     dockerUtils,
     { DockerSSHClient },
     { buildEnsureEmbeddingSidecarCmd },
   ] = await Promise.all([
     import("@elizaos/cloud-shared/db/repositories/docker-nodes"),
+    import(
+      "@elizaos/cloud-shared/db/repositories/agent-backup-source-authority"
+    ),
     import(
       "@elizaos/cloud-shared/lib/services/containers/hetzner-client/registry"
     ),
@@ -69,6 +75,7 @@ async function loadDeps() {
   return {
     dockerNodesRepository,
     stampDockerNodeEnvironmentMetadata,
+    parseLinuxBootId,
     ensureRegistryAccess,
     buildEnsureNetworkCmd: dockerUtils.buildEnsureNetworkCmd,
     shellQuote: dockerUtils.shellQuote,
@@ -142,6 +149,12 @@ interface ExistingDockerNodePin {
   capacity: number;
 }
 
+interface ExistingDockerNodeSourceAuthority {
+  fleet_kind: "robot" | "cloud" | null;
+  infrastructure_provider: "hetzner" | null;
+  provider_server_id: string | null;
+}
+
 interface OnboardSshConfig {
   hostname: string;
   port: number;
@@ -171,6 +184,41 @@ export function hostKeyFingerprintForOnboardUpsert(
   capturedFingerprint: string | undefined,
 ): string | null {
   return existing?.host_key_fingerprint ?? capturedFingerprint ?? null;
+}
+
+export function assertRobotOnboardAuthorityCompatible(
+  existing: ExistingDockerNodeSourceAuthority | null,
+): void {
+  if (!existing) return;
+  const isUnclassifiedLegacy =
+    existing.fleet_kind === null &&
+    existing.infrastructure_provider === null &&
+    existing.provider_server_id === null;
+  const isExactRobot =
+    existing.fleet_kind === "robot" &&
+    existing.infrastructure_provider === "hetzner" &&
+    existing.provider_server_id === null;
+  if (!isUnclassifiedLegacy && !isExactRobot) {
+    throw new Error(
+      "Refusing to reinterpret an ambiguous or typed Cloud node as Robot authority",
+    );
+  }
+}
+
+export function requireOnboardHostKeyFingerprint(
+  existing: ExistingDockerNodePin | null,
+  capturedFingerprint: string | undefined,
+): string {
+  const fingerprint = hostKeyFingerprintForOnboardUpsert(
+    existing,
+    capturedFingerprint,
+  );
+  if (!fingerprint?.trim()) {
+    throw new Error(
+      "Robot source authority requires an SSH host-key fingerprint",
+    );
+  }
+  return fingerprint.trim();
 }
 
 /**
@@ -270,6 +318,7 @@ async function main(): Promise<void> {
   const {
     dockerNodesRepository,
     stampDockerNodeEnvironmentMetadata,
+    parseLinuxBootId,
     ensureRegistryAccess,
     buildEnsureNetworkCmd,
     shellQuote,
@@ -278,6 +327,7 @@ async function main(): Promise<void> {
   } = await loadDeps();
   const summary: string[] = [];
   const existing = await dockerNodesRepository.findByNodeId(args.nodeId);
+  assertRobotOnboardAuthorityCompatible(existing);
 
   // Re-onboard must verify against the stored pin before any root SSH command
   // runs. Only a never-pinned node takes the TOFU branch and persists the
@@ -372,27 +422,42 @@ async function main(): Promise<void> {
         summary.push("agent image pre-pull FAILED (non-fatal)");
       });
 
-    // 7. Register / upsert into docker_nodes — same shape as bootstrap-callback.
+    // 7. Read the exact running-kernel identity over the same verified SSH
+    // connection. Unlike image warming, this proof is mandatory: without it
+    // the node must not become manifest-v2 source authority.
+    const nodeIncarnation = parseLinuxBootId(
+      await ssh.exec("cat /proc/sys/kernel/random/boot_id", 30_000),
+    );
+    const hostKeyFingerprint = requireOnboardHostKeyFingerprint(
+      existing,
+      capturedFingerprint,
+    );
+    summary.push(`boot incarnation attested (${nodeIncarnation})`);
+
+    // 8. Register / upsert exact Robot authority. Existing rows use one CAS
+    // write so reboot rotation and operational host updates cannot tear apart.
     if (existing) {
-      await dockerNodesRepository.update(existing.id, {
-        hostname: args.host,
-        ssh_port: args.sshPort,
-        ssh_user: args.sshUser,
-        // Preserve an operator-tuned capacity across re-onboards; the
-        // `--capacity` default only seeds a brand-new row (see create branch).
-        capacity: capacityForOnboardUpsert(existing, args.capacity),
-        status: "unknown",
-        // Never overwrite an established pin during re-onboard; a differing
-        // presented key must fail in DockerSSHClient before this update.
-        host_key_fingerprint: hostKeyFingerprintForOnboardUpsert(
-          existing,
-          capturedFingerprint,
-        ),
-        metadata: stampDockerNodeEnvironmentMetadata({
-          ...((existing.metadata as Record<string, unknown>) ?? {}),
-          provider: "operator-onboarded",
-          lastOnboardedAt: new Date().toISOString(),
-        }),
+      await dockerNodesRepository.attestRobotSourceAuthority({
+        id: existing.id,
+        nodeId: args.nodeId,
+        expectedIncarnation: existing.node_incarnation,
+        expectedHostKeyFingerprint: existing.host_key_fingerprint,
+        observedIncarnation: nodeIncarnation,
+        registration: {
+          hostname: args.host,
+          sshPort: args.sshPort,
+          sshUser: args.sshUser,
+          // Preserve an operator-tuned capacity across re-onboards; the
+          // `--capacity` default only seeds a brand-new row.
+          capacity: capacityForOnboardUpsert(existing, args.capacity),
+          status: "unknown",
+          hostKeyFingerprint,
+          metadata: stampDockerNodeEnvironmentMetadata({
+            ...((existing.metadata as Record<string, unknown>) ?? {}),
+            provider: "operator-onboarded",
+            lastOnboardedAt: new Date().toISOString(),
+          }),
+        },
       });
       summary.push(`docker_nodes row updated (${args.nodeId})`);
     } else {
@@ -405,11 +470,11 @@ async function main(): Promise<void> {
         enabled: true,
         status: "unknown",
         allocated_count: 0,
-        // Persist the TOFU-captured pin so later control-plane SSH is verified.
-        host_key_fingerprint: hostKeyFingerprintForOnboardUpsert(
-          null,
-          capturedFingerprint,
-        ),
+        host_key_fingerprint: hostKeyFingerprint,
+        fleet_kind: "robot",
+        infrastructure_provider: "hetzner",
+        provider_server_id: null,
+        node_incarnation: nodeIncarnation,
         metadata: stampDockerNodeEnvironmentMetadata({
           provider: "operator-onboarded",
           onboardedAt: new Date().toISOString(),

--- a/packages/cloud/services/container-control-plane/src/index.ts
+++ b/packages/cloud/services/container-control-plane/src/index.ts
@@ -612,8 +612,7 @@ async function handleInternal(c: Context, fn: () => Promise<Response>) {
 
 async function mirrorControlPlaneNodes(nodes: DockerNode[]): Promise<void> {
   for (const node of nodes) {
-    const data = {
-      node_id: node.node_id,
+    const mutableData = {
       hostname: node.hostname,
       ssh_port: node.ssh_port,
       capacity: node.capacity,
@@ -621,16 +620,19 @@ async function mirrorControlPlaneNodes(nodes: DockerNode[]): Promise<void> {
       status: node.status,
       last_health_check: node.last_health_check,
       ssh_user: node.ssh_user,
-      host_key_fingerprint: node.host_key_fingerprint,
       metadata: stampDockerNodeEnvironmentMetadata(node.metadata),
     };
 
     const existing = await dockerNodesRepository.findByNodeId(node.node_id);
     if (existing) {
-      await dockerNodesRepository.update(existing.id, data);
+      // node_id is immutable provider authority once the row exists. The
+      // mirror may refresh operational fields but must never rewrite identity.
+      await dockerNodesRepository.update(existing.id, mutableData);
     } else {
       await dockerNodesRepository.create({
-        ...data,
+        node_id: node.node_id,
+        ...mutableData,
+        host_key_fingerprint: node.host_key_fingerprint,
         allocated_count: 0,
       });
     }

--- a/packages/cloud/shared/docs/agent-backup.md
+++ b/packages/cloud/shared/docs/agent-backup.md
@@ -85,12 +85,118 @@ The backup lands through the existing backup row and heavy-payload storage path:
   operator route enqueues `agent_downgrade` daemon jobs; it never runs
   automatically.
 
+## Manifest-v3 catalogue capture and publication
+
+The manifest-v3 catalogue lane is additive and fail-closed. Existing sandbox
+rows migrate with no activation authority, so they are ineligible for periodic
+capture until a later control-plane release publishes the complete immutable
+activation and vault authorities. This release does not infer those values from
+mutable container names, current node placement, or process environment.
+
+An eligible capture is bound to the exact organization, agent, activation
+generation, lifecycle revision, source node record and boot incarnation,
+immutable Docker container ID, and image digest. Robot sources additionally
+require an operator-pinned SSH host key; changing or losing that pin atomically
+revokes the node incarnation until the new boot is attested. Cloud sources bind
+the Hetzner server identity. Reservation locks the source while it records this
+authority, so lifecycle changes cannot race a stale capture. The full-only gate
+described below prevents this release from traversing or advertising an
+incremental chain.
+
+The Agent `/api/snapshot/v2` producer emits bounded authenticated frames. Cloud
+parses and encrypts those frames into a durable, bounded manifest-v3 spool.
+PGlite 0.4.x is a documented exception inside the producer: its official dump
+API materializes the file list, tar, gzip buffers, and Blob before framing can
+begin. This release therefore takes the physical-size preflight and dump under
+PGlite's exclusive query/transaction fence and the adapter lifecycle fence,
+accepts at most 40 MiB of logical database files, and estimates archive size as
+the 512-byte-rounded file sizes plus 4 KiB per entry and 1 MiB fixed overhead.
+Before materialization, the process must have at least eight archive-sized
+copies plus 32 MiB of emergency headroom available. The legacy JSON snapshot
+path uses the same consumer-lifetime export lease and performs a second gate of
+four compressed-Blob copies plus 32 MiB before array-buffer, base64, and JSON
+conversion. Availability comes from the process-aware runtime metric with an OS
+fallback; no low-baseline RSS assumption is made. A missing bounded exporter,
+an unprovable physical directory, or a database above that limit fails before
+the dump starts. There is no live-file fallback in capture v2. An uncancellable
+late dump keeps the physical-directory lane busy until it settles, so a
+disconnected client cannot start overlapping dumps.
+
+Capture revalidates the execution lease and source authority, derives manifest
+inventory, plugin-set, watermark, chain, operation key-bundle, and
+vault-reference projections at the database boundary, and stops at a confirmed
+`captured` state. A request deadline may change on replay; the operation,
+source, manifest, and spool authorities may not.
+
+This executable lane currently admits full snapshots only. Incremental
+reservation and direct pipeline invocation fail before allocating catalogue,
+KMS, network, or spool authority. The schema retains bounded parent/base chain
+fields for the required follow-up, but the gate may be removed only with a real
+delta producer, periodic full checkpoint, maximum chain depth, compaction, and
+restore-chain proof; relabeling full component bytes as a delta is forbidden.
+
+Publication then follows one replayable sequence for every encrypted chunk:
+
+1. reserve the canonical tenant-scoped object key in the primary database;
+2. durably mark provider-write intent;
+3. revalidate the catalogue lease immediately before every bounded provider
+   write attempt;
+4. create the immutable Cloudflare R2 object and persist its exact generation,
+   checksum, and receipt before marking it verified;
+5. read that exact persisted primary generation into a bounded fresh buffer,
+   verify it again, and create the independent Hetzner Object Storage copy;
+6. transition to `protected` only when the secondary inventory exactly equals
+   the authenticated primary manifest inventory.
+
+This slice uses one bounded immutable provider PUT per encrypted chunk. It does
+not yet implement provider-native multipart upload, upload-part replay, or
+multipart abort receipts; those remain required before Goal 3 can be declared
+complete.
+
+Provider reads, writes, retries, and backoff share an absolute transfer
+deadline and caller abort signal. Buffers holding ciphertext or key material are
+zeroized after use. Garbage collection uses only durable locators and receipts;
+ambiguous provider response loss is reconciled before deletion, and divergent
+objects are quarantined instead of guessed away. A spool is removable only
+after an exact current `protected`, `retained`, or `restore_verified` catalogue
+proof covers every primary and secondary object.
+
+### Periodic RPO admission remains dormant
+
+The database scheduler uses database time, preserves one operation ID across
+response loss, admits at most one due operation per organization and source
+node, and advances `next_backup_at` only after exact current manifest-v3 dual
+protection. Retry backoff has a separate timestamp, so a failure never moves the
+RPO deadline or hides an overdue agent.
+
+`AGENT_BACKUP_RPO_SCHEDULER_ENABLED` is off by default. This PR deliberately
+does not wire the catalogue runtime into the provisioning daemon and does not
+construct production capture, KMS, publication, or spool-cleanup executors from
+environment variables. It therefore makes no production 15-minute RPO claim.
+Activation/vault writers, a dedicated control-plane cadence of at most 60
+seconds, durable superseded-operation cancellation, coexistence fencing against
+legacy/manual producers, and fleet-capacity evidence must land before the gate
+may be enabled. Missing authority remains overdue and unroutable; it is never
+reported as protected.
+
 ## Operational proof
 
 The code path is tested for local manifest backup/restore, corrupt backup
 refusal, encrypted local file restore, cloud diff safety, encrypted backup row
 storage, metadata-only backup listing, pre-upgrade blocking, rollback restore,
 and daemon rollback job execution.
+
+The manifest-v3 slice additionally exercises an opt-in synthetic 1 GiB framed
+stream under a fixed RSS ceiling, a 128 MiB encrypted spool pipeline, a real
+PGlite lifecycle-fenced dump/restore proof together with capture-level
+preflight and memory-bound tests, primary and secondary response-loss replay,
+lease loss, source/node ABA fencing, exact locator garbage collection,
+divergent-object quarantine, migration replay, and database-clock scheduler
+concurrency. The synthetic 1 GiB proof validates framing and backpressure, not
+PGlite's materializing exporter. Supporting a real database above 40 MiB
+requires a genuinely streaming, consistency-fenced exporter and a fleet-side
+quota that prevents the database from crossing the supported limit. These are
+local integration proofs, not a production RPO attestation.
 
 Full PR evidence still requires a live staging run: backup -> wipe -> restore,
 plus upgrade -> rollback, with real agent logs, DB/media artifacts,

--- a/packages/cloud/shared/src/db/agent-backup-activation-foundation-migration.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-activation-foundation-migration.test.ts
@@ -1,0 +1,121 @@
+/** Replay and current-locator binding proofs for activation foundation migration 0230. */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+
+const MIGRATIONS_DIR = join(import.meta.dir, "migrations");
+const MIGRATION = readFileSync(
+  join(MIGRATIONS_DIR, "0230_agent_backup_activation_authority_foundation.sql"),
+  "utf8",
+);
+const LEGACY_AGENT = "00000000-0000-4000-8000-00000000a001";
+const ACTIVE_AGENT = "00000000-0000-4000-8000-00000000a002";
+const GENERATION = "00000000-0000-4000-8000-00000000a003";
+const BOOT_ID = "00000000-0000-4000-8000-00000000a004";
+const SHA = "a".repeat(64);
+
+async function legacyDatabase(): Promise<PGlite> {
+  const database = new PGlite();
+  await database.exec(`
+    CREATE TABLE agent_sandboxes (
+      id uuid PRIMARY KEY,
+      sandbox_id text,
+      node_id text,
+      image_digest text,
+      lifecycle_revision bigint NOT NULL DEFAULT 0
+    );
+    INSERT INTO agent_sandboxes (id, lifecycle_revision)
+    VALUES ('${LEGACY_AGENT}', 7);
+  `);
+  return database;
+}
+
+function activeColumns(): string {
+  return `
+    INSERT INTO agent_sandboxes (
+      id, sandbox_id, node_id, image_digest, lifecycle_revision,
+      activation_generation, activation_lifecycle_revision, activation_phase,
+      activation_receipt_hash, activation_container_id, activation_node_id,
+      activation_image_digest, activation_boot_id, activation_authority_published_at,
+      activation_dispatched_at, activation_completed_at
+    ) VALUES (
+      '${ACTIVE_AGENT}', 'agent-container', 'node-a', 'sha256:${SHA}',
+      9223372036854775807, '${GENERATION}', 9223372036854775807, 'active',
+      '${SHA}', '${"b".repeat(64)}', 'node-a', 'sha256:${SHA}', '${BOOT_ID}',
+      '2026-08-17T10:00:00Z', '2026-08-17T10:00:01Z', '2026-08-17T10:00:02Z'
+    )
+  `;
+}
+
+describe("0230 agent backup activation-authority foundation migration", () => {
+  test("preserves legacy rows, retains exact int64 revisions, and replays", async () => {
+    const database = await legacyDatabase();
+    try {
+      await database.exec(MIGRATION);
+      await database.exec(MIGRATION);
+      await database.exec(activeColumns());
+
+      const rows = await database.query<{
+        id: string;
+        activation_generation: string | null;
+        activation_lifecycle_revision: string | null;
+      }>(`SELECT id, activation_generation,
+          activation_lifecycle_revision::text AS activation_lifecycle_revision
+        FROM agent_sandboxes ORDER BY id`);
+      expect(rows.rows).toEqual([
+        { id: LEGACY_AGENT, activation_generation: null, activation_lifecycle_revision: null },
+        {
+          id: ACTIVE_AGENT,
+          activation_generation: GENERATION,
+          activation_lifecycle_revision: "9223372036854775807",
+        },
+      ]);
+
+      const proof = await database.query<{
+        constraints: number;
+        indexes: number;
+        validated: boolean;
+      }>(`SELECT
+        (SELECT count(*)::int FROM pg_constraint
+          WHERE conname = 'agent_sandboxes_activation_state_check') AS constraints,
+        (SELECT count(*)::int FROM pg_indexes
+          WHERE indexname = 'agent_sandboxes_activation_generation_idx') AS indexes,
+        (SELECT convalidated FROM pg_constraint
+          WHERE conname = 'agent_sandboxes_activation_state_check') AS validated`);
+      expect(proof.rows).toEqual([{ constraints: 1, indexes: 1, validated: true }]);
+    } finally {
+      await database.close();
+    }
+  }, 60_000);
+
+  test("rejects partial authorities and authorities detached from current locators", async () => {
+    const database = await legacyDatabase();
+    try {
+      await database.exec(MIGRATION);
+      await expect(
+        database.exec(`UPDATE agent_sandboxes
+        SET activation_generation = '${GENERATION}' WHERE id = '${LEGACY_AGENT}'`),
+      ).rejects.toThrow(/agent_sandboxes_activation_state_check/);
+      await database.exec(activeColumns());
+      for (const statement of [
+        `UPDATE agent_sandboxes SET activation_node_id = 'node-b' WHERE id = '${ACTIVE_AGENT}'`,
+        `UPDATE agent_sandboxes SET activation_image_digest = 'sha256:${"c".repeat(64)}'
+          WHERE id = '${ACTIVE_AGENT}'`,
+        `UPDATE agent_sandboxes SET sandbox_id = '${"b".repeat(64)}'
+          WHERE id = '${ACTIVE_AGENT}'`,
+        `UPDATE agent_sandboxes SET activation_lifecycle_revision = 7
+          WHERE id = '${ACTIVE_AGENT}'`,
+        `UPDATE agent_sandboxes SET activation_completed_at = '2026-08-17T09:59:59Z'
+          WHERE id = '${ACTIVE_AGENT}'`,
+      ]) {
+        await expect(database.exec(statement)).rejects.toThrow(
+          /agent_sandboxes_activation_state_check/,
+        );
+      }
+    } finally {
+      await database.close();
+    }
+  }, 60_000);
+});

--- a/packages/cloud/shared/src/db/agent-backup-catalog-v3-migration.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-catalog-v3-migration.test.ts
@@ -1,0 +1,199 @@
+/** Replay and fail-closed envelope proofs for manifest-v3 migrations 0233 and 0234. */
+
+import { describe, expect, test } from "bun:test";
+import { Buffer } from "node:buffer";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+
+const MIGRATIONS_DIR = join(import.meta.dir, "migrations");
+const COLUMNS_MIGRATION = readFileSync(
+  join(MIGRATIONS_DIR, "0233_agent_backup_catalog_manifest_v3_columns.sql"),
+  "utf8",
+);
+const SHAPE_MIGRATION = readFileSync(
+  join(MIGRATIONS_DIR, "0234_agent_backup_catalog_manifest_v3_shape.sql"),
+  "utf8",
+);
+const OPERATION_ID = "00000000-0000-4000-8000-000000000001";
+const KEY_GENERATION_ID = "00000000-0000-4000-8000-000000000002";
+const VAULT_GENERATION_ID = "00000000-0000-4000-8000-000000000003";
+const SHA = "a".repeat(64);
+const KEY_BUNDLE_BASE64 = Buffer.alloc(92, 0x42).toString("base64");
+
+async function legacyDatabase(): Promise<PGlite> {
+  const database = new PGlite();
+  await database.exec(`
+    CREATE TABLE agent_sandbox_backups (
+      id uuid PRIMARY KEY,
+      backup_operation_id uuid,
+      catalog_version integer,
+      catalog_state text,
+      catalog_resume_state text,
+      manifest_format text,
+      manifest_version integer,
+      manifest_digest text,
+      manifest_canonical_draft text,
+      manifest_object_count integer,
+      object_inventory_digest text,
+      backup_image_digest text,
+      database_schema_version text,
+      plugin_set_digest text,
+      watermark_digest text,
+      raw_size_bytes bigint,
+      compressed_size_bytes bigint,
+      encrypted_size_bytes bigint,
+      backup_kms_key_id text,
+      backup_kms_key_version bigint,
+      wrapped_dek_ref text,
+      wrapped_dek_ciphertext_base64 text,
+      wrapped_dek_sha256 text,
+      wrapped_dek_size_bytes integer,
+      wrapped_dek_receipt_digest text,
+      CONSTRAINT agent_sandbox_backups_catalog_manifest_shape_check CHECK (true)
+    );
+  `);
+  return database;
+}
+
+function commonCapturedValues(id: string, version: number, kmsVersion = "1"): string {
+  return `
+    '${id}', '${OPERATION_ID}', 2, 'captured', 'elizaos.agent-backup', ${version},
+    '${SHA}', '{}', 1, '${SHA}', 'sha256:${SHA}', '1', '${SHA}', '${SHA}',
+    64, 64, 92, 'org:00000000-0000-4000-8000-000000000004/dek/v1', ${kmsVersion}
+  `;
+}
+
+const COMMON_COLUMNS = `
+  id, backup_operation_id, catalog_version, catalog_state, manifest_format,
+  manifest_version, manifest_digest, manifest_canonical_draft, manifest_object_count,
+  object_inventory_digest, backup_image_digest, database_schema_version,
+  plugin_set_digest, watermark_digest, raw_size_bytes, compressed_size_bytes,
+  encrypted_size_bytes, backup_kms_key_id, backup_kms_key_version
+`;
+
+describe("0233/0234 agent backup catalogue manifest-v3 migrations", () => {
+  test("replays while accepting exact v2, v3, and pre-capture shapes", async () => {
+    const database = await legacyDatabase();
+    try {
+      await database.exec(COLUMNS_MIGRATION);
+      await database.exec(SHAPE_MIGRATION);
+      await database.exec(COLUMNS_MIGRATION);
+      await database.exec(SHAPE_MIGRATION);
+      await database.exec(`
+        INSERT INTO agent_sandbox_backups (${COMMON_COLUMNS}, wrapped_dek_ref,
+          wrapped_dek_ciphertext_base64, wrapped_dek_sha256, wrapped_dek_size_bytes,
+          wrapped_dek_receipt_digest)
+        VALUES (${commonCapturedValues("00000000-0000-4000-8000-000000000011", 2)},
+          'backup-dek:${OPERATION_ID}', 'Qg==', '${SHA}', 1, '${SHA}');
+
+        INSERT INTO agent_sandbox_backups (${COMMON_COLUMNS},
+          operation_key_bundle_generation_id, operation_key_bundle_format,
+          operation_key_bundle_ref, operation_key_bundle_ciphertext_base64,
+          operation_key_bundle_sha256, operation_key_bundle_size_bytes,
+          operation_key_bundle_context, operation_key_bundle_context_derivation,
+          operation_key_bundle_local_receipt_derivation,
+          operation_key_bundle_local_receipt_digest, vault_key_generation_id,
+          vault_key_authority_receipt_digest)
+        VALUES (${commonCapturedValues("00000000-0000-4000-8000-000000000012", 3)},
+          '${KEY_GENERATION_ID}', 'kms-aead-operation-key-bundle-v1',
+          'backup-key-bundle:${OPERATION_ID}', '${KEY_BUNDLE_BASE64}', '${SHA}', 92,
+          '{"context":"exact"}', 'elizaos.agent-backup.operation-key-bundle-context.v1',
+          'elizaos.kms-aead-operation-key-bundle.local-receipt.v1', '${SHA}',
+          '${VAULT_GENERATION_ID}', '${SHA}');
+
+        INSERT INTO agent_sandbox_backups (
+          id, backup_operation_id, catalog_version, catalog_state
+        ) VALUES ('00000000-0000-4000-8000-000000000013', '${OPERATION_ID}', 2, 'scheduled');
+      `);
+
+      const rows = await database.query<{ manifest_version: number | null }>(`
+        SELECT manifest_version FROM agent_sandbox_backups ORDER BY id
+      `);
+      expect(rows.rows).toEqual([
+        { manifest_version: 2 },
+        { manifest_version: 3 },
+        { manifest_version: null },
+      ]);
+      const constraint = await database.query<{ convalidated: boolean }>(`
+        SELECT convalidated FROM pg_constraint
+        WHERE conname = 'agent_sandbox_backups_catalog_manifest_shape_check'
+      `);
+      expect(constraint.rows).toEqual([{ convalidated: false }]);
+      const plaintextColumns = await database.query<{ column_name: string }>(`
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'agent_sandbox_backups'
+          AND column_name LIKE 'operation_key_bundle_plaintext%'
+      `);
+      expect(plaintextColumns.rows).toEqual([]);
+    } finally {
+      await database.close();
+    }
+  }, 60_000);
+
+  test("rejects unknown versions, partial envelopes, mixtures, and unsafe KMS versions", async () => {
+    const database = await legacyDatabase();
+    try {
+      await database.exec(COLUMNS_MIGRATION);
+      await database.exec(SHAPE_MIGRATION);
+      const invalidStatements = [
+        `INSERT INTO agent_sandbox_backups (${COMMON_COLUMNS}, wrapped_dek_ref,
+          wrapped_dek_ciphertext_base64, wrapped_dek_sha256, wrapped_dek_size_bytes,
+          wrapped_dek_receipt_digest)
+        VALUES (${commonCapturedValues("00000000-0000-4000-8000-000000000021", 4)},
+          'backup-dek:${OPERATION_ID}', 'Qg==', '${SHA}', 1, '${SHA}')`,
+        `INSERT INTO agent_sandbox_backups (${COMMON_COLUMNS}, wrapped_dek_ref,
+          wrapped_dek_ciphertext_base64, wrapped_dek_sha256, wrapped_dek_size_bytes,
+          wrapped_dek_receipt_digest, operation_key_bundle_generation_id)
+        VALUES (${commonCapturedValues("00000000-0000-4000-8000-000000000022", 2)},
+          'backup-dek:${OPERATION_ID}', 'Qg==', '${SHA}', 1, '${SHA}',
+          '${KEY_GENERATION_ID}')`,
+        `INSERT INTO agent_sandbox_backups (${COMMON_COLUMNS}, wrapped_dek_ref,
+          operation_key_bundle_generation_id, operation_key_bundle_format,
+          operation_key_bundle_ref, operation_key_bundle_ciphertext_base64,
+          operation_key_bundle_sha256, operation_key_bundle_size_bytes,
+          operation_key_bundle_context, operation_key_bundle_context_derivation,
+          operation_key_bundle_local_receipt_derivation,
+          operation_key_bundle_local_receipt_digest, vault_key_generation_id,
+          vault_key_authority_receipt_digest)
+        VALUES (${commonCapturedValues("00000000-0000-4000-8000-000000000023", 3)},
+          'mixed-v2-envelope', '${KEY_GENERATION_ID}', 'kms-aead-operation-key-bundle-v1',
+          'backup-key-bundle:${OPERATION_ID}', '${KEY_BUNDLE_BASE64}', '${SHA}', 92, '{}',
+          'elizaos.agent-backup.operation-key-bundle-context.v1',
+          'elizaos.kms-aead-operation-key-bundle.local-receipt.v1', '${SHA}',
+          '${VAULT_GENERATION_ID}', '${SHA}')`,
+        `INSERT INTO agent_sandbox_backups (
+          id, backup_operation_id, catalog_version, catalog_state, manifest_version
+        ) VALUES ('00000000-0000-4000-8000-000000000024', '${OPERATION_ID}', 2,
+          'scheduled', 3)`,
+        `INSERT INTO agent_sandbox_backups (${COMMON_COLUMNS},
+          operation_key_bundle_generation_id, operation_key_bundle_format,
+          operation_key_bundle_ref, operation_key_bundle_ciphertext_base64,
+          operation_key_bundle_sha256, operation_key_bundle_size_bytes,
+          operation_key_bundle_context, operation_key_bundle_context_derivation,
+          operation_key_bundle_local_receipt_derivation,
+          operation_key_bundle_local_receipt_digest)
+        VALUES (${commonCapturedValues("00000000-0000-4000-8000-000000000025", 3)},
+          '${KEY_GENERATION_ID}', 'kms-aead-operation-key-bundle-v1',
+          'backup-key-bundle:${OPERATION_ID}', '${KEY_BUNDLE_BASE64}', '${SHA}', 92, '{}',
+          'elizaos.agent-backup.operation-key-bundle-context.v1',
+          'elizaos.kms-aead-operation-key-bundle.local-receipt.v1', '${SHA}')`,
+        `INSERT INTO agent_sandbox_backups (${COMMON_COLUMNS}, wrapped_dek_ref,
+          wrapped_dek_ciphertext_base64, wrapped_dek_sha256, wrapped_dek_size_bytes,
+          wrapped_dek_receipt_digest)
+        VALUES (${commonCapturedValues(
+          "00000000-0000-4000-8000-000000000026",
+          2,
+          "9007199254740992",
+        )}, 'backup-dek:${OPERATION_ID}', 'Qg==', '${SHA}', 1, '${SHA}')`,
+      ];
+      for (const statement of invalidStatements) {
+        await expect(database.exec(statement)).rejects.toThrow(
+          /agent_sandbox_backups_catalog_manifest_shape_check/,
+        );
+      }
+    } finally {
+      await database.close();
+    }
+  }, 60_000);
+});

--- a/packages/cloud/shared/src/db/agent-backup-rpo-scheduler-migration.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-rpo-scheduler-migration.test.ts
@@ -1,0 +1,146 @@
+/** Fresh, legacy-upgrade, replay, and lifecycle-scope proofs for migration 0235. */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+
+const MIGRATIONS_DIR = join(import.meta.dir, "migrations");
+const MIGRATION = readFileSync(join(MIGRATIONS_DIR, "0235_agent_backup_rpo_scheduler.sql"), "utf8");
+const ORG = "00000000-0000-4000-8000-00000000e001";
+const AGENT = "00000000-0000-4000-8000-00000000e002";
+const OPERATION = "00000000-0000-4000-8000-00000000e003";
+const GENERATION = "00000000-0000-4000-8000-00000000e004";
+
+async function databaseWithAgentTable(seedLegacy: boolean): Promise<PGlite> {
+  const database = new PGlite();
+  await database.exec(`
+    CREATE TABLE agent_sandboxes (
+      id uuid PRIMARY KEY,
+      organization_id uuid NOT NULL,
+      legacy_marker text,
+      lifecycle_revision bigint NOT NULL DEFAULT 0
+    );
+    CREATE OR REPLACE FUNCTION advance_agent_sandbox_lifecycle_revision()
+    RETURNS trigger LANGUAGE plpgsql AS $$
+    BEGIN
+      NEW.lifecycle_revision := OLD.lifecycle_revision + 1;
+      RETURN NEW;
+    END;
+    $$;
+    CREATE TRIGGER agent_sandboxes_lifecycle_revision_trigger
+    BEFORE UPDATE ON agent_sandboxes FOR EACH ROW
+    EXECUTE FUNCTION advance_agent_sandbox_lifecycle_revision();
+    ${
+      seedLegacy
+        ? `INSERT INTO agent_sandboxes (id, organization_id, legacy_marker)
+           VALUES ('${AGENT}', '${ORG}', 'preserve-me');`
+        : ""
+    }
+  `);
+  return database;
+}
+
+describe("0235 agent backup RPO scheduler migration", () => {
+  test("installs a fresh scheduler schema and replays idempotently", async () => {
+    const database = await databaseWithAgentTable(false);
+    try {
+      await database.exec(MIGRATION);
+      await database.exec(MIGRATION);
+      await database.exec(`
+        INSERT INTO agent_sandboxes (
+          id, organization_id, next_backup_at, backup_schedule_operation_id,
+          backup_schedule_claim_owner, backup_schedule_claim_generation,
+          backup_schedule_claim_expires_at
+        ) VALUES (
+          '${AGENT}', '${ORG}', NOW(), '${OPERATION}', 'scheduler-a',
+          '${GENERATION}', NOW() + INTERVAL '2 minutes'
+        )
+      `);
+
+      const row = await database.query<{
+        attempts: number;
+        retry_at: Date | null;
+        last_protected_at: Date | null;
+      }>(`SELECT backup_schedule_attempts AS attempts,
+          backup_schedule_retry_at AS retry_at,
+          backup_schedule_last_protected_at AS last_protected_at
+        FROM agent_sandboxes WHERE id = '${AGENT}'`);
+      expect(row.rows).toEqual([{ attempts: 0, retry_at: null, last_protected_at: null }]);
+
+      const indexes = await database.query<{ indexname: string }>(`
+        SELECT indexname FROM pg_indexes
+        WHERE tablename = 'agent_sandboxes'
+          AND indexname LIKE 'agent_sandboxes_backup_schedule_%_idx'
+        ORDER BY indexname
+      `);
+      expect(indexes.rows.map(({ indexname }) => indexname)).toEqual([
+        "agent_sandboxes_backup_schedule_claim_expiry_idx",
+        "agent_sandboxes_backup_schedule_due_idx",
+        "agent_sandboxes_backup_schedule_operation_idx",
+      ]);
+    } finally {
+      await database.close();
+    }
+  }, 60_000);
+
+  test("preserves legacy rows and excludes scheduler writes from lifecycle revisions", async () => {
+    const database = await databaseWithAgentTable(true);
+    try {
+      await database.exec(MIGRATION);
+      const legacy = await database.query<{
+        legacy_marker: string;
+        next_backup_at: Date | null;
+        attempts: number;
+        lifecycle_revision: number | string;
+      }>(`SELECT legacy_marker, next_backup_at,
+          backup_schedule_attempts AS attempts, lifecycle_revision
+        FROM agent_sandboxes WHERE id = '${AGENT}'`);
+      expect(legacy.rows).toEqual([
+        {
+          legacy_marker: "preserve-me",
+          next_backup_at: null,
+          attempts: 0,
+          lifecycle_revision: 0,
+        },
+      ]);
+
+      await database.exec(`UPDATE agent_sandboxes SET next_backup_at = NOW()
+        WHERE id = '${AGENT}'`);
+      const schedulerRevision = await database.query<{ lifecycle_revision: number | string }>(`
+        SELECT lifecycle_revision FROM agent_sandboxes WHERE id = '${AGENT}'
+      `);
+      expect(Number(schedulerRevision.rows[0]?.lifecycle_revision)).toBe(0);
+      await database.exec(`UPDATE agent_sandboxes SET legacy_marker = 'lifecycle-write'
+        WHERE id = '${AGENT}'`);
+      const lifecycleRevision = await database.query<{ lifecycle_revision: number | string }>(`
+        SELECT lifecycle_revision FROM agent_sandboxes WHERE id = '${AGENT}'
+      `);
+      expect(Number(lifecycleRevision.rows[0]?.lifecycle_revision)).toBe(1);
+    } finally {
+      await database.close();
+    }
+  }, 60_000);
+
+  test("rejects partial leases, negative attempts, and non-canonical error codes", async () => {
+    const database = await databaseWithAgentTable(true);
+    try {
+      await database.exec(MIGRATION);
+      for (const statement of [
+        `UPDATE agent_sandboxes SET backup_schedule_claim_owner = 'partial-owner'
+          WHERE id = '${AGENT}'`,
+        `UPDATE agent_sandboxes SET backup_schedule_attempts = -1 WHERE id = '${AGENT}'`,
+        `UPDATE agent_sandboxes SET backup_schedule_last_error_code = '${"X".repeat(97)}'
+          WHERE id = '${AGENT}'`,
+        `UPDATE agent_sandboxes SET backup_schedule_last_error_code = 'not_canonical'
+          WHERE id = '${AGENT}'`,
+      ]) {
+        await expect(database.exec(statement)).rejects.toThrow(
+          /agent_sandboxes_backup_schedule_(claim_shape|attempts)_check/,
+        );
+      }
+    } finally {
+      await database.close();
+    }
+  }, 60_000);
+});

--- a/packages/cloud/shared/src/db/agent-backup-source-authority-migration.test.ts
+++ b/packages/cloud/shared/src/db/agent-backup-source-authority-migration.test.ts
@@ -1,0 +1,200 @@
+/** Replay and fail-closed shape proofs for source-authority migrations 0231 and 0232. */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { PGlite } from "@electric-sql/pglite";
+
+const MIGRATIONS_DIR = join(import.meta.dir, "migrations");
+const NODE_MIGRATION = readFileSync(
+  join(MIGRATIONS_DIR, "0231_agent_backup_docker_source_authority.sql"),
+  "utf8",
+);
+const CATALOG_MIGRATION = readFileSync(
+  join(MIGRATIONS_DIR, "0232_agent_backup_catalog_source_authority.sql"),
+  "utf8",
+);
+const ROBOT_ID = "00000000-0000-4000-8000-000000000001";
+const CLOUD_ID = "00000000-0000-4000-8000-000000000002";
+const ROBOT_BOOT_ID = "00000000-0000-4000-8000-000000000011";
+const CLOUD_BOOT_ID = "00000000-0000-4000-8000-000000000012";
+
+async function legacyDatabase(): Promise<PGlite> {
+  const database = new PGlite();
+  await database.exec(`
+    CREATE TABLE docker_nodes (
+      id uuid PRIMARY KEY,
+      node_id text NOT NULL UNIQUE,
+      host_key_fingerprint text,
+      metadata jsonb NOT NULL DEFAULT '{}'::jsonb
+    );
+    CREATE TABLE agent_sandbox_backups (
+      id uuid PRIMARY KEY,
+      catalog_version integer,
+      source_provider text,
+      retention_reason text,
+      retention_until timestamp with time zone
+    );
+  `);
+  return database;
+}
+
+describe("0231/0232 agent backup source-authority migrations", () => {
+  test("replays without promoting metadata-shaped legacy rows", async () => {
+    const database = await legacyDatabase();
+    try {
+      await database.exec(`
+        INSERT INTO docker_nodes (id, node_id, metadata) VALUES
+          ('${ROBOT_ID}', 'robot-old', '{"provider":"operator-onboarded"}'),
+          ('${CLOUD_ID}', 'cloud-old', '{"provider":"hetzner-cloud","hcloudServerId":4242}');
+        INSERT INTO agent_sandbox_backups (id, catalog_version, source_provider)
+          VALUES ('00000000-0000-4000-8000-000000000003', 2, 'hetzner-cloud');
+      `);
+
+      await database.exec(NODE_MIGRATION);
+      await database.exec(CATALOG_MIGRATION);
+      await database.exec(NODE_MIGRATION);
+      await database.exec(CATALOG_MIGRATION);
+
+      const nodes = await database.query<{
+        fleet_kind: string | null;
+        infrastructure_provider: string | null;
+        provider_server_id: string | null;
+        node_incarnation: string | null;
+      }>(`SELECT fleet_kind, infrastructure_provider, provider_server_id, node_incarnation
+          FROM docker_nodes ORDER BY node_id`);
+      expect(nodes.rows).toEqual([
+        {
+          fleet_kind: null,
+          infrastructure_provider: null,
+          provider_server_id: null,
+          node_incarnation: null,
+        },
+        {
+          fleet_kind: null,
+          infrastructure_provider: null,
+          provider_server_id: null,
+          node_incarnation: null,
+        },
+      ]);
+
+      const backup = await database.query<{
+        source_node_incarnation: string | null;
+        source_provider_server_id: string | null;
+      }>(`SELECT source_node_incarnation, source_provider_server_id
+          FROM agent_sandbox_backups`);
+      expect(backup.rows).toEqual([
+        { source_node_incarnation: null, source_provider_server_id: null },
+      ]);
+    } finally {
+      await database.close();
+    }
+  }, 60_000);
+
+  test("accepts exact Robot/Cloud rows and rejects ambiguous authorities", async () => {
+    const database = await legacyDatabase();
+    try {
+      await database.exec(NODE_MIGRATION);
+      await database.exec(CATALOG_MIGRATION);
+      await database.exec(`
+        INSERT INTO docker_nodes (
+          id, node_id, fleet_kind, infrastructure_provider,
+          provider_server_id, node_incarnation, host_key_fingerprint
+        ) VALUES
+          ('${ROBOT_ID}', 'robot-exact', 'robot', 'hetzner', NULL,
+            '${ROBOT_BOOT_ID}', 'robot-host-key'),
+          ('${CLOUD_ID}', 'cloud-exact', 'cloud', 'hetzner', '4242',
+            '${CLOUD_BOOT_ID}', 'cloud-host-key');
+        INSERT INTO agent_sandbox_backups (
+          id, catalog_version, source_provider, source_node_record_id, source_node_id,
+          source_node_incarnation, source_provider_server_id, source_provider_handle,
+          source_container_id, retention_reason, retention_until
+        ) VALUES
+          ('00000000-0000-4000-8000-000000000021', 2, 'operator-onboarded',
+            '${ROBOT_ID}', 'robot-exact', '${ROBOT_BOOT_ID}', NULL, 'agent-a',
+            '${"a".repeat(64)}', 'schedule', NOW() + INTERVAL '1 day'),
+          ('00000000-0000-4000-8000-000000000022', 2, 'hetzner-cloud',
+            '${CLOUD_ID}', 'cloud-exact', '${CLOUD_BOOT_ID}', '4242', 'agent-b',
+            '${"b".repeat(64)}', 'schedule', NOW() + INTERVAL '1 day');
+      `);
+
+      for (const statement of [
+        `INSERT INTO agent_sandbox_backups (id, catalog_version)
+          VALUES ('00000000-0000-4000-8000-000000000030', 2)`,
+        `INSERT INTO docker_nodes (id, node_id, fleet_kind, infrastructure_provider)
+          VALUES ('00000000-0000-4000-8000-000000000031', 'cloud-no-server', 'cloud', 'hetzner')`,
+        `INSERT INTO docker_nodes (
+          id, node_id, fleet_kind, infrastructure_provider, provider_server_id
+        ) VALUES ('00000000-0000-4000-8000-000000000032', 'robot-with-server',
+          'robot', 'hetzner', '99')`,
+        `INSERT INTO docker_nodes (
+          id, node_id, fleet_kind, infrastructure_provider, provider_server_id
+        ) VALUES ('00000000-0000-4000-8000-000000000033', 'cloud-overflow',
+          'cloud', 'hetzner', '18446744073709551616')`,
+        `INSERT INTO agent_sandbox_backups (
+          id, catalog_version, source_provider, source_node_record_id, source_node_id,
+          source_node_incarnation, source_provider_server_id, source_provider_handle,
+          source_container_id, retention_reason, retention_until
+        ) VALUES ('00000000-0000-4000-8000-000000000034', 2, 'hetzner-cloud',
+          '${CLOUD_ID}', 'cloud-exact', '${CLOUD_BOOT_ID}', '18446744073709551616',
+          'agent-c', '${"c".repeat(64)}', 'schedule', NOW() + INTERVAL '1 day')`,
+        `INSERT INTO agent_sandbox_backups (
+          id, catalog_version, source_provider, source_node_record_id, source_node_id,
+          source_node_incarnation, source_provider_handle, source_container_id,
+          retention_reason, retention_until
+        ) VALUES ('00000000-0000-4000-8000-000000000035', 2, 'operator-onboarded',
+          '${ROBOT_ID}', '   ', '${ROBOT_BOOT_ID}', 'agent-d', '${"d".repeat(64)}',
+          'schedule', NOW() + INTERVAL '1 day')`,
+      ]) {
+        await expect(database.exec(statement)).rejects.toThrow(
+          /source_authority|source_check|shape/,
+        );
+      }
+
+      const rolloutConstraints = await database.query<{ conname: string; convalidated: boolean }>(`
+        SELECT conname, convalidated FROM pg_constraint
+        WHERE conname IN (
+          'agent_sandbox_backups_catalog_v2_source_check',
+          'agent_sandbox_backups_catalog_v2_source_authority_check'
+        ) ORDER BY conname
+      `);
+      expect(rolloutConstraints.rows).toEqual([
+        {
+          conname: "agent_sandbox_backups_catalog_v2_source_authority_check",
+          convalidated: false,
+        },
+        { conname: "agent_sandbox_backups_catalog_v2_source_check", convalidated: false },
+      ]);
+    } finally {
+      await database.close();
+    }
+  }, 60_000);
+
+  test("keeps provider server ids and boot incarnations globally unique", async () => {
+    const database = await legacyDatabase();
+    try {
+      await database.exec(NODE_MIGRATION);
+      await database.exec(`INSERT INTO docker_nodes (
+        id, node_id, fleet_kind, infrastructure_provider, provider_server_id,
+        node_incarnation, host_key_fingerprint
+      ) VALUES ('${CLOUD_ID}', 'cloud-exact', 'cloud', 'hetzner', '4242',
+        '${CLOUD_BOOT_ID}', 'cloud-host-key')`);
+
+      await expect(
+        database.exec(`INSERT INTO docker_nodes (
+          id, node_id, fleet_kind, infrastructure_provider, provider_server_id
+        ) VALUES ('00000000-0000-4000-8000-000000000041', 'duplicate-server',
+          'cloud', 'hetzner', '4242')`),
+      ).rejects.toThrow(/docker_nodes_provider_server_uidx/);
+      await expect(
+        database.exec(`INSERT INTO docker_nodes (
+          id, node_id, fleet_kind, infrastructure_provider, node_incarnation,
+          host_key_fingerprint
+        ) VALUES ('00000000-0000-4000-8000-000000000042', 'duplicate-boot',
+          'robot', 'hetzner', '${CLOUD_BOOT_ID}', 'robot-host-key')`),
+      ).rejects.toThrow(/docker_nodes_node_incarnation_uidx/);
+    } finally {
+      await database.close();
+    }
+  }, 60_000);
+});

--- a/packages/cloud/shared/src/db/migration-journal-registration.test.ts
+++ b/packages/cloud/shared/src/db/migration-journal-registration.test.ts
@@ -70,18 +70,18 @@ describe("migrations/meta/_journal.json registration", () => {
 
   test("the catalogue and capture stack is registered in strict deployment order", () => {
     const tags = [
-      "0212_agent_backup_catalog_columns",
-      "0213_agent_backup_catalog_legacy_backfill",
-      "0214_agent_backup_catalog_authority",
-      "0215_agent_backup_catalog_ownership_fks",
-      "0216_agent_backup_catalog_identity_checks",
-      "0217_agent_backup_catalog_runtime_checks",
-      "0218_agent_backup_catalog_manifest_v2_check",
-      "0219_agent_backup_catalog_indexes",
-      "0220_agent_backup_objects",
-      "0221_agent_backup_gc_outbox",
-      "0222_agent_backup_catalog_tenant_authority",
-      "0223_agent_backup_catalog_chain_authority",
+      "0218_agent_backup_catalog_columns",
+      "0219_agent_backup_catalog_legacy_backfill",
+      "0220_agent_backup_catalog_authority",
+      "0221_agent_backup_catalog_ownership_fks",
+      "0222_agent_backup_catalog_identity_checks",
+      "0223_agent_backup_catalog_runtime_checks",
+      "0224_agent_backup_catalog_manifest_v2_check",
+      "0225_agent_backup_catalog_indexes",
+      "0226_agent_backup_objects",
+      "0227_agent_backup_gc_outbox",
+      "0228_agent_backup_catalog_tenant_authority",
+      "0229_agent_backup_catalog_chain_authority",
       "0230_agent_backup_activation_authority_foundation",
       "0231_agent_backup_docker_source_authority",
       "0232_agent_backup_catalog_source_authority",
@@ -92,7 +92,7 @@ describe("migrations/meta/_journal.json registration", () => {
     const tail = journalEntries().slice(-tags.length);
 
     expect(tail.map(({ tag }) => tag)).toEqual(tags);
-    expect(tail.map(({ idx }) => idx)).toEqual(tags.map((_, offset) => 211 + offset));
+    expect(tail.map(({ idx }) => idx)).toEqual(tags.map((_, offset) => 217 + offset));
     expect(tail.map(({ when }) => when)).toEqual(
       tags.map((_, offset) => 1787947200000 + offset * 86_400_000),
     );

--- a/packages/cloud/shared/src/db/migration-journal-registration.test.ts
+++ b/packages/cloud/shared/src/db/migration-journal-registration.test.ts
@@ -67,4 +67,47 @@ describe("migrations/meta/_journal.json registration", () => {
     expect(entries.map((e) => e.idx)).toEqual(entries.map((_, i) => i));
     expect(new Set(entries.map((e) => e.tag)).size).toBe(entries.length);
   });
+
+  test("the catalogue and capture stack is registered in strict deployment order", () => {
+    const tags = [
+      "0212_agent_backup_catalog_columns",
+      "0213_agent_backup_catalog_legacy_backfill",
+      "0214_agent_backup_catalog_authority",
+      "0215_agent_backup_catalog_ownership_fks",
+      "0216_agent_backup_catalog_identity_checks",
+      "0217_agent_backup_catalog_runtime_checks",
+      "0218_agent_backup_catalog_manifest_v2_check",
+      "0219_agent_backup_catalog_indexes",
+      "0220_agent_backup_objects",
+      "0221_agent_backup_gc_outbox",
+      "0222_agent_backup_catalog_tenant_authority",
+      "0223_agent_backup_catalog_chain_authority",
+      "0230_agent_backup_activation_authority_foundation",
+      "0231_agent_backup_docker_source_authority",
+      "0232_agent_backup_catalog_source_authority",
+      "0233_agent_backup_catalog_manifest_v3_columns",
+      "0234_agent_backup_catalog_manifest_v3_shape",
+      "0235_agent_backup_rpo_scheduler",
+    ];
+    const tail = journalEntries().slice(-tags.length);
+
+    expect(tail.map(({ tag }) => tag)).toEqual(tags);
+    expect(tail.map(({ idx }) => idx)).toEqual(tags.map((_, offset) => 211 + offset));
+    expect(tail.map(({ when }) => when)).toEqual(
+      tags.map((_, offset) => 1787947200000 + offset * 86_400_000),
+    );
+  });
+
+  test("each capture migration remains below the review-size ceiling", () => {
+    const captureTags = journalEntries()
+      .filter(({ idx }) => idx >= 223 && idx <= 228)
+      .map(({ tag }) => tag);
+
+    for (const tag of captureTags) {
+      const source = readFileSync(join(MIGRATIONS_DIR, `${tag}.sql`), "utf8");
+      expect(source.split(/\r?\n/).length, `${tag}.sql must stay below 100 lines`).toBeLessThan(
+        100,
+      );
+    }
+  });
 });

--- a/packages/cloud/shared/src/db/migrations/0230_agent_backup_activation_authority_foundation.sql
+++ b/packages/cloud/shared/src/db/migrations/0230_agent_backup_activation_authority_foundation.sql
@@ -1,0 +1,67 @@
+-- Nullable, fail-closed activation authority consumed by backup capture and RPO admission.
+-- Restore adds intermediate quarantine phases in a later migration; this slice accepts only
+-- legacy all-null rows or one fully published active generation.
+-- The lifecycle copy is signed int64 because its source column is PostgreSQL bigint.
+
+ALTER TABLE "agent_sandboxes"
+  ADD COLUMN IF NOT EXISTS "activation_generation" uuid,
+  ADD COLUMN IF NOT EXISTS "activation_lifecycle_revision" bigint,
+  ADD COLUMN IF NOT EXISTS "activation_phase" text,
+  ADD COLUMN IF NOT EXISTS "activation_receipt_hash" text,
+  ADD COLUMN IF NOT EXISTS "activation_container_id" text,
+  ADD COLUMN IF NOT EXISTS "activation_node_id" text,
+  ADD COLUMN IF NOT EXISTS "activation_image_digest" text,
+  ADD COLUMN IF NOT EXISTS "activation_boot_id" uuid,
+  ADD COLUMN IF NOT EXISTS "activation_authority_published_at" timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS "activation_dispatched_at" timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS "activation_completed_at" timestamp with time zone;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_sandboxes_activation_generation_idx"
+  ON "agent_sandboxes" ("activation_generation")
+  WHERE "activation_generation" IS NOT NULL;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'agent_sandboxes_activation_state_check'
+      AND conrelid = 'agent_sandboxes'::regclass
+  ) THEN
+    ALTER TABLE "agent_sandboxes" ADD CONSTRAINT
+      "agent_sandboxes_activation_state_check" CHECK (((
+        "activation_generation" IS NULL
+        AND "activation_lifecycle_revision" IS NULL
+        AND "activation_phase" IS NULL
+        AND "activation_receipt_hash" IS NULL
+        AND "activation_container_id" IS NULL
+        AND "activation_node_id" IS NULL
+        AND "activation_image_digest" IS NULL
+        AND "activation_boot_id" IS NULL
+        AND "activation_authority_published_at" IS NULL
+        AND "activation_dispatched_at" IS NULL
+        AND "activation_completed_at" IS NULL
+      ) OR (
+        "activation_generation" IS NOT NULL
+        AND "activation_lifecycle_revision" IS NOT NULL
+        AND "activation_lifecycle_revision" >= 0
+        AND "activation_lifecycle_revision" = "lifecycle_revision"
+        AND "activation_phase" = 'active'
+        AND "activation_receipt_hash" ~ '^[0-9a-f]{64}$'
+        AND "activation_container_id" ~ '^[0-9a-f]{64}$'
+        AND "sandbox_id" IS NOT NULL
+        AND "activation_container_id" <> "sandbox_id"
+        AND "activation_node_id" IS NOT NULL AND btrim("activation_node_id") <> ''
+        AND "activation_node_id" = "node_id"
+        AND "activation_image_digest" ~ '^sha256:[0-9a-f]{64}$'
+        AND "activation_image_digest" = "image_digest"
+        AND "activation_boot_id" IS NOT NULL
+        AND "activation_authority_published_at" IS NOT NULL
+        AND "activation_dispatched_at" IS NOT NULL
+        AND "activation_completed_at" IS NOT NULL
+        AND "activation_authority_published_at" <= "activation_dispatched_at"
+        AND "activation_dispatched_at" <= "activation_completed_at"
+      )) IS TRUE) NOT VALID;
+  END IF;
+END $$;
+--> statement-breakpoint
+ALTER TABLE "agent_sandboxes"
+  VALIDATE CONSTRAINT "agent_sandboxes_activation_state_check";

--- a/packages/cloud/shared/src/db/migrations/0231_agent_backup_docker_source_authority.sql
+++ b/packages/cloud/shared/src/db/migrations/0231_agent_backup_docker_source_authority.sql
@@ -1,0 +1,53 @@
+-- Typed Robot/Cloud source identity. Existing weak node registrations remain all-null and
+-- therefore ineligible for manifest-v3 capture until host-key-verified attestation completes.
+
+ALTER TABLE "docker_nodes"
+  ADD COLUMN IF NOT EXISTS "fleet_kind" text,
+  ADD COLUMN IF NOT EXISTS "infrastructure_provider" text,
+  ADD COLUMN IF NOT EXISTS "provider_server_id" text,
+  ADD COLUMN IF NOT EXISTS "node_incarnation" uuid;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "docker_nodes_provider_server_uidx"
+  ON "docker_nodes" ("infrastructure_provider", "provider_server_id")
+  WHERE "provider_server_id" IS NOT NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "docker_nodes_node_incarnation_uidx"
+  ON "docker_nodes" ("node_incarnation")
+  WHERE "node_incarnation" IS NOT NULL;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'docker_nodes_backup_source_authority_shape_check'
+      AND conrelid = 'docker_nodes'::regclass
+  ) THEN
+    ALTER TABLE "docker_nodes" ADD CONSTRAINT
+      "docker_nodes_backup_source_authority_shape_check" CHECK (((
+        "fleet_kind" IS NULL
+        AND "infrastructure_provider" IS NULL
+        AND "provider_server_id" IS NULL
+        AND "node_incarnation" IS NULL
+      ) OR (
+        "infrastructure_provider" = 'hetzner'
+        AND ("node_incarnation" IS NULL OR (
+          "host_key_fingerprint" IS NOT NULL
+          AND btrim("host_key_fingerprint") <> ''
+        ))
+        AND (
+          ("fleet_kind" = 'robot' AND "provider_server_id" IS NULL)
+          OR (
+            "fleet_kind" = 'cloud'
+            AND "provider_server_id" IS NOT NULL
+            AND CASE
+              WHEN "provider_server_id" ~ '^[1-9][0-9]{0,19}$'
+                THEN "provider_server_id"::numeric <= 18446744073709551615
+              ELSE false
+            END
+          )
+        )
+      )) IS TRUE) NOT VALID;
+  END IF;
+END $$;
+--> statement-breakpoint
+ALTER TABLE "docker_nodes"
+  VALIDATE CONSTRAINT "docker_nodes_backup_source_authority_shape_check";

--- a/packages/cloud/shared/src/db/migrations/0232_agent_backup_catalog_source_authority.sql
+++ b/packages/cloud/shared/src/db/migrations/0232_agent_backup_catalog_source_authority.sql
@@ -1,0 +1,53 @@
+-- Bind each new catalogue row to a typed node boot and immutable Docker container id.
+
+ALTER TABLE "agent_sandbox_backups"
+  ADD COLUMN IF NOT EXISTS "source_provider" text,
+  ADD COLUMN IF NOT EXISTS "source_node_record_id" uuid,
+  ADD COLUMN IF NOT EXISTS "source_node_id" text,
+  ADD COLUMN IF NOT EXISTS "source_node_incarnation" uuid,
+  ADD COLUMN IF NOT EXISTS "source_provider_server_id" text,
+  ADD COLUMN IF NOT EXISTS "source_provider_handle" text,
+  ADD COLUMN IF NOT EXISTS "source_container_id" text;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'agent_sandbox_backups_catalog_v2_source_check'
+      AND conrelid = 'agent_sandbox_backups'::regclass
+  ) THEN
+    ALTER TABLE "agent_sandbox_backups" ADD CONSTRAINT
+      "agent_sandbox_backups_catalog_v2_source_check" CHECK ((
+        "catalog_version" IS DISTINCT FROM 2 OR (
+          "source_provider" IN ('operator-onboarded', 'hetzner-cloud')
+          AND "source_node_record_id" IS NOT NULL
+          AND "source_node_id" IS NOT NULL AND btrim("source_node_id") <> ''
+          AND "source_provider_handle" IS NOT NULL AND btrim("source_provider_handle") <> ''
+          AND "source_container_id" ~ '^[0-9a-f]{64}$'
+          AND "source_provider_handle" <> "source_container_id"
+          AND "retention_reason" IS NOT NULL AND "retention_until" IS NOT NULL
+        )
+      ) IS TRUE) NOT VALID;
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'agent_sandbox_backups_catalog_v2_source_authority_check'
+      AND conrelid = 'agent_sandbox_backups'::regclass
+  ) THEN
+    ALTER TABLE "agent_sandbox_backups" ADD CONSTRAINT
+      "agent_sandbox_backups_catalog_v2_source_authority_check" CHECK ((
+        "catalog_version" IS DISTINCT FROM 2 OR (
+          "source_node_incarnation" IS NOT NULL
+          AND (
+            ("source_provider" = 'operator-onboarded'
+              AND "source_provider_server_id" IS NULL)
+            OR ("source_provider" = 'hetzner-cloud'
+              AND "source_provider_server_id" ~ '^[1-9][0-9]{0,19}$'
+              AND "source_provider_server_id"::numeric <= 18446744073709551615)
+          )
+        )
+      ) IS TRUE) NOT VALID;
+  END IF;
+END $$;

--- a/packages/cloud/shared/src/db/migrations/0233_agent_backup_catalog_manifest_v3_columns.sql
+++ b/packages/cloud/shared/src/db/migrations/0233_agent_backup_catalog_manifest_v3_columns.sql
@@ -1,0 +1,16 @@
+-- Persist manifest-v3's atomic operation-key envelope and authenticated vault pointer.
+-- Vault authority tables arrive with restore; these scalar receipt fields fail closed today.
+
+ALTER TABLE "agent_sandbox_backups"
+  ADD COLUMN IF NOT EXISTS "operation_key_bundle_generation_id" uuid,
+  ADD COLUMN IF NOT EXISTS "operation_key_bundle_format" text,
+  ADD COLUMN IF NOT EXISTS "operation_key_bundle_ref" text,
+  ADD COLUMN IF NOT EXISTS "operation_key_bundle_ciphertext_base64" text,
+  ADD COLUMN IF NOT EXISTS "operation_key_bundle_sha256" text,
+  ADD COLUMN IF NOT EXISTS "operation_key_bundle_size_bytes" integer,
+  ADD COLUMN IF NOT EXISTS "operation_key_bundle_context" text,
+  ADD COLUMN IF NOT EXISTS "operation_key_bundle_context_derivation" text,
+  ADD COLUMN IF NOT EXISTS "operation_key_bundle_local_receipt_derivation" text,
+  ADD COLUMN IF NOT EXISTS "operation_key_bundle_local_receipt_digest" text,
+  ADD COLUMN IF NOT EXISTS "vault_key_generation_id" uuid,
+  ADD COLUMN IF NOT EXISTS "vault_key_authority_receipt_digest" text;

--- a/packages/cloud/shared/src/db/migrations/0234_agent_backup_catalog_manifest_v3_shape.sql
+++ b/packages/cloud/shared/src/db/migrations/0234_agent_backup_catalog_manifest_v3_shape.sql
@@ -1,0 +1,79 @@
+-- Enforce mutually exclusive v2 wrapped-DEK and v3 operation-key/vault shapes.
+-- NOT VALID preserves rollout compatibility while every new or updated row is checked.
+
+ALTER TABLE "agent_sandbox_backups"
+  DROP CONSTRAINT IF EXISTS "agent_sandbox_backups_catalog_manifest_shape_check";
+--> statement-breakpoint
+ALTER TABLE "agent_sandbox_backups" ADD CONSTRAINT
+  "agent_sandbox_backups_catalog_manifest_shape_check" CHECK ((
+  "catalog_version" IS DISTINCT FROM 2 OR (
+    (("catalog_state" IN ('scheduled', 'capturing') OR
+      ("catalog_state" IN ('failed_retryable', 'failed_terminal') AND
+       "catalog_resume_state" IN ('scheduled', 'capturing'))) AND num_nonnulls(
+      "manifest_format", "manifest_version", "manifest_digest", "manifest_canonical_draft",
+      "manifest_object_count", "object_inventory_digest", "backup_image_digest",
+      "database_schema_version", "plugin_set_digest", "watermark_digest", "raw_size_bytes",
+      "compressed_size_bytes", "encrypted_size_bytes", "backup_kms_key_id",
+      "backup_kms_key_version", "wrapped_dek_ref", "wrapped_dek_ciphertext_base64",
+      "wrapped_dek_sha256", "wrapped_dek_size_bytes", "wrapped_dek_receipt_digest",
+      "operation_key_bundle_generation_id", "operation_key_bundle_format",
+      "operation_key_bundle_ref", "operation_key_bundle_ciphertext_base64",
+      "operation_key_bundle_sha256", "operation_key_bundle_size_bytes",
+      "operation_key_bundle_context", "operation_key_bundle_context_derivation",
+      "operation_key_bundle_local_receipt_derivation",
+      "operation_key_bundle_local_receipt_digest", "vault_key_generation_id",
+      "vault_key_authority_receipt_digest") = 0)
+    OR (("catalog_state" IN ('captured', 'uploading', 'primary_uploaded', 'primary_verified',
+      'secondary_pending', 'protected', 'retained', 'expiration_pending', 'deleting', 'deleted',
+      'restore_verified') OR ("catalog_state" IN ('failed_retryable', 'failed_terminal') AND
+      "catalog_resume_state" IN ('captured', 'uploading', 'primary_uploaded', 'primary_verified',
+      'secondary_pending', 'protected', 'retained', 'expiration_pending', 'deleting',
+      'restore_verified')))
+      AND "manifest_format" = 'elizaos.agent-backup' AND "manifest_version" IN (2, 3)
+      AND "manifest_digest" ~ '^[0-9a-f]{64}$' AND "manifest_canonical_draft" IS NOT NULL
+      AND octet_length("manifest_canonical_draft") BETWEEN 1 AND 4194304
+      AND "manifest_object_count" BETWEEN 1 AND 8192
+      AND "object_inventory_digest" ~ '^[0-9a-f]{64}$'
+      AND "backup_image_digest" IS NOT NULL AND "backup_image_digest" <> ''
+      AND "database_schema_version" IS NOT NULL AND "plugin_set_digest" ~ '^[0-9a-f]{64}$'
+      AND "watermark_digest" ~ '^[0-9a-f]{64}$' AND "raw_size_bytes" IS NOT NULL
+      AND "compressed_size_bytes" IS NOT NULL AND "encrypted_size_bytes" IS NOT NULL
+      AND "backup_kms_key_id" IS NOT NULL AND "backup_kms_key_id" <> ''
+      AND "backup_kms_key_version" BETWEEN 1 AND 9007199254740991
+      AND (("manifest_version" = 2 AND num_nulls("wrapped_dek_ref",
+        "wrapped_dek_ciphertext_base64", "wrapped_dek_sha256", "wrapped_dek_size_bytes",
+        "wrapped_dek_receipt_digest") = 0 AND "wrapped_dek_ref" <> ''
+        AND octet_length("wrapped_dek_ciphertext_base64") BETWEEN 4 AND 21848
+        AND "wrapped_dek_sha256" ~ '^[0-9a-f]{64}$'
+        AND "wrapped_dek_size_bytes" BETWEEN 1 AND 16384
+        AND "wrapped_dek_receipt_digest" ~ '^[0-9a-f]{64}$' AND num_nonnulls(
+          "operation_key_bundle_generation_id", "operation_key_bundle_format",
+          "operation_key_bundle_ref", "operation_key_bundle_ciphertext_base64",
+          "operation_key_bundle_sha256", "operation_key_bundle_size_bytes",
+          "operation_key_bundle_context", "operation_key_bundle_context_derivation",
+          "operation_key_bundle_local_receipt_derivation",
+          "operation_key_bundle_local_receipt_digest", "vault_key_generation_id",
+          "vault_key_authority_receipt_digest") = 0)
+      OR ("manifest_version" = 3 AND num_nonnulls("wrapped_dek_ref",
+        "wrapped_dek_ciphertext_base64", "wrapped_dek_sha256", "wrapped_dek_size_bytes",
+        "wrapped_dek_receipt_digest") = 0 AND num_nulls(
+          "operation_key_bundle_generation_id", "operation_key_bundle_format",
+          "operation_key_bundle_ref", "operation_key_bundle_ciphertext_base64",
+          "operation_key_bundle_sha256", "operation_key_bundle_size_bytes",
+          "operation_key_bundle_context", "operation_key_bundle_context_derivation",
+          "operation_key_bundle_local_receipt_derivation",
+          "operation_key_bundle_local_receipt_digest", "vault_key_generation_id",
+          "vault_key_authority_receipt_digest") = 0
+        AND "operation_key_bundle_format" = 'kms-aead-operation-key-bundle-v1'
+        AND "operation_key_bundle_ref" = 'backup-key-bundle:' || "backup_operation_id"::text
+        AND "operation_key_bundle_ciphertext_base64" ~ '^[A-Za-z0-9+/]{123}=$'
+        AND "operation_key_bundle_sha256" ~ '^[0-9a-f]{64}$'
+        AND "operation_key_bundle_size_bytes" = 92
+        AND octet_length("operation_key_bundle_context") BETWEEN 1 AND 65536
+        AND "operation_key_bundle_context_derivation" =
+          'elizaos.agent-backup.operation-key-bundle-context.v1'
+        AND "operation_key_bundle_local_receipt_derivation" =
+          'elizaos.kms-aead-operation-key-bundle.local-receipt.v1'
+        AND "operation_key_bundle_local_receipt_digest" ~ '^[0-9a-f]{64}$'
+        AND "vault_key_authority_receipt_digest" ~ '^[0-9a-f]{64}$')))
+  )) IS TRUE) NOT VALID;

--- a/packages/cloud/shared/src/db/migrations/0235_agent_backup_rpo_scheduler.sql
+++ b/packages/cloud/shared/src/db/migrations/0235_agent_backup_rpo_scheduler.sql
@@ -1,0 +1,84 @@
+-- DB-clock scheduler authority for the 15-minute backup RPO admission lane.
+
+ALTER TABLE "agent_sandboxes"
+  ADD COLUMN IF NOT EXISTS "next_backup_at" timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS "backup_schedule_operation_id" uuid,
+  ADD COLUMN IF NOT EXISTS "backup_schedule_retry_at" timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS "backup_schedule_claim_owner" text,
+  ADD COLUMN IF NOT EXISTS "backup_schedule_claim_generation" uuid,
+  ADD COLUMN IF NOT EXISTS "backup_schedule_claim_expires_at" timestamp with time zone,
+  ADD COLUMN IF NOT EXISTS "backup_schedule_attempts" integer DEFAULT 0 NOT NULL,
+  ADD COLUMN IF NOT EXISTS "backup_schedule_last_error_code" text,
+  ADD COLUMN IF NOT EXISTS "backup_schedule_last_protected_at" timestamp with time zone;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_sandboxes_backup_schedule_due_idx"
+  ON "agent_sandboxes" ("next_backup_at", "backup_schedule_retry_at", "organization_id", "id")
+  WHERE "next_backup_at" IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_sandboxes_backup_schedule_claim_expiry_idx"
+  ON "agent_sandboxes" ("backup_schedule_claim_expires_at")
+  WHERE "backup_schedule_claim_expires_at" IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_sandboxes_backup_schedule_operation_idx"
+  ON "agent_sandboxes" ("organization_id", "id", "backup_schedule_operation_id")
+  WHERE "backup_schedule_operation_id" IS NOT NULL;
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint
+    WHERE conname = 'agent_sandboxes_backup_schedule_claim_shape_check'
+      AND conrelid = 'agent_sandboxes'::regclass) THEN
+    ALTER TABLE "agent_sandboxes" ADD CONSTRAINT
+      "agent_sandboxes_backup_schedule_claim_shape_check" CHECK (((
+        "backup_schedule_claim_owner" IS NULL
+        AND "backup_schedule_claim_generation" IS NULL
+        AND "backup_schedule_claim_expires_at" IS NULL
+      ) OR (
+        "next_backup_at" IS NOT NULL AND "backup_schedule_operation_id" IS NOT NULL
+        AND "backup_schedule_claim_owner" IS NOT NULL
+        AND "backup_schedule_claim_owner" <> ''
+        AND "backup_schedule_claim_generation" IS NOT NULL
+        AND "backup_schedule_claim_expires_at" IS NOT NULL
+      )) IS TRUE) NOT VALID;
+  END IF;
+END $$;
+--> statement-breakpoint
+ALTER TABLE "agent_sandboxes"
+  VALIDATE CONSTRAINT "agent_sandboxes_backup_schedule_claim_shape_check";
+--> statement-breakpoint
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint
+    WHERE conname = 'agent_sandboxes_backup_schedule_attempts_check'
+      AND conrelid = 'agent_sandboxes'::regclass) THEN
+    ALTER TABLE "agent_sandboxes" ADD CONSTRAINT
+      "agent_sandboxes_backup_schedule_attempts_check" CHECK ((
+        "backup_schedule_attempts" >= 0
+        AND ("backup_schedule_last_error_code" IS NULL
+          OR "backup_schedule_last_error_code" ~ '^[A-Z][A-Z0-9_]{0,95}$')
+      ) IS TRUE) NOT VALID;
+  END IF;
+END $$;
+--> statement-breakpoint
+ALTER TABLE "agent_sandboxes"
+  VALIDATE CONSTRAINT "agent_sandboxes_backup_schedule_attempts_check";
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS agent_sandboxes_lifecycle_revision_trigger ON "agent_sandboxes";
+--> statement-breakpoint
+CREATE TRIGGER agent_sandboxes_lifecycle_revision_trigger
+BEFORE UPDATE ON "agent_sandboxes" FOR EACH ROW WHEN (
+  to_jsonb(OLD) - ARRAY[
+    'billing_status', 'last_billed_at', 'hourly_rate', 'total_billed',
+    'shutdown_warning_sent_at', 'scheduled_shutdown_at', 'updated_at',
+    'next_backup_at', 'backup_schedule_operation_id', 'backup_schedule_retry_at',
+    'backup_schedule_claim_owner', 'backup_schedule_claim_generation',
+    'backup_schedule_claim_expires_at', 'backup_schedule_attempts',
+    'backup_schedule_last_error_code', 'backup_schedule_last_protected_at'
+  ]::text[] IS DISTINCT FROM to_jsonb(NEW) - ARRAY[
+    'billing_status', 'last_billed_at', 'hourly_rate', 'total_billed',
+    'shutdown_warning_sent_at', 'scheduled_shutdown_at', 'updated_at',
+    'next_backup_at', 'backup_schedule_operation_id', 'backup_schedule_retry_at',
+    'backup_schedule_claim_owner', 'backup_schedule_claim_generation',
+    'backup_schedule_claim_expires_at', 'backup_schedule_attempts',
+    'backup_schedule_last_error_code', 'backup_schedule_last_protected_at'
+  ]::text[]
+)
+EXECUTE FUNCTION advance_agent_sandbox_lifecycle_revision();

--- a/packages/cloud/shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud/shared/src/db/migrations/meta/_journal.json
@@ -1604,6 +1604,48 @@
       "when": 1788897600000,
       "tag": "0229_agent_backup_catalog_chain_authority",
       "breakpoints": true
+    },
+    {
+      "idx": 229,
+      "version": "7",
+      "when": 1788984000000,
+      "tag": "0230_agent_backup_activation_authority_foundation",
+      "breakpoints": true
+    },
+    {
+      "idx": 230,
+      "version": "7",
+      "when": 1789070400000,
+      "tag": "0231_agent_backup_docker_source_authority",
+      "breakpoints": true
+    },
+    {
+      "idx": 231,
+      "version": "7",
+      "when": 1789156800000,
+      "tag": "0232_agent_backup_catalog_source_authority",
+      "breakpoints": true
+    },
+    {
+      "idx": 232,
+      "version": "7",
+      "when": 1789243200000,
+      "tag": "0233_agent_backup_catalog_manifest_v3_columns",
+      "breakpoints": true
+    },
+    {
+      "idx": 233,
+      "version": "7",
+      "when": 1789329600000,
+      "tag": "0234_agent_backup_catalog_manifest_v3_shape",
+      "breakpoints": true
+    },
+    {
+      "idx": 234,
+      "version": "7",
+      "when": 1789416000000,
+      "tag": "0235_agent_backup_rpo_scheduler",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog.pglite.test.ts
@@ -4,10 +4,21 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:tes
 import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
 import {
+  AGENT_BACKUP_OPERATION_CONTENT_HMAC_DERIVATION,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_CONTEXT_DERIVATION,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_FORMAT,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_LOCAL_RECEIPT_DERIVATION,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1,
+  AGENT_VAULT_KEY_AUTHORITY_FORMAT,
+  AGENT_VAULT_KEY_AUTHORITY_RECEIPT_DERIVATION,
   type AgentBackupManifestV2Draft,
+  type AgentBackupManifestV3Draft,
   canonicalizeAgentBackupManifestV2,
+  canonicalizeAgentBackupManifestV3,
+  canonicalizeAgentBackupOperationKeyBundleContext,
   computeAgentBackupChunkAadDigest,
   computeAgentBackupManifestV2Digest,
+  createAgentBackupManifestV3,
 } from "@elizaos/shared";
 import { eq, sql } from "drizzle-orm";
 
@@ -30,17 +41,21 @@ import {
   agentBackupObjects,
 } from "../../schemas/agent-backup-catalog";
 import { agentSandboxBackups, agentSandboxes } from "../../schemas/agent-sandboxes";
+import { dockerNodes } from "../../schemas/docker-nodes";
 import { organizations } from "../../schemas/organizations";
 import { userCharacters } from "../../schemas/user-characters";
 import { users } from "../../schemas/users";
 import {
   agentBackupObjectInventoryDigest,
   buildAgentBackupObjectKey,
+  claimDueAgentBackupOperations,
   failAgentBackupOperation,
   markAgentBackupObjectUploading,
   markAgentBackupObjectVerified,
   recordAgentBackupObjectPresent,
+  recordCapturedAgentBackupManifest,
   reserveAgentBackupObject,
+  reserveAgentBackupOperation,
   transitionAgentBackupOperation,
 } from "../agent-backup-catalog";
 import {
@@ -60,6 +75,7 @@ const AGENT_ID = "00000000-0000-4000-8000-00000000c003";
 const OPERATION_ID = "00000000-0000-4000-8000-00000000c004";
 const LIFECYCLE_GENERATION = "00000000-0000-4000-8000-00000000c005";
 const NODE_RECORD_ID = "00000000-0000-4000-8000-00000000c006";
+const NODE_INCARNATION = "00000000-0000-4000-8000-00000000c00d";
 const INCREMENTAL_OPERATION_ID = "00000000-0000-4000-8000-00000000c007";
 const INCREMENTAL_GENERATION = "00000000-0000-4000-8000-00000000c008";
 const NONCATALOG_BACKUP_ID = "00000000-0000-4000-8000-00000000c00b";
@@ -68,6 +84,11 @@ const SHA_A = "a".repeat(64);
 const SHA_B = "b".repeat(64);
 const SHA_C = "c".repeat(64);
 const SHA_D = "d".repeat(64);
+const SOURCE_CONTAINER_ID = "f".repeat(64);
+const SOURCE_IMAGE_DIGEST = `sha256:${"9".repeat(64)}`;
+const KEY_BUNDLE_GENERATION_ID = "00000000-0000-4000-8000-00000000c014";
+const VAULT_KEY_GENERATION_ID = "00000000-0000-4000-8000-00000000c015";
+const WRAPPED_KEY_BUNDLE = Buffer.alloc(AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.wrappedBytes, 0x43);
 const PRIMARY_ENDPOINT_FINGERPRINT = `sha256:${"1".repeat(64)}`;
 const SECONDARY_ENDPOINT_FINGERPRINT = `sha256:${"2".repeat(64)}`;
 
@@ -84,6 +105,13 @@ interface TestBackupReservation {
   backupKind: "full" | "incremental";
   parentBackupId?: string;
   baseBackupId?: string;
+  sourceProvider: "operator-onboarded" | "hetzner-cloud";
+  sourceNodeRecordId: string;
+  sourceNodeId: string;
+  sourceNodeIncarnation: string;
+  sourceProviderServerId: string | null;
+  sourceProviderHandle: string;
+  sourceContainerId: string;
   retentionReason:
     | "schedule"
     | "manual"
@@ -107,8 +135,40 @@ function reservation(overrides: Partial<TestBackupReservation> = {}): TestBackup
     lifecycleRevision: "0",
     snapshotType: "auto" as const,
     backupKind: "full" as const,
+    sourceProvider: "operator-onboarded" as const,
+    sourceNodeRecordId: NODE_RECORD_ID,
+    sourceNodeId: "robot-node-1",
+    sourceNodeIncarnation: NODE_INCARNATION,
+    sourceProviderServerId: null,
+    sourceProviderHandle: "container-generation-1",
+    sourceContainerId: SOURCE_CONTAINER_ID,
     retentionReason: "schedule" as const,
     retentionUntil: new Date("2020-01-01T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function exactReservation(
+  overrides: Partial<Parameters<typeof reserveAgentBackupOperation>[0]> = {},
+): Parameters<typeof reserveAgentBackupOperation>[0] {
+  return {
+    organizationId: ORG_ID,
+    agentId: AGENT_ID,
+    sandboxRecordId: AGENT_ID,
+    operationId: OPERATION_ID,
+    activationGeneration: LIFECYCLE_GENERATION,
+    lifecycleRevision: "0",
+    snapshotType: "auto",
+    backupKind: "full",
+    sourceProvider: "operator-onboarded",
+    sourceNodeRecordId: NODE_RECORD_ID,
+    sourceNodeId: "robot-node-1",
+    sourceNodeIncarnation: NODE_INCARNATION,
+    sourceProviderServerId: null,
+    sourceProviderHandle: "container-generation-1",
+    sourceContainerId: SOURCE_CONTAINER_ID,
+    retentionReason: "schedule",
+    retentionUntil: new Date("2026-09-17T00:00:00.000Z"),
     ...overrides,
   };
 }
@@ -145,6 +205,13 @@ async function reserveTestBackup(overrides: Partial<TestBackupReservation> = {})
       catalog_agent_id: input.agentId,
       lifecycle_generation: input.lifecycleGeneration,
       lifecycle_revision: BigInt(input.lifecycleRevision),
+      source_provider: input.sourceProvider,
+      source_node_record_id: input.sourceNodeRecordId,
+      source_node_id: input.sourceNodeId,
+      source_node_incarnation: input.sourceNodeIncarnation,
+      source_provider_server_id: input.sourceProviderServerId,
+      source_provider_handle: input.sourceProviderHandle,
+      source_container_id: input.sourceContainerId,
       retention_reason: input.retentionReason,
       retention_until: input.retentionUntil,
       catalog_next_attempt_at: new Date("2020-01-01T00:00:00.000Z"),
@@ -165,7 +232,15 @@ function objectDescriptor(index = 0) {
   };
 }
 
-async function capturedManifest(inventory: ReturnType<typeof objectDescriptor>[]) {
+async function capturedManifest(
+  inventory: ReturnType<typeof objectDescriptor>[],
+  options: Readonly<{
+    operationId?: string;
+    createdAt?: string;
+    chain?: AgentBackupManifestV2Draft["chain"];
+  }> = {},
+) {
+  const operationId = options.operationId ?? OPERATION_ID;
   const identity = {
     organizationId: ORG_ID,
     agentId: AGENT_ID,
@@ -190,7 +265,7 @@ async function capturedManifest(inventory: ReturnType<typeof objectDescriptor>[]
         ...descriptor,
         aadSha256: await computeAgentBackupChunkAadDigest({
           identity,
-          operationId: OPERATION_ID,
+          operationId,
           component: { name: "database", format: "raw-v1", compression: "none" },
           chunk: {
             index: descriptor.index,
@@ -203,7 +278,11 @@ async function capturedManifest(inventory: ReturnType<typeof objectDescriptor>[]
       };
     }),
   );
-  const components = ["character", "database", "media", "state-files", "vault"].map((name) => {
+  const componentNames =
+    options.chain?.kind === "incremental"
+      ? (["database"] as const)
+      : (["character", "database", "media", "state-files", "vault"] as const);
+  const components = componentNames.map((name) => {
     const chunks = name === "database" ? databaseChunks : [];
     const totals = chunks.reduce(
       (sum, chunk) => ({
@@ -219,7 +298,16 @@ async function capturedManifest(inventory: ReturnType<typeof objectDescriptor>[]
       format: "raw-v1",
       compression: "none" as const,
       payloadContentHmacSha256: SHA_A,
-      state: { kind: "full" as const, resultContentHmacSha256: SHA_A },
+      state:
+        options.chain?.kind === "incremental"
+          ? {
+              kind: "delta" as const,
+              baseContentHmacSha256: SHA_B,
+              resultContentHmacSha256: SHA_A,
+              tombstoneCount: 0,
+              overlayOrder: "delete-then-upsert" as const,
+            }
+          : { kind: "full" as const, resultContentHmacSha256: SHA_A },
       totals,
       chunks,
     };
@@ -238,24 +326,24 @@ async function capturedManifest(inventory: ReturnType<typeof objectDescriptor>[]
   const draft: AgentBackupManifestV2Draft = {
     format: "elizaos.agent-backup",
     schemaVersion: 2,
-    operationId: OPERATION_ID,
-    createdAt: "2026-08-17T00:00:00.000Z",
+    operationId,
+    createdAt: options.createdAt ?? "2026-08-17T00:00:00.000Z",
     identity,
     source: {
       kind: "robot",
       provider: "hetzner",
       nodeRecordId: NODE_RECORD_ID,
-      nodeIncarnation: LIFECYCLE_GENERATION,
+      nodeIncarnation: NODE_INCARNATION,
       nodeId: "robot-node-1",
-      containerId: "container-generation-1",
+      containerId: SOURCE_CONTAINER_ID,
     },
     runtime: {
-      imageDigest: `sha256:${"9".repeat(64)}`,
+      imageDigest: SOURCE_IMAGE_DIGEST,
       agentSchemaVersion: "2",
       databaseSchemaVersion: "1",
       plugins: [],
     },
-    chain: {
+    chain: options.chain ?? {
       kind: "full",
       baseOperationId: null,
       parentOperationId: null,
@@ -266,7 +354,7 @@ async function capturedManifest(inventory: ReturnType<typeof objectDescriptor>[]
     totals,
     encryption: {
       algorithm: "AES-256-GCM",
-      dekGenerationId: OPERATION_ID,
+      dekGenerationId: operationId,
       envelopeVersion: 1,
       chunkEnvelope: "aes-256-gcm-v1",
       nonceBytes: 12,
@@ -277,7 +365,7 @@ async function capturedManifest(inventory: ReturnType<typeof objectDescriptor>[]
       kms: { provider: "steward", keyId: kmsKeyId, keyVersion: 1 },
       wrappedDek: {
         format: "kms-aead-envelope-v1",
-        ref: `backup-dek:${OPERATION_ID}`,
+        ref: `backup-dek:${operationId}`,
         bytes: wrappedDek.byteLength,
         sha256: await digestHex(wrappedDek),
         contextDerivation: "elizaos.agent-backup.dek-context.v1",
@@ -304,8 +392,8 @@ async function capturedManifest(inventory: ReturnType<typeof objectDescriptor>[]
     objectInventoryDigest: await agentBackupObjectInventoryDigest(inventory),
     imageDigest: draft.runtime.imageDigest,
     databaseSchemaVersion: draft.runtime.databaseSchemaVersion,
-    pluginSetDigest: SHA_B,
-    watermarkDigest: SHA_C,
+    pluginSetDigest: await digestCanonical({ version: 1, plugins: draft.runtime.plugins }),
+    watermarkDigest: await digestCanonical({ version: 1, watermarks: draft.watermarks }),
     rawSizeBytes: totals.plainBytes,
     compressedSizeBytes: totals.compressedBytes,
     encryptedSizeBytes: totals.encryptedBytes,
@@ -313,6 +401,138 @@ async function capturedManifest(inventory: ReturnType<typeof objectDescriptor>[]
     kmsKeyVersion: 1,
     wrappedDekCiphertextBase64: Buffer.from(wrappedDek).toString("base64"),
     wrappedDekReceiptDigest: SHA_B,
+  };
+}
+
+function operationKeyBundleContext(operationId: string): string {
+  return canonicalizeAgentBackupOperationKeyBundleContext({
+    organizationId: ORG_ID,
+    agentId: AGENT_ID,
+    activationGeneration: LIFECYCLE_GENERATION,
+    lifecycleRevision: "0",
+    operationId,
+    keyBundleGenerationId: KEY_BUNDLE_GENERATION_ID,
+    sourceKind: "robot",
+    sourceProvider: "hetzner",
+    kmsProvider: "steward",
+    keyId: `org:${ORG_ID}/dek/v1`,
+    keyVersion: 1,
+  });
+}
+
+async function operationKeyBundleLocalReceiptDigest(input: {
+  keyId: string;
+  keyVersion: number;
+  canonicalContext: string;
+  wrappedKeyBundle: Uint8Array;
+}): Promise<string> {
+  return digestHex(
+    new TextEncoder().encode(
+      JSON.stringify({
+        derivation: AGENT_BACKUP_OPERATION_KEY_BUNDLE_LOCAL_RECEIPT_DERIVATION,
+        format: AGENT_BACKUP_OPERATION_KEY_BUNDLE_FORMAT,
+        keyId: input.keyId,
+        keyVersion: input.keyVersion,
+        contextSha256: await digestHex(new TextEncoder().encode(input.canonicalContext)),
+        wrappedKeyBundleSha256: await digestHex(input.wrappedKeyBundle),
+      }),
+    ),
+  );
+}
+
+async function capturedManifestV3(
+  inventory: ReturnType<typeof objectDescriptor>[],
+  options: Readonly<{ operationId?: string; createdAt?: string }> = {},
+) {
+  const operationId = options.operationId ?? OPERATION_ID;
+  const v2 = await capturedManifest(inventory, {
+    operationId,
+    createdAt: options.createdAt,
+  });
+  const v2Draft = JSON.parse(v2.canonicalManifestDraft) as AgentBackupManifestV2Draft;
+  const {
+    schemaVersion: _schemaVersion,
+    encryption: v2Encryption,
+    integrity: v2Integrity,
+    ...common
+  } = v2Draft;
+  const canonicalContext = operationKeyBundleContext(operationId);
+  const wrappedKeyBundleSha256 = await digestHex(WRAPPED_KEY_BUNDLE);
+  const wrappedKeyBundleLocalReceiptDigest = await operationKeyBundleLocalReceiptDigest({
+    keyId: v2Encryption.kms.keyId,
+    keyVersion: v2Encryption.kms.keyVersion,
+    canonicalContext,
+    wrappedKeyBundle: WRAPPED_KEY_BUNDLE,
+  });
+  const draft: AgentBackupManifestV3Draft = {
+    ...common,
+    schemaVersion: 3,
+    vaultKeyAuthority: {
+      format: AGENT_VAULT_KEY_AUTHORITY_FORMAT,
+      generationId: VAULT_KEY_GENERATION_ID,
+      receiptDerivation: AGENT_VAULT_KEY_AUTHORITY_RECEIPT_DERIVATION,
+      receiptDigest: SHA_D,
+    },
+    encryption: {
+      algorithm: v2Encryption.algorithm,
+      chunkEnvelope: v2Encryption.chunkEnvelope,
+      nonceBytes: v2Encryption.nonceBytes,
+      tagBytes: v2Encryption.tagBytes,
+      noncePlacement: v2Encryption.noncePlacement,
+      tagPlacement: v2Encryption.tagPlacement,
+      aad: v2Encryption.aad,
+      kms: { ...v2Encryption.kms, provider: "steward" },
+      operationKeyBundle: {
+        format: AGENT_BACKUP_OPERATION_KEY_BUNDLE_FORMAT,
+        generationId: KEY_BUNDLE_GENERATION_ID,
+        plaintextBytes: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.plaintextBytes,
+        dek: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.dek,
+        contentHmac: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.contentHmac,
+        wrapped: {
+          ref: `backup-key-bundle:${operationId}`,
+          bytes: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.wrappedBytes,
+          sha256: wrappedKeyBundleSha256,
+          localReceiptDerivation: AGENT_BACKUP_OPERATION_KEY_BUNDLE_LOCAL_RECEIPT_DERIVATION,
+          localReceiptDigest: wrappedKeyBundleLocalReceiptDigest,
+          contextDerivation: AGENT_BACKUP_OPERATION_KEY_BUNDLE_CONTEXT_DERIVATION,
+        },
+      },
+    },
+    integrity: {
+      framedContentHmacSha256: v2Integrity.framedContentHmacSha256,
+      contentAddressing: {
+        algorithm: "HMAC-SHA-256",
+        scope: "operation",
+        derivation: AGENT_BACKUP_OPERATION_CONTENT_HMAC_DERIVATION,
+        keyBundleFormat: AGENT_BACKUP_OPERATION_KEY_BUNDLE_FORMAT,
+        keyOffsetBytes: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.contentHmac.offsetBytes,
+        keyBytes: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.contentHmac.bytes,
+      },
+    },
+  };
+  const manifest = await createAgentBackupManifestV3(draft);
+  return {
+    canonicalManifestDraft: canonicalizeAgentBackupManifestV3(draft),
+    format: manifest.format,
+    version: manifest.schemaVersion,
+    digest: manifest.integrity.manifestSha256,
+    objectCount: inventory.length,
+    objectInventoryDigest: await agentBackupObjectInventoryDigest(inventory),
+    imageDigest: manifest.runtime.imageDigest,
+    databaseSchemaVersion: manifest.runtime.databaseSchemaVersion,
+    pluginSetDigest: await digestCanonical({ version: 1, plugins: manifest.runtime.plugins }),
+    watermarkDigest: await digestCanonical({ version: 1, watermarks: manifest.watermarks }),
+    rawSizeBytes: manifest.totals.plainBytes,
+    compressedSizeBytes: manifest.totals.compressedBytes,
+    encryptedSizeBytes: manifest.totals.encryptedBytes,
+    kmsKeyId: manifest.encryption.kms.keyId,
+    kmsKeyVersion: manifest.encryption.kms.keyVersion,
+    wrappedKeyBundleCiphertextBase64: WRAPPED_KEY_BUNDLE.toString("base64"),
+    wrappedKeyBundleSha256,
+    wrappedKeyBundleLocalReceiptDigest,
+    wrappedKeyBundleGenerationId: KEY_BUNDLE_GENERATION_ID,
+    vaultKeyGenerationId: VAULT_KEY_GENERATION_ID,
+    vaultKeyAuthorityReceiptDigest: SHA_D,
   };
 }
 
@@ -377,11 +597,30 @@ async function captureBackup(
 }
 
 function digestHex(bytes: Uint8Array): Promise<string> {
+  const owned = new Uint8Array(new ArrayBuffer(bytes.byteLength));
+  owned.set(bytes);
   return crypto.subtle
-    .digest("SHA-256", bytes)
+    .digest("SHA-256", owned)
     .then((digest) =>
       Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join(""),
     );
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") return String(value);
+  if (Array.isArray(value)) return `[${value.map((entry) => canonicalJson(entry)).join(",")}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+    .join(",")}}`;
+}
+
+function digestCanonical(value: unknown): Promise<string> {
+  return digestHex(new TextEncoder().encode(canonicalJson(value)));
 }
 
 function exactRuntimeBucket(): {
@@ -417,8 +656,8 @@ function exactRuntimeBucket(): {
           size,
           etag: `etag-${key.length}`,
           version: `version-${key.length}`,
-          checksums: { sha256 },
-          customMetadata: options.customMetadata,
+          checksums: { sha256: sha256.slice(0) },
+          customMetadata: options?.customMetadata,
         };
         objects.set(key, object);
         return object;
@@ -587,6 +826,7 @@ beforeAll(async () => {
         organizations,
         users,
         userCharacters,
+        dockerNodes,
         agentSandboxes,
         agentSandboxBackups,
         agentBackupCatalogAuthorities,
@@ -608,6 +848,7 @@ beforeEach(async () => {
   await dbWrite.delete(agentSandboxBackups);
   await dbWrite.delete(agentBackupCatalogAuthorities);
   await dbWrite.delete(agentSandboxes);
+  await dbWrite.delete(dockerNodes);
   await dbWrite.delete(userCharacters);
   await dbWrite.delete(users);
   await dbWrite.delete(organizations);
@@ -628,6 +869,18 @@ beforeEach(async () => {
     steward_user_id: "backup-catalogue-user",
     organization_id: ORG_ID,
   });
+  const sourceNode = {
+    id: NODE_RECORD_ID,
+    node_id: "robot-node-1",
+    hostname: "robot-node-1.example.test",
+    host_key_fingerprint: "sha256:robot-host-key",
+    fleet_kind: "robot",
+    infrastructure_provider: "hetzner",
+    node_incarnation: NODE_INCARNATION,
+    status: "healthy",
+    enabled: true,
+  } satisfies typeof dockerNodes.$inferInsert;
+  await dbWrite.insert(dockerNodes).values(sourceNode);
   await dbWrite.insert(agentSandboxes).values({
     id: AGENT_ID,
     organization_id: ORG_ID,
@@ -637,6 +890,19 @@ beforeEach(async () => {
     sandbox_id: "container-generation-1",
     node_id: "robot-node-1",
     container_name: "backup-catalogue-agent",
+    image_digest: SOURCE_IMAGE_DIGEST,
+    lifecycle_revision: 0,
+    activation_generation: LIFECYCLE_GENERATION,
+    activation_lifecycle_revision: 0n,
+    activation_phase: "active",
+    activation_receipt_hash: SHA_D,
+    activation_container_id: SOURCE_CONTAINER_ID,
+    activation_node_id: "robot-node-1",
+    activation_image_digest: SOURCE_IMAGE_DIGEST,
+    activation_boot_id: NODE_INCARNATION,
+    activation_authority_published_at: new Date("2026-08-17T00:00:00.000Z"),
+    activation_dispatched_at: new Date("2026-08-17T00:00:01.000Z"),
+    activation_completed_at: new Date("2026-08-17T00:00:02.000Z"),
   });
 });
 
@@ -645,6 +911,202 @@ afterAll(async () => {
 });
 
 describe("agent backup catalogue on primary PGlite", () => {
+  test("reserves and claims only one exact active source authority", async () => {
+    const first = await reserveAgentBackupOperation(exactReservation());
+    const replay = await reserveAgentBackupOperation(exactReservation());
+    expect(replay.id).toBe(first.id);
+    expect(first).toMatchObject({
+      source_node_record_id: NODE_RECORD_ID,
+      source_node_incarnation: NODE_INCARNATION,
+      source_provider_handle: "container-generation-1",
+      source_container_id: SOURCE_CONTAINER_ID,
+    });
+
+    await expect(
+      reserveAgentBackupOperation(
+        exactReservation({ sourceNodeIncarnation: LIFECYCLE_GENERATION }),
+      ),
+    ).rejects.toThrow(/source|stale|authority/i);
+    const claims = await claimDueAgentBackupOperations({
+      ownerId: "capture-worker-1",
+      limit: 2,
+      leaseMs: 60_000,
+    });
+    expect(claims).toHaveLength(1);
+    expect(claims[0]?.backup.id).toBe(first.id);
+  });
+
+  test("derives manifest projections and revalidates the active image before capture commit", async () => {
+    const reserved = await reserveAgentBackupOperation(exactReservation());
+    const [claim] = await claimDueAgentBackupOperations({
+      ownerId: "capture-worker-1",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    if (!claim) throw new Error("Expected one capture claim");
+    const execution = { ownerId: claim.ownerId, generation: claim.generation };
+    await transitionAgentBackupOperation({
+      organizationId: ORG_ID,
+      backupId: reserved.id,
+      operationId: OPERATION_ID,
+      lifecycleGeneration: LIFECYCLE_GENERATION,
+      expectedState: "scheduled",
+      to: "capturing",
+      execution,
+    });
+    const manifest = await capturedManifest([objectDescriptor()], {
+      createdAt: reserved.created_at.toISOString(),
+    });
+    await expect(
+      recordCapturedAgentBackupManifest({
+        organizationId: ORG_ID,
+        backupId: reserved.id,
+        operationId: OPERATION_ID,
+        expectedActivationGeneration: LIFECYCLE_GENERATION,
+        expectedLifecycleRevision: "0",
+        execution,
+        manifest: { ...manifest, pluginSetDigest: SHA_A },
+      }),
+    ).rejects.toThrow(/projection digests/);
+
+    const capture = {
+      organizationId: ORG_ID,
+      backupId: reserved.id,
+      operationId: OPERATION_ID,
+      expectedActivationGeneration: LIFECYCLE_GENERATION,
+      expectedLifecycleRevision: "0",
+      execution,
+      manifest,
+    } as const;
+    await recordCapturedAgentBackupManifest(capture);
+    await recordCapturedAgentBackupManifest(capture);
+    const [captured] = await dbWrite
+      .select()
+      .from(agentSandboxBackups)
+      .where(eq(agentSandboxBackups.id, reserved.id));
+    expect(captured).toMatchObject({
+      catalog_state: "captured",
+      plugin_set_digest: manifest.pluginSetDigest,
+      watermark_digest: manifest.watermarkDigest,
+      image_digest: SOURCE_IMAGE_DIGEST,
+    });
+  });
+
+  test("persists and exactly replays one manifest-v3 operation key bundle", async () => {
+    const reserved = await reserveAgentBackupOperation(exactReservation());
+    const [claim] = await claimDueAgentBackupOperations({
+      ownerId: "capture-worker-v3",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    if (!claim) throw new Error("Expected one manifest-v3 capture claim");
+    const execution = { ownerId: claim.ownerId, generation: claim.generation };
+    await transitionAgentBackupOperation({
+      organizationId: ORG_ID,
+      backupId: reserved.id,
+      operationId: OPERATION_ID,
+      lifecycleGeneration: LIFECYCLE_GENERATION,
+      expectedState: "scheduled",
+      to: "capturing",
+      execution,
+    });
+    const manifest = await capturedManifestV3([objectDescriptor()], {
+      createdAt: reserved.created_at.toISOString(),
+    });
+    const common = {
+      organizationId: ORG_ID,
+      backupId: reserved.id,
+      operationId: OPERATION_ID,
+      expectedActivationGeneration: LIFECYCLE_GENERATION,
+      expectedLifecycleRevision: "0",
+      execution,
+    } as const;
+    await expect(
+      recordCapturedAgentBackupManifest({
+        ...common,
+        manifest: { ...manifest, wrappedKeyBundleLocalReceiptDigest: SHA_A },
+      }),
+    ).rejects.toThrow(/canonical manifest-v3 authority/);
+
+    await recordCapturedAgentBackupManifest({ ...common, manifest });
+    await recordCapturedAgentBackupManifest({ ...common, manifest });
+    const [captured] = await dbWrite
+      .select()
+      .from(agentSandboxBackups)
+      .where(eq(agentSandboxBackups.id, reserved.id));
+    expect(captured).toMatchObject({
+      manifest_version: 3,
+      wrapped_dek_ref: null,
+      operation_key_bundle_generation_id: KEY_BUNDLE_GENERATION_ID,
+      operation_key_bundle_format: AGENT_BACKUP_OPERATION_KEY_BUNDLE_FORMAT,
+      operation_key_bundle_ref: `backup-key-bundle:${OPERATION_ID}`,
+      operation_key_bundle_ciphertext_base64: manifest.wrappedKeyBundleCiphertextBase64,
+      operation_key_bundle_sha256: manifest.wrappedKeyBundleSha256,
+      operation_key_bundle_local_receipt_digest: manifest.wrappedKeyBundleLocalReceiptDigest,
+      vault_key_generation_id: VAULT_KEY_GENERATION_ID,
+      vault_key_authority_receipt_digest: SHA_D,
+    });
+  });
+
+  test("rejects capture when the active runtime image changes after reservation", async () => {
+    const reserved = await reserveAgentBackupOperation(exactReservation());
+    const [claim] = await claimDueAgentBackupOperations({
+      ownerId: "capture-worker-1",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    if (!claim) throw new Error("Expected one capture claim");
+    const execution = { ownerId: claim.ownerId, generation: claim.generation };
+    await transitionAgentBackupOperation({
+      organizationId: ORG_ID,
+      backupId: reserved.id,
+      operationId: OPERATION_ID,
+      lifecycleGeneration: LIFECYCLE_GENERATION,
+      expectedState: "scheduled",
+      to: "capturing",
+      execution,
+    });
+    const manifest = await capturedManifest([objectDescriptor()], {
+      createdAt: reserved.created_at.toISOString(),
+    });
+    const changedImage = `sha256:${"8".repeat(64)}`;
+    await dbWrite
+      .update(agentSandboxes)
+      .set({ image_digest: changedImage, activation_image_digest: changedImage })
+      .where(eq(agentSandboxes.id, AGENT_ID));
+    await expect(
+      recordCapturedAgentBackupManifest({
+        organizationId: ORG_ID,
+        backupId: reserved.id,
+        operationId: OPERATION_ID,
+        expectedActivationGeneration: LIFECYCLE_GENERATION,
+        expectedLifecycleRevision: "0",
+        execution,
+        manifest,
+      }),
+    ).rejects.toThrow(/source activation changed/);
+  });
+
+  test("rejects incremental capture before allocating a catalogue operation", async () => {
+    const base = await protectBackup();
+    await expect(
+      reserveAgentBackupOperation(
+        exactReservation({
+          operationId: INCREMENTAL_OPERATION_ID,
+          backupKind: "incremental",
+          parentBackupId: base.backupId,
+          baseBackupId: base.backupId,
+        }),
+      ),
+    ).rejects.toThrow(/full-only/);
+    expect(
+      await dbWrite
+        .select({ id: agentSandboxBackups.id })
+        .from(agentSandboxBackups)
+        .where(eq(agentSandboxBackups.backup_operation_id, INCREMENTAL_OPERATION_ID)),
+    ).toEqual([]);
+  });
+
   test("hides v2 placeholders and enforces operation uniqueness", async () => {
     const first = await reserveTestBackup();
     expect(await agentSandboxesRepository.getLatestStoredBackup(AGENT_ID)).toBeUndefined();
@@ -708,7 +1170,12 @@ describe("agent backup catalogue on primary PGlite", () => {
       .from(agentSandboxBackups)
       .where(sql`${agentSandboxBackups.id} IN (${NONCATALOG_BACKUP_ID}, ${LEGACY_BACKUP_ID})`)
       .orderBy(agentSandboxBackups.id);
-    expect(compatible).toEqual([
+    expect(
+      compatible.map((row) => ({
+        ...row,
+        retentionReason: row.retentionReason as string | null,
+      })),
+    ).toEqual([
       {
         id: NONCATALOG_BACKUP_ID,
         catalogVersion: null,

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-catalog.pglite.test.ts
@@ -65,6 +65,10 @@ import {
   finalizeAgentBackupDeletion,
   settleAgentBackupGc,
 } from "../agent-backup-gc";
+import {
+  authorizeAgentBackupProtectedSpoolCleanup,
+  listAgentBackupProtectedSpoolCleanupCandidates,
+} from "../agent-backup-publication";
 import { agentSandboxesRepository } from "../agent-sandboxes";
 
 const PGLITE_TIMEOUT = 60_000;
@@ -819,6 +823,104 @@ async function protectBackup(objectCount = 1) {
   };
 }
 
+async function protectManifestV3Backup() {
+  const reserved = await reserveAgentBackupOperation(
+    exactReservation({ retentionUntil: new Date("2020-01-01T00:00:00.000Z") }),
+  );
+  const [claim] = await claimDueAgentBackupOperations({
+    ownerId: "capture-worker-v3",
+    limit: 1,
+    leaseMs: 60_000,
+  });
+  if (!claim) throw new Error("Expected one manifest-v3 capture claim");
+  const execution = { ownerId: claim.ownerId, generation: claim.generation };
+  await transitionAgentBackupOperation({
+    organizationId: ORG_ID,
+    backupId: reserved.id,
+    operationId: OPERATION_ID,
+    lifecycleGeneration: LIFECYCLE_GENERATION,
+    expectedState: "scheduled",
+    to: "capturing",
+    execution,
+  });
+  const descriptor = objectDescriptor();
+  const manifest = await capturedManifestV3([descriptor], {
+    createdAt: reserved.created_at.toISOString(),
+  });
+  await recordCapturedAgentBackupManifest({
+    organizationId: ORG_ID,
+    backupId: reserved.id,
+    operationId: OPERATION_ID,
+    expectedActivationGeneration: LIFECYCLE_GENERATION,
+    expectedLifecycleRevision: "0",
+    execution,
+    manifest,
+  });
+  await transitionAgentBackupOperation({
+    organizationId: ORG_ID,
+    backupId: reserved.id,
+    operationId: OPERATION_ID,
+    lifecycleGeneration: LIFECYCLE_GENERATION,
+    expectedState: "captured",
+    to: "uploading",
+    execution,
+  });
+  const primary = await reserveCopy(reserved.id, "primary", execution, descriptor);
+  await markAgentBackupObjectUploading({ organizationId: ORG_ID, objectId: primary.id, execution });
+  await recordAgentBackupObjectPresent({
+    organizationId: ORG_ID,
+    objectId: primary.id,
+    providerEtag: "etag-primary-v3",
+    uploadReceiptDigest: SHA_D,
+    execution,
+  });
+  await transitionAgentBackupOperation({
+    organizationId: ORG_ID,
+    backupId: reserved.id,
+    operationId: OPERATION_ID,
+    lifecycleGeneration: LIFECYCLE_GENERATION,
+    expectedState: "uploading",
+    to: "primary_uploaded",
+    execution,
+  });
+  await markAgentBackupObjectVerified({
+    organizationId: ORG_ID,
+    objectId: primary.id,
+    uploadReceiptDigest: SHA_D,
+    execution,
+  });
+  await transitionAgentBackupOperation({
+    organizationId: ORG_ID,
+    backupId: reserved.id,
+    operationId: OPERATION_ID,
+    lifecycleGeneration: LIFECYCLE_GENERATION,
+    expectedState: "primary_uploaded",
+    to: "primary_verified",
+    execution,
+  });
+  await transitionAgentBackupOperation({
+    organizationId: ORG_ID,
+    backupId: reserved.id,
+    operationId: OPERATION_ID,
+    lifecycleGeneration: LIFECYCLE_GENERATION,
+    expectedState: "primary_verified",
+    to: "secondary_pending",
+    execution,
+  });
+  const secondary = await reserveCopy(reserved.id, "secondary", execution, descriptor);
+  await markPresentAndVerified(secondary.id, execution, SHA_C);
+  await transitionAgentBackupOperation({
+    organizationId: ORG_ID,
+    backupId: reserved.id,
+    operationId: OPERATION_ID,
+    lifecycleGeneration: LIFECYCLE_GENERATION,
+    expectedState: "secondary_pending",
+    to: "protected",
+    execution,
+  });
+  return { backupId: reserved.id, manifest };
+}
+
 beforeAll(async () => {
   try {
     const { apply } = await pushSchema(
@@ -1046,6 +1148,40 @@ describe("agent backup catalogue on primary PGlite", () => {
       vault_key_generation_id: VAULT_KEY_GENERATION_ID,
       vault_key_authority_receipt_digest: SHA_D,
     });
+  });
+
+  test("keeps exact spool cleanup authority after retention enters object GC", async () => {
+    const { backupId, manifest } = await protectManifestV3Backup();
+    const authorization = {
+      organizationId: ORG_ID,
+      agentId: AGENT_ID,
+      backupId,
+      operationId: OPERATION_ID,
+      activationGeneration: LIFECYCLE_GENERATION,
+      lifecycleRevision: "0",
+      manifestDigest: manifest.digest,
+      objectInventoryDigest: manifest.objectInventoryDigest,
+    };
+
+    await expect(authorizeAgentBackupProtectedSpoolCleanup(authorization)).resolves.toMatchObject({
+      id: backupId,
+      catalog_state: "protected",
+    });
+    await enqueueAgentBackupDeletion({
+      organizationId: ORG_ID,
+      backupId,
+      operationId: OPERATION_ID,
+    });
+
+    await expect(authorizeAgentBackupProtectedSpoolCleanup(authorization)).resolves.toMatchObject({
+      id: backupId,
+      catalog_state: "deleting",
+    });
+    const candidates = await listAgentBackupProtectedSpoolCleanupCandidates({
+      operationId: OPERATION_ID,
+    });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({ id: backupId, catalog_state: "deleting" });
   });
 
   test("rejects capture when the active runtime image changes after reservation", async () => {

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-scheduler.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-scheduler.pglite.test.ts
@@ -1,0 +1,802 @@
+/** Real-PGlite proofs for fair, DB-clock periodic backup admission. */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { pushSchema } from "drizzle-kit/api";
+import { sql } from "drizzle-orm";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
+
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
+import { agentBackupCatalogAuthorities } from "../../schemas/agent-backup-catalog";
+import { agentSandboxBackups, agentSandboxes } from "../../schemas/agent-sandboxes";
+import { dockerNodes } from "../../schemas/docker-nodes";
+import { organizations } from "../../schemas/organizations";
+import { userCharacters } from "../../schemas/user-characters";
+import { users } from "../../schemas/users";
+import {
+  AgentBackupScheduleFenceError,
+  claimDueAgentBackupSchedules,
+  countOverdueAgentBackupSchedules,
+  deferClaimedAgentBackupSchedule,
+  enrollEligibleAgentBackupSchedules,
+  reconcileAgentBackupSchedules,
+  reserveClaimedAgentBackupSchedule,
+} from "../agent-backup-scheduler";
+
+const TIMEOUT = 60_000;
+const ORG_A = "00000000-0000-4000-8000-00000000d001";
+const ORG_B = "00000000-0000-4000-8000-00000000d002";
+const USER_A = "00000000-0000-4000-8000-00000000d003";
+const USER_B = "00000000-0000-4000-8000-00000000d004";
+const AGENT_A = "00000000-0000-4000-8000-00000000d005";
+const AGENT_B = "00000000-0000-4000-8000-00000000d006";
+const AGENT_C = "00000000-0000-4000-8000-00000000d007";
+const NODE_A = "00000000-0000-4000-8000-00000000d008";
+const NODE_B = "00000000-0000-4000-8000-00000000d009";
+const INCARNATION_A = "00000000-0000-4000-8000-00000000d010";
+const INCARNATION_B = "00000000-0000-4000-8000-00000000d011";
+const GENERATION_A = "00000000-0000-4000-8000-00000000d012";
+const GENERATION_B = "00000000-0000-4000-8000-00000000d013";
+const GENERATION_C = "00000000-0000-4000-8000-00000000d014";
+const BOOT_ID = "00000000-0000-4000-8000-00000000d015";
+const CONCURRENT_OPERATION = "00000000-0000-4000-8000-00000000d016";
+const CONCURRENT_CLAIM_GENERATION = "00000000-0000-4000-8000-00000000d017";
+const GENERATION_D = "00000000-0000-4000-8000-00000000d018";
+const IMAGE_DIGEST = `sha256:${"9".repeat(64)}`;
+const OTHER_IMAGE_DIGEST = `sha256:${"8".repeat(64)}`;
+const CONTAINER_A = "a".repeat(64);
+const CONTAINER_B = "b".repeat(64);
+const CONTAINER_C = "c".repeat(64);
+const CONTAINER_D = "d".repeat(64);
+const SHA_A = "a".repeat(64);
+const SHA_B = "b".repeat(64);
+const WRAPPED_KEY_BUNDLE = `${"A".repeat(123)}=`;
+
+let schemaFailure = "";
+
+async function insertAgent(params: {
+  id: string;
+  organizationId: string;
+  userId: string;
+  generation: string;
+  nodeId: string;
+  providerHandle: string;
+  containerId: string;
+}) {
+  await dbWrite.insert(agentSandboxes).values({
+    id: params.id,
+    organization_id: params.organizationId,
+    user_id: params.userId,
+    agent_name: `scheduled-${params.id}`,
+    status: "running",
+    execution_tier: "dedicated-always",
+    sandbox_id: params.providerHandle,
+    node_id: params.nodeId,
+    container_name: params.providerHandle,
+    image_digest: IMAGE_DIGEST,
+    lifecycle_revision: 7,
+    activation_generation: params.generation,
+    activation_lifecycle_revision: 7n,
+    activation_phase: "active",
+    activation_receipt_hash: SHA_A,
+    activation_container_id: params.containerId,
+    activation_node_id: params.nodeId,
+    activation_image_digest: IMAGE_DIGEST,
+    activation_boot_id: BOOT_ID,
+    activation_authority_published_at: new Date("2026-08-16T00:00:00.000Z"),
+    activation_dispatched_at: new Date("2026-08-16T00:00:01.000Z"),
+    activation_completed_at: new Date("2026-08-16T00:00:02.000Z"),
+  });
+}
+
+async function markProtectedManifestV3(backupId: string) {
+  const [backup] = await dbWrite
+    .select({ operationId: agentSandboxBackups.backup_operation_id })
+    .from(agentSandboxBackups)
+    .where(sql`${agentSandboxBackups.id} = ${backupId}`);
+  if (!backup?.operationId) throw new Error("Scheduled backup operation is missing");
+  const protectedAt = new Date();
+  await dbWrite
+    .update(agentSandboxBackups)
+    .set({
+      catalog_state: "protected",
+      catalog_next_attempt_at: null,
+      manifest_format: "elizaos.agent-backup",
+      manifest_version: 3,
+      manifest_digest: SHA_A,
+      manifest_canonical_draft: "{}",
+      manifest_object_count: 1,
+      object_inventory_digest: SHA_B,
+      image_digest: IMAGE_DIGEST,
+      database_schema_version: "scheduler-test-v1",
+      plugin_set_digest: SHA_A,
+      watermark_digest: SHA_B,
+      raw_size_bytes: 1,
+      compressed_size_bytes: 1,
+      encrypted_size_bytes: 1,
+      kms_key_id: "org:scheduler/dek/v1",
+      kms_key_version: 1,
+      operation_key_bundle_generation_id: GENERATION_C,
+      operation_key_bundle_format: "kms-aead-operation-key-bundle-v1",
+      operation_key_bundle_ref: `backup-key-bundle:${backup.operationId}`,
+      operation_key_bundle_ciphertext_base64: WRAPPED_KEY_BUNDLE,
+      operation_key_bundle_sha256: SHA_A,
+      operation_key_bundle_size_bytes: 92,
+      operation_key_bundle_context: "scheduler-test-context",
+      operation_key_bundle_context_derivation:
+        "elizaos.agent-backup.operation-key-bundle-context.v1",
+      operation_key_bundle_local_receipt_derivation:
+        "elizaos.kms-aead-operation-key-bundle.local-receipt.v1",
+      operation_key_bundle_local_receipt_digest: SHA_B,
+      vault_key_generation_id: GENERATION_D,
+      vault_key_authority_receipt_digest: SHA_A,
+      primary_verified_at: protectedAt,
+      secondary_verified_at: protectedAt,
+      catalog_updated_at: protectedAt,
+    })
+    .where(sql`${agentSandboxBackups.id} = ${backupId}`);
+  return protectedAt;
+}
+
+beforeAll(async () => {
+  try {
+    const { apply } = await pushSchema(
+      {
+        organizations,
+        users,
+        userCharacters,
+        dockerNodes,
+        agentSandboxes,
+        agentSandboxBackups,
+        agentBackupCatalogAuthorities,
+      } as never,
+      dbWrite as never,
+    );
+    await apply();
+    for (const migration of [
+      "../../migrations/0189_agent_sandbox_lifecycle_revision_scope.sql",
+      "../../migrations/0235_agent_backup_rpo_scheduler.sql",
+    ]) {
+      const source = readFileSync(new URL(migration, import.meta.url), "utf8");
+      for (const statement of source.split("--> statement-breakpoint")) {
+        if (statement.trim()) await dbWrite.execute(statement);
+      }
+    }
+  } catch (error) {
+    schemaFailure = error instanceof Error ? error.message : String(error);
+  }
+}, TIMEOUT);
+
+beforeEach(async () => {
+  expect(schemaFailure).toBe("");
+  await dbWrite.delete(agentSandboxBackups);
+  await dbWrite.delete(agentBackupCatalogAuthorities);
+  await dbWrite.delete(agentSandboxes);
+  await dbWrite.delete(dockerNodes);
+  await dbWrite.delete(userCharacters);
+  await dbWrite.delete(users);
+  await dbWrite.delete(organizations);
+  await dbWrite.insert(organizations).values([
+    { id: ORG_A, name: "Schedule A", slug: "schedule-a" },
+    { id: ORG_B, name: "Schedule B", slug: "schedule-b" },
+  ]);
+  await dbWrite.insert(users).values([
+    { id: USER_A, steward_user_id: "schedule-user-a", organization_id: ORG_A },
+    { id: USER_B, steward_user_id: "schedule-user-b", organization_id: ORG_B },
+  ]);
+  await dbWrite.insert(dockerNodes).values([
+    {
+      id: NODE_A,
+      node_id: "robot-schedule-a",
+      hostname: "robot-schedule-a.internal",
+      host_key_fingerprint: "robot-schedule-a-host-key",
+      fleet_kind: "robot",
+      infrastructure_provider: "hetzner",
+      node_incarnation: INCARNATION_A,
+      metadata: { provider: "operator-onboarded" },
+    },
+    {
+      id: NODE_B,
+      node_id: "cloud-schedule-b",
+      hostname: "cloud-schedule-b.internal",
+      host_key_fingerprint: "cloud-schedule-b-host-key",
+      fleet_kind: "cloud",
+      infrastructure_provider: "hetzner",
+      provider_server_id: "42",
+      node_incarnation: INCARNATION_B,
+      metadata: { provider: "hetzner-cloud", autoscaled: true },
+    },
+  ]);
+  await insertAgent({
+    id: AGENT_A,
+    organizationId: ORG_A,
+    userId: USER_A,
+    generation: GENERATION_A,
+    nodeId: "robot-schedule-a",
+    providerHandle: "agent-schedule-a",
+    containerId: CONTAINER_A,
+  });
+  await insertAgent({
+    id: AGENT_B,
+    organizationId: ORG_B,
+    userId: USER_B,
+    generation: GENERATION_B,
+    nodeId: "cloud-schedule-b",
+    providerHandle: "agent-schedule-b",
+    containerId: CONTAINER_B,
+  });
+  await insertAgent({
+    id: AGENT_C,
+    organizationId: ORG_A,
+    userId: USER_A,
+    generation: GENERATION_C,
+    nodeId: "robot-schedule-a",
+    providerHandle: "agent-schedule-c",
+    containerId: CONTAINER_C,
+  });
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+describe("agent backup RPO scheduler", () => {
+  test("enrolls and claims fairly with one capture per organization and node", async () => {
+    expect(await enrollEligibleAgentBackupSchedules({ limit: 100 })).toBe(3);
+
+    const claims = await claimDueAgentBackupSchedules({
+      ownerId: "schedule-worker-a",
+      limit: 100,
+      leaseMs: 60_000,
+    });
+    expect(claims).toHaveLength(2);
+    expect(new Set(claims.map((claim) => claim.organizationId)).size).toBe(2);
+    expect(
+      claims.filter((claim) => claim.agentId === AGENT_A || claim.agentId === AGENT_C),
+    ).toHaveLength(1);
+  });
+
+  test("rotates bounded enrollment across organizations before taking a second row", async () => {
+    expect(await enrollEligibleAgentBackupSchedules({ limit: 1 })).toBe(1);
+    const firstWave = (await dbWrite.select().from(agentSandboxes)).filter(
+      (sandbox) => sandbox.next_backup_at !== null,
+    );
+    expect(firstWave).toHaveLength(1);
+
+    expect(await enrollEligibleAgentBackupSchedules({ limit: 1 })).toBe(1);
+    const secondWave = (await dbWrite.select().from(agentSandboxes)).filter(
+      (sandbox) => sandbox.next_backup_at !== null,
+    );
+    expect(secondWave).toHaveLength(2);
+    expect(new Set(secondWave.map((sandbox) => sandbox.organization_id))).toEqual(
+      new Set([ORG_A, ORG_B]),
+    );
+
+    expect(await enrollEligibleAgentBackupSchedules({ limit: 1 })).toBe(1);
+    expect(
+      (await dbWrite.select().from(agentSandboxes)).filter(
+        (sandbox) => sandbox.next_backup_at !== null,
+      ),
+    ).toHaveLength(3);
+  });
+
+  test("concurrent claimers never own the same due sandbox, organization, or node", async () => {
+    expect(await enrollEligibleAgentBackupSchedules({ limit: 100 })).toBe(3);
+    const batches = await Promise.all(
+      Array.from({ length: 8 }, (_, index) =>
+        claimDueAgentBackupSchedules({
+          ownerId: `schedule-worker-${index}`,
+          limit: 1,
+          leaseMs: 60_000,
+        }),
+      ),
+    );
+    const all = batches.flat();
+    expect(new Set(all.map((claim) => claim.agentId)).size).toBe(all.length);
+    expect(new Set(all.map((claim) => claim.operationId)).size).toBe(all.length);
+    expect(new Set(all.map((claim) => claim.organizationId)).size).toBe(all.length);
+    expect(all).toHaveLength(2);
+  });
+
+  test("counts only exact DB-clock RPO breaches without manifest-v3 protection", async () => {
+    await dbWrite.update(agentSandboxes).set({
+      backup_schedule_last_protected_at: sql`NOW()`,
+      next_backup_at: null,
+    });
+    expect(await countOverdueAgentBackupSchedules()).toBe(0);
+    await dbWrite
+      .update(agentSandboxes)
+      .set({
+        activation_lifecycle_revision: 8n,
+        activation_completed_at: sql`NOW()`,
+        backup_schedule_last_protected_at: sql`NOW() - INTERVAL '1 day'`,
+      })
+      .where(sql`${agentSandboxes.id} = ${AGENT_A}`);
+    expect(await countOverdueAgentBackupSchedules()).toBe(0);
+    await dbWrite
+      .update(agentSandboxes)
+      .set({
+        activation_lifecycle_revision: 9n,
+        activation_completed_at: sql`NOW() - INTERVAL '16 minutes'`,
+      })
+      .where(sql`${agentSandboxes.id} = ${AGENT_A}`);
+    expect(await countOverdueAgentBackupSchedules()).toBe(1);
+
+    await enrollEligibleAgentBackupSchedules({ limit: 100 });
+    await dbWrite.update(agentSandboxes).set({
+      next_backup_at: sql`NOW() - INTERVAL '1 minute'`,
+      backup_schedule_last_protected_at: sql`NOW()`,
+    });
+    expect(await countOverdueAgentBackupSchedules()).toBe(0);
+
+    await dbWrite
+      .update(agentSandboxes)
+      .set({ backup_schedule_last_protected_at: sql`NOW() - INTERVAL '16 minutes'` })
+      .where(sql`${agentSandboxes.id} = ${AGENT_A}`);
+    expect(await countOverdueAgentBackupSchedules()).toBe(1);
+
+    const [claim] = await claimDueAgentBackupSchedules({
+      ownerId: "schedule-worker-a",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    const receipt = await reserveClaimedAgentBackupSchedule({
+      claim: claim as NonNullable<typeof claim>,
+    });
+    await markProtectedManifestV3(receipt.backupId);
+    expect(await countOverdueAgentBackupSchedules()).toBe(0);
+
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({ image_digest: OTHER_IMAGE_DIGEST })
+      .where(sql`${agentSandboxBackups.id} = ${receipt.backupId}`);
+    expect(await countOverdueAgentBackupSchedules()).toBe(1);
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({ image_digest: IMAGE_DIGEST })
+      .where(sql`${agentSandboxBackups.id} = ${receipt.backupId}`);
+    expect(await countOverdueAgentBackupSchedules()).toBe(0);
+
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({
+        primary_verified_at: sql`NOW() - INTERVAL '16 minutes'`,
+        secondary_verified_at: sql`NOW() - INTERVAL '16 minutes'`,
+      })
+      .where(sql`${agentSandboxBackups.id} = ${receipt.backupId}`);
+    expect(await countOverdueAgentBackupSchedules()).toBe(1);
+
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({ secondary_verified_at: null })
+      .where(sql`${agentSandboxBackups.id} = ${receipt.backupId}`);
+    expect(await countOverdueAgentBackupSchedules()).toBe(1);
+  });
+
+  test("counts a running dedicated sandbox with missing activation authority", async () => {
+    await dbWrite.update(agentSandboxes).set({
+      backup_schedule_last_protected_at: sql`NOW()`,
+      next_backup_at: null,
+    });
+    await dbWrite
+      .update(agentSandboxes)
+      .set({
+        activation_generation: null,
+        activation_lifecycle_revision: null,
+        activation_phase: null,
+        activation_receipt_hash: null,
+        activation_container_id: null,
+        activation_node_id: null,
+        activation_image_digest: null,
+        activation_boot_id: null,
+        activation_authority_published_at: null,
+        activation_dispatched_at: null,
+        activation_completed_at: null,
+      })
+      .where(sql`${agentSandboxes.id} = ${AGENT_A}`);
+
+    expect(await countOverdueAgentBackupSchedules()).toBe(1);
+  });
+
+  test("reservation rechecks fair-lane authority after the scheduler lease", async () => {
+    await enrollEligibleAgentBackupSchedules({ limit: 100 });
+    const [claim] = await claimDueAgentBackupSchedules({
+      ownerId: "schedule-worker-a",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    expect(claim?.agentId).toBe(AGENT_A);
+    await dbWrite
+      .update(agentSandboxes)
+      .set({
+        backup_schedule_operation_id: CONCURRENT_OPERATION,
+        backup_schedule_claim_owner: "schedule-worker-b",
+        backup_schedule_claim_generation: CONCURRENT_CLAIM_GENERATION,
+        backup_schedule_claim_expires_at: sql`clock_timestamp() + INTERVAL '1 minute'`,
+      })
+      .where(sql`${agentSandboxes.id} = ${AGENT_C}`);
+
+    await expect(
+      reserveClaimedAgentBackupSchedule({ claim: claim as NonNullable<typeof claim> }),
+    ).rejects.toBeInstanceOf(AgentBackupScheduleFenceError);
+    expect(await dbWrite.select().from(agentSandboxBackups)).toHaveLength(0);
+  });
+
+  test("an active reservation globally closes its source-node lane", async () => {
+    await dbWrite.delete(agentSandboxes).where(sql`${agentSandboxes.id} = ${AGENT_B}`);
+    await insertAgent({
+      id: AGENT_B,
+      organizationId: ORG_B,
+      userId: USER_B,
+      generation: GENERATION_B,
+      nodeId: "robot-schedule-a",
+      providerHandle: "agent-schedule-b",
+      containerId: CONTAINER_B,
+    });
+    await enrollEligibleAgentBackupSchedules({ limit: 100 });
+    const [claim] = await claimDueAgentBackupSchedules({
+      ownerId: "schedule-worker-a",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    expect(claim?.agentId).toBe(AGENT_A);
+    await reserveClaimedAgentBackupSchedule({ claim: claim as NonNullable<typeof claim> });
+
+    const nextClaims = await claimDueAgentBackupSchedules({
+      ownerId: "schedule-worker-b",
+      limit: 100,
+      leaseMs: 60_000,
+    });
+    expect(nextClaims).toHaveLength(0);
+  });
+
+  test("advances the DB-clock RPO only after exact manifest-v3 protection proof", async () => {
+    await enrollEligibleAgentBackupSchedules({ limit: 100 });
+    const claims = await claimDueAgentBackupSchedules({
+      ownerId: "schedule-worker-a",
+      limit: 100,
+      leaseMs: 60_000,
+    });
+    const receipts = await Promise.all(
+      claims.map((claim) => reserveClaimedAgentBackupSchedule({ claim })),
+    );
+    expect(receipts).toHaveLength(2);
+    const backups = await dbWrite.select().from(agentSandboxBackups);
+    expect(backups).toHaveLength(2);
+    expect(backups.every((backup) => backup.snapshot_type === "auto")).toBe(true);
+    expect(backups.every((backup) => backup.backup_kind === "full")).toBe(true);
+    expect(new Set(backups.map((backup) => backup.source_provider))).toEqual(
+      new Set(["operator-onboarded", "hetzner-cloud"]),
+    );
+    expect(backups.every((backup) => backup.catalog_state === "scheduled")).toBe(true);
+    const sandboxes = await dbWrite.select().from(agentSandboxes);
+    for (const sandbox of sandboxes.filter((row) =>
+      receipts.some((item) => item.agentId === row.id),
+    )) {
+      const receipt = receipts.find((item) => item.agentId === sandbox.id);
+      if (!receipt || sandbox.activation_lifecycle_revision === null || !sandbox.next_backup_at) {
+        throw new Error("Expected a complete reserved scheduler receipt fixture");
+      }
+      expect(sandbox.backup_schedule_operation_id).toBe(receipt.operationId);
+      expect(sandbox.backup_schedule_claim_owner).toBeNull();
+      expect(sandbox.backup_schedule_retry_at).toBeNull();
+      expect(sandbox.backup_schedule_last_protected_at).toBeNull();
+      expect(BigInt(sandbox.lifecycle_revision)).toBe(sandbox.activation_lifecycle_revision);
+      expect(sandbox.next_backup_at.getTime()).toBe(receipt.dueAt.getTime());
+    }
+
+    expect(await reconcileAgentBackupSchedules({ limit: 100 })).toEqual({
+      protected: 0,
+      recycled: 0,
+    });
+    const protectedAtByAgent = new Map<string, Date>();
+    for (const receipt of receipts) {
+      protectedAtByAgent.set(receipt.agentId, await markProtectedManifestV3(receipt.backupId));
+    }
+    expect(await reconcileAgentBackupSchedules({ limit: 100 })).toEqual({
+      protected: 2,
+      recycled: 0,
+    });
+    const settled = await dbWrite.select().from(agentSandboxes);
+    for (const sandbox of settled.filter((row) => protectedAtByAgent.has(row.id))) {
+      const protectedAt = protectedAtByAgent.get(sandbox.id) as Date;
+      expect(sandbox.backup_schedule_operation_id).toBeNull();
+      expect(sandbox.backup_schedule_attempts).toBe(0);
+      expect(sandbox.backup_schedule_last_protected_at?.getTime()).toBe(protectedAt.getTime());
+      const nextDelayMs = (sandbox.next_backup_at as Date).getTime() - protectedAt.getTime();
+      expect(nextDelayMs).toBeGreaterThanOrEqual(10 * 60_000);
+      expect(nextDelayMs).toBeLessThanOrEqual(15 * 60_000);
+    }
+  });
+
+  test("recycles malformed protected evidence without moving the RPO deadline", async () => {
+    await enrollEligibleAgentBackupSchedules({ limit: 100 });
+    const [claim] = await claimDueAgentBackupSchedules({
+      ownerId: "schedule-worker-a",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    const receipt = await reserveClaimedAgentBackupSchedule({
+      claim: claim as NonNullable<typeof claim>,
+    });
+    await markProtectedManifestV3(receipt.backupId);
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({ secondary_verified_at: null })
+      .where(sql`${agentSandboxBackups.id} = ${receipt.backupId}`);
+
+    expect(await reconcileAgentBackupSchedules({ limit: 100 })).toEqual({
+      protected: 0,
+      recycled: 1,
+    });
+    const [sandbox] = await dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(sql`${agentSandboxes.id} = ${receipt.agentId}`);
+    expect(sandbox?.next_backup_at?.getTime()).toBe(receipt.dueAt.getTime());
+    expect(sandbox?.backup_schedule_operation_id).toBeNull();
+    expect(sandbox?.backup_schedule_retry_at).toBeInstanceOf(Date);
+    expect(sandbox?.backup_schedule_last_protected_at).toBeNull();
+    expect(sandbox?.backup_schedule_last_error_code).toBe(
+      "BACKUP_SCHEDULE_PROTECTION_PROOF_INVALID",
+    );
+  });
+
+  test("rejects protected evidence for a different activation image", async () => {
+    await enrollEligibleAgentBackupSchedules({ limit: 100 });
+    const [claim] = await claimDueAgentBackupSchedules({
+      ownerId: "schedule-worker-a",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    const receipt = await reserveClaimedAgentBackupSchedule({
+      claim: claim as NonNullable<typeof claim>,
+    });
+    await markProtectedManifestV3(receipt.backupId);
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({ image_digest: OTHER_IMAGE_DIGEST })
+      .where(sql`${agentSandboxBackups.id} = ${receipt.backupId}`);
+
+    expect(await reconcileAgentBackupSchedules({ limit: 100 })).toEqual({
+      protected: 0,
+      recycled: 1,
+    });
+    const [sandbox] = await dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(sql`${agentSandboxes.id} = ${receipt.agentId}`);
+    expect(sandbox?.next_backup_at?.getTime()).toBe(receipt.dueAt.getTime());
+    expect(sandbox?.backup_schedule_last_protected_at).toBeNull();
+    expect(sandbox?.backup_schedule_last_error_code).toBe(
+      "BACKUP_SCHEDULE_PROTECTION_PROOF_INVALID",
+    );
+  });
+
+  test("rejects protection proof from a superseded activation vector", async () => {
+    await dbWrite.update(agentSandboxes).set({ backup_schedule_last_protected_at: sql`NOW()` });
+    await enrollEligibleAgentBackupSchedules({ limit: 100 });
+    const [claim] = await claimDueAgentBackupSchedules({
+      ownerId: "schedule-worker-a",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    const receipt = await reserveClaimedAgentBackupSchedule({
+      claim: claim as NonNullable<typeof claim>,
+    });
+    await dbWrite
+      .update(agentSandboxes)
+      .set({
+        activation_generation: GENERATION_D,
+        activation_lifecycle_revision: 8n,
+        activation_container_id: CONTAINER_D,
+        activation_completed_at: sql`NOW() - INTERVAL '16 minutes'`,
+        backup_schedule_last_protected_at: null,
+      })
+      .where(sql`${agentSandboxes.id} = ${receipt.agentId}`);
+    await markProtectedManifestV3(receipt.backupId);
+
+    const [reactivated] = await dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(sql`${agentSandboxes.id} = ${receipt.agentId}`);
+    expect(reactivated?.lifecycle_revision).toBe(8);
+    expect(reactivated?.activation_lifecycle_revision).toBe(8n);
+    expect(await countOverdueAgentBackupSchedules()).toBe(1);
+    expect(await reconcileAgentBackupSchedules({ limit: 100 })).toEqual({
+      protected: 0,
+      recycled: 1,
+    });
+
+    const [recycled] = await dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(sql`${agentSandboxes.id} = ${receipt.agentId}`);
+    expect(recycled?.next_backup_at?.getTime()).toBe(receipt.dueAt.getTime());
+    expect(recycled?.backup_schedule_operation_id).toBeNull();
+    expect(recycled?.backup_schedule_last_protected_at).toBeNull();
+    expect(recycled?.backup_schedule_last_error_code).toBe(
+      "BACKUP_SCHEDULE_PROTECTION_PROOF_INVALID",
+    );
+    expect(await countOverdueAgentBackupSchedules()).toBe(1);
+  });
+
+  test("keeps a superseded active lane closed until durable terminal settlement", async () => {
+    await enrollEligibleAgentBackupSchedules({ limit: 100 });
+    const [claim] = await claimDueAgentBackupSchedules({
+      ownerId: "schedule-worker-a",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    const original = await reserveClaimedAgentBackupSchedule({
+      claim: claim as NonNullable<typeof claim>,
+    });
+    await dbWrite
+      .update(agentSandboxes)
+      .set({
+        activation_generation: GENERATION_D,
+        activation_lifecycle_revision: 8n,
+        activation_container_id: CONTAINER_D,
+      })
+      .where(sql`${agentSandboxes.id} = ${original.agentId}`);
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({
+        catalog_state: "failed_retryable",
+        catalog_resume_state: "scheduled",
+        catalog_last_error_code: "BACKUP_SOURCE_RETRY",
+        catalog_last_error: "The old source remains retryable",
+        catalog_next_attempt_at: sql`NOW() + INTERVAL '1 hour'`,
+      })
+      .where(sql`${agentSandboxBackups.id} = ${original.backupId}`);
+
+    expect(await reconcileAgentBackupSchedules({ limit: 100 })).toEqual({
+      protected: 0,
+      recycled: 0,
+    });
+    const [blocked] = await dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(sql`${agentSandboxes.id} = ${original.agentId}`);
+    expect(blocked?.next_backup_at?.getTime()).toBe(original.dueAt.getTime());
+    expect(blocked?.backup_schedule_operation_id).toBe(original.operationId);
+    const whileActive = await claimDueAgentBackupSchedules({
+      ownerId: "schedule-worker-b",
+      limit: 100,
+      leaseMs: 60_000,
+    });
+    expect(whileActive.some((item) => item.agentId === original.agentId)).toBe(false);
+
+    await dbWrite
+      .update(agentSandboxBackups)
+      .set({
+        catalog_state: "failed_terminal",
+        catalog_resume_state: "scheduled",
+        catalog_last_error_code: "BACKUP_SOURCE_SUPERSEDED",
+        catalog_last_error: "The reserved source activation was superseded",
+        catalog_next_attempt_at: null,
+      })
+      .where(sql`${agentSandboxBackups.id} = ${original.backupId}`);
+    expect(await reconcileAgentBackupSchedules({ limit: 100 })).toEqual({
+      protected: 0,
+      recycled: 1,
+    });
+    const [recycled] = await dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(sql`${agentSandboxes.id} = ${original.agentId}`);
+    expect(recycled?.next_backup_at?.getTime()).toBe(original.dueAt.getTime());
+    expect(recycled?.backup_schedule_operation_id).toBeNull();
+    expect(recycled?.backup_schedule_last_error_code).toBe(
+      "BACKUP_SCHEDULE_RESERVATION_SUPERSEDED",
+    );
+
+    await dbWrite
+      .update(agentSandboxes)
+      .set({ backup_schedule_retry_at: sql`NOW() - INTERVAL '1 second'` })
+      .where(sql`${agentSandboxes.id} = ${original.agentId}`);
+    const claims = await claimDueAgentBackupSchedules({
+      ownerId: "schedule-worker-c",
+      limit: 100,
+      leaseMs: 60_000,
+    });
+    const replacementClaim = claims.find((item) => item.agentId === original.agentId);
+    expect(replacementClaim).toBeDefined();
+    const replacement = await reserveClaimedAgentBackupSchedule({
+      claim: replacementClaim as NonNullable<typeof replacementClaim>,
+    });
+    expect(replacement.operationId).not.toBe(original.operationId);
+    expect(
+      (await dbWrite.select().from(agentSandboxBackups)).filter(
+        (backup) => backup.catalog_agent_id === original.agentId,
+      ),
+    ).toHaveLength(2);
+    expect(
+      (await dbWrite.select().from(agentSandboxBackups)).filter(
+        (backup) =>
+          backup.catalog_agent_id === original.agentId &&
+          backup.catalog_state !== "failed_terminal",
+      ),
+    ).toHaveLength(1);
+  });
+
+  test("source authority loss after claim fails closed and exact defer releases the lease", async () => {
+    await enrollEligibleAgentBackupSchedules({ limit: 100 });
+    const [claim] = await claimDueAgentBackupSchedules({
+      ownerId: "schedule-worker-a",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    expect(claim).toBeDefined();
+    const originalDueAt = (claim as NonNullable<typeof claim>).dueAt.getTime();
+    const operationId = (claim as NonNullable<typeof claim>).operationId;
+    await dbWrite
+      .update(dockerNodes)
+      .set({ node_incarnation: null })
+      .where(
+        sql`${dockerNodes.node_id} = ${
+          claim?.agentId === AGENT_B ? "cloud-schedule-b" : "robot-schedule-a"
+        }`,
+      );
+    await expect(
+      reserveClaimedAgentBackupSchedule({ claim: claim as NonNullable<typeof claim> }),
+    ).rejects.toBeInstanceOf(AgentBackupScheduleFenceError);
+    expect(await dbWrite.select().from(agentSandboxBackups)).toHaveLength(0);
+    expect(
+      await deferClaimedAgentBackupSchedule({
+        claim: claim as NonNullable<typeof claim>,
+        retryDelayMs: 30_000,
+        errorCode: "BACKUP_SOURCE_REATTEST_REQUIRED",
+      }),
+    ).toBe(true);
+    const [deferred] = await dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(sql`${agentSandboxes.id} = ${(claim as NonNullable<typeof claim>).agentId}`);
+    expect(deferred?.next_backup_at?.getTime()).toBe(originalDueAt);
+    expect(deferred?.backup_schedule_operation_id).toBe(operationId);
+    expect(deferred?.backup_schedule_retry_at).toBeInstanceOf(Date);
+    expect(deferred?.backup_schedule_claim_owner).toBeNull();
+    expect(deferred?.backup_schedule_last_error_code).toBe("BACKUP_SOURCE_REATTEST_REQUIRED");
+    const immediate = await claimDueAgentBackupSchedules({
+      ownerId: "schedule-worker-b",
+      limit: 100,
+      leaseMs: 60_000,
+    });
+    expect(immediate.some((item) => item.agentId === deferred?.id)).toBe(false);
+  });
+
+  test("a successful reservation response loss cannot create a second logical backup", async () => {
+    await enrollEligibleAgentBackupSchedules({ limit: 100 });
+    const [claim] = await claimDueAgentBackupSchedules({
+      ownerId: "schedule-worker-a",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+    const receipt = await reserveClaimedAgentBackupSchedule({
+      claim: claim as NonNullable<typeof claim>,
+    });
+    await expect(
+      reserveClaimedAgentBackupSchedule({ claim: claim as NonNullable<typeof claim> }),
+    ).rejects.toBeInstanceOf(AgentBackupScheduleFenceError);
+    const backups = await dbWrite.select().from(agentSandboxBackups);
+    expect(backups).toHaveLength(1);
+    expect(backups[0]?.id).toBe(receipt.backupId);
+    const [sandbox] = await dbWrite
+      .select()
+      .from(agentSandboxes)
+      .where(sql`${agentSandboxes.id} = ${receipt.agentId}`);
+    expect(sandbox?.backup_schedule_operation_id).toBe(receipt.operationId);
+    expect(sandbox?.next_backup_at?.getTime()).toBe(receipt.dueAt.getTime());
+    const nextClaims = await claimDueAgentBackupSchedules({
+      ownerId: "schedule-worker-b",
+      limit: 100,
+      leaseMs: 60_000,
+    });
+    expect(nextClaims.some((item) => item.agentId === receipt.agentId)).toBe(false);
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-source-authority.pglite.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-backup-source-authority.pglite.test.ts
@@ -1,0 +1,336 @@
+/** Primary-DB proofs for Robot/Cloud source resolution and boot CAS fencing. */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+process.env.SKIP_AGENT_SANDBOX_ENSURE = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
+import { dockerNodes } from "../../schemas/docker-nodes";
+import {
+  AgentBackupSourceAuthorityError,
+  parseLinuxBootId,
+  resolveAgentBackupManifestSourceAuthority,
+} from "../agent-backup-source-authority";
+import { dockerNodesRepository } from "../docker-nodes";
+
+const PGLITE_TIMEOUT = 60_000;
+const ROBOT_RECORD_ID = "00000000-0000-4000-8000-000000000101";
+const CLOUD_RECORD_ID = "00000000-0000-4000-8000-000000000102";
+const BOOT_A = "00000000-0000-4000-8000-000000000111";
+const BOOT_B = "00000000-0000-4000-8000-000000000112";
+const BOOT_C = "00000000-0000-4000-8000-000000000113";
+const BOOT_WITH_LETTERS = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1";
+const CONTAINER_ID = "a".repeat(64);
+
+let schemaFailure = "";
+
+function registration(hostname = "robot.example.test") {
+  return {
+    hostname,
+    sshPort: 22,
+    sshUser: "root",
+    capacity: 8,
+    status: "unknown" as const,
+    hostKeyFingerprint: "robot-host-key",
+    metadata: { provider: "operator-onboarded" },
+  };
+}
+
+beforeAll(async () => {
+  try {
+    const { apply } = await pushSchema({ dockerNodes } as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    schemaFailure = error instanceof Error ? error.message : String(error);
+  }
+}, PGLITE_TIMEOUT);
+
+beforeEach(async () => {
+  expect(schemaFailure).toBe("");
+  await dbWrite.delete(dockerNodes);
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+describe("agent backup source authority on primary PGlite", () => {
+  test("parses one exact lowercase Linux boot UUID", () => {
+    expect(parseLinuxBootId(`${BOOT_A}\n`)).toBe(BOOT_A);
+    expect(() => parseLinuxBootId(BOOT_WITH_LETTERS.toUpperCase())).toThrow(/lowercase UUID/);
+    expect(() => parseLinuxBootId(`${BOOT_A}\n${BOOT_B}`)).toThrow(/lowercase UUID/);
+  });
+
+  test("never promotes metadata-shaped legacy rows or aliases record and node handles", async () => {
+    await dbWrite.insert(dockerNodes).values({
+      id: ROBOT_RECORD_ID,
+      node_id: "robot-runtime-1",
+      hostname: "robot.example.test",
+      host_key_fingerprint: "robot-host-key",
+      metadata: { provider: "operator-onboarded", fleet: "robot" },
+    });
+
+    await expect(
+      resolveAgentBackupManifestSourceAuthority({
+        nodeRecordId: ROBOT_RECORD_ID,
+        nodeId: "robot-runtime-1",
+        nodeIncarnation: BOOT_A,
+        containerId: CONTAINER_ID,
+      }),
+    ).rejects.toThrow(/legacy|unattested|stale/);
+    await expect(
+      resolveAgentBackupManifestSourceAuthority({
+        nodeRecordId: CLOUD_RECORD_ID,
+        nodeId: ROBOT_RECORD_ID,
+        nodeIncarnation: BOOT_A,
+        containerId: CONTAINER_ID,
+      }),
+    ).rejects.toBeInstanceOf(AgentBackupSourceAuthorityError);
+  });
+
+  test(
+    "explicit Robot onboarding is idempotent and reboot rotation is stale-safe",
+    async () => {
+      await dbWrite.insert(dockerNodes).values({
+        id: ROBOT_RECORD_ID,
+        node_id: "robot-runtime-1",
+        hostname: "old.example.test",
+        host_key_fingerprint: "robot-host-key",
+      });
+
+      const promoted = await dockerNodesRepository.attestRobotSourceAuthority({
+        id: ROBOT_RECORD_ID,
+        nodeId: "robot-runtime-1",
+        expectedIncarnation: null,
+        expectedHostKeyFingerprint: "robot-host-key",
+        observedIncarnation: BOOT_A,
+        registration: registration(),
+      });
+      expect(promoted).toMatchObject({
+        fleet_kind: "robot",
+        infrastructure_provider: "hetzner",
+        provider_server_id: null,
+        node_incarnation: BOOT_A,
+        hostname: "robot.example.test",
+      });
+
+      const replay = await dockerNodesRepository.attestRobotSourceAuthority({
+        id: ROBOT_RECORD_ID,
+        nodeId: "robot-runtime-1",
+        expectedIncarnation: BOOT_A,
+        expectedHostKeyFingerprint: "robot-host-key",
+        observedIncarnation: BOOT_A,
+        registration: registration("robot-renamed.example.test"),
+      });
+      expect(replay.node_incarnation).toBe(BOOT_A);
+      expect(replay.hostname).toBe("robot-renamed.example.test");
+
+      const rebooted = await dockerNodesRepository.attestNodeIncarnation({
+        id: ROBOT_RECORD_ID,
+        nodeId: "robot-runtime-1",
+        expectedIncarnation: BOOT_A,
+        expectedHostKeyFingerprint: "robot-host-key",
+        observedIncarnation: BOOT_B,
+      });
+      expect(rebooted.node_incarnation).toBe(BOOT_B);
+      await expect(
+        dockerNodesRepository.attestNodeIncarnation({
+          id: ROBOT_RECORD_ID,
+          nodeId: "robot-runtime-1",
+          expectedIncarnation: BOOT_A,
+          expectedHostKeyFingerprint: "robot-host-key",
+          observedIncarnation: BOOT_C,
+        }),
+      ).rejects.toThrow(/compare-and-swap/);
+      expect((await dockerNodesRepository.findById(ROBOT_RECORD_ID))?.node_incarnation).toBe(
+        BOOT_B,
+      );
+
+      await expect(
+        resolveAgentBackupManifestSourceAuthority({
+          nodeRecordId: ROBOT_RECORD_ID,
+          nodeId: "robot-runtime-1",
+          nodeIncarnation: BOOT_A,
+          containerId: CONTAINER_ID,
+        }),
+      ).rejects.toThrow(/stale/);
+      await expect(
+        resolveAgentBackupManifestSourceAuthority({
+          nodeRecordId: ROBOT_RECORD_ID,
+          nodeId: "robot-runtime-1",
+          nodeIncarnation: BOOT_B,
+          containerId: CONTAINER_ID,
+        }),
+      ).resolves.toEqual({
+        kind: "robot",
+        provider: "hetzner",
+        nodeRecordId: ROBOT_RECORD_ID,
+        nodeIncarnation: BOOT_B,
+        nodeId: "robot-runtime-1",
+        containerId: CONTAINER_ID,
+      });
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "stale invalidation cannot erase a newer boot and exact invalidation fails closed",
+    async () => {
+      await dbWrite.insert(dockerNodes).values({
+        id: ROBOT_RECORD_ID,
+        node_id: "robot-runtime-1",
+        hostname: "robot.example.test",
+        host_key_fingerprint: "robot-host-key",
+        fleet_kind: "robot",
+        infrastructure_provider: "hetzner",
+        node_incarnation: BOOT_B,
+      });
+
+      await expect(
+        dockerNodesRepository.invalidateNodeIncarnation({
+          id: ROBOT_RECORD_ID,
+          nodeId: "robot-runtime-1",
+          expectedIncarnation: BOOT_A,
+          expectedHostKeyFingerprint: "robot-host-key",
+        }),
+      ).rejects.toThrow(/compare-and-swap/);
+      expect((await dockerNodesRepository.findById(ROBOT_RECORD_ID))?.node_incarnation).toBe(
+        BOOT_B,
+      );
+
+      await dockerNodesRepository.invalidateNodeIncarnation({
+        id: ROBOT_RECORD_ID,
+        nodeId: "robot-runtime-1",
+        expectedIncarnation: BOOT_B,
+        expectedHostKeyFingerprint: "robot-host-key",
+      });
+      await expect(
+        resolveAgentBackupManifestSourceAuthority({
+          nodeRecordId: ROBOT_RECORD_ID,
+          nodeId: "robot-runtime-1",
+          nodeIncarnation: BOOT_B,
+          containerId: CONTAINER_ID,
+        }),
+      ).rejects.toThrow(/unattested|stale/);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "host-key rotation atomically revokes capture authority until the new pin re-attests",
+    async () => {
+      await dbWrite.insert(dockerNodes).values({
+        id: ROBOT_RECORD_ID,
+        node_id: "robot-runtime-1",
+        hostname: "robot.example.test",
+        host_key_fingerprint: "old-host-key",
+        fleet_kind: "robot",
+        infrastructure_provider: "hetzner",
+        node_incarnation: BOOT_A,
+      });
+
+      await expect(
+        resolveAgentBackupManifestSourceAuthority({
+          nodeRecordId: ROBOT_RECORD_ID,
+          nodeId: "robot-runtime-1",
+          nodeIncarnation: BOOT_A,
+          containerId: CONTAINER_ID,
+        }),
+      ).resolves.toMatchObject({ nodeIncarnation: BOOT_A });
+
+      const rotated = await dockerNodesRepository.rotateNodeHostKeyFingerprint({
+        id: ROBOT_RECORD_ID,
+        nodeId: "robot-runtime-1",
+        expectedFingerprint: "old-host-key",
+        observedFingerprint: "new-host-key",
+      });
+      expect(rotated).toMatchObject({
+        host_key_fingerprint: "new-host-key",
+        node_incarnation: null,
+      });
+      await expect(
+        resolveAgentBackupManifestSourceAuthority({
+          nodeRecordId: ROBOT_RECORD_ID,
+          nodeId: "robot-runtime-1",
+          nodeIncarnation: BOOT_A,
+          containerId: CONTAINER_ID,
+        }),
+      ).rejects.toThrow(/unattested|stale/);
+
+      await expect(
+        dockerNodesRepository.attestNodeIncarnation({
+          id: ROBOT_RECORD_ID,
+          nodeId: "robot-runtime-1",
+          expectedIncarnation: null,
+          expectedHostKeyFingerprint: "old-host-key",
+          observedIncarnation: BOOT_B,
+        }),
+      ).rejects.toThrow(/compare-and-swap/);
+
+      await dockerNodesRepository.attestNodeIncarnation({
+        id: ROBOT_RECORD_ID,
+        nodeId: "robot-runtime-1",
+        expectedIncarnation: null,
+        expectedHostKeyFingerprint: "new-host-key",
+        observedIncarnation: BOOT_B,
+      });
+      await expect(
+        resolveAgentBackupManifestSourceAuthority({
+          nodeRecordId: ROBOT_RECORD_ID,
+          nodeId: "robot-runtime-1",
+          nodeIncarnation: BOOT_B,
+          containerId: CONTAINER_ID,
+        }),
+      ).resolves.toMatchObject({ nodeIncarnation: BOOT_B });
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "keeps exact Robot and Cloud source variants disjoint",
+    async () => {
+      await dbWrite.insert(dockerNodes).values({
+        id: CLOUD_RECORD_ID,
+        node_id: "cloud-runtime-1",
+        hostname: "cloud.example.test",
+        host_key_fingerprint: "cloud-host-key",
+        fleet_kind: "cloud",
+        infrastructure_provider: "hetzner",
+        provider_server_id: "4242",
+        node_incarnation: BOOT_C,
+      });
+
+      await expect(
+        resolveAgentBackupManifestSourceAuthority({
+          nodeRecordId: CLOUD_RECORD_ID,
+          nodeId: "cloud-runtime-1",
+          nodeIncarnation: BOOT_C,
+          containerId: CONTAINER_ID,
+        }),
+      ).resolves.toEqual({
+        kind: "cloud",
+        provider: "hetzner",
+        nodeRecordId: CLOUD_RECORD_ID,
+        nodeIncarnation: BOOT_C,
+        nodeId: "cloud-runtime-1",
+        containerId: CONTAINER_ID,
+        providerServerId: "4242",
+      });
+      await expect(
+        dockerNodesRepository.attestRobotSourceAuthority({
+          id: CLOUD_RECORD_ID,
+          nodeId: "cloud-runtime-1",
+          expectedIncarnation: BOOT_C,
+          expectedHostKeyFingerprint: "cloud-host-key",
+          observedIncarnation: BOOT_C,
+          registration: registration(),
+        }),
+      ).rejects.toThrow(/Cloud registration/);
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud/shared/src/db/repositories/agent-backup-catalog.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-catalog.ts
@@ -1,9 +1,28 @@
 /** Durable, tenant-scoped operations for the v2 sandbox-backup catalogue. */
 
-import { and, eq, gt, lte, or, sql } from "drizzle-orm";
+import { Buffer } from "node:buffer";
+import { randomUUID } from "node:crypto";
+import {
+  AGENT_BACKUP_MANIFEST_V2_LIMITS,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_CONTEXT_DERIVATION,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_FORMAT,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_LOCAL_RECEIPT_DERIVATION,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1,
+  type AgentBackupManifestV2,
+  type AgentBackupManifestV2Draft,
+  type AgentBackupManifestV3,
+  type AgentBackupManifestV3Draft,
+  canonicalizeAgentBackupManifestV2,
+  canonicalizeAgentBackupManifestV3,
+  canonicalizeAgentBackupOperationKeyBundleContext,
+  parseAgentBackupManifestV2,
+  parseAgentBackupManifestV3,
+} from "@elizaos/shared";
+import { and, eq, gt, inArray, isNull, lte, or, sql } from "drizzle-orm";
 import {
   assertAgentBackupCatalogTransition,
   boundedBackupCatalogError,
+  catalogStateAllowsRestore,
   requireBoundedIdentity,
   requireSha256Hex,
 } from "../../lib/services/agent-backup-catalog-state";
@@ -21,11 +40,32 @@ import {
 } from "../schemas/agent-backup-catalog";
 import {
   type AgentBackupCatalogState,
+  type AgentBackupKind,
+  type AgentBackupPlainStateData,
+  type AgentBackupRetentionReason,
+  type AgentBackupSnapshotType,
+  type AgentBackupSourceProvider,
   agentSandboxBackups,
+  agentSandboxes,
   type StoredAgentSandboxBackup,
 } from "../schemas/agent-sandboxes";
+import {
+  AgentBackupSourceAuthorityError,
+  requireCanonicalNodeIncarnation,
+  requireCanonicalProviderServerId,
+  resolveAgentBackupManifestSourceAuthorityInTransaction,
+} from "./agent-backup-source-authority";
 
+const EMPTY_BACKUP_STATE: AgentBackupPlainStateData = {
+  memories: [],
+  config: {},
+  workspaceFiles: {},
+};
 const MAX_CATALOG_OBJECT_BYTES = 1024 * 1024 * 1024;
+const MAX_CATALOG_BACKUP_BYTES = 1024 * 1024 * 1024;
+const MAX_OPERATION_CLAIM_BATCH = 100;
+const MAX_OPERATION_LEASE_MS = 5 * 60 * 1_000;
+const MAX_INCREMENTAL_CHAIN_DEPTH = 20;
 
 const EXECUTION_OWNED_STATES = [
   "scheduled",
@@ -41,6 +81,10 @@ const EXECUTION_OWNED_STATES = [
 export interface AgentBackupOperationExecution {
   ownerId: string;
   generation: string;
+}
+
+export interface AgentBackupOperationClaim extends AgentBackupOperationExecution {
+  backup: StoredAgentSandboxBackup;
 }
 
 export class AgentBackupCatalogConflictError extends Error {
@@ -60,6 +104,32 @@ function requireSafeBytes(value: number, field: string, max = Number.MAX_SAFE_IN
     throw new Error(`${field} must be a safe integer between 0 and ${max}`);
   }
   return value;
+}
+
+function requireCanonicalUint64(value: string, field: string): bigint {
+  if (!/^(0|[1-9][0-9]*)$/.test(value)) {
+    throw new Error(`${field} must be a canonical unsigned decimal integer`);
+  }
+  const parsed = BigInt(value);
+  if (parsed > 18_446_744_073_709_551_615n) {
+    throw new Error(`${field} must fit uint64`);
+  }
+  return parsed;
+}
+
+async function createAndLockCatalogAuthority(
+  tx: DbTransaction,
+  organizationId: string,
+  agentId: string,
+): Promise<typeof agentBackupCatalogAuthorities.$inferSelect> {
+  await tx
+    .insert(agentBackupCatalogAuthorities)
+    .values({
+      organization_id: organizationId.toLowerCase(),
+      agent_id: agentId.toLowerCase(),
+    })
+    .onConflictDoNothing();
+  return lockAgentBackupCatalogAuthority(tx, organizationId, agentId);
 }
 
 /** Lock the existing per-agent catalogue authority before any revision CAS. */
@@ -178,6 +248,55 @@ async function sha256Bytes(bytes: Uint8Array): Promise<string> {
   return Array.from(digest, (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value < 0 || Object.is(value, -0)) {
+      throw new AgentBackupCatalogConflictError(
+        "Canonical backup authority contains a non-canonical number",
+      );
+    }
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalJson(entry)).join(",")}]`;
+  }
+  if (typeof value !== "object" || value === undefined) {
+    throw new AgentBackupCatalogConflictError(
+      "Canonical backup authority contains a non-JSON value",
+    );
+  }
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+    .join(",")}}`;
+}
+
+async function canonicalProjectionDigest(value: unknown): Promise<string> {
+  return sha256Hex(canonicalJson(value));
+}
+
+async function operationKeyBundleLocalReceiptDigest(input: {
+  keyId: string;
+  keyVersion: number;
+  canonicalContext: string;
+  wrappedKeyBundle: Uint8Array;
+}): Promise<string> {
+  return sha256Hex(
+    JSON.stringify({
+      derivation: AGENT_BACKUP_OPERATION_KEY_BUNDLE_LOCAL_RECEIPT_DERIVATION,
+      format: AGENT_BACKUP_OPERATION_KEY_BUNDLE_FORMAT,
+      keyId: input.keyId,
+      keyVersion: input.keyVersion,
+      contextSha256: await sha256Hex(input.canonicalContext),
+      wrappedKeyBundleSha256: await sha256Bytes(input.wrappedKeyBundle),
+    }),
+  );
+}
+
 export interface AgentBackupObjectInventoryEntry {
   component: string;
   chunkIndex: number;
@@ -208,6 +327,1309 @@ export async function agentBackupObjectInventoryDigest(
         }),
     }),
   );
+}
+
+function canonicalReservationPayload(input: ReserveAgentBackupOperationInput): string {
+  return JSON.stringify({
+    organizationId: input.organizationId.toLowerCase(),
+    agentId: input.agentId.toLowerCase(),
+    sandboxRecordId: input.sandboxRecordId.toLowerCase(),
+    operationId: input.operationId.toLowerCase(),
+    activationGeneration: input.activationGeneration.toLowerCase(),
+    lifecycleRevision: input.lifecycleRevision,
+    snapshotType: input.snapshotType,
+    backupKind: input.backupKind,
+    parentBackupId: input.parentBackupId?.toLowerCase() ?? null,
+    baseBackupId: input.baseBackupId?.toLowerCase() ?? null,
+    sourceProvider: input.sourceProvider,
+    sourceNodeRecordId: input.sourceNodeRecordId.toLowerCase(),
+    sourceNodeId: input.sourceNodeId,
+    sourceNodeIncarnation: input.sourceNodeIncarnation,
+    sourceProviderServerId: input.sourceProviderServerId,
+    sourceProviderHandle: input.sourceProviderHandle,
+    sourceContainerId: input.sourceContainerId,
+    retentionReason: input.retentionReason,
+    retentionUntil: input.retentionUntil.toISOString(),
+  });
+}
+
+export interface ReserveAgentBackupOperationInput {
+  organizationId: string;
+  agentId: string;
+  sandboxRecordId: string;
+  operationId: string;
+  activationGeneration: string;
+  lifecycleRevision: string;
+  snapshotType: AgentBackupSnapshotType;
+  backupKind: AgentBackupKind;
+  parentBackupId?: string;
+  baseBackupId?: string;
+  sourceProvider: AgentBackupSourceProvider;
+  sourceNodeRecordId: string;
+  sourceNodeId: string;
+  sourceNodeIncarnation: string;
+  sourceProviderServerId: string | null;
+  sourceProviderHandle: string;
+  sourceContainerId: string;
+  retentionReason: AgentBackupRetentionReason;
+  retentionUntil: Date;
+}
+
+function validateReservationInput(input: ReserveAgentBackupOperationInput): void {
+  requireUuid(input.organizationId, "organizationId");
+  requireUuid(input.agentId, "agentId");
+  requireUuid(input.sandboxRecordId, "sandboxRecordId");
+  requireUuid(input.operationId, "operationId");
+  requireUuid(input.activationGeneration, "activationGeneration");
+  requireCanonicalUint64(input.lifecycleRevision, "lifecycleRevision");
+  requireUuid(input.sourceNodeRecordId, "sourceNodeRecordId");
+  requireBoundedIdentity(input.sourceNodeId, "sourceNodeId");
+  requireCanonicalNodeIncarnation(input.sourceNodeIncarnation);
+  if (input.sourceProvider === "operator-onboarded") {
+    if (input.sourceProviderServerId !== null) {
+      throw new Error("Robot backup sourceProviderServerId must be null");
+    }
+  } else if (input.sourceProviderServerId === null) {
+    throw new Error("Cloud backup sourceProviderServerId is required");
+  } else {
+    requireCanonicalProviderServerId(input.sourceProviderServerId);
+  }
+  requireBoundedIdentity(input.sourceProviderHandle, "sourceProviderHandle");
+  if (!/^[0-9a-f]{64}$/.test(input.sourceContainerId)) {
+    throw new Error("sourceContainerId must be a canonical immutable Docker ID");
+  }
+  if (input.sourceProviderHandle === input.sourceContainerId) {
+    throw new Error("sourceProviderHandle and sourceContainerId must be distinct authorities");
+  }
+  if (!Number.isFinite(input.retentionUntil.getTime())) {
+    throw new Error("retentionUntil must be a valid timestamp");
+  }
+  if (input.backupKind !== "full") {
+    throw new AgentBackupCatalogConflictError(
+      "Manifest-v3 catalogue capture is full-only until a real delta producer and compactor are available",
+    );
+  }
+  if (input.parentBackupId !== undefined || input.baseBackupId !== undefined) {
+    throw new Error("A full backup cannot reference parent/base backups");
+  }
+}
+
+function assertReservationReplay(
+  row: StoredAgentSandboxBackup,
+  input: ReserveAgentBackupOperationInput,
+  payloadDigest: string,
+): void {
+  const matches =
+    row.backup_operation_id === input.operationId.toLowerCase() &&
+    row.catalog_organization_id === input.organizationId.toLowerCase() &&
+    row.catalog_agent_id === input.agentId.toLowerCase() &&
+    row.sandbox_record_id === input.sandboxRecordId.toLowerCase() &&
+    row.lifecycle_generation === input.activationGeneration.toLowerCase() &&
+    row.lifecycle_revision === BigInt(input.lifecycleRevision) &&
+    row.catalog_payload_digest === payloadDigest &&
+    row.snapshot_type === input.snapshotType &&
+    row.backup_kind === input.backupKind &&
+    row.parent_backup_id === (input.parentBackupId?.toLowerCase() ?? null) &&
+    row.base_backup_id === (input.baseBackupId?.toLowerCase() ?? null) &&
+    row.source_provider === input.sourceProvider &&
+    row.source_node_record_id === input.sourceNodeRecordId.toLowerCase() &&
+    row.source_node_id === input.sourceNodeId &&
+    row.source_node_incarnation === input.sourceNodeIncarnation &&
+    row.source_provider_server_id === input.sourceProviderServerId &&
+    row.source_provider_handle === input.sourceProviderHandle &&
+    row.source_container_id === input.sourceContainerId &&
+    row.retention_reason === input.retentionReason &&
+    row.retention_until?.getTime() === input.retentionUntil.getTime();
+  if (!matches) {
+    throw new AgentBackupCatalogConflictError(
+      "Backup operation ID was already reserved with a different immutable payload",
+    );
+  }
+}
+
+export async function reserveAgentBackupOperation(
+  input: ReserveAgentBackupOperationInput,
+): Promise<StoredAgentSandboxBackup> {
+  return dbWrite.transaction((tx) => reserveAgentBackupOperationInTransaction(tx, input));
+}
+
+/**
+ * Transaction-aware reservation used by lifecycle authorities that must make
+ * the catalogue row and their owning operation visible in one commit. Callers
+ * own the outer lock order; this function locks the sandbox source authority,
+ * then the exact backup row, source node, and per-agent catalogue authority.
+ */
+export async function reserveAgentBackupOperationInTransaction(
+  tx: DbTransaction,
+  input: ReserveAgentBackupOperationInput,
+): Promise<StoredAgentSandboxBackup> {
+  validateReservationInput(input);
+  const payloadDigest = await sha256Hex(canonicalReservationPayload(input));
+
+  const [sandbox] = await tx
+    .select({
+      id: agentSandboxes.id,
+      organizationId: agentSandboxes.organization_id,
+      nodeId: agentSandboxes.node_id,
+      sandboxId: agentSandboxes.sandbox_id,
+      status: agentSandboxes.status,
+      lifecycleRevision: sql<string>`${agentSandboxes.lifecycle_revision}::text`,
+      activationGeneration: agentSandboxes.activation_generation,
+      activationLifecycleRevision: sql<
+        string | null
+      >`${agentSandboxes.activation_lifecycle_revision}::text`,
+      activationPhase: agentSandboxes.activation_phase,
+      activationReceiptHash: agentSandboxes.activation_receipt_hash,
+      activationContainerId: agentSandboxes.activation_container_id,
+      activationNodeId: agentSandboxes.activation_node_id,
+      activationImageDigest: agentSandboxes.activation_image_digest,
+      activationBootId: agentSandboxes.activation_boot_id,
+      activationAuthorityPublishedAt: agentSandboxes.activation_authority_published_at,
+      activationDispatchedAt: agentSandboxes.activation_dispatched_at,
+      activationCompletedAt: agentSandboxes.activation_completed_at,
+    })
+    .from(agentSandboxes)
+    .where(eq(agentSandboxes.id, input.sandboxRecordId))
+    .for("update")
+    .limit(1);
+  if (!sandbox || sandbox.organizationId !== input.organizationId.toLowerCase()) {
+    throw new AgentBackupCatalogConflictError("Sandbox backup owner does not match");
+  }
+  if (input.agentId.toLowerCase() !== sandbox.id) {
+    throw new AgentBackupCatalogConflictError("Backup agent identity does not match sandbox");
+  }
+  const lifecycleRevision = requireCanonicalUint64(input.lifecycleRevision, "lifecycleRevision");
+  if (
+    sandbox.status !== "running" ||
+    sandbox.activationPhase !== "active" ||
+    sandbox.activationGeneration !== input.activationGeneration.toLowerCase() ||
+    sandbox.lifecycleRevision !== input.lifecycleRevision ||
+    sandbox.activationLifecycleRevision !== input.lifecycleRevision ||
+    !sandbox.activationReceiptHash ||
+    !sandbox.activationBootId ||
+    !sandbox.activationImageDigest ||
+    !sandbox.activationAuthorityPublishedAt ||
+    !sandbox.activationDispatchedAt ||
+    !sandbox.activationCompletedAt ||
+    sandbox.nodeId !== input.sourceNodeId ||
+    sandbox.activationNodeId !== input.sourceNodeId ||
+    sandbox.sandboxId !== input.sourceProviderHandle ||
+    sandbox.activationContainerId !== input.sourceContainerId
+  ) {
+    throw new AgentBackupCatalogConflictError("Backup source generation no longer matches");
+  }
+  let sourceAuthority;
+  try {
+    sourceAuthority = await resolveAgentBackupManifestSourceAuthorityInTransaction(tx, {
+      nodeRecordId: input.sourceNodeRecordId,
+      nodeId: input.sourceNodeId,
+      nodeIncarnation: input.sourceNodeIncarnation,
+      containerId: input.sourceContainerId,
+    });
+  } catch (cause) {
+    if (cause instanceof AgentBackupSourceAuthorityError) {
+      throw new AgentBackupCatalogConflictError(cause.message);
+    }
+    throw cause;
+  }
+  const sourceKind = input.sourceProvider === "operator-onboarded" ? "robot" : "cloud";
+  const resolvedProviderServerId =
+    sourceAuthority.kind === "cloud" ? sourceAuthority.providerServerId : null;
+  if (
+    sourceAuthority.kind !== sourceKind ||
+    resolvedProviderServerId !== input.sourceProviderServerId
+  ) {
+    throw new AgentBackupCatalogConflictError(
+      "Backup source node record or Robot/Cloud provider authority does not match",
+    );
+  }
+
+  if (input.backupKind === "incremental") {
+    const [directParent] = await tx
+      .select()
+      .from(agentSandboxBackups)
+      .where(
+        and(
+          eq(agentSandboxBackups.id, input.parentBackupId as string),
+          eq(agentSandboxBackups.catalog_organization_id, input.organizationId),
+          eq(agentSandboxBackups.catalog_agent_id, input.agentId),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (
+      !directParent ||
+      !directParent.catalog_state ||
+      !catalogStateAllowsRestore(directParent.catalog_state)
+    ) {
+      throw new AgentBackupCatalogConflictError("Incremental parent is not restorable");
+    }
+    const expectedBase =
+      directParent.backup_kind === "full" ? directParent.id : directParent.base_backup_id;
+    if (expectedBase !== input.baseBackupId?.toLowerCase()) {
+      throw new AgentBackupCatalogConflictError("Incremental base does not match parent chain");
+    }
+    const seen = new Set<string>();
+    let cursor = directParent;
+    let parentDepth = 1;
+    while (cursor.backup_kind === "incremental") {
+      if (seen.has(cursor.id)) {
+        throw new AgentBackupCatalogConflictError("Incremental backup chain contains a cycle");
+      }
+      seen.add(cursor.id);
+      if (parentDepth + 1 >= MAX_INCREMENTAL_CHAIN_DEPTH) {
+        throw new AgentBackupCatalogConflictError(
+          `Incremental backup chain cannot exceed ${MAX_INCREMENTAL_CHAIN_DEPTH} rows`,
+        );
+      }
+      if (!cursor.parent_backup_id) {
+        throw new AgentBackupCatalogConflictError("Incremental ancestor has no parent");
+      }
+      const [ancestor] = await tx
+        .select()
+        .from(agentSandboxBackups)
+        .where(
+          and(
+            eq(agentSandboxBackups.id, cursor.parent_backup_id),
+            eq(agentSandboxBackups.catalog_organization_id, input.organizationId),
+            eq(agentSandboxBackups.catalog_agent_id, input.agentId),
+          ),
+        )
+        .for("update")
+        .limit(1);
+      if (!ancestor?.catalog_state || !catalogStateAllowsRestore(ancestor.catalog_state)) {
+        throw new AgentBackupCatalogConflictError(
+          "Incremental ancestor is missing or no longer restorable",
+        );
+      }
+      cursor = ancestor;
+      parentDepth += 1;
+    }
+    if (cursor.id !== input.baseBackupId?.toLowerCase()) {
+      throw new AgentBackupCatalogConflictError("Incremental chain does not terminate at base");
+    }
+  }
+
+  const reservationAuthority = await createAndLockCatalogAuthority(
+    tx,
+    input.organizationId,
+    input.agentId,
+  );
+  const [inserted] = await tx
+    .insert(agentSandboxBackups)
+    .values({
+      id: randomUUID(),
+      sandbox_record_id: input.sandboxRecordId.toLowerCase(),
+      snapshot_type: input.snapshotType,
+      state_data: EMPTY_BACKUP_STATE,
+      state_data_storage: "inline",
+      size_bytes: 0,
+      backup_kind: input.backupKind,
+      parent_backup_id: input.parentBackupId?.toLowerCase() ?? null,
+      base_backup_id: input.baseBackupId?.toLowerCase() ?? null,
+      backup_operation_id: input.operationId.toLowerCase(),
+      catalog_version: 2,
+      catalog_state: "scheduled",
+      catalog_payload_digest: payloadDigest,
+      catalog_organization_id: input.organizationId.toLowerCase(),
+      catalog_agent_id: input.agentId.toLowerCase(),
+      lifecycle_generation: input.activationGeneration.toLowerCase(),
+      lifecycle_revision: lifecycleRevision,
+      source_provider: input.sourceProvider,
+      source_node_record_id: input.sourceNodeRecordId.toLowerCase(),
+      source_node_id: input.sourceNodeId,
+      source_node_incarnation: input.sourceNodeIncarnation,
+      source_provider_server_id: input.sourceProviderServerId,
+      source_provider_handle: input.sourceProviderHandle,
+      source_container_id: input.sourceContainerId,
+      retention_reason: input.retentionReason,
+      retention_until: input.retentionUntil,
+      catalog_next_attempt_at: sql`NOW()`,
+      catalog_updated_at: sql`NOW()`,
+    })
+    .onConflictDoNothing()
+    .returning({ id: agentSandboxBackups.id });
+
+  if (inserted) {
+    const catalogRevision = await advanceAgentBackupCatalogRevision(tx, {
+      organizationId: input.organizationId,
+      agentId: input.agentId,
+      expectedRevision: reservationAuthority.catalog_revision,
+    });
+    const [revisionStamped] = await tx
+      .update(agentSandboxBackups)
+      .set({ catalog_revision: catalogRevision })
+      .where(
+        and(eq(agentSandboxBackups.id, inserted.id), eq(agentSandboxBackups.catalog_revision, 0n)),
+      )
+      .returning({ id: agentSandboxBackups.id });
+    if (!revisionStamped) {
+      throw new AgentBackupCatalogConflictError(
+        "Backup reservation lost its catalogue revision stamp",
+      );
+    }
+  }
+
+  const [row] = await tx
+    .select()
+    .from(agentSandboxBackups)
+    .where(
+      and(
+        eq(agentSandboxBackups.catalog_organization_id, input.organizationId),
+        eq(agentSandboxBackups.catalog_agent_id, input.agentId),
+        eq(agentSandboxBackups.backup_operation_id, input.operationId),
+      ),
+    )
+    .for("update")
+    .limit(1);
+  if (!row) throw new Error("Backup operation reservation disappeared");
+  assertReservationReplay(row, input, payloadDigest);
+  const authority = await lockAgentBackupCatalogAuthority(tx, input.organizationId, input.agentId);
+  if (row.catalog_revision > authority.catalog_revision) {
+    throw new AgentBackupCatalogConflictError(
+      "Backup reservation revision exceeds its catalogue authority",
+    );
+  }
+  return row;
+}
+
+/**
+ * Fairly claim at most one due operation per tenant. Every capture/upload
+ * mutation must carry the returned owner+generation fence.
+ */
+export async function claimDueAgentBackupOperations(params: {
+  ownerId: string;
+  limit: number;
+  leaseMs: number;
+}): Promise<AgentBackupOperationClaim[]> {
+  requireBoundedIdentity(params.ownerId, "ownerId");
+  if (
+    !Number.isSafeInteger(params.limit) ||
+    params.limit < 1 ||
+    params.limit > MAX_OPERATION_CLAIM_BATCH
+  ) {
+    throw new Error(`limit must be between 1 and ${MAX_OPERATION_CLAIM_BATCH}`);
+  }
+  if (
+    !Number.isSafeInteger(params.leaseMs) ||
+    params.leaseMs < 1 ||
+    params.leaseMs > MAX_OPERATION_LEASE_MS
+  ) {
+    throw new Error(`leaseMs must be between 1 and ${MAX_OPERATION_LEASE_MS}`);
+  }
+  const generation = randomUUID();
+
+  return dbWrite.transaction(async (tx) => {
+    const candidates = await sqlRows<{ id: string }>(
+      tx,
+      sql`
+        WITH fair AS MATERIALIZED (
+          SELECT DISTINCT ON (backup.catalog_organization_id)
+            backup.id,
+            backup.catalog_organization_id,
+            COALESCE(backup.catalog_next_attempt_at, backup.created_at) AS due_at,
+            backup.created_at
+          FROM ${agentSandboxBackups} AS backup
+          WHERE backup.catalog_version = 2
+            AND backup.sandbox_record_id IS NOT NULL
+            AND backup.source_provider IN ('operator-onboarded', 'hetzner-cloud')
+            AND backup.source_node_record_id IS NOT NULL
+            AND backup.source_node_id IS NOT NULL
+            AND backup.source_node_id <> ''
+            AND backup.source_node_incarnation IS NOT NULL
+            AND backup.source_provider_handle IS NOT NULL
+            AND backup.source_provider_handle <> ''
+            AND backup.source_container_id ~ '^[0-9a-f]{64}$'
+            AND backup.source_provider_handle <> backup.source_container_id
+            AND (
+              (backup.source_provider = 'operator-onboarded'
+                AND backup.source_provider_server_id IS NULL)
+              OR
+              (backup.source_provider = 'hetzner-cloud'
+                AND CASE
+                  WHEN backup.source_provider_server_id ~ '^[1-9][0-9]{0,19}$'
+                    THEN backup.source_provider_server_id::numeric <= 18446744073709551615
+                  ELSE FALSE
+                END)
+            )
+            AND backup.catalog_state IN (
+              'scheduled', 'capturing', 'captured', 'uploading',
+              'primary_uploaded', 'primary_verified', 'secondary_pending',
+              'failed_retryable'
+            )
+            AND (backup.catalog_next_attempt_at IS NULL OR backup.catalog_next_attempt_at <= NOW())
+            AND (backup.catalog_lease_expires_at IS NULL OR backup.catalog_lease_expires_at <= NOW())
+          ORDER BY backup.catalog_organization_id,
+            COALESCE(backup.catalog_next_attempt_at, backup.created_at), backup.created_at
+        )
+        SELECT backup.id
+        FROM ${agentSandboxBackups} AS backup
+        JOIN fair ON fair.id = backup.id
+        ORDER BY fair.due_at, fair.created_at, backup.id
+        LIMIT ${params.limit}
+        FOR UPDATE OF backup SKIP LOCKED
+      `,
+    );
+    if (candidates.length === 0) return [];
+    const claimed = await tx
+      .update(agentSandboxBackups)
+      .set({
+        catalog_lease_owner: params.ownerId,
+        catalog_lease_generation: generation,
+        catalog_lease_expires_at: sql`NOW() + (${params.leaseMs} * INTERVAL '1 millisecond')`,
+        catalog_updated_at: sql`NOW()`,
+      })
+      .where(
+        and(
+          inArray(
+            agentSandboxBackups.id,
+            candidates.map((candidate) => candidate.id),
+          ),
+          sql`${agentSandboxBackups.sandbox_record_id} IS NOT NULL`,
+          sql`${agentSandboxBackups.source_provider} IN ('operator-onboarded', 'hetzner-cloud')`,
+          sql`${agentSandboxBackups.source_node_record_id} IS NOT NULL`,
+          sql`${agentSandboxBackups.source_node_id} IS NOT NULL
+            AND ${agentSandboxBackups.source_node_id} <> ''`,
+          sql`${agentSandboxBackups.source_node_incarnation} IS NOT NULL`,
+          sql`${agentSandboxBackups.source_provider_handle} IS NOT NULL
+            AND ${agentSandboxBackups.source_provider_handle} <> ''`,
+          sql`${agentSandboxBackups.source_container_id} ~ '^[0-9a-f]{64}$'`,
+          sql`${agentSandboxBackups.source_provider_handle}
+            <> ${agentSandboxBackups.source_container_id}`,
+          sql`(
+            (${agentSandboxBackups.source_provider} = 'operator-onboarded'
+              AND ${agentSandboxBackups.source_provider_server_id} IS NULL)
+            OR
+            (${agentSandboxBackups.source_provider} = 'hetzner-cloud'
+              AND CASE
+                WHEN ${agentSandboxBackups.source_provider_server_id} ~ '^[1-9][0-9]{0,19}$'
+                  THEN ${agentSandboxBackups.source_provider_server_id}::numeric
+                    <= 18446744073709551615
+                ELSE FALSE
+              END)
+          )`,
+          sql`(${agentSandboxBackups.catalog_lease_expires_at} IS NULL
+            OR ${agentSandboxBackups.catalog_lease_expires_at} <= NOW())`,
+        ),
+      )
+      .returning();
+    return claimed.map((backup) => ({
+      backup,
+      ownerId: params.ownerId,
+      generation,
+    }));
+  });
+}
+
+export async function heartbeatAgentBackupOperation(params: {
+  organizationId: string;
+  backupId: string;
+  execution: AgentBackupOperationExecution;
+  leaseMs: number;
+}): Promise<StoredAgentSandboxBackup> {
+  requireUuid(params.organizationId, "organizationId");
+  requireUuid(params.backupId, "backupId");
+  requireOperationExecution(params.execution);
+  if (
+    !Number.isSafeInteger(params.leaseMs) ||
+    params.leaseMs < 1 ||
+    params.leaseMs > MAX_OPERATION_LEASE_MS
+  ) {
+    throw new Error(`leaseMs must be between 1 and ${MAX_OPERATION_LEASE_MS}`);
+  }
+  const [updated] = await dbWrite
+    .update(agentSandboxBackups)
+    .set({
+      catalog_lease_expires_at: sql`NOW() + (${params.leaseMs} * INTERVAL '1 millisecond')`,
+      catalog_updated_at: sql`NOW()`,
+    })
+    .where(
+      and(
+        eq(agentSandboxBackups.id, params.backupId),
+        eq(agentSandboxBackups.catalog_organization_id, params.organizationId),
+        eq(agentSandboxBackups.catalog_lease_owner, params.execution.ownerId),
+        eq(agentSandboxBackups.catalog_lease_generation, params.execution.generation),
+        gt(agentSandboxBackups.catalog_lease_expires_at, sql`NOW()`),
+        sql`${agentSandboxBackups.sandbox_record_id} IS NOT NULL`,
+        sql`${agentSandboxBackups.catalog_state} IN (${sql.join(
+          EXECUTION_OWNED_STATES.map((state) => sql`${state}`),
+          sql`, `,
+        )})`,
+      ),
+    )
+    .returning();
+  if (!updated) {
+    throw new AgentBackupCatalogConflictError(
+      "Backup operation heartbeat lost its execution generation",
+    );
+  }
+  return updated;
+}
+
+interface CapturedAgentBackupManifestCommon {
+  /** Exact canonical manifest draft bytes (integrity.manifestSha256 omitted). */
+  canonicalManifestDraft: string;
+  format: string;
+  version: number;
+  digest: string;
+  objectCount: number;
+  objectInventoryDigest: string;
+  imageDigest: string;
+  databaseSchemaVersion: string;
+  pluginSetDigest: string;
+  watermarkDigest: string;
+  rawSizeBytes: number;
+  compressedSizeBytes: number;
+  encryptedSizeBytes: number;
+  kmsKeyId: string;
+  kmsKeyVersion: number;
+}
+
+export interface CapturedAgentBackupManifestV2
+  extends Omit<CapturedAgentBackupManifestCommon, "version"> {
+  version: 2;
+  wrappedDekCiphertextBase64: string;
+  wrappedDekReceiptDigest: string;
+  wrappedKeyBundleCiphertextBase64?: never;
+  wrappedKeyBundleSha256?: never;
+  wrappedKeyBundleLocalReceiptDigest?: never;
+  wrappedKeyBundleGenerationId?: never;
+  vaultKeyGenerationId?: never;
+  vaultKeyAuthorityReceiptDigest?: never;
+}
+
+export interface CapturedAgentBackupManifestV3
+  extends Omit<CapturedAgentBackupManifestCommon, "version"> {
+  version: 3;
+  wrappedDekCiphertextBase64?: never;
+  wrappedDekReceiptDigest?: never;
+  /** Exact 92-byte nonce || ciphertext || tag KMS envelope. */
+  wrappedKeyBundleCiphertextBase64: string;
+  wrappedKeyBundleSha256: string;
+  wrappedKeyBundleLocalReceiptDigest: string;
+  wrappedKeyBundleGenerationId: string;
+  vaultKeyGenerationId: string;
+  vaultKeyAuthorityReceiptDigest: string;
+}
+
+export type CapturedAgentBackupManifest =
+  | CapturedAgentBackupManifestV2
+  | CapturedAgentBackupManifestV3;
+
+/** Temporary structural compatibility for the already-separated v2 producer. */
+type CompatibleCapturedAgentBackupManifestV2 = CapturedAgentBackupManifestCommon & {
+  wrappedDekCiphertextBase64: string;
+  wrappedDekReceiptDigest: string;
+  wrappedKeyBundleCiphertextBase64?: never;
+  wrappedKeyBundleSha256?: never;
+  wrappedKeyBundleLocalReceiptDigest?: never;
+  wrappedKeyBundleGenerationId?: never;
+  vaultKeyGenerationId?: never;
+  vaultKeyAuthorityReceiptDigest?: never;
+};
+
+type CapturedAgentBackupManifestInput =
+  | CapturedAgentBackupManifest
+  | CompatibleCapturedAgentBackupManifestV2;
+
+interface CapturedManifestEnvelopeColumns {
+  wrapped_dek_ref: string | null;
+  wrapped_dek_ciphertext_base64: string | null;
+  wrapped_dek_sha256: string | null;
+  wrapped_dek_size_bytes: number | null;
+  wrapped_dek_receipt_digest: string | null;
+  operation_key_bundle_generation_id: string | null;
+  operation_key_bundle_format: string | null;
+  operation_key_bundle_ref: string | null;
+  operation_key_bundle_ciphertext_base64: string | null;
+  operation_key_bundle_sha256: string | null;
+  operation_key_bundle_size_bytes: number | null;
+  operation_key_bundle_context: string | null;
+  operation_key_bundle_context_derivation: string | null;
+  operation_key_bundle_local_receipt_derivation: string | null;
+  operation_key_bundle_local_receipt_digest: string | null;
+  vault_key_generation_id: string | null;
+  vault_key_authority_receipt_digest: string | null;
+}
+
+interface ValidatedCapturedManifest {
+  parsed: AgentBackupManifestV2 | AgentBackupManifestV3;
+  canonicalDraft: string;
+  envelope: CapturedManifestEnvelopeColumns;
+}
+
+const V2_CAPTURE_FIELDS = ["wrappedDekCiphertextBase64", "wrappedDekReceiptDigest"] as const;
+const V3_CAPTURE_FIELDS = [
+  "wrappedKeyBundleCiphertextBase64",
+  "wrappedKeyBundleSha256",
+  "wrappedKeyBundleLocalReceiptDigest",
+  "wrappedKeyBundleGenerationId",
+  "vaultKeyGenerationId",
+  "vaultKeyAuthorityReceiptDigest",
+] as const;
+
+function ownsField(value: object, field: PropertyKey): boolean {
+  return Object.hasOwn(value, field);
+}
+
+function requireCapturedString(
+  manifest: CapturedAgentBackupManifestInput,
+  field: (typeof V2_CAPTURE_FIELDS)[number] | (typeof V3_CAPTURE_FIELDS)[number],
+): string {
+  const value: unknown = Reflect.get(manifest, field);
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`manifest.${field} must be a non-empty string`);
+  }
+  return value;
+}
+
+function decodeCanonicalBase64(value: string, field: string): Uint8Array {
+  const bytes = Buffer.from(value, "base64");
+  if (bytes.byteLength === 0 || bytes.toString("base64") !== value) {
+    throw new AgentBackupCatalogConflictError(`${field} must be canonical base64`);
+  }
+  return bytes;
+}
+
+function withManifestDigest(draft: unknown, digest: string): unknown {
+  if (typeof draft !== "object" || draft === null || Array.isArray(draft)) {
+    throw new Error("manifest.canonicalManifestDraft must contain a JSON object");
+  }
+  const integrity = (draft as Record<string, unknown>).integrity;
+  if (typeof integrity !== "object" || integrity === null || Array.isArray(integrity)) {
+    throw new Error("manifest.canonicalManifestDraft must contain integrity metadata");
+  }
+  return {
+    ...draft,
+    integrity: { ...integrity, manifestSha256: digest },
+  };
+}
+
+async function validateCapturedManifest(
+  manifest: CapturedAgentBackupManifestInput,
+): Promise<ValidatedCapturedManifest> {
+  requireBoundedIdentity(manifest.format, "manifest.format");
+  requireBoundedIdentity(manifest.imageDigest, "manifest.imageDigest");
+  requireBoundedIdentity(manifest.databaseSchemaVersion, "manifest.databaseSchemaVersion");
+  requireBoundedIdentity(manifest.kmsKeyId, "manifest.kmsKeyId");
+  requireSha256Hex(manifest.digest, "manifest.digest");
+  requireSha256Hex(manifest.objectInventoryDigest, "manifest.objectInventoryDigest");
+  requireSha256Hex(manifest.pluginSetDigest, "manifest.pluginSetDigest");
+  requireSha256Hex(manifest.watermarkDigest, "manifest.watermarkDigest");
+  requireSafeBytes(manifest.rawSizeBytes, "manifest.rawSizeBytes", MAX_CATALOG_BACKUP_BYTES);
+  requireSafeBytes(
+    manifest.compressedSizeBytes,
+    "manifest.compressedSizeBytes",
+    MAX_CATALOG_BACKUP_BYTES,
+  );
+  requireSafeBytes(
+    manifest.encryptedSizeBytes,
+    "manifest.encryptedSizeBytes",
+    MAX_CATALOG_BACKUP_BYTES,
+  );
+  requireSafeBytes(manifest.objectCount, "manifest.objectCount", 8_192);
+  if (manifest.objectCount < 1) {
+    throw new Error("manifest.objectCount must be between 1 and 8192");
+  }
+  if (manifest.version !== 2 && manifest.version !== 3) {
+    throw new Error("manifest.version must be exactly 2 or 3");
+  }
+  if (!Number.isSafeInteger(manifest.kmsKeyVersion) || manifest.kmsKeyVersion < 1) {
+    throw new Error("manifest.kmsKeyVersion must be a positive safe integer");
+  }
+  if (
+    new TextEncoder().encode(manifest.canonicalManifestDraft).byteLength >
+    AGENT_BACKUP_MANIFEST_V2_LIMITS.maxManifestBytes
+  ) {
+    throw new Error("manifest.canonicalManifestDraft exceeds the manifest byte limit");
+  }
+  let draft: unknown;
+  try {
+    draft = JSON.parse(manifest.canonicalManifestDraft);
+  } catch (cause) {
+    throw new Error("manifest.canonicalManifestDraft must be valid JSON", { cause });
+  }
+  const canonicalDraft =
+    manifest.version === 2
+      ? canonicalizeAgentBackupManifestV2(draft as AgentBackupManifestV2Draft)
+      : canonicalizeAgentBackupManifestV3(draft as AgentBackupManifestV3Draft);
+  if (canonicalDraft !== manifest.canonicalManifestDraft) {
+    throw new Error(
+      `manifest.canonicalManifestDraft must use canonical manifest-v${manifest.version} JSON`,
+    );
+  }
+  const completeManifest = withManifestDigest(draft, manifest.digest);
+  const parsed =
+    manifest.version === 2
+      ? await parseAgentBackupManifestV2(completeManifest)
+      : await parseAgentBackupManifestV3(completeManifest);
+  if (
+    parsed.format !== manifest.format ||
+    parsed.schemaVersion !== manifest.version ||
+    parsed.integrity.manifestSha256 !== manifest.digest ||
+    parsed.runtime.imageDigest !== manifest.imageDigest ||
+    parsed.runtime.databaseSchemaVersion !== manifest.databaseSchemaVersion ||
+    parsed.totals.plainBytes !== manifest.rawSizeBytes ||
+    parsed.totals.compressedBytes !== manifest.compressedSizeBytes ||
+    parsed.totals.encryptedBytes !== manifest.encryptedSizeBytes ||
+    parsed.encryption.kms.keyId !== manifest.kmsKeyId ||
+    parsed.encryption.kms.keyVersion !== manifest.kmsKeyVersion
+  ) {
+    throw new AgentBackupCatalogConflictError(
+      `Captured manifest summary does not match its canonical manifest-v${manifest.version} authority`,
+    );
+  }
+  const expectedPluginSetDigest = await canonicalProjectionDigest({
+    version: 1,
+    plugins: parsed.runtime.plugins,
+  });
+  const expectedWatermarkDigest = await canonicalProjectionDigest({
+    version: 1,
+    watermarks: parsed.watermarks,
+  });
+  if (
+    manifest.pluginSetDigest !== expectedPluginSetDigest ||
+    manifest.watermarkDigest !== expectedWatermarkDigest
+  ) {
+    throw new AgentBackupCatalogConflictError(
+      `Captured manifest projection digests do not match canonical manifest-v${manifest.version} authority`,
+    );
+  }
+  const inventory = parsed.components.flatMap((component) =>
+    component.chunks.map((chunk) => ({
+      component: component.name,
+      chunkIndex: chunk.index,
+      contentHmacSha256: chunk.contentHmacSha256,
+      ciphertextSha256: chunk.sha256,
+      sizeBytes: chunk.encryptedBytes,
+    })),
+  );
+  if (
+    inventory.length !== manifest.objectCount ||
+    (await agentBackupObjectInventoryDigest(inventory)) !== manifest.objectInventoryDigest
+  ) {
+    throw new AgentBackupCatalogConflictError(
+      `Captured object inventory does not match canonical manifest-v${manifest.version} chunks`,
+    );
+  }
+
+  if (manifest.version === 2) {
+    if (V3_CAPTURE_FIELDS.some((field) => ownsField(manifest, field))) {
+      throw new AgentBackupCatalogConflictError(
+        "Manifest-v2 capture cannot contain operation key-bundle fields",
+      );
+    }
+    const wrappedDekCiphertextBase64 = requireCapturedString(
+      manifest,
+      "wrappedDekCiphertextBase64",
+    );
+    const wrappedDekReceiptDigest = requireCapturedString(manifest, "wrappedDekReceiptDigest");
+    requireSha256Hex(wrappedDekReceiptDigest, "manifest.wrappedDekReceiptDigest");
+    const wrappedDek = decodeCanonicalBase64(
+      wrappedDekCiphertextBase64,
+      "manifest.wrappedDekCiphertextBase64",
+    );
+    if (
+      parsed.schemaVersion !== 2 ||
+      wrappedDek.byteLength !== parsed.encryption.wrappedDek.bytes ||
+      (await sha256Bytes(wrappedDek)) !== parsed.encryption.wrappedDek.sha256
+    ) {
+      throw new AgentBackupCatalogConflictError(
+        "Wrapped DEK bytes do not match canonical manifest-v2 authority",
+      );
+    }
+    return {
+      parsed,
+      canonicalDraft,
+      envelope: {
+        wrapped_dek_ref: parsed.encryption.wrappedDek.ref,
+        wrapped_dek_ciphertext_base64: wrappedDekCiphertextBase64,
+        wrapped_dek_sha256: parsed.encryption.wrappedDek.sha256,
+        wrapped_dek_size_bytes: parsed.encryption.wrappedDek.bytes,
+        wrapped_dek_receipt_digest: wrappedDekReceiptDigest,
+        operation_key_bundle_generation_id: null,
+        operation_key_bundle_format: null,
+        operation_key_bundle_ref: null,
+        operation_key_bundle_ciphertext_base64: null,
+        operation_key_bundle_sha256: null,
+        operation_key_bundle_size_bytes: null,
+        operation_key_bundle_context: null,
+        operation_key_bundle_context_derivation: null,
+        operation_key_bundle_local_receipt_derivation: null,
+        operation_key_bundle_local_receipt_digest: null,
+        vault_key_generation_id: null,
+        vault_key_authority_receipt_digest: null,
+      },
+    };
+  }
+
+  if (V2_CAPTURE_FIELDS.some((field) => ownsField(manifest, field))) {
+    throw new AgentBackupCatalogConflictError(
+      "Manifest-v3 capture cannot contain wrapped-DEK fields",
+    );
+  }
+  if (parsed.schemaVersion !== 3) {
+    throw new AgentBackupCatalogConflictError("Manifest-v3 parser returned the wrong version");
+  }
+  // This durable boundary has no trusted deployment-environment authority, so
+  // local wrapping fails closed instead of being accepted outside development.
+  if (parsed.encryption.kms.provider !== "steward") {
+    throw new AgentBackupCatalogConflictError(
+      "Durable Hetzner catalogue capture requires a Steward-wrapped manifest-v3 key bundle",
+    );
+  }
+  const wrappedKeyBundleCiphertextBase64 = requireCapturedString(
+    manifest,
+    "wrappedKeyBundleCiphertextBase64",
+  );
+  const wrappedKeyBundleSha256 = requireCapturedString(manifest, "wrappedKeyBundleSha256");
+  const wrappedKeyBundleLocalReceiptDigest = requireCapturedString(
+    manifest,
+    "wrappedKeyBundleLocalReceiptDigest",
+  );
+  const wrappedKeyBundleGenerationId = requireCapturedString(
+    manifest,
+    "wrappedKeyBundleGenerationId",
+  );
+  const vaultKeyGenerationId = requireCapturedString(manifest, "vaultKeyGenerationId");
+  const vaultKeyAuthorityReceiptDigest = requireCapturedString(
+    manifest,
+    "vaultKeyAuthorityReceiptDigest",
+  );
+  requireUuid(wrappedKeyBundleGenerationId, "manifest.wrappedKeyBundleGenerationId");
+  requireUuid(vaultKeyGenerationId, "manifest.vaultKeyGenerationId");
+  requireSha256Hex(wrappedKeyBundleSha256, "manifest.wrappedKeyBundleSha256");
+  requireSha256Hex(
+    wrappedKeyBundleLocalReceiptDigest,
+    "manifest.wrappedKeyBundleLocalReceiptDigest",
+  );
+  requireSha256Hex(vaultKeyAuthorityReceiptDigest, "manifest.vaultKeyAuthorityReceiptDigest");
+  const operationKeyBundle = parsed.encryption.operationKeyBundle;
+  const wrapped = operationKeyBundle.wrapped;
+  const wrappedKeyBundle = decodeCanonicalBase64(
+    wrappedKeyBundleCiphertextBase64,
+    "manifest.wrappedKeyBundleCiphertextBase64",
+  );
+  const canonicalContext = canonicalizeAgentBackupOperationKeyBundleContext({
+    organizationId: parsed.identity.organizationId,
+    agentId: parsed.identity.agentId,
+    activationGeneration: parsed.identity.activationGeneration,
+    lifecycleRevision: parsed.identity.lifecycleRevision,
+    operationId: parsed.operationId,
+    keyBundleGenerationId: operationKeyBundle.generationId,
+    sourceKind: parsed.source.kind,
+    sourceProvider: parsed.source.provider,
+    kmsProvider: parsed.encryption.kms.provider,
+    keyId: parsed.encryption.kms.keyId,
+    keyVersion: parsed.encryption.kms.keyVersion,
+  });
+  const computedBundleSha256 = await sha256Bytes(wrappedKeyBundle);
+  const computedLocalReceiptDigest = await operationKeyBundleLocalReceiptDigest({
+    keyId: parsed.encryption.kms.keyId,
+    keyVersion: parsed.encryption.kms.keyVersion,
+    canonicalContext,
+    wrappedKeyBundle,
+  });
+  if (
+    operationKeyBundle.format !== AGENT_BACKUP_OPERATION_KEY_BUNDLE_FORMAT ||
+    wrapped.bytes !== AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.wrappedBytes ||
+    wrappedKeyBundle.byteLength !== wrapped.bytes ||
+    wrappedKeyBundleGenerationId !== operationKeyBundle.generationId ||
+    wrappedKeyBundleSha256 !== wrapped.sha256 ||
+    computedBundleSha256 !== wrapped.sha256 ||
+    wrapped.contextDerivation !== AGENT_BACKUP_OPERATION_KEY_BUNDLE_CONTEXT_DERIVATION ||
+    wrapped.localReceiptDerivation !== AGENT_BACKUP_OPERATION_KEY_BUNDLE_LOCAL_RECEIPT_DERIVATION ||
+    wrappedKeyBundleLocalReceiptDigest !== wrapped.localReceiptDigest ||
+    computedLocalReceiptDigest !== wrapped.localReceiptDigest ||
+    vaultKeyGenerationId !== parsed.vaultKeyAuthority.generationId ||
+    vaultKeyAuthorityReceiptDigest !== parsed.vaultKeyAuthority.receiptDigest
+  ) {
+    throw new AgentBackupCatalogConflictError(
+      "Wrapped operation key bundle does not match canonical manifest-v3 authority",
+    );
+  }
+  return {
+    parsed,
+    canonicalDraft,
+    envelope: {
+      wrapped_dek_ref: null,
+      wrapped_dek_ciphertext_base64: null,
+      wrapped_dek_sha256: null,
+      wrapped_dek_size_bytes: null,
+      wrapped_dek_receipt_digest: null,
+      operation_key_bundle_generation_id: operationKeyBundle.generationId,
+      operation_key_bundle_format: operationKeyBundle.format,
+      operation_key_bundle_ref: wrapped.ref,
+      operation_key_bundle_ciphertext_base64: wrappedKeyBundleCiphertextBase64,
+      operation_key_bundle_sha256: wrapped.sha256,
+      operation_key_bundle_size_bytes: wrapped.bytes,
+      operation_key_bundle_context: canonicalContext,
+      operation_key_bundle_context_derivation: wrapped.contextDerivation,
+      operation_key_bundle_local_receipt_derivation: wrapped.localReceiptDerivation,
+      operation_key_bundle_local_receipt_digest: wrapped.localReceiptDigest,
+      vault_key_generation_id: parsed.vaultKeyAuthority.generationId,
+      vault_key_authority_receipt_digest: parsed.vaultKeyAuthority.receiptDigest,
+    },
+  };
+}
+
+function capturedManifestMatches(
+  row: StoredAgentSandboxBackup,
+  manifest: CapturedAgentBackupManifestInput,
+  validated: ValidatedCapturedManifest,
+): boolean {
+  return (
+    row.manifest_format === manifest.format &&
+    row.manifest_version === manifest.version &&
+    row.manifest_digest === manifest.digest &&
+    row.manifest_canonical_draft === manifest.canonicalManifestDraft &&
+    row.manifest_object_count === manifest.objectCount &&
+    row.object_inventory_digest === manifest.objectInventoryDigest &&
+    row.image_digest === manifest.imageDigest &&
+    row.database_schema_version === manifest.databaseSchemaVersion &&
+    row.plugin_set_digest === manifest.pluginSetDigest &&
+    row.watermark_digest === manifest.watermarkDigest &&
+    row.raw_size_bytes === manifest.rawSizeBytes &&
+    row.compressed_size_bytes === manifest.compressedSizeBytes &&
+    row.encrypted_size_bytes === manifest.encryptedSizeBytes &&
+    row.kms_key_id === manifest.kmsKeyId &&
+    row.kms_key_version === manifest.kmsKeyVersion &&
+    Object.entries(validated.envelope).every(
+      ([field, value]) => row[field as keyof CapturedManifestEnvelopeColumns] === value,
+    )
+  );
+}
+
+async function resolveReservedManifestChainAuthority(
+  tx: DbTransaction,
+  row: StoredAgentSandboxBackup,
+): Promise<AgentBackupManifestV3["chain"]> {
+  if (row.backup_kind === "full") {
+    return { kind: "full", baseOperationId: null, parentOperationId: null, depth: 0 };
+  }
+  if (
+    !row.parent_backup_id ||
+    !row.base_backup_id ||
+    !row.catalog_organization_id ||
+    !row.catalog_agent_id
+  ) {
+    throw new AgentBackupCatalogConflictError(
+      "Canonical manifest chain does not match the incremental backup reservation",
+    );
+  }
+
+  const seen = new Set<string>();
+  let cursorId = row.parent_backup_id;
+  let depth = 1;
+  let directParentOperationId: string | null = null;
+  let baseOperationId: string | null = null;
+  for (;;) {
+    if (seen.has(cursorId) || depth > MAX_INCREMENTAL_CHAIN_DEPTH) {
+      throw new AgentBackupCatalogConflictError(
+        "Incremental backup reservation contains an invalid chain",
+      );
+    }
+    seen.add(cursorId);
+    const [ancestor] = await tx
+      .select()
+      .from(agentSandboxBackups)
+      .where(
+        and(
+          eq(agentSandboxBackups.id, cursorId),
+          eq(agentSandboxBackups.catalog_organization_id, row.catalog_organization_id),
+          eq(agentSandboxBackups.catalog_agent_id, row.catalog_agent_id),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (!ancestor?.backup_operation_id) {
+      throw new AgentBackupCatalogConflictError(
+        "Incremental backup reservation references a missing chain authority",
+      );
+    }
+    directParentOperationId ??= ancestor.backup_operation_id;
+    if (ancestor.backup_kind === "full") {
+      if (ancestor.id !== row.base_backup_id) {
+        throw new AgentBackupCatalogConflictError(
+          "Incremental backup reservation does not terminate at its base",
+        );
+      }
+      baseOperationId = ancestor.backup_operation_id;
+      break;
+    }
+    if (!ancestor.parent_backup_id) {
+      throw new AgentBackupCatalogConflictError(
+        "Incremental backup reservation contains an ancestor without a parent",
+      );
+    }
+    cursorId = ancestor.parent_backup_id;
+    depth += 1;
+  }
+
+  if (!directParentOperationId || !baseOperationId) {
+    throw new AgentBackupCatalogConflictError(
+      "Incremental backup reservation has no complete operation chain",
+    );
+  }
+  return {
+    kind: "incremental",
+    parentOperationId: directParentOperationId,
+    baseOperationId,
+    depth,
+  };
+}
+
+async function assertCapturedManifestChainMatchesReservation(
+  tx: DbTransaction,
+  row: StoredAgentSandboxBackup,
+  parsed: AgentBackupManifestV2 | AgentBackupManifestV3,
+): Promise<void> {
+  const expected = await resolveReservedManifestChainAuthority(tx, row);
+  if (canonicalJson(parsed.chain) !== canonicalJson(expected)) {
+    throw new AgentBackupCatalogConflictError(
+      "Canonical manifest chain differs from its durable reservation",
+    );
+  }
+}
+
+/** Resolve the exact manifest chain for one currently owned capture operation. */
+export async function loadAgentBackupManifestChainAuthority(params: {
+  organizationId: string;
+  backupId: string;
+  operationId: string;
+  execution: AgentBackupOperationExecution;
+}): Promise<AgentBackupManifestV3["chain"]> {
+  requireUuid(params.organizationId, "organizationId");
+  requireUuid(params.backupId, "backupId");
+  requireUuid(params.operationId, "operationId");
+  return dbWrite.transaction(async (tx) => {
+    const [row] = await tx
+      .select()
+      .from(agentSandboxBackups)
+      .where(
+        and(
+          eq(agentSandboxBackups.id, params.backupId),
+          eq(agentSandboxBackups.catalog_organization_id, params.organizationId),
+          eq(agentSandboxBackups.backup_operation_id, params.operationId),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (!row?.catalog_state || row.catalog_state !== "capturing") {
+      throw new AgentBackupCatalogConflictError(
+        "Manifest chain authority requires an owned capturing operation",
+      );
+    }
+    await assertOwnedOperationExecution(tx, row, params.execution);
+    return resolveReservedManifestChainAuthority(tx, row);
+  });
+}
+
+export async function recordCapturedAgentBackupManifest(params: {
+  organizationId: string;
+  backupId: string;
+  operationId: string;
+  expectedActivationGeneration: string;
+  expectedLifecycleRevision: string;
+  execution: AgentBackupOperationExecution;
+  manifest: CapturedAgentBackupManifestInput;
+}): Promise<StoredAgentSandboxBackup> {
+  requireUuid(params.organizationId, "organizationId");
+  requireUuid(params.backupId, "backupId");
+  requireUuid(params.operationId, "operationId");
+  requireUuid(params.expectedActivationGeneration, "expectedActivationGeneration");
+  const expectedLifecycleRevision = requireCanonicalUint64(
+    params.expectedLifecycleRevision,
+    "expectedLifecycleRevision",
+  );
+  const validatedManifest = await validateCapturedManifest(params.manifest);
+
+  return dbWrite.transaction(async (tx) => {
+    const [row] = await tx
+      .select()
+      .from(agentSandboxBackups)
+      .where(
+        and(
+          eq(agentSandboxBackups.id, params.backupId),
+          eq(agentSandboxBackups.catalog_organization_id, params.organizationId),
+          eq(agentSandboxBackups.backup_operation_id, params.operationId),
+          eq(agentSandboxBackups.lifecycle_generation, params.expectedActivationGeneration),
+          eq(agentSandboxBackups.lifecycle_revision, expectedLifecycleRevision),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (!row?.catalog_state) throw new AgentBackupCatalogConflictError("Backup operation missing");
+    await assertOwnedOperationExecution(tx, row, params.execution);
+    if (
+      !row.sandbox_record_id ||
+      !row.catalog_organization_id ||
+      !row.catalog_agent_id ||
+      !row.source_node_record_id ||
+      !row.source_node_id ||
+      !row.source_node_incarnation ||
+      !row.source_container_id
+    ) {
+      throw new AgentBackupCatalogConflictError(
+        "Captured backup is missing its immutable source authority",
+      );
+    }
+    const [sourceSandbox] = await tx
+      .select({
+        status: agentSandboxes.status,
+        nodeId: agentSandboxes.node_id,
+        sandboxId: agentSandboxes.sandbox_id,
+        lifecycleRevision: sql<string>`${agentSandboxes.lifecycle_revision}::text`,
+        activationGeneration: agentSandboxes.activation_generation,
+        activationLifecycleRevision: sql<
+          string | null
+        >`${agentSandboxes.activation_lifecycle_revision}::text`,
+        activationPhase: agentSandboxes.activation_phase,
+        activationReceiptHash: agentSandboxes.activation_receipt_hash,
+        activationContainerId: agentSandboxes.activation_container_id,
+        activationNodeId: agentSandboxes.activation_node_id,
+        activationImageDigest: agentSandboxes.activation_image_digest,
+        activationBootId: agentSandboxes.activation_boot_id,
+        activationAuthorityPublishedAt: agentSandboxes.activation_authority_published_at,
+        activationDispatchedAt: agentSandboxes.activation_dispatched_at,
+        activationCompletedAt: agentSandboxes.activation_completed_at,
+      })
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.id, row.sandbox_record_id),
+          eq(agentSandboxes.organization_id, row.catalog_organization_id),
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (
+      !sourceSandbox ||
+      sourceSandbox.status !== "running" ||
+      sourceSandbox.activationPhase !== "active" ||
+      sourceSandbox.activationGeneration !== row.lifecycle_generation ||
+      sourceSandbox.lifecycleRevision !== params.expectedLifecycleRevision ||
+      sourceSandbox.activationLifecycleRevision !== params.expectedLifecycleRevision ||
+      !sourceSandbox.activationReceiptHash ||
+      !sourceSandbox.activationBootId ||
+      !sourceSandbox.activationAuthorityPublishedAt ||
+      !sourceSandbox.activationDispatchedAt ||
+      !sourceSandbox.activationCompletedAt ||
+      sourceSandbox.nodeId !== row.source_node_id ||
+      sourceSandbox.activationNodeId !== row.source_node_id ||
+      sourceSandbox.sandboxId !== row.source_provider_handle ||
+      sourceSandbox.activationContainerId !== row.source_container_id ||
+      sourceSandbox.activationImageDigest !== validatedManifest.parsed.runtime.imageDigest
+    ) {
+      throw new AgentBackupCatalogConflictError(
+        "Backup source activation changed before the manifest was recorded",
+      );
+    }
+    let currentSourceAuthority;
+    try {
+      currentSourceAuthority = await resolveAgentBackupManifestSourceAuthorityInTransaction(tx, {
+        nodeRecordId: row.source_node_record_id,
+        nodeId: row.source_node_id,
+        nodeIncarnation: row.source_node_incarnation,
+        containerId: row.source_container_id,
+      });
+    } catch (cause) {
+      if (cause instanceof AgentBackupSourceAuthorityError) {
+        throw new AgentBackupCatalogConflictError(cause.message);
+      }
+      throw cause;
+    }
+    const currentProviderServerId =
+      currentSourceAuthority.kind === "cloud" ? currentSourceAuthority.providerServerId : null;
+    if (
+      currentSourceAuthority.kind !==
+        (row.source_provider === "operator-onboarded" ? "robot" : "cloud") ||
+      currentProviderServerId !== row.source_provider_server_id
+    ) {
+      throw new AgentBackupCatalogConflictError(
+        "Backup source node authority changed before the manifest was recorded",
+      );
+    }
+    const expectedSourceKind = row.source_provider === "operator-onboarded" ? "robot" : "cloud";
+    if (
+      validatedManifest.parsed.operationId !== params.operationId.toLowerCase() ||
+      validatedManifest.parsed.identity.organizationId !== params.organizationId.toLowerCase() ||
+      validatedManifest.parsed.identity.agentId !== row.catalog_agent_id ||
+      validatedManifest.parsed.identity.activationGeneration !==
+        params.expectedActivationGeneration.toLowerCase() ||
+      validatedManifest.parsed.identity.lifecycleRevision !== params.expectedLifecycleRevision ||
+      validatedManifest.parsed.source.kind !== expectedSourceKind ||
+      validatedManifest.parsed.source.nodeRecordId !== row.source_node_record_id ||
+      validatedManifest.parsed.source.nodeId !== row.source_node_id ||
+      validatedManifest.parsed.source.nodeIncarnation !== row.source_node_incarnation ||
+      (validatedManifest.parsed.source.kind === "cloud"
+        ? validatedManifest.parsed.source.providerServerId
+        : null) !== row.source_provider_server_id ||
+      validatedManifest.parsed.source.containerId !== row.source_container_id ||
+      validatedManifest.parsed.runtime.imageDigest !== sourceSandbox.activationImageDigest ||
+      validatedManifest.parsed.createdAt !== row.created_at.toISOString()
+    ) {
+      throw new AgentBackupCatalogConflictError(
+        `Canonical manifest-v${validatedManifest.parsed.schemaVersion} identity or immutable source does not match reservation`,
+      );
+    }
+    await assertCapturedManifestChainMatchesReservation(tx, row, validatedManifest.parsed);
+    if (row.catalog_state === "captured") {
+      if (!capturedManifestMatches(row, params.manifest, validatedManifest)) {
+        throw new AgentBackupCatalogConflictError(
+          "Backup operation was already captured with a different manifest",
+        );
+      }
+      return row;
+    }
+    assertAgentBackupCatalogTransition({ from: row.catalog_state, to: "captured" });
+    if (!row.catalog_organization_id || !row.catalog_agent_id) {
+      throw new AgentBackupCatalogConflictError("Backup catalogue authority is missing");
+    }
+    const authority = await lockAgentBackupCatalogAuthority(
+      tx,
+      row.catalog_organization_id,
+      row.catalog_agent_id,
+    );
+    const catalogRevision = await advanceAgentBackupCatalogRevision(tx, {
+      organizationId: row.catalog_organization_id,
+      agentId: row.catalog_agent_id,
+      expectedRevision: authority.catalog_revision,
+    });
+    const [updated] = await tx
+      .update(agentSandboxBackups)
+      .set({
+        catalog_state: "captured",
+        catalog_revision: catalogRevision,
+        manifest_format: params.manifest.format,
+        manifest_version: validatedManifest.parsed.schemaVersion,
+        manifest_digest: params.manifest.digest,
+        manifest_canonical_draft: validatedManifest.canonicalDraft,
+        manifest_object_count: params.manifest.objectCount,
+        object_inventory_digest: params.manifest.objectInventoryDigest,
+        image_digest: params.manifest.imageDigest,
+        database_schema_version: params.manifest.databaseSchemaVersion,
+        plugin_set_digest: params.manifest.pluginSetDigest,
+        watermark_digest: params.manifest.watermarkDigest,
+        raw_size_bytes: params.manifest.rawSizeBytes,
+        compressed_size_bytes: params.manifest.compressedSizeBytes,
+        encrypted_size_bytes: params.manifest.encryptedSizeBytes,
+        kms_key_id: params.manifest.kmsKeyId,
+        kms_key_version: params.manifest.kmsKeyVersion,
+        ...validatedManifest.envelope,
+        catalog_updated_at: sql`NOW()`,
+      })
+      .where(
+        and(
+          eq(agentSandboxBackups.id, row.id),
+          eq(agentSandboxBackups.catalog_state, row.catalog_state),
+          isNull(agentSandboxBackups.manifest_digest),
+        ),
+      )
+      .returning();
+    if (!updated) throw new AgentBackupCatalogConflictError("Backup capture transition lost");
+    return updated;
+  });
 }
 
 async function assertTransitionEvidence(

--- a/packages/cloud/shared/src/db/repositories/agent-backup-publication.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-publication.ts
@@ -1,0 +1,344 @@
+/**
+ * Reads the persisted primary-copy authority for post-capture replication.
+ * The query is tenant-, operation-, lifecycle-, and execution-lease scoped so
+ * secondary workers cannot accept a caller-supplied capture inventory.
+ */
+
+import { and, eq, gt, inArray, sql } from "drizzle-orm";
+import { requireBoundedIdentity } from "../../lib/services/agent-backup-catalog-state";
+import { isValidUUID } from "../../lib/utils/validation";
+import { dbWrite } from "../helpers";
+import { type AgentBackupObject, agentBackupObjects } from "../schemas/agent-backup-catalog";
+import type { StoredAgentSandboxBackup } from "../schemas/agent-sandboxes";
+import { agentSandboxBackups } from "../schemas/agent-sandboxes";
+import {
+  AgentBackupCatalogConflictError,
+  type AgentBackupOperationExecution,
+  agentBackupObjectInventoryDigest,
+} from "./agent-backup-catalog";
+
+const UINT64_MAX = 18_446_744_073_709_551_615n;
+const PROTECTED_SPOOL_CLEANUP_STATES = ["protected", "retained", "restore_verified"] as const;
+
+function requireUuid(value: string, field: string): string {
+  if (!isValidUUID(value) || value !== value.toLowerCase()) {
+    throw new Error(`${field} must be a canonical lowercase UUID`);
+  }
+  return value;
+}
+
+function requireCanonicalUint64(value: string): bigint {
+  if (!/^(0|[1-9][0-9]*)$/.test(value)) {
+    throw new Error("lifecycleRevision must be a canonical unsigned decimal integer");
+  }
+  const parsed = BigInt(value);
+  if (parsed > UINT64_MAX) throw new Error("lifecycleRevision must fit uint64");
+  return parsed;
+}
+
+export interface ListVerifiedPrimaryAgentBackupObjectsInput {
+  organizationId: string;
+  agentId: string;
+  backupId: string;
+  operationId: string;
+  activationGeneration: string;
+  lifecycleRevision: string;
+  execution: AgentBackupOperationExecution;
+}
+
+/**
+ * Return the exact verified primary rows in canonical manifest order while
+ * holding the operation row lock for the complete inventory check.
+ */
+export async function listVerifiedPrimaryAgentBackupObjectsForReplication(
+  input: Readonly<ListVerifiedPrimaryAgentBackupObjectsInput>,
+): Promise<AgentBackupObject[]> {
+  requireUuid(input.organizationId, "organizationId");
+  requireUuid(input.agentId, "agentId");
+  requireUuid(input.backupId, "backupId");
+  requireUuid(input.operationId, "operationId");
+  requireUuid(input.activationGeneration, "activationGeneration");
+  requireBoundedIdentity(input.execution.ownerId, "execution.ownerId");
+  requireUuid(input.execution.generation, "execution.generation");
+  const lifecycleRevision = requireCanonicalUint64(input.lifecycleRevision);
+
+  return dbWrite.transaction(async (tx) => {
+    const [backup] = await tx
+      .select({
+        manifestObjectCount: agentSandboxBackups.manifest_object_count,
+        inventoryDigest: agentSandboxBackups.object_inventory_digest,
+      })
+      .from(agentSandboxBackups)
+      .where(
+        and(
+          eq(agentSandboxBackups.id, input.backupId),
+          eq(agentSandboxBackups.catalog_organization_id, input.organizationId),
+          eq(agentSandboxBackups.catalog_agent_id, input.agentId),
+          eq(agentSandboxBackups.backup_operation_id, input.operationId),
+          eq(agentSandboxBackups.lifecycle_generation, input.activationGeneration),
+          eq(agentSandboxBackups.lifecycle_revision, lifecycleRevision),
+          eq(agentSandboxBackups.catalog_state, "secondary_pending"),
+          eq(agentSandboxBackups.catalog_lease_owner, input.execution.ownerId),
+          eq(agentSandboxBackups.catalog_lease_generation, input.execution.generation),
+          gt(agentSandboxBackups.catalog_lease_expires_at, sql`NOW()`),
+          sql`${agentSandboxBackups.sandbox_record_id} IS NOT NULL`,
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (!backup?.manifestObjectCount || !backup.inventoryDigest) {
+      throw new AgentBackupCatalogConflictError(
+        "Secondary replication authority is absent, expired, or incomplete",
+      );
+    }
+
+    const objects = await tx
+      .select()
+      .from(agentBackupObjects)
+      .where(
+        and(
+          eq(agentBackupObjects.organization_id, input.organizationId),
+          eq(agentBackupObjects.backup_id, input.backupId),
+          eq(agentBackupObjects.copy_role, "primary"),
+          eq(agentBackupObjects.state, "verified"),
+        ),
+      )
+      .orderBy(agentBackupObjects.component, agentBackupObjects.chunk_index);
+    const digest = await agentBackupObjectInventoryDigest(
+      objects.map((object) => ({
+        component: object.component,
+        chunkIndex: object.chunk_index,
+        contentHmacSha256: object.content_hmac_sha256,
+        ciphertextSha256: object.ciphertext_sha256,
+        sizeBytes: object.size_bytes,
+      })),
+    );
+    if (objects.length !== backup.manifestObjectCount || digest !== backup.inventoryDigest) {
+      throw new AgentBackupCatalogConflictError(
+        "Verified primary inventory does not match the authenticated manifest",
+      );
+    }
+    return objects;
+  });
+}
+
+export interface AuthorizeAgentBackupProtectedSpoolCleanupInput {
+  organizationId: string;
+  agentId: string;
+  backupId: string;
+  operationId: string;
+  activationGeneration: string;
+  lifecycleRevision: string;
+  manifestDigest: string;
+  objectInventoryDigest: string;
+}
+
+export interface AuthorizeAgentBackupTerminalSpoolCleanupInput {
+  organizationId: string;
+  agentId: string;
+  backupId: string;
+  operationId: string;
+  activationGeneration: string;
+  lifecycleRevision: string;
+  terminalErrorCode: string;
+}
+
+function requireSha256(value: string, field: string): string {
+  if (!/^[0-9a-f]{64}$/.test(value)) throw new Error(`${field} must be canonical SHA-256 hex`);
+  return value;
+}
+
+/**
+ * Locate possible catalogue rows for one filesystem operation identifier.
+ * Callers must still derive the row's request/authority hashes and invoke the
+ * locked authorization check below before creating a cleanup intent.
+ */
+export async function listAgentBackupProtectedSpoolCleanupCandidates(params: {
+  operationId: string;
+  limit?: number;
+}): Promise<StoredAgentSandboxBackup[]> {
+  requireUuid(params.operationId, "operationId");
+  const limit = params.limit ?? 8;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+    throw new Error("Protected spool cleanup candidate limit must be between 1 and 100");
+  }
+  return dbWrite
+    .select()
+    .from(agentSandboxBackups)
+    .where(
+      and(
+        eq(agentSandboxBackups.catalog_version, 2),
+        eq(agentSandboxBackups.manifest_version, 3),
+        eq(agentSandboxBackups.backup_operation_id, params.operationId),
+        inArray(agentSandboxBackups.catalog_state, PROTECTED_SPOOL_CLEANUP_STATES),
+        sql`${agentSandboxBackups.secondary_verified_at} IS NOT NULL`,
+      ),
+    )
+    .orderBy(agentSandboxBackups.created_at, agentSandboxBackups.id)
+    .limit(limit);
+}
+
+/**
+ * Re-prove the exact protected catalogue row and a matching verified upload
+ * receipt from both providers for every manifest object. Merely observing a
+ * local spool, a transition response, or secondary_pending is insufficient.
+ */
+export async function authorizeAgentBackupProtectedSpoolCleanup(
+  input: Readonly<AuthorizeAgentBackupProtectedSpoolCleanupInput>,
+): Promise<StoredAgentSandboxBackup> {
+  requireUuid(input.organizationId, "organizationId");
+  requireUuid(input.agentId, "agentId");
+  requireUuid(input.backupId, "backupId");
+  requireUuid(input.operationId, "operationId");
+  requireUuid(input.activationGeneration, "activationGeneration");
+  const lifecycleRevision = requireCanonicalUint64(input.lifecycleRevision);
+  requireSha256(input.manifestDigest, "manifestDigest");
+  requireSha256(input.objectInventoryDigest, "objectInventoryDigest");
+
+  return dbWrite.transaction(async (tx) => {
+    const [backup] = await tx
+      .select()
+      .from(agentSandboxBackups)
+      .where(
+        and(
+          eq(agentSandboxBackups.id, input.backupId),
+          eq(agentSandboxBackups.catalog_version, 2),
+          eq(agentSandboxBackups.manifest_version, 3),
+          eq(agentSandboxBackups.catalog_organization_id, input.organizationId),
+          eq(agentSandboxBackups.catalog_agent_id, input.agentId),
+          eq(agentSandboxBackups.backup_operation_id, input.operationId),
+          eq(agentSandboxBackups.lifecycle_generation, input.activationGeneration),
+          eq(agentSandboxBackups.lifecycle_revision, lifecycleRevision),
+          eq(agentSandboxBackups.manifest_digest, input.manifestDigest),
+          eq(agentSandboxBackups.object_inventory_digest, input.objectInventoryDigest),
+          inArray(agentSandboxBackups.catalog_state, PROTECTED_SPOOL_CLEANUP_STATES),
+          sql`${agentSandboxBackups.secondary_verified_at} IS NOT NULL`,
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (!backup?.manifest_object_count || !backup.object_inventory_digest) {
+      throw new AgentBackupCatalogConflictError(
+        "Protected spool cleanup authority is absent or incomplete",
+      );
+    }
+
+    const objects = await tx
+      .select()
+      .from(agentBackupObjects)
+      .where(
+        and(
+          eq(agentBackupObjects.organization_id, input.organizationId),
+          eq(agentBackupObjects.backup_id, input.backupId),
+        ),
+      )
+      .orderBy(
+        agentBackupObjects.copy_role,
+        agentBackupObjects.component,
+        agentBackupObjects.chunk_index,
+      )
+      .for("share");
+    const primaries = objects.filter((object) => object.copy_role === "primary");
+    const secondaries = new Map(
+      objects
+        .filter((object) => object.copy_role === "secondary")
+        .map((object) => [`${object.component}:${object.chunk_index}`, object]),
+    );
+    if (
+      primaries.length !== backup.manifest_object_count ||
+      secondaries.size !== backup.manifest_object_count ||
+      objects.length !== backup.manifest_object_count * 2
+    ) {
+      throw new AgentBackupCatalogConflictError(
+        "Protected spool cleanup requires exact dual-provider object coverage",
+      );
+    }
+    for (const primary of primaries) {
+      const secondary = secondaries.get(`${primary.component}:${primary.chunk_index}`);
+      if (
+        primary.provider !== "cloudflare-r2" ||
+        primary.state !== "verified" ||
+        !primary.verified_at ||
+        !primary.upload_receipt_digest ||
+        !/^[0-9a-f]{64}$/.test(primary.upload_receipt_digest) ||
+        !secondary ||
+        secondary.provider !== "hetzner-object-storage" ||
+        secondary.state !== "verified" ||
+        !secondary.verified_at ||
+        !secondary.upload_receipt_digest ||
+        !/^[0-9a-f]{64}$/.test(secondary.upload_receipt_digest) ||
+        secondary.content_hmac_sha256 !== primary.content_hmac_sha256 ||
+        secondary.ciphertext_sha256 !== primary.ciphertext_sha256 ||
+        secondary.size_bytes !== primary.size_bytes
+      ) {
+        throw new AgentBackupCatalogConflictError(
+          "Protected spool cleanup requires matching verified provider receipts",
+        );
+      }
+    }
+    const digest = await agentBackupObjectInventoryDigest(
+      primaries.map((object) => ({
+        component: object.component,
+        chunkIndex: object.chunk_index,
+        contentHmacSha256: object.content_hmac_sha256,
+        ciphertextSha256: object.ciphertext_sha256,
+        sizeBytes: object.size_bytes,
+      })),
+    );
+    if (digest !== backup.object_inventory_digest) {
+      throw new AgentBackupCatalogConflictError(
+        "Protected spool cleanup object inventory differs from the manifest",
+      );
+    }
+    return backup;
+  });
+}
+
+/**
+ * Re-prove an exact pre-publication terminal settlement. Local candidate files
+ * are discovery evidence only and cannot authorize deletion without this row.
+ */
+export async function authorizeAgentBackupTerminalSpoolCleanup(
+  input: Readonly<AuthorizeAgentBackupTerminalSpoolCleanupInput>,
+): Promise<StoredAgentSandboxBackup> {
+  requireUuid(input.organizationId, "organizationId");
+  requireUuid(input.agentId, "agentId");
+  requireUuid(input.backupId, "backupId");
+  requireUuid(input.operationId, "operationId");
+  requireUuid(input.activationGeneration, "activationGeneration");
+  const lifecycleRevision = requireCanonicalUint64(input.lifecycleRevision);
+  if (!/^[A-Z][A-Z0-9_]{0,95}$/.test(input.terminalErrorCode)) {
+    throw new Error("terminalErrorCode must be a bounded canonical error code");
+  }
+
+  return dbWrite.transaction(async (tx) => {
+    const [backup] = await tx
+      .select()
+      .from(agentSandboxBackups)
+      .where(
+        and(
+          eq(agentSandboxBackups.id, input.backupId),
+          eq(agentSandboxBackups.catalog_version, 2),
+          eq(agentSandboxBackups.catalog_organization_id, input.organizationId),
+          eq(agentSandboxBackups.catalog_agent_id, input.agentId),
+          eq(agentSandboxBackups.backup_operation_id, input.operationId),
+          eq(agentSandboxBackups.lifecycle_generation, input.activationGeneration),
+          eq(agentSandboxBackups.lifecycle_revision, lifecycleRevision),
+          eq(agentSandboxBackups.catalog_state, "failed_terminal"),
+          eq(agentSandboxBackups.catalog_resume_state, "capturing"),
+          eq(agentSandboxBackups.catalog_last_error_code, input.terminalErrorCode),
+          sql`${agentSandboxBackups.manifest_digest} IS NULL`,
+          sql`${agentSandboxBackups.manifest_canonical_draft} IS NULL`,
+          sql`${agentSandboxBackups.object_inventory_digest} IS NULL`,
+        ),
+      )
+      .for("update")
+      .limit(1);
+    if (!backup) {
+      throw new AgentBackupCatalogConflictError(
+        "Terminal spool cleanup authority is absent, superseded, or incomplete",
+      );
+    }
+    return backup;
+  });
+}

--- a/packages/cloud/shared/src/db/repositories/agent-backup-publication.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-publication.ts
@@ -18,7 +18,12 @@ import {
 } from "./agent-backup-catalog";
 
 const UINT64_MAX = 18_446_744_073_709_551_615n;
-const PROTECTED_SPOOL_CLEANUP_STATES = ["protected", "retained", "restore_verified"] as const;
+const PUBLISHED_SPOOL_CLEANUP_STATES = ["protected", "retained", "restore_verified"] as const;
+const EXPIRED_SPOOL_CLEANUP_STATES = ["expiration_pending", "deleting", "deleted"] as const;
+const PROTECTED_SPOOL_CLEANUP_STATES = [
+  ...PUBLISHED_SPOOL_CLEANUP_STATES,
+  ...EXPIRED_SPOOL_CLEANUP_STATES,
+] as const;
 
 function requireUuid(value: string, field: string): string {
   if (!isValidUUID(value) || value !== value.toLowerCase()) {
@@ -171,7 +176,24 @@ export async function listAgentBackupProtectedSpoolCleanupCandidates(params: {
         eq(agentSandboxBackups.manifest_version, 3),
         eq(agentSandboxBackups.backup_operation_id, params.operationId),
         inArray(agentSandboxBackups.catalog_state, PROTECTED_SPOOL_CLEANUP_STATES),
-        sql`${agentSandboxBackups.secondary_verified_at} IS NOT NULL`,
+        sql`(
+          (
+            ${agentSandboxBackups.catalog_state} IN ('protected', 'retained', 'restore_verified')
+            AND ${agentSandboxBackups.secondary_verified_at} IS NOT NULL
+          )
+          OR (
+            ${agentSandboxBackups.catalog_state} IN ('expiration_pending', 'deleting')
+            AND ${agentSandboxBackups.retention_until} <= NOW()
+            AND ${agentSandboxBackups.retention_reason} <> 'legal-hold'
+          )
+          OR (
+            ${agentSandboxBackups.catalog_state} = 'deleted'
+            AND ${agentSandboxBackups.retention_until} <= NOW()
+            AND ${agentSandboxBackups.retention_reason} <> 'legal-hold'
+            AND ${agentSandboxBackups.catalog_delete_receipt_digest} IS NOT NULL
+            AND ${agentSandboxBackups.catalog_deleted_at} IS NOT NULL
+          )
+        )`,
       ),
     )
     .orderBy(agentSandboxBackups.created_at, agentSandboxBackups.id)
@@ -212,7 +234,24 @@ export async function authorizeAgentBackupProtectedSpoolCleanup(
           eq(agentSandboxBackups.manifest_digest, input.manifestDigest),
           eq(agentSandboxBackups.object_inventory_digest, input.objectInventoryDigest),
           inArray(agentSandboxBackups.catalog_state, PROTECTED_SPOOL_CLEANUP_STATES),
-          sql`${agentSandboxBackups.secondary_verified_at} IS NOT NULL`,
+          sql`(
+            (
+              ${agentSandboxBackups.catalog_state} IN ('protected', 'retained', 'restore_verified')
+              AND ${agentSandboxBackups.secondary_verified_at} IS NOT NULL
+            )
+            OR (
+              ${agentSandboxBackups.catalog_state} IN ('expiration_pending', 'deleting')
+              AND ${agentSandboxBackups.retention_until} <= NOW()
+              AND ${agentSandboxBackups.retention_reason} <> 'legal-hold'
+            )
+            OR (
+              ${agentSandboxBackups.catalog_state} = 'deleted'
+              AND ${agentSandboxBackups.retention_until} <= NOW()
+              AND ${agentSandboxBackups.retention_reason} <> 'legal-hold'
+              AND ${agentSandboxBackups.catalog_delete_receipt_digest} IS NOT NULL
+              AND ${agentSandboxBackups.catalog_deleted_at} IS NOT NULL
+            )
+          )`,
         ),
       )
       .for("update")
@@ -221,6 +260,18 @@ export async function authorizeAgentBackupProtectedSpoolCleanup(
       throw new AgentBackupCatalogConflictError(
         "Protected spool cleanup authority is absent or incomplete",
       );
+    }
+
+    // Once the primary DB has authoritatively expired this exact backup, local
+    // ciphertext cleanup remains safe even while provider GC mutates or removes
+    // the object rows. The immutable manifest identity above and DB-clock
+    // retention/tombstone proof replace the earlier dual-receipt proof.
+    if (
+      EXPIRED_SPOOL_CLEANUP_STATES.includes(
+        backup.catalog_state as (typeof EXPIRED_SPOOL_CLEANUP_STATES)[number],
+      )
+    ) {
+      return backup;
     }
 
     const objects = await tx

--- a/packages/cloud/shared/src/db/repositories/agent-backup-scheduler.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-scheduler.ts
@@ -1,0 +1,1144 @@
+/**
+ * Primary-DB authority for periodic manifest-v3 backup admission.
+ *
+ * The scheduler performs no provider mutation. It enrolls exact active
+ * dedicated sandboxes, leases a fair DB-clock due set, atomically reserves a
+ * catalogue operation, and advances the RPO deadline only after the exact
+ * operation has durable primary and secondary protection evidence.
+ */
+
+import { randomUUID } from "node:crypto";
+import { and, eq, gt, type SQL, sql } from "drizzle-orm";
+import { requireBoundedIdentity } from "../../lib/services/agent-backup-catalog-state";
+import type { DbTransaction } from "../client";
+import { sqlRows } from "../execute-helpers";
+import { dbWrite } from "../helpers";
+import { agentSandboxBackups, agentSandboxes } from "../schemas/agent-sandboxes";
+import { dockerNodes } from "../schemas/docker-nodes";
+import { organizations } from "../schemas/organizations";
+import { reserveAgentBackupOperationInTransaction } from "./agent-backup-catalog";
+
+export const DEFAULT_AGENT_BACKUP_SCHEDULE_INTERVAL_MS = 10 * 60_000;
+export const DEFAULT_AGENT_BACKUP_RPO_MS = 15 * 60_000;
+export const DEFAULT_AGENT_BACKUP_SCHEDULE_LEASE_MS = 2 * 60_000;
+export const DEFAULT_AGENT_BACKUP_SCHEDULE_RETRY_MS = 30_000;
+export const DEFAULT_AGENT_BACKUP_SCHEDULE_RETENTION_MS = 7 * 24 * 60 * 60_000;
+export const MAX_AGENT_BACKUP_SCHEDULE_BATCH = 100;
+export const MAX_AGENT_BACKUP_SCHEDULE_LEASE_MS = 5 * 60_000;
+export const MAX_AGENT_BACKUP_SCHEDULE_RETRY_MS = 5 * 60_000;
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const ACTIVE_OPERATION_STATES = [
+  "scheduled",
+  "capturing",
+  "captured",
+  "uploading",
+  "primary_uploaded",
+  "primary_verified",
+  "secondary_pending",
+  "failed_retryable",
+] as const;
+const PROTECTED_OPERATION_STATES = ["protected", "retained", "restore_verified"] as const;
+const RECYCLABLE_OPERATION_STATES = [
+  "failed_terminal",
+  "expiration_pending",
+  "deleting",
+  "deleted",
+] as const;
+
+export interface AgentBackupScheduleClaim {
+  organizationId: string;
+  agentId: string;
+  operationId: string;
+  ownerId: string;
+  generation: string;
+  expiresAt: Date;
+  /** Original protected-backup deadline; it never moves for an attempt. */
+  dueAt: Date;
+  attempts: number;
+}
+
+export interface AgentBackupScheduleReservation {
+  organizationId: string;
+  agentId: string;
+  operationId: string;
+  backupId: string;
+  /** Original protected-backup deadline, retained until catalogue proof. */
+  dueAt: Date;
+}
+
+export interface AgentBackupScheduleReconcileSummary {
+  protected: number;
+  recycled: number;
+}
+
+export class AgentBackupScheduleFenceError extends Error {
+  override readonly name = "AgentBackupScheduleFenceError";
+}
+
+function requireUuid(value: string, field: string): string {
+  if (!UUID_PATTERN.test(value)) throw new Error(`${field} must be a canonical lowercase UUID`);
+  return value;
+}
+
+function requireBoundedInteger(params: {
+  value: number;
+  field: string;
+  min: number;
+  max: number;
+}): number {
+  if (
+    !Number.isSafeInteger(params.value) ||
+    params.value < params.min ||
+    params.value > params.max
+  ) {
+    throw new Error(`${params.field} must be between ${params.min} and ${params.max}`);
+  }
+  return params.value;
+}
+
+function requireScheduleErrorCode(value: string): string {
+  if (!/^[A-Z][A-Z0-9_]{0,95}$/.test(value)) {
+    throw new Error("errorCode must be a bounded canonical error code");
+  }
+  return value;
+}
+
+function requireDatabaseDate(value: Date | string, field: string): Date {
+  const date = value instanceof Date ? value : new Date(value);
+  if (!Number.isFinite(date.getTime())) {
+    throw new Error(`${field} must be a valid primary-database timestamp`);
+  }
+  return date;
+}
+
+function validateClaimIdentity(claim: AgentBackupScheduleClaim): void {
+  requireUuid(claim.organizationId, "claim.organizationId");
+  requireUuid(claim.agentId, "claim.agentId");
+  requireUuid(claim.operationId, "claim.operationId");
+  requireUuid(claim.generation, "claim.generation");
+  requireBoundedIdentity(claim.ownerId, "claim.ownerId");
+}
+
+function stableScheduleJitterMs(agentId: string, maxJitterMs: number): number {
+  if (maxJitterMs <= 0) return 0;
+  let hash = 2_166_136_261;
+  for (const char of agentId) {
+    hash ^= char.charCodeAt(0);
+    hash = Math.imul(hash, 16_777_619) >>> 0;
+  }
+  return hash % Math.max(1, maxJitterMs);
+}
+
+function validateBatch(value: number): number {
+  return requireBoundedInteger({
+    value,
+    field: "limit",
+    min: 1,
+    max: MAX_AGENT_BACKUP_SCHEDULE_BATCH,
+  });
+}
+
+function validateCadence(params: { intervalMs?: number; rpoMs?: number }): {
+  intervalMs: number;
+  rpoMs: number;
+} {
+  const intervalMs = requireBoundedInteger({
+    value: params.intervalMs ?? DEFAULT_AGENT_BACKUP_SCHEDULE_INTERVAL_MS,
+    field: "intervalMs",
+    min: 60_000,
+    max: DEFAULT_AGENT_BACKUP_RPO_MS,
+  });
+  const rpoMs = requireBoundedInteger({
+    value: params.rpoMs ?? DEFAULT_AGENT_BACKUP_RPO_MS,
+    field: "rpoMs",
+    min: intervalMs,
+    max: DEFAULT_AGENT_BACKUP_RPO_MS,
+  });
+  return { intervalMs, rpoMs };
+}
+
+/** Every active catalogue lane, including work superseded by a later activation. */
+function activeBackupLanes(activeStates: SQL): SQL {
+  return sql`
+    SELECT backup.catalog_organization_id AS organization_id,
+      backup.source_node_id AS node_id
+    FROM ${agentSandboxBackups} AS backup
+    WHERE backup.catalog_state IN (${activeStates})
+  `;
+}
+
+/**
+ * Count every active dedicated sandbox whose last exact protection is beyond
+ * the 15-minute RPO, including rows not yet reached by bounded enrollment. A
+ * running row without a complete immutable activation authority is counted
+ * immediately: it is not eligible for capture and must remain observable until
+ * the activation slice repairs it. The primary database clock is the only time
+ * authority. Before the first scheduled proof, activation completion starts
+ * the exposure clock. A protected-but-not-yet-reconciled operation is excluded
+ * only when the same strict manifest-v3 evidence used by reconciliation exists.
+ */
+export async function countOverdueAgentBackupSchedules(): Promise<number> {
+  const protectedStates = sql.join(
+    PROTECTED_OPERATION_STATES.map((state) => sql`${state}`),
+    sql`, `,
+  );
+  const [result] = await sqlRows<{ overdue: number | string }>(
+    dbWrite,
+    sql`
+      SELECT COUNT(*)::int AS overdue
+      FROM ${agentSandboxes} AS sandbox
+      WHERE sandbox.status = 'running'
+        AND sandbox.pool_status IS NULL
+        AND sandbox.execution_tier <> 'shared'
+        AND (
+          (
+            sandbox.activation_phase = 'active'
+            AND sandbox.activation_generation IS NOT NULL
+            AND sandbox.activation_lifecycle_revision IS NOT NULL
+            AND sandbox.activation_receipt_hash ~ '^[0-9a-f]{64}$'
+            AND sandbox.activation_container_id ~ '^[0-9a-f]{64}$'
+            AND sandbox.activation_node_id IS NOT NULL
+            AND sandbox.activation_image_digest ~ '^sha256:[0-9a-f]{64}$'
+            AND sandbox.activation_boot_id IS NOT NULL
+            AND sandbox.activation_authority_published_at IS NOT NULL
+            AND sandbox.activation_dispatched_at IS NOT NULL
+            AND sandbox.activation_completed_at IS NOT NULL
+          ) IS NOT TRUE
+          OR (
+            GREATEST(
+              sandbox.activation_completed_at,
+              COALESCE(
+                sandbox.backup_schedule_last_protected_at,
+                sandbox.activation_completed_at
+              )
+            ) + (${DEFAULT_AGENT_BACKUP_RPO_MS} * INTERVAL '1 millisecond') <= NOW()
+            AND NOT EXISTS (
+              SELECT 1
+              FROM ${agentSandboxBackups} AS backup
+              WHERE backup.catalog_organization_id = sandbox.organization_id
+                AND backup.catalog_agent_id = sandbox.id
+                AND backup.sandbox_record_id = sandbox.id
+                AND backup.backup_operation_id = sandbox.backup_schedule_operation_id
+                AND backup.lifecycle_generation = sandbox.activation_generation
+                AND backup.lifecycle_revision = sandbox.activation_lifecycle_revision
+                AND sandbox.lifecycle_revision = sandbox.activation_lifecycle_revision
+                AND backup.source_node_id = sandbox.activation_node_id
+                AND backup.source_container_id = sandbox.activation_container_id
+                AND backup.backup_image_digest = sandbox.activation_image_digest
+                AND backup.catalog_version = 2
+                AND backup.snapshot_type = 'auto'
+                AND backup.backup_kind = 'full'
+                AND backup.retention_reason = 'schedule'
+                AND backup.catalog_state IN (${protectedStates})
+                AND backup.manifest_format = 'elizaos.agent-backup'
+                AND backup.manifest_version = 3
+                AND backup.manifest_digest ~ '^[0-9a-f]{64}$'
+                AND backup.primary_verified_at IS NOT NULL
+                AND backup.secondary_verified_at IS NOT NULL
+                AND backup.secondary_verified_at >= backup.primary_verified_at
+                AND backup.secondary_verified_at <= NOW()
+                AND backup.secondary_verified_at
+                  + (${DEFAULT_AGENT_BACKUP_RPO_MS} * INTERVAL '1 millisecond') > NOW()
+            )
+          )
+        )
+    `,
+  );
+  const overdue = Number(result?.overdue ?? 0);
+  if (!Number.isSafeInteger(overdue) || overdue < 0) {
+    throw new Error("Primary database returned an invalid overdue RPO count");
+  }
+  return overdue;
+}
+
+/** Enroll a bounded, organization-fair slice; every newly enrolled row is due now. */
+export async function enrollEligibleAgentBackupSchedules(params: {
+  limit: number;
+}): Promise<number> {
+  const limit = validateBatch(params.limit);
+  const enrolled = await sqlRows<{ id: string }>(
+    dbWrite,
+    sql`
+      WITH organization_watermarks AS MATERIALIZED (
+        SELECT organization_id, MAX(next_backup_at) AS last_enrolled_at
+        FROM ${agentSandboxes}
+        WHERE next_backup_at IS NOT NULL
+        GROUP BY organization_id
+      ), ranked AS MATERIALIZED (
+        SELECT
+          sandbox.id,
+          sandbox.organization_id,
+          organization_watermarks.last_enrolled_at,
+          ROW_NUMBER() OVER (
+            PARTITION BY sandbox.organization_id
+            ORDER BY sandbox.created_at, sandbox.id
+          ) AS organization_rank
+        FROM ${agentSandboxes} AS sandbox
+        LEFT JOIN organization_watermarks
+          ON organization_watermarks.organization_id = sandbox.organization_id
+        WHERE sandbox.next_backup_at IS NULL
+          AND sandbox.status = 'running'
+          AND sandbox.pool_status IS NULL
+          AND sandbox.execution_tier <> 'shared'
+          AND sandbox.activation_phase = 'active'
+          AND sandbox.activation_generation IS NOT NULL
+          AND sandbox.activation_lifecycle_revision IS NOT NULL
+          AND sandbox.lifecycle_revision = sandbox.activation_lifecycle_revision
+          AND sandbox.activation_receipt_hash IS NOT NULL
+          AND sandbox.activation_container_id ~ '^[0-9a-f]{64}$'
+          AND sandbox.activation_node_id IS NOT NULL
+          AND sandbox.activation_image_digest IS NOT NULL
+          AND sandbox.activation_authority_published_at IS NOT NULL
+          AND sandbox.activation_dispatched_at IS NOT NULL
+          AND sandbox.activation_completed_at IS NOT NULL
+          AND EXISTS (
+            SELECT 1
+            FROM ${dockerNodes} AS source_node
+            WHERE source_node.node_id = sandbox.activation_node_id
+              AND source_node.node_incarnation IS NOT NULL
+              AND (
+                (source_node.fleet_kind = 'robot'
+                  AND source_node.provider_server_id IS NULL)
+                OR (source_node.fleet_kind = 'cloud'
+                  AND source_node.provider_server_id IS NOT NULL)
+              )
+          )
+      ), candidates AS MATERIALIZED (
+        SELECT id
+        FROM ranked
+        ORDER BY organization_rank, last_enrolled_at NULLS FIRST, organization_id, id
+        LIMIT ${limit}
+      )
+      UPDATE ${agentSandboxes} AS sandbox
+      SET next_backup_at = NOW(),
+          backup_schedule_operation_id = NULL,
+          backup_schedule_retry_at = NULL,
+          backup_schedule_attempts = 0,
+          backup_schedule_last_error_code = NULL,
+          updated_at = NOW()
+      FROM candidates
+      WHERE sandbox.id = candidates.id
+        AND sandbox.next_backup_at IS NULL
+      RETURNING sandbox.id
+    `,
+  );
+  return enrolled.length;
+}
+
+/**
+ * Settle exact protected operations and recycle terminal operations without
+ * ever treating reservation, capture, retry, or deferral as RPO success.
+ */
+export async function reconcileAgentBackupSchedules(params: {
+  limit: number;
+  intervalMs?: number;
+  rpoMs?: number;
+  terminalRetryDelayMs?: number;
+}): Promise<AgentBackupScheduleReconcileSummary> {
+  const limit = validateBatch(params.limit);
+  const { intervalMs, rpoMs } = validateCadence(params);
+  const terminalRetryDelayMs = requireBoundedInteger({
+    value: params.terminalRetryDelayMs ?? DEFAULT_AGENT_BACKUP_SCHEDULE_RETRY_MS,
+    field: "terminalRetryDelayMs",
+    min: 1,
+    max: MAX_AGENT_BACKUP_SCHEDULE_RETRY_MS,
+  });
+  const successStates = sql.join(
+    PROTECTED_OPERATION_STATES.map((state) => sql`${state}`),
+    sql`, `,
+  );
+  const recyclableStates = sql.join(
+    RECYCLABLE_OPERATION_STATES.map((state) => sql`${state}`),
+    sql`, `,
+  );
+
+  return dbWrite.transaction(async (tx) => {
+    // Active operations remain attached even when a lifecycle change made
+    // their source stale. This scheduler has no catalogue cancellation lease;
+    // retaining the pointer keeps the organization/node lane fail-closed until
+    // durable protection or terminal settlement makes recycling safe.
+    const candidates = await sqlRows<{
+      id: string;
+      organization_id: string;
+      operation_id: string;
+      activation_generation: string | null;
+      activation_lifecycle_revision: string | null;
+      lifecycle_revision: string;
+      activation_node_id: string | null;
+      activation_container_id: string | null;
+      activation_image_digest: string | null;
+    }>(
+      tx,
+      sql`
+        SELECT sandbox.id, sandbox.organization_id,
+          sandbox.backup_schedule_operation_id AS operation_id,
+          sandbox.activation_generation,
+          sandbox.activation_lifecycle_revision::text AS activation_lifecycle_revision,
+          sandbox.lifecycle_revision::text AS lifecycle_revision,
+          sandbox.activation_node_id,
+          sandbox.activation_container_id,
+          sandbox.activation_image_digest
+        FROM ${agentSandboxes} AS sandbox
+        WHERE sandbox.backup_schedule_operation_id IS NOT NULL
+          AND sandbox.backup_schedule_claim_owner IS NULL
+          AND EXISTS (
+            SELECT 1
+            FROM ${agentSandboxBackups} AS backup
+            WHERE backup.catalog_organization_id = sandbox.organization_id
+              AND backup.catalog_agent_id = sandbox.id
+              AND backup.sandbox_record_id = sandbox.id
+              AND backup.backup_operation_id = sandbox.backup_schedule_operation_id
+              AND (
+                backup.catalog_state IN (${successStates}, ${recyclableStates})
+                OR backup.catalog_state IS NULL
+              )
+          )
+        ORDER BY sandbox.next_backup_at, sandbox.organization_id, sandbox.id
+        FOR UPDATE OF sandbox SKIP LOCKED
+        LIMIT ${limit}
+      `,
+    );
+    if (candidates.length === 0) return { protected: 0, recycled: 0 };
+
+    let protectedCount = 0;
+    let recycled = 0;
+    const [clock] = await sqlRows<{ now: Date | string }>(tx, sql`SELECT NOW() AS now`);
+    if (!clock?.now) throw new Error("Primary database clock is unavailable");
+    const databaseNow = requireDatabaseDate(clock.now, "databaseNow");
+    for (const candidate of candidates) {
+      const [backup] = await tx
+        .select({
+          state: agentSandboxBackups.catalog_state,
+          manifestFormat: agentSandboxBackups.manifest_format,
+          manifestVersion: agentSandboxBackups.manifest_version,
+          manifestDigest: agentSandboxBackups.manifest_digest,
+          primaryVerifiedAt: agentSandboxBackups.primary_verified_at,
+          secondaryVerifiedAt: agentSandboxBackups.secondary_verified_at,
+          lastErrorCode: agentSandboxBackups.catalog_last_error_code,
+          lifecycleGeneration: agentSandboxBackups.lifecycle_generation,
+          lifecycleRevision: agentSandboxBackups.lifecycle_revision,
+          sourceNodeId: agentSandboxBackups.source_node_id,
+          sourceContainerId: agentSandboxBackups.source_container_id,
+          catalogVersion: agentSandboxBackups.catalog_version,
+          snapshotType: agentSandboxBackups.snapshot_type,
+          backupKind: agentSandboxBackups.backup_kind,
+          retentionReason: agentSandboxBackups.retention_reason,
+          imageDigest: agentSandboxBackups.image_digest,
+        })
+        .from(agentSandboxBackups)
+        .where(
+          and(
+            eq(agentSandboxBackups.catalog_organization_id, candidate.organization_id),
+            eq(agentSandboxBackups.catalog_agent_id, candidate.id),
+            eq(agentSandboxBackups.sandbox_record_id, candidate.id),
+            eq(agentSandboxBackups.backup_operation_id, candidate.operation_id),
+          ),
+        )
+        .for("key share")
+        .limit(1);
+      if (!backup) continue;
+
+      const reservationMatchesCurrentActivation =
+        backup.state !== null &&
+        backup.catalogVersion === 2 &&
+        backup.snapshotType === "auto" &&
+        backup.backupKind === "full" &&
+        backup.retentionReason === "schedule" &&
+        candidate.activation_generation !== null &&
+        backup.lifecycleGeneration === candidate.activation_generation &&
+        candidate.activation_lifecycle_revision !== null &&
+        backup.lifecycleRevision !== null &&
+        String(backup.lifecycleRevision) === candidate.activation_lifecycle_revision &&
+        candidate.lifecycle_revision === candidate.activation_lifecycle_revision &&
+        candidate.activation_node_id !== null &&
+        backup.sourceNodeId === candidate.activation_node_id &&
+        candidate.activation_container_id !== null &&
+        backup.sourceContainerId === candidate.activation_container_id;
+
+      if (
+        reservationMatchesCurrentActivation &&
+        PROTECTED_OPERATION_STATES.includes(
+          backup.state as (typeof PROTECTED_OPERATION_STATES)[number],
+        ) &&
+        backup.manifestFormat === "elizaos.agent-backup" &&
+        backup.manifestVersion === 3 &&
+        typeof backup.manifestDigest === "string" &&
+        /^[0-9a-f]{64}$/.test(backup.manifestDigest) &&
+        backup.primaryVerifiedAt instanceof Date &&
+        backup.secondaryVerifiedAt instanceof Date &&
+        candidate.activation_image_digest !== null &&
+        backup.imageDigest === candidate.activation_image_digest &&
+        backup.secondaryVerifiedAt.getTime() >= backup.primaryVerifiedAt.getTime() &&
+        backup.secondaryVerifiedAt.getTime() <= databaseNow.getTime()
+      ) {
+        const jitterMs = stableScheduleJitterMs(
+          candidate.id,
+          Math.min(Math.floor(intervalMs / 10), rpoMs - intervalMs),
+        );
+        const nextDelayMs = intervalMs + jitterMs;
+        if (nextDelayMs > rpoMs) {
+          throw new Error("Periodic backup jitter exceeds the configured RPO target");
+        }
+        const [updated] = await tx
+          .update(agentSandboxes)
+          .set({
+            // `secondary_verified_at` is stamped by PostgreSQL when the exact
+            // operation becomes protected. Basing the next deadline on that
+            // clock prevents a delayed reconciler from silently extending RPO.
+            next_backup_at: new Date(backup.secondaryVerifiedAt.getTime() + nextDelayMs),
+            backup_schedule_operation_id: null,
+            backup_schedule_retry_at: null,
+            backup_schedule_claim_owner: null,
+            backup_schedule_claim_generation: null,
+            backup_schedule_claim_expires_at: null,
+            backup_schedule_attempts: 0,
+            backup_schedule_last_error_code: null,
+            backup_schedule_last_protected_at: backup.secondaryVerifiedAt,
+            updated_at: sql`NOW()`,
+          })
+          .where(
+            and(
+              eq(agentSandboxes.id, candidate.id),
+              eq(agentSandboxes.organization_id, candidate.organization_id),
+              eq(agentSandboxes.backup_schedule_operation_id, candidate.operation_id),
+            ),
+          )
+          .returning({ id: agentSandboxes.id });
+        if (updated) protectedCount += 1;
+        continue;
+      }
+
+      const invalidProtectedProof = PROTECTED_OPERATION_STATES.includes(
+        backup.state as (typeof PROTECTED_OPERATION_STATES)[number],
+      );
+      if (
+        invalidProtectedProof ||
+        !reservationMatchesCurrentActivation ||
+        RECYCLABLE_OPERATION_STATES.includes(
+          backup.state as (typeof RECYCLABLE_OPERATION_STATES)[number],
+        )
+      ) {
+        const errorCode = invalidProtectedProof
+          ? "BACKUP_SCHEDULE_PROTECTION_PROOF_INVALID"
+          : !reservationMatchesCurrentActivation
+            ? "BACKUP_SCHEDULE_RESERVATION_SUPERSEDED"
+            : backup.lastErrorCode && /^[A-Z][A-Z0-9_]{0,95}$/.test(backup.lastErrorCode)
+              ? backup.lastErrorCode
+              : "BACKUP_OPERATION_NOT_PROTECTED";
+        const [updated] = await tx
+          .update(agentSandboxes)
+          .set({
+            backup_schedule_operation_id: null,
+            backup_schedule_retry_at: sql`NOW()
+              + (${terminalRetryDelayMs} * INTERVAL '1 millisecond')`,
+            backup_schedule_claim_owner: null,
+            backup_schedule_claim_generation: null,
+            backup_schedule_claim_expires_at: null,
+            backup_schedule_last_error_code: errorCode,
+            updated_at: sql`NOW()`,
+          })
+          .where(
+            and(
+              eq(agentSandboxes.id, candidate.id),
+              eq(agentSandboxes.organization_id, candidate.organization_id),
+              eq(agentSandboxes.backup_schedule_operation_id, candidate.operation_id),
+            ),
+          )
+          .returning({ id: agentSandboxes.id });
+        if (updated) recycled += 1;
+      }
+    }
+    return { protected: protectedCount, recycled };
+  });
+}
+
+/**
+ * Claim at most one due sandbox per organization and source node. Organization
+ * and node authority rows are locked with SKIP LOCKED, so concurrent workers
+ * cannot reserve two fair-lane entries from the same tenant or source node.
+ */
+export async function claimDueAgentBackupSchedules(params: {
+  ownerId: string;
+  limit: number;
+  leaseMs?: number;
+}): Promise<AgentBackupScheduleClaim[]> {
+  requireBoundedIdentity(params.ownerId, "ownerId");
+  const limit = validateBatch(params.limit);
+  const leaseMs = requireBoundedInteger({
+    value: params.leaseMs ?? DEFAULT_AGENT_BACKUP_SCHEDULE_LEASE_MS,
+    field: "leaseMs",
+    min: 1,
+    max: MAX_AGENT_BACKUP_SCHEDULE_LEASE_MS,
+  });
+  const generation = randomUUID();
+  const activeStates = sql.join(
+    ACTIVE_OPERATION_STATES.map((state) => sql`${state}`),
+    sql`, `,
+  );
+  const activeLanes = activeBackupLanes(activeStates);
+  return dbWrite.transaction(async (tx) => {
+    const candidates = await sqlRows<{
+      id: string;
+      organization_id: string;
+      activation_node_id: string;
+      activation_generation: string;
+      activation_lifecycle_revision: string;
+      lifecycle_revision: string;
+      activation_container_id: string;
+    }>(
+      tx,
+      sql`
+        WITH active_operation_lanes AS MATERIALIZED (${activeLanes}),
+        eligible AS MATERIALIZED (
+          SELECT
+            sandbox.id,
+            sandbox.organization_id,
+            sandbox.activation_node_id,
+            sandbox.activation_generation,
+            sandbox.activation_lifecycle_revision,
+            sandbox.lifecycle_revision,
+            sandbox.activation_container_id,
+            sandbox.next_backup_at,
+            ROW_NUMBER() OVER (
+              PARTITION BY sandbox.organization_id
+              ORDER BY sandbox.next_backup_at, sandbox.id
+            ) AS organization_rank,
+            ROW_NUMBER() OVER (
+              PARTITION BY sandbox.activation_node_id
+              ORDER BY sandbox.next_backup_at, sandbox.organization_id, sandbox.id
+            ) AS node_rank
+          FROM ${agentSandboxes} AS sandbox
+          WHERE sandbox.next_backup_at IS NOT NULL
+            AND sandbox.next_backup_at <= clock_timestamp()
+            AND (sandbox.backup_schedule_retry_at IS NULL
+              OR sandbox.backup_schedule_retry_at <= clock_timestamp())
+            AND sandbox.status = 'running'
+            AND sandbox.pool_status IS NULL
+            AND sandbox.execution_tier <> 'shared'
+            AND sandbox.activation_phase = 'active'
+            AND sandbox.activation_generation IS NOT NULL
+            AND sandbox.activation_lifecycle_revision IS NOT NULL
+            AND sandbox.lifecycle_revision = sandbox.activation_lifecycle_revision
+            AND sandbox.activation_receipt_hash IS NOT NULL
+            AND sandbox.activation_container_id ~ '^[0-9a-f]{64}$'
+            AND sandbox.activation_node_id IS NOT NULL
+            AND sandbox.activation_image_digest IS NOT NULL
+            AND EXISTS (
+              SELECT 1
+              FROM ${dockerNodes} AS source_node
+              WHERE source_node.node_id = sandbox.activation_node_id
+                AND source_node.node_incarnation IS NOT NULL
+                AND (
+                  (source_node.fleet_kind = 'robot'
+                    AND source_node.provider_server_id IS NULL)
+                  OR (source_node.fleet_kind = 'cloud'
+                    AND source_node.provider_server_id IS NOT NULL)
+                )
+            )
+            AND (sandbox.backup_schedule_claim_expires_at IS NULL
+              OR sandbox.backup_schedule_claim_expires_at <= clock_timestamp())
+            AND (
+              sandbox.backup_schedule_operation_id IS NULL
+              OR NOT EXISTS (
+                SELECT 1
+                FROM ${agentSandboxBackups} AS reserved_backup
+                WHERE reserved_backup.catalog_organization_id = sandbox.organization_id
+                  AND reserved_backup.catalog_agent_id = sandbox.id
+                  AND reserved_backup.backup_operation_id = sandbox.backup_schedule_operation_id
+              )
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM ${agentSandboxes} AS organization_claim
+              WHERE organization_claim.id <> sandbox.id
+                AND organization_claim.organization_id = sandbox.organization_id
+                AND organization_claim.backup_schedule_claim_expires_at > clock_timestamp()
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM active_operation_lanes AS organization_backup
+              WHERE organization_backup.organization_id = sandbox.organization_id
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM active_operation_lanes AS node_backup
+              WHERE node_backup.node_id = sandbox.activation_node_id
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM ${agentSandboxes} AS node_claim
+              WHERE node_claim.id <> sandbox.id
+                AND node_claim.activation_node_id = sandbox.activation_node_id
+                AND node_claim.backup_schedule_claim_expires_at > clock_timestamp()
+            )
+        ), ranked_candidates AS MATERIALIZED (
+          SELECT id, organization_id, activation_node_id, activation_generation,
+            activation_lifecycle_revision, lifecycle_revision,
+            activation_container_id, next_backup_at
+          FROM eligible
+          WHERE organization_rank = 1
+            AND node_rank = 1
+        )
+        SELECT sandbox.id, candidate.organization_id,
+          candidate.activation_node_id, candidate.activation_generation,
+          candidate.activation_lifecycle_revision::text AS activation_lifecycle_revision,
+          candidate.lifecycle_revision::text AS lifecycle_revision,
+          candidate.activation_container_id
+        FROM ranked_candidates AS candidate
+        JOIN ${agentSandboxes} AS sandbox
+          ON sandbox.id = candidate.id
+          AND sandbox.organization_id = candidate.organization_id
+          AND sandbox.activation_node_id = candidate.activation_node_id
+          AND sandbox.activation_generation = candidate.activation_generation
+          AND sandbox.activation_lifecycle_revision = candidate.activation_lifecycle_revision
+          AND sandbox.lifecycle_revision = candidate.lifecycle_revision
+          AND sandbox.activation_container_id = candidate.activation_container_id
+        JOIN ${organizations} AS organization_row
+          ON organization_row.id = candidate.organization_id
+        JOIN ${dockerNodes} AS node_row
+          ON node_row.node_id = candidate.activation_node_id
+        ORDER BY candidate.next_backup_at, candidate.organization_id, sandbox.id
+        FOR UPDATE OF sandbox, organization_row, node_row SKIP LOCKED
+        LIMIT ${limit}
+      `,
+    );
+    if (candidates.length === 0) return [];
+
+    // The locking statement and mutation are deliberately separate. Under
+    // READ COMMITTED this second statement receives a fresh snapshot after all
+    // organization/node locks were acquired. A concurrent claimer that
+    // committed while this transaction was selecting can therefore never slip
+    // through on the selection statement's stale snapshot.
+    const lockedCandidates = sql.join(
+      candidates.map(
+        (candidate) => sql`(
+          ${candidate.id}::uuid,
+          ${candidate.organization_id}::uuid,
+          ${candidate.activation_node_id}::text,
+          ${candidate.activation_generation}::uuid,
+          ${candidate.activation_lifecycle_revision}::bigint,
+          ${candidate.lifecycle_revision}::bigint,
+          ${candidate.activation_container_id}::text
+        )`,
+      ),
+      sql`, `,
+    );
+    const claimed = await sqlRows<{
+      organization_id: string;
+      id: string;
+      operation_id: string;
+      expires_at: Date | string;
+      next_backup_at: Date | string;
+      attempts: number;
+    }>(
+      tx,
+      sql`
+        WITH active_operation_lanes AS MATERIALIZED (${activeLanes}),
+        locked_candidates (
+          id,
+          organization_id,
+          activation_node_id,
+          activation_generation,
+          activation_lifecycle_revision,
+          lifecycle_revision,
+          activation_container_id
+        ) AS (VALUES ${lockedCandidates})
+        UPDATE ${agentSandboxes} AS sandbox
+        SET backup_schedule_operation_id = COALESCE(
+              sandbox.backup_schedule_operation_id,
+              gen_random_uuid()
+            ),
+            backup_schedule_retry_at = NULL,
+            backup_schedule_claim_owner = ${params.ownerId},
+            backup_schedule_claim_generation = ${generation},
+            backup_schedule_claim_expires_at = clock_timestamp()
+              + (${leaseMs} * INTERVAL '1 millisecond'),
+            backup_schedule_attempts = sandbox.backup_schedule_attempts + 1,
+            backup_schedule_last_error_code = NULL,
+            updated_at = NOW()
+        FROM locked_candidates AS candidate
+        WHERE sandbox.id = candidate.id
+          AND sandbox.organization_id = candidate.organization_id
+          AND sandbox.activation_node_id = candidate.activation_node_id
+          AND sandbox.activation_generation = candidate.activation_generation
+          AND sandbox.activation_lifecycle_revision = candidate.activation_lifecycle_revision
+          AND sandbox.lifecycle_revision = candidate.lifecycle_revision
+          AND sandbox.activation_container_id = candidate.activation_container_id
+          AND sandbox.next_backup_at IS NOT NULL
+          AND sandbox.next_backup_at <= clock_timestamp()
+          AND (sandbox.backup_schedule_retry_at IS NULL
+            OR sandbox.backup_schedule_retry_at <= clock_timestamp())
+          AND sandbox.status = 'running'
+          AND sandbox.pool_status IS NULL
+          AND sandbox.execution_tier <> 'shared'
+          AND sandbox.activation_phase = 'active'
+          AND sandbox.activation_generation IS NOT NULL
+          AND sandbox.activation_lifecycle_revision IS NOT NULL
+          AND sandbox.lifecycle_revision = sandbox.activation_lifecycle_revision
+          AND sandbox.activation_receipt_hash IS NOT NULL
+          AND sandbox.activation_container_id ~ '^[0-9a-f]{64}$'
+          AND sandbox.activation_node_id IS NOT NULL
+          AND sandbox.activation_image_digest IS NOT NULL
+          AND sandbox.activation_authority_published_at IS NOT NULL
+          AND sandbox.activation_dispatched_at IS NOT NULL
+          AND sandbox.activation_completed_at IS NOT NULL
+          AND EXISTS (
+            SELECT 1
+            FROM ${dockerNodes} AS source_node
+            WHERE source_node.node_id = sandbox.activation_node_id
+              AND source_node.node_incarnation IS NOT NULL
+              AND (
+                (source_node.fleet_kind = 'robot'
+                  AND source_node.provider_server_id IS NULL)
+                OR (source_node.fleet_kind = 'cloud'
+                  AND source_node.provider_server_id IS NOT NULL)
+              )
+          )
+          AND (sandbox.backup_schedule_claim_expires_at IS NULL
+            OR sandbox.backup_schedule_claim_expires_at <= clock_timestamp())
+          AND (
+            sandbox.backup_schedule_operation_id IS NULL
+            OR NOT EXISTS (
+              SELECT 1
+              FROM ${agentSandboxBackups} AS reserved_backup
+              WHERE reserved_backup.catalog_organization_id = sandbox.organization_id
+                AND reserved_backup.catalog_agent_id = sandbox.id
+                AND reserved_backup.backup_operation_id = sandbox.backup_schedule_operation_id
+            )
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM ${agentSandboxes} AS organization_claim
+            WHERE organization_claim.id <> sandbox.id
+              AND organization_claim.organization_id = sandbox.organization_id
+              AND organization_claim.backup_schedule_claim_expires_at > clock_timestamp()
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM active_operation_lanes AS organization_backup
+            WHERE organization_backup.organization_id = sandbox.organization_id
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM active_operation_lanes AS node_backup
+            WHERE node_backup.node_id = sandbox.activation_node_id
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM ${agentSandboxes} AS node_claim
+            WHERE node_claim.id <> sandbox.id
+              AND node_claim.activation_node_id = sandbox.activation_node_id
+              AND node_claim.backup_schedule_claim_expires_at > clock_timestamp()
+          )
+        RETURNING sandbox.organization_id, sandbox.id,
+          sandbox.backup_schedule_operation_id AS operation_id,
+          sandbox.backup_schedule_claim_expires_at AS expires_at,
+          sandbox.next_backup_at,
+          sandbox.backup_schedule_attempts AS attempts
+      `,
+    );
+    return claimed
+      .map((row) => ({
+        organizationId: row.organization_id,
+        agentId: row.id,
+        operationId: row.operation_id,
+        ownerId: params.ownerId,
+        generation,
+        expiresAt: requireDatabaseDate(row.expires_at, "claim.expiresAt"),
+        dueAt: requireDatabaseDate(row.next_backup_at, "claim.dueAt"),
+        attempts: row.attempts,
+      }))
+      .sort(
+        (left, right) =>
+          left.dueAt.getTime() - right.dueAt.getTime() ||
+          left.organizationId.localeCompare(right.organizationId) ||
+          left.agentId.localeCompare(right.agentId),
+      );
+  });
+}
+
+async function lockClaimedSandbox(
+  tx: DbTransaction,
+  claim: AgentBackupScheduleClaim,
+): Promise<{
+  organizationId: string;
+  agentId: string;
+  dueAt: Date;
+  activationGeneration: string;
+  lifecycleRevision: string;
+  nodeId: string;
+  providerHandle: string;
+  containerId: string;
+}> {
+  const [sandbox] = await tx
+    .select({
+      organizationId: agentSandboxes.organization_id,
+      agentId: agentSandboxes.id,
+      dueAt: agentSandboxes.next_backup_at,
+      status: agentSandboxes.status,
+      poolStatus: agentSandboxes.pool_status,
+      executionTier: agentSandboxes.execution_tier,
+      activationPhase: agentSandboxes.activation_phase,
+      activationGeneration: agentSandboxes.activation_generation,
+      lifecycleRevision: sql<string>`${agentSandboxes.lifecycle_revision}::text`,
+      activationLifecycleRevision: sql<
+        string | null
+      >`${agentSandboxes.activation_lifecycle_revision}::text`,
+      nodeId: agentSandboxes.activation_node_id,
+      providerHandle: agentSandboxes.sandbox_id,
+      containerId: agentSandboxes.activation_container_id,
+      claimOwner: agentSandboxes.backup_schedule_claim_owner,
+      claimGeneration: agentSandboxes.backup_schedule_claim_generation,
+      claimExpiresAt: agentSandboxes.backup_schedule_claim_expires_at,
+      operationId: agentSandboxes.backup_schedule_operation_id,
+    })
+    .from(agentSandboxes)
+    .where(
+      and(
+        eq(agentSandboxes.id, claim.agentId),
+        eq(agentSandboxes.organization_id, claim.organizationId),
+        eq(agentSandboxes.backup_schedule_claim_owner, claim.ownerId),
+        eq(agentSandboxes.backup_schedule_claim_generation, claim.generation),
+        eq(agentSandboxes.backup_schedule_operation_id, claim.operationId),
+        gt(agentSandboxes.backup_schedule_claim_expires_at, sql`clock_timestamp()`),
+      ),
+    )
+    .for("update")
+    .limit(1);
+  if (
+    !sandbox ||
+    sandbox.claimOwner !== claim.ownerId ||
+    sandbox.claimGeneration !== claim.generation ||
+    sandbox.operationId !== claim.operationId ||
+    !(sandbox.claimExpiresAt instanceof Date) ||
+    !(sandbox.dueAt instanceof Date)
+  ) {
+    throw new AgentBackupScheduleFenceError("Periodic backup scheduler lease is stale");
+  }
+  if (
+    sandbox.status !== "running" ||
+    sandbox.poolStatus !== null ||
+    sandbox.executionTier === "shared" ||
+    sandbox.activationPhase !== "active" ||
+    !sandbox.activationGeneration ||
+    sandbox.lifecycleRevision === null ||
+    sandbox.lifecycleRevision !== sandbox.activationLifecycleRevision ||
+    !sandbox.nodeId ||
+    !sandbox.providerHandle ||
+    !sandbox.containerId
+  ) {
+    throw new AgentBackupScheduleFenceError(
+      "Periodic backup source is no longer one exact active dedicated sandbox",
+    );
+  }
+  return {
+    organizationId: sandbox.organizationId,
+    agentId: sandbox.agentId,
+    dueAt: sandbox.dueAt,
+    activationGeneration: sandbox.activationGeneration,
+    lifecycleRevision: sandbox.activationLifecycleRevision,
+    nodeId: sandbox.nodeId,
+    providerHandle: sandbox.providerHandle,
+    containerId: sandbox.containerId,
+  };
+}
+
+/**
+ * Convert one scheduler lease into one catalogue-v3 full-backup operation.
+ * The deadline and operation id stay attached until protection reconciliation.
+ */
+export async function reserveClaimedAgentBackupSchedule(params: {
+  claim: AgentBackupScheduleClaim;
+  retentionMs?: number;
+}): Promise<AgentBackupScheduleReservation> {
+  const claim = params.claim;
+  validateClaimIdentity(claim);
+  const retentionMs = requireBoundedInteger({
+    value: params.retentionMs ?? DEFAULT_AGENT_BACKUP_SCHEDULE_RETENTION_MS,
+    field: "retentionMs",
+    min: 24 * 60 * 60_000,
+    max: 365 * 24 * 60 * 60_000,
+  });
+  return dbWrite.transaction(async (tx) => {
+    const source = await lockClaimedSandbox(tx, claim);
+    const [organization] = await tx
+      .select({ id: organizations.id })
+      .from(organizations)
+      .where(eq(organizations.id, source.organizationId))
+      .for("update")
+      .limit(1);
+    if (!organization) {
+      throw new AgentBackupScheduleFenceError("Periodic backup organization authority disappeared");
+    }
+    const [node] = await tx
+      .select({
+        recordId: dockerNodes.id,
+        nodeId: dockerNodes.node_id,
+        fleetKind: dockerNodes.fleet_kind,
+        providerServerId: dockerNodes.provider_server_id,
+        incarnation: dockerNodes.node_incarnation,
+      })
+      .from(dockerNodes)
+      .where(eq(dockerNodes.node_id, source.nodeId))
+      .for("update")
+      .limit(1);
+    if (
+      !node ||
+      !node.incarnation ||
+      (node.fleetKind !== "robot" && node.fleetKind !== "cloud") ||
+      (node.fleetKind === "robot" && node.providerServerId !== null) ||
+      (node.fleetKind === "cloud" && node.providerServerId === null)
+    ) {
+      throw new AgentBackupScheduleFenceError(
+        "Periodic backup source node lacks exact Robot/Cloud incarnation authority",
+      );
+    }
+    const activeStates = sql.join(
+      ACTIVE_OPERATION_STATES.map((state) => sql`${state}`),
+      sql`, `,
+    );
+    const activeLanes = activeBackupLanes(activeStates);
+    const [conflicts] = await sqlRows<{
+      organization_claim: boolean;
+      organization_backup: boolean;
+      node_claim: boolean;
+      node_backup: boolean;
+    }>(
+      tx,
+      sql`
+        WITH active_operation_lanes AS MATERIALIZED (${activeLanes})
+        SELECT
+          EXISTS (
+            SELECT 1 FROM ${agentSandboxes} AS other_claim
+            WHERE other_claim.id <> ${source.agentId}
+              AND other_claim.organization_id = ${source.organizationId}
+              AND other_claim.backup_schedule_claim_expires_at > clock_timestamp()
+          ) AS organization_claim,
+          EXISTS (
+            SELECT 1 FROM active_operation_lanes AS other_backup
+            WHERE other_backup.organization_id = ${source.organizationId}
+          ) AS organization_backup,
+          EXISTS (
+            SELECT 1 FROM ${agentSandboxes} AS other_claim
+            WHERE other_claim.id <> ${source.agentId}
+              AND other_claim.activation_node_id = ${source.nodeId}
+              AND other_claim.backup_schedule_claim_expires_at > clock_timestamp()
+          ) AS node_claim,
+          EXISTS (
+            SELECT 1 FROM active_operation_lanes AS other_backup
+            WHERE other_backup.node_id = ${source.nodeId}
+          ) AS node_backup
+      `,
+    );
+    if (
+      !conflicts ||
+      conflicts.organization_claim ||
+      conflicts.organization_backup ||
+      conflicts.node_claim ||
+      conflicts.node_backup
+    ) {
+      throw new AgentBackupScheduleFenceError("Periodic backup fair-lane authority was superseded");
+    }
+    const [clock] = await sqlRows<{ now: Date | string }>(tx, sql`SELECT NOW() AS now`);
+    if (!clock?.now) throw new Error("Primary database clock is unavailable");
+    const databaseNow = clock.now instanceof Date ? clock.now : new Date(clock.now);
+    if (!Number.isFinite(databaseNow.getTime())) {
+      throw new Error("Primary database clock returned an invalid timestamp");
+    }
+    const backup = await reserveAgentBackupOperationInTransaction(tx, {
+      organizationId: source.organizationId,
+      agentId: source.agentId,
+      sandboxRecordId: source.agentId,
+      operationId: claim.operationId,
+      activationGeneration: source.activationGeneration,
+      lifecycleRevision: source.lifecycleRevision,
+      snapshotType: "auto",
+      backupKind: "full",
+      sourceProvider: node.fleetKind === "robot" ? "operator-onboarded" : "hetzner-cloud",
+      sourceNodeRecordId: node.recordId,
+      sourceNodeId: node.nodeId,
+      sourceNodeIncarnation: node.incarnation,
+      sourceProviderServerId: node.providerServerId,
+      sourceProviderHandle: source.providerHandle,
+      sourceContainerId: source.containerId,
+      retentionReason: "schedule",
+      retentionUntil: new Date(databaseNow.getTime() + retentionMs),
+    });
+    const [updated] = await tx
+      .update(agentSandboxes)
+      .set({
+        backup_schedule_retry_at: null,
+        backup_schedule_claim_owner: null,
+        backup_schedule_claim_generation: null,
+        backup_schedule_claim_expires_at: null,
+        backup_schedule_last_error_code: null,
+        updated_at: sql`NOW()`,
+      })
+      .where(
+        and(
+          eq(agentSandboxes.id, claim.agentId),
+          eq(agentSandboxes.organization_id, claim.organizationId),
+          eq(agentSandboxes.backup_schedule_claim_owner, claim.ownerId),
+          eq(agentSandboxes.backup_schedule_claim_generation, claim.generation),
+          eq(agentSandboxes.backup_schedule_operation_id, claim.operationId),
+          gt(agentSandboxes.backup_schedule_claim_expires_at, sql`clock_timestamp()`),
+        ),
+      )
+      .returning({ dueAt: agentSandboxes.next_backup_at });
+    if (!(updated?.dueAt instanceof Date)) {
+      throw new AgentBackupScheduleFenceError(
+        "Periodic backup reservation lost its scheduler lease CAS",
+      );
+    }
+    return {
+      organizationId: source.organizationId,
+      agentId: source.agentId,
+      operationId: claim.operationId,
+      backupId: backup.id,
+      dueAt: updated.dueAt,
+    };
+  });
+}
+
+/**
+ * Release an unconverted claim with separate DB-clock backpressure. The RPO
+ * deadline and retry-stable operation id remain unchanged.
+ */
+export async function deferClaimedAgentBackupSchedule(params: {
+  claim: AgentBackupScheduleClaim;
+  retryDelayMs: number;
+  errorCode: string;
+}): Promise<boolean> {
+  validateClaimIdentity(params.claim);
+  const retryDelayMs = requireBoundedInteger({
+    value: params.retryDelayMs,
+    field: "retryDelayMs",
+    min: 1,
+    max: MAX_AGENT_BACKUP_SCHEDULE_RETRY_MS,
+  });
+  const errorCode = requireScheduleErrorCode(params.errorCode);
+  const [updated] = await dbWrite
+    .update(agentSandboxes)
+    .set({
+      backup_schedule_retry_at: sql`clock_timestamp()
+        + (${retryDelayMs} * INTERVAL '1 millisecond')`,
+      backup_schedule_claim_owner: null,
+      backup_schedule_claim_generation: null,
+      backup_schedule_claim_expires_at: null,
+      backup_schedule_last_error_code: errorCode,
+      updated_at: sql`NOW()`,
+    })
+    .where(
+      and(
+        eq(agentSandboxes.id, params.claim.agentId),
+        eq(agentSandboxes.organization_id, params.claim.organizationId),
+        eq(agentSandboxes.backup_schedule_claim_owner, params.claim.ownerId),
+        eq(agentSandboxes.backup_schedule_claim_generation, params.claim.generation),
+        eq(agentSandboxes.backup_schedule_operation_id, params.claim.operationId),
+        gt(agentSandboxes.backup_schedule_claim_expires_at, sql`clock_timestamp()`),
+      ),
+    )
+    .returning({ id: agentSandboxes.id });
+  return Boolean(updated);
+}

--- a/packages/cloud/shared/src/db/repositories/agent-backup-source-authority.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-backup-source-authority.ts
@@ -1,0 +1,155 @@
+/** Exact, fail-closed Robot/Cloud authority used by backup manifest v2. */
+
+import type { AgentBackupManifestV2Source } from "@elizaos/shared";
+import { and, eq } from "drizzle-orm";
+import type { DbTransaction } from "../client";
+import { dbWrite } from "../helpers";
+import { dockerNodes } from "../schemas/docker-nodes";
+
+const LOWERCASE_UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const DOCKER_ID_PATTERN = /^[0-9a-f]{64}$/;
+const PROVIDER_SERVER_ID_PATTERN = /^[1-9][0-9]{0,19}$/;
+const UINT64_MAX = 18_446_744_073_709_551_615n;
+
+export class AgentBackupSourceAuthorityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AgentBackupSourceAuthorityError";
+  }
+}
+
+export function requireCanonicalNodeIncarnation(value: string): string {
+  if (!LOWERCASE_UUID_PATTERN.test(value)) {
+    throw new AgentBackupSourceAuthorityError("nodeIncarnation must be an exact lowercase UUID");
+  }
+  return value;
+}
+
+/** Parse one exact Linux `/proc/sys/kernel/random/boot_id` response. */
+export function parseLinuxBootId(output: string): string {
+  return requireCanonicalNodeIncarnation(output.trim());
+}
+
+export function requireCanonicalProviderServerId(value: string): string {
+  if (!PROVIDER_SERVER_ID_PATTERN.test(value) || BigInt(value) > UINT64_MAX) {
+    throw new AgentBackupSourceAuthorityError(
+      "providerServerId must be a canonical positive uint64 decimal",
+    );
+  }
+  return value;
+}
+
+function requireNodeRecordId(value: string): string {
+  if (!LOWERCASE_UUID_PATTERN.test(value)) {
+    throw new AgentBackupSourceAuthorityError("nodeRecordId must be a lowercase UUID");
+  }
+  return value;
+}
+
+function requireNodeId(value: string): string {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(value)) {
+    throw new AgentBackupSourceAuthorityError("nodeId must be a canonical node handle");
+  }
+  return value;
+}
+
+function requireContainerId(value: string): string {
+  if (!DOCKER_ID_PATTERN.test(value)) {
+    throw new AgentBackupSourceAuthorityError(
+      "containerId must be an exact lowercase 64-character Docker ID",
+    );
+  }
+  return value;
+}
+
+export interface AgentBackupManifestSourceAuthorityLocator {
+  nodeRecordId: string;
+  nodeId: string;
+  nodeIncarnation: string;
+  containerId: string;
+}
+
+function validateLocator(
+  input: AgentBackupManifestSourceAuthorityLocator,
+): AgentBackupManifestSourceAuthorityLocator {
+  return {
+    nodeRecordId: requireNodeRecordId(input.nodeRecordId),
+    nodeId: requireNodeId(input.nodeId),
+    nodeIncarnation: requireCanonicalNodeIncarnation(input.nodeIncarnation),
+    containerId: requireContainerId(input.containerId),
+  };
+}
+
+/**
+ * Resolve exact source identity inside a caller-owned primary transaction.
+ * The key-share lock prevents re-registration/reboot authority from changing
+ * until the caller has durably snapshotted the returned vector.
+ */
+export async function resolveAgentBackupManifestSourceAuthorityInTransaction(
+  tx: DbTransaction,
+  input: AgentBackupManifestSourceAuthorityLocator,
+): Promise<AgentBackupManifestV2Source> {
+  const locator = validateLocator(input);
+  const [node] = await tx
+    .select({
+      nodeRecordId: dockerNodes.id,
+      nodeId: dockerNodes.node_id,
+      fleetKind: dockerNodes.fleet_kind,
+      infrastructureProvider: dockerNodes.infrastructure_provider,
+      providerServerId: dockerNodes.provider_server_id,
+      nodeIncarnation: dockerNodes.node_incarnation,
+      hostKeyFingerprint: dockerNodes.host_key_fingerprint,
+    })
+    .from(dockerNodes)
+    .where(
+      and(
+        eq(dockerNodes.id, locator.nodeRecordId),
+        eq(dockerNodes.node_id, locator.nodeId),
+        eq(dockerNodes.node_incarnation, locator.nodeIncarnation),
+      ),
+    )
+    .for("no key update")
+    .limit(1);
+
+  if (
+    !node ||
+    node.infrastructureProvider !== "hetzner" ||
+    node.nodeIncarnation !== locator.nodeIncarnation ||
+    !node.hostKeyFingerprint?.trim()
+  ) {
+    throw new AgentBackupSourceAuthorityError(
+      "Backup source node is legacy, unattested, stale, or no longer matches",
+    );
+  }
+
+  const base = {
+    provider: "hetzner" as const,
+    nodeRecordId: node.nodeRecordId,
+    nodeIncarnation: node.nodeIncarnation,
+    nodeId: node.nodeId,
+    containerId: locator.containerId,
+  };
+  if (node.fleetKind === "robot" && node.providerServerId === null) {
+    return Object.freeze({ kind: "robot" as const, ...base });
+  }
+  if (node.fleetKind === "cloud" && node.providerServerId !== null) {
+    return Object.freeze({
+      kind: "cloud" as const,
+      ...base,
+      providerServerId: requireCanonicalProviderServerId(node.providerServerId),
+    });
+  }
+  throw new AgentBackupSourceAuthorityError(
+    "Backup source node has an incomplete or contradictory Robot/Cloud authority",
+  );
+}
+
+/** Resolve against the primary, never a replica or JSON metadata projection. */
+export async function resolveAgentBackupManifestSourceAuthority(
+  input: AgentBackupManifestSourceAuthorityLocator,
+): Promise<AgentBackupManifestV2Source> {
+  return dbWrite.transaction((tx) =>
+    resolveAgentBackupManifestSourceAuthorityInTransaction(tx, input),
+  );
+}

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
@@ -529,7 +529,7 @@ describe("AgentSandboxesRepository", () => {
       expect(JSON.stringify(insertData.state_data)).not.toContain("secret pre-wipe memory");
       expect(JSON.stringify(insertData.state_data)).not.toContain("secret-config");
 
-      const hydrated = await hydrateAgentSandboxBackup({
+      const storedFixture = {
         id: backupId,
         sandbox_record_id: sandboxRecordId,
         snapshot_type: "manual",
@@ -548,7 +548,8 @@ describe("AgentSandboxesRepository", () => {
         verified_at: null,
         verification_error: null,
         created_at: createdAt,
-      });
+      } as Parameters<typeof hydrateAgentSandboxBackup>[0];
+      const hydrated = await hydrateAgentSandboxBackup(storedFixture);
 
       expect(hydrated.state_data).toEqual(stateData);
     } finally {

--- a/packages/cloud/shared/src/db/repositories/docker-nodes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/docker-nodes.test.ts
@@ -124,6 +124,30 @@ describe("DockerNodesRepository environment guard", () => {
     expect(Date.parse(parsed.embeddingSidecar.checkedAt)).toBeGreaterThan(0);
   });
 
+  test("generic update rejects every Docker authority identity field", async () => {
+    const { DockerNodesRepository } = await import("./docker-nodes");
+    const repository = new DockerNodesRepository();
+    const identityMutations = [
+      ["id", "replacement-row"],
+      ["node_id", "replacement-node"],
+      ["node_incarnation", "99999999-9999-4999-8999-999999999999"],
+      ["fleet_kind", "cloud"],
+      ["infrastructure_provider", "hetzner"],
+      ["provider_server_id", "12345"],
+      ["host_key_fingerprint", "replacement-pin"],
+    ] as const;
+
+    for (const [field, value] of identityMutations) {
+      await expect(repository.update("row-1", { [field]: value } as never)).rejects.toThrow(
+        `cannot mutate identity field '${field}'`,
+      );
+      expect(capturedSet).toBeUndefined();
+    }
+
+    await expect(repository.update("row-1", { enabled: false })).resolves.toBeNull();
+    expect(capturedSet).toMatchObject({ enabled: false });
+  });
+
   test("findLeastLoaded applies the same environment guard to schedulable capacity", async () => {
     const { DockerNodesRepository } = await import("./docker-nodes");
 
@@ -149,7 +173,6 @@ describe("DockerNodesRepository environment guard", () => {
         hostname: "203.0.113.10",
         ssh_port: 22,
         ssh_user: "root",
-        host_key_fingerprint: "SHA256:node",
         status: "unknown",
       },
       {

--- a/packages/cloud/shared/src/db/repositories/docker-nodes.ts
+++ b/packages/cloud/shared/src/db/repositories/docker-nodes.ts
@@ -6,13 +6,114 @@ import { logger } from "../../lib/utils/logger";
 import { dbRead, dbWrite } from "../helpers";
 import {
   type DockerNode,
+  type DockerNodeFleetKind,
+  type DockerNodeInfrastructureProvider,
   type DockerNodeStatus,
   dockerNodes,
   type NewDockerNode,
   PLACEABLE_NODE_STATE,
 } from "../schemas/docker-nodes";
+import {
+  AgentBackupSourceAuthorityError,
+  requireCanonicalNodeIncarnation,
+} from "./agent-backup-source-authority";
 
-export type { DockerNode, DockerNodeStatus, NewDockerNode };
+export type {
+  DockerNode,
+  DockerNodeFleetKind,
+  DockerNodeInfrastructureProvider,
+  DockerNodeStatus,
+  NewDockerNode,
+};
+
+export interface NodeIncarnationCasInput {
+  id: string;
+  nodeId: string;
+  expectedIncarnation: string | null;
+}
+
+export interface NodeHostKeyFingerprintCasInput {
+  id: string;
+  nodeId: string;
+  expectedFingerprint: string | null;
+  observedFingerprint: string | null;
+}
+
+export interface RobotSourceAuthorityRegistration {
+  hostname: string;
+  sshPort: number;
+  sshUser: string;
+  capacity: number;
+  status: DockerNodeStatus;
+  hostKeyFingerprint: string;
+  metadata: Record<string, unknown>;
+}
+
+const DOCKER_NODE_IDENTITY_FIELDS = [
+  "id",
+  "node_id",
+  "node_incarnation",
+  "fleet_kind",
+  "infrastructure_provider",
+  "provider_server_id",
+  "host_key_fingerprint",
+] as const;
+
+type DockerNodeIdentityField = (typeof DOCKER_NODE_IDENTITY_FIELDS)[number];
+export type DockerNodeMutableUpdate = Partial<Omit<NewDockerNode, DockerNodeIdentityField>>;
+
+function rejectDockerNodeIdentityMutation(data: DockerNodeMutableUpdate): void {
+  for (const field of DOCKER_NODE_IDENTITY_FIELDS) {
+    if (Object.hasOwn(data, field)) {
+      throw new AgentBackupSourceAuthorityError(
+        `Generic Docker node update cannot mutate identity field '${field}'`,
+      );
+    }
+  }
+}
+
+function requireExpectedIncarnation(value: string | null): string | null {
+  return value === null ? null : requireCanonicalNodeIncarnation(value);
+}
+
+function requireHostKeyFingerprint(value: string): string {
+  if (!value.trim()) {
+    throw new AgentBackupSourceAuthorityError("Node host-key fingerprint must not be empty");
+  }
+  return value;
+}
+
+function canonicalizeHostKeyFingerprint(value: string): string {
+  return requireHostKeyFingerprint(value).trim();
+}
+
+function nodeIncarnationCasPredicate(expectedIncarnation: string | null) {
+  return sql`${dockerNodes.node_incarnation} IS NOT DISTINCT FROM ${expectedIncarnation}`;
+}
+
+function hostKeyFingerprintCasPredicate(expectedFingerprint: string | null) {
+  return sql`${dockerNodes.host_key_fingerprint} IS NOT DISTINCT FROM ${expectedFingerprint}`;
+}
+
+function typedSourceAuthorityPredicate() {
+  return sql`${dockerNodes.infrastructure_provider} = 'hetzner'
+    AND ${dockerNodes.host_key_fingerprint} IS NOT NULL
+    AND btrim(${dockerNodes.host_key_fingerprint}) <> ''
+    AND (
+      (${dockerNodes.fleet_kind} = 'robot' AND ${dockerNodes.provider_server_id} IS NULL)
+      OR (${dockerNodes.fleet_kind} = 'cloud'
+        AND CASE
+          WHEN ${dockerNodes.provider_server_id} ~ '^[1-9][0-9]{0,19}$'
+            THEN ${dockerNodes.provider_server_id}::numeric <= 18446744073709551615
+          ELSE false
+        END)
+    )`;
+}
+
+async function findDockerNodeByIdOnPrimary(id: string): Promise<DockerNode | null> {
+  const [node] = await dbWrite.select().from(dockerNodes).where(eq(dockerNodes.id, id)).limit(1);
+  return node ?? null;
+}
 
 function currentDeploymentEnvironment(): string | null {
   const env = typeof process !== "undefined" ? process.env.ENVIRONMENT?.trim() : undefined;
@@ -141,13 +242,208 @@ export class DockerNodesRepository {
     return r;
   }
 
-  async update(id: string, data: Partial<NewDockerNode>): Promise<DockerNode | null> {
+  async update(id: string, data: DockerNodeMutableUpdate): Promise<DockerNode | null> {
+    rejectDockerNodeIdentityMutation(data);
     const [r] = await dbWrite
       .update(dockerNodes)
       .set({ ...data, updated_at: new Date() })
       .where(eq(dockerNodes.id, id))
       .returning();
     return r ?? null;
+  }
+
+  /**
+   * Rotate a typed node's exact Linux boot UUID with compare-and-swap fencing.
+   * Same-boot replay is idempotent; a stale expected UUID can never roll back
+   * a newer attestation.
+   */
+  async attestNodeIncarnation(
+    input: NodeIncarnationCasInput & {
+      expectedHostKeyFingerprint: string;
+      observedIncarnation: string;
+    },
+  ): Promise<DockerNode> {
+    const expected = requireExpectedIncarnation(input.expectedIncarnation);
+    const expectedHostKeyFingerprint = requireHostKeyFingerprint(input.expectedHostKeyFingerprint);
+    const observed = requireCanonicalNodeIncarnation(input.observedIncarnation);
+    const [updated] = await dbWrite
+      .update(dockerNodes)
+      .set({ node_incarnation: observed, updated_at: new Date() })
+      .where(
+        and(
+          eq(dockerNodes.id, input.id),
+          eq(dockerNodes.node_id, input.nodeId),
+          nodeIncarnationCasPredicate(expected),
+          hostKeyFingerprintCasPredicate(expectedHostKeyFingerprint),
+          typedSourceAuthorityPredicate(),
+        ),
+      )
+      .returning();
+    if (updated) return updated;
+
+    const current = await findDockerNodeByIdOnPrimary(input.id);
+    if (
+      current?.node_id === input.nodeId &&
+      current.host_key_fingerprint === expectedHostKeyFingerprint &&
+      current.node_incarnation === observed
+    ) {
+      return current;
+    }
+    throw new AgentBackupSourceAuthorityError(
+      "Node incarnation attestation lost its compare-and-swap authority",
+    );
+  }
+
+  /** Fail closed after a typed node's boot-id probe becomes unavailable. */
+  async invalidateNodeIncarnation(
+    input: NodeIncarnationCasInput & { expectedHostKeyFingerprint: string | null },
+  ): Promise<DockerNode> {
+    const expected = requireExpectedIncarnation(input.expectedIncarnation);
+    const expectedHostKeyFingerprint =
+      input.expectedHostKeyFingerprint === null
+        ? null
+        : requireHostKeyFingerprint(input.expectedHostKeyFingerprint);
+    const [updated] = await dbWrite
+      .update(dockerNodes)
+      .set({ node_incarnation: null, updated_at: new Date() })
+      .where(
+        and(
+          eq(dockerNodes.id, input.id),
+          eq(dockerNodes.node_id, input.nodeId),
+          nodeIncarnationCasPredicate(expected),
+          hostKeyFingerprintCasPredicate(expectedHostKeyFingerprint),
+          typedSourceAuthorityPredicate(),
+        ),
+      )
+      .returning();
+    if (updated) return updated;
+
+    const current = await findDockerNodeByIdOnPrimary(input.id);
+    if (
+      current?.node_id === input.nodeId &&
+      current.host_key_fingerprint === expectedHostKeyFingerprint &&
+      current.node_incarnation === null
+    ) {
+      return current;
+    }
+    throw new AgentBackupSourceAuthorityError(
+      "Node incarnation invalidation lost its compare-and-swap authority",
+    );
+  }
+
+  /**
+   * Establish or rotate the SSH host-key pin under compare-and-swap fencing.
+   * Any pin write invalidates the boot UUID in the same statement, so capture
+   * stays ineligible until that exact key verifies a fresh boot attestation.
+   */
+  async rotateNodeHostKeyFingerprint(input: NodeHostKeyFingerprintCasInput): Promise<DockerNode> {
+    const expectedFingerprint =
+      input.expectedFingerprint === null
+        ? null
+        : requireHostKeyFingerprint(input.expectedFingerprint);
+    const observedFingerprint =
+      input.observedFingerprint === null
+        ? null
+        : canonicalizeHostKeyFingerprint(input.observedFingerprint);
+    const [updated] = await dbWrite
+      .update(dockerNodes)
+      .set({
+        host_key_fingerprint: observedFingerprint,
+        node_incarnation: null,
+        updated_at: new Date(),
+      })
+      .where(
+        and(
+          eq(dockerNodes.id, input.id),
+          eq(dockerNodes.node_id, input.nodeId),
+          hostKeyFingerprintCasPredicate(expectedFingerprint),
+        ),
+      )
+      .returning();
+    if (updated) return updated;
+
+    const current = await findDockerNodeByIdOnPrimary(input.id);
+    if (
+      current?.node_id === input.nodeId &&
+      current.host_key_fingerprint === observedFingerprint &&
+      current.node_incarnation === null
+    ) {
+      return current;
+    }
+    throw new AgentBackupSourceAuthorityError(
+      "Node host-key rotation lost its compare-and-swap authority",
+    );
+  }
+
+  /**
+   * Explicit Robot onboarding may establish authority for an all-null legacy
+   * row, but never reinterpret a typed Cloud row or metadata projection.
+   */
+  async attestRobotSourceAuthority(
+    input: NodeIncarnationCasInput & {
+      expectedHostKeyFingerprint: string | null;
+      observedIncarnation: string;
+      registration: RobotSourceAuthorityRegistration;
+    },
+  ): Promise<DockerNode> {
+    const expected = requireExpectedIncarnation(input.expectedIncarnation);
+    const expectedHostKeyFingerprint =
+      input.expectedHostKeyFingerprint === null
+        ? null
+        : requireHostKeyFingerprint(input.expectedHostKeyFingerprint);
+    const observed = requireCanonicalNodeIncarnation(input.observedIncarnation);
+    const hostKeyFingerprint = canonicalizeHostKeyFingerprint(
+      input.registration.hostKeyFingerprint,
+    );
+    const [updated] = await dbWrite
+      .update(dockerNodes)
+      .set({
+        fleet_kind: "robot",
+        infrastructure_provider: "hetzner",
+        provider_server_id: null,
+        node_incarnation: observed,
+        hostname: input.registration.hostname,
+        ssh_port: input.registration.sshPort,
+        ssh_user: input.registration.sshUser,
+        capacity: input.registration.capacity,
+        status: input.registration.status,
+        host_key_fingerprint: hostKeyFingerprint,
+        metadata: input.registration.metadata,
+        updated_at: new Date(),
+      })
+      .where(
+        and(
+          eq(dockerNodes.id, input.id),
+          eq(dockerNodes.node_id, input.nodeId),
+          nodeIncarnationCasPredicate(expected),
+          hostKeyFingerprintCasPredicate(expectedHostKeyFingerprint),
+          sql`(
+            (${dockerNodes.fleet_kind} IS NULL
+              AND ${dockerNodes.infrastructure_provider} IS NULL
+              AND ${dockerNodes.provider_server_id} IS NULL)
+            OR (${dockerNodes.fleet_kind} = 'robot'
+              AND ${dockerNodes.infrastructure_provider} = 'hetzner'
+              AND ${dockerNodes.provider_server_id} IS NULL)
+          )`,
+        ),
+      )
+      .returning();
+    if (updated) return updated;
+
+    const current = await findDockerNodeByIdOnPrimary(input.id);
+    if (
+      current?.node_id === input.nodeId &&
+      current.fleet_kind === "robot" &&
+      current.infrastructure_provider === "hetzner" &&
+      current.provider_server_id === null &&
+      current.host_key_fingerprint === hostKeyFingerprint &&
+      current.node_incarnation === observed
+    ) {
+      return current;
+    }
+    throw new AgentBackupSourceAuthorityError(
+      "Robot source-authority attestation conflicts with a newer or Cloud registration",
+    );
   }
 
   /**
@@ -162,7 +458,6 @@ export class DockerNodesRepository {
       hostname: string;
       ssh_port: number;
       ssh_user: string;
-      host_key_fingerprint: string;
       status: DockerNodeStatus;
     },
     metadataPatch: Record<string, unknown>,
@@ -246,27 +541,6 @@ export class DockerNodesRepository {
         `[docker-nodes] decrementAllocated clamped to 0 for node ${nodeId} — allocation count may be out of sync`,
       );
     }
-  }
-
-  /**
-   * Persist a host-key fingerprint captured via Trust-On-First-Use.
-   *
-   * Only writes when the row is still unpinned (`host_key_fingerprint IS NULL`),
-   * so it never clobbers an existing pin — a later differing key must surface as
-   * a MISMATCH in the SSH verifier, not be silently re-pinned here. Idempotent:
-   * concurrent health checks racing to pin the same node all no-op after the
-   * first write.
-   */
-  async setHostKeyFingerprint(nodeId: string, fingerprint: string): Promise<void> {
-    await dbWrite
-      .update(dockerNodes)
-      .set({
-        host_key_fingerprint: fingerprint,
-        updated_at: new Date(),
-      })
-      .where(
-        and(eq(dockerNodes.node_id, nodeId), sql`${dockerNodes.host_key_fingerprint} IS NULL`),
-      );
   }
 
   /**

--- a/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
@@ -132,6 +132,30 @@ export const agentSandboxes = pgTable(
     status: text("status").$type<AgentSandboxStatus>().notNull().default("pending"),
     lifecycle_job_id: uuid("lifecycle_job_id"),
     lifecycle_execution_generation: uuid("lifecycle_execution_generation"),
+    /**
+     * Fully published activation authority consumed by capture and RPO
+     * scheduling. Intermediate quarantine phases are introduced by the
+     * restore slice; this foundation deliberately accepts only all-null or a
+     * complete active generation.
+     */
+    activation_generation: uuid("activation_generation"),
+    /**
+     * Exact signed-int64 copy of `lifecycle_revision`. The source column is a
+     * PostgreSQL bigint, so bigint mode avoids a lossy JavaScript number while
+     * retaining direct SQL equality and the source column's int64 upper bound.
+     */
+    activation_lifecycle_revision: bigint("activation_lifecycle_revision", { mode: "bigint" }),
+    activation_phase: text("activation_phase").$type<"active">(),
+    activation_receipt_hash: text("activation_receipt_hash"),
+    activation_container_id: text("activation_container_id"),
+    activation_node_id: text("activation_node_id"),
+    activation_image_digest: text("activation_image_digest"),
+    activation_boot_id: uuid("activation_boot_id"),
+    activation_authority_published_at: timestamp("activation_authority_published_at", {
+      withTimezone: true,
+    }),
+    activation_dispatched_at: timestamp("activation_dispatched_at", { withTimezone: true }),
+    activation_completed_at: timestamp("activation_completed_at", { withTimezone: true }),
     deletion_attempt_id: uuid("deletion_attempt_id"),
     deletion_started_at: timestamp("deletion_started_at", { withTimezone: true }),
     /** Lifecycle state captured when a reversible deletion generation begins. */
@@ -221,6 +245,28 @@ export const agentSandboxes = pgTable(
      * due-set window and starve backup-capable agents (#15783).
      */
     backup_unsupported_reason: text("backup_unsupported_reason"),
+    /**
+     * Primary-DB clock authority for the next periodic catalogue-v3 backup.
+     * Null means the row is not enrolled; it never proves that a due backup
+     * completed.
+     */
+    next_backup_at: timestamp("next_backup_at", { withTimezone: true }),
+    /** Retry-stable operation id allocated before a due row leaves the DB. */
+    backup_schedule_operation_id: uuid("backup_schedule_operation_id"),
+    /** DB-clock backpressure that does not advance the protected-backup deadline. */
+    backup_schedule_retry_at: timestamp("backup_schedule_retry_at", { withTimezone: true }),
+    /** Exact bounded scheduler lease. All three members are null or present. */
+    backup_schedule_claim_owner: text("backup_schedule_claim_owner"),
+    backup_schedule_claim_generation: uuid("backup_schedule_claim_generation"),
+    backup_schedule_claim_expires_at: timestamp("backup_schedule_claim_expires_at", {
+      withTimezone: true,
+    }),
+    backup_schedule_attempts: integer("backup_schedule_attempts").notNull().default(0),
+    backup_schedule_last_error_code: text("backup_schedule_last_error_code"),
+    /** DB-clock time of the exact catalogue proof that advanced the RPO deadline. */
+    backup_schedule_last_protected_at: timestamp("backup_schedule_last_protected_at", {
+      withTimezone: true,
+    }),
     last_heartbeat_at: timestamp("last_heartbeat_at", { withTimezone: true }),
     error_message: text("error_message"),
     error_count: integer("error_count").notNull().default(0),
@@ -350,6 +396,76 @@ export const agentSandboxes = pgTable(
     lifecycle_execution_idx: index("agent_sandboxes_lifecycle_execution_idx")
       .on(table.lifecycle_job_id, table.lifecycle_execution_generation)
       .where(sql`${table.lifecycle_execution_generation} IS NOT NULL`),
+    activation_generation_idx: index("agent_sandboxes_activation_generation_idx")
+      .on(table.activation_generation)
+      .where(sql`${table.activation_generation} IS NOT NULL`),
+    backup_schedule_due_idx: index("agent_sandboxes_backup_schedule_due_idx")
+      .on(table.next_backup_at, table.backup_schedule_retry_at, table.organization_id, table.id)
+      .where(sql`${table.next_backup_at} IS NOT NULL`),
+    backup_schedule_claim_expiry_idx: index("agent_sandboxes_backup_schedule_claim_expiry_idx")
+      .on(table.backup_schedule_claim_expires_at)
+      .where(sql`${table.backup_schedule_claim_expires_at} IS NOT NULL`),
+    backup_schedule_operation_idx: index("agent_sandboxes_backup_schedule_operation_idx")
+      .on(table.organization_id, table.id, table.backup_schedule_operation_id)
+      .where(sql`${table.backup_schedule_operation_id} IS NOT NULL`),
+    backup_schedule_claim_shape_check: check(
+      "agent_sandboxes_backup_schedule_claim_shape_check",
+      sql`((
+        ${table.backup_schedule_claim_owner} IS NULL
+        AND ${table.backup_schedule_claim_generation} IS NULL
+        AND ${table.backup_schedule_claim_expires_at} IS NULL
+      ) OR (
+        ${table.next_backup_at} IS NOT NULL
+        AND ${table.backup_schedule_operation_id} IS NOT NULL
+        AND ${table.backup_schedule_claim_owner} IS NOT NULL
+        AND ${table.backup_schedule_claim_owner} <> ''
+        AND ${table.backup_schedule_claim_generation} IS NOT NULL
+        AND ${table.backup_schedule_claim_expires_at} IS NOT NULL
+      )) IS TRUE`,
+    ),
+    backup_schedule_attempts_check: check(
+      "agent_sandboxes_backup_schedule_attempts_check",
+      sql`(${table.backup_schedule_attempts} >= 0
+        AND (${table.backup_schedule_last_error_code} IS NULL
+          OR ${table.backup_schedule_last_error_code} ~ '^[A-Z][A-Z0-9_]{0,95}$')) IS TRUE`,
+    ),
+    activation_state_check: check(
+      "agent_sandboxes_activation_state_check",
+      sql`((
+        ${table.activation_generation} IS NULL
+        AND ${table.activation_lifecycle_revision} IS NULL
+        AND ${table.activation_phase} IS NULL
+        AND ${table.activation_receipt_hash} IS NULL
+        AND ${table.activation_container_id} IS NULL
+        AND ${table.activation_node_id} IS NULL
+        AND ${table.activation_image_digest} IS NULL
+        AND ${table.activation_boot_id} IS NULL
+        AND ${table.activation_authority_published_at} IS NULL
+        AND ${table.activation_dispatched_at} IS NULL
+        AND ${table.activation_completed_at} IS NULL
+      ) OR (
+        ${table.activation_generation} IS NOT NULL
+        AND ${table.activation_lifecycle_revision} IS NOT NULL
+        AND ${table.activation_lifecycle_revision} >= 0
+        AND ${table.activation_lifecycle_revision} = ${table.lifecycle_revision}
+        AND ${table.activation_phase} = 'active'
+        AND ${table.activation_receipt_hash} ~ '^[0-9a-f]{64}$'
+        AND ${table.activation_container_id} ~ '^[0-9a-f]{64}$'
+        AND ${table.sandbox_id} IS NOT NULL
+        AND ${table.activation_container_id} <> ${table.sandbox_id}
+        AND ${table.activation_node_id} IS NOT NULL
+        AND btrim(${table.activation_node_id}) <> ''
+        AND ${table.activation_node_id} = ${table.node_id}
+        AND ${table.activation_image_digest} ~ '^sha256:[0-9a-f]{64}$'
+        AND ${table.activation_image_digest} = ${table.image_digest}
+        AND ${table.activation_boot_id} IS NOT NULL
+        AND ${table.activation_authority_published_at} IS NOT NULL
+        AND ${table.activation_dispatched_at} IS NOT NULL
+        AND ${table.activation_completed_at} IS NOT NULL
+        AND ${table.activation_authority_published_at} <= ${table.activation_dispatched_at}
+        AND ${table.activation_dispatched_at} <= ${table.activation_completed_at}
+      )) IS TRUE`,
+    ),
     deletion_intent_pair_check: check(
       "agent_sandboxes_deletion_intent_pair_check",
       sql`(
@@ -486,6 +602,10 @@ export type AgentBackupVerificationStatus = "verified" | "failed" | "errored";
  * `agent-backup-diff.ts` for the delta format and reconstruction.
  */
 export type AgentBackupKind = "full" | "incremental";
+
+export const AGENT_BACKUP_SOURCE_PROVIDERS = ["operator-onboarded", "hetzner-cloud"] as const;
+
+export type AgentBackupSourceProvider = (typeof AGENT_BACKUP_SOURCE_PROVIDERS)[number];
 
 /**
  * Durable lifecycle of a logical backup operation. `legacy_unmigrated` is a
@@ -680,6 +800,17 @@ export const agentSandboxBackups = pgTable(
       scale: 0,
       mode: "bigint",
     }),
+    source_provider: text("source_provider").$type<AgentBackupSourceProvider>(),
+    source_node_record_id: uuid("source_node_record_id"),
+    source_node_id: text("source_node_id"),
+    /** Immutable Linux boot UUID resolved from typed node authority at reservation. */
+    source_node_incarnation: uuid("source_node_incarnation"),
+    /** Exact Hetzner Cloud server id; null for operator-onboarded Robot nodes. */
+    source_provider_server_id: text("source_provider_server_id"),
+    /** Provider/container-name handle used only to locate the running sandbox. */
+    source_provider_handle: text("source_provider_handle"),
+    /** Immutable Docker ID from activation create/inspect. */
+    source_container_id: text("source_container_id"),
     manifest_format: text("manifest_format"),
     manifest_version: integer("manifest_version"),
     manifest_digest: text("manifest_digest"),
@@ -702,6 +833,23 @@ export const agentSandboxBackups = pgTable(
     wrapped_dek_sha256: text("wrapped_dek_sha256"),
     wrapped_dek_size_bytes: integer("wrapped_dek_size_bytes"),
     wrapped_dek_receipt_digest: text("wrapped_dek_receipt_digest"),
+    /** Manifest-v3's one-operation DEK + content-HMAC envelope. Never populated for v2. */
+    operation_key_bundle_generation_id: uuid("operation_key_bundle_generation_id"),
+    operation_key_bundle_format: text("operation_key_bundle_format"),
+    operation_key_bundle_ref: text("operation_key_bundle_ref"),
+    operation_key_bundle_ciphertext_base64: text("operation_key_bundle_ciphertext_base64"),
+    operation_key_bundle_sha256: text("operation_key_bundle_sha256"),
+    operation_key_bundle_size_bytes: integer("operation_key_bundle_size_bytes"),
+    /** Exact canonical KMS AAD required to unwrap the v3 bundle after restore. */
+    operation_key_bundle_context: text("operation_key_bundle_context"),
+    operation_key_bundle_context_derivation: text("operation_key_bundle_context_derivation"),
+    operation_key_bundle_local_receipt_derivation: text(
+      "operation_key_bundle_local_receipt_derivation",
+    ),
+    operation_key_bundle_local_receipt_digest: text("operation_key_bundle_local_receipt_digest"),
+    /** Authenticated scalar pointer to a vault authority introduced in the restore slice. */
+    vault_key_generation_id: uuid("vault_key_generation_id"),
+    vault_key_authority_receipt_digest: text("vault_key_authority_receipt_digest"),
     catalog_attempts: integer("catalog_attempts").notNull().default(0),
     catalog_lease_owner: text("catalog_lease_owner"),
     catalog_lease_generation: uuid("catalog_lease_generation"),
@@ -912,43 +1060,75 @@ export const agentSandboxBackups = pgTable(
         'pre-move', 'billing-freeze', 'legal-hold', 'user-erasure'
       ))) IS TRUE`,
     ),
+    catalog_v2_source_check: check(
+      "agent_sandbox_backups_catalog_v2_source_check",
+      sql`(${table.catalog_version} IS DISTINCT FROM 2 OR (
+        ${table.source_provider} IN ('operator-onboarded', 'hetzner-cloud')
+        AND ${table.source_node_record_id} IS NOT NULL
+        AND ${table.source_node_id} IS NOT NULL AND btrim(${table.source_node_id}) <> ''
+        AND ${table.source_provider_handle} IS NOT NULL
+        AND btrim(${table.source_provider_handle}) <> ''
+        AND ${table.source_container_id} ~ '^[0-9a-f]{64}$'
+        AND ${table.source_provider_handle} <> ${table.source_container_id}
+        AND ${table.retention_reason} IS NOT NULL
+        AND ${table.retention_until} IS NOT NULL
+      )) IS TRUE`,
+    ),
+    catalog_v2_source_authority_check: check(
+      "agent_sandbox_backups_catalog_v2_source_authority_check",
+      sql`(${table.catalog_version} IS DISTINCT FROM 2 OR (
+        ${table.source_node_incarnation} IS NOT NULL
+        AND (
+          (${table.source_provider} = 'operator-onboarded'
+            AND ${table.source_provider_server_id} IS NULL)
+          OR (${table.source_provider} = 'hetzner-cloud'
+            AND ${table.source_provider_server_id} IS NOT NULL
+            AND CASE
+              WHEN ${table.source_provider_server_id} ~ '^[1-9][0-9]{0,19}$'
+                THEN ${table.source_provider_server_id}::numeric <= 18446744073709551615
+              ELSE false
+            END)
+        )
+      )) IS TRUE`,
+    ),
     catalog_manifest_shape_check: check(
       "agent_sandbox_backups_catalog_manifest_shape_check",
       sql`(${table.catalog_version} IS DISTINCT FROM 2 OR (
-        (
-          ${table.catalog_state} IN ('scheduled', 'capturing')
-          OR (${table.catalog_state} IN ('failed_retryable', 'failed_terminal')
-            AND ${table.catalog_resume_state} IN ('scheduled', 'capturing'))
-        )
-        AND ${table.manifest_digest} IS NULL
-        AND ${table.manifest_canonical_draft} IS NULL
-        AND ${table.wrapped_dek_ref} IS NULL
-        AND ${table.wrapped_dek_ciphertext_base64} IS NULL
-        AND ${table.wrapped_dek_sha256} IS NULL
-        AND ${table.wrapped_dek_size_bytes} IS NULL
-        AND ${table.wrapped_dek_receipt_digest} IS NULL
+        ((${table.catalog_state} IN ('scheduled', 'capturing')
+            OR (${table.catalog_state} IN ('failed_retryable', 'failed_terminal')
+              AND ${table.catalog_resume_state} IN ('scheduled', 'capturing')))
+          AND num_nonnulls(
+            ${table.manifest_format}, ${table.manifest_version}, ${table.manifest_digest},
+            ${table.manifest_canonical_draft}, ${table.manifest_object_count},
+            ${table.object_inventory_digest}, ${table.image_digest},
+            ${table.database_schema_version}, ${table.plugin_set_digest},
+            ${table.watermark_digest}, ${table.raw_size_bytes},
+            ${table.compressed_size_bytes}, ${table.encrypted_size_bytes},
+            ${table.kms_key_id}, ${table.kms_key_version}, ${table.wrapped_dek_ref},
+            ${table.wrapped_dek_ciphertext_base64}, ${table.wrapped_dek_sha256},
+            ${table.wrapped_dek_size_bytes}, ${table.wrapped_dek_receipt_digest},
+            ${table.operation_key_bundle_generation_id}, ${table.operation_key_bundle_format},
+            ${table.operation_key_bundle_ref}, ${table.operation_key_bundle_ciphertext_base64},
+            ${table.operation_key_bundle_sha256}, ${table.operation_key_bundle_size_bytes},
+            ${table.operation_key_bundle_context}, ${table.operation_key_bundle_context_derivation},
+            ${table.operation_key_bundle_local_receipt_derivation},
+            ${table.operation_key_bundle_local_receipt_digest}, ${table.vault_key_generation_id},
+            ${table.vault_key_authority_receipt_digest}
+          ) = 0)
       ) OR (
-        (
-          ${table.catalog_state} IN (
+        (${table.catalog_state} IN (
             'captured', 'uploading', 'primary_uploaded', 'primary_verified',
             'secondary_pending', 'protected', 'retained', 'expiration_pending',
             'deleting', 'deleted', 'restore_verified'
           )
-          OR (${table.catalog_state} = 'failed_retryable'
+          OR (${table.catalog_state} IN ('failed_retryable', 'failed_terminal')
             AND ${table.catalog_resume_state} IN (
               'captured', 'uploading', 'primary_uploaded', 'primary_verified',
               'secondary_pending', 'protected', 'retained', 'expiration_pending',
               'deleting', 'restore_verified'
-            ))
-          OR (${table.catalog_state} = 'failed_terminal'
-            AND ${table.catalog_resume_state} IN (
-              'captured', 'uploading', 'primary_uploaded', 'primary_verified',
-              'secondary_pending', 'protected', 'retained', 'expiration_pending',
-              'deleting', 'restore_verified'
-            ))
-        )
+            )))
         AND ${table.manifest_format} = 'elizaos.agent-backup'
-        AND ${table.manifest_version} = 2
+        AND ${table.manifest_version} IN (2, 3)
         AND ${table.manifest_digest} ~ '^[0-9a-f]{64}$'
         AND ${table.manifest_canonical_draft} IS NOT NULL
         AND octet_length(${table.manifest_canonical_draft}) BETWEEN 1 AND 4194304
@@ -963,11 +1143,48 @@ export const agentSandboxBackups = pgTable(
         AND ${table.encrypted_size_bytes} IS NOT NULL
         AND ${table.kms_key_id} IS NOT NULL AND ${table.kms_key_id} <> ''
         AND ${table.kms_key_version} BETWEEN 1 AND 9007199254740991
-        AND ${table.wrapped_dek_ref} IS NOT NULL AND ${table.wrapped_dek_ref} <> ''
-        AND octet_length(${table.wrapped_dek_ciphertext_base64}) BETWEEN 4 AND 21848
-        AND ${table.wrapped_dek_sha256} ~ '^[0-9a-f]{64}$'
-        AND ${table.wrapped_dek_size_bytes} BETWEEN 1 AND 16384
-        AND ${table.wrapped_dek_receipt_digest} ~ '^[0-9a-f]{64}$'
+        AND ((${table.manifest_version} = 2
+          AND num_nulls(${table.wrapped_dek_ref}, ${table.wrapped_dek_ciphertext_base64},
+            ${table.wrapped_dek_sha256}, ${table.wrapped_dek_size_bytes},
+            ${table.wrapped_dek_receipt_digest}) = 0
+          AND ${table.wrapped_dek_ref} <> ''
+          AND octet_length(${table.wrapped_dek_ciphertext_base64}) BETWEEN 4 AND 21848
+          AND ${table.wrapped_dek_sha256} ~ '^[0-9a-f]{64}$'
+          AND ${table.wrapped_dek_size_bytes} BETWEEN 1 AND 16384
+          AND ${table.wrapped_dek_receipt_digest} ~ '^[0-9a-f]{64}$'
+          AND num_nonnulls(${table.operation_key_bundle_generation_id},
+            ${table.operation_key_bundle_format}, ${table.operation_key_bundle_ref},
+            ${table.operation_key_bundle_ciphertext_base64},
+            ${table.operation_key_bundle_sha256}, ${table.operation_key_bundle_size_bytes},
+            ${table.operation_key_bundle_context}, ${table.operation_key_bundle_context_derivation},
+            ${table.operation_key_bundle_local_receipt_derivation},
+            ${table.operation_key_bundle_local_receipt_digest}, ${table.vault_key_generation_id},
+            ${table.vault_key_authority_receipt_digest}) = 0)
+        OR (${table.manifest_version} = 3
+          AND num_nonnulls(${table.wrapped_dek_ref}, ${table.wrapped_dek_ciphertext_base64},
+            ${table.wrapped_dek_sha256}, ${table.wrapped_dek_size_bytes},
+            ${table.wrapped_dek_receipt_digest}) = 0
+          AND num_nulls(${table.operation_key_bundle_generation_id},
+            ${table.operation_key_bundle_format}, ${table.operation_key_bundle_ref},
+            ${table.operation_key_bundle_ciphertext_base64},
+            ${table.operation_key_bundle_sha256}, ${table.operation_key_bundle_size_bytes},
+            ${table.operation_key_bundle_context}, ${table.operation_key_bundle_context_derivation},
+            ${table.operation_key_bundle_local_receipt_derivation},
+            ${table.operation_key_bundle_local_receipt_digest}, ${table.vault_key_generation_id},
+            ${table.vault_key_authority_receipt_digest}) = 0
+          AND ${table.operation_key_bundle_format} = 'kms-aead-operation-key-bundle-v1'
+          AND ${table.operation_key_bundle_ref} =
+            'backup-key-bundle:' || ${table.backup_operation_id}::text
+          AND ${table.operation_key_bundle_ciphertext_base64} ~ '^[A-Za-z0-9+/]{123}=$'
+          AND ${table.operation_key_bundle_sha256} ~ '^[0-9a-f]{64}$'
+          AND ${table.operation_key_bundle_size_bytes} = 92
+          AND octet_length(${table.operation_key_bundle_context}) BETWEEN 1 AND 65536
+          AND ${table.operation_key_bundle_context_derivation} =
+            'elizaos.agent-backup.operation-key-bundle-context.v1'
+          AND ${table.operation_key_bundle_local_receipt_derivation} =
+            'elizaos.kms-aead-operation-key-bundle.local-receipt.v1'
+          AND ${table.operation_key_bundle_local_receipt_digest} ~ '^[0-9a-f]{64}$'
+          AND ${table.vault_key_authority_receipt_digest} ~ '^[0-9a-f]{64}$'))
       )) IS TRUE`,
     ),
     catalog_lease_shape_check: check(

--- a/packages/cloud/shared/src/db/schemas/docker-nodes.ts
+++ b/packages/cloud/shared/src/db/schemas/docker-nodes.ts
@@ -1,17 +1,21 @@
 // Defines the docker nodes Drizzle table shape used by cloud repositories and services.
-import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { type InferInsertModel, type InferSelectModel, sql } from "drizzle-orm";
 import {
   boolean,
+  check,
   index,
   integer,
   jsonb,
   pgTable,
   text,
   timestamp,
+  uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
 
 export type DockerNodeStatus = "healthy" | "degraded" | "offline" | "unknown";
+export type DockerNodeFleetKind = "robot" | "cloud";
+export type DockerNodeInfrastructureProvider = "hetzner";
 
 /**
  * Whether a node may receive NEW placements, independent of whether it is
@@ -47,6 +51,17 @@ export const dockerNodes = pgTable(
     last_health_check: timestamp("last_health_check", { withTimezone: true }),
     ssh_user: text("ssh_user").notNull().default("root"),
     host_key_fingerprint: text("host_key_fingerprint"),
+    /**
+     * Typed backup-source identity. All four fields remain nullable for
+     * pre-authority rows; callers must never infer them from metadata,
+     * hostname, or the mutable node handle.
+     */
+    fleet_kind: text("fleet_kind").$type<DockerNodeFleetKind>(),
+    infrastructure_provider:
+      text("infrastructure_provider").$type<DockerNodeInfrastructureProvider>(),
+    provider_server_id: text("provider_server_id"),
+    /** Exact lowercase Linux boot UUID attested over host-key-verified SSH. */
+    node_incarnation: uuid("node_incarnation"),
     metadata: jsonb("metadata").$type<Record<string, unknown>>().notNull().default({}),
     created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
@@ -55,6 +70,39 @@ export const dockerNodes = pgTable(
     node_id_idx: index("docker_nodes_node_id_idx").on(table.node_id),
     status_idx: index("docker_nodes_status_idx").on(table.status),
     enabled_idx: index("docker_nodes_enabled_idx").on(table.enabled),
+    provider_server_uidx: uniqueIndex("docker_nodes_provider_server_uidx")
+      .on(table.infrastructure_provider, table.provider_server_id)
+      .where(sql`${table.provider_server_id} IS NOT NULL`),
+    node_incarnation_uidx: uniqueIndex("docker_nodes_node_incarnation_uidx")
+      .on(table.node_incarnation)
+      .where(sql`${table.node_incarnation} IS NOT NULL`),
+    backup_source_authority_shape_check: check(
+      "docker_nodes_backup_source_authority_shape_check",
+      sql`((
+        ${table.fleet_kind} IS NULL
+        AND ${table.infrastructure_provider} IS NULL
+        AND ${table.provider_server_id} IS NULL
+        AND ${table.node_incarnation} IS NULL
+      ) OR (
+        ${table.infrastructure_provider} = 'hetzner'
+        AND (${table.node_incarnation} IS NULL OR (
+          ${table.host_key_fingerprint} IS NOT NULL
+          AND btrim(${table.host_key_fingerprint}) <> ''
+        ))
+        AND (
+          (${table.fleet_kind} = 'robot' AND ${table.provider_server_id} IS NULL)
+          OR (
+            ${table.fleet_kind} = 'cloud'
+            AND ${table.provider_server_id} IS NOT NULL
+            AND CASE
+              WHEN ${table.provider_server_id} ~ '^[1-9][0-9]{0,19}$'
+                THEN ${table.provider_server_id}::numeric <= 18446744073709551615
+              ELSE false
+            END
+          )
+        )
+      )) IS TRUE`,
+    ),
   }),
 );
 

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-catalog-executor.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-catalog-executor.test.ts
@@ -1,0 +1,747 @@
+/**
+ * @file Tests the owned catalogue capture boundary against the manifest-v3
+ * operation key-bundle pipeline.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { KmsAeadOperationKeyBundleProvider, LocalKmsAdapter } from "@elizaos/core/security/kms";
+import {
+  AGENT_BACKUP_CAPTURE_V2_CONTENT_TYPE,
+  AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+  AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+  type AgentBackupCaptureV2FrameHeader,
+  type AgentBackupCaptureV2Request,
+  readAgentBackupCaptureV2FrameDigest,
+  serializeAgentBackupCaptureV2Frame,
+} from "@elizaos/shared";
+import type { AgentBackupOperationClaim } from "../../db/repositories/agent-backup-catalog";
+import {
+  type AgentBackupCaptureV2CatalogExecutionContext,
+  type AgentBackupCaptureV2RuntimeAttestation,
+  executeAgentBackupCaptureV2CatalogClaim,
+} from "./agent-backup-capture-v2-catalog-executor";
+import { isTrustedAgentBackupCaptureV2TerminalDisposition } from "./agent-backup-capture-v2-failure-disposition";
+import type { AgentBackupCaptureV3KeyBundleProvider } from "./agent-backup-capture-v2-pipeline";
+
+const ORGANIZATION_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const BACKUP_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const OPERATION_ID = "11111111-1111-4111-8111-111111111111";
+const AGENT_ID = "22222222-2222-4222-8222-222222222222";
+const ACTIVATION_GENERATION = "33333333-3333-4333-8333-333333333333";
+const CLAIM_GENERATION = "44444444-4444-4444-8444-444444444444";
+const NODE_RECORD_ID = "55555555-5555-4555-8555-555555555555";
+const NODE_INCARNATION = "66666666-6666-4666-8666-666666666666";
+const CONTAINER_ID = "c".repeat(64);
+const VAULT_KEY_GENERATION_ID = "77777777-7777-4777-8777-777777777777";
+
+const vaultKeyAuthority = {
+  format: "kms-aead-vault-passphrase-v1" as const,
+  generationId: VAULT_KEY_GENERATION_ID,
+  receiptDerivation: "elizaos.agent-vault-key.authority-receipt.v1" as const,
+  receiptDigest: "f".repeat(64),
+};
+
+function claim(): AgentBackupOperationClaim {
+  return {
+    ownerId: "capture-worker-1",
+    generation: CLAIM_GENERATION,
+    backup: {
+      id: BACKUP_ID,
+      catalog_state: "capturing",
+      catalog_organization_id: ORGANIZATION_ID,
+      catalog_agent_id: AGENT_ID,
+      backup_operation_id: OPERATION_ID,
+      lifecycle_generation: ACTIVATION_GENERATION,
+      lifecycle_revision: 7n,
+      source_provider: "hetzner-cloud",
+      source_node_record_id: NODE_RECORD_ID,
+      source_node_id: "cloud-node-9",
+      source_node_incarnation: NODE_INCARNATION,
+      source_provider_server_id: "1234",
+      source_provider_handle: "agent-runtime-name",
+      source_container_id: CONTAINER_ID,
+      catalog_attempts: 0,
+      created_at: new Date("2026-08-15T10:00:00.000Z"),
+    },
+  } as AgentBackupOperationClaim;
+}
+
+function attestation(): AgentBackupCaptureV2RuntimeAttestation {
+  return {
+    organizationId: ORGANIZATION_ID,
+    agentId: AGENT_ID,
+    activationGeneration: ACTIVATION_GENERATION,
+    lifecycleRevision: "7",
+    source: {
+      kind: "cloud",
+      provider: "hetzner",
+      nodeRecordId: NODE_RECORD_ID,
+      nodeId: "cloud-node-9",
+      nodeIncarnation: NODE_INCARNATION,
+      containerId: CONTAINER_ID,
+      providerServerId: "1234",
+    },
+    runtime: {
+      imageDigest: `sha256:${"a".repeat(64)}`,
+      agentSchemaVersion: "agent-v2",
+      databaseSchemaVersion: "pglite-v1",
+      plugins: [{ id: "@elizaos/plugin-sql", version: "2.0.0" }],
+    },
+    watermarks: [{ namespace: "database.lsn", value: "snapshot-7" }],
+  };
+}
+
+async function wireFrames(request: AgentBackupCaptureV2Request): Promise<Uint8Array[]> {
+  const components = ["character", "database", "media", "state-files", "vault"] as const;
+  const frames: Uint8Array[] = [];
+  const digests: Uint8Array[] = [];
+  const push = async (header: AgentBackupCaptureV2FrameHeader, payload?: Uint8Array) => {
+    const wire = await serializeAgentBackupCaptureV2Frame({ header, payload });
+    frames.push(wire);
+    digests.push(readAgentBackupCaptureV2FrameDigest(wire));
+  };
+  await push({
+    format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+    schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+    sequence: 0,
+    kind: "capture-start",
+    operationId: request.operationId,
+    agentId: request.agentId,
+    activationGeneration: request.activationGeneration,
+    lifecycleRevision: request.lifecycleRevision,
+    createdAt: "2026-08-15T10:00:01.000Z",
+    componentCount: components.length,
+    maxFramePayloadBytes: 256 * 1024,
+  });
+  let sequence = 1;
+  let plainBytes = 0;
+  for (const [componentIndex, name] of components.entries()) {
+    await push({
+      format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+      schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+      sequence: sequence++,
+      kind: "component-start",
+      componentIndex,
+      component: {
+        name,
+        format: "opaque-v1",
+        compression: "none",
+        contentKind: "opaque",
+        consistency: "transactional",
+      },
+    });
+    const payload = new TextEncoder().encode(`durable ${name} state`);
+    await push(
+      {
+        format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+        schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+        sequence: sequence++,
+        kind: "data",
+        componentIndex,
+        componentName: name,
+        dataIndex: 0,
+        offsetBytes: 0,
+        payloadBytes: payload.byteLength,
+      },
+      payload,
+    );
+    await push({
+      format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+      schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+      sequence: sequence++,
+      kind: "component-end",
+      componentIndex,
+      componentName: name,
+      dataFrameCount: 1,
+      plainBytes: payload.byteLength,
+      payloadSha256: createHash("sha256").update(payload).digest("hex"),
+    });
+    plainBytes += payload.byteLength;
+  }
+  const chain = createHash("sha256");
+  for (const digest of digests) chain.update(digest);
+  await push({
+    format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+    schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+    sequence,
+    kind: "capture-end",
+    componentCount: components.length,
+    dataFrameCount: components.length,
+    plainBytes,
+    frameDigestChainSha256: chain.digest("hex"),
+  });
+  return frames;
+}
+
+function responseFor(request: AgentBackupCaptureV2Request, frames: Uint8Array[]): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      pull(controller) {
+        const next = frames.shift();
+        if (next) controller.enqueue(next);
+        else controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": AGENT_BACKUP_CAPTURE_V2_CONTENT_TYPE,
+        "X-Eliza-Backup-Operation-Id": request.operationId,
+      },
+    },
+  );
+}
+
+function keyBundle(): AgentBackupCaptureV3KeyBundleProvider {
+  return new KmsAeadOperationKeyBundleProvider(
+    new LocalKmsAdapter({ rootKey: new Uint8Array(32).fill(0xa5) }),
+  );
+}
+
+async function stateDirectory(): Promise<string> {
+  return fs.promises.realpath(
+    await fs.promises.mkdtemp(path.join(os.homedir(), ".eliza-catalog-capture-test-")),
+  );
+}
+
+async function removeStateDirectory(directory: string): Promise<void> {
+  await fs.promises.rm(directory, { recursive: true, force: true });
+}
+
+function inertContext(
+  directory: string,
+  overrides: Partial<AgentBackupCaptureV2CatalogExecutionContext> = {},
+): AgentBackupCaptureV2CatalogExecutionContext {
+  const initialAttestation = attestation();
+  return {
+    attestation: initialAttestation,
+    async revalidateAttestation() {
+      return structuredClone(initialAttestation);
+    },
+    transport: {
+      agentApiBaseUrl: "https://exact-agent.invalid",
+      apiToken: "exact-agent-token",
+      fetch: (async () => {
+        throw new Error("HTTP capture must not start");
+      }) as typeof fetch,
+    },
+    spool: {
+      stateDirectory: directory,
+      maxSpoolBytes: 8 * 1024 * 1024,
+      minFreeBytes: 0,
+      lockAuthority: {
+        async currentProcessIdentity() {
+          return {
+            linuxBootId: "77777777-7777-4777-8777-777777777777",
+            pid: 4242,
+            processStartTime: "100",
+          };
+        },
+        async isProcessIdentityAlive() {
+          return true;
+        },
+      },
+    },
+    keyBundle: keyBundle(),
+    kms: {
+      provider: "steward",
+      keyId: `org:${ORGANIZATION_ID}/dek/v1`,
+      keyVersion: 1,
+    },
+    vaultKeyAuthority,
+    ...overrides,
+  };
+}
+
+describe("executeAgentBackupCaptureV2CatalogClaim", () => {
+  it("uses the authenticated HTTP client, heartbeats, spools, and records captured only", async () => {
+    const directory = await stateDirectory();
+    const heartbeats: unknown[] = [];
+    const records: unknown[] = [];
+    let revalidations = 0;
+    let fetches = 0;
+    const initialAttestation = attestation();
+    try {
+      const result = await executeAgentBackupCaptureV2CatalogClaim({
+        claim: claim(),
+        leaseMs: 240_000,
+        dependencies: {
+          now: () => 1_000_000,
+          heartbeatOperation: async (input) => {
+            heartbeats.push(input);
+            return claim().backup;
+          },
+          loadManifestChainAuthority: async () => ({
+            kind: "full",
+            baseOperationId: null,
+            parentOperationId: null,
+            depth: 0,
+          }),
+          recordCaptured: async (input) => {
+            records.push(input);
+            return claim().backup;
+          },
+          async resolveContext(input) {
+            expect(input.expectedSource).toEqual(initialAttestation.source);
+            const fetchStub = (async (_url: string | URL | Request, init?: RequestInit) => {
+              fetches += 1;
+              const headers = new Headers(init?.headers);
+              expect(headers.get("authorization")).toBe("Bearer exact-agent-token");
+              const request = JSON.parse(String(init?.body)) as AgentBackupCaptureV2Request;
+              return responseFor(request, await wireFrames(request));
+            }) as typeof fetch;
+            return {
+              attestation: initialAttestation,
+              async revalidateAttestation() {
+                revalidations += 1;
+                return structuredClone(initialAttestation);
+              },
+              transport: {
+                agentApiBaseUrl: "https://exact-agent.invalid",
+                apiToken: "exact-agent-token",
+                fetch: fetchStub,
+              },
+              spool: {
+                stateDirectory: directory,
+                maxSpoolBytes: 8 * 1024 * 1024,
+                minFreeBytes: 0,
+                lockAuthority: {
+                  async currentProcessIdentity() {
+                    return {
+                      linuxBootId: "77777777-7777-4777-8777-777777777777",
+                      pid: 4242,
+                      processStartTime: "100",
+                    };
+                  },
+                  async isProcessIdentityAlive() {
+                    return true;
+                  },
+                },
+              },
+              keyBundle: keyBundle(),
+              kms: {
+                provider: "steward",
+                keyId: `org:${ORGANIZATION_ID}/dek/v1`,
+                keyVersion: 1,
+              },
+              vaultKeyAuthority,
+            } satisfies AgentBackupCaptureV2CatalogExecutionContext;
+          },
+        },
+      });
+
+      expect(result).toMatchObject({
+        state: "captured-upload-pending",
+        cleanup: "blocked-on-upload",
+      });
+      expect(result.spool.phase).toBe("sealed");
+      expect(result.spool.chunks.every((chunk) => !result.spool.isChunkUploaded(chunk))).toBe(true);
+      expect(fetches).toBe(1);
+      expect(heartbeats.length).toBeGreaterThan(3);
+      expect(revalidations).toBe(heartbeats.length - 1);
+      expect(records).toHaveLength(1);
+      expect(records[0]).toMatchObject({
+        organizationId: ORGANIZATION_ID,
+        backupId: BACKUP_ID,
+        operationId: OPERATION_ID,
+        expectedActivationGeneration: ACTIVATION_GENERATION,
+        expectedLifecycleRevision: "7",
+        manifest: {
+          version: 3,
+          wrappedKeyBundleGenerationId: expect.any(String),
+          wrappedKeyBundleCiphertextBase64: expect.any(String),
+          wrappedKeyBundleSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+          wrappedKeyBundleLocalReceiptDigest: expect.stringMatching(/^[0-9a-f]{64}$/),
+        },
+      });
+      await result.spool.close();
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  }, 30_000);
+
+  it("fails before HTTP capture when independent source revalidation changes", async () => {
+    const directory = await stateDirectory();
+    let fetches = 0;
+    let records = 0;
+    const initialAttestation = attestation();
+    try {
+      await expect(
+        executeAgentBackupCaptureV2CatalogClaim({
+          claim: claim(),
+          leaseMs: 240_000,
+          dependencies: {
+            now: () => 1_000_000,
+            heartbeatOperation: async () => claim().backup,
+            loadManifestChainAuthority: async () => ({
+              kind: "full",
+              baseOperationId: null,
+              parentOperationId: null,
+              depth: 0,
+            }),
+            recordCaptured: async () => {
+              records += 1;
+              return claim().backup;
+            },
+            async resolveContext() {
+              return {
+                attestation: initialAttestation,
+                async revalidateAttestation() {
+                  return {
+                    ...initialAttestation,
+                    runtime: {
+                      ...initialAttestation.runtime,
+                      imageDigest: `sha256:${"b".repeat(64)}`,
+                    },
+                  };
+                },
+                transport: {
+                  agentApiBaseUrl: "https://exact-agent.invalid",
+                  apiToken: "exact-agent-token",
+                  fetch: (async () => {
+                    fetches += 1;
+                    throw new Error("unreachable");
+                  }) as typeof fetch,
+                },
+                spool: {
+                  stateDirectory: directory,
+                  maxSpoolBytes: 8 * 1024 * 1024,
+                  minFreeBytes: 0,
+                },
+                keyBundle: keyBundle(),
+                kms: {
+                  provider: "steward",
+                  keyId: `org:${ORGANIZATION_ID}/dek/v1`,
+                  keyVersion: 1,
+                },
+                vaultKeyAuthority,
+              } satisfies AgentBackupCaptureV2CatalogExecutionContext;
+            },
+          },
+        }),
+      ).rejects.toMatchObject({ code: "AGENT_BACKUP_V2_RUNTIME_ATTESTATION_CHANGED" });
+      expect(fetches).toBe(0);
+      expect(records).toBe(0);
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("attaches exact spool authority to a validated terminal Agent response", async () => {
+    const directory = await stateDirectory();
+    let records = 0;
+    try {
+      const context = inertContext(directory, {
+        transport: {
+          agentApiBaseUrl: "https://exact-agent.invalid",
+          apiToken: "exact-agent-token",
+          fetch: (async () =>
+            new Response(
+              JSON.stringify({
+                error: "PGlite physical bytes exceed the bounded exporter limit",
+                code: "AGENT_BACKUP_V2_PGLITE_PHYSICAL_BYTES_LIMIT",
+              }),
+              {
+                status: 413,
+                headers: { "Content-Type": "application/json" },
+              },
+            )) as typeof fetch,
+        },
+      });
+      await expect(
+        executeAgentBackupCaptureV2CatalogClaim({
+          claim: claim(),
+          leaseMs: 240_000,
+          dependencies: {
+            heartbeatOperation: async () => claim().backup,
+            loadManifestChainAuthority: async () => ({
+              kind: "full",
+              baseOperationId: null,
+              parentOperationId: null,
+              depth: 0,
+            }),
+            recordCaptured: async () => {
+              records += 1;
+              return claim().backup;
+            },
+            resolveContext: async () => context,
+          },
+        }),
+      ).rejects.toMatchObject({
+        code: "AGENT_BACKUP_V2_PGLITE_PHYSICAL_BYTES_LIMIT",
+        terminal: true,
+        terminalSpoolCleanup: {
+          organizationId: ORGANIZATION_ID,
+          agentId: AGENT_ID,
+          backupId: BACKUP_ID,
+          operationId: OPERATION_ID,
+          activationGeneration: ACTIVATION_GENERATION,
+          lifecycleRevision: "7",
+          requestSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+          authoritySha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+        },
+      });
+      expect(records).toBe(0);
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("preserves exact terminal authority through an AggregateError cleanup failure", async () => {
+    const directory = await stateDirectory();
+    const baseKeyBundle = keyBundle();
+    const releaseFailure = new Error("KMS release acknowledgement was lost");
+    const failingReleaseKeyBundle: AgentBackupCaptureV3KeyBundleProvider = {
+      acquire: (input) => baseKeyBundle.acquire(input),
+      unwrap: (input) => baseKeyBundle.unwrap(input),
+      release(handle): never {
+        baseKeyBundle.release(handle);
+        throw releaseFailure;
+      },
+    };
+    let failure: unknown;
+    try {
+      const context = inertContext(directory, {
+        keyBundle: failingReleaseKeyBundle,
+        transport: {
+          agentApiBaseUrl: "https://exact-agent.invalid",
+          apiToken: "exact-agent-token",
+          fetch: (async () =>
+            new Response(
+              JSON.stringify({
+                error: "PGlite physical bytes exceed the bounded exporter limit",
+                code: "AGENT_BACKUP_V2_PGLITE_PHYSICAL_BYTES_LIMIT",
+              }),
+              {
+                status: 413,
+                headers: { "Content-Type": "application/json" },
+              },
+            )) as typeof fetch,
+        },
+      });
+      try {
+        await executeAgentBackupCaptureV2CatalogClaim({
+          claim: claim(),
+          leaseMs: 240_000,
+          dependencies: {
+            heartbeatOperation: async () => claim().backup,
+            loadManifestChainAuthority: async () => ({
+              kind: "full",
+              baseOperationId: null,
+              parentOperationId: null,
+              depth: 0,
+            }),
+            recordCaptured: async () => claim().backup,
+            resolveContext: async () => context,
+          },
+        });
+      } catch (cause) {
+        failure = cause;
+      }
+
+      expect(isTrustedAgentBackupCaptureV2TerminalDisposition(failure)).toBe(true);
+      const aggregateCause = (failure as Error).cause;
+      expect(aggregateCause).toBeInstanceOf(AggregateError);
+      expect((aggregateCause as AggregateError).errors).toContain(releaseFailure);
+      expect(failure).toMatchObject({
+        code: "AGENT_BACKUP_V2_PGLITE_PHYSICAL_BYTES_LIMIT",
+        terminal: true,
+        terminalSpoolCleanup: {
+          organizationId: ORGANIZATION_ID,
+          agentId: AGENT_ID,
+          backupId: BACKUP_ID,
+          operationId: OPERATION_ID,
+          activationGeneration: ACTIVATION_GENERATION,
+          lifecycleRevision: "7",
+          requestSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+          authoritySha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+        },
+      });
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("applies the absolute deadline to a never-settling context resolver", async () => {
+    const directory = await stateDirectory();
+    let chainLoads = 0;
+    let records = 0;
+    let resolverSignal: AbortSignal | undefined;
+    try {
+      await expect(
+        executeAgentBackupCaptureV2CatalogClaim({
+          claim: claim(),
+          leaseMs: 240_000,
+          dependencies: {
+            captureDeadlineMs: 20,
+            heartbeatOperation: async () => claim().backup,
+            loadManifestChainAuthority: async () => {
+              chainLoads += 1;
+              throw new Error("Manifest chain must not load");
+            },
+            recordCaptured: async () => {
+              records += 1;
+              return claim().backup;
+            },
+            resolveContext(input) {
+              resolverSignal = input.signal;
+              return new Promise<AgentBackupCaptureV2CatalogExecutionContext>(() => undefined);
+            },
+          },
+        }),
+      ).rejects.toMatchObject({ code: "AGENT_BACKUP_V2_CAPTURE_DEADLINE_EXCEEDED" });
+      expect(resolverSignal?.aborted).toBe(true);
+      expect(chainLoads).toBe(0);
+      expect(records).toBe(0);
+      expect(await fs.promises.readdir(directory)).toEqual([]);
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("applies the absolute deadline to the first catalogue heartbeat", async () => {
+    let contextResolutions = 0;
+    await expect(
+      executeAgentBackupCaptureV2CatalogClaim({
+        claim: claim(),
+        leaseMs: 240_000,
+        dependencies: {
+          captureDeadlineMs: 20,
+          heartbeatOperation: () => new Promise(() => undefined),
+          recordCaptured: async () => claim().backup,
+          resolveContext: async () => {
+            contextResolutions += 1;
+            throw new Error("Context must not resolve");
+          },
+        },
+      }),
+    ).rejects.toMatchObject({ code: "AGENT_BACKUP_V2_CAPTURE_DEADLINE_EXCEEDED" });
+    expect(contextResolutions).toBe(0);
+  });
+
+  it("applies the absolute deadline to manifest chain authority loading", async () => {
+    const directory = await stateDirectory();
+    let fetches = 0;
+    let records = 0;
+    try {
+      const context = inertContext(directory, {
+        transport: {
+          agentApiBaseUrl: "https://exact-agent.invalid",
+          apiToken: "exact-agent-token",
+          fetch: (async () => {
+            fetches += 1;
+            throw new Error("HTTP capture must not start");
+          }) as typeof fetch,
+        },
+      });
+      await expect(
+        executeAgentBackupCaptureV2CatalogClaim({
+          claim: claim(),
+          leaseMs: 240_000,
+          dependencies: {
+            captureDeadlineMs: 20,
+            heartbeatOperation: async () => claim().backup,
+            loadManifestChainAuthority: () => new Promise(() => undefined),
+            recordCaptured: async () => {
+              records += 1;
+              return claim().backup;
+            },
+            resolveContext: async () => context,
+          },
+        }),
+      ).rejects.toMatchObject({ code: "AGENT_BACKUP_V2_CAPTURE_DEADLINE_EXCEEDED" });
+      expect(fetches).toBe(0);
+      expect(records).toBe(0);
+      expect(await fs.promises.readdir(directory)).toEqual([]);
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("propagates caller cancellation through the same pre-HTTP authority", async () => {
+    const directory = await stateDirectory();
+    const caller = new AbortController();
+    let resolverSignal: AbortSignal | undefined;
+    let markResolverStarted: (() => void) | undefined;
+    const resolverStarted = new Promise<void>((resolve) => {
+      markResolverStarted = resolve;
+    });
+    try {
+      const execution = executeAgentBackupCaptureV2CatalogClaim({
+        claim: claim(),
+        leaseMs: 240_000,
+        signal: caller.signal,
+        dependencies: {
+          heartbeatOperation: async () => claim().backup,
+          recordCaptured: async () => claim().backup,
+          resolveContext(input) {
+            resolverSignal = input.signal;
+            markResolverStarted?.();
+            return new Promise<AgentBackupCaptureV2CatalogExecutionContext>(() => undefined);
+          },
+        },
+      });
+      await resolverStarted;
+      caller.abort(new Error("operator stopped the capture"));
+      await expect(execution).rejects.toMatchObject({ code: "AGENT_BACKUP_V2_CAPTURE_ABORTED" });
+      expect(resolverSignal?.aborted).toBe(true);
+      expect(await fs.promises.readdir(directory)).toEqual([]);
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("stops before chain, HTTP, spool, and record when revalidation never settles", async () => {
+    const directory = await stateDirectory();
+    let chainLoads = 0;
+    let fetches = 0;
+    let records = 0;
+    let revalidationSignal: AbortSignal | undefined;
+    try {
+      const context = inertContext(directory, {
+        async revalidateAttestation(signal) {
+          revalidationSignal = signal;
+          return new Promise<AgentBackupCaptureV2RuntimeAttestation>(() => undefined);
+        },
+        transport: {
+          agentApiBaseUrl: "https://exact-agent.invalid",
+          apiToken: "exact-agent-token",
+          fetch: (async () => {
+            fetches += 1;
+            throw new Error("HTTP capture must not start");
+          }) as typeof fetch,
+        },
+      });
+      await expect(
+        executeAgentBackupCaptureV2CatalogClaim({
+          claim: claim(),
+          leaseMs: 240_000,
+          dependencies: {
+            captureDeadlineMs: 20,
+            heartbeatOperation: async () => claim().backup,
+            loadManifestChainAuthority: async () => {
+              chainLoads += 1;
+              throw new Error("Manifest chain must not load");
+            },
+            recordCaptured: async () => {
+              records += 1;
+              return claim().backup;
+            },
+            resolveContext: async () => context,
+          },
+        }),
+      ).rejects.toMatchObject({ code: "AGENT_BACKUP_V2_CAPTURE_DEADLINE_EXCEEDED" });
+      expect(revalidationSignal?.aborted).toBe(true);
+      expect(chainLoads).toBe(0);
+      expect(fetches).toBe(0);
+      expect(records).toBe(0);
+      expect(await fs.promises.readdir(directory)).toEqual([]);
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-catalog-executor.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-catalog-executor.test.ts
@@ -22,6 +22,8 @@ import type { AgentBackupOperationClaim } from "../../db/repositories/agent-back
 import {
   type AgentBackupCaptureV2CatalogExecutionContext,
   type AgentBackupCaptureV2RuntimeAttestation,
+  createAgentBackupCaptureV2CatalogExecutor,
+  type ExecuteAgentBackupCaptureV2CatalogClaimDependencies,
   executeAgentBackupCaptureV2CatalogClaim,
 } from "./agent-backup-capture-v2-catalog-executor";
 import { isTrustedAgentBackupCaptureV2TerminalDisposition } from "./agent-backup-capture-v2-failure-disposition";
@@ -44,6 +46,29 @@ const vaultKeyAuthority = {
   receiptDerivation: "elizaos.agent-vault-key.authority-receipt.v1" as const,
   receiptDigest: "f".repeat(64),
 };
+
+describe("capture-v3 legacy-writer rollout fence", () => {
+  const dependencies = {} as ExecuteAgentBackupCaptureV2CatalogClaimDependencies;
+
+  it("refuses activation without a canonical deployment drain receipt", () => {
+    expect(() =>
+      createAgentBackupCaptureV2CatalogExecutor(dependencies, {
+        format: "elizaos.agent-backup.capture-v3-legacy-writer-drain.v1",
+        deploymentId: "rollout-42",
+        drainedAt: "not-a-timestamp",
+      }),
+    ).toThrow("legacy-writer drain receipt");
+  });
+
+  it("binds the executor only after the deployment drain receipt is valid", () => {
+    const executor = createAgentBackupCaptureV2CatalogExecutor(dependencies, {
+      format: "elizaos.agent-backup.capture-v3-legacy-writer-drain.v1",
+      deploymentId: "rollout-42",
+      drainedAt: "2026-08-17T00:00:00.000Z",
+    });
+    expect(executor.execute).toBeTypeOf("function");
+  });
+});
 
 function claim(): AgentBackupOperationClaim {
   return {

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-catalog-executor.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-catalog-executor.ts
@@ -46,6 +46,8 @@ const DOCKER_ID_PATTERN = /^[0-9a-f]{64}$/;
 const NODE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
 const PROVIDER_SERVER_ID_PATTERN = /^[1-9][0-9]{0,19}$/;
 const UINT64_MAX = 18_446_744_073_709_551_615n;
+const LEGACY_WRITER_DRAIN_FORMAT =
+  "elizaos.agent-backup.capture-v3-legacy-writer-drain.v1" as const;
 
 export interface AgentBackupCaptureV2RuntimeAttestation {
   organizationId: string;
@@ -104,6 +106,29 @@ export interface ExecuteAgentBackupCaptureV2CatalogClaimDependencies {
   }): Promise<unknown>;
   now?: () => number;
   captureDeadlineMs?: number;
+}
+
+/** Deployment evidence that every pre-v3 spool writer has exited before activation. */
+export interface AgentBackupCaptureV3LegacyWriterDrainReceipt {
+  format: typeof LEGACY_WRITER_DRAIN_FORMAT;
+  deploymentId: string;
+  drainedAt: string;
+}
+
+function assertLegacyWriterDrainReceipt(
+  receipt: Readonly<AgentBackupCaptureV3LegacyWriterDrainReceipt>,
+): void {
+  if (
+    receipt.format !== LEGACY_WRITER_DRAIN_FORMAT ||
+    !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(receipt.deploymentId) ||
+    !Number.isFinite(Date.parse(receipt.drainedAt)) ||
+    new Date(receipt.drainedAt).toISOString() !== receipt.drainedAt
+  ) {
+    executorError(
+      "AGENT_BACKUP_V3_LEGACY_WRITERS_NOT_DRAINED",
+      "Capture-v3 activation requires a canonical legacy-writer drain receipt",
+    );
+  }
 }
 
 export interface ExecuteAgentBackupCaptureV2CatalogClaimInput {
@@ -539,7 +564,12 @@ export { AgentBackupCaptureV2CatalogExecutorError } from "./agent-backup-capture
 /** Bind deployment authorities once, then inject this executor into the catalogue runtime. */
 export function createAgentBackupCaptureV2CatalogExecutor(
   dependencies: ExecuteAgentBackupCaptureV2CatalogClaimDependencies,
+  legacyWriterDrain: Readonly<AgentBackupCaptureV3LegacyWriterDrainReceipt>,
 ): AgentBackupCatalogRuntimeCaptureExecutor {
+  // A filesystem lock can fence other v3 claimants, but code deployed before
+  // that lock existed cannot observe it. Requiring a deployment-produced drain
+  // receipt makes rolling activation fail closed until those processes exit.
+  assertLegacyWriterDrainReceipt(legacyWriterDrain);
   return {
     execute: ({ claim, leaseMs, signal }) =>
       executeAgentBackupCaptureV2CatalogClaim({

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-catalog-executor.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-catalog-executor.ts
@@ -1,0 +1,552 @@
+/**
+ * Production boundary between one owned catalogue capture lease and capture-v2.
+ *
+ * This module deliberately does not guess sandbox runtime metadata, routing, or
+ * cryptographic authority. A deployment must inject an independently
+ * revalidatable attestation plus one real KMS operation-key-bundle provider. Once those
+ * authorities are present, the remaining path is concrete: authenticated HTTP
+ * capture, bounded encrypted spool, lease heartbeats, and idempotent catalogue
+ * recordCaptured persistence. Upload and replication are not entered here.
+ */
+
+import { isDeepStrictEqual } from "node:util";
+import {
+  AGENT_BACKUP_CAPTURE_V2_LIMITS,
+  AGENT_BACKUP_CAPTURE_V2_REQUEST_FORMAT,
+  AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+  type AgentBackupCaptureV2Request,
+  type AgentBackupManifestV3,
+} from "@elizaos/shared";
+import {
+  type AgentBackupOperationClaim,
+  heartbeatAgentBackupOperation,
+  loadAgentBackupManifestChainAuthority,
+} from "../../db/repositories/agent-backup-catalog";
+import { openAgentBackupCaptureV2 } from "./agent-backup-capture-v2-client";
+import {
+  AgentBackupCaptureV2CatalogExecutorError,
+  createAgentBackupCaptureV2ExecutorError,
+  normalizeAgentBackupCaptureV2TerminalFailure,
+} from "./agent-backup-capture-v2-failure-disposition";
+import {
+  type AgentBackupCaptureV2PipelineResult,
+  type AgentBackupCaptureV3CatalogManifest,
+  type AgentBackupCaptureV3KeyBundleProvider,
+  type AgentBackupCaptureV3ManifestAuthority,
+  deriveAgentBackupCaptureV3SpoolAuthorityDigests,
+  runAgentBackupCaptureV2Pipeline,
+} from "./agent-backup-capture-v2-pipeline";
+import type { AgentBackupCaptureV3SpoolConfig } from "./agent-backup-capture-v2-spool";
+import type { AgentBackupCaptureV3TerminalSpoolCleanupAuthority } from "./agent-backup-capture-v3-spool-cleanup";
+import type { AgentBackupCatalogRuntimeCaptureExecutor } from "./agent-backup-catalog-runtime";
+
+const DEFAULT_CAPTURE_DEADLINE_MS = 14 * 60_000;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const DOCKER_ID_PATTERN = /^[0-9a-f]{64}$/;
+const NODE_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const PROVIDER_SERVER_ID_PATTERN = /^[1-9][0-9]{0,19}$/;
+const UINT64_MAX = 18_446_744_073_709_551_615n;
+
+export interface AgentBackupCaptureV2RuntimeAttestation {
+  organizationId: string;
+  agentId: string;
+  activationGeneration: string;
+  lifecycleRevision: string;
+  source: AgentBackupManifestV3["source"];
+  runtime: AgentBackupManifestV3["runtime"];
+  watermarks: AgentBackupManifestV3["watermarks"];
+}
+
+export interface AgentBackupCaptureV2CatalogExecutionContext {
+  /** Exact, independently sourced sandbox/runtime evidence for this generation. */
+  attestation: AgentBackupCaptureV2RuntimeAttestation;
+  /** Must re-read authority; replaying `attestation` without checking is invalid. */
+  revalidateAttestation(signal?: AbortSignal): Promise<AgentBackupCaptureV2RuntimeAttestation>;
+  /** Already-authorized and SSRF-checked route to the exact reserved container. */
+  transport: {
+    agentApiBaseUrl: string;
+    apiToken: string;
+    fetch?: typeof fetch;
+  };
+  spool: AgentBackupCaptureV3SpoolConfig;
+  keyBundle: AgentBackupCaptureV3KeyBundleProvider;
+  kms: AgentBackupCaptureV3ManifestAuthority["kms"];
+  /** Primary-database vault generation selected before any capture bytes flow. */
+  vaultKeyAuthority: AgentBackupManifestV3["vaultKeyAuthority"];
+}
+
+export interface ResolveAgentBackupCaptureV2CatalogExecutionContextInput {
+  claim: Readonly<AgentBackupOperationClaim>;
+  request: Readonly<AgentBackupCaptureV2Request>;
+  expectedSource: Readonly<AgentBackupManifestV3["source"]>;
+  /** Context resolution may heartbeat while contacting external authorities. */
+  heartbeat(): Promise<true>;
+  signal?: AbortSignal;
+}
+
+export type ResolveAgentBackupCaptureV2CatalogExecutionContext = (
+  input: ResolveAgentBackupCaptureV2CatalogExecutionContextInput,
+) => Promise<AgentBackupCaptureV2CatalogExecutionContext>;
+
+export interface ExecuteAgentBackupCaptureV2CatalogClaimDependencies {
+  resolveContext: ResolveAgentBackupCaptureV2CatalogExecutionContext;
+  heartbeatOperation?: typeof heartbeatAgentBackupOperation;
+  loadManifestChainAuthority?: typeof loadAgentBackupManifestChainAuthority;
+  /** Must be the manifest-v3 repository boundary; v2 repositories are incompatible. */
+  recordCaptured(params: {
+    organizationId: string;
+    backupId: string;
+    operationId: string;
+    expectedActivationGeneration: string;
+    expectedLifecycleRevision: string;
+    execution: { ownerId: string; generation: string };
+    manifest: AgentBackupCaptureV3CatalogManifest;
+  }): Promise<unknown>;
+  now?: () => number;
+  captureDeadlineMs?: number;
+}
+
+export interface ExecuteAgentBackupCaptureV2CatalogClaimInput {
+  claim: Readonly<AgentBackupOperationClaim>;
+  leaseMs: number;
+  dependencies: ExecuteAgentBackupCaptureV2CatalogClaimDependencies;
+  signal?: AbortSignal;
+}
+
+export type AgentBackupCaptureV2CatalogClaimResult = Extract<
+  AgentBackupCaptureV2PipelineResult,
+  { state: "captured-upload-pending" }
+>;
+
+function executorError(code: string, message: string, cause?: unknown): never {
+  throw createAgentBackupCaptureV2ExecutorError(code, message, cause);
+}
+
+function requireString(value: string | null, field: string): string {
+  if (!value) {
+    executorError(
+      "AGENT_BACKUP_V2_CLAIM_AUTHORITY_INCOMPLETE",
+      `Catalogue claim is missing ${field}`,
+    );
+  }
+  return value;
+}
+
+function expectedSourceFromClaim(
+  claim: Readonly<AgentBackupOperationClaim>,
+): AgentBackupManifestV3["source"] {
+  const backup = claim.backup;
+  const nodeRecordId = requireString(backup.source_node_record_id, "source_node_record_id");
+  const nodeId = requireString(backup.source_node_id, "source_node_id");
+  const nodeIncarnation = requireString(backup.source_node_incarnation, "source_node_incarnation");
+  const containerId = requireString(backup.source_container_id, "source_container_id");
+  const providerHandle = requireString(backup.source_provider_handle, "source_provider_handle");
+  if (
+    !UUID_PATTERN.test(nodeRecordId) ||
+    !UUID_PATTERN.test(nodeIncarnation) ||
+    !NODE_ID_PATTERN.test(nodeId)
+  ) {
+    executorError(
+      "AGENT_BACKUP_V2_CLAIM_AUTHORITY_INVALID",
+      "Catalogue claim has a non-canonical node authority",
+    );
+  }
+  if (!DOCKER_ID_PATTERN.test(containerId)) {
+    executorError(
+      "AGENT_BACKUP_V2_CLAIM_AUTHORITY_INVALID",
+      "Catalogue claim has a non-canonical immutable container ID",
+    );
+  }
+  if (providerHandle === containerId) {
+    executorError(
+      "AGENT_BACKUP_V2_CLAIM_AUTHORITY_INVALID",
+      "Mutable provider handle cannot replace the immutable container ID",
+    );
+  }
+  const base = {
+    provider: "hetzner" as const,
+    nodeRecordId,
+    nodeId,
+    nodeIncarnation,
+    containerId,
+  };
+  if (backup.source_provider === "operator-onboarded") {
+    if (backup.source_provider_server_id !== null) {
+      executorError(
+        "AGENT_BACKUP_V2_CLAIM_AUTHORITY_INVALID",
+        "Robot claim unexpectedly contains a Cloud server authority",
+      );
+    }
+    return { kind: "robot", ...base };
+  }
+  if (backup.source_provider === "hetzner-cloud") {
+    const providerServerId = requireString(
+      backup.source_provider_server_id,
+      "source_provider_server_id",
+    );
+    if (
+      !PROVIDER_SERVER_ID_PATTERN.test(providerServerId) ||
+      BigInt(providerServerId) > UINT64_MAX
+    ) {
+      executorError(
+        "AGENT_BACKUP_V2_CLAIM_AUTHORITY_INVALID",
+        "Cloud claim has a non-canonical provider server authority",
+      );
+    }
+    return {
+      kind: "cloud",
+      ...base,
+      providerServerId,
+    };
+  }
+  executorError(
+    "AGENT_BACKUP_V2_CLAIM_AUTHORITY_INVALID",
+    "Catalogue claim has an unsupported source provider",
+  );
+}
+
+function claimRequest(params: {
+  claim: Readonly<AgentBackupOperationClaim>;
+  deadlineEpochMs: number;
+}): AgentBackupCaptureV2Request {
+  const backup = params.claim.backup;
+  if (
+    backup.catalog_state !== "capturing" ||
+    !backup.catalog_organization_id ||
+    !backup.catalog_agent_id ||
+    !backup.backup_operation_id ||
+    !backup.lifecycle_generation ||
+    backup.lifecycle_revision === null
+  ) {
+    executorError(
+      "AGENT_BACKUP_V2_CLAIM_NOT_CAPTURING",
+      "Capture executor requires one complete owned capturing claim",
+    );
+  }
+  return {
+    format: AGENT_BACKUP_CAPTURE_V2_REQUEST_FORMAT,
+    schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+    operationId: backup.backup_operation_id,
+    agentId: backup.catalog_agent_id,
+    activationGeneration: backup.lifecycle_generation,
+    lifecycleRevision: backup.lifecycle_revision.toString(),
+    deadlineEpochMs: params.deadlineEpochMs,
+  };
+}
+
+function canonicalCreatedAt(claim: Readonly<AgentBackupOperationClaim>): string {
+  const createdAt = claim.backup.created_at;
+  if (!(createdAt instanceof Date) || !Number.isFinite(createdAt.getTime())) {
+    executorError(
+      "AGENT_BACKUP_V2_CLAIM_CREATED_AT_INVALID",
+      "Catalogue claim has no canonical durable reservation timestamp",
+    );
+  }
+  return createdAt.toISOString();
+}
+
+function assertAttestation(params: {
+  attestation: Readonly<AgentBackupCaptureV2RuntimeAttestation>;
+  request: Readonly<AgentBackupCaptureV2Request>;
+  organizationId: string;
+  expectedSource: Readonly<AgentBackupManifestV3["source"]>;
+  expected?: Readonly<AgentBackupCaptureV2RuntimeAttestation>;
+}): void {
+  const observed = params.attestation;
+  if (
+    observed.organizationId !== params.organizationId ||
+    observed.agentId !== params.request.agentId ||
+    observed.activationGeneration !== params.request.activationGeneration ||
+    observed.lifecycleRevision !== params.request.lifecycleRevision ||
+    !isDeepStrictEqual(observed.source, params.expectedSource)
+  ) {
+    executorError(
+      "AGENT_BACKUP_V2_RUNTIME_ATTESTATION_MISMATCH",
+      "Runtime attestation does not match the exact catalogue source generation",
+    );
+  }
+  if (params.expected && !isDeepStrictEqual(observed, params.expected)) {
+    executorError(
+      "AGENT_BACKUP_V2_RUNTIME_ATTESTATION_CHANGED",
+      "Runtime attestation changed while capture held the catalogue lease",
+    );
+  }
+}
+
+function readCaptureDeadlineMs(value: number | undefined): number {
+  const resolved = value ?? DEFAULT_CAPTURE_DEADLINE_MS;
+  if (
+    !Number.isSafeInteger(resolved) ||
+    resolved < 1 ||
+    resolved > AGENT_BACKUP_CAPTURE_V2_LIMITS.maxDeadlineAheadMs
+  ) {
+    executorError(
+      "AGENT_BACKUP_V2_CAPTURE_DEADLINE_INVALID",
+      `Capture deadline must be between 1 and ${AGENT_BACKUP_CAPTURE_V2_LIMITS.maxDeadlineAheadMs}`,
+    );
+  }
+  return resolved;
+}
+
+interface CaptureExecutionControl {
+  readonly signal: AbortSignal;
+  await<T>(label: string, operation: () => T | PromiseLike<T>): Promise<T>;
+  close(): void;
+}
+
+function captureControlError(signal: AbortSignal): AgentBackupCaptureV2CatalogExecutorError {
+  const reason = signal.reason;
+  if (reason instanceof AgentBackupCaptureV2CatalogExecutorError) return reason;
+  return createAgentBackupCaptureV2ExecutorError(
+    "AGENT_BACKUP_V2_CAPTURE_ABORTED",
+    "Catalogue capture execution was cancelled",
+    reason,
+  );
+}
+
+function createCaptureExecutionControl(params: {
+  deadlineEpochMs: number;
+  now: () => number;
+  callerSignal?: AbortSignal;
+}): CaptureExecutionControl {
+  const controller = new AbortController();
+  const abortFromCaller = () => {
+    if (!controller.signal.aborted) {
+      controller.abort(
+        createAgentBackupCaptureV2ExecutorError(
+          "AGENT_BACKUP_V2_CAPTURE_ABORTED",
+          "Catalogue capture execution was cancelled",
+          params.callerSignal?.reason,
+        ),
+      );
+    }
+  };
+  if (params.callerSignal?.aborted) abortFromCaller();
+  else params.callerSignal?.addEventListener("abort", abortFromCaller, { once: true });
+
+  const remainingMs = params.deadlineEpochMs - params.now();
+  const timer = setTimeout(
+    () => {
+      if (!controller.signal.aborted) {
+        controller.abort(
+          createAgentBackupCaptureV2ExecutorError(
+            "AGENT_BACKUP_V2_CAPTURE_DEADLINE_EXCEEDED",
+            "Catalogue capture execution exceeded its absolute deadline",
+          ),
+        );
+      }
+    },
+    Math.max(0, Math.min(remainingMs, 2_147_483_647)),
+  );
+
+  return {
+    signal: controller.signal,
+    async await<T>(label: string, operation: () => T | PromiseLike<T>): Promise<T> {
+      if (controller.signal.aborted) throw captureControlError(controller.signal);
+      const pending = Promise.resolve().then(operation);
+      let abortListener: (() => void) | undefined;
+      const interrupted = new Promise<never>((_resolve, reject) => {
+        abortListener = () => reject(captureControlError(controller.signal));
+        controller.signal.addEventListener("abort", abortListener, { once: true });
+      });
+      try {
+        return await Promise.race([pending, interrupted]);
+      } catch (cause) {
+        if (controller.signal.aborted) {
+          // Non-cancellable authorities may settle after the caller has left.
+          // Keep their rejection observed without allowing late success to
+          // advance HTTP, spool, or catalogue state.
+          void pending.catch((_lateFailure: unknown) => undefined);
+          throw captureControlError(controller.signal);
+        }
+        throw cause;
+      } finally {
+        if (abortListener) controller.signal.removeEventListener("abort", abortListener);
+      }
+    },
+    close() {
+      clearTimeout(timer);
+      params.callerSignal?.removeEventListener("abort", abortFromCaller);
+    },
+  };
+}
+
+/** Execute one already-normalized `capturing` claim, stopping before upload. */
+export async function executeAgentBackupCaptureV2CatalogClaim(
+  input: Readonly<ExecuteAgentBackupCaptureV2CatalogClaimInput>,
+): Promise<AgentBackupCaptureV2CatalogClaimResult> {
+  const now = input.dependencies.now ?? Date.now;
+  const nowMs = now();
+  if (!Number.isSafeInteger(nowMs) || nowMs < 1) {
+    executorError("AGENT_BACKUP_V2_CLOCK_INVALID", "Capture runtime clock is invalid");
+  }
+  const request = claimRequest({
+    claim: input.claim,
+    deadlineEpochMs: nowMs + readCaptureDeadlineMs(input.dependencies.captureDeadlineMs),
+  });
+  if (!Number.isSafeInteger(request.deadlineEpochMs)) {
+    executorError("AGENT_BACKUP_V2_CLOCK_INVALID", "Capture deadline exceeds safe integer range");
+  }
+  const organizationId = input.claim.backup.catalog_organization_id as string;
+  const expectedSource = expectedSourceFromClaim(input.claim);
+  const execution = {
+    ownerId: input.claim.ownerId,
+    generation: input.claim.generation,
+  };
+  const control = createCaptureExecutionControl({
+    deadlineEpochMs: request.deadlineEpochMs,
+    now,
+    callerSignal: input.signal,
+  });
+  const heartbeatOperation = input.dependencies.heartbeatOperation ?? heartbeatAgentBackupOperation;
+  const heartbeatCatalog = async (): Promise<true> => {
+    await control.await("Catalogue lease heartbeat", () =>
+      heartbeatOperation({
+        organizationId,
+        backupId: input.claim.backup.id,
+        execution,
+        leaseMs: input.leaseMs,
+      }),
+    );
+    return true;
+  };
+
+  try {
+    await heartbeatCatalog();
+    const context = await control.await("Capture context resolution", () =>
+      input.dependencies.resolveContext({
+        claim: input.claim,
+        request,
+        expectedSource,
+        heartbeat: heartbeatCatalog,
+        signal: control.signal,
+      }),
+    );
+    if (context.kms.provider !== "steward") {
+      executorError(
+        "AGENT_BACKUP_V3_KMS_AUTHORITY_INVALID",
+        "Durable Hetzner capture requires a Steward-wrapped operation key bundle",
+      );
+    }
+    assertAttestation({
+      attestation: context.attestation,
+      request,
+      organizationId,
+      expectedSource,
+    });
+    const initialAttestation = structuredClone(context.attestation);
+    const heartbeat = async (): Promise<true> => {
+      await heartbeatCatalog();
+      const current = await control.await("Runtime attestation revalidation", () =>
+        context.revalidateAttestation(control.signal),
+      );
+      assertAttestation({
+        attestation: current,
+        request,
+        organizationId,
+        expectedSource,
+        expected: initialAttestation,
+      });
+      return true;
+    };
+    await heartbeat();
+
+    const chain = await control.await("Manifest chain authority load", () =>
+      (input.dependencies.loadManifestChainAuthority ?? loadAgentBackupManifestChainAuthority)({
+        organizationId,
+        backupId: input.claim.backup.id,
+        operationId: request.operationId,
+        execution,
+      }),
+    );
+    await heartbeat();
+
+    const authority: AgentBackupCaptureV3ManifestAuthority = {
+      createdAt: canonicalCreatedAt(input.claim),
+      organizationId,
+      source: expectedSource,
+      runtime: initialAttestation.runtime,
+      chain,
+      watermarks: initialAttestation.watermarks,
+      kms: context.kms,
+      vaultKeyAuthority: context.vaultKeyAuthority,
+    };
+    const terminalSpoolCleanup: AgentBackupCaptureV3TerminalSpoolCleanupAuthority = {
+      organizationId,
+      agentId: request.agentId,
+      backupId: input.claim.backup.id,
+      operationId: request.operationId,
+      activationGeneration: request.activationGeneration,
+      lifecycleRevision: request.lifecycleRevision,
+      ...deriveAgentBackupCaptureV3SpoolAuthorityDigests({ request, authority }),
+    };
+    const recordCaptured = input.dependencies.recordCaptured;
+    let result: AgentBackupCaptureV2PipelineResult;
+    try {
+      result = await control.await("Capture-v2 pipeline", () =>
+        runAgentBackupCaptureV2Pipeline({
+          request,
+          executionToken: input.claim.generation,
+          authority,
+          openCapture: (signal) =>
+            openAgentBackupCaptureV2({
+              ...context.transport,
+              request,
+              signal,
+              now,
+            }),
+          spool: context.spool,
+          keyBundle: context.keyBundle,
+          publication: {
+            mode: "capture-only",
+            async recordCaptured(artifacts) {
+              await recordCaptured({
+                organizationId,
+                backupId: input.claim.backup.id,
+                operationId: request.operationId,
+                expectedActivationGeneration: request.activationGeneration,
+                expectedLifecycleRevision: request.lifecycleRevision,
+                execution,
+                manifest: artifacts.catalogManifest,
+              });
+              return true;
+            },
+          },
+          heartbeat,
+          signal: control.signal,
+          now,
+        }),
+      );
+    } catch (cause) {
+      const terminal = normalizeAgentBackupCaptureV2TerminalFailure(cause, terminalSpoolCleanup);
+      if (terminal) throw terminal;
+      throw cause;
+    }
+    if (result.state !== "captured-upload-pending") {
+      executorError(
+        "AGENT_BACKUP_V2_CAPTURE_ONLY_BOUNDARY_BROKEN",
+        "Capture executor unexpectedly crossed into publication",
+      );
+    }
+    return result;
+  } finally {
+    control.close();
+  }
+}
+
+export { AgentBackupCaptureV2CatalogExecutorError } from "./agent-backup-capture-v2-failure-disposition";
+
+/** Bind deployment authorities once, then inject this executor into the catalogue runtime. */
+export function createAgentBackupCaptureV2CatalogExecutor(
+  dependencies: ExecuteAgentBackupCaptureV2CatalogClaimDependencies,
+): AgentBackupCatalogRuntimeCaptureExecutor {
+  return {
+    execute: ({ claim, leaseMs, signal }) =>
+      executeAgentBackupCaptureV2CatalogClaim({
+        claim,
+        leaseMs,
+        dependencies,
+        signal,
+      }),
+  };
+}

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-client.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-client.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
+import {
+  AGENT_BACKUP_CAPTURE_V2_CONTENT_TYPE,
+  AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+  AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+  type AgentBackupCaptureV2FrameHeader,
+  type AgentBackupCaptureV2Request,
+  readAgentBackupCaptureV2FrameDigest,
+  serializeAgentBackupCaptureV2Frame,
+} from "@elizaos/shared";
+import {
+  AgentBackupCaptureV2HttpError,
+  openAgentBackupCaptureV2,
+} from "./agent-backup-capture-v2-client";
+
+const request: AgentBackupCaptureV2Request = {
+  format: "elizaos.agent-backup.capture-request",
+  schemaVersion: 2,
+  operationId: "11111111-1111-4111-8111-111111111111",
+  agentId: "22222222-2222-4222-8222-222222222222",
+  activationGeneration: "33333333-3333-4333-8333-333333333333",
+  lifecycleRevision: "7",
+  deadlineEpochMs: 2_000_000,
+};
+
+async function wireFrames(): Promise<Uint8Array[]> {
+  const frames: Uint8Array[] = [];
+  const digests: Uint8Array[] = [];
+  const push = async (header: AgentBackupCaptureV2FrameHeader, payload?: Uint8Array) => {
+    const wire = await serializeAgentBackupCaptureV2Frame({ header, payload });
+    frames.push(wire);
+    digests.push(readAgentBackupCaptureV2FrameDigest(wire));
+  };
+  await push({
+    format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+    schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+    sequence: 0,
+    kind: "capture-start",
+    operationId: request.operationId,
+    agentId: request.agentId,
+    activationGeneration: request.activationGeneration,
+    lifecycleRevision: request.lifecycleRevision,
+    createdAt: "2026-08-15T10:00:00.000Z",
+    componentCount: 1,
+    maxFramePayloadBytes: 256 * 1024,
+  });
+  await push({
+    format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+    schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+    sequence: 1,
+    kind: "component-start",
+    componentIndex: 0,
+    component: {
+      name: "database",
+      format: "opaque-v1",
+      compression: "none",
+      contentKind: "opaque",
+      consistency: "transactional",
+    },
+  });
+  const payload = new TextEncoder().encode("durable state");
+  await push(
+    {
+      format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+      schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+      sequence: 2,
+      kind: "data",
+      componentIndex: 0,
+      componentName: "database",
+      dataIndex: 0,
+      offsetBytes: 0,
+      payloadBytes: payload.byteLength,
+    },
+    payload,
+  );
+  await push({
+    format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+    schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+    sequence: 3,
+    kind: "component-end",
+    componentIndex: 0,
+    componentName: "database",
+    dataFrameCount: 1,
+    plainBytes: payload.byteLength,
+    payloadSha256: createHash("sha256").update(payload).digest("hex"),
+  });
+  const chain = createHash("sha256");
+  for (const digest of digests) chain.update(digest);
+  await push({
+    format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+    schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+    sequence: 4,
+    kind: "capture-end",
+    componentCount: 1,
+    dataFrameCount: 1,
+    plainBytes: payload.byteLength,
+    frameDigestChainSha256: chain.digest("hex"),
+  });
+  return frames;
+}
+
+function responseFor(frames: Uint8Array[]): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      pull(controller) {
+        const frame = frames.shift();
+        if (frame) controller.enqueue(frame);
+        else controller.close();
+      },
+    }),
+    {
+      status: 200,
+      headers: {
+        "Content-Type": AGENT_BACKUP_CAPTURE_V2_CONTENT_TYPE,
+        "X-Eliza-Backup-Operation-Id": request.operationId,
+      },
+    },
+  );
+}
+
+describe("openAgentBackupCaptureV2", () => {
+  it("authenticates the exact v2 route and enforces stream fences", async () => {
+    const frames = await wireFrames();
+    let observedUrl = "";
+    const fetchStub: typeof fetch = Object.assign(
+      async (url: string | URL | Request, init?: RequestInit) => {
+        observedUrl = String(url);
+        const headers = new Headers(init?.headers);
+        expect(headers.get("authorization")).toBe("Bearer secret-token");
+        expect(headers.get("x-api-key")).toBe("secret-token");
+        expect(headers.get("x-eliza-token")).toBe("secret-token");
+        expect(init?.redirect).toBe("manual");
+        expect(JSON.parse(String(init?.body))).toEqual(request);
+        return responseFor([...frames]);
+      },
+      { preconnect: fetch.preconnect },
+    ) as typeof fetch;
+
+    const kinds: string[] = [];
+    for await (const frame of openAgentBackupCaptureV2({
+      agentApiBaseUrl: "https://agent.example.test/base/",
+      apiToken: " secret-token ",
+      request,
+      fetch: fetchStub,
+      now: () => 1_200_000,
+    })) {
+      kinds.push(frame.header.kind);
+    }
+
+    expect(observedUrl).toBe("https://agent.example.test/base/api/snapshot/v2");
+    expect(kinds).toEqual([
+      "capture-start",
+      "component-start",
+      "data",
+      "component-end",
+      "capture-end",
+    ]);
+  });
+
+  it("rejects a tampered frame before yielding a false terminal capture", async () => {
+    const frames = await wireFrames();
+    frames[2] = Uint8Array.from(frames[2] ?? [], (byte, index) => (index === 20 ? byte ^ 1 : byte));
+    const fetchStub = (async () => responseFor(frames)) as typeof fetch;
+    const consume = async (): Promise<void> => {
+      for await (const _frame of openAgentBackupCaptureV2({
+        agentApiBaseUrl: "https://agent.example.test",
+        apiToken: "secret-token",
+        request,
+        fetch: fetchStub,
+        now: () => 1_200_000,
+      })) {
+        // Intentionally consume through the tampered frame.
+      }
+    };
+    await expect(consume()).rejects.toMatchObject({ code: "CAPTURE_V2_FRAME_TAMPERED" });
+  });
+
+  it("fails closed on an operation response-header mismatch", async () => {
+    const frames = await wireFrames();
+    const fetchStub = (async () => {
+      const response = responseFor(frames);
+      response.headers.set("X-Eliza-Backup-Operation-Id", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+      return response;
+    }) as typeof fetch;
+    const consume = async (): Promise<void> => {
+      for await (const _frame of openAgentBackupCaptureV2({
+        agentApiBaseUrl: "https://agent.example.test",
+        apiToken: "secret-token",
+        request,
+        fetch: fetchStub,
+        now: () => 1_200_000,
+      })) {
+        // No frame may be accepted with the wrong response fence.
+      }
+    };
+    await expect(consume()).rejects.toBeInstanceOf(AgentBackupCaptureV2HttpError);
+    await expect(consume()).rejects.toMatchObject({
+      code: "AGENT_BACKUP_V2_HTTP_OPERATION_MISMATCH",
+    });
+  });
+
+  it("preserves only an allowlisted remote failure with its exact status", async () => {
+    const consume = async (status: number, body: unknown): Promise<void> => {
+      for await (const _frame of openAgentBackupCaptureV2({
+        agentApiBaseUrl: "https://agent.example.test",
+        apiToken: "secret-token",
+        request,
+        fetch: (async () =>
+          new Response(body instanceof Uint8Array ? body : JSON.stringify(body), {
+            status,
+            headers: { "Content-Type": "application/json" },
+          })) as typeof fetch,
+        now: () => 1_200_000,
+      })) {
+        // Error responses cannot yield capture frames.
+      }
+    };
+
+    await expect(
+      consume(413, {
+        error: "PGlite is larger than the bounded exporter limit",
+        code: "AGENT_BACKUP_V2_PGLITE_PHYSICAL_BYTES_LIMIT",
+      }),
+    ).rejects.toMatchObject({
+      code: "AGENT_BACKUP_V2_HTTP_STATUS",
+      status: 413,
+      remoteCode: "AGENT_BACKUP_V2_PGLITE_PHYSICAL_BYTES_LIMIT",
+    });
+    await expect(
+      consume(503, {
+        error: "The process RSS budget is temporarily exhausted",
+        code: "AGENT_BACKUP_V2_PGLITE_RSS_BUDGET_EXCEEDED",
+      }),
+    ).rejects.toMatchObject({
+      status: 503,
+      remoteCode: "AGENT_BACKUP_V2_PGLITE_RSS_BUDGET_EXCEEDED",
+    });
+  });
+
+  it("does not trust unknown, malformed, or status-mismatched remote codes", async () => {
+    const capture = async (status: number, body: unknown): Promise<unknown> => {
+      try {
+        for await (const _frame of openAgentBackupCaptureV2({
+          agentApiBaseUrl: "https://agent.example.test",
+          apiToken: "secret-token",
+          request,
+          fetch: (async () =>
+            new Response(body instanceof Uint8Array ? body : JSON.stringify(body), {
+              status,
+              headers: { "Content-Type": "application/json" },
+            })) as typeof fetch,
+          now: () => 1_200_000,
+        })) {
+          // Error responses cannot yield capture frames.
+        }
+      } catch (error) {
+        return error;
+      }
+      throw new Error("Expected capture-v2 HTTP failure");
+    };
+
+    for (const error of [
+      await capture(503, {
+        error: "wrong status",
+        code: "AGENT_BACKUP_V2_PGLITE_PHYSICAL_BYTES_LIMIT",
+      }),
+      await capture(500, { error: "unknown", code: "AGENT_BACKUP_V2_DELETE_EVERYTHING" }),
+      await capture(413, {
+        error: "extra untrusted shape",
+        code: "AGENT_BACKUP_V2_PGLITE_PHYSICAL_BYTES_LIMIT",
+        terminal: true,
+      }),
+      await capture(
+        413,
+        new Uint8Array([
+          ...new TextEncoder().encode('{"error":"'),
+          0xff,
+          ...new TextEncoder().encode('","code":"AGENT_BACKUP_V2_PGLITE_PHYSICAL_BYTES_LIMIT"}'),
+        ]),
+      ),
+    ]) {
+      expect(error).toMatchObject({
+        code: "AGENT_BACKUP_V2_HTTP_STATUS",
+        remoteCode: undefined,
+      });
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-client.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-client.ts
@@ -1,0 +1,353 @@
+/**
+ * Authenticated, bounded HTTP client for the agent capture-v2 framed stream.
+ * It owns transport validation only; provider provenance and durable backup
+ * authority remain control-plane concerns.
+ */
+
+import { createHash } from "node:crypto";
+import {
+  AGENT_BACKUP_CAPTURE_V2_CONTENT_TYPE,
+  AGENT_BACKUP_CAPTURE_V2_LIMITS,
+  type AgentBackupCaptureV2Frame,
+  type AgentBackupCaptureV2Request,
+  parseAgentBackupCaptureV2Frames,
+  parseAgentBackupCaptureV2Request,
+} from "@elizaos/shared";
+
+const MAX_ERROR_BODY_BYTES = 4 * 1024;
+const REMOTE_CAPTURE_FAILURE_STATUS = Object.freeze({
+  AGENT_BACKUP_V2_INVALID_REQUEST: [400],
+  AGENT_BACKUP_V2_AGENT_MISMATCH: [409],
+  AGENT_BACKUP_V2_FILE_CHANGED: [409],
+  AGENT_BACKUP_V2_PGLITE_PREFLIGHT_CHANGED: [409],
+  AGENT_BACKUP_V2_CAPTURE_DEADLINE_EXCEEDED: [408],
+  AGENT_BACKUP_V2_INVALID_DEADLINE: [408],
+  AGENT_BACKUP_V2_PGLITE_PHYSICAL_BYTES_LIMIT: [413],
+  AGENT_BACKUP_V2_PGLITE_PREFLIGHT_ENTRY_LIMIT: [413],
+  AGENT_BACKUP_V2_PGLITE_DUMP_EXCEEDS_PREFLIGHT: [413],
+  AGENT_BACKUP_V2_CAPTURE_BUSY: [429],
+  AGENT_BACKUP_V2_PGLITE_DUMP_BUSY: [429],
+  AGENT_BACKUP_V2_CAPTURE_ABORTED: [499],
+  AGENT_BACKUP_V2_CLIENT_DISCONNECTED: [499],
+  AGENT_BACKUP_V2_POSTGRES_UNSUPPORTED: [501],
+  AGENT_BACKUP_V2_PGLITE_NOT_FILESYSTEM: [501],
+  AGENT_BACKUP_V2_PGLITE_MANAGED_DUMP_UNAVAILABLE: [501],
+  AGENT_BACKUP_V2_PGLITE_RSS_BUDGET_EXCEEDED: [503],
+  AGENT_BACKUP_V2_CAPTURE_FAILED: [500],
+  AGENT_BACKUP_V2_DIRECTORY_IDENTITY_INVALID: [500],
+  AGENT_BACKUP_V2_PGLITE_COMPONENT_OVERLAP: [500],
+  AGENT_BACKUP_V2_PGLITE_DIRECTORY_MISMATCH: [500],
+  AGENT_BACKUP_V2_PGLITE_DIRECTORY_UNATTESTED: [500],
+  AGENT_BACKUP_V2_PGLITE_DUMP_ALREADY_CONSUMED: [500],
+  AGENT_BACKUP_V2_PGLITE_DUMP_FAILED: [500],
+  AGENT_BACKUP_V2_PGLITE_DUMP_NOT_STREAMABLE: [500],
+  AGENT_BACKUP_V2_PGLITE_PREFLIGHT_UNPROVEN: [500],
+  AGENT_BACKUP_V2_PGLITE_STATE_OVERLAP: [500],
+} satisfies Record<string, readonly number[]>);
+
+export class AgentBackupCaptureV2HttpError extends Error {
+  override readonly name = "AgentBackupCaptureV2HttpError";
+
+  constructor(
+    readonly code: string,
+    message: string,
+    options?: { cause?: unknown; status?: number; remoteCode?: string },
+  ) {
+    super(message, { cause: options?.cause });
+    this.status = options?.status;
+    this.remoteCode = options?.remoteCode;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+
+  readonly status: number | undefined;
+  readonly remoteCode: string | undefined;
+}
+
+export interface OpenAgentBackupCaptureV2Input {
+  /** Already-authorized, SSRF-checked agent API base URL. */
+  agentApiBaseUrl: string;
+  apiToken: string;
+  request: AgentBackupCaptureV2Request;
+  signal?: AbortSignal;
+  fetch?: typeof fetch;
+  now?: () => number;
+}
+
+function clientError(code: string, message: string, cause?: unknown): never {
+  throw new AgentBackupCaptureV2HttpError(code, message, { cause });
+}
+
+function sha256Digest(bytes: Uint8Array): Uint8Array {
+  return createHash("sha256").update(bytes).digest();
+}
+
+function sha256StreamFactory(): {
+  update(bytes: Uint8Array): void;
+  digestHex(): string;
+} {
+  const hash = createHash("sha256");
+  return {
+    update(bytes): void {
+      hash.update(bytes);
+    },
+    digestHex(): string {
+      return hash.digest("hex");
+    },
+  };
+}
+
+function resolveCaptureUrl(baseUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(baseUrl);
+  } catch (cause) {
+    clientError("AGENT_BACKUP_V2_INVALID_ENDPOINT", "Agent capture-v2 base URL is invalid", cause);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    clientError(
+      "AGENT_BACKUP_V2_INVALID_ENDPOINT",
+      "Agent capture-v2 requires an HTTP(S) endpoint",
+    );
+  }
+  parsed.username = "";
+  parsed.password = "";
+  const normalizedPath = parsed.pathname.replace(/\/+$/, "");
+  parsed.pathname = `${normalizedPath}/api/snapshot/v2`.replace(/^\/\//, "/");
+  parsed.search = "";
+  parsed.hash = "";
+  return parsed.toString();
+}
+
+function abortError(signal: AbortSignal): AgentBackupCaptureV2HttpError {
+  return new AgentBackupCaptureV2HttpError(
+    "AGENT_BACKUP_V2_HTTP_ABORTED",
+    "Agent capture-v2 HTTP request was cancelled",
+    { cause: signal.reason },
+  );
+}
+
+function combineAbortSignals(
+  callerSignal: AbortSignal | undefined,
+  deadlineEpochMs: number,
+  now: () => number,
+): { signal: AbortSignal; close(): void } {
+  const controller = new AbortController();
+  const remainingMs = deadlineEpochMs - now();
+  if (remainingMs <= 0) {
+    clientError("AGENT_BACKUP_V2_HTTP_DEADLINE_EXCEEDED", "Agent capture-v2 deadline has expired");
+  }
+  const deadlineTimer = setTimeout(
+    () =>
+      controller.abort(
+        new AgentBackupCaptureV2HttpError(
+          "AGENT_BACKUP_V2_HTTP_DEADLINE_EXCEEDED",
+          "Agent capture-v2 HTTP deadline exceeded",
+        ),
+      ),
+    Math.min(remainingMs, 2_147_483_647),
+  );
+  const onAbort = (): void => {
+    if (!controller.signal.aborted && callerSignal) {
+      controller.abort(abortError(callerSignal));
+    }
+  };
+  callerSignal?.addEventListener("abort", onAbort, { once: true });
+  if (callerSignal?.aborted) onAbort();
+  return {
+    signal: controller.signal,
+    close(): void {
+      clearTimeout(deadlineTimer);
+      callerSignal?.removeEventListener("abort", onAbort);
+    },
+  };
+}
+
+async function readBoundedErrorBody(
+  response: Response,
+): Promise<{ excerpt: string; remoteCode?: string }> {
+  if (!response.body) return { excerpt: "" };
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let received = 0;
+  let result = "";
+  let complete = false;
+  try {
+    while (received <= MAX_ERROR_BODY_BYTES) {
+      const next = await reader.read();
+      if (next.done) {
+        complete = true;
+        break;
+      }
+      if (next.value.byteLength === 0) continue;
+      const take = Math.min(next.value.byteLength, MAX_ERROR_BODY_BYTES - received);
+      result += decoder.decode(next.value.subarray(0, take), { stream: true });
+      received += take;
+      if (take !== next.value.byteLength || received === MAX_ERROR_BODY_BYTES) break;
+    }
+    result += decoder.decode();
+  } catch {
+    return { excerpt: "" };
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+  const excerpt = result.replace(/[\r\n\t]+/g, " ").trim();
+  if (
+    !complete ||
+    response.headers.get("content-type")?.split(";", 1)[0]?.trim() !== "application/json"
+  ) {
+    return { excerpt };
+  }
+  try {
+    const parsed = JSON.parse(result) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return { excerpt };
+    const record = parsed as Record<string, unknown>;
+    if (
+      Object.keys(record).sort().join(",") !== "code,error" ||
+      typeof record.code !== "string" ||
+      typeof record.error !== "string" ||
+      record.error.length > 2_048
+    ) {
+      return { excerpt };
+    }
+    const expectedStatuses = Reflect.get(REMOTE_CAPTURE_FAILURE_STATUS, record.code) as
+      | readonly number[]
+      | undefined;
+    if (!expectedStatuses?.includes(response.status)) return { excerpt };
+    return { excerpt, remoteCode: record.code };
+  } catch {
+    return { excerpt };
+  }
+}
+
+async function* responseBytes(response: Response, signal: AbortSignal): AsyncGenerator<Uint8Array> {
+  if (!response.body) {
+    clientError("AGENT_BACKUP_V2_HTTP_BODY_MISSING", "Agent capture-v2 response has no body");
+  }
+  const reader = response.body.getReader();
+  try {
+    for (;;) {
+      if (signal.aborted) throw abortError(signal);
+      const next = await reader.read();
+      if (next.done) break;
+      if (next.value.byteLength === 0) {
+        clientError(
+          "AGENT_BACKUP_V2_HTTP_ZERO_PROGRESS",
+          "Agent capture-v2 response yielded an empty transport chunk",
+        );
+      }
+      if (next.value.byteLength > AGENT_BACKUP_CAPTURE_V2_LIMITS.maxIngressChunkBytes) {
+        clientError(
+          "AGENT_BACKUP_V2_HTTP_CHUNK_TOO_LARGE",
+          "Agent capture-v2 response exceeded its ingress chunk bound",
+        );
+      }
+      yield next.value;
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+}
+
+/**
+ * Open and parse one capture-v2 response. The generator pulls at most one
+ * transport frame ahead, preserving response-stream backpressure.
+ */
+export async function* openAgentBackupCaptureV2(
+  input: Readonly<OpenAgentBackupCaptureV2Input>,
+): AsyncGenerator<AgentBackupCaptureV2Frame> {
+  const request = parseAgentBackupCaptureV2Request(input.request);
+  const token = input.apiToken.trim();
+  if (!token) {
+    clientError("AGENT_BACKUP_V2_HTTP_AUTH_MISSING", "Agent capture-v2 requires an API token");
+  }
+  const now = input.now ?? Date.now;
+  if (request.deadlineEpochMs - now() > AGENT_BACKUP_CAPTURE_V2_LIMITS.maxDeadlineAheadMs) {
+    clientError(
+      "AGENT_BACKUP_V2_HTTP_INVALID_DEADLINE",
+      "Agent capture-v2 deadline is too far in the future",
+    );
+  }
+  const control = combineAbortSignals(input.signal, request.deadlineEpochMs, now);
+  let response: Response;
+  try {
+    response = await (input.fetch ?? globalThis.fetch)(resolveCaptureUrl(input.agentApiBaseUrl), {
+      method: "POST",
+      redirect: "manual",
+      signal: control.signal,
+      headers: {
+        Accept: AGENT_BACKUP_CAPTURE_V2_CONTENT_TYPE,
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "X-Api-Key": token,
+        "X-Eliza-Token": token,
+      },
+      body: JSON.stringify(request),
+    });
+  } catch (cause) {
+    control.close();
+    if (control.signal.aborted) throw abortError(control.signal);
+    clientError(
+      "AGENT_BACKUP_V2_HTTP_REQUEST_FAILED",
+      "Agent capture-v2 HTTP request failed",
+      cause,
+    );
+  }
+
+  try {
+    if (response.status >= 300 && response.status < 400) {
+      clientError(
+        "AGENT_BACKUP_V2_HTTP_REDIRECT_REJECTED",
+        "Agent capture-v2 refused an HTTP redirect",
+      );
+    }
+    if (!response.ok) {
+      const failure = await readBoundedErrorBody(response);
+      throw new AgentBackupCaptureV2HttpError(
+        "AGENT_BACKUP_V2_HTTP_STATUS",
+        `Agent capture-v2 returned HTTP ${response.status}${failure.excerpt ? `: ${failure.excerpt}` : ""}`,
+        { status: response.status, remoteCode: failure.remoteCode },
+      );
+    }
+    const contentType = response.headers.get("content-type")?.split(";", 1)[0]?.trim();
+    if (contentType !== AGENT_BACKUP_CAPTURE_V2_CONTENT_TYPE) {
+      clientError(
+        "AGENT_BACKUP_V2_HTTP_CONTENT_TYPE",
+        "Agent capture-v2 returned an unexpected content type",
+      );
+    }
+    if (response.headers.get("x-eliza-backup-operation-id") !== request.operationId) {
+      clientError(
+        "AGENT_BACKUP_V2_HTTP_OPERATION_MISMATCH",
+        "Agent capture-v2 response operation fence does not match",
+      );
+    }
+
+    let first = true;
+    for await (const frame of parseAgentBackupCaptureV2Frames(
+      responseBytes(response, control.signal),
+      { digest: sha256Digest, sha256StreamFactory },
+    )) {
+      if (first) {
+        first = false;
+        if (
+          frame.header.kind !== "capture-start" ||
+          frame.header.operationId !== request.operationId ||
+          frame.header.agentId !== request.agentId ||
+          frame.header.activationGeneration !== request.activationGeneration ||
+          frame.header.lifecycleRevision !== request.lifecycleRevision
+        ) {
+          clientError(
+            "AGENT_BACKUP_V2_HTTP_FENCE_MISMATCH",
+            "Agent capture-v2 stream identity fences do not match the request",
+          );
+        }
+      }
+      yield frame;
+    }
+    if (first) {
+      clientError("AGENT_BACKUP_V2_HTTP_EMPTY_STREAM", "Agent capture-v2 returned no frames");
+    }
+  } finally {
+    control.close();
+  }
+}

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-failure-disposition.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-failure-disposition.ts
@@ -1,0 +1,238 @@
+/**
+ * Trusted capture-v2 failure policy shared by the concrete executor and the
+ * catalogue runtime. Only this module can brand a terminal disposition; raw
+ * error fields from injected executors, abort reasons, or remote bodies never
+ * authorize irreversible catalogue settlement or local spool cleanup.
+ */
+
+import { AgentBackupCaptureV2ProtocolError } from "@elizaos/shared";
+import { AgentBackupCaptureV2HttpError } from "./agent-backup-capture-v2-client";
+import { AgentBackupCaptureV2PipelineError } from "./agent-backup-capture-v2-pipeline";
+import { AgentBackupCaptureV3SpoolError } from "./agent-backup-capture-v2-spool";
+import type { AgentBackupCaptureV3TerminalSpoolCleanupAuthority } from "./agent-backup-capture-v3-spool-cleanup";
+
+const TERMINAL_CAPTURE_FAILURE_CODES = new Set([
+  "AGENT_BACKUP_V2_AUTHORITY_INVALID",
+  "AGENT_BACKUP_V2_CAPTURE_ONLY_BOUNDARY_BROKEN",
+  "AGENT_BACKUP_V2_CAPTURE_STATE",
+  "AGENT_BACKUP_V2_CLAIM_AUTHORITY_INCOMPLETE",
+  "AGENT_BACKUP_V2_CLAIM_AUTHORITY_INVALID",
+  "AGENT_BACKUP_V2_CLAIM_CREATED_AT_INVALID",
+  "AGENT_BACKUP_V2_AGENT_MISMATCH",
+  "AGENT_BACKUP_V2_DIRECTORY_IDENTITY_INVALID",
+  "AGENT_BACKUP_V2_FILE_CHANGED",
+  "AGENT_BACKUP_V2_HTTP_AUTH_MISSING",
+  "AGENT_BACKUP_V2_HTTP_CHUNK_TOO_LARGE",
+  "AGENT_BACKUP_V2_HTTP_CONTENT_TYPE",
+  "AGENT_BACKUP_V2_HTTP_FENCE_MISMATCH",
+  "AGENT_BACKUP_V2_HTTP_OPERATION_MISMATCH",
+  "AGENT_BACKUP_V2_HTTP_REDIRECT_REJECTED",
+  "AGENT_BACKUP_V2_INVALID_REQUEST",
+  "AGENT_BACKUP_V2_PGLITE_COMPONENT_OVERLAP",
+  "AGENT_BACKUP_V2_PGLITE_DIRECTORY_MISMATCH",
+  "AGENT_BACKUP_V2_PGLITE_DIRECTORY_UNATTESTED",
+  "AGENT_BACKUP_V2_PGLITE_DUMP_ALREADY_CONSUMED",
+  "AGENT_BACKUP_V2_PGLITE_DUMP_EXCEEDS_PREFLIGHT",
+  "AGENT_BACKUP_V2_PGLITE_DUMP_NOT_STREAMABLE",
+  "AGENT_BACKUP_V2_PGLITE_MANAGED_DUMP_UNAVAILABLE",
+  "AGENT_BACKUP_V2_PGLITE_NOT_FILESYSTEM",
+  "AGENT_BACKUP_V2_PGLITE_PHYSICAL_BYTES_LIMIT",
+  "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_ENTRY_LIMIT",
+  "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_UNPROVEN",
+  "AGENT_BACKUP_V2_PGLITE_STATE_OVERLAP",
+  "AGENT_BACKUP_V2_POSTGRES_UNSUPPORTED",
+  "AGENT_BACKUP_V2_RUNTIME_ATTESTATION_CHANGED",
+  "AGENT_BACKUP_V2_RUNTIME_ATTESTATION_MISMATCH",
+  "AGENT_BACKUP_V2_SPOOL_REPLAY_CONFLICT",
+  "AGENT_BACKUP_V3_CATALOG_REPLAY_CONFLICT",
+  "AGENT_BACKUP_V3_INCREMENTAL_CAPTURE_UNSUPPORTED",
+  "AGENT_BACKUP_V3_KMS_AUTHORITY_INVALID",
+  "AGENT_BACKUP_V3_SPOOL_INVENTORY_CONFLICT",
+  "AGENT_BACKUP_V3_SPOOL_REPLAY_CONFLICT",
+  "CAPTURE_V2_BAD_MAGIC",
+  "CAPTURE_V2_CAPTURE_TOTALS",
+  "CAPTURE_V2_CHAIN_DIGEST",
+  "CAPTURE_V2_COMPONENT_DIGEST",
+  "CAPTURE_V2_COMPONENT_ORDER",
+  "CAPTURE_V2_COMPONENT_STATE",
+  "CAPTURE_V2_COMPONENT_TOTALS",
+  "CAPTURE_V2_CONTROL_FRAME_PAYLOAD",
+  "CAPTURE_V2_DATA_FRAME_LIMIT",
+  "CAPTURE_V2_DATA_STATE",
+  "CAPTURE_V2_FILE_ENTRY_REQUIRED",
+  "CAPTURE_V2_FILE_METADATA_DRIFT",
+  "CAPTURE_V2_FILE_OFFSET",
+  "CAPTURE_V2_FILE_ORDER",
+  "CAPTURE_V2_FILE_SIZE_EXCEEDED",
+  "CAPTURE_V2_FRAME_TAMPERED",
+  "CAPTURE_V2_HEADER_LENGTH",
+  "CAPTURE_V2_HEADER_TOO_LARGE",
+  "CAPTURE_V2_INGRESS_CHUNK_TOO_LARGE",
+  "CAPTURE_V2_INVALID_HEADER",
+  "CAPTURE_V2_INVALID_HEADER_JSON",
+  "CAPTURE_V2_INVALID_INGRESS_CHUNK",
+  "CAPTURE_V2_KIND_MISMATCH",
+  "CAPTURE_V2_PAYLOAD_LENGTH_MISMATCH",
+  "CAPTURE_V2_PAYLOAD_TOO_LARGE",
+  "CAPTURE_V2_PLAIN_BYTES_LIMIT",
+  "CAPTURE_V2_SEQUENCE",
+  "CAPTURE_V2_STATE",
+  "CAPTURE_V2_TRAILING_BYTES",
+  "CAPTURE_V2_TRUNCATED_FILE",
+  "CAPTURE_V2_UNEXPECTED_FILE_ENTRY",
+  "CAPTURE_V2_UNKNOWN_FRAME_KIND",
+  "CAPTURE_V2_UNSUPPORTED_VERSION",
+]);
+
+const TRUSTED_TERMINAL_DISPOSITIONS = new WeakSet<AgentBackupCaptureV2CatalogExecutorError>();
+
+export class AgentBackupCaptureV2CatalogExecutorError extends Error {
+  override readonly name = "AgentBackupCaptureV2CatalogExecutorError";
+
+  constructor(
+    readonly code: string,
+    message: string,
+    options?: {
+      cause?: unknown;
+      terminal?: boolean;
+      terminalSpoolCleanup?: AgentBackupCaptureV3TerminalSpoolCleanupAuthority;
+    },
+  ) {
+    super(message, { cause: options?.cause });
+    this.terminal = options?.terminal ?? false;
+    this.terminalSpoolCleanup = options?.terminalSpoolCleanup;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+
+  readonly terminal: boolean;
+  readonly terminalSpoolCleanup: AgentBackupCaptureV3TerminalSpoolCleanupAuthority | undefined;
+}
+
+export function isTerminalAgentBackupCaptureV2FailureCode(code: string): boolean {
+  return TERMINAL_CAPTURE_FAILURE_CODES.has(code);
+}
+
+export function isTrustedAgentBackupCaptureV2TerminalDisposition(
+  error: unknown,
+): error is AgentBackupCaptureV2CatalogExecutorError & { terminal: true } {
+  return (
+    error instanceof AgentBackupCaptureV2CatalogExecutorError &&
+    error.terminal === true &&
+    TRUSTED_TERMINAL_DISPOSITIONS.has(error)
+  );
+}
+
+function trustedTerminalDisposition(params: {
+  code: string;
+  message: string;
+  cause?: unknown;
+  terminalSpoolCleanup?: AgentBackupCaptureV3TerminalSpoolCleanupAuthority;
+}): AgentBackupCaptureV2CatalogExecutorError {
+  const error = new AgentBackupCaptureV2CatalogExecutorError(params.code, params.message, {
+    cause: params.cause,
+    terminal: true,
+    terminalSpoolCleanup: params.terminalSpoolCleanup,
+  });
+  TRUSTED_TERMINAL_DISPOSITIONS.add(error);
+  return error;
+}
+
+/** Construct an executor-owned error, branding deterministic local policy only. */
+export function createAgentBackupCaptureV2ExecutorError(
+  code: string,
+  message: string,
+  cause?: unknown,
+): AgentBackupCaptureV2CatalogExecutorError {
+  return isTerminalAgentBackupCaptureV2FailureCode(code)
+    ? trustedTerminalDisposition({ code, message, cause })
+    : new AgentBackupCaptureV2CatalogExecutorError(code, message, { cause });
+}
+
+const CAUSE_BARRIER_CODES = new Set([
+  "AGENT_BACKUP_V2_CAPTURE_ABORTED",
+  "AGENT_BACKUP_V2_CAPTURE_DEADLINE_EXCEEDED",
+  "AGENT_BACKUP_V2_HTTP_ABORTED",
+  "AGENT_BACKUP_V2_HTTP_DEADLINE_EXCEEDED",
+  "AGENT_BACKUP_V2_PIPELINE_ABORTED",
+  "AGENT_BACKUP_V2_PIPELINE_DEADLINE_EXCEEDED",
+]);
+
+function typedFailure(error: unknown): { code: string; message: string } | undefined {
+  if (isTrustedAgentBackupCaptureV2TerminalDisposition(error)) {
+    return { code: error.code, message: error.message };
+  }
+  if (error instanceof AgentBackupCaptureV2HttpError) {
+    const code =
+      error.code === "AGENT_BACKUP_V2_HTTP_STATUS" && error.remoteCode
+        ? error.remoteCode
+        : error.code;
+    return { code, message: error.message };
+  }
+  if (
+    error instanceof AgentBackupCaptureV2ProtocolError ||
+    error instanceof AgentBackupCaptureV2PipelineError ||
+    error instanceof AgentBackupCaptureV3SpoolError
+  ) {
+    return { code: error.code, message: error.message };
+  }
+  return undefined;
+}
+
+function typedCause(error: unknown): unknown {
+  if (
+    error instanceof AgentBackupCaptureV2HttpError ||
+    error instanceof AgentBackupCaptureV2ProtocolError ||
+    error instanceof AgentBackupCaptureV2PipelineError ||
+    error instanceof AgentBackupCaptureV3SpoolError
+  ) {
+    return CAUSE_BARRIER_CODES.has(error.code) ? undefined : error.cause;
+  }
+  return undefined;
+}
+
+/**
+ * Normalize terminal evidence at the concrete executor boundary. Aggregate
+ * containers may be generic, but only known typed leaves can affect policy.
+ */
+export function normalizeAgentBackupCaptureV2TerminalFailure(
+  error: unknown,
+  terminalSpoolCleanup?: AgentBackupCaptureV3TerminalSpoolCleanupAuthority,
+): AgentBackupCaptureV2CatalogExecutorError | undefined {
+  if (isTrustedAgentBackupCaptureV2TerminalDisposition(error)) {
+    if (terminalSpoolCleanup && !error.terminalSpoolCleanup) {
+      return trustedTerminalDisposition({
+        code: error.code,
+        message: error.message,
+        cause: error,
+        terminalSpoolCleanup,
+      });
+    }
+    return error;
+  }
+
+  const pending: unknown[] = [error];
+  const seen = new Set<unknown>();
+  while (pending.length > 0 && seen.size < 32) {
+    const current = pending.shift();
+    if (!current || (typeof current !== "object" && typeof current !== "function")) continue;
+    if (seen.has(current)) continue;
+    seen.add(current);
+
+    const failure = typedFailure(current);
+    if (failure && isTerminalAgentBackupCaptureV2FailureCode(failure.code)) {
+      return trustedTerminalDisposition({
+        ...failure,
+        cause: error,
+        terminalSpoolCleanup,
+      });
+    }
+    if (current instanceof AggregateError) {
+      pending.push(...current.errors);
+      if (current.cause !== undefined) pending.push(current.cause);
+      continue;
+    }
+    const cause = typedCause(current);
+    if (cause !== undefined) pending.push(cause);
+  }
+  return undefined;
+}

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-pipeline.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-pipeline.test.ts
@@ -1,0 +1,1177 @@
+/**
+ * Exercises capture-v2 composition into a durable manifest-v3 spool using the
+ * real local KMS operation-key-bundle adapter and bounded synthetic ingress.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  type KmsAeadOperationKeyBundleHandle,
+  KmsAeadOperationKeyBundleProvider,
+  LocalKmsAdapter,
+} from "@elizaos/core/security/kms";
+import {
+  AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+  AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+  type AgentBackupCaptureV2ComponentDescriptor,
+  type AgentBackupCaptureV2Frame,
+  type AgentBackupCaptureV2Request,
+} from "@elizaos/shared";
+import {
+  type AgentBackupCaptureV2PublicationBoundary,
+  type AgentBackupCaptureV3Artifacts,
+  type AgentBackupCaptureV3KeyBundleProvider,
+  type AgentBackupCaptureV3ManifestAuthority,
+  runAgentBackupCaptureV2Pipeline,
+} from "./agent-backup-capture-v2-pipeline";
+import {
+  AgentBackupCaptureV3Spool,
+  type AgentBackupCaptureV3SpoolLockAuthority,
+  type AgentBackupCaptureV3SpoolProcessIdentity,
+} from "./agent-backup-capture-v2-spool";
+
+const MIB = 1024 * 1024;
+const FRAME_BYTES = 256 * 1024;
+const OPERATION_ID = "11111111-1111-4111-8111-111111111111";
+const ORGANIZATION_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const AGENT_ID = "22222222-2222-4222-8222-222222222222";
+const ACTIVATION_ID = "33333333-3333-4333-8333-333333333333";
+const EXECUTION_TOKEN = "66666666-6666-4666-8666-666666666666";
+const NEXT_EXECUTION_TOKEN = "77777777-7777-4777-8777-777777777777";
+const TEST_BOOT_ID = "88888888-8888-4888-8888-888888888888";
+const VAULT_KEY_GENERATION_ID = "99999999-9999-4999-8999-999999999999";
+
+const request: AgentBackupCaptureV2Request = {
+  format: "elizaos.agent-backup.capture-request",
+  schemaVersion: 2,
+  operationId: OPERATION_ID,
+  agentId: AGENT_ID,
+  activationGeneration: ACTIVATION_ID,
+  lifecycleRevision: "42",
+  deadlineEpochMs: 2_000_000,
+};
+
+const authority: AgentBackupCaptureV3ManifestAuthority = {
+  createdAt: "2026-08-15T10:00:00.000Z",
+  organizationId: ORGANIZATION_ID,
+  source: {
+    kind: "cloud",
+    provider: "hetzner",
+    nodeRecordId: "44444444-4444-4444-8444-444444444444",
+    nodeIncarnation: "55555555-5555-4555-8555-555555555555",
+    nodeId: "cloud-node-9",
+    containerId: "agent-container-42",
+    providerServerId: "1234",
+  },
+  runtime: {
+    imageDigest: `sha256:${"a".repeat(64)}`,
+    agentSchemaVersion: "agent-v2",
+    databaseSchemaVersion: "pglite-v1",
+    plugins: [{ id: "@elizaos/plugin-sql", version: "2.0.0" }],
+  },
+  chain: { kind: "full", baseOperationId: null, parentOperationId: null, depth: 0 },
+  watermarks: [{ namespace: "database.lsn", value: "snapshot-42" }],
+  vaultKeyAuthority: {
+    format: "kms-aead-vault-passphrase-v1",
+    generationId: VAULT_KEY_GENERATION_ID,
+    receiptDerivation: "elizaos.agent-vault-key.authority-receipt.v1",
+    receiptDigest: "f".repeat(64),
+  },
+  kms: {
+    provider: "local",
+    keyId: `org:${ORGANIZATION_ID}/dek/v1`,
+    keyVersion: 1,
+  },
+};
+
+const COMPONENTS = ["character", "database", "media", "state-files", "vault"] as const;
+
+function descriptor(name: (typeof COMPONENTS)[number]): AgentBackupCaptureV2ComponentDescriptor {
+  return {
+    name,
+    format: "synthetic-v1",
+    compression: "none",
+    contentKind: "opaque",
+    consistency: "transactional",
+  };
+}
+
+function frame(header: AgentBackupCaptureV2Frame["header"], payload = new Uint8Array(0)) {
+  return { header, payload, frameSha256: "0".repeat(64) } satisfies AgentBackupCaptureV2Frame;
+}
+
+async function* syntheticCapture(
+  totalPayloadBytes: number,
+): AsyncGenerator<AgentBackupCaptureV2Frame> {
+  let sequence = 0;
+  let dataFrameCount = 0;
+  let totalPlainBytes = 0;
+  yield frame({
+    format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+    schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+    sequence: sequence++,
+    kind: "capture-start",
+    operationId: OPERATION_ID,
+    agentId: AGENT_ID,
+    activationGeneration: ACTIVATION_ID,
+    lifecycleRevision: "42",
+    createdAt: "2026-08-15T10:00:01.000Z",
+    componentCount: COMPONENTS.length,
+    maxFramePayloadBytes: FRAME_BYTES,
+  });
+
+  const databaseBytes = Math.max(1, totalPayloadBytes - (COMPONENTS.length - 1));
+  for (const [componentIndex, name] of COMPONENTS.entries()) {
+    yield frame({
+      format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+      schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+      sequence: sequence++,
+      kind: "component-start",
+      componentIndex,
+      component: descriptor(name),
+    });
+    const componentBytes = name === "database" ? databaseBytes : 1;
+    const payloadHash = createHash("sha256");
+    let componentOffset = 0;
+    let componentFrames = 0;
+    while (componentOffset < componentBytes) {
+      const length = Math.min(FRAME_BYTES, componentBytes - componentOffset);
+      const payload = new Uint8Array(length);
+      payload.fill((componentIndex * 37 + componentFrames) & 0xff);
+      payloadHash.update(payload);
+      yield frame(
+        {
+          format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+          schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+          sequence: sequence++,
+          kind: "data",
+          componentIndex,
+          componentName: name,
+          dataIndex: componentFrames,
+          offsetBytes: componentOffset,
+          payloadBytes: payload.byteLength,
+        },
+        payload,
+      );
+      componentOffset += payload.byteLength;
+      componentFrames += 1;
+      dataFrameCount += 1;
+      totalPlainBytes += payload.byteLength;
+    }
+    yield frame({
+      format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+      schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+      sequence: sequence++,
+      kind: "component-end",
+      componentIndex,
+      componentName: name,
+      dataFrameCount: componentFrames,
+      plainBytes: componentBytes,
+      payloadSha256: payloadHash.digest("hex"),
+    });
+  }
+  yield frame({
+    format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+    schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+    sequence: sequence++,
+    kind: "capture-end",
+    componentCount: COMPONENTS.length,
+    dataFrameCount,
+    plainBytes: totalPlainBytes,
+    frameDigestChainSha256: "0".repeat(64),
+  });
+}
+
+function keyBundleProvider(): AgentBackupCaptureV3KeyBundleProvider {
+  return new KmsAeadOperationKeyBundleProvider(
+    new LocalKmsAdapter({ rootKey: new Uint8Array(32).fill(0xa5) }),
+  );
+}
+
+interface PublicationProbe {
+  boundary: AgentBackupCaptureV2PublicationBoundary;
+  recordCalls: AgentBackupCaptureV3Artifacts[];
+  uploaded: Map<string, { sha256: string; bytes: number }>;
+  maxRss: () => number;
+}
+
+function publicationProbe(options: { loseFirstUploadResponse?: boolean } = {}): PublicationProbe {
+  const recordCalls: AgentBackupCaptureV3Artifacts[] = [];
+  const uploaded = new Map<string, { sha256: string; bytes: number }>();
+  let lost = false;
+  let observedMaxRss = process.memoryUsage.rss();
+  return {
+    recordCalls,
+    uploaded,
+    maxRss: () => observedMaxRss,
+    boundary: {
+      async recordCaptured(input) {
+        recordCalls.push(input);
+        return true;
+      },
+      async uploadPrimary(input) {
+        observedMaxRss = Math.max(observedMaxRss, process.memoryUsage.rss());
+        const key = `${input.component}:${input.chunkIndex}`;
+        const observed = {
+          sha256: createHash("sha256").update(input.body).digest("hex"),
+          bytes: input.body.byteLength,
+        };
+        expect(observed.sha256).toBe(input.ciphertextSha256);
+        expect(observed.bytes).toBe(input.encryptedBytes);
+        const prior = uploaded.get(key);
+        if (prior) expect(observed).toEqual(prior);
+        uploaded.set(key, observed);
+        if (options.loseFirstUploadResponse && !lost) {
+          lost = true;
+          throw new Error("synthetic response loss after immutable PUT");
+        }
+        return true;
+      },
+    },
+  };
+}
+
+async function stateDirectory(): Promise<string> {
+  const created = await fs.promises.mkdtemp(
+    path.join(os.homedir(), ".eliza-capture-v2-spool-test-"),
+  );
+  return fs.promises.realpath(created);
+}
+
+async function removeStateDirectory(directory: string): Promise<void> {
+  await fs.promises.rm(directory, { recursive: true, force: true });
+}
+
+function testLockAuthority(
+  current: { value: AgentBackupCaptureV3SpoolProcessIdentity } = {
+    value: { linuxBootId: TEST_BOOT_ID, pid: 4242, processStartTime: "100" },
+  },
+): AgentBackupCaptureV3SpoolLockAuthority {
+  return {
+    async currentProcessIdentity() {
+      return { ...current.value };
+    },
+    async isProcessIdentityAlive(identity) {
+      return (
+        identity.linuxBootId === current.value.linuxBootId &&
+        identity.pid === current.value.pid &&
+        identity.processStartTime === current.value.processStartTime
+      );
+    },
+  };
+}
+
+function pipelineInput(
+  directory: string,
+  bytes: number,
+  publication: AgentBackupCaptureV2PublicationBoundary,
+  openCount: { value: number },
+) {
+  return {
+    request,
+    executionToken: EXECUTION_TOKEN,
+    authority,
+    openCapture() {
+      openCount.value += 1;
+      return syntheticCapture(bytes);
+    },
+    spool: {
+      stateDirectory: directory,
+      maxSpoolBytes: 700 * MIB,
+      minFreeBytes: 0,
+      lockAuthority: testLockAuthority(),
+    },
+    keyBundle: keyBundleProvider(),
+    publication,
+    heartbeat: () => true as const,
+    now: () => 1_000_000,
+  };
+}
+
+function directSpoolInput(executionToken: string) {
+  return {
+    operationId: OPERATION_ID,
+    executionToken,
+    requestSha256: "1".repeat(64),
+    authoritySha256: "2".repeat(64),
+  };
+}
+
+describe("runAgentBackupCaptureV2Pipeline", () => {
+  it("rejects incremental authority before opening capture or allocating a spool", async () => {
+    const directory = await stateDirectory();
+    const probe = publicationProbe();
+    const openCount = { value: 0 };
+    try {
+      const input = pipelineInput(directory, MIB, probe.boundary, openCount);
+      await expect(
+        runAgentBackupCaptureV2Pipeline({
+          ...input,
+          authority: {
+            ...input.authority,
+            chain: {
+              kind: "incremental",
+              baseOperationId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaab",
+              parentOperationId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaac",
+              depth: 1,
+            },
+          },
+        }),
+      ).rejects.toMatchObject({ code: "AGENT_BACKUP_V3_INCREMENTAL_CAPTURE_UNSUPPORTED" });
+      expect(openCount.value).toBe(0);
+      expect(await fs.promises.readdir(directory)).toEqual([]);
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("streams and publishes a real 10 MiB capture with explicit pending cleanup", async () => {
+    const directory = await stateDirectory();
+    const probe = publicationProbe();
+    const openCount = { value: 0 };
+    try {
+      const result = await runAgentBackupCaptureV2Pipeline(
+        pipelineInput(directory, 10 * MIB, probe.boundary, openCount),
+      );
+      expect(result.state).toBe("published-cleanup-pending");
+      expect(result.cleanup).toBe("pending");
+      expect(result.chunkCount).toBeGreaterThan(5);
+      expect(openCount.value).toBe(1);
+      expect(probe.recordCalls).toHaveLength(1);
+      expect(probe.uploaded.size).toBe(result.chunkCount);
+      expect(probe.recordCalls[0]?.manifest.components.map((entry) => entry.name)).toEqual([
+        "character",
+        "database",
+        "media",
+        "state-files",
+        "vault",
+      ]);
+      expect(await result.spool.cleanup()).toEqual({
+        operationId: OPERATION_ID,
+        status: "complete",
+      });
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  }, 30_000);
+
+  it("stops after durable recordCaptured without starting upload or permitting cleanup", async () => {
+    const directory = await stateDirectory();
+    const recordCalls: AgentBackupCaptureV3Artifacts[] = [];
+    const openCount = { value: 0 };
+    const publication = {
+      mode: "capture-only" as const,
+      async recordCaptured(input: AgentBackupCaptureV3Artifacts) {
+        recordCalls.push(input);
+        return true as const;
+      },
+    };
+    try {
+      const firstInput = pipelineInput(directory, 2 * MIB, publication, openCount);
+      const captured = await runAgentBackupCaptureV2Pipeline(firstInput);
+      expect(captured).toMatchObject({
+        state: "captured-upload-pending",
+        cleanup: "blocked-on-upload",
+      });
+      expect(captured.spool.phase).toBe("sealed");
+      expect(captured.spool.recordCaptured).toBe(true);
+      expect(captured.spool.chunks.every((chunk) => !captured.spool.isChunkUploaded(chunk))).toBe(
+        true,
+      );
+      expect(recordCalls).toHaveLength(1);
+      expect(recordCalls[0]?.manifest.schemaVersion).toBe(3);
+      expect(recordCalls[0]?.manifest.encryption.operationKeyBundle.wrapped.bytes).toBe(92);
+      expect(await captured.spool.cleanup()).toEqual({
+        operationId: OPERATION_ID,
+        status: "pending",
+      });
+
+      const publicationProbeAfterCapture = publicationProbe();
+      const resumed = await runAgentBackupCaptureV2Pipeline({
+        ...firstInput,
+        executionToken: NEXT_EXECUTION_TOKEN,
+        request: { ...firstInput.request, deadlineEpochMs: 2_500_000 },
+        publication: publicationProbeAfterCapture.boundary,
+      });
+      expect(resumed.state).toBe("published-cleanup-pending");
+      expect(openCount.value).toBe(1);
+      expect(recordCalls).toHaveLength(1);
+      expect(publicationProbeAfterCapture.recordCalls).toHaveLength(0);
+      expect(publicationProbeAfterCapture.uploaded.size).toBe(resumed.chunkCount);
+      await resumed.spool.cleanup();
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  }, 30_000);
+
+  it("rejects a byte-changed catalogue handoff before reopening publication", async () => {
+    const directory = await stateDirectory();
+    const openCount = { value: 0 };
+    const captureBoundary = {
+      mode: "capture-only" as const,
+      async recordCaptured() {
+        return true as const;
+      },
+    };
+    try {
+      const input = pipelineInput(directory, MIB, captureBoundary, openCount);
+      await runAgentBackupCaptureV2Pipeline(input);
+      const catalogPath = path.join(
+        directory,
+        "agent-backup-capture-v3",
+        OPERATION_ID,
+        "catalog-manifest.json",
+      );
+      const bytes = new Uint8Array(await fs.promises.readFile(catalogPath));
+      bytes[Math.floor(bytes.byteLength / 2)] ^= 1;
+      await fs.promises.writeFile(catalogPath, bytes);
+      await expect(
+        runAgentBackupCaptureV2Pipeline({
+          ...input,
+          executionToken: NEXT_EXECUTION_TOKEN,
+          publication: publicationProbe().boundary,
+        }),
+      ).rejects.toMatchObject({ code: "AGENT_BACKUP_V3_SPOOL_CATALOG_INVALID" });
+      expect(openCount.value).toBe(1);
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  }, 30_000);
+
+  it("rejects journal chunk metadata that differs from the sealed v3 manifest", async () => {
+    const directory = await stateDirectory();
+    const openCount = { value: 0 };
+    const captureBoundary = {
+      mode: "capture-only" as const,
+      async recordCaptured() {
+        return true as const;
+      },
+    };
+    try {
+      const input = pipelineInput(directory, MIB, captureBoundary, openCount);
+      await runAgentBackupCaptureV2Pipeline(input);
+      const journalPath = path.join(
+        directory,
+        "agent-backup-capture-v3",
+        OPERATION_ID,
+        "journal.json",
+      );
+      const journal = JSON.parse(await fs.promises.readFile(journalPath, "utf8")) as {
+        chunks: Array<{ ciphertextSha256: string }>;
+      };
+      const firstChunk = journal.chunks[0];
+      expect(firstChunk).toBeDefined();
+      if (firstChunk) firstChunk.ciphertextSha256 = "f".repeat(64);
+      await fs.promises.writeFile(journalPath, JSON.stringify(journal));
+
+      await expect(
+        runAgentBackupCaptureV2Pipeline({
+          ...input,
+          executionToken: NEXT_EXECUTION_TOKEN,
+          publication: publicationProbe().boundary,
+        }),
+      ).rejects.toMatchObject({ code: "AGENT_BACKUP_V3_SPOOL_INVENTORY_CONFLICT" });
+      expect(openCount.value).toBe(1);
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  }, 30_000);
+
+  it("adopts an exact ciphertext orphan after a crash before its journal commit", async () => {
+    const directory = await stateDirectory();
+    const openCount = { value: 0 };
+    const capturedArtifacts: AgentBackupCaptureV3Artifacts[] = [];
+    const captureBoundary = {
+      mode: "capture-only" as const,
+      async recordCaptured(artifacts: AgentBackupCaptureV3Artifacts) {
+        capturedArtifacts.push(artifacts);
+        return true as const;
+      },
+    };
+    try {
+      const input = pipelineInput(directory, 2 * MIB, captureBoundary, openCount);
+      const first = await runAgentBackupCaptureV2Pipeline(input);
+      expect(capturedArtifacts).toHaveLength(1);
+      const journalPath = path.join(
+        directory,
+        "agent-backup-capture-v3",
+        OPERATION_ID,
+        "journal.json",
+      );
+      const journal = JSON.parse(await fs.promises.readFile(journalPath, "utf8")) as {
+        phase: string;
+        chunks: Array<{ encryptedBytes: number; file: string }>;
+        manifest?: { bytes: number };
+        catalogManifest?: { bytes: number };
+        recordCaptured: string;
+        uploadedChunkKeys: string[];
+        committedBytes: number;
+      };
+      const orphan = journal.chunks.pop();
+      expect(orphan).toBeDefined();
+      expect(journal.manifest).toBeDefined();
+      expect(journal.catalogManifest).toBeDefined();
+      const orphanPath = path.join(
+        directory,
+        "agent-backup-capture-v3",
+        OPERATION_ID,
+        orphan?.file ?? "missing",
+      );
+      const orphanDigest = createHash("sha256")
+        .update(await fs.promises.readFile(orphanPath))
+        .digest("hex");
+      journal.committedBytes -=
+        (orphan?.encryptedBytes ?? 0) +
+        (journal.manifest?.bytes ?? 0) +
+        (journal.catalogManifest?.bytes ?? 0);
+      journal.phase = "capturing";
+      journal.recordCaptured = "pending";
+      journal.uploadedChunkKeys = [];
+      delete journal.manifest;
+      delete journal.catalogManifest;
+      await fs.promises.writeFile(journalPath, JSON.stringify(journal));
+
+      const publicationAfterCrash = publicationProbe();
+      const resumed = await runAgentBackupCaptureV2Pipeline({
+        ...input,
+        executionToken: NEXT_EXECUTION_TOKEN,
+        publication: publicationAfterCrash.boundary,
+      });
+      expect(resumed.manifestSha256).toBe(first.manifestSha256);
+      expect(resumed.chunkCount).toBe(first.chunkCount);
+      expect(openCount.value).toBe(2);
+      expect(publicationAfterCrash.uploaded.size).toBe(first.chunkCount);
+      expect(
+        createHash("sha256")
+          .update(await fs.promises.readFile(orphanPath))
+          .digest("hex"),
+      ).toBe(orphanDigest);
+      await resumed.spool.cleanup();
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  }, 30_000);
+
+  it("replays identical ciphertext and manifest after an upload response is lost", async () => {
+    const directory = await stateDirectory();
+    const probe = publicationProbe({ loseFirstUploadResponse: true });
+    const openCount = { value: 0 };
+    const input = pipelineInput(directory, 2 * MIB, probe.boundary, openCount);
+    try {
+      await expect(runAgentBackupCaptureV2Pipeline(input)).rejects.toThrow(
+        "synthetic response loss after immutable PUT",
+      );
+      const firstManifest = probe.recordCalls[0]?.catalogManifest;
+      const firstUpload = [...probe.uploaded.entries()][0];
+      const resumed = await runAgentBackupCaptureV2Pipeline({
+        ...input,
+        executionToken: NEXT_EXECUTION_TOKEN,
+      });
+      expect(openCount.value).toBe(1);
+      expect(probe.recordCalls).toHaveLength(1);
+      expect(probe.recordCalls[0]?.catalogManifest).toEqual(firstManifest);
+      expect([...probe.uploaded.entries()][0]).toEqual(firstUpload);
+      expect(resumed.state).toBe("published-cleanup-pending");
+      await resumed.spool.cleanup();
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  }, 30_000);
+
+  it("keeps RSS bounded while encrypting and publishing 128 MiB", async () => {
+    const directory = await stateDirectory();
+    const probe = publicationProbe();
+    const openCount = { value: 0 };
+    const baselineRss = process.memoryUsage.rss();
+    try {
+      const result = await runAgentBackupCaptureV2Pipeline(
+        pipelineInput(directory, 128 * MIB, probe.boundary, openCount),
+      );
+      expect(result.chunkCount).toBeGreaterThanOrEqual(32);
+      expect(probe.uploaded.size).toBe(result.chunkCount);
+      expect(probe.maxRss() - baselineRss).toBeLessThan(192 * MIB);
+      await result.spool.cleanup();
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  }, 120_000);
+
+  it("fails before capture when the lease heartbeat is not acknowledged", async () => {
+    const directory = await stateDirectory();
+    const probe = publicationProbe();
+    const openCount = { value: 0 };
+    try {
+      const input = pipelineInput(directory, MIB, probe.boundary, openCount);
+      await expect(
+        runAgentBackupCaptureV2Pipeline({ ...input, heartbeat: () => false as const }),
+      ).rejects.toMatchObject({ code: "AGENT_BACKUP_V2_PIPELINE_LEASE_LOST" });
+      expect(openCount.value).toBe(0);
+      expect(probe.recordCalls).toHaveLength(0);
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("honors abort before opening a capture source", async () => {
+    const directory = await stateDirectory();
+    const probe = publicationProbe();
+    const openCount = { value: 0 };
+    const controller = new AbortController();
+    controller.abort(new Error("lease execution superseded"));
+    try {
+      const input = pipelineInput(directory, MIB, probe.boundary, openCount);
+      await expect(
+        runAgentBackupCaptureV2Pipeline({ ...input, signal: controller.signal }),
+      ).rejects.toMatchObject({ code: "AGENT_BACKUP_V2_PIPELINE_ABORTED" });
+      expect(openCount.value).toBe(0);
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("cancels a stuck capture read, bounds close, and erases late ingress", async () => {
+    const directory = await stateDirectory();
+    const probe = publicationProbe();
+    const openCount = { value: 0 };
+    const controller = new AbortController();
+    const latePayload = new Uint8Array(64).fill(0x5a);
+    let resolveNext: ((result: IteratorResult<AgentBackupCaptureV2Frame>) => void) | undefined;
+    let notifyReadStarted: (() => void) | undefined;
+    const readStarted = new Promise<void>((resolve) => {
+      notifyReadStarted = resolve;
+    });
+    let returnCalls = 0;
+    try {
+      const input = pipelineInput(directory, MIB, probe.boundary, openCount);
+      const running = runAgentBackupCaptureV2Pipeline({
+        ...input,
+        signal: controller.signal,
+        openCapture() {
+          openCount.value += 1;
+          return {
+            [Symbol.asyncIterator]() {
+              return {
+                next: () => {
+                  notifyReadStarted?.();
+                  return new Promise<IteratorResult<AgentBackupCaptureV2Frame>>((resolve) => {
+                    resolveNext = resolve;
+                  });
+                },
+                return: () => {
+                  returnCalls += 1;
+                  return new Promise<IteratorResult<AgentBackupCaptureV2Frame>>(() => undefined);
+                },
+              };
+            },
+          };
+        },
+      });
+      await readStarted;
+      const started = Date.now();
+      controller.abort(new Error("capture lease superseded"));
+      await expect(running).rejects.toMatchObject({
+        code: "AGENT_BACKUP_V2_PIPELINE_ABORTED",
+      });
+      expect(Date.now() - started).toBeLessThan(1_000);
+      expect(returnCalls).toBe(1);
+      expect(resolveNext).toBeDefined();
+      resolveNext?.({
+        done: false,
+        value: frame(
+          {
+            format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+            schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+            sequence: 1,
+            kind: "data",
+            componentIndex: 0,
+            componentName: "database",
+            dataIndex: 0,
+            offsetBytes: 0,
+            payloadBytes: latePayload.byteLength,
+          },
+          latePayload,
+        ),
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(latePayload.every((byte) => byte === 0)).toBe(true);
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("does not let a stuck capture read outlive the operation deadline", async () => {
+    const directory = await stateDirectory();
+    const probe = publicationProbe();
+    const openCount = { value: 0 };
+    let returnCalls = 0;
+    try {
+      const input = pipelineInput(directory, MIB, probe.boundary, openCount);
+      await expect(
+        runAgentBackupCaptureV2Pipeline({
+          ...input,
+          request: { ...input.request, deadlineEpochMs: 1_000_250 },
+          openCapture() {
+            openCount.value += 1;
+            return {
+              [Symbol.asyncIterator]() {
+                return {
+                  next: () =>
+                    new Promise<IteratorResult<AgentBackupCaptureV2Frame>>(() => undefined),
+                  return: async () => {
+                    returnCalls += 1;
+                    return { done: true as const, value: undefined };
+                  },
+                };
+              },
+            };
+          },
+        }),
+      ).rejects.toMatchObject({
+        code: "AGENT_BACKUP_V2_PIPELINE_DEADLINE_EXCEEDED",
+      });
+      expect(openCount.value).toBe(1);
+      expect(returnCalls).toBe(1);
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("releases and erases a key bundle returned after cancellation", async () => {
+    const directory = await stateDirectory();
+    const probe = publicationProbe();
+    const openCount = { value: 0 };
+    const controller = new AbortController();
+    const base = keyBundleProvider();
+    let unblock: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      unblock = resolve;
+    });
+    let notifyAcquired: (() => void) | undefined;
+    const acquired = new Promise<void>((resolve) => {
+      notifyAcquired = resolve;
+    });
+    let notifyReleased: (() => void) | undefined;
+    const released = new Promise<void>((resolve) => {
+      notifyReleased = resolve;
+    });
+    const observed: Uint8Array[] = [];
+    const provider: AgentBackupCaptureV3KeyBundleProvider = {
+      async acquire(input) {
+        const result = await base.acquire(input);
+        observed.push(result.handle.dek, result.handle.contentHmacKey);
+        notifyAcquired?.();
+        await gate;
+        return result;
+      },
+      unwrap: (input) => base.unwrap(input),
+      release(handle) {
+        const result = base.release(handle);
+        notifyReleased?.();
+        return result;
+      },
+    };
+    try {
+      const input = pipelineInput(directory, MIB, probe.boundary, openCount);
+      const running = runAgentBackupCaptureV2Pipeline({
+        ...input,
+        signal: controller.signal,
+        keyBundle: provider,
+      });
+      await acquired;
+      controller.abort(new Error("cancel delayed KMS response"));
+      await expect(running).rejects.toMatchObject({
+        code: "AGENT_BACKUP_V2_PIPELINE_ABORTED",
+      });
+      expect(observed).toHaveLength(2);
+      expect(observed.some((view) => view.some((byte) => byte !== 0))).toBe(true);
+      unblock?.();
+      await released;
+      for (const view of observed) expect(view.every((byte) => byte === 0)).toBe(true);
+      expect(openCount.value).toBe(0);
+    } finally {
+      unblock?.();
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("rejects a tampered fresh key-bundle envelope and zeroizes its handle", async () => {
+    const directory = await stateDirectory();
+    const probe = publicationProbe();
+    const openCount = { value: 0 };
+    const base = keyBundleProvider();
+    const observed: Uint8Array[] = [];
+    const observedEnvelopes: Uint8Array[] = [];
+    const provider: AgentBackupCaptureV3KeyBundleProvider = {
+      async acquire(input) {
+        const acquired = await base.acquire(input);
+        observed.push(acquired.handle.dek, acquired.handle.contentHmacKey);
+        observedEnvelopes.push(acquired.wrapped.wrappedKeyBundle);
+        acquired.wrapped.wrappedKeyBundle[0] ^= 0xff;
+        return acquired;
+      },
+      unwrap: (input) => base.unwrap(input),
+      release: (handle) => base.release(handle),
+    };
+    try {
+      const input = pipelineInput(directory, MIB, probe.boundary, openCount);
+      await expect(
+        runAgentBackupCaptureV2Pipeline({ ...input, keyBundle: provider }),
+      ).rejects.toMatchObject({
+        code: "AGENT_BACKUP_V3_KEY_BUNDLE_ENVELOPE_INVALID",
+      });
+      expect(openCount.value).toBe(0);
+      expect(observed).toHaveLength(2);
+      for (const key of observed) expect(key.every((byte) => byte === 0)).toBe(true);
+      expect(observedEnvelopes).toHaveLength(1);
+      expect(observedEnvelopes[0]?.every((byte) => byte === 0)).toBe(true);
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("recomputes the local key-bundle receipt before persisting the envelope", async () => {
+    const directory = await stateDirectory();
+    const probe = publicationProbe();
+    const openCount = { value: 0 };
+    const base = keyBundleProvider();
+    const observed: Uint8Array[] = [];
+    const provider: AgentBackupCaptureV3KeyBundleProvider = {
+      async acquire(input) {
+        const acquired = await base.acquire(input);
+        observed.push(
+          acquired.handle.dek,
+          acquired.handle.contentHmacKey,
+          acquired.wrapped.wrappedKeyBundle,
+        );
+        return {
+          ...acquired,
+          wrapped: { ...acquired.wrapped, localReceiptDigest: "f".repeat(64) },
+        };
+      },
+      unwrap: (input) => base.unwrap(input),
+      release: (handle) => base.release(handle),
+    };
+    try {
+      const input = pipelineInput(directory, MIB, probe.boundary, openCount);
+      await expect(
+        runAgentBackupCaptureV2Pipeline({ ...input, keyBundle: provider }),
+      ).rejects.toMatchObject({ code: "AGENT_BACKUP_V3_KEY_BUNDLE_RECEIPT_INVALID" });
+      expect(openCount.value).toBe(0);
+      expect(observed).toHaveLength(3);
+      for (const bytes of observed) expect(bytes.every((byte) => byte === 0)).toBe(true);
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("zeroizes fresh and crash-replayed operation key bundles", async () => {
+    const directory = await stateDirectory();
+    const probe = publicationProbe();
+    const openCount = { value: 0 };
+    const base = keyBundleProvider();
+    const observed: Uint8Array[] = [];
+    const provider: AgentBackupCaptureV3KeyBundleProvider = {
+      async acquire(input) {
+        const acquired = await base.acquire(input);
+        observed.push(acquired.handle.dek, acquired.handle.contentHmacKey);
+        return acquired;
+      },
+      async unwrap(input) {
+        const handle = await base.unwrap(input);
+        observed.push(handle.dek, handle.contentHmacKey);
+        return handle;
+      },
+      release: (handle) => base.release(handle),
+    };
+    try {
+      const input = pipelineInput(directory, MIB, probe.boundary, openCount);
+      await expect(
+        runAgentBackupCaptureV2Pipeline({
+          ...input,
+          keyBundle: provider,
+          async *openCapture() {
+            openCount.value += 1;
+            yield frame({
+              format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+              schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+              sequence: 0,
+              kind: "capture-start",
+              operationId: OPERATION_ID,
+              agentId: AGENT_ID,
+              activationGeneration: ACTIVATION_ID,
+              lifecycleRevision: "42",
+              createdAt: "2026-08-15T10:00:01.000Z",
+              componentCount: COMPONENTS.length,
+              maxFramePayloadBytes: FRAME_BYTES,
+            });
+            throw new Error("synthetic capture crash");
+          },
+        }),
+      ).rejects.toThrow("synthetic capture crash");
+      const resumed = await runAgentBackupCaptureV2Pipeline({
+        ...input,
+        executionToken: NEXT_EXECUTION_TOKEN,
+        keyBundle: provider,
+      });
+      expect(resumed.state).toBe("published-cleanup-pending");
+      expect(observed).toHaveLength(4);
+      for (const key of observed) expect(key.every((byte) => byte === 0)).toBe(true);
+      await resumed.spool.cleanup();
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("zeroizes both key slices even when provider release throws", async () => {
+    const directory = await stateDirectory();
+    const probe = publicationProbe();
+    const openCount = { value: 0 };
+    const base = keyBundleProvider();
+    const observed: Uint8Array[] = [];
+    const provider: AgentBackupCaptureV3KeyBundleProvider = {
+      async acquire(input) {
+        const acquired = await base.acquire(input);
+        observed.push(acquired.handle.dek, acquired.handle.contentHmacKey);
+        return acquired;
+      },
+      unwrap: (input) => base.unwrap(input),
+      release(handle: KmsAeadOperationKeyBundleHandle) {
+        base.release(handle);
+        throw new Error("synthetic key-bundle release failure");
+      },
+    };
+    try {
+      const input = pipelineInput(directory, MIB, probe.boundary, openCount);
+      await expect(
+        runAgentBackupCaptureV2Pipeline({ ...input, keyBundle: provider }),
+      ).rejects.toThrow("synthetic key-bundle release failure");
+      expect(observed).toHaveLength(2);
+      for (const key of observed) expect(key.every((byte) => byte === 0)).toBe(true);
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("rejects a StateDirectory inside the system temporary tree", async () => {
+    const created = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "eliza-capture-v2-spool-rejected-"),
+    );
+    const directory = await fs.promises.realpath(created);
+    const probe = publicationProbe();
+    const openCount = { value: 0 };
+    try {
+      await expect(
+        runAgentBackupCaptureV2Pipeline(pipelineInput(directory, MIB, probe.boundary, openCount)),
+      ).rejects.toMatchObject({
+        code: "AGENT_BACKUP_V2_SPOOL_STATE_DIRECTORY_TEMPORARY",
+      });
+      expect(openCount.value).toBe(0);
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("rejects an operation that would exceed its durable spool quota", async () => {
+    const directory = await stateDirectory();
+    const probe = publicationProbe();
+    const openCount = { value: 0 };
+    try {
+      const input = pipelineInput(directory, 2 * MIB, probe.boundary, openCount);
+      await expect(
+        runAgentBackupCaptureV2Pipeline({
+          ...input,
+          spool: { ...input.spool, maxSpoolBytes: 512 * 1024 },
+        }),
+      ).rejects.toMatchObject({ code: "AGENT_BACKUP_V2_SPOOL_QUOTA_EXCEEDED" });
+      expect(probe.recordCalls).toHaveLength(0);
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("returns cleanup pending when deletion and parent fsync cannot be proven", async () => {
+    const directory = await stateDirectory();
+    const probe = publicationProbe();
+    const openCount = { value: 0 };
+    try {
+      const result = await runAgentBackupCaptureV2Pipeline(
+        pipelineInput(directory, MIB, probe.boundary, openCount),
+      );
+      await fs.promises.mkdir(path.join(result.spool.operationDirectory, "unexpected-directory"));
+      expect(await result.spool.cleanup()).toEqual({
+        operationId: OPERATION_ID,
+        status: "pending",
+      });
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+});
+
+describe("AgentBackupCaptureV3Spool execution fencing", () => {
+  it("quarantines a legacy v2 spool without mutating or promoting it", async () => {
+    const directory = await stateDirectory();
+    const legacyOperation = path.join(directory, "agent-backup-capture-v2", OPERATION_ID);
+    const legacyJournal = JSON.stringify({
+      format: "elizaos.agent-backup.capture-v2-spool",
+      version: 2,
+      operationId: OPERATION_ID,
+    });
+    try {
+      await fs.promises.mkdir(legacyOperation, { recursive: true });
+      await fs.promises.writeFile(path.join(legacyOperation, "journal.json"), legacyJournal);
+      await expect(
+        AgentBackupCaptureV3Spool.open(
+          {
+            stateDirectory: directory,
+            maxSpoolBytes: 8 * MIB,
+            minFreeBytes: 0,
+            lockAuthority: testLockAuthority(),
+          },
+          directSpoolInput(EXECUTION_TOKEN),
+        ),
+      ).rejects.toMatchObject({
+        code: "AGENT_BACKUP_V3_LEGACY_SPOOL_QUARANTINED",
+      });
+      expect(await fs.promises.readFile(path.join(legacyOperation, "journal.json"), "utf8")).toBe(
+        legacyJournal,
+      );
+      await expect(
+        fs.promises.lstat(path.join(directory, "agent-backup-capture-v3", OPERATION_ID)),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("never steals an old lock from a live process and hands off only after close", async () => {
+    const directory = await stateDirectory();
+    const lockAuthority = testLockAuthority();
+    const config = {
+      stateDirectory: directory,
+      maxSpoolBytes: 8 * MIB,
+      minFreeBytes: 0,
+      lockAuthority,
+    };
+    let first: AgentBackupCaptureV3Spool | undefined;
+    let second: AgentBackupCaptureV3Spool | undefined;
+    try {
+      first = await AgentBackupCaptureV3Spool.open(config, directSpoolInput(EXECUTION_TOKEN));
+      const ownerPath = path.join(first.namespaceDirectory, `.${OPERATION_ID}.lock`, "owner.json");
+      expect(JSON.parse(await fs.promises.readFile(ownerPath, "utf8"))).toMatchObject({
+        executionToken: EXECUTION_TOKEN,
+      });
+      await fs.promises.utimes(ownerPath, new Date(0), new Date(0));
+      await expect(
+        AgentBackupCaptureV3Spool.open(config, directSpoolInput(NEXT_EXECUTION_TOKEN)),
+      ).rejects.toMatchObject({ code: "AGENT_BACKUP_V2_SPOOL_LOCKED" });
+
+      await first.close();
+      const temporary = path.join(first.operationDirectory, `.journal.json.${"a".repeat(24)}.tmp`);
+      await fs.promises.writeFile(temporary, "abandoned");
+      second = await AgentBackupCaptureV3Spool.open(config, directSpoolInput(NEXT_EXECUTION_TOKEN));
+      expect(JSON.parse(await fs.promises.readFile(ownerPath, "utf8"))).toMatchObject({
+        executionToken: NEXT_EXECUTION_TOKEN,
+      });
+      await expect(fs.promises.lstat(temporary)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(first.markPublishing()).rejects.toMatchObject({
+        code: "AGENT_BACKUP_V2_SPOOL_CLOSED",
+      });
+      expect(await second.cleanup()).toEqual({
+        operationId: OPERATION_ID,
+        status: "complete",
+      });
+    } finally {
+      await first?.close();
+      await second?.close();
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("reclaims a PID-reused owner and fences the stale writer", async () => {
+    const directory = await stateDirectory();
+    const current = {
+      value: {
+        linuxBootId: TEST_BOOT_ID,
+        pid: 4242,
+        processStartTime: "100",
+      },
+    };
+    const config = {
+      stateDirectory: directory,
+      maxSpoolBytes: 8 * MIB,
+      minFreeBytes: 0,
+      lockAuthority: testLockAuthority(current),
+    };
+    let stale: AgentBackupCaptureV3Spool | undefined;
+    let successor: AgentBackupCaptureV3Spool | undefined;
+    try {
+      stale = await AgentBackupCaptureV3Spool.open(config, directSpoolInput(EXECUTION_TOKEN));
+      current.value = { ...current.value, processStartTime: "200" };
+      successor = await AgentBackupCaptureV3Spool.open(
+        config,
+        directSpoolInput(NEXT_EXECUTION_TOKEN),
+      );
+      await expect(stale.markPublishing()).rejects.toMatchObject({
+        code: "AGENT_BACKUP_V2_SPOOL_LOCK_LOST",
+      });
+      expect(await successor.cleanup()).toEqual({
+        operationId: OPERATION_ID,
+        status: "complete",
+      });
+    } finally {
+      await stale?.close();
+      await successor?.close();
+      await removeStateDirectory(directory);
+    }
+  });
+
+  it("fails closed when exact owner liveness cannot be inspected", async () => {
+    const directory = await stateDirectory();
+    const firstAuthority = testLockAuthority();
+    const config = {
+      stateDirectory: directory,
+      maxSpoolBytes: 8 * MIB,
+      minFreeBytes: 0,
+      lockAuthority: firstAuthority,
+    };
+    let first: AgentBackupCaptureV3Spool | undefined;
+    try {
+      first = await AgentBackupCaptureV3Spool.open(config, directSpoolInput(EXECUTION_TOKEN));
+      await expect(
+        AgentBackupCaptureV3Spool.open(
+          {
+            ...config,
+            lockAuthority: {
+              async currentProcessIdentity() {
+                return {
+                  linuxBootId: TEST_BOOT_ID,
+                  pid: 5252,
+                  processStartTime: "200",
+                };
+              },
+              async isProcessIdentityAlive() {
+                throw Object.assign(new Error("synthetic /proc permission failure"), {
+                  code: "EACCES",
+                });
+              },
+            },
+          },
+          directSpoolInput(NEXT_EXECUTION_TOKEN),
+        ),
+      ).rejects.toMatchObject({
+        code: "AGENT_BACKUP_V2_SPOOL_LOCK_LIVENESS_UNPROVABLE",
+      });
+      await expect(first.markPublishing()).rejects.toMatchObject({
+        code: "AGENT_BACKUP_V2_SPOOL_MANIFEST_MISSING",
+      });
+    } finally {
+      await first?.close();
+      await removeStateDirectory(directory);
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-pipeline.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-pipeline.ts
@@ -1,0 +1,1940 @@
+/**
+ * Fail-closed capture-v2 composer. It converts authenticated agent frames into
+ * provider-neutral record-stream plaintext, bounded AES-GCM ciphertext chunks,
+ * and a canonical manifest-v3 backed by one operation KMS key bundle. No
+ * database, storage credential, or infrastructure provider is assumed.
+ */
+
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  createHmac,
+  randomBytes,
+  randomUUID,
+} from "node:crypto";
+import {
+  computeKmsAeadOperationKeyBundleLocalReceiptDigest,
+  KMS_AEAD_OPERATION_KEY_BUNDLE_LOCAL_RECEIPT_DERIVATION,
+  KMS_AEAD_OPERATION_KEY_BUNDLE_V1,
+  type KmsAeadOperationKeyBundleHandle,
+  type KmsAeadOperationKeyBundleProvider,
+  type KmsAeadOperationKeyBundleWrapped,
+} from "@elizaos/core/security/kms";
+import {
+  AGENT_BACKUP_CHUNK_ENVELOPE_V1,
+  AGENT_BACKUP_MANIFEST_FORMAT,
+  AGENT_BACKUP_MANIFEST_V2_LIMITS,
+  AGENT_BACKUP_MANIFEST_V3_SCHEMA_VERSION,
+  AGENT_BACKUP_OPERATION_CONTENT_HMAC_DERIVATION,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_CONTEXT_DERIVATION,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_LOCAL_RECEIPT_DERIVATION,
+  AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1,
+  AGENT_BACKUP_PAYLOAD_DIGEST_DERIVATION,
+  AGENT_BACKUP_RECORD_STREAM_V1_FORMAT,
+  type AgentBackupCaptureV2ComponentDescriptor,
+  type AgentBackupCaptureV2Frame,
+  type AgentBackupCaptureV2Request,
+  type AgentBackupManifestV3,
+  type AgentBackupManifestV3Draft,
+  type AgentBackupManifestV3KmsProvider,
+  canonicalizeAgentBackupChunkAad,
+  canonicalizeAgentBackupManifestV3,
+  canonicalizeAgentBackupOperationKeyBundleContext,
+  computeAgentBackupChunkAadDigest,
+  createAgentBackupManifestV3,
+  parseAgentBackupCaptureV2Request,
+  parseAgentBackupManifestV3,
+  serializeAgentBackupRecordStreamV1Magic,
+  serializeAgentBackupRecordStreamV1Record,
+} from "@elizaos/shared";
+import {
+  AgentBackupCaptureV3Spool,
+  type AgentBackupCaptureV3SpoolChunk,
+  type AgentBackupCaptureV3SpoolConfig,
+} from "./agent-backup-capture-v2-spool";
+
+const DEFAULT_CHUNK_PLAIN_BYTES = 4 * 1024 * 1024;
+const MIN_CHUNK_PLAIN_BYTES = 256 * 1024;
+const MAX_HEARTBEAT_BYTES = 4 * 1024 * 1024;
+const HEX_SHA256_PATTERN = /^[0-9a-f]{64}$/;
+
+export interface AgentBackupCaptureV3ManifestAuthority {
+  /** Durable reservation time, reused byte-for-byte across retries. */
+  createdAt: string;
+  organizationId: string;
+  source: AgentBackupManifestV3["source"];
+  runtime: AgentBackupManifestV3["runtime"];
+  chain: AgentBackupManifestV3["chain"];
+  watermarks: AgentBackupManifestV3["watermarks"];
+  vaultKeyAuthority: AgentBackupManifestV3["vaultKeyAuthority"];
+  kms: {
+    provider: AgentBackupManifestV3KmsProvider;
+    keyId: string;
+    keyVersion: number;
+  };
+}
+
+export interface AgentBackupCaptureV2DigestStream {
+  update(bytes: Uint8Array): void | Promise<void>;
+  digestHex(): string | Promise<string>;
+}
+
+export type AgentBackupCaptureV3KeyBundleProvider = Pick<
+  KmsAeadOperationKeyBundleProvider,
+  "acquire" | "unwrap" | "release"
+>;
+
+export interface AgentBackupCaptureV3CatalogManifest {
+  canonicalManifestDraft: string;
+  format: typeof AGENT_BACKUP_MANIFEST_FORMAT;
+  version: typeof AGENT_BACKUP_MANIFEST_V3_SCHEMA_VERSION;
+  digest: string;
+  objectCount: number;
+  objectInventoryDigest: string;
+  imageDigest: string;
+  databaseSchemaVersion: string;
+  pluginSetDigest: string;
+  watermarkDigest: string;
+  rawSizeBytes: number;
+  compressedSizeBytes: number;
+  encryptedSizeBytes: number;
+  kmsKeyId: string;
+  kmsKeyVersion: number;
+  /** Bounded KMS envelope only; capture payloads are never base64 encoded. */
+  wrappedKeyBundleCiphertextBase64: string;
+  wrappedKeyBundleSha256: string;
+  wrappedKeyBundleLocalReceiptDigest: string;
+  wrappedKeyBundleGenerationId: string;
+  vaultKeyGenerationId: string;
+  vaultKeyAuthorityReceiptDigest: string;
+}
+
+export interface AgentBackupCaptureV3Artifacts {
+  manifest: AgentBackupManifestV3;
+  catalogManifest: AgentBackupCaptureV3CatalogManifest;
+  wrappedKeyBundle: Uint8Array;
+  chunks: readonly AgentBackupCaptureV3SpoolChunk[];
+}
+
+interface AgentBackupCaptureV2CatalogBoundary {
+  recordCaptured(input: AgentBackupCaptureV3Artifacts): Promise<true>;
+}
+
+export interface AgentBackupCaptureV2CaptureOnlyBoundary
+  extends AgentBackupCaptureV2CatalogBoundary {
+  /** Persist the captured manifest, but leave every ciphertext chunk in the spool. */
+  mode: "capture-only";
+}
+
+export interface AgentBackupCaptureV2UploadBoundary extends AgentBackupCaptureV2CatalogBoundary {
+  /** Omitted for backwards compatibility with the original publish pipeline. */
+  mode?: "capture-and-upload";
+  uploadPrimary(input: {
+    operationId: string;
+    manifestSha256: string;
+    component: string;
+    chunkIndex: number;
+    contentHmacSha256: string;
+    ciphertextSha256: string;
+    encryptedBytes: number;
+    body: Uint8Array;
+  }): Promise<true>;
+}
+
+export type AgentBackupCaptureV2PublicationBoundary =
+  | AgentBackupCaptureV2CaptureOnlyBoundary
+  | AgentBackupCaptureV2UploadBoundary;
+
+export interface RunAgentBackupCaptureV2PipelineInput {
+  request: AgentBackupCaptureV2Request;
+  /** Durable job execution fence bound to exclusive spool ownership. */
+  executionToken: string;
+  authority: AgentBackupCaptureV3ManifestAuthority;
+  /** Opens a fresh authenticated HTTP framed stream for initial/partial replay. */
+  openCapture(signal?: AbortSignal): AsyncIterable<AgentBackupCaptureV2Frame>;
+  spool: AgentBackupCaptureV3SpoolConfig;
+  keyBundle: AgentBackupCaptureV3KeyBundleProvider;
+  publication: AgentBackupCaptureV2PublicationBoundary;
+  /** Lease callback must return true for the same operation execution fence. */
+  heartbeat(): true | Promise<true>;
+  signal?: AbortSignal;
+  now?: () => number;
+  chunkPlainBytes?: number;
+}
+
+interface AgentBackupCaptureV2PipelineResultBase {
+  operationId: string;
+  manifestSha256: string;
+  chunkCount: number;
+  /** Capture-only returns this handle closed; publication must reopen it. */
+  spool: AgentBackupCaptureV3Spool;
+}
+
+export type AgentBackupCaptureV2PipelineResult =
+  | (AgentBackupCaptureV2PipelineResultBase & {
+      state: "captured-upload-pending";
+      /** The spool is the only ciphertext copy and must not be cleaned yet. */
+      cleanup: "blocked-on-upload";
+    })
+  | (AgentBackupCaptureV2PipelineResultBase & {
+      state: "published-cleanup-pending";
+      cleanup: "pending";
+    });
+
+export class AgentBackupCaptureV2PipelineError extends Error {
+  override readonly name = "AgentBackupCaptureV2PipelineError";
+
+  constructor(
+    readonly code: string,
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(message, { cause: options?.cause });
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+function pipelineError(code: string, message: string, cause?: unknown): never {
+  throw new AgentBackupCaptureV2PipelineError(code, message, { cause });
+}
+
+async function releaseAndZeroizeKeyBundle(
+  provider: AgentBackupCaptureV3KeyBundleProvider,
+  handle: KmsAeadOperationKeyBundleHandle,
+  keyViews: Readonly<{
+    dek: Uint8Array;
+    contentHmacKey: Uint8Array;
+  }>,
+): Promise<void> {
+  let releaseFailure: unknown;
+  try {
+    if (provider.release(handle) !== true || !handle.released) {
+      releaseFailure = new AgentBackupCaptureV2PipelineError(
+        "AGENT_BACKUP_V3_KEY_BUNDLE_RELEASE_UNCONFIRMED",
+        "KMS provider did not acknowledge operation key-bundle release",
+      );
+    }
+  } catch (cause) {
+    // error-policy:J3 release is mandatory and its failure remains observable.
+    releaseFailure = cause;
+  } finally {
+    // The two views cover the exact 64-byte bundle, so local zeroization still
+    // succeeds even if a non-conforming provider throws before erasing it.
+    keyViews.dek.fill(0);
+    keyViews.contentHmacKey.fill(0);
+  }
+  if (releaseFailure !== undefined) throw releaseFailure;
+}
+
+function observableKeyBundleViews(handle: unknown): Uint8Array[] {
+  const views: Uint8Array[] = [];
+  if (!handle || typeof handle !== "object") return views;
+  try {
+    const dek = (handle as { dek?: unknown }).dek;
+    if (dek instanceof Uint8Array) views.push(dek);
+  } catch (_invalidHandle: unknown) {
+    // error-policy:J5 continue to the other independently observable view.
+  }
+  try {
+    const contentHmacKey = (handle as { contentHmacKey?: unknown }).contentHmacKey;
+    if (contentHmacKey instanceof Uint8Array && !views.includes(contentHmacKey)) {
+      views.push(contentHmacKey);
+    }
+  } catch (_invalidHandle: unknown) {
+    // error-policy:J5 release and erase every other observable view.
+  }
+  return views;
+}
+
+function releaseInvalidKeyBundleHandle(
+  provider: AgentBackupCaptureV3KeyBundleProvider,
+  handle: KmsAeadOperationKeyBundleHandle,
+): void {
+  const views = observableKeyBundleViews(handle);
+  let releaseFailure: unknown;
+  try {
+    if (provider.release(handle) !== true || !handle.released) {
+      releaseFailure = new AgentBackupCaptureV2PipelineError(
+        "AGENT_BACKUP_V3_KEY_BUNDLE_RELEASE_UNCONFIRMED",
+        "KMS provider did not acknowledge invalid operation key-bundle release",
+      );
+    }
+  } catch (cause) {
+    releaseFailure = cause;
+  } finally {
+    for (const view of views) view.fill(0);
+  }
+  if (releaseFailure !== undefined) throw releaseFailure;
+}
+
+function sha256Hex(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.byteLength !== right.byteLength) return false;
+  let difference = 0;
+  for (let index = 0; index < left.byteLength; index += 1) {
+    difference |= (left[index] ?? 0) ^ (right[index] ?? 0);
+  }
+  return difference === 0;
+}
+
+function compareCanonicalComponentNames(left: string, right: string): number {
+  if (left === right) return 0;
+  return left < right ? -1 : 1;
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value < 0 || Object.is(value, -0)) {
+      pipelineError(
+        "AGENT_BACKUP_V2_AUTHORITY_INVALID",
+        "Backup authority contains a non-canonical number",
+      );
+    }
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalJson(entry)).join(",")}]`;
+  }
+  if (typeof value !== "object" || value === undefined) {
+    pipelineError(
+      "AGENT_BACKUP_V2_AUTHORITY_INVALID",
+      "Backup authority contains a non-JSON value",
+    );
+  }
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+    .join(",")}}`;
+}
+
+/** Exact durable catalogue-handoff bytes shared by capture and replay repair. */
+export function canonicalAgentBackupCaptureV3CatalogManifestBytes(
+  manifest: Readonly<AgentBackupCaptureV3CatalogManifest>,
+): Uint8Array {
+  return new TextEncoder().encode(canonicalJson(manifest));
+}
+
+function digestCanonical(value: unknown): string {
+  return sha256Hex(new TextEncoder().encode(canonicalJson(value)));
+}
+
+/**
+ * Immutable filesystem-spool authority shared by capture and post-capture
+ * publication. The HTTP deadline is deliberately absent so a fresh catalogue
+ * execution can reopen an interrupted operation without weakening its fence.
+ */
+export function deriveAgentBackupCaptureV3SpoolAuthorityDigests(params: {
+  request: Pick<
+    AgentBackupCaptureV2Request,
+    | "format"
+    | "schemaVersion"
+    | "operationId"
+    | "agentId"
+    | "activationGeneration"
+    | "lifecycleRevision"
+  >;
+  authority: Readonly<AgentBackupCaptureV3ManifestAuthority>;
+}): { requestSha256: string; authoritySha256: string } {
+  return {
+    requestSha256: digestCanonical({
+      format: params.request.format,
+      schemaVersion: params.request.schemaVersion,
+      operationId: params.request.operationId,
+      agentId: params.request.agentId,
+      activationGeneration: params.request.activationGeneration,
+      lifecycleRevision: params.request.lifecycleRevision,
+    }),
+    authoritySha256: digestCanonical(params.authority),
+  };
+}
+
+function uint64BigEndian(value: number): Uint8Array {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    pipelineError(
+      "AGENT_BACKUP_V2_BYTE_ACCOUNTING_INVALID",
+      "Backup byte accounting exceeded its safe range",
+    );
+  }
+  const result = new Uint8Array(8);
+  new DataView(result.buffer).setBigUint64(0, BigInt(value), false);
+  return result;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let output = "";
+  for (const byte of bytes) output += byte.toString(16).padStart(2, "0");
+  return output;
+}
+
+function boundedBase64(bytes: Uint8Array): string {
+  if (bytes.byteLength > AGENT_BACKUP_MANIFEST_V2_LIMITS.maxWrappedDekBytes) {
+    pipelineError(
+      "AGENT_BACKUP_V3_KEY_BUNDLE_TOO_LARGE",
+      "Wrapped operation key bundle exceeds the manifest envelope bound",
+    );
+  }
+  return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString("base64");
+}
+
+async function updateDigest(
+  stream: AgentBackupCaptureV2DigestStream,
+  bytes: Uint8Array,
+): Promise<void> {
+  await stream.update(bytes);
+}
+
+async function finishDigest(stream: AgentBackupCaptureV2DigestStream): Promise<string> {
+  const digest = await stream.digestHex();
+  if (!HEX_SHA256_PATTERN.test(digest)) {
+    pipelineError(
+      "AGENT_BACKUP_V2_HMAC_PROVIDER_INVALID",
+      "Content HMAC provider returned a non-SHA-256 digest",
+    );
+  }
+  return digest;
+}
+
+function createContentHmac(key: Uint8Array): AgentBackupCaptureV2DigestStream {
+  if (!(key instanceof Uint8Array) || key.byteLength !== 32) {
+    pipelineError(
+      "AGENT_BACKUP_V3_KEY_BUNDLE_INVALID",
+      "Operation content-HMAC key must contain exactly 32 bytes",
+    );
+  }
+  const hmac = createHmac("sha256", key);
+  let finished = false;
+  return {
+    update(bytes) {
+      if (finished) {
+        pipelineError(
+          "AGENT_BACKUP_V3_HMAC_STATE_INVALID",
+          "Operation content HMAC was updated after finalization",
+        );
+      }
+      hmac.update(bytes);
+    },
+    digestHex() {
+      if (finished) {
+        pipelineError(
+          "AGENT_BACKUP_V3_HMAC_STATE_INVALID",
+          "Operation content HMAC was finalized more than once",
+        );
+      }
+      finished = true;
+      return hmac.digest("hex");
+    },
+  };
+}
+
+function assertActive(input: RunAgentBackupCaptureV2PipelineInput): void {
+  if (input.signal?.aborted) {
+    pipelineError(
+      "AGENT_BACKUP_V2_PIPELINE_ABORTED",
+      "Backup capture pipeline was cancelled",
+      input.signal.reason,
+    );
+  }
+  if ((input.now ?? Date.now)() >= input.request.deadlineEpochMs) {
+    pipelineError(
+      "AGENT_BACKUP_V2_PIPELINE_DEADLINE_EXCEEDED",
+      "Backup capture pipeline deadline exceeded",
+    );
+  }
+}
+
+async function awaitWithPipelineControl<T>(
+  input: RunAgentBackupCaptureV2PipelineInput,
+  label: string,
+  operation: () => T | PromiseLike<T>,
+): Promise<T> {
+  assertActive(input);
+  const remainingMs = input.request.deadlineEpochMs - (input.now ?? Date.now)();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let abortListener: (() => void) | undefined;
+  const interrupted = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () =>
+        reject(
+          new AgentBackupCaptureV2PipelineError(
+            "AGENT_BACKUP_V2_PIPELINE_DEADLINE_EXCEEDED",
+            `${label} exceeded the backup operation deadline`,
+          ),
+        ),
+      Math.min(remainingMs, 2_147_483_647),
+    );
+    if (input.signal) {
+      abortListener = () =>
+        reject(
+          new AgentBackupCaptureV2PipelineError(
+            "AGENT_BACKUP_V2_PIPELINE_ABORTED",
+            `${label} was cancelled`,
+            { cause: input.signal?.reason },
+          ),
+        );
+      input.signal.addEventListener("abort", abortListener, { once: true });
+    }
+  });
+  try {
+    return await Promise.race([Promise.resolve().then(operation), interrupted]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+    if (abortListener) input.signal?.removeEventListener("abort", abortListener);
+  }
+}
+
+async function heartbeat(input: RunAgentBackupCaptureV2PipelineInput): Promise<void> {
+  assertActive(input);
+  if (
+    (await awaitWithPipelineControl(input, "Backup lease heartbeat", () => input.heartbeat())) !==
+    true
+  ) {
+    pipelineError(
+      "AGENT_BACKUP_V2_PIPELINE_LEASE_LOST",
+      "Backup catalogue lease heartbeat was not acknowledged",
+    );
+  }
+  assertActive(input);
+}
+
+class BoundedPlainChunkBuilder {
+  private buffer: Uint8Array;
+  private length = 0;
+
+  constructor(private readonly limit: number) {
+    this.buffer = new Uint8Array(limit);
+  }
+
+  async append(part: Uint8Array, flush: (chunk: Uint8Array) => Promise<void>): Promise<void> {
+    let offset = 0;
+    while (offset < part.byteLength) {
+      const take = Math.min(part.byteLength - offset, this.limit - this.length);
+      this.buffer.set(part.subarray(offset, offset + take), this.length);
+      this.length += take;
+      offset += take;
+      if (this.length === this.limit) {
+        const full = this.buffer;
+        this.buffer = new Uint8Array(this.limit);
+        this.length = 0;
+        try {
+          await flush(full);
+        } finally {
+          full.fill(0);
+        }
+      }
+    }
+  }
+
+  async finish(flush: (chunk: Uint8Array) => Promise<void>): Promise<void> {
+    if (this.length === 0) return;
+    const final = this.buffer.subarray(0, this.length);
+    this.buffer = new Uint8Array(this.limit);
+    this.length = 0;
+    try {
+      await flush(final);
+    } finally {
+      final.fill(0);
+    }
+  }
+
+  release(): void {
+    this.buffer.fill(0);
+    this.buffer = new Uint8Array(0);
+    this.length = 0;
+  }
+}
+
+function zeroizeCaptureFrame(frame: AgentBackupCaptureV2Frame): void {
+  if (frame.header.kind === "data") frame.payload.fill(0);
+}
+
+async function nextCaptureFrame(
+  input: RunAgentBackupCaptureV2PipelineInput,
+  iterator: AsyncIterator<AgentBackupCaptureV2Frame>,
+): Promise<IteratorResult<AgentBackupCaptureV2Frame>> {
+  const pending = Promise.resolve().then(() => iterator.next());
+  try {
+    return await awaitWithPipelineControl(input, "Capture ingress read", () => pending);
+  } catch (cause) {
+    // error-policy:J5 the losing ingress read remains observed. If an
+    // uncooperative iterator eventually yields plaintext, erase it immediately.
+    void pending.then(
+      (late) => {
+        if (!late.done) zeroizeCaptureFrame(late.value);
+      },
+      (_lateFailure: unknown) => undefined,
+    );
+    throw cause;
+  }
+}
+
+async function closeCaptureIterator(
+  iterator: AsyncIterator<AgentBackupCaptureV2Frame>,
+): Promise<void> {
+  let close: Promise<IteratorResult<AgentBackupCaptureV2Frame> | undefined>;
+  try {
+    close = Promise.resolve(iterator.return?.());
+  } catch (_closeFailure: unknown) {
+    // error-policy:J5 capture failure/deadline is authoritative and the source
+    // may already have torn down synchronously.
+    return;
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const bounded = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, 250);
+  });
+  try {
+    await Promise.race([
+      close.then(
+        (result) => {
+          if (result && !result.done) zeroizeCaptureFrame(result.value);
+        },
+        (_closeFailure: unknown) => undefined,
+      ),
+      bounded,
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+async function encryptAndStoreChunk(input: {
+  pipeline: RunAgentBackupCaptureV2PipelineInput;
+  spool: AgentBackupCaptureV3Spool;
+  dek: Uint8Array;
+  contentHmacKey: Uint8Array;
+  descriptor: AgentBackupCaptureV2ComponentDescriptor;
+  componentHmac: AgentBackupCaptureV2DigestStream;
+  componentIndex: number;
+  chunkIndex: number;
+  offsetBytes: number;
+  plaintext: Uint8Array;
+  nonceOwners: Map<string, string>;
+}): Promise<AgentBackupCaptureV3SpoolChunk> {
+  const { pipeline, spool, descriptor, plaintext } = input;
+  assertActive(pipeline);
+  const chunkHmac = createContentHmac(input.contentHmacKey);
+  await updateDigest(chunkHmac, plaintext);
+  const contentHmacSha256 = await finishDigest(chunkHmac);
+  await updateDigest(input.componentHmac, plaintext);
+
+  const replayNonce = await spool.loadCiphertextChunkNonceForReplay(
+    descriptor.name,
+    input.chunkIndex,
+  );
+  const nonce =
+    replayNonce ?? new Uint8Array(randomBytes(AGENT_BACKUP_CHUNK_ENVELOPE_V1.nonceBytes));
+  const nonceHex = bytesToHex(nonce);
+  const owner = `${descriptor.name}:${input.chunkIndex}`;
+  const priorOwner = input.nonceOwners.get(nonceHex);
+  if (priorOwner && priorOwner !== owner) {
+    pipelineError(
+      "AGENT_BACKUP_V2_NONCE_REUSE",
+      "AES-GCM nonce is already owned by another chunk in this operation",
+    );
+  }
+  input.nonceOwners.set(nonceHex, owner);
+
+  const aadInput = {
+    identity: {
+      organizationId: pipeline.authority.organizationId,
+      agentId: pipeline.request.agentId,
+      activationGeneration: pipeline.request.activationGeneration,
+      lifecycleRevision: pipeline.request.lifecycleRevision,
+    },
+    operationId: pipeline.request.operationId,
+    component: {
+      name: descriptor.name,
+      format: AGENT_BACKUP_RECORD_STREAM_V1_FORMAT,
+      compression: "none" as const,
+    },
+    chunk: {
+      index: input.chunkIndex,
+      offsetBytes: input.offsetBytes,
+      plainBytes: plaintext.byteLength,
+      compressedBytes: plaintext.byteLength,
+      contentHmacSha256,
+    },
+  };
+  const aad = new TextEncoder().encode(canonicalizeAgentBackupChunkAad(aadInput));
+  const aadSha256 = await computeAgentBackupChunkAadDigest(aadInput);
+  const cipher = createCipheriv("aes-256-gcm", input.dek, nonce);
+  cipher.setAAD(aad);
+  const ciphertext = cipher.update(plaintext);
+  const final = cipher.final();
+  const tag = cipher.getAuthTag();
+  const encryptedBytes =
+    nonce.byteLength + ciphertext.byteLength + final.byteLength + tag.byteLength;
+  const ciphertextHash = createHash("sha256");
+  ciphertextHash.update(nonce);
+  ciphertextHash.update(ciphertext);
+  if (final.byteLength > 0) ciphertextHash.update(final);
+  ciphertextHash.update(tag);
+  const metadata: AgentBackupCaptureV3SpoolChunk = {
+    component: descriptor.name,
+    index: input.chunkIndex,
+    file: `chunk-${descriptor.name}-${String(input.chunkIndex).padStart(6, "0")}.bin`,
+    nonceHex,
+    plainBytes: plaintext.byteLength,
+    compressedBytes: plaintext.byteLength,
+    encryptedBytes,
+    contentHmacSha256,
+    aadSha256,
+    ciphertextSha256: ciphertextHash.digest("hex"),
+  };
+  try {
+    return await spool.storeCiphertextChunk(metadata, [
+      nonce,
+      ciphertext,
+      ...(final.byteLength > 0 ? [final] : []),
+      tag,
+    ]);
+  } finally {
+    aad.fill(0);
+    nonce.fill(0);
+    ciphertext.fill(0);
+    final.fill(0);
+    tag.fill(0);
+  }
+}
+
+interface ComposedComponent {
+  manifest: AgentBackupManifestV3["components"][number];
+  descriptor: AgentBackupCaptureV2ComponentDescriptor;
+}
+
+async function composeCapture(
+  input: RunAgentBackupCaptureV2PipelineInput,
+  spool: AgentBackupCaptureV3Spool,
+  dek: Uint8Array,
+  contentHmacKey: Uint8Array,
+  chunkPlainBytes: number,
+): Promise<readonly ComposedComponent[]> {
+  const components: ComposedComponent[] = [];
+  const nonceOwners = new Map<string, string>();
+  for (const chunk of spool.chunks) {
+    const owner = `${chunk.component}:${chunk.index}`;
+    if (nonceOwners.has(chunk.nonceHex)) {
+      pipelineError(
+        "AGENT_BACKUP_V2_NONCE_REUSE",
+        "Durable spool contains a duplicate AES-GCM nonce",
+      );
+    }
+    nonceOwners.set(chunk.nonceHex, owner);
+  }
+  let active:
+    | {
+        index: number;
+        descriptor: AgentBackupCaptureV2ComponentDescriptor;
+        builder: BoundedPlainChunkBuilder;
+        hmac: AgentBackupCaptureV2DigestStream;
+        chunks: AgentBackupCaptureV3SpoolChunk[];
+        plainBytes: number;
+      }
+    | undefined;
+  let sawStart = false;
+  let sawEnd = false;
+  let expectedComponents = 0;
+  let bytesSinceHeartbeat = 0;
+
+  await heartbeat(input);
+  const captureIterator = input.openCapture(input.signal)[Symbol.asyncIterator]();
+  try {
+    while (true) {
+      const next = await nextCaptureFrame(input, captureIterator);
+      if (next.done) break;
+      const frame = next.value;
+      try {
+        assertActive(input);
+        if (frame.header.kind === "capture-start") {
+          if (sawStart) {
+            pipelineError(
+              "AGENT_BACKUP_V2_CAPTURE_STATE",
+              "Capture stream repeated its start frame",
+            );
+          }
+          sawStart = true;
+          expectedComponents = frame.header.componentCount;
+          continue;
+        }
+        if (!sawStart || sawEnd) {
+          pipelineError(
+            "AGENT_BACKUP_V2_CAPTURE_STATE",
+            "Capture stream emitted a frame outside its active interval",
+          );
+        }
+        if (frame.header.kind === "component-start") {
+          const descriptor = frame.header.component;
+          if (active) {
+            pipelineError(
+              "AGENT_BACKUP_V2_CAPTURE_STATE",
+              "Capture stream overlapped two components",
+            );
+          }
+          active = {
+            index: frame.header.componentIndex,
+            descriptor,
+            builder: new BoundedPlainChunkBuilder(chunkPlainBytes),
+            hmac: createContentHmac(contentHmacKey),
+            chunks: [],
+            plainBytes: 0,
+          };
+          for (const part of [
+            serializeAgentBackupRecordStreamV1Magic(),
+            ...serializeAgentBackupRecordStreamV1Record({
+              kind: "component-start",
+              descriptor,
+            }),
+          ]) {
+            await active.builder.append(part, async (plaintext) => {
+              if (!active) throw new Error("Component unexpectedly closed");
+              const chunk = await encryptAndStoreChunk({
+                pipeline: input,
+                spool,
+                dek,
+                contentHmacKey,
+                descriptor: active.descriptor,
+                componentHmac: active.hmac,
+                componentIndex: active.index,
+                chunkIndex: active.chunks.length,
+                offsetBytes: active.plainBytes,
+                plaintext,
+                nonceOwners,
+              });
+              active.chunks.push(chunk);
+              active.plainBytes += plaintext.byteLength;
+            });
+          }
+          continue;
+        }
+        if (frame.header.kind === "data") {
+          if (!active || frame.header.componentIndex !== active.index) {
+            pipelineError(
+              "AGENT_BACKUP_V2_CAPTURE_STATE",
+              "Capture data does not belong to the active component",
+            );
+          }
+          for (const part of serializeAgentBackupRecordStreamV1Record({
+            kind: "data",
+            dataIndex: frame.header.dataIndex,
+            offsetBytes: frame.header.offsetBytes,
+            payloadBytes: frame.header.payloadBytes,
+            entry: frame.header.entry ?? null,
+            payload: frame.payload,
+          })) {
+            await active.builder.append(part, async (plaintext) => {
+              if (!active) throw new Error("Component unexpectedly closed");
+              const chunk = await encryptAndStoreChunk({
+                pipeline: input,
+                spool,
+                dek,
+                contentHmacKey,
+                descriptor: active.descriptor,
+                componentHmac: active.hmac,
+                componentIndex: active.index,
+                chunkIndex: active.chunks.length,
+                offsetBytes: active.plainBytes,
+                plaintext,
+                nonceOwners,
+              });
+              active.chunks.push(chunk);
+              active.plainBytes += plaintext.byteLength;
+            });
+          }
+          bytesSinceHeartbeat += frame.payload.byteLength;
+          if (bytesSinceHeartbeat >= MAX_HEARTBEAT_BYTES) {
+            await heartbeat(input);
+            bytesSinceHeartbeat = 0;
+          }
+          continue;
+        }
+        if (frame.header.kind === "component-end") {
+          if (!active || frame.header.componentIndex !== active.index) {
+            pipelineError(
+              "AGENT_BACKUP_V2_CAPTURE_STATE",
+              "Capture component-end does not match the active component",
+            );
+          }
+          for (const part of serializeAgentBackupRecordStreamV1Record({
+            kind: "component-end",
+            dataFrameCount: frame.header.dataFrameCount,
+            payloadBytes: frame.header.plainBytes,
+            payloadSha256: frame.header.payloadSha256,
+          })) {
+            await active.builder.append(part, async (plaintext) => {
+              if (!active) throw new Error("Component unexpectedly closed");
+              const chunk = await encryptAndStoreChunk({
+                pipeline: input,
+                spool,
+                dek,
+                contentHmacKey,
+                descriptor: active.descriptor,
+                componentHmac: active.hmac,
+                componentIndex: active.index,
+                chunkIndex: active.chunks.length,
+                offsetBytes: active.plainBytes,
+                plaintext,
+                nonceOwners,
+              });
+              active.chunks.push(chunk);
+              active.plainBytes += plaintext.byteLength;
+            });
+          }
+          await active.builder.finish(async (plaintext) => {
+            if (!active) throw new Error("Component unexpectedly closed");
+            const chunk = await encryptAndStoreChunk({
+              pipeline: input,
+              spool,
+              dek,
+              contentHmacKey,
+              descriptor: active.descriptor,
+              componentHmac: active.hmac,
+              componentIndex: active.index,
+              chunkIndex: active.chunks.length,
+              offsetBytes: active.plainBytes,
+              plaintext,
+              nonceOwners,
+            });
+            active.chunks.push(chunk);
+            active.plainBytes += plaintext.byteLength;
+          });
+          const componentContentHmac = await finishDigest(active.hmac);
+          const totals = active.chunks.reduce(
+            (sum, chunk) => ({
+              plainBytes: sum.plainBytes + chunk.plainBytes,
+              compressedBytes: sum.compressedBytes + chunk.compressedBytes,
+              encryptedBytes: sum.encryptedBytes + chunk.encryptedBytes,
+              chunkCount: sum.chunkCount + 1,
+            }),
+            { plainBytes: 0, compressedBytes: 0, encryptedBytes: 0, chunkCount: 0 },
+          );
+          let manifestOffset = 0;
+          const manifestChunks = active.chunks.map((chunk) => {
+            const offsetBytes = manifestOffset;
+            manifestOffset += chunk.plainBytes;
+            return {
+              index: chunk.index,
+              offsetBytes,
+              plainBytes: chunk.plainBytes,
+              compressedBytes: chunk.compressedBytes,
+              encryptedBytes: chunk.encryptedBytes,
+              contentHmacSha256: chunk.contentHmacSha256,
+              aadSha256: chunk.aadSha256,
+              sha256: chunk.ciphertextSha256,
+            };
+          });
+          components.push({
+            descriptor: active.descriptor,
+            manifest: {
+              name: active.descriptor.name,
+              format: AGENT_BACKUP_RECORD_STREAM_V1_FORMAT,
+              compression: "none",
+              payloadContentHmacSha256: componentContentHmac,
+              state: { kind: "full", resultContentHmacSha256: componentContentHmac },
+              totals,
+              chunks: manifestChunks,
+            },
+          });
+          active = undefined;
+          await heartbeat(input);
+          continue;
+        }
+        if (frame.header.kind === "capture-end") {
+          if (active || frame.header.componentCount !== components.length) {
+            pipelineError(
+              "AGENT_BACKUP_V2_CAPTURE_STATE",
+              "Capture terminal frame does not match completed components",
+            );
+          }
+          sawEnd = true;
+        }
+      } finally {
+        zeroizeCaptureFrame(frame);
+      }
+    }
+  } finally {
+    active?.builder.release();
+    await closeCaptureIterator(captureIterator);
+  }
+  if (!sawStart || !sawEnd || components.length !== expectedComponents) {
+    pipelineError(
+      "AGENT_BACKUP_V2_CAPTURE_TRUNCATED",
+      "Capture stream ended without its authenticated terminal state",
+    );
+  }
+  const composedKeys = new Set(
+    components.flatMap((component) =>
+      component.manifest.chunks.map((chunk) => `${component.manifest.name}:${chunk.index}`),
+    ),
+  );
+  if (
+    spool.chunks.length !== composedKeys.size ||
+    spool.chunks.some((chunk) => !composedKeys.has(`${chunk.component}:${chunk.index}`))
+  ) {
+    pipelineError(
+      "AGENT_BACKUP_V2_SPOOL_REPLAY_CONFLICT",
+      "Partial capture replay produced a different ciphertext inventory",
+    );
+  }
+  return components;
+}
+
+async function computeFramedContentHmac(input: {
+  pipeline: RunAgentBackupCaptureV2PipelineInput;
+  spool: AgentBackupCaptureV3Spool;
+  dek: Uint8Array;
+  contentHmacKey: Uint8Array;
+  components: readonly ComposedComponent[];
+}): Promise<string> {
+  const digest = createContentHmac(input.contentHmacKey);
+  const encoder = new TextEncoder();
+  await updateDigest(digest, encoder.encode(AGENT_BACKUP_PAYLOAD_DIGEST_DERIVATION));
+  await updateDigest(digest, uint64BigEndian(input.components.length));
+  const readBuffer = new Uint8Array(256 * 1024);
+
+  for (const component of input.components) {
+    const name = encoder.encode(component.manifest.name);
+    await updateDigest(digest, uint64BigEndian(name.byteLength));
+    await updateDigest(digest, name);
+    await updateDigest(digest, uint64BigEndian(component.manifest.totals.plainBytes));
+    for (const manifestChunk of component.manifest.chunks) {
+      assertActive(input.pipeline);
+      const spoolChunk = input.spool.chunks.find(
+        (chunk) =>
+          chunk.component === component.manifest.name && chunk.index === manifestChunk.index,
+      );
+      if (!spoolChunk) {
+        pipelineError(
+          "AGENT_BACKUP_V2_SPOOL_CHUNK_UNKNOWN",
+          "Manifest references a missing ciphertext spool chunk",
+        );
+      }
+      const handle = await input.spool.openCiphertextChunk(spoolChunk);
+      const nonce = new Uint8Array(AGENT_BACKUP_CHUNK_ENVELOPE_V1.nonceBytes);
+      const tag = new Uint8Array(AGENT_BACKUP_CHUNK_ENVELOPE_V1.tagBytes);
+      const ciphertextBytes = spoolChunk.encryptedBytes - nonce.byteLength - tag.byteLength;
+      try {
+        const nonceRead = await handle.read(nonce, 0, nonce.byteLength, 0);
+        const tagRead = await handle.read(
+          tag,
+          0,
+          tag.byteLength,
+          spoolChunk.encryptedBytes - tag.byteLength,
+        );
+        if (nonceRead.bytesRead !== nonce.byteLength || tagRead.bytesRead !== tag.byteLength) {
+          pipelineError(
+            "AGENT_BACKUP_V2_SPOOL_TRUNCATED",
+            "Ciphertext envelope nonce or tag is truncated",
+          );
+        }
+        const aadInput = {
+          identity: {
+            organizationId: input.pipeline.authority.organizationId,
+            agentId: input.pipeline.request.agentId,
+            activationGeneration: input.pipeline.request.activationGeneration,
+            lifecycleRevision: input.pipeline.request.lifecycleRevision,
+          },
+          operationId: input.pipeline.request.operationId,
+          component: {
+            name: component.manifest.name,
+            format: component.manifest.format,
+            compression: component.manifest.compression,
+          },
+          chunk: {
+            index: manifestChunk.index,
+            offsetBytes: manifestChunk.offsetBytes,
+            plainBytes: manifestChunk.plainBytes,
+            compressedBytes: manifestChunk.compressedBytes,
+            contentHmacSha256: manifestChunk.contentHmacSha256,
+          },
+        };
+        const decipher = createDecipheriv("aes-256-gcm", input.dek, nonce);
+        decipher.setAAD(encoder.encode(canonicalizeAgentBackupChunkAad(aadInput)));
+        decipher.setAuthTag(tag);
+        let offset = 0;
+        let plainBytes = 0;
+        while (offset < ciphertextBytes) {
+          const take = Math.min(readBuffer.byteLength, ciphertextBytes - offset);
+          const read = await handle.read(readBuffer, 0, take, nonce.byteLength + offset);
+          if (read.bytesRead === 0) {
+            pipelineError("AGENT_BACKUP_V2_SPOOL_TRUNCATED", "Ciphertext envelope is truncated");
+          }
+          const plaintext = decipher.update(readBuffer.subarray(0, read.bytesRead));
+          if (plaintext.byteLength > 0) {
+            try {
+              await updateDigest(digest, plaintext);
+              plainBytes += plaintext.byteLength;
+            } finally {
+              plaintext.fill(0);
+            }
+          }
+          offset += read.bytesRead;
+        }
+        const final = decipher.final();
+        if (final.byteLength > 0) {
+          try {
+            await updateDigest(digest, final);
+            plainBytes += final.byteLength;
+          } finally {
+            final.fill(0);
+          }
+        }
+        if (plainBytes !== manifestChunk.plainBytes) {
+          pipelineError(
+            "AGENT_BACKUP_V2_SPOOL_CHUNK_INVALID",
+            "Authenticated ciphertext plaintext length differs from its manifest",
+          );
+        }
+      } finally {
+        await handle.close();
+        nonce.fill(0);
+        tag.fill(0);
+      }
+    }
+    await heartbeat(input.pipeline);
+  }
+  return finishDigest(digest);
+}
+
+function manifestTotals(components: readonly ComposedComponent[]): {
+  plainBytes: number;
+  compressedBytes: number;
+  encryptedBytes: number;
+  chunkCount: number;
+} {
+  return components.reduce(
+    (total, component) => ({
+      plainBytes: total.plainBytes + component.manifest.totals.plainBytes,
+      compressedBytes: total.compressedBytes + component.manifest.totals.compressedBytes,
+      encryptedBytes: total.encryptedBytes + component.manifest.totals.encryptedBytes,
+      chunkCount: total.chunkCount + component.manifest.totals.chunkCount,
+    }),
+    { plainBytes: 0, compressedBytes: 0, encryptedBytes: 0, chunkCount: 0 },
+  );
+}
+
+function draftFromManifest(manifest: AgentBackupManifestV3): AgentBackupManifestV3Draft {
+  const { manifestSha256: _manifestSha256, ...integrity } = manifest.integrity;
+  return { ...manifest, integrity };
+}
+
+async function inventoryDigest(manifest: AgentBackupManifestV3): Promise<string> {
+  return sha256Hex(
+    new TextEncoder().encode(
+      JSON.stringify({
+        version: 3,
+        objects: manifest.components
+          .flatMap((component) =>
+            component.chunks.map((chunk) => ({
+              component: component.name,
+              index: chunk.index,
+              contentHmac: chunk.contentHmacSha256,
+              cipherSha: chunk.sha256,
+              encryptedBytes: chunk.encryptedBytes,
+            })),
+          )
+          .sort(
+            (left, right) =>
+              compareCanonicalComponentNames(left.component, right.component) ||
+              left.index - right.index,
+          ),
+      }),
+    ),
+  );
+}
+
+async function catalogManifest(
+  manifest: AgentBackupManifestV3,
+  wrappedKeyBundle: Uint8Array,
+): Promise<AgentBackupCaptureV3CatalogManifest> {
+  const draft = draftFromManifest(manifest);
+  const bundle = manifest.encryption.operationKeyBundle;
+  if (
+    wrappedKeyBundle.byteLength !== bundle.wrapped.bytes ||
+    sha256Hex(wrappedKeyBundle) !== bundle.wrapped.sha256
+  ) {
+    pipelineError(
+      "AGENT_BACKUP_V3_KEY_BUNDLE_ENVELOPE_INVALID",
+      "Wrapped operation key bundle differs from its manifest",
+    );
+  }
+  return {
+    canonicalManifestDraft: canonicalizeAgentBackupManifestV3(draft),
+    format: manifest.format,
+    version: manifest.schemaVersion,
+    digest: manifest.integrity.manifestSha256,
+    objectCount: manifest.totals.chunkCount,
+    objectInventoryDigest: await inventoryDigest(manifest),
+    imageDigest: manifest.runtime.imageDigest,
+    databaseSchemaVersion: manifest.runtime.databaseSchemaVersion,
+    pluginSetDigest: digestCanonical({ version: 1, plugins: manifest.runtime.plugins }),
+    watermarkDigest: digestCanonical({ version: 1, watermarks: manifest.watermarks }),
+    rawSizeBytes: manifest.totals.plainBytes,
+    compressedSizeBytes: manifest.totals.compressedBytes,
+    encryptedSizeBytes: manifest.totals.encryptedBytes,
+    kmsKeyId: manifest.encryption.kms.keyId,
+    kmsKeyVersion: manifest.encryption.kms.keyVersion,
+    wrappedKeyBundleCiphertextBase64: boundedBase64(wrappedKeyBundle),
+    wrappedKeyBundleSha256: bundle.wrapped.sha256,
+    wrappedKeyBundleLocalReceiptDigest: bundle.wrapped.localReceiptDigest,
+    wrappedKeyBundleGenerationId: bundle.generationId,
+    vaultKeyGenerationId: manifest.vaultKeyAuthority.generationId,
+    vaultKeyAuthorityReceiptDigest: manifest.vaultKeyAuthority.receiptDigest,
+  };
+}
+
+function operationKeyBundleContext(
+  request: AgentBackupCaptureV2Request,
+  authority: AgentBackupCaptureV3ManifestAuthority,
+  generationId: string,
+): string {
+  return canonicalizeAgentBackupOperationKeyBundleContext({
+    organizationId: authority.organizationId,
+    agentId: request.agentId,
+    activationGeneration: request.activationGeneration,
+    lifecycleRevision: request.lifecycleRevision,
+    operationId: request.operationId,
+    keyBundleGenerationId: generationId,
+    sourceKind: authority.source.kind,
+    sourceProvider: authority.source.provider,
+    kmsProvider: authority.kms.provider,
+    keyId: authority.kms.keyId,
+    keyVersion: authority.kms.keyVersion,
+  });
+}
+
+interface AcquiredOperationKeyBundle {
+  handle: KmsAeadOperationKeyBundleHandle;
+  dek: Uint8Array;
+  contentHmacKey: Uint8Array;
+  wrapped: KmsAeadOperationKeyBundleWrapped;
+  generationId: string;
+  canonicalContext: string;
+}
+
+function readKeyBundleViews(
+  handle: KmsAeadOperationKeyBundleHandle,
+): Pick<AcquiredOperationKeyBundle, "dek" | "contentHmacKey"> {
+  if (!handle || handle.format !== KMS_AEAD_OPERATION_KEY_BUNDLE_V1.format || handle.released) {
+    pipelineError(
+      "AGENT_BACKUP_V3_KEY_BUNDLE_INVALID",
+      "KMS returned an inactive operation key-bundle handle",
+    );
+  }
+  const dek = handle.dek;
+  const contentHmacKey = handle.contentHmacKey;
+  if (
+    !(dek instanceof Uint8Array) ||
+    dek.byteLength !== AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.dek.bytes ||
+    !(contentHmacKey instanceof Uint8Array) ||
+    contentHmacKey.byteLength !== AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.contentHmac.bytes ||
+    (dek.buffer === contentHmacKey.buffer &&
+      dek.byteOffset < contentHmacKey.byteOffset + contentHmacKey.byteLength &&
+      contentHmacKey.byteOffset < dek.byteOffset + dek.byteLength)
+  ) {
+    pipelineError(
+      "AGENT_BACKUP_V3_KEY_BUNDLE_INVALID",
+      "KMS operation key-bundle handle has invalid key slices",
+    );
+  }
+  return { dek, contentHmacKey };
+}
+
+function assertWrappedKeyBundle(
+  wrapped: KmsAeadOperationKeyBundleWrapped,
+  authority: Pick<AgentBackupCaptureV3ManifestAuthority, "kms">,
+  canonicalContext: string,
+): void {
+  if (
+    !wrapped ||
+    wrapped.format !== KMS_AEAD_OPERATION_KEY_BUNDLE_V1.format ||
+    wrapped.keyId !== authority.kms.keyId ||
+    wrapped.keyVersion !== authority.kms.keyVersion ||
+    wrapped.plaintextBytes !== KMS_AEAD_OPERATION_KEY_BUNDLE_V1.plaintextBytes ||
+    wrapped.nonceBytes !== KMS_AEAD_OPERATION_KEY_BUNDLE_V1.nonceBytes ||
+    wrapped.authTagBytes !== KMS_AEAD_OPERATION_KEY_BUNDLE_V1.authTagBytes ||
+    wrapped.bytes !== KMS_AEAD_OPERATION_KEY_BUNDLE_V1.wrappedBytes ||
+    wrapped.localReceiptDerivation !== KMS_AEAD_OPERATION_KEY_BUNDLE_LOCAL_RECEIPT_DERIVATION ||
+    !(wrapped.wrappedKeyBundle instanceof Uint8Array) ||
+    wrapped.wrappedKeyBundle.byteLength !== wrapped.bytes ||
+    !HEX_SHA256_PATTERN.test(wrapped.sha256) ||
+    sha256Hex(wrapped.wrappedKeyBundle) !== wrapped.sha256 ||
+    !HEX_SHA256_PATTERN.test(wrapped.localReceiptDigest)
+  ) {
+    pipelineError(
+      "AGENT_BACKUP_V3_KEY_BUNDLE_ENVELOPE_INVALID",
+      "KMS returned invalid operation key-bundle envelope metadata",
+    );
+  }
+  const contextBytes = new TextEncoder().encode(canonicalContext);
+  try {
+    if (
+      computeKmsAeadOperationKeyBundleLocalReceiptDigest({
+        keyId: wrapped.keyId,
+        keyVersion: wrapped.keyVersion,
+        canonicalContext: contextBytes,
+        wrappedKeyBundle: wrapped.wrappedKeyBundle,
+      }) !== wrapped.localReceiptDigest
+    ) {
+      pipelineError(
+        "AGENT_BACKUP_V3_KEY_BUNDLE_RECEIPT_INVALID",
+        "KMS operation key-bundle envelope has an invalid local receipt",
+      );
+    }
+  } finally {
+    contextBytes.fill(0);
+  }
+}
+
+function observeLateKeyBundleHandle(
+  provider: AgentBackupCaptureV3KeyBundleProvider,
+  pending: Promise<KmsAeadOperationKeyBundleHandle>,
+): void {
+  void pending.then(
+    (handle) => {
+      try {
+        releaseInvalidKeyBundleHandle(provider, handle);
+      } catch (_releaseFailure: unknown) {
+        // error-policy:J5 the operation cancellation/deadline is authoritative;
+        // local observable views were still erased by the release boundary.
+      }
+    },
+    (_lateFailure: unknown) => undefined,
+  );
+}
+
+function observeLateKeyBundleAcquisition(
+  provider: AgentBackupCaptureV3KeyBundleProvider,
+  pending: Promise<{
+    handle: KmsAeadOperationKeyBundleHandle;
+    wrapped: KmsAeadOperationKeyBundleWrapped;
+  }>,
+): void {
+  void pending.then(
+    (late) => {
+      let wrappedKeyBundle: Uint8Array | undefined;
+      try {
+        if (late.wrapped.wrappedKeyBundle instanceof Uint8Array) {
+          wrappedKeyBundle = late.wrapped.wrappedKeyBundle;
+        }
+      } catch (_invalidEnvelope: unknown) {
+        // error-policy:J5 handle release remains independently mandatory.
+      }
+      try {
+        releaseInvalidKeyBundleHandle(provider, late.handle);
+      } catch (_releaseFailure: unknown) {
+        // error-policy:J5 cancellation/deadline remains the primary failure.
+      } finally {
+        wrappedKeyBundle?.fill(0);
+      }
+    },
+    (_lateFailure: unknown) => undefined,
+  );
+}
+
+async function acquireOperationKeyBundle(
+  input: RunAgentBackupCaptureV2PipelineInput,
+  spool: AgentBackupCaptureV3Spool,
+): Promise<AcquiredOperationKeyBundle> {
+  const stored = spool.getOperationKeyBundleMetadata();
+  if (stored) {
+    const expectedContext = operationKeyBundleContext(
+      input.request,
+      input.authority,
+      stored.generationId,
+    );
+    if (stored.canonicalContext !== expectedContext) {
+      pipelineError(
+        "AGENT_BACKUP_V3_KEY_BUNDLE_CONTEXT_MISMATCH",
+        "Durable operation key-bundle context differs from current authority",
+      );
+    }
+    const wrappedKeyBundle = await spool.loadOperationKeyBundle();
+    const wrapped: KmsAeadOperationKeyBundleWrapped = {
+      format: stored.format,
+      keyId: input.authority.kms.keyId,
+      keyVersion: input.authority.kms.keyVersion,
+      plaintextBytes: stored.plaintextBytes,
+      nonceBytes: stored.nonceBytes,
+      authTagBytes: stored.authTagBytes,
+      bytes: stored.bytes,
+      sha256: stored.sha256,
+      localReceiptDerivation: stored.localReceiptDerivation,
+      localReceiptDigest: stored.localReceiptDigest,
+      wrappedKeyBundle,
+    };
+    try {
+      assertWrappedKeyBundle(wrapped, input.authority, expectedContext);
+    } catch (cause) {
+      wrappedKeyBundle.fill(0);
+      throw cause;
+    }
+    const contextBytes = new TextEncoder().encode(expectedContext);
+    let handle: KmsAeadOperationKeyBundleHandle;
+    const unwrapPending = Promise.resolve().then(() =>
+      input.keyBundle.unwrap({
+        wrapped,
+        canonicalContext: contextBytes,
+      }),
+    );
+    try {
+      handle = await awaitWithPipelineControl(
+        input,
+        "Operation key-bundle unwrap",
+        () => unwrapPending,
+      );
+    } catch (cause) {
+      observeLateKeyBundleHandle(input.keyBundle, unwrapPending);
+      wrappedKeyBundle.fill(0);
+      throw cause;
+    } finally {
+      contextBytes.fill(0);
+    }
+    let views: Pick<AcquiredOperationKeyBundle, "dek" | "contentHmacKey">;
+    try {
+      views = readKeyBundleViews(handle);
+    } catch (cause) {
+      wrappedKeyBundle.fill(0);
+      try {
+        releaseInvalidKeyBundleHandle(input.keyBundle, handle);
+      } catch (releaseCause) {
+        throw new AggregateError(
+          [cause, releaseCause],
+          "Stored key-bundle validation and release both failed",
+        );
+      }
+      throw cause;
+    }
+    return {
+      handle,
+      ...views,
+      wrapped,
+      generationId: stored.generationId,
+      canonicalContext: expectedContext,
+    };
+  }
+
+  const generationId = randomUUID();
+  const canonicalContext = operationKeyBundleContext(input.request, input.authority, generationId);
+  const contextBytes = new TextEncoder().encode(canonicalContext);
+  let acquired: Awaited<ReturnType<AgentBackupCaptureV3KeyBundleProvider["acquire"]>>;
+  const acquirePending = Promise.resolve().then(() =>
+    input.keyBundle.acquire({
+      keyId: input.authority.kms.keyId,
+      keyVersion: input.authority.kms.keyVersion,
+      canonicalContext: contextBytes,
+    }),
+  );
+  try {
+    acquired = await awaitWithPipelineControl(
+      input,
+      "Fresh operation key-bundle wrap",
+      () => acquirePending,
+    );
+  } catch (cause) {
+    observeLateKeyBundleAcquisition(input.keyBundle, acquirePending);
+    throw cause;
+  } finally {
+    contextBytes.fill(0);
+  }
+  let views: Pick<AcquiredOperationKeyBundle, "dek" | "contentHmacKey">;
+  let wrappedKeyBundle: Uint8Array | undefined;
+  let providerWrappedKeyBundle: Uint8Array | undefined;
+  try {
+    if (acquired.wrapped.wrappedKeyBundle instanceof Uint8Array) {
+      providerWrappedKeyBundle = acquired.wrapped.wrappedKeyBundle;
+    }
+    views = readKeyBundleViews(acquired.handle);
+    assertWrappedKeyBundle(acquired.wrapped, input.authority, canonicalContext);
+    wrappedKeyBundle = Uint8Array.from(acquired.wrapped.wrappedKeyBundle);
+    await spool.storeOperationKeyBundle(
+      {
+        generationId,
+        format: acquired.wrapped.format,
+        plaintextBytes: acquired.wrapped.plaintextBytes,
+        nonceBytes: acquired.wrapped.nonceBytes,
+        authTagBytes: acquired.wrapped.authTagBytes,
+        bytes: acquired.wrapped.bytes,
+        sha256: acquired.wrapped.sha256,
+        localReceiptDerivation: acquired.wrapped.localReceiptDerivation,
+        localReceiptDigest: acquired.wrapped.localReceiptDigest,
+        canonicalContext,
+      },
+      wrappedKeyBundle,
+    );
+    providerWrappedKeyBundle?.fill(0);
+  } catch (cause) {
+    // error-policy:J3 an unpersisted operation bundle must be released and
+    // zeroed before the capture source can be opened.
+    let releaseFailure: unknown;
+    try {
+      releaseInvalidKeyBundleHandle(input.keyBundle, acquired.handle);
+    } catch (releaseCause) {
+      releaseFailure = releaseCause;
+    } finally {
+      wrappedKeyBundle?.fill(0);
+      providerWrappedKeyBundle?.fill(0);
+    }
+    if (releaseFailure !== undefined) {
+      throw new AggregateError(
+        [cause, releaseFailure],
+        "Operation key-bundle persistence and release both failed",
+      );
+    }
+    throw cause;
+  }
+  if (!wrappedKeyBundle) {
+    pipelineError(
+      "AGENT_BACKUP_V3_KEY_BUNDLE_INCOMPLETE",
+      "Fresh operation key bundle has no owned envelope bytes",
+    );
+  }
+  return {
+    handle: acquired.handle,
+    ...views,
+    wrapped: { ...acquired.wrapped, wrappedKeyBundle },
+    generationId,
+    canonicalContext,
+  };
+}
+
+export async function loadAgentBackupCaptureV3SealedArtifacts(
+  spool: AgentBackupCaptureV3Spool,
+): Promise<AgentBackupCaptureV3Artifacts> {
+  const manifestBytes = await spool.loadManifestBytes();
+  let decoded: unknown;
+  let manifestJson: string;
+  try {
+    manifestJson = new TextDecoder("utf-8", { fatal: true }).decode(manifestBytes);
+    decoded = JSON.parse(manifestJson);
+  } catch (cause) {
+    pipelineError(
+      "AGENT_BACKUP_V3_SPOOL_MANIFEST_INVALID",
+      "Durable manifest is not valid UTF-8 JSON",
+      cause,
+    );
+  }
+  const manifest = await parseAgentBackupManifestV3(decoded);
+  if (manifestJson !== canonicalJson(manifest)) {
+    pipelineError(
+      "AGENT_BACKUP_V3_SPOOL_MANIFEST_NON_CANONICAL",
+      "Durable manifest bytes are not the canonical v3 wire",
+    );
+  }
+  const wrappedKeyBundle = await spool.loadOperationKeyBundle();
+  try {
+    const wrapped = spool.getOperationKeyBundleMetadata();
+    if (!wrapped) {
+      pipelineError(
+        "AGENT_BACKUP_V3_SPOOL_KEY_BUNDLE_MISSING",
+        "Sealed backup operation is missing its operation key bundle",
+      );
+    }
+    const expectedContext = canonicalizeAgentBackupOperationKeyBundleContext({
+      organizationId: manifest.identity.organizationId,
+      agentId: manifest.identity.agentId,
+      activationGeneration: manifest.identity.activationGeneration,
+      lifecycleRevision: manifest.identity.lifecycleRevision,
+      operationId: manifest.operationId,
+      keyBundleGenerationId: manifest.encryption.operationKeyBundle.generationId,
+      sourceKind: manifest.source.kind,
+      sourceProvider: manifest.source.provider,
+      kmsProvider: manifest.encryption.kms.provider,
+      keyId: manifest.encryption.kms.keyId,
+      keyVersion: manifest.encryption.kms.keyVersion,
+    });
+    const bundle = manifest.encryption.operationKeyBundle;
+    if (
+      wrapped.canonicalContext !== expectedContext ||
+      wrapped.generationId !== bundle.generationId ||
+      wrapped.format !== bundle.format ||
+      wrapped.plaintextBytes !== bundle.plaintextBytes ||
+      wrapped.bytes !== bundle.wrapped.bytes ||
+      wrapped.sha256 !== bundle.wrapped.sha256 ||
+      wrapped.localReceiptDerivation !== bundle.wrapped.localReceiptDerivation ||
+      wrapped.localReceiptDigest !== bundle.wrapped.localReceiptDigest
+    ) {
+      pipelineError(
+        "AGENT_BACKUP_V3_KEY_BUNDLE_CONTEXT_MISMATCH",
+        "Durable key-bundle context differs from its sealed manifest",
+      );
+    }
+    assertWrappedKeyBundle(
+      {
+        format: wrapped.format,
+        keyId: manifest.encryption.kms.keyId,
+        keyVersion: manifest.encryption.kms.keyVersion,
+        plaintextBytes: wrapped.plaintextBytes,
+        nonceBytes: wrapped.nonceBytes,
+        authTagBytes: wrapped.authTagBytes,
+        bytes: wrapped.bytes,
+        sha256: wrapped.sha256,
+        localReceiptDerivation: wrapped.localReceiptDerivation,
+        localReceiptDigest: wrapped.localReceiptDigest,
+        wrappedKeyBundle,
+      },
+      { kms: manifest.encryption.kms },
+      expectedContext,
+    );
+    const chunks = spool.chunks;
+    const manifestChunks = manifest.components.flatMap((component) =>
+      component.chunks.map((chunk) => ({ component: component.name, chunk })),
+    );
+    if (chunks.length !== manifestChunks.length) {
+      pipelineError(
+        "AGENT_BACKUP_V3_SPOOL_INVENTORY_CONFLICT",
+        "Durable ciphertext inventory count differs from the sealed manifest",
+      );
+    }
+    for (let index = 0; index < manifestChunks.length; index += 1) {
+      const expected = manifestChunks[index];
+      const observed = chunks[index];
+      if (
+        !expected ||
+        !observed ||
+        observed.component !== expected.component ||
+        observed.index !== expected.chunk.index ||
+        observed.file !==
+          `chunk-${expected.component}-${String(expected.chunk.index).padStart(6, "0")}.bin` ||
+        observed.plainBytes !== expected.chunk.plainBytes ||
+        observed.compressedBytes !== expected.chunk.compressedBytes ||
+        observed.encryptedBytes !== expected.chunk.encryptedBytes ||
+        observed.contentHmacSha256 !== expected.chunk.contentHmacSha256 ||
+        observed.aadSha256 !== expected.chunk.aadSha256 ||
+        observed.ciphertextSha256 !== expected.chunk.sha256
+      ) {
+        pipelineError(
+          "AGENT_BACKUP_V3_SPOOL_INVENTORY_CONFLICT",
+          "Durable ciphertext mapping differs from the sealed manifest",
+        );
+      }
+      const handle = await spool.openCiphertextChunk(observed);
+      const nonce = new Uint8Array(AGENT_BACKUP_CHUNK_ENVELOPE_V1.nonceBytes);
+      try {
+        const read = await handle.read(nonce, 0, nonce.byteLength, 0);
+        if (read.bytesRead !== nonce.byteLength || bytesToHex(nonce) !== observed.nonceHex) {
+          pipelineError(
+            "AGENT_BACKUP_V3_SPOOL_INVENTORY_CONFLICT",
+            "Durable ciphertext nonce differs from its spool mapping",
+          );
+        }
+      } finally {
+        nonce.fill(0);
+        await handle.close();
+      }
+    }
+    const artifacts: AgentBackupCaptureV3Artifacts = {
+      manifest,
+      catalogManifest: await catalogManifest(manifest, wrappedKeyBundle),
+      wrappedKeyBundle,
+      chunks,
+    };
+    if (spool.recordCaptured) {
+      const durableCatalogBytes = await spool.loadCatalogManifestBytes();
+      const expectedCatalogBytes = new TextEncoder().encode(
+        canonicalJson(artifacts.catalogManifest),
+      );
+      if (!equalBytes(durableCatalogBytes, expectedCatalogBytes)) {
+        pipelineError(
+          "AGENT_BACKUP_V3_CATALOG_REPLAY_CONFLICT",
+          "Durable catalogue handoff differs byte-for-byte from the sealed spool",
+        );
+      }
+    }
+    return artifacts;
+  } catch (cause) {
+    wrappedKeyBundle.fill(0);
+    throw cause;
+  }
+}
+
+async function publishArtifacts(
+  input: RunAgentBackupCaptureV2PipelineInput,
+  spool: AgentBackupCaptureV3Spool,
+  artifacts: AgentBackupCaptureV3Artifacts,
+): Promise<void> {
+  const publication = input.publication;
+  if (publication.mode !== "capture-only") {
+    await spool.markPublishing();
+  }
+  if (!spool.recordCaptured) {
+    await heartbeat(input);
+    if (
+      (await awaitWithPipelineControl(input, "Catalogue recordCaptured", () =>
+        publication.recordCaptured(artifacts),
+      )) !== true
+    ) {
+      pipelineError(
+        "AGENT_BACKUP_V2_RECORD_CAPTURED_UNCONFIRMED",
+        "Catalogue did not acknowledge the captured manifest",
+      );
+    }
+    const catalogBytes = canonicalAgentBackupCaptureV3CatalogManifestBytes(
+      artifacts.catalogManifest,
+    );
+    await spool.markRecordCaptured(catalogBytes, {
+      bytes: catalogBytes.byteLength,
+      sha256: sha256Hex(catalogBytes),
+    });
+  }
+  if (publication.mode === "capture-only") return;
+  for (const chunk of artifacts.chunks) {
+    if (spool.isChunkUploaded(chunk)) continue;
+    await heartbeat(input);
+    const body = await spool.readCiphertextChunk(chunk);
+    try {
+      if (
+        (await awaitWithPipelineControl(input, "Primary ciphertext upload", () =>
+          publication.uploadPrimary({
+            operationId: input.request.operationId,
+            manifestSha256: artifacts.manifest.integrity.manifestSha256,
+            component: chunk.component,
+            chunkIndex: chunk.index,
+            contentHmacSha256: chunk.contentHmacSha256,
+            ciphertextSha256: chunk.ciphertextSha256,
+            encryptedBytes: chunk.encryptedBytes,
+            body,
+          }),
+        )) !== true
+      ) {
+        pipelineError(
+          "AGENT_BACKUP_V2_UPLOAD_UNCONFIRMED",
+          "Primary object upload was not durably acknowledged",
+        );
+      }
+    } finally {
+      body.fill(0);
+    }
+    await spool.markChunkUploaded(chunk);
+  }
+  await spool.markPublished();
+}
+
+/**
+ * Capture (or resume), seal, and publish one exact operation. Local cleanup is
+ * deliberately a separate explicit call on the returned spool; this function
+ * can never erase the only response-loss replay evidence before its caller has
+ * durably recorded completion.
+ */
+export async function runAgentBackupCaptureV2Pipeline(
+  inputRaw: Readonly<RunAgentBackupCaptureV2PipelineInput>,
+): Promise<AgentBackupCaptureV2PipelineResult> {
+  const request = parseAgentBackupCaptureV2Request(inputRaw.request);
+  let authority: AgentBackupCaptureV3ManifestAuthority;
+  try {
+    authority = JSON.parse(
+      JSON.stringify(inputRaw.authority),
+    ) as AgentBackupCaptureV3ManifestAuthority;
+  } catch (cause) {
+    pipelineError(
+      "AGENT_BACKUP_V2_AUTHORITY_INVALID",
+      "Manifest authority must be serializable immutable JSON",
+      cause,
+    );
+  }
+  const input: RunAgentBackupCaptureV2PipelineInput = {
+    ...inputRaw,
+    request,
+    authority,
+  };
+  if (input.authority.chain.kind !== "full") {
+    pipelineError(
+      "AGENT_BACKUP_V3_INCREMENTAL_CAPTURE_UNSUPPORTED",
+      "Manifest-v3 capture is full-only until a real delta producer and compactor are available",
+    );
+  }
+  const chunkPlainBytes = input.chunkPlainBytes ?? DEFAULT_CHUNK_PLAIN_BYTES;
+  if (
+    !Number.isSafeInteger(chunkPlainBytes) ||
+    chunkPlainBytes < MIN_CHUNK_PLAIN_BYTES ||
+    chunkPlainBytes > AGENT_BACKUP_MANIFEST_V2_LIMITS.maxChunkPlainBytes
+  ) {
+    pipelineError(
+      "AGENT_BACKUP_V2_CHUNK_BOUND_INVALID",
+      "Plaintext chunk bound is outside the supported manifest range",
+    );
+  }
+  assertActive(input);
+  // A deadline is transport freshness, not durable operation identity. Binding
+  // it into the spool would make an interrupted capture impossible to resume
+  // with a fresh, valid HTTP deadline after the old one expires.
+  const { requestSha256, authoritySha256 } = deriveAgentBackupCaptureV3SpoolAuthorityDigests({
+    request,
+    authority: input.authority,
+  });
+  const spool = await AgentBackupCaptureV3Spool.open(input.spool, {
+    operationId: request.operationId,
+    executionToken: input.executionToken,
+    requestSha256,
+    authoritySha256,
+  });
+
+  try {
+    let artifacts: AgentBackupCaptureV3Artifacts;
+    if (spool.phase === "sealed" || spool.phase === "publishing" || spool.phase === "published") {
+      artifacts = await loadAgentBackupCaptureV3SealedArtifacts(spool);
+    } else {
+      const acquired = await acquireOperationKeyBundle(input, spool);
+      let processingFailure: unknown;
+      let composedArtifacts: AgentBackupCaptureV3Artifacts | undefined;
+      try {
+        const components = await composeCapture(
+          input,
+          spool,
+          acquired.dek,
+          acquired.contentHmacKey,
+          chunkPlainBytes,
+        );
+        const framedContentHmacSha256 = await computeFramedContentHmac({
+          pipeline: input,
+          spool,
+          dek: acquired.dek,
+          contentHmacKey: acquired.contentHmacKey,
+          components,
+        });
+        const totals = manifestTotals(components);
+        const manifest = await createAgentBackupManifestV3({
+          format: AGENT_BACKUP_MANIFEST_FORMAT,
+          schemaVersion: AGENT_BACKUP_MANIFEST_V3_SCHEMA_VERSION,
+          operationId: request.operationId,
+          createdAt: input.authority.createdAt,
+          identity: {
+            organizationId: input.authority.organizationId,
+            agentId: request.agentId,
+            activationGeneration: request.activationGeneration,
+            lifecycleRevision: request.lifecycleRevision,
+          },
+          source: input.authority.source,
+          runtime: input.authority.runtime,
+          chain: input.authority.chain,
+          components: components.map((component) => component.manifest),
+          watermarks: [...input.authority.watermarks],
+          totals,
+          vaultKeyAuthority: input.authority.vaultKeyAuthority,
+          encryption: {
+            algorithm: "AES-256-GCM",
+            chunkEnvelope: AGENT_BACKUP_CHUNK_ENVELOPE_V1.name,
+            nonceBytes: AGENT_BACKUP_CHUNK_ENVELOPE_V1.nonceBytes,
+            tagBytes: AGENT_BACKUP_CHUNK_ENVELOPE_V1.tagBytes,
+            noncePlacement: AGENT_BACKUP_CHUNK_ENVELOPE_V1.noncePlacement,
+            tagPlacement: AGENT_BACKUP_CHUNK_ENVELOPE_V1.tagPlacement,
+            aad: { version: 1, derivation: "elizaos.agent-backup.chunk-aad.v1" },
+            kms: input.authority.kms,
+            operationKeyBundle: {
+              format: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.format,
+              generationId: acquired.generationId,
+              plaintextBytes: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.plaintextBytes,
+              dek: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.dek,
+              contentHmac: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.contentHmac,
+              wrapped: {
+                ref: `backup-key-bundle:${request.operationId}`,
+                bytes: acquired.wrapped.bytes,
+                sha256: acquired.wrapped.sha256,
+                localReceiptDerivation: AGENT_BACKUP_OPERATION_KEY_BUNDLE_LOCAL_RECEIPT_DERIVATION,
+                localReceiptDigest: acquired.wrapped.localReceiptDigest,
+                contextDerivation: AGENT_BACKUP_OPERATION_KEY_BUNDLE_CONTEXT_DERIVATION,
+              },
+            },
+          },
+          integrity: {
+            framedContentHmacSha256,
+            contentAddressing: {
+              algorithm: "HMAC-SHA-256",
+              scope: "operation",
+              derivation: AGENT_BACKUP_OPERATION_CONTENT_HMAC_DERIVATION,
+              keyBundleFormat: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.format,
+              keyOffsetBytes: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.contentHmac.offsetBytes,
+              keyBytes: AGENT_BACKUP_OPERATION_KEY_BUNDLE_V1.contentHmac.bytes,
+            },
+          },
+        });
+        const manifestBytes = new TextEncoder().encode(canonicalJson(manifest));
+        await spool.sealManifest(manifestBytes, {
+          bytes: manifestBytes.byteLength,
+          sha256: sha256Hex(manifestBytes),
+        });
+        composedArtifacts = {
+          manifest,
+          catalogManifest: await catalogManifest(manifest, acquired.wrapped.wrappedKeyBundle),
+          wrappedKeyBundle: Uint8Array.from(acquired.wrapped.wrappedKeyBundle),
+          chunks: spool.chunks,
+        };
+      } catch (cause) {
+        // error-policy:J3 retain processing failure until mandatory key release.
+        processingFailure = cause;
+      }
+      let releaseFailure: unknown;
+      try {
+        await releaseAndZeroizeKeyBundle(input.keyBundle, acquired.handle, acquired);
+      } catch (cause) {
+        // error-policy:J3 retain mandatory release failure below.
+        releaseFailure = cause;
+      } finally {
+        acquired.wrapped.wrappedKeyBundle.fill(0);
+      }
+      if (processingFailure !== undefined && releaseFailure !== undefined) {
+        throw new AggregateError(
+          [processingFailure, releaseFailure],
+          "Backup processing and key-bundle release both failed",
+        );
+      }
+      if (processingFailure !== undefined) throw processingFailure;
+      if (releaseFailure !== undefined) throw releaseFailure;
+      if (!composedArtifacts) {
+        pipelineError(
+          "AGENT_BACKUP_V2_PIPELINE_INCOMPLETE",
+          "Backup composition completed without durable artifacts",
+        );
+      }
+      artifacts = composedArtifacts;
+    }
+
+    const manifestSha256 = artifacts.manifest.integrity.manifestSha256;
+    const chunkCount = artifacts.chunks.length;
+    try {
+      await publishArtifacts(input, spool, artifacts);
+    } finally {
+      artifacts.wrappedKeyBundle.fill(0);
+    }
+    if (input.publication.mode === "capture-only") {
+      await spool.close();
+      return {
+        operationId: request.operationId,
+        manifestSha256,
+        chunkCount,
+        state: "captured-upload-pending",
+        cleanup: "blocked-on-upload",
+        spool,
+      };
+    }
+    return {
+      operationId: request.operationId,
+      manifestSha256,
+      chunkCount,
+      state: "published-cleanup-pending",
+      cleanup: "pending",
+      spool,
+    };
+  } catch (cause) {
+    // error-policy:J3 a failed execution relinquishes only its lock and keeps
+    // durable replay artifacts. Preserve a close failure alongside the cause.
+    try {
+      await spool.close();
+    } catch (closeCause) {
+      throw new AggregateError(
+        [cause, closeCause],
+        "Backup pipeline and spool lock release both failed",
+      );
+    }
+    throw cause;
+  }
+}
+
+export { AGENT_BACKUP_RECORD_STREAM_V1_FORMAT as AGENT_BACKUP_CAPTURE_V2_RECORD_STREAM_FORMAT };

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-spool.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v2-spool.ts
@@ -1,0 +1,2002 @@
+/**
+ * Durable ciphertext-only filesystem spool for capture-v2/manifest-v3
+ * composition. Plaintext is never accepted by this boundary. Legacy v2 spools
+ * stay isolated and fail closed; they are never promoted into this namespace.
+ */
+
+import { Buffer } from "node:buffer";
+import { createHash, randomBytes } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  KMS_AEAD_OPERATION_KEY_BUNDLE_LOCAL_RECEIPT_DERIVATION,
+  KMS_AEAD_OPERATION_KEY_BUNDLE_V1,
+} from "@elizaos/core/security/kms";
+import { AGENT_BACKUP_CHUNK_ENVELOPE_V1, AGENT_BACKUP_MANIFEST_V2_LIMITS } from "@elizaos/shared";
+import z from "zod";
+
+const SPOOL_FORMAT = "elizaos.agent-backup.capture-v3-spool" as const;
+const SPOOL_VERSION = 3 as const;
+const LEGACY_SPOOL_FORMAT = "elizaos.agent-backup.capture-v2-spool" as const;
+const LEGACY_SPOOL_VERSION = 2 as const;
+const JOURNAL_FILE = "journal.json";
+const MANIFEST_FILE = "manifest.json";
+const CATALOG_MANIFEST_FILE = "catalog-manifest.json";
+const NAMESPACE_DIRECTORY = "agent-backup-capture-v3";
+const LEGACY_NAMESPACE_DIRECTORY = "agent-backup-capture-v2";
+const LOCK_OWNER_FILE = "owner.json";
+const LOCK_FORMAT = "elizaos.agent-backup.capture-v3-spool-lock" as const;
+const LOCK_VERSION = 1 as const;
+const MAX_JOURNAL_BYTES = 4 * 1024 * 1024;
+const MAX_LOCK_OWNER_BYTES = 4096;
+const MAX_MANIFEST_BYTES = 4 * 1024 * 1024;
+const MAX_CATALOG_MANIFEST_BYTES = 4 * 1024 * 1024;
+const MAX_KEY_BUNDLE_CONTEXT_BYTES = 64 * 1024;
+const FILE_MODE = 0o600;
+const DIRECTORY_MODE = 0o700;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const OWNER_NONCE_PATTERN = /^[0-9a-f]{48}$/;
+const PROCESS_START_TIME_PATTERN = /^(?:0|[1-9][0-9]*)$/;
+const LOCK_DIRECTORY_PATTERN =
+  /^\.[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.lock$/;
+
+const SafeIntegerSchema = z.number().int().safe().nonnegative();
+const ChunkIndexSchema = SafeIntegerSchema.max(
+  AGENT_BACKUP_MANIFEST_V2_LIMITS.maxChunksPerComponent - 1,
+);
+const ChunkSchema = z.strictObject({
+  component: z.string().regex(/^[a-z][a-z0-9-]{0,63}$/),
+  index: ChunkIndexSchema,
+  file: z.string().regex(/^chunk-[a-z][a-z0-9-]{0,63}-[0-9]{6}\.bin$/),
+  nonceHex: z.string().regex(/^[0-9a-f]{24}$/),
+  plainBytes: SafeIntegerSchema.positive().max(AGENT_BACKUP_MANIFEST_V2_LIMITS.maxChunkPlainBytes),
+  compressedBytes: SafeIntegerSchema.positive().max(
+    AGENT_BACKUP_MANIFEST_V2_LIMITS.maxChunkCompressedBytes,
+  ),
+  encryptedBytes: SafeIntegerSchema.positive().max(
+    AGENT_BACKUP_MANIFEST_V2_LIMITS.maxChunkEncryptedBytes,
+  ),
+  contentHmacSha256: z.string().regex(SHA256_PATTERN),
+  aadSha256: z.string().regex(SHA256_PATTERN),
+  ciphertextSha256: z.string().regex(SHA256_PATTERN),
+});
+
+const UploadedChunkKeySchema = z.string().regex(/^[a-z][a-z0-9-]{0,63}:(?:0|[1-9][0-9]*)$/);
+
+export type AgentBackupCaptureV3SpoolChunk = z.infer<typeof ChunkSchema>;
+
+const OperationKeyBundleSchema = z.strictObject({
+  generationId: z.string().regex(UUID_PATTERN),
+  format: z.literal(KMS_AEAD_OPERATION_KEY_BUNDLE_V1.format),
+  plaintextBytes: z.literal(KMS_AEAD_OPERATION_KEY_BUNDLE_V1.plaintextBytes),
+  nonceBytes: z.literal(KMS_AEAD_OPERATION_KEY_BUNDLE_V1.nonceBytes),
+  authTagBytes: z.literal(KMS_AEAD_OPERATION_KEY_BUNDLE_V1.authTagBytes),
+  bytes: z.literal(KMS_AEAD_OPERATION_KEY_BUNDLE_V1.wrappedBytes),
+  sha256: z.string().regex(SHA256_PATTERN),
+  localReceiptDerivation: z.literal(KMS_AEAD_OPERATION_KEY_BUNDLE_LOCAL_RECEIPT_DERIVATION),
+  localReceiptDigest: z.string().regex(SHA256_PATTERN),
+  canonicalContext: z.string().min(1).max(MAX_KEY_BUNDLE_CONTEXT_BYTES),
+  canonicalContextSha256: z.string().regex(SHA256_PATTERN),
+  ciphertextBase64: z.string().min(4).max(256),
+});
+
+const ManifestSchema = z.strictObject({
+  file: z.literal(MANIFEST_FILE),
+  bytes: z.number().int().safe().positive().max(MAX_MANIFEST_BYTES),
+  sha256: z.string().regex(SHA256_PATTERN),
+});
+
+const CatalogManifestSchema = z.strictObject({
+  file: z.literal(CATALOG_MANIFEST_FILE),
+  bytes: z.number().int().safe().positive().max(MAX_CATALOG_MANIFEST_BYTES),
+  sha256: z.string().regex(SHA256_PATTERN),
+});
+
+const LockOwnerSchema = z.strictObject({
+  format: z.literal(LOCK_FORMAT),
+  version: z.literal(LOCK_VERSION),
+  operationId: z.string().regex(UUID_PATTERN),
+  executionToken: z.string().regex(UUID_PATTERN),
+  linuxBootId: z.string().regex(UUID_PATTERN),
+  pid: z.number().int().safe().positive(),
+  processStartTime: z.string().regex(PROCESS_START_TIME_PATTERN),
+  ownerNonce: z.string().regex(OWNER_NONCE_PATTERN),
+});
+
+const JournalSchema = z
+  .strictObject({
+    format: z.literal(SPOOL_FORMAT),
+    version: z.literal(SPOOL_VERSION),
+    operationId: z.string().regex(UUID_PATTERN),
+    requestSha256: z.string().regex(SHA256_PATTERN),
+    authoritySha256: z.string().regex(SHA256_PATTERN),
+    phase: z.enum(["initialized", "capturing", "sealed", "publishing", "published"]),
+    operationKeyBundle: OperationKeyBundleSchema.optional(),
+    chunks: z.array(ChunkSchema).max(AGENT_BACKUP_MANIFEST_V2_LIMITS.maxChunks),
+    manifest: ManifestSchema.optional(),
+    catalogManifest: CatalogManifestSchema.optional(),
+    recordCaptured: z.enum(["pending", "confirmed"]),
+    uploadedChunkKeys: z
+      .array(UploadedChunkKeySchema)
+      .max(AGENT_BACKUP_MANIFEST_V2_LIMITS.maxChunks),
+    cleanup: z.literal("pending"),
+    committedBytes: SafeIntegerSchema,
+  })
+  .superRefine((value, context) => {
+    const chunkKeys = new Set<string>();
+    const componentNames = new Set<string>();
+    const nonces = new Set<string>();
+    let previousChunk: AgentBackupCaptureV3SpoolChunk | undefined;
+    for (let index = 0; index < value.chunks.length; index += 1) {
+      const chunk = value.chunks[index];
+      if (!chunk) continue;
+      const key = `${chunk.component}:${chunk.index}`;
+      componentNames.add(chunk.component);
+      if (chunk.file !== chunkFile(chunk.component, chunk.index)) {
+        context.addIssue({
+          code: "custom",
+          path: ["chunks", index, "file"],
+          message: "Ciphertext artifact name differs from its chunk identity",
+        });
+      }
+      if (chunkKeys.has(key)) {
+        context.addIssue({
+          code: "custom",
+          path: ["chunks", index],
+          message: "Ciphertext chunk identities must be unique",
+        });
+      }
+      chunkKeys.add(key);
+      if (nonces.has(chunk.nonceHex)) {
+        context.addIssue({
+          code: "custom",
+          path: ["chunks", index, "nonceHex"],
+          message: "Ciphertext nonces must be unique within one operation",
+        });
+      }
+      nonces.add(chunk.nonceHex);
+      if (
+        chunk.compressedBytes !== chunk.plainBytes ||
+        chunk.encryptedBytes !==
+          chunk.compressedBytes +
+            AGENT_BACKUP_CHUNK_ENVELOPE_V1.nonceBytes +
+            AGENT_BACKUP_CHUNK_ENVELOPE_V1.tagBytes
+      ) {
+        context.addIssue({
+          code: "custom",
+          path: ["chunks", index, "encryptedBytes"],
+          message: "Capture-v3 spool chunks require the canonical uncompressed GCM envelope",
+        });
+      }
+      if (previousChunk) {
+        const componentOrder = compareCanonicalComponentNames(
+          previousChunk.component,
+          chunk.component,
+        );
+        if (
+          componentOrder > 0 ||
+          (componentOrder === 0 && chunk.index !== previousChunk.index + 1)
+        ) {
+          context.addIssue({
+            code: "custom",
+            path: ["chunks", index],
+            message: "Ciphertext chunks must use canonical component and contiguous index order",
+          });
+        }
+      } else if (chunk.index !== 0) {
+        context.addIssue({
+          code: "custom",
+          path: ["chunks", index, "index"],
+          message: "The first ciphertext chunk for a component must have index zero",
+        });
+      }
+      if (previousChunk?.component !== chunk.component && chunk.index !== 0) {
+        context.addIssue({
+          code: "custom",
+          path: ["chunks", index, "index"],
+          message: "The first ciphertext chunk for a component must have index zero",
+        });
+      }
+      previousChunk = chunk;
+    }
+    if (componentNames.size > AGENT_BACKUP_MANIFEST_V2_LIMITS.maxComponents) {
+      context.addIssue({
+        code: "custom",
+        path: ["chunks"],
+        message: "Ciphertext inventory exceeds the component limit",
+      });
+    }
+
+    const uploadedKeys = new Set(value.uploadedChunkKeys);
+    if (uploadedKeys.size !== value.uploadedChunkKeys.length) {
+      context.addIssue({
+        code: "custom",
+        path: ["uploadedChunkKeys"],
+        message: "Ciphertext upload receipts must be unique",
+      });
+    }
+    for (let index = 0; index < value.uploadedChunkKeys.length; index += 1) {
+      const key = value.uploadedChunkKeys[index];
+      if (key && !chunkKeys.has(key)) {
+        context.addIssue({
+          code: "custom",
+          path: ["uploadedChunkKeys", index],
+          message: "Ciphertext upload receipt references an unknown chunk",
+        });
+      }
+      if (
+        index > 0 &&
+        key !== undefined &&
+        value.uploadedChunkKeys[index - 1] !== undefined &&
+        compareCanonicalComponentNames(value.uploadedChunkKeys[index - 1] ?? "", key) >= 0
+      ) {
+        context.addIssue({
+          code: "custom",
+          path: ["uploadedChunkKeys", index],
+          message: "Ciphertext upload receipts must use canonical order",
+        });
+      }
+    }
+    if (value.recordCaptured === "confirmed" && !value.catalogManifest) {
+      context.addIssue({
+        code: "custom",
+        path: ["catalogManifest"],
+        message: "Confirmed catalogue handoff requires exact durable bytes",
+      });
+    }
+    if (value.catalogManifest && value.recordCaptured !== "confirmed") {
+      context.addIssue({
+        code: "custom",
+        path: ["recordCaptured"],
+        message: "Durable catalogue bytes require a confirmed handoff receipt",
+      });
+    }
+    if (value.manifest && !value.operationKeyBundle) {
+      context.addIssue({
+        code: "custom",
+        path: ["operationKeyBundle"],
+        message: "A sealed v3 manifest requires one operation key bundle",
+      });
+    }
+    if (
+      (value.phase === "sealed" || value.phase === "publishing" || value.phase === "published") &&
+      !value.manifest
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["manifest"],
+        message: "A sealed or publishing operation requires a durable manifest",
+      });
+    }
+    if (
+      (value.phase === "initialized" || value.phase === "capturing") &&
+      (value.manifest ||
+        value.catalogManifest ||
+        value.recordCaptured === "confirmed" ||
+        value.uploadedChunkKeys.length > 0)
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["phase"],
+        message: "An unsealed operation cannot contain publication authority",
+      });
+    }
+    if (value.phase === "initialized" && (value.operationKeyBundle || value.chunks.length > 0)) {
+      context.addIssue({
+        code: "custom",
+        path: ["phase"],
+        message: "An initialized operation cannot contain capture artifacts",
+      });
+    }
+    if (value.phase === "capturing" && !value.operationKeyBundle) {
+      context.addIssue({
+        code: "custom",
+        path: ["operationKeyBundle"],
+        message: "A capturing v3 operation requires its durable key bundle",
+      });
+    }
+    if (
+      value.phase !== "publishing" &&
+      value.phase !== "published" &&
+      value.uploadedChunkKeys.length > 0
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["uploadedChunkKeys"],
+        message: "Chunk upload receipts require an active publication phase",
+      });
+    }
+    if (
+      value.phase === "published" &&
+      (value.recordCaptured !== "confirmed" || uploadedKeys.size !== chunkKeys.size)
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["phase"],
+        message: "Published state requires catalogue and every chunk receipt",
+      });
+    }
+  });
+
+const LegacyJournalHeaderSchema = z.object({
+  format: z.literal(LEGACY_SPOOL_FORMAT),
+  version: z.literal(LEGACY_SPOOL_VERSION),
+  operationId: z.string().regex(UUID_PATTERN),
+});
+
+type SpoolJournal = z.infer<typeof JournalSchema>;
+type SpoolLockOwner = z.infer<typeof LockOwnerSchema>;
+
+export interface AgentBackupCaptureV3SpoolProcessIdentity {
+  linuxBootId: string;
+  pid: number;
+  /** Linux `/proc/<pid>/stat` field 22, expressed in clock ticks. */
+  processStartTime: string;
+}
+
+export interface AgentBackupCaptureV3SpoolLockAuthority {
+  /** Trusted local-host identity for the process acquiring this operation. */
+  currentProcessIdentity(): Promise<AgentBackupCaptureV3SpoolProcessIdentity>;
+  /** Must return false only when the exact boot/pid/starttime identity is dead. */
+  isProcessIdentityAlive(identity: AgentBackupCaptureV3SpoolProcessIdentity): Promise<boolean>;
+}
+
+export interface AgentBackupCaptureV3SpoolConfig {
+  /** Explicit persistent StateDirectory; no temporary-directory fallback. */
+  stateDirectory: string;
+  maxSpoolBytes: number;
+  /** Space that must remain available after the next durable write. */
+  minFreeBytes: number;
+  /** Host authority is injectable only for deterministic non-Linux tests. */
+  lockAuthority?: AgentBackupCaptureV3SpoolLockAuthority;
+}
+
+export interface OpenAgentBackupCaptureV3SpoolInput {
+  operationId: string;
+  /** Durable job execution fence; distinct claimants must use distinct UUIDs. */
+  executionToken: string;
+  requestSha256: string;
+  authoritySha256: string;
+}
+
+export interface AgentBackupCaptureV3OperationKeyBundleMetadata {
+  generationId: string;
+  format: typeof KMS_AEAD_OPERATION_KEY_BUNDLE_V1.format;
+  plaintextBytes: typeof KMS_AEAD_OPERATION_KEY_BUNDLE_V1.plaintextBytes;
+  nonceBytes: typeof KMS_AEAD_OPERATION_KEY_BUNDLE_V1.nonceBytes;
+  authTagBytes: typeof KMS_AEAD_OPERATION_KEY_BUNDLE_V1.authTagBytes;
+  bytes: typeof KMS_AEAD_OPERATION_KEY_BUNDLE_V1.wrappedBytes;
+  sha256: string;
+  localReceiptDerivation: typeof KMS_AEAD_OPERATION_KEY_BUNDLE_LOCAL_RECEIPT_DERIVATION;
+  localReceiptDigest: string;
+  canonicalContext: string;
+  canonicalContextSha256: string;
+}
+
+export interface AgentBackupCaptureV3ManifestMetadata {
+  bytes: number;
+  sha256: string;
+}
+
+export interface AgentBackupCaptureV3CatalogManifestMetadata {
+  bytes: number;
+  sha256: string;
+}
+
+export interface AgentBackupCaptureV3CleanupReceipt {
+  operationId: string;
+  status: "complete" | "pending";
+}
+
+export interface AgentBackupCaptureV3DurableOperationAuthority {
+  operationId: string;
+  requestSha256: string;
+  authoritySha256: string;
+  phase: SpoolJournal["phase"];
+  recordCaptured: boolean;
+}
+
+export class AgentBackupCaptureV3SpoolError extends Error {
+  override readonly name = "AgentBackupCaptureV3SpoolError";
+
+  constructor(
+    readonly code: string,
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(message, { cause: options?.cause });
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+function spoolError(code: string, message: string, cause?: unknown): never {
+  throw new AgentBackupCaptureV3SpoolError(code, message, { cause });
+}
+
+function assertSafeByteCount(value: number, name: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    spoolError("AGENT_BACKUP_V2_SPOOL_CONFIG_INVALID", `${name} must be a safe byte count`);
+  }
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let output = "";
+  for (const byte of bytes) output += byte.toString(16).padStart(2, "0");
+  return output;
+}
+
+function sha256Hex(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function fsyncDirectory(directory: string): Promise<void> {
+  const handle = await fs.promises.open(directory, fs.constants.O_RDONLY);
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function lstatRegularFile(filePath: string): Promise<fs.Stats | null> {
+  try {
+    const stat = await fs.promises.lstat(filePath);
+    if (stat.isSymbolicLink() || !stat.isFile()) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_UNSAFE_ENTRY",
+        "Backup spool artifact is not a regular file",
+      );
+    }
+    return stat;
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw cause;
+  }
+}
+
+async function hashFile(
+  filePath: string,
+  maxBytes: number,
+): Promise<{ bytes: number; sha256: string }> {
+  const handle = await fs.promises.open(
+    filePath,
+    fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0),
+  );
+  const hash = createHash("sha256");
+  const buffer = new Uint8Array(256 * 1024);
+  let bytes = 0;
+  try {
+    for (;;) {
+      const read = await handle.read(buffer, 0, buffer.byteLength, null);
+      if (read.bytesRead === 0) break;
+      bytes += read.bytesRead;
+      if (bytes > maxBytes) {
+        spoolError(
+          "AGENT_BACKUP_V2_SPOOL_ARTIFACT_TOO_LARGE",
+          "Backup spool artifact exceeds its declared bound",
+        );
+      }
+      hash.update(buffer.subarray(0, read.bytesRead));
+    }
+  } finally {
+    await handle.close();
+  }
+  return { bytes, sha256: hash.digest("hex") };
+}
+
+async function readBoundedFile(filePath: string, maxBytes: number): Promise<Uint8Array> {
+  const stat = await lstatRegularFile(filePath);
+  if (!stat || stat.size > maxBytes) {
+    spoolError(
+      "AGENT_BACKUP_V2_SPOOL_ARTIFACT_INVALID",
+      "Backup spool artifact is missing or exceeds its bound",
+    );
+  }
+  const handle = await fs.promises.open(
+    filePath,
+    fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0),
+  );
+  const bytes = new Uint8Array(stat.size);
+  let offset = 0;
+  try {
+    while (offset < bytes.byteLength) {
+      const read = await handle.read(bytes, offset, bytes.byteLength - offset, offset);
+      if (read.bytesRead === 0) {
+        spoolError(
+          "AGENT_BACKUP_V2_SPOOL_TRUNCATED",
+          "Backup spool artifact was truncated while reading",
+        );
+      }
+      offset += read.bytesRead;
+    }
+  } finally {
+    await handle.close();
+  }
+  return bytes;
+}
+
+function parseLinuxProcessStartTime(stat: string): string {
+  const commandEnd = stat.lastIndexOf(")");
+  if (commandEnd < 2 || stat[commandEnd + 1] !== " ") {
+    spoolError(
+      "AGENT_BACKUP_V2_SPOOL_LOCK_LIVENESS_UNPROVABLE",
+      "Linux process stat record is malformed",
+    );
+  }
+  // Tokens after the command begin with field 3 (`state`); starttime is field 22.
+  const fields = stat
+    .slice(commandEnd + 2)
+    .trim()
+    .split(/\s+/);
+  const startTime = fields[19];
+  if (!startTime || !PROCESS_START_TIME_PATTERN.test(startTime)) {
+    spoolError(
+      "AGENT_BACKUP_V2_SPOOL_LOCK_LIVENESS_UNPROVABLE",
+      "Linux process starttime is unavailable",
+    );
+  }
+  return startTime;
+}
+
+async function readLinuxProcessStartTime(pid: number): Promise<string | null> {
+  try {
+    const stat = await fs.promises.readFile(`/proc/${pid}/stat`, "utf8");
+    if (stat.length > MAX_LOCK_OWNER_BYTES) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_LOCK_LIVENESS_UNPROVABLE",
+        "Linux process stat record exceeds its bound",
+      );
+    }
+    return parseLinuxProcessStartTime(stat);
+  } catch (cause) {
+    // error-policy:J2 ENOENT proves the exact PID is absent; every other host
+    // inspection failure is retained because lock takeover must fail closed.
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw cause;
+  }
+}
+
+const linuxSpoolLockAuthority: AgentBackupCaptureV3SpoolLockAuthority = {
+  async currentProcessIdentity() {
+    if (process.platform !== "linux") {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_LOCK_LIVENESS_UNPROVABLE",
+        "Capture spool locking requires Linux /proc process identity",
+      );
+    }
+    const linuxBootId = (
+      await fs.promises.readFile("/proc/sys/kernel/random/boot_id", "utf8")
+    ).trim();
+    const processStartTime = await readLinuxProcessStartTime(process.pid);
+    if (!UUID_PATTERN.test(linuxBootId) || processStartTime === null) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_LOCK_LIVENESS_UNPROVABLE",
+        "Current Linux boot or process identity is unavailable",
+      );
+    }
+    return { linuxBootId, pid: process.pid, processStartTime };
+  },
+  async isProcessIdentityAlive(identity) {
+    if (process.platform !== "linux") {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_LOCK_LIVENESS_UNPROVABLE",
+        "Capture spool lock liveness requires Linux /proc",
+      );
+    }
+    const currentBootId = (
+      await fs.promises.readFile("/proc/sys/kernel/random/boot_id", "utf8")
+    ).trim();
+    if (!UUID_PATTERN.test(currentBootId)) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_LOCK_LIVENESS_UNPROVABLE",
+        "Current Linux boot identity is invalid",
+      );
+    }
+    if (currentBootId !== identity.linuxBootId) return false;
+    const observedStartTime = await readLinuxProcessStartTime(identity.pid);
+    return observedStartTime !== null && observedStartTime === identity.processStartTime;
+  },
+};
+
+interface AcquiredSpoolLock {
+  authority: AgentBackupCaptureV3SpoolLockAuthority;
+  directory: string;
+  ownerPath: string;
+  ownerHandle: fs.promises.FileHandle;
+  ownerStat: fs.Stats;
+  record: SpoolLockOwner;
+}
+
+async function readLockOwner(ownerPath: string): Promise<SpoolLockOwner> {
+  try {
+    const bytes = await readBoundedFile(ownerPath, MAX_LOCK_OWNER_BYTES);
+    return LockOwnerSchema.parse(JSON.parse(new TextDecoder().decode(bytes)));
+  } catch (cause) {
+    // error-policy:J1 an invalid owner destroys the only safe liveness proof;
+    // retain the parse failure and refuse takeover.
+    spoolError(
+      "AGENT_BACKUP_V2_SPOOL_LOCK_LIVENESS_UNPROVABLE",
+      "Capture spool lock owner is invalid",
+      cause,
+    );
+  }
+}
+
+async function removeReclaimableLockDirectory(directory: string): Promise<void> {
+  const entries = await fs.promises.readdir(directory, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name !== LOCK_OWNER_FILE || !entry.isFile() || entry.isSymbolicLink()) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_LOCK_LIVENESS_UNPROVABLE",
+        "Reclaimable capture spool lock contains an unsafe entry",
+      );
+    }
+    await fs.promises.unlink(path.join(directory, entry.name));
+  }
+  await fs.promises.rmdir(directory);
+}
+
+async function acquireSpoolLock(input: {
+  namespaceDirectory: string;
+  operationId: string;
+  executionToken: string;
+  authority: AgentBackupCaptureV3SpoolLockAuthority;
+}): Promise<AcquiredSpoolLock> {
+  const identity = await input.authority.currentProcessIdentity();
+  const record = LockOwnerSchema.parse({
+    format: LOCK_FORMAT,
+    version: LOCK_VERSION,
+    operationId: input.operationId,
+    executionToken: input.executionToken,
+    ...identity,
+    ownerNonce: bytesToHex(randomBytes(24)),
+  });
+  const directory = path.join(input.namespaceDirectory, `.${input.operationId}.lock`);
+  const ownerPath = path.join(directory, LOCK_OWNER_FILE);
+
+  for (;;) {
+    try {
+      await fs.promises.mkdir(directory, { mode: DIRECTORY_MODE });
+    } catch (cause) {
+      // error-policy:J2 EEXIST is inspected through exact Linux process
+      // identity. No age, timeout, or execution token can prove an owner dead.
+      if ((cause as NodeJS.ErrnoException).code !== "EEXIST") throw cause;
+      const existing = await readLockOwner(ownerPath);
+      let alive: boolean;
+      try {
+        alive = await input.authority.isProcessIdentityAlive({
+          linuxBootId: existing.linuxBootId,
+          pid: existing.pid,
+          processStartTime: existing.processStartTime,
+        });
+      } catch (livenessCause) {
+        // error-policy:J2 an inspection failure cannot prove the prior owner
+        // dead, so takeover fails closed with a stable domain error.
+        spoolError(
+          "AGENT_BACKUP_V2_SPOOL_LOCK_LIVENESS_UNPROVABLE",
+          "Capture spool lock owner liveness could not be proven",
+          livenessCause,
+        );
+      }
+      if (alive) {
+        spoolError(
+          "AGENT_BACKUP_V2_SPOOL_LOCKED",
+          "Backup operation spool is owned by a live process",
+        );
+      }
+      const quarantine = `${directory}.reclaim-${record.ownerNonce}`;
+      try {
+        await fs.promises.rename(directory, quarantine);
+      } catch (renameCause) {
+        // error-policy:J2 another claimant may have completed the exact
+        // reclaim first; retry only when the source disappeared.
+        if ((renameCause as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw renameCause;
+      }
+      await removeReclaimableLockDirectory(quarantine);
+      await fsyncDirectory(input.namespaceDirectory);
+      continue;
+    }
+
+    let ownerHandle: fs.promises.FileHandle | undefined;
+    try {
+      ownerHandle = await fs.promises.open(
+        ownerPath,
+        fs.constants.O_CREAT |
+          fs.constants.O_EXCL |
+          fs.constants.O_RDWR |
+          (fs.constants.O_NOFOLLOW ?? 0),
+        FILE_MODE,
+      );
+      const bytes = new TextEncoder().encode(JSON.stringify(record));
+      await ownerHandle.writeFile(bytes);
+      await ownerHandle.sync();
+      await fsyncDirectory(directory);
+      await fsyncDirectory(input.namespaceDirectory);
+      const ownerStat = await ownerHandle.stat();
+      return {
+        authority: input.authority,
+        directory,
+        ownerPath,
+        ownerHandle,
+        ownerStat,
+        record,
+      };
+    } catch (cause) {
+      // error-policy:J3 retain initialization failure after best-effort
+      // removal of this claimant's incomplete lock directory.
+      await ownerHandle?.close().catch(() => undefined);
+      await fs.promises.unlink(ownerPath).catch(() => undefined);
+      await fs.promises.rmdir(directory).catch(() => undefined);
+      throw cause;
+    }
+  }
+}
+
+async function assertSpoolLockOwner(lock: AcquiredSpoolLock): Promise<void> {
+  let current: fs.Stats;
+  try {
+    current = await fs.promises.lstat(lock.ownerPath);
+  } catch (cause) {
+    // error-policy:J1 loss of the exact owner inode is a hard execution-fence
+    // failure; retain the filesystem cause for the caller.
+    spoolError(
+      "AGENT_BACKUP_V2_SPOOL_LOCK_LOST",
+      "Backup spool execution lock is no longer current",
+      cause,
+    );
+  }
+  if (
+    !current.isFile() ||
+    current.isSymbolicLink() ||
+    current.dev !== lock.ownerStat.dev ||
+    current.ino !== lock.ownerStat.ino
+  ) {
+    spoolError(
+      "AGENT_BACKUP_V2_SPOOL_LOCK_LOST",
+      "Backup spool execution lock was replaced by another claimant",
+    );
+  }
+  const currentRecord = await readLockOwner(lock.ownerPath);
+  if (
+    currentRecord.ownerNonce !== lock.record.ownerNonce ||
+    currentRecord.executionToken !== lock.record.executionToken ||
+    currentRecord.operationId !== lock.record.operationId
+  ) {
+    spoolError(
+      "AGENT_BACKUP_V2_SPOOL_LOCK_LOST",
+      "Backup spool owner nonce or execution token changed",
+    );
+  }
+}
+
+async function releaseSpoolLock(lock: AcquiredSpoolLock): Promise<void> {
+  let stillOwner = false;
+  try {
+    await assertSpoolLockOwner(lock);
+    stillOwner = true;
+  } catch {
+    // error-policy:J4 a superseded claimant must never unlink the successor's
+    // lock; closing its private inode is the only safe action.
+  }
+  await lock.ownerHandle.close();
+  if (!stillOwner) return;
+  await fs.promises.unlink(lock.ownerPath);
+  await fsyncDirectory(lock.directory);
+  await fs.promises.rmdir(lock.directory);
+  await fsyncDirectory(path.dirname(lock.directory));
+}
+
+function isOwnedTemporaryArtifact(name: string): boolean {
+  return /^\.(?:journal\.json|manifest\.json|catalog-manifest\.json|chunk-[a-z][a-z0-9-]{0,63}-[0-9]{6}\.bin)\.[0-9a-f]{24}\.tmp$/.test(
+    name,
+  );
+}
+
+function compareCanonicalComponentNames(left: string, right: string): number {
+  if (left === right) return 0;
+  return left < right ? -1 : 1;
+}
+
+function chunkKey(chunk: Pick<AgentBackupCaptureV3SpoolChunk, "component" | "index">): string {
+  return `${chunk.component}:${chunk.index}`;
+}
+
+function chunkFile(component: string, index: number): string {
+  return `chunk-${component}-${String(index).padStart(6, "0")}.bin`;
+}
+
+function equalChunk(
+  left: AgentBackupCaptureV3SpoolChunk,
+  right: AgentBackupCaptureV3SpoolChunk,
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+async function assertNoLegacyV2Spool(stateDirectory: string, operationId: string): Promise<void> {
+  const legacyNamespace = path.join(stateDirectory, LEGACY_NAMESPACE_DIRECTORY);
+  let namespaceStat: fs.Stats;
+  try {
+    namespaceStat = await fs.promises.lstat(legacyNamespace);
+  } catch (cause) {
+    // error-policy:J2 absence proves there is no legacy operation to quarantine.
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw cause;
+  }
+  if (namespaceStat.isSymbolicLink() || !namespaceStat.isDirectory()) {
+    spoolError(
+      "AGENT_BACKUP_V3_LEGACY_SPOOL_UNSAFE",
+      "Legacy backup spool namespace is not a safe directory",
+    );
+  }
+  const legacyLockDirectory = path.join(legacyNamespace, `.${operationId}.lock`);
+  try {
+    await fs.promises.lstat(legacyLockDirectory);
+    spoolError(
+      "AGENT_BACKUP_V3_LEGACY_SPOOL_QUARANTINED",
+      "Legacy backup operation lock is isolated and cannot be promoted to v3",
+    );
+  } catch (cause) {
+    // error-policy:J2 absence proves no legacy claimant currently owns the
+    // well-known v2 lock path; every observed entry is quarantined above.
+    if ((cause as NodeJS.ErrnoException).code !== "ENOENT") throw cause;
+  }
+  const legacyOperationDirectory = path.join(legacyNamespace, operationId);
+  let operationStat: fs.Stats;
+  try {
+    operationStat = await fs.promises.lstat(legacyOperationDirectory);
+  } catch (cause) {
+    // error-policy:J2 absence proves this operation has no legacy spool.
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw cause;
+  }
+  if (operationStat.isSymbolicLink() || !operationStat.isDirectory()) {
+    spoolError(
+      "AGENT_BACKUP_V3_LEGACY_SPOOL_UNSAFE",
+      "Legacy backup operation spool is not a safe directory",
+    );
+  }
+  try {
+    const journal = await readBoundedFile(
+      path.join(legacyOperationDirectory, JOURNAL_FILE),
+      MAX_JOURNAL_BYTES,
+    );
+    const header = LegacyJournalHeaderSchema.parse(
+      JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(journal)),
+    );
+    if (header.operationId !== operationId) {
+      spoolError(
+        "AGENT_BACKUP_V3_LEGACY_SPOOL_UNSAFE",
+        "Legacy backup spool identity differs from its directory",
+      );
+    }
+  } catch (cause) {
+    // error-policy:J1 an unreadable legacy spool cannot be reinterpreted as v3.
+    if (cause instanceof AgentBackupCaptureV3SpoolError) throw cause;
+    spoolError(
+      "AGENT_BACKUP_V3_LEGACY_SPOOL_UNSAFE",
+      "Legacy backup spool cannot be safely classified",
+      cause,
+    );
+  }
+  spoolError(
+    "AGENT_BACKUP_V3_LEGACY_SPOOL_QUARANTINED",
+    "Legacy manifest-v2 spool is isolated and cannot be promoted to v3",
+  );
+}
+
+/** Ciphertext-only, one-operation durable spool. */
+export class AgentBackupCaptureV3Spool {
+  private closed = false;
+  private cleanupComplete = false;
+
+  private constructor(
+    private readonly config: Readonly<AgentBackupCaptureV3SpoolConfig>,
+    readonly namespaceDirectory: string,
+    readonly operationDirectory: string,
+    private journal: SpoolJournal,
+    private readonly lock: AcquiredSpoolLock,
+  ) {}
+
+  static async open(
+    configInput: Readonly<AgentBackupCaptureV3SpoolConfig>,
+    input: Readonly<OpenAgentBackupCaptureV3SpoolInput>,
+  ): Promise<AgentBackupCaptureV3Spool> {
+    const spool = await AgentBackupCaptureV3Spool.openInternal(configInput, input, false);
+    if (!spool) {
+      spoolError(
+        "AGENT_BACKUP_V3_SPOOL_OPEN_INVALID",
+        "Fresh backup spool open unexpectedly resolved as absent",
+      );
+    }
+    return spool;
+  }
+
+  /** Open only durable existing artifacts; never recreate a cleaned operation. */
+  static async openExisting(
+    configInput: Readonly<AgentBackupCaptureV3SpoolConfig>,
+    input: Readonly<OpenAgentBackupCaptureV3SpoolInput>,
+  ): Promise<AgentBackupCaptureV3Spool | undefined> {
+    return AgentBackupCaptureV3Spool.openInternal(configInput, input, true);
+  }
+
+  /**
+   * Enumerate only validated journal authorities. This is the protected-cleanup
+   * recovery cursor after a catalogue transition response is lost.
+   */
+  static async listDurableOperationAuthorities(
+    configInput: Readonly<AgentBackupCaptureV3SpoolConfig>,
+  ): Promise<AgentBackupCaptureV3DurableOperationAuthority[]> {
+    const config = { ...configInput };
+    assertSafeByteCount(config.maxSpoolBytes, "maxSpoolBytes");
+    assertSafeByteCount(config.minFreeBytes, "minFreeBytes");
+    if (config.maxSpoolBytes === 0 || !path.isAbsolute(config.stateDirectory)) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_CONFIG_INVALID",
+        "Backup spool discovery requires an absolute persistent directory and positive cap",
+      );
+    }
+    const stateDirectory = path.resolve(config.stateDirectory);
+    let stateStat: fs.Stats;
+    try {
+      stateStat = await fs.promises.lstat(stateDirectory);
+    } catch (cause) {
+      if ((cause as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw cause;
+    }
+    const realStateDirectory = await fs.promises.realpath(stateDirectory);
+    if (
+      stateStat.isSymbolicLink() ||
+      !stateStat.isDirectory() ||
+      realStateDirectory !== stateDirectory
+    ) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_STATE_DIRECTORY_UNSAFE",
+        "Backup StateDirectory must not traverse a symbolic link",
+      );
+    }
+    const realTemporaryDirectory = await fs.promises.realpath(os.tmpdir());
+    const relativeToTemporary = path.relative(realTemporaryDirectory, stateDirectory);
+    if (
+      relativeToTemporary === "" ||
+      (!relativeToTemporary.startsWith("..") && !path.isAbsolute(relativeToTemporary))
+    ) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_STATE_DIRECTORY_TEMPORARY",
+        "Backup StateDirectory must be persistent and outside the system temporary directory",
+      );
+    }
+    const namespaceDirectory = path.join(stateDirectory, NAMESPACE_DIRECTORY);
+    let namespaceStat: fs.Stats;
+    try {
+      namespaceStat = await fs.promises.lstat(namespaceDirectory);
+    } catch (cause) {
+      if ((cause as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw cause;
+    }
+    if (namespaceStat.isSymbolicLink() || !namespaceStat.isDirectory()) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_STATE_DIRECTORY_UNSAFE",
+        "Backup spool namespace is not a safe directory",
+      );
+    }
+    const authorities: AgentBackupCaptureV3DurableOperationAuthority[] = [];
+    const entries = await fs.promises.readdir(namespaceDirectory, { withFileTypes: true });
+    for (const entry of entries) {
+      if (LOCK_DIRECTORY_PATTERN.test(entry.name)) {
+        if (!entry.isDirectory() || entry.isSymbolicLink()) {
+          spoolError(
+            "AGENT_BACKUP_V2_SPOOL_UNSAFE_ENTRY",
+            "Backup spool discovery encountered an unsafe lock entry",
+          );
+        }
+        continue;
+      }
+      if (!UUID_PATTERN.test(entry.name) || !entry.isDirectory() || entry.isSymbolicLink()) {
+        spoolError(
+          "AGENT_BACKUP_V2_SPOOL_UNSAFE_ENTRY",
+          "Backup spool discovery encountered an unsafe namespace entry",
+        );
+      }
+      let raw: Uint8Array;
+      try {
+        raw = await readBoundedFile(
+          path.join(namespaceDirectory, entry.name, JOURNAL_FILE),
+          MAX_JOURNAL_BYTES,
+        );
+      } catch (cause) {
+        if ((cause as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw cause;
+      }
+      let journal: SpoolJournal;
+      try {
+        journal = JournalSchema.parse(
+          JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(raw)),
+        );
+      } catch (cause) {
+        spoolError(
+          "AGENT_BACKUP_V2_SPOOL_JOURNAL_INVALID",
+          "Backup spool discovery found an invalid journal",
+          cause,
+        );
+      }
+      if (journal.operationId !== entry.name) {
+        spoolError(
+          "AGENT_BACKUP_V2_SPOOL_REPLAY_CONFLICT",
+          "Backup spool journal differs from its operation directory",
+        );
+      }
+      authorities.push(
+        Object.freeze({
+          operationId: journal.operationId,
+          requestSha256: journal.requestSha256,
+          authoritySha256: journal.authoritySha256,
+          phase: journal.phase,
+          recordCaptured: journal.recordCaptured === "confirmed",
+        }),
+      );
+    }
+    authorities.sort((left, right) => left.operationId.localeCompare(right.operationId));
+    return authorities;
+  }
+
+  private static async openInternal(
+    configInput: Readonly<AgentBackupCaptureV3SpoolConfig>,
+    input: Readonly<OpenAgentBackupCaptureV3SpoolInput>,
+    requireExisting: boolean,
+  ): Promise<AgentBackupCaptureV3Spool | undefined> {
+    const config = { ...configInput };
+    assertSafeByteCount(config.maxSpoolBytes, "maxSpoolBytes");
+    assertSafeByteCount(config.minFreeBytes, "minFreeBytes");
+    if (config.maxSpoolBytes === 0) {
+      spoolError("AGENT_BACKUP_V2_SPOOL_CONFIG_INVALID", "maxSpoolBytes must be positive");
+    }
+    if (!path.isAbsolute(config.stateDirectory)) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_STATE_DIRECTORY_INVALID",
+        "Backup StateDirectory must be an absolute persistent path",
+      );
+    }
+    if (!UUID_PATTERN.test(input.operationId)) {
+      spoolError("AGENT_BACKUP_V2_SPOOL_IDENTITY_INVALID", "operationId must be canonical UUID");
+    }
+    if (!UUID_PATTERN.test(input.executionToken)) {
+      spoolError("AGENT_BACKUP_V2_SPOOL_IDENTITY_INVALID", "executionToken must be canonical UUID");
+    }
+    if (!SHA256_PATTERN.test(input.requestSha256) || !SHA256_PATTERN.test(input.authoritySha256)) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_IDENTITY_INVALID",
+        "Spool request and authority digests must be SHA-256 hex",
+      );
+    }
+
+    const stateDirectory = path.resolve(config.stateDirectory);
+    await fs.promises.mkdir(stateDirectory, { recursive: true, mode: DIRECTORY_MODE });
+    const stateStat = await fs.promises.lstat(stateDirectory);
+    const realStateDirectory = await fs.promises.realpath(stateDirectory);
+    if (
+      stateStat.isSymbolicLink() ||
+      !stateStat.isDirectory() ||
+      realStateDirectory !== stateDirectory
+    ) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_STATE_DIRECTORY_UNSAFE",
+        "Backup StateDirectory must not traverse a symbolic link",
+      );
+    }
+    const realTemporaryDirectory = await fs.promises.realpath(os.tmpdir());
+    const relativeToTemporary = path.relative(realTemporaryDirectory, stateDirectory);
+    if (
+      relativeToTemporary === "" ||
+      (!relativeToTemporary.startsWith("..") && !path.isAbsolute(relativeToTemporary))
+    ) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_STATE_DIRECTORY_TEMPORARY",
+        "Backup StateDirectory must be persistent and outside the system temporary directory",
+      );
+    }
+    await assertNoLegacyV2Spool(stateDirectory, input.operationId);
+    const namespaceDirectory = path.join(stateDirectory, NAMESPACE_DIRECTORY);
+    await fs.promises.mkdir(namespaceDirectory, {
+      recursive: true,
+      mode: DIRECTORY_MODE,
+    });
+    const namespaceStat = await fs.promises.lstat(namespaceDirectory);
+    if (namespaceStat.isSymbolicLink() || !namespaceStat.isDirectory()) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_STATE_DIRECTORY_UNSAFE",
+        "Backup spool namespace is not a safe directory",
+      );
+    }
+    const lock = await acquireSpoolLock({
+      namespaceDirectory,
+      operationId: input.operationId,
+      executionToken: input.executionToken,
+      authority: config.lockAuthority ?? linuxSpoolLockAuthority,
+    });
+    try {
+      // Narrow the cross-namespace cutover race after v3 ownership. Deployment
+      // must still drain v2 writers because old binaries do not know this lock.
+      await assertNoLegacyV2Spool(stateDirectory, input.operationId);
+      const operationDirectory = path.join(namespaceDirectory, input.operationId);
+      let operationStat: fs.Stats;
+      try {
+        operationStat = await fs.promises.lstat(operationDirectory);
+      } catch (cause) {
+        if ((cause as NodeJS.ErrnoException).code !== "ENOENT") throw cause;
+        if (requireExisting) {
+          await releaseSpoolLock(lock);
+          return undefined;
+        }
+        await fs.promises.mkdir(operationDirectory, {
+          recursive: false,
+          mode: DIRECTORY_MODE,
+        });
+        operationStat = await fs.promises.lstat(operationDirectory);
+      }
+      if (operationStat.isSymbolicLink() || !operationStat.isDirectory()) {
+        spoolError(
+          "AGENT_BACKUP_V2_SPOOL_STATE_DIRECTORY_UNSAFE",
+          "Backup operation spool is not a safe directory",
+        );
+      }
+
+      const journalPath = path.join(operationDirectory, JOURNAL_FILE);
+      const existing = await lstatRegularFile(journalPath);
+      if (requireExisting && !existing) {
+        await releaseSpoolLock(lock);
+        return undefined;
+      }
+      let journal: SpoolJournal;
+      if (existing) {
+        const raw = await readBoundedFile(journalPath, MAX_JOURNAL_BYTES);
+        try {
+          journal = JournalSchema.parse(JSON.parse(new TextDecoder().decode(raw)));
+        } catch (cause) {
+          // error-policy:J1 invalid durable authority is retained and blocks
+          // replay; it is never replaced by a fresh journal.
+          spoolError(
+            "AGENT_BACKUP_V2_SPOOL_JOURNAL_INVALID",
+            "Backup spool journal is invalid",
+            cause,
+          );
+        }
+        if (
+          journal.operationId !== input.operationId ||
+          journal.requestSha256 !== input.requestSha256 ||
+          journal.authoritySha256 !== input.authoritySha256
+        ) {
+          spoolError(
+            "AGENT_BACKUP_V2_SPOOL_REPLAY_CONFLICT",
+            "Backup operation spool belongs to different immutable authority",
+          );
+        }
+      } else {
+        journal = {
+          format: SPOOL_FORMAT,
+          version: SPOOL_VERSION,
+          operationId: input.operationId,
+          requestSha256: input.requestSha256,
+          authoritySha256: input.authoritySha256,
+          phase: "initialized",
+          chunks: [],
+          recordCaptured: "pending",
+          uploadedChunkKeys: [],
+          cleanup: "pending",
+          committedBytes: 0,
+        };
+      }
+      const spool = new AgentBackupCaptureV3Spool(
+        Object.freeze({ ...config, stateDirectory }),
+        namespaceDirectory,
+        operationDirectory,
+        journal,
+        lock,
+      );
+      await spool.reapTemporaryArtifacts();
+      if (!existing) await spool.persistJournal();
+      await spool.verifyCommittedAccounting();
+      await spool.preflightWrite(0);
+      return spool;
+    } catch (cause) {
+      // error-policy:J3 opening never leaks ownership. Preserve both the open
+      // failure and a lock-release failure when the filesystem reports both.
+      try {
+        await releaseSpoolLock(lock);
+      } catch (releaseCause) {
+        throw new AggregateError(
+          [cause, releaseCause],
+          "Backup spool open and lock release both failed",
+        );
+      }
+      throw cause;
+    }
+  }
+
+  get operationId(): string {
+    return this.journal.operationId;
+  }
+
+  get phase(): SpoolJournal["phase"] {
+    return this.journal.phase;
+  }
+
+  get chunks(): readonly AgentBackupCaptureV3SpoolChunk[] {
+    return this.journal.chunks.map((chunk) => Object.freeze({ ...chunk }));
+  }
+
+  get recordCaptured(): boolean {
+    return this.journal.recordCaptured === "confirmed";
+  }
+
+  isChunkUploaded(chunk: Pick<AgentBackupCaptureV3SpoolChunk, "component" | "index">): boolean {
+    return this.journal.uploadedChunkKeys.includes(chunkKey(chunk));
+  }
+
+  private assertOpen(): void {
+    if (this.closed) {
+      spoolError("AGENT_BACKUP_V2_SPOOL_CLOSED", "Backup operation spool is closed");
+    }
+  }
+
+  private async assertMutationAuthority(): Promise<void> {
+    this.assertOpen();
+    await assertSpoolLockOwner(this.lock);
+  }
+
+  private async reapTemporaryArtifacts(): Promise<void> {
+    await this.assertMutationAuthority();
+    const entries = await fs.promises.readdir(this.operationDirectory, {
+      withFileTypes: true,
+    });
+    let reaped = false;
+    for (const entry of entries) {
+      if (!isOwnedTemporaryArtifact(entry.name)) continue;
+      if (!entry.isFile() || entry.isSymbolicLink()) {
+        spoolError(
+          "AGENT_BACKUP_V2_SPOOL_UNSAFE_ENTRY",
+          "Backup spool temporary artifact is not a regular file",
+        );
+      }
+      await this.assertMutationAuthority();
+      await fs.promises.unlink(path.join(this.operationDirectory, entry.name));
+      reaped = true;
+    }
+    if (reaped) await fsyncDirectory(this.operationDirectory);
+  }
+
+  private async preflightWrite(bytes: number): Promise<void> {
+    await this.assertMutationAuthority();
+    assertSafeByteCount(bytes, "artifact bytes");
+    let physicalBytes = 0;
+    const entries = await fs.promises.readdir(this.operationDirectory, {
+      withFileTypes: true,
+    });
+    for (const entry of entries) {
+      if (!entry.isFile() || entry.isSymbolicLink()) {
+        spoolError(
+          "AGENT_BACKUP_V2_SPOOL_UNSAFE_ENTRY",
+          "Backup spool contains a non-regular filesystem entry",
+        );
+      }
+      const stat = await fs.promises.lstat(path.join(this.operationDirectory, entry.name));
+      physicalBytes += stat.size;
+      if (!Number.isSafeInteger(physicalBytes)) {
+        spoolError(
+          "AGENT_BACKUP_V2_SPOOL_ACCOUNTING_INVALID",
+          "Backup spool physical byte accounting overflowed",
+        );
+      }
+    }
+    if (physicalBytes > this.config.maxSpoolBytes - bytes) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_QUOTA_EXCEEDED",
+        "Backup operation physical files would exceed its spool byte cap",
+      );
+    }
+    const stats = await fs.promises.statfs(this.operationDirectory);
+    const available = Number(stats.bavail) * Number(stats.bsize);
+    if (!Number.isSafeInteger(available) || available < bytes + this.config.minFreeBytes) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_SPACE_EXHAUSTED",
+        "Backup StateDirectory does not have enough reserved free space",
+      );
+    }
+  }
+
+  private async persistJournal(): Promise<void> {
+    await this.assertMutationAuthority();
+    const parsed = JournalSchema.parse(this.journal);
+    const bytes = new TextEncoder().encode(JSON.stringify(parsed));
+    if (bytes.byteLength > MAX_JOURNAL_BYTES) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_JOURNAL_TOO_LARGE",
+        "Backup spool journal exceeds its byte limit",
+      );
+    }
+    await this.preflightWrite(bytes.byteLength);
+    await this.atomicReplace(JOURNAL_FILE, [bytes], MAX_JOURNAL_BYTES);
+  }
+
+  private async atomicReplace(
+    fileName: string,
+    parts: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,
+    maxBytes: number,
+  ): Promise<{ bytes: number; sha256: string }> {
+    await this.assertMutationAuthority();
+    const temporaryName = `.${fileName}.${bytesToHex(randomBytes(12))}.tmp`;
+    const temporaryPath = path.join(this.operationDirectory, temporaryName);
+    const finalPath = path.join(this.operationDirectory, fileName);
+    const handle = await fs.promises.open(
+      temporaryPath,
+      fs.constants.O_CREAT |
+        fs.constants.O_EXCL |
+        fs.constants.O_WRONLY |
+        (fs.constants.O_NOFOLLOW ?? 0),
+      FILE_MODE,
+    );
+    const hash = createHash("sha256");
+    let bytes = 0;
+    try {
+      for await (const part of parts) {
+        if (!(part instanceof Uint8Array) || part.byteLength === 0) {
+          spoolError(
+            "AGENT_BACKUP_V2_SPOOL_ZERO_PROGRESS",
+            "Backup spool writer yielded an invalid empty fragment",
+          );
+        }
+        if (bytes > maxBytes - part.byteLength) {
+          spoolError(
+            "AGENT_BACKUP_V2_SPOOL_ARTIFACT_TOO_LARGE",
+            "Backup spool artifact exceeds its byte limit",
+          );
+        }
+        let offset = 0;
+        while (offset < part.byteLength) {
+          const written = await handle.write(part, offset, part.byteLength - offset, null);
+          if (written.bytesWritten === 0) {
+            spoolError(
+              "AGENT_BACKUP_V2_SPOOL_ZERO_PROGRESS",
+              "Backup spool filesystem write made no progress",
+            );
+          }
+          offset += written.bytesWritten;
+        }
+        hash.update(part);
+        bytes += part.byteLength;
+      }
+      await handle.sync();
+    } catch (cause) {
+      // error-policy:J4 the incomplete create-only temporary file is safe to
+      // remove; retain the originating write failure.
+      await handle.close().catch(() => undefined);
+      await fs.promises.unlink(temporaryPath).catch(() => undefined);
+      throw cause;
+    }
+    await handle.close();
+    await this.assertMutationAuthority();
+    await fs.promises.rename(temporaryPath, finalPath);
+    await fsyncDirectory(this.operationDirectory);
+    await this.assertMutationAuthority();
+    return { bytes, sha256: hash.digest("hex") };
+  }
+
+  private async writeCreateOnlyArtifact(
+    fileName: string,
+    parts: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,
+    expected: Readonly<{ bytes: number; sha256: string }>,
+    maxBytes: number,
+  ): Promise<void> {
+    const finalPath = path.join(this.operationDirectory, fileName);
+    const existing = await lstatRegularFile(finalPath);
+    if (existing) {
+      const observed = await hashFile(finalPath, maxBytes);
+      if (observed.bytes !== expected.bytes || observed.sha256 !== expected.sha256) {
+        spoolError(
+          "AGENT_BACKUP_V2_SPOOL_REPLAY_CONFLICT",
+          "Existing backup spool artifact differs from the exact replay",
+        );
+      }
+      return;
+    }
+    await this.preflightWrite(expected.bytes);
+    const written = await this.atomicReplace(fileName, parts, maxBytes);
+    if (written.bytes !== expected.bytes || written.sha256 !== expected.sha256) {
+      await this.assertMutationAuthority();
+      await fs.promises.unlink(finalPath).catch(() => undefined);
+      await fsyncDirectory(this.operationDirectory).catch(() => undefined);
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_DIGEST_MISMATCH",
+        "Backup spool writer produced bytes different from declared metadata",
+      );
+    }
+  }
+
+  private async verifyCommittedAccounting(): Promise<void> {
+    let committedBytes = 0;
+    if (this.journal.operationKeyBundle) {
+      committedBytes += this.journal.operationKeyBundle.bytes;
+    }
+    if (this.journal.manifest) committedBytes += this.journal.manifest.bytes;
+    if (this.journal.catalogManifest) {
+      committedBytes += this.journal.catalogManifest.bytes;
+    }
+    for (const chunk of this.journal.chunks) committedBytes += chunk.encryptedBytes;
+    if (committedBytes !== this.journal.committedBytes) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_ACCOUNTING_INVALID",
+        "Backup spool journal byte accounting is inconsistent",
+      );
+    }
+    if (committedBytes > this.config.maxSpoolBytes) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_QUOTA_EXCEEDED",
+        "Existing backup spool exceeds its configured byte cap",
+      );
+    }
+  }
+
+  async storeOperationKeyBundle(
+    metadata: Readonly<
+      Omit<AgentBackupCaptureV3OperationKeyBundleMetadata, "canonicalContextSha256">
+    >,
+    wrappedKeyBundle: Uint8Array,
+  ): Promise<void> {
+    await this.assertMutationAuthority();
+    if (this.journal.phase !== "initialized" && this.journal.phase !== "capturing") {
+      spoolError(
+        "AGENT_BACKUP_V3_SPOOL_PHASE_INVALID",
+        "Cannot replace an operation key bundle after manifest sealing",
+      );
+    }
+    const ciphertextBase64 = Buffer.from(
+      wrappedKeyBundle.buffer,
+      wrappedKeyBundle.byteOffset,
+      wrappedKeyBundle.byteLength,
+    ).toString("base64");
+    const parsed = OperationKeyBundleSchema.parse({
+      ...metadata,
+      canonicalContextSha256: sha256Hex(new TextEncoder().encode(metadata.canonicalContext)),
+      ciphertextBase64,
+    });
+    if (
+      wrappedKeyBundle.byteLength !== parsed.bytes ||
+      sha256Hex(wrappedKeyBundle) !== parsed.sha256
+    ) {
+      spoolError(
+        "AGENT_BACKUP_V3_SPOOL_KEY_BUNDLE_INVALID",
+        "Wrapped operation key bundle does not match its durable metadata",
+      );
+    }
+    if (this.journal.operationKeyBundle) {
+      if (JSON.stringify(this.journal.operationKeyBundle) !== JSON.stringify(parsed)) {
+        spoolError(
+          "AGENT_BACKUP_V3_SPOOL_REPLAY_CONFLICT",
+          "Backup operation already owns a different operation key bundle",
+        );
+      }
+      return;
+    }
+    this.journal.operationKeyBundle = parsed;
+    this.journal.committedBytes += parsed.bytes;
+    this.journal.phase = "capturing";
+    await this.persistJournal();
+  }
+
+  getOperationKeyBundleMetadata():
+    | Readonly<AgentBackupCaptureV3OperationKeyBundleMetadata>
+    | undefined {
+    const stored = this.journal.operationKeyBundle;
+    if (!stored) return undefined;
+    return Object.freeze({
+      generationId: stored.generationId,
+      format: stored.format,
+      plaintextBytes: stored.plaintextBytes,
+      nonceBytes: stored.nonceBytes,
+      authTagBytes: stored.authTagBytes,
+      bytes: stored.bytes,
+      sha256: stored.sha256,
+      localReceiptDerivation: stored.localReceiptDerivation,
+      localReceiptDigest: stored.localReceiptDigest,
+      canonicalContext: stored.canonicalContext,
+      canonicalContextSha256: stored.canonicalContextSha256,
+    });
+  }
+
+  async loadOperationKeyBundle(): Promise<Uint8Array> {
+    await this.assertMutationAuthority();
+    const metadata = this.journal.operationKeyBundle;
+    if (!metadata) {
+      spoolError(
+        "AGENT_BACKUP_V3_SPOOL_KEY_BUNDLE_MISSING",
+        "Backup operation has no durable operation key bundle",
+      );
+    }
+    const decoded = Buffer.from(metadata.ciphertextBase64, "base64");
+    const bytes = new Uint8Array(decoded.buffer, decoded.byteOffset, decoded.byteLength);
+    try {
+      if (bytes.byteLength !== metadata.bytes || sha256Hex(bytes) !== metadata.sha256) {
+        spoolError(
+          "AGENT_BACKUP_V3_SPOOL_KEY_BUNDLE_INVALID",
+          "Durable operation key bundle failed size or digest verification",
+        );
+      }
+      if (Buffer.from(bytes).toString("base64") !== metadata.ciphertextBase64) {
+        spoolError(
+          "AGENT_BACKUP_V3_SPOOL_KEY_BUNDLE_INVALID",
+          "Durable operation key bundle is not canonical base64",
+        );
+      }
+      if (
+        sha256Hex(new TextEncoder().encode(metadata.canonicalContext)) !==
+        metadata.canonicalContextSha256
+      ) {
+        spoolError(
+          "AGENT_BACKUP_V3_SPOOL_KEY_BUNDLE_CONTEXT_INVALID",
+          "Durable operation key-bundle context failed digest verification",
+        );
+      }
+      return Uint8Array.from(bytes);
+    } finally {
+      bytes.fill(0);
+    }
+  }
+
+  async storeCiphertextChunk(
+    metadataInput: Readonly<AgentBackupCaptureV3SpoolChunk>,
+    ciphertextParts: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,
+  ): Promise<Readonly<AgentBackupCaptureV3SpoolChunk>> {
+    await this.assertMutationAuthority();
+    if (!this.journal.operationKeyBundle || this.journal.phase !== "capturing") {
+      spoolError(
+        "AGENT_BACKUP_V3_SPOOL_PHASE_INVALID",
+        "Ciphertext chunks require an active capture and its operation key bundle",
+      );
+    }
+    const file = chunkFile(metadataInput.component, metadataInput.index);
+    const metadata = ChunkSchema.parse({ ...metadataInput, file });
+    const existing = this.journal.chunks.find(
+      (chunk) => chunk.component === metadata.component && chunk.index === metadata.index,
+    );
+    if (existing && !equalChunk(existing, metadata)) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_REPLAY_CONFLICT",
+        "Backup chunk metadata changed while replaying one operation",
+      );
+    }
+    await this.writeCreateOnlyArtifact(
+      metadata.file,
+      ciphertextParts,
+      { bytes: metadata.encryptedBytes, sha256: metadata.ciphertextSha256 },
+      metadata.encryptedBytes,
+    );
+    if (!existing) {
+      this.journal.chunks.push(metadata);
+      this.journal.chunks.sort(
+        (left, right) =>
+          compareCanonicalComponentNames(left.component, right.component) ||
+          left.index - right.index,
+      );
+      this.journal.committedBytes += metadata.encryptedBytes;
+      this.journal.phase = "capturing";
+      await this.persistJournal();
+    }
+    return Object.freeze({ ...metadata });
+  }
+
+  /**
+   * Recover the nonce from a fully renamed ciphertext artifact whose journal
+   * commit was interrupted. Re-encrypting the same replay bytes with this nonce
+   * lets `storeCiphertextChunk` verify and adopt the exact create-only artifact.
+   */
+  async loadCiphertextChunkNonceForReplay(
+    componentInput: string,
+    indexInput: number,
+  ): Promise<Uint8Array | undefined> {
+    await this.assertMutationAuthority();
+    if (!this.journal.operationKeyBundle || this.journal.phase !== "capturing") {
+      spoolError(
+        "AGENT_BACKUP_V3_SPOOL_PHASE_INVALID",
+        "Ciphertext replay nonce recovery requires an active capture",
+      );
+    }
+    const identity = z
+      .strictObject({
+        component: z.string().regex(/^[a-z][a-z0-9-]{0,63}$/),
+        index: ChunkIndexSchema,
+      })
+      .parse({ component: componentInput, index: indexInput });
+    const committed = this.journal.chunks.find(
+      (chunk) => chunk.component === identity.component && chunk.index === identity.index,
+    );
+    if (committed) return Uint8Array.from(Buffer.from(committed.nonceHex, "hex"));
+
+    const filePath = path.join(
+      this.operationDirectory,
+      chunkFile(identity.component, identity.index),
+    );
+    const stat = await lstatRegularFile(filePath);
+    if (!stat) return undefined;
+    if (
+      stat.size <
+        AGENT_BACKUP_CHUNK_ENVELOPE_V1.nonceBytes + AGENT_BACKUP_CHUNK_ENVELOPE_V1.tagBytes ||
+      stat.size > AGENT_BACKUP_MANIFEST_V2_LIMITS.maxChunkEncryptedBytes
+    ) {
+      spoolError(
+        "AGENT_BACKUP_V3_SPOOL_ORPHAN_INVALID",
+        "Interrupted ciphertext artifact has an invalid envelope length",
+      );
+    }
+    const handle = await fs.promises.open(
+      filePath,
+      fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0),
+    );
+    const nonce = new Uint8Array(AGENT_BACKUP_CHUNK_ENVELOPE_V1.nonceBytes);
+    let failure: unknown;
+    try {
+      const read = await handle.read(nonce, 0, nonce.byteLength, 0);
+      if (read.bytesRead !== nonce.byteLength) {
+        spoolError(
+          "AGENT_BACKUP_V3_SPOOL_ORPHAN_INVALID",
+          "Interrupted ciphertext artifact has a truncated nonce",
+        );
+      }
+    } catch (cause) {
+      failure = cause;
+    }
+    try {
+      await handle.close();
+    } catch (cause) {
+      failure =
+        failure === undefined
+          ? cause
+          : new AggregateError(
+              [failure, cause],
+              "Interrupted ciphertext nonce read and close both failed",
+            );
+    }
+    if (failure !== undefined) {
+      nonce.fill(0);
+      throw failure;
+    }
+    return nonce;
+  }
+
+  async readCiphertextChunk(chunk: AgentBackupCaptureV3SpoolChunk): Promise<Uint8Array> {
+    await this.assertMutationAuthority();
+    const stored = this.journal.chunks.find(
+      (candidate) => candidate.component === chunk.component && candidate.index === chunk.index,
+    );
+    if (!stored || !equalChunk(stored, chunk)) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_CHUNK_UNKNOWN",
+        "Requested ciphertext chunk is not owned by this operation",
+      );
+    }
+    const bytes = await readBoundedFile(
+      path.join(this.operationDirectory, stored.file),
+      stored.encryptedBytes,
+    );
+    if (
+      bytes.byteLength !== stored.encryptedBytes ||
+      sha256Hex(bytes) !== stored.ciphertextSha256
+    ) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_CHUNK_INVALID",
+        "Durable ciphertext chunk failed size or digest verification",
+      );
+    }
+    return bytes;
+  }
+
+  async openCiphertextChunk(
+    chunk: AgentBackupCaptureV3SpoolChunk,
+  ): Promise<fs.promises.FileHandle> {
+    await this.assertMutationAuthority();
+    const stored = this.journal.chunks.find((candidate) => equalChunk(candidate, chunk));
+    if (!stored) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_CHUNK_UNKNOWN",
+        "Requested ciphertext chunk is not owned by this operation",
+      );
+    }
+    return fs.promises.open(
+      path.join(this.operationDirectory, stored.file),
+      fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0),
+    );
+  }
+
+  async sealManifest(
+    manifestBytes: Uint8Array,
+    metadataInput: Readonly<AgentBackupCaptureV3ManifestMetadata>,
+  ): Promise<void> {
+    await this.assertMutationAuthority();
+    if (!this.journal.operationKeyBundle) {
+      spoolError(
+        "AGENT_BACKUP_V3_SPOOL_KEY_BUNDLE_MISSING",
+        "Cannot seal a v3 manifest without an operation key bundle",
+      );
+    }
+    const metadata = ManifestSchema.parse({ file: MANIFEST_FILE, ...metadataInput });
+    if (
+      manifestBytes.byteLength !== metadata.bytes ||
+      sha256Hex(manifestBytes) !== metadata.sha256
+    ) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_MANIFEST_INVALID",
+        "Canonical backup manifest does not match its durable metadata",
+      );
+    }
+    if (
+      this.journal.manifest &&
+      JSON.stringify(this.journal.manifest) !== JSON.stringify(metadata)
+    ) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_REPLAY_CONFLICT",
+        "Backup operation already owns a different canonical manifest",
+      );
+    }
+    if (!this.journal.manifest && this.journal.phase !== "capturing") {
+      spoolError(
+        "AGENT_BACKUP_V3_SPOOL_PHASE_INVALID",
+        "A fresh manifest can only seal an active capture",
+      );
+    }
+    await this.writeCreateOnlyArtifact(
+      MANIFEST_FILE,
+      [manifestBytes],
+      metadata,
+      MAX_MANIFEST_BYTES,
+    );
+    if (!this.journal.manifest) {
+      this.journal.manifest = metadata;
+      this.journal.committedBytes += metadata.bytes;
+      this.journal.phase = "sealed";
+      await this.persistJournal();
+    }
+  }
+
+  async loadManifestBytes(): Promise<Uint8Array> {
+    await this.assertMutationAuthority();
+    const metadata = this.journal.manifest;
+    if (!metadata) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_MANIFEST_MISSING",
+        "Backup operation has no sealed manifest",
+      );
+    }
+    const bytes = await readBoundedFile(
+      path.join(this.operationDirectory, metadata.file),
+      metadata.bytes,
+    );
+    if (bytes.byteLength !== metadata.bytes || sha256Hex(bytes) !== metadata.sha256) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_MANIFEST_INVALID",
+        "Durable backup manifest failed size or digest verification",
+      );
+    }
+    return bytes;
+  }
+
+  async markPublishing(): Promise<void> {
+    await this.assertMutationAuthority();
+    if (!this.journal.manifest) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_MANIFEST_MISSING",
+        "Cannot publish an unsealed backup operation",
+      );
+    }
+    if (this.journal.phase === "publishing" || this.journal.phase === "published") {
+      return;
+    }
+    if (this.journal.phase !== "sealed") {
+      spoolError(
+        "AGENT_BACKUP_V3_SPOOL_PHASE_INVALID",
+        "Primary publication can only begin from a sealed operation",
+      );
+    }
+    this.journal.phase = "publishing";
+    await this.persistJournal();
+  }
+
+  async markRecordCaptured(
+    catalogManifestBytes: Uint8Array,
+    metadataInput: Readonly<AgentBackupCaptureV3CatalogManifestMetadata>,
+  ): Promise<void> {
+    await this.assertMutationAuthority();
+    if (!this.journal.manifest) {
+      spoolError(
+        "AGENT_BACKUP_V3_SPOOL_MANIFEST_MISSING",
+        "Cannot receipt a catalogue handoff without a sealed manifest",
+      );
+    }
+    if (
+      this.journal.phase !== "sealed" &&
+      this.journal.phase !== "publishing" &&
+      this.journal.phase !== "published"
+    ) {
+      spoolError(
+        "AGENT_BACKUP_V3_SPOOL_PHASE_INVALID",
+        "Catalogue handoff requires a sealed backup operation",
+      );
+    }
+    const metadata = CatalogManifestSchema.parse({
+      file: CATALOG_MANIFEST_FILE,
+      ...metadataInput,
+    });
+    if (
+      catalogManifestBytes.byteLength !== metadata.bytes ||
+      sha256Hex(catalogManifestBytes) !== metadata.sha256
+    ) {
+      spoolError(
+        "AGENT_BACKUP_V3_SPOOL_CATALOG_INVALID",
+        "Catalogue handoff bytes differ from their durable metadata",
+      );
+    }
+    if (
+      this.journal.catalogManifest &&
+      JSON.stringify(this.journal.catalogManifest) !== JSON.stringify(metadata)
+    ) {
+      spoolError(
+        "AGENT_BACKUP_V3_SPOOL_REPLAY_CONFLICT",
+        "Backup operation already owns a different catalogue handoff",
+      );
+    }
+    await this.writeCreateOnlyArtifact(
+      CATALOG_MANIFEST_FILE,
+      [catalogManifestBytes],
+      metadata,
+      MAX_CATALOG_MANIFEST_BYTES,
+    );
+    if (!this.journal.catalogManifest) {
+      this.journal.catalogManifest = metadata;
+      this.journal.committedBytes += metadata.bytes;
+    }
+    this.journal.recordCaptured = "confirmed";
+    await this.persistJournal();
+  }
+
+  async loadCatalogManifestBytes(): Promise<Uint8Array> {
+    await this.assertMutationAuthority();
+    const metadata = this.journal.catalogManifest;
+    if (this.journal.recordCaptured !== "confirmed" || !metadata) {
+      spoolError(
+        "AGENT_BACKUP_V3_SPOOL_CATALOG_MISSING",
+        "Backup operation has no confirmed catalogue handoff bytes",
+      );
+    }
+    const bytes = await readBoundedFile(
+      path.join(this.operationDirectory, metadata.file),
+      metadata.bytes,
+    );
+    if (bytes.byteLength !== metadata.bytes || sha256Hex(bytes) !== metadata.sha256) {
+      spoolError(
+        "AGENT_BACKUP_V3_SPOOL_CATALOG_INVALID",
+        "Durable catalogue handoff failed size or digest verification",
+      );
+    }
+    return bytes;
+  }
+
+  async markChunkUploaded(chunk: AgentBackupCaptureV3SpoolChunk): Promise<void> {
+    await this.assertMutationAuthority();
+    if (this.journal.phase !== "publishing" && this.journal.phase !== "published") {
+      spoolError(
+        "AGENT_BACKUP_V3_SPOOL_PHASE_INVALID",
+        "Chunk upload receipts require an active publication phase",
+      );
+    }
+    const key = chunkKey(chunk);
+    if (!this.journal.chunks.some((candidate) => equalChunk(candidate, chunk))) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_CHUNK_UNKNOWN",
+        "Cannot receipt an unknown backup chunk upload",
+      );
+    }
+    if (!this.journal.uploadedChunkKeys.includes(key)) {
+      this.journal.uploadedChunkKeys.push(key);
+      this.journal.uploadedChunkKeys.sort();
+      await this.persistJournal();
+    }
+  }
+
+  async markPublished(): Promise<void> {
+    await this.assertMutationAuthority();
+    if (this.journal.phase !== "publishing" && this.journal.phase !== "published") {
+      spoolError(
+        "AGENT_BACKUP_V3_SPOOL_PHASE_INVALID",
+        "Published state requires an active publication phase",
+      );
+    }
+    if (
+      this.journal.recordCaptured !== "confirmed" ||
+      this.journal.uploadedChunkKeys.length !== this.journal.chunks.length
+    ) {
+      spoolError(
+        "AGENT_BACKUP_V2_SPOOL_PUBLISH_INCOMPLETE",
+        "Backup publication receipts are incomplete",
+      );
+    }
+    this.journal.phase = "published";
+    await this.persistJournal();
+  }
+
+  /**
+   * Explicit cleanup boundary. A failure returns `pending`; callers must retain
+   * their durable cleanup/outbox intent and retry instead of recording success.
+   * Production wiring must invoke this only from a catalogue-authorized janitor
+   * after the backup is durably `protected`; `close()` is the handoff primitive.
+   */
+  async cleanup(): Promise<AgentBackupCaptureV3CleanupReceipt> {
+    if (this.closed) {
+      return {
+        operationId: this.journal.operationId,
+        status: this.cleanupComplete ? "complete" : "pending",
+      };
+    }
+    const operationId = this.journal.operationId;
+    try {
+      await this.assertMutationAuthority();
+      let operationExists = true;
+      try {
+        const stat = await fs.promises.lstat(this.operationDirectory);
+        if (stat.isSymbolicLink() || !stat.isDirectory()) {
+          spoolError(
+            "AGENT_BACKUP_V2_SPOOL_UNSAFE_ENTRY",
+            "Backup spool cleanup target is not a safe directory",
+          );
+        }
+      } catch (cause) {
+        // error-policy:J2 an absent operation directory means an earlier
+        // cleanup removed its artifacts before lock release; other errors stay.
+        if ((cause as NodeJS.ErrnoException).code === "ENOENT") operationExists = false;
+        else throw cause;
+      }
+      if (operationExists) {
+        const entries = (
+          await fs.promises.readdir(this.operationDirectory, {
+            withFileTypes: true,
+          })
+        ).sort((left, right) => {
+          // Keep the journal as the last retry authority. A failed unlink of a
+          // chunk/manifest can then be reopened and completed without guessing
+          // which immutable operation owned the remaining artifacts.
+          if (left.name === JOURNAL_FILE) return 1;
+          if (right.name === JOURNAL_FILE) return -1;
+          return left.name.localeCompare(right.name);
+        });
+        for (const entry of entries) {
+          if (!entry.isFile() || entry.isSymbolicLink()) {
+            spoolError(
+              "AGENT_BACKUP_V2_SPOOL_UNSAFE_ENTRY",
+              "Backup spool cleanup encountered an unsafe entry",
+            );
+          }
+          await this.assertMutationAuthority();
+          await fs.promises.unlink(path.join(this.operationDirectory, entry.name));
+        }
+        await fsyncDirectory(this.operationDirectory);
+        await this.assertMutationAuthority();
+        await fs.promises.rmdir(this.operationDirectory);
+        await fsyncDirectory(this.namespaceDirectory);
+      }
+      await releaseSpoolLock(this.lock);
+      this.closed = true;
+      this.cleanupComplete = true;
+      return { operationId, status: "complete" };
+    } catch {
+      // error-policy:J4 cleanup is a durable retry boundary. Keep ownership
+      // and report pending instead of losing the only ciphertext evidence.
+      return { operationId, status: "pending" };
+    }
+  }
+
+  /** Release execution ownership without deleting replay artifacts. */
+  async close(): Promise<void> {
+    if (this.closed) return;
+    await releaseSpoolLock(this.lock);
+    this.closed = true;
+  }
+}

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-publication-source.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-publication-source.test.ts
@@ -692,7 +692,7 @@ describe("capture-v3 publication source", () => {
     }
   });
 
-  test("retains a durable cleanup intent after pending and retries it", async () => {
+  test("retains a durable cleanup intent across retention expiry and retries it", async () => {
     const directory = await stateDirectory();
     try {
       const artifacts = await capturedFixture(directory);
@@ -707,6 +707,7 @@ describe("capture-v3 publication source", () => {
       const authority =
         await deriveAgentBackupCaptureV3SpoolAuthorityFromCatalogBackup(protectedBackup);
       let cleanupStatus: "complete" | "pending" = "pending";
+      let authorizedBackup: AgentBackupOperationClaim["backup"] = protectedBackup;
       let authorizations = 0;
       let closes = 0;
       const janitor = createAgentBackupCaptureV3SpoolCleanupJanitor(
@@ -726,7 +727,7 @@ describe("capture-v3 publication source", () => {
           listCandidates: async () => [protectedBackup],
           authorize: async () => {
             authorizations += 1;
-            return protectedBackup;
+            return authorizedBackup;
           },
           openExisting: async () =>
             ({
@@ -749,6 +750,11 @@ describe("capture-v3 publication source", () => {
       const outbox = path.join(directory, "agent-backup-capture-v3-cleanup-outbox");
       expect(await fs.promises.readdir(outbox)).toContain(`${OPERATION_ID}.json`);
 
+      authorizedBackup = {
+        ...protectedBackup,
+        catalog_state: "deleting",
+        retention_until: new Date(NOW_MS - 1),
+      };
       cleanupStatus = "complete";
       const completed = await janitor.runCycle();
       expect(completed).toMatchObject({ authorized: 0, completed: 1, pending: 0 });

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-publication-source.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-publication-source.test.ts
@@ -1,0 +1,761 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { KmsAeadOperationKeyBundleProvider, LocalKmsAdapter } from "@elizaos/core/security/kms";
+import {
+  AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+  AGENT_BACKUP_CAPTURE_V2_REQUEST_FORMAT,
+  AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+  type AgentBackupCaptureV2ComponentDescriptor,
+  type AgentBackupCaptureV2Frame,
+  type AgentBackupCaptureV2Request,
+  canonicalizeAgentBackupOperationKeyBundleContext,
+} from "@elizaos/shared";
+import type { AgentBackupOperationClaim } from "../../db/repositories/agent-backup-catalog";
+import {
+  type AgentBackupCaptureV3Artifacts,
+  type AgentBackupCaptureV3ManifestAuthority,
+  deriveAgentBackupCaptureV3SpoolAuthorityDigests,
+  runAgentBackupCaptureV2Pipeline,
+} from "./agent-backup-capture-v2-pipeline";
+import type {
+  AgentBackupCaptureV3SpoolConfig,
+  AgentBackupCaptureV3SpoolLockAuthority,
+} from "./agent-backup-capture-v2-spool";
+import { AgentBackupCaptureV3Spool } from "./agent-backup-capture-v2-spool";
+import {
+  createAgentBackupCaptureV3PublicationSourceResolver,
+  deriveAgentBackupCaptureV3SpoolAuthorityFromCatalogBackup,
+} from "./agent-backup-capture-v3-publication-source";
+import { createAgentBackupCaptureV3SpoolCleanupJanitor } from "./agent-backup-capture-v3-spool-cleanup";
+
+const ORGANIZATION_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const AGENT_ID = "22222222-2222-4222-8222-222222222222";
+const BACKUP_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const OPERATION_ID = "11111111-1111-4111-8111-111111111111";
+const ACTIVATION_GENERATION = "33333333-3333-4333-8333-333333333333";
+const CAPTURE_EXECUTION = "66666666-6666-4666-8666-666666666666";
+const PUBLICATION_EXECUTION = "77777777-7777-4777-8777-777777777777";
+const RETRY_EXECUTION = "99999999-9999-4999-8999-999999999999";
+const NODE_RECORD_ID = "44444444-4444-4444-8444-444444444444";
+const NODE_INCARNATION = "55555555-5555-4555-8555-555555555555";
+const VAULT_KEY_GENERATION_ID = "88888888-8888-4888-8888-888888888888";
+const CONTAINER_ID = "c".repeat(64);
+const NOW_MS = Date.parse("2026-08-15T10:01:00.000Z");
+const COMPONENTS = ["character", "database", "media", "state-files", "vault"] as const;
+
+const request: AgentBackupCaptureV2Request = {
+  format: AGENT_BACKUP_CAPTURE_V2_REQUEST_FORMAT,
+  schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+  operationId: OPERATION_ID,
+  agentId: AGENT_ID,
+  activationGeneration: ACTIVATION_GENERATION,
+  lifecycleRevision: "42",
+  deadlineEpochMs: NOW_MS + 60_000,
+};
+
+const authority: AgentBackupCaptureV3ManifestAuthority = {
+  createdAt: "2026-08-15T10:00:00.000Z",
+  organizationId: ORGANIZATION_ID,
+  source: {
+    kind: "cloud",
+    provider: "hetzner",
+    nodeRecordId: NODE_RECORD_ID,
+    nodeIncarnation: NODE_INCARNATION,
+    nodeId: "cloud-node-9",
+    containerId: CONTAINER_ID,
+    providerServerId: "1234",
+  },
+  runtime: {
+    imageDigest: `sha256:${"a".repeat(64)}`,
+    agentSchemaVersion: "agent-v2",
+    databaseSchemaVersion: "pglite-v1",
+    plugins: [{ id: "@elizaos/plugin-sql", version: "2.0.0" }],
+  },
+  chain: {
+    kind: "full",
+    baseOperationId: null,
+    parentOperationId: null,
+    depth: 0,
+  },
+  watermarks: [{ namespace: "database.lsn", value: "snapshot-42" }],
+  vaultKeyAuthority: {
+    format: "kms-aead-vault-passphrase-v1",
+    generationId: VAULT_KEY_GENERATION_ID,
+    receiptDerivation: "elizaos.agent-vault-key.authority-receipt.v1",
+    receiptDigest: "f".repeat(64),
+  },
+  kms: {
+    provider: "steward",
+    keyId: `org:${ORGANIZATION_ID}/dek/v1`,
+    keyVersion: 1,
+  },
+};
+
+function descriptor(name: (typeof COMPONENTS)[number]): AgentBackupCaptureV2ComponentDescriptor {
+  return {
+    name,
+    format: "synthetic-v1",
+    compression: "none",
+    contentKind: "opaque",
+    consistency: "transactional",
+  };
+}
+
+function frame(header: AgentBackupCaptureV2Frame["header"], payload = new Uint8Array(0)) {
+  return { header, payload, frameSha256: "0".repeat(64) } satisfies AgentBackupCaptureV2Frame;
+}
+
+async function* captureFrames(payloadOffset = 0): AsyncGenerator<AgentBackupCaptureV2Frame> {
+  let sequence = 0;
+  let totalPlainBytes = 0;
+  yield frame({
+    format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+    schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+    sequence: sequence++,
+    kind: "capture-start",
+    operationId: OPERATION_ID,
+    agentId: AGENT_ID,
+    activationGeneration: ACTIVATION_GENERATION,
+    lifecycleRevision: "42",
+    createdAt: "2026-08-15T10:00:01.000Z",
+    componentCount: COMPONENTS.length,
+    maxFramePayloadBytes: 256 * 1024,
+  });
+  for (const [componentIndex, name] of COMPONENTS.entries()) {
+    yield frame({
+      format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+      schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+      sequence: sequence++,
+      kind: "component-start",
+      componentIndex,
+      component: descriptor(name),
+    });
+    const payload = new Uint8Array([componentIndex + 1 + payloadOffset]);
+    yield frame(
+      {
+        format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+        schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+        sequence: sequence++,
+        kind: "data",
+        componentIndex,
+        componentName: name,
+        dataIndex: 0,
+        offsetBytes: 0,
+        payloadBytes: payload.byteLength,
+      },
+      payload,
+    );
+    yield frame({
+      format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+      schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+      sequence: sequence++,
+      kind: "component-end",
+      componentIndex,
+      componentName: name,
+      dataFrameCount: 1,
+      plainBytes: payload.byteLength,
+      payloadSha256: createHash("sha256").update(payload).digest("hex"),
+    });
+    totalPlainBytes += payload.byteLength;
+  }
+  yield frame({
+    format: AGENT_BACKUP_CAPTURE_V2_FRAME_FORMAT,
+    schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+    sequence,
+    kind: "capture-end",
+    componentCount: COMPONENTS.length,
+    dataFrameCount: COMPONENTS.length,
+    plainBytes: totalPlainBytes,
+    frameDigestChainSha256: "0".repeat(64),
+  });
+}
+
+async function* partialCaptureFrames(): AsyncGenerator<AgentBackupCaptureV2Frame> {
+  for await (const captured of captureFrames()) {
+    yield captured;
+    if (captured.header.kind === "component-end") return;
+  }
+}
+
+function lockAuthority(): AgentBackupCaptureV3SpoolLockAuthority {
+  return {
+    async currentProcessIdentity() {
+      return {
+        linuxBootId: "88888888-8888-4888-8888-888888888888",
+        pid: 4242,
+        processStartTime: "100",
+      };
+    },
+    async isProcessIdentityAlive() {
+      return true;
+    },
+  };
+}
+
+async function stateDirectory(): Promise<string> {
+  return fs.promises.realpath(
+    await fs.promises.mkdtemp(path.join(os.homedir(), ".eliza-v3-publication-source-test-")),
+  );
+}
+
+function spoolConfig(directory: string): AgentBackupCaptureV3SpoolConfig {
+  return {
+    stateDirectory: directory,
+    maxSpoolBytes: 8 * 1024 * 1024,
+    minFreeBytes: 0,
+    lockAuthority: lockAuthority(),
+  };
+}
+
+async function capturedFixture(directory: string): Promise<AgentBackupCaptureV3Artifacts> {
+  let captured: AgentBackupCaptureV3Artifacts | undefined;
+  await runAgentBackupCaptureV2Pipeline({
+    request,
+    executionToken: CAPTURE_EXECUTION,
+    authority,
+    openCapture: () => captureFrames(),
+    spool: spoolConfig(directory),
+    keyBundle: new KmsAeadOperationKeyBundleProvider(
+      new LocalKmsAdapter({ rootKey: new Uint8Array(32).fill(0xa5) }),
+    ),
+    publication: {
+      mode: "capture-only",
+      async recordCaptured(artifacts) {
+        captured = artifacts;
+        return true;
+      },
+    },
+    heartbeat: () => true,
+    now: () => NOW_MS,
+  });
+  if (!captured) throw new Error("capture fixture did not record manifest");
+  return captured;
+}
+
+function claim(
+  artifacts: AgentBackupCaptureV3Artifacts,
+  generation = PUBLICATION_EXECUTION,
+): AgentBackupOperationClaim {
+  const manifest = artifacts.manifest;
+  const catalog = artifacts.catalogManifest;
+  const bundle = manifest.encryption.operationKeyBundle;
+  const context = canonicalizeAgentBackupOperationKeyBundleContext({
+    organizationId: ORGANIZATION_ID,
+    agentId: AGENT_ID,
+    activationGeneration: ACTIVATION_GENERATION,
+    lifecycleRevision: "42",
+    operationId: OPERATION_ID,
+    keyBundleGenerationId: bundle.generationId,
+    sourceKind: "cloud",
+    sourceProvider: "hetzner",
+    kmsProvider: "steward",
+    keyId: authority.kms.keyId,
+    keyVersion: authority.kms.keyVersion,
+  });
+  return {
+    ownerId: "publication-worker-1",
+    generation,
+    backup: {
+      id: BACKUP_ID,
+      catalog_version: 2,
+      catalog_state: "uploading",
+      catalog_organization_id: ORGANIZATION_ID,
+      catalog_agent_id: AGENT_ID,
+      backup_operation_id: OPERATION_ID,
+      lifecycle_generation: ACTIVATION_GENERATION,
+      lifecycle_revision: 42n,
+      source_provider: "hetzner-cloud",
+      source_node_record_id: NODE_RECORD_ID,
+      source_node_id: "cloud-node-9",
+      source_node_incarnation: NODE_INCARNATION,
+      source_provider_server_id: "1234",
+      source_provider_handle: "agent-cloud-42",
+      source_container_id: CONTAINER_ID,
+      manifest_format: catalog.format,
+      manifest_version: catalog.version,
+      manifest_digest: catalog.digest,
+      manifest_canonical_draft: catalog.canonicalManifestDraft,
+      manifest_object_count: catalog.objectCount,
+      object_inventory_digest: catalog.objectInventoryDigest,
+      image_digest: catalog.imageDigest,
+      database_schema_version: catalog.databaseSchemaVersion,
+      plugin_set_digest: catalog.pluginSetDigest,
+      watermark_digest: catalog.watermarkDigest,
+      raw_size_bytes: catalog.rawSizeBytes,
+      compressed_size_bytes: catalog.compressedSizeBytes,
+      encrypted_size_bytes: catalog.encryptedSizeBytes,
+      kms_key_id: catalog.kmsKeyId,
+      kms_key_version: catalog.kmsKeyVersion,
+      wrapped_dek_ref: null,
+      wrapped_dek_ciphertext_base64: null,
+      wrapped_dek_sha256: null,
+      wrapped_dek_size_bytes: null,
+      wrapped_dek_receipt_digest: null,
+      operation_key_bundle_generation_id: catalog.wrappedKeyBundleGenerationId,
+      operation_key_bundle_format: bundle.format,
+      operation_key_bundle_ref: bundle.wrapped.ref,
+      operation_key_bundle_ciphertext_base64: catalog.wrappedKeyBundleCiphertextBase64,
+      operation_key_bundle_sha256: catalog.wrappedKeyBundleSha256,
+      operation_key_bundle_size_bytes: bundle.wrapped.bytes,
+      operation_key_bundle_context: context,
+      operation_key_bundle_context_derivation: bundle.wrapped.contextDerivation,
+      operation_key_bundle_local_receipt_derivation: bundle.wrapped.localReceiptDerivation,
+      operation_key_bundle_local_receipt_digest: catalog.wrappedKeyBundleLocalReceiptDigest,
+      vault_key_generation_id: catalog.vaultKeyGenerationId,
+      vault_key_authority_receipt_digest: catalog.vaultKeyAuthorityReceiptDigest,
+      catalog_lease_owner: "publication-worker-1",
+      catalog_lease_generation: generation,
+      catalog_lease_expires_at: new Date(NOW_MS + 60_000),
+      created_at: new Date(authority.createdAt),
+    },
+  } as AgentBackupOperationClaim;
+}
+
+describe("capture-v3 publication source", () => {
+  test("reopens capture-only handoff, verifies bytes, and resumes partial publication", async () => {
+    const directory = await stateDirectory();
+    try {
+      const artifacts = await capturedFixture(directory);
+      const resolve = createAgentBackupCaptureV3PublicationSourceResolver({
+        spool: spoolConfig(directory),
+        now: () => NOW_MS,
+      });
+      const firstClaim = claim(artifacts);
+      const first = await resolve({
+        claim: firstClaim,
+        execution: { ownerId: firstClaim.ownerId, generation: firstClaim.generation },
+      });
+      expect(first.chunks).toHaveLength(5);
+      await first.beginPrimaryPublication();
+      const firstChunk = first.chunks[0]!;
+      const bytes = await first.readCiphertextChunk(firstChunk);
+      expect(bytes.byteLength).toBe(firstChunk.sizeBytes);
+      expect(createHash("sha256").update(bytes).digest("hex")).toBe(firstChunk.ciphertextSha256);
+      bytes.fill(0);
+      await first.markPrimaryChunkUploaded(firstChunk);
+      // Simulate response/process loss after one immutable PUT receipt. Close
+      // releases only ownership; it does not remove the sealed operation.
+      await first.close();
+
+      const retryClaim = claim(artifacts, RETRY_EXECUTION);
+      const retry = await resolve({
+        claim: retryClaim,
+        execution: { ownerId: retryClaim.ownerId, generation: retryClaim.generation },
+      });
+      await retry.beginPrimaryPublication();
+      for (const chunk of retry.chunks) await retry.markPrimaryChunkUploaded(chunk);
+      await retry.markPrimaryPublished();
+      await retry.close();
+
+      const replayGeneration = "12121212-1212-4212-8212-121212121212";
+      const replayClaim = claim(artifacts, replayGeneration);
+      replayClaim.backup.catalog_state = "primary_uploaded";
+      const replay = await resolve({
+        claim: replayClaim,
+        execution: { ownerId: replayClaim.ownerId, generation: replayClaim.generation },
+      });
+      expect(replay.chunks).toEqual(retry.chunks);
+      await replay.beginPrimaryPublication();
+      await replay.markPrimaryPublished();
+      await replay.close();
+    } finally {
+      await fs.promises.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("repairs a lost recordCaptured response before captured advances to uploading", async () => {
+    const directory = await stateDirectory();
+    try {
+      const artifacts = await capturedFixture(directory);
+      const operationDirectory = path.join(directory, "agent-backup-capture-v3", OPERATION_ID);
+      const journalPath = path.join(operationDirectory, "journal.json");
+      const journal = JSON.parse(await fs.promises.readFile(journalPath, "utf8")) as {
+        recordCaptured: "pending" | "confirmed";
+        committedBytes: number;
+        catalogManifest?: { bytes: number };
+      };
+      expect(journal.recordCaptured).toBe("confirmed");
+      expect(journal.catalogManifest).toBeDefined();
+      journal.committedBytes -= journal.catalogManifest?.bytes ?? 0;
+      journal.recordCaptured = "pending";
+      delete journal.catalogManifest;
+      await fs.promises.unlink(path.join(operationDirectory, "catalog-manifest.json"));
+      await fs.promises.writeFile(journalPath, `${JSON.stringify(journal)}\n`);
+
+      let terminalAuthorizations = 0;
+      const janitor = createAgentBackupCaptureV3SpoolCleanupJanitor(
+        { spool: spoolConfig(directory), batchSize: 1 },
+        {
+          now: () => NOW_MS,
+          executionToken: () => RETRY_EXECUTION,
+          authorizeTerminal: async () => {
+            terminalAuthorizations += 1;
+            throw new Error("recordCaptured won; terminal cleanup must not authorize");
+          },
+        },
+      );
+      await janitor.stageTerminalFailure({
+        authority: {
+          organizationId: ORGANIZATION_ID,
+          agentId: AGENT_ID,
+          backupId: BACKUP_ID,
+          operationId: OPERATION_ID,
+          activationGeneration: ACTIVATION_GENERATION,
+          lifecycleRevision: "42",
+          ...deriveAgentBackupCaptureV3SpoolAuthorityDigests({ request, authority }),
+        },
+        terminalErrorCode: "BACKUP_CAPTURE_V2_TERMINAL",
+      });
+
+      const resolve = createAgentBackupCaptureV3PublicationSourceResolver({
+        spool: spoolConfig(directory),
+        now: () => NOW_MS,
+      });
+      const capturedClaim = claim(artifacts);
+      capturedClaim.backup.catalog_state = "captured";
+      const source = await resolve({
+        claim: capturedClaim,
+        execution: {
+          ownerId: capturedClaim.ownerId,
+          generation: capturedClaim.generation,
+        },
+      });
+      await source.close();
+
+      const repaired = JSON.parse(await fs.promises.readFile(journalPath, "utf8")) as {
+        recordCaptured: string;
+        catalogManifest?: { file: string; bytes: number; sha256: string };
+      };
+      expect(repaired.recordCaptured).toBe("confirmed");
+      expect(repaired.catalogManifest).toMatchObject({
+        file: "catalog-manifest.json",
+        bytes: expect.any(Number),
+        sha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+      });
+      const reconciled = await janitor.runCycle();
+      expect(reconciled.completed).toBe(0);
+      expect(terminalAuthorizations).toBe(0);
+      expect(
+        await fs.promises.readdir(
+          path.join(directory, "agent-backup-capture-v3-terminal-cleanup-candidates"),
+        ),
+      ).toEqual([]);
+    } finally {
+      await fs.promises.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("rejects stale execution before taking the spool lock", async () => {
+    const directory = await stateDirectory();
+    try {
+      const artifacts = await capturedFixture(directory);
+      const resolve = createAgentBackupCaptureV3PublicationSourceResolver({
+        spool: spoolConfig(directory),
+        now: () => NOW_MS,
+      });
+      const ownedClaim = claim(artifacts);
+      await expect(
+        resolve({
+          claim: ownedClaim,
+          execution: { ownerId: ownedClaim.ownerId, generation: RETRY_EXECUTION },
+        }),
+      ).rejects.toMatchObject({ code: "AGENT_BACKUP_V3_PUBLICATION_EXECUTION_STALE" });
+
+      const source = await resolve({
+        claim: ownedClaim,
+        execution: { ownerId: ownedClaim.ownerId, generation: ownedClaim.generation },
+      });
+      await source.close();
+    } finally {
+      await fs.promises.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps published spool until authoritative protected proof, then removes it", async () => {
+    const directory = await stateDirectory();
+    try {
+      const artifacts = await capturedFixture(directory);
+      const resolve = createAgentBackupCaptureV3PublicationSourceResolver({
+        spool: spoolConfig(directory),
+        now: () => NOW_MS,
+      });
+      const publicationClaim = claim(artifacts);
+      const source = await resolve({
+        claim: publicationClaim,
+        execution: {
+          ownerId: publicationClaim.ownerId,
+          generation: publicationClaim.generation,
+        },
+      });
+      await source.beginPrimaryPublication();
+      for (const chunk of source.chunks) await source.markPrimaryChunkUploaded(chunk);
+      await source.markPrimaryPublished();
+      await source.close();
+
+      const protectedBackup = {
+        ...publicationClaim.backup,
+        catalog_state: "protected" as const,
+        catalog_lease_owner: null,
+        catalog_lease_generation: null,
+        catalog_lease_expires_at: null,
+        secondary_verified_at: new Date(NOW_MS),
+      };
+      const spoolAuthority =
+        await deriveAgentBackupCaptureV3SpoolAuthorityFromCatalogBackup(protectedBackup);
+      let protectedVisible = false;
+      const janitor = createAgentBackupCaptureV3SpoolCleanupJanitor(
+        { spool: spoolConfig(directory), batchSize: 4 },
+        {
+          now: () => NOW_MS,
+          listCandidates: async () => (protectedVisible ? [protectedBackup] : []),
+          authorize: async () => {
+            if (!protectedVisible) throw new Error("secondary_pending has no cleanup authority");
+            return protectedBackup;
+          },
+        },
+      );
+      const beforeProtection = await janitor.runCycle();
+      expect(beforeProtection).toMatchObject({ completed: 0, skippedUnprotected: 1 });
+      expect(
+        await AgentBackupCaptureV3Spool.listDurableOperationAuthorities(spoolConfig(directory)),
+      ).toHaveLength(1);
+
+      protectedVisible = true;
+      const protectedCleanup = await janitor.runCycle();
+      expect(protectedCleanup).toMatchObject({ authorized: 1, completed: 1, pending: 0 });
+      expect(
+        await AgentBackupCaptureV3Spool.listDurableOperationAuthorities(spoolConfig(directory)),
+      ).toHaveLength(0);
+      await expect(
+        resolve({
+          claim: publicationClaim,
+          execution: {
+            ownerId: publicationClaim.ownerId,
+            generation: publicationClaim.generation,
+          },
+        }),
+      ).rejects.toMatchObject({ code: "AGENT_BACKUP_V3_PUBLICATION_HANDOFF_MISSING" });
+      expect(
+        await AgentBackupCaptureV3Spool.openExisting(spoolConfig(directory), {
+          ...spoolAuthority,
+          executionToken: "13131313-1313-4313-8313-131313131313",
+        }),
+      ).toBeUndefined();
+      expect(
+        await AgentBackupCaptureV3Spool.listDurableOperationAuthorities(spoolConfig(directory)),
+      ).toHaveLength(0);
+    } finally {
+      await fs.promises.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("retains changed partial replay until terminal settlement authorizes bounded cleanup", async () => {
+    const directory = await stateDirectory();
+    const pipelineInput = {
+      request,
+      authority,
+      spool: spoolConfig(directory),
+      keyBundle: new KmsAeadOperationKeyBundleProvider(
+        new LocalKmsAdapter({ rootKey: new Uint8Array(32).fill(0xa5) }),
+      ),
+      publication: {
+        mode: "capture-only" as const,
+        async recordCaptured() {
+          throw new Error("Partial capture must not reach recordCaptured");
+        },
+      },
+      heartbeat: () => true as const,
+      now: () => NOW_MS,
+    };
+    try {
+      await expect(
+        runAgentBackupCaptureV2Pipeline({
+          ...pipelineInput,
+          executionToken: CAPTURE_EXECUTION,
+          openCapture: () => partialCaptureFrames(),
+        }),
+      ).rejects.toMatchObject({ code: "AGENT_BACKUP_V2_CAPTURE_TRUNCATED" });
+
+      await expect(
+        runAgentBackupCaptureV2Pipeline({
+          ...pipelineInput,
+          executionToken: RETRY_EXECUTION,
+          openCapture: () => captureFrames(10),
+        }),
+      ).rejects.toMatchObject({ code: "AGENT_BACKUP_V2_SPOOL_REPLAY_CONFLICT" });
+
+      const terminalAuthority = {
+        organizationId: ORGANIZATION_ID,
+        agentId: AGENT_ID,
+        backupId: BACKUP_ID,
+        operationId: OPERATION_ID,
+        activationGeneration: ACTIVATION_GENERATION,
+        lifecycleRevision: "42",
+        ...deriveAgentBackupCaptureV3SpoolAuthorityDigests({ request, authority }),
+      };
+      const terminalBackup = {
+        id: BACKUP_ID,
+        catalog_version: 2,
+        catalog_state: "failed_terminal",
+        catalog_resume_state: "capturing",
+        catalog_organization_id: ORGANIZATION_ID,
+        catalog_agent_id: AGENT_ID,
+        backup_operation_id: OPERATION_ID,
+        lifecycle_generation: ACTIVATION_GENERATION,
+        lifecycle_revision: 42n,
+        catalog_last_error_code: "BACKUP_CAPTURE_V2_TERMINAL",
+        manifest_digest: null,
+        manifest_canonical_draft: null,
+        object_inventory_digest: null,
+      } as AgentBackupOperationClaim["backup"];
+      let terminalSettled = false;
+      let terminalProofStable = false;
+      let terminalProofs = 0;
+      const janitor = createAgentBackupCaptureV3SpoolCleanupJanitor(
+        { spool: spoolConfig(directory), batchSize: 1 },
+        {
+          now: () => NOW_MS,
+          executionToken: () => RETRY_EXECUTION,
+          authorizeTerminal: async () => {
+            if (!terminalSettled) throw new Error("terminal CAS is not yet visible");
+            terminalProofs += 1;
+            if (terminalProofs > 1 && !terminalProofStable) {
+              throw new Error("terminal authority changed before cleanup");
+            }
+            return terminalBackup;
+          },
+        },
+      );
+
+      const beforeSettlement = await janitor.runCycle();
+      expect(beforeSettlement).toMatchObject({
+        discovered: 1,
+        completed: 0,
+        skippedUnprotected: 1,
+      });
+      expect(
+        await AgentBackupCaptureV3Spool.listDurableOperationAuthorities(spoolConfig(directory)),
+      ).toHaveLength(1);
+
+      await expect(
+        janitor.stageTerminalFailure({
+          authority: { ...terminalAuthority, requestSha256: "f".repeat(64) },
+          terminalErrorCode: "BACKUP_CAPTURE_V2_TERMINAL",
+        }),
+      ).rejects.toThrow("Terminal spool cleanup candidate differs from durable capture state");
+      expect(
+        await AgentBackupCaptureV3Spool.listDurableOperationAuthorities(spoolConfig(directory)),
+      ).toHaveLength(1);
+      await janitor.stageTerminalFailure({
+        authority: terminalAuthority,
+        terminalErrorCode: "BACKUP_CAPTURE_V2_TERMINAL",
+      });
+      const terminalCandidates = path.join(
+        directory,
+        "agent-backup-capture-v3-terminal-cleanup-candidates",
+      );
+      const terminalOutbox = path.join(
+        directory,
+        "agent-backup-capture-v3-terminal-cleanup-outbox",
+      );
+      expect(await fs.promises.readdir(terminalCandidates)).toEqual([`${OPERATION_ID}.json`]);
+      expect(await fs.promises.readdir(terminalOutbox)).toEqual([]);
+
+      const ambiguous = await janitor.runCycle();
+      expect(ambiguous).toMatchObject({ completed: 0, pending: 1 });
+      expect(await fs.promises.readdir(terminalCandidates)).toEqual([`${OPERATION_ID}.json`]);
+      expect(
+        await AgentBackupCaptureV3Spool.listDurableOperationAuthorities(spoolConfig(directory)),
+      ).toHaveLength(1);
+
+      terminalSettled = true;
+      const changedBeforeCleanup = await janitor.runCycle();
+      expect(changedBeforeCleanup).toMatchObject({ authorized: 1, completed: 0, pending: 1 });
+      expect(await fs.promises.readdir(terminalCandidates)).toEqual([]);
+      expect(await fs.promises.readdir(terminalOutbox)).toEqual([`${OPERATION_ID}.json`]);
+      expect(
+        await AgentBackupCaptureV3Spool.listDurableOperationAuthorities(spoolConfig(directory)),
+      ).toHaveLength(1);
+
+      terminalProofStable = true;
+      const cleaned = await janitor.runCycle();
+      expect(cleaned).toMatchObject({ authorized: 0, completed: 1, pending: 0 });
+      expect(await fs.promises.readdir(terminalOutbox)).toEqual([]);
+      expect(
+        await AgentBackupCaptureV3Spool.listDurableOperationAuthorities(spoolConfig(directory)),
+      ).toHaveLength(0);
+    } finally {
+      await fs.promises.rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("retains a durable cleanup intent after pending and retries it", async () => {
+    const directory = await stateDirectory();
+    try {
+      const artifacts = await capturedFixture(directory);
+      const protectedBackup = {
+        ...claim(artifacts).backup,
+        catalog_state: "protected" as const,
+        catalog_lease_owner: null,
+        catalog_lease_generation: null,
+        catalog_lease_expires_at: null,
+        secondary_verified_at: new Date(NOW_MS),
+      };
+      const authority =
+        await deriveAgentBackupCaptureV3SpoolAuthorityFromCatalogBackup(protectedBackup);
+      let cleanupStatus: "complete" | "pending" = "pending";
+      let authorizations = 0;
+      let closes = 0;
+      const janitor = createAgentBackupCaptureV3SpoolCleanupJanitor(
+        { spool: spoolConfig(directory), batchSize: 1 },
+        {
+          now: () => NOW_MS,
+          executionToken: () => RETRY_EXECUTION,
+          listDurableOperations: async () => [
+            {
+              operationId: authority.operationId,
+              requestSha256: authority.requestSha256,
+              authoritySha256: authority.authoritySha256,
+              phase: "published",
+              recordCaptured: true,
+            },
+          ],
+          listCandidates: async () => [protectedBackup],
+          authorize: async () => {
+            authorizations += 1;
+            return protectedBackup;
+          },
+          openExisting: async () =>
+            ({
+              operationId: authority.operationId,
+              phase: "published",
+              recordCaptured: true,
+              async cleanup() {
+                return { operationId: authority.operationId, status: cleanupStatus };
+              },
+              async close() {
+                closes += 1;
+              },
+            }) as unknown as AgentBackupCaptureV3Spool,
+        },
+      );
+
+      const pending = await janitor.runCycle();
+      expect(pending).toMatchObject({ authorized: 1, completed: 0, pending: 1 });
+      expect(closes).toBe(1);
+      const outbox = path.join(directory, "agent-backup-capture-v3-cleanup-outbox");
+      expect(await fs.promises.readdir(outbox)).toContain(`${OPERATION_ID}.json`);
+
+      cleanupStatus = "complete";
+      const completed = await janitor.runCycle();
+      expect(completed).toMatchObject({ authorized: 0, completed: 1, pending: 0 });
+      expect(await fs.promises.readdir(outbox)).toEqual([]);
+      expect(authorizations).toBe(3);
+    } finally {
+      await fs.promises.rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-publication-source.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-publication-source.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
@@ -45,6 +45,8 @@ const VAULT_KEY_GENERATION_ID = "88888888-8888-4888-8888-888888888888";
 const CONTAINER_ID = "c".repeat(64);
 const NOW_MS = Date.parse("2026-08-15T10:01:00.000Z");
 const COMPONENTS = ["character", "database", "media", "state-files", "vault"] as const;
+
+setDefaultTimeout(30_000);
 
 const request: AgentBackupCaptureV2Request = {
   format: AGENT_BACKUP_CAPTURE_V2_REQUEST_FORMAT,

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-publication-source.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-publication-source.ts
@@ -1,0 +1,501 @@
+/**
+ * Concrete bridge from one authenticated manifest-v3 capture spool to the
+ * manifest-agnostic primary publication executor. Every catalogue and spool
+ * authority is re-derived before a filesystem lock is returned to callers.
+ */
+
+import { createHash } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
+import { ElizaError } from "@elizaos/core";
+import {
+  AGENT_BACKUP_CAPTURE_V2_REQUEST_FORMAT,
+  AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+  AGENT_BACKUP_MANIFEST_V3_SCHEMA_VERSION,
+  type AgentBackupManifestV3,
+  type AgentBackupManifestV3Draft,
+  canonicalizeAgentBackupManifestV3,
+  canonicalizeAgentBackupOperationKeyBundleContext,
+  computeAgentBackupManifestV3Digest,
+} from "@elizaos/shared";
+import type {
+  AgentBackupOperationClaim,
+  AgentBackupOperationExecution,
+} from "../../db/repositories/agent-backup-catalog";
+import type { StoredAgentSandboxBackup } from "../../db/schemas/agent-sandboxes";
+import { MAX_IMMUTABLE_SINGLE_PUT_BYTES } from "../storage/object-store";
+import {
+  type AgentBackupCaptureV3CatalogManifest,
+  type AgentBackupCaptureV3ManifestAuthority,
+  canonicalAgentBackupCaptureV3CatalogManifestBytes,
+  deriveAgentBackupCaptureV3SpoolAuthorityDigests,
+  loadAgentBackupCaptureV3SealedArtifacts,
+} from "./agent-backup-capture-v2-pipeline";
+import {
+  AgentBackupCaptureV3Spool,
+  type AgentBackupCaptureV3SpoolChunk,
+  type AgentBackupCaptureV3SpoolConfig,
+} from "./agent-backup-capture-v2-spool";
+import type {
+  AgentBackupCapturedPublicationChunk,
+  AgentBackupCapturedPublicationSource,
+  ResolveAgentBackupCapturedPublicationSource,
+} from "./agent-backup-publication-executor";
+
+const PUBLICATION_SOURCE_STATES = ["captured", "uploading", "primary_uploaded"] as const;
+
+export interface AgentBackupCaptureV3SpoolAuthority {
+  organizationId: string;
+  agentId: string;
+  backupId: string;
+  operationId: string;
+  activationGeneration: string;
+  lifecycleRevision: string;
+  manifestDigest: string;
+  objectInventoryDigest: string;
+  requestSha256: string;
+  authoritySha256: string;
+}
+
+export interface AgentBackupCaptureV3PublicationSourceConfig {
+  spool: Readonly<AgentBackupCaptureV3SpoolConfig>;
+  now?: () => number;
+}
+
+function sourceError(code: string, message: string, cause?: unknown): never {
+  throw new ElizaError(message, {
+    code,
+    cause,
+    severity: "fatal",
+  });
+}
+
+function parseCanonicalDraft(value: string | null): AgentBackupManifestV3Draft {
+  if (!value) {
+    sourceError(
+      "AGENT_BACKUP_V3_PUBLICATION_AUTHORITY_INCOMPLETE",
+      "Catalogue has no canonical manifest-v3 draft",
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch (cause) {
+    sourceError(
+      "AGENT_BACKUP_V3_PUBLICATION_AUTHORITY_INVALID",
+      "Catalogue manifest-v3 draft is not valid JSON",
+      cause,
+    );
+  }
+  let canonical: string;
+  try {
+    canonical = canonicalizeAgentBackupManifestV3(parsed as AgentBackupManifestV3Draft);
+  } catch (cause) {
+    sourceError(
+      "AGENT_BACKUP_V3_PUBLICATION_AUTHORITY_INVALID",
+      "Catalogue manifest-v3 draft is invalid",
+      cause,
+    );
+  }
+  if (canonical !== value) {
+    sourceError(
+      "AGENT_BACKUP_V3_PUBLICATION_AUTHORITY_INVALID",
+      "Catalogue manifest-v3 draft is not canonical",
+    );
+  }
+  return parsed as AgentBackupManifestV3Draft;
+}
+
+function manifestAuthority(
+  draft: AgentBackupManifestV3Draft,
+): AgentBackupCaptureV3ManifestAuthority {
+  return {
+    createdAt: draft.createdAt,
+    organizationId: draft.identity.organizationId,
+    source: draft.source,
+    runtime: draft.runtime,
+    chain: draft.chain,
+    watermarks: draft.watermarks,
+    kms: draft.encryption.kms,
+    vaultKeyAuthority: draft.vaultKeyAuthority,
+  };
+}
+
+function assertExecutionAuthority(params: {
+  claim: Readonly<AgentBackupOperationClaim>;
+  execution: Readonly<AgentBackupOperationExecution>;
+  now: number;
+}): void {
+  const backup = params.claim.backup;
+  if (
+    params.execution.ownerId !== params.claim.ownerId ||
+    params.execution.generation !== params.claim.generation ||
+    backup.catalog_lease_owner !== params.execution.ownerId ||
+    backup.catalog_lease_generation !== params.execution.generation ||
+    !(backup.catalog_lease_expires_at instanceof Date) ||
+    !Number.isFinite(backup.catalog_lease_expires_at.getTime()) ||
+    backup.catalog_lease_expires_at.getTime() <= params.now
+  ) {
+    sourceError(
+      "AGENT_BACKUP_V3_PUBLICATION_EXECUTION_STALE",
+      "Capture spool publication requires the exact live catalogue execution",
+    );
+  }
+}
+
+function assertManifestIdentity(params: {
+  backup: Readonly<StoredAgentSandboxBackup>;
+  draft: AgentBackupManifestV3Draft;
+}): void {
+  const backup = params.backup;
+  const draft = params.draft;
+  const expectedSourceProvider =
+    draft.source.kind === "robot" ? "operator-onboarded" : "hetzner-cloud";
+  if (
+    backup.catalog_version !== 2 ||
+    backup.manifest_version !== AGENT_BACKUP_MANIFEST_V3_SCHEMA_VERSION ||
+    !backup.catalog_organization_id ||
+    !backup.catalog_agent_id ||
+    !backup.backup_operation_id ||
+    !backup.lifecycle_generation ||
+    backup.lifecycle_revision === null ||
+    backup.manifest_digest === null ||
+    backup.object_inventory_digest === null ||
+    backup.vault_key_generation_id === null ||
+    backup.vault_key_authority_receipt_digest === null ||
+    draft.operationId !== backup.backup_operation_id ||
+    draft.identity.organizationId !== backup.catalog_organization_id ||
+    draft.identity.agentId !== backup.catalog_agent_id ||
+    draft.identity.activationGeneration !== backup.lifecycle_generation ||
+    draft.identity.lifecycleRevision !== backup.lifecycle_revision.toString() ||
+    draft.vaultKeyAuthority.generationId !== backup.vault_key_generation_id ||
+    draft.vaultKeyAuthority.receiptDigest !== backup.vault_key_authority_receipt_digest ||
+    draft.source.provider !== "hetzner" ||
+    backup.source_provider !== expectedSourceProvider ||
+    draft.source.nodeRecordId !== backup.source_node_record_id ||
+    draft.source.nodeId !== backup.source_node_id ||
+    draft.source.nodeIncarnation !== backup.source_node_incarnation ||
+    draft.source.containerId !== backup.source_container_id ||
+    (draft.source.kind === "cloud" ? draft.source.providerServerId : null) !==
+      backup.source_provider_server_id ||
+    !(backup.created_at instanceof Date) ||
+    draft.createdAt !== backup.created_at.toISOString()
+  ) {
+    sourceError(
+      "AGENT_BACKUP_V3_PUBLICATION_AUTHORITY_MISMATCH",
+      "Catalogue manifest-v3 identity differs from the owned backup operation",
+    );
+  }
+}
+
+/**
+ * Re-derive the immutable spool locator from one authoritative catalogue row.
+ * Cleanup reconciliation uses the same derivation as publication; neither
+ * caller may supply request or manifest-authority digests independently.
+ */
+export async function deriveAgentBackupCaptureV3SpoolAuthorityFromCatalogBackup(
+  backup: Readonly<StoredAgentSandboxBackup>,
+): Promise<AgentBackupCaptureV3SpoolAuthority> {
+  const draft = parseCanonicalDraft(backup.manifest_canonical_draft);
+  assertManifestIdentity({ backup, draft });
+  const computedManifestDigest = await computeAgentBackupManifestV3Digest(draft);
+  if (
+    computedManifestDigest !== backup.manifest_digest ||
+    !backup.object_inventory_digest ||
+    !backup.catalog_organization_id ||
+    !backup.catalog_agent_id ||
+    !backup.backup_operation_id ||
+    !backup.lifecycle_generation ||
+    backup.lifecycle_revision === null
+  ) {
+    sourceError(
+      "AGENT_BACKUP_V3_PUBLICATION_AUTHORITY_MISMATCH",
+      "Catalogue manifest digest differs from its canonical draft",
+    );
+  }
+  const digests = deriveAgentBackupCaptureV3SpoolAuthorityDigests({
+    request: {
+      format: AGENT_BACKUP_CAPTURE_V2_REQUEST_FORMAT,
+      schemaVersion: AGENT_BACKUP_CAPTURE_V2_SCHEMA_VERSION,
+      operationId: draft.operationId,
+      agentId: draft.identity.agentId,
+      activationGeneration: draft.identity.activationGeneration,
+      lifecycleRevision: draft.identity.lifecycleRevision,
+    },
+    authority: manifestAuthority(draft),
+  });
+  return Object.freeze({
+    organizationId: backup.catalog_organization_id,
+    agentId: backup.catalog_agent_id,
+    backupId: backup.id,
+    operationId: backup.backup_operation_id,
+    activationGeneration: backup.lifecycle_generation,
+    lifecycleRevision: backup.lifecycle_revision.toString(),
+    manifestDigest: computedManifestDigest,
+    objectInventoryDigest: backup.object_inventory_digest,
+    ...digests,
+  });
+}
+
+function assertCatalogManifest(params: {
+  claim: Readonly<AgentBackupOperationClaim>;
+  manifest: AgentBackupManifestV3;
+  catalog: AgentBackupCaptureV3CatalogManifest;
+}): void {
+  const backup = params.claim.backup;
+  const bundle = params.manifest.encryption.operationKeyBundle;
+  const context = canonicalizeAgentBackupOperationKeyBundleContext({
+    organizationId: params.manifest.identity.organizationId,
+    agentId: params.manifest.identity.agentId,
+    activationGeneration: params.manifest.identity.activationGeneration,
+    lifecycleRevision: params.manifest.identity.lifecycleRevision,
+    operationId: params.manifest.operationId,
+    keyBundleGenerationId: bundle.generationId,
+    sourceKind: params.manifest.source.kind,
+    sourceProvider: params.manifest.source.provider,
+    kmsProvider: params.manifest.encryption.kms.provider,
+    keyId: params.manifest.encryption.kms.keyId,
+    keyVersion: params.manifest.encryption.kms.keyVersion,
+  });
+  if (
+    params.manifest.encryption.kms.provider !== "steward" ||
+    params.catalog.canonicalManifestDraft !== backup.manifest_canonical_draft ||
+    params.catalog.format !== backup.manifest_format ||
+    params.catalog.version !== backup.manifest_version ||
+    params.catalog.digest !== backup.manifest_digest ||
+    params.catalog.objectCount !== backup.manifest_object_count ||
+    params.catalog.objectInventoryDigest !== backup.object_inventory_digest ||
+    params.catalog.imageDigest !== backup.image_digest ||
+    params.catalog.databaseSchemaVersion !== backup.database_schema_version ||
+    params.catalog.pluginSetDigest !== backup.plugin_set_digest ||
+    params.catalog.watermarkDigest !== backup.watermark_digest ||
+    params.catalog.rawSizeBytes !== backup.raw_size_bytes ||
+    params.catalog.compressedSizeBytes !== backup.compressed_size_bytes ||
+    params.catalog.encryptedSizeBytes !== backup.encrypted_size_bytes ||
+    params.catalog.kmsKeyId !== backup.kms_key_id ||
+    params.catalog.kmsKeyVersion !== backup.kms_key_version ||
+    params.catalog.wrappedKeyBundleGenerationId !== backup.operation_key_bundle_generation_id ||
+    bundle.format !== backup.operation_key_bundle_format ||
+    bundle.wrapped.ref !== backup.operation_key_bundle_ref ||
+    params.catalog.wrappedKeyBundleCiphertextBase64 !==
+      backup.operation_key_bundle_ciphertext_base64 ||
+    params.catalog.wrappedKeyBundleSha256 !== backup.operation_key_bundle_sha256 ||
+    bundle.wrapped.bytes !== backup.operation_key_bundle_size_bytes ||
+    context !== backup.operation_key_bundle_context ||
+    bundle.wrapped.contextDerivation !== backup.operation_key_bundle_context_derivation ||
+    bundle.wrapped.localReceiptDerivation !==
+      backup.operation_key_bundle_local_receipt_derivation ||
+    params.catalog.wrappedKeyBundleLocalReceiptDigest !==
+      backup.operation_key_bundle_local_receipt_digest ||
+    params.catalog.vaultKeyGenerationId !== backup.vault_key_generation_id ||
+    params.catalog.vaultKeyAuthorityReceiptDigest !== backup.vault_key_authority_receipt_digest ||
+    params.manifest.vaultKeyAuthority.generationId !== backup.vault_key_generation_id ||
+    params.manifest.vaultKeyAuthority.receiptDigest !== backup.vault_key_authority_receipt_digest ||
+    backup.wrapped_dek_ref !== null ||
+    backup.wrapped_dek_ciphertext_base64 !== null ||
+    backup.wrapped_dek_sha256 !== null ||
+    backup.wrapped_dek_size_bytes !== null ||
+    backup.wrapped_dek_receipt_digest !== null
+  ) {
+    sourceError(
+      "AGENT_BACKUP_V3_PUBLICATION_CATALOG_MISMATCH",
+      "Durable capture spool differs from catalogue manifest-v3 authority",
+    );
+  }
+}
+
+function publicationChunk(
+  chunk: AgentBackupCaptureV3SpoolChunk,
+): AgentBackupCapturedPublicationChunk {
+  return Object.freeze({
+    component: chunk.component,
+    chunkIndex: chunk.index,
+    contentHmacSha256: chunk.contentHmacSha256,
+    ciphertextSha256: chunk.ciphertextSha256,
+    sizeBytes: chunk.encryptedBytes,
+  });
+}
+
+function publicationChunkKey(
+  chunk: Pick<AgentBackupCapturedPublicationChunk, "component" | "chunkIndex">,
+): string {
+  return `${chunk.component}:${chunk.chunkIndex}`;
+}
+
+class CaptureV3PublicationSource implements AgentBackupCapturedPublicationSource {
+  readonly chunks: readonly AgentBackupCapturedPublicationChunk[];
+  private readonly spoolChunks = new Map<string, AgentBackupCaptureV3SpoolChunk>();
+
+  constructor(
+    readonly organizationId: string,
+    readonly agentId: string,
+    readonly backupId: string,
+    readonly operationId: string,
+    readonly manifestDigest: string,
+    readonly objectInventoryDigest: string,
+    private readonly spool: AgentBackupCaptureV3Spool,
+  ) {
+    this.chunks = Object.freeze(
+      spool.chunks.map((chunk) => {
+        this.spoolChunks.set(
+          publicationChunkKey({ component: chunk.component, chunkIndex: chunk.index }),
+          chunk,
+        );
+        return publicationChunk(chunk);
+      }),
+    );
+  }
+
+  async beginPrimaryPublication(): Promise<void> {
+    await this.spool.markPublishing();
+  }
+
+  async readCiphertextChunk(
+    chunk: Readonly<AgentBackupCapturedPublicationChunk>,
+    signal?: AbortSignal,
+  ): Promise<Uint8Array> {
+    signal?.throwIfAborted();
+    const stored = this.spoolChunks.get(publicationChunkKey(chunk));
+    if (
+      !stored ||
+      chunk.contentHmacSha256 !== stored.contentHmacSha256 ||
+      chunk.ciphertextSha256 !== stored.ciphertextSha256 ||
+      chunk.sizeBytes !== stored.encryptedBytes ||
+      stored.encryptedBytes > MAX_IMMUTABLE_SINGLE_PUT_BYTES
+    ) {
+      sourceError(
+        "AGENT_BACKUP_V3_PUBLICATION_CHUNK_MISMATCH",
+        "Requested publication chunk differs from the sealed spool inventory",
+      );
+    }
+    const bytes = await this.spool.readCiphertextChunk(stored);
+    if (signal?.aborted) {
+      bytes.fill(0);
+      signal.throwIfAborted();
+    }
+    return bytes;
+  }
+
+  async markPrimaryChunkUploaded(
+    chunk: Readonly<AgentBackupCapturedPublicationChunk>,
+  ): Promise<void> {
+    const stored = this.spoolChunks.get(publicationChunkKey(chunk));
+    if (
+      !stored ||
+      chunk.contentHmacSha256 !== stored.contentHmacSha256 ||
+      chunk.ciphertextSha256 !== stored.ciphertextSha256 ||
+      chunk.sizeBytes !== stored.encryptedBytes
+    ) {
+      sourceError(
+        "AGENT_BACKUP_V3_PUBLICATION_CHUNK_MISMATCH",
+        "Publication receipt differs from the sealed spool inventory",
+      );
+    }
+    await this.spool.markChunkUploaded(stored);
+  }
+
+  async markPrimaryPublished(): Promise<void> {
+    await this.spool.markPublished();
+  }
+
+  async close(): Promise<void> {
+    await this.spool.close();
+  }
+}
+
+/**
+ * Resolve and lock an exact capture spool for primary publication. Secondary
+ * replication never calls this resolver, and closing the returned source only
+ * releases its lock.
+ */
+export function createAgentBackupCaptureV3PublicationSourceResolver(
+  config: Readonly<AgentBackupCaptureV3PublicationSourceConfig>,
+): ResolveAgentBackupCapturedPublicationSource {
+  const now = config.now ?? Date.now;
+  return async ({ claim, execution, signal }) => {
+    signal?.throwIfAborted();
+    const nowMs = now();
+    if (!Number.isSafeInteger(nowMs) || nowMs < 1) {
+      sourceError(
+        "AGENT_BACKUP_V3_PUBLICATION_CLOCK_INVALID",
+        "Publication resolver clock is invalid",
+      );
+    }
+    assertExecutionAuthority({ claim, execution, now: nowMs });
+    if (
+      !PUBLICATION_SOURCE_STATES.includes(
+        claim.backup.catalog_state as (typeof PUBLICATION_SOURCE_STATES)[number],
+      )
+    ) {
+      sourceError(
+        "AGENT_BACKUP_V3_PUBLICATION_AUTHORITY_MISMATCH",
+        "Catalogue operation is not in a primary publication state",
+      );
+    }
+    const draft = parseCanonicalDraft(claim.backup.manifest_canonical_draft);
+    const spoolAuthority = await deriveAgentBackupCaptureV3SpoolAuthorityFromCatalogBackup(
+      claim.backup,
+    );
+    const spool = await AgentBackupCaptureV3Spool.openExisting(config.spool, {
+      operationId: draft.operationId,
+      executionToken: execution.generation,
+      requestSha256: spoolAuthority.requestSha256,
+      authoritySha256: spoolAuthority.authoritySha256,
+    });
+    if (!spool) {
+      sourceError(
+        "AGENT_BACKUP_V3_PUBLICATION_HANDOFF_MISSING",
+        "Capture spool is absent; publication cannot recreate captured authority",
+      );
+    }
+    let failure: unknown;
+    try {
+      const artifacts = await loadAgentBackupCaptureV3SealedArtifacts(spool);
+      try {
+        if (!isDeepStrictEqual(artifacts.manifest.source, draft.source)) {
+          sourceError(
+            "AGENT_BACKUP_V3_PUBLICATION_AUTHORITY_MISMATCH",
+            "Sealed spool source differs from catalogue authority",
+          );
+        }
+        assertCatalogManifest({
+          claim,
+          manifest: artifacts.manifest,
+          catalog: artifacts.catalogManifest,
+        });
+        if (!spool.recordCaptured) {
+          signal?.throwIfAborted();
+          const catalogBytes = canonicalAgentBackupCaptureV3CatalogManifestBytes(
+            artifacts.catalogManifest,
+          );
+          await spool.markRecordCaptured(catalogBytes, {
+            bytes: catalogBytes.byteLength,
+            sha256: createHash("sha256").update(catalogBytes).digest("hex"),
+          });
+        }
+      } finally {
+        artifacts.wrappedKeyBundle.fill(0);
+      }
+      signal?.throwIfAborted();
+      return new CaptureV3PublicationSource(
+        draft.identity.organizationId,
+        draft.identity.agentId,
+        claim.backup.id,
+        draft.operationId,
+        claim.backup.manifest_digest as string,
+        claim.backup.object_inventory_digest as string,
+        spool,
+      );
+    } catch (cause) {
+      failure = cause;
+    }
+    try {
+      await spool.close();
+    } catch (closeCause) {
+      throw new AggregateError(
+        [failure, closeCause],
+        "Capture-v3 publication source validation and close both failed",
+      );
+    }
+    throw failure;
+  };
+}

--- a/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-spool-cleanup.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-capture-v3-spool-cleanup.ts
@@ -1,0 +1,1016 @@
+/**
+ * Durable protected→spool cleanup reconciliation. A local operation directory
+ * is only a discovery cursor: authoritative catalogue state and matching
+ * primary+secondary provider receipts are re-proved before an outbox intent is
+ * persisted or any ciphertext is removed.
+ */
+
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import z from "zod";
+import {
+  type AuthorizeAgentBackupProtectedSpoolCleanupInput,
+  type AuthorizeAgentBackupTerminalSpoolCleanupInput,
+  authorizeAgentBackupProtectedSpoolCleanup,
+  authorizeAgentBackupTerminalSpoolCleanup,
+  listAgentBackupProtectedSpoolCleanupCandidates,
+} from "../../db/repositories/agent-backup-publication";
+import type { StoredAgentSandboxBackup } from "../../db/schemas/agent-sandboxes";
+import {
+  type AgentBackupCaptureV3DurableOperationAuthority,
+  AgentBackupCaptureV3Spool,
+  type AgentBackupCaptureV3SpoolConfig,
+} from "./agent-backup-capture-v2-spool";
+import {
+  type AgentBackupCaptureV3SpoolAuthority,
+  deriveAgentBackupCaptureV3SpoolAuthorityFromCatalogBackup,
+} from "./agent-backup-capture-v3-publication-source";
+
+const OUTBOX_DIRECTORY = "agent-backup-capture-v3-cleanup-outbox";
+const TERMINAL_OUTBOX_DIRECTORY = "agent-backup-capture-v3-terminal-cleanup-outbox";
+const TERMINAL_CANDIDATE_DIRECTORY = "agent-backup-capture-v3-terminal-cleanup-candidates";
+const OUTBOX_FORMAT = "elizaos.agent-backup.capture-v3-cleanup" as const;
+const TERMINAL_OUTBOX_FORMAT = "elizaos.agent-backup.capture-v3-terminal-cleanup" as const;
+const TERMINAL_CANDIDATE_FORMAT =
+  "elizaos.agent-backup.capture-v3-terminal-cleanup-candidate" as const;
+const OUTBOX_VERSION = 1 as const;
+const MAX_INTENT_BYTES = 16 * 1024;
+const FILE_MODE = 0o600;
+const DIRECTORY_MODE = 0o700;
+const DEFAULT_BATCH_SIZE = 32;
+const MAX_BATCH_SIZE = 100;
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const OWNED_TEMPORARY_PATTERN =
+  /^\.[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.tmp$/;
+
+const IntentSchema = z.strictObject({
+  format: z.literal(OUTBOX_FORMAT),
+  version: z.literal(OUTBOX_VERSION),
+  organizationId: z.string().regex(UUID_PATTERN),
+  agentId: z.string().regex(UUID_PATTERN),
+  backupId: z.string().regex(UUID_PATTERN),
+  operationId: z.string().regex(UUID_PATTERN),
+  activationGeneration: z.string().regex(UUID_PATTERN),
+  lifecycleRevision: z.string().regex(/^(?:0|[1-9][0-9]{0,19})$/),
+  manifestDigest: z.string().regex(SHA256_PATTERN),
+  objectInventoryDigest: z.string().regex(SHA256_PATTERN),
+  requestSha256: z.string().regex(SHA256_PATTERN),
+  authoritySha256: z.string().regex(SHA256_PATTERN),
+  authorizedAt: z.string().datetime({ offset: true }),
+});
+
+type CleanupIntent = z.infer<typeof IntentSchema>;
+
+const TerminalIntentSchema = z.strictObject({
+  format: z.literal(TERMINAL_OUTBOX_FORMAT),
+  version: z.literal(OUTBOX_VERSION),
+  organizationId: z.string().regex(UUID_PATTERN),
+  agentId: z.string().regex(UUID_PATTERN),
+  backupId: z.string().regex(UUID_PATTERN),
+  operationId: z.string().regex(UUID_PATTERN),
+  activationGeneration: z.string().regex(UUID_PATTERN),
+  lifecycleRevision: z.string().regex(/^(?:0|[1-9][0-9]{0,19})$/),
+  requestSha256: z.string().regex(SHA256_PATTERN),
+  authoritySha256: z.string().regex(SHA256_PATTERN),
+  terminalErrorCode: z
+    .string()
+    .min(1)
+    .max(96)
+    .regex(/^[A-Z][A-Z0-9_]*$/),
+  authorizedAt: z.string().datetime({ offset: true }),
+});
+
+type TerminalCleanupIntent = z.infer<typeof TerminalIntentSchema>;
+
+const TerminalCandidateSchema = TerminalIntentSchema.omit({
+  format: true,
+  authorizedAt: true,
+}).extend({
+  format: z.literal(TERMINAL_CANDIDATE_FORMAT),
+  stagedAt: z.string().datetime({ offset: true }),
+});
+
+type TerminalCleanupCandidate = z.infer<typeof TerminalCandidateSchema>;
+
+export interface AgentBackupCaptureV3TerminalSpoolCleanupAuthority {
+  organizationId: string;
+  agentId: string;
+  backupId: string;
+  operationId: string;
+  activationGeneration: string;
+  lifecycleRevision: string;
+  requestSha256: string;
+  authoritySha256: string;
+}
+
+export interface AgentBackupCaptureV3SpoolCleanupDependencies {
+  listCandidates(params: {
+    operationId: string;
+    limit?: number;
+  }): Promise<StoredAgentSandboxBackup[]>;
+  authorize(
+    input: Readonly<AuthorizeAgentBackupProtectedSpoolCleanupInput>,
+  ): Promise<StoredAgentSandboxBackup>;
+  authorizeTerminal(
+    input: Readonly<AuthorizeAgentBackupTerminalSpoolCleanupInput>,
+  ): Promise<StoredAgentSandboxBackup>;
+  deriveAuthority(
+    backup: Readonly<StoredAgentSandboxBackup>,
+  ): Promise<AgentBackupCaptureV3SpoolAuthority>;
+  listDurableOperations(
+    config: Readonly<AgentBackupCaptureV3SpoolConfig>,
+  ): Promise<AgentBackupCaptureV3DurableOperationAuthority[]>;
+  openExisting(
+    config: Readonly<AgentBackupCaptureV3SpoolConfig>,
+    input: {
+      operationId: string;
+      executionToken: string;
+      requestSha256: string;
+      authoritySha256: string;
+    },
+  ): Promise<AgentBackupCaptureV3Spool | undefined>;
+  now(): number;
+  executionToken(): string;
+}
+
+const DEFAULT_DEPENDENCIES: AgentBackupCaptureV3SpoolCleanupDependencies = {
+  listCandidates: listAgentBackupProtectedSpoolCleanupCandidates,
+  authorize: authorizeAgentBackupProtectedSpoolCleanup,
+  authorizeTerminal: authorizeAgentBackupTerminalSpoolCleanup,
+  deriveAuthority: deriveAgentBackupCaptureV3SpoolAuthorityFromCatalogBackup,
+  listDurableOperations: AgentBackupCaptureV3Spool.listDurableOperationAuthorities,
+  openExisting: AgentBackupCaptureV3Spool.openExisting,
+  now: Date.now,
+  executionToken: randomUUID,
+};
+
+export interface AgentBackupCaptureV3SpoolCleanupJanitorConfig {
+  spool: Readonly<AgentBackupCaptureV3SpoolConfig>;
+  batchSize?: number;
+}
+
+export interface AgentBackupCaptureV3SpoolCleanupSummary {
+  discovered: number;
+  authorized: number;
+  completed: number;
+  pending: number;
+  skippedUnprotected: number;
+  indeterminate: number;
+}
+
+export interface AgentBackupCaptureV3SpoolCleanupJanitor {
+  enqueueProtectedBackup(backup: Readonly<StoredAgentSandboxBackup>): Promise<"pending">;
+  /** Persist non-authorizing evidence before the terminal catalogue CAS. */
+  stageTerminalFailure(input: {
+    authority: Readonly<AgentBackupCaptureV3TerminalSpoolCleanupAuthority>;
+    terminalErrorCode: string;
+  }): Promise<"pending">;
+  runCycle(): Promise<AgentBackupCaptureV3SpoolCleanupSummary>;
+}
+
+function batchSize(value: number | undefined): number {
+  const resolved = value ?? DEFAULT_BATCH_SIZE;
+  if (!Number.isSafeInteger(resolved) || resolved < 1 || resolved > MAX_BATCH_SIZE) {
+    throw new Error(`Backup spool cleanup batch size must be between 1 and ${MAX_BATCH_SIZE}`);
+  }
+  return resolved;
+}
+
+function authorizationInput(
+  authority: Readonly<AgentBackupCaptureV3SpoolAuthority>,
+): AuthorizeAgentBackupProtectedSpoolCleanupInput {
+  return {
+    organizationId: authority.organizationId,
+    agentId: authority.agentId,
+    backupId: authority.backupId,
+    operationId: authority.operationId,
+    activationGeneration: authority.activationGeneration,
+    lifecycleRevision: authority.lifecycleRevision,
+    manifestDigest: authority.manifestDigest,
+    objectInventoryDigest: authority.objectInventoryDigest,
+  };
+}
+
+function terminalAuthorizationInput(
+  evidence: Readonly<AgentBackupCaptureV3TerminalSpoolCleanupAuthority> & {
+    terminalErrorCode: string;
+  },
+): AuthorizeAgentBackupTerminalSpoolCleanupInput {
+  return {
+    organizationId: evidence.organizationId,
+    agentId: evidence.agentId,
+    backupId: evidence.backupId,
+    operationId: evidence.operationId,
+    activationGeneration: evidence.activationGeneration,
+    lifecycleRevision: evidence.lifecycleRevision,
+    terminalErrorCode: evidence.terminalErrorCode,
+  };
+}
+
+function terminalCleanupAuthority(
+  evidence: Readonly<AgentBackupCaptureV3TerminalSpoolCleanupAuthority>,
+): AgentBackupCaptureV3TerminalSpoolCleanupAuthority {
+  return {
+    organizationId: evidence.organizationId,
+    agentId: evidence.agentId,
+    backupId: evidence.backupId,
+    operationId: evidence.operationId,
+    activationGeneration: evidence.activationGeneration,
+    lifecycleRevision: evidence.lifecycleRevision,
+    requestSha256: evidence.requestSha256,
+    authoritySha256: evidence.authoritySha256,
+  };
+}
+
+function sameAuthority(
+  left: Readonly<AgentBackupCaptureV3SpoolAuthority>,
+  right: Readonly<AgentBackupCaptureV3SpoolAuthority>,
+): boolean {
+  return (
+    left.organizationId === right.organizationId &&
+    left.agentId === right.agentId &&
+    left.backupId === right.backupId &&
+    left.operationId === right.operationId &&
+    left.activationGeneration === right.activationGeneration &&
+    left.lifecycleRevision === right.lifecycleRevision &&
+    left.manifestDigest === right.manifestDigest &&
+    left.objectInventoryDigest === right.objectInventoryDigest &&
+    left.requestSha256 === right.requestSha256 &&
+    left.authoritySha256 === right.authoritySha256
+  );
+}
+
+function intentAuthority(intent: Readonly<CleanupIntent>): AgentBackupCaptureV3SpoolAuthority {
+  return {
+    organizationId: intent.organizationId,
+    agentId: intent.agentId,
+    backupId: intent.backupId,
+    operationId: intent.operationId,
+    activationGeneration: intent.activationGeneration,
+    lifecycleRevision: intent.lifecycleRevision,
+    manifestDigest: intent.manifestDigest,
+    objectInventoryDigest: intent.objectInventoryDigest,
+    requestSha256: intent.requestSha256,
+    authoritySha256: intent.authoritySha256,
+  };
+}
+
+async function fsyncDirectory(directory: string): Promise<void> {
+  const handle = await fs.promises.open(directory, fs.constants.O_RDONLY);
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readIntent(file: string): Promise<CleanupIntent> {
+  const handle = await fs.promises.open(
+    file,
+    fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0),
+  );
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.size < 1 || stat.size > MAX_INTENT_BYTES) {
+      throw new Error("Backup spool cleanup intent has an invalid size");
+    }
+    const bytes = new Uint8Array(stat.size);
+    const read = await handle.read(bytes, 0, bytes.byteLength, 0);
+    if (read.bytesRead !== bytes.byteLength) {
+      throw new Error("Backup spool cleanup intent is truncated");
+    }
+    return IntentSchema.parse(JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)));
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readTerminalIntent(file: string): Promise<TerminalCleanupIntent> {
+  const handle = await fs.promises.open(
+    file,
+    fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0),
+  );
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.size < 1 || stat.size > MAX_INTENT_BYTES) {
+      throw new Error("Terminal backup spool cleanup intent has an invalid size");
+    }
+    const bytes = new Uint8Array(stat.size);
+    const read = await handle.read(bytes, 0, bytes.byteLength, 0);
+    if (read.bytesRead !== bytes.byteLength) {
+      throw new Error("Terminal backup spool cleanup intent is truncated");
+    }
+    return TerminalIntentSchema.parse(
+      JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)),
+    );
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readTerminalCandidate(file: string): Promise<TerminalCleanupCandidate> {
+  const handle = await fs.promises.open(
+    file,
+    fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0),
+  );
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.size < 1 || stat.size > MAX_INTENT_BYTES) {
+      throw new Error("Terminal backup spool cleanup candidate has an invalid size");
+    }
+    const bytes = new Uint8Array(stat.size);
+    const read = await handle.read(bytes, 0, bytes.byteLength, 0);
+    if (read.bytesRead !== bytes.byteLength) {
+      throw new Error("Terminal backup spool cleanup candidate is truncated");
+    }
+    return TerminalCandidateSchema.parse(
+      JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)),
+    );
+  } finally {
+    await handle.close();
+  }
+}
+
+async function ensureOutboxDirectory(
+  stateDirectoryInput: string,
+  directoryName = OUTBOX_DIRECTORY,
+): Promise<string> {
+  if (!path.isAbsolute(stateDirectoryInput)) {
+    throw new Error("Backup spool cleanup StateDirectory must be absolute");
+  }
+  const stateDirectory = path.resolve(stateDirectoryInput);
+  await fs.promises.mkdir(stateDirectory, { recursive: true, mode: DIRECTORY_MODE });
+  const stateStat = await fs.promises.lstat(stateDirectory);
+  const realStateDirectory = await fs.promises.realpath(stateDirectory);
+  if (
+    stateStat.isSymbolicLink() ||
+    !stateStat.isDirectory() ||
+    realStateDirectory !== stateDirectory
+  ) {
+    throw new Error("Backup spool cleanup StateDirectory is not a safe directory");
+  }
+  const realTemporaryDirectory = await fs.promises.realpath(os.tmpdir());
+  const relativeToTemporary = path.relative(realTemporaryDirectory, stateDirectory);
+  if (
+    relativeToTemporary === "" ||
+    (!relativeToTemporary.startsWith("..") && !path.isAbsolute(relativeToTemporary))
+  ) {
+    throw new Error("Backup spool cleanup StateDirectory must be persistent");
+  }
+  const outbox = path.join(stateDirectory, directoryName);
+  await fs.promises.mkdir(outbox, { recursive: true, mode: DIRECTORY_MODE });
+  const stat = await fs.promises.lstat(outbox);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new Error("Backup spool cleanup outbox is not a safe directory");
+  }
+  const real = await fs.promises.realpath(outbox);
+  if (real !== outbox || path.dirname(real) !== stateDirectory) {
+    throw new Error("Backup spool cleanup outbox escaped its StateDirectory");
+  }
+  return outbox;
+}
+
+async function persistIntent(params: {
+  outbox: string;
+  authority: Readonly<AgentBackupCaptureV3SpoolAuthority>;
+  authorizedAt: string;
+  nonce: string;
+}): Promise<void> {
+  const intent = IntentSchema.parse({
+    format: OUTBOX_FORMAT,
+    version: OUTBOX_VERSION,
+    ...params.authority,
+    authorizedAt: params.authorizedAt,
+  });
+  const finalPath = path.join(params.outbox, `${intent.operationId}.json`);
+  try {
+    const existing = await readIntent(finalPath);
+    if (!sameAuthority(intentAuthority(existing), intentAuthority(intent))) {
+      throw new Error("Backup spool cleanup operation already has different authority");
+    }
+    return;
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code !== "ENOENT") throw cause;
+  }
+  const temporaryPath = path.join(params.outbox, `.${intent.operationId}.${params.nonce}.tmp`);
+  const bytes = new TextEncoder().encode(`${JSON.stringify(intent)}\n`);
+  if (bytes.byteLength > MAX_INTENT_BYTES)
+    throw new Error("Backup spool cleanup intent is too large");
+  const handle = await fs.promises.open(
+    temporaryPath,
+    fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL,
+    FILE_MODE,
+  );
+  let failure: unknown;
+  try {
+    await handle.writeFile(bytes);
+    await handle.sync();
+  } catch (cause) {
+    failure = cause;
+  }
+  try {
+    await handle.close();
+  } catch (cause) {
+    failure = failure === undefined ? cause : new AggregateError([failure, cause]);
+  }
+  if (failure !== undefined) {
+    await fs.promises.unlink(temporaryPath).catch(() => undefined);
+    throw failure;
+  }
+  try {
+    // Same-directory hard-link publication is create-only on POSIX. `rename`
+    // would replace an existing different authority instead of failing closed.
+    await fs.promises.link(temporaryPath, finalPath);
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code !== "EEXIST") throw cause;
+    const existing = await readIntent(finalPath);
+    if (!sameAuthority(intentAuthority(existing), intentAuthority(intent))) throw cause;
+  } finally {
+    await fs.promises.unlink(temporaryPath).catch(() => undefined);
+  }
+  await fsyncDirectory(params.outbox);
+}
+
+function sameTerminalIntent(
+  left: Readonly<TerminalCleanupIntent>,
+  right: Readonly<TerminalCleanupIntent>,
+): boolean {
+  return (
+    left.organizationId === right.organizationId &&
+    left.agentId === right.agentId &&
+    left.backupId === right.backupId &&
+    left.operationId === right.operationId &&
+    left.activationGeneration === right.activationGeneration &&
+    left.lifecycleRevision === right.lifecycleRevision &&
+    left.requestSha256 === right.requestSha256 &&
+    left.authoritySha256 === right.authoritySha256 &&
+    left.terminalErrorCode === right.terminalErrorCode
+  );
+}
+
+async function persistTerminalIntent(params: {
+  outbox: string;
+  authority: Readonly<AgentBackupCaptureV3TerminalSpoolCleanupAuthority>;
+  terminalErrorCode: string;
+  authorizedAt: string;
+  nonce: string;
+}): Promise<void> {
+  const intent = TerminalIntentSchema.parse({
+    format: TERMINAL_OUTBOX_FORMAT,
+    version: OUTBOX_VERSION,
+    ...params.authority,
+    terminalErrorCode: params.terminalErrorCode,
+    authorizedAt: params.authorizedAt,
+  });
+  const finalPath = path.join(params.outbox, `${intent.operationId}.json`);
+  try {
+    const existing = await readTerminalIntent(finalPath);
+    if (!sameTerminalIntent(existing, intent)) {
+      throw new Error("Terminal backup spool cleanup operation already has different authority");
+    }
+    return;
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code !== "ENOENT") throw cause;
+  }
+  const temporaryPath = path.join(params.outbox, `.${intent.operationId}.${params.nonce}.tmp`);
+  const bytes = new TextEncoder().encode(`${JSON.stringify(intent)}\n`);
+  if (bytes.byteLength > MAX_INTENT_BYTES) {
+    throw new Error("Terminal backup spool cleanup intent is too large");
+  }
+  const handle = await fs.promises.open(
+    temporaryPath,
+    fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL,
+    FILE_MODE,
+  );
+  let failure: unknown;
+  try {
+    await handle.writeFile(bytes);
+    await handle.sync();
+  } catch (cause) {
+    failure = cause;
+  }
+  try {
+    await handle.close();
+  } catch (cause) {
+    failure = failure === undefined ? cause : new AggregateError([failure, cause]);
+  }
+  if (failure !== undefined) {
+    await fs.promises.unlink(temporaryPath).catch(() => undefined);
+    throw failure;
+  }
+  try {
+    await fs.promises.link(temporaryPath, finalPath);
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code !== "EEXIST") throw cause;
+    const existing = await readTerminalIntent(finalPath);
+    if (!sameTerminalIntent(existing, intent)) throw cause;
+  } finally {
+    await fs.promises.unlink(temporaryPath).catch(() => undefined);
+  }
+  await fsyncDirectory(params.outbox);
+}
+
+function sameTerminalCandidate(
+  left: Readonly<TerminalCleanupCandidate>,
+  right: Readonly<TerminalCleanupCandidate>,
+): boolean {
+  return (
+    left.organizationId === right.organizationId &&
+    left.agentId === right.agentId &&
+    left.backupId === right.backupId &&
+    left.operationId === right.operationId &&
+    left.activationGeneration === right.activationGeneration &&
+    left.lifecycleRevision === right.lifecycleRevision &&
+    left.requestSha256 === right.requestSha256 &&
+    left.authoritySha256 === right.authoritySha256 &&
+    left.terminalErrorCode === right.terminalErrorCode
+  );
+}
+
+async function persistTerminalCandidate(params: {
+  outbox: string;
+  authority: Readonly<AgentBackupCaptureV3TerminalSpoolCleanupAuthority>;
+  terminalErrorCode: string;
+  stagedAt: string;
+  nonce: string;
+}): Promise<void> {
+  const candidate = TerminalCandidateSchema.parse({
+    format: TERMINAL_CANDIDATE_FORMAT,
+    version: OUTBOX_VERSION,
+    ...params.authority,
+    terminalErrorCode: params.terminalErrorCode,
+    stagedAt: params.stagedAt,
+  });
+  const finalPath = path.join(params.outbox, `${candidate.operationId}.json`);
+  try {
+    const existing = await readTerminalCandidate(finalPath);
+    if (!sameTerminalCandidate(existing, candidate)) {
+      throw new Error("Terminal backup spool cleanup candidate already has different authority");
+    }
+    return;
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code !== "ENOENT") throw cause;
+  }
+  const temporaryPath = path.join(params.outbox, `.${candidate.operationId}.${params.nonce}.tmp`);
+  const bytes = new TextEncoder().encode(`${JSON.stringify(candidate)}\n`);
+  if (bytes.byteLength > MAX_INTENT_BYTES) {
+    throw new Error("Terminal backup spool cleanup candidate is too large");
+  }
+  const handle = await fs.promises.open(
+    temporaryPath,
+    fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL,
+    FILE_MODE,
+  );
+  let failure: unknown;
+  try {
+    await handle.writeFile(bytes);
+    await handle.sync();
+  } catch (cause) {
+    failure = cause;
+  }
+  try {
+    await handle.close();
+  } catch (cause) {
+    failure = failure === undefined ? cause : new AggregateError([failure, cause]);
+  }
+  if (failure !== undefined) {
+    await fs.promises.unlink(temporaryPath).catch(() => undefined);
+    throw failure;
+  }
+  try {
+    await fs.promises.link(temporaryPath, finalPath);
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code !== "EEXIST") throw cause;
+    const existing = await readTerminalCandidate(finalPath);
+    if (!sameTerminalCandidate(existing, candidate)) throw cause;
+  } finally {
+    await fs.promises.unlink(temporaryPath).catch(() => undefined);
+  }
+  await fsyncDirectory(params.outbox);
+}
+
+async function listIntents(outbox: string, limit: number): Promise<CleanupIntent[]> {
+  const entries = await fs.promises.readdir(outbox, { withFileTypes: true });
+  const intents: CleanupIntent[] = [];
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (OWNED_TEMPORARY_PATTERN.test(entry.name)) {
+      if (!entry.isFile() || entry.isSymbolicLink()) {
+        throw new Error("Backup spool cleanup outbox contains an unsafe temporary entry");
+      }
+      // An in-flight concurrent writer may still own this create-only file.
+      // It is ignored, not reaped, until an age-aware maintenance pass exists.
+      continue;
+    }
+    if (!entry.name.endsWith(".json") || !entry.isFile() || entry.isSymbolicLink()) {
+      throw new Error("Backup spool cleanup outbox contains an unsafe entry");
+    }
+    const operationId = entry.name.slice(0, -5);
+    if (!UUID_PATTERN.test(operationId)) {
+      throw new Error("Backup spool cleanup outbox contains an invalid operation identity");
+    }
+    const intent = await readIntent(path.join(outbox, entry.name));
+    if (intent.operationId !== operationId) {
+      throw new Error("Backup spool cleanup intent differs from its filename");
+    }
+    intents.push(intent);
+    if (intents.length >= limit) break;
+  }
+  return intents;
+}
+
+async function listTerminalIntents(
+  outbox: string,
+  limit: number,
+): Promise<TerminalCleanupIntent[]> {
+  const entries = await fs.promises.readdir(outbox, { withFileTypes: true });
+  const intents: TerminalCleanupIntent[] = [];
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (OWNED_TEMPORARY_PATTERN.test(entry.name)) {
+      if (!entry.isFile() || entry.isSymbolicLink()) {
+        throw new Error("Terminal backup spool cleanup outbox contains an unsafe temporary entry");
+      }
+      continue;
+    }
+    if (!entry.name.endsWith(".json") || !entry.isFile() || entry.isSymbolicLink()) {
+      throw new Error("Terminal backup spool cleanup outbox contains an unsafe entry");
+    }
+    const operationId = entry.name.slice(0, -5);
+    if (!UUID_PATTERN.test(operationId)) {
+      throw new Error("Terminal backup spool cleanup outbox has an invalid operation identity");
+    }
+    const intent = await readTerminalIntent(path.join(outbox, entry.name));
+    if (intent.operationId !== operationId) {
+      throw new Error("Terminal backup spool cleanup intent differs from its filename");
+    }
+    intents.push(intent);
+    if (intents.length >= limit) break;
+  }
+  return intents;
+}
+
+async function listTerminalCandidates(
+  outbox: string,
+  limit: number,
+): Promise<TerminalCleanupCandidate[]> {
+  const entries = await fs.promises.readdir(outbox, { withFileTypes: true });
+  const candidates: TerminalCleanupCandidate[] = [];
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (OWNED_TEMPORARY_PATTERN.test(entry.name)) {
+      if (!entry.isFile() || entry.isSymbolicLink()) {
+        throw new Error(
+          "Terminal backup spool cleanup candidate outbox contains an unsafe temporary entry",
+        );
+      }
+      continue;
+    }
+    if (!entry.name.endsWith(".json") || !entry.isFile() || entry.isSymbolicLink()) {
+      throw new Error("Terminal backup spool cleanup candidate outbox contains an unsafe entry");
+    }
+    const operationId = entry.name.slice(0, -5);
+    if (!UUID_PATTERN.test(operationId)) {
+      throw new Error(
+        "Terminal backup spool cleanup candidate outbox has an invalid operation identity",
+      );
+    }
+    const candidate = await readTerminalCandidate(path.join(outbox, entry.name));
+    if (candidate.operationId !== operationId) {
+      throw new Error("Terminal backup spool cleanup candidate differs from its filename");
+    }
+    candidates.push(candidate);
+    if (candidates.length >= limit) break;
+  }
+  return candidates;
+}
+
+async function removeIntent(outbox: string, operationId: string): Promise<void> {
+  await fs.promises.unlink(path.join(outbox, `${operationId}.json`)).catch((cause) => {
+    if ((cause as NodeJS.ErrnoException).code !== "ENOENT") throw cause;
+  });
+  await fsyncDirectory(outbox);
+}
+
+function canonicalAuthorizedAt(now: number): string {
+  if (!Number.isSafeInteger(now) || now < 1)
+    throw new Error("Backup spool cleanup clock is invalid");
+  return new Date(now).toISOString();
+}
+
+function assertTerminalCleanupAuthorization(params: {
+  backup: Readonly<StoredAgentSandboxBackup>;
+  authority: Readonly<AgentBackupCaptureV3TerminalSpoolCleanupAuthority>;
+  terminalErrorCode: string;
+}): void {
+  const { backup, authority } = params;
+  if (
+    backup.catalog_version !== 2 ||
+    backup.catalog_state !== "failed_terminal" ||
+    backup.catalog_resume_state !== "capturing" ||
+    backup.id !== authority.backupId ||
+    backup.catalog_organization_id !== authority.organizationId ||
+    backup.catalog_agent_id !== authority.agentId ||
+    backup.backup_operation_id !== authority.operationId ||
+    backup.lifecycle_generation !== authority.activationGeneration ||
+    backup.lifecycle_revision?.toString() !== authority.lifecycleRevision ||
+    backup.catalog_last_error_code !== params.terminalErrorCode ||
+    backup.manifest_digest !== null ||
+    backup.object_inventory_digest !== null
+  ) {
+    throw new Error(
+      "Terminal spool cleanup requires the exact confirmed pre-publication failure authority",
+    );
+  }
+  TerminalIntentSchema.pick({
+    organizationId: true,
+    agentId: true,
+    backupId: true,
+    operationId: true,
+    activationGeneration: true,
+    lifecycleRevision: true,
+    requestSha256: true,
+    authoritySha256: true,
+    terminalErrorCode: true,
+  }).parse({ ...authority, terminalErrorCode: params.terminalErrorCode });
+}
+
+export function createAgentBackupCaptureV3SpoolCleanupJanitor(
+  config: Readonly<AgentBackupCaptureV3SpoolCleanupJanitorConfig>,
+  dependenciesInput: Partial<AgentBackupCaptureV3SpoolCleanupDependencies> = {},
+): AgentBackupCaptureV3SpoolCleanupJanitor {
+  const dependencies = { ...DEFAULT_DEPENDENCIES, ...dependenciesInput };
+  const limit = batchSize(config.batchSize);
+
+  const authorizeAndPersist = async (
+    outbox: string,
+    authority: Readonly<AgentBackupCaptureV3SpoolAuthority>,
+  ): Promise<void> => {
+    const authorized = await dependencies.authorize(authorizationInput(authority));
+    const rederived = await dependencies.deriveAuthority(authorized);
+    if (!sameAuthority(authority, rederived)) {
+      throw new Error("Protected cleanup repository returned different spool authority");
+    }
+    await persistIntent({
+      outbox,
+      authority,
+      authorizedAt: canonicalAuthorizedAt(dependencies.now()),
+      nonce: dependencies.executionToken(),
+    });
+  };
+
+  return {
+    async enqueueProtectedBackup(backup) {
+      await dependencies.listDurableOperations(config.spool);
+      const outbox = await ensureOutboxDirectory(config.spool.stateDirectory);
+      const authority = await dependencies.deriveAuthority(backup);
+      await authorizeAndPersist(outbox, authority);
+      const candidateOutbox = await ensureOutboxDirectory(
+        config.spool.stateDirectory,
+        TERMINAL_CANDIDATE_DIRECTORY,
+      );
+      await removeIntent(candidateOutbox, authority.operationId);
+      return "pending";
+    },
+
+    async stageTerminalFailure(input) {
+      TerminalCandidateSchema.pick({
+        organizationId: true,
+        agentId: true,
+        backupId: true,
+        operationId: true,
+        activationGeneration: true,
+        lifecycleRevision: true,
+        requestSha256: true,
+        authoritySha256: true,
+        terminalErrorCode: true,
+      }).parse({ ...input.authority, terminalErrorCode: input.terminalErrorCode });
+      const durable = await dependencies.listDurableOperations(config.spool);
+      const operation = durable.find(
+        (candidate) => candidate.operationId === input.authority.operationId,
+      );
+      if (
+        operation &&
+        (operation.requestSha256 !== input.authority.requestSha256 ||
+          operation.authoritySha256 !== input.authority.authoritySha256 ||
+          operation.recordCaptured)
+      ) {
+        throw new Error("Terminal spool cleanup candidate differs from durable capture state");
+      }
+      const outbox = await ensureOutboxDirectory(
+        config.spool.stateDirectory,
+        TERMINAL_CANDIDATE_DIRECTORY,
+      );
+      await persistTerminalCandidate({
+        outbox,
+        authority: input.authority,
+        terminalErrorCode: input.terminalErrorCode,
+        stagedAt: canonicalAuthorizedAt(dependencies.now()),
+        nonce: dependencies.executionToken(),
+      });
+      return "pending";
+    },
+
+    async runCycle() {
+      const summary: AgentBackupCaptureV3SpoolCleanupSummary = {
+        discovered: 0,
+        authorized: 0,
+        completed: 0,
+        pending: 0,
+        skippedUnprotected: 0,
+        indeterminate: 0,
+      };
+      const durable = await dependencies.listDurableOperations(config.spool);
+      const outbox = await ensureOutboxDirectory(config.spool.stateDirectory);
+      const terminalOutbox = await ensureOutboxDirectory(
+        config.spool.stateDirectory,
+        TERMINAL_OUTBOX_DIRECTORY,
+      );
+      const terminalCandidateOutbox = await ensureOutboxDirectory(
+        config.spool.stateDirectory,
+        TERMINAL_CANDIDATE_DIRECTORY,
+      );
+      summary.discovered = durable.length;
+      const terminalCandidates = await listTerminalCandidates(terminalCandidateOutbox, limit);
+      for (const candidate of terminalCandidates) {
+        const operation = durable.find(
+          (durableOperation) => durableOperation.operationId === candidate.operationId,
+        );
+        if (!operation) {
+          await removeIntent(terminalCandidateOutbox, candidate.operationId);
+          continue;
+        }
+        if (operation.recordCaptured) {
+          // A confirmed local handoff is written only after exact catalogue
+          // proof. The stale pre-CAS candidate must never block publication or
+          // the later protected-spool cleanup path.
+          await removeIntent(terminalCandidateOutbox, candidate.operationId);
+          continue;
+        }
+        if (
+          operation.requestSha256 !== candidate.requestSha256 ||
+          operation.authoritySha256 !== candidate.authoritySha256
+        ) {
+          summary.indeterminate += 1;
+          continue;
+        }
+        try {
+          const authority = terminalCleanupAuthority(candidate);
+          const authorized = await dependencies.authorizeTerminal(
+            terminalAuthorizationInput(candidate),
+          );
+          assertTerminalCleanupAuthorization({
+            backup: authorized,
+            authority,
+            terminalErrorCode: candidate.terminalErrorCode,
+          });
+          await persistTerminalIntent({
+            outbox: terminalOutbox,
+            authority,
+            terminalErrorCode: candidate.terminalErrorCode,
+            authorizedAt: canonicalAuthorizedAt(dependencies.now()),
+            nonce: dependencies.executionToken(),
+          });
+          await removeIntent(terminalCandidateOutbox, candidate.operationId);
+          summary.authorized += 1;
+        } catch {
+          // A staged candidate is deliberately non-authorizing. Keep it until
+          // the exact terminal row becomes visible or a confirmed handoff makes
+          // the candidate stale.
+          summary.pending += 1;
+        }
+      }
+      const terminalIntents = await listTerminalIntents(terminalOutbox, limit);
+      const terminalOperationIds = new Set(terminalIntents.map((intent) => intent.operationId));
+      const existingIntents = new Set(
+        (await listIntents(outbox, MAX_BATCH_SIZE)).map((intent) => intent.operationId),
+      );
+      for (const operation of durable.slice(0, limit)) {
+        if (
+          existingIntents.has(operation.operationId) ||
+          terminalOperationIds.has(operation.operationId)
+        ) {
+          continue;
+        }
+        if (!operation.recordCaptured || operation.phase !== "published") {
+          summary.skippedUnprotected += 1;
+          continue;
+        }
+        try {
+          const candidates = await dependencies.listCandidates({
+            operationId: operation.operationId,
+          });
+          const matches: AgentBackupCaptureV3SpoolAuthority[] = [];
+          for (const candidate of candidates) {
+            const authority = await dependencies.deriveAuthority(candidate);
+            if (
+              authority.operationId === operation.operationId &&
+              authority.requestSha256 === operation.requestSha256 &&
+              authority.authoritySha256 === operation.authoritySha256
+            ) {
+              matches.push(authority);
+            }
+          }
+          if (matches.length === 0) {
+            summary.skippedUnprotected += 1;
+            continue;
+          }
+          if (matches.length !== 1) throw new Error("Protected cleanup authority is ambiguous");
+          await authorizeAndPersist(outbox, matches[0]!);
+          await removeIntent(terminalCandidateOutbox, operation.operationId);
+          existingIntents.add(operation.operationId);
+          summary.authorized += 1;
+        } catch {
+          summary.indeterminate += 1;
+        }
+      }
+
+      for (const intent of terminalIntents) {
+        let spool: AgentBackupCaptureV3Spool | undefined;
+        try {
+          const authority = terminalCleanupAuthority(intent);
+          const authorized = await dependencies.authorizeTerminal(
+            terminalAuthorizationInput(intent),
+          );
+          assertTerminalCleanupAuthorization({
+            backup: authorized,
+            authority,
+            terminalErrorCode: intent.terminalErrorCode,
+          });
+          spool = await dependencies.openExisting(config.spool, {
+            operationId: intent.operationId,
+            executionToken: dependencies.executionToken(),
+            requestSha256: intent.requestSha256,
+            authoritySha256: intent.authoritySha256,
+          });
+          if (!spool) {
+            await removeIntent(terminalOutbox, intent.operationId);
+            summary.completed += 1;
+            continue;
+          }
+          if (spool.recordCaptured) {
+            await spool.close();
+            summary.indeterminate += 1;
+            continue;
+          }
+          const receipt = await spool.cleanup();
+          if (receipt.status === "complete") {
+            await removeIntent(terminalOutbox, intent.operationId);
+            summary.completed += 1;
+          } else {
+            await spool.close();
+            summary.pending += 1;
+          }
+        } catch {
+          if (spool) await spool.close().catch(() => undefined);
+          summary.pending += 1;
+        }
+      }
+
+      const protectedCleanupLimit = Math.max(0, limit - terminalIntents.length);
+      const intents =
+        protectedCleanupLimit > 0 ? await listIntents(outbox, protectedCleanupLimit) : [];
+      for (const intent of intents) {
+        const authority = intentAuthority(intent);
+        let spool: AgentBackupCaptureV3Spool | undefined;
+        try {
+          const authorized = await dependencies.authorize(authorizationInput(authority));
+          const rederived = await dependencies.deriveAuthority(authorized);
+          if (!sameAuthority(authority, rederived)) {
+            throw new Error("Protected cleanup intent no longer matches catalogue authority");
+          }
+          spool = await dependencies.openExisting(config.spool, {
+            operationId: authority.operationId,
+            executionToken: dependencies.executionToken(),
+            requestSha256: authority.requestSha256,
+            authoritySha256: authority.authoritySha256,
+          });
+          if (!spool) {
+            await removeIntent(outbox, authority.operationId);
+            await removeIntent(terminalCandidateOutbox, authority.operationId);
+            summary.completed += 1;
+            continue;
+          }
+          if (!spool.recordCaptured || spool.phase !== "published") {
+            await spool.close();
+            summary.pending += 1;
+            continue;
+          }
+          const receipt = await spool.cleanup();
+          if (receipt.status === "complete") {
+            await removeIntent(outbox, authority.operationId);
+            await removeIntent(terminalCandidateOutbox, authority.operationId);
+            summary.completed += 1;
+          } else {
+            await spool.close();
+            summary.pending += 1;
+          }
+        } catch {
+          if (spool) await spool.close().catch(() => undefined);
+          summary.pending += 1;
+        }
+      }
+      return summary;
+    },
+  };
+}

--- a/packages/cloud/shared/src/lib/services/agent-backup-catalog-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-catalog-runtime.test.ts
@@ -1,0 +1,1339 @@
+/** Deterministic unit proofs for the bounded backup catalogue runtime tick. */
+
+import { describe, expect, test } from "bun:test";
+import type { AgentBackupOperationClaim } from "../../db/repositories/agent-backup-catalog";
+import type { AgentBackupGcClaim } from "../../db/repositories/agent-backup-gc";
+import type { AgentBackupObjectStoreRegistry } from "../storage/agent-backup-object-store";
+import { normalizeAgentBackupCaptureV2TerminalFailure } from "./agent-backup-capture-v2-failure-disposition";
+import { AgentBackupCaptureV2PipelineError } from "./agent-backup-capture-v2-pipeline";
+import type { AgentBackupCaptureV3TerminalSpoolCleanupAuthority } from "./agent-backup-capture-v3-spool-cleanup";
+import {
+  type AgentBackupCatalogRuntimeConfig,
+  type AgentBackupCatalogRuntimeDependencies,
+  agentBackupCatalogRetryDelay,
+  createAgentBackupCatalogRegistryFromEnv,
+  readAgentBackupCatalogRuntimeConfig,
+  runAgentBackupCatalogRuntimeCycle,
+  runAgentBackupCatalogRuntimeCycleFromEnv,
+} from "./agent-backup-catalog-runtime";
+
+const ORG_ID = "00000000-0000-4000-8000-000000000001";
+const AGENT_ID = "00000000-0000-4000-8000-000000000007";
+const BACKUP_ID = "00000000-0000-4000-8000-000000000002";
+const OPERATION_ID = "00000000-0000-4000-8000-000000000003";
+const LIFECYCLE_GENERATION = "00000000-0000-4000-8000-000000000004";
+const CLAIM_GENERATION = "00000000-0000-4000-8000-000000000005";
+
+function trustedTerminalCaptureFailure(
+  code: string,
+  terminalSpoolCleanup?: AgentBackupCaptureV3TerminalSpoolCleanupAuthority,
+): Error {
+  const disposition = normalizeAgentBackupCaptureV2TerminalFailure(
+    new AgentBackupCaptureV2PipelineError(code, "deterministic capture rejection"),
+    terminalSpoolCleanup,
+  );
+  if (!disposition) throw new Error(`Test terminal code ${code} is not in capture policy`);
+  return disposition;
+}
+
+const ENABLED_CONFIG: Extract<AgentBackupCatalogRuntimeConfig, { enabled: true }> = {
+  enabled: true,
+  ownerId: "catalogue-worker-staging",
+  scheduleEnabled: false,
+  scheduleBatchSize: 32,
+  scheduleLeaseMs: 120_000,
+  scheduleRetryMs: 30_000,
+  operationBatchSize: 8,
+  gcBatchSize: 32,
+  deletionBatchSize: 32,
+  operationLeaseMs: 240_000,
+  gcLeaseMs: 240_000,
+  operationRetryBaseMs: 60_000,
+  operationRetryMaxMs: 21_600_000,
+  gcRetryBaseMs: 30_000,
+  gcRetryMaxMs: 1_800_000,
+};
+
+function operationClaim(
+  state: "scheduled" | "failed_retryable" = "scheduled",
+): AgentBackupOperationClaim {
+  return {
+    ownerId: ENABLED_CONFIG.ownerId,
+    generation: CLAIM_GENERATION,
+    backup: {
+      id: BACKUP_ID,
+      catalog_organization_id: ORG_ID,
+      catalog_agent_id: AGENT_ID,
+      backup_operation_id: OPERATION_ID,
+      lifecycle_generation: LIFECYCLE_GENERATION,
+      lifecycle_revision: 7n,
+      catalog_state: state,
+      catalog_resume_state: state === "failed_retryable" ? "capturing" : null,
+      catalog_attempts: 0,
+    },
+  } as AgentBackupOperationClaim;
+}
+
+function publicationClaim(
+  state:
+    | "captured"
+    | "uploading"
+    | "primary_uploaded"
+    | "primary_verified"
+    | "secondary_pending"
+    | "failed_retryable",
+  resumeState: "uploading" | "secondary_pending" | null = null,
+): AgentBackupOperationClaim {
+  const scheduled = operationClaim();
+  return {
+    ...scheduled,
+    backup: {
+      ...scheduled.backup,
+      catalog_state: state,
+      catalog_resume_state: state === "failed_retryable" ? resumeState : null,
+    },
+  };
+}
+
+function gcClaim(index: number): AgentBackupGcClaim {
+  return {
+    outbox: {
+      id: `gc-${index}`,
+      attempts: 1,
+      claim_owner: ENABLED_CONFIG.ownerId,
+      claim_generation: CLAIM_GENERATION,
+    },
+    object: {},
+    multipart: null,
+  } as AgentBackupGcClaim;
+}
+
+function dependencies(
+  overrides: Partial<AgentBackupCatalogRuntimeDependencies> = {},
+): AgentBackupCatalogRuntimeDependencies {
+  return {
+    enrollSchedules: async () => 0,
+    reconcileSchedules: async () => ({ protected: 0, recycled: 0 }),
+    claimSchedules: async () => [],
+    reserveSchedule: async () => undefined,
+    deferSchedule: async () => false,
+    countOverdueSchedules: async () => 0,
+    claimOperations: async () => [],
+    heartbeatOperation: async () => undefined,
+    transitionOperation: async () => {
+      throw new Error("unexpected transition");
+    },
+    failOperation: async () => {
+      throw new Error("unexpected failure writeback");
+    },
+    listDueDeletions: async () => [],
+    enqueueDeletion: async () => {
+      throw new Error("unexpected deletion enqueue");
+    },
+    claimGc: async () => [],
+    executeGcClaims: async () => ({ completed: 0, failed: 0 }),
+    listFinalizableDeletions: async () => [],
+    finalizeDeletion: async () => {
+      throw new Error("unexpected deletion finalization");
+    },
+    ...overrides,
+  };
+}
+
+const UNUSED_REGISTRY = Object.freeze({}) as AgentBackupObjectStoreRegistry;
+
+describe("agent backup catalogue runtime config", () => {
+  test("gate off does not require or inspect storage configuration", async () => {
+    expect(readAgentBackupCatalogRuntimeConfig({})).toEqual({ enabled: false });
+    const summary = await runAgentBackupCatalogRuntimeCycleFromEnv({ env: {} });
+    expect(summary).toEqual({
+      enabled: false,
+      scheduleEnrolled: 0,
+      scheduleProtected: 0,
+      scheduleRecycled: 0,
+      scheduleClaimed: 0,
+      scheduleReserved: 0,
+      scheduleDeferred: 0,
+      scheduleIndeterminate: 0,
+      scheduleOverdue: 0,
+      operationClaimed: 0,
+      operationCaptured: 0,
+      operationCaptureRetryScheduled: 0,
+      operationCaptureTerminal: 0,
+      operationProtected: 0,
+      operationPublicationRetryScheduled: 0,
+      operationDeferred: 0,
+      operationIndeterminate: 0,
+      spoolCleanup: {
+        discovered: 0,
+        authorized: 0,
+        completed: 0,
+        pending: 0,
+        skippedUnprotected: 0,
+        indeterminate: 0,
+      },
+      deletionCandidates: 0,
+      deletionEnqueued: 0,
+      deletionEnqueueIndeterminate: 0,
+      gcClaimed: 0,
+      gcCompleted: 0,
+      gcFailed: 0,
+      gcIndeterminate: 0,
+      deletionFinalized: 0,
+      deletionFinalizeIndeterminate: 0,
+      alertCodes: [],
+    });
+  });
+
+  test("gate on fails before claiming when explicit worker/storage authority is absent", async () => {
+    expect(() =>
+      readAgentBackupCatalogRuntimeConfig({ AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "1" }),
+    ).toThrow("AGENT_BACKUP_CATALOG_WORKER_ID");
+
+    await expect(
+      runAgentBackupCatalogRuntimeCycleFromEnv({
+        env: {
+          AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "1",
+          AGENT_BACKUP_CATALOG_WORKER_ID: "worker-1",
+        },
+      }),
+    ).rejects.toThrow("AGENT_BACKUP_R2_ENDPOINT_ALIAS");
+  });
+
+  test("starts the operation dispatcher at one claim unless explicitly raised", () => {
+    const config = readAgentBackupCatalogRuntimeConfig({
+      AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "1",
+      AGENT_BACKUP_CATALOG_WORKER_ID: "worker-1",
+    });
+    expect(config).toMatchObject({
+      enabled: true,
+      scheduleEnabled: false,
+      scheduleBatchSize: 32,
+      operationBatchSize: 1,
+    });
+  });
+
+  test("keeps periodic admission off by default and rejects an orphaned schedule gate", () => {
+    expect(() =>
+      readAgentBackupCatalogRuntimeConfig({ AGENT_BACKUP_RPO_SCHEDULER_ENABLED: "1" }),
+    ).toThrow("requires AGENT_BACKUP_CATALOG_RUNTIME_ENABLED=1");
+
+    const config = readAgentBackupCatalogRuntimeConfig({
+      AGENT_BACKUP_CATALOG_RUNTIME_ENABLED: "1",
+      AGENT_BACKUP_RPO_SCHEDULER_ENABLED: "1",
+      AGENT_BACKUP_CATALOG_WORKER_ID: "worker-1",
+    });
+    expect(config).toMatchObject({
+      enabled: true,
+      scheduleEnabled: true,
+      scheduleBatchSize: 32,
+      scheduleLeaseMs: 120_000,
+      scheduleRetryMs: 30_000,
+    });
+  });
+
+  test("builds explicit native-R2 primary and Hetzner S3 secondary authorities", async () => {
+    const registry = await createAgentBackupCatalogRegistryFromEnv({
+      env: {
+        AGENT_BACKUP_R2_ENDPOINT_ALIAS: "r2-primary",
+        AGENT_BACKUP_R2_ACCOUNT_ID: "cloudflare-account-a",
+        AGENT_BACKUP_R2_BUCKET: "sandbox-backups-primary",
+        AGENT_BACKUP_R2_REGION: "auto",
+        AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS: "hetzner-secondary",
+        AGENT_BACKUP_HETZNER_ACCOUNT_ID: "hetzner-project-a",
+        AGENT_BACKUP_HETZNER_ENDPOINT: "https://fsn1.your-objectstorage.com",
+        AGENT_BACKUP_HETZNER_BUCKET: "sandbox-backups-secondary",
+        AGENT_BACKUP_HETZNER_REGION: "fsn1",
+        AGENT_BACKUP_HETZNER_ACCESS_KEY_ID: "access-id",
+        AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY: "secret-value",
+      },
+      primaryR2Binding: {
+        bindingIdentity: "cloud-api:BACKUP_R2:v1",
+        bucketBinding: {
+          async head() {
+            return null;
+          },
+          async get() {
+            return null;
+          },
+          async put() {
+            return undefined;
+          },
+          async delete() {
+            return undefined;
+          },
+        },
+      },
+    });
+
+    expect(registry.forNewObject("r2-primary").authority).toMatchObject({
+      provider: "cloudflare-r2",
+      transport: "worker-r2",
+      endpointAlias: "r2-primary",
+      bucket: "sandbox-backups-primary",
+    });
+    expect(registry.forNewObject("hetzner-secondary").authority).toMatchObject({
+      provider: "hetzner-object-storage",
+      transport: "s3-compatible",
+      endpointAlias: "hetzner-secondary",
+      bucket: "sandbox-backups-secondary",
+    });
+  });
+
+  test("builds the daemon's explicit S3-compatible R2 authority without provider I/O", async () => {
+    const registry = await createAgentBackupCatalogRegistryFromEnv({
+      env: {
+        AGENT_BACKUP_R2_ENDPOINT_ALIAS: "r2-primary",
+        AGENT_BACKUP_R2_ACCOUNT_ID: "cloudflare-account-a",
+        AGENT_BACKUP_R2_ENDPOINT: "https://account-a.r2.cloudflarestorage.com",
+        AGENT_BACKUP_R2_BUCKET: "sandbox-backups-primary",
+        AGENT_BACKUP_R2_REGION: "auto",
+        AGENT_BACKUP_R2_ACCESS_KEY_ID: "r2-access-id",
+        AGENT_BACKUP_R2_SECRET_ACCESS_KEY: "r2-secret-value",
+        AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS: "hetzner-secondary",
+        AGENT_BACKUP_HETZNER_ACCOUNT_ID: "hetzner-project-a",
+        AGENT_BACKUP_HETZNER_ENDPOINT: "https://fsn1.your-objectstorage.com",
+        AGENT_BACKUP_HETZNER_BUCKET: "sandbox-backups-secondary",
+        AGENT_BACKUP_HETZNER_REGION: "fsn1",
+        AGENT_BACKUP_HETZNER_ACCESS_KEY_ID: "hetzner-access-id",
+        AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY: "hetzner-secret-value",
+      },
+    });
+
+    expect(registry.forNewObject("r2-primary").authority).toMatchObject({
+      provider: "cloudflare-r2",
+      transport: "s3-compatible",
+      endpointAlias: "r2-primary",
+    });
+  });
+
+  test("uses bounded symmetric jitter without exceeding the retry cap", () => {
+    expect(
+      agentBackupCatalogRetryDelay({ attempt: 2, baseMs: 1_000, maxMs: 10_000, random: () => 0 }),
+    ).toBe(3_200);
+    expect(
+      agentBackupCatalogRetryDelay({ attempt: 20, baseMs: 1_000, maxMs: 10_000, random: () => 1 }),
+    ).toBe(10_000);
+  });
+});
+
+describe("agent backup catalogue runtime scheduling", () => {
+  test("admits a bounded fair schedule only behind its explicit feature gate", async () => {
+    const calls: string[] = [];
+    const scheduleClaim = {
+      organizationId: ORG_ID,
+      agentId: AGENT_ID,
+      operationId: OPERATION_ID,
+      ownerId: ENABLED_CONFIG.ownerId,
+      generation: CLAIM_GENERATION,
+      expiresAt: new Date("2026-08-16T00:02:00.000Z"),
+      dueAt: new Date("2026-08-16T00:00:00.000Z"),
+      attempts: 1,
+    };
+    let reconcilePass = 0;
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: { ...ENABLED_CONFIG, scheduleEnabled: true },
+      registry: UNUSED_REGISTRY,
+      dependencies: dependencies({
+        reconcileSchedules: async ({ limit }) => {
+          calls.push(`reconcile:${limit}`);
+          reconcilePass += 1;
+          return reconcilePass === 1
+            ? { protected: 1, recycled: 0 }
+            : { protected: 1, recycled: 1 };
+        },
+        enrollSchedules: async ({ limit }) => {
+          calls.push(`enroll:${limit}`);
+          return 3;
+        },
+        claimSchedules: async ({ ownerId, limit, leaseMs }) => {
+          calls.push(`claim:${ownerId}:${limit}:${leaseMs}`);
+          return [scheduleClaim];
+        },
+        reserveSchedule: async ({ claim }) => {
+          calls.push(`reserve:${claim.operationId}`);
+        },
+        claimOperations: async () => {
+          calls.push("catalogue");
+          return [];
+        },
+        countOverdueSchedules: async () => {
+          calls.push("overdue");
+          return 0;
+        },
+      }),
+    });
+
+    expect(calls).toEqual([
+      "reconcile:32",
+      "enroll:32",
+      "claim:catalogue-worker-staging:32:120000",
+      `reserve:${OPERATION_ID}`,
+      "overdue",
+      "catalogue",
+      "reconcile:32",
+    ]);
+    expect(summary).toMatchObject({
+      scheduleEnrolled: 3,
+      scheduleProtected: 2,
+      scheduleRecycled: 1,
+      scheduleClaimed: 1,
+      scheduleReserved: 1,
+      scheduleDeferred: 0,
+      scheduleIndeterminate: 0,
+    });
+  });
+
+  test("alerts on the exact current DB-clock overdue count after reconciliation", async () => {
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: { ...ENABLED_CONFIG, scheduleEnabled: true },
+      registry: UNUSED_REGISTRY,
+      dependencies: dependencies({ countOverdueSchedules: async () => 7 }),
+    });
+
+    expect(summary.scheduleOverdue).toBe(7);
+    expect(summary.alertCodes).toContain("BACKUP_SCHEDULE_RPO_OVERDUE");
+  });
+
+  test("preserves the RPO signal when unrelated catalogue and GC phases fail", async () => {
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: { ...ENABLED_CONFIG, scheduleEnabled: true },
+      registry: UNUSED_REGISTRY,
+      dependencies: dependencies({
+        countOverdueSchedules: async () => 4,
+        claimOperations: async () => {
+          throw new Error("catalogue claim unavailable");
+        },
+        listDueDeletions: async () => {
+          throw new Error("deletion scan unavailable");
+        },
+        claimGc: async () => {
+          throw new Error("GC claim unavailable");
+        },
+        listFinalizableDeletions: async () => {
+          throw new Error("finalization scan unavailable");
+        },
+      }),
+    });
+
+    expect(summary.scheduleOverdue).toBe(4);
+    expect(summary.alertCodes).toEqual(
+      expect.arrayContaining([
+        "BACKUP_SCHEDULE_RPO_OVERDUE",
+        "BACKUP_OPERATION_RECONCILE_REQUIRED",
+        "BACKUP_DELETION_ENQUEUE_RECONCILE_REQUIRED",
+        "BACKUP_GC_RECONCILE_REQUIRED",
+        "BACKUP_DELETION_FINALIZE_RECONCILE_REQUIRED",
+      ]),
+    );
+  });
+
+  test("defers a failed admission without inventing success and fences response loss", async () => {
+    const claims = [
+      {
+        organizationId: ORG_ID,
+        agentId: AGENT_ID,
+        operationId: OPERATION_ID,
+        ownerId: ENABLED_CONFIG.ownerId,
+        generation: CLAIM_GENERATION,
+        expiresAt: new Date("2026-08-16T00:02:00.000Z"),
+        dueAt: new Date("2026-08-16T00:00:00.000Z"),
+        attempts: 1,
+      },
+      {
+        organizationId: "00000000-0000-4000-8000-000000000010",
+        agentId: "00000000-0000-4000-8000-000000000011",
+        operationId: "00000000-0000-4000-8000-000000000012",
+        ownerId: ENABLED_CONFIG.ownerId,
+        generation: "00000000-0000-4000-8000-000000000013",
+        expiresAt: new Date("2026-08-16T00:02:00.000Z"),
+        dueAt: new Date("2026-08-16T00:00:00.000Z"),
+        attempts: 1,
+      },
+    ];
+    const deferred: string[] = [];
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: { ...ENABLED_CONFIG, scheduleEnabled: true },
+      registry: UNUSED_REGISTRY,
+      dependencies: dependencies({
+        claimSchedules: async () => claims,
+        reserveSchedule: async () => {
+          throw new Error("reservation response unavailable");
+        },
+        deferSchedule: async ({ claim, retryDelayMs, errorCode }) => {
+          deferred.push(`${claim.operationId}:${retryDelayMs}:${errorCode}`);
+          return claim === claims[0];
+        },
+      }),
+    });
+
+    expect(deferred).toEqual([
+      `${OPERATION_ID}:30000:BACKUP_SCHEDULE_RESERVATION_RETRY`,
+      "00000000-0000-4000-8000-000000000012:30000:BACKUP_SCHEDULE_RESERVATION_RETRY",
+    ]);
+    expect(summary).toMatchObject({
+      scheduleClaimed: 2,
+      scheduleReserved: 0,
+      scheduleDeferred: 1,
+      scheduleIndeterminate: 1,
+    });
+    expect(summary.alertCodes).toEqual([
+      "BACKUP_SCHEDULE_RECONCILE_REQUIRED",
+      "BACKUP_SCHEDULE_RESERVATION_RETRY",
+    ]);
+  });
+
+  test("normalizes an owned scheduled claim and runs only the capture-only executor", async () => {
+    const claim = operationClaim();
+    const calls: string[] = [];
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: ENABLED_CONFIG,
+      registry: UNUSED_REGISTRY,
+      dependencies: dependencies({
+        claimOperations: async () => [claim],
+        transitionOperation: async (params) => {
+          calls.push(`${params.expectedState}->${params.to}`);
+          return { ...claim.backup, catalog_state: params.to };
+        },
+      }),
+      captureExecutor: {
+        async execute({ claim: normalized, leaseMs }) {
+          calls.push(`capture:${normalized.backup.catalog_state}:${leaseMs}`);
+          return { state: "captured-upload-pending" };
+        },
+      },
+    });
+
+    expect(calls).toEqual(["scheduled->capturing", "capture:capturing:240000"]);
+    expect(summary).toMatchObject({
+      operationClaimed: 1,
+      operationCaptured: 1,
+      operationCaptureRetryScheduled: 0,
+      operationDeferred: 0,
+      operationIndeterminate: 0,
+    });
+  });
+
+  test("records a bounded retry when capture fails before recordCaptured is confirmed", async () => {
+    const claim = operationClaim();
+    const calls: string[] = [];
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: ENABLED_CONFIG,
+      registry: UNUSED_REGISTRY,
+      random: () => 0.5,
+      dependencies: dependencies({
+        claimOperations: async () => [claim],
+        transitionOperation: async (params) => ({
+          ...claim.backup,
+          catalog_state: params.to,
+        }),
+        failOperation: async (params) => {
+          calls.push(`${params.expectedState}:${params.error.code}:${params.retryDelayMs}`);
+          return claim.backup;
+        },
+      }),
+      captureExecutor: {
+        async execute() {
+          throw new Error("capture transport closed");
+        },
+      },
+    });
+
+    expect(calls).toEqual(["capturing:BACKUP_CAPTURE_V2_RETRY_SCHEDULED:60000"]);
+    expect(summary.operationCaptured).toBe(0);
+    expect(summary.operationCaptureRetryScheduled).toBe(1);
+    expect(summary.operationIndeterminate).toBe(0);
+    expect(summary.alertCodes).toContain("BACKUP_CAPTURE_V2_RETRY_SCHEDULED");
+  });
+
+  for (const deterministicCode of [
+    "AGENT_BACKUP_V3_INCREMENTAL_CAPTURE_UNSUPPORTED",
+    "AGENT_BACKUP_V2_POSTGRES_UNSUPPORTED",
+    "AGENT_BACKUP_V2_RUNTIME_ATTESTATION_CHANGED",
+    "CAPTURE_V2_UNSUPPORTED_VERSION",
+    "CAPTURE_V2_FRAME_TAMPERED",
+    "AGENT_BACKUP_V2_SPOOL_REPLAY_CONFLICT",
+    "AGENT_BACKUP_V2_PGLITE_PHYSICAL_BYTES_LIMIT",
+    "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_ENTRY_LIMIT",
+    "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_UNPROVEN",
+    "AGENT_BACKUP_V2_PGLITE_DUMP_EXCEEDS_PREFLIGHT",
+    "AGENT_BACKUP_V2_PGLITE_DUMP_NOT_STREAMABLE",
+    "AGENT_BACKUP_V2_PGLITE_MANAGED_DUMP_UNAVAILABLE",
+    "AGENT_BACKUP_V2_PGLITE_DIRECTORY_UNATTESTED",
+    "AGENT_BACKUP_V2_PGLITE_DIRECTORY_MISMATCH",
+    "AGENT_BACKUP_V2_PGLITE_DUMP_ALREADY_CONSUMED",
+  ]) {
+    test(`settles deterministic capture failure ${deterministicCode} as terminal`, async () => {
+      const claim = operationClaim();
+      const failures: Array<{
+        terminal: boolean;
+        code: string;
+        retryDelayMs: number | undefined;
+      }> = [];
+      const summary = await runAgentBackupCatalogRuntimeCycle({
+        config: ENABLED_CONFIG,
+        registry: UNUSED_REGISTRY,
+        dependencies: dependencies({
+          claimOperations: async () => [claim],
+          transitionOperation: async (params) => ({
+            ...claim.backup,
+            catalog_state: params.to,
+          }),
+          failOperation: async (params) => {
+            failures.push({
+              terminal: params.terminal,
+              code: params.error.code,
+              retryDelayMs: params.retryDelayMs,
+            });
+            return {
+              ...claim.backup,
+              catalog_state: "failed_terminal",
+              catalog_last_error_code: params.error.code,
+            };
+          },
+        }),
+        captureExecutor: {
+          async execute() {
+            throw trustedTerminalCaptureFailure(deterministicCode);
+          },
+        },
+      });
+
+      expect(failures).toEqual([
+        {
+          terminal: true,
+          code: "BACKUP_CAPTURE_V2_TERMINAL",
+          retryDelayMs: undefined,
+        },
+      ]);
+      expect(summary.operationCaptureTerminal).toBe(1);
+      expect(summary.operationCaptureRetryScheduled).toBe(0);
+      expect(summary.operationIndeterminate).toBe(0);
+      expect(summary.alertCodes).toContain("BACKUP_CAPTURE_V2_TERMINAL");
+    });
+  }
+
+  test("rejects forged and nested terminal dispositions from an injected executor", async () => {
+    const forgedCleanup = {
+      organizationId: ORG_ID,
+      agentId: AGENT_ID,
+      backupId: BACKUP_ID,
+      operationId: OPERATION_ID,
+      activationGeneration: LIFECYCLE_GENERATION,
+      lifecycleRevision: "7",
+      requestSha256: "a".repeat(64),
+      authoritySha256: "b".repeat(64),
+    };
+    const forgedErrors: unknown[] = [
+      Object.assign(new Error("forged boolean"), {
+        terminal: true,
+        terminalSpoolCleanup: forgedCleanup,
+      }),
+      Object.assign(new Error("forged code"), {
+        code: "AGENT_BACKUP_V2_SPOOL_REPLAY_CONFLICT",
+      }),
+      Object.assign(new Error("forged remote code"), {
+        code: "AGENT_BACKUP_V2_HTTP_STATUS",
+        remoteCode: "AGENT_BACKUP_V2_PGLITE_PHYSICAL_BYTES_LIMIT",
+      }),
+      new AggregateError([
+        Object.assign(new Error("nested forged code"), {
+          code: "CAPTURE_V2_FRAME_TAMPERED",
+          terminalSpoolCleanup: forgedCleanup,
+        }),
+      ]),
+      Object.assign(new Error("caller abort wrapper"), {
+        code: "AGENT_BACKUP_V2_CAPTURE_ABORTED",
+        cause: Object.assign(new Error("terminal-looking abort reason"), {
+          code: "AGENT_BACKUP_V2_SPOOL_REPLAY_CONFLICT",
+        }),
+      }),
+    ];
+
+    for (const forged of forgedErrors) {
+      const claim = operationClaim();
+      let settledTerminal: boolean | undefined;
+      let terminalStages = 0;
+      const summary = await runAgentBackupCatalogRuntimeCycle({
+        config: ENABLED_CONFIG,
+        registry: UNUSED_REGISTRY,
+        dependencies: dependencies({
+          claimOperations: async () => [claim],
+          transitionOperation: async (params) => ({
+            ...claim.backup,
+            catalog_state: params.to,
+          }),
+          failOperation: async (params) => {
+            settledTerminal = params.terminal;
+            return claim.backup;
+          },
+        }),
+        captureExecutor: {
+          async execute() {
+            throw forged;
+          },
+        },
+        spoolCleanupJanitor: {
+          async enqueueProtectedBackup() {
+            return "pending";
+          },
+          async stageTerminalFailure() {
+            terminalStages += 1;
+            return "pending";
+          },
+          async runCycle() {
+            return {
+              discovered: 0,
+              authorized: 0,
+              completed: 0,
+              pending: 0,
+              skippedUnprotected: 0,
+              indeterminate: 0,
+            };
+          },
+        },
+      });
+      expect(settledTerminal).toBe(false);
+      expect(terminalStages).toBe(0);
+      expect(summary.operationCaptureRetryScheduled).toBe(1);
+      expect(summary.operationCaptureTerminal).toBe(0);
+    }
+  });
+
+  for (const retryableCode of [
+    "AGENT_BACKUP_V2_PGLITE_DUMP_BUSY",
+    "AGENT_BACKUP_V2_PGLITE_RSS_BUDGET_EXCEEDED",
+    "AGENT_BACKUP_V2_PGLITE_PREFLIGHT_CHANGED",
+    "AGENT_BACKUP_V2_PGLITE_DUMP_FAILED",
+    "AGENT_BACKUP_V2_PIPELINE_LEASE_LOST",
+  ]) {
+    test(`keeps transient capture failure ${retryableCode} retryable`, async () => {
+      const claim = operationClaim();
+      let failure:
+        | { terminal: boolean; code: string; retryDelayMs: number | undefined }
+        | undefined;
+      const summary = await runAgentBackupCatalogRuntimeCycle({
+        config: ENABLED_CONFIG,
+        registry: UNUSED_REGISTRY,
+        random: () => 0.5,
+        dependencies: dependencies({
+          claimOperations: async () => [claim],
+          transitionOperation: async (params) => ({
+            ...claim.backup,
+            catalog_state: params.to,
+          }),
+          failOperation: async (params) => {
+            failure = {
+              terminal: params.terminal,
+              code: params.error.code,
+              retryDelayMs: params.retryDelayMs,
+            };
+            return claim.backup;
+          },
+        }),
+        captureExecutor: {
+          async execute() {
+            throw Object.assign(new Error("transient capture rejection"), {
+              code: "AGENT_BACKUP_V2_HTTP_STATUS",
+              remoteCode: retryableCode,
+            });
+          },
+        },
+      });
+
+      expect(failure).toEqual({
+        terminal: false,
+        code: "BACKUP_CAPTURE_V2_RETRY_SCHEDULED",
+        retryDelayMs: 60_000,
+      });
+      expect(summary.operationCaptureRetryScheduled).toBe(1);
+      expect(summary.operationCaptureTerminal).toBe(0);
+    });
+  }
+
+  test("enqueues exact partial-spool cleanup only after terminal settlement is confirmed", async () => {
+    const claim = operationClaim();
+    const events: string[] = [];
+    const terminalSpoolCleanup = {
+      organizationId: ORG_ID,
+      agentId: AGENT_ID,
+      backupId: BACKUP_ID,
+      operationId: OPERATION_ID,
+      activationGeneration: LIFECYCLE_GENERATION,
+      lifecycleRevision: "7",
+      requestSha256: "a".repeat(64),
+      authoritySha256: "b".repeat(64),
+    };
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: ENABLED_CONFIG,
+      registry: UNUSED_REGISTRY,
+      dependencies: dependencies({
+        claimOperations: async () => [claim],
+        transitionOperation: async (params) => ({
+          ...claim.backup,
+          catalog_state: params.to,
+        }),
+        failOperation: async (params) => {
+          events.push(`settle:${params.terminal}:${params.error.code}`);
+          return {
+            ...claim.backup,
+            catalog_version: 2,
+            catalog_state: "failed_terminal",
+            catalog_last_error_code: params.error.code,
+            manifest_digest: null,
+            object_inventory_digest: null,
+          };
+        },
+      }),
+      captureExecutor: {
+        async execute() {
+          events.push("capture");
+          throw trustedTerminalCaptureFailure(
+            "AGENT_BACKUP_V2_SPOOL_REPLAY_CONFLICT",
+            terminalSpoolCleanup,
+          );
+        },
+      },
+      spoolCleanupJanitor: {
+        async enqueueProtectedBackup() {
+          throw new Error("Protected cleanup must not authorize a terminal partial spool");
+        },
+        async stageTerminalFailure(input) {
+          events.push(`stage:${input.terminalErrorCode}:${input.authority.operationId}`);
+          return "pending";
+        },
+        async runCycle() {
+          events.push("cleanup");
+          return {
+            discovered: 1,
+            authorized: 0,
+            completed: 1,
+            pending: 0,
+            skippedUnprotected: 0,
+            indeterminate: 0,
+          };
+        },
+      },
+    });
+
+    expect(events).toEqual([
+      "capture",
+      `stage:BACKUP_CAPTURE_V2_TERMINAL:${OPERATION_ID}`,
+      "settle:true:BACKUP_CAPTURE_V2_TERMINAL",
+      "cleanup",
+    ]);
+    expect(summary.operationCaptureTerminal).toBe(1);
+    expect(summary.spoolCleanup.completed).toBe(1);
+    expect(summary.operationIndeterminate).toBe(0);
+  });
+
+  test("does not commit terminal when the pre-CAS cleanup candidate is not durable", async () => {
+    const claim = operationClaim();
+    let failureWrites = 0;
+    const terminalSpoolCleanup = {
+      organizationId: ORG_ID,
+      agentId: AGENT_ID,
+      backupId: BACKUP_ID,
+      operationId: OPERATION_ID,
+      activationGeneration: LIFECYCLE_GENERATION,
+      lifecycleRevision: "7",
+      requestSha256: "a".repeat(64),
+      authoritySha256: "b".repeat(64),
+    };
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: ENABLED_CONFIG,
+      registry: UNUSED_REGISTRY,
+      dependencies: dependencies({
+        claimOperations: async () => [claim],
+        transitionOperation: async (params) => ({
+          ...claim.backup,
+          catalog_state: params.to,
+        }),
+        failOperation: async () => {
+          failureWrites += 1;
+          return claim.backup;
+        },
+      }),
+      captureExecutor: {
+        async execute() {
+          throw trustedTerminalCaptureFailure(
+            "AGENT_BACKUP_V2_SPOOL_REPLAY_CONFLICT",
+            terminalSpoolCleanup,
+          );
+        },
+      },
+      spoolCleanupJanitor: {
+        async enqueueProtectedBackup() {
+          return "pending";
+        },
+        async stageTerminalFailure() {
+          throw new Error("candidate fsync failed");
+        },
+        async runCycle() {
+          return {
+            discovered: 1,
+            authorized: 0,
+            completed: 0,
+            pending: 0,
+            skippedUnprotected: 1,
+            indeterminate: 0,
+          };
+        },
+      },
+    });
+
+    expect(failureWrites).toBe(0);
+    expect(summary.operationCaptureTerminal).toBe(0);
+    expect(summary.operationIndeterminate).toBe(1);
+    expect(summary.spoolCleanup.indeterminate).toBe(1);
+    expect(summary.alertCodes).toContain("BACKUP_SPOOL_CLEANUP_RECONCILE_REQUIRED");
+  });
+
+  test("stages terminal cleanup before a settlement response can be lost", async () => {
+    const claim = operationClaim();
+    let terminalStages = 0;
+    const terminalSpoolCleanup = {
+      organizationId: ORG_ID,
+      agentId: AGENT_ID,
+      backupId: BACKUP_ID,
+      operationId: OPERATION_ID,
+      activationGeneration: LIFECYCLE_GENERATION,
+      lifecycleRevision: "7",
+      requestSha256: "a".repeat(64),
+      authoritySha256: "b".repeat(64),
+    };
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: ENABLED_CONFIG,
+      registry: UNUSED_REGISTRY,
+      dependencies: dependencies({
+        claimOperations: async () => [claim],
+        transitionOperation: async (params) => ({
+          ...claim.backup,
+          catalog_state: params.to,
+        }),
+        failOperation: async () => {
+          throw new Error("terminal CAS committed but response was lost");
+        },
+      }),
+      captureExecutor: {
+        async execute() {
+          throw trustedTerminalCaptureFailure(
+            "AGENT_BACKUP_V2_SPOOL_REPLAY_CONFLICT",
+            terminalSpoolCleanup,
+          );
+        },
+      },
+      spoolCleanupJanitor: {
+        async enqueueProtectedBackup() {
+          return "pending";
+        },
+        async stageTerminalFailure() {
+          terminalStages += 1;
+          return "pending";
+        },
+        async runCycle() {
+          return {
+            discovered: 1,
+            authorized: 1,
+            completed: 1,
+            pending: 0,
+            skippedUnprotected: 0,
+            indeterminate: 0,
+          };
+        },
+      },
+    });
+
+    expect(terminalStages).toBe(1);
+    expect(summary.operationCaptureTerminal).toBe(0);
+    expect(summary.operationIndeterminate).toBe(1);
+    expect(summary.spoolCleanup).toMatchObject({ authorized: 1, completed: 1 });
+    expect(summary.alertCodes).toContain("BACKUP_OPERATION_RECONCILE_REQUIRED");
+  });
+
+  test("heartbeats and durably defers an unsupported capture stage", async () => {
+    const claim = operationClaim();
+    const calls: string[] = [];
+    let retryDelayMs = 0;
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: ENABLED_CONFIG,
+      registry: UNUSED_REGISTRY,
+      random: () => 0.5,
+      dependencies: dependencies({
+        claimOperations: async ({ limit }) => {
+          calls.push(`claim:${limit}`);
+          return [claim];
+        },
+        heartbeatOperation: async () => {
+          calls.push("heartbeat");
+        },
+        failOperation: async (params) => {
+          calls.push(`defer:${params.expectedState}:${params.error.code}`);
+          retryDelayMs = params.retryDelayMs ?? 0;
+          return claim.backup;
+        },
+      }),
+    });
+
+    expect(calls).toEqual([
+      "claim:8",
+      "heartbeat",
+      "defer:scheduled:BACKUP_PIPELINE_STAGE_UNAVAILABLE",
+    ]);
+    expect(retryDelayMs).toBe(60_000);
+    expect(summary.operationDeferred).toBe(1);
+    expect(summary.operationIndeterminate).toBe(0);
+    expect(summary.alertCodes).toContain("BACKUP_PIPELINE_STAGE_UNAVAILABLE");
+  });
+
+  test("resumes the exact failed state before writing the next retry", async () => {
+    const claim = operationClaim("failed_retryable");
+    const transitions: string[] = [];
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: ENABLED_CONFIG,
+      registry: UNUSED_REGISTRY,
+      dependencies: dependencies({
+        claimOperations: async () => [claim],
+        transitionOperation: async (params) => {
+          transitions.push(`${params.expectedState}->${params.to}`);
+          return { ...claim.backup, catalog_state: params.to };
+        },
+        failOperation: async (params) => {
+          transitions.push(`${params.expectedState}->failed_retryable`);
+          return claim.backup;
+        },
+      }),
+    });
+
+    expect(transitions).toEqual(["failed_retryable->capturing", "capturing->failed_retryable"]);
+    expect(summary.operationDeferred).toBe(1);
+  });
+
+  test("dispatches post-capture work through protected without synthetic deferral", async () => {
+    const owned = publicationClaim("captured");
+    const calls: string[] = [];
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: ENABLED_CONFIG,
+      registry: UNUSED_REGISTRY,
+      dependencies: dependencies({ claimOperations: async () => [owned] }),
+      publicationExecutor: {
+        async execute({ claim, leaseMs }) {
+          calls.push(`${claim.backup.catalog_state}:${leaseMs}`);
+          return { state: "protected" };
+        },
+      },
+    });
+
+    expect(calls).toEqual(["captured:240000"]);
+    expect(summary).toMatchObject({
+      operationClaimed: 1,
+      operationProtected: 1,
+      operationPublicationRetryScheduled: 0,
+      operationDeferred: 0,
+      operationIndeterminate: 0,
+    });
+  });
+
+  test("schedules an exact publication retry and continues past a poison claim", async () => {
+    const retryable = publicationClaim("uploading");
+    const healthy = publicationClaim("secondary_pending");
+    healthy.backup.id = "00000000-0000-4000-8000-000000000008";
+    const executed: string[] = [];
+    const failures: string[] = [];
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: { ...ENABLED_CONFIG, operationBatchSize: 2 },
+      registry: UNUSED_REGISTRY,
+      random: () => 0.5,
+      dependencies: dependencies({
+        claimOperations: async () => [retryable, healthy],
+        failOperation: async (input) => {
+          failures.push(`${input.expectedState}:${input.error.code}:${input.retryDelayMs}`);
+          return retryable.backup;
+        },
+      }),
+      publicationExecutor: {
+        async execute({ claim }) {
+          executed.push(claim.backup.id);
+          if (claim.backup.id === retryable.backup.id) {
+            return {
+              state: "retryable-failure",
+              expectedState: "uploading",
+              error: {
+                code: "BACKUP_PRIMARY_PUBLICATION_RETRY",
+                message: "Primary publication remains durably retryable",
+              },
+            };
+          }
+          return { state: "protected" };
+        },
+      },
+    });
+
+    expect(executed).toEqual([retryable.backup.id, healthy.backup.id]);
+    expect(failures).toEqual(["uploading:BACKUP_PRIMARY_PUBLICATION_RETRY:60000"]);
+    expect(summary).toMatchObject({
+      operationClaimed: 2,
+      operationProtected: 1,
+      operationPublicationRetryScheduled: 1,
+      operationIndeterminate: 0,
+    });
+    expect(summary.alertCodes).toContain("BACKUP_PUBLICATION_RETRY_SCHEDULED");
+  });
+
+  test("keeps transition and retry response loss indeterminate while preserving fairness", async () => {
+    const responseLost = publicationClaim("uploading");
+    const healthy = publicationClaim("secondary_pending");
+    healthy.backup.id = "00000000-0000-4000-8000-000000000009";
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: { ...ENABLED_CONFIG, operationBatchSize: 2 },
+      registry: UNUSED_REGISTRY,
+      dependencies: dependencies({
+        claimOperations: async () => [responseLost, healthy],
+      }),
+      publicationExecutor: {
+        async execute({ claim }) {
+          if (claim.backup.id === responseLost.backup.id) {
+            throw new Error("transition committed but response was lost");
+          }
+          return { state: "protected" };
+        },
+      },
+    });
+
+    expect(summary).toMatchObject({
+      operationClaimed: 2,
+      operationProtected: 1,
+      operationPublicationRetryScheduled: 0,
+      operationIndeterminate: 1,
+    });
+    expect(summary.alertCodes).toContain("BACKUP_OPERATION_RECONCILE_REQUIRED");
+  });
+
+  test("runs protected spool reconciliation even after a lost publication response", async () => {
+    const responseLost = publicationClaim("secondary_pending");
+    let cleanupCycles = 0;
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: ENABLED_CONFIG,
+      registry: UNUSED_REGISTRY,
+      dependencies: dependencies({ claimOperations: async () => [responseLost] }),
+      publicationExecutor: {
+        async execute() {
+          throw new Error("protected committed but transition response was lost");
+        },
+      },
+      spoolCleanupJanitor: {
+        async enqueueProtectedBackup() {
+          return "pending";
+        },
+        async stageTerminalFailure() {
+          return "pending";
+        },
+        async runCycle() {
+          cleanupCycles += 1;
+          return {
+            discovered: 1,
+            authorized: 1,
+            completed: 1,
+            pending: 0,
+            skippedUnprotected: 0,
+            indeterminate: 0,
+          };
+        },
+      },
+    });
+
+    expect(cleanupCycles).toBe(1);
+    expect(summary.operationIndeterminate).toBe(1);
+    expect(summary.spoolCleanup).toMatchObject({ authorized: 1, completed: 1 });
+    expect(summary.alertCodes).toContain("BACKUP_OPERATION_RECONCILE_REQUIRED");
+  });
+
+  test("does not let an indeterminate publication poison the next serial tick", async () => {
+    const poison = publicationClaim("uploading");
+    const healthy = publicationClaim("secondary_pending");
+    healthy.backup.id = "00000000-0000-4000-8000-00000000000a";
+    let cycle = 0;
+    const claimedLimits: number[] = [];
+    const runtimeDependencies = dependencies({
+      claimOperations: async ({ limit }) => {
+        claimedLimits.push(limit);
+        return cycle++ === 0 ? [poison] : [healthy];
+      },
+    });
+    const publicationExecutor = {
+      async execute({ claim }: { claim: Readonly<AgentBackupOperationClaim> }) {
+        if (claim.backup.id === poison.backup.id) {
+          throw new Error("provider response is indeterminate");
+        }
+        return { state: "protected" as const };
+      },
+    };
+
+    const poisoned = await runAgentBackupCatalogRuntimeCycle({
+      config: { ...ENABLED_CONFIG, operationBatchSize: 1 },
+      registry: UNUSED_REGISTRY,
+      dependencies: runtimeDependencies,
+      publicationExecutor,
+    });
+    const completed = await runAgentBackupCatalogRuntimeCycle({
+      config: { ...ENABLED_CONFIG, operationBatchSize: 1 },
+      registry: UNUSED_REGISTRY,
+      dependencies: runtimeDependencies,
+      publicationExecutor,
+    });
+
+    expect(claimedLimits).toEqual([1, 1]);
+    expect(poisoned).toMatchObject({ operationIndeterminate: 1, operationProtected: 0 });
+    expect(completed).toMatchObject({ operationIndeterminate: 0, operationProtected: 1 });
+  });
+
+  test("isolates one hundred poison claims and completes healthy work on the next bounded tick", async () => {
+    const poisonClaims = Array.from({ length: 100 }, (_, index) => gcClaim(index));
+    const healthyClaim = gcClaim(100);
+    const attempted: string[] = [];
+    let claimCycle = 0;
+    const runtimeDependencies = dependencies({
+      claimGc: async () => (claimCycle++ === 0 ? poisonClaims : [healthyClaim]),
+      executeGcClaims: async ({ claims: [claim] }) => {
+        const id = claim?.outbox.id ?? "missing";
+        attempted.push(id);
+        if (id !== "gc-100") {
+          throw new Error("provider poison or lost settlement response");
+        }
+        return { completed: 1, failed: 0 };
+      },
+    });
+    const boundedConfig = { ...ENABLED_CONFIG, gcBatchSize: 100 };
+    const poisoned = await runAgentBackupCatalogRuntimeCycle({
+      config: boundedConfig,
+      registry: UNUSED_REGISTRY,
+      dependencies: runtimeDependencies,
+    });
+    const healthy = await runAgentBackupCatalogRuntimeCycle({
+      config: boundedConfig,
+      registry: UNUSED_REGISTRY,
+      dependencies: runtimeDependencies,
+    });
+
+    expect(attempted).toHaveLength(101);
+    expect(attempted.at(-1)).toBe("gc-100");
+    expect(poisoned).toMatchObject({
+      gcClaimed: 100,
+      gcCompleted: 0,
+      gcFailed: 0,
+      gcIndeterminate: 100,
+    });
+    expect(healthy).toMatchObject({
+      gcClaimed: 1,
+      gcCompleted: 1,
+      gcFailed: 0,
+      gcIndeterminate: 0,
+    });
+    expect(poisoned.alertCodes).toContain("BACKUP_GC_RECONCILE_REQUIRED");
+  });
+
+  test("preserves executor-scheduled GC retries as aggregate alerts", async () => {
+    let retryDelayMs = 0;
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: ENABLED_CONFIG,
+      registry: UNUSED_REGISTRY,
+      random: () => 0.5,
+      dependencies: dependencies({
+        claimGc: async () => [gcClaim(1)],
+        executeGcClaims: async (params) => {
+          retryDelayMs = params.retryDelayMs;
+          return { completed: 0, failed: 1 };
+        },
+      }),
+    });
+
+    expect(retryDelayMs).toBe(60_000);
+    expect(summary.gcFailed).toBe(1);
+    expect(summary.alertCodes).toContain("BACKUP_GC_RETRY_SCHEDULED");
+  });
+
+  test("enqueues due deletion before GC and finalizes only after receipted execution", async () => {
+    const candidate = {
+      organizationId: ORG_ID,
+      backupId: BACKUP_ID,
+      operationId: OPERATION_ID,
+    };
+    const order: string[] = [];
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: ENABLED_CONFIG,
+      registry: UNUSED_REGISTRY,
+      dependencies: dependencies({
+        listDueDeletions: async ({ limit }) => {
+          order.push(`list-due:${limit}`);
+          return [candidate];
+        },
+        enqueueDeletion: async () => {
+          order.push("enqueue");
+          return { backup: operationClaim().backup, enqueued: 2 };
+        },
+        claimGc: async () => {
+          order.push("claim-gc");
+          return [gcClaim(1)];
+        },
+        executeGcClaims: async () => {
+          order.push("execute-gc");
+          return { completed: 1, failed: 0 };
+        },
+        listFinalizableDeletions: async ({ limit }) => {
+          order.push(`list-finalizable:${limit}`);
+          return [candidate];
+        },
+        finalizeDeletion: async () => {
+          order.push("finalize");
+          return operationClaim().backup;
+        },
+      }),
+    });
+
+    expect(order).toEqual([
+      "list-due:32",
+      "enqueue",
+      "claim-gc",
+      "execute-gc",
+      "list-finalizable:32",
+      "finalize",
+    ]);
+    expect(summary).toMatchObject({
+      deletionCandidates: 1,
+      deletionEnqueued: 2,
+      deletionEnqueueIndeterminate: 0,
+      gcCompleted: 1,
+      deletionFinalized: 1,
+      deletionFinalizeIndeterminate: 0,
+    });
+  });
+
+  test("isolates lost enqueue/finalize responses without exposing candidate identity", async () => {
+    const candidate = {
+      organizationId: ORG_ID,
+      backupId: BACKUP_ID,
+      operationId: OPERATION_ID,
+    };
+    const summary = await runAgentBackupCatalogRuntimeCycle({
+      config: ENABLED_CONFIG,
+      registry: UNUSED_REGISTRY,
+      dependencies: dependencies({
+        listDueDeletions: async () => [candidate],
+        enqueueDeletion: async () => {
+          throw new Error("response lost after enqueue commit");
+        },
+        listFinalizableDeletions: async () => [candidate],
+        finalizeDeletion: async () => {
+          throw new Error("response lost after tombstone commit");
+        },
+      }),
+    });
+
+    expect(summary.deletionEnqueueIndeterminate).toBe(1);
+    expect(summary.deletionFinalizeIndeterminate).toBe(1);
+    expect(summary.alertCodes).toEqual([
+      "BACKUP_DELETION_ENQUEUE_RECONCILE_REQUIRED",
+      "BACKUP_DELETION_FINALIZE_RECONCILE_REQUIRED",
+    ]);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-backup-catalog-runtime.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-catalog-runtime.ts
@@ -1,0 +1,1083 @@
+/**
+ * Runs one bounded scheduler tick for the durable sandbox-backup catalogue.
+ *
+ * The caller owns cadence and logging. Production daemon composition is
+ * intentionally absent until activation/vault authorities and a dedicated
+ * sub-minute lane exist. This service owns feature-gated storage authority
+ * resolution, fair operation leases, retry deferral for pipeline stages that
+ * do not yet have an executor, and isolated exact-object GC. It never logs
+ * credentials, endpoint URLs, object keys, or locators.
+ */
+
+import {
+  type AgentBackupOperationClaim,
+  type AgentBackupOperationExecution,
+  claimDueAgentBackupOperations,
+  failAgentBackupOperation,
+  heartbeatAgentBackupOperation,
+  transitionAgentBackupOperation,
+} from "../../db/repositories/agent-backup-catalog";
+import {
+  type AgentBackupDeletionCandidate,
+  type AgentBackupGcClaim,
+  claimAgentBackupGc,
+  enqueueAgentBackupDeletion,
+  finalizeAgentBackupDeletion,
+  listDueAgentBackupDeletions,
+  listFinalizableAgentBackupDeletions,
+} from "../../db/repositories/agent-backup-gc";
+import {
+  type AgentBackupScheduleClaim,
+  claimDueAgentBackupSchedules,
+  countOverdueAgentBackupSchedules,
+  deferClaimedAgentBackupSchedule,
+  enrollEligibleAgentBackupSchedules,
+  reconcileAgentBackupSchedules,
+  reserveClaimedAgentBackupSchedule,
+} from "../../db/repositories/agent-backup-scheduler";
+import type { AgentBackupCatalogState } from "../../db/schemas/agent-sandboxes";
+import {
+  type AgentBackupObjectStoreRegistry,
+  type AgentBackupStorageEndpoint,
+  createAgentBackupObjectStoreRegistry,
+} from "../storage/agent-backup-object-store";
+import type { RuntimeR2Bucket } from "../storage/r2-runtime-binding";
+import { isTrustedAgentBackupCaptureV2TerminalDisposition } from "./agent-backup-capture-v2-failure-disposition";
+import type {
+  AgentBackupCaptureV3SpoolCleanupJanitor,
+  AgentBackupCaptureV3SpoolCleanupSummary,
+} from "./agent-backup-capture-v3-spool-cleanup";
+import { executeAgentBackupGcClaims } from "./agent-backup-catalog-worker";
+
+const MAX_OPERATION_BATCH = 100;
+const MAX_SCHEDULE_BATCH = 100;
+const MAX_GC_BATCH = 100;
+const MAX_LEASE_MS = 5 * 60_000;
+const MAX_OPERATION_RETRY_MS = 24 * 60 * 60_000;
+const MAX_GC_RETRY_MS = 6 * 60 * 60_000;
+
+// Start deliberately serial. Operators may raise the bounded override after
+// observing provider quotas and memory pressure in their own deployment.
+const DEFAULT_OPERATION_BATCH = 1;
+const DEFAULT_SCHEDULE_BATCH = 32;
+const DEFAULT_SCHEDULE_LEASE_MS = 2 * 60_000;
+const DEFAULT_SCHEDULE_RETRY_MS = 30_000;
+const DEFAULT_GC_BATCH = 32;
+const DEFAULT_DELETION_BATCH = 32;
+const DEFAULT_LEASE_MS = 4 * 60_000;
+const DEFAULT_OPERATION_RETRY_BASE_MS = 60_000;
+const DEFAULT_OPERATION_RETRY_MAX_MS = 6 * 60 * 60_000;
+const DEFAULT_GC_RETRY_BASE_MS = 30_000;
+const DEFAULT_GC_RETRY_MAX_MS = 30 * 60_000;
+
+const OPERATION_UNAVAILABLE_CODE = "BACKUP_PIPELINE_STAGE_UNAVAILABLE";
+const SCHEDULE_RETRY_CODE = "BACKUP_SCHEDULE_RESERVATION_RETRY";
+const SCHEDULE_RECONCILE_CODE = "BACKUP_SCHEDULE_RECONCILE_REQUIRED";
+const SCHEDULE_RPO_OVERDUE_CODE = "BACKUP_SCHEDULE_RPO_OVERDUE";
+const OPERATION_CAPTURE_RETRY_CODE = "BACKUP_CAPTURE_V2_RETRY_SCHEDULED";
+const OPERATION_CAPTURE_TERMINAL_CODE = "BACKUP_CAPTURE_V2_TERMINAL";
+const OPERATION_PUBLICATION_RETRY_CODE = "BACKUP_PUBLICATION_RETRY_SCHEDULED";
+const OPERATION_RECONCILE_CODE = "BACKUP_OPERATION_RECONCILE_REQUIRED";
+const GC_RETRY_CODE = "BACKUP_GC_RETRY_SCHEDULED";
+const GC_RECONCILE_CODE = "BACKUP_GC_RECONCILE_REQUIRED";
+const DELETION_ENQUEUE_RECONCILE_CODE = "BACKUP_DELETION_ENQUEUE_RECONCILE_REQUIRED";
+const DELETION_FINALIZE_RECONCILE_CODE = "BACKUP_DELETION_FINALIZE_RECONCILE_REQUIRED";
+const SPOOL_CLEANUP_RECONCILE_CODE = "BACKUP_SPOOL_CLEANUP_RECONCILE_REQUIRED";
+
+type RetryableOperationState = Exclude<
+  AgentBackupCatalogState,
+  "legacy_unmigrated" | "failed_retryable" | "failed_terminal" | "deleting" | "deleted"
+>;
+
+export interface AgentBackupCatalogRuntimeR2Binding {
+  bucketBinding: RuntimeR2Bucket;
+  /** Stable deployment/binding identity; never a credential. */
+  bindingIdentity: string;
+}
+
+export type AgentBackupCatalogRuntimeConfig =
+  | { enabled: false }
+  | {
+      enabled: true;
+      ownerId: string;
+      scheduleEnabled: boolean;
+      scheduleBatchSize: number;
+      scheduleLeaseMs: number;
+      scheduleRetryMs: number;
+      operationBatchSize: number;
+      gcBatchSize: number;
+      deletionBatchSize: number;
+      operationLeaseMs: number;
+      gcLeaseMs: number;
+      operationRetryBaseMs: number;
+      operationRetryMaxMs: number;
+      gcRetryBaseMs: number;
+      gcRetryMaxMs: number;
+    };
+
+export interface AgentBackupCatalogRuntimeSummary {
+  enabled: boolean;
+  scheduleEnrolled: number;
+  scheduleProtected: number;
+  scheduleRecycled: number;
+  scheduleClaimed: number;
+  scheduleReserved: number;
+  scheduleDeferred: number;
+  scheduleIndeterminate: number;
+  /** Exact current DB-clock 15-minute RPO breaches lacking strict proof. */
+  scheduleOverdue: number;
+  operationClaimed: number;
+  operationCaptured: number;
+  operationCaptureRetryScheduled: number;
+  operationCaptureTerminal: number;
+  operationProtected: number;
+  operationPublicationRetryScheduled: number;
+  operationDeferred: number;
+  operationIndeterminate: number;
+  spoolCleanup: AgentBackupCaptureV3SpoolCleanupSummary;
+  deletionCandidates: number;
+  deletionEnqueued: number;
+  deletionEnqueueIndeterminate: number;
+  gcClaimed: number;
+  gcCompleted: number;
+  gcFailed: number;
+  gcIndeterminate: number;
+  deletionFinalized: number;
+  deletionFinalizeIndeterminate: number;
+  /** Bounded static codes safe for structured logs and alert aggregation. */
+  alertCodes: readonly string[];
+}
+
+export interface AgentBackupCatalogRuntimeDependencies {
+  enrollSchedules(params: { limit: number }): Promise<number>;
+  reconcileSchedules(params: { limit: number }): Promise<{
+    protected: number;
+    recycled: number;
+  }>;
+  claimSchedules(params: {
+    ownerId: string;
+    limit: number;
+    leaseMs: number;
+  }): Promise<AgentBackupScheduleClaim[]>;
+  reserveSchedule(params: { claim: AgentBackupScheduleClaim }): Promise<unknown>;
+  deferSchedule(params: {
+    claim: AgentBackupScheduleClaim;
+    retryDelayMs: number;
+    errorCode: string;
+  }): Promise<boolean>;
+  countOverdueSchedules(): Promise<number>;
+  claimOperations(params: {
+    ownerId: string;
+    limit: number;
+    leaseMs: number;
+  }): Promise<AgentBackupOperationClaim[]>;
+  heartbeatOperation(params: {
+    organizationId: string;
+    backupId: string;
+    execution: AgentBackupOperationExecution;
+    leaseMs: number;
+  }): Promise<unknown>;
+  transitionOperation: typeof transitionAgentBackupOperation;
+  failOperation: typeof failAgentBackupOperation;
+  listDueDeletions: typeof listDueAgentBackupDeletions;
+  enqueueDeletion: typeof enqueueAgentBackupDeletion;
+  claimGc(params: {
+    ownerId: string;
+    limit: number;
+    leaseMs: number;
+  }): Promise<AgentBackupGcClaim[]>;
+  executeGcClaims: typeof executeAgentBackupGcClaims;
+  listFinalizableDeletions: typeof listFinalizableAgentBackupDeletions;
+  finalizeDeletion: typeof finalizeAgentBackupDeletion;
+}
+
+export interface AgentBackupCatalogRuntimeCaptureExecutor {
+  execute(params: {
+    /** Always normalized to an owned `capturing` operation. */
+    claim: Readonly<AgentBackupOperationClaim>;
+    leaseMs: number;
+    signal?: AbortSignal;
+  }): Promise<{ state: "captured-upload-pending" }>;
+}
+
+export type AgentBackupCatalogRuntimePublicationState =
+  | "captured"
+  | "uploading"
+  | "primary_uploaded"
+  | "primary_verified"
+  | "secondary_pending";
+
+export interface AgentBackupCatalogRuntimePublicationExecutor {
+  execute(params: { claim: Readonly<AgentBackupOperationClaim>; leaseMs: number }): Promise<
+    | { state: "protected" }
+    | {
+        state: "retryable-failure";
+        expectedState: AgentBackupCatalogRuntimePublicationState;
+        error: {
+          code: "BACKUP_PRIMARY_PUBLICATION_RETRY" | "BACKUP_SECONDARY_REPLICATION_RETRY";
+          message: string;
+        };
+      }
+  >;
+}
+
+const DEFAULT_DEPENDENCIES: AgentBackupCatalogRuntimeDependencies = {
+  enrollSchedules: enrollEligibleAgentBackupSchedules,
+  reconcileSchedules: reconcileAgentBackupSchedules,
+  claimSchedules: claimDueAgentBackupSchedules,
+  reserveSchedule: reserveClaimedAgentBackupSchedule,
+  deferSchedule: deferClaimedAgentBackupSchedule,
+  countOverdueSchedules: countOverdueAgentBackupSchedules,
+  claimOperations: claimDueAgentBackupOperations,
+  heartbeatOperation: heartbeatAgentBackupOperation,
+  transitionOperation: transitionAgentBackupOperation,
+  failOperation: failAgentBackupOperation,
+  listDueDeletions: listDueAgentBackupDeletions,
+  enqueueDeletion: enqueueAgentBackupDeletion,
+  claimGc: claimAgentBackupGc,
+  executeGcClaims: executeAgentBackupGcClaims,
+  listFinalizableDeletions: listFinalizableAgentBackupDeletions,
+  finalizeDeletion: finalizeAgentBackupDeletion,
+};
+
+function readBoundedInteger(params: {
+  env: NodeJS.ProcessEnv;
+  name: string;
+  fallback: number;
+  min: number;
+  max: number;
+}): number {
+  const raw = params.env[params.name];
+  if (raw === undefined || raw === "") return params.fallback;
+  if (!/^[1-9][0-9]*$/.test(raw)) {
+    throw new Error(`${params.name} must be a canonical positive integer`);
+  }
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < params.min || value > params.max) {
+    throw new Error(`${params.name} must be between ${params.min} and ${params.max}`);
+  }
+  return value;
+}
+
+function requiredEnv(env: NodeJS.ProcessEnv, name: string): string {
+  const value = env[name];
+  if (!value || value.trim() !== value || value.includes("\0")) {
+    throw new Error(
+      `${name} must be explicitly configured when backup catalogue runtime is enabled`,
+    );
+  }
+  return value;
+}
+
+/** Parse the fail-closed runtime gate without reading storage credentials while disabled. */
+export function readAgentBackupCatalogRuntimeConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): AgentBackupCatalogRuntimeConfig {
+  const scheduleEnabled = env.AGENT_BACKUP_RPO_SCHEDULER_ENABLED === "1";
+  if (env.AGENT_BACKUP_CATALOG_RUNTIME_ENABLED !== "1") {
+    if (scheduleEnabled) {
+      throw new Error(
+        "AGENT_BACKUP_RPO_SCHEDULER_ENABLED requires AGENT_BACKUP_CATALOG_RUNTIME_ENABLED=1",
+      );
+    }
+    return { enabled: false };
+  }
+
+  const operationRetryBaseMs = readBoundedInteger({
+    env,
+    name: "AGENT_BACKUP_OPERATION_RETRY_BASE_MS",
+    fallback: DEFAULT_OPERATION_RETRY_BASE_MS,
+    min: 1,
+    max: MAX_OPERATION_RETRY_MS,
+  });
+  const operationRetryMaxMs = readBoundedInteger({
+    env,
+    name: "AGENT_BACKUP_OPERATION_RETRY_MAX_MS",
+    fallback: DEFAULT_OPERATION_RETRY_MAX_MS,
+    min: 1,
+    max: MAX_OPERATION_RETRY_MS,
+  });
+  const gcRetryBaseMs = readBoundedInteger({
+    env,
+    name: "AGENT_BACKUP_GC_RETRY_BASE_MS",
+    fallback: DEFAULT_GC_RETRY_BASE_MS,
+    min: 1,
+    max: MAX_GC_RETRY_MS,
+  });
+  const gcRetryMaxMs = readBoundedInteger({
+    env,
+    name: "AGENT_BACKUP_GC_RETRY_MAX_MS",
+    fallback: DEFAULT_GC_RETRY_MAX_MS,
+    min: 1,
+    max: MAX_GC_RETRY_MS,
+  });
+  if (operationRetryBaseMs > operationRetryMaxMs) {
+    throw new Error("AGENT_BACKUP_OPERATION_RETRY_BASE_MS cannot exceed its retry maximum");
+  }
+  if (gcRetryBaseMs > gcRetryMaxMs) {
+    throw new Error("AGENT_BACKUP_GC_RETRY_BASE_MS cannot exceed its retry maximum");
+  }
+
+  return {
+    enabled: true,
+    ownerId: requiredEnv(env, "AGENT_BACKUP_CATALOG_WORKER_ID"),
+    scheduleEnabled,
+    scheduleBatchSize: readBoundedInteger({
+      env,
+      name: "AGENT_BACKUP_SCHEDULE_BATCH_SIZE",
+      fallback: DEFAULT_SCHEDULE_BATCH,
+      min: 1,
+      max: MAX_SCHEDULE_BATCH,
+    }),
+    scheduleLeaseMs: readBoundedInteger({
+      env,
+      name: "AGENT_BACKUP_SCHEDULE_LEASE_MS",
+      fallback: DEFAULT_SCHEDULE_LEASE_MS,
+      min: 1,
+      max: MAX_LEASE_MS,
+    }),
+    scheduleRetryMs: readBoundedInteger({
+      env,
+      name: "AGENT_BACKUP_SCHEDULE_RETRY_MS",
+      fallback: DEFAULT_SCHEDULE_RETRY_MS,
+      min: 1,
+      max: 5 * 60_000,
+    }),
+    operationBatchSize: readBoundedInteger({
+      env,
+      name: "AGENT_BACKUP_OPERATION_BATCH_SIZE",
+      fallback: DEFAULT_OPERATION_BATCH,
+      min: 1,
+      max: MAX_OPERATION_BATCH,
+    }),
+    gcBatchSize: readBoundedInteger({
+      env,
+      name: "AGENT_BACKUP_GC_BATCH_SIZE",
+      fallback: DEFAULT_GC_BATCH,
+      min: 1,
+      max: MAX_GC_BATCH,
+    }),
+    deletionBatchSize: readBoundedInteger({
+      env,
+      name: "AGENT_BACKUP_DELETION_BATCH_SIZE",
+      fallback: DEFAULT_DELETION_BATCH,
+      min: 1,
+      max: MAX_GC_BATCH,
+    }),
+    operationLeaseMs: readBoundedInteger({
+      env,
+      name: "AGENT_BACKUP_OPERATION_LEASE_MS",
+      fallback: DEFAULT_LEASE_MS,
+      min: 1,
+      max: MAX_LEASE_MS,
+    }),
+    gcLeaseMs: readBoundedInteger({
+      env,
+      name: "AGENT_BACKUP_GC_LEASE_MS",
+      fallback: DEFAULT_LEASE_MS,
+      min: 1,
+      max: MAX_LEASE_MS,
+    }),
+    operationRetryBaseMs,
+    operationRetryMaxMs,
+    gcRetryBaseMs,
+    gcRetryMaxMs,
+  };
+}
+
+/**
+ * Build the two immutable storage authorities required by the catalogue.
+ * R2 may arrive as a native Worker binding or explicit S3 credentials; the
+ * Hetzner secondary is always the S3-compatible Object Storage API.
+ */
+export async function createAgentBackupCatalogRegistryFromEnv(
+  params: { env?: NodeJS.ProcessEnv; primaryR2Binding?: AgentBackupCatalogRuntimeR2Binding } = {},
+): Promise<AgentBackupObjectStoreRegistry> {
+  const env = params.env ?? process.env;
+  const primaryBase = {
+    provider: "cloudflare-r2" as const,
+    endpointAlias: requiredEnv(env, "AGENT_BACKUP_R2_ENDPOINT_ALIAS"),
+    accountIdentity: requiredEnv(env, "AGENT_BACKUP_R2_ACCOUNT_ID"),
+    bucket: requiredEnv(env, "AGENT_BACKUP_R2_BUCKET"),
+    region: requiredEnv(env, "AGENT_BACKUP_R2_REGION"),
+  };
+  const primary: AgentBackupStorageEndpoint = params.primaryR2Binding
+    ? {
+        ...primaryBase,
+        transport: "worker-r2",
+        bindingIdentity: params.primaryR2Binding.bindingIdentity,
+        bucketBinding: params.primaryR2Binding.bucketBinding,
+      }
+    : {
+        ...primaryBase,
+        transport: "s3-compatible",
+        endpoint: requiredEnv(env, "AGENT_BACKUP_R2_ENDPOINT"),
+        accessKeyId: requiredEnv(env, "AGENT_BACKUP_R2_ACCESS_KEY_ID"),
+        secretAccessKey: requiredEnv(env, "AGENT_BACKUP_R2_SECRET_ACCESS_KEY"),
+      };
+  const secondary: AgentBackupStorageEndpoint = {
+    provider: "hetzner-object-storage",
+    transport: "s3-compatible",
+    endpointAlias: requiredEnv(env, "AGENT_BACKUP_HETZNER_ENDPOINT_ALIAS"),
+    accountIdentity: requiredEnv(env, "AGENT_BACKUP_HETZNER_ACCOUNT_ID"),
+    endpoint: requiredEnv(env, "AGENT_BACKUP_HETZNER_ENDPOINT"),
+    bucket: requiredEnv(env, "AGENT_BACKUP_HETZNER_BUCKET"),
+    region: requiredEnv(env, "AGENT_BACKUP_HETZNER_REGION"),
+    accessKeyId: requiredEnv(env, "AGENT_BACKUP_HETZNER_ACCESS_KEY_ID"),
+    secretAccessKey: requiredEnv(env, "AGENT_BACKUP_HETZNER_SECRET_ACCESS_KEY"),
+  };
+  return createAgentBackupObjectStoreRegistry([primary, secondary]);
+}
+
+/** Exponential retry with bounded symmetric jitter; always respects provider/repository caps. */
+export function agentBackupCatalogRetryDelay(params: {
+  attempt: number;
+  baseMs: number;
+  maxMs: number;
+  random?: () => number;
+}): number {
+  const exponent = Math.max(0, Math.min(30, Math.trunc(params.attempt)));
+  const capped = Math.min(params.maxMs, params.baseMs * 2 ** exponent);
+  const random = params.random ?? Math.random;
+  const sample = Math.min(1, Math.max(0, random()));
+  const jitterFactor = 0.8 + sample * 0.4;
+  return Math.max(1, Math.min(params.maxMs, Math.round(capped * jitterFactor)));
+}
+
+function isRetryableOperationState(
+  state: AgentBackupCatalogState,
+): state is RetryableOperationState {
+  return ![
+    "legacy_unmigrated",
+    "failed_retryable",
+    "failed_terminal",
+    "deleting",
+    "deleted",
+  ].includes(state);
+}
+
+function claimIdentity(claim: AgentBackupOperationClaim): {
+  organizationId: string;
+  backupId: string;
+  operationId: string;
+  activationGeneration: string;
+  lifecycleGeneration: string;
+  lifecycleRevision: string;
+} | null {
+  const backup = claim.backup;
+  if (
+    !backup.catalog_organization_id ||
+    !backup.backup_operation_id ||
+    !backup.lifecycle_generation ||
+    backup.lifecycle_revision === null
+  ) {
+    return null;
+  }
+  return {
+    organizationId: backup.catalog_organization_id,
+    backupId: backup.id,
+    operationId: backup.backup_operation_id,
+    activationGeneration: backup.lifecycle_generation,
+    lifecycleGeneration: backup.lifecycle_generation,
+    lifecycleRevision: backup.lifecycle_revision.toString(),
+  };
+}
+
+async function deferUnsupportedOperation(params: {
+  claim: AgentBackupOperationClaim;
+  config: Extract<AgentBackupCatalogRuntimeConfig, { enabled: true }>;
+  dependencies: AgentBackupCatalogRuntimeDependencies;
+  random?: () => number;
+}): Promise<boolean> {
+  const identity = claimIdentity(params.claim);
+  const initialState = params.claim.backup.catalog_state;
+  if (!identity || !initialState) return false;
+  const execution = {
+    ownerId: params.claim.ownerId,
+    generation: params.claim.generation,
+  };
+  await params.dependencies.heartbeatOperation({
+    organizationId: identity.organizationId,
+    backupId: identity.backupId,
+    execution,
+    leaseMs: params.config.operationLeaseMs,
+  });
+
+  let state = initialState;
+  if (state === "failed_retryable") {
+    const resumeState = params.claim.backup.catalog_resume_state;
+    if (!resumeState || !isRetryableOperationState(resumeState)) return false;
+    await params.dependencies.transitionOperation({
+      ...identity,
+      expectedState: "failed_retryable",
+      to: resumeState,
+      resumeState,
+      execution,
+    });
+    state = resumeState;
+  }
+  if (!isRetryableOperationState(state)) return false;
+
+  await params.dependencies.failOperation({
+    ...identity,
+    expectedState: state,
+    terminal: false,
+    error: {
+      code: OPERATION_UNAVAILABLE_CODE,
+      message:
+        "Backup pipeline stage is not enabled on this runtime; work remains durable and retryable",
+    },
+    retryDelayMs: agentBackupCatalogRetryDelay({
+      attempt: params.claim.backup.catalog_attempts,
+      baseMs: params.config.operationRetryBaseMs,
+      maxMs: params.config.operationRetryMaxMs,
+      random: params.random,
+    }),
+    execution,
+  });
+  return true;
+}
+
+function isCaptureOperationClaim(claim: Readonly<AgentBackupOperationClaim>): boolean {
+  const state = claim.backup.catalog_state;
+  return (
+    state === "scheduled" ||
+    state === "capturing" ||
+    (state === "failed_retryable" &&
+      (claim.backup.catalog_resume_state === "scheduled" ||
+        claim.backup.catalog_resume_state === "capturing"))
+  );
+}
+
+interface CaptureFailureDisposition {
+  terminal: boolean;
+  terminalSpoolCleanup?: Parameters<
+    AgentBackupCaptureV3SpoolCleanupJanitor["stageTerminalFailure"]
+  >[0]["authority"];
+}
+
+function classifyCaptureFailure(error: unknown): CaptureFailureDisposition {
+  if (!isTrustedAgentBackupCaptureV2TerminalDisposition(error)) return { terminal: false };
+  return {
+    terminal: true,
+    terminalSpoolCleanup: error.terminalSpoolCleanup,
+  };
+}
+
+function isPublicationOperationClaim(claim: Readonly<AgentBackupOperationClaim>): boolean {
+  const state = claim.backup.catalog_state;
+  return (
+    state === "captured" ||
+    state === "uploading" ||
+    state === "primary_uploaded" ||
+    state === "primary_verified" ||
+    state === "secondary_pending" ||
+    (state === "failed_retryable" &&
+      (claim.backup.catalog_resume_state === "captured" ||
+        claim.backup.catalog_resume_state === "uploading" ||
+        claim.backup.catalog_resume_state === "primary_uploaded" ||
+        claim.backup.catalog_resume_state === "primary_verified" ||
+        claim.backup.catalog_resume_state === "secondary_pending"))
+  );
+}
+
+async function normalizeCaptureOperationClaim(params: {
+  claim: AgentBackupOperationClaim;
+  dependencies: AgentBackupCatalogRuntimeDependencies;
+}): Promise<AgentBackupOperationClaim> {
+  const identity = claimIdentity(params.claim);
+  if (!identity) throw new Error("Capture claim identity is incomplete");
+  const execution = {
+    ownerId: params.claim.ownerId,
+    generation: params.claim.generation,
+  };
+  let backup = params.claim.backup;
+  if (backup.catalog_state === "failed_retryable") {
+    const resumeState = backup.catalog_resume_state;
+    if (resumeState !== "scheduled" && resumeState !== "capturing") {
+      throw new Error("Capture retry does not own a capture state");
+    }
+    backup = await params.dependencies.transitionOperation({
+      ...identity,
+      expectedState: "failed_retryable",
+      to: resumeState,
+      resumeState,
+      execution,
+    });
+  }
+  if (backup.catalog_state === "scheduled") {
+    backup = await params.dependencies.transitionOperation({
+      ...identity,
+      expectedState: "scheduled",
+      to: "capturing",
+      execution,
+    });
+  }
+  if (backup.catalog_state !== "capturing") {
+    throw new Error("Capture claim could not be normalized to capturing");
+  }
+  return { ...params.claim, backup };
+}
+
+/** Run one bounded, non-looping scheduler/GC tick. */
+export async function runAgentBackupCatalogRuntimeCycle(params: {
+  config: AgentBackupCatalogRuntimeConfig;
+  registry?: AgentBackupObjectStoreRegistry;
+  dependencies?: AgentBackupCatalogRuntimeDependencies;
+  captureExecutor?: AgentBackupCatalogRuntimeCaptureExecutor;
+  publicationExecutor?: AgentBackupCatalogRuntimePublicationExecutor;
+  /** Inject only on the capture node that owns the persistent spool StateDirectory. */
+  spoolCleanupJanitor?: AgentBackupCaptureV3SpoolCleanupJanitor;
+  random?: () => number;
+  signal?: AbortSignal;
+}): Promise<AgentBackupCatalogRuntimeSummary> {
+  const summary: AgentBackupCatalogRuntimeSummary = {
+    enabled: params.config.enabled,
+    scheduleEnrolled: 0,
+    scheduleProtected: 0,
+    scheduleRecycled: 0,
+    scheduleClaimed: 0,
+    scheduleReserved: 0,
+    scheduleDeferred: 0,
+    scheduleIndeterminate: 0,
+    scheduleOverdue: 0,
+    operationClaimed: 0,
+    operationCaptured: 0,
+    operationCaptureRetryScheduled: 0,
+    operationCaptureTerminal: 0,
+    operationProtected: 0,
+    operationPublicationRetryScheduled: 0,
+    operationDeferred: 0,
+    operationIndeterminate: 0,
+    spoolCleanup: {
+      discovered: 0,
+      authorized: 0,
+      completed: 0,
+      pending: 0,
+      skippedUnprotected: 0,
+      indeterminate: 0,
+    },
+    deletionCandidates: 0,
+    deletionEnqueued: 0,
+    deletionEnqueueIndeterminate: 0,
+    gcClaimed: 0,
+    gcCompleted: 0,
+    gcFailed: 0,
+    gcIndeterminate: 0,
+    deletionFinalized: 0,
+    deletionFinalizeIndeterminate: 0,
+    alertCodes: [],
+  };
+  if (!params.config.enabled) return summary;
+  if (!params.registry) {
+    throw new Error("Backup catalogue runtime requires both configured storage authorities");
+  }
+
+  const dependencies = params.dependencies ?? DEFAULT_DEPENDENCIES;
+  const alertCodes = new Set<string>();
+  const reconcileSchedules = async (): Promise<void> => {
+    if (!params.config.enabled || !params.config.scheduleEnabled) return;
+    try {
+      const reconciled = await dependencies.reconcileSchedules({
+        limit: params.config.scheduleBatchSize,
+      });
+      summary.scheduleProtected += reconciled.protected;
+      summary.scheduleRecycled += reconciled.recycled;
+    } catch {
+      summary.scheduleIndeterminate += 1;
+      alertCodes.add(SCHEDULE_RECONCILE_CODE);
+    }
+  };
+  const countOverdueSchedules = async (): Promise<void> => {
+    if (!params.config.enabled || !params.config.scheduleEnabled) return;
+    try {
+      summary.scheduleOverdue = await dependencies.countOverdueSchedules();
+      if (summary.scheduleOverdue > 0) {
+        alertCodes.add(SCHEDULE_RPO_OVERDUE_CODE);
+      }
+    } catch {
+      summary.scheduleIndeterminate += 1;
+      alertCodes.add(SCHEDULE_RECONCILE_CODE);
+    }
+  };
+
+  if (params.config.scheduleEnabled) {
+    await reconcileSchedules();
+    try {
+      summary.scheduleEnrolled = await dependencies.enrollSchedules({
+        limit: params.config.scheduleBatchSize,
+      });
+    } catch {
+      summary.scheduleIndeterminate += 1;
+      alertCodes.add(SCHEDULE_RECONCILE_CODE);
+    }
+
+    let scheduleClaims: AgentBackupScheduleClaim[] = [];
+    try {
+      scheduleClaims = await dependencies.claimSchedules({
+        ownerId: params.config.ownerId,
+        limit: params.config.scheduleBatchSize,
+        leaseMs: params.config.scheduleLeaseMs,
+      });
+      summary.scheduleClaimed = scheduleClaims.length;
+    } catch {
+      summary.scheduleIndeterminate += 1;
+      alertCodes.add(SCHEDULE_RECONCILE_CODE);
+    }
+    for (const claim of scheduleClaims) {
+      try {
+        await dependencies.reserveSchedule({ claim });
+        summary.scheduleReserved += 1;
+      } catch {
+        try {
+          if (
+            await dependencies.deferSchedule({
+              claim,
+              retryDelayMs: params.config.scheduleRetryMs,
+              errorCode: SCHEDULE_RETRY_CODE,
+            })
+          ) {
+            summary.scheduleDeferred += 1;
+            alertCodes.add(SCHEDULE_RETRY_CODE);
+          } else {
+            summary.scheduleIndeterminate += 1;
+            alertCodes.add(SCHEDULE_RECONCILE_CODE);
+          }
+        } catch {
+          summary.scheduleIndeterminate += 1;
+          alertCodes.add(SCHEDULE_RECONCILE_CODE);
+        }
+      }
+    }
+  }
+
+  // Emit the strict RPO signal before unrelated catalogue/GC dependencies can
+  // fail. A later pass refreshes it when this tick may have published proof.
+  await countOverdueSchedules();
+
+  let operationClaims: AgentBackupOperationClaim[] = [];
+  try {
+    operationClaims = await dependencies.claimOperations({
+      ownerId: params.config.ownerId,
+      limit: params.config.operationBatchSize,
+      leaseMs: params.config.operationLeaseMs,
+    });
+    summary.operationClaimed = operationClaims.length;
+  } catch (error) {
+    if (!params.config.scheduleEnabled) throw error;
+    summary.operationIndeterminate += 1;
+    alertCodes.add(OPERATION_RECONCILE_CODE);
+  }
+  for (const claim of operationClaims) {
+    if (params.captureExecutor && isCaptureOperationClaim(claim)) {
+      let normalized: AgentBackupOperationClaim;
+      try {
+        normalized = await normalizeCaptureOperationClaim({ claim, dependencies });
+      } catch {
+        // A lost transition response is indeterminate. The exact lease/state
+        // will reconcile on a later claim without running a second executor.
+        summary.operationIndeterminate += 1;
+        alertCodes.add(OPERATION_RECONCILE_CODE);
+        continue;
+      }
+      try {
+        const result = await params.captureExecutor.execute({
+          claim: normalized,
+          leaseMs: params.config.operationLeaseMs,
+          signal: params.signal,
+        });
+        if (result.state !== "captured-upload-pending") {
+          throw new Error("Capture executor crossed an unsupported publication boundary");
+        }
+        summary.operationCaptured += 1;
+      } catch (error) {
+        const identity = claimIdentity(normalized);
+        if (!identity) {
+          summary.operationIndeterminate += 1;
+          alertCodes.add(OPERATION_RECONCILE_CODE);
+          continue;
+        }
+        const disposition = classifyCaptureFailure(error);
+        const terminal = disposition.terminal;
+        if (terminal && disposition.terminalSpoolCleanup) {
+          if (!params.spoolCleanupJanitor) {
+            summary.operationIndeterminate += 1;
+            summary.spoolCleanup.pending += 1;
+            alertCodes.add(OPERATION_RECONCILE_CODE);
+            alertCodes.add(SPOOL_CLEANUP_RECONCILE_CODE);
+            continue;
+          }
+          try {
+            await params.spoolCleanupJanitor.stageTerminalFailure({
+              authority: disposition.terminalSpoolCleanup,
+              terminalErrorCode: OPERATION_CAPTURE_TERMINAL_CODE,
+            });
+          } catch {
+            // The non-authorizing local candidate is the crash bridge between
+            // the terminal database CAS and cleanup. Never commit terminal when
+            // that bridge is not durably confirmed.
+            summary.operationIndeterminate += 1;
+            summary.spoolCleanup.indeterminate += 1;
+            alertCodes.add(OPERATION_RECONCILE_CODE);
+            alertCodes.add(SPOOL_CLEANUP_RECONCILE_CODE);
+            continue;
+          }
+        }
+        try {
+          await dependencies.failOperation({
+            ...identity,
+            expectedState: "capturing",
+            terminal,
+            error: {
+              code: terminal ? OPERATION_CAPTURE_TERMINAL_CODE : OPERATION_CAPTURE_RETRY_CODE,
+              message: terminal
+                ? "Capture-v2 returned deterministic authority, format, or replay-conflict evidence"
+                : "Capture-v2 did not reach a confirmed recordCaptured boundary; retry remains safe",
+            },
+            ...(terminal
+              ? {}
+              : {
+                  retryDelayMs: agentBackupCatalogRetryDelay({
+                    attempt: normalized.backup.catalog_attempts,
+                    baseMs: params.config.operationRetryBaseMs,
+                    maxMs: params.config.operationRetryMaxMs,
+                    random: params.random,
+                  }),
+                }),
+            execution: {
+              ownerId: normalized.ownerId,
+              generation: normalized.generation,
+            },
+          });
+          if (terminal) {
+            summary.operationCaptureTerminal += 1;
+            alertCodes.add(OPERATION_CAPTURE_TERMINAL_CODE);
+          } else {
+            summary.operationCaptureRetryScheduled += 1;
+            alertCodes.add(OPERATION_CAPTURE_RETRY_CODE);
+          }
+        } catch {
+          // recordCaptured or the failure write may have committed before a lost
+          // response. Never overwrite that ambiguity with a synthetic success.
+          summary.operationIndeterminate += 1;
+          alertCodes.add(OPERATION_RECONCILE_CODE);
+        }
+      }
+      continue;
+    }
+    if (params.publicationExecutor && isPublicationOperationClaim(claim)) {
+      try {
+        const result = await params.publicationExecutor.execute({
+          claim,
+          leaseMs: params.config.operationLeaseMs,
+        });
+        if (result.state === "protected") {
+          summary.operationProtected += 1;
+          continue;
+        }
+        const identity = claimIdentity(claim);
+        if (!identity) {
+          summary.operationIndeterminate += 1;
+          alertCodes.add(OPERATION_RECONCILE_CODE);
+          continue;
+        }
+        await dependencies.failOperation({
+          ...identity,
+          expectedState: result.expectedState,
+          terminal: false,
+          error: result.error,
+          retryDelayMs: agentBackupCatalogRetryDelay({
+            attempt: claim.backup.catalog_attempts,
+            baseMs: params.config.operationRetryBaseMs,
+            maxMs: params.config.operationRetryMaxMs,
+            random: params.random,
+          }),
+          execution: {
+            ownerId: claim.ownerId,
+            generation: claim.generation,
+          },
+        });
+        summary.operationPublicationRetryScheduled += 1;
+        alertCodes.add(OPERATION_PUBLICATION_RETRY_CODE);
+      } catch {
+        // A transition or retry write may have committed before response loss.
+        // Leave the exact leased row for reconciliation rather than guessing.
+        summary.operationIndeterminate += 1;
+        alertCodes.add(OPERATION_RECONCILE_CODE);
+      }
+      continue;
+    }
+    try {
+      if (
+        await deferUnsupportedOperation({
+          claim,
+          config: params.config,
+          dependencies,
+          random: params.random,
+        })
+      ) {
+        summary.operationDeferred += 1;
+        alertCodes.add(OPERATION_UNAVAILABLE_CODE);
+      } else {
+        summary.operationIndeterminate += 1;
+        alertCodes.add(OPERATION_RECONCILE_CODE);
+      }
+    } catch {
+      // error-policy:J1 the daemon receives static aggregate evidence; the
+      // durable lease/state is reconciled after expiry without leaking locator data.
+      summary.operationIndeterminate += 1;
+      alertCodes.add(OPERATION_RECONCILE_CODE);
+    }
+  }
+
+  // A publication executor may have reached `protected` in this cycle. Run a
+  // second bounded exact-proof pass so its DB-clock RPO deadline is visible
+  // immediately; response-loss cases are picked up here as well.
+  await reconcileSchedules();
+  if (operationClaims.length > 0) await countOverdueSchedules();
+
+  if (params.spoolCleanupJanitor) {
+    try {
+      const cleanup = await params.spoolCleanupJanitor.runCycle();
+      summary.spoolCleanup = {
+        discovered: summary.spoolCleanup.discovered + cleanup.discovered,
+        authorized: summary.spoolCleanup.authorized + cleanup.authorized,
+        completed: summary.spoolCleanup.completed + cleanup.completed,
+        pending: summary.spoolCleanup.pending + cleanup.pending,
+        skippedUnprotected: summary.spoolCleanup.skippedUnprotected + cleanup.skippedUnprotected,
+        indeterminate: summary.spoolCleanup.indeterminate + cleanup.indeterminate,
+      };
+      if (summary.spoolCleanup.pending > 0 || summary.spoolCleanup.indeterminate > 0) {
+        alertCodes.add(SPOOL_CLEANUP_RECONCILE_CODE);
+      }
+    } catch {
+      summary.spoolCleanup.indeterminate += 1;
+      alertCodes.add(SPOOL_CLEANUP_RECONCILE_CODE);
+    }
+  }
+
+  let dueDeletions: AgentBackupDeletionCandidate[] = [];
+  try {
+    dueDeletions = await dependencies.listDueDeletions({
+      limit: params.config.deletionBatchSize,
+    });
+    summary.deletionCandidates = dueDeletions.length;
+  } catch (error) {
+    if (!params.config.scheduleEnabled) throw error;
+    summary.deletionEnqueueIndeterminate += 1;
+    alertCodes.add(DELETION_ENQUEUE_RECONCILE_CODE);
+  }
+  for (const candidate of dueDeletions) {
+    try {
+      const result = await dependencies.enqueueDeletion(candidate);
+      summary.deletionEnqueued += result.enqueued;
+    } catch {
+      // error-policy:J1 enqueue revalidates under lock; a stale or lost response
+      // is retried from durable catalogue state without logging its locator.
+      summary.deletionEnqueueIndeterminate += 1;
+      alertCodes.add(DELETION_ENQUEUE_RECONCILE_CODE);
+    }
+  }
+
+  let gcClaims: AgentBackupGcClaim[] = [];
+  try {
+    gcClaims = await dependencies.claimGc({
+      ownerId: params.config.ownerId,
+      limit: params.config.gcBatchSize,
+      leaseMs: params.config.gcLeaseMs,
+    });
+    summary.gcClaimed = gcClaims.length;
+  } catch (error) {
+    if (!params.config.scheduleEnabled) throw error;
+    summary.gcIndeterminate += 1;
+    alertCodes.add(GC_RECONCILE_CODE);
+  }
+  for (const claim of gcClaims) {
+    try {
+      const result = await dependencies.executeGcClaims({
+        claims: [claim],
+        registry: params.registry,
+        retryDelayMs: agentBackupCatalogRetryDelay({
+          attempt: claim.outbox.attempts,
+          baseMs: params.config.gcRetryBaseMs,
+          maxMs: params.config.gcRetryMaxMs,
+          random: params.random,
+        }),
+      });
+      summary.gcCompleted += result.completed;
+      summary.gcFailed += result.failed;
+      if (result.failed > 0) alertCodes.add(GC_RETRY_CODE);
+    } catch {
+      // A lost settlement response is deliberately indeterminate: the durable
+      // completed row wins, or the lease expires and the exact claim is retried.
+      summary.gcIndeterminate += 1;
+      alertCodes.add(GC_RECONCILE_CODE);
+    }
+  }
+
+  let finalizable: AgentBackupDeletionCandidate[] = [];
+  try {
+    finalizable = await dependencies.listFinalizableDeletions({
+      limit: params.config.deletionBatchSize,
+    });
+  } catch (error) {
+    if (!params.config.scheduleEnabled) throw error;
+    summary.deletionFinalizeIndeterminate += 1;
+    alertCodes.add(DELETION_FINALIZE_RECONCILE_CODE);
+  }
+  for (const candidate of finalizable) {
+    try {
+      await dependencies.finalizeDeletion(candidate);
+      summary.deletionFinalized += 1;
+    } catch {
+      // error-policy:J1 finalization is receipt/CAS guarded; an ambiguous
+      // response is harmless and a later bounded tick reconciles the tombstone.
+      summary.deletionFinalizeIndeterminate += 1;
+      alertCodes.add(DELETION_FINALIZE_RECONCILE_CODE);
+    }
+  }
+  summary.alertCodes = [...alertCodes].sort();
+  return summary;
+}
+
+let cachedProcessRegistry:
+  | { env: NodeJS.ProcessEnv; registry: AgentBackupObjectStoreRegistry }
+  | undefined;
+
+/** Environment-driven composition seam; no production daemon calls it in this slice. */
+export async function runAgentBackupCatalogRuntimeCycleFromEnv(
+  params: {
+    env?: NodeJS.ProcessEnv;
+    primaryR2Binding?: AgentBackupCatalogRuntimeR2Binding;
+    captureExecutor?: AgentBackupCatalogRuntimeCaptureExecutor;
+    publicationExecutor?: AgentBackupCatalogRuntimePublicationExecutor;
+    /** Requires durable node/spool affinity; it is intentionally not inferred from env. */
+    spoolCleanupJanitor?: AgentBackupCaptureV3SpoolCleanupJanitor;
+    random?: () => number;
+    signal?: AbortSignal;
+  } = {},
+): Promise<AgentBackupCatalogRuntimeSummary> {
+  const env = params.env ?? process.env;
+  const config = readAgentBackupCatalogRuntimeConfig(env);
+  if (!config.enabled) return runAgentBackupCatalogRuntimeCycle({ config });
+  const registry = params.primaryR2Binding
+    ? await createAgentBackupCatalogRegistryFromEnv({
+        env,
+        primaryR2Binding: params.primaryR2Binding,
+      })
+    : cachedProcessRegistry?.env === env
+      ? cachedProcessRegistry.registry
+      : await createAgentBackupCatalogRegistryFromEnv({ env });
+  if (!params.primaryR2Binding && cachedProcessRegistry?.env !== env) {
+    cachedProcessRegistry = { env, registry };
+  }
+  return runAgentBackupCatalogRuntimeCycle({
+    config,
+    registry,
+    captureExecutor: params.captureExecutor,
+    publicationExecutor: params.publicationExecutor,
+    spoolCleanupJanitor: params.spoolCleanupJanitor,
+    random: params.random,
+    signal: params.signal,
+  });
+}

--- a/packages/cloud/shared/src/lib/services/agent-backup-catalog-worker.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-catalog-worker.test.ts
@@ -1,0 +1,659 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentBackupObject } from "../../db/schemas/agent-backup-catalog";
+import type {
+  AgentBackupObjectStore,
+  AgentBackupObjectStoreRegistry,
+  AgentBackupStorageAuthority,
+} from "../storage/agent-backup-object-store";
+import {
+  type ExactObjectRead,
+  ObjectLocatorReceipt,
+  ObjectStorageLifecycleError,
+} from "../storage/object-store";
+import {
+  type AgentBackupObjectUploadRepository,
+  executeAgentBackupObjectUpload,
+  executeAgentBackupSecondaryObjectReplication,
+} from "./agent-backup-catalog-worker";
+
+const ORGANIZATION_ID = "a0000000-0000-4000-8000-000000000001";
+const BACKUP_ID = "b0000000-0000-4000-8000-000000000002";
+const OPERATION_ID = "c0000000-0000-4000-8000-000000000003";
+const EXECUTION = {
+  ownerId: "publication-worker-1",
+  generation: "d0000000-0000-4000-8000-000000000004",
+} as const;
+const PRIMARY_KEY = `agent-sandbox-backups/v2/${ORGANIZATION_ID}/${BACKUP_ID}/primary/database/00000003.bin`;
+const SECONDARY_KEY = `agent-sandbox-backups/v2/${ORGANIZATION_ID}/${BACKUP_ID}/secondary/database/00000003.bin`;
+const FINGERPRINT = `sha256:${"1".repeat(64)}`;
+const CONTENT_HMAC = "b".repeat(64);
+
+function ownedBytes(input: Uint8Array): Uint8Array<ArrayBuffer> {
+  const output = new Uint8Array(new ArrayBuffer(input.byteLength));
+  output.set(input);
+  return output;
+}
+
+async function sha256(input: Uint8Array | string): Promise<{ hex: string; base64: string }> {
+  const bytes = typeof input === "string" ? new TextEncoder().encode(input) : input;
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", ownedBytes(bytes)));
+  return {
+    hex: Array.from(digest, (byte) => byte.toString(16).padStart(2, "0")).join(""),
+    base64: Buffer.from(digest).toString("base64"),
+  };
+}
+
+function locator(params: {
+  authority: AgentBackupStorageAuthority;
+  keyFingerprint: string;
+  version: string;
+  transport?: "worker-r2-binding" | "s3-compatible";
+  provider?: "r2" | "s3";
+}): ObjectLocatorReceipt {
+  return new ObjectLocatorReceipt({
+    transport:
+      params.transport ??
+      (params.authority.transport === "worker-r2" ? "worker-r2-binding" : "s3-compatible"),
+    provider: params.provider ?? (params.authority.provider === "cloudflare-r2" ? "r2" : "s3"),
+    endpointAlias: params.authority.endpointAlias,
+    backendIdentityFingerprint: params.authority.endpointIdentityFingerprint,
+    bucket: params.authority.bucket,
+    region: params.authority.region,
+    keyFingerprint: params.keyFingerprint,
+    version: params.version,
+    versionSource: "provider",
+  });
+}
+
+function objectRow(params: {
+  id: string;
+  role: "primary" | "secondary";
+  provider: AgentBackupObject["provider"];
+  transport: AgentBackupObject["transport"];
+  authority: AgentBackupStorageAuthority;
+  objectKey: string;
+  keyFingerprint: string;
+  ciphertextSha256: string;
+  sizeBytes: number;
+  state?: AgentBackupObject["state"];
+  providerWriteStarted?: boolean;
+}): AgentBackupObject {
+  const now = new Date("2026-08-16T00:00:00.000Z");
+  const verified = params.state === "verified";
+  return {
+    id: params.id,
+    organization_id: ORGANIZATION_ID,
+    backup_id: BACKUP_ID,
+    copy_role: params.role,
+    component: "database",
+    chunk_index: 3,
+    state: params.state ?? "reserved",
+    transport: params.transport,
+    provider: params.provider,
+    endpoint_alias: params.authority.endpointAlias,
+    endpoint_identity_fingerprint: params.authority.endpointIdentityFingerprint,
+    bucket: params.authority.bucket,
+    region: params.authority.region,
+    object_key: params.objectKey,
+    key_fingerprint: params.keyFingerprint,
+    provider_write_started: params.providerWriteStarted ?? verified,
+    provider_version_id: verified ? "primary-version-1" : null,
+    content_hmac_sha256: CONTENT_HMAC,
+    ciphertext_sha256: params.ciphertextSha256,
+    size_bytes: params.sizeBytes,
+    provider_etag: null,
+    provider_checksum: verified
+      ? "sha256:base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+      : null,
+    upload_receipt_digest: verified ? "c".repeat(64) : null,
+    delete_receipt_digest: null,
+    verified_at: verified ? now : null,
+    deleted_at: null,
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+async function fixture(
+  options: {
+    readFailure?: Error;
+    bodyFailure?: Error;
+    putFailures?: number;
+    markerFailure?: Error;
+    receiptTransport?: "worker-r2-binding" | "s3-compatible";
+    receiptProvider?: "r2" | "s3";
+  } = {},
+) {
+  const body = ownedBytes(new TextEncoder().encode("encrypted-backup-chunk"));
+  const bodyDigest = await sha256(body);
+  const primaryKeyDigest = await sha256(PRIMARY_KEY);
+  const events: string[] = [];
+  const rows = new Map<"primary" | "secondary", AgentBackupObject>();
+  const uploadedBodies: Uint8Array[] = [];
+  let eof = false;
+  let remainingPutFailures = options.putFailures ?? 0;
+
+  const primaryAuthority: AgentBackupStorageAuthority = {
+    provider: "cloudflare-r2",
+    transport: "worker-r2",
+    endpointAlias: "primary-r2",
+    endpointIdentityFingerprint: FINGERPRINT,
+    bucket: "primary-bucket",
+    region: "auto",
+  };
+  const secondaryAuthority: AgentBackupStorageAuthority = {
+    provider: "hetzner-object-storage",
+    transport: "s3-compatible",
+    endpointAlias: "secondary-hetzner",
+    endpointIdentityFingerprint: `sha256:${"2".repeat(64)}`,
+    bucket: "secondary-bucket",
+    region: "fsn1",
+  };
+  const primary = objectRow({
+    id: "e0000000-0000-4000-8000-000000000005",
+    role: "primary",
+    provider: "cloudflare-r2",
+    transport: "worker-r2",
+    authority: primaryAuthority,
+    objectKey: PRIMARY_KEY,
+    keyFingerprint: primaryKeyDigest.hex,
+    ciphertextSha256: bodyDigest.hex,
+    sizeBytes: body.byteLength,
+    state: "verified",
+  });
+
+  function uploadStore(
+    authority: AgentBackupStorageAuthority,
+    role: "primary" | "secondary",
+  ): AgentBackupObjectStore {
+    return {
+      authority,
+      async getExactObject() {
+        throw new Error("unexpected upload-store GET");
+      },
+      async head() {
+        throw new Error("unexpected upload-store HEAD");
+      },
+      async putImmutable(input) {
+        await input.beforeWriteAttempt?.();
+        events.push(`put-${role}`);
+        uploadedBodies.push(
+          input.body instanceof ArrayBuffer
+            ? new Uint8Array(input.body)
+            : new Uint8Array(input.body.buffer, input.body.byteOffset, input.body.byteLength),
+        );
+        if (remainingPutFailures > 0) {
+          remainingPutFailures -= 1;
+          throw new TypeError("provider response lost");
+        }
+        const digest = await sha256(uploadedBodies.at(-1) ?? new Uint8Array());
+        const keyDigest = await sha256(input.key);
+        return {
+          locator: locator({
+            authority,
+            keyFingerprint: `sha256:${keyDigest.hex}`,
+            version: `${role}-version-1`,
+            ...(options.receiptTransport ? { transport: options.receiptTransport } : {}),
+            ...(options.receiptProvider ? { provider: options.receiptProvider } : {}),
+          }),
+          metadata: {
+            sizeBytes: body.byteLength,
+            checksum: { algorithm: "sha256", encoding: "base64", value: digest.base64 },
+          },
+          verifiedPresent: true,
+        };
+      },
+      async delete() {
+        throw new Error("unexpected upload-store delete");
+      },
+    };
+  }
+
+  const primaryReadStore: AgentBackupObjectStore = {
+    authority: primaryAuthority,
+    async getExactObject(input): Promise<ExactObjectRead> {
+      events.push("primary-get");
+      if (
+        input.locator.key !== PRIMARY_KEY ||
+        input.locator.receipt.keyFingerprint !== `sha256:${primaryKeyDigest.hex}`
+      ) {
+        throw new ObjectStorageLifecycleError(
+          "OBJECT_STORAGE_LOCATOR_MISMATCH",
+          "Exact object key does not match persisted authority",
+        );
+      }
+      let delivered = false;
+      const stream = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          if (!delivered) {
+            delivered = true;
+            controller.enqueue(body.slice(0, 5));
+            controller.enqueue(body.slice(5));
+            return;
+          }
+          if (options.bodyFailure) {
+            events.push("primary-body-error");
+            controller.error(options.bodyFailure);
+            return;
+          }
+          eof = true;
+          events.push("primary-eof");
+          controller.close();
+        },
+      });
+      return {
+        body: stream,
+        declaredMetadata: {
+          sizeBytes: body.byteLength,
+          checksum: { algorithm: "sha256", encoding: "base64", value: bodyDigest.base64 },
+        },
+        completion: options.readFailure
+          ? Promise.reject(options.readFailure)
+          : Promise.resolve({
+              locator: input.locator.receipt,
+              metadata: {
+                sizeBytes: body.byteLength,
+                checksum: { algorithm: "sha256", encoding: "base64", value: bodyDigest.base64 },
+              },
+              verifiedComplete: true,
+            }),
+      };
+    },
+    async head() {
+      throw new Error("unexpected primary HEAD");
+    },
+    async putImmutable() {
+      throw new Error("unexpected primary PUT");
+    },
+    async delete() {
+      throw new Error("unexpected primary delete");
+    },
+  };
+
+  const primaryUploadStore = uploadStore(primaryAuthority, "primary");
+  const secondaryStore = uploadStore(secondaryAuthority, "secondary");
+  const registry: AgentBackupObjectStoreRegistry = {
+    forNewObject(endpointAlias) {
+      if (endpointAlias === primaryAuthority.endpointAlias) return primaryUploadStore;
+      if (endpointAlias === secondaryAuthority.endpointAlias) return secondaryStore;
+      throw new Error("unknown endpoint alias");
+    },
+    forStoredObject(authority) {
+      if (JSON.stringify(authority) !== JSON.stringify(primaryAuthority)) {
+        throw new ObjectStorageLifecycleError(
+          "OBJECT_STORAGE_LOCATOR_MISMATCH",
+          "Stored primary authority no longer matches configuration",
+        );
+      }
+      return primaryReadStore;
+    },
+  };
+
+  const repository: AgentBackupObjectUploadRepository = {
+    async reserveObject(input) {
+      events.push(`reserve-${input.copyRole}`);
+      const existing = rows.get(input.copyRole);
+      if (existing) return existing;
+      const objectKey = input.copyRole === "primary" ? PRIMARY_KEY : SECONDARY_KEY;
+      const keyDigest = await sha256(objectKey);
+      const row = objectRow({
+        id:
+          input.copyRole === "primary"
+            ? "f0000000-0000-4000-8000-000000000006"
+            : "f0000000-0000-4000-8000-000000000007",
+        role: input.copyRole,
+        provider: input.provider,
+        transport: input.transport,
+        authority: {
+          provider: input.provider,
+          transport: input.transport,
+          endpointAlias: input.endpointAlias,
+          endpointIdentityFingerprint: input.endpointIdentityFingerprint,
+          bucket: input.bucket,
+          region: input.region,
+        },
+        objectKey,
+        keyFingerprint: keyDigest.hex,
+        ciphertextSha256: input.ciphertextSha256,
+        sizeBytes: input.sizeBytes,
+      });
+      rows.set(input.copyRole, row);
+      return row;
+    },
+    async markUploading(input) {
+      const role = [...rows.entries()].find(([, row]) => row.id === input.objectId)?.[0];
+      if (!role) throw new Error("reservation missing");
+      events.push(`marker-${role}`);
+      if (options.markerFailure) throw options.markerFailure;
+      const row = rows.get(role);
+      if (!row) throw new Error("reservation disappeared");
+      const updated = { ...row, state: "uploading" as const, provider_write_started: true };
+      rows.set(role, updated);
+      return updated;
+    },
+    async recordPresent(input) {
+      const entry = [...rows.entries()].find(([, row]) => row.id === input.objectId);
+      if (!entry) throw new Error("upload marker missing");
+      const [role, row] = entry;
+      events.push(`present-${role}`);
+      const updated = {
+        ...row,
+        state: "present" as const,
+        provider_version_id: input.providerVersionId ?? null,
+        provider_etag: input.providerEtag ?? null,
+        provider_checksum: input.providerChecksum ?? null,
+        upload_receipt_digest: input.uploadReceiptDigest,
+      };
+      rows.set(role, updated);
+      return updated;
+    },
+    async markVerified(input) {
+      const entry = [...rows.entries()].find(([, row]) => row.id === input.objectId);
+      if (!entry) throw new Error("present object missing");
+      const [role, row] = entry;
+      events.push(`verified-${role}`);
+      const updated = { ...row, state: "verified" as const, verified_at: new Date() };
+      rows.set(role, updated);
+      return updated;
+    },
+  };
+
+  return {
+    body,
+    bodyDigest,
+    events,
+    primary,
+    registry,
+    repository,
+    rows,
+    uploadedBodies,
+    reachedPrimaryEof: () => eof,
+  };
+}
+
+describe("immutable backup upload authority", () => {
+  test("uses the repository-owned key and marks write intent before every lease-gated PUT", async () => {
+    const prepared = await fixture();
+    const deadline = new Date(Date.now() + 30_000);
+    const result = await executeAgentBackupObjectUpload({
+      organizationId: ORGANIZATION_ID,
+      backupId: BACKUP_ID,
+      copyRole: "primary",
+      component: "database",
+      chunkIndex: 3,
+      endpointAlias: "primary-r2",
+      contentHmacSha256: CONTENT_HMAC,
+      ciphertextSha256: prepared.bodyDigest.hex,
+      execution: EXECUTION,
+      registry: prepared.registry,
+      repository: prepared.repository,
+      body: prepared.body,
+      deadline,
+      revalidateLease: async () => {
+        prepared.events.push("lease-primary");
+      },
+    });
+
+    expect(result).toMatchObject({ state: "verified", object_key: PRIMARY_KEY });
+    expect(prepared.events).toEqual([
+      "reserve-primary",
+      "marker-primary",
+      "lease-primary",
+      "put-primary",
+      "present-primary",
+      "verified-primary",
+    ]);
+    expect(prepared.uploadedBodies).toHaveLength(1);
+    expect(prepared.uploadedBodies[0]?.buffer).toBe(prepared.body.buffer);
+    expect(prepared.uploadedBodies[0]?.every((byte) => byte === 0)).toBe(true);
+  });
+
+  test("cannot adopt provider state when the post-marker lease fence fails", async () => {
+    const prepared = await fixture();
+    await expect(
+      executeAgentBackupObjectUpload({
+        organizationId: ORGANIZATION_ID,
+        backupId: BACKUP_ID,
+        copyRole: "primary",
+        component: "database",
+        chunkIndex: 3,
+        endpointAlias: "primary-r2",
+        contentHmacSha256: CONTENT_HMAC,
+        ciphertextSha256: prepared.bodyDigest.hex,
+        execution: EXECUTION,
+        registry: prepared.registry,
+        repository: prepared.repository,
+        body: ownedBytes(new TextEncoder().encode("encrypted-backup-chunk")),
+        revalidateLease: async () => {
+          prepared.events.push("lease-primary");
+          throw new Error("lease expired");
+        },
+      }),
+    ).rejects.toThrow("lease expired");
+
+    expect(prepared.events).toEqual(["reserve-primary", "marker-primary", "lease-primary"]);
+    expect(prepared.rows.get("primary")).toMatchObject({
+      state: "uploading",
+      provider_write_started: true,
+      upload_receipt_digest: null,
+    });
+    expect(prepared.uploadedBodies).toHaveLength(0);
+  });
+
+  test("never starts provider I/O when durable write-start publication fails", async () => {
+    const prepared = await fixture({ markerFailure: new Error("marker unavailable") });
+    await expect(
+      executeAgentBackupObjectUpload({
+        organizationId: ORGANIZATION_ID,
+        backupId: BACKUP_ID,
+        copyRole: "primary",
+        component: "database",
+        chunkIndex: 3,
+        endpointAlias: "primary-r2",
+        contentHmacSha256: CONTENT_HMAC,
+        ciphertextSha256: prepared.bodyDigest.hex,
+        execution: EXECUTION,
+        registry: prepared.registry,
+        repository: prepared.repository,
+        body: prepared.body,
+        revalidateLease: async () => {
+          prepared.events.push("lease-primary");
+        },
+      }),
+    ).rejects.toThrow("marker unavailable");
+    expect(prepared.events).toEqual(["reserve-primary", "marker-primary"]);
+    expect(prepared.uploadedBodies).toHaveLength(0);
+  });
+
+  test("fails closed when the durable marker response does not prove write authority", async () => {
+    const prepared = await fixture();
+    const regressedRepository: AgentBackupObjectUploadRepository = {
+      ...prepared.repository,
+      async markUploading(input) {
+        const marked = await prepared.repository.markUploading(input);
+        return { ...marked, state: "reserved", provider_write_started: false };
+      },
+    };
+    await expect(
+      executeAgentBackupObjectUpload({
+        organizationId: ORGANIZATION_ID,
+        backupId: BACKUP_ID,
+        copyRole: "primary",
+        component: "database",
+        chunkIndex: 3,
+        endpointAlias: "primary-r2",
+        contentHmacSha256: CONTENT_HMAC,
+        ciphertextSha256: prepared.bodyDigest.hex,
+        execution: EXECUTION,
+        registry: prepared.registry,
+        repository: regressedRepository,
+        body: prepared.body,
+        revalidateLease: async () => {
+          prepared.events.push("lease-primary");
+        },
+      }),
+    ).rejects.toMatchObject({ code: "OBJECT_STORAGE_LOCATOR_MISMATCH" });
+    expect(prepared.events).toEqual(["reserve-primary", "marker-primary"]);
+    expect(prepared.uploadedBodies).toHaveLength(0);
+  });
+
+  test("rejects provider and transport receipt confusion before durable settlement", async () => {
+    for (const override of [
+      { receiptProvider: "s3" as const },
+      { receiptTransport: "s3-compatible" as const },
+    ]) {
+      const prepared = await fixture(override);
+      await expect(
+        executeAgentBackupObjectUpload({
+          organizationId: ORGANIZATION_ID,
+          backupId: BACKUP_ID,
+          copyRole: "primary",
+          component: "database",
+          chunkIndex: 3,
+          endpointAlias: "primary-r2",
+          contentHmacSha256: CONTENT_HMAC,
+          ciphertextSha256: prepared.bodyDigest.hex,
+          execution: EXECUTION,
+          registry: prepared.registry,
+          repository: prepared.repository,
+          body: prepared.body,
+          revalidateLease: async () => {
+            prepared.events.push("lease-primary");
+          },
+        }),
+      ).rejects.toMatchObject({ code: "OBJECT_STORAGE_LOCATOR_MISMATCH" });
+      expect(prepared.events).not.toContain("present-primary");
+    }
+  });
+
+  test("replays an uploading reservation after response loss without caller-owned keys", async () => {
+    const prepared = await fixture({ putFailures: 1 });
+    const freshBody = () => ownedBytes(new TextEncoder().encode("encrypted-backup-chunk"));
+    const upload = () =>
+      executeAgentBackupObjectUpload({
+        organizationId: ORGANIZATION_ID,
+        backupId: BACKUP_ID,
+        copyRole: "primary",
+        component: "database",
+        chunkIndex: 3,
+        endpointAlias: "primary-r2",
+        contentHmacSha256: CONTENT_HMAC,
+        ciphertextSha256: prepared.bodyDigest.hex,
+        execution: EXECUTION,
+        registry: prepared.registry,
+        repository: prepared.repository,
+        body: freshBody(),
+        revalidateLease: async () => {
+          prepared.events.push("lease-primary");
+        },
+      });
+
+    await expect(upload()).rejects.toThrow("provider response lost");
+    await expect(upload()).resolves.toMatchObject({ state: "verified", object_key: PRIMARY_KEY });
+    expect(prepared.uploadedBodies).toHaveLength(2);
+    expect(prepared.uploadedBodies.every((bytes) => bytes.every((byte) => byte === 0))).toBe(true);
+  });
+});
+
+describe("secondary backup replication", () => {
+  test("drains and verifies the exact primary before repository-owned secondary publication", async () => {
+    const prepared = await fixture();
+    const deadline = new Date(Date.now() + 30_000);
+    const result = await executeAgentBackupSecondaryObjectReplication({
+      organizationId: ORGANIZATION_ID,
+      backupId: BACKUP_ID,
+      primaryObject: prepared.primary,
+      secondaryEndpointAlias: "secondary-hetzner",
+      scope: "production-eu",
+      operationId: OPERATION_ID,
+      manifestDigest: "a".repeat(64),
+      registry: prepared.registry,
+      execution: EXECUTION,
+      deadline,
+      revalidateLease: async () => {
+        prepared.events.push("lease-secondary");
+      },
+      uploadRepository: prepared.repository,
+    });
+
+    expect(result).toMatchObject({
+      state: "verified",
+      copy_role: "secondary",
+      object_key: SECONDARY_KEY,
+    });
+    expect(prepared.reachedPrimaryEof()).toBe(true);
+    expect(prepared.events).toEqual([
+      "primary-get",
+      "primary-eof",
+      "reserve-secondary",
+      "marker-secondary",
+      "lease-secondary",
+      "put-secondary",
+      "present-secondary",
+      "verified-secondary",
+    ]);
+    expect(prepared.uploadedBodies[0]?.every((byte) => byte === 0)).toBe(true);
+  });
+
+  test("does not reserve or mutate secondary storage after exact-read response loss", async () => {
+    const prepared = await fixture({
+      readFailure: new ObjectStorageLifecycleError(
+        "OBJECT_STORAGE_READ_HASH_MISMATCH",
+        "Exact primary read failed ciphertext verification",
+      ),
+    });
+    await expect(
+      executeAgentBackupSecondaryObjectReplication({
+        organizationId: ORGANIZATION_ID,
+        backupId: BACKUP_ID,
+        primaryObject: prepared.primary,
+        secondaryEndpointAlias: "secondary-hetzner",
+        scope: "production-eu",
+        operationId: OPERATION_ID,
+        manifestDigest: "a".repeat(64),
+        registry: prepared.registry,
+        execution: EXECUTION,
+        revalidateLease: async () => undefined,
+        uploadRepository: prepared.repository,
+      }),
+    ).rejects.toMatchObject({ code: "OBJECT_STORAGE_READ_HASH_MISMATCH" });
+    expect(prepared.events).toEqual(["primary-get", "primary-eof"]);
+    expect(prepared.rows.has("secondary")).toBe(false);
+    expect(prepared.uploadedBodies).toHaveLength(0);
+  });
+
+  test("observes completion rejection when the provider body fails first", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      const prepared = await fixture({
+        bodyFailure: new Error("provider body failed"),
+        readFailure: new Error("completion also failed"),
+      });
+      await expect(
+        executeAgentBackupSecondaryObjectReplication({
+          organizationId: ORGANIZATION_ID,
+          backupId: BACKUP_ID,
+          primaryObject: prepared.primary,
+          secondaryEndpointAlias: "secondary-hetzner",
+          scope: "production-eu",
+          operationId: OPERATION_ID,
+          manifestDigest: "a".repeat(64),
+          registry: prepared.registry,
+          execution: EXECUTION,
+          revalidateLease: async () => undefined,
+          uploadRepository: prepared.repository,
+        }),
+      ).rejects.toThrow("provider body failed");
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(unhandled).toEqual([]);
+      expect(prepared.events).toEqual(["primary-get", "primary-body-error"]);
+      expect(prepared.rows.has("secondary")).toBe(false);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-backup-catalog-worker.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-catalog-worker.ts
@@ -6,6 +6,16 @@
  * Callers never provide an arbitrary successful receipt.
  */
 
+import type {
+  AgentBackupOperationExecution,
+  ReserveAgentBackupObjectInput,
+} from "../../db/repositories/agent-backup-catalog";
+import {
+  markAgentBackupObjectUploading,
+  markAgentBackupObjectVerified,
+  recordAgentBackupObjectPresent,
+  reserveAgentBackupObject,
+} from "../../db/repositories/agent-backup-catalog";
 import type { AgentBackupGcClaim } from "../../db/repositories/agent-backup-gc";
 import {
   adoptAgentBackupGcObservedLocator,
@@ -19,6 +29,8 @@ import type {
   AgentBackupStorageAuthority,
 } from "../storage/agent-backup-object-store";
 import {
+  type ExactObjectRead,
+  MAX_IMMUTABLE_SINGLE_PUT_BYTES,
   type ObjectChecksumReceipt,
   type ObjectDeleteReceipt,
   type ObjectHeadReceipt,
@@ -31,7 +43,11 @@ const MAX_GC_RETRY_DELAY_MS = 6 * 60 * 60 * 1_000;
 async function sha256Bytes(bytes: Uint8Array): Promise<Uint8Array> {
   const stableBytes = new Uint8Array(new ArrayBuffer(bytes.byteLength));
   stableBytes.set(bytes);
-  return new Uint8Array(await globalThis.crypto.subtle.digest("SHA-256", stableBytes));
+  try {
+    return new Uint8Array(await globalThis.crypto.subtle.digest("SHA-256", stableBytes));
+  } finally {
+    stableBytes.fill(0);
+  }
 }
 
 function bytesToHex(bytes: Uint8Array): string {
@@ -65,14 +81,25 @@ function sha256HexToBase64(value: string): string {
   for (let index = 0; index < bytes.length; index += 1) {
     bytes[index] = Number.parseInt(value.slice(index * 2, index * 2 + 2), 16);
   }
-  return bytesToBase64(bytes);
+  try {
+    return bytesToBase64(bytes);
+  } finally {
+    bytes.fill(0);
+  }
 }
 
 async function sha256Canonical(value: unknown): Promise<string> {
-  return bytesToHex(await sha256Bytes(new TextEncoder().encode(JSON.stringify(value))));
+  const digest = await sha256Bytes(new TextEncoder().encode(JSON.stringify(value)));
+  try {
+    return bytesToHex(digest);
+  } finally {
+    digest.fill(0);
+  }
 }
 
-function storedAuthority(object: AgentBackupObject): AgentBackupStorageAuthority {
+export function storedAgentBackupObjectAuthority(
+  object: AgentBackupObject,
+): AgentBackupStorageAuthority {
   return {
     provider: object.provider,
     transport: object.transport,
@@ -87,7 +114,12 @@ function requireLocatorMatchesObject(
   object: AgentBackupObject,
   observed: ObjectHeadReceipt["locator"],
 ): void {
+  const expectedTransport =
+    object.transport === "worker-r2" ? "worker-r2-binding" : "s3-compatible";
+  const expectedProvider = object.provider === "cloudflare-r2" ? "r2" : "s3";
   if (
+    observed.transport !== expectedTransport ||
+    observed.provider !== expectedProvider ||
     observed.endpointAlias !== object.endpoint_alias ||
     observed.backendIdentityFingerprint !== object.endpoint_identity_fingerprint ||
     observed.bucket !== object.bucket ||
@@ -235,6 +267,377 @@ function checksumIdentity(checksum: ObjectChecksumReceipt): string {
   return `${checksum.algorithm}:${checksum.encoding}:${checksum.value}`;
 }
 
+function catalogTransport(authority: AgentBackupStorageAuthority): "worker-r2" | "s3-compatible" {
+  return authority.transport;
+}
+
+function requireStoreMatchesRole(
+  store: AgentBackupObjectStore,
+  copyRole: "primary" | "secondary",
+): void {
+  const valid =
+    (copyRole === "primary" && store.authority.provider === "cloudflare-r2") ||
+    (copyRole === "secondary" && store.authority.provider === "hetzner-object-storage");
+  if (!valid) {
+    throw new ObjectStorageLifecycleError(
+      "OBJECT_STORAGE_LOCATOR_MISMATCH",
+      "Backup copy role does not match the configured storage authority",
+    );
+  }
+}
+
+function transferredBytes(body: ArrayBuffer | Uint8Array): Uint8Array<ArrayBuffer> {
+  if (body instanceof ArrayBuffer) return new Uint8Array(body);
+  if (body.buffer instanceof ArrayBuffer) {
+    return new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
+  }
+  const copy = new Uint8Array(new ArrayBuffer(body.byteLength));
+  copy.set(body);
+  return copy;
+}
+
+function wipeInputBytes(body: ArrayBuffer | Uint8Array): void {
+  (body instanceof ArrayBuffer ? new Uint8Array(body) : body).fill(0);
+}
+
+export interface ExecuteAgentBackupObjectUploadInput
+  extends Omit<
+    ReserveAgentBackupObjectInput,
+    "transport" | "provider" | "endpointIdentityFingerprint" | "bucket" | "region" | "sizeBytes"
+  > {
+  registry: AgentBackupObjectStoreRegistry;
+  /** Transferred mutable bytes; the worker wipes this exact range on settlement. */
+  body: ArrayBuffer | Uint8Array;
+  contentType?: string;
+  signal?: AbortSignal;
+  /** Absolute wall-clock deadline shared by PUT, HEAD, and retry backoff. */
+  deadline?: Date;
+  /** Revalidates the fenced operation lease before provider mutation. */
+  revalidateLease(): Promise<void>;
+  repository?: AgentBackupObjectUploadRepository;
+}
+
+export interface AgentBackupObjectUploadRepository {
+  reserveObject: typeof reserveAgentBackupObject;
+  markUploading: typeof markAgentBackupObjectUploading;
+  recordPresent: typeof recordAgentBackupObjectPresent;
+  markVerified: typeof markAgentBackupObjectVerified;
+}
+
+const DEFAULT_UPLOAD_REPOSITORY: AgentBackupObjectUploadRepository = {
+  reserveObject: reserveAgentBackupObject,
+  markUploading: markAgentBackupObjectUploading,
+  recordPresent: recordAgentBackupObjectPresent,
+  markVerified: markAgentBackupObjectVerified,
+};
+
+/**
+ * Reserve a repository-owned key, durably mark provider-write intent, then
+ * create and verify one immutable encrypted object under the fenced lease.
+ */
+export async function executeAgentBackupObjectUpload(
+  input: ExecuteAgentBackupObjectUploadInput,
+): Promise<AgentBackupObject> {
+  if (input.body.byteLength > MAX_IMMUTABLE_SINGLE_PUT_BYTES) {
+    wipeInputBytes(input.body);
+    throw new ObjectStorageLifecycleError(
+      "OBJECT_STORAGE_UPLOAD_TOO_LARGE",
+      "Immutable single-PUT object exceeds the bounded upload limit",
+    );
+  }
+  const repository = input.repository ?? DEFAULT_UPLOAD_REPOSITORY;
+  const store = input.registry.forNewObject(input.endpointAlias);
+  requireStoreMatchesRole(store, input.copyRole);
+  const body = transferredBytes(input.body);
+  let bodyDigest: Uint8Array | undefined;
+  try {
+    bodyDigest = await sha256Bytes(body);
+    const bodyDigestHex = bytesToHex(bodyDigest);
+    const bodyDigestBase64 = bytesToBase64(bodyDigest);
+    if (bodyDigestHex !== input.ciphertextSha256) {
+      throw new ObjectStorageLifecycleError(
+        "OBJECT_STORAGE_METADATA_INVALID",
+        "Encrypted backup chunk does not match its catalogue ciphertext digest",
+      );
+    }
+
+    const reserved = await repository.reserveObject({
+      organizationId: input.organizationId,
+      backupId: input.backupId,
+      copyRole: input.copyRole,
+      component: input.component,
+      chunkIndex: input.chunkIndex,
+      transport: catalogTransport(store.authority),
+      provider: store.authority.provider,
+      endpointAlias: store.authority.endpointAlias,
+      endpointIdentityFingerprint: store.authority.endpointIdentityFingerprint,
+      bucket: store.authority.bucket,
+      region: store.authority.region,
+      contentHmacSha256: input.contentHmacSha256,
+      ciphertextSha256: input.ciphertextSha256,
+      sizeBytes: body.byteLength,
+      execution: input.execution,
+    });
+    const uploading = await repository.markUploading({
+      organizationId: input.organizationId,
+      objectId: reserved.id,
+      execution: input.execution,
+    });
+    const markerMatchesReservation =
+      uploading.id === reserved.id &&
+      uploading.organization_id === reserved.organization_id &&
+      uploading.backup_id === reserved.backup_id &&
+      uploading.copy_role === reserved.copy_role &&
+      uploading.component === reserved.component &&
+      uploading.chunk_index === reserved.chunk_index &&
+      uploading.transport === reserved.transport &&
+      uploading.provider === reserved.provider &&
+      uploading.endpoint_alias === reserved.endpoint_alias &&
+      uploading.object_key === reserved.object_key &&
+      uploading.key_fingerprint === reserved.key_fingerprint &&
+      uploading.endpoint_identity_fingerprint === reserved.endpoint_identity_fingerprint &&
+      uploading.bucket === reserved.bucket &&
+      uploading.region === reserved.region &&
+      uploading.content_hmac_sha256 === reserved.content_hmac_sha256 &&
+      uploading.ciphertext_sha256 === reserved.ciphertext_sha256 &&
+      uploading.size_bytes === reserved.size_bytes &&
+      uploading.provider_write_started &&
+      (uploading.state === "uploading" ||
+        uploading.state === "present" ||
+        uploading.state === "verified");
+    if (!markerMatchesReservation) {
+      throw new ObjectStorageLifecycleError(
+        "OBJECT_STORAGE_LOCATOR_MISMATCH",
+        "Durable backup write-start marker does not match the reserved object authority",
+      );
+    }
+
+    // The storage boundary runs this fence after the durable write-start marker
+    // and immediately before every bounded provider PUT attempt.
+    const uploaded = await store.putImmutable({
+      key: uploading.object_key,
+      body,
+      contentType: input.contentType,
+      signal: input.signal,
+      deadline: input.deadline,
+      beforeWriteAttempt: input.revalidateLease,
+      transferBodyOwnership: true,
+    });
+    requireLocatorMatchesObject(uploading, uploaded.locator);
+    if (
+      uploaded.metadata.sizeBytes !== uploading.size_bytes ||
+      uploaded.metadata.checksum.algorithm !== "sha256" ||
+      uploaded.metadata.checksum.encoding !== "base64" ||
+      uploaded.metadata.checksum.value !== bodyDigestBase64
+    ) {
+      throw new ObjectStorageLifecycleError(
+        "OBJECT_STORAGE_METADATA_INVALID",
+        "Provider upload receipt does not match the encrypted catalogue object",
+      );
+    }
+    const uploadReceiptDigest = await sha256Canonical({
+      version: 1,
+      objectId: uploading.id,
+      organizationId: uploading.organization_id,
+      backupId: uploading.backup_id,
+      copyRole: uploading.copy_role,
+      endpointIdentityFingerprint: uploading.endpoint_identity_fingerprint,
+      keyFingerprint: uploading.key_fingerprint,
+      locator: uploaded.locator.toJSON(),
+      sizeBytes: uploaded.metadata.sizeBytes,
+      checksum: uploaded.metadata.checksum,
+    });
+    const version = providerReceiptFields(uploaded.locator);
+    const present = await repository.recordPresent({
+      organizationId: input.organizationId,
+      objectId: uploading.id,
+      ...version,
+      providerChecksum: checksumIdentity(uploaded.metadata.checksum),
+      uploadReceiptDigest,
+      execution: input.execution,
+    });
+    return await repository.markVerified({
+      organizationId: input.organizationId,
+      objectId: present.id,
+      uploadReceiptDigest,
+      execution: input.execution,
+    });
+  } finally {
+    body.fill(0);
+    bodyDigest?.fill(0);
+  }
+}
+
+/** Rebuild the exact private read locator from one verified catalogue row. */
+export function storedAgentBackupObjectLocator(object: AgentBackupObject): {
+  key: string;
+  receipt: ObjectLocatorReceipt;
+} {
+  if (
+    object.state !== "verified" ||
+    !object.provider_write_started ||
+    !object.upload_receipt_digest ||
+    !/^[0-9a-f]{64}$/.test(object.upload_receipt_digest) ||
+    !/^[0-9a-f]{64}$/.test(object.key_fingerprint)
+  ) {
+    throw new ObjectStorageLifecycleError(
+      "OBJECT_STORAGE_LOCATOR_UNAVAILABLE",
+      "Exact backup read requires a verified persisted upload receipt",
+    );
+  }
+  const receipt = storedObjectLocator(object);
+  if (!receipt) {
+    throw new ObjectStorageLifecycleError(
+      "OBJECT_STORAGE_LOCATOR_UNAVAILABLE",
+      "Verified backup object is missing its persisted provider generation",
+    );
+  }
+  return { key: object.object_key, receipt };
+}
+
+/**
+ * Drain a verified provider read into a fresh bounded buffer. Declared HEAD
+ * metadata is not authority: the completion receipt must resolve after EOF.
+ */
+export async function readExactAgentBackupObjectToFreshBuffer(params: {
+  read: ExactObjectRead;
+  expectedSize: number;
+}): Promise<Uint8Array<ArrayBuffer>> {
+  if (
+    !Number.isSafeInteger(params.expectedSize) ||
+    params.expectedSize < 0 ||
+    params.expectedSize > MAX_IMMUTABLE_SINGLE_PUT_BYTES
+  ) {
+    throw new ObjectStorageLifecycleError(
+      "OBJECT_STORAGE_UPLOAD_TOO_LARGE",
+      "Secondary replication object exceeds the bounded immutable PUT limit",
+    );
+  }
+  const completion = params.read.completion.then(
+    (receipt) => ({ status: "fulfilled" as const, receipt }),
+    (error: unknown) => ({ status: "rejected" as const, error }),
+  );
+  const bytes = new Uint8Array(new ArrayBuffer(params.expectedSize));
+  const reader = params.read.body.getReader();
+  let offset = 0;
+  try {
+    for (;;) {
+      const next = await reader.read();
+      if (next.done) break;
+      if (!(next.value instanceof Uint8Array) || next.value.byteLength === 0) {
+        throw new ObjectStorageLifecycleError(
+          "OBJECT_STORAGE_READ_FAILED",
+          "Exact backup read returned an invalid byte fragment",
+        );
+      }
+      if (offset > bytes.byteLength - next.value.byteLength) {
+        throw new ObjectStorageLifecycleError(
+          "OBJECT_STORAGE_READ_OVERFLOW",
+          "Exact backup read exceeded its bounded replication buffer",
+        );
+      }
+      bytes.set(next.value, offset);
+      offset += next.value.byteLength;
+    }
+    const settledCompletion = await completion;
+    if (settledCompletion.status === "rejected") throw settledCompletion.error;
+    const { receipt } = settledCompletion;
+    if (!receipt.verifiedComplete || offset !== bytes.byteLength) {
+      throw new ObjectStorageLifecycleError(
+        "OBJECT_STORAGE_READ_TRUNCATED",
+        "Exact backup read did not reach its verified byte length",
+      );
+    }
+    return bytes;
+  } catch (cause) {
+    bytes.fill(0);
+    try {
+      await reader.cancel();
+    } catch {
+      // error-policy:J6 cancellation cannot replace the verified read failure.
+    }
+    throw cause;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export interface ExecuteAgentBackupSecondaryObjectReplicationInput {
+  organizationId: string;
+  backupId: string;
+  primaryObject: AgentBackupObject;
+  secondaryEndpointAlias: string;
+  /** Retained in the publication boundary; object keys are repository-owned. */
+  scope: string;
+  operationId: string;
+  manifestDigest: string;
+  registry: AgentBackupObjectStoreRegistry;
+  execution: AgentBackupOperationExecution;
+  revalidateLease(): Promise<void>;
+  signal?: AbortSignal;
+  deadline?: Date;
+  uploadRepository?: AgentBackupObjectUploadRepository;
+}
+
+/** Replicate only from the persisted exact primary generation. */
+export async function executeAgentBackupSecondaryObjectReplication(
+  input: ExecuteAgentBackupSecondaryObjectReplicationInput,
+): Promise<AgentBackupObject> {
+  const primary = input.primaryObject;
+  if (
+    primary.organization_id !== input.organizationId ||
+    primary.backup_id !== input.backupId ||
+    primary.copy_role !== "primary" ||
+    primary.provider !== "cloudflare-r2"
+  ) {
+    throw new ObjectStorageLifecycleError(
+      "OBJECT_STORAGE_LOCATOR_MISMATCH",
+      "Secondary replication source does not match the persisted primary authority",
+    );
+  }
+  if (primary.size_bytes > MAX_IMMUTABLE_SINGLE_PUT_BYTES) {
+    throw new ObjectStorageLifecycleError(
+      "OBJECT_STORAGE_UPLOAD_TOO_LARGE",
+      "Secondary replication requires a bounded single-PUT source object",
+    );
+  }
+  const primaryStore = input.registry.forStoredObject(storedAgentBackupObjectAuthority(primary));
+  requireStoreMatchesRole(primaryStore, "primary");
+  const read = await primaryStore.getExactObject({
+    locator: storedAgentBackupObjectLocator(primary),
+    expectedSize: primary.size_bytes,
+    expectedCipherSha256: primary.ciphertext_sha256,
+    signal: input.signal,
+    deadline: input.deadline,
+  });
+  const body = await readExactAgentBackupObjectToFreshBuffer({
+    read,
+    expectedSize: primary.size_bytes,
+  });
+  try {
+    return await executeAgentBackupObjectUpload({
+      organizationId: input.organizationId,
+      backupId: input.backupId,
+      copyRole: "secondary",
+      component: primary.component,
+      chunkIndex: primary.chunk_index,
+      endpointAlias: input.secondaryEndpointAlias,
+      contentHmacSha256: primary.content_hmac_sha256,
+      ciphertextSha256: primary.ciphertext_sha256,
+      execution: input.execution,
+      registry: input.registry,
+      body,
+      contentType: "application/octet-stream",
+      revalidateLease: input.revalidateLease,
+      signal: input.signal,
+      deadline: input.deadline,
+      ...(input.uploadRepository ? { repository: input.uploadRepository } : {}),
+    });
+  } finally {
+    body.fill(0);
+  }
+}
+
 async function deletionReceiptDigest(
   claim: AgentBackupGcClaim,
   receipt: ObjectDeleteReceipt,
@@ -265,7 +668,7 @@ export async function executeAgentBackupGcClaim(params: {
   if (!generation || !ownerId) {
     throw new Error("Claimed backup GC intent is missing its execution fence");
   }
-  const store = params.registry.forStoredObject(storedAuthority(claim.object));
+  const store = params.registry.forStoredObject(storedAgentBackupObjectAuthority(claim.object));
   const resolved = await resolveGcDeletionLocator(store, claim);
   const receipt = await store.delete({
     key: resolved.claim.object.object_key,

--- a/packages/cloud/shared/src/lib/services/agent-backup-publication-executor.test.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-publication-executor.test.ts
@@ -1,0 +1,524 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type AgentBackupOperationClaim,
+  agentBackupObjectInventoryDigest,
+} from "../../db/repositories/agent-backup-catalog";
+import type { AgentBackupObject } from "../../db/schemas/agent-backup-catalog";
+import type { AgentBackupCatalogState } from "../../db/schemas/agent-sandboxes";
+import type { AgentBackupObjectStoreRegistry } from "../storage/agent-backup-object-store";
+import {
+  type AgentBackupCapturedPublicationChunk,
+  type AgentBackupCapturedPublicationSource,
+  type AgentBackupPublicationExecutorDependencies,
+  AgentBackupPublicationStageError,
+  executeAgentBackupPostCapturePublication,
+  executeAgentBackupPrimaryPublication,
+  executeAgentBackupSecondaryReplication,
+} from "./agent-backup-publication-executor";
+
+const ORGANIZATION_ID = "a0000000-0000-4000-8000-000000000001";
+const AGENT_ID = "b0000000-0000-4000-8000-000000000002";
+const BACKUP_ID = "c0000000-0000-4000-8000-000000000003";
+const OPERATION_ID = "d0000000-0000-4000-8000-000000000004";
+const LIFECYCLE_GENERATION = "e0000000-0000-4000-8000-000000000005";
+const CLAIM_GENERATION = "f0000000-0000-4000-8000-000000000006";
+const MANIFEST_DIGEST = "a".repeat(64);
+const UNUSED_REGISTRY = Object.freeze({}) as AgentBackupObjectStoreRegistry;
+
+function ownedBytes(input: Uint8Array): Uint8Array<ArrayBuffer> {
+  const output = new Uint8Array(new ArrayBuffer(input.byteLength));
+  output.set(input);
+  return output;
+}
+
+async function digestHex(input: Uint8Array): Promise<string> {
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", ownedBytes(input)));
+  return Array.from(digest, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function publicationFixture() {
+  const bodies = [
+    ownedBytes(new TextEncoder().encode("encrypted-database-0")),
+    ownedBytes(new TextEncoder().encode("encrypted-state-files-0")),
+  ];
+  const chunks: AgentBackupCapturedPublicationChunk[] = [
+    {
+      component: "database",
+      chunkIndex: 0,
+      contentHmacSha256: "b".repeat(64),
+      ciphertextSha256: await digestHex(bodies[0] ?? new Uint8Array()),
+      sizeBytes: bodies[0]?.byteLength ?? 0,
+    },
+    {
+      component: "state-files",
+      chunkIndex: 0,
+      contentHmacSha256: "c".repeat(64),
+      ciphertextSha256: await digestHex(bodies[1] ?? new Uint8Array()),
+      sizeBytes: bodies[1]?.byteLength ?? 0,
+    },
+  ];
+  return {
+    bodies,
+    chunks,
+    inventoryDigest: await agentBackupObjectInventoryDigest(chunks),
+  };
+}
+
+function claim(params: {
+  state: AgentBackupCatalogState;
+  inventoryDigest: string;
+  resumeState?: AgentBackupCatalogState | null;
+}): AgentBackupOperationClaim {
+  return {
+    ownerId: "publication-worker-1",
+    generation: CLAIM_GENERATION,
+    backup: {
+      id: BACKUP_ID,
+      catalog_organization_id: ORGANIZATION_ID,
+      catalog_agent_id: AGENT_ID,
+      backup_operation_id: OPERATION_ID,
+      lifecycle_generation: LIFECYCLE_GENERATION,
+      lifecycle_revision: 7n,
+      catalog_state: params.state,
+      catalog_resume_state: params.resumeState ?? null,
+      catalog_attempts: 1,
+      manifest_digest: MANIFEST_DIGEST,
+      manifest_object_count: 2,
+      object_inventory_digest: params.inventoryDigest,
+    },
+  } as AgentBackupOperationClaim;
+}
+
+function primaryObject(
+  chunk: AgentBackupCapturedPublicationChunk,
+  overrides: Partial<AgentBackupObject> = {},
+): AgentBackupObject {
+  return {
+    organization_id: ORGANIZATION_ID,
+    backup_id: BACKUP_ID,
+    copy_role: "primary",
+    provider: "cloudflare-r2",
+    state: "verified",
+    component: chunk.component,
+    chunk_index: chunk.chunkIndex,
+    content_hmac_sha256: chunk.contentHmacSha256,
+    ciphertext_sha256: chunk.ciphertextSha256,
+    size_bytes: chunk.sizeBytes,
+    ...overrides,
+  } as AgentBackupObject;
+}
+
+function sourceFixture(params: {
+  chunks: readonly AgentBackupCapturedPublicationChunk[];
+  bodies: readonly Uint8Array[];
+  inventoryDigest: string;
+  events: string[];
+  returnedBodies: Uint8Array[];
+}): AgentBackupCapturedPublicationSource {
+  return {
+    organizationId: ORGANIZATION_ID,
+    agentId: AGENT_ID,
+    backupId: BACKUP_ID,
+    operationId: OPERATION_ID,
+    manifestDigest: MANIFEST_DIGEST,
+    objectInventoryDigest: params.inventoryDigest,
+    chunks: params.chunks,
+    async beginPrimaryPublication() {
+      params.events.push("source-begin");
+    },
+    async readCiphertextChunk(chunk) {
+      params.events.push(`source-read:${chunk.component}:${chunk.chunkIndex}`);
+      const index = params.chunks.findIndex(
+        (candidate) =>
+          candidate.component === chunk.component && candidate.chunkIndex === chunk.chunkIndex,
+      );
+      const sourceBody = params.bodies[index];
+      if (!sourceBody) throw new Error("missing test chunk body");
+      const body = sourceBody.slice();
+      params.returnedBodies.push(body);
+      return body;
+    },
+    async markPrimaryChunkUploaded(chunk) {
+      params.events.push(`source-uploaded:${chunk.component}:${chunk.chunkIndex}`);
+    },
+    async markPrimaryPublished() {
+      params.events.push("source-published");
+    },
+    async close() {
+      params.events.push("source-close");
+    },
+  };
+}
+
+function dependencies(params: {
+  initialClaim: AgentBackupOperationClaim;
+  events: string[];
+  upload?: AgentBackupPublicationExecutorDependencies["uploadObject"];
+  listPrimary?: AgentBackupPublicationExecutorDependencies["listVerifiedPrimaryObjects"];
+  replicate?: AgentBackupPublicationExecutorDependencies["replicateObject"];
+  heartbeat?: AgentBackupPublicationExecutorDependencies["heartbeatOperation"];
+}): AgentBackupPublicationExecutorDependencies {
+  let durableBackup = params.initialClaim.backup;
+  return {
+    heartbeatOperation:
+      params.heartbeat ??
+      (async () => {
+        params.events.push("heartbeat");
+      }),
+    async transitionOperation(input) {
+      params.events.push(`transition:${input.expectedState}->${input.to}`);
+      if (durableBackup.catalog_state !== input.expectedState) {
+        throw new Error("test transition CAS mismatch");
+      }
+      durableBackup = {
+        ...durableBackup,
+        catalog_state: input.to,
+        catalog_resume_state: null,
+      };
+      return durableBackup;
+    },
+    listVerifiedPrimaryObjects:
+      params.listPrimary ??
+      (async () => {
+        throw new Error("unexpected primary inventory read");
+      }),
+    uploadObject:
+      params.upload ??
+      (async () => {
+        throw new Error("unexpected primary upload");
+      }),
+    replicateObject:
+      params.replicate ??
+      (async () => {
+        throw new Error("unexpected secondary replication");
+      }),
+    now: () => Date.parse("2026-08-16T03:00:00.000Z"),
+  };
+}
+
+describe("post-capture backup publication", () => {
+  test("publishes repository-owned primary slots, journals every chunk, and zeroes spool copies", async () => {
+    const fixture = await publicationFixture();
+    const initialClaim = claim({ state: "captured", inventoryDigest: fixture.inventoryDigest });
+    const events: string[] = [];
+    const returnedBodies: Uint8Array[] = [];
+    const slots: string[] = [];
+    const result = await executeAgentBackupPrimaryPublication({
+      claim: initialClaim,
+      leaseMs: 60_000,
+      scope: "production-eu",
+      primaryEndpointAlias: "primary-r2",
+      registry: UNUSED_REGISTRY,
+      resolveSource: async ({ claim: sourceClaim }) => {
+        events.push(`source-resolve:${sourceClaim.backup.catalog_state}`);
+        return sourceFixture({
+          chunks: fixture.chunks,
+          bodies: fixture.bodies,
+          inventoryDigest: fixture.inventoryDigest,
+          events,
+          returnedBodies,
+        });
+      },
+      dependencies: dependencies({
+        initialClaim,
+        events,
+        upload: async (input) => {
+          expect(typeof input.revalidateLease).toBe("function");
+          await input.revalidateLease?.();
+          events.push(`upload:${input.component}:${input.chunkIndex}`);
+          expect("objectKey" in input).toBe(false);
+          expect(input.deadline).toEqual(new Date("2026-08-16T03:02:00.000Z"));
+          slots.push(`${input.component}:${input.chunkIndex}:${input.copyRole}`);
+          expect(input.body.some((byte) => byte !== 0)).toBe(true);
+          return primaryObject(fixture.chunks[input.chunkIndex] ?? fixture.chunks[0]!);
+        },
+      }),
+    });
+
+    expect(result.backup.catalog_state).toBe("primary_verified");
+    expect(slots).toEqual(["database:0:primary", "state-files:0:primary"]);
+    expect(returnedBodies.every((body) => body.every((byte) => byte === 0))).toBe(true);
+    expect(events.filter((event) => event.startsWith("source-uploaded:"))).toEqual([
+      "source-uploaded:database:0",
+      "source-uploaded:state-files:0",
+    ]);
+    expect(events.indexOf("source-resolve:captured")).toBeLessThan(
+      events.indexOf("transition:captured->uploading"),
+    );
+    expect(events.at(-1)).toBe("source-close");
+  });
+
+  test("replays repository-owned slots after crash on chunk N and resumes the exact failed state", async () => {
+    const fixture = await publicationFixture();
+    const firstClaim = claim({ state: "captured", inventoryDigest: fixture.inventoryDigest });
+    const events: string[] = [];
+    const slots: string[] = [];
+    let uploadAttempt = 0;
+    const shared = {
+      events,
+      upload: async (
+        input: Parameters<AgentBackupPublicationExecutorDependencies["uploadObject"]>[0],
+      ) => {
+        expect("objectKey" in input).toBe(false);
+        slots.push(`${input.component}:${input.chunkIndex}:${input.copyRole}`);
+        uploadAttempt += 1;
+        if (uploadAttempt === 2) throw new Error("crash while uploading chunk 1");
+        return primaryObject(fixture.chunks[input.chunkIndex] ?? fixture.chunks[0]!);
+      },
+    };
+    await expect(
+      executeAgentBackupPrimaryPublication({
+        claim: firstClaim,
+        leaseMs: 60_000,
+        scope: "production-eu",
+        primaryEndpointAlias: "primary-r2",
+        registry: UNUSED_REGISTRY,
+        resolveSource: async () =>
+          sourceFixture({
+            chunks: fixture.chunks,
+            bodies: fixture.bodies,
+            inventoryDigest: fixture.inventoryDigest,
+            events,
+            returnedBodies: [],
+          }),
+        dependencies: dependencies({ initialClaim: firstClaim, ...shared }),
+      }),
+    ).rejects.toMatchObject({
+      operationState: "uploading",
+      retryCode: "BACKUP_PRIMARY_PUBLICATION_RETRY",
+    });
+
+    const retryClaim = claim({
+      state: "failed_retryable",
+      resumeState: "uploading",
+      inventoryDigest: fixture.inventoryDigest,
+    });
+    uploadAttempt = 2;
+    const completed = await executeAgentBackupPrimaryPublication({
+      claim: retryClaim,
+      leaseMs: 60_000,
+      scope: "production-eu",
+      primaryEndpointAlias: "primary-r2",
+      registry: UNUSED_REGISTRY,
+      resolveSource: async () =>
+        sourceFixture({
+          chunks: fixture.chunks,
+          bodies: fixture.bodies,
+          inventoryDigest: fixture.inventoryDigest,
+          events,
+          returnedBodies: [],
+        }),
+      dependencies: dependencies({ initialClaim: retryClaim, ...shared }),
+    });
+
+    expect(completed.backup.catalog_state).toBe("primary_verified");
+    expect(slots[0]).toBe(slots[2]);
+    expect(slots[1]).toBe(slots[3]);
+  });
+
+  test("requires the durable agent identity before reading a capture source", async () => {
+    const fixture = await publicationFixture();
+    const missingAgent = claim({ state: "uploading", inventoryDigest: fixture.inventoryDigest });
+    missingAgent.backup.catalog_agent_id = null;
+    let resolved = false;
+    await expect(
+      executeAgentBackupPrimaryPublication({
+        claim: missingAgent,
+        leaseMs: 60_000,
+        scope: "production-eu",
+        primaryEndpointAlias: "primary-r2",
+        registry: UNUSED_REGISTRY,
+        resolveSource: async () => {
+          resolved = true;
+          throw new Error("must not resolve");
+        },
+        dependencies: dependencies({ initialClaim: missingAgent, events: [] }),
+      }),
+    ).rejects.toMatchObject({ code: "BACKUP_PUBLICATION_AUTHORITY_INCOMPLETE" });
+    expect(resolved).toBe(false);
+  });
+
+  test("replicates only the verified persisted primary inventory without resolving the spool", async () => {
+    const fixture = await publicationFixture();
+    const initialClaim = claim({
+      state: "primary_verified",
+      inventoryDigest: fixture.inventoryDigest,
+    });
+    const events: string[] = [];
+    const primaries = fixture.chunks.map((chunk) => primaryObject(chunk));
+    const replicated: string[] = [];
+    const result = await executeAgentBackupPostCapturePublication({
+      claim: initialClaim,
+      leaseMs: 60_000,
+      config: {
+        scope: "production-eu",
+        primaryEndpointAlias: "primary-r2",
+        secondaryEndpointAlias: "secondary-hetzner",
+      },
+      registry: UNUSED_REGISTRY,
+      resolveSource: async () => {
+        throw new Error("secondary replay must never resolve capture spool");
+      },
+      dependencies: dependencies({
+        initialClaim,
+        events,
+        listPrimary: async (input) => {
+          expect(input).toMatchObject({
+            organizationId: ORGANIZATION_ID,
+            agentId: AGENT_ID,
+            backupId: BACKUP_ID,
+            operationId: OPERATION_ID,
+          });
+          return primaries;
+        },
+        replicate: async (input) => {
+          expect("secondaryObjectKey" in input).toBe(false);
+          expect(input).toMatchObject({
+            scope: "production-eu",
+            operationId: OPERATION_ID,
+            manifestDigest: MANIFEST_DIGEST,
+          });
+          replicated.push(`${input.primaryObject.component}:${input.primaryObject.chunk_index}`);
+          return {} as AgentBackupObject;
+        },
+      }),
+    });
+
+    expect(result.backup.catalog_state).toBe("protected");
+    expect(replicated).toEqual(["database:0", "state-files:0"]);
+  });
+
+  test("keeps secondary outages retryable at the exact secondary_pending boundary", async () => {
+    const fixture = await publicationFixture();
+    const initialClaim = claim({
+      state: "secondary_pending",
+      inventoryDigest: fixture.inventoryDigest,
+    });
+    const primaries = fixture.chunks.map((chunk) => primaryObject(chunk));
+    await expect(
+      executeAgentBackupSecondaryReplication({
+        claim: initialClaim,
+        leaseMs: 60_000,
+        scope: "production-eu",
+        secondaryEndpointAlias: "secondary-hetzner",
+        registry: UNUSED_REGISTRY,
+        dependencies: dependencies({
+          initialClaim,
+          events: [],
+          listPrimary: async () => primaries,
+          replicate: async () => {
+            throw new Error("Hetzner endpoint unavailable");
+          },
+        }),
+      }),
+    ).rejects.toBeInstanceOf(AgentBackupPublicationStageError);
+  });
+
+  test("replays partial secondary rows idempotently from the persisted primary inventory", async () => {
+    const fixture = await publicationFixture();
+    const primaries = fixture.chunks.map((chunk) => primaryObject(chunk));
+    const replicated: string[] = [];
+    let failSecond = true;
+    const execute = (ownedClaim: AgentBackupOperationClaim) =>
+      executeAgentBackupSecondaryReplication({
+        claim: ownedClaim,
+        leaseMs: 60_000,
+        scope: "production-eu",
+        secondaryEndpointAlias: "secondary-hetzner",
+        registry: UNUSED_REGISTRY,
+        dependencies: dependencies({
+          initialClaim: ownedClaim,
+          events: [],
+          listPrimary: async () => primaries,
+          replicate: async (input) => {
+            replicated.push(
+              `${input.operationId}:${input.primaryObject.component}:${input.primaryObject.chunk_index}`,
+            );
+            if (failSecond && input.primaryObject.component === "state-files") {
+              failSecond = false;
+              throw new Error("crash on secondary chunk 1");
+            }
+            return {} as AgentBackupObject;
+          },
+        }),
+      });
+
+    await expect(
+      execute(claim({ state: "secondary_pending", inventoryDigest: fixture.inventoryDigest })),
+    ).rejects.toMatchObject({ operationState: "secondary_pending" });
+    const completed = await execute(
+      claim({
+        state: "failed_retryable",
+        resumeState: "secondary_pending",
+        inventoryDigest: fixture.inventoryDigest,
+      }),
+    );
+
+    expect(completed.backup.catalog_state).toBe("protected");
+    expect(replicated).toEqual([
+      `${OPERATION_ID}:database:0`,
+      `${OPERATION_ID}:state-files:0`,
+      `${OPERATION_ID}:database:0`,
+      `${OPERATION_ID}:state-files:0`,
+    ]);
+  });
+
+  test("fails closed on wrong-tenant primary rows and on an expired lease", async () => {
+    const fixture = await publicationFixture();
+    const initialClaim = claim({
+      state: "secondary_pending",
+      inventoryDigest: fixture.inventoryDigest,
+    });
+    const wrongTenant = fixture.chunks.map((chunk) =>
+      primaryObject(chunk, { organization_id: OPERATION_ID }),
+    );
+    let replicated = 0;
+    await expect(
+      executeAgentBackupSecondaryReplication({
+        claim: initialClaim,
+        leaseMs: 60_000,
+        scope: "production-eu",
+        secondaryEndpointAlias: "secondary-hetzner",
+        registry: UNUSED_REGISTRY,
+        dependencies: dependencies({
+          initialClaim,
+          events: [],
+          listPrimary: async () => wrongTenant,
+          replicate: async () => {
+            replicated += 1;
+            return {} as AgentBackupObject;
+          },
+        }),
+      }),
+    ).rejects.toMatchObject({ operationState: "secondary_pending" });
+    expect(replicated).toBe(0);
+
+    let heartbeats = 0;
+    await expect(
+      executeAgentBackupSecondaryReplication({
+        claim: initialClaim,
+        leaseMs: 60_000,
+        scope: "production-eu",
+        secondaryEndpointAlias: "secondary-hetzner",
+        registry: UNUSED_REGISTRY,
+        dependencies: dependencies({
+          initialClaim,
+          events: [],
+          heartbeat: async () => {
+            heartbeats += 1;
+            if (heartbeats === 2) throw new Error("lease expired");
+          },
+          listPrimary: async () => fixture.chunks.map((chunk) => primaryObject(chunk)),
+          replicate: async () => {
+            replicated += 1;
+            return {} as AgentBackupObject;
+          },
+        }),
+      }),
+    ).rejects.toMatchObject({
+      operationState: "secondary_pending",
+      retryCode: "BACKUP_SECONDARY_REPLICATION_RETRY",
+    });
+    expect(replicated).toBe(0);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/agent-backup-publication-executor.ts
+++ b/packages/cloud/shared/src/lib/services/agent-backup-publication-executor.ts
@@ -1,0 +1,766 @@
+/**
+ * Advances captured backups through immutable R2 publication and independent
+ * Hetzner replication under the catalogue execution lease. The executor is
+ * manifest-version agnostic: its only byte authority is the authenticated
+ * chunk inventory already persisted by recordCaptured.
+ */
+
+import { ElizaError } from "@elizaos/core";
+import {
+  type AgentBackupOperationClaim,
+  type AgentBackupOperationExecution,
+  agentBackupObjectInventoryDigest,
+  heartbeatAgentBackupOperation,
+  transitionAgentBackupOperation,
+} from "../../db/repositories/agent-backup-catalog";
+import {
+  type ListVerifiedPrimaryAgentBackupObjectsInput,
+  listVerifiedPrimaryAgentBackupObjectsForReplication,
+} from "../../db/repositories/agent-backup-publication";
+import type { AgentBackupObject } from "../../db/schemas/agent-backup-catalog";
+import type {
+  AgentBackupCatalogState,
+  StoredAgentSandboxBackup,
+} from "../../db/schemas/agent-sandboxes";
+import type { AgentBackupObjectStoreRegistry } from "../storage/agent-backup-object-store";
+import { MAX_IMMUTABLE_SINGLE_PUT_BYTES } from "../storage/object-store";
+import type { AgentBackupCatalogRuntimePublicationExecutor } from "./agent-backup-catalog-runtime";
+import {
+  type ExecuteAgentBackupObjectUploadInput,
+  type ExecuteAgentBackupSecondaryObjectReplicationInput,
+  executeAgentBackupObjectUpload,
+  executeAgentBackupSecondaryObjectReplication,
+} from "./agent-backup-catalog-worker";
+
+const MAX_LEASE_MS = 5 * 60_000;
+const MAX_TRANSFER_DEADLINE_MS = 5 * 60_000;
+const DEFAULT_TRANSFER_DEADLINE_MS = 2 * 60_000;
+const PUBLICATION_RESUME_STATES = [
+  "captured",
+  "uploading",
+  "primary_uploaded",
+  "primary_verified",
+  "secondary_pending",
+] as const satisfies readonly AgentBackupCatalogState[];
+
+export interface AgentBackupCapturedPublicationChunk {
+  component: string;
+  chunkIndex: number;
+  contentHmacSha256: string;
+  ciphertextSha256: string;
+  sizeBytes: number;
+}
+
+/** Durable capture-spool view used only for primary publication. */
+export interface AgentBackupCapturedPublicationSource {
+  readonly organizationId: string;
+  readonly agentId: string;
+  readonly backupId: string;
+  readonly operationId: string;
+  readonly manifestDigest: string;
+  readonly objectInventoryDigest: string;
+  readonly chunks: readonly AgentBackupCapturedPublicationChunk[];
+  beginPrimaryPublication(): Promise<void>;
+  /** Returns a fresh, exact, digest-verified buffer no larger than 32 MiB. */
+  readCiphertextChunk(
+    chunk: Readonly<AgentBackupCapturedPublicationChunk>,
+    signal?: AbortSignal,
+  ): Promise<Uint8Array>;
+  markPrimaryChunkUploaded(chunk: Readonly<AgentBackupCapturedPublicationChunk>): Promise<void>;
+  markPrimaryPublished(): Promise<void>;
+  /** Releases the spool lock; it must not remove durable replay data. */
+  close(): Promise<void>;
+}
+
+export type ResolveAgentBackupCapturedPublicationSource = (input: {
+  claim: Readonly<AgentBackupOperationClaim>;
+  execution: Readonly<AgentBackupOperationExecution>;
+  signal?: AbortSignal;
+}) => Promise<AgentBackupCapturedPublicationSource>;
+
+export interface AgentBackupPublicationExecutorConfig {
+  scope: string;
+  primaryEndpointAlias: string;
+  secondaryEndpointAlias: string;
+  /** Total wall-clock budget shared by primary writes and secondary replication. */
+  objectTransferDeadlineMs?: number;
+}
+
+export interface AgentBackupPublicationExecutorDependencies {
+  heartbeatOperation: typeof heartbeatAgentBackupOperation;
+  transitionOperation: typeof transitionAgentBackupOperation;
+  listVerifiedPrimaryObjects(
+    input: Readonly<ListVerifiedPrimaryAgentBackupObjectsInput>,
+  ): Promise<AgentBackupObject[]>;
+  uploadObject(input: ExecuteAgentBackupObjectUploadInput): Promise<AgentBackupObject>;
+  replicateObject(
+    input: ExecuteAgentBackupSecondaryObjectReplicationInput,
+  ): Promise<AgentBackupObject>;
+  now(): number;
+}
+
+const DEFAULT_DEPENDENCIES: AgentBackupPublicationExecutorDependencies = {
+  heartbeatOperation: heartbeatAgentBackupOperation,
+  transitionOperation: transitionAgentBackupOperation,
+  listVerifiedPrimaryObjects: listVerifiedPrimaryAgentBackupObjectsForReplication,
+  uploadObject: executeAgentBackupObjectUpload,
+  replicateObject: executeAgentBackupSecondaryObjectReplication,
+  now: Date.now,
+};
+
+export class AgentBackupPublicationStageError extends ElizaError {
+  override readonly name = "AgentBackupPublicationStageError";
+
+  constructor(
+    readonly operationState: (typeof PUBLICATION_RESUME_STATES)[number],
+    readonly retryCode: "BACKUP_PRIMARY_PUBLICATION_RETRY" | "BACKUP_SECONDARY_REPLICATION_RETRY",
+    message: string,
+    cause: unknown,
+  ) {
+    super(message, {
+      code: retryCode,
+      cause,
+      context: { operationState },
+      severity: "ephemeral",
+    });
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+function stageFailure(params: {
+  state: AgentBackupPublicationStageError["operationState"];
+  phase: "primary" | "secondary";
+  cause: unknown;
+}): AgentBackupPublicationStageError {
+  if (params.cause instanceof AgentBackupPublicationStageError) return params.cause;
+  return new AgentBackupPublicationStageError(
+    params.state,
+    params.phase === "primary"
+      ? "BACKUP_PRIMARY_PUBLICATION_RETRY"
+      : "BACKUP_SECONDARY_REPLICATION_RETRY",
+    params.phase === "primary"
+      ? "Primary backup publication did not reach its durable verification boundary"
+      : "Secondary backup replication did not reach its durable verification boundary",
+    params.cause,
+  );
+}
+
+function operationIdentity(claim: Readonly<AgentBackupOperationClaim>): {
+  organizationId: string;
+  agentId: string;
+  backupId: string;
+  operationId: string;
+  activationGeneration: string;
+  lifecycleGeneration: string;
+  lifecycleRevision: string;
+} {
+  const backup = claim.backup;
+  if (
+    !backup.catalog_organization_id ||
+    !backup.catalog_agent_id ||
+    !backup.backup_operation_id ||
+    !backup.lifecycle_generation ||
+    backup.lifecycle_revision === null
+  ) {
+    throw new ElizaError("Backup publication claim identity is incomplete", {
+      code: "BACKUP_PUBLICATION_AUTHORITY_INCOMPLETE",
+      severity: "fatal",
+    });
+  }
+  return {
+    organizationId: backup.catalog_organization_id,
+    agentId: backup.catalog_agent_id,
+    backupId: backup.id,
+    operationId: backup.backup_operation_id,
+    activationGeneration: backup.lifecycle_generation,
+    lifecycleGeneration: backup.lifecycle_generation,
+    lifecycleRevision: backup.lifecycle_revision.toString(),
+  };
+}
+
+function execution(claim: Readonly<AgentBackupOperationClaim>): AgentBackupOperationExecution {
+  return { ownerId: claim.ownerId, generation: claim.generation };
+}
+
+function transferDeadlineMs(value: number | undefined): number {
+  const resolved = value ?? DEFAULT_TRANSFER_DEADLINE_MS;
+  if (!Number.isSafeInteger(resolved) || resolved < 1 || resolved > MAX_TRANSFER_DEADLINE_MS) {
+    throw new ElizaError("Backup publication transfer deadline is invalid", {
+      code: "BACKUP_PUBLICATION_CONFIG_INVALID",
+      severity: "fatal",
+    });
+  }
+  return resolved;
+}
+
+function resolveTransferDeadline(params: {
+  deadline?: Date;
+  deadlineMs?: number;
+  dependencies: AgentBackupPublicationExecutorDependencies;
+}): Date {
+  const now = params.dependencies.now();
+  if (!Number.isSafeInteger(now) || now < 1) {
+    throw new ElizaError("Backup publication clock is invalid", {
+      code: "BACKUP_PUBLICATION_CLOCK_INVALID",
+      severity: "fatal",
+    });
+  }
+  if (params.deadline) {
+    const deadline = params.deadline.getTime();
+    if (
+      !Number.isSafeInteger(deadline) ||
+      deadline <= now ||
+      deadline - now > MAX_TRANSFER_DEADLINE_MS
+    ) {
+      throw new ElizaError("Backup publication transfer deadline is invalid", {
+        code: "BACKUP_PUBLICATION_CONFIG_INVALID",
+        severity: "fatal",
+      });
+    }
+    return new Date(deadline);
+  }
+  const duration = transferDeadlineMs(params.deadlineMs);
+  if (now > Number.MAX_SAFE_INTEGER - duration) {
+    throw new ElizaError("Backup publication clock is invalid", {
+      code: "BACKUP_PUBLICATION_CLOCK_INVALID",
+      severity: "fatal",
+    });
+  }
+  return new Date(now + duration);
+}
+
+function requireLeaseMs(value: number): void {
+  if (!Number.isSafeInteger(value) || value < 1 || value > MAX_LEASE_MS) {
+    throw new ElizaError("Backup publication lease duration is invalid", {
+      code: "BACKUP_PUBLICATION_CONFIG_INVALID",
+      severity: "fatal",
+    });
+  }
+}
+
+async function heartbeat(params: {
+  claim: Readonly<AgentBackupOperationClaim>;
+  leaseMs: number;
+  dependencies: AgentBackupPublicationExecutorDependencies;
+}): Promise<void> {
+  const identity = operationIdentity(params.claim);
+  await params.dependencies.heartbeatOperation({
+    organizationId: identity.organizationId,
+    backupId: identity.backupId,
+    execution: execution(params.claim),
+    leaseMs: params.leaseMs,
+  });
+}
+
+async function transition(params: {
+  claim: Readonly<AgentBackupOperationClaim>;
+  expectedState: AgentBackupCatalogState;
+  to: AgentBackupCatalogState;
+  resumeState?: AgentBackupCatalogState;
+  leaseMs: number;
+  dependencies: AgentBackupPublicationExecutorDependencies;
+}): Promise<AgentBackupOperationClaim> {
+  await heartbeat(params);
+  const backup = await params.dependencies.transitionOperation({
+    ...operationIdentity(params.claim),
+    expectedState: params.expectedState,
+    to: params.to,
+    resumeState: params.resumeState,
+    execution: execution(params.claim),
+  });
+  return { ...params.claim, backup };
+}
+
+async function resumePublicationClaim(params: {
+  claim: Readonly<AgentBackupOperationClaim>;
+  leaseMs: number;
+  dependencies: AgentBackupPublicationExecutorDependencies;
+}): Promise<AgentBackupOperationClaim> {
+  const state = params.claim.backup.catalog_state;
+  if (state !== "failed_retryable") return { ...params.claim };
+  const resumeState = params.claim.backup.catalog_resume_state;
+  if (
+    !resumeState ||
+    !PUBLICATION_RESUME_STATES.includes(resumeState as (typeof PUBLICATION_RESUME_STATES)[number])
+  ) {
+    throw new ElizaError("Backup publication retry has no exact resumable state", {
+      code: "BACKUP_PUBLICATION_RESUME_INVALID",
+      severity: "fatal",
+    });
+  }
+  return transition({
+    ...params,
+    expectedState: "failed_retryable",
+    to: resumeState,
+    resumeState,
+  });
+}
+
+function canonicalChunks(
+  chunks: readonly AgentBackupCapturedPublicationChunk[],
+): AgentBackupCapturedPublicationChunk[] {
+  const sorted = chunks
+    .map((chunk) => ({ ...chunk }))
+    .sort(
+      (left, right) =>
+        left.component.localeCompare(right.component) || left.chunkIndex - right.chunkIndex,
+    );
+  const seen = new Set<string>();
+  for (const chunk of sorted) {
+    const identity = `${chunk.component}:${chunk.chunkIndex}`;
+    if (seen.has(identity)) {
+      throw new ElizaError("Captured publication source contains a duplicate object slot", {
+        code: "BACKUP_PUBLICATION_SOURCE_INVALID",
+        severity: "fatal",
+      });
+    }
+    seen.add(identity);
+    if (
+      !Number.isSafeInteger(chunk.sizeBytes) ||
+      chunk.sizeBytes < 0 ||
+      chunk.sizeBytes > MAX_IMMUTABLE_SINGLE_PUT_BYTES ||
+      !/^[0-9a-f]{64}$/.test(chunk.contentHmacSha256) ||
+      !/^[0-9a-f]{64}$/.test(chunk.ciphertextSha256)
+    ) {
+      throw new ElizaError("Captured publication source has invalid bounded chunk metadata", {
+        code: "BACKUP_PUBLICATION_SOURCE_INVALID",
+        severity: "fatal",
+      });
+    }
+  }
+  return sorted;
+}
+
+async function validatePublicationSource(params: {
+  claim: Readonly<AgentBackupOperationClaim>;
+  source: AgentBackupCapturedPublicationSource;
+}): Promise<AgentBackupCapturedPublicationChunk[]> {
+  const identity = operationIdentity(params.claim);
+  const backup = params.claim.backup;
+  if (
+    params.source.organizationId !== identity.organizationId ||
+    params.source.agentId !== identity.agentId ||
+    params.source.backupId !== identity.backupId ||
+    params.source.operationId !== identity.operationId ||
+    !backup.manifest_digest ||
+    params.source.manifestDigest !== backup.manifest_digest ||
+    !backup.object_inventory_digest ||
+    params.source.objectInventoryDigest !== backup.object_inventory_digest ||
+    !backup.manifest_object_count
+  ) {
+    throw new ElizaError("Captured publication source does not match catalogue authority", {
+      code: "BACKUP_PUBLICATION_SOURCE_MISMATCH",
+      severity: "fatal",
+    });
+  }
+  const chunks = canonicalChunks(params.source.chunks);
+  if (
+    chunks.length !== backup.manifest_object_count ||
+    (await agentBackupObjectInventoryDigest(chunks)) !== backup.object_inventory_digest
+  ) {
+    throw new ElizaError("Captured publication inventory does not match the manifest digest", {
+      code: "BACKUP_PUBLICATION_SOURCE_MISMATCH",
+      severity: "fatal",
+    });
+  }
+  return chunks;
+}
+
+async function closeSource(
+  source: AgentBackupCapturedPublicationSource,
+  failure: unknown,
+): Promise<void> {
+  try {
+    await source.close();
+  } catch (closeFailure) {
+    // error-policy:J2 spool ownership must not be silently lost. Preserve both
+    // failures so the scheduler treats the outcome as indeterminate.
+    if (failure !== undefined) {
+      throw new AggregateError(
+        [failure, closeFailure],
+        "Backup publication and capture-source close both failed",
+      );
+    }
+    throw closeFailure;
+  }
+  if (failure !== undefined) throw failure;
+}
+
+export interface ExecuteAgentBackupPrimaryPublicationInput {
+  claim: Readonly<AgentBackupOperationClaim>;
+  leaseMs: number;
+  scope: string;
+  primaryEndpointAlias: string;
+  registry: AgentBackupObjectStoreRegistry;
+  resolveSource: ResolveAgentBackupCapturedPublicationSource;
+  dependencies?: AgentBackupPublicationExecutorDependencies;
+  signal?: AbortSignal;
+  objectTransferDeadlineMs?: number;
+  /** Optional parent-owned deadline shared with secondary replication. */
+  deadline?: Date;
+}
+
+/** Publish every captured chunk to primary R2 and verify the full inventory. */
+export async function executeAgentBackupPrimaryPublication(
+  input: Readonly<ExecuteAgentBackupPrimaryPublicationInput>,
+): Promise<AgentBackupOperationClaim> {
+  requireLeaseMs(input.leaseMs);
+  const dependencies = input.dependencies ?? DEFAULT_DEPENDENCIES;
+  const deadline = resolveTransferDeadline({
+    deadline: input.deadline,
+    deadlineMs: input.objectTransferDeadlineMs,
+    dependencies,
+  });
+  let claim = await resumePublicationClaim({
+    claim: input.claim,
+    leaseMs: input.leaseMs,
+    dependencies,
+  });
+  let state = claim.backup.catalog_state;
+  if (state === "primary_verified" || state === "secondary_pending") return claim;
+  if (state !== "captured" && state !== "uploading" && state !== "primary_uploaded") {
+    throw new ElizaError("Primary publication received an unsupported catalogue state", {
+      code: "BACKUP_PUBLICATION_STATE_INVALID",
+      context: { state },
+      severity: "fatal",
+    });
+  }
+  // Validate all durable tenant/agent/lifecycle identity before opening a
+  // filesystem-backed capture source.
+  operationIdentity(claim);
+
+  let source: AgentBackupCapturedPublicationSource;
+  try {
+    source = await input.resolveSource({
+      claim,
+      execution: execution(claim),
+      signal: input.signal,
+    });
+  } catch (cause) {
+    // error-policy:J2 source failures retain their durable spool and become an
+    // exact-state retry without exposing filesystem or object-key details.
+    throw stageFailure({ state, phase: "primary", cause });
+  }
+
+  let failure: unknown;
+  try {
+    const chunks = await validatePublicationSource({ claim, source });
+    if (state === "captured") {
+      try {
+        claim = await transition({
+          claim,
+          expectedState: "captured",
+          to: "uploading",
+          leaseMs: input.leaseMs,
+          dependencies,
+        });
+        state = "uploading";
+      } catch (cause) {
+        throw stageFailure({ state: "captured", phase: "primary", cause });
+      }
+    }
+    await source.beginPrimaryPublication();
+    if (state === "uploading") {
+      const identity = operationIdentity(claim);
+      for (const chunk of chunks) {
+        await heartbeat({ claim, leaseMs: input.leaseMs, dependencies });
+        let body: Uint8Array | undefined;
+        try {
+          body = await source.readCiphertextChunk(chunk, input.signal);
+          if (body.byteLength !== chunk.sizeBytes) {
+            throw new ElizaError("Capture spool returned a different encrypted byte length", {
+              code: "BACKUP_PUBLICATION_SOURCE_MISMATCH",
+              severity: "fatal",
+            });
+          }
+          await dependencies.uploadObject({
+            organizationId: identity.organizationId,
+            backupId: identity.backupId,
+            copyRole: "primary",
+            component: chunk.component,
+            chunkIndex: chunk.chunkIndex,
+            endpointAlias: input.primaryEndpointAlias,
+            contentHmacSha256: chunk.contentHmacSha256,
+            ciphertextSha256: chunk.ciphertextSha256,
+            execution: execution(claim),
+            registry: input.registry,
+            body,
+            contentType: "application/octet-stream",
+            signal: input.signal,
+            deadline,
+            revalidateLease: () => heartbeat({ claim, leaseMs: input.leaseMs, dependencies }),
+          });
+          await source.markPrimaryChunkUploaded(chunk);
+        } catch (cause) {
+          // error-policy:J2 the static stage error preserves the underlying
+          // provider/spool cause without exposing its key in the public message.
+          throw stageFailure({ state: "uploading", phase: "primary", cause });
+        } finally {
+          body?.fill(0);
+        }
+        await heartbeat({ claim, leaseMs: input.leaseMs, dependencies });
+      }
+      claim = await transition({
+        claim,
+        expectedState: "uploading",
+        to: "primary_uploaded",
+        leaseMs: input.leaseMs,
+        dependencies,
+      });
+    }
+    try {
+      await source.markPrimaryPublished();
+    } catch (cause) {
+      // error-policy:J2 the persisted primary objects remain replayable while
+      // the exact primary_uploaded state retains source-journal reconciliation.
+      throw stageFailure({ state: "primary_uploaded", phase: "primary", cause });
+    }
+    claim = await transition({
+      claim,
+      expectedState: "primary_uploaded",
+      to: "primary_verified",
+      leaseMs: input.leaseMs,
+      dependencies,
+    });
+  } catch (cause) {
+    failure = cause;
+  }
+  await closeSource(source, failure);
+  return claim;
+}
+
+async function validatePrimaryInventory(params: {
+  backup: StoredAgentSandboxBackup;
+  objects: readonly AgentBackupObject[];
+}): Promise<AgentBackupObject[]> {
+  if (!params.backup.manifest_object_count || !params.backup.object_inventory_digest) {
+    throw new ElizaError("Secondary replication is missing manifest inventory authority", {
+      code: "BACKUP_PUBLICATION_AUTHORITY_INCOMPLETE",
+      severity: "fatal",
+    });
+  }
+  const objects = [...params.objects].sort(
+    (left, right) =>
+      left.component.localeCompare(right.component) || left.chunk_index - right.chunk_index,
+  );
+  for (const object of objects) {
+    if (
+      object.organization_id !== params.backup.catalog_organization_id ||
+      object.backup_id !== params.backup.id ||
+      object.copy_role !== "primary" ||
+      object.provider !== "cloudflare-r2" ||
+      object.state !== "verified"
+    ) {
+      throw new ElizaError("Secondary source row does not match verified primary authority", {
+        code: "BACKUP_PRIMARY_INVENTORY_MISMATCH",
+        severity: "fatal",
+      });
+    }
+  }
+  const digest = await agentBackupObjectInventoryDigest(
+    objects.map((object) => ({
+      component: object.component,
+      chunkIndex: object.chunk_index,
+      contentHmacSha256: object.content_hmac_sha256,
+      ciphertextSha256: object.ciphertext_sha256,
+      sizeBytes: object.size_bytes,
+    })),
+  );
+  if (
+    objects.length !== params.backup.manifest_object_count ||
+    digest !== params.backup.object_inventory_digest
+  ) {
+    throw new ElizaError("Verified primary rows do not match the manifest inventory", {
+      code: "BACKUP_PRIMARY_INVENTORY_MISMATCH",
+      severity: "fatal",
+    });
+  }
+  return objects;
+}
+
+export interface ExecuteAgentBackupSecondaryReplicationInput {
+  claim: Readonly<AgentBackupOperationClaim>;
+  leaseMs: number;
+  scope: string;
+  secondaryEndpointAlias: string;
+  registry: AgentBackupObjectStoreRegistry;
+  objectTransferDeadlineMs?: number;
+  dependencies?: AgentBackupPublicationExecutorDependencies;
+  signal?: AbortSignal;
+  /** Optional parent-owned deadline shared with primary publication. */
+  deadline?: Date;
+}
+
+/** Replicate only from persisted exact R2 locators, then mark dual protection. */
+export async function executeAgentBackupSecondaryReplication(
+  input: Readonly<ExecuteAgentBackupSecondaryReplicationInput>,
+): Promise<AgentBackupOperationClaim> {
+  requireLeaseMs(input.leaseMs);
+  const dependencies = input.dependencies ?? DEFAULT_DEPENDENCIES;
+  const deadline = resolveTransferDeadline({
+    deadline: input.deadline,
+    deadlineMs: input.objectTransferDeadlineMs,
+    dependencies,
+  });
+  let claim = await resumePublicationClaim({
+    claim: input.claim,
+    leaseMs: input.leaseMs,
+    dependencies,
+  });
+  if (claim.backup.catalog_state === "primary_verified") {
+    claim = await transition({
+      claim,
+      expectedState: "primary_verified",
+      to: "secondary_pending",
+      leaseMs: input.leaseMs,
+      dependencies,
+    });
+  }
+  if (claim.backup.catalog_state === "protected") return claim;
+  if (claim.backup.catalog_state !== "secondary_pending") {
+    throw new ElizaError("Secondary replication received an unsupported catalogue state", {
+      code: "BACKUP_PUBLICATION_STATE_INVALID",
+      context: { state: claim.backup.catalog_state },
+      severity: "fatal",
+    });
+  }
+  const identity = operationIdentity(claim);
+  const manifestDigest = claim.backup.manifest_digest;
+  if (!manifestDigest) {
+    throw new ElizaError("Secondary replication is missing manifest digest authority", {
+      code: "BACKUP_PUBLICATION_AUTHORITY_INCOMPLETE",
+      severity: "fatal",
+    });
+  }
+  let primaryObjects: AgentBackupObject[];
+  try {
+    await heartbeat({ claim, leaseMs: input.leaseMs, dependencies });
+    primaryObjects = await dependencies.listVerifiedPrimaryObjects({
+      ...identity,
+      execution: execution(claim),
+    });
+    primaryObjects = await validatePrimaryInventory({
+      backup: claim.backup,
+      objects: primaryObjects,
+    });
+  } catch (cause) {
+    // error-policy:J2 an unprovable persisted primary inventory remains in the
+    // exact secondary_pending state for fenced retry.
+    throw stageFailure({ state: "secondary_pending", phase: "secondary", cause });
+  }
+
+  for (const primaryObject of primaryObjects) {
+    try {
+      await heartbeat({ claim, leaseMs: input.leaseMs, dependencies });
+      await dependencies.replicateObject({
+        organizationId: identity.organizationId,
+        backupId: identity.backupId,
+        primaryObject,
+        secondaryEndpointAlias: input.secondaryEndpointAlias,
+        scope: input.scope,
+        operationId: identity.operationId,
+        manifestDigest,
+        registry: input.registry,
+        execution: execution(claim),
+        revalidateLease: () => heartbeat({ claim, leaseMs: input.leaseMs, dependencies }),
+        signal: input.signal,
+        deadline,
+      });
+      await heartbeat({ claim, leaseMs: input.leaseMs, dependencies });
+    } catch (cause) {
+      // error-policy:J2 provider/read failures stay key-free and retry from the
+      // persisted exact primary locator; no capture source is available here.
+      throw stageFailure({ state: "secondary_pending", phase: "secondary", cause });
+    }
+  }
+  return transition({
+    claim,
+    expectedState: "secondary_pending",
+    to: "protected",
+    leaseMs: input.leaseMs,
+    dependencies,
+  });
+}
+
+export interface ExecuteAgentBackupPostCapturePublicationInput {
+  claim: Readonly<AgentBackupOperationClaim>;
+  leaseMs: number;
+  config: Readonly<AgentBackupPublicationExecutorConfig>;
+  registry: AgentBackupObjectStoreRegistry;
+  resolveSource: ResolveAgentBackupCapturedPublicationSource;
+  dependencies?: AgentBackupPublicationExecutorDependencies;
+  signal?: AbortSignal;
+}
+
+/** Advance one owned post-capture claim as far as dual-provider protection. */
+export async function executeAgentBackupPostCapturePublication(
+  input: Readonly<ExecuteAgentBackupPostCapturePublicationInput>,
+): Promise<AgentBackupOperationClaim> {
+  const dependencies = input.dependencies ?? DEFAULT_DEPENDENCIES;
+  const deadline = resolveTransferDeadline({
+    deadlineMs: input.config.objectTransferDeadlineMs,
+    dependencies,
+  });
+  const primary = await executeAgentBackupPrimaryPublication({
+    claim: input.claim,
+    leaseMs: input.leaseMs,
+    scope: input.config.scope,
+    primaryEndpointAlias: input.config.primaryEndpointAlias,
+    registry: input.registry,
+    resolveSource: input.resolveSource,
+    dependencies,
+    signal: input.signal,
+    deadline,
+  });
+  return executeAgentBackupSecondaryReplication({
+    claim: primary,
+    leaseMs: input.leaseMs,
+    scope: input.config.scope,
+    secondaryEndpointAlias: input.config.secondaryEndpointAlias,
+    registry: input.registry,
+    dependencies,
+    signal: input.signal,
+    deadline,
+  });
+}
+
+/** Bind post-capture authorities once for the bounded catalogue dispatcher. */
+export function createAgentBackupCatalogPublicationExecutor(params: {
+  config: Readonly<AgentBackupPublicationExecutorConfig>;
+  registry: AgentBackupObjectStoreRegistry;
+  resolveSource: ResolveAgentBackupCapturedPublicationSource;
+  dependencies?: AgentBackupPublicationExecutorDependencies;
+}): AgentBackupCatalogRuntimePublicationExecutor {
+  return {
+    async execute({ claim, leaseMs }) {
+      try {
+        const completed = await executeAgentBackupPostCapturePublication({
+          claim,
+          leaseMs,
+          config: params.config,
+          registry: params.registry,
+          resolveSource: params.resolveSource,
+          dependencies: params.dependencies,
+        });
+        if (completed.backup.catalog_state !== "protected") {
+          throw new ElizaError("Backup publication did not reach protected", {
+            code: "BACKUP_PUBLICATION_STATE_INVALID",
+            severity: "fatal",
+          });
+        }
+        return { state: "protected" };
+      } catch (cause) {
+        // error-policy:J1 only exact-state provider/source failures become a
+        // scheduler retry; transition/response ambiguity remains thrown.
+        if (cause instanceof AgentBackupPublicationStageError) {
+          return {
+            state: "retryable-failure",
+            expectedState: cause.operationState,
+            error: { code: cause.retryCode, message: cause.message },
+          };
+        }
+        throw cause;
+      }
+    },
+  };
+}

--- a/packages/cloud/shared/src/lib/services/containers/node-autoscaler.test.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-autoscaler.test.ts
@@ -219,6 +219,10 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
         enabled: true,
         status: "unknown",
         ssh_user: "root",
+        fleet_kind: "cloud",
+        infrastructure_provider: "hetzner",
+        provider_server_id: "4242",
+        node_incarnation: null,
         metadata: expect.objectContaining({
           provider: "hetzner-cloud",
           autoscaled: true,

--- a/packages/cloud/shared/src/lib/services/containers/node-autoscaler.ts
+++ b/packages/cloud/shared/src/lib/services/containers/node-autoscaler.ts
@@ -17,6 +17,7 @@
  *    provision and drain.
  */
 
+import { requireCanonicalProviderServerId } from "../../../db/repositories/agent-backup-source-authority";
 import { dockerNodesRepository } from "../../../db/repositories/docker-nodes";
 import type { DockerNode } from "../../../db/schemas/docker-nodes";
 import { containersEnv } from "../../config/containers-env";
@@ -352,6 +353,10 @@ export class NodeAutoscaler {
       const hcloudServerId = Number(provisioned.server.id);
 
       try {
+        const providerServerId =
+          providerName === "hetzner"
+            ? requireCanonicalProviderServerId(String(provisioned.server.id))
+            : null;
         await authority.createNode({
           node_id: nodeId,
           hostname: ip,
@@ -363,6 +368,12 @@ export class NodeAutoscaler {
           status: "unknown",
           allocated_count: 0,
           ssh_user: "root",
+          fleet_kind: providerName === "hetzner" ? "cloud" : null,
+          infrastructure_provider: providerName === "hetzner" ? "hetzner" : null,
+          provider_server_id: providerServerId,
+          // The provider API proves server identity, not the running kernel.
+          // Health SSH publishes the first boot UUID after host-key verification.
+          node_incarnation: null,
           metadata: {
             provider: providerName === "hetzner" ? "hetzner-cloud" : providerName,
             environment,
@@ -542,6 +553,14 @@ function generateNodeId(): string {
 }
 
 function getHcloudServerId(node: DockerNode): number | undefined {
+  if (
+    node.fleet_kind === "cloud" &&
+    node.infrastructure_provider === "hetzner" &&
+    node.provider_server_id !== null
+  ) {
+    const providerId = Number(node.provider_server_id);
+    return Number.isSafeInteger(providerId) && providerId > 0 ? providerId : undefined;
+  }
   const meta = (node.metadata ?? {}) as Record<string, unknown>;
   return typeof meta.hcloudServerId === "number" ? meta.hcloudServerId : undefined;
 }

--- a/packages/cloud/shared/src/lib/services/docker-node-manager-embedding-sidecar.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager-embedding-sidecar.test.ts
@@ -50,7 +50,7 @@ mock.module("../../db/repositories/docker-nodes", () => ({
       return Promise.resolve();
     },
     markOfflineAndDisable: () => Promise.resolve(),
-    setHostKeyFingerprint: () => Promise.resolve(),
+    rotateNodeHostKeyFingerprint: () => Promise.resolve(),
     findAll: () => Promise.resolve(findAllNodes),
   },
 }));

--- a/packages/cloud/shared/src/lib/services/docker-node-manager-health-disable.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager-health-disable.test.ts
@@ -26,12 +26,16 @@ const realNodeDisk = { ...realNodeDiskNs };
 const repoCalls = {
   updateStatus: [] as Array<{ nodeId: string; status: string }>,
   markOfflineAndDisable: [] as string[],
-  setHostKeyFingerprint: [] as Array<{ nodeId: string; fingerprint: string }>,
+  rotateNodeHostKeyFingerprint: [] as Array<Record<string, unknown>>,
+  attestNodeIncarnation: [] as Array<Record<string, unknown>>,
+  invalidateNodeIncarnation: [] as Array<Record<string, unknown>>,
 };
+let invalidateNodeIncarnationError: Error | null = null;
 
 const sshMock = {
   connect: mock(),
   exec: mock(),
+  getVerifiedHostKeyFingerprint: mock(),
 };
 
 mock.module("../../db/repositories/docker-nodes", () => ({
@@ -44,9 +48,20 @@ mock.module("../../db/repositories/docker-nodes", () => ({
       repoCalls.markOfflineAndDisable.push(nodeId);
       return Promise.resolve();
     },
-    setHostKeyFingerprint: (nodeId: string, fingerprint: string) => {
-      repoCalls.setHostKeyFingerprint.push({ nodeId, fingerprint });
-      return Promise.resolve();
+    rotateNodeHostKeyFingerprint: (input: Record<string, unknown>) => {
+      repoCalls.rotateNodeHostKeyFingerprint.push(input);
+      return Promise.resolve({ host_key_fingerprint: input.observedFingerprint });
+    },
+    setEmbeddingSidecarHealth: () => Promise.resolve(),
+    attestNodeIncarnation: (input: Record<string, unknown>) => {
+      repoCalls.attestNodeIncarnation.push(input);
+      return Promise.resolve({});
+    },
+    invalidateNodeIncarnation: (input: Record<string, unknown>) => {
+      repoCalls.invalidateNodeIncarnation.push(input);
+      return invalidateNodeIncarnationError
+        ? Promise.reject(invalidateNodeIncarnationError)
+        : Promise.resolve({});
     },
   },
 }));
@@ -90,6 +105,10 @@ function node(nodeId: string): DockerNode {
     // Canonical (operator-managed) node: no autoscaler metadata. This is exactly
     // the class the old code refused to ever mark offline.
     host_key_fingerprint: "SHA256:test",
+    fleet_kind: null,
+    infrastructure_provider: null,
+    provider_server_id: null,
+    node_incarnation: null,
     metadata: {},
     created_at: new Date("2026-01-01T00:00:00.000Z"),
     updated_at: new Date("2026-01-01T00:00:00.000Z"),
@@ -117,9 +136,13 @@ beforeEach(() => {
   __resetNodeHealthFailureStateForTests();
   repoCalls.updateStatus = [];
   repoCalls.markOfflineAndDisable = [];
-  repoCalls.setHostKeyFingerprint = [];
+  repoCalls.rotateNodeHostKeyFingerprint = [];
+  repoCalls.attestNodeIncarnation = [];
+  repoCalls.invalidateNodeIncarnation = [];
+  invalidateNodeIncarnationError = null;
   sshMock.connect.mockReset();
   sshMock.exec.mockReset();
+  sshMock.getVerifiedHostKeyFingerprint.mockReset();
 });
 
 describe("healthCheckNode auto-disable on repeated failure", () => {
@@ -174,5 +197,162 @@ describe("healthCheckNode auto-disable on repeated failure", () => {
     }
     await manager.healthCheckNode(target);
     expect(repoCalls.markOfflineAndDisable).toEqual(["flapping-node"]);
+  });
+
+  test("attests a typed node boot and invalidates malformed observations without hiding health", async () => {
+    const manager = DockerNodeManager.getInstance();
+    const target = {
+      ...node("typed-cloud-node"),
+      id: "00000000-0000-4000-8000-000000000201",
+      fleet_kind: "cloud" as const,
+      infrastructure_provider: "hetzner" as const,
+      provider_server_id: "4242",
+      node_incarnation: "00000000-0000-4000-8000-000000000211",
+    };
+    const observed = "00000000-0000-4000-8000-000000000212";
+    sshMock.connect.mockResolvedValue(undefined);
+    sshMock.exec.mockImplementation((command: string) => {
+      if (command === "cat /proc/sys/kernel/random/boot_id") return Promise.resolve(observed);
+      if (command.includes("embedding")) return Promise.resolve("running");
+      return Promise.resolve("DOCKER-ID-123");
+    });
+
+    await expect(manager.healthCheckNode(target)).resolves.toBe("healthy");
+    expect(repoCalls.attestNodeIncarnation).toEqual([
+      {
+        id: target.id,
+        nodeId: target.node_id,
+        expectedIncarnation: target.node_incarnation,
+        expectedHostKeyFingerprint: target.host_key_fingerprint,
+        observedIncarnation: observed,
+      },
+    ]);
+    expect(repoCalls.invalidateNodeIncarnation).toHaveLength(0);
+
+    repoCalls.attestNodeIncarnation = [];
+    sshMock.exec.mockImplementation((command: string) => {
+      if (command === "cat /proc/sys/kernel/random/boot_id") {
+        return Promise.resolve("not-a-boot-id");
+      }
+      if (command.includes("embedding")) return Promise.resolve("running");
+      return Promise.resolve("DOCKER-ID-123");
+    });
+    await expect(manager.healthCheckNode(target)).resolves.toBe("healthy");
+    expect(repoCalls.attestNodeIncarnation).toHaveLength(0);
+    expect(repoCalls.invalidateNodeIncarnation).toEqual([
+      {
+        id: target.id,
+        nodeId: target.node_id,
+        expectedIncarnation: target.node_incarnation,
+        expectedHostKeyFingerprint: target.host_key_fingerprint,
+      },
+    ]);
+  });
+
+  test("pins a first Cloud host key before publishing its initial boot authority", async () => {
+    const manager = DockerNodeManager.getInstance();
+    const target = {
+      ...node("new-cloud-node"),
+      id: "00000000-0000-4000-8000-000000000221",
+      host_key_fingerprint: null,
+      fleet_kind: "cloud" as const,
+      infrastructure_provider: "hetzner" as const,
+      provider_server_id: "4343",
+      node_incarnation: null,
+    };
+    const observed = "00000000-0000-4000-8000-000000000222";
+    sshMock.connect.mockResolvedValue(undefined);
+    sshMock.getVerifiedHostKeyFingerprint.mockReturnValue("first-cloud-pin");
+    sshMock.exec.mockImplementation((command: string) => {
+      if (command === "cat /proc/sys/kernel/random/boot_id") return Promise.resolve(observed);
+      if (command.includes("embedding")) return Promise.resolve("running");
+      return Promise.resolve("DOCKER-ID-123");
+    });
+
+    await expect(manager.healthCheckNode(target)).resolves.toBe("healthy");
+    expect(repoCalls.rotateNodeHostKeyFingerprint).toEqual([
+      {
+        id: target.id,
+        nodeId: target.node_id,
+        expectedFingerprint: null,
+        observedFingerprint: "first-cloud-pin",
+      },
+    ]);
+    expect(repoCalls.attestNodeIncarnation).toEqual([
+      {
+        id: target.id,
+        nodeId: target.node_id,
+        expectedIncarnation: null,
+        expectedHostKeyFingerprint: "first-cloud-pin",
+        observedIncarnation: observed,
+      },
+    ]);
+  });
+
+  test("never reports healthy when stale boot authority cannot be revoked", async () => {
+    const manager = DockerNodeManager.getInstance();
+    const target = {
+      ...node("revocation-failure-node"),
+      id: "00000000-0000-4000-8000-000000000231",
+      fleet_kind: "cloud" as const,
+      infrastructure_provider: "hetzner" as const,
+      provider_server_id: "4444",
+      node_incarnation: "00000000-0000-4000-8000-000000000232",
+    };
+    invalidateNodeIncarnationError = new Error("primary write unavailable");
+    sshMock.connect.mockResolvedValue(undefined);
+    sshMock.exec.mockImplementation((command: string) => {
+      if (command === "cat /proc/sys/kernel/random/boot_id") {
+        return Promise.resolve("malformed-boot-id");
+      }
+      return Promise.resolve("DOCKER-ID-123");
+    });
+
+    await expect(manager.healthCheckNode(target)).resolves.toBe("offline");
+    expect(repoCalls.invalidateNodeIncarnation).toHaveLength(3);
+    expect(repoCalls.updateStatus).toContainEqual({
+      nodeId: target.node_id,
+      status: "offline",
+    });
+    expect(repoCalls.updateStatus).not.toContainEqual({
+      nodeId: target.node_id,
+      status: "healthy",
+    });
+  });
+
+  test("revokes a typed boot when SSH fails before Docker or Docker returns no identity", async () => {
+    const manager = DockerNodeManager.getInstance();
+    const target = {
+      ...node("unverifiable-source-node"),
+      id: "00000000-0000-4000-8000-000000000241",
+      fleet_kind: "cloud" as const,
+      infrastructure_provider: "hetzner" as const,
+      provider_server_id: "4545",
+      node_incarnation: "00000000-0000-4000-8000-000000000242",
+    };
+    const expectedRevocation = {
+      id: target.id,
+      nodeId: target.node_id,
+      expectedIncarnation: target.node_incarnation,
+      expectedHostKeyFingerprint: target.host_key_fingerprint,
+    };
+
+    sshMock.connect.mockRejectedValue(new Error("host key mismatch"));
+    await expect(manager.healthCheckNode(target)).resolves.toBe("offline");
+    expect(repoCalls.invalidateNodeIncarnation).toEqual([
+      expectedRevocation,
+      expectedRevocation,
+      expectedRevocation,
+    ]);
+
+    repoCalls.invalidateNodeIncarnation = [];
+    sshMock.connect.mockResolvedValue(undefined);
+    sshMock.exec.mockResolvedValue("");
+    await expect(manager.healthCheckNode(target)).resolves.toBe("degraded");
+    expect(repoCalls.invalidateNodeIncarnation).toEqual([
+      expectedRevocation,
+      expectedRevocation,
+      expectedRevocation,
+    ]);
   });
 });

--- a/packages/cloud/shared/src/lib/services/docker-node-manager-memory-admission.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager-memory-admission.test.ts
@@ -53,7 +53,7 @@ mock.module("../../db/repositories/docker-nodes", () => ({
     // so it mirrors findEnabled.
     findPlaceable: () => Promise.resolve(enabledNodes),
     updateStatus: () => Promise.resolve(),
-    setHostKeyFingerprint: () => Promise.resolve(),
+    rotateNodeHostKeyFingerprint: () => Promise.resolve(),
   },
 }));
 

--- a/packages/cloud/shared/src/lib/services/docker-node-manager-placement-breaker.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager-placement-breaker.test.ts
@@ -42,7 +42,7 @@ mock.module("../../db/repositories/docker-nodes", () => ({
       repoCalls.updateStatus.push({ nodeId, status });
       return Promise.resolve();
     },
-    setHostKeyFingerprint: () => Promise.resolve(),
+    rotateNodeHostKeyFingerprint: () => Promise.resolve(),
   },
 }));
 

--- a/packages/cloud/shared/src/lib/services/docker-node-manager-placement-state.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager-placement-state.test.ts
@@ -37,7 +37,7 @@ mock.module("../../db/repositories/docker-nodes", () => ({
       return Promise.resolve(allNodes.filter((n) => n.enabled && n.placement_state === "open"));
     },
     updateStatus: () => Promise.resolve(),
-    setHostKeyFingerprint: () => Promise.resolve(),
+    rotateNodeHostKeyFingerprint: () => Promise.resolve(),
     markOfflineAndDisable: () => Promise.resolve(),
   },
 }));

--- a/packages/cloud/shared/src/lib/services/docker-node-manager-robot-first.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager-robot-first.test.ts
@@ -35,7 +35,7 @@ mock.module("../../db/repositories/docker-nodes", () => ({
     findEnabled: () => Promise.resolve(enabledNodes),
     findPlaceable: () => Promise.resolve(enabledNodes),
     updateStatus: () => Promise.resolve(),
-    setHostKeyFingerprint: () => Promise.resolve(),
+    rotateNodeHostKeyFingerprint: () => Promise.resolve(),
   },
 }));
 

--- a/packages/cloud/shared/src/lib/services/docker-node-manager-tofu-persist.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager-tofu-persist.test.ts
@@ -5,16 +5,16 @@
  * (`host_key_fingerprint = NULL`), `DockerNodeManager.sshClientForNode(node)`
  * wires an `onHostKeyDiscovered` callback into the SSH client. After the client
  * accepts the presented key on first connect and captures its fingerprint, that
- * callback persists the fingerprint via
- * `dockerNodesRepository.setHostKeyFingerprint(node_id, fingerprint)` — so every
- * later connect verifies against a real pin.
+ * callback persists the fingerprint via the repository's compare-and-swap pin
+ * rotation API — so every later connect verifies against a real pin.
  *
  * These drive the REAL manager (`healthCheckNode`) with a stubbed repository and
  * a stubbed SSH client that models the boundary: `getClient` captures the wired
  * `onHostKeyDiscovered`, and `connect()` fires it with a concrete captured
  * fingerprint exactly as docker-ssh's post-`ready` handler does — but only when
  * a callback was actually wired (i.e. the row was NULL-pinned). We assert:
- *   1. an unpinned node persists the discovered fingerprint exactly once;
+ *   1. an unpinned node persists the discovered fingerprint exactly once
+ *      through the CAS rotation API that also clears any boot authority;
  *   2. a pinned node wires NO callback and NEVER persists.
  */
 
@@ -35,7 +35,7 @@ const DISCOVERED_FP = "abc123discoveredfingerprint";
 
 const repoCalls = {
   updateStatus: [] as Array<{ nodeId: string; status: string }>,
-  setHostKeyFingerprint: [] as Array<{ nodeId: string; fingerprint: string }>,
+  rotateNodeHostKeyFingerprint: [] as Array<Record<string, unknown>>,
 };
 
 /**
@@ -53,9 +53,9 @@ mock.module("../../db/repositories/docker-nodes", () => ({
       repoCalls.updateStatus.push({ nodeId, status });
       return Promise.resolve();
     },
-    setHostKeyFingerprint: (nodeId: string, fingerprint: string) => {
-      repoCalls.setHostKeyFingerprint.push({ nodeId, fingerprint });
-      return Promise.resolve();
+    rotateNodeHostKeyFingerprint: (input: Record<string, unknown>) => {
+      repoCalls.rotateNodeHostKeyFingerprint.push(input);
+      return Promise.resolve({ host_key_fingerprint: input.observedFingerprint });
     },
   },
 }));
@@ -119,6 +119,10 @@ function node(nodeId: string, hostKeyFingerprint: string | null): DockerNode {
     last_health_check: null,
     ssh_user: "root",
     host_key_fingerprint: hostKeyFingerprint,
+    fleet_kind: null,
+    infrastructure_provider: null,
+    provider_server_id: null,
+    node_incarnation: null,
     metadata: {},
     created_at: new Date("2026-01-01T00:00:00.000Z"),
     updated_at: new Date("2026-01-01T00:00:00.000Z"),
@@ -128,7 +132,7 @@ function node(nodeId: string, hostKeyFingerprint: string | null): DockerNode {
 beforeEach(() => {
   __resetNodeHealthFailureStateForTests();
   repoCalls.updateStatus = [];
-  repoCalls.setHostKeyFingerprint = [];
+  repoCalls.rotateNodeHostKeyFingerprint = [];
   wiredCallbacks.length = 0;
 });
 
@@ -148,8 +152,13 @@ describe("DockerNodeManager TOFU-persist wiring", () => {
     expect(status).toBe("healthy");
     expect(wiredCallbacks).toHaveLength(1);
     expect(wiredCallbacks[0]).toBeDefined();
-    expect(repoCalls.setHostKeyFingerprint).toEqual([
-      { nodeId: "unpinned-node", fingerprint: DISCOVERED_FP },
+    expect(repoCalls.rotateNodeHostKeyFingerprint).toEqual([
+      {
+        id: "unpinned-node-uuid",
+        nodeId: "unpinned-node",
+        expectedFingerprint: null,
+        observedFingerprint: DISCOVERED_FP,
+      },
     ]);
   });
 
@@ -166,6 +175,6 @@ describe("DockerNodeManager TOFU-persist wiring", () => {
     // never a silent re-pin.
     expect(status).toBe("healthy");
     expect(wiredCallbacks).toEqual([undefined]);
-    expect(repoCalls.setHostKeyFingerprint).toHaveLength(0);
+    expect(repoCalls.rotateNodeHostKeyFingerprint).toHaveLength(0);
   });
 });

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.ts
@@ -8,6 +8,7 @@
  */
 
 import crypto from "node:crypto";
+import { parseLinuxBootId } from "../../db/repositories/agent-backup-source-authority";
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import type { DockerNode, DockerNodeStatus } from "../../db/schemas/docker-nodes";
 import { containersEnv } from "../config/containers-env";
@@ -30,6 +31,15 @@ import {
 } from "./docker-sandbox-utils";
 import { DockerSSHClient } from "./docker-ssh";
 import { type DiskHealthVerdict, diskHealthVerdict, probeNodeDiskUsage } from "./node-disk-manager";
+
+const NODE_BOOT_ID_COMMAND = "cat /proc/sys/kernel/random/boot_id";
+
+class BackupSourceRevocationError extends Error {
+  constructor(cause: unknown) {
+    super("Failed to revoke stale backup source authority", { cause });
+    this.name = "BackupSourceRevocationError";
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Pre-pull self-heal bookkeeping (see recoverAfterTimedOutPrePull)
@@ -786,7 +796,12 @@ export class DockerNodeManager {
       node.host_key_fingerprint
         ? undefined
         : async (hostname, fingerprint) => {
-            await dockerNodesRepository.setHostKeyFingerprint(node.node_id, fingerprint);
+            await dockerNodesRepository.rotateNodeHostKeyFingerprint({
+              id: node.id,
+              nodeId: node.node_id,
+              expectedFingerprint: null,
+              observedFingerprint: fingerprint,
+            });
             logger.warn(
               `[docker-node-manager] TOFU-pinned host key for node ${node.node_id} (${hostname}): SHA256:${fingerprint}`,
             );
@@ -831,6 +846,7 @@ export class DockerNodeManager {
         const dockerId = await ssh.exec("docker info --format '{{.ID}}'", 10_000);
 
         if (dockerId.trim()) {
+          await this.attestBackupSourceBoot(node, ssh);
           // Disk-aware verdict: a node whose Docker daemon answers but whose
           // disk is critically full still can't pull images or provision agents
           // (`no space left on device`). Mark it `degraded` so the scheduler
@@ -873,10 +889,23 @@ export class DockerNodeManager {
           await dockerNodesRepository.updateStatus(node.node_id, "healthy");
           return "healthy";
         } else {
+          await this.invalidateBackupSourceBoot(node);
           lastError = "Docker returned empty ID";
         }
       } catch (error: unknown) {
         lastError = error instanceof Error ? error.message : String(error);
+        if (!(error instanceof BackupSourceRevocationError)) {
+          try {
+            await this.invalidateBackupSourceBoot(node);
+          } catch (invalidationError) {
+            // error-policy:J1 the health-loop boundary retains a failed revoke as
+            // the attempt failure and returns only an explicit offline verdict.
+            lastError =
+              invalidationError instanceof Error
+                ? invalidationError.message
+                : String(invalidationError);
+          }
+        }
         if (attempt < MAX_RETRIES) {
           logger.warn(
             `[docker-node-manager] Health check attempt ${attempt}/${MAX_RETRIES} failed for ${node.node_id}: ${lastError}, retrying in ${RETRY_DELAY_MS}ms`,
@@ -936,6 +965,74 @@ export class DockerNodeManager {
     );
     await dockerNodesRepository.updateStatus(node.node_id, "offline");
     return "offline";
+  }
+
+  /**
+   * Publish an exact boot UUID only for explicitly typed Robot/Cloud rows.
+   * An invalid observation may preserve operational health only after the old
+   * incarnation is durably CAS-invalidated; failure to revoke it propagates to
+   * the health/readiness boundary instead of leaving stale capture authority.
+   */
+  private async attestBackupSourceBoot(node: DockerNode, ssh: DockerSSHClient): Promise<void> {
+    if (!hasTypedBackupSourceClassification(node)) return;
+    let expectedHostKeyFingerprint = node.host_key_fingerprint;
+    try {
+      if (expectedHostKeyFingerprint === null) {
+        const observedFingerprint = ssh.getVerifiedHostKeyFingerprint();
+        if (!observedFingerprint) {
+          throw new Error("Verified SSH connection did not expose its host-key fingerprint");
+        }
+        const pinned = await dockerNodesRepository.rotateNodeHostKeyFingerprint({
+          id: node.id,
+          nodeId: node.node_id,
+          expectedFingerprint: null,
+          observedFingerprint,
+        });
+        expectedHostKeyFingerprint = pinned.host_key_fingerprint;
+      }
+      if (expectedHostKeyFingerprint === null) {
+        throw new Error("Backup source node has no persisted SSH host-key fingerprint");
+      }
+      const observedIncarnation = parseLinuxBootId(await ssh.exec(NODE_BOOT_ID_COMMAND, 10_000));
+      await dockerNodesRepository.attestNodeIncarnation({
+        id: node.id,
+        nodeId: node.node_id,
+        expectedIncarnation: node.node_incarnation,
+        expectedHostKeyFingerprint,
+        observedIncarnation,
+      });
+    } catch (error) {
+      // error-policy:J1 source-attestation boundary translates every failed
+      // proof into durable revocation before operational health may continue.
+      logger.error(
+        "[docker-node-manager] Backup source boot attestation failed; invalidating source authority",
+        {
+          nodeId: node.node_id,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+      await this.invalidateBackupSourceBoot(node, expectedHostKeyFingerprint);
+    }
+  }
+
+  /** Revoke a typed source boot without inferring identity from node metadata. */
+  private async invalidateBackupSourceBoot(
+    node: DockerNode,
+    expectedHostKeyFingerprint: string | null = node.host_key_fingerprint,
+  ): Promise<void> {
+    if (!hasTypedBackupSourceClassification(node)) return;
+    try {
+      await dockerNodesRepository.invalidateNodeIncarnation({
+        id: node.id,
+        nodeId: node.node_id,
+        expectedIncarnation: node.node_incarnation,
+        expectedHostKeyFingerprint,
+      });
+    } catch (error) {
+      // error-policy:J2 callers must distinguish failed revocation from the
+      // original SSH/probe error and preserve the repository failure as cause.
+      throw new BackupSourceRevocationError(error);
+    }
   }
 
   /**
@@ -1069,6 +1166,7 @@ export class DockerNodeManager {
       const psiSection = readProbeSection(probeOutput, READINESS_PROBE_PSI_MARKER);
       const { dockerId, architecture } = parseDockerInfoProbe(dockerSection);
       if (dockerId.trim()) {
+        await this.attestBackupSourceBoot(node, ssh);
         if (
           !isArchitectureCompatibleWithPlatform(architecture, options.requiredPlatform) &&
           requiredArchitectureForPlatform(options.requiredPlatform)
@@ -1139,6 +1237,7 @@ export class DockerNodeManager {
         await dockerNodesRepository.updateStatus(node.node_id, "healthy");
         return true;
       }
+      await this.invalidateBackupSourceBoot(node);
       if (isAutoscaledNode(node)) {
         await dockerNodesRepository.updateStatus(node.node_id, "degraded");
       } else {
@@ -1149,7 +1248,19 @@ export class DockerNodeManager {
       logger.warn(`[docker-node-manager] Node ${node.node_id} Docker probe returned empty ID`);
       return false;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      let message = error instanceof Error ? error.message : String(error);
+      if (!(error instanceof BackupSourceRevocationError)) {
+        try {
+          await this.invalidateBackupSourceBoot(node);
+        } catch (invalidationError) {
+          // error-policy:J1 readiness fails explicitly when source revocation
+          // cannot be persisted; placement never treats this as a healthy node.
+          message =
+            invalidationError instanceof Error
+              ? invalidationError.message
+              : String(invalidationError);
+        }
+      }
       // See healthCheckNode for rationale: canonical nodes are never marked
       // offline from a transient ssh failure during scheduling.
       if (isAutoscaledNode(node)) {
@@ -1444,6 +1555,16 @@ export class DockerNodeManager {
       return null;
     }
   }
+}
+
+function hasTypedBackupSourceClassification(node: DockerNode): boolean {
+  if (node.infrastructure_provider !== "hetzner") return false;
+  return (
+    (node.fleet_kind === "robot" && node.provider_server_id === null) ||
+    (node.fleet_kind === "cloud" &&
+      typeof node.provider_server_id === "string" &&
+      node.provider_server_id.length > 0)
+  );
 }
 
 export const dockerNodeManager = DockerNodeManager.getInstance();

--- a/packages/cloud/shared/src/lib/storage/agent-backup-object-store-exact-read.test.ts
+++ b/packages/cloud/shared/src/lib/storage/agent-backup-object-store-exact-read.test.ts
@@ -86,6 +86,7 @@ function makeRuntimeBucket(): {
   providerPullCount(): number;
   providerCancelCount(): number;
   setReadMode(mode: RuntimeReadMode): void;
+  setCancelHangs(value: boolean): void;
   setDeclaredSize(key: string, size: number): void;
   changeGeneration(key: string): void;
 } {
@@ -95,6 +96,7 @@ function makeRuntimeBucket(): {
   let mode: RuntimeReadMode = "normal";
   let pulls = 0;
   let cancels = 0;
+  let cancelHangs = false;
 
   const streamFor = (stored: RuntimeStoredObject): ReadableStream<Uint8Array> => {
     let bytes = stored.bodyBytes.slice();
@@ -128,6 +130,7 @@ function makeRuntimeBucket(): {
       },
       async cancel() {
         cancelled = true;
+        if (cancelHangs) return new Promise<never>(() => undefined);
         await new Promise((resolve) => setTimeout(resolve, 2));
         cancels += 1;
       },
@@ -141,6 +144,9 @@ function makeRuntimeBucket(): {
     providerCancelCount: () => cancels,
     setReadMode(nextMode) {
       mode = nextMode;
+    },
+    setCancelHangs(value) {
+      cancelHangs = value;
     },
     setDeclaredSize(key, size) {
       const stored = objects.get(key);
@@ -193,7 +199,7 @@ function makeRuntimeBucket(): {
           size: body.byteLength,
           etag: `etag-${key.length}`,
           version: `version-${key.length}`,
-          checksums: { sha256: checksum },
+          checksums: { sha256: checksum.slice(0) },
           customMetadata: options?.customMetadata,
         };
         objects.set(key, stored);
@@ -505,6 +511,19 @@ describe("agent backup exact streamed reads", () => {
     expect(runtime.providerCancelCount()).toBe(cancelCountBeforeInvalidMetadata + 1);
     expect(runtime.getCalls).toHaveLength(getCount + 4);
     expect(runtime.providerCancelCount()).toBeGreaterThanOrEqual(3);
+
+    runtime.setCancelHangs(true);
+    const hungCancelStartedAt = Date.now();
+    await expect(
+      store.getExactObject({
+        locator: exactLocator,
+        expectedSize: bytes.byteLength,
+        expectedCipherSha256: digest.hex,
+        deadline: new Date(Date.now() + 10),
+      }),
+    ).rejects.toMatchObject({ code: "OBJECT_STORAGE_METADATA_INVALID" });
+    expect(Date.now() - hungCancelStartedAt).toBeLessThan(250);
+    runtime.setCancelHangs(false);
 
     const emptyKey = "agent-sandbox-backups/org-read/backup-headers/chunk-empty";
     const empty = new Uint8Array();

--- a/packages/cloud/shared/src/lib/storage/agent-backup-object-store.test.ts
+++ b/packages/cloud/shared/src/lib/storage/agent-backup-object-store.test.ts
@@ -64,7 +64,7 @@ function makeRuntimeBucket(): {
           size,
           etag: `etag-${key.length}`,
           version: `version-${key.length}`,
-          checksums: { sha256 },
+          checksums: { sha256: sha256.slice(0) },
           customMetadata: options.customMetadata,
         };
         objects.set(key, object);
@@ -168,6 +168,16 @@ afterAll(() => {
 });
 
 describe("agent backup explicit object storage", () => {
+  test("rejects non-loopback cleartext S3 endpoints before credentials can be used", async () => {
+    await expect(
+      createAgentBackupObjectStore(
+        s3Endpoint("hetzner-object-storage", {
+          endpoint: "http://object-storage.example.invalid",
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "OBJECT_STORAGE_LOCATOR_UNAVAILABLE" });
+  });
+
   test("maps Worker R2 primary authority and keeps receipts privacy-safe", async () => {
     const runtime = makeRuntimeBucket();
     const endpoint = workerEndpoint(runtime.bucket);

--- a/packages/cloud/shared/src/lib/storage/agent-backup-object-store.ts
+++ b/packages/cloud/shared/src/lib/storage/agent-backup-object-store.ts
@@ -18,7 +18,9 @@ import {
   type ObjectDeleteReceipt,
   type ObjectDeleteTarget,
   type ObjectHeadReceipt,
+  type ObjectRequestControl,
   ObjectStorageLifecycleError,
+  type PutImmutableObjectInput,
   putImmutableObjectAtBackend,
 } from "./object-store";
 import type { RuntimeR2Bucket } from "./r2-runtime-binding";
@@ -67,14 +69,10 @@ export interface AgentBackupStorageAuthority {
 
 export interface AgentBackupObjectStore {
   readonly authority: AgentBackupStorageAuthority;
-  head(key: string): Promise<ObjectHeadReceipt>;
+  head(key: string, control?: ObjectRequestControl): Promise<ObjectHeadReceipt>;
   /** Stream one exact catalogued generation; await `completion` before commit. */
   getExactObject(input: GetExactObjectInput): Promise<ExactObjectRead>;
-  putImmutable(params: {
-    key: string;
-    body: ArrayBuffer | Uint8Array;
-    contentType?: string;
-  }): Promise<ImmutableObjectUploadReceipt>;
+  putImmutable(params: PutImmutableObjectInput): Promise<ImmutableObjectUploadReceipt>;
   delete(target: ObjectDeleteTarget): Promise<ObjectDeleteReceipt>;
 }
 
@@ -107,8 +105,13 @@ function normalizeEndpoint(endpoint: string): string {
       "Agent backup S3 storage requires a canonical endpoint URL",
     );
   }
+  const loopbackHttp =
+    parsed.protocol === "http:" &&
+    (parsed.hostname === "localhost" ||
+      /^127(?:\.[0-9]{1,3}){3}$/.test(parsed.hostname) ||
+      parsed.hostname === "[::1]");
   if (
-    (parsed.protocol !== "https:" && parsed.protocol !== "http:") ||
+    (parsed.protocol !== "https:" && !loopbackHttp) ||
     parsed.username ||
     parsed.password ||
     parsed.search ||
@@ -221,7 +224,8 @@ export async function createAgentBackupObjectStore(
 
   return Object.freeze({
     authority,
-    head: (key: string) => headObjectAtBackend(backend, key),
+    head: (key: string, control?: ObjectRequestControl) =>
+      headObjectAtBackend(backend, key, control),
     getExactObject: (input: GetExactObjectInput) => getExactObjectAtBackend({ backend, input }),
     putImmutable: (params: Parameters<AgentBackupObjectStore["putImmutable"]>[0]) =>
       putImmutableObjectAtBackend({ backend, ...params }),

--- a/packages/cloud/shared/src/lib/storage/object-store-immutable-upload.test.ts
+++ b/packages/cloud/shared/src/lib/storage/object-store-immutable-upload.test.ts
@@ -291,7 +291,7 @@ describe("Worker R2 immutable exact-key upload", () => {
     expect(providerBody?.buffer).not.toBe(transferred.buffer);
     expect(transferred.every((byte) => byte === 0)).toBe(true);
     expect(providerBody?.every((byte) => byte === 0)).toBe(true);
-  });
+  }, 30_000);
 
   test("replays the same HEAD receipt after response loss and refuses different bytes", async () => {
     const key = "agent-sandbox-backups/private-org/operation-a/chunk-0001";

--- a/packages/cloud/shared/src/lib/storage/object-store-immutable-upload.test.ts
+++ b/packages/cloud/shared/src/lib/storage/object-store-immutable-upload.test.ts
@@ -37,7 +37,9 @@ const ORIGINAL_STORAGE_ENV = new Map(
 
 interface StoredS3Object {
   size: number;
-  sha256: string;
+  providerSha256: string;
+  declaredSha256: string;
+  exposeProviderChecksum?: boolean;
   etag: string;
   version: string;
 }
@@ -45,6 +47,7 @@ interface StoredS3Object {
 interface S3PutBehavior {
   status: number;
   persist: boolean;
+  delayMs?: number;
 }
 
 interface S3Call {
@@ -105,12 +108,18 @@ function s3Error(status: number): Response {
   });
 }
 
-function storeS3Object(key: string, size: number, sha256: string): void {
+function storeS3Object(
+  key: string,
+  size: number,
+  providerSha256: string,
+  declaredSha256: string,
+): void {
   s3Objects.set(key, {
     size,
-    sha256,
-    etag: `etag-${sha256.slice(0, 12)}`,
-    version: `version-${sha256.slice(0, 12)}`,
+    providerSha256,
+    declaredSha256,
+    etag: `etag-${providerSha256.slice(0, 12)}`,
+    version: `version-${providerSha256.slice(0, 12)}`,
   });
 }
 
@@ -159,16 +168,19 @@ beforeAll(() => {
             headers: { "x-amz-request-id": "head-missing" },
           });
         }
+        const headers: Record<string, string> = {
+          "content-length": String(object.size),
+          etag: `"${object.etag}"`,
+          "x-amz-meta-eliza-content-sha256": object.declaredSha256,
+          "x-amz-request-id": "head-present",
+          "x-amz-version-id": object.version,
+        };
+        if (object.exposeProviderChecksum !== false) {
+          headers["x-amz-checksum-sha256"] = object.providerSha256;
+        }
         return new Response(null, {
           status: 200,
-          headers: {
-            "content-length": String(object.size),
-            etag: `"${object.etag}"`,
-            "x-amz-checksum-sha256": object.sha256,
-            "x-amz-meta-eliza-content-sha256": object.sha256,
-            "x-amz-request-id": "head-present",
-            "x-amz-version-id": object.version,
-          },
+          headers,
         });
       }
 
@@ -182,7 +194,15 @@ beforeAll(() => {
         if (s3Objects.has(key)) return s3Error(412);
 
         const behavior = s3PutBehaviors.get(key)?.shift();
-        if (behavior?.persist || !behavior) storeS3Object(key, body.byteLength, sha256);
+        if (behavior?.delayMs) {
+          await new Promise((resolve) => setTimeout(resolve, behavior.delayMs));
+        }
+        const providerSha256 = Buffer.from(await crypto.subtle.digest("SHA-256", body)).toString(
+          "base64",
+        );
+        if (behavior?.persist || !behavior) {
+          storeS3Object(key, body.byteLength, providerSha256, sha256);
+        }
         if (behavior && behavior.status !== 200) return s3Error(behavior.status);
         const stored = s3Objects.get(key);
         return new Response(null, {
@@ -234,11 +254,51 @@ describe("Worker R2 immutable exact-key upload", () => {
     expect(String(error)).not.toContain(key);
   });
 
+  test("uploads the maximum transferred body with only one provider-attempt copy", async () => {
+    const key = "agent-sandbox-backups/private-org/operation-max-transfer/chunk-0001";
+    const transferred = new Uint8Array(MAX_IMMUTABLE_SINGLE_PUT_BYTES);
+    transferred[0] = 0x51;
+    transferred[transferred.length - 1] = 0x52;
+    let providerBody: Uint8Array | undefined;
+    let stored: RuntimeR2ObjectMetadata | null = null;
+    process.env.STORAGE_HEAVY_PAYLOADS_BUCKET = "runtime-private-backups";
+    setRuntimeR2Bucket({
+      async head() {
+        return stored;
+      },
+      async get() {
+        return null;
+      },
+      async put(_exactKey, value, options) {
+        if (!(value instanceof Uint8Array)) throw new Error("expected transferred byte body");
+        providerBody = value;
+        const checksum = options?.sha256;
+        if (!(checksum instanceof ArrayBuffer)) throw new Error("expected SHA-256 bytes");
+        stored = {
+          size: value.byteLength,
+          etag: "maximum-transfer-etag",
+          version: "maximum-transfer-version",
+          checksums: { sha256: checksum.slice(0) },
+        };
+        return stored;
+      },
+      async delete() {},
+    });
+
+    await expect(
+      putImmutableObject({ key, body: transferred, transferBodyOwnership: true }),
+    ).resolves.toMatchObject({ metadata: { sizeBytes: MAX_IMMUTABLE_SINGLE_PUT_BYTES } });
+    expect(providerBody?.buffer).not.toBe(transferred.buffer);
+    expect(transferred.every((byte) => byte === 0)).toBe(true);
+    expect(providerBody?.every((byte) => byte === 0)).toBe(true);
+  });
+
   test("replays the same HEAD receipt after response loss and refuses different bytes", async () => {
     const key = "agent-sandbox-backups/private-org/operation-a/chunk-0001";
     let stored: RuntimeR2ObjectMetadata | null = null;
     let putCalls = 0;
     let loseFirstResponse = true;
+    const providerDigestInputs: ArrayBuffer[] = [];
     process.env.STORAGE_HEAVY_PAYLOADS_BUCKET = "runtime-private-backups";
     const bucket: RuntimeR2Bucket = {
       async head() {
@@ -257,11 +317,12 @@ describe("Worker R2 immutable exact-key upload", () => {
         const size = value instanceof Uint8Array ? value.byteLength : 0;
         const sha256 = options?.sha256;
         if (!(sha256 instanceof ArrayBuffer)) throw new Error("expected SHA-256 bytes");
+        providerDigestInputs.push(sha256);
         stored = {
           size,
           etag: "runtime-etag-a",
           version: "runtime-version-a",
-          checksums: { sha256 },
+          checksums: { sha256: sha256.slice(0) },
           customMetadata: options.customMetadata,
         };
         if (loseFirstResponse) {
@@ -289,12 +350,16 @@ describe("Worker R2 immutable exact-key upload", () => {
     );
     expect(String(mismatch)).not.toContain(key);
     expect(putCalls).toBe(3);
+    expect(
+      providerDigestInputs.every((digest) => new Uint8Array(digest).every((byte) => byte === 0)),
+    ).toBe(true);
   });
 
   test("retries 429/5xx within the explicit budget and stops at the cap", async () => {
     const key = "agent-sandbox-backups/private-org/operation-b/chunk-0001";
     let stored: RuntimeR2ObjectMetadata | null = null;
     let putCalls = 0;
+    let leaseChecks = 0;
     const failures = [429, 503];
     process.env.STORAGE_HEAVY_PAYLOADS_BUCKET = "runtime-private-backups";
     setRuntimeR2Bucket({
@@ -314,18 +379,27 @@ describe("Worker R2 immutable exact-key upload", () => {
           size: value instanceof Uint8Array ? value.byteLength : 0,
           etag: "runtime-etag-b",
           version: "runtime-version-b",
-          checksums: { sha256 },
+          checksums: { sha256: sha256.slice(0) },
         };
         return stored;
       },
       async delete() {},
     });
 
-    await expect(putImmutableObject({ key, body: bytes(5, 6, 7) })).resolves.toMatchObject({
+    await expect(
+      putImmutableObject({
+        key,
+        body: bytes(5, 6, 7),
+        beforeWriteAttempt: async () => {
+          leaseChecks += 1;
+        },
+      }),
+    ).resolves.toMatchObject({
       verifiedPresent: true,
       metadata: { sizeBytes: 3 },
     });
     expect(putCalls).toBe(MAX_IMMUTABLE_PUT_ATTEMPTS);
+    expect(leaseChecks).toBe(MAX_IMMUTABLE_PUT_ATTEMPTS);
 
     stored = null;
     putCalls = 0;
@@ -335,6 +409,225 @@ describe("Worker R2 immutable exact-key upload", () => {
       "OBJECT_STORAGE_UPLOAD_RETRY_EXHAUSTED",
     );
     expect(putCalls).toBe(MAX_IMMUTABLE_PUT_ATTEMPTS);
+  });
+
+  test("never starts a later retry after its lease fence is rejected", async () => {
+    const key = "agent-sandbox-backups/private-org/operation-retry-fenced/chunk-0001";
+    let putCalls = 0;
+    let leaseChecks = 0;
+    process.env.STORAGE_HEAVY_PAYLOADS_BUCKET = "runtime-private-backups";
+    setRuntimeR2Bucket({
+      async head() {
+        return null;
+      },
+      async get() {
+        return null;
+      },
+      async put() {
+        putCalls += 1;
+        throw providerFailure(503);
+      },
+      async delete() {},
+    });
+
+    await expect(
+      putImmutableObject({
+        key,
+        body: bytes(59),
+        beforeWriteAttempt: async () => {
+          leaseChecks += 1;
+          if (leaseChecks === 2) throw new Error("lease generation expired");
+        },
+      }),
+    ).rejects.toThrow("lease generation expired");
+    expect(leaseChecks).toBe(2);
+    expect(putCalls).toBe(1);
+  });
+
+  test("bounds a hung provider PUT with the absolute deadline and never starts HEAD", async () => {
+    const key = "agent-sandbox-backups/private-org/operation-hung/chunk-0001";
+    let putCalls = 0;
+    let headCalls = 0;
+    process.env.STORAGE_HEAVY_PAYLOADS_BUCKET = "runtime-private-backups";
+    setRuntimeR2Bucket({
+      async head() {
+        headCalls += 1;
+        return null;
+      },
+      async get() {
+        return null;
+      },
+      async put() {
+        putCalls += 1;
+        return new Promise<never>(() => undefined);
+      },
+      async delete() {},
+    });
+
+    await expectLifecycleError(
+      putImmutableObject({
+        key,
+        body: bytes(61, 62),
+        deadline: new Date(Date.now() + 15),
+      }),
+      "OBJECT_STORAGE_UPLOAD_DEADLINE_EXCEEDED",
+    );
+    expect(putCalls).toBe(1);
+    expect(headCalls).toBe(0);
+  });
+
+  test("cancels a hung provider PUT from the caller signal without retrying", async () => {
+    const key = "agent-sandbox-backups/private-org/operation-aborted/chunk-0001";
+    const controller = new AbortController();
+    let putCalls = 0;
+    process.env.STORAGE_HEAVY_PAYLOADS_BUCKET = "runtime-private-backups";
+    setRuntimeR2Bucket({
+      async head() {
+        throw new Error("aborted upload must not reach HEAD");
+      },
+      async get() {
+        return null;
+      },
+      async put() {
+        putCalls += 1;
+        controller.abort();
+        return new Promise<never>(() => undefined);
+      },
+      async delete() {},
+    });
+
+    await expectLifecycleError(
+      putImmutableObject({ key, body: bytes(64), signal: controller.signal }),
+      "OBJECT_STORAGE_UPLOAD_ABORTED",
+    );
+    expect(putCalls).toBe(1);
+  });
+
+  test("bounds the post-write verification HEAD with the same deadline", async () => {
+    const key = "agent-sandbox-backups/private-org/operation-hung-head/chunk-0001";
+    let headCalls = 0;
+    process.env.STORAGE_HEAVY_PAYLOADS_BUCKET = "runtime-private-backups";
+    setRuntimeR2Bucket({
+      async head() {
+        headCalls += 1;
+        return new Promise<never>(() => undefined);
+      },
+      async get() {
+        return null;
+      },
+      async put(_exactKey, value, options) {
+        const checksum = options?.sha256;
+        if (!(checksum instanceof ArrayBuffer)) throw new Error("expected SHA-256 bytes");
+        return {
+          size: value instanceof Uint8Array ? value.byteLength : 0,
+          etag: "hung-head-etag",
+          version: "hung-head-version",
+          checksums: { sha256: checksum.slice(0) },
+        };
+      },
+      async delete() {},
+    });
+
+    await expectLifecycleError(
+      putImmutableObject({
+        key,
+        body: bytes(65),
+        deadline: new Date(Date.now() + 15),
+      }),
+      "OBJECT_STORAGE_UPLOAD_DEADLINE_EXCEEDED",
+    );
+    expect(headCalls).toBe(1);
+  });
+
+  test("does not start a retry after the shared deadline expires in backoff", async () => {
+    const key = "agent-sandbox-backups/private-org/operation-backoff-deadline/chunk-0001";
+    let putCalls = 0;
+    process.env.STORAGE_HEAVY_PAYLOADS_BUCKET = "runtime-private-backups";
+    setRuntimeR2Bucket({
+      async head() {
+        return null;
+      },
+      async get() {
+        return null;
+      },
+      async put() {
+        putCalls += 1;
+        throw providerFailure(503);
+      },
+      async delete() {},
+    });
+
+    await expectLifecycleError(
+      putImmutableObject({
+        key,
+        body: bytes(66),
+        deadline: new Date(Date.now() + 10),
+      }),
+      "OBJECT_STORAGE_UPLOAD_DEADLINE_EXCEEDED",
+    );
+    expect(putCalls).toBe(1);
+  });
+
+  test("does not adopt a pre-existing object when the pre-write fence rejects", async () => {
+    const key = "agent-sandbox-backups/private-org/operation-fenced/chunk-0001";
+    let putCalls = 0;
+    let headCalls = 0;
+    process.env.STORAGE_HEAVY_PAYLOADS_BUCKET = "runtime-private-backups";
+    setRuntimeR2Bucket({
+      async head() {
+        headCalls += 1;
+        throw new Error("pre-existing object must not be inspected");
+      },
+      async get() {
+        return null;
+      },
+      async put() {
+        putCalls += 1;
+        throw new Error("provider write must not start");
+      },
+      async delete() {},
+    });
+
+    await expect(
+      putImmutableObject({
+        key,
+        body: bytes(63),
+        beforeWriteAttempt: async () => {
+          throw new Error("lease fence rejected");
+        },
+      }),
+    ).rejects.toThrow("lease fence rejected");
+    expect(putCalls).toBe(0);
+    expect(headCalls).toBe(0);
+  });
+
+  test("does not treat forged uploader metadata as a provider-validated R2 checksum", async () => {
+    const key = "agent-sandbox-backups/private-org/operation-forged-r2/chunk-0001";
+    let stored: RuntimeR2ObjectMetadata | null = null;
+    process.env.STORAGE_HEAVY_PAYLOADS_BUCKET = "runtime-private-backups";
+    setRuntimeR2Bucket({
+      async head() {
+        return stored;
+      },
+      async get() {
+        return null;
+      },
+      async put(_exactKey, value, options) {
+        stored = {
+          size: value instanceof Uint8Array ? value.byteLength : 0,
+          etag: "forged-metadata-etag",
+          version: "forged-metadata-version",
+          customMetadata: options?.customMetadata,
+        };
+        return stored;
+      },
+      async delete() {},
+    });
+
+    await expectLifecycleError(
+      putImmutableObject({ key, body: bytes(67, 68) }),
+      "OBJECT_STORAGE_IMMUTABLE_CONFLICT",
+    );
   });
 });
 
@@ -405,5 +698,72 @@ describe("S3-compatible immutable exact-key upload", () => {
     expect(String(error)).not.toContain(key);
     expect(s3Calls.filter(({ method }) => method === "PUT")).toHaveLength(1);
     expect(s3Objects.has(key)).toBe(false);
+  });
+
+  test("never adopts matching bytes persisted by unsupported or fatal PUT responses", async () => {
+    configureS3();
+    const unsupportedKey =
+      "agent-sandbox-backups/private-org/operation-unsupported-persisted/chunk-0001";
+    s3PutBehaviors.set(unsupportedKey, [{ status: 501, persist: true }]);
+    await expectLifecycleError(
+      putImmutableObject({ key: unsupportedKey, body: bytes(42) }),
+      "OBJECT_STORAGE_IMMUTABLE_PUT_UNSUPPORTED",
+    );
+    expect(s3Objects.has(unsupportedKey)).toBe(true);
+    expect(
+      s3Calls.filter(({ method, key }) => method === "HEAD" && key === unsupportedKey),
+    ).toHaveLength(0);
+
+    const fatalKey = "agent-sandbox-backups/private-org/operation-fatal-persisted/chunk-0001";
+    s3PutBehaviors.set(fatalKey, [{ status: 400, persist: true }]);
+    await expectLifecycleError(
+      putImmutableObject({ key: fatalKey, body: bytes(43) }),
+      "OBJECT_STORAGE_UPLOAD_FAILED",
+    );
+    expect(s3Objects.has(fatalKey)).toBe(true);
+    expect(s3Calls.filter(({ method, key }) => method === "HEAD" && key === fatalKey)).toHaveLength(
+      0,
+    );
+  });
+
+  test("does not adopt a same-size S3 object with forged checksum metadata", async () => {
+    configureS3();
+    const key = "agent-sandbox-backups/private-org/operation-forged-s3/chunk-0001";
+    const expectedBody = bytes(44, 45);
+    const expectedSha256 = Buffer.from(
+      await crypto.subtle.digest("SHA-256", expectedBody),
+    ).toString("base64");
+    const corruptSha256 = Buffer.from(
+      await crypto.subtle.digest("SHA-256", bytes(45, 44)),
+    ).toString("base64");
+    s3Objects.set(key, {
+      size: expectedBody.byteLength,
+      providerSha256: corruptSha256,
+      declaredSha256: expectedSha256,
+      exposeProviderChecksum: false,
+      etag: "forged-s3-etag",
+      version: "forged-s3-version",
+    });
+
+    await expectLifecycleError(
+      putImmutableObject({ key, body: expectedBody }),
+      "OBJECT_STORAGE_IMMUTABLE_CONFLICT",
+    );
+  });
+
+  test("aborts a hung secondary-compatible PUT at the shared absolute deadline", async () => {
+    configureS3();
+    const key = "agent-sandbox-backups/private-org/operation-s3-hung/chunk-0001";
+    s3PutBehaviors.set(key, [{ status: 200, persist: true, delayMs: 150 }]);
+
+    await expectLifecycleError(
+      putImmutableObject({
+        key,
+        body: bytes(71, 72),
+        deadline: new Date(Date.now() + 20),
+      }),
+      "OBJECT_STORAGE_UPLOAD_DEADLINE_EXCEEDED",
+    );
+    expect(s3Calls.filter(({ method }) => method === "HEAD")).toHaveLength(0);
   });
 });

--- a/packages/cloud/shared/src/lib/storage/object-store.ts
+++ b/packages/cloud/shared/src/lib/storage/object-store.ts
@@ -204,12 +204,36 @@ export interface ImmutableObjectUploadReceipt {
   verifiedPresent: true;
 }
 
+/** Caller cancellation plus an absolute wall-clock bound for provider I/O. */
+export interface ObjectRequestControl {
+  readonly signal?: AbortSignal;
+  readonly deadline?: Date;
+}
+
+export interface PutImmutableObjectInput extends ObjectRequestControl {
+  readonly key: string;
+  readonly body: ArrayBuffer | Uint8Array;
+  readonly contentType?: string;
+  /**
+   * Transfer this exact mutable byte range to the storage boundary. The bytes
+   * are wiped before settlement; callers must not read or mutate them again.
+   */
+  readonly transferBodyOwnership?: boolean;
+  /**
+   * Fenced authority check run immediately before every provider PUT attempt.
+   * A rejection prevents both the PUT and any response-loss reconciliation.
+   */
+  readonly beforeWriteAttempt?: () => Promise<void>;
+}
+
 /**
  * Single-PUT uploads are intentionally smaller than the Worker memory limit.
  * Larger backup artifacts must use the future streaming/multipart primitive.
  */
 export const MAX_IMMUTABLE_SINGLE_PUT_BYTES = 32 * 1024 * 1024;
 export const MAX_IMMUTABLE_PUT_ATTEMPTS = 3;
+export const MAX_IMMUTABLE_UPLOAD_DURATION_MS = 5 * 60 * 1_000;
+export const DEFAULT_IMMUTABLE_UPLOAD_DURATION_MS = 2 * 60 * 1_000;
 /** Mirrors the durable backup catalogue's per-object safety ceiling. */
 export const MAX_EXACT_OBJECT_READ_BYTES = 1024 * 1024 * 1024;
 
@@ -228,6 +252,8 @@ export type ObjectStorageLifecycleErrorCode =
   | "OBJECT_STORAGE_UPLOAD_FAILED"
   | "OBJECT_STORAGE_UPLOAD_UNCONFIRMED"
   | "OBJECT_STORAGE_UPLOAD_RETRY_EXHAUSTED"
+  | "OBJECT_STORAGE_UPLOAD_ABORTED"
+  | "OBJECT_STORAGE_UPLOAD_DEADLINE_EXCEEDED"
   | "OBJECT_STORAGE_READ_TOO_LARGE"
   | "OBJECT_STORAGE_READ_NOT_FOUND"
   | "OBJECT_STORAGE_READ_BODY_UNAVAILABLE"
@@ -558,7 +584,10 @@ function requireObjectSize(value: number | undefined): number {
   return value;
 }
 
-function runtimeChecksum(object: RuntimeR2ObjectMetadata): ObjectChecksumReceipt {
+function runtimeChecksum(
+  object: RuntimeR2ObjectMetadata,
+  requireProviderValidated = false,
+): ObjectChecksumReceipt {
   if (object.checksums?.sha256) {
     return {
       algorithm: "sha256",
@@ -566,9 +595,11 @@ function runtimeChecksum(object: RuntimeR2ObjectMetadata): ObjectChecksumReceipt
       value: checksumBytesToBase64(object.checksums.sha256),
     };
   }
-  const declaredSha256 = normalizedSha256(object.customMetadata?.[IMMUTABLE_SHA256_METADATA_KEY]);
-  if (declaredSha256) {
-    return { algorithm: "sha256", encoding: "base64", value: declaredSha256 };
+  if (!requireProviderValidated) {
+    const declaredSha256 = normalizedSha256(object.customMetadata?.[IMMUTABLE_SHA256_METADATA_KEY]);
+    if (declaredSha256) {
+      return { algorithm: "sha256", encoding: "base64", value: declaredSha256 };
+    }
   }
   if (object.checksums?.sha1) {
     return {
@@ -592,13 +623,18 @@ function runtimeChecksum(object: RuntimeR2ObjectMetadata): ObjectChecksumReceipt
   );
 }
 
-function s3Checksum(object: HeadObjectCommandOutput): ObjectChecksumReceipt {
+function s3Checksum(
+  object: HeadObjectCommandOutput,
+  requireProviderValidated = false,
+): ObjectChecksumReceipt {
   if (object.ChecksumSHA256) {
     return { algorithm: "sha256", encoding: "base64", value: object.ChecksumSHA256 };
   }
-  const declaredSha256 = normalizedSha256(object.Metadata?.[IMMUTABLE_SHA256_METADATA_KEY]);
-  if (declaredSha256) {
-    return { algorithm: "sha256", encoding: "base64", value: declaredSha256 };
+  if (!requireProviderValidated) {
+    const declaredSha256 = normalizedSha256(object.Metadata?.[IMMUTABLE_SHA256_METADATA_KEY]);
+    if (declaredSha256) {
+      return { algorithm: "sha256", encoding: "base64", value: declaredSha256 };
+    }
   }
   if (object.ChecksumSHA1) {
     return { algorithm: "sha1", encoding: "base64", value: object.ChecksumSHA1 };
@@ -725,9 +761,11 @@ async function headObjectOnBackend(
   keyFingerprint: string,
   requestChecksum = false,
   providerVersionId?: string,
+  control?: ImmutableUploadAbortContext,
 ): Promise<ObjectHeadReceipt> {
   if (backend.runtimeBucket) {
-    const object = await backend.runtimeBucket.head(key);
+    const request = backend.runtimeBucket.head(key);
+    const object = control ? await control.race(request) : await request;
     if (!object) {
       return {
         status: "absent",
@@ -735,7 +773,7 @@ async function headObjectOnBackend(
         metadata: null,
       };
     }
-    const checksum = runtimeChecksum(object);
+    const checksum = runtimeChecksum(object, requestChecksum);
     return {
       status: "present",
       locator: makeLocator(
@@ -748,15 +786,17 @@ async function headObjectOnBackend(
   }
 
   try {
-    const object = await backend.s3Client.send(
+    const request = backend.s3Client.send(
       new HeadObjectCommand({
         Bucket: backend.locator.bucket,
         Key: key,
         VersionId: providerVersionId,
         ChecksumMode: requestChecksum ? "ENABLED" : undefined,
       }),
+      control ? { abortSignal: control.signal } : undefined,
     );
-    const checksum = s3Checksum(object);
+    const object = control ? await control.race(request) : await request;
+    const checksum = s3Checksum(object, requestChecksum);
     return {
       status: "present",
       locator: makeLocator(
@@ -767,8 +807,7 @@ async function headObjectOnBackend(
       metadata: { sizeBytes: requireObjectSize(object.ContentLength), checksum },
     };
   } catch (error) {
-    // error-policy:J1 translate only the provider's authoritative not-found
-    // response into the explicit absent result at the object-store boundary.
+    if (control?.signal.aborted) throw control.failure();
     if (!isS3ObjectNotFound(error)) throw error;
     return {
       status: "absent",
@@ -1013,10 +1052,13 @@ function s3ResponseBodyStream(body: GetObjectCommandOutput["Body"]): ReadableStr
   );
 }
 
-async function cancelUntransferredBody(body: unknown): Promise<void> {
+async function cancelUntransferredBody(
+  body: unknown,
+  context: ExactReadAbortContext,
+): Promise<void> {
   try {
     if (isReadableByteStream(body)) {
-      await body.cancel();
+      await raceRuntimeGet(Promise.resolve(body.cancel()), context);
       return;
     }
     if (
@@ -1035,11 +1077,12 @@ async function cancelUntransferredBody(body: unknown): Promise<void> {
       typeof body.transformToWebStream === "function"
     ) {
       const stream = body.transformToWebStream();
-      if (isReadableByteStream(stream)) await stream.cancel();
+      if (isReadableByteStream(stream)) {
+        await raceRuntimeGet(Promise.resolve(stream.cancel()), context);
+      }
     }
   } catch {
-    // error-policy:J6 best-effort teardown must not replace the static
-    // storage-domain error.
+    // Best-effort teardown must not replace the static storage-domain error.
   }
 }
 
@@ -1099,9 +1142,8 @@ function createVerifiedExactRead(input: {
     resolveCompletion = resolve;
     rejectCompletion = reject;
   });
-  // error-policy:J5 the contract requires callers to await completion, but
-  // attach an observer so an abandoned caller cannot create an unhandled
-  // rejection. The same rejection remains observable through `completion`.
+  // The contract requires callers to await completion, but attach a rejection
+  // observer so an abandoned caller cannot create an unhandled rejection.
   void completion.catch(() => undefined);
 
   const cleanup = () => {
@@ -1117,8 +1159,6 @@ function createVerifiedExactRead(input: {
           () => undefined,
         );
       } catch {
-        // error-policy:J6 cancellation is best-effort after the read has
-        // already failed or been abandoned.
         providerCancellation = Promise.resolve();
       }
     }
@@ -1133,8 +1173,7 @@ function createVerifiedExactRead(input: {
     try {
       streamController?.error(translated);
     } catch {
-      // error-policy:J6 the public stream may already be in its cancelled
-      // state; the completion promise retains the authoritative failure.
+      // The public stream may already be in its cancelled state.
     }
     return cancelProvider();
   };
@@ -1195,8 +1234,6 @@ function createVerifiedExactRead(input: {
         hasher.update(next.value);
         controller.enqueue(next.value);
       } catch (error) {
-        // error-policy:J1 the ReadableStream boundary publishes the translated
-        // failure through both the stream and its completion promise.
         await fail(error);
       }
     },
@@ -1287,8 +1324,6 @@ async function getExactObjectOnBackend(
         object = await raceRuntimeGet(providerRequest, context);
       } catch (error) {
         if (context.signal.aborted) {
-          // error-policy:J5 the raced request is still observed and a late
-          // response body is cancelled; the abort remains authoritative.
           void providerRequest
             .then((lateObject) => lateObject?.body?.cancel())
             .catch(() => undefined);
@@ -1328,7 +1363,7 @@ async function getExactObjectOnBackend(
         bodyTransferred = true;
         return read;
       } finally {
-        if (!bodyTransferred) await cancelUntransferredBody(object.body);
+        if (!bodyTransferred) await cancelUntransferredBody(object.body, context);
       }
     }
 
@@ -1370,10 +1405,9 @@ async function getExactObjectOnBackend(
       bodyTransferred = true;
       return read;
     } finally {
-      if (!bodyTransferred) await cancelUntransferredBody(object.Body);
+      if (!bodyTransferred) await cancelUntransferredBody(object.Body, context);
     }
   } catch (error) {
-    // error-policy:J2 add stable storage-domain context while preserving cause.
     context.dispose();
     throw providerReadFailure(error, context);
   }
@@ -1387,24 +1421,147 @@ export async function getExactObjectAtBackend(params: {
   return getExactObjectOnBackend(params.backend, params.input);
 }
 
+interface ImmutableUploadAbortContext {
+  readonly signal: AbortSignal;
+  ensureActive(): void;
+  failure(): ObjectStorageLifecycleError;
+  race<T>(request: Promise<T>): Promise<T>;
+  wait(delayMs: number): Promise<void>;
+  dispose(): void;
+}
+
+function createImmutableUploadAbortContext(
+  input: ObjectRequestControl,
+): ImmutableUploadAbortContext {
+  const now = Date.now();
+  const suppliedDeadline = input.deadline?.getTime();
+  if (suppliedDeadline !== undefined && !Number.isFinite(suppliedDeadline)) {
+    throw new ObjectStorageLifecycleError(
+      "OBJECT_STORAGE_METADATA_INVALID",
+      "Immutable object upload requires a valid absolute deadline",
+    );
+  }
+  const deadlineAt = suppliedDeadline ?? now + DEFAULT_IMMUTABLE_UPLOAD_DURATION_MS;
+  if (deadlineAt - now > MAX_IMMUTABLE_UPLOAD_DURATION_MS) {
+    throw new ObjectStorageLifecycleError(
+      "OBJECT_STORAGE_METADATA_INVALID",
+      "Immutable object upload deadline exceeds the bounded provider-I/O window",
+    );
+  }
+
+  const controller = new AbortController();
+  let source: "caller" | "deadline" | null = null;
+  let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+  let disposed = false;
+  const abort = (nextSource: "caller" | "deadline") => {
+    if (source !== null || disposed) return;
+    source = nextSource;
+    controller.abort();
+  };
+  const onCallerAbort = () => abort("caller");
+  input.signal?.addEventListener("abort", onCallerAbort, { once: true });
+  if (input.signal?.aborted) abort("caller");
+
+  const armDeadline = () => {
+    if (source !== null || disposed) return;
+    const remaining = deadlineAt - Date.now();
+    if (remaining <= 0) {
+      abort("deadline");
+      return;
+    }
+    deadlineTimer = setTimeout(armDeadline, Math.min(remaining, 2_147_483_647));
+  };
+  armDeadline();
+
+  const failure = () =>
+    source === "deadline"
+      ? new ObjectStorageLifecycleError(
+          "OBJECT_STORAGE_UPLOAD_DEADLINE_EXCEEDED",
+          "Immutable object provider I/O exceeded its deadline",
+        )
+      : new ObjectStorageLifecycleError(
+          "OBJECT_STORAGE_UPLOAD_ABORTED",
+          "Immutable object provider I/O was aborted",
+        );
+
+  const ensureActive = () => {
+    if (Date.now() >= deadlineAt) abort("deadline");
+    if (input.signal?.aborted) abort("caller");
+    if (controller.signal.aborted) throw failure();
+  };
+
+  const race = async <T>(request: Promise<T>): Promise<T> => {
+    ensureActive();
+    let onAbort: (() => void) | undefined;
+    const aborted = new Promise<never>((_resolve, reject) => {
+      onAbort = () => reject(failure());
+      controller.signal.addEventListener("abort", onAbort, { once: true });
+    });
+    try {
+      return await Promise.race([request, aborted]);
+    } finally {
+      if (onAbort) controller.signal.removeEventListener("abort", onAbort);
+    }
+  };
+
+  return {
+    signal: controller.signal,
+    ensureActive,
+    failure,
+    race,
+    async wait(delayMs: number) {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await race(
+          new Promise<void>((resolve) => {
+            timer = setTimeout(resolve, delayMs);
+          }),
+        );
+      } finally {
+        if (timer !== undefined) clearTimeout(timer);
+      }
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      if (deadlineTimer !== null) clearTimeout(deadlineTimer);
+      input.signal?.removeEventListener("abort", onCallerAbort);
+    },
+  };
+}
+
 /** HEAD one exact key without downloading its body. */
-export async function headObject(key: string): Promise<ObjectHeadReceipt> {
+export async function headObject(
+  key: string,
+  control: ObjectRequestControl = {},
+): Promise<ObjectHeadReceipt> {
   requireExactKey(key);
-  const [backend, keyFingerprint] = await Promise.all([
-    resolveLifecycleBackend(),
-    fingerprintKey(key),
-  ]);
-  return headObjectOnBackend(backend, key, keyFingerprint);
+  const context = createImmutableUploadAbortContext(control);
+  try {
+    const [backend, keyFingerprint] = await context.race(
+      Promise.all([resolveLifecycleBackend(), fingerprintKey(key)]),
+    );
+    return await headObjectOnBackend(backend, key, keyFingerprint, false, undefined, context);
+  } finally {
+    context.dispose();
+  }
 }
 
 /** HEAD one exact key on a caller-resolved backend. */
 export async function headObjectAtBackend(
   backend: ExactObjectStorageBackend,
   key: string,
+  control: ObjectRequestControl = {},
 ): Promise<ObjectHeadReceipt> {
   requireExactKey(key);
   requireExactBackendLocator(backend.locator);
-  return headObjectOnBackend(backend, key, await fingerprintKey(key));
+  const context = createImmutableUploadAbortContext(control);
+  try {
+    const keyFingerprint = await context.race(fingerprintKey(key));
+    return await headObjectOnBackend(backend, key, keyFingerprint, false, undefined, context);
+  } finally {
+    context.dispose();
+  }
 }
 
 type ImmutableWriteFailure = "none" | "precondition" | "retryable" | "unsupported" | "fatal";
@@ -1460,13 +1617,18 @@ function classifyImmutableWriteFailure(error: unknown): ImmutableWriteFailure {
   return isRetryableProviderError(error) ? "retryable" : "fatal";
 }
 
-function immutableUploadBytes(body: ArrayBuffer | Uint8Array): Uint8Array<ArrayBuffer> {
-  if (body instanceof ArrayBuffer) return new Uint8Array(body);
-  if (body.buffer instanceof ArrayBuffer) {
-    return new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
+function immutableUploadBytes(
+  body: ArrayBuffer | Uint8Array,
+  transferBodyOwnership: boolean,
+): Uint8Array<ArrayBuffer> {
+  if (transferBodyOwnership) {
+    if (body instanceof ArrayBuffer) return new Uint8Array(body);
+    if (body.buffer instanceof ArrayBuffer) {
+      return new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
+    }
   }
   const copy = new Uint8Array(body.byteLength);
-  copy.set(body);
+  copy.set(body instanceof ArrayBuffer ? new Uint8Array(body) : body);
   return copy;
 }
 
@@ -1515,9 +1677,12 @@ function immutableReceiptFromHead(
   };
 }
 
-async function immutableRetryBackoff(attempt: number): Promise<void> {
+async function immutableRetryBackoff(
+  attempt: number,
+  context: ImmutableUploadAbortContext,
+): Promise<void> {
   const delayMs = 25 * 2 ** Math.max(0, attempt - 1);
-  await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+  await context.wait(delayMs);
 }
 
 /**
@@ -1530,133 +1695,189 @@ async function immutableRetryBackoff(attempt: number): Promise<void> {
  */
 async function putImmutableObjectOnBackend(params: {
   backend: ExactObjectStorageBackend;
-  key: string;
-  body: ArrayBuffer | Uint8Array;
-  contentType?: string;
+  key: PutImmutableObjectInput["key"];
+  body: PutImmutableObjectInput["body"];
+  contentType?: PutImmutableObjectInput["contentType"];
+  signal?: PutImmutableObjectInput["signal"];
+  deadline?: PutImmutableObjectInput["deadline"];
+  beforeWriteAttempt?: PutImmutableObjectInput["beforeWriteAttempt"];
+  transferBodyOwnership?: PutImmutableObjectInput["transferBodyOwnership"];
 }): Promise<ImmutableObjectUploadReceipt> {
   requireExactKey(params.key);
   requireExactBackendLocator(params.backend.locator);
-  const body = immutableUploadBytes(params.body);
-  if (body.byteLength > MAX_IMMUTABLE_SINGLE_PUT_BYTES) {
+  if (params.body.byteLength > MAX_IMMUTABLE_SINGLE_PUT_BYTES) {
+    if (params.transferBodyOwnership) {
+      (params.body instanceof ArrayBuffer ? new Uint8Array(params.body) : params.body).fill(0);
+    }
     throw new ObjectStorageLifecycleError(
       "OBJECT_STORAGE_UPLOAD_TOO_LARGE",
       "Immutable single-PUT object exceeds the bounded upload limit",
     );
   }
+  const body = immutableUploadBytes(params.body, params.transferBodyOwnership === true);
+  let context: ImmutableUploadAbortContext | undefined;
+  let digestBytes: Uint8Array<ArrayBuffer> | undefined;
+  try {
+    context = createImmutableUploadAbortContext(params);
+    const backend = params.backend;
+    const [keyFingerprint, sha256] = await context.race(
+      Promise.all([fingerprintKey(params.key), immutableSha256(body)]),
+    );
+    digestBytes = new Uint8Array(sha256.bytes);
+    const expected: ImmutableObjectUploadReceipt["metadata"] = {
+      sizeBytes: body.byteLength,
+      checksum: sha256.receipt,
+    };
 
-  const backend = params.backend;
-  const [keyFingerprint, sha256] = await Promise.all([
-    fingerprintKey(params.key),
-    immutableSha256(body),
-  ]);
-  const expected: ImmutableObjectUploadReceipt["metadata"] = {
-    sizeBytes: body.byteLength,
-    checksum: sha256.receipt,
-  };
-
-  for (let attempt = 1; attempt <= MAX_IMMUTABLE_PUT_ATTEMPTS; attempt += 1) {
-    let writeFailure: ImmutableWriteFailure = "none";
-    try {
-      if (backend.runtimeBucket) {
-        const onlyIf = new Headers({ "if-none-match": "*" });
-        const result = await backend.runtimeBucket.put(params.key, body, {
-          onlyIf,
-          httpMetadata: {
-            contentType: params.contentType ?? "application/octet-stream",
-          },
-          customMetadata: {
-            [IMMUTABLE_SHA256_METADATA_KEY]: sha256.receipt.value,
-          },
-          sha256: sha256.bytes,
-        });
-        // Native R2 returns null when the create-only precondition fails.
-        if (result === null) writeFailure = "precondition";
-      } else {
-        await backend.s3Client.send(
-          new PutObjectCommand({
-            Bucket: backend.locator.bucket,
-            Key: params.key,
-            Body: body,
-            ContentLength: body.byteLength,
-            ContentType: params.contentType ?? "application/octet-stream",
-            ChecksumSHA256: sha256.receipt.value,
-            Metadata: {
-              [IMMUTABLE_SHA256_METADATA_KEY]: sha256.receipt.value,
-            },
-            IfNoneMatch: "*",
-          }),
-        );
-      }
-    } catch (error) {
-      // error-policy:J1 provider failures are reconciled below and translated
-      // to static key-free domain errors at this storage boundary.
-      writeFailure = classifyImmutableWriteFailure(error);
-    }
-
-    try {
-      const observed = await headObjectOnBackend(backend, params.key, keyFingerprint, true);
-      const receipt = immutableReceiptFromHead(observed, expected);
-      if (receipt) return receipt;
-    } catch (error) {
-      // error-policy:J1 reconcile the provider response at the immutable-write
-      // boundary before returning a receipt or a static domain failure.
-      if (
-        error instanceof ObjectStorageLifecycleError &&
-        error.code === "OBJECT_STORAGE_IMMUTABLE_CONFLICT"
-      ) {
+    for (let attempt = 1; attempt <= MAX_IMMUTABLE_PUT_ATTEMPTS; attempt += 1) {
+      let writeFailure: ImmutableWriteFailure = "none";
+      const attemptBody = body.slice();
+      const attemptDigest = digestBytes.slice();
+      try {
+        context.ensureActive();
+        if (params.beforeWriteAttempt) {
+          await context.race(Promise.resolve().then(params.beforeWriteAttempt));
+        }
+        context.ensureActive();
+      } catch (error) {
+        attemptBody.fill(0);
+        attemptDigest.fill(0);
         throw error;
       }
-      if (
-        error instanceof ObjectStorageLifecycleError &&
-        error.code === "OBJECT_STORAGE_METADATA_INVALID"
-      ) {
+      let providerRequest: Promise<unknown>;
+      try {
+        if (backend.runtimeBucket) {
+          const onlyIf = new Headers({ "if-none-match": "*" });
+          providerRequest = Promise.resolve(
+            backend.runtimeBucket.put(params.key, attemptBody, {
+              onlyIf,
+              httpMetadata: {
+                contentType: params.contentType ?? "application/octet-stream",
+              },
+              customMetadata: {
+                [IMMUTABLE_SHA256_METADATA_KEY]: sha256.receipt.value,
+              },
+              sha256: attemptDigest.buffer,
+            }),
+          );
+        } else {
+          providerRequest = backend.s3Client.send(
+            new PutObjectCommand({
+              Bucket: backend.locator.bucket,
+              Key: params.key,
+              Body: attemptBody,
+              ContentLength: attemptBody.byteLength,
+              ContentType: params.contentType ?? "application/octet-stream",
+              ChecksumSHA256: sha256.receipt.value,
+              Metadata: {
+                [IMMUTABLE_SHA256_METADATA_KEY]: sha256.receipt.value,
+              },
+              IfNoneMatch: "*",
+            }),
+            { abortSignal: context.signal },
+          );
+        }
+      } catch (error) {
+        attemptBody.fill(0);
+        attemptDigest.fill(0);
+        throw error;
+      }
+      const trackedRequest = providerRequest.finally(() => {
+        attemptBody.fill(0);
+        attemptDigest.fill(0);
+      });
+      try {
+        const result = await context.race(trackedRequest);
+        // Native R2 returns null when the create-only precondition fails.
+        if (backend.runtimeBucket && result === null) writeFailure = "precondition";
+      } catch (error) {
+        // A timed-out binding request may settle after this execution returns.
+        // Its private attempt buffer is wiped only after that provider request
+        // settles, so late provider consumption cannot observe zeroed bytes.
+        void trackedRequest.catch(() => undefined);
+        if (context.signal.aborted) throw context.failure();
+        // error-policy:J1 provider failures are reconciled below and translated
+        // to static key-free domain errors at this storage boundary.
+        writeFailure = classifyImmutableWriteFailure(error);
+      }
+
+      // A provider that rejected or does not implement create-only PUT cannot
+      // establish immutable-write authority. Do not adopt a matching HEAD from
+      // a pre-existing or non-conformant write under either failure class.
+      if (writeFailure === "unsupported") {
         throw new ObjectStorageLifecycleError(
-          "OBJECT_STORAGE_IMMUTABLE_CONFLICT",
-          "Immutable object upload refused because existing content could not be verified",
+          "OBJECT_STORAGE_IMMUTABLE_PUT_UNSUPPORTED",
+          "Storage provider does not support create-only immutable object uploads",
         );
       }
-      if (!isRetryableProviderError(error)) {
+      if (writeFailure === "fatal") {
         throw new ObjectStorageLifecycleError(
-          "OBJECT_STORAGE_UPLOAD_UNCONFIRMED",
-          "Immutable object upload could not be confirmed by the storage provider",
+          "OBJECT_STORAGE_UPLOAD_FAILED",
+          "Storage provider rejected the immutable object upload",
         );
       }
-      writeFailure = "retryable";
+
+      try {
+        const observed = await headObjectOnBackend(
+          backend,
+          params.key,
+          keyFingerprint,
+          true,
+          undefined,
+          context,
+        );
+        const receipt = immutableReceiptFromHead(observed, expected);
+        if (receipt) return receipt;
+      } catch (error) {
+        if (context.signal.aborted) throw context.failure();
+        if (
+          error instanceof ObjectStorageLifecycleError &&
+          error.code === "OBJECT_STORAGE_IMMUTABLE_CONFLICT"
+        ) {
+          throw error;
+        }
+        if (
+          error instanceof ObjectStorageLifecycleError &&
+          error.code === "OBJECT_STORAGE_METADATA_INVALID"
+        ) {
+          throw new ObjectStorageLifecycleError(
+            "OBJECT_STORAGE_IMMUTABLE_CONFLICT",
+            "Immutable object upload refused because existing content could not be verified",
+          );
+        }
+        if (!isRetryableProviderError(error)) {
+          throw new ObjectStorageLifecycleError(
+            "OBJECT_STORAGE_UPLOAD_UNCONFIRMED",
+            "Immutable object upload could not be confirmed by the storage provider",
+          );
+        }
+        writeFailure = "retryable";
+      }
+
+      if (attempt === MAX_IMMUTABLE_PUT_ATTEMPTS) {
+        throw new ObjectStorageLifecycleError(
+          "OBJECT_STORAGE_UPLOAD_RETRY_EXHAUSTED",
+          "Immutable object upload exhausted its bounded retry budget",
+        );
+      }
+      await immutableRetryBackoff(attempt, context);
     }
 
-    if (writeFailure === "unsupported") {
-      throw new ObjectStorageLifecycleError(
-        "OBJECT_STORAGE_IMMUTABLE_PUT_UNSUPPORTED",
-        "Storage provider does not support create-only immutable object uploads",
-      );
-    }
-    if (writeFailure === "fatal") {
-      throw new ObjectStorageLifecycleError(
-        "OBJECT_STORAGE_UPLOAD_FAILED",
-        "Storage provider rejected the immutable object upload",
-      );
-    }
-    if (attempt === MAX_IMMUTABLE_PUT_ATTEMPTS) {
-      throw new ObjectStorageLifecycleError(
-        "OBJECT_STORAGE_UPLOAD_RETRY_EXHAUSTED",
-        "Immutable object upload exhausted its bounded retry budget",
-      );
-    }
-    await immutableRetryBackoff(attempt);
+    throw new ObjectStorageLifecycleError(
+      "OBJECT_STORAGE_UPLOAD_RETRY_EXHAUSTED",
+      "Immutable object upload exhausted its bounded retry budget",
+    );
+  } finally {
+    body.fill(0);
+    digestBytes?.fill(0);
+    context?.dispose();
   }
-
-  throw new ObjectStorageLifecycleError(
-    "OBJECT_STORAGE_UPLOAD_RETRY_EXHAUSTED",
-    "Immutable object upload exhausted its bounded retry budget",
-  );
 }
 
 /** Put an immutable object using the legacy process-global backend selector. */
-export async function putImmutableObject(params: {
-  key: string;
-  body: ArrayBuffer | Uint8Array;
-  contentType?: string;
-}): Promise<ImmutableObjectUploadReceipt> {
+export async function putImmutableObject(
+  params: PutImmutableObjectInput,
+): Promise<ImmutableObjectUploadReceipt> {
   requireExactKey(params.key);
   if (params.body.byteLength > MAX_IMMUTABLE_SINGLE_PUT_BYTES) {
     throw new ObjectStorageLifecycleError(
@@ -1673,9 +1894,13 @@ export async function putImmutableObject(params: {
 /** Put an immutable object on a caller-resolved exact backend. */
 export async function putImmutableObjectAtBackend(params: {
   backend: ExactObjectStorageBackend;
-  key: string;
-  body: ArrayBuffer | Uint8Array;
-  contentType?: string;
+  key: PutImmutableObjectInput["key"];
+  body: PutImmutableObjectInput["body"];
+  contentType?: PutImmutableObjectInput["contentType"];
+  signal?: PutImmutableObjectInput["signal"];
+  deadline?: PutImmutableObjectInput["deadline"];
+  beforeWriteAttempt?: PutImmutableObjectInput["beforeWriteAttempt"];
+  transferBodyOwnership?: PutImmutableObjectInput["transferBodyOwnership"];
 }): Promise<ImmutableObjectUploadReceipt> {
   return putImmutableObjectOnBackend(params);
 }
@@ -1759,8 +1984,6 @@ async function deleteObjectOnBackend(
       );
       providerRequestId = output.$metadata.requestId ?? null;
     } catch (error) {
-      // error-policy:J1 translate conditional-delete and not-found responses at
-      // the exact object lifecycle boundary; all other failures propagate.
       if (providerHttpStatus(error) === 412) {
         throw new ObjectStorageLifecycleError(
           "OBJECT_STORAGE_VERSION_MISMATCH",

--- a/packages/cloud/shared/src/lib/storage/object-store.ts
+++ b/packages/cloud/shared/src/lib/storage/object-store.ts
@@ -808,6 +808,8 @@ async function headObjectOnBackend(
     };
   } catch (error) {
     if (control?.signal.aborted) throw control.failure();
+    // error-policy:J1 translate only the provider's authoritative not-found
+    // response into the explicit absent result at the object-store boundary.
     if (!isS3ObjectNotFound(error)) throw error;
     return {
       status: "absent",
@@ -1082,7 +1084,8 @@ async function cancelUntransferredBody(
       }
     }
   } catch {
-    // Best-effort teardown must not replace the static storage-domain error.
+    // error-policy:J6 best-effort teardown must not replace the static
+    // storage-domain error.
   }
 }
 
@@ -1142,8 +1145,9 @@ function createVerifiedExactRead(input: {
     resolveCompletion = resolve;
     rejectCompletion = reject;
   });
-  // The contract requires callers to await completion, but attach a rejection
-  // observer so an abandoned caller cannot create an unhandled rejection.
+  // error-policy:J5 the contract requires callers to await completion, but
+  // attach an observer so an abandoned caller cannot create an unhandled
+  // rejection. The same rejection remains observable through `completion`.
   void completion.catch(() => undefined);
 
   const cleanup = () => {
@@ -1159,6 +1163,8 @@ function createVerifiedExactRead(input: {
           () => undefined,
         );
       } catch {
+        // error-policy:J6 cancellation is best-effort after the read has
+        // already failed or been abandoned.
         providerCancellation = Promise.resolve();
       }
     }
@@ -1173,7 +1179,8 @@ function createVerifiedExactRead(input: {
     try {
       streamController?.error(translated);
     } catch {
-      // The public stream may already be in its cancelled state.
+      // error-policy:J6 the public stream may already be in its cancelled
+      // state; the completion promise retains the authoritative failure.
     }
     return cancelProvider();
   };
@@ -1234,6 +1241,8 @@ function createVerifiedExactRead(input: {
         hasher.update(next.value);
         controller.enqueue(next.value);
       } catch (error) {
+        // error-policy:J1 the ReadableStream boundary publishes the translated
+        // failure through both the stream and its completion promise.
         await fail(error);
       }
     },
@@ -1324,6 +1333,8 @@ async function getExactObjectOnBackend(
         object = await raceRuntimeGet(providerRequest, context);
       } catch (error) {
         if (context.signal.aborted) {
+          // error-policy:J5 the raced request is still observed and a late
+          // response body is cancelled; the abort remains authoritative.
           void providerRequest
             .then((lateObject) => lateObject?.body?.cancel())
             .catch(() => undefined);
@@ -1408,6 +1419,7 @@ async function getExactObjectOnBackend(
       if (!bodyTransferred) await cancelUntransferredBody(object.Body, context);
     }
   } catch (error) {
+    // error-policy:J2 add stable storage-domain context while preserving cause.
     context.dispose();
     throw providerReadFailure(error, context);
   }

--- a/plugins/plugin-sql/src/__tests__/pglite-adapter-liveness.test.ts
+++ b/plugins/plugin-sql/src/__tests__/pglite-adapter-liveness.test.ts
@@ -36,8 +36,14 @@ function makeAdapter() {
   const manager = {
     close: vi.fn(async () => undefined),
     dumpDataDir: vi.fn(async () => new Blob(["snapshot"])),
+    dumpDataDirAfterPreflight: vi.fn(async <T>(preflight: () => Promise<T>) => ({
+      dump: new Blob(["bounded-snapshot"]),
+      preflight: await preflight(),
+      release: vi.fn(),
+    })),
     ensureSync: vi.fn(async () => undefined),
     getConnection: vi.fn(() => rawConnection),
+    getDataDir: vi.fn(() => "/tmp/pglite-test"),
     initialize: vi.fn(async () => undefined),
     isInitialized: vi.fn(() => true),
     isShuttingDown: vi.fn(() => false),
@@ -79,8 +85,17 @@ describe("PgliteDatabaseAdapter liveness", () => {
     await expect(adapter.init()).resolves.toBeUndefined();
     await expect(adapter.getConnection()).resolves.toBe(db);
     expect(adapter.getRawConnection()).toBe(rawConnection);
+    expect(adapter.getPgliteDataDir()).toBe("/tmp/pglite-test");
     await expect(adapter.dumpPgliteDataDir("gzip")).resolves.toBeInstanceOf(Blob);
     expect(manager.dumpDataDir).toHaveBeenCalledWith("gzip");
+    await expect(
+      adapter.dumpPgliteDataDirAfterPreflight(async () => "bounded", "gzip")
+    ).resolves.toEqual({
+      dump: expect.any(Blob),
+      preflight: "bounded",
+      release: expect.any(Function),
+    });
+    expect(manager.dumpDataDirAfterPreflight).toHaveBeenCalledWith(expect.any(Function), "gzip");
     await expect(
       adapter.withEntityContext(null, async (tx) => {
         expect(tx).toBe(db);

--- a/plugins/plugin-sql/src/__tests__/pglite-lifecycle-serialization.test.ts
+++ b/plugins/plugin-sql/src/__tests__/pglite-lifecycle-serialization.test.ts
@@ -3,15 +3,33 @@
  * with client teardown so neither operation can observe a half-closed handle.
  */
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { PGlite } from "@electric-sql/pglite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { PGliteClientManager } from "../pglite/manager";
+
+async function waitForAssertion(assertion: () => void, maxAttempts = 1_000): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+  }
+  throw lastError;
+}
 
 describe("PGlite snapshot lifecycle serialization", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("lets an admitted dump finish before close reaches the client", async () => {
+  it("holds close until an admitted bounded export is fully consumed", async () => {
     const manager = new PGliteClientManager({ dataDir: "memory://" });
     const client = manager.getConnection();
     let releaseDump!: (value: Blob) => void;
@@ -23,15 +41,22 @@ describe("PGlite snapshot lifecycle serialization", () => {
     );
     const closeSpy = vi.spyOn(client, "close").mockResolvedValue(undefined);
 
-    const dumpPromise = manager.dumpDataDir("gzip");
+    const dumpPromise = manager.dumpDataDirAfterPreflight(async () => "bounded", "gzip");
     const closePromise = manager.close();
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(dumpSpy).toHaveBeenCalledTimes(1);
+    await waitForAssertion(() => expect(dumpSpy).toHaveBeenCalledTimes(1));
     expect(closeSpy).not.toHaveBeenCalled();
 
     releaseDump(new Blob(["snapshot"]));
-    await expect(dumpPromise).resolves.toBeInstanceOf(Blob);
+    const bounded = await dumpPromise;
+    expect(bounded).toEqual({
+      dump: expect.any(Blob),
+      preflight: "bounded",
+      release: expect.any(Function),
+    });
+    await Promise.resolve();
+    expect(closeSpy).not.toHaveBeenCalled();
+
+    bounded.release();
     await expect(closePromise).resolves.toBeUndefined();
     expect(closeSpy).toHaveBeenCalledTimes(1);
   });
@@ -43,9 +68,163 @@ describe("PGlite snapshot lifecycle serialization", () => {
     const closeSpy = vi.spyOn(client, "close").mockResolvedValue(undefined);
 
     const closePromise = manager.close();
-    await expect(manager.dumpDataDir("gzip")).rejects.toThrow("PGlite is closing");
+    await expect(manager.dumpDataDirAfterPreflight(async () => "bounded", "gzip")).rejects.toThrow(
+      "PGlite is closing"
+    );
     await expect(closePromise).resolves.toBeUndefined();
     expect(dumpSpy).not.toHaveBeenCalled();
     expect(closeSpy).toHaveBeenCalledTimes(1);
   });
+
+  it("fences preflight and dump ahead of competing query work", async () => {
+    const manager = new PGliteClientManager({ dataDir: "memory://" });
+    const client = manager.getConnection();
+    const events: string[] = [];
+    let releaseDump!: (value: Blob) => void;
+    vi.spyOn(client, "dumpDataDir").mockImplementation(
+      async () =>
+        await new Promise<Blob>((resolve) => {
+          events.push("dump:start");
+          releaseDump = (value) => {
+            events.push("dump:end");
+            resolve(value);
+          };
+        })
+    );
+    vi.spyOn(client, "close").mockResolvedValue(undefined);
+
+    const dumpPromise = manager.dumpDataDirAfterPreflight(async () => {
+      events.push("preflight");
+      return "bounded";
+    });
+    await waitForAssertion(() => expect(events).toEqual(["preflight", "dump:start"]));
+
+    const competingQuery = client.runExclusive(async () => {
+      events.push("query");
+    });
+    await Promise.resolve();
+    expect(events).toEqual(["preflight", "dump:start"]);
+
+    releaseDump(new Blob(["snapshot"]));
+    const bounded = await dumpPromise;
+    expect(bounded).toEqual({
+      dump: expect.any(Blob),
+      preflight: "bounded",
+      release: expect.any(Function),
+    });
+    await expect(competingQuery).resolves.toBeUndefined();
+    expect(events).toEqual(["preflight", "dump:start", "dump:end", "query"]);
+    bounded.release();
+    await manager.close();
+  });
+
+  it("blocks the legacy exporter while a bounded Blob consumer owns the shared lease", async () => {
+    const manager = new PGliteClientManager({ dataDir: "memory://" });
+    const client = manager.getConnection();
+    const dumpSpy = vi
+      .spyOn(client, "dumpDataDir")
+      .mockResolvedValue(new Blob(["bounded-snapshot"]));
+    vi.spyOn(client, "close").mockResolvedValue(undefined);
+
+    const bounded = await manager.dumpDataDirAfterPreflight(async () => "bounded", "gzip");
+    await expect(manager.dumpDataDir("gzip")).rejects.toMatchObject({
+      code: "PGLITE_DATA_DIR_EXPORT_BUSY",
+    });
+    expect(dumpSpy).toHaveBeenCalledTimes(1);
+
+    bounded.release();
+    await expect(manager.dumpDataDir("gzip")).rejects.toMatchObject({
+      code: "PGLITE_DATA_DIR_EXPORT_UNBOUNDED",
+    });
+    expect(dumpSpy).toHaveBeenCalledTimes(1);
+    await manager.close();
+  });
+
+  it("releases the shared lease when preflight rejects before materialization", async () => {
+    const manager = new PGliteClientManager({ dataDir: "memory://" });
+    const client = manager.getConnection();
+    const dumpSpy = vi
+      .spyOn(client, "dumpDataDir")
+      .mockResolvedValue(new Blob(["bounded-snapshot"]));
+    vi.spyOn(client, "close").mockResolvedValue(undefined);
+
+    await expect(
+      manager.dumpDataDirAfterPreflight(async () => {
+        throw new Error("preflight refused");
+      })
+    ).rejects.toThrow("preflight refused");
+    expect(dumpSpy).not.toHaveBeenCalled();
+
+    const second = await manager.dumpDataDirAfterPreflight(async () => "bounded", "gzip");
+    expect(dumpSpy).toHaveBeenCalledTimes(1);
+    second.release();
+    await manager.close();
+  });
+
+  it("restores the pre-write state while a competing real write waits for the dump fence", async () => {
+    const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "pglite-bounded-dump-"));
+    const sourceDir = path.join(root, "source");
+    const restoredDir = path.join(root, "restored");
+    const previousDisableExtensions = process.env.ELIZA_PGLITE_DISABLE_EXTENSIONS;
+    process.env.ELIZA_PGLITE_DISABLE_EXTENSIONS = "1";
+    const manager = new PGliteClientManager({ dataDir: sourceDir });
+    let restored: PGlite | undefined;
+    let releaseBounded: (() => void) | undefined;
+    try {
+      const client = manager.getConnection();
+      await client.exec(
+        "CREATE TABLE backup_fence_marker (value text PRIMARY KEY); INSERT INTO backup_fence_marker VALUES ('before');"
+      );
+
+      let releasePreflight!: () => void;
+      const preflightBlocked = new Promise<void>((resolve) => {
+        releasePreflight = resolve;
+      });
+      let preflightEntered = false;
+      const dumpPromise = manager.dumpDataDirAfterPreflight(async () => {
+        preflightEntered = true;
+        await preflightBlocked;
+        return "physical-size-proven";
+      });
+      await waitForAssertion(() => expect(preflightEntered).toBe(true));
+
+      let competingWriteSettled = false;
+      const competingWrite = client
+        .query("INSERT INTO backup_fence_marker VALUES ('after')")
+        .then(() => {
+          competingWriteSettled = true;
+        });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(competingWriteSettled).toBe(false);
+
+      releasePreflight();
+      const bounded = await dumpPromise;
+      releaseBounded = bounded.release;
+      await competingWrite;
+      expect(bounded.preflight).toBe("physical-size-proven");
+
+      restored = new PGlite({
+        dataDir: restoredDir,
+        loadDataDir: bounded.dump,
+      });
+      await restored.waitReady;
+      const restoredRows = await restored.query<{ value: string }>(
+        "SELECT value FROM backup_fence_marker ORDER BY value"
+      );
+      expect(restoredRows.rows).toEqual([{ value: "before" }]);
+      releaseBounded();
+      releaseBounded = undefined;
+      await manager.close();
+    } finally {
+      await restored?.close();
+      releaseBounded?.();
+      await manager.close();
+      if (previousDisableExtensions === undefined) {
+        delete process.env.ELIZA_PGLITE_DISABLE_EXTENSIONS;
+      } else {
+        process.env.ELIZA_PGLITE_DISABLE_EXTENSIONS = previousDisableExtensions;
+      }
+      await fs.promises.rm(root, { recursive: true, force: true });
+    }
+  }, 30_000);
 });

--- a/plugins/plugin-sql/src/pglite/adapter.ts
+++ b/plugins/plugin-sql/src/pglite/adapter.ts
@@ -23,7 +23,7 @@ import { sql } from "drizzle-orm";
 import { drizzle, type PgliteDatabase } from "drizzle-orm/pglite";
 import { BaseDrizzleAdapter } from "../base";
 import { DIMENSION_MAP, type EmbeddingDimensionColumn } from "../schema/embedding";
-import type { PGliteClientManager } from "./manager";
+import type { PGliteClientManager, PgliteBoundedDataDirExport } from "./manager";
 
 export class PgliteDatabaseAdapter extends BaseDrizzleAdapter {
   private manager: PGliteClientManager;
@@ -152,8 +152,19 @@ export class PgliteDatabaseAdapter extends BaseDrizzleAdapter {
     return this.manager.getConnection();
   }
 
+  getPgliteDataDir(): string | null {
+    return this.manager.getDataDir();
+  }
+
   async dumpPgliteDataDir(compression: "gzip" = "gzip"): Promise<File | Blob> {
     return await this.manager.dumpDataDir(compression);
+  }
+
+  async dumpPgliteDataDirAfterPreflight<T>(
+    preflight: () => Promise<T>,
+    compression: "gzip" = "gzip"
+  ): Promise<PgliteBoundedDataDirExport<T>> {
+    return await this.manager.dumpDataDirAfterPreflight(preflight, compression);
   }
 
   // ── Electric write-back notification overrides ─────────────────────────

--- a/plugins/plugin-sql/src/pglite/manager.ts
+++ b/plugins/plugin-sql/src/pglite/manager.ts
@@ -72,6 +72,16 @@ export type PgliteSyncStatus = "syncing" | "synced" | "error" | "disabled";
 /** Per-table sync state. */
 export type PgliteSyncTableState = "pending" | "synced" | "error";
 
+export const PGLITE_DATA_DIR_EXPORT_BUSY_CODE = "PGLITE_DATA_DIR_EXPORT_BUSY";
+export const PGLITE_DATA_DIR_EXPORT_UNBOUNDED_CODE = "PGLITE_DATA_DIR_EXPORT_UNBOUNDED";
+
+export interface PgliteBoundedDataDirExport<T> {
+  dump: File | Blob;
+  preflight: T;
+  /** Release only after every consumer has finished with the materialized Blob. */
+  release: () => void;
+}
+
 /** Per-table status map exposed by getSyncStatus(). */
 export type PgliteSyncTableStatus = Record<string, { state: PgliteSyncTableState; error?: string }>;
 
@@ -134,6 +144,13 @@ export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
   private initializePromise: Promise<void> | null = null;
   private lifecycleTail: Promise<void> = Promise.resolve();
   private closePromise: Promise<void> | null = null;
+  private activeDataDirExport:
+    | {
+        token: symbol;
+        released: Promise<void>;
+        release: () => void;
+      }
+    | undefined;
   private lockFd: number | null = null;
   private lockPath: string | null = null;
   private syncUrl: string | null;
@@ -189,15 +206,82 @@ export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
   }
 
   /**
-   * Capture the live PGlite data directory without racing client teardown.
-   * Once close has begun, new captures fail explicitly instead of touching a
-   * monotonically closing handle.
+   * The legacy exporter cannot prove a physical-size/RSS bound before PGlite
+   * materializes its archive, so it is intentionally fail-closed. Callers must
+   * use dumpDataDirAfterPreflight() and retain its lease through Blob use.
    */
   public async dumpDataDir(compression: "gzip" = "gzip"): Promise<File | Blob> {
+    void compression;
     if (this.shuttingDown) {
       throw new Error("PGlite is closing");
     }
-    return await this.withLifecycleLock(async () => await this.client.dumpDataDir(compression));
+    if (this.activeDataDirExport) {
+      throw this.createDataDirExportError(
+        PGLITE_DATA_DIR_EXPORT_BUSY_CODE,
+        "A PGlite data-directory export is already active"
+      );
+    }
+    throw this.createDataDirExportError(
+      PGLITE_DATA_DIR_EXPORT_UNBOUNDED_CODE,
+      "Unbounded PGlite data-directory export is disabled"
+    );
+  }
+
+  /**
+   * Run a bounded-export preflight and the materializing PGlite dump under one
+   * query fence, while the outer lifecycle fence prevents concurrent close.
+   */
+  public async dumpDataDirAfterPreflight<T>(
+    preflight: () => Promise<T>,
+    compression: "gzip" = "gzip"
+  ): Promise<PgliteBoundedDataDirExport<T>> {
+    if (this.shuttingDown) {
+      throw new Error("PGlite is closing");
+    }
+    const lease = this.acquireDataDirExportLease();
+    try {
+      const bounded = await this.withLifecycleLock(
+        async () =>
+          await this.client.runExclusive(async () => {
+            const preflightResult = await preflight();
+            const dump = await this.client.dumpDataDir(compression);
+            return { dump, preflight: preflightResult };
+          })
+      );
+      return { ...bounded, release: lease.release };
+    } catch (error) {
+      lease.release();
+      throw error;
+    }
+  }
+
+  private acquireDataDirExportLease(): { release: () => void } {
+    if (this.activeDataDirExport) {
+      throw this.createDataDirExportError(
+        PGLITE_DATA_DIR_EXPORT_BUSY_CODE,
+        "A PGlite data-directory export is already active"
+      );
+    }
+    const token = Symbol("pglite-data-dir-export");
+    let resolveReleased!: () => void;
+    const released = new Promise<void>((resolve) => {
+      resolveReleased = resolve;
+    });
+    let releasedOnce = false;
+    const release = () => {
+      if (releasedOnce) return;
+      releasedOnce = true;
+      if (this.activeDataDirExport?.token === token) {
+        this.activeDataDirExport = undefined;
+      }
+      resolveReleased();
+    };
+    this.activeDataDirExport = { token, released, release };
+    return { release };
+  }
+
+  private createDataDirExportError(code: string, message: string): Error {
+    return Object.assign(new Error(message), { code });
   }
 
   private async withLifecycleLock<T>(operation: () => Promise<T>): Promise<T> {
@@ -292,6 +376,10 @@ export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
   }
 
   private async closeInternal(): Promise<void> {
+    // Keep the process/data-dir ownership fence until the materialized archive
+    // is no longer retained by its consumer. Releasing it earlier could let a
+    // replacement manager overlap another full PGlite archive in memory.
+    await this.activeDataDirExport?.released;
     // Flush pending write-backs before tearing down.
     if (this.writeBack.enabled) {
       try {
@@ -374,7 +462,8 @@ export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
     });
   }
 
-  private getDataDir(): string | null {
+  /** Physical-storage configuration attested to bounded backup callers. */
+  public getDataDir(): string | null {
     const optionsWithDataDir = this.options as PGliteOptions & {
       dataDir?: unknown;
       dataPath?: unknown;


### PR DESCRIPTION
## Status

**REVIEWED — safe to merge, not safe to activate.** This is PR 3 in the Goal 3 stack; #20782 is merged. Every automatic production caller and feature gate remains inactive.

Goal tracking: #20726

## Summary

- add an authenticated `/api/snapshot/v2` Agent producer with bounded framed streaming, strict deadlines, single-flight capture, and fail-closed source validation
- serialize PGlite exports across the v2 and legacy snapshot paths, fence normal database writes, and reject unbounded or unprovable exports before materialization
- reserve manifest-v3 captures against immutable activation, node-incarnation, container, image, lifecycle, and vault-reference authorities
- spool encrypted manifest-v3 capture output durably and reconcile response loss without re-encrypting divergent content
- publish exact primary and secondary objects with repository-derived keys, provider-native verification, bounded retries, and exact locator-aware garbage collection
- add a database-clock RPO scheduler with fair claims, retry-stable operation IDs, and overdue visibility
- add fail-closed Robot and Cloud node-source attestation, including atomic SSH host-key rotation revocation

## Safety boundaries

- The catalogue runtime and RPO scheduler have no production daemon/control-plane caller in this PR.
- Existing rows receive no activation authority, so scheduler enrollment remains empty until a later release publishes exact activation and vault authorities.
- `AGENT_BACKUP_RPO_SCHEDULER_ENABLED` remains off and inert without a caller.
- Capture is full-only. Incremental reservation and direct incremental execution fail before allocating catalogue or spool authority.
- Provider multipart publication is not implemented; objects use bounded immutable single PUTs.
- PGlite's official 0.4.x exporter materializes its archive. This PR therefore supports at most 40 MiB of logical PGlite files, with a conservative process/cgroup-aware available-memory gate. Larger real databases fail closed and require a genuinely streaming exporter.
- The 1 GiB test proves framed-stream backpressure only; it is not a real PGlite export proof.
- No 15-minute production RPO claim is made. Dedicated cadence, capacity evidence, cancellation authority, producer coexistence fencing, PR4 activation/vault writers, and staging evidence are still required.

## Independent review repairs

- Closed the retention/object-GC versus encrypted-spool cleanup race with exact expired/deleting/deleted catalogue authority and database-clock/tombstone proof.
- Made a canonical legacy-writer deployment drain receipt mandatory before executor construction.
- Added a real filesystem-backed plugin-sql PGlite producer capture-and-restore end-to-end test.
- Renumbered capture migrations to `0230`–`0235` after the merged catalogue range.
- Fixed the exact typecheck-discovered `BlobPart` generic mismatch with Blob-owned archive bytes.

Remaining delta/compaction, multipart, restore coordination, functional staging proof, live R2/Hetzner validation, and operational activation remain later deployment gates; no caller or scheduler is activated here.

## Verification

- Agent capture/API focused suites: 53 passed, 1 intentionally skipped nightly case
- opt-in synthetic 1 GiB framed-stream proof: 1 passed, 4,099 assertions
- real snapshot-to-restore route integration: 1 passed
- legacy snapshot transient-path suite: 2 passed
- plugin-sql PGlite lifecycle/restore suites: 9 passed
- Cloud capture, publication, object-storage, response-loss, and catalogue suites: 157 passed, 862 assertions
- node/source attestation and manager suites: 147 passed, 568 assertions
- migration, source-authority, and scheduler suites: 35 passed, 202 assertions
- all six new migrations are replay-tested, ordered as 0230–0235, and remain below 100 lines
- Cloud shared typecheck passes; Agent exact typecheck cleared the one stack-owned BlobPart error, with remaining failures limited to unrelated optional-workspace artifacts and pre-existing outside-stack errors
- package Biome checks, Drizzle schema checks, tenant-scope checks, and `git diff --check` passed
- Cloud API production bundle completed with Wrangler `--dry-run`; nothing was deployed
- independent final review found no blocker/P1/P2 after the listed repairs; merge is approved while activation remains gated

## AI contribution

Implemented and reviewed with OpenAI Codex using `gpt-5.6-sol` at Ultra reasoning effort, coordinated from lane `/root`. Human review remains required before this draft can be marked ready.


# Evidence Gate

<!-- evidence-head:013971982d7f8910b46755aa6a023008e84030b9 -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend capture, database, and storage change with no rendered UI.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend capture, database, and storage change with no rendered UI.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive visual flow is activated.
<!-- evidence-row:backend-logs -->
- [x] [20864-PR20864_REVIEW_01397198.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20864-PR20864_REVIEW_01397198.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or request flow changed.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, or LLM behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no production provider object or database was mutated; disposable real PGlite and MinIO results are recorded in the backend receipt.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered visual surface.

## Activation boundary

No production caller, scheduler, provider credential, deployment, or feature gate is activated by this merge. Live provider and staging evidence remain mandatory before later activation.
