### PR TITLE
fix(cloud): 400 malformed wallet RPC JSON

### DIFF
--- a/packages/cloud/api/v1/user/wallets/rpc/route.json-body.test.ts
+++ b/packages/cloud/api/v1/user/wallets/rpc/route.json-body.test.ts
@@ -9,12 +9,21 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const WALLET = "0x1111111111111111111111111111111111111111";
 
-const verifyWalletSignature = mock(async () => {
-  throw new Error("verifyWalletSignature must not run");
-});
-const executeServerWalletRpc = mock(async () => {
-  throw new Error("executeServerWalletRpc must not run");
-});
+interface RpcExecutionInput {
+  clientAddress: string;
+  payload: {
+    method: string;
+    params: unknown[];
+    timestamp: number;
+    nonce: string;
+  };
+  signature: `0x${string}`;
+}
+
+const verifyWalletSignature =
+  mock<(request: Request) => Promise<{ wallet_address?: string } | null>>();
+const executeServerWalletRpc =
+  mock<(input: RpcExecutionInput) => Promise<unknown>>();
 
 mock.module("@/lib/auth/wallet-auth", () => ({
   verifyWalletSignature,
@@ -32,8 +41,9 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
 }));
 
 mock.module("@/lib/api/cloud-worker-errors", () => ({
-  failureResponse: mock((c: { json: (body: unknown, status: number) => unknown }) =>
-    c.json({ success: false, error: "An unexpected error occurred" }, 500),
+  failureResponse: mock(
+    (c: { json: (body: unknown, status: number) => unknown }) =>
+      c.json({ success: false, error: "An unexpected error occurred" }, 500),
   ),
 }));
 
@@ -87,7 +97,7 @@ describe("POST /api/v1/user/wallets/rpc JSON body", () => {
       const res = await post(raw);
 
       expect(res.status).toBe(400);
-      expect(await res.json()).toEqual({
+      expect((await res.json()) as unknown).toEqual({
         success: false,
         error: "Invalid JSON body",
       });
@@ -102,7 +112,7 @@ describe("POST /api/v1/user/wallets/rpc JSON body", () => {
       const res = await post(raw);
 
       expect(res.status).toBe(400);
-      expect(await res.json()).toEqual({
+      expect((await res.json()) as unknown).toEqual({
         success: false,
         error: "Invalid JSON body",
       });
@@ -131,7 +141,7 @@ describe("POST /api/v1/user/wallets/rpc JSON body", () => {
     const res = await post(canonical);
 
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({
+    expect((await res.json()) as unknown).toEqual({
       success: true,
       data: { result: "0x1" },
     });

--- a/packages/cloud/api/v1/user/wallets/rpc/route.json-body.test.ts
+++ b/packages/cloud/api/v1/user/wallets/rpc/route.json-body.test.ts
@@ -1,0 +1,145 @@
+/**
+ * POST /api/v1/user/wallets/rpc untrusted JSON body contract.
+ *
+ * Hono 4.13 `c.req.json()` is a bare `JSON.parse`. The handler catch maps
+ * SyntaxError through `failureResponse` to HTTP 500 instead of a caller 400.
+ * Server-wallet RPC must not verify a signature or execute on garbage.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const WALLET = "0x1111111111111111111111111111111111111111";
+
+const verifyWalletSignature = mock(async () => {
+  throw new Error("verifyWalletSignature must not run");
+});
+const executeServerWalletRpc = mock(async () => {
+  throw new Error("executeServerWalletRpc must not run");
+});
+
+mock.module("@/lib/auth/wallet-auth", () => ({
+  verifyWalletSignature,
+}));
+
+mock.module("@/lib/services/server-wallets", () => ({
+  executeServerWalletRpc,
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STANDARD: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+}));
+
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: mock((c: { json: (body: unknown, status: number) => unknown }) =>
+    c.json({ success: false, error: "An unexpected error occurred" }, 500),
+  ),
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+  },
+}));
+
+const { default: app } = await import("./route");
+
+function post(raw: string) {
+  return app.fetch(
+    new Request("http://test.local/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Wallet-Address": WALLET,
+      },
+      body: raw,
+    }),
+  );
+}
+
+const canonical = JSON.stringify({
+  clientAddress: WALLET,
+  payload: { method: "eth_blockNumber", params: [] },
+  signature: "0xabc",
+  timestamp: 1_700_000_000,
+  nonce: "n1",
+});
+
+describe("POST /api/v1/user/wallets/rpc JSON body", () => {
+  beforeEach(() => {
+    verifyWalletSignature.mockClear();
+    executeServerWalletRpc.mockClear();
+    verifyWalletSignature.mockImplementation(async () => {
+      throw new Error("verifyWalletSignature must not run");
+    });
+    executeServerWalletRpc.mockImplementation(async () => {
+      throw new Error("executeServerWalletRpc must not run");
+    });
+  });
+
+  test.each(["", "   ", "{", "not-json"])(
+    "rejects malformed wallet RPC body %j with 400",
+    async (raw) => {
+      const res = await post(raw);
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({
+        success: false,
+        error: "Invalid JSON body",
+      });
+      expect(verifyWalletSignature).not.toHaveBeenCalled();
+      expect(executeServerWalletRpc).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(['["eth_call"]', '"eth_call"', "null", "12"])(
+    "rejects non-object wallet RPC body %s with 400",
+    async (raw) => {
+      const res = await post(raw);
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({
+        success: false,
+        error: "Invalid JSON body",
+      });
+      expect(verifyWalletSignature).not.toHaveBeenCalled();
+      expect(executeServerWalletRpc).not.toHaveBeenCalled();
+    },
+  );
+
+  test("still 400s a parseable object missing fields via zod", async () => {
+    const res = await post("{}");
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { success?: boolean; error?: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Validation error");
+    expect(verifyWalletSignature).not.toHaveBeenCalled();
+    expect(executeServerWalletRpc).not.toHaveBeenCalled();
+  });
+
+  test("still executes a canonical signed object body", async () => {
+    verifyWalletSignature.mockResolvedValue({
+      wallet_address: WALLET,
+    });
+    executeServerWalletRpc.mockResolvedValue({ result: "0x1" });
+
+    const res = await post(canonical);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      success: true,
+      data: { result: "0x1" },
+    });
+    expect(verifyWalletSignature).toHaveBeenCalledTimes(1);
+    expect(executeServerWalletRpc).toHaveBeenCalledTimes(1);
+    expect(executeServerWalletRpc.mock.calls[0]?.[0]).toMatchObject({
+      clientAddress: WALLET,
+      signature: "0xabc",
+    });
+  });
+});

--- a/packages/cloud/api/v1/user/wallets/rpc/route.ts
+++ b/packages/cloud/api/v1/user/wallets/rpc/route.ts
@@ -41,7 +41,19 @@ app.use("*", rateLimit(RateLimitPresets.STANDARD));
 
 app.post("/", async (c) => {
   try {
-    const body = await c.req.json();
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      // error-policy:J3 untrusted request JSON — Hono's c.req.json() is a
+      // bare JSON.parse. SyntaxError must be a caller 400, not the
+      // failureResponse 500 that treats it as an unexpected server fault.
+      // Wallet-signature verify and server-wallet RPC must not run on garbage.
+      return c.json({ success: false, error: "Invalid JSON body" }, 400);
+    }
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return c.json({ success: false, error: "Invalid JSON body" }, 400);
+    }
     const validated = rpcPayloadSchema.parse(body);
 
     const url = new URL(c.req.url);


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Cloud fail-closed untrusted-input fix
on `POST /api/v1/user/wallets/rpc` JSON. Not a twin of iMessage or LifeOps
`limit` prefix-coercion, percent-encoded paths, SIWS chainId, orchestrator
lines, provisioning-worker env ints, invites-accept, cli-auth, redemption
quote, compat agent-logs, first-run, login persist, billing, avatar,
org-credentials, or room-welcome. Disjoint from the referral-apply JSON parse.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. JSON-parse only on `POST /api/v1/user/wallets/rpc` before wallet-signature
auth. Canonical signed `{ clientAddress, payload, signature, timestamp, nonce }`
still executes after verify. Syntax errors and non-object JSON 400 before
`verifyWalletSignature` / `executeServerWalletRpc`. Missing fields on a real
object stay 400 via zod.

# Background

## What does this PR do?

`c.req.json()` sat in the same try that maps every throw to
`failureResponse(..., 500)`. Syntax errors were a server fault on the
server-wallet RPC path. Those bodies are client garbage and must be
400 `{ success: false, error: "Invalid JSON body" }` before any signature
verify or RPC execute.

- `{not-json` / array / primitive / `null` → **400** `Invalid JSON body`
  before `verifyWalletSignature` / `executeServerWalletRpc`
- `{}` still 400 Validation error (zod)
- canonical signed object still 200 after wallet-signature auth

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

A malformed wallet-RPC body was a server fault on the server-wallet execute
path. Caller garbage must not 500 or verify/execute an RPC.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/cloud/api/v1/user/wallets/rpc/route.json-body.test.ts` —
malformed bodies 400 with signature verify and RPC execute uncalled; zod
missing fields stay 400; canonical signed object still 200.

## Detailed testing steps

```bash
cd packages/cloud/api && bun test v1/user/wallets/rpc/route.json-body.test.ts
```

10 passed at the evidence head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; JSON parse only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; JSON parse only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; JSON parse only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real handler and assert 400 before wallet-signature verify / RPC execute; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, wallet, or generated-file writes in the 400 path.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal JSON 400s
before wallet-signature verify / RPC execute; missing fields stay 400 via zod;
canonical signed object still 200.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file wallet-RPC JSON parse
with a green focused suite (10 tests). Full monorepo verify is unrelated to
this body grammar and was skipped to keep the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:4b5950726459326b1b6e9fa1b549b08ee254a1a7 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
