### PR TITLE
fix(app): paint eliza.app white before marketing boot

### DIFF
--- a/packages/app/AGENTS.md
+++ b/packages/app/AGENTS.md
@@ -71,18 +71,23 @@ packages/app/
 - `../homepage/src/embedded-home.tsx` and `embedded-downloads.tsx` — public
   marketing entrypoints consumed through the `@homepage/*` Vite alias. Their
   package is source/test-only; this app owns every served and deployed build.
+- `src/entry.ts` — synchronous renderer selector. The root marketing route uses
+  `src/marketing-home-entry.tsx` so its static hero does not wait for the Cloud
+  auth router, service worker, wallet providers, or the normal app boot graph.
 
 ## Boot sequence
 
-1. `main()` resolves embed, smoke-test, managed-launch, popout, and detached-window
+1. `entry.ts` selects the marketing-only root, hosted public routes, or the
+   normal application entry before importing any renderer graph.
+2. `main()` resolves embed, smoke-test, managed-launch, popout, and detached-window
    paths before the normal application path.
-2. `initializeAppModules()` assembles `AppBootConfig` and calls `setBootConfig()`;
+3. `initializeAppModules()` assembles `AppBootConfig` and calls `setBootConfig()`;
    feature modules not needed for first paint remain on the deferred idle path.
-3. The normal native path hydrates the storage bridge before rendering because
+4. The normal native path hydrates the storage bridge before rendering because
    session, first-run, and theme state must exist on the first React read.
-4. Platform-specific request, fetch, vision, voice, and desktop bridges are
+5. Platform-specific request, fetch, vision, voice, and desktop bridges are
    installed in their required order.
-5. React mounts the `@elizaos/ui` application, deferred modules are scheduled,
+6. React mounts the `@elizaos/ui` application, deferred modules are scheduled,
    and `initializePlatform()` completes the remaining lifecycle integration.
 
 ## Commands

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -71,18 +71,23 @@ packages/app/
 - `../homepage/src/embedded-home.tsx` and `embedded-downloads.tsx` — public
   marketing entrypoints consumed through the `@homepage/*` Vite alias. Their
   package is source/test-only; this app owns every served and deployed build.
+- `src/entry.ts` — synchronous renderer selector. The root marketing route uses
+  `src/marketing-home-entry.tsx` so its static hero does not wait for the Cloud
+  auth router, service worker, wallet providers, or the normal app boot graph.
 
 ## Boot sequence
 
-1. `main()` resolves embed, smoke-test, managed-launch, popout, and detached-window
+1. `entry.ts` selects the marketing-only root, hosted public routes, or the
+   normal application entry before importing any renderer graph.
+2. `main()` resolves embed, smoke-test, managed-launch, popout, and detached-window
    paths before the normal application path.
-2. `initializeAppModules()` assembles `AppBootConfig` and calls `setBootConfig()`;
+3. `initializeAppModules()` assembles `AppBootConfig` and calls `setBootConfig()`;
    feature modules not needed for first paint remain on the deferred idle path.
-3. The normal native path hydrates the storage bridge before rendering because
+4. The normal native path hydrates the storage bridge before rendering because
    session, first-run, and theme state must exist on the first React read.
-4. Platform-specific request, fetch, vision, voice, and desktop bridges are
+5. Platform-specific request, fetch, vision, voice, and desktop bridges are
    installed in their required order.
-5. React mounts the `@elizaos/ui` application, deferred modules are scheduled,
+6. React mounts the `@elizaos/ui` application, deferred modules are scheduled,
    and `initializePlatform()` completes the remaining lifecycle integration.
 
 ## Commands

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -67,17 +67,16 @@ App identity lives in `app.config.ts` (`envPrefix: "ELIZA"`); copy that file to
 white-label a new app. Runtime/build env vars use the `ELIZA_` prefix. See `AGENTS.md`
 for the full env var table; `.env.example` documents the build-time `VITE_*` flags.
 
-## Launch Surface
+## Launch surfaces
 
