### PR TITLE
fix(agent): reject unknown approval request state

### DIFF
--- a/packages/agent/src/api/approval-routes.test.ts
+++ b/packages/agent/src/api/approval-routes.test.ts
@@ -3,7 +3,7 @@
  * `approvalTaskToPendingAction` projection: pending user actions are merged
  * newest-first and de-duplicated across the approval queue, the ApprovalService
  * task rows, and the pending-prompts service, and missing services yield empty
- * arrays. The untrusted `limit` query is fail-closed. Runs against a mock
+ * arrays. The untrusted `limit` and `state` queries are fail-closed. Runs against a mock
  * runtime and a real ApprovalService backed by an in-memory task store — no
  * live model or HTTP.
  */
@@ -25,6 +25,7 @@ import { PENDING_PROMPTS_SERVICE } from "../services/pending-prompts/service.ts"
 import {
   approvalTaskToPendingAction,
   handleApprovalRoute,
+  parseApprovalState,
 } from "./approval-routes.ts";
 
 const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
@@ -436,5 +437,83 @@ describe("handleApprovalRoute", () => {
       action: null,
       limit: expected,
     });
+  });
+
+  it.each(["DONE", "PENDING", "complete", "open", "ALL", "pending "])(
+    "rejects unknown state %j with 400 before listing",
+    async (raw) => {
+      const { runtime, queueList } = runtimeWithApprovals({});
+      const helpers = makeHelpers();
+
+      const handled = await handleApprovalRoute(
+        req(`/api/approvals?state=${encodeURIComponent(raw)}`),
+        res,
+        "/api/approvals",
+        "GET",
+        { runtime },
+        helpers,
+      );
+
+      expect(handled).toBe(true);
+      expect(helpers.error).toHaveBeenCalledWith(
+        res,
+        "state must be one of: all, pending, approved, executing, retryable, reconciliation_required, done, rejected, expired",
+        400,
+      );
+      expect(helpers.json).not.toHaveBeenCalled();
+      expect(queueList).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    [undefined, "pending"],
+    ["pending", "pending"],
+    ["done", "done"],
+    ["approved", "approved"],
+    ["all", null],
+  ] as const)("accepts state %j as %s", async (raw, expected) => {
+    const { runtime, queueList } = runtimeWithApprovals({});
+    const helpers = makeHelpers();
+    const url =
+      raw === undefined ? "/api/approvals" : `/api/approvals?state=${raw}`;
+
+    await handleApprovalRoute(
+      req(url),
+      res,
+      "/api/approvals",
+      "GET",
+      { runtime },
+      helpers,
+    );
+
+    expect(helpers.error).not.toHaveBeenCalled();
+    expect(queueList).toHaveBeenCalledWith({
+      subjectUserId: null,
+      state: expected,
+      action: null,
+      limit: 50,
+    });
+  });
+});
+
+describe("parseApprovalState", () => {
+  it("omitted and empty keep the pending default", () => {
+    expect(parseApprovalState(null)).toEqual({ ok: true, state: "pending" });
+    expect(parseApprovalState("")).toEqual({ ok: true, state: "pending" });
+  });
+
+  it("accepts all and the lifecycle identities", () => {
+    expect(parseApprovalState("all")).toEqual({ ok: true, state: null });
+    expect(parseApprovalState("done")).toEqual({ ok: true, state: "done" });
+    expect(parseApprovalState("rejected")).toEqual({
+      ok: true,
+      state: "rejected",
+    });
+  });
+
+  it("rejects unknown tokens instead of returning pending", () => {
+    expect(parseApprovalState("DONE").ok).toBe(false);
+    expect(parseApprovalState("complete").ok).toBe(false);
+    expect(parseApprovalState("ALL").ok).toBe(false);
   });
 });

--- a/packages/agent/src/api/approval-routes.ts
+++ b/packages/agent/src/api/approval-routes.ts
@@ -125,12 +125,26 @@ function parseLimit(raw: string | null): number | null {
   return Math.min(parsed, 500);
 }
 
