### PR TITLE
fix(app-core): dead @elizaos/core/edge vitest alias shadowed by the core catch-all

### DIFF
--- a/packages/app-core/vitest.config.ts
+++ b/packages/app-core/vitest.config.ts
@@ -264,6 +264,13 @@ export default defineConfig({
         find: /^@elizaos\/core\/atomic-json$/,
         replacement: path.join(coreSrc, "utils/atomic-json.ts"),
       },
+      {
+        // Must precede the @elizaos/core/(.+) catch-all: aliases match in
+        // array order, and the catch-all would rewrite core/edge to the
+        // nonexistent src/edge (plugin-scheduling imports @elizaos/core/edge).
+        find: /^@elizaos\/core\/edge$/,
+        replacement: path.join(coreSrc, "index.edge.ts"),
+      },
       { find: /^@elizaos\/core\/(.+)$/, replacement: path.join(coreSrc, "$1") },
       {
         find: /^@elizaos\/vault$/,
@@ -363,13 +370,6 @@ export default defineConfig({
       {
         find: /^@elizaos\/plugin-task-coordinator\/(.+)$/,
         replacement: `${toVitePath(appTaskCoordinatorSrc)}/$1`,
-      },
-      {
-        // plugin-scheduling (source-aliased below) imports @elizaos/core/edge;
-        // vite's test-mode resolver misses linked-package subpath exports, so
-        // pin it to the edge source entry (mirrors plugin-calendar, #19815).
-        find: /^@elizaos\/core\/edge$/,
-        replacement: path.join(monorepoRoot, "packages/core/src/index.edge.ts"),
       },
       {
         find: /^@elizaos\/plugin-scheduling$/,


### PR DESCRIPTION
## Summary

`bun run --cwd packages/app-core test` fails on develop tip: every suite that transitively imports `plugin-scheduling`'s runner dies at collection with

```
Error: Cannot find package '@elizaos/core/edge' imported from .../plugin-scheduling/src/scheduled-task/runner.ts
```

**Cause:** vitest array aliases match in order. `vitest.config.ts` has a general `/^@elizaos\/core\/(.+)$/` catch-all that rewrites `@elizaos/core/edge` to the nonexistent `packages/core/src/edge`. The dedicated edge alias (added by #19815, pointing at `src/index.edge.ts`) sits ~100 lines AFTER the catch-all and is dead code — it can never match.

**Fix:** move the edge alias immediately before the catch-all (with a comment on the ordering constraint) and remove the dead later entry.

## Verification (exact head)

```
npx vitest run src/api/conversation-restore-relaunch.test.ts: 5 passed (was: failed to collect)
```

Triage note for the remaining red in a full local lane run: `static-asset-contract` failures are local overlay leftovers (files present in the working tree but not in HEAD — pristine checkouts are green), and `dev-ui-vite` / `run-node-supervisor` / `docker-entrypoint` failures require a Node 24+ host (this box runs 22.x; the dev-ui-vite error message states the requirement explicitly). Only the alias bug is a genuine develop regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)