### PR TITLE
fix(cloud): close remaining strong revocation races

### DIFF
--- a/packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.miniflare.test.ts
@@ -290,6 +290,7 @@ describe("Miniflare Durable Object integration", () => {
       organizationId: "org-miniflare",
       kind: "steward_session",
       userId: "00000000-0000-0000-0000-000000000202",
+      stewardUserId: "steward-user-202",
     };
     expect(
       (
@@ -308,6 +309,43 @@ describe("Miniflare Durable Object integration", () => {
     ).toBe(200);
   });
 
+  test("revoked session bindings reject new tokens using a stale user mapping", async () => {
+    const credential = {
+      organizationId: "org-miniflare-session-binding",
+      kind: "steward_session",
+      userId: "00000000-0000-0000-0000-000000000205",
+      stewardUserId: "steward-user-unlinked",
+      issuedAt: 201,
+    };
+    expect((await post("/credential/check", credential)).status).toBe(200);
+    expect(
+      (
+        await post("/session/set-binding-active", {
+          organizationId: credential.organizationId,
+          userId: credential.userId,
+          stewardUserId: credential.stewardUserId,
+          active: false,
+        })
+      ).status,
+    ).toBe(200);
+    const denied = await post("/credential/check", {
+      ...credential,
+      issuedAt: credential.issuedAt + 1,
+    });
+    expect(denied.status).toBe(403);
+    expect(JSON.parse(await denied.text())).toEqual({
+      allowed: false,
+      reason: "session_binding_revoked",
+    });
+    await post("/session/set-binding-active", {
+      organizationId: credential.organizationId,
+      userId: credential.userId,
+      stewardUserId: credential.stewardUserId,
+      active: true,
+    });
+    expect((await post("/credential/check", credential)).status).toBe(200);
+  });
+
   test("subject and organization suspension are reversible durable fences", async () => {
     const credential = {
       organizationId: "org-miniflare",
@@ -321,6 +359,7 @@ describe("Miniflare Durable Object integration", () => {
           organizationId: credential.organizationId,
           userId: credential.userId,
           active: false,
+          reason: "account",
         })
       ).status,
     ).toBe(200);
@@ -329,6 +368,7 @@ describe("Miniflare Durable Object integration", () => {
       organizationId: credential.organizationId,
       userId: credential.userId,
       active: true,
+      reason: "account",
     });
     expect((await post("/credential/check", credential)).status).toBe(200);
 
@@ -400,4 +440,51 @@ describe("Miniflare Durable Object integration", () => {
     expect(body.cutoverAt).toBeGreaterThan(Date.now());
     expect(body.cutoverAt - Date.now()).toBeLessThanOrEqual(60_000);
   }, 120_000);
+
+  test("clearing one subject denial cannot clear an independent denial", async () => {
+    const credential = {
+      organizationId: "org-miniflare-independent-fences",
+      kind: "api_key",
+      credentialId: "00000000-0000-0000-0000-000000000103",
+      userId: "00000000-0000-0000-0000-000000000204",
+    };
+    for (const reason of ["account", "moderation"]) {
+      expect(
+        (
+          await post("/subject/set-active", {
+            organizationId: credential.organizationId,
+            userId: credential.userId,
+            active: false,
+            reason,
+          })
+        ).status,
+      ).toBe(200);
+    }
+
+    expect((await post("/credential/check", credential)).status).toBe(403);
+    expect(
+      (
+        await post("/subject/set-active", {
+          organizationId: credential.organizationId,
+          userId: credential.userId,
+          active: true,
+          reason: "moderation",
+        })
+      ).status,
+    ).toBe(200);
+    const stillDenied = await post("/credential/check", credential);
+    expect(stillDenied.status).toBe(403);
+    expect(JSON.parse(await stillDenied.text())).toEqual({
+      allowed: false,
+      reason: "subject_account_disabled",
+    });
+
+    await post("/subject/set-active", {
+      organizationId: credential.organizationId,
+      userId: credential.userId,
+      active: true,
+      reason: "account",
+    });
+    expect((await post("/credential/check", credential)).status).toBe(200);
+  });
 });

--- a/packages/cloud/api/__tests__/inference-admission-gate.test.ts
+++ b/packages/cloud/api/__tests__/inference-admission-gate.test.ts
@@ -35,9 +35,23 @@ class TestStorage {
   failNextSetAlarm = false;
   failNextTransactionCommit = false;
 
-  async get<T>(key: string): Promise<T | undefined> {
+  async get<T>(key: string): Promise<T | undefined>;
+  async get<T>(keys: string[]): Promise<Map<string, T>>;
+  async get<T>(
+    keyOrKeys: string | string[],
+  ): Promise<T | undefined | Map<string, T>> {
     await Promise.resolve();
-    const value = this.values.get(key);
+    if (Array.isArray(keyOrKeys)) {
+      return new Map(
+        keyOrKeys.flatMap((key) => {
+          const value = this.values.get(key);
+          return value === undefined
+            ? []
+            : [[key, structuredClone(value) as T]];
+        }),
+      );
+    }
+    const value = this.values.get(keyOrKeys);
     return value === undefined ? undefined : (structuredClone(value) as T);
   }
 

--- a/packages/cloud/api/docs/inference-hot-path.md
+++ b/packages/cloud/api/docs/inference-hot-path.md
@@ -132,10 +132,13 @@ unless the strong boundary flag is also true. API keys use their immutable row
 ID, Steward logout records the verified token `iat`, user lifecycle changes
 fence the immutable Cloud user ID, and organization suspension fences the
 organization object. Revocation mutations commit the fence before returning;
-reactivation clears only reversible subject or organization fences, while a
-revoked API-key identity can never be reused. Organization moves and local role
-or Steward-identity changes advance the session cutoff before the corresponding
-database mutation reports success.
+reactivation clears only its reason-scoped account, moderation, or membership
+fence, while a revoked API-key identity can never be reused. Organization moves
+and local role or Steward-identity changes advance the session cutoff before the
+corresponding database mutation reports success. Steward-identity changes also
+disable the old `(Cloud user, Steward subject)` binding before mutation and
+enable only the post-commit binding, so a newly issued token cannot authorize
+through a stale pre-change identity projection.
 
 Pricing, affiliate attribution, app/agent policy, and uninitialized Durable
 Objects follow the same fail-closed warming pattern. Route-scope caches add no

--- a/packages/cloud/api/src/inference-admission-gate.ts
+++ b/packages/cloud/api/src/inference-admission-gate.ts
@@ -99,6 +99,7 @@ type CredentialCheckRequest =
       organizationId: string;
       kind: "steward_session";
       userId: string;
+      stewardUserId: string;
       issuedAt: number;
     };
 
@@ -112,12 +113,22 @@ interface SubjectStateRequest {
   organizationId: string;
   userId: string;
   active: boolean;
+  reason: SubjectDisableReason;
 }
+
+type SubjectDisableReason = "account" | "moderation" | "membership";
 
 interface SessionRevokeRequest {
   organizationId: string;
   userId: string;
   issuedAt: number;
+}
+
+interface SessionBindingStateRequest {
+  organizationId: string;
+  userId: string;
+  stewardUserId: string;
+  active: boolean;
 }
 
 interface OrganizationStateRequest {
@@ -148,6 +159,7 @@ const REVOKED_API_KEY_PREFIX = "revocation:api-key:";
 const DISABLED_SUBJECT_PREFIX = "revocation:subject-disabled:";
 const SESSION_CUTOFF_PREFIX = "revocation:session-cutoff:";
 const RATE_LIMIT_CUTOVERS_KEY = "rate-limit-v2-cutovers";
+const REVOKED_SESSION_BINDING_PREFIX = "revocation:session-binding:";
 const MAX_LEASE_AGE_MS = 20 * 60_000;
 const RECOVERY_RETRY_MS = 60_000;
 const MAX_ACTIVE_LEASES = 2_048;
@@ -173,6 +185,11 @@ const APP_REVIEW_STATUSES = new Set([
   "approved",
   "rejected",
 ]);
+const SUBJECT_DISABLE_REASONS: readonly SubjectDisableReason[] = [
+  "account",
+  "moderation",
+  "membership",
+];
 
 function nonNegativeFinite(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value >= 0;
@@ -197,6 +214,20 @@ function validTrimmedId(value: unknown): value is string {
 
 function revocationStorageKey(prefix: string, id: string): string {
   return `${prefix}${encodeURIComponent(id)}`;
+}
+
+function subjectRevocationStorageKey(
+  userId: string,
+  reason: SubjectDisableReason,
+): string {
+  return `${revocationStorageKey(DISABLED_SUBJECT_PREFIX, userId)}:${reason}`;
+}
+
+function sessionBindingStorageKey(
+  userId: string,
+  stewardUserId: string,
+): string {
+  return `${revocationStorageKey(REVOKED_SESSION_BINDING_PREFIX, userId)}:${encodeURIComponent(stewardUserId)}`;
 }
 
 function validRecoveryContext(
@@ -1024,32 +1055,47 @@ export class InferenceAdmissionGate {
       !validTrimmedId(request.userId) ||
       (request.kind === "api_key" && !validTrimmedId(request.credentialId)) ||
       (request.kind === "steward_session" &&
-        (!Number.isSafeInteger(request.issuedAt) || request.issuedAt <= 0))
+        (!validTrimmedId(request.stewardUserId) ||
+          !Number.isSafeInteger(request.issuedAt) ||
+          request.issuedAt <= 0))
     ) {
       return jsonError("Invalid inference credential check", 400);
     }
 
-    if (await this.state.storage.get<boolean>(ORGANIZATION_DISABLED_KEY)) {
+    const subjectKeys = SUBJECT_DISABLE_REASONS.map((reason) =>
+      subjectRevocationStorageKey(request.userId, reason),
+    );
+    const credentialKeys =
+      request.kind === "api_key"
+        ? [revocationStorageKey(REVOKED_API_KEY_PREFIX, request.credentialId)]
+        : [
+            sessionBindingStorageKey(request.userId, request.stewardUserId),
+            revocationStorageKey(SESSION_CUTOFF_PREFIX, request.userId),
+          ];
+    const revocations = await this.state.storage.get<boolean | number>([
+      ORGANIZATION_DISABLED_KEY,
+      ...subjectKeys,
+      ...credentialKeys,
+    ]);
+
+    if (revocations.get(ORGANIZATION_DISABLED_KEY) === true) {
       return Response.json(
         { allowed: false, reason: "organization_disabled" },
         { status: 403 },
       );
     }
-    if (
-      await this.state.storage.get<boolean>(
-        revocationStorageKey(DISABLED_SUBJECT_PREFIX, request.userId),
-      )
-    ) {
-      return Response.json(
-        { allowed: false, reason: "subject_disabled" },
-        { status: 403 },
-      );
+    for (const [index, reason] of SUBJECT_DISABLE_REASONS.entries()) {
+      const key = subjectKeys[index];
+      if (key && revocations.get(key) === true) {
+        return Response.json(
+          { allowed: false, reason: `subject_${reason}_disabled` },
+          { status: 403 },
+        );
+      }
     }
 
     if (request.kind === "api_key") {
-      const revoked = await this.state.storage.get<boolean>(
-        revocationStorageKey(REVOKED_API_KEY_PREFIX, request.credentialId),
-      );
+      const revoked = revocations.get(credentialKeys[0] ?? "") === true;
       return revoked
         ? Response.json(
             { allowed: false, reason: "credential_revoked" },
@@ -1058,9 +1104,15 @@ export class InferenceAdmissionGate {
         : Response.json({ allowed: true });
     }
 
-    const cutoff = await this.state.storage.get<number>(
-      revocationStorageKey(SESSION_CUTOFF_PREFIX, request.userId),
-    );
+    if (revocations.get(credentialKeys[0] ?? "") === true) {
+      return Response.json(
+        { allowed: false, reason: "session_binding_revoked" },
+        { status: 403 },
+      );
+    }
+
+    const cutoffValue = revocations.get(credentialKeys[1] ?? "");
+    const cutoff = typeof cutoffValue === "number" ? cutoffValue : undefined;
     return cutoff !== undefined && request.issuedAt <= cutoff
       ? Response.json(
           { allowed: false, reason: "session_revoked" },
@@ -1092,11 +1144,12 @@ export class InferenceAdmissionGate {
     if (
       !validTrimmedId(request.organizationId) ||
       !validTrimmedId(request.userId) ||
-      typeof request.active !== "boolean"
+      typeof request.active !== "boolean" ||
+      !SUBJECT_DISABLE_REASONS.includes(request.reason)
     ) {
       return jsonError("Invalid inference subject state", 400);
     }
-    const key = revocationStorageKey(DISABLED_SUBJECT_PREFIX, request.userId);
+    const key = subjectRevocationStorageKey(request.userId, request.reason);
     if (request.active) await this.state.storage.delete(key);
     else await this.state.storage.put(key, true);
     return Response.json({ committed: true });
@@ -1116,6 +1169,23 @@ export class InferenceAdmissionGate {
     const key = revocationStorageKey(SESSION_CUTOFF_PREFIX, request.userId);
     const previous = (await this.state.storage.get<number>(key)) ?? 0;
     await this.state.storage.put(key, Math.max(previous, request.issuedAt));
+    return Response.json({ committed: true });
+  }
+
+  private async setSessionBindingActive(
+    request: SessionBindingStateRequest,
+  ): Promise<Response> {
+    if (
+      !validTrimmedId(request.organizationId) ||
+      !validTrimmedId(request.userId) ||
+      !validTrimmedId(request.stewardUserId) ||
+      typeof request.active !== "boolean"
+    ) {
+      return jsonError("Invalid inference session binding revocation", 400);
+    }
+    const key = sessionBindingStorageKey(request.userId, request.stewardUserId);
+    if (request.active) await this.state.storage.delete(key);
+    else await this.state.storage.put(key, true);
     return Response.json({ committed: true });
   }
 
@@ -1153,6 +1223,7 @@ export class InferenceAdmissionGate {
       | CredentialRevokeRequest
       | SubjectStateRequest
       | SessionRevokeRequest
+      | SessionBindingStateRequest
       | OrganizationStateRequest
       | RateLimitCutoverRequest;
     try {
@@ -1166,6 +1237,7 @@ export class InferenceAdmissionGate {
         | CredentialRevokeRequest
         | SubjectStateRequest
         | SessionRevokeRequest
+        | SessionBindingStateRequest
         | OrganizationStateRequest
         | RateLimitCutoverRequest;
     } catch {
@@ -1224,6 +1296,11 @@ export class InferenceAdmissionGate {
     if (path === "/session/revoke-through") {
       return await this.serialize(() =>
         this.revokeSessionsThrough(body as SessionRevokeRequest),
+      );
+    }
+    if (path === "/session/set-binding-active") {
+      return await this.serialize(() =>
+        this.setSessionBindingActive(body as SessionBindingStateRequest),
       );
     }
     if (path === "/organization/set-active") {

--- a/packages/cloud/shared/src/lib/services/admin-moderation-iac.test.ts
+++ b/packages/cloud/shared/src/lib/services/admin-moderation-iac.test.ts
@@ -26,7 +26,10 @@ mock.module("../../db/client", () => ({
     query: {
       userModerationStatus: { findFirst: async () => existingStatus },
       users: {
-        findFirst: async () => ({ steward_user_id: "steward-user-1" }),
+        findFirst: async () => ({
+          steward_user_id: "steward-user-1",
+          organization_id: "org-1",
+        }),
       },
     },
   },
@@ -46,9 +49,15 @@ mock.module("../../db/repositories", () => ({
 
 const invalidateSpy = mock(async (_hashes: readonly string[]) => undefined);
 const invalidateSessionSpy = mock(async (_ids: readonly string[]) => undefined);
+const subjectFenceSpy = mock(
+  async (_orgId: string, _userId: string, _active: boolean, _reason: string) => undefined,
+);
 mock.module("./inference-auth-cache", () => ({
   invalidateInferenceAuthContextsByKeyHashes: invalidateSpy,
   invalidateInferenceSessionAuthContexts: invalidateSessionSpy,
+}));
+mock.module("./inference-credential-revocation", () => ({
+  setInferenceSubjectActive: subjectFenceSpy,
 }));
 
 const { adminService } = await import("./admin");
@@ -66,6 +75,7 @@ async function recordRefusal(userId = "user-1") {
 beforeEach(() => {
   invalidateSpy.mockClear();
   invalidateSessionSpy.mockClear();
+  subjectFenceSpy.mockClear();
 });
 
 describe("moderation auto-suspension invalidates IAC", () => {
@@ -81,6 +91,7 @@ describe("moderation auto-suspension invalidates IAC", () => {
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
     expect(invalidateSpy).toHaveBeenCalledWith(["hash-1", "hash-2"]);
     expect(invalidateSessionSpy).toHaveBeenCalledWith(["steward-user-1"]);
+    expect(subjectFenceSpy).toHaveBeenCalledWith("org-1", "user-1", false, "moderation");
   });
 
   test("an already-blocking user does not re-invalidate (transition-only)", async () => {
@@ -93,6 +104,7 @@ describe("moderation auto-suspension invalidates IAC", () => {
     };
     await recordRefusal();
     expect(invalidateSpy).not.toHaveBeenCalled();
+    expect(subjectFenceSpy).not.toHaveBeenCalled();
   });
 
   test("a violation below the blocking threshold does not invalidate", async () => {
@@ -105,11 +117,13 @@ describe("moderation auto-suspension invalidates IAC", () => {
     };
     await recordRefusal();
     expect(invalidateSpy).not.toHaveBeenCalled();
+    expect(subjectFenceSpy).not.toHaveBeenCalled();
   });
 
   test("a brand-new violator (no prior row) does not invalidate", async () => {
     existingStatus = undefined;
     await recordRefusal();
     expect(invalidateSpy).not.toHaveBeenCalled();
+    expect(subjectFenceSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/shared/src/lib/services/admin.ts
+++ b/packages/cloud/shared/src/lib/services/admin.ts
@@ -379,6 +379,18 @@ class AdminService {
         newStatus = "warned";
       }
 
+      const wasBlocking = existing.status === "banned" || existing.totalViolations >= 5;
+      const isBlocking = newStatus === "banned" || newTotalViolations >= 5;
+      if (isBlocking && !wasBlocking) {
+        const user = await dbRead.query.users.findFirst({
+          where: eq(users.id, userId),
+          columns: { organization_id: true },
+        });
+        if (user?.organization_id) {
+          await setInferenceSubjectActive(user.organization_id, userId, false, "moderation");
+        }
+      }
+
       await dbWrite
         .update(userModerationStatus)
         .set({
@@ -397,8 +409,6 @@ class AdminService {
       // inference auth-context so they stop fast-pathing inference within the
       // request, not after the IAC TTL. Wired into the authoritative mutation so
       // every moderation entrypoint (chat, messages, A2A) is covered uniformly.
-      const wasBlocking = existing.status === "banned" || existing.totalViolations >= 5;
-      const isBlocking = newStatus === "banned" || newTotalViolations >= 5;
       if (isBlocking && !wasBlocking) {
         await invalidateUserInferenceContext(userId);
       }
@@ -495,7 +505,7 @@ class AdminService {
       columns: { organization_id: true },
     });
     if (user?.organization_id) {
-      await setInferenceSubjectActive(user.organization_id, userId, false);
+      await setInferenceSubjectActive(user.organization_id, userId, false, "moderation");
     }
 
     if (existing) {
@@ -552,7 +562,7 @@ class AdminService {
       columns: { organization_id: true },
     });
     if (user?.organization_id) {
-      await setInferenceSubjectActive(user.organization_id, userId, true);
+      await setInferenceSubjectActive(user.organization_id, userId, true, "moderation");
     }
 
     logger.info("[Admin] User unbanned", { userId, adminUserId });

--- a/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-auth-lifecycle.test.ts
@@ -39,14 +39,27 @@ mock.module("./inference-auth-cache", () => ({
 }));
 
 mock.module("./inference-credential-revocation", () => ({
+  setInferenceSessionBindingActive: async (
+    orgId: string,
+    userId: string,
+    stewardUserId: string,
+    active: boolean,
+  ) => {
+    lifecycleEvents.push(`session-binding:${orgId}:${userId}:${stewardUserId}:${active}`);
+  },
   revokeInferenceSessionsThrough: async (orgId: string, userId: string) => {
     lifecycleEvents.push(`session:${orgId}:${userId}`);
   },
   setInferenceOrganizationActive: async (orgId: string, active: boolean) => {
     lifecycleEvents.push(`organization:${orgId}:${active}`);
   },
-  setInferenceSubjectActive: async (orgId: string, userId: string, active: boolean) => {
-    lifecycleEvents.push(`subject:${orgId}:${userId}:${active}`);
+  setInferenceSubjectActive: async (
+    orgId: string,
+    userId: string,
+    active: boolean,
+    reason: string,
+  ) => {
+    lifecycleEvents.push(`subject:${orgId}:${userId}:${active}:${reason}`);
   },
 }));
 
@@ -166,12 +179,13 @@ describe("UsersService — IAC invalidation on lifecycle", () => {
     await usersService.update("u1", { organization_id: "o2" });
 
     expect(lifecycleEvents).toEqual([
-      "subject:o1:u1:false",
-      "subject:o2:u1:false",
+      "subject:o1:u1:false:membership",
+      "subject:o2:u1:false:membership",
       "session:o2:u1",
       "session:o1:u1",
       "user-update:u1",
-      "subject:o2:u1:true",
+      "subject:o2:u1:true:account",
+      "subject:o2:u1:true:membership",
     ]);
   });
 
@@ -186,7 +200,48 @@ describe("UsersService — IAC invalidation on lifecycle", () => {
     const { usersService } = await import("./users");
     await usersService.upsertStewardIdentity("u1", "steward-new");
 
-    expect(lifecycleEvents).toEqual(["session:o1:u1", "identity-upsert:u1:steward-new"]);
+    expect(lifecycleEvents).toEqual([
+      "session-binding:o1:u1:steward-old:false",
+      "session:o1:u1",
+      "identity-upsert:u1:steward-new",
+      "session-binding:o1:u1:steward-new:true",
+    ]);
+  });
+
+  test("direct Steward identity update swaps the durable binding around the row write", async () => {
+    userRecord = {
+      id: "u1",
+      organization_id: "o1",
+      email: null,
+      steward_user_id: "steward-old",
+    };
+
+    const { usersService } = await import("./users");
+    await usersService.update("u1", { steward_user_id: "steward-new" });
+
+    expect(lifecycleEvents).toEqual([
+      "session-binding:o1:u1:steward-old:false",
+      "session:o1:u1",
+      "user-update:u1",
+      "session-binding:o1:u1:steward-new:true",
+    ]);
+  });
+
+  test("retrying a committed Steward identity update repairs its active binding", async () => {
+    userRecord = {
+      id: "u1",
+      organization_id: "o1",
+      email: null,
+      steward_user_id: "steward-current",
+    };
+
+    const { usersService } = await import("./users");
+    await usersService.update("u1", { steward_user_id: "steward-current" });
+
+    expect(lifecycleEvents).toEqual([
+      "user-update:u1",
+      "session-binding:o1:u1:steward-current:true",
+    ]);
   });
 
   test("Steward identity link fences the prior session generation before relinking", async () => {
@@ -200,7 +255,12 @@ describe("UsersService — IAC invalidation on lifecycle", () => {
     const { usersService } = await import("./users");
     await usersService.linkStewardId("u1", "steward-new");
 
-    expect(lifecycleEvents).toEqual(["session:o1:u1", "identity-link:u1:steward-new"]);
+    expect(lifecycleEvents).toEqual([
+      "session-binding:o1:u1:steward-old:false",
+      "session:o1:u1",
+      "identity-link:u1:steward-new",
+      "session-binding:o1:u1:steward-new:true",
+    ]);
   });
 
   test("delete resolves the key hashes BEFORE deleting the row", async () => {

--- a/packages/cloud/shared/src/lib/services/inference-credential-revocation.ts
+++ b/packages/cloud/shared/src/lib/services/inference-credential-revocation.ts
@@ -20,7 +20,9 @@ const OPERATION_TIMEOUT_MS = 1_500;
 
 type CredentialCheck =
   | { kind: "api_key"; credentialId: string; userId: string }
-  | { kind: "steward_session"; userId: string; issuedAt: number };
+  | { kind: "steward_session"; userId: string; stewardUserId: string; issuedAt: number };
+
+export type InferenceSubjectDisableReason = "account" | "moderation" | "membership";
 
 interface RevocationResponse {
   allowed?: boolean;
@@ -168,8 +170,9 @@ export async function setInferenceSubjectActive(
   organizationId: string,
   userId: string,
   active: boolean,
+  reason: InferenceSubjectDisableReason,
 ): Promise<void> {
-  await commitMutation(organizationId, "/subject/set-active", { userId, active });
+  await commitMutation(organizationId, "/subject/set-active", { userId, active, reason });
 }
 
 /** Revoke Steward sessions issued at or before the supplied immutable iat. */
@@ -179,6 +182,20 @@ export async function revokeInferenceSessionsThrough(
   issuedAt: number,
 ): Promise<void> {
   await commitMutation(organizationId, "/session/revoke-through", { userId, issuedAt });
+}
+
+/** Disable or re-enable one Steward-subject to Cloud-user identity binding. */
+export async function setInferenceSessionBindingActive(
+  organizationId: string,
+  userId: string,
+  stewardUserId: string,
+  active: boolean,
+): Promise<void> {
+  await commitMutation(organizationId, "/session/set-binding-active", {
+    userId,
+    stewardUserId,
+    active,
+  });
 }
 
 /** Disable or re-enable every inference credential in an organization. */

--- a/packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts
+++ b/packages/cloud/shared/src/lib/services/inference-session-auth-context.test.ts
@@ -27,6 +27,7 @@ let getUser:
 let userReads = 0;
 let moderationReads = 0;
 let assertSessionActive: () => Promise<void>;
+const strongCredentialChecks: Array<Record<string, unknown>> = [];
 const ADMISSION = {
   balance: { balanceUsd: 100, balanceAt: 1, balanceRevision: "1" },
   rateLimits: {
@@ -75,8 +76,15 @@ mock.module("./inference-credential-revocation", () => ({
       this.name = "InferenceCredentialRevokedError";
     }
   },
-  assertInferenceCredentialActive: () => assertSessionActive(),
+  assertInferenceCredentialActive: (
+    _organizationId: string,
+    credential: Record<string, unknown>,
+  ) => {
+    strongCredentialChecks.push(credential);
+    return assertSessionActive();
+  },
   revokeInferenceApiKey: async () => undefined,
+  setInferenceSessionBindingActive: async () => undefined,
   revokeInferenceSessionsThrough: async () => undefined,
   setInferenceOrganizationActive: async () => undefined,
   setInferenceSubjectActive: async () => undefined,
@@ -105,6 +113,7 @@ beforeEach(async () => {
   };
   userReads = 0;
   moderationReads = 0;
+  strongCredentialChecks.length = 0;
   assertSessionActive = async () => undefined;
   getUser = async () => ({
     id: "user-1",
@@ -140,7 +149,6 @@ describe("resolveInferenceSessionAuthContext", () => {
     expect(waited).toHaveLength(1);
     expect(userReads).toBe(1);
     expect(moderationReads).toBe(0);
-
     releaseUser();
     await Promise.all(waited);
     expect(moderationReads).toBe(1);
@@ -174,6 +182,12 @@ describe("resolveInferenceSessionAuthContext", () => {
     });
     expect(userReads).toBe(0);
     expect(moderationReads).toBe(0);
+    expect(strongCredentialChecks.at(-1)).toEqual({
+      kind: "steward_session",
+      userId: "user-1",
+      stewardUserId: "steward-1",
+      issuedAt: claims?.issuedAt,
+    });
   });
 
   test("warm verified session is denied when its issued-at cutoff is revoked", async () => {
@@ -199,6 +213,27 @@ describe("resolveInferenceSessionAuthContext", () => {
     expect(result).toEqual({ kind: "rejected", status: 401 });
     expect(userReads).toBe(0);
     expect(moderationReads).toBe(0);
+  });
+
+  test("warm session is rejected when its stale Steward-to-Cloud binding is revoked", async () => {
+    const waited: Promise<unknown>[] = [];
+    await resolveInferenceSessionAuthContext(request(), {
+      cacheOnly: true,
+      useAuthCache: true,
+      executionCtx: { waitUntil: (promise) => waited.push(promise) },
+    });
+    await Promise.all(waited);
+    assertSessionActive = async () => {
+      const { InferenceCredentialRevokedError } = await import("./inference-credential-revocation");
+      throw new InferenceCredentialRevokedError("session_binding_revoked");
+    };
+
+    expect(
+      await resolveInferenceSessionAuthContext(request(), {
+        cacheOnly: true,
+        useAuthCache: true,
+      }),
+    ).toEqual({ kind: "rejected", status: 401 });
   });
 
   test("concurrent cold requests share one authoritative hydration", async () => {

--- a/packages/cloud/shared/src/lib/services/inference-session-auth-context.ts
+++ b/packages/cloud/shared/src/lib/services/inference-session-auth-context.ts
@@ -142,6 +142,7 @@ function toResolution(
 
 async function enforceStrongSessionBoundary(
   decision: InferenceSessionAuthDecision,
+  stewardUserId: string,
   issuedAt: number,
   source: "cache" | "origin",
 ): Promise<InferenceSessionAuthResolution> {
@@ -151,12 +152,13 @@ async function enforceStrongSessionBoundary(
     await assertInferenceCredentialActive(resolved.ctx.orgId, {
       kind: "steward_session",
       userId: resolved.ctx.userId,
+      stewardUserId,
       issuedAt,
     });
     return resolved;
   } catch (error) {
     if (error instanceof InferenceCredentialRevokedError) {
-      return error.reason === "session_revoked"
+      return error.reason === "session_revoked" || error.reason === "session_binding_revoked"
         ? { kind: "rejected", status: 401 }
         : { kind: "suspended", userId: resolved.ctx.userId };
     }
@@ -277,6 +279,7 @@ export async function resolveInferenceSessionAuthContext(
         stewardUserId: claims.userId,
         admission: await loadInferenceAdmissionSnapshot(user.organization_id),
       },
+      claims.userId,
       claims.issuedAt,
       "origin",
     );
@@ -312,7 +315,7 @@ export async function resolveInferenceSessionAuthContext(
           });
         options.executionCtx.waitUntil(refresh);
       }
-      return await enforceStrongSessionBoundary(cached, claims.issuedAt, "cache");
+      return await enforceStrongSessionBoundary(cached, claims.userId, claims.issuedAt, "cache");
     }
   }
 
@@ -352,7 +355,12 @@ export async function resolveInferenceSessionAuthContext(
     },
     options.useAuthCache === true,
   );
-  const resolved = await enforceStrongSessionBoundary(decision, claims.issuedAt, "origin");
+  const resolved = await enforceStrongSessionBoundary(
+    decision,
+    claims.userId,
+    claims.issuedAt,
+    "origin",
+  );
   if (resolved.kind === "rejected") {
     if (resolved.status === 401) throw AuthenticationError();
     throw ForbiddenError();

--- a/packages/cloud/shared/src/lib/services/users.ts
+++ b/packages/cloud/shared/src/lib/services/users.ts
@@ -20,6 +20,7 @@ import {
 } from "./inference-auth-cache";
 import {
   revokeInferenceSessionsThrough,
+  setInferenceSessionBindingActive,
   setInferenceSubjectActive,
 } from "./inference-credential-revocation";
 
@@ -299,21 +300,42 @@ export class UsersService {
     const sessionRevocationCutoff =
       movingOrganizations || sessionAuthorityChanged ? Math.floor(Date.now() / 1000) : null;
     if (movingOrganizations && existing?.organization_id) {
-      await setInferenceSubjectActive(existing.organization_id, id, false);
+      await setInferenceSubjectActive(existing.organization_id, id, false, "membership");
+    }
+    if (
+      typeof data.steward_user_id === "string" &&
+      existing?.organization_id &&
+      existing.steward_user_id &&
+      data.steward_user_id !== existing.steward_user_id
+    ) {
+      await setInferenceSessionBindingActive(
+        existing.organization_id,
+        id,
+        existing.steward_user_id,
+        false,
+      );
     }
     if (movingOrganizations && typeof data.organization_id === "string") {
-      await setInferenceSubjectActive(data.organization_id, id, false);
+      await setInferenceSubjectActive(data.organization_id, id, false, "membership");
       if (sessionRevocationCutoff !== null) {
         await revokeInferenceSessionsThrough(data.organization_id, id, sessionRevocationCutoff);
       }
     }
     if (data.is_active === false && existing?.organization_id) {
-      await setInferenceSubjectActive(existing.organization_id, id, false);
+      await setInferenceSubjectActive(existing.organization_id, id, false, "account");
     }
     if (sessionRevocationCutoff !== null && existing?.organization_id) {
       await revokeInferenceSessionsThrough(existing.organization_id, id, sessionRevocationCutoff);
     }
     const result = await usersRepository.update(id, data);
+    if (result?.organization_id && typeof data.steward_user_id === "string") {
+      await setInferenceSessionBindingActive(
+        result.organization_id,
+        id,
+        data.steward_user_id,
+        true,
+      );
+    }
     if (existing) {
       await this.invalidateCache(existing);
     }
@@ -326,10 +348,13 @@ export class UsersService {
       await this.invalidateInferenceAuthForUser(id);
     }
     if (data.is_active === true && result?.organization_id && !movingOrganizations) {
-      await setInferenceSubjectActive(result.organization_id, id, true);
+      await setInferenceSubjectActive(result.organization_id, id, true, "account");
     }
     if (typeof data.organization_id === "string" && result?.organization_id) {
-      await setInferenceSubjectActive(result.organization_id, id, result.is_active);
+      // Establish the account fence before clearing the move fence so an
+      // inactive account is never briefly admitted between serialized writes.
+      await setInferenceSubjectActive(result.organization_id, id, result.is_active, "account");
+      await setInferenceSubjectActive(result.organization_id, id, true, "membership");
     }
     return result;
   }
@@ -347,6 +372,14 @@ export class UsersService {
 
     const user = await usersRepository.findById(userId);
     if (user?.organization_id) {
+      if (existingIdentity?.steward_user_id) {
+        await setInferenceSessionBindingActive(
+          user.organization_id,
+          userId,
+          existingIdentity.steward_user_id,
+          false,
+        );
+      }
       await revokeInferenceSessionsThrough(
         user.organization_id,
         userId,
@@ -355,6 +388,9 @@ export class UsersService {
     }
 
     await usersRepository.upsertStewardIdentity(userId, stewardUserId);
+    if (user?.organization_id) {
+      await setInferenceSessionBindingActive(user.organization_id, userId, stewardUserId, true);
+    }
 
     const cacheDeletes = [
       cache.del(CacheKeys.user.byStewardId(stewardUserId)),
@@ -376,6 +412,14 @@ export class UsersService {
   async linkStewardId(userId: string, stewardUserId: string): Promise<void> {
     const existing = await usersRepository.findById(userId);
     if (existing?.organization_id && existing.steward_user_id !== stewardUserId) {
+      if (existing.steward_user_id) {
+        await setInferenceSessionBindingActive(
+          existing.organization_id,
+          userId,
+          existing.steward_user_id,
+          false,
+        );
+      }
       await revokeInferenceSessionsThrough(
         existing.organization_id,
         userId,
@@ -383,6 +427,9 @@ export class UsersService {
       );
     }
     const updated = await usersRepository.linkStewardId(userId, stewardUserId);
+    if (updated?.organization_id) {
+      await setInferenceSessionBindingActive(updated.organization_id, userId, stewardUserId, true);
+    }
 
     if (existing) {
       await this.invalidateCache(existing);
@@ -413,7 +460,7 @@ export class UsersService {
       throw new Error(`User ${id} not found`);
     }
     if (user.organization_id) {
-      await setInferenceSubjectActive(user.organization_id, id, false);
+      await setInferenceSubjectActive(user.organization_id, id, false, "membership");
     }
 
     let slug = generatePersonalOrgSlug(user);
@@ -480,7 +527,7 @@ export class UsersService {
     const organizationId = user.organization_id;
 
     if (organizationId) {
-      await setInferenceSubjectActive(organizationId, id, false);
+      await setInferenceSubjectActive(organizationId, id, false, "account");
     }
 
     await this.invalidateCache(user);


### PR DESCRIPTION
## Summary

Follow-up to #20854 and #17093. Post-merge review found four remaining strong-revocation gaps:

- independent account, moderation, and membership fences shared one subject key, so clearing one reason could accidentally clear another
- a newly issued session could reuse a stale Steward-to-Cloud identity mapping after relinking
- automatic moderation suspension updated the database and eventual cache without first committing a strong denial fence
- if the database relink committed but post-commit binding activation failed, retrying the same update could leave the valid current binding disabled

This change separates subject-denial reasons, makes Steward identity bindings durably and reversibly active/inactive around database mutations, repairs the current binding on idempotent retries, and commits moderation fences before suspension writes. The credential check also reads all relevant Durable Object keys in one storage operation.

The rollout flag remains default-off. This PR does not deploy or activate the feature.

Fixes #17093

## Verification

Exact head: 28b8aadcc0d26562f6cddc45f0ce50686f311289

- 77 focused tests pass across six isolated Bun test processes
- real Miniflare Durable Object tests cover stale positive API-key cache, session cutoff, stale identity binding, reversible subject/org fences, independent denial reasons, and rate-limit interaction
- exact-head cloud shared and cloud API typecheck and lint pass
- full bun run verify passed on the immediately preceding rebased revision: 356/356 workspace tasks, all repository audits, and 8,442 test files scanned with no focused tests or orphaned skips
- after the final conflict-free rebase onto develop at 16f8ba204804e0b2a74e03e8b954ca982d7a782d, all 77 focused tests and cloud package gates were rerun and passed
- git diff --check passes
