### PR TITLE
fix(plugin-personal-assistant): reject whitespace-padded entities limit query

### DIFF
--- a/plugins/plugin-personal-assistant/src/routes/entities-limit-query.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/entities-limit-query.test.ts
@@ -109,6 +109,16 @@ describe("GET /api/lifeops/entities limit query", () => {
     });
   });
 
+  it("empty limit (?limit=) still lists without a bound", async () => {
+    const { ctx, res } = buildCtx("?limit=");
+    await handleEntityRoutes(ctx);
+    expect(res.statusCode).toBe(200);
+    expect(kg.list).toHaveBeenCalledWith({});
+    expect(JSON.parse(res.body ?? "")).toEqual({
+      entities: [{ entityId: "e1" }, { entityId: "e2" }],
+    });
+  });
+
   it("canonical limit=2 reaches store.list", async () => {
     const { ctx, res } = buildCtx("?limit=2");
     await handleEntityRoutes(ctx);
@@ -132,7 +142,15 @@ describe("GET /api/lifeops/entities limit query", () => {
     "-1",
     "50abc",
     "9007199254740992",
-  ])("rejects limit=%s with 400 before store.list", async (limit) => {
+    // Whitespace-only and whitespace-padded tokens must not trim into either
+    // an "unbounded" list or a coerced integer. encodeURIComponent preserves
+    // the raw whitespace through the URL parser (e.g. " 2" -> "%202" -> " 2").
+    " ",
+    " 2",
+    "2 ",
+    "\t2",
+    "2\n",
+  ])("rejects limit=%j with 400 before store.list", async (limit) => {
     const { ctx, res } = buildCtx(`?limit=${encodeURIComponent(limit)}`);
     await handleEntityRoutes(ctx);
     expect(res.statusCode).toBe(400);

--- a/plugins/plugin-personal-assistant/src/routes/entities.ts
+++ b/plugins/plugin-personal-assistant/src/routes/entities.ts
@@ -43,16 +43,16 @@ function makeStore(ctx: LifeOpsRouteContext): EntityStore | null {
 function parseEntityLimit(
   raw: string | null,
 ): { ok: true; limit?: number } | { ok: false; message: string } {
-  if (raw === null || raw.trim() === "") {
+  if (raw === null || raw === "") {
     return { ok: true };
   }
-  const trimmed = raw.trim();
-  // Prefix coercion or leading zeros can turn a malformed paging request into
-  // an unintended unbounded knowledge-graph response.
-  if (!/^[1-9]\d*$/.test(trimmed)) {
+  // Validate the raw token without trimming: whitespace padding or a
+  // whitespace-only value used to trim away and either coerce a malformed
+  // paging request or silently drop the limit into an unbounded response.
+  if (!/^[1-9]\d*$/.test(raw)) {
     return { ok: false, message: "limit must be a positive integer" };
   }
-  const limit = Number(trimmed);
+  const limit = Number(raw);
   if (!Number.isSafeInteger(limit)) {
     return { ok: false, message: "limit must be a positive integer" };
   }


### PR DESCRIPTION
# Relates to

Closes #20880

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker. (See **Known gaps / failures** — the sandbox blocks `bun install` via a machine-wide `minimumReleaseAge` supply-chain policy; focused package checks were run against a hardlinked, lockfile-identical install.)
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: `yes`
<!-- attribution-row:models -->
- Model(s) used: `anthropic/claude-opus-4-8`
<!-- attribution-row:client -->
- Agent tooling: `pi-coding-agent/eliza-swarm`
<!-- attribution-row:skill-revision -->
- Skill path: `elizaOS/eliza@88531115dde449cb600e283ad17ed4faa783a84e:packages/skills/skills/contribute-to-eliza`
<!-- attribution-row:status -->
- Provenance status: `self-reported`

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts. (`git rev-list --count HEAD..origin/develop` = 0.)
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. The change tightens input validation on a single dev/runtime route
(`GET /api/lifeops/entities?limit=`) that already rejected malformed limits.
It narrows what is accepted (whitespace-padded / whitespace-only tokens now
400 instead of being silently trimmed) while preserving the two documented
backward-compatible unbounded cases (param omitted and `?limit=` empty). No
public type, export, or signature changes.

# Background

## What does this PR do?

Merged PR #20856 hardened the entities `limit` query guard, but
`parseEntityLimit` validated a **trimmed copy** of the raw query token. As a
result non-canonical raw values were incorrectly accepted even though the route
contract requires canonical raw `/^[1-9]\d*$/` input:

- `limit=%202` (decodes to `" 2"`) → accepted as `2`
- `limit=2%20` (decodes to `"2 "`) → accepted as `2`
- `limit=%20` (decodes to `" "`, whitespace-only) → trimmed to empty and treated
  as **"no limit"**, silently producing an unbounded knowledge-graph list.

The fix validates the **raw** token without trimming, and treats only the truly
absent/empty case (param omitted, or `?limit=`) as unbounded:

```ts
if (raw === null || raw === "") {
  return { ok: true };            // omitted or ?limit= stays unbounded
}
if (!/^[1-9]\d*$/.test(raw)) {     // no trim: any whitespace now rejected
  return { ok: false, message: "limit must be a positive integer" };
}
const limit = Number(raw);
if (!Number.isSafeInteger(limit)) {
  return { ok: false, message: "limit must be a positive integer" };
}
return { ok: true, limit };
```

This preserves #20856's safe-integer rejection and all existing rejections
(`1e2`, `12px`, `007`, `0`, `abc`, `-1`, `50abc`, `9007199254740992`).

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation. The route
contract (canonical raw `/^[1-9]\d*$/`) is unchanged; this PR makes the
implementation honor it.

# Testing

## Where should a reviewer start?

`plugins/plugin-personal-assistant/src/routes/entities.ts` — the
`parseEntityLimit` function, and the focused regression test
`plugins/plugin-personal-assistant/src/routes/entities-limit-query.test.ts`.

## Detailed testing steps

From `plugins/plugin-personal-assistant`:

```bash
vitest run --config vitest.config.ts src/routes/entities-limit-query.test.ts
```

The test drives the real `handleEntityRoutes` route handler with a captured
`ServerResponse`, mocking only the knowledge-graph service boundary
(`@elizaos/agent`). It asserts each whitespace/padded token yields HTTP 400 with
body `{ "error": "limit must be a positive integer" }` **before** `store.list`
is invoked (`kg.list` not called), that `?limit=` (empty) still returns 200 and
lists without a bound (`kg.list` called with `{}`), and that canonical `limit=2`
still reaches `store.list` with `{ limit: 2 }`.

# Evidence Gate

<!-- evidence-head:d0a2fa1e546cd47c562f613ed4fc7548ef7c810b -->

<!-- evidence-row:before-screenshots -->
- [x] `N/A - no UI surface. This is a server-side HTTP route validation change (plugins/plugin-personal-assistant/src/routes/entities.ts); no rendered component changes.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - no UI surface (server-side route validation only).`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no UI/user flow; the change is a query-parameter validation guard exercised via the focused test below.`
<!-- evidence-row:backend-logs -->
- [ ] N/A - fork contributor has pull-only permission on elizaOS/eliza, so scripts/pr-evidence.mjs release-asset upload returns HTTP 404 and user-attachment URLs cannot be minted via CLI; the structured route-path test output (real handleEntityRoutes handler, verbose) is pasted inline under Evidence Details > Backend + frontend logs.
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend/client involved; the contract is a raw HTTP query token parsed server-side.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model behavior changes; pure input-validation fix.`
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - same fork upload limitation; the failing-then-passing route-outcome reproduction (HTTP status + whether EntityStore.list was reached) is pasted inline under Evidence Details > Backend + frontend logs.
<!-- evidence-row:ocr-review -->
- [x] `N/A - no rendered visual surface.`

# Evidence Details

## Real LLM-call trajectory

`N/A - no agent/action/provider/prompt/model changes.`

## Backend + frontend logs

The focused test exercises the real `handleEntityRoutes` code path end to end
(only the `@elizaos/agent` knowledge-graph service boundary is mocked) and
asserts the observable outcome: HTTP status and whether `EntityStore.list` was
reached.

**Failing-then-passing reproduction** (revert the guard to #20856's trimmed
behavior → the new whitespace cases fail; restore the fix → all pass):

<details>
<summary>Before fix (buggy trim behavior) — whitespace cases wrongly return 200</summary>

```
############ BEFORE FIX (buggy #20856 trim behavior) ############
     × rejects limit=" " with 400 before store.list 7ms
     × rejects limit=" 2" with 400 before store.list 1ms
     × rejects limit="2 " with 400 before store.list 2ms
     × rejects limit="\t2" with 400 before store.list 1ms
     × rejects limit="2\n" with 400 before store.list 2ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 5 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected 200 to be 400 // Object.is equality
 Test Files  1 failed (1)
      Tests  5 failed | 12 passed (17)
```

</details>

<details>
<summary>After fix — full verbose run, 17/17 pass</summary>

```
 ✓ ... > omitted limit still lists without a bound 7ms
 ✓ ... > empty limit (?limit=) still lists without a bound 2ms
 ✓ ... > canonical limit=2 reaches store.list 1ms
 ✓ ... > keeps type filter when limit is canonical 1ms
 ✓ ... > rejects limit="1e2" with 400 before store.list 1ms
 ✓ ... > rejects limit="12px" with 400 before store.list 1ms
 ✓ ... > rejects limit="007" with 400 before store.list 1ms
 ✓ ... > rejects limit="0" with 400 before store.list 0ms
 ✓ ... > rejects limit="abc" with 400 before store.list 2ms
 ✓ ... > rejects limit="-1" with 400 before store.list 1ms
 ✓ ... > rejects limit="50abc" with 400 before store.list 1ms
 ✓ ... > rejects limit="9007199254740992" with 400 before store.list 0ms
 ✓ ... > rejects limit=" " with 400 before store.list 0ms
 ✓ ... > rejects limit=" 2" with 400 before store.list 0ms
 ✓ ... > rejects limit="2 " with 400 before store.list 0ms
 ✓ ... > rejects limit="\t2" with 400 before store.list 1ms
 ✓ ... > rejects limit="2\n" with 400 before store.list 0ms

 Test Files  1 passed (1)
      Tests  17 passed (17)
```

</details>

**Lint (Biome) on the changed files:**

```
$ bunx @biomejs/biome check src/routes/entities.ts src/routes/entities-limit-query.test.ts
Checked 2 files in 58ms. No fixes applied.
EXIT=0
```

**Typecheck:** `tsc --noEmit -p tsconfig.build.json` fails wholesale on
`origin/develop` for this package (1621 pre-existing errors from unbuilt
workspace `@elizaos/*` type declarations — `Cannot find module '@elizaos/core'`,
missing `../contracts/index.js` members, etc.). Verified this PR introduces
**zero** new errors: running the identical typecheck on a clean, fully-installed
checkout at the same develop base yields 1621 errors both with and without this
patch (`comm -13` delta is empty). This is an environmental/pre-existing blocker
unrelated to the change — see **Known gaps / failures**.

## Screenshots (before / after) + video walkthrough

`N/A - server-side HTTP route validation change with no rendered UI surface.`

## Audio / voice walkthrough

`N/A - no voice/audio/TTS/STT surface.`

## Known gaps / failures

- **`bun install` / root `bun run verify` could not run in this sandbox.** The
  machine enforces a global `minimumReleaseAge = 604800` (7-day) bun
  supply-chain policy, so recently-published transitive deps (`viem`,
  `smthrs`, `kubernetes-fluent-client`) fail to resolve and abort the install.
  To run the focused checks I reused a lockfile-identical (`diff bun.lock` =
  identical) sibling install via relative-symlink-preserving hardlinks, so the
  workspace `@elizaos/*` links resolve to **this** worktree's source. The
  package test, verbose run, failing-then-passing reproduction, and Biome all
  execute against that install and are shown above.
- **Package `typecheck` is a pre-existing wholesale failure** on `origin/develop`
  (unbuilt workspace type declarations). Proven unrelated: identical 1621-error
  output with and without this patch on a clean install; zero new errors from
  this diff. Not a blocker for this change.

## Contribution provenance

- AI assistance: yes
- AI provider/model: anthropic / claude-opus-4-8
- Client / agent tooling: pi coding agent (eliza-swarm, autonomous)
- Attribution status: self-reported

<!-- eliza-computer-attribution:v1 {"provider":"anthropic","model":"claude-opus-4-8","client":"pi-coding-agent/eliza-swarm","skill_revision":"elizaOS/eliza@88531115dde449cb600e283ad17ed4faa783a84e:packages/skills/skills/contribute-to-eliza"} -->

