### PR TITLE
fix(core): record account-policy and validate-false rejections so mixed sets stop mislabeling as privacy

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -533,6 +533,112 @@ describe("runV5MessageRuntimeStage1", () => {
 		expect(useModelCalls(runtime)).toHaveLength(2);
 	});
 
+	it("keeps a MIXED disclosure+validate-false rejection set on the planner path (#20869)", async () => {
+		// The #20679 fix routed mixed sets correctly for the four actionGateRejection
+		// kinds, but a candidate rejected by validate()===false was warned and
+		// dropped WITHOUT being recorded as a non-disclosure rejection, so
+		// {disclosure-denied + validate-false-denied} still looked like a pure
+		// disclosure set to the privacy short-circuit — the same mislabel class,
+		// one corner further out.
+		const runtime = makeRuntime([
+			stage1Response({
+				thought: "The user asked for an owner read and an unavailable action.",
+				contexts: ["general"],
+				candidateActionNames: ["OWNER_TODOS", "UNAVAILABLE_TASK"],
+				extra: { requiresTool: true },
+			}),
+			JSON.stringify({
+				thought: "Explain that the second action is not available right now.",
+				toolCalls: [],
+				messageToUser: "That action is not available in the current state.",
+			}),
+		]);
+		runtime.actions = [
+			{
+				...makeMemorySearchAction(),
+				name: "OWNER_TODOS",
+				disclosureGate: { require: "owner_exclusive" },
+			},
+			{
+				...makeMemorySearchAction(),
+				name: "UNAVAILABLE_TASK",
+				contexts: ["general"],
+				validate: async () => false,
+			},
+		];
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ channelType: ChannelType.GROUP }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000019" as UUID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"That action is not available in the current state.",
+			);
+			expect(result.result.responseContent?.text).not.toMatch(
+				/that's private|owner's private info|private information in this conversation/i,
+			);
+		}
+		expect(useModelCalls(runtime)).toHaveLength(2);
+	});
+
+	it("keeps a MIXED disclosure+account-policy rejection set on the planner path (#20869)", async () => {
+		// Twin of the validate-false case: a connector-account-policy denial (a
+		// required policy for a provider with no registered accounts) is likewise a
+		// non-disclosure rejection and must be recorded so the privacy template
+		// stands down for the compound turn.
+		const runtime = makeRuntime([
+			stage1Response({
+				thought:
+					"The user asked for an owner read and a connector-bound action.",
+				contexts: ["general"],
+				candidateActionNames: ["OWNER_TODOS", "CONNECTOR_TASK"],
+				extra: { requiresTool: true },
+			}),
+			JSON.stringify({
+				thought:
+					"Explain that no connector account is available for the action.",
+				toolCalls: [],
+				messageToUser: "No connected account is available for that action.",
+			}),
+		]);
+		runtime.actions = [
+			{
+				...makeMemorySearchAction(),
+				name: "OWNER_TODOS",
+				disclosureGate: { require: "owner_exclusive" },
+			},
+			{
+				...makeMemorySearchAction(),
+				name: "CONNECTOR_TASK",
+				contexts: ["general"],
+				connectorAccountPolicy: { provider: "unregistered-provider" },
+			} as Action,
+		];
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ channelType: ChannelType.GROUP }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000020" as UUID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"No connected account is available for that action.",
+			);
+			expect(result.result.responseContent?.text).not.toMatch(
+				/that's private|owner's private info|private information in this conversation/i,
+			);
+		}
+		expect(useModelCalls(runtime)).toHaveLength(2);
+	});
+
 	it("blocks a Stage-1 action envelope before the direct-reply route", async () => {
 		const actionEnvelope =
 			'{"action":"BROWSER","parameters":{"url":"https://example.com"},"status":"retry","toolCallId":"call-1"}';

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2770,11 +2770,12 @@ async function collectV5PlannerCandidateActions(args: {
 		 * `disclosureRejectedExplicitCandidates`. */
 		disclosureRejectedReasons: string[];
 		/** Normalized names of EXPLICIT stage-1 candidates rejected by a
-		 * NON-disclosure gate (role/context/private-action). A privacy denial
-		 * only proves a disclosure boundary; when the same turn also has a
-		 * non-disclosure rejection the request is compound, so the privacy
-		 * short-circuit must stand down and let the planner/recovery path answer
-		 * the non-disclosure limitation honestly (#20679). */
+		 * NON-disclosure gate: role/context/private-action (#20679), plus
+		 * connector-account-policy denials and `validate() === false` (#20869).
+		 * A privacy denial only proves a disclosure boundary; when the same turn
+		 * also has a non-disclosure rejection the request is compound, so the
+		 * privacy short-circuit must stand down and let the planner/recovery
+		 * path answer the non-disclosure limitation honestly. */
 		nonDisclosureRejectedExplicitCandidates: string[];
 	};
 }): Promise<Action[]> {
@@ -2859,6 +2860,12 @@ async function collectV5PlannerCandidateActions(args: {
 			);
 			if (!accountPolicy.allowed) {
 				if (explicitCandidateName) {
+					// An account-policy denial is a non-disclosure rejection: record it
+					// so a mixed {disclosure + policy} set is visible to the privacy
+					// short-circuit's onlyDisclosureRejections conjunct (#20869).
+					args.diagnostics?.nonDisclosureRejectedExplicitCandidates.push(
+						action.name,
+					);
 					args.runtime.logger.warn(
 						{
 							src: "service:message",
@@ -2880,6 +2887,12 @@ async function collectV5PlannerCandidateActions(args: {
 				);
 				if (!valid) {
 					if (explicitCandidateName) {
+						// validate()===false is likewise a non-disclosure rejection
+						// (#20869); without this record the mixed set short-circuits to
+						// the privacy template — the #20679 mislabel class.
+						args.diagnostics?.nonDisclosureRejectedExplicitCandidates.push(
+							action.name,
+						);
 						args.runtime.logger.warn(
 							{
 								src: "service:message",


### PR DESCRIPTION
Closes #20869.

## What breaks today

#20679/#20691 made the deterministic privacy template fire only for PURE disclosure rejection sets, by recording every `actionGateRejection` kind into one of two diagnostic arrays. But at the `collectV5PlannerCandidateActions` chokepoint, two other rejection paths — connector-account-policy denials and `validate() === false` — warned via `runtime.logger.warn` and dropped the candidate **without recording it in either array**. Invisible to `onlyDisclosureRejections`, a `{disclosure-denied + validate-false-denied}` set with no survivor still satisfied the pure-disclosure conjunct and short-circuited to the privacy template: the same mislabel class #20679 fixed, one corner further out. Verified against the issue's P5 probe shape at the full Stage-1 runtime level before claiming.

## The fix

Both branches now push the action name into `nonDisclosureRejectedExplicitCandidates` — they are non-disclosure rejections by definition — so the existing conjunct sees the mixed set and the turn reaches the planner/recovery path to answer the non-disclosure limitation honestly. The privacy short-circuit itself is untouched; the diagnostics doc comment names the two new sources alongside the #20679 kinds. Pure-disclosure sets still fire the template (the existing #20660/#20679 tests hold).

## Tests

Two regressions in `message-runtime-stage1.test.ts`, mirroring the #20679 harness (real Stage-1 runtime, deterministic model responses, no mocks of the surface under test):

- `{OWNER_TODOS disclosure-denied on a GROUP surface + UNAVAILABLE_TASK with validate: async () => false}` — asserts the planner's reply lands and the privacy template does not fire.
- `{OWNER_TODOS disclosure-denied + CONNECTOR_TASK with a required connectorAccountPolicy for a provider with no registered accounts}` — the account-policy twin, same assertions.

Both fail against the previous chokepoint (2 failed / 143 passed) and pass with the fix (145/145).

# Evidence

<!-- evidence-head:aacdc4ebbde2aafc60ec895883084d9be1dd0ee1 -->

<!-- evidence-row:before-screenshots -->
N/A - message-service candidate routing; no rendered UI surface in the diff.

<!-- evidence-row:after-screenshots -->
N/A - message-service candidate routing; no rendered UI surface in the diff.

<!-- evidence-row:walkthrough-video -->
N/A - non-UI change; behavior proven by the failing-before/passing-after runtime tests below.

<!-- evidence-row:backend-logs -->
Suite at this head:

```
packages/core: bun run test src/__tests__/message-runtime-stage1.test.ts
      Tests  145 passed (145)
 New: keeps a MIXED disclosure+validate-false rejection set on the planner path (#20869)
 New: keeps a MIXED disclosure+account-policy rejection set on the planner path (#20869)
Root bun run verify at this exact head: exit 0 (repo-wide lint pre-swept clean; all Turbo tasks + root audits green).
```

<!-- evidence-row:frontend-logs -->
N/A - no frontend surface; the change is inside @elizaos/core's message service.

<!-- evidence-row:llm-trajectory -->
N/A - the surface under test is deterministic candidate classification between Stage-1 output and the planner; the tests drive the real Stage-1 runtime with fixed model responses (the same harness the #20679 fix used), and no prompt/model/provider behavior changes.

<!-- evidence-row:domain-artifacts -->
Failing-before proof — the two new tests against the previous chokepoint (message.ts stashed, tests kept):

```
 × keeps a MIXED disclosure+validate-false rejection set on the planner path (#20869) 12ms
 × keeps a MIXED disclosure+account-policy rejection set on the planner path (#20869) 6ms
      Tests  2 failed | 143 passed (145)
(stash popped; suite returns to 145 passed)
```

The failure mode is the issue's exact claim: the turn short-circuits to the privacy template instead of reaching the planner reply.

<!-- evidence-row:ocr-review -->
N/A - no rendered visual surface in this change.

---
AI provider/model: anthropic / claude-fable-5
Client / agent tooling: claude-code
Contribution skill revision: elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza
Compute receipt: 0 project-attributed tokens (unavailable; device-signed, locally reported)
Attribution status: self-reported
— [kenjohnscreates]
<!-- elizaos-contribution-attribution:v2 {"provider":"anthropic","model":"claude-fable-5","client":"claude-code","skill_revision":"elizaOS/army@9259107132edeab02d9e47dbb7ce383721bada77:skills/contribute-to-eliza","run":{"schema_version":"1","run_id":"run_01M06Z6B4FCVDXWM310SRW867D","project":"eliza","repository":"elizaOS/eliza","started_at":"2026-08-17T04:20:35.599Z","completed_at":"2026-08-17T04:33:52.850Z","skill_sha256":"7318f8392eba7a5888573a69ff936b0fe4496c501bf40bfebb339afc76c1d8d6","usage":{"source":"ccusage-session-v20","confidence":"unavailable","input_tokens":0,"output_tokens":0,"cache_creation_tokens":0,"cache_read_tokens":0,"total_tokens":0,"cost_micro_usd":"0","session_count":0},"trajectory_sha256":null,"signature_algorithm":"ed25519","device_public_key":"MCowBQYDK2VwAyEAQ02FuP7I_LN-J_iadT_q0j0Rj0Yugo5SJvOjhR_hrfw","device_key_id":"15e4c3effe5c8a2b2c22617596afd1044544026dfb99605709a677bf57050d3b","device_signature":"kf7NjEmTcg_0m7k_U6n0Hw2Rfy3EHGw0t06HOxdc96nMD-jwD8-KRcs2y7Im2RtcpAGhDicVz52QuxNs6j2GAg"}} -->