-function parseState(raw: string | null): ApprovalRequestState | null {
-  if (!raw) return "pending";
-  if (raw === "all") return null;
-  return APPROVAL_STATES.includes(raw as ApprovalRequestState)
-    ? (raw as ApprovalRequestState)
-    : "pending";
+/**
+ * Parse the approvals `state` query. Omitted/empty keeps the pending default.
+ * `all` means no state filter. A known lifecycle state selects that queue.
+ * Any other token used to fall through to pending, so `state=DONE` or
+ * `state=complete` silently listed pending work.
+ */
+export function parseApprovalState(
+  raw: string | null,
+):
+  | { ok: true; state: ApprovalRequestState | null }
+  | { ok: false; message: string } {
+  if (raw === null || raw === "") return { ok: true, state: "pending" };
+  if (raw === "all") return { ok: true, state: null };
+  if (APPROVAL_STATES.includes(raw as ApprovalRequestState)) {
+    return { ok: true, state: raw as ApprovalRequestState };
+  }
+  return {
+    ok: false,
+    message: `state must be one of: all, ${APPROVAL_STATES.join(", ")}`,
+  };
 }
 
 function getAgentApprovalQueue(
@@ -327,9 +341,14 @@ export async function handleApprovalRoute(
     helpers.error(res, "limit must be a positive integer", 400);
     return true;
   }
+  const parsedState = parseApprovalState(url.searchParams.get("state"));
+  if (!parsedState.ok) {
+    helpers.error(res, parsedState.message, 400);
+    return true;
+  }
   const filter: ApprovalListFilter = {
     subjectUserId: null,
-    state: parseState(url.searchParams.get("state")),
+    state: parsedState.state,
     action: null,
     limit,
   };


### PR DESCRIPTION
# Relates to

Operator request: disjoint honest Eliza Fix on approvals `state`.
State-identity class, not leftover tax on database-rows sort/page,
memory-viewer type, VFS encoding, models catalogOnly/refresh, Cloud JSON-400,
prefix-coerced limit, percent-encoded paths, SIWS chainId, orchestrator lines,
provisioning-worker env ints, invites-accept, cli-auth, redemption quote,
compat agent-logs, or avatar. Disjoint from commands `surface`.
`limit` parser untouched.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Contribution provenance

Declare the actual assistance used for implementation and review. This is
self-reported provenance, not a request for chain-of-thought. Never include
prompts containing secrets, tokens, private session IDs, or hidden reasoning.
Use exact `provider/model-id` values; `GPT`, `Claude`, or `AI` are not specific
enough. Human-only work must say so explicitly.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented below.

# Risks

Low. GET `state` only on `/api/approvals`. Omitted `state` still lists pending.
Canonical lifecycle tokens and `all` still 200. Unknown tokens 400 before
`queue.list`. Existing `limit` fail-closed path unchanged.

# Background

## What does this PR do?

`GET /api/approvals?state=` treated every token other than the eight lifecycle
states and `all` as `pending`. A client that asked for `DONE`, `complete`, or
`ALL` received the pending queue.

- omitted / empty → **200** pending (today's default)
- `all` → **200** no state filter
- `pending` / `approved` / `executing` / `retryable` / `reconciliation_required`
  / `done` / `rejected` / `expired` → **200** that state
- `DONE` / `PENDING` / `complete` / `ALL` → **400**
  `state must be one of: all, pending, …` before `queue.list`

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The approvals `state` query is supposed to select a lifecycle slice. Unknown
tokens must not silently list pending work. Omit remains the pending default
the route already uses.

# Documentation changes needed?

No.

# Testing

## Where should a reviewer start?

`packages/agent/src/api/approval-routes.test.ts` — existing limit table still
green; unknown `state=DONE` 400s with `queue.list` never called; parser table
for omit / canonical / reject.

## Detailed testing steps

```bash
cd packages/agent && bunx vitest run --config vitest.config.ts \
  src/api/approval-routes.test.ts --coverage.enabled=false
```

41 passed at the evidence head.

# Evidence Gate

Evidence must match the exact commit reviewed.

<!-- evidence-row:before-screenshots -->
- [x] N/A - no rendered UI; approvals `state` query only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no rendered UI; approvals `state` query only.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no rendered UI; approvals `state` query only.
<!-- evidence-row:backend-logs -->
- [x] N/A - focused parser tests drive the real `state` identity and assert 400 before `queue.list`; no production log capture is required to see the contract.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request path in this proof.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, or model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no approval write; illegal `state` 400s before `queue.list`.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model change.

## Backend + frontend logs

N/A - the acceptance proof is the focused bun test output: illegal `state`
tokens reject; omitted/`pending`/`done`/`all` still parse.

## Screenshots (before / after) + video walkthrough

N/A - no UI.

## Audio / voice walkthrough

N/A - no voice/TTS/STT change.

## Known gaps / failures

`bun run verify` was not run. This is a two-file approvals `state` parse with a
green focused suite (41 tests). Full monorepo verify is unrelated to this query
grammar and was skipped to keep the proof tied to the changed path.

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: xai/grok-4.6
<!-- attribution-row:client -->
- Agent tooling: Cursor
<!-- attribution-row:skill-revision -->
- Skill path: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
<!-- attribution-row:status -->
- Provenance status: self-reported

<!-- evidence-head:781d06aeae0aebad2e0c938554c624e082cda548 -->

AI provider/model: xAI / grok-4.6
Client / agent tooling: Cursor
Contribution skill revision: elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza
Attribution status: self-reported
— [cursor-ss251]
<!-- eliza-computer-attribution:v1 {"provider":"xai","model":"grok-4.6","client":"Cursor","skill_revision":"elizaOS/slopdotcash@72e4239ebed8c99d34181d5d1f21fb316cacecd6:skills/contribute-to-eliza"} -->
