### PR TITLE
feat(cloud): reserve production Telegram edge cutover secret

### DIFF
--- a/packages/cloud/api/src/index.test.ts
+++ b/packages/cloud/api/src/index.test.ts
@@ -1006,7 +1006,7 @@ describe("cloud-api worker entrypoint", () => {
     );
   });
 
-  test("keeps the legacy edge guard false and reserves the replacement name for the cutover secret", async () => {
+  test("keeps the legacy edge guard false and reserves the replacement names for the cutover secrets", async () => {
     const config = Bun.TOML.parse(
       await Bun.file(new URL("../wrangler.toml", import.meta.url)).text(),
     ) as {
@@ -1014,6 +1014,7 @@ describe("cloud-api worker entrypoint", () => {
         PERSONAL_DELIVERY_PROJECTION_READ_ENABLED?: string;
         PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
         PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED?: string;
         ELIZA_INFERENCE_TIMING?: string;
       };
       env?: {
@@ -1022,6 +1023,7 @@ describe("cloud-api worker entrypoint", () => {
             PERSONAL_DELIVERY_PROJECTION_READ_ENABLED?: string;
             PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
             PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
+            PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED?: string;
             ELIZA_INFERENCE_TIMING?: string;
           };
         };
@@ -1030,6 +1032,7 @@ describe("cloud-api worker entrypoint", () => {
             PERSONAL_DELIVERY_PROJECTION_READ_ENABLED?: string;
             PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
             PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
+            PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED?: string;
             ELIZA_INFERENCE_TIMING?: string;
           };
         };
@@ -1061,6 +1064,17 @@ describe("cloud-api worker entrypoint", () => {
     expect(
       config.env?.production?.vars
         ?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED,
+    ).toBeUndefined();
+    expect(
+      config.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED,
+    ).toBeUndefined();
+    expect(
+      config.env?.staging?.vars
+        ?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED,
+    ).toBeUndefined();
+    expect(
+      config.env?.production?.vars
+        ?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED,
     ).toBeUndefined();
     expect(config.vars?.ELIZA_INFERENCE_TIMING).toBeUndefined();
     expect(config.env?.staging?.vars?.ELIZA_INFERENCE_TIMING).toBe("info");

--- a/packages/cloud/api/src/personal-shared-telegram-edge.test.ts
+++ b/packages/cloud/api/src/personal-shared-telegram-edge.test.ts
@@ -33,6 +33,54 @@ describe("Personal Shared Telegram edge gate", () => {
     ],
     [{ PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED: "1" }, false],
     [{ PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED: " true " }, false],
+    [
+      {
+        ENVIRONMENT: "production",
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED: "true",
+      },
+      true,
+    ],
+    [
+      {
+        ENVIRONMENT: "production",
+        PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED: "false",
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED: "true",
+      },
+      true,
+    ],
+    [
+      {
+        ENVIRONMENT: "staging",
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED: "true",
+      },
+      false,
+    ],
+    [
+      { PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED: "true" },
+      false,
+    ],
+    [
+      {
+        ENVIRONMENT: "production",
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED: "1",
+      },
+      false,
+    ],
+    [
+      {
+        ENVIRONMENT: "production",
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED: " true ",
+      },
+      false,
+    ],
+    [
+      {
+        ENVIRONMENT: "production",
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED: "true",
+        PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED: "false",
+      },
+      false,
+    ],
   ])("resolves %o as %s", (env, expected) => {
     expect(isPersonalSharedTelegramEdgeEnabled(env)).toBe(expected);
   });

--- a/packages/cloud/api/src/personal-shared-telegram-edge.ts
+++ b/packages/cloud/api/src/personal-shared-telegram-edge.ts
@@ -4,11 +4,15 @@ export interface PersonalSharedTelegramEdgeBindings {
   ENVIRONMENT?: string;
   PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
   PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
+  PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED?: string;
 }
 
 /**
- * The replacement binding lets staging escape a stale plaintext name without
- * weakening the old default/production guard. Only an exact true opts in.
+ * The replacement bindings let each environment escape a stale plaintext name
+ * without weakening the old default guard. Every cutover secret is fresh and
+ * environment-pinned — staging and production names never cross-activate, so a
+ * copied binding in the wrong environment stays inert. Only an exact true
+ * opts in.
  */
 export function isPersonalSharedTelegramEdgeEnabled(
   env: PersonalSharedTelegramEdgeBindings,
@@ -16,6 +20,8 @@ export function isPersonalSharedTelegramEdgeEnabled(
   return (
     env.PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED === "true" ||
     (env.ENVIRONMENT === "staging" &&
-      env.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED === "true")
+      env.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED === "true") ||
+    (env.ENVIRONMENT === "production" &&
+      env.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED === "true")
   );
 }

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -189,9 +189,11 @@ NODE_ENV = "production"
 SHARED_ELIZA_AGENT_RUNTIME = "false"
 PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "false"
 PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED = "false"
-# PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED is deliberately absent from
-# every [vars] block. The protected staging workflow owns it as a secret, while
-# the legacy explicit-false binding stays as the default/production guard.
+# PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED and
+# PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED are deliberately
+# absent from every [vars] block. The protected activation workflows own them
+# as environment-pinned secrets, while the legacy explicit-false binding stays
+# as the default guard.
 NEXT_PUBLIC_APP_URL = "https://cloud.eliza.app"
 NEXT_PUBLIC_API_URL = "https://api.eliza.app"
 ELIZA_CLOUD_URL = "https://api.eliza.app"
@@ -744,6 +746,11 @@ NODE_ENV = "production"
 SHARED_ELIZA_AGENT_RUNTIME = "true"
 PERSONAL_DELIVERY_PROJECTION_READ_ENABLED = "false"
 PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED = "false"
+# The protected production cutover owns
+# PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED as a secret binding.
+# The name is fresh (never bound in production, so no plaintext collision) and
+# environment-pinned: the helper honors it only when ENVIRONMENT is production,
+# and it must be exactly true to opt in.
 THIN_INFERENCE_ENTRY_ENABLED = "true"
 # Apps deploy (Product 2): arms the Worker-side deploy trigger (configureAppsDeployTrigger,
 # bootstrap-app.ts) so POST /api/v1/apps/:id/deploy enqueues a real APP_DEPLOY job instead of

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -422,6 +422,8 @@ export interface Bindings {
   PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED?: string;
   /** Collision-free secret used by the protected staging edge cutover. */
   PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED?: string;
+  /** Collision-free secret used by the protected production edge cutover; inert outside production. */
+  PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED?: string;
   ELIZA_APP_TELEGRAM_BOT_TOKEN?: string;
   ELIZA_APP_TELEGRAM_WEBHOOK_SECRET?: string;
   // Dedicated shared secret stamped onto forwarded webhook calls so the internal


### PR DESCRIPTION
Part of #20658; extends the #20664 contract to production.

## Why

The staging cutover binding is deliberately staging-pinned — the helper refuses `PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED` outside staging, and the legacy `PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED` name stays an explicit-false plaintext var in production, so a same-name `wrangler secret put` would hit the 10053 secret-versus-var collision that started this arc. Production therefore needs its own fresh, environment-pinned replacement name before any production activation can happen. This PR is the code-side prep only: production behavior is unchanged until the secret is actually set through the protected activation chain.

## What

- `PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED`: fresh name (never bound in production → no plaintext collision), honored by the single shared exact-true helper only when `ENVIRONMENT` is `production`; inert in staging/default, exactly mirroring the staging binding's pinning.
- Legacy default guard untouched; legacy exact-true still wins everywhere.
- `Bindings` type gains the new optional secret.
- `wrangler.toml` comments extended: both cutover names reserved out of every `[vars]` block; production block documents the reserved secret.
- Config-contract test (`index.test.ts`) now asserts the production name is absent from all three vars blocks, same tripwire as the staging name.
- Gate test matrix extended: production exact-true honored (including over explicit-false legacy, matching staging semantics), refused in staging/default, `"1"`/`" true "` refused, staging binding still refused in production.

## Not in this PR (dependency)

`.github/workflows/activate-personal-shared-telegram-edge.yml` must grow a production mode that mutates ONLY the new name (activation + rollback). Workflow-file pushes need workflow scope this lane does not have — flagged at HQ for the workflow-scope lane. Activation itself additionally requires the explicit production go.

## Evidence

- `src/personal-shared-telegram-edge.test.ts`: 15/15 (full pin matrix above).
- `src/index.test.ts`: 42/42 including the extended wrangler reservation contract.
- `__tests__/personal-telegram-edge.test.ts`: 8/8.
- `wrangler deploy --dry-run --env production`: bundle retains `PERSONAL_SHARED_TELEGRAM_EDGE_ENABLED="false"` and contains NO cutover binding of either name.
- cloud-api typecheck clean on touched files; Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)