### PR TITLE
fix(agent): reject non-boolean models catalogOnly and refresh

### DIFF
--- a/packages/agent/src/api/models-routes.test.ts
+++ b/packages/agent/src/api/models-routes.test.ts
@@ -76,6 +76,53 @@ describe("handleModelsRoutes catalog field", () => {
     expect(ctx.getOrFetchProvider).not.toHaveBeenCalled();
   });
 
+  it("accepts the refresh=true boolean identity for catalogOnly", async () => {
+    const { ctx, json } = makeCtx("/api/models?catalogOnly=true");
+    await expect(handleModelsRoutes(ctx as never)).resolves.toBe(true);
+    expect(json).toHaveBeenCalledWith(ctx.res, {
+      providers: {},
+      catalog: fakeCatalog,
+    });
+    expect(ctx.getOrFetchAllProviders).not.toHaveBeenCalled();
+    expect(ctx.getOrFetchProvider).not.toHaveBeenCalled();
+  });
+
+  it("accepts the catalogOnly=1 boolean identity for refresh", async () => {
+    const unlinkFile = vi.fn();
+    const { ctx, json } = makeCtx("/api/models?provider=openai&refresh=1");
+    ctx.unlinkFile = unlinkFile;
+    await expect(handleModelsRoutes(ctx as never)).resolves.toBe(true);
+    expect(unlinkFile).toHaveBeenCalledWith("/tmp/openai.json");
+    expect(ctx.getOrFetchProvider).toHaveBeenCalledWith("openai", true);
+    expect(json).toHaveBeenCalledWith(ctx.res, {
+      provider: "openai",
+      models: [{ id: "m1" }],
+      catalog: fakeCatalog,
+    });
+  });
+
+  it("rejects non-boolean catalogOnly and refresh before any provider fetch", async () => {
+    for (const query of [
+      "catalogOnly=truee",
+      "catalogOnly=1e2",
+      "catalogOnly=yesplease",
+      "refresh=truee",
+      "refresh=1e2",
+      "refresh=12px",
+      "catalogOnly=1&refresh=1e2",
+    ]) {
+      const { ctx, json } = makeCtx(`/api/models?${query}`);
+      await expect(handleModelsRoutes(ctx as never)).resolves.toBe(true);
+      expect(json, query).toHaveBeenCalledWith(
+        ctx.res,
+        { error: expect.stringMatching(/must be a boolean/) },
+        400,
+      );
+      expect(ctx.getOrFetchAllProviders, query).not.toHaveBeenCalled();
+      expect(ctx.getOrFetchProvider, query).not.toHaveBeenCalled();
+    }
+  });
+
   it("declines non-matching routes", async () => {
     const { ctx } = makeCtx("/api/models");
     ctx.pathname = "/api/models/config";

--- a/packages/agent/src/api/models-routes.ts
+++ b/packages/agent/src/api/models-routes.ts
@@ -9,8 +9,21 @@
  * access are injected through the route context so the handler stays
  * transport-agnostic and unit-testable.
  */
-import type { RouteHelpers, RouteRequestMeta } from "@elizaos/core";
+import {
+  parseBooleanValue,
+  type RouteHelpers,
+  type RouteRequestMeta,
+} from "@elizaos/core";
 import { buildModelCatalog, type ModelCatalog } from "./model-catalog.ts";
+
+function parseOptionalBooleanQuery(
+  raw: string | null,
+): { ok: true; value?: boolean } | { ok: false } {
+  if (raw === null) return { ok: true };
+  const parsed = parseBooleanValue(raw);
+  if (parsed === undefined) return { ok: false };
+  return { ok: true, value: parsed };
+}
 
 export interface ModelsRouteContext
   extends RouteRequestMeta,
@@ -51,7 +64,19 @@ export async function handleModelsRoutes(
 
   if (method !== "GET" || pathname !== "/api/models") return false;
 
-  const force = url.searchParams.get("refresh") === "true";
+  const catalogOnlyParsed = parseOptionalBooleanQuery(
+    url.searchParams.get("catalogOnly"),
+  );
+  if (!catalogOnlyParsed.ok) {
+    json(res, { error: "catalogOnly must be a boolean" }, 400);
+    return true;
+  }
+  const refreshParsed = parseOptionalBooleanQuery(url.searchParams.get("refresh"));
+  if (!refreshParsed.ok) {
+    json(res, { error: "refresh must be a boolean" }, 400);
+    return true;
+  }
+  const force = refreshParsed.value === true;
   const specificProvider = url.searchParams.get("provider");
   // Built per request: the codex slice re-reads the CLI's models_cache.json
   // at call time so a refreshed server catalog shows up without a restart.
@@ -62,7 +87,8 @@ export async function handleModelsRoutes(
   // The all-providers fan-out below hits every provider's live model-list API
   // and takes tens of seconds on a cold cache, which blows the UI client's
   // 10s fetch budget and renders as a failed options load.
-  if (url.searchParams.get("catalogOnly") === "1") {
+  // Accept both shipped identities: UI catalog path uses `1`, refresh uses `true`.
+  if (catalogOnlyParsed.value === true) {
     json(res, { providers: {}, catalog });
     return true;
   }

--- a/packages/agent/src/api/models-routes.ts
+++ b/packages/agent/src/api/models-routes.ts
@@ -71,7 +71,9 @@ export async function handleModelsRoutes(
     json(res, { error: "catalogOnly must be a boolean" }, 400);
     return true;
   }
-  const refreshParsed = parseOptionalBooleanQuery(url.searchParams.get("refresh"));
+  const refreshParsed = parseOptionalBooleanQuery(
+    url.searchParams.get("refresh"),
+  );
   if (!refreshParsed.ok) {
     json(res, { error: "refresh must be a boolean" }, 400);
     return true;


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on `GET /api/models` boolean
query identity. Not leftover tax on Cloud JSON-400, prefix-coerced limit,
percent-encoded paths, SIWS chainId, orchestrator lines, provisioning-worker
env ints, invites-accept, cli-auth, redemption quote, compat agent-logs,
first-run, login persist, billing, or avatar. Disjoint from Workbench VFS
file encoding.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. Boolean query parse only on `GET /api/models`. Shipped UI
`catalogOnly=1` and `refresh=true` still 200. The opposite identities
(`catalogOnly=true`, `refresh=1`) now take the intended path. Garbage 400
before provider fetch or cache unlink.

# Background

## What does this PR do?

`GET /api/models` used two different boolean spellings. The settings catalog
path sends `catalogOnly=1`. The refresh path sends `refresh=true`.
`catalogOnly=true` (the refresh spelling) did **not** skip the all-providers
fan-out and blew the 10s UI fetch budget. `refresh=1` (the catalogOnly
spelling) did **not** bust cache. Prefix-legal garbage (`1e2`, `truee`)
silently took the wrong path.

Both flags now go through `parseBooleanValue` (core): omitted keeps today's
defaults; `1`/`true`/`yes`/`on` and `0`/`false`/`no`/`off` apply; anything
else is 400 before `getOrFetch*` / `unlinkFile`.

- `catalogOnly=1` and `catalogOnly=true` → **200** catalog only, no fan-out
- `refresh=true` and `refresh=1` → cache bust + fetch with `force=true`
- `truee` / `1e2` / `12px` / `yesplease` → **400** `must be a boolean`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The settings model panel and slash completions depend on `catalogOnly`
skipping the cold all-providers fan-out. Mixed boolean identity made the
documented `true` spelling take the slow path. Refresh with the `1` spelling
left stale cache in place.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/models-routes.test.ts` — catalogOnly=1 still skips
fetchers; catalogOnly=true now does too; refresh=1 unlinks; garbage 400 with
fetchers uncalled.

## Detailed testing steps

```bash
cd packages/agent && bunx vitest run --config vitest.config.ts \
  src/api/models-routes.test.ts --coverage.enabled=false
```

7 passed at the evidence head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; models query parse only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; models query parse only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; models query parse only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real handler and assert 400 before provider fetch / cache unlink; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, wallet, or generated-file writes in the 400 path.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: both shipped
boolean identities 200; garbage 400 before provider fetch.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file models query parse with a
green focused suite (7 tests). Full monorepo verify is unrelated to this
boolean grammar and was skipped to keep the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:4277af5e9878330cba208a25fbaf61187b2da1cc -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
