### PR TITLE
feat(cloud): protect production Telegram edge activation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -96,7 +96,12 @@ Representative examples:
   of the tracked service `railway.toml`; follows the returned deployment id to
   success; proves that exact id remains active around the public probes; and
   verifies the applied Dockerfile/health manifest, live health, and canonical
-  cloud/agent fallback routing pair. It also sends a headerless `GET` to the
+  cloud/agent fallback routing pair. A successful release publishes a
+  source/environment/deployment-id receipt; the protected edge-activation
+  workflow downloads that exact run receipt, revalidates the active Railway
+  deployment before and after its probes and edge mutation, and shares this
+  workflow's per-environment concurrency key so canonical releases cannot race
+  a cutover. It also sends a headerless `GET` to the
   dedicated `/ready/forwarder-auth/eliza-app` contract and requires the exact
   enforced-gate 401 response before reasserting the active deployment. A
   disabled secret or mismatched forwarded project produces a distinct non-401

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -100,8 +100,10 @@ Representative examples:
   source/environment/deployment-id receipt; the protected edge-activation
   workflow downloads that exact run receipt, revalidates the active Railway
   deployment before and after its probes and edge mutation, and shares this
-  workflow's per-environment concurrency key so canonical releases cannot race
-  a cutover. It also sends a headerless `GET` to the
+  workflow's per-environment concurrency key so gateway releases, canonical
+  Cloudflare releases, and cutovers cannot race. Protected-environment approval
+  completes before any of those jobs enters the shared mutation lock. It also
+  sends a headerless `GET` to the
   dedicated `/ready/forwarder-auth/eliza-app` contract and requires the exact
   enforced-gate 401 response before reasserting the active deployment. A
   disabled secret or mismatched forwarded project produces a distinct non-401

--- a/.github/workflows/activate-personal-shared-telegram-edge.yml
+++ b/.github/workflows/activate-personal-shared-telegram-edge.yml
@@ -3,8 +3,16 @@ name: Activate Personal Shared Telegram Edge
 on:
   workflow_dispatch:
     inputs:
+      environment:
+        description: Protected environment whose edge gate will be changed
+        required: true
+        default: staging
+        type: choice
+        options:
+          - staging
+          - production
       expected_source_sha:
-        description: Exact currently served staging Worker source SHA
+        description: Exact currently served Worker source SHA
         required: true
         type: string
       enabled:
@@ -12,26 +20,41 @@ on:
         required: true
         default: false
         type: boolean
+      production_approval_comment_url:
+        description: NubsCarson approval comment bound to production source and state; blank for staging
+        required: false
+        type: string
 
 permissions:
   actions: read
   contents: read
+  issues: read
 
 concurrency:
-  group: activate-personal-shared-telegram-edge-staging
+  group: deploy-gateway-webhook-${{ inputs.environment == 'production' && 'production' || 'staging' }}
   cancel-in-progress: false
 
 jobs:
   cutover:
-    name: Cut over Personal Shared Telegram edge
+    name: Cut over Personal Shared Telegram edge (${{ inputs.environment == 'production' && 'production' || 'staging' }})
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    environment: staging
+    environment: ${{ inputs.environment == 'production' && 'production' || 'staging' }}
     env:
+      REQUESTED_ENVIRONMENT: ${{ inputs.environment }}
+      TARGET_ENVIRONMENT: ${{ inputs.environment == 'production' && 'production' || 'staging' }}
+      EXPECTED_BRANCH: ${{ inputs.environment == 'production' && 'main' || 'develop' }}
+      EDGE_SECRET_NAME: ${{ inputs.environment == 'production' && 'PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED' || 'PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED' }}
       EXPECTED_SOURCE_SHA: ${{ inputs.expected_source_sha }}
       DESIRED_ENABLED: ${{ inputs.enabled && 'true' || 'false' }}
-      HEALTH_URL: https://api-staging.eliza.app/api/health
-      GATEWAY_URL: https://gateway-webhook-stg-staging.up.railway.app
+      PRODUCTION_APPROVAL_COMMENT_URL: ${{ inputs.production_approval_comment_url }}
+      HEALTH_URL: ${{ inputs.environment == 'production' && 'https://api.eliza.app/api/health' || 'https://api-staging.eliza.app/api/health' }}
+      GATEWAY_URL: ${{ inputs.environment == 'production' && 'https://gateway-webhook-production.up.railway.app' || 'https://gateway-webhook-stg-staging.up.railway.app' }}
+      EXPECTED_GATEWAY_SERVICE_NAME: ${{ inputs.environment == 'production' && 'gateway-webhook' || 'gateway-webhook-stg' }}
+      RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+      RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+      RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID_GATEWAY_WEBHOOK }}
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       GH_TOKEN: ${{ github.token }}
@@ -45,20 +68,73 @@ jobs:
         with:
           bun-version: "1.3.14"
 
