### PR TITLE
fix(shared): exclude newline from TTS sentence snips

### DIFF
--- a/packages/shared/src/voice/first-sentence-snip.test.ts
+++ b/packages/shared/src/voice/first-sentence-snip.test.ts
@@ -99,6 +99,24 @@ describe("firstSentenceSnip — happy path", () => {
     expect(r?.raw).toBe("Hi.");
     expect(r?.normalized).toBe("hi");
   });
+  it("excludes a newline-only boundary from raw text and its end offset", () => {
+    const r = firstSentenceSnip("Hello there\nSecond line.");
+    expect(r?.raw).toBe("Hello there");
+    expect(r?.normalized).toBe("hello there");
+    expect(r?.endOffset).toBe("Hello there".length);
+  });
+  it("excludes horizontal whitespace immediately before a newline boundary", () => {
+    const r = firstSentenceSnip("Hello there \t \nSecond line.");
+    expect(r?.raw).toBe("Hello there");
+    expect(r?.normalized).toBe("hello there");
+    expect(r?.endOffset).toBe("Hello there".length);
+  });
+  it("matches the trimmed whole-input boundary when the input ends in whitespace and newline", () => {
+    const text = "Hello there \t\n";
+    const r = firstSentenceSnip(text);
+    expect(r?.raw).toBe("Hello there");
+    expect(r?.endOffset).toBe(text.trimEnd().length);
+  });
   it("treats CJK terminators as boundaries", () => {
     const r = firstSentenceSnip("我知道了。");
     expect(r?.normalized).toBe("我知道了");

--- a/packages/shared/src/voice/first-sentence-snip.ts
+++ b/packages/shared/src/voice/first-sentence-snip.ts
@@ -121,8 +121,10 @@ function findTerminatorEnd(text: string, start: number): number {
 
     // Newline acts as a soft terminator (e.g. message body broken into lines).
     if (ch === "\n") {
-      // Strip trailing whitespace from the run by returning index of \n.
-      return i;
+      // Neither the delimiter nor horizontal spacing before it is spoken.
+      let end = i - 1;
+      while (end >= start && /\s/u.test(text[end] ?? "")) end--;
+      return end;
     }
 
     // Open / close quotes for skipping terminators inside.


### PR DESCRIPTION
# Relates to

New finding, no prior issue.

# Contribution provenance

<!-- contribution-attribution:v1 -->
AI-assisted. Initial bug identification, reproduction, and fix drafted by OpenAI Codex (`gpt-5.6-sol` via AgentRouter) running in a sandboxed worktree with no git-write access, so it could not commit itself. I independently re-verified before shipping: re-ran the focused test suite and full mutation check myself from a clean stash, re-ran typecheck/biome, and re-traced the reachability claim directly against `packages/cloud/api/v1/voice/tts/route.ts` before committing and pushing.

# Sync with develop

Branched from and rebased onto current `develop` tip immediately before starting.

# Risks

Low. Single-line change to one boundary case (`\n`) inside `findTerminatorEnd`; every other terminator branch (period, exclamation, question, ellipsis, CJK) is untouched. `FIRST_SENTENCE_SNIP_VERSION` is deliberately left at `"1"` — the normalized cache key output is unchanged, only `raw`/`endOffset` for the newline case.

# Background

## What does this PR do?

`findTerminatorEnd` treats a newline as a soft sentence boundary but returned the newline's own index, including it in `raw` and `endOffset`. Two observable effects:

1. Background cache population sent `snipResult.raw` with a trailing `\n` directly to Cartesia/ElevenLabs — synthesizing the delimiter itself as spoken content, not just sentence text.
2. For a whole input ending in a newline, the production whole-input predicate `snipResult.endOffset === text.trimEnd().length` was false, so an otherwise-cacheable short utterance missed the first-line cache path.

Pre-fix reproduction on the current tree:
```json
{"result":{"raw":"Hello there\n","normalized":"hello there","wordCount":2,"endOffset":12},"wholeInput":false}
```

Post-fix:
```json
{"result":{"raw":"Hello there","normalized":"hello there","wordCount":2,"endOffset":11},"wholeInput":true}
```

Fix: return the index before the newline instead of the newline's own index, matching how every other terminator is already handled.

## What kind of change is this?

Bug fix — no new capability, no schema change, no cache-key version bump needed.

# Documentation changes needed?

No.

# Testing

New test in `first-sentence-snip.test.ts`:
```ts
it("excludes a newline-only boundary from raw text and its end offset", () => {
  const r = firstSentenceSnip("Hello there\nSecond line.");
  expect(r?.raw).toBe("Hello there");
  expect(r?.normalized).toBe("hello there");
  expect(r?.endOffset).toBe("Hello there".length);
});
```

# Evidence Gate

<!-- evidence-head:250f54aac481870b85a62eb71ebf9ec50cde5836 -->

- <!-- evidence-row:before-after-screenshots --> N/A - backend text-processing logic, no UI surface
- <!-- evidence-row:walkthrough-video -->
- [ ] N/A: no interactive user flow

## Known gaps / failures

None known in the touched surface. `packages/cloud/api/v1/voice/tts/route.ts` also has a Kokoro cache path using the identical `endOffset === text.trimEnd().length` predicate — same fix benefits it, no separate change needed there.

---

AI provider/model: openai / gpt-5.6-sol (initial fix, via AgentRouter) + anthropic / claude-sonnet-5 (independent re-verification, commit, PR)
Client/tooling: Codex CLI (initial), Claude Code (verification/shipping)
Attribution status: self-reported

<!-- evidence-row:domain-artifacts -->
- [x] [20873-pr20873-domain-artifacts.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20873-pr20873-domain-artifacts.log)

<!-- evidence-row:before-screenshots -->
- [ ] N/A: backend text-boundary logic; no visual surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A: backend text-boundary logic; no visual surface

<!-- evidence-row:frontend-logs -->
- [ ] N/A: no frontend path

<!-- evidence-row:llm-trajectory -->
- [ ] N/A: deterministic text processing; no model behavior

<!-- evidence-row:backend-logs -->
- [x] [20873-pr20873-shared-full.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20873-pr20873-shared-full.log)
