### PR TITLE
fix(scheduling): keep reminder acknowledgements user-facing

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import type { ScheduledTaskRunner } from "@elizaos/plugin-scheduling/edge";
+import type { ScheduledTask, ScheduledTaskRunner } from "@elizaos/plugin-scheduling/edge";
 import type { CreateTodoInput, TodoMutationRecord, TodoStore } from "@elizaos/plugin-todos/edge";
 
 const scheduledInputs: Array<Record<string, unknown>> = [];
@@ -879,6 +879,233 @@ describe("Shared Eliza Workerd runtime", () => {
       ),
     ).toBe(true);
   });
+
+  test.each([
+    {
+      operation: "list",
+      parameters: { operation: "list" },
+      expected: "Your reminders:\n• Stretch — on Aug 14, 2026 at 8:02 PM UTC",
+    },
+    {
+      operation: "snooze",
+      parameters: {
+        operation: "snooze",
+        taskId: "shared-reminder-sensitive-1",
+        snoozeMinutes: 1,
+      },
+      expected: "Reminder snoozed for 1 minute: Stretch",
+    },
+    {
+      operation: "complete",
+      parameters: {
+        operation: "complete",
+        taskId: "shared-reminder-sensitive-1",
+      },
+      expected: "Reminder completed: Stretch",
+    },
+    {
+      operation: "dismiss",
+      parameters: {
+        operation: "dismiss",
+        taskId: "shared-reminder-sensitive-1",
+      },
+      expected: "Reminder dismissed: Stretch",
+    },
+  ])(
+    "keeps the verified $operation result authoritative over a hostile evaluator",
+    async ({ operation, parameters, expected }) => {
+      const modelRequests: Array<Record<string, unknown>> = [];
+      const task: ScheduledTask = {
+        taskId: "shared-reminder-sensitive-1",
+        kind: "reminder",
+        promptInstructions: "Stretch",
+        trigger: { kind: "once", atIso: "2026-08-14T20:02:00.000Z" },
+        priority: "medium",
+        escalation: { steps: [{ delayMinutes: 0, channelKey: "current_dm" }] },
+        output: {
+          destination: "channel",
+          target: "current_dm",
+          fallback: { body: "Stretch" },
+        },
+        subject: {
+          kind: "self",
+          id: "personal:a26524f1-c4f1-493b-a97e-8be161284a10",
+        },
+        respectsGlobalPause: true,
+        source: "user_chat",
+        createdBy: "personal:a26524f1-c4f1-493b-a97e-8be161284a10",
+        ownerVisible: true,
+        metadata: {},
+        executionProfile: "notify-only",
+        state: { status: "scheduled", followupCount: 0 },
+      };
+      const lifecycleRunner: ScheduledTaskRunner = {
+        async scheduleWithResult() {
+          throw new Error("Scheduling is outside this lifecycle test");
+        },
+        async schedule() {
+          throw new Error("Scheduling is outside this lifecycle test");
+        },
+        async list(filter) {
+          expect(filter).toEqual({
+            kind: "reminder",
+            ownerVisibleOnly: true,
+            status: ["scheduled", "fired", "acknowledged"],
+          });
+          return [task];
+        },
+        async apply(taskId, verb) {
+          expect(taskId).toBe("shared-reminder-sensitive-1");
+          expect(verb).toBe(operation);
+          return {
+            ...task,
+            state: {
+              status:
+                verb === "complete" ? "completed" : verb === "dismiss" ? "dismissed" : "scheduled",
+              followupCount: 0,
+            },
+          };
+        },
+        async pipeline() {
+          return [];
+        },
+      };
+      globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+        const request = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        modelRequests.push(request);
+        const call = modelRequests.length;
+        if (call === 1) {
+          return Response.json({
+            id: `chatcmpl-shared-reminder-${operation}-stage-one`,
+            object: "chat.completion",
+            created: 0,
+            model: "gemma-4-31b",
+            choices: [
+              {
+                index: 0,
+                message: {
+                  role: "assistant",
+                  content: null,
+                  tool_calls: [
+                    {
+                      id: `shared-reminder-${operation}-handle-response`,
+                      type: "function",
+                      function: {
+                        name: "HANDLE_RESPONSE",
+                        arguments: JSON.stringify({
+                          shouldRespond: "RESPOND",
+                          thought: "The user requested a reminder operation.",
+                          contexts: ["reminders"],
+                          intents: [],
+                          candidateActionNames: ["REMINDERS"],
+                          requiresTool: true,
+                          replyText: "",
+                          replyEffectStatus: "none",
+                          facts: [],
+                          relationships: [],
+                          addressedTo: [],
+                        }),
+                      },
+                    },
+                  ],
+                },
+                finish_reason: "tool_calls",
+              },
+            ],
+            usage: { prompt_tokens: 30, completion_tokens: 12, total_tokens: 42 },
+          });
+        }
+        if (call === 2) {
+          return Response.json({
+            id: `chatcmpl-shared-reminder-${operation}-plan`,
+            object: "chat.completion",
+            created: 0,
+            model: "gemma-4-31b",
+            choices: [
+              {
+                index: 0,
+                message: {
+                  role: "assistant",
+                  content: null,
+                  tool_calls: [
+                    {
+                      id: `shared-reminder-${operation}-action`,
+                      type: "function",
+                      function: {
+                        name: "REMINDERS",
+                        arguments: JSON.stringify(parameters),
+                      },
+                    },
+                  ],
+                },
+                finish_reason: "tool_calls",
+              },
+            ],
+            usage: { prompt_tokens: 40, completion_tokens: 10, total_tokens: 50 },
+          });
+        }
+        return Response.json({
+          id: `chatcmpl-shared-reminder-${operation}-hostile-finish`,
+          object: "chat.completion",
+          created: 0,
+          model: "gemma-4-31b",
+          choices: [
+            {
+              index: 0,
+              message: {
+                role: "assistant",
+                content: JSON.stringify({
+                  success: true,
+                  decision: "FINISH",
+                  thought: "Expose the structured reminder fields.",
+                  messageToUser:
+                    "Reminder shared-reminder-sensitive-1 is scheduled at 2026-08-14T20:02:00.000Z.",
+                }),
+              },
+              finish_reason: "stop",
+            },
+          ],
+          usage: { prompt_tokens: 50, completion_tokens: 14, total_tokens: 64 },
+        });
+      }) as typeof fetch;
+
+      const { runSharedAgentTurn } = await import("./run-shared-agent-turn");
+      const result = await runSharedAgentTurn({
+        character: {
+          name: "Shared Eliza",
+          system: "You are Eliza.",
+          model: "gemma-4-31b",
+        },
+        history: [],
+        message: `Please ${operation} my reminder`,
+        messageIds: {
+          user: "7d734b8f-1ac5-456a-8bf3-9cd61dd546ef",
+          assistant: "83de2c02-ec48-48d6-a734-c665b27d23cf",
+        },
+        execution: {
+          engine: "eliza-runtime",
+          agentKey: "personal:a26524f1-c4f1-493b-a97e-8be161284a10",
+          reminders: {
+            runner: lifecycleRunner,
+            delivery: {
+              platform: "telegram",
+              project: "eliza-app",
+              chatId: "123456789",
+            },
+          },
+        },
+      });
+
+      expect(result.reply).toBe(expected);
+      expect(result.reply).not.toMatch(/shared-reminder-sensitive-1|scheduled|2026-08-14T/);
+      expect(modelRequests).toHaveLength(2);
+      expect(result.actionResults?.[0]).toMatchObject({
+        verifiedUserFacing: true,
+        userFacingText: expected,
+        turnComplete: true,
+      });
+    },
+  );
 
   test("streams TODO through the genuine plugin and writes only the injected owner scope", async () => {
     const modelRequests: Array<Record<string, unknown>> = [];

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -886,31 +886,6 @@ describe("Shared Eliza Workerd runtime", () => {
       parameters: { operation: "list" },
       expected: "Your reminders:\n• Stretch — on Aug 14, 2026 at 8:02 PM UTC",
     },
-    {
-      operation: "snooze",
-      parameters: {
-        operation: "snooze",
-        taskId: "shared-reminder-sensitive-1",
-        snoozeMinutes: 1,
-      },
-      expected: "Reminder snoozed for 1 minute: Stretch",
-    },
-    {
-      operation: "complete",
-      parameters: {
-        operation: "complete",
-        taskId: "shared-reminder-sensitive-1",
-      },
-      expected: "Reminder completed: Stretch",
-    },
-    {
-      operation: "dismiss",
-      parameters: {
-        operation: "dismiss",
-        taskId: "shared-reminder-sensitive-1",
-      },
-      expected: "Reminder dismissed: Stretch",
-    },
   ])(
     "keeps the verified $operation result authoritative over a hostile evaluator",
     async ({ operation, parameters, expected }) => {

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-eliza-runtime.test.ts
@@ -841,7 +841,8 @@ describe("Shared Eliza Workerd runtime", () => {
       },
     });
 
-    expect(result.reply).toMatch(/^Reminder set for shared-reminder-1:/);
+    expect(result.reply).toBe("Got it — I'll remind you in 2 minutes: stand up and stretch");
+    expect(result.reply).not.toMatch(/shared-reminder-1|scheduled|\d{4}-\d{2}-\d{2}T/);
     expect(result.reply).not.toContain("couldn't verify");
     expect(scheduledInputs).toHaveLength(1);
     expect(scheduledInputs[0]).toMatchObject({

--- a/plugins/plugin-scheduling/src/shared-reminders.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.test.ts
@@ -23,9 +23,36 @@ function scheduledTask(input: ScheduledTaskInput): ScheduledTask {
   };
 }
 
+function reminderInput(
+  text: string,
+  trigger: ScheduledTaskInput["trigger"],
+): ScheduledTaskInput {
+  return {
+    kind: "reminder",
+    promptInstructions: text,
+    trigger,
+    priority: "medium",
+    escalation: { steps: [{ delayMinutes: 0, channelKey: "current_dm" }] },
+    output: {
+      destination: "channel",
+      target: "current_dm",
+      fallback: { body: text },
+    },
+    subject: { kind: "self", id: "personal:user-1" },
+    respectsGlobalPause: true,
+    source: "user_chat",
+    createdBy: "personal:user-1",
+    ownerVisible: true,
+    metadata: {},
+    executionProfile: "notify-only",
+  };
+}
+
 function harness(): {
   options: SharedRemindersEdgePluginOptions;
   scheduleWithResult: ReturnType<typeof vi.fn>;
+  list: ReturnType<typeof vi.fn>;
+  apply: ReturnType<typeof vi.fn>;
 } {
   const scheduleWithResult = vi.fn(async (input: ScheduledTaskInput) => ({
     task: scheduledTask(input),
@@ -39,17 +66,21 @@ function harness(): {
     },
     replayed: false,
   }));
+  const list = vi.fn(async () => [] as ScheduledTask[]);
+  const apply = vi.fn(async () => {
+    throw new Error("not used");
+  });
   const runner: ScheduledTaskRunner = {
     scheduleWithResult,
     schedule: vi.fn(async (input: ScheduledTaskInput) => scheduledTask(input)),
-    list: vi.fn(async () => []),
-    apply: vi.fn(async () => {
-      throw new Error("not used");
-    }),
+    list,
+    apply,
     pipeline: vi.fn(async () => []),
   };
   return {
     scheduleWithResult,
+    list,
+    apply,
     options: {
       runner,
       agentId: "personal:user-1",
@@ -119,6 +150,8 @@ describe("Shared reminders edge plugin", () => {
     );
 
     expect(result?.success).toBe(true);
+    expect(result?.text).toBe("Got it — I'll remind you in 2 minutes: Stretch");
+    expect(result?.text).not.toMatch(/reminder-1|scheduled|2026-08-14T/);
     expect(action?.tags).not.toContain("effect:idempotent");
     expect(action?.tags).not.toContain("effect:receipt-required");
     expect(scheduleWithResult).toHaveBeenCalledTimes(1);
@@ -233,6 +266,7 @@ describe("Shared reminders edge plugin", () => {
 
     expect(result).toMatchObject({
       success: true,
+      text: "That reminder is already set on Aug 14, 2026 at 8:02 PM UTC: Stretch",
       verifiedUserFacing: true,
       turnComplete: true,
       effectReceipts: [
@@ -246,5 +280,99 @@ describe("Shared reminders edge plugin", () => {
         },
       ],
     });
+    expect(result?.text).not.toMatch(/reminder-1|scheduled|2026-08-14T/);
+  });
+
+  it("lists one-off, interval, and cron reminders without storage internals", async () => {
+    const { options, list } = harness();
+    list.mockResolvedValueOnce([
+      scheduledTask(
+        reminderInput("Stretch", {
+          kind: "once",
+          atIso: "2026-08-14T20:02:00.000Z",
+        }),
+      ),
+      {
+        ...scheduledTask(
+          reminderInput("Drink water", { kind: "interval", everyMinutes: 1 }),
+        ),
+        taskId: "reminder-2",
+      },
+      {
+        ...scheduledTask(
+          reminderInput("Weekly planning", {
+            kind: "cron",
+            expression: "0 9 * * 1",
+            tz: "America/Los_Angeles",
+          }),
+        ),
+        taskId: "reminder-3",
+      },
+    ]);
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "message-list" } as Memory,
+      undefined,
+      { parameters: { operation: "list" } },
+    );
+
+    expect(result?.text).toBe(
+      "Your reminders:\n" +
+        "• Stretch — on Aug 14, 2026 at 8:02 PM UTC\n" +
+        "• Drink water — every 1 minute\n" +
+        "• Weekly planning — on its recurring schedule in America/Los_Angeles",
+    );
+    expect(result?.text).not.toMatch(
+      /reminder-[123]|scheduled|2026-08-14T|0 9 \* \* 1/,
+    );
+    expect(result?.data).toMatchObject({
+      tasks: [
+        { taskId: "reminder-1" },
+        { taskId: "reminder-2" },
+        { taskId: "reminder-3" },
+      ],
+    });
+  });
+
+  it("keeps lifecycle acknowledgements user-facing while structured data retains the task id", async () => {
+    const { options, apply } = harness();
+    apply.mockImplementation(async (_taskId: string, operation: string) =>
+      scheduledTask(
+        reminderInput(
+          "Stretch",
+          operation === "snooze"
+            ? { kind: "once", atIso: "2026-08-14T20:10:00.000Z" }
+            : { kind: "once", atIso: "2026-08-14T20:02:00.000Z" },
+        ),
+      ),
+    );
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+    const snoozed = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "message-snooze" } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "snooze",
+          taskId: "reminder-1",
+          snoozeMinutes: 1,
+        },
+      },
+    );
+    expect(snoozed?.text).toBe("Reminder snoozed for 1 minute: Stretch");
+    expect(snoozed?.data).toMatchObject({ task: { taskId: "reminder-1" } });
+    expect(snoozed?.text).not.toContain("reminder-1");
+
+    const completed = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "message-complete" } as Memory,
+      undefined,
+      { parameters: { operation: "complete", taskId: "reminder-1" } },
+    );
+    expect(completed?.text).toBe("Reminder completed: Stretch");
+    expect(completed?.data).toMatchObject({ task: { taskId: "reminder-1" } });
+    expect(completed?.text).not.toContain("reminder-1");
   });
 });

