### PR TITLE
fix(agent): reject non-canonical database rows sort order

### DIFF
--- a/packages/agent/src/api/database.pagination.test.ts
+++ b/packages/agent/src/api/database.pagination.test.ts
@@ -4,7 +4,7 @@
  * the `LIMIT ... OFFSET ...` clause. Deterministic, no server or DB.
  */
 import { describe, expect, it } from "vitest";
-import { parseRowsPagination } from "./database.ts";
+import { parseRowsPagination, parseRowsSortOrder } from "./database.ts";
 
 /**
  * GET /api/database/tables/:table/rows interpolates `offset`/`limit` straight
@@ -62,6 +62,34 @@ describe("parseRowsPagination", () => {
       expect(offset).toBeGreaterThanOrEqual(0);
       expect(limit).toBeGreaterThanOrEqual(1);
       expect(limit).toBeLessThanOrEqual(500);
+    }
+  });
+});
+
+describe("parseRowsSortOrder", () => {
+  it("defaults omitted and empty tokens to ASC", () => {
+    expect(parseRowsSortOrder(null)).toEqual({ ok: true, order: "ASC" });
+    expect(parseRowsSortOrder("")).toEqual({ ok: true, order: "ASC" });
+  });
+
+  it("accepts the Control UI identities", () => {
+    expect(parseRowsSortOrder("asc")).toEqual({ ok: true, order: "ASC" });
+    expect(parseRowsSortOrder("desc")).toEqual({ ok: true, order: "DESC" });
+  });
+
+  it("rejects SQL-case and garbage instead of silently sorting ASC", () => {
+    for (const raw of [
+      "DESC",
+      "ASC",
+      "descending",
+      "ascending",
+      "desc ",
+      " desc",
+      "1e2",
+      "foo",
+      "0",
+    ]) {
+      expect(parseRowsSortOrder(raw)).toEqual({ ok: false });
     }
   });
 });

--- a/packages/agent/src/api/database.ts
+++ b/packages/agent/src/api/database.ts
@@ -802,6 +802,21 @@ export function parseRowsPagination(
 }
 
 /**
+ * Parse the `order` query for row retrieval. The token is interpolated into
+ * `ORDER BY ... ASC|DESC`, so only the Control UI's exact `asc`/`desc`
+ * identities are legal. `order=DESC` used to become ASC because only the
+ * lowercase `desc` token flipped the direction.
+ */
+export function parseRowsSortOrder(
+  raw: string | null,
+): { ok: true; order: "ASC" | "DESC" } | { ok: false } {
+  if (raw === null || raw === "") return { ok: true, order: "ASC" };
+  if (raw === "asc") return { ok: true, order: "ASC" };
+  if (raw === "desc") return { ok: true, order: "DESC" };
+  return { ok: false };
+}
+
+/**
  * GET /api/database/tables/:table/rows?offset=0&limit=50&sort=col&order=asc&search=term
  * Paginated row retrieval for a specific table.
  */
@@ -819,8 +834,13 @@ async function handleGetRows(
     url.searchParams.get("offset"),
     url.searchParams.get("limit"),
   );
+  const parsedOrder = parseRowsSortOrder(url.searchParams.get("order"));
+  if (!parsedOrder.ok) {
+    sendJsonError(res, "order must be asc or desc", 400);
+    return;
+  }
   const sortCol = url.searchParams.get("sort") ?? "";
-  const sortOrder = url.searchParams.get("order") === "desc" ? "DESC" : "ASC";
+  const sortOrder = parsedOrder.order;
   const search = url.searchParams.get("search") ?? "";
 
   if (!(await assertTableExists(runtime, tableName))) {


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on Control UI database row
`order`. Sort-direction identity, not leftover tax on VFS encoding enum,
models catalogOnly/refresh, Cloud JSON-400, prefix-coerced limit,
percent-encoded paths, SIWS chainId, orchestrator lines, provisioning-worker
env ints, invites-accept, cli-auth, redemption quote, compat agent-logs,
first-run, login persist, billing, or avatar. Disjoint from #20784
database-rows limit/offset (app-core compat). Pagination parser untouched.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `order` only on Control UI table rows. Pagination `limit`/`offset`
parser is unchanged. Canonical omitted / `asc` / `desc` still reach SQL.
Unknown tokens 400 before `assertTableExists` / `executeRawSql`.

# Background

## What does this PR do?

`GET /api/database/tables/:table/rows?order=` treated every token other than
exact `desc` as `ASC`. A client that asked for `DESC` (SQL-case), `ASC`,
`descending`, or junk received an ascending page interpolated into
`ORDER BY ... ASC`. The Control UI sends exact `asc`/`desc`. Those stay 200.

- omitted / empty → **ASC** (today's default)
- exact `asc` / `desc` → **ASC** / **DESC**
- `DESC` / `ASC` / `descending` / `1e2` / `foo` → **400**
  `order must be asc or desc` before table lookup or SQL

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Row sort direction is interpolated into OWNER SQL. `order=DESC` silently
reversing to ASC is the wrong page of potentially sensitive tables. Fail-closed
exact tokens match the Control UI identities.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/database.pagination.test.ts` — `parseRowsSortOrder`
table: omitted/empty/`asc`/`desc` ok; SQL-case and garbage rejected.

## Detailed testing steps

```bash
cd packages/agent && bunx vitest run --config vitest.config.ts \
  src/api/database.pagination.test.ts --coverage.enabled=false
```

9 passed at the evidence head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; database rows `order` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; database rows `order` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; database rows `order` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused parser tests drive the real `order` identity and assert 400 before SQL; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB write; illegal `order` 400s before `executeRawSql`.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal `order`
tokens reject; omitted/`asc`/`desc` still parse.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file database row `order` parse
with a green focused suite (9 tests). Full monorepo verify is unrelated to
this query grammar and was skipped to keep the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:45373fe3a2b06083e23ee1f916493714551a5339 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
