### PR TITLE
fix(core,discord): planner fallback + visible failure for configured-to-answer group messages; single resolved Discord respond-policy

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -3051,6 +3051,90 @@ describe("runV5MessageRuntimeStage1", () => {
 		expect(routed.plan.candidateActions).toEqual(["TASKS"]);
 	});
 
+	it("falls back to the planner for a connector-eligible group message when Stage 1 is unparseable (no mention required)", async () => {
+		// The silent-drop case: a PLAIN guild message (no mention, no reply, no
+		// agent name in text) that the Discord connector already decided the
+		// agent should answer (allowlisted channel + mentions-only disabled).
+		// The connector stamps `respondEligible: true`; a malformed Stage 1
+		// completion must degrade to the planner fallback instead of throwing
+		// "v5 messageHandler returned invalid MessageHandlerResult".
+		const runtime = makeRuntime([
+			"{not valid HANDLE_RESPONSE",
+			JSON.stringify({
+				thought: "Fallback planner can answer.",
+				toolCalls: [],
+				messageToUser: "Recovered for the eligible group message.",
+			}),
+		]);
+		const message = makeMessage({
+			text: "what do you all think about the release?",
+			channelType: ChannelType.GROUP,
+			source: "discord",
+			respondEligible: true,
+			mentionContext: {
+				isMention: false,
+				isReply: false,
+				isThread: false,
+				mentionType: "none",
+			},
+		});
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message,
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"Recovered for the eligible group message.",
+			);
+		}
+	});
+
+	it("still throws for a plain group message WITHOUT connector eligibility, with one loud channel-scoped error line", async () => {
+		// Bidirectional guard: absent the respondEligible stamp (ambient group
+		// chatter the connector never vouched for), the invalid Stage 1 result
+		// keeps the original throw — but never silently: exactly one
+		// logger.error line names the room and reason before the throw.
+		const runtime = makeRuntime(["{not valid HANDLE_RESPONSE"]);
+		const message = makeMessage({
+			text: "random ambient chatter",
+			channelType: ChannelType.GROUP,
+			source: "discord",
+			mentionContext: {
+				isMention: false,
+				isReply: false,
+				isThread: false,
+				mentionType: "none",
+			},
+		});
+
+		await expect(
+			runV5MessageRuntimeStage1({
+				runtime,
+				message,
+				state: makeState(),
+				responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+			}),
+		).rejects.toThrow(/invalid MessageHandlerResult/);
+		expect(runtime.useModel).toHaveBeenCalledTimes(1);
+		const errorCalls = (
+			runtime.logger.error as { mock: { calls: unknown[][] } }
+		).mock.calls;
+		expect(errorCalls).toHaveLength(1);
+		expect(errorCalls[0][0]).toMatchObject({
+			src: "service:message",
+			roomId: message.roomId,
+			reason: "invalid MessageHandlerResult",
+			respondEligible: false,
+		});
+		expect(String(errorCalls[0][1])).toContain("not a silent drop");
+	});
+
 	it("falls back to the planner when an explicitly addressed Stage 1 turn is unparseable", async () => {
 		const runtime = makeRuntime([
 			"{not valid HANDLE_RESPONSE",

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -6406,6 +6406,17 @@ function shouldUseStage1PlannerFallback(
 	if (mentionContext?.isMention === true || mentionContext?.isReply === true) {
 		return true;
 	}
+	// A connector that already ran its own delivery policy (allowlisted
+	// channel + mentions-only disabled, DM gate passed, etc.) stamps
+	// `respondEligible: true` on the inbound content. That message was
+	// DELIVERED to the agent as one it is CONFIGURED to answer, so a Stage 1
+	// parse failure must degrade to the planner fallback exactly like an
+	// explicit mention. Before this flag, a plain (no-mention) group message
+	// in an allowlisted channel hit the invalid-MessageHandlerResult throw
+	// and the user saw nothing (silent drop).
+	if (content.respondEligible === true) {
+		return true;
+	}
 	const source = String(content.source ?? "").toLowerCase();
 	if (source.includes(MESSAGE_SOURCE_CLIENT_CHAT)) {
 		return true;
@@ -8084,6 +8095,25 @@ export async function runV5MessageRuntimeStage1(args: {
 		);
 
 		if (!messageHandler) {
+			// All recovery chains (native parse, truncation recovery, planner
+			// fallback) failed. This throw is the last line of defense before a
+			// message becomes user-visible silence, so log ONE loud, greppable
+			// error line naming the channel and the exact reason before throwing.
+			const stage1DropReason = isEmptyStage1Result(rawMessageHandler)
+				? `empty Stage 1 result after ${stage1RetryLimit + 1} attempts`
+				: "invalid MessageHandlerResult";
+			args.runtime.logger?.error?.(
+				{
+					src: "service:message",
+					agentId: args.runtime.agentId,
+					roomId: args.message.roomId,
+					channelType: String(args.message.content?.channelType ?? ""),
+					source: String(args.message.content?.source ?? ""),
+					respondEligible: args.message.content?.respondEligible === true,
+					reason: stage1DropReason,
+				},
+				"[message] Stage 1 exhausted every recovery path; the inbound message will surface as a failure, not a silent drop",
+			);
 			if (isEmptyStage1Result(rawMessageHandler)) {
 				throw new Error(
 					`v5 messageHandler returned empty Stage 1 result after ${stage1RetryLimit + 1} attempts`,
@@ -14050,6 +14080,12 @@ export class DefaultMessageService implements IMessageService {
 				gate.shouldRespond ||
 				args.mentionContext?.isMention === true ||
 				args.mentionContext?.isReply === true ||
+				// The delivering connector already ran its own respond policy and
+				// decided this message is one the agent is configured to answer
+				// (allowlisted channel + mentions-only disabled). A runtime failure
+				// on such a turn must surface to the user, not vanish as the IGNORE
+				// it would never have gotten.
+				args.message.content?.respondEligible === true ||
 				args.isAutonomous ||
 				args.hasDeliveredEarlyReply,
 			reason: gate.reason,

--- a/packages/core/src/types/primitives.ts
+++ b/packages/core/src/types/primitives.ts
@@ -162,6 +162,18 @@ export interface Content {
 	mentionContext?: MentionContext;
 
 	/**
+	 * Set by the delivering connector when its own respond policy already
+	 * decided the agent is CONFIGURED to answer this message (for example a
+	 * Discord guild message in an allowlisted channel with mentions-only
+	 * disabled, after the bot/DM/strict-mode gates all passed). The message
+	 * runtime uses this as an addressing signal: a Stage 1 parse failure on a
+	 * respond-eligible message degrades to the planner fallback (and, if that
+	 * also fails, a user-visible failure reply) instead of a silent drop that
+	 * only explicit mentions were protected from.
+	 */
+	respondEligible?: boolean;
+
+	/**
 	 * Internal message ID used for streaming coordination.
 	 * Set during response generation to ensure streaming chunks and
 	 * final broadcast use the same message ID.

--- a/plugins/plugin-discord/__tests__/resolved-policy.test.ts
+++ b/plugins/plugin-discord/__tests__/resolved-policy.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for `resolveDiscordRespondPolicy` / `logResolvedDiscordPolicy` — the
+ * single resolution point for the Discord respond/allowlist flags that
+ * historically lived in three layers with different casing and undocumented
+ * precedence:
+ *
+ *   - env `DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS` (via runtime.getSetting)
+ *   - flat `character.settings["DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS"]`
+ *     (string "true"/"false")
+ *   - typed `character.settings.discord.shouldRespondOnlyToMentions` (boolean)
+ *   - plus `CHANNEL_IDS` vs `settings.discord.allowedChannelIds`
+ *
+ * Documented precedence (highest wins): character.settings.discord object >
+ * flat character settings > env/runtime > DISCORD_DEFAULTS. The resolver also
+ * reports WHICH layer supplied each value so the boot banner can print an
+ * honest one-line provenance summary, and `getDiscordSettings` consumes the
+ * same resolver so the strict-mode gate and the banner can never disagree.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	getDiscordSettings,
+	logResolvedDiscordPolicy,
+	resolveDiscordRespondPolicy,
+} from "../environment";
+
+const POLICY_ENV_KEYS = [
+	"DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS",
+	"DISCORD_SHOULD_IGNORE_BOT_MESSAGES",
+	"DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES",
+	"CHANNEL_IDS",
+] as const;
+
+beforeEach(() => {
+	for (const key of POLICY_ENV_KEYS) {
+		delete process.env[key];
+	}
+});
+
+function runtimeWith(options: {
+	discord?: Record<string, unknown>;
+	flat?: Record<string, unknown>;
+	env?: Record<string, unknown>;
+}): IAgentRuntime {
+	const info = vi.fn();
+	return {
+		agentId: "00000000-0000-0000-0000-0000000000aa",
+		character: {
+			settings: {
+				...(options.flat ?? {}),
+				...(options.discord ? { discord: options.discord } : {}),
+			},
+		},
+		getSetting: (key: string) => options.env?.[key],
+		logger: { info, warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+	} as unknown as IAgentRuntime;
+}
+
+describe("resolveDiscordRespondPolicy precedence", () => {
+	it("typed character.settings.discord wins over flat settings AND env", () => {
+		const runtime = runtimeWith({
+			discord: { shouldRespondOnlyToMentions: false },
+			flat: { DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS: "true" },
+			env: { DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS: "true" },
+		});
+		const policy = resolveDiscordRespondPolicy(runtime);
+		expect(policy.mentionsOnly.value).toBe(false);
+		expect(policy.mentionsOnly.source).toBe("character.settings.discord");
+	});
+
+	it("typed layer accepts a string 'false' arriving from deserialized character JSON", () => {
+		const runtime = runtimeWith({
+			discord: { shouldRespondOnlyToMentions: "false" },
+			env: { DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS: "true" },
+		});
+		const policy = resolveDiscordRespondPolicy(runtime);
+		expect(policy.mentionsOnly.value).toBe(false);
+		expect(policy.mentionsOnly.source).toBe("character.settings.discord");
+	});
+
+	it("flat character settings win over env when the typed object is absent", () => {
+		const runtime = runtimeWith({
+			flat: { DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS: "true" },
+			env: { DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS: "false" },
+		});
+		const policy = resolveDiscordRespondPolicy(runtime);
+		expect(policy.mentionsOnly.value).toBe(true);
+		expect(policy.mentionsOnly.source).toBe("character.settings");
+	});
+
+	it("env supplies the value when no character layer sets it", () => {
+		const runtime = runtimeWith({
+			env: { DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS: "true" },
+		});
+		const policy = resolveDiscordRespondPolicy(runtime);
+		expect(policy.mentionsOnly.value).toBe(true);
+		expect(policy.mentionsOnly.source).toBe("env");
+	});
+
+	it("falls through to the conversational defaults with full provenance", () => {
+		const runtime = runtimeWith({});
+		const policy = resolveDiscordRespondPolicy(runtime);
+		expect(policy.mentionsOnly).toEqual({ value: false, source: "default" });
+		expect(policy.ignoreBots).toEqual({ value: false, source: "default" });
+		expect(policy.ignoreDMs).toEqual({ value: true, source: "default" });
+		expect(policy.allowedChannelIds.source).toBe("default");
+	});
+
+	it("settings.discord.allowedChannelIds wins over CHANNEL_IDS env", () => {
+		const runtime = runtimeWith({
+			discord: { allowedChannelIds: ["111", "222"] },
+			env: { CHANNEL_IDS: "999" },
+		});
+		const policy = resolveDiscordRespondPolicy(runtime);
+		expect(policy.allowedChannelIds.value).toEqual(["111", "222"]);
+		expect(policy.allowedChannelIds.source).toBe("character.settings.discord");
+	});
+
+	it("flat CHANNEL_IDS string beats env CHANNEL_IDS and parses csv", () => {
+		const runtime = runtimeWith({
+			flat: { CHANNEL_IDS: "111, 222 ,333" },
+			env: { CHANNEL_IDS: "999" },
+		});
+		const policy = resolveDiscordRespondPolicy(runtime);
+		expect(policy.allowedChannelIds.value).toEqual(["111", "222", "333"]);
+		expect(policy.allowedChannelIds.source).toBe("character.settings");
+	});
+
+	it("env CHANNEL_IDS applies when no character layer configures channels", () => {
+		const runtime = runtimeWith({ env: { CHANNEL_IDS: "444,555" } });
+		const policy = resolveDiscordRespondPolicy(runtime);
+		expect(policy.allowedChannelIds.value).toEqual(["444", "555"]);
+		expect(policy.allowedChannelIds.source).toBe("env");
+	});
+
+	it("getDiscordSettings consumes the same resolver (no drift with the gate)", () => {
+		const runtime = runtimeWith({
+			discord: { shouldRespondOnlyToMentions: false },
+			env: {
+				DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS: "true",
+				CHANNEL_IDS: "777",
+			},
+		});
+		const settings = getDiscordSettings(runtime);
+		expect(settings.shouldRespondOnlyToMentions).toBe(false);
+		expect(settings.allowedChannelIds).toEqual(["777"]);
+	});
+});
+
+describe("logResolvedDiscordPolicy", () => {
+	it("emits one INFO line naming resolved values and their sources", () => {
+		const runtime = runtimeWith({
+			discord: { shouldRespondOnlyToMentions: false },
+			env: {
+				DISCORD_SHOULD_IGNORE_BOT_MESSAGES: "true",
+				CHANNEL_IDS: "123,456",
+			},
+		});
+		logResolvedDiscordPolicy(runtime);
+		const info = (runtime.logger.info as ReturnType<typeof vi.fn>).mock.calls;
+		expect(info).toHaveLength(1);
+		const line = String(info[0][1]);
+		expect(line).toContain("[discord] resolved policy:");
+		expect(line).toContain("mentionsOnly=false");
+		expect(line).toContain("ignoreBots=true");
+		expect(line).toContain("ignoreDMs=true");
+		expect(line).toContain("allowedChannels=[123,456]");
+		expect(line).toContain("mentionsOnly=character.settings.discord");
+		expect(line).toContain("ignoreBots=env");
+		expect(line).toContain("allowedChannels=env");
+	});
+
+	it("prints (all) when no channel allowlist is configured", () => {
+		const runtime = runtimeWith({});
+		logResolvedDiscordPolicy(runtime);
+		const info = (runtime.logger.info as ReturnType<typeof vi.fn>).mock.calls;
+		expect(String(info[0][1])).toContain("allowedChannels=(all)");
+	});
+});

--- a/plugins/plugin-discord/__tests__/respond-eligible-stamp.test.ts
+++ b/plugins/plugin-discord/__tests__/respond-eligible-stamp.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Locks the connector-side half of the silent-drop fix (#20755): a plain
+ * (no-mention) guild message that passes every delivery gate (allowlisted
+ * channel via event listener, autoReply on, strict mode off, no other target)
+ * must reach `messageService.handleMessage` with `content.respondEligible ===
+ * true` — the flag the core message runtime uses to extend the Stage 1
+ * planner fallback (and visible-failure gate) to messages the agent is
+ * CONFIGURED to answer. DMs and mention-gated turns keep the flag false: their
+ * existing addressing signals (channelType / mentionContext) already cover
+ * them. The harness drives the REAL MessageManager with discord.js objects
+ * stubbed, mirroring messages-inbound-idempotency.test.ts.
+ */
+import { randomUUID } from "node:crypto";
+import {
+	ChannelType,
+	type Content,
+	createUniqueUuid,
+	type Memory,
+	type UUID,
+} from "@elizaos/core";
+import type { Message as DiscordMessage } from "discord.js";
+import { ChannelType as DiscordChannelType } from "discord.js";
+import { describe, expect, it, vi } from "vitest";
+import { MessageManager } from "../messages.ts";
+import type { ICompatRuntime, IDiscordService } from "../types.ts";
+
+const AGENT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" as UUID;
+const AUTHOR_ID = "555000111222333444";
+const CHANNEL_ID = "777000000000000000";
+// Distinct DM channel identity: the connector's process-wide outbound dedupe
+// suppresses an identical account/channel/text tuple within two seconds, so
+// the DM case must not reuse the guild channel id (see
+// connector-loop.real.test.ts for the same guard).
+const DM_CHANNEL_ID = "777000000000000001";
+const GUILD_ID = "666555444333222111";
+const CLIENT_ID = "888000000000000000";
+
+interface Sent {
+	content?: string;
+}
+
+interface Harness {
+	runtime: ICompatRuntime;
+	sends: Sent[];
+	dispatchedMessages: Memory[];
+}
+
+function makeRuntime(): Harness {
+	const memories = new Map<string, Memory>();
+	const sends: Sent[] = [];
+	const dispatchedMessages: Memory[] = [];
+	const rooms = new Map<UUID, { id: UUID; type?: string }>();
+	const participantsByRoom = new Map<UUID, UUID[]>();
+	const runtime = {
+		agentId: AGENT_ID,
+		character: { name: "Eliza" },
+		logger: {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		},
+		getSetting: (key: string) =>
+			key === "ELIZA_LIFEOPS_PASSIVE_CONNECTORS" ? "false" : undefined,
+		getService: () => null,
+		ensureConnection: vi.fn(
+			async (params: { entityId: UUID; roomId: UUID; type?: string }) => {
+				rooms.set(params.roomId, { id: params.roomId, type: params.type });
+				participantsByRoom.set(params.roomId, [params.entityId, AGENT_ID]);
+			},
+		),
+		getRoom: vi.fn(async (roomId: UUID) => rooms.get(roomId) ?? null),
+		getParticipantsForRoom: vi.fn(
+			async (roomId: UUID) => participantsByRoom.get(roomId) ?? [],
+		),
+		reportError: vi.fn(),
+		getMemoryById: vi.fn(async (id: UUID) => memories.get(id) ?? null),
+		createMemory: vi.fn(async (memory: Memory) => {
+			const id =
+				memory.id ?? createUniqueUuid(runtime as ICompatRuntime, randomUUID());
+			memories.set(id, { ...memory, id });
+			return id;
+		}),
+		getMemories: vi.fn(async () => []),
+		messageService: {
+			handleMessage: async (
+				_runtime: unknown,
+				message: Memory,
+				callback: (content: Content) => Promise<unknown>,
+			) => {
+				dispatchedMessages.push(message);
+				if (message.id && !memories.has(message.id)) {
+					await runtime.createMemory(message, "messages");
+				}
+				await callback({ text: "reply", source: "discord" });
+			},
+		},
+		emitEvent: vi.fn(),
+	} as unknown as ICompatRuntime;
+	return { runtime, sends, dispatchedMessages };
+}
+
+function makeGuildChannel(sends: Sent[], guild: unknown) {
+	return {
+		id: CHANNEL_ID,
+		type: DiscordChannelType.GuildText,
+		name: "general",
+		guild,
+		client: { user: { id: CLIENT_ID } },
+		isThread: () => false,
+		permissionsFor: () => ({ has: () => true }),
+		send: async (options: Sent | string) => {
+			const normalized =
+				typeof options === "string" ? { content: options } : options;
+			sends.push(normalized);
+			return {
+				id: `99000000000000000${sends.length}`,
+				content: normalized.content ?? "",
+				url: `https://discord.com/channels/${GUILD_ID}/${CHANNEL_ID}/99000000000000000${sends.length}`,
+				createdTimestamp: Date.now(),
+				attachments: { size: 0 },
+			};
+		},
+		sendTyping: async () => {},
+	};
+}
+
+function makeDmChannel(sends: Sent[]) {
+	return {
+		id: DM_CHANNEL_ID,
+		type: DiscordChannelType.DM,
+		isThread: () => false,
+		send: async (options: Sent | string) => {
+			const normalized =
+				typeof options === "string" ? { content: options } : options;
+			sends.push(normalized);
+			return {
+				id: `99000000000000000${sends.length}`,
+				content: normalized.content ?? "",
+				url: `https://discord.com/channels/@me/${DM_CHANNEL_ID}/99000000000000000${sends.length}`,
+				createdTimestamp: Date.now(),
+				attachments: { size: 0 },
+			};
+		},
+		sendTyping: async () => {},
+	};
+}
+
+function makeGuild() {
+	const botMember = { id: CLIENT_ID };
+	const guild: Record<string, unknown> = {
+		id: GUILD_ID,
+		name: "Test Guild",
+		ownerId: "111100000000000000",
+		members: { cache: new Map([[CLIENT_ID, botMember]]) },
+	};
+	guild.fetch = async () => guild;
+	return guild;
+}
+
+function makeInboundMemory(messageId: string): Memory {
+	return {
+		id: createUniqueUuid(
+			{ agentId: AGENT_ID } as ICompatRuntime,
+			messageId,
+		) as UUID,
+		entityId: createUniqueUuid(
+			{ agentId: AGENT_ID } as ICompatRuntime,
+			AUTHOR_ID,
+		) as UUID,
+		agentId: AGENT_ID,
+		roomId: createUniqueUuid(
+			{ agentId: AGENT_ID } as ICompatRuntime,
+			CHANNEL_ID,
+		) as UUID,
+		content: { text: "plain group message", source: "discord" },
+	};
+}
+
+function makeDiscordService(options: {
+	channelType: ChannelType;
+	settings?: Record<string, unknown>;
+}): IDiscordService {
+	return {
+		client: { user: { id: CLIENT_ID } },
+		accountId: "default",
+		getChannelType: async () => options.channelType,
+		discordSettings: {
+			autoReply: true,
+			dmPolicy: "open",
+			shouldIgnoreBotMessages: true,
+			shouldIgnoreDirectMessages: false,
+			shouldRespondOnlyToMentions: false,
+			replyToMode: "off",
+			...(options.settings ?? {}),
+		},
+		buildMemoryFromMessage: vi.fn(
+			async (
+				message: DiscordMessage,
+				buildOptions?: { extraContent?: Record<string, unknown> },
+			) => {
+				const memory = makeInboundMemory(message.id);
+				return {
+					...memory,
+					content: {
+						...memory.content,
+						...(buildOptions?.extraContent ?? {}),
+					},
+				};
+			},
+		),
+	} as unknown as IDiscordService;
+}
+
+function makeInbound(
+	channel: unknown,
+	options: {
+		guild?: unknown;
+		messageId?: string;
+		mentionsBot?: boolean;
+	} = {},
+): DiscordMessage {
+	const mentionUsers = new Map<string, { id: string }>();
+	if (options.mentionsBot) {
+		mentionUsers.set(CLIENT_ID, { id: CLIENT_ID });
+	}
+	return {
+		id: options.messageId ?? "666000000000000000",
+		content: options.mentionsBot
+			? `<@${CLIENT_ID}> plain group message`
+			: "plain group message",
+		createdTimestamp: Date.now(),
+		author: {
+			id: AUTHOR_ID,
+			bot: false,
+			username: "tester",
+			globalName: "Tester",
+			displayName: "Tester",
+			discriminator: "0",
+		},
+		member: options.guild ? { displayName: "Tester" } : null,
+		channel,
+		guild: options.guild,
+		interaction: null,
+		reference: undefined,
+		embeds: [],
+		stickers: { size: 0 },
+		attachments: { size: 0 },
+		mentions: { users: mentionUsers, repliedUser: undefined },
+		react: async () => undefined,
+		reactions: { resolve: () => null },
+	} as unknown as DiscordMessage;
+}
+
+describe("respondEligible connector stamp", () => {
+	it("stamps respondEligible=true on a plain guild message the agent is configured to answer", async () => {
+		const harness = makeRuntime();
+		const guild = makeGuild();
+		const channel = makeGuildChannel(harness.sends, guild);
+		const service = makeDiscordService({ channelType: ChannelType.GROUP });
+		const manager = new MessageManager(service, harness.runtime);
+
+		await manager.handleMessage(makeInbound(channel, { guild }));
+
+		expect(harness.dispatchedMessages).toHaveLength(1);
+		const dispatched = harness.dispatchedMessages[0];
+		expect(dispatched.content.respondEligible).toBe(true);
+		// The message is genuinely plain: no platform mention, no reply.
+		expect(dispatched.content.mentionContext).toMatchObject({
+			isMention: false,
+			isReply: false,
+		});
+		expect(harness.sends).toHaveLength(1);
+	});
+
+	it("keeps respondEligible=false on DMs (channelType already covers them)", async () => {
+		const harness = makeRuntime();
+		const channel = makeDmChannel(harness.sends);
+		const service = makeDiscordService({ channelType: ChannelType.DM });
+		const manager = new MessageManager(service, harness.runtime);
+
+		await manager.handleMessage(makeInbound(channel));
+
+		expect(harness.dispatchedMessages).toHaveLength(1);
+		expect(harness.dispatchedMessages[0].content.respondEligible).toBe(false);
+		expect(harness.sends).toHaveLength(1);
+	});
+
+	it("never dispatches (and so never stamps) a plain guild message under strict mentions-only mode", async () => {
+		const harness = makeRuntime();
+		const guild = makeGuild();
+		const channel = makeGuildChannel(harness.sends, guild);
+		const service = makeDiscordService({
+			channelType: ChannelType.GROUP,
+			settings: { shouldRespondOnlyToMentions: true },
+		});
+		const manager = new MessageManager(service, harness.runtime);
+
+		await manager.handleMessage(makeInbound(channel, { guild }));
+
+		expect(harness.dispatchedMessages).toHaveLength(0);
+		expect(harness.sends).toHaveLength(0);
+	});
+
+	it("stamps respondEligible=true on a mention that passes strict mode", async () => {
+		const harness = makeRuntime();
+		const guild = makeGuild();
+		const channel = makeGuildChannel(harness.sends, guild);
+		const service = makeDiscordService({
+			channelType: ChannelType.GROUP,
+			settings: { shouldRespondOnlyToMentions: true },
+		});
+		const manager = new MessageManager(service, harness.runtime);
+
+		await manager.handleMessage(
+			makeInbound(channel, { guild, mentionsBot: true }),
+		);
+
+		expect(harness.dispatchedMessages).toHaveLength(1);
+		const dispatched = harness.dispatchedMessages[0];
+		expect(dispatched.content.respondEligible).toBe(true);
+		expect(dispatched.content.mentionContext).toMatchObject({
+			isMention: true,
+		});
+	});
+});

--- a/plugins/plugin-discord/banner.ts
+++ b/plugins/plugin-discord/banner.ts
@@ -7,7 +7,7 @@
 import type { IAgentRuntime } from "@elizaos/core";
 import { lifeOpsPassiveConnectorsEnabled } from "@elizaos/core";
 import { listEnabledDiscordAccounts } from "./accounts";
-import { getDiscordSettings } from "./environment";
+import { getDiscordSettings, logResolvedDiscordPolicy } from "./environment";
 import {
 	type DiscordPermissionValues,
 	getPermissionValues,
@@ -483,6 +483,13 @@ export function printBanner(options: BannerOptions): void {
 	lines.push("");
 
 	runtime.logger.info(lines.join("\n"));
+
+	// One INFO line naming the RESOLVED respond policy and which config layer
+	// supplied each value — the banner above prints raw per-key settings, but
+	// with the same flag living in env, flat character settings, AND the typed
+	// settings.discord object, only the resolver output tells the operator
+	// what the bot will actually do.
+	logResolvedDiscordPolicy(runtime);
 
 	// Diagnostics: if the effective config will suppress all auto-replies, warn
 	// the operator with the exact reason(s) instead of failing silently.

--- a/plugins/plugin-discord/environment.ts
+++ b/plugins/plugin-discord/environment.ts
@@ -84,6 +84,209 @@ export const discordEnvSchema = z.object({
 
 export type DiscordConfig = z.infer<typeof discordEnvSchema>;
 
+/**
+ * Which configuration layer supplied a resolved respond-policy value.
+ * Precedence (highest wins):
+ *   1. `character.settings.discord.*` — the typed per-character object
+ *   2. flat `character.settings["DISCORD_*"]` keys (string "true"/"false")
+ *   3. env / runtime settings (`runtime.getSetting`, which also covers
+ *      DB-seeded values re-imported from ELIZA_AGENT_CHARACTER_JSON at boot)
+ *   4. `DISCORD_DEFAULTS`
+ */
+export type DiscordPolicySource =
+	| "character.settings.discord"
+	| "character.settings"
+	| "env"
+	| "default";
+
+export interface ResolvedDiscordPolicyValue<T> {
+	value: T;
+	source: DiscordPolicySource;
+}
+
+/**
+ * The respond/allowlist flags that historically existed in three layers with
+ * different casing and undocumented precedence (env
+ * `DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS`, flat character settings string,
+ * typed `character.settings.discord.shouldRespondOnlyToMentions`, plus
+ * `CHANNEL_IDS` vs `settings.discord.allowedChannelIds`). This is THE single
+ * resolution result: both the strict-mode gate (via `getDiscordSettings`) and
+ * the boot policy banner consume it, so they can never disagree again.
+ */
+export interface ResolvedDiscordRespondPolicy {
+	mentionsOnly: ResolvedDiscordPolicyValue<boolean>;
+	ignoreBots: ResolvedDiscordPolicyValue<boolean>;
+	ignoreDMs: ResolvedDiscordPolicyValue<boolean>;
+	allowedChannelIds: ResolvedDiscordPolicyValue<string[] | undefined>;
+}
+
+function readFlatCharacterSetting(
+	runtime: IAgentRuntime,
+	key: string,
+): unknown {
+	const settings = runtime.character?.settings;
+	if (!settings || typeof settings !== "object") return undefined;
+	return (settings as Record<string, unknown>)[key];
+}
+
+function parseChannelIdList(value: unknown): string[] | undefined {
+	if (Array.isArray(value)) {
+		const entries = value
+			.map((entry) => String(entry).trim())
+			.filter((entry) => entry.length > 0);
+		return entries;
+	}
+	if (typeof value === "string" && value.trim().length > 0) {
+		return value
+			.split(",")
+			.map((entry) => entry.trim())
+			.filter((entry) => entry.length > 0);
+	}
+	return undefined;
+}
+
+function resolveBooleanPolicy(
+	runtime: IAgentRuntime,
+	typedValue: unknown,
+	envKey: string,
+	defaultValue: boolean,
+): ResolvedDiscordPolicyValue<boolean> {
+	// The typed object is deserialized from character JSON, so a value that
+	// SHOULD be boolean can arrive as the string "true"/"false". Both count as
+	// the typed layer.
+	if (typeof typedValue === "boolean") {
+		return { value: typedValue, source: "character.settings.discord" };
+	}
+	if (typeof typedValue === "string" && typedValue.trim().length > 0) {
+		return {
+			value: parseBooleanFromText(typedValue),
+			source: "character.settings.discord",
+		};
+	}
+	const flat = readFlatCharacterSetting(runtime, envKey);
+	if (typeof flat === "boolean") {
+		return { value: flat, source: "character.settings" };
+	}
+	if (typeof flat === "string" && flat.trim().length > 0) {
+		return { value: parseBooleanFromText(flat), source: "character.settings" };
+	}
+	const runtimeValue = runtime.getSetting(envKey);
+	if (
+		runtimeValue !== undefined &&
+		runtimeValue !== null &&
+		runtimeValue !== ""
+	) {
+		return {
+			value:
+				typeof runtimeValue === "boolean"
+					? runtimeValue
+					: parseBooleanFromText(String(runtimeValue)),
+			source: "env",
+		};
+	}
+	return { value: defaultValue, source: "default" };
+}
+
+/**
+ * Resolve the effective Discord respond/allowlist policy from every
+ * configuration layer with a single documented precedence:
+ * `character.settings.discord` object > flat character settings > env /
+ * runtime settings > defaults. Returns the resolved value AND the layer that
+ * supplied it, so the boot banner can print an honest provenance line.
+ */
+export function resolveDiscordRespondPolicy(
+	runtime: IAgentRuntime,
+): ResolvedDiscordRespondPolicy {
+	const characterSettings =
+		(runtime.character?.settings &&
+			(runtime.character.settings.discord as DiscordSettings)) ||
+		{};
+
+	const mentionsOnly = resolveBooleanPolicy(
+		runtime,
+		characterSettings.shouldRespondOnlyToMentions,
+		"DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS",
+		DISCORD_DEFAULTS.SHOULD_RESPOND_ONLY_TO_MENTIONS,
+	);
+	const ignoreBots = resolveBooleanPolicy(
+		runtime,
+		characterSettings.shouldIgnoreBotMessages,
+		"DISCORD_SHOULD_IGNORE_BOT_MESSAGES",
+		DISCORD_DEFAULTS.SHOULD_IGNORE_BOT_MESSAGES,
+	);
+	const ignoreDMs = resolveBooleanPolicy(
+		runtime,
+		characterSettings.shouldIgnoreDirectMessages,
+		"DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES",
+		DISCORD_DEFAULTS.SHOULD_IGNORE_DIRECT_MESSAGES,
+	);
+
+	let allowedChannelIds: ResolvedDiscordPolicyValue<string[] | undefined>;
+	const typedChannels = parseChannelIdList(characterSettings.allowedChannelIds);
+	const flatChannels = parseChannelIdList(
+		readFlatCharacterSetting(runtime, "CHANNEL_IDS"),
+	);
+	const envChannels = parseChannelIdList(runtime.getSetting("CHANNEL_IDS"));
+	if (typedChannels !== undefined) {
+		allowedChannelIds = {
+			value: typedChannels.length > 0 ? typedChannels : undefined,
+			source: "character.settings.discord",
+		};
+	} else if (flatChannels !== undefined) {
+		allowedChannelIds = {
+			value: flatChannels.length > 0 ? flatChannels : undefined,
+			source: "character.settings",
+		};
+	} else if (envChannels !== undefined) {
+		allowedChannelIds = {
+			value: envChannels.length > 0 ? envChannels : undefined,
+			source: "env",
+		};
+	} else {
+		allowedChannelIds = {
+			value:
+				DISCORD_DEFAULTS.ALLOWED_CHANNEL_IDS.length > 0
+					? [...DISCORD_DEFAULTS.ALLOWED_CHANNEL_IDS]
+					: undefined,
+			source: "default",
+		};
+	}
+
+	return { mentionsOnly, ignoreBots, ignoreDMs, allowedChannelIds };
+}
+
+/**
+ * One INFO line at boot naming the RESOLVED effective respond policy and
+ * which configuration layer supplied each value. Before this line existed the
+ * same flag lived in >=3 layers with different casing, boot re-seeded agent
+ * DB settings from ELIZA_AGENT_CHARACTER_JSON (so DB edits silently
+ * reverted), and nothing ever printed the winner: operators diagnosed silent
+ * no-reply incidents by bisecting env files.
+ */
+export function logResolvedDiscordPolicy(runtime: IAgentRuntime): void {
+	const policy = resolveDiscordRespondPolicy(runtime);
+	const channels = policy.allowedChannelIds.value;
+	const channelList = channels ? `[${channels.join(",")}]` : "(all)";
+	runtime.logger?.info?.(
+		{
+			src: "plugin:discord",
+			agentId: runtime.agentId,
+			mentionsOnly: policy.mentionsOnly.value,
+			ignoreBots: policy.ignoreBots.value,
+			ignoreDMs: policy.ignoreDMs.value,
+			allowedChannelIds: channels,
+		},
+		`[discord] resolved policy: mentionsOnly=${policy.mentionsOnly.value} ` +
+			`ignoreBots=${policy.ignoreBots.value} ` +
+			`ignoreDMs=${policy.ignoreDMs.value} ` +
+			`allowedChannels=${channelList} ` +
+			`(sources: mentionsOnly=${policy.mentionsOnly.source}, ` +
+			`ignoreBots=${policy.ignoreBots.source}, ` +
+			`ignoreDMs=${policy.ignoreDMs.source}, ` +
+			`allowedChannels=${policy.allowedChannelIds.source})`,
+	);
+}
+
 export function getDiscordSettings(runtime: IAgentRuntime): DiscordSettings {
 	const characterSettings =
 		(runtime.character.settings &&
@@ -105,44 +308,20 @@ export function getDiscordSettings(runtime: IAgentRuntime): DiscordSettings {
 		return characterValue ?? defaultValue;
 	};
 
-	const resolvedAllowedChannelIds = resolveSetting<string[]>(
-		"CHANNEL_IDS",
-		characterSettings.allowedChannelIds,
-		DISCORD_DEFAULTS.ALLOWED_CHANNEL_IDS,
-		(value: string) =>
-			value
-				.split(",")
-				.map((s) => s.trim())
-				.filter((s) => s.length > 0),
-	);
+	// The four respond/allowlist flags flow through the single resolver so the
+	// strict-mode gate, the inbound allowlist, and the boot policy banner all
+	// agree on the same effective values and precedence.
+	const respondPolicy = resolveDiscordRespondPolicy(runtime);
 
 	return {
 		...characterSettings,
-		shouldIgnoreBotMessages: resolveSetting(
-			"DISCORD_SHOULD_IGNORE_BOT_MESSAGES",
-			characterSettings.shouldIgnoreBotMessages,
-			DISCORD_DEFAULTS.SHOULD_IGNORE_BOT_MESSAGES,
-			parseBooleanFromText,
-		),
+		shouldIgnoreBotMessages: respondPolicy.ignoreBots.value,
 
-		shouldIgnoreDirectMessages: resolveSetting(
-			"DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES",
-			characterSettings.shouldIgnoreDirectMessages,
-			DISCORD_DEFAULTS.SHOULD_IGNORE_DIRECT_MESSAGES,
-			parseBooleanFromText,
-		),
+		shouldIgnoreDirectMessages: respondPolicy.ignoreDMs.value,
 
-		shouldRespondOnlyToMentions: resolveSetting(
-			"DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS",
-			characterSettings.shouldRespondOnlyToMentions,
-			DISCORD_DEFAULTS.SHOULD_RESPOND_ONLY_TO_MENTIONS,
-			parseBooleanFromText,
-		),
+		shouldRespondOnlyToMentions: respondPolicy.mentionsOnly.value,
 
-		allowedChannelIds:
-			resolvedAllowedChannelIds.length > 0
-				? resolvedAllowedChannelIds
-				: undefined,
+		allowedChannelIds: respondPolicy.allowedChannelIds.value,
 
 		dmPolicy: resolveSetting(
 			"DISCORD_DM_POLICY",

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -1541,6 +1541,25 @@ export class MessageManager {
 				!isBotDirectlyAddressed &&
 				(mentionedOtherUsers || isReplyToOtherUser);
 
+			// This plugin has already run its full delivery policy by the time the
+			// reply path dispatches: the channel allowlist gate lives in
+			// setupEventListeners (a disallowed guild channel never reaches this
+			// manager), bot/self messages returned above, and the strict-mode /
+			// other-target / autoReply gates below close the turn as ingest-only
+			// before any model dispatch. So a guild message that reaches
+			// messageService.handleMessage with this flag true is one the agent is
+			// CONFIGURED to answer — the core runtime uses it to extend the Stage 1
+			// planner fallback (and the visible-failure gate) to plain, no-mention
+			// group messages, which previously died in a silent drop when the
+			// RESPONSE_HANDLER model returned malformed output (#20755 evidence:
+			// "v5 messageHandler returned invalid MessageHandlerResult" at
+			// message.ts runV5MessageRuntimeStage1 via plugin-discord messages.ts).
+			const respondEligible =
+				!isDM &&
+				this.discordSettings.autoReply !== false &&
+				!ignoresOtherTarget &&
+				(!strictModeEnabled || strictModeShouldProcess);
+
 			// Use the service's buildMemoryFromMessage method with pre-processed content
 			const newMessage = await this.discordService.buildMemoryFromMessage(
 				message,
@@ -1549,6 +1568,7 @@ export class MessageManager {
 					processedAttachments: attachments,
 					extraContent: {
 						currentMessageText,
+						respondEligible,
 						mentionContext: {
 							isMention: isBotPlatformMentioned,
 							isReply: isReplyToBot,


### PR DESCRIPTION
## Summary

Two durable fixes for the Discord respond pipeline, from a live incident on a sol-dev deployment (2026-08-16) where every plain (no-mention) group message in an allowlisted channel silently vanished.

### Bug 1 (P0): Stage-1 failure on plain group messages = SILENT DROP

**Evidence (backend logs):**
- `v5 messageHandler returned invalid MessageHandlerResult` thrown from `runV5MessageRuntimeStage1` (`packages/core/src/services/message.ts`), reached via `plugin-discord/messages.ts` dispatch
- haiku-4.5 as RESPONSE_HANDLER repeatedly returned malformed HANDLE_RESPONSE tool calls; every non-mention message died at the throw. Mentions survived only because `shouldUseStage1PlannerFallback` covered them.

**Root cause:** `shouldUseStage1PlannerFallback` only recognized DM/VOICE_DM/SELF/API channels, `mentionContext.isMention/isReply`, client-chat source, or agent-name-in-text. A guild message the agent was **delivered** and **configured to answer** (allowlisted channel + `shouldRespondOnlyToMentions=false`) had none of those signals, so an invalid Stage 1 result hit the throw and the user saw nothing. Worst possible failure mode: silent.

**Fix (three layers, all behavioral):**
1. `plugin-discord` stamps `content.respondEligible: true` on inbound guild messages after its own delivery policy passes (channel allowlist gate, autoReply on, not targeting another user, strict mode off or satisfied). The connector's "I already decided this message is eligible" signal now flows into core.
2. `shouldUseStage1PlannerFallback` honors `respondEligible`, so Stage 1 parse failures on these messages degrade to the planner fallback exactly like an explicit mention.
3. If ALL fallbacks still fail: `isDeterministicallyAddressedTurn` also honors `respondEligible` so the structured failure reply is delivered (user-visible), and the final no-handler throw now emits ONE loud `logger.error` line naming roomId, channelType, source, eligibility, and the exact reason. Never a silent drop.

### Bug 2 (P1): respond/allowlist config sprawl, no resolved-policy visibility

The same flag existed in >=3 layers with different casing and undocumented precedence:
- env `DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS`
- flat `character.settings["DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS"]` (string "true"/"false")
- typed `character.settings.discord.shouldRespondOnlyToMentions` (boolean)
- plus `CHANNEL_IDS` vs `settings.discord.allowedChannelIds`

Boot re-seeds agent DB settings from `ELIZA_AGENT_CHARACTER_JSON`, so DB edits silently reverted, and nothing logged the resolved effective policy.

**Fix:**
- `resolveDiscordRespondPolicy(runtime)` in `plugin-discord/environment.ts`: single resolution function, documented precedence (**`character.settings.discord` object > flat character settings > env/runtime > defaults**), returns value + supplying layer per flag.
- `getDiscordSettings` consumes the same resolver, so the strict-mode gate and the boot banner cannot disagree.
- One INFO boot line:
  `[discord] resolved policy: mentionsOnly=X ignoreBots=X ignoreDMs=X allowedChannels=[...] (sources: mentionsOnly=..., ignoreBots=..., ignoreDMs=..., allowedChannels=...)`

## Bidirectional test proof

New tests **fail on develop** (fix stashed) and **pass with the fix**:

```
# baseline (fix stashed, tests applied):
cd packages/core && bun run test src/__tests__/message-runtime-stage1.test.ts
#   2 failed | 143 passed  (both new stage-1 tests fail: eligible group message throws;
#                           no loud error line on the throw path)
cd plugins/plugin-discord && bunx vitest run __tests__/respond-eligible-stamp.test.ts __tests__/resolved-policy.test.ts
#   14 failed | 1 passed   (no respondEligible stamp; resolver/log APIs absent)

# with fix:
cd packages/core && bun run test src/__tests__/message-runtime-stage1.test.ts
#   145 passed (145)
cd plugins/plugin-discord && bun run test
#   82 files, 655 passed (full plugin suite)
```

Also verified:
- `packages/core` message-service suites: `bun run test "src/__tests__/message"` → 289 passed, 2 failed **only** in `message-v5-widget-markers.test.ts`, which fails identically on clean develop (pre-existing, unrelated: ACTION_PLANNER queue exhaustion).
- `packages/core` typecheck: clean.
- Biome: clean on all touched files.

## Test coverage added

**core (`message-runtime-stage1.test.ts`):**
- connector-eligible plain group message (`respondEligible: true`, no mention) + unparseable Stage 1 → planner fallback engages, reply delivered
- plain group message WITHOUT eligibility + invalid Stage 1 → still throws, with exactly one channel-scoped `logger.error` line (`reason: "invalid MessageHandlerResult"`, `respondEligible: false`)

**plugin-discord:**
- `respond-eligible-stamp.test.ts` (real MessageManager, stubbed discord.js): plain guild message → stamped true; DM → false; strict mode + no mention → never dispatched; strict mode + mention → stamped true
- `resolved-policy.test.ts`: full precedence matrix (typed > flat > env > default) for booleans and channel allowlists, string-"false" tolerance in the typed layer, `getDiscordSettings` consistency, INFO-line content/provenance

## Non-goals
- No auto-merge, no check weakening, no prod/runtime changes; the live deployment was left untouched (report-only).