+      - name: Validate protected target and production approval
+        run: |
+          set -euo pipefail
+
+          require_exact() {
+            local name="$1"
+            local actual="$2"
+            local expected="$3"
+            if [ "$actual" != "$expected" ]; then
+              echo "::error::$name does not match the protected $TARGET_ENVIRONMENT cutover contract"
+              exit 1
+            fi
+          }
+
+          require_exact REQUESTED_ENVIRONMENT "$REQUESTED_ENVIRONMENT" "$TARGET_ENVIRONMENT"
+          case "$TARGET_ENVIRONMENT" in
+            staging)
+              require_exact EXPECTED_BRANCH "$EXPECTED_BRANCH" develop
+              require_exact GITHUB_REF "$GITHUB_REF" refs/heads/develop
+              require_exact EDGE_SECRET_NAME "$EDGE_SECRET_NAME" PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED
+              require_exact HEALTH_URL "$HEALTH_URL" https://api-staging.eliza.app/api/health
+              require_exact GATEWAY_URL "$GATEWAY_URL" https://gateway-webhook-stg-staging.up.railway.app
+              if [ -n "$PRODUCTION_APPROVAL_COMMENT_URL" ]; then
+                echo "::error::Production approval must not be supplied to a staging cutover"
+                exit 1
+              fi
+              ;;
+            production)
+              require_exact EXPECTED_BRANCH "$EXPECTED_BRANCH" main
+              require_exact GITHUB_REF "$GITHUB_REF" refs/heads/main
+              require_exact EDGE_SECRET_NAME "$EDGE_SECRET_NAME" PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED
+              require_exact HEALTH_URL "$HEALTH_URL" https://api.eliza.app/api/health
+              require_exact GATEWAY_URL "$GATEWAY_URL" https://gateway-webhook-production.up.railway.app
+
+              if [[ ! "$PRODUCTION_APPROVAL_COMMENT_URL" =~ ^https://github\.com/elizaOS/eliza/(issues|pull)/[0-9]+#issuecomment-([0-9]+)$ ]]; then
+                echo "::error::Production cutover requires a canonical NubsCarson approval comment URL"
+                exit 1
+              fi
+              approval_comment_id="${BASH_REMATCH[2]}"
+              approval="$(mktemp)"
+              gh api "repos/$GITHUB_REPOSITORY/issues/comments/$approval_comment_id" > "$approval"
+              expected_approval="[production-telegram-edge] APPROVE source=$EXPECTED_SOURCE_SHA enabled=$DESIRED_ENABLED"
+              if ! jq -e --arg expected "$expected_approval" \
+                '.user.login == "NubsCarson" and (.body | split("\n") | index($expected) != null)' \
+                "$approval" >/dev/null; then
+                rm -f "$approval"
+                echo "::error::Production approval is not authored by NubsCarson and bound to the exact source and desired state"
+                exit 1
+              fi
+              rm -f "$approval"
+              ;;
+            *)
+              echo "::error::Unsupported protected environment"
+              exit 1
+              ;;
+          esac
+
       - name: Validate exact served Worker source
         run: |
           set -euo pipefail
-          if [ "$GITHUB_REF" != "refs/heads/develop" ]; then
-            echo "::error::Staging edge cutover must run from refs/heads/develop"
-            exit 1
-          fi
           if [[ ! "$EXPECTED_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
             echo "::error::expected_source_sha must be an exact lowercase commit SHA"
             exit 1
           fi
           git cat-file -e "$EXPECTED_SOURCE_SHA^{commit}"
           if ! git merge-base --is-ancestor "$EXPECTED_SOURCE_SHA" "$GITHUB_SHA"; then
-            echo "::error::Expected Worker source is not in canonical develop history"
+            echo "::error::Expected Worker source is not in canonical $EXPECTED_BRANCH history"
             exit 1
           fi
 
@@ -67,28 +143,76 @@ jobs:
             code="$(curl -sS -o "$health" -w '%{http_code}' -m 20 "$HEALTH_URL" || echo '000')"
             if [ "$code" = "200" ] && jq -e \
               --arg sha "$EXPECTED_SOURCE_SHA" \
+              --arg environment "$TARGET_ENVIRONMENT" \
               '.status == "ok" and
-               .environment == "staging" and
+               .environment == $environment and
                .commit == $sha and
                (.personalSharedTelegramEdge.enabled | type == "boolean")' \
               "$health" >/dev/null; then
               rm -f "$health"
-              echo "Staging Worker serves the exact requested source."
+              echo "$TARGET_ENVIRONMENT Worker serves the exact requested source."
               exit 0
             fi
             [ "$attempt" -lt 6 ] && sleep 10
           done
           rm -f "$health"
-          echo "::error::Staging Worker does not serve the exact requested source and edge beacon"
+          echo "::error::$TARGET_ENVIRONMENT Worker does not serve the exact requested source and edge beacon"
           exit 1
 
-      - name: Verify exact-source gateway before enable
+      - name: Install pinned Railway CLI
+        if: inputs.enabled == true
+        shell: bash
+        run: |
+          set -euo pipefail
+          cli_root="$RUNNER_TEMP/railway-cli"
+          archive="$RUNNER_TEMP/railway-v5.38.0.tar.gz"
+          mkdir -p "$cli_root"
+          curl \
+            --fail \
+            --location \
+            --silent \
+            --show-error \
+            --retry 3 \
+            --output "$archive" \
+            "https://github.com/railwayapp/cli/releases/download/v5.38.0/railway-v5.38.0-x86_64-unknown-linux-gnu.tar.gz"
+          printf '%s  %s\n' \
+            "72835c48a710c48c4542141bf12264823cf3a029b514f9e27994096c036c539e" \
+            "$archive" | sha256sum --check --status
+          tar -xzf "$archive" -C "$cli_root" railway
+          chmod 0755 "$cli_root/railway"
+          echo "$cli_root" >> "$GITHUB_PATH"
+          "$cli_root/railway" --version | grep -F "railway 5.38.0"
+
+      - name: Verify exact active gateway before enable
+        id: gateway_proof
         if: inputs.enabled == true
         run: |
           set -euo pipefail
+          required_settings=(
+            EXPECTED_GATEWAY_SERVICE_NAME
+            RAILWAY_PROJECT_ID
+            RAILWAY_ENVIRONMENT_ID
+            RAILWAY_SERVICE_ID
+            RAILWAY_TOKEN
+          )
+          for name in "${required_settings[@]}"; do
+            value="${!name:-}"
+            if [ -z "${value//[[:space:]]/}" ]; then
+              echo "::error::Missing protected $TARGET_ENVIRONMENT gateway setting name: $name"
+              exit 1
+            fi
+          done
+          for name in RAILWAY_PROJECT_ID RAILWAY_ENVIRONMENT_ID RAILWAY_SERVICE_ID; do
+            value="${!name}"
+            if [[ ! "$value" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+              echo "::error::$name must be a Railway UUID on the protected $TARGET_ENVIRONMENT environment"
+              exit 1
+            fi
+          done
+
           gateway_run="$(mktemp)"
           gh api \
-            "repos/$GITHUB_REPOSITORY/actions/workflows/deploy-gateway-webhook.yml/runs?branch=develop&event=workflow_dispatch&per_page=1" \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/deploy-gateway-webhook.yml/runs?branch=$EXPECTED_BRANCH&event=workflow_dispatch&per_page=1" \
             > "$gateway_run"
           if ! jq -e \
             --arg sha "$EXPECTED_SOURCE_SHA" \
@@ -98,17 +222,64 @@ jobs:
              .[0].conclusion == "success"' \
             "$gateway_run" >/dev/null; then
             rm -f "$gateway_run"
-            echo "::error::Latest protected staging gateway release is not successful on the exact Worker source"
+            echo "::error::Latest protected $TARGET_ENVIRONMENT gateway release is not successful on the exact Worker source"
             exit 1
           fi
           gateway_run_id="$(jq -r '.workflow_runs[0].id' "$gateway_run")"
           rm -f "$gateway_run"
 
+          receipt_dir="$RUNNER_TEMP/gateway-webhook-deployment-receipt"
+          artifact_name="gateway-webhook-deployment-$TARGET_ENVIRONMENT-$EXPECTED_SOURCE_SHA"
+          mkdir -p "$receipt_dir"
+          gh run download "$gateway_run_id" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "$artifact_name" \
+            --dir "$receipt_dir"
+          receipt="$receipt_dir/gateway-webhook-deployment.json"
+          if ! jq -e \
+            --arg sha "$EXPECTED_SOURCE_SHA" \
+            --arg environment "$TARGET_ENVIRONMENT" \
+            --arg service "$EXPECTED_GATEWAY_SERVICE_NAME" \
+            '.sourceSha == $sha and
+             .environment == $environment and
+             .service == $service and
+             (.deploymentId | type == "string" and
+              test("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"))' \
+            "$receipt" >/dev/null; then
+            echo "::error::Protected gateway deployment receipt is absent or does not match the exact source and environment"
+            exit 1
+          fi
+          gateway_deployment_id="$(jq -r '.deploymentId' "$receipt")"
+
+          active_gateway="$RUNNER_TEMP/gateway-webhook-active-deployment.json"
+          assert_active_gateway() {
+            local phase="$1"
+            railway service status \
+              --project "$RAILWAY_PROJECT_ID" \
+              --environment "$RAILWAY_ENVIRONMENT_ID" \
+              --service "$RAILWAY_SERVICE_ID" \
+              --json > "$active_gateway"
+            jq -e \
+              --arg id "$gateway_deployment_id" \
+              --arg service "$RAILWAY_SERVICE_ID" \
+              --arg name "$EXPECTED_GATEWAY_SERVICE_NAME" \
+              '.id == $service and
+               .name == $name and
+               .deploymentId == $id and
+               .status == "SUCCESS" and
+               .stopped == false' \
+              "$active_gateway" >/dev/null || {
+              echo "::error::Exact-source gateway deployment is not active $phase public verification"
+              exit 1
+            }
+          }
+
+          assert_active_gateway before
           health="$(mktemp)"
           code="$(curl -sS -o "$health" -w '%{http_code}' -m 20 "$GATEWAY_URL/health" || echo '000')"
           if [ "$code" != "200" ] || ! jq -e '.status == "healthy"' "$health" >/dev/null; then
             rm -f "$health"
-            echo "::error::Exact-source staging gateway is not healthy"
+            echo "::error::Exact-source $TARGET_ENVIRONMENT gateway is not healthy"
             exit 1
           fi
           rm -f "$health"
@@ -128,16 +299,20 @@ jobs:
             exit 1
           fi
           rm -f "$readiness"
-          echo "Protected gateway run $gateway_run_id is healthy on the exact Worker source."
+          assert_active_gateway after
+          echo "deployment_id=$gateway_deployment_id" >> "$GITHUB_OUTPUT"
+          echo "Protected gateway run $gateway_run_id has active deployment $gateway_deployment_id on the exact Worker source."
 
       - name: Apply and verify served edge state
         working-directory: packages/cloud/api
+        env:
+          EXPECTED_GATEWAY_DEPLOYMENT_ID: ${{ steps.gateway_proof.outputs.deployment_id }}
         run: |
           set -euo pipefail
 
           disable_edge() {
             node "$GITHUB_WORKSPACE/packages/cloud/scripts/ensure-worker-secret-absent.mjs" \
-              PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED --env staging >/dev/null
+              "$EDGE_SECRET_NAME" --env "$TARGET_ENVIRONMENT" >/dev/null
           }
 
           # A secret mutation can reach Cloudflare even when the CLI response is
@@ -154,11 +329,45 @@ jobs:
           trap rollback_on_unproven_exit EXIT
           trap 'exit 1' INT TERM
 
+          assert_active_gateway() {
+            local phase="$1"
+            if [ "$DESIRED_ENABLED" != "true" ]; then
+              return 0
+            fi
+            if [[ ! "$EXPECTED_GATEWAY_DEPLOYMENT_ID" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+              echo "::error::Exact active gateway deployment proof is absent"
+              return 1
+            fi
+            active_gateway="$(mktemp)"
+            railway service status \
+              --project "$RAILWAY_PROJECT_ID" \
+              --environment "$RAILWAY_ENVIRONMENT_ID" \
+              --service "$RAILWAY_SERVICE_ID" \
+              --json > "$active_gateway"
+            if ! jq -e \
+              --arg id "$EXPECTED_GATEWAY_DEPLOYMENT_ID" \
+              --arg service "$RAILWAY_SERVICE_ID" \
+              --arg name "$EXPECTED_GATEWAY_SERVICE_NAME" \
+              '.id == $service and
+               .name == $name and
+               .deploymentId == $id and
+               .status == "SUCCESS" and
+               .stopped == false' \
+              "$active_gateway" >/dev/null; then
+              rm -f "$active_gateway"
+              echo "::error::Exact-source gateway deployment is not active $phase edge mutation"
+              return 1
+            fi
+            rm -f "$active_gateway"
+          }
+
+          assert_active_gateway before
+
           if [ "$DESIRED_ENABLED" = "true" ]; then
             activation_cli_confirmed=false
             for attempt in 1 2 3; do
               if printf '%s' 'true' | bunx wrangler@4.100.0 secret put \
-                PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED --env staging; then
+                "$EDGE_SECRET_NAME" --env "$TARGET_ENVIRONMENT"; then
                 activation_cli_confirmed=true
                 break
               fi
@@ -176,13 +385,15 @@ jobs:
             code="$(curl -sS -o "$health" -w '%{http_code}' -m 20 "$HEALTH_URL" || echo '000')"
             if [ "$code" = "200" ] && jq -e \
               --arg sha "$EXPECTED_SOURCE_SHA" \
+              --arg environment "$TARGET_ENVIRONMENT" \
               --argjson enabled "$DESIRED_ENABLED" \
               '.status == "ok" and
-               .environment == "staging" and
+               .environment == $environment and
                .commit == $sha and
                .personalSharedTelegramEdge.enabled == $enabled' \
               "$health" >/dev/null; then
               rm -f "$health"
+              assert_active_gateway after
               rollback_needed=false
               echo "Personal Shared Telegram edge serves the requested state on the exact Worker source."
               exit 0
@@ -193,7 +404,7 @@ jobs:
 
           if disable_edge; then
             rollback_needed=false
-            echo "::warning::Telegram edge proof failed; staging was rolled back off"
+            echo "::warning::Telegram edge proof failed; $TARGET_ENVIRONMENT was rolled back off"
           else
             echo "::error::Telegram edge proof failed and rollback could not be confirmed"
           fi
@@ -205,8 +416,14 @@ jobs:
           {
             echo "### Personal Shared Telegram edge"
             echo
+            echo "- Environment: $TARGET_ENVIRONMENT"
             echo "- Worker source: $EXPECTED_SOURCE_SHA"
             echo "- Desired enabled state: $DESIRED_ENABLED"
             echo "- Served-state proof: passed"
-            echo "- Production: untouched"
+            echo "- Mutated binding: $EDGE_SECRET_NAME"
+            if [ "$TARGET_ENVIRONMENT" = "staging" ]; then
+              echo "- Production: untouched"
+            else
+              echo "- Production approval: $PRODUCTION_APPROVAL_COMMENT_URL"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/activate-personal-shared-telegram-edge.yml
+++ b/.github/workflows/activate-personal-shared-telegram-edge.yml
@@ -129,6 +129,7 @@ jobs:
     concurrency:
       group: cloud-cf-release-v6-${{ inputs.environment == 'production' && 'production' || 'staging' }}
       cancel-in-progress: false
+      queue: max
     env:
       REQUESTED_ENVIRONMENT: ${{ inputs.environment }}
       TARGET_ENVIRONMENT: ${{ inputs.environment == 'production' && 'production' || 'staging' }}

--- a/.github/workflows/activate-personal-shared-telegram-edge.yml
+++ b/.github/workflows/activate-personal-shared-telegram-edge.yml
@@ -129,7 +129,6 @@ jobs:
     concurrency:
       group: cloud-cf-release-v6-${{ inputs.environment == 'production' && 'production' || 'staging' }}
       cancel-in-progress: false
-      queue: max
     env:
       REQUESTED_ENVIRONMENT: ${{ inputs.environment }}
       TARGET_ENVIRONMENT: ${{ inputs.environment == 'production' && 'production' || 'staging' }}

--- a/.github/workflows/activate-personal-shared-telegram-edge.yml
+++ b/.github/workflows/activate-personal-shared-telegram-edge.yml
@@ -30,17 +30,11 @@ permissions:
   contents: read
   issues: read
 
-concurrency:
-  # Secret mutation and the full Cloudflare release must never overlap.
-  group: cloud-cf-release-v6-${{ inputs.environment == 'production' && 'production' || 'staging' }}
-  cancel-in-progress: false
-
 jobs:
-  cutover:
-    name: Cut over Personal Shared Telegram edge (${{ inputs.environment == 'production' && 'production' || 'staging' }})
+  validate-request:
+    name: Validate Personal Shared Telegram edge request
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
-    environment: ${{ inputs.environment == 'production' && 'production' || 'staging' }}
+    timeout-minutes: 2
     env:
       REQUESTED_ENVIRONMENT: ${{ inputs.environment }}
       TARGET_ENVIRONMENT: ${{ inputs.environment == 'production' && 'production' || 'staging' }}
@@ -51,24 +45,8 @@ jobs:
       PRODUCTION_APPROVAL_COMMENT_URL: ${{ inputs.production_approval_comment_url }}
       HEALTH_URL: ${{ inputs.environment == 'production' && 'https://api.eliza.app/api/health' || 'https://api-staging.eliza.app/api/health' }}
       GATEWAY_URL: ${{ inputs.environment == 'production' && 'https://gateway-webhook-production.up.railway.app' || 'https://gateway-webhook-stg-staging.up.railway.app' }}
-      EXPECTED_GATEWAY_SERVICE_NAME: ${{ inputs.environment == 'production' && 'gateway-webhook' || 'gateway-webhook-stg' }}
-      RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
-      RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
-      RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID_GATEWAY_WEBHOOK }}
-      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
-        with:
-          bun-version: "1.3.14"
-
       - name: Validate protected target and production approval
         run: |
           set -euo pipefail
@@ -126,7 +104,61 @@ jobs:
               ;;
           esac
 
-      - name: Validate exact served Worker source
+  authorize-target:
+    name: Authorize Personal Shared Telegram edge (${{ inputs.environment == 'production' && 'production' || 'staging' }})
+    needs: validate-request
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    # Approval must finish before the mutation job enters the shared release
+    # lock. Otherwise a waiting protected-environment review can block every
+    # Cloudflare or gateway release for this environment.
+    environment: ${{ inputs.environment == 'production' && 'production' || 'staging' }}
+    steps:
+      - name: Record protected-environment authorization
+        run: echo "${{ inputs.environment }} Telegram edge operation authorized"
+
+  cutover:
+    name: Cut over Personal Shared Telegram edge (${{ inputs.environment == 'production' && 'production' || 'staging' }})
+    needs: authorize-target
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment: ${{ inputs.environment == 'production' && 'production' || 'staging' }}
+    # Cloudflare releases, gateway releases, and edge mutation share one
+    # post-authorization critical section. The gateway receipt therefore
+    # cannot become stale behind our final active-deployment check.
+    concurrency:
+      group: cloud-cf-release-v6-${{ inputs.environment == 'production' && 'production' || 'staging' }}
+      cancel-in-progress: false
+    env:
+      REQUESTED_ENVIRONMENT: ${{ inputs.environment }}
+      TARGET_ENVIRONMENT: ${{ inputs.environment == 'production' && 'production' || 'staging' }}
+      EXPECTED_BRANCH: ${{ inputs.environment == 'production' && 'main' || 'develop' }}
+      EDGE_SECRET_NAME: ${{ inputs.environment == 'production' && 'PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED' || 'PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED' }}
+      EXPECTED_SOURCE_SHA: ${{ inputs.expected_source_sha }}
+      DESIRED_ENABLED: ${{ inputs.enabled && 'true' || 'false' }}
+      PRODUCTION_APPROVAL_COMMENT_URL: ${{ inputs.production_approval_comment_url }}
+      HEALTH_URL: ${{ inputs.environment == 'production' && 'https://api.eliza.app/api/health' || 'https://api-staging.eliza.app/api/health' }}
+      GATEWAY_URL: ${{ inputs.environment == 'production' && 'https://gateway-webhook-production.up.railway.app' || 'https://gateway-webhook-stg-staging.up.railway.app' }}
+      EXPECTED_GATEWAY_SERVICE_NAME: ${{ inputs.environment == 'production' && 'gateway-webhook' || 'gateway-webhook-stg' }}
+      RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+      RAILWAY_ENVIRONMENT_ID: ${{ vars.RAILWAY_ENVIRONMENT_ID }}
+      RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID_GATEWAY_WEBHOOK }}
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: "1.3.14"
+
+      - name: Validate exact served Worker source before enable
+        if: inputs.enabled == true
         run: |
           set -euo pipefail
           if [[ ! "$EXPECTED_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
@@ -296,7 +328,7 @@ jobs:
              .status == "enforced"' \
             "$readiness" >/dev/null; then
             rm -f "$readiness"
-            echo "::error::Exact-source staging gateway forwarder gate is not enforced"
+            echo "::error::Exact-source $TARGET_ENVIRONMENT gateway forwarder gate is not enforced"
             exit 1
           fi
           rm -f "$readiness"
@@ -323,10 +355,9 @@ jobs:
               code="$(curl -sS -o "$health" -w '%{http_code}' -m 20 "$HEALTH_URL" || echo '000')"
               if [ "$code" = "200" ] && jq -e \
                 --arg environment "$TARGET_ENVIRONMENT" \
-                --arg sha "$EXPECTED_SOURCE_SHA" \
                 '.status == "ok" and
                  .environment == $environment and
-                 .commit == $sha and
+                 (.commit | type == "string" and test("^[0-9a-f]{40}$")) and
                  .personalSharedTelegramEdge.enabled == false' \
                 "$health" >/dev/null; then
                 rm -f "$health"
@@ -341,6 +372,23 @@ jobs:
           disable_edge() {
             remove_edge_secret && prove_edge_disabled
           }
+
+          # Disable is the emergency-safe path: once the target and protected
+          # environment are authorized, remove the binding before consulting
+          # Worker health. A down or drifted Worker makes served-off proof
+          # unavailable, but must never prevent the deletion attempt.
+          if [ "$DESIRED_ENABLED" != "true" ]; then
+            if ! remove_edge_secret; then
+              echo "::error::$TARGET_ENVIRONMENT edge secret removal could not be confirmed"
+              exit 1
+            fi
+            if prove_edge_disabled; then
+              echo "Personal Shared Telegram edge is confirmed disabled in $TARGET_ENVIRONMENT."
+              exit 0
+            fi
+            echo "::error::$TARGET_ENVIRONMENT edge secret removal was confirmed, but served-off proof is unavailable"
+            exit 1
+          fi
 
           # A secret mutation can reach Cloudflare even when the CLI response is
           # ambiguous. Until the served health beacon proves the desired state,
@@ -390,21 +438,17 @@ jobs:
 
           assert_active_gateway before
 
-          if [ "$DESIRED_ENABLED" = "true" ]; then
-            activation_cli_confirmed=false
-            for attempt in 1 2 3; do
-              if printf '%s' 'true' | bunx wrangler@4.100.0 secret put \
-                "$EDGE_SECRET_NAME" --env "$TARGET_ENVIRONMENT"; then
-                activation_cli_confirmed=true
-                break
-              fi
-              [ "$attempt" -lt 3 ] && sleep 10
-            done
-            if [ "$activation_cli_confirmed" != "true" ]; then
-              echo "::warning::Telegram edge activation CLI result was ambiguous; requiring served-state proof"
+          activation_cli_confirmed=false
+          for attempt in 1 2 3; do
+            if printf '%s' 'true' | bunx wrangler@4.100.0 secret put \
+              "$EDGE_SECRET_NAME" --env "$TARGET_ENVIRONMENT"; then
+              activation_cli_confirmed=true
+              break
             fi
-          else
-            remove_edge_secret
+            [ "$attempt" -lt 3 ] && sleep 10
+          done
+          if [ "$activation_cli_confirmed" != "true" ]; then
+            echo "::warning::Telegram edge activation CLI result was ambiguous; requiring served-state proof"
           fi
 
           for attempt in 1 2 3 4 5 6; do

--- a/.github/workflows/activate-personal-shared-telegram-edge.yml
+++ b/.github/workflows/activate-personal-shared-telegram-edge.yml
@@ -31,7 +31,8 @@ permissions:
   issues: read
 
 concurrency:
-  group: deploy-gateway-webhook-${{ inputs.environment == 'production' && 'production' || 'staging' }}
+  # Secret mutation and the full Cloudflare release must never overlap.
+  group: cloud-cf-release-v6-${{ inputs.environment == 'production' && 'production' || 'staging' }}
   cancel-in-progress: false
 
 jobs:
@@ -310,9 +311,35 @@ jobs:
         run: |
           set -euo pipefail
 
-          disable_edge() {
+          remove_edge_secret() {
             node "$GITHUB_WORKSPACE/packages/cloud/scripts/ensure-worker-secret-absent.mjs" \
               "$EDGE_SECRET_NAME" --env "$TARGET_ENVIRONMENT" >/dev/null
+          }
+
+          prove_edge_disabled() {
+            local health code
+            health="$(mktemp)"
+            for attempt in 1 2 3 4 5 6; do
+              code="$(curl -sS -o "$health" -w '%{http_code}' -m 20 "$HEALTH_URL" || echo '000')"
+              if [ "$code" = "200" ] && jq -e \
+                --arg environment "$TARGET_ENVIRONMENT" \
+                --arg sha "$EXPECTED_SOURCE_SHA" \
+                '.status == "ok" and
+                 .environment == $environment and
+                 .commit == $sha and
+                 .personalSharedTelegramEdge.enabled == false' \
+                "$health" >/dev/null; then
+                rm -f "$health"
+                return 0
+              fi
+              [ "$attempt" -lt 6 ] && sleep 10
+            done
+            rm -f "$health"
+            return 1
+          }
+
+          disable_edge() {
+            remove_edge_secret && prove_edge_disabled
           }
 
           # A secret mutation can reach Cloudflare even when the CLI response is
@@ -377,7 +404,7 @@ jobs:
               echo "::warning::Telegram edge activation CLI result was ambiguous; requiring served-state proof"
             fi
           else
-            disable_edge
+            remove_edge_secret
           fi
 
           for attempt in 1 2 3 4 5 6; do

--- a/.github/workflows/deploy-gateway-webhook.yml
+++ b/.github/workflows/deploy-gateway-webhook.yml
@@ -482,6 +482,34 @@ jobs:
           assert_active_deployment after
           echo "Exact manifest, active deployment identity, live health, canonical fallback, and forwarder-auth readiness passed."
 
+      - name: Write exact deployment receipt
+        shell: bash
+        env:
+          DEPLOYMENT_ID: ${{ steps.railway_deploy.outputs.deployment_id }}
+        run: |
+          set -euo pipefail
+          receipt_dir="$RUNNER_TEMP/gateway-webhook-deployment-receipt"
+          mkdir -p "$receipt_dir"
+          jq -n \
+            --arg sourceSha "$GITHUB_SHA" \
+            --arg environment "$TARGET_ENVIRONMENT" \
+            --arg deploymentId "$DEPLOYMENT_ID" \
+            --arg service "$EXPECTED_SERVICE_NAME" \
+            '{
+              sourceSha: $sourceSha,
+              environment: $environment,
+              deploymentId: $deploymentId,
+              service: $service
+            }' > "$receipt_dir/gateway-webhook-deployment.json"
+
+      - name: Publish exact deployment receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: gateway-webhook-deployment-${{ inputs.environment }}-${{ github.sha }}
+          path: ${{ runner.temp }}/gateway-webhook-deployment-receipt/gateway-webhook-deployment.json
+          if-no-files-found: error
+          retention-days: 30
+
       - name: Write deployment summary
         shell: bash
         env:
@@ -520,7 +548,8 @@ jobs:
             "$RUNNER_TEMP/gateway-webhook-active-deployment.json" \
             "$RUNNER_TEMP/gateway-webhook-forwarder-auth-readiness.json" \
             "$RUNNER_TEMP/gateway-webhook-postdeploy-variables-raw.json" \
-            "$RUNNER_TEMP/gateway-webhook-postdeploy-canonical.json"; do
+            "$RUNNER_TEMP/gateway-webhook-postdeploy-canonical.json" \
+            "$RUNNER_TEMP/gateway-webhook-deployment-receipt/gateway-webhook-deployment.json"; do
             if [ -f "$path" ]; then
               shred -u "$path"
             fi

--- a/.github/workflows/deploy-gateway-webhook.yml
+++ b/.github/workflows/deploy-gateway-webhook.yml
@@ -37,7 +37,6 @@ jobs:
     concurrency:
       group: cloud-cf-release-v6-${{ inputs.environment }}
       cancel-in-progress: false
-      queue: max
     env:
       TARGET_ENVIRONMENT: ${{ inputs.environment }}
       DEPLOY_BRANCH: ${{ inputs.environment == 'production' && 'main' || 'develop' }}

--- a/.github/workflows/deploy-gateway-webhook.yml
+++ b/.github/workflows/deploy-gateway-webhook.yml
@@ -14,16 +14,29 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: deploy-gateway-webhook-${{ inputs.environment }}
-  cancel-in-progress: false
-
 jobs:
+  authorize-target:
+    name: Authorize gateway webhook (${{ inputs.environment }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    # Approval completes outside the shared mutation lock so a waiting review
+    # cannot block Cloudflare releases or edge rollback.
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Record protected-environment authorization
+        run: echo "${{ inputs.environment }} gateway release authorized"
+
   deploy:
     name: Deploy gateway webhook (${{ inputs.environment }})
+    needs: authorize-target
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     environment: ${{ inputs.environment }}
+    # The active deployment receipt is consumed by the edge cutover, so both
+    # mutations and the canonical Cloudflare release use one critical section.
+    concurrency:
+      group: cloud-cf-release-v6-${{ inputs.environment }}
+      cancel-in-progress: false
     env:
       TARGET_ENVIRONMENT: ${{ inputs.environment }}
       DEPLOY_BRANCH: ${{ inputs.environment == 'production' && 'main' || 'develop' }}

--- a/.github/workflows/deploy-gateway-webhook.yml
+++ b/.github/workflows/deploy-gateway-webhook.yml
@@ -37,6 +37,7 @@ jobs:
     concurrency:
       group: cloud-cf-release-v6-${{ inputs.environment }}
       cancel-in-progress: false
+      queue: max
     env:
       TARGET_ENVIRONMENT: ${{ inputs.environment }}
       DEPLOY_BRANCH: ${{ inputs.environment == 'production' && 'main' || 'develop' }}

--- a/packages/cloud/services/gateway-webhook/AGENTS.md
+++ b/packages/cloud/services/gateway-webhook/AGENTS.md
@@ -94,7 +94,9 @@ active identity around live health and canonical fallback checks.
 The successful run publishes a source/environment/deployment-id receipt for
 the protected Telegram edge cutover, which verifies the receipt against the
 currently active Railway service before and after mutation under the same
-per-environment concurrency key.
+per-environment concurrency key. Protected-environment authorization completes
+before either workflow enters that shared Cloudflare/gateway mutation lock, so
+a waiting approval cannot block releases.
 It then proves the dedicated headerless `/ready/forwarder-auth/eliza-app`
 contract returns the exact enforced-gate 401 and reasserts the exact active
 deployment. The route returns distinct non-401 states when the secret is

--- a/packages/cloud/services/gateway-webhook/AGENTS.md
+++ b/packages/cloud/services/gateway-webhook/AGENTS.md
@@ -91,6 +91,10 @@ project/environment/service ids and public URL, materializes the tracked
 service manifest byte-for-byte at the root config path Railway expects, and
 waits for that exact deployment id before proving its applied manifest and
 active identity around live health and canonical fallback checks.
+The successful run publishes a source/environment/deployment-id receipt for
+the protected Telegram edge cutover, which verifies the receipt against the
+currently active Railway service before and after mutation under the same
+per-environment concurrency key.
 It then proves the dedicated headerless `/ready/forwarder-auth/eliza-app`
 contract returns the exact enforced-gate 401 and reasserts the exact active
 deployment. The route returns distinct non-401 states when the secret is

--- a/packages/cloud/services/gateway-webhook/CLAUDE.md
+++ b/packages/cloud/services/gateway-webhook/CLAUDE.md
@@ -94,7 +94,9 @@ active identity around live health and canonical fallback checks.
 The successful run publishes a source/environment/deployment-id receipt for
 the protected Telegram edge cutover, which verifies the receipt against the
 currently active Railway service before and after mutation under the same
-per-environment concurrency key.
+per-environment concurrency key. Protected-environment authorization completes
+before either workflow enters that shared Cloudflare/gateway mutation lock, so
+a waiting approval cannot block releases.
 It then proves the dedicated headerless `/ready/forwarder-auth/eliza-app`
 contract returns the exact enforced-gate 401 and reasserts the exact active
 deployment. The route returns distinct non-401 states when the secret is

--- a/packages/cloud/services/gateway-webhook/CLAUDE.md
+++ b/packages/cloud/services/gateway-webhook/CLAUDE.md
@@ -91,6 +91,10 @@ project/environment/service ids and public URL, materializes the tracked
 service manifest byte-for-byte at the root config path Railway expects, and
 waits for that exact deployment id before proving its applied manifest and
 active identity around live health and canonical fallback checks.
+The successful run publishes a source/environment/deployment-id receipt for
+the protected Telegram edge cutover, which verifies the receipt against the
+currently active Railway service before and after mutation under the same
+per-environment concurrency key.
 It then proves the dedicated headerless `/ready/forwarder-auth/eliza-app`
 contract returns the exact enforced-gate 401 and reasserts the exact active
 deployment. The route returns distinct non-401 states when the secret is

--- a/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
@@ -408,6 +408,7 @@ describe("Personal Shared Telegram edge deploy", () => {
       "cloud-cf-release-v6-${{ inputs.environment == 'production' && 'production' || 'staging' }}",
     );
     expect(job?.concurrency?.["cancel-in-progress"]).toBe(false);
+    expect(job?.concurrency?.queue).toBe("max");
     expect(job?.env?.REQUESTED_ENVIRONMENT).toBe("${{ inputs.environment }}");
     expect(job?.env?.TARGET_ENVIRONMENT).toBe(
       "${{ inputs.environment == 'production' && 'production' || 'staging' }}",

--- a/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
@@ -4,7 +4,16 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const repoRoot = new URL("../../../", import.meta.url);
 const source = readFileSync(
@@ -16,6 +25,7 @@ const source = readFileSync(
 );
 
 interface WorkflowStep {
+  id?: string;
   name?: string;
   if?: string;
   env?: Record<string, string>;
@@ -23,6 +33,19 @@ interface WorkflowStep {
 }
 
 interface Workflow {
+  on?: {
+    workflow_dispatch?: {
+      inputs?: Record<
+        string,
+        {
+          default?: string | boolean;
+          options?: string[];
+          required?: boolean;
+          type?: string;
+        }
+      >;
+    };
+  };
   permissions?: Record<string, string>;
   concurrency?: Record<string, string | boolean>;
   jobs?: Record<
@@ -49,28 +72,323 @@ function index(name: string): number {
   return steps.findIndex((candidate) => candidate.name === name);
 }
 
+function validateTarget(
+  overrides: Record<string, string> = {},
+): ReturnType<typeof Bun.spawnSync> {
+  const validation = step("Validate protected target and production approval");
+  return Bun.spawnSync(["bash", "-c", validation.run ?? ""], {
+    env: {
+      ...process.env,
+      DESIRED_ENABLED: "true",
+      EDGE_SECRET_NAME: "PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED",
+      EXPECTED_BRANCH: "develop",
+      EXPECTED_SOURCE_SHA: "a".repeat(40),
+      GATEWAY_URL: "https://gateway-webhook-stg-staging.up.railway.app",
+      GITHUB_REF: "refs/heads/develop",
+      GITHUB_REPOSITORY: "elizaOS/eliza",
+      HEALTH_URL: "https://api-staging.eliza.app/api/health",
+      PRODUCTION_APPROVAL_COMMENT_URL: "",
+      REQUESTED_ENVIRONMENT: "staging",
+      TARGET_ENVIRONMENT: "staging",
+      ...overrides,
+    },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+}
+
+function validateProductionApproval(
+  author: string,
+  approvalLine: string,
+): ReturnType<typeof Bun.spawnSync> {
+  const mockRoot = mkdtempSync(join(tmpdir(), "edge-approval-"));
+  const responsePath = join(mockRoot, "comment.json");
+  const ghPath = join(mockRoot, "gh");
+  writeFileSync(
+    responsePath,
+    JSON.stringify({ body: approvalLine, user: { login: author } }),
+  );
+  writeFileSync(ghPath, '#!/bin/sh\ncat "$MOCK_GH_RESPONSE"\n');
+  chmodSync(ghPath, 0o755);
+
+  try {
+    return validateTarget({
+      EDGE_SECRET_NAME:
+        "PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED",
+      EXPECTED_BRANCH: "main",
+      GATEWAY_URL: "https://gateway-webhook-production.up.railway.app",
+      GITHUB_REF: "refs/heads/main",
+      HEALTH_URL: "https://api.eliza.app/api/health",
+      MOCK_GH_RESPONSE: responsePath,
+      PATH: `${mockRoot}:${process.env.PATH ?? ""}`,
+      PRODUCTION_APPROVAL_COMMENT_URL:
+        "https://github.com/elizaOS/eliza/issues/20877#issuecomment-123",
+      REQUESTED_ENVIRONMENT: "production",
+      TARGET_ENVIRONMENT: "production",
+    });
+  } finally {
+    rmSync(mockRoot, { force: true, recursive: true });
+  }
+}
+
+function verifyGatewayProof(options: {
+  activeDeploymentId?: string;
+  receiptSourceSha?: string;
+} = {}): ReturnType<typeof Bun.spawnSync> {
+  const fixtureRoot = mkdtempSync(join(tmpdir(), "edge-gateway-proof-"));
+  const binRoot = join(fixtureRoot, "bin");
+  const receiptPath = join(fixtureRoot, "gateway-webhook-deployment.json");
+  const activePath = join(fixtureRoot, "active.json");
+  const outputPath = join(fixtureRoot, "github-output.txt");
+  const sourceSha = "a".repeat(40);
+  const deploymentId = "11111111-1111-4111-8111-111111111111";
+  const serviceId = "22222222-2222-4222-8222-222222222222";
+  const environmentId = "33333333-3333-4333-8333-333333333333";
+  const projectId = "44444444-4444-4444-8444-444444444444";
+  mkdirSync(binRoot, { recursive: true });
+  writeFileSync(
+    receiptPath,
+    JSON.stringify({
+      sourceSha: options.receiptSourceSha ?? sourceSha,
+      environment: "staging",
+      deploymentId,
+      service: "gateway-webhook-stg",
+    }),
+  );
+  writeFileSync(
+    activePath,
+    JSON.stringify({
+      id: serviceId,
+      name: "gateway-webhook-stg",
+      deploymentId: options.activeDeploymentId ?? deploymentId,
+      status: "SUCCESS",
+      stopped: false,
+    }),
+  );
+  writeFileSync(
+    join(binRoot, "gh"),
+    `#!/bin/sh
+set -eu
+if [ "$1" = "api" ]; then
+  printf '{"workflow_runs":[{"id":123,"head_sha":"%s","status":"completed","conclusion":"success"}]}' "$EXPECTED_SOURCE_SHA"
+  exit 0
+fi
+if [ "$1" = "run" ] && [ "$2" = "download" ]; then
+  shift 2
+  destination=""
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "--dir" ]; then
+      destination="$2"
+      shift 2
+    else
+      shift
+    fi
+  done
+  mkdir -p "$destination"
+  cp "$MOCK_RECEIPT" "$destination/gateway-webhook-deployment.json"
+  exit 0
+fi
+exit 2
+`,
+  );
+  writeFileSync(
+    join(binRoot, "railway"),
+    `#!/bin/sh
+set -eu
+if [ "$1" = "service" ] && [ "$2" = "status" ]; then
+  cat "$MOCK_ACTIVE"
+  exit 0
+fi
+exit 2
+`,
+  );
+  writeFileSync(
+    join(binRoot, "curl"),
+    `#!/bin/sh
+set -eu
+output=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o|--output) output="$2"; shift 2 ;;
+    -w|--write-out|-m|--max-time) shift 2 ;;
+    -s|-S|-sS|--silent|--show-error) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+case "$url" in
+  */health)
+    printf '{"status":"healthy"}' > "$output"
+    printf '200'
+    ;;
+  */ready/forwarder-auth/eliza-app)
+    printf '{"error":"unauthorized","project":"eliza-app","status":"enforced"}' > "$output"
+    printf '401'
+    ;;
+  *) exit 2 ;;
+esac
+`,
+  );
+  for (const command of ["gh", "railway", "curl"]) {
+    chmodSync(join(binRoot, command), 0o755);
+  }
+
+  try {
+    return Bun.spawnSync(
+      [
+        "bash",
+        "-c",
+        step("Verify exact active gateway before enable").run ?? "",
+      ],
+      {
+        env: {
+          ...process.env,
+          EXPECTED_BRANCH: "develop",
+          EXPECTED_GATEWAY_SERVICE_NAME: "gateway-webhook-stg",
+          EXPECTED_SOURCE_SHA: sourceSha,
+          GATEWAY_URL: "https://gateway.example",
+          GITHUB_OUTPUT: outputPath,
+          GITHUB_REPOSITORY: "elizaOS/eliza",
+          MOCK_ACTIVE: activePath,
+          MOCK_RECEIPT: receiptPath,
+          PATH: `${binRoot}:${process.env.PATH ?? ""}`,
+          RAILWAY_ENVIRONMENT_ID: environmentId,
+          RAILWAY_PROJECT_ID: projectId,
+          RAILWAY_SERVICE_ID: serviceId,
+          RAILWAY_TOKEN: "fixture-token",
+          RUNNER_TEMP: fixtureRoot,
+          TARGET_ENVIRONMENT: "staging",
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    );
+  } finally {
+    rmSync(fixtureRoot, { force: true, recursive: true });
+  }
+}
+
 describe("Personal Shared Telegram edge deploy", () => {
-  test("is staging-only, serialized, and least-privileged", () => {
-    expect(job?.environment).toBe("staging");
-    expect(workflow.permissions).toEqual({ actions: "read", contents: "read" });
+  test("selects one protected environment, serialization key, and canonical endpoint set", () => {
+    const inputs = workflow.on?.workflow_dispatch?.inputs;
+    expect(inputs?.environment).toEqual({
+      description: "Protected environment whose edge gate will be changed",
+      required: true,
+      default: "staging",
+      type: "choice",
+      options: ["staging", "production"],
+    });
+    expect(inputs?.production_approval_comment_url?.required).toBe(false);
+    expect(job?.environment).toBe(
+      "${{ inputs.environment == 'production' && 'production' || 'staging' }}",
+    );
+    expect(workflow.permissions).toEqual({
+      actions: "read",
+      contents: "read",
+      issues: "read",
+    });
     expect(workflow.concurrency?.group).toBe(
-      "activate-personal-shared-telegram-edge-staging",
+      "deploy-gateway-webhook-${{ inputs.environment == 'production' && 'production' || 'staging' }}",
     );
     expect(workflow.concurrency?.["cancel-in-progress"]).toBe(false);
+    expect(job?.env?.REQUESTED_ENVIRONMENT).toBe("${{ inputs.environment }}");
+    expect(job?.env?.TARGET_ENVIRONMENT).toBe(
+      "${{ inputs.environment == 'production' && 'production' || 'staging' }}",
+    );
+    expect(job?.env?.EXPECTED_BRANCH).toBe(
+      "${{ inputs.environment == 'production' && 'main' || 'develop' }}",
+    );
+    expect(job?.env?.EDGE_SECRET_NAME).toBe(
+      "${{ inputs.environment == 'production' && 'PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED' || 'PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED' }}",
+    );
     expect(job?.env?.HEALTH_URL).toBe(
-      "https://api-staging.eliza.app/api/health",
+      "${{ inputs.environment == 'production' && 'https://api.eliza.app/api/health' || 'https://api-staging.eliza.app/api/health' }}",
     );
     expect(job?.env?.GATEWAY_URL).toBe(
-      "https://gateway-webhook-stg-staging.up.railway.app",
+      "${{ inputs.environment == 'production' && 'https://gateway-webhook-production.up.railway.app' || 'https://gateway-webhook-stg-staging.up.railway.app' }}",
     );
-    expect(source).not.toContain("api.eliza.app/api/health");
-    expect(source).not.toContain("--env production");
+    expect(job?.env?.EXPECTED_GATEWAY_SERVICE_NAME).toBe(
+      "${{ inputs.environment == 'production' && 'gateway-webhook' || 'gateway-webhook-stg' }}",
+    );
+    expect(job?.env?.RAILWAY_PROJECT_ID).toBe(
+      "${{ vars.RAILWAY_PROJECT_ID }}",
+    );
+    expect(job?.env?.RAILWAY_ENVIRONMENT_ID).toBe(
+      "${{ vars.RAILWAY_ENVIRONMENT_ID }}",
+    );
+    expect(job?.env?.RAILWAY_SERVICE_ID).toBe(
+      "${{ vars.RAILWAY_SERVICE_ID_GATEWAY_WEBHOOK }}",
+    );
+    expect(job?.env?.RAILWAY_TOKEN).toBe("${{ secrets.RAILWAY_TOKEN }}");
   });
 
-  test("proves exact served Worker and gateway sources before enable", () => {
+  test("rejects cross-environment selectors before any Worker or secret operation", () => {
+    expect(validateTarget().exitCode).toBe(0);
+    for (const overrides of [
+      {
+        EDGE_SECRET_NAME:
+          "PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED",
+      },
+      { EXPECTED_BRANCH: "main" },
+      { HEALTH_URL: "https://api.eliza.app/api/health" },
+      {
+        GATEWAY_URL: "https://gateway-webhook-production.up.railway.app",
+      },
+      {
+        PRODUCTION_APPROVAL_COMMENT_URL:
+          "https://github.com/elizaOS/eliza/issues/20877#issuecomment-1",
+      },
+      { REQUESTED_ENVIRONMENT: "production" },
+    ]) {
+      expect(validateTarget(overrides).exitCode).not.toBe(0);
+    }
+
+    expect(
+      validateTarget({
+        EDGE_SECRET_NAME:
+          "PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED",
+        EXPECTED_BRANCH: "main",
+        GATEWAY_URL: "https://gateway-webhook-production.up.railway.app",
+        GITHUB_REF: "refs/heads/main",
+        HEALTH_URL: "https://api.eliza.app/api/health",
+        TARGET_ENVIRONMENT: "production",
+      }).exitCode,
+    ).not.toBe(0);
+  });
+
+  test("requires a NubsCarson production approval bound to source and desired state", () => {
+    const validation = step("Validate protected target and production approval");
+    expect(validation.run).toContain(
+      "^https://github\\.com/elizaOS/eliza/(issues|pull)/[0-9]+#issuecomment-([0-9]+)$",
+    );
+    expect(validation.run).toContain(
+      'gh api "repos/$GITHUB_REPOSITORY/issues/comments/$approval_comment_id"',
+    );
+    expect(validation.run).toContain('.user.login == "NubsCarson"');
+    expect(validation.run).toContain(
+      "[production-telegram-edge] APPROVE source=$EXPECTED_SOURCE_SHA enabled=$DESIRED_ENABLED",
+    );
+
+    const approval =
+      "[production-telegram-edge] APPROVE source=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa enabled=true";
+    expect(validateProductionApproval("NubsCarson", approval).exitCode).toBe(0);
+    expect(validateProductionApproval("someone-else", approval).exitCode).not.toBe(
+      0,
+    );
+    expect(
+      validateProductionApproval(
+        "NubsCarson",
+        "[production-telegram-edge] APPROVE source=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb enabled=true",
+      ).exitCode,
+    ).not.toBe(0);
+  });
+
+  test("proves exact served Worker and same-environment gateway sources before enable", () => {
     const ordered = [
+      "Validate protected target and production approval",
       "Validate exact served Worker source",
-      "Verify exact-source gateway before enable",
+      "Install pinned Railway CLI",
+      "Verify exact active gateway before enable",
       "Apply and verify served edge state",
       "Write cutover summary",
     ].map(index);
@@ -78,39 +396,81 @@ describe("Personal Shared Telegram edge deploy", () => {
     expect(ordered).toEqual([...ordered].sort((a, b) => a - b));
 
     const worker = step("Validate exact served Worker source");
-    expect(worker.run).toContain('"refs/heads/develop"');
     expect(worker.run).toContain("git merge-base --is-ancestor");
+    expect(worker.run).toContain("canonical $EXPECTED_BRANCH history");
     expect(worker.run).toContain(".commit == $sha");
+    expect(worker.run).toContain(".environment == $environment");
     expect(worker.run).toContain("personalSharedTelegramEdge.enabled");
 
-    const gateway = step("Verify exact-source gateway before enable");
+    const gateway = step("Verify exact active gateway before enable");
+    expect(gateway.id).toBe("gateway_proof");
     expect(gateway.if).toContain("inputs.enabled == true");
     expect(gateway.run).toContain(
       "actions/workflows/deploy-gateway-webhook.yml/runs",
     );
+    expect(gateway.run).toContain("branch=$EXPECTED_BRANCH");
     expect(gateway.run).toContain(".[0].head_sha == $sha");
     expect(gateway.run).toContain('.[0].conclusion == "success"');
+    expect(gateway.run).toContain('gh run download "$gateway_run_id"');
+    expect(gateway.run).toContain(
+      'artifact_name="gateway-webhook-deployment-$TARGET_ENVIRONMENT-$EXPECTED_SOURCE_SHA"',
+    );
+    expect(gateway.run).toContain(".sourceSha == $sha");
+    expect(gateway.run).toContain(".environment == $environment");
+    expect(gateway.run).toContain(".service == $service");
+    expect(gateway.run).toContain("railway service status");
+    expect(gateway.run).toContain(".deploymentId == $id");
+    expect(
+      gateway.run?.match(/^\s*assert_active_gateway (before|after)$/gm)?.length,
+    ).toBe(2);
     expect(gateway.run).toContain("$GATEWAY_URL/health");
     expect(gateway.run).toContain("ready/forwarder-auth/eliza-app");
   });
 
-  test("applies the gate last and rolls every unproven exit back off", () => {
+  test("executes the active-deployment proof and fails closed on receipt or service drift", () => {
+    expect(verifyGatewayProof().exitCode).toBe(0);
+    expect(
+      verifyGatewayProof({
+        activeDeploymentId: "55555555-5555-4555-8555-555555555555",
+      }).exitCode,
+    ).not.toBe(0);
+    expect(
+      verifyGatewayProof({ receiptSourceSha: "b".repeat(40) }).exitCode,
+    ).not.toBe(0);
+  });
+
+  test("mutates only the selected environment binding and rolls every unproven exit back off", () => {
     const apply = step("Apply and verify served edge state");
+    expect(apply.env?.EXPECTED_GATEWAY_DEPLOYMENT_ID).toContain(
+      "steps.gateway_proof.outputs.deployment_id",
+    );
     expect(apply.run).toContain("wrangler@4.100.0 secret put");
     expect(apply.run).toContain(
-      "PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED --env staging",
+      '"$EDGE_SECRET_NAME" --env "$TARGET_ENVIRONMENT"',
     );
     expect(apply.run).toContain("ensure-worker-secret-absent.mjs");
     expect(apply.run).toContain("trap rollback_on_unproven_exit EXIT");
+    expect(apply.run).toContain("railway service status");
+    expect(apply.run).toContain(".deploymentId == $id");
+    expect(apply.run).toContain("assert_active_gateway before");
+    expect(apply.run).toContain("assert_active_gateway after");
     expect(apply.run).toContain(".commit == $sha");
     expect(apply.run).toContain(
       ".personalSharedTelegramEdge.enabled == $enabled",
     );
     expect(apply.run).toContain("if disable_edge; then");
     expect(apply.run).not.toContain('grep -qi "not found"');
+    expect(apply.run).not.toContain("--env staging");
+    expect(apply.run).not.toContain("--env production");
+    expect(apply.run).not.toContain(
+      "PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED --env",
+    );
+    expect(apply.run).not.toContain(
+      "PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED --env",
+    );
   });
 
-  test("keeps the legacy guard false and reserves the replacement name for the activation secret", () => {
+  test("keeps the legacy guard false and reserves both environment-pinned activation secret names", () => {
     const config = Bun.TOML.parse(
       readFileSync(
         new URL("packages/cloud/api/wrangler.toml", repoRoot),
@@ -136,6 +496,17 @@ describe("Personal Shared Telegram edge deploy", () => {
     expect(
       config.env?.production?.vars
         ?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED,
+    ).toBeUndefined();
+    expect(
+      config.vars?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED,
+    ).toBeUndefined();
+    expect(
+      config.env?.staging?.vars
+        ?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED,
+    ).toBeUndefined();
+    expect(
+      config.env?.production?.vars
+        ?.PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED,
     ).toBeUndefined();
   });
 });

--- a/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
@@ -49,23 +49,29 @@ interface Workflow {
     };
   };
   permissions?: Record<string, string>;
-  concurrency?: Record<string, string | boolean>;
   jobs?: Record<
     string,
     {
+      concurrency?: Record<string, string | boolean>;
       environment?: string;
       env?: Record<string, string>;
+      needs?: string;
       steps?: WorkflowStep[];
     }
   >;
 }
 
 const workflow = Bun.YAML.parse(source) as Workflow;
+const validation = workflow.jobs?.["validate-request"];
 const job = workflow.jobs?.cutover;
+const authorization = workflow.jobs?.["authorize-target"];
 const steps = job?.steps ?? [];
+const validationSteps = validation?.steps ?? [];
 
 function step(name: string): WorkflowStep {
-  const found = steps.find((candidate) => candidate.name === name);
+  const found = [...validationSteps, ...steps].find(
+    (candidate) => candidate.name === name,
+  );
   if (!found?.run) throw new Error(`Missing executable workflow step: ${name}`);
   return found;
 }
@@ -332,8 +338,51 @@ printf '200'`,
   }
 }
 
+function exerciseUnavailableDisableProof(): ReturnType<typeof Bun.spawnSync> {
+  const mockRoot = mkdtempSync(join(tmpdir(), "edge-disable-proof-"));
+  const removalMarker = join(mockRoot, "secret-removal-attempted");
+  const executable = (name: string, body: string): void => {
+    const path = join(mockRoot, name);
+    writeFileSync(path, `#!/bin/sh\n${body}\n`);
+    chmodSync(path, 0o755);
+  };
+  executable("node", 'touch "$MOCK_REMOVAL_MARKER"');
+  executable("curl", "exit 1");
+  executable("sleep", "exit 0");
+
+  try {
+    const result = Bun.spawnSync(
+      ["bash", "-c", step("Apply and verify served edge state").run ?? ""],
+      {
+        cwd: fileURLToPath(new URL("packages/cloud/api/", repoRoot)),
+        env: {
+          ...process.env,
+          DESIRED_ENABLED: "false",
+          EDGE_SECRET_NAME: "PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED",
+          EXPECTED_SOURCE_SHA: "a".repeat(40),
+          GITHUB_WORKSPACE: fileURLToPath(repoRoot),
+          HEALTH_URL: "https://api-staging.eliza.app/api/health",
+          MOCK_REMOVAL_MARKER: removalMarker,
+          PATH: `${mockRoot}:${process.env.PATH ?? ""}`,
+          TARGET_ENVIRONMENT: "staging",
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    );
+    if (!existsSync(removalMarker)) {
+      throw new Error(
+        "disable did not attempt secret removal before health proof",
+      );
+    }
+    return result;
+  } finally {
+    rmSync(mockRoot, { force: true, recursive: true });
+  }
+}
+
 describe("Personal Shared Telegram edge deploy", () => {
-  test("selects one protected environment, serialization key, and canonical endpoint set", () => {
+  test("authorizes before entering one protected mutation lock and canonical endpoint set", () => {
     const inputs = workflow.on?.workflow_dispatch?.inputs;
     expect(inputs?.environment).toEqual({
       description: "Protected environment whose edge gate will be changed",
@@ -343,18 +392,22 @@ describe("Personal Shared Telegram edge deploy", () => {
       options: ["staging", "production"],
     });
     expect(inputs?.production_approval_comment_url?.required).toBe(false);
-    expect(job?.environment).toBe(
-      "${{ inputs.environment == 'production' && 'production' || 'staging' }}",
-    );
+    const protectedEnvironment =
+      "${{ inputs.environment == 'production' && 'production' || 'staging' }}";
+    expect(authorization?.environment).toBe(protectedEnvironment);
+    expect(authorization?.concurrency).toBeUndefined();
+    expect(authorization?.needs).toBe("validate-request");
+    expect(job?.environment).toBe(protectedEnvironment);
+    expect(job?.needs).toBe("authorize-target");
     expect(workflow.permissions).toEqual({
       actions: "read",
       contents: "read",
       issues: "read",
     });
-    expect(workflow.concurrency?.group).toBe(
+    expect(job?.concurrency?.group).toBe(
       "cloud-cf-release-v6-${{ inputs.environment == 'production' && 'production' || 'staging' }}",
     );
-    expect(workflow.concurrency?.["cancel-in-progress"]).toBe(false);
+    expect(job?.concurrency?.["cancel-in-progress"]).toBe(false);
     expect(job?.env?.REQUESTED_ENVIRONMENT).toBe("${{ inputs.environment }}");
     expect(job?.env?.TARGET_ENVIRONMENT).toBe(
       "${{ inputs.environment == 'production' && 'production' || 'staging' }}",
@@ -449,8 +502,7 @@ describe("Personal Shared Telegram edge deploy", () => {
 
   test("proves exact served Worker and same-environment gateway sources before enable", () => {
     const ordered = [
-      "Validate protected target and production approval",
-      "Validate exact served Worker source",
+      "Validate exact served Worker source before enable",
       "Install pinned Railway CLI",
       "Verify exact active gateway before enable",
       "Apply and verify served edge state",
@@ -459,7 +511,8 @@ describe("Personal Shared Telegram edge deploy", () => {
     expect(ordered.every((value) => value >= 0)).toBe(true);
     expect(ordered).toEqual([...ordered].sort((a, b) => a - b));
 
-    const worker = step("Validate exact served Worker source");
+    const worker = step("Validate exact served Worker source before enable");
+    expect(worker.if).toBe("inputs.enabled == true");
     expect(worker.run).toContain("git merge-base --is-ancestor");
     expect(worker.run).toContain("canonical $EXPECTED_BRANCH history");
     expect(worker.run).toContain(".commit == $sha");
@@ -538,6 +591,17 @@ describe("Personal Shared Telegram edge deploy", () => {
     const rollback = exerciseFailedActivationRollback();
     expect(rollback.exitCode).not.toBe(0);
     expect(rollback.stdout.toString()).toContain("staging was rolled back off");
+  });
+
+  test("authorized disable removes first and reports unavailable served-off proof distinctly", () => {
+    const worker = step("Validate exact served Worker source before enable");
+    expect(worker.if).toBe("inputs.enabled == true");
+
+    const unavailable = exerciseUnavailableDisableProof();
+    expect(unavailable.exitCode).not.toBe(0);
+    expect(unavailable.stdout.toString()).toContain(
+      "edge secret removal was confirmed, but served-off proof is unavailable",
+    );
   });
 
   test("keeps the legacy guard false and reserves both environment-pinned activation secret names", () => {

--- a/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
@@ -408,7 +408,6 @@ describe("Personal Shared Telegram edge deploy", () => {
       "cloud-cf-release-v6-${{ inputs.environment == 'production' && 'production' || 'staging' }}",
     );
     expect(job?.concurrency?.["cancel-in-progress"]).toBe(false);
-    expect(job?.concurrency?.queue).toBe("max");
     expect(job?.env?.REQUESTED_ENVIRONMENT).toBe("${{ inputs.environment }}");
     expect(job?.env?.TARGET_ENVIRONMENT).toBe(
       "${{ inputs.environment == 'production' && 'production' || 'staging' }}",

--- a/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -14,6 +15,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const repoRoot = new URL("../../../", import.meta.url);
 const source = readFileSync(
@@ -268,6 +270,68 @@ esac
   }
 }
 
+function exerciseFailedActivationRollback(): ReturnType<typeof Bun.spawnSync> {
+  const mockRoot = mkdtempSync(join(tmpdir(), "edge-rollback-"));
+  const rollbackMarker = join(mockRoot, "rollback-attempted");
+  const executable = (name: string, body: string): void => {
+    const path = join(mockRoot, name);
+    writeFileSync(path, `#!/bin/sh\n${body}\n`);
+    chmodSync(path, 0o755);
+  };
+  executable("bunx", "exit 0");
+  executable("sleep", "exit 0");
+  executable("node", 'touch "$MOCK_ROLLBACK_MARKER"');
+  executable(
+    "railway",
+    `printf '%s' '{"id":"22222222-2222-4222-8222-222222222222","name":"gateway-webhook-stg","deploymentId":"11111111-1111-4111-8111-111111111111","status":"SUCCESS","stopped":false}'`,
+  );
+  executable(
+    "curl",
+    `output=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-o" ]; then
+    output="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+printf '%s' '{"status":"ok","environment":"staging","commit":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","personalSharedTelegramEdge":{"enabled":false}}' > "$output"
+printf '200'`,
+  );
+
+  try {
+    const result = Bun.spawnSync(
+      ["bash", "-c", step("Apply and verify served edge state").run ?? ""],
+      {
+        cwd: fileURLToPath(new URL("packages/cloud/api/", repoRoot)),
+        env: {
+          ...process.env,
+          DESIRED_ENABLED: "true",
+          EDGE_SECRET_NAME: "PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED",
+          EXPECTED_GATEWAY_DEPLOYMENT_ID: "11111111-1111-4111-8111-111111111111",
+          EXPECTED_GATEWAY_SERVICE_NAME: "gateway-webhook-stg",
+          EXPECTED_SOURCE_SHA: "a".repeat(40),
+          GITHUB_WORKSPACE: fileURLToPath(repoRoot),
+          HEALTH_URL: "https://api-staging.eliza.app/api/health",
+          MOCK_ROLLBACK_MARKER: rollbackMarker,
+          PATH: `${mockRoot}:${process.env.PATH ?? ""}`,
+          RAILWAY_ENVIRONMENT_ID: "33333333-3333-4333-8333-333333333333",
+          RAILWAY_PROJECT_ID: "44444444-4444-4444-8444-444444444444",
+          RAILWAY_SERVICE_ID: "22222222-2222-4222-8222-222222222222",
+          TARGET_ENVIRONMENT: "staging",
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      },
+    );
+    expect(existsSync(rollbackMarker)).toBe(true);
+    return result;
+  } finally {
+    rmSync(mockRoot, { force: true, recursive: true });
+  }
+}
+
 describe("Personal Shared Telegram edge deploy", () => {
   test("selects one protected environment, serialization key, and canonical endpoint set", () => {
     const inputs = workflow.on?.workflow_dispatch?.inputs;
@@ -288,7 +352,7 @@ describe("Personal Shared Telegram edge deploy", () => {
       issues: "read",
     });
     expect(workflow.concurrency?.group).toBe(
-      "deploy-gateway-webhook-${{ inputs.environment == 'production' && 'production' || 'staging' }}",
+      "cloud-cf-release-v6-${{ inputs.environment == 'production' && 'production' || 'staging' }}",
     );
     expect(workflow.concurrency?.["cancel-in-progress"]).toBe(false);
     expect(job?.env?.REQUESTED_ENVIRONMENT).toBe("${{ inputs.environment }}");
@@ -449,6 +513,8 @@ describe("Personal Shared Telegram edge deploy", () => {
       '"$EDGE_SECRET_NAME" --env "$TARGET_ENVIRONMENT"',
     );
     expect(apply.run).toContain("ensure-worker-secret-absent.mjs");
+    expect(apply.run).toContain("prove_edge_disabled");
+    expect(apply.run).toContain(".personalSharedTelegramEdge.enabled == false");
     expect(apply.run).toContain("trap rollback_on_unproven_exit EXIT");
     expect(apply.run).toContain("railway service status");
     expect(apply.run).toContain(".deploymentId == $id");
@@ -468,6 +534,10 @@ describe("Personal Shared Telegram edge deploy", () => {
     expect(apply.run).not.toContain(
       "PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_PRODUCTION_ENABLED --env",
     );
+
+    const rollback = exerciseFailedActivationRollback();
+    expect(rollback.exitCode).not.toBe(0);
+    expect(rollback.stdout.toString()).toContain("staging was rolled back off");
   });
 
   test("keeps the legacy guard false and reserves both environment-pinned activation secret names", () => {

--- a/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/cloud-cf-personal-telegram-edge-deploy-workflow.test.ts
@@ -133,10 +133,9 @@ function validateProductionApproval(
   }
 }
 
-function verifyGatewayProof(options: {
-  activeDeploymentId?: string;
-  receiptSourceSha?: string;
-} = {}): ReturnType<typeof Bun.spawnSync> {
+function verifyGatewayProof(
+  options: { activeDeploymentId?: string; receiptSourceSha?: string } = {},
+): ReturnType<typeof Bun.spawnSync> {
   const fixtureRoot = mkdtempSync(join(tmpdir(), "edge-gateway-proof-"));
   const binRoot = join(fixtureRoot, "bin");
   const receiptPath = join(fixtureRoot, "gateway-webhook-deployment.json");
@@ -309,7 +308,8 @@ printf '200'`,
           ...process.env,
           DESIRED_ENABLED: "true",
           EDGE_SECRET_NAME: "PERSONAL_SHARED_TELEGRAM_EDGE_CUTOVER_ENABLED",
-          EXPECTED_GATEWAY_DEPLOYMENT_ID: "11111111-1111-4111-8111-111111111111",
+          EXPECTED_GATEWAY_DEPLOYMENT_ID:
+            "11111111-1111-4111-8111-111111111111",
           EXPECTED_GATEWAY_SERVICE_NAME: "gateway-webhook-stg",
           EXPECTED_SOURCE_SHA: "a".repeat(40),
           GITHUB_WORKSPACE: fileURLToPath(repoRoot),
@@ -374,9 +374,7 @@ describe("Personal Shared Telegram edge deploy", () => {
     expect(job?.env?.EXPECTED_GATEWAY_SERVICE_NAME).toBe(
       "${{ inputs.environment == 'production' && 'gateway-webhook' || 'gateway-webhook-stg' }}",
     );
-    expect(job?.env?.RAILWAY_PROJECT_ID).toBe(
-      "${{ vars.RAILWAY_PROJECT_ID }}",
-    );
+    expect(job?.env?.RAILWAY_PROJECT_ID).toBe("${{ vars.RAILWAY_PROJECT_ID }}");
     expect(job?.env?.RAILWAY_ENVIRONMENT_ID).toBe(
       "${{ vars.RAILWAY_ENVIRONMENT_ID }}",
     );
@@ -421,7 +419,9 @@ describe("Personal Shared Telegram edge deploy", () => {
   });
 
   test("requires a NubsCarson production approval bound to source and desired state", () => {
-    const validation = step("Validate protected target and production approval");
+    const validation = step(
+      "Validate protected target and production approval",
+    );
     expect(validation.run).toContain(
       "^https://github\\.com/elizaOS/eliza/(issues|pull)/[0-9]+#issuecomment-([0-9]+)$",
     );
@@ -436,9 +436,9 @@ describe("Personal Shared Telegram edge deploy", () => {
     const approval =
       "[production-telegram-edge] APPROVE source=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa enabled=true";
     expect(validateProductionApproval("NubsCarson", approval).exitCode).toBe(0);
-    expect(validateProductionApproval("someone-else", approval).exitCode).not.toBe(
-      0,
-    );
+    expect(
+      validateProductionApproval("someone-else", approval).exitCode,
+    ).not.toBe(0);
     expect(
       validateProductionApproval(
         "NubsCarson",

--- a/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
@@ -40,7 +40,6 @@ interface WorkflowJob {
   concurrency?: {
     "cancel-in-progress"?: boolean;
     group?: string;
-    queue?: string;
   };
   env?: Record<string, string>;
   environment?: string;
@@ -209,7 +208,6 @@ describe("protected gateway-webhook deployment workflow", () => {
       ["cloud-cf-release-v6-", githubExpression("inputs.environment")].join(""),
     );
     expect(deploy?.concurrency?.["cancel-in-progress"]).toBe(false);
-    expect(deploy?.concurrency?.queue).toBe("max");
 
     expect(deploy?.env).toEqual(expectedJobEnvironment);
     expect(() => assertExactProtectedRouting(deploy)).not.toThrow();

--- a/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
@@ -40,6 +40,7 @@ interface WorkflowJob {
   concurrency?: {
     "cancel-in-progress"?: boolean;
     group?: string;
+    queue?: string;
   };
   env?: Record<string, string>;
   environment?: string;
@@ -208,6 +209,7 @@ describe("protected gateway-webhook deployment workflow", () => {
       ["cloud-cf-release-v6-", githubExpression("inputs.environment")].join(""),
     );
     expect(deploy?.concurrency?.["cancel-in-progress"]).toBe(false);
+    expect(deploy?.concurrency?.queue).toBe("max");
 
     expect(deploy?.env).toEqual(expectedJobEnvironment);
     expect(() => assertExactProtectedRouting(deploy)).not.toThrow();

--- a/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
@@ -495,6 +495,29 @@ describe("protected gateway-webhook deployment workflow", () => {
       ),
     ).toThrow("forwarder readiness probe entered a forbidden path");
 
+    const receipt = step("Write exact deployment receipt");
+    expect(receipt.env?.DEPLOYMENT_ID).toContain(
+      "steps.railway_deploy.outputs.deployment_id",
+    );
+    expect(receipt.run).toContain('--arg sourceSha "$GITHUB_SHA"');
+    expect(receipt.run).toContain('--arg environment "$TARGET_ENVIRONMENT"');
+    expect(receipt.run).toContain('--arg deploymentId "$DEPLOYMENT_ID"');
+    expect(receipt.run).toContain('--arg service "$EXPECTED_SERVICE_NAME"');
+    expect(receipt.run).toContain("gateway-webhook-deployment.json");
+
+    const publish = steps.find(
+      (candidate) => candidate.name === "Publish exact deployment receipt",
+    );
+    expect(publish?.uses).toBe(
+      "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+    );
+    expect(publish?.with).toEqual({
+      name: "gateway-webhook-deployment-${{ inputs.environment }}-${{ github.sha }}",
+      path: "${{ runner.temp }}/gateway-webhook-deployment-receipt/gateway-webhook-deployment.json",
+      "if-no-files-found": "error",
+      "retention-days": 30,
+    });
+
     const summary = step("Write deployment summary");
     expect(summary.run).toContain("$GITHUB_SHA");
     expect(summary.run).toContain("$DEPLOYMENT_ID");
@@ -510,6 +533,9 @@ describe("protected gateway-webhook deployment workflow", () => {
     expect(cleanup.run).toContain("gateway-webhook-railway-variables-raw.json");
     expect(cleanup.run).toContain(
       "gateway-webhook-postdeploy-variables-raw.json",
+    );
+    expect(cleanup.run).toContain(
+      "gateway-webhook-deployment-receipt/gateway-webhook-deployment.json",
     );
   });
 });

--- a/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
+++ b/packages/scripts/__tests__/gateway-webhook-deploy-workflow.test.ts
@@ -37,16 +37,17 @@ interface WorkflowStep {
 }
 
 interface WorkflowJob {
-  env?: Record<string, string>;
-  environment?: string;
-  steps?: WorkflowStep[];
-}
-
-interface Workflow {
   concurrency?: {
     "cancel-in-progress"?: boolean;
     group?: string;
   };
+  env?: Record<string, string>;
+  environment?: string;
+  needs?: string;
+  steps?: WorkflowStep[];
+}
+
+interface Workflow {
   jobs?: Record<string, WorkflowJob>;
   on?: {
     workflow_dispatch?: {
@@ -64,6 +65,7 @@ interface Workflow {
 
 const workflow = Bun.YAML.parse(source) as Workflow;
 const deploy = workflow.jobs?.deploy;
+const authorization = workflow.jobs?.["authorize-target"];
 const steps = deploy?.steps ?? [];
 
 function step(name: string): WorkflowStep {
@@ -187,7 +189,7 @@ function assertExactForwarderAuthReadinessProbe(run: string): void {
 }
 
 describe("protected gateway-webhook deployment workflow", () => {
-  test("is manual, least-privileged, protected, and serialized per environment", () => {
+  test("authorizes before the shared protected mutation lock", () => {
     expect(Object.keys(workflow.on ?? {})).toEqual(["workflow_dispatch"]);
     expect(workflow.on?.workflow_dispatch?.inputs?.environment).toEqual({
       description: "Protected environment to deploy",
@@ -196,9 +198,16 @@ describe("protected gateway-webhook deployment workflow", () => {
       options: ["staging", "production"],
     });
     expect(workflow.permissions).toEqual({ contents: "read" });
+    expect(authorization?.environment).toBe(
+      githubExpression("inputs.environment"),
+    );
+    expect(authorization?.concurrency).toBeUndefined();
     expect(deploy?.environment).toBe(githubExpression("inputs.environment"));
-    expect(workflow.concurrency?.group).toContain("inputs.environment");
-    expect(workflow.concurrency?.["cancel-in-progress"]).toBe(false);
+    expect(deploy?.needs).toBe("authorize-target");
+    expect(deploy?.concurrency?.group).toBe(
+      ["cloud-cf-release-v6-", githubExpression("inputs.environment")].join(""),
+    );
+    expect(deploy?.concurrency?.["cancel-in-progress"]).toBe(false);
 
     expect(deploy?.env).toEqual(expectedJobEnvironment);
     expect(() => assertExactProtectedRouting(deploy)).not.toThrow();


### PR DESCRIPTION
Part of #20877.

## Protected activation contract

- Validates selectors and the exact public NubsCarson production approval before entering the protected Environment boundary.
- Obtains protected authorization without holding a mutation lock, then acquires the shared `cloud-cf-release-v6-${environment}` lock only in the credential-bearing cutover job.
- Uses that same lock for Cloudflare release, gateway deploy, and Telegram edge activation, so the deployment receipt cannot change during cutover.
- Enable requires the exact canonical Worker SHA and exact active same-environment gateway deployment receipt.
- Disable removes only the selected environment secret first, even if Worker health/source is unavailable, then proves served `enabled=false` or exits with the distinct truthful state that secret removal succeeded but served-off proof is unavailable.
- Failed enablement removes the selected secret and polls the exact live environment until the served health beacon proves the gate is off.
- Legacy guards remain false.

## Exact revision

- Head: `4ec293293bbb0907eb7f8203ac085fbdf21259e3`
- Recorded branch base: `5f708649703e0e874cce68ea684dfd0f98fe9f70`
- This six-commit stack is range-diff `=` patch-equivalent to the independently audited stack ending at `71fac0d635d3a6ba4ddcbf9a9d1d03b0a4693352`.

## Independent repair

Two later author commits repeatedly added `concurrency.queue: max` to job-level GitHub Actions concurrency objects. That key is not accepted by `actionlint`; valid job concurrency keys here are `group` and `cancel-in-progress`. The final head removes the unsupported key and its self-affirming assertions while retaining the authorization and serialization architecture above.

## Validation

- Executable activation and gateway workflow tests: 14/14 passed, 242 assertions.
- `actionlint` passed for both workflows.
- Biome passed with zero errors; 15 existing workflow-expression fixture warnings remain.
- `bun run check:agents-claude` passed for 155 guide pairs.
- `git diff --check` passed.
- No workflow dispatch, rerun, deploy, secret/channel mutation, rollback, or production-state change was performed.

This remains draft. Readiness and activation require a separately authorized exact-head protected run proving gateway receipt, Worker health/auth, desired served state, and real rollback/disable behavior.

<!-- evidence-head:4ec293293bbb0907eb7f8203ac085fbdf21259e3 -->

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - protected backend workflow with no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - no activation run was authorized`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no activation run was authorized`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `Pending - exact-head protected activation and rollback/disable logs require separate authorization`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend path changed`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model behavior changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `Pending - exact protected gateway and Worker activation receipt requires a separately authorized run`.
<!-- evidence-row:ocr-review -->
- [ ] OCR review `N/A - no rendered visual surface changed`.

AI provider/model: OpenAI / GPT-5
Client / agent tooling: Codex
Contribution skill revision: N/A - no contribution skill used
Attribution status: self-reported

— [codex]

<!-- eliza-computer-attribution:v1 {"provider":"openai","model":"gpt-5","client":"Codex","skill_revision":"N/A"} -->
