### PR TITLE
feat(agent): bulk lossless import route for transferred shared memories

### DIFF
--- a/packages/agent/src/api/memory-import.test.ts
+++ b/packages/agent/src/api/memory-import.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Contract tests for the bulk transferred-memory import surface. Deterministic:
+ * the runtime is a recorder double so every assertion inspects exactly what
+ * would be persisted — verbatim ids/timestamps/content/vectors, the deliberate
+ * agent/authored-entity remap, scaffolding upserts with preserved ids, and
+ * idempotent re-import. The wire shape mirrors the cloud-side fidelity
+ * transform's output.
+ */
+
+import { describe, expect, test } from "vitest";
+import type { AgentRuntime, Memory, UUID } from "@elizaos/core";
+import {
+  importTransferredMemories,
+  type MemoryImportItem,
+  PostMemoryImportRequestSchema,
+} from "./memory-import.ts";
+
+const LOCAL_AGENT = "11111111-1111-4111-8111-111111111111" as UUID;
+const SOURCE_AGENT = "8f1f7f72-0577-4b4a-b15b-229c751d5484";
+const USER_ENTITY = "1d88c441-09a2-47ac-a8fd-a502884390c3";
+const ROOM = "866e5ec5-5e66-4387-9333-6be867377d63";
+const WORLD = "d04cf4d3-a60e-4209-ad78-d67d6a38ff95";
+
+interface RecordedRuntime {
+  runtime: AgentRuntime;
+  createdMemories: Array<{ memory: Memory; tableName: string }>;
+  worlds: Array<Record<string, unknown>>;
+  rooms: Array<Record<string, unknown>>;
+  entities: Array<Record<string, unknown>>;
+  existingMemoryIds: Set<string>;
+  existingEntityIds: Set<string>;
+}
+
+function recorderRuntime(): RecordedRuntime {
+  const state: RecordedRuntime = {
+    runtime: undefined as unknown as AgentRuntime,
+    createdMemories: [],
+    worlds: [],
+    rooms: [],
+    entities: [],
+    existingMemoryIds: new Set(),
+    existingEntityIds: new Set(),
+  };
+  state.runtime = {
+    agentId: LOCAL_AGENT,
+    ensureWorldExists: async (world: Record<string, unknown>) => {
+      state.worlds.push(world);
+    },
+    ensureRoomExists: async (room: Record<string, unknown>) => {
+      state.rooms.push(room);
+    },
+    getEntityById: async (id: string) =>
+      state.existingEntityIds.has(id)
+        ? { id, names: [], agentId: LOCAL_AGENT }
+        : null,
+    createEntity: async (entity: Record<string, unknown>) => {
+      state.entities.push(entity);
+      return true;
+    },
+    getMemoryById: async (id: string) =>
+      state.existingMemoryIds.has(id) ? ({ id } as Memory) : null,
+    adapter: {
+      createMemories: async (
+        batch: Array<{ memory: Memory; tableName: string }>,
+      ) => {
+        state.createdMemories.push(...batch);
+        return batch.map((entry) => entry.memory.id as UUID);
+      },
+    },
+  } as unknown as AgentRuntime;
+  return state;
+}
+
+function transferItem(
+  overrides: Partial<MemoryImportItem["memory"]> = {},
+): MemoryImportItem {
+  return {
+    memory: {
+      id: "96a23079-4032-49f3-ae44-d8a25471e473",
+      type: "messages",
+      created_at: "2026-08-17T03:44:45.770Z",
+      content: { text: "hi", source: "shared-runtime", channelType: "DM" },
+      entity_id: USER_ENTITY,
+      agent_id: SOURCE_AGENT,
+      room_id: ROOM,
+      world_id: WORLD,
+      unique: true,
+      metadata: { source: "shared-runtime-transfer" },
+      ...overrides,
+    },
+    embedding: {
+      memory_id:
+        (overrides.id as string) ?? "96a23079-4032-49f3-ae44-d8a25471e473",
+      dim_384: Array.from({ length: 384 }, (_, i) => Math.sin(i) / 2),
+    },
+  };
+}
+
+describe("transferred memory import", () => {
+  test("persists rows verbatim while remapping only the agent-owned identities", async () => {
+    const state = recorderRuntime();
+    const userRow = transferItem();
+    const assistantRow = transferItem({
+      id: "ada43714-95cf-4418-a568-a7ea232287fc",
+      entity_id: SOURCE_AGENT,
+      content: { text: "hello there", source: "shared-runtime" },
+    });
+
+    const result = await importTransferredMemories(state.runtime, [
+      userRow,
+      assistantRow,
+    ]);
+
+    expect(result).toEqual({
+      ok: true,
+      requested: 2,
+      imported: 2,
+      skippedExisting: 0,
+      embeddingsWritten: 2,
+      remappedAgentRows: 1,
+    });
+
+    const [user, assistant] = state.createdMemories;
+    expect(user?.tableName).toBe("messages");
+    expect(user?.memory.id).toBe(userRow.memory.id as UUID);
+    expect(user?.memory.createdAt).toBe(Date.parse("2026-08-17T03:44:45.770Z"));
+    expect(JSON.stringify(user?.memory.content)).toBe(
+      JSON.stringify(userRow.memory.content),
+    );
+    expect(user?.memory.unique).toBe(true);
+    expect(user?.memory.embedding).toEqual(
+      userRow.embedding?.dim_384 as number[],
+    );
+    // The user's identity survives; the row now belongs to the local agent.
+    expect(user?.memory.entityId).toBe(USER_ENTITY as UUID);
+    expect(user?.memory.agentId).toBe(LOCAL_AGENT);
+    expect(user?.memory.roomId).toBe(ROOM as UUID);
+    expect(user?.memory.worldId).toBe(WORLD as UUID);
+    // Assistant-authored rows remap entity_id: the source agent has no entity
+    // row here, and recall attributes agent speech by the local agent id.
+    expect(assistant?.memory.entityId).toBe(LOCAL_AGENT);
+  });
+
+  test("ensures scaffolding with transferred ids before any memory insert", async () => {
+    const state = recorderRuntime();
+    await importTransferredMemories(state.runtime, [transferItem()]);
+
+    expect(state.worlds).toEqual([
+      expect.objectContaining({ id: WORLD, agentId: LOCAL_AGENT }),
+    ]);
+    expect(state.rooms).toEqual([
+      expect.objectContaining({
+        id: ROOM,
+        worldId: WORLD,
+        source: "shared-runtime-transfer",
+      }),
+    ]);
+    expect(state.entities).toEqual([
+      expect.objectContaining({ id: USER_ENTITY, agentId: LOCAL_AGENT }),
+    ]);
+  });
+
+  test("re-importing the same batch is a no-op reported as skippedExisting", async () => {
+    const state = recorderRuntime();
+    const item = transferItem();
+    state.existingMemoryIds.add(item.memory.id);
+    state.existingEntityIds.add(USER_ENTITY);
+
+    const result = await importTransferredMemories(state.runtime, [item]);
+
+    expect(result.imported).toBe(0);
+    expect(result.skippedExisting).toBe(1);
+    expect(state.createdMemories).toHaveLength(0);
+    expect(state.entities).toHaveLength(0);
+  });
+
+  test("vector-less rows import without an embedding", async () => {
+    const state = recorderRuntime();
+    const item = transferItem();
+    const vectorless: MemoryImportItem = { memory: item.memory };
+
+    const result = await importTransferredMemories(state.runtime, [vectorless]);
+
+    expect(result.embeddingsWritten).toBe(0);
+    expect(state.createdMemories[0]?.memory.embedding).toBeUndefined();
+  });
+
+  test("schema rejects wrong-width vectors, bad uuids, and oversized batches", () => {
+    const item = transferItem();
+    expect(
+      PostMemoryImportRequestSchema.safeParse({
+        exports: [
+          {
+            memory: item.memory,
+            embedding: { memory_id: item.memory.id, dim_384: [1, 2, 3] },
+          },
+        ],
+      }).success,
+    ).toBe(false);
+    expect(
+      PostMemoryImportRequestSchema.safeParse({
+        exports: [{ memory: { ...item.memory, id: "not-a-uuid" } }],
+      }).success,
+    ).toBe(false);
+    expect(
+      PostMemoryImportRequestSchema.safeParse({
+        exports: Array.from({ length: 501 }, () => ({ memory: item.memory })),
+      }).success,
+    ).toBe(false);
+    expect(
+      PostMemoryImportRequestSchema.safeParse({
+        exports: [{ memory: item.memory }],
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/packages/agent/src/api/memory-import.ts
+++ b/packages/agent/src/api/memory-import.ts
@@ -1,0 +1,237 @@
+/**
+ * Bulk lossless import of transferred memory rows into this agent's database —
+ * the container-side landing half of a Shared→Dedicated cutover. The cloud
+ * control plane exports `shared_agent_memories` rows through its fidelity
+ * transform and POSTs them here once the container is reachable; the wire shape
+ * mirrors that transform's output (snake_case core `memories` row + optional
+ * `dim_384` embedding leg).
+ *
+ * Fidelity invariants: memory ids, `created_at`, `content`, `metadata`,
+ * `unique`, and vectors are persisted verbatim, so writes go through
+ * `runtime.adapter.createMemory` directly — the runtime wrapper's secret
+ * redaction and fact dedupe would mutate transferred history. Two identities
+ * are deliberately remapped: every row's `agent_id`, and the `entity_id` of
+ * rows authored by the source agent, become THIS runtime's agent id — the
+ * source agent id has no entity/agent row here (FK), and recall scopes by the
+ * local agent id. Referenced worlds/rooms/entities are upserted first with
+ * their transferred ids so foreign keys hold and cross-row identity survives.
+ * Re-POSTing a batch is a no-op per already-present id (adapter conflict
+ * skip + a pre-check that reports `skippedExisting` honestly).
+ */
+
+import {
+  type AgentRuntime,
+  ChannelType,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
+import { z } from "zod";
+import type { MemoryRouteContext } from "./memory-routes.ts";
+
+export const MEMORY_IMPORT_SOURCE = "shared-runtime-transfer";
+export const MEMORY_IMPORT_MAX_BATCH = 500;
+/** Vectored rows are ~4KB each; 500 rows plus content fits well inside this. */
+export const MEMORY_IMPORT_MAX_BODY_BYTES = 16 * 1024 * 1024;
+
+const UuidSchema = z.uuid();
+
+const ImportMemorySchema = z.object({
+  id: UuidSchema,
+  type: z.string().trim().min(1).max(64),
+  created_at: z.iso.datetime(),
+  content: z.record(z.string(), z.unknown()),
+  entity_id: UuidSchema.nullable(),
+  agent_id: UuidSchema,
+  room_id: UuidSchema.nullable(),
+  world_id: UuidSchema.nullable(),
+  unique: z.boolean(),
+  metadata: z.record(z.string(), z.unknown()),
+});
+
+const ImportEmbeddingSchema = z.object({
+  memory_id: UuidSchema,
+  dim_384: z.array(z.number().finite()).length(384),
+});
+
+const ImportItemSchema = z.object({
+  memory: ImportMemorySchema,
+  embedding: ImportEmbeddingSchema.optional(),
+});
+
+export const PostMemoryImportRequestSchema = z.object({
+  exports: z.array(ImportItemSchema).min(1).max(MEMORY_IMPORT_MAX_BATCH),
+});
+
+export type MemoryImportItem = z.infer<typeof ImportItemSchema>;
+
+export interface MemoryImportResult {
+  ok: true;
+  requested: number;
+  imported: number;
+  skippedExisting: number;
+  embeddingsWritten: number;
+  remappedAgentRows: number;
+}
+
+function transferWorldId(runtime: AgentRuntime): UUID {
+  // Deterministic per agent so retries and later batches converge on one world.
+  return `${runtime.agentId}` as UUID;
+}
+
+async function ensureScaffolding(
+  runtime: AgentRuntime,
+  items: MemoryImportItem[],
+): Promise<Map<string, UUID>> {
+  const sourceAgentIds = new Set(items.map((item) => item.memory.agent_id));
+
+  const worldIds = new Set<string>();
+  for (const item of items) {
+    if (item.memory.world_id) worldIds.add(item.memory.world_id);
+    else if (item.memory.room_id) worldIds.add(transferWorldId(runtime));
+  }
+  for (const worldId of worldIds) {
+    await runtime.ensureWorldExists({
+      id: worldId as UUID,
+      name: "Transferred shared history",
+      agentId: runtime.agentId,
+      metadata: { type: MEMORY_IMPORT_SOURCE },
+    });
+  }
+
+  // room id → effective world id, preserving the transferred pairing.
+  const roomWorlds = new Map<string, UUID>();
+  for (const item of items) {
+    if (!item.memory.room_id) continue;
+    const worldId = (item.memory.world_id ?? transferWorldId(runtime)) as UUID;
+    roomWorlds.set(item.memory.room_id, worldId);
+  }
+  for (const [roomId, worldId] of roomWorlds) {
+    await runtime.ensureRoomExists({
+      id: roomId as UUID,
+      name: "Transferred shared history",
+      source: MEMORY_IMPORT_SOURCE,
+      type: ChannelType.DM,
+      worldId,
+      metadata: { type: MEMORY_IMPORT_SOURCE },
+    });
+  }
+
+  const entityIds = new Set<string>();
+  for (const item of items) {
+    const entityId = item.memory.entity_id;
+    if (entityId && !sourceAgentIds.has(entityId)) entityIds.add(entityId);
+  }
+  for (const entityId of entityIds) {
+    const existing = await runtime.getEntityById(entityId as UUID);
+    if (existing) continue;
+    await runtime.createEntity({
+      id: entityId as UUID,
+      names: ["Transferred user"],
+      agentId: runtime.agentId,
+      metadata: { type: MEMORY_IMPORT_SOURCE },
+    });
+  }
+
+  return roomWorlds;
+}
+
+export async function importTransferredMemories(
+  runtime: AgentRuntime,
+  items: MemoryImportItem[],
+): Promise<MemoryImportResult> {
+  const sourceAgentIds = new Set(items.map((item) => item.memory.agent_id));
+  const roomWorlds = await ensureScaffolding(runtime, items);
+
+  let imported = 0;
+  let skippedExisting = 0;
+  let embeddingsWritten = 0;
+  let remappedAgentRows = 0;
+
+  for (const item of items) {
+    const row = item.memory;
+    const existing = await runtime.getMemoryById(row.id as UUID);
+    if (existing) {
+      skippedExisting += 1;
+      continue;
+    }
+
+    const authoredBySourceAgent =
+      row.entity_id !== null && sourceAgentIds.has(row.entity_id);
+    if (authoredBySourceAgent) remappedAgentRows += 1;
+
+    const memory: Memory = {
+      id: row.id as UUID,
+      agentId: runtime.agentId,
+      entityId: (authoredBySourceAgent
+        ? runtime.agentId
+        : (row.entity_id ?? runtime.agentId)) as UUID,
+      roomId: (row.room_id ?? undefined) as UUID,
+      worldId: row.room_id
+        ? roomWorlds.get(row.room_id)
+        : ((row.world_id ?? undefined) as UUID | undefined),
+      content: row.content as Memory["content"],
+      metadata: row.metadata as Memory["metadata"],
+      unique: row.unique,
+      createdAt: Date.parse(row.created_at),
+      ...(item.embedding ? { embedding: item.embedding.dim_384 } : {}),
+    };
+
+    // Adapter-direct on purpose: preserves id/createdAt/unique verbatim,
+    // skips the runtime wrapper's content redaction and fact dedupe, and is
+    // idempotent via the memories-table conflict skip.
+    await runtime.adapter.createMemories([
+      { memory, tableName: row.type, unique: row.unique },
+    ]);
+    imported += 1;
+    if (item.embedding) embeddingsWritten += 1;
+  }
+
+  return {
+    ok: true,
+    requested: items.length,
+    imported,
+    skippedExisting,
+    embeddingsWritten,
+    remappedAgentRows,
+  };
+}
+
+/** POST /api/memories/import — validates the batch and lands it losslessly. */
+export async function handleMemoryImportRoute(
+  ctx: MemoryRouteContext,
+): Promise<boolean> {
+  const { req, res, runtime, json, error, readJsonBody } = ctx;
+  if (!runtime) {
+    error(res, "Agent runtime is not available", 503);
+    return true;
+  }
+
+  const raw = await readJsonBody<Record<string, unknown>>(req, res, {
+    maxBytes: MEMORY_IMPORT_MAX_BODY_BYTES,
+  });
+  if (raw === null) return true;
+
+  const parsed = PostMemoryImportRequestSchema.safeParse(raw);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    const path = issue?.path.length ? ` at ${issue.path.join(".")}` : "";
+    error(res, `${issue?.message ?? "Invalid import payload"}${path}`, 400);
+    return true;
+  }
+
+  const mismatched = parsed.data.exports.find(
+    (item) => item.embedding && item.embedding.memory_id !== item.memory.id,
+  );
+  if (mismatched) {
+    error(
+      res,
+      `embedding.memory_id does not match memory.id for ${mismatched.memory.id}`,
+      400,
+    );
+    return true;
+  }
+
+  const result = await importTransferredMemories(runtime, parsed.data.exports);
+  json(res, result);
+  return true;
+}

--- a/packages/agent/src/api/memory-routes.ts
+++ b/packages/agent/src/api/memory-routes.ts
@@ -440,6 +440,13 @@ export async function handleMemoryRoutes(
     return true;
   }
 
+  // Dispatched before ensureMemoryConnection: a transfer import must not
+  // create the client-chat room, and it manages its own scaffolding rows.
+  if (method === "POST" && pathname === "/api/memories/import") {
+    const { handleMemoryImportRoute } = await import("./memory-import.ts");
+    return handleMemoryImportRoute(ctx);
+  }
+
   const resolvedAgentName = resolveAgentName(runtime, agentName);
   const { roomId, entityId } = await ensureMemoryConnection(
     runtime,


### PR DESCRIPTION
Part 2 of the Shared→Dedicated memory transfer (P2.5); consumes the fidelity transform merged in #20861. This is the container-side landing half — the cloud-side provisioning step that reads `shared_agent_memories`, transforms, and POSTs here is the follow-up PR, so this route ships dark until it lands.

## Why

`dedicated-bootstrap` is a serving handoff only: a promoted agent's container starts with an empty DB and the user's Shared history never follows. The backup/restore pipeline can't carry it either — `agent_sandbox_backups` payloads are file-level, KMS-encrypted container state with hash-verified manifests, and synthesizing one for a never-booted agent would fight the restorability verifier. The existing memory endpoints are also unusable for this (`/api/memory/remember` is a hash-note store; PATCH re-embeds). The transfer needs a dedicated lossless surface.

## What

`POST /api/memories/import` on the agent control API (behind its auth layer), wire shape mirroring the #20861 transform output (snake_case `memories` row + optional `dim_384` leg), batches ≤500:

- **Verbatim persistence**: memory ids, `created_at`, `content`, `metadata`, `unique`, and vectors go through `runtime.adapter.createMemories` directly — deliberately bypassing the runtime wrapper, whose secret redaction and fact dedupe would mutate transferred history.
- **Deliberate identity remap (the only mutation)**: every row's `agent_id`, and the `entity_id` of rows authored by the source agent, become the local runtime's agent id — the source agent has no entity/agent row in the container (FK), and recall scopes by the local id.
- **Scaffolding**: referenced worlds/rooms/entities are upserted first with their transferred ids, so FKs hold and cross-row identity survives; rooms with no world land in a deterministic per-agent transfer world.
- **Idempotent**: re-POST is a no-op per already-present id (adapter conflict skip + pre-check reported honestly as `skippedExisting`).
- **Validation**: zod at the boundary — uuids, ISO timestamps, exactly-384 finite vectors, embedding/memory id agreement, batch and body-size caps.
- Dispatched before `ensureMemoryConnection` so an import can't create the client-chat room.

## Evidence

- 5/5 vitest (package lane runner): verbatim-persistence + remap matrix, scaffolding ids, idempotent re-import, vector-less rows, schema rejections (wrong-width vector, bad uuid, oversize batch).
- Agent package typecheck clean on touched files; Biome clean.
- End-to-end promotion-path proof lands with the cloud-side follow-up, which exercises this route against a real container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)