### PR TITLE
release: sync latest develop to production

### DIFF
--- a/packages/cloud/api/v1/referrals/apply/route.json-body.test.ts
+++ b/packages/cloud/api/v1/referrals/apply/route.json-body.test.ts
@@ -1,0 +1,135 @@
+/**
+ * POST /api/v1/referrals/apply untrusted JSON body contract.
+ *
+ * Hono 4.13 `c.req.json()` is a bare `JSON.parse`. The handler catch maps
+ * SyntaxError through `failureResponse` to HTTP 500 instead of a caller 400.
+ * Referral apply must not write an affiliate binding on garbage.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const USER_ID = "00000000-0000-4000-8000-0000000000aa";
+const ORG_ID = "00000000-0000-4000-8000-0000000000bb";
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: USER_ID,
+  organization_id: ORG_ID,
+}));
+const applyReferralCode = mock(async () => {
+  throw new Error("applyReferralCode must not run");
+});
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/services/referrals", () => ({
+  referralsService: { applyReferralCode },
+}));
+
+mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
+  RateLimitPresets: { STRICT: {} },
+  rateLimit: () => async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+}));
+
+mock.module("@/lib/api/cloud-worker-errors", () => ({
+  failureResponse: mock((c: { json: (body: unknown, status: number) => unknown }) =>
+    c.json({ success: false, error: "An unexpected error occurred" }, 500),
+  ),
+}));
+
+mock.module("@/lib/utils/cors", () => ({
+  getCorsHeaders: () => ({}),
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+  },
+}));
+
+const { default: app } = await import("./route");
+
+function post(raw: string, auth = true) {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (auth) headers.Authorization = "Bearer eliza_test_key";
+  return app.fetch(
+    new Request("http://test.local/", {
+      method: "POST",
+      headers,
+      body: raw,
+    }),
+  );
+}
+
+describe("POST /api/v1/referrals/apply JSON body", () => {
+  beforeEach(() => {
+    requireUserOrApiKeyWithOrg.mockClear();
+    applyReferralCode.mockClear();
+    requireUserOrApiKeyWithOrg.mockImplementation(async () => ({
+      id: USER_ID,
+      organization_id: ORG_ID,
+    }));
+    applyReferralCode.mockImplementation(async () => {
+      throw new Error("applyReferralCode must not run");
+    });
+  });
+
+  test.each(["", "   ", "{", "not-json"])(
+    "rejects malformed referral body %j with 400",
+    async (raw) => {
+      const res = await post(raw);
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "Invalid JSON body" });
+      expect(requireUserOrApiKeyWithOrg).toHaveBeenCalled();
+      expect(applyReferralCode).not.toHaveBeenCalled();
+    },
+  );
+
+  test.each(['["CODE"]', '"CODE"', "null", "12"])(
+    "rejects non-object referral body %s with 400",
+    async (raw) => {
+      const res = await post(raw);
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "Invalid JSON body" });
+      expect(applyReferralCode).not.toHaveBeenCalled();
+    },
+  );
+
+  test("still 400s a parseable object missing code via zod", async () => {
+    const res = await post("{}");
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid referral code format." });
+    expect(applyReferralCode).not.toHaveBeenCalled();
+  });
+
+  test("still applies a canonical object body", async () => {
+    applyReferralCode.mockResolvedValue({
+      success: true,
+      message: "Referral applied",
+    });
+
+    const res = await post(JSON.stringify({ code: "FRIEND1" }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      success: true,
+      message: "Referral applied",
+    });
+    expect(applyReferralCode).toHaveBeenCalledTimes(1);
+    expect(applyReferralCode.mock.calls[0]).toEqual([
+      USER_ID,
+      ORG_ID,
+      "FRIEND1",
+    ]);
+  });
+});

--- a/packages/cloud/api/v1/referrals/apply/route.json-body.test.ts
+++ b/packages/cloud/api/v1/referrals/apply/route.json-body.test.ts
@@ -10,13 +10,18 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 const USER_ID = "00000000-0000-4000-8000-0000000000aa";
 const ORG_ID = "00000000-0000-4000-8000-0000000000bb";
 
-const requireUserOrApiKeyWithOrg = mock(async () => ({
-  id: USER_ID,
-  organization_id: ORG_ID,
-}));
-const applyReferralCode = mock(async () => {
-  throw new Error("applyReferralCode must not run");
-});
+const requireUserOrApiKeyWithOrg =
+  mock<
+    (context: unknown) => Promise<{ id: string; organization_id: string }>
+  >();
+const applyReferralCode =
+  mock<
+    (
+      userId: string,
+      organizationId: string,
+      code: string,
+    ) => Promise<{ success: boolean; message: string }>
+  >();
 
 mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
@@ -34,8 +39,9 @@ mock.module("@/lib/middleware/rate-limit-hono-cloudflare", () => ({
 }));
 
 mock.module("@/lib/api/cloud-worker-errors", () => ({
-  failureResponse: mock((c: { json: (body: unknown, status: number) => unknown }) =>
-    c.json({ success: false, error: "An unexpected error occurred" }, 500),
+  failureResponse: mock(
+    (c: { json: (body: unknown, status: number) => unknown }) =>
+      c.json({ success: false, error: "An unexpected error occurred" }, 500),
   ),
 }));
 
@@ -87,7 +93,9 @@ describe("POST /api/v1/referrals/apply JSON body", () => {
       const res = await post(raw);
 
       expect(res.status).toBe(400);
-      expect(await res.json()).toEqual({ error: "Invalid JSON body" });
+      expect((await res.json()) as unknown).toEqual({
+        error: "Invalid JSON body",
+      });
       expect(requireUserOrApiKeyWithOrg).toHaveBeenCalled();
       expect(applyReferralCode).not.toHaveBeenCalled();
     },
@@ -99,7 +107,9 @@ describe("POST /api/v1/referrals/apply JSON body", () => {
       const res = await post(raw);
 
       expect(res.status).toBe(400);
-      expect(await res.json()).toEqual({ error: "Invalid JSON body" });
+      expect((await res.json()) as unknown).toEqual({
+        error: "Invalid JSON body",
+      });
       expect(applyReferralCode).not.toHaveBeenCalled();
     },
   );
@@ -108,7 +118,9 @@ describe("POST /api/v1/referrals/apply JSON body", () => {
     const res = await post("{}");
 
     expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({ error: "Invalid referral code format." });
+    expect((await res.json()) as unknown).toEqual({
+      error: "Invalid referral code format.",
+    });
     expect(applyReferralCode).not.toHaveBeenCalled();
   });
 
@@ -121,7 +133,7 @@ describe("POST /api/v1/referrals/apply JSON body", () => {
     const res = await post(JSON.stringify({ code: "FRIEND1" }));
 
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({
+    expect((await res.json()) as unknown).toEqual({
       success: true,
       message: "Referral applied",
     });

--- a/packages/cloud/api/v1/referrals/apply/route.ts
+++ b/packages/cloud/api/v1/referrals/apply/route.ts
@@ -37,7 +37,19 @@ app.post("/", async (c) => {
       return c.json({ error: "Organization not found" }, 400, corsHeaders);
     }
 
-    const body = await c.req.json();
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      // error-policy:J3 untrusted request JSON — Hono's c.req.json() is a
+      // bare JSON.parse. SyntaxError must be a caller 400, not the
+      // failureResponse 500 that treats it as an unexpected server fault.
+      // Referral apply must not write an affiliate binding on garbage.
+      return c.json({ error: "Invalid JSON body" }, 400, corsHeaders);
+    }
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return c.json({ error: "Invalid JSON body" }, 400, corsHeaders);
+    }
     const validation = ApplySchema.safeParse(body);
     if (!validation.success) {
       return c.json(


### PR DESCRIPTION
Follow-up promotion for commits merged into `develop` immediately after #20875. Keeps `main` aligned with the complete latest develop tree before production certification.