### PR TITLE
fix(agent): reject unknown slash-command catalog surface

### DIFF
--- a/packages/agent/src/api/commands-routes.test.ts
+++ b/packages/agent/src/api/commands-routes.test.ts
@@ -7,7 +7,10 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
-import { handleCommandsRoutes } from "./commands-routes.ts";
+import {
+  handleCommandsRoutes,
+  parseCommandSurface,
+} from "./commands-routes.ts";
 
 const res = {} as never;
 
@@ -148,22 +151,29 @@ describe("handleCommandsRoutes", () => {
     expect(keys.has("settings")).toBe(false); // app navigation is GUI-only
   });
 
-  it("ignores an invalid surface and serves the unscoped catalog", async () => {
-    const json = vi.fn();
-    const error = vi.fn();
-    await handleCommandsRoutes({
-      req: {} as never,
-      res,
-      method: "GET",
-      pathname: "/api/commands",
-      url: makeUrl("/api/commands?surface=bogus"),
-      json,
-      error,
-      runtime: null,
-    });
-    const payload = json.mock.calls[0][1] as { surface: string | null };
-    expect(payload.surface).toBeNull();
-  });
+  it.each(["bogus", "DISCORD", "GUI", "web", "slack", " Discord"])(
+    "rejects unknown surface %j with 400 before serving the catalog",
+    async (raw) => {
+      const json = vi.fn();
+      const error = vi.fn();
+      await handleCommandsRoutes({
+        req: {} as never,
+        res,
+        method: "GET",
+        pathname: "/api/commands",
+        url: makeUrl(`/api/commands?surface=${encodeURIComponent(raw)}`),
+        json,
+        error,
+        runtime: null,
+      });
+      expect(error).toHaveBeenCalledWith(
+        res,
+        "surface must be one of: gui, tui, discord, telegram",
+        400,
+      );
+      expect(json).not.toHaveBeenCalled();
+    },
+  );
 
   it("scopes the store to the runtime's agent id when present", async () => {
     const json = vi.fn();
@@ -296,5 +306,31 @@ describe("handleCommandsRoutes", () => {
       // Global navigation commands stay available.
       expect(keys.has("settings")).toBe(true);
     });
+  });
+});
+
+describe("parseCommandSurface", () => {
+  it("omitted and empty keep the historical GUI default", () => {
+    expect(parseCommandSurface(null)).toEqual({ ok: true, surface: null });
+    expect(parseCommandSurface("")).toEqual({ ok: true, surface: null });
+  });
+
+  it("accepts the catalog surface identities", () => {
+    expect(parseCommandSurface("gui")).toEqual({ ok: true, surface: "gui" });
+    expect(parseCommandSurface("tui")).toEqual({ ok: true, surface: "tui" });
+    expect(parseCommandSurface("discord")).toEqual({
+      ok: true,
+      surface: "discord",
+    });
+    expect(parseCommandSurface("telegram")).toEqual({
+      ok: true,
+      surface: "telegram",
+    });
+  });
+
+  it("rejects unknown tokens instead of returning the GUI catalog", () => {
+    expect(parseCommandSurface("DISCORD").ok).toBe(false);
+    expect(parseCommandSurface("web").ok).toBe(false);
+    expect(parseCommandSurface("bogus").ok).toBe(false);
   });
 });