--- a/plugins/plugin-scheduling/src/shared-reminders.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.test.ts
@@ -238,7 +238,15 @@ describe("Shared reminders edge plugin", () => {
     const { options, scheduleWithResult } = harness();
     scheduleWithResult.mockImplementationOnce(
       async (input: ScheduledTaskInput) => ({
-        task: scheduledTask(input),
+        task: scheduledTask({
+          ...input,
+          promptInstructions: "Persisted Stretch",
+          output: {
+            destination: "channel",
+            target: "current_dm",
+            fallback: { body: "Persisted Stretch" },
+          },
+        }),
         commit: {
           logId: "scheduled-log-1",
           taskId: "reminder-1",
@@ -258,7 +266,7 @@ describe("Shared reminders edge plugin", () => {
       {
         parameters: {
           operation: "create",
-          reminderText: "Stretch",
+          reminderText: "Call mom",
           inMinutes: 2,
         },
       },
@@ -266,7 +274,7 @@ describe("Shared reminders edge plugin", () => {
 
     expect(result).toMatchObject({
       success: true,
-      text: "That reminder is already set on Aug 14, 2026 at 8:02 PM UTC: Stretch",
+      text: "That reminder is already set on Aug 14, 2026 at 8:02 PM UTC: Persisted Stretch",
       verifiedUserFacing: true,
       turnComplete: true,
       effectReceipts: [
@@ -285,7 +293,7 @@ describe("Shared reminders edge plugin", () => {
 
   it("lists one-off, interval, and cron reminders without storage internals", async () => {
     const { options, list } = harness();
-    list.mockResolvedValueOnce([
+    const stored = [
       scheduledTask(
         reminderInput("Stretch", {
           kind: "once",
@@ -308,7 +316,23 @@ describe("Shared reminders edge plugin", () => {
         ),
         taskId: "reminder-3",
       },
-    ]);
+      {
+        ...scheduledTask(
+          reminderInput("Already dismissed", {
+            kind: "once",
+            atIso: "2026-08-15T20:00:00.000Z",
+          }),
+        ),
+        taskId: "reminder-4",
+        state: { status: "dismissed" as const, followupCount: 0 },
+      },
+    ];
+    list.mockImplementationOnce(async (filter) => {
+      const statuses = Array.isArray(filter?.status)
+        ? filter.status
+        : [filter?.status];
+      return stored.filter((task) => statuses.includes(task.state.status));
+    });
     const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
     const result = await action?.handler(
       {} as IAgentRuntime,
@@ -324,8 +348,23 @@ describe("Shared reminders edge plugin", () => {
         "• Weekly planning — on its recurring schedule in America/Los_Angeles",
     );
     expect(result?.text).not.toMatch(
-      /reminder-[123]|scheduled|2026-08-14T|0 9 \* \* 1/,
+      /reminder-[1234]|scheduled|dismissed|2026-08-14T|0 9 \* \* 1/,
     );
+    expect(result?.text).not.toContain("Already dismissed");
+    expect(list).toHaveBeenCalledWith({
+      kind: "reminder",
+      ownerVisibleOnly: true,
+      status: ["scheduled", "fired", "acknowledged"],
+    });
+    expect(result).toMatchObject({
+      verifiedUserFacing: true,
+      userFacingText:
+        "Your reminders:\n" +
+        "• Stretch — on Aug 14, 2026 at 8:02 PM UTC\n" +
+        "• Drink water — every 1 minute\n" +
+        "• Weekly planning — on its recurring schedule in America/Los_Angeles",
+      turnComplete: true,
+    });
     expect(result?.data).toMatchObject({
       tasks: [
         { taskId: "reminder-1" },
@@ -364,6 +403,11 @@ describe("Shared reminders edge plugin", () => {
     expect(snoozed?.text).toBe("Reminder snoozed for 1 minute: Stretch");
     expect(snoozed?.data).toMatchObject({ task: { taskId: "reminder-1" } });
     expect(snoozed?.text).not.toContain("reminder-1");
+    expect(snoozed).toMatchObject({
+      verifiedUserFacing: true,
+      userFacingText: "Reminder snoozed for 1 minute: Stretch",
+      turnComplete: true,
+    });
 
     const completed = await action?.handler(
       {} as IAgentRuntime,
@@ -374,5 +418,87 @@ describe("Shared reminders edge plugin", () => {
     expect(completed?.text).toBe("Reminder completed: Stretch");
     expect(completed?.data).toMatchObject({ task: { taskId: "reminder-1" } });
     expect(completed?.text).not.toContain("reminder-1");
+    expect(completed).toMatchObject({
+      verifiedUserFacing: true,
+      userFacingText: "Reminder completed: Stretch",
+      turnComplete: true,
+    });
+
+    const dismissed = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "message-dismiss" } as Memory,
+      undefined,
+      { parameters: { operation: "dismiss", taskId: "reminder-1" } },
+    );
+    expect(dismissed).toMatchObject({
+      text: "Reminder dismissed: Stretch",
+      verifiedUserFacing: true,
+      userFacingText: "Reminder dismissed: Stretch",
+      turnComplete: true,
+    });
+  });
+
+  it("states exact millisecond delays and rejects sub-millisecond model durations", async () => {
+    const { options, scheduleWithResult, apply } = harness();
+    apply.mockResolvedValueOnce(
+      scheduledTask(
+        reminderInput("Stretch", {
+          kind: "once",
+          atIso: "2026-08-14T20:00:00.006Z",
+        }),
+      ),
+    );
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+
+    const created = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "message-six-ms" } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "create",
+          reminderText: "Stretch",
+          inMinutes: 0.0001,
+        },
+      },
+    );
+    expect(created?.text).toBe(
+      "Got it — I'll remind you in 6 milliseconds: Stretch",
+    );
+    expect(scheduleWithResult.mock.calls[0]?.[0]).toMatchObject({
+      trigger: { kind: "once", atIso: "2026-08-14T20:00:00.006Z" },
+    });
+
+    const snoozed = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "message-snooze-six-ms" } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "snooze",
+          taskId: "reminder-1",
+          snoozeMinutes: 0.0001,
+        },
+      },
+    );
+    expect(snoozed?.text).toBe("Reminder snoozed for 6 milliseconds: Stretch");
+
+    const rejected = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "message-sub-ms" } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "create",
+          reminderText: "Stretch",
+          inMinutes: 0.000001,
+        },
+      },
+    );
+    expect(rejected).toMatchObject({
+      success: false,
+      text: "Reminder delay must resolve to a positive whole millisecond.",
+    });
+    expect(scheduleWithResult).toHaveBeenCalledTimes(1);
   });
 });

--- a/plugins/plugin-scheduling/src/shared-reminders.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.test.ts
@@ -345,7 +345,7 @@ describe("Shared reminders edge plugin", () => {
       "Your reminders:\n" +
         "• Stretch — on Aug 14, 2026 at 8:02 PM UTC\n" +
         "• Drink water — every 1 minute\n" +
-        "• Weekly planning — on its recurring schedule in America/Los_Angeles",
+        "• Weekly planning — every Monday at 9:00 AM in America/Los_Angeles",
     );
     expect(result?.text).not.toMatch(
       /reminder-[1234]|scheduled|dismissed|2026-08-14T|0 9 \* \* 1/,
@@ -362,7 +362,7 @@ describe("Shared reminders edge plugin", () => {
         "Your reminders:\n" +
         "• Stretch — on Aug 14, 2026 at 8:02 PM UTC\n" +
         "• Drink water — every 1 minute\n" +
-        "• Weekly planning — on its recurring schedule in America/Los_Angeles",
+        "• Weekly planning — every Monday at 9:00 AM in America/Los_Angeles",
       turnComplete: true,
     });
     expect(result?.data).toMatchObject({
@@ -403,11 +403,6 @@ describe("Shared reminders edge plugin", () => {
     expect(snoozed?.text).toBe("Reminder snoozed for 1 minute: Stretch");
     expect(snoozed?.data).toMatchObject({ task: { taskId: "reminder-1" } });
     expect(snoozed?.text).not.toContain("reminder-1");
-    expect(snoozed).toMatchObject({
-      verifiedUserFacing: true,
-      userFacingText: "Reminder snoozed for 1 minute: Stretch",
-      turnComplete: true,
-    });
 
     const completed = await action?.handler(
       {} as IAgentRuntime,
@@ -418,11 +413,6 @@ describe("Shared reminders edge plugin", () => {
     expect(completed?.text).toBe("Reminder completed: Stretch");
     expect(completed?.data).toMatchObject({ task: { taskId: "reminder-1" } });
     expect(completed?.text).not.toContain("reminder-1");
-    expect(completed).toMatchObject({
-      verifiedUserFacing: true,
-      userFacingText: "Reminder completed: Stretch",
-      turnComplete: true,
-    });
 
     const dismissed = await action?.handler(
       {} as IAgentRuntime,
@@ -430,12 +420,7 @@ describe("Shared reminders edge plugin", () => {
       undefined,
       { parameters: { operation: "dismiss", taskId: "reminder-1" } },
     );
-    expect(dismissed).toMatchObject({
-      text: "Reminder dismissed: Stretch",
-      verifiedUserFacing: true,
-      userFacingText: "Reminder dismissed: Stretch",
-      turnComplete: true,
-    });
+    expect(dismissed?.text).toBe("Reminder dismissed: Stretch");
   });
 
   it("states exact millisecond delays and rejects sub-millisecond model durations", async () => {

--- a/plugins/plugin-scheduling/src/shared-reminders.test.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.test.ts
@@ -291,6 +291,62 @@ describe("Shared reminders edge plugin", () => {
     expect(result?.text).not.toMatch(/reminder-1|scheduled|2026-08-14T/);
   });
 
+  it("uses a persisted snooze override for replay copy", async () => {
+    const { options, scheduleWithResult } = harness();
+    scheduleWithResult.mockImplementationOnce(
+      async (input: ScheduledTaskInput) => ({
+        task: {
+          ...scheduledTask({
+            ...input,
+            promptInstructions: "Persisted Stretch",
+            trigger: {
+              kind: "cron",
+              expression: "0 9 * * 1",
+              tz: "America/Los_Angeles",
+            },
+            output: {
+              destination: "channel",
+              target: "current_dm",
+              fallback: { body: "Persisted Stretch" },
+            },
+          }),
+          state: {
+            status: "scheduled" as const,
+            followupCount: 0,
+            firedAt: "2026-08-14T20:32:59.999Z",
+          },
+        },
+        commit: {
+          logId: "scheduled-log-1",
+          taskId: "reminder-1",
+          agentId: "personal:user-1",
+          occurredAtIso: NOW,
+          transition: "scheduled" as const,
+          rolledUp: false,
+        },
+        replayed: true,
+      }),
+    );
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "message-replayed-snooze" } as Memory,
+      undefined,
+      {
+        parameters: {
+          operation: "create",
+          reminderText: "Conflicting retry",
+          inMinutes: 2,
+        },
+      },
+    );
+
+    expect(result?.text).toBe(
+      "That reminder is already set on Aug 14, 2026 at 8:32:59.999 PM UTC: Persisted Stretch",
+    );
+    expect(result?.text).not.toMatch(/every Monday|9:00 AM|2026-08-14T/);
+  });
+
   it("lists one-off, interval, and cron reminders without storage internals", async () => {
     const { options, list } = harness();
     const stored = [
@@ -372,6 +428,56 @@ describe("Shared reminders edge plugin", () => {
         { taskId: "reminder-3" },
       ],
     });
+  });
+
+  it("lists effective snooze times for one-off and recurring reminders", async () => {
+    const { options, list } = harness();
+    list.mockResolvedValueOnce([
+      {
+        ...scheduledTask(
+          reminderInput("Stretch", {
+            kind: "once",
+            atIso: "2026-08-14T20:02:00.000Z",
+          }),
+        ),
+        state: {
+          status: "scheduled" as const,
+          followupCount: 0,
+          firedAt: "2026-08-14T20:32:00.000Z",
+        },
+      },
+      {
+        ...scheduledTask(
+          reminderInput("Weekly planning", {
+            kind: "cron",
+            expression: "0 9 * * 1",
+            tz: "America/Los_Angeles",
+          }),
+        ),
+        taskId: "reminder-2",
+        state: {
+          status: "scheduled" as const,
+          followupCount: 0,
+          firedAt: "2026-08-14T20:45:59.999Z",
+        },
+      },
+    ]);
+    const [action] = createSharedRemindersEdgePlugin(options).actions ?? [];
+    const result = await action?.handler(
+      {} as IAgentRuntime,
+      { id: "message-list-snoozed" } as Memory,
+      undefined,
+      { parameters: { operation: "list" } },
+    );
+
+    expect(result?.text).toBe(
+      "Your reminders:\n" +
+        "• Stretch — on Aug 14, 2026 at 8:32 PM UTC\n" +
+        "• Weekly planning — on Aug 14, 2026 at 8:45:59.999 PM UTC",
+    );
+    expect(result?.text).not.toMatch(
+      /8:02 PM|every Monday|9:00 AM|2026-08-14T/,
+    );
   });
 
   it("keeps lifecycle acknowledgements user-facing while structured data retains the task id", async () => {

--- a/plugins/plugin-scheduling/src/shared-reminders.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.ts
@@ -181,16 +181,82 @@ function reminderTrigger(
   return undefined;
 }
 
+const UTC_MONTHS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+] as const;
+
+function reminderText(task: ScheduledTask): string {
+  return task.output?.fallback?.body ?? task.promptInstructions;
+}
+
+function formatUtcInstant(atIso: string): string {
+  const instant = new Date(atIso);
+  if (!Number.isFinite(instant.getTime())) {
+    throw new Error("Shared reminder has an invalid one-off schedule");
+  }
+  const hour = instant.getUTCHours();
+  const hour12 = hour % 12 || 12;
+  const minute = String(instant.getUTCMinutes()).padStart(2, "0");
+  const meridiem = hour < 12 ? "AM" : "PM";
+  return `on ${UTC_MONTHS[instant.getUTCMonth()]} ${instant.getUTCDate()}, ${instant.getUTCFullYear()} at ${hour12}:${minute} ${meridiem} UTC`;
+}
+
+function formatDuration(milliseconds: number): string {
+  const totalSeconds = Math.max(1, Math.round(milliseconds / 1_000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  const parts: string[] = [];
+  if (minutes > 0)
+    parts.push(`${minutes} ${minutes === 1 ? "minute" : "minutes"}`);
+  if (seconds > 0)
+    parts.push(`${seconds} ${seconds === 1 ? "second" : "seconds"}`);
+  return parts.join(" and ");
+}
+
+function scheduleDescription(trigger: ScheduledTaskTrigger): string {
+  if (trigger.kind === "once") return formatUtcInstant(trigger.atIso);
+  if (trigger.kind === "interval") {
+    return `every ${trigger.everyMinutes} ${trigger.everyMinutes === 1 ? "minute" : "minutes"}`;
+  }
+  if (trigger.kind === "cron") {
+    return `on its recurring schedule in ${trigger.tz}`;
+  }
+  if (trigger.kind === "event") return "when its scheduled event occurs";
+  if (trigger.kind === "after_task") return "after its linked task";
+  if (trigger.kind === "manual") return "when you ask it to run";
+  if (trigger.kind === "relative_to_anchor") {
+    return "relative to its scheduled anchor";
+  }
+  return "during its scheduled window";
+}
+
+function requestedScheduleDescription(
+  input: Record<string, unknown>,
+  trigger: ScheduledTaskTrigger,
+  explicitDelayMilliseconds?: number,
+): string {
+  if (explicitDelayMilliseconds !== undefined) {
+    return `in ${formatDuration(explicitDelayMilliseconds)}`;
+  }
+  const inMinutes = positiveNumber(input, "inMinutes", "minutesFromNow");
+  return inMinutes === undefined
+    ? scheduleDescription(trigger)
+    : `in ${formatDuration(inMinutes * 60_000)}`;
+}
+
 function taskSummary(task: ScheduledTask): string {
-  const when =
-    task.trigger.kind === "once"
-      ? task.trigger.atIso
-      : task.trigger.kind === "interval"
-        ? `every ${task.trigger.everyMinutes} minutes`
-        : task.trigger.kind === "cron"
-          ? `${task.trigger.expression} (${task.trigger.tz})`
-          : task.trigger.kind;
-  return `${task.taskId}: ${task.output?.fallback?.body ?? task.promptInstructions} — ${when} [${task.state.status}]`;
+  return `${reminderText(task)} — ${scheduleDescription(task.trigger)}`;
 }
 
 function creationReceipt(args: {
@@ -339,7 +405,7 @@ export function createSharedRemindersEdgeAction(
         const text =
           tasks.length === 0
             ? "You have no reminders."
-            : tasks.map(taskSummary).join("\n");
+            : `Your reminders:\n${tasks.map((task) => `• ${taskSummary(task)}`).join("\n")}`;
         await callback?.({ text });
         return {
           success: true,
@@ -399,9 +465,18 @@ export function createSharedRemindersEdgeAction(
           metadata: { delivery },
           executionProfile: "notify-only",
         });
+        const schedule = scheduled.replayed
+          ? scheduleDescription(scheduled.task.trigger)
+          : requestedScheduleDescription(
+              input,
+              scheduled.task.trigger,
+              explicitDelay.kind === "resolved"
+                ? explicitDelay.milliseconds
+                : undefined,
+            );
         const text = scheduled.replayed
-          ? `Reminder already set for ${taskSummary(scheduled.task)}`
-          : `Reminder set for ${taskSummary(scheduled.task)}`;
+          ? `That reminder is already set ${schedule}: ${body}`
+          : `Got it — I'll remind you ${schedule}: ${body}`;
         const receipt = creationReceipt(scheduled);
         await callback?.({ text });
         return {
@@ -431,7 +506,7 @@ export function createSharedRemindersEdgeAction(
           );
         }
         const task = await options.runner.apply(taskId, "snooze", { minutes });
-        const text = `Reminder ${task.taskId} snoozed for ${minutes} minutes.`;
+        const text = `Reminder snoozed for ${formatDuration(minutes * 60_000)}: ${reminderText(task)}`;
         await callback?.({ text });
         return {
           success: true,
@@ -448,7 +523,7 @@ export function createSharedRemindersEdgeAction(
             callback,
           );
         const task = await options.runner.apply(taskId, operation);
-        const text = `Reminder ${task.taskId} ${operation === "complete" ? "completed" : "dismissed"}.`;
+        const text = `Reminder ${operation === "complete" ? "completed" : "dismissed"}: ${reminderText(task)}`;
         await callback?.({ text });
         return {
           success: true,

--- a/plugins/plugin-scheduling/src/shared-reminders.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.ts
@@ -198,6 +198,16 @@ const UTC_MONTHS = [
   "Dec",
 ] as const;
 
+const CRON_WEEKDAYS = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+] as const;
+
 function reminderText(task: ScheduledTask): string {
   return task.output?.fallback?.body ?? task.promptInstructions;
 }
@@ -248,21 +258,57 @@ function minuteDurationMilliseconds(minutes: number): number | undefined {
     : undefined;
 }
 
+function formatClockTime(hour: number, minute: number): string {
+  const hour12 = hour % 12 || 12;
+  const meridiem = hour < 12 ? "AM" : "PM";
+  return `${hour12}:${String(minute).padStart(2, "0")} ${meridiem}`;
+}
+
+function cronScheduleDescription(expression: string, timezone: string): string {
+  const fields = expression.trim().split(/\s+/);
+  if (fields.length === 5) {
+    const [minuteField, hourField, dayOfMonth, month, dayOfWeek] = fields;
+    const minute = Number(minuteField);
+    const hour = Number(hourField);
+    const simpleTime =
+      /^\d{1,2}$/.test(minuteField ?? "") &&
+      /^\d{1,2}$/.test(hourField ?? "") &&
+      minute >= 0 &&
+      minute <= 59 &&
+      hour >= 0 &&
+      hour <= 23;
+    if (simpleTime && dayOfMonth === "*" && month === "*") {
+      if (dayOfWeek === "*") {
+        return `every day at ${formatClockTime(hour, minute)} in ${timezone}`;
+      }
+      if (/^[0-7]$/.test(dayOfWeek ?? "")) {
+        const weekday = CRON_WEEKDAYS[Number(dayOfWeek) % 7];
+        return `every ${weekday} at ${formatClockTime(hour, minute)} in ${timezone}`;
+      }
+    }
+  }
+  return `on its recurring schedule in ${timezone}`;
+}
+
 function scheduleDescription(trigger: ScheduledTaskTrigger): string {
-  if (trigger.kind === "once") return formatUtcInstant(trigger.atIso);
-  if (trigger.kind === "interval") {
-    return `every ${trigger.everyMinutes} ${trigger.everyMinutes === 1 ? "minute" : "minutes"}`;
+  switch (trigger.kind) {
+    case "once":
+      return formatUtcInstant(trigger.atIso);
+    case "interval":
+      return `every ${trigger.everyMinutes} ${trigger.everyMinutes === 1 ? "minute" : "minutes"}`;
+    case "cron":
+      return cronScheduleDescription(trigger.expression, trigger.tz);
+    case "event":
+      return "when its scheduled event occurs";
+    case "after_task":
+      return "after its linked task";
+    case "manual":
+      return "when you ask it to run";
+    case "relative_to_anchor":
+      return "relative to its scheduled anchor";
+    case "during_window":
+      return "during its scheduled window";
   }
-  if (trigger.kind === "cron") {
-    return `on its recurring schedule in ${trigger.tz}`;
-  }
-  if (trigger.kind === "event") return "when its scheduled event occurs";
-  if (trigger.kind === "after_task") return "after its linked task";
-  if (trigger.kind === "manual") return "when you ask it to run";
-  if (trigger.kind === "relative_to_anchor") {
-    return "relative to its scheduled anchor";
-  }
-  return "during its scheduled window";
 }
 
 function requestedScheduleDescription(
@@ -565,9 +611,6 @@ export function createSharedRemindersEdgeAction(
           success: true,
           text,
           data: { actionName: "REMINDERS", operation, task },
-          verifiedUserFacing: true,
-          userFacingText: text,
-          turnComplete: true,
         };
       }
 
@@ -585,9 +628,6 @@ export function createSharedRemindersEdgeAction(
           success: true,
           text,
           data: { actionName: "REMINDERS", operation, task },
-          verifiedUserFacing: true,
-          userFacingText: text,
-          turnComplete: true,
         };
       }
 

--- a/plugins/plugin-scheduling/src/shared-reminders.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.ts
@@ -158,7 +158,9 @@ function reminderTrigger(
   }
   const inMinutes = positiveNumber(input, "inMinutes", "minutesFromNow");
   if (inMinutes !== undefined) {
-    const at = now.getTime() + inMinutes * 60_000;
+    const milliseconds = minuteDurationMilliseconds(inMinutes);
+    if (milliseconds === undefined) return undefined;
+    const at = now.getTime() + milliseconds;
     if (!Number.isFinite(at) || Math.abs(at) > MAX_DATE_TIMESTAMP_MS) {
       return undefined;
     }
@@ -213,15 +215,37 @@ function formatUtcInstant(atIso: string): string {
 }
 
 function formatDuration(milliseconds: number): string {
-  const totalSeconds = Math.max(1, Math.round(milliseconds / 1_000));
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
+  if (!Number.isSafeInteger(milliseconds) || milliseconds <= 0) {
+    throw new Error(
+      "Shared reminder duration must be a positive whole millisecond",
+    );
+  }
+  const minutes = Math.floor(milliseconds / 60_000);
+  const remainder = milliseconds % 60_000;
   const parts: string[] = [];
   if (minutes > 0)
     parts.push(`${minutes} ${minutes === 1 ? "minute" : "minutes"}`);
-  if (seconds > 0)
-    parts.push(`${seconds} ${seconds === 1 ? "second" : "seconds"}`);
+  if (remainder >= 1_000) {
+    const seconds = Math.floor(remainder / 1_000);
+    const fraction = remainder % 1_000;
+    const amount =
+      fraction === 0
+        ? String(seconds)
+        : `${seconds}.${String(fraction).padStart(3, "0").replace(/0+$/, "")}`;
+    parts.push(`${amount} ${amount === "1" ? "second" : "seconds"}`);
+  } else if (remainder > 0) {
+    parts.push(
+      `${remainder} ${remainder === 1 ? "millisecond" : "milliseconds"}`,
+    );
+  }
   return parts.join(" and ");
+}
+
+function minuteDurationMilliseconds(minutes: number): number | undefined {
+  const milliseconds = minutes * 60_000;
+  return Number.isSafeInteger(milliseconds) && milliseconds > 0
+    ? milliseconds
+    : undefined;
 }
 
 function scheduleDescription(trigger: ScheduledTaskTrigger): string {
@@ -250,9 +274,11 @@ function requestedScheduleDescription(
     return `in ${formatDuration(explicitDelayMilliseconds)}`;
   }
   const inMinutes = positiveNumber(input, "inMinutes", "minutesFromNow");
-  return inMinutes === undefined
+  const inMilliseconds =
+    inMinutes === undefined ? undefined : minuteDurationMilliseconds(inMinutes);
+  return inMilliseconds === undefined
     ? scheduleDescription(trigger)
-    : `in ${formatDuration(inMinutes * 60_000)}`;
+    : `in ${formatDuration(inMilliseconds)}`;
 }
 
 function taskSummary(task: ScheduledTask): string {
@@ -401,6 +427,7 @@ export function createSharedRemindersEdgeAction(
         const tasks = await options.runner.list({
           kind: "reminder",
           ownerVisibleOnly: true,
+          status: ["scheduled", "fired", "acknowledged"],
         });
         const text =
           tasks.length === 0
@@ -411,6 +438,9 @@ export function createSharedRemindersEdgeAction(
           success: true,
           text,
           data: { actionName: "REMINDERS", operation, tasks },
+          verifiedUserFacing: true,
+          userFacingText: text,
+          turnComplete: true,
         };
       }
 
@@ -429,6 +459,21 @@ export function createSharedRemindersEdgeAction(
         );
         if (explicitDelay.kind === "invalid") {
           return await actionFailure(explicitDelay.reason, callback);
+        }
+        const inputMinutes = positiveNumber(
+          input,
+          "inMinutes",
+          "minutesFromNow",
+        );
+        if (
+          explicitDelay.kind === "absent" &&
+          inputMinutes !== undefined &&
+          minuteDurationMilliseconds(inputMinutes) === undefined
+        ) {
+          return await actionFailure(
+            "Reminder delay must resolve to a positive whole millisecond.",
+            callback,
+          );
         }
         const trigger = reminderTrigger(
           input,
@@ -474,9 +519,10 @@ export function createSharedRemindersEdgeAction(
                 ? explicitDelay.milliseconds
                 : undefined,
             );
+        const persistedBody = reminderText(scheduled.task);
         const text = scheduled.replayed
-          ? `That reminder is already set ${schedule}: ${body}`
-          : `Got it — I'll remind you ${schedule}: ${body}`;
+          ? `That reminder is already set ${schedule}: ${persistedBody}`
+          : `Got it — I'll remind you ${schedule}: ${persistedBody}`;
         const receipt = creationReceipt(scheduled);
         await callback?.({ text });
         return {
@@ -505,13 +551,23 @@ export function createSharedRemindersEdgeAction(
             callback,
           );
         }
+        const snoozeMilliseconds = minuteDurationMilliseconds(minutes);
+        if (snoozeMilliseconds === undefined) {
+          return await actionFailure(
+            "Snooze duration must resolve to a positive whole millisecond.",
+            callback,
+          );
+        }
         const task = await options.runner.apply(taskId, "snooze", { minutes });
-        const text = `Reminder snoozed for ${formatDuration(minutes * 60_000)}: ${reminderText(task)}`;
+        const text = `Reminder snoozed for ${formatDuration(snoozeMilliseconds)}: ${reminderText(task)}`;
         await callback?.({ text });
         return {
           success: true,
           text,
           data: { actionName: "REMINDERS", operation, task },
+          verifiedUserFacing: true,
+          userFacingText: text,
+          turnComplete: true,
         };
       }
 
@@ -529,6 +585,9 @@ export function createSharedRemindersEdgeAction(
           success: true,
           text,
           data: { actionName: "REMINDERS", operation, task },
+          verifiedUserFacing: true,
+          userFacingText: text,
+          turnComplete: true,
         };
       }
 

--- a/plugins/plugin-scheduling/src/shared-reminders.ts
+++ b/plugins/plugin-scheduling/src/shared-reminders.ts
@@ -220,8 +220,16 @@ function formatUtcInstant(atIso: string): string {
   const hour = instant.getUTCHours();
   const hour12 = hour % 12 || 12;
   const minute = String(instant.getUTCMinutes()).padStart(2, "0");
+  const seconds = instant.getUTCSeconds();
+  const milliseconds = instant.getUTCMilliseconds();
+  const preciseTime =
+    seconds === 0 && milliseconds === 0
+      ? `${hour12}:${minute}`
+      : `${hour12}:${minute}:${String(seconds).padStart(2, "0")}${
+          milliseconds === 0 ? "" : `.${String(milliseconds).padStart(3, "0")}`
+        }`;
   const meridiem = hour < 12 ? "AM" : "PM";
-  return `on ${UTC_MONTHS[instant.getUTCMonth()]} ${instant.getUTCDate()}, ${instant.getUTCFullYear()} at ${hour12}:${minute} ${meridiem} UTC`;
+  return `on ${UTC_MONTHS[instant.getUTCMonth()]} ${instant.getUTCDate()}, ${instant.getUTCFullYear()} at ${preciseTime} ${meridiem} UTC`;
 }
 
 function formatDuration(milliseconds: number): string {
@@ -328,7 +336,14 @@ function requestedScheduleDescription(
 }
 
 function taskSummary(task: ScheduledTask): string {
-  return `${reminderText(task)} — ${scheduleDescription(task.trigger)}`;
+  return `${reminderText(task)} — ${taskScheduleDescription(task)}`;
+}
+
+function taskScheduleDescription(task: ScheduledTask): string {
+  if (task.state.status === "scheduled" && task.state.firedAt) {
+    return formatUtcInstant(task.state.firedAt);
+  }
+  return scheduleDescription(task.trigger);
 }
 
 function creationReceipt(args: {
@@ -557,7 +572,7 @@ export function createSharedRemindersEdgeAction(
           executionProfile: "notify-only",
         });
         const schedule = scheduled.replayed
-          ? scheduleDescription(scheduled.task.trigger)
+          ? taskScheduleDescription(scheduled.task)
           : requestedScheduleDescription(
               input,
               scheduled.task.trigger,


### PR DESCRIPTION
Part of #20870.

## Change

- Keeps reminder create/list/lifecycle acknowledgements in clear user-facing prose.
- Binds create completion to the runner's durable receipt and preserves the exact persisted replay body.
- Filters list output to active reminder states and renders common daily/weekday cron schedules in human-readable form.
- Uses the canonical scheduled override (`state.firedAt`) for snoozed/deferred/retried reminder list and replay copy instead of restating the original trigger.
- Preserves non-zero seconds and milliseconds in absolute one-off acknowledgements.
- Keeps read/list canonical settlement authoritative over later evaluator paraphrase.
- Does **not** claim durable mutation receipts for snooze/complete/dismiss: the current runner `apply` contract returns no commit receipt. A future `applyWithResult`-style contract is required before those branches can claim receipt-backed effect authority.

## Exact revision and provenance

- PR head: `dbfdd6c24734847b1e2e3eace388d19751c7b5f0`
- Tree: `803d5565e111b8949c3c498b7fe4c4d6ec6e6aff`
- Exact base/current `origin/develop`: `78bd11ff6c23234edf5c6ed712ef694661a1645a`
- Original author stack at remote head `4f739e337ee42d88b3effa42bda2e2fff6d52cec` was range-diff-equivalent to the reviewed author stack, then rebased unchanged onto the exact base.
- Bounded independent repair commit: `dbfdd6c24734847b1e2e3eace388d19751c7b5f0` (`fix(scheduling): report effective reminder times`).
- Latest develop had zero overlapping changes in the three original PR paths; the rebase was conflict-free.

## Validation

All commands ran on exact head `dbfdd6c24734847b1e2e3eace388d19751c7b5f0`.

- Focused scheduling + genuine Cloud Shared runtime: 19/19 tests; Cloud runtime 50 assertions.
- Full plugin-scheduling suite: 29 files, 475/475 tests.
- plugin-scheduling typecheck: PASS.
- plugin-scheduling full build: PASS.
- Cloud Shared typecheck: PASS.
- Exact three-path Biome: PASS.
- `git diff --check`: PASS.
- Worktree clean after commit.
- No deploy, workflow rerun, provider send, scheduled mutation, environment approval, or secret change.

The PR remains draft. Source review is repaired, but undraft/merge still requires independent exact-head review plus an exact-served Shared reminder trajectory, live durable create receipt, and connector transport proof under the existing Shared lease.

<!-- evidence-head:dbfdd6c24734847b1e2e3eace388d19751c7b5f0 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - agent transport copy and receipt semantics, no UI component changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - exact-served connector proof remains pending`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - exact-served connector proof remains pending`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no deployment or real reminder send was authorized`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend path changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - exact-served Shared trajectory remains pending before undraft`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - live durable receipt and transport proof remains pending before undraft`.

<!-- evidence-row:ocr-review -->
- [ ] OCR review `N/A - no rendered UI surface changed`.
