### PR TITLE
fix(ci): resolve Discord gateway source exports

### DIFF
--- a/.github/workflows/cloud-gateway-discord.yml
+++ b/.github/workflows/cloud-gateway-discord.yml
@@ -85,13 +85,23 @@ jobs:
       - name: Install root dependencies
         run: bun install --frozen-lockfile --no-save && git diff --exit-code -- bun.lock
 
+      - name: Generate source keyword modules
+        working-directory: .
+        run: bun run --cwd packages/shared build:i18n
+
       - name: Run service tests
         working-directory: packages/cloud/services/gateway-discord
-        run: bun test tests/ --timeout 60000
+        # The gateway imports source-form workspace subpaths such as
+        # @elizaos/shared/discord-dm-policy. Match the package-owned test
+        # script's export condition so a clean runner never falls through to
+        # an unbuilt dist/ entry.
+        run: bun --conditions=eliza-source test tests/ --timeout 60000
         env:
           SKIP_SERVER_CHECK: "true"
 
       - name: Run lib tests
-        run: bun test src/lib/services/gateway-discord/__tests__ --timeout 60000
+        # These tests traverse plugin/runtime source exports as part of the
+        # routing contract, so they need the same clean-runner source condition.
+        run: bun --conditions=eliza-source test src/lib/services/gateway-discord/__tests__ --timeout 60000
         env:
           SKIP_SERVER_CHECK: "true"

--- a/packages/cloud/shared/scripts/messaging-gateway-preflight.test.mjs
+++ b/packages/cloud/shared/scripts/messaging-gateway-preflight.test.mjs
@@ -87,4 +87,21 @@ test("workflow keeps trusted configuration checks manual and source tests on dev
     /ELIZA_APP_WEBHOOK_GATEWAY_URL: \$\{\{ secrets\.ELIZA_APP_WEBHOOK_GATEWAY_URL \}\}/,
   );
   assert.match(workflow, /GATEWAY_INTERNAL_SECRET: \$\{\{ secrets\.GATEWAY_INTERNAL_SECRET \}\}/);
+  assert.match(
+    workflow,
+    /name: Generate source keyword modules\s+working-directory: \.\s+run: bun run --cwd packages\/shared build:i18n/,
+  );
+  assert.match(
+    workflow,
+    /working-directory: packages\/cloud\/services\/gateway-discord\s+[\s\S]*?run: bun --conditions=eliza-source test tests\/ --timeout 60000/,
+  );
+  assert.match(
+    workflow,
+    /run: bun --conditions=eliza-source test src\/lib\/services\/gateway-discord\/__tests__ --timeout 60000/,
+  );
+  assert.doesNotMatch(workflow, /run: bun test tests\/ --timeout 60000/);
+  assert.doesNotMatch(
+    workflow,
+    /run: bun test src\/lib\/services\/gateway-discord\/__tests__ --timeout 60000/,
+  );
 });


### PR DESCRIPTION
# Relates to

Closes #20867.

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts.
- [x] `bun install` and `bun run verify` were run after sync.
- [x] A reviewer can confirm the change works from the focused clean-runner logs below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `openai/gpt-5.6-sol`
<!-- attribution-row:client -->
- Agent tooling: `Codex Desktop`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@88531115dde449cb600e283ad17ed4faa783a84e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased onto exact `origin/develop@9c5e896c4c7d49c272edc284c519f984270fc617`; zero conflicts.
- [x] Full `bun run verify` passed 356/356 on the immediately preceding rebased head. After the final two-commit disjoint Cloud rebase, all 231 focused tests, pinned workflow lint, formatting, and diff checks were rerun at exact head.

# Risks

Low. The diff changes only a validation workflow and its executable contract test. It does not deploy, change Discord runtime behavior, or read protected values. The failure mode is limited to CI setup: source-form workspace exports and generated keyword modules must exist before the gateway suites run.

# Background

## What does this PR do?

The clean `Cloud Gateway Discord` runner invoked raw `bun test`, so Bun resolved source-form workspace subpaths through missing `dist` output. The first visible error was `@elizaos/shared/discord-dm-policy`; the shared routing suite would then fail on the generated validation-keyword module.

This PR makes the workflow match the package-owned test contract:

- generate the source keyword modules after install;
- run both gateway suites with `--conditions=eliza-source`; and
- pin those commands with the existing messaging workflow contract test.

## What kind of change is this?

Bug fix (non-breaking CI correction).

# Documentation changes needed?

No product documentation change is required. The package manifest already defines `eliza-source` as the supported test condition; this workflow now follows it.

# Testing

## Where should a reviewer start?

Review `.github/workflows/cloud-gateway-discord.yml`, then run the workflow contract test in `packages/cloud/shared/scripts/messaging-gateway-preflight.test.mjs`.

## Detailed testing steps

- `bun install --frozen-lockfile` — 3,816 installs checked, no changes.
- Gateway service suite — 116/116 tests, 352 expectations.
- Shared Discord routing suite — 111/111 tests, 179 expectations.
- Messaging workflow contract — 4/4 tests.
- Pinned `actionlint` — pass.
- Biome on both changed files — pass.
- `git diff --check` — pass.
- Full root `bun run verify` on the immediately preceding rebased head — 356/356, all follow-on audits and anti-larp clean; the final disjoint two-commit rebase was followed by an exact-head 231/231 focused rerun plus workflow lint and diff checks.

# Evidence Gate

<!-- evidence-head:fff08f7e2cee884473b79fcc3169f4a88d2bab3c -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A: workflow-only change with no rendered UI surface
<!-- evidence-row:after-screenshots -->
- [ ] N/A: workflow-only change with no rendered UI surface
<!-- evidence-row:walkthrough-video -->
- [ ] N/A: workflow-only change with no interactive user flow
<!-- evidence-row:backend-logs -->
- [x] [20900-20867-service-tests-final.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20900-20867-service-tests-final.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A: no frontend runtime path changes
<!-- evidence-row:llm-trajectory -->
- [ ] N/A: no agent, prompt, provider, or model behavior changes
<!-- evidence-row:domain-artifacts -->
- [x] [20900-20867-lib-tests-final.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence-5/20900-20867-lib-tests-final.log)
<!-- evidence-row:ocr-review -->
- [ ] N/A: no visual text or rendered UI changes

# Evidence Details

## Real LLM-call trajectory

N/A - no model behavior changes.

## Backend + frontend logs

The focused service, shared routing, workflow-contract, and root verification logs are attached as immutable release artifacts.

## Screenshots (before / after) + video walkthrough

N/A - workflow-only change.

## Known gaps / failures

The hosted `Cloud Gateway Discord` workflow can only prove the clean GitHub runner path after this PR lands on `develop`; that post-merge run remains part of issue acceptance. There is no runtime deployment in this PR.

Client / agent tooling: Codex Desktop
Contribution skill revision: elizaOS/eliza@88531115dde449cb600e283ad17ed4faa783a84e:packages/skills/skills/contribute-to-eliza
Attribution status: self-reported