--- a/packages/agent/src/api/commands-routes.ts
+++ b/packages/agent/src/api/commands-routes.ts
@@ -31,6 +31,28 @@ const VALID_SURFACES: ReadonlySet<string> = new Set([
 
 type CommandSurface = "gui" | "tui" | "discord" | "telegram";
 
+const SURFACE_ERROR =
+  "surface must be one of: gui, tui, discord, telegram";
+
+/**
+ * Parse the slash-command catalog `surface` query. Omitted/empty keeps the
+ * historical GUI default (response `surface` stays null). A known surface
+ * filters the catalog. Any other token used to fall through to that same GUI
+ * catalog, so `surface=DISCORD` or `surface=web` silently served GUI-only
+ * commands.
+ */
+export function parseCommandSurface(
+  raw: string | null,
+):
+  | { ok: true; surface: CommandSurface | null }
+  | { ok: false; message: string } {
+  if (raw === null || raw === "") return { ok: true, surface: null };
+  if (VALID_SURFACES.has(raw)) {
+    return { ok: true, surface: raw as CommandSurface };
+  }
+  return { ok: false, message: SURFACE_ERROR };
+}
+
 export interface CommandsRouteContext {
   req: http.IncomingMessage;
   res: http.ServerResponse;
@@ -52,11 +74,12 @@ export async function handleCommandsRoutes(
     return true;
   }
 
-  const surfaceParam = url.searchParams.get("surface");
-  const surface: CommandSurface | null =
-    surfaceParam && VALID_SURFACES.has(surfaceParam)
-      ? (surfaceParam as CommandSurface)
-      : null;
+  const parsedSurface = parseCommandSurface(url.searchParams.get("surface"));
+  if (!parsedSurface.ok) {
+    error(res, parsedSurface.message, 400);
+    return true;
+  }
+  const surface = parsedSurface.surface;
 
   // View-scoped commands (#8798) appear only when their view is foreground.
   // Prefer an explicit ?view= (the client knows what it is rendering), else fall

--- a/packages/agent/src/api/commands-routes.ts
+++ b/packages/agent/src/api/commands-routes.ts
@@ -31,8 +31,7 @@ const VALID_SURFACES: ReadonlySet<string> = new Set([
 
 type CommandSurface = "gui" | "tui" | "discord" | "telegram";
 
-const SURFACE_ERROR =
-  "surface must be one of: gui, tui, discord, telegram";
+const SURFACE_ERROR = "surface must be one of: gui, tui, discord, telegram";
 
 /**
  * Parse the slash-command catalog `surface` query. Omitted/empty keeps the


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on slash-command catalog `surface`.
Surface-identity class, not leftover tax on database-rows sort/page,
memory-viewer type, VFS encoding, models catalogOnly/refresh, Cloud JSON-400,
prefix-coerced limit, percent-encoded paths, SIWS chainId, orchestrator lines,
provisioning-worker env ints, invites-accept, cli-auth, redemption quote,
compat agent-logs, or avatar. Disjoint from approvals `state`.
`view` query untouched.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `surface` only on `/api/commands`. Omitted `surface` still serves the
historical GUI catalog. Canonical `gui` / `tui` / `discord` / `telegram` still
200. Unknown tokens 400 before `getCatalogCommands`.

# Background

## What does this PR do?

`GET /api/commands?surface=` treated every token other than the four catalog
surfaces as "no surface" and then called `getCatalogCommands("gui")`. A client
that asked for `DISCORD`, `web`, or `GUI` received the GUI catalog, including
GUI-only commands.

- omitted / empty → **200** GUI catalog, `surface: null` (today's default)
- `gui` / `tui` / `discord` / `telegram` → **200** that surface
- `DISCORD` / `GUI` / `web` / `bogus` → **400**
  `surface must be one of: gui, tui, discord, telegram` before catalog load

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The catalog `surface` query is supposed to filter commands. Unknown tokens must
not silently serve the GUI catalog. Omit remains the web-composer default the
route already documents.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/commands-routes.test.ts` — existing surface scoping
still green; unknown `surface=DISCORD` 400s with no catalog JSON; parser table
for omit / canonical / reject.

## Detailed testing steps

```bash
cd packages/agent && bunx vitest run --config vitest.config.ts \
  src/api/commands-routes.test.ts --coverage.enabled=false
```

24 passed at the evidence head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; commands catalog `surface` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; commands catalog `surface` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; commands catalog `surface` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused parser tests drive the real `surface` identity and assert 400 before catalog load; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no catalog write; illegal `surface` 400s before `getCatalogCommands`.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal `surface`
tokens reject; omitted/`gui`/`discord`/`telegram`/`tui` still parse.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file commands catalog `surface`
parse with a green focused suite (24 tests). Full monorepo verify is unrelated
to this query grammar and was skipped to keep the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:9349717cfac7658dd12cea67bf94b13bea680ff6 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