-All boot/launch surfaces are black `#000000` (`DEFAULT_BACKGROUND_COLOR`, the
-base field under the home ShaderBackground's orange ember glow): the native
-splashes (`capacitor.config.ts`, Android launch resources, iOS
-`LaunchScreen.storyboard`) and the persistent host-chrome surfaces
-(`index.html` FOUC background, `<meta name="theme-color">` / manifest colors
-via `app.config.ts`, the renderer root CSS). The persistent surfaces stay
-visible under the app (iOS home-indicator safe-area, overscroll), so they
-must equal the default home background base for bleed-through to be
-invisible — and boot never paints orange. The brand accent stays `#FF5800`.
+The native and agent-app launch surfaces remain black `#000000`
+(`DEFAULT_BACKGROUND_COLOR`, the base field under the app's orange ember
+glow). The shared HTML shell classifies approved marketing hosts before its
+FOUC styles parse and overrides their launch background, foreground,
+`color-scheme`, and `theme-color` to the landing page's warm white `#fdfaf7`.
+This keeps `eliza.app` visually continuous while its marketing renderer loads
+without changing desktop, mobile, or `cloud.eliza.app` app chrome. The brand
+accent remains `#FF5800`.
 
 ## License
 

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -262,11 +262,64 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/brand/favicons/apple-touch-icon.png" />
   <link rel="manifest" href="/site.webmanifest" />
   <script>
-    // The app has one curated dark appearance. Apply it before first paint so
-    // persisted legacy values and OS color-scheme changes cannot flash white.
+    // One bundle serves both the dark agent app and the light public marketing
+    // pages. Seed the marketing launch surface before the inline FOUC CSS is
+    // parsed so #root cannot paint the app's black fallback while the public
+    // renderer and its lazy landing-page chunk are still downloading.
+    (() => {
+      const marketingHostnames = [
+        "eliza.app",
+        "www.eliza.app",
+        "staging.eliza.app",
+        "elizacloud.ai",
+        "www.elizacloud.ai",
+        "dev.elizacloud.ai",
+        "b.eliza.app",
+        "eliza-app-b.pages.dev",
+      ];
+      const hostname = (location.hostname || "").toLowerCase().replace(/\.$/, "");
+      if (marketingHostnames.indexOf(hostname) === -1) return;
+
+      const root = document.documentElement;
+      root.setAttribute("data-public-marketing", "true");
+      root.style.setProperty("--launch-bg", "#fdfaf7");
+      root.style.setProperty("--launch-foreground", "#000000");
+      root.style.colorScheme = "light";
+
+      const themeColor = document.querySelector('meta[name="theme-color"]');
+      const colorScheme = document.querySelector('meta[name="color-scheme"]');
+      if (themeColor) themeColor.setAttribute("content", "#fdfaf7");
+      if (colorScheme) colorScheme.setAttribute("content", "light");
+
+      // These are the only above-the-fold image requests in the desktop
+      // static hero. Start them from the HTML parse instead of waiting for
+      // the entry -> public shell -> landing-page module chain.
+      if (window.matchMedia("(min-width: 641px)").matches) {
+        for (const href of [
+          "/brand/logos/logo_white_orangebg.svg",
+          "/brand/logos/eliza_text_black.svg",
+        ]) {
+          const preload = document.createElement("link");
+          preload.rel = "preload";
+          preload.as = "image";
+          preload.href = href;
+          preload.setAttribute("fetchpriority", "high");
+          document.head.appendChild(preload);
+        }
+      }
+    })();
+  </script>
+  <script>
+    // The agent app has one curated dark appearance. Public marketing was
+    // classified above and keeps its light launch surface through first paint.
     (() => {
       try {
         const root = document.documentElement;
+        if (root.getAttribute('data-public-marketing') === 'true') {
+          root.classList.remove('dark');
+          root.setAttribute('data-theme', 'light');
+          return;
+        }
         root.classList.add('dark');
         root.style.colorScheme = 'dark';
         root.setAttribute('data-theme', 'dark');
@@ -418,28 +471,11 @@
       const shell = document.getElementById("eliza-preboot-shell");
       const root = document.getElementById("root");
       if (!shell) return;
-      // Public marketing hosts render a static landing page, not the agent
-      // app, so there is nothing to boot and the branded "Booting up…" splash
-      // would only flash dark chrome over a light page. Drop it synchronously
-      // (this script runs immediately after the element parses, before any
-      // paint) and let the page's own background show. Hostnames mirror the
-      // marketing + legacy-marketing roles in
-      // packages/shared/src/elizacloud/domain-contract.ts.
-      const MARKETING_HOSTNAMES = [
-        "eliza.app",
-        "www.eliza.app",
-        "staging.eliza.app",
-        "elizacloud.ai",
-        "www.elizacloud.ai",
-        "dev.elizacloud.ai",
-        "b.eliza.app",
-        "eliza-app-b.pages.dev",
-      ];
-      const hostname = (location.hostname || "").toLowerCase().replace(/\.$/, "");
-      if (MARKETING_HOSTNAMES.indexOf(hostname) !== -1) {
+      // The head classified public marketing before any CSS could paint. Drop
+      // the agent-branded boot shell synchronously and leave the already-white
+      // root visible until the static hero commits.
+      if (document.documentElement.getAttribute("data-public-marketing") === "true") {
         shell.remove();
-        document.documentElement.style.background = "#fdfaf7";
-        document.body.style.background = "#fdfaf7";
         return;
       }
       if (!root || typeof MutationObserver !== "function") return;

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -274,6 +274,7 @@
         "elizacloud.ai",
         "www.elizacloud.ai",
         "dev.elizacloud.ai",
+        "staging.elizacloud.ai",
         "b.eliza.app",
         "eliza-app-b.pages.dev",
       ];

--- a/packages/app/scripts/verify-chunk-safety.mjs
+++ b/packages/app/scripts/verify-chunk-safety.mjs
@@ -228,6 +228,36 @@ if (entryClosure) {
   );
 }
 
+// The marketing homepage lazy-loads its WebGL background after useful content
+// renders. React Three Fiber and wallet providers both consume the local
+// useSyncExternalStore shim; without an explicit neutral chunk assignment,
+// Rollup can fold that shared shim into vendor-crypto and make the decorative
+// shader fetch the entire wallet graph. Keep crypto off this visual-only path.
+const shaderChunks = files.filter((file) =>
+  /^ShaderBackground-[^.]+\.js$/.test(file),
+);
+const shaderCryptoImports = shaderChunks.filter((file) =>
+  /from["']\.\/vendor-crypto-[^"']+\.js["']/.test(
+    readFileSync(path.join(distAssets, file), "utf8"),
+  ),
+);
+if (shaderCryptoImports.length > 0) {
+  console.error(
+    "[verify-chunk-safety] FAIL: the marketing shader statically imports vendor-crypto:",
+  );
+  for (const file of shaderCryptoImports) console.error(`  - ${file}`);
+  console.error(
+    "\nPin shared browser shims to runtime-shims so the decorative homepage\n" +
+      "background never downloads wallet/crypto code.",
+  );
+  process.exit(1);
+}
+if (shaderChunks.length > 0) {
+  console.log(
+    `[verify-chunk-safety] OK: ${shaderChunks.length} marketing shader chunk(s) do not import vendor-crypto.`,
+  );
+}
+
 // ── Web SPA base regression guard ──
 // build:web sets ELIZA_WEB_ABSOLUTE_BASE=1 → Vite base "/". A relative base
 // ("./assets/…") boots fine at depth-1 routes (/, /login) but 404s its bundle

--- a/packages/app/src/entry.ts
+++ b/packages/app/src/entry.ts
@@ -4,7 +4,10 @@
  * desktop, harness, and agent-app route retains the established main entry.
  */
 
-import { shouldUsePublicWebEntry } from "./web-entry-policy";
+import {
+  shouldUseMarketingHomeEntry,
+  shouldUsePublicWebEntry,
+} from "./web-entry-policy";
 
 declare const __ELIZA_WEB_SHELL__: boolean | undefined;
 declare const __ELIZA_CHAT_UI_HARNESS__: boolean | undefined;
@@ -24,7 +27,7 @@ function hasDesktopShellMarker(): boolean {
   );
 }
 
-const usePublicEntry = shouldUsePublicWebEntry({
+const entryDecisionInput = {
   pathname: window.location.pathname,
   hostname: window.location.hostname,
   webShellEnabled: __ELIZA_WEB_SHELL__ === true,
@@ -33,11 +36,16 @@ const usePublicEntry = shouldUsePublicWebEntry({
   forceApexConsole:
     import.meta.env?.DEV === true &&
     import.meta.env?.VITE_FORCE_APEX_CONSOLE === "true",
-});
+};
 
-const rendererEntry = usePublicEntry
-  ? import("./public-web-entry")
-  : import("./main");
+const useMarketingHomeEntry = shouldUseMarketingHomeEntry(entryDecisionInput);
+const usePublicEntry = shouldUsePublicWebEntry(entryDecisionInput);
+
+const rendererEntry = useMarketingHomeEntry
+  ? import("./marketing-home-entry")
+  : usePublicEntry
+    ? import("./public-web-entry")
+    : import("./main");
 
 // error-policy:J1 renderer-entry boundary — import failures render the same
 // actionable reload card as failures inside the established main boot.

--- a/packages/app/src/marketing-home-entry.tsx
+++ b/packages/app/src/marketing-home-entry.tsx
@@ -1,0 +1,43 @@
+/**
+ * Mounts the marketing homepage without the Cloud auth/router or service-worker
+ * graphs, keeping the first useful render independent of wallet and app code.
+ */
+
+import "@elizaos/ui/styles";
+import "./renderer-build-stamp";
+
+import { ErrorBoundary } from "@elizaos/ui/components/ui/error-boundary";
+import EmbeddedHomePage from "@homepage/embedded-home";
+import * as React from "react";
+import { createRoot } from "react-dom/client";
+import { renderBootFailure } from "./boot-failure";
+
+function mountMarketingHome(): void {
+  const rootElement = document.getElementById("root");
+  if (!rootElement) throw new Error("Root element #root not found");
+  createRoot(rootElement).render(
+    <ErrorBoundary>
+      <React.StrictMode>
+        <EmbeddedHomePage />
+      </React.StrictMode>
+    </ErrorBoundary>,
+  );
+}
+
+function bootMarketingHome(): void {
+  try {
+    mountMarketingHome();
+  } catch (error) {
+    // error-policy:J1 marketing renderer boundary — preserve the established
+    // actionable recovery when the initial mount fails.
+    renderBootFailure(error);
+  }
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", bootMarketingHome, {
+    once: true,
+  });
+} else {
+  bootMarketingHome();
+}

--- a/packages/app/src/web-entry-policy.test.ts
+++ b/packages/app/src/web-entry-policy.test.ts
@@ -9,6 +9,7 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   isHostedPublicPath,
+  shouldUseMarketingHomeEntry,
   shouldUsePublicWebEntry,
 } from "./web-entry-policy";
 
@@ -92,7 +93,7 @@ function extractPolicyParamPatterns(policySource: string): RegExp[] {
 }
 
 describe("hosted public renderer entry policy", () => {
-  it("ships the selector as the HTML entry and keeps both renderers dynamic", () => {
+  it("ships the selector as the HTML entry and keeps all renderers dynamic", () => {
     const indexHtml = readFileSync(resolve(appRoot, "index.html"), "utf8");
     const entrySource = readFileSync(resolve(appRoot, "src/entry.ts"), "utf8");
     const publicEntrySource = readFileSync(
@@ -102,6 +103,7 @@ describe("hosted public renderer entry policy", () => {
 
     expect(indexHtml).toContain('src="/src/entry.ts"');
     expect(entrySource).toContain('import("./public-web-entry")');
+    expect(entrySource).toContain('import("./marketing-home-entry")');
     expect(entrySource).toContain('import("./main")');
     expect(publicEntrySource).not.toMatch(/from\s+["']\.\/main["']/);
     expect(publicEntrySource).toContain('import("./main")');
@@ -137,8 +139,48 @@ describe("hosted public renderer entry policy", () => {
       true,
     );
     expect(
+      shouldUseMarketingHomeEntry({ ...common, hostname: "eliza.app" }),
+    ).toBe(true);
+    expect(
       shouldUsePublicWebEntry({ ...common, hostname: "cloud.eliza.app" }),
     ).toBe(false);
+    expect(
+      shouldUseMarketingHomeEntry({ ...common, hostname: "cloud.eliza.app" }),
+    ).toBe(false);
+  });
+
+  it("keeps auth routes and forced apex console out of the marketing-only entry", () => {
+    const common = {
+      hostname: "eliza.app",
+      webShellEnabled: true,
+      chatHarnessEnabled: false,
+      desktopShell: false,
+      forceApexConsole: false,
+    };
+    expect(shouldUseMarketingHomeEntry({ ...common, pathname: "/login" })).toBe(
+      false,
+    );
+    expect(
+      shouldUseMarketingHomeEntry({
+        ...common,
+        hostname: "cloud.eliza.app",
+        pathname: "/",
+        forceApexConsole: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps the marketing entry free of auth-router and service-worker startup", () => {
+    const marketingEntrySource = readFileSync(
+      resolve(appRoot, "src/marketing-home-entry.tsx"),
+      "utf8",
+    );
+    expect(marketingEntrySource).toContain(
+      'import EmbeddedHomePage from "@homepage/embedded-home"',
+    );
+    expect(marketingEntrySource).not.toContain("CloudRouterShell");
+    expect(marketingEntrySource).not.toContain("registerPublicCloudSurfaces");
+    expect(marketingEntrySource).not.toContain("registerViewServiceWorker");
   });
 
   it("never bypasses the established desktop, disabled-shell, or harness boot", () => {

--- a/packages/app/src/web-entry-policy.ts
+++ b/packages/app/src/web-entry-policy.ts
@@ -61,6 +61,22 @@ export function isHostedPublicPath(pathname: string): boolean {
   );
 }
 
+/** Whether the URL can use the marketing-only root without the auth router. */
+export function shouldUseMarketingHomeEntry(
+  input: WebEntryDecisionInput,
+): boolean {
+  if (
+    !input.webShellEnabled ||
+    input.chatHarnessEnabled ||
+    input.desktopShell ||
+    normalizePathname(input.pathname) !== "/"
+  ) {
+    return false;
+  }
+  const role = classifyElizaHostname(input.hostname).role;
+  return role === "marketing" || role === "legacy-marketing";
+}
+
 /** Decide which renderer entry may execute before any application modules load. */
 export function shouldUsePublicWebEntry(input: WebEntryDecisionInput): boolean {
   if (
@@ -73,6 +89,5 @@ export function shouldUsePublicWebEntry(input: WebEntryDecisionInput): boolean {
   if (isHostedPublicPath(input.pathname)) return true;
   if (normalizePathname(input.pathname) !== "/") return false;
   if (input.forceApexConsole) return true;
-  const role = classifyElizaHostname(input.hostname).role;
-  return role === "marketing" || role === "legacy-marketing";
+  return shouldUseMarketingHomeEntry(input);
 }

--- a/packages/app/test/brand-surface.test.ts
+++ b/packages/app/test/brand-surface.test.ts
@@ -36,6 +36,7 @@ const appCorePlatformsRoot = join(root, "..", "app-core", "platforms");
 const BRAND_ORANGE = "#FF5800";
 const LAUNCH_BLACK = "#000000";
 const LAUNCH_FOREGROUND = "#fdfaf7";
+const PUBLIC_MARKETING_WHITE = "#fdfaf7";
 const SPLASH_BLACK = "#000000";
 const SPLASH_BLACK_RGB = [0, 0, 0];
 const ANDROID_SPLASH_TEMPLATE_FILES = [
@@ -202,6 +203,37 @@ describe("brand surfaces", () => {
     expect(html).not.toMatch(/var\(--bg,\s*#FF5800\)/);
   });
 
+  it("seeds public marketing hosts with a white first paint before the dark app theme", () => {
+    const html = read("index.html");
+    const marketingSeed = html.indexOf(
+      'root.setAttribute("data-public-marketing", "true")',
+    );
+    const foucStyles = html.indexOf("/* FOUC guard");
+
+    expect(marketingSeed).toBeGreaterThan(-1);
+    expect(marketingSeed).toBeLessThan(foucStyles);
+    expect(html).toContain(
+      `root.style.setProperty("--launch-bg", "${PUBLIC_MARKETING_WHITE}")`,
+    );
+    expect(html).toContain(
+      `themeColor.setAttribute("content", "${PUBLIC_MARKETING_WHITE}")`,
+    );
+    expect(html).toContain(
+      "root.getAttribute('data-public-marketing') === 'true'",
+    );
+    expect(html).toContain(
+      'document.documentElement.getAttribute("data-public-marketing") === "true"',
+    );
+  });
+
+  it("preloads the above-the-fold desktop marketing marks from the document head", () => {
+    const html = read("index.html");
+    expect(html).toContain('window.matchMedia("(min-width: 641px)").matches');
+    expect(html).toContain('"/brand/logos/logo_white_orangebg.svg"');
+    expect(html).toContain('"/brand/logos/eliza_text_black.svg"');
+    expect(html).toContain('preload.setAttribute("fetchpriority", "high")');
+  });
+
   it("keeps the branded preboot status visible until React takes over", () => {
     const html = read("index.html");
     expect(html).toContain('class="eliza-preboot-shell__mark"');
@@ -218,9 +250,7 @@ describe("brand surfaces", () => {
     const html = read("index.html");
     expect(html).toMatch(/<div id="root"><\/div>/);
     expect(html).toMatch(/<div id="eliza-preboot-shell"/);
-    expect(html).toMatch(
-      /\.eliza-preboot-shell\s*\{[^}]*position:\s*fixed/s,
-    );
+    expect(html).toMatch(/\.eliza-preboot-shell\s*\{[^}]*position:\s*fixed/s);
     expect(html).toContain("new MutationObserver");
     expect(html).toContain("hasMeaningfulContent");
   });

--- a/packages/app/test/brand-surface.test.ts
+++ b/packages/app/test/brand-surface.test.ts
@@ -4,15 +4,12 @@
  * color for their lifetime, so the user never sees a foreign color — or a
  * glowing orange band — behind or after the home background paints.
  *
- * Three colors, kept deliberately separate (issue #9565):
- *  - LAUNCH_BLACK (#000000) — every PERSISTENT host-chrome surface: the
- *    index.html FOUC background (html/body/#root stays the page background
- *    under the app forever — it bleeds through the iOS home-indicator
- *    safe-area and overscroll zones), the PWA <meta theme-color> and manifest
- *    colors (iOS standalone paints the home-indicator inset with it). This
- *    MUST equal DEFAULT_BACKGROUND_COLOR (packages/ui/src/state/
- *    ui-preferences.ts) — the brand-orange field of the default home
- *    ShaderBackground — so any bleed-through is invisible against the app.
+ * Four colors, kept deliberately separate (issue #9565):
+ *  - LAUNCH_BLACK (#000000) — the default PERSISTENT agent-app host chrome.
+ *    It MUST equal DEFAULT_BACKGROUND_COLOR (packages/ui/src/state/
+ *    ui-preferences.ts) so safe-area and overscroll bleed-through is invisible.
+ *  - PUBLIC_MARKETING_WHITE (#fdfaf7) — the synchronous host-specific launch
+ *    override for public landing pages; it matches the landing page background.
  *  - SPLASH_BLACK (#000000) — native boot splash surfaces (capacitor splash,
  *    Android splash resources, iOS LaunchScreen). Currently the same hex as
  *    LAUNCH_BLACK, but kept a separate constant: splash tracks the boot
@@ -26,6 +23,10 @@
  */
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import {
+  ELIZA_DOMAIN_CONTRACTS,
+  LEGACY_ELIZA_DOMAIN_CONTRACTS,
+} from "@elizaos/shared/elizacloud/domain-contract";
 import sharp from "sharp";
 import { describe, expect, it } from "vitest";
 
@@ -224,6 +225,23 @@ describe("brand surfaces", () => {
     expect(html).toContain(
       'document.documentElement.getAttribute("data-public-marketing") === "true"',
     );
+
+    const hostnameBlock = html.match(
+      /const marketingHostnames = \[([\s\S]*?)\];/,
+    );
+    expect(hostnameBlock).not.toBeNull();
+    const inlineHostnames = [
+      ...(hostnameBlock?.[1].matchAll(/"([^"]+)"/g) ?? []),
+    ].map((match) => match[1]);
+    const canonicalHostname = (origin: string) => new URL(origin).hostname;
+    const expectedHostnames = [
+      canonicalHostname(ELIZA_DOMAIN_CONTRACTS.production.marketingOrigin),
+      `www.${canonicalHostname(ELIZA_DOMAIN_CONTRACTS.production.marketingOrigin)}`,
+      canonicalHostname(ELIZA_DOMAIN_CONTRACTS.staging.marketingOrigin),
+      ...LEGACY_ELIZA_DOMAIN_CONTRACTS.production.marketingHostnames,
+      ...LEGACY_ELIZA_DOMAIN_CONTRACTS.staging.marketingHostnames,
+    ];
+    expect(new Set(inlineHostnames)).toEqual(new Set(expectedHostnames));
   });
 
   it("preloads the above-the-fold desktop marketing marks from the document head", () => {

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1543,7 +1543,8 @@ function resolveManualChunk(id: string): string | undefined {
   if (
     normalizedId.includes("vite/preload-helper") ||
     normalizedId.includes("native-stub:") ||
-    normalizedId.includes(BUFFER_ESM_SHIM_ID)
+    normalizedId.includes(BUFFER_ESM_SHIM_ID) ||
+    normalizedId.includes("/src/shims/use-sync-external-store")
   ) {
     return "runtime-shims";
   }

--- a/packages/homepage/AGENTS.md
+++ b/packages/homepage/AGENTS.md
@@ -8,8 +8,9 @@ root and deployable artifact for both `eliza.app` and `cloud.eliza.app`.
 ## Purpose / role
 
 This package owns the public landing/download components, their assets, and
-focused source and visual regression tests. `packages/app/src/main.tsx` imports
-the approved `embedded-home` and `embedded-downloads` entrypoints, and
+focused source and visual regression tests. The app renderer selector imports
+the approved `embedded-home` root through its lightweight marketing entry and
+the remaining public shell imports `embedded-downloads`; then
 `packages/app/scripts/sync-homepage-assets.mjs` materializes the required public
 files into the unified app build. The older route harness remains test-only so
 its component coverage and reviewed visual baselines stay available; it is not

--- a/packages/homepage/CLAUDE.md
+++ b/packages/homepage/CLAUDE.md
@@ -8,8 +8,9 @@ root and deployable artifact for both `eliza.app` and `cloud.eliza.app`.
 ## Purpose / role
 
 This package owns the public landing/download components, their assets, and
-focused source and visual regression tests. `packages/app/src/main.tsx` imports
-the approved `embedded-home` and `embedded-downloads` entrypoints, and
+focused source and visual regression tests. The app renderer selector imports
+the approved `embedded-home` root through its lightweight marketing entry and
+the remaining public shell imports `embedded-downloads`; then
 `packages/app/scripts/sync-homepage-assets.mjs` materializes the required public
 files into the unified app build. The older route harness remains test-only so
 its component coverage and reviewed visual baselines stay available; it is not

--- a/packages/homepage/src/pages/landing.tsx
+++ b/packages/homepage/src/pages/landing.tsx
@@ -43,6 +43,28 @@ const ShaderBackground = lazy(
   () => import("@/components/ShaderBackground/ShaderBackground"),
 );
 
+function DeferredShaderBackground(): React.JSX.Element | null {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let secondFrame = 0;
+    const firstFrame = window.requestAnimationFrame(() => {
+      secondFrame = window.requestAnimationFrame(() => setReady(true));
+    });
+    return () => {
+      window.cancelAnimationFrame(firstFrame);
+      if (secondFrame !== 0) window.cancelAnimationFrame(secondFrame);
+    };
+  }, []);
+
+  if (!ready) return null;
+  return (
+    <Suspense fallback={null}>
+      <ShaderBackground />
+    </Suspense>
+  );
+}
+
 type DemoCard = LandingDemoCard;
 type DemoStep = LandingDemoStep;
 
@@ -691,9 +713,7 @@ export default function LandingPage() {
           });
   return (
     <div className="landing-page theme-app">
-      <Suspense fallback={null}>
-        <ShaderBackground />
-      </Suspense>
+      <DeferredShaderBackground />
       <div aria-hidden="true" className="landing-grain" />
       <header className="landing-header">
         <a

--- a/packages/homepage/tests/smoke.node.test.mjs
+++ b/packages/homepage/tests/smoke.node.test.mjs
@@ -88,6 +88,16 @@ test("landing stays a static surface with no animation-framework dependencies", 
     /const ShaderBackground = lazy\(/,
     "the shader background must stay behind a lazy boundary",
   );
+  assert.match(
+    landing,
+    /function DeferredShaderBackground\(\)/,
+    "the shader must not compete with the first useful hero paint",
+  );
+  assert.match(
+    landing,
+    /requestAnimationFrame\(\(\) => setReady\(true\)\)/,
+    "the shader import must begin only after the static hero has painted",
+  );
   for (const script of ["dev", "build", "preview", "deploy:production"]) {
     assert.equal(packageJson.scripts[script], undefined);
   }


### PR DESCRIPTION
# Relates to

Closes #20868.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change from the attached before/after evidence, walkthrough, and logs.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `OpenAI/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `N/A - no contribution skill used`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync: 356/356 Turbo tasks plus all repository audits.

# Risks

Low. The optimized entry is selected only for the marketing root on the public/legacy web hosts. Desktop, native, cloud-console, harness, auth, and non-root public routes continue through their established entry paths. Hostname-set equality tests prevent the document prepaint policy from drifting from the canonical domain contract.

# Background

## What does this PR do?

- Paints `eliza.app` and the documented marketing aliases with the homepage warm-white surface synchronously in the HTML head, including light color-scheme and theme-color metadata.
- Gives the marketing root a minimal React entry that skips the public auth router, service-worker startup, cloud shell registration, and crypto vendor graph.
- Defers the Three.js shader until after two animation frames so the static hero can paint first.
- Preloads only the two above-the-fold desktop marks; mobile avoids those preloads.
- Adds entry-policy, hostname-contract, chunk-safety, and homepage smoke coverage.

## What kind of change is this?

Bug fix and frontend performance improvement; no public API or persistence change.

# Documentation changes needed?

The app and homepage package guides and README were updated to document the marketing-only entry and its white first-paint contract.

# Testing

## Where should a reviewer start?

Start with `packages/app/index.html`, `packages/app/src/entry.ts`, `packages/app/src/marketing-home-entry.tsx`, and `packages/homepage/src/pages/landing.tsx`. The attached report records colors, console diagnostics, and the request waterfall for production-before and reviewed-after runs with the entry script delayed by 1.5 seconds.

## Detailed testing steps

1. Load `https://eliza.app/` in a fresh context with the entry script delayed.
2. Before JavaScript executes, verify `html` and `#root` are `rgb(253, 250, 247)`, theme color is `#fdfaf7`, and color scheme is light.
3. Let the page settle and verify the marketing hero renders on desktop and mobile.
4. Inspect the request waterfall: the marketing critical path must not include `public-web-entry`, `CloudRouterShell`, `sw-registration`, or `vendor-crypto`; the shader/Three chunks start after the hero module.
5. Verify a non-marketing/app-host root still uses the established application boot path.

Commands completed:

- `bun install`
- `bun run verify` — 356/356 Turbo tasks passed; repository audits passed
- focused app/homepage tests — 51 passed
- `bun run --cwd packages/app build:web` — chunk/viewport guards passed
- `bun run --cwd packages/app audit:app` — 219/219 captures passed; broken=0, needs-work=0
- packaged OCR — 216 views; broken=0
- exact-head throttled module-chain replay — reviewed heading 1.44s vs production baseline 1.82s (about 21% faster in the comparable harness; repeated runs measured 21-26%)

# Evidence Gate

<!-- evidence-head:117d1042cfd11cf07c9f5af20d07951c36627a5f -->

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20894-before-desktop-mobile.jpg)
<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20894-after-desktop-mobile.jpg)
<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20894-first-paint-walkthrough.mp4
<!-- evidence-row:backend-logs -->
- [ ] N/A - static frontend path; no backend request participates in the affected flow
<!-- evidence-row:frontend-logs -->
- [x] [20894-first-paint-report.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20894-first-paint-report.json)
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, action, provider, prompt, or model behavior changed
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain artifact changed
<!-- evidence-row:ocr-review -->
- [x] [20894-ocr-triage.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20894-ocr-triage.json)

# Evidence Details

## Real LLM-call trajectory

N/A - no agent, action, provider, prompt, or model behavior changed.

## Backend + frontend logs

Backend: N/A - static frontend path only.

Frontend: the attached JSON contains the production and reviewed console diagnostics, exact build IDs, computed prepaint colors, and full request waterfalls for desktop and mobile.

## Screenshots (before / after) + video walkthrough

Evidence rows above are populated with release assets by the repository evidence helper immediately after PR creation.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice path changed.

## Known gaps / failures

- GitHub Project status could not be read or updated because the authenticated token lacks `read:project`; no OAuth scope was expanded for this PR.
- The production-before Playwright console reports service-worker registration blocked by the isolated capture context. This is intentional capture isolation and does not affect the page/network comparison.
- After the full 219-view audit, the final rebase incorporated an unrelated already-merged browser cron-parser shim. The affected marketing files and rendered behavior did not change; the exact PR head is rebuilt and recaptured separately.

# Deploy Notes

No manual migration or configuration is required. The existing develop-push Cloudflare deployment should publish the renderer; production must be verified by renderer manifest, HTML metadata, delayed-entry prepaint, and live request waterfall before closing the issue.

AI provider/model: OpenAI / gpt-5.6-sol
Client / agent tooling: Codex desktop
Contribution skill revision: N/A - no repository contribution skill used
Attribution status: self-reported
— [codex-eliza-app-first-paint]
<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5.6-sol","client":"Codex desktop","skill_revision":"N/A - no repository contribution skill used","attribution_status":"self-reported","lane":"codex-eliza-app-first-paint"} -->


