### PR TITLE
fix(personal-assistant): reject padded entity limits

### DIFF
--- a/plugins/plugin-personal-assistant/src/routes/entities-limit-query.test.ts
+++ b/plugins/plugin-personal-assistant/src/routes/entities-limit-query.test.ts
@@ -1,7 +1,6 @@
 /**
- * GET /api/lifeops/entities?limit= must reject prefix-coerced tokens before
- * EntityStore.list. Malformed limits used to be dropped, so the knowledge
- * graph dumped every entity.
+ * Deterministic HTTP route coverage verifies that entity-list limits are
+ * canonical positive integers before the knowledge-graph store is queried.
  */
 import { IncomingMessage, ServerResponse } from "node:http";
 import { Socket } from "node:net";
@@ -131,6 +130,9 @@ describe("GET /api/lifeops/entities limit query", () => {
     "abc",
     "-1",
     "50abc",
+    " 2",
+    "2 ",
+    " ",
     "9007199254740992",
   ])("rejects limit=%s with 400 before store.list", async (limit) => {
     const { ctx, res } = buildCtx(`?limit=${encodeURIComponent(limit)}`);

--- a/plugins/plugin-personal-assistant/src/routes/entities.ts
+++ b/plugins/plugin-personal-assistant/src/routes/entities.ts
@@ -43,16 +43,15 @@ function makeStore(ctx: LifeOpsRouteContext): EntityStore | null {
 function parseEntityLimit(
   raw: string | null,
 ): { ok: true; limit?: number } | { ok: false; message: string } {
-  if (raw === null || raw.trim() === "") {
+  if (raw === null || raw === "") {
     return { ok: true };
   }
-  const trimmed = raw.trim();
   // Prefix coercion or leading zeros can turn a malformed paging request into
   // an unintended unbounded knowledge-graph response.
-  if (!/^[1-9]\d*$/.test(trimmed)) {
+  if (!/^[1-9]\d*$/.test(raw)) {
     return { ok: false, message: "limit must be a positive integer" };
   }
-  const limit = Number(trimmed);
+  const limit = Number(raw);
   if (!Number.isSafeInteger(limit)) {
     return { ok: false, message: "limit must be a positive integer" };
   }


### PR DESCRIPTION
## Summary

Closes #20880.

The personal-assistant entity-list route now validates the raw `limit` query token instead of trimming it before validation. Omitted and exactly empty values remain unbounded; canonical positive safe integers are accepted; whitespace-padded, whitespace-only, prefix-coerced, zero, negative, and unsafe values fail with HTTP 400 before `EntityStore.list` runs.

This is a narrow follow-up to merged #20856. That PR added the safe-integer bound but its trim-first parser still accepted padded values contrary to its raw-canonical contract.

## Verification

Exact published head: `6037032153d135bf4bf152f33a602eeeae649163`, rebased on `develop@4dc9220e99211175dcbe949ca93bd785faa81567`.

- Focused route contract: 14/14.
- Personal-assistant typecheck: pass.
- Personal-assistant build: pass.
- Changed-file Biome and `git diff --check`: pass.
- Forced root `bun run verify` on byte-identical patch candidate `4f495e26ac2c36f0fcca258360a2792fdb3e261c` atop `develop@88531115dde449cb600e283ad17ed4faa783a84e`: 356/356, 0 cached, every repository audit passed; anti-larp scanned 8,442 test files with 0 focused and 0 orphaned skips.
- Final rebase added only merged Cloud rate-limit changes outside both touched files; focused 14/14 reran on the exact published head.

The full personal-assistant aggregate currently has three unrelated current-base test-contract failures outside this diff: two mocks omit the newly required `MONEY_TAGS` export, and one scheduler mock returns `undefined` from `list()`. Each reproduces in isolation; this PR does not mask or modify them.

## Evidence

<!-- evidence-head:6037032153d135bf4bf152f33a602eeeae649163 -->
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend query validation only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend query validation only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - deterministic HTTP route behavior; no interactive surface.
<!-- evidence-row:backend-logs -->
- [x] Focused route transcript:
  <details><summary>Boundary proof</summary>

  ```text
  14 passed, 0 failed
  canonical limit=2 reaches EntityStore.list({ limit: 2 })
  omitted and exactly empty limit remain unbounded
  " 2", "2 ", and " " return HTTP 400 before EntityStore.list
  prefix-coerced, zero, negative, and unsafe integer tokens remain rejected
  ```

  </details>
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent, prompt, provider, action, or model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - invalid-token tests verify zero `EntityStore.list` calls, so no database, memory, deployment, or generated artifact is written.
<!-- evidence-row:ocr-review -->
- [x] N/A - no rendered visual surface.

## Contribution provenance

<!-- contribution-attribution:v1 -->
<!-- attribution-row:ai-assistance -->
- AI assistance: yes
<!-- attribution-row:models -->
- Model(s) used: openai/gpt-5.6-sol
<!-- attribution-row:client -->
- Agent tooling: Codex Desktop
<!-- attribution-row:skill-revision -->
- Skill path: N/A - repository guide followed directly
<!-- attribution-row:status -->
- Provenance status: self-reported
