### PR TITLE
fix(agent): reject unknown memory viewer table type

### DIFF
--- a/packages/agent/src/api/memory-feed-cursor.test.ts
+++ b/packages/agent/src/api/memory-feed-cursor.test.ts
@@ -6,10 +6,7 @@
 import type { AgentRuntime, UUID } from "@elizaos/core";
 import { describe, expect, test, vi } from "vitest";
 import type { MemoryRouteContext } from "./memory-routes.ts";
-import {
-  handleMemoryRoutes,
-  parseMemoryTableFilter,
-} from "./memory-routes.ts";
+import { handleMemoryRoutes, parseMemoryTableFilter } from "./memory-routes.ts";
 
 describe("GET /api/memories/feed cursor", () => {
   test("honors a before cursor at the Unix epoch", async () => {

--- a/packages/agent/src/api/memory-feed-cursor.test.ts
+++ b/packages/agent/src/api/memory-feed-cursor.test.ts
@@ -6,7 +6,10 @@
 import type { AgentRuntime, UUID } from "@elizaos/core";
 import { describe, expect, test, vi } from "vitest";
 import type { MemoryRouteContext } from "./memory-routes.ts";
-import { handleMemoryRoutes } from "./memory-routes.ts";
+import {
+  handleMemoryRoutes,
+  parseMemoryTableFilter,
+} from "./memory-routes.ts";
 
 describe("GET /api/memories/feed cursor", () => {
   test("honors a before cursor at the Unix epoch", async () => {
@@ -51,5 +54,65 @@ describe("GET /api/memories/feed cursor", () => {
       limit: 50,
       hasMore: false,
     });
+  });
+
+  test("rejects an unknown type before scanning tables", async () => {
+    const getMemories = vi.fn(async () => []);
+    const runtime = {
+      agentId: "11111111-1111-4111-8111-111111111111" as UUID,
+      character: { name: "Eliza" },
+      ensureConnection: vi.fn(async () => undefined),
+      getMemories,
+    } as unknown as AgentRuntime;
+    const errors: Array<{ message: string; status?: number }> = [];
+    const context: MemoryRouteContext = {
+      req: {} as never,
+      res: {} as never,
+      method: "GET",
+      pathname: "/api/memories/feed",
+      url: new URL("https://agent.test/api/memories/feed?type=notes"),
+      runtime,
+      agentName: "Eliza",
+      json: () => {
+        throw new Error("unexpected 200");
+      },
+      error: (_res, message, status) => {
+        errors.push({ message, status });
+      },
+      readJsonBody: async <T extends object>() => ({}) as T,
+    };
+
+    expect(await handleMemoryRoutes(context)).toBe(true);
+    expect(errors).toEqual([
+      {
+        message: "type must be one of: messages, memories, facts, documents",
+        status: 400,
+      },
+    ]);
+    expect(getMemories).not.toHaveBeenCalled();
+  });
+});
+
+describe("parseMemoryTableFilter", () => {
+  test("omitted and empty keep the unfiltered all-tables scan", () => {
+    expect(parseMemoryTableFilter(null)).toEqual({ ok: true });
+    expect(parseMemoryTableFilter("")).toEqual({ ok: true });
+  });
+
+  test("accepts the viewer table identities", () => {
+    expect(parseMemoryTableFilter("messages")).toEqual({
+      ok: true,
+      tables: ["messages"],
+    });
+    expect(parseMemoryTableFilter("FACTS")).toEqual({
+      ok: true,
+      tables: ["facts"],
+    });
+  });
+
+  test("rejects unknown tokens instead of returning every table", () => {
+    expect(parseMemoryTableFilter("notes").ok).toBe(false);
+    expect(parseMemoryTableFilter("message").ok).toBe(false);
+    expect(parseMemoryTableFilter("all").ok).toBe(false);
   });
 });

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -400,15 +400,26 @@ async function fetchMemoriesFromTables(
   return filtered;
 }
 
-function resolveTableFilter(
+/**
+ * Parse the memory-viewer `type` query. Omitted/empty means every table
+ * (the "all" tab). A known table name narrows the scan. Any other token
+ * used to fall through to that same unfiltered scan, so `type=notes` or
+ * `type=message` silently returned the whole feed.
+ */
+export function parseMemoryTableFilter(
   typeParam: string | null,
-): readonly string[] | undefined {
-  if (!typeParam) return undefined;
+):
+  | { ok: true; tables?: readonly string[] }
+  | { ok: false; message: string } {
+  if (typeParam === null || typeParam === "") return { ok: true };
   const t = typeParam.toLowerCase();
   if (MEMORY_TABLE_NAMES.includes(t as (typeof MEMORY_TABLE_NAMES)[number])) {
-    return [t];
+    return { ok: true, tables: [t] };
   }
-  return undefined;
+  return {
+    ok: false,
+    message: `type must be one of: ${MEMORY_TABLE_NAMES.join(", ")}`,
+  };
 }
 
 export async function handleMemoryRoutes(
@@ -566,7 +577,12 @@ export async function handleMemoryRoutes(
     const limit = Math.min(Math.max(requestedLimit, 1), MEMORY_FEED_MAX_LIMIT);
     const beforeParam = url.searchParams.get("before");
     const before = beforeParam ? Number(beforeParam) : undefined;
-    const tables = resolveTableFilter(url.searchParams.get("type"));
+    const tableFilter = parseMemoryTableFilter(url.searchParams.get("type"));
+    if (!tableFilter.ok) {
+      error(res, tableFilter.message, 400);
+      return true;
+    }
+    const tables = tableFilter.tables;
 
     const allMemories = await fetchMemoriesFromTables(runtime, {
       tables,
@@ -596,7 +612,12 @@ export async function handleMemoryRoutes(
       MEMORY_BROWSE_MAX_LIMIT,
     );
     const offset = parsePositiveInteger(url.searchParams.get("offset"), 0);
-    const tables = resolveTableFilter(url.searchParams.get("type"));
+    const tableFilter = parseMemoryTableFilter(url.searchParams.get("type"));
+    if (!tableFilter.ok) {
+      error(res, tableFilter.message, 400);
+      return true;
+    }
+    const tables = tableFilter.tables;
     const entityIdParam = url.searchParams.get("entityId");
     const entityIdsParam = url.searchParams.get("entityIds");
     const roomIdParam = url.searchParams.get("roomId");
@@ -668,7 +689,12 @@ export async function handleMemoryRoutes(
       MEMORY_BROWSE_MAX_LIMIT,
     );
     const offset = parsePositiveInteger(url.searchParams.get("offset"), 0);
-    const tables = resolveTableFilter(url.searchParams.get("type"));
+    const tableFilter = parseMemoryTableFilter(url.searchParams.get("type"));
+    if (!tableFilter.ok) {
+      error(res, tableFilter.message, 400);
+      return true;
+    }
+    const tables = tableFilter.tables;
 
     const allMemories = await fetchMemoriesFromTables(runtime, {
       entityIds,

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -408,9 +408,7 @@ async function fetchMemoriesFromTables(
  */
 export function parseMemoryTableFilter(
   typeParam: string | null,
-):
-  | { ok: true; tables?: readonly string[] }
-  | { ok: false; message: string } {
+): { ok: true; tables?: readonly string[] } | { ok: false; message: string } {
   if (typeParam === null || typeParam === "") return { ok: true };
   const t = typeParam.toLowerCase();
   if (MEMORY_TABLE_NAMES.includes(t as (typeof MEMORY_TABLE_NAMES)[number])) {


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on memory-viewer `type`.
Table-identity class, not leftover tax on VFS encoding enum, models
catalogOnly/refresh, Cloud JSON-400, prefix-coerced limit, percent-encoded
paths, SIWS chainId, orchestrator lines, provisioning-worker env ints,
invites-accept, cli-auth, redemption quote, compat agent-logs, first-run,
login persist, billing, or avatar. Disjoint from database row `order`.
Feed `limit`/`before` parsers untouched.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `type` only on memory feed / browse / by-entity. The viewer "all" tab
omits `type` and still scans every table. Canonical `messages` / `memories` /
`facts` / `documents` still 200. Unknown tokens 400 before `getMemories`.

# Background

## What does this PR do?

`GET /api/memories/feed?type=` (and browse / by-entity) treated every token
other than the four viewer tables as "no filter". A client that asked for
`notes`, `message`, or `all` received the entire feed. The Memory Viewer sends
a single canonical table name, or omits `type` for the all-tables tab.

- omitted / empty → **200** unfiltered (today's default)
- `messages` / `memories` / `facts` / `documents` (any case) → **200** that table
- `notes` / `message` / `all` / junk → **400**
  `type must be one of: messages, memories, facts, documents` before scan

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The memory viewer `type` query is supposed to narrow the scan. Unknown tokens
must not silently dump every table. Omit remains the all-tables path the UI
already uses.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/memory-feed-cursor.test.ts` — existing epoch cursor
still green; unknown `type=notes` 400s with `getMemories` never called;
parser table for omit / canonical / reject.

## Detailed testing steps

```bash
cd packages/agent && bunx vitest run --config vitest.config.ts \
  src/api/memory-feed-cursor.test.ts --coverage.enabled=false
```

5 passed at the evidence head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; memory-viewer `type` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; memory-viewer `type` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; memory-viewer `type` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused route tests drive the real handler and assert 400 before getMemories; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no memory write; illegal `type` 400s before table scan.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal `type`
tokens 400 before `getMemories`; omitted/canonical tables still 200.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file memory-viewer `type` parse
with a green focused suite (5 tests). Full monorepo verify is unrelated to
this query grammar and was skipped to keep the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:33bbd5b7e41b0713fc80eddbf49b2f7e5ea44b9a -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
